### PR TITLE
feat(mcp): a seat can tell a missing capability from a stale schema (#16320)

### DIFF
--- a/ai/mcp/ToolService.mjs
+++ b/ai/mcp/ToolService.mjs
@@ -8,6 +8,16 @@ import {buildZodSchema,
 import Base                                               from '../../src/core/Base.mjs';
 
 /**
+ * Label prefixing the advertised-surface digest inside the carrier tool's description.
+ *
+ * Exported because it is the anchor the documented comparison procedure tells a reader to look for,
+ * and the same literal the result side reports back. A second copy of this string anywhere would let
+ * the two halves drift apart while both still look correct.
+ * @type {String}
+ */
+export const ADVERTISED_SURFACE_DIGEST_LABEL = 'Advertised-surface digest at attach:';
+
+/**
  * Shared service for managing, listing, calling, and validating MCP tools.
  * Can be instantiated by both MCP Servers (with OpenAPI spec) and MCP Clients.
  *
@@ -36,7 +46,15 @@ class ToolService_tmp extends Base {
          * Maximum description length emitted through compact `tools/list`.
          * @member {Number} toolListDescriptionMaxLength=160
          */
-        toolListDescriptionMaxLength: 160
+        toolListDescriptionMaxLength: 160,
+        /**
+         * Tool whose DESCRIPTION carries the advertised-surface digest a client caches at attach.
+         *
+         * `healthcheck` is the carrier because it is the one tool every server exposes and the one
+         * an unhealthy server still answers — a seat holding a stale surface can always reach it.
+         * @member {String} surfaceDigestCarrierTool='healthcheck'
+         */
+        surfaceDigestCarrierTool: 'healthcheck'
     }
 
     /**
@@ -370,6 +388,10 @@ class ToolService_tmp extends Base {
 
     /**
      * Provides a paginated list of available tools.
+     *
+     * The carrier tool's description is stamped with {@link ToolService#getAdvertisedSurfaceDigest}
+     * so the value travels into the client's schema cache at attach. See
+     * {@link ToolService#stampSurfaceDigest} for why the descriptor is the right place to put it.
      * @param {Object} [options]
      * @param {Number} [options.cursor=0]
      * @param {Number} [options.limit]
@@ -383,7 +405,7 @@ class ToolService_tmp extends Base {
 
         if (!limit) {
             return {
-                tools     : toolsForListing,
+                tools     : me.stampSurfaceDigest(toolsForListing, toolProjection),
                 nextCursor: undefined
             };
         }
@@ -394,9 +416,73 @@ class ToolService_tmp extends Base {
         const nextCursor = end < toolsForListing.length ? String(end) : undefined;
 
         return {
-            tools: toolsSlice,
+            tools: me.stampSurfaceDigest(toolsSlice, toolProjection),
             nextCursor
         };
+    }
+
+    /**
+     * @summary Stamps the advertised-surface digest into the carrier tool's description.
+     *
+     * ## Why the descriptor, and not a new tool
+     *
+     * The staleness this measures is invisible precisely because a stale client never asks again. A
+     * new tool would be unreachable to exactly the seats that need it — they attached before it
+     * existed. The descriptor is the one surface a stale attachment provably still holds, because
+     * holding it is what makes the attachment stale. Pairing it with the live value on the
+     * `healthcheck` RESULT gives both halves of the comparison to a client that changed nothing.
+     *
+     * Returns copies. `allToolsForListing` is a shared cache and the digest is projection-dependent,
+     * so stamping in place would leak one projection's digest into another's listing.
+     *
+     * **Paging is out of scope, deliberately.** The digest covers the whole advertised surface for the
+     * projection, but it only rides the page that contains the carrier. A client paging past that page
+     * sees no token and must read the absence as `unknown` — never as `current`.
+     * @param {Object[]} tools Tools about to be listed.
+     * @param {Object|String} [toolProjection] Projection context, as passed to `listTools`.
+     * @returns {Object[]}
+     * @protected
+     */
+    stampSurfaceDigest(tools, toolProjection) {
+        const me      = this,
+              carrier = me.surfaceDigestCarrierTool;
+
+        if (!carrier || !tools.some(tool => tool?.name === carrier)) {
+            return tools;
+        }
+
+        const digest = me.getAdvertisedSurfaceDigest(toolProjection);
+
+        return tools.map(tool => tool?.name === carrier ? {
+            ...tool,
+            description: `${tool.description || ''}\n\n${ADVERTISED_SURFACE_DIGEST_LABEL} ${digest}`.trim()
+        } : tool)
+    }
+
+    /**
+     * @summary Reports the surface this server advertises RIGHT NOW for a projection.
+     *
+     * The result-side half of the comparison. A client compares this against the token its cached
+     * `healthcheck` descriptor carries: equal means the attachment was provisioned from this same
+     * advertised-surface generation, different means it was not, and **either one missing means
+     * `unknown` — never `current`**, because an absent token is indistinguishable from a server that
+     * predates the instrument.
+     *
+     * Equality claims that and nothing more. It is not a guarantee against host-side truncation or
+     * paging, which no server-side value can see.
+     * @param {Object|String} [toolProjection] Projection context, as passed to `listTools`.
+     * @returns {{digest: String, toolCount: Number, carrierTool: String}}
+     */
+    describeAdvertisedSurface(toolProjection) {
+        const me = this;
+
+        me.initializeToolMapping();
+
+        return {
+            carrierTool: me.surfaceDigestCarrierTool,
+            digest     : me.getAdvertisedSurfaceDigest(toolProjection),
+            toolCount  : me.getToolsForProjection(toolProjection).filter(Boolean).length
+        }
     }
 
     /**

--- a/ai/mcp/ToolService.mjs
+++ b/ai/mcp/ToolService.mjs
@@ -1,3 +1,4 @@
+import crypto    from 'node:crypto';
 import fs        from 'fs';
 import * as yaml from 'js-yaml';
 import {buildZodSchema,
@@ -405,6 +406,72 @@ class ToolService_tmp extends Base {
     getToolProjectionPolicy() {
         this.initializeToolMapping();
         return this.harnessToolProjection;
+    }
+
+    /**
+     * @summary Serializes a value with deterministic object-key ordering.
+     *
+     * `JSON.stringify` preserves insertion order, so two structurally identical schemas built by
+     * different code paths serialize differently and would digest differently. That would report a
+     * seat as stale for a surface it actually holds — a false positive on the one axis this exists to
+     * measure, and the kind that trains readers to ignore the signal.
+     * @param {*} value
+     * @returns {String}
+     * @protected
+     */
+    canonicalize(value) {
+        if (Array.isArray(value)) {
+            return `[${value.map(item => this.canonicalize(item)).join(',')}]`
+        }
+
+        if (value && typeof value === 'object') {
+            return `{${Object.keys(value).sort().map(key => `${JSON.stringify(key)}:${this.canonicalize(value[key])}`).join(',')}}`
+        }
+
+        return JSON.stringify(value ?? null)
+    }
+
+    /**
+     * @summary Digests the tool surface this server ADVERTISES for a given projection.
+     *
+     * The staleness axis it serves is **capability reachability**: can the caller reach the tools and
+     * argument shapes this server currently exposes? A client caches the advertised set at connect and
+     * never revalidates, so a capability shipped after that connect is rejected client-side before the
+     * call leaves — and the rejection names the stale enum as authoritative, which is how a seat
+     * concludes a shipped capability does not exist and reports that as fact.
+     *
+     * ## What is digested, and why the rest is deliberately excluded
+     *
+     * **Tool names plus input schemas only.** Descriptions, titles and output schemas are excluded,
+     * and that exclusion is load-bearing twice over:
+     *
+     * 1. **It makes the digest non-recursive.** The digest is published *inside* a tool description,
+     *    so digesting descriptions would make the value an input to itself.
+     * 2. **It keeps the axis honest.** A reworded description does not make a capability unreachable;
+     *    treating that as staleness would cry wolf until seats ignore the signal entirely.
+     *
+     * Computed over {@link #getToolsForProjection}'s result rather than the raw OpenAPI file, because a
+     * profile legitimately advertises a subset — digesting the unfiltered set would report every
+     * projected seat as permanently stale.
+     *
+     * Equality claims exactly one thing: **this attachment was provisioned from the same
+     * advertised-surface generation.** It does not claim the host delivered the full list; truncation
+     * and paging are a separate, explicitly out-of-scope concern.
+     *
+     * @param {Object|String} [toolProjection] Projection context, as passed to `listTools`.
+     * @returns {String} Short hex digest of the advertised surface.
+     */
+    getAdvertisedSurfaceDigest(toolProjection) {
+        const me = this;
+
+        me.initializeToolMapping();
+
+        const canonicalSurface = me.getToolsForProjection(toolProjection)
+            .filter(Boolean)
+            .map(tool => ({name: tool.name, inputSchema: tool.inputSchema ?? null}))
+            .sort((lhs, rhs) => lhs.name < rhs.name ? -1 : lhs.name > rhs.name ? 1 : 0);
+
+        return crypto.createHash('sha256').update(me.canonicalize(canonicalSurface)).digest('hex').slice(0, 12)
     }
 
     /**

--- a/ai/mcp/server/BaseServer.mjs
+++ b/ai/mcp/server/BaseServer.mjs
@@ -433,6 +433,14 @@ class BaseServer extends Base {
      * Never throws into the call. A digest that cannot be computed must degrade to a result with no
      * token — which the procedure reads as `unknown` — rather than failing a healthcheck a stale seat
      * may be depending on to diagnose itself.
+     *
+     * **Stated bound.** The guard tests for the PRESENCE of an `error` key, because that is what
+     * `formatToolResult` routes to an error envelope — stamping a surface claim onto a payload about to
+     * be rendered as a failure would publish it inside an error. No health service's success path
+     * carries that key, so the happy path always stamps. But a service that RETURNS rather than throws
+     * a degraded verdict yields no token, and a seat asking a degraded server therefore reads
+     * `unknown`. Fail-closed, never a false `current` — and written here rather than left for the next
+     * reader to rediscover, because it is the one case where the intent above is only partly served.
      * @param {Object}        context
      * @param {String}        context.name Tool name that was called.
      * @param {*}             context.result Dispatch result.

--- a/ai/mcp/server/BaseServer.mjs
+++ b/ai/mcp/server/BaseServer.mjs
@@ -407,7 +407,7 @@ class BaseServer extends Base {
                 const dispatch = () => toolService.callTool(name, args, {toolProjection});
                 const result   = await this.wrapDispatch(dispatch);
 
-                return this.formatToolResult(result);
+                return this.formatToolResult(this.attachAdvertisedSurface({name, result, toolProjection}));
             } catch (error) {
                 if (error?.code === 'POLICY_REFUSED') {
                     this.logger?.warn?.(`[MCP] Policy refused tool ${name}:`, error.reason || error.message);
@@ -417,6 +417,46 @@ class BaseServer extends Base {
                 return this.formatToolError(name, error);
             }
         });
+    }
+
+    /**
+     * @summary Adds the server's live advertised-surface descriptor to the carrier tool's result.
+     *
+     * The result-side half of the schema-staleness comparison. The descriptor half rides the
+     * carrier tool's DESCRIPTION and is therefore frozen in the client's cache at attach; this half is
+     * computed per call, so a client that changed nothing holds both an old token and a current one and
+     * can tell them apart. `advertisedSurface` is deliberately a separate key from `runtimeFreshness`:
+     * that block answers "did my OpenAPI change since I booted", server-against-its-own-disk. This one
+     * answers "is the caller holding the surface I currently advertise", which is a different axis and
+     * was the one nothing measured.
+     *
+     * Never throws into the call. A digest that cannot be computed must degrade to a result with no
+     * token — which the procedure reads as `unknown` — rather than failing a healthcheck a stale seat
+     * may be depending on to diagnose itself.
+     * @param {Object}        context
+     * @param {String}        context.name Tool name that was called.
+     * @param {*}             context.result Dispatch result.
+     * @param {Object|String} [context.toolProjection] Projection the call was dispatched under.
+     * @returns {*} The result, augmented when it is the carrier tool's.
+     * @protected
+     */
+    attachAdvertisedSurface({name, result, toolProjection}) {
+        const toolService = this.getToolService();
+
+        if (!Neo.isObject(result) || 'error' in result || !toolService?.describeAdvertisedSurface) {
+            return result;
+        }
+
+        if (name !== toolService.surfaceDigestCarrierTool) {
+            return result;
+        }
+
+        try {
+            return {...result, advertisedSurface: toolService.describeAdvertisedSurface(toolProjection)};
+        } catch (error) {
+            this.logger?.warn?.('[MCP] Could not describe the advertised surface:', error.message);
+            return result;
+        }
     }
 
     /**

--- a/learn/agentos/tooling/TroubleshootingToolCalls.md
+++ b/learn/agentos/tooling/TroubleshootingToolCalls.md
@@ -42,6 +42,54 @@ Some tools may have names that are unique across all servers. Harnesses can stil
 
 If a remembered tool name fails, inspect the current tool surface before retrying; do not synthesize alternate names from stale guidance.
 
+## When the error message is the wrong clue: a stale tool schema
+
+The Scientific Method above says the error message is your most important clue. There is one failure
+where it points the wrong way, and it is worth naming because the wrong conclusion gets published as
+fact.
+
+Your client caches each server's tool schemas **at connect** and never revalidates. Every Neo server
+declares `tools: {listChanged: false}`, so no refresh signal will ever arrive. If a capability shipped
+after you attached, your client rejects the call *before it leaves* — and the rejection quotes your own
+cached schema as if it were the server's:
+
+```
+MCP error -32602: Invalid arguments for tool manage_wake_subscription:
+  "values": ["bootstrap","subscribe","unsubscribe","update","list","resync"]
+```
+
+Read literally, that says the server does not support the action. It says no such thing. It says *your
+copy* does not. Three wrong moves follow: reporting the capability as absent, building a workaround for
+something that already shipped, or filing a bug against a working server.
+
+**Reading your own tool list does not help** — it is the same cache.
+
+### The comparison
+
+`healthcheck` carries both halves, and you need no new call beyond the one you were going to make:
+
+| where | what it is |
+|---|---|
+| the `healthcheck` **description** you hold | `Advertised-surface digest at attach: <token>` — frozen into your cache when you attached |
+| the `healthcheck` **result** | `advertisedSurface.digest` — computed by the server on this call |
+
+| tokens | verdict | what to do |
+|---|---|---|
+| equal | `current` | Your schema matches what this server advertises. An absence really is an absence. |
+| different | `stale` | Reconnect before asserting anything about capability. Do not report a capability as missing. |
+| either absent | **`unknown`** | The comparison did not happen. **Never read this as `current`** — a server predating the instrument looks exactly like this, and so does a page that did not contain `healthcheck`. |
+
+Equality claims one thing only: this attachment was provisioned from the same advertised-surface
+generation the server serves now. It says nothing about host-side truncation or paging, which no
+server-side value can see.
+
+The digest covers tool **names and input schemas** for the projection you were served. Descriptions are
+excluded, so a reworded description does not move it — the axis is whether a capability is *reachable*,
+not whether its prose is current.
+
+**The rule this exists to enforce:** an absence-claim about a capability requires a `current` verdict.
+Without one, the honest statement is *"my schema may predate it"*, not *"it does not exist"*.
+
 ## Conclusion
 
 Flexibility and a systematic, evidence-based approach are key. Do not rigidly adhere to a rule that has been proven false by an experiment. Use every success and failure to build a more accurate mental model of the tool environment.

--- a/test/playwright/unit/ai/mcp/advertisedSurfaceDigest.spec.mjs
+++ b/test/playwright/unit/ai/mcp/advertisedSurfaceDigest.spec.mjs
@@ -1,0 +1,131 @@
+import {setup} from '../../../setup.mjs';
+
+const appName = 'AdvertisedSurfaceDigestTest';
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name             : appName,
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../../src/Neo.mjs';
+import * as core      from '../../../../../src/core/_export.mjs';
+
+/**
+ * Covers the advertised-surface digest — the carrier that lets a seat discover its cached tool schema
+ * no longer matches what the server exposes.
+ *
+ * The properties asserted here are the ones a future refactor would silently break: that a reworded
+ * description does NOT move the digest (otherwise the signal cries wolf and gets ignored), and that
+ * key ordering does NOT move it (otherwise a seat is reported stale for a surface it actually holds).
+ */
+test.describe('ToolService advertised-surface digest', () => {
+    let ToolService;
+
+    /**
+     * @summary Builds a ToolService stub exposing a fixed advertised surface.
+     * @param {Object[]} tools Advertised tools.
+     * @returns {Object}
+     */
+    function serviceWith(tools) {
+        const instance = Object.create(ToolService.prototype);
+
+        instance.initializeToolMapping   = () => {};
+        instance.getToolsForProjection   = () => tools;
+
+        return instance
+    }
+
+    test.beforeAll(async () => {
+        ToolService = (await import('../../../../../ai/mcp/ToolService.mjs')).default
+    });
+
+    test('identical surfaces digest identically, and an added tool changes it', () => {
+        const base = [
+            {name: 'alpha', inputSchema: {type: 'object', properties: {a: {type: 'string'}}}},
+            {name: 'beta',  inputSchema: {type: 'object', properties: {b: {type: 'number'}}}}
+        ];
+
+        const digestA = serviceWith(base).getAdvertisedSurfaceDigest(),
+              digestB = serviceWith([...base]).getAdvertisedSurfaceDigest();
+
+        expect(digestA).toBe(digestB);
+
+        // The defect this exists to detect: a capability shipped after the client connected.
+        const withNewTool = serviceWith([...base, {name: 'gamma', inputSchema: {type: 'object'}}]).getAdvertisedSurfaceDigest();
+
+        expect(withNewTool).not.toBe(digestA)
+    });
+
+    test('a changed enum on an existing tool changes the digest', () => {
+        // The measured defect was exactly this shape: `manage_wake_subscription` gained a `resume`
+        // action, and a client holding the old enum rejected the call before it left.
+        const before = serviceWith([{name: 'manage_wake_subscription', inputSchema: {
+            type: 'object', properties: {action: {enum: ['bootstrap', 'list', 'resync']}}
+        }}]).getAdvertisedSurfaceDigest();
+
+        const after = serviceWith([{name: 'manage_wake_subscription', inputSchema: {
+            type: 'object', properties: {action: {enum: ['bootstrap', 'list', 'resync', 'resume']}}
+        }}]).getAdvertisedSurfaceDigest();
+
+        expect(after).not.toBe(before)
+    });
+
+    test('a reworded description does NOT change the digest', () => {
+        const withDescription = serviceWith([
+            {name: 'alpha', description: 'original wording', inputSchema: {type: 'object'}}
+        ]).getAdvertisedSurfaceDigest();
+
+        const reworded = serviceWith([
+            {name: 'alpha', description: 'completely different prose, and a published digest literal', inputSchema: {type: 'object'}}
+        ]).getAdvertisedSurfaceDigest();
+
+        // Load-bearing twice: it keeps the digest non-recursive (the value is published INSIDE a tool
+        // description), and it keeps the axis capability-reachability rather than copy-freshness.
+        expect(reworded).toBe(withDescription)
+    });
+
+    test('tool order and object-key order do not change the digest', () => {
+        const ordered = serviceWith([
+            {name: 'alpha', inputSchema: {type: 'object', properties: {a: {type: 'string'}}}},
+            {name: 'beta',  inputSchema: {type: 'object', properties: {b: {type: 'number'}}}}
+        ]).getAdvertisedSurfaceDigest();
+
+        // Same surface, reversed listing order and reversed key insertion order. A digest sensitive to
+        // either would report a seat stale for a surface it demonstrably holds — a false positive on
+        // the one axis this measures.
+        const shuffled = serviceWith([
+            {name: 'beta',  inputSchema: {properties: {b: {type: 'number'}}, type: 'object'}},
+            {name: 'alpha', inputSchema: {properties: {a: {type: 'string'}}, type: 'object'}}
+        ]).getAdvertisedSurfaceDigest();
+
+        expect(shuffled).toBe(ordered)
+    });
+
+    test('a projected subset digests differently from the full surface', () => {
+        const full = serviceWith([
+            {name: 'alpha', inputSchema: {type: 'object'}},
+            {name: 'beta',  inputSchema: {type: 'object'}}
+        ]).getAdvertisedSurfaceDigest();
+
+        // Computed over what the projection ADVERTISES, not the raw OpenAPI file — otherwise every
+        // profiled seat reads permanently stale against a surface it was never offered.
+        const projected = serviceWith([{name: 'alpha', inputSchema: {type: 'object'}}]).getAdvertisedSurfaceDigest();
+
+        expect(projected).not.toBe(full)
+    });
+
+    test('an absent inputSchema is stable rather than throwing', () => {
+        const first  = serviceWith([{name: 'alpha'}]).getAdvertisedSurfaceDigest(),
+              second = serviceWith([{name: 'alpha', inputSchema: null}]).getAdvertisedSurfaceDigest();
+
+        expect(first).toBe(second);
+        expect(first).toMatch(/^[0-9a-f]{12}$/)
+    })
+});

--- a/test/playwright/unit/ai/mcp/advertisedSurfaceDigest.spec.mjs
+++ b/test/playwright/unit/ai/mcp/advertisedSurfaceDigest.spec.mjs
@@ -129,3 +129,162 @@ test.describe('ToolService advertised-surface digest', () => {
         expect(first).toMatch(/^[0-9a-f]{12}$/)
     })
 });
+
+/**
+ * Covers the two halves a seat actually compares: the token frozen into its cached `healthcheck`
+ * DESCRIPTOR at attach, and the token the live `healthcheck` RESULT reports back.
+ *
+ * The three cells are asserted through `readSurfaceVerdict`, which is this file's executable copy of
+ * the documented procedure. Its `unknown` branch is the one worth guarding: a missing token means the
+ * comparison could not be made, and reading that as `current` would turn the instrument into a source
+ * of exactly the false confidence it exists to remove.
+ */
+test.describe('advertised-surface descriptor and result', () => {
+    let ADVERTISED_SURFACE_DIGEST_LABEL, ToolService;
+
+    /**
+     * @summary Builds a ToolService stub advertising a fixed surface, with the real listing methods.
+     * @param {Object[]} tools Advertised tools.
+     * @returns {Object}
+     */
+    function serviceWith(tools) {
+        const instance = Object.create(ToolService.prototype);
+
+        instance.initializeToolMapping    = () => {};
+        instance.getToolsForProjection    = () => tools;
+        instance.surfaceDigestCarrierTool = 'healthcheck';
+
+        return instance
+    }
+
+    /**
+     * @summary The documented comparison, executed. Extracts the attach-time token from a cached
+     * descriptor and compares it against a live result token.
+     * @param {Object} options
+     * @param {String|null} options.cachedDescription Description the client cached at attach.
+     * @param {Object|null} options.liveResult `healthcheck` result the client just received.
+     * @returns {'current'|'stale'|'unknown'}
+     */
+    function readSurfaceVerdict({cachedDescription, liveResult}) {
+        const match = String(cachedDescription ?? '')
+                  .match(new RegExp(`${ADVERTISED_SURFACE_DIGEST_LABEL}\\s*([0-9a-f]{12})`)),
+              attached  = match?.[1] ?? null,
+              live      = liveResult?.advertisedSurface?.digest ?? null;
+
+        // Either side missing means the comparison did not happen. It is NOT evidence of freshness:
+        // a server predating this instrument produces exactly this shape.
+        if (!attached || !live) {
+            return 'unknown';
+        }
+
+        return attached === live ? 'current' : 'stale'
+    }
+
+    const surface = [
+        {name: 'alpha',       inputSchema: {type: 'object'}},
+        {name: 'healthcheck', description: 'Health Check', inputSchema: {type: 'object'}}
+    ];
+    const grownSurface = [...surface, {name: 'resume', inputSchema: {type: 'object'}}];
+
+    test.beforeAll(async () => {
+        const module = await import('../../../../../ai/mcp/ToolService.mjs');
+
+        ADVERTISED_SURFACE_DIGEST_LABEL = module.ADVERTISED_SURFACE_DIGEST_LABEL;
+        ToolService                     = module.default
+    });
+
+    test('the carrier descriptor carries the live digest, and other tools are untouched', () => {
+        const service = serviceWith(surface),
+              {tools} = service.listTools({}),
+              carrier = tools.find(tool => tool.name === 'healthcheck');
+
+        expect(carrier.description)
+            .toBe(`Health Check\n\n${ADVERTISED_SURFACE_DIGEST_LABEL} ${service.getAdvertisedSurfaceDigest()}`);
+        // Control: without it, a stamp applied to every tool would satisfy the assertion above.
+        expect(tools.find(tool => tool.name === 'alpha').description).toBeUndefined()
+    });
+
+    test('stamping the descriptor does not move the digest — the value is not an input to itself', () => {
+        const service = serviceWith(surface),
+              before  = service.getAdvertisedSurfaceDigest(),
+              {tools} = service.listTools({});
+
+        // Re-digest the surface as it is now ADVERTISED, stamp included. Descriptions are excluded
+        // from the canonical form precisely so this holds; digesting them would make the published
+        // value change the value being published.
+        expect(serviceWith(tools).getAdvertisedSurfaceDigest()).toBe(before)
+    });
+
+    test('stamping does not mutate the shared listing cache', () => {
+        const service = serviceWith(surface);
+
+        service.listTools({});
+
+        // The cache is shared across projections. Stamping in place would leak one projection's
+        // digest into another projection's listing, which reads as staleness that is not there.
+        expect(surface.find(tool => tool.name === 'healthcheck').description).toBe('Health Check')
+    });
+
+    test('the result reports the same digest the descriptor carries', () => {
+        const service   = serviceWith(surface),
+              {tools}   = service.listTools({}),
+              described = service.describeAdvertisedSurface();
+
+        expect(described).toMatchObject({carrierTool: 'healthcheck', toolCount: 2});
+        expect(tools.find(tool => tool.name === 'healthcheck').description).toContain(described.digest)
+    });
+
+    test('CELL 1 — matching tokens read as current', () => {
+        const service = serviceWith(surface),
+              {tools} = service.listTools({});
+
+        expect(readSurfaceVerdict({
+            cachedDescription: tools.find(tool => tool.name === 'healthcheck').description,
+            liveResult       : {advertisedSurface: service.describeAdvertisedSurface()}
+        })).toBe('current')
+    });
+
+    test('CELL 2 — a descriptor cached before a tool shipped reads as stale', () => {
+        // The observed defect this reproduces: a tool gained an action after the seat attached, the
+        // seat's cached enum rejected the call client-side, and the seat had no way to notice.
+        const attached = serviceWith(surface).listTools({}).tools
+                  .find(tool => tool.name === 'healthcheck').description,
+              liveAfter = serviceWith(grownSurface).describeAdvertisedSurface();
+
+        expect(readSurfaceVerdict({cachedDescription: attached, liveResult: {advertisedSurface: liveAfter}}))
+            .toBe('stale')
+    });
+
+    test('CELL 3 — either side missing reads as unknown, never current', () => {
+        const service = serviceWith(surface),
+              live    = {advertisedSurface: service.describeAdvertisedSurface()},
+              stamped = service.listTools({}).tools.find(tool => tool.name === 'healthcheck').description;
+
+        // A server that predates the instrument: descriptor has no token.
+        expect(readSurfaceVerdict({cachedDescription: 'Health Check', liveResult: live})).toBe('unknown');
+        // A result that could not compute one.
+        expect(readSurfaceVerdict({cachedDescription: stamped, liveResult: {}})).toBe('unknown');
+        expect(readSurfaceVerdict({cachedDescription: null, liveResult: null})).toBe('unknown')
+    });
+
+    test('the descriptor digest is scoped to the projection that was listed', () => {
+        const full = serviceWith(surface).listTools({}).tools
+                  .find(tool => tool.name === 'healthcheck').description,
+              projected = serviceWith([surface[1]]).listTools({}).tools
+                  .find(tool => tool.name === 'healthcheck').description;
+
+        // A profiled seat must not read stale merely because it was offered fewer tools.
+        expect(projected).not.toBe(full)
+    });
+
+    test('a page without the carrier carries no token, which is unknown rather than current', () => {
+        const service = serviceWith(surface),
+              {tools} = service.listTools({cursor: 0, limit: 1});
+
+        expect(tools.map(tool => tool.name)).toEqual(['alpha']);
+        expect(readSurfaceVerdict({
+            cachedDescription: tools[0].description,
+            liveResult       : {advertisedSurface: service.describeAdvertisedSurface()}
+        })).toBe('unknown')
+    })
+});

--- a/test/playwright/unit/ai/mcp/server/BaseServer.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/BaseServer.spec.mjs
@@ -919,3 +919,120 @@ test.describe('Neo.ai.mcp.server.BaseServer — plane-member boundary (#15799)',
         }
     });
 });
+
+/**
+ * Covers the result-side half of the advertised-surface staleness signal.
+ *
+ * The descriptor half is proven in `ai/mcp/advertisedSurfaceDigest.spec.mjs`; nothing there proves the
+ * server actually publishes the live value, which is the half a stale seat fetches. Without a witness
+ * here the instrument could stop firing and every other test stays green — the same shape the digest
+ * exists to remove, one layer up.
+ */
+test.describe('Neo.ai.mcp.server.BaseServer — advertised-surface descriptor on results', () => {
+    /**
+     * @summary Builds a tool service whose surface describer is observable.
+     * @param {Object} [options]
+     * @returns {Object}
+     */
+    function surfaceAwareToolService({describe, carrier = 'healthcheck', result} = {}) {
+        return {
+            surfaceDigestCarrierTool : carrier,
+            describeAdvertisedSurface: describe || (toolProjection => ({
+                carrierTool: carrier,
+                digest     : toolProjection ? 'projected0000' : 'abcdef012345',
+                toolCount  : 2
+            })),
+            listTools: () => ({tools: [], nextCursor: null}),
+            callTool : async () => result ?? {status: 'healthy'}
+        }
+    }
+
+    /**
+     * @summary Invokes the registered CallTool handler for a tool name.
+     * @param {Object} server
+     * @param {String} name
+     * @returns {Promise<Object>}
+     */
+    async function callTool(server, name) {
+        const mockMcp = makeMockMcpServer();
+
+        server.setupRequestHandlers(mockMcp);
+
+        return mockMcp.getCallToolHandler()({params: {name, arguments: {}}})
+    }
+
+    test('the carrier tool result carries the live advertised surface', async () => {
+        const toolService = surfaceAwareToolService();
+        const server      = Neo.create(makeTestServerClass({getToolService: () => toolService}));
+
+        const response = await callTool(server, 'healthcheck');
+
+        expect(response.structuredContent.advertisedSurface)
+            .toEqual({carrierTool: 'healthcheck', digest: 'abcdef012345', toolCount: 2});
+        // The pre-existing payload must survive untouched.
+        expect(response.structuredContent.status).toBe('healthy')
+    });
+
+    test('a non-carrier tool result is untouched', async () => {
+        const toolService = surfaceAwareToolService();
+        const server      = Neo.create(makeTestServerClass({getToolService: () => toolService}));
+
+        const response = await callTool(server, 'add_memory');
+
+        // The control. Without it, an implementation that decorates EVERY result satisfies the
+        // assertion above while publishing a surface token on tools that never carry one.
+        expect(response.structuredContent.advertisedSurface).toBeUndefined()
+    });
+
+    test('the digest is computed for the projection the call ran under', async () => {
+        const toolService = surfaceAwareToolService();
+        const server      = Neo.create(makeTestServerClass({
+            getToolService            : () => toolService,
+            buildToolProjectionContext: () => ({mode: 'harness'})
+        }));
+
+        const response = await callTool(server, 'healthcheck');
+
+        // A profiled seat compares against the surface it was OFFERED. Publishing the unfiltered
+        // digest would report every profiled seat permanently stale.
+        expect(response.structuredContent.advertisedSurface.digest).toBe('projected0000')
+    });
+
+    test('a describer that throws degrades to no token instead of failing the call', async () => {
+        const toolService = surfaceAwareToolService({
+            describe: () => { throw new Error('surface unreadable') }
+        });
+        const server = Neo.create(makeTestServerClass({getToolService: () => toolService}));
+
+        const response = await callTool(server, 'healthcheck');
+
+        // A stale seat may be calling healthcheck precisely to diagnose itself. Failing that call to
+        // report a freshness problem would remove the one surface it can still reach.
+        expect(response.isError).toBeFalsy();
+        expect(response.structuredContent.status).toBe('healthy');
+        expect(response.structuredContent.advertisedSurface).toBeUndefined()
+    });
+
+    test('an error result is not decorated', async () => {
+        const toolService = surfaceAwareToolService({result: {error: 'nope'}});
+        const server      = Neo.create(makeTestServerClass({getToolService: () => toolService}));
+
+        const response = await callTool(server, 'healthcheck');
+
+        expect(response.isError).toBe(true);
+        expect(JSON.stringify(response)).not.toContain('advertisedSurface')
+    });
+
+    test('a tool service without a describer still answers', async () => {
+        const server = Neo.create(makeTestServerClass({
+            getToolService: () => ({
+                listTools: () => ({tools: [], nextCursor: null}),
+                callTool : async () => ({status: 'healthy'})
+            })
+        }));
+
+        const response = await callTool(server, 'healthcheck');
+
+        expect(response.structuredContent).toEqual({status: 'healthy'})
+    })
+});


### PR DESCRIPTION
## A seat cannot currently tell a missing capability from a stale schema

Resolves #16320

Evidence: L2 (unit specs over stubbed tool services + the registered MCP handlers, run locally + exact-head CI) → L3 required for the one AC that needs a real attachment, listed under Post-Merge Validation. Residual: the connected-before-a-tool-shipped proof [#16320].

A client caches each server's tool schemas **at connect** and never revalidates, and all six servers declare `tools: {listChanged: false}`, so no refresh signal will ever arrive. A capability shipped after attach is rejected *client-side*, and the rejection quotes the cached enum as if it were the server's:

```
MCP error -32602: Invalid arguments for tool manage_wake_subscription:
  "values": ["bootstrap","subscribe","unsubscribe","update","list","resync"]
```

Read literally that says the server lacks the action. It says the *client's copy* lacks it. Reading your own tool list does not help — it is the same cache. The ticket was filed one sentence away from publishing exactly that false absence-claim.

## Why the descriptor, and why that ordering is the design

The staleness is invisible precisely because a stale client never asks again. **A new tool would be unreachable to the seats that need it** — they attached before it existed. So the attach-time token rides the `healthcheck` **description**, which is the one surface a stale attachment provably still holds, because holding it is what makes the attachment stale. The live token rides the `healthcheck` **result**. A client that changed nothing ends up holding both and can compare them.

| tokens | verdict |
|---|---|
| equal | `current` |
| different | `stale` |
| either absent | **`unknown`** — never `current` |

`unknown` is load-bearing: a server predating this instrument is indistinguishable from a fresh one, and so is a page that did not contain `healthcheck`. Reading absence as freshness would rebuild the false confidence this removes.

**Descriptions are excluded from the canonical form**, which pays twice: the published value cannot be an input to itself, and a reworded description does not fire a staleness alarm — the axis is capability *reachability*, not prose currency.

`advertisedSurface` is a separate key from `runtimeFreshness` on purpose. That block compares the server against its own disk ("did my OpenAPI change since boot"). This one compares the caller against what the server advertises now. Different question — and per the ticket, the reason the condition was invisible.

## Test Evidence

`15 passed` digest + descriptor; `53 passed` BaseServer; `573 passed` across `test/playwright/unit/ai/mcp/`.

**Mutation-proven, six mutations:**

| mutation | result |
|---|---|
| descriptor stamp → no-op | **5 failed** |
| digest includes descriptions | **2 failed** |
| stamp mutates the shared cache in place | **1 failed** |
| result attachment → pass-through | **2 failed** |
| carrier check dropped (decorate everything) | **1 failed** |
| `try`/`catch` removed from the describer call | **1 failed** |

The third mutation initially reported "13 did not run" — a syntax error, which proves nothing. Rewritten until it compiled before the red was counted.

**The BaseServer specs exist because the first cut did not have them.** `describeAdvertisedSurface` was proven directly while nothing proved the server ever *publishes* it — an instrument that could stop firing with every test green, which is the shape this ticket exists to remove, one layer up. Each behaviour carries its control: a non-carrier tool proves the decoration is targeted rather than universal, and a throwing describer proves it degrades to no token instead of failing the healthcheck a stale seat may be calling to diagnose itself.

**Six local failures are pre-existing.** Verified by reverting both source files to `895bfea945` and re-running the two suites that touch my surfaces: the same 3 fail identically without my changes. The other 3 are the known local config-template/logger set. CI is the oracle.

## Post-Merge Validation

- [ ] **L3, the AC that needs a real attachment:** a seat connected before a tool addition reads `stale` rather than reporting the capability missing. Requires a running plane and an attachment straddling a deploy, which the sandbox cannot stage.
- [ ] Confirm the token appears on every server's `healthcheck` descriptor, not only Memory Core's.

## Deltas

- `ai/mcp/ToolService.mjs` — `surfaceDigestCarrierTool` config, exported `ADVERTISED_SURFACE_DIGEST_LABEL`, `stampSurfaceDigest` (returns copies; the listing cache is shared and the digest is projection-scoped), `describeAdvertisedSurface`.
- `ai/mcp/server/BaseServer.mjs` — `attachAdvertisedSurface` on the one shared `tools/call` boundary, so all six servers are covered by one edit rather than six `HealthService` copies.
- `test/…/advertisedSurfaceDigest.spec.mjs`, `test/…/server/BaseServer.spec.mjs` — 9 + 6 specs.
- `learn/agentos/tooling/TroubleshootingToolCalls.md` — the documented procedure, placed where someone whose tool call just failed would look. That guide currently teaches "the error message is your most important clue"; this is the failure that defeats it, so the exception belongs beside the rule.
- **Substrate accretion:** one config, one exported constant, two methods, no new module, no new dependency, and the doc extends an existing file already in `learn/tree.json` rather than adding one. Sunset condition: the descriptor half retires if `listChanged: true` ever ships and clients handle the notification — at which point this becomes the fallback for clients that do not.

## Review notes

Two judgment calls worth checking.

**The label is a string literal in a description.** It is exported and asserted from one place, but it is still prose a client parses.

**Corrected after review — the original reason here was false.** I wrote that a structured field "is not available". It is: `ToolSchema` in the pinned `@modelcontextprotocol/sdk@1.29.0` carries `_meta`, the spec's designated extension point, on the Tool object itself. Verified directly — `ToolSchema.shape` is `name, title, icons, description, inputSchema, outputSchema, annotations, execution, _meta`.

The design still stands, on the reason @neo-opus-vega supplied: **survivability, not availability.** `_meta` is an optional passthrough and nothing obliges a client to retain unknown keys when caching — a client that drops it leaves a permanent `unknown`. `description` is retained because it is load-bearing for tool selection: the client must keep it to function. Correcting in place rather than quietly, because this body is graph-ingested and "no extension point exists" is the constraint the next author would inherit.

**`attachAdvertisedSurface` keys on a tool name inside `BaseServer`.** That is the shared boundary the ticket's ledger points at, and the alternative is the same decoration copied into six `HealthService` classes. I think one name check beats six copies, but it is a fair thing to push on.

Authored by @neo-opus-grace (Claude Opus 5).

