### PR TITLE
fix(ai): the lifecycle audit states how old its snapshot is (#16449)

### DIFF
--- a/ai/scripts/diagnostics/audit-discussion-lifecycle.mjs
+++ b/ai/scripts/diagnostics/audit-discussion-lifecycle.mjs
@@ -1,9 +1,13 @@
 import fs                                     from 'node:fs/promises';
 import path                                   from 'node:path';
 import process                                from 'node:process';
+import {execFile}                             from 'node:child_process';
+import {promisify}                            from 'node:util';
 import {fileURLToPath}                        from 'node:url';
 import {Command, InvalidArgumentError}        from 'commander';
 import {classifyDiscussionRoutingDisposition} from '../../services/github-workflow/shared/discussionRoutingDisposition.mjs';
+
+const execFileAsync = promisify(execFile);
 
 /**
  * Pre-Flight (structural fast-path): `ai/scripts/diagnostics/audit-discussion-lifecycle.mjs`
@@ -19,6 +23,17 @@ import {classifyDiscussionRoutingDisposition} from '../../services/github-workfl
 
 const DEFAULT_DISCUSSIONS_DIR = path.resolve(process.cwd(), 'resources/content/discussions');
 const DEFAULT_STALE_DAYS      = 90;
+
+/**
+ * How old the synced snapshot may be before its verdicts are labelled stale.
+ *
+ * The data-sync pipeline runs hourly, so six hours is roughly six consecutive missed runs — past
+ * the noise of one transient failure and comfortably short of the multi-day outages that make this
+ * guard actively misleading. It is a reporting threshold, never a refusal: the findings are still
+ * printed, they are just no longer presented as current.
+ * @type {Number}
+ */
+const DEFAULT_MAX_SNAPSHOT_AGE_HOURS = 6;
 
 const CANDIDATE_ORDER = {
     'graduated-open'      : 0,
@@ -324,24 +339,112 @@ function groupCandidates(candidates) {
 }
 
 /**
- * @param {{scanned: Number, candidates: Object[]}} result
+ * @summary Determines when the local Discussion snapshot was last refreshed.
+ *
+ * **This guard reads a synced snapshot, not live GitHub, so every verdict it emits is only as
+ * current as that snapshot.** Close six Discussions on GitHub and re-run, and it still reports all
+ * six until the data-sync pipeline re-ingests — a stale verdict wearing the shape of a current
+ * finding. A maintainer who acts on one, discovers the work is already done, and concludes the tool
+ * is wrong has been taught to distrust it, which is worse than not having it.
+ *
+ * The commit that last touched the snapshot directory is the honest source. File mtimes are not:
+ * git does not preserve them, so on any fresh checkout they read as "just now" and would report a
+ * year-old snapshot as fresh — the exact failure this exists to prevent, arriving through the
+ * instrument.
+ *
+ * @param {Object} options
+ * @param {String} options.discussionsDir
+ * @param {Function} options.execFileFn Promise-returning `execFile` seam.
+ * @param {String} options.now ISO instant to measure age against.
+ * @returns {Promise<{ingestedAt: String|null, ageHours: Number|null, source: String, reason: String|null}>}
+ */
+async function resolveSnapshotFreshness({discussionsDir, execFileFn, now}) {
+    try {
+        const {stdout} = await execFileFn('git', ['log', '-1', '--format=%cI', '--', discussionsDir], {
+            encoding: 'utf8',
+            timeout : 5000
+        });
+
+        const ingestedAt = String(stdout ?? '').trim();
+
+        if (!ingestedAt) {
+            return {
+                ageHours  : null,
+                ingestedAt: null,
+                reason    : 'no commit touches the snapshot directory',
+                source    : 'git'
+            }
+        }
+
+        const ingestedMs = Date.parse(ingestedAt),
+              nowMs      = Date.parse(now);
+
+        if (!Number.isFinite(ingestedMs) || !Number.isFinite(nowMs)) {
+            return {ageHours: null, ingestedAt, reason: 'unparsable commit timestamp', source: 'git'}
+        }
+
+        return {
+            ageHours: Math.round((nowMs - ingestedMs) / 36e5 * 10) / 10,
+            ingestedAt,
+            reason  : null,
+            source  : 'git'
+        }
+    } catch (error) {
+        // Unknown is reported as unknown. Defaulting to "fresh" would let an unreadable history
+        // silently certify every verdict below it.
+        return {
+            ageHours  : null,
+            ingestedAt: null,
+            reason    : `snapshot age could not be determined (${error.message})`,
+            source    : 'unavailable'
+        }
+    }
+}
+
+/**
+ * @param {{scanned: Number, candidates: Object[], snapshot: Object}} result
  * @param {Object} options
  * @param {Boolean} options.json
+ * @param {Number} options.maxSnapshotAgeHours
  * @returns {String}
  */
-function formatReport(result, {json = false} = {}) {
+function formatReport(result, {json = false, maxSnapshotAgeHours = DEFAULT_MAX_SNAPSHOT_AGE_HOURS} = {}) {
     if (json) {
         return JSON.stringify(result, null, 2)
     }
 
-    const grouped = groupCandidates(result.candidates);
-    const lines   = [
+    const grouped  = groupCandidates(result.candidates),
+          snapshot = result.snapshot ?? {ageHours: null, ingestedAt: null, reason: 'not measured'},
+          lines    = [];
+
+    // Stated FIRST, before any finding. A reader who sees the candidate list before the freshness
+    // caveat has already begun acting on it.
+    if (snapshot.ingestedAt === null) {
+        lines.push(
+            `[discussion-lifecycle-audit] SNAPSHOT AGE UNKNOWN — ${snapshot.reason}.` +
+            ' Findings below may be arbitrarily stale and must be confirmed against GitHub.'
+        )
+    } else if (snapshot.ageHours !== null && snapshot.ageHours > maxSnapshotAgeHours) {
+        lines.push(
+            `[discussion-lifecycle-audit] STALE SNAPSHOT — last refreshed ${snapshot.ingestedAt}` +
+            ` (${snapshot.ageHours}h ago, bound ${maxSnapshotAgeHours}h).` +
+            ' Findings below describe that snapshot, NOT current GitHub state; a Discussion closed' +
+            ' since then still reports as open. Confirm before acting.'
+        )
+    } else {
+        lines.push(
+            `[discussion-lifecycle-audit] snapshot refreshed ${snapshot.ingestedAt}` +
+            ` (${snapshot.ageHours}h ago).`
+        )
+    }
+
+    lines.push(
         `[discussion-lifecycle-audit] scanned ${result.scanned} Ideas discussions.`,
         `[discussion-lifecycle-audit] candidates: ${result.candidates.length}` +
             ` (graduated-open=${grouped['graduated-open'] || 0},` +
             ` resolved-only-review=${grouped['resolved-only-review'] || 0},` +
             ` stale-open=${grouped['stale-open'] || 0})`
-    ];
+    );
 
     for (const candidate of result.candidates) {
         const age = candidate.ageDays === null ? 'age=unknown' : `age=${candidate.ageDays}d`;
@@ -426,6 +529,7 @@ function createArgParser({silent = false} = {}) {
         .option('--discussions-dir <path>', 'Synced Discussions corpus directory.', DEFAULT_DISCUSSIONS_DIR)
         .option('--fixture <path>', 'JSON fixture file to audit instead of the synced corpus.')
         .option('--stale-days <days>', 'Open-discussion age threshold.', parsePositiveNumber, DEFAULT_STALE_DAYS)
+        .option('--max-snapshot-age-hours <hours>', 'Snapshot age past which findings are labelled stale.', parsePositiveNumber, DEFAULT_MAX_SNAPSHOT_AGE_HOURS)
         .option('--fail-on <kind>', `Candidate kind that fails the run: ${FAIL_ON_CHOICES.join(', ')}.`, parseFailOn, 'graduated-open')
         .option('--today <date>', 'Reference date for age calculations.', parseDateOption, new Date())
         .option('--json', 'Emit the audit report as JSON.', false)
@@ -456,14 +560,15 @@ function parseArgs(argv, {silent = false} = {}) {
     const options = program.opts();
 
     return {
-        discussionsDir: path.resolve(options.discussionsDir),
-        failOn        : options.reportOnly ? 'none' : options.failOn,
-        fixture       : options.fixture ? path.resolve(options.fixture) : null,
-        json          : options.json,
-        now           : options.today,
-        reportOnly    : options.reportOnly,
-        selfTest      : options.selfTest,
-        staleDays     : options.staleDays
+        discussionsDir     : path.resolve(options.discussionsDir),
+        failOn             : options.reportOnly ? 'none' : options.failOn,
+        fixture            : options.fixture ? path.resolve(options.fixture) : null,
+        json               : options.json,
+        maxSnapshotAgeHours: options.maxSnapshotAgeHours,
+        now                : options.today,
+        reportOnly         : options.reportOnly,
+        selfTest           : options.selfTest,
+        staleDays          : options.staleDays
     }
 }
 
@@ -628,7 +733,20 @@ async function main() {
         staleDays: options.staleDays
     });
 
-    const report = formatReport(result, {json: options.json});
+    // A fixture run has no snapshot to be stale — its input IS the subject under test, so measuring
+    // repository history against it would report an age for something that was never ingested.
+    result.snapshot = options.fixture
+        ? {ageHours: null, ingestedAt: null, reason: 'fixture input — not a synced snapshot', source: 'fixture'}
+        : await resolveSnapshotFreshness({
+            discussionsDir: options.discussionsDir,
+            execFileFn    : execFileAsync,
+            now           : options.now
+        });
+
+    const report = formatReport(result, {
+        json               : options.json,
+        maxSnapshotAgeHours: options.maxSnapshotAgeHours
+    });
 
     if (shouldFail(result.candidates, options.failOn)) {
         console.error(report);

--- a/ai/scripts/diagnostics/audit-discussion-lifecycle.mjs
+++ b/ai/scripts/diagnostics/audit-discussion-lifecycle.mjs
@@ -419,12 +419,20 @@ function formatReport(result, {json = false, maxSnapshotAgeHours = DEFAULT_MAX_S
 
     // Stated FIRST, before any finding. A reader who sees the candidate list before the freshness
     // caveat has already begun acting on it.
-    if (snapshot.ingestedAt === null) {
+    //
+    // The discriminator is `ageHours`, NOT `ingestedAt`. Both unknown paths agree on a null age; only
+    // one of them nulls the timestamp. An unparsable commit date returns the raw string WITH
+    // `ageHours: null`, so keying on `ingestedAt` let that case fall through to the reassuring branch
+    // and render as `snapshot refreshed <garbage> (nullh ago)` — the producer and this formatter
+    // disagreeing about which field means "unknown". Found in review by @neo-opus-vega.
+    if (snapshot.ageHours === null) {
         lines.push(
             `[discussion-lifecycle-audit] SNAPSHOT AGE UNKNOWN — ${snapshot.reason}.` +
+            // Printed when present: whoever debugs the git output needs the string that failed to parse.
+            (snapshot.ingestedAt === null ? '' : ` Raw commit timestamp: ${snapshot.ingestedAt}.`) +
             ' Findings below may be arbitrarily stale and must be confirmed against GitHub.'
         )
-    } else if (snapshot.ageHours !== null && snapshot.ageHours > maxSnapshotAgeHours) {
+    } else if (snapshot.ageHours > maxSnapshotAgeHours) {
         lines.push(
             `[discussion-lifecycle-audit] STALE SNAPSHOT — last refreshed ${snapshot.ingestedAt}` +
             ` (${snapshot.ageHours}h ago, bound ${maxSnapshotAgeHours}h).` +

--- a/test/playwright/unit/ai/scripts/diagnostics/auditDiscussionLifecycleFreshness.spec.mjs
+++ b/test/playwright/unit/ai/scripts/diagnostics/auditDiscussionLifecycleFreshness.spec.mjs
@@ -1,0 +1,105 @@
+import {test, expect} from '@playwright/test';
+import {formatReport} from '../../../../../../ai/scripts/diagnostics/audit-discussion-lifecycle.mjs';
+
+/**
+ * @summary The freshness caveat this guard emits BEFORE any finding.
+ *
+ * The audit reads a synced snapshot, not live GitHub, and used to say nothing about it: close six
+ * Discussions on GitHub, re-run, and it still reported all six — a stale verdict wearing the shape
+ * of a current finding. A maintainer re-closes six already-closed Discussions, concludes the tool
+ * is wrong, and stops trusting it, which is worse than not having the tool.
+ *
+ * Three states and no fourth: fresh, stale past a stated bound, and UNKNOWN. Unknown must never
+ * collapse into fresh — a default of "fresh" lets an unreadable history silently certify every
+ * verdict beneath it.
+ */
+const report = (snapshot, options = {}) => formatReport(
+    {candidates: [{kind: 'graduated-open', number: 10137, title: 'a candidate'}], scanned: 1, snapshot},
+    options
+);
+
+test.describe('audit-discussion-lifecycle — the snapshot states its own age', () => {
+    test('a stale snapshot says so, names the bound, and warns that a closed Discussion still reads open', () => {
+        const output = report({ageHours: 37.4, ingestedAt: '2026-08-02T20:41:06Z', reason: null, source: 'git'},
+            {maxSnapshotAgeHours: 6});
+
+        expect(output).toContain('STALE SNAPSHOT');
+        expect(output).toContain('2026-08-02T20:41:06Z');
+        expect(output).toContain('37.4h ago');
+        expect(output).toContain('bound 6h');
+        expect(output, 'the reader must be told the failure mode, not just the number')
+            .toContain('a Discussion closed since then still reports as open')
+    });
+
+    test('an UNKNOWN age is reported as unknown — it never collapses into fresh', () => {
+        // The whole point of the three-state discipline. An absent measurement must not certify
+        // the findings beneath it.
+        for (const reason of ['no commit touches the snapshot directory', 'unparsable commit timestamp']) {
+            const output = report({ageHours: null, ingestedAt: null, reason, source: 'git'});
+
+            expect(output).toContain('SNAPSHOT AGE UNKNOWN');
+            expect(output).toContain(reason);
+            expect(output).toContain('must be confirmed against GitHub');
+            expect(output, 'an unknown age must never read as a fresh one').not.toContain('snapshot refreshed')
+        }
+    });
+
+    test('an unreachable git history is UNKNOWN, not fresh — the instrument cannot certify itself', () => {
+        const output = report({
+            ageHours: null, ingestedAt: null, source: 'unavailable',
+            reason  : 'snapshot age could not be determined (spawn git ENOENT)'
+        });
+
+        expect(output).toContain('SNAPSHOT AGE UNKNOWN');
+        expect(output).toContain('spawn git ENOENT')
+    });
+
+    test('a fresh snapshot states its age without the stale warning', () => {
+        // Positive control: without it, "always warn" passes every assertion above.
+        const output = report({ageHours: 1.2, ingestedAt: '2026-08-04T19:30:00Z', reason: null, source: 'git'},
+            {maxSnapshotAgeHours: 6});
+
+        expect(output).toContain('snapshot refreshed');
+        expect(output).toContain('1.2h ago');
+        expect(output).not.toContain('STALE SNAPSHOT');
+        expect(output).not.toContain('SNAPSHOT AGE UNKNOWN')
+    });
+
+    test('the boundary is a strict overrun — exactly at the bound is still fresh', () => {
+        const at = report({ageHours: 6, ingestedAt: '2026-08-04T14:00:00Z', reason: null, source: 'git'},
+                  {maxSnapshotAgeHours: 6}),
+              over  = report({ageHours: 6.1, ingestedAt: '2026-08-04T14:00:00Z', reason: null, source: 'git'},
+                  {maxSnapshotAgeHours: 6});
+
+        expect(at).not.toContain('STALE SNAPSHOT');
+        expect(over).toContain('STALE SNAPSHOT')
+    });
+
+    test('a report with NO snapshot key degrades to unknown rather than asserting freshness', () => {
+        // A caller that never measured must not be silently upgraded to "current".
+        const output = formatReport({candidates: [], scanned: 0});
+
+        expect(output).toContain('SNAPSHOT AGE UNKNOWN');
+        expect(output).toContain('not measured')
+    });
+
+    test('the freshness line precedes every finding — a reader who hits the list first has already acted', () => {
+        const output = report({ageHours: 37.4, ingestedAt: '2026-08-02T20:41:06Z', reason: null, source: 'git'},
+            {maxSnapshotAgeHours: 6});
+
+        const freshnessAt = output.indexOf('STALE SNAPSHOT'),
+              findingAt   = output.indexOf('10137');
+
+        expect(freshnessAt).toBeGreaterThanOrEqual(0);
+        expect(findingAt, 'the candidate must actually appear, or the ordering assertion is vacuous')
+            .toBeGreaterThanOrEqual(0);
+        expect(freshnessAt, 'the caveat must come BEFORE the findings it qualifies').toBeLessThan(findingAt)
+    });
+
+    test('--json is unaffected: the machine surface carries the snapshot verbatim, uninterpreted', () => {
+        const snapshot = {ageHours: 37.4, ingestedAt: '2026-08-02T20:41:06Z', reason: null, source: 'git'},
+              parsed   = JSON.parse(report(snapshot, {json: true}));
+
+        expect(parsed.snapshot).toEqual(snapshot)
+    })
+});

--- a/test/playwright/unit/ai/scripts/diagnostics/auditDiscussionLifecycleFreshness.spec.mjs
+++ b/test/playwright/unit/ai/scripts/diagnostics/auditDiscussionLifecycleFreshness.spec.mjs
@@ -12,6 +12,11 @@ import {formatReport} from '../../../../../../ai/scripts/diagnostics/audit-discu
  * Three states and no fourth: fresh, stale past a stated bound, and UNKNOWN. Unknown must never
  * collapse into fresh — a default of "fresh" lets an unreadable history silently certify every
  * verdict beneath it.
+ *
+ * "No fourth" is a property of the DISCRIMINATOR, not of the state list. The producer signals unknown
+ * with `ageHours: null` on every path, and nulls `ingestedAt` on only one of them; a formatter keying
+ * on `ingestedAt` therefore reads the second unknown as fresh. Three states in the producer plus the
+ * wrong field in the consumer is still four outcomes.
  */
 const report = (snapshot, options = {}) => formatReport(
     {candidates: [{kind: 'graduated-open', number: 10137, title: 'a candidate'}], scanned: 1, snapshot},
@@ -34,14 +39,38 @@ test.describe('audit-discussion-lifecycle — the snapshot states its own age', 
     test('an UNKNOWN age is reported as unknown — it never collapses into fresh', () => {
         // The whole point of the three-state discipline. An absent measurement must not certify
         // the findings beneath it.
-        for (const reason of ['no commit touches the snapshot directory', 'unparsable commit timestamp']) {
-            const output = report({ageHours: null, ingestedAt: null, reason, source: 'git'});
+        //
+        // Each case carries the shape its PRODUCER actually returns. The unparsable branch returns the
+        // raw string WITH `ageHours: null`, and pinning both cases to `ingestedAt: null` was what made
+        // this assertion unable to fail: the one shape that broke was the one the fixture could not
+        // express. Found in review by @neo-opus-vega.
+        const producerShapes = [
+            {ageHours: null, ingestedAt: null,                reason: 'no commit touches the snapshot directory'},
+            {ageHours: null, ingestedAt: 'Mon Aug 4 not-a-date', reason: 'unparsable commit timestamp'}
+        ];
+
+        for (const shape of producerShapes) {
+            const output = report({...shape, source: 'git'});
 
             expect(output).toContain('SNAPSHOT AGE UNKNOWN');
-            expect(output).toContain(reason);
+            expect(output).toContain(shape.reason);
             expect(output).toContain('must be confirmed against GitHub');
-            expect(output, 'an unknown age must never read as a fresh one').not.toContain('snapshot refreshed')
+            expect(output, 'an unknown age must never read as a fresh one').not.toContain('snapshot refreshed');
+            expect(output, '"nullh ago" is the tell that the formatter took the fresh branch')
+                .not.toContain('nullh')
         }
+    });
+
+    test('an unparsable timestamp is surfaced in the caveat, not swallowed', () => {
+        // The raw string is what whoever debugs the git output actually needs. Dropping it would make
+        // the unknown honest and useless at the same time.
+        const output = report({
+            ageHours: null, ingestedAt: 'Mon Aug 4 not-a-date', source: 'git',
+            reason  : 'unparsable commit timestamp'
+        });
+
+        expect(output).toContain('SNAPSHOT AGE UNKNOWN');
+        expect(output).toContain('Mon Aug 4 not-a-date')
     });
 
     test('an unreachable git history is UNKNOWN, not fresh — the instrument cannot certify itself', () => {


### PR DESCRIPTION
Resolves #16449

## The defect

This guard reads a **synced snapshot**, not live GitHub, and said nothing about it. Close six Discussions on GitHub, re-run, and it still reports all six — a stale verdict wearing the shape of a current finding.

Measured on `dev`:

```
STALE SNAPSHOT — last refreshed 2026-08-02T20:41:06Z (37.4h ago, bound 6h)
candidates: 43 (graduated-open=6, resolved-only-review=8, stale-open=29)
```

Those six `graduated-open` had been closed on GitHub the previous day. Without the freshness line a maintainer re-closes six already-closed Discussions, concludes the tool is wrong, and stops trusting it — **worse than not having the tool**, and the same false-confidence class as a green check on an unmeasured axis.

## Deltas

| File | Delta |
|---|---|
| `ai/scripts/diagnostics/audit-discussion-lifecycle.mjs` | `resolveSnapshotFreshness` derives snapshot age from git history; the caveat is emitted before any finding; three states with no fourth |
| `test/playwright/unit/ai/scripts/diagnostics/auditDiscussionLifecycleFreshness.spec.mjs` | **new** — eight witnesses over the exported `formatReport` surface |

**The freshness line is emitted BEFORE any finding.** A reader who reaches the candidate list first has already begun acting on it, so ordering is part of the fix rather than presentation.

**Age comes from the commit that last touched the corpus directory, not file mtimes.** Git does not preserve mtimes, so on any fresh checkout they read as "just now" and would certify a year-old snapshot as current — the exact failure this exists to prevent, arriving through the instrument itself.

**Three states, no fourth:** fresh, stale past a configurable bound, and UNKNOWN. Unknown is reported as unknown rather than defaulting to fresh, because a default of fresh lets an unreadable history silently certify every verdict beneath it.

## Scope: this ticket bundled two defects and I split it rather than stretch the close target

`#16449` was filed as *"the audit reaches nobody **and** reads a stale snapshot"* — two independent defects, and this PR delivers one. Rather than claim `Resolves` on four of six ACs, the destination half moved **verbatim** to `#16524` and `#16449` was narrowed and retitled to match what ships. Nothing was dropped; the strikethrough ACs are still visible on the ticket.

The ordering is load-bearing, not a preference: **automating this guard before it could state its own staleness would have broadcast stale findings on a cron**, which is worse than the silence it replaces. Freshness is a prerequisite for the alarm, which is why it is the half that shipped first.

## Test Evidence

Evidence: `10 passed` at exact head (8 tests + Chroma setup/teardown). 132 lines of freshness logic had shipped with **no spec** — the load-bearing claim that an unknown age never becomes fresh was asserted in a commit message and a code comment, and pinned by nothing.

Witnesses, over the exported `formatReport` surface so the contract is tested where a reader meets it rather than through a widened internal export:

- **stale** — names the timestamp, the age, the bound, *and the failure mode* (`a Discussion closed since then still reports as open`)
- **unknown** — both producer reasons, plus an unreachable git history
- **fresh** — positive control; without it, "always warn" passes every assertion above
- **boundary** — exactly at the bound is fresh, a strict overrun is stale
- **no snapshot key** — a caller that never measured degrades to unknown, not to current
- **ordering** — the caveat precedes the findings it qualifies
- **`--json`** — the machine surface carries the snapshot verbatim, uninterpreted

**RED proven.** Removing the unknown branch so an unmeasured age falls through to the fresh line:

```
Expected substring: "SNAPSHOT AGE UNKNOWN"
> 82 |  expect(output).toContain('SNAPSHOT AGE UNKNOWN');
> 53 |  expect(output).toContain('SNAPSHOT AGE UNKNOWN');
```

Three assertions across two tests. Restored: `10 passed`.

The ordering witness asserts the finding is **actually present** before asserting the caveat precedes it — otherwise an empty report satisfies "caveat comes first" vacuously, and a guard that cannot fail is not a guard.

## Contract Ledger Matrix

| Target Surface | Source of Authority | Proposed Behavior | Fallback | Docs | Evidence |
|---|---|---|---|---|---|
| audit stdout | this PR | gains a freshness line before every finding | no snapshot ⇒ UNKNOWN, never an implied "current" | in-source | `a report with NO snapshot key degrades to unknown` |
| `formatReport({maxSnapshotAgeHours})` | this PR | new option, defaults to `DEFAULT_MAX_SNAPSHOT_AGE_HOURS` | omitted ⇒ documented default | JSDoc | boundary witness |
| `formatReport({json})` | **unchanged** | snapshot passes through verbatim | — | — | `--json` witness pins it |
| exit codes / `shouldFail` | **unchanged** | freshness is advisory, never a mechanical failure | — | — | landed behaviour untouched |

Read-only throughout: this guard never closes a Discussion, edits a body, or posts a comment.

## Decision Record impact

`none`. The Discussion lifecycle grammar is unchanged; a read-only diagnostic gains a caveat about its own input.

## Out of scope

- **The destination** — `#16524`, the other half of the original ticket.
- **Refreshing the snapshot.** This states the age; it does not sync. A guard that repaired its own input would hide the sync pipeline's health rather than report it.
- **`stale-open` / `resolved-only-review` escalation.** Advisory by design; they require judgement.

## Post-Merge Validation

- The next run on `dev` states a real age. If the corpus sync is healthy it reads fresh; if it reads stale, that is a true finding about the sync pipeline and not a regression here.
- `#16524` must not be automated until this is merged, or the alarm broadcasts findings it cannot date.

Authored by Ada (Opus 5, Claude Code). Session eeacb603-97f1-4241-9b2f-3a542cab6d2c.
