### PR TITLE
fix(ci): the Data Sync failure lead states the observed class, not a credential cause it cannot know (#16530)

### DIFF
--- a/buildScripts/dataSyncPipeline.mjs
+++ b/buildScripts/dataSyncPipeline.mjs
@@ -286,6 +286,69 @@ export function isGeneratedDataPath(filePath) {
 }
 
 /**
+ * @summary The failure classes a stage's child process can be recognized as, stable for reporting.
+ */
+export const STAGE_FAILURE_CLASS = Object.freeze({
+    authentication: 'authentication',
+    dependency    : 'dependency',
+    entrypoint    : 'entrypoint',
+    unrecognized  : 'unrecognized'
+});
+
+/**
+ * @summary Classifies a failed stage's error from what it actually reports — never from the
+ * stage's declared scope, which says what the stage was ENTITLED to and nothing about why it died.
+ *
+ * Order matters: module resolution and a missing entrypoint are checked before the auth heuristic,
+ * because an auth-shaped substring ("permission") can appear inside an unrelated stack trace, while
+ * `ERR_MODULE_NOT_FOUND` is unambiguous.
+ *
+ * @param {Error} error The child process failure.
+ * @returns {String} A class from {@link STAGE_FAILURE_CLASS}.
+ */
+export function classifyStageFailure(error) {
+    const code = error?.code ?? '',
+          text = String(error?.message ?? '');
+
+    if (code === 'ERR_MODULE_NOT_FOUND' || code === 'MODULE_NOT_FOUND' || /Cannot find package|Cannot find module/u.test(text)) {
+        return STAGE_FAILURE_CLASS.dependency;
+    }
+    if (code === 'ENOENT') {
+        return STAGE_FAILURE_CLASS.entrypoint;
+    }
+    if (/\b(401|403)\b|authentication|credentials|unauthorized|permission denied|Bad credentials/iu.test(text)) {
+        return STAGE_FAILURE_CLASS.authentication;
+    }
+
+    return STAGE_FAILURE_CLASS.unrecognized
+}
+
+/**
+ * @summary The one-line lead for a stage failure, stating the OBSERVED class rather than a cause
+ * the annotation cannot know.
+ *
+ * The declared scope is still reported by the caller as context — it is genuinely useful — but it
+ * no longer leads, because in an operator-visible log tail the lead is the only line read.
+ *
+ * @param {Error} error The child process failure.
+ * @returns {String}
+ */
+export function describeStageFailure(error) {
+    switch (classifyStageFailure(error)) {
+        case STAGE_FAILURE_CLASS.dependency:
+            return 'failed to LOAD: a package it imports is not installed in this environment. ' +
+                'This is a packaging/import-graph failure, NOT an authentication one — no credential change fixes it.';
+        case STAGE_FAILURE_CLASS.entrypoint:
+            return 'could not start: its entrypoint or working directory is missing.';
+        case STAGE_FAILURE_CLASS.authentication:
+            return 'failed with an AUTHENTICATION-shaped error. A stage must be granted a scope ' +
+                'that permits the call — never an ambient credential.';
+        default:
+            return 'failed with an UNRECOGNIZED error class; the cause is not established below.';
+    }
+}
+
+/**
  * @summary Executes one git argv sequence through the injected process boundary.
  * @param {Function} execute Child-process executor.
  * @param {String}   cwd Repository root.
@@ -540,13 +603,20 @@ export async function emitGeneratedData({
             // That misreading has already cost several scheduled runs, because a child's own
             // missing-auth message can advise an interactive login that CI cannot perform.
             //
+            // But the annotation knows the SCOPE, not the CAUSE — and prepending it unconditionally
+            // produced the mirror-image defect. Twenty consecutive runs failed on
+            // `ERR_MODULE_NOT_FOUND: Cannot find package 'chromadb'` while the operator-visible last
+            // line said "failed under declared credential scope `reader`", sending diagnosis toward
+            // auth. The `If this is an authentication failure` hedge is only readable by someone who
+            // already has the answer: in a log tail the annotation is last and the real error has
+            // scrolled away. So classify FIRST and let the observed class lead.
+            //
             // Deliberately NOT a per-stage `requiresCredential` flag: that would be a second
             // hand-maintained declaration beside `tokenScope`, free to drift from it, with nothing
-            // deriving either from what the stage actually does. Annotating the failure is derived
-            // from observed behaviour and cannot disagree with itself.
-            error.message = `[DataSync] stage "${label}" failed under declared credential scope ` +
-                `\`${tokenScope}\`. If this is an authentication failure, the stage requires a scope ` +
-                `that grants it — never an ambient credential.\n${error.message}`;
+            // deriving either from what the stage actually does. The classification below is derived
+            // from the observed error and keeps that same property.
+            error.message = `[DataSync] stage "${label}" ${describeStageFailure(error)} ` +
+                `Declared credential scope: \`${tokenScope}\`.\n${error.message}`;
 
             if (publishGeneratedProgressOnFailure) {
                 deferredError = error;

--- a/buildScripts/dataSyncPipeline.mjs
+++ b/buildScripts/dataSyncPipeline.mjs
@@ -296,6 +296,24 @@ export const STAGE_FAILURE_CLASS = Object.freeze({
 });
 
 /**
+ * @summary Auth-failure evidence inside a child process's combined output.
+ *
+ * The numeric codes carry an HTTP-ish context requirement. A bare `\b(401|403)\b` also matches the
+ * LINE NUMBER of a stack frame — `at run (/repo/buildScripts/dataSyncPipeline.mjs:401:9)` — because
+ * `:` is a non-word character on both sides. stderr folds into `error.message` at the spawn site, so
+ * a stack trace is the ORDINARY content of this string rather than an edge case, and the misread would
+ * land on the one class this classifier exists to stop over-claiming. Found in review by
+ * @neo-opus-vega.
+ *
+ * The word forms carry the observed GitHub and git failures — `Bad credentials` from the API and
+ * `permission denied` from a push. Anything outside both sets stays `unrecognized`, which remains the
+ * honest verdict: a wrong lead costs more than an absent one.
+ * @type {RegExp}
+ */
+const AUTH_FAILURE_PATTERN =
+    /\bHTTP\/?\d(?:\.\d)?\s+(?:401|403)\b|\bstatus(?:\s+code)?\s*[:=]?\s*(?:401|403)\b|\b(?:401|403)\s+(?:Unauthorized|Forbidden)\b|authentication|credentials|unauthorized|permission denied|Bad credentials/iu;
+
+/**
  * @summary Classifies a failed stage's error from what it actually reports — never from the
  * stage's declared scope, which says what the stage was ENTITLED to and nothing about why it died.
  *
@@ -316,7 +334,7 @@ export function classifyStageFailure(error) {
     if (code === 'ENOENT') {
         return STAGE_FAILURE_CLASS.entrypoint;
     }
-    if (/\b(401|403)\b|authentication|credentials|unauthorized|permission denied|Bad credentials/iu.test(text)) {
+    if (AUTH_FAILURE_PATTERN.test(text)) {
         return STAGE_FAILURE_CLASS.authentication;
     }
 

--- a/test/playwright/unit/ai/buildScripts/DataSyncPipeline.spec.mjs
+++ b/test/playwright/unit/ai/buildScripts/DataSyncPipeline.spec.mjs
@@ -8,6 +8,8 @@ import process        from 'node:process';
 import {CREDENTIAL_FAMILIES} from '../../../../../ai/services/fleet/redactCredentials.mjs';
 
 import {
+    classifyStageFailure,
+    describeStageFailure,
     emitGeneratedData,
     executeCommand,
     GENERATED_DATA_PATHS,
@@ -15,7 +17,8 @@ import {
     gitAuthenticated,
     rawCredentialNames,
     runDataSyncPipeline,
-    scopedStageEnv
+    scopedStageEnv,
+    STAGE_FAILURE_CLASS
 } from '../../../../../buildScripts/dataSyncPipeline.mjs';
 
 const generatedFile = 'apps/devindex/resources/data/users.jsonl';
@@ -585,10 +588,54 @@ test.describe('tokenScope validation fails closed', () => {
             execute  : async () => { throw failure },
             log      : () => {},
             preflight: async () => {}
-        })).rejects.toThrow(/stage "install dependencies" failed under declared credential scope `none`/);
+        })).rejects.toThrow(/stage "install dependencies"[\s\S]*Declared credential scope: `none`/);
 
         // the child's own message is preserved, not replaced -- the annotation prefixes context
-        expect(failure.message).toContain('child exited with code 1')
+        expect(failure.message).toContain('child exited with code 1');
+
+        // ...and a generic child error is reported as UNRECOGNIZED rather than as a credential
+        // cause. The scope is context; it was never evidence about why the child died.
+        expect(failure.message).toContain('UNRECOGNIZED')
+    });
+
+    test('the failure lead states the OBSERVED class, never a cause the scope cannot establish', () => {
+        // Twenty consecutive Data Sync runs died on `Cannot find package 'chromadb'` while the
+        // operator-visible last line read "failed under declared credential scope `reader`". The
+        // annotation knows what the stage was ENTITLED to, not why it died, and led with the latter.
+        const dependency = Object.assign(new Error(
+                  "Cannot find package 'chromadb' imported from ai/services/knowledge-base/ChromaManager.mjs"
+              ), {code: 'ERR_MODULE_NOT_FOUND'}),
+              entrypoint = Object.assign(new Error('spawn node ENOENT'), {code: 'ENOENT'}),
+              auth       = new Error('HttpError: Bad credentials (401)'),
+              generic    = new Error('child exited with code 1');
+
+        expect(classifyStageFailure(dependency)).toBe(STAGE_FAILURE_CLASS.dependency);
+        expect(classifyStageFailure(entrypoint)).toBe(STAGE_FAILURE_CLASS.entrypoint);
+        expect(classifyStageFailure(auth)).toBe(STAGE_FAILURE_CLASS.authentication);
+        expect(classifyStageFailure(generic)).toBe(STAGE_FAILURE_CLASS.unrecognized);
+
+        // The regression witness: a packaging failure must say so, and must NOT read as auth.
+        expect(describeStageFailure(dependency)).toContain('NOT an authentication one');
+        expect(describeStageFailure(dependency)).toMatch(/packaging|not installed/);
+
+        // The case the annotation was originally built for must not regress.
+        expect(describeStageFailure(auth)).toContain('AUTHENTICATION');
+        expect(describeStageFailure(auth)).toContain('never an ambient credential');
+
+        // An unknown class states that it is unknown rather than asserting any cause.
+        expect(describeStageFailure(generic)).toContain('UNRECOGNIZED');
+        expect(describeStageFailure(generic)).not.toMatch(/AUTHENTICATION|packaging/)
+    });
+
+    test('module resolution is classified before the auth heuristic — a stack trace can contain "permission"', () => {
+        // Order guard: an auth-shaped substring inside an unrelated trace must not outrank an
+        // unambiguous ERR_MODULE_NOT_FOUND.
+        const mixed = Object.assign(
+            new Error("Cannot find package 'chromadb'\n    at checkPermission (/app/permission denied.mjs:1:1)"),
+            {code: 'ERR_MODULE_NOT_FOUND'}
+        );
+
+        expect(classifyStageFailure(mixed)).toBe(STAGE_FAILURE_CLASS.dependency)
     });
 });
 

--- a/test/playwright/unit/ai/buildScripts/DataSyncPipeline.spec.mjs
+++ b/test/playwright/unit/ai/buildScripts/DataSyncPipeline.spec.mjs
@@ -637,6 +637,36 @@ test.describe('tokenScope validation fails closed', () => {
 
         expect(classifyStageFailure(mixed)).toBe(STAGE_FAILURE_CLASS.dependency)
     });
+
+    test('a stack-frame LINE NUMBER of 401 or 403 is not an auth failure', () => {
+        // stderr folds into `error.message` at the spawn site, so a stack trace is the ordinary
+        // content of the classified string. A bare `\b(401|403)\b` matches `:401:` — `:` is a
+        // non-word character on both sides — so an unrelated crash deep in a long file would have
+        // led with AUTHENTICATION, which is the exact over-claim this classifier exists to end.
+        // Found in review by @neo-opus-vega.
+        const lineNumbered = new Error(
+            'TypeError: Cannot read properties of undefined (reading \'push\')\n' +
+            '    at emitCorpus (/repo/buildScripts/dataSyncPipeline.mjs:401:9)\n' +
+            '    at async run (/repo/buildScripts/dataSyncPipeline.mjs:403:5)'
+        );
+
+        expect(classifyStageFailure(lineNumbered)).toBe(STAGE_FAILURE_CLASS.unrecognized);
+        expect(describeStageFailure(lineNumbered)).not.toContain('AUTHENTICATION')
+    });
+
+    test('a 401 or 403 in HTTP context IS still auth — the narrowing did not delete the capability', () => {
+        // Positive control for the test above. Without it, deleting the numeric half entirely would
+        // pass the line-number witness while silently dropping every code-only auth failure.
+        const codes = [
+            new Error('request failed: HTTP/1.1 401'),
+            new Error('github api responded with status: 403'),
+            new Error('remote returned 403 Forbidden')
+        ];
+
+        for (const error of codes) {
+            expect(classifyStageFailure(error), error.message).toBe(STAGE_FAILURE_CLASS.authentication)
+        }
+    });
 });
 
 /**


### PR DESCRIPTION
Resolves #16530

> **This PR does not fix the Data Sync breach.** The 20 consecutive failures are caused by `chromadb`, and **PR #16496 is that fix** — green, MERGEABLE, waiting on a cross-family seat. This PR fixes the *message that misdirected the diagnosis*.

## The defect

Run [30971652217](https://github.com/neomjs/neo/actions/runs/30971652217), operator-visible last line:

```
[DataSync] stage "GitHub Workflow corpus" failed under declared credential scope `reader`.
If this is an authentication failure, the stage requires a scope that grants it — never an
ambient credential.
```

The actual error, **550 log lines earlier**:

```
Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'chromadb'
  imported from ai/services/knowledge-base/ChromaManager.mjs
```

Not authentication. Not credential scope. **Packaging.**

`buildScripts/dataSyncPipeline.mjs:547` prepended the credential framing to *every* stage failure, unconditionally — before knowing anything about the failure's class.

The original reasoning is sound and is preserved in-source: a bare child failure reads as *"the tool is broken"* when the finding is *"this stage was granted `none` and needs a credential"*, and a child's own missing-auth message can advise an interactive login CI cannot perform. But the annotation knows the **scope**, not the **cause**, and stating one as the other produced the mirror-image defect.

The `If this is an authentication failure` hedge is technically honest and operationally useless: **it is only readable by someone who already has the answer.** In a log tail the annotation is last and the true error has scrolled away.

## Deltas

| File | Delta |
|---|---|
| `buildScripts/dataSyncPipeline.mjs` | `STAGE_FAILURE_CLASS` + `classifyStageFailure` + `describeStageFailure`; the lead now states the observed class, scope reported as context |
| `test/playwright/unit/ai/buildScripts/DataSyncPipeline.spec.mjs` | landed spec updated to its stated intent; three new witnesses |

```
ERR_MODULE_NOT_FOUND / MODULE_NOT_FOUND  -> dependency
ENOENT                                    -> entrypoint
401 / 403 / credentials / unauthorized    -> authentication
anything else                             -> unrecognized, stated AS unrecognized
```

**Order is load-bearing.** Module resolution is checked *before* the auth heuristic, because an auth-shaped substring (`permission`) can appear inside an unrelated stack trace while `ERR_MODULE_NOT_FOUND` is unambiguous. That has its own witness.

The declared scope still appears in **every** case — it is real context. It simply no longer leads with a hypothesis it cannot support.

**Deliberately still not a per-stage `requiresCredential` flag.** That was rejected in the original design for a good reason — a second hand-maintained declaration beside `tokenScope`, free to drift from it. Classification derived from the observed error keeps exactly that property.

## Test Evidence

Evidence: `35 passed` at exact head in `DataSyncPipeline.spec.mjs`.

**RED proven.** Restoring the unconditional credential framing fails the dependency witness on the exact misleading string:

```
Expected substring: "NOT an authentication one"
Received string:    "failed under declared credential scope. If this is an authentication
                     failure, the stage requires a scope that grants it — never an ambient
                     credential."
> 618 |  expect(describeStageFailure(dependency)).toContain('NOT an authentication one');
  1 failed
```

Restored: `35 passed`.

**I updated a landed spec rather than deleting it, and that deserves scrutiny.** Its assertion was `/stage "install dependencies" failed under declared credential scope `none`/`. Its stated intent, in its own comment, was:

> *"The annotation must therefore carry BOTH the stage label and its declared scope — asserting only that the original error survives would pass without the annotation."*

That intent **still holds** and is still asserted; only the regex had hardened around the old sentence. It now additionally asserts that a generic child error is reported as `UNRECOGNIZED` rather than as a credential cause — a stronger claim than before. The authentication case keeps its original guidance verbatim, so the failure mode the annotation was built for does not regress.

## Contract Ledger Matrix

| Target Surface | Source of Authority | Proposed Behavior | Fallback | Docs | Evidence |
|---|---|---|---|---|---|
| `emitStages` failure message | this PR | leads with observed class; scope stated as context | unrecognized ⇒ says so, asserts no cause | in-source | class witnesses |
| `classifyStageFailure` / `describeStageFailure` / `STAGE_FAILURE_CLASS` (new exports) | this PR | pure, no I/O | — | JSDoc | direct unit coverage |
| `tokenScope` | **unchanged** | still the only scope authority | — | — | no new flag |
| deferral / exit-code behaviour | **unchanged** | `publishGeneratedProgressOnFailure` untouched | — | — | landed pipeline specs green |

## Decision Record impact

`none`. Message construction inside one build script.

## Out of scope

- **The `chromadb` failure** — `#16495` / **PR #16496**. That is the breach fix.
- **The `[skip ci]` ↔ ruleset interaction.** Ruleset `19087298` ("code scanning merge protection") targets `~DEFAULT_BRANCH` with `code_scanning` + `required_status_checks` and `bypass_actors: []`. Hourly corpus commits carry `[skip ci]`, so those checks never run and can never report — hence a "Bypassed rule violations" record on every push. That is repo security configuration and operator-owned; not touched here.

## Post-Merge Validation

- The next genuine stage failure names its class in the last line. If a future failure reads `UNRECOGNIZED`, that is the classifier honestly declining — add the class rather than widening an existing branch to swallow it.
- Watch that `authentication` does not become a catch-all. It is last among the recognized classes by construction; if it starts matching often, the heuristic is too loose.

Authored by Ada (Opus 5, Claude Code). Session eeacb603-97f1-4241-9b2f-3a542cab6d2c.
