### PR TITLE
docs(deploy): the predicate's public shape now admits what it actually accepts (#16505)

### DIFF
--- a/ai/scripts/setup/cohortAdmissibility.mjs
+++ b/ai/scripts/setup/cohortAdmissibility.mjs
@@ -1,4 +1,3 @@
-#!/usr/bin/env node
 /**
  * @module ai/scripts/setup/cohortAdmissibility
  * @summary Answers "may target T take cohort C?" — and when the answer is no, names the leaves that
@@ -16,6 +15,20 @@
  * The raw material already exists and is machine-readable — every leaf that can block a boot
  * declares `requiredFor` on its own descriptor. What was missing is a predicate over it. This module
  * is that predicate and nothing more: it reads, it never migrates, and it never relaxes a guard.
+ *
+ * ## Why it lives here, and why it carries no shebang
+ *
+ * Settled rather than left implicit, because a consumed library and a one-shot script want different
+ * homes and this directory holds both. It stays beside `migrateConfigOverlay.mjs`, which covers the
+ * config-overlay half of the same problem while stating it never handles env-resolved values — this
+ * module is the half that was left uncovered, so the pair belongs together. `initServerConfigs.mjs`
+ * and `seedAgentIdentities.mjs` are the precedent that a library is at home in this directory; the
+ * folder is not CLI-only.
+ *
+ * It carried `#!/usr/bin/env node` on the way in, and that was simply wrong: there is no argv
+ * handling, no `import.meta.url` entry guard, and no `main()` — only exports. A shebang announces
+ * "runnable as a program", so on a pure library it misdeclares the file to every reader and to any
+ * census that sorts scripts from libraries. Removed rather than made true.
  *
  * ## Derived, never hand-listed
  *
@@ -369,15 +382,28 @@ export function assessCohortSource(cohortData) {
  * @summary Answers "may target T take cohort C?".
  *
  * @param {Object} options
- * @param {Object} options.cohortData The cohort's `config.data` tree.
+ * @param {*} options.cohortData The cohort's `config.data` tree — typed `{*}` deliberately, NOT
+ *   `{Object}`. This function is specified to accept `undefined`, `null`, a scalar, an array and a
+ *   descriptor-free tree, and to refuse each of them through `sourceError`. Annotating it `{Object}`
+ *   would tell a caller to pre-validate, and the two ways they would do that are both wrong: a
+ *   duplicate upstream guard reimplements this one less carefully, and throwing on a non-object lets
+ *   a single unreadable candidate abort a whole selection pass instead of being skipped and recorded.
  * @param {Object} [options.currentCohortData=null] The cohort the target is ON, for retirement diffing.
  *   Omitted means retirement is not guessed — absence of a comparison point is not evidence.
  * @param {Object} [options.forbiddenEnv=null] `$composeDefaultParity.forbiddenEnv`, key → reason.
  * @param {Object} options.target `{entrypoint, mode, consumerClaims, providedEnv}`.
- * @returns {{admissible: Boolean, blocking: Object[], indeterminate: Object[], retired: Object[], forbidden: Object[], evaluated: Number}}
+ * @returns {{admissible: Boolean, sourceError: Object|null, blocking: Object[], indeterminate: Object[], retired: Object[], forbidden: Object[], evaluated: Number}}
  *   `blocking` names each leaf whose requirement applies and whose input the target does not supply,
  *   with the requirement's own `reason`. `indeterminate` names each leaf whose applicability could
  *   not be decided, with the axes that were unstated. Admissible only when BOTH are empty.
+ *
+ *   `sourceError` is the discriminator between the two ways a verdict can be inadmissible, and a
+ *   consumer that ignores it collapses them back together. It is `{observed, leafCount, reason}` when
+ *   the cohort could not be READ — a failed load, a wrong shape, a tree with no leaf descriptors — and
+ *   **`null` on every successfully-observed evaluation**, including inadmissible ones. So
+ *   `admissible: false` with `sourceError: null` means *this cohort does not fit this target*, while a
+ *   non-null `sourceError` means *we never saw a cohort at all*; the first is a fact about the target,
+ *   the second is a fault upstream of it, and an operator acts on them differently.
  *
  *   `retired` and `forbidden` are ADVISORY and never affect `admissible` — neither can fail a
  *   readiness check, so gating on them would refuse a migration for an input that is merely inert.


### PR DESCRIPTION
Resolves #16505

Follow-up from PR #16489's approval, deferred by @neo-gpt-emmy rather than bought with another review cycle. Documentation and one deleted line; **no runtime change**.

## The `@param` was arguing against the contract, not just imprecise

`evaluateCohortAdmissibility` was annotated `@param {Object} options.cohortData`. The function is **specified to accept** `undefined`, `null`, a scalar, an array and a descriptor-free tree, and to refuse each through `sourceError` — that acceptance *is* the source guard's deliverable.

`{Object}` tells a caller to pre-validate, and both ways they would do that are wrong:

- a **duplicate upstream guard** reimplements this one, less carefully
- **throwing** on a non-object lets one unreadable candidate abort a whole selection pass, instead of being skipped and recorded — exactly what the review's fork resolution ruled out

**Evidence:** `assessCohortSource` in the same file already typed its own input `{*}`, so the module contradicted itself at two adjacent entry points.

## `sourceError` was invisible to the consumer it exists for

Absent from the documented return shape. Now stated, including the half that carries the meaning: it is **`null` on every successfully-observed evaluation, including inadmissible ones.**

So `admissible: false` with `sourceError: null` is *a fact about the target*; a non-null `sourceError` is *a fault upstream of it*. A consumer that never learns the field exists collapses both into a bare boolean — the exact conflation the guard was built to prevent, reappearing one layer down.

## Placement: settled, and the answer is smaller than the ticket predicted

The ticket asserted `ai/scripts/setup/` holds only one-shot CLIs, so a consumed library sits wrong there. **Checking falsified my own premise:** `initServerConfigs.mjs` and `seedAgentIdentities.mjs` carry no shebang and are libraries. The folder is not CLI-only, and the module is already at home beside `migrateConfigOverlay.mjs` — the sibling covering the config-overlay half of the same problem while stating it never handles env-resolved values, which is precisely the half this covers. Relocating would have churned a just-merged file to solve a problem that was not there. Ticket body corrected in place.

**The real defect was one line.** The file carried `#!/usr/bin/env node` with no argv handling, no `import.meta.url` entry guard and no `main()` — ten exports and nothing else. Its mode is `-rw-r--r--`, so the shebang could not have functioned even if something had tried to run it, and nothing does. A shebang announces *"runnable as a program"*; on a pure library it misdeclares the file to every reader and to any census that sorts scripts from libraries. Removed rather than made true, with the reasoning recorded in the module header where the next reader meets it.

## Test Evidence

**120 passed** across `ai/scripts/setup/`, spec **unmodified** — which is the point: a documentation change that altered behaviour would show up as a spec edit, and there is none. The 24-case `cohortAdmissibility` suite already pins every input shape the widened `@param` now documents, so the annotation is describing tested behaviour rather than asserting new behaviour.

No mutation receipts: nothing executable changed. The one runtime-adjacent edit is the shebang deletion, and its falsifier is that the file has no exec bit and no invoker — `git grep cohortAdmissibility -- package.json ai/` returns only the module itself.

## Deltas

- `ai/scripts/setup/cohortAdmissibility.mjs` — `@param` widened to `{*}` with the accepted shapes named; `sourceError` added to `@returns` with its `null`-on-success contract; placement rationale recorded in the module header; false shebang removed.
- **No other file touched.** No spec change, no behaviour change, no relocation.

## Post-Merge Validation

Closes every #16505 AC. The two items @neo-gpt-emmy scoped onto `#16451` are correctly split: the **ineligibility-record** half stays there because that record is selection's own data structure, and only the module-facing half landed here.

Watch for one thing after `#16451` wires a consumer: this documents `sourceError` as the discriminator, and the value of that only realises if the consumer branches on it rather than on `admissible` alone. If the ineligibility record ends up carrying a bare boolean, the annotation was accurate and still failed to do its job.

Authored by @neo-opus-grace (Claude Opus 5)
