### PR TITLE
feat(ai): an activation is authorized by proof, and nothing else is a proceed (#16452)

### DIFF
--- a/ai/services/shared/activationReceipt.mjs
+++ b/ai/services/shared/activationReceipt.mjs
@@ -1,14 +1,19 @@
 /**
  * @module ai/services/shared/activationReceipt
  * @summary The closure that decides whether a plane may be mutated: an activation is authorized only
- * by a durable receipt proving a fresh restorable result was observed BEFORE the first mutation, and
- * every other input refuses.
+ * by a receipt proving a fresh restorable result was observed BEFORE the first mutation, and every
+ * other input refuses.
  *
  * **A guard that is merely reachable is bypassable.** `redeployPreflight` already decides correctly,
  * but it decides and returns — it leaves behind no artifact, so nothing downstream can tell "the
  * preflight passed" from "the preflight was never run". Any mutation path that simply does not call
  * it inherits no refusal. This module supplies the missing half: a receipt that must be produced and
  * presented, so the absence of proof is itself a refusal rather than a silence.
+ *
+ * **Scope boundary — this is enforceable, not yet enforced.** Everything here is a pure predicate
+ * over values handed in. It does not write a receipt, store one, read a clock, or compel any caller
+ * to consult it. Emission, durable storage and mandatory consumption live in the deploy path that
+ * calls this; nothing in this module should be read as providing durability or provenance.
  *
  * **Two states, never three.** {@link authorizeActivation} returns `authorize` or `refuse` and
  * nothing else. Malformed receipts, unparsable timestamps, missing bindings and unrecognised verdicts
@@ -63,7 +68,53 @@ export const REFUSAL_REASON = Object.freeze({
 export const RESTORABLE_VERDICT = 'RESTORABLE';
 
 /**
- * @summary Parses an ISO timestamp into epoch milliseconds, or `null` when it is not a timestamp.
+ * A complete ISO-8601 instant: full calendar date, full time, and an EXPLICIT zone designator.
+ * Optional fractional seconds. Nothing shorter and nothing locale-shaped.
+ * @type {RegExp}
+ */
+const INSTANT_PATTERN = /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})(?:\.\d{1,9})?(?:Z|[+-](\d{2}):(\d{2}))$/;
+
+/**
+ * @summary Whether these calendar fields describe a day that exists.
+ *
+ * Checked arithmetically rather than by round-tripping through `Date`, because the thing being
+ * defended against is precisely `Date`'s willingness to normalize — and a validator built from the
+ * normalizer inherits its blind spot.
+ *
+ * @param {Number} year
+ * @param {Number} month 1-12.
+ * @param {Number} day
+ * @returns {Boolean}
+ */
+function isRealCalendarDay(year, month, day) {
+    if (month < 1 || month > 12 || day < 1) {
+        return false
+    }
+
+    const leap      = (year % 4 === 0 && year % 100 !== 0) || year % 400 === 0,
+          monthDays = [31, leap ? 29 : 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
+
+    return day <= monthDays[month - 1]
+}
+
+/**
+ * @summary Parses a PORTABLE ISO-8601 instant into epoch milliseconds, or `null` when the value is
+ * not one.
+ *
+ * **`Date.parse` is not an instant validator and must not be used as one here.** It answers "can this
+ * engine normalize the string", which is a different and much weaker question, and it fails this
+ * module's contract in three ways that all end in `authorize`:
+ *
+ * - **It normalizes impossible dates rather than rejecting them.** `2026-02-30T10:00:00.000Z` — a day
+ *   that does not exist — becomes `2026-03-02T10:00:00.000Z`, which is fresh against a March 2 clock.
+ * - **It accepts locale and partial forms.** `'August 4, 2026 10:00:00 UTC'` parses; so does the bare
+ *   string `'2026'`.
+ * - **It reads a zone-less string as LOCAL time**, so the identical receipt authorizes on a UTC host
+ *   and refuses on a UTC+2 one. Measured. A mutation-authority decision that depends on the
+ *   consumer's `TZ` is not a decision.
+ *
+ * So the grammar is enforced first, the calendar day is verified arithmetically, and `Date.parse` is
+ * used only to convert a value already proven well-formed.
  *
  * `null` rather than `NaN` or `0`, because both of those compare as numbers and would let an
  * unparsable timestamp participate in a freshness or ordering comparison instead of failing it.
@@ -72,13 +123,44 @@ export const RESTORABLE_VERDICT = 'RESTORABLE';
  * @returns {Number|null}
  */
 export function parseInstant(value) {
-    const parsed = typeof value === 'string' ? Date.parse(value) : NaN;
+    if (typeof value !== 'string') {
+        return null
+    }
+
+    const match = INSTANT_PATTERN.exec(value);
+
+    if (!match) {
+        return null
+    }
+
+    const [, year, month, day, hour, minute, second, offsetHour, offsetMinute] = match;
+
+    if (!isRealCalendarDay(Number(year), Number(month), Number(day))) {
+        return null
+    }
+
+    // Leap seconds are rejected rather than normalized: `Date` silently rolls `:60` into the next
+    // minute, which would make two distinct written instants compare equal.
+    if (Number(hour) > 23 || Number(minute) > 59 || Number(second) > 59) {
+        return null
+    }
+
+    if (offsetHour !== undefined && (Number(offsetHour) > 23 || Number(offsetMinute) > 59)) {
+        return null
+    }
+
+    const parsed = Date.parse(value);
 
     return Number.isFinite(parsed) ? parsed : null
 }
 
 /**
- * @summary Assembles the durable receipt from what was actually observed.
+ * @summary Assembles the receipt payload from what was actually observed.
+ *
+ * **In-memory only.** This constructs and shapes a value; it does not write, store, or timestamp
+ * anything. Durability, provenance, and the clock that supplies `observedAt` belong to the emitting
+ * caller, so calling this payload "durable" here would claim a guarantee no code in this module
+ * provides.
  *
  * Takes no decision argument, for the same reason {@link module:ai/services/shared/captureReceipt}
  * does not: callers report observations, and the single derivation stays here so a second consumer

--- a/ai/services/shared/activationReceipt.mjs
+++ b/ai/services/shared/activationReceipt.mjs
@@ -1,0 +1,194 @@
+/**
+ * @module ai/services/shared/activationReceipt
+ * @summary The closure that decides whether a plane may be mutated: an activation is authorized only
+ * by a durable receipt proving a fresh restorable result was observed BEFORE the first mutation, and
+ * every other input refuses.
+ *
+ * **A guard that is merely reachable is bypassable.** `redeployPreflight` already decides correctly,
+ * but it decides and returns — it leaves behind no artifact, so nothing downstream can tell "the
+ * preflight passed" from "the preflight was never run". Any mutation path that simply does not call
+ * it inherits no refusal. This module supplies the missing half: a receipt that must be produced and
+ * presented, so the absence of proof is itself a refusal rather than a silence.
+ *
+ * **Two states, never three.** {@link authorizeActivation} returns `authorize` or `refuse` and
+ * nothing else. Malformed receipts, unparsable timestamps, missing bindings and unrecognised verdicts
+ * all map to `refuse` under distinct reasons. A "warn and proceed" outcome is not a weaker
+ * authorization, it is the defect this exists to remove: the incident behind this work was a
+ * destructive path that ran because nothing positively said no.
+ *
+ * **The receipt binds the CONTAINER CONFIG, not the image digest.** `docker compose` freezes
+ * `healthcheck`, `command` and env into the container at CREATE time, so an activation that rebuilds
+ * images at the target revision and leaves containers in place moves the code and leaves the contract
+ * behind. Measured on our own plane: the image carried a merged healthcheck flag, the checkout carried
+ * it, the revision label read current — and the running container's healthcheck predated the change,
+ * because the container was created before it. A receipt bound to an image digest is SATISFIED by that
+ * half-applied state, which is the third state this module's closure would otherwise admit through the
+ * binding rather than through the decision.
+ *
+ * @see https://github.com/neomjs/neo/issues/16452
+ */
+
+/**
+ * The only two outcomes. There is deliberately no `warn`, no `proceed-with-caution`, and no value
+ * meaning "undecided" — an activation gate that can express uncertainty will eventually express it
+ * into a running plane.
+ * @type {Object}
+ */
+export const ACTIVATION_DECISION = Object.freeze({
+    authorize: 'authorize',
+    refuse   : 'refuse'
+});
+
+/**
+ * Why an activation was refused. Distinct values because "no receipt was presented" and "a receipt was
+ * presented and it was stale" are different operational facts, and an audit that cannot tell them
+ * apart cannot answer whether a guard was bypassed or merely unsatisfied.
+ * @type {Object}
+ */
+export const REFUSAL_REASON = Object.freeze({
+    noReceipt             : 'no-receipt',
+    preflightNotRestorable: 'preflight-not-restorable',
+    receiptMalformed      : 'receipt-malformed',
+    receiptNotPreMutation : 'receipt-not-pre-mutation',
+    receiptStale          : 'receipt-stale',
+    stageBindingMismatch  : 'stage-binding-mismatch',
+    targetBindingMismatch : 'target-binding-mismatch'
+});
+
+/**
+ * The single preflight verdict that can carry an activation. Any other code — and any absence of a
+ * code — refuses.
+ * @type {String}
+ */
+export const RESTORABLE_VERDICT = 'RESTORABLE';
+
+/**
+ * @summary Parses an ISO timestamp into epoch milliseconds, or `null` when it is not a timestamp.
+ *
+ * `null` rather than `NaN` or `0`, because both of those compare as numbers and would let an
+ * unparsable timestamp participate in a freshness or ordering comparison instead of failing it.
+ *
+ * @param {String} value
+ * @returns {Number|null}
+ */
+export function parseInstant(value) {
+    const parsed = typeof value === 'string' ? Date.parse(value) : NaN;
+
+    return Number.isFinite(parsed) ? parsed : null
+}
+
+/**
+ * @summary Assembles the durable receipt from what was actually observed.
+ *
+ * Takes no decision argument, for the same reason {@link module:ai/services/shared/captureReceipt}
+ * does not: callers report observations, and the single derivation stays here so a second consumer
+ * cannot invent a different reading of the same facts.
+ *
+ * @param {Object}       options
+ * @param {String}       options.verdictCode           A `verifyLatestBackupRestorable` code.
+ * @param {String}       options.observedAt            ISO instant the preflight result was observed.
+ * @param {String}       options.stageReceiptId        Identity of the selected cohort candidate.
+ * @param {String}       options.targetConfigDigest    Digest over the RESOLVED CONTAINER CONFIG.
+ * @param {String|null} [options.bundleRoot=null]      Bundle the verdict was decided on.
+ * @param {String|null} [options.composeProject=null]  Compose project the activation targets.
+ * @returns {Object}
+ */
+export function buildActivationReceipt({
+    verdictCode,
+    observedAt,
+    stageReceiptId,
+    targetConfigDigest,
+    bundleRoot     = null,
+    composeProject = null
+} = {}) {
+    return {
+        bundleRoot,
+        composeProject,
+        observedAt,
+        preflightRestorable: verdictCode === RESTORABLE_VERDICT,
+        stageReceiptId,
+        targetConfigDigest,
+        verdictCode        : verdictCode ?? null
+    }
+}
+
+/**
+ * @summary The closure. Authorizes a plane mutation, or refuses with a reason.
+ *
+ * Order is load-bearing. Presence is checked before shape, shape before content, and the
+ * pre-mutation ordering before freshness — so a receipt minted DURING a mutation is reported as
+ * `receipt-not-pre-mutation` rather than as whatever else it also happens to violate. A receipt that
+ * arrives after the first mutation cannot be repaired by being recent.
+ *
+ * @param {Object}       options
+ * @param {Object|null}  options.receipt                  The presented receipt, or `null`/absent.
+ * @param {String}       options.selectedStageReceiptId   Identity the selection sub bound.
+ * @param {String}       options.observedTargetConfigDigest Digest over the target's CURRENT resolved container config.
+ * @param {String}       options.now                      ISO instant of this decision.
+ * @param {Number}       options.maxReceiptAgeMs          How old a receipt may be and still carry an activation.
+ * @param {String|null} [options.firstMutationAt=null]    ISO instant the first mutation occurred, when one has.
+ * @returns {{decision: String, reason: String|null, receiptAgeMs: Number|null}}
+ */
+export function authorizeActivation({
+    receipt,
+    selectedStageReceiptId,
+    observedTargetConfigDigest,
+    now,
+    maxReceiptAgeMs,
+    firstMutationAt = null
+} = {}) {
+    const refuse = reason => ({decision: ACTIVATION_DECISION.refuse, reason, receiptAgeMs: null});
+
+    if (!receipt || typeof receipt !== 'object') {
+        return refuse(REFUSAL_REASON.noReceipt)
+    }
+
+    const observedInstant = parseInstant(receipt.observedAt),
+          nowInstant      = parseInstant(now);
+
+    // An unreadable clock on either side makes every downstream comparison meaningless. It is a
+    // malformed receipt rather than a stale one: we cannot say it is old, only that we cannot say.
+    if (observedInstant === null || nowInstant === null) {
+        return refuse(REFUSAL_REASON.receiptMalformed)
+    }
+
+    if (typeof receipt.stageReceiptId !== 'string' || receipt.stageReceiptId.length === 0 ||
+        typeof receipt.targetConfigDigest !== 'string' || receipt.targetConfigDigest.length === 0) {
+        return refuse(REFUSAL_REASON.receiptMalformed)
+    }
+
+    if (receipt.preflightRestorable !== true || receipt.verdictCode !== RESTORABLE_VERDICT) {
+        return refuse(REFUSAL_REASON.preflightNotRestorable)
+    }
+
+    // Checked BEFORE freshness. A receipt produced after the plane was already touched does not
+    // describe the pre-transition state at all, and no amount of recency changes that.
+    if (firstMutationAt !== null) {
+        const mutationInstant = parseInstant(firstMutationAt);
+
+        if (mutationInstant === null || observedInstant >= mutationInstant) {
+            return refuse(REFUSAL_REASON.receiptNotPreMutation)
+        }
+    }
+
+    const receiptAgeMs = nowInstant - observedInstant;
+
+    // A future-dated receipt is not fresh, it is unexplained. Treated as stale rather than accepted,
+    // because the alternative is that a clock skew or a forged instant buys unlimited validity.
+    if (!Number.isFinite(maxReceiptAgeMs) || receiptAgeMs < 0 || receiptAgeMs > maxReceiptAgeMs) {
+        return refuse(REFUSAL_REASON.receiptStale)
+    }
+
+    if (receipt.stageReceiptId !== selectedStageReceiptId) {
+        return refuse(REFUSAL_REASON.stageBindingMismatch)
+    }
+
+    // The binding that distinguishes a complete activation from a half-applied one. Compared against
+    // the target's RESOLVED CONTAINER CONFIG — never its image, revision label, or checkout, all
+    // three of which read current while the running contract is stale.
+    if (receipt.targetConfigDigest !== observedTargetConfigDigest) {
+        return refuse(REFUSAL_REASON.targetBindingMismatch)
+    }
+
+    return {decision: ACTIVATION_DECISION.authorize, reason: null, receiptAgeMs}
+}

--- a/test/playwright/unit/ai/services/shared/activationReceipt.spec.mjs
+++ b/test/playwright/unit/ai/services/shared/activationReceipt.spec.mjs
@@ -1,0 +1,273 @@
+import {test, expect} from '@playwright/test';
+
+import {
+    ACTIVATION_DECISION,
+    authorizeActivation,
+    buildActivationReceipt,
+    parseInstant,
+    REFUSAL_REASON,
+    RESTORABLE_VERDICT
+} from '../../../../../../ai/services/shared/activationReceipt.mjs';
+
+const
+    CONFIG_DIGEST = 'sha256:resolved-container-config-abc',
+    MAX_AGE_MS    = 5 * 60 * 1000,
+    NOW           = '2026-08-04T10:01:00.000Z',
+    OBSERVED_AT   = '2026-08-04T10:00:00.000Z',
+    STAGE_ID      = 'stage-receipt:9f2c1a';
+
+/** The receipt every negative case mutates exactly one field of. */
+const goodReceipt = () => buildActivationReceipt({
+    observedAt        : OBSERVED_AT,
+    stageReceiptId    : STAGE_ID,
+    targetConfigDigest: CONFIG_DIGEST,
+    verdictCode       : RESTORABLE_VERDICT
+});
+
+/** The authorizing call. Negative cases override one key. */
+const call = overrides => authorizeActivation({
+    maxReceiptAgeMs           : MAX_AGE_MS,
+    now                       : NOW,
+    observedTargetConfigDigest: CONFIG_DIGEST,
+    receipt                   : goodReceipt(),
+    selectedStageReceiptId    : STAGE_ID,
+    ...overrides
+});
+
+/**
+ * @summary The activation kernel is the only mutation path, and its gate has exactly two outcomes.
+ *
+ * A guard that is merely reachable is bypassable, so the property under test is not "the happy path
+ * authorizes" but "nothing else does". The closure test below is the load-bearing one: every other
+ * case in this file is a named instance of it.
+ */
+test.describe('authorizeActivation — two states, never three', () => {
+    test('THE CLOSURE: across the full input cross-product, every outcome is authorize or refuse', () => {
+        // Generated rather than enumerated by hand: a hand-written list proves only that the cases
+        // I thought of are closed, which is the weaker claim and the one that hides the third state.
+        const axes = {
+            receipt: [
+                ['present',   goodReceipt()],
+                ['absent',    null],
+                ['undefined', undefined],
+                ['notObject', 'a string'],
+                ['emptyObj',  {}],
+                ['badClock',  {...goodReceipt(), observedAt: 'not-a-date'}],
+                ['noStageId', {...goodReceipt(), stageReceiptId: ''}],
+                ['noDigest',  {...goodReceipt(), targetConfigDigest: ''}],
+                ['notRestorable', buildActivationReceipt({
+                    observedAt        : OBSERVED_AT,
+                    stageReceiptId    : STAGE_ID,
+                    targetConfigDigest: CONFIG_DIGEST,
+                    verdictCode       : 'REFUSE_NO_VERIFIED_BUNDLE'
+                })]
+            ],
+            // Named for the RECEIPT's position, not the mutation's. `firstMutationAt` is a mutation
+            // instant, so a label like "afterReceipt" reads as a claim about the receipt and inverts
+            // under a careless read — which is exactly what it did while this test was being written.
+            firstMutationAt: [
+                ['noMutationYet',       null],
+                ['receiptPreMutation',  '2026-08-04T10:00:30.000Z'],
+                ['receiptPostMutation', '2026-08-04T09:59:00.000Z'],
+                ['unparsableMutation',  'whenever']
+            ],
+            now: [
+                ['fresh',  NOW],
+                ['stale',  '2026-08-04T10:30:00.000Z'],
+                ['future', '2026-08-04T09:00:00.000Z']
+            ],
+            selectedStageReceiptId    : [['match', STAGE_ID], ['mismatch', 'stage-receipt:other']],
+            observedTargetConfigDigest: [['match', CONFIG_DIGEST], ['mismatch', 'sha256:half-applied']]
+        };
+
+        const authorized = [],
+              decisions  = new Set(),
+              reasons    = new Set();
+        let caseCount = 0;
+
+        for (const [receiptLabel, receipt] of axes.receipt) {
+            for (const [mutationLabel, firstMutationAt] of axes.firstMutationAt) {
+                for (const [nowLabel, now] of axes.now) {
+                    for (const [stageLabel, selectedStageReceiptId] of axes.selectedStageReceiptId) {
+                        for (const [digestLabel, observedTargetConfigDigest] of axes.observedTargetConfigDigest) {
+                            const result = authorizeActivation({
+                                firstMutationAt,
+                                maxReceiptAgeMs: MAX_AGE_MS,
+                                now,
+                                observedTargetConfigDigest,
+                                receipt,
+                                selectedStageReceiptId
+                            });
+
+                            caseCount++;
+                            decisions.add(result.decision);
+                            result.reason !== null && reasons.add(result.reason);
+
+                            if (result.decision === ACTIVATION_DECISION.authorize) {
+                                authorized.push([receiptLabel, mutationLabel, nowLabel, stageLabel, digestLabel].join('/'))
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        expect(caseCount).toBe(9 * 4 * 3 * 2 * 2);
+
+        // No third state: the decision vocabulary is closed over the entire input space.
+        expect([...decisions].sort()).toEqual([ACTIVATION_DECISION.authorize, ACTIVATION_DECISION.refuse]);
+
+        // Every refusal names a reason from the frozen vocabulary — no ad-hoc strings, no nulls.
+        const known = new Set(Object.values(REFUSAL_REASON));
+        expect([...reasons].filter(reason => !known.has(reason))).toEqual([]);
+
+        // And the authorizing set is EXACTLY the fully-satisfied cases: a present valid receipt,
+        // observed before any mutation, fresh, with both bindings matching. Asserting the full list
+        // rather than a count, so a new authorizing combination fails loudly instead of shifting a number.
+        expect(authorized.sort()).toEqual([
+            'present/noMutationYet/fresh/match/match',
+            'present/receiptPreMutation/fresh/match/match'
+        ]);
+    });
+
+    test('no receipt at all refuses — absence of proof is the refusal, not a silence', () => {
+        // The defect this module exists for: a mutation path that simply never ran the preflight
+        // inherited no refusal, because nothing positively said no.
+        for (const receipt of [null, undefined, 'string', 42, []]) {
+            const result = call({receipt});
+
+            expect(result.decision).toBe(ACTIVATION_DECISION.refuse);
+            expect([REFUSAL_REASON.noReceipt, REFUSAL_REASON.receiptMalformed]).toContain(result.reason);
+        }
+    });
+
+    test('a non-RESTORABLE preflight cannot carry an activation', () => {
+        const result = call({
+            receipt: buildActivationReceipt({
+                observedAt        : OBSERVED_AT,
+                stageReceiptId    : STAGE_ID,
+                targetConfigDigest: CONFIG_DIGEST,
+                verdictCode       : 'REFUSE_NO_VERIFIED_BUNDLE'
+            })
+        });
+
+        expect(result.decision).toBe(ACTIVATION_DECISION.refuse);
+        expect(result.reason).toBe(REFUSAL_REASON.preflightNotRestorable);
+    });
+
+    test('a receipt minted AFTER the first mutation refuses, however recent it is', () => {
+        // AC3. The receipt must describe the PRE-transition state; one produced after the plane was
+        // touched describes something else entirely, and recency cannot repair that.
+        const result = call({firstMutationAt: '2026-08-04T09:59:59.999Z'});
+
+        expect(result.decision).toBe(ACTIVATION_DECISION.refuse);
+        expect(result.reason).toBe(REFUSAL_REASON.receiptNotPreMutation);
+    });
+
+    test('a receipt minted at the EXACT mutation instant refuses — the boundary is closed', () => {
+        // Simultaneity proves nothing about ordering, so `>=` rather than `>`.
+        const result = call({firstMutationAt: OBSERVED_AT});
+
+        expect(result.decision).toBe(ACTIVATION_DECISION.refuse);
+        expect(result.reason).toBe(REFUSAL_REASON.receiptNotPreMutation);
+    });
+
+    test('ORDERING: a receipt that is both post-mutation AND stale reports post-mutation', () => {
+        // Deliberate precedence. If staleness were reported first, the operator-visible fix would be
+        // "re-run the preflight" — which would mint a fresh receipt that is STILL post-mutation, and
+        // the second attempt would authorize a plane that had already been touched.
+        const result = call({
+            firstMutationAt: '2026-08-04T09:59:59.999Z',
+            now            : '2026-08-04T11:00:00.000Z'
+        });
+
+        expect(result.reason).toBe(REFUSAL_REASON.receiptNotPreMutation);
+    });
+
+    test('a stale receipt refuses, and so does a future-dated one', () => {
+        expect(call({now: '2026-08-04T10:30:00.000Z'}).reason).toBe(REFUSAL_REASON.receiptStale);
+        // Future-dated is not fresh, it is unexplained. Accepting it would let clock skew or a forged
+        // instant buy unlimited validity.
+        expect(call({now: '2026-08-04T09:00:00.000Z'}).reason).toBe(REFUSAL_REASON.receiptStale);
+    });
+
+    test('a receipt bound to a DIFFERENT selected candidate refuses', () => {
+        // AC4.
+        const result = call({selectedStageReceiptId: 'stage-receipt:some-other-cohort'});
+
+        expect(result.decision).toBe(ACTIVATION_DECISION.refuse);
+        expect(result.reason).toBe(REFUSAL_REASON.stageBindingMismatch);
+    });
+
+    test('THE HALF-APPLIED CASE: a target whose resolved container config differs refuses', () => {
+        // Measured on our own plane: image rebuilt at the target revision, revision label current,
+        // merged code present inside the image — and the RUNNING container still executing the
+        // pre-change healthcheck, because compose freezes it at create time. Every cheap probe reads
+        // "landed". A receipt bound to an image digest is satisfied by exactly that state; this one
+        // is not, because it binds the resolved container config.
+        const result = call({observedTargetConfigDigest: 'sha256:containers-never-recreated'});
+
+        expect(result.decision).toBe(ACTIVATION_DECISION.refuse);
+        expect(result.reason).toBe(REFUSAL_REASON.targetBindingMismatch);
+    });
+
+    test('the fully satisfied case authorizes, and reports the age it was judged on', () => {
+        // Positive control. Without it every assertion above is satisfied by a function that always
+        // refuses — which would be a closed gate and a useless one.
+        const result = call({});
+
+        expect(result.decision).toBe(ACTIVATION_DECISION.authorize);
+        expect(result.reason).toBeNull();
+        expect(result.receiptAgeMs).toBe(60_000);
+    });
+
+    test('parseInstant returns null for anything that is not a timestamp', () => {
+        // null rather than NaN or 0: both of those compare as numbers and would let an unparsable
+        // instant participate in a freshness comparison instead of failing it.
+        expect(parseInstant(OBSERVED_AT)).toBe(Date.parse(OBSERVED_AT));
+        for (const value of ['', 'not-a-date', null, undefined, 42, {}]) {
+            expect(parseInstant(value)).toBeNull()
+        }
+    });
+});
+
+test.describe('buildActivationReceipt — records observations, derives one thing', () => {
+    test('derives preflightRestorable from the verdict rather than accepting it as an argument', () => {
+        expect(buildActivationReceipt({
+            observedAt        : OBSERVED_AT,
+            stageReceiptId    : STAGE_ID,
+            targetConfigDigest: CONFIG_DIGEST,
+            verdictCode       : RESTORABLE_VERDICT
+        }).preflightRestorable).toBe(true);
+
+        for (const verdictCode of ['REFUSE_NO_VERIFIED_BUNDLE', 'PROCEED_INITIALIZING', 'restorable', '', undefined]) {
+            expect(buildActivationReceipt({
+                observedAt        : OBSERVED_AT,
+                stageReceiptId    : STAGE_ID,
+                targetConfigDigest: CONFIG_DIGEST,
+                verdictCode
+            }).preflightRestorable).toBe(false)
+        }
+    });
+
+    test('PROCEED_INITIALIZING is not restorable — a declared first install proves no recoverable state', () => {
+        // The preflight may legitimately proceed on an initialization declaration, and that decision
+        // says the opposite of what an activation receipt must assert: there is nothing to restore.
+        // Treating any PROCEED_* as sufficient would authorize mutation of a plane with no bundle.
+        const receipt = buildActivationReceipt({
+            observedAt        : OBSERVED_AT,
+            stageReceiptId    : STAGE_ID,
+            targetConfigDigest: CONFIG_DIGEST,
+            verdictCode       : 'PROCEED_INITIALIZING'
+        });
+
+        expect(receipt.preflightRestorable).toBe(false);
+        expect(authorizeActivation({
+            maxReceiptAgeMs           : MAX_AGE_MS,
+            now                       : NOW,
+            observedTargetConfigDigest: CONFIG_DIGEST,
+            receipt,
+            selectedStageReceiptId    : STAGE_ID
+        }).reason).toBe(REFUSAL_REASON.preflightNotRestorable);
+    });
+});

--- a/test/playwright/unit/ai/services/shared/activationReceipt.spec.mjs
+++ b/test/playwright/unit/ai/services/shared/activationReceipt.spec.mjs
@@ -53,6 +53,10 @@ test.describe('authorizeActivation — two states, never three', () => {
                 ['notObject', 'a string'],
                 ['emptyObj',  {}],
                 ['badClock',  {...goodReceipt(), observedAt: 'not-a-date'}],
+                // Not merely unparsable — a value `Date.parse` NORMALIZES into a real instant. It
+                // belongs in the closure rather than only in its own witness, because that is the
+                // shape that reached `authorize`.
+                ['normalized', {...goodReceipt(), observedAt: '2026-02-30T10:00:00.000Z'}],
                 ['noStageId', {...goodReceipt(), stageReceiptId: ''}],
                 ['noDigest',  {...goodReceipt(), targetConfigDigest: ''}],
                 ['notRestorable', buildActivationReceipt({
@@ -112,7 +116,7 @@ test.describe('authorizeActivation — two states, never three', () => {
             }
         }
 
-        expect(caseCount).toBe(9 * 4 * 3 * 2 * 2);
+        expect(caseCount).toBe(10 * 4 * 3 * 2 * 2);
 
         // No third state: the decision vocabulary is closed over the entire input space.
         expect([...decisions].sort()).toEqual([ACTIVATION_DECISION.authorize, ACTIVATION_DECISION.refuse]);
@@ -228,6 +232,78 @@ test.describe('authorizeActivation — two states, never three', () => {
         for (const value of ['', 'not-a-date', null, undefined, 42, {}]) {
             expect(parseInstant(value)).toBeNull()
         }
+    });
+
+    test('STRICT INSTANT: every value Date.parse would normalize is refused AT THE AUTHORIZATION LEVEL', () => {
+        // `Date.parse` answers "can this engine normalize the string", not "is this a portable
+        // instant". Each of these reached `authorize` before the grammar was enforced — asserted here
+        // through authorizeActivation rather than through parseInstant, because the escape that
+        // matters is the one that ends in a mutated plane, not the one that ends in a null.
+        const escapes = {
+            'impossible calendar day': '2026-02-30T10:00:00.000Z',  // normalized to Mar 2, then fresh
+            'zone-less (local time)' : '2026-08-04T10:00:00',       // decision depended on host TZ
+            'locale form'            : 'August 4, 2026 10:00:00 UTC',
+            'bare year'              : '2026',
+            'date only'              : '2026-08-04',
+            'leap second'            : '2026-08-04T10:00:60.000Z',  // Date rolls :60 into the next minute
+            'hour 24'                : '2026-08-04T24:00:00.000Z',
+            'month 13'               : '2026-13-04T10:00:00.000Z',
+            'offset hour 99'         : '2026-08-04T10:00:00.000+99:00'
+        };
+
+        for (const [label, observedAt] of Object.entries(escapes)) {
+            const result = call({
+                receipt: buildActivationReceipt({
+                    observedAt,
+                    stageReceiptId    : STAGE_ID,
+                    targetConfigDigest: CONFIG_DIGEST,
+                    verdictCode       : RESTORABLE_VERDICT
+                }),
+                // A clock the normalized value would have looked fresh against, so a pass here cannot
+                // be an accident of the default `now` being far away.
+                now: '2026-03-02T10:01:00.000Z'
+            });
+
+            expect(result.decision, `${label} must not authorize`).toBe(ACTIVATION_DECISION.refuse);
+            expect(result.reason,   `${label} must be malformed, not stale`).toBe(REFUSAL_REASON.receiptMalformed);
+        }
+    });
+
+    test('a zone-less instant is refused, which is what makes the decision host-independent', () => {
+        // Measured before the fix: the identical receipt returned `authorize` under TZ=UTC and
+        // `refuse` under TZ=Europe/Berlin, because Date.parse reads a zone-less string as LOCAL time.
+        // A mutation-authority decision that depends on the consumer's TZ is not a decision. Rejecting
+        // the zone-less form outright is what removes the dependency, so this pins the cause.
+        expect(parseInstant('2026-08-04T10:00:00')).toBeNull();
+        expect(parseInstant('2026-08-04T10:00:00.000')).toBeNull();
+    });
+
+    test('valid portable instants still parse — Z, offsets, and fractional seconds', () => {
+        // Positive control for the grammar. Without it, "reject everything" passes every assertion
+        // above and the module becomes a gate nothing can open.
+        for (const value of [
+            '2026-08-04T10:00:00Z',
+            '2026-08-04T10:00:00.000Z',
+            '2026-08-04T10:00:00.123456Z',
+            '2026-08-04T10:00:00+02:00',
+            '2026-08-04T10:00:00.500-08:00',
+            '2024-02-29T10:00:00.000Z'      // a leap day that DOES exist
+        ]) {
+            expect(parseInstant(value), value).toBe(Date.parse(value))
+        }
+
+        // And the offset forms carry an authorization, so the grammar did not merely stop rejecting.
+        const result = call({
+            receipt: buildActivationReceipt({
+                observedAt        : '2026-08-04T12:00:00+02:00',   // === 10:00:00Z
+                stageReceiptId    : STAGE_ID,
+                targetConfigDigest: CONFIG_DIGEST,
+                verdictCode       : RESTORABLE_VERDICT
+            })
+        });
+
+        expect(result.decision).toBe(ACTIVATION_DECISION.authorize);
+        expect(result.receiptAgeMs).toBe(60_000);
     });
 });
 


### PR DESCRIPTION
Resolves #16486

Refs #16452

**On the close target.** This was first opened against #16452 with `Refs` only, because it does not deliver that ticket: #16452 requires the activation kernel to be the sole mutation path **enforced**, and nothing routes through this contract yet. `§9.1` allows `Refs`-only for drafts and otherwise directs you to *"add the honest delivered leaf close target or split/file the narrow ticket"* — so I filed #16486 for the half this actually delivers. #16452 stays open and owns the wiring — pointing the closing keyword at it would auto-close a ticket whose invariant is not live.

Evidence: N/A to the L1–L4 runtime ladder — every #16486 AC is fully unit-decidable over a pure predicate, and the ladder measures reach against live surfaces, which this diff has none of. (Corrected from `L3` at @neo-gpt's review: L3 means invoking a real live surface, not testing a pure function in process. Claiming a rung this diff cannot occupy overstated it in the direction that flatters.) Unit receipt stated normally under Test Evidence. Residual: none for #16486; the unwired-contract residual belongs to #16452 and is listed under Post-Merge Validation.

`redeployPreflight` decides correctly and then returns. It leaves no artifact — so nothing downstream can distinguish *"the preflight passed"* from *"the preflight was never run"*, and a mutation path that simply does not call it inherits no refusal. That gap is what makes a reachable guard a bypassable one, and it is the half this adds: a receipt that must be **produced and presented**, so absence of proof is itself a refusal rather than a silence.

## Deltas from ticket

**One AC needed a dimension it did not have, and it came from a measurement rather than a reading.** Posted as an intake finding on the ticket before writing code, and applied here.

AC1 requires *"a durable activation receipt linking a fresh RESTORABLE result before first mutation, **or** no mutation. No third state."* **A third state already exists.** `docker compose` freezes `healthcheck`, `command` and env into the **container at create time**, so an activation that rebuilds images at the target revision and leaves containers in place moves the code and leaves the contract behind — half-applied, and reporting success.

Measured on `neo-local-canonical` after PR #16465 merged:

```
image label org.opencontainers.image.revision  = d2ddb89180   ← dev HEAD at the time
image contains parseExpectedStatuses           = 3            ← merged code IS in the image
checkout overlay contains --expected-status    = 2            ← merged contract IS in the checkout
RUNNING container healthcheck                  = [… --expected-plane-id …]  ← NO --expected-status
containers created                             = 21:45:21Z    ← predates the change
```

Every cheap probe reads *landed*. Only `docker inspect <container>` shows the contract is stale. **A receipt bound to an image digest is satisfied by exactly this state** — so a digest binding admits the third state through the binding rather than through the decision. The receipt therefore binds the **resolved container config**.

Re-verified against the live plane before building on it, and it had moved: the container was recreated `2026-08-04T00:50:54Z` and now carries `--expected-status healthy,degraded` at dev HEAD. Correct now, and correct *because containers were recreated rather than rebuilt*. Both states have been observed on the same plane, which is what makes this an enforceable invariant rather than a hypothesis. Reachability only — a live before/after is not a control and I am not claiming causation.

**Ordering is load-bearing, and not the obvious one.** The pre-mutation check runs *before* freshness. A receipt minted during a mutation reports `receipt-not-pre-mutation` rather than `receipt-stale` — because if staleness were reported first, the operator-visible fix is "re-run the preflight", which mints a *fresh* receipt that is **still post-mutation**, and the second attempt authorizes an already-touched plane.

**`PROCEED_INITIALIZING` is explicitly not restorable.** The preflight may legitimately proceed on a declared first install, and that decision asserts the opposite of what an activation receipt must: there is nothing to restore. Treating any `PROCEED_*` as sufficient would authorize mutating a plane with no bundle. Witnessed.

## Test Evidence

```
npm run test-unit -- test/playwright/unit/ai/services/shared/activationReceipt.spec.mjs
→ 15 passed (3.1s)
```

**The closure is generated, not enumerated** — 432 cases across six axes (receipt validity × mutation ordering × freshness × stage binding × target binding). A hand-written list proves only that the cases I thought of are closed, which is precisely where a third state hides. The test asserts three things: every decision is in the frozen two-value vocabulary; every refusal reason is in the frozen reason vocabulary; and the authorizing set is **exactly** two named cases, listed in full so a new authorizing combination fails loudly instead of shifting a count.

**Mutation-verified.** Replacing the target-binding refusal with a `warn-and-proceed` return fails **2 of 15** — the closure test and the half-applied witness, and only those:

| mutation | fails |
|---|---|
| `warn-and-proceed` third state introduced | closure test + half-applied witness, nothing else |

**A naming trap the test caught in itself.** The cross-product axis labelled mutation instants `afterReceipt`/`beforeReceipt`; those describe the *mutation's* position, and I read them as the *receipt's* and wrote an inverted expectation. The implementation was right and the assertion was wrong. Renamed to `receiptPreMutation`/`receiptPostMutation` — fixing the ambiguity rather than the expected value, since a reviewer would invert it the same way.

Surfaces touched: `ai/services/shared/activationReceipt.mjs` → `test/playwright/unit/ai/services/shared/activationReceipt.spec.mjs` (15 passed). No existing module imports it yet — see the residual below. No production behaviour changes in this diff.

## Post-Merge Validation

- [ ] **The residual, and the reason #16452 stays open:** nothing consumes `authorizeActivation` yet. The contract is proven closed; it is not yet the *sole* path, because no mutation path is routed through it. Two follow-on pieces are needed and are mine: `redeployPreflight` emitting a durable receipt on its verified path, and the reference deploy transaction presenting one and refusing without it. Reviewing the contract shape **before** wiring is deliberate — the vocabulary and decision semantics are what a reviewer should challenge while they are still free to change.
- [ ] `targetConfigDigest` is consumed as an opaque string here. The helper that derives it from `docker inspect` of the **container** — never the image, label, or checkout — lands with the wiring.
- [ ] `stageReceiptId` is likewise opaque, so this does not depend on #16450's selection artifact existing. AC4 is a comparison; reaching into that module's internals would be a layering violation.
- [ ] AC5's documented bound (#16442's lineage truth does not reach the preflight; #16404 holds partial-unavailable restorable) is **not** covered by this diff.

## Review round 1 — an impossible date authorized a plane mutation

@neo-gpt found that `parseInstant` used `Date.parse` as an instant validator. It is not one: it answers *"can this engine normalize the string"*, which is a weaker question, and it failed this contract in three ways that all end in `authorize`.

Reproduced at his exact head, and **the worst case is one neither of us reported first**:

```
                                          BEFORE            AFTER
2026-02-30T10:00:00.000Z (no such day) →  authorize      →  refuse / receipt-malformed
August 4, 2026 10:00:00 UTC            →  authorize      →  refuse / receipt-malformed
2026            (a bare year!)          →  authorize      →  refuse / receipt-malformed
2026-08-04T10:00:00 (zone-less), TZ=UTC →  AUTHORIZE      →  refuse / receipt-malformed
2026-08-04T10:00:00 (zone-less), TZ=CET →  refuse/stale   →  refuse / receipt-malformed
2026-08-04T12:00:00+02:00 (valid)       →  authorize      →  authorize  (positive control)
```

**The zone-less row is the one that would have shipped.** `Date.parse` reads a string without a zone as *local* time, so the identical receipt authorized under `TZ=UTC` and refused under `TZ=Europe/Berlin`. Deployment planes run UTC; local dev usually does not — so the escape is live exactly where it matters and invisible exactly where it would be caught. A mutation-authority decision that depends on the consumer's `TZ` is not a decision.

The grammar is now enforced before anything else, and **the calendar day is checked arithmetically rather than by round-tripping through `Date`** — the behaviour being defended against is precisely `Date`'s willingness to normalize, so a validator built from the normalizer inherits its blind spot. Leap seconds are rejected rather than rolled forward, since `Date` would otherwise make two distinct written instants compare equal.

Witnessed **at the authorization level**, not at `parseInstant`: nine normalizing forms each asserted to return `receipt-malformed`, against a clock the normalized value would have looked fresh against, so a pass cannot be an accident of the default `now` being far away. The normalizing case also joined the generated closure (now 480 cases) because that is the shape which actually reached `authorize`. A positive control keeps valid `Z`, offset and fractional forms authorizing — this is not "reject everything".

**Two framing corrections from the same review, both fair.** The module no longer calls its in-memory payload "durable" (it constructs a value; it writes nothing), and now states plainly that the contract is *enforceable, not enforced*. The `Evidence:` line is corrected above — I had claimed L3 for a pure predicate, and L3 means touching a live surface.

## Merge gate I am NOT clearing myself

@neo-gpt's second Required Action is a planning gate, and he is right that a post-review leaf split cannot be its own exemption.

@neo-opus-vega's Epic Review on #16448 (05:51Z) returned **Revisions Requested** and states that it halts sub pickup — *"including my own of #16455 — I am not clearing my own path."* #16486 was created at 08:03Z, after it.

- **3b is discharged.** It was the one finding that landed on my own ticket: #16452's Out of Scope now records that #16454's `git ls-remote` SHA resolution is the pre-cohort path, not a competing binding token, and migrates onto the bound `stageReceiptId` once #16450 lands.
- **3a, 3c and the Decision Record line are Epic-body items** and belong to @neo-opus-grace as author. Raised, not adopted — taking them would be me editing an Epic to unblock my own leaf.
- **This PR should not merge until that disposition exists**, whether that is Grace resolving the findings or an explicit authority call that a pure-predicate leaf with no plane behaviour sits outside the gate. That call is @neo-opus-grace's or @tobiu's, and I am not taking it.

Authored by Ada (Claude Opus 5, Claude Code). Session eeacb603-97f1-4241-9b2f-3a542cab6d2c.
