### PR TITLE
fix(workstation): replay probes restore the live document (#16467)

### DIFF
--- a/apps/workstation/view/Workspace.mjs
+++ b/apps/workstation/view/Workspace.mjs
@@ -2307,13 +2307,15 @@ class Workspace extends Container {
         // Two consumer contracts share this front door. As a DRIVER (default), the replay's
         // resulting document stays live — the film pipeline and journey specs continue from it.
         // As a PROBE (`restoreDocument: true`), the displaced live document is restored after
-        // the replay, so a replay can never edit the surface it measures. The baseline swap and
-        // the restore can each change topology, so both projections are full — neither may
-        // declare a geometry-only projection over the transition.
-        me.dockModel = DockZoneModel.clone(initialDocument);
-        await me.refreshDockWorkspace();
-
+        // the replay, so a replay can never edit the surface it measures. The transaction owns
+        // the baseline swap too: a rejecting entry projection must still destroy the runner and
+        // service, and must still restore the probe's displaced document. Both projections are
+        // full — the swap and the restore can each change topology, so neither may declare a
+        // geometry-only projection over the transition.
         try {
+            me.dockModel = DockZoneModel.clone(initialDocument);
+            await me.refreshDockWorkspace();
+
             const result = await runner.start();
 
             await me.refreshPromise;
@@ -2325,7 +2327,9 @@ class Workspace extends Container {
 
             if (restoreDocument && !me.isDestroyed) {
                 me.dockModel = liveDocument;
-                await me.refreshDockWorkspace()
+                // The document assignment IS the restore; a rejecting restore projection must
+                // not mask the original transaction error.
+                await me.refreshDockWorkspace().catch(() => null)
             }
         }
     }

--- a/apps/workstation/view/Workspace.mjs
+++ b/apps/workstation/view/Workspace.mjs
@@ -2324,7 +2324,9 @@ class Workspace extends Container {
 
             const out = {...result, document: DockZoneModel.clone(me.dockModel)};
 
-            completed = true;
+            // A structured runner failure is a primary outcome the caller must receive intact —
+            // only a genuinely clean replay may let a restore failure replace the return.
+            completed = result?.completed === true && !result?.errors?.length;
 
             return out
         } finally {
@@ -2336,8 +2338,8 @@ class Workspace extends Container {
 
                 // The document assignment IS the restore. On a clean replay a rejecting restore
                 // projection must surface (a probe may not report success over an un-projected
-                // surface); while an original transaction error is in flight it must not be
-                // masked by the restore's own failure.
+                // surface); while a primary outcome is in flight — a thrown transaction error OR
+                // a structured runner failure — it must not be masked by the restore's own failure.
                 completed
                     ? await me.refreshDockWorkspace()
                     : await me.refreshDockWorkspace().catch(() => null)

--- a/apps/workstation/view/Workspace.mjs
+++ b/apps/workstation/view/Workspace.mjs
@@ -2312,7 +2312,8 @@ class Workspace extends Container {
         // service, and must still restore the probe's displaced document. Both projections are
         // full — the swap and the restore can each change topology, so neither may declare a
         // geometry-only projection over the transition.
-        let completed = false;
+        let completed = false,
+            out       = null;
 
         try {
             me.dockModel = DockZoneModel.clone(initialDocument);
@@ -2322,7 +2323,7 @@ class Workspace extends Container {
 
             await me.refreshPromise;
 
-            const out = {...result, document: DockZoneModel.clone(me.dockModel)};
+            out = {...result, document: DockZoneModel.clone(me.dockModel)};
 
             // A structured runner failure is a primary outcome the caller must receive intact —
             // only a genuinely clean replay may let a restore failure replace the return.
@@ -2336,13 +2337,16 @@ class Workspace extends Container {
             if (restoreDocument && !me.isDestroyed) {
                 me.dockModel = liveDocument;
 
-                // The document assignment IS the restore. On a clean replay a rejecting restore
-                // projection must surface (a probe may not report success over an un-projected
-                // surface); while a primary outcome is in flight — a thrown transaction error OR
-                // a structured runner failure — it must not be masked by the restore's own failure.
+                // The document assignment IS the restore. Restore-projection failure precedence:
+                // a clean replay propagates it (a probe may not report success over an
+                // un-projected surface); a structured primary keeps its result and RECORDS the
+                // restore failure as a namespaced entry in the returned errors; a thrown primary
+                // owns the return channel and the restore failure stays suppressed.
                 completed
                     ? await me.refreshDockWorkspace()
-                    : await me.refreshDockWorkspace().catch(() => null)
+                    : await me.refreshDockWorkspace().catch(error => {
+                        out?.errors?.push(`restore projection failed: ${error.message}`)
+                    })
             }
         }
     }

--- a/apps/workstation/view/Workspace.mjs
+++ b/apps/workstation/view/Workspace.mjs
@@ -2312,6 +2312,8 @@ class Workspace extends Container {
         // service, and must still restore the probe's displaced document. Both projections are
         // full — the swap and the restore can each change topology, so neither may declare a
         // geometry-only projection over the transition.
+        let completed = false;
+
         try {
             me.dockModel = DockZoneModel.clone(initialDocument);
             await me.refreshDockWorkspace();
@@ -2320,16 +2322,25 @@ class Workspace extends Container {
 
             await me.refreshPromise;
 
-            return {...result, document: DockZoneModel.clone(me.dockModel)}
+            const out = {...result, document: DockZoneModel.clone(me.dockModel)};
+
+            completed = true;
+
+            return out
         } finally {
             runner.destroy();
             dockService.destroy();
 
             if (restoreDocument && !me.isDestroyed) {
                 me.dockModel = liveDocument;
-                // The document assignment IS the restore; a rejecting restore projection must
-                // not mask the original transaction error.
-                await me.refreshDockWorkspace().catch(() => null)
+
+                // The document assignment IS the restore. On a clean replay a rejecting restore
+                // projection must surface (a probe may not report success over an un-projected
+                // surface); while an original transaction error is in flight it must not be
+                // masked by the restore's own failure.
+                completed
+                    ? await me.refreshDockWorkspace()
+                    : await me.refreshDockWorkspace().catch(() => null)
             }
         }
     }

--- a/apps/workstation/view/Workspace.mjs
+++ b/apps/workstation/view/Workspace.mjs
@@ -827,6 +827,17 @@ class Workspace extends Container {
 
                 me.cueReceipts.push({cue: {...cue}, receipt});
 
+                // Settlement is the cue's EFFECT, not its promise: executors report `errors`
+                // and `applied` (a cancel terminal settles legitimately un-applied). The
+                // receipt stays pushed either way, so a failure carries its own forensics.
+                if (receipt.errors?.length) {
+                    throw new Error(receipt.errors.join('; '))
+                }
+
+                if (receipt.applied === false && !receipt.cancelled) {
+                    throw new Error('terminal effect did not apply')
+                }
+
                 return receipt
             }).catch(error => {
                 const message = `${cue.type}: ${error.message}`;
@@ -2269,21 +2280,38 @@ class Workspace extends Container {
     /**
      * Replays one script's document tier from a fresh document in spec mode. Runtime-only
      * cues remain the visible tour's responsibility and are verified through its receipt.
-     * @param {Object} [script=workstationTourScript]
+     * By default the replay result stays live (the driver contract journey specs and the film
+     * pipeline continue from); `restoreDocument: true` turns the replay into a pure probe that
+     * restores the displaced live document afterwards.
+     * @param {Object} [script=workstationTourScript] `null` also resolves to the default script.
+     * @param {Object} [opts]
+     * @param {Boolean} [opts.restoreDocument=false] Restore the pre-replay live document after the run.
      * @returns {Promise<Object>}
      */
-    async runTourSpec(script=workstationTourScript) {
-        let me          = this,
-            dockService = Neo.create(DockService, {}),
-            runner      = Neo.create(TourRunner, {
-                componentId: me.id,
-                dockService,
-                mode       : 'spec',
-                script
-            });
+    async runTourSpec(script=workstationTourScript, {restoreDocument=false}={}) {
+        let me           = this,
+            dockService  = Neo.create(DockService, {}),
+            liveDocument = me.dockModel,
+            runner;
 
+        // Transport callers can only deliver `null` for "use the default script".
+        script ??= workstationTourScript;
+
+        runner = Neo.create(TourRunner, {
+            componentId: me.id,
+            dockService,
+            mode       : 'spec',
+            script
+        });
+
+        // Two consumer contracts share this front door. As a DRIVER (default), the replay's
+        // resulting document stays live — the film pipeline and journey specs continue from it.
+        // As a PROBE (`restoreDocument: true`), the displaced live document is restored after
+        // the replay, so a replay can never edit the surface it measures. The baseline swap and
+        // the restore can each change topology, so both projections are full — neither may
+        // declare a geometry-only projection over the transition.
         me.dockModel = DockZoneModel.clone(initialDocument);
-        await me.refreshDockWorkspace({geometryOnly: true});
+        await me.refreshDockWorkspace();
 
         try {
             const result = await runner.start();
@@ -2293,7 +2321,12 @@ class Workspace extends Container {
             return {...result, document: DockZoneModel.clone(me.dockModel)}
         } finally {
             runner.destroy();
-            dockService.destroy()
+            dockService.destroy();
+
+            if (restoreDocument && !me.isDestroyed) {
+                me.dockModel = liveDocument;
+                await me.refreshDockWorkspace()
+            }
         }
     }
 

--- a/test/playwright/e2e/workstation/WorkstationCrossZoneCueNL.spec.mjs
+++ b/test/playwright/e2e/workstation/WorkstationCrossZoneCueNL.spec.mjs
@@ -1,0 +1,104 @@
+import {test, expect} from '../../fixtures.mjs';
+
+/**
+ * @summary Whitebox E2E witness for the dense tour's audit cross-zone cue, invoked standalone.
+ *
+ * The tour runner fires surface cues without consuming their results, so a cue whose terminal
+ * commit produces no document mutation still lets the tour report every cue as settled. This
+ * spec invokes the exact tour cue directly on the Workspace and binds the executor's own
+ * return contract — `applied`, empty `errors`, the two-dwell beat log, and the committed
+ * document — so a silent commit no-op fails loudly with the executor's full forensic payload
+ * in the assertion message.
+ *
+ * Run: NEO_E2E_PORT=8151 npx playwright test workstation/WorkstationCrossZoneCueNL -c test/playwright/playwright.config.e2e.mjs --workers=1
+ */
+test.describe('Workstation — the audit cross-zone cue commits what it previews', () => {
+    test.setTimeout(90000);
+    test.use({
+        contextOptions: {screen: {height: 1080, width: 1920}},
+        viewport      : {height: 800, width: 1280}
+    });
+
+    test('the tour cue, invoked standalone, lands audit inside right-bottom-tabs', async ({page, neuralLink}) => {
+        const pageErrors = [];
+
+        page.on('pageerror', error => {
+            let value = error == null ? '' : String(error.stack || error.message || error);
+            value && value !== 'undefined' && pageErrors.push(value)
+        });
+
+        await page.goto('/apps/workstation/index.html');
+        await page.waitForSelector('.workstation-dock-host', {timeout: 60000});
+        await page.waitForSelector('.neo-tab-header-button.neo-draggable', {timeout: 60000});
+        await page.waitForFunction(() => {
+            const host = document.querySelector('.workstation-dock-host');
+
+            return host?.getBoundingClientRect().height > 300
+        }, {timeout: 60000});
+        await page.waitForTimeout(1200);
+
+        const app        = await neuralLink.connectToApp('Workstation'),
+              workspaces = await app.findInstances({className: 'Workstation.view.Workspace'}, ['id']),
+              wsId       = (Array.isArray(workspaces) ? workspaces[0] : workspaces)?.id;
+
+        expect(wsId, 'the workstation Workspace must exist in the App Worker').toBeTruthy();
+
+        const before = (await app.getDockTopology(wsId)).document;
+
+        expect(
+            before.nodes['right-top-tabs']?.items,
+            'precondition: audit is held by its tour source node'
+        ).toContain('audit');
+
+        // The exact cue the dense tour fires (apps/workstation/tour/denseWorkstation.mjs),
+        // invoked through the same entry the tour runner uses.
+        const result = await app.callMethod(wsId, 'executeCue', [{
+            type        : 'cross-zone-showcase',
+            itemId      : 'audit',
+            sourceNodeId: 'right-top-tabs',
+            terminal    : 'commit',
+            dwells      : [
+                {targetNodeId: 'scale-tabs',        placementKind: 'edge-bottom'},
+                {targetNodeId: 'right-bottom-tabs', placementKind: 'tab-into'}
+            ],
+            options: {dwellDelay: 700, moveDelay: 24, moveSteps: 18, showCursor: true}
+        }]);
+
+        const receipt = JSON.stringify(result);
+
+        expect(result, `the cue must return its result contract: ${receipt}`).toBeTruthy();
+        expect(result.errors ?? ['<no errors array>'], `cue errors must be empty: ${receipt}`).toEqual([]);
+        expect(result.applied, `the terminal commit must apply the previewed operation: ${receipt}`).toBe(true);
+        expect(
+            (result.beatLog ?? []).map(beat => beat.placementKind),
+            `both dwells must present their previews in order: ${receipt}`
+        ).toEqual(['edge-bottom', 'tab-into']);
+
+        const after = (await app.getDockTopology(wsId)).document;
+
+        expect(
+            after.nodes['right-bottom-tabs']?.items,
+            `document truth: audit joins right-bottom-tabs — after=${JSON.stringify(after.nodes['right-bottom-tabs'])}`
+        ).toContain('audit');
+        expect(
+            after.nodes['right-top-tabs']?.items ?? [],
+            'document truth: audit left its source node'
+        ).not.toContain('audit');
+
+        // Chrome truth must follow the document: the pane component and its header button
+        // re-home into the destination tab container, not merely the model.
+        const targetChrome = await app.callMethod(wsId, 'getTabChromeIdentity', ['right-bottom-tabs']),
+              sourceChrome = await app.callMethod(wsId, 'getTabChromeIdentity', ['right-top-tabs']);
+
+        expect(
+            targetChrome?.buttons?.audit,
+            `chrome truth: audit's header button lives under right-bottom-tabs — target=${JSON.stringify(targetChrome)} source=${JSON.stringify(sourceChrome)}`
+        ).toBeTruthy();
+        expect(
+            sourceChrome?.buttons?.audit ?? null,
+            `chrome truth: audit's header button left right-top-tabs — source=${JSON.stringify(sourceChrome)}`
+        ).toBeNull();
+
+        expect(pageErrors, 'the gesture surfaces no page errors').toEqual([])
+    });
+});

--- a/test/playwright/e2e/workstation/WorkstationNL.spec.mjs
+++ b/test/playwright/e2e/workstation/WorkstationNL.spec.mjs
@@ -1777,8 +1777,8 @@ test.describe('Workstation — dense living-data composition', () => {
 
         // Two fresh document-tier spec runs remain byte-identical; the real-button receipt above
         // is the separate authority for asynchronous surface cues.
-        const run1 = await app.callMethod(workspaceId, 'runTourSpec', []),
-              run2 = await app.callMethod(workspaceId, 'runTourSpec', []);
+        const run1 = await app.callMethod(workspaceId, 'runTourSpec', [null, {restoreDocument: true}]),
+              run2 = await app.callMethod(workspaceId, 'runTourSpec', [null, {restoreDocument: true}]);
 
         expect(run1.completed, `run 1 errors: ${JSON.stringify(run1.errors)}`).toBe(true);
         expect(run1.errors).toEqual([]);
@@ -1824,8 +1824,19 @@ test.describe('Workstation — dense living-data composition', () => {
                 }
             };
 
+        const
+            postTourDocument = (await app.getDockTopology(workspaceId)).document,
+            postTourReceipt  = await app.callMethod(workspaceId, 'getTourReceipt', []),
+            crossZoneCue     = postTourReceipt?.cueReceipts
+                ?.find(entry => entry.cue?.type === 'cross-zone-showcase')?.receipt;
+
         expect(postTourChrome,
-            'cross-zone + split/return preserve every chrome identity while Audit changes owner')
+            'cross-zone + split/return preserve every chrome identity while Audit changes owner — ' +
+            `document right-top=${JSON.stringify(postTourDocument.nodes['right-top-tabs']?.items)} ` +
+            `right-bottom=${JSON.stringify(postTourDocument.nodes['right-bottom-tabs']?.items)} ` +
+            `cueApplied=${crossZoneCue?.applied} ` +
+            `cueDocAfter right-top=${JSON.stringify(crossZoneCue?.proof?.documentAfter?.nodes?.['right-top-tabs']?.items)} ` +
+            `right-bottom=${JSON.stringify(crossZoneCue?.proof?.documentAfter?.nodes?.['right-bottom-tabs']?.items)}`)
             .toEqual(expectedPostTourChrome);
 
         const indicatorSetup = await page.evaluate(receipt => {

--- a/test/playwright/unit/apps/workstation/Workspace.spec.mjs
+++ b/test/playwright/unit/apps/workstation/Workspace.spec.mjs
@@ -2170,3 +2170,124 @@ test.describe.serial('Workstation.view.Workspace', () => {
         }
     })
 });
+
+/**
+ * Builds the minimal host surface `onTourBeat` consumes, with a scripted `executeCue`.
+ * @param {Object} cueResult Receipt the scripted executor resolves.
+ * @returns {Object}
+ */
+function createCueHost(cueResult) {
+    return {
+        captions      : [],
+        cueErrors     : [],
+        cuePromise    : Promise.resolve(),
+        cueReceipts   : [],
+        cueSettlements: new Map(),
+        executeCue() {
+            return Promise.resolve(cueResult)
+        },
+        setTourCaption(text) {
+            this.captions.push(text)
+        }
+    }
+}
+
+test.describe('cue settlement truth-binding (prototype-call)', () => {
+    const beat = {cue: {type: 'cross-zone-showcase'}, sceneIndex: 0, stepIndex: 0};
+
+    test('an un-applied, error-free, non-cancel receipt fails the settlement and retains its forensics', async () => {
+        const host = createCueHost({applied: false, errors: []});
+
+        Workspace.prototype.onTourBeat.call(host, beat);
+        await host.cueSettlements.get('0:0');
+
+        expect(host.cueErrors).toEqual(['cross-zone-showcase: terminal effect did not apply']);
+        expect(host.cueReceipts, 'the forensic receipt is retained alongside the failure')
+            .toHaveLength(1);
+        expect(host.captions.at(-1)).toContain('Surface cue failed')
+    });
+
+    test('a receipt carrying errors fails the settlement with those errors', async () => {
+        const host = createCueHost({applied: true, errors: ['zone unreachable', 'no candidate']});
+
+        Workspace.prototype.onTourBeat.call(host, beat);
+        await host.cueSettlements.get('0:0');
+
+        expect(host.cueErrors).toEqual(['cross-zone-showcase: zone unreachable; no candidate']);
+        expect(host.cueReceipts).toHaveLength(1)
+    });
+
+    test('a cancel terminal settles legitimately un-applied', async () => {
+        const host = createCueHost({applied: false, cancelled: true, errors: []});
+
+        Workspace.prototype.onTourBeat.call(host, beat);
+        await host.cueSettlements.get('0:0');
+
+        expect(host.cueErrors).toEqual([]);
+        expect(host.cueReceipts).toHaveLength(1)
+    });
+
+    test('a healthy applied receipt settles clean', async () => {
+        const host = createCueHost({applied: true, beatLog: [], errors: []});
+
+        Workspace.prototype.onTourBeat.call(host, beat);
+        await host.cueSettlements.get('0:0');
+
+        expect(host.cueErrors).toEqual([]);
+        expect(host.cueReceipts).toHaveLength(1)
+    });
+});
+
+test.describe('replay probe transaction (prototype-call)', () => {
+    test('a rejecting entry projection still restores the displaced document under restoreDocument', async () => {
+        const
+            liveDocument = {nodes: {marker: 'live'}},
+            refreshCalls = [],
+            host         = {
+                dockModel     : liveDocument,
+                id            : 'fake-workspace',
+                isDestroyed   : false,
+                refreshPromise: Promise.resolve(),
+                refreshDockWorkspace(options) {
+                    refreshCalls.push(options ?? {});
+
+                    return refreshCalls.length === 1
+                        ? Promise.reject(new Error('entry projection rejected'))
+                        : Promise.resolve()
+                }
+            };
+
+        await expect(
+            Workspace.prototype.runTourSpec.call(host, null, {restoreDocument: true}),
+            'the transaction error propagates'
+        ).rejects.toThrow('entry projection rejected');
+
+        expect(host.dockModel, 'the exact displaced document is restored').toBe(liveDocument);
+        expect(refreshCalls, 'entry projection + restore projection both ran').toHaveLength(2)
+    });
+
+    test('a rejecting entry projection leaves the driver default without a restore', async () => {
+        const
+            liveDocument = {nodes: {marker: 'live'}},
+            refreshCalls = [],
+            host         = {
+                dockModel     : liveDocument,
+                id            : 'fake-workspace',
+                isDestroyed   : false,
+                refreshPromise: Promise.resolve(),
+                refreshDockWorkspace(options) {
+                    refreshCalls.push(options ?? {});
+
+                    return Promise.reject(new Error('entry projection rejected'))
+                }
+            };
+
+        await expect(
+            Workspace.prototype.runTourSpec.call(host, null)
+        ).rejects.toThrow('entry projection rejected');
+
+        expect(host.dockModel, 'the driver contract keeps the baseline (no silent restore)')
+            .not.toBe(liveDocument);
+        expect(refreshCalls).toHaveLength(1)
+    });
+});

--- a/test/playwright/unit/apps/workstation/Workspace.spec.mjs
+++ b/test/playwright/unit/apps/workstation/Workspace.spec.mjs
@@ -2266,6 +2266,35 @@ test.describe('replay probe transaction (prototype-call)', () => {
         expect(refreshCalls, 'entry projection + restore projection both ran').toHaveLength(2)
     });
 
+    test('a successful replay surfaces a rejecting restore projection instead of swallowing it', async () => {
+        const
+            liveDocument = {nodes: {marker: 'live'}},
+            refreshCalls = [],
+            host         = {
+                dockModel     : liveDocument,
+                id            : 'fake-workspace',
+                isDestroyed   : false,
+                refreshPromise: Promise.resolve(),
+                refreshDockWorkspace(options) {
+                    refreshCalls.push(options ?? {});
+
+                    // entry projection succeeds; the restore projection rejects
+                    return refreshCalls.length === 1
+                        ? Promise.resolve()
+                        : Promise.reject(new Error('restore projection rejected'))
+                }
+            },
+            script = {schema: 'neo.tour.script.v1', id: 'noop', title: 'noop', scenes: []};
+
+        await expect(
+            Workspace.prototype.runTourSpec.call(host, script, {restoreDocument: true}),
+            'a probe may not report success over an un-projected surface'
+        ).rejects.toThrow('restore projection rejected');
+
+        expect(host.dockModel, 'the displaced document is still restored').toBe(liveDocument);
+        expect(refreshCalls).toHaveLength(2)
+    });
+
     test('a rejecting entry projection leaves the driver default without a restore', async () => {
         const
             liveDocument = {nodes: {marker: 'live'}},

--- a/test/playwright/unit/apps/workstation/Workspace.spec.mjs
+++ b/test/playwright/unit/apps/workstation/Workspace.spec.mjs
@@ -2333,9 +2333,16 @@ test.describe('replay probe transaction (prototype-call)', () => {
         const result = await Workspace.prototype.runTourSpec.call(host, script, {restoreDocument: true});
 
         expect(result.completed, 'the structured failure reaches the caller').toBe(false);
-        expect(result.errors.length, 'the runner forensics survive the restore').toBeGreaterThan(0);
+        expect(
+            result.errors.some(error => !error.includes('restore projection failed')),
+            'the runner forensics survive the restore'
+        ).toBe(true);
+        expect(
+            result.errors.some(error => error.includes('restore projection failed: restore projection rejected')),
+            'the suppressed restore failure is recorded on the structured result'
+        ).toBe(true);
         expect(host.dockModel, 'the displaced document is still restored').toBe(liveDocument);
-        expect(refreshCalls, 'the rejecting restore projection ran and was suppressed').toHaveLength(2)
+        expect(refreshCalls, 'the rejecting restore projection ran and was recorded').toHaveLength(2)
     });
 
     test('a rejecting entry projection leaves the driver default without a restore', async () => {

--- a/test/playwright/unit/apps/workstation/Workspace.spec.mjs
+++ b/test/playwright/unit/apps/workstation/Workspace.spec.mjs
@@ -2284,7 +2284,12 @@ test.describe('replay probe transaction (prototype-call)', () => {
                         : Promise.reject(new Error('restore projection rejected'))
                 }
             },
-            script = {schema: 'neo.tour.script.v1', id: 'noop', title: 'noop', scenes: []};
+            script = {
+                schema: 'neo.tour.script.v1',
+                id    : 'clean-pause',
+                title : 'clean pause',
+                scenes: [{id: 's1', title: 'pause', steps: [{type: 'pause', ms: 1}]}]
+            };
 
         await expect(
             Workspace.prototype.runTourSpec.call(host, script, {restoreDocument: true}),
@@ -2293,6 +2298,44 @@ test.describe('replay probe transaction (prototype-call)', () => {
 
         expect(host.dockModel, 'the displaced document is still restored').toBe(liveDocument);
         expect(refreshCalls).toHaveLength(2)
+    });
+
+    test('a structured runner failure returns intact — a rejecting restore projection may not replace it', async () => {
+        const
+            liveDocument = {nodes: {marker: 'live'}},
+            refreshCalls = [],
+            host         = {
+                dockModel     : liveDocument,
+                id            : 'fake-workspace-unregistered',
+                isDestroyed   : false,
+                refreshPromise: Promise.resolve(),
+                refreshDockWorkspace(options) {
+                    refreshCalls.push(options ?? {});
+
+                    return refreshCalls.length === 1
+                        ? Promise.resolve()
+                        : Promise.reject(new Error('restore projection rejected'))
+                }
+            },
+            // The unregistered holder id makes every dock-service step fail STRUCTURALLY:
+            // the runner reports {completed:false, errors:[...]} without throwing.
+            script = {
+                schema: 'neo.tour.script.v1',
+                id    : 'structured-failure',
+                title : 'structured failure',
+                scenes: [{
+                    id   : 's1',
+                    title: 'assert',
+                    steps: [{type: 'topology-assert', expect: [{path: 'nodes.missing.items', equals: ['x']}]}]
+                }]
+            };
+
+        const result = await Workspace.prototype.runTourSpec.call(host, script, {restoreDocument: true});
+
+        expect(result.completed, 'the structured failure reaches the caller').toBe(false);
+        expect(result.errors.length, 'the runner forensics survive the restore').toBeGreaterThan(0);
+        expect(host.dockModel, 'the displaced document is still restored').toBe(liveDocument);
+        expect(refreshCalls, 'the rejecting restore projection ran and was suppressed').toHaveLength(2)
     });
 
     test('a rejecting entry projection leaves the driver default without a restore', async () => {


### PR DESCRIPTION
Resolves #16467

The audit tab's commit was never lost — the probe was the editor. The real tour commits the cue and re-homes chrome correctly (1s-sampled timeline receipts, both viewports); the failing chrome assertion sits downstream of the spec's two `runTourSpec()` determinism replays, and each replay **reset the live document to the script baseline and never restored it** (with a stable-topology-declaring `geometryOnly` refresh over the swap — the `#16412` hazard shape). Cues are structurally external to replays (the replay runner wires no beat listener — by TourRunner's own contract), so the replays legitimately re-play ops-only from baseline: audit lands back home, terminally. The assertion itself was **unreachable from birth** — authored in the same PR as the replay ordering and masked in every historical run by the `#16356` clipped-frames red — so this is a latent authored-red exposed by un-masking, not a regression (label corrected on the ticket).

Two repairs, one witness, one oracle upgrade:

1. **`runTourSpec` gains an explicit consumer contract** — `restoreDocument: false` (default) keeps the existing DRIVER behavior (the replay result stays live: the five-beat journey specs and the film pipeline continue from it — verified, their live-document polls encode exactly this); `restoreDocument: true` makes the replay a pure PROBE that snapshots and restores the displaced live document in `finally`. The dense spec's two determinism replays opt into the probe contract. Both the baseline swap and the restore are FULL projections (either can change topology; the previous `geometryOnly` over the baseline swap was the `#16412` hazard shape and is retired here).
2. **Cue settlement binds effect truth** (`onTourBeat`): a cue reporting `errors`, or a non-cancel `applied: false`, fails the tour loudly with the executor's own forensics — the settle-report can no longer count a no-op as settled. Receipts stay pushed pre-throw, so failures carry their proof. Verified against every cue executor's return shape (cancel terminals legitimately settle un-applied; shape-free executors unaffected).
3. **New witness `WorkstationCrossZoneCueNL`**: the tour's exact cue invoked standalone — document truth (audit joins `right-bottom-tabs`) plus chrome truth (`getTabChromeIdentity`: the header button re-homes, the source loses it).
4. **Oracle diagnostics**: the dense spec's chrome assertion failure message now carries the post-tour document state and the cue's own `proof.documentAfter` — the exact discrimination that cracked this case, kept permanent.

Evidence: L3 achieved (browser-rendered runtime on this host: the dense tour row green END TO END — 24.3s headed — including every assertion beyond the chrome check, reached for the first time since PR `#15952` authored them; standalone witness green; headless battery at the same tree) → L3 required (close-target ACs are runtime-verifiable locally). Battery receipt + attribution in the PR thread before the reviewer seat request.

## Deltas from ticket

- The ticket's premise inverted twice under receipts: the "commit no-op" is real only as a *terminal-state* observation — the commit lands and is then displaced by the replays' un-restored reset. The prescribed "instrument the commit leg" happened (writer-log instrumentation, since removed) and named a different owning seam than any suspect: `runTourSpec`'s residue, not the drag pipeline. Iris's flagged `onDrop` gaps are exonerated for this defect entirely.
- The `regression` label was removed with receipts: the assertion was never reachable before the `#16356` repair (its author's own masking receipts), so there is no green history to regress from.
- The cue settle-contract question (ticket AC4) landed as the `onTourBeat` truth-binding rather than a runner change — the accounting infrastructure existed and only consumed receipt truthiness.
- AC3's "twice consecutively" is satisfied by the verdict run + the combined re-run at the same tree.

## Evolution

The first repair shape made the restore unconditional — and the battery immediately convicted it: FiveBeat scenes 1 and 5 consume the replay's residue as their driving mechanism (`expect.poll` on the live document after `runTourSpec`), and the film pipeline replays scripts to drive the app the same way. The restore became an explicit opt-in (`restoreDocument`), preserving the driver contract by default and giving the dense spec's determinism replays the probe contract they need. Both consumers now state their contract at the call site.

## Test Evidence

- Dense tour row (`workstation/WorkstationNL --grep "the real tour keeps density"`, headed, port 8137): **1 passed (24.3s)** — first full end-to-end green of this row; the chrome assertion and all downstream assertions pass. Re-confirmed headless in the combined run below (AC3's second consecutive pass).
- Combined contract verification (`WorkstationFiveBeatNL + WorkstationNL + WorkstationCrossZoneCueNL`, headless, port 8155): **11 passed / 2 take-gated skips** — the driver contract (FiveBeat scenes 1 + 5, healed after the Evolution pivot), the probe contract (dense row), and the new standalone witness together at the final tree.
- Headless regression battery (`workstation/ + dashboard/DockMotionNL + agentos/FleetCockpitDockNL`, port 8141): posted to the PR thread with per-fail attribution before the reviewer seat request (the `#16357`/`#16365`/PopupOverlap pre-existing reds are expected and receipted on their tickets).
- Classification receipts (timeline probes, writer log, wiring proof, archaeology): #16467 comments r1/r2/final.

## Post-Merge Validation

- [ ] CI full unit suite green on the merge commit (no unit surface touched; guard only)
- [ ] The dense tour row stays green on the next film-lane headed pass (#15252)
- [ ] `#16412`'s broader geometryOnly-caller audit proceeds independently — this PR removes one instance (the replay swap), not the class

## Commits

- single commit — `fix(workstation): replay probes restore the live document (#16467)`

Authored by Mnemosyne (Fable 5, Claude Code). Session dd021188-1651-4759-80e5-b6eccf4c65cc.
