### PR TITLE
fix(dashboard): a paused pointer is not a departure, and an unknown one is (#16497)

### DIFF
--- a/src/dashboard/DockVesselConversion.mjs
+++ b/src/dashboard/DockVesselConversion.mjs
@@ -22,10 +22,13 @@
  *   convert-out is its inverse. The design record's source-hook pair (`suspendWindowDrag` /
  *   `resumeWindowDrag`) is the contract-named actuator set a host binds the two seams to — the
  *   record's outcome machine gains NO state and needs NO amendment for this capability.
- * - **The pointer gate holds in BOTH directions.** Rect overlap alone never converts (intent stays
- *   pointer-owned: convert-in requires the pointer inside the target's dock-accepting region, the
- *   claim-protocol feed) — and rect overlap alone never HOLDS a conversion: the pointer leaving
- *   the target reverts at any ratio, so a stale claim can never pin a converted vessel.
+ * - **The pointer gate is asymmetric, deliberately.** Rect overlap alone never converts: intent
+ *   stays pointer-owned, so convert-in requires a LIVE claim on the target's dock-accepting region.
+ *   Convert-OUT is different — it requires an OBSERVED exit or a geometric retreat, never the mere
+ *   absence of a claim. A claim expires 300ms after its last refresh, and a stationary pointer
+ *   refreshes nothing, so an ordinary pause over the drop target used to un-convert a vessel that
+ *   had not moved at all. An un-converted vessel still cannot be pinned by a stale claim, because
+ *   convert-in kept its live-claim requirement.
  * - **The dead band IS the Schmitt trigger.** `convertThreshold` (in) sits strictly above
  *   `revertThreshold` (out), validated fail-loud; a decision fires only on crossing its OWN
  *   threshold, so the convert-in moment lies above the revert band by construction — the false-flip
@@ -221,15 +224,27 @@ export function createVesselConversionSensor(config = {}) {
          * convert-out on crossing below `revertThreshold` OR the pointer leaving the target.
          * Samples inside the dead band (gate unchanged) fire nothing — the hysteresis hold.
          * @param {Object} data
-         * @param {Boolean} data.pointerInTarget The claim-protocol feed: pointer inside the
-         *     target's dock-accepting region. Gates conversion in BOTH directions.
+         * @param {Boolean} data.pointerInTarget The claim-protocol feed: a LIVE claim on the
+         *     target's dock-accepting region. It answers "is there a live claim?", NOT "is the
+         *     pointer inside?" — a claim expires 300ms after its last refresh, and a stationary
+         *     pointer refreshes nothing. Gates convert-IN unconditionally; gates convert-OUT only
+         *     when `pointerExitedTarget` is absent.
+         * @param {Boolean} [data.pointerExitedTarget] TRI-STATE observed departure, and absence
+         *     fails SAFE. `true` is an observed exit and reverts at any ratio. `false` is an
+         *     observed still-inside and HOLDS the conversion through a lapsed claim — the only
+         *     state that suppresses the pause flicker. ABSENT (`undefined`/`null`) means the host
+         *     cannot distinguish a real exit from an expired claim, and falls back to the landed
+         *     contract where losing the claim reverts. Absence must never buy the permissive
+         *     reading: defaulting it to "not exited" would let rect overlap alone HOLD a
+         *     conversion for every caller not yet taught this signal, deleting the
+         *     both-directions gate by omission rather than by decision.
          * @param {Object} data.sourceRect Live `{x, y, width, height}` of the dragged vessel
          * @param {Object} data.targetRect Live `{x, y, width, height}` of the target vessel
          * @returns {Object} The sample record `{composed, converted, pointerInTarget, rx, ry,
          *     sourceRect, targetRect}`. While strict async admission is pending it additionally
          *     carries `transitioning: true`, and `converted` remains the prior admitted state.
          */
-        sample({pointerInTarget, sourceRect, targetRect} = {}) {
+        sample({pointerExitedTarget, pointerInTarget, sourceRect, targetRect} = {}) {
             // Invalid geometry DOMINATES: a missing, degenerate, or non-finite rect forces the
             // whole sample to zero WITHOUT consulting the composition seam — a degenerate axis
             // produces a valid-looking 0 ratio, and a non-min injected composer could elevate it
@@ -237,6 +252,33 @@ export function createVesselConversionSensor(config = {}) {
             const
                 measurable = isMeasurableRect(sourceRect) && isMeasurableRect(targetRect),
                 pointer    = pointerInTarget === true,
+                // A CONVERTED vessel reverts on a genuine exit, never on mere claim absence — but
+                // ONLY when the host can actually tell those apart.
+                //
+                // `pointerInTarget` is the claim arbiter's live resolution, and a claim expires
+                // `claimTtlMs` (300ms) after its last refresh. A stationary pointer fires no move
+                // events, so an ordinary human pause over the drop target lets the claim lapse
+                // while the vessel sits fully inside the target — measured: `composed` stays at
+                // 1.000 while `converted` flips true→false→true per pause. That is a user-visible
+                // convert/revert flicker on every hover, not a stale claim. `pointerInTarget`
+                // answers "is there a live claim?" while this decision needs "did the pointer
+                // leave?", and a lapsed timer is not a departure.
+                //
+                // So `pointerExitedTarget` is TRI-STATE, and absence fails SAFE rather than
+                // permissive. `true` is an observed exit and reverts. `false` is an observed
+                // still-inside — the flicker fix, and the only state that holds a conversion
+                // through a lapsed claim. ABSENT means the host cannot distinguish the two, and
+                // must never silently buy the permissive reading: it falls back to the landed
+                // contract where losing the claim reverts. Defaulting absence to "not exited"
+                // would let rect overlap alone HOLD a conversion for every caller that has not
+                // been taught the new signal — deleting the documented both-directions gate by
+                // omission rather than by decision.
+                //
+                // Convert-IN is deliberately unchanged and still demands a live claim, so a stale
+                // claim can never pin a vessel that was never converted.
+                exitObserved = pointerExitedTarget === true,
+                exitUnknown  = pointerExitedTarget === undefined || pointerExitedTarget === null,
+                exited       = exitObserved || (exitUnknown && !pointer),
                 rx         = measurable ? axisRatio(sourceRect, targetRect, 'x', 'width')  : 0,
                 ry         = measurable ? axisRatio(sourceRect, targetRect, 'y', 'height') : 0,
                 composed   = measurable ? clampRatio(composeRatios({rx, ry})) : 0;
@@ -244,12 +286,14 @@ export function createVesselConversionSensor(config = {}) {
             let event = null,
                 next  = converted;
 
+            // Convert-IN still requires a live claim: an un-converted vessel must never be pinned
+            // by a claim that is not currently valid.
             if (!transition && !converted) {
                 if (pointer && composed >= convertThreshold) {
                     event = onConvertIn;
                     next  = true
                 }
-            } else if (!transition && (!pointer || composed < revertThreshold)) {
+            } else if (!transition && (exited || composed < revertThreshold)) {
                 event = onConvertOut;
                 next  = false
             }

--- a/test/playwright/unit/dashboard/DockVesselConversion.spec.mjs
+++ b/test/playwright/unit/dashboard/DockVesselConversion.spec.mjs
@@ -342,5 +342,104 @@ test.describe('Neo.dashboard.DockVesselConversion — createVesselConversionSens
             .toThrow(/required function seams/);
         expect(() => createVesselConversionSensor({...seams, composeRatios: 'min'}))
             .toThrow(/composeRatios must be a function seam/)
+    });
+
+    // `pointerInTarget` is the claim arbiter's LIVE resolution and a claim expires 300ms after its
+    // last refresh, so it answers "is there a live claim?" — not "is the pointer inside?". A
+    // stationary pointer fires no move events, so an ordinary human pause lets the claim lapse
+    // while the vessel sits fully inside the target. `pointerExitedTarget` is the tri-state that
+    // separates the two, and its ABSENT state is the one that matters most.
+    test.describe('a lapsed claim is not a departure', () => {
+        const source = rect(0, 0, 100, 100),
+              target = rect(0, 0, 100, 100);
+
+        const converted = () => {
+            const h = harness();
+            h.sensor.sample({pointerInTarget: true, sourceRect: source, targetRect: target});
+            expect(h.calls.converted).toHaveLength(1);
+            return h
+        };
+
+        test('an observed still-inside HOLDS the conversion through a lapsed claim — the flicker fix', () => {
+            const {calls, sensor} = converted();
+
+            // The pause: the claim has lapsed (pointerInTarget false) but the host observed that
+            // the pointer never left. Measured behaviour before the fix: converted flips
+            // true→false→true per pause at composed 1.000, a visible flicker on every hover.
+            for (let i = 0; i < 5; i++) {
+                const record = sensor.sample({
+                    pointerExitedTarget: false,
+                    pointerInTarget    : false,
+                    sourceRect         : source,
+                    targetRect         : target
+                });
+                expect(record.composed).toBe(1);
+                expect(record.converted).toBe(true)
+            }
+
+            expect(calls.reverted, 'a lapsed claim must not revert a converted vessel').toHaveLength(0)
+        });
+
+        test('an observed exit reverts, even while the rects still fully overlap', () => {
+            const {calls, sensor} = converted();
+
+            sensor.sample({
+                pointerExitedTarget: true,
+                pointerInTarget    : false,
+                sourceRect         : source,
+                targetRect         : target
+            });
+
+            expect(calls.reverted).toHaveLength(1);
+            expect(calls.reverted[0].composed, 'reversion happened at full rect overlap').toBe(1)
+        });
+
+        test('an ABSENT signal falls back to the landed contract — losing the claim reverts', () => {
+            // The fail-safe that keeps every caller not yet taught the new signal on the
+            // documented both-directions gate. Defaulting absence to "not exited" would let rect
+            // overlap alone HOLD a conversion, deleting that gate by omission rather than by
+            // decision. `null` is the same unknown as `undefined`.
+            for (const absent of [undefined, null]) {
+                const {calls, sensor} = converted();
+
+                sensor.sample({
+                    pointerExitedTarget: absent,
+                    pointerInTarget    : false,
+                    sourceRect         : source,
+                    targetRect         : target
+                });
+
+                expect(calls.reverted, `an unknown exit signal (${absent}) must fail SAFE`).toHaveLength(1)
+            }
+        });
+
+        test('an observed still-inside still yields to a GEOMETRIC retreat', () => {
+            // Holding through a lapsed claim must not become "rect overlap can never revert it".
+            const {calls, sensor} = converted();
+
+            sensor.sample({
+                pointerExitedTarget: false,
+                pointerInTarget    : false,
+                sourceRect         : rect(90, 0, 100, 100), // rx = 10/100 = 0.1, below revertThreshold
+                targetRect         : target
+            });
+
+            expect(calls.reverted, 'geometry below revertThreshold reverts regardless of the exit signal').toHaveLength(1)
+        });
+
+        test('convert-IN is unchanged: an observed still-inside never converts without a live claim', () => {
+            // The asymmetry is deliberate. Holding a conversion through a lapsed claim is safe;
+            // STARTING one on a claim that is not currently valid is not.
+            const {calls, sensor} = harness();
+
+            sensor.sample({
+                pointerExitedTarget: false,
+                pointerInTarget    : false,
+                sourceRect         : source,
+                targetRect         : target
+            });
+
+            expect(calls.converted, 'a lapsed claim must never pin a vessel that was never converted').toHaveLength(0)
+        })
     })
 });


### PR DESCRIPTION
Resolves #16497

## The defect

`pointerInTarget` is the claim arbiter's **live** resolution, and a claim expires 300ms after its last refresh (`GestureClaimArbiter`, `claimTtlMs`). A stationary pointer fires no move events, so an ordinary human pause over the drop target lets the claim lapse **while the vessel sits fully inside the target**.

Measured: `composed` stays at `1.000` while `converted` flips `true → false → true` per pause. A user-visible convert/revert flicker on every hover.

The value answers *"is there a live claim?"*; the decision needs *"did the pointer leave?"* **A lapsed timer is not a departure.**

## Deltas

| File | Delta |
|---|---|
| `src/dashboard/DockVesselConversion.mjs` | `pointerExitedTarget` tri-state separates an observed exit from an expired claim; convert-OUT consults it, convert-IN unchanged |
| `test/playwright/unit/dashboard/DockVesselConversion.spec.mjs` | five witnesses under `a lapsed claim is not a departure` |

```
true     observed exit          -> revert at any ratio
false    observed still-inside  -> HOLD through the lapsed claim   (the fix)
absent   host cannot tell       -> fall back to the landed contract
```

## My first cut was wrong, and the landed spec caught it

The original commit read `exited = pointerExitedTarget === true`. So a host that never passes the signal stopped reverting on pointer exit **altogether**, keeping only the geometric threshold — silently deleting this module's documented both-directions gate (*"rect overlap alone never HOLDS a conversion"*) for every existing caller, **by omission rather than by decision**.

The landed spec `pointer gate, both directions: overlap alone never converts, and overlap alone never HOLDS a conversion` went red, and it was right to. I had not run it before pushing that commit.

So absence now **fails safe**. This is the same discipline as a refused measurement anywhere else: an absent observation must not be spent as evidence for the permissive outcome. Only a host that explicitly reports `pointerExitedTarget: false` — *"I looked, the pointer is still inside"* — buys the flicker suppression.

**Convert-IN is deliberately unchanged** and still demands a live claim. The asymmetry is the point: holding a conversion through a lapsed claim is safe; *starting* one on a claim that is not currently valid is not, so a stale claim can never pin a vessel that was never converted.

## Test Evidence

Evidence: `525 passed` across `test/playwright/unit/dashboard/` at exact head, and `19 passed` in the conversion spec specifically (14 landed + 5 new).

**The flicker witness is proven RED against the pre-fix predicate.** Restoring `(!pointer || composed < revertThreshold)`:

```
      380 |  expect(calls.reverted, 'a lapsed claim must not revert a converted vessel').toHaveLength(0)
  1 failed
  18 passed
```

Restored: `19 passed`.

Only **one** of the five new tests fails pre-fix, and that is deliberate. The other four pin behaviour that was already correct — an observed exit still reverts at full overlap, an absent signal still reverts, a geometric retreat still wins over an observed still-inside, and convert-IN never fires without a live claim — so they are the guards that stop the fix over-reaching into the contract it was narrowing. A change this shape needs the *non*-witnesses as much as the witness.

## Contract Ledger Matrix

| Target Surface | Source of Authority | Proposed Behavior | Fallback | Docs | Evidence |
|---|---|---|---|---|---|
| `sample({pointerExitedTarget})` | this PR | new optional tri-state input | ABSENT ⇒ landed contract (claim absence reverts) — never the permissive reading | `@param` rewritten | `an ABSENT signal falls back to the landed contract` |
| `sample({pointerInTarget})` | unchanged shape | still gates convert-IN unconditionally; gates convert-OUT only when the exit signal is absent | — | `@param` clarified: it answers "is there a live claim?", not "is the pointer inside?" | `convert-IN is unchanged` |
| sample record | unchanged | no new fields | — | — | landed record assertions untouched |
| `onConvertIn` / `onConvertOut` seams | unchanged | same call shape, same admission semantics | — | — | 525 dashboard specs green |

No caller is required to change: every existing host keeps today's behaviour until it opts in by reporting the signal.

## Decision Record impact

`none`. ADR 0029 §2.8.1/§2.8.2 owns the gesture claim protocol and the arbiter's PULL-ONLY `claimTtlMs`; this PR changes neither. It changes how one downstream sensor *interprets* an expired claim, and the arbiter is untouched.

## Out of scope

- **`claimTtlMs` itself.** 300ms may well be wrong for a human hover, but that is the arbiter's leaf and an ADR-0029 surface. This fix works correctly at any TTL, which is the better property.
- **Threshold calibration.** The threshold was never the defect — it converts at step 10/24 covering 10.5% of the target and is self-documented as a placeholder awaiting headed calibration. I had this backwards earlier in the lane and the measurement corrected me.
- **The `min()` divisor asymmetry** — `axisRatio` divides by `min(sourceExtent, targetExtent)`, so the ratio's meaning flips with the rect-size relationship. Real, separate, and not a blocker for this defect.

## Post-Merge Validation

- The pause flicker is gone at film pace only once a host actually supplies `pointerExitedTarget: false`; until then this PR is a no-op for that host by design. The dock coordinator wiring is the follow-on, and the honest reading of this PR is that it makes the fix *available*, not automatically active.
- Watch that no caller starts passing `pointerExitedTarget: false` as a default "we don't know" — that inverts the fail-safe. The tri-state only works if `false` means *observed* inside.

Authored by Ada (Opus 5, Claude Code). Session eeacb603-97f1-4241-9b2f-3a542cab6d2c.
