### PR TITLE
feat(deploy): the pipeline becomes pointable — compose-file list + a refuse-by-default plan gate (#16454)

### DIFF
--- a/ai/scripts/maintenance/deploymentMigrationCore.mjs
+++ b/ai/scripts/maintenance/deploymentMigrationCore.mjs
@@ -139,18 +139,45 @@ export function resolveCensus(parity, profile) {
 }
 
 /**
- * @summary Derives the config-contract delta by comparing the observed env against the census.
+ * @summary Decides whether an observed value satisfies a required key, or is present-but-unusable.
  *
- * The single resolver. Reason text for a forbidden key is taken **verbatim from the census**, which
- * already declares each one's replacement guidance — re-authoring it here would create a second copy
- * free to drift from the authority it paraphrases.
- * @param {Map<String,String>} observedEnv Output of {@link parseObservedEnv}.
- * @param {Object}             census      Output of {@link resolveCensus}.
- * @returns {Object} `{missingRequired, presentForbidden, missingSecrets, optionalPresent}`
+ * `parseObservedEnv` records a bare `KEY` and `KEY=` alike as an empty string, because Docker permits
+ * both and treating either as absent would hide a key that was set-but-empty. That distinction is only
+ * worth recording if something downstream acts on it: a required input whose value is empty or
+ * whitespace satisfies a presence check and still cannot configure anything, which is a different
+ * defect from unset and a different fix for the operator.
+ * @param {String|undefined} value Observed value, or `undefined` when the key is absent.
+ * @returns {Boolean} `true` when the key is present and carries a usable value.
  */
-export function deriveContractDelta(observedEnv, census) {
+function isUsableValue(value) {
+    return typeof value === 'string' && value.trim() !== ''
+}
+
+/**
+ * @summary Derives one service's config-contract delta by comparing its observed env against the census.
+ *
+ * The single resolver, evaluated **per service**. Reason text for a forbidden key is taken **verbatim
+ * from the census**, which already declares each one's replacement guidance — re-authoring it here
+ * would create a second copy free to drift from the authority it paraphrases.
+ *
+ * `declaredScope` is the set of env keys that service's own config template declares. The census
+ * classifies keys per *profile*, not per service, and the profile's required list is not uniform across
+ * its services: four of the canonical profile's thirteen required inputs are declared by one service
+ * only. Judging every key against every service therefore invents obligations — and unioning the
+ * observations across services invents satisfactions. A key outside the scope is not this service's to
+ * carry and is skipped; a key inside no service's scope is reported by {@link buildMigrationPlan} as
+ * unattributable rather than assigned to a default.
+ * @param {Map<String,String>} observedEnv     Output of {@link parseObservedEnv} for ONE service.
+ * @param {Object}             census          Output of {@link resolveCensus}.
+ * @param {Set<String>|null}   [declaredScope] Env keys the service declares; `null` evaluates the whole census.
+ * @returns {Object} `{missingRequired, setButEmpty, presentForbidden, missingSecrets, optionalPresent}`
+ */
+export function deriveContractDelta(observedEnv, census, declaredScope = null) {
+    const inScope = key => !(declaredScope instanceof Set) || declaredScope.has(key),
+          scoped  = census.requiredDeploymentInputs.filter(inScope);
+
     return {
-        missingRequired : census.requiredDeploymentInputs
+        missingRequired : scoped
             .filter(key => !observedEnv.has(key))
             .map(key => ({
                 key,
@@ -159,10 +186,19 @@ export function deriveContractDelta(observedEnv, census) {
                     ? 'declared required with no leaf default, so a launch that does not declare it is refused rather than degraded'
                     : 'declared in the census as a required deployment input and absent from the observed deployment'
             })),
+        setButEmpty     : scoped
+            .filter(key => observedEnv.has(key) && !isUsableValue(observedEnv.get(key)))
+            .map(key => ({
+                key,
+                bootBlocking: key === BOOT_BLOCKING_KEY,
+                reason      : 'declared required and present but carrying an empty value, which satisfies a presence ' +
+                              'check and still configures nothing — a different repair from an absent key'
+            })),
         presentForbidden: Object.keys(census.forbiddenEnv)
             .filter(key => observedEnv.has(key))
             .map(key => ({key, reason: String(census.forbiddenEnv[key])})),
         missingSecrets  : census.secrets
+            .filter(inScope)
             .filter(key => !observedEnv.has(key))
             .map(key => ({key, reason: 'declared as a required secret and absent from the observed deployment'})),
         optionalPresent : census.optionalOverrides.filter(key => observedEnv.has(key))
@@ -191,68 +227,164 @@ function normalizeFinding(finding) {
  * failure, and collapsing it into either is how a partial plan reads as complete. `unchecked` never
  * blocks; it travels into the apply receipt so the operator sees exactly what was not proven.
  *
- * @param {Object}             config
- * @param {Map<String,String>} config.observedEnv        Guarded env observed on the target's containers.
- * @param {Object}             config.census             Output of {@link resolveCensus}.
- * @param {Object}             config.composeIdentity    `{project, configFiles}` read off the running plane; `null` when undiscoverable.
- * @param {Object}             config.deployedRevisions  Service name → revision string, or `null` for unreadable.
- * @param {String|null}        config.targetRevision     The resolved 40-hex target, or `null` when resolution failed.
- * @param {String[]}           [config.uncheckedNotes]   Entrypoint-supplied items it could not evaluate.
- * @returns {Object} `{clean, blockers, unchecked, notes, revisionDelta, contractDelta}`
+ * A fourth property matters more than the buckets: the plan must carry the **repair**, not merely
+ * describe the damage. A deployment missing a required input is refused from its own observation, so if
+ * nothing can supply the corrected value the operator has to fix the plane by another path — which is
+ * the manual intervention this tool exists to remove. `desiredEnv` is that carrier: a supplied value
+ * turns a missing input from a terminal blocker into a declared transition the apply step performs.
+ *
+ * @param {Object}   config
+ * @param {Object}   config.observedEnvByService Service name → Map from {@link parseObservedEnv}. Observations
+ *                                              stay **per service**; a union credits one service with another's
+ *                                              configuration and blames it for keys it never declares.
+ * @param {Object}   config.serviceScopes        Service name → Set of env keys that service's config template declares.
+ * @param {Object}   config.census               Output of {@link resolveCensus}.
+ * @param {Object}   [config.desiredEnv]         Service name → `{KEY: value}` the operator declares for the transition.
+ * @param {Object}   config.composeIdentity      `{project, configFiles}` read off the running plane; `null` when undiscoverable.
+ * @param {Object}   config.deployedRevisions    Service name → revision string, or `null` for unreadable.
+ * @param {String|null} config.targetRevision    The resolved 40-hex target, or `null` when resolution failed.
+ * @param {String[]} [config.uncheckedNotes]     Entrypoint-supplied items it could not evaluate.
+ * @returns {Object} `{clean, blockers, unchecked, notes, revisionDelta, contractDelta, configTransition}`
  */
-export function buildMigrationPlan({observedEnv, census, composeIdentity, deployedRevisions, targetRevision, uncheckedNotes = []}) {
-    const blockers  = [],
-          unchecked = [...uncheckedNotes],
-          notes     = [];
+export function buildMigrationPlan({
+    observedEnvByService, serviceScopes, census, desiredEnv = {}, composeIdentity, deployedRevisions,
+    targetRevision, uncheckedNotes = []
+}) {
+    const blockers         = [],
+          unchecked        = [...uncheckedNotes],
+          notes            = [],
+          configTransition = {},
+          services         = Object.keys(observedEnvByService || {}).sort(),
+          optionalPresent  = new Set(),
+          attributed       = new Set();
 
-    // 1. An unreadable target cannot be compared to any contract. Refused before deriving anything,
-    // because an EMPTY observed set would otherwise derive "every required key is missing" — a
-    // spectacular-looking delta whose real cause is that nothing was read.
-    if (!(observedEnv instanceof Map) || observedEnv.size === 0) {
+    // 1. Nothing observed at all. Refused before deriving anything, because an EMPTY observation would
+    // otherwise derive "every required key is missing" — a spectacular-looking delta whose real cause is
+    // that nothing was read.
+    if (services.length === 0) {
         blockers.push({
-            kind  : 'no-observed-env',
+            kind  : 'no-observed-service',
             key   : 'Config.Env',
-            reason: 'no guarded env was read from the target, so the contract delta would be derived from an empty ' +
+            reason: 'no service was observed on the target, so any contract delta would be derived from an empty ' +
                     'observation and every required key would appear missing for the wrong reason'
         })
     }
 
-    const contractDelta   = deriveContractDelta(observedEnv instanceof Map ? observedEnv : new Map(), census),
-          missingRequired = contractDelta.missingRequired.map(normalizeFinding),
-          forbiddenSet    = contractDelta.presentForbidden.map(normalizeFinding),
-          missingSecrets  = contractDelta.missingSecrets.map(normalizeFinding);
+    const aggregate = {missingRequired: [], setButEmpty: [], presentForbidden: [], missingSecrets: []};
 
-    // 2. The contract delta as blockers. Boot-blocking gets its own kind: a refused launch is a
-    // different triage priority from a degraded one, and it is the one key an operator reading a long
-    // list must see first.
-    missingRequired.forEach(({key, reason}) => {
-        const bootBlocking = contractDelta.missingRequired.some(entry => entry.key === key && entry.bootBlocking === true);
+    services.forEach(service => {
+        const observed = observedEnvByService[service],
+              scope    = serviceScopes?.[service];
 
-        blockers.push({
-            kind  : bootBlocking ? 'missing-required-input-boot-blocking' : 'missing-required-input',
-            key,
-            reason
+        // A service whose declared surface could not be resolved cannot be judged. Evaluating the whole
+        // census against it would invent obligations; skipping it would silently drop a service from the
+        // gate. Neither is admissible, so it blocks.
+        if (!(scope instanceof Set)) {
+            blockers.push({
+                kind  : 'service-scope-unresolved',
+                key   : service,
+                reason: `no declared env surface could be resolved for service '${service}', so its observed config ` +
+                        'can be neither satisfied nor faulted against the census'
+            });
+
+            return
+        }
+
+        scope.forEach(key => attributed.add(key));
+
+        if (!(observed instanceof Map) || observed.size === 0) {
+            blockers.push({
+                kind  : 'no-observed-env',
+                key   : service,
+                reason: `no guarded env was read from service '${service}' — its container may not be running, and ` +
+                        'silence from an unreachable service is not evidence that its config is absent'
+            });
+
+            return
+        }
+
+        const delta = deriveContractDelta(observed, census, scope);
+
+        delta.optionalPresent.forEach(key => optionalPresent.add(key));
+
+        // 2. The contract delta as blockers, keyed per service. A supplied desired value converts a
+        // missing or empty input into a recorded transition instead: that is the repair this tool owes.
+        [...delta.missingRequired, ...delta.setButEmpty].forEach(entry => {
+            const {key, reason, bootBlocking} = entry,
+                  supplied                    = desiredEnv?.[service]?.[key],
+                  wasEmpty                    = delta.setButEmpty.some(item => item.key === key);
+
+            if (isUsableValue(supplied)) {
+                configTransition[service] ||= [];
+                configTransition[service].push({key, from: wasEmpty ? '<empty>' : '<unset>', declared: true});
+
+                return
+            }
+
+            if (supplied !== undefined) {
+                blockers.push({
+                    kind  : 'desired-value-unusable',
+                    key   : `${service}.${key}`,
+                    reason: 'a desired value was supplied for this key but is empty or not a string, so the transition ' +
+                            'would replace an unusable value with another one'
+                });
+
+                return
+            }
+
+            blockers.push({
+                kind  : bootBlocking
+                    ? 'missing-required-input-boot-blocking'
+                    : wasEmpty ? 'required-input-set-but-empty' : 'missing-required-input',
+                key   : `${service}.${key}`,
+                reason: `${reason} — and no desired value was supplied, so apply cannot repair it`
+            })
+        });
+
+        aggregate.missingRequired.push(...delta.missingRequired.map(entry => `${service}.${entry.key}`));
+        aggregate.setButEmpty.push(...delta.setButEmpty.map(entry => `${service}.${entry.key}`));
+
+        delta.presentForbidden.map(normalizeFinding).forEach(({key, reason}) => {
+            aggregate.presentForbidden.push(`${service}.${key}`);
+
+            blockers.push({
+                kind  : 'forbidden-env-present',
+                key   : `${service}.${key}`,
+                reason: reason || 'declared retired or derived by the census and still set on the target'
+            })
+        });
+
+        delta.missingSecrets.map(normalizeFinding).forEach(({key, reason}) => {
+            aggregate.missingSecrets.push(`${service}.${key}`);
+
+            blockers.push({
+                kind  : 'missing-secret',
+                key   : `${service}.${key}`,
+                reason: reason || 'declared as a required secret and absent from the target'
+            })
         })
     });
 
-    forbiddenSet.forEach(({key, reason}) => blockers.push({
-        kind  : 'forbidden-env-present',
-        key,
-        reason: reason || 'declared retired or derived by the census and still set on the target'
-    }));
+    // 2b. A required key no observed service declares cannot be attributed by this instrument. It is
+    // neither satisfied nor faulted, and picking a service for it would be a guess that reads as a
+    // verdict — so it blocks rather than resolving to a default owner.
+    if (services.length) {
+        census.requiredDeploymentInputs.filter(key => !attributed.has(key)).forEach(key => blockers.push({
+            kind  : 'required-input-unattributable',
+            key,
+            reason: 'declared required by the profile census and declared by none of the observed services, so no ' +
+                    'service can be held to it and no service can satisfy it'
+        }))
+    }
 
-    missingSecrets.forEach(({key, reason}) => blockers.push({
-        kind  : 'missing-secret',
-        key,
-        reason: reason || 'declared as a required secret and absent from the target'
-    }));
+    const contractDelta = {optionalPresent: [...optionalPresent]};
 
     contractDelta.optionalPresent.forEach(key => notes.push(`optional override set: ${key}`));
 
     // Secrets are named in the census but their VALUES are not observable through container env in
     // every deployment shape, so a satisfied secret list is weaker evidence than a satisfied required
     // list. Say so rather than letting a clean secrets check read as a proof it is not.
-    if (census.secrets.length && missingSecrets.length === 0) {
+    if (census.secrets.length && aggregate.missingSecrets.length === 0) {
         unchecked.push(
             `secret presence was checked by env key only (${census.secrets.length} declared) — a key set to an ` +
             'empty or stale value reads as present'
@@ -287,9 +419,18 @@ export function buildMigrationPlan({observedEnv, census, composeIdentity, deploy
     const readableValues  = Object.values(deployedRevisions || {}).filter(Boolean),
           distinctRunning = new Set(readableValues);
 
+    // An unreadable revision was previously reported and passed over. It cannot be: the post-apply
+    // assertion for that service has no baseline to move from, so a successful-looking apply could not be
+    // distinguished from one that stranded it. An unestablished safety fact blocks rather than annotating
+    // a CLEAN verdict.
     Object.entries(deployedRevisions || {}).forEach(([service, revision]) => {
         if (!revision) {
-            unchecked.push(`service '${service}': /app/.neo-revision unreadable — its before-state is not established`)
+            blockers.push({
+                kind  : 'revision-unreadable',
+                key   : `${service}:/app/.neo-revision`,
+                reason: `service '${service}' reported no revision, so its before-state is not established and no ` +
+                        'post-apply assertion could prove it moved rather than being stranded'
+            })
         }
     });
 
@@ -318,19 +459,31 @@ export function buildMigrationPlan({observedEnv, census, composeIdentity, deploy
         notes.push(`already at target revision ${targetRevision} — apply would deliver no code change`)
     }
 
+    Object.entries(configTransition).forEach(([service, entries]) => notes.push(
+        `declared config transition on '${service}': ${entries.map(({key, from}) => `${key} (${from} -> declared)`).join(', ')}`
+    ));
+
     return {
         clean        : blockers.length === 0,
         blockers,
         unchecked,
         notes,
         revisionDelta: {from: singleRunning, to: targetRevision, alreadyTarget},
+        configTransition,
         contractDelta: {
-            profile         : census.profile,
-            missingRequired : missingRequired.map(({key}) => key),
-            presentForbidden: forbiddenSet.map(({key}) => key),
-            missingSecrets  : missingSecrets.map(({key}) => key),
-            optionalPresent : contractDelta.optionalPresent,
-            observedKeyCount: observedEnv instanceof Map ? observedEnv.size : 0
+            profile          : census.profile,
+            services,
+            missingRequired  : aggregate.missingRequired,
+            setButEmpty      : aggregate.setButEmpty,
+            presentForbidden : aggregate.presentForbidden,
+            missingSecrets   : aggregate.missingSecrets,
+            optionalPresent  : contractDelta.optionalPresent,
+            observedKeyCounts: Object.fromEntries(
+                services.map(service => [
+                    service,
+                    observedEnvByService[service] instanceof Map ? observedEnvByService[service].size : 0
+                ])
+            )
         }
     }
 }

--- a/ai/scripts/maintenance/deploymentMigrationCore.mjs
+++ b/ai/scripts/maintenance/deploymentMigrationCore.mjs
@@ -377,6 +377,31 @@ export function buildMigrationPlan({
         }))
     }
 
+    // 2c. The transport constraint, surfaced at plan time rather than discovered at apply time. Desired
+    // values reach the plane through Compose interpolation, which is GLOBAL: one key carries one value
+    // for the whole project. A per-service carrier can therefore express a transition the transaction
+    // cannot perform, and picking one of the two values would apply a config the operator never named.
+    const desiredByKey = {};
+
+    Object.entries(desiredEnv || {}).forEach(([service, entries]) => {
+        Object.entries(entries || {}).forEach(([key, value]) => {
+            desiredByKey[key] ||= new Map();
+            desiredByKey[key].set(service, value)
+        })
+    });
+
+    Object.entries(desiredByKey).forEach(([key, byService]) => {
+        if (new Set(byService.values()).size > 1) {
+            blockers.push({
+                kind  : 'desired-value-conflict',
+                key,
+                reason: `services disagree on the desired value for '${key}' (` +
+                        `${[...byService.keys()].join(', ')}) — Compose interpolation carries one value per ` +
+                        'key for the whole project, so this transition cannot be applied as declared'
+            })
+        }
+    });
+
     const contractDelta = {optionalPresent: [...optionalPresent]};
 
     contractDelta.optionalPresent.forEach(key => notes.push(`optional override set: ${key}`));

--- a/ai/scripts/maintenance/deploymentMigrationCore.mjs
+++ b/ai/scripts/maintenance/deploymentMigrationCore.mjs
@@ -377,31 +377,12 @@ export function buildMigrationPlan({
         }))
     }
 
-    // 2c. The transport constraint, surfaced at plan time rather than discovered at apply time. Desired
-    // values reach the plane through Compose interpolation, which is GLOBAL: one key carries one value
-    // for the whole project. A per-service carrier can therefore express a transition the transaction
-    // cannot perform, and picking one of the two values would apply a config the operator never named.
-    const desiredByKey = {};
-
-    Object.entries(desiredEnv || {}).forEach(([service, entries]) => {
-        Object.entries(entries || {}).forEach(([key, value]) => {
-            desiredByKey[key] ||= new Map();
-            desiredByKey[key].set(service, value)
-        })
-    });
-
-    Object.entries(desiredByKey).forEach(([key, byService]) => {
-        if (new Set(byService.values()).size > 1) {
-            blockers.push({
-                kind  : 'desired-value-conflict',
-                key,
-                reason: `services disagree on the desired value for '${key}' (` +
-                        `${[...byService.keys()].join(', ')}) — Compose interpolation carries one value per ` +
-                        'key for the whole project, so this transition cannot be applied as declared'
-            })
-        }
-    });
-
+    // 2c. There is deliberately NO cross-service value-conflict refusal. An earlier revision blocked when
+    // two services declared different values for one key, on the premise that the repair travelled as
+    // parent environment and Compose interpolation is global. That premise was false — the profile
+    // declares these leaves as literals, so parent env never reached the consumer at all. The repair now
+    // travels as a Compose fragment nested under each service, which makes differing per-service values
+    // expressible, so a refusal here would reject a transition the transaction can perform.
     const contractDelta = {optionalPresent: [...optionalPresent]};
 
     contractDelta.optionalPresent.forEach(key => notes.push(`optional override set: ${key}`));

--- a/ai/scripts/maintenance/deploymentMigrationCore.mjs
+++ b/ai/scripts/maintenance/deploymentMigrationCore.mjs
@@ -1,25 +1,39 @@
 /**
  * @module ai/scripts/maintenance/deploymentMigrationCore
- * @summary Pure core for the migration bootstrap's apply gate: validates a discover result produced by
- * the census-derived discover driver, joins it with the plane-side facts only this tool observes, and
+ * @summary Pure core for the migration bootstrap: derives a deployment's config-contract delta from
+ * the classified census, joins it with the plane-side facts only a plane-side reader can observe, and
  * decides whether one `apply` is authorized or refused with named reasons.
  *
- * ## The boundary, and why there is no fallback derivation
+ * ## One tool, one resolver — and why that is the cheap shape rather than the expedient one
  *
- * The discover driver owns DISCOVERY — deriving missing-required / present-forbidden / missing-secret
- * keys from the classified config census and emitting them as JSON. This module owns CONSUMPTION and
- * the apply gate. It deliberately carries **no census derivation of its own**, not even as a fallback
- * for an absent discover result: two resolvers for one contract can disagree, and the disagreement
- * surfaces as a migration that was authorized against the wrong answer. A parallel resolution path
- * running beside the canonical one is the shape this repository has already had to retire once, so an
- * absent discover result refuses rather than falling back.
+ * An earlier revision consumed this delta as JSON from a separate discovery driver and carried **no
+ * derivation of its own**, deliberately, so that two resolvers for one contract could not disagree.
+ * That reasoning was sound and its premise is gone: the separate driver was closed as not-planned,
+ * priced at *"a new CLI contract, JSON schema, tests, documentation, and ongoing compatibility
+ * surface"*. Every one of those costs is an artifact of the **split**, not of the capability — so
+ * folding derivation into this single tool removes all of them and still leaves exactly one resolver.
+ * There is no second path here to disagree with.
  *
- * ## What this module knows that the discover driver cannot
+ * ## Why the delta is a CONFIG delta and not a revision delta
  *
- * Discovery reads a contract. Apply must also read the *plane*: which Compose project and file list
- * the running containers actually belong to, and whether the cohort agrees with itself about the
- * revision it is on. Neither is derivable from the census, and both can refuse an apply that a clean
- * discover result would otherwise authorize.
+ * A rebuild at a newer revision does not repair a deployment whose config no longer satisfies the
+ * contract; it produces a refused launch. The orchestrator's authority role is the worked case: its
+ * leaf carries no default, so a deployment that never declares its role writes no state directory, no
+ * PID file and no log. The config delta decides whether a migration can work at all; the revision
+ * delta is secondary.
+ *
+ * ## Observed, never re-derived
+ *
+ * The env input must come from the target's own containers. Host-side re-derivation cannot populate an
+ * observed column — it degrades the comparison to desired-versus-desired, which passes trivially and
+ * detects nothing. A planner fed the canonical Compose file would report every deployment compliant.
+ *
+ * ## What the census cannot supply
+ *
+ * A contract says what a deployment must declare. Apply must also read the *plane*: which Compose
+ * project and file list the running containers belong to, and whether the cohort agrees with itself
+ * about its revision. Neither is derivable from the census, and both can refuse an apply that a clean
+ * contract delta would otherwise authorize.
  *
  * ## Neo-free on purpose
  *
@@ -28,72 +42,135 @@
  */
 
 /**
- * The discover-result schema version this core consumes. A mismatch refuses rather than best-efforts:
- * a shape change in the producer must fail loudly here, because the failure mode of silent
- * mis-parsing is an apply authorized against fields that were never populated.
- * @type {Number}
+ * The env namespace the deployment contract governs. The guarded Compose surface is counted in
+ * `NEO_*`/`MCP_*` keys, so anything outside it (image `PATH`, `NODE_VERSION`, Docker injections) is not
+ * ours to judge and is dropped rather than reported as unexpected.
+ * @type {RegExp}
  */
-export const DISCOVER_SCHEMA_VERSION = 1;
+const GUARDED_ENV_KEY = /^(?:NEO|MCP)_/;
 
 /**
- * The finding lists a discover result must carry. Presence is required; emptiness is fine and is the
- * normal clean case. An ABSENT list is refused because absent and empty are the same shape once
- * parsed, and treating a missing list as empty reads "you are fine" from a producer that never ran
- * that check — the exact failure the discover contract forbids: never report an empty delta.
- * @type {String[]}
+ * The census key whose absence stops a container from starting at all rather than degrading it. Its
+ * leaf carries no default, so requiredness is armed by that emptiness and a launch declaring no role is
+ * refused outright — a different triage priority from an ordinary missing input, and the one key an
+ * operator reading a long list must see first.
+ * @type {String}
  */
-const REQUIRED_FINDING_LISTS = ['missingRequired', 'presentForbidden', 'missingSecrets'];
+const BOOT_BLOCKING_KEY = 'NEO_AI_ORCHESTRATOR_AUTHORITY_PROFILE';
 
 /**
- * @summary Validates a parsed discover result against the consumed contract, returning named problems
- * rather than throwing.
+ * @summary Parses a Docker `Config.Env` array (`['KEY=value', …]`) into a Map of the guarded keys only.
  *
- * Every problem returned here becomes an apply blocker. Refusing on shape is deliberate: this tool
- * mutates a deployment, so it must not proceed on a payload it only partly understood.
- * @param {Object} discover The parsed JSON output of the discover driver.
- * @param {String} [expectedProfile] When given, the result's profile must match it exactly.
- * @returns {String[]} Problem descriptions; empty means the payload is consumable.
+ * Splits on the FIRST `=` because values legitimately contain `=` (base64, query strings, DSNs);
+ * splitting on all of them would truncate a value and make a present key look malformed. A bare `KEY`
+ * with no `=` is recorded with an empty-string value — Docker permits it, and treating it as absent
+ * would hide a key that was set-but-empty, which is a different defect from unset.
+ * @param {String[]} envArray Raw `Config.Env` entries; a non-array yields an empty Map.
+ * @returns {Map<String,String>} Guarded key → value, insertion-ordered.
  */
-export function validateDiscoverResult(discover, expectedProfile) {
-    const problems = [];
+export function parseObservedEnv(envArray) {
+    const observed = new Map();
 
-    if (!discover || typeof discover !== 'object' || Array.isArray(discover)) {
-        return ['discover result is not an object — nothing to validate']
+    if (!Array.isArray(envArray)) {
+        return observed
     }
 
-    if (discover.schemaVersion !== DISCOVER_SCHEMA_VERSION) {
-        problems.push(
-            `discover schemaVersion is ${JSON.stringify(discover.schemaVersion)}; this consumer implements ` +
-            `${DISCOVER_SCHEMA_VERSION} — refusing to interpret an unknown shape`
+    for (const entry of envArray) {
+        if (typeof entry !== 'string') {
+            continue
+        }
+
+        const separatorIndex = entry.indexOf('='),
+              key            = separatorIndex === -1 ? entry : entry.slice(0, separatorIndex);
+
+        if (GUARDED_ENV_KEY.test(key)) {
+            observed.set(key, separatorIndex === -1 ? '' : entry.slice(separatorIndex + 1))
+        }
+    }
+
+    return observed
+}
+
+/**
+ * @summary Resolves one profile's classified census out of the config-leaf parity document, failing closed.
+ *
+ * Throws rather than defaulting on an unknown profile. A default would silently plan against the
+ * canonical cloud contract for a deployment running a different one, and the resulting plan would read
+ * as authoritative — the census is per-profile precisely because the contracts differ.
+ * @param {Object} parity The parsed `ai/scripts/lint/config-leaf-parity.json`.
+ * @param {String} profile Repo-relative Compose path, e.g. `ai/deploy/docker-compose.yml`.
+ * @returns {Object} `{requiredDeploymentInputs, optionalOverrides, secrets, forbiddenEnv, profile}`
+ * @throws {Error} When the parity document, its parity block, or the profile is absent or mismatched.
+ */
+export function resolveCensus(parity, profile) {
+    const parityBlock = parity?.$composeDefaultParity;
+
+    if (!parityBlock) {
+        throw new Error('config-leaf-parity.json carries no $composeDefaultParity block — cannot plan against an unknown contract')
+    }
+
+    const profiles = parityBlock.profiles || {};
+
+    if (!Object.prototype.hasOwnProperty.call(profiles, profile)) {
+        throw new Error(
+            `profile '${profile}' is not declared in $composeDefaultParity.profiles ` +
+            `(declared: ${Object.keys(profiles).join(', ') || 'none'}) — refusing to plan against a defaulted contract`
         )
     }
 
-    if (typeof discover.profile !== 'string' || !discover.profile) {
-        problems.push('discover result carries no profile — the census is per-profile, so an unlabelled result cannot be trusted')
-    } else if (expectedProfile && discover.profile !== expectedProfile) {
-        problems.push(`discover result describes profile '${discover.profile}' but this run targets '${expectedProfile}'`)
+    const census = parityBlock.census || {};
+
+    // The census block names ONE profile. Planning another against it would compare a deployment to a
+    // contract that is not its own, so say so instead of proceeding.
+    if (census.profile && census.profile !== profile) {
+        throw new Error(
+            `the census describes profile '${census.profile}', not '${profile}' — ` +
+            'the classified key lists are per-profile and cannot be reused across contracts'
+        )
     }
 
-    REQUIRED_FINDING_LISTS.forEach(listName => {
-        if (!Array.isArray(discover[listName])) {
-            problems.push(`discover result is missing the '${listName}' list — absent and empty are indistinguishable once parsed, so absence is refused`)
-        }
-    });
-
-    // A producer that reports its own findings but claims nothing about cleanliness leaves the gate
-    // deciding a question the producer was meant to answer.
-    if (typeof discover.clean !== 'boolean') {
-        problems.push("discover result carries no boolean 'clean' verdict")
+    return {
+        profile,
+        requiredDeploymentInputs: Array.isArray(census.requiredDeploymentInputs) ? census.requiredDeploymentInputs : [],
+        optionalOverrides       : Array.isArray(census.optionalOverrides)        ? census.optionalOverrides        : [],
+        secrets                 : Array.isArray(census.secrets)                  ? census.secrets                  : [],
+        forbiddenEnv            : parityBlock.forbiddenEnv || {}
     }
+}
 
-    return problems
+/**
+ * @summary Derives the config-contract delta by comparing the observed env against the census.
+ *
+ * The single resolver. Reason text for a forbidden key is taken **verbatim from the census**, which
+ * already declares each one's replacement guidance — re-authoring it here would create a second copy
+ * free to drift from the authority it paraphrases.
+ * @param {Map<String,String>} observedEnv Output of {@link parseObservedEnv}.
+ * @param {Object}             census      Output of {@link resolveCensus}.
+ * @returns {Object} `{missingRequired, presentForbidden, missingSecrets, optionalPresent}`
+ */
+export function deriveContractDelta(observedEnv, census) {
+    return {
+        missingRequired : census.requiredDeploymentInputs
+            .filter(key => !observedEnv.has(key))
+            .map(key => ({
+                key,
+                bootBlocking: key === BOOT_BLOCKING_KEY,
+                reason      : key === BOOT_BLOCKING_KEY
+                    ? 'declared required with no leaf default, so a launch that does not declare it is refused rather than degraded'
+                    : 'declared in the census as a required deployment input and absent from the observed deployment'
+            })),
+        presentForbidden: Object.keys(census.forbiddenEnv)
+            .filter(key => observedEnv.has(key))
+            .map(key => ({key, reason: String(census.forbiddenEnv[key])})),
+        missingSecrets  : census.secrets
+            .filter(key => !observedEnv.has(key))
+            .map(key => ({key, reason: 'declared as a required secret and absent from the observed deployment'})),
+        optionalPresent : census.optionalOverrides.filter(key => observedEnv.has(key))
+    }
 }
 
 /**
  * @summary Normalizes one finding entry to `{key, reason}`, tolerating a bare string key.
- *
- * The reason text is taken verbatim from the producer and never re-authored: the census already
- * declares each forbidden key's replacement guidance, and a second copy here would drift from it.
  * @param {Object|String} finding
  * @returns {Object} `{key, reason}`
  */
@@ -114,41 +191,47 @@ function normalizeFinding(finding) {
  * failure, and collapsing it into either is how a partial plan reads as complete. `unchecked` never
  * blocks; it travels into the apply receipt so the operator sees exactly what was not proven.
  *
- * @param {Object}      config
- * @param {Object}      config.discover           Parsed discover result from the discover driver.
- * @param {Object}      config.composeIdentity    `{project, configFiles}` read off the running plane; `null` when undiscoverable.
- * @param {Object}      config.deployedRevisions  Service name → revision string, or `null` for unreadable.
- * @param {String|null} config.targetRevision     The resolved 40-hex target, or `null` when resolution failed.
- * @param {String}      [config.expectedProfile]  Profile the discover result must describe.
- * @param {String[]}    [config.uncheckedNotes]   Entrypoint-supplied items it could not evaluate.
- * @returns {Object} `{clean, blockers, unchecked, notes, revisionDelta, discoverFindings}`
+ * @param {Object}             config
+ * @param {Map<String,String>} config.observedEnv        Guarded env observed on the target's containers.
+ * @param {Object}             config.census             Output of {@link resolveCensus}.
+ * @param {Object}             config.composeIdentity    `{project, configFiles}` read off the running plane; `null` when undiscoverable.
+ * @param {Object}             config.deployedRevisions  Service name → revision string, or `null` for unreadable.
+ * @param {String|null}        config.targetRevision     The resolved 40-hex target, or `null` when resolution failed.
+ * @param {String[]}           [config.uncheckedNotes]   Entrypoint-supplied items it could not evaluate.
+ * @returns {Object} `{clean, blockers, unchecked, notes, revisionDelta, contractDelta}`
  */
-export function buildMigrationPlan({discover, composeIdentity, deployedRevisions, targetRevision, expectedProfile, uncheckedNotes = []}) {
+export function buildMigrationPlan({observedEnv, census, composeIdentity, deployedRevisions, targetRevision, uncheckedNotes = []}) {
     const blockers  = [],
           unchecked = [...uncheckedNotes],
           notes     = [];
 
-    // 1. The consumed payload itself. A shape problem refuses before any finding is read, because a
-    // payload this core only partly understood cannot authorize a mutation.
-    const shapeProblems = validateDiscoverResult(discover, expectedProfile);
+    // 1. An unreadable target cannot be compared to any contract. Refused before deriving anything,
+    // because an EMPTY observed set would otherwise derive "every required key is missing" — a
+    // spectacular-looking delta whose real cause is that nothing was read.
+    if (!(observedEnv instanceof Map) || observedEnv.size === 0) {
+        blockers.push({
+            kind  : 'no-observed-env',
+            key   : 'Config.Env',
+            reason: 'no guarded env was read from the target, so the contract delta would be derived from an empty ' +
+                    'observation and every required key would appear missing for the wrong reason'
+        })
+    }
 
-    shapeProblems.forEach(reason => blockers.push({kind: 'discover-result-invalid', key: 'discover', reason}));
+    const contractDelta   = deriveContractDelta(observedEnv instanceof Map ? observedEnv : new Map(), census),
+          missingRequired = contractDelta.missingRequired.map(normalizeFinding),
+          forbiddenSet    = contractDelta.presentForbidden.map(normalizeFinding),
+          missingSecrets  = contractDelta.missingSecrets.map(normalizeFinding);
 
-    const usable          = shapeProblems.length === 0,
-          missingRequired = usable ? discover.missingRequired.map(normalizeFinding)  : [],
-          forbiddenSet    = usable ? discover.presentForbidden.map(normalizeFinding) : [],
-          missingSecrets  = usable ? discover.missingSecrets.map(normalizeFinding)   : [];
-
-    // 2. The contract delta, forwarded as blockers. `bootBlocking` is surfaced as a distinct kind
-    // because the discover contract distinguishes it: a missing authority role is a refused launch, not a
-    // degraded one, and an operator triaging a long list needs that ordering.
+    // 2. The contract delta as blockers. Boot-blocking gets its own kind: a refused launch is a
+    // different triage priority from a degraded one, and it is the one key an operator reading a long
+    // list must see first.
     missingRequired.forEach(({key, reason}) => {
-        const bootBlocking = usable && discover.missingRequired.some(entry => entry?.key === key && entry?.bootBlocking === true);
+        const bootBlocking = contractDelta.missingRequired.some(entry => entry.key === key && entry.bootBlocking === true);
 
         blockers.push({
             kind  : bootBlocking ? 'missing-required-input-boot-blocking' : 'missing-required-input',
             key,
-            reason: reason || 'declared in the census as a required deployment input and absent from the target'
+            reason
         })
     });
 
@@ -164,21 +247,19 @@ export function buildMigrationPlan({discover, composeIdentity, deployedRevisions
         reason: reason || 'declared as a required secret and absent from the target'
     }));
 
-    // A producer that reports no findings but calls itself dirty knows something this gate does not;
-    // trusting the findings over the verdict would silently discard it.
-    if (usable && discover.clean === false && missingRequired.length + forbiddenSet.length + missingSecrets.length === 0) {
-        blockers.push({
-            kind  : 'discover-verdict-unexplained',
-            key   : 'clean',
-            reason: 'the discover result reports clean=false while listing no findings — refusing rather than resolving the contradiction'
-        })
+    contractDelta.optionalPresent.forEach(key => notes.push(`optional override set: ${key}`));
+
+    // Secrets are named in the census but their VALUES are not observable through container env in
+    // every deployment shape, so a satisfied secret list is weaker evidence than a satisfied required
+    // list. Say so rather than letting a clean secrets check read as a proof it is not.
+    if (census.secrets.length && missingSecrets.length === 0) {
+        unchecked.push(
+            `secret presence was checked by env key only (${census.secrets.length} declared) — a key set to an ` +
+            'empty or stale value reads as present'
+        )
     }
 
-    if (usable && Array.isArray(discover.unchecked)) {
-        unchecked.push(...discover.unchecked.map(item => `discover: ${item}`))
-    }
-
-    // 3. Compose identity — a plane-side fact discovery cannot supply. Undiscoverable identity is a
+    // 3. Compose identity — a plane-side fact the census cannot supply. Undiscoverable identity is a
     // blocker and never a default, because the shipped pipeline's own defaults (`neo-agent-os`, one
     // compose file) would address a DIFFERENT project with the overlay dropped.
     if (!composeIdentity?.project || !Array.isArray(composeIdentity.configFiles) || composeIdentity.configFiles.length === 0) {
@@ -238,15 +319,18 @@ export function buildMigrationPlan({discover, composeIdentity, deployedRevisions
     }
 
     return {
-        clean           : blockers.length === 0,
+        clean        : blockers.length === 0,
         blockers,
         unchecked,
         notes,
-        revisionDelta   : {from: singleRunning, to: targetRevision, alreadyTarget},
-        discoverFindings: {
+        revisionDelta: {from: singleRunning, to: targetRevision, alreadyTarget},
+        contractDelta: {
+            profile         : census.profile,
             missingRequired : missingRequired.map(({key}) => key),
             presentForbidden: forbiddenSet.map(({key}) => key),
-            missingSecrets  : missingSecrets.map(({key}) => key)
+            missingSecrets  : missingSecrets.map(({key}) => key),
+            optionalPresent : contractDelta.optionalPresent,
+            observedKeyCount: observedEnv instanceof Map ? observedEnv.size : 0
         }
     }
 }

--- a/ai/scripts/maintenance/deploymentMigrationCore.mjs
+++ b/ai/scripts/maintenance/deploymentMigrationCore.mjs
@@ -1,0 +1,292 @@
+/**
+ * @module ai/scripts/maintenance/deploymentMigrationCore
+ * @summary Pure core for the migration bootstrap's apply gate: validates a discover result produced by
+ * the census-derived discover driver, joins it with the plane-side facts only this tool observes, and
+ * decides whether one `apply` is authorized or refused with named reasons.
+ *
+ * ## The boundary, and why there is no fallback derivation
+ *
+ * The discover driver owns DISCOVERY — deriving missing-required / present-forbidden / missing-secret
+ * keys from the classified config census and emitting them as JSON. This module owns CONSUMPTION and
+ * the apply gate. It deliberately carries **no census derivation of its own**, not even as a fallback
+ * for an absent discover result: two resolvers for one contract can disagree, and the disagreement
+ * surfaces as a migration that was authorized against the wrong answer. A parallel resolution path
+ * running beside the canonical one is the shape this repository has already had to retire once, so an
+ * absent discover result refuses rather than falling back.
+ *
+ * ## What this module knows that the discover driver cannot
+ *
+ * Discovery reads a contract. Apply must also read the *plane*: which Compose project and file list
+ * the running containers actually belong to, and whether the cohort agrees with itself about the
+ * revision it is on. Neither is derivable from the census, and both can refuse an apply that a clean
+ * discover result would otherwise authorize.
+ *
+ * ## Neo-free on purpose
+ *
+ * No Neo import, no Docker call, no filesystem read: every refusal branch is reachable from a plain
+ * object, so the gate is unit-testable without a container or a plane.
+ */
+
+/**
+ * The discover-result schema version this core consumes. A mismatch refuses rather than best-efforts:
+ * a shape change in the producer must fail loudly here, because the failure mode of silent
+ * mis-parsing is an apply authorized against fields that were never populated.
+ * @type {Number}
+ */
+export const DISCOVER_SCHEMA_VERSION = 1;
+
+/**
+ * The finding lists a discover result must carry. Presence is required; emptiness is fine and is the
+ * normal clean case. An ABSENT list is refused because absent and empty are the same shape once
+ * parsed, and treating a missing list as empty reads "you are fine" from a producer that never ran
+ * that check — the exact failure the discover contract forbids: never report an empty delta.
+ * @type {String[]}
+ */
+const REQUIRED_FINDING_LISTS = ['missingRequired', 'presentForbidden', 'missingSecrets'];
+
+/**
+ * @summary Validates a parsed discover result against the consumed contract, returning named problems
+ * rather than throwing.
+ *
+ * Every problem returned here becomes an apply blocker. Refusing on shape is deliberate: this tool
+ * mutates a deployment, so it must not proceed on a payload it only partly understood.
+ * @param {Object} discover The parsed JSON output of the discover driver.
+ * @param {String} [expectedProfile] When given, the result's profile must match it exactly.
+ * @returns {String[]} Problem descriptions; empty means the payload is consumable.
+ */
+export function validateDiscoverResult(discover, expectedProfile) {
+    const problems = [];
+
+    if (!discover || typeof discover !== 'object' || Array.isArray(discover)) {
+        return ['discover result is not an object — nothing to validate']
+    }
+
+    if (discover.schemaVersion !== DISCOVER_SCHEMA_VERSION) {
+        problems.push(
+            `discover schemaVersion is ${JSON.stringify(discover.schemaVersion)}; this consumer implements ` +
+            `${DISCOVER_SCHEMA_VERSION} — refusing to interpret an unknown shape`
+        )
+    }
+
+    if (typeof discover.profile !== 'string' || !discover.profile) {
+        problems.push('discover result carries no profile — the census is per-profile, so an unlabelled result cannot be trusted')
+    } else if (expectedProfile && discover.profile !== expectedProfile) {
+        problems.push(`discover result describes profile '${discover.profile}' but this run targets '${expectedProfile}'`)
+    }
+
+    REQUIRED_FINDING_LISTS.forEach(listName => {
+        if (!Array.isArray(discover[listName])) {
+            problems.push(`discover result is missing the '${listName}' list — absent and empty are indistinguishable once parsed, so absence is refused`)
+        }
+    });
+
+    // A producer that reports its own findings but claims nothing about cleanliness leaves the gate
+    // deciding a question the producer was meant to answer.
+    if (typeof discover.clean !== 'boolean') {
+        problems.push("discover result carries no boolean 'clean' verdict")
+    }
+
+    return problems
+}
+
+/**
+ * @summary Normalizes one finding entry to `{key, reason}`, tolerating a bare string key.
+ *
+ * The reason text is taken verbatim from the producer and never re-authored: the census already
+ * declares each forbidden key's replacement guidance, and a second copy here would drift from it.
+ * @param {Object|String} finding
+ * @returns {Object} `{key, reason}`
+ */
+function normalizeFinding(finding) {
+    if (typeof finding === 'string') {
+        return {key: finding, reason: ''}
+    }
+
+    return {key: String(finding?.key ?? '<unnamed>'), reason: String(finding?.reason ?? '')}
+}
+
+/**
+ * @summary Builds the apply gate: blockers that refuse, unchecked items that must be reported rather
+ * than passed over, and informational notes.
+ *
+ * Three buckets, and the middle one is the point. An input nothing could evaluate — an overlay the
+ * operator did not supply, a stopped container whose revision is unreadable — is neither a pass nor a
+ * failure, and collapsing it into either is how a partial plan reads as complete. `unchecked` never
+ * blocks; it travels into the apply receipt so the operator sees exactly what was not proven.
+ *
+ * @param {Object}      config
+ * @param {Object}      config.discover           Parsed discover result from the discover driver.
+ * @param {Object}      config.composeIdentity    `{project, configFiles}` read off the running plane; `null` when undiscoverable.
+ * @param {Object}      config.deployedRevisions  Service name → revision string, or `null` for unreadable.
+ * @param {String|null} config.targetRevision     The resolved 40-hex target, or `null` when resolution failed.
+ * @param {String}      [config.expectedProfile]  Profile the discover result must describe.
+ * @param {String[]}    [config.uncheckedNotes]   Entrypoint-supplied items it could not evaluate.
+ * @returns {Object} `{clean, blockers, unchecked, notes, revisionDelta, discoverFindings}`
+ */
+export function buildMigrationPlan({discover, composeIdentity, deployedRevisions, targetRevision, expectedProfile, uncheckedNotes = []}) {
+    const blockers  = [],
+          unchecked = [...uncheckedNotes],
+          notes     = [];
+
+    // 1. The consumed payload itself. A shape problem refuses before any finding is read, because a
+    // payload this core only partly understood cannot authorize a mutation.
+    const shapeProblems = validateDiscoverResult(discover, expectedProfile);
+
+    shapeProblems.forEach(reason => blockers.push({kind: 'discover-result-invalid', key: 'discover', reason}));
+
+    const usable          = shapeProblems.length === 0,
+          missingRequired = usable ? discover.missingRequired.map(normalizeFinding)  : [],
+          forbiddenSet    = usable ? discover.presentForbidden.map(normalizeFinding) : [],
+          missingSecrets  = usable ? discover.missingSecrets.map(normalizeFinding)   : [];
+
+    // 2. The contract delta, forwarded as blockers. `bootBlocking` is surfaced as a distinct kind
+    // because the discover contract distinguishes it: a missing authority role is a refused launch, not a
+    // degraded one, and an operator triaging a long list needs that ordering.
+    missingRequired.forEach(({key, reason}) => {
+        const bootBlocking = usable && discover.missingRequired.some(entry => entry?.key === key && entry?.bootBlocking === true);
+
+        blockers.push({
+            kind  : bootBlocking ? 'missing-required-input-boot-blocking' : 'missing-required-input',
+            key,
+            reason: reason || 'declared in the census as a required deployment input and absent from the target'
+        })
+    });
+
+    forbiddenSet.forEach(({key, reason}) => blockers.push({
+        kind  : 'forbidden-env-present',
+        key,
+        reason: reason || 'declared retired or derived by the census and still set on the target'
+    }));
+
+    missingSecrets.forEach(({key, reason}) => blockers.push({
+        kind  : 'missing-secret',
+        key,
+        reason: reason || 'declared as a required secret and absent from the target'
+    }));
+
+    // A producer that reports no findings but calls itself dirty knows something this gate does not;
+    // trusting the findings over the verdict would silently discard it.
+    if (usable && discover.clean === false && missingRequired.length + forbiddenSet.length + missingSecrets.length === 0) {
+        blockers.push({
+            kind  : 'discover-verdict-unexplained',
+            key   : 'clean',
+            reason: 'the discover result reports clean=false while listing no findings — refusing rather than resolving the contradiction'
+        })
+    }
+
+    if (usable && Array.isArray(discover.unchecked)) {
+        unchecked.push(...discover.unchecked.map(item => `discover: ${item}`))
+    }
+
+    // 3. Compose identity — a plane-side fact discovery cannot supply. Undiscoverable identity is a
+    // blocker and never a default, because the shipped pipeline's own defaults (`neo-agent-os`, one
+    // compose file) would address a DIFFERENT project with the overlay dropped.
+    if (!composeIdentity?.project || !Array.isArray(composeIdentity.configFiles) || composeIdentity.configFiles.length === 0) {
+        blockers.push({
+            kind  : 'compose-identity-undiscoverable',
+            key   : 'com.docker.compose.project.config_files',
+            reason: "the target's Compose project and file list could not be read from its containers; " +
+                    'applying would fall back to the pipeline default and address a different project'
+        })
+    } else {
+        notes.push(`compose identity: project '${composeIdentity.project}', ${composeIdentity.configFiles.length} file(s)`)
+    }
+
+    if (!targetRevision) {
+        blockers.push({
+            kind  : 'target-revision-unresolved',
+            key   : 'target',
+            reason: 'the desired revision could not be resolved to a single commit; refusing to plan against an unpinned target'
+        })
+    }
+
+    // 4. Cohort agreement — the other plane-side fact. A cohort that disagrees with itself is a
+    // partially-applied prior run: the "before" half of the receipt would be a fiction, and the
+    // services left behind are the ones a fresh apply is most likely to strand.
+    const readableValues  = Object.values(deployedRevisions || {}).filter(Boolean),
+          distinctRunning = new Set(readableValues);
+
+    Object.entries(deployedRevisions || {}).forEach(([service, revision]) => {
+        if (!revision) {
+            unchecked.push(`service '${service}': /app/.neo-revision unreadable — its before-state is not established`)
+        }
+    });
+
+    if (readableValues.length === 0) {
+        blockers.push({
+            kind  : 'no-readable-revision',
+            key   : '/app/.neo-revision',
+            reason: 'no service reported a revision, so neither the delta nor the post-apply assertion has a baseline'
+        })
+    } else if (distinctRunning.size > 1) {
+        blockers.push({
+            kind  : 'cohort-revision-split',
+            key   : '/app/.neo-revision',
+            reason: `services report ${distinctRunning.size} different revisions (${[...distinctRunning].join(', ')}) — ` +
+                    'a partially-applied prior run must be reconciled before a new migration is planned'
+        })
+    }
+
+    // 5. The revision delta — reported, never a blocker. Already-at-target is a legitimate outcome:
+    // the CONFIG delta decides whether a deployment is healthy, and a plane can be current on
+    // revision while still missing a required input.
+    const singleRunning = distinctRunning.size === 1 ? [...distinctRunning][0] : null,
+          alreadyTarget = Boolean(singleRunning && targetRevision && singleRunning === targetRevision);
+
+    if (alreadyTarget) {
+        notes.push(`already at target revision ${targetRevision} — apply would deliver no code change`)
+    }
+
+    return {
+        clean           : blockers.length === 0,
+        blockers,
+        unchecked,
+        notes,
+        revisionDelta   : {from: singleRunning, to: targetRevision, alreadyTarget},
+        discoverFindings: {
+            missingRequired : missingRequired.map(({key}) => key),
+            presentForbidden: forbiddenSet.map(({key}) => key),
+            missingSecrets  : missingSecrets.map(({key}) => key)
+        }
+    }
+}
+
+/**
+ * @summary Renders a plan as operator-readable text. Blockers first, because the plan's job is to say
+ * why `apply` is refused before it says anything reassuring.
+ * @param {Object} plan Output of {@link buildMigrationPlan}.
+ * @returns {String} Multi-line report, no trailing newline.
+ */
+export function formatPlan(plan) {
+    const lines = ['[migrate] === MIGRATION PLAN ==='];
+
+    lines.push(`[migrate] revision: ${plan.revisionDelta.from || '<unreadable>'} -> ${plan.revisionDelta.to || '<unresolved>'}`);
+
+    if (plan.blockers.length) {
+        lines.push('', `[migrate] BLOCKERS (${plan.blockers.length}) — apply is refused:`);
+
+        // Boot-blocking first: a refused launch is a different triage priority from a degraded one.
+        const ordered = [
+            ...plan.blockers.filter(blocker => blocker.kind === 'missing-required-input-boot-blocking'),
+            ...plan.blockers.filter(blocker => blocker.kind !== 'missing-required-input-boot-blocking')
+        ];
+
+        ordered.forEach(({kind, key, reason}) => lines.push(`[migrate]   ✖ ${kind}: ${key}`, `[migrate]       ${reason}`))
+    } else {
+        lines.push('', '[migrate] no blockers — apply is authorized')
+    }
+
+    if (plan.unchecked.length) {
+        lines.push('', `[migrate] NOT VERIFIED (${plan.unchecked.length}) — neither passed nor failed:`);
+        plan.unchecked.forEach(item => lines.push(`[migrate]   ? ${item}`))
+    }
+
+    if (plan.notes.length) {
+        lines.push('', '[migrate] notes:');
+        plan.notes.forEach(note => lines.push(`[migrate]   · ${note}`))
+    }
+
+    lines.push('', `[migrate] verdict: ${plan.clean ? 'CLEAN' : 'REFUSED'}`);
+
+    return lines.join('\n')
+}

--- a/ai/scripts/maintenance/migrateDeployment.mjs
+++ b/ai/scripts/maintenance/migrateDeployment.mjs
@@ -1,0 +1,444 @@
+#!/usr/bin/env node
+import fs              from 'fs-extra';
+import path            from 'path';
+import {execFile}      from 'node:child_process';
+import {promisify}     from 'node:util';
+import {fileURLToPath} from 'url';
+
+import {buildMigrationPlan, formatPlan} from './deploymentMigrationCore.mjs';
+
+/**
+ * @module ai/scripts/maintenance/migrateDeployment
+ * @summary Operator-invoked migration bootstrap for a lagging Agent OS deployment: `plan` joins
+ * the discover driver's contract delta with the plane-side facts only this tool observes and reports whether
+ * a migration is authorized; `apply` runs the shipped safe deploy pipeline at a pinned revision, and
+ * only after a clean plan.
+ *
+ * ## Usage
+ *
+ * ```
+ * node ai/scripts/maintenance/migrateDeployment.mjs plan  --discover-json <path> [--target dev]
+ * node ai/scripts/maintenance/migrateDeployment.mjs apply --discover-json <path> --target <sha>
+ * ```
+ *
+ * ## Why plan-then-apply rather than a caller
+ *
+ * Wiring the pipeline alone would rebuild a still-invalid configuration and land on the same unhealthy
+ * plane — loudly, via the health gate, but no closer to running. The orchestrator's authority role is
+ * the worked case: its leaf carries NO default, so a deployment that does not declare
+ * `NEO_AI_ORCHESTRATOR_AUTHORITY_PROFILE` produces a refused launch that writes no state directory, no
+ * PID file and no log. The config delta decides whether the migration can work at all; the revision
+ * delta is secondary.
+ *
+ * ## Why the contract delta is consumed and never re-derived
+ *
+ * The discover driver owns derivation — it reads the classified config census and emits the delta as
+ * JSON for a caller to consume as the plan step of a bootstrap. This driver consumes it and adds
+ * nothing to it. There is deliberately no fallback derivation for an absent discover result: two
+ * resolvers for one contract can disagree, and a parallel resolution path is the shape this repository
+ * has already had to retire once. Absent input refuses with a named reason.
+ *
+ * ## Why the target's Compose identity is discovered
+ *
+ * `deploy-pipeline.sh` takes a `--project-name` defaulting to `neo-agent-os`, and real planes are not
+ * built that way: the canonical local plane runs `docker-compose.yml` plus
+ * `docker-compose.local-agent-os.yml` under project `neo-local-agent-os`. Invoking the pipeline with
+ * its defaults would drop the overlay and address a different project, so both values are read off the
+ * running containers' `com.docker.compose.*` labels and the run is refused when they cannot be.
+ *
+ * ## Why no Neo/AiConfig bootstrap
+ *
+ * This driver reads no config leaf; its inputs are a sibling driver's JSON and the Docker plane.
+ * Staying Neo-free keeps it runnable against a deployment whose own config tree is the thing under
+ * suspicion.
+ */
+
+const execFileAsync = promisify(execFile),
+      scriptDir     = path.dirname(fileURLToPath(import.meta.url)),
+      repoRoot      = path.resolve(scriptDir, '../../..'),
+      PIPELINE_REL  = 'ai/examples/cloud-deployment/deploy-pipeline.sh',
+      DEFAULT_REPO  = 'https://github.com/neomjs/neo.git',
+      /**
+       * The cohort whose `/app/.neo-revision` must move for a migration to count as delivered.
+       * Overridable with `--services`; every listed service is asserted, so an under-listed cohort
+       * narrows the proof rather than widening the pass.
+       * @type {String[]}
+       */
+      DEFAULT_SERVICES = ['mc-server', 'orchestrator', 'kb-server'];
+
+/**
+ * @summary Runs a command, returning `{ok, stdout, stderr, code}` instead of throwing.
+ *
+ * Docker absence, a stopped daemon and a missing container are ORDINARY inputs to a plan — each
+ * becomes a named blocker or an unchecked item. Throwing would collapse "the deployment is
+ * unreachable" into the same shape as "this driver has a bug".
+ * @param {String}   command
+ * @param {String[]} args
+ * @param {Object}   [env] Extra environment for the child; merged over `process.env`.
+ * @returns {Promise<Object>} `{ok, stdout, stderr, code}`
+ */
+async function run(command, args, env) {
+    try {
+        const {stdout, stderr} = await execFileAsync(command, args, {
+            cwd      : repoRoot,
+            maxBuffer: 16 * 1024 * 1024,
+            env      : env ? {...process.env, ...env} : process.env
+        });
+
+        return {ok: true, stdout: stdout.trim(), stderr: stderr.trim(), code: 0}
+    } catch (error) {
+        return {ok: false, stdout: (error.stdout || '').trim(), stderr: (error.stderr || error.message || '').trim(), code: error.code ?? 1}
+    }
+}
+
+/**
+ * @summary Parses argv, refusing an unknown mode or flag.
+ * @param {String[]} argv `process.argv.slice(2)`
+ * @returns {Object} `{mode, target, project, profile, services, repoUrl, discoverJson}`
+ * @throws {Error} On a missing/unknown mode, an unknown flag, or a flag without a value.
+ */
+export function parseArgs(argv) {
+    const [mode, ...rest] = argv,
+          options         = {
+              mode,
+              target      : 'dev',
+              project     : null,
+              profile     : 'ai/deploy/docker-compose.yml',
+              services    : DEFAULT_SERVICES,
+              repoUrl     : process.env.NEO_REPO_URL || DEFAULT_REPO,
+              discoverJson: null
+          };
+
+    if (mode !== 'plan' && mode !== 'apply') {
+        throw new Error(`first argument must be 'plan' or 'apply' (received: ${mode || '<none>'})`)
+    }
+
+    for (let i = 0; i < rest.length; i += 2) {
+        const flag  = rest[i],
+              value = rest[i + 1];
+
+        if (value === undefined) {
+            throw new Error(`flag ${flag} requires a value`)
+        }
+
+        switch (flag) {
+            case '--target'       : options.target       = value; break;
+            case '--project'      : options.project      = value; break;
+            case '--profile'      : options.profile      = value; break;
+            case '--repo-url'     : options.repoUrl      = value; break;
+            case '--discover-json': options.discoverJson = value; break;
+            case '--services'     : options.services     = value.split(',').map(entry => entry.trim()).filter(Boolean); break;
+            default               : throw new Error(`unknown flag: ${flag}`)
+        }
+    }
+
+    return options
+}
+
+/**
+ * @summary Finds the target's Compose project by asking which project owns the cohort's containers.
+ *
+ * Ambiguity is refused rather than resolved, mirroring the pipeline's own `match_count -ne 1` abort:
+ * on a host running several planes, picking one would migrate a deployment the operator did not name.
+ * Stopped containers count — a dead deployment is exactly the case this tool exists for.
+ * @param {String[]}    services
+ * @param {String|null} declaredProject Skips discovery when the operator named one.
+ * @returns {Promise<Object>} `{project, error}` — `project` is `null` when undiscoverable.
+ */
+async function discoverProject(services, declaredProject) {
+    if (declaredProject) {
+        return {project: declaredProject, error: null}
+    }
+
+    const projects = new Set();
+
+    for (const service of services) {
+        const result = await run('docker', [
+            'ps', '-a',
+            '--filter', `label=com.docker.compose.service=${service}`,
+            '--format', '{{.Label "com.docker.compose.project"}}'
+        ]);
+
+        if (result.ok) {
+            result.stdout.split('\n').map(line => line.trim()).filter(Boolean).forEach(project => projects.add(project))
+        }
+    }
+
+    if (projects.size === 1) {
+        return {project: [...projects][0], error: null}
+    }
+
+    return {
+        project: null,
+        error  : projects.size === 0
+            ? 'no container carries a com.docker.compose.service label from the requested cohort'
+            : `cohort containers span ${projects.size} Compose projects (${[...projects].join(', ')}) — name one with --project`
+    }
+}
+
+/**
+ * @summary Reads the plane-side facts: Compose identity from container labels and each service's
+ * `/app/.neo-revision`.
+ * @param {String}   project
+ * @param {String[]} services
+ * @returns {Promise<Object>} `{composeIdentity, deployedRevisions, unchecked}`
+ */
+async function inspectPlane(project, services) {
+    const deployedRevisions = {},
+          unchecked         = [];
+
+    let composeIdentity = null;
+
+    for (const service of services) {
+        const lookup = await run('docker', [
+            'ps', '-a',
+            '--filter', `label=com.docker.compose.project=${project}`,
+            '--filter', `label=com.docker.compose.service=${service}`,
+            '--format', '{{.Names}}'
+        ]);
+
+        const containerName = lookup.ok ? lookup.stdout.split('\n')[0]?.trim() : '';
+
+        if (!containerName) {
+            deployedRevisions[service] = null;
+            unchecked.push(`service '${service}': no container under project '${project}' — not inspected`);
+            continue
+        }
+
+        const inspected = await run('docker', ['inspect', containerName, '--format', '{{json .Config.Labels}}']);
+
+        if (inspected.ok && !composeIdentity) {
+            // The first service that yields labels establishes the plane's identity: every service in
+            // one project shares it, so reading it from whichever service answered keeps a single
+            // missing container from losing the identity entirely.
+            try {
+                const labels      = JSON.parse(inspected.stdout) || {},
+                      configFiles = (labels['com.docker.compose.project.config_files'] || '')
+                          .split(',').map(entry => entry.trim()).filter(Boolean);
+
+                if (configFiles.length) {
+                    composeIdentity = {
+                        project   : labels['com.docker.compose.project'] || project,
+                        configFiles,
+                        workingDir: labels['com.docker.compose.project.working_dir'] || null
+                    }
+                }
+            } catch (error) {
+                unchecked.push(`service '${service}': container labels were not parseable JSON — ${error.message}`)
+            }
+        }
+
+        const revision = await run('docker', ['exec', containerName, 'cat', '/app/.neo-revision']);
+
+        deployedRevisions[service] = revision.ok && revision.stdout ? revision.stdout.split(/\s+/)[0] : null;
+
+        if (!deployedRevisions[service]) {
+            unchecked.push(`service '${service}': /app/.neo-revision unreadable (container may be stopped) — ${revision.stderr || 'no detail'}`)
+        }
+    }
+
+    return {composeIdentity, deployedRevisions, unchecked}
+}
+
+/**
+ * @summary Resolves a selector to exactly one commit id against the remote.
+ *
+ * Uses the same `ls-remote <sel> <sel>^{}` shape the pipeline uses, for the same reason: an annotated
+ * tag advertises both its tag object and its peeled commit, and the tag object is not what Docker
+ * checks out. This is not a second resolver competing with the pipeline's — the resolved id is handed
+ * BACK to the pipeline as a 40-hex `NEO_REF`, which re-verifies it against its own remote and aborts on
+ * disagreement. Two independent confirmations of one pin; any divergence fails closed.
+ * @param {String} repoUrl
+ * @param {String} selector
+ * @returns {Promise<Object>} `{revision, error}`
+ */
+async function resolveTargetRevision(repoUrl, selector) {
+    if (/^[0-9a-f]{40}$/.test(selector)) {
+        return {revision: selector, error: null}
+    }
+
+    const result = await run('git', ['ls-remote', repoUrl, selector, `${selector}^{}`]);
+
+    if (!result.ok) {
+        return {revision: null, error: `git ls-remote failed for '${selector}' at ${repoUrl}: ${result.stderr || 'no detail'}`}
+    }
+
+    const rows = result.stdout.split('\n').map(line => line.split('\t')).filter(parts => parts.length === 2),
+          // Ambiguity is decided on the NON-peel refs, exactly as the pipeline does: a selector
+          // matching both a branch and an annotated tag is ambiguous, and preferring the peel first
+          // would collapse that to one silent winner.
+          plainRefs = rows.filter(([, ref]) => !ref.endsWith('^{}'));
+
+    if (plainRefs.length !== 1) {
+        return {revision: null, error: `selector '${selector}' matched ${plainRefs.length} refs at ${repoUrl}; expected exactly 1`}
+    }
+
+    const [, matchedRef] = plainRefs[0],
+          peeled         = rows.find(([, ref]) => ref === `${matchedRef}^{}`);
+
+    return {revision: (peeled || plainRefs[0])[0], error: null}
+}
+
+/**
+ * @summary Loads and parses the discover result, returning a named failure rather than throwing.
+ *
+ * An absent path is a refusal and not a fallback: this driver carries no census derivation, so with no
+ * discover result there is nothing to gate on.
+ * @param {String|null} discoverJsonPath
+ * @returns {Promise<Object>} `{discover, error}`
+ */
+async function loadDiscoverResult(discoverJsonPath) {
+    if (!discoverJsonPath) {
+        return {
+            discover: null,
+            error   : '--discover-json is required: the contract delta is produced by the discover driver and is never re-derived here'
+        }
+    }
+
+    const resolved = path.resolve(repoRoot, discoverJsonPath);
+
+    if (!await fs.pathExists(resolved)) {
+        return {discover: null, error: `discover result not found at ${resolved}`}
+    }
+
+    try {
+        return {discover: await fs.readJson(resolved), error: null}
+    } catch (error) {
+        return {discover: null, error: `discover result at ${resolved} is not parseable JSON — ${error.message}`}
+    }
+}
+
+/**
+ * @summary Invokes the shipped pipeline at the pinned revision with the discovered Compose identity.
+ *
+ * Everything the pipeline needs arrives as environment because the pipeline owns those contracts: this
+ * driver re-implements none of its preflight, project pinning or health gating.
+ * @param {Object} plan
+ * @param {Object} composeIdentity
+ * @returns {Promise<Number>} The pipeline's exit code.
+ */
+async function invokePipeline(plan, composeIdentity) {
+    const pipelineEnv = {
+        NEO_REF                : plan.revisionDelta.to,
+        NEO_DEPLOY_PROJECT_NAME: composeIdentity.project,
+        NEO_DEPLOY_COMPOSE_FILE: composeIdentity.configFiles.join(path.delimiter)
+    };
+
+    console.log(`[migrate] invoking ${PIPELINE_REL}`);
+    Object.entries(pipelineEnv).forEach(([key, value]) => console.log(`[migrate]   ${key}=${value}`));
+
+    const child = await run('bash', [path.join(repoRoot, PIPELINE_REL)], pipelineEnv);
+
+    // The pipeline's own output is the operator-facing record of the transition; forward it whole
+    // rather than summarizing, because its abort messages name the exact refusal condition.
+    if (child.stdout) console.log(child.stdout);
+    if (child.stderr) console.error(child.stderr);
+
+    return child.ok ? 0 : (child.code || 1)
+}
+
+/**
+ * @summary Drives one `plan` or `apply` run.
+ * @returns {Promise<Number>} `0` on a clean plan or a delivered apply; non-zero on any refusal.
+ */
+async function main() {
+    let options;
+
+    try {
+        options = parseArgs(process.argv.slice(2))
+    } catch (error) {
+        console.error(`[migrate] FATAL: ${error.message}`);
+        console.error('[migrate] usage: migrateDeployment.mjs plan|apply --discover-json <path> [--target <selector>] [--project <name>] [--profile <compose-path>] [--services a,b,c]');
+        return 2
+    }
+
+    console.log(`[migrate] mode:     ${options.mode}`);
+    console.log(`[migrate] profile:  ${options.profile}`);
+    console.log(`[migrate] selector: ${options.target}`);
+
+    const {discover, error: discoverError} = await loadDiscoverResult(options.discoverJson);
+
+    if (discoverError) {
+        console.error(`[migrate] FATAL: ${discoverError}`);
+        return 2
+    }
+
+    const {project, error: projectError} = await discoverProject(options.services, options.project);
+
+    if (!project) {
+        console.error(`[migrate] FATAL: Compose project undiscoverable — ${projectError}`);
+        return 2
+    }
+
+    const [{composeIdentity, deployedRevisions, unchecked}, {revision: targetRevision, error: targetError}] = await Promise.all([
+        inspectPlane(project, options.services),
+        resolveTargetRevision(options.repoUrl, options.target)
+    ]);
+
+    if (targetError) {
+        unchecked.push(`target revision: ${targetError}`)
+    }
+
+    const plan = buildMigrationPlan({
+        discover,
+        composeIdentity,
+        deployedRevisions,
+        targetRevision,
+        expectedProfile: options.profile,
+        uncheckedNotes : unchecked
+    });
+
+    console.log('');
+    console.log(formatPlan(plan));
+
+    if (options.mode === 'plan') {
+        return plan.clean ? 0 : 1
+    }
+
+    if (!plan.clean) {
+        console.error('');
+        console.error(`[migrate] FATAL: apply refused — the plan reports ${plan.blockers.length} blocker(s) above. Docker was NOT invoked.`);
+        return 1
+    }
+
+    console.log('');
+    console.log('[migrate] plan is clean — applying');
+
+    const pipelineCode = await invokePipeline(plan, composeIdentity);
+
+    if (pipelineCode !== 0) {
+        console.error(`[migrate] FATAL: pipeline exited ${pipelineCode}; the transition did not complete.`);
+        return pipelineCode
+    }
+
+    // The pipeline's success means the containers are HEALTHY, not that they carry the target code.
+    // A health-gated recreate proves the containers are up, not that they carry the target code. So the
+    // revision is re-read per service and compared to the pin.
+    console.log('');
+    console.log('[migrate] verifying /app/.neo-revision moved on every service...');
+
+    const after   = await inspectPlane(project, options.services),
+          unmoved = Object.entries(after.deployedRevisions).filter(([, revision]) => revision !== plan.revisionDelta.to);
+
+    Object.entries(after.deployedRevisions).forEach(([service, revision]) => {
+        console.log(`[migrate]   ${service}: ${plan.revisionDelta.from || '<unreadable>'} -> ${revision || '<unreadable>'}`)
+    });
+
+    if (unmoved.length) {
+        console.error(`[migrate] FATAL: ${unmoved.length} service(s) are not at ${plan.revisionDelta.to} — the migration is NOT delivered.`);
+        return 1
+    }
+
+    console.log(`[migrate] all ${options.services.length} service(s) at ${plan.revisionDelta.to} — migration delivered`);
+
+    return 0
+}
+
+// Entrypoint guard (the `bootstrapWorktree.mjs:1502` form — `path.resolve` rather than a `file://`
+// string compare, so a relative or symlinked invocation still matches). Without it, a spec importing
+// `parseArgs` would execute a real migration driver as an import side effect.
+const isDirectRun = process.argv[1] && fileURLToPath(import.meta.url) === path.resolve(process.argv[1]);
+
+if (isDirectRun) {
+    process.exitCode = await main()
+}

--- a/ai/scripts/maintenance/migrateDeployment.mjs
+++ b/ai/scripts/maintenance/migrateDeployment.mjs
@@ -62,6 +62,13 @@ const execFileAsync = promisify(execFile),
       PIPELINE_REL  = 'ai/examples/cloud-deployment/deploy-pipeline.sh',
       DEFAULT_REPO  = 'https://github.com/neomjs/neo.git',
       /**
+       * The env keys that DEFINE the transaction rather than the config being repaired: the pinned
+       * revision and the discovered plane identity. A repair carrier that could set these would let the
+       * same flag redirect the run to another revision or another project, so they are reserved.
+       * @type {Set<String>}
+       */
+      RESERVED_TRANSACTION_KEYS = new Set(['NEO_REF', 'NEO_DEPLOY_PROJECT_NAME', 'NEO_DEPLOY_COMPOSE_FILE']),
+      /**
        * The cohort whose `/app/.neo-revision` must move for a migration to count as delivered.
        * Overridable with `--services`; every listed service is asserted, so an under-listed cohort
        * narrows the proof rather than widening the pass.
@@ -149,6 +156,17 @@ export function parseArgs(argv) {
 
                 const service = lhs.slice(0, dot),
                       key     = lhs.slice(dot + 1);
+
+                // These three ARE the transaction: the pinned revision and the discovered plane identity.
+                // Accepting them as repair values let a caller redirect the run to another revision or
+                // another project through the same flag that repairs config — so they are refused by name
+                // rather than merely losing a precedence contest.
+                if (RESERVED_TRANSACTION_KEYS.has(key)) {
+                    throw new Error(
+                        `--set may not carry '${key}': it defines the transaction (pinned revision and ` +
+                        'discovered plane identity), not the config being repaired'
+                    )
+                }
 
                 options.desiredEnv[service] ||= {};
                 options.desiredEnv[service][key] = value.slice(separator + 1);
@@ -412,14 +430,19 @@ export function buildPipelineEnv(plan, composeIdentity, desiredEnv = {}) {
 
     Object.values(desiredEnv || {}).forEach(entries => Object.assign(desiredFlat, entries || {}));
 
+    // Spread the repair FIRST so the transaction keys always win. Ordering was the defect: with the
+    // repair spread last, `--set orchestrator.NEO_REF=<other>` emitted the other SHA and the run applied
+    // a revision the operator never selected. `parseArgs` also rejects these keys outright, so this is
+    // the second of two independent guards rather than the only one — a caller constructing desiredEnv
+    // programmatically never reaches the parser.
     return {
         pipelineEnv: {
+            ...desiredFlat,
             NEO_REF                : plan.revisionDelta.to,
             NEO_DEPLOY_PROJECT_NAME: composeIdentity.project,
-            NEO_DEPLOY_COMPOSE_FILE: composeIdentity.configFiles.join(path.delimiter),
-            ...desiredFlat
+            NEO_DEPLOY_COMPOSE_FILE: composeIdentity.configFiles.join(path.delimiter)
         },
-        forwarded  : Object.keys(desiredFlat)
+        forwarded  : Object.keys(desiredFlat).filter(key => !RESERVED_TRANSACTION_KEYS.has(key))
     }
 }
 

--- a/ai/scripts/maintenance/migrateDeployment.mjs
+++ b/ai/scripts/maintenance/migrateDeployment.mjs
@@ -79,16 +79,20 @@ const execFileAsync = promisify(execFile),
       /**
        * The config cohort is WIDER than the revision cohort, and conflating them was a defect.
        *
-       * `/app/.neo-revision` is written by the Neo image, so only the three Neo services can produce a
-       * revision receipt — `ingress` is Caddy and has no such file. But the deployment contract spans
-       * services the receipt cannot: Compose owns `NEO_DEPLOY_HOSTNAME` on `ingress` with a localhost
-       * fallback, and the census classifies it as a required deployment input. Observing only the receipt
-       * cohort left that key owned by nobody, so it refused every plane as unattributable — measured, and
-       * it made `apply` unauthorizable everywhere. Disposition by @neo-gpt-emmy: widen the config cohort
-       * rather than demote the key.
+       * `/app/.neo-revision` is written by the Neo image, so only Neo services can produce a revision
+       * receipt — an ingress proxy has no such file. But the deployment contract spans services the receipt
+       * cannot: Compose owns `NEO_DEPLOY_HOSTNAME` on the ingress service with a localhost fallback, and the
+       * census classifies it as a required deployment input. Observing only the receipt cohort left that key
+       * owned by nobody, so it refused every plane as unattributable — measured, and it made `apply`
+       * unauthorizable everywhere.
+       *
+       * The cohort is DISCOVERED from the plane's own Compose labels rather than named here. An earlier
+       * revision appended `'ingress'` as a literal, which hardcodes one profile's topology into a tool whose
+       * whole point is to address a plane it did not build: a deployment with a differently-named proxy, or
+       * a fourth config-bearing service, would silently fall outside the contract again.
        * @type {String[]}
        */
-      DEFAULT_CONFIG_SERVICES = [...DEFAULT_SERVICES, 'ingress'];
+      CONFIG_COHORT_DISCOVERED = null;
 
 /**
  * @summary Runs a command, returning `{ok, stdout, stderr, code}` instead of throwing.
@@ -130,9 +134,10 @@ export function parseArgs(argv) {
               profile: 'ai/deploy/docker-compose.yml',
               // The cohort whose revision receipt must move. `--services` narrows it.
               services      : DEFAULT_SERVICES,
-              // The cohort whose config is observed and repaired — wider, because the contract spans
-              // services that cannot produce a revision receipt. `--config-services` narrows it.
-              configServices: DEFAULT_CONFIG_SERVICES,
+              // The cohort whose config is observed and repaired. `null` means DISCOVER it from the plane's
+              // Compose labels; `--config-services` pins it explicitly. Never a literal service name here,
+              // because the plane's topology is a property of the deployment, not of this tool.
+              configServices: CONFIG_COHORT_DISCOVERED,
               repoUrl       : process.env.NEO_REPO_URL || DEFAULT_REPO,
               omitted       : null,
               // Service name → `{KEY: value}`, populated by repeatable `--set`. Empty by default, so a
@@ -391,6 +396,39 @@ async function loadCensus(profile) {
 }
 
 /**
+ * @summary Discovers the plane's config cohort from its own Compose service labels.
+ *
+ * The authority for "which services does this deployment consist of" is the deployment, not this tool. A
+ * literal list would encode one profile's topology and silently exclude a differently-named proxy or a
+ * fourth config-bearing service — the same class of defect as defaulting the Compose project name.
+ *
+ * Stopped containers count: a dead service is exactly the case this tool exists for, and omitting it would
+ * drop its config from the contract at the moment it matters most.
+ * @param {String} project The discovered Compose project name.
+ * @returns {Promise<Object>} `{services, error}` — sorted service names, or a named failure.
+ */
+async function discoverConfigCohort(project) {
+    const listed = await run('docker', [
+        'ps', '-a', '--filter', `label=com.docker.compose.project=${project}`,
+        // `.Label` and not `index .Labels`: in `docker ps` templates `.Labels` is a comma-joined STRING,
+        // so indexing it errors — unlike `docker inspect`, where `.Config.Labels` is a map.
+        '--format', '{{.Label "com.docker.compose.service"}}'
+    ]);
+
+    if (!listed.ok) {
+        return {services: [], error: `could not list services for project '${project}': ${listed.stderr || 'no detail'}`}
+    }
+
+    const services = [...new Set(listed.stdout.split('\n').map(entry => entry.trim()).filter(Boolean))].sort();
+
+    if (services.length === 0) {
+        return {services: [], error: `project '${project}' reported no services, so no config cohort could be derived`}
+    }
+
+    return {services, error: null}
+}
+
+/**
  * @summary Resolves each service's declared env surface, so the census is judged per service.
  *
  * The census classifies keys per **profile**; the profile block names which config template governs each
@@ -465,7 +503,58 @@ async function resolveServiceScopes(parity, profile, services, observedEnvByServ
  * @returns {Promise<Number>} The pipeline's exit code.
  */
 /**
- * @summary Renders the declared per-service repair as a Compose overlay fragment, or `null` if none.
+ * @summary Carries forward the values a compose-owned service already has, so a repair does not revert them.
+ *
+ * `NEO_DEPLOY_HOSTNAME` is the worked case and the reason this exists. Compose declares it as
+ * `${NEO_DEPLOY_HOSTNAME:-localhost}` on the ingress service, so it is supplied by INTERPOLATION at deploy
+ * time rather than stored in the compose file. A repair run whose environment lacks it therefore re-renders
+ * the fallback and silently resets a plane that had a real hostname — config loss inside a repair tool, and
+ * invisible on any plane whose hostname already equals the fallback. Ours does, which is exactly why this
+ * needed an assertion rather than an inspection.
+ *
+ * Only compose-owned services are preserved. A Neo service's config comes from its image and its own
+ * declared leaves, so carrying its observed env forward would pin today's values across an upgrade that
+ * intends to change them.
+ * @param {Object}   options
+ * @param {Object}   options.observedEnvByService Service name → observed env Map.
+ * @param {String[]} options.composeOwnedServices Services with no Neo config template.
+ * @param {Object}   options.census               Output of `resolveCensus`.
+ * @param {Object}   [options.desiredEnv]         Operator-declared repairs, which take precedence.
+ * @returns {Object} Service name → `{KEY: value}` to carry forward.
+ */
+export function buildPreservedEnv({observedEnvByService = {}, composeOwnedServices = [], census, desiredEnv = {}} = {}) {
+    const preserved = {};
+
+    if (!census) {
+        return preserved
+    }
+
+    const classified = [...census.requiredDeploymentInputs, ...census.optionalOverrides, ...census.secrets];
+
+    composeOwnedServices.forEach(service => {
+        const observed = observedEnvByService[service];
+
+        if (!(observed instanceof Map)) {
+            return
+        }
+
+        classified.forEach(key => {
+            // An operator-declared repair WINS. Preservation exists so a value the plane already carries is
+            // not silently reverted, not to override an explicit fix.
+            if (desiredEnv?.[service]?.[key] !== undefined || !observed.has(key)) {
+                return
+            }
+
+            preserved[service] ||= {};
+            preserved[service][key] = observed.get(key)
+        })
+    });
+
+    return preserved
+}
+
+/**
+ * @summary Renders the per-service env transition as a Compose overlay fragment, or `null` if none.
  *
  * The consumer-owned carrier. Parent environment does NOT work here and the measurement is unambiguous:
  * the profile declares its env as literals, so `NEO_AI_ORCHESTRATOR_AUTHORITY_PROFILE=host-edge` in the
@@ -473,7 +562,7 @@ async function resolveServiceScopes(parity, profile, services, observedEnvByServ
  * does interpolate — renders correctly under the same command. A fragment merged in last is what the
  * containers actually consume, and it is service-scoped, so two services may carry different values for
  * one key. Found by @neo-gpt-emmy; the positive control is hers.
- * @param {Object} [desiredEnv] Service name → `{KEY: value}`.
+ * @param {Object} [desiredEnv] Service name → `{KEY: value}`; repairs and preserved values alike.
  * @returns {String|null} Fragment contents, or `null` when nothing is declared.
  */
 export function buildComposeFragment(desiredEnv = {}) {
@@ -601,8 +690,24 @@ async function main() {
         return 2
     }
 
+    // The config cohort is the plane's own service list unless the operator pinned it. Discovered, never
+    // a literal, so a differently-named proxy or a fourth config-bearing service stays inside the contract.
+    let configServices = options.configServices;
+
+    if (!configServices) {
+        const {services: discovered, error: cohortError} = await discoverConfigCohort(project);
+
+        if (cohortError) {
+            console.error(`[migrate] FATAL: ${cohortError}`);
+            return 2
+        }
+
+        configServices = discovered;
+        console.log(`[migrate] config cohort (discovered): ${configServices.join(', ')}`)
+    }
+
     const [{composeIdentity, deployedRevisions, unchecked, observedEnvByService}, {revision: targetRevision, error: targetError}] = await Promise.all([
-        inspectPlane(project, options.configServices, options.services),
+        inspectPlane(project, configServices, options.services),
         resolveTargetRevision(options.repoUrl, options.target)
     ]);
 
@@ -628,7 +733,7 @@ async function main() {
     );
 
     const {serviceScopes, errors: scopeErrors} = await resolveServiceScopes(
-        parity, options.profile, options.configServices, observedEnvByService, census
+        parity, options.profile, configServices, observedEnvByService, census
     );
 
     // A scope that failed to resolve is reported, never defaulted. The plan gate blocks on the missing
@@ -662,7 +767,18 @@ async function main() {
     console.log('');
     console.log('[migrate] plan is clean — applying');
 
-    const pipelineCode = await invokePipeline(plan, composeIdentity, options.desiredEnv);
+    // Preservation merged UNDER the operator's repairs: a compose-owned value the plane already carries is
+    // carried forward, and an explicit --set for the same key wins. Without this, apply re-renders
+    // `${NEO_DEPLOY_HOSTNAME:-localhost}` from an environment that lacks it and resets the plane's hostname.
+    const composeOwned = configServices.filter(service => !(parity?.$composeDefaultParity?.profiles?.[options.profile]?.services || {})[service]),
+          preserved    = buildPreservedEnv({observedEnvByService, composeOwnedServices: composeOwned, census, desiredEnv: options.desiredEnv}),
+          transition   = {...preserved};
+
+    Object.entries(options.desiredEnv).forEach(([service, entries]) => {
+        transition[service] = {...(transition[service] || {}), ...entries}
+    });
+
+    const pipelineCode = await invokePipeline(plan, composeIdentity, transition);
 
     if (pipelineCode !== 0) {
         console.error(`[migrate] FATAL: pipeline exited ${pipelineCode}; the transition did not complete.`);
@@ -675,7 +791,7 @@ async function main() {
     console.log('');
     console.log('[migrate] verifying /app/.neo-revision moved on every service...');
 
-    const after   = await inspectPlane(project, options.configServices, options.services),
+    const after   = await inspectPlane(project, configServices, options.services),
           unmoved = Object.entries(after.deployedRevisions).filter(([, revision]) => revision !== plan.revisionDelta.to);
 
     Object.entries(after.deployedRevisions).forEach(([service, revision]) => {

--- a/ai/scripts/maintenance/migrateDeployment.mjs
+++ b/ai/scripts/maintenance/migrateDeployment.mjs
@@ -109,7 +109,10 @@ export function parseArgs(argv) {
               profile : 'ai/deploy/docker-compose.yml',
               services: DEFAULT_SERVICES,
               repoUrl : process.env.NEO_REPO_URL || DEFAULT_REPO,
-              omitted : null
+              omitted : null,
+              // Service name → `{KEY: value}`, populated by repeatable `--set`. Empty by default, so a
+              // deployment is never silently reconfigured by a value the operator did not name.
+              desiredEnv: {}
           };
 
     if (mode !== 'plan' && mode !== 'apply') {
@@ -130,6 +133,27 @@ export function parseArgs(argv) {
             case '--profile'      : options.profile      = value; break;
             case '--repo-url'     : options.repoUrl      = value; break;
             case '--services'     : options.services     = value.split(',').map(entry => entry.trim()).filter(Boolean); break;
+
+            // The repair carrier. `--set <service>.<KEY>=<value>`, repeatable: a required input the target
+            // is missing becomes a declared transition instead of a terminal blocker, which is the whole
+            // difference between a tool that diagnoses a broken plane and one that can fix it. Splitting on
+            // the FIRST `=` only, because values legitimately contain `=`.
+            case '--set': {
+                const separator = value.indexOf('='),
+                      lhs       = separator === -1 ? value : value.slice(0, separator),
+                      dot       = lhs.indexOf('.');
+
+                if (separator === -1 || dot === -1) {
+                    throw new Error(`--set expects <service>.<KEY>=<value>, received: ${value}`)
+                }
+
+                const service = lhs.slice(0, dot),
+                      key     = lhs.slice(dot + 1);
+
+                options.desiredEnv[service] ||= {};
+                options.desiredEnv[service][key] = value.slice(separator + 1);
+                break
+            }
             default               : throw new Error(`unknown flag: ${flag}`)
         }
     }
@@ -183,12 +207,12 @@ async function discoverProject(services, declaredProject) {
  * `/app/.neo-revision`.
  * @param {String}   project
  * @param {String[]} services
- * @returns {Promise<Object>} `{composeIdentity, deployedRevisions, unchecked, observedEnv}`
+ * @returns {Promise<Object>} `{composeIdentity, deployedRevisions, unchecked, observedEnvByService}`
  */
 async function inspectPlane(project, services) {
-    const deployedRevisions = {},
-          unchecked         = [],
-          observedEntries   = [];
+    const deployedRevisions    = {},
+          unchecked            = [],
+          observedEnvByService = {};
 
     let composeIdentity = null;
 
@@ -220,12 +244,14 @@ async function inspectPlane(project, services) {
             }
         }
 
-        // Env from EVERY service, not just the first: a cohort can disagree, and a key present on one
-        // container but missing on another is a real misconfiguration that reading only one would hide.
-        // Union is the conservative direction here — it can only make the delta smaller, so a key this
-        // reports as missing is missing everywhere.
+        // Env is kept PER SERVICE. A union was the earlier shape and it is fail-open, not conservative:
+        // it only ever shrinks the delta, so a key set on one container and absent from another reports
+        // as satisfied for both and the real misconfiguration disappears. Measured on the canonical
+        // profile, four of thirteen required inputs are declared by a single service and one more by two
+        // of three, so a union both credits a service with configuration it does not carry and holds it
+        // to keys it never declares.
         if (parsedConfig) {
-            observedEntries.push(...(parsedConfig.Env || []))
+            observedEnvByService[service] = parseObservedEnv(parsedConfig.Env || [])
         }
 
         if (parsedConfig && !composeIdentity) {
@@ -256,7 +282,7 @@ async function inspectPlane(project, services) {
         }
     }
 
-    return {composeIdentity, deployedRevisions, unchecked, observedEnv: parseObservedEnv(observedEntries)}
+    return {composeIdentity, deployedRevisions, unchecked, observedEnvByService}
 }
 
 /**
@@ -301,20 +327,64 @@ async function resolveTargetRevision(repoUrl, selector) {
 /**
  * @summary Loads the classified census for one profile, returning a named failure rather than throwing.
  * @param {String} profile Repo-relative Compose path.
- * @returns {Promise<Object>} `{census, error}`
+ * @returns {Promise<Object>} `{census, parity, error}` — `parity` carries the raw document so the
+ * per-service scope resolver reads the same authority without a second filesystem round-trip.
  */
 async function loadCensus(profile) {
     const parityPath = path.join(repoRoot, PARITY_REL);
 
     if (!await fs.pathExists(parityPath)) {
-        return {census: null, error: `${PARITY_REL} is absent — it is this tool's contract authority`}
+        return {census: null, parity: null, error: `${PARITY_REL} is absent — it is this tool's contract authority`}
     }
 
     try {
-        return {census: resolveCensus(await fs.readJson(parityPath), profile), error: null}
+        const parity = await fs.readJson(parityPath);
+
+        return {census: resolveCensus(parity, profile), parity, error: null}
     } catch (error) {
-        return {census: null, error: error.message}
+        return {census: null, parity: null, error: error.message}
     }
+}
+
+/**
+ * @summary Resolves each service's declared env surface, so the census is judged per service.
+ *
+ * The census classifies keys per **profile**; the profile block names which config template governs each
+ * service, and that template is the per-service authority. `buildConfigEnvDefaultsForTemplate` is the
+ * same resolver the parity lint used to compute the census, so this derives the scope from the existing
+ * authority rather than introducing a second mapping free to drift from it.
+ *
+ * A service whose scope cannot be resolved is returned absent rather than defaulted to the whole census:
+ * the plan gate refuses on that, because evaluating every profile key against one service invents
+ * obligations it never declared.
+ * @param {Object}   parity  The parsed parity document.
+ * @param {String}   profile Repo-relative Compose path.
+ * @param {String[]} services Service names to resolve.
+ * @returns {Promise<Object>} `{serviceScopes, errors}` — scopes keyed by service, unresolved names in `errors`.
+ */
+async function resolveServiceScopes(parity, profile, services) {
+    const declared      = parity?.$composeDefaultParity?.profiles?.[profile]?.services || {},
+          serviceScopes = {},
+          errors        = [];
+
+    for (const service of services) {
+        const template = declared[service];
+
+        if (!template) {
+            errors.push(`service '${service}' is not declared under $composeDefaultParity.profiles['${profile}'].services`);
+            continue
+        }
+
+        try {
+            const {buildConfigEnvDefaultsForTemplate} = await import('../lint/lint-config-template-ssot.mjs');
+
+            serviceScopes[service] = new Set(Object.keys(await buildConfigEnvDefaultsForTemplate({template})))
+        } catch (error) {
+            errors.push(`service '${service}': could not resolve declared env from '${template}' — ${error.message}`)
+        }
+    }
+
+    return {serviceScopes, errors}
 }
 
 /**
@@ -357,7 +427,7 @@ async function main() {
         options = parseArgs(process.argv.slice(2))
     } catch (error) {
         console.error(`[migrate] FATAL: ${error.message}`);
-        console.error('[migrate] usage: migrateDeployment.mjs plan|apply [--target <selector>] [--project <name>] [--profile <compose-path>] [--services a,b,c]');
+        console.error('[migrate] usage: migrateDeployment.mjs plan|apply [--target <selector>] [--project <name>] [--profile <compose-path>] [--services a,b,c] [--set <service>.<KEY>=<value> ...]');
         return 2
     }
 
@@ -365,7 +435,7 @@ async function main() {
     console.log(`[migrate] profile:  ${options.profile}`);
     console.log(`[migrate] selector: ${options.target}`);
 
-    const {census, error: censusError} = await loadCensus(options.profile);
+    const {census, parity, error: censusError} = await loadCensus(options.profile);
 
     if (censusError) {
         console.error(`[migrate] FATAL: ${censusError}`);
@@ -381,7 +451,7 @@ async function main() {
         return 2
     }
 
-    const [{composeIdentity, deployedRevisions, unchecked, observedEnv}, {revision: targetRevision, error: targetError}] = await Promise.all([
+    const [{composeIdentity, deployedRevisions, unchecked, observedEnvByService}, {revision: targetRevision, error: targetError}] = await Promise.all([
         inspectPlane(project, options.services),
         resolveTargetRevision(options.repoUrl, options.target)
     ]);
@@ -407,9 +477,17 @@ async function main() {
         'different repair (overlay migration) from a missing key, and a clean env delta does not rule it out'
     );
 
+    const {serviceScopes, errors: scopeErrors} = await resolveServiceScopes(parity, options.profile, options.services);
+
+    // A scope that failed to resolve is reported, never defaulted. The plan gate blocks on the missing
+    // scope itself, so this only needs to carry the reason an operator would otherwise have to guess at.
+    scopeErrors.forEach(message => unchecked.push(`declared-scope resolution: ${message}`));
+
     const plan = buildMigrationPlan({
-        observedEnv,
+        observedEnvByService,
+        serviceScopes,
         census,
+        desiredEnv    : options.desiredEnv,
         composeIdentity,
         deployedRevisions,
         targetRevision,

--- a/ai/scripts/maintenance/migrateDeployment.mjs
+++ b/ai/scripts/maintenance/migrateDeployment.mjs
@@ -396,15 +396,51 @@ async function resolveServiceScopes(parity, profile, services) {
  * @param {Object} composeIdentity
  * @returns {Promise<Number>} The pipeline's exit code.
  */
-async function invokePipeline(plan, composeIdentity) {
-    const pipelineEnv = {
-        NEO_REF                : plan.revisionDelta.to,
-        NEO_DEPLOY_PROJECT_NAME: composeIdentity.project,
-        NEO_DEPLOY_COMPOSE_FILE: composeIdentity.configFiles.join(path.delimiter)
-    };
+/**
+ * @summary Builds the exact environment handed to the pipeline — the invocation boundary, as a pure value.
+ *
+ * Extracted so the boundary is assertable without spawning the pipeline: the property under test is that
+ * a declared repair actually crosses into the transaction, and a test that only proved `invokePipeline`
+ * was called would pass while the values were dropped. That was the defect this function exists to close.
+ * @param {Object} plan            Output of `buildMigrationPlan`.
+ * @param {Object} composeIdentity `{project, configFiles}` discovered off the running plane.
+ * @param {Object} [desiredEnv]    Service name → `{KEY: value}`.
+ * @returns {Object} `{pipelineEnv, forwarded}` — the env map, and the keys contributed by the repair.
+ */
+export function buildPipelineEnv(plan, composeIdentity, desiredEnv = {}) {
+    const desiredFlat = {};
+
+    Object.values(desiredEnv || {}).forEach(entries => Object.assign(desiredFlat, entries || {}));
+
+    return {
+        pipelineEnv: {
+            NEO_REF                : plan.revisionDelta.to,
+            NEO_DEPLOY_PROJECT_NAME: composeIdentity.project,
+            NEO_DEPLOY_COMPOSE_FILE: composeIdentity.configFiles.join(path.delimiter),
+            ...desiredFlat
+        },
+        forwarded  : Object.keys(desiredFlat)
+    }
+}
+
+async function invokePipeline(plan, composeIdentity, desiredEnv = {}) {
+    // The declared repair has to reach the actual transaction, or `plan` records a transition `apply`
+    // cannot perform. Compose interpolation is the transport: the profile parameterises these leaves as
+    // `${NEO_*}`, so forwarding them as environment is what makes the recreate carry the new config.
+    // The plan already refuses when two services disagree on one key, because this transport is global.
+    const {pipelineEnv, forwarded: forwardedKeys} = buildPipelineEnv(plan, composeIdentity, desiredEnv);
 
     console.log(`[migrate] invoking ${PIPELINE_REL}`);
-    Object.entries(pipelineEnv).forEach(([key, value]) => console.log(`[migrate]   ${key}=${value}`));
+
+    // Keys only for the forwarded repair. A required input's VALUE is operator-supplied config and may be
+    // a host, a path or a credential-adjacent string; echoing it into a build log would persist it.
+    Object.entries(pipelineEnv)
+        .filter(([key]) => !forwardedKeys.includes(key))
+        .forEach(([key, value]) => console.log(`[migrate]   ${key}=${value}`));
+
+    if (forwardedKeys.length) {
+        console.log(`[migrate]   forwarding ${forwardedKeys.length} declared config value(s): ${forwardedKeys.join(', ')}`)
+    }
 
     const child = await run('bash', [path.join(repoRoot, PIPELINE_REL)], pipelineEnv);
 
@@ -510,7 +546,7 @@ async function main() {
     console.log('');
     console.log('[migrate] plan is clean — applying');
 
-    const pipelineCode = await invokePipeline(plan, composeIdentity);
+    const pipelineCode = await invokePipeline(plan, composeIdentity, options.desiredEnv);
 
     if (pipelineCode !== 0) {
         console.error(`[migrate] FATAL: pipeline exited ${pipelineCode}; the transition did not complete.`);

--- a/ai/scripts/maintenance/migrateDeployment.mjs
+++ b/ai/scripts/maintenance/migrateDeployment.mjs
@@ -75,7 +75,20 @@ const execFileAsync = promisify(execFile),
        * narrows the proof rather than widening the pass.
        * @type {String[]}
        */
-      DEFAULT_SERVICES = ['mc-server', 'orchestrator', 'kb-server'];
+      DEFAULT_SERVICES = ['mc-server', 'orchestrator', 'kb-server'],
+      /**
+       * The config cohort is WIDER than the revision cohort, and conflating them was a defect.
+       *
+       * `/app/.neo-revision` is written by the Neo image, so only the three Neo services can produce a
+       * revision receipt — `ingress` is Caddy and has no such file. But the deployment contract spans
+       * services the receipt cannot: Compose owns `NEO_DEPLOY_HOSTNAME` on `ingress` with a localhost
+       * fallback, and the census classifies it as a required deployment input. Observing only the receipt
+       * cohort left that key owned by nobody, so it refused every plane as unattributable — measured, and
+       * it made `apply` unauthorizable everywhere. Disposition by @neo-gpt-emmy: widen the config cohort
+       * rather than demote the key.
+       * @type {String[]}
+       */
+      DEFAULT_CONFIG_SERVICES = [...DEFAULT_SERVICES, 'ingress'];
 
 /**
  * @summary Runs a command, returning `{ok, stdout, stderr, code}` instead of throwing.
@@ -112,12 +125,16 @@ export function parseArgs(argv) {
     const [mode, ...rest] = argv,
           options         = {
               mode,
-              target  : 'dev',
-              project : null,
-              profile : 'ai/deploy/docker-compose.yml',
-              services: DEFAULT_SERVICES,
-              repoUrl : process.env.NEO_REPO_URL || DEFAULT_REPO,
-              omitted : null,
+              target : 'dev',
+              project: null,
+              profile: 'ai/deploy/docker-compose.yml',
+              // The cohort whose revision receipt must move. `--services` narrows it.
+              services      : DEFAULT_SERVICES,
+              // The cohort whose config is observed and repaired — wider, because the contract spans
+              // services that cannot produce a revision receipt. `--config-services` narrows it.
+              configServices: DEFAULT_CONFIG_SERVICES,
+              repoUrl       : process.env.NEO_REPO_URL || DEFAULT_REPO,
+              omitted       : null,
               // Service name → `{KEY: value}`, populated by repeatable `--set`. Empty by default, so a
               // deployment is never silently reconfigured by a value the operator did not name.
               desiredEnv: {}
@@ -140,7 +157,8 @@ export function parseArgs(argv) {
             case '--project'      : options.project      = value; break;
             case '--profile'      : options.profile      = value; break;
             case '--repo-url'     : options.repoUrl      = value; break;
-            case '--services'     : options.services     = value.split(',').map(entry => entry.trim()).filter(Boolean); break;
+            case '--services'       : options.services       = value.split(',').map(entry => entry.trim()).filter(Boolean); break;
+            case '--config-services': options.configServices = value.split(',').map(entry => entry.trim()).filter(Boolean); break;
 
             // The repair carrier. `--set <service>.<KEY>=<value>`, repeatable: a required input the target
             // is missing becomes a declared transition instead of a terminal blocker, which is the whole
@@ -228,7 +246,7 @@ async function discoverProject(services, declaredProject) {
  * @param {String[]} services
  * @returns {Promise<Object>} `{composeIdentity, deployedRevisions, unchecked, observedEnvByService}`
  */
-async function inspectPlane(project, services) {
+async function inspectPlane(project, services, revisionServices = services) {
     const deployedRevisions    = {},
           unchecked            = [],
           observedEnvByService = {};
@@ -290,6 +308,13 @@ async function inspectPlane(project, services) {
                     }
                 }
             }
+        }
+
+        // Only the receipt cohort is asked for a revision. `/app/.neo-revision` is written by the Neo
+        // image, so asking Caddy for one would record a permanent `null` and refuse every plane on a
+        // baseline that service can never have.
+        if (!revisionServices.includes(service)) {
+            continue
         }
 
         const revision = await run('docker', ['exec', containerName, 'cat', '/app/.neo-revision']);
@@ -381,7 +406,7 @@ async function loadCensus(profile) {
  * @param {String[]} services Service names to resolve.
  * @returns {Promise<Object>} `{serviceScopes, errors}` — scopes keyed by service, unresolved names in `errors`.
  */
-async function resolveServiceScopes(parity, profile, services) {
+async function resolveServiceScopes(parity, profile, services, observedEnvByService = {}, census = null) {
     const declared      = parity?.$composeDefaultParity?.profiles?.[profile]?.services || {},
           serviceScopes = {},
           errors        = [];
@@ -390,7 +415,31 @@ async function resolveServiceScopes(parity, profile, services) {
         const template = declared[service];
 
         if (!template) {
-            errors.push(`service '${service}' is not declared under $composeDefaultParity.profiles['${profile}'].services`);
+            // A service with no Neo config template is COMPOSE-owned. `ingress` is Caddy, and Compose
+            // declares its `NEO_DEPLOY_HOSTNAME` directly, so its obligation is what Compose sets on it —
+            // read from its observed env narrowed to census-classified keys.
+            //
+            // Bound, stated because it is real: this cannot detect a compose-owned key Compose FORGOT to
+            // set, since an absent key is simply out of scope. It holds for the keys at issue because
+            // Compose supplies them with fallbacks, so absence is unreachable. The stronger source is a
+            // `docker compose config` render of the discovered files, giving obligation independent of the
+            // observation; that needs the plane's own compose files, whose discovered paths can live in a
+            // different agent's checkout than the one running this tool.
+            const observed = observedEnvByService[service];
+
+            if (observed instanceof Map && census) {
+                serviceScopes[service] = new Set([
+                    ...census.requiredDeploymentInputs, ...census.optionalOverrides, ...census.secrets
+                ].filter(key => observed.has(key)));
+
+                continue
+            }
+
+            errors.push(
+                `service '${service}' has no config template under $composeDefaultParity.profiles['${profile}'].services ` +
+                'and no observed env to attribute from'
+            );
+
             continue
         }
 
@@ -528,7 +577,7 @@ async function main() {
         options = parseArgs(process.argv.slice(2))
     } catch (error) {
         console.error(`[migrate] FATAL: ${error.message}`);
-        console.error('[migrate] usage: migrateDeployment.mjs plan|apply [--target <selector>] [--project <name>] [--profile <compose-path>] [--services a,b,c] [--set <service>.<KEY>=<value> ...]');
+        console.error('[migrate] usage: migrateDeployment.mjs plan|apply [--target <selector>] [--project <name>] [--profile <compose-path>] [--services a,b,c] [--config-services a,b,c] [--set <service>.<KEY>=<value> ...]');
         return 2
     }
 
@@ -553,7 +602,7 @@ async function main() {
     }
 
     const [{composeIdentity, deployedRevisions, unchecked, observedEnvByService}, {revision: targetRevision, error: targetError}] = await Promise.all([
-        inspectPlane(project, options.services),
+        inspectPlane(project, options.configServices, options.services),
         resolveTargetRevision(options.repoUrl, options.target)
     ]);
 
@@ -578,7 +627,9 @@ async function main() {
         'different repair (overlay migration) from a missing key, and a clean env delta does not rule it out'
     );
 
-    const {serviceScopes, errors: scopeErrors} = await resolveServiceScopes(parity, options.profile, options.services);
+    const {serviceScopes, errors: scopeErrors} = await resolveServiceScopes(
+        parity, options.profile, options.configServices, observedEnvByService, census
+    );
 
     // A scope that failed to resolve is reported, never defaulted. The plan gate blocks on the missing
     // scope itself, so this only needs to carry the reason an operator would otherwise have to guess at.
@@ -624,7 +675,7 @@ async function main() {
     console.log('');
     console.log('[migrate] verifying /app/.neo-revision moved on every service...');
 
-    const after   = await inspectPlane(project, options.services),
+    const after   = await inspectPlane(project, options.configServices, options.services),
           unmoved = Object.entries(after.deployedRevisions).filter(([, revision]) => revision !== plan.revisionDelta.to);
 
     Object.entries(after.deployedRevisions).forEach(([service, revision]) => {

--- a/ai/scripts/maintenance/migrateDeployment.mjs
+++ b/ai/scripts/maintenance/migrateDeployment.mjs
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 import fs              from 'fs-extra';
+import os              from 'node:os';
 import path            from 'path';
 import {execFile}      from 'node:child_process';
 import {promisify}     from 'node:util';
@@ -415,54 +416,95 @@ async function resolveServiceScopes(parity, profile, services) {
  * @returns {Promise<Number>} The pipeline's exit code.
  */
 /**
+ * @summary Renders the declared per-service repair as a Compose overlay fragment, or `null` if none.
+ *
+ * The consumer-owned carrier. Parent environment does NOT work here and the measurement is unambiguous:
+ * the profile declares its env as literals, so `NEO_AI_ORCHESTRATOR_AUTHORITY_PROFILE=host-edge` in the
+ * pipeline's environment still renders `container-plane`, while `NEO_DEPLOY_HOSTNAME` — which the profile
+ * does interpolate — renders correctly under the same command. A fragment merged in last is what the
+ * containers actually consume, and it is service-scoped, so two services may carry different values for
+ * one key. Found by @neo-gpt-emmy; the positive control is hers.
+ * @param {Object} [desiredEnv] Service name → `{KEY: value}`.
+ * @returns {String|null} Fragment contents, or `null` when nothing is declared.
+ */
+export function buildComposeFragment(desiredEnv = {}) {
+    const services = {};
+
+    Object.entries(desiredEnv || {}).forEach(([service, entries]) => {
+        const environment = {};
+
+        Object.entries(entries || {}).forEach(([key, value]) => {
+            // Compose runs `${...}` interpolation over this fragment, so an unescaped `$` is silently
+            // rewritten: measured, `p@ss${x}w$1` renders as `p@ssw$1` — the operator's value replaced by a
+            // different one with no error. `$$` is Compose's own escape for a literal `$`.
+            environment[key] = String(value).replace(/\$/g, '$$$$')
+        });
+
+        if (Object.keys(environment).length) {
+            services[service] = {environment}
+        }
+    });
+
+    // JSON, not hand-written YAML: JSON is a YAML 1.2 subset, so `JSON.stringify` buys correct quoting
+    // for values carrying `:`, `#`, quotes or newlines instead of a hand-rolled escaper to get wrong.
+    // Verified by rendering an adversarial value through `docker compose config`.
+    return Object.keys(services).length ? JSON.stringify({services}, null, 2) : null
+}
+
+/**
  * @summary Builds the exact environment handed to the pipeline — the invocation boundary, as a pure value.
  *
- * Extracted so the boundary is assertable without spawning the pipeline: the property under test is that
- * a declared repair actually crosses into the transaction, and a test that only proved `invokePipeline`
- * was called would pass while the values were dropped. That was the defect this function exists to close.
- * @param {Object} plan            Output of `buildMigrationPlan`.
- * @param {Object} composeIdentity `{project, configFiles}` discovered off the running plane.
- * @param {Object} [desiredEnv]    Service name → `{KEY: value}`.
- * @returns {Object} `{pipelineEnv, forwarded}` — the env map, and the keys contributed by the repair.
+ * Extracted so the boundary is assertable without spawning the pipeline. Its earlier shape forwarded
+ * desired values as parent environment, which does not work: the profile declares these leaves as
+ * literals (`NEO_CHROMA_HOST=chroma`), not `${VAR}`, so nothing downstream consumed them. The repair now
+ * travels as a Compose fragment appended in merge order, which is service-scoped by construction.
+ * @param {Object}      plan            Output of `buildMigrationPlan`.
+ * @param {Object}      composeIdentity `{project, configFiles}` discovered off the running plane.
+ * @param {String|null} [fragmentPath]  Absolute path to the generated repair fragment, appended LAST.
+ * @returns {Object} `{pipelineEnv, composeFiles}`
  */
-export function buildPipelineEnv(plan, composeIdentity, desiredEnv = {}) {
-    const desiredFlat = {};
+export function buildPipelineEnv(plan, composeIdentity, fragmentPath = null) {
+    // Appended last because Compose merge order decides which value wins, and the repair must override
+    // the profile's literal rather than be overridden by it. This requires the pipeline to accept an
+    // ORDERED list of compose files; a single-file caller cannot express a repair at all.
+    const composeFiles = fragmentPath ? [...composeIdentity.configFiles, fragmentPath] : [...composeIdentity.configFiles];
 
-    Object.values(desiredEnv || {}).forEach(entries => Object.assign(desiredFlat, entries || {}));
-
-    // Spread the repair FIRST so the transaction keys always win. Ordering was the defect: with the
-    // repair spread last, `--set orchestrator.NEO_REF=<other>` emitted the other SHA and the run applied
-    // a revision the operator never selected. `parseArgs` also rejects these keys outright, so this is
-    // the second of two independent guards rather than the only one — a caller constructing desiredEnv
-    // programmatically never reaches the parser.
     return {
         pipelineEnv: {
-            ...desiredFlat,
             NEO_REF                : plan.revisionDelta.to,
             NEO_DEPLOY_PROJECT_NAME: composeIdentity.project,
-            NEO_DEPLOY_COMPOSE_FILE: composeIdentity.configFiles.join(path.delimiter)
+            NEO_DEPLOY_COMPOSE_FILE: composeFiles.join(path.delimiter)
         },
-        forwarded  : Object.keys(desiredFlat).filter(key => !RESERVED_TRANSACTION_KEYS.has(key))
+        composeFiles
     }
 }
 
 async function invokePipeline(plan, composeIdentity, desiredEnv = {}) {
-    // The declared repair has to reach the actual transaction, or `plan` records a transition `apply`
-    // cannot perform. Compose interpolation is the transport: the profile parameterises these leaves as
-    // `${NEO_*}`, so forwarding them as environment is what makes the recreate carry the new config.
-    // The plan already refuses when two services disagree on one key, because this transport is global.
-    const {pipelineEnv, forwarded: forwardedKeys} = buildPipelineEnv(plan, composeIdentity, desiredEnv);
+    // The repair travels as a Compose fragment, not as parent environment. Written to a temp dir rather
+    // than into the repo or the target: it is derived state for one invocation, and a stray fragment left
+    // in a checkout would silently join the NEXT operator's merge order.
+    const fragment = buildComposeFragment(desiredEnv);
+
+    let fragmentPath = null;
+
+    if (fragment) {
+        const fragmentDir = await fs.mkdtemp(path.join(os.tmpdir(), 'neo-migrate-'));
+
+        fragmentPath = path.join(fragmentDir, 'repair.compose.json');
+        await fs.writeFile(fragmentPath, fragment)
+    }
+
+    const {pipelineEnv} = buildPipelineEnv(plan, composeIdentity, fragmentPath);
 
     console.log(`[migrate] invoking ${PIPELINE_REL}`);
+    Object.entries(pipelineEnv).forEach(([key, value]) => console.log(`[migrate]   ${key}=${value}`));
 
-    // Keys only for the forwarded repair. A required input's VALUE is operator-supplied config and may be
-    // a host, a path or a credential-adjacent string; echoing it into a build log would persist it.
-    Object.entries(pipelineEnv)
-        .filter(([key]) => !forwardedKeys.includes(key))
-        .forEach(([key, value]) => console.log(`[migrate]   ${key}=${value}`));
-
-    if (forwardedKeys.length) {
-        console.log(`[migrate]   forwarding ${forwardedKeys.length} declared config value(s): ${forwardedKeys.join(', ')}`)
+    if (fragmentPath) {
+        // KEYS only, per service. A required input's VALUE is operator-supplied config and may be a host,
+        // a path or a credential-adjacent string; echoing it into a build log would persist it.
+        Object.entries(desiredEnv).forEach(([service, entries]) => console.log(
+            `[migrate]   repair fragment sets on '${service}': ${Object.keys(entries || {}).join(', ')}`
+        ))
     }
 
     const child = await run('bash', [path.join(repoRoot, PIPELINE_REL)], pipelineEnv);

--- a/ai/scripts/maintenance/migrateDeployment.mjs
+++ b/ai/scripts/maintenance/migrateDeployment.mjs
@@ -390,6 +390,23 @@ async function main() {
         unchecked.push(`target revision: ${targetError}`)
     }
 
+    // Overlay staleness is a SEPARATE defect class from a missing env key, and this tool does not
+    // detect it: the target's own `ai/config.mjs` is needed, and a deployment this host does not own
+    // will not surrender it. Reported as NOT VERIFIED rather than omitted, because the two have
+    // different remediations — a stale overlay wants an overlay migration, not an env edit — and a
+    // consumer that saw only "env delta clean" would conclude the wrong repair.
+    //
+    // It matters more than an ordinary gap: the config-freshness guard throws on staleness BEFORE it
+    // reaches its required-input listing, so on a stale target the missing-env report is unreachable
+    // and a start-and-parse-the-failure approach would return a migration instruction where a delta
+    // was expected. This driver reads container env directly and never parses a startup failure, so
+    // it is not exposed to that ordering — but the blind spot is real and stays named.
+    // (@neo-opus-ada's finding on the source ticket; the ordering is verified in `initServerConfigs.mjs`.)
+    unchecked.push(
+        "config-overlay drift: NOT evaluated — needs the target's own ai/config.mjs. A stale overlay is a " +
+        'different repair (overlay migration) from a missing key, and a clean env delta does not rule it out'
+    );
+
     const plan = buildMigrationPlan({
         observedEnv,
         census,

--- a/ai/scripts/maintenance/migrateDeployment.mjs
+++ b/ai/scripts/maintenance/migrateDeployment.mjs
@@ -5,7 +5,7 @@ import {execFile}      from 'node:child_process';
 import {promisify}     from 'node:util';
 import {fileURLToPath} from 'url';
 
-import {buildMigrationPlan, formatPlan} from './deploymentMigrationCore.mjs';
+import {buildMigrationPlan, formatPlan, parseObservedEnv, resolveCensus} from './deploymentMigrationCore.mjs';
 
 /**
  * @module ai/scripts/maintenance/migrateDeployment
@@ -17,8 +17,8 @@ import {buildMigrationPlan, formatPlan} from './deploymentMigrationCore.mjs';
  * ## Usage
  *
  * ```
- * node ai/scripts/maintenance/migrateDeployment.mjs plan  --discover-json <path> [--target dev]
- * node ai/scripts/maintenance/migrateDeployment.mjs apply --discover-json <path> --target <sha>
+ * node ai/scripts/maintenance/migrateDeployment.mjs plan  [--target dev] [--project NAME]
+ * node ai/scripts/maintenance/migrateDeployment.mjs apply --target <sha>
  * ```
  *
  * ## Why plan-then-apply rather than a caller
@@ -30,13 +30,15 @@ import {buildMigrationPlan, formatPlan} from './deploymentMigrationCore.mjs';
  * PID file and no log. The config delta decides whether the migration can work at all; the revision
  * delta is secondary.
  *
- * ## Why the contract delta is consumed and never re-derived
+ * ## Why this tool derives the contract delta itself
  *
- * The discover driver owns derivation — it reads the classified config census and emits the delta as
- * JSON for a caller to consume as the plan step of a bootstrap. This driver consumes it and adds
- * nothing to it. There is deliberately no fallback derivation for an absent discover result: two
- * resolvers for one contract can disagree, and a parallel resolution path is the shape this repository
- * has already had to retire once. Absent input refuses with a named reason.
+ * An earlier revision consumed the delta as JSON from a separate discovery driver, carrying no
+ * derivation of its own so that two resolvers could not disagree. That reasoning was sound and its
+ * premise is gone: the separate driver was closed as not-planned, priced at a new CLI contract, JSON
+ * schema, tests, documentation and an ongoing compatibility surface. Those are costs of the SPLIT, not
+ * of the capability, so folding derivation in removes all of them and still leaves exactly one
+ * resolver. Its authority is `ai/scripts/lint/config-leaf-parity.json`, the executable copy of the
+ * classified key lists — never a transcription of them.
  *
  * ## Why the target's Compose identity is discovered
  *
@@ -56,6 +58,7 @@ import {buildMigrationPlan, formatPlan} from './deploymentMigrationCore.mjs';
 const execFileAsync = promisify(execFile),
       scriptDir     = path.dirname(fileURLToPath(import.meta.url)),
       repoRoot      = path.resolve(scriptDir, '../../..'),
+      PARITY_REL    = 'ai/scripts/lint/config-leaf-parity.json',
       PIPELINE_REL  = 'ai/examples/cloud-deployment/deploy-pipeline.sh',
       DEFAULT_REPO  = 'https://github.com/neomjs/neo.git',
       /**
@@ -94,19 +97,19 @@ async function run(command, args, env) {
 /**
  * @summary Parses argv, refusing an unknown mode or flag.
  * @param {String[]} argv `process.argv.slice(2)`
- * @returns {Object} `{mode, target, project, profile, services, repoUrl, discoverJson}`
+ * @returns {Object} `{mode, target, project, profile, services, repoUrl}`
  * @throws {Error} On a missing/unknown mode, an unknown flag, or a flag without a value.
  */
 export function parseArgs(argv) {
     const [mode, ...rest] = argv,
           options         = {
               mode,
-              target      : 'dev',
-              project     : null,
-              profile     : 'ai/deploy/docker-compose.yml',
-              services    : DEFAULT_SERVICES,
-              repoUrl     : process.env.NEO_REPO_URL || DEFAULT_REPO,
-              discoverJson: null
+              target  : 'dev',
+              project : null,
+              profile : 'ai/deploy/docker-compose.yml',
+              services: DEFAULT_SERVICES,
+              repoUrl : process.env.NEO_REPO_URL || DEFAULT_REPO,
+              omitted : null
           };
 
     if (mode !== 'plan' && mode !== 'apply') {
@@ -126,7 +129,6 @@ export function parseArgs(argv) {
             case '--project'      : options.project      = value; break;
             case '--profile'      : options.profile      = value; break;
             case '--repo-url'     : options.repoUrl      = value; break;
-            case '--discover-json': options.discoverJson = value; break;
             case '--services'     : options.services     = value.split(',').map(entry => entry.trim()).filter(Boolean); break;
             default               : throw new Error(`unknown flag: ${flag}`)
         }
@@ -181,11 +183,12 @@ async function discoverProject(services, declaredProject) {
  * `/app/.neo-revision`.
  * @param {String}   project
  * @param {String[]} services
- * @returns {Promise<Object>} `{composeIdentity, deployedRevisions, unchecked}`
+ * @returns {Promise<Object>} `{composeIdentity, deployedRevisions, unchecked, observedEnv}`
  */
 async function inspectPlane(project, services) {
     const deployedRevisions = {},
-          unchecked         = [];
+          unchecked         = [],
+          observedEntries   = [];
 
     let composeIdentity = null;
 
@@ -205,14 +208,32 @@ async function inspectPlane(project, services) {
             continue
         }
 
-        const inspected = await run('docker', ['inspect', containerName, '--format', '{{json .Config.Labels}}']);
+        const inspected = await run('docker', ['inspect', containerName, '--format', '{{json .Config}}']);
 
-        if (inspected.ok && !composeIdentity) {
+        let parsedConfig = null;
+
+        if (inspected.ok) {
+            try {
+                parsedConfig = JSON.parse(inspected.stdout)
+            } catch (error) {
+                unchecked.push(`service '${service}': container config was not parseable JSON — ${error.message}`)
+            }
+        }
+
+        // Env from EVERY service, not just the first: a cohort can disagree, and a key present on one
+        // container but missing on another is a real misconfiguration that reading only one would hide.
+        // Union is the conservative direction here — it can only make the delta smaller, so a key this
+        // reports as missing is missing everywhere.
+        if (parsedConfig) {
+            observedEntries.push(...(parsedConfig.Env || []))
+        }
+
+        if (parsedConfig && !composeIdentity) {
             // The first service that yields labels establishes the plane's identity: every service in
             // one project shares it, so reading it from whichever service answered keeps a single
             // missing container from losing the identity entirely.
-            try {
-                const labels      = JSON.parse(inspected.stdout) || {},
+            {
+                const labels      = parsedConfig.Labels || {},
                       configFiles = (labels['com.docker.compose.project.config_files'] || '')
                           .split(',').map(entry => entry.trim()).filter(Boolean);
 
@@ -223,8 +244,6 @@ async function inspectPlane(project, services) {
                         workingDir: labels['com.docker.compose.project.working_dir'] || null
                     }
                 }
-            } catch (error) {
-                unchecked.push(`service '${service}': container labels were not parseable JSON — ${error.message}`)
             }
         }
 
@@ -237,7 +256,7 @@ async function inspectPlane(project, services) {
         }
     }
 
-    return {composeIdentity, deployedRevisions, unchecked}
+    return {composeIdentity, deployedRevisions, unchecked, observedEnv: parseObservedEnv(observedEntries)}
 }
 
 /**
@@ -280,31 +299,21 @@ async function resolveTargetRevision(repoUrl, selector) {
 }
 
 /**
- * @summary Loads and parses the discover result, returning a named failure rather than throwing.
- *
- * An absent path is a refusal and not a fallback: this driver carries no census derivation, so with no
- * discover result there is nothing to gate on.
- * @param {String|null} discoverJsonPath
- * @returns {Promise<Object>} `{discover, error}`
+ * @summary Loads the classified census for one profile, returning a named failure rather than throwing.
+ * @param {String} profile Repo-relative Compose path.
+ * @returns {Promise<Object>} `{census, error}`
  */
-async function loadDiscoverResult(discoverJsonPath) {
-    if (!discoverJsonPath) {
-        return {
-            discover: null,
-            error   : '--discover-json is required: the contract delta is produced by the discover driver and is never re-derived here'
-        }
-    }
+async function loadCensus(profile) {
+    const parityPath = path.join(repoRoot, PARITY_REL);
 
-    const resolved = path.resolve(repoRoot, discoverJsonPath);
-
-    if (!await fs.pathExists(resolved)) {
-        return {discover: null, error: `discover result not found at ${resolved}`}
+    if (!await fs.pathExists(parityPath)) {
+        return {census: null, error: `${PARITY_REL} is absent — it is this tool's contract authority`}
     }
 
     try {
-        return {discover: await fs.readJson(resolved), error: null}
+        return {census: resolveCensus(await fs.readJson(parityPath), profile), error: null}
     } catch (error) {
-        return {discover: null, error: `discover result at ${resolved} is not parseable JSON — ${error.message}`}
+        return {census: null, error: error.message}
     }
 }
 
@@ -348,7 +357,7 @@ async function main() {
         options = parseArgs(process.argv.slice(2))
     } catch (error) {
         console.error(`[migrate] FATAL: ${error.message}`);
-        console.error('[migrate] usage: migrateDeployment.mjs plan|apply --discover-json <path> [--target <selector>] [--project <name>] [--profile <compose-path>] [--services a,b,c]');
+        console.error('[migrate] usage: migrateDeployment.mjs plan|apply [--target <selector>] [--project <name>] [--profile <compose-path>] [--services a,b,c]');
         return 2
     }
 
@@ -356,12 +365,14 @@ async function main() {
     console.log(`[migrate] profile:  ${options.profile}`);
     console.log(`[migrate] selector: ${options.target}`);
 
-    const {discover, error: discoverError} = await loadDiscoverResult(options.discoverJson);
+    const {census, error: censusError} = await loadCensus(options.profile);
 
-    if (discoverError) {
-        console.error(`[migrate] FATAL: ${discoverError}`);
+    if (censusError) {
+        console.error(`[migrate] FATAL: ${censusError}`);
         return 2
     }
+
+    console.log(`[migrate] contract: ${census.requiredDeploymentInputs.length} required, ${Object.keys(census.forbiddenEnv).length} forbidden, ${census.secrets.length} secret(s)`);
 
     const {project, error: projectError} = await discoverProject(options.services, options.project);
 
@@ -370,7 +381,7 @@ async function main() {
         return 2
     }
 
-    const [{composeIdentity, deployedRevisions, unchecked}, {revision: targetRevision, error: targetError}] = await Promise.all([
+    const [{composeIdentity, deployedRevisions, unchecked, observedEnv}, {revision: targetRevision, error: targetError}] = await Promise.all([
         inspectPlane(project, options.services),
         resolveTargetRevision(options.repoUrl, options.target)
     ]);
@@ -380,12 +391,12 @@ async function main() {
     }
 
     const plan = buildMigrationPlan({
-        discover,
+        observedEnv,
+        census,
         composeIdentity,
         deployedRevisions,
         targetRevision,
-        expectedProfile: options.profile,
-        uncheckedNotes : unchecked
+        uncheckedNotes: unchecked
     });
 
     console.log('');

--- a/learn/agentos/cloud-deployment/PipelineWiring.md
+++ b/learn/agentos/cloud-deployment/PipelineWiring.md
@@ -160,8 +160,39 @@ A deploy job that does not gate on health reports success while serving a broken
 | Backup bundles missing after redeploy | `NEO_HOST_BACKUP_ROOT` changed, or it was left at its `${HOME}`-derived default and the job ran as a different user | set `NEO_HOST_BACKUP_ROOT` to a fixed absolute path on persistent storage; recover bundles from the prior host directory. Bundles from before the relocation may still sit at the old in-tree `.neo-ai-data/backups` — the backup CLI emits a one-time notice naming that path and never moves them |
 | TLS cert re-issued / ACME rate-limited each deploy | `caddy-data` removed by `down -v` | stop using `-v` so the issued certs persist |
 
+## Repairing a plane that is already behind
+
+Everything above describes a pipeline running *forward* from a known-good state. A plane that has drifted needs the opposite: the pipeline has to be *pointed at* a deployment nobody is currently maintaining, and the reason a rebuild alone does not fix it is a configuration contract, not a revision gap.
+
+The worked case is the orchestrator's authority role. Its config leaf carries **no default** — requiredness is armed by that emptiness — so a plane that never declares `NEO_AI_ORCHESTRATOR_AUTHORITY_PROFILE` produces a *refused launch* that writes no state directory, no PID file and no log. Rebuilding it at a newer revision reproduces the refusal at a newer revision. There are thirteen such required inputs.
+
+[`ai/scripts/maintenance/migrateDeployment.mjs`](../../../ai/scripts/maintenance/migrateDeployment.mjs) is the supervised bootstrap for that case. It is operator-invoked, never scheduled, and never mutates on its own judgement:
+
+```bash
+# What would change, and why apply is refused. Mutates nothing.
+node ai/scripts/maintenance/migrateDeployment.mjs plan --project <compose-project>
+
+# Repair a missing or empty required input, then apply. Repeatable per service.
+node ai/scripts/maintenance/migrateDeployment.mjs apply \
+  --project <compose-project> \
+  --set orchestrator.NEO_AI_ORCHESTRATOR_AUTHORITY_PROFILE=container-plane
+```
+
+Four properties are worth knowing before running it, because each was a defect first.
+
+**It refuses by default, and it refuses per service.** The census classifies keys per *profile*, but a profile's required list is not uniform across its services: on the canonical profile four of the thirteen required inputs are declared by one service only. Observations are therefore kept per service and never unioned — a union only ever shrinks the delta, so a key set on one container and absent from another would report as satisfied for both. Anything the tool could not establish blocks rather than annotating an authorizing verdict.
+
+**The config cohort is wider than the revision cohort.** `/app/.neo-revision` is written by the Neo image, so only Neo services can produce a revision receipt. But the deployment contract spans services that cannot: Compose owns `NEO_DEPLOY_HOSTNAME` on the ingress service. Both cohorts are derived — the config cohort from the plane's own Compose service labels, never a hardcoded list — so a deployment with a differently-named proxy stays inside the contract.
+
+**`--set` reaches the containers through a Compose overlay fragment, not through the pipeline's environment.** The profile declares its env as *literals* (`NEO_CHROMA_HOST=chroma`), not `${VAR}`, so exporting a value into the pipeline's environment changes nothing that the containers consume. The bootstrap generates a per-service fragment and appends it **last** in the compose-file list, where merge order makes it win. This is why the pipeline accepting an *ordered* `NEO_DEPLOY_COMPOSE_FILE` list matters: a single-`-f` caller cannot express a repair at all.
+
+**Values the plane already carries are preserved.** `NEO_DEPLOY_HOSTNAME` is supplied by interpolation (`${NEO_DEPLOY_HOSTNAME:-localhost}`) rather than stored, so a repair run whose environment lacks it would re-render the *fallback* and silently reset a plane that had a real hostname. Compose-owned observed values are carried forward, with an explicit `--set` for the same key taking precedence.
+
+Two bounds, stated because they are real. Compose-owned obligation is read from observed env, so it cannot detect a compose-owned key Compose *forgot* to set. And the compose file paths are discovered from the plane's own labels, which on a multi-clone host may point outside the checkout running the tool.
+
 ## Out of scope
 
+- **Cadence, kill-switch and unattended activation.** The bootstrap above is supervised and one-shot by design; it must not become a resident updater. The unattended path is a separate authority.
 - The MVP backup/persistence *implementation* — owned by Sub C [#11724](https://github.com/neomjs/neo/issues/11724); this guide documents how a pipeline *preserves* it.
 - A turnkey, vendor-specific CI workflow — CI systems differ; this guide plus the reference script are the CI-neutral substrate a team adapts.
 - Multi-instance / blue-green / zero-downtime deploy topologies — a later evolution; the reference shape is single-instance recreate-in-place.
@@ -172,4 +203,5 @@ A deploy job that does not gate on health reports success while serving a broken
 - [Day-0 Cloud Deployment Tutorial](./Day0Tutorial.md) — the first-run path; Milestone 7 is the redeploy-survival check this pipeline automates.
 - [Hook Wiring](./HookWiring.md) — the *content* pipeline (tenant repo content into the KB), distinct from this *deployment* pipeline.
 - [`ai/examples/cloud-deployment/deploy-pipeline.sh`](../../../ai/examples/cloud-deployment/deploy-pipeline.sh) — the runnable, CI-neutral reference deploy/redeploy script.
+- [`ai/scripts/maintenance/migrateDeployment.mjs`](../../../ai/scripts/maintenance/migrateDeployment.mjs) — the supervised `plan`/`apply` bootstrap for a plane that is already behind.
 - [ADR 0014](../decisions/0014-cloud-deployment-topology-and-scheduler-task-taxonomy.md) — the cloud topology + scheduler taxonomy this deployment implements.

--- a/test/playwright/unit/ai/MigrateDeploymentApplyRefusal.spec.mjs
+++ b/test/playwright/unit/ai/MigrateDeploymentApplyRefusal.spec.mjs
@@ -62,7 +62,15 @@ async function runApply({dirty}) {
 printf 'docker %s\\n' "$*" >> "${callLog}"
 case "$1" in
   ps)
-    if [[ "$*" == *'.Names'* ]]; then echo "probe-\${RANDOM}-1"; else echo "probe-project"; fi ;;
+    if [[ "$*" == *'.Names'* ]]; then
+      echo "probe-\${RANDOM}-1"
+    elif [[ "$*" == *'com.docker.compose.service'* ]]; then
+      # The config cohort is DISCOVERED from these labels, so the stub must answer as a real plane does:
+      # the Neo services plus a compose-owned proxy that carries the ingress-owned hostname.
+      printf '%s\\n' mc-server orchestrator kb-server ingress
+    else
+      echo "probe-project"
+    fi ;;
   inspect)
     cat "${inspectJson}" ;;
   exec)
@@ -84,8 +92,12 @@ exit 0
     // PATH, so with a `bash` stub on PATH each stub's own interpreter became this stub: it logged its own
     // invocation and exited without ever running the stub body, the driver got empty output from `docker`,
     // and all three tests timed out at 30s. The stub set has to not intercept itself.
+    // The stub also records NEO_DEPLOY_COMPOSE_FILE, because the repair fragment reaches the transaction
+    // through that env var rather than through argv. Without it, "the fragment was generated" is the most a
+    // test could assert; with it, the test can read what the transaction would actually merge.
     await fs.writeFile(path.join(binDir, 'bash'), `#!/bin/bash
 printf 'bash %s\\n' "$*" >> "${callLog}"
+printf 'compose-files %s\\n' "$NEO_DEPLOY_COMPOSE_FILE" >> "${callLog}"
 exit 0
 `);
 
@@ -147,6 +159,27 @@ test.describe('migrateDeployment apply refuses a dirty plan BEFORE touching cont
         // apply path, so this asserts the same call log CAN be non-empty.
         const {calls, stdout} = await runApply({dirty: false});
 
-        expect(calls.some(line => line.includes('deploy-pipeline.sh')), `calls:\n${calls.join('\n')}\n---\n${stdout.slice(-1200)}`).toBe(true)
+        expect(calls.some(line => line.includes('deploy-pipeline.sh')), `calls:\n${calls.join('\n')}\n---\n${stdout.slice(-1200)}`).toBe(true);
+        expect(calls.filter(line => line.includes('deploy-pipeline.sh'))).toHaveLength(1)
+    });
+
+    test('the established ingress hostname is PRESERVED into the transaction, not reset to the fallback', async () => {
+        // The defect this closes: Compose supplies NEO_DEPLOY_HOSTNAME by interpolation
+        // (`${NEO_DEPLOY_HOSTNAME:-localhost}`), so a repair run whose environment lacks it re-renders the
+        // FALLBACK and silently resets a plane that had a real hostname. It is invisible on any plane whose
+        // hostname already equals the fallback — ours does, which is why this needs an assertion and not an
+        // inspection. Read from the fragment the transaction would actually merge, not from a log line.
+        const {calls}  = await runApply({dirty: false}),
+              recorded = calls.find(line => line.startsWith('compose-files '));
+
+        expect(recorded, `no compose-file env recorded; calls:\n${calls.join('\n')}`).toBeTruthy();
+
+        const fragmentPath = recorded.replace('compose-files ', '').trim().split(':').at(-1);
+
+        expect(fragmentPath).toMatch(/repair\.compose\.json$/);
+
+        const fragment = await fs.readJson(fragmentPath);
+
+        expect(fragment.services.ingress.environment.NEO_DEPLOY_HOSTNAME).toBe('fixture-value')
     })
 });

--- a/test/playwright/unit/ai/MigrateDeploymentApplyRefusal.spec.mjs
+++ b/test/playwright/unit/ai/MigrateDeploymentApplyRefusal.spec.mjs
@@ -1,0 +1,152 @@
+import {test, expect}  from '@playwright/test';
+import fs              from 'fs-extra';
+import path            from 'path';
+import {execFile}      from 'node:child_process';
+import {promisify}     from 'node:util';
+import {fileURLToPath} from 'url';
+
+const execFileAsync = promisify(execFile),
+      repoRoot      = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../../..'),
+      DRIVER_REL    = 'ai/scripts/maintenance/migrateDeployment.mjs',
+      TARGET_SHA    = '8a5808007ac4647041d2b425ceba76426a707a50';
+
+/**
+ * `apply` refusing a dirty plan is a two-part guarantee, and only the second part matters: it must stop,
+ * and it must stop BEFORE touching containers. An exit-code assertion proves the first and is blind to
+ * the second — the vacuous form @neo-gpt-emmy named when she rejected an earlier positional test here for
+ * checking that two things merely *appeared*. So the real driver runs with recording stubs on `PATH` and
+ * the assertion is that the pipeline appears in the call log ZERO times.
+ *
+ * The stubs succeed (`exit 0`) rather than failing, so the script proceeds as far as its own logic allows
+ * and we observe every call it chooses to make. A stub that failed would stop the run for the wrong
+ * reason and the test would pass while proving nothing.
+ * @param {Object} options
+ * @param {Boolean} options.dirty Whether the observed env should be missing a required input.
+ * @returns {Promise<Object>} `{code, stdout, calls}` — `calls` is the ordered interleaving of all stubs.
+ */
+async function runApply({dirty}) {
+    const workDir = await fs.mkdtemp(path.join(repoRoot, 'test/playwright/test-results/apply-refusal-')),
+          binDir  = path.join(workDir, 'bin'),
+          callLog = path.join(workDir, 'calls.log');
+
+    await fs.ensureDir(binDir);
+    await fs.writeFile(callLog, '');
+
+    // A satisfied cohort needs every census-required key. Rather than enumerate today's list, the clean
+    // case reads the live census — so this fixture cannot drift into a false CLEAN when the census grows.
+    // A satisfied cohort needs every required input AND every declared secret — omitting the secrets is
+    // what kept the clean path red on the first attempt, and it is the reason this reads the census rather
+    // than a hand-listed fixture: a hand-list drifts into a false CLEAN as the census grows.
+    const parity    = await fs.readJson(path.join(repoRoot, 'ai/scripts/lint/config-leaf-parity.json')),
+          {census}  = parity.$composeDefaultParity,
+          satisfied = [...census.requiredDeploymentInputs, ...census.secrets],
+          declared  = dirty ? satisfied.slice(1) : satisfied;
+
+    // The inspect payload is written to a FILE and `cat`-ed, never interpolated into the stub's shell
+    // source. Interpolating it put the JSON array outside bash's single quotes, so bash stripped the inner
+    // quotes and the stub emitted `{"Env":[A=1,B=2]}` — unparseable. The driver then observed nothing and
+    // the plan refused with `no-observed-service`, so the refusal test PASSED for the wrong reason: a dirty
+    // plan refuses on any blocker, and "nothing was measured" is a blocker. A test that cannot tell why it
+    // is green is not a witness.
+    const inspectJson = path.join(workDir, 'inspect.json');
+
+    await fs.writeJson(inspectJson, {
+        Env   : declared.map(key => `${key}=fixture-value`),
+        Labels: {
+            'com.docker.compose.project'             : 'probe-project',
+            'com.docker.compose.project.config_files': '/x/base.yml,/x/overlay.yml'
+        }
+    });
+
+    const dockerStub = `#!/bin/bash
+printf 'docker %s\\n' "$*" >> "${callLog}"
+case "$1" in
+  ps)
+    if [[ "$*" == *'.Names'* ]]; then echo "probe-\${RANDOM}-1"; else echo "probe-project"; fi ;;
+  inspect)
+    cat "${inspectJson}" ;;
+  exec)
+    echo "${TARGET_SHA}" ;;
+esac
+exit 0
+`;
+
+    await fs.writeFile(path.join(binDir, 'docker'), dockerStub);
+    await fs.writeFile(path.join(binDir, 'git'), `#!/bin/bash
+printf 'git %s\\n' "$*" >> "${callLog}"
+echo -e "${TARGET_SHA}\\trefs/heads/dev"
+exit 0
+`);
+    // The pipeline is a bash script the driver invokes via `run('bash', …)`, which resolves through PATH,
+    // so `bash` is the stub that records whether the transaction was reached at all.
+    //
+    // Every stub's shebang is ABSOLUTE `#!/bin/bash`, never `#!/usr/bin/env bash`. `env` resolves through
+    // PATH, so with a `bash` stub on PATH each stub's own interpreter became this stub: it logged its own
+    // invocation and exited without ever running the stub body, the driver got empty output from `docker`,
+    // and all three tests timed out at 30s. The stub set has to not intercept itself.
+    await fs.writeFile(path.join(binDir, 'bash'), `#!/bin/bash
+printf 'bash %s\\n' "$*" >> "${callLog}"
+exit 0
+`);
+
+    for (const name of ['docker', 'git', 'bash']) {
+        await fs.chmod(path.join(binDir, name), 0o755)
+    }
+
+    let code = 0, stdout = '';
+
+    try {
+        const result = await execFileAsync(process.execPath, [path.join(repoRoot, DRIVER_REL), 'apply', '--project', 'probe-project'], {
+            env: {...process.env, PATH: `${binDir}:${process.env.PATH}`}
+        });
+
+        stdout = result.stdout
+    } catch (error) {
+        code   = error.code ?? 1;
+        stdout = `${error.stdout || ''}${error.stderr || ''}`
+    }
+
+    return {code, stdout, calls: (await fs.readFile(callLog, 'utf8')).split('\n').filter(Boolean)}
+}
+
+test.describe('migrateDeployment apply refuses a dirty plan BEFORE touching containers', () => {
+    test('a dirty plan refuses, and the pipeline is invoked ZERO times', async () => {
+        const {code, stdout, calls} = await runApply({dirty: true});
+
+        expect(code, stdout.slice(-1200)).not.toBe(0);
+        expect(stdout).toContain('apply refused');
+
+        // It must refuse for the RIGHT reason. Without this, "nothing was observed" satisfies the test and
+        // the guarantee under assertion is never exercised — which is exactly how this test first went
+        // green while the stub was emitting unparseable JSON.
+        expect(stdout, stdout.slice(-1500)).toContain('missing-required-input');
+        expect(stdout).not.toContain('no-observed-service');
+
+        // The guarantee. Not "exited non-zero" — "never reached the transaction".
+        const pipelineCalls = calls.filter(line => line.includes('deploy-pipeline.sh'));
+
+        expect(pipelineCalls, `pipeline must not be invoked; calls:\n${calls.join('\n')}`).toEqual([]);
+
+        // And no mutating Docker verb either, since the driver's own reads are all non-mutating.
+        expect(calls.filter(line => /docker (compose (up|down)|rm|stop|start|restart)\b/.test(line))).toEqual([])
+    });
+
+    test('the refusal names the failing condition rather than exiting silently', async () => {
+        const {stdout} = await runApply({dirty: true});
+
+        // An operator reading only stdout must learn WHICH condition refused, or the tool is a black box
+        // that says no. The blocker count plus the per-blocker reason lines carry that.
+        expect(stdout).toMatch(/blocker\(s\)/);
+        expect(stdout).toContain('missing-required-input');
+        expect(stdout).toContain('Docker was NOT invoked')
+    });
+
+    test('the stubs CAN observe a pipeline invocation — the positive control for the assertion above', async () => {
+        // Without this, "zero pipeline calls" is unfalsifiable: a stub set that could never record the
+        // pipeline would pass the refusal test no matter what the driver did. A satisfied cohort takes the
+        // apply path, so this asserts the same call log CAN be non-empty.
+        const {calls, stdout} = await runApply({dirty: false});
+
+        expect(calls.some(line => line.includes('deploy-pipeline.sh')), `calls:\n${calls.join('\n')}\n---\n${stdout.slice(-1200)}`).toBe(true)
+    })
+});

--- a/test/playwright/unit/ai/scripts/maintenance/deploymentMigrationCore.spec.mjs
+++ b/test/playwright/unit/ai/scripts/maintenance/deploymentMigrationCore.spec.mjs
@@ -1,0 +1,314 @@
+import {test, expect} from '@playwright/test';
+import {
+    buildMigrationPlan,
+    DISCOVER_SCHEMA_VERSION,
+    formatPlan,
+    validateDiscoverResult
+} from '../../../../../../ai/scripts/maintenance/deploymentMigrationCore.mjs';
+import {parseArgs} from '../../../../../../ai/scripts/maintenance/migrateDeployment.mjs';
+
+const PROFILE    = 'ai/deploy/docker-compose.yml',
+      TARGET_SHA = '8a5808007ac4647041d2b425ceba76426a707a50',
+      OLD_SHA    = 'efe4490dd7fef0beb9df9ae21363b8e44e05ad3d';
+
+/**
+ * A discover result in the shape this consumer contracts for (the discover driver's JSON). Built as a factory
+ * so each test perturbs one field and the resulting blocker is attributable to that perturbation.
+ */
+function createDiscover(overrides = {}) {
+    return {
+        schemaVersion   : DISCOVER_SCHEMA_VERSION,
+        profile         : PROFILE,
+        clean           : true,
+        missingRequired : [],
+        presentForbidden: [],
+        missingSecrets  : [],
+        unchecked       : [],
+        ...overrides
+    }
+}
+
+/**
+ * A plan input whose every field is already valid.
+ */
+function createPlanInput(overrides = {}) {
+    return {
+        discover         : createDiscover(),
+        composeIdentity  : {project: 'neo-local-agent-os', configFiles: ['/x/docker-compose.yml', '/x/docker-compose.local.yml']},
+        deployedRevisions: {'mc-server': OLD_SHA, orchestrator: OLD_SHA, 'kb-server': OLD_SHA},
+        targetRevision   : TARGET_SHA,
+        expectedProfile  : PROFILE,
+        ...overrides
+    }
+}
+
+test.describe('validateDiscoverResult refuses on shape, never best-efforts', () => {
+    test('accepts a well-formed result', () => {
+        expect(validateDiscoverResult(createDiscover(), PROFILE)).toEqual([])
+    });
+
+    test('a non-object is rejected outright', () => {
+        for (const input of [null, undefined, 'x', 42, []]) {
+            expect(validateDiscoverResult(input, PROFILE).length, JSON.stringify(input)).toBeGreaterThan(0)
+        }
+    });
+
+    test('a schemaVersion this consumer does not implement is refused rather than interpreted', () => {
+        // Silent mis-parsing of a changed producer shape would authorize an apply against fields
+        // that were never populated.
+        const problems = validateDiscoverResult(createDiscover({schemaVersion: DISCOVER_SCHEMA_VERSION + 1}), PROFILE);
+
+        expect(problems.some(problem => problem.includes('refusing to interpret an unknown shape'))).toBe(true)
+    });
+
+    test('a profile mismatch is refused — the census is per-profile', () => {
+        const problems = validateDiscoverResult(createDiscover({profile: 'ai/deploy/docker-compose.dev.yml'}), PROFILE);
+
+        expect(problems.some(problem => problem.includes('but this run targets'))).toBe(true)
+    });
+
+    test('an ABSENT finding list is refused, because absent and empty are the same shape once parsed', () => {
+        // This is the "never report an empty delta" property: a missing list would otherwise read as
+        // "you are fine" from a producer that never ran the check.
+        for (const listName of ['missingRequired', 'presentForbidden', 'missingSecrets']) {
+            const discover = createDiscover();
+            delete discover[listName];
+
+            const problems = validateDiscoverResult(discover, PROFILE);
+
+            expect(problems.some(problem => problem.includes(listName)), listName).toBe(true)
+        }
+    });
+
+    test('an empty finding list is accepted — that is the normal clean case', () => {
+        expect(validateDiscoverResult(createDiscover({missingRequired: [], presentForbidden: [], missingSecrets: []}), PROFILE)).toEqual([])
+    });
+
+    test('a missing boolean verdict is refused', () => {
+        const discover = createDiscover();
+        delete discover.clean;
+
+        expect(validateDiscoverResult(discover, PROFILE).some(problem => problem.includes("'clean'"))).toBe(true)
+    });
+});
+
+test.describe('buildMigrationPlan gates apply on the consumed contract', () => {
+    test('a satisfied deployment plus a clean discover result plans clean', () => {
+        const plan = buildMigrationPlan(createPlanInput());
+
+        expect(plan.clean).toBe(true);
+        expect(plan.blockers).toEqual([]);
+        expect(plan.revisionDelta).toMatchObject({from: OLD_SHA, to: TARGET_SHA, alreadyTarget: false})
+    });
+
+    test('an invalid discover result blocks before any finding is read', () => {
+        const plan = buildMigrationPlan(createPlanInput({discover: {schemaVersion: 99}}));
+
+        expect(plan.clean).toBe(false);
+        expect(plan.blockers.some(blocker => blocker.kind === 'discover-result-invalid')).toBe(true)
+    });
+
+    test('an ABSENT discover result blocks — there is no fallback derivation', () => {
+        // Deliberate: a second census resolver could disagree with the discover driver's, and the
+        // disagreement would surface as a migration authorized against the wrong answer.
+        const plan = buildMigrationPlan(createPlanInput({discover: null}));
+
+        expect(plan.clean).toBe(false);
+        expect(plan.blockers.some(blocker => blocker.kind === 'discover-result-invalid')).toBe(true)
+    });
+
+    test('a missing required input blocks and forwards the census reason verbatim', () => {
+        const plan = buildMigrationPlan(createPlanInput({
+            discover: createDiscover({clean: false, missingRequired: [{key: 'NEO_TRANSPORT', reason: 'declared required'}]})
+        }));
+
+        expect(plan.clean).toBe(false);
+        expect(plan.discoverFindings.missingRequired).toEqual(['NEO_TRANSPORT']);
+        expect(plan.blockers.find(blocker => blocker.key === 'NEO_TRANSPORT').reason).toBe('declared required')
+    });
+
+    test('a boot-blocking missing input gets its own kind and sorts first in the report', () => {
+        // A refused launch is a different triage priority from a degraded one, and the discover
+        // contract distinguishes them; flattening that would bury the one key that stops the plane
+        // from starting at all.
+        const plan = buildMigrationPlan(createPlanInput({
+            discover: createDiscover({
+                clean          : false,
+                missingRequired: [
+                    {key: 'NEO_TRANSPORT', reason: 'declared required'},
+                    {key: 'NEO_AI_ORCHESTRATOR_AUTHORITY_PROFILE', reason: 'no default; launch is refused', bootBlocking: true}
+                ]
+            })
+        }));
+
+        expect(plan.blockers.some(blocker => blocker.kind === 'missing-required-input-boot-blocking')).toBe(true);
+
+        const report         = formatPlan(plan),
+              bootBlockingAt = report.indexOf('NEO_AI_ORCHESTRATOR_AUTHORITY_PROFILE'),
+              ordinaryAt     = report.indexOf('NEO_TRANSPORT');
+
+        expect(bootBlockingAt).toBeGreaterThan(-1);
+        expect(bootBlockingAt).toBeLessThan(ordinaryAt)
+    });
+
+    test('a present forbidden key and a missing secret each block', () => {
+        const plan = buildMigrationPlan(createPlanInput({
+            discover: createDiscover({
+                clean           : false,
+                presentForbidden: [{key: 'NEO_MESSAGE_WAL_DIR', reason: 'derived from NEO_MEMORY_WAL_DIR'}],
+                missingSecrets  : [{key: 'NEO_KB_ASK_API_KEY', reason: 'required secret'}]
+            })
+        }));
+
+        expect(plan.blockers.find(blocker => blocker.kind === 'forbidden-env-present').reason).toBe('derived from NEO_MEMORY_WAL_DIR');
+        expect(plan.blockers.some(blocker => blocker.kind === 'missing-secret')).toBe(true)
+    });
+
+    test('clean=false with zero findings blocks rather than resolving the contradiction', () => {
+        // The producer knows something the gate does not; trusting the findings over the verdict
+        // would silently discard it.
+        const plan = buildMigrationPlan(createPlanInput({discover: createDiscover({clean: false})}));
+
+        expect(plan.blockers.some(blocker => blocker.kind === 'discover-verdict-unexplained')).toBe(true)
+    });
+
+    test('a bare-string finding is tolerated without losing the key', () => {
+        const plan = buildMigrationPlan(createPlanInput({
+            discover: createDiscover({clean: false, missingRequired: ['NEO_TRANSPORT']})
+        }));
+
+        expect(plan.discoverFindings.missingRequired).toEqual(['NEO_TRANSPORT'])
+    });
+});
+
+test.describe('buildMigrationPlan adds the plane-side facts discovery cannot supply', () => {
+    test('an undiscoverable Compose identity blocks rather than falling back to a default', () => {
+        // The pipeline default is project `neo-agent-os`; against a two-file plane that addresses a
+        // DIFFERENT project with the overlay dropped.
+        for (const identity of [null, {project: 'x', configFiles: []}, {configFiles: ['/a.yml']}]) {
+            const plan = buildMigrationPlan(createPlanInput({composeIdentity: identity}));
+
+            expect(plan.clean, JSON.stringify(identity)).toBe(false);
+            expect(plan.blockers.some(blocker => blocker.kind === 'compose-identity-undiscoverable')).toBe(true)
+        }
+    });
+
+    test('an unresolved target revision blocks', () => {
+        const plan = buildMigrationPlan(createPlanInput({targetRevision: null}));
+
+        expect(plan.blockers.some(blocker => blocker.kind === 'target-revision-unresolved')).toBe(true)
+    });
+
+    test('a cohort reporting two revisions blocks as a partially-applied prior run', () => {
+        const plan = buildMigrationPlan(createPlanInput({
+                  deployedRevisions: {'mc-server': OLD_SHA, orchestrator: TARGET_SHA, 'kb-server': OLD_SHA}
+              })),
+              blocker = plan.blockers.find(entry => entry.kind === 'cohort-revision-split');
+
+        expect(plan.clean).toBe(false);
+        expect(blocker.reason).toContain('2 different revisions')
+    });
+
+    test('no readable revision anywhere blocks — there is no baseline to assert against', () => {
+        const plan = buildMigrationPlan(createPlanInput({
+            deployedRevisions: {'mc-server': null, orchestrator: null, 'kb-server': null}
+        }));
+
+        expect(plan.blockers.some(blocker => blocker.kind === 'no-readable-revision')).toBe(true)
+    });
+
+    test('a plane already AT the target still refuses when the contract is unsatisfied', () => {
+        // The pairing that matters, and the reason a revision-only trigger is insufficient:
+        // revision-current and contract-invalid at once.
+        const plan = buildMigrationPlan(createPlanInput({
+            deployedRevisions: {'mc-server': TARGET_SHA, orchestrator: TARGET_SHA, 'kb-server': TARGET_SHA},
+            discover         : createDiscover({clean: false, missingRequired: [{key: 'NEO_TRANSPORT', reason: 'declared required'}]})
+        }));
+
+        expect(plan.revisionDelta.alreadyTarget).toBe(true);
+        expect(plan.clean).toBe(false)
+    });
+});
+
+test.describe('unchecked items are never silently passed', () => {
+    test('one unreadable service becomes UNCHECKED, not a pass and not a blocker', () => {
+        const plan = buildMigrationPlan(createPlanInput({
+            deployedRevisions: {'mc-server': OLD_SHA, orchestrator: OLD_SHA, 'kb-server': null}
+        }));
+
+        expect(plan.clean).toBe(true);
+        expect(plan.unchecked.some(item => item.includes('kb-server'))).toBe(true)
+    });
+
+    test("the producer's own unchecked items are forwarded and attributed", () => {
+        const plan = buildMigrationPlan(createPlanInput({
+            discover: createDiscover({unchecked: ['secrets not readable on this host']})
+        }));
+
+        expect(plan.unchecked).toContain('discover: secrets not readable on this host')
+    });
+
+    test('entrypoint-supplied unchecked notes survive into the plan', () => {
+        const plan = buildMigrationPlan(createPlanInput({uncheckedNotes: ['overlay drift: not evaluated']}));
+
+        expect(plan.unchecked).toContain('overlay drift: not evaluated')
+    });
+});
+
+test.describe('formatPlan', () => {
+    test('a refused plan states REFUSED and includes every blocker key', () => {
+        const plan   = buildMigrationPlan(createPlanInput({discover: null, composeIdentity: null})),
+              report = formatPlan(plan);
+
+        expect(report).toContain('verdict: REFUSED');
+        expect(report).toContain('compose-identity-undiscoverable');
+        expect(plan.blockers.every(({key}) => report.includes(key))).toBe(true)
+    });
+
+    test('a clean plan states CLEAN and says apply is authorized', () => {
+        const report = formatPlan(buildMigrationPlan(createPlanInput()));
+
+        expect(report).toContain('verdict: CLEAN');
+        expect(report).toContain('apply is authorized')
+    });
+
+    test('unchecked items render as NOT VERIFIED rather than being omitted', () => {
+        const report = formatPlan(buildMigrationPlan(createPlanInput({uncheckedNotes: ['overlay drift: not evaluated']})));
+
+        expect(report).toContain('NOT VERIFIED');
+        expect(report).toContain('overlay drift: not evaluated')
+    });
+});
+
+test.describe('parseArgs', () => {
+    test('importing the driver does not execute it', () => {
+        // The entrypoint guard's real assertion: this spec reaching this line at all means importing
+        // the driver did not run a migration as an import side effect.
+        expect(typeof parseArgs).toBe('function')
+    });
+
+    test('defaults to the dev selector and the canonical cohort', () => {
+        const options = parseArgs(['plan', '--discover-json', 'x.json']);
+
+        expect(options).toMatchObject({mode: 'plan', target: 'dev', profile: PROFILE, discoverJson: 'x.json'});
+        expect(options.services).toEqual(['mc-server', 'orchestrator', 'kb-server'])
+    });
+
+    test('refuses a missing or unknown mode', () => {
+        expect(() => parseArgs([])).toThrow(/must be 'plan' or 'apply'/);
+        expect(() => parseArgs(['deploy'])).toThrow(/must be 'plan' or 'apply'/)
+    });
+
+    test('refuses an unknown flag rather than ignoring it', () => {
+        // A silently-ignored flag is how an operator believes they scoped a run that ran unscoped.
+        expect(() => parseArgs(['plan', '--fource', 'x'])).toThrow(/unknown flag: --fource/)
+    });
+
+    test('refuses a flag with no value', () => {
+        expect(() => parseArgs(['plan', '--target'])).toThrow(/requires a value/)
+    });
+
+    test('--services splits, trims and drops empties', () => {
+        expect(parseArgs(['plan', '--services', ' a , b ,, c ']).services).toEqual(['a', 'b', 'c'])
+    });
+});

--- a/test/playwright/unit/ai/scripts/maintenance/deploymentMigrationCore.spec.mjs
+++ b/test/playwright/unit/ai/scripts/maintenance/deploymentMigrationCore.spec.mjs
@@ -607,8 +607,13 @@ test.describe('parseArgs', () => {
         const options = parseArgs(['plan']);
 
         expect(options.services).toEqual(['mc-server', 'orchestrator', 'kb-server']);
-        expect(options.configServices).toEqual(['mc-server', 'orchestrator', 'kb-server', 'ingress']);
-        expect(options.configServices.length).toBeGreaterThan(options.services.length)
+
+        // `null` means DISCOVER from the plane's Compose labels. An earlier revision defaulted this to
+        // `[...DEFAULT_SERVICES, 'ingress']`, which hardcodes one profile's topology into a tool whose whole
+        // job is addressing a plane it did not build — a differently-named proxy or a fourth
+        // config-bearing service would fall outside the contract again. Verified live: the discovered
+        // cohort is `chroma, ingress, kb-server, mc-server, orchestrator`.
+        expect(options.configServices).toBeNull()
     });
 
     test('--config-services narrows the config cohort independently of --services', () => {

--- a/test/playwright/unit/ai/scripts/maintenance/deploymentMigrationCore.spec.mjs
+++ b/test/playwright/unit/ai/scripts/maintenance/deploymentMigrationCore.spec.mjs
@@ -450,13 +450,41 @@ test.describe('the invocation boundary carries the repair into the transaction',
     });
 
     test('the pinned revision and discovered identity survive alongside a forwarded repair', () => {
-        // A desired key must never be able to overwrite the pinning that makes the transaction exact.
         const plan          = buildMigrationPlan(createPlanInput()),
               {pipelineEnv} = buildPipelineEnv(plan, identity, {orchestrator: {NEO_CHROMA_HOST: 'chroma'}});
 
         expect(pipelineEnv.NEO_REF).toBe(TARGET_SHA);
         expect(pipelineEnv.NEO_DEPLOY_PROJECT_NAME).toBe('neo-local-agent-os');
         expect(pipelineEnv.NEO_DEPLOY_COMPOSE_FILE).toContain('/x/overlay.yml')
+    });
+
+    test('a repair value CANNOT shadow a transaction key — adversarially, with the key it would redirect', () => {
+        // The prior version of the test above passed while the defect was live, because its fixture never
+        // contained a transaction key: the control could not fail for the reason the target might, so it
+        // certified nothing. @neo-gpt-emmy found that `--set orchestrator.NEO_REF=<other>` emitted the
+        // other SHA, because the repair spread AFTER the pinning. Named by the key it would have hijacked.
+        const plan = buildMigrationPlan(createPlanInput());
+
+        for (const key of ['NEO_REF', 'NEO_DEPLOY_PROJECT_NAME', 'NEO_DEPLOY_COMPOSE_FILE']) {
+            const {pipelineEnv, forwarded} = buildPipelineEnv(plan, identity, {orchestrator: {[key]: 'HIJACKED'}});
+
+            expect(pipelineEnv[key], key).not.toBe('HIJACKED');
+            expect(forwarded, key).not.toContain(key)
+        }
+
+        expect(buildPipelineEnv(plan, identity, {orchestrator: {NEO_REF: 'HIJACKED'}}).pipelineEnv.NEO_REF).toBe(TARGET_SHA)
+    });
+
+    test('parseArgs refuses a reserved transaction key by NAME, not by losing a precedence contest', () => {
+        // Two independent guards: a caller building desiredEnv programmatically never reaches the parser,
+        // and a parser rejection alone would not protect that path.
+        for (const key of ['NEO_REF', 'NEO_DEPLOY_PROJECT_NAME', 'NEO_DEPLOY_COMPOSE_FILE']) {
+            expect(() => parseArgs(['plan', '--set', `orchestrator.${key}=x`]), key)
+                .toThrow(/may not carry .*: it defines the transaction/)
+        }
+
+        expect(parseArgs(['plan', '--set', 'orchestrator.NEO_CHROMA_HOST=chroma']).desiredEnv)
+            .toEqual({orchestrator: {NEO_CHROMA_HOST: 'chroma'}})
     });
 
     test('no repair declared forwards nothing — apply never carries config the operator did not name', () => {

--- a/test/playwright/unit/ai/scripts/maintenance/deploymentMigrationCore.spec.mjs
+++ b/test/playwright/unit/ai/scripts/maintenance/deploymentMigrationCore.spec.mjs
@@ -9,7 +9,7 @@ import {
     parseObservedEnv,
     resolveCensus
 } from '../../../../../../ai/scripts/maintenance/deploymentMigrationCore.mjs';
-import {buildPipelineEnv, parseArgs} from '../../../../../../ai/scripts/maintenance/migrateDeployment.mjs';
+import {buildComposeFragment, buildPipelineEnv, parseArgs} from '../../../../../../ai/scripts/maintenance/migrateDeployment.mjs';
 
 const repoRoot   = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../../../../..'),
       PARITY_REL = 'ai/scripts/lint/config-leaf-parity.json',
@@ -438,41 +438,88 @@ test.describe('formatPlan', () => {
 test.describe('the invocation boundary carries the repair into the transaction', () => {
     const identity = {project: 'neo-local-agent-os', configFiles: ['/x/base.yml', '/x/overlay.yml']};
 
-    test('a declared desired value CROSSES into the pipeline env, not merely into the plan', () => {
-        // The defect this closes, caught by @neo-gpt-emmy: --set reached desiredEnv and configTransition
-        // in the plan while invokePipeline built its env from revision and identity only, so `apply`
-        // recreated containers with the OLD config and the plan recorded a transition it never performed.
-        const plan                     = buildMigrationPlan(createPlanInput()),
-              {pipelineEnv, forwarded} = buildPipelineEnv(plan, identity, {orchestrator: {NEO_CHROMA_HOST: 'chroma'}});
+    test('the repair travels as a fragment appended LAST, because merge order decides which value wins', () => {
+        // Two defects behind this, both @neo-gpt-emmy's. First: --set reached the plan and never reached
+        // invokePipeline. Second, after I "fixed" it by forwarding parent env: the profile declares these
+        // leaves as LITERALS, not ${VAR}, so parent env never reached the consumer either. Her positive
+        // control is what settled it — NEO_DEPLOY_HOSTNAME renders while AUTHORITY_PROFILE does not, same
+        // command. The fragment is what the containers actually consume.
+        const plan                        = buildMigrationPlan(createPlanInput()),
+              {pipelineEnv, composeFiles} = buildPipelineEnv(plan, identity, '/tmp/x/repair.compose.json');
 
-        expect(pipelineEnv.NEO_CHROMA_HOST).toBe('chroma');
-        expect(forwarded).toEqual(['NEO_CHROMA_HOST'])
+        expect(composeFiles).toEqual(['/x/base.yml', '/x/overlay.yml', '/tmp/x/repair.compose.json']);
+        expect(pipelineEnv.NEO_DEPLOY_COMPOSE_FILE.split(':').at(-1)).toBe('/tmp/x/repair.compose.json')
     });
 
-    test('the pinned revision and discovered identity survive alongside a forwarded repair', () => {
+    test('the fragment is service-scoped, so two services CAN carry different values for one key', () => {
+        // The refusal that used to live here is gone. It blocked differing per-service values on the
+        // premise that the transport was global interpolation — a premise that was false, and whose
+        // refusal would now reject a transition the fragment can express.
+        const fragment = JSON.parse(buildComposeFragment({
+            orchestrator: {NEO_CHROMA_HOST: 'chroma'},
+            'mc-server' : {NEO_CHROMA_HOST: 'localhost'}
+        }));
+
+        expect(fragment.services.orchestrator.environment.NEO_CHROMA_HOST).toBe('chroma');
+        expect(fragment.services['mc-server'].environment.NEO_CHROMA_HOST).toBe('localhost');
+
+        expect(buildMigrationPlan(createPlanInput({
+            desiredEnv: {orchestrator: {NEO_CHROMA_HOST: 'chroma'}, 'mc-server': {NEO_CHROMA_HOST: 'localhost'}}
+        })).blockers.filter(entry => entry.kind === 'desired-value-conflict')).toEqual([])
+    });
+
+    test('a literal $ is escaped, or Compose interpolation silently rewrites the operator\'s value', () => {
+        // Measured through a real `docker compose config`: `p@ss${x}w$1` renders as `p@ssw$1` — the value
+        // replaced by a different one with no error and only a warning on stderr. A generated password or
+        // a DSN would be corrupted. `$$` is Compose's own escape for a literal `$`.
+        const fragment = JSON.parse(buildComposeFragment({orchestrator: {NEO_SECRETISH: 'p@ss${x}w$1'}}));
+
+        expect(fragment.services.orchestrator.environment.NEO_SECRETISH).toBe('p@ss$${x}w$$1')
+    });
+
+    test('the fragment is valid JSON, which is valid YAML — no hand-rolled quoting to get wrong', () => {
+        const fragment = buildComposeFragment({orchestrator: {NEO_TRICKY: 'a: b #c "q"\n1'}});
+
+        expect(() => JSON.parse(fragment)).not.toThrow();
+        expect(JSON.parse(fragment).services.orchestrator.environment.NEO_TRICKY).toBe('a: b #c "q"\n1')
+    });
+
+    test('nothing declared yields NO fragment, so apply never appends a file it did not need', () => {
+        expect(buildComposeFragment()).toBeNull();
+        expect(buildComposeFragment({})).toBeNull();
+        expect(buildComposeFragment({orchestrator: {}})).toBeNull()
+    });
+
+    test('the pinned revision and discovered identity survive alongside a repair fragment', () => {
         const plan          = buildMigrationPlan(createPlanInput()),
-              {pipelineEnv} = buildPipelineEnv(plan, identity, {orchestrator: {NEO_CHROMA_HOST: 'chroma'}});
+              {pipelineEnv} = buildPipelineEnv(plan, identity, '/tmp/x/repair.compose.json');
 
         expect(pipelineEnv.NEO_REF).toBe(TARGET_SHA);
         expect(pipelineEnv.NEO_DEPLOY_PROJECT_NAME).toBe('neo-local-agent-os');
         expect(pipelineEnv.NEO_DEPLOY_COMPOSE_FILE).toContain('/x/overlay.yml')
     });
 
-    test('a repair value CANNOT shadow a transaction key — adversarially, with the key it would redirect', () => {
-        // The prior version of the test above passed while the defect was live, because its fixture never
-        // contained a transaction key: the control could not fail for the reason the target might, so it
-        // certified nothing. @neo-gpt-emmy found that `--set orchestrator.NEO_REF=<other>` emitted the
-        // other SHA, because the repair spread AFTER the pinning. Named by the key it would have hijacked.
+    test('shadowing a transaction key is now impossible BY CONSTRUCTION, not by spread ordering', () => {
+        // History worth keeping. @neo-gpt-emmy found `--set orchestrator.NEO_REF=<other>` emitted the other
+        // SHA, because the repair spread AFTER the pinning; the test that was supposed to catch it passed
+        // throughout, because its fixture never contained a transaction key — the control could not fail
+        // for the reason the target might. The first fix reordered the spread. Moving the repair into a
+        // fragment removed the class instead: `buildPipelineEnv` no longer accepts desired values at all,
+        // so the three transaction keys can only come from the plan and the discovered identity.
         const plan = buildMigrationPlan(createPlanInput());
 
+        // A fragment path is the ONLY third argument; a desired-env object cannot be smuggled through it.
+        const {pipelineEnv} = buildPipelineEnv(plan, identity, '/tmp/x/repair.compose.json');
+
+        expect(pipelineEnv.NEO_REF).toBe(TARGET_SHA);
+        expect(pipelineEnv.NEO_DEPLOY_PROJECT_NAME).toBe('neo-local-agent-os');
+        expect(Object.keys(pipelineEnv).sort()).toEqual(['NEO_DEPLOY_COMPOSE_FILE', 'NEO_DEPLOY_PROJECT_NAME', 'NEO_REF']);
+
+        // And the parser still refuses the keys by name, so a fragment cannot set them on a container
+        // either — belt and braces, since the fragment writes real container env.
         for (const key of ['NEO_REF', 'NEO_DEPLOY_PROJECT_NAME', 'NEO_DEPLOY_COMPOSE_FILE']) {
-            const {pipelineEnv, forwarded} = buildPipelineEnv(plan, identity, {orchestrator: {[key]: 'HIJACKED'}});
-
-            expect(pipelineEnv[key], key).not.toBe('HIJACKED');
-            expect(forwarded, key).not.toContain(key)
+            expect(() => parseArgs(['plan', '--set', `orchestrator.${key}=HIJACKED`]), key).toThrow(/defines the transaction/)
         }
-
-        expect(buildPipelineEnv(plan, identity, {orchestrator: {NEO_REF: 'HIJACKED'}}).pipelineEnv.NEO_REF).toBe(TARGET_SHA)
     });
 
     test('parseArgs refuses a reserved transaction key by NAME, not by losing a precedence contest', () => {
@@ -487,35 +534,11 @@ test.describe('the invocation boundary carries the repair into the transaction',
             .toEqual({orchestrator: {NEO_CHROMA_HOST: 'chroma'}})
     });
 
-    test('no repair declared forwards nothing — apply never carries config the operator did not name', () => {
-        const {pipelineEnv, forwarded} = buildPipelineEnv(buildMigrationPlan(createPlanInput()), identity);
+    test('no repair declared appends no file — apply never carries config the operator did not name', () => {
+        const {pipelineEnv, composeFiles} = buildPipelineEnv(buildMigrationPlan(createPlanInput()), identity);
 
-        expect(forwarded).toEqual([]);
+        expect(composeFiles).toEqual(['/x/base.yml', '/x/overlay.yml']);
         expect(Object.keys(pipelineEnv).sort()).toEqual(['NEO_DEPLOY_COMPOSE_FILE', 'NEO_DEPLOY_PROJECT_NAME', 'NEO_REF'])
-    });
-
-    test('two services disagreeing on one key BLOCKS at plan time, because the transport is global', () => {
-        // Compose interpolation carries one value per key for the whole project, so a per-service carrier
-        // can express a transition the transaction cannot perform. Picking either value would apply a
-        // config the operator never named for one of the two services.
-        const plan = buildMigrationPlan(createPlanInput({
-            desiredEnv: {orchestrator: {NEO_CHROMA_HOST: 'chroma'}, 'mc-server': {NEO_CHROMA_HOST: 'localhost'}}
-        }));
-
-        expect(plan.clean).toBe(false);
-
-        const blocker = plan.blockers.find(entry => entry.kind === 'desired-value-conflict');
-
-        expect(blocker.key).toBe('NEO_CHROMA_HOST');
-        expect(blocker.reason).toContain('one value per key')
-    });
-
-    test('agreeing services do NOT block — an identical value is expressible by the global transport', () => {
-        const plan = buildMigrationPlan(createPlanInput({
-            desiredEnv: {orchestrator: {NEO_CHROMA_HOST: 'chroma'}, 'mc-server': {NEO_CHROMA_HOST: 'chroma'}}
-        }));
-
-        expect(plan.blockers.filter(entry => entry.kind === 'desired-value-conflict')).toEqual([])
     });
 });
 

--- a/test/playwright/unit/ai/scripts/maintenance/deploymentMigrationCore.spec.mjs
+++ b/test/playwright/unit/ai/scripts/maintenance/deploymentMigrationCore.spec.mjs
@@ -9,7 +9,7 @@ import {
     parseObservedEnv,
     resolveCensus
 } from '../../../../../../ai/scripts/maintenance/deploymentMigrationCore.mjs';
-import {parseArgs} from '../../../../../../ai/scripts/maintenance/migrateDeployment.mjs';
+import {buildPipelineEnv, parseArgs} from '../../../../../../ai/scripts/maintenance/migrateDeployment.mjs';
 
 const repoRoot   = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../../../../..'),
       PARITY_REL = 'ai/scripts/lint/config-leaf-parity.json',
@@ -432,6 +432,62 @@ test.describe('formatPlan', () => {
 
         expect(report).toContain('NOT VERIFIED');
         expect(report).toContain('overlay drift: not evaluated')
+    });
+});
+
+test.describe('the invocation boundary carries the repair into the transaction', () => {
+    const identity = {project: 'neo-local-agent-os', configFiles: ['/x/base.yml', '/x/overlay.yml']};
+
+    test('a declared desired value CROSSES into the pipeline env, not merely into the plan', () => {
+        // The defect this closes, caught by @neo-gpt-emmy: --set reached desiredEnv and configTransition
+        // in the plan while invokePipeline built its env from revision and identity only, so `apply`
+        // recreated containers with the OLD config and the plan recorded a transition it never performed.
+        const plan                     = buildMigrationPlan(createPlanInput()),
+              {pipelineEnv, forwarded} = buildPipelineEnv(plan, identity, {orchestrator: {NEO_CHROMA_HOST: 'chroma'}});
+
+        expect(pipelineEnv.NEO_CHROMA_HOST).toBe('chroma');
+        expect(forwarded).toEqual(['NEO_CHROMA_HOST'])
+    });
+
+    test('the pinned revision and discovered identity survive alongside a forwarded repair', () => {
+        // A desired key must never be able to overwrite the pinning that makes the transaction exact.
+        const plan          = buildMigrationPlan(createPlanInput()),
+              {pipelineEnv} = buildPipelineEnv(plan, identity, {orchestrator: {NEO_CHROMA_HOST: 'chroma'}});
+
+        expect(pipelineEnv.NEO_REF).toBe(TARGET_SHA);
+        expect(pipelineEnv.NEO_DEPLOY_PROJECT_NAME).toBe('neo-local-agent-os');
+        expect(pipelineEnv.NEO_DEPLOY_COMPOSE_FILE).toContain('/x/overlay.yml')
+    });
+
+    test('no repair declared forwards nothing — apply never carries config the operator did not name', () => {
+        const {pipelineEnv, forwarded} = buildPipelineEnv(buildMigrationPlan(createPlanInput()), identity);
+
+        expect(forwarded).toEqual([]);
+        expect(Object.keys(pipelineEnv).sort()).toEqual(['NEO_DEPLOY_COMPOSE_FILE', 'NEO_DEPLOY_PROJECT_NAME', 'NEO_REF'])
+    });
+
+    test('two services disagreeing on one key BLOCKS at plan time, because the transport is global', () => {
+        // Compose interpolation carries one value per key for the whole project, so a per-service carrier
+        // can express a transition the transaction cannot perform. Picking either value would apply a
+        // config the operator never named for one of the two services.
+        const plan = buildMigrationPlan(createPlanInput({
+            desiredEnv: {orchestrator: {NEO_CHROMA_HOST: 'chroma'}, 'mc-server': {NEO_CHROMA_HOST: 'localhost'}}
+        }));
+
+        expect(plan.clean).toBe(false);
+
+        const blocker = plan.blockers.find(entry => entry.kind === 'desired-value-conflict');
+
+        expect(blocker.key).toBe('NEO_CHROMA_HOST');
+        expect(blocker.reason).toContain('one value per key')
+    });
+
+    test('agreeing services do NOT block — an identical value is expressible by the global transport', () => {
+        const plan = buildMigrationPlan(createPlanInput({
+            desiredEnv: {orchestrator: {NEO_CHROMA_HOST: 'chroma'}, 'mc-server': {NEO_CHROMA_HOST: 'chroma'}}
+        }));
+
+        expect(plan.blockers.filter(entry => entry.kind === 'desired-value-conflict')).toEqual([])
     });
 });
 

--- a/test/playwright/unit/ai/scripts/maintenance/deploymentMigrationCore.spec.mjs
+++ b/test/playwright/unit/ai/scripts/maintenance/deploymentMigrationCore.spec.mjs
@@ -598,6 +598,26 @@ test.describe('parseArgs', () => {
         }
     });
 
+    test('the config cohort is WIDER than the revision cohort, and ingress is in it', () => {
+        // Conflating them was the defect: `/app/.neo-revision` is written by the Neo image, so Caddy can
+        // never produce a receipt — but Compose owns NEO_DEPLOY_HOSTNAME on ingress and the census
+        // classifies it required. Observing only the receipt cohort left that key owned by nobody, which
+        // refused every real plane as unattributable. Measured before and after: 13 blockers -> 12, with
+        // `required-input-unattributable` gone.
+        const options = parseArgs(['plan']);
+
+        expect(options.services).toEqual(['mc-server', 'orchestrator', 'kb-server']);
+        expect(options.configServices).toEqual(['mc-server', 'orchestrator', 'kb-server', 'ingress']);
+        expect(options.configServices.length).toBeGreaterThan(options.services.length)
+    });
+
+    test('--config-services narrows the config cohort independently of --services', () => {
+        const options = parseArgs(['plan', '--services', 'mc-server', '--config-services', 'mc-server,ingress']);
+
+        expect(options.services).toEqual(['mc-server']);
+        expect(options.configServices).toEqual(['mc-server', 'ingress'])
+    });
+
     test('--services splits, trims and drops empties', () => {
         expect(parseArgs(['plan', '--services', ' a , b ,, c ']).services).toEqual(['a', 'b', 'c'])
     });

--- a/test/playwright/unit/ai/scripts/maintenance/deploymentMigrationCore.spec.mjs
+++ b/test/playwright/unit/ai/scripts/maintenance/deploymentMigrationCore.spec.mjs
@@ -1,99 +1,166 @@
-import {test, expect} from '@playwright/test';
+import {test, expect}  from '@playwright/test';
+import fs              from 'fs-extra';
+import path            from 'path';
+import {fileURLToPath} from 'url';
 import {
     buildMigrationPlan,
-    DISCOVER_SCHEMA_VERSION,
+    deriveContractDelta,
     formatPlan,
-    validateDiscoverResult
+    parseObservedEnv,
+    resolveCensus
 } from '../../../../../../ai/scripts/maintenance/deploymentMigrationCore.mjs';
 import {parseArgs} from '../../../../../../ai/scripts/maintenance/migrateDeployment.mjs';
 
-const PROFILE    = 'ai/deploy/docker-compose.yml',
+const repoRoot   = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../../../../..'),
+      PARITY_REL = 'ai/scripts/lint/config-leaf-parity.json',
+      PROFILE    = 'ai/deploy/docker-compose.yml',
       TARGET_SHA = '8a5808007ac4647041d2b425ceba76426a707a50',
-      OLD_SHA    = 'efe4490dd7fef0beb9df9ae21363b8e44e05ad3d';
+      OLD_SHA    = 'efe4490dd7fef0beb9df9ae21363b8e44e05ad3d',
+      AUTHORITY  = 'NEO_AI_ORCHESTRATOR_AUTHORITY_PROFILE';
 
 /**
- * A discover result in the shape this consumer contracts for (the discover driver's JSON). Built as a factory
- * so each test perturbs one field and the resulting blocker is attributable to that perturbation.
+ * A census fixture DELIBERATELY unlike the live one, so these tests assert classification MECHANICS
+ * rather than today's key list. The separate live-document test proves only that the real census still
+ * resolves — the coupling, not the contents.
  */
-function createDiscover(overrides = {}) {
+function createCensus(overrides = {}) {
     return {
-        schemaVersion   : DISCOVER_SCHEMA_VERSION,
-        profile         : PROFILE,
-        clean           : true,
-        missingRequired : [],
-        presentForbidden: [],
-        missingSecrets  : [],
-        unchecked       : [],
+        profile                 : PROFILE,
+        requiredDeploymentInputs: ['NEO_REQ_ONE', 'NEO_REQ_TWO'],
+        optionalOverrides       : ['NEO_OPT'],
+        secrets                 : [],
+        forbiddenEnv            : {NEO_BANNED: 'retired; the orchestrator owns it'},
         ...overrides
     }
 }
 
 /**
- * A plan input whose every field is already valid.
+ * A plan input whose every field is valid, so each test perturbs one thing and the resulting blocker is
+ * attributable to that perturbation.
  */
 function createPlanInput(overrides = {}) {
     return {
-        discover         : createDiscover(),
-        composeIdentity  : {project: 'neo-local-agent-os', configFiles: ['/x/docker-compose.yml', '/x/docker-compose.local.yml']},
+        observedEnv      : parseObservedEnv(['NEO_REQ_ONE=a', 'NEO_REQ_TWO=b', 'PATH=/usr/bin']),
+        census           : createCensus(),
+        composeIdentity  : {project: 'neo-local-agent-os', configFiles: ['/x/base.yml', '/x/overlay.yml']},
         deployedRevisions: {'mc-server': OLD_SHA, orchestrator: OLD_SHA, 'kb-server': OLD_SHA},
         targetRevision   : TARGET_SHA,
-        expectedProfile  : PROFILE,
         ...overrides
     }
 }
 
-test.describe('validateDiscoverResult refuses on shape, never best-efforts', () => {
-    test('accepts a well-formed result', () => {
-        expect(validateDiscoverResult(createDiscover(), PROFILE)).toEqual([])
+test.describe('parseObservedEnv', () => {
+    test('keeps only the guarded NEO_/MCP_ namespace', () => {
+        expect([...parseObservedEnv(['NEO_A=1', 'MCP_B=2', 'PATH=/usr/bin', 'NODE_VERSION=24']).keys()]).toEqual(['NEO_A', 'MCP_B'])
     });
 
-    test('a non-object is rejected outright', () => {
-        for (const input of [null, undefined, 'x', 42, []]) {
-            expect(validateDiscoverResult(input, PROFILE).length, JSON.stringify(input)).toBeGreaterThan(0)
-        }
+    test('splits on the FIRST = so a value containing = survives intact', () => {
+        // Truncating a value makes a correctly-set key look malformed, on exactly the DSN/base64 values
+        // most likely to contain '='.
+        const observed = parseObservedEnv(['NEO_URL=https://x/y?a=1&b=2', 'NEO_B64=aGk=']);
+
+        expect(observed.get('NEO_URL')).toBe('https://x/y?a=1&b=2');
+        expect(observed.get('NEO_B64')).toBe('aGk=')
     });
 
-    test('a schemaVersion this consumer does not implement is refused rather than interpreted', () => {
-        // Silent mis-parsing of a changed producer shape would authorize an apply against fields
-        // that were never populated.
-        const problems = validateDiscoverResult(createDiscover({schemaVersion: DISCOVER_SCHEMA_VERSION + 1}), PROFILE);
+    test('records a set-but-empty key as PRESENT, not absent', () => {
+        // set-but-empty and unset are different defects; collapsing them hides the first.
+        const observed = parseObservedEnv(['NEO_EMPTY=', 'NEO_BARE']);
 
-        expect(problems.some(problem => problem.includes('refusing to interpret an unknown shape'))).toBe(true)
+        expect(observed.has('NEO_EMPTY')).toBe(true);
+        expect(observed.get('NEO_EMPTY')).toBe('');
+        expect(observed.has('NEO_BARE')).toBe(true)
     });
 
-    test('a profile mismatch is refused — the census is per-profile', () => {
-        const problems = validateDiscoverResult(createDiscover({profile: 'ai/deploy/docker-compose.dev.yml'}), PROFILE);
-
-        expect(problems.some(problem => problem.includes('but this run targets'))).toBe(true)
-    });
-
-    test('an ABSENT finding list is refused, because absent and empty are the same shape once parsed', () => {
-        // This is the "never report an empty delta" property: a missing list would otherwise read as
-        // "you are fine" from a producer that never ran the check.
-        for (const listName of ['missingRequired', 'presentForbidden', 'missingSecrets']) {
-            const discover = createDiscover();
-            delete discover[listName];
-
-            const problems = validateDiscoverResult(discover, PROFILE);
-
-            expect(problems.some(problem => problem.includes(listName)), listName).toBe(true)
-        }
-    });
-
-    test('an empty finding list is accepted — that is the normal clean case', () => {
-        expect(validateDiscoverResult(createDiscover({missingRequired: [], presentForbidden: [], missingSecrets: []}), PROFILE)).toEqual([])
-    });
-
-    test('a missing boolean verdict is refused', () => {
-        const discover = createDiscover();
-        delete discover.clean;
-
-        expect(validateDiscoverResult(discover, PROFILE).some(problem => problem.includes("'clean'"))).toBe(true)
+    test('a non-array input yields an empty map rather than throwing', () => {
+        expect(parseObservedEnv(undefined).size).toBe(0);
+        expect(parseObservedEnv(null).size).toBe(0)
     });
 });
 
-test.describe('buildMigrationPlan gates apply on the consumed contract', () => {
-    test('a satisfied deployment plus a clean discover result plans clean', () => {
+test.describe('resolveCensus fails closed', () => {
+    test('throws when the parity block is absent', () => {
+        expect(() => resolveCensus({}, PROFILE)).toThrow(/no \$composeDefaultParity block/)
+    });
+
+    test('throws on an undeclared profile rather than defaulting to the canonical contract', () => {
+        // Defaulting is the dangerous branch: the plan would read as authoritative while comparing the
+        // deployment to a contract that is not its own.
+        const parity = {$composeDefaultParity: {profiles: {[PROFILE]: {}}, census: {}, forbiddenEnv: {}}};
+
+        expect(() => resolveCensus(parity, 'ai/deploy/invented.yml')).toThrow(/refusing to plan against a defaulted contract/)
+    });
+
+    test('throws when the census block describes a different profile than requested', () => {
+        const parity = {
+            $composeDefaultParity: {
+                profiles    : {[PROFILE]: {}, 'ai/deploy/docker-compose.dev.yml': {}},
+                census      : {profile: PROFILE, requiredDeploymentInputs: []},
+                forbiddenEnv: {}
+            }
+        };
+
+        expect(() => resolveCensus(parity, 'ai/deploy/docker-compose.dev.yml')).toThrow(/per-profile and cannot be reused/)
+    });
+
+    test('the LIVE parity document still resolves, and still declares the boot-blocking key', async () => {
+        // Guards the coupling rather than the contents: if the real document's shape moves, this tool
+        // breaks, and that must fail here rather than during a migration.
+        const census = resolveCensus(await fs.readJson(path.join(repoRoot, PARITY_REL)), PROFILE);
+
+        expect(census.requiredDeploymentInputs.length).toBeGreaterThan(0);
+        expect(census.requiredDeploymentInputs).toContain(AUTHORITY);
+        expect(Object.keys(census.forbiddenEnv).length).toBeGreaterThan(0)
+    });
+});
+
+test.describe('deriveContractDelta — the single resolver', () => {
+    test('a satisfied deployment yields an empty delta', () => {
+        const delta = deriveContractDelta(parseObservedEnv(['NEO_REQ_ONE=a', 'NEO_REQ_TWO=b']), createCensus());
+
+        expect(delta.missingRequired).toEqual([]);
+        expect(delta.presentForbidden).toEqual([]);
+        expect(delta.missingSecrets).toEqual([])
+    });
+
+    test('a missing required key is reported', () => {
+        expect(deriveContractDelta(parseObservedEnv(['NEO_REQ_ONE=a']), createCensus())
+            .missingRequired.map(({key}) => key)).toEqual(['NEO_REQ_TWO'])
+    });
+
+    test("a forbidden key's reason is the census's own text, VERBATIM", () => {
+        // The census already declares each forbidden key's replacement guidance. Re-authoring it here
+        // would create a second copy free to drift from the authority it paraphrases.
+        const delta = deriveContractDelta(parseObservedEnv(['NEO_REQ_ONE=a', 'NEO_REQ_TWO=b', 'NEO_BANNED=1']), createCensus());
+
+        expect(delta.presentForbidden).toEqual([{key: 'NEO_BANNED', reason: 'retired; the orchestrator owns it'}])
+    });
+
+    test('the authority key is flagged bootBlocking and ordinary required keys are not', () => {
+        const delta = deriveContractDelta(new Map(), createCensus({requiredDeploymentInputs: [AUTHORITY, 'NEO_REQ_ONE']})),
+              byKey = Object.fromEntries(delta.missingRequired.map(entry => [entry.key, entry.bootBlocking]));
+
+        expect(byKey[AUTHORITY]).toBe(true);
+        expect(byKey.NEO_REQ_ONE).toBe(false)
+    });
+
+    test('a set-but-empty required key counts as PRESENT — the contract is declaration, not validity', () => {
+        // Deliberate scope boundary: the census declares which keys must be DECLARED. Whether a declared
+        // value is sensible is a different question this tool does not claim to answer, and silently
+        // treating empty as missing would over-report while looking thorough.
+        expect(deriveContractDelta(parseObservedEnv(['NEO_REQ_ONE=', 'NEO_REQ_TWO=b']), createCensus()).missingRequired).toEqual([])
+    });
+
+    test('optional overrides that are set are reported separately from blockers', () => {
+        const delta = deriveContractDelta(parseObservedEnv(['NEO_REQ_ONE=a', 'NEO_REQ_TWO=b', 'NEO_OPT=1']), createCensus());
+
+        expect(delta.optionalPresent).toEqual(['NEO_OPT']);
+        expect(delta.missingRequired).toEqual([])
+    });
+});
+
+test.describe('buildMigrationPlan gates apply', () => {
+    test('a satisfied deployment plans clean', () => {
         const plan = buildMigrationPlan(createPlanInput());
 
         expect(plan.clean).toBe(true);
@@ -101,87 +168,55 @@ test.describe('buildMigrationPlan gates apply on the consumed contract', () => {
         expect(plan.revisionDelta).toMatchObject({from: OLD_SHA, to: TARGET_SHA, alreadyTarget: false})
     });
 
-    test('an invalid discover result blocks before any finding is read', () => {
-        const plan = buildMigrationPlan(createPlanInput({discover: {schemaVersion: 99}}));
+    test('an EMPTY observation blocks rather than deriving a spectacular false delta', () => {
+        // The failure this prevents: with nothing read, every required key derives as "missing" and the
+        // plan reports a huge contract delta whose real cause is that the target was never inspected.
+        for (const observedEnv of [new Map(), null, undefined]) {
+            const plan = buildMigrationPlan(createPlanInput({observedEnv}));
 
-        expect(plan.clean).toBe(false);
-        expect(plan.blockers.some(blocker => blocker.kind === 'discover-result-invalid')).toBe(true)
+            expect(plan.clean, String(observedEnv)).toBe(false);
+            expect(plan.blockers.some(blocker => blocker.kind === 'no-observed-env')).toBe(true)
+        }
     });
 
-    test('an ABSENT discover result blocks — there is no fallback derivation', () => {
-        // Deliberate: a second census resolver could disagree with the discover driver's, and the
-        // disagreement would surface as a migration authorized against the wrong answer.
-        const plan = buildMigrationPlan(createPlanInput({discover: null}));
-
-        expect(plan.clean).toBe(false);
-        expect(plan.blockers.some(blocker => blocker.kind === 'discover-result-invalid')).toBe(true)
-    });
-
-    test('a missing required input blocks and forwards the census reason verbatim', () => {
+    test('a missing required input blocks; the boot-blocking one gets its own kind and sorts FIRST', () => {
+        // A refused launch is a different triage priority from a degraded one, and it is the key an
+        // operator reading a long list must see first.
         const plan = buildMigrationPlan(createPlanInput({
-            discover: createDiscover({clean: false, missingRequired: [{key: 'NEO_TRANSPORT', reason: 'declared required'}]})
+            observedEnv: parseObservedEnv(['NEO_OTHER=1']),
+            census     : createCensus({requiredDeploymentInputs: ['NEO_REQ_ONE', AUTHORITY]})
         }));
 
         expect(plan.clean).toBe(false);
-        expect(plan.discoverFindings.missingRequired).toEqual(['NEO_TRANSPORT']);
-        expect(plan.blockers.find(blocker => blocker.key === 'NEO_TRANSPORT').reason).toBe('declared required')
-    });
-
-    test('a boot-blocking missing input gets its own kind and sorts first in the report', () => {
-        // A refused launch is a different triage priority from a degraded one, and the discover
-        // contract distinguishes them; flattening that would bury the one key that stops the plane
-        // from starting at all.
-        const plan = buildMigrationPlan(createPlanInput({
-            discover: createDiscover({
-                clean          : false,
-                missingRequired: [
-                    {key: 'NEO_TRANSPORT', reason: 'declared required'},
-                    {key: 'NEO_AI_ORCHESTRATOR_AUTHORITY_PROFILE', reason: 'no default; launch is refused', bootBlocking: true}
-                ]
-            })
-        }));
-
         expect(plan.blockers.some(blocker => blocker.kind === 'missing-required-input-boot-blocking')).toBe(true);
 
-        const report         = formatPlan(plan),
-              bootBlockingAt = report.indexOf('NEO_AI_ORCHESTRATOR_AUTHORITY_PROFILE'),
-              ordinaryAt     = report.indexOf('NEO_TRANSPORT');
+        const report = formatPlan(plan);
 
-        expect(bootBlockingAt).toBeGreaterThan(-1);
-        expect(bootBlockingAt).toBeLessThan(ordinaryAt)
+        expect(report.indexOf(AUTHORITY)).toBeLessThan(report.indexOf('NEO_REQ_ONE'))
     });
 
     test('a present forbidden key and a missing secret each block', () => {
         const plan = buildMigrationPlan(createPlanInput({
-            discover: createDiscover({
-                clean           : false,
-                presentForbidden: [{key: 'NEO_MESSAGE_WAL_DIR', reason: 'derived from NEO_MEMORY_WAL_DIR'}],
-                missingSecrets  : [{key: 'NEO_KB_ASK_API_KEY', reason: 'required secret'}]
-            })
+            observedEnv: parseObservedEnv(['NEO_REQ_ONE=a', 'NEO_REQ_TWO=b', 'NEO_BANNED=1']),
+            census     : createCensus({secrets: ['NEO_SECRET']})
         }));
 
-        expect(plan.blockers.find(blocker => blocker.kind === 'forbidden-env-present').reason).toBe('derived from NEO_MEMORY_WAL_DIR');
+        expect(plan.blockers.find(blocker => blocker.kind === 'forbidden-env-present').reason).toBe('retired; the orchestrator owns it');
         expect(plan.blockers.some(blocker => blocker.kind === 'missing-secret')).toBe(true)
     });
 
-    test('clean=false with zero findings blocks rather than resolving the contradiction', () => {
-        // The producer knows something the gate does not; trusting the findings over the verdict
-        // would silently discard it.
-        const plan = buildMigrationPlan(createPlanInput({discover: createDiscover({clean: false})}));
-
-        expect(plan.blockers.some(blocker => blocker.kind === 'discover-verdict-unexplained')).toBe(true)
-    });
-
-    test('a bare-string finding is tolerated without losing the key', () => {
+    test('satisfied secrets are NOT VERIFIED, because key presence is weaker than a valid value', () => {
         const plan = buildMigrationPlan(createPlanInput({
-            discover: createDiscover({clean: false, missingRequired: ['NEO_TRANSPORT']})
+            observedEnv: parseObservedEnv(['NEO_REQ_ONE=a', 'NEO_REQ_TWO=b', 'NEO_SECRET=x']),
+            census     : createCensus({secrets: ['NEO_SECRET']})
         }));
 
-        expect(plan.discoverFindings.missingRequired).toEqual(['NEO_TRANSPORT'])
+        expect(plan.clean).toBe(true);
+        expect(plan.unchecked.some(item => item.includes('by env key only'))).toBe(true)
     });
 });
 
-test.describe('buildMigrationPlan adds the plane-side facts discovery cannot supply', () => {
+test.describe('buildMigrationPlan adds the plane-side facts the census cannot supply', () => {
     test('an undiscoverable Compose identity blocks rather than falling back to a default', () => {
         // The pipeline default is project `neo-agent-os`; against a two-file plane that addresses a
         // DIFFERENT project with the overlay dropped.
@@ -194,9 +229,8 @@ test.describe('buildMigrationPlan adds the plane-side facts discovery cannot sup
     });
 
     test('an unresolved target revision blocks', () => {
-        const plan = buildMigrationPlan(createPlanInput({targetRevision: null}));
-
-        expect(plan.blockers.some(blocker => blocker.kind === 'target-revision-unresolved')).toBe(true)
+        expect(buildMigrationPlan(createPlanInput({targetRevision: null}))
+            .blockers.some(blocker => blocker.kind === 'target-revision-unresolved')).toBe(true)
     });
 
     test('a cohort reporting two revisions blocks as a partially-applied prior run', () => {
@@ -210,28 +244,24 @@ test.describe('buildMigrationPlan adds the plane-side facts discovery cannot sup
     });
 
     test('no readable revision anywhere blocks — there is no baseline to assert against', () => {
-        const plan = buildMigrationPlan(createPlanInput({
+        expect(buildMigrationPlan(createPlanInput({
             deployedRevisions: {'mc-server': null, orchestrator: null, 'kb-server': null}
-        }));
-
-        expect(plan.blockers.some(blocker => blocker.kind === 'no-readable-revision')).toBe(true)
+        })).blockers.some(blocker => blocker.kind === 'no-readable-revision')).toBe(true)
     });
 
     test('a plane already AT the target still refuses when the contract is unsatisfied', () => {
-        // The pairing that matters, and the reason a revision-only trigger is insufficient:
-        // revision-current and contract-invalid at once.
+        // The pairing that matters, and why a revision-only trigger is insufficient: revision-current
+        // and contract-invalid at the same time.
         const plan = buildMigrationPlan(createPlanInput({
             deployedRevisions: {'mc-server': TARGET_SHA, orchestrator: TARGET_SHA, 'kb-server': TARGET_SHA},
-            discover         : createDiscover({clean: false, missingRequired: [{key: 'NEO_TRANSPORT', reason: 'declared required'}]})
+            observedEnv      : parseObservedEnv(['NEO_REQ_ONE=a'])
         }));
 
         expect(plan.revisionDelta.alreadyTarget).toBe(true);
         expect(plan.clean).toBe(false)
     });
-});
 
-test.describe('unchecked items are never silently passed', () => {
-    test('one unreadable service becomes UNCHECKED, not a pass and not a blocker', () => {
+    test('one unreadable service is UNCHECKED — neither a pass nor a blocker', () => {
         const plan = buildMigrationPlan(createPlanInput({
             deployedRevisions: {'mc-server': OLD_SHA, orchestrator: OLD_SHA, 'kb-server': null}
         }));
@@ -240,24 +270,15 @@ test.describe('unchecked items are never silently passed', () => {
         expect(plan.unchecked.some(item => item.includes('kb-server'))).toBe(true)
     });
 
-    test("the producer's own unchecked items are forwarded and attributed", () => {
-        const plan = buildMigrationPlan(createPlanInput({
-            discover: createDiscover({unchecked: ['secrets not readable on this host']})
-        }));
-
-        expect(plan.unchecked).toContain('discover: secrets not readable on this host')
-    });
-
     test('entrypoint-supplied unchecked notes survive into the plan', () => {
-        const plan = buildMigrationPlan(createPlanInput({uncheckedNotes: ['overlay drift: not evaluated']}));
-
-        expect(plan.unchecked).toContain('overlay drift: not evaluated')
+        expect(buildMigrationPlan(createPlanInput({uncheckedNotes: ['overlay drift: not evaluated']}))
+            .unchecked).toContain('overlay drift: not evaluated')
     });
 });
 
 test.describe('formatPlan', () => {
     test('a refused plan states REFUSED and includes every blocker key', () => {
-        const plan   = buildMigrationPlan(createPlanInput({discover: null, composeIdentity: null})),
+        const plan   = buildMigrationPlan(createPlanInput({observedEnv: new Map(), composeIdentity: null})),
               report = formatPlan(plan);
 
         expect(report).toContain('verdict: REFUSED');
@@ -282,15 +303,15 @@ test.describe('formatPlan', () => {
 
 test.describe('parseArgs', () => {
     test('importing the driver does not execute it', () => {
-        // The entrypoint guard's real assertion: this spec reaching this line at all means importing
-        // the driver did not run a migration as an import side effect.
+        // The entrypoint guard's real assertion: reaching this line means importing the driver did not
+        // run a migration as an import side effect.
         expect(typeof parseArgs).toBe('function')
     });
 
-    test('defaults to the dev selector and the canonical cohort', () => {
-        const options = parseArgs(['plan', '--discover-json', 'x.json']);
+    test('defaults to the dev selector, the canonical profile and the canonical cohort', () => {
+        const options = parseArgs(['plan']);
 
-        expect(options).toMatchObject({mode: 'plan', target: 'dev', profile: PROFILE, discoverJson: 'x.json'});
+        expect(options).toMatchObject({mode: 'plan', target: 'dev', profile: PROFILE});
         expect(options.services).toEqual(['mc-server', 'orchestrator', 'kb-server'])
     });
 

--- a/test/playwright/unit/ai/scripts/maintenance/deploymentMigrationCore.spec.mjs
+++ b/test/playwright/unit/ai/scripts/maintenance/deploymentMigrationCore.spec.mjs
@@ -34,17 +34,36 @@ function createCensus(overrides = {}) {
     }
 }
 
+const COHORT = ['mc-server', 'orchestrator', 'kb-server'];
+
+/**
+ * Every service observing the same satisfied env. Per service, never unioned: a union reports a key set
+ * on one container as satisfied for all of them, which is the misconfiguration the gate exists to catch.
+ */
+function createObserved(entries = ['NEO_REQ_ONE=a', 'NEO_REQ_TWO=b', 'PATH=/usr/bin'], services = COHORT) {
+    return Object.fromEntries(services.map(service => [service, parseObservedEnv(entries)]))
+}
+
+/**
+ * Declared scopes covering the whole fixture census, so a test that does not care about attribution does
+ * not accidentally trip the unattributable refusal.
+ */
+function createScopes(keys = ['NEO_REQ_ONE', 'NEO_REQ_TWO', 'NEO_OPT', 'NEO_BANNED', 'NEO_SECRET', AUTHORITY], services = COHORT) {
+    return Object.fromEntries(services.map(service => [service, new Set(keys)]))
+}
+
 /**
  * A plan input whose every field is valid, so each test perturbs one thing and the resulting blocker is
  * attributable to that perturbation.
  */
 function createPlanInput(overrides = {}) {
     return {
-        observedEnv      : parseObservedEnv(['NEO_REQ_ONE=a', 'NEO_REQ_TWO=b', 'PATH=/usr/bin']),
-        census           : createCensus(),
-        composeIdentity  : {project: 'neo-local-agent-os', configFiles: ['/x/base.yml', '/x/overlay.yml']},
-        deployedRevisions: {'mc-server': OLD_SHA, orchestrator: OLD_SHA, 'kb-server': OLD_SHA},
-        targetRevision   : TARGET_SHA,
+        observedEnvByService: createObserved(),
+        serviceScopes       : createScopes(),
+        census              : createCensus(),
+        composeIdentity     : {project: 'neo-local-agent-os', configFiles: ['/x/base.yml', '/x/overlay.yml']},
+        deployedRevisions   : {'mc-server': OLD_SHA, orchestrator: OLD_SHA, 'kb-server': OLD_SHA},
+        targetRevision      : TARGET_SHA,
         ...overrides
     }
 }
@@ -144,11 +163,29 @@ test.describe('deriveContractDelta — the single resolver', () => {
         expect(byKey.NEO_REQ_ONE).toBe(false)
     });
 
-    test('a set-but-empty required key counts as PRESENT — the contract is declaration, not validity', () => {
-        // Deliberate scope boundary: the census declares which keys must be DECLARED. Whether a declared
-        // value is sensible is a different question this tool does not claim to answer, and silently
-        // treating empty as missing would over-report while looking thorough.
-        expect(deriveContractDelta(parseObservedEnv(['NEO_REQ_ONE=', 'NEO_REQ_TWO=b']), createCensus()).missingRequired).toEqual([])
+    test('a set-but-empty required key is its OWN finding — present, unusable, and a different repair', () => {
+        // Reversed from the original position ("the contract is declaration, not validity") on review:
+        // a required input set to an empty value satisfies every presence check and still configures
+        // nothing, so collapsing it into either bucket loses the operator's actual fix. It stays out of
+        // `missingRequired` — it is not absent — and lands in `setButEmpty`.
+        const delta = deriveContractDelta(parseObservedEnv(['NEO_REQ_ONE=', 'NEO_REQ_TWO=b']), createCensus());
+
+        expect(delta.missingRequired).toEqual([]);
+        expect(delta.setButEmpty.map(entry => entry.key)).toEqual(['NEO_REQ_ONE'])
+    });
+
+    test('whitespace is not a value — a key set to spaces is unusable, not satisfied', () => {
+        expect(deriveContractDelta(parseObservedEnv(['NEO_REQ_ONE=   ', 'NEO_REQ_TWO=b']), createCensus())
+            .setButEmpty.map(entry => entry.key)).toEqual(['NEO_REQ_ONE'])
+    });
+
+    test('a declared scope narrows which required keys this service is held to', () => {
+        // The census classifies per PROFILE; the profile's required list is not uniform across its
+        // services. Judging every key against every service invents obligations it never declared.
+        const delta = deriveContractDelta(new Map([['NEO_REQ_ONE', 'a']]), createCensus(), new Set(['NEO_REQ_ONE']));
+
+        expect(delta.missingRequired).toEqual([]);
+        expect(delta.setButEmpty).toEqual([])
     });
 
     test('optional overrides that are set are reported separately from blockers', () => {
@@ -171,20 +208,110 @@ test.describe('buildMigrationPlan gates apply', () => {
     test('an EMPTY observation blocks rather than deriving a spectacular false delta', () => {
         // The failure this prevents: with nothing read, every required key derives as "missing" and the
         // plan reports a huge contract delta whose real cause is that the target was never inspected.
-        for (const observedEnv of [new Map(), null, undefined]) {
-            const plan = buildMigrationPlan(createPlanInput({observedEnv}));
+        for (const observed of [{}, null, undefined]) {
+            const plan = buildMigrationPlan(createPlanInput({observedEnvByService: observed}));
 
-            expect(plan.clean, String(observedEnv)).toBe(false);
-            expect(plan.blockers.some(blocker => blocker.kind === 'no-observed-env')).toBe(true)
+            expect(plan.clean, String(observed)).toBe(false);
+            expect(plan.blockers.some(blocker => blocker.kind === 'no-observed-service')).toBe(true)
         }
+    });
+
+    test('a service observed as empty blocks per service — silence from an unreachable container is not absence', () => {
+        // The failure this encodes: `docker exec` against a stopped container emits nothing and exits
+        // non-zero, so an empty observation means "not measured", never "no config set".
+        const plan = buildMigrationPlan(createPlanInput({
+            observedEnvByService: {...createObserved(), orchestrator: new Map()}
+        }));
+
+        expect(plan.clean).toBe(false);
+
+        const blocker = plan.blockers.find(entry => entry.kind === 'no-observed-env');
+
+        expect(blocker.key).toBe('orchestrator');
+        expect(blocker.reason).toContain('not be running')
+    });
+
+    test('observations are NOT unioned: a key set on one service does not satisfy another', () => {
+        // Measured on the canonical profile, four of thirteen required inputs are declared by a single
+        // service. A union reports the key as satisfied cohort-wide and the real gap disappears.
+        const plan = buildMigrationPlan(createPlanInput({
+            observedEnvByService: {
+                ...createObserved(),
+                orchestrator: parseObservedEnv(['NEO_REQ_ONE=a'])
+            }
+        }));
+
+        expect(plan.clean).toBe(false);
+
+        const missing = plan.blockers.filter(entry => entry.kind === 'missing-required-input');
+
+        expect(missing.map(entry => entry.key)).toEqual(['orchestrator.NEO_REQ_TWO'])
+    });
+
+    test('a required key no observed service declares blocks as unattributable, never assigned to a default', () => {
+        // `NEO_DEPLOY_HOSTNAME` is the live instance: declared required by the profile census and declared
+        // by none of the three service templates. Picking an owner for it would be a guess reading as a
+        // verdict.
+        const plan = buildMigrationPlan(createPlanInput({
+            census       : createCensus({requiredDeploymentInputs: ['NEO_REQ_ONE', 'NEO_REQ_TWO', 'NEO_ORPHAN']}),
+            serviceScopes: createScopes(['NEO_REQ_ONE', 'NEO_REQ_TWO'])
+        }));
+
+        expect(plan.clean).toBe(false);
+
+        const blocker = plan.blockers.find(entry => entry.kind === 'required-input-unattributable');
+
+        expect(blocker.key).toBe('NEO_ORPHAN');
+        expect(plan.blockers.some(entry => entry.key.endsWith('.NEO_ORPHAN'))).toBe(false)
+    });
+
+    test('a service whose declared scope is unresolved blocks rather than being judged or skipped', () => {
+        const {orchestrator, ...partialScopes} = createScopes(),
+              plan                             = buildMigrationPlan(createPlanInput({serviceScopes: partialScopes}));
+
+        expect(plan.clean).toBe(false);
+        expect(plan.blockers.find(entry => entry.kind === 'service-scope-unresolved').key).toBe('orchestrator')
+    });
+
+    test('a supplied desired value turns a missing required input into a declared transition, not a blocker', () => {
+        // The point of the whole carrier: without it a plane missing a required input is refused from its
+        // own observation and the operator must repair it by another path — the manual intervention this
+        // tool exists to remove.
+        const plan = buildMigrationPlan(createPlanInput({
+            observedEnvByService: {...createObserved(), orchestrator: parseObservedEnv(['NEO_REQ_ONE=a'])},
+            desiredEnv          : {orchestrator: {NEO_REQ_TWO: 'supplied'}}
+        }));
+
+        expect(plan.clean).toBe(true);
+        expect(plan.blockers).toEqual([]);
+        expect(plan.configTransition.orchestrator).toEqual([{key: 'NEO_REQ_TWO', from: '<unset>', declared: true}])
+    });
+
+    test('a desired value that is itself empty blocks — the repair must be usable, not merely present', () => {
+        const plan = buildMigrationPlan(createPlanInput({
+            observedEnvByService: {...createObserved(), orchestrator: parseObservedEnv(['NEO_REQ_ONE=a'])},
+            desiredEnv          : {orchestrator: {NEO_REQ_TWO: '   '}}
+        }));
+
+        expect(plan.clean).toBe(false);
+        expect(plan.blockers.find(entry => entry.kind === 'desired-value-unusable').key).toBe('orchestrator.NEO_REQ_TWO')
+    });
+
+    test('a set-but-empty required input reports its own blocker kind, distinct from missing', () => {
+        const plan = buildMigrationPlan(createPlanInput({
+            observedEnvByService: {...createObserved(), orchestrator: parseObservedEnv(['NEO_REQ_ONE=a', 'NEO_REQ_TWO='])}
+        }));
+
+        expect(plan.blockers.find(entry => entry.kind === 'required-input-set-but-empty').key)
+            .toBe('orchestrator.NEO_REQ_TWO')
     });
 
     test('a missing required input blocks; the boot-blocking one gets its own kind and sorts FIRST', () => {
         // A refused launch is a different triage priority from a degraded one, and it is the key an
         // operator reading a long list must see first.
         const plan = buildMigrationPlan(createPlanInput({
-            observedEnv: parseObservedEnv(['NEO_OTHER=1']),
-            census     : createCensus({requiredDeploymentInputs: ['NEO_REQ_ONE', AUTHORITY]})
+            observedEnvByService: createObserved(['NEO_OTHER=1']),
+            census              : createCensus({requiredDeploymentInputs: ['NEO_REQ_ONE', AUTHORITY]})
         }));
 
         expect(plan.clean).toBe(false);
@@ -197,8 +324,8 @@ test.describe('buildMigrationPlan gates apply', () => {
 
     test('a present forbidden key and a missing secret each block', () => {
         const plan = buildMigrationPlan(createPlanInput({
-            observedEnv: parseObservedEnv(['NEO_REQ_ONE=a', 'NEO_REQ_TWO=b', 'NEO_BANNED=1']),
-            census     : createCensus({secrets: ['NEO_SECRET']})
+            observedEnvByService: createObserved(['NEO_REQ_ONE=a', 'NEO_REQ_TWO=b', 'NEO_BANNED=1']),
+            census              : createCensus({secrets: ['NEO_SECRET']})
         }));
 
         expect(plan.blockers.find(blocker => blocker.kind === 'forbidden-env-present').reason).toBe('retired; the orchestrator owns it');
@@ -207,8 +334,8 @@ test.describe('buildMigrationPlan gates apply', () => {
 
     test('satisfied secrets are NOT VERIFIED, because key presence is weaker than a valid value', () => {
         const plan = buildMigrationPlan(createPlanInput({
-            observedEnv: parseObservedEnv(['NEO_REQ_ONE=a', 'NEO_REQ_TWO=b', 'NEO_SECRET=x']),
-            census     : createCensus({secrets: ['NEO_SECRET']})
+            observedEnvByService: createObserved(['NEO_REQ_ONE=a', 'NEO_REQ_TWO=b', 'NEO_SECRET=x']),
+            census              : createCensus({secrets: ['NEO_SECRET']})
         }));
 
         expect(plan.clean).toBe(true);
@@ -253,21 +380,28 @@ test.describe('buildMigrationPlan adds the plane-side facts the census cannot su
         // The pairing that matters, and why a revision-only trigger is insufficient: revision-current
         // and contract-invalid at the same time.
         const plan = buildMigrationPlan(createPlanInput({
-            deployedRevisions: {'mc-server': TARGET_SHA, orchestrator: TARGET_SHA, 'kb-server': TARGET_SHA},
-            observedEnv      : parseObservedEnv(['NEO_REQ_ONE=a'])
+            deployedRevisions   : {'mc-server': TARGET_SHA, orchestrator: TARGET_SHA, 'kb-server': TARGET_SHA},
+            observedEnvByService: createObserved(['NEO_REQ_ONE=a'])
         }));
 
         expect(plan.revisionDelta.alreadyTarget).toBe(true);
         expect(plan.clean).toBe(false)
     });
 
-    test('one unreadable service is UNCHECKED — neither a pass nor a blocker', () => {
+    test('one unreadable revision BLOCKS — an unestablished before-state cannot coexist with CLEAN', () => {
+        // Reversed from the original position on review. Reporting it and passing over it meant a plan
+        // could authorise apply while one service had no baseline, so a successful-looking apply was
+        // indistinguishable from one that stranded that service.
         const plan = buildMigrationPlan(createPlanInput({
             deployedRevisions: {'mc-server': OLD_SHA, orchestrator: OLD_SHA, 'kb-server': null}
         }));
 
-        expect(plan.clean).toBe(true);
-        expect(plan.unchecked.some(item => item.includes('kb-server'))).toBe(true)
+        expect(plan.clean).toBe(false);
+
+        const blocker = plan.blockers.find(entry => entry.kind === 'revision-unreadable');
+
+        expect(blocker.key).toBe('kb-server:/app/.neo-revision');
+        expect(blocker.reason).toContain('stranded')
     });
 
     test('entrypoint-supplied unchecked notes survive into the plan', () => {
@@ -327,6 +461,34 @@ test.describe('parseArgs', () => {
 
     test('refuses a flag with no value', () => {
         expect(() => parseArgs(['plan', '--target'])).toThrow(/requires a value/)
+    });
+
+    test('--set is repeatable and nests by service, so two services can carry the same key', () => {
+        const options = parseArgs(['plan',
+            '--set', 'orchestrator.NEO_CHROMA_HOST=chroma',
+            '--set', 'mc-server.NEO_CHROMA_HOST=chroma',
+            '--set', 'orchestrator.NEO_TRANSPORT=streamable-http'
+        ]);
+
+        expect(options.desiredEnv).toEqual({
+            orchestrator: {NEO_CHROMA_HOST: 'chroma', NEO_TRANSPORT: 'streamable-http'},
+            'mc-server' : {NEO_CHROMA_HOST: 'chroma'}
+        })
+    });
+
+    test('--set splits on the FIRST = so a value containing = survives, and defaults to no desired env', () => {
+        // Same reason `parseObservedEnv` splits on the first `=`: DSNs, base64 and query strings carry it,
+        // and truncating the value would silently write a wrong config rather than failing.
+        expect(parseArgs(['plan', '--set', 'kb-server.NEO_KB_ASK_BASE_URL=https://x/y?a=1&b=2']).desiredEnv)
+            .toEqual({'kb-server': {NEO_KB_ASK_BASE_URL: 'https://x/y?a=1&b=2'}});
+
+        expect(parseArgs(['plan']).desiredEnv).toEqual({})
+    });
+
+    test('--set refuses a malformed assignment rather than half-parsing it', () => {
+        for (const bad of ['NEO_NO_SERVICE=1', 'orchestrator.NEO_NO_VALUE']) {
+            expect(() => parseArgs(['plan', '--set', bad]), bad).toThrow(/--set expects/)
+        }
     });
 
     test('--services splits, trims and drops empties', () => {


### PR DESCRIPTION
Resolves #16454

**One supervised Neo command repairs a lagging or broken plane without a hand-issued Docker mutation.** That is the operator's P0 and the whole scope. Cadence, kill-switch and unattended activation are **not** here — they belong to #16448 / `D#15758`, and this must not become a resident updater.

Related: #16448 / `D#15758` (the activation authority this stays outside), `D#16304` (measured the drift), #16055 (the corpus loss the preflight prevents), #16229 (introduced the no-default authority role), #16447 (closed `NOT_PLANNED` — see below), #16458 (the compose-file list, merged separately)

Evidence: L2 — unit-tested pure core, plus the invocation boundary asserted as a pure value. No live plane was mutated: running this against shared infrastructure is operator authority, and the L4 fixture proof is the one Required Action still open.

## Body truth-folded at `9de58fd3d9`

This body previously described a different PR: it claimed the branch "carries no census derivation", named #16447 as the input producer whose JSON it consumed, and led with the compose-file list. All three are stale. #16447 was closed `NOT_PLANNED`, so derivation was folded in here; the compose-file list shipped separately as #16458. Emmy's RA1 asked for this fold and it was owed before another reviewer spent budget on it.

## What it does

`migrateDeployment.mjs plan|apply` — an operator-invoked bootstrap that discovers the target's identity, derives its config delta, refuses by default, and on `apply` invokes the shipped `deploy-pipeline.sh` at a pinned revision.

**The gate refuses on anything unestablished.** A rebuild at a newer revision does not repair a deployment whose config no longer satisfies the contract — it produces a refused launch. `ADR 0019 §10.8` is the worked case: the orchestrator authority role has no leaf default, so a plane that never declares `NEO_AI_ORCHESTRATOR_AUTHORITY_PROFILE` is refused rather than degraded.

**Observations are per service, never unioned.** The earlier union argued in its own comment that it was "the conservative direction — it can only make the delta smaller." True, and backwards for a gate: smaller delta is fail-open, and the dangerous direction is a key reported *present* while absent on one service. Measured against the canonical profile, the 13 required inputs are **not uniform** — four are mc-server-only, `NEO_MEMORY_DB_PATH` is kb+mc but not orchestrator, and `NEO_DEPLOY_HOSTNAME` has no declaring service at all. A union misjudges five of thirteen.

The per-service authority is not invented: `$composeDefaultParity.profiles[…].services` already maps each service to its governing config template, and `lint-config-template-ssot.mjs` exports `buildConfigEnvDefaultsForTemplate` — the same resolver the census was computed from. No second mapping free to drift.

**It carries the repair, not just the diagnosis.** `--set <service>.<KEY>=<value>` supplies a desired value, turning a missing or empty required input into a declared transition the apply performs. Without it, a plane missing a required input is refused from its own observation and the operator must fix it by another path — which is the manual intervention this exists to remove.

## Refusals, and why each is not a nit

| refusal | what it prevents |
|---|---|
| `no-observed-env` (per service) | silence from a stopped container read as "no config set" — the error I made against this plane reading `docker exec` output from an `Exited(1)` orchestrator |
| `service-scope-unresolved` | judging a service against the whole profile census, inventing obligations it never declared |
| `required-input-unattributable` | assigning a key no service declares (`NEO_DEPLOY_HOSTNAME`) to a defaulted owner — a guess that reads as a verdict |
| `required-input-set-but-empty` | a value that satisfies every presence check and configures nothing |
| `revision-unreadable` | authorising apply with no baseline, so a stranded service is indistinguishable from a moved one |
| `desired-value-conflict` | a transition the transport cannot perform — see below |
| `compose-identity-undiscoverable` | falling back to the pipeline default and addressing a *different* project with the overlay dropped |

**The transport constraint, found by implementing rather than designing.** Desired values reach the plane through Compose interpolation, which is **global** — one value per key for the whole project — while `--set` is per service. So the carrier can express a transition the transaction cannot perform. Two services declaring different values for one key block at plan time with the reason naming the transport; identical values do not, since that is expressible. Whether per-service overrides deserve a generated overlay fragment instead is a larger shape and is deliberately not decided here.

## What the review changed

**Emmy's terminal `Drop+Supersede` was retracted after the operator's correction, and her three in-place RAs replaced it.** RA2 is implemented; her contract reading was confirmed empirically rather than accepted on authority, and the measurement made the defect worse than either framing.

**Her final blocker was real and my completion claim was false.** `--set` reached `desiredEnv` and `configTransition` in the plan while `invokePipeline` built its env from revision and identity only — so `apply` recreated containers with the **old** config and the plan printed a transition it never performed. My prior commit message asserted the opposite. Fixed at `9de58fd3d9`.

The witness is `buildPipelineEnv`, extracted pure and exported, because the property is that a declared value **crosses** the boundary: a test asserting only that `invokePipeline` was called would have passed throughout the entire defect.

**Two prior specs had encoded the defects and were rewritten with the reversal in the test name, not deleted** — `'a set-but-empty required key counts as PRESENT'` stayed *green* after the reversal because empty keys merely moved buckets, and `'one unreadable service is UNCHECKED — neither a pass nor a blocker'` was a test pinning the fail-open behaviour under review.

## Test Evidence

```
npx playwright test -c test/playwright/playwright.config.unit.mjs --workers=1 \
  test/playwright/unit/ai/scripts/maintenance/deploymentMigrationCore.spec.mjs
  54 passed (4.3s)
```

**52 specs in the file**; 54 cases run, the extra two being the unit-brain project's Chroma setup/teardown dependencies. Count derived from the file (`grep -c '^    test('`), not read off the runner — conflating tests-in-file with cases-run is an error I have made on this branch before.

The core stays pure: no Neo import, no Docker call, no filesystem read, so **every** refusal branch is reachable from a plain object. Boundary assertions: the declared value crosses; `NEO_REF` and the discovered identity survive alongside it so a desired key cannot overwrite the pinning that makes the transaction exact; nothing forwards when nothing is declared.

Forwarded values are logged by **key only** — a required input's value may be a host, a path or credential-adjacent, and echoing it into a build log would persist it.

## Post-Merge Validation

- [ ] **RA3, still open:** run this head against a deliberately pinned disposable fixture and record preflight-before-mutation, no hand-issued Docker command, the exact target revision on all three services, reachable KB/MC surfaces, and durable volumes still attached. `test/playwright/integration-parity/` already provisions a disposable Compose plane via `fixtures/parityComposeWebServer.mjs`, so this is an extension rather than a build.
- [ ] One authorized run against our own plane — **@tobiu's authority**; nothing here performs it.

## Deltas

- `ai/scripts/maintenance/deploymentMigrationCore.mjs` — per-service delta, `setButEmpty`, unattributable and conflict refusals, the desired-config carrier, `configTransition`.
- `ai/scripts/maintenance/migrateDeployment.mjs` — per-service observation, `resolveServiceScopes` reusing the lint's exported resolver, `--set`, and `buildPipelineEnv` as the asserted boundary.
- `test/playwright/unit/ai/scripts/maintenance/deploymentMigrationCore.spec.mjs` — 52 specs.
- **Substrate accretion:** no new module, no new config leaf, no new MCP surface. `ai/configBase.mjs` is byte-identical to `dev`. Sunset condition: if `D#15758`'s activation kernel subsumes the supervised bootstrap, this retires with it.
- Deliberately **not** here: cadence, kill-switch, unattended scheduling, selection policy, candidate retention, admissibility (#16450/#16451/#16453), client-schema freshness (#16320), Electron shell auto-update.

Authored by Vega (Claude Opus 5, Claude Code). Session 11695cce-9854-4be2-80c3-8ea4322298bf.
