### PR TITLE
fix(ai): a degraded Memory Core no longer takes the whole plane's ingress down (#16430)

### DIFF
--- a/ai/deploy/docker-compose.dev.yml
+++ b/ai/deploy/docker-compose.dev.yml
@@ -262,11 +262,16 @@ services:
     # Served identity, same contract as kb-server above — both servers declare `plane {id, dataRoot}`
     # in their healthcheck response schema, so both can be asked to prove which plane they serve.
     healthcheck:
+      # Restated, not inherited: a list-valued `healthcheck.test` override REPLACES the base command.
+      # The parity stack runs beside the canonical plane against a real provider, so it carries the
+      # same cold-start exposure — a degraded-but-serving Memory Core must not gate startup here
+      # either. `unhealthy` still fails.
       test: ["CMD", "node", "./ai/scripts/diagnostics/mcpHealthcheck.mjs",
              "--url", "http://127.0.0.1:3001",
              "--client-name", "neo-mc-parity-healthcheck",
              "--expected-plane-id", *plane-id,
-             "--expected-plane-data-root", "/app/.neo-ai-data-parity"]
+             "--expected-plane-data-root", "/app/.neo-ai-data-parity",
+             "--expected-status", "healthy,degraded"]
       interval: 15s
       timeout: 10s
       retries: 10

--- a/ai/deploy/docker-compose.local-agent-os.yml
+++ b/ai/deploy/docker-compose.local-agent-os.yml
@@ -47,8 +47,15 @@ services:
       <<: [*local-auth, *local-provider]
     secrets:
       - mcp-auth-token
+    # `healthcheck.test` is a LIST, so this override REPLACES the base command rather than extending
+    # it — every argument the base carries must be restated here or it is silently dropped from the
+    # rendered plane. `--expected-status healthy,degraded` is one of them: without it a Memory Core
+    # that is serving correctly with the host provider down is marked unhealthy, and `ingress` +
+    # `orchestrator` gate on `service_healthy`, so the whole loopback plane fails to come up — taking
+    # a perfectly healthy Knowledge Base with it. This profile wires the host provider explicitly
+    # (`host.docker.internal:1234`), which is precisely the cold-start exposure.
     healthcheck:
-      test: ["CMD", "node", "./ai/scripts/diagnostics/mcpHealthcheck.mjs", "--url", "http://127.0.0.1:3001", "--expected-plane-id", "neo-local-canonical", "--expected-plane-data-root", "/app/.neo-ai-data"]
+      test: ["CMD", "node", "./ai/scripts/diagnostics/mcpHealthcheck.mjs", "--url", "http://127.0.0.1:3001", "--expected-plane-id", "neo-local-canonical", "--expected-plane-data-root", "/app/.neo-ai-data", "--expected-status", "healthy,degraded"]
 
   orchestrator:
     restart: unless-stopped

--- a/ai/deploy/docker-compose.yml
+++ b/ai/deploy/docker-compose.yml
@@ -205,8 +205,21 @@ services:
     # If this deployment opts into NEO_AUTH_MODE=gitlab-pat, the in-container MCP
     # self-probe must authenticate too. Ensure NEO_MCP_HEALTHCHECK_TOKEN is present
     # in the container environment; mcpHealthcheck.mjs sends it as a bearer token.
+    #
+    # `degraded` counts as ALIVE here, and that is a deliberate agreement with the server rather
+    # than a relaxation. Memory Core treats its non-WAL dependencies as best-effort on purpose
+    # (Server.mjs `prepareStartupDependency`): a provider-dependent canary must never veto MCP
+    # startup, or the mandatory end-of-turn save disappears exactly when a degraded deployment most
+    # needs lossless WAL capture. This probe defaulted to `healthy` only, so a server that was
+    # serving correctly with one provider unreachable was marked unhealthy — and because `ingress`
+    # and `orchestrator` both gate on `service_healthy`, a cold host whose embedding provider was
+    # not yet up lost its entire loopback plane, taking the Knowledge Base down with it despite
+    # `kb-server` being perfectly healthy.
+    #
+    # `unhealthy` is still failing, and is still the only failing verdict. The point is to
+    # distinguish the two, not to erase both.
     healthcheck:
-      test: ["CMD", "node", "./ai/scripts/diagnostics/mcpHealthcheck.mjs", "--url", "http://127.0.0.1:3001", "--client-name", "neo-mc-container-healthcheck"]
+      test: ["CMD", "node", "./ai/scripts/diagnostics/mcpHealthcheck.mjs", "--url", "http://127.0.0.1:3001", "--client-name", "neo-mc-container-healthcheck", "--expected-status", "healthy,degraded"]
       interval: 10s
       timeout: 10s
       retries: 12

--- a/ai/scripts/diagnostics/mcpHealthcheck.mjs
+++ b/ai/scripts/diagnostics/mcpHealthcheck.mjs
@@ -105,7 +105,7 @@ export function parseArgs(argv = [], env = process.env) {
         .option('--identity <identity>', 'Trusted proxy identity header value.', env.NEO_MCP_HEALTHCHECK_IDENTITY || 'neo-container-healthcheck')
         .option('--bearer-token-env <name>', 'Environment variable containing an OAuth bearer token.', env.NEO_MCP_HEALTHCHECK_TOKEN_ENV || 'NEO_MCP_HEALTHCHECK_TOKEN')
         .option('--bearer-token-file <path>', 'File containing an OAuth bearer token.', env.NEO_MCP_HEALTHCHECK_TOKEN_FILE || null)
-        .option('--expected-status <status>', 'Expected healthcheck status value.', env.NEO_MCP_HEALTHCHECK_EXPECTED_STATUS || 'healthy')
+        .option('--expected-status <statuses>', 'Comma-separated healthcheck statuses accepted as passing (e.g. "healthy,degraded").', env.NEO_MCP_HEALTHCHECK_EXPECTED_STATUS || 'healthy')
         .option('--expected-plane-id <id>', 'Plane identity the served process MUST report.', env.NEO_MCP_HEALTHCHECK_EXPECTED_PLANE_ID || null)
         .option('--expected-plane-data-root <path>', 'Plane data root the served process MUST report.', env.NEO_MCP_HEALTHCHECK_EXPECTED_PLANE_DATA_ROOT || null)
         .option('--client-name <name>', 'MCP client name.', env.NEO_MCP_HEALTHCHECK_CLIENT_NAME || 'neo-container-healthcheck')
@@ -221,12 +221,43 @@ export function readToolJson(result) {
 }
 
 /**
+ * @summary Resolves the set of healthcheck statuses this probe accepts as passing.
+ *
+ * **A liveness expectation is a SET, because "is it alive" and "is it fully well" are different
+ * questions and a container healthcheck asks the first one.** A server can be serving correctly while
+ * one provider-dependent dependency is degraded; expressing that with a single literal is impossible,
+ * since setting the literal to `degraded` would reject `healthy` — the well state failing the check.
+ *
+ * Deliberately strict about what it accepts. An empty or whitespace-only value **throws** rather than
+ * resolving to "accept anything": a healthcheck that cannot fail is not a healthcheck, and the way
+ * that arrives in practice is a misconfigured argument silently widening the gate.
+ *
+ * @param {String} expectedStatus Comma-separated status list; a single value stays a single value.
+ * @returns {String[]} The accepted statuses, de-duplicated and in declaration order.
+ */
+export function parseExpectedStatuses(expectedStatus) {
+    const accepted = String(expectedStatus ?? '')
+        .split(',')
+        .map(status => status.trim())
+        .filter(Boolean);
+
+    if (accepted.length === 0) {
+        throw new Error(
+            `--expected-status resolved to no statuses (got ${JSON.stringify(expectedStatus)}). ` +
+            'An empty expectation would accept every status, which is not a healthcheck.'
+        );
+    }
+
+    return [...new Set(accepted)]
+}
+
+/**
  * @summary Calls the remote MCP `healthcheck` tool and validates the returned status.
  * @param {Object} options
  * @param {String|URL} options.url The MCP server base URL.
  * @param {String|null} [options.identity]
  * @param {String|null} [options.bearerToken]
- * @param {String} [options.expectedStatus='healthy']
+ * @param {String} [options.expectedStatus='healthy'] Comma-separated set; see {@link parseExpectedStatuses}.
  * @param {String} [options.clientName='neo-container-healthcheck']
  * @param {String} [options.mcpPath='/mcp'] MCP endpoint path below `url`.
  * @param {Number} [options.timeoutMs=DEFAULT_TIMEOUT_MS]
@@ -284,10 +315,14 @@ export async function runHealthcheck({
             throw new Error('MCP healthcheck tool returned isError=true.');
         }
 
-        const health = readToolJson(result);
+        const health   = readToolJson(result),
+              accepted = parseExpectedStatuses(expectedStatus);
 
-        if (health.status !== expectedStatus) {
-            throw new Error(`Expected healthcheck status '${expectedStatus}', got '${health.status || '<missing>'}'.`);
+        if (!accepted.includes(health.status)) {
+            throw new Error(
+                `Expected healthcheck status ${accepted.map(status => `'${status}'`).join(' or ')}, ` +
+                `got '${health.status || '<missing>'}'.`
+            );
         }
 
         const plane = assertServedPlane(health, {expectedPlaneId, expectedPlaneDataRoot});

--- a/test/playwright/unit/ai/scripts/diagnostics/mcpHealthcheck.spec.mjs
+++ b/test/playwright/unit/ai/scripts/diagnostics/mcpHealthcheck.spec.mjs
@@ -667,20 +667,76 @@ test.describe('mcpHealthcheck — a liveness expectation is a SET', () => {
         await expect(probe('degraded')).rejects.toThrow(/Expected healthcheck status 'healthy', got 'degraded'/);
     });
 
-    test('the production compose actually OPTS IN — the two layers agree in the shipped file', () => {
-        // Without this the unit fix passes while the deployment keeps the old behaviour: the defect
-        // lived in the gap between a correct instrument and the argument it was never given.
-        const test_ = readProductionCompose().services['mc-server'].healthcheck.test;
+    /**
+     * `healthcheck.test` is a LIST, and Compose REPLACES list-valued fields across `-f` layers
+     * rather than merging them. So an overlay that restates the whole command to add plane
+     * assertions silently drops every argument the base carried — and the first version of this fix
+     * did exactly that: the base opted in, the canonical local overlay overrode it, and the plane
+     * the incident happened on rendered the old healthy-only probe. Green CI, unchanged deployment.
+     *
+     * Asserted over EVERY compose file that overrides the command rather than over one rendered
+     * composition, because a rendered check only covers the layerings someone thought to enumerate.
+     * This one cannot be escaped by adding a profile.
+     */
+    const composeFiles = ['docker-compose.yml', 'docker-compose.local-agent-os.yml', 'docker-compose.dev.yml'];
 
-        expect(test_.join(' ')).toContain('--expected-status healthy,degraded');
+    /**
+     * Reads one deploy compose file and returns each service's healthcheck command as a string.
+     *
+     * Compose's merge tags (`!override`, `!reset`) are not core YAML, and a plain `yaml.load` THROWS
+     * on the overlay that uses them — which is the one file that carried this defect. They are
+     * stripped rather than schema-registered because this js-yaml build exposes no `Type` /
+     * `DEFAULT_SCHEMA` on its ESM namespace; the tags only annotate merge behaviour and carry no
+     * value this assertion reads.
+     *
+     * @param {String} file
+     * @returns {Object} `{service: joinedCommand}` for services that define `healthcheck.test`.
+     */
+    function healthcheckCommands(file) {
+        const source = fs
+            .readFileSync(new URL(`../../../../../../ai/deploy/${file}`, import.meta.url), 'utf8')
+            .replace(/(:[ \t]*)![a-z]+\b/g, '$1');
+
+        const doc = yaml.load(source);
+
+        return Object.fromEntries(
+            Object.entries(doc.services || {})
+                .filter(([, service]) => Array.isArray(service?.healthcheck?.test))
+                .map(([name, service]) => [name, service.healthcheck.test.join(' ')])
+        );
+    }
+
+    test('EVERY compose file that owns an mc-server healthcheck command carries the liveness set', () => {
+        const owning = composeFiles.filter(file => healthcheckCommands(file)['mc-server']);
+
+        // The sweep is only as good as its population: if this ever finds nothing, the assertion
+        // below is vacuously true and proves nothing.
+        expect(owning.length).toBeGreaterThanOrEqual(3);
+
+        for (const file of owning) {
+            expect(healthcheckCommands(file)['mc-server'], file).toContain('--expected-status healthy,degraded');
+        }
     });
 
-    test('the change is SCOPED: kb-server is untouched', () => {
-        // kb-server measured `healthy` throughout the incident window — it does not degrade on a cold
-        // embedding provider, so it needs no opt-in. Pinned so a future blanket edit is visible
-        // rather than inherited.
-        const test_ = readProductionCompose().services['kb-server'].healthcheck.test;
+    test('the canonical local composition renders the liveness set — the documented two-file order', () => {
+        // The runbook's start command is base + local overlay, in that order. Compose replaces the
+        // list, so the LAST file that defines it wins; that resolved command is what the plane runs.
+        const [, local] = composeFiles.map(file => healthcheckCommands(file)['mc-server']);
 
-        expect(test_.join(' ')).not.toContain('--expected-status');
+        expect(local).toContain('--expected-status healthy,degraded');
+        expect(local).toContain('--expected-plane-id neo-local-canonical');  // identity assertions retained
+    });
+
+    test('the change is SCOPED: no kb-server healthcheck opts in, in any file', () => {
+        // kb-server measured `healthy` throughout the incident window — it does not degrade on a cold
+        // embedding provider, so it needs no opt-in. Pinned across every file so a future blanket
+        // edit is visible rather than inherited.
+        for (const file of composeFiles) {
+            const command = healthcheckCommands(file)['kb-server'];
+
+            if (command) {
+                expect(command, file).not.toContain('--expected-status');
+            }
+        }
     });
 });

--- a/test/playwright/unit/ai/scripts/diagnostics/mcpHealthcheck.spec.mjs
+++ b/test/playwright/unit/ai/scripts/diagnostics/mcpHealthcheck.spec.mjs
@@ -340,6 +340,10 @@ test.describe('ai/scripts/diagnostics/mcpHealthcheck (#11725)', () => {
             'neo-kb-container-healthcheck'
         ]);
 
+        // MC alone opts into treating `degraded` as alive: its non-WAL dependencies are best-effort
+        // by design, so a provider-dependent canary must not mark the container unhealthy and gate
+        // every service waiting on it. KB above carries no opt-in — it measured healthy throughout
+        // the incident window and does not degrade on a cold embedding provider.
         expect(compose.services['mc-server'].healthcheck.test).toEqual([
             'CMD',
             'node',
@@ -347,9 +351,14 @@ test.describe('ai/scripts/diagnostics/mcpHealthcheck (#11725)', () => {
             '--url',
             'http://127.0.0.1:3001',
             '--client-name',
-            'neo-mc-container-healthcheck'
+            'neo-mc-container-healthcheck',
+            '--expected-status',
+            'healthy,degraded'
         ]);
 
+        // The gate itself is deliberately UNCHANGED. `service_healthy` still guards startup; what
+        // changed is which server states count as healthy. Relaxing this to `service_started` would
+        // have let a genuinely broken Memory Core through, which is a worse defect than the one fixed.
         expect(compose.services.orchestrator.depends_on['kb-server']).toEqual({condition: 'service_healthy'});
         expect(compose.services.orchestrator.depends_on['mc-server']).toEqual({condition: 'service_healthy'});
     });
@@ -569,5 +578,109 @@ test.describe('served-plane verification — a healthy status is not an identity
             url   : 'http://127.0.0.1:8100/',
             plane : {id: 'neo-local-parity', dataRoot: '/app/.neo-ai-data-parity'}
         });
+    });
+});
+
+/**
+ * @summary `degraded` is alive, and one provider must not remove the plane's ingress.
+ *
+ * Memory Core treats its non-WAL dependencies as best-effort by design: a provider-dependent canary
+ * must never veto MCP startup, or the mandatory end-of-turn save disappears exactly when a degraded
+ * deployment most needs lossless WAL capture. The container probe disagreed — it accepted only
+ * `healthy` — so a server that was serving correctly with one provider unreachable was marked
+ * unhealthy, and `ingress` + `orchestrator` both gate on `service_healthy`.
+ *
+ * Measured during a real cold boot: `mc-server` unhealthy with a failing streak of 56 while its WAL
+ * was caught-up and it answered over the ingress, `kb-server` perfectly healthy — and the documented
+ * `up -d --wait` start command could not bring the plane up, taking the Knowledge Base down with it.
+ *
+ * These specs pin the agreement between the two layers, and the bound that keeps it from becoming a
+ * relaxation: `unhealthy` stays the failing verdict.
+ */
+test.describe('mcpHealthcheck — a liveness expectation is a SET', () => {
+    let parseExpectedStatuses, runHealthcheck;
+
+    const readProductionCompose = () => yaml.load(fs.readFileSync(
+        new URL('../../../../../../ai/deploy/docker-compose.yml', import.meta.url),
+        'utf8'
+    ));
+
+    /** Minimal transport + client pair returning one status. */
+    class FakeTransport {}
+
+    const clientReturning = status => class {
+        async connect() {}
+        async callTool() { return {structuredContent: {status}} }
+        async close() {}
+    };
+
+    const probe = (status, expectedStatus) => runHealthcheck({
+        url           : 'http://127.0.0.1:3001',
+        ...(expectedStatus ? {expectedStatus} : {}),
+        ClientClass   : clientReturning(status),
+        TransportClass: FakeTransport
+    });
+
+    test.beforeAll(async () => {
+        const mod = await import('../../../../../../ai/scripts/diagnostics/mcpHealthcheck.mjs');
+
+        parseExpectedStatuses = mod.parseExpectedStatuses;
+        runHealthcheck        = mod.runHealthcheck;
+    });
+
+    test('a single value stays a single value — the existing default is untouched', () => {
+        expect(parseExpectedStatuses('healthy')).toEqual(['healthy']);
+    });
+
+    test('a comma-separated list becomes the accepted set, trimmed and de-duplicated', () => {
+        expect(parseExpectedStatuses('healthy,degraded')).toEqual(['healthy', 'degraded']);
+        expect(parseExpectedStatuses(' healthy , degraded ')).toEqual(['healthy', 'degraded']);
+        expect(parseExpectedStatuses('healthy,healthy')).toEqual(['healthy']);
+    });
+
+    test('an EMPTY expectation throws — a healthcheck that cannot fail is not a healthcheck', () => {
+        // The realistic arrival is a misconfigured argument, and the dangerous resolution is
+        // "accept anything". Fail at parse rather than silently widening the gate.
+        for (const value of ['', '   ', ',', ' , ', null, undefined]) {
+            expect(() => parseExpectedStatuses(value), JSON.stringify(value)).toThrow(/not a healthcheck/);
+        }
+    });
+
+    test('THE FIX: with the set, a degraded-but-serving Memory Core PASSES', async () => {
+        await expect(probe('degraded', 'healthy,degraded')).resolves.toMatchObject({status: 'degraded'});
+    });
+
+    test('…and healthy still passes — the set widens, it does not swap', async () => {
+        // Load-bearing: a single-literal expectation of `degraded` would have made the WELL state
+        // fail. That impossibility is why the option had to become a set rather than a new default.
+        await expect(probe('healthy', 'healthy,degraded')).resolves.toMatchObject({status: 'healthy'});
+    });
+
+    test('THE BOUND: `unhealthy` still fails, so the signal is not flattened', async () => {
+        await expect(probe('unhealthy', 'healthy,degraded'))
+            .rejects.toThrow(/Expected healthcheck status 'healthy' or 'degraded', got 'unhealthy'/);
+    });
+
+    test('REGRESSION GUARD: the DEFAULT expectation still rejects degraded', async () => {
+        // Callers that pass nothing keep the old contract exactly. Only the deployment that opted in
+        // treats degraded as alive; nothing else silently loosened.
+        await expect(probe('degraded')).rejects.toThrow(/Expected healthcheck status 'healthy', got 'degraded'/);
+    });
+
+    test('the production compose actually OPTS IN — the two layers agree in the shipped file', () => {
+        // Without this the unit fix passes while the deployment keeps the old behaviour: the defect
+        // lived in the gap between a correct instrument and the argument it was never given.
+        const test_ = readProductionCompose().services['mc-server'].healthcheck.test;
+
+        expect(test_.join(' ')).toContain('--expected-status healthy,degraded');
+    });
+
+    test('the change is SCOPED: kb-server is untouched', () => {
+        // kb-server measured `healthy` throughout the incident window — it does not degrade on a cold
+        // embedding provider, so it needs no opt-in. Pinned so a future blanket edit is visible
+        // rather than inherited.
+        const test_ = readProductionCompose().services['kb-server'].healthcheck.test;
+
+        expect(test_.join(' ')).not.toContain('--expected-status');
     });
 });


### PR DESCRIPTION
Resolves #16430

Two layers disagreed about what `degraded` means, and the container layer won. Memory Core treats its non-WAL dependencies as best-effort **by design** — a provider-dependent canary must never veto MCP startup, or the mandatory end-of-turn save disappears exactly when a degraded deployment most needs lossless WAL capture. But `mcpHealthcheck.mjs` accepted only `healthy`, so a server that was serving correctly with one provider unreachable exited non-zero and its container was marked unhealthy.

`ingress` and `orchestrator` both gate on `service_healthy` for `mc-server`, so on a cold host whose embedding provider was not yet up, the documented `up -d --wait` start command could not bring the plane up at all — and **the Knowledge Base went down with it**, unreachable through a blocked ingress despite `kb-server` being perfectly healthy. A provider-side fault removed the half of the plane that does not depend on the provider.

The expectation becomes a **set** rather than a literal, because *"is it alive"* and *"is it fully well"* are different questions and a container healthcheck asks the first. A single value cannot express it: setting the literal to `degraded` would reject `healthy` — the well state failing the check. That impossibility is why the option had to widen rather than switch.

Evidence: L2 (mock dispatch over the real `runHealthcheck`, plus contract assertions read from the shipped `docker-compose.yml`; the verdict guard is mutation-verified) → L3 required (a live cold boot with the embedding provider down, running the runbook's own start command). Residual: AC1, AC2 and AC4 [#16430].

## Deltas from ticket

**Only the first of the two candidate shapes was taken.** The ticket offered `and/or`: fix the healthcheck expectation, and/or relax `ingress`/`orchestrator` to `service_started`. I did the first and deliberately not the second.

Gating on `service_started` removes the gate rather than correcting it — a genuinely broken Memory Core would then be allowed to start everything downstream, which is a worse defect than the one being fixed and would violate the ticket's own AC3. What needed changing was *which server states count as healthy*, not *whether a health gate exists*. The `depends_on` blocks are unchanged, and a spec now pins that they stayed `service_healthy` with the reason attached.

**`kb-server` is deliberately untouched, and that was measured rather than assumed.** Both KB and MC can emit `degraded`, and both compose healthchecks share the same instrument — so an MC-only fix is only sufficient if KB does not also degrade on a cold provider. The ticket's own incident table answers it: `kb-server health=healthy` throughout the window in which the provider was down. KB needs no opt-in, and a spec pins its absence so a future blanket edit is visible rather than inherited.

**An empty expectation throws.** `--expected-status ""` could have resolved to an empty accepted set. Depending on the comparison that is either accept-nothing or accept-everything, and the second is a healthcheck that cannot fail. The realistic arrival is a misconfigured argument in a compose file, so it fails at parse with the reason.

## Test Evidence

```
npm run test-unit -- test/playwright/unit/ai/scripts/diagnostics/mcpHealthcheck.spec.mjs
→ 36 passed
```

Every spec that reads the production compose, run together — because this change edits that file and the contract assertions live scattered across the tree:

```
npm run test-unit -- .../mcpHealthcheck.spec.mjs test/playwright/unit/ai/deploy \
                     test/playwright/unit/ai/daemons/orchestrator \
                     .../DeployPipelineRevisionPin.spec.mjs test/playwright/unit/harness/pack.spec.mjs
→ 1244 passed (1.1m)
```

**Mutation-verified.** Flattening the verdict (`if (false && !accepted.includes(...))`) fails exactly three specs and no others:

| spec | why it must fail |
|---|---|
| *(pre-existing)* `runHealthcheck fails on unhealthy status` | the original contract |
| `THE BOUND: unhealthy still fails` | AC3 — the change must not flatten `unhealthy` into alive |
| `REGRESSION GUARD: the DEFAULT expectation still rejects degraded` | callers passing nothing keep the old behaviour |

The two fix-enabling specs (`degraded` passes, `healthy` still passes) keep passing under that mutation, which is correct — they are positive cases and cannot detect a too-permissive guard. That is what the three above are for.

Surfaces touched: `ai/scripts/diagnostics/mcpHealthcheck.mjs` → `mcpHealthcheck.spec.mjs` (36 passed) | `ai/deploy/docker-compose.yml` → asserted from the shipped file by `mcpHealthcheck.spec.mjs` plus the 1244-spec compose-reader sweep above.

The compose assertion is deliberately read out of the real `docker-compose.yml` rather than a fixture. The defect lived in the gap between a correct instrument and the argument it was never given — a unit test of the instrument alone would have passed on the broken deployment.

## Post-Merge Validation

- [ ] **AC1** — with the embedding provider unreachable from a cold start, the runbook's `up -d --wait` brings `ingress` up and `127.0.0.1:3102/kb/mcp` answers `healthy`. Expected to fail RED before this change.
- [ ] **AC2** — a `degraded` Memory Core gates no other service's startup, witnessed from a live run rather than reasoned.
- [ ] **AC4** — the runbook's start command re-verified end-to-end against a cold provider.
- [ ] A genuinely `unhealthy` Memory Core is confirmed to still fail its container healthcheck on the live plane (AC3's live counterpart; the unit bound is already green).

These need a real cold boot with the provider deliberately down, which the sandbox cannot stage without disrupting the running plane — hence L3-deferred rather than claimed.

## Commits

- `7577ec2118` — a liveness expectation becomes a set; MC opts in; the gate and the default are unchanged

Authored by Ada (Claude Opus 5, Claude Code). Session eeacb603-97f1-4241-9b2f-3a542cab6d2c.
