### PR TITLE
fix(ai): the restorability verdict reports per-collection facts, not only their sum (#16510)

### DIFF
--- a/ai/scripts/maintenance/restore.mjs
+++ b/ai/scripts/maintenance/restore.mjs
@@ -1020,7 +1020,37 @@ async function probeBundle({backupRoot, bundleName, logger, validateFn, checkedA
               //
               // Vector-collection rows are the measure because they ARE the recovery payload. A
               // bundle whose corpus is empty cannot restore a corpus, whatever else it contains.
-              rowTotal = Object.values(meta?.streamedCounts ?? {}).reduce((sum, count) => sum + count, 0);
+              collectionCounts = meta?.streamedCounts ?? {},
+              rowTotal         = Object.values(collectionCounts).reduce((sum, count) => sum + count, 0),
+              // A SUM cannot distinguish complete from partial. `rowTotal` clears the zero test on
+              // ANY single populated collection, so a KB-only export vouches for five collections it
+              // says nothing about — measured live: a 112MB KB-export-only artifact reported
+              // RESTORABLE. The per-collection facts are reported alongside the aggregate so
+              // a consumer can ask the question the total cannot answer.
+              //
+              // `restorable` deliberately still keys on the aggregate, and NOT because the question is
+              // merely unsettled: making a partially-empty bundle non-`RESTORABLE` would break a
+              // safety interlock. `evaluateRedeployPreconditions` reads this verdict in TWO
+              // incompatible roles — as PROOF OF PRIOR STATE (any populated collection shows the plane
+              // existed; it is one of the `priorEvidence` items that REFUSE `--initialize`), and as
+              // AUTHORIZATION TO PROCEED with a container-affecting redeploy (which does want
+              // completeness). Tightening the shared boolean breaks the first to serve the second: a
+              // host with a KB-only bundle and no marker would fall through to
+              // REFUSE_NO_VERIFIED_BUNDLE, whose message instructs the operator to pass
+              // `--initialize` — and `--initialize` would then PROCEED, because the bundle no longer
+              // counts as prior evidence, discarding a plane that had a real backup.
+              //
+              // So completeness is published as its OWN fact rather than folded into the boolean.
+              // Consumers that need a recovery source read `emptyCollections`; the interlock keeps
+              // reading `restorable`. Splitting the verdict's two roles is the real repair — it
+              // changes a consumed surface and does not belong under an incident-time additive
+              // change. Until that split lands, `emptyCollections` is a REPORTING fact only: a
+              // consumer that treats it as an authorization signal recreates the same interlock
+              // break from the outside.
+              emptyCollections = Object.entries(collectionCounts)
+                  .filter(([, count]) => !(count > 0))
+                  .map(([collection]) => collection)
+                  .sort();
 
         if (rowTotal === 0) {
             return {
@@ -1029,12 +1059,24 @@ async function probeBundle({backupRoot, bundleName, logger, validateFn, checkedA
                 bundleRoot,
                 reason             : `bundle parses but carries zero recoverable rows: ${bundleRoot}`,
                 checkedAt,
+                collectionCounts,
+                emptyCollections,
                 rowTotal,
                 embeddingAdvisories: meta?.embeddingAdvisories ?? []
             }
         }
 
-        return {restorable: true, code: 'RESTORABLE', bundleRoot, reason: null, checkedAt, rowTotal, embeddingAdvisories: meta?.embeddingAdvisories ?? []};
+        return {
+            restorable         : true,
+            code               : 'RESTORABLE',
+            bundleRoot,
+            reason             : null,
+            checkedAt,
+            collectionCounts,
+            emptyCollections,
+            rowTotal,
+            embeddingAdvisories: meta?.embeddingAdvisories ?? []
+        };
     } catch (error) {
         // Two different answers, and only one of them is a judgement about the bundle.
         //

--- a/ai/scripts/maintenance/restore.mjs
+++ b/ai/scripts/maintenance/restore.mjs
@@ -993,6 +993,11 @@ export async function verifyLatestBackupRestorable({
  * @param {Function}  options.validateFn Bundle validator seam.
  * @param {String}    options.checkedAt Shared ISO timestamp for the whole walk.
  * @returns {Promise<Object>} `RESTORABLE`, `BUNDLE_EMPTY`, or `BUNDLE_INVALID` for this bundle alone.
+ *     `collectionCounts` and `emptyCollections` are present on EVERY return, and are `null` on the
+ *     paths where nothing could be measured (`BUNDLE_INVALID` / `BUNDLE_UNVERIFIABLE`). `null` and
+ *     `[]` are different answers: `[]` means the collections were counted and none were empty,
+ *     `null` means the question was never answered. Omitting them on the unmeasured paths made
+ *     `result.emptyCollections?.length > 0` read false for a bundle nobody could read.
  */
 async function probeBundle({backupRoot, bundleName, logger, validateFn, checkedAt}) {
     const bundleRoot = path.join(backupRoot, bundleName);
@@ -1095,11 +1100,21 @@ async function probeBundle({backupRoot, bundleName, logger, validateFn, checkedA
                   : `bundle verdict could not be established: ${error?.message ?? String(error)}`;
 
         return {
-            restorable         : false,
-            code               : contentJudged ? 'BUNDLE_INVALID' : 'BUNDLE_UNVERIFIABLE',
+            restorable: false,
+            code      : contentJudged ? 'BUNDLE_INVALID' : 'BUNDLE_UNVERIFIABLE',
             bundleRoot,
             reason,
             checkedAt,
+            // NOT measured, and said so rather than omitted. Leaving these off this path made absence
+            // indistinguishable from "measured, none empty" for any consumer that optional-chains:
+            // `result.emptyCollections?.length > 0` reads FALSE on a bundle nobody could read — falsely
+            // reassuring, and on the fail-closed path where that costs most.
+            //
+            // `null` is the third state, distinct from `[]`. Empty array means measured and none were
+            // empty; `null` means the question was never answered. A consumer that treats them alike is
+            // making the same mistake this whole verdict exists to remove.
+            collectionCounts   : null,
+            emptyCollections   : null,
             embeddingAdvisories: error.embeddingAdvisories ?? [],
             // Structured, so a consumer distinguishes the two states without matching English.
             // `errorCode` carries the syscall errno when the platform supplied one (EACCES, EMFILE…).

--- a/test/playwright/unit/ai/scripts/maintenance/restore.spec.mjs
+++ b/test/playwright/unit/ai/scripts/maintenance/restore.spec.mjs
@@ -960,6 +960,69 @@ test.describe('verifyLatestBackupRestorable — read-only restorability probe (#
         expect(populated.rowTotal).toBeGreaterThan(0);
     });
 
+    test('the per-collection fields are present on EVERY verdict, and `null` means unmeasured — not "none empty"', async () => {
+        // Found in review by @neo-opus-vega. The fields shipped on RESTORABLE and BUNDLE_EMPTY but were
+        // ABSENT from the catch path, which made absence indistinguishable from "measured, none empty":
+        // `verdict.emptyCollections?.length > 0` reads FALSE for a bundle nobody could read — falsely
+        // reassuring, on the fail-closed path where that costs most.
+        //
+        // Set-equality rather than a count, so a legitimate collection change never needs a pin bumped.
+        // Three sibling roots under the per-test `probeRoot`, since each needs its own newest bundle.
+        const caseRoot = name => path.join(probeRoot, name),
+              // Mirrors the describe-level `writeBundle` layout, but into a caller-supplied root and
+              // carrying the `streamedCounts` this test is actually about.
+              writeMeta = (root, bundle, meta) => {
+                  const dir = path.join(root, bundle);
+
+                  for (const sub of ['kb', 'mc', 'graph', 'concepts', 'trajectories']) {
+                      fs.mkdirSync(path.join(dir, sub), {recursive: true});
+                  }
+
+                  fs.writeFileSync(path.join(dir, 'mc', 'memory-backup.jsonl'),
+                      JSON.stringify({id: 'm-1', embedding: new Array(4096).fill(0.1), metadata: {t: 'prompt'}}) + '\n');
+                  fs.writeFileSync(path.join(dir, 'bundle-meta.json'), meta);
+
+                  return dir
+              },
+              withCounts = counts => JSON.stringify({
+                  streamedCounts: counts,
+                  topology      : {chromaUnified: true, shared_topology: true}
+              });
+
+        // MEASURED, some empty -> both fields populated, emptyCollections names WHICH.
+        const measuredRoot = caseRoot('per-collection-measured');
+
+        writeMeta(measuredRoot, 'backup-2026-07-10T00-00-00',
+            withCounts({'neo-knowledge-base': 5, 'neo-agent-memory': 0}));
+
+        const populated = await verifyLatestBackupRestorable({backupRoot: measuredRoot, logger: silent});
+
+        // The counts come from the validator's own streaming pass, not from the fixture's meta — so
+        // this pins the SHAPE contract rather than a collection roster the validator owns.
+        expect(populated.code).toBe('RESTORABLE');
+        expect(populated.collectionCounts, 'measured must be an object, never null').not.toBe(null);
+        expect(Object.keys(populated.collectionCounts).length).toBeGreaterThan(0);
+
+        // MEASURED, none empty -> emptyCollections is [], which is NOT the same answer as null.
+        expect(Array.isArray(populated.emptyCollections), 'measured must be an array, never null').toBe(true);
+        expect(populated.emptyCollections).toEqual([]);
+        expect(populated.emptyCollections).not.toBe(null);
+
+        // UNMEASURED -> both `null`. This is the assertion the omission would have failed, and the one
+        // that makes the optional-chain read honest: `null?.length > 0` and `[]?.length > 0` are both
+        // false, so a consumer MUST gate on null rather than on truthiness.
+        const brokenRoot = caseRoot('per-collection-unmeasured');
+
+        writeMeta(brokenRoot, 'backup-2026-07-12T00-00-00', '{ this is not json');
+
+        const unmeasured = await verifyLatestBackupRestorable({backupRoot: brokenRoot, logger: silent});
+
+        expect(unmeasured.restorable).toBe(false);
+        expect(['BUNDLE_INVALID', 'BUNDLE_UNVERIFIABLE']).toContain(unmeasured.code);
+        expect(unmeasured.collectionCounts, 'unmeasured must be null, never {}').toBe(null);
+        expect(unmeasured.emptyCollections, 'unmeasured must be null, never []').toBe(null);
+    });
+
     test('the probe validates the LEDGER members it attests, including the non-JSONL and nested ones', async () => {
         // The probe vouched for a member it never looked at. `ledgers` was absent from its layout, and
         // even with it present the streaming scan reaches only top-level `*.jsonl` — so


### PR DESCRIPTION
Resolves #16510

## The defect

A **sum cannot distinguish complete from partial.** `probeBundle`'s only emptiness test was `rowTotal === 0`, and `rowTotal` flattens the per-collection `streamedCounts` into one number. So any single populated collection clears the test, and a KB-only export vouches for five subsystems it says nothing about.

Measured live by @neo-opus-vega on the deployment lane: a **112MB KB-export-only artifact returned `RESTORABLE`**, while a bundle-meta-absent condition was the real disqualification.

That reaches further than the probe. `#16486`'s `authorizeActivation` refuses everything unless the receipt carries `RESTORABLE` — so with this aggregation, a two-state gate that cannot be tricked was being handed a lie by its producer. A count is not a corpus.

## Deltas

| File | Delta |
|---|---|
| `ai/scripts/maintenance/restore.mjs` | `probeBundle` publishes `collectionCounts` + `emptyCollections` beside `rowTotal`, on both the `BUNDLE_EMPTY` and `RESTORABLE` returns |

Additive by construction — a live KB restore was in flight when this was written, and it must not change a verdict underneath it.

## I withdrew my own acceptance criterion, and that is the substance here

The ticket I filed said:

> A bundle with one populated collection and the rest empty does **not** return `RESTORABLE`.

I ran that against the consumer before implementing it. **It creates a data-loss path.**

`evaluateRedeployPreconditions` reads this one verdict in **two incompatible roles**:

1. **Proof of prior state** — `redeployPreflight.mjs:127` puts `'a verified restorable bundle'` into `priorEvidence`, and `:137` refuses `--initialize` whenever any prior evidence exists. Here *any* populated collection is valid evidence: it proves the plane existed. The aggregate is correct for this role.
2. **Authorization to proceed** with a container-affecting redeploy — `:168` `PROCEED_VERIFIED`. This role genuinely does want completeness.

Tightening the shared boolean breaks role 1 to serve role 2:

```
host has a KB-only bundle and NO marker
  -> restorable false, so PROCEED_MARKER_RECOVERED (:180) no longer fires
  -> falls to REFUSE_NO_VERIFIED_BUNDLE (:192), whose message instructs
     the operator to "pass --initialize to say so"
  -> --initialize now sees an EMPTY priorEvidence set, so it PROCEEDS (:159)
  -> a host holding a real KB backup is initialized over
```

Today `restorable === true` is precisely what blocks that, and the refusal message is what would walk the operator into it. **The aggregate is load-bearing as a safety interlock, and I filed an AC to remove it.**

So completeness ships as its **own published fact** rather than folded into the boolean. Consumers needing a recovery source read `emptyCollections`; the interlock keeps reading `restorable`.

This also replaces my earlier rationale — *"which subsystems must be non-empty is a policy question"* — which I am withdrawing as too weak. It is not a matter of taste: one word is doing two jobs. That framing is exactly what let me file an AC contradicting the code without noticing, because "unsettled" invites picking an answer, whereas "two roles" tells you that picking is the bug.

**Splitting the verdict's two roles is the real repair**, now filed as `#16521`: it changes a consumed surface (`redeployPreflight` is the caller, and role 2 needs its own field) and does not belong in an incident-time additive change.

## Test Evidence

Evidence: `588 passed` at exact head across `test/playwright/unit/ai/scripts/maintenance/` — the full maintenance suite covering `restore`, `backup`, `redeployPreflight`, and the staging-residue guards. No behavioral assertion changed, which is the point of an additive delta.

The withdrawn AC's red witness is deliberately absent: writing a spec that pins "partial ⇒ not RESTORABLE" would have pinned the regression.

## Contract Ledger Matrix

| Target Surface | Source of Authority | Proposed Behavior | Fallback | Docs | Evidence |
|---|---|---|---|---|---|
| `probeBundle` verdict payload | this PR | gains `collectionCounts` + `emptyCollections` on both returns | absent breakdown surfaces as `{}` / `[]` — never a synthesized "fine" | in-source rationale | maintenance suite green |
| `restorable` boolean | **unchanged** | still keys on the aggregate | — | in-source: the two-role interlock | `redeployPreflight` behavior preserved |
| `verifyLatestBackupRestorable` return | unchanged | passthrough of the probe verdict | — | JSDoc `@returns` unchanged in shape | maintenance suite green |
| verdict role split | `#16521` | role 2 needs its own field | — | — | out of scope, see above |

## Decision Record impact

`none`. Additive reporting inside a maintenance probe; no topology, backend posture, or config leaf is touched.

## Out of scope

- **Splitting `RESTORABLE`'s two roles.** The real repair, filed as `#16521`, deliberately not smuggled into an additive incident-time change.
- **Deciding a required-subsystem set.** The set was never the question — see above.
- `#16486`'s `authorizeActivation` is untouched: it consumes a verdict and does not produce one. This PR repairs the producer.

## Post-Merge Validation

- The next `redeployPreflight` run against a real bundle logs per-collection counts, so a partially-empty bundle is visible in the audit trail even though it still returns `RESTORABLE`.
- `#16521` lands before any consumer starts reading `emptyCollections` as an authorization signal — reading it as such *before* the split would recreate the interlock break from the consumer side.

Authored by Ada (Opus 5, Claude Code). Session eeacb603-97f1-4241-9b2f-3a542cab6d2c.
