### PR TITLE
fix(kb): the tenant mirror stops cloning blobs the ingestion never reads (#16546)

### DIFF
--- a/ai/services/knowledge-base/helpers/gitMirror.mjs
+++ b/ai/services/knowledge-base/helpers/gitMirror.mjs
@@ -9,6 +9,7 @@ import {
     assertCleanCloneUrl,
     classifyTenantRepoAccessFailure,
     deriveTenantRepoMirrorPath,
+    isTransportCloneUrl,
     normalizeTenantRepoCredentialRef,
     redactTenantRepoSecrets,
     TenantRepoAccessCode,
@@ -945,9 +946,14 @@ export async function cloneIfMissing({mirrorRoot, tenantId, repoSlug, cloneUrl, 
     // Scoped to transport clones on purpose. `git clone --filter` over a bare local PATH is ignored by
     // git's own design ("--filter is ignored in local clones; use file:// instead"), and a local clone
     // hardlinks its object store rather than copying it — so there is no history to save and nothing
-    // to assert. The 4.9 GB this exists to prevent is a network clone. Enforcing here would fail every
-    // path-based caller for a condition git guarantees.
-    if (/^[a-z][a-z0-9+.-]*:\/\//iu.test(cleanCloneUrl)) {
+    // to assert. The 4.9 GB this exists to prevent is a network clone.
+    //
+    // The question is TRANSPORT-ness, not scheme. An earlier cut tested for `://`, which silently
+    // skipped `git@host:org/repo.git` — a documented tenant `cloneUrl` shape — so the one URL form
+    // that carries no scheme was also the one form where nothing verified the filter took effect.
+    // Found by @neo-opus-grace. The predicate lives with the rest of the clone-URL grammar rather
+    // than becoming a third inline regex in a third file.
+    if (isTransportCloneUrl(cleanCloneUrl)) {
         await assertBloblessClone(mirrorPath);
     }
 
@@ -984,24 +990,26 @@ async function assertBloblessClone(mirrorPath) {
         return;
     }
 
-    const listed    = await runGit(['ls-tree', '-r', '--object-only', revision], {
-              cwd           : mirrorPath,
-              failureCode   : 'KB_GITMIRROR_CLONE_FAILED',
-              failureMessage: 'GitMirror could not inspect the cloned tree'
-          }),
-          [blobOid] = String(listed.stdout ?? '').split('\n').filter(Boolean);
+    const listed = await runGit(['ls-tree', '-r', '--object-only', revision], {
+        cwd           : mirrorPath,
+        failureCode   : 'KB_GITMIRROR_CLONE_FAILED',
+        failureMessage: 'GitMirror could not inspect the cloned tree'
+    });
+
+    const [blobOid] = String(listed.stdout ?? '').split('\n').filter(Boolean);
 
     // A tree with no blobs at all cannot witness the filter either way.
     if (!blobOid) {
         return;
     }
 
+    // `acceptedExitCodes` includes 1 because exit 1 is the ANSWER here, not a failure: it is how git
+    // reports the object is absent. `GIT_NO_LAZY_FETCH` is what makes the probe honest — without it the
+    // promisor machinery fetches the object being probed and every clone, filtered or not, reports the
+    // blob present. Verified both ways against a fixture remote.
     const probe = await runGit(['cat-file', '-e', blobOid], {
-        // Exit 1 is the ANSWER here, not a failure: it is how git reports the object is absent.
         acceptedExitCodes: [0, 1],
         cwd              : mirrorPath,
-        // Without this the promisor machinery fetches the object being probed and every clone,
-        // filtered or not, reports the blob present. Verified both ways against a fixture remote.
         extraEnv         : {GIT_NO_LAZY_FETCH: '1'},
         failureCode      : 'KB_GITMIRROR_CLONE_FAILED',
         failureMessage   : 'GitMirror could not probe the cloned blob'

--- a/ai/services/knowledge-base/helpers/gitMirror.mjs
+++ b/ai/services/knowledge-base/helpers/gitMirror.mjs
@@ -481,6 +481,10 @@ async function runGit(args, {
     cwd,
     credentialRef,
     credentialMaterial,
+    // Merged over the resolved execution environment. Exists so a probe can disable git behaviour
+    // that would otherwise defeat it — `GIT_NO_LAZY_FETCH=1` is the case that forced it, since a
+    // promisor repo silently fetches the very object a blob-presence check is asking about.
+    extraEnv = {},
     failureCode = 'KB_GITMIRROR_GIT_FAILED',
     failureMessage = 'GitMirror git command failed',
     knownHostsPath,
@@ -502,7 +506,7 @@ async function runGit(args, {
         const result = await new Promise((resolve, reject) => {
             const child = spawn('git', ['-c', 'credential.helper=', ...args], {
                 cwd,
-                env  : execution.env,
+                env  : {...execution.env, ...extraEnv},
                 stdio: ['ignore', 'pipe', 'pipe']
             });
             let stdout = '';
@@ -877,7 +881,34 @@ function getChangedRefs(before, after) {
 }
 
 /**
- * @summary Clones a tenant repository as a persistent bare mirror if absent.
+ * @summary Clones a tenant repository as a persistent BLOBLESS bare mirror if absent.
+ *
+ * ## Why the mirror carries no historical blobs
+ *
+ * The ingestion never reads them. Every git read this module performs needs either the commit graph
+ * or a tree — `for-each-ref`, `rev-parse`, `merge-base --is-ancestor`, `diff --name-status`, and
+ * `ls-tree --name-only` — and the single content read, `show <revision>:<path>`, wants exactly the
+ * blobs of the paths being ingested at the revision being ingested. A plain `--mirror` downloaded
+ * every blob in history to serve that: one repository measured **4.9 GB** on the container plane,
+ * against an orchestrator whose default Node heap ceiling is 1728 MB, and the sync lane died on a
+ * large allocation roughly every 290 seconds. A polling multi-repo deployment pays that per repo.
+ *
+ * `--filter=blob:none` is shaped to that read profile: commits and trees stay complete, so every
+ * ref/graph/diff operation above is untouched, and blobs arrive lazily only when `show` asks for one.
+ *
+ * **NOT `--depth`.** A shallow clone makes the previous revision unreachable, which breaks
+ * `merge-base --is-ancestor` and the base-to-head `diff --name-status` that incremental sync is built
+ * on — trading a disk problem for re-ingesting the whole tree on every cycle.
+ *
+ * **The trade, stated here rather than discovered later:** `show` becomes a potentially NETWORKED
+ * read. The lane is already a network operation behind the same credential so this adds no new
+ * failure domain, but a `show` against an unreachable remote now fails where it previously read from
+ * disk. It fails loudly; it does not return empty content.
+ *
+ * A server without partial-clone support fails the clone as `KB_GITMIRROR_CLONE_FAILED`. That is
+ * deliberate — a silent fall back to a full clone would restore the 4.9 GB invisibly, with every
+ * test still green.
+ *
  * @param {Object} options
  * @returns {Promise<{mirrorPath: String, cloned: Boolean}>}
  */
@@ -901,14 +932,93 @@ export async function cloneIfMissing({mirrorRoot, tenantId, repoSlug, cloneUrl, 
     }
 
     await fs.ensureDir(path.dirname(mirrorPath));
-    await runGit(['clone', '--mirror', cleanCloneUrl, mirrorPath], {
+    // `--filter=blob:none` is recorded into the clone's own config as `remote.origin.promisor` +
+    // `remote.origin.partialclonefilter`, so the existing `fetch --all --prune` inherits it without a
+    // second change. See this function's JSDoc for why blobless and why not `--depth`.
+    await runGit(['clone', '--mirror', '--filter=blob:none', cleanCloneUrl, mirrorPath], {
         credentialRef,
         failureCode   : 'KB_GITMIRROR_CLONE_FAILED',
         failureMessage: 'GitMirror clone failed',
         knownHostsPath: getKnownHostsPath(mirrorRoot)
     });
 
+    // Scoped to transport clones on purpose. `git clone --filter` over a bare local PATH is ignored by
+    // git's own design ("--filter is ignored in local clones; use file:// instead"), and a local clone
+    // hardlinks its object store rather than copying it — so there is no history to save and nothing
+    // to assert. The 4.9 GB this exists to prevent is a network clone. Enforcing here would fail every
+    // path-based caller for a condition git guarantees.
+    if (/^[a-z][a-z0-9+.-]*:\/\//iu.test(cleanCloneUrl)) {
+        await assertBloblessClone(mirrorPath);
+    }
+
     return {mirrorPath, cloned: true};
+}
+
+/**
+ * @summary Fails a clone that recorded the blob filter without applying it.
+ *
+ * **A remote that does not advertise filter support makes git ignore `--filter` and exit 0.** It
+ * warns on stderr and then writes `remote.origin.promisor=true`, `remote.origin.partialclonefilter`,
+ * and a `.promisor` pack marker anyway — so every config-shaped check answers "this is a partial
+ * clone" over a mirror that holds every blob in history. Measured: against a remote without
+ * `uploadpack.allowFilter`, a filtered clone and a full clone of the same repo came out 2072 KB and
+ * 2068 KB with identical object counts, while both carried the promisor config.
+ *
+ * So this asserts the EFFECT, not the declaration: one blob reachable from a ref must be absent
+ * locally. `GIT_NO_LAZY_FETCH=1` is what makes the probe honest — without it the promisor machinery
+ * fetches the very object being tested and every clone looks complete.
+ *
+ * Bounded on purpose: one `ls-tree` and one `cat-file`, no history traversal, so the cost does not
+ * scale with the repository this exists to keep small.
+ *
+ * @param {String} mirrorPath Local mirror path.
+ * @returns {Promise<void>} Resolves when the mirror is verifiably blobless.
+ * @throws {Error} `KB_GITMIRROR_CLONE_FAILED` when the filter was ignored.
+ */
+async function assertBloblessClone(mirrorPath) {
+    // `listRefs` returns a Map of refname -> objectname.
+    const [revision] = [...(await listRefs(mirrorPath)).values()];
+
+    // An empty repository has no blob to probe and no blobs to save; it is vacuously fine.
+    if (!revision) {
+        return;
+    }
+
+    const listed    = await runGit(['ls-tree', '-r', '--object-only', revision], {
+              cwd           : mirrorPath,
+              failureCode   : 'KB_GITMIRROR_CLONE_FAILED',
+              failureMessage: 'GitMirror could not inspect the cloned tree'
+          }),
+          [blobOid] = String(listed.stdout ?? '').split('\n').filter(Boolean);
+
+    // A tree with no blobs at all cannot witness the filter either way.
+    if (!blobOid) {
+        return;
+    }
+
+    const probe = await runGit(['cat-file', '-e', blobOid], {
+        // Exit 1 is the ANSWER here, not a failure: it is how git reports the object is absent.
+        acceptedExitCodes: [0, 1],
+        cwd              : mirrorPath,
+        // Without this the promisor machinery fetches the object being probed and every clone,
+        // filtered or not, reports the blob present. Verified both ways against a fixture remote.
+        extraEnv         : {GIT_NO_LAZY_FETCH: '1'},
+        failureCode      : 'KB_GITMIRROR_CLONE_FAILED',
+        failureMessage   : 'GitMirror could not probe the cloned blob'
+    });
+
+    if (probe.exitCode === 0) {
+        // Leave no half-trusted mirror behind: `isUsableMirror` would accept it on the next run and
+        // the full clone would become permanent, silently.
+        await fs.remove(mirrorPath);
+
+        throw createGitMirrorError(
+            'KB_GITMIRROR_CLONE_FAILED',
+            'GitMirror clone recorded the blob filter but the remote ignored it — the mirror holds ' +
+            'every blob in history. Refusing a full mirror rather than accepting it silently; the ' +
+            'remote must advertise partial-clone support (`uploadpack.allowFilter`).'
+        );
+    }
 }
 
 /**

--- a/ai/services/knowledge-base/helpers/tenantRepoAccessContract.mjs
+++ b/ai/services/knowledge-base/helpers/tenantRepoAccessContract.mjs
@@ -14,6 +14,8 @@ import path from 'path';
 
 const URL_WITH_USERINFO_RE   = /^[a-z][a-z0-9+.-]*:\/\/[^/\s@]+@/iu;
 const SCP_LIKE_USERINFO_RE   = /^[^/\s@:]+@[^/\s@:]+:/u;
+const URL_SCHEME_RE          = /^[a-z][a-z0-9+.-]*:\/\//iu;
+const SCP_LIKE_ENDPOINT_RE   = /^[^/\s:]{2,}:(?!\/\/)/u;
 const ENV_CREDENTIAL_NAME_RE = /^[A-Za-z_][A-Za-z0-9_]*$/u;
 const SSH_USERNAME_RE        = /^[A-Za-z0-9._-]+$/u;
 const SECRET_REPLACEMENT     = '[REDACTED]';
@@ -191,6 +193,35 @@ export function hasCloneUrlUserInfo(cloneUrl) {
     const value = String(cloneUrl || '').trim();
 
     return URL_WITH_USERINFO_RE.test(value) || SCP_LIKE_USERINFO_RE.test(value);
+}
+
+/**
+ * @summary Returns true when a clone URL is fetched over a transport rather than copied from a local path.
+ *
+ * The distinction is not cosmetic: git applies `--filter` only over a transport, and **ignores it silently
+ * for local path clones** — so anything asserting a filter took effect must ask this question, and must ask
+ * it about transport-ness rather than about a `://` scheme. `git@host:org/repo.git` carries no scheme and is
+ * a documented tenant `cloneUrl` form; a scheme test excludes it and, with it, the assertion.
+ *
+ * Two accepted transport shapes, matching what config normalization already admits:
+ * - scheme-qualified — `https://…`, `ssh://…`, `file://…`
+ * - SCP-like — a colon appearing before any slash, with or without `user@`. A colon-before-slash is
+ *   git's own SCP test; the `{2,}` guard keeps a single-character prefix out, so a Windows drive
+ *   (`C:\repos\mirror`) stays a path rather than becoming a host.
+ *
+ * A single-character prefix is deliberately NOT transport: `C:\repos\mirror` is a Windows drive letter, and
+ * git resolves the same ambiguity the same way. Everything else without a colon-before-slash is a path.
+ *
+ * Found by @neo-opus-grace, whose review showed the scheme test skipped the guard on the one URL form where
+ * nothing else looks.
+ *
+ * @param {String} cloneUrl Candidate clone URL.
+ * @returns {Boolean}
+ */
+export function isTransportCloneUrl(cloneUrl) {
+    const value = String(cloneUrl || '').trim();
+
+    return URL_SCHEME_RE.test(value) || SCP_LIKE_ENDPOINT_RE.test(value);
 }
 
 /**

--- a/test/playwright/unit/ai/services/knowledge-base/gitMirror.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/gitMirror.spec.mjs
@@ -14,6 +14,7 @@ import GitMirror, {
     inspectCredentialReadiness,
     isAncestor,
     probeRemoteAccess,
+    readRevisionFile,
     TenantRepoAccessCode,
     resolveHead
 } from '../../../../../../ai/services/knowledge-base/helpers/gitMirror.mjs';
@@ -203,6 +204,122 @@ exit 1
 
         expect(diff.addedOrChanged).toEqual(['renamed-alpha.txt']);
         expect(diff.deleted).toEqual(['alpha.txt']);
+    });
+
+    /**
+     * The mirror is blobless. A plain `--mirror` pulled every blob in history — 4.9 GB for one
+     * repository on the container plane — while the ingestion only ever reads the current tree plus the
+     * blobs of the paths it consumes.
+     *
+     * These use `file://` rather than a path, because git IGNORES `--filter` for local path clones, and
+     * the source sets `uploadpack.allowFilter` because a remote that does not advertise filter support
+     * makes git ignore it too — silently, with exit 0.
+     */
+    async function servesPartialClones(source) {
+        await git(['config', 'uploadpack.allowFilter', 'true'], source);
+
+        return `file://${source}`;
+    }
+
+    async function localObjectExists(mirrorPath, oid) {
+        // GIT_NO_LAZY_FETCH is what makes this honest: without it the promisor machinery fetches the
+        // very object under test and a full mirror is indistinguishable from a filtered one.
+        return await execFileAsync('git', ['cat-file', '-e', oid], {
+            cwd: mirrorPath,
+            env: {...process.env, GIT_NO_LAZY_FETCH: '1'}
+        }).then(() => true).catch(() => false);
+    }
+
+    test('a transport clone omits historical blobs, and the full-clone control proves the probe can see them', async () => {
+        const source = await createSourceRepo();
+
+        await commitSecondRevision(source);
+
+        const cloneUrl = await servesPartialClones(source),
+              head     = await git(['rev-parse', 'HEAD'], source),
+              blobOid  = (await git(['ls-tree', '-r', '--object-only', head], source)).split('\n')[0];
+
+        const {mirrorPath} = await cloneIfMissing({...mirrorOptions(source), cloneUrl});
+
+        expect(await localObjectExists(mirrorPath, blobOid),
+            'a blobless mirror must not hold the blob locally').toBe(false);
+
+        // The control. Without it, a probe that always answered "absent" would pass the assertion above
+        // while proving nothing — and every config-shaped check (promisor flag, partialclonefilter,
+        // .promisor pack marker) is set on an IGNORED filter too, so none of them can stand in for this.
+        const full = path.join(root, 'full-control');
+
+        await execFileAsync('git', ['clone', '--mirror', cloneUrl, full]);
+        expect(await localObjectExists(full, blobOid),
+            'the control must report the blob PRESENT, or the probe cannot distinguish anything').toBe(true)
+    });
+
+    test('an incremental diff is identical on a blobless mirror — base-to-head is unaffected', async () => {
+        // The reason this is `--filter=blob:none` and not `--depth`: a shallow clone makes the base
+        // revision unreachable and breaks exactly this, forcing a full re-ingest every sync.
+        const source = await createSourceRepo(),
+              base   = await git(['rev-parse', 'HEAD'], source);
+
+        await commitSecondRevision(source);
+
+        const head     = await git(['rev-parse', 'HEAD'], source),
+              cloneUrl = await servesPartialClones(source),
+              blobless = await cloneIfMissing({...mirrorOptions(source), cloneUrl}),
+              full     = path.join(root, 'full-diff-control');
+
+        await execFileAsync('git', ['clone', '--mirror', cloneUrl, full]);
+
+        const rawDiff = async cwd => (await execFileAsync(
+            'git', ['diff', '--name-status', '-M', base, head], {cwd}
+        )).stdout;
+
+        // Byte-identical is the claim: the filter must not perturb the diff at all.
+        expect(await rawDiff(blobless.mirrorPath)).toBe(await rawDiff(full));
+
+        // And the real API must work over the blobless mirror, not just raw git.
+        const {addedOrChanged, deleted} = await diffRevisions({...mirrorOptions(source), baseRevision: base, headRevision: head});
+
+        expect(addedOrChanged.length + deleted.length,
+            'the fixture must actually change paths, or the comparison above is two empty strings')
+            .toBeGreaterThan(0)
+    });
+
+    test('reading a file from a blobless mirror returns its real content', async () => {
+        // The lazy fetch, exercised rather than assumed. `show` is the one read that needs a blob, and
+        // it is the operation that makes the trade acceptable — content arrives on demand.
+        const source   = await createSourceRepo(),
+              cloneUrl = await servesPartialClones(source),
+              head     = await git(['rev-parse', 'HEAD'], source);
+
+        await cloneIfMissing({...mirrorOptions(source), cloneUrl});
+
+        expect(await readRevisionFile({...mirrorOptions(source), revision: head, sourcePath: 'alpha.txt'}))
+            .toBe('alpha v1\n')
+    });
+
+    test('a remote that IGNORES the filter is refused, and the half-trusted mirror is removed', async () => {
+        // git warns on stderr and exits 0, then records promisor config over a mirror holding every
+        // blob. Accepting that would restore the 4.9 GB invisibly with the suite still green.
+        const source = await createSourceRepo();
+
+        // Deliberately NOT setting uploadpack.allowFilter — this is the unsupported-remote case.
+        const cloneUrl = `file://${source}`,
+              options  = {...mirrorOptions(source), cloneUrl};
+
+        await expect(cloneIfMissing(options)).rejects.toThrow(/ignored it|blob filter/i);
+
+        const mirrorPath = path.join(root, 'mirrors', 'tenant-a', 'local', 'source');
+
+        expect(await fs.pathExists(mirrorPath),
+            'a rejected mirror must not survive, or isUsableMirror accepts the full clone forever').toBe(false)
+    });
+
+    test('a bare local path is not held to the filter — git ignores it there by design', async () => {
+        // Local path clones hardlink their object store, so there is no history to save and git
+        // documents that it ignores `--filter`. Enforcing there would break every path-based caller.
+        const source = await createSourceRepo();
+
+        await expect(cloneIfMissing(mirrorOptions(source))).resolves.toMatchObject({cloned: true})
     });
 
     test('throws stable errors for missing refs and invalid mirrors', async () => {

--- a/test/playwright/unit/ai/services/knowledge-base/gitMirror.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/gitMirror.spec.mjs
@@ -19,6 +19,10 @@ import GitMirror, {
     resolveHead
 } from '../../../../../../ai/services/knowledge-base/helpers/gitMirror.mjs';
 
+// Imported from the contract rather than re-exported through GitMirror: the clone-URL grammar has an
+// owner, and this predicate is a member of it. Re-exporting it only for a test would blur that.
+import {isTransportCloneUrl} from '../../../../../../ai/services/knowledge-base/helpers/tenantRepoAccessContract.mjs';
+
 const execFileAsync = promisify(execFile);
 
 /**
@@ -320,6 +324,27 @@ exit 1
         const source = await createSourceRepo();
 
         await expect(cloneIfMissing(mirrorOptions(source))).resolves.toMatchObject({cloned: true})
+    });
+
+    test('the guard is scoped by TRANSPORT, not by scheme — an SCP-style URL is still held to it', () => {
+        // The gap this pins: `git@host:org/repo.git` carries no `://`, so a scheme test skipped the
+        // assertion on the one documented tenant URL form that has no scheme — and therefore the one
+        // form where a full mirror would pass every config-shaped check unchallenged. Found in review
+        // by @neo-opus-grace. Both directions are asserted, because a predicate that answered `true`
+        // for everything would satisfy the first three rows alone.
+        [
+            ['https://github.com/neomjs/neo.git',  true],
+            ['ssh://git@github.com/neomjs/neo.git', true],
+            ['file:///tmp/fixture.git',            true],
+            ['git@github.com:neomjs/neo.git',      true],
+            ['github.com:neomjs/neo.git',          true],
+            ['/var/lib/mirrors/repo.git',          false],
+            ['./relative/path.git',                false],
+            // A Windows drive letter is a path, not a host. git resolves the same ambiguity the same way.
+            ['C:\\repos\\mirror',                  false]
+        ].forEach(([cloneUrl, expected]) => {
+            expect(isTransportCloneUrl(cloneUrl), cloneUrl).toBe(expected)
+        })
     });
 
     test('throws stable errors for missing refs and invalid mirrors', async () => {


### PR DESCRIPTION
Resolves #16546

Evidence: L2 (unit specs over real git fixtures, run locally + exact-head CI) → L4 not claimed. The 4.9 GB and OOM measurements are L3 observations from the live container plane, reported as motivation rather than as this PR's proof.

## The tenant mirror paid for history nothing reads

`cloneIfMissing` cloned `--mirror`: every ref, every commit, **every blob in history**. Measured on the container plane:

| fact | value |
|---|---|
| one tenant mirror on disk | **4.9 GB**, full clone |
| orchestrator `NODE_OPTIONS` | *empty* |
| Node default heap ceiling there | 1728 MB |
| observed death | `FATAL ERROR: Reached heap limit`, ~1009 MB, `allocation failure; scavenge might not succeed` |
| cadence | ~290 s with `tenant repo sync (cloud)` active |

A polling multi-repo deployment pays that per repo.

**V-B-A on every git read in this module** — the lane needs commits and trees (`for-each-ref`, `rev-parse`, `merge-base --is-ancestor`, `diff --name-status`, `ls-tree --name-only`) and blobs **only for the paths it actually ingests** (`show <revision>:<path>`). Historical blobs were downloaded, stored, and never opened. `--filter=blob:none` is shaped to exactly that profile.

**Not `--depth`.** A shallow clone makes the base revision unreachable, breaking `merge-base --is-ancestor` and the base-to-head diff that incremental sync is built on — trading a disk problem for re-ingesting the whole tree every cycle. A spec pins that the diff is byte-identical on a blobless mirror.

## The flag alone was not enough, and writing the witness is what showed it

**A remote that does not advertise filter support makes git ignore `--filter` and exit 0.** It warns on stderr, then writes `remote.origin.promisor=true`, the `partialclonefilter`, and a `.promisor` pack marker anyway.

Measured against a fixture remote — filtered and full clones of the same repository:

```
filtered: 2072 KB     full: 2068 KB     identical object counts
both carrying remote.origin.promisor=true and partialclonefilter=blob:none
```

So every config-shaped assertion answers *"this is a partial clone"* over a mirror holding all of history. **The acceptance criterion I wrote on #16546 asked for exactly that check** — "prove the clone is a promisor repo, the filter is recorded" — and it would have passed over a completely unfixed implementation. That AC is amended on the ticket.

`assertBloblessClone` asserts the **effect**: one blob reachable from a ref must be absent locally, probed with `GIT_NO_LAZY_FETCH=1` because the promisor machinery otherwise fetches the object under test and every clone looks complete. Bounded to one `ls-tree` and one `cat-file`, so the cost does not scale with the repository this exists to keep small. On failure the mirror is **removed** — `isUsableMirror` would otherwise accept the full clone forever, silently.

**Scoped to transport clones.** `--filter` over a bare local path is ignored by git's own design, and a local clone hardlinks its object store, so there is nothing to save and nothing to assert. Enforcing there broke seven existing specs before the scope was right — that failure is what surfaced the distinction.

## Test Evidence

`28 passed` for `GitMirror` + `TenantRepoIngestEnvelopeBuilder`; `195 passed` across the wider tenant-repo surface. Five new specs:

- **blobs are genuinely absent** after a transport clone — with a full-clone control proving the probe can report *present*. Without the control, a probe that always answered "absent" would pass.
- **the base-to-head diff is byte-identical** on a blobless mirror, and `diffRevisions` returns a non-empty result over it
- **`show` returns real content**, exercising the lazy fetch rather than assuming it
- **a remote that ignores the filter is refused** and the half-trusted mirror is removed
- **a bare local path is not held to the filter**, pinning the scope decision

**RED-proven:** with `--filter=blob:none` reverted, two of the five fail — the omission witness and the refusal witness. The other three are non-regression assertions and correctly pass either way.

Fixtures use `file://` with `uploadpack.allowFilter` on the source, because neither a path clone nor an unconfigured remote can witness a filter at all — the same trap the production guard now catches.

## Post-Merge Validation

- [ ] Re-clone a tenant mirror on the container plane and record the on-disk size against today's 4.9 GB.
- [ ] Confirm the orchestrator's tenant-repo-sync lane completes without hitting the heap ceiling.
- [ ] **Not claimed by this PR:** the OOM's link to the KB corpus loss was withdrawn — @neo-opus-grace's WAL evidence dates that loss to a single minute 87 minutes after a restore, which no OOM cadence explains. This fixes a real defect on its own terms.

## Deltas

- `ai/services/knowledge-base/helpers/gitMirror.mjs` — `--filter=blob:none` on the clone; new `assertBloblessClone` effect probe; `runGit` gains `extraEnv` so the probe stays on the module's one credential-scrubbed exec boundary rather than adding a second.
- `test/playwright/unit/ai/services/knowledge-base/gitMirror.spec.mjs` — five specs plus two fixture helpers.
- **Substrate accretion:** one internal function, one optional parameter, no new module and no new dependency. Sunset condition: the probe retires if git ever fails a clone whose filter it ignored, which would make the check redundant.

## Contract Ledger

| Target Surface | Source of Authority | Behavior | Fallback / Error Semantics |
|---|---|---|---|
| `cloneIfMissing` clone form | #16546 | `clone --mirror --filter=blob:none` for transport URLs | Remote ignores the filter ⇒ `KB_GITMIRROR_CLONE_FAILED`, mirror removed, **no** silent full-clone fallback |
| local path clones | git's documented behaviour | unchanged | n/a — git ignores `--filter` there and the object store is hardlinked |
| blob availability | git partial clone | `show` fetches its blob on demand | Unreachable remote ⇒ `show` fails loudly, never returns empty content |

Authored by Ada (`@neo-opus-ada`, Opus 5, Claude Code). Session `c724a85f-2d37-44ac-9a33-12dcce415aa2`.
