### PR TITLE
fix: Workstation resident cards size from their pane, not the viewport (#16423)

### DIFF
--- a/resources/scss/src/apps/workstation/Viewport.scss
+++ b/resources/scss/src/apps/workstation/Viewport.scss
@@ -215,15 +215,23 @@
 
 // The resident pane — the class the reported vessel actually hosts. Its root and its card
 // children are the skin whose absence read as "raw stacked text" on the operator's frame.
+//
+// The pane is also the card's size-query container. The card sizes its type and padding from
+// container units, and the card cannot query itself — its own padding needs an ancestor
+// container, so the reference lives here. `size` (not `inline-size`) because the defect axis
+// is height: the dock hands short panes MORE width than tall ones, so width-keyed units would
+// invert the correction. Size containment is safe — the dock (or a tear-out vessel) imposes
+// the pane's box; it never auto-sizes from content.
 .workstation-placeholder {
     background:
         radial-gradient(circle at 82% 16%, color-mix(in srgb, var(--workstation-signal) 16%, transparent), transparent 38%),
         linear-gradient(145deg, var(--workstation-panel), color-mix(in srgb, var(--workstation-signal) 5%, var(--workstation-panel-2)));
     border        : 1px solid var(--workstation-line-soft);
     border-radius : 8px;
-    overflow: hidden;
-    padding : 0;
-    position: relative;
+    container: workstation-pane / size;
+    overflow : hidden;
+    padding  : 0;
+    position : relative;
 
     &::after {
         background: linear-gradient(90deg, transparent, color-mix(in srgb, var(--workstation-signal) 55%, transparent), transparent);
@@ -236,13 +244,19 @@
     }
 }
 
+// Card sizing is keyed to the PANE (cqh against `.workstation-placeholder`), never the viewport:
+// two panes of different height in one window must resolve different type sizes. Each fluid
+// track is calibrated so a 436px pane reproduces the pre-container rendered values (the design
+// reference the tall cards already had) while a 188px pane walks toward the clamp minimum.
+// Without a container ancestor the units fall back to small-viewport units, which is the old
+// behavior — degradation, not breakage.
 .workstation-resident-card {
     box-sizing    : border-box;
     display       : flex;
     flex-direction: column;
     height        : 100%;
     min-height    : 0;
-    padding : clamp(12px, 2vw, 24px);
+    padding : clamp(12px, 2px + 5cqh, 24px);
     position: relative;
 }
 
@@ -267,7 +281,7 @@
 
 .workstation-resident-icon {
     color    : color-mix(in srgb, var(--workstation-signal) 72%, var(--workstation-ink));
-    font-size: clamp(18px, 2vw, 30px);
+    font-size: clamp(18px, 12px + 2.6cqh, 30px);
     margin : auto 0 8px;
     opacity: .82;
 }
@@ -275,7 +289,7 @@
 .workstation-resident-metric {
     color         : var(--workstation-ink);
     font-family   : var(--workstation-font-mono);
-    font-size     : clamp(24px, 4vw, 58px);
+    font-size     : clamp(24px, 12px + 8cqh, 58px);
     font-weight   : 800;
     letter-spacing: -.06em;
     line-height   : .95;
@@ -285,7 +299,7 @@
 .workstation-resident-title {
     color         : var(--workstation-ink);
     font-family   : var(--workstation-font-sans);
-    font-size     : clamp(11px, 1.2vw, 16px);
+    font-size     : clamp(11px, 9px + 1.2cqh, 16px);
     font-weight   : 650;
     letter-spacing: .02em;
     margin-top    : 8px;
@@ -314,6 +328,10 @@
 .workstation-resident-wave {
     align-items: end;
     display: flex;
+    // A declared 15px element must never silently resolve to 0 — with negative slack, flex
+    // shrinks the only shrinkable child to nothing. The floor makes a too-short card overflow
+    // loudly instead; the disclosure thresholds below keep that state unreachable.
+    flex-shrink: 0;
     gap    : 3px;
     height : 15px;
     margin-top : 9px;
@@ -330,6 +348,19 @@
         &:nth-child(4) {height: 62%}
         &:nth-child(6) {height: 28%}
     }
+}
+
+// Progressive disclosure: a genuinely short pane DROPS trim, by rule, instead of letting flex
+// shrink it toward invisibility. Thresholds come from the card's fit arithmetic at clamp
+// minimums — wave visible needs ~167px (padding 24 + fixed rows 78.5 + minimum fluid type
+// ~64.5), footer-without-wave needs ~141px — each threshold sits a guard band above its
+// break-even so the flex-shrink floor above can never be asked to absorb negative slack.
+@container workstation-pane (max-height: 170px) {
+    .workstation-resident-wave {display: none}
+}
+
+@container workstation-pane (max-height: 145px) {
+    .workstation-resident-footer {display: none}
 }
 
 // ScalePane's grid CELL classes — they ride the pane's own grid, so they travel with it.

--- a/test/playwright/e2e/workstation/WorkstationFiveBeatNL.spec.mjs
+++ b/test/playwright/e2e/workstation/WorkstationFiveBeatNL.spec.mjs
@@ -1678,9 +1678,10 @@ test.describe('Workstation — the five-beat multi-window journey', () => {
         expect(paneSkin.paneRadius, 'the pane must carry its own corner radius').toBeGreaterThan(0);
 
         // Responsive values are asserted as a RANGE, never byte-equal against the main window. The
-        // padding is `clamp(12px, 2vw, 24px)`, so a vessel and its parent legitimately differ by
-        // viewport width — pinning the number would make the suite fail on a resized window while
-        // still passing on a pane with no rules at all, which is the wrong test in both directions.
+        // padding is `clamp(12px, 2px + 5cqh, 24px)` against the pane container, so a vessel and its
+        // parent legitimately differ by pane height — pinning the number would make the suite fail on
+        // a resized window while still passing on a pane with no rules at all, which is the wrong
+        // test in both directions.
         expect(paneSkin.cardPadding, 'padding must resolve inside the declared clamp, not to the unstyled 0')
             .toBeGreaterThanOrEqual(12);
         expect(paneSkin.cardPadding).toBeLessThanOrEqual(24);

--- a/test/playwright/e2e/workstation/WorkstationResidentCardSizingNL.spec.mjs
+++ b/test/playwright/e2e/workstation/WorkstationResidentCardSizingNL.spec.mjs
@@ -1,0 +1,143 @@
+import {test, expect} from '../../fixtures.mjs';
+
+/**
+ * @summary Whitebox E2E witness for resident-card container sizing (pane-keyed, not viewport-keyed).
+ *
+ * The resident cards size their type from container units against their pane, so two panes of
+ * materially different height in the same window must resolve materially different type — and a
+ * declared trim element (the sparkline wave) must never silently resolve to a used height of 0:
+ * it either renders, or an explicit container-query rule hides it. The assertions bind the
+ * relationships, never pixel values or the disclosure thresholds themselves, so a design retune
+ * that preserves the contract stays green.
+ *
+ * Run: NEO_E2E_PORT=8152 npx playwright test workstation/WorkstationResidentCardSizingNL -c test/playwright/playwright.config.e2e.mjs --workers=1
+ */
+
+/**
+ * Boots the workstation app and waits for the resident cards to be laid out.
+ * @param {Object} page Playwright page
+ * @returns {Promise<void>}
+ */
+async function bootWorkstation(page) {
+    await page.goto('/apps/workstation/index.html');
+    await page.waitForSelector('.workstation-dock-host', {timeout: 60000});
+    await page.waitForSelector('.workstation-resident-card', {timeout: 60000});
+    await page.waitForFunction(() => {
+        const panes = [...document.querySelectorAll('.workstation-placeholder')];
+
+        return panes.length > 1 && panes.every(pane => pane.getBoundingClientRect().height > 0)
+    }, {timeout: 60000});
+    await page.waitForTimeout(1200)
+}
+
+/**
+ * Collects the per-card sizing facts the assertions consume.
+ * @param {Object} page Playwright page
+ * @returns {Promise<Object[]>}
+ */
+function collectCards(page) {
+    return page.evaluate(() => [...document.querySelectorAll('.workstation-resident-card')].map(card => {
+        const pane     = card.closest('.workstation-placeholder'),
+              cardCs   = getComputedStyle(card),
+              cardRect = card.getBoundingClientRect(),
+              metric   = card.querySelector('.workstation-resident-metric'),
+              wave     = card.querySelector('.workstation-resident-wave'),
+              visible  = [...card.children].filter(child => getComputedStyle(child).display !== 'none'),
+              lastVis  = visible.at(-1)?.getBoundingClientRect();
+
+        return {
+            title      : card.querySelector('.workstation-resident-title')?.textContent?.trim(),
+            paneHeight : pane.getBoundingClientRect().height,
+            metricFs   : parseFloat(getComputedStyle(metric).fontSize),
+            waveDisplay: getComputedStyle(wave).display,
+            waveHeight : wave.getBoundingClientRect().height,
+            // Positive values mean the last visible child escapes the card's content box —
+            // the flex layout was asked to absorb negative slack.
+            slackOverrun: lastVis ? lastVis.bottom - (cardRect.bottom - parseFloat(cardCs.paddingBottom)) : 0
+        }
+    }))
+}
+
+/**
+ * Asserts the three sizing relationships on a collected card set.
+ * @param {Object[]} cards
+ */
+function assertSizingContract(cards) {
+    expect(cards.length, 'resident cards must be present').toBeGreaterThan(1);
+
+    const byHeight = [...cards].sort((a, b) => a.paneHeight - b.paneHeight),
+          shortest = byHeight.at(0),
+          tallest  = byHeight.at(-1);
+
+    // Precondition, not an assertion target: the dock layout hands this app materially
+    // different pane heights. If it ever stops doing so, the relationship below is vacuous
+    // and the spec must fail loudly rather than pass silently.
+    expect(
+        tallest.paneHeight / shortest.paneHeight,
+        `pane heights must differ materially (tallest ${tallest.paneHeight}, shortest ${shortest.paneHeight})`
+    ).toBeGreaterThan(1.5);
+
+    expect(
+        tallest.metricFs,
+        `metric type must track the pane: tallest pane ${tallest.paneHeight}px (${tallest.title}) vs shortest ${shortest.paneHeight}px (${shortest.title})`
+    ).toBeGreaterThan(shortest.metricFs);
+
+    cards.forEach(card => {
+        if (card.waveDisplay !== 'none') {
+            expect(
+                card.waveHeight,
+                `${card.title}: a rendered wave must never resolve to 0 height (pane ${card.paneHeight}px)`
+            ).toBeGreaterThan(0)
+        }
+
+        expect(
+            card.slackOverrun,
+            `${card.title}: visible content must fit the card's content box (pane ${card.paneHeight}px)`
+        ).toBeLessThanOrEqual(0.5)
+    })
+}
+
+test.describe('Workstation resident cards — pane-keyed sizing at a roomy viewport', () => {
+    test.setTimeout(90000);
+    test.use({
+        contextOptions: {screen: {height: 1080, width: 1920}},
+        viewport      : {height: 840, width: 1180}
+    });
+
+    test('unequal panes resolve unequal type; declared trim never renders at 0', async ({page}) => {
+        await bootWorkstation(page);
+
+        const cards = await collectCards(page);
+
+        assertSizingContract(cards);
+
+        // At this viewport every resident pane clears the disclosure thresholds: the wave is
+        // part of the composition and must be present on every card, tall and short alike.
+        cards.forEach(card => {
+            expect(card.waveDisplay, `${card.title}: wave must render at ${card.paneHeight}px pane height`).not.toBe('none')
+        })
+    })
+});
+
+test.describe('Workstation resident cards — progressive disclosure at a short viewport', () => {
+    test.setTimeout(90000);
+    test.use({
+        contextOptions: {screen: {height: 1080, width: 1920}},
+        viewport      : {height: 700, width: 900}
+    });
+
+    test('short panes drop trim by rule instead of shrinking it to nothing', async ({page}) => {
+        await bootWorkstation(page);
+
+        const cards = await collectCards(page);
+
+        assertSizingContract(cards);
+
+        // The short band of this layout sits below the wave threshold: at least one card must
+        // have taken the explicit-hide branch, proving disclosure is a rule, not an accident.
+        expect(
+            cards.some(card => card.waveDisplay === 'none'),
+            'at least one short pane must hide its wave via the container query'
+        ).toBe(true)
+    })
+});


### PR DESCRIPTION
Resolves #16423

The resident cards now size their type, padding, and trim from their **pane** instead of the viewport: `.workstation-placeholder` becomes a named size-query container (`workstation-pane / size`), every fluid `clamp()` track moves from `vw` to `cqh`, the sparkline wave gets a `flex-shrink: 0` floor, and two `@container` max-height rules drop the wave (≤170px) and footer (≤145px) explicitly instead of letting flex shrink them to nothing. The formulas are calibrated so a 436px pane reproduces the pre-change rendered values byte-close (metric `47.2px → 46.9px`) — the tall cards the operator liked are visually invariant — while a 188px pane resolves `27px` metric type, `12px` padding, and a **visible 15px wave** where it previously rendered `0px`. The same container travels with a torn-out vessel, so pane-keyed sizing holds in both boot modes for free.

Evidence: L3 (browser-rendered receipts at `1180x840` + `900x700`, both themes, plus the red/green stash cycle and the adjacent e2e battery below) → L3 required (every AC is a rendered-CSS relationship). Residual: none.

## Deltas from ticket

- **`cqh`, not `cqi`/`cqmin`:** the ticket prescribed moving the fluid tracks to `cqi` / `cqh`; live measurement showed the dock hands the *short* panes **more** width than the tall ones (`287px` wide at `188px` tall vs `233px` wide at `436px` tall), so any width-keyed unit corrects in the wrong direction. Every track keys on `cqh` with a px base (`clamp(24px, 12px + 8cqh, 58px)` etc.), calibrated against the measured pane boxes.
- **Disclosure thresholds derived, not chosen:** `170px` / `145px` come from the card's fit arithmetic at clamp minimums (wave-visible break-even ≈167px, footer-without-wave ≈141px), each with a guard band so the `flex-shrink: 0` floor is never asked to absorb negative slack. The SCSS comment carries the arithmetic.
- **Spec asserts relationships, never mechanism:** an earlier draft asserted `container-type: size` on the pane; that pins the implementation rather than the contract, so it was removed. The red-proof below convicts on the symptom assertions alone.
- **`WorkstationFiveBeatNL` comment truth-fix:** its vessel skin check documents the padding formula it range-asserts; the prose named the retired `2vw` form. Comment-only.

## Test Evidence

New witness `test/playwright/e2e/workstation/WorkstationResidentCardSizingNL.spec.mjs` (two boot-state describes, no mid-test resize): unequal panes ⟹ unequal metric type (guarded by a ≥1.5× pane-height-ratio precondition so the relationship can never pass vacuously), `zero-height wave ⟹ explicitly hidden`, and per-card non-negative slack (last visible child inside the content box).

- Head: `2 passed` (`NEO_E2E_PORT=8152 npx playwright test workstation/WorkstationResidentCardSizingNL -c test/playwright/playwright.config.e2e.mjs --workers=1`).
- Red-proof (fix stashed, themes rebuilt): `2 failed`, both convicting on `metric type must track the pane` with equal `47.2px` type across a `438px`/`190px` spread — the exact defect, at the symptom level.
- Live measurements at head: `1180x840` tall/short metric `46.88px`/`27.04px`, wave `15px` on all four cards (baseline: `47.2px` everywhere, wave `0px` on both short cards); `900x700` tall `38.7px` with wave visible, short (`137px` pane) drops wave+footer by rule at the `24px` type floor; both themes structurally identical (sizing lives in the theme-independent src layer).
- Adjacent battery: `WorkstationNL` (full dense tour, 26.5s) + `WorkstationDockPreviewSymmetryNL` + `WorkstationDragTextSelectionNL` → 5/6; `WorkstationFiveBeatNL` headed → 9 passed / 1 take-gated skip, byte-identical to the dev-head baseline receipt, including the vessel skin range-assert over the new formula.
- The one battery red (`DragTextSelectionNL` off-document-release recovery) is a load-window flake, not this diff: red only under battery load or immediately after (test times 6.7s/7.4s, timeout-shaped), green 5/5 at cooled head (1.7–1.9s) and 3/3 at cooled baseline — the same signature as the `SplitterGridGeometryNL` environment-window exoneration banked on #16467's thread. Cost note for the record: container units re-resolve card type during pane resizes (bounded to the four placeholder panes); no measured drag regression in the green runs above.

Surface coverage — `apps/workstation`: `WorkstationResidentCardSizingNL` (new), `WorkstationNL`, `WorkstationFiveBeatNL`, `WorkstationDockPreviewSymmetryNL`, `WorkstationDragTextSelectionNL`, all listed above.

## Post-Merge Validation

- [ ] Resident cards render un-pressed on the operator's own frame sizes during the next film-take rehearsal (the originating eyewitness report).
- [ ] A torn-out resident vessel at a small window size resolves pane-keyed type (container travels with `.workstation-placeholder`; verified via the FiveBeat vessel check locally, worth one human glance on a real tear-out).

Authored by Mnemosyne (Fable 5, Claude Code). Session 1913de09-6dc0-4d1e-a9a3-b51c33b46cdc.
