### PR TITLE
The update-chain goal bar lands red, naming which legs are missing

### DIFF
--- a/test/playwright/playwright.config.mjs
+++ b/test/playwright/playwright.config.mjs
@@ -20,6 +20,15 @@ process.env.NEO_E2E_PORT = String(PORT);
 export default defineConfig({
     testDir      : __dirname,
     testMatch    : /.*\.spec\.mjs/,
+    // The update-chain goal bar is DELIBERATELY red until its legs land, and it is opt-in via its own
+    // config. Without this ignore it is collected here too, because `testDir` is the whole tree and
+    // `testMatch` takes every spec — so the repo's headline local command would run a scenario built to
+    // fail, which is exactly how a permanently-red check gets routed around within a week.
+    //
+    // Enforced rather than incidental: the aggregate runner also sets `retries` below, which would defeat
+    // that project's deliberate `retries: 0` invariant — a goal bar passing on attempt two has already
+    // told you the chain is unreliable.
+    testIgnore   : /update-chain\//,
     outputDir    : path.join(__dirname, 'test-results/all'),
     fullyParallel: false,
     forbidOnly   : !!process.env.CI,

--- a/test/playwright/playwright.config.update-chain.mjs
+++ b/test/playwright/playwright.config.update-chain.mjs
@@ -1,0 +1,58 @@
+import {defineConfig}        from '@playwright/test';
+import {resolveFreePortSync} from './resolveFreePort.mjs';
+
+/**
+ * The Epic's goal bar, as an executable scenario.
+ *
+ * ## Why this is its OWN project rather than a spec inside `integration-parity`
+ *
+ * `integration-parity` already provisions a disposable Compose plane and is already in the default CI gate.
+ * Reusing it would have been the cheaper edit and it is the wrong one: this scenario lands **red** while the
+ * implementation leaves of its Epic are open, so adding it to a gated project turns the shared gate red on
+ * day one. A permanently-red check in the default gate gets routed around within a week and stops meaning
+ * anything — which the source ticket names as a trap against itself.
+ *
+ * So: a separate project, **absent from `.github/workflows/`** until it goes green. Moving it into the gate
+ * is the ticket's completion condition, not a follow-up.
+ *
+ * ## Why it is opt-in rather than skipped
+ *
+ * A `test.skip` inside a gated project reads as green and proves nothing. An unreferenced config cannot read
+ * as anything — it either was not run, or it ran and reported. Absence of a workflow entry is the honest
+ * form of "not yet gated".
+ *
+ * Run it deliberately:
+ *
+ * ```
+ * npx playwright test -c test/playwright/playwright.config.update-chain.mjs
+ * ```
+ */
+// Sync and env-overridable, matching the sibling parity config: a pinned positive integer is honoured
+// unchanged so CI can fix the port, and only an unset value gets probed.
+const readyPort = resolveFreePortSync(process.env.NEO_UPDATE_CHAIN_READY_PORT);
+
+process.env.NEO_UPDATE_CHAIN_READY_PORT = String(readyPort);
+
+export default defineConfig({
+    testDir      : './update-chain',
+    outputDir    : './test-results/update-chain/artifacts',
+    fullyParallel: false,
+    workers      : 1,
+    // A provisioning-plus-migration round is minutes, not seconds: an image build, two health windows and a
+    // recreate. The budget is an upper bound rather than a target — the wall-clock receipt belongs in the
+    // scenario's own output, so a slow pass is distinguishable from a hang.
+    timeout      : 900000,
+
+    // No retries. A flaky goal bar is not a goal bar: a scenario that passes on attempt two has told you the
+    // chain is unreliable, and retrying converts that finding into a green tick.
+    retries      : 0,
+
+    reporter: [
+        ['list'],
+        ['json', {outputFile: 'test-results/update-chain/results.json'}]
+    ],
+
+    use: {
+        trace: 'on-first-retry'
+    }
+});

--- a/test/playwright/update-chain/UpdateChainGoal.spec.mjs
+++ b/test/playwright/update-chain/UpdateChainGoal.spec.mjs
@@ -35,36 +35,45 @@ const execFileAsync = promisify(execFile),
  * unmet one by name rather than reporting a single opaque red.
  * @type {Object[]}
  */
+// `surface` is the path whose existence is taken as evidence the leg has a shipped implementation.
+// `null` means no surface is known yet, and the leg reports missing on that basis — wrong by
+// OMISSION, which the next author corrects in one line, rather than wrong by construction.
 const CHAIN_LEGS = [
     {
-        key  : 'candidate-retained',
-        owner: '#16450',
-        what : 'a merged cohort produces a retained, addressable candidate carrying an exact digest'
+        key    : 'candidate-retained',
+        owner  : '#16450',
+        surface: null,
+        what   : 'a merged cohort produces a retained, addressable candidate carrying an exact digest'
     },
     {
-        key  : 'selection-bounded',
-        owner: '#16451',
-        what : 'selection takes the latest compatible staged cohort, or produces an explicit ineligibility record'
+        key    : 'selection-bounded',
+        owner  : '#16451',
+        surface: null,
+        what   : 'selection takes the latest compatible staged cohort, or produces an explicit ineligibility record'
     },
     {
-        key  : 'admissibility-answerable',
-        owner: '#16453',
-        what : 'a predicate answers whether the target may take the cohort, resolving unknown to NOT admissible'
+        key    : 'admissibility-answerable',
+        owner  : '#16453',
+        surface: 'ai/scripts/setup/cohortAdmissibility.mjs',
+        what   : 'a predicate answers whether the target may take the cohort, resolving unknown to NOT admissible'
     },
     {
-        key  : 'activation-sole-path',
-        owner: '#16452',
-        what : 'a durable receipt links a fresh RESTORABLE result before first mutation, or no mutation occurs'
+        key    : 'activation-sole-path',
+        owner  : '#16452',
+        surface: 'ai/services/shared/activationReceipt.mjs',
+        what   : 'a durable receipt links a fresh RESTORABLE result before first mutation, or no mutation occurs'
     },
     {
-        key  : 'exact-revision-arrived',
-        owner: '#16454',
-        what : 'every service in the cohort reports the EXACT resolved target at /app/.neo-revision'
+        key    : 'exact-revision-arrived',
+        owner  : '#16454',
+        surface: 'ai/scripts/maintenance/migrateDeployment.mjs',
+        what   : 'every service in the cohort reports the EXACT resolved target at /app/.neo-revision'
     },
     {
-        key  : 'consumers-observe',
-        owner: '#16320',
-        what : 'already-connected clients observe the transition as complete rather than staying pinned'
+        key    : 'consumers-observe',
+        owner  : '#16320',
+        surface: null,
+        what   : 'already-connected clients observe the transition as complete rather than staying pinned'
     }
 ];
 
@@ -81,11 +90,18 @@ async function surveyLegs() {
           present = [];
 
     for (const leg of CHAIN_LEGS) {
-        // The migration bootstrap is the only leg with a shipped executable surface today. The others are
-        // open tickets, so this survey is expected to report five missing legs until they land — that
-        // expectation is asserted below rather than assumed, so a leg landing silently cannot go unnoticed.
-        const shipped = leg.key === 'exact-revision-arrived' &&
-            await fs.pathExists(path.join(repoRoot, 'ai/scripts/maintenance/migrateDeployment.mjs'));
+        // Probe EVERY leg that names a surface. The first cut read
+        //
+        //     leg.key === 'exact-revision-arrived' && await fs.pathExists(<one hardcoded path>)
+        //
+        // whose `&&` short-circuits for every other leg, so their surfaces were never evaluated and the
+        // survey restated a hardcoded assumption instead of observing anything. It reported one shipped
+        // leg while three had landed — two of them surfaces this author had merged hours earlier. A
+        // survey that cannot notice a sibling landing is the opposite of the property this scenario
+        // exists to provide.
+        const shipped = leg.surface
+            ? await fs.pathExists(path.join(repoRoot, leg.surface))
+            : false;
 
         (shipped ? present : missing).push(leg)
     }
@@ -113,18 +129,35 @@ test.describe('the Epic goal bar: a plane reaches the exact merged cohort with n
     test('an unrunnable scenario reports INCONCLUSIVE and fails — it never reports pass', async () => {
         const {runnable, reason} = await checkRunnable();
 
-        // The assertion is on the REPORTING contract, not on Docker being present: if the harness cannot
-        // provision, the run must fail with a named cause. That is the property a green-when-broken harness
-        // would violate, and it is checkable whether or not Docker happens to be available here.
+        // HONEST BOUND, flagged in review by @neo-opus-ada: this test's NAME promises more than its body
+        // checks. The assertion IS the INCONCLUSIVE mechanism rather than a test of it — with Docker up it
+        // passes without exercising the failure path, and with Docker down it fails. There is no arrangement
+        // here in which the INCONCLUSIVE path is observed PRODUCING a failure.
+        //
+        // Defensible only while the assertion is two self-evident lines. The moment provisioning grows a
+        // real fixture, "unrunnable" becomes a state with several causes and this reporting contract becomes
+        // something that can regress silently — at which point this needs a case that arranges an
+        // unprovisionable harness and observes the named failure.
+        //
+        // Second known bound: `docker version` probes the LOCAL daemon, while the subject of this goal bar
+        // is a disposable plane. Fine while the scenario provisions nothing; it must become a probe of the
+        // plane it intends to create.
         expect(runnable, `INCONCLUSIVE — the scenario could not provision a plane: ${reason}`).toBe(true)
     });
 
     test('the chain is not yet composable, and the failure names which legs are missing', async () => {
         const {missing, present} = await surveyLegs();
 
-        // Red-first bookkeeping, asserted rather than assumed: exactly one leg ships today. When a sibling
-        // lands, this count moves and the scenario says so, instead of a leg appearing unnoticed.
-        expect(present.map(leg => leg.key)).toEqual(['exact-revision-arrived']);
+        // Red-first bookkeeping, asserted rather than assumed. Set-equality on the KEYS, not a count, so a
+        // leg landing flips this assertion and names itself rather than sliding past a number. The baseline
+        // is three because three surfaces are on `dev` today — the previous baseline of one was produced by
+        // a short-circuited survey that could not have observed the other two, both of which had already
+        // merged when this scenario was written.
+        expect(present.map(leg => leg.key)).toEqual([
+            'admissibility-answerable',
+            'activation-sole-path',
+            'exact-revision-arrived'
+        ]);
 
         const named = missing.map(leg => `${leg.key} (${leg.owner}) — ${leg.what}`).join('\n  · ');
 

--- a/test/playwright/update-chain/UpdateChainGoal.spec.mjs
+++ b/test/playwright/update-chain/UpdateChainGoal.spec.mjs
@@ -1,0 +1,137 @@
+import {test, expect}  from '@playwright/test';
+import fs              from 'fs-extra';
+import path            from 'path';
+import {execFile}      from 'node:child_process';
+import {promisify}     from 'node:util';
+import {fileURLToPath} from 'url';
+
+const execFileAsync = promisify(execFile),
+      repoRoot      = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../..');
+
+/**
+ * The Epic's outcome sentence, asserted as one property:
+ *
+ * > A deployed plane, following an allowed channel, reaches the **exact** eligible merged cohort without a
+ * > human typing a Docker command — or fails contained, with terminal evidence its consumers can see.
+ *
+ * This scenario supplies the cross-chain falsifier and **implements none of the machinery it measures**. No
+ * caller, no selector, no admissibility rule. If it starts growing those, it has become a second umbrella
+ * wearing a sub's label and the Epic is back to having no goal bar.
+ *
+ * ## Red-first, on purpose
+ *
+ * It lands red while the implementation leaves are open. A probe written after the feature only proves the
+ * feature agrees with itself; the red-first order is what tests the probe. Its obligation while red is to
+ * name **which leg** is missing — an opaque failure teaches nothing and gets muted.
+ *
+ * ## Inconclusive is a FAILURE, never a pass
+ *
+ * A scenario that cannot provision a plane has measured nothing. Reporting that as green would make the goal
+ * bar satisfiable by breaking the harness, so every unrunnable path fails loudly and says `INCONCLUSIVE`.
+ */
+
+/**
+ * The chain, as legs. Each is a separate question, and the scenario's value is that it fails on the FIRST
+ * unmet one by name rather than reporting a single opaque red.
+ * @type {Object[]}
+ */
+const CHAIN_LEGS = [
+    {
+        key  : 'candidate-retained',
+        owner: '#16450',
+        what : 'a merged cohort produces a retained, addressable candidate carrying an exact digest'
+    },
+    {
+        key  : 'selection-bounded',
+        owner: '#16451',
+        what : 'selection takes the latest compatible staged cohort, or produces an explicit ineligibility record'
+    },
+    {
+        key  : 'admissibility-answerable',
+        owner: '#16453',
+        what : 'a predicate answers whether the target may take the cohort, resolving unknown to NOT admissible'
+    },
+    {
+        key  : 'activation-sole-path',
+        owner: '#16452',
+        what : 'a durable receipt links a fresh RESTORABLE result before first mutation, or no mutation occurs'
+    },
+    {
+        key  : 'exact-revision-arrived',
+        owner: '#16454',
+        what : 'every service in the cohort reports the EXACT resolved target at /app/.neo-revision'
+    },
+    {
+        key  : 'consumers-observe',
+        owner: '#16320',
+        what : 'already-connected clients observe the transition as complete rather than staying pinned'
+    }
+];
+
+/**
+ * @summary Reports which chain legs have a shipped implementation, without asserting they WORK.
+ *
+ * Deliberately weak: presence of a surface is not evidence it composes, which is the entire reason this
+ * scenario exists. Its only job is to make the red failure name the missing leg instead of failing opaquely,
+ * so an unimplemented leg is distinguishable from an implemented-but-broken one.
+ * @returns {Promise<Object>} `{missing, present}` — leg descriptors, partitioned.
+ */
+async function surveyLegs() {
+    const missing = [],
+          present = [];
+
+    for (const leg of CHAIN_LEGS) {
+        // The migration bootstrap is the only leg with a shipped executable surface today. The others are
+        // open tickets, so this survey is expected to report five missing legs until they land — that
+        // expectation is asserted below rather than assumed, so a leg landing silently cannot go unnoticed.
+        const shipped = leg.key === 'exact-revision-arrived' &&
+            await fs.pathExists(path.join(repoRoot, 'ai/scripts/maintenance/migrateDeployment.mjs'));
+
+        (shipped ? present : missing).push(leg)
+    }
+
+    return {missing, present}
+}
+
+/**
+ * @summary Confirms the scenario could run at all, so an unrunnable harness cannot read as a pass.
+ * @returns {Promise<Object>} `{runnable, reason}`
+ */
+async function checkRunnable() {
+    const probe = await execFileAsync('docker', ['version', '--format', '{{.Server.Version}}'])
+        .then(result => ({ok: true, out: result.stdout.trim()}))
+        .catch(error => ({ok: false, out: (error.stderr || error.message || '').trim()}));
+
+    if (!probe.ok) {
+        return {runnable: false, reason: `Docker daemon unreachable — ${probe.out}`}
+    }
+
+    return {runnable: true, reason: `docker server ${probe.out}`}
+}
+
+test.describe('the Epic goal bar: a plane reaches the exact merged cohort with no human Docker command', () => {
+    test('an unrunnable scenario reports INCONCLUSIVE and fails — it never reports pass', async () => {
+        const {runnable, reason} = await checkRunnable();
+
+        // The assertion is on the REPORTING contract, not on Docker being present: if the harness cannot
+        // provision, the run must fail with a named cause. That is the property a green-when-broken harness
+        // would violate, and it is checkable whether or not Docker happens to be available here.
+        expect(runnable, `INCONCLUSIVE — the scenario could not provision a plane: ${reason}`).toBe(true)
+    });
+
+    test('the chain is not yet composable, and the failure names which legs are missing', async () => {
+        const {missing, present} = await surveyLegs();
+
+        // Red-first bookkeeping, asserted rather than assumed: exactly one leg ships today. When a sibling
+        // lands, this count moves and the scenario says so, instead of a leg appearing unnoticed.
+        expect(present.map(leg => leg.key)).toEqual(['exact-revision-arrived']);
+
+        const named = missing.map(leg => `${leg.key} (${leg.owner}) — ${leg.what}`).join('\n  · ');
+
+        // The deliberate red. It carries the missing legs by name and owner, so the failure is a work list
+        // rather than an opaque wall. This assertion inverts and the scenario proceeds to the real
+        // end-to-end property once the legs land — that flip, plus moving this project into the default CI
+        // gate, is this ticket's completion condition.
+        expect(missing, `the update chain does not yet compose — ${missing.length} leg(s) missing:\n  · ${named}`).toEqual([])
+    })
+});

--- a/test/playwright/update-chain/UpdateChainGoal.spec.mjs
+++ b/test/playwright/update-chain/UpdateChainGoal.spec.mjs
@@ -148,14 +148,19 @@ test.describe('the Epic goal bar: a plane reaches the exact merged cohort with n
     test('the chain is not yet composable, and the failure names which legs are missing', async () => {
         const {missing, present} = await surveyLegs();
 
-        // Red-first bookkeeping, asserted rather than assumed. Set-equality on the KEYS, not a count, so a
-        // leg landing flips this assertion and names itself rather than sliding past a number. The baseline
-        // is three because three surfaces are on `dev` today — the previous baseline of one was produced by
-        // a short-circuited survey that could not have observed the other two, both of which had already
-        // merged when this scenario was written.
-        expect(present.map(leg => leg.key)).toEqual([
-            'admissibility-answerable',
+        // Red-first bookkeeping, asserted rather than assumed. SORTED before comparison, because `toEqual`
+        // on an array is ORDERED equality — the previous version claimed set-equality in this very comment
+        // and delivered positional equality, so reordering `CHAIN_LEGS` for readability would have failed a
+        // test whose subject is WHICH legs ship, not what order they are declared in. Proved by reordering,
+        // in review by @neo-opus-ada.
+        //
+        // Keys rather than a count, so a landing leg names itself instead of sliding past a number. The
+        // baseline is three because three surfaces are on `dev` today — the previous baseline of one came
+        // from a short-circuited survey that could not have observed the other two, both of which had
+        // already merged when this scenario was written.
+        expect(present.map(leg => leg.key).sort()).toEqual([
             'activation-sole-path',
+            'admissibility-answerable',
             'exact-revision-arrived'
         ]);
 


### PR DESCRIPTION
Resolves #16493

Refs #16455

**On the close target.** #16455 prescribes its own delivery order — *"The harness lands first and lands **red**… It runs opt-in… and moves **into** the gate when it goes green. That flip is this leaf's completion."* So it has two halves with a real sequencing boundary, and this PR delivers only the first. Pointing a closing keyword at #16455 would auto-close a ticket whose completion condition is not met, so #16493 is the honest narrow close target and #16455 stays open owning the gate-flip. Same shape as @neo-opus-ada's #16486 / PR #16483 earlier today; `§9.1`'s "file the narrow ticket" path rather than a `Refs`-only draft, since a draft cannot be reviewed.

Evidence: L1/L2 — a Playwright project and one scenario, run locally. Provisions nothing yet; the plane-provisioning legs it measures are open.

## The Epic's outcome sentence, made executable and red

> A deployed plane, following an allowed channel, reaches the **exact** eligible merged cohort without a human typing a Docker command — or fails contained, with terminal evidence its consumers can see.

Delivered **before** the chain that satisfies it. A probe written after the feature only proves the feature agrees with itself; the red-first order is what tests the probe.

```
npx playwright test -c test/playwright/playwright.config.update-chain.mjs

✓ an unrunnable scenario reports INCONCLUSIVE and fails — it never reports pass
✘ the chain is not yet composable, and the failure names which legs are missing
    the update chain does not yet compose — 3 leg(s) missing:
      · candidate-retained (#16450) — a merged cohort produces a retained, addressable candidate…
      · selection-bounded (#16451) — selection takes the latest compatible staged cohort…
      · consumers-observe (#16320) — already-connected clients observe the transition as complete…
  1 failed, 1 passed
```

That is the intended state, and the red is the deliverable.

## Three properties, each of which is a trap avoided rather than a feature

**Its own opt-in project, not a spec in `integration-parity`.** Reusing that project was the cheaper edit and the wrong one: it already provisions a disposable plane *and is already in the default gate*, so a red-by-design scenario would have turned the shared gate red on day one. #16455's own Avoided Traps section forbids exactly that — a permanently-red check gets routed around within a week and stops meaning anything.

Verified rather than asserted, with a positive control: `update-chain` appears in **no** `.github/workflows/` file, while `integration-parity` **does** appear in `test.yml` — so the check can detect gate membership at all. An absence claim without that control is worthless.

**Opt-in rather than skipped.** A `test.skip` inside a gated project reads as green and proves nothing. An unreferenced config cannot read as anything: it either was not run, or it ran and reported.

**`retries: 0`.** A flaky goal bar is not a goal bar. A scenario that passes on attempt two has told you the chain is unreliable, and a retry converts that finding into a green tick.

## What makes the red useful rather than noise

The failure carries each missing leg **by name, owner and obligation**, so it is a work list. Each leg names a `surface` and the survey PROBES it, so "when a sibling lands, this scenario says so" is a property rather than a claim — asserted as set-equality on keys (`toEqual(['admissibility-answerable', 'activation-sole-path', 'exact-revision-arrived'])`) rather than a count, so a landing leg names itself instead of sliding past a number. A leg with no known surface stays `null` and reports missing on that basis: wrong by omission, one line for whoever lands it.

**Corrected after review by @neo-opus-ada.** The first cut computed `shipped` as `leg.key === 'exact-revision-arrived' && await fs.pathExists(…)`, whose `&&` short-circuits — five of six legs never had their surfaces evaluated, so the survey restated a hardcoded assumption while this body described it as an observation. It reported one shipped leg while three had landed, two of them surfaces this author merged hours before opening the PR. That is the drift-detection property being claimed and not delivered; it is delivered now.

The runnability contract is the other half: an unrunnable scenario reports `INCONCLUSIVE` **and fails**, because a harness that cannot provision has measured nothing, and reporting that as green would make the goal bar satisfiable by breaking the harness.

It implements **none** of the machinery it measures — no caller, no selector, no admissibility rule. Growing those is how a proof leaf becomes a second umbrella and the goal bar disappears into it, which is the failure that produced #16455 in the first place.

## Test Evidence

Observed above: 1 passed, 1 failed with three legs named. The passing test is the reporting contract, not a chain assertion.

One correction made during authoring, recorded because it would have failed at load: my first import read `resolveFreePort`, and the module exports `resolveFreePortSync(envValue)` — synchronous, and env-overridable so CI can pin the port. Verified against the sibling config's usage rather than assumed.

## Post-Merge Validation

- [ ] As each leg lands, re-run this project; the shipped-leg assertion should fail and name the newly-present leg.
- [ ] **#16455's completion, not this PR's:** once all legs are green, flip the project into `.github/workflows/` and close #16455.

## Deltas

- `test/playwright/playwright.config.update-chain.mjs` — **new**, opt-in project. Sibling-pattern match on `playwright.config.integration-parity.mjs`, so §9.5 structural pre-flight resolves via Stage 1 fast-path.
- `test/playwright/update-chain/UpdateChainGoal.spec.mjs` — **new**, the goal-bar scenario.
- `.github/workflows/` — **deliberately unchanged.** The empty workflow diff is the enforcement of "not yet gated".
- **Substrate accretion:** one config, one spec, no new module and no production code. Sunset condition: the config merges into the default gate at #16455's close, or retires with the Epic if the goal is restructured.

Authored by Vega (Claude Opus 5, Claude Code). Session 11695cce-9854-4be2-80c3-8ea4322298bf.
