### PR TITLE
fix(dock): never stage a zero-area First as a zero-scale mover (#16356)

### DIFF
--- a/src/main/addon/DockFlip.mjs
+++ b/src/main/addon/DockFlip.mjs
@@ -20,8 +20,10 @@ const MOTION_EPSILON_POSITION = 0.5,
  * Correlation is marker-class based (`{markerPrefix}<stableKey>`), because projected pane
  * component instances may be recreated across a coarse refresh while their dock ITEM identity
  * is stable — classes travel with the item's config, so First/Last rects correlate even when
- * the DOM nodes are new. Entering elements (no First rect) fade/scale in from their landing
- * spot; exiting elements are the outgoing tree's problem and need no animation.
+ * the DOM nodes are new. Entering elements (no First rect, or a First captured without
+ * presentable area — a mounted-but-hidden card) fade/scale in from their landing spot;
+ * zero-area Lasts have nothing to present and land instantly; exiting elements are the
+ * outgoing tree's problem and need no animation.
  *
  * Native atomic cross-boundary moves preserve the exact marker nodes. That branch skips the
  * replacement-tree detach poll and, when the First rect would be clipped by the destination,
@@ -612,7 +614,18 @@ class DockFlip extends Base {
                     firstRect = firstRects.get(key),
                     last      = el.getBoundingClientRect();
 
-                if (!firstRect) {
+                // A zero-area Last does not present at its destination (hidden card, collapsed
+                // box): there is no motion to show — the committed layout owns it.
+                if (!(last.width > 0) || !(last.height > 0)) {
+                    return
+                }
+
+                // An element without presentable First geometry is an entering element, not a
+                // mover — including a zero-area capture (a mounted-but-hidden card at First
+                // time). Inverting from a zero-area rect would install translate(-last.left,
+                // -last.top) scale(0, 0): a box collapsed onto the viewport origin, presenting
+                // blank staged frames until the transition escapes zero.
+                if (!firstRect || !(firstRect.width > 0) || !(firstRect.height > 0)) {
                     // entering element: grow into place from its landing spot
                     moves.push({el, fixedStage: false, transform: 'scale(0.92)', fade: true, last});
                     return
@@ -621,8 +634,8 @@ class DockFlip extends Base {
                 const
                     dx                  = firstRect.left - last.left,
                     dy                  = firstRect.top  - last.top,
-                    sx                  = last.width  > 0 ? firstRect.width  / last.width  : 1,
-                    sy                  = last.height > 0 ? firstRect.height / last.height : 1,
+                    sx                  = firstRect.width  / last.width,
+                    sy                  = firstRect.height / last.height,
                     preservedIdentity   = firstMarkers.get(key) === el && el.isConnected,
                     movedAcrossBoundary = preservedIdentity
                         && this.hasAncestorLineageChanged(el, firstLineages.get(key), hostEl),

--- a/test/playwright/e2e/workstation/WorkstationNL.spec.mjs
+++ b/test/playwright/e2e/workstation/WorkstationNL.spec.mjs
@@ -1299,6 +1299,7 @@ test.describe('Workstation — dense living-data composition', () => {
                 sampledFrames                  : 0,
                 securityCaptured               : false,
                 securityActiveHeaderMissFrames : 0,
+                securityEnterMotionFrames      : 0,
                 securityBodyMissingFrames      : 0,
                 securityFullyClippedFrames     : 0,
                 securityFullyClippedSamples    : [],
@@ -1522,17 +1523,45 @@ test.describe('Workstation — dense living-data composition', () => {
                         }
 
                         if (!painted) {
+                            const
+                                nodeStyle  = getComputedStyle(currentSecurityNode),
+                                parentRect = currentSecurityNode.parentElement?.getBoundingClientRect();
+
                             state.securityFullyClippedFrames++;
                             state.securityFullyClippedSamples.length < 20
                                 && state.securityFullyClippedSamples.push({
-                                    bottom: Math.round(rect.bottom),
-                                    height: Math.round(rect.height),
-                                    left  : Math.round(rect.left),
-                                    right : Math.round(rect.right),
-                                    top   : Math.round(rect.top),
-                                    width : Math.round(rect.width)
+                                    bottom           : Math.round(rect.bottom),
+                                    burst            : state.securityStageBursts,
+                                    caption          : document.querySelector('.workstation-tour-caption')?.textContent?.trim() || '',
+                                    computedTransform: nodeStyle.transform,
+                                    connected        : currentSecurityNode.isConnected,
+                                    display          : nodeStyle.display,
+                                    frameInBurst     : state.securityStageFramesByBurst.at(-1),
+                                    height           : Math.round(rect.height),
+                                    inlineTransform  : currentSecurityNode.style.transform,
+                                    left             : Math.round(rect.left),
+                                    parentRect       : parentRect && {
+                                        height: Math.round(parentRect.height),
+                                        left  : Math.round(parentRect.left),
+                                        top   : Math.round(parentRect.top),
+                                        width : Math.round(parentRect.width)
+                                    },
+                                    position : nodeStyle.position,
+                                    right    : Math.round(rect.right),
+                                    stagePins: {
+                                        height: currentSecurityNode.style.height,
+                                        left  : currentSecurityNode.style.left,
+                                        top   : currentSecurityNode.style.top,
+                                        width : currentSecurityNode.style.width
+                                    },
+                                    top  : Math.round(rect.top),
+                                    width: Math.round(rect.width)
                                 })
                         }
+                    }
+
+                    if (!staged && getComputedStyle(currentSecurityNode).transform !== 'none') {
+                        state.securityEnterMotionFrames++
                     }
 
                     securityWasStaged = staged
@@ -1719,12 +1748,14 @@ test.describe('Workstation — dense living-data composition', () => {
             `the active Security pane never leaves the DOM after capture: ${JSON.stringify(monitor.securityPresenceTransitions)}`)
             .toBe(0);
         expect(monitor.securityReplacementFrames, 'Security keeps the same DOM node across split and return').toBe(0);
-        expect(monitor.securityStageBursts, 'split and return each expose one preserved-identity fixed stage').toBe(2);
-        expect(monitor.securityStageFramesByBurst, 'the sequential sampler isolates the split and return stages')
-            .toHaveLength(2);
-        expect(monitor.securityStageFramesByBurst[0], 'the split stage spans multiple sequential samples')
-            .toBeGreaterThan(1);
-        expect(monitor.securityStageFramesByBurst[1], 'the return stage spans multiple sequential samples')
+        expect(monitor.securityStageBursts,
+            'only the return crossing stages: the split promotes a never-presented card (entering, unstaged)').toBe(1);
+        expect(monitor.securityEnterMotionFrames,
+            'the promoted never-presented pane presents its entering grow-in without a fixed stage')
+            .toBeGreaterThan(0);
+        expect(monitor.securityStageFramesByBurst, 'the sequential sampler isolates the return stage')
+            .toHaveLength(1);
+        expect(monitor.securityStageFramesByBurst[0], 'the return stage spans multiple sequential samples')
             .toBeGreaterThan(1);
         expect(monitor.securityStageFrames).toBe(monitor.securityStageFramesByBurst.reduce((sum, count) => sum + count, 0));
         expect(monitor.securityBodyMissingFrames,
@@ -1732,7 +1763,7 @@ test.describe('Workstation — dense living-data composition', () => {
         expect(monitor.securityActiveHeaderMissFrames,
             'every staged frame retains a visible active tab header').toBe(0);
         expect(monitor.securityOverflowMutationFrames,
-            'the real tab-body overflow contract stays hidden throughout both moves').toBe(0);
+            'the real tab-body overflow contract stays hidden throughout the staged return').toBe(0);
         expect(monitor.securityFullyClippedFrames,
             `every staged frame paints pane content: ${JSON.stringify(monitor.securityFullyClippedSamples)}`).toBe(0);
         expect(monitor.palettes.length, 'the actual tour materially renders both theme palettes').toBeGreaterThanOrEqual(2);

--- a/test/playwright/unit/dashboard/DockFlip.spec.mjs
+++ b/test/playwright/unit/dashboard/DockFlip.spec.mjs
@@ -572,6 +572,144 @@ test.describe('Neo.main.addon.DockFlip', () => {
         expect(marker.classList.contains('neo-dock-flip-fixed-stage')).toBe(false)
     });
 
+    test('classifies a zero-area First as entering: no fixed stage, no zero-scale inverse (#16356)', async () => {
+        const
+            markerClass     = 'dock-flip-item-alpha',
+            movingClass     = 'dock-flip-item-beta',
+            marker          = createMarker(markerClass, {bottom: 0, height: 0, left: 0, right: 0, top: 0, width: 0}),
+            movingMarker    = createMarker(movingClass, {bottom: 100, height: 100, left: 0, right: 100, top: 0, width: 100}),
+            sourceBody      = {parentElement: null},
+            destinationBody = {
+                parentElement: null,
+                style        : {},
+                getBoundingClientRect() {
+                    return {bottom: 200, height: 100, left: 200, right: 300, top: 100, width: 100}
+                }
+            },
+            host            = {
+                classList    : createClassList(),
+                parentElement: null,
+                querySelector() {
+                    return null
+                },
+                querySelectorAll() {
+                    return [marker, movingMarker]
+                }
+            },
+            visibleStyle = {
+                contain    : 'none',
+                filter     : 'none',
+                overflowX  : 'visible',
+                overflowY  : 'visible',
+                perspective: 'none',
+                transform  : 'none',
+                willChange : 'auto',
+                getPropertyValue(name) {
+                    return name === '--dock-transition-duration' ? '1ms' : 'linear'
+                }
+            };
+
+        sourceBody.parentElement      = host;
+        destinationBody.parentElement = host;
+        marker.parentElement          = sourceBody;
+        movingMarker.parentElement    = sourceBody;
+
+        globalThis.document = {
+            getElementById(id) {
+                return id === 'dock-host' ? host : null
+            }
+        };
+        globalThis.getComputedStyle = element => element === destinationBody
+            ? {...visibleStyle, overflowX: 'hidden', overflowY: 'hidden'}
+            : visibleStyle;
+
+        dockFlip.captureFirst({hostId: 'dock-host', markerPrefix: 'dock-flip-item-'});
+        marker.parentElement       = destinationBody;
+        movingMarker.parentElement = destinationBody;
+        marker.setRect({bottom: 200, height: 100, left: 200, right: 300, top: 100, width: 100});
+        movingMarker.setRect({bottom: 150, height: 50, left: 210, right: 290, top: 100, width: 80});
+
+        const commitSamples = [];
+
+        globalThis.requestAnimationFrame = callback => {
+            commitSamples.push({
+                opacity  : marker.style.opacity,
+                staged   : marker.classList.contains('neo-dock-flip-fixed-stage'),
+                transform: marker.style.transform
+            });
+            callback()
+        };
+
+        await expect(dockFlip.play({
+            hostId      : 'dock-host',
+            markerPrefix: 'dock-flip-item-'
+        })).resolves.toBe(true);
+
+        expect(commitSamples).toEqual([{
+            opacity  : '0.001',
+            staged   : false,
+            transform: 'scale(0.92)'
+        }]);
+        expect(marker.classList.contains('neo-dock-flip-fixed-stage'),
+            'a never-presented element leaves no stage residue').toBe(false);
+        expect(marker.style.transform ?? '', 'no zero-scale inverse is ever installed').not.toContain('scale(0,');
+        expect(marker.style.opacity ?? '', 'the entering fade releases and restores').not.toBe('0.001')
+    });
+
+    test('skips a zero-area Last: nothing presents at the destination, the committed layout owns it (#16356)', async () => {
+        const
+            markerClass     = 'dock-flip-item-alpha',
+            marker          = createMarker(markerClass, {bottom: 100, height: 100, left: 0, right: 100, top: 0, width: 100}),
+            sourceBody      = {parentElement: null},
+            destinationBody = {parentElement: null, style: {}},
+            host            = {
+                classList    : createClassList(),
+                parentElement: null,
+                querySelector() {
+                    return null
+                },
+                querySelectorAll() {
+                    return [marker]
+                }
+            },
+            visibleStyle = {
+                contain    : 'none',
+                filter     : 'none',
+                overflowX  : 'visible',
+                overflowY  : 'visible',
+                perspective: 'none',
+                transform  : 'none',
+                willChange : 'auto',
+                getPropertyValue(name) {
+                    return name === '--dock-transition-duration' ? '1ms' : 'linear'
+                }
+            };
+
+        sourceBody.parentElement      = host;
+        destinationBody.parentElement = host;
+        marker.parentElement          = sourceBody;
+
+        globalThis.document = {
+            getElementById(id) {
+                return id === 'dock-host' ? host : null
+            }
+        };
+        globalThis.getComputedStyle    = () => visibleStyle;
+        globalThis.requestAnimationFrame = callback => callback();
+
+        dockFlip.captureFirst({hostId: 'dock-host', markerPrefix: 'dock-flip-item-'});
+        marker.parentElement = destinationBody;
+        marker.setRect({bottom: 100, height: 0, left: 200, right: 200, top: 100, width: 0});
+
+        await expect(dockFlip.play({
+            hostId      : 'dock-host',
+            markerPrefix: 'dock-flip-item-'
+        })).resolves.toBe(false);
+
+        expect(marker.style.transform, 'no motion is installed toward a non-presenting destination').toBeUndefined();
+        expect(marker.classList.contains('neo-dock-flip-fixed-stage')).toBe(false)
+    });
+
     test('destroy interrupts an active fixed stage and restores its presentation state', async () => {
         const
             markerClass     = 'dock-flip-item-alpha',


### PR DESCRIPTION
Resolves #16356

The zero-rect staged frame is not a staging-order defect — install and restore are both frame-atomic (source-verified). The seam is upstream, in mover-vs-entering classification: `captureFirst` records every marker's rect unconditionally, so a mounted-but-hidden card (the tour's overflow cue mounts Security while `heavy-tabs` keeps `alerts` active) captures a `{0,0,0,0}` First. `play()` then treats that as witnessed mover geometry and installs `translate(-last.left, -last.top) scale(0, 0)` — a box collapsed onto the viewport origin, blank on every sampled frame until the transition escapes zero. The repair classifies at the seam: an element without presentable First area is an **entering** element (the existing grow-in branch, unstaged); symmetrically, a zero-area **Last** has nothing to present — no motion, the committed layout owns it. The now-dead zero-guards in the scale math are retired. The conviction receipt is the enriched clipped-sample the ticket prescribed (burst, frame-in-burst, caption, computed + inline transform, stage pins, ancestor rect), which is kept as permanent oracle diagnostics: the single failing sample's arithmetic (`dx = −300 ⟹ first.left = 0`; `sx = 0 ⟹ first.width = 0`) named the mechanism in one run.

Evidence: L3 achieved (browser-rendered runtime on this host: unit red/green proof + headed tour Security-family receipts + headless regression battery, all at the diff = branch head `6981d0ceea3a` based on dev `3a39616cd3`) → L3 required (close-target ACs are runtime-verifiable locally). Scope stated exactly: the headed row's Security-family segment — everything #16356 owns — is green; the full row terminates at independent, newly-reachable #16467 (receipted + filed). AC5 restatement-map: #16356 issuecomment-5171475070 (per review RA-1, ticket-author-prescribed). Battery receipt + five-fail attribution: PR comment issuecomment-5171478114.

## Deltas from ticket

- The root cause is neither of the body's two candidate seams (fixed-stage ownership before rect seeding / one-frame style clear): both are single-synchronous-block atomic. The lifecycle seam repaired is First/Last presentability classification in `play()`.
- Same-seam hardening beyond the witnessed defect: zero-area **Last** markers are skipped (previously: a real First + zero Last installed a translate toward the hidden destination behind the `sx/sy` guards). Unwitnessed in the tour, deterministically unit-pinned.
- Oracle re-shape in `WorkstationNL`: stage-bursts `2 → 1` — post-repair the split leg legitimately never stages (a never-presented card enters at its landing spot; no clip boundary is crossed). The oracle is strengthened, not weakened: new pin `securityEnterMotionFrames > 0` asserts the grow-in presents unstaged, and the clipped-frames/identity/residue assertions are unchanged. The enriched clipped-sample payload ships as permanent diagnostics.
- Discovery delta: advancing the row past the repaired oracle exposed a deterministic, independent drag-commit defect (audit cue commits nothing) — receipted and filed as #16467, out of this PR's scope.

## Test Evidence

- `npx playwright test unit/dashboard/DockFlip -c test/playwright/playwright.config.unit.mjs` → **17 passed** (3.3s). Two new witnesses: entering-classification (zero-area First → no stage class, `scale(0.92)` fade commit-frame sample, no zero-scale inverse) + zero-area-Last skip (play resolves `false`, no motion installed). **Red-proven**: with `src/main/addon/DockFlip.mjs` stashed, exactly these 2 fail (deep-equality catches the staged zero-scale install; resolves-check catches the phantom move).
- Headed tour row (`workstation/WorkstationNL --grep "the real tour keeps density"`, port 8137, browser-rendered = L3): Security-family oracles all green at branch head `6981d0ceea3a` (the diff over dev `3a39616cd3`; runs executed on the content-identical pre-commit tree) — `securityFullyClippedFrames` **0** (pre-repair: 1–3 across runs, receipts on #16356), one return-leg stage burst with multi-frame span, `securityEnterMotionFrames > 0`, identity/residue unchanged-green. The row then terminates at newly-reachable, independent #16467 (2/2 deterministic — receipts + window analysis on that ticket).
- Headless regression battery at the same head (`workstation/ + dashboard/DockMotionNL + agentos/FleetCockpitDockNL`, port 8141): **33 passed · 5 failed · 2 take-gated skips**, with all five fails baseline-stash-attributed as pre-existing or #16467 — full receipt + attribution table: PR comment issuecomment-5171478114.
- Workstation five-beat suite at dev head pre-branch: 9 passed / 1 take-gated skip (film-lane receipt, #15252).

## Post-Merge Validation

- [ ] CI e2e workstation battery green on the merge commit
- [ ] #16467 receipts re-taken on the merged head (independent defect, masked until this repair)
- [ ] Film-lane staged take re-verification consumes the repaired split presentation (#15252)

## Commits

- single commit — `fix(dock): never stage a zero-area First as a zero-scale mover (#16356)`

Authored by Mnemosyne (Fable 5, Claude Code). Session 0ea45eb0-5687-4796-8bef-c2cf37b08186.
