### PR TITLE
Startup warns on an empty corpus, and rescue-only retrieval says so

### DIFF
--- a/ai/mcp/server/knowledge-base/Server.mjs
+++ b/ai/mcp/server/knowledge-base/Server.mjs
@@ -1,11 +1,12 @@
-import BaseServer                       from '../BaseServer.mjs';
-import aiConfig                         from './config.mjs';
-import ConfigBase, {PLANE_MEMBER_PATHS} from './configBase.mjs';
-import logger                           from './logger.mjs';
-import DatabaseService                  from '../../../services/knowledge-base/DatabaseService.mjs';
-import HealthService                    from '../../../services/knowledge-base/HealthService.mjs';
-import KBRecorderService                from '../../../services/knowledge-base/KBRecorderService.mjs';
-import {listTools, callTool}            from './toolService.mjs';
+import BaseServer                             from '../BaseServer.mjs';
+import aiConfig                               from './config.mjs';
+import ConfigBase, {PLANE_MEMBER_PATHS}       from './configBase.mjs';
+import logger                                 from './logger.mjs';
+import DatabaseService                        from '../../../services/knowledge-base/DatabaseService.mjs';
+import HealthService                          from '../../../services/knowledge-base/HealthService.mjs';
+import KBRecorderService                      from '../../../services/knowledge-base/KBRecorderService.mjs';
+import {listTools, callTool}                  from './toolService.mjs';
+import {describeCollectionStats, STATS_LEVEL} from './describeCollectionStats.mjs';
 
 /**
  * @summary The Knowledge Base MCP Server application.
@@ -177,43 +178,13 @@ class Server extends BaseServer {
      * @param {Object} health
      */
     logCollectionStats(health) {
-        const knowledgeBase = health.database.connection.collections?.knowledgeBase;
+        // The decision lives in `describeCollectionStats` so it can be witnessed without standing up
+        // an MCP server; this method owns only the forwarding. Reviewers asked for proof that the
+        // replacement instrument fires, and a decision reachable only through a class boot is a
+        // decision nothing asserts.
+        const {level, lines} = describeCollectionStats(health.database.connection.collections?.knowledgeBase);
 
-        if (!knowledgeBase) {
-            return
-        }
-
-        if (!knowledgeBase.exists) {
-            logger.info('   - Knowledge Base: unavailable');
-            return
-        }
-
-        // An empty corpus printed as `info` under the success banner is how a six-day corpus outage
-        // stayed invisible. A dockerization migration recreated `neo-knowledge-base`, ~61,206
-        // documents stayed behind in the previous data root, and startup rendered
-        //
-        //     ✅ [Startup] Knowledge Base health check passed
-        //        - Knowledge Base: 0
-        //
-        // The count was never missing — it was framed as success. The correction belongs here, at the
-        // render, and NOT on `health.status`: that field is the container liveness gate, mcpHealthcheck
-        // accepts only `healthy` by default, and `ingress` + `orchestrator` both gate on
-        // `service_healthy` — so degrading an empty corpus stops a fresh plane from booting at all.
-        const {count} = knowledgeBase;
-
-        if (typeof count !== 'number') {
-            logger.warn('   - Knowledge Base: document count unreadable — corpus size unverified');
-            return
-        }
-
-        if (count === 0) {
-            logger.warn('   - Knowledge Base: 0 documents — retrieval cannot return a grounded result');
-            logger.warn('     A collection recreated by a migration presents exactly this way. Check whether the');
-            logger.warn('     corpus was left behind in a previous data root before assuming ingestion has not run.');
-            return
-        }
-
-        logger.info(`   - Knowledge Base: ${count}`);
+        lines.forEach(line => level === STATS_LEVEL.warn ? logger.warn(line) : logger.info(line));
     }
 }
 

--- a/ai/mcp/server/knowledge-base/Server.mjs
+++ b/ai/mcp/server/knowledge-base/Server.mjs
@@ -179,10 +179,41 @@ class Server extends BaseServer {
     logCollectionStats(health) {
         const knowledgeBase = health.database.connection.collections?.knowledgeBase;
 
-        if (knowledgeBase) {
-            const suffix = knowledgeBase.exists ? knowledgeBase.count : 'unavailable';
-            logger.info(`   - Knowledge Base: ${suffix}`);
+        if (!knowledgeBase) {
+            return
         }
+
+        if (!knowledgeBase.exists) {
+            logger.info('   - Knowledge Base: unavailable');
+            return
+        }
+
+        // An empty corpus printed as `info` under the success banner is how a six-day corpus outage
+        // stayed invisible. A dockerization migration recreated `neo-knowledge-base`, ~61,206
+        // documents stayed behind in the previous data root, and startup rendered
+        //
+        //     ✅ [Startup] Knowledge Base health check passed
+        //        - Knowledge Base: 0
+        //
+        // The count was never missing — it was framed as success. The correction belongs here, at the
+        // render, and NOT on `health.status`: that field is the container liveness gate, mcpHealthcheck
+        // accepts only `healthy` by default, and `ingress` + `orchestrator` both gate on
+        // `service_healthy` — so degrading an empty corpus stops a fresh plane from booting at all.
+        const {count} = knowledgeBase;
+
+        if (typeof count !== 'number') {
+            logger.warn('   - Knowledge Base: document count unreadable — corpus size unverified');
+            return
+        }
+
+        if (count === 0) {
+            logger.warn('   - Knowledge Base: 0 documents — retrieval cannot return a grounded result');
+            logger.warn('     A collection recreated by a migration presents exactly this way. Check whether the');
+            logger.warn('     corpus was left behind in a previous data root before assuming ingestion has not run.');
+            return
+        }
+
+        logger.info(`   - Knowledge Base: ${count}`);
     }
 }
 

--- a/ai/mcp/server/knowledge-base/describeCollectionStats.mjs
+++ b/ai/mcp/server/knowledge-base/describeCollectionStats.mjs
@@ -1,0 +1,78 @@
+/**
+ * @module ai/mcp/server/knowledge-base/describeCollectionStats
+ * @summary Pure render decision for the startup collection-stats line: which log level a corpus
+ * observation earns, and what to print. Extracted from the Server so the decision is witnessable
+ * without instantiating an MCP server — the class stays a thin caller that forwards to a logger.
+ */
+
+/**
+ * Log levels this decision can return. `silent` means there is nothing to say at all, which is
+ * distinct from having something to say at `info`.
+ * @type {Object}
+ */
+export const STATS_LEVEL = Object.freeze({
+    info  : 'info',
+    silent: 'silent',
+    warn  : 'warn'
+});
+
+/**
+ * @summary Decides how a Knowledge Base collection observation should be rendered at startup.
+ *
+ * An empty corpus printed as `info` under the success banner is how a six-day corpus outage stayed
+ * invisible: a dockerization migration recreated the canonical collection, ~61,206 documents stayed
+ * behind in the previous data root, and startup rendered a green "health check passed" followed by
+ * `- Knowledge Base: 0`. The count was never missing — it was framed as success.
+ *
+ * The correction belongs at the render and deliberately NOT on `health.status`: that field is the
+ * container liveness gate, the MCP healthcheck accepts only `healthy` by default, and both ingress
+ * and the orchestrator gate on `service_healthy` — so degrading an empty corpus stops a fresh plane
+ * from booting at all. Reporting loudly is free; changing the gate is not.
+ *
+ * Readability is checked with `Number.isFinite` and NOT `typeof count === 'number'`, because
+ * `typeof NaN === 'number'` is true: a NaN count clears a typeof guard, then fails the `=== 0` test,
+ * and renders as a populated corpus at `info`. That is the original failure mode wearing a new
+ * value — the witnessing spec in this module's sibling test caught it on first run. `Number.isFinite`
+ * also rejects `Infinity`, `null`, `undefined` and numeric strings without coercing any of them.
+ * A partially migrated or mid-swap collection presents exactly this way.
+ *
+ * @param {Object|null|undefined} knowledgeBase The collection descriptor from a health payload's
+ * `database.connection.collections.knowledgeBase`, or a falsy value when the payload carries none.
+ * @param {Boolean} [knowledgeBase.exists] Whether the collection was found.
+ * @param {Number}  [knowledgeBase.count] Row count observed for the collection.
+ * @returns {{level: String, lines: String[]}} The level every line should be emitted at, and the
+ * lines themselves. `lines` is empty exactly when `level` is `silent`.
+ */
+export function describeCollectionStats(knowledgeBase) {
+    if (!knowledgeBase) {
+        return {level: STATS_LEVEL.silent, lines: []}
+    }
+
+    if (!knowledgeBase.exists) {
+        return {level: STATS_LEVEL.info, lines: ['   - Knowledge Base: unavailable']}
+    }
+
+    const {count} = knowledgeBase;
+
+    if (!Number.isFinite(count)) {
+        return {
+            level: STATS_LEVEL.warn,
+            lines: ['   - Knowledge Base: document count unreadable — corpus size unverified']
+        }
+    }
+
+    if (count === 0) {
+        return {
+            level: STATS_LEVEL.warn,
+            lines: [
+                '   - Knowledge Base: 0 documents — retrieval cannot return a grounded result',
+                '     A collection recreated by a migration presents exactly this way. Check whether the',
+                '     corpus was left behind in a previous data root before assuming ingestion has not run.'
+            ]
+        }
+    }
+
+    return {level: STATS_LEVEL.info, lines: [`   - Knowledge Base: ${count}`]}
+}
+
+export default describeCollectionStats;

--- a/ai/services/knowledge-base/HealthService.mjs
+++ b/ai/services/knowledge-base/HealthService.mjs
@@ -212,7 +212,12 @@ class HealthService extends Base {
                 return {
                     ...base,
                     exists: true,
-                    count : await collection.count()
+                    count : await collection.count(),
+                    // The collection IDENTITY, reported because `exists` cannot distinguish a preserved
+                    // collection from a fresh one that took its name. Dockerization recreated this collection
+                    // (`a9637b4c…` → `ab75f86b…`, 61,206 rows → 0) and every health surface stayed green,
+                    // because a recreated collection exists exactly as convincingly as a preserved one.
+                    id    : collection.id ?? null
                 };
             } catch (error) {
                 if (attempt > 0 || !ChromaManager.isCollectionNotFoundError(error)) {
@@ -328,7 +333,7 @@ class HealthService extends Base {
             status   : 'healthy',
             timestamp: new Date().toISOString(),
             database : {
-                process: DatabaseLifecycleService.getDatabaseStatus(),
+                process   : DatabaseLifecycleService.getDatabaseStatus(),
                 connection: {
                     connected  : false,
                     collections: null
@@ -337,9 +342,9 @@ class HealthService extends Base {
             features: {
                 embedding: false
             },
-            details: [],
-            version: process.env.npm_package_version || '1.0.0',
-            uptime : process.uptime(),
+            details         : [],
+            version         : process.env.npm_package_version || '1.0.0',
+            uptime          : process.uptime(),
             runtimeFreshness: await this.resolveRuntimeFreshness()
         };
 
@@ -362,6 +367,37 @@ class HealthService extends Base {
         if (collectionsCheck.error || !collectionsCheck.knowledgeBase?.exists) {
             payload.status = 'degraded';
             payload.details.push(collectionsCheck.error || 'The required knowledge base collection is missing');
+        } else {
+            // `exists` is the wrong predicate on its own, and the right one was already in this payload.
+            //
+            // A dockerization migration recreated this collection — a fresh, empty `neo-knowledge-base` took
+            // the name while ~61,206 documents stayed behind in the previous data root. `exists` was true
+            // throughout, `count` was gathered and attached below, and nothing read it: the service reported
+            // "All features are operational" for six days over an empty corpus, while queries answered from
+            // the lexical-rescue supplement alone.
+            //
+            // An empty corpus is not a healthy one. Retrieval against it cannot return a single grounded
+            // result, so this degrades rather than reporting success.
+            const {count} = collectionsCheck.knowledgeBase;
+
+            if (typeof count !== 'number') {
+                // Unknown corpus size is not health either. An unreadable count is the state a partially
+                // migrated or mid-swap collection presents, and blessing it is how the previous failure
+                // stayed invisible.
+                payload.status = 'degraded';
+                payload.details.push(
+                    `Knowledge base collection '${collectionsCheck.knowledgeBase.name}' exists but its document ` +
+                    'count could not be read — corpus size unknown, so retrieval groundedness is unverified'
+                )
+            } else if (count === 0) {
+                payload.status = 'degraded';
+                payload.details.push(
+                    `Knowledge base collection '${collectionsCheck.knowledgeBase.name}' exists but holds 0 documents ` +
+                    '— retrieval cannot return a grounded result. A collection recreated by a migration presents ' +
+                    'exactly this way; check whether the corpus was left behind in a previous data root rather ' +
+                    'than assuming ingestion has not run yet.'
+                )
+            }
         }
 
         // Step 3: Check embedding provider readiness (provider-aware; only 'gemini' needs a key)

--- a/ai/services/knowledge-base/HealthService.mjs
+++ b/ai/services/knowledge-base/HealthService.mjs
@@ -212,12 +212,7 @@ class HealthService extends Base {
                 return {
                     ...base,
                     exists: true,
-                    count : await collection.count(),
-                    // The collection IDENTITY, reported because `exists` cannot distinguish a preserved
-                    // collection from a fresh one that took its name. Dockerization recreated this collection
-                    // (`a9637b4c…` → `ab75f86b…`, 61,206 rows → 0) and every health surface stayed green,
-                    // because a recreated collection exists exactly as convincingly as a preserved one.
-                    id    : collection.id ?? null
+                    count : await collection.count()
                 };
             } catch (error) {
                 if (attempt > 0 || !ChromaManager.isCollectionNotFoundError(error)) {
@@ -367,37 +362,6 @@ class HealthService extends Base {
         if (collectionsCheck.error || !collectionsCheck.knowledgeBase?.exists) {
             payload.status = 'degraded';
             payload.details.push(collectionsCheck.error || 'The required knowledge base collection is missing');
-        } else {
-            // `exists` is the wrong predicate on its own, and the right one was already in this payload.
-            //
-            // A dockerization migration recreated this collection — a fresh, empty `neo-knowledge-base` took
-            // the name while ~61,206 documents stayed behind in the previous data root. `exists` was true
-            // throughout, `count` was gathered and attached below, and nothing read it: the service reported
-            // "All features are operational" for six days over an empty corpus, while queries answered from
-            // the lexical-rescue supplement alone.
-            //
-            // An empty corpus is not a healthy one. Retrieval against it cannot return a single grounded
-            // result, so this degrades rather than reporting success.
-            const {count} = collectionsCheck.knowledgeBase;
-
-            if (typeof count !== 'number') {
-                // Unknown corpus size is not health either. An unreadable count is the state a partially
-                // migrated or mid-swap collection presents, and blessing it is how the previous failure
-                // stayed invisible.
-                payload.status = 'degraded';
-                payload.details.push(
-                    `Knowledge base collection '${collectionsCheck.knowledgeBase.name}' exists but its document ` +
-                    'count could not be read — corpus size unknown, so retrieval groundedness is unverified'
-                )
-            } else if (count === 0) {
-                payload.status = 'degraded';
-                payload.details.push(
-                    `Knowledge base collection '${collectionsCheck.knowledgeBase.name}' exists but holds 0 documents ` +
-                    '— retrieval cannot return a grounded result. A collection recreated by a migration presents ' +
-                    'exactly this way; check whether the corpus was left behind in a previous data root rather ' +
-                    'than assuming ingestion has not run yet.'
-                )
-            }
         }
 
         // Step 3: Check embedding provider readiness (provider-aware; only 'gemini' needs a key)

--- a/ai/services/knowledge-base/QueryService.mjs
+++ b/ai/services/knowledge-base/QueryService.mjs
@@ -1,17 +1,17 @@
-import fs                   from 'fs-extra';
-import TextEmbeddingService from '../memory-core/TextEmbeddingService.mjs';
-import mcConfig             from '../../mcp/server/memory-core/config.mjs';
-import aiConfig             from '../../mcp/server/knowledge-base/config.mjs';
-import Base                 from '../../../src/core/Base.mjs';
-import ChromaManager        from './ChromaManager.mjs';
+import fs                                       from 'fs-extra';
+import TextEmbeddingService                     from '../memory-core/TextEmbeddingService.mjs';
+import mcConfig                                 from '../../mcp/server/memory-core/config.mjs';
+import aiConfig                                 from '../../mcp/server/knowledge-base/config.mjs';
+import Base                                     from '../../../src/core/Base.mjs';
+import ChromaManager                            from './ChromaManager.mjs';
 import RequestContextService, {normalizeUserId} from '../../mcp/server/shared/services/RequestContextService.mjs';
-import dotenv               from 'dotenv';
-import path                 from 'path';
+import dotenv                                   from 'dotenv';
+import path                                     from 'path';
 
 const {queryScoreWeights} = aiConfig;
 
-const cwd       = aiConfig.neoRootDir;
-const insideNeo = process.env.npm_package_name?.includes('neo.mjs') ?? false;
+const cwd                     = aiConfig.neoRootDir;
+const insideNeo               = process.env.npm_package_name?.includes('neo.mjs') ?? false;
 const lexicalRescueExtensions = new Set(['.js', '.json', '.md', '.mjs', '.yaml', '.yml']);
 const lexicalRescueSkipDirs   = new Set([
     '.git',
@@ -25,7 +25,7 @@ const lexicalRescueSkipDirs   = new Set([
 ]);
 const codeTermRescueRoots     = ['ai/services', 'ai/mcp/server', 'ai/graph'];
 const codeTermRescueFileLimit = 500;
-const sourceLikeTypeAliases = {
+const sourceLikeTypeAliases   = {
     src: ['src', 'ai-infrastructure']
 };
 
@@ -88,7 +88,7 @@ class QueryService extends Base {
 
         // If a root is specified, find all subclasses recursively
         const subtree = {};
-        const queue = [root];
+        const queue   = [root];
 
         // Include the root itself if it exists (parent is the value)
         if (Object.hasOwn(hierarchy, root)) {
@@ -137,17 +137,17 @@ class QueryService extends Base {
         // `tenantId` query arg is therefore ignored). No request context (stdio single-tenant
         // / offline daemon) → no tenant filter, byte-equivalent with the legacy behavior.
         const requesterTenantId = normalizeUserId(RequestContextService.getUserId());
-        const queryOptions    = this.createQueryOptions({queryEmbeddingValues, requesterTenantId, type});
-        const queryResults    = await Promise.all(queryOptions.map(options => collection.query(options)));
-        const sourceScores   = {};
-        const sourceMetadata = {};
-        const metadatas      = this.dedupeCandidateMetadatas(queryResults.flatMap(result => result.metadatas?.[0] || []));
-        const queryWords     = this.getQueryWords(queryLower);
+        const queryOptions      = this.createQueryOptions({queryEmbeddingValues, requesterTenantId, type});
+        const queryResults      = await Promise.all(queryOptions.map(options => collection.query(options)));
+        const sourceScores      = {};
+        const sourceMetadata    = {};
+        const metadatas         = this.dedupeCandidateMetadatas(queryResults.flatMap(result => result.metadatas?.[0] || []));
+        const queryWords        = this.getQueryWords(queryLower);
 
         metadatas.forEach((metadata, index) => {
             if (!metadata.source || metadata.source === 'unknown') return;
 
-            let score             = (metadatas.length - index) * queryScoreWeights.baseIncrement;
+            let   score           = (metadatas.length - index) * queryScoreWeights.baseIncrement;
             const sourcePath      = metadata.source;
             const sourcePathLower = sourcePath.toLowerCase();
             const fileName        = sourcePath.split('/').pop().toLowerCase();
@@ -161,7 +161,7 @@ class QueryService extends Base {
             }
 
             queryWords.forEach(queryWord => {
-                const keyword = queryWord;
+                const keyword         = queryWord;
                 const keywordSingular = keyword.endsWith('s') ? keyword.slice(0, -1) : keyword;
 
                 if (keywordSingular.length > 2) {
@@ -195,7 +195,7 @@ class QueryService extends Base {
             sourceScores[sourcePath] = (sourceScores[sourcePath] || 0) + score;
 
             const inheritanceChain = JSON.parse(metadata.inheritanceChain || '[]');
-            let boost = queryScoreWeights.inheritanceBoost;
+            let   boost            = queryScoreWeights.inheritanceBoost;
             inheritanceChain.forEach(parent => {
                 if (parent.source) {
                     sourceScores[parent.source] = (sourceScores[parent.source] || 0) + boost;
@@ -203,6 +203,12 @@ class QueryService extends Base {
                 boost = Math.floor(boost * queryScoreWeights.inheritanceDecay);
             });
         });
+
+        // How many sources vector retrieval contributed, captured BEFORE the rescue runs. Rescue both adds
+        // new sources and boosts existing ones, so after the fact the two are indistinguishable — and that
+        // indistinguishability is the defect: with an empty collection this method still returned results,
+        // scores and a topResult, from rescue alone, in a response shape identical to a grounded answer.
+        const vectorSourceCount = Object.keys(sourceScores).length;
 
         await this.addLexicalRescueScores({
             query,
@@ -218,12 +224,12 @@ class QueryService extends Base {
         }
 
         const sortedSources = Object.entries(sourceScores).sort(([, a], [, b]) => b - a);
-        const finalScores = {};
+        const finalScores   = {};
         const topSourceDirs = sortedSources.slice(0, 5).map(([source]) => path.dirname(source));
 
         sortedSources.forEach(([source, score]) => {
-            let finalScore = score;
-            const sourceDir = path.dirname(source);
+            let   finalScore = score;
+            const sourceDir  = path.dirname(source);
             if (topSourceDirs.includes(sourceDir)) {
                 finalScore *= 1.1;
             }
@@ -244,10 +250,29 @@ class QueryService extends Base {
             });
 
         if (finalSorted.length > 0) {
-            return {
+            const response = {
                 topResult: finalSorted[0].source,
-                results  : finalSorted
+                results  : finalSorted,
+                // Aggregate provenance. Per-row `lexicalRescueReasons` was already correct and was already
+                // there — but a caller reading `topResult` and a score has no reason to inspect every row's
+                // metadata, so a supplement standing in for the entire primary read as a grounded answer for
+                // six days. This states it once, where it cannot be missed.
+                retrieval: {vectorSources: vectorSourceCount}
             };
+
+            if (vectorSourceCount === 0) {
+                // Not an error and not empty results: the rescue is a designed capability and its hits may be
+                // exactly what the caller wanted. But semantic retrieval contributed NOTHING, so these results
+                // are filename and path matches over local sources — never evidence of what the corpus holds.
+                response.retrieval.rescueOnly = true;
+                response.retrieval.warning    =
+                    'Vector retrieval returned 0 sources — every result below comes from the local lexical ' +
+                    'rescue path (path/filename matching over on-disk sources), not from the ingested corpus. ' +
+                    'Treat these as unsourced: an empty or unreachable knowledge-base collection presents ' +
+                    'exactly this way. Check the knowledge-base healthcheck before relying on them.'
+            }
+
+            return response;
         }
 
         return {message: 'No relevant source files found after scoring.'};
@@ -301,12 +326,12 @@ class QueryService extends Base {
             ];
         }
 
-        const total = Math.max(1, Number(aiConfig.nResults) || 1);
-        let allocated = 0;
+        const total     = Math.max(1, Number(aiConfig.nResults) || 1);
+        let   allocated = 0;
 
         return activePools
             .map((pool, index) => {
-                const isLast = index === activePools.length - 1;
+                const isLast     = index === activePools.length - 1;
                 const rawResults = pool.nResults ?? (
                     isLast ? total - allocated : Math.floor(total * (pool.share ?? 0))
                 );
@@ -384,7 +409,7 @@ class QueryService extends Base {
      * @returns {Object} Chroma query options.
      */
     createQueryOption({queryEmbeddingValues, requesterTenantId, typeFilter, nResults}) {
-        const where = this.createWhereClause({requesterTenantId, typeFilter});
+        const where  = this.createWhereClause({requesterTenantId, typeFilter});
         const option = {
             queryEmbeddings: [queryEmbeddingValues],
             nResults
@@ -812,7 +837,7 @@ class QueryService extends Base {
         if (source.startsWith('resources/content/release-notes/') || source.startsWith('.github/RELEASE_NOTES/')) return 'release';
 
         const apiSourceMap = aiConfig.sourcePaths.ApiSource || {};
-        const match = Object.entries(apiSourceMap).find(([sourceRoot]) =>
+        const match        = Object.entries(apiSourceMap).find(([sourceRoot]) =>
             source === sourceRoot || source.startsWith(`${sourceRoot}/`)
         );
 

--- a/ai/services/knowledge-base/QueryService.mjs
+++ b/ai/services/knowledge-base/QueryService.mjs
@@ -4,6 +4,7 @@ import mcConfig                                 from '../../mcp/server/memory-co
 import aiConfig                                 from '../../mcp/server/knowledge-base/config.mjs';
 import Base                                     from '../../../src/core/Base.mjs';
 import ChromaManager                            from './ChromaManager.mjs';
+import {describeRetrievalProvenance}            from './retrievalProvenance.mjs';
 import RequestContextService, {normalizeUserId} from '../../mcp/server/shared/services/RequestContextService.mjs';
 import dotenv                                   from 'dotenv';
 import path                                     from 'path';
@@ -255,29 +256,15 @@ class QueryService extends Base {
             });
 
         if (finalSorted.length > 0) {
-            const response = {
+            // The provenance decision lives in `describeRetrievalProvenance` so it can be witnessed
+            // without a Chroma collection; this method owns capturing the count at the right moment
+            // and nothing else. `vectorSourceCount` was read BEFORE the rescue merge above, which is
+            // the ordering the whole signal depends on.
+            return {
                 topResult: finalSorted[0].source,
                 results  : finalSorted,
-                // Aggregate provenance. Per-row `lexicalRescueReasons` was already correct and was already
-                // there — but a caller reading `topResult` and a score has no reason to inspect every row's
-                // metadata, so a supplement standing in for the entire primary read as a grounded answer for
-                // six days. This states it once, where it cannot be missed.
-                retrieval: {vectorSources: vectorSourceCount}
+                retrieval: describeRetrievalProvenance(vectorSourceCount)
             };
-
-            if (vectorSourceCount === 0) {
-                // Not an error and not empty results: the rescue is a designed capability and its hits may be
-                // exactly what the caller wanted. But semantic retrieval contributed NOTHING, so these results
-                // are filename and path matches over local sources — never evidence of what the corpus holds.
-                response.retrieval.rescueOnly = true;
-                response.retrieval.warning    =
-                    'Vector retrieval returned 0 sources — every result below comes from the local lexical ' +
-                    'rescue path (path/filename matching over on-disk sources), not from the ingested corpus. ' +
-                    'Treat these as unsourced: an empty or unreachable knowledge-base collection presents ' +
-                    'exactly this way. Check the knowledge-base healthcheck before relying on them.'
-            }
-
-            return response;
         }
 
         return {message: 'No relevant source files found after scoring.'};

--- a/ai/services/knowledge-base/QueryService.mjs
+++ b/ai/services/knowledge-base/QueryService.mjs
@@ -10,8 +10,13 @@ import path                                     from 'path';
 
 const {queryScoreWeights} = aiConfig;
 
-const cwd                     = aiConfig.neoRootDir;
-const insideNeo               = process.env.npm_package_name?.includes('neo.mjs') ?? false;
+// `cwd`'s exact spacing is fingerprinted by AI_CONFIG_MODULE_SCOPE_BASELINE
+// in ai/scripts/lint/lint-config-template-ssot.mjs. Widening it to align with the longer names below
+// reads to that lint as "the baselined capture was removed" AND "a new capture appeared", failing
+// twice for a whitespace change. Keep this pair at its own width; new names get their own group.
+const cwd       = aiConfig.neoRootDir;
+const insideNeo = process.env.npm_package_name?.includes('neo.mjs') ?? false;
+
 const lexicalRescueExtensions = new Set(['.js', '.json', '.md', '.mjs', '.yaml', '.yml']);
 const lexicalRescueSkipDirs   = new Set([
     '.git',

--- a/ai/services/knowledge-base/retrievalProvenance.mjs
+++ b/ai/services/knowledge-base/retrievalProvenance.mjs
@@ -1,0 +1,54 @@
+/**
+ * @module ai/services/knowledge-base/retrievalProvenance
+ * @summary Pure provenance decision for a query response: how many sources vector retrieval
+ * contributed, and whether the answer came from the lexical rescue path alone. Extracted from
+ * `QueryService` so the decision is witnessable without a Chroma collection.
+ */
+
+/**
+ * @typedef {Object} RetrievalProvenance
+ * @property {Number}  vectorSources Sources vector retrieval contributed, always present — so a
+ * caller never reads an absent field as a grounded answer.
+ * @property {Boolean} [rescueOnly] Present and `true` only when vector retrieval contributed nothing,
+ * meaning every result came from the local lexical rescue path.
+ * @property {String}  [warning] Present only alongside `rescueOnly`, naming the cause rather than the
+ * state — an empty or unreachable collection presents identically to a healthy one otherwise.
+ */
+
+/**
+ * @summary Builds the aggregate retrieval-provenance block for a query response.
+ *
+ * Per-row `lexicalRescueReasons` was already correct and already present, but a caller reading
+ * `topResult` and a score has no reason to inspect every row's metadata — so a supplement standing
+ * in for the entire primary read as a grounded answer for six days. This states it once, in one
+ * place a caller cannot skip.
+ *
+ * The zero case is deliberately NOT an error and NOT empty results: the lexical rescue is a designed
+ * capability and its hits may be exactly what the caller wanted. What must not happen is a caller
+ * mistaking path and filename matches over on-disk sources for evidence of what the ingested corpus
+ * holds — an empty or unreachable collection presents identically to a healthy one otherwise.
+ *
+ * The count MUST be captured before the rescue merge runs. Rescue both adds new sources and boosts
+ * existing ones, so read afterwards the two are indistinguishable — and that indistinguishability is
+ * the whole defect. Callers own that ordering; this function only reports what it is handed.
+ *
+ * @param {Number} vectorSourceCount Sources contributed by vector retrieval, counted BEFORE the
+ * lexical rescue merge.
+ * @returns {RetrievalProvenance}
+ */
+export function describeRetrievalProvenance(vectorSourceCount) {
+    const retrieval = {vectorSources: vectorSourceCount};
+
+    if (vectorSourceCount === 0) {
+        retrieval.rescueOnly = true;
+        retrieval.warning    =
+            'Vector retrieval returned 0 sources — every result below comes from the local lexical ' +
+            'rescue path (path/filename matching over on-disk sources), not from the ingested corpus. ' +
+            'Treat these as unsourced: an empty or unreachable knowledge-base collection presents ' +
+            'exactly this way. Check the knowledge-base healthcheck before relying on them.'
+    }
+
+    return retrieval;
+}
+
+export default describeRetrievalProvenance;

--- a/test/playwright/unit/ai/mcp/server/knowledge-base/describeCollectionStats.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/knowledge-base/describeCollectionStats.spec.mjs
@@ -1,0 +1,90 @@
+import {setup} from '../../../../../setup.mjs';
+
+const appName = 'KBDescribeCollectionStatsTest';
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name             : appName,
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect}                         from '@playwright/test';
+import Neo                                    from '../../../../../../../src/Neo.mjs';
+import * as core                              from '../../../../../../../src/core/_export.mjs';
+import {describeCollectionStats, STATS_LEVEL} from '../../../../../../../ai/mcp/server/knowledge-base/describeCollectionStats.mjs';
+
+/**
+ * The startup collection-stats render, witnessed.
+ *
+ * This decision replaced an instrument that rendered a six-day corpus outage as success: startup
+ * printed a green "health check passed" followed by `- Knowledge Base: 0`, both at info level. The
+ * count was never missing — it was framed as success.
+ *
+ * A replacement instrument with nothing proving it fires repeats that shape one layer up, so the
+ * POSITIVE case is the control here: without asserting that a populated corpus still renders at
+ * `info`, an "always warn" implementation would satisfy every other assertion in this file.
+ */
+test.describe('describeCollectionStats — the startup corpus render decision', () => {
+    test('a populated corpus renders at info — the CONTROL that an always-warn version would fail', async () => {
+        const {level, lines} = describeCollectionStats({exists: true, count: 61206});
+
+        expect(level).toBe(STATS_LEVEL.info);
+        expect(lines).toEqual(['   - Knowledge Base: 61206']);
+    });
+
+    test('an empty corpus WARNS and never renders under the success framing', async () => {
+        const {level, lines} = describeCollectionStats({exists: true, count: 0});
+
+        expect(level).toBe(STATS_LEVEL.warn);
+        expect(lines.length).toBeGreaterThan(1);
+        expect(lines[0]).toContain('0 documents');
+
+        // The recreated-collection cause must be named, because "0" alone reads as "ingestion has not
+        // run yet" — which is the wrong conclusion in exactly the incident this exists to surface.
+        expect(lines.join(' ')).toContain('recreated by a migration');
+        expect(lines.join(' ')).toContain('previous data root');
+    });
+
+    test('an unreadable count WARNS as unverified rather than passing as populated', async () => {
+        for (const count of [undefined, null, NaN, '61206']) {
+            const {level, lines} = describeCollectionStats({exists: true, count});
+
+            expect(level, `count ${String(count)} must not render as success`).toBe(STATS_LEVEL.warn);
+            expect(lines.join(' ')).toContain('unverified');
+        }
+    });
+
+    test('the unreadable check precedes the zero check, so a non-number never reports as 0 documents', async () => {
+        // Ordering is load-bearing: `NaN === 0` is false, but a string or object count would sort into
+        // whichever branch runs first. An unreadable count must say "unverified", not "0 documents",
+        // because the two carry different operator actions.
+        const {lines} = describeCollectionStats({exists: true, count: NaN});
+
+        expect(lines.join(' ')).not.toContain('0 documents');
+    });
+
+    test('a missing collection is info, and no descriptor at all is silent with no lines', async () => {
+        const absent = describeCollectionStats({exists: false});
+
+        expect(absent.level).toBe(STATS_LEVEL.info);
+        expect(absent.lines).toEqual(['   - Knowledge Base: unavailable']);
+
+        // `silent` is a distinct answer from "info with nothing to add": lines is empty exactly here,
+        // so a caller forwarding lines emits nothing rather than an empty log entry.
+        for (const nothing of [null, undefined]) {
+            const result = describeCollectionStats(nothing);
+
+            expect(result.level).toBe(STATS_LEVEL.silent);
+            expect(result.lines).toEqual([]);
+        }
+    });
+
+    test('levels are frozen, so a caller cannot mutate the token it compares against', async () => {
+        expect(Object.isFrozen(STATS_LEVEL)).toBe(true);
+    });
+});

--- a/test/playwright/unit/ai/services/knowledge-base/retrievalProvenance.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/retrievalProvenance.spec.mjs
@@ -1,0 +1,81 @@
+import {setup} from '../../../../setup.mjs';
+
+const appName = 'KBRetrievalProvenanceTest';
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name             : appName,
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect}                from '@playwright/test';
+import Neo                           from '../../../../../../src/Neo.mjs';
+import * as core                     from '../../../../../../src/core/_export.mjs';
+import {describeRetrievalProvenance} from '../../../../../../ai/services/knowledge-base/retrievalProvenance.mjs';
+
+/**
+ * The aggregate retrieval-provenance block, witnessed.
+ *
+ * A query over an empty collection still returned results, scores and a topResult from the lexical
+ * rescue path alone, in a response shape identical to a grounded answer. Per-row rescue metadata was
+ * already present and already correct; nothing read it, because a caller with a topResult and a score
+ * has no reason to inspect every row.
+ *
+ * The POSITIVE case is the control: without asserting that a grounded answer carries NO warning, an
+ * always-warn implementation would satisfy every other assertion here.
+ */
+test.describe('describeRetrievalProvenance — grounded vs rescue-only answers', () => {
+    test('a grounded answer reports its source count and carries NO warning — the CONTROL', async () => {
+        const retrieval = describeRetrievalProvenance(7);
+
+        expect(retrieval.vectorSources).toBe(7);
+        expect(retrieval.rescueOnly).toBeUndefined();
+        expect(retrieval.warning).toBeUndefined();
+    });
+
+    test('zero vector sources marks the answer rescue-only and says why', async () => {
+        const retrieval = describeRetrievalProvenance(0);
+
+        expect(retrieval.vectorSources).toBe(0);
+        expect(retrieval.rescueOnly).toBe(true);
+        expect(typeof retrieval.warning).toBe('string');
+
+        // The warning must name the CAUSE, not merely the state. "0 sources" alone reads as "no match
+        // found", which is the wrong conclusion: an empty or unreachable collection presents this way.
+        expect(retrieval.warning).toContain('empty or unreachable');
+        expect(retrieval.warning).toContain('healthcheck');
+    });
+
+    test('the warning does not claim an error or empty results — the rescue is a designed capability', async () => {
+        const {warning} = describeRetrievalProvenance(0);
+
+        // Calling this an error would be wrong and would train callers to ignore it: the rescue hits may
+        // be exactly what was wanted. The claim is about PROVENANCE, never about failure.
+        expect(warning.toLowerCase()).not.toContain('error');
+        expect(warning.toLowerCase()).not.toContain('failed');
+        expect(warning).toContain('unsourced');
+    });
+
+    test('vectorSources is always present, so a caller never reads absence as a grounded answer', async () => {
+        for (const count of [0, 1, 42]) {
+            const retrieval = describeRetrievalProvenance(count);
+
+            expect(Object.hasOwn(retrieval, 'vectorSources'), `count ${count} must report its source count`).toBe(true);
+            expect(retrieval.vectorSources).toBe(count);
+        }
+    });
+
+    test('a single vector source is NOT rescue-only — the boundary sits at zero, not at "few"', async () => {
+        // Guards against a future "too few sources" threshold being folded into this predicate. Scarcity
+        // and absence are different claims; only absence means the corpus contributed nothing.
+        const retrieval = describeRetrievalProvenance(1);
+
+        expect(retrieval.rescueOnly).toBeUndefined();
+        expect(retrieval.warning).toBeUndefined();
+    });
+});


### PR DESCRIPTION
Resolves #16512

Two blind spots from the knowledge-base corpus outage, where the corpus was absent and every surface read green. **The first revision of this PR fixed the second one and got the first one wrong; both the diagnosis and the fix changed. See the correction section.**

## 1. Startup framed an empty corpus as success

`Server.logCollectionStats` printed the document count at `logger.info`, directly beneath the green banner. For six days startup rendered:

```
✅ [Startup] Knowledge Base health check passed
   - Knowledge Base: 0
```

Evidence: a dockerization migration recreated `neo-knowledge-base` while ~61,206 documents stayed behind in the previous data root. The count was correct and visible the whole time.

Now an empty or unreadable corpus warns instead, and names the recreated-collection cause rather than letting a reader assume ingestion simply has not run yet.

## 2. Retrieval answered from the rescue path without saying so

When the vector search contributes nothing, `addLexicalRescueScores` still returns results using additive integer weights. That is disclosed design and is unchanged here. Its signature is a set of identical integer scores — three results tied at exactly `3575` during the incident, which reads as a scoring bug and is actually a corpus-absent signal wearing a plausible number.

`QueryService` now captures `vectorSourceCount` **before** the rescue merge and reports `retrieval: {vectorSources}`, plus `rescueOnly: true` and a warning when the vector side contributed zero. The ordering is load-bearing: read after the merge and the count includes rescue sources, so the field would report healthy vector contribution in exactly the case it exists to expose.

## Correction: what changed after CI, and why

The first revision degraded `health.status` to `degraded` on an empty corpus. **That was the wrong field, and it would have shipped a boot-breaker.**

- `mcpHealthcheck.mjs` defaults `expectedStatus` to `'healthy'` (`:108`, `:272`).
- The base compose kb-server healthcheck passes no `--expected-status`.
- `ingress` and `orchestrator` both declare `depends_on: kb-server: service_healthy`.

So a fresh cloud deployment whose corpus has not been ingested yet would never finish booting — the same class of unbootable-plane failure as #16206. `health.status` is a container liveness gate, not a corpus-integrity verdict, and overloading it breaks the gate.

**Twelve integration specs caught this**, all of them standing up an empty Knowledge Base as a neutral substrate for auth, wipe and restore proofs: `AdoptionLadderJourney` milestones 0/2/3/4/5, `healthcheck`, `HeartbeatPropagation`, `KBAuthRejection` ×2, `KBBackupRestoreWipe`, `KBOidcAuth` ×2. Their failure was the correct signal, not fixture noise, so they are unchanged — the code moved instead.

The first revision's stated diagnosis was also wrong. It claimed the count "was gathered and nothing read it." `logCollectionStats` read it at `Server.mjs:183`. The defect was never a missing number; it was a number rendered as success.

`details` was considered as the alternative channel and rejected as provably vacuous: `HealthService` appends "All features are operational" on the healthy path, and the only consumers (`Server.mjs:155`, `:165`) iterate `details` **only** in the `unhealthy` and `degraded` branches. A diagnostic pushed there while status stayed healthy would never surface.

## Deltas

- `ai/mcp/server/knowledge-base/Server.mjs` — `logCollectionStats` warns on a zero or unreadable count; a populated corpus still logs at `info`.
- `ai/services/knowledge-base/QueryService.mjs` — `vectorSourceCount` captured before the rescue merge; `retrieval.vectorSources`, `rescueOnly`, and the warning. Also restores the fingerprinted width of the `cwd` module-scope capture: the config SSOT lint matches baseline rows by exact text, so re-aligning that line failed twice at once — as a removed baseline row *and* a new capture. A comment states why the width is load-bearing.
- `ai/services/knowledge-base/HealthService.mjs` — **behaviourally unchanged.** Four lines of block alignment, mandated by the `check-block-alignment` pre-commit hook on pre-existing drift in `dev`.

Deliberately **not** included: a collection-`id` field on the health payload. It would distinguish a recreated collection from a preserved one, which is genuinely useful, but it is additive payload surface and does not belong in a round whose job is to remove a boot-breaker.

## Test Evidence

`lintConfigTemplateSsot.spec.mjs` + `knowledge-base/Server.spec.mjs` run locally: **54 passed**. The SSOT lint CLI passes directly — `OK — 4 module-scope AiConfig capture(s), all baselined`, exit 0. That lint spec was the sole real `unit` failure in the previous round; the other reported failure (`McpServerListToolsSmoke`) was marked flaky and passed on retry.

No spec asserted the old render string, so the warn-instead-of-info change breaks no existing assertion.

## Post-Merge Validation

Against the restored corpus, startup logs `- Knowledge Base: <n>` at info and queries carry a non-zero `vectorSources` with `rescueOnly` absent. Pointed at an empty collection, startup warns with the recreated-collection hint, `status` stays `healthy` so dependents still start, and queries carry `rescueOnly: true`.

Authored by @neo-opus-vega
