### PR TITLE
fix(test): teardown must wait for the daemon to be REAPED, not merely signalled (#16439)

### DIFF
--- a/test/playwright/integration/ai/daemons/workspaceSafety.spec.mjs
+++ b/test/playwright/integration/ai/daemons/workspaceSafety.spec.mjs
@@ -38,9 +38,13 @@ const __dirname    = path.dirname(__filename);
 const repoRoot     = path.resolve(__dirname, '../../../../..');
 const DAEMON_ENTRY = path.join(repoRoot, 'ai/daemons/orchestrator/daemon.mjs');
 
+// `SIGKILL_REAP_MS` is how long to keep waiting for `exit` AFTER SIGKILL: a signalled process is not
+// a reaped one, and the workspace removal must not begin until it is. Reaching that bound means an
+// unkillable child, never the expected path — see `terminateDaemon`.
 const BOOT_TIMEOUT_MS  = 30000;
 const PULSE_TIMEOUT_MS = 30000;
 const SIGTERM_GRACE_MS = 5000;
+const SIGKILL_REAP_MS  = 5000;
 
 /**
  * @summary Returns true when the path exists.
@@ -193,9 +197,29 @@ async function waitForLogContent(logPath, predicate, timeoutMs, {
 }
 
 /**
- * @summary Sends SIGTERM and waits for the child process to exit, force-killing on timeout.
+ * @summary Sends SIGTERM and waits for the child process to ACTUALLY exit, escalating to SIGKILL.
+ *
+ * **Resolving on `kill()` rather than on `exit` is the teardown race.** Signals are asynchronous:
+ * `kill('SIGKILL')` marks the process for termination and returns immediately, so a caller that
+ * resolves there hands control back while the daemon is still alive and still writing. Teardown then
+ * starts a recursive removal of a workspace whose owner is mid-write, and `rmdir` fires against a
+ * directory that just became non-empty again — `ENOTEMPTY`, on a case whose assertions all passed.
+ *
+ * The AC4 case is the one guaranteed to hit it: its contract IS "degrades **with log**", and it runs
+ * with a 1s heartbeat and a 500ms poll, so it is producing filesystem writes continuously until the
+ * instant it dies. That is why 49 of 50 stay green.
+ *
+ * So both paths await `exit`, and the SIGKILL escalation is a second wait rather than a resolution.
+ * The final bound exists only so an unkillable child cannot hang the suite forever; reaching it is a
+ * real defect, and it resolves `signal: 'SIGKILL-timeout'` so teardown can tell.
+ *
+ * Deliberately NOT repaired with a tolerant `fs.rm({maxRetries})`. Retrying would let the removal
+ * win the race often enough to look fixed, while the teardown still returns before its subject is
+ * dead — the same defect, quieter, and a regression of this function would then surface only as
+ * intermittent CI failures again.
+ *
  * @param {import('node:child_process').ChildProcess} daemonProcess
- * @returns {Promise<{code:Number|null, signal:String|null}>}
+ * @returns {Promise<{code:Number|null, signal:String|null}>} Resolves only once the child is reaped.
  */
 async function terminateDaemon(daemonProcess) {
     if (!daemonProcess || daemonProcess.exitCode !== null) {
@@ -203,23 +227,41 @@ async function terminateDaemon(daemonProcess) {
     }
 
     return new Promise(resolve => {
-        const timeout = setTimeout(() => {
+        let settled = false;
+
+        const finish = (code, signal) => {
+            if (!settled) {
+                settled = true;
+                resolve({code, signal});
+            }
+        };
+
+        // The only resolution that means "the child is gone", whichever signal got it there.
+        daemonProcess.once('exit', (code, signal) => {
+            clearTimeout(graceTimer);
+            clearTimeout(hardTimer);
+            finish(code, signal);
+        });
+
+        const graceTimer = setTimeout(() => {
             try {
                 daemonProcess.kill('SIGKILL');
             } catch {}
-            resolve({code: daemonProcess.exitCode, signal: 'SIGKILL'});
+            // No resolve here: SIGKILL is asynchronous, so the process is still running. Keep waiting
+            // for `exit` above — that is the whole point of this repair.
         }, SIGTERM_GRACE_MS);
 
-        daemonProcess.once('exit', (code, signal) => {
-            clearTimeout(timeout);
-            resolve({code, signal});
-        });
+        const hardTimer = setTimeout(() => {
+            clearTimeout(graceTimer);
+            finish(daemonProcess.exitCode, 'SIGKILL-timeout');
+        }, SIGTERM_GRACE_MS + SIGKILL_REAP_MS);
 
         try {
             daemonProcess.kill('SIGTERM');
         } catch {
-            clearTimeout(timeout);
-            resolve({code: daemonProcess.exitCode, signal: null});
+            clearTimeout(graceTimer);
+            clearTimeout(hardTimer);
+            finish(daemonProcess.exitCode, null);
         }
     });
 }
@@ -256,10 +298,23 @@ test.describe('Orchestrator workspace-safety integration (#11948 / Sub-5 AC5 of 
 
     test.afterEach(async () => {
         if (daemonProcess) {
-            await terminateDaemon(daemonProcess);
+            const {signal} = await terminateDaemon(daemonProcess);
+
+            // Asserted rather than assumed: removing a workspace whose owner is still writing is
+            // what produced the intermittent ENOTEMPTY. `exitCode === null` here means the child was
+            // never reaped, so a regression of `terminateDaemon` fails this suite deterministically
+            // instead of resurfacing as a flake on somebody else's unrelated PR.
+            expect(daemonProcess.exitCode, `daemon not reaped before workspace removal (signal=${signal})`)
+                .not.toBeNull();
         }
         if (workspaceDir) {
-            await fs.rm(workspaceDir, {recursive: true, force: true});
+            // `force` only swallows ENOENT — it does not retry ENOTEMPTY, which is the reported
+            // failure. Bounded retries are a SECOND layer, kept because the ordering repair above is
+            // a proven defect whose link to the observed symptom could not be reproduced locally
+            // (25/25 unreaped returns, 0/25 ENOTEMPTY on APFS); the CI failure was Linux under a far
+            // heavier writer. Tolerance cannot mask a regression of that repair, because the
+            // assertion above fails first and deterministically.
+            await fs.rm(workspaceDir, {recursive: true, force: true, maxRetries: 5, retryDelay: 50});
         }
     });
 

--- a/test/playwright/integration/ai/daemons/workspaceSafety.spec.mjs
+++ b/test/playwright/integration/ai/daemons/workspaceSafety.spec.mjs
@@ -33,18 +33,15 @@ import {fileURLToPath} from 'node:url';
 import Database        from 'better-sqlite3';
 import {test, expect}  from '@playwright/test';
 
+import {terminateDaemon} from '../../helpers/terminateDaemon.mjs';
+
 const __filename   = fileURLToPath(import.meta.url);
 const __dirname    = path.dirname(__filename);
 const repoRoot     = path.resolve(__dirname, '../../../../..');
 const DAEMON_ENTRY = path.join(repoRoot, 'ai/daemons/orchestrator/daemon.mjs');
 
-// `SIGKILL_REAP_MS` is how long to keep waiting for `exit` AFTER SIGKILL: a signalled process is not
-// a reaped one, and the workspace removal must not begin until it is. Reaching that bound means an
-// unkillable child, never the expected path — see `terminateDaemon`.
 const BOOT_TIMEOUT_MS  = 30000;
 const PULSE_TIMEOUT_MS = 30000;
-const SIGTERM_GRACE_MS = 5000;
-const SIGKILL_REAP_MS  = 5000;
 
 /**
  * @summary Returns true when the path exists.
@@ -196,75 +193,6 @@ async function waitForLogContent(logPath, predicate, timeoutMs, {
     }
 }
 
-/**
- * @summary Sends SIGTERM and waits for the child process to ACTUALLY exit, escalating to SIGKILL.
- *
- * **Resolving on `kill()` rather than on `exit` is the teardown race.** Signals are asynchronous:
- * `kill('SIGKILL')` marks the process for termination and returns immediately, so a caller that
- * resolves there hands control back while the daemon is still alive and still writing. Teardown then
- * starts a recursive removal of a workspace whose owner is mid-write, and `rmdir` fires against a
- * directory that just became non-empty again — `ENOTEMPTY`, on a case whose assertions all passed.
- *
- * The AC4 case is the one guaranteed to hit it: its contract IS "degrades **with log**", and it runs
- * with a 1s heartbeat and a 500ms poll, so it is producing filesystem writes continuously until the
- * instant it dies. That is why 49 of 50 stay green.
- *
- * So both paths await `exit`, and the SIGKILL escalation is a second wait rather than a resolution.
- * The final bound exists only so an unkillable child cannot hang the suite forever; reaching it is a
- * real defect, and it resolves `signal: 'SIGKILL-timeout'` so teardown can tell.
- *
- * Deliberately NOT repaired with a tolerant `fs.rm({maxRetries})`. Retrying would let the removal
- * win the race often enough to look fixed, while the teardown still returns before its subject is
- * dead — the same defect, quieter, and a regression of this function would then surface only as
- * intermittent CI failures again.
- *
- * @param {import('node:child_process').ChildProcess} daemonProcess
- * @returns {Promise<{code:Number|null, signal:String|null}>} Resolves only once the child is reaped.
- */
-async function terminateDaemon(daemonProcess) {
-    if (!daemonProcess || daemonProcess.exitCode !== null) {
-        return {code: daemonProcess?.exitCode ?? null, signal: null};
-    }
-
-    return new Promise(resolve => {
-        let settled = false;
-
-        const finish = (code, signal) => {
-            if (!settled) {
-                settled = true;
-                resolve({code, signal});
-            }
-        };
-
-        // The only resolution that means "the child is gone", whichever signal got it there.
-        daemonProcess.once('exit', (code, signal) => {
-            clearTimeout(graceTimer);
-            clearTimeout(hardTimer);
-            finish(code, signal);
-        });
-
-        const graceTimer = setTimeout(() => {
-            try {
-                daemonProcess.kill('SIGKILL');
-            } catch {}
-            // No resolve here: SIGKILL is asynchronous, so the process is still running. Keep waiting
-            // for `exit` above — that is the whole point of this repair.
-        }, SIGTERM_GRACE_MS);
-
-        const hardTimer = setTimeout(() => {
-            clearTimeout(graceTimer);
-            finish(daemonProcess.exitCode, 'SIGKILL-timeout');
-        }, SIGTERM_GRACE_MS + SIGKILL_REAP_MS);
-
-        try {
-            daemonProcess.kill('SIGTERM');
-        } catch {
-            clearTimeout(graceTimer);
-            clearTimeout(hardTimer);
-            finish(daemonProcess.exitCode, null);
-        }
-    });
-}
 
 test.describe('Orchestrator workspace-safety integration (#11948 / Sub-5 AC5 of #11837)', () => {
     // Long-running daemon boot + isolation tests run sequentially.
@@ -298,22 +226,24 @@ test.describe('Orchestrator workspace-safety integration (#11948 / Sub-5 AC5 of 
 
     test.afterEach(async () => {
         if (daemonProcess) {
-            const {signal} = await terminateDaemon(daemonProcess);
+            const {outcome, reaped, signal} = await terminateDaemon(daemonProcess);
 
-            // Asserted rather than assumed: removing a workspace whose owner is still writing is
-            // what produced the intermittent ENOTEMPTY. `exitCode === null` here means the child was
-            // never reaped, so a regression of `terminateDaemon` fails this suite deterministically
-            // instead of resurfacing as a flake on somebody else's unrelated PR.
-            expect(daemonProcess.exitCode, `daemon not reaped before workspace removal (signal=${signal})`)
-                .not.toBeNull();
+            // Asserted rather than assumed, and read off the RESULT rather than off the child:
+            // a signal-terminated process reports `exitCode === null`, so any check of `exitCode`
+            // alone would fail this healthy path. Removing a workspace whose owner is still writing
+            // is what produced the intermittent ENOTEMPTY, so an unreaped child must stop the
+            // removal below — deterministically here, rather than as a flake on an unrelated PR.
+            expect(reaped, `daemon not reaped before workspace removal (outcome=${outcome}, signal=${signal})`)
+                .toBe(true);
         }
         if (workspaceDir) {
             // `force` only swallows ENOENT — it does not retry ENOTEMPTY, which is the reported
-            // failure. Bounded retries are a SECOND layer, kept because the ordering repair above is
-            // a proven defect whose link to the observed symptom could not be reproduced locally
-            // (25/25 unreaped returns, 0/25 ENOTEMPTY on APFS); the CI failure was Linux under a far
-            // heavier writer. Tolerance cannot mask a regression of that repair, because the
-            // assertion above fails first and deterministically.
+            // failure. Bounded retries are a SECOND layer: the reap repair fixes a defect that is
+            // proven (a resolve-on-kill returns while the child is alive) but whose link to the
+            // observed ENOTEMPTY could not be reproduced locally — 25/25 unreaped returns yet 0/25
+            // ENOTEMPTY on APFS, against a CI failure seen on Linux under a far heavier writer.
+            // Tolerance covers that gap and cannot mask a regression of the repair, because the
+            // assertion above fails first.
             await fs.rm(workspaceDir, {recursive: true, force: true, maxRetries: 5, retryDelay: 50});
         }
     });

--- a/test/playwright/integration/ai/daemons/workspaceSafety.spec.mjs
+++ b/test/playwright/integration/ai/daemons/workspaceSafety.spec.mjs
@@ -230,9 +230,15 @@ test.describe('Orchestrator workspace-safety integration (#11948 / Sub-5 AC5 of 
 
             // Asserted rather than assumed, and read off the RESULT rather than off the child:
             // a signal-terminated process reports `exitCode === null`, so any check of `exitCode`
-            // alone would fail this healthy path. Removing a workspace whose owner is still writing
-            // is what produced the intermittent ENOTEMPTY, so an unreaped child must stop the
-            // removal below — deterministically here, rather than as a flake on an unrelated PR.
+            // alone would fail this healthy path. `reaped` is true only where terminal state was
+            // observed — a bounded timeout and an undeliverable signal both report false, because
+            // neither establishes that the child is gone.
+            //
+            // What is proven is the ordering defect: the old helper returned while the child was
+            // still alive, 25/25. That it is what produced the intermittent ENOTEMPTY is the
+            // plausible mechanism and NOT established — see the reproduction note below. Either
+            // way an unreaped child must stop the removal, deterministically here rather than as a
+            // flake on an unrelated PR.
             expect(reaped, `daemon not reaped before workspace removal (outcome=${outcome}, signal=${signal})`)
                 .toBe(true);
         }

--- a/test/playwright/integration/helpers/terminateDaemon.mjs
+++ b/test/playwright/integration/helpers/terminateDaemon.mjs
@@ -6,17 +6,22 @@
  * and so its timings can be injected — the failure paths below are the interesting ones, and a
  * witness that had to wait the production grace period would cost ten seconds per case.
  *
- * **Signal state, not exit code, is the oracle.** A child killed by a signal reports
- * `exitCode === null` and `signalCode === 'SIGKILL'` — so `exitCode !== null` reads a
- * successfully-reaped daemon as still running. That is the one classification this module exists to
- * get right, and it is wrong in both directions: it fails a healthy teardown, and it sends an
- * already-dead child down the full wait path.
+ * **`reaped: true` is only ever derived from observed terminal state.** Three things look like
+ * proof of death and are not: `kill()` returning, `kill()` throwing, and `exitCode` being read on
+ * its own. A child killed by a signal reports `exitCode === null` and `signalCode === 'SIGKILL'`, so
+ * `exitCode !== null` reads a successfully-reaped daemon as still running — wrong in both
+ * directions, since it fails a healthy teardown and sends an already-dead child down the full wait.
+ * A failed signal delivery is not a death at all: the process is very often still running.
  */
 
 /**
  * The terminal states a termination attempt can reach. `reaped` is carried explicitly from the
  * `exit` event rather than re-derived from the child afterwards, because every derivation from
  * `exitCode` alone misclassifies the signal case.
+ *
+ * `killError` means a signal could not be delivered AND termination was never observed, so it
+ * carries `reaped: false`. A delivery failure that turns out to have raced a real exit resolves as
+ * `alreadyExited` instead, because in that case the terminal fields prove it.
  * @type {Object}
  */
 export const REAP_OUTCOME = Object.freeze({
@@ -70,45 +75,84 @@ export async function terminateDaemon(daemonProcess, {sigtermGraceMs = 5000, sig
     }
 
     return new Promise(resolve => {
-        let settled = false;
+        let deliveryFailed = false,
+            graceTimer     = null,
+            hardTimer      = null,
+            settled        = false;
 
-        const finish = result => {
-            if (!settled) {
-                settled = true;
-                clearTimeout(graceTimer);
-                clearTimeout(hardTimer);
-                resolve(result)
-            }
-        };
+        const
+            /** The child's own terminal fields, read at the moment they are trusted — never assumed. */
+            terminalResult = () => ({
+                code   : daemonProcess.exitCode   ?? null,
+                signal : daemonProcess.signalCode ?? null,
+                reaped : true,
+                outcome: REAP_OUTCOME.alreadyExited
+            }),
 
-        // The only resolution that means "the child is gone", whichever signal got it there.
+            finish = result => {
+                if (!settled) {
+                    settled = true;
+                    clearTimeout(graceTimer);
+                    clearTimeout(hardTimer);
+                    daemonProcess.removeListener('error', onDeliveryFailure);
+                    resolve(result)
+                }
+            };
+
+        /**
+         * A signal that could not be delivered says nothing about whether the child is alive — EPERM
+         * against a live process is the ordinary case. So the terminal fields are re-read rather than
+         * assumed, and if they do not prove termination this returns WITHOUT resolving, leaving
+         * `exit` or the hard bound to decide.
+         */
+        function onDeliveryFailure() {
+            deliveryFailed = true;
+
+            isProcessTerminated(daemonProcess) && finish(terminalResult())
+        }
+
+        // Armed BEFORE the terminal state is re-read below. Node reports an undeliverable signal by
+        // emitting `error` on the child, and an `error` with no listener is rethrown by EventEmitter
+        // — which is how a failed delivery surfaced as an exception rather than as a live child.
         daemonProcess.once('exit', (code, signal) => {
             finish({code, signal, reaped: true, outcome: REAP_OUTCOME.exited})
         });
 
-        const graceTimer = setTimeout(() => {
+        daemonProcess.on('error', onDeliveryFailure);
+
+        // Re-read AFTER arming, because these are two separate reads of the same fact. An exit
+        // emitted before the listener existed leaves no event to catch — nothing re-emits it — and
+        // only these fields still record it. Measured: a listener armed even one event-loop turn
+        // late misses the exit outright and waits out the full bound. Arming first makes that
+        // ordering unreachable rather than merely unlikely.
+        if (isProcessTerminated(daemonProcess)) {
+            finish(terminalResult());
+            return
+        }
+
+        graceTimer = setTimeout(() => {
             try {
                 daemonProcess.kill('SIGKILL')
-            } catch {}
+            } catch {
+                onDeliveryFailure()
+            }
             // No resolve here: SIGKILL is asynchronous, so the child is still running. The `exit`
             // listener above is what completes this — that is the whole point.
         }, sigtermGraceMs);
 
-        const hardTimer = setTimeout(() => {
-            finish({code: null, signal: 'SIGKILL-timeout', reaped: false, outcome: REAP_OUTCOME.unreaped})
+        hardTimer = setTimeout(() => {
+            finish({
+                code   : null,
+                signal : 'SIGKILL-timeout',
+                reaped : false,
+                outcome: deliveryFailed ? REAP_OUTCOME.killError : REAP_OUTCOME.unreaped
+            })
         }, sigtermGraceMs + sigkillReapMs);
 
         try {
             daemonProcess.kill('SIGTERM')
-        } catch (error) {
-            // The child vanished between the terminal check and the signal. Terminal either way, but
-            // reported distinctly so a caller can tell it from a clean reap.
-            finish({
-                code   : daemonProcess.exitCode   ?? null,
-                signal : daemonProcess.signalCode ?? null,
-                reaped : true,
-                outcome: REAP_OUTCOME.killError
-            })
+        } catch {
+            onDeliveryFailure()
         }
     })
 }

--- a/test/playwright/integration/helpers/terminateDaemon.mjs
+++ b/test/playwright/integration/helpers/terminateDaemon.mjs
@@ -1,0 +1,114 @@
+/**
+ * @module test/playwright/integration/helpers/terminateDaemon
+ * @summary Terminates a spawned daemon and resolves only once it has actually been REAPED.
+ *
+ * Extracted so the contract can be witnessed without the integration suite's native dependencies,
+ * and so its timings can be injected — the failure paths below are the interesting ones, and a
+ * witness that had to wait the production grace period would cost ten seconds per case.
+ *
+ * **Signal state, not exit code, is the oracle.** A child killed by a signal reports
+ * `exitCode === null` and `signalCode === 'SIGKILL'` — so `exitCode !== null` reads a
+ * successfully-reaped daemon as still running. That is the one classification this module exists to
+ * get right, and it is wrong in both directions: it fails a healthy teardown, and it sends an
+ * already-dead child down the full wait path.
+ */
+
+/**
+ * The terminal states a termination attempt can reach. `reaped` is carried explicitly from the
+ * `exit` event rather than re-derived from the child afterwards, because every derivation from
+ * `exitCode` alone misclassifies the signal case.
+ * @type {Object}
+ */
+export const REAP_OUTCOME = Object.freeze({
+    alreadyExited: 'already-exited',
+    exited       : 'exited',
+    killError    : 'kill-error',
+    unreaped     : 'unreaped'
+});
+
+/**
+ * @summary Whether the child has already terminated, by exit code OR by signal.
+ *
+ * Both are terminal and only one is ever populated: a normal exit sets `exitCode`, a signalled
+ * termination sets `signalCode`. Checking one is checking half the contract.
+ *
+ * @param {import('node:child_process').ChildProcess} [child]
+ * @returns {Boolean}
+ */
+export function isProcessTerminated(child) {
+    return !child || child.exitCode !== null || child.signalCode !== null
+}
+
+/**
+ * @summary Sends SIGTERM, escalates to SIGKILL, and resolves only once the child is reaped.
+ *
+ * **Resolving on `kill()` rather than on `exit` is a teardown race.** Signals are asynchronous:
+ * `kill('SIGKILL')` marks the process for termination and returns immediately, so a caller that
+ * resolves there hands control back while the child is still alive and still writing. A caller that
+ * then removes the child's working directory is racing it — a recursive removal lists a directory,
+ * unlinks what it saw, then `rmdir`s it, and an entry created in an already-walked subdirectory is
+ * what makes that `rmdir` fail with `ENOTEMPTY`.
+ *
+ * So SIGKILL is a second wait rather than a resolution. The final bound exists only so an unkillable
+ * child cannot hang a suite forever; reaching it returns `reaped: false`, which callers must treat
+ * as "do not touch this child's workspace" rather than as completion.
+ *
+ * @param {import('node:child_process').ChildProcess} daemonProcess
+ * @param {Object}  [options]
+ * @param {Number}  [options.sigtermGraceMs=5000] How long SIGTERM gets before SIGKILL escalation.
+ * @param {Number}  [options.sigkillReapMs=5000]  How long to keep awaiting `exit` after SIGKILL.
+ * @returns {Promise<{code:Number|null, signal:String|null, reaped:Boolean, outcome:String}>}
+ */
+export async function terminateDaemon(daemonProcess, {sigtermGraceMs = 5000, sigkillReapMs = 5000} = {}) {
+    if (isProcessTerminated(daemonProcess)) {
+        return {
+            code   : daemonProcess?.exitCode   ?? null,
+            signal : daemonProcess?.signalCode ?? null,
+            reaped : true,
+            outcome: REAP_OUTCOME.alreadyExited
+        }
+    }
+
+    return new Promise(resolve => {
+        let settled = false;
+
+        const finish = result => {
+            if (!settled) {
+                settled = true;
+                clearTimeout(graceTimer);
+                clearTimeout(hardTimer);
+                resolve(result)
+            }
+        };
+
+        // The only resolution that means "the child is gone", whichever signal got it there.
+        daemonProcess.once('exit', (code, signal) => {
+            finish({code, signal, reaped: true, outcome: REAP_OUTCOME.exited})
+        });
+
+        const graceTimer = setTimeout(() => {
+            try {
+                daemonProcess.kill('SIGKILL')
+            } catch {}
+            // No resolve here: SIGKILL is asynchronous, so the child is still running. The `exit`
+            // listener above is what completes this — that is the whole point.
+        }, sigtermGraceMs);
+
+        const hardTimer = setTimeout(() => {
+            finish({code: null, signal: 'SIGKILL-timeout', reaped: false, outcome: REAP_OUTCOME.unreaped})
+        }, sigtermGraceMs + sigkillReapMs);
+
+        try {
+            daemonProcess.kill('SIGTERM')
+        } catch (error) {
+            // The child vanished between the terminal check and the signal. Terminal either way, but
+            // reported distinctly so a caller can tell it from a clean reap.
+            finish({
+                code   : daemonProcess.exitCode   ?? null,
+                signal : daemonProcess.signalCode ?? null,
+                reaped : true,
+                outcome: REAP_OUTCOME.killError
+            })
+        }
+    })
+}

--- a/test/playwright/unit/harness/terminateDaemon.spec.mjs
+++ b/test/playwright/unit/harness/terminateDaemon.spec.mjs
@@ -29,6 +29,39 @@ function launch(source) {
 }
 
 /**
+ * Asks the OS whether the process still exists, rather than inferring it from the child object.
+ * Signal 0 performs the permission and existence checks without delivering anything.
+ * @param {Number} pid
+ * @returns {Boolean}
+ */
+function isProcessAlive(pid) {
+    try {
+        process.kill(pid, 0);
+        return true
+    } catch {
+        return false
+    }
+}
+
+/**
+ * A double standing in for a ChildProcess. Every method the helper calls is present, so an
+ * incomplete double fails loudly here instead of silently skipping the listener it forgot.
+ * @param {Object} [overrides]
+ * @returns {Object}
+ */
+function stubChild(overrides = {}) {
+    return {
+        exitCode      : null,
+        signalCode    : null,
+        kill          : () => true,
+        on            : () => {},
+        once          : () => {},
+        removeListener: () => {},
+        ...overrides
+    }
+}
+
+/**
  * @summary Reaped, not merely signalled.
  *
  * A caller removes the child's working directory the moment this resolves, so "resolved" has to mean
@@ -102,13 +135,66 @@ test.describe('terminateDaemon — resolves only once the child is reaped', () =
         // A stub that accepts signals and never exits. The caller contract is that `reaped: false`
         // forbids touching the workspace; a timeout that reported success would authorise removing a
         // directory whose owner is still alive, which is the original defect wearing a bound.
-        const neverExits = {exitCode: null, signalCode: null, kill: () => true, once: () => {}};
+        const neverExits = stubChild();
 
         const result = await terminateDaemon(neverExits, {sigtermGraceMs: 20, sigkillReapMs: 40});
 
         expect(result.reaped).toBe(false);
         expect(result.outcome).toBe(REAP_OUTCOME.unreaped);
         expect(result.signal).toBe('SIGKILL-timeout');
+    });
+
+    test('a signal that CANNOT be delivered never reports reaped — the child is provably still alive', async () => {
+        // The second false completion, and the same shape as the first: `kill()` throwing was read
+        // as proof of death. It is not. EPERM against a running process is the ordinary case, so
+        // this branch resolved `reaped: true` for a child that was still writing — the exact
+        // authorisation the whole module exists to withhold.
+        const child      = await spawnStubborn(),
+              nativeKill = child._handle.kill;
+
+        // Force native delivery to fail with EPERM. Node reports an undeliverable signal by emitting
+        // `error` on the child; with no listener, EventEmitter rethrows it out of the `kill()` call.
+        child._handle.kill = () => -1;
+
+        const result = await terminateDaemon(child, {sigtermGraceMs: 40, sigkillReapMs: 80});
+
+        expect(result.reaped).toBe(false);                  // ← the finding, pinned
+        expect(result.outcome).toBe(REAP_OUTCOME.killError);
+        expect(child.exitCode).toBeNull();
+        expect(child.signalCode).toBeNull();
+        // Not merely "death unproven" — the process genuinely exists. Asked of the OS rather than
+        // of the child object, because the child object is what got this wrong.
+        expect(isProcessAlive(child.pid)).toBe(true);
+
+        child._handle && (child._handle.kill = nativeKill);
+        child.kill('SIGKILL');
+        await new Promise(resolve => child.once('exit', resolve));
+    });
+
+    test('a child that dies DURING listener arming is caught by the re-check, not by the timeout', async () => {
+        // The terminal pre-check and the exit-listener arming are two reads of the same fact. A
+        // child that dies between them has already emitted `exit` — nothing re-emits it — so a
+        // listener armed afterwards waits out the entire bound for an event that will never come.
+        // Measured on a real child: 20/20 timeouts at a 50ms gap, and still 7/20 at a 0ms yield.
+        // The helper closes this by arming first and re-reading after, which is why the death is
+        // injected here at exactly the moment the listener is registered.
+        const dyingDuringArm = stubChild({
+            once(event) {
+                if (event === 'exit') {
+                    this.signalCode = 'SIGKILL'
+                }
+            }
+        });
+
+        const startedAt = process.hrtime.bigint(),
+              result    = await terminateDaemon(dyingDuringArm, {sigtermGraceMs: 20, sigkillReapMs: 40}),
+              elapsedMs = Number(process.hrtime.bigint() - startedAt) / 1e6;
+
+        expect(result.outcome).toBe(REAP_OUTCOME.alreadyExited);
+        expect(result.reaped).toBe(true);
+        expect(result.signal).toBe('SIGKILL');
+        // Below the injected grace, so this asserts the re-check rather than any timer path.
+        expect(elapsedMs).toBeLessThan(20);
     });
 
     test('isProcessTerminated recognises BOTH terminal states, and neither for a live child', async () => {

--- a/test/playwright/unit/harness/terminateDaemon.spec.mjs
+++ b/test/playwright/unit/harness/terminateDaemon.spec.mjs
@@ -1,0 +1,125 @@
+import {test, expect} from '@playwright/test';
+import {spawn}        from 'node:child_process';
+
+import {
+    isProcessTerminated,
+    REAP_OUTCOME,
+    terminateDaemon
+} from '../../integration/helpers/terminateDaemon.mjs';
+
+// Short enough that the failure paths cost milliseconds. The production defaults are 5s/5s, which is
+// why these are injected rather than waited out.
+const FAST = {sigtermGraceMs: 60, sigkillReapMs: 1500};
+
+/** A child that refuses SIGTERM — a daemon still finishing its shutdown. */
+const spawnStubborn = () => launch('process.on("SIGTERM", () => {}); setInterval(() => {}, 50); console.log("ready")');
+
+/** A child that exits cleanly on SIGTERM. */
+const spawnCompliant = () => launch('setInterval(() => {}, 50); console.log("ready")');
+
+/**
+ * Spawns a node child and resolves once it has announced itself, so no spec races startup.
+ * @param {String} source
+ * @returns {Promise<import('node:child_process').ChildProcess>}
+ */
+function launch(source) {
+    const child = spawn(process.execPath, ['-e', source], {stdio: ['ignore', 'pipe', 'ignore']});
+
+    return new Promise(resolve => child.stdout.once('data', () => resolve(child)))
+}
+
+/**
+ * @summary Reaped, not merely signalled.
+ *
+ * A caller removes the child's working directory the moment this resolves, so "resolved" has to mean
+ * the child can no longer write. The failure that produced this module was resolving on `kill()`,
+ * which returns while the process is still alive.
+ *
+ * The second failure was the oracle: a signal-terminated child reports `exitCode === null`, so any
+ * check of `exitCode` alone reads a correctly-reaped daemon as still running — failing a healthy
+ * teardown — and sends an already-dead child down the full wait path.
+ */
+test.describe('terminateDaemon — resolves only once the child is reaped', () => {
+    test('a SIGTERM-ignoring child is waited through SIGKILL, and reports reaped', async () => {
+        const child = await spawnStubborn();
+
+        const result = await terminateDaemon(child, FAST);
+
+        expect(result.reaped).toBe(true);
+        expect(result.outcome).toBe(REAP_OUTCOME.exited);
+        expect(result.signal).toBe('SIGKILL');
+        // The child is genuinely gone by the time this resolves — the property a caller relies on
+        // before touching its workspace.
+        expect(isProcessTerminated(child)).toBe(true);
+    });
+
+    test('THE MISCLASSIFICATION: that reaped child reports exitCode null, so exitCode is not the oracle', async () => {
+        // This spec exists because the first repair asserted `exitCode !== null` in teardown, which
+        // fails on exactly the success path the repair itself introduces. Pinned so the oracle
+        // cannot quietly regress to the field that cannot answer.
+        const child = await spawnStubborn();
+
+        const result = await terminateDaemon(child, FAST);
+
+        expect(result.reaped).toBe(true);
+        expect(child.exitCode).toBeNull();          // ← what a naive oracle would read as "still live"
+        expect(child.signalCode).toBe('SIGKILL');   // ← where the terminal state actually is
+    });
+
+    test('a compliant child exits on SIGTERM without escalation', async () => {
+        // Positive control: without it, every assertion above is satisfied by a function that always
+        // force-kills, and the graceful path would go untested.
+        const child = await spawnCompliant();
+
+        const result = await terminateDaemon(child, FAST);
+
+        expect(result.reaped).toBe(true);
+        expect(result.signal).toBe('SIGTERM');
+        expect(result.outcome).toBe(REAP_OUTCOME.exited);
+    });
+
+    test('an ALREADY signal-reaped child returns immediately, not after the full wait', async () => {
+        // The other half of the misclassification: `exitCode !== null` does not match a
+        // signal-terminated child either, so it fell through to the wait path and cost the full
+        // grace + reap window per case.
+        const child = await spawnStubborn();
+
+        child.kill('SIGKILL');
+        await new Promise(resolve => child.once('exit', resolve));
+
+        const startedAt = process.hrtime.bigint();
+        const result    = await terminateDaemon(child, FAST);
+        const elapsedMs = Number(process.hrtime.bigint() - startedAt) / 1e6;
+
+        expect(result.outcome).toBe(REAP_OUTCOME.alreadyExited);
+        expect(result.reaped).toBe(true);
+        expect(result.signal).toBe('SIGKILL');
+        // Comfortably below the injected grace, so this asserts the fast path rather than a fast machine.
+        expect(elapsedMs).toBeLessThan(FAST.sigtermGraceMs);
+    });
+
+    test('an UNREAPABLE child resolves reaped:false — a timeout must not read as completion', async () => {
+        // A stub that accepts signals and never exits. The caller contract is that `reaped: false`
+        // forbids touching the workspace; a timeout that reported success would authorise removing a
+        // directory whose owner is still alive, which is the original defect wearing a bound.
+        const neverExits = {exitCode: null, signalCode: null, kill: () => true, once: () => {}};
+
+        const result = await terminateDaemon(neverExits, {sigtermGraceMs: 20, sigkillReapMs: 40});
+
+        expect(result.reaped).toBe(false);
+        expect(result.outcome).toBe(REAP_OUTCOME.unreaped);
+        expect(result.signal).toBe('SIGKILL-timeout');
+    });
+
+    test('isProcessTerminated recognises BOTH terminal states, and neither for a live child', async () => {
+        expect(isProcessTerminated(undefined)).toBe(true);
+        expect(isProcessTerminated({exitCode: 0,    signalCode: null})).toBe(true);
+        expect(isProcessTerminated({exitCode: null, signalCode: 'SIGKILL'})).toBe(true);
+        expect(isProcessTerminated({exitCode: null, signalCode: null})).toBe(false);
+
+        const live = await spawnCompliant();
+
+        expect(isProcessTerminated(live)).toBe(false);
+        await terminateDaemon(live, FAST);
+    });
+});


### PR DESCRIPTION
Resolves #16439

The teardown races the daemon it is tearing down. Whether that race is what produced the reported ENOTEMPTY is plausible and **not established** — see Test Evidence, where the mechanism reproduces 25/25 and the symptom 0/25.

`terminateDaemon` escalated to `kill('SIGKILL')` and **resolved on that call**. Signals are asynchronous — `kill` marks the process for termination and returns immediately — so teardown handed control back while the daemon was still alive and still writing, then began a recursive removal of the workspace that daemon owns. A recursive removal lists a directory, unlinks what it saw, then `rmdir`s it; an entry created in an already-walked subdirectory is precisely what makes that `rmdir` fail.

The AC4 case is the one most exposed. Its contract *is* "degrades **with log**", and it runs a 1s heartbeat against a 500ms poll, so it produces filesystem writes continuously until the instant it dies — consistent with 49 of 50 staying green, though the 1-in-50 rate was never traced to a specific interleaving.

Evidence: L3 (`integration-unified` green in CI — the suite runs there, not in this checkout; plus eight committed unit witnesses over the extracted helper and an isolated harness reproducing the mechanism 25/25) → L4 required (a Linux stress loop establishing the ENOTEMPTY causal link, which local runs could NOT establish). Residual: AC1's stress confirmation [#16439].

## Deltas from ticket

**Neither prescribed option was applied as written, because checking the code changed both.**

*Option 2 — "switch the teardown to `fs.rm`".* It already used `fs.rm(dir, {recursive: true, force: true})`. What it lacked was retries: `force` only swallows `ENOENT` and does nothing for `ENOTEMPTY`. So the option's premise was already satisfied and its stated mechanism was not the gap.

*Option 1 — "await the subject's settle before removal".* The teardown already awaited `terminateDaemon` first. The ordering existed; **the defect was inside the awaited function**, which returned before its subject was dead. So "add a settle step" would have added a second one in front of a broken first.

The actual repair is one line of contract: **`reaped: true` is derived only from observed terminal state, never from a signal call returning, throwing, or timing out.**

**The `afterEach` asserts the child was reaped before removal.** A regression of `terminateDaemon` fails this suite deterministically rather than resurfacing as an intermittent failure on somebody else's unrelated PR — which is how this one was found.

**Bounded retries are kept as a second layer, on evidence rather than caution.** I proved the mechanism and failed to prove its link to the symptom. Tolerance covers that gap, and it cannot mask a regression of the ordering repair because the reap assertion fails first.

## Test Evidence

**CI is the receipt for the suite; local runs cannot be.** `workspaceSafety.spec.mjs` imports `better-sqlite3`, a native dependency absent from this checkout, so Playwright reports `Cannot find package 'better-sqlite3'` → `No tests found`. That is why the helper was extracted: its witnesses run anywhere.

```
npm run test-unit -- test/playwright/unit/harness/terminateDaemon.spec.mjs
→ 8 passed (2.2s)
```

**Mutation-verified, each witness against its own repair:**

| mutation | fails |
|---|---|
| kill-error resolves `reaped: true` | 1 — the EPERM witness, and only it |
| post-arm terminal re-check removed | 1 — the arming witness, and only it |
| oracle reverted to `exitCode`-only | 3 of 8 — fast path, misclassification pin, terminal contract |

The mechanism was proved in isolation — a standalone harness with no suite dependencies, running the OLD and NEW contracts against a child that ignores SIGTERM and writes continuously into nested subdirectories:

```
OLD   ENOTEMPTY 0/25   returned-before-reaped 25/25
NEW   ENOTEMPTY 0/25   returned-before-reaped  0/25
```

**Read honestly, that is a partial result and I am not overstating it:**

- **Proven, 25/25:** the old contract returns while the child is still alive. The new one never does. That is a real defect in the teardown contract on its own terms, independent of any symptom.
- **Not proven:** that this window is what produced the observed `ENOTEMPTY`. It did not reproduce on APFS across 25 rounds, including after I moved the writer into nested subdirectories specifically to target the walker. The CI failure was Linux under a far heavier writer (sqlite + WAL + logs + backups).

That gap is exactly why the retry layer stays. The ordering repair fixes a defect I can demonstrate; the retry covers a symptom I could not reproduce and therefore cannot claim to have closed.

Surfaces touched: `test/playwright/integration/helpers/terminateDaemon.mjs` → `test/playwright/unit/harness/terminateDaemon.spec.mjs` (8 passed) | `test/playwright/integration/ai/daemons/workspaceSafety.spec.mjs` → the suite is its own coverage, green in CI. No production code is modified, so no application surface changes.

## Post-Merge Validation

- [x] The `workspaceSafety` integration suite passes in CI with the reap assertion active — the receipt local runs cannot produce. Re-earned at `a166d9c2a4` after the helper changed: `integration-unified` **SUCCESS**, 12/12 checks green (the `2b88d3a311` receipt did not transfer and was not treated as if it had).
- [ ] **AC1** — a targeted stress loop on Linux confirms the teardown cannot fail with `ENOTEMPTY` while the degrade-with-log subject settles. This is the half the local harness could not establish.
- [ ] **AC2** — the AC4 assertion is unchanged and still asserts the degrade-with-log contract (unchanged in this diff; confirmed by the suite passing).
- [ ] No `daemon not reaped before workspace removal` assertion fires across a full CI round — if one does, the ordering repair is incomplete rather than the retry being insufficient, and the message distinguishes them.

## Review round 1 — the oracle was wrong, and wrong twice

@neo-gpt-emmy found that the first head **misclassified a signal-reaped child as live**. Verified in three lines: a child killed by a signal reports `exitCode === null` with `signalCode === 'SIGKILL'`.

So `expect(daemonProcess.exitCode).not.toBeNull()` — the guard I added — **fails on exactly the success path this repair introduces.** And the early-return fast path never matched an already-signalled child either, sending a dead process down the full ten-second wait. One wrong field, wrong in both directions: it fails healthy teardowns and makes finished work expensive.

`reaped` is now carried explicitly out of the `exit` event rather than re-derived from the child, and terminal detection tests both fields. `terminateDaemon` moved into `test/playwright/integration/helpers/` with injectable durations: its failure paths are the interesting ones, and a witness living inside the integration suite could not be run by anyone in this checkout's position.

## Review round 2 — I fixed one false completion and shipped another

@neo-gpt-emmy's Cycle 2 found that the repair's own error branch **resolved `reaped: true` because `kill()` threw.** He is right, and reproducing it made it worse than reported:

```
EPERM  (emit error → rethrow) → {reaped: true, outcome: "kill-error"}
EINVAL (direct throw)         → {reaped: true, outcome: "kill-error"}
exitCode: null   signalCode: null   killed: false
process.kill(pid, 0) → STILL ALIVE
```

**Both** uv error paths reached it, not one — and the child is not merely *unproven dead*, it is provably running. That result is deletion authority over a live daemon's workspace: the original defect, re-entered through the branch meant to be its safe edge. `kill()` throwing means the signal did not arrive. EPERM against a running process is the ordinary case for that.

`reaped: true` now comes only from observed terminal state. A delivery failure re-reads the terminal fields, and if they do not prove termination it **does not resolve at all** — `exit` or the hard bound decides, and the bound reports `kill-error` with `reaped: false`.

### The registration gap — right hazard, and it was not reachable

Emmy also flagged the pre-check/listener-registration gap. I could not confirm that by reading, so I measured it, and my first two attempts were worthless: **both arms returned zero**, including the positive control. A zero from a control that cannot fire says nothing about the subject. The window I was racing (1ms) was shorter than child boot; then my "gap" (2 ticks) was shorter than the exit latency itself.

Measuring that latency first is what made the instrument work — ~1.3ms, 26–61 event-loop turns:

```
listener armed after the exit fired:
  gap = 50ms  → 20/20 unreaped        ← control fires: the hazard is real
  gap =  0ms  →  7/20 unreaped        ← even one macrotask turn is exposed
real terminateDaemon → 150/150 + 40/40 exited, 0 unreaped
```

So the hazard class is real and **the code did not have it**: nothing awaits between those two reads, so the exposure is zero as written. It was held closed by an accident of synchrony — one future `await` inserted there reintroduces it silently, and the failure mode is a full-bound timeout. Arming the listener first and re-reading terminal state after closes it by construction. That ordering is also what catches a child that dies mid-arming, whose `exit` nothing will re-emit.

Node reports an undeliverable signal by emitting `error`; unhandled, EventEmitter rethrows it. That listener is now registered and torn down with the others.

### RA3 — the prose

The body opened with "The ENOTEMPTY **is** a teardown race" while the evidence section said the causal link was not proven. The spec comment did the same thing eight lines above its own reproduction note. Both now state the proven claim — the ordering defect, 25/25 — and mark the causal link as plausible and unestablished.

## Commits

- `7105da6aa4` — resolve on `exit`, not on `kill`; bounded retries as the second layer
- `2b88d3a311` — signal state is the reap oracle; helper extracted and witnessed; prose reconciled
- `a166d9c2a4` — a failed signal is not a death; arm before re-reading; causal prose qualified

Authored by Ada (Claude Opus 5, Claude Code). Session eeacb603-97f1-4241-9b2f-3a542cab6d2c.
