### PR TITLE
feat(deploy): a predicate can answer whether a cohort is admissible to a target (#16453)

### DIFF
--- a/ai/scripts/setup/cohortAdmissibility.mjs
+++ b/ai/scripts/setup/cohortAdmissibility.mjs
@@ -250,17 +250,55 @@ export function providesValue(providedEnv, envVarName) {
 }
 
 /**
+ * @summary Which keys the target sets that the parity census forbids — each with its recorded reason.
+ *
+ * `config-leaf-parity.json`'s `forbiddenEnv` is a key→reason map covering three distinct classes that
+ * share one instruction, *stop setting this*: **retired** controls whose owner moved (`NEO_AUTO_DREAM`
+ * — *"the orchestrator owns Dream"*), **derived** values the runtime computes for itself (the
+ * `NEO_AUTH_*` family — *"derived from auth.mode"*), and **posture-fixed** keys a canonical deployment
+ * does not get to choose (`NEO_AI_DEPLOYMENT_MODE`).
+ *
+ * This is the half {@link diffCohortLeafSets} structurally cannot supply. A diff derives THAT a key
+ * stopped being declared; only this map records WHY, and the why is the entire actionable content —
+ * "no longer declared" tells an operator nothing about what replaced it.
+ *
+ * ADVISORY, and that is an evidential claim rather than a cautious one: `lint-config-template-ssot.mjs`
+ * enforces this map against OUR Compose profiles in OUR CI, and nothing measured shows a foreign plane
+ * refusing to boot on one. Gating on it would assert a failure mode we have not observed.
+ *
+ * @param {Object} options
+ * @param {Object} options.providedEnv The target's resolved environment.
+ * @param {Object|null} options.forbiddenEnv `$composeDefaultParity.forbiddenEnv`, key → reason.
+ * @returns {Object[]} Rows `{env, reason}`, only for keys the target actually supplies.
+ */
+export function collectForbiddenKeysInUse({providedEnv = {}, forbiddenEnv = null} = {}) {
+    if (!forbiddenEnv) {
+        return []
+    }
+
+    return Object.entries(forbiddenEnv)
+        .filter(([env]) => providesValue(providedEnv, env))
+        .map(([env, reason]) => ({env, reason: reason ?? null}))
+}
+
+/**
  * @summary Answers "may target T take cohort C?".
  *
  * @param {Object} options
  * @param {Object} options.cohortData The cohort's `config.data` tree.
+ * @param {Object} [options.currentCohortData=null] The cohort the target is ON, for retirement diffing.
+ *   Omitted means retirement is not guessed — absence of a comparison point is not evidence.
+ * @param {Object} [options.forbiddenEnv=null] `$composeDefaultParity.forbiddenEnv`, key → reason.
  * @param {Object} options.target `{entrypoint, mode, consumerClaims, providedEnv}`.
- * @returns {{admissible: Boolean, blocking: Object[], indeterminate: Object[], evaluated: Number}}
+ * @returns {{admissible: Boolean, blocking: Object[], indeterminate: Object[], retired: Object[], forbidden: Object[], evaluated: Number}}
  *   `blocking` names each leaf whose requirement applies and whose input the target does not supply,
  *   with the requirement's own `reason`. `indeterminate` names each leaf whose applicability could
  *   not be decided, with the axes that were unstated. Admissible only when BOTH are empty.
+ *
+ *   `retired` and `forbidden` are ADVISORY and never affect `admissible` — neither can fail a
+ *   readiness check, so gating on them would refuse a migration for an input that is merely inert.
  */
-export function evaluateCohortAdmissibility({cohortData, currentCohortData = null, target = {}} = {}) {
+export function evaluateCohortAdmissibility({cohortData, currentCohortData = null, forbiddenEnv = null, target = {}} = {}) {
     const census        = collectRequirednessCensus(cohortData),
           providedEnv   = target.providedEnv ?? {},
           blocking      = [],
@@ -269,10 +307,19 @@ export function evaluateCohortAdmissibility({cohortData, currentCohortData = nul
     // Retired keys are ADVISORY and deliberately do not affect the verdict: an input the new cohort
     // no longer declares cannot fail a readiness check, so refusing the move over one would block a
     // migration for a setting that is merely inert. Reported, never gating.
+    //
+    // The parity map is consulted for a reason when it has one. A derived retirement can only say "no
+    // longer declared", which names the symptom; `forbiddenEnv` names what took the key's place.
     const retired = currentCohortData
         ? diffCohortLeafSets({fromData: currentCohortData, toData: cohortData}).retired
             .filter(row => row.env && providesValue(providedEnv, row.env))
+            .map(row => ({...row, reason: forbiddenEnv?.[row.env] ?? null}))
         : [];
+
+    // Independent of any diff, and deliberately so: this needs no `currentCohortData`, so a target
+    // that cannot say which cohort it is on still gets an actionable list. That is the common case
+    // for a plane far enough behind that nobody recorded what it was built from.
+    const forbidden = collectForbiddenKeysInUse({providedEnv, forbiddenEnv});
 
     for (const entry of census) {
         for (const requirement of entry.requirements) {
@@ -303,12 +350,17 @@ export function evaluateCohortAdmissibility({cohortData, currentCohortData = nul
         }
     }
 
+    const retiredEnvNames = new Set(retired.map(row => row.env));
+
     return {
         admissible: blocking.length === 0 && indeterminate.length === 0,
         blocking,
         indeterminate,
         retired,
-        evaluated : census.length
+        // A key can be both diff-retired and parity-forbidden. Reporting it twice would read as two
+        // separate problems and cost the operator a reconciliation they gain nothing from.
+        forbidden: forbidden.filter(row => !retiredEnvNames.has(row.env)),
+        evaluated: census.length
     }
 }
 
@@ -327,13 +379,21 @@ export function formatAdmissibilityVerdict(verdict) {
     // the migration still carrying them.
     const retiredLines = (verdict.retired ?? []).flatMap(row => [
         `  RETIRED   ${row.leafPath}${row.env ? ` (${row.env})` : ''}`,
-        '            You set this and the target cohort no longer declares it — inert, not blocking. Remove it, or a future reader preserves it as intentional.'
+        row.reason
+            ? `            ${row.reason}`
+            : '            You set this and the target cohort no longer declares it — inert, not blocking. Remove it, or a future reader preserves it as intentional.'
+    ]);
+
+    const forbiddenLines = (verdict.forbidden ?? []).flatMap(row => [
+        `  FORBIDDEN ${row.env}`,
+        `            ${row.reason ?? 'The parity census forbids this key; it is retired, derived, or fixed by posture.'}`
     ]);
 
     if (verdict.admissible) {
         return [
             `ADMISSIBLE — ${verdict.evaluated} requirement-bearing leaf/leaves evaluated, none blocking.`,
-            ...retiredLines
+            ...retiredLines,
+            ...forbiddenLines
         ]
     }
 
@@ -351,7 +411,7 @@ export function formatAdmissibilityVerdict(verdict) {
         lines.push('            Unknown is not admissible: the requirement may or may not apply, and guessing favours the case we know least about.')
     }
 
-    lines.push(...retiredLines);
+    lines.push(...retiredLines, ...forbiddenLines);
 
     return lines
 }

--- a/ai/scripts/setup/cohortAdmissibility.mjs
+++ b/ai/scripts/setup/cohortAdmissibility.mjs
@@ -1,0 +1,261 @@
+#!/usr/bin/env node
+/**
+ * @module ai/scripts/setup/cohortAdmissibility
+ * @summary Answers "may target T take cohort C?" — and when the answer is no, names the leaves that
+ * block it and why.
+ *
+ * ## The gap this closes
+ *
+ * Four daemons fail CLOSED when a required configuration input is absent — `embed/daemon.mjs`,
+ * `message/daemon.mjs`, `wake/daemon.mjs` and `orchestrator/daemon.mjs` each name `--migrate-config`
+ * and exit. So moving a lagging deployment onto a newer cohort can produce a plane whose daemons
+ * refuse to boot, and nothing in the tree could say so BEFORE the move: `compatibilityContract`,
+ * `supportMatrix`, `minimumSupportedRevision` and `externallyAdmissible` return zero hits across
+ * `ai/`, `src/` and `buildScripts/`.
+ *
+ * The raw material already exists and is machine-readable — every leaf that can block a boot
+ * declares `requiredFor` on its own descriptor. What was missing is a predicate over it. This module
+ * is that predicate and nothing more: it reads, it never migrates, and it never relaxes a guard.
+ *
+ * ## Derived, never hand-listed
+ *
+ * The census is walked from the cohort's own `config.data` leaf descriptors. A hand-maintained list
+ * of "inputs the new version needs" is exactly what staled in the written upgrade guide, and it
+ * stales the same way here — one leaf added without a matching list edit and the predicate starts
+ * certifying a plane into a fail-closed boot.
+ *
+ * ## Unknown is inadmissible, and that INVERTS the runtime matcher
+ *
+ * `ConfigProvider`'s `matchesContext(list, actual)` is `!list || list.includes(actual)`. With an
+ * `actual` of `undefined` and a constraining list that yields FALSE — the requirement does not match,
+ * so the runtime treats the leaf as not-required and boots. That is correct for a live process, which
+ * knows its own entrypoint and mode by construction.
+ *
+ * It is exactly wrong here. A target whose mode we cannot state is a target whose requirements we
+ * cannot evaluate, and answering "admissible" for it would certify precisely the case we know least
+ * about. So this module does NOT reuse that matcher: an unspecified axis that some requirement
+ * constrains is reported as INDETERMINATE and the verdict is not admissible. Absence of evidence is
+ * never admissibility.
+ */
+
+/**
+ * @summary Whether a value is a `leaf()` descriptor rather than a namespace node.
+ *
+ * Mirrors `migrateConfigOverlay.isLeafDescriptor` deliberately rather than importing it: that module
+ * is a CLI with side effects at import time, and this one is consulted by selection. The shape it
+ * tests is the `leaf()` contract itself, which changing would break both.
+ *
+ * @param {*} value
+ * @returns {Boolean}
+ */
+export function isLeafDescriptor(value) {
+    return Boolean(value) && typeof value === 'object' && !Array.isArray(value) &&
+        Object.hasOwn(value, 'default') && (Object.hasOwn(value, 'env') || Object.hasOwn(value, 'type'))
+}
+
+/**
+ * @summary Walks a cohort's config data and returns every leaf that can block a boot.
+ *
+ * Only leaves carrying `requiredFor` are returned — a leaf with a usable default cannot fail a
+ * readiness check, so including it would pad the verdict with rows no operator can act on.
+ *
+ * @param {Object} data A cohort's `config.data` tree (leaf descriptors at the leaves).
+ * @param {String} [prefix=''] Internal recursion path.
+ * @returns {Object[]} `[{leafPath, env, type, requirements}]`, requirements always an array.
+ */
+export function collectRequirednessCensus(data, prefix = '') {
+    const census = [];
+
+    if (!data || typeof data !== 'object') {
+        return census
+    }
+
+    for (const [key, value] of Object.entries(data)) {
+        const leafPath = prefix ? `${prefix}.${key}` : key;
+
+        if (isLeafDescriptor(value)) {
+            // `requiredFor` may sit on the descriptor or inside its metadata bag, depending on how
+            // the leaf was declared. Reading only one of the two would silently under-report.
+            const declared = value.requiredFor ?? value.metadata?.requiredFor;
+
+            if (declared) {
+                census.push({
+                    leafPath,
+                    env         : value.env ?? null,
+                    type        : value.type ?? null,
+                    requirements: Array.isArray(declared) ? declared : [declared]
+                })
+            }
+
+            continue
+        }
+
+        if (value && typeof value === 'object' && !Array.isArray(value)) {
+            census.push(...collectRequirednessCensus(value, leafPath))
+        }
+    }
+
+    return census
+}
+
+/**
+ * @summary Classifies ONE requirement against a target context.
+ *
+ * Three outcomes rather than two, and the third is the point: a requirement that constrains an axis
+ * the target has not stated is neither "applies" nor "does not apply" — it is unevaluable, and
+ * collapsing it into either is how a predicate starts lying.
+ *
+ * @param {Object} requirement A `requiredFor` entry.
+ * @param {Object} context `{entrypoint, mode, consumerClaims}` — any may be undefined.
+ * @returns {{verdict: 'applies'|'excluded'|'indeterminate', unknownAxes: String[]}}
+ */
+export function classifyRequirement(requirement, context = {}) {
+    const axes = [
+        {name: 'entrypoints',    constraint: requirement.entrypoints,    actual: context.entrypoint},
+        {name: 'modes',          constraint: requirement.modes,          actual: context.mode},
+        {name: 'consumerClaims', constraint: requirement.consumerClaims, actual: context.consumerClaims}
+    ];
+
+    const unknownAxes = [];
+
+    let excluded = false;
+
+    for (const axis of axes) {
+        // `'*'`, null and undefined are the wildcard, exactly as `ConfigProvider.normalizeList`
+        // defines it — a wildcard axis constrains nothing, so an unstated actual is harmless there.
+        const list = axis.constraint === undefined || axis.constraint === null || axis.constraint === '*'
+            ? null
+            : (Array.isArray(axis.constraint) ? axis.constraint : [axis.constraint]);
+
+        if (!list) {
+            continue
+        }
+
+        if (axis.actual === undefined || axis.actual === null) {
+            unknownAxes.push(axis.name);
+            continue
+        }
+
+        // `consumerClaims` is a SET on the target: a claim list matches when any claim the target
+        // makes is named. Treating it as a scalar would silently exclude multi-claim targets.
+        const actuals = Array.isArray(axis.actual) ? axis.actual : [axis.actual];
+
+        if (!actuals.some(actual => list.includes(actual))) {
+            excluded = true
+        }
+    }
+
+    if (excluded) {
+        return {verdict: 'excluded', unknownAxes: []}
+    }
+
+    return unknownAxes.length > 0
+        ? {verdict: 'indeterminate', unknownAxes}
+        : {verdict: 'applies', unknownAxes: []}
+}
+
+/**
+ * @summary Whether a target supplies a usable value for a leaf's env var.
+ *
+ * Mirrors `ConfigProvider.isEmptyRequiredValue`: an empty string is ABSENT, not present. A deployment
+ * that exports `NEO_AUTH_LOCAL_BEARER_TOKEN=` has not supplied a token, and reading it as supplied is
+ * the exact shape that lets a plane certify itself into a fail-closed boot.
+ *
+ * @param {Object} providedEnv
+ * @param {String|null} envVarName
+ * @returns {Boolean}
+ */
+export function providesValue(providedEnv, envVarName) {
+    if (!envVarName) {
+        return false
+    }
+
+    const value = providedEnv?.[envVarName];
+
+    return !(value === undefined || value === null || (typeof value === 'string' && value.trim() === ''))
+}
+
+/**
+ * @summary Answers "may target T take cohort C?".
+ *
+ * @param {Object} options
+ * @param {Object} options.cohortData The cohort's `config.data` tree.
+ * @param {Object} options.target `{entrypoint, mode, consumerClaims, providedEnv}`.
+ * @returns {{admissible: Boolean, blocking: Object[], indeterminate: Object[], evaluated: Number}}
+ *   `blocking` names each leaf whose requirement applies and whose input the target does not supply,
+ *   with the requirement's own `reason`. `indeterminate` names each leaf whose applicability could
+ *   not be decided, with the axes that were unstated. Admissible only when BOTH are empty.
+ */
+export function evaluateCohortAdmissibility({cohortData, target = {}} = {}) {
+    const census        = collectRequirednessCensus(cohortData),
+          providedEnv   = target.providedEnv ?? {},
+          blocking      = [],
+          indeterminate = [];
+
+    for (const entry of census) {
+        for (const requirement of entry.requirements) {
+            const {verdict, unknownAxes} = classifyRequirement(requirement, target);
+
+            if (verdict === 'excluded') {
+                continue
+            }
+
+            if (verdict === 'indeterminate') {
+                indeterminate.push({
+                    leafPath: entry.leafPath,
+                    env     : entry.env,
+                    unknownAxes,
+                    reason  : requirement.reason ?? null
+                });
+                continue
+            }
+
+            if (!providesValue(providedEnv, entry.env)) {
+                blocking.push({
+                    leafPath: entry.leafPath,
+                    env     : entry.env,
+                    reason  : requirement.reason ?? null,
+                    requirement
+                })
+            }
+        }
+    }
+
+    return {
+        admissible: blocking.length === 0 && indeterminate.length === 0,
+        blocking,
+        indeterminate,
+        evaluated : census.length
+    }
+}
+
+/**
+ * @summary Renders a verdict as operator-readable lines.
+ *
+ * A bare boolean is unactionable — an operator told "inadmissible" with no leaf named cannot move
+ * their deployment, and the written guide this replaces failed exactly by not being specific.
+ *
+ * @param {Object} verdict Output of {@link evaluateCohortAdmissibility}.
+ * @returns {String[]}
+ */
+export function formatAdmissibilityVerdict(verdict) {
+    if (verdict.admissible) {
+        return [`ADMISSIBLE — ${verdict.evaluated} requirement-bearing leaf/leaves evaluated, none blocking.`]
+    }
+
+    const lines = [`NOT ADMISSIBLE — ${verdict.blocking.length} blocking, ${verdict.indeterminate.length} indeterminate.`];
+
+    for (const row of verdict.blocking) {
+        lines.push(`  BLOCKING  ${row.leafPath}${row.env ? ` (${row.env})` : ''}`);
+        if (row.reason) {
+            lines.push(`            ${row.reason}`)
+        }
+    }
+
+    for (const row of verdict.indeterminate) {
+        lines.push(`  UNKNOWN   ${row.leafPath}${row.env ? ` (${row.env})` : ''} — target did not state: ${row.unknownAxes.join(', ')}`);
+        lines.push('            Unknown is not admissible: the requirement may or may not apply, and guessing favours the case we know least about.')
+    }
+
+    return lines
+}

--- a/ai/scripts/setup/cohortAdmissibility.mjs
+++ b/ai/scripts/setup/cohortAdmissibility.mjs
@@ -99,6 +99,80 @@ export function collectRequirednessCensus(data, prefix = '') {
 }
 
 /**
+ * @summary Every leaf path a cohort declares, requirement-bearing or not.
+ *
+ * The requiredness census answers "what could block a boot". This answers "what exists", which is the
+ * other half of a migration: a lagging deployment needs to know which of the inputs it currently sets
+ * have stopped meaning anything.
+ *
+ * @param {Object} data A cohort's `config.data` tree.
+ * @param {String} [prefix='']
+ * @returns {Map<String,{env: String|null}>} Keyed by leaf path.
+ */
+export function collectLeafPaths(data, prefix = '') {
+    const paths = new Map();
+
+    if (!data || typeof data !== 'object') {
+        return paths
+    }
+
+    for (const [key, value] of Object.entries(data)) {
+        const leafPath = prefix ? `${prefix}.${key}` : key;
+
+        if (isLeafDescriptor(value)) {
+            paths.set(leafPath, {env: value.env ?? null});
+            continue
+        }
+
+        if (value && typeof value === 'object' && !Array.isArray(value)) {
+            for (const [nested, meta] of collectLeafPaths(value, leafPath)) {
+                paths.set(nested, meta)
+            }
+        }
+    }
+
+    return paths
+}
+
+/**
+ * @summary Which leaves a move INTRODUCES and which it RETIRES.
+ *
+ * Retired keys are not a cosmetic tidy-up. An operator carrying an env var the new cohort no longer
+ * declares has a setting that silently does nothing — and the failure mode is worse than useless,
+ * because the value LOOKS load-bearing in their compose file and will be preserved through future
+ * migrations by anyone reading it as intentional.
+ *
+ * Direction is explicit rather than inferred from argument order alone: `from` is the cohort the
+ * target is ON, `to` is the cohort it would move TO.
+ *
+ * @param {Object} options
+ * @param {Object} options.fromData The cohort the target currently runs.
+ * @param {Object} options.toData The cohort under consideration.
+ * @returns {{introduced: Object[], retired: Object[]}} Each row `{leafPath, env}`.
+ */
+export function diffCohortLeafSets({fromData, toData} = {}) {
+    const from = collectLeafPaths(fromData),
+          to   = collectLeafPaths(toData);
+
+    const introduced = [],
+          retired    = [];
+
+    for (const [leafPath, meta] of to) {
+        if (!from.has(leafPath)) {
+            introduced.push({leafPath, env: meta.env})
+        }
+    }
+
+    for (const [leafPath, meta] of from) {
+        if (!to.has(leafPath)) {
+            retired.push({leafPath, env: meta.env})
+        }
+    }
+
+    return {introduced, retired}
+}
+
+/**
  * @summary Classifies ONE requirement against a target context.
  *
  * Three outcomes rather than two, and the third is the point: a requirement that constrains an axis
@@ -186,11 +260,19 @@ export function providesValue(providedEnv, envVarName) {
  *   with the requirement's own `reason`. `indeterminate` names each leaf whose applicability could
  *   not be decided, with the axes that were unstated. Admissible only when BOTH are empty.
  */
-export function evaluateCohortAdmissibility({cohortData, target = {}} = {}) {
+export function evaluateCohortAdmissibility({cohortData, currentCohortData = null, target = {}} = {}) {
     const census        = collectRequirednessCensus(cohortData),
           providedEnv   = target.providedEnv ?? {},
           blocking      = [],
           indeterminate = [];
+
+    // Retired keys are ADVISORY and deliberately do not affect the verdict: an input the new cohort
+    // no longer declares cannot fail a readiness check, so refusing the move over one would block a
+    // migration for a setting that is merely inert. Reported, never gating.
+    const retired = currentCohortData
+        ? diffCohortLeafSets({fromData: currentCohortData, toData: cohortData}).retired
+            .filter(row => row.env && providesValue(providedEnv, row.env))
+        : [];
 
     for (const entry of census) {
         for (const requirement of entry.requirements) {
@@ -225,6 +307,7 @@ export function evaluateCohortAdmissibility({cohortData, target = {}} = {}) {
         admissible: blocking.length === 0 && indeterminate.length === 0,
         blocking,
         indeterminate,
+        retired,
         evaluated : census.length
     }
 }
@@ -239,8 +322,19 @@ export function evaluateCohortAdmissibility({cohortData, target = {}} = {}) {
  * @returns {String[]}
  */
 export function formatAdmissibilityVerdict(verdict) {
+    // Retired keys are reported on BOTH verdicts. An admissible move still leaves the operator holding
+    // inputs that no longer mean anything, and a verdict that says only "ADMISSIBLE" sends them into
+    // the migration still carrying them.
+    const retiredLines = (verdict.retired ?? []).flatMap(row => [
+        `  RETIRED   ${row.leafPath}${row.env ? ` (${row.env})` : ''}`,
+        '            You set this and the target cohort no longer declares it — inert, not blocking. Remove it, or a future reader preserves it as intentional.'
+    ]);
+
     if (verdict.admissible) {
-        return [`ADMISSIBLE — ${verdict.evaluated} requirement-bearing leaf/leaves evaluated, none blocking.`]
+        return [
+            `ADMISSIBLE — ${verdict.evaluated} requirement-bearing leaf/leaves evaluated, none blocking.`,
+            ...retiredLines
+        ]
     }
 
     const lines = [`NOT ADMISSIBLE — ${verdict.blocking.length} blocking, ${verdict.indeterminate.length} indeterminate.`];
@@ -256,6 +350,8 @@ export function formatAdmissibilityVerdict(verdict) {
         lines.push(`  UNKNOWN   ${row.leafPath}${row.env ? ` (${row.env})` : ''} — target did not state: ${row.unknownAxes.join(', ')}`);
         lines.push('            Unknown is not admissible: the requirement may or may not apply, and guessing favours the case we know least about.')
     }
+
+    lines.push(...retiredLines);
 
     return lines
 }

--- a/ai/scripts/setup/cohortAdmissibility.mjs
+++ b/ai/scripts/setup/cohortAdmissibility.mjs
@@ -37,6 +37,12 @@
  * constrains is reported as INDETERMINATE and the verdict is not admissible. Absence of evidence is
  * never admissibility.
  *
+ * That rule holds at TWO levels, and the second is easy to miss because the first one reads as though
+ * it covered everything. Missing evidence about the TARGET is handled by the matcher above; missing
+ * evidence about the COHORT ITSELF is handled by {@link assessCohortSource}, which runs BEFORE any
+ * finding is drawn. Without it, an unreadable cohort produces an empty census, an empty census reads
+ * as "nothing blocked", and the weakest possible evidence yields the strongest possible verdict.
+ *
  * ## `providedEnv` MUST be the RENDERED environment, not the declared one
  *
  * This is a caller contract and getting it wrong produces the one failure direction this module
@@ -303,6 +309,63 @@ export function collectForbiddenKeysInUse({providedEnv = {}, forbiddenEnv = null
 }
 
 /**
+ * @summary Whether the cohort evidence was actually OBSERVED, before any finding is drawn from it.
+ *
+ * **"No blockers found" and "no cohort was observed" are different states, and only the first is a
+ * permission.** Folding them together is the failure this guard exists to prevent: an empty finding
+ * set read as a clean bill, so a loader that returned nothing, an import that failed, or a path that
+ * pointed at the wrong tree all render as ADMISSIBLE — the strongest possible verdict produced by the
+ * weakest possible evidence.
+ *
+ * That inversion is worse here than anywhere else in this module. Every other branch refuses when it
+ * cannot decide; this one would grant permission precisely when it knows least, on a predicate whose
+ * whole purpose is to keep a plane out of a fail-closed boot.
+ *
+ * ## The discriminator is leaf descriptors, NOT requirements
+ *
+ * A cohort that carries descriptors but none with `requiredFor` is a legitimate, fully-observed cohort
+ * with nothing that can block a boot — it must stay admissible. A cohort with no descriptors at all is
+ * not a permissive cohort, it is a failed reading. Counting requirements conflates the two; counting
+ * descriptors separates them, because a real `config.data` tree carries hundreds of leaves whether or
+ * not any of them constrain anything.
+ *
+ * @param {*} cohortData The value handed in as the cohort's `config.data` tree.
+ * @returns {{observed: Boolean, leafCount: Number, reason: String|null}}
+ */
+export function assessCohortSource(cohortData) {
+    if (cohortData === undefined || cohortData === null) {
+        return {
+            observed : false,
+            leafCount: 0,
+            reason   : 'No cohort data was supplied. This is a failed observation, not an empty ' +
+                'cohort — resolve the candidate\'s config tree and re-run rather than reading this as a pass.'
+        }
+    }
+
+    if (typeof cohortData !== 'object' || Array.isArray(cohortData)) {
+        return {
+            observed : false,
+            leafCount: 0,
+            reason   : `Cohort data is ${Array.isArray(cohortData) ? 'an array' : `a ${typeof cohortData}`}, ` +
+                'not a config tree. Something upstream returned the wrong shape; a verdict drawn from it would be meaningless.'
+        }
+    }
+
+    const leafCount = collectLeafPaths(cohortData).size;
+
+    if (leafCount === 0) {
+        return {
+            observed : false,
+            leafCount: 0,
+            reason   : 'The cohort tree carries no leaf descriptors at all. A real config tree carries ' +
+                'hundreds regardless of what they require, so zero means the tree was not read — not that it demands nothing.'
+        }
+    }
+
+    return {observed: true, leafCount, reason: null}
+}
+
+/**
  * @summary Answers "may target T take cohort C?".
  *
  * @param {Object} options
@@ -320,6 +383,23 @@ export function collectForbiddenKeysInUse({providedEnv = {}, forbiddenEnv = null
  *   readiness check, so gating on them would refuse a migration for an input that is merely inert.
  */
 export function evaluateCohortAdmissibility({cohortData, currentCohortData = null, forbiddenEnv = null, target = {}} = {}) {
+    // FIRST, and before any finding is drawn: was the cohort observed at all? An unreadable source
+    // must never reach the census loop, because an empty census is indistinguishable from a clean one
+    // once it gets there — and "nothing blocked" would then be reported as permission.
+    const source = assessCohortSource(cohortData);
+
+    if (!source.observed) {
+        return {
+            admissible   : false,
+            sourceError  : source,
+            blocking     : [],
+            indeterminate: [],
+            retired      : [],
+            forbidden    : [],
+            evaluated    : 0
+        }
+    }
+
     const census        = collectRequirednessCensus(cohortData),
           providedEnv   = target.providedEnv ?? {},
           blocking      = [],
@@ -374,7 +454,10 @@ export function evaluateCohortAdmissibility({cohortData, currentCohortData = nul
     const retiredEnvNames = new Set(retired.map(row => row.env));
 
     return {
-        admissible: blocking.length === 0 && indeterminate.length === 0,
+        admissible : blocking.length === 0 && indeterminate.length === 0,
+        // Explicitly null rather than absent: a consumer checking `verdict.sourceError` must be able to
+        // distinguish "observed, no source problem" from a verdict shape that predates this guard.
+        sourceError: null,
         blocking,
         indeterminate,
         retired,
@@ -395,6 +478,18 @@ export function evaluateCohortAdmissibility({cohortData, currentCohortData = nul
  * @returns {String[]}
  */
 export function formatAdmissibilityVerdict(verdict) {
+    // Rendered as its own verdict, never as "0 blocking". An operator shown "NOT ADMISSIBLE — 0
+    // blocking, 0 indeterminate" would reasonably read it as a bug in the tool and re-run; the
+    // actionable fact is that the cohort was never read, and the fix is upstream of this predicate.
+    if (verdict.sourceError) {
+        return [
+            'NOT ADMISSIBLE — the cohort could not be observed.',
+            `  UNREADABLE  ${verdict.sourceError.reason}`,
+            '              No requirement was evaluated, so this is not a finding about the target. ' +
+                '"Nothing blocked" and "nothing was read" are different states and only the first is a pass.'
+        ]
+    }
+
     // Retired keys are reported on BOTH verdicts. An admissible move still leaves the operator holding
     // inputs that no longer mean anything, and a verdict that says only "ADMISSIBLE" sends them into
     // the migration still carrying them.

--- a/ai/scripts/setup/cohortAdmissibility.mjs
+++ b/ai/scripts/setup/cohortAdmissibility.mjs
@@ -36,6 +36,27 @@
  * about. So this module does NOT reuse that matcher: an unspecified axis that some requirement
  * constrains is reported as INDETERMINATE and the verdict is not admissible. Absence of evidence is
  * never admissibility.
+ *
+ * ## `providedEnv` MUST be the RENDERED environment, not the declared one
+ *
+ * This is a caller contract and getting it wrong produces the one failure direction this module
+ * cannot tolerate: a FALSE INADMISSIBLE that refuses a migration which would have succeeded.
+ *
+ * The reference Compose profile does not template every required value. `NEO_AI_ORCHESTRATOR_AUTHORITY_PROFILE`
+ * is written as a literal — `ai/deploy/docker-compose.yml:270` and `docker-compose.dev.yml:318` both
+ * pin `container-plane` directly rather than interpolating `${...}`. A caller that reads the
+ * deployment's `.env` file and passes that as `providedEnv` therefore sees the key as absent, and this
+ * predicate correctly reports the input it was given as missing — while the daemon it is asked about
+ * would have booted fine.
+ *
+ * So resolve the target's environment the way the daemon will actually see it (`docker compose config`
+ * against the target's own ordered profile set, or the container's inspected env), never the
+ * hand-authored overlay alone.
+ *
+ * The same hardcoding defeats an env-based override in the other direction: exporting this key into a
+ * parent process does not change the rendered service either. A `docker compose config` render shows
+ * it staying `container-plane` while an interpolated control such as `NEO_DEPLOY_HOSTNAME` picks up
+ * its override normally — so the render, not the export, is the boundary that settles both questions.
  */
 
 /**

--- a/test/playwright/unit/ai/daemons/orchestrator/HostEdgePosture.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/HostEdgePosture.spec.mjs
@@ -59,7 +59,8 @@ const DECLARED_LAUNCHERS = Object.freeze([
 /**
  * @summary Files that name the daemon entry WITHOUT launching it — the generic image entrypoint
  * (its role comes from the Compose service that sets `SERVICE_ENTRYPOINT`), sibling daemons that
- * reference the path for singleton self-detection, and the lint that reads it as data.
+ * reference the path for singleton self-detection, the lint that reads it as data, and modules whose
+ * documentation cites the daemon as the consumer whose behaviour they exist to explain.
  * @type {ReadonlyArray<String>}
  */
 const NON_LAUNCHER_REFERENCES = Object.freeze([
@@ -69,7 +70,10 @@ const NON_LAUNCHER_REFERENCES = Object.freeze([
     'ai/daemons/wake/daemon.mjs',
     'ai/deploy/Dockerfile',
     'ai/deploy/hostEdgeProfile.mjs',
-    'ai/scripts/lint/lint-config-template-ssot.mjs'
+    'ai/scripts/lint/lint-config-template-ssot.mjs',
+    // Cites the four fail-closed daemons in prose to explain WHY a cohort can be inadmissible.
+    // Reads only; it spawns nothing and resolves no entrypoint.
+    'ai/scripts/setup/cohortAdmissibility.mjs'
 ]);
 
 /**

--- a/test/playwright/unit/ai/scripts/setup/cohortAdmissibility.spec.mjs
+++ b/test/playwright/unit/ai/scripts/setup/cohortAdmissibility.spec.mjs
@@ -351,6 +351,48 @@ test.describe('cohortAdmissibility — may target T take cohort C? (#16453)', ()
         expect(formatAdmissibilityVerdict(verdict).join('\n')).toContain('FORBIDDEN NEO_AUTO_DREAM');
     });
 
+    /**
+     * THE CALLER CONTRACT, and the only failure direction this module cannot tolerate: a FALSE
+     * INADMISSIBLE refuses a migration that would have succeeded — on exactly the lagging plane the
+     * predicate exists to unblock.
+     *
+     * The reference profile writes `NEO_AI_ORCHESTRATOR_AUTHORITY_PROFILE` as a LITERAL rather than
+     * interpolating it, so a caller passing the deployment's hand-authored `.env` sees it absent while
+     * the daemon would have booted. The census is only as true as the environment it is handed.
+     *
+     * Premise anchored against the shipped Compose file below: if someone later templates that value,
+     * this test fails and the caller-contract note in the module header needs revisiting. That is the
+     * correct thing to be told, not a brittle assertion.
+     */
+    test('providedEnv must be the RENDERED env — the declared-only case is a false inadmissible', () => {
+        const composeSrc = readFileSync(new URL('../../../../../../ai/deploy/docker-compose.yml', import.meta.url), 'utf8');
+
+        // The premise: pinned literally, NOT as `${NEO_AI_ORCHESTRATOR_AUTHORITY_PROFILE...}`.
+        expect(composeSrc).toContain('NEO_AI_ORCHESTRATOR_AUTHORITY_PROFILE=container-plane');
+        expect(composeSrc).not.toContain('NEO_AI_ORCHESTRATOR_AUTHORITY_PROFILE=${');
+
+        const target = {entrypoint: 'orchestrator-daemon', mode: 'none', consumerClaims: ['readiness']};
+
+        // Declared-only: the operator's .env carries nothing for a key their profile hardcodes.
+        const fromDeclared = evaluateCohortAdmissibility({
+            cohortData: ConfigBase.config.data,
+            target    : {...target, providedEnv: {}}
+        });
+
+        // Rendered: `docker compose config` resolves the literal the service pins.
+        const fromRendered = evaluateCohortAdmissibility({
+            cohortData: ConfigBase.config.data,
+            target    : {...target, providedEnv: {NEO_AI_ORCHESTRATOR_AUTHORITY_PROFILE: 'container-plane'}}
+        });
+
+        expect(fromDeclared.admissible).toBe(false);
+        expect(fromRendered.admissible).toBe(true);
+
+        // Same cohort, same target, opposite verdicts — the difference is ONLY which environment the
+        // caller resolved, which is why the module header makes it a contract rather than a hint.
+        expect(fromDeclared.blocking[0].env).toBe('NEO_AI_ORCHESTRATOR_AUTHORITY_PROFILE');
+    });
+
     test('isLeafDescriptor separates leaves from namespace nodes', () => {
         expect(isLeafDescriptor({default: '', env: 'X'})).toBe(true);
         expect(isLeafDescriptor({default: 1, type: 'number'})).toBe(true);

--- a/test/playwright/unit/ai/scripts/setup/cohortAdmissibility.spec.mjs
+++ b/test/playwright/unit/ai/scripts/setup/cohortAdmissibility.spec.mjs
@@ -4,6 +4,7 @@ import Neo            from '../../../../../../src/Neo.mjs';
 import '../../../../../../src/core/_export.mjs';
 import ConfigBase      from '../../../../../../ai/configBase.mjs';
 import {
+    assessCohortSource,
     classifyRequirement,
     collectForbiddenKeysInUse,
     collectLeafPaths,
@@ -391,6 +392,111 @@ test.describe('cohortAdmissibility — may target T take cohort C? (#16453)', ()
         // Same cohort, same target, opposite verdicts — the difference is ONLY which environment the
         // caller resolved, which is why the module header makes it a contract rather than a hint.
         expect(fromDeclared.blocking[0].env).toBe('NEO_AI_ORCHESTRATOR_AUTHORITY_PROFILE');
+    });
+
+    /**
+     * THE EVIDENCE-SOURCE GUARD. Every other branch of this module refuses when it cannot decide; this
+     * one would have GRANTED permission when it knew least — the strongest verdict from the weakest
+     * evidence, on a predicate whose whole purpose is keeping a plane out of a fail-closed boot.
+     *
+     * A loader returning nothing, a failed import, or a path aimed at the wrong tree all arrive here as
+     * an empty census, and an empty census read as "nothing blocked" is a pass. Caught in review by
+     * @neo-gpt-emmy against the shipped head, not by this suite — the suite had no source-absence case
+     * at all, so it could not have failed on it.
+     *
+     * The positive control is carried INSIDE this test on purpose: without it, every assertion below
+     * would still pass if the predicate simply refused everything.
+     */
+    test('an unobserved cohort FAILS CLOSED — "nothing blocked" and "nothing was read" are different states', () => {
+        // Positive control first: the predicate must still be capable of a real, specific refusal,
+        // otherwise "refuses on bad input" proves nothing.
+        const control = evaluateCohortAdmissibility({
+            cohortData: ConfigBase.config.data,
+            target    : {entrypoint: 'orchestrator-daemon', mode: 'none', consumerClaims: ['readiness'], providedEnv: {}}
+        });
+
+        expect(control.admissible).toBe(false);
+        expect(control.blocking).toHaveLength(1);
+        expect(control.evaluated).toBeGreaterThan(0);
+        expect(control.sourceError).toBeNull();
+
+        // …and a fully-supplied target on the same real tree is admissible, so the module is not
+        // simply refusing everything handed to it.
+        expect(evaluateCohortAdmissibility({
+            cohortData: ConfigBase.config.data,
+            target    : {
+                entrypoint    : 'orchestrator-daemon',
+                mode          : 'none',
+                consumerClaims: ['readiness'],
+                providedEnv   : {NEO_AI_ORCHESTRATOR_AUTHORITY_PROFILE: 'container-plane'}
+            }
+        }).admissible).toBe(true);
+
+        // Now the failed observations. Each is a DIFFERENT way the evidence never arrived.
+        const unobserved = {
+            'omitted'        : undefined,
+            'null'           : null,
+            'a scalar'       : 'oops',
+            'a number'       : 7,
+            'an array'       : [],
+            'an empty object': {},
+            'namespaces only': {a: {b: {}}, c: {}}
+        };
+
+        for (const [label, cohortData] of Object.entries(unobserved)) {
+            const verdict = evaluateCohortAdmissibility({
+                cohortData,
+                target: {entrypoint: 'orchestrator-daemon', mode: 'none', providedEnv: {}}
+            });
+
+            expect(verdict.admissible, `${label} must never certify admissible`).toBe(false);
+            expect(verdict.sourceError, `${label} must name a source problem`).toBeTruthy();
+            expect(verdict.evaluated).toBe(0);
+
+            // Rendered as its own verdict, not as "0 blocking" — which an operator would read as a
+            // tool bug and re-run, instead of fixing the upstream read.
+            const rendered = formatAdmissibilityVerdict(verdict).join('\n');
+
+            expect(rendered).toContain('could not be observed');
+            expect(rendered).not.toContain('0 blocking');
+        }
+    });
+
+    /**
+     * The distinction the guard turns on, and the reason it counts DESCRIPTORS rather than
+     * REQUIREMENTS: a cohort can be completely observed and legitimately demand nothing. Counting
+     * requirements would collapse that into the failure case and refuse every migration to a cohort
+     * that happens to constrain nothing — a false inadmissible manufactured by the fix itself.
+     */
+    test('a cohort with descriptors but ZERO requiredFor is legitimately admissible, not a failed read', () => {
+        const observedButUndemanding = {group: {a: leafOf({env: 'NEO_A'}), b: leafOf({env: 'NEO_B'})}};
+
+        const source = assessCohortSource(observedButUndemanding);
+
+        expect(source.observed).toBe(true);
+        expect(source.leafCount).toBe(2);
+
+        const verdict = evaluateCohortAdmissibility({
+            cohortData: observedButUndemanding,
+            target    : {entrypoint: 'anything', mode: 'none', providedEnv: {}}
+        });
+
+        expect(verdict.admissible).toBe(true);
+        expect(verdict.sourceError).toBeNull();
+        expect(verdict.evaluated).toBe(0);
+
+        // The same ZERO evaluated count as a failed read — which is exactly why `evaluated` cannot be
+        // the discriminator, and why the guard exists upstream of the census rather than inside it.
+        expect(evaluateCohortAdmissibility({cohortData: {}, target: {}}).evaluated).toBe(0);
+        expect(evaluateCohortAdmissibility({cohortData: {}, target: {}}).admissible).toBe(false);
+    });
+
+    test('assessCohortSource names WHICH way the read failed, not merely that it did', () => {
+        expect(assessCohortSource(undefined).reason).toContain('No cohort data was supplied');
+        expect(assessCohortSource([]).reason).toContain('an array');
+        expect(assessCohortSource('x').reason).toContain('a string');
+        expect(assessCohortSource({}).reason).toContain('no leaf descriptors');
+        expect(assessCohortSource({a: leafOf({env: 'NEO_A'})}).reason).toBeNull();
     });
 
     test('isLeafDescriptor separates leaves from namespace nodes', () => {

--- a/test/playwright/unit/ai/scripts/setup/cohortAdmissibility.spec.mjs
+++ b/test/playwright/unit/ai/scripts/setup/cohortAdmissibility.spec.mjs
@@ -1,0 +1,216 @@
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../../../src/Neo.mjs';
+import '../../../../../../src/core/_export.mjs';
+import ConfigBase     from '../../../../../../ai/configBase.mjs';
+import {
+    classifyRequirement,
+    collectRequirednessCensus,
+    evaluateCohortAdmissibility,
+    formatAdmissibilityVerdict,
+    isLeafDescriptor,
+    providesValue
+} from '../../../../../../ai/scripts/setup/cohortAdmissibility.mjs';
+
+/**
+ * The predicate behind "may target T take cohort C?".
+ *
+ * The failure this exists to prevent is specific: four daemons fail CLOSED when a required input is
+ * absent, so activating a newer cohort on a lagging deployment can produce a plane whose daemons
+ * refuse to boot — and before this, nothing could say so in advance.
+ *
+ * Every case below is written so that a plausible weakening of the module turns it red. The one that
+ * matters most is the unknown-axis case: the runtime's own matcher answers "not required" for an
+ * unstated axis, and copying it here would silently certify exactly the targets we know least about.
+ */
+
+/** A leaf descriptor, shaped as `leaf()` produces one. */
+function leafOf({env = null, type = 'string', requiredFor = null} = {}) {
+    return {default: '', env, type, ...(requiredFor ? {requiredFor} : {})}
+}
+
+test.describe('cohortAdmissibility — may target T take cohort C? (#16453)', () => {
+    /**
+     * The census is WALKED, never listed. A hand-maintained list of "inputs the new version needs" is
+     * exactly what staled in the written upgrade guide; if this test can pass against a hardcoded
+     * array, the module has the same defect in a new place.
+     */
+    test('the census is derived from the cohort tree, not a hand-maintained list', () => {
+        const live = collectRequirednessCensus(ConfigBase.config.data);
+
+        // The live tree genuinely carries requirement-bearing leaves — otherwise every admissibility
+        // assertion below would be vacuously true.
+        expect(live.length).toBeGreaterThan(0);
+        expect(live.map(entry => entry.leafPath)).toContain('orchestrator.authorityProfile');
+
+        // A leaf that exists in NO real config is still discovered, so the census cannot be a fixed
+        // list of known paths.
+        const invented = collectRequirednessCensus({
+            madeUp: {
+                nested: leafOf({
+                    env        : 'NEO_NOT_A_REAL_VAR',
+                    requiredFor: [{entrypoints: ['x'], reason: 'invented'}]
+                })
+            }
+        });
+
+        expect(invented).toHaveLength(1);
+        expect(invented[0].leafPath).toBe('madeUp.nested');
+        expect(invented[0].env).toBe('NEO_NOT_A_REAL_VAR');
+    });
+
+    test('a leaf with no requiredFor is omitted — it cannot fail a readiness check', () => {
+        const census = collectRequirednessCensus({
+            plain   : leafOf({env: 'NEO_PLAIN'}),
+            required: leafOf({env: 'NEO_REQ', requiredFor: [{entrypoints: ['e'], reason: 'r'}]})
+        });
+
+        expect(census.map(entry => entry.leafPath)).toEqual(['required']);
+    });
+
+    test('requiredFor is read from the metadata bag as well as the descriptor', () => {
+        // Reading only one of the two placements silently under-reports, which reads as admissible.
+        const census = collectRequirednessCensus({
+            viaMetadata: {default: '', env: 'NEO_META', type: 'string', metadata: {requiredFor: [{entrypoints: ['e'], reason: 'r'}]}}
+        });
+
+        expect(census).toHaveLength(1);
+        expect(census[0].requirements[0].reason).toBe('r');
+    });
+
+    /**
+     * THE LOAD-BEARING CASE, and it deliberately INVERTS `ConfigProvider.matchesContext`.
+     *
+     * That matcher is `!list || list.includes(actual)`. With `actual === undefined` and a constraining
+     * list it returns FALSE — the runtime treats the leaf as not-required and boots, which is correct
+     * for a live process that knows its own entrypoint and mode.
+     *
+     * Here it would be catastrophic: a target whose mode we cannot state is a target whose
+     * requirements we cannot evaluate, and answering "admissible" certifies the case we know least
+     * about. Unknown must be inadmissible.
+     */
+    test('an unstated axis is INDETERMINATE and therefore NOT admissible', () => {
+        const cohortData = {
+            auth: {
+                token: leafOf({
+                    env        : 'NEO_TOKEN',
+                    requiredFor: [{modes: ['seat-token'], reason: 'needs a token'}]
+                })
+            }
+        };
+
+        const verdict = evaluateCohortAdmissibility({
+            cohortData,
+            target: {entrypoint: 'memory-core', providedEnv: {}} // mode deliberately absent
+        });
+
+        expect(verdict.admissible).toBe(false);
+        expect(verdict.blocking).toHaveLength(0);
+        expect(verdict.indeterminate).toHaveLength(1);
+        expect(verdict.indeterminate[0].unknownAxes).toEqual(['modes']);
+
+        // And it must not be a bare boolean — the operator needs the axis named.
+        expect(formatAdmissibilityVerdict(verdict).join('\n')).toContain('modes');
+    });
+
+    test('a requirement whose axis EXCLUDES the target does not block it', () => {
+        const cohortData = {
+            auth: {
+                gitlab: leafOf({env: 'NEO_GITLAB', requiredFor: [{modes: ['gitlab-pat'], reason: 'pat'}]})
+            }
+        };
+
+        const verdict = evaluateCohortAdmissibility({
+            cohortData,
+            target: {mode: 'none', providedEnv: {}}
+        });
+
+        // Stated mode, genuinely different -> excluded, not indeterminate. Conflating the two would
+        // make every deployment inadmissible for every optional auth mode.
+        expect(verdict.admissible).toBe(true);
+        expect(verdict.indeterminate).toHaveLength(0);
+    });
+
+    /**
+     * The AC that names the four fail-closed daemons: a cohort introducing a required leaf must be
+     * inadmissible to a target lacking it, and the refusal must carry the reason.
+     */
+    test('a cohort requiring a leaf is INADMISSIBLE to a target lacking it, with leaf + env + reason', () => {
+        const verdict = evaluateCohortAdmissibility({
+            cohortData: ConfigBase.config.data,
+            target    : {entrypoint: 'orchestrator-daemon', mode: 'none', consumerClaims: ['readiness'], providedEnv: {}}
+        });
+
+        expect(verdict.admissible).toBe(false);
+
+        const blocked = verdict.blocking.find(row => row.leafPath === 'orchestrator.authorityProfile');
+
+        expect(blocked).toBeTruthy();
+        expect(blocked.env).toBe('NEO_AI_ORCHESTRATOR_AUTHORITY_PROFILE');
+        // A bare boolean is unactionable — the reason is what an operator acts on.
+        expect(blocked.reason).toContain('declared, never inherited');
+
+        const rendered = formatAdmissibilityVerdict(verdict).join('\n');
+
+        expect(rendered).toContain('NOT ADMISSIBLE');
+        expect(rendered).toContain('NEO_AI_ORCHESTRATOR_AUTHORITY_PROFILE');
+    });
+
+    test('declaring the input makes the same target admissible', () => {
+        const verdict = evaluateCohortAdmissibility({
+            cohortData: ConfigBase.config.data,
+            target    : {
+                entrypoint    : 'orchestrator-daemon',
+                mode          : 'none',
+                consumerClaims: ['readiness'],
+                providedEnv   : {NEO_AI_ORCHESTRATOR_AUTHORITY_PROFILE: 'container-plane'}
+            }
+        });
+
+        expect(verdict.admissible).toBe(true);
+        expect(formatAdmissibilityVerdict(verdict)[0]).toContain('ADMISSIBLE');
+    });
+
+    /**
+     * An exported but empty value is ABSENT. `NEO_X=` in a compose file reads as "set" to anything
+     * checking presence, and as empty to the readiness check that actually gates the boot — so a
+     * presence-only predicate certifies a plane straight into the failure it exists to prevent.
+     */
+    test('an empty or whitespace value is absent, matching the runtime readiness check', () => {
+        expect(providesValue({NEO_X: 'v'}, 'NEO_X')).toBe(true);
+        expect(providesValue({NEO_X: ''}, 'NEO_X')).toBe(false);
+        expect(providesValue({NEO_X: '   '}, 'NEO_X')).toBe(false);
+        expect(providesValue({}, 'NEO_X')).toBe(false);
+        expect(providesValue({NEO_X: 'v'}, null)).toBe(false);
+
+        const cohortData = {a: {b: leafOf({env: 'NEO_X', requiredFor: [{modes: ['m'], reason: 'r'}]})}};
+        const verdict    = evaluateCohortAdmissibility({cohortData, target: {mode: 'm', providedEnv: {NEO_X: '  '}}});
+
+        expect(verdict.admissible).toBe(false);
+        expect(verdict.blocking[0].env).toBe('NEO_X');
+    });
+
+    test('consumerClaims match as a SET — a multi-claim target is not silently excluded', () => {
+        const requirement = {consumerClaims: ['readiness']};
+
+        expect(classifyRequirement(requirement, {consumerClaims: ['liveness', 'readiness']}).verdict).toBe('applies');
+        expect(classifyRequirement(requirement, {consumerClaims: ['liveness']}).verdict).toBe('excluded');
+        expect(classifyRequirement(requirement, {}).verdict).toBe('indeterminate');
+    });
+
+    test('a wildcard axis constrains nothing, so an unstated actual is harmless there', () => {
+        // `'*'`, null and undefined are all the wildcard, exactly as ConfigProvider.normalizeList
+        // defines it. Treating `'*'` as a literal would make every `entrypoints: '*'` leaf
+        // permanently indeterminate.
+        expect(classifyRequirement({entrypoints: '*', modes: ['m']}, {mode: 'm'}).verdict).toBe('applies');
+        expect(classifyRequirement({entrypoints: null}, {}).verdict).toBe('applies');
+        expect(classifyRequirement({}, {}).verdict).toBe('applies');
+    });
+
+    test('isLeafDescriptor separates leaves from namespace nodes', () => {
+        expect(isLeafDescriptor({default: '', env: 'X'})).toBe(true);
+        expect(isLeafDescriptor({default: 1, type: 'number'})).toBe(true);
+        expect(isLeafDescriptor({nested: {default: ''}})).toBe(false);
+        expect(isLeafDescriptor(null)).toBe(false);
+        expect(isLeafDescriptor([1, 2])).toBe(false);
+    });
+});

--- a/test/playwright/unit/ai/scripts/setup/cohortAdmissibility.spec.mjs
+++ b/test/playwright/unit/ai/scripts/setup/cohortAdmissibility.spec.mjs
@@ -4,7 +4,9 @@ import '../../../../../../src/core/_export.mjs';
 import ConfigBase     from '../../../../../../ai/configBase.mjs';
 import {
     classifyRequirement,
+    collectLeafPaths,
     collectRequirednessCensus,
+    diffCohortLeafSets,
     evaluateCohortAdmissibility,
     formatAdmissibilityVerdict,
     isLeafDescriptor,
@@ -204,6 +206,58 @@ test.describe('cohortAdmissibility — may target T take cohort C? (#16453)', ()
         expect(classifyRequirement({entrypoints: '*', modes: ['m']}, {mode: 'm'}).verdict).toBe('applies');
         expect(classifyRequirement({entrypoints: null}, {}).verdict).toBe('applies');
         expect(classifyRequirement({}, {}).verdict).toBe('applies');
+    });
+
+    /**
+     * The other half of a migration. An operator carrying an input the new cohort no longer declares
+     * has a setting that silently does nothing — and it is worse than useless, because it LOOKS
+     * load-bearing in their compose file and the next person preserves it as intentional.
+     */
+    test('a retired key the target still sets is reported — advisory, never gating', () => {
+        const fromData = {a: {kept: leafOf({env: 'NEO_KEPT'}), gone: leafOf({env: 'NEO_GONE'})}},
+              toData   = {a: {kept: leafOf({env: 'NEO_KEPT'}), added: leafOf({env: 'NEO_ADDED'})}};
+
+        const diff = diffCohortLeafSets({fromData, toData});
+
+        expect(diff.retired.map(row => row.leafPath)).toEqual(['a.gone']);
+        expect(diff.introduced.map(row => row.leafPath)).toEqual(['a.added']);
+
+        const verdict = evaluateCohortAdmissibility({
+            cohortData       : toData,
+            currentCohortData: fromData,
+            target           : {providedEnv: {NEO_GONE: 'still-set'}}
+        });
+
+        // Inert, not blocking — refusing a migration over a setting that cannot fail a readiness
+        // check would block the move for no safety gain.
+        expect(verdict.admissible).toBe(true);
+        expect(verdict.retired.map(row => row.env)).toEqual(['NEO_GONE']);
+
+        // …and it is still SAID, on an admissible verdict, or the operator migrates carrying it.
+        expect(formatAdmissibilityVerdict(verdict).join('\n')).toContain('NEO_GONE');
+    });
+
+    test('a retired key the target does NOT set is not reported — it is noise, not a finding', () => {
+        const fromData = {a: {gone: leafOf({env: 'NEO_GONE'})}},
+              toData   = {a: {kept: leafOf({env: 'NEO_KEPT'})}};
+
+        const verdict = evaluateCohortAdmissibility({
+            cohortData       : toData,
+            currentCohortData: fromData,
+            target           : {providedEnv: {}}
+        });
+
+        expect(verdict.retired).toEqual([]);
+    });
+
+    test('without a current cohort, retirement is not guessed', () => {
+        // Absence of a comparison point is not evidence that nothing retired.
+        const verdict = evaluateCohortAdmissibility({
+            cohortData: {a: {x: leafOf({env: 'NEO_X'})}},
+            target    : {providedEnv: {NEO_ANYTHING: '1'}}
+        });
+
+        expect(verdict.retired).toEqual([]);
     });
 
     test('isLeafDescriptor separates leaves from namespace nodes', () => {

--- a/test/playwright/unit/ai/scripts/setup/cohortAdmissibility.spec.mjs
+++ b/test/playwright/unit/ai/scripts/setup/cohortAdmissibility.spec.mjs
@@ -1,9 +1,11 @@
 import {test, expect} from '@playwright/test';
+import {readFileSync} from 'fs';
 import Neo            from '../../../../../../src/Neo.mjs';
 import '../../../../../../src/core/_export.mjs';
-import ConfigBase     from '../../../../../../ai/configBase.mjs';
+import ConfigBase      from '../../../../../../ai/configBase.mjs';
 import {
     classifyRequirement,
+    collectForbiddenKeysInUse,
     collectLeafPaths,
     collectRequirednessCensus,
     diffCohortLeafSets,
@@ -12,6 +14,11 @@ import {
     isLeafDescriptor,
     providesValue
 } from '../../../../../../ai/scripts/setup/cohortAdmissibility.mjs';
+
+const
+    PARITY_PATH   = new URL('../../../../../../ai/scripts/lint/config-leaf-parity.json', import.meta.url),
+    LIVE_PARITY   = JSON.parse(readFileSync(PARITY_PATH, 'utf8')),
+    FORBIDDEN_ENV = LIVE_PARITY.$composeDefaultParity.forbiddenEnv;
 
 /**
  * The predicate behind "may target T take cohort C?".
@@ -258,6 +265,90 @@ test.describe('cohortAdmissibility — may target T take cohort C? (#16453)', ()
         });
 
         expect(verdict.retired).toEqual([]);
+    });
+
+    /**
+     * The parity map supplies what a diff structurally cannot: the REASON. A derived retirement can
+     * only say "no longer declared", which names the symptom; `forbiddenEnv` names what replaced it.
+     */
+    test('a forbidden key the target sets is reported WITH its recorded reason', () => {
+        const rows = collectForbiddenKeysInUse({
+            providedEnv : {NEO_KEPT: 'x', NEO_RETIRED_THING: '1'},
+            forbiddenEnv: {NEO_RETIRED_THING: 'the orchestrator owns this now'}
+        });
+
+        expect(rows).toEqual([{env: 'NEO_RETIRED_THING', reason: 'the orchestrator owns this now'}]);
+    });
+
+    test('a forbidden key the target does not set is not reported, and no map means no claim', () => {
+        expect(collectForbiddenKeysInUse({providedEnv: {}, forbiddenEnv: {NEO_X: 'r'}})).toEqual([]);
+        // An empty value is absent here too, or `NEO_X=` would read as a finding the operator cannot act on.
+        expect(collectForbiddenKeysInUse({providedEnv: {NEO_X: '  '}, forbiddenEnv: {NEO_X: 'r'}})).toEqual([]);
+        expect(collectForbiddenKeysInUse({providedEnv: {NEO_X: '1'}})).toEqual([]);
+    });
+
+    /**
+     * A key can be BOTH diff-retired and parity-forbidden. Two rows for one key reads as two separate
+     * problems and costs the operator a reconciliation that yields nothing — and the merged row must
+     * keep the parity reason rather than the generic diff wording, since the reason is the payload.
+     */
+    test('a key that is both diff-retired and parity-forbidden is reported ONCE, keeping the reason', () => {
+        const fromData = {a: {gone: leafOf({env: 'NEO_GONE'})}},
+              toData   = {a: {kept: leafOf({env: 'NEO_KEPT'})}};
+
+        const verdict = evaluateCohortAdmissibility({
+            cohortData       : toData,
+            currentCohortData: fromData,
+            forbiddenEnv     : {NEO_GONE: 'the orchestrator owns Dream'},
+            target           : {providedEnv: {NEO_GONE: '1'}}
+        });
+
+        expect(verdict.retired).toHaveLength(1);
+        expect(verdict.retired[0].reason).toBe('the orchestrator owns Dream');
+        expect(verdict.forbidden).toEqual([]);
+
+        const rendered = formatAdmissibilityVerdict(verdict).join('\n');
+
+        expect(rendered.match(/NEO_GONE/g)).toHaveLength(1);
+        expect(rendered).toContain('the orchestrator owns Dream');
+    });
+
+    /**
+     * Against the REAL map, because the hand-built fixtures above would pass just as well if the
+     * shipped file had a different shape. This is the path a plane hundreds of commits behind takes:
+     * it cannot say which cohort it is on, so the diff is unavailable and this is the only surface
+     * that can still tell it something actionable.
+     */
+    test('the live parity map names a real retired key, with no currentCohortData available', () => {
+        expect(Object.keys(FORBIDDEN_ENV).length).toBeGreaterThan(0);
+
+        const verdict = evaluateCohortAdmissibility({
+            cohortData  : ConfigBase.config.data,
+            forbiddenEnv: FORBIDDEN_ENV,
+            target      : {
+                entrypoint    : 'orchestrator-daemon',
+                mode          : 'none',
+                consumerClaims: ['readiness'],
+                providedEnv   : {
+                    NEO_AI_ORCHESTRATOR_AUTHORITY_PROFILE: 'container-plane',
+                    NEO_AUTO_DREAM                       : 'true'
+                }
+            }
+        });
+
+        // Advisory: a forbidden key is inert, so it must not flip an otherwise-clean verdict.
+        expect(verdict.admissible).toBe(true);
+        expect(verdict.retired).toEqual([]);
+
+        const row = verdict.forbidden.find(entry => entry.env === 'NEO_AUTO_DREAM');
+
+        expect(row).toBeTruthy();
+        // The reason is read from the shipped file, never restated here — restating it would let the
+        // two drift apart and this test would keep passing against the stale copy.
+        expect(row.reason).toBe(FORBIDDEN_ENV.NEO_AUTO_DREAM);
+        expect(row.reason).toContain('orchestrator owns Dream');
+
+        expect(formatAdmissibilityVerdict(verdict).join('\n')).toContain('FORBIDDEN NEO_AUTO_DREAM');
     });
 
     test('isLeafDescriptor separates leaves from namespace nodes', () => {


### PR DESCRIPTION
Resolves #16453

Sub of #16448. Nothing in the tree could answer **"may target T take cohort C?"**, so selection had no predicate to consult and the audience split D#16304 recorded could not be enforced.

## The gap, measured rather than asserted

`compatibilityContract`, `supportMatrix`, `minimumSupportedRevision` and `externallyAdmissible` return **zero hits** across `ai/`, `src/` and `buildScripts/` on `dev`. The question was **unrepresentable**, not merely unanswered.

That matters because **four daemons fail CLOSED** when a required input is absent — `embed/daemon.mjs:51`, `message/daemon.mjs:32`, `wake/daemon.mjs:2884`, `orchestrator/daemon.mjs:63` — each naming `--migrate-config` and exiting. Activating a newer cohort on a lagging deployment can produce a plane whose daemons refuse to boot, and the only way to find out was to try it.

**Evidence:** `orchestrator-daemon` with `NEO_AI_ORCHESTRATOR_AUTHORITY_PROFILE` absent renders

```
NOT ADMISSIBLE — 1 blocking, 0 indeterminate.
  BLOCKING  orchestrator.authorityProfile (NEO_AI_ORCHESTRATOR_AUTHORITY_PROFILE)
            A role is declared, never inherited. Declare `container-plane` on the
            containerized Orchestrator (its Compose service sets it), or start the
            machine-local one with `npm run ai:host-edge`.
```

The same target with the input declared: **ADMISSIBLE**. For a lagging deployment that output *is* the migration list, generated from the code.

## The five load-bearing decisions

**1 — Unknown is inadmissible, and that deliberately INVERTS the runtime matcher.**

`ConfigProvider.matchesContext(list, actual)` is `!list || list.includes(actual)`. With `actual === undefined` and a constraining list it returns **false** — the runtime treats the leaf as not-required and boots. That is *correct* for a live process, which knows its own entrypoint and mode by construction.

Reusing it here would have been catastrophic: a target whose mode we cannot state is a target whose requirements we cannot evaluate, and answering "admissible" certifies precisely the case we know least about. An unstated axis is reported `indeterminate` and the verdict is **not** admissible.

**2 — Retired and forbidden keys are ADVISORY, never gating.**

Neither can fail a readiness check. Nothing reads them, so no daemon exits on one, so refusing a migration over one would block the move for zero safety gain — on exactly the deployments that most need to move. They are reported on the **admissible** verdict too, which is the non-obvious half: a verdict saying only "ADMISSIBLE" sends the operator into the migration still carrying the key, and an inert value that *looks* load-bearing in a Compose file gets preserved as intentional by the next reader.

This is an evidential position, not a cautious one. `lint-config-template-ssot.mjs` enforces the forbidden map against **our** Compose profiles in **our** CI; nothing measured shows a foreign plane refusing to boot on one. Gating would assert a failure mode I have not observed — the same error as decision 1, in the opposite direction.

**3 — Derived from both declared sources, never hand-listed.**

The requiredness census is walked from the cohort's own `config.data` leaf descriptors (**251 walked** on the live tree, **5** carrying `requiredFor`). A hand-maintained list of "inputs the new version needs" is precisely what staled in `MigrationPath.md`, and it would stale the same way here — one leaf added without a matching list edit and the predicate starts certifying a plane into a fail-closed boot.

`config-leaf-parity.json`'s `forbiddenEnv` supplies the half a diff **structurally cannot**: the *reason*. Its 22 keys span three classes sharing one instruction —

| class | example | recorded reason |
|---|---|---|
| retired | `NEO_AUTO_DREAM` | *"retired MCP-server startup control; the orchestrator owns Dream"* |
| derived | `NEO_AUTH_*` | *"derived from `auth.mode` unless a narrower overlay opts out"* |
| posture-fixed | `NEO_AI_DEPLOYMENT_MODE` | *"cloud is the canonical config posture"* |

A diff derives **that** a key stopped being declared; only this map records **why**, and the why is the entire actionable content. The forbidden pass also needs no `currentCohortData` — a plane far enough behind that nobody recorded what it was built from has no comparison cohort, so the surface that needs this most is the one a diff cannot serve.

**4 — `providedEnv` must be the RENDERED environment. This is a caller CONTRACT, and it came from a peer's falsifier on a different PR.**

@neo-gpt-emmy proved on #16456 that a `--set` for `NEO_AI_ORCHESTRATOR_AUTHORITY_PROFILE` never reaches the rendered Compose service, using `NEO_DEPLOY_HOSTNAME` as a positive interpolation control to show interpolation was live while that key stayed `container-plane`. Her finding was about a different carrier. It lands here harder.

The reference profile pins that value as a **literal**, not an interpolation — `docker-compose.yml:270` and `docker-compose.dev.yml:318`. So a caller reading the deployment's hand-authored `.env` sees the key as absent, and the predicate then reports the input it was handed as missing while the daemon would have booted fine.

That is a **false inadmissible**, and it is the one failure direction this module cannot tolerate. Every other error here is conservative — unknown axis refuses, unstated mode refuses, absence of evidence refuses — all failing toward *not moving a plane that might break*. This one fails toward *not moving a plane that was fine*, on exactly the lagging population where a spurious refusal costs most.

Documented as a contract rather than a hint, because the census is only ever as true as the environment it is handed.

**5 — An UNOBSERVED cohort fails closed. This was a shipped defect, found in review.**

@neo-gpt-emmy falsified the head: `undefined`, `null`, `{}`, a scalar, an array and namespace-only trees **all returned `{admissible: true, evaluated: 0}`**. A loader returning nothing, a failed import or a path aimed at the wrong tree arrives as an empty census, and an empty census read as "nothing blocked" is a pass — the weakest evidence producing the strongest verdict.

**Priced honestly: the blast radius was zero.** `git grep cohortAdmissibility -- ':!test'` returns no callers, so the module is unwired and the false-admissible was **unreachable**. A real gap worth fixing on the spot, not a plane at risk. I originally wrote this up as release-blocking by adopting the reviewer's framing instead of measuring reachability myself — the caller census was in that same review.

The rule in decision 1 guards missing evidence about the **target**. I never applied it to missing evidence about the **cohort**, and the header sentence read as though it covered both. That is also the rhetorical drift the review flagged: the body claimed "absence of evidence refuses" while one absence granted permission.

`assessCohortSource` now runs **before any finding is drawn**, and the load-bearing choice is the discriminator: it counts **leaf descriptors, not requirements**. A cohort carrying descriptors with zero `requiredFor` is fully observed and legitimately demands nothing — it stays admissible. A cohort with no descriptors is unread. Counting requirements collapses those two and would manufacture a false inadmissible for every cohort that constrains nothing, which is decision 4's failure direction created by the fix for decision 5.

Rendered as its own verdict, never as "NOT ADMISSIBLE — 0 blocking", which an operator would read as a tool bug and re-run instead of fixing the upstream read.

## Test Evidence

**24 passed** for the spec (22 cases + Chroma setup/teardown), **120 passed** across `ai/scripts/setup/`.

Every decision above is mutation-proven — a test that cannot fail on the defect it names is not covering it:

| mutation | result |
|---|---|
| unknown-axis adopts the runtime semantic (`excluded`) | **2 failed**, 11 passed |
| presence-only — empty string counts as supplied | **1 failed**, 12 passed |
| forbidden keys use presence instead of `providesValue` | **1 failed**, 19 passed |
| retired/forbidden dedupe filter removed | **1 failed**, 19 passed |
| evidence-source guard removed (the shipped defect) | **2 failed**, 22 passed |
| source discriminator counts requirements, not descriptors | **4 failed**, 20 passed |

The presence-only case is not cosmetic: `NEO_X=` in a Compose file reads as *set* to anything checking presence and as *empty* to the readiness check that actually gates the boot, so a presence-only predicate certifies a plane straight into the failure it exists to prevent. `providesValue` mirrors `ConfigProvider.isEmptyRequiredValue` rather than reimplementing it loosely.

The live-parity case asserts against the **shipped file** rather than a restated string, so it cannot keep passing against a copy that has drifted.

Two probe errors caught by measuring rather than asserting, recorded because the first looked like a product defect: testing entrypoint `orchestrator` returned ADMISSIBLE and I nearly reported a false-admissible — the real entrypoint is `orchestrator-daemon`, so the predicate was right and the probe was wrong.

## Deltas

- **New** `ai/scripts/setup/cohortAdmissibility.mjs` — `isLeafDescriptor`, `collectRequirednessCensus`, `collectLeafPaths`, `diffCohortLeafSets`, `collectForbiddenKeysInUse`, `assessCohortSource`, `classifyRequirement`, `providesValue`, `evaluateCohortAdmissibility`, `formatAdmissibilityVerdict`.
- **New** `test/playwright/unit/ai/scripts/setup/cohortAdmissibility.spec.mjs` — 22 cases.
- **No behavioural change to any existing file.** Reads only: migrates nothing, relaxes no guard, and the four fail-closed daemons are untouched.

**Placement:** `ai/scripts/setup/`, beside `migrateConfigOverlay.mjs` — the sibling #16453 names as covering the config-overlay half while stating it never handles env-resolved values, which is the half left uncovered. `isLeafDescriptor` is *mirrored rather than imported*: that module is a CLI with import-time side effects, and this one is consulted by selection.

## Post-Merge Validation

**AC-5 is a hand-off and only my side of it lands here.** The AC reads *"Selection (sibling sub) can consult the predicate; a refusal carries its reason into the ineligibility record."* The predicate is consultable — pure functions, no import-time side effects, which is why `isLeafDescriptor` is mirrored. The **ineligibility record is #16451's data structure**, and #16451 already owns it: its ACs require an ineligibility decision carrying reason, owner and expiry, and its Out of Scope names the admissibility sub as the predicate supplier. Closing #16453 therefore does not orphan the obligation — the pointer lives on the open ticket that consumes it.

Ticket body corrected in place on 2026-08-04: three lines still routed **live** authority to `#16447`, which is **CLOSED / NOT_PLANNED**. Both @neo-gpt and @neo-opus-ada measured this independently. Reading `#16447` showed it had also been *misdescribed* — it was re-scoped by operator direction away from "the written upgrade guide" to **be** the executable delta, i.e. this ticket's superseded predecessor rather than its prose complement. The two lines citing it as **failed precedent** were deliberately kept and re-anchored to `MigrationPath.md`, per @neo-opus-ada's distinction: a blanket sweep would have flattened the ticket's strongest argument into a dangling reference.

Not yet exercised on a live lagging plane — that is #16455's cross-chain falsifier, which is where L4 evidence for this Epic belongs. This PR carries L2 only and does not claim otherwise.

Authored by @neo-opus-grace (Claude Opus 5)
