### PR TITLE
fix(ai): turn presence reaches the deployment instead of the checkout (#16513)

### DIFF
--- a/.claude/hooks/turnPresenceHook.mjs
+++ b/.claude/hooks/turnPresenceHook.mjs
@@ -1,4 +1,4 @@
-import {fileURLToPath, pathToFileURL} from 'node:url';
+import {pathToFileURL} from 'node:url';
 import {
     readHookPayload,
     recordTurnPresenceFromHook
@@ -44,21 +44,50 @@ function resolveNote({action, hookPayload} = {}) {
 }
 
 /**
- * @summary Records fail-soft Claude Code turn-presence from hook input.
+ * @summary Reads the plane leaves from `AiConfig`, the one config read in this process.
+ *
+ * Imported lazily so the module stays loadable — and its pure helpers unit-testable — without booting
+ * the Neo state Provider. The hook process is an entrypoint, so reading the config singleton here is
+ * the sanctioned shape; the writer it feeds is not one, and deliberately resolves nothing itself.
+ * @returns {Promise<Object>} `{baseUrl, credential}`
+ */
+export async function readPlaneConfig() {
+    // Namespace bootstrap before the config import, the entry-point invariant `devFleetServer.mjs`
+    // documents: without them `ai/config.mjs` throws `Neo is not defined` at module-load.
+    await import('../../src/Neo.mjs');
+    await import('../../src/core/_export.mjs');
+
+    const {default: AiConfig} = await import('../../ai/config.mjs'),
+          planeBase           = String(AiConfig.fleet.planeBase ?? '').trim().replace(/\/+$/, '');
+
+    return {
+        baseUrl   : planeBase ? `${planeBase}/mc/mcp` : '',
+        credential: AiConfig.fleet.planeBearer ?? ''
+    };
+}
+
+/**
+ * @summary Records Claude Code turn-presence into the store the deployment serves.
+ *
+ * **This is the entrypoint, and the only place config is resolved.** It reads the plane leaves and
+ * injects them into a writer that resolves nothing — the same split `wakeArmingHook` uses. The
+ * previous shape let the writer derive a filesystem path from its own module location, which is how
+ * every beacon ended up in a private checkout that no reader queries.
+ *
  * @param {Object} options
  * @param {'start'|'progress'|'terminal'} [options.actionArg] Optional action override.
  * @param {Object} [options.env=process.env] Environment source.
  * @param {*} [options.hookPayload] Parsed Claude Code hook payload.
- * @param {String|Date|Number} [options.now=new Date()] Clock override for tests.
- * @param {String} [options.rootDir] Repository root.
- * @returns {Promise<Object>|undefined}
+ * @param {String|Date|Number} [options.now] Clock override for tests.
+ * @param {Object} [options.plane] Injected `{baseUrl, credential}`; read from `AiConfig` when absent.
+ * @returns {Promise<Object>} `{status}` — `recorded`, or `skipped` with a reason.
  */
 export async function recordClaudeTurnPresence({
     actionArg,
     env = process.env,
     hookPayload,
-    now = new Date(),
-    rootDir = fileURLToPath(new URL('../../', import.meta.url))
+    now,
+    plane
 } = {}) {
     const action = resolveAction({actionArg, hookPayload});
 
@@ -68,7 +97,7 @@ export async function recordClaudeTurnPresence({
         hookPayload,
         note  : resolveNote({action, hookPayload}),
         now,
-        rootDir,
+        plane : plane ?? await readPlaneConfig(),
         source: resolveSource({action, hookPayload})
     });
 }
@@ -76,10 +105,17 @@ export async function recordClaudeTurnPresence({
 async function main() {
     const hookPayload = parseHookPayload(await readHookPayload());
 
-    await recordClaudeTurnPresence({
+    // Never fails the session — presence is an enhancement, not a precondition for working. But it is
+    // never silent either: a skip or a throw says so on stderr, where the harness captures it. The
+    // failure this replaces was invisible precisely because it reported nothing and wrote anyway.
+    const result = await recordClaudeTurnPresence({
         actionArg: process.argv[2],
         hookPayload
-    }).catch(() => {});
+    }).catch(error => ({status: 'failed', reason: `turn-presence threw: ${error?.message || error}`}));
+
+    if (result?.status && result.status !== 'recorded') {
+        console.error(`[WARN] [turn-presence] not recorded — ${result.reason || result.status}`);
+    }
 }
 
 if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {

--- a/.claude/hooks/turnPresenceHook.mjs
+++ b/.claude/hooks/turnPresenceHook.mjs
@@ -80,6 +80,7 @@ export async function readPlaneConfig() {
  * @param {*} [options.hookPayload] Parsed Claude Code hook payload.
  * @param {String|Date|Number} [options.now] Clock override for tests.
  * @param {Object} [options.plane] Injected `{baseUrl, credential}`; read from `AiConfig` when absent.
+ * @param {Function} [options.record] Transport seam.
  * @returns {Promise<Object>} `{status}` — `recorded`, or `skipped` with a reason.
  */
 export async function recordClaudeTurnPresence({
@@ -87,7 +88,8 @@ export async function recordClaudeTurnPresence({
     env = process.env,
     hookPayload,
     now,
-    plane
+    plane,
+    record
 } = {}) {
     const action = resolveAction({actionArg, hookPayload});
 
@@ -98,7 +100,8 @@ export async function recordClaudeTurnPresence({
         note  : resolveNote({action, hookPayload}),
         now,
         plane : plane ?? await readPlaneConfig(),
-        source: resolveSource({action, hookPayload})
+        source: resolveSource({action, hookPayload}),
+        ...(record ? {record} : {})
     });
 }
 

--- a/.codex/hooks/codex-context.mjs
+++ b/.codex/hooks/codex-context.mjs
@@ -152,17 +152,49 @@ export function writePromptContextFromHookPayload({
 }
 
 /**
- * @summary Emits a fail-soft Codex turn-start beacon without importing Neo singletons.
+ * @summary Reads the plane leaves from `AiConfig`, the one config read in this process.
+ *
+ * Imported lazily so the module stays loadable — and its pure helpers unit-testable — without booting
+ * the Neo state Provider. The hook process is an entrypoint, so reading the config singleton here is
+ * the sanctioned shape; the writer it feeds is not one, and deliberately resolves nothing itself.
+ * @returns {Promise<Object>} `{baseUrl, credential}`
+ */
+export async function readPlaneConfig() {
+    await import('../../src/Neo.mjs');
+    await import('../../src/core/_export.mjs');
+
+    const {default: AiConfig} = await import('../../ai/config.mjs'),
+          planeBase           = String(AiConfig.fleet.planeBase ?? '').trim().replace(/\/+$/, '');
+
+    return {
+        baseUrl   : planeBase ? `${planeBase}/mc/mcp` : '',
+        credential: AiConfig.fleet.planeBearer ?? ''
+    };
+}
+
+/**
+ * @summary Emits a Codex turn-start beacon into the store the deployment serves.
+ *
+ * **This is the entrypoint, and the only place config is resolved.** It injects the plane leaves into
+ * a writer that resolves nothing — replacing a path the writer derived from its own module location,
+ * which sent every beacon to a private checkout that no reader queries.
+ *
+ * The wake-submit nonce matters more on this seat than on the others: the wake daemon's Codex
+ * delivery proof correlates a submit to the interval it produced by matching that exact value, so it
+ * travels with the event rather than being recomputed anywhere downstream.
+ *
  * @param {Object} options
  * @param {Object} [options.env=process.env] Environment source.
- * @param {String} [options.rootDir] Repository root.
  * @param {*} [options.hookPayload] Codex hook payload used to extract a wake-submit nonce.
- * @returns {Promise<void>|undefined}
+ * @param {Object} [options.plane] Injected `{baseUrl, credential}`; read from `AiConfig` when absent.
+ * @param {Function} [options.record] Transport seam.
+ * @returns {Promise<Object>} `{status}` — `recorded`, or `skipped` with a reason.
  */
 export async function recordTurnStarted({
     env = process.env,
-    rootDir = fileURLToPath(new URL('../../', import.meta.url)),
-    hookPayload
+    hookPayload,
+    plane,
+    record
 } = {}) {
     try {
         writePromptContextFromHookPayload({env, hookPayload});
@@ -174,8 +206,9 @@ export async function recordTurnStarted({
         env,
         hookPayload,
         note  : 'codex UserPromptSubmit',
-        rootDir,
-        source: 'codex-user-prompt-submit'
+        plane : plane ?? await readPlaneConfig(),
+        source: 'codex-user-prompt-submit',
+        ...(record ? {record} : {})
     });
 }
 

--- a/.kimi-code/hooks/turnPresenceHook.mjs
+++ b/.kimi-code/hooks/turnPresenceHook.mjs
@@ -1,4 +1,4 @@
-import {fileURLToPath, pathToFileURL} from 'node:url';
+import {pathToFileURL} from 'node:url';
 import {
     readHookPayload,
     recordTurnPresenceFromHook
@@ -61,19 +61,44 @@ export function resolveKimiTurnPresenceEvent(hookPayload) {
 }
 
 /**
- * @summary Records fail-soft Kimi Code turn presence through Memory Core's existing local writer.
+ * @summary Reads the plane leaves from `AiConfig`, the one config read in this process.
+ *
+ * Imported lazily so the module stays loadable — and its pure helpers unit-testable — without booting
+ * the Neo state Provider. The hook process is an entrypoint, so reading the config singleton here is
+ * the sanctioned shape; the writer it feeds is not one, and deliberately resolves nothing itself.
+ * @returns {Promise<Object>} `{baseUrl, credential}`
+ */
+export async function readPlaneConfig() {
+    await import('../../src/Neo.mjs');
+    await import('../../src/core/_export.mjs');
+
+    const {default: AiConfig} = await import('../../ai/config.mjs'),
+          planeBase           = String(AiConfig.fleet.planeBase ?? '').trim().replace(/\/+$/, '');
+
+    return {
+        baseUrl   : planeBase ? `${planeBase}/mc/mcp` : '',
+        credential: AiConfig.fleet.planeBearer ?? ''
+    };
+}
+
+/**
+ * @summary Records Kimi Code turn presence into the store the deployment serves.
+ *
+ * **This is the entrypoint, and the only place config is resolved.** It injects the plane leaves into
+ * a writer that resolves nothing — replacing a path the writer used to derive from its own module
+ * location, which sent every beacon to a private checkout no reader queries.
  * @param {Object} options
  * @param {Object} [options.env=process.env] Environment inherited by the hook command.
  * @param {*} [options.hookPayload] Parsed Kimi hook payload.
- * @param {String|Date|Number} [options.now=new Date()] Clock override for tests.
- * @param {String} [options.rootDir] Repository root.
+ * @param {String|Date|Number} [options.now] Clock override for tests.
+ * @param {Object} [options.plane] Injected `{baseUrl, credential}`; read from `AiConfig` when absent.
  * @returns {Promise<Object|undefined>}
  */
 export async function recordKimiTurnPresence({
     env = process.env,
     hookPayload,
-    now = new Date(),
-    rootDir = fileURLToPath(new URL('../../', import.meta.url))
+    now,
+    plane
 } = {}) {
     const event = resolveKimiTurnPresenceEvent(hookPayload);
 
@@ -106,9 +131,9 @@ export async function recordKimiTurnPresence({
         action,
         env,
         hookPayload,
-        note: `kimi ${eventName}${toolSuffix}`,
+        note : `kimi ${eventName}${toolSuffix}`,
         now,
-        rootDir,
+        plane: plane ?? await readPlaneConfig(),
         source,
         terminalState
     })
@@ -121,7 +146,15 @@ export async function recordKimiTurnPresence({
 async function main() {
     const hookPayload = parseKimiHookPayload(await readHookPayload());
 
-    await recordKimiTurnPresence({hookPayload})
+    // Fail-open at the session boundary, but never silent: `unsupported-hook-event` is a deliberate
+    // no-op and stays quiet, while anything else says why it did not record. A presence write that
+    // reports nothing and stores nowhere is the exact failure this path is being repaired for.
+    const result = await recordKimiTurnPresence({hookPayload})
+        .catch(error => ({status: 'failed', reason: `turn-presence threw: ${error?.message || error}`}));
+
+    if (result?.status && !['recorded', 'noop'].includes(result.status)) {
+        process.stderr.write(`kimi turnPresenceHook: not recorded — ${result.reason || result.status}\n`)
+    }
 }
 
 if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {

--- a/.kimi-code/hooks/turnPresenceHook.mjs
+++ b/.kimi-code/hooks/turnPresenceHook.mjs
@@ -92,13 +92,15 @@ export async function readPlaneConfig() {
  * @param {*} [options.hookPayload] Parsed Kimi hook payload.
  * @param {String|Date|Number} [options.now] Clock override for tests.
  * @param {Object} [options.plane] Injected `{baseUrl, credential}`; read from `AiConfig` when absent.
+ * @param {Function} [options.record] Transport seam.
  * @returns {Promise<Object|undefined>}
  */
 export async function recordKimiTurnPresence({
     env = process.env,
     hookPayload,
     now,
-    plane
+    plane,
+    record
 } = {}) {
     const event = resolveKimiTurnPresenceEvent(hookPayload);
 
@@ -135,7 +137,8 @@ export async function recordKimiTurnPresence({
         now,
         plane: plane ?? await readPlaneConfig(),
         source,
-        terminalState
+        terminalState,
+        ...(record ? {record} : {})
     })
 }
 

--- a/ai/mcp/server/memory-core/helpers/TurnPresenceHookWriter.mjs
+++ b/ai/mcp/server/memory-core/helpers/TurnPresenceHookWriter.mjs
@@ -73,8 +73,9 @@ export function readHookPayload({stdin = process.stdin} = {}) {
  * hook file physically lived in, and the write **succeeded** there. In a containerized deployment the
  * served graph is a Docker named volume with no host-visible path, so every beacon landed in a private
  * file no reader ever queries — and nothing failed, because a writable SQLite file accepts writes
- * happily. Measured before this changed: 6,000+ intervals across four seats in a single day, none of
- * them readable, one orphaned store per checkout.
+ * happily. Measured before this changed: 7192 accumulated intervals from 9 distinct agents in one
+ * maintainer checkout, none of them readable — and their newest timestamps spread across four separate
+ * days, because each seat writes the checkout its own hook file lives in.
  *
  * That is why an unreachable plane must produce a **named skip** here rather than any fallback write.
  * A beacon in a store nobody reads is strictly worse than no beacon at all: it makes an unmeasured

--- a/ai/mcp/server/memory-core/helpers/TurnPresenceHookWriter.mjs
+++ b/ai/mcp/server/memory-core/helpers/TurnPresenceHookWriter.mjs
@@ -1,162 +1,14 @@
-import {randomUUID}    from 'node:crypto';
-import {fileURLToPath} from 'node:url';
-import {
-    resolveMemoryCoreGraphPath,
-    resolveTurnPresenceRuntimeConfig
-} from './TurnPresenceConfig.mjs';
-import {normalizeAgentIdentityNodeId} from '../../../../graph/normalizeAgentIdentityNodeId.mjs';
+import {recordTurnPresenceOverMcp}        from './recordTurnPresenceOverMcp.mjs';
+import {resolveTurnPresenceRuntimeConfig} from './TurnPresenceConfig.mjs';
+import {normalizeAgentIdentityNodeId}     from '../../../../graph/normalizeAgentIdentityNodeId.mjs';
 
 const WAKE_SUBMIT_NONCE_PATTERN = /NEO_WAKE_SUBMIT_NONCE:([0-9a-fA-F-]{36})/;
-
-function coerceDate(value) {
-    const date = value instanceof Date ? value : new Date(value);
-    if (Number.isNaN(date.getTime())) {
-        throw new Error(`Invalid turn presence timestamp: ${value}`);
-    }
-    return date;
-}
 
 function normalizeWakeSubmitNonce(value) {
     if (!value || typeof value !== 'string') return null;
 
     const trimmed = value.trim();
     return /^[0-9a-fA-F-]{36}$/.test(trimmed) ? trimmed.toLowerCase() : null;
-}
-
-function buildTurnPresenceId(agentIdentity, turnId) {
-    return `AGENT_TURN_PRESENCE:${agentIdentity}:${turnId}`;
-}
-
-function getTurnPresenceProperties(db, nodeId) {
-    const row = db.prepare('SELECT data FROM Nodes WHERE id = ?').get(nodeId);
-    if (!row?.data) return null;
-
-    try {
-        return JSON.parse(row.data).properties || null;
-    } catch {
-        return null;
-    }
-}
-
-function findNewestActiveTurnId(db, agentIdentity, nowIso) {
-    const row = db.prepare(`
-        SELECT data FROM Nodes
-        WHERE (
-            json_extract(data, '$.label') = 'AGENT_TURN_PRESENCE'
-            OR json_extract(data, '$.type') = 'AGENT_TURN_PRESENCE'
-        )
-          AND json_extract(data, '$.properties.agentIdentity') = ?
-          AND COALESCE(json_extract(data, '$.properties.status'), 'active') = 'active'
-          AND (
-            json_extract(data, '$.properties.expiresAt') IS NULL
-            OR json_extract(data, '$.properties.expiresAt') > ?
-          )
-        ORDER BY json_extract(data, '$.properties.lastProgressAt') DESC
-        LIMIT 1
-    `).get(agentIdentity, nowIso);
-
-    if (!row?.data) return null;
-
-    try {
-        return JSON.parse(row.data).properties?.turnId || null;
-    } catch {
-        return null;
-    }
-}
-
-async function withTimeout(promise, timeoutMs) {
-    let timer;
-    try {
-        return await Promise.race([
-            promise,
-            new Promise((_, reject) => {
-                timer = setTimeout(() => reject(new Error('turn presence hook timed out')), timeoutMs);
-                timer.unref?.();
-            })
-        ]);
-    } finally {
-        if (timer) clearTimeout(timer);
-    }
-}
-
-async function writeTurnPresenceEvent({
-    action,
-    agentIdentity,
-    dbPath,
-    freshMs,
-    note,
-    noteMaxChars,
-    now,
-    source,
-    terminalState,
-    ttlMs,
-    turnId,
-    wakeSubmitNonce
-}) {
-    const {default: Database} = await import('better-sqlite3');
-    const db                  = new Database(dbPath, {fileMustExist: true});
-
-    try {
-        const hasNodesTable = db.prepare(`
-            SELECT name FROM sqlite_master
-            WHERE type = 'table' AND name = 'Nodes'
-            LIMIT 1
-        `).get();
-        if (!hasNodesTable) return {status: 'noop', reason: 'missing-nodes-table', action, agentIdentity};
-
-        const nowDate      = coerceDate(now),
-              nowIso       = nowDate.toISOString(),
-              targetTurnId = turnId || (action === 'start'
-                  ? randomUUID()
-                  : findNewestActiveTurnId(db, agentIdentity, nowIso));
-
-        if (!targetTurnId) {
-            return {status: 'noop', reason: 'no-active-turn', action, agentIdentity};
-        }
-
-        const nodeId     = buildTurnPresenceId(agentIdentity, targetTurnId),
-              current    = getTurnPresenceProperties(db, nodeId) || {},
-              startedAt  = current.startedAt || nowIso,
-              properties = {
-                  ...current,
-                  agentIdentity,
-                  turnId        : targetTurnId,
-                  startedAt,
-                  lastProgressAt: nowIso,
-                  freshUntil    : new Date(nowDate.getTime() + freshMs).toISOString(),
-                  expiresAt     : new Date(nowDate.getTime() + ttlMs).toISOString(),
-                  terminalState : action === 'terminal' ? terminalState : null,
-                  status        : action === 'terminal' ? 'terminal' : 'active',
-                  source,
-                  note          : typeof note === 'string' ? note.slice(0, noteMaxChars) : null,
-                  updatedAt     : nowIso,
-                  userId        : agentIdentity,
-                  sharedEntity  : false,
-                  ...(wakeSubmitNonce ? {wakeSubmitNonce} : {})
-              },
-              node       = {
-                  id   : nodeId,
-                  label: 'AGENT_TURN_PRESENCE',
-                  type : 'AGENT_TURN_PRESENCE',
-                  name : `TurnPresence ${agentIdentity}`,
-                  properties
-              };
-
-        db.prepare(`
-            INSERT INTO Nodes (id, user_id, data)
-            VALUES (?, ?, ?)
-            ON CONFLICT(id) DO UPDATE SET data = excluded.data, user_id = excluded.user_id
-        `).run(nodeId, agentIdentity, JSON.stringify(node));
-
-        return {
-            ...properties,
-            status: 'recorded',
-            action,
-            id    : nodeId
-        };
-    } finally {
-        db.close();
-    }
 }
 
 /**
@@ -211,55 +63,100 @@ export function readHookPayload({stdin = process.stdin} = {}) {
 }
 
 /**
- * @summary Emits a fail-soft turn-presence hook write without importing Neo singletons.
+ * @summary Emits a turn-presence beacon into the store the deployment serves, without importing Neo
+ * singletons.
+ *
+ * ## Why this goes over the service instead of opening the store
+ *
+ * The earlier implementation resolved `rootDir` from `import.meta.url` and opened the resulting path
+ * with `better-sqlite3`. Both halves were wrong together: the path followed whichever *checkout* the
+ * hook file physically lived in, and the write **succeeded** there. In a containerized deployment the
+ * served graph is a Docker named volume with no host-visible path, so every beacon landed in a private
+ * file no reader ever queries — and nothing failed, because a writable SQLite file accepts writes
+ * happily. Measured before this changed: 6,000+ intervals across four seats in a single day, none of
+ * them readable, one orphaned store per checkout.
+ *
+ * That is why an unreachable plane must produce a **named skip** here rather than any fallback write.
+ * A beacon in a store nobody reads is strictly worse than no beacon at all: it makes an unmeasured
+ * state look measured, which is the failure this whole path is being repaired for.
+ *
+ * ## The freshness policy deliberately does not live here any more
+ *
+ * `freshMs` / `ttlMs` / `noteMaxChars` were previously resolved hook-side and written into the node.
+ * The service owns those bounds, so computing them again here was a second copy of a policy that only
+ * one party is authoritative for. It now sends the event and lets the server stamp the interval.
+ *
  * @param {Object} options
+ * @param {Object} options.plane Injected `{baseUrl, credential}` for the deployment's Memory Core. The
+ * hook adapter is the entrypoint that resolves these; this module reads no config of its own.
  * @param {'start'|'progress'|'terminal'} [options.action='start'] Event kind.
  * @param {Object} [options.env=process.env] Environment source.
  * @param {*} [options.hookPayload] Raw hook payload, used for optional wake nonce extraction.
  * @param {String} [options.note] Bounded diagnostic note.
- * @param {String|Date|Number} [options.now=new Date()] Clock override for tests.
- * @param {String} [options.rootDir] Repository root.
+ * @param {String|Date|Number} [options.now] Clock override for tests.
+ * @param {Function} [options.record=recordTurnPresenceOverMcp] Transport seam.
  * @param {String} [options.source='harness-hook'] Hook source identifier.
  * @param {'completed'|'blocked'|'aborted'|'stale'} [options.terminalState='completed'] Terminal state.
- * @param {String} [options.turnId] Stable active-turn identifier.
+ * @param {String} [options.turnId] Stable active-turn identifier; the server resolves it when omitted.
  * @param {String} [options.wakeSubmitNonce] Optional explicit wake-submit nonce.
- * @returns {Promise<Object>|undefined}
+ * @returns {Promise<Object>} `{status}` — `recorded`, or `skipped` with a `reason` naming what was
+ * missing. Never a silent success.
  */
 export async function recordTurnPresenceFromHook({
+    plane,
     action = 'start',
     env = process.env,
     hookPayload,
     note,
-    now = new Date(),
-    rootDir = fileURLToPath(new URL('../../../../../', import.meta.url)),
+    now,
+    record = recordTurnPresenceOverMcp,
     source = 'harness-hook',
     terminalState = 'completed',
     turnId,
     wakeSubmitNonce = extractWakeSubmitNonce(hookPayload)
 } = {}) {
     const agentIdentity = normalizeAgentIdentityNodeId(env.NEO_AGENT_IDENTITY);
-    if (!agentIdentity) return;
+
+    if (!agentIdentity) {
+        return {status: 'skipped', reason: 'no NEO_AGENT_IDENTITY in the hook environment', action};
+    }
 
     const validActions = ['start', 'progress', 'terminal'];
     if (!validActions.includes(action)) {
         throw new Error(`Invalid turn presence action '${action}'. Must be one of: ${validActions.join(', ')}.`);
     }
 
-    const {freshMs, ttlMs, noteMaxChars, hookWriteTimeoutMs: timeoutMs} = resolveTurnPresenceRuntimeConfig({env});
-    if (!Number.isFinite(timeoutMs) || timeoutMs <= 0) return;
+    const baseUrl = String(plane?.baseUrl ?? '').trim();
 
-    return withTimeout(writeTurnPresenceEvent({
+    // A named skip, never a guessed endpoint: an unconfigured plane is a state the caller can express,
+    // and guessing localhost would either fail obscurely or publish against whatever is listening.
+    if (!baseUrl) {
+        return {
+            status: 'skipped',
+            reason: 'no Memory Core plane is configured, so there is no served store to record presence in',
+            action,
+            agentIdentity
+        };
+    }
+
+    const {hookWriteTimeoutMs: timeoutMs} = resolveTurnPresenceRuntimeConfig({env});
+    if (!Number.isFinite(timeoutMs) || timeoutMs <= 0) {
+        return {status: 'skipped', reason: 'turn-presence hook write timeout is not configured', action, agentIdentity};
+    }
+
+    const recorded = await record({
+        baseUrl,
+        identity  : agentIdentity,
+        credential: plane?.credential ?? '',
+        deadlineMs: timeoutMs,
         action,
-        agentIdentity,
-        dbPath: resolveMemoryCoreGraphPath({env, rootDir}),
-        freshMs,
         note,
-        noteMaxChars,
-        now,
         source,
-        terminalState,
-        ttlMs,
-        turnId,
-        wakeSubmitNonce
-    }), timeoutMs);
+        wakeSubmitNonce,
+        ...(now           !== undefined ? {now}           : {}),
+        ...(turnId        !== undefined ? {turnId}        : {}),
+        ...(action === 'terminal'       ? {terminalState} : {})
+    });
+
+    return {...recorded, status: recorded?.status ?? 'recorded', action};
 }

--- a/ai/mcp/server/memory-core/helpers/recordTurnPresenceOverMcp.mjs
+++ b/ai/mcp/server/memory-core/helpers/recordTurnPresenceOverMcp.mjs
@@ -44,8 +44,10 @@ export function readToolJson(result) {
  * host path to point an env var at. A path-based write therefore lands in the maintainer's *checkout*
  * and **succeeds** — which is the whole failure mode, because a successful write to an unread file is
  * indistinguishable from a working beacon until someone reads liveness and finds `turnPresence: null`.
- * Measured before this module existed: 6,000+ beacons across four seats in one day, none of them
- * readable by `who_is_online`, one orphaned store per checkout.
+ * Measured before this module existed: 7192 accumulated intervals from 9 distinct agents sitting in a
+ * single maintainer checkout, none of them readable by `who_is_online`. Their newest timestamps land on
+ * four different days, which is the tell that each seat writes its own checkout rather than one shared
+ * wrong file — the store holds a frozen fragment of every seat that ever ran from it.
  *
  * ## Identity is required here, unlike in the read sibling
  *

--- a/ai/mcp/server/memory-core/helpers/recordTurnPresenceOverMcp.mjs
+++ b/ai/mcp/server/memory-core/helpers/recordTurnPresenceOverMcp.mjs
@@ -1,0 +1,179 @@
+import {Client}                        from '@modelcontextprotocol/sdk/client/index.js';
+import {StreamableHTTPClientTransport} from '@modelcontextprotocol/sdk/client/streamableHttp.js';
+
+/**
+ * @module ai/mcp/server/memory-core/helpers/recordTurnPresenceOverMcp
+ * @summary Records a turn-presence beacon through the Memory Core's MCP surface, so the write lands in
+ * the store the deployment actually serves.
+ *
+ * Pure collaborator: every value it needs is INJECTED, nothing is resolved here. The entrypoint — the
+ * harness hook adapter — reads the config leaves once and passes them in, mirroring
+ * {@link module:ai/daemons/wake/readSubscriptionsOverMcp} and the `wakeArmingHook` entrypoint that
+ * feeds it. Resolving a leaf at module scope here would re-derive config in a module that is not a
+ * thread entrypoint — the exact shape that is not permitted to read the config singleton, and the one
+ * that made the writer this replaces resolve a path of its own in the first place.
+ */
+
+/**
+ * Budget for the whole exchange (connect + call), not per stage.
+ * @type {Number}
+ */
+export const DEFAULT_TIMEOUT_MS = 8000;
+
+/**
+ * @summary Extracts the JSON payload an MCP tool returned in its text content block.
+ * @param {Object} result A `callTool` result.
+ * @returns {*}
+ */
+export function readToolJson(result) {
+    const text = result?.content?.find(entry => entry?.type === 'text')?.text;
+
+    if (typeof text !== 'string' || !text.trim()) {
+        throw new Error('The MCP tool returned no text content to parse')
+    }
+
+    return JSON.parse(text)
+}
+
+/**
+ * @summary Records one turn-presence event over MCP, targeting the served store rather than a path.
+ *
+ * This exists instead of a direct `better-sqlite3` handle because a host process cannot reach the
+ * containerized Memory Core's SQLite at all: `shared-sqlite-data` is a Docker-managed **named volume**
+ * (`ai/deploy/docker-compose.yml`), so on macOS it lives inside the Docker Desktop VM and there is no
+ * host path to point an env var at. A path-based write therefore lands in the maintainer's *checkout*
+ * and **succeeds** — which is the whole failure mode, because a successful write to an unread file is
+ * indistinguishable from a working beacon until someone reads liveness and finds `turnPresence: null`.
+ * Measured before this module existed: 6,000+ beacons across four seats in one day, none of them
+ * readable by `who_is_online`, one orphaned store per checkout.
+ *
+ * ## Identity is required here, unlike in the read sibling
+ *
+ * The server resolves the beacon's owner from the request context, not from the payload. Without
+ * `X-PREFERRED-USERNAME` the plane answers as the **credential's** owner, so a shared token would
+ * record this turn's presence against somebody else's identity — publishing a peer as mid-turn when
+ * they are not. For a read that mistake returns the wrong rows; for a write it corrupts a liveness
+ * signal other agents route on. So identity is a hard precondition rather than an optional header, and
+ * the caller still verifies agreement against the returned `agentIdentity` rather than trusting the
+ * header to have been honoured.
+ *
+ * @param {Object} options
+ * @param {String} options.baseUrl Fully-resolved MCP endpoint, injected by the entrypoint.
+ * @param {String} options.identity Seat identity naming WHICH agent this beacon belongs to. Required.
+ * @param {'start'|'progress'|'terminal'} [options.action='start'] Event kind.
+ * @param {String} [options.credential=''] Bearer credential; empty means a tokenless plane, which
+ * decides admission itself and fail-closed.
+ * @param {String} [options.note] Bounded diagnostic note.
+ * @param {String} [options.source] Hook source identifier.
+ * @param {String} [options.terminalState] Terminal state, honoured only when `action` is `terminal`.
+ * @param {String} [options.turnId] Explicit turn id; omitted lets the server resolve or mint one.
+ * @param {Number} [options.deadlineMs=DEFAULT_TIMEOUT_MS] Budget for ALL stages COMBINED, not per
+ * stage. Per-stage budgets do not compose: two 8s stages under one 15s caller deadline can consume 16s.
+ * @param {Function} [options.ClientClass=Client] Spec seam.
+ * @param {Function} [options.TransportClass=StreamableHTTPClientTransport] Spec seam.
+ * @returns {Promise<Object>} The recorded beacon payload as the server persisted it.
+ */
+export async function recordTurnPresenceOverMcp({
+    baseUrl,
+    identity,
+    action         = 'start',
+    credential     = '',
+    note,
+    source,
+    terminalState,
+    turnId,
+    deadlineMs     = DEFAULT_TIMEOUT_MS,
+    ClientClass    = Client,
+    TransportClass = StreamableHTTPClientTransport
+} = {}) {
+    if (!baseUrl) {
+        throw new Error('recordTurnPresenceOverMcp requires an injected baseUrl — it resolves no config itself')
+    }
+
+    if (!identity) {
+        throw new Error(
+            'recordTurnPresenceOverMcp requires an identity: without it the plane records this beacon ' +
+            'against the credential owner, publishing the wrong agent as mid-turn'
+        )
+    }
+
+    const headers = {'X-PREFERRED-USERNAME': identity};
+
+    if (credential) headers['Authorization'] = `Bearer ${credential}`;
+
+    const abortController = new AbortController();
+
+    const transport = new TransportClass(new URL(baseUrl), {
+        requestInit: {
+            headers,
+            signal: abortController.signal
+        }
+    });
+
+    const client = new ClientClass({name: 'neo-turn-presence', version: '1.0.0'}, {capabilities: {}});
+
+    // One deadline for the whole exchange: each stage gets whatever is LEFT, so connect + call can never
+    // exceed the caller's budget between them. Takes a THUNK, not a promise — passing an already-evaluated
+    // promise starts the stage before the deadline is examined, so the guard would report "not started"
+    // for work that demonstrably ran.
+    const deadline = Date.now() + deadlineMs,
+          bound    = (start, label) => {
+              const remaining = deadline - Date.now();
+
+              if (remaining <= 0) {
+                  abortController.abort();
+                  return Promise.reject(new Error(
+                      `${label} not started: the ${deadlineMs}ms turn-presence deadline was already spent`
+                  ))
+              }
+
+              return new Promise((resolve, reject) => {
+                  const timer = setTimeout(() => {
+                      abortController.abort();
+                      reject(new Error(`${label} timed out with ${remaining}ms left of the ${deadlineMs}ms deadline`))
+                  }, remaining);
+
+                  start().then(resolve, reject).finally(() => clearTimeout(timer));
+              })
+          };
+
+    try {
+        await bound(() => client.connect(transport), 'turn-presence MCP connect');
+
+        // Only send what the caller actually specified. Passing `undefined` through would override the
+        // tool's own documented defaults with an explicit absence, which is a different contract.
+        const args = {action};
+
+        if (note          !== undefined) args.note          = note;
+        if (source        !== undefined) args.source        = source;
+        if (terminalState !== undefined) args.terminalState = terminalState;
+        if (turnId        !== undefined) args.turnId        = turnId;
+
+        const result = await bound(
+            () => client.callTool({name: 'record_turn_presence', arguments: args}),
+            `turn-presence record_turn_presence ${action}`
+        );
+
+        if (result?.isError) {
+            throw new Error(`record_turn_presence ${action} returned isError=true`)
+        }
+
+        const payload = readToolJson(result);
+
+        // The header names the seat; it does not guarantee the plane honoured it. A beacon persisted
+        // under another identity is worse than no beacon — it publishes a peer as present — so this is
+        // checked rather than assumed. `noop` carries no identity to disagree with and passes through.
+        if (payload?.agentIdentity && payload.agentIdentity !== identity) {
+            throw new Error(
+                `record_turn_presence recorded presence for '${payload.agentIdentity}' but this seat is ` +
+                `'${identity}' — refusing to report a beacon written against another agent`
+            )
+        }
+
+        return payload
+    } finally {
+        await client.close().catch(() => {});
+    }
+}
+
+export default recordTurnPresenceOverMcp;

--- a/ai/mcp/server/memory-core/openapi.yaml
+++ b/ai/mcp/server/memory-core/openapi.yaml
@@ -2412,8 +2412,14 @@ paths:
 
         The caller identity is server-derived; do not pass an identity field. `start` emits
         the primary active-turn beacon, `progress` refreshes `lastProgressAt` and freshness
-        bounds for the same `turnId`, and `terminal` closes the interval. When a terminal event
-        omits `turnId`, the newest active turn for the bound identity is closed.
+        bounds for the same `turnId`, and `terminal` closes the interval. When `progress` or
+        `terminal` omits `turnId`, the newest active turn for the bound identity is used — and
+        when no interval is open, the call is a no-op rather than an error.
+
+        This is the surface a harness hook writes through. A hook cannot open the served store
+        itself: in a containerized deployment the graph lives on a Docker named volume with no
+        host-visible path, so a path-based write silently lands in the caller's checkout and
+        succeeds, producing beacons that no reader ever sees.
       tags: [TurnPresence]
       requestBody:
         required: false
@@ -3172,7 +3178,7 @@ components:
           description: Event kind. `start` creates/refreshes the interval, `progress` refreshes it, and `terminal` closes it.
         turnId:
           type: string
-          description: Stable active-turn id. Optional on `start` (generated if omitted); required for progress; optional for terminal, which then closes the newest active turn.
+          description: Stable active-turn id. Optional throughout — `start` generates one, while `progress` and `terminal` resolve the newest active turn when it is omitted. A harness hook reaching this surface over MCP holds no turn id of its own, so requiring one would force it to read the store directly.
           example: "7ac7f929-0e77-4f61-92d2-1f078e871fe4"
         terminalState:
           type: string
@@ -3186,6 +3192,10 @@ components:
         note:
           type: string
           description: Optional bounded diagnostic note.
+        wakeSubmitNonce:
+          type: string
+          description: Per-submit correlation id linking this interval to the wake submit that caused it. The wake daemon's delivery proof matches on this exact value, so a malformed one is rejected rather than silently dropped.
+          example: "7ac7f929-0e77-4f61-92d2-1f078e871fe4"
         now:
           description: Optional clock override for tests.
           oneOf:

--- a/ai/services/memory-core/TurnPresenceService.mjs
+++ b/ai/services/memory-core/TurnPresenceService.mjs
@@ -44,19 +44,41 @@ class TurnPresenceService extends Base {
     validTerminalStates = ['completed', 'blocked', 'aborted', 'stale']
 
     /**
+     * Shape of a wake-submit correlation id. Matched here rather than trusted because this value is now
+     * supplied by a client over the tool surface, and the daemon that consumes it matches on equality —
+     * a nonce that is merely *stored* but never matchable is indistinguishable from an absent one.
+     * @member {RegExp} wakeSubmitNoncePattern
+     * @protected
+     */
+    wakeSubmitNoncePattern = /^[0-9a-fA-F-]{36}$/
+
+    /**
      * Records a turn-presence event for the request-bound AgentIdentity.
      *
-     * The caller may provide `turnId` on progress/terminal updates. When it is omitted for a
-     * terminal update, the newest active turn for the bound identity is terminalized. This lets
-     * completed-turn signals such as `add_memory` close the interval without inheriting
-     * `add_memory` as the liveness primary.
+     * The caller may provide `turnId` on progress/terminal updates. When it is omitted, the newest
+     * active turn for the bound identity is used. This lets completed-turn signals such as
+     * `add_memory` close the interval without inheriting `add_memory` as the liveness primary — and
+     * it is what allows a harness hook to emit progress at all: a hook that reaches this service over
+     * MCP holds no turn id of its own, and the server is the only party that can answer which turn is
+     * the caller's. Requiring the id from a client that cannot know it forces the client to open the
+     * store directly, which is precisely the bypass this surface exists to remove.
+     *
+     * A `progress` or `terminal` event with no open interval is a **no-op, not an error**: the turn it
+     * would refresh has already expired or closed, and refusing the call would turn an ordinary race
+     * into a failed write.
      *
      * @param {Object} options
      * @param {'start'|'progress'|'terminal'} [options.action='start'] Event kind.
-     * @param {String} [options.turnId] Stable active-turn identifier.
+     * @param {String} [options.turnId] Stable active-turn identifier. Optional throughout: `start`
+     * mints one, `progress` and `terminal` resolve the newest active interval when it is omitted.
      * @param {'completed'|'blocked'|'aborted'|'stale'} [options.terminalState] Terminal state.
      * @param {String} [options.source] Harness/source emitting the event.
      * @param {String} [options.note] Optional bounded diagnostic note.
+     * @param {String} [options.wakeSubmitNonce] Per-submit correlation id linking this interval back to
+     * the wake submit that caused it. The wake daemon's delivery proof matches on this exact value, so a
+     * malformed one is rejected rather than dropped — a silently discarded nonce degrades every
+     * subsequent proof to `wake-submit-unknown`, which reads as "delivery unverifiable" rather than
+     * "correlation key was malformed".
      * @param {String|Date|Number} [options.now=new Date()] Clock override for tests.
      * @returns {Object} Persisted turn-presence payload.
      */
@@ -66,6 +88,7 @@ class TurnPresenceService extends Base {
         terminalState = 'completed',
         source = 'mcp-client',
         note,
+        wakeSubmitNonce,
         now = new Date()
     } = {}) {
         GraphService.requireDb('TurnPresenceService.recordTurnPresence');
@@ -82,8 +105,8 @@ class TurnPresenceService extends Base {
         if (action === 'terminal' && !this.validTerminalStates.includes(terminalState)) {
             throw new Error(`Invalid terminalState '${terminalState}'. Must be one of: ${this.validTerminalStates.join(', ')}.`);
         }
-        if (action === 'progress' && !turnId) {
-            throw new Error('turnId is required when action is progress.');
+        if (wakeSubmitNonce !== undefined && wakeSubmitNonce !== null && !this.wakeSubmitNoncePattern.test(String(wakeSubmitNonce).trim())) {
+            throw new Error(`Invalid wakeSubmitNonce '${wakeSubmitNonce}'. Must be a 36-character UUID.`);
         }
 
         const nowDate = this._coerceDate(now),
@@ -98,7 +121,11 @@ class TurnPresenceService extends Base {
             throw new Error(`turnPresence.ttlMs must be a positive finite number, got ${ttlMs}`);
         }
 
-        const targetTurnId = turnId || (action === 'terminal' ? this._findNewestActiveTurnId(agentIdentity, nowDate) : crypto.randomUUID());
+        // `start` mints an interval; everything else joins the newest open one. A null result here is the
+        // no-op path below, not a failure — see the contract note on this method.
+        const targetTurnId = turnId || (action === 'start'
+            ? crypto.randomUUID()
+            : this._findNewestActiveTurnId(agentIdentity, nowDate));
         if (!targetTurnId) {
             return {
                 status: 'noop',
@@ -125,7 +152,10 @@ class TurnPresenceService extends Base {
                   note          : typeof note === 'string' ? note.slice(0, aiConfig.turnPresence.noteMaxChars) : null,
                   updatedAt     : nowIso,
                   userId        : normalizeUserId(agentIdentity),   // canonical isolation key (no @-form); agentIdentity above stays the @-form label
-                  sharedEntity  : false
+                  sharedEntity  : false,
+                  // Spread last and only when supplied, so a later progress event without a nonce keeps the
+                  // one its `start` carried (via `...current`) instead of erasing the correlation mid-turn.
+                  ...(wakeSubmitNonce ? {wakeSubmitNonce: String(wakeSubmitNonce).trim().toLowerCase()} : {})
               };
 
         GraphService.upsertNode({

--- a/test/playwright/unit/ai/mcp/server/memory-core/recordTurnPresenceOverMcp.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/memory-core/recordTurnPresenceOverMcp.spec.mjs
@@ -1,0 +1,142 @@
+import {test, expect} from '@playwright/test';
+
+import {
+    recordTurnPresenceOverMcp,
+    readToolJson
+} from '../../../../../../../ai/mcp/server/memory-core/helpers/recordTurnPresenceOverMcp.mjs';
+
+const BASE_URL = 'http://plane.test/mc/mcp';
+
+/**
+ * @summary Builds the client/transport seam pair, capturing what the collaborator sent.
+ * @param {Object} [options]
+ * @param {Object} [options.payload] JSON the fake tool returns.
+ * @param {Boolean} [options.isError=false] Whether the tool result reports an error.
+ * @returns {Object} Captured state plus the two seam classes.
+ */
+function createClientSeam({payload = {agentIdentity: '@test-seat', status: 'recorded'}, isError = false} = {}) {
+    const state = {calls: [], headers: null, url: null, closed: false};
+
+    class TransportStub {
+        constructor(url, {requestInit} = {}) {
+            state.url     = url.toString();
+            state.headers = requestInit?.headers
+        }
+    }
+
+    class ClientStub {
+        async connect() {}
+
+        async callTool(request) {
+            state.calls.push(request);
+
+            return {isError, content: [{type: 'text', text: JSON.stringify(payload)}]}
+        }
+
+        async close() { state.closed = true }
+    }
+
+    return {state, ClientClass: ClientStub, TransportClass: TransportStub}
+}
+
+test.describe('recordTurnPresenceOverMcp', () => {
+    test('sends the event to the served store and names the seat in the identity header', async () => {
+        const {state, ClientClass, TransportClass} = createClientSeam();
+
+        const result = await recordTurnPresenceOverMcp({
+            baseUrl   : BASE_URL,
+            identity  : '@test-seat',
+            credential: 'test-bearer',
+            action    : 'progress',
+            note      : 'claude PostToolUse Read',
+            source    : 'claude-post-tool-use',
+            ClientClass,
+            TransportClass
+        });
+
+        expect(state.url).toBe(BASE_URL);
+        expect(state.calls).toHaveLength(1);
+        expect(state.calls[0].name).toBe('record_turn_presence');
+        expect(state.calls[0].arguments).toEqual({
+            action: 'progress',
+            note  : 'claude PostToolUse Read',
+            source: 'claude-post-tool-use'
+        });
+        expect(result.status).toBe('recorded');
+        expect(state.closed).toBe(true);
+
+        // The header is not decoration. Without it the plane records the beacon against the credential's
+        // owner, which for a WRITE means publishing a peer as mid-turn when they are not.
+        expect(state.headers['X-PREFERRED-USERNAME']).toBe('@test-seat');
+        expect(state.headers.Authorization).toBe('Bearer test-bearer')
+    });
+
+    test('omits unspecified fields rather than sending explicit undefined', async () => {
+        const {state, ClientClass, TransportClass} = createClientSeam();
+
+        await recordTurnPresenceOverMcp({baseUrl: BASE_URL, identity: '@test-seat', ClientClass, TransportClass});
+
+        // Passing `turnId: undefined` through would override the tool's own resolution with an explicit
+        // absence — a different contract from not mentioning it.
+        expect(Object.keys(state.calls[0].arguments)).toEqual(['action']);
+        expect(state.headers.Authorization).toBeUndefined()
+    });
+
+    test('refuses to resolve its own endpoint or identity', async () => {
+        const {ClientClass, TransportClass} = createClientSeam();
+
+        await expect(recordTurnPresenceOverMcp({identity: '@test-seat', ClientClass, TransportClass}))
+            .rejects.toThrow(/requires an injected baseUrl/);
+
+        await expect(recordTurnPresenceOverMcp({baseUrl: BASE_URL, ClientClass, TransportClass}))
+            .rejects.toThrow(/requires an identity/)
+    });
+
+    test('rejects a beacon the plane recorded against a DIFFERENT agent', async () => {
+        const {state, ClientClass, TransportClass} = createClientSeam({
+            payload: {agentIdentity: '@somebody-else', status: 'recorded'}
+        });
+
+        // The header names the seat; it does not guarantee the plane honoured it. Reporting success here
+        // would publish another agent as mid-turn — strictly worse than recording nothing.
+        await expect(recordTurnPresenceOverMcp({
+            baseUrl : BASE_URL,
+            identity: '@test-seat',
+            ClientClass,
+            TransportClass
+        })).rejects.toThrow(/recorded presence for '@somebody-else' but this seat is '@test-seat'/);
+
+        expect(state.closed).toBe(true)
+    });
+
+    test('surfaces a tool-level error instead of returning a hollow success', async () => {
+        const {ClientClass, TransportClass} = createClientSeam({isError: true});
+
+        await expect(recordTurnPresenceOverMcp({
+            baseUrl : BASE_URL,
+            identity: '@test-seat',
+            ClientClass,
+            TransportClass
+        })).rejects.toThrow(/isError=true/)
+    });
+
+    test('a no-op result carries no identity to disagree with and passes through', async () => {
+        const {ClientClass, TransportClass} = createClientSeam({
+            payload: {status: 'noop', reason: 'no-active-turn'}
+        });
+
+        await expect(recordTurnPresenceOverMcp({
+            baseUrl : BASE_URL,
+            identity: '@test-seat',
+            action  : 'terminal',
+            ClientClass,
+            TransportClass
+        })).resolves.toMatchObject({status: 'noop', reason: 'no-active-turn'})
+    });
+
+    test('readToolJson refuses an empty content block rather than inventing a payload', () => {
+        expect(() => readToolJson({content: []})).toThrow(/no text content/);
+        expect(() => readToolJson({content: [{type: 'text', text: '  '}]})).toThrow(/no text content/);
+        expect(readToolJson({content: [{type: 'text', text: '{"status":"recorded"}'}]})).toEqual({status: 'recorded'})
+    })
+});

--- a/test/playwright/unit/ai/services/memory-core/TurnPresenceService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/TurnPresenceService.spec.mjs
@@ -13,10 +13,10 @@ setup({
     }
 });
 
-import {test, expect}        from '@playwright/test';
-import Neo                   from '../../../../../../src/Neo.mjs';
-import * as core             from '../../../../../../src/core/_export.mjs';
-import RequestContextService from '../../../../../../ai/mcp/server/shared/services/RequestContextService.mjs';
+import {test, expect}         from '@playwright/test';
+import Neo                    from '../../../../../../src/Neo.mjs';
+import * as core              from '../../../../../../src/core/_export.mjs';
+import RequestContextService  from '../../../../../../ai/mcp/server/shared/services/RequestContextService.mjs';
 import fs                     from 'fs';
 import path                   from 'path';
 import * as yaml              from 'js-yaml';
@@ -195,6 +195,89 @@ test.describe('Neo.ai.services.memory-core.TurnPresenceService', () => {
             action       : 'terminal',
             agentIdentity: '@agent-turn'
         });
+    });
+
+    test('progress without turnId joins the newest active interval instead of refusing', async () => {
+        // A harness hook reaching this over MCP holds no turn id — it stopped querying a database to get
+        // one. Requiring the id from a client that cannot know it is precisely what pushed the hook into
+        // opening the store directly, so this widening is what removes the incentive for that bypass.
+        await asAgent(() => TurnPresenceService.recordTurnPresence({
+            action: 'start',
+            turnId: 'hookless-older',
+            now   : '2026-06-19T02:00:00.000Z'
+        }));
+        await asAgent(() => TurnPresenceService.recordTurnPresence({
+            action: 'start',
+            turnId: 'hookless-newer',
+            now   : '2026-06-19T02:05:00.000Z'
+        }));
+
+        const result = await asAgent(() => TurnPresenceService.recordTurnPresence({
+            action: 'progress',
+            source: 'claude-post-tool-use',
+            now   : '2026-06-19T02:06:00.000Z'
+        }));
+
+        expect(result.turnId).toBe('hookless-newer');
+        expect(result.startedAt).toBe('2026-06-19T02:05:00.000Z');
+        expect(result.lastProgressAt).toBe('2026-06-19T02:06:00.000Z');
+        // It must JOIN an interval, never mint a second one for the same turn.
+        expect(getNode('hookless-older').properties.lastProgressAt).toBe('2026-06-19T02:00:00.000Z');
+    });
+
+    test('progress with no open interval is a no-op, not an error', async () => {
+        const result = await asAgent(() => TurnPresenceService.recordTurnPresence({
+            action: 'progress',
+            now   : '2026-06-19T03:00:00.000Z'
+        }));
+
+        // The turn it would refresh has already expired or closed. Refusing the call would turn an
+        // ordinary race into a failed write on a path that must never break a session.
+        expect(result).toEqual({
+            status       : 'noop',
+            reason       : 'no-active-turn',
+            action       : 'progress',
+            agentIdentity: '@agent-turn'
+        });
+    });
+
+    test('wakeSubmitNonce persists, survives a later progress, and is rejected when malformed', async () => {
+        const nonce = '7ac7f929-0e77-4f61-92d2-1f078e871fe4';
+
+        await asAgent(() => TurnPresenceService.recordTurnPresence({
+            action         : 'start',
+            turnId         : 'turn-nonce',
+            wakeSubmitNonce: nonce,
+            now            : '2026-06-19T04:00:00.000Z'
+        }));
+
+        expect(getNode('turn-nonce').properties.wakeSubmitNonce).toBe(nonce);
+
+        await asAgent(() => TurnPresenceService.recordTurnPresence({
+            action: 'progress',
+            turnId: 'turn-nonce',
+            now   : '2026-06-19T04:01:00.000Z'
+        }));
+
+        // The wake daemon's delivery proof matches on this exact value. A progress event that omitted the
+        // nonce must not erase the correlation mid-turn, or the proof degrades to `wake-submit-unknown`
+        // for a delivery that demonstrably happened.
+        expect(getNode('turn-nonce').properties.wakeSubmitNonce).toBe(nonce);
+
+        // Rejected rather than dropped: a stored-but-unmatchable nonce is indistinguishable from an
+        // absent one, so silently normalising it away would report correlation that can never fire.
+        // Synchronous throw — asserted through a thunk, because `asAgent(...)` would raise before
+        // `expect` ever received a promise to reject.
+        expect(() => asAgent(() => TurnPresenceService.recordTurnPresence({
+            action         : 'start',
+            turnId         : 'turn-bad-nonce',
+            wakeSubmitNonce: 'not-a-uuid',
+            now            : '2026-06-19T04:02:00.000Z'
+        }))).toThrow(/Invalid wakeSubmitNonce/);
+
+        // And nothing was persisted for the rejected call — the validation runs BEFORE the upsert, so a
+        // malformed nonce cannot leave a half-written interval behind.
+        expect(getNode('turn-bad-nonce')).toBeFalsy();
     });
 
     test('successful add_memory terminalizes the active turn interval', async () => {

--- a/test/playwright/unit/hooks/codexContextHook.spec.mjs
+++ b/test/playwright/unit/hooks/codexContextHook.spec.mjs
@@ -1,5 +1,4 @@
 import {test, expect} from '@playwright/test';
-import Database       from 'better-sqlite3';
 import fs             from 'node:fs';
 import os             from 'node:os';
 import path           from 'node:path';
@@ -48,42 +47,36 @@ test.describe('codex-context hook - wake submit nonce', () => {
         })).toBe(nonce);
     });
 
-    test('records wakeSubmitNonce on the turn-presence row when present', async () => {
-        const dir    = fs.mkdtempSync(path.join(os.tmpdir(), 'codex-context-hook-')),
-              dbPath = path.join(dir, 'graph.sqlite'),
-              db     = new Database(dbPath),
-              nonce  = '123e4567-e89b-12d3-a456-426614174001';
-
-        db.exec(`
-            CREATE TABLE Nodes (
-                id TEXT PRIMARY KEY,
-                user_id TEXT,
-                data TEXT
-            )
-        `);
+    test('carries wakeSubmitNonce to the served store, because the delivery proof matches on it', async () => {
+        const dir   = fs.mkdtempSync(path.join(os.tmpdir(), 'codex-context-hook-')),
+              nonce = '123e4567-e89b-12d3-a456-426614174001',
+              calls = [];
 
         try {
             await recordTurnStarted({
                 env: {
                     NEO_AGENT_IDENTITY: '@test-codex',
-                    NEO_MEMORY_DB_PATH: dbPath,
                     NEO_AI_DAEMON_DIR : dir
                 },
                 hookPayload: {
                     prompt: `[WAKE]\n<!-- NEO_WAKE_SUBMIT_NONCE:${nonce} -->`
                 },
-                rootDir: path.resolve(new URL('../../../..', import.meta.url).pathname)
+                plane : {baseUrl: 'http://plane.test/mc/mcp', credential: 'test-bearer'},
+                record: async args => { calls.push(args); return {agentIdentity: args.identity, status: 'recorded'} }
             });
 
-            const row = db.prepare('SELECT data FROM Nodes WHERE id LIKE ?').get('AGENT_TURN_PRESENCE:%');
-            expect(row).toBeTruthy();
-
-            const node = JSON.parse(row.data);
-            expect(node.properties.agentIdentity).toBe('@test-codex');
-            expect(node.properties.source).toBe('codex-user-prompt-submit');
-            expect(node.properties.wakeSubmitNonce).toBe(nonce);
+            // Asserted at the transport boundary rather than against a local SQLite file. The previous
+            // shape wrote to a temp database and read the row back — which is the very thing the hook
+            // used to do wrong, so it could go green while no beacon ever reached the deployment.
+            expect(calls).toHaveLength(1);
+            expect(calls[0]).toMatchObject({
+                baseUrl        : 'http://plane.test/mc/mcp',
+                identity       : '@test-codex',
+                source         : 'codex-user-prompt-submit',
+                action         : 'start',
+                wakeSubmitNonce: nonce
+            });
         } finally {
-            db.close();
             fs.rmSync(dir, {recursive: true, force: true});
         }
     });
@@ -166,94 +159,57 @@ test.describe('codex-context hook - wake submit nonce', () => {
 });
 
 test.describe('turn-presence hook writer', () => {
-    test('Claude UserPromptSubmit starts and PostToolUse refreshes the active turn', async () => {
-        const dir     = fs.mkdtempSync(path.join(os.tmpdir(), 'claude-turn-presence-hook-')),
-              dbPath  = path.join(dir, 'graph.sqlite'),
-              db      = new Database(dbPath),
-              rootDir = path.resolve(new URL('../../../..', import.meta.url).pathname),
-              env     = {
-                  NEO_AGENT_IDENTITY        : '@test-claude',
-                  NEO_MEMORY_DB_PATH        : dbPath,
-                  NEO_AI_DAEMON_DIR         : dir,
-                  NEO_TURN_PRESENCE_FRESH_MS: '60000',
-                  NEO_TURN_PRESENCE_TTL_MS  : '600000'
-              },
-              startedAt = '2026-06-25T00:00:00.000Z',
-              progressAt = '2026-06-25T00:05:00.000Z';
+    const PLANE = Object.freeze({baseUrl: 'http://plane.test/mc/mcp', credential: 'test-bearer'});
 
-        db.exec(`
-            CREATE TABLE Nodes (
-                id TEXT PRIMARY KEY,
-                user_id TEXT,
-                data TEXT
-            )
-        `);
+    test('Claude UserPromptSubmit starts and PostToolUse refreshes the SAME turn, without inventing an id', async () => {
+        const calls = [];
 
-        try {
-            await recordClaudeTurnPresence({
-                env,
-                hookPayload: {hook_event_name: 'UserPromptSubmit'},
-                now        : startedAt,
-                rootDir
-            });
+        const record = async args => { calls.push(args); return {agentIdentity: args.identity, status: 'recorded'} };
 
-            await recordClaudeTurnPresence({
-                env,
-                hookPayload: {hook_event_name: 'PostToolUse', tool_name: 'Bash'},
-                now        : progressAt,
-                rootDir
-            });
+        await recordClaudeTurnPresence({
+            env        : {NEO_AGENT_IDENTITY: '@test-claude'},
+            hookPayload: {hook_event_name: 'UserPromptSubmit'},
+            plane      : PLANE,
+            record
+        });
 
-            const rows = db.prepare('SELECT data FROM Nodes WHERE id LIKE ?').all('AGENT_TURN_PRESENCE:%');
-            expect(rows).toHaveLength(1);
+        await recordClaudeTurnPresence({
+            env        : {NEO_AGENT_IDENTITY: '@test-claude'},
+            hookPayload: {hook_event_name: 'PostToolUse', tool_name: 'Bash'},
+            plane      : PLANE,
+            record
+        });
 
-            const node = JSON.parse(rows[0].data);
-            expect(node.properties.agentIdentity).toBe('@test-claude');
-            expect(node.properties.source).toBe('claude-post-tool-use');
-            expect(node.properties.note).toBe('claude PostToolUse Bash');
-            expect(node.properties.startedAt).toBe(startedAt);
-            expect(node.properties.lastProgressAt).toBe(progressAt);
-            expect(node.properties.freshUntil).toBe('2026-06-25T00:06:00.000Z');
-            expect(node.properties.status).toBe('active');
-        } finally {
-            db.close();
-            fs.rmSync(dir, {recursive: true, force: true});
-        }
+        expect(calls.map(({action, source, note}) => ({action, source, note}))).toEqual([
+            {action: 'start',    source: 'claude-user-prompt-submit', note: 'claude UserPromptSubmit'},
+            {action: 'progress', source: 'claude-post-tool-use',      note: 'claude PostToolUse Bash'}
+        ]);
+
+        calls.forEach(call => {
+            expect(call.identity).toBe('@test-claude');
+            expect(call.baseUrl).toBe(PLANE.baseUrl);
+            // Neither call may carry a locally-minted turnId. The hook holds none and the server owns
+            // interval identity; sending one would fork a second turn on every tool call. The freshness
+            // bounds this test used to assert are the server's to stamp, not the hook's to compute.
+            expect(call.turnId).toBeUndefined();
+        });
     });
 
-    test('Claude PostToolUse progress is a no-op without an active turn', async () => {
-        const dir    = fs.mkdtempSync(path.join(os.tmpdir(), 'claude-turn-presence-hook-')),
-              dbPath = path.join(dir, 'graph.sqlite'),
-              db     = new Database(dbPath);
+    test('an unconfigured plane skips by NAME and never reaches the transport', async () => {
+        const calls = [];
 
-        db.exec(`
-            CREATE TABLE Nodes (
-                id TEXT PRIMARY KEY,
-                user_id TEXT,
-                data TEXT
-            )
-        `);
+        const result = await recordClaudeTurnPresence({
+            env        : {NEO_AGENT_IDENTITY: '@test-claude'},
+            hookPayload: {hook_event_name: 'PostToolUse', tool_name: 'Bash'},
+            plane      : {baseUrl: ''},
+            record     : async args => { calls.push(args); return {status: 'recorded'} }
+        });
 
-        try {
-            const result = await recordClaudeTurnPresence({
-                env: {
-                    NEO_AGENT_IDENTITY: '@test-claude',
-                    NEO_MEMORY_DB_PATH: dbPath,
-                    NEO_AI_DAEMON_DIR : dir
-                },
-                hookPayload: {hook_event_name: 'PostToolUse', tool_name: 'Bash'},
-                rootDir    : path.resolve(new URL('../../../..', import.meta.url).pathname)
-            });
-
-            expect(result).toMatchObject({
-                action: 'progress',
-                reason: 'no-active-turn',
-                status: 'noop'
-            });
-            expect(db.prepare('SELECT COUNT(*) AS count FROM Nodes').get().count).toBe(0);
-        } finally {
-            db.close();
-            fs.rmSync(dir, {recursive: true, force: true});
-        }
+        // The replaced behaviour wrote to whatever path it computed and reported success. A skip that
+        // says why is the whole point: a beacon in a store nobody reads makes an unmeasured state look
+        // measured.
+        expect(result.status).toBe('skipped');
+        expect(result.reason).toContain('no Memory Core plane is configured');
+        expect(calls).toHaveLength(0);
     });
 });

--- a/test/playwright/unit/hooks/kimiTurnPresenceHook.spec.mjs
+++ b/test/playwright/unit/hooks/kimiTurnPresenceHook.spec.mjs
@@ -1,9 +1,6 @@
 import {test, expect}  from '@playwright/test';
-import Database        from 'better-sqlite3';
 import {spawnSync}     from 'node:child_process';
 import fs              from 'node:fs';
-import os              from 'node:os';
-import path            from 'node:path';
 import {fileURLToPath} from 'node:url';
 
 import {
@@ -15,48 +12,33 @@ import {
 const
     configPath = fileURLToPath(new URL('../../../../.kimi-code/hooks/turn-presence.example.toml', import.meta.url)),
     hookPath   = fileURLToPath(new URL('../../../../.kimi-code/hooks/turnPresenceHook.mjs', import.meta.url)),
-    rootDir    = fileURLToPath(new URL('../../../..', import.meta.url));
+    PLANE      = Object.freeze({baseUrl: 'http://plane.test/mc/mcp', credential: 'test-bearer'});
 
 /**
- * @summary Creates the minimal graph fixture consumed by the fail-soft hook writer.
- * @param {String} prefix Temporary-directory prefix.
- * @returns {{db: Database, dbPath: String, dir: String}}
+ * @summary Captures every call the adapter routes to the transport, standing in for the served store.
+ *
+ * The predecessor of this fixture was a temporary SQLite file, and the assertions read rows back out of
+ * it. That shape could not fail on the defect it was meant to guard: writing to a local file is exactly
+ * what the hook used to do wrong, so a green suite proved only that *some* store received the beacon —
+ * never that the deployment's store did. Recording the outbound call instead pins the contract at the
+ * boundary the beacon actually has to cross.
+ * @returns {{calls: Object[], record: Function}}
  */
-function createGraphFixture(prefix='kimi-turn-presence-hook-') {
-    const dir    = fs.mkdtempSync(path.join(os.tmpdir(), prefix)),
-          dbPath = path.join(dir, 'graph.sqlite'),
-          db     = new Database(dbPath);
+function createTransportRecorder() {
+    const calls = [];
 
-    db.exec(`
-        CREATE TABLE Nodes (
-            id TEXT PRIMARY KEY,
-            user_id TEXT,
-            data TEXT
-        )
-    `);
+    return {
+        calls,
+        record: async args => {
+            calls.push(args);
 
-    return {db, dbPath, dir}
-}
-
-/**
- * @summary Closes and removes one temporary graph fixture.
- * @param {{db: Database, dir: String}} fixture Graph fixture.
- * @returns {void}
- */
-function destroyGraphFixture({db, dir}) {
-    db.close();
-    fs.rmSync(dir, {recursive: true, force: true})
-}
-
-/**
- * @summary Reads every persisted turn-presence node from a fixture database.
- * @param {Database} db SQLite database.
- * @returns {Object[]}
- */
-function readTurnPresenceNodes(db) {
-    return db.prepare('SELECT data FROM Nodes WHERE id LIKE ? ORDER BY id')
-        .all('AGENT_TURN_PRESENCE:%')
-        .map(({data}) => JSON.parse(data))
+            return {
+                agentIdentity: args.identity,
+                turnId       : 'turn-under-test',
+                status       : 'recorded'
+            }
+        }
+    }
 }
 
 test.describe('Kimi Code turn-presence hook adapter', () => {
@@ -135,176 +117,158 @@ test.describe('Kimi Code turn-presence hook adapter', () => {
         })
     });
 
-    test('records start, progress, and completed terminal state on one active turn', async () => {
-        const fixture = createGraphFixture();
-        const env     = {
-            NEO_AGENT_IDENTITY        : '@test-kimi',
-            NEO_MEMORY_DB_PATH        : fixture.dbPath,
-            NEO_TURN_PRESENCE_FRESH_MS: '60000',
-            NEO_TURN_PRESENCE_TTL_MS  : '600000'
-        };
+    test('each mapped event reaches the served store with its own action, source and terminal state', async () => {
+        const {calls, record} = createTransportRecorder(),
+              env             = {NEO_AGENT_IDENTITY: '@test-kimi'};
 
-        try {
+        for (const [hook_event_name, extra] of [
+            ['UserPromptSubmit', {session_id: 'session-test'}],
+            ['PostToolUse',      {tool_name: 'Shell'}],
+            ['Stop',             {}]
+        ]) {
             await recordKimiTurnPresence({
                 env,
-                hookPayload: {hook_event_name: 'UserPromptSubmit', session_id: 'session-test'},
-                now        : '2026-07-19T20:00:00.000Z',
-                rootDir
-            });
-            await recordKimiTurnPresence({
-                env,
-                hookPayload: {hook_event_name: 'PostToolUse', tool_name: 'Shell'},
-                now        : '2026-07-19T20:01:00.000Z',
-                rootDir
-            });
-            const result = await recordKimiTurnPresence({
-                env,
-                hookPayload: {hook_event_name: 'Stop'},
-                now        : '2026-07-19T20:02:00.000Z',
-                rootDir
-            });
-
-            expect(result).toMatchObject({
-                action       : 'terminal',
-                agentIdentity: '@test-kimi',
-                source       : 'kimi-stop',
-                status       : 'recorded',
-                terminalState: 'completed'
-            });
-
-            const nodes = readTurnPresenceNodes(fixture.db);
-            expect(nodes).toHaveLength(1);
-            expect(nodes[0].properties).toMatchObject({
-                agentIdentity : '@test-kimi',
-                lastProgressAt: '2026-07-19T20:02:00.000Z',
-                note          : 'kimi Stop',
-                source        : 'kimi-stop',
-                startedAt     : '2026-07-19T20:00:00.000Z',
-                status        : 'terminal',
-                terminalState : 'completed'
+                hookPayload: {hook_event_name, ...extra},
+                plane      : PLANE,
+                record
             })
-        } finally {
-            destroyGraphFixture(fixture)
         }
+
+        expect(calls.map(({action, source, note}) => ({action, source, note}))).toEqual([
+            {action: 'start',    source: 'kimi-user-prompt-submit', note: 'kimi UserPromptSubmit'},
+            {action: 'progress', source: 'kimi-post-tool-use',      note: 'kimi PostToolUse Shell'},
+            {action: 'terminal', source: 'kimi-stop',               note: 'kimi Stop'}
+        ]);
+
+        // Only the terminal call carries a terminalState — sending one on start/progress would assert a
+        // close that did not happen.
+        expect(calls.map(({terminalState}) => terminalState)).toEqual([undefined, undefined, 'completed']);
+
+        // Every call must name THIS seat and THIS plane. Without the identity the server records the
+        // beacon against the credential's owner, publishing the wrong agent as mid-turn.
+        calls.forEach(call => {
+            expect(call.identity).toBe('@test-kimi');
+            expect(call.baseUrl).toBe(PLANE.baseUrl);
+            expect(call.credential).toBe(PLANE.credential)
+        });
+
+        // No turnId is sent: the hook holds none, and the server resolves the open interval. Sending a
+        // locally-invented id is what would fork a second turn per event.
+        expect(calls.every(({turnId}) => turnId === undefined)).toBe(true)
     });
 
-    for (const eventName of ['StopFailure', 'Interrupt']) {
-        test(`${eventName} terminates the active turn as aborted`, async () => {
-            const fixture = createGraphFixture();
-            const env     = {
-                NEO_AGENT_IDENTITY: '@test-kimi',
-                NEO_MEMORY_DB_PATH: fixture.dbPath
-            };
+    for (const [eventName, source] of [['StopFailure', 'kimi-stop-failure'], ['Interrupt', 'kimi-interrupt']]) {
+        test(`${eventName} closes the turn as aborted`, async () => {
+            const {calls, record} = createTransportRecorder();
 
-            try {
-                await recordKimiTurnPresence({
-                    env,
-                    hookPayload: {hook_event_name: 'UserPromptSubmit'},
-                    now        : '2026-07-19T20:00:00.000Z',
-                    rootDir
-                });
-                await recordKimiTurnPresence({
-                    env,
-                    hookPayload: {hook_event_name: eventName},
-                    now        : '2026-07-19T20:01:00.000Z',
-                    rootDir
-                });
+            await recordKimiTurnPresence({
+                env        : {NEO_AGENT_IDENTITY: '@test-kimi'},
+                hookPayload: {hook_event_name: eventName},
+                plane      : PLANE,
+                record
+            });
 
-                expect(readTurnPresenceNodes(fixture.db)[0].properties).toMatchObject({
-                    source       : eventName === 'Interrupt' ? 'kimi-interrupt' : 'kimi-stop-failure',
-                    status       : 'terminal',
-                    terminalState: 'aborted'
-                })
-            } finally {
-                destroyGraphFixture(fixture)
-            }
+            expect(calls).toHaveLength(1);
+            expect(calls[0]).toMatchObject({action: 'terminal', source, terminalState: 'aborted'})
         })
     }
 
-    test('session events and missing identity fail soft without writing', async () => {
-        const fixture = createGraphFixture();
+    test('an unsupported event, a missing identity, and an unconfigured plane each skip WITHOUT reaching the transport', async () => {
+        const {calls, record} = createTransportRecorder();
 
-        try {
-            await expect(recordKimiTurnPresence({
-                env        : {NEO_AGENT_IDENTITY: '@test-kimi', NEO_MEMORY_DB_PATH: fixture.dbPath},
-                hookPayload: {hook_event_name: 'SessionStart'},
-                rootDir
-            })).resolves.toEqual({
-                eventName: 'SessionStart',
-                reason   : 'unsupported-hook-event',
-                status   : 'noop'
-            });
+        await expect(recordKimiTurnPresence({
+            env        : {NEO_AGENT_IDENTITY: '@test-kimi'},
+            hookPayload: {hook_event_name: 'SessionStart'},
+            plane      : PLANE,
+            record
+        })).resolves.toEqual({eventName: 'SessionStart', reason: 'unsupported-hook-event', status: 'noop'});
 
-            await expect(recordKimiTurnPresence({
-                env        : {NEO_MEMORY_DB_PATH: fixture.dbPath},
-                hookPayload: {hook_event_name: 'UserPromptSubmit'},
-                rootDir
-            })).resolves.toBeUndefined();
+        await expect(recordKimiTurnPresence({
+            env        : {},
+            hookPayload: {hook_event_name: 'UserPromptSubmit'},
+            plane      : PLANE,
+            record
+        })).resolves.toMatchObject({status: 'skipped'});
 
-            expect(readTurnPresenceNodes(fixture.db)).toHaveLength(0)
-        } finally {
-            destroyGraphFixture(fixture)
-        }
+        // The load-bearing case: an unconfigured plane must NAME the skip, never fall back to writing
+        // somewhere reachable. A beacon in a store nobody reads makes an unmeasured state look measured,
+        // which is the defect this whole path was repaired for.
+        const unconfigured = await recordKimiTurnPresence({
+            env        : {NEO_AGENT_IDENTITY: '@test-kimi'},
+            hookPayload: {hook_event_name: 'UserPromptSubmit'},
+            plane      : {baseUrl: ''},
+            record
+        });
+
+        expect(unconfigured.status).toBe('skipped');
+        expect(unconfigured.reason).toContain('no Memory Core plane is configured');
+        expect(calls).toHaveLength(0)
     });
 
     test('missing identity warns once on UserPromptSubmit, never on PostToolUse, always fail-open', async () => {
-        const fixture       = createGraphFixture();
-        const writes        = [];
-        const originalWrite = process.stderr.write;
+        const {calls, record} = createTransportRecorder(),
+              writes          = [],
+              originalWrite   = process.stderr.write;
 
         process.stderr.write = chunk => { writes.push(String(chunk)); return true };
 
         try {
             await expect(recordKimiTurnPresence({
-                env        : {NEO_MEMORY_DB_PATH: fixture.dbPath},
+                env        : {},
                 hookPayload: {hook_event_name: 'UserPromptSubmit'},
-                rootDir
-            })).resolves.toBeUndefined();
+                plane      : PLANE,
+                record
+            })).resolves.toMatchObject({status: 'skipped'});
             expect(writes).toHaveLength(1);
             expect(writes[0]).toContain('NEO_AGENT_IDENTITY unresolved');
             expect(writes[0]).toContain('--env-file-if-exists');
 
             writes.length = 0;
             await expect(recordKimiTurnPresence({
-                env        : {NEO_MEMORY_DB_PATH: fixture.dbPath},
+                env        : {},
                 hookPayload: {hook_event_name: 'PostToolUse', tool_name: 'Shell'},
-                rootDir
-            })).resolves.toBeUndefined();
+                plane      : PLANE,
+                record
+            })).resolves.toMatchObject({status: 'skipped'});
             expect(writes).toHaveLength(0);
 
             await expect(recordKimiTurnPresence({
-                env        : {NEO_AGENT_IDENTITY: '@test-kimi', NEO_MEMORY_DB_PATH: fixture.dbPath},
+                env        : {NEO_AGENT_IDENTITY: '@test-kimi'},
                 hookPayload: {hook_event_name: 'UserPromptSubmit'},
-                rootDir
+                plane      : PLANE,
+                record
             })).resolves.toMatchObject({status: 'recorded'});
-            expect(writes).toHaveLength(0)
+            expect(writes).toHaveLength(0);
+            expect(calls).toHaveLength(1)
         } finally {
-            process.stderr.write = originalWrite;
-            destroyGraphFixture(fixture)
+            process.stderr.write = originalWrite
         }
     });
 
-    test('the executable adapter exits cleanly when the local writer rejects', () => {
-        const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'kimi-turn-presence-process-'));
+    test('the executable adapter survives an unreachable plane and SAYS SO on stderr', () => {
+        const result = spawnSync(process.execPath, [hookPath], {
+            encoding: 'utf8',
+            env     : {
+                ...process.env,
+                NEO_AGENT_IDENTITY: '@test-kimi',
+                // A port nothing is listening on: the write cannot land, which must surface rather than
+                // pass silently. The predecessor of this test asserted EMPTY stderr here — it encoded the
+                // silence as the contract, so the failure it should have caught was the behaviour it pinned.
+                NEO_FLEET_PLANE_BASE: 'http://127.0.0.1:1'
+            },
+            input  : JSON.stringify({hook_event_name: 'UserPromptSubmit'}),
+            timeout: 20000
+        });
 
-        try {
-            const result = spawnSync(process.execPath, [hookPath], {
-                encoding: 'utf8',
-                env     : {
-                    ...process.env,
-                    NEO_AGENT_IDENTITY: '@test-kimi',
-                    NEO_MEMORY_DB_PATH: path.join(dir, 'missing.sqlite')
-                },
-                input  : JSON.stringify({hook_event_name: 'UserPromptSubmit'}),
-                timeout: 5000
-            });
+        expect(result.error).toBeUndefined();
+        expect(result.status).toBe(0);
+        expect(result.stdout).toBe('');
 
-            expect(result.error).toBeUndefined();
-            expect(result.status).toBe(0);
-            expect(result.stdout).toBe('');
-            expect(result.stderr).toBe('')
-        } finally {
-            fs.rmSync(dir, {recursive: true, force: true})
-        }
+        // Discriminated deliberately: 'not recorded' alone would ALSO be printed by the unconfigured-plane
+        // skip, so asserting it would let this test pass without the transport ever being attempted. The
+        // throw text can only come from a plane that was configured, reached for, and failed.
+        expect(result.stderr).toContain('not recorded');
+        expect(result.stderr).toContain('threw');
+        expect(result.stderr).not.toContain('no Memory Core plane is configured')
     })
 });


### PR DESCRIPTION
## Summary

Turn-presence beacons never reached this deployment. The hook writer resolved its target from `import.meta.url` and opened it with `better-sqlite3`, so every beacon landed in whichever *checkout* the hook file lived in — and **succeeded** there, which is why nothing surfaced.

This routes the write through the `record_turn_presence` tool that already existed server-side, makes the three hook adapters the entrypoints that resolve the plane, and deletes the path machinery.

Resolves #16513

## Why it could not be a config fix

`docker-compose.yml:483` declares `shared-sqlite-data` as a Docker **named volume** (inside the Docker VM on macOS); `:193` mounts it at the served graph path. Control in the same file: `:327` mounts backups as a real host bind — which is why backups *are* host-reachable and the graph is not. So no env var had anything to point at.

Re-confirms #16401's ruling from the subscription side — *the contract was right and the in-repo precedent was wrong* — where `TurnPresenceHookWriter` **was** the precedent.

Evidence: 7192 unreadable intervals from 9 agents in one checkout (163 written today); `who_is_online` read the author `idle` beside a live beacon, and one write over MCP flipped it to `online — mid-turn rescue` with all other agents at `turnPresence: null`. Full measurement, corrections, and the per-agent table: #16513.

## Deltas

- `helpers/recordTurnPresenceOverMcp.mjs` — **new.** Pure collaborator lifted from `readSubscriptionsOverMcp.mjs`. Identity is a **precondition**, not an optional header, and the returned `agentIdentity` is verified: for a read a missing header returns the wrong rows, for a **write** it publishes a peer as mid-turn.
- `helpers/TurnPresenceHookWriter.mjs` — **−135 lines.** No path, no sqlite, no duplicated freshness policy. Returns `{status, reason}`; an unconfigured plane is a **named skip, never a fallback write** — a beacon in an unread store makes an unmeasured state look measured.
- `TurnPresenceService.mjs` — two widenings forced by the transport change: `progress` resolves the newest interval when `turnId` is omitted (a hook over MCP holds none; *the requirement is what forced the bypass*), and `wakeSubmitNonce` is persisted so the wake daemon's delivery proof keeps its correlation key. Malformed nonce rejected, not normalised away.
- `openapi.yaml` — `wakeSubmitNonce`; corrected `turnId` and path semantics.
- `.claude` / `.kimi-code` / `.codex` hook adapters — all three become entrypoints reading `AiConfig.fleet.planeBase`/`planeBearer`, mirroring `wakeArmingHook`. None reports success silently.

## Test Evidence

- **263/263** `test/playwright/unit/hooks/` · **2071/2072** memory-core + mcp.
- The one failure reproduces on clean `dev` with this branch stashed (plus a second this branch doesn't hit) — pre-existing parallel-ordering flake; passes 5/5 isolated here.

The three hook specs asserted against a temp SQLite file — the shape that let the defect live, since writing to a local database is exactly what the hook did wrong. One asserted **empty stderr on failure**, pinning the silence as the contract. They now assert the call crossing the boundary: per-event action/source/note, the identity header, that no locally-minted `turnId` is sent, and that an unconfigured plane skips **without reaching the transport**. Plus a new spec for the collaborator.

## Post-Merge Validation

1. With `fleet.planeBase` set, take one turn → `who_is_online` returns non-null `turnPresence` with `mid-turn rescue` while `add_memory` is stale.
2. A seat with no plane prints the named skip and creates **no** rows in its checkout.
3. `.neo-ai-data/sqlite/memory-core-graph.sqlite` stops accruing rows in maintainer checkouts.

**Known limit:** `fleet.planeBase` is empty on the author's seat and Claude hooks launch without `--env-file`, so presence there is an honest visible skip until that leaf is set. Step 1 needs a configured seat.

**Latent, tracked:** #16526 — `wake/daemon.mjs` proof-reads the same host path, so starting it with this merged degrades Codex delivery proof. Latent because that process isn't running (`launchctl` binds the wake agent to `receiver.mjs`). It couldn't ride along: the daemon serves 8 reads off one handle, so moving one leaves it reading two stores. `wakeSubmitNonce` ships here so the key is waiting.

## Review notes

Two places worth an adversarial eye:

1. **Named skip over any fallback** — a misconfigured seat emits nothing. Argument: an unread beacon is worse than none, and `who_is_online` already degrades to `add_memory`-recency. Falsify if that doesn't hold.
2. **Rejecting a malformed nonce fails the whole beacon** over a diagnostic field. The alternative trades a loud caller bug for a silently unprovable delivery.

**Regression window is dated.** Splitting beacons by writer per day, server-side and hook writes both landed in this store in matching volumes through 2026-07-30; the server drops to 1 on 07-31 and 0 from 08-02, while hook writes continue. The writer was **correct-by-colocation** until containerization and has been fully split since. Beacons before 07-31 were fine. Table on #16513.

Authored by @neo-opus-grace (Claude Opus 5)
