### PR TITLE
fix: Theme-deferral gates read Neo.currentWorker live across worker reuse (#16503)

### DIFF
--- a/src/mixin/VdomLifecycle.mjs
+++ b/src/mixin/VdomLifecycle.mjs
@@ -6,6 +6,9 @@ import VDomUpdate       from '../manager/VDomUpdate.mjs';
 import VNodeUtil        from '../util/VNode.mjs';
 import {isDescriptor}   from '../core/ConfigSymbols.mjs';
 
+// Load-time binding: safe ONLY for per-process environment constants (e.g. `isSharedWorker`).
+// Mutable worker state (counters, event registration) must read `Neo.currentWorker` live — test
+// runners reuse worker processes across spec files and reassign the world between them.
 const {currentWorker} = Neo;
 
 /**
@@ -559,9 +562,14 @@ class VdomLifecycle extends Base {
         // any caller-side single-flight latch — tracks the REAL mount attempt instead of a
         // wrapper that resolves before the work begins. Rejections propagate through the chain
         // for the same reason.
-        if (!unitTestMode && autoMount && currentWorker.countLoadingThemeFiles !== 0) {
+        // Read `Neo.currentWorker` LIVE, never the module-load binding: this gate consults MUTABLE
+        // worker state, and under test-runner worker-process reuse a later spec file's setup builds
+        // a fresh app world and reassigns `Neo.currentWorker` — a load-time binding then reads the
+        // PREVIOUS world's counter (0) while the live world is mid-load, silently skipping the
+        // deferral. One worker world per real runtime process makes both reads identical there.
+        if (!unitTestMode && autoMount && Neo.currentWorker.countLoadingThemeFiles !== 0) {
             return new Promise((resolve, reject) => {
-                currentWorker.on('themeFilesLoaded', function() {
+                Neo.currentWorker.on('themeFilesLoaded', function() {
                     me.mounted ? resolve() : me.initVnode(mount).then(resolve, reject)
                 }, me, {once: true})
             })
@@ -1021,9 +1029,10 @@ class VdomLifecycle extends Base {
                     //     me.updateDepth = adjustedDepth;
                     // }
 
-                    // Verify that the critical rendering path => CSS files for the new tree is in place
-                    if (!config.isMiddleware && !config.unitTestMode && currentWorker.countLoadingThemeFiles !== 0) {
-                        currentWorker.on('themeFilesLoaded', function() {
+                    // Verify that the critical rendering path => CSS files for the new tree is in place.
+                    // Live `Neo.currentWorker` read — mutable state; see the initVnode deferral gate.
+                    if (!config.isMiddleware && !config.unitTestMode && Neo.currentWorker.countLoadingThemeFiles !== 0) {
+                        Neo.currentWorker.on('themeFilesLoaded', function() {
                             me.updateVdom(resolve, reject)
                         }, me, {once: true})
                     } else {

--- a/test/playwright/unit/tab/plugin/Overflow.spec.mjs
+++ b/test/playwright/unit/tab/plugin/Overflow.spec.mjs
@@ -253,7 +253,9 @@ test.describe('Neo.tab.plugin.Overflow (re-entrancy contract)', () => {
         const plugin = createPlugin(async ids => ids[0] === 'tab-overflow-test-owner' ? [{width: 1000}] : [{width: 10}, {width: 10}]);
         await new Promise(resolve => setTimeout(resolve, 0));
 
-        plugin.control = {theme: 'neo-theme-neo-dark'};
+        // The theme-change handler re-projects (render-truth edge); the all-fit stub extents then
+        // reach syncControl's teardown, which destroys the control — the stub honors that contract.
+        plugin.control = {destroy() {}, theme: 'neo-theme-neo-dark'};
         plugin.owner.theme = 'neo-theme-neo-light';
         plugin.onOwnerThemeChange();
 
@@ -865,7 +867,7 @@ test.describe('Neo.tab.plugin.Overflow (tab-set mutation invalidation)', () => {
                       items          : [{id: 'b1'}, {id: 'b2'}],
                       parent,
                       getTheme       : function () { return this.theme },
-                      getDomRect     : async ids => ids[0] === 'tab-overflow-test-owner' ? [{width: 1000}] : [{width: 10}, {width: 10}],
+                      getDomRect     : async ids => ids[0] === 'wired-owner' ? [{width: 1000}] : [{width: 10}, {width: 10}],
                       add            : () => ({}),
                       addDomListeners: () => {},
                       remove         : () => {},


### PR DESCRIPTION
Resolves #16503

The theme-deferral gates in `VdomLifecycle` now read `Neo.currentWorker` **live** instead of the module-load binding (`const {currentWorker} = Neo` at the file top). The binding is only safe for per-process environment constants (`isSharedWorker`, which keeps it); the deferral gates consult MUTABLE worker state (`countLoadingThemeFiles`) and register `themeFilesLoaded` listeners — under test-runner worker-process reuse, a later spec file's `setup()` builds a fresh app world and reassigns `Neo.currentWorker`, so the load-time binding read the PREVIOUS world's counter (0) while the live world was mid-load, silently skipping the deferral. Both twin sites (`initVnode` + the `updateVdom` path) are converted, and a guard comment at the binding names the rule so the next mutable consumer does not repeat the class. Real-runtime behavior is unchanged: one worker world per process makes both reads the same object. Two test-hygiene residues fixed in the same suite: the theme-change unit test's stub control gains the `destroy()` the (PR #16490) re-projection path exercises, and the tab-set-mutation describe's `getDomRect` discriminator keys on its OWN owner id (`wired-owner`) — a prior blanket stub rewrite had silently pasted the other describe's id, inverting its "wide extent, nothing overflows" premise.

Evidence: L2 (deterministic unit reproduction + red/green stash cycle) → L2 required (the ACs are unit-suite behaviors). Residual: none.

## Deltas from ticket

- The tab-set-mutation stub-id repair was found during the noise sweep (the ticket only named the stub-`destroy()` residue): six `project() threw against a live owner` log lines traced to the wrong-id discriminator forcing overflow extents into three tests whose premise is all-fit. Same hygiene class, same file, folded in.

## Test Evidence

Reported and independently reproduced before the fix (credit: @neo-opus-grace's three-run table on `#16498`'s lane, plus her PR `#16489` CI casualty): full tab suite `npx playwright test test/playwright/unit/tab/ -c test/playwright/playwright.config.unit.mjs --workers=1` → `1 failed / 30 passed`, always `the first sync arms exactly one deferral listener: expected 1, received 0`; `Overflow.spec.mjs` alone → `26 passed`.

At this head:
- Full tab suite: `31 passed` ×3 consecutive.
- Isolation: `26 passed`.
- Suite log noise: `project() threw` occurrences `6 → 0`.
- Red-proof: stashing ONLY `src/mixin/VdomLifecycle.mjs` at this head reproduces `1 failed / 30 passed` at the exact witness; restoring returns `31 passed`.

Surface coverage — `src/mixin/VdomLifecycle.mjs`: `unit/tab/plugin/Overflow.spec.mjs` (the deferral + re-arm witnesses), full component boot paths across the unit/e2e suites in CI; `test/playwright/unit/tab/plugin/Overflow.spec.mjs`: itself.

## Post-Merge Validation

- [ ] Peer PR unit-CI runs stop failing at the deferral witness (PR `#16489` was the first casualty; any currently-red unit lanes should clear on rebase).

Authored by Mnemosyne (Fable 5, Claude Code). Session 1913de09-6dc0-4d1e-a9a3-b51c33b46cdc.
