### PR TITLE
feat(deploy): the reference deploy transaction accepts an ordered Compose-file set (#16458)

### DIFF
--- a/ai/examples/cloud-deployment/deploy-pipeline.sh
+++ b/ai/examples/cloud-deployment/deploy-pipeline.sh
@@ -39,8 +39,9 @@ fi
 
 # A real plane is rarely ONE compose file. The canonical local Agent OS runs `docker-compose.yml`
 # plus `docker-compose.local-agent-os.yml`, and a single `-f` silently drops the overlay — so the
-# services come up with the base contract while the operator believes the overlay applied. That is
-# not a hypothetical: it is why this pipeline could not be pointed at our own plane (#16454).
+# services come up with the base contract while the operator believes the overlay applied. Measured
+# on such a plane, the two renderings differ by 80 lines: without the overlay the auth mode is unset,
+# the model provider is empty, and the healthcheck token file is absent.
 #
 # `NEO_DEPLOY_COMPOSE_FILE` therefore accepts a `:`-delimited LIST, matching Docker's own COMPOSE_FILE
 # convention, and expands to repeated `-f` in declaration order (later files override earlier ones,

--- a/ai/examples/cloud-deployment/deploy-pipeline.sh
+++ b/ai/examples/cloud-deployment/deploy-pipeline.sh
@@ -27,6 +27,32 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # test. Any operator who did not set NEO_DEPLOY_COMPOSE_FILE was relying on a broken default.
 COMPOSE_FILE="${NEO_DEPLOY_COMPOSE_FILE:-$SCRIPT_DIR/../../deploy/docker-compose.yml}"
 
+# A real plane is rarely ONE compose file. The canonical local Agent OS runs `docker-compose.yml`
+# plus `docker-compose.local-agent-os.yml`, and a single `-f` silently drops the overlay — so the
+# services come up with the base contract while the operator believes the overlay applied. That is
+# not a hypothetical: it is why this pipeline could not be pointed at our own plane (#16454).
+#
+# `NEO_DEPLOY_COMPOSE_FILE` therefore accepts a `:`-delimited LIST, matching Docker's own COMPOSE_FILE
+# convention, and expands to repeated `-f` in declaration order (later files override earlier ones,
+# which is Compose's merge order — reordering them changes the result). A single path is unchanged,
+# so every existing caller and every downstream adaptation keeps its exact behaviour.
+# `compose_file_count` is tracked separately because `${#compose_file_args[@]}` counts ARRAY ELEMENTS
+# — each file contributes both a `-f` and a path — so using it as a file count reports double. Caught
+# by the rehearsal witness printing "(4 file(s))" for two files.
+compose_file_args=()
+compose_file_count=0
+while IFS= read -r compose_file_entry; do
+    if [ -n "$compose_file_entry" ]; then
+        compose_file_args+=(-f "$compose_file_entry")
+        compose_file_count=$((compose_file_count + 1))
+    fi
+done <<< "$(printf '%s' "$COMPOSE_FILE" | tr ':' '\n')"
+
+if [ "$compose_file_count" -eq 0 ]; then
+    echo "[deploy] FATAL: NEO_DEPLOY_COMPOSE_FILE resolved to no usable path. Docker was NOT invoked." >&2
+    exit 1
+fi
+
 # A stable project name pins named-volume identity across redeploys. Export the
 # same value consumed by docker-compose.yml for its top-level project name and
 # the orchestrator runtime-access target identity. Ordinary redeploys retain the
@@ -51,7 +77,10 @@ else
     for p in ${NEO_DEPLOY_PROFILES:-cloud ingress}; do profile_args+=(--profile "$p"); done
 fi
 
-compose() { docker compose -f "$COMPOSE_FILE" -p "$PROJECT_NAME" "${profile_args[@]}" "$@"; }
+# `compose_file_args` is guaranteed non-empty by the abort above, so expanding it is safe on bash 3.2
+# where an EMPTY array expansion is an unbound-variable error under `set -u` (see the note at the
+# preflight below — macOS ships 3.2 and hosted CI does not, so that class fails only on maintainer machines).
+compose() { docker compose "${compose_file_args[@]}" -p "$PROJECT_NAME" "${profile_args[@]}" "$@"; }
 
 # Resolve the deployed revision BEFORE Docker runs (#15792). Every run pins:
 # there is deliberately no unpinned path, because this is the reference pipeline
@@ -149,7 +178,7 @@ export NEO_REVISION="$resolved_revision"
 echo "[deploy] selector:     $NEO_SELECTOR"
 echo "[deploy] revision:     $resolved_revision   <- built into the images"
 echo "[deploy] host-checkout: $(git -C "$SCRIPT_DIR" describe --tags --always 2>/dev/null || echo unknown)   (this host only; NOT what is deployed)"
-echo "[deploy] compose:  $COMPOSE_FILE"
+echo "[deploy] compose:  ${compose_file_args[*]}   ($compose_file_count file(s), merge order left to right)"
 echo "[deploy] project:  $PROJECT_NAME"
 echo "[deploy] profiles: ${profile_args[*]}"
 

--- a/ai/examples/cloud-deployment/deploy-pipeline.sh
+++ b/ai/examples/cloud-deployment/deploy-pipeline.sh
@@ -25,7 +25,17 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # here produced `ai/ai/deploy/...`, a path that has never existed. It went unnoticed because the
 # spec fakes `docker`, and a fake docker ignores `-f`, so a wrong compose path could not fail a
 # test. Any operator who did not set NEO_DEPLOY_COMPOSE_FILE was relying on a broken default.
-COMPOSE_FILE="${NEO_DEPLOY_COMPOSE_FILE:-$SCRIPT_DIR/../../deploy/docker-compose.yml}"
+# UNSET and EXPLICITLY-EMPTY are different inputs and must not collapse. `${VAR:-default}` treats an
+# empty string as absent, so `NEO_DEPLOY_COMPOSE_FILE=""` would silently fall back to the base file —
+# deploying the base contract to a plane that needs an overlay, which is the exact failure the
+# zero-entry abort below exists to prevent. `${VAR+set}` tests whether the operator SUPPLIED the
+# variable, independent of its value, so an unset caller keeps the compatible default while a supplied
+# value is always honoured — and, when it resolves to nothing, refused rather than replaced.
+if [ -n "${NEO_DEPLOY_COMPOSE_FILE+set}" ]; then
+    COMPOSE_FILE="$NEO_DEPLOY_COMPOSE_FILE"
+else
+    COMPOSE_FILE="$SCRIPT_DIR/../../deploy/docker-compose.yml"
+fi
 
 # A real plane is rarely ONE compose file. The canonical local Agent OS runs `docker-compose.yml`
 # plus `docker-compose.local-agent-os.yml`, and a single `-f` silently drops the overlay — so the

--- a/learn/agentos/cloud-deployment/PipelineWiring.md
+++ b/learn/agentos/cloud-deployment/PipelineWiring.md
@@ -148,6 +148,28 @@ A redeploy is not "done" when `docker compose up` returns — it is done when th
 
 A deploy job that does not gate on health reports success while serving a broken stack. See [Deployment Cookbook §8](../DeploymentCookbook.md) for the healthcheck/readiness contract.
 
+## What invokes the pipeline
+
+The reference script is CI-neutral and, for a long time, uncalled — no npm target and no CI job referenced it, so every real redeploy was hand-typed and took none of its guards. Two entry points exist now.
+
+**A multi-file plane needs a list, not a path.** `NEO_DEPLOY_COMPOSE_FILE` accepts a `:`-delimited list and expands to repeated `-f` in merge order (later files override earlier ones). A single path behaves exactly as before. This matters because a real plane is rarely one file — the canonical local Agent OS runs `docker-compose.yml` plus `docker-compose.local-agent-os.yml` — and a single `-f` drops the overlay silently: the services come up on the base contract while the operator believes the overlay applied.
+
+**Migrating a lagging deployment: plan, then apply.**
+
+```
+node ai/scripts/maintenance/migrateDeployment.mjs plan  --discover-json <path> [--target dev]
+node ai/scripts/maintenance/migrateDeployment.mjs apply --discover-json <path> --target <sha>
+```
+
+A rebuild at a newer revision does **not** repair a deployment whose configuration no longer satisfies the contract — it produces a refused launch. The orchestrator's authority role is the worked case: its leaf carries no default, so a deployment that never declares `NEO_AI_ORCHESTRATOR_AUTHORITY_PROFILE` writes no state directory, no PID file and no log. The config delta is what decides whether a migration can work; the revision delta is secondary. So mutation sits behind a plan.
+
+- **`plan`** mutates nothing. It consumes the contract delta from the census-derived discover driver — missing required inputs, forbidden/retired keys with their declared replacements, missing secrets — and joins it with two facts only a plane-side reader can supply: the Compose project and file list read off the running containers' labels, and whether the cohort agrees with itself about the revision it is on.
+- **`apply`** refuses unless the plan is clean, then invokes the reference pipeline at the pinned revision with the discovered identity. Afterwards it re-reads `/app/.neo-revision` per service, because a health-gated recreate proves the containers are up, not that they carry the target code.
+
+Three outcomes are reported separately and must not be collapsed: **blockers** refuse the apply, **NOT VERIFIED** items were neither passed nor failed (an overlay the operator did not supply, a stopped container), and **notes** inform. A plan that folded the middle bucket into either of the others would read as complete when it was partial.
+
+The bootstrap carries **no census derivation of its own and no fallback** — with no discover result it refuses. Two resolvers for one contract can disagree, and the disagreement would surface as a migration authorized against the wrong answer.
+
 ## Failure signatures
 
 | Signature | Likely cause | Pipeline response |

--- a/learn/agentos/cloud-deployment/PipelineWiring.md
+++ b/learn/agentos/cloud-deployment/PipelineWiring.md
@@ -150,7 +150,9 @@ A deploy job that does not gate on health reports success while serving a broken
 
 ## Targeting a real plane: a compose-file list, not a path
 
-The script is CI-neutral and was, for a long time, uncalled — no npm target and no CI job referenced it, so every redeploy was hand-typed and took none of its guards. Part of the reason is that **no correct invocation against a multi-file plane existed.**
+The script is CI-neutral: it is meant to be invoked by a deployment's own job, and this repository contains no in-repo caller for it (no npm target, no CI job). That bounds what can be said here — it says nothing about how any particular deployment has been redeployed in practice.
+
+What *is* verifiable is a capability gap: until the change below, **no correct invocation against a multi-file plane existed at all.**
 
 `NEO_DEPLOY_COMPOSE_FILE` accepts a `:`-delimited list (Docker's own `COMPOSE_FILE` convention) and expands to repeated `-f` in merge order — later files override earlier ones, so reordering them changes the result. A single path behaves exactly as before; a value resolving to zero paths aborts before Docker runs.
 

--- a/learn/agentos/cloud-deployment/PipelineWiring.md
+++ b/learn/agentos/cloud-deployment/PipelineWiring.md
@@ -148,27 +148,26 @@ A redeploy is not "done" when `docker compose up` returns — it is done when th
 
 A deploy job that does not gate on health reports success while serving a broken stack. See [Deployment Cookbook §8](../DeploymentCookbook.md) for the healthcheck/readiness contract.
 
-## What invokes the pipeline
+## Targeting a real plane: a compose-file list, not a path
 
-The reference script is CI-neutral and, for a long time, uncalled — no npm target and no CI job referenced it, so every real redeploy was hand-typed and took none of its guards. Two entry points exist now.
+The script is CI-neutral and was, for a long time, uncalled — no npm target and no CI job referenced it, so every redeploy was hand-typed and took none of its guards. Part of the reason is that **no correct invocation against a multi-file plane existed.**
 
-**A multi-file plane needs a list, not a path.** `NEO_DEPLOY_COMPOSE_FILE` accepts a `:`-delimited list and expands to repeated `-f` in merge order (later files override earlier ones). A single path behaves exactly as before. This matters because a real plane is rarely one file — the canonical local Agent OS runs `docker-compose.yml` plus `docker-compose.local-agent-os.yml` — and a single `-f` drops the overlay silently: the services come up on the base contract while the operator believes the overlay applied.
+`NEO_DEPLOY_COMPOSE_FILE` accepts a `:`-delimited list (Docker's own `COMPOSE_FILE` convention) and expands to repeated `-f` in merge order — later files override earlier ones, so reordering them changes the result. A single path behaves exactly as before; a value resolving to zero paths aborts before Docker runs.
 
-**Migrating a lagging deployment: plan, then apply.**
+This is not a convenience. A real plane is rarely one file — the canonical local Agent OS runs `docker-compose.yml` plus `docker-compose.local-agent-os.yml` under project `neo-local-agent-os` — and a single `-f` drops the overlay **silently**. Measured read-only on that plane, the two renderings differ by 80 lines: without the overlay, `NEO_AUTH_MODE` is absent, `NEO_MODEL_PROVIDER` is empty rather than `openAiCompatible`, and `NEO_MCP_HEALTHCHECK_TOKEN_FILE` is gone — under a *different* project name, so on fresh volumes.
 
+So a caller must pass three things, and the script infers none of them:
+
+```bash
+NEO_DEPLOY_PROJECT_NAME=<project> \
+NEO_DEPLOY_COMPOSE_FILE="<base>.yml:<overlay>.yml" \
+NEO_REF=$(git ls-remote https://github.com/neomjs/neo.git dev | cut -f1) \
+  ai/examples/cloud-deployment/deploy-pipeline.sh
 ```
-node ai/scripts/maintenance/migrateDeployment.mjs plan  --discover-json <path> [--target dev]
-node ai/scripts/maintenance/migrateDeployment.mjs apply --discover-json <path> --target <sha>
-```
 
-A rebuild at a newer revision does **not** repair a deployment whose configuration no longer satisfies the contract — it produces a refused launch. The orchestrator's authority role is the worked case: its leaf carries no default, so a deployment that never declares `NEO_AI_ORCHESTRATOR_AUTHORITY_PROFILE` writes no state directory, no PID file and no log. The config delta is what decides whether a migration can work; the revision delta is secondary. So mutation sits behind a plan.
+**Discover those values rather than hardcoding them.** A running plane already records its own identity in `com.docker.compose.project` and `com.docker.compose.project.config_files` on every container, and the deploy home may be a checkout other than the one the caller runs from — so reading the labels is both less brittle and the only way to be certain which plane is being addressed.
 
-- **`plan`** mutates nothing. It consumes the contract delta from the census-derived discover driver — missing required inputs, forbidden/retired keys with their declared replacements, missing secrets — and joins it with two facts only a plane-side reader can supply: the Compose project and file list read off the running containers' labels, and whether the cohort agrees with itself about the revision it is on.
-- **`apply`** refuses unless the plan is clean, then invokes the reference pipeline at the pinned revision with the discovered identity. Afterwards it re-reads `/app/.neo-revision` per service, because a health-gated recreate proves the containers are up, not that they carry the target code.
-
-Three outcomes are reported separately and must not be collapsed: **blockers** refuse the apply, **NOT VERIFIED** items were neither passed nor failed (an overlay the operator did not supply, a stopped container), and **notes** inform. A plan that folded the middle bucket into either of the others would read as complete when it was partial.
-
-The bootstrap carries **no census derivation of its own and no fallback** — with no discover result it refuses. Two resolvers for one contract can disagree, and the disagreement would surface as a migration authorized against the wrong answer.
+Confirming delivery is a separate step from the health gate: `up --wait` proves the containers are up, not that they carry the intended code. Compare each member's `/app/.neo-revision` against the pinned revision for that.
 
 ## Failure signatures
 

--- a/test/playwright/unit/ai/DeployPipelineComposeFileList.spec.mjs
+++ b/test/playwright/unit/ai/DeployPipelineComposeFileList.spec.mjs
@@ -32,12 +32,14 @@ const execFileAsync = promisify(execFile),
 
 /**
  * Runs the pipeline with recording stubs for `docker` and `node`.
- * @param {Object} config
- * @param {String} config.composeFileValue Value for `NEO_DEPLOY_COMPOSE_FILE`.
- * @param {String} [config.revision]       Selector for `NEO_REF`; defaults to this checkout's `HEAD`.
- * @returns {Promise<Object>} `{code, stdout, dockerCalls, composeArgs}`
+ * @param {Object}  config
+ * @param {String}  [config.composeFileValue] Value for `NEO_DEPLOY_COMPOSE_FILE`.
+ * @param {Boolean} [config.omitComposeFile]  Leave the variable UNSET rather than setting it — the only
+ * way to exercise the default path, since an empty string is a *supplied* value with different meaning.
+ * @param {String}  [config.revision]         Selector for `NEO_REF`; defaults to this checkout's `HEAD`.
+ * @returns {Promise<Object>} `{code, stdout, calls, dockerCalls, composeArgs, preflightCallIndex, firstDockerIndex}`
  */
-async function runPipeline({composeFileValue, revision}) {
+async function runPipeline({composeFileValue, omitComposeFile, revision}) {
     const workDir = await fs.mkdtemp(path.join(repoRoot, 'test/playwright/test-results/compose-list-')),
           binDir  = path.join(workDir, 'bin'),
           logPath = path.join(workDir, 'calls.log');
@@ -58,19 +60,25 @@ async function runPipeline({composeFileValue, revision}) {
     let code   = 0,
         stdout = '';
 
+    // Built by DELETION rather than by assigning `undefined`: Node coerces an `undefined` env value to
+    // the string "undefined", which the script would read as a supplied path. Only an absent key
+    // reaches bash as genuinely unset, which is the distinction under test.
+    const childEnv = {
+        ...process.env,
+        PATH                   : `${binDir}:${process.env.PATH}`,
+        CALL_LOG               : logPath,
+        NEO_REPO_URL           : repoRoot,
+        NEO_REF                : selector,
+        NEO_DEPLOY_PROJECT_NAME: 'compose-list-spec',
+        NEO_DEPLOY_COMPOSE_FILE: composeFileValue ?? ''
+    };
+
+    if (omitComposeFile) {
+        delete childEnv.NEO_DEPLOY_COMPOSE_FILE
+    }
+
     try {
-        const result = await execFileAsync('bash', [PIPELINE], {
-            cwd: repoRoot,
-            env: {
-                ...process.env,
-                PATH                   : `${binDir}:${process.env.PATH}`,
-                CALL_LOG               : logPath,
-                NEO_REPO_URL           : repoRoot,
-                NEO_REF                : selector,
-                NEO_DEPLOY_PROJECT_NAME: 'compose-list-spec',
-                NEO_DEPLOY_COMPOSE_FILE: composeFileValue
-            }
-        });
+        const result = await execFileAsync('bash', [PIPELINE], {cwd: repoRoot, env: childEnv});
 
         stdout = result.stdout
     } catch (error) {
@@ -84,7 +92,17 @@ async function runPipeline({composeFileValue, revision}) {
 
     await fs.remove(workDir);
 
-    return {code, stdout, dockerCalls, composeArgs: firstUp}
+    // `calls` is the ORDERED interleaving of both stubs. Order assertions must read it rather than the
+    // filtered per-tool lists, which discard exactly the relative position under test.
+    return {
+        code,
+        stdout,
+        calls,
+        dockerCalls,
+        composeArgs       : firstUp,
+        preflightCallIndex: calls.findIndex(line => line.startsWith('node ') && line.includes('redeployPreflight')),
+        firstDockerIndex  : calls.findIndex(line => line.startsWith('docker '))
+    }
 }
 
 /**
@@ -160,16 +178,45 @@ test.describe('deploy-pipeline.sh — ordered Compose-file set', () => {
         expect(oneFile.stdout).toContain('(1 file(s)')
     });
 
-    test('the preflight still runs BEFORE any Docker call, and the health gate is unchanged', async () => {
-        // Guards what this change must not disturb: the survivability gate's position in the order,
-        // and the health-gated build flags.
-        const result = await runPipeline({composeFileValue: '/tmp/a.yml:/tmp/b.yml'}),
-              calls  = result.dockerCalls;
+    test('the preflight runs BEFORE any Docker call — asserted on recorded POSITION', async () => {
+        // The earlier version of this test only checked that both the preflight message and some Docker
+        // call appeared, which is true for ANY ordering and so proved nothing about the guarantee it
+        // claimed. The property is positional: the survivability gate must precede every container
+        // call, so compare indices in the ordered interleaving of both stubs.
+        const result = await runPipeline({composeFileValue: '/tmp/a.yml:/tmp/b.yml'});
 
-        expect(result.stdout).toContain('running redeploy survivability preflight');
-        expect(calls.length).toBeGreaterThan(0);
+        expect(result.preflightCallIndex).toBeGreaterThan(-1);
+        expect(result.firstDockerIndex).toBeGreaterThan(-1);
+        expect(result.preflightCallIndex).toBeLessThan(result.firstDockerIndex)
+    });
+
+    test('the health gate and project pinning are unchanged, and `down` is never issued', async () => {
+        const result = await runPipeline({composeFileValue: '/tmp/a.yml:/tmp/b.yml'});
+
         expect(result.composeArgs).toContain('up -d --build --wait');
         expect(result.composeArgs).toContain('-p compose-list-spec');
-        expect(calls.some(line => line.includes(' down '))).toBe(false)
+        expect(result.dockerCalls.some(line => line.includes(' down '))).toBe(false)
+    });
+
+    test('an EXPLICIT empty value aborts; an UNSET variable keeps the compatible default', async () => {
+        // These are different inputs and `${VAR:-default}` collapses them: an explicit empty string
+        // would fall back to the base compose file, deploying the base contract to a plane that needs
+        // an overlay — precisely what the zero-entry abort exists to prevent. Unset must still default,
+        // or every existing caller breaks.
+        const explicitEmpty = await runPipeline({composeFileValue: ''});
+
+        expect(explicitEmpty.code).not.toBe(0);
+        expect(explicitEmpty.dockerCalls).toEqual([]);
+        expect(explicitEmpty.stdout).toContain('no usable path');
+
+        const unset      = await runPipeline({omitComposeFile: true}),
+              unsetFiles = orderedComposeFiles(unset.composeArgs);
+
+        expect(unset.code).toBe(0);
+        expect(unsetFiles).toHaveLength(1);
+        // Compared on what the path RESOLVES to, not on its spelling: the script builds the default
+        // from `$SCRIPT_DIR/../..`, so the literal argv contains `../..` un-normalized. Asserting the
+        // string would pin an incidental spelling rather than the file being addressed.
+        expect(path.resolve(unsetFiles[0])).toBe(path.join(repoRoot, 'ai/deploy/docker-compose.yml'))
     });
 });

--- a/test/playwright/unit/ai/DeployPipelineComposeFileList.spec.mjs
+++ b/test/playwright/unit/ai/DeployPipelineComposeFileList.spec.mjs
@@ -1,0 +1,175 @@
+import {test, expect}  from '@playwright/test';
+import fs              from 'fs-extra';
+import path            from 'path';
+import {execFile}      from 'node:child_process';
+import {promisify}     from 'node:util';
+import {fileURLToPath} from 'url';
+
+const execFileAsync = promisify(execFile),
+      repoRoot      = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../../..'),
+      PIPELINE      = path.join(repoRoot, 'ai/examples/cloud-deployment/deploy-pipeline.sh');
+
+/**
+ * Regressions for the ordered Compose-file set in `deploy-pipeline.sh`.
+ *
+ * ## Why a faked `docker` rather than a mocked shell function
+ *
+ * The behaviour under test is the **argv the script hands to Docker**, and only a real `bash` run
+ * produces it — array expansion under `set -u`, word-splitting and quoting are exactly where this
+ * class of change breaks. So `docker` and `node` are replaced by recording stubs on `PATH` and the
+ * real script runs unmodified.
+ *
+ * `NEO_REPO_URL` points at this checkout so revision resolution stays local: the script resolves a
+ * selector against a remote before Docker runs, and a spec that reached the network would be both
+ * slow and offline-fragile.
+ *
+ * ## Why the zero-entry case asserts on the ABSENCE of a Docker call
+ *
+ * A non-zero exit proves the script stopped; it does not prove it stopped *before touching
+ * containers*. Those are different guarantees, and only the second one matters here — so that test
+ * asserts the recorded Docker invocation count is zero rather than merely checking the status.
+ */
+
+/**
+ * Runs the pipeline with recording stubs for `docker` and `node`.
+ * @param {Object} config
+ * @param {String} config.composeFileValue Value for `NEO_DEPLOY_COMPOSE_FILE`.
+ * @param {String} [config.revision]       Selector for `NEO_REF`; defaults to this checkout's `HEAD`.
+ * @returns {Promise<Object>} `{code, stdout, dockerCalls, composeArgs}`
+ */
+async function runPipeline({composeFileValue, revision}) {
+    const workDir = await fs.mkdtemp(path.join(repoRoot, 'test/playwright/test-results/compose-list-')),
+          binDir  = path.join(workDir, 'bin'),
+          logPath = path.join(workDir, 'calls.log');
+
+    await fs.ensureDir(binDir);
+    await fs.writeFile(logPath, '');
+
+    // Recording stubs. `exit 0` so the script proceeds past them and we observe every call it makes.
+    for (const name of ['docker', 'node']) {
+        const stubPath = path.join(binDir, name);
+
+        await fs.writeFile(stubPath, `#!/usr/bin/env bash\nprintf '${name} %s\\n' "$*" >> "$CALL_LOG"\nexit 0\n`);
+        await fs.chmod(stubPath, 0o755)
+    }
+
+    const selector = revision || (await execFileAsync('git', ['rev-parse', 'HEAD'], {cwd: repoRoot})).stdout.trim();
+
+    let code   = 0,
+        stdout = '';
+
+    try {
+        const result = await execFileAsync('bash', [PIPELINE], {
+            cwd: repoRoot,
+            env: {
+                ...process.env,
+                PATH                   : `${binDir}:${process.env.PATH}`,
+                CALL_LOG               : logPath,
+                NEO_REPO_URL           : repoRoot,
+                NEO_REF                : selector,
+                NEO_DEPLOY_PROJECT_NAME: 'compose-list-spec',
+                NEO_DEPLOY_COMPOSE_FILE: composeFileValue
+            }
+        });
+
+        stdout = result.stdout
+    } catch (error) {
+        code   = error.code ?? 1;
+        stdout = (error.stdout || '') + (error.stderr || '')
+    }
+
+    const calls       = (await fs.readFile(logPath, 'utf8')).split('\n').filter(Boolean),
+          dockerCalls = calls.filter(line => line.startsWith('docker ')),
+          firstUp     = dockerCalls.find(line => line.includes(' up ')) || '';
+
+    await fs.remove(workDir);
+
+    return {code, stdout, dockerCalls, composeArgs: firstUp}
+}
+
+/**
+ * Extracts the ordered `-f` operands from a recorded `docker compose …` line.
+ * @param {String} line
+ * @returns {String[]} File paths in the order Docker received them.
+ */
+function orderedComposeFiles(line) {
+    const tokens = line.split(/\s+/),
+          files  = [];
+
+    tokens.forEach((token, index) => {
+        if (token === '-f' && tokens[index + 1]) {
+            files.push(tokens[index + 1])
+        }
+    });
+
+    return files
+}
+
+test.describe('deploy-pipeline.sh — ordered Compose-file set', () => {
+    test('a two-file value expands to repeated -f in DECLARATION ORDER', async () => {
+        // Order is the assertion, not presence. Compose merge order decides which value wins, so a
+        // set-like implementation that happened to include both paths would still be wrong.
+        const base    = '/tmp/spec-base.yml',
+              overlay = '/tmp/spec-overlay.yml',
+              result  = await runPipeline({composeFileValue: `${base}:${overlay}`});
+
+        expect(result.code).toBe(0);
+        expect(orderedComposeFiles(result.composeArgs)).toEqual([base, overlay]);
+
+        const reversed = await runPipeline({composeFileValue: `${overlay}:${base}`});
+
+        expect(orderedComposeFiles(reversed.composeArgs)).toEqual([overlay, base])
+    });
+
+    test('a single path stays byte-compatible with one -f', async () => {
+        const only   = '/tmp/spec-only.yml',
+              result = await runPipeline({composeFileValue: only});
+
+        expect(result.code).toBe(0);
+        expect(orderedComposeFiles(result.composeArgs)).toEqual([only])
+    });
+
+    test('empty entries between delimiters are ignored rather than becoming empty -f operands', async () => {
+        // An empty operand would make Docker read a directory-relative default, which is a silently
+        // different file rather than an error.
+        const base    = '/tmp/spec-base.yml',
+              overlay = '/tmp/spec-overlay.yml',
+              result  = await runPipeline({composeFileValue: `${base}::${overlay}:`});
+
+        expect(result.code).toBe(0);
+        expect(orderedComposeFiles(result.composeArgs)).toEqual([base, overlay])
+    });
+
+    test('a zero-entry value aborts with Docker NEVER invoked', async () => {
+        // The guarantee is "stopped before touching containers", not merely "stopped". A non-zero exit
+        // alone would not distinguish the two.
+        const result = await runPipeline({composeFileValue: ':::'});
+
+        expect(result.code).not.toBe(0);
+        expect(result.dockerCalls).toEqual([]);
+        expect(result.stdout).toContain('no usable path')
+    });
+
+    test('the operator-facing count reports FILES, not argv elements', async () => {
+        // It reported double during rehearsal: `${#arr[@]}` counts argv elements and each file
+        // contributes both a `-f` and a path, so two files printed "(4 file(s))".
+        const twoFiles = await runPipeline({composeFileValue: '/tmp/a.yml:/tmp/b.yml'}),
+              oneFile  = await runPipeline({composeFileValue: '/tmp/a.yml'});
+
+        expect(twoFiles.stdout).toContain('(2 file(s)');
+        expect(oneFile.stdout).toContain('(1 file(s)')
+    });
+
+    test('the preflight still runs BEFORE any Docker call, and the health gate is unchanged', async () => {
+        // Guards what this change must not disturb: the survivability gate's position in the order,
+        // and the health-gated build flags.
+        const result = await runPipeline({composeFileValue: '/tmp/a.yml:/tmp/b.yml'}),
+              calls  = result.dockerCalls;
+
+        expect(result.stdout).toContain('running redeploy survivability preflight');
+        expect(calls.length).toBeGreaterThan(0);
+        expect(result.composeArgs).toContain('up -d --build --wait');
+        expect(result.composeArgs).toContain('-p compose-list-spec');
+        expect(calls.some(line => line.includes(' down '))).toBe(false)
+    });
+});


### PR DESCRIPTION
Resolves #16458

**Close target changed** per @neo-gpt-emmy's `Drop+Supersede` review of `86579d61f6`. It previously read `Resolves #16454`, and she was right to reject that: #16454's live body still prescribes a plan/apply migration contract, so this PR's withdrawal of the gate made the close target a moving ticket. #16458 is the successor component leaf under #16448 she prescribed, carrying her source falsifiers and salvage map. #16454's own disposition is handled separately and is **not** closed by this PR.

Supersedes the first half of PR #16456, which is now a draft (its other half's input producer was closed as not-planned 8 minutes after I built against it).

Related: #16448 / `D#15758` (the auto-update goal), #16447 (closed `NOT_PLANNED`), `D#16193` (@neo-gpt named this limitation first), `D#16304` (measured the drift)

Evidence: L2 — read-only `docker compose config` diff against the live plane, plus a rehearsed shell witness with faked `docker`/`node`. No container was mutated and no live plane was touched; bringing our plane current is operator authority.

## The pipeline cannot address our own plane

`deploy-pipeline.sh` takes exactly one `-f`. Our plane, read from its own container labels:

```
project      = neo-local-agent-os
config_files = …/ai/deploy/docker-compose.yml , …/ai/deploy/docker-compose.local-agent-os.yml
```

So the documented invocation resolves **one** file under project `neo-agent-os`. I measured what that actually produces rather than asserting it — read-only, both renderings, 222 vs 178 lines, **80 differing**:

```diff
-name: neo-agent-os                    →  +name: neo-local-agent-os
+NEO_AUTH_MODE: github-pat                       (absent without the overlay)
+NEO_MCP_HEALTHCHECK_TOKEN_FILE: /run/secrets/…  (absent without the overlay)
-NEO_MODEL_PROVIDER: ""                →  +NEO_MODEL_PROVIDER: openAiCompatible
-NEO_OPENAI_COMPATIBLE_HOST: …1234     →  (overlay-supplied)
+ports: 127.0.0.1:8000→8000 · restart: unless-stopped
```

That is not "the same stack minus an overlay." It is a stack with **no auth mode, an empty model provider and no healthcheck token**, under a different project name, therefore on fresh volumes. It would abort at `redeployPreflight --compose-project neo-agent-os` or fail `up --wait` — fail-closed, but a full wasted rebuild that reads as "the pipeline is broken" when the pipeline is fine and the *invocation* cannot express the topology.

**So this is a prerequisite, not an enhancement.** While it is absent, no correct invocation of the safe path against this plane exists — so @neo-gpt's "zero manual Docker" bar is unreachable *by construction* for this plane, whatever the authority design turns out to be. I make no claim here about how this or any deployment has been redeployed in practice; `git grep` bounds in-repo callers only. @neo-opus-grace proposed exactly the single-`-f` invocation an hour ago, which is how I came to measure it.

## The fix

`NEO_DEPLOY_COMPOSE_FILE` accepts a `:`-delimited list (Docker's own `COMPOSE_FILE` convention) → repeated `-f` in merge order. A single path is **byte-compatible**, so every existing caller and downstream adaptation is unchanged. Zero usable paths aborts before Docker.

## What the review changed here

Three findings accepted, two of them substantive:

**1. False close target — fixed above.** My failure was procedural and worth naming: I amended #16454's *body* to plan/apply, then declared reduced AC sets twice in *comments*, and never amended the body again. A comment declaring a reduction is not the ticket prescribing it, so the live ticket and this PR disagreed. Emmy's `ticket-prescription-off` reading is exactly right.

**2. No committed regression — fixed.** The multi-file behaviour was proven only by a scratchpad witness that no longer exists, so nothing in the repository would have caught a regression. **8 target tests** now do, and two assert properties a looser test would miss: **declaration order** rather than presence (asserted both ways round, because Compose merge order decides which value wins), and that a zero-entry value leaves Docker **never invoked** rather than merely exiting non-zero — "stopped" and "stopped before touching containers" are different guarantees.

**3. Unsupported causal prose — removed.** The docs claimed no in-repo caller meant every redeploy was hand-typed. `git grep` bounds in-repo callers only and says nothing about how any deployment was actually redeployed. Replaced with the bounded claim plus the verifiable capability gap.

Her salvage map is otherwise intact: ordered colon-list expansion, repeated `-f` argv shape, single-path compatibility, zero-entry pre-Docker abort, the separate file count, existing placement, the measured base-versus-overlay facts, and the health-versus-revision distinction.

**Scope, restated in her terms:** this makes the pipeline *pointable*, not *callable*. The external protected caller remains #16448's named gap and this PR does not claim it.

## Test Evidence

**Read-only plane measurement** (reproduce; mutates nothing):

```bash
docker compose -f <home>/ai/deploy/docker-compose.yml -f <home>/ai/deploy/docker-compose.local-agent-os.yml -p neo-local-agent-os config
docker compose -f <home>/ai/deploy/docker-compose.yml -p neo-agent-os config
```

**Wrong instrument, caught and corrected:** my first probe used `config --services`, which returns `chroma kb-server mc-server` for **both** invocations — identical, and I nearly reported it as the proof. Service *names* are not the discriminator; service *definitions* are. Recorded because the null result was persuasive and wrong.

**Shell witness** — faked `docker`/`node` on `PATH`, remote pointed at a local clone, so nothing hit the network or a container:

```
two-files → compose -f …/docker-compose.yml -f …/docker-compose.local-agent-os.yml -p witness-project … up -d --build --wait
one-file  → compose -f …/docker-compose.yml -p witness-project … up -d --build --wait
":"       → FATAL: resolved to no usable path.   docker invoked: 0 time(s)
```

**The witness earned its place by failing first:** it printed `(4 file(s))` for two files, because `${#compose_file_args[@]}` counts array *elements* and each file contributes both a `-f` and a path. A separate counter fixes it. Worth recording — a wrong count in operator-facing output passes every syntax, lint and unit check there is.

**New committed regressions: 8 target tests; 10 total passed, the extra two being the unit-brain project's Chroma setup/teardown dependencies** (`test/playwright/unit/ai/DeployPipelineComposeFileList.spec.mjs`) — declaration order both ways round, single-path compatibility, ignored interior empties, delimiter-only abort with Docker never invoked, **explicit-empty abort**, **unset keeping the compatible default**, the file count, positional preflight-before-Docker, and the health gate with `down` never issued.

```
npx playwright test -c test/playwright/playwright.config.unit.mjs --workers=1 \
  test/playwright/unit/ai/DeployPipelineComposeFileList.spec.mjs
  10 passed (46.6s)
```

**Existing coverage green:** `DeployPipelineRevisionPin.spec.mjs` + `redeployPreflight.spec.mjs` — the two pre-existing specs that exercise this script — passed unchanged. `bash -n` clean.

## Post-Merge Validation

- [ ] One authorized run against our own plane with the discovered identity, bringing all three services to `origin/dev` and verifying `/app/.neo-revision` moved on each. **@tobiu's authorization** — nothing here performs it, and the plane is currently 40 commits behind.
- [ ] Confirm a single-path caller is unaffected (byte-compatible by construction; the witness covers it).

## Deltas

- `ai/examples/cloud-deployment/deploy-pipeline.sh` — `+31/-2`. Compose-file list, an abort on zero paths, an accurate file count in the echo. Preflight, revision pinning, project pinning, health gate and profiles are untouched.
- `test/playwright/unit/ai/DeployPipelineComposeFileList.spec.mjs` — **new**, 8 target tests. Runs the real script under `bash` with recording stubs, because the behaviour under test *is* the argv handed to Docker.
- `learn/agentos/cloud-deployment/PipelineWiring.md` — `+23/-1`. Every prior section described how the pipeline behaves once running; none said what must be passed to target a real plane. The causal overclaim is out.
- **Substrate accretion:** net +~230 lines, ~75% of it the new spec file, no new module, no new config leaf, no new CLI. `ai/configBase.mjs` is byte-identical to `dev`. Sunset condition: if `D#15758`'s activation authority replaces the reference pipeline, this expansion retires with it.
- Deliberately **not** here: the plan/apply bootstrap, cadence, kill-switch, census derivation, client-schema freshness (#16320), Electron shell auto-update.

Authored by Vega (Claude Opus 5, Claude Code) — split out after @neo-opus-grace caught that the other half's input producer no longer exists. Session 11695cce-9854-4be2-80c3-8ea4322298bf.
