### PR TITLE
An empty guarded env is two observations, and provenance tells them apart

### DIFF
--- a/ai/scripts/maintenance/deploymentMigrationCore.mjs
+++ b/ai/scripts/maintenance/deploymentMigrationCore.mjs
@@ -238,6 +238,11 @@ function normalizeFinding(finding) {
  *                                              stay **per service**; a union credits one service with another's
  *                                              configuration and blames it for keys it never declares.
  * @param {Object}   config.serviceScopes        Service name → Set of env keys that service's config template declares.
+ * @param {Object}   [config.observationByService] Service name → `{inspected, configRead}` provenance. An empty
+ *                                              guarded set is ambiguous on its own: a container that could not be
+ *                                              read and one that legitimately carries no Neo config both yield an
+ *                                              empty Map. Provenance is the discriminator, and its ABSENCE is
+ *                                              treated as unmeasured so a caller cannot authorize by omission.
  * @param {Object}   config.census               Output of {@link resolveCensus}.
  * @param {Object}   [config.desiredEnv]         Service name → `{KEY: value}` the operator declares for the transition.
  * @param {Object}   config.composeIdentity      `{project, configFiles}` read off the running plane; `null` when undiscoverable.
@@ -248,7 +253,7 @@ function normalizeFinding(finding) {
  */
 export function buildMigrationPlan({
     observedEnvByService, serviceScopes, census, desiredEnv = {}, composeIdentity, deployedRevisions,
-    targetRevision, uncheckedNotes = []
+    targetRevision, uncheckedNotes = [], observationByService = null
 }) {
     const blockers         = [],
           unchecked        = [...uncheckedNotes],
@@ -292,13 +297,41 @@ export function buildMigrationPlan({
 
         scope.forEach(key => attributed.add(key));
 
-        if (!(observed instanceof Map) || observed.size === 0) {
+        // An empty guarded set is TWO different observations wearing one value, and the discriminator is
+        // provenance rather than the value itself:
+        //
+        //   the container was never read      -> not measured; blocks, and this is the case the refusal
+        //                                        exists for (a stopped container emits nothing, and silence
+        //                                        is not evidence that config is absent)
+        //   the container was read, set empty -> the service carries no Neo config; owes nothing
+        //
+        // Chroma is the live instance of the second: `docker inspect` succeeds and its guarded set is empty,
+        // because it is a third-party image with no Neo configuration surface. Conflating the two refused
+        // every real plane for a service behaving correctly.
+        //
+        // Provenance ABSENT is treated as not-measured, never as empty-by-design — a caller that omits the
+        // discriminator must not be able to authorize by omission.
+        const provenance = observationByService?.[service],
+              wasRead    = provenance?.configRead === true;
+
+        if (!wasRead) {
             blockers.push({
-                kind  : 'no-observed-env',
+                kind  : 'service-unmeasured',
                 key   : service,
-                reason: `no guarded env was read from service '${service}' — its container may not be running, and ` +
-                        'silence from an unreachable service is not evidence that its config is absent'
+                reason: provenance
+                    ? `service '${service}' was not read (container found: ${provenance.inspected === true}), so its ` +
+                      'config is unestablished — silence from an unreachable service is not evidence of absence'
+                    : `no observation provenance was supplied for service '${service}', so whether its config was ` +
+                      'read cannot be established; treated as unmeasured rather than assumed empty'
             });
+
+            return
+        }
+
+        if (!(observed instanceof Map) || observed.size === 0) {
+            // Read and legitimately empty. Reported so an operator sees the service was inspected and found
+            // irrelevant, rather than it silently vanishing from the plan.
+            notes.push(`service '${service}': read, carries no guarded NEO_/MCP_ config — nothing owed`);
 
             return
         }

--- a/ai/scripts/maintenance/migrateDeployment.mjs
+++ b/ai/scripts/maintenance/migrateDeployment.mjs
@@ -254,7 +254,8 @@ async function discoverProject(services, declaredProject) {
 async function inspectPlane(project, services, revisionServices = services) {
     const deployedRevisions    = {},
           unchecked            = [],
-          observedEnvByService = {};
+          observedEnvByService = {},
+          observationByService = {};
 
     let composeIdentity = null;
 
@@ -270,6 +271,7 @@ async function inspectPlane(project, services, revisionServices = services) {
 
         if (!containerName) {
             deployedRevisions[service] = null;
+            observationByService[service] = {inspected: false, configRead: false};
             unchecked.push(`service '${service}': no container under project '${project}' — not inspected`);
             continue
         }
@@ -295,6 +297,12 @@ async function inspectPlane(project, services, revisionServices = services) {
         if (parsedConfig) {
             observedEnvByService[service] = parseObservedEnv(parsedConfig.Env || [])
         }
+
+        // Provenance, reported rather than discarded. These two facts are already known here and nowhere
+        // else: an empty guarded set means "not measured" when the read failed and "carries no Neo config"
+        // when it succeeded, and the pure core cannot tell them apart from the Map alone. Chroma is the live
+        // case — inspect succeeds, guarded set is empty, and conflating the two refused every real plane.
+        observationByService[service] = {inspected: true, configRead: Boolean(parsedConfig)};
 
         if (parsedConfig && !composeIdentity) {
             // The first service that yields labels establishes the plane's identity: every service in
@@ -331,7 +339,7 @@ async function inspectPlane(project, services, revisionServices = services) {
         }
     }
 
-    return {composeIdentity, deployedRevisions, unchecked, observedEnvByService}
+    return {composeIdentity, deployedRevisions, unchecked, observedEnvByService, observationByService}
 }
 
 /**
@@ -706,7 +714,7 @@ async function main() {
         console.log(`[migrate] config cohort (discovered): ${configServices.join(', ')}`)
     }
 
-    const [{composeIdentity, deployedRevisions, unchecked, observedEnvByService}, {revision: targetRevision, error: targetError}] = await Promise.all([
+    const [{composeIdentity, deployedRevisions, unchecked, observedEnvByService, observationByService}, {revision: targetRevision, error: targetError}] = await Promise.all([
         inspectPlane(project, configServices, options.services),
         resolveTargetRevision(options.repoUrl, options.target)
     ]);
@@ -742,6 +750,7 @@ async function main() {
 
     const plan = buildMigrationPlan({
         observedEnvByService,
+        observationByService,
         serviceScopes,
         census,
         desiredEnv    : options.desiredEnv,

--- a/test/playwright/unit/ai/scripts/maintenance/deploymentMigrationCore.spec.mjs
+++ b/test/playwright/unit/ai/scripts/maintenance/deploymentMigrationCore.spec.mjs
@@ -56,9 +56,19 @@ function createScopes(keys = ['NEO_REQ_ONE', 'NEO_REQ_TWO', 'NEO_OPT', 'NEO_BANN
  * A plan input whose every field is valid, so each test perturbs one thing and the resulting blocker is
  * attributable to that perturbation.
  */
+/**
+ * Provenance for a fully-measured cohort. Supplied by default because its ABSENCE is a refusal: an empty
+ * guarded set means "not measured" or "carries no Neo config" depending on whether the read succeeded, and
+ * a caller that omits the discriminator must not be able to authorize by omission.
+ */
+function createObservation(services = COHORT, overrides = {}) {
+    return {...Object.fromEntries(services.map(service => [service, {inspected: true, configRead: true}])), ...overrides}
+}
+
 function createPlanInput(overrides = {}) {
     return {
         observedEnvByService: createObserved(),
+        observationByService: createObservation(),
         serviceScopes       : createScopes(),
         census              : createCensus(),
         composeIdentity     : {project: 'neo-local-agent-os', configFiles: ['/x/base.yml', '/x/overlay.yml']},
@@ -216,19 +226,80 @@ test.describe('buildMigrationPlan gates apply', () => {
         }
     });
 
-    test('a service observed as empty blocks per service — silence from an unreachable container is not absence', () => {
-        // The failure this encodes: `docker exec` against a stopped container emits nothing and exits
-        // non-zero, so an empty observation means "not measured", never "no config set".
+    test('an UNREAD service blocks — silence from an unreachable container is not absence', () => {
+        // The failure this encodes: `docker exec`/`inspect` against a stopped container emits nothing, so an
+        // empty observation from a failed read means "not measured", never "no config set". I published three
+        // false facts off exactly that silence.
         const plan = buildMigrationPlan(createPlanInput({
-            observedEnvByService: {...createObserved(), orchestrator: new Map()}
+            observedEnvByService: {...createObserved(), orchestrator: new Map()},
+            observationByService: createObservation(COHORT, {orchestrator: {inspected: true, configRead: false}})
         }));
 
         expect(plan.clean).toBe(false);
 
-        const blocker = plan.blockers.find(entry => entry.kind === 'no-observed-env');
+        const blocker = plan.blockers.find(entry => entry.kind === 'service-unmeasured');
 
         expect(blocker.key).toBe('orchestrator');
-        expect(blocker.reason).toContain('not be running')
+        expect(blocker.reason).toContain('not evidence of absence')
+    });
+
+    test('a READ service with a legitimately empty guarded set owes nothing, and says so', () => {
+        // Chroma is the live instance: `docker inspect` succeeds and the guarded set is empty, because it is a
+        // third-party image with no Neo configuration surface. Conflating this with an unread container refused
+        // every real plane for a service behaving correctly. Measured before/after: 13 blockers -> 12.
+        const plan = buildMigrationPlan(createPlanInput({
+            observedEnvByService: {...createObserved(), chroma: new Map()},
+            observationByService: createObservation([...COHORT, 'chroma']),
+            serviceScopes       : {...createScopes(), chroma: new Set()}
+        }));
+
+        expect(plan.blockers.filter(entry => entry.key === 'chroma')).toEqual([]);
+
+        // Visible, not silent: an operator must see the service was inspected and found irrelevant.
+        expect(plan.notes.some(note => note.includes("service 'chroma'") && note.includes('nothing owed'))).toBe(true)
+    });
+
+    test('the same empty Map yields OPPOSITE verdicts depending only on provenance', () => {
+        // The state the prior fixtures could not represent, which is why this class was missed: they always
+        // populated every observed service, so observed-and-empty had no representation at all. Both cases
+        // below pass an IDENTICAL empty Map; only the discriminator differs.
+        const observedEnvByService = {...createObserved(), chroma: new Map()},
+              scopes               = {...createScopes(), chroma: new Set()},
+              read                 = buildMigrationPlan(createPlanInput({
+                  observedEnvByService, serviceScopes: scopes,
+                  observationByService: createObservation([...COHORT, 'chroma'])
+              })),
+              unread               = buildMigrationPlan(createPlanInput({
+                  observedEnvByService, serviceScopes: scopes,
+                  observationByService: createObservation([...COHORT, 'chroma'], {chroma: {inspected: true, configRead: false}})
+              }));
+
+        expect(read.blockers.filter(entry => entry.key === 'chroma')).toEqual([]);
+        expect(unread.blockers.find(entry => entry.key === 'chroma').kind).toBe('service-unmeasured')
+    });
+
+    test('the discriminator is provenance, not an image allowlist — no third-party name in the source', async () => {
+        // Deliberately a STRUCTURAL claim, which is all a source-text guard can carry: allowlisting `chroma`
+        // would fix this plane and mis-handle the next third-party service, the same hardcode that cohort
+        // discovery removed one layer up. The behavioural claims are the specs above.
+        for (const rel of ['ai/scripts/maintenance/deploymentMigrationCore.mjs', 'ai/scripts/maintenance/migrateDeployment.mjs']) {
+            const source = await fs.readFile(path.join(repoRoot, rel), 'utf8'),
+                  code   = source.split('\n').filter(line => !/^\s*(\/\/|\*|\/\*)/.test(line)).join('\n');
+
+            expect(code, `${rel} must not name a third-party service`).not.toMatch(/['"`]chroma['"`]/);
+            expect(code, `${rel} must not name the proxy service`).not.toMatch(/['"`]ingress['"`]/)
+        }
+    });
+
+    test('ABSENT provenance fails closed — a caller cannot authorize by omission', () => {
+        const plan = buildMigrationPlan(createPlanInput({observationByService: null}));
+
+        expect(plan.clean).toBe(false);
+
+        const blockers = plan.blockers.filter(entry => entry.kind === 'service-unmeasured');
+
+        expect(blockers.length).toBe(COHORT.length);
+        expect(blockers[0].reason).toContain('no observation provenance')
     });
 
     test('observations are NOT unioned: a key set on one service does not satisfy another', () => {


### PR DESCRIPTION
Resolves #16491

Evidence: L3 — read-only `plan` runs against the canonical local plane, plus unit specs and the existing real-driver witness. Nothing was mutated; `plan` never touches a container.

## One empty Map was standing in for two different observations

`no-observed-env` blocked any service yielding no guarded `NEO_`/`MCP_` env, on reasoning that is correct and was earned: silence from an unreachable container is not evidence its config is absent. I published three false facts off exactly that silence earlier the same day, reading `docker exec` output from an `Exited(1)` orchestrator.

Then #16454 widened the config cohort from three named services to the plane's discovered service list, and chroma tripped the blocker on every real plane. Measured: `docker inspect` on the chroma container **succeeds**, and its `Config.Env` contains **zero** keys matching `^(NEO|MCP)_`. It is `chromadb/chroma:1.5.9` — a third-party image with no Neo configuration surface.

| observation | meaning | disposition |
|---|---|---|
| read failed / container absent | **not measured** | blocks — the case the refusal exists for |
| read succeeded, guarded set empty | **carries no Neo config** | owes nothing |

The pure core cannot recover that difference from the `Map`, so it has to be *given* it.

## The fix

`inspectPlane` reports the two facts it already held and discarded — whether a container was found, and whether its config parsed. `buildMigrationPlan` then raises `service-unmeasured` on the unread case, naming its cause instead of inferring it from an empty result, and emits a **note** for a read-and-empty service so an operator sees it was inspected and found irrelevant rather than silently absent from the plan.

**Provenance absent is treated as unmeasured**, never as empty-by-design, so a caller that omits the discriminator cannot authorize by omission.

**Provenance, not an allowlist.** Allowlisting `chroma` would fix this plane and mis-handle the next third-party service — the same hardcode cohort discovery removed one layer up. A structural guard asserts no third-party or proxy service name appears in either module's code, with the comment lines stripped so prose explaining the reasoning cannot satisfy it.

## Test Evidence

```
node ai/scripts/maintenance/migrateDeployment.mjs plan --project neo-local-agent-os
  config cohort (discovered): chroma, ingress, kb-server, mc-server, orchestrator
  BLOCKERS (12) — apply is refused
  · service 'chroma': read, carries no guarded NEO_/MCP_ config — nothing owed
```

13 → 12 blockers, `no-observed-env: chroma` gone, chroma visible as a note, and the genuine kb-server/mc-server contract violations unaffected.

```
npx playwright test -c test/playwright/playwright.config.unit.mjs --workers=1 \
  test/playwright/unit/ai/scripts/maintenance/deploymentMigrationCore.spec.mjs \
  test/playwright/unit/ai/MigrateDeploymentApplyRefusal.spec.mjs
  67 passed
```

**64 specs** in the core file. The real-driver witness passes **unchanged**, which is the provenance path exercised end to end rather than a second mock of it.

**The spec worth reading is the one representing what the old fixtures could not.** Two plans built from an *identical* empty `Map` now reach opposite verdicts, differing only in the discriminator. The prior fixtures always populated every observed service, so observed-and-empty had no representation at all — which is precisely why the unit suite missed this and the integration witness caught it on first contact with a real plane.

## Post-Merge Validation

- [ ] One authorized `apply` against a real plane — **@tobiu's authority**; nothing here performs it.

## Deltas

- `ai/scripts/maintenance/migrateDeployment.mjs` — `observationByService` recorded in `inspectPlane` and threaded to the plan.
- `ai/scripts/maintenance/deploymentMigrationCore.mjs` — `service-unmeasured` replaces the ambiguous refusal; read-and-empty becomes a note. Still pure: no Neo import, no Docker call, no filesystem read.
- `test/playwright/unit/.../deploymentMigrationCore.spec.mjs` — provenance in the shared fixture (its absence is a refusal, so it must be supplied deliberately), five new specs, and the structural guard.
- **Substrate accretion:** no new module, no new config leaf, no new CLI flag. Sunset condition: retires with the migration bootstrap itself.
- Deliberately **not** here: the kb-server/mc-server census discrepancy (its own ticket — the root config base declares those leaves for all three servers while the profile sets them only on the orchestrator), and RA3's pinned disposable fixture (#16455 owns the standing form).

Authored by Vega (Claude Opus 5, Claude Code). Session 11695cce-9854-4be2-80c3-8ea4322298bf.
