### PR TITLE
refactor(ai): remove the checkout-relative graph-path resolver (#16544)

### DIFF
--- a/ai/mcp/server/memory-core/helpers/TurnPresenceConfig.mjs
+++ b/ai/mcp/server/memory-core/helpers/TurnPresenceConfig.mjs
@@ -1,5 +1,3 @@
-import path from 'node:path';
-
 export const MEMORY_CORE_GRAPH_DB_ENV = 'NEO_MEMORY_DB_PATH';
 
 export const TURN_PRESENCE_ENV = Object.freeze({
@@ -15,18 +13,6 @@ export const TURN_PRESENCE_DEFAULTS = Object.freeze({
     noteMaxChars      : 512,
     hookWriteTimeoutMs: 1500
 });
-
-/**
- * @summary Resolves the Memory Core graph SQLite path without importing Neo singletons.
- * @param {Object} options
- * @param {Object} [options.env=process.env] Environment source.
- * @param {String} options.rootDir Repository root.
- * @returns {String}
- */
-export function resolveMemoryCoreGraphPath({env = process.env, rootDir} = {}) {
-    const override = env[MEMORY_CORE_GRAPH_DB_ENV];
-    return override ? override : path.resolve(rootDir, '.neo-ai-data/sqlite/memory-core-graph.sqlite');
-}
 
 function resolveNumber({env, key, fallback}) {
     const envName = TURN_PRESENCE_ENV[key],


### PR DESCRIPTION
## Summary

`resolveMemoryCoreGraphPath` lost its only caller when PR #16527 routed the turn-presence hook over MCP. Removing it, plus the `node:path` import it stranded.

Resolves #16544

**14 deletions, one file.** Split from `#16543` so it can land now — that ticket keeps the substantive finding (a network exchange budgeted with a timeout sized for a local file write), which was deliberately re-scoped out of PRIO-0 because it can only fire where a harness hook runs.

## Why a dead export matters more than usual here

This function **is** the pattern `#16513` was filed to remove:

```js
path.resolve(rootDir, '.neo-ai-data/sqlite/memory-core-graph.sqlite')
```

…where `rootDir` came from the caller's own module location. That produced **7192 turn-presence intervals from 9 distinct agents** written into maintainer checkouts no reader ever queried — invisible because a writable SQLite file accepts writes happily and reports success.

Leaving it exported leaves a working, importable, apparently-sanctioned helper for exactly the mistake we just spent a ticket removing. The next author wanting a graph path finds it, and it does what its name says.

## Deltas

- `ai/mcp/server/memory-core/helpers/TurnPresenceConfig.mjs` — removed `resolveMemoryCoreGraphPath` and the now-unused `import path from 'node:path'`.

**Deliberately kept:** `MEMORY_CORE_GRAPH_DB_ENV`. It is separately consumed by `ai/mcp/server/memory-core/configBase.mjs:229` for the `graphProd` leaf, so removing it would break a live consumer. `TURN_PRESENCE_ENV`, `TURN_PRESENCE_DEFAULTS` and `resolveTurnPresenceRuntimeConfig` are untouched — the hook still reads its runtime values through the last of those.

## Test Evidence

Orphan status established by **walking every `.mjs`/`.json`/`.md`/`.yaml` blob on merged `dev`** rather than grepping a worktree — my first attempt grepped my own branch, which was cut from *pre-merge* `dev` and therefore still contained the replaced caller, reporting the exact opposite of the truth.

Evidence: all four ACs verified mechanically after the change —

| AC | result |
|---|---|
| zero references tree-wide | `grep -rn` across `ai/ src/ test/ buildScripts/ .claude/ .codex/ .kimi-code/` → **0** |
| `MEMORY_CORE_GRAPH_DB_ENV` consumer intact | `configBase.mjs:7` import + `:229` `graphProd` leaf still resolve |
| `resolveTurnPresenceRuntimeConfig` unchanged | still exported |
| no stranded `path.` usage | none remain in the file |

Suites: **272 passed** — the full `test/playwright/unit/hooks/` tree plus `TurnPresenceService.spec.mjs`.

## Post-Merge Validation

1. Turn-presence hooks still emit on a plane-configured seat — the removal touches no runtime path, but it is the file the hook reads its timeout from.
2. Memory Core still resolves `graphProd` from `NEO_MEMORY_DB_PATH`, which is the one consumer of the retained constant.

## Review notes

The only judgment call worth checking: **is keeping `MEMORY_CORE_GRAPH_DB_ENV` right, or should the env var have gone with the function?** I kept it because `configBase.mjs` consumes it independently for the server's own graph path — which is a legitimate use, since server-side code resolving its own store is not the checkout-relative defect. If you think that consumer should own the constant instead of importing it from a turn-presence helper, that is a fair structural objection and worth raising.

Authored by @neo-opus-grace (Claude Opus 5)
