### PR TITLE
Wait out a self-succession lease refusal instead of exiting into a restart loop

### DIFF
--- a/ai/daemons/orchestrator/daemon.mjs
+++ b/ai/daemons/orchestrator/daemon.mjs
@@ -32,7 +32,7 @@ import path                                                              from 'p
 import {execSync}                                                        from 'child_process';
 import AiConfig                                                          from '../../config.mjs';
 import Orchestrator, {rotateLogFileIfNewDay}                             from './Orchestrator.mjs';
-import {acquireAuthorityLease}                                           from './authorityLease.mjs';
+import {acquireAuthorityLease, AUTHORITY_LEASE_TTL_MS}                   from './authorityLease.mjs';
 import {assertAuthorityProfile, isTaskOwnedByProfile}                    from './taskAuthority.mjs';
 import {assertConfigFresh}                                               from '../../scripts/setup/initServerConfigs.mjs';
 import Tier1ConfigBase, {PLANE_MEMBER_PATHS as TIER1_PLANE_MEMBER_PATHS} from '../../configBase.mjs';
@@ -307,6 +307,78 @@ export function requiresOrchestratorPlane(
  * @param {Object} [options] Test-injection seams (scriptDir, dbPath, taskDefinitions, ...).
  * @returns {Promise<void>}
  */
+/**
+ * @summary Claims the authority lease, waiting out a self-succession refusal instead of exiting.
+ *
+ * A container restart meets its own predecessor's lease. The entrypoint is always pid 1 and the
+ * hostname is the container id, so the recorded holder is byte-identical to the requester and the
+ * lease is still inside its freshness window — the claim is refused, the boot throws, Docker restarts,
+ * and the cycle repeats. Measured on the local plane at **720 restarts**: ExitCode 0, OOMKilled false,
+ * 25% heap. A clean-exit loop with no resource signal, which is why it read as a mystery; the earlier
+ * heap work fixed a real but different cause sitting underneath it.
+ *
+ * **Waiting is the corroboration, and it is why this belongs here rather than in the lease core.**
+ * `fileLease.mjs` is explicit that identity cannot settle this — *"pid-equality cannot mean ours"*,
+ * because numeric pids collide across namespaces — and `FileLeaseHeldError` says a consumer wanting
+ * the dead-predecessor claim must corroborate it with something the error does not carry. Elapsed time
+ * is that something: **a dead predecessor stops pulsing, so its lease goes stale; a live holder keeps
+ * pulsing, so it stays fresh.** One TTL of patience separates them without relaxing the single-owner
+ * invariant by a single condition. Relaxing the core instead — reclaiming on pid equality — would let a
+ * container evict a live host holder, the exact duplicate the module exists to refuse.
+ *
+ * A second refusal after the wait means the holder kept its lease alive, so it IS a live duplicate:
+ * that rethrows and the boot fails loud, unchanged.
+ * @param {Object} options            Passed through to {@link acquireAuthorityLease}.
+ * @param {String} options.dir        Lease directory.
+ * @param {String} options.profile    Authority profile.
+ * @param {Function} [options.sleep]  Injectable delay, for tests.
+ * @param {Number} [options.ttlMs]    Freshness window; defaults to the authority lease TTL.
+ * @returns {Promise<Object>} The acquired lease handle.
+ */
+export async function acquireAuthorityLeaseSurvivingSelfSuccession({
+    dir,
+    profile,
+    sleep = ms => new Promise(resolve => setTimeout(resolve, ms)),
+    ttlMs = AUTHORITY_LEASE_TTL_MS
+}) {
+    try {
+        return acquireAuthorityLease({dir, profile, ttlMs})
+    } catch (error) {
+        // Only self-succession waits. Any other refusal is a genuine second claimant and must still
+        // fail immediately — a blanket retry would convert every duplicate-start into a slow one.
+        if (error.code !== 'FILE_LEASE_HELD' || !error.holderIdentityMatchesRequester) {
+            throw error
+        }
+
+        const heldSince = Date.parse(error.holder?.lastPulse ?? error.holder?.startedAt),
+              // Wait out the remaining freshness window rather than a flat TTL: a predecessor that died
+              // most of a window ago should cost us the remainder, not a fresh 60s.
+              remaining = Number.isFinite(heldSince)
+                  ? Math.max(0, ttlMs - (Date.now() - heldSince)) + 1_000
+                  : ttlMs + 1_000;
+
+        console.warn(
+            `[orchestrator] authority lease held by an identity indistinguishable from ours ` +
+            `(${error.holder?.owner} pid ${error.holder?.pid}, since ${error.holder?.startedAt}). ` +
+            `In a container this is our own predecessor: pid 1 and the hostname both survive a restart. ` +
+            `Waiting ${Math.round(remaining / 1000)}s for the lease to go stale rather than exiting into ` +
+            `a restart loop. If the holder is genuinely alive it will keep pulsing and this boot will then ` +
+            `fail loud.`
+        );
+
+        await sleep(remaining);
+
+        // Second attempt. A dead predecessor's lease is now stale and reclaimable; a live holder has
+        // pulsed and this throws again — fail-closed, and the message names it as a real duplicate.
+        //
+        // `ttlMs` MUST reach both claims. Omitting it here left the retry on the 60s default while the wait
+        // was computed from the injected window, so the dead-predecessor case still refused — and the
+        // live-holder control passed VACUOUSLY, refusing because of the default TTL rather than because the
+        // holder pulsed. One missing argument made the guard's own witness meaningless in both directions.
+        return acquireAuthorityLease({dir, profile, ttlMs})
+    }
+}
+
 export async function startOrchestrator(options = {}) {
     const dataDir = daemonDataDir();
 
@@ -316,7 +388,7 @@ export async function startOrchestrator(options = {}) {
     // The role authority lease is claimed AHEAD of the legacy PID singleton: a refused boot must
     // leave the incumbent unsignaled and the plane untouched — enforceSingleton() can SIGTERM
     // whatever holds the PID file, so nothing that might refuse may run after it.
-    const authorityLease = acquireAuthorityLease({
+    const authorityLease = await acquireAuthorityLeaseSurvivingSelfSuccession({
         dir    : dataDir,
         profile: AiConfig.orchestrator.authorityProfile
     });

--- a/test/playwright/unit/ai/daemons/orchestrator/daemon.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/daemon.spec.mjs
@@ -7,12 +7,14 @@ import * as yaml      from 'js-yaml';
 import '../../../../../../src/Neo.mjs';
 import '../../../../../../src/core/_export.mjs';
 import {
+    acquireAuthorityLeaseSurvivingSelfSuccession,
     enforceSingleton,
     LOCAL_AI_CONFIG_FILE,
     isOrchestratorDaemonCommand,
     loadLocalAiConfig,
     requiresOrchestratorPlane
 } from '../../../../../../ai/daemons/orchestrator/daemon.mjs';
+import {acquireAuthorityLease} from '../../../../../../ai/daemons/orchestrator/authorityLease.mjs';
 import {
     AUTHORITY_LEASE_TTL_MS,
     authorityLeaseFilename
@@ -26,6 +28,71 @@ import {
 
 test.describe('ai/daemons/orchestrator/daemon.mjs (#11006/#11009)', () => {
 
+
+    test.describe('self-succession: a restarted container waits out its own predecessor (720-restart loop)', () => {
+        function leaseDir() {
+            return fs.mkdtempSync(path.join(os.tmpdir(), 'neo-self-succession-'));
+        }
+
+        test('a DEAD predecessor is waited out and the lease is acquired — not an exit into a restart loop', async () => {
+            // The loop, reproduced. A container entrypoint is always pid 1 and the hostname is the container
+            // id, so a restart meets a lease whose recorded holder is byte-identical to the requester and
+            // still fresh. Before this the boot threw, the process exited, Docker restarted it, and the cycle
+            // repeated — 720 times on the local plane, ExitCode 0 and OOMKilled false, which is why it read
+            // as a mystery rather than a lock.
+            const dir     = leaseDir(),
+                  profile = 'container-plane';
+
+            // The predecessor: same identity this process will present, then it "dies" — nothing pulses it.
+            acquireAuthorityLease({dir, profile});
+
+            let sleptMs = 0;
+
+            const handle = await acquireAuthorityLeaseSurvivingSelfSuccession({
+                dir,
+                profile,
+                // The wait is what corroborates death: a dead predecessor stops pulsing, so its lease goes
+                // stale. Injected rather than real so the test does not sleep a minute — but note it must
+                // actually advance PAST the freshness window for the second claim to succeed, which is why
+                // the assertion below checks the duration and not merely that sleep was called.
+                // Records the requested duration but sleeps a SHORT REAL interval, because the lease's
+                // freshness check reads real time — a zero-wait stub leaves the predecessor fresh and the
+                // retry refuses, which is exactly how the first version of this test failed. The window is
+                // tiny so the real wait stays negligible while genuinely elapsing past it.
+                sleep: async ms => { sleptMs = ms; await new Promise(r => setTimeout(r, 60)); },
+                ttlMs: 40
+            });
+
+            expect(handle, 'a restarted container must acquire after waiting, never exit').toBeTruthy();
+            expect(sleptMs, 'it must wait past the freshness window, not retry immediately').toBeGreaterThan(0);
+
+            handle.release();
+        });
+
+        test('a LIVE holder that keeps pulsing still REFUSES after the wait — fail-closed preserved', async () => {
+            // The control, and the reason waiting is sound rather than a relaxation: the single-owner
+            // invariant is untouched. A genuinely live duplicate keeps its lease fresh, so the second claim
+            // refuses exactly as before. Without this, "wait and retry" would be indistinguishable from
+            // deleting the refusal.
+            const dir     = leaseDir(),
+                  profile = 'container-plane',
+                  holder  = acquireAuthorityLease({dir, profile});
+
+            await expect(acquireAuthorityLeaseSurvivingSelfSuccession({
+                dir,
+                profile,
+                // The wait must ELAPSE past the window and the holder must pulse inside it, so the lease is
+                // fresh at the retry *because of the pulse* — the signature of a live process. An earlier
+                // version pulsed without elapsing, which left the lease fresh at 0ms and would have passed
+                // with the pulse removed entirely: a control that cannot fail proves nothing. The paired
+                // test above is the proof this one discriminates — identical timing, no pulse, acquires.
+                sleep: async () => { await new Promise(r => setTimeout(r, 60)); holder.pulse(); },
+                ttlMs: 40
+            })).rejects.toThrow(/is held by/);
+
+            holder.release();
+        });
+    });
 
     test('builds task commands around existing manual maintenance scripts', () => {
         const scriptDir = path.resolve(process.cwd(), 'ai/scripts');


### PR DESCRIPTION
Resolves #16462

A container-plane orchestrator that restarts inherits pid 1 and its own previous identity. `acquireAuthorityLease` correctly refuses — the lease on disk names the same owner — and the daemon treated that refusal as fatal and exited. Docker restarted it, it refused again, and the plane spun.

Evidence: measured on the live plane before the fix — container `339f011e1f84`, on-disk lease `{"pid":1,"owner":"orchestrator@339f011e1f84", …}`, `RestartCount` **846**, roughly 40 refusals per hour. The orchestrator was never up long enough to own anything.

## The fix is caller-side, deliberately

My first attempt weakened the primitive: reclaim the lease when the holder's pid equals ours. A pre-existing spec in `fileLease.spec.mjs` killed it —

> TOKEN IDENTITY: an equal numeric pid with a different token is NOT ours

— which is correct and load-bearing: pids collide across namespaces, so pid equality cannot imply identity. The lock keeps its strictness. `acquireAuthorityLeaseSurvivingSelfSuccession` sits above it and waits out the dead predecessor's remaining TTL, then retries exactly once. A refusal from a *live* holder still propagates unchanged.

## Test Evidence

`test/playwright/unit/ai/daemons/orchestrator/daemon.spec.mjs` — two specs:

- **dead predecessor, same identity** → the wait elapses and the second acquire succeeds. The stub genuinely sleeps (`setTimeout(r, 60)` against `ttlMs: 40`); an instant stub made the first version of this spec vacuous, since it passed whether or not the code waited.
- **live holder, same identity** → the stub elapses *and then pulses*, so the lease is still fresh on retry and the refusal propagates. This is the direction that matters: the fix must not become a way to steal a live lease.

Both directions asserted, because only asserting the first would have shipped a lock-stealer.

## Post-Merge Validation

On the container plane, `RestartCount` stops climbing and the orchestrator reaches a steady `Up`. The authority lease on disk shows one owner with a pulsing `lastPulse` rather than a rewritten `startedAt`.

## Deltas

- `ai/daemons/orchestrator/daemon.mjs` — adds `acquireAuthorityLeaseSurvivingSelfSuccession`; imports `AUTHORITY_LEASE_TTL_MS` alongside `acquireAuthorityLease`. Rethrows anything that is not `FILE_LEASE_HELD` with `holderIdentityMatchesRequester`.
- `test/playwright/unit/ai/daemons/orchestrator/daemon.spec.mjs` — the two specs above.
- `ai/daemons/shared/fileLease.mjs` — **unchanged**. That is the point.

Authored by @neo-opus-vega
