### PR TITLE
fix(main): batch the moveBefore layout heal, and never run it mid-transition (#16533)

### DIFF
--- a/src/main/DeltaUpdates.mjs
+++ b/src/main/DeltaUpdates.mjs
@@ -668,6 +668,9 @@ class DeltaUpdates extends Base {
      * for a 590-item reorder against 18ms without it. Deferring is safe because no paint happens
      * between deltas inside one `update()` task, so every intermediate box tree was already invisible.
      *
+     * Skipped entirely for a parent whose subtree is mid-transition, because `display: none` cancels
+     * running transitions rather than pausing them — see the gate's own reasoning below.
+     *
      * The toggle zeroes the parent's own scroll position and can drop focus, so both are captured
      * immediately before it and restored after. Boundary, unchanged from the per-move form: scrolled
      * DESCENDANTS inside the parent also reset and are not walked here, since that would reintroduce a
@@ -691,6 +694,20 @@ class DeltaUpdates extends Base {
                 containsFocus           = activeElement && parentNode.contains(activeElement),
                 displayValue            = parentNode.style.display,
                 {scrollLeft, scrollTop} = parentNode;
+
+            // Setting `display: none` CANCELS every running CSS transition and animation in the subtree
+            // — an element with no box has no running transitions to resume. So a parent whose children
+            // are mid-flight cannot be healed this way without destroying the motion outright, which is
+            // exactly what it did: a sorted 590-item helix reordered and snapped instead of animating.
+            //
+            // The two harms are not symmetric. The cancellation is certain and plainly visible; the
+            // staleness this heals is a Chromium sibling-chain artifact that has never been reported
+            // under animation, and a subtree that is animating is being repainted every frame anyway.
+            // Skipping while animating therefore trades a guaranteed regression for a hypothetical one.
+            //
+            // It also costs the grid case nothing, which is where the heal came from: a column drag
+            // reorders siblings that carry no transitions, so this gate never fires there.
+            if (parentNode.getAnimations?.({subtree: true}).length > 0) return;
 
             parentNode.style.display = 'none';
             void parentNode.offsetHeight;

--- a/src/main/DeltaUpdates.mjs
+++ b/src/main/DeltaUpdates.mjs
@@ -85,6 +85,19 @@ class DeltaUpdates extends Base {
     nativeMoveBefore = null
 
     /**
+     * Parents that received a `moveBefore()` during the current delta batch and still need their box
+     * tree rebuilt once, collected by {@link #moveNode} and drained by {@link #flushLayoutHeals}.
+     *
+     * The rebuild is deferred rather than run per move because its cost scales with the parent's child
+     * count: doing it inside the loop makes reordering N siblings O(N²). Measured on a 590-item helix
+     * sort, the per-move form cost 8137ms of blocked main thread against 18ms for the same reorder
+     * without it.
+     * @member {Set|null} pendingLayoutHeals=null
+     * @protected
+     */
+    pendingLayoutHeals = null
+
+    /**
      * @param {Object} config
      */
     construct(config) {
@@ -614,32 +627,14 @@ class DeltaUpdates extends Base {
                     // Chromium (observed in 146 & 149) can leave the parent's box-tree sibling chain
                     // stale after moveBefore(): the DOM order updates, but one neighbor keeps
                     // rendering at its pre-move slot — and structural child-list changes do NOT
-                    // re-dirty it. Rebuilding the parent's boxes synchronously (no paint happens
-                    // in between) restores the layout while keeping what moveBefore preserves:
-                    // iframes and canvas survive display toggles (unlike the insertBefore fallback,
-                    // which reloads iframes); only CSS-animation continuity inside the parent resets.
-                    // The toggle also zeroes the parent's own scroll state, so it gets captured and
-                    // restored alongside focus. Boundary: scrolled DESCENDANTS inside the parent
-                    // reset too and are not walked here (subtree-scan cost on every move) — tracked
-                    // with the heal-gating follow-up.
-                    const
-                        activeElement = document.activeElement,
-                        containsFocus = activeElement && parentNode.contains(activeElement),
-                        displayValue  = parentNode.style.display,
-                        {scrollLeft, scrollTop} = parentNode;
-
-                    parentNode.style.display = 'none';
-                    void parentNode.offsetHeight;
-                    parentNode.style.display = displayValue;
-
-                    if (scrollLeft || scrollTop) {
-                        parentNode.scrollLeft = scrollLeft;
-                        parentNode.scrollTop  = scrollTop
-                    }
-
-                    if (containsFocus && document.activeElement !== activeElement) {
-                        activeElement.focus()
-                    }
+                    // re-dirty it. The parent's boxes therefore need one rebuild, which
+                    // flushLayoutHeals() performs at the end of the batch.
+                    //
+                    // Deferred rather than done here: the rebuild costs O(parent's children), so
+                    // running it per move makes an N-sibling reorder O(N²). Batching is sound because
+                    // no paint occurs between deltas within a single update() task, making the
+                    // intermediate rebuilds unobservable — only the final box tree is ever displayed.
+                    (this.pendingLayoutHeals ||= new Set()).add(parentNode)
                 } else {
                     const
                         activeElement = document.activeElement,
@@ -658,6 +653,58 @@ class DeltaUpdates extends Base {
                 }
             }
         }
+    }
+
+    /**
+     * @summary Rebuilds the box tree of every parent that received a `moveBefore()` in this batch.
+     *
+     * `moveBefore()` can leave a parent's box-tree sibling chain stale in Chromium, and a structural
+     * child-list change does not re-dirty it. Toggling `display` forces the rebuild while keeping what
+     * `moveBefore` preserves — iframes and canvas survive it, unlike the `insertBefore` fallback which
+     * reloads iframes; only CSS-animation continuity inside the parent resets.
+     *
+     * Runs once per parent per batch rather than once per move. The toggle's cost scales with the
+     * parent's child count, so the per-move form made an N-sibling reorder O(N²) — measurably 8137ms
+     * for a 590-item reorder against 18ms without it. Deferring is safe because no paint happens
+     * between deltas inside one `update()` task, so every intermediate box tree was already invisible.
+     *
+     * The toggle zeroes the parent's own scroll position and can drop focus, so both are captured
+     * immediately before it and restored after. Boundary, unchanged from the per-move form: scrolled
+     * DESCENDANTS inside the parent also reset and are not walked here, since that would reintroduce a
+     * subtree scan.
+     * @protected
+     */
+    flushLayoutHeals() {
+        const parents = this.pendingLayoutHeals;
+
+        if (!parents) return;
+
+        // Cleared first: a throw inside the loop must not strand this batch's parents into the next one.
+        this.pendingLayoutHeals = null;
+
+        parents.forEach(parentNode => {
+            // A parent moved into and out of the document within the same batch has no boxes to heal.
+            if (!parentNode.isConnected) return;
+
+            const
+                activeElement           = document.activeElement,
+                containsFocus           = activeElement && parentNode.contains(activeElement),
+                displayValue            = parentNode.style.display,
+                {scrollLeft, scrollTop} = parentNode;
+
+            parentNode.style.display = 'none';
+            void parentNode.offsetHeight;
+            parentNode.style.display = displayValue;
+
+            if (scrollLeft || scrollTop) {
+                parentNode.scrollLeft = scrollLeft;
+                parentNode.scrollTop  = scrollTop
+            }
+
+            if (containsFocus && document.activeElement !== activeElement) {
+                activeElement.focus()
+            }
+        })
     }
 
     /**
@@ -951,8 +998,8 @@ class DeltaUpdates extends Base {
     validateDeltaGrammarBatch(deltas) {
         const
             {checkStructuralUniqueness, validateBatch} = this.deltaGrammar,
-            validation = validateBatch(deltas, {useDomApiRenderer: NeoConfig.useDomApiRenderer}),
-            context    = {
+            validation                                 = validateBatch(deltas, {useDomApiRenderer: NeoConfig.useDomApiRenderer}),
+            context                                    = {
                 deltas,
                 useDomApiRenderer: NeoConfig.useDomApiRenderer
             };
@@ -1041,41 +1088,48 @@ class DeltaUpdates extends Base {
             me.countDeltasPer250ms += len
         }
 
-        while (i < len) {
-            const delta = deltas[i];
+        try {
+            while (i < len) {
+                const delta = deltas[i];
 
-            // Batching optimization for sequential insertNode operations
-            if (delta.action === 'insertNode' && i < len - 1) {
-                let j     = i + 1,
-                    batch = [delta];
+                // Batching optimization for sequential insertNode operations
+                if (delta.action === 'insertNode' && i < len - 1) {
+                    let j     = i + 1,
+                        batch = [delta];
 
-                while (j < len) {
-                    const
-                        nextDelta = deltas[j],
-                        prevDelta = deltas[j - 1];
+                    while (j < len) {
+                        const
+                            nextDelta = deltas[j],
+                            prevDelta = deltas[j - 1];
 
-                    if (
-                        nextDelta.action === 'insertNode' &&
-                        nextDelta.parentId === delta.parentId &&
-                        nextDelta.index === prevDelta.index + 1 // Ensure sequential indices
-                    ) {
-                        batch.push(nextDelta);
-                        j++
-                    } else {
-                        break
+                        if (
+                            nextDelta.action === 'insertNode' &&
+                            nextDelta.parentId === delta.parentId &&
+                            nextDelta.index === prevDelta.index + 1 // Ensure sequential indices
+                        ) {
+                            batch.push(nextDelta);
+                            j++
+                        } else {
+                            break
+                        }
+                    }
+
+                    if (batch.length > 1) {
+                        me.insertNodeBatch(batch);
+                        i = j; // Skip the processed batch
+                        continue
                     }
                 }
 
-                if (batch.length > 1) {
-                    me.insertNodeBatch(batch);
-                    i = j; // Skip the processed batch
-                    continue
-                }
+                // Fallback for non-batched operations
+                me[delta.action || 'updateNode'](delta);
+                i++
             }
-
-            // Fallback for non-batched operations
-            me[delta.action || 'updateNode'](delta);
-            i++
+        } finally {
+            // In `finally` deliberately: a delta that throws mid-batch would otherwise leave an
+            // already-moved parent rendering from a stale sibling chain until some unrelated later
+            // batch happened to heal it. The moves that did land still need their one rebuild.
+            me.flushLayoutHeals()
         }
 
         // The ledger mirrors what reached the DOM: commit only after the batch applied.


### PR DESCRIPTION
## Summary

Two coupled defects in `moveNode`'s post-`moveBefore()` layout heal, which does `display:none` → read `offsetHeight` → restore.

1. **It ran per move.** The rebuild costs O(parent's children), so reordering N siblings was O(N²).
2. **`display:none` cancels every running CSS transition in the subtree.** An element with no box has no transition to resume, so any parent whose children were animating had the motion destroyed.

Now it runs **once per parent per `update()` batch**, and is **skipped entirely while that subtree is mid-transition**.

Resolves #16533

## Why batching is sound

No paint occurs between deltas inside a single `update()` task, so every intermediate box tree was already invisible. Only the final one is ever displayed — and that final state is what `#12894` needed correct. Flushed from a `finally` block, so a delta throwing mid-batch cannot leave an already-moved parent rendering from a stale sibling chain until some unrelated later batch heals it.

## Deltas

- `src/main/DeltaUpdates.mjs` — `moveNode` collects parents into `pendingLayoutHeals`; new `flushLayoutHeals()` drains them once per batch and skips any parent with running animations in its subtree; `update()`'s delta loop wrapped in `try/finally`. Focus and scroll capture/restore move with the toggle, unchanged in behaviour.

## Why skipping under animation is the right trade

The two harms are not symmetric. The cancellation is **certain and plainly visible** — motion is destroyed outright. The staleness the heal repairs is a Chromium sibling-chain artifact that has never been reported under animation, and an animating subtree is being repainted every frame regardless. Skipping while animating trades a guaranteed regression for a hypothetical one.

It costs the originating case nothing: `#12894` healed a **grid column drag**, whose siblings carry no transitions, so the gate never fires there — confirmed by the grid suites below staying green.

`getAnimations({subtree: true})` measured at **0–0.2ms** against a 590-child parent, and runs once per parent per batch rather than per move.

## Test Evidence

Measured on `examples/component/helix`, 600 items, toggling only `nativeMoveBefore` — before the fix:

| path | `moveNode` total | long tasks |
|---|---|---|
| per-move heal | **8137ms** | one, 8133ms |
| `insertBefore` fallback (no heal) | **18ms** | none |

`updateNode` in the same run: **7ms across 1182 calls**. That is why mouse-wheel rotation (~70k deltas/sec, transform updates only) was never affected — it moves no nodes, so the VDom engine and delta throughput were never implicated.

After the fix, same sort: transforms applied at **92ms**, **no long task over 50ms**, and the helix transition class outlives the transform application by **1134ms** where it previously trailed it by **−13ms** — the −13ms being what cancelled the reported animation.

Evidence: `PerformanceObserver({entryTypes:['longtask']})` plus `MutationObserver` on the helix `class` and an item's `style`, comparing computed `transitionDuration` at each mutation.

Suites: **156** vdom unit specs. Grid e2e — `ColumnCrossBodyDnD`, `LockedDnDDuplication` (cross-region re-homes, the `#12883` neighbourhood this heal was introduced for), `LockedCellHorizontalStability`, `ColumnOverdragScroll`, `RowPinning` — all green.

## Post-Merge Validation

1. Sort 600 helix items: no multi-second freeze, items animate to their new positions.
2. Grid column drag to the locked-end region still re-homes correctly (`#12883`).
3. Any large list/tree reorder — by construction this path is shared, though it was measured only on the helix.

**Stated bound — the visual result is NOT verified by me.** My harness reports `document.hidden: true` even when the tab is fronted, and a background tab neither composites nor runs transitions. So the animation gate literally cannot be exercised there: `getAnimations()` returns empty because nothing is animating. Every number above is JS-execution timing, which is blind to compositing cost.

What is established: the O(N²) blocking is gone (measured), the grid cases stay green (measured), and the operator confirmed on a visible tab that removing the heal entirely makes sorting *"a LOT better"* — this change is that override made conditional rather than global.

What is outstanding: confirmation on a visible tab that repeated sorts now animate smoothly. The earlier version of this PR claimed the animation was restored on the strength of hidden-tab metrics; that claim was wrong and the operator's manual test caught it. Treat the visual check as required, not ceremonial.

## Known adjacent defect, not fixed here

Every helix sort reorders the DOM **twice**: `Helix.sortItems` hand-writes 590 `moveNode` deltas straight to `applyDeltas`, and the vdom differ — which never saw them — then emits ~586 of its own, measured as three batches (`{moveNode:590}` → `{moveNode:586, updateNode:590}` → `{updateNode:590}`). That redundancy lives in `Helix.sortItems`, not in this file, and is left to #16533's follow-up.

## Review notes

1. **Is once-per-batch enough for every `moveBefore` staleness case?** The argument rests on no paint occurring mid-task. If a consumer reads layout between deltas in the same batch it would observe a stale box tree; I found no such reader (`moveNode`'s own index lookups are DOM-order, not layout), but that is the assumption to attack.
2. **`#12894`'s heal was for a stale *flex* sibling chain**, yet it applies to every parent including 3D-transformed and non-flex containers. This PR does not narrow that — batching alone fixes the cost. Gating remains open on #16533 if someone wants it scoped.

Authored by @neo-opus-grace (Claude Opus 5)
