### PR TITLE
fix: The active tab never runs beneath the floating overflow control (#16424)

### DIFF
--- a/resources/scss/src/tab/header/Button.scss
+++ b/resources/scss/src/tab/header/Button.scss
@@ -75,6 +75,19 @@
         }
     }
 
+    // The overflow plugin bounds a degenerate over-wide active button (inline max-width) so its box —
+    // and the absolute per-button indicator spanning that box — ends where the floating overflow
+    // control begins. The box bound alone would let the label glyphs overflow the shrunken box; this
+    // turns the covered cut into an honest ellipsis.
+    &.neo-tab-overflow-capped {
+        .neo-button-text {
+            min-width    : 0;
+            overflow     : hidden;
+            text-overflow: ellipsis;
+            white-space  : nowrap;
+        }
+    }
+
     &:not(:last-child) {
         margin-right: var(--tab-button-gap);
     }

--- a/src/tab/plugin/Overflow.mjs
+++ b/src/tab/plugin/Overflow.mjs
@@ -138,6 +138,15 @@ class Overflow extends Plugin {
      */
     measuring = false
     /**
+     * The control's RENDERED width, measured while it is mounted (same round-trip as the extent read).
+     * The `controlWidth` config is only the pre-creation estimate — the first overflow decision runs
+     * before any control exists to measure. Once render truth is available, the reservation uses
+     * `max(config, measured)`, so a skin that renders the control wider than the estimate can never
+     * let packed buttons underlap it. `null` until the control has been measured; cleared with the control.
+     * @member {Number|null} measuredControlWidth=null
+     */
+    measuredControlWidth = null
+    /**
      * Natural (un-hidden) header widths keyed by tab-button id — see the class note on natural-width
      * discipline. `null` until the first capture.
      * @member {Object|null} naturalWidths=null
@@ -303,13 +312,23 @@ class Overflow extends Plugin {
         try {
             // 1. Natural widths — measured once while every button is visible, then cached.
             if (recapture || !me.naturalWidths) {
-                const removedButtons = buttons.filter(button => button.hidden);
+                const removedButtons = buttons.filter(button => button.hidden),
+                      cappedButtons  = buttons.filter(button => button.style?.maxWidth);
+
+                // A degenerate-case cap (applySplit) bounds the live rect below the natural width, so
+                // measuring through it would poison the cache with the capped value. Lift caps under the
+                // same latch that restores hidden buttons; the split re-applies them right after.
+                cappedButtons.forEach(button => {
+                    const {maxWidth, ...style} = button.style;
+
+                    button.setSilent({style})
+                });
 
                 // A prior split removes overflowing buttons from DOM. Restore them under this method's
                 // measuring latch, then reconcile their closest common parent once so getDomRect observes
                 // natural geometry. Any resize raised by that update queues behind the latch and drains as
                 // an extent-only pass after this authoritative capture.
-                if (removedButtons.length > 0) {
+                if (removedButtons.length > 0 || cappedButtons.length > 0) {
                     removedButtons.forEach(button => {
                         button.setSilent({hidden: false});
                         // setSilent intentionally bypasses Component#show(). Keep the config and VDOM
@@ -336,23 +355,37 @@ class Overflow extends Plugin {
                 })
             }
 
-            // 2. The strip extent — the toolbar itself never hides, so it is always measurable.
-            let extentRect   = await owner.getDomRect(),
-                extent       = Math.floor(extentRect?.width || 0),
+            // 2. The strip extent — the toolbar itself never hides, so it is always measurable. When the
+            //    control is mounted, its rendered width rides the same round-trip: render truth for the
+            //    reservation costs no extra latency.
+            let controlId    = me.control?.mounted ? me.control.id : null,
+                rects        = await owner.getDomRect(controlId ? [owner.id, controlId] : [owner.id]),
+                extent       = Math.floor(rects[0]?.width || 0),
                 tabContainer = me.getTabContainer(),
                 activeButton = buttons[tabContainer?.activeIndex] || null,
-                items        = buttons.map(button => ({id: button.id, headerWidth: me.naturalWidths[button.id]})),
+                items        = buttons.map(button => ({id: button.id, headerWidth: me.naturalWidths[button.id]}));
 
-                // 3. The pure decision: active-never-hidden packing, overflow-only control reservation.
-                //    The pure core is this plugin's own static (below) — no adapter namespace-reach, no cycle.
-                {hidden} = Overflow.computeOverflow({
+            if (controlId && rects[1]?.width > 0) {
+                me.measuredControlWidth = Math.ceil(rects[1].width)
+            }
+
+            // 3. The pure decision: active-never-hidden packing, overflow-only control reservation.
+            //    The pure core is this plugin's own static (below) — no adapter namespace-reach, no cycle.
+            let controlWidth = Math.max(me.controlWidth, me.measuredControlWidth || 0),
+                {hidden}     = Overflow.computeOverflow({
                     activeItemId: activeButton?.id,
-                    controlWidth: me.controlWidth,
+                    controlWidth,
                     extent,
                     items
                 });
 
-            me.applySplit(hidden, buttons, tabContainer)
+            me.applySplit(hidden, buttons, tabContainer, {
+                activeButton,
+                // The degenerate branch keeps an over-wide active visible past `usable` — cap its box so
+                // every geometry derived from the button (the persistent per-button indicator, the strip's
+                // crossfade indicator, the label itself) ends where the control begins.
+                usable: hidden.length > 0 ? Math.max(0, extent - controlWidth) : null
+            })
         } catch (error) {
             // getDomRect losing a race with teardown (owner unmounting mid-measure) is the ONE expected
             // failure: it must neither reject a fire-and-forget handler nor skip the drain below, and the
@@ -380,19 +413,29 @@ class Overflow extends Plugin {
     }
 
     /**
-     * Applies the computed hidden set: hides the overflowing header buttons and reflects the remainder
-     * through the overflow control.
+     * Applies the computed hidden set: hides the overflowing header buttons, bounds the degenerate
+     * over-wide active button to the usable extent, and reflects the remainder through the overflow
+     * control.
+     *
+     * The cap is horizontal-only by design: this plugin packs widths against a horizontal strip extent
+     * (`tabBarPosition: 'top'` / `'bottom'` compositions); a vertical tab bar never mounts it, so the
+     * vertical indicator branch has no overflow control to collide with.
      * @param {String[]} hidden  Overflowing button ids, in header order.
      * @param {Neo.tab.header.Button[]} buttons
      * @param {Neo.tab.Container} tabContainer
+     * @param {Object}  activeCap
+     * @param {Neo.tab.header.Button|null} activeCap.activeButton
+     * @param {Number|null} activeCap.usable  Cap for the active button while overflowing; `null` clears.
      */
-    applySplit(hidden, buttons, tabContainer) {
+    applySplit(hidden, buttons, tabContainer, {activeButton, usable} = {}) {
         let me         = this,
             hiddenSet  = new Set(hidden),
             hiddenMeta = [];
 
         buttons.forEach((button, index) => {
-            let isHidden = hiddenSet.has(button.id);
+            let isHidden = hiddenSet.has(button.id),
+                needsCap = button === activeButton && usable !== null && usable !== undefined
+                    && me.naturalWidths?.[button.id] > usable;
 
             // Neo's built-in `hidden` (removeDom) rather than a cls needing an external stylesheet rule —
             // the natural-width cache (captured while every button was visible) survives the DOM removal,
@@ -404,6 +447,22 @@ class Overflow extends Plugin {
                 // removeDom still exists; assigning false again is then a reactive no-op, whereas
                 // show() clears the marker and schedules the toolbar update which remounts the header.
                 button.show()
+            }
+
+            // Degenerate-branch bound: `computeOverflow` keeps an active wider than `usable` visible
+            // (active-never-hidden), so its box would run beneath the floating control — and with it every
+            // geometry derived from the box: the persistent `.neo-tab-button-indicator` child, the strip's
+            // crossfade indicator (sized from this rect), and the label glyphs the opaque control would
+            // otherwise cover instead of an honest ellipsis. Cleared on every non-degenerate pass so the
+            // ordinary full-width case never inherits a stale bound.
+            if (needsCap) {
+                button.addCls('neo-tab-overflow-capped');
+                button.style = {...button.style, maxWidth: `${usable}px`}
+            } else if (button.style?.maxWidth) {
+                const {maxWidth, ...style} = button.style;
+
+                button.removeCls('neo-tab-overflow-capped');
+                button.style = style
             }
 
             if (isHidden) {
@@ -433,7 +492,9 @@ class Overflow extends Plugin {
         if (hiddenMeta.length < 1) {
             if (me.control) {
                 me.control.destroy(true);
-                me.control = null
+                me.control              = null;
+                // The measurement belongs to the torn-down embodiment; the next control re-measures.
+                me.measuredControlWidth = null
             }
             return
         }

--- a/src/tab/plugin/Overflow.mjs
+++ b/src/tab/plugin/Overflow.mjs
@@ -127,6 +127,15 @@ class Overflow extends Plugin {
     }
 
     /**
+     * Plugin-owned active-button caps: button id → the caller's own `maxWidth` config value at
+     * cap time (`null` when the consumer had none). Property presence on the button is NOT
+     * provenance — a consumer may legitimately configure `maxWidth` — so this ledger is the one
+     * source of truth for "the plugin installed this cap", and clearing always restores the exact
+     * recorded caller value through the same public config channel.
+     * @member {Map|null} appliedCaps=null
+     */
+    appliedCaps = null
+    /**
      * The overflow control (a menu button), created on first overflow and torn down when everything fits.
      * @member {Neo.button.Base|null} control=null
      */
@@ -152,6 +161,15 @@ class Overflow extends Plugin {
      * @member {Object|null} naturalWidths=null
      */
     naturalWidths = null
+    /**
+     * Signature of the hidden set the control currently reflects (`index:text:iconCls` per entry).
+     * Projections fire on many no-op events (resize, activation, the render-truth edges), and
+     * rewriting identical menu items is not free: it rebuilds the dropdown list and closes an OPEN
+     * menu mid-interaction. The signature makes syncControl's menu mutation idempotent — only a
+     * changed partition touches the menu; re-arm and re-align stay unconditional.
+     * @member {String|null} hiddenSignature=null
+     */
+    hiddenSignature = null
     /**
      * A project() call arrived while a measure pass was in flight; drained once the pass releases the
      * latch, so a coalesced resize / activation / tab-set change still applies against current extents.
@@ -274,6 +292,9 @@ class Overflow extends Plugin {
 
     /**
      * Re-resolves the source toolbar's nearest active theme onto the out-of-tree overflow embodiment.
+     * A theme flip can change the control's rendered width (fonts, paddings), so the reservation
+     * re-projects through the ordinary measure pass — the getDomRect round-trip queues behind the
+     * theme update on the same channel, so it observes the re-skinned control.
      */
     onOwnerThemeChange() {
         let me        = this,
@@ -281,7 +302,8 @@ class Overflow extends Plugin {
             value     = me.owner.getTheme();
 
         if (control && control.theme !== value) {
-            control.theme = value
+            control.theme = value;
+            me.project(false)
         }
     }
 
@@ -313,15 +335,18 @@ class Overflow extends Plugin {
             // 1. Natural widths — measured once while every button is visible, then cached.
             if (recapture || !me.naturalWidths) {
                 const removedButtons = buttons.filter(button => button.hidden),
-                      cappedButtons  = buttons.filter(button => button.style?.maxWidth);
+                      cappedButtons  = buttons.filter(button => me.appliedCaps?.has(button.id));
 
-                // A degenerate-case cap (applySplit) bounds the live rect below the natural width, so
-                // measuring through it would poison the cache with the capped value. Lift caps under the
-                // same latch that restores hidden buttons; the split re-applies them right after.
+                // A plugin-installed cap (applySplit) bounds the live rect below the natural width, so
+                // measuring through it would poison the cache with the capped value. Restore the CALLER's
+                // recorded maxWidth (reactively — the config's afterSet owns the vdom key; a silent write
+                // would leave the capped vdom in place and measure the cap anyway) under the same latch
+                // that restores hidden buttons. Ledger entries stay: the split right after re-caps against
+                // fresh numbers (the recorded caller value stays authoritative) or clears via its ordinary
+                // restore branch. Only ledger members are touched — a consumer-configured maxWidth is not
+                // plugin residue and measures as part of the button's real constraint set.
                 cappedButtons.forEach(button => {
-                    const {maxWidth, ...style} = button.style;
-
-                    button.setSilent({style})
+                    button.maxWidth = me.appliedCaps.get(button.id)
                 });
 
                 // A prior split removes overflowing buttons from DOM. Restore them under this method's
@@ -453,16 +478,21 @@ class Overflow extends Plugin {
             // (active-never-hidden), so its box would run beneath the floating control — and with it every
             // geometry derived from the box: the persistent `.neo-tab-button-indicator` child, the strip's
             // crossfade indicator (sized from this rect), and the label glyphs the opaque control would
-            // otherwise cover instead of an honest ellipsis. Cleared on every non-degenerate pass so the
-            // ordinary full-width case never inherits a stale bound.
+            // otherwise cover instead of an honest ellipsis. The cap rides the PUBLIC `maxWidth` config
+            // (one channel, one vdom owner — the consumer's `style.maxWidth` is never touched), and the
+            // `appliedCaps` ledger carries provenance: only a plugin-installed cap is ever cleared, and
+            // clearing restores the exact caller value recorded at cap time.
             if (needsCap) {
-                button.addCls('neo-tab-overflow-capped');
-                button.style = {...button.style, maxWidth: `${usable}px`}
-            } else if (button.style?.maxWidth) {
-                const {maxWidth, ...style} = button.style;
+                if (!me.appliedCaps?.has(button.id)) {
+                    (me.appliedCaps ??= new Map()).set(button.id, button.maxWidth ?? null);
+                    button.addCls('neo-tab-overflow-capped')
+                }
 
+                button.maxWidth = usable
+            } else if (me.appliedCaps?.has(button.id)) {
                 button.removeCls('neo-tab-overflow-capped');
-                button.style = style
+                button.maxWidth = me.appliedCaps.get(button.id);
+                me.appliedCaps.delete(button.id)
             }
 
             if (isHidden) {
@@ -493,13 +523,15 @@ class Overflow extends Plugin {
             if (me.control) {
                 me.control.destroy(true);
                 me.control              = null;
+                me.hiddenSignature      = null;
                 // The measurement belongs to the torn-down embodiment; the next control re-measures.
                 me.measuredControlWidth = null
             }
             return
         }
 
-        let menuItems = hiddenMeta.map(meta => ({
+        let signature = hiddenMeta.map(meta => `${meta.index}:${meta.text}:${meta.iconCls}`).join('|'),
+            menuItems = hiddenMeta.map(meta => ({
                 handler: () => {tabContainer.activeIndex = meta.index},
                 iconCls: meta.iconCls,
                 text   : meta.text
@@ -512,10 +544,15 @@ class Overflow extends Plugin {
             };
 
         if (me.control) {
-            if (me.control.menuList) {
-                me.control.menuList.items = menuItems
-            } else {
-                me.control.menu = menuConfig
+            // Idempotence gate: a projection that did not change the partition must not touch the
+            // menu — rewriting identical items rebuilds the dropdown and closes it mid-interaction
+            // (the render-truth edges made no-op projections routine, so this is load-bearing).
+            if (signature !== me.hiddenSignature) {
+                if (me.control.menuList) {
+                    me.control.menuList.items = menuItems
+                } else {
+                    me.control.menu = menuConfig
+                }
             }
 
             // Re-arm a transiently unmounted control. A floating instance mounts once at
@@ -574,8 +611,21 @@ class Overflow extends Plugin {
                 parentId     : 'document.body',
                 theme        : me.owner.getTheme(),
                 windowId     : me.owner.windowId
-            })
+            });
+
+            // The reservation's render-truth EDGE: the pass that creates the control computed its split
+            // with the pre-creation estimate — the rendered width does not exist yet, and no external
+            // event is owed. Re-project when the mount lands (and on any later re-mount — idempotent, and
+            // a fresh embodiment deserves a fresh measurement), so the estimate→rendered convergence is
+            // this plugin's own lifecycle, never a wait for an unrelated resize/activation/mutation.
+            if (Neo.typeOf(me.control) === 'NeoInstance') {
+                me.observeConfig(me.control, 'mounted', value => {
+                    value && !me.isDestroyed && me.project(false)
+                })
+            }
         }
+
+        me.hiddenSignature = signature;
 
         // RA-13: re-align against the CURRENT owner rect. A floating component aligns once at mount and does
         // NOT re-align when its target moves — and a sync-driven projection change (tabs hidden/shown) moves
@@ -590,8 +640,22 @@ class Overflow extends Plugin {
      * @override
      */
     destroy(...args) {
-        this.control?.destroy(true);
-        this.control = null;
+        let me = this;
+
+        // A dying plugin must not strand its caps (a dock rebuild replaces the plugin, not the
+        // buttons): restore each recorded caller value through the same channel the cap used.
+        me.appliedCaps?.forEach((priorMaxWidth, buttonId) => {
+            const button = me.getTabButtons().find(item => item.id === buttonId);
+
+            if (button && !button.isDestroyed) {
+                button.removeCls?.('neo-tab-overflow-capped');
+                button.maxWidth = priorMaxWidth
+            }
+        });
+
+        me.appliedCaps = null;
+        me.control?.destroy(true);
+        me.control = null;
         super.destroy(...args)
     }
 }

--- a/test/playwright/e2e/workstation/WorkstationTabOverflowCapNL.spec.mjs
+++ b/test/playwright/e2e/workstation/WorkstationTabOverflowCapNL.spec.mjs
@@ -1,0 +1,119 @@
+import {test, expect} from '../../fixtures.mjs';
+
+/**
+ * @summary Whitebox E2E witness: an over-wide active tab is bounded at the overflow control's edge.
+ *
+ * The overflow packing keeps the active tab visible even when it alone is wider than the usable
+ * strip (active-never-hidden). Unbounded, that box — and every geometry derived from it: the
+ * persistent per-button indicator, the strip's crossfade indicator, the label glyphs — runs
+ * beneath the floating overflow control. The workstation heavy header stages this degenerate
+ * case at default boot (twelve canonical titles in a narrow pane), so the assertions run against
+ * the real composition: the capped box must end where the control begins, the reservation the cap
+ * used must equal the RENDERED control width (one value, render-grounded, never a second
+ * derivation), and headers without an overflow control must keep their full natural width.
+ *
+ * Run: NEO_E2E_PORT=8156 npx playwright test workstation/WorkstationTabOverflowCapNL -c test/playwright/playwright.config.e2e.mjs --workers=1
+ */
+test.describe('Workstation — the active tab never runs beneath the overflow control', () => {
+    test.setTimeout(90000);
+    test.use({
+        contextOptions: {screen: {height: 1080, width: 1920}},
+        viewport      : {height: 840, width: 1180}
+    });
+
+    test('the degenerate over-wide active is capped at the control edge; ordinary headers stay full width', async ({page}) => {
+        const pageErrors = [];
+
+        page.on('pageerror', error => {
+            let value = error == null ? '' : String(error.stack || error.message || error);
+            value && value !== 'undefined' && pageErrors.push(value)
+        });
+
+        await page.goto('/apps/workstation/index.html');
+        await page.waitForSelector('.workstation-dock-host', {timeout: 60000});
+        await page.waitForSelector('.neo-tab-overflow-control', {timeout: 60000});
+        // The cap rides the same projection pass that syncs the control; the settle keeps this spec
+        // anchored on the control (which exists in every variant) so a cap-less build fails on the
+        // painted-intersection assertions below instead of a selector timeout.
+        await page.waitForTimeout(1200);
+
+        const facts = await page.evaluate(() => {
+            const rect = el => {
+                      const {left, right, top, bottom, width} = el.getBoundingClientRect();
+                      return {left, right, top, bottom, width}
+                  },
+                  overlap = (a, b) => Math.max(0,
+                      Math.min(a.right, b.right) - Math.max(a.left, b.left)) * Math.max(0,
+                      Math.min(a.bottom, b.bottom) - Math.max(a.top, b.top)),
+                  control = document.querySelector('.neo-tab-overflow-control'),
+                  capped  = document.querySelector('.neo-tab-overflow-capped'),
+                  toolbar = capped?.closest('.neo-tab-header-toolbar'),
+                  pressed = [...document.querySelectorAll('.neo-tab-header-button.pressed')];
+
+            return {
+                control: control && rect(control),
+                capped : capped && {
+                    rect         : rect(capped),
+                    maxWidth     : parseFloat(capped.style.maxWidth),
+                    textOverflow : getComputedStyle(capped.querySelector('.neo-button-text')).textOverflow,
+                    indicatorRect: rect(capped.querySelector('.neo-tab-button-indicator')),
+                    controlIx    : control ? overlap(rect(capped), rect(control)) : -1
+                },
+                toolbarRect: toolbar && rect(toolbar),
+                pressedIx  : pressed.map(button => ({
+                    text: button.textContent.trim(),
+                    ix  : control ? overlap(rect(button), rect(control)) : -1
+                })),
+                // Ordinary case: every pressed button OUTSIDE the overflowing header is uncapped and its
+                // absolute indicator spans its full box.
+                ordinary: pressed.filter(button => !button.classList.contains('neo-tab-overflow-capped'))
+                    .map(button => {
+                        const indicator = button.querySelector('.neo-tab-button-indicator');
+                        return {
+                            text       : button.textContent.trim(),
+                            hasCapStyle: !!button.style.maxWidth,
+                            widthDelta : indicator ? Math.abs(rect(indicator).width - rect(button).width) : null
+                        }
+                    })
+            }
+        });
+
+        expect(facts.control, 'precondition: the heavy header must render its overflow control at default boot').toBeTruthy();
+
+        // The symptom, first: no pressed button anywhere paints beneath the control. This is the
+        // assertion that convicts an uncapped build directly with the measured overlap in the message.
+        facts.pressedIx.forEach(entry => {
+            expect(entry.ix, `${entry.text}: pressed button must not intersect the overflow control`).toBe(0)
+        });
+
+        expect(facts.capped, 'the degenerate over-wide active must be capped — if no cap exists, the stage no longer exercises this branch and the spec must fail loudly').toBeTruthy();
+
+        // The core geometry: the capped active box — and the per-button indicator spanning it — ends
+        // where the control begins. Zero painted intersection.
+        expect(facts.capped.controlIx, 'capped active button must not intersect the overflow control').toBe(0);
+        expect(facts.capped.rect.right, 'capped box ends at or before the control edge').toBeLessThanOrEqual(facts.control.left + 0.5);
+        expect(
+            Math.abs(facts.capped.indicatorRect.width - facts.capped.rect.width),
+            'the per-button indicator spans exactly the capped box'
+        ).toBeLessThanOrEqual(1);
+
+        // Reservation truth (single value, render-grounded): the cap the plugin applied equals the
+        // toolbar extent minus the RENDERED control width — not the pre-creation estimate.
+        expect(
+            facts.capped.maxWidth,
+            `cap must derive from the rendered control width (extent ${facts.toolbarRect.width}, control ${facts.control.width})`
+        ).toBe(Math.floor(facts.toolbarRect.width) - Math.ceil(facts.control.width));
+
+        // The covered cut becomes an honest ellipsis.
+        expect(facts.capped.textOverflow, 'capped label must ellipsize').toBe('ellipsis');
+
+        // Ordinary headers (no overflow): full natural width, no stale cap, indicator spans the box.
+        expect(facts.ordinary.length, 'the app must also stage ordinary non-overflowing headers').toBeGreaterThan(0);
+        facts.ordinary.forEach(entry => {
+            expect(entry.hasCapStyle, `${entry.text}: an uncapped button must carry no maxWidth`).toBe(false);
+            entry.widthDelta !== null && expect(entry.widthDelta, `${entry.text}: indicator spans the full button`).toBeLessThanOrEqual(1)
+        });
+
+        expect(pageErrors, 'no page errors during the overflow-cap journey').toEqual([])
+    })
+});

--- a/test/playwright/unit/tab/plugin/Overflow.spec.mjs
+++ b/test/playwright/unit/tab/plugin/Overflow.spec.mjs
@@ -146,12 +146,13 @@ test.describe('Neo.tab.plugin.Overflow (re-entrancy contract)', () => {
             callCount  = 0;
 
         // first pass gates on getDomRect; the second project() call must queue rather than drop.
-        // A wide extent (button-id calls → per-button rects; the no-arg extent call → one wide rect)
-        // keeps nothing overflowing, so the pass completes cleanly through applySplit.
+        // A wide extent (button-id calls → per-button rects; the extent call — an array led by the
+        // owner id, optionally trailing the mounted control id — → one wide rect) keeps nothing
+        // overflowing, so the pass completes cleanly through applySplit.
         const plugin = createPlugin(async ids => {
             callCount++;
             if (callCount === 1) { await gate }
-            return ids ? [{width: 10}, {width: 10}] : {width: 1000}
+            return ids[0] === 'tab-overflow-test-owner' ? [{width: 1000}] : [{width: 10}, {width: 10}]
         });
 
         const first = plugin.project(false); // enters, latches, awaits the gate
@@ -187,7 +188,7 @@ test.describe('Neo.tab.plugin.Overflow (re-entrancy contract)', () => {
                 vdom: {removeDom: true}
             }),
             buttons = [makeButton('b1'), makeButton('b2')],
-            plugin  = createPlugin(async ids => ids ? [{width: 10}, {width: 10}] : {width: 1000});
+            plugin  = createPlugin(async ids => ids[0] === 'tab-overflow-test-owner' ? [{width: 1000}] : [{width: 10}, {width: 10}]);
 
         await new Promise(resolve => setTimeout(resolve, 0));
 
@@ -207,7 +208,7 @@ test.describe('Neo.tab.plugin.Overflow (re-entrancy contract)', () => {
     test('all-fit teardown: syncControl destroys and nulls the control when the overflow set empties (so a later overflow recreates a fresh one, not a dead instance)', async () => {
         // A wide extent keeps nothing overflowing, so the create-time auto-project (onOwnerMounted) settles
         // cleanly with no control; await a tick so it does not race the direct syncControl call below.
-        const plugin = createPlugin(async ids => ids ? [{width: 10}, {width: 10}] : {width: 1000});
+        const plugin = createPlugin(async ids => ids[0] === 'tab-overflow-test-owner' ? [{width: 1000}] : [{width: 10}, {width: 10}]);
         await new Promise(resolve => setTimeout(resolve, 0));
 
         let destroyed = false;
@@ -220,7 +221,7 @@ test.describe('Neo.tab.plugin.Overflow (re-entrancy contract)', () => {
     });
 
     test('an owner theme change is carried onto the live out-of-tree control', async () => {
-        const plugin = createPlugin(async ids => ids ? [{width: 10}, {width: 10}] : {width: 1000});
+        const plugin = createPlugin(async ids => ids[0] === 'tab-overflow-test-owner' ? [{width: 1000}] : [{width: 10}, {width: 10}]);
         await new Promise(resolve => setTimeout(resolve, 0));
 
         plugin.control = {theme: 'neo-theme-neo-dark'};
@@ -270,7 +271,7 @@ test.describe('Neo.tab.plugin.Overflow (re-entrancy contract)', () => {
         let   shouldThrow = false;
         const plugin      = createPlugin(async ids => {
             if (shouldThrow) { shouldThrow = false; throw new Error('transient measure failure') }
-            return ids ? [{width: 10}, {width: 10}] : {width: 1000}
+            return ids[0] === 'tab-overflow-test-owner' ? [{width: 1000}] : [{width: 10}, {width: 10}]
         });
         await new Promise(resolve => setTimeout(resolve, 0)); // auto-project settles (no throw)
 
@@ -292,7 +293,7 @@ test.describe('Neo.tab.plugin.Overflow (re-entrancy contract)', () => {
     });
 
     test('recreation: after an all-fit teardown, a subsequent overflow enters the CREATE branch (fresh instance, not a reused reference)', async () => {
-        const plugin = createPlugin(async ids => ids ? [{width: 10}, {width: 10}] : {width: 1000});
+        const plugin = createPlugin(async ids => ids[0] === 'tab-overflow-test-owner' ? [{width: 1000}] : [{width: 10}, {width: 10}]);
         await new Promise(resolve => setTimeout(resolve, 0)); // settle the create-time auto-project
 
         plugin.control = {destroy: () => {}};
@@ -329,7 +330,7 @@ test.describe('Neo.tab.plugin.Overflow (re-entrancy contract)', () => {
         // a tour reset) previously ratcheted into a permanent wedge: the update branch only
         // mutated menu items on the unmounted instance, and no path ever re-attempted the
         // mount. The re-arm makes the surface self-healing; this pins its full lifecycle.
-        const plugin = createPlugin(async ids => ids ? [{width: 10}, {width: 10}] : {width: 1000});
+        const plugin = createPlugin(async ids => ids[0] === 'tab-overflow-test-owner' ? [{width: 1000}] : [{width: 10}, {width: 10}]);
         await new Promise(resolve => setTimeout(resolve, 0));
 
         const hiddenMeta = [{text: 'Agents', iconCls: 'fa fa-users', index: 0}];
@@ -382,7 +383,7 @@ test.describe('Neo.tab.plugin.Overflow (re-entrancy contract)', () => {
     });
 
     test('re-arm skips a control whose own initVnode is still in flight (#16434)', async () => {
-        const plugin = createPlugin(async ids => ids ? [{width: 10}, {width: 10}] : {width: 1000});
+        const plugin = createPlugin(async ids => ids[0] === 'tab-overflow-test-owner' ? [{width: 1000}] : [{width: 10}, {width: 10}]);
         await new Promise(resolve => setTimeout(resolve, 0));
 
         let initCalls = 0;
@@ -411,7 +412,7 @@ test.describe('Neo.tab.plugin.Overflow (re-entrancy contract)', () => {
         // WHOLE deferral: repeated syncs must not register overlapping themeFilesLoaded
         // callbacks. Pre-repair the wrapper resolved early, the latch released, and every
         // sync stacked another listener (reviewer falsifier: registrations 1 → 2).
-        const plugin = createPlugin(async ids => ids ? [{width: 10}, {width: 10}] : {width: 1000});
+        const plugin = createPlugin(async ids => ids[0] === 'tab-overflow-test-owner' ? [{width: 1000}] : [{width: 10}, {width: 10}]);
         await new Promise(resolve => setTimeout(resolve, 0));
 
         const
@@ -474,7 +475,7 @@ test.describe('Neo.tab.plugin.Overflow (re-entrancy contract)', () => {
         // guard skipped every later sync and the promised retry never ran (reviewer
         // falsifier: create calls 1 → 1). The catch now releases the flag; this drives the
         // REAL initVnode through a rejecting Neo.vdom.Helper.create and proves the retry.
-        const plugin = createPlugin(async ids => ids ? [{width: 10}, {width: 10}] : {width: 1000});
+        const plugin = createPlugin(async ids => ids[0] === 'tab-overflow-test-owner' ? [{width: 1000}] : [{width: 10}, {width: 10}]);
         await new Promise(resolve => setTimeout(resolve, 0));
 
         // The Helper registers Neo.vdom.Helper at import time; this spec's own module graph
@@ -664,7 +665,7 @@ test.describe('Neo.tab.plugin.Overflow (tab-set mutation invalidation)', () => {
                       items          : [{id: 'b1'}, {id: 'b2'}],
                       parent,
                       getTheme       : function () { return this.theme },
-                      getDomRect     : async ids => ids ? [{width: 10}, {width: 10}] : {width: 1000},
+                      getDomRect     : async ids => ids[0] === 'tab-overflow-test-owner' ? [{width: 1000}] : [{width: 10}, {width: 10}],
                       add            : () => ({}),
                       addDomListeners: () => {},
                       remove         : () => {},

--- a/test/playwright/unit/tab/plugin/Overflow.spec.mjs
+++ b/test/playwright/unit/tab/plugin/Overflow.spec.mjs
@@ -58,6 +58,35 @@ class ThemeOwner extends ThemeAncestor {
 ThemeOwner = Neo.setupClass(ThemeOwner);
 
 /**
+ * @summary Mountable control fixture: a real config-system instance, so the plugin's
+ * `observeConfig('mounted')` render-truth projection edge fires exactly as it would on a
+ * component embodiment, without needing the full button.Base construction unit mode lacks.
+ */
+class MountableControl extends Neo.core.Base {
+    static config = {
+        className: 'Test.Unit.Tab.Plugin.Overflow.MountableControl',
+        mounted_ : false
+    }
+
+    isVnodeInitializing = false
+    menuList = null
+
+    /**
+     * Alignment seam consumed by syncControl on mounted controls.
+     */
+    alignTo() {}
+
+    /**
+     * Re-arm seam; unused in these tests but part of the control contract.
+     * @returns {Promise<void>}
+     */
+    initVnode() {
+        return Promise.resolve()
+    }
+}
+MountableControl = Neo.setupClass(MountableControl);
+
+/**
  * @summary Focused tests for the Neo.tab.plugin.Overflow re-entrancy contract — the part of
  * the runtime overflow plugin that must survive a resize / activation storm without stranding state.
  *
@@ -528,6 +557,177 @@ test.describe('Neo.tab.plugin.Overflow (re-entrancy contract)', () => {
             Neo.vdom.Helper.create = originalCreate;
             console.error = originalError;
             originalApp === undefined ? delete Neo.apps['test-app'] : Neo.apps['test-app'] = originalApp;
+            control.destroy()
+        }
+    })
+});
+
+test.describe('Neo.tab.plugin.Overflow (cap ownership + reservation lifecycle)', () => {
+    let Overflow;
+
+    test.beforeAll(async () => {
+        Overflow = (await import('../../../../../src/tab/plugin/Overflow.mjs')).default
+    });
+
+    const
+
+        settle = () => new Promise(resolve => setTimeout(resolve, 10)),
+
+        /** A tab-button stub carrying the public channels the cap contract touches. */
+        makeCapButton = (id, config = {}) => ({
+            cls     : [],
+            hidden  : false,
+            id,
+            maxWidth: null,
+            style   : {},
+            vdom    : {},
+            addCls(value) { !this.cls.includes(value) && this.cls.push(value) },
+            removeCls(value) { this.cls = this.cls.filter(item => item !== value) },
+            setSilent(values) { Object.assign(this, values) },
+            show() {
+                this.hidden = false;
+                delete this.vdom.removeDom
+            },
+            ...config
+        }),
+
+        /** A toolbar-owner stub with the parent seam the active-button resolution needs. */
+        createCapPlugin = ({buttons, getDomRect}) => Neo.create(Overflow, {
+            owner: {
+                id      : 'cap-owner',
+                appName : 'test-app',
+                items   : buttons,
+                mounted : true,
+                parent  : {activeIndex: 0, on() {}},
+                theme   : 'neo-theme-neo-dark',
+                windowId: 1,
+                getDomRect,
+                getTheme() { return this.theme },
+                add            : () => ({}),
+                addDomListeners() {},
+                on() {},
+                un() {},
+                remove() {},
+                promiseUpdate: async () => {},
+                update() {}
+            }
+        });
+
+    test('render-truth edge: the pass that creates the control converges estimate→rendered at mount, no external event needed', async () => {
+        const
+            b1         = makeCapButton('b1'),
+            b2         = makeCapButton('b2'),
+            control    = Neo.create(MountableControl),
+            origCreate = Neo.create;
+
+        let createdConfig = null;
+
+        // The projection's create branch must receive a real config-system instance (the mounted
+        // observer is the contract under test); spy only the single-object component create.
+        Neo.create = (a, b) => a?.module ? (createdConfig = a, control) : origCreate(a, b);
+
+        try {
+            const plugin = createCapPlugin({
+                buttons   : [b1, b2],
+                // extent 236; rendered control 49 — measurable only once mounted. Naturals: the
+                // active b1 (227) alone exceeds usable, staging the degenerate cap.
+                getDomRect: async ids => ids[0] === 'cap-owner'
+                    ? (ids.length === 2 ? [{width: 236}, {width: 49}] : [{width: 236}])
+                    : [{width: 227}, {width: 100}]
+            });
+
+            await settle();
+
+            // The reviewer-falsified state, now pinned as the INTERMEDIATE contract: the single
+            // projection that created the (unmounted) control could only use the estimate…
+            expect(createdConfig, 'the projection created the control').toBeTruthy();
+            expect(plugin.measuredControlWidth, 'no render truth exists before the mount').toBe(null);
+            expect(b1.maxWidth, 'the cap uses the pre-creation estimate').toBe(236 - 40);
+            expect(plugin.projectQueued, 'and no external pass is owed').toBe(false);
+
+            // …and the mount itself is the projection edge: no resize, activation, or tab
+            // mutation occurs past this line.
+            control.mounted = true;
+            await settle();
+
+            expect(plugin.measuredControlWidth, 'the mount edge measured the rendered control').toBe(49);
+            expect(b1.maxWidth, 'the cap converged to the rendered reservation').toBe(236 - 49);
+
+            plugin.destroy()
+        } finally {
+            Neo.create = origCreate;
+            control.destroy()
+        }
+    });
+
+    test('a consumer-configured maxWidth is never plugin residue: ordinary and recapture passes leave it untouched', async () => {
+        const
+            b1     = makeCapButton('b1'),
+            b2     = makeCapButton('b2', {maxWidth: 120, style: {color: 'red', maxWidth: '120px'}}),
+            plugin = createCapPlugin({
+                buttons   : [b1, b2],
+                getDomRect: async ids => ids[0] === 'cap-owner' ? [{width: 1000}] : [{width: 100}, {width: 100}]
+            });
+
+        await settle();
+
+        expect(b2.maxWidth, 'consumer maxWidth config preserved on the ordinary pass').toBe(120);
+        expect(b2.style, 'consumer style object untouched').toEqual({color: 'red', maxWidth: '120px'});
+        expect(b2.cls, 'no plugin cap marker').toEqual([]);
+        expect(plugin.appliedCaps, 'no ownership recorded for consumer values').toBe(null);
+
+        await plugin.project(true);
+
+        expect(b2.maxWidth, 'recapture does not classify the consumer value as residue').toBe(120);
+        expect(b2.style).toEqual({color: 'red', maxWidth: '120px'});
+
+        plugin.destroy()
+    });
+
+    test('cap → recapture → no-overflow restores the exact caller value through the public channel', async () => {
+        const
+            b1         = makeCapButton('b1', {maxWidth: 300}),
+            b2         = makeCapButton('b2'),
+            control    = Neo.create(MountableControl),
+            origCreate = Neo.create;
+
+        let extent = 236;
+
+        Neo.create = (a, b) => a?.module ? control : origCreate(a, b);
+
+        try {
+            const plugin = createCapPlugin({
+                buttons   : [b1, b2],
+                getDomRect: async ids => ids[0] === 'cap-owner'
+                    ? (ids.length === 2 ? [{width: extent}, {width: 49}] : [{width: extent}])
+                    : [{width: 227}, {width: 100}]
+            });
+
+            await settle();
+
+            // Stage 1 — capped: provenance recorded with the caller's own ceiling.
+            expect(plugin.appliedCaps?.get('b1'), 'the caller value is recorded at cap time').toBe(300);
+            expect(b1.maxWidth, 'the cap overrides through the same public channel').toBe(236 - 40);
+            expect(b1.cls, 'the cap marker is present').toContain('neo-tab-overflow-capped');
+
+            // Stage 2 — recapture: the lift restores the caller value for measurement, then the
+            // split re-caps; the recorded provenance survives un-overwritten.
+            await plugin.project(true);
+
+            expect(plugin.appliedCaps?.get('b1'), 'recapture must not re-record the plugin cap as prior').toBe(300);
+            expect(b1.maxWidth, 'the re-applied cap holds after recapture').toBe(236 - 40);
+
+            // Stage 3 — the overflow retires: the exact caller value returns.
+            extent = 1000;
+            await plugin.project(false);
+
+            expect(b1.maxWidth, 'the exact caller value is restored').toBe(300);
+            expect(b1.cls, 'the cap marker is removed').toEqual([]);
+            expect(plugin.appliedCaps?.size ?? 0, 'the ledger empties').toBe(0);
+
+            plugin.destroy()
+        } finally {
+            Neo.create = origCreate;
             control.destroy()
         }
     })


### PR DESCRIPTION
Resolves #16424

The active tab can no longer paint beneath the floating overflow control. Two changes in `Neo.tab.plugin.Overflow`, both at the layer the ticket's own reproduce-first AC surfaced: (1) in the degenerate active-never-hidden branch (active alone wider than the usable strip), `applySplit` now bounds the active button's box with an inline `max-width` — and because the persistent `.neo-tab-button-indicator` is an absolute child spanning that box, and the strip's crossfade indicator sizes from that rect, and the label lives inside it, all three painted layers inherit the correction from the single geometry they derive from; a `neo-tab-overflow-capped` cls turns the previously covered label cut into an honest ellipsis. (2) The reservation handed to `computeOverflow` is now `max(controlWidth config, rendered control width)` — the control's real width rides the same `getDomRect` round-trip as the extent (zero added latency), closing a measured `9px` under-reservation (config `40`, rendered `49`) that let packed buttons underlap the control with no degenerate case involved. The cap lifts under the recapture latch before natural-width measurement, so a capped rect can never poison the natural-width cache. The pure `computeOverflow` core is untouched.

Evidence: L3 (live measured receipts on the workstation heavy header + red/green stash cycle + unit/e2e batteries below) → L3 required (the ACs are painted-geometry relationships). Residual: none.

## Deltas from ticket

- **Mechanism reframe (classification r1 on the ticket):** the prescribed options clamp inside `Strip.moveActiveIndicator`, but reproduction showed the ticket's named element is a ~300ms crossfade flash (`width: 0, opacity: 0` at rest — the ticket's own trap datum, now explained); the persistent segment is the per-button `.neo-tab-button-indicator`, and the BUTTON box is the root geometry. The fix moved one layer up so one owner corrects all three painted layers; `Strip.mjs` is deliberately untouched, and option 2's plugin↔Strip contract never becomes necessary.
- **The "reserves correctly" out-of-scope premise was falsified by measurement** (`40` config vs `49` rendered), so the reservation-truth half landed here rather than as a papered-over constant bump — the measured width self-maintains across skins.
- **Unit-stub seam update:** the extent read changed shape (`getDomRect()` no-arg → `getDomRect([ownerId(, controlId)])`, one round-trip). The plugin unit spec's lean-owner stubs keyed on call arity; they now key on content (`ids[0] === ownerId`). Real `component.getDomRect` handles both shapes; no runtime consumer changes.
- **AC5 verdict (vertical tab bars):** the plugin packs widths against a horizontal strip extent and is mounted by dock compositions with `top`/`bottom` headers only; a vertical bar never mounts it, so the vertical `moveActiveIndicator` branch has no overflow control to collide with. Stated in `applySplit`'s JSDoc rather than a vacuous vertical spec.

## Test Evidence

New witness `test/playwright/e2e/workstation/WorkstationTabOverflowCapNL.spec.mjs` — the workstation heavy header stages the degenerate branch at default `1180x840` boot (twelve canonical titles in a narrow pane; the ticket author could not stage overflow because this composition is where it lives). Asserts, in symptom-first order: zero pressed-button ∩ control intersection anywhere, the capped box ends at the control edge, the per-button indicator spans exactly the capped box, `maxWidth === floor(extent) − ceil(rendered control width)` (AC4's same-value, render-grounded), ellipsis on the capped label, and full-width/no-cap on every ordinary header (AC3).

- Head: `1 passed` ×4 (`NEO_E2E_PORT=8156 npx playwright test workstation/WorkstationTabOverflowCapNL -c test/playwright/playwright.config.e2e.mjs --workers=1`).
- Red-proof (fix stashed, themes rebuilt): `1 failed` in 2.7s convicting on the symptom — `Priority Alert Observatory: pressed button must not intersect the overflow control` (the live baseline overlap measures `39.6px × 48px`).
- Live receipts at head: cap `187px = floor(236.5) − ceil(49)`; capped box right `822.5` against control left `823`; all pressed-button intersections `0`; `text-overflow: ellipsis` computed.
- Unit: `test/playwright/unit/tab/` + `unit/dashboard/DockLayoutAdapter.spec.mjs` → `62 passed` (plugin file 23/23 ×3 head AND ×3 stashed-baseline; one early single-run flake of the theme-deferral test did not reproduce in 7 subsequent runs on either state).
- e2e adjacency: `dashboard/DockTabOverflowNL` (the generic floating-control journey: alignment, menu, partition, selection) + `workstation/WorkstationNL` full dense tour (26.2s — the tour drives this exact control via `getPlugin('tab-overflow')`) + overflow-menu theme test → `3 passed`.

Surface coverage — `src/tab/plugin/Overflow.mjs`: `unit/tab/plugin/Overflow.spec.mjs`, `e2e/dashboard/DockTabOverflowNL`, `e2e/workstation/WorkstationTabOverflowCapNL` (new); `apps/workstation`: `WorkstationNL`, `WorkstationTabOverflowCapNL`.

## Post-Merge Validation

- [ ] The operator's originating frame (heavy header, long active title beside the `…` control) shows the underline stopping at the control edge with an ellipsized label during the next film-take rehearsal.
- [ ] A dock composition with a customized control skin (wider than `49px`) keeps buttons clear of the control — the measured reservation should self-maintain; worth one glance if any skin restyles `.neo-tab-overflow-control`.

Authored by Mnemosyne (Fable 5, Claude Code). Session 1913de09-6dc0-4d1e-a9a3-b51c33b46cdc.
