### PR TITLE
Commit the heap-ceiling proofs only a reviewer had run

### DIFF
--- a/ai/configBase.mjs
+++ b/ai/configBase.mjs
@@ -29,9 +29,17 @@ const DAY_MS  = 24 * HOUR_MS;
  * trades a catchable `FATAL ERROR: heap limit` for an uncatchable kernel OOM kill that leaves no
  * diagnostic at all.
  *
- * @param {String} value Raw env value.
- * @returns {Number}
- * @throws {TypeError} When the override is not a positive integer.
+ * The signature is the reason this JSDoc is worth reading carefully. A `metadata.parse` hook does
+ * NOT receive the value — it receives the env var's NAME and reads the value itself, which is what
+ * lets it distinguish "unset" from "set to something invalid". The first draft of this parser was
+ * written against the value signature and threw on every input including unset, which would have
+ * failed boot for every deployment that never set the override.
+ *
+ * @param {String} envVarName The env var's NAME, not its value.
+ * @param {Object} [options]
+ * @param {Object} [options.env=process.env] Env source; injectable for tests.
+ * @returns {Number|undefined} `undefined` when unset, so the leaf default applies.
+ * @throws {TypeError} When the override is set but is not a positive integer.
  */
 function parseSupervisedTaskHeapMb(envVarName, {env = process.env} = {}) {
     const rawValue = env[envVarName];

--- a/test/playwright/unit/ai/configBase.spec.mjs
+++ b/test/playwright/unit/ai/configBase.spec.mjs
@@ -32,6 +32,54 @@ test.describe('ai/configBase — delta-only subclass overlays (overlay-drift roo
         return {cls, instance, proxy: createConfigProxy(instance)};
     }
 
+    /**
+     * AC-F1 — the supervised-child heap ceiling's fail-closed parse, committed.
+     *
+     * @neo-gpt-emmy verified this rejection by hand at the merged heap-ceiling head and approved on
+     * that evidence; nothing in the tree pinned it. Reviewer execution is not regression coverage —
+     * it proves the head she ran, not the next edit.
+     *
+     * The value of failing closed is not tidiness. `-1` does NOT fail on its own: Node reports
+     * `--max-old-space-size=-1` out of bounds, **exits 0**, and continues with a ~4.5 GB heap limit
+     * — above the 3 GiB cgroup. So the invalid override yields a LARGER ceiling than any valid one,
+     * and trades a catchable `FATAL ERROR: heap limit` for an uncatchable kernel OOM kill that
+     * leaves no diagnostic. A permissive parser inverts the property the ceiling exists for.
+     *
+     * All three branches are asserted because the first draft of this parser was written against a
+     * `(value)` signature rather than `(envVarName, {env})` and threw on EVERY input including
+     * unset, which would have failed boot for every deployment that never set the override. Only
+     * probing all of them caught it.
+     */
+    test('#16463 — the supervised-child heap ceiling refuses a non-positive override rather than falling back', () => {
+        const envName  = 'NEO_SUPERVISED_TASK_HEAP_MB',
+              original = process.env[envName];
+
+        const build = className => createOverlayFixture(className, null);
+
+        try {
+            delete process.env[envName];
+            // Unset resolves the leaf default — the branch a value-signature parser would have thrown on.
+            expect(build('Neo.ai.unittest.HeapCeilingUnsetFixture').proxy.orchestrator.supervisedTaskHeapMb).toBe(384);
+
+            process.env[envName] = '512';
+            expect(build('Neo.ai.unittest.HeapCeilingOverrideFixture').proxy.orchestrator.supervisedTaskHeapMb).toBe(512);
+
+            // Refusal, not fallback. Falling back to 384 here would be silent, and the operator would
+            // be running a 4.5 GB child under a 3 GiB cap with nothing saying so.
+            for (const bad of ['-1', '0', '1.5', 'abc']) {
+                process.env[envName] = bad;
+                expect(() => build(`Neo.ai.unittest.HeapCeilingRejects${bad.replace(/\W/g, '')}Fixture`), `${bad} must be refused`)
+                    .toThrow(TypeError);
+            }
+        } finally {
+            if (original === undefined) {
+                delete process.env[envName];
+            } else {
+                process.env[envName] = original;
+            }
+        }
+    });
+
     test('a base leaf NOT named in the delta resolves through the subclass — zero overlay edits (AC-1)', () => {
         // Deltas are leaf() declarations exactly like the base — the data plane's invariant.
         // (A bare primitive merged over a leaf descriptor does not survive construction; the

--- a/test/playwright/unit/ai/configBase.spec.mjs
+++ b/test/playwright/unit/ai/configBase.spec.mjs
@@ -54,22 +54,33 @@ test.describe('ai/configBase — delta-only subclass overlays (overlay-drift roo
         const envName  = 'NEO_SUPERVISED_TASK_HEAP_MB',
               original = process.env[envName];
 
-        const build = className => createOverlayFixture(className, null);
+        // ONE retained instance, refreshed per case, destroyed in `finally`.
+        //
+        // An earlier revision constructed a fresh fixture per branch, which left every successful one
+        // registered and — because the invalid branch throws DURING construction — leaked a
+        // half-built provider that no `destroy()` could reach (@neo-gpt-emmy measured registered
+        // instances moving 0 -> 1 and staying there after the expected TypeError). `refreshEnv()`
+        // re-applies the env layer on a live instance, so the same four branches are exercised with
+        // one object whose lifecycle a `finally` can actually own.
+        let fixture = null;
 
         try {
             delete process.env[envName];
-            // Unset resolves the leaf default — the branch a value-signature parser would have thrown on.
-            expect(build('Neo.ai.unittest.HeapCeilingUnsetFixture').proxy.orchestrator.supervisedTaskHeapMb).toBe(384);
+            fixture = createOverlayFixture('Neo.ai.unittest.HeapCeilingFixture', null);
+
+            // Unset resolves the leaf default — the branch a value-signature parser would have
+            // thrown on, which is how the backwards first draft was caught.
+            expect(fixture.proxy.orchestrator.supervisedTaskHeapMb).toBe(384);
 
             process.env[envName] = '512';
-            expect(build('Neo.ai.unittest.HeapCeilingOverrideFixture').proxy.orchestrator.supervisedTaskHeapMb).toBe(512);
+            fixture.instance.refreshEnv();
+            expect(fixture.proxy.orchestrator.supervisedTaskHeapMb).toBe(512);
 
-            // Refusal, not fallback. Falling back to 384 here would be silent, and the operator would
-            // be running a 4.5 GB child under a 3 GiB cap with nothing saying so.
+            // Refusal, not fallback. Falling back to 384 here would be silent, and the operator
+            // would be running a ~4.5 GB child under a 3 GiB cap with nothing saying so.
             for (const bad of ['-1', '0', '1.5', 'abc']) {
                 process.env[envName] = bad;
-                expect(() => build(`Neo.ai.unittest.HeapCeilingRejects${bad.replace(/\W/g, '')}Fixture`), `${bad} must be refused`)
-                    .toThrow(TypeError);
+                expect(() => fixture.instance.refreshEnv(), `${bad} must be refused`).toThrow(TypeError);
             }
         } finally {
             if (original === undefined) {
@@ -77,6 +88,8 @@ test.describe('ai/configBase — delta-only subclass overlays (overlay-drift roo
             } else {
                 process.env[envName] = original;
             }
+
+            fixture?.instance?.destroy();
         }
     });
 

--- a/test/playwright/unit/ai/daemons/orchestrator/Orchestrator.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/Orchestrator.spec.mjs
@@ -1,11 +1,14 @@
-import {test, expect}             from '@playwright/test';
-import fs                         from 'fs-extra';
-import path                       from 'path';
-import Neo                        from '../../../../../../src/Neo.mjs';
-import * as core                  from '../../../../../../src/core/_export.mjs';
-import AiConfig                   from '../../../../../../ai/config.template.mjs';
-import {Orchestrator}             from '../../../../../../ai/daemons/orchestrator/Orchestrator.mjs';
-import {ProcessSupervisorService} from '../../../../../../ai/daemons/orchestrator/services/ProcessSupervisorService.mjs';
+import {test, expect} from '@playwright/test';
+import fs             from 'fs-extra';
+import path           from 'path';
+import Neo            from '../../../../../../src/Neo.mjs';
+import * as core      from '../../../../../../src/core/_export.mjs';
+import AiConfig       from '../../../../../../ai/config.template.mjs';
+import {Orchestrator} from '../../../../../../ai/daemons/orchestrator/Orchestrator.mjs';
+import {
+    buildSupervisedTaskEnv,
+    ProcessSupervisorService
+} from '../../../../../../ai/daemons/orchestrator/services/ProcessSupervisorService.mjs';
 import {
     DEFAULT_HEAVY_MAINTENANCE_TASK_NAMES
 } from '../../../../../../ai/daemons/orchestrator/services/MaintenanceBackpressureService.mjs';
@@ -2531,5 +2534,59 @@ test.describe('taskDefinitions — chroma persist dir rides the resolved leaf (#
         const tasks = buildTaskDefinitions({chromaPort: 8000});
 
         expect(tasks.chroma.args).toEqual(['run', '--path', '.neo-ai-data/chroma/unified', '--port', '8000']);
+    });
+});
+
+/**
+ * AC-F2 — the supervised-child heap ceiling actually ARRIVES at the constructed supervisor.
+ *
+ * @neo-gpt-emmy proved this seam by executing the merged heap-ceiling head and approved on that;
+ * her delta challenge recorded that exact-head search finds `NEO_SUPERVISED_TASK_HEAP_MB` only where
+ * the helper proves it IGNORES the env var — which is the opposite property. The env-independence
+ * of `buildSupervisedTaskEnv` was pinned; the injection that gives it a value was not.
+ *
+ * The trap this test is shaped around: `ProcessSupervisorService` carries
+ * `FALLBACK_SUPERVISED_TASK_HEAP_MB = 384`, and the leaf default is ALSO 384. So asserting the
+ * default would pass with the injection line deleted — the supervisor would reach the same number
+ * by falling back, and a test that cannot fail on the deletion is not covering it. The override is
+ * therefore set to a value no fallback can produce.
+ */
+test.describe('Neo.ai.daemons.Orchestrator — supervised-child heap ceiling injection (#16463)', () => {
+    const LEAF_PATH = 'orchestrator.supervisedTaskHeapMb',
+          // Deliberately not 384, and not any other constant in the module under test.
+          INJECTED   = 777;
+
+    let saved;
+
+    test.beforeEach(() => {
+        saved = AiConfig.orchestrator.supervisedTaskHeapMb;
+        AiConfig.setData(LEAF_PATH, INJECTED);
+    });
+
+    test.afterEach(() => {
+        AiConfig.setData(LEAF_PATH, saved);
+    });
+
+    test('the resolved leaf reaches the constructed ProcessSupervisorService', () => {
+        // The premise: the injected value is distinguishable from the service's own fallback.
+        expect(INJECTED).not.toBe(384);
+        expect(AiConfig.orchestrator.supervisedTaskHeapMb).toBe(INJECTED);
+
+        const orchestrator = createTestOrchestrator();
+
+        expect(orchestrator.processSupervisorService.supervisedTaskHeapMb).toBe(INJECTED);
+    });
+
+    test('the injected member is what the child env builder consumes, not the module fallback', () => {
+        const orchestrator = createTestOrchestrator(),
+              // The exact expression the spawn path evaluates
+              // (`ProcessSupervisorService.runSupervisedTask`).
+              env          = buildSupervisedTaskEnv({
+                  baseEnv      : {},
+                  defaultHeapMb: orchestrator.processSupervisorService.supervisedTaskHeapMb
+              });
+
+        // The member is only worth injecting if it lands on the child's actual NODE_OPTIONS.
+        expect(env.NODE_OPTIONS).toBe(`--max-old-space-size=${INJECTED}`);
     });
 });

--- a/test/playwright/unit/ai/daemons/orchestrator/Orchestrator.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/Orchestrator.spec.mjs
@@ -2577,16 +2577,51 @@ test.describe('Neo.ai.daemons.Orchestrator — supervised-child heap ceiling inj
         expect(orchestrator.processSupervisorService.supervisedTaskHeapMb).toBe(INJECTED);
     });
 
-    test('the injected member is what the child env builder consumes, not the module fallback', () => {
+    /**
+     * SECOND HOP, driven rather than replayed.
+     *
+     * The previous revision of this test called `buildSupervisedTaskEnv({defaultHeapMb: <member>})`
+     * itself — it hand-fed the value across the very boundary it claimed to cover, so it asserted
+     * that a pure function formats a number it was given. @neo-gpt-emmy mutated `runTask`'s read to
+     * the module fallback and BOTH tests stayed green; the service-to-child hop had no coverage at
+     * all while its test name claimed otherwise.
+     *
+     * This drives the real `runTask` on the orchestrator-constructed service and reads the ceiling
+     * off the spawn arguments, so the assertion depends on the production expression rather than on
+     * a copy of it.
+     */
+    test('the injected ceiling reaches the SPAWNED child env — driven through runTask, not replayed', () => {
         const orchestrator = createTestOrchestrator(),
-              // The exact expression the spawn path evaluates
-              // (`ProcessSupervisorService.runSupervisedTask`).
-              env          = buildSupervisedTaskEnv({
-                  baseEnv      : {},
-                  defaultHeapMb: orchestrator.processSupervisorService.supervisedTaskHeapMb
-              });
+              supervisor   = orchestrator.processSupervisorService;
 
-        // The member is only worth injecting if it lands on the child's actual NODE_OPTIONS.
-        expect(env.NODE_OPTIONS).toBe(`--max-old-space-size=${INJECTED}`);
+        let spawnedEnv = null;
+
+        const probeDefinition = {
+            heapCeilingProbe: {
+                label          : 'Heap Ceiling Probe',
+                command        : 'node',
+                args           : ['--version'],
+                pidFileName    : 'heap-ceiling-probe.pid',
+                expectedCommand: 'node'
+            }
+        };
+
+        supervisor.taskDefinitions = {...supervisor.taskDefinitions, ...probeDefinition};
+
+        // `taskState` is seeded from the definitions the harness constructed with, so a definition
+        // added afterwards has none and `runTask` reads `state.running` off undefined. Seeded with
+        // the same factory rather than a hand-shaped literal, so the probe cannot drift from the
+        // real initial shape.
+        Object.assign(TaskStateService.taskState, createInitialTaskState(probeDefinition));
+
+        supervisor.spawnFn = (command, args, options) => {
+            spawnedEnv = options.env;
+            return {pid: 4711, on: () => {}, stderr: {on: () => {}}};
+        };
+
+        expect(supervisor.runTask('heapCeilingProbe', 'heap-ceiling-witness')).toBe(true);
+
+        // Read off the spawn call, which is the only surface a real child ever sees.
+        expect(spawnedEnv.NODE_OPTIONS).toBe(`--max-old-space-size=${INJECTED}`);
     });
 });

--- a/test/playwright/unit/ai/daemons/shared/fileLease.spec.mjs
+++ b/test/playwright/unit/ai/daemons/shared/fileLease.spec.mjs
@@ -323,12 +323,19 @@ test.describe('#16230 — file lease: claim, refuse, reclaim, release (TTL-liven
     });
 
     /**
-     * A refusal whose holder identity is byte-identical to the requester's is self-succession: the
-     * same slot restarted inside the freshness window and is refused against its own predecessor.
-     * The refusal is correct; the "stop the duplicate" remediation is not, and it sent an operator
-     * hunting for a second process that did not exist while the real cause — a crash loop — scrolled
-     * past above it. Containers make this the common case: hostname is the container id and the
-     * entrypoint is always pid 1, so every restart reproduces the previous identity exactly.
+     * A refusal whose holder identity is byte-identical to the requester's is EVIDENCE of
+     * self-succession, not proof of it — the field is named `holderIdentityMatchesRequester` for
+     * that reason, and the guidance says "may be" rather than "is".
+     *
+     * The distinction is load-bearing, because the same byte-identical identity is exactly what a
+     * genuine duplicate produces. Containers make both cases collide: hostname is the container id
+     * and the entrypoint is always pid 1, so a restart of the same slot AND a second container
+     * started from the same image reproduce the previous identity equally well. Nothing in the
+     * refusal can separate them, so the message must not pick one.
+     *
+     * What it replaces is worse than imprecise: "stop the duplicate" sent an operator hunting for a
+     * second process that did not exist while the real cause — a crash loop — scrolled past above
+     * it. Asserting self-succession instead would fail the same way in the other direction.
      */
     test('#16459 — an identical holder identity reports the identity match instead of telling you to stop a duplicate', () => {
         const holder = {owner: 'orchestrator@21ccb536bbb9', pid: 1, startedAt: '2026-08-03T18:09:24.177Z'},


### PR DESCRIPTION
## Summary

@neo-gpt-emmy approved [#16460](https://github.com/neomjs/neo/pull/16460) with follow-up and it merged as `a4ad9aca71`, on the correct reasoning that a stopped, repeatedly OOMing orchestrator should not wait behind test and prose debt. **This is that debt.**

Two properties were proven by **reviewer execution** and by nothing in the tree. Reviewer execution proves the head she ran; it says nothing about the next edit. Her delta challenge named it exactly: exact-head search finds `NEO_SUPERVISED_TASK_HEAP_MB` in tests only where the helper proves it *ignores* the env var — the opposite property. The env-independence of `buildSupervisedTaskEnv` was pinned. The injection that gives it a value was not.

This PR adds no runtime behaviour. `ai/daemons/orchestrator/Orchestrator.mjs` and `ProcessSupervisorService.mjs` are untouched.

## What changed

**AC-F1 — the parser refuses rather than falls back** (`test/playwright/unit/ai/configBase.spec.mjs`)

`-1` does not fail on its own. Node reports `--max-old-space-size=-1` out of bounds, **exits 0**, and continues with a ~4.5 GB heap limit — above the 3 GiB cgroup. The invalid override therefore yields a **larger** ceiling than any valid one, and trades a catchable `FATAL ERROR: heap limit` for an uncatchable kernel OOM kill that leaves no diagnostic. Falling back to 384 would be silent, and the operator would be running a 4.5 GB child under a 3 GiB cap with nothing saying so.

Unset / valid / invalid are all asserted, because the first draft of this parser was written against a `(value)` signature rather than `(envVarName, {env})` and threw on **every** input including unset — which would have failed boot for every deployment that never set the override. Only probing all three branches caught it.

**AC-F2 — the ceiling reaches the spawned child, across BOTH hops** (`Orchestrator.spec.mjs`)

Shaped around a trap worth naming: `ProcessSupervisorService` carries `FALLBACK_SUPERVISED_TASK_HEAP_MB = 384`, and the leaf default is **also 384**. A test asserting the default would pass with the injection line deleted — the supervisor reaches the same number by falling back. A test that cannot fail on the deletion is not covering it. The override is `777`, which no fallback can produce.

**Cycle-1 correction.** My first version of the second test called `buildSupervisedTaskEnv({defaultHeapMb: <the member>})` itself — it hand-fed the value *across the boundary it claimed to cover*, so it asserted only that a pure function formats a number it was handed, and `runTask` was never called. @neo-gpt-emmy mutated `runTask`'s read to the module fallback and **both tests stayed green**; I reproduced that exactly (79 passed with the hop severed). The test name claimed consumption it never exercised.

The witness now drives the real `runTask` on the orchestrator-constructed service with a capturing `spawnFn` and reads the ceiling off the spawn arguments, so the assertion depends on the production expression rather than a copy of it.

**AC-F3 — two prose surfaces that outran the code**

- `ai/configBase.mjs` — the parser's JSDoc said `@param {String} value Raw env value` on a function whose signature is `(envVarName, {env})`. Not cosmetic: that is precisely the confusion that produced the backwards first draft, so the JSDoc was still teaching the mistake. It now states that a `metadata.parse` hook receives the **name**, reads the value itself, and that this is what lets it distinguish unset from invalid.
- `fileLease.spec.mjs` — the rationale still said a matching holder identity **is** self-succession. The implementation was already softened to `holderIdentityMatchesRequester` with "may be" guidance, because the same byte-identical identity is exactly what a genuine duplicate produces: in a container, hostname is the container id and the entrypoint is always pid 1, so a restart and a second container from the same image are indistinguishable. Nothing in the refusal can separate them, so the message must not pick one. Asserting self-succession would fail the same way `stop the duplicate` did, in the other direction.

## Test Evidence

Evidence: mutation-proven per hop, not asserted. Two hops, two independent mutations, as @neo-gpt-emmy required.

```
leaf -> service    Orchestrator.mjs:417 -> `supervisedTaskHeapMb: 0`
                   2 failed, 77 passed   (both tests; the member is upstream of both)

service -> child   runTask read -> `FALLBACK_SUPERVISED_TASK_HEAP_MB`
                   1 failed, 78 passed   (ONLY the driven witness — it is the sole
                                          discriminator for this hop, which is exactly
                                          the property the Cycle-1 test lacked)
```

The second row is the one that matters: at Cycle 1 that same mutation produced **79 passed**. The delta between 79-green and 1-red is the repair.

Implementation restored byte-identical after both — `git diff --stat` on `ai/daemons/orchestrator/` is empty. The only `ai/` change in this PR is the parser JSDoc.

Suite: **105 passed** across `configBase.spec.mjs`, `Orchestrator.spec.mjs`, `fileLease.spec.mjs`.

Fixture lifecycle: the parser test built a fresh fixture per branch, so every successful one stayed registered and the invalid branch — which throws *during* construction — leaked a half-built provider no `destroy()` could reach. Now one retained instance, `refreshEnv()` per case, `destroy()` in `finally`.

## Post-Merge Validation

None required — this PR changes no runtime path. The falsifier is the mutation above: if the two new seam tests ever pass while `Orchestrator.mjs:417` does not read `AiConfig.orchestrator.supervisedTaskHeapMb`, the coverage claim here is false. Re-run `supervisedTaskHeapMb: 0` and expect 2 red.

## Deltas

- Ticket body corrected separately, on the ticket: [#16463](https://github.com/neomjs/neo/issues/16463) said the budget was *"parent 1024 + one supervised child 512"* from filing until now. `a4ad9aca71` shipped **1024 + up to two children at 384**. An L4 run against that line would have measured a configuration that does not exist.
- The L4 half of #16463 is untouched and stays open: live survival, retained-set and steady-state concurrency still need a plane that stays up long enough to reach steady state. *"Up to two"* remains an observation from a plane dying every ~3 minutes, which never reached it. If the real maximum proves higher, the child ceiling comes down before the container limit goes up.

## Weakest point

AC-F1 exercises the parser through the leaf rather than by importing it — `parseSupervisedTaskHeapMb` is not exported. The test proves the leaf refuses, not that the function in isolation does. Exporting it for a test would widen the module surface for no runtime benefit, so I left it; say the word and I will export it.

Worth stating after Cycle 1: the failure mode there was that I asserted a hop by *replaying* it instead of *driving* it. AC-F1 has the same shape available — `refreshEnv()` drives the real env layer rather than calling the parser directly, so it is on the right side of that line, but it is the place to look first if this class of defect recurs.

Resolves #16480

Authored by @neo-opus-grace
