### PR TITLE
feat: the wake-route panel shows each seat's path, axis by axis (#16431)

### DIFF
--- a/ai/services/fleet/FleetControlBridge.mjs
+++ b/ai/services/fleet/FleetControlBridge.mjs
@@ -117,6 +117,15 @@ class FleetControlBridge extends Base {
      */
     memoriesSource = null
     /**
+     * Viewer-bound wake-routes source — an injected collaborator exposing `readWakeRoutes(params)`:
+     * the DECOMPOSED per-seat wake-path envelope (subscription, arming, delivery lane, last
+     * terminal failure, presence), every axis answering as itself under the fail-honest contract.
+     * The source resolves the viewer from authenticated request context at each call; this bridge
+     * carries no viewer field and never fuses axes.
+     * @member {Object|null} wakeRoutesSource=null
+     */
+    wakeRoutesSource = null
+    /**
      * Per-agent mailbox-mirror **read-observe** source — an injected collaborator exposing
      * `readMailboxMirror({subjectAgentId, limit, offset})` that returns the S1 mirror snapshot
      * (`{capability, admission, rows, page}`). Same DI contract as {@link #activitySource}: the

--- a/ai/services/fleet/FleetControlBridge.mjs
+++ b/ai/services/fleet/FleetControlBridge.mjs
@@ -515,6 +515,25 @@ class FleetControlBridge extends Base {
     }
 
     /**
+     * @summary READ-OBSERVE: read the decomposed per-seat wake-route snapshot for the authenticated
+     * viewer — every axis of the wake path answering as itself, never fused. The source envelope
+     * passes through untouched; an unwired source is named as unavailable rather than fabricated
+     * as a silent fleet.
+     * @param {Object} [params]
+     * @returns {Promise<Object>|Object}
+     */
+    fleetWakeRoutes(params = {}) {
+        return typeof this.wakeRoutesSource?.readWakeRoutes === 'function'
+            ? this.wakeRoutesSource.readWakeRoutes(params)
+            : {
+                capability: {state: 'unavailable', reason: 'fleet wake-routes source not wired'},
+                viewer    : null,
+                count     : 0,
+                seats     : []
+            };
+    }
+
+    /**
      * @summary RUNTIME-WRITE: explicitly advance the authenticated viewer's process-lifetime
      * catch-up anchor through the exact latest rendered window end. This is not a graph/browser
      * write and carries no caller-supplied identity.

--- a/ai/services/fleet/devFleetServer.mjs
+++ b/ai/services/fleet/devFleetServer.mjs
@@ -58,7 +58,7 @@ import {createPlaneMailboxClient}             from './planeMailboxClient.mjs';
 import {createPlaneWakeIdentitiesReader}      from './planeWakeIdentitiesReader.mjs';
 import {createPlaneWhoIsOnlineReader}         from './planeWhoIsOnlineReader.mjs';
 import {readActiveWakeSubscriptionIdentities} from '../memory-core/readActiveWakeSubscriptionIdentities.mjs';
-import {resolveDaemonLiveness}                from './fleetWakeStateAdapter.mjs';
+import {createTerminalDeliveryFailuresFileReader, resolveDaemonLiveness} from './fleetWakeStateAdapter.mjs';
 import {wireBootIdentityReadSource}           from './wireBootIdentityReadSource.mjs';
 import {wireFleetActivityReadSource}          from './wireFleetActivityReadSource.mjs';
 import {wireFleetCatchUpSource}               from './wireFleetCatchUpSource.mjs';
@@ -182,7 +182,12 @@ async function boot() {
             (FleetManager.wakeStateOptions.pidFilePath
                 ? () => resolveDaemonLiveness({pidFilePath: FleetManager.wakeStateOptions.pidFilePath})
                 : null),
-        resolveTerminalDeliveryFailures: FleetManager.wakeStateOptions.resolveTerminalDeliveryFailures ?? null,
+        resolveTerminalDeliveryFailures: FleetManager.wakeStateOptions.resolveTerminalDeliveryFailures ??
+            (FleetManager.wakeStateOptions.deliveryFailureFilePath
+                ? createTerminalDeliveryFailuresFileReader({
+                    deliveryFailureFilePath: FleetManager.wakeStateOptions.deliveryFailureFilePath
+                })
+                : null),
         readPresence                   : planeClient ? createPlaneWhoIsOnlineReader(planeClient) : null
     });
 

--- a/ai/services/fleet/devFleetServer.mjs
+++ b/ai/services/fleet/devFleetServer.mjs
@@ -56,11 +56,14 @@ import {probeExistingFleetServer, resolveFleetBearer, resolveFleetViewer,
         resolveFleetViewerClaim}                                          from './fleetLaunchContract.mjs';
 import {createPlaneMailboxClient}             from './planeMailboxClient.mjs';
 import {createPlaneWakeIdentitiesReader}      from './planeWakeIdentitiesReader.mjs';
+import {createPlaneWhoIsOnlineReader}         from './planeWhoIsOnlineReader.mjs';
 import {readActiveWakeSubscriptionIdentities} from '../memory-core/readActiveWakeSubscriptionIdentities.mjs';
+import {resolveDaemonLiveness}                from './fleetWakeStateAdapter.mjs';
 import {wireBootIdentityReadSource}           from './wireBootIdentityReadSource.mjs';
 import {wireFleetActivityReadSource}          from './wireFleetActivityReadSource.mjs';
 import {wireFleetCatchUpSource}               from './wireFleetCatchUpSource.mjs';
 import {wireFleetMemoriesSource}              from './wireFleetMemoriesSource.mjs';
+import {wireFleetWakeRoutesSource}            from './wireFleetWakeRoutesSource.mjs';
 import {wireOperatorComposeWriter}            from './wireOperatorComposeWriter.mjs';
 import path                                   from 'node:path';
 import {fileURLToPath, pathToFileURL}         from 'node:url';
@@ -142,7 +145,7 @@ async function boot() {
             // — the reader consumes them directly; a second parse here would reject every healthy
             // answer and silently blind the whole axis.
             listActiveSubscriptionIdentities: createPlaneWakeIdentitiesReader(planeClient),
-            resolveDeliveryLiveness: () => ({
+            resolveDeliveryLiveness         : () => ({
                 alive : 'unknown',
                 reason: 'delivery-lane liveness is not exposed by the containerized plane yet'
             }),
@@ -166,6 +169,22 @@ async function boot() {
 
         console.log('[fleet] wake-state seam stays host-local (host plane: daemon PID file + host graph subscription scan)')
     }
+
+    // The decomposed wake-routes verb rides the SAME per-mode truth the fused wake axis was bound
+    // to above — one authority per axis, never a second source. Presence joins plane-side over the
+    // proven client; host mode wraps the daemon PID-file liveness read and leaves presence and
+    // terminal receipts honestly unbound until host surfaces exist for them.
+    wireFleetWakeRoutesSource({
+        listAgents                      : () => FleetManager.getLifecycleService().getRegistry().listAgents(),
+        resolveViewerIdentity           : () => RequestContextService.getAgentIdentityNodeId(),
+        listActiveSubscriptionIdentities: FleetManager.wakeStateOptions.listActiveSubscriptionIdentities ?? null,
+        resolveDeliveryLiveness         : FleetManager.wakeStateOptions.resolveDeliveryLiveness ??
+            (FleetManager.wakeStateOptions.pidFilePath
+                ? () => resolveDaemonLiveness({pidFilePath: FleetManager.wakeStateOptions.pidFilePath})
+                : null),
+        resolveTerminalDeliveryFailures: FleetManager.wakeStateOptions.resolveTerminalDeliveryFailures ?? null,
+        readPresence                   : planeClient ? createPlaneWhoIsOnlineReader(planeClient) : null
+    });
 
     // Wire the composed activitySource onto FleetControlBridge. The memory-core mailbox + graph
     // singletons are imported lazily at this boot use site (mirroring readActiveWakeSubscriptionIdentities's

--- a/ai/services/fleet/fleetWakeRoutesSource.mjs
+++ b/ai/services/fleet/fleetWakeRoutesSource.mjs
@@ -1,0 +1,344 @@
+import {redactCredentials} from './redactCredentials.mjs'
+
+/**
+ * @module ai/services/fleet/fleetWakeRoutesSource
+ * @summary The DECOMPOSED per-seat wake-route read: one row per registered agent carrying each
+ * axis of the wake path separately — subscription intent, seat-side route arming, delivery-lane
+ * liveness, the last terminal delivery failure, and presence freshness — plus a capability
+ * envelope declaring how much of that truth was reachable.
+ *
+ * The sibling wake view (`fleetWakeStateAdapter.readFleetWakeStateSnapshot`) FUSES its axes into
+ * one taxonomy word per agent, which is right for a roster telltale and wrong for diagnosis: a
+ * fused verdict cannot say WHICH leg broke, and a crash-loop that hides behind a healthy-looking
+ * fused answer is precisely the incident class this surface exists to end. This source never
+ * fuses: every axis answers as itself, with its own reason when it cannot answer.
+ *
+ * Fail-honest discipline, verbatim from the adapter it complements: every unreachable source
+ * degrades to its own `unknown` with the reason preserved; an axis nobody can observe yet is a
+ * typed `unobserved`, never a fabricated healthy default; and a throwing collaborator can never
+ * take a sibling axis down with it. The source resolves no configuration — every read path is
+ * injected at the composing entrypoint, and construction refuses to exist without the collaborators
+ * it cannot honestly substitute.
+ */
+
+export const WAKE_ROUTES_SOURCE_LABEL = 'fleet:wakeRoutes'
+
+const
+    DELIVERY_STATES  = Object.freeze(['alive', 'down', 'unknown']),
+    PRESENCE_STATES  = Object.freeze(['online', 'idle', 'dark', 'benched', 'neverConnected']),
+    ARMED_UNOBSERVED = Object.freeze({
+        state : 'unobserved',
+        reason: 'seat-side route arming is not exposed to the fleet server yet'
+    })
+
+/**
+ * @summary Builds the wake-routes read source over injected collaborators.
+ * @param {Object} options
+ * @param {Function} options.listAgents `() => Object[]` registry roster rows (each needs an `id`).
+ * @param {Function} options.resolveViewerIdentity `() => String|null` — the authenticated viewer.
+ * @param {Function|null} [options.listActiveSubscriptionIdentities] `() => Iterable<String>`
+ *     (sync or async) yielding wake identities holding an ACTIVE subscription. Absent ⇒ the
+ *     subscription axis is honestly unreadable for every seat.
+ * @param {Function|null} [options.resolveDeliveryLiveness] `() => {alive: Boolean|'unknown',
+ *     reason}` (sync or async) — the delivery-lane authority. Absent ⇒ axis unknown with reason.
+ * @param {Function|null} [options.resolveTerminalDeliveryFailures] `() => {state:
+ *     'observed'|'unknown', reason, byIdentity: Map}` (sync or async). Absent ⇒ axis unknown.
+ * @param {Function|null} [options.readPresence] `() => Object` (sync or async) resolving the
+ *     roster-presence report (`who_is_online` payload shape: `{agents: [{identity, state,
+ *     reason, signals}]}`). Absent ⇒ the presence axis is a typed `unobserved`.
+ * @param {Function} [options.wakeIdentityFor] `(agent) => String` roster row → wake identity.
+ *     Default: `'@' + (githubUsername ?? id)` — the swarm's mailbox-identity convention.
+ * @param {Function} [options.now] Clock override for tests.
+ * @returns {{readWakeRoutes: Function}}
+ */
+export function createFleetWakeRoutesSource({
+    listAgents,
+    resolveViewerIdentity,
+    listActiveSubscriptionIdentities = null,
+    resolveDeliveryLiveness = null,
+    resolveTerminalDeliveryFailures = null,
+    readPresence = null,
+    wakeIdentityFor = agent => `@${agent.githubUsername ?? agent.id}`,
+    now = () => new Date()
+} = {}) {
+    if (typeof listAgents !== 'function') {
+        throw new TypeError('createFleetWakeRoutesSource requires a listAgents collaborator')
+    }
+    if (typeof resolveViewerIdentity !== 'function') {
+        throw new TypeError('createFleetWakeRoutesSource requires a resolveViewerIdentity collaborator')
+    }
+
+    /**
+     * @summary Reads one decomposed wake-route snapshot across the registered roster.
+     * @returns {Promise<Object>} `{capability, viewer, count, seats}` — see the module note.
+     */
+    async function readWakeRoutes() {
+        const
+            viewer       = safeViewer(resolveViewerIdentity),
+            subscription = await readSubscriptionAxis(listActiveSubscriptionIdentities),
+            delivery     = await readDeliveryAxis(resolveDeliveryLiveness),
+            failures     = await readFailuresAxis(resolveTerminalDeliveryFailures),
+            presence     = await readPresenceAxis(readPresence)
+
+        let agents
+
+        try {
+            agents = await listAgents()
+        } catch (error) {
+            // No roster means no rows CAN exist — that is a source-level degrade, not an empty fleet.
+            return {
+                capability: {
+                    source    : WAKE_ROUTES_SOURCE_LABEL,
+                    state     : 'degraded',
+                    confidence: 'none',
+                    capturedAt: toIsoString(now()),
+                    reason    : redactReason(error) || 'fleet roster unreadable'
+                },
+                viewer,
+                count: 0,
+                seats: []
+            }
+        }
+
+        const seats = []
+
+        for (const agent of Array.isArray(agents) ? agents : []) {
+            if (!agent?.id) continue
+
+            const identity = wakeIdentityFor(agent)
+
+            seats.push({
+                agentId      : agent.id,
+                agentIdentity: identity,
+                subscription : subscription.rowFor(identity),
+                armed        : {...ARMED_UNOBSERVED},
+                delivery     : {state: delivery.state, reason: delivery.reason},
+                lastFailure  : failures.rowFor(identity),
+                presence     : presence.rowFor(identity)
+            })
+        }
+
+        // Axis availability decides the envelope: every axis answering = wired/observed; some =
+        // degraded/partial (the reason names each silent axis); none = degraded/none. "We cannot
+        // see" stays distinguishable from "the route is down" — per axis AND per envelope.
+        const
+            axisOk   = [subscription.ok, delivery.ok, failures.ok, presence.ok],
+            fullyOk  = axisOk.every(Boolean),
+            anyTruth = axisOk.some(Boolean)
+
+        return {
+            capability: {
+                source    : WAKE_ROUTES_SOURCE_LABEL,
+                state     : fullyOk ? 'wired' : 'degraded',
+                confidence: fullyOk ? 'observed' : (anyTruth ? 'partial' : 'none'),
+                capturedAt: toIsoString(now()),
+                reason    : fullyOk ? null : [
+                    subscription.ok ? null : `subscription axis: ${subscription.reason}`,
+                    delivery.ok     ? null : `delivery axis: ${delivery.reason}`,
+                    failures.ok     ? null : `failure axis: ${failures.reason}`,
+                    presence.ok     ? null : `presence axis: ${presence.reason}`
+                ].filter(Boolean).join('; ') || null
+            },
+            viewer,
+            count: seats.length,
+            seats
+        }
+    }
+
+    return {readWakeRoutes}
+}
+
+/**
+ * @summary Resolves the subscription axis once per snapshot: a bulk identity scan becomes a
+ * per-seat membership answer. A missing reader or a failed scan degrades EVERY seat's axis with
+ * the same reason — never a fabricated `none`.
+ * @param {Function|null} listActiveSubscriptionIdentities
+ * @returns {Promise<{ok: Boolean, reason: String|null, rowFor: Function}>}
+ * @private
+ */
+async function readSubscriptionAxis(listActiveSubscriptionIdentities) {
+    if (typeof listActiveSubscriptionIdentities !== 'function') {
+        const reason = 'subscription read path unavailable'
+
+        return {ok: false, reason, rowFor: () => ({state: 'unknown', reason})}
+    }
+
+    try {
+        const identities = new Set(await listActiveSubscriptionIdentities())
+
+        return {
+            ok    : true,
+            reason: null,
+            rowFor: identity => identities.has(identity)
+                ? {state: 'active', reason: null}
+                : {state: 'none', reason: null}
+        }
+    } catch (error) {
+        const reason = redactReason(error) || 'subscription scan failed'
+
+        return {ok: false, reason, rowFor: () => ({state: 'unknown', reason})}
+    }
+}
+
+/**
+ * @summary Resolves the delivery-lane axis under the injected-resolver contract: `alive` must be
+ * `true`/`false`/`'unknown'`; a throw or an out-of-contract answer degrades to `unknown` with the
+ * reason preserved — an injected authority can never fabricate a state.
+ * @param {Function|null} resolveDeliveryLiveness
+ * @returns {Promise<{ok: Boolean, state: String, reason: String|null}>}
+ * @private
+ */
+async function readDeliveryAxis(resolveDeliveryLiveness) {
+    if (typeof resolveDeliveryLiveness !== 'function') {
+        return {ok: false, state: 'unknown', reason: 'delivery liveness read path unavailable'}
+    }
+
+    let answer
+
+    try {
+        answer = await resolveDeliveryLiveness()
+    } catch (error) {
+        return {ok: false, state: 'unknown', reason: redactReason(error) || 'delivery liveness read failed'}
+    }
+
+    const alive = answer?.alive
+
+    if (alive === true)  return {ok: true, state: 'alive', reason: null}
+    if (alive === false) return {ok: true, state: 'down', reason: redactReason(answer.reason)}
+
+    return {
+        ok    : false,
+        state : 'unknown',
+        reason: redactReason(answer?.reason) || (alive === 'unknown'
+            ? 'delivery liveness resolver answered unknown'
+            : 'delivery liveness resolver returned an out-of-contract value')
+    }
+}
+
+/**
+ * @summary Resolves the terminal-failure axis: `state` must be `'observed'`/`'unknown'` with a
+ * `byIdentity` Map — anything else degrades to `unknown` for every seat. Observed-with-no-receipt
+ * is a first-class healthy answer, distinct from unreadable.
+ * @param {Function|null} resolveTerminalDeliveryFailures
+ * @returns {Promise<{ok: Boolean, reason: String|null, rowFor: Function}>}
+ * @private
+ */
+async function readFailuresAxis(resolveTerminalDeliveryFailures) {
+    const degraded = reason => ({
+        ok    : false,
+        reason,
+        rowFor: () => ({state: 'unknown', reason, receipt: null})
+    })
+
+    if (typeof resolveTerminalDeliveryFailures !== 'function') {
+        return degraded('terminal delivery read path unavailable')
+    }
+
+    let answer
+
+    try {
+        answer = await resolveTerminalDeliveryFailures()
+    } catch (error) {
+        return degraded(redactReason(error) || 'terminal delivery read failed')
+    }
+
+    if ((answer?.state !== 'observed' && answer?.state !== 'unknown') || !(answer?.byIdentity instanceof Map)) {
+        return degraded('terminal delivery resolver returned an out-of-contract value')
+    }
+
+    if (answer.state === 'unknown') {
+        return degraded(redactReason(answer.reason) || 'terminal delivery resolver answered unknown')
+    }
+
+    return {
+        ok    : true,
+        reason: null,
+        rowFor: identity => {
+            const receipt = answer.byIdentity.get(identity)?.[0] || null
+
+            return {
+                state  : 'observed',
+                reason : receipt ? `terminal wake delivery failure: ${receipt.errorClass}` : null,
+                receipt: receipt ? {errorClass: receipt.errorClass, failedAt: receipt.failedAt} : null
+            }
+        }
+    }
+}
+
+/**
+ * @summary Resolves the presence axis from the roster-presence report. Absent reader ⇒ typed
+ * `unobserved` (nobody asked — never rendered as absence); malformed or throwing reader ⇒
+ * `unknown` with the reason; a seat missing from a healthy report answers `unknown` for itself
+ * without degrading its siblings.
+ * @param {Function|null} readPresence
+ * @returns {Promise<{ok: Boolean, reason: String|null, rowFor: Function}>}
+ * @private
+ */
+async function readPresenceAxis(readPresence) {
+    if (typeof readPresence !== 'function') {
+        const reason = 'presence read path unavailable'
+
+        return {ok: false, reason, rowFor: () => ({state: 'unobserved', lastSeenAt: null, reason})}
+    }
+
+    let payload
+
+    try {
+        payload = await readPresence()
+    } catch (error) {
+        const reason = redactReason(error) || 'presence read failed'
+
+        return {ok: false, reason, rowFor: () => ({state: 'unknown', lastSeenAt: null, reason})}
+    }
+
+    if (!Array.isArray(payload?.agents)) {
+        const reason = 'presence answer unreadable'
+
+        return {ok: false, reason, rowFor: () => ({state: 'unknown', lastSeenAt: null, reason})}
+    }
+
+    const byIdentity = new Map()
+
+    for (const row of payload.agents) {
+        if (typeof row?.identity !== 'string' || !PRESENCE_STATES.includes(row.state)) continue
+
+        byIdentity.set(row.identity, {
+            state     : row.state,
+            lastSeenAt: row.signals?.activityRecency?.lastActivityAt ?? null,
+            reason    : typeof row.reason === 'string' ? redactReason(row.reason) : null
+        })
+    }
+
+    return {
+        ok    : true,
+        reason: null,
+        rowFor: identity => byIdentity.get(identity) ??
+            {state: 'unknown', lastSeenAt: null, reason: 'seat absent from the presence report'}
+    }
+}
+
+function safeViewer(resolveViewerIdentity) {
+    try {
+        const viewer = resolveViewerIdentity()
+
+        return typeof viewer === 'string' && viewer.length > 0 ? viewer : null
+    } catch {
+        return null
+    }
+}
+
+function redactReason(value) {
+    if (value == null) return null
+
+    const text = String(value?.message || value || '').replace(/\s+/g, ' ').trim().slice(0, 240)
+
+    return text ? redactCredentials(text) : null
+}
+
+function toIsoString(value) {
+    const date = value instanceof Date ? value : new Date(value)
+
+    return Number.isNaN(date.getTime()) ? new Date().toISOString() : date.toISOString()
+}
+
+export default createFleetWakeRoutesSource;

--- a/ai/services/fleet/fleetWakeRoutesSource.mjs
+++ b/ai/services/fleet/fleetWakeRoutesSource.mjs
@@ -85,14 +85,20 @@ export function createFleetWakeRoutesSource({
         try {
             agents = await listAgents()
         } catch (error) {
-            // No roster means no rows CAN exist — that is a source-level degrade, not an empty fleet.
+            agents = error
+        }
+
+        if (!Array.isArray(agents)) {
+            // No roster means no rows CAN exist — a throw AND a non-array answer are both a
+            // source-level degrade, never an empty fleet: "we cannot see the registry" must stay
+            // distinguishable from "the registry is empty".
             return {
                 capability: {
                     source    : WAKE_ROUTES_SOURCE_LABEL,
                     state     : 'degraded',
                     confidence: 'none',
                     capturedAt: toIsoString(now()),
-                    reason    : redactReason(error) || 'fleet roster unreadable'
+                    reason    : (agents instanceof Error ? redactReason(agents) : 'fleet roster answer unreadable') || 'fleet roster unreadable'
                 },
                 viewer,
                 count: 0,
@@ -102,7 +108,7 @@ export function createFleetWakeRoutesSource({
 
         const seats = []
 
-        for (const agent of Array.isArray(agents) ? agents : []) {
+        for (const agent of agents) {
             if (!agent?.id) continue
 
             const identity = wakeIdentityFor(agent)
@@ -118,11 +124,14 @@ export function createFleetWakeRoutesSource({
             })
         }
 
-        // Axis availability decides the envelope: every axis answering = wired/observed; some =
-        // degraded/partial (the reason names each silent axis); none = degraded/none. "We cannot
-        // see" stays distinguishable from "the route is down" — per axis AND per envelope.
+        // Axis availability decides the envelope over EVERY declared axis — including the
+        // structurally silent arming axis, because a decomposed diagnostic envelope must certify
+        // the conjunction of all its constituents: `wired/observed` while any declared axis cannot
+        // answer would be the fused over-certification this surface exists to end. Today that
+        // makes `wired` unreachable BY CONSTRUCTION (arming has no read yet) — correct, and the
+        // reason names it. Some axes answering = degraded/partial; none = degraded/none.
         const
-            axisOk   = [subscription.ok, delivery.ok, failures.ok, presence.ok],
+            axisOk   = [subscription.ok, false, delivery.ok, failures.ok, presence.ok],
             fullyOk  = axisOk.every(Boolean),
             anyTruth = axisOk.some(Boolean)
 
@@ -134,6 +143,7 @@ export function createFleetWakeRoutesSource({
                 capturedAt: toIsoString(now()),
                 reason    : fullyOk ? null : [
                     subscription.ok ? null : `subscription axis: ${subscription.reason}`,
+                    `arming axis: ${ARMED_UNOBSERVED.reason}`,
                     delivery.ok     ? null : `delivery axis: ${delivery.reason}`,
                     failures.ok     ? null : `failure axis: ${failures.reason}`,
                     presence.ok     ? null : `presence axis: ${presence.reason}`

--- a/ai/services/fleet/fleetWakeStateAdapter.mjs
+++ b/ai/services/fleet/fleetWakeStateAdapter.mjs
@@ -197,6 +197,23 @@ function readTerminalDeliveryFailures({
 }
 
 /**
+ * @summary Wraps the receipt-file source as an injected-resolver-contract reader, so a sibling
+ * composition can consume the SAME file-backed authority (same parsing, same fail-honest
+ * degradation) without duplicating it. The returned function matches the
+ * `resolveTerminalDeliveryFailures` axis contract exactly.
+ * @param {Object} options={}
+ * @param {String|null} [options.deliveryFailureFilePath]
+ * @param {Function} [options.readDeliveryFailureFile] Test seam, as on the snapshot reader.
+ * @returns {Function} `() => {state, reason, byIdentity}`.
+ */
+export function createTerminalDeliveryFailuresFileReader({deliveryFailureFilePath = null, readDeliveryFailureFile} = {}) {
+    return () => readTerminalDeliveryFailures({
+        deliveryFailureFilePath,
+        ...(readDeliveryFailureFile && {readDeliveryFailureFile})
+    })
+}
+
+/**
  * @summary Default process-identity reader: the probed pid's command line via `ps` (portable across
  * macOS/Linux). Returns `null` when `ps` yields nothing (the identity stays unknown, never guessed).
  * @param {Number} pid

--- a/ai/services/fleet/planeWhoIsOnlineReader.mjs
+++ b/ai/services/fleet/planeWhoIsOnlineReader.mjs
@@ -18,7 +18,9 @@
  */
 export function createPlaneWhoIsOnlineReader(planeClient) {
     return async () => {
-        const payload = await planeClient.callTool('who_is_online', {})
+        // The verbose contract is load-bearing: the terse report omits the per-agent `agents`
+        // rows this reader exists to fetch, so a terse request would throw on every healthy call.
+        const payload = await planeClient.callTool('who_is_online', {verbose: true})
 
         if (!Array.isArray(payload?.agents)) {
             throw new Error('plane who_is_online answer unreadable')

--- a/ai/services/fleet/planeWhoIsOnlineReader.mjs
+++ b/ai/services/fleet/planeWhoIsOnlineReader.mjs
@@ -1,0 +1,31 @@
+/**
+ * @module ai/services/fleet/planeWhoIsOnlineReader
+ * @summary The plane-mode presence reader: composes the identity-proven plane client's
+ * `who_is_online` call into the wake-routes source's `readPresence` contract.
+ *
+ * The client's `callTool` returns the PARSED tool payload (its `mapToolResult` owns envelope
+ * handling) — this reader passes it through after one payload-contract guard: anything without a
+ * top-level `agents` array throws, and the source converts that throw into an honest per-seat
+ * `unknown` under a degraded capability. A refused or wrong-shape answer never fabricates an
+ * absent fleet.
+ */
+
+/**
+ * @summary Builds the source-facing presence reader over a proven plane client.
+ * @param {Object} planeClient A `planeMailboxClient`-contract client: `callTool(name, args)`
+ *     resolving to the parsed tool payload (never the wire envelope).
+ * @returns {Function} `() => Promise<Object>` matching the wake-routes source's `readPresence` seam.
+ */
+export function createPlaneWhoIsOnlineReader(planeClient) {
+    return async () => {
+        const payload = await planeClient.callTool('who_is_online', {})
+
+        if (!Array.isArray(payload?.agents)) {
+            throw new Error('plane who_is_online answer unreadable')
+        }
+
+        return payload
+    }
+}
+
+export default createPlaneWhoIsOnlineReader;

--- a/ai/services/fleet/wireFleetWakeRoutesSource.mjs
+++ b/ai/services/fleet/wireFleetWakeRoutesSource.mjs
@@ -1,0 +1,57 @@
+import FleetControlBridge            from './FleetControlBridge.mjs';
+import {createFleetWakeRoutesSource} from './fleetWakeRoutesSource.mjs';
+
+/**
+ * @module ai/services/fleet/wireFleetWakeRoutesSource
+ * @summary Installs the decomposed wake-routes source onto the Fleet control bridge at the
+ * authenticated server entry. Every read path is injected at that use site; this wiring imports
+ * neither MCP tool service nor request context, and a missing required collaborator leaves the
+ * verb honestly unwired instead of half-alive.
+ */
+
+/**
+ * @summary Wire one process-lifetime wake-routes source.
+ * @param {Object} options
+ * @param {Function} options.listAgents
+ * @param {Function} options.resolveViewerIdentity
+ * @param {Function|null} [options.listActiveSubscriptionIdentities]
+ * @param {Function|null} [options.resolveDeliveryLiveness]
+ * @param {Function|null} [options.resolveTerminalDeliveryFailures]
+ * @param {Function|null} [options.readPresence]
+ * @param {Function} [options.wakeIdentityFor]
+ * @param {Function} [options.now]
+ * @param {Object} [options.bridge=FleetControlBridge]
+ * @param {Function} [options.createSource=createFleetWakeRoutesSource]
+ * @returns {Object|null}
+ */
+export function wireFleetWakeRoutesSource({
+    listAgents,
+    resolveViewerIdentity,
+    listActiveSubscriptionIdentities = null,
+    resolveDeliveryLiveness = null,
+    resolveTerminalDeliveryFailures = null,
+    readPresence = null,
+    wakeIdentityFor,
+    now,
+    bridge       = FleetControlBridge,
+    createSource = createFleetWakeRoutesSource
+} = {}) {
+    if (typeof listAgents !== 'function' || typeof resolveViewerIdentity !== 'function') {
+        return null
+    }
+
+    bridge.wakeRoutesSource = createSource({
+        listAgents,
+        resolveViewerIdentity,
+        listActiveSubscriptionIdentities,
+        resolveDeliveryLiveness,
+        resolveTerminalDeliveryFailures,
+        readPresence,
+        ...(wakeIdentityFor ? {wakeIdentityFor} : {}),
+        ...(now ? {now} : {})
+    });
+
+    return bridge.wakeRoutesSource
+}
+
+export default wireFleetWakeRoutesSource;

--- a/apps/agentos/model/WakeRouteSeat.mjs
+++ b/apps/agentos/model/WakeRouteSeat.mjs
@@ -1,0 +1,105 @@
+import Model from '../../../src/data/Model.mjs';
+
+/**
+ * @class AgentOS.model.WakeRouteSeat
+ * @extends Neo.data.Model
+ *
+ * @summary One view-projection record in the Fleet wake-routes pane: a single seat's DECOMPOSED
+ * wake path exactly as the `fleetWakeRoutes` read returned it — one field pair per axis (state +
+ * reason), never re-fused and never re-derived. The model is intentionally thin projection input;
+ * the string converts are the rendering guards for the vocabulary-collision class: a non-string
+ * value becomes `null` and the pane names it honestly instead of coercing.
+ */
+class WakeRouteSeat extends Model {
+    static config = {
+        /**
+         * @member {String} className='AgentOS.model.WakeRouteSeat'
+         * @protected
+         */
+        className: 'AgentOS.model.WakeRouteSeat',
+        /**
+         * @member {String} keyProperty='agentIdentity'
+         * @reactive
+         */
+        keyProperty: 'agentIdentity',
+        /**
+         * @member {Object[]} fields
+         */
+        fields: [{
+            name: 'agentIdentity',
+            type: 'String'
+        }, {
+            name        : 'agentId',
+            type        : 'String',
+            convert     : value => typeof value === 'string' ? value : null,
+            defaultValue: null
+        }, {
+            name        : 'subscriptionState',
+            type        : 'String',
+            convert     : value => typeof value === 'string' ? value : null,
+            defaultValue: null
+        }, {
+            name        : 'subscriptionReason',
+            type        : 'String',
+            convert     : value => typeof value === 'string' ? value : null,
+            defaultValue: null
+        }, {
+            name        : 'armedState',
+            type        : 'String',
+            convert     : value => typeof value === 'string' ? value : null,
+            defaultValue: null
+        }, {
+            name        : 'armedReason',
+            type        : 'String',
+            convert     : value => typeof value === 'string' ? value : null,
+            defaultValue: null
+        }, {
+            name        : 'deliveryState',
+            type        : 'String',
+            convert     : value => typeof value === 'string' ? value : null,
+            defaultValue: null
+        }, {
+            name        : 'deliveryReason',
+            type        : 'String',
+            convert     : value => typeof value === 'string' ? value : null,
+            defaultValue: null
+        }, {
+            name        : 'failureState',
+            type        : 'String',
+            convert     : value => typeof value === 'string' ? value : null,
+            defaultValue: null
+        }, {
+            name        : 'failureReason',
+            type        : 'String',
+            convert     : value => typeof value === 'string' ? value : null,
+            defaultValue: null
+        }, {
+            name        : 'failureErrorClass',
+            type        : 'String',
+            convert     : value => typeof value === 'string' ? value : null,
+            defaultValue: null
+        }, {
+            name        : 'failureAt',
+            type        : 'String',
+            convert     : value => typeof value === 'string' ? value : null,
+            defaultValue: null
+        }, {
+            name        : 'presenceState',
+            type        : 'String',
+            convert     : value => typeof value === 'string' ? value : null,
+            defaultValue: null
+        }, {
+            name        : 'presenceLastSeenAt',
+            type        : 'String',
+            convert     : value => typeof value === 'string' ? value : null,
+            defaultValue: null
+        }, {
+            name        : 'presenceReason',
+            type        : 'String',
+            convert     : value => typeof value === 'string' ? value : null,
+            defaultValue: null
+        }]
+    }
+}
+
+export default Neo.setupClass(WakeRouteSeat);

--- a/apps/agentos/store/AgentWakeRoutes.mjs
+++ b/apps/agentos/store/AgentWakeRoutes.mjs
@@ -1,0 +1,31 @@
+import Store              from '../../../src/data/Store.mjs';
+import WakeRouteSeatModel from '../model/WakeRouteSeat.mjs';
+
+/**
+ * @class AgentOS.store.AgentWakeRoutes
+ * @extends Neo.data.Store
+ *
+ * @summary Pane-local projection store for the decomposed per-seat wake-route rows. Each
+ * WakeRoutePane owns its store and destroys it with the pane; the route truth remains query-time
+ * on the plane and no record survives the view/process lifecycle.
+ */
+class AgentWakeRoutes extends Store {
+    static config = {
+        /**
+         * @member {String} className='AgentOS.store.AgentWakeRoutes'
+         * @protected
+         */
+        className: 'AgentOS.store.AgentWakeRoutes',
+        /**
+         * @member {String} keyProperty='agentIdentity'
+         */
+        keyProperty: 'agentIdentity',
+        /**
+         * @member {Neo.data.Model} model=WakeRouteSeatModel
+         * @reactive
+         */
+        model: WakeRouteSeatModel
+    }
+}
+
+export default Neo.setupClass(AgentWakeRoutes);

--- a/apps/agentos/view/fleet/FleetCockpit.mjs
+++ b/apps/agentos/view/fleet/FleetCockpit.mjs
@@ -17,6 +17,7 @@ import FleetGrid                   from './FleetGrid.mjs';
 import FleetRoster                 from '../../store/FleetRoster.mjs';
 import MemoriesPane                from './MemoriesPane.mjs';
 import OperatorMailbox             from './OperatorMailbox.mjs';
+import WakeRoutePane               from './WakeRoutePane.mjs';
 import StateProvider               from '../../../../src/state/Provider.mjs';
 import cockpitDockDocument         from './cockpitDockDocument.mjs';
 import cockpitPresetCollection     from './cockpitPresets.mjs';
@@ -549,6 +550,16 @@ class FleetCockpit extends Container {
      * @member {String|null} memoriesTarget=null
      */
     memoriesTarget = null
+    /**
+     * Latest wake-routes envelope, owner-held so rail re-projection rematerializes from current truth.
+     * @member {Object|null} wakeRoutesSnapshot=null
+     */
+    wakeRoutesSnapshot = null
+    /**
+     * Read-generation fence for {@link #loadWakeRoutes} — a slow older read never overwrites a newer one.
+     * @member {Number} wakeRoutesReadGeneration=0
+     */
+    wakeRoutesReadGeneration = 0
     /**
      * Detached-detail bookkeeping — `null` while the inspector is docked. While detached it holds
      * `{homeTabsNodeId, homeTabIndex, windowId, windowName, connectTimer}`: the tabs node + EXACT
@@ -1248,6 +1259,16 @@ class FleetCockpit extends Container {
                     agentOptions: me.buildMemoriesAgentOptions(),
                     listeners   : {memoriesRequest: 'onMemoriesRequest'},
                     reference   : 'memories'
+                };
+            case 'wakeRoutes':
+                // The snapshot travels with rematerialization like the memories sibling: a torn or
+                // re-projected pane reopens on the last ACCEPTED envelope, never a blank claim.
+                return {
+                    module   : WakeRoutePane,
+                    cls      : [marker],
+                    snapshot : me.wakeRoutesSnapshot,
+                    listeners: {wakeRoutesRequest: 'onWakeRoutesRequest'},
+                    reference: 'wakeRoutes'
                 };
             default:
                 // perspectives arrives with its own leaf — an honest labelled placeholder, never a
@@ -2444,6 +2465,50 @@ class FleetCockpit extends Container {
             // the accepted truth into the DESTROYED instance and leave the live pane pending
             // forever. The owner state above plus this live-resolve keep both variants coherent.
             const livePane = me.getReference('memories');
+
+            livePane && (livePane.snapshot = snapshot)
+        }
+
+        return snapshot
+    }
+
+    /**
+     * @summary Read the decomposed per-seat wake-route envelope through the cockpit-owned
+     * authenticated bridge — the memories sibling, same discipline end to end: generation-fenced
+     * (a slow older read never overwrites a newer one), fail-honest (an unwired verb or a throwing
+     * bridge lands as a typed unavailable envelope, never fabricated seats), and the pane resolves
+     * at WRITE time so a removed-and-rematerialized pane receives the accepted truth instead of a
+     * destroyed instance swallowing it.
+     * @param {Object} [params]
+     * @returns {Promise<Object>}
+     */
+    async loadWakeRoutes(params = {}) {
+        const me         = this,
+              bridge     = globalThis.AgentOS?.fleet?.registryBridge,
+              generation = ++me.wakeRoutesReadGeneration,
+              fallback   = reason => ({
+                  capability: {state: 'unavailable', reason},
+                  viewer    : null,
+                  count     : 0,
+                  seats     : []
+              });
+
+        let snapshot;
+
+        if (typeof bridge?.fleetWakeRoutes !== 'function') {
+            snapshot = fallback('fleet wake-routes verb not wired')
+        } else {
+            try {
+                snapshot = await bridge.fleetWakeRoutes(params)
+            } catch (error) {
+                snapshot = fallback('fleet wake-routes read failed')
+            }
+        }
+
+        if (generation === me.wakeRoutesReadGeneration && !me.isDestroyed) {
+            me.wakeRoutesSnapshot = snapshot;
+
+            const livePane = me.getReference('wakeRoutes');
 
             livePane && (livePane.snapshot = snapshot)
         }

--- a/apps/agentos/view/fleet/FleetCockpitController.mjs
+++ b/apps/agentos/view/fleet/FleetCockpitController.mjs
@@ -289,6 +289,17 @@ class FleetCockpitController extends Controller {
     }
 
     /**
+     * @summary Relay a WakeRoutePane read intent to the cockpit-owned authenticated bridge.
+     * @param {Object} data
+     * @returns {Promise<Object>}
+     */
+    onWakeRoutesRequest(data) {
+        const {source, ...params} = data;
+
+        return this.component.loadWakeRoutes(params)
+    }
+
+    /**
      * @summary Re-poll the roster once a lifecycle intent has genuinely changed runtime state.
      *
      * `loadRoster` is the ONLY path that maps live runtime truth onto the roster records, and the

--- a/apps/agentos/view/fleet/WakeRoutePane.mjs
+++ b/apps/agentos/view/fleet/WakeRoutePane.mjs
@@ -142,7 +142,13 @@ class WakeRoutePane extends Container {
             snapshot = me.snapshot,
             metaEl   = me.getReference('wakeroutes-meta'),
             wired    = snapshot?.capability?.state === 'wired',
-            partial  = snapshot?.capability?.state === 'degraded' && Array.isArray(snapshot?.seats)
+            // Rows are adoptable only when the envelope carries PARTIAL truth. `degraded/none`
+            // means the source could observe nothing (an unreadable roster included) — adopting
+            // its empty seat list would render "No seats in the registry" for a registry nobody
+            // could read, the exact fabrication the envelope exists to prevent.
+            partial  = snapshot?.capability?.state === 'degraded' &&
+                snapshot?.capability?.confidence === 'partial' &&
+                Array.isArray(snapshot?.seats)
 
         if (!me.seatStore) return;
 

--- a/apps/agentos/view/fleet/WakeRoutePane.mjs
+++ b/apps/agentos/view/fleet/WakeRoutePane.mjs
@@ -1,0 +1,285 @@
+import AgentWakeRoutes from '../../store/AgentWakeRoutes.mjs';
+import Button          from '../../../../src/button/Base.mjs';
+import Component       from '../../../../src/component/Base.mjs';
+import Container       from '../../../../src/container/Base.mjs';
+
+/**
+ * The invoked Fleet wake-routes surface: can each seat be woken right now — and if not, WHICH leg
+ * of the route broke.
+ *
+ * @summary Renders one viewer-bound `fleetWakeRoutes` envelope of DECOMPOSED per-seat wake axes
+ * (subscription, arming, delivery lane, last terminal failure, presence) without fusing, ranking,
+ * or caching them. The pane owns only a local projection Store of seat rows; it fires intent
+ * events for reads and the owning FleetCockpit holds the authenticated bridge.
+ *
+ * Honest states are first-class, per axis AND per envelope: an axis nobody could observe renders
+ * its own typed reason (`unobserved` / `unknown` — never coerced to healthy or absent), a degraded
+ * capability names every silent axis in the meta line, and an unavailable verb renders as exactly
+ * that. Fusing is the one thing this surface refuses to do: a fused verdict cannot say which leg
+ * broke, and the crash-loop-that-reported-healthy incident class is why the legs stay separate.
+ *
+ * @class AgentOS.view.fleet.WakeRoutePane
+ * @extends Neo.container.Base
+ */
+class WakeRoutePane extends Container {
+    static config = {
+        /**
+         * @member {String} className='AgentOS.view.fleet.WakeRoutePane'
+         * @protected
+         */
+        className: 'AgentOS.view.fleet.WakeRoutePane',
+        /**
+         * @member {String} ntype='fm-wakeroutes-pane'
+         * @protected
+         */
+        ntype: 'fm-wakeroutes-pane',
+        /**
+         * @member {String[]} baseCls=['fm-wakeroutes-pane']
+         */
+        baseCls: ['fm-wakeroutes-pane'],
+        /**
+         * Latest wake-routes envelope. `null` is unobserved, never empty.
+         * @member {Object|null} snapshot_=null
+         * @reactive
+         */
+        snapshot_: null,
+        /**
+         * @member {Object} layout={ntype:'vbox',align:'stretch'}
+         * @reactive
+         */
+        layout: {ntype: 'vbox', align: 'stretch'},
+        /**
+         * @member {Object[]} items
+         */
+        items: [{
+            ntype : 'container',
+            cls   : ['fm-wakeroutes-head'],
+            flex  : 'none',
+            layout: {ntype: 'hbox', align: 'center'},
+            items : [{
+                ntype: 'component',
+                cls  : ['fm-wakeroutes-title'],
+                flex : 1,
+                text : 'Can they be woken?'
+            }, {
+                ntype: 'component',
+                cls  : ['fm-wakeroutes-authority'],
+                text : 'per-seat route axes · query-time · never fused'
+            }]
+        }, {
+            ntype    : 'component',
+            cls      : ['fm-wakeroutes-meta'],
+            flex     : 'none',
+            reference: 'wakeroutes-meta',
+            text     : 'Wake routes not observed yet'
+        }, {
+            ntype    : 'container',
+            cls      : ['fm-wakeroutes-rows'],
+            flex     : 1,
+            layout   : {ntype: 'vbox', align: 'stretch'},
+            reference: 'wakeroutes-rows'
+        }, {
+            ntype : 'container',
+            cls   : ['fm-wakeroutes-actions'],
+            flex  : 'none',
+            layout: {ntype: 'hbox', align: 'center'},
+            items : [{
+                ntype: 'component',
+                flex : 1
+            }, {
+                module   : Button,
+                reference: 'wakeroutes-refresh',
+                text     : 'Read routes',
+                iconCls  : 'fa fa-tower-broadcast',
+                ui       : 'ghost',
+                handler  : 'up.onRefreshClick'
+            }]
+        }]
+    }
+
+    /** @member {AgentOS.store.AgentWakeRoutes|null} seatStore=null */
+    seatStore = null
+
+    /**
+     * @summary Create the pane-local Store and render held owner state. No read fires here:
+     * reading the fleet's routes is the explicit first act, so an auto-hidden pane construction
+     * never queries the plane on its own.
+     * @param {...*} args
+     */
+    onConstructed(...args) {
+        super.onConstructed(...args);
+
+        this.seatStore = Neo.create(AgentWakeRoutes);
+        this.applySnapshot()
+    }
+
+    /** @param {...*} args */
+    destroy(...args) {
+        this.seatStore?.destroy();
+        this.seatStore = null;
+        super.destroy(...args)
+    }
+
+    /** @param {Object|null} value @param {Object|null} oldValue */
+    afterSetSnapshot(value, oldValue) {
+        this.isConstructed && this.applySnapshot()
+    }
+
+    /** @summary Read (or re-read) the decomposed routes for the whole roster. */
+    onRefreshClick() {
+        this.fire('wakeRoutesRequest', {})
+    }
+
+    /**
+     * @summary Project the latest envelope into Store rows and honest chrome. A fresh envelope
+     * always replaces the rows (the read is whole-roster, so partial merges could only fabricate
+     * continuity); a degraded capability keeps its rows AND names every silent axis in the meta
+     * line, because partial truth plus a named gap beats both silence and fabrication.
+     */
+    applySnapshot() {
+        const
+            me       = this,
+            snapshot = me.snapshot,
+            metaEl   = me.getReference('wakeroutes-meta'),
+            wired    = snapshot?.capability?.state === 'wired',
+            partial  = snapshot?.capability?.state === 'degraded' && Array.isArray(snapshot?.seats)
+
+        if (!me.seatStore) return;
+
+        me.seatStore.clear();
+
+        if ((wired || partial) && Array.isArray(snapshot.seats)) {
+            me.seatStore.add(snapshot.seats
+                .filter(seat => typeof seat?.agentIdentity === 'string' && seat.agentIdentity)
+                .map(seat => ({
+                    agentIdentity     : seat.agentIdentity,
+                    agentId           : seat.agentId,
+                    subscriptionState : seat.subscription?.state,
+                    subscriptionReason: seat.subscription?.reason,
+                    armedState        : seat.armed?.state,
+                    armedReason       : seat.armed?.reason,
+                    deliveryState     : seat.delivery?.state,
+                    deliveryReason    : seat.delivery?.reason,
+                    failureState      : seat.lastFailure?.state,
+                    failureReason     : seat.lastFailure?.reason,
+                    failureErrorClass : seat.lastFailure?.receipt?.errorClass,
+                    failureAt         : seat.lastFailure?.receipt?.failedAt,
+                    presenceState     : seat.presence?.state,
+                    presenceLastSeenAt: seat.presence?.lastSeenAt,
+                    presenceReason    : seat.presence?.reason
+                })))
+        }
+
+        if (metaEl) {
+            metaEl.text = !snapshot
+                ? 'Read the routes to see each seat’s wake path.'
+                : wired
+                    ? `${me.seatStore.count} seat routes · every axis observed · captured ${me.formatStamp(snapshot.capability.capturedAt)}`
+                    : partial
+                        ? `${me.seatStore.count} seat routes · silent axes: ${snapshot.capability.reason || 'unnamed'} · captured ${me.formatStamp(snapshot.capability.capturedAt)}`
+                        : `Wake routes unavailable · ${snapshot.capability?.reason || 'unknown reason'}`
+        }
+
+        me.renderRows(snapshot, wired || partial)
+    }
+
+    /**
+     * @summary Render the Store's seat rows (or the honest unobserved/unavailable/empty state).
+     * @param {Object|null} snapshot
+     * @param {Boolean} usable Whether the envelope carried adoptable rows.
+     */
+    renderRows(snapshot, usable) {
+        const target = this.getReference('wakeroutes-rows');
+
+        if (!target) return;
+
+        target.removeAll(true);
+
+        if (!snapshot) {
+            target.add({
+                module: Component,
+                cls   : ['fm-wakeroutes-empty'],
+                text  : 'Nothing here claims route health yet — reading is the explicit first act.'
+            });
+            return
+        }
+
+        if (!usable) {
+            target.add({
+                module: Component,
+                cls   : ['fm-wakeroutes-empty'],
+                text  : 'The wake-routes source did not answer. Nothing here claims reachability.'
+            });
+            return
+        }
+
+        if (this.seatStore.count === 0) {
+            target.add({module: Component, cls: ['fm-wakeroutes-empty'], text: 'No seats in the registry.'});
+            return
+        }
+
+        target.add(this.seatStore.items.map(record => this.seatCardConfig(record)))
+    }
+
+    /**
+     * @summary Build one seat card from a Store record: the identity headline, the presence stamp,
+     * and one line per axis — state in the SENTENCE (never colour alone), with the axis's own
+     * retained reason when it could not answer or carries a diagnosis.
+     * @param {Neo.data.Model} record
+     * @returns {Object}
+     */
+    seatCardConfig(record) {
+        const
+            me   = this,
+            axes = [
+                me.axisConfig('subscription', record.subscriptionState, record.subscriptionReason),
+                me.axisConfig('armed',        record.armedState,        record.armedReason),
+                me.axisConfig('delivery',     record.deliveryState,     record.deliveryReason),
+                me.axisConfig('last failure', record.failureErrorClass
+                    ? `${record.failureErrorClass} at ${me.formatStamp(record.failureAt)}`
+                    : record.failureState, record.failureErrorClass ? null : record.failureReason),
+                me.axisConfig('presence', record.presenceLastSeenAt
+                    ? `${record.presenceState} · last seen ${me.formatStamp(record.presenceLastSeenAt)}`
+                    : record.presenceState, record.presenceReason)
+            ]
+
+        return {
+            module: Container,
+            cls   : ['fm-wakeroutes-card'],
+            flex  : 'none',
+            layout: {ntype: 'vbox', align: 'stretch'},
+            items : [{
+                module: Component,
+                cls   : ['fm-wakeroutes-card-title'],
+                text  : record.agentIdentity
+            }, ...axes]
+        }
+    }
+
+    /**
+     * @summary Build one axis line. The state word travels in the text and doubles as the skin
+     * hook (`is-<state>`); a null state is named as unreported rather than dropped.
+     * @param {String} label
+     * @param {String|null} state
+     * @param {String|null} reason
+     * @returns {Object}
+     */
+    axisConfig(label, state, reason) {
+        const stateWord = state || 'unreported'
+
+        return {
+            module: Component,
+            cls   : ['fm-wakeroutes-axis', `is-${stateWord.replace(/[^a-zA-Z0-9-]/g, '-')}`],
+            text  : `${label}: ${stateWord}${reason ? ` — ${reason}` : ''}`
+        }
+    }
+
+    /** @param {Date|String|Number|null} value @returns {String} */
+    formatStamp(value) {
+        const date = new Date(value);
+
+        return Number.isFinite(date.getTime()) ? date.toISOString().replace('T', ' ').slice(0, 16) + 'Z' : 'unknown time'
+    }
+}
+
+export default Neo.setupClass(WakeRoutePane);

--- a/apps/agentos/view/fleet/cockpitDockDocument.mjs
+++ b/apps/agentos/view/fleet/cockpitDockDocument.mjs
@@ -36,7 +36,8 @@ export function cockpitDockDocument() {
             catchUp     : {componentRef: 'catch-up',          title: 'Catch up',     kind: 'tool',      autoHidden: true},
             // invoked per-agent session-summary recall — the memory complement to catch-up's
             // window digests; team-visible summary corpus, never ambient cockpit density
-            memories    : {componentRef: 'memories',          title: 'Memories',     kind: 'tool',      autoHidden: true},
+            memories  : {componentRef: 'memories',          title: 'Memories',     kind: 'tool',      autoHidden: true},
+            wakeRoutes: {componentRef: 'wakeRoutes',        title: 'Wake routes',  kind: 'tool',      autoHidden: true},
             // the operator's own mailbox + compose surface — a secondary tool pane like
             // perspectives, so it rides the auto-hide rail and never crowds the split
             operator    : {componentRef: 'operator-mailbox',  title: 'Operator',     kind: 'tool',      autoHidden: true}
@@ -49,7 +50,7 @@ export function cockpitDockDocument() {
             'fleet-tabs'   : {type: 'tabs', items: ['fleet'],  activeItemId: 'fleet'},
             'stream-tabs'  : {type: 'tabs', items: ['stream'], activeItemId: 'stream'},
             // Secondary panes collapse to this edge's rail (§2.7): their item records carry `autoHidden`.
-            'secondary-rail': {type: 'tabs', items: ['detail', 'perspectives', 'defineAgent', 'catchUp', 'memories', 'operator'], activeItemId: 'detail'}
+            'secondary-rail': {type: 'tabs', items: ['detail', 'perspectives', 'defineAgent', 'catchUp', 'memories', 'wakeRoutes', 'operator'], activeItemId: 'detail'}
         }
     }
 }

--- a/src/ai/fleet/fleetWireMethods.mjs
+++ b/src/ai/fleet/fleetWireMethods.mjs
@@ -11,11 +11,12 @@
  * `Object` / `Neo.core.Base` member, so a crafted `{method:'getManager'}` / `{method:'constructor'}`
  * request cannot reach a non-operation.
  *
- * `getBootIdentity`, `fleetActivity`, `fleetHistory`, `fleetMemories`, `fleetRoster`, and `fleetMailboxMirror`
- * are **read-observe** verbs — the advisory boot-identity fact, the bounded fleet activity snapshot,
- * one viewer-bound catch-up window, one page of an agent's session summaries (the team-visible
- * corpus; the wire carries the canonical target and paging only), the assembled roster cockpit
- * DTO, and one agent's mailbox mirror: they carry NO lifecycle-write / restart authority. The
+ * `getBootIdentity`, `fleetActivity`, `fleetHistory`, `fleetMemories`, `fleetRoster`, `fleetMailboxMirror`,
+ * and `fleetWakeRoutes` are **read-observe** verbs — the advisory boot-identity fact, the bounded
+ * fleet activity snapshot, one viewer-bound catch-up window, one page of an agent's session
+ * summaries (the team-visible corpus; the wire carries the canonical target and paging only), the
+ * assembled roster cockpit DTO, one agent's mailbox mirror, and the decomposed per-seat wake-route
+ * envelope: they carry NO lifecycle-write / restart authority. The
  * R3 read-observe ÷ lifecycle-write seam keeps the daemon-core restart actuator physically OFF this
  * client wire — only advisory reads ride it.
  *

--- a/src/ai/fleet/fleetWireMethods.mjs
+++ b/src/ai/fleet/fleetWireMethods.mjs
@@ -55,7 +55,7 @@ export const FLEET_WIRE_METHODS = Object.freeze([
     'defineAgent', 'configureAgent', 'setRepo', 'setAvatar', 'listAgents', 'getAgent',
     'startAgent', 'stopAgent', 'restartAgent', 'removeAgent', 'fleetStatus', 'fleetRuntimeStatus',
     'getBootIdentity', 'fleetActivity', 'fleetHistory', 'fleetMemories', 'fleetRoster', 'fleetMailboxMirror', 'connectTenant', 'listTenants',
-    'composeOperatorMessage', 'markFleetCaughtUp', 'resolveViewerIdentity'
+    'composeOperatorMessage', 'markFleetCaughtUp', 'resolveViewerIdentity', 'fleetWakeRoutes'
 ]);
 
 /**

--- a/test/playwright/unit/ai/services/fleet/dispatchFleetRequest.spec.mjs
+++ b/test/playwright/unit/ai/services/fleet/dispatchFleetRequest.spec.mjs
@@ -132,13 +132,15 @@ test.describe('dispatchFleetRequest — the app↔fleet wire allowlist + routing
             // session summaries + one agent's mailbox mirror + the whoami identity-bootstrap) plus
             // the two explicit write verbs. Catch-up mark is process-local only; compose persists
             // payload while the server stamps identity.
-            ['composeOperatorMessage', 'configureAgent', 'connectTenant', 'defineAgent', 'fleetActivity', 'fleetHistory', 'fleetMailboxMirror', 'fleetMemories', 'fleetRoster', 'fleetRuntimeStatus', 'fleetStatus', 'getAgent', 'getBootIdentity', 'listAgents', 'listTenants', 'markFleetCaughtUp', 'removeAgent', 'resolveViewerIdentity', 'restartAgent', 'setAvatar', 'setRepo', 'startAgent', 'stopAgent'].sort()
+            ['composeOperatorMessage', 'configureAgent', 'connectTenant', 'defineAgent', 'fleetActivity', 'fleetHistory', 'fleetMailboxMirror', 'fleetMemories', 'fleetRoster', 'fleetRuntimeStatus', 'fleetStatus', 'fleetWakeRoutes', 'getAgent', 'getBootIdentity', 'listAgents', 'listTenants', 'markFleetCaughtUp', 'removeAgent', 'resolveViewerIdentity', 'restartAgent', 'setAvatar', 'setRepo', 'startAgent', 'stopAgent'].sort()
         );
         expect(FLEET_WIRE_METHODS).toContain('getBootIdentity');   // the read-observe verbs ride the wire; the lifecycle-write restart actuator does NOT (R3)
         expect(FLEET_WIRE_METHODS).toContain('fleetActivity');
         expect(FLEET_WIRE_METHODS).toContain('fleetHistory');
         expect(FLEET_WIRE_METHODS).toContain('fleetMemories');
         expect(FLEET_WIRE_METHODS).toContain('fleetRoster');
+        // the decomposed per-seat wake-route read — bounded read-observe, no resolver seam
+        expect(FLEET_WIRE_METHODS).toContain('fleetWakeRoutes');
         // the wire's first WRITE verb: compose rides the authenticated transport with a whitelisted
         // payload — the author is the server-stamped ambient identity, never a wire parameter
         expect(FLEET_WIRE_METHODS).toContain('composeOperatorMessage');

--- a/test/playwright/unit/ai/services/fleet/fleetWakeRoutesSource.spec.mjs
+++ b/test/playwright/unit/ai/services/fleet/fleetWakeRoutesSource.spec.mjs
@@ -45,12 +45,16 @@ test.describe('fleetWakeRoutesSource — the decomposed per-seat wake-route read
         expect(() => createFleetWakeRoutesSource({resolveViewerIdentity: () => '@a'})).toThrow(TypeError)
     });
 
-    test('a fully-answered read is wired/observed with every axis speaking for itself', async () => {
+    test('the armed-certification control: every injected axis answering still cannot certify wired while arming is structurally silent', async () => {
         const snapshot = await harness().readWakeRoutes();
 
+        // The conjunction rule: a decomposed envelope certifies EVERY declared axis, and the
+        // arming axis has no read yet — so `wired/observed` is unreachable BY CONSTRUCTION, and
+        // the reason names exactly the one silent axis.
         expect(snapshot.capability).toEqual({
-            source    : 'fleet:wakeRoutes', state: 'wired', confidence: 'observed',
-            capturedAt: '2026-08-03T20:01:00.000Z', reason: null
+            source    : 'fleet:wakeRoutes', state: 'degraded', confidence: 'partial',
+            capturedAt: '2026-08-03T20:01:00.000Z',
+            reason    : 'arming axis: seat-side route arming is not exposed to the fleet server yet'
         });
         expect(snapshot.viewer).toBe('@e2e-operator');
         expect(snapshot.count).toBe(2);
@@ -149,7 +153,8 @@ test.describe('fleetWakeRoutesSource — the decomposed per-seat wake-route read
             resolveDeliveryLiveness: () => ({alive: false, reason: 'stale PID file: recorded process is gone'})
         }).readWakeRoutes();
 
-        expect(snapshot.capability.state).toBe('wired');
+        expect(snapshot.capability.state).toBe('degraded');
+        expect(snapshot.capability.reason).not.toContain('delivery axis');
         expect(snapshot.seats[0].delivery).toEqual({
             state : 'down',
             reason: 'stale PID file: recorded process is gone'
@@ -175,7 +180,7 @@ test.describe('fleetWakeRoutesSource — the decomposed per-seat wake-route read
         const ada  = partial.seats.find(seat => seat.agentIdentity === '@neo-opus-ada'),
               clio = partial.seats.find(seat => seat.agentIdentity === '@neo-fable-clio');
 
-        expect(partial.capability.state).toBe('wired');
+        expect(partial.capability.state).toBe('degraded');
         expect(clio.presence.state).toBe('online');
         expect(ada.presence).toEqual({
             state: 'unknown', lastSeenAt: null, reason: 'seat absent from the presence report'
@@ -220,6 +225,51 @@ test.describe('fleetWakeRoutesSource — the decomposed per-seat wake-route read
         }).readWakeRoutes();
 
         expect(snapshot.viewer).toBeNull();
-        expect(snapshot.capability.state).toBe('wired')
+        expect(snapshot.capability.state).toBe('degraded')
+    });
+
+    test('a NON-ARRAY roster answer is unreadable, never an empty fleet — the control against observed-empty', async () => {
+        const unreadable = await harness({
+            listAgents: () => ({rows: 'not an array'})
+        }).readWakeRoutes();
+
+        expect(unreadable.capability.state).toBe('degraded');
+        expect(unreadable.capability.confidence).toBe('none');
+        expect(unreadable.capability.reason).toContain('unreadable');
+        expect(unreadable.seats).toEqual([]);
+
+        // The control: a genuinely empty roster READS as observed-empty partial truth (the arming
+        // axis alone degrades it), with zero seats and NO roster complaint in the reason.
+        const observedEmpty = await harness({listAgents: () => []}).readWakeRoutes();
+
+        expect(observedEmpty.capability.confidence).toBe('partial');
+        expect(observedEmpty.capability.reason).not.toContain('roster');
+        expect(observedEmpty.count).toBe(0)
+    });
+
+    test('the file-backed receipt reader feeds the source: a host receipt reaches exactly its seat', async () => {
+        const {createTerminalDeliveryFailuresFileReader} = await import('../../../../../../ai/services/fleet/fleetWakeStateAdapter.mjs');
+
+        const receiptFile = JSON.stringify({
+            'sub-clio': {
+                subscriptionId: 'sub-clio',
+                agentIdentity : '@neo-fable-clio',
+                errorClass    : 'receiver-unreachable',
+                failedAt      : '2026-08-03T19:00:00.000Z'
+            }
+        });
+
+        const snapshot = await harness({
+            resolveTerminalDeliveryFailures: createTerminalDeliveryFailuresFileReader({
+                deliveryFailureFilePath: '/virtual/wake-delivery-failures.json',
+                readDeliveryFailureFile: () => receiptFile
+            })
+        }).readWakeRoutes();
+
+        const clio = snapshot.seats.find(seat => seat.agentIdentity === '@neo-fable-clio'),
+              ada  = snapshot.seats.find(seat => seat.agentIdentity === '@neo-opus-ada');
+
+        expect(clio.lastFailure.receipt).toEqual({errorClass: 'receiver-unreachable', failedAt: '2026-08-03T19:00:00.000Z'});
+        expect(ada.lastFailure).toEqual({state: 'observed', reason: null, receipt: null})
     })
 });

--- a/test/playwright/unit/ai/services/fleet/fleetWakeRoutesSource.spec.mjs
+++ b/test/playwright/unit/ai/services/fleet/fleetWakeRoutesSource.spec.mjs
@@ -1,0 +1,225 @@
+import {expect, test}                from '@playwright/test';
+import {createFleetWakeRoutesSource} from '../../../../../../ai/services/fleet/fleetWakeRoutesSource.mjs';
+
+const ROSTER = [
+    {id: 'ada',  githubUsername: 'neo-opus-ada'},
+    {id: 'clio', githubUsername: 'neo-fable-clio'}
+];
+
+const PRESENCE_PAYLOAD = {
+    generatedAt: '2026-08-03T20:00:00.000Z',
+    agents     : [
+        {
+            identity: '@neo-opus-ada', state: 'idle', reason: 'stale add_memory activity',
+            signals : {activityRecency: {lastActivityAt: '2026-08-03T18:29:27.443Z', fresh: false}}
+        },
+        {
+            identity: '@neo-fable-clio', state: 'online', reason: 'recent add_memory activity',
+            signals : {activityRecency: {lastActivityAt: '2026-08-03T19:55:00.000Z', fresh: true}}
+        }
+    ]
+};
+
+/**
+ * @summary Build one fully-wired harness; per-axis collaborators are overridable per test.
+ * @param {Object} [overrides]
+ * @returns {Object}
+ */
+function harness(overrides = {}) {
+    return createFleetWakeRoutesSource({
+        listAgents                      : () => ROSTER,
+        resolveViewerIdentity           : () => '@e2e-operator',
+        listActiveSubscriptionIdentities: () => ['@neo-fable-clio'],
+        resolveDeliveryLiveness         : () => ({alive: true, reason: null}),
+        resolveTerminalDeliveryFailures : () => ({state: 'observed', reason: null, byIdentity: new Map()}),
+        readPresence                    : () => PRESENCE_PAYLOAD,
+        now                             : () => new Date('2026-08-03T20:01:00.000Z'),
+        ...overrides
+    })
+}
+
+test.describe('fleetWakeRoutesSource — the decomposed per-seat wake-route read', () => {
+    test('construction refuses missing required collaborators', () => {
+        expect(() => createFleetWakeRoutesSource()).toThrow(TypeError);
+        expect(() => createFleetWakeRoutesSource({listAgents: () => []})).toThrow(TypeError);
+        expect(() => createFleetWakeRoutesSource({resolveViewerIdentity: () => '@a'})).toThrow(TypeError)
+    });
+
+    test('a fully-answered read is wired/observed with every axis speaking for itself', async () => {
+        const snapshot = await harness().readWakeRoutes();
+
+        expect(snapshot.capability).toEqual({
+            source    : 'fleet:wakeRoutes', state: 'wired', confidence: 'observed',
+            capturedAt: '2026-08-03T20:01:00.000Z', reason: null
+        });
+        expect(snapshot.viewer).toBe('@e2e-operator');
+        expect(snapshot.count).toBe(2);
+
+        const [ada, clio] = snapshot.seats;
+
+        expect(ada.agentIdentity).toBe('@neo-opus-ada');
+        expect(ada.subscription).toEqual({state: 'none', reason: null});
+        expect(clio.subscription).toEqual({state: 'active', reason: null});
+        expect(clio.delivery).toEqual({state: 'alive', reason: null});
+        expect(clio.lastFailure).toEqual({state: 'observed', reason: null, receipt: null});
+        expect(clio.presence).toEqual({
+            state: 'online', lastSeenAt: '2026-08-03T19:55:00.000Z', reason: 'recent add_memory activity'
+        });
+        // The one axis nobody can observe yet is a TYPED unobserved, present on every row.
+        expect(ada.armed.state).toBe('unobserved');
+        expect(typeof ada.armed.reason).toBe('string')
+    });
+
+    test('a terminal receipt reaches its seat as a first-class row fact', async () => {
+        const byIdentity = new Map([[
+            '@neo-fable-clio',
+            [{subscriptionId: 'sub-1', errorClass: 'connect-timeout', failedAt: '2026-08-03T19:00:00.000Z'}]
+        ]]);
+
+        const snapshot = await harness({
+            resolveTerminalDeliveryFailures: () => ({state: 'observed', reason: null, byIdentity})
+        }).readWakeRoutes();
+
+        const clio = snapshot.seats.find(seat => seat.agentIdentity === '@neo-fable-clio');
+
+        expect(clio.lastFailure.receipt).toEqual({errorClass: 'connect-timeout', failedAt: '2026-08-03T19:00:00.000Z'});
+        expect(clio.lastFailure.reason).toContain('connect-timeout');
+
+        // The sibling seat keeps its own clean answer — no shared-state bleed.
+        const ada = snapshot.seats.find(seat => seat.agentIdentity === '@neo-opus-ada');
+
+        expect(ada.lastFailure.receipt).toBeNull()
+    });
+
+    test('a throwing subscription scan degrades EVERY seat axis with the same reason, never a fabricated none', async () => {
+        const snapshot = await harness({
+            listActiveSubscriptionIdentities: () => { throw new Error('plane wake fleet-identities answer unreadable') }
+        }).readWakeRoutes();
+
+        expect(snapshot.capability.state).toBe('degraded');
+        expect(snapshot.capability.confidence).toBe('partial');
+        expect(snapshot.capability.reason).toContain('subscription axis');
+
+        for (const seat of snapshot.seats) {
+            expect(seat.subscription.state).toBe('unknown');
+            expect(seat.subscription.reason).toContain('unreadable')
+        }
+    });
+
+    test('typed-unknown delivery axes (the plane mode reality) degrade honestly and name themselves', async () => {
+        const snapshot = await harness({
+            resolveDeliveryLiveness: () => ({
+                alive : 'unknown',
+                reason: 'delivery-lane liveness is not exposed by the containerized plane yet'
+            }),
+            resolveTerminalDeliveryFailures: () => ({
+                state     : 'unknown',
+                reason    : 'terminal delivery receipts live with the containerized delivery authority; not exposed yet',
+                byIdentity: new Map()
+            })
+        }).readWakeRoutes();
+
+        expect(snapshot.capability.state).toBe('degraded');
+        expect(snapshot.capability.reason).toContain('delivery axis');
+        expect(snapshot.capability.reason).toContain('failure axis');
+
+        const seat = snapshot.seats[0];
+
+        expect(seat.delivery.state).toBe('unknown');
+        expect(seat.delivery.reason).toContain('not exposed by the containerized plane');
+        expect(seat.lastFailure.state).toBe('unknown');
+        // The observable axes stay untouched by the silent ones.
+        expect(seat.subscription.state).not.toBe('unknown');
+        expect(seat.presence.state).toBe('idle')
+    });
+
+    test('an out-of-contract delivery answer cannot fabricate a state', async () => {
+        const snapshot = await harness({
+            resolveDeliveryLiveness: () => ({alive: 'yes-definitely'})
+        }).readWakeRoutes();
+
+        expect(snapshot.seats[0].delivery).toEqual({
+            state : 'unknown',
+            reason: 'delivery liveness resolver returned an out-of-contract value'
+        })
+    });
+
+    test('a down delivery lane is an OBSERVED fact, distinct from unreadable', async () => {
+        const snapshot = await harness({
+            resolveDeliveryLiveness: () => ({alive: false, reason: 'stale PID file: recorded process is gone'})
+        }).readWakeRoutes();
+
+        expect(snapshot.capability.state).toBe('wired');
+        expect(snapshot.seats[0].delivery).toEqual({
+            state : 'down',
+            reason: 'stale PID file: recorded process is gone'
+        })
+    });
+
+    test('an absent presence reader is a typed unobserved; a malformed answer is unknown; a missing seat answers only for itself', async () => {
+        const unbound = await harness({readPresence: null}).readWakeRoutes();
+
+        expect(unbound.seats[0].presence.state).toBe('unobserved');
+        expect(unbound.capability.reason).toContain('presence axis');
+
+        const malformed = await harness({readPresence: () => ({nope: true})}).readWakeRoutes();
+
+        expect(malformed.seats[0].presence).toEqual({
+            state: 'unknown', lastSeenAt: null, reason: 'presence answer unreadable'
+        });
+
+        const partial = await harness({
+            readPresence: () => ({agents: [PRESENCE_PAYLOAD.agents[1]]})
+        }).readWakeRoutes();
+
+        const ada  = partial.seats.find(seat => seat.agentIdentity === '@neo-opus-ada'),
+              clio = partial.seats.find(seat => seat.agentIdentity === '@neo-fable-clio');
+
+        expect(partial.capability.state).toBe('wired');
+        expect(clio.presence.state).toBe('online');
+        expect(ada.presence).toEqual({
+            state: 'unknown', lastSeenAt: null, reason: 'seat absent from the presence report'
+        })
+    });
+
+    test('an unreadable roster is a source-level degrade with zero seats — never an empty fleet claim', async () => {
+        const snapshot = await harness({
+            listAgents: () => { throw new Error('registry unavailable') }
+        }).readWakeRoutes();
+
+        expect(snapshot.capability.state).toBe('degraded');
+        expect(snapshot.capability.confidence).toBe('none');
+        expect(snapshot.capability.reason).toContain('registry unavailable');
+        expect(snapshot.seats).toEqual([]);
+        expect(snapshot.count).toBe(0)
+    });
+
+    test('every axis silent still answers rows: all-unknown seats under degraded/none-adjacent truth', async () => {
+        const snapshot = await harness({
+            listActiveSubscriptionIdentities: null,
+            resolveDeliveryLiveness         : null,
+            resolveTerminalDeliveryFailures : null,
+            readPresence                    : null
+        }).readWakeRoutes();
+
+        expect(snapshot.capability.state).toBe('degraded');
+        expect(snapshot.capability.confidence).toBe('none');
+        expect(snapshot.count).toBe(2);
+
+        const seat = snapshot.seats[0];
+
+        expect(seat.subscription.state).toBe('unknown');
+        expect(seat.delivery.state).toBe('unknown');
+        expect(seat.lastFailure.state).toBe('unknown');
+        expect(seat.presence.state).toBe('unobserved')
+    });
+
+    test('a throwing viewer resolver yields a null viewer without taking the read down', async () => {
+        const snapshot = await harness({
+            resolveViewerIdentity: () => { throw new Error('no request context') }
+        }).readWakeRoutes();
+
+        expect(snapshot.viewer).toBeNull();
+        expect(snapshot.capability.state).toBe('wired')
+    })
+});

--- a/test/playwright/unit/ai/services/fleet/planeWhoIsOnlineReader.spec.mjs
+++ b/test/playwright/unit/ai/services/fleet/planeWhoIsOnlineReader.spec.mjs
@@ -1,0 +1,38 @@
+import {expect, test}                 from '@playwright/test';
+import {createPlaneWhoIsOnlineReader} from '../../../../../../ai/services/fleet/planeWhoIsOnlineReader.mjs';
+
+test.describe('planeWhoIsOnlineReader — the plane-mode presence read', () => {
+    test('the production request shape is the verbose contract — argument-captured, not assumed', async () => {
+        // The terse report omits the per-agent rows entirely, so the exact request arguments ARE
+        // the contract under test: a reader that "works" against a hand-injected verbose payload
+        // while sending the terse request would throw on every healthy production call.
+        const
+            calls   = [],
+            payload = {agents: [{identity: '@neo-fable-clio', state: 'online', reason: null, signals: {}}]},
+            reader  = createPlaneWhoIsOnlineReader({
+                callTool: (name, args) => {
+                    calls.push([name, args]);
+                    return Promise.resolve(payload)
+                }
+            });
+
+        await expect(reader()).resolves.toBe(payload);
+        expect(calls).toEqual([['who_is_online', {verbose: true}]])
+    });
+
+    test('an answer without a top-level agents array throws — the source converts that into honest unknown', async () => {
+        const reader = createPlaneWhoIsOnlineReader({
+            callTool: () => Promise.resolve({signalStatus: 'terse shape, no rows'})
+        });
+
+        await expect(reader()).rejects.toThrow('plane who_is_online answer unreadable')
+    });
+
+    test('a client rejection propagates untouched — degradation policy belongs to the consumer', async () => {
+        const reader = createPlaneWhoIsOnlineReader({
+            callTool: () => Promise.reject(new Error('plane unreachable'))
+        });
+
+        await expect(reader()).rejects.toThrow('plane unreachable')
+    })
+});

--- a/test/playwright/unit/apps/agentos/view/fleet/fleetCockpit.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/fleetCockpit.spec.mjs
@@ -18,9 +18,9 @@ import {createAppLifecycle} from '../../../../../../../harness/appLifecycle.mjs'
 import {readFileSync}       from 'fs';
 import path                 from 'path';
 import {fileURLToPath}      from 'url';
-import Neo             from '../../../../../../../src/Neo.mjs';
-import * as core       from '../../../../../../../src/core/_export.mjs';
-import Instance        from '../../../../../../../src/manager/Instance.mjs';
+import Neo                  from '../../../../../../../src/Neo.mjs';
+import * as core            from '../../../../../../../src/core/_export.mjs';
+import Instance             from '../../../../../../../src/manager/Instance.mjs';
 
 const seedPath = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../../../../../../apps/agentos/resources/data/fleetRoster.json');
 
@@ -2167,6 +2167,90 @@ test.describe('Fleet cockpit — the liveness owner lifecycle (start/stop, #1529
             expect(host.applied, 'older news never overwrites newer truth').toEqual([{cause: null, state: 'running'}]);
             expect(host.brainHealthReadInFlight, 'both wires settled, both slots free').toBe(0)
         })
+    })
+});
+
+/**
+ * Covers the cockpit-owned wake-routes read (`loadWakeRoutes`): the memories-sibling loader under
+ * the same three laws — a typed unavailable envelope for an unwired or throwing bridge (never
+ * fabricated seats), the generation fence (a slow older read never overwrites a newer one), and
+ * write-time pane resolution (the accepted truth reaches the LIVE pane, and an owner-held snapshot
+ * survives pane rematerialization). Prototype-call harness; the bridge mock is scoped to the
+ * `fleet` subkey only, per the loadActivity block's discipline.
+ */
+test.describe('Fleet cockpit — the wake-routes read (loadWakeRoutes)', () => {
+    let FleetCockpit;
+
+    test.beforeAll(async () => {
+        FleetCockpit = (await import('../../../../../../../apps/agentos/view/fleet/FleetCockpit.mjs')).default
+    });
+
+    const clearFleetBridge = () => { delete globalThis.AgentOS?.fleet };
+    const setFleetBridge   = bridge => { (globalThis.AgentOS ??= {}).fleet = {registryBridge: bridge} };
+
+    const makeHost = pane => ({
+        isDestroyed             : false,
+        wakeRoutesReadGeneration: 0,
+        wakeRoutesSnapshot      : null,
+        getReference            : reference => reference === 'wakeRoutes' ? pane : null,
+        loadWakeRoutes          : FleetCockpit.prototype.loadWakeRoutes
+    });
+
+    test('an unwired verb lands as a typed unavailable envelope on the owner AND the live pane', async () => {
+        clearFleetBridge();
+
+        const pane = {snapshot: null},
+              host = makeHost(pane);
+
+        const snapshot = await host.loadWakeRoutes();
+
+        expect(snapshot.capability).toEqual({state: 'unavailable', reason: 'fleet wake-routes verb not wired'});
+        expect(snapshot.seats).toEqual([]);
+        expect(host.wakeRoutesSnapshot).toBe(snapshot);
+        expect(pane.snapshot).toBe(snapshot)
+    });
+
+    test('a throwing bridge is transport truth, never fabricated seats', async () => {
+        setFleetBridge({fleetWakeRoutes: () => { throw new Error('boom') }});
+
+        try {
+            const host     = makeHost(null),
+                  snapshot = await host.loadWakeRoutes();
+
+            expect(snapshot.capability.reason).toBe('fleet wake-routes read failed');
+            expect(snapshot.seats).toEqual([])
+        } finally {
+            clearFleetBridge()
+        }
+    });
+
+    test('the generation fence: a slow older read never overwrites the newer accepted truth', async () => {
+        const wires = [];
+
+        setFleetBridge({fleetWakeRoutes: () => new Promise(resolve => wires.push(resolve))});
+
+        try {
+            const pane = {snapshot: null},
+                  host = makeHost(pane);
+
+            const slow = host.loadWakeRoutes(),
+                  fast = host.loadWakeRoutes();
+
+            const newer = {capability: {state: 'wired'}, count: 1, seats: [{agentIdentity: '@a'}]},
+                  older = {capability: {state: 'wired'}, count: 9, seats: []};
+
+            wires[1](newer);
+            await fast;
+            expect(host.wakeRoutesSnapshot).toBe(newer);
+            expect(pane.snapshot).toBe(newer);
+
+            wires[0](older);
+            await slow;
+            expect(host.wakeRoutesSnapshot, 'the loser never writes').toBe(newer);
+            expect(pane.snapshot).toBe(newer)
+        } finally {
+            clearFleetBridge()
+        }
     })
 });
 

--- a/test/playwright/unit/apps/agentos/view/fleet/fleetCockpitPopOut.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/fleetCockpitPopOut.spec.mjs
@@ -224,7 +224,7 @@ test.describe.serial('AgentOS.view.fleet.FleetCockpit — detail pop-out state m
 
         // the placement truth: `addTab` appends by default — the restore must land the item back
         // at its STORED index (0, before the rest of the rail), not at the tail
-        expect(cockpit.getDockZoneDocument().nodes['secondary-rail'].items).toEqual(['detail', 'perspectives', 'defineAgent', 'catchUp', 'memories', 'operator']);
+        expect(cockpit.getDockZoneDocument().nodes['secondary-rail'].items).toEqual(['detail', 'perspectives', 'defineAgent', 'catchUp', 'memories', 'wakeRoutes', 'operator']);
 
         // same instance re-adopted by the projection; the vessel was closed by name
         expect(cockpit.getReference('agent-detail')).toBe(pane);
@@ -259,7 +259,7 @@ test.describe.serial('AgentOS.view.fleet.FleetCockpit — detail pop-out state m
 
             // the SAME instance is docked again at its exact home; nothing was closed (nothing opened)
             expect(cockpit.getReference('agent-detail')).toBe(pane);
-            expect(cockpit.getDockZoneDocument().nodes['secondary-rail'].items).toEqual(['detail', 'perspectives', 'defineAgent', 'catchUp', 'memories', 'operator']);
+            expect(cockpit.getDockZoneDocument().nodes['secondary-rail'].items).toEqual(['detail', 'perspectives', 'defineAgent', 'catchUp', 'memories', 'wakeRoutes', 'operator']);
             expect(vessel.closeCalls).toHaveLength(0)
         } finally {
             console.warn = origWarn

--- a/test/playwright/unit/apps/agentos/view/fleet/fleetCockpitProjection.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/fleetCockpitProjection.spec.mjs
@@ -296,6 +296,7 @@ test.describe('Fleet cockpit — dock projection wiring (the resize commit loop)
             'defineAgent',
             'catchUp',
             'memories',
+            'wakeRoutes',
             'operator'
         ])
     });

--- a/test/playwright/unit/apps/agentos/view/fleet/wakeRoutePane.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/wakeRoutePane.spec.mjs
@@ -1,0 +1,197 @@
+import {setup} from '../../../../../setup.mjs';
+
+setup({
+    appConfig: {
+        name: 'WakeRoutePaneHonestyTest'
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../../../../src/Neo.mjs';
+import * as core      from '../../../../../../../src/core/_export.mjs';
+import '../../../../../../../src/manager/Instance.mjs';
+import WakeRoutePane  from '../../../../../../../apps/agentos/view/fleet/WakeRoutePane.mjs';
+
+/**
+ * @summary One seat row in the exact `fleetWakeRoutes` contract shape.
+ * @param {String} identity
+ * @param {Object} [overrides]
+ * @returns {Object}
+ */
+function seat(identity, overrides = {}) {
+    return {
+        agentId      : identity.replace('@', ''),
+        agentIdentity: identity,
+        subscription : {state: 'active', reason: null},
+        armed        : {state: 'unobserved', reason: 'seat-side route arming is not exposed to the fleet server yet'},
+        delivery     : {state: 'alive', reason: null},
+        lastFailure  : {state: 'observed', reason: null, receipt: null},
+        presence     : {state: 'online', lastSeenAt: '2026-08-03T19:55:00.000Z', reason: null},
+        ...overrides
+    }
+}
+
+/**
+ * @summary One wired source envelope.
+ * @param {Object[]} seats
+ * @param {Object} [capability]
+ * @returns {Object}
+ */
+function envelope(seats, capability = {}) {
+    return {
+        capability: {
+            source    : 'fleet:wakeRoutes', state: 'wired', confidence: 'observed',
+            capturedAt: '2026-08-03T20:01:00.000Z', reason: null, ...capability
+        },
+        viewer: '@e2e-operator',
+        count : seats.length,
+        seats
+    }
+}
+
+/**
+ * @summary Create the pane with captured `wakeRoutesRequest` intents.
+ * @param {Object} [config]
+ * @returns {{pane: Object, requests: Object[]}}
+ */
+function createPane(config = {}) {
+    const requests = [],
+          pane     = Neo.create(WakeRoutePane, {
+              listeners: {wakeRoutesRequest: data => {
+                  const {source, ...params} = data;
+                  requests.push(params)
+              }},
+              ...config
+          });
+
+    return {pane, requests}
+}
+
+test.describe('WakeRoutePane — decomposed per-seat honesty (never fused)', () => {
+    test('an unobserved pane claims nothing and never queries on its own', () => {
+        const {pane, requests} = createPane();
+
+        expect(requests).toEqual([]);
+        expect(pane.seatStore.count).toBe(0);
+        expect(pane.getReference('wakeroutes-meta').text).toBe('Read the routes to see each seat’s wake path.');
+
+        pane.destroy()
+    });
+
+    test('a wired envelope projects every axis into Store rows and each axis renders as ITSELF', () => {
+        const {pane} = createPane();
+
+        pane.snapshot = envelope([
+            seat('@neo-opus-ada', {
+                subscription: {state: 'none', reason: null},
+                presence    : {state: 'idle', lastSeenAt: '2026-08-03T18:29:27.443Z', reason: 'stale add_memory activity'}
+            }),
+            seat('@neo-fable-clio', {
+                lastFailure: {
+                    state  : 'observed',
+                    reason : 'terminal wake delivery failure: connect-timeout',
+                    receipt: {errorClass: 'connect-timeout', failedAt: '2026-08-03T19:00:00.000Z'}
+                }
+            })
+        ]);
+
+        expect(pane.seatStore.count).toBe(2);
+
+        const ada = pane.seatStore.get('@neo-opus-ada');
+
+        expect(ada.subscriptionState).toBe('none');
+        expect(ada.presenceState).toBe('idle');
+        expect(ada.armedState).toBe('unobserved');
+
+        const clio = pane.seatStore.get('@neo-fable-clio');
+
+        expect(clio.failureErrorClass).toBe('connect-timeout');
+        expect(clio.failureAt).toBe('2026-08-03T19:00:00.000Z');
+
+        expect(pane.getReference('wakeroutes-meta').text)
+            .toBe('2 seat routes · every axis observed · captured 2026-08-03 20:01Z');
+
+        // The rendered card carries the state IN THE SENTENCE (never colour alone), reason attached.
+        const rows  = pane.getReference('wakeroutes-rows'),
+              texts = rows.items.map(card => card.items.map(line => line.text));
+
+        expect(texts[0][0]).toBe('@neo-opus-ada');
+        expect(texts[0][1]).toBe('subscription: none');
+        expect(texts[0][2]).toContain('armed: unobserved — seat-side route arming');
+        expect(texts[0][5]).toContain('presence: idle · last seen 2026-08-03 18:29Z — stale add_memory activity');
+        expect(texts[1][4]).toBe('last failure: connect-timeout at 2026-08-03 19:00Z');
+
+        pane.destroy()
+    });
+
+    test('a degraded-partial envelope keeps its rows AND names every silent axis — partial truth plus a named gap', () => {
+        const {pane} = createPane();
+
+        pane.snapshot = envelope([
+            seat('@neo-fable-clio', {
+                delivery   : {state: 'unknown', reason: 'delivery-lane liveness is not exposed by the containerized plane yet'},
+                lastFailure: {state: 'unknown', reason: 'terminal delivery receipts live with the containerized delivery authority; not exposed yet', receipt: null}
+            })
+        ], {
+            state     : 'degraded',
+            confidence: 'partial',
+            reason    : 'delivery axis: not exposed yet; failure axis: not exposed yet'
+        });
+
+        expect(pane.seatStore.count).toBe(1);
+        expect(pane.getReference('wakeroutes-meta').text)
+            .toContain('silent axes: delivery axis: not exposed yet; failure axis: not exposed yet');
+
+        const texts = pane.getReference('wakeroutes-rows').items[0].items.map(line => line.text);
+
+        expect(texts[3]).toContain('delivery: unknown — delivery-lane liveness is not exposed');
+
+        pane.destroy()
+    });
+
+    test('an unavailable envelope clears the rows and claims exactly that', () => {
+        const {pane} = createPane();
+
+        pane.snapshot = envelope([seat('@neo-fable-clio')]);
+        expect(pane.seatStore.count).toBe(1);
+
+        pane.snapshot = {
+            capability: {state: 'unavailable', reason: 'fleet wake-routes verb not wired'},
+            viewer    : null,
+            count     : 0,
+            seats     : []
+        };
+
+        expect(pane.seatStore.count).toBe(0);
+        expect(pane.getReference('wakeroutes-meta').text)
+            .toBe('Wake routes unavailable · fleet wake-routes verb not wired');
+        expect(pane.getReference('wakeroutes-rows').items[0].text)
+            .toBe('The wake-routes source did not answer. Nothing here claims reachability.');
+
+        pane.destroy()
+    });
+
+    test('an empty registry renders as an honest empty, distinct from unavailable', () => {
+        const {pane} = createPane();
+
+        pane.snapshot = envelope([]);
+
+        expect(pane.getReference('wakeroutes-rows').items[0].text).toBe('No seats in the registry.');
+
+        pane.destroy()
+    });
+
+    test('the read is the explicit act: Refresh fires the intent, and destroy releases the Store', () => {
+        const {pane, requests} = createPane();
+
+        pane.onRefreshClick();
+        expect(requests).toEqual([{}]);
+
+        const store = pane.seatStore;
+
+        pane.destroy();
+        // A destroyed instance releases its fields (undefined-or-null — the point is: no live ref).
+        expect(pane.seatStore ?? null).toBeNull();
+        expect(store.isDestroyed ?? store.isDestroying ?? true).toBeTruthy()
+    })
+});

--- a/test/playwright/unit/apps/agentos/view/fleet/wakeRoutePane.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/wakeRoutePane.spec.mjs
@@ -181,6 +181,38 @@ test.describe('WakeRoutePane — decomposed per-seat honesty (never fused)', () 
         pane.destroy()
     });
 
+    test('degraded/none never claims an empty registry — the roster-unreadable vs observed-empty control pair', () => {
+        const {pane} = createPane();
+
+        // An unreadable roster arrives as degraded/none with zero seats. Adopting it would render
+        // "No seats in the registry" for a registry nobody could read — the pane must refuse.
+        pane.snapshot = {
+            capability: {
+                source    : 'fleet:wakeRoutes', state: 'degraded', confidence: 'none',
+                capturedAt: '2026-08-03T20:01:00.000Z', reason: 'fleet roster unreadable'
+            },
+            viewer: null,
+            count : 0,
+            seats : []
+        };
+
+        expect(pane.seatStore.count).toBe(0);
+        expect(pane.getReference('wakeroutes-meta').text).toBe('Wake routes unavailable · fleet roster unreadable');
+        expect(pane.getReference('wakeroutes-rows').items[0].text)
+            .toBe('The wake-routes source did not answer. Nothing here claims reachability.');
+
+        // The control: observed-empty PARTIAL truth claims the empty registry honestly.
+        pane.snapshot = envelope([], {
+            state     : 'degraded',
+            confidence: 'partial',
+            reason    : 'arming axis: seat-side route arming is not exposed to the fleet server yet'
+        });
+
+        expect(pane.getReference('wakeroutes-rows').items[0].text).toBe('No seats in the registry.');
+
+        pane.destroy()
+    });
+
     test('the read is the explicit act: Refresh fires the intent, and destroy releases the Store', () => {
         const {pane, requests} = createPane();
 


### PR DESCRIPTION
Resolves #16469

Refs #16431

The cockpit gains its per-seat wake-route panel — the DECOMPOSED complement to the roster's fused wake telltale. One new `fleetWakeRoutes` wire verb answers an envelope where every axis of each seat's wake path speaks as itself: subscription intent, seat-side arming, delivery-lane liveness, the last terminal failure receipt, and presence freshness. Nothing fuses, because a fused verdict cannot say WHICH leg broke — and a crash-looping orchestrator that reported healthy for 968 restarts is this week's proof of why the legs must stay separate. Brain side: `fleetWakeRoutesSource` composes injected per-axis readers under the wake adapter's fail-honest discipline; the entry binds the SAME per-mode truth the fused axis already uses — one authority per axis, nothing double-sourced. Body side: `WakeRoutePane` projects the envelope into a pane-local Store of per-seat records (state in the sentence, never colour alone; reading is the explicit first act), and the cockpit loader rides the full house discipline — generation fence, typed fallbacks, write-time pane resolution.

**Close-target honesty (review round 1):** this PR fully delivers #16469 — the four-observable-axes leaf split out per the cycle-1 review — while #16431 stays open and explicitly owns the server-side arming read and the real-plane-row evidence. The five-axis contract is still encoded: the arming axis ships as a typed `unobserved` that PARTICIPATES in capability certification, so `wired/observed` is unreachable by construction until its read exists.

**Review round 1 (@neo-gpt, PRR 4848222830), all four RAs repaired at `e38485ae2d`:** the production presence reader now requests the verbose `who_is_online` contract with an argument-capture test (the terse shape omits the rows — a reader validated only against hand-injected payloads would throw on every healthy production call); the envelope certifies the conjunction of ALL FIVE declared axes with silent axes named per-axis and per-envelope; an unreadable roster (throw OR non-array) is `degraded/none` and the pane adopts rows only from `partial` confidence — roster-unreadable vs observed-empty is a spec'd control pair on both sides; host terminal receipts reconnect through the adapter's newly exported file-backed reader factory (same parsing, same degradation), witnessed receipt-file → source → exact seat. Plus the review's polish: `fleetWakeRoutes` in the read-observe verb inventory and the `wakeRoutesSource` DI field declared beside its siblings.

Evidence: L2 achieved (hermetic units across every seam: source axis matrix incl. the armed-certification and roster-unreadable controls, reader argument capture, pane honesty states, loader fence/fallback/write-time-resolve) + L3-wire achieved (a live booted fleet server answered the authenticated verb — receipt below) → the plane-mode seat rows and rendered-pane observation are #16431-retained work behind the operator-gated `fleet.planeBearer` (single-viewer invariant), annotated there. Residual: none on #16469.

## Deltas from ticket

- **The armed axis participates in envelope truth** (review round 1 sharpening): typed `unobserved` in every row AND counted in capability certification — `wired` is unreachable while any declared axis is structurally silent, which is the conjunction rule a decomposed diagnostic must keep or it re-imports fused over-certification.
- **Presence rides the verbose `who_is_online` contract** over the proven plane client — payload shape verified live, request shape argument-capture-tested (the round-1 catch: I had verified verbose and bound terse).
- **The panel reads on explicit intent** (Read routes button), matching the MemoriesPane no-auto-query discipline; liveness-cadence integration is follow-up material once the panel earns a resident slot.
- **Capability envelope semantics**: `degraded/partial` names each silent axis; `degraded/none` (unreadable roster included) never renders as an empty registry.

## Test Evidence

Per-file runs only (the multi-file `test-unit` undercount from PR `#16437` stands as verification law):

- `fleetWakeRoutesSource.spec.mjs` → **15 passed** (armed-certification control; terminal receipt row-locality; throwing scan degrades every seat with its reason; typed-unknown plane axes; out-of-contract answers cannot fabricate; observed-down vs unreadable; absent/malformed/partial presence; roster throw AND non-array = unreadable vs observed-empty control; all-silent axes; throwing viewer resolver; the file-backed receipt reader feeding the source end to end).
- `planeWhoIsOnlineReader.spec.mjs` → **3 passed** (argument capture pins `callTool('who_is_online', {verbose:true})`; non-array answer throws; client rejection propagates).
- `wakeRoutePane.spec.mjs` → **7 passed** (adds the `degraded/none` vs observed-empty control pair).
- `fleetCockpit.spec.mjs` → **90 passed** including three `loadWakeRoutes` tests (typed unavailable to owner AND live pane; throwing bridge; generation fence with real out-of-order wires).
- Contract pins + regressions: `dispatchFleetRequest` 12/12 (wire allowlist exact list) · `fleetWakeStateAdapter` 35/35 (the new export beside untouched behavior) · `fleetCockpitProjection` 13/13 · `fleetCockpitPopOut` 13/13 · `memoriesPane` 5/5 · `cockpitDockDocument` 7/7 · `fleetCapability` 8/8 · `createFleetRegistryBridge` 8/8.

Live wire receipt (host mode, real booted `devFleetServer`, authenticated):

```
POST /fleet {"method":"fleetWakeRoutes","params":{}}
→ {"ok":true,"result":{"capability":{"source":"fleet:wakeRoutes","state":"degraded","confidence":"partial",
   "capturedAt":"2026-08-03T19:31:24.720Z","reason":"failure axis: terminal delivery read path unavailable;
   presence axis: presence read path unavailable"},"viewer":"@neo-fable-clio","count":0,"seats":[]}
```

The receipt exercises the honest paths end to end: authenticated viewer binding, per-axis silence NAMED in the envelope, and an empty host registry answering zero seats rather than fabricated rows (`listAgents` → `[]` verified alongside). It predates the round-1 repairs; the current head additionally reconnects the host failure axis and names the arming axis in that reason line — asserted by the per-file suites above at the exact head.

## Post-Merge Validation

- [ ] Wake routes tab in the secondary rail: Read routes → seat cards render with per-axis lines on a dev cockpit against the local fleet server.

(The containerized-plane seat rows and the arming axis activation are #16431-retained work, annotated there — not validation items of this leaf.)

## Commits

- d0f6214881 — the whole vertical: source + wiring + verb + allowlist + entry binding, model + store + pane + cockpit loader/controller/dock, and all specs.
- c59540c6dd — three full-suite contract pins learn the new surface (wire allowlist, projection census, pop-out index restores).
- e38485ae2d — review round 1: verbose presence contract + argument capture; five-axis envelope certification; roster-unreadable vs observed-empty on both sides; host receipt authority reconnected via the adapter's exported reader.

Authored by Clio (Claude Fable 5, Claude Code). Session 3211d581-d2d7-4b68-a710-86be26a38ff6.
