### PR TITLE
fix(ai): every export path states what it captured, and the plane gets backups again (#16516)

### DIFF
--- a/ai/services/knowledge-base/DatabaseService.mjs
+++ b/ai/services/knowledge-base/DatabaseService.mjs
@@ -1,10 +1,11 @@
-import aiConfig                        from '../../mcp/server/knowledge-base/config.mjs';
-import {partitionRowsByVectorValidity} from '../memory-core/helpers/vectorWriteInvariant.mjs';
-import {validateJsonlSourceFile}       from '../memory-core/helpers/vectorJsonlSourceValidation.mjs';
-import Base                            from '../../../src/core/Base.mjs';
-import ChromaManager                   from './ChromaManager.mjs';
-import DestructiveOperationGuard       from '../../mcp/server/shared/services/DestructiveOperationGuard.mjs';
-import VectorService                   from './VectorService.mjs';
+import aiConfig                                          from '../../mcp/server/knowledge-base/config.mjs';
+import {classifyExportCompleteness, EXPORT_COMPLETENESS} from '../memory-core/helpers/exportCompleteness.mjs';
+import {partitionRowsByVectorValidity}                   from '../memory-core/helpers/vectorWriteInvariant.mjs';
+import {validateJsonlSourceFile}                         from '../memory-core/helpers/vectorJsonlSourceValidation.mjs';
+import Base                                              from '../../../src/core/Base.mjs';
+import ChromaManager                                     from './ChromaManager.mjs';
+import DestructiveOperationGuard                         from '../../mcp/server/shared/services/DestructiveOperationGuard.mjs';
+import VectorService                                     from './VectorService.mjs';
 // SourceRegistry owns KB source discovery. Importing `./source/_export.mjs` triggers
 // auto-registration of Neo's default Source classes when `aiConfig.useDefaultSources !== false`,
 // plus declarative `aiConfig.customSources` entries.
@@ -115,12 +116,15 @@ class DatabaseService extends Base {
      * @param {Object}  options
      * @param {String} [options.backupPath=aiConfig.backupPath] Directory for the JSONL artifact.
      * @returns {Promise<{message: String, count: Number, collectionId: String|null}>} `count` is the
-     *          numeric export row count, consumed by the backup orchestrator's `verifyBundleIntegrity`
-     *          for KB row-count parity (without it the verifier reads a non-numeric source count and
-     *          skips KB parity). `collectionId` is the source's identity at capture time — the axis
-     *          that lets a `count: 0` receipt distinguish "this source was empty" from "a different
-     *          source is here now"; `null` degrades that axis to `unknown` rather than asserting
-     *          continuity. See `ai/services/shared/captureReceipt.mjs`.
+     *          number of rows actually WRITTEN to the artifact — not the pre-pass collection snapshot.
+     *          It is consumed by the backup orchestrator's `verifyBundleIntegrity` for KB row-count
+     *          parity (without it the verifier reads a non-numeric source count and skips KB parity),
+     *          so returning the snapshot made the verifier compare it against itself and an export
+     *          that dropped rows in the per-id rescue path verified clean. `collectionId` is the
+     *          source's identity at capture time — the axis that lets a `count: 0` receipt
+     *          distinguish "this source was empty" from "a different source is here now"; `null`
+     *          degrades that axis to `unknown` rather than asserting continuity.
+     *          See `ai/services/shared/captureReceipt.mjs`.
      */
     async exportDatabase({backupPath = aiConfig.backupPath} = {}) {
         try {
@@ -147,10 +151,20 @@ class DatabaseService extends Base {
      * subsystems. Pagination cap + surgical per-id rescue mode make this robust against
      * partially corrupted HNSW segments.
      *
+     * Completeness is classified through the shared {@link module:ai/services/memory-core/helpers/exportCompleteness}
+     * predicate rather than a local comparison: the duplication above is deliberate for the export
+     * *logic*, but the three-way verdict is not — a two-way inequality here left the plane with zero
+     * backups, and the per-path accuracy caveat stays local while the predicate does not diverge.
+     *
      * @param {Object} collection The ChromaDB collection to export.
      * @param {String} backupPath The directory to save the backup file.
      * @param {String} filePrefix The prefix for the backup filename.
-     * @returns {Promise<Number>} The number of exported documents.
+     * @returns {Promise<Number>} The number of rows actually written to the artifact. An empty
+     *          source short-circuits to `0` before any file is created, preserving the receipt
+     *          substrate's "this source was empty" semantic.
+     * @throws {Error} `PARTIAL_COLLECTION_EXPORT` when rows the snapshot counted are missing from
+     *          the artifact, or when either count is unreadable — an absent measurement must never
+     *          certify a bundle.
      * @private
      */
     async #exportCollection(collection, backupPath, filePrefix) {
@@ -169,8 +183,10 @@ class DatabaseService extends Base {
         const backupFile  = path.join(backupPath, `${filePrefix}-${timestamp}.jsonl`);
         const writeStream = fs.createWriteStream(backupFile);
 
-        const limit  = 2000;
-        let   offset = 0;
+        const limit    = 2000;
+        let   exported = 0,
+              offset   = 0,
+              skipped  = 0;
 
         while (offset < count) {
             logger.log(`Fetching batch: ${offset} to ${Math.min(offset + limit, count)} of ${count}`);
@@ -203,6 +219,7 @@ class DatabaseService extends Base {
                             batch.embeddings.push(single.embeddings[0]);
                         }
                     } catch (singleErr) {
+                        skipped++;
                         logger.error(`Skipping corrupted vector ID during export: ${id}`);
                     }
                 }
@@ -218,14 +235,44 @@ class DatabaseService extends Base {
                     document : batch.documents[i]
                 };
                 writeStream.write(JSON.stringify(record) + '\n');
+                exported++;
             }
 
             offset += limit;
         }
 
         await new Promise(resolve => writeStream.end(resolve));
-        logger.log(`Successfully exported ${count} documents to: ${backupFile}`);
-        return count;
+
+        // This used to `return count` — the PRE-PASS snapshot — and log it as the exported total,
+        // so the receipt restated the input instead of measuring the bundle. The backup
+        // orchestrator's `verifyBundleIntegrity` consumes this number for KB row-count parity, so
+        // it was comparing the snapshot against itself: an export that silently dropped rows in the
+        // per-id rescue path above passed integrity verification. Count what was WRITTEN.
+        const verdict = classifyExportCompleteness(exported, count);
+
+        if (verdict === EXPORT_COMPLETENESS.partial || verdict === EXPORT_COMPLETENESS.indeterminate) {
+            const error = new Error(
+                `PARTIAL_COLLECTION_EXPORT: ${collection.name} exported ${exported}/${count} ` +
+                `records to ${backupFile}; skipped ${skipped} corrupted vector id(s). Verdict: ${verdict}.`
+            );
+            error.code    = 'PARTIAL_COLLECTION_EXPORT';
+            error.details = {collection: collection.name, backupFile, expected: count, exported, skipped, verdict};
+            throw error
+        }
+
+        if (verdict === EXPORT_COMPLETENESS.grew) {
+            // Complete-or-better: every snapshotted row was captured plus late arrivals. Not an
+            // abort — that is what left the whole plane with zero backups — and not a clean capture
+            // either, because this loop pages by offset.
+            logger.warn(
+                `[DatabaseService] ${collection.name} grew during export: ${exported}/${count} ` +
+                `(+${exported - count}). Every snapshotted row was captured; because this path pages ` +
+                'by offset, the bundle is complete-or-better but not provably exact.'
+            );
+        }
+
+        logger.log(`Successfully exported ${exported}/${count} documents to: ${backupFile}`);
+        return exported;
     }
 
     /**

--- a/ai/services/memory-core/DatabaseService.mjs
+++ b/ai/services/memory-core/DatabaseService.mjs
@@ -1,14 +1,15 @@
-import aiConfig                                                   from '../../mcp/server/memory-core/config.mjs';
-import fs                                                         from 'fs-extra';
-import logger                                                     from '../../mcp/server/memory-core/logger.mjs';
-import path                                                       from 'path';
-import readline                                                   from 'readline';
-import Base                                                       from '../../../src/core/Base.mjs';
-import StorageRouter                                              from './managers/StorageRouter.mjs';
-import DestructiveOperationGuard                                  from '../../mcp/server/shared/services/DestructiveOperationGuard.mjs';
-import {partitionRowsByVectorValidity, summarizeVectorRejections} from './helpers/vectorWriteInvariant.mjs';
-import {validateJsonlSourceFile}                                  from './helpers/vectorJsonlSourceValidation.mjs';
-import {importGraphJsonl}                                         from './helpers/graphJsonlImport.mjs';
+import aiConfig                                                              from '../../mcp/server/memory-core/config.mjs';
+import fs                                                                    from 'fs-extra';
+import logger                                                                from '../../mcp/server/memory-core/logger.mjs';
+import path                                                                  from 'path';
+import readline                                                              from 'readline';
+import Base                                                                  from '../../../src/core/Base.mjs';
+import StorageRouter                                                         from './managers/StorageRouter.mjs';
+import DestructiveOperationGuard                                             from '../../mcp/server/shared/services/DestructiveOperationGuard.mjs';
+import {classifyExportCompleteness, EXPORT_COMPLETENESS, recordExportGrowth} from './helpers/exportCompleteness.mjs';
+import {partitionRowsByVectorValidity, summarizeVectorRejections}            from './helpers/vectorWriteInvariant.mjs';
+import {validateJsonlSourceFile}                                             from './helpers/vectorJsonlSourceValidation.mjs';
+import {importGraphJsonl}                                                    from './helpers/graphJsonlImport.mjs';
 
 /**
  * @summary Service for exporting and importing memory core data.
@@ -157,14 +158,34 @@ class DatabaseService extends Base {
         }
 
         await new Promise(resolve => writeStream.end(resolve));
-        if (stats.exported !== stats.expected) {
+
+        const verdict = classifyExportCompleteness(stats.exported, stats.expected);
+
+        // An unreadable count cannot certify a bundle, and a collection that GREW is not a loss.
+        // Treating every inequality as a partial export aborted the entire backup on `32272/32271`
+        // — one row MORE than expected — because a live agent wrote a memory mid-export.
+        if (verdict === EXPORT_COMPLETENESS.partial || verdict === EXPORT_COMPLETENESS.indeterminate) {
             const error = new Error(
                 `PARTIAL_COLLECTION_EXPORT: ${collectionName} exported ${stats.exported}/${stats.expected} ` +
-                `records to ${backupFile}; skipped ${stats.skipped} corrupted vector id(s).`
+                `records to ${backupFile}; skipped ${stats.skipped} corrupted vector id(s). Verdict: ${verdict}.`
             );
             error.code    = 'PARTIAL_COLLECTION_EXPORT';
-            error.details = stats;
+            error.details = {...stats, verdict};
             throw error
+        }
+
+        if (verdict === EXPORT_COMPLETENESS.grew) {
+            // Every row the snapshot knew about was written, plus late arrivals — aborting here
+            // destroys a usable bundle. It is NOT provable completeness either: this loop pages by
+            // offset, so an insert landing in an already-walked page shifts later rows, and a
+            // concurrent write can skip one row while duplicating another and still finish high.
+            recordExportGrowth(stats);
+
+            logger.warn(
+                `[DatabaseService] ${collectionName} grew during export: ${stats.exported}/${stats.expected} ` +
+                `(+${stats.growthDelta}). Every snapshotted row was captured; because this path pages by ` +
+                'offset, the bundle is complete-or-better but not provably exact.'
+            );
         }
 
         logger.log(`Successfully exported ${stats.exported}/${stats.expected} documents from ${collectionName} to: ${backupFile}`);
@@ -276,14 +297,32 @@ class DatabaseService extends Base {
         }
 
         await new Promise(resolve => writeStream.end(resolve));
-        if (stats.exported !== stats.expected) {
+
+        const verdict = classifyExportCompleteness(stats.exported, stats.expected);
+
+        if (verdict === EXPORT_COMPLETENESS.partial || verdict === EXPORT_COMPLETENESS.indeterminate) {
             const error = new Error(
                 `PARTIAL_COLLECTION_EXPORT: ${collectionName} exported ${stats.exported}/${stats.expected} ` +
-                `records to ${backupFile}; skipped ${stats.skipped} unreadable graph row(s).`
+                `records to ${backupFile}; skipped ${stats.skipped} unreadable graph row(s). Verdict: ${verdict}.`
             );
             error.code    = 'PARTIAL_COLLECTION_EXPORT';
-            error.details = stats;
+            error.details = {...stats, verdict};
             throw error
+        }
+
+        if (verdict === EXPORT_COMPLETENESS.grew) {
+            // The graph grew between the count and the scan. Nothing holds the source still across
+            // that window — the two counts, the `await`ed directory/stream setup, and the two
+            // iterations are all separate reads, and a second connection (another daemon writing one
+            // memory) lands in it. Nodes and Edges are also read as two statements, so the tables can
+            // come from different instants: complete-or-better, not a single-instant snapshot.
+            recordExportGrowth(stats);
+
+            logger.warn(
+                `[DatabaseService] ${collectionName} grew during export: ${stats.exported}/${stats.expected} ` +
+                `(+${stats.growthDelta}). Every counted row was captured; because Nodes and Edges are read ` +
+                'as separate statements, the bundle is complete-or-better but not a single-instant snapshot.'
+            );
         }
 
         logger.log(`Successfully exported ${stats.exported}/${stats.expected} graph elements to: ${backupFile}`);

--- a/ai/services/memory-core/helpers/exportCompleteness.mjs
+++ b/ai/services/memory-core/helpers/exportCompleteness.mjs
@@ -1,0 +1,78 @@
+/**
+ * @summary The pure three-way verdict over an export's row counts — the gate that stops a collection
+ * which GREW during streaming from being destroyed as a partial export.
+ *
+ * Every backup on this plane aborted for hours with
+ * `PARTIAL_COLLECTION_EXPORT: neo-agent-memory exported 32272/32271` — one row MORE than expected.
+ * The guard used strict inequality in BOTH directions, so a single live agent writing one memory
+ * mid-export manufactured the data-integrity failure it then reported, and the corpus sat unprotected.
+ *
+ * `expected` is a count snapshot taken BEFORE the streaming pass, and nothing holds the source still
+ * across it, so the comparison has three outcomes rather than two:
+ *
+ * - `exported < expected` — rows the snapshot knew about are MISSING. A genuine loss; the caller aborts.
+ * - `exported > expected` — the source GREW. Every snapshotted row was captured plus late arrivals, so
+ *   aborting destroys a usable bundle. Complete-or-better, but NOT provably exact (see below).
+ * - `exported === expected` — clean.
+ *
+ * A grown export must not be recorded as a clean capture. Neither export path holds a single-instant
+ * read across the whole pass: the vector path walks by offset, where an insert landing in an
+ * already-walked page shifts later rows, so a concurrent write can skip one row while duplicating
+ * another and still finish high; the graph path reads Nodes and Edges as two separate statements, so
+ * the two tables can come from different instants. Both are complete-or-better with a caveat, and the
+ * caveat belongs in the receipt.
+ *
+ * `indeterminate` exists so an unreadable count can never certify a bundle. A missing or non-finite
+ * count is not evidence of completeness, and defaulting it to `complete` would let an absent
+ * measurement vouch for everything beneath it — the exact shape this module exists to remove.
+ * @module ai/services/memory-core/helpers/exportCompleteness
+ */
+
+/**
+ * @summary The verdicts an export's row counts can carry, stable for reporting and for callers to switch on.
+ */
+export const EXPORT_COMPLETENESS = Object.freeze({
+    complete     : 'complete',
+    grew         : 'grew-during-export',
+    indeterminate: 'indeterminate',
+    partial      : 'partial'
+});
+
+/**
+ * @summary Classifies one export's row counts into a three-way verdict, refusing on unreadable counts.
+ *
+ * Pure and I/O-free: the caller owns the policy (abort on `partial` and `indeterminate`, record the
+ * advisory on `grew`), because the accuracy caveat differs per export path and belongs in that path's
+ * own message.
+ *
+ * @param {Number} exported Rows actually written by the streaming pass.
+ * @param {Number} expected The pre-pass count snapshot.
+ * @returns {String} A verdict from {@link EXPORT_COMPLETENESS}.
+ */
+export function classifyExportCompleteness(exported, expected) {
+    if (!Number.isFinite(exported) || !Number.isFinite(expected)) {
+        return EXPORT_COMPLETENESS.indeterminate;
+    }
+    if (exported < expected) {
+        return EXPORT_COMPLETENESS.partial;
+    }
+    if (exported > expected) {
+        return EXPORT_COMPLETENESS.grew;
+    }
+
+    return EXPORT_COMPLETENESS.complete;
+}
+
+/**
+ * @summary Stamps the growth advisory onto an export's `stats`, so the bundle's receipt states
+ * complete-or-better rather than claiming a clean capture.
+ *
+ * @param {Object} stats The export statistics object, mutated in place.
+ * @returns {Object} The same `stats`, for call-site chaining.
+ */
+export function recordExportGrowth(stats) {
+    stats.grewDuringExport = true;
+    stats.growthDelta      = stats.exported - stats.expected;
+
+    return stats
+}

--- a/test/playwright/unit/ai/services/memory-core/exportCompleteness.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/exportCompleteness.spec.mjs
@@ -1,0 +1,86 @@
+import {test, expect}                                                        from '@playwright/test';
+import fs                                                                    from 'fs-extra';
+import path                                                                  from 'path';
+import {fileURLToPath}                                                       from 'url';
+import {classifyExportCompleteness, EXPORT_COMPLETENESS, recordExportGrowth} from '../../../../../../ai/services/memory-core/helpers/exportCompleteness.mjs';
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../../../../..');
+
+test.describe('exportCompleteness — a collection that GREW is not a partial export', () => {
+    test('the exact production abort (32272/32271) is growth, not a loss', () => {
+        // Every backup on the plane died on this comparison: one row MORE than the pre-pass count,
+        // because a live agent wrote a single memory mid-export.
+        expect(classifyExportCompleteness(32272, 32271)).toBe(EXPORT_COMPLETENESS.grew)
+    });
+
+    test('a genuine loss still aborts — the guard keeps its teeth', () => {
+        expect(classifyExportCompleteness(32270, 32271)).toBe(EXPORT_COMPLETENESS.partial);
+        expect(classifyExportCompleteness(0, 61206)).toBe(EXPORT_COMPLETENESS.partial)
+    });
+
+    test('an exact match is complete', () => {
+        expect(classifyExportCompleteness(32271, 32271)).toBe(EXPORT_COMPLETENESS.complete);
+        expect(classifyExportCompleteness(0, 0)).toBe(EXPORT_COMPLETENESS.complete)
+    });
+
+    test('an unreadable count refuses — it can never certify a bundle', () => {
+        // The failure this whole module exists to remove: an absent measurement vouching for
+        // everything beneath it. Neither `complete` nor `grew` is an honest answer here.
+        for (const bad of [undefined, null, NaN, Infinity, -Infinity, '32271', {}]) {
+            expect(classifyExportCompleteness(bad, 32271)).toBe(EXPORT_COMPLETENESS.indeterminate);
+            expect(classifyExportCompleteness(32271, bad)).toBe(EXPORT_COMPLETENESS.indeterminate)
+        }
+    });
+
+    test('growth is stamped on the receipt, so the bundle never reads as a clean capture', () => {
+        const stats = {collection: 'neo-agent-memory', expected: 32271, exported: 32272};
+
+        recordExportGrowth(stats);
+
+        expect(stats.grewDuringExport).toBe(true);
+        expect(stats.growthDelta).toBe(1)
+    });
+});
+
+test.describe('exportCompleteness — every export path states what it actually captured', () => {
+    // The predicate was wrong at BOTH Memory Core sites, and the second was found only by grepping
+    // for the SHAPE rather than for the error that fired. The third — the Knowledge Base mirror —
+    // was found only by asking who consumes the count. This is the mechanical sunset: a fourth
+    // export path fails here instead of silently mis-reporting backups again.
+    const EXPORT_PATHS = [
+        {file: 'ai/services/memory-core/DatabaseService.mjs',    classifierCalls: 2},
+        {file: 'ai/services/knowledge-base/DatabaseService.mjs', classifierCalls: 1}
+    ];
+
+    for (const {file, classifierCalls} of EXPORT_PATHS) {
+        test(`${file} compares counts only through the shared classifier`, () => {
+            const source = fs.readFileSync(path.join(REPO_ROOT, file), 'utf8');
+
+            const bareComparisons = source
+                .split('\n')
+                .map((line, index) => ({line: line.trim(), number: index + 1}))
+                .filter(({line}) => /\bexported\s*(!==|!=|===|==)\s*(stats\.)?(expected|count)\b/.test(line));
+
+            expect(bareComparisons, 'bare exported/expected comparisons must route through ' +
+                `classifyExportCompleteness — found: ${JSON.stringify(bareComparisons)}`).toEqual([]);
+
+            // Positive control: the scan really is pointed at a file that classifies, so an empty
+            // result means "routed", never "the file moved and the scan found nothing".
+            expect(source.match(/classifyExportCompleteness\(/g)).toHaveLength(classifierCalls)
+        });
+    }
+
+    test('the KB export returns what it WROTE, never the pre-pass snapshot', () => {
+        // `exportDatabase`'s count feeds the backup orchestrator's verifyBundleIntegrity KB
+        // row-count parity. Returning the snapshot made the verifier compare it against itself,
+        // so an export that dropped rows in the per-id rescue path verified clean.
+        const source = fs.readFileSync(
+            path.join(REPO_ROOT, 'ai/services/knowledge-base/DatabaseService.mjs'), 'utf8'
+        );
+
+        expect(source).not.toMatch(/^\s*return count;\s*$/m);
+        expect(source).toMatch(/^\s*return exported;\s*$/m);
+        // and the rescue path must TALLY its drops, not only log them
+        expect(source).toMatch(/skipped\+\+/)
+    });
+});


### PR DESCRIPTION
Resolves #16516

## Why this is urgent

Memory Core healthcheck, live at `2026-08-04T20:52:18Z`:

```json
"backup": {"lastSuccessful": null, "lastCompleted": null, "count": 0, "unusableCount": 0, "unverifiedCount": 0}
```

The plane has **zero backups**. The Knowledge Base corpus @neo-opus-grace restored today (61,206 chunks) was unprotected the moment it came back, and the backup layer had been failing for hours while reporting a data-integrity error it manufactured itself.

## What was wrong

Three export paths own completeness accounting. All three mis-stated what they captured — in two opposite directions.

### Over-strict: a collection that GREW was destroyed as a partial export

```
PARTIAL_COLLECTION_EXPORT: neo-agent-memory exported 32272/32271 records
```

One row **more** than expected. `expected` is a count snapshot taken before the streaming pass, and the guard used strict inequality in both directions — so one live agent writing one memory aborted the whole bundle. The collection is demonstrably still growing: the same healthcheck reads 32,358.

### Under-strict: the Knowledge Base export could not detect loss at all

`Knowledge_DatabaseService#exportCollection` never counted what it wrote. It returned `count` — the pre-pass snapshot — logged it as the exported total, and dropped corrupted vectors in its per-id rescue path with a log line and no tally.

That number is consumed by the backup orchestrator's `verifyBundleIntegrity` for KB row-count parity, per `exportDatabase`'s own JSDoc. **The integrity verifier was comparing the snapshot against itself.** An export that silently lost rows verified clean — and this is the instrument that certified the backup set the restore depended on.

## The shape of the fix

New pure helper `ai/services/memory-core/helpers/exportCompleteness.mjs` — sibling precedent `vectorWriteInvariant.mjs` / `vectorJsonlSourceValidation.mjs` / `graphJsonlImport.mjs` in the same folder, two of which the KB service already imports.

| counts | verdict | action |
|---|---|---|
| `exported < expected` | `partial` | throw — unchanged |
| `exported > expected` | `grew` | keep the bundle, record the caveat |
| `exported === expected` | `complete` | unchanged |
| either non-finite | `indeterminate` | throw |

`indeterminate` is the point of the module as much as `grew` is: a missing or non-finite count must never certify a bundle. Defaulting it to `complete` would let an absent measurement vouch for everything beneath it.

A grown export is **not** recorded as clean. Neither path holds a single-instant read, so the accuracy caveat stays at the call site where the mechanism differs:

- the vector paths page by offset — an insert landing in an already-walked page shifts later rows, so a concurrent write can skip one row while duplicating another and still finish high;
- the graph path reads Nodes and Edges as two separate statements, so the two tables can come from different instants.

The KB site additionally counts what it writes, tallies rescue-path skips, and returns `exported` — so `verifyBundleIntegrity` receives a measurement instead of a restatement.

## How each site was found — the failure name found only the first

The error named `neo-agent-memory`, so the Memory Core vector path was obvious. The **native-graph** site turned up only by grepping for the *shape* rather than the error that fired. The **Knowledge Base** site turned up only by asking who consumes the returned count. Fixing the path that threw would have left the corpus-protecting path broken.

## Deltas

| File | Delta |
|---|---|
| `ai/services/memory-core/helpers/exportCompleteness.mjs` | **new** — frozen `EXPORT_COMPLETENESS` verdicts, pure `classifyExportCompleteness`, `recordExportGrowth` receipt stamp |
| `ai/services/memory-core/DatabaseService.mjs` | both export sites route through the classifier; growth recorded as an advisory instead of aborting |
| `ai/services/knowledge-base/DatabaseService.mjs` | counts rows written, tallies rescue-path skips, returns `exported` not the snapshot, classifies completeness |
| `test/playwright/unit/ai/services/memory-core/exportCompleteness.spec.mjs` | **new** — verdict coverage + the mechanical sunset across all three export paths |

## Test Evidence

**The graph window needs no second process.** Between the two `count(*)` statements and the two `iterate()` scans, the method awaits two dynamic imports and `fs.ensureDir`. `better-sqlite3` blocks writes only on the *same* connection during iteration, so another daemon lands in that gap freely. Reproduced against a real WAL database, one concurrent insert from a second connection:

```
expected=100  exported=101  (one concurrent insert)
SHIPPED guard  (exported !== expected) -> destroys backup: true
REPAIRED guard (exported <   expected) -> destroys backup: false
negative control — genuine loss (98/101) still aborts under (<): true
```

**The mechanical sunset was proven red, not assumed.** Re-introducing the two-way predicate at one site failed the spec naming the exact line:

```
Error: bare exported/expected comparisons must route through classifyExportCompleteness
  — found: [{"line":"if (stats.exported !== stats.expected) {","number":302}]
  1 failed
  7 passed
```

then restored to green.

Evidence: `32 passed` at exact head across the new `exportCompleteness.spec.mjs` plus every pre-existing spec on the changed paths — `DatabaseService.graphBackup.spec.mjs`, `DatabaseService.backupPath.spec.mjs`, `captureReceipt.spec.mjs`. The two fail-loud partial-export assertions pass **unchanged**: the guard kept its teeth.

## Post-Merge Validation

One AC cannot be satisfied before merge, and it is the one that matters most:

- **Healthcheck `backup.lastSuccessful` becomes non-null on the next scheduled run.** Today it is `null` with `count: 0`. If it stays null after this lands, the export guard was not the whole cause and the lane reopens.
- `backup.unusableCount` / `unverifiedCount` stay at `0` — the repaired KB count feeds real parity into `verifyBundleIntegrity`, so a bundle that genuinely lost rows must now surface there rather than verifying clean.

## Contract Ledger Matrix

| Target Surface | Source of Authority | Proposed Behavior | Fallback | Docs | Evidence |
|---|---|---|---|---|---|
| `exportCompleteness.mjs` exports (new) | this PR | 3-way verdict + growth stamp; pure, I/O-free | n/a — new module | module `@summary` + per-export JSDoc | `exportCompleteness.spec.mjs` |
| `stats.grewDuringExport`, `stats.growthDelta` (new) | `Memory_DatabaseService#exportCollection` / `#exportGraph` | present only on the `grew` verdict | absent = not grown; no consumer reads them today (grep across `ai/`, `buildScripts/`, `test/`) | JSDoc on `recordExportGrowth` | grep: no external reader |
| `PARTIAL_COLLECTION_EXPORT` `error.details` | both services | gains `verdict` | existing keys unchanged | in-source | `graphBackup` + `backupPath` specs pass unchanged |
| `PARTIAL_COLLECTION_EXPORT` message | both services | gains `Verdict: <v>.` suffix | prefix unchanged, so existing `toContain` assertions hold | in-source | both pre-existing specs green |
| `Knowledge_DatabaseService#exportCollection` return | `exportDatabase` → `verifyBundleIntegrity` | rows **written**, not the pre-pass snapshot | still a `Number`; empty-source `0` early-return unchanged, preserving the `count: 0` receipt semantic | JSDoc updated in this PR | `captureReceipt.spec.mjs` green |

## Decision Record impact

`none`. Reviewed ADR-0003 / ADR-0017 (Chroma topology) and ADR-0015 (graph store backend posture) — this changes neither topology nor backend posture, only completeness accounting inside the export routines. No config leaf is introduced or read, so ADR-0019 does not apply.

## Out of scope

- **Making the export atomic.** A single-instant snapshot needs a read transaction or a Chroma-side snapshot API. This PR makes the receipt *honest* about the window rather than closing it.
- **The `verifyBundleIntegrity` parity rule itself** — it now receives a real measurement; whether its threshold is right is a separate question.
- **Consolidating the deliberate KB / Memory Core export duplication.** That mirror is documented as intentional; this PR shares only the *predicate*. The broader duplication concern is what `#16515` measures and `#16514` exemplifies.
- **Restore-side per-collection reporting** — that is `#16510`.

## Reviewer notes

- The `--fix` block-aligner is known to corrupt multi-line destructured imports, so every new import here is single-line and all four files were re-verified with `node --check` after alignment.
- `#16428` is the auto-maintained `[DATA-SYNC-ALARM]` this defect helped keep firing. It is deliberately **not** the close target — an auto-maintained alarm is the wrong artifact to close from a code fix.
- Post-merge verification is the one AC I cannot satisfy pre-merge: healthcheck `backup.lastSuccessful` becoming non-null on the next scheduled run.

Authored by Ada (Opus 5, Claude Code). Session eeacb603-97f1-4241-9b2f-3a542cab6d2c.
