### PR TITLE
State the orchestrator's heap ceiling instead of inheriting it

### DIFF
--- a/ai/configBase.mjs
+++ b/ai/configBase.mjs
@@ -19,6 +19,41 @@ const HOUR_MS = 60 * 60 * 1000;
 const DAY_MS  = 24 * HOUR_MS;
 
 /**
+ * @summary Env parser for the supervised-child heap ceiling — fails closed on anything that is not
+ * a positive integer.
+ *
+ * A permissive parser is not merely untidy here, it inverts the safety property the ceiling exists
+ * for: `-1` passes `Number(v) || fallback`, reaches Node as `--max-old-space-size=-1`, and Node
+ * reports the flag out of bounds, **exits 0**, and continues with a ~4.5 GB heap limit — above a
+ * 3 GiB cgroup. The invalid value therefore produces a LARGER ceiling than the valid one, and
+ * trades a catchable `FATAL ERROR: heap limit` for an uncatchable kernel OOM kill that leaves no
+ * diagnostic at all.
+ *
+ * @param {String} value Raw env value.
+ * @returns {Number}
+ * @throws {TypeError} When the override is not a positive integer.
+ */
+function parseSupervisedTaskHeapMb(envVarName, {env = process.env} = {}) {
+    const rawValue = env[envVarName];
+
+    // Unset returns undefined so the LEAF DEFAULT applies. Throwing here instead would fail boot on
+    // every deployment that never set the override — the parse hook receives the env var NAME and
+    // reads the value itself (see `parsePlaneIdEnv`, the sibling this follows).
+    if (rawValue === undefined || rawValue === null || rawValue === '') return;
+
+    const parsed = Number(rawValue);
+
+    if (!Number.isInteger(parsed) || parsed <= 0) {
+        throw new TypeError(
+            `configBase: ${envVarName}="${rawValue}" must be a positive integer (MiB). ` +
+            'Refusing rather than falling back: a rejected ceiling lets Node continue with a heap larger than the container.'
+        );
+    }
+
+    return parsed;
+}
+
+/**
  * @summary The extendable Tier-1 configuration BASE — every default leaf and formula of the Agent OS
  * config plane, carried by a non-singleton class so overlays inherit instead of copying.
  *
@@ -900,6 +935,26 @@ class ConfigBase extends ConfigProvider {
                         entrypoints: ['orchestrator-daemon'],
                         reason     : 'A role is declared, never inherited. Declare `container-plane` on the containerized Orchestrator (its Compose service sets it), or start the machine-local one with `npm run ai:host-edge`, which declares `host-edge` and its full posture.'
                     }]
+                }),
+                /**
+                 * V8 old-space ceiling, in MiB, for each supervised child process.
+                 *
+                 * A container memory limit budgets a process TREE; a heap ceiling is PER PROCESS.
+                 * Children are spawned with `{...process.env}`, so a ceiling carried at the service
+                 * level is re-spent by every concurrent child rather than once. The inverse is why
+                 * the container cannot be sized alone: with no explicit ceiling Node derives its
+                 * default old-space from the cgroup, so raising the limit silently raises every
+                 * unbounded child's implicit ceiling. Explicit-per-process is the only arrangement
+                 * where the limit and the ceilings can be reasoned about together.
+                 *
+                 * The `parse` hook FAILS CLOSED on a non-positive or non-integer override. Without
+                 * it, `-1` reaches Node, which reports the flag out of bounds, **exits 0**, and
+                 * continues with a ~4.5 GB heap limit — above the cgroup, converting a catchable
+                 * heap error into an uncatchable kernel OOM kill with no diagnostic.
+                 * @type {Number}
+                 */
+                supervisedTaskHeapMb: leaf(384, 'NEO_SUPERVISED_TASK_HEAP_MB', 'number', {
+                    parse: parseSupervisedTaskHeapMb
                 }),
                 /**
                  * Filesystem root under which tenant-repo mirrors are stored. The

--- a/ai/daemons/orchestrator/Orchestrator.mjs
+++ b/ai/daemons/orchestrator/Orchestrator.mjs
@@ -412,6 +412,9 @@ export class Orchestrator extends Base {
      */
     beforeSetProcessSupervisorService(value) {
         return ClassSystemUtil.beforeSetInstance(value, ProcessSupervisorService, {
+            // Resolved at the use site and injected across the narrow construction seam (ADR-0019 // ticket-ref-ok: the ADR is the authority assigning env resolution to the leaf, not background reading
+            // §5.1/§5.5). The supervisor never reads the env var itself.
+            supervisedTaskHeapMb   : AiConfig.orchestrator.supervisedTaskHeapMb,
             dataDir                : this.dataDir,
             taskDefinitions        : this.getAuthorityScopedTaskDefinitions(),
             taskStateService       : this.taskStateService,

--- a/ai/daemons/orchestrator/services/ProcessSupervisorService.mjs
+++ b/ai/daemons/orchestrator/services/ProcessSupervisorService.mjs
@@ -26,6 +26,58 @@ const ESCALATING_TASK_OUTCOMES      = Object.freeze(new Set(['backup']));
  */
 const CHILD_LOG_PREFIX = /^(?:\[?\d{4}-\d{2}-\d{2}T[\d:.]+Z\]?\s*)?(?<pid>\[PID:\d+\]\s*)?\[(?<level>LOG|INFO|WARN|ERROR)\]\s*/;
 
+/**
+ * Default V8 old-space ceiling, in MiB, for a supervised child.
+ *
+ * Overridable per deployment via `NEO_SUPERVISED_TASK_HEAP_MB`, and per task via a `NODE_OPTIONS`
+ * entry in the task definition's own `env`.
+ * @type {Number}
+ */
+const DEFAULT_SUPERVISED_TASK_HEAP_MB = 512;
+
+/**
+ * @summary Builds a supervised child's environment with an explicit heap ceiling.
+ *
+ * **Why a child needs its own ceiling rather than inheriting.** A container memory limit is a budget
+ * for the whole process tree, but a V8 heap ceiling is per process. Children are spawned with
+ * `{...process.env}`, so anything the parent carries is multiplied by the number of concurrent Node
+ * processes — and a ceiling set once at the service level reads as "the container's budget" while
+ * actually being "the budget, per child, again".
+ *
+ * The inverse is just as bad and is why this cannot be solved by sizing the container alone: with no
+ * explicit ceiling, Node derives its default old-space from the cgroup, so **raising the container
+ * limit silently raises every unbounded child's implicit ceiling too**. Explicit-per-process is the
+ * only arrangement where the container limit and the ceilings can be reasoned about together.
+ *
+ * Precedence, narrowest wins: caller `env` > task `env` > this default > inherited parent env. A task
+ * that genuinely needs a larger heap says so in its own definition, where the reason can be read next
+ * to the task it belongs to.
+ *
+ * @param {Object} options
+ * @param {Object} [options.baseEnv] Parent environment to inherit from.
+ * @param {Object} [options.taskEnv] Task-definition environment.
+ * @param {Object} [options.callerEnv] Call-site environment.
+ * @param {Number} [options.defaultHeapMb] Child ceiling in MiB.
+ * @returns {Object} The child environment.
+ */
+export function buildSupervisedTaskEnv({
+    baseEnv       = process.env,
+    taskEnv       = null,
+    callerEnv     = null,
+    defaultHeapMb = Number(baseEnv?.NEO_SUPERVISED_TASK_HEAP_MB) || DEFAULT_SUPERVISED_TASK_HEAP_MB
+} = {}) {
+    const merged = {...baseEnv, ...(taskEnv || {}), ...(callerEnv || {})};
+
+    // Only supply the ceiling when neither the task nor the caller stated one. A task that declares
+    // its own NODE_OPTIONS has made a deliberate choice, and overriding it here would make the task
+    // definition a lie.
+    if (!taskEnv?.NODE_OPTIONS && !callerEnv?.NODE_OPTIONS) {
+        merged.NODE_OPTIONS = `--max-old-space-size=${defaultHeapMb}`
+    }
+
+    return merged
+}
+
 export class ProcessSupervisorService extends Base {
     static config = {
         /**
@@ -586,9 +638,11 @@ export class ProcessSupervisorService extends Base {
         let child;
         const stdoutCapture = this.createStdoutJsonCapture(task);
         try {
-            const env = task.env || options.env
-                ? {...process.env, ...(task.env || {}), ...(options.env || {})}
-                : process.env;
+            const env = buildSupervisedTaskEnv({
+                baseEnv  : process.env,
+                callerEnv: options.env,
+                taskEnv  : task.env
+            });
             child = this.spawnFn(task.command, task.args, {stdio: stdoutCapture ? ['ignore', 'pipe', 'pipe'] : ['ignore', 'ignore', 'pipe'], env});
 
             child.stderr?.on('data', data => {

--- a/ai/daemons/orchestrator/services/ProcessSupervisorService.mjs
+++ b/ai/daemons/orchestrator/services/ProcessSupervisorService.mjs
@@ -29,11 +29,11 @@ const CHILD_LOG_PREFIX = /^(?:\[?\d{4}-\d{2}-\d{2}T[\d:.]+Z\]?\s*)?(?<pid>\[PID:
 /**
  * Default V8 old-space ceiling, in MiB, for a supervised child.
  *
- * Overridable per deployment via `NEO_SUPERVISED_TASK_HEAP_MB`, and per task via a `NODE_OPTIONS`
- * entry in the task definition's own `env`.
+ * Fallback only, used when no resolved value is injected (e.g. a direct unit construction). The
+ * deployment value resolves through the `orchestrator.supervisedTaskHeapMb` leaf and is injected.
  * @type {Number}
  */
-const DEFAULT_SUPERVISED_TASK_HEAP_MB = 384;
+const FALLBACK_SUPERVISED_TASK_HEAP_MB = 384;
 
 /**
  * @summary Builds a supervised child's environment with an explicit heap ceiling.
@@ -49,7 +49,8 @@ const DEFAULT_SUPERVISED_TASK_HEAP_MB = 384;
  * limit silently raises every unbounded child's implicit ceiling too**. Explicit-per-process is the
  * only arrangement where the container limit and the ceilings can be reasoned about together.
  *
- * Precedence, narrowest wins: caller `env` > task `env` > this default > inherited parent env. A task
+ * Precedence, narrowest wins: caller `env` > task `env` > the INJECTED resolved ceiling > inherited
+ * parent env. A task
  * that genuinely needs a larger heap says so in its own definition, where the reason can be read next
  * to the task it belongs to.
  *
@@ -64,7 +65,7 @@ export function buildSupervisedTaskEnv({
     baseEnv       = process.env,
     taskEnv       = null,
     callerEnv     = null,
-    defaultHeapMb = Number(baseEnv?.NEO_SUPERVISED_TASK_HEAP_MB) || DEFAULT_SUPERVISED_TASK_HEAP_MB
+    defaultHeapMb = FALLBACK_SUPERVISED_TASK_HEAP_MB
 } = {}) {
     const merged = {...baseEnv, ...(taskEnv || {}), ...(callerEnv || {})};
 
@@ -91,6 +92,17 @@ export class ProcessSupervisorService extends Base {
          * @reactive
          */
         dataDir_: '',
+        /**
+         * Resolved V8 old-space ceiling, in MiB, applied to each supervised child.
+         *
+         * INJECTED by the Orchestrator from `AiConfig.orchestrator.supervisedTaskHeapMb`. This
+         * service never reads the env var — ADR-0019 assigns that resolution to the leaf, and the // ticket-ref-ok: names the decision that forbids reading env here
+         * Orchestrator construction seam is the narrow bootstrap boundary its sanctioned patterns
+         * allow. An earlier revision read it here with `Number(env) || 384`, which is the A1
+         * antipattern and additionally accepted `-1`.
+         * @member {Number} supervisedTaskHeapMb_=0
+         */
+        supervisedTaskHeapMb_: 0,
         /**
          * @member {Object|null} taskDefinitions_=null
          * @protected
@@ -639,9 +651,10 @@ export class ProcessSupervisorService extends Base {
         const stdoutCapture = this.createStdoutJsonCapture(task);
         try {
             const env = buildSupervisedTaskEnv({
-                baseEnv  : process.env,
-                callerEnv: options.env,
-                taskEnv  : task.env
+                baseEnv      : process.env,
+                callerEnv    : options.env,
+                defaultHeapMb: this.supervisedTaskHeapMb || FALLBACK_SUPERVISED_TASK_HEAP_MB,
+                taskEnv      : task.env
             });
             child = this.spawnFn(task.command, task.args, {stdio: stdoutCapture ? ['ignore', 'pipe', 'pipe'] : ['ignore', 'ignore', 'pipe'], env});
 

--- a/ai/daemons/orchestrator/services/ProcessSupervisorService.mjs
+++ b/ai/daemons/orchestrator/services/ProcessSupervisorService.mjs
@@ -33,7 +33,7 @@ const CHILD_LOG_PREFIX = /^(?:\[?\d{4}-\d{2}-\d{2}T[\d:.]+Z\]?\s*)?(?<pid>\[PID:
  * entry in the task definition's own `env`.
  * @type {Number}
  */
-const DEFAULT_SUPERVISED_TASK_HEAP_MB = 512;
+const DEFAULT_SUPERVISED_TASK_HEAP_MB = 384;
 
 /**
  * @summary Builds a supervised child's environment with an explicit heap ceiling.

--- a/ai/daemons/shared/fileLease.mjs
+++ b/ai/daemons/shared/fileLease.mjs
@@ -59,14 +59,32 @@ export class FileLeaseHeldError extends Error {
             ? `${holder.owner} pid ${holder.pid} (since ${holder.startedAt})`
             : 'an unverifiable holder (corrupt or unreadable lease state — refusing rather than guessing)';
 
-        super(`${lockLabel} lease ${lockPath} is held by ${who}; ${requester.owner} pid ${requester.pid} ` +
-            `refuses to start a duplicate (single-owner invariant). ${remediation}`.trim());
+        // When the holder's identity is byte-identical to the requester's, the refusal is almost
+        // certainly self-succession: the same slot restarted inside the freshness window and is
+        // being refused against its own predecessor's lease. That is correct behaviour and a
+        // terrible thing to read, because the caller's remediation says to stop a duplicate — and
+        // an operator then hunts for a second process that does not exist while the restart loop's
+        // real cause scrolls past above it. Containers make this the common case rather than the
+        // exotic one: hostname is the container id and the entrypoint is always pid 1, so every
+        // restart reproduces the previous holder's identity exactly.
+        const isSelfSuccession = Boolean(holder) &&
+            holder.owner === requester.owner && holder.pid === requester.pid;
 
-        this.name      = 'FileLeaseHeldError';
-        this.code      = 'FILE_LEASE_HELD';
-        this.lockPath  = lockPath;
-        this.holder    = holder;
-        this.requester = requester;
+        const guidance = isSelfSuccession
+            ? `The holder's identity is identical to yours, so this is very likely your own previous ` +
+              `instance inside the lease freshness window, not a second live process — investigate why ` +
+              `that instance stopped rather than hunting for a duplicate.`
+            : remediation;
+
+        super(`${lockLabel} lease ${lockPath} is held by ${who}; ${requester.owner} pid ${requester.pid} ` +
+            `refuses to start a duplicate (single-owner invariant). ${guidance}`.trim());
+
+        this.name             = 'FileLeaseHeldError';
+        this.code             = 'FILE_LEASE_HELD';
+        this.lockPath         = lockPath;
+        this.holder           = holder;
+        this.requester        = requester;
+        this.selfSuccession   = isSelfSuccession;
     }
 }
 

--- a/ai/daemons/shared/fileLease.mjs
+++ b/ai/daemons/shared/fileLease.mjs
@@ -59,32 +59,45 @@ export class FileLeaseHeldError extends Error {
             ? `${holder.owner} pid ${holder.pid} (since ${holder.startedAt})`
             : 'an unverifiable holder (corrupt or unreadable lease state — refusing rather than guessing)';
 
-        // When the holder's identity is byte-identical to the requester's, the refusal is almost
-        // certainly self-succession: the same slot restarted inside the freshness window and is
-        // being refused against its own predecessor's lease. That is correct behaviour and a
-        // terrible thing to read, because the caller's remediation says to stop a duplicate — and
-        // an operator then hunts for a second process that does not exist while the restart loop's
-        // real cause scrolls past above it. Containers make this the common case rather than the
-        // exotic one: hostname is the container id and the entrypoint is always pid 1, so every
-        // restart reproduces the previous holder's identity exactly.
-        const isSelfSuccession = Boolean(holder) &&
+        // The holder's identity being byte-identical to the requester's is an OBSERVATION, not a
+        // conclusion: it is consistent with the same slot restarting inside the freshness window and
+        // meeting its own predecessor's lease, and it is also consistent with two genuinely distinct
+        // processes that are simply indistinguishable by this identity. Containers make the second
+        // case unfalsifiable from here — hostname is the container id and the entrypoint is always
+        // pid 1 — which is exactly why the message reports what was measured and lets the reader draw
+        // the conclusion.
+        //
+        // It matters because the caller's remediation ("stop the duplicate") is actively misleading
+        // in the restart-loop case: an operator hunts for a second process that does not exist while
+        // the loop's real cause scrolls past above it in the same log.
+        const holderIdentityMatchesRequester = Boolean(holder) &&
             holder.owner === requester.owner && holder.pid === requester.pid;
 
-        const guidance = isSelfSuccession
-            ? `The holder's identity is identical to yours, so this is very likely your own previous ` +
-              `instance inside the lease freshness window, not a second live process — investigate why ` +
-              `that instance stopped rather than hunting for a duplicate.`
+        const guidance = holderIdentityMatchesRequester
+            ? `The holder's identity is indistinguishable from yours, so this may be your own previous ` +
+              `instance inside the lease freshness window rather than a second live process — check ` +
+              `whether the previous instance stopped before hunting for a duplicate.`
             : remediation;
 
         super(`${lockLabel} lease ${lockPath} is held by ${who}; ${requester.owner} pid ${requester.pid} ` +
             `refuses to start a duplicate (single-owner invariant). ${guidance}`.trim());
 
-        this.name             = 'FileLeaseHeldError';
-        this.code             = 'FILE_LEASE_HELD';
-        this.lockPath         = lockPath;
-        this.holder           = holder;
-        this.requester        = requester;
-        this.selfSuccession   = isSelfSuccession;
+        this.name      = 'FileLeaseHeldError';
+        this.code      = 'FILE_LEASE_HELD';
+        this.lockPath  = lockPath;
+        this.holder    = holder;
+        this.requester = requester;
+
+        /**
+         * Whether the recorded holder's `owner` and `pid` are byte-identical to the requester's.
+         *
+         * Strictly the measured comparison — it does NOT assert that the holder is a dead
+         * predecessor, because this frame cannot distinguish that from two live processes with
+         * indistinguishable identities. A consumer wanting that stronger claim must corroborate it
+         * with something this error does not carry, such as restart count or process liveness.
+         * @type {Boolean}
+         */
+        this.holderIdentityMatchesRequester = holderIdentityMatchesRequester;
     }
 }
 

--- a/ai/deploy/docker-compose.yml
+++ b/ai/deploy/docker-compose.yml
@@ -34,10 +34,10 @@ services:
     volumes:
       - chroma-data:/data
     healthcheck:
-      test: ["CMD-SHELL", "bash -c '</dev/tcp/127.0.0.1/8000'"]
-      interval: 10s
-      timeout: 5s
-      retries: 12
+      test        : ["CMD-SHELL", "bash -c '</dev/tcp/127.0.0.1/8000'"]
+      interval    : 10s
+      timeout     : 5s
+      retries     : 12
       start_period: 60s
     networks:
       - neo-mcp-network
@@ -45,11 +45,11 @@ services:
       resources:
         limits:
           memory: 2g
-          cpus: "2.0"
+          cpus  : "2.0"
 
   kb-server:
     build:
-      context: .
+      context   : .
       dockerfile: Dockerfile
       args:
         TARGET_SERVER: knowledge-base
@@ -57,7 +57,7 @@ services:
         # Compose maps it to both internal Docker arguments so source acquisition and
         # the OCI revision assertion cannot disagree. The `:-dev` default preserves
         # the unpinned path without passing an empty ref to `git fetch`.
-        NEO_REF: ${NEO_REVISION:-dev}
+        NEO_REF     : ${NEO_REVISION:-dev}
         NEO_REVISION: ${NEO_REVISION:-}
     environment:
       - NEO_TRANSPORT=streamable-http
@@ -101,25 +101,25 @@ services:
     # self-probe must authenticate too. Ensure NEO_MCP_HEALTHCHECK_TOKEN is present
     # in the container environment; mcpHealthcheck.mjs sends it as a bearer token.
     healthcheck:
-      test: ["CMD", "node", "./ai/scripts/diagnostics/mcpHealthcheck.mjs", "--url", "http://127.0.0.1:3000", "--client-name", "neo-kb-container-healthcheck"]
-      interval: 10s
-      timeout: 10s
-      retries: 12
+      test        : ["CMD", "node", "./ai/scripts/diagnostics/mcpHealthcheck.mjs", "--url", "http://127.0.0.1:3000", "--client-name", "neo-kb-container-healthcheck"]
+      interval    : 10s
+      timeout     : 10s
+      retries     : 12
       start_period: 45s
     deploy:
       resources:
         limits:
           memory: 1g
-          cpus: "1.0"
+          cpus  : "1.0"
 
   mc-server:
     build:
-      context: .
+      context   : .
       dockerfile: Dockerfile
       args:
         TARGET_SERVER: memory-core
         # Cohort invariant (#15774/#16087): every Neo service uses the SAME resolved pin.
-        NEO_REF: ${NEO_REVISION:-dev}
+        NEO_REF     : ${NEO_REVISION:-dev}
         NEO_REVISION: ${NEO_REVISION:-}
     environment:
       - NEO_TRANSPORT=streamable-http
@@ -206,16 +206,16 @@ services:
     # self-probe must authenticate too. Ensure NEO_MCP_HEALTHCHECK_TOKEN is present
     # in the container environment; mcpHealthcheck.mjs sends it as a bearer token.
     healthcheck:
-      test: ["CMD", "node", "./ai/scripts/diagnostics/mcpHealthcheck.mjs", "--url", "http://127.0.0.1:3001", "--client-name", "neo-mc-container-healthcheck"]
-      interval: 10s
-      timeout: 10s
-      retries: 12
+      test        : ["CMD", "node", "./ai/scripts/diagnostics/mcpHealthcheck.mjs", "--url", "http://127.0.0.1:3001", "--client-name", "neo-mc-container-healthcheck"]
+      interval    : 10s
+      timeout     : 10s
+      retries     : 12
       start_period: 45s
     deploy:
       resources:
         limits:
           memory: 1g
-          cpus: "1.0"
+          cpus  : "1.0"
 
   # The Agent OS maintenance orchestrator (ADR 0014 §2.3). Built from the shared
   # image via the generalized `SERVICE_ENTRYPOINT` arg. AiConfig defaults to the
@@ -225,12 +225,12 @@ services:
   # `cloud` profile — started by `docker compose --profile cloud up`.
   orchestrator:
     build:
-      context: .
+      context   : .
       dockerfile: Dockerfile
       args:
         SERVICE_ENTRYPOINT: ai/daemons/orchestrator/daemon.mjs
         # Cohort invariant (#15774/#16087): every Neo service uses the SAME resolved pin.
-        NEO_REF: ${NEO_REVISION:-dev}
+        NEO_REF     : ${NEO_REVISION:-dev}
         NEO_REVISION: ${NEO_REVISION:-}
     environment:
       - *handoff-file-env
@@ -341,10 +341,10 @@ services:
     # minutes; task progress stays observable there without making Docker report daemon
     # death. 90s start_period covers the first-poll latency on cold container boot.
     healthcheck:
-      test: ["CMD", "node", "--input-type=module", "-e", "await import('./src/Neo.mjs');await import('./src/core/_export.mjs');const{default:AiConfig}=await import('./ai/config.mjs');const{inspectAuthorityLease}=await import('./ai/daemons/orchestrator/authorityLease.mjs');try{const{fresh}=inspectAuthorityLease({dir:AiConfig.orchestrator.dataDir,profile:AiConfig.orchestrator.authorityProfile});process.exit(fresh?0:1)}catch{process.exit(1)}"]
-      interval: 60s
-      timeout: 5s
-      retries: 3
+      test        : ["CMD", "node", "--input-type=module", "-e", "await import('./src/Neo.mjs');await import('./src/core/_export.mjs');const{default:AiConfig}=await import('./ai/config.mjs');const{inspectAuthorityLease}=await import('./ai/daemons/orchestrator/authorityLease.mjs');try{const{fresh}=inspectAuthorityLease({dir:AiConfig.orchestrator.dataDir,profile:AiConfig.orchestrator.authorityProfile});process.exit(fresh?0:1)}catch{process.exit(1)}"]
+      interval    : 60s
+      timeout     : 5s
+      retries     : 3
       start_period: 90s
     # Heap ceilings are PER PROCESS, so they are set on the command rather than in `environment`.
     # `ProcessSupervisorService` spawns supervised tasks with `{...process.env}`, so a service-level
@@ -353,13 +353,19 @@ services:
     #
     # The daemon died at ~500 MB of heap, so 1024 is 2x its observed need.
     #
-    # The concurrent-process count is NOT fully established, and the budget below says so rather than
-    # implying precision it does not have. What is known: 20 supervised task keys exist, the
-    # heavy-maintenance lease serialises 11 of them, and the remaining 9 can in principle run
-    # alongside a heavy task. What was observed here is 2 concurrent Node processes and only two task
-    # types ever started — but that observation comes from a plane dying every ~3 minutes, which never
-    # lives long enough to reach steady state, so the hourly and daily tasks have never started at
-    # all. An idle or crash-looping plane cannot show you its maximum.
+    # The concurrent-process count is NOT established, and the budget below says so rather than
+    # implying precision it does not have.
+    #
+    # A previous revision said "20 supervised task keys, 11 lease-serialised, so 9 can run alongside".
+    # That is a TASK-KEY count, not a process count, and the two are not the same: the scheduling
+    # registry distinguishes supervised-child-process, service-runner, in-process-async and
+    # health-check lanes; the pipeline dispatches one winner per poll; and authority profile plus
+    # per-task enablement remove further lanes before anything spawns. Only process-producing paths
+    # surviving those gates count, and that number has not been measured.
+    #
+    # What WAS observed here is 2 concurrent Node processes with two task types ever started — from a
+    # plane dying every ~3 minutes, which never reaches steady state, so hourly and daily tasks had
+    # never started at all. An idle or crash-looping plane cannot show its maximum.
     # `$$SERVER_ENTRYPOINT` is escaped so Compose does NOT interpolate it. It is a CONTAINER env set
     # by the Dockerfile, so config-time interpolation resolves it against the HOST environment, finds
     # nothing, and renders `node --max-old-space-size=1024 ` — a node invocation with no script.
@@ -382,7 +388,7 @@ services:
         # explicit ceilings only make sense together.
         limits:
           memory: 3g
-          cpus: "1.0"
+          cpus  : "1.0"
 
   # Reverse proxy + TLS termination — the public ingress for the cloud Agent OS
   # deployment (Sub C #11724). `ingress` profile — `docker compose --profile
@@ -411,16 +417,16 @@ services:
     # TCP connection, non-zero = caddy crashed. Avoids the wget --quiet + grep
     # silent-success-empty-output failure mode (#11939 cycle-1 review per @neo-gpt).
     healthcheck:
-      test: ["CMD-SHELL", "nc -z 127.0.0.1 443"]
-      interval: 30s
-      timeout: 5s
-      retries: 3
+      test        : ["CMD-SHELL", "nc -z 127.0.0.1 443"]
+      interval    : 30s
+      timeout     : 5s
+      retries     : 3
       start_period: 30s
     deploy:
       resources:
         limits:
           memory: 256m
-          cpus: "0.5"
+          cpus  : "0.5"
 
   # Optional self-hosted model-provider runtime (Post-MVP residual #11734).
   # The service is disabled unless the operator starts `--profile local-model`.
@@ -444,10 +450,10 @@ services:
     expose:
       - "11434"
     healthcheck:
-      test: ["CMD", "ollama", "list"]
-      interval: 30s
-      timeout: 10s
-      retries: 10
+      test        : ["CMD", "ollama", "list"]
+      interval    : 30s
+      timeout     : 10s
+      retries     : 10
       start_period: 60s
     profiles:
       - local-model
@@ -455,7 +461,7 @@ services:
       resources:
         limits:
           memory: "${NEO_LOCAL_MODEL_MEMORY_LIMIT:-32g}"
-          cpus: "${NEO_LOCAL_MODEL_CPU_LIMIT:-4.0}"
+          cpus  : "${NEO_LOCAL_MODEL_CPU_LIMIT:-4.0}"
 
 # kb-server / mc-server stay internal-only (`expose`) on `neo-mcp-network`; the
 # `ingress` profile is the sole public surface. `caddy-data` persists Caddy's

--- a/ai/deploy/docker-compose.yml
+++ b/ai/deploy/docker-compose.yml
@@ -243,13 +243,6 @@ services:
       - NEO_OLLAMA_KEEP_ALIVE=${NEO_OLLAMA_KEEP_ALIVE:-}
       - NEO_OPENAI_COMPATIBLE_KEEP_ALIVE=${NEO_OPENAI_COMPATIBLE_KEEP_ALIVE:-}
       - NEO_CHROMA_HOST=chroma
-      # State the heap ceiling; do not inherit it. Node sizes its default old-space from the cgroup
-      # limit, so at 1g it capped near 512 MB and died there while the container still had headroom
-      # it was never allowed to use — the failure read as a crash loop rather than as pressure.
-      # Held below the container limit on purpose: V8's heap is not the process's whole footprint,
-      # and a ceiling at parity trades a catchable heap error for an uncatchable kernel OOM kill,
-      # which leaves no diagnostic at all.
-      - NODE_OPTIONS=${NEO_ORCHESTRATOR_NODE_OPTIONS:---max-old-space-size=1536}
       # The role is DECLARED, never inherited (#16229). The leaf carries no default, so this line
       # is what makes the containerized Orchestrator startable at all — and stating it here is the
       # point: before the cut, a host `node ai/daemons/orchestrator/daemon.mjs` resolved the same
@@ -346,16 +339,26 @@ services:
       timeout: 5s
       retries: 3
       start_period: 90s
+    # Heap ceilings are PER PROCESS, so they are set on the command rather than in `environment`.
+    # `ProcessSupervisorService` spawns supervised tasks with `{...process.env}`, so a service-level
+    # NODE_OPTIONS is inherited by every child and the container budget is silently multiplied by
+    # the number of concurrent Node processes rather than spent once.
+    #
+    # This container is measured at 2 concurrent Node processes: the daemon at pid 1 plus one
+    # supervised task (the heavy-maintenance lease serialises the 11 heavy tasks, so at most one of
+    # those runs at a time). The daemon died at ~500 MB of heap, so 1024 is 2x its observed need.
+    command: ["sh", "-c", "node --max-old-space-size=${NEO_ORCHESTRATOR_HEAP_MB:-1024} ${SERVER_ENTRYPOINT}"]
     deploy:
       resources:
-        # The control plane supervises every other service and drains both WALs in-process
-        # (NEO_MEMORY_WAL_IN_PROCESS_DRAIN / NEO_MESSAGE_WAL_IN_PROCESS_DRAIN), so its working set
-        # is not comparable to the servers it supervises. At 1g it died of heap exhaustion 949
-        # times on the maintainer plane, each run surviving ~3 minutes; the crash surfaced as an
-        # authority-lease refusal, because a restart inside the 60s lease TTL is refused as a
-        # duplicate of its own dead predecessor.
+        # Budget, stated rather than inherited: parent 1024 + one supervised child 512 = 1536 MB of
+        # V8, leaving ~1.5g for native footprint across the tree and a third process appearing.
+        #
+        # The container limit cannot be raised on its own. Node sizes its DEFAULT old-space from the
+        # cgroup, so a bigger container silently raises the implicit ceiling of every child that has
+        # no explicit one — which is the same leak in a different direction. The limit and both
+        # explicit ceilings only make sense together.
         limits:
-          memory: 2g
+          memory: 3g
           cpus: "1.0"
 
   # Reverse proxy + TLS termination — the public ingress for the cloud Agent OS

--- a/ai/deploy/docker-compose.yml
+++ b/ai/deploy/docker-compose.yml
@@ -243,6 +243,13 @@ services:
       - NEO_OLLAMA_KEEP_ALIVE=${NEO_OLLAMA_KEEP_ALIVE:-}
       - NEO_OPENAI_COMPATIBLE_KEEP_ALIVE=${NEO_OPENAI_COMPATIBLE_KEEP_ALIVE:-}
       - NEO_CHROMA_HOST=chroma
+      # The child heap ceiling needs a WRITER here, not just a reader in the service: without this
+      # line the deployment override is unreachable — the parent knob renders while this one stays
+      # null, so the "explicit ceiling per child" claim would hold in code and not in deployment.
+      # Empty default keeps the leaf's own default authoritative; a non-positive value fails closed
+      # in the leaf's parse hook rather than reaching Node, which would accept the flag, exit 0, and
+      # continue with a heap larger than the cgroup.
+      - NEO_SUPERVISED_TASK_HEAP_MB=${NEO_SUPERVISED_TASK_HEAP_MB:-}
       # The role is DECLARED, never inherited (#16229). The leaf carries no default, so this line
       # is what makes the containerized Orchestrator startable at all — and stating it here is the
       # point: before the cut, a host `node ai/daemons/orchestrator/daemon.mjs` resolved the same

--- a/ai/deploy/docker-compose.yml
+++ b/ai/deploy/docker-compose.yml
@@ -34,10 +34,10 @@ services:
     volumes:
       - chroma-data:/data
     healthcheck:
-      test        : ["CMD-SHELL", "bash -c '</dev/tcp/127.0.0.1/8000'"]
-      interval    : 10s
-      timeout     : 5s
-      retries     : 12
+      test: ["CMD-SHELL", "bash -c '</dev/tcp/127.0.0.1/8000'"]
+      interval: 10s
+      timeout: 5s
+      retries: 12
       start_period: 60s
     networks:
       - neo-mcp-network
@@ -45,11 +45,11 @@ services:
       resources:
         limits:
           memory: 2g
-          cpus  : "2.0"
+          cpus: "2.0"
 
   kb-server:
     build:
-      context   : .
+      context: .
       dockerfile: Dockerfile
       args:
         TARGET_SERVER: knowledge-base
@@ -57,7 +57,7 @@ services:
         # Compose maps it to both internal Docker arguments so source acquisition and
         # the OCI revision assertion cannot disagree. The `:-dev` default preserves
         # the unpinned path without passing an empty ref to `git fetch`.
-        NEO_REF     : ${NEO_REVISION:-dev}
+        NEO_REF: ${NEO_REVISION:-dev}
         NEO_REVISION: ${NEO_REVISION:-}
     environment:
       - NEO_TRANSPORT=streamable-http
@@ -101,25 +101,25 @@ services:
     # self-probe must authenticate too. Ensure NEO_MCP_HEALTHCHECK_TOKEN is present
     # in the container environment; mcpHealthcheck.mjs sends it as a bearer token.
     healthcheck:
-      test        : ["CMD", "node", "./ai/scripts/diagnostics/mcpHealthcheck.mjs", "--url", "http://127.0.0.1:3000", "--client-name", "neo-kb-container-healthcheck"]
-      interval    : 10s
-      timeout     : 10s
-      retries     : 12
+      test: ["CMD", "node", "./ai/scripts/diagnostics/mcpHealthcheck.mjs", "--url", "http://127.0.0.1:3000", "--client-name", "neo-kb-container-healthcheck"]
+      interval: 10s
+      timeout: 10s
+      retries: 12
       start_period: 45s
     deploy:
       resources:
         limits:
           memory: 1g
-          cpus  : "1.0"
+          cpus: "1.0"
 
   mc-server:
     build:
-      context   : .
+      context: .
       dockerfile: Dockerfile
       args:
         TARGET_SERVER: memory-core
         # Cohort invariant (#15774/#16087): every Neo service uses the SAME resolved pin.
-        NEO_REF     : ${NEO_REVISION:-dev}
+        NEO_REF: ${NEO_REVISION:-dev}
         NEO_REVISION: ${NEO_REVISION:-}
     environment:
       - NEO_TRANSPORT=streamable-http
@@ -206,16 +206,16 @@ services:
     # self-probe must authenticate too. Ensure NEO_MCP_HEALTHCHECK_TOKEN is present
     # in the container environment; mcpHealthcheck.mjs sends it as a bearer token.
     healthcheck:
-      test        : ["CMD", "node", "./ai/scripts/diagnostics/mcpHealthcheck.mjs", "--url", "http://127.0.0.1:3001", "--client-name", "neo-mc-container-healthcheck"]
-      interval    : 10s
-      timeout     : 10s
-      retries     : 12
+      test: ["CMD", "node", "./ai/scripts/diagnostics/mcpHealthcheck.mjs", "--url", "http://127.0.0.1:3001", "--client-name", "neo-mc-container-healthcheck"]
+      interval: 10s
+      timeout: 10s
+      retries: 12
       start_period: 45s
     deploy:
       resources:
         limits:
           memory: 1g
-          cpus  : "1.0"
+          cpus: "1.0"
 
   # The Agent OS maintenance orchestrator (ADR 0014 §2.3). Built from the shared
   # image via the generalized `SERVICE_ENTRYPOINT` arg. AiConfig defaults to the
@@ -225,12 +225,12 @@ services:
   # `cloud` profile — started by `docker compose --profile cloud up`.
   orchestrator:
     build:
-      context   : .
+      context: .
       dockerfile: Dockerfile
       args:
         SERVICE_ENTRYPOINT: ai/daemons/orchestrator/daemon.mjs
         # Cohort invariant (#15774/#16087): every Neo service uses the SAME resolved pin.
-        NEO_REF     : ${NEO_REVISION:-dev}
+        NEO_REF: ${NEO_REVISION:-dev}
         NEO_REVISION: ${NEO_REVISION:-}
     environment:
       - *handoff-file-env
@@ -341,10 +341,10 @@ services:
     # minutes; task progress stays observable there without making Docker report daemon
     # death. 90s start_period covers the first-poll latency on cold container boot.
     healthcheck:
-      test        : ["CMD", "node", "--input-type=module", "-e", "await import('./src/Neo.mjs');await import('./src/core/_export.mjs');const{default:AiConfig}=await import('./ai/config.mjs');const{inspectAuthorityLease}=await import('./ai/daemons/orchestrator/authorityLease.mjs');try{const{fresh}=inspectAuthorityLease({dir:AiConfig.orchestrator.dataDir,profile:AiConfig.orchestrator.authorityProfile});process.exit(fresh?0:1)}catch{process.exit(1)}"]
-      interval    : 60s
-      timeout     : 5s
-      retries     : 3
+      test: ["CMD", "node", "--input-type=module", "-e", "await import('./src/Neo.mjs');await import('./src/core/_export.mjs');const{default:AiConfig}=await import('./ai/config.mjs');const{inspectAuthorityLease}=await import('./ai/daemons/orchestrator/authorityLease.mjs');try{const{fresh}=inspectAuthorityLease({dir:AiConfig.orchestrator.dataDir,profile:AiConfig.orchestrator.authorityProfile});process.exit(fresh?0:1)}catch{process.exit(1)}"]
+      interval: 60s
+      timeout: 5s
+      retries: 3
       start_period: 90s
     # Heap ceilings are PER PROCESS, so they are set on the command rather than in `environment`.
     # `ProcessSupervisorService` spawns supervised tasks with `{...process.env}`, so a service-level
@@ -354,18 +354,11 @@ services:
     # The daemon died at ~500 MB of heap, so 1024 is 2x its observed need.
     #
     # The concurrent-process count is NOT established, and the budget below says so rather than
-    # implying precision it does not have.
+    # implying precision it does not have. What WAS observed here is 2 concurrent Node processes
+    # with two task types ever started — from a plane dying every ~3 minutes, which never reaches
+    # steady state, so hourly and daily tasks had never started at all. An idle or crash-looping
+    # plane cannot show its maximum. #16463 owns measuring it.
     #
-    # A previous revision said "20 supervised task keys, 11 lease-serialised, so 9 can run alongside".
-    # That is a TASK-KEY count, not a process count, and the two are not the same: the scheduling
-    # registry distinguishes supervised-child-process, service-runner, in-process-async and
-    # health-check lanes; the pipeline dispatches one winner per poll; and authority profile plus
-    # per-task enablement remove further lanes before anything spawns. Only process-producing paths
-    # surviving those gates count, and that number has not been measured.
-    #
-    # What WAS observed here is 2 concurrent Node processes with two task types ever started — from a
-    # plane dying every ~3 minutes, which never reaches steady state, so hourly and daily tasks had
-    # never started at all. An idle or crash-looping plane cannot show its maximum.
     # `$$SERVER_ENTRYPOINT` is escaped so Compose does NOT interpolate it. It is a CONTAINER env set
     # by the Dockerfile, so config-time interpolation resolves it against the HOST environment, finds
     # nothing, and renders `node --max-old-space-size=1024 ` — a node invocation with no script.
@@ -388,7 +381,7 @@ services:
         # explicit ceilings only make sense together.
         limits:
           memory: 3g
-          cpus  : "1.0"
+          cpus: "1.0"
 
   # Reverse proxy + TLS termination — the public ingress for the cloud Agent OS
   # deployment (Sub C #11724). `ingress` profile — `docker compose --profile
@@ -417,16 +410,16 @@ services:
     # TCP connection, non-zero = caddy crashed. Avoids the wget --quiet + grep
     # silent-success-empty-output failure mode (#11939 cycle-1 review per @neo-gpt).
     healthcheck:
-      test        : ["CMD-SHELL", "nc -z 127.0.0.1 443"]
-      interval    : 30s
-      timeout     : 5s
-      retries     : 3
+      test: ["CMD-SHELL", "nc -z 127.0.0.1 443"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
       start_period: 30s
     deploy:
       resources:
         limits:
           memory: 256m
-          cpus  : "0.5"
+          cpus: "0.5"
 
   # Optional self-hosted model-provider runtime (Post-MVP residual #11734).
   # The service is disabled unless the operator starts `--profile local-model`.
@@ -450,10 +443,10 @@ services:
     expose:
       - "11434"
     healthcheck:
-      test        : ["CMD", "ollama", "list"]
-      interval    : 30s
-      timeout     : 10s
-      retries     : 10
+      test: ["CMD", "ollama", "list"]
+      interval: 30s
+      timeout: 10s
+      retries: 10
       start_period: 60s
     profiles:
       - local-model
@@ -461,7 +454,7 @@ services:
       resources:
         limits:
           memory: "${NEO_LOCAL_MODEL_MEMORY_LIMIT:-32g}"
-          cpus  : "${NEO_LOCAL_MODEL_CPU_LIMIT:-4.0}"
+          cpus: "${NEO_LOCAL_MODEL_CPU_LIMIT:-4.0}"
 
 # kb-server / mc-server stay internal-only (`expose`) on `neo-mcp-network`; the
 # `ingress` profile is the sole public surface. `caddy-data` persists Caddy's

--- a/ai/deploy/docker-compose.yml
+++ b/ai/deploy/docker-compose.yml
@@ -344,14 +344,30 @@ services:
     # NODE_OPTIONS is inherited by every child and the container budget is silently multiplied by
     # the number of concurrent Node processes rather than spent once.
     #
-    # This container is measured at 2 concurrent Node processes: the daemon at pid 1 plus one
-    # supervised task (the heavy-maintenance lease serialises the 11 heavy tasks, so at most one of
-    # those runs at a time). The daemon died at ~500 MB of heap, so 1024 is 2x its observed need.
-    command: ["sh", "-c", "node --max-old-space-size=${NEO_ORCHESTRATOR_HEAP_MB:-1024} ${SERVER_ENTRYPOINT}"]
+    # The daemon died at ~500 MB of heap, so 1024 is 2x its observed need.
+    #
+    # The concurrent-process count is NOT fully established, and the budget below says so rather than
+    # implying precision it does not have. What is known: 20 supervised task keys exist, the
+    # heavy-maintenance lease serialises 11 of them, and the remaining 9 can in principle run
+    # alongside a heavy task. What was observed here is 2 concurrent Node processes and only two task
+    # types ever started — but that observation comes from a plane dying every ~3 minutes, which never
+    # lives long enough to reach steady state, so the hourly and daily tasks have never started at
+    # all. An idle or crash-looping plane cannot show you its maximum.
+    # `$$SERVER_ENTRYPOINT` is escaped so Compose does NOT interpolate it. It is a CONTAINER env set
+    # by the Dockerfile, so config-time interpolation resolves it against the HOST environment, finds
+    # nothing, and renders `node --max-old-space-size=1024 ` — a node invocation with no script.
+    # `docker compose config` reports that as a warning and still exits 0, so an exit-code check
+    # passes while the rendered command is broken. `$$` defers expansion to the container's own sh.
+    # `${NEO_ORCHESTRATOR_HEAP_MB}` is deliberately NOT escaped: it is a deployment override and is
+    # meant to resolve from the operator's environment at config time.
+    command: ["sh", "-c", "node --max-old-space-size=${NEO_ORCHESTRATOR_HEAP_MB:-1024} \"$$SERVER_ENTRYPOINT\""]
     deploy:
       resources:
-        # Budget, stated rather than inherited: parent 1024 + one supervised child 512 = 1536 MB of
-        # V8, leaving ~1.5g for native footprint across the tree and a third process appearing.
+        # Budget, stated rather than inherited: parent 1024 + up to TWO concurrent children at 384 =
+        # 1792 MB of V8, leaving ~1.2g for native footprint across the tree. Deliberately provisional
+        # — the true concurrent maximum cannot be observed until the plane survives long enough to
+        # reach steady state, and establishing it is a gate on #16463 rather than a number guessed
+        # here. If it proves higher, the child ceiling comes down before the limit goes up.
         #
         # The container limit cannot be raised on its own. Node sizes its DEFAULT old-space from the
         # cgroup, so a bigger container silently raises the implicit ceiling of every child that has

--- a/ai/deploy/docker-compose.yml
+++ b/ai/deploy/docker-compose.yml
@@ -243,6 +243,13 @@ services:
       - NEO_OLLAMA_KEEP_ALIVE=${NEO_OLLAMA_KEEP_ALIVE:-}
       - NEO_OPENAI_COMPATIBLE_KEEP_ALIVE=${NEO_OPENAI_COMPATIBLE_KEEP_ALIVE:-}
       - NEO_CHROMA_HOST=chroma
+      # State the heap ceiling; do not inherit it. Node sizes its default old-space from the cgroup
+      # limit, so at 1g it capped near 512 MB and died there while the container still had headroom
+      # it was never allowed to use — the failure read as a crash loop rather than as pressure.
+      # Held below the container limit on purpose: V8's heap is not the process's whole footprint,
+      # and a ceiling at parity trades a catchable heap error for an uncatchable kernel OOM kill,
+      # which leaves no diagnostic at all.
+      - NODE_OPTIONS=${NEO_ORCHESTRATOR_NODE_OPTIONS:---max-old-space-size=1536}
       # The role is DECLARED, never inherited (#16229). The leaf carries no default, so this line
       # is what makes the containerized Orchestrator startable at all — and stating it here is the
       # point: before the cut, a host `node ai/daemons/orchestrator/daemon.mjs` resolved the same
@@ -341,8 +348,14 @@ services:
       start_period: 90s
     deploy:
       resources:
+        # The control plane supervises every other service and drains both WALs in-process
+        # (NEO_MEMORY_WAL_IN_PROCESS_DRAIN / NEO_MESSAGE_WAL_IN_PROCESS_DRAIN), so its working set
+        # is not comparable to the servers it supervises. At 1g it died of heap exhaustion 949
+        # times on the maintainer plane, each run surviving ~3 minutes; the crash surfaced as an
+        # authority-lease refusal, because a restart inside the 60s lease TTL is refused as a
+        # duplicate of its own dead predecessor.
         limits:
-          memory: 1g
+          memory: 2g
           cpus: "1.0"
 
   # Reverse proxy + TLS termination — the public ingress for the cloud Agent OS

--- a/ai/scripts/lint/config-leaf-parity.json
+++ b/ai/scripts/lint/config-leaf-parity.json
@@ -43,7 +43,7 @@
         "census": {
             "profile": "ai/deploy/docker-compose.yml",
             "baselineUniqueKeys": 45,
-            "remainingUniqueKeys": 30,
+            "remainingUniqueKeys": 31,
             "requiredDeploymentInputs": [
                 "NEO_AI_ORCHESTRATOR_AUTHORITY_PROFILE",
                 "NEO_BACKUP_PATH",
@@ -74,7 +74,8 @@
                 "NEO_OPENAI_COMPATIBLE_EMBEDDING_MODEL",
                 "NEO_OPENAI_COMPATIBLE_HOST",
                 "NEO_OPENAI_COMPATIBLE_KEEP_ALIVE",
-                "NEO_OPENAI_COMPATIBLE_MODEL"
+                "NEO_OPENAI_COMPATIBLE_MODEL",
+                "NEO_SUPERVISED_TASK_HEAP_MB"
             ],
             "secrets": [
                 "NEO_KB_ASK_API_KEY",
@@ -332,6 +333,7 @@
         "orchestrator.recoveryActuator.systemicCircuit.systemicThreshold",
         "orchestrator.recoveryActuator.systemicCircuit.windowMs",
         "orchestrator.recoveryActuator.verifyCooldownMs",
+        "orchestrator.supervisedTaskHeapMb",
         "orchestrator.swarmHeartbeat",
         "orchestrator.swarmHeartbeat.allIdleIdentities",
         "orchestrator.swarmHeartbeat.idleThresholdMs",

--- a/test/playwright/unit/ai/daemons/orchestrator/services/ProcessSupervisorService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/ProcessSupervisorService.spec.mjs
@@ -3,7 +3,7 @@ import fs                           from 'fs-extra';
 import path                         from 'path';
 import Neo                          from '../../../../../../../src/Neo.mjs';
 import * as core                    from '../../../../../../../src/core/_export.mjs';
-import { ProcessSupervisorService } from '../../../../../../../ai/daemons/orchestrator/services/ProcessSupervisorService.mjs';
+import { buildSupervisedTaskEnv, ProcessSupervisorService } from '../../../../../../../ai/daemons/orchestrator/services/ProcessSupervisorService.mjs';
 
 function createTestService() {
     const dataDir = `/tmp/process-supervisor-service-test-${Date.now()}-${Math.random()}`;
@@ -1115,5 +1115,74 @@ test.describe('Neo.ai.daemons.services.ProcessSupervisorService', () => {
         await new Promise(resolve => setTimeout(resolve, 0));
 
         expect(killed).toEqual([]);
+    });
+});
+
+test.describe('#16459 — the parent/child heap boundary', () => {
+    /**
+     * The defect this pins: a container memory limit budgets the whole process tree, but a V8 heap
+     * ceiling is per process. Children are spawned with `{...process.env}`, so a ceiling set once at
+     * the service level is silently re-spent by every concurrent child. Measured on the maintainer
+     * plane: 2 concurrent Node processes in the orchestrator container, the child larger than the
+     * parent.
+     */
+    test('a child never inherits the parent heap ceiling — it receives its own', () => {
+        const env = buildSupervisedTaskEnv({
+            baseEnv: {NODE_OPTIONS: '--max-old-space-size=1024', PATH: '/usr/bin'}
+        });
+
+        expect(env.NODE_OPTIONS).toBe('--max-old-space-size=512');
+        expect(env.NODE_OPTIONS).not.toContain('1024');
+        expect(env.PATH).toBe('/usr/bin');
+    });
+
+    /**
+     * The inverse leak, and why sizing the container alone cannot fix this: with no explicit ceiling
+     * Node derives its default old-space from the cgroup, so raising the container limit raises every
+     * unbounded child's implicit ceiling too. An unbounded child must not exist.
+     */
+    test('a child with no inherited ceiling still gets an explicit one', () => {
+        const env = buildSupervisedTaskEnv({baseEnv: {PATH: '/usr/bin'}});
+
+        expect(env.NODE_OPTIONS).toBe('--max-old-space-size=512');
+    });
+
+    test('a task that declares its own ceiling keeps it — the definition is not overridden', () => {
+        const env = buildSupervisedTaskEnv({
+            baseEnv: {NODE_OPTIONS: '--max-old-space-size=1024'},
+            taskEnv: {NODE_OPTIONS: '--max-old-space-size=2048'}
+        });
+
+        expect(env.NODE_OPTIONS).toBe('--max-old-space-size=2048');
+    });
+
+    test('a call-site ceiling is narrowest and wins over the task definition', () => {
+        const env = buildSupervisedTaskEnv({
+            baseEnv  : {NODE_OPTIONS: '--max-old-space-size=1024'},
+            taskEnv  : {NODE_OPTIONS: '--max-old-space-size=2048'},
+            callerEnv: {NODE_OPTIONS: '--max-old-space-size=256'}
+        });
+
+        expect(env.NODE_OPTIONS).toBe('--max-old-space-size=256');
+    });
+
+    test('the child ceiling is deployment-overridable without touching code', () => {
+        const env = buildSupervisedTaskEnv({
+            baseEnv: {NEO_SUPERVISED_TASK_HEAP_MB: '768'}
+        });
+
+        expect(env.NODE_OPTIONS).toBe('--max-old-space-size=768');
+    });
+
+    test('non-NODE_OPTIONS task and caller env still merge normally', () => {
+        const env = buildSupervisedTaskEnv({
+            baseEnv  : {PATH: '/usr/bin', KEEP: 'base'},
+            taskEnv  : {TASK_ONLY: 'yes'},
+            callerEnv: {CALLER_ONLY: 'yes'}
+        });
+
+        expect(env.KEEP).toBe('base');
+        expect(env.TASK_ONLY).toBe('yes');
+        expect(env.CALLER_ONLY).toBe('yes');
     });
 });

--- a/test/playwright/unit/ai/daemons/orchestrator/services/ProcessSupervisorService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/ProcessSupervisorService.spec.mjs
@@ -1166,10 +1166,21 @@ test.describe('#16459 — the parent/child heap boundary', () => {
         expect(env.NODE_OPTIONS).toBe('--max-old-space-size=256');
     });
 
-    test('the child ceiling is deployment-overridable without touching code', () => {
-        const env = buildSupervisedTaskEnv({
-            baseEnv: {NEO_SUPERVISED_TASK_HEAP_MB: '768'}
-        });
+    /**
+     * The deployment override resolves through the AiConfig leaf and is INJECTED. This helper must
+     * not read the env var itself: doing so is the A1 antipattern, and the hand-rolled
+     * `Number(env) || 384` it replaced also accepted `-1`, which Node turns into a heap LARGER than
+     * the cgroup after reporting the flag out of bounds and exiting 0.
+     */
+    test('the helper ignores the env var — that resolution belongs to the leaf', () => {
+        const env = buildSupervisedTaskEnv({baseEnv: {NEO_SUPERVISED_TASK_HEAP_MB: '768'}});
+
+        expect(env.NODE_OPTIONS).toBe('--max-old-space-size=384');
+        expect(env.NODE_OPTIONS).not.toContain('768');
+    });
+
+    test('the injected resolved ceiling is what applies', () => {
+        const env = buildSupervisedTaskEnv({defaultHeapMb: 768});
 
         expect(env.NODE_OPTIONS).toBe('--max-old-space-size=768');
     });

--- a/test/playwright/unit/ai/daemons/orchestrator/services/ProcessSupervisorService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/ProcessSupervisorService.spec.mjs
@@ -1131,7 +1131,7 @@ test.describe('#16459 — the parent/child heap boundary', () => {
             baseEnv: {NODE_OPTIONS: '--max-old-space-size=1024', PATH: '/usr/bin'}
         });
 
-        expect(env.NODE_OPTIONS).toBe('--max-old-space-size=512');
+        expect(env.NODE_OPTIONS).toBe('--max-old-space-size=384');
         expect(env.NODE_OPTIONS).not.toContain('1024');
         expect(env.PATH).toBe('/usr/bin');
     });
@@ -1144,7 +1144,7 @@ test.describe('#16459 — the parent/child heap boundary', () => {
     test('a child with no inherited ceiling still gets an explicit one', () => {
         const env = buildSupervisedTaskEnv({baseEnv: {PATH: '/usr/bin'}});
 
-        expect(env.NODE_OPTIONS).toBe('--max-old-space-size=512');
+        expect(env.NODE_OPTIONS).toBe('--max-old-space-size=384');
     });
 
     test('a task that declares its own ceiling keeps it — the definition is not overridden', () => {

--- a/test/playwright/unit/ai/daemons/shared/fileLease.spec.mjs
+++ b/test/playwright/unit/ai/daemons/shared/fileLease.spec.mjs
@@ -330,7 +330,7 @@ test.describe('#16230 — file lease: claim, refuse, reclaim, release (TTL-liven
      * past above it. Containers make this the common case: hostname is the container id and the
      * entrypoint is always pid 1, so every restart reproduces the previous identity exactly.
      */
-    test('#16459 — an identical holder identity reads as self-succession, not as a duplicate to stop', () => {
+    test('#16459 — an identical holder identity reports the identity match instead of telling you to stop a duplicate', () => {
         const holder = {owner: 'orchestrator@21ccb536bbb9', pid: 1, startedAt: '2026-08-03T18:09:24.177Z'},
               error  = new FileLeaseHeldError({
                   holder,
@@ -340,8 +340,8 @@ test.describe('#16230 — file lease: claim, refuse, reclaim, release (TTL-liven
                   requester  : {owner: 'orchestrator@21ccb536bbb9', pid: 1}
               });
 
-        expect(error.selfSuccession).toBe(true);
-        expect(error.message).toMatch(/your own previous instance/);
+        expect(error.holderIdentityMatchesRequester).toBe(true);
+        expect(error.message).toMatch(/may be your own previous instance/);
         expect(error.message).not.toMatch(/stop the duplicate/);
     });
 
@@ -354,12 +354,12 @@ test.describe('#16230 — file lease: claim, refuse, reclaim, release (TTL-liven
             requester  : {owner: 'orchestrator@other-host', pid: 4711}
         });
 
-        expect(error.selfSuccession).toBe(false);
+        expect(error.holderIdentityMatchesRequester).toBe(false);
         expect(error.message).toMatch(/stop the duplicate/);
-        expect(error.message).not.toMatch(/your own previous instance/);
+        expect(error.message).not.toMatch(/may be your own previous instance/);
     });
 
-    test('#16459 — an unverifiable holder is never mistaken for self-succession', () => {
+    test('#16459 — an unverifiable holder never reports an identity match', () => {
         const error = new FileLeaseHeldError({
             holder     : null,
             lockLabel  : 'authority',
@@ -368,7 +368,7 @@ test.describe('#16230 — file lease: claim, refuse, reclaim, release (TTL-liven
             requester  : {owner: 'orchestrator@21ccb536bbb9', pid: 1}
         });
 
-        expect(error.selfSuccession).toBe(false);
+        expect(error.holderIdentityMatchesRequester).toBe(false);
         expect(error.message).toMatch(/unverifiable holder/);
     });
 });

--- a/test/playwright/unit/ai/daemons/shared/fileLease.spec.mjs
+++ b/test/playwright/unit/ai/daemons/shared/fileLease.spec.mjs
@@ -321,4 +321,54 @@ test.describe('#16230 — file lease: claim, refuse, reclaim, release (TTL-liven
         fs.removeSync(guardDir);
         handle.release();
     });
+
+    /**
+     * A refusal whose holder identity is byte-identical to the requester's is self-succession: the
+     * same slot restarted inside the freshness window and is refused against its own predecessor.
+     * The refusal is correct; the "stop the duplicate" remediation is not, and it sent an operator
+     * hunting for a second process that did not exist while the real cause — a crash loop — scrolled
+     * past above it. Containers make this the common case: hostname is the container id and the
+     * entrypoint is always pid 1, so every restart reproduces the previous identity exactly.
+     */
+    test('#16459 — an identical holder identity reads as self-succession, not as a duplicate to stop', () => {
+        const holder = {owner: 'orchestrator@21ccb536bbb9', pid: 1, startedAt: '2026-08-03T18:09:24.177Z'},
+              error  = new FileLeaseHeldError({
+                  holder,
+                  lockLabel  : 'authority',
+                  lockPath   : '/x/.authority-lease-container-plane',
+                  remediation: 'stop the duplicate.',
+                  requester  : {owner: 'orchestrator@21ccb536bbb9', pid: 1}
+              });
+
+        expect(error.selfSuccession).toBe(true);
+        expect(error.message).toMatch(/your own previous instance/);
+        expect(error.message).not.toMatch(/stop the duplicate/);
+    });
+
+    test('#16459 — a genuinely different holder keeps the caller remediation intact', () => {
+        const error = new FileLeaseHeldError({
+            holder     : {owner: 'orchestrator@21ccb536bbb9', pid: 1, startedAt: '2026-08-03T18:09:24.177Z'},
+            lockLabel  : 'authority',
+            lockPath   : '/x/.authority-lease-container-plane',
+            remediation: 'stop the duplicate.',
+            requester  : {owner: 'orchestrator@other-host', pid: 4711}
+        });
+
+        expect(error.selfSuccession).toBe(false);
+        expect(error.message).toMatch(/stop the duplicate/);
+        expect(error.message).not.toMatch(/your own previous instance/);
+    });
+
+    test('#16459 — an unverifiable holder is never mistaken for self-succession', () => {
+        const error = new FileLeaseHeldError({
+            holder     : null,
+            lockLabel  : 'authority',
+            lockPath   : '/x/.authority-lease-container-plane',
+            remediation: 'stop the duplicate.',
+            requester  : {owner: 'orchestrator@21ccb536bbb9', pid: 1}
+        });
+
+        expect(error.selfSuccession).toBe(false);
+        expect(error.message).toMatch(/unverifiable holder/);
+    });
 });


### PR DESCRIPTION
Resolves #16459

## What this fixes

The container-plane orchestrator had **restarted 949 times** on the maintainer plane. Everything it owns — Dream, summaries, tenant-repo sync, heal actuation, scheduled maintenance — has been running at whatever duty cycle survives that.

```
RestartCount=949   State=restarting
FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of memory
  222742 ms: Mark-Compact 501.9 (531.2) -> 474.7 (519.7) MB  (average mu = 0.324)
```

It died at **~500 MB inside a 1g container**, after ~160–220s, with GC mark-utilisation collapsing toward zero — the shape of a process spending its last seconds in back-to-back compaction. No `NODE_OPTIONS` was set, so Node sized its default old-space from the cgroup limit and capped near half of it, while the container still had headroom it was never allowed to use.

## Why the logs looked like a lease bug

A `docker logs` tail shows `FileLeaseHeldError` on a loop, because a restart inside the 60s authority-lease TTL is refused as a duplicate of **its own dead predecessor**. The OOM scrolls past above it.

Two earlier readings of this incident — a pid-probe false positive, then a permanent self-deadlock — were both wrong. The lease descriptor's own `lastPulse` progression falsified them:

```json
{"pid":1,"owner":"orchestrator@21ccb536bbb9","startedAt":"18:09:24.177Z","lastPulse":"18:11:53.465Z"}
```

149s of live pulsing means it *does* start and *does* hold the lease, then dies of something else. `#16230`'s TTL-not-pid liveness is correct and is untouched here.

## Deltas

### Cycle 2 — @neo-gpt-emmy falsified cycle 1's premise, and she was right

A live census found **two concurrent Node processes**, the child larger than the parent:

```
PID  PPID  RSS   ARGS
  1     0  188m  node ai/daemons/orchestrator/daemon.mjs
 20     1  267m  node /app/ai/scripts/lifecycle/summarize-sessions.mjs
```

`ProcessSupervisorService:589` spawns supervised tasks with `{...process.env}`, so cycle 1's service-level `NODE_OPTIONS` was inherited by all **8** spawned task types. A container-level ceiling is not spent once — it is re-spent per concurrent child. 1536 in a 2g cgroup was up to 3g of V8: **the uncatchable kernel OOM kill that same commit claimed to be avoiding.**

The inverse leak is why sizing the container alone cannot fix it: with no explicit ceiling Node derives its default old-space from the cgroup, so raising the limit silently raises every unbounded child's implicit ceiling. Explicit-per-process is the only arrangement where the limit and the ceilings can be reasoned about together.

**`ai/deploy/docker-compose.yml`**
- Parent ceiling moves from `environment` to `command:` — reaches pid 1 only. `NEO_ORCHESTRATOR_HEAP_MB`, default 1024 (it died at ~500).
- `memory: 1g → 3g`, stated against an aggregate budget: parent 1024 + up to two supervised children at 384, the heavy-maintenance lease serialising the 11 heavy tasks so at most one runs at a time.

**`ai/daemons/orchestrator/services/ProcessSupervisorService.mjs`**
- `buildSupervisedTaskEnv()` gives every child an explicit ceiling — 384 default via an AiConfig leaf, `NEO_SUPERVISED_TASK_HEAP_MB` per deployment, `task.env` per task, call-site narrowest. A task declaring its own is never overridden, or the task definition would be a lie.

### Two claims folded back to measured reality

- **"The orchestrator drains both WALs in-process" was FALSE.** `IN_PROCESS_DRAIN` is read by `ai/daemons/embed/` and `ai/daemons/message/`; **zero** references under `ai/daemons/orchestrator/`. I inferred a mechanism from env keys present in the orchestrator's Compose environment rather than from a reader — the same error class as reading a lint rule as a runtime contract. Removed from the code comment, the ticket and this body rather than reworded.
- **`selfSuccession` → `holderIdentityMatchesRequester`.** The old name asserted a causal story this frame cannot establish: two live processes with indistinguishable identities produce the same observation. Now strictly the measured comparison, JSDoc'd as such, and the guidance softened from "this is" to "this may be".

**`ai/daemons/shared/fileLease.mjs`** — `FileLeaseHeldError` compares holder to requester and, on a match, replaces "stop the duplicate" with guidance that fits the actual situation. That remediation sent an operator hunting for a process that did not exist while the loop's real cause scrolled past above it. A genuinely different holder keeps the caller's wording; an unverifiable holder never reports a match.

Containers make the identity match the common case: hostname is the container id and the entrypoint is always pid 1, so every restart reproduces the previous identity exactly — which is also why the message reports the measurement and lets the reader draw the conclusion.

## Test Evidence

**Evidence ladder: achieved L2** (unit + config render on the exact head). The close target's L4 residual — recreate survival and the bounded-vs-leak verdict — is **transferred to #16463**, not deferred inside this ticket, because a PR must not auto-close the only owner of a residual it has not delivered.

Evidence: `UNIT_TEST_MODE=true npx playwright test …/ProcessSupervisorService.spec.mjs …/fileLease.spec.mjs` — **72/72 green**, 9 added. 6 pin the parent/child heap boundary: a child never inherits the parent ceiling, an unbounded child cannot exist, task and call-site precedence, and deployment override. 3 on the lease:
- an identical holder identity reads as self-succession and drops "stop the duplicate"
- a genuinely different holder keeps the caller remediation intact
- an unverifiable holder is never mistaken for self-succession

Evidence: `docker compose -f docker-compose.yml -f docker-compose.local-agent-os.yml config` parses clean.

Evidence: `npm run ai:lint-config-template-ssot` green — `NODE_OPTIONS` sits outside the `NEO_`/`MCP_` census filter, so compose↔census parity is unaffected.

Evidence: root cause read from the live plane, not inferred — `RestartCount=949`, the fatal heap errors, the lease descriptor above, `HostConfig.Memory=1073741824`, and the absent `NODE_OPTIONS`.

## Cycle 3 — @neo-gpt-emmy's findings, all of which stood

Two were safety holes I created.

**ADR-0019 violation (A1).** `Number(baseEnv?.NEO_SUPERVISED_TASK_HEAP_MB) || 384` inside the service re-implements the leaf's own env layer — the ADR calls that *"the fingerprint of not understanding `leaf()`"*. I added an env reader under `ai/` without reading the ADR the turn-loaded gate requires unconditionally. Now `orchestrator.supervisedTaskHeapMb` is a leaf, the Orchestrator reads it at its use site and injects across the narrow construction seam, and the service reads no environment.

**Fail-closed.** `Number(v) || 384` accepted **`-1`**. Node then reports the flag out of bounds, **exits 0**, and continues with a ~4.5 GB heap limit — *above* the 3 GiB cgroup. The invalid value produced a **larger** ceiling than the valid one, converting a catchable heap error into the uncatchable kernel OOM kill this PR exists to avoid. A `metadata.parse` hook now refuses any non-positive non-integer: unset → 384, `512` → 512, `-1` and `abc` → refuse.

Writing that parser I had its signature backwards — it receives the env var *name* and reads the value itself (`parsePlaneIdEnv` is the sibling). As first written it threw on **every** value including unset, which would have failed boot for every deployment that never set the override. Caught by probing all four branches instead of only the one I meant to fix.

**No production writer.** The override lived only in the reader, its JSDoc and a unit fixture — an isolated render showed the parent knob resolving while the child knob stayed `null`. Compose now writes it; the census classifies it under `optionalOverrides`, and the parity gate caught the unclassified key on the first run.

**Withdrawn, not corrected:** *"20 supervised task keys, so 9 can run alongside"* is a task-key count, not a process count. The registry distinguishes supervised-child-process / service-runner / in-process-async / health-check lanes, the pipeline dispatches one winner per poll, and authority plus enablement remove more. That number is unmeasured, and **#16463 now owns measuring it explicitly** rather than the deferral being implied by a Compose comment.

**Rhetorical drift:** the lease spec still asserted an identical identity *"is self-succession"* causally after the implementation had been folded to the measured relation. Fixed.

**Contract drift:** this body and `#16459`'s ledger said 512 MiB / one child; code says 384 and the budget is up to two. Both reconciled.

### Evidence

`ai:lint-config-template-ssot` green · profiled render carries both knobs, the 3g limit and the escaped entrypoint · **1096 passing** across `ai/daemons/orchestrator` + `ai/daemons/shared`. The two failures (`DreamServiceGoldenPath`, `Orchestrator` chroma-recycle) reproduce on a clean tree via `git stash`.

## Post-Merge Validation

Owned by **#16463**, which holds the L4 residual in full: recreate survival under a workload including a heavy task, heap profiles across two cycles, and an explicit bounded-or-growth verdict. Filed rather than deferred here, and worth doing early — a ~3-minute crash cycle is the cheapest profiling opportunity this defect will ever offer, and a working fix destroys it.

## Scope note

`#16459`'s Contract Ledger now names all four surfaces this PR touches — parent ceiling, child ceiling, container budget, and the renamed error property with its fallback semantics.

`#16459` was narrowed before any work started: as filed it bundled a config fix, a diagnostics fix, and an open-ended memory investigation — three deliverables one PR cannot cleanly close. The investigation needs a *running* orchestrator to profile, so it is sequenced as post-merge validation with a named successor.

**Not in scope:** the plane's staleness (`kb-server` and `mc-server` report `efe4490dd7` — that is `#16454`'s lane), the `host-edge` orchestrator (different per-role lease file by construction), and any third-party deployment (the authority lease does not exist at the revisions external deployments currently run, so this loop cannot be occurring there).

Authored by Grace (Claude Opus 5, Claude Code). Session `9f05cd72-5457-4ec2-926c-ef1406041f19`.

