### PR TITLE
fix(component): a helix sort reorders the DOM once, not twice (#16538)

### DIFF
--- a/resources/scss/src/component/Helix.scss
+++ b/resources/scss/src/component/Helix.scss
@@ -33,6 +33,15 @@
         }
     }
 
+    // Scoped to the ITEM, not the container, unlike its siblings above. `neo-transition-100` and
+    // `-1000` are added to the Helix element and cascade down; `neo-transition-600` is added to a
+    // single expanded clone (`Helix.applyItemTransitions` vs the clone paths in `Helix.mjs`), so a
+    // container-scoped `&.neo-transition-600` copy of the pattern above would match nothing — which
+    // is how this class stayed a silent no-op while looking like it had a rule.
+    .neo-helix-item.neo-transition-600 {
+        transition: all .6s ease-in-out;
+    }
+
     .container {
         display: flex;
     }

--- a/src/component/Helix.mjs
+++ b/src/component/Helix.mjs
@@ -26,7 +26,7 @@ class Helix extends Component {
         ntype: 'helix',
         /**
          * The background color of the helix container
-         * @member {String} backgroundColor_='#000000'
+         * @member {String} backgroundColor_='#000000' ticket-ref-ok: hex colour, not an issue ref
          * @reactive
          */
         backgroundColor_: '#000000',
@@ -479,8 +479,14 @@ class Helix extends Component {
                     remove: []
                 }
             }).then(() => {
-                callback.apply(me, [callbackParam]);
-
+                // Awaited, not fire-and-forget. A transition can only START once the transform is
+                // applied, and the callback's work is unbounded — so a timer started here measures
+                // from the wrong event. Anchoring the window to the callback's completion means the
+                // class outlives the transform by construction rather than by winning a race: before
+                // the per-move layout heal was batched, the transform landed at 6780ms and the class
+                // was removed 13ms later, so the animation never ran.
+                return Promise.resolve(callback.apply(me, [callbackParam]))
+            }).then(() => {
                 timeoutId = setTimeout(() => {
                     NeoArray.remove(me.transitionTimeouts, timeoutId);
 
@@ -599,11 +605,11 @@ class Helix extends Component {
      * @protected
      */
     createItems(startIndex) {
-        let me    = this,
+        let me                                                                                           = this,
             {deltaY, itemAngle, matrix, radius, rotationAngle, translateX, translateY, translateZ, vdom} = me,
-            group = me.getItemsRoot(),
-            i     = startIndex || 0,
-            len   = Math.min(me.maxItems, me.store.count),
+            group                                                                                        = me.getItemsRoot(),
+            i                                                                                            = startIndex || 0,
+            len                                                                                          = Math.min(me.maxItems, me.store.count),
             angle, item, matrixItems, transformStyle, vdomItem, c, s, x, y, z;
 
         if (!me.mounted) {
@@ -975,12 +981,12 @@ class Helix extends Component {
      * @protected
      */
     refresh() {
-        let me     = this,
-            deltas = [],
-            {deltaY, flipped, itemAngle, matrix, radius, rotationAngle, rotationMatrix, translateX, translateY, translateZ, vdom} = me,
-            index  = 0,
-            len    = Math.min(me.maxItems, me.store.getCount()),
-            angle, item, opacity, rotateY, transformStyle, vdomItem, c, s, x, y, z;
+        let me                                                                                                              = this,
+            deltas                                                                                                          = [],
+            {deltaY, flipped, itemAngle, matrix, radius, rotationAngle, rotationMatrix, translateX, translateY, translateZ} = me,
+            index                                                                                                           = 0,
+            len                                                                                                             = Math.min(me.maxItems, me.store.getCount()),
+            angle, item, opacity, rotateY, transformStyle, c, s, x, y, z;
 
         if (flipped) {
             rotateY = Matrix.rotateY(180 * Math.PI / 180);
@@ -995,8 +1001,7 @@ class Helix extends Component {
         }
 
         for (; index < len; index++) {
-            item     = me.store.getAt(index);
-            vdomItem = vdom.cn[0].cn[0].cn[index];
+            item = me.store.getAt(index);
 
             angle = -rotationAngle + index * itemAngle;
 
@@ -1043,7 +1048,10 @@ class Helix extends Component {
             })
         }
 
-        Neo.applyDeltas(me.windowId, deltas)
+        // Returned so callers can anchor work to the transform actually being applied. `sortItems`
+        // relies on this to hold the transition window open past the transform rather than past a
+        // wall-clock timer started before it.
+        return Neo.applyDeltas(me.windowId, deltas)
     }
 
     /**
@@ -1056,34 +1064,33 @@ class Helix extends Component {
     /**
      *
      */
+    /**
+     * @summary Applies the post-sort transforms. Reordering is NOT done here.
+     *
+     * `data.Store` re-fires a sort as a `load` (`Store.onCollectionSort`), and this component binds
+     * both events — so a single sort already drives {@link Helix#onStoreLoad}, which rebuilds the item
+     * vdom in the new order and lets the differ reorder the DOM. This method used to hand-write one
+     * `moveNode` delta per item on top of that, giving every sort two independent reorder passes over
+     * the same nodes: ~1176 moves where 590 suffice, on 590 items. Node reordering is the expensive
+     * operation in this component; the transform updates below are not.
+     *
+     * The manual pass was also the reason the vdom and the real DOM diverged across a sort — it moved
+     * nodes through `Neo.applyDeltas`, which the differ never sees.
+     *
+     * @returns {Promise<*>} Resolves once the transform deltas have been applied — the caller uses this
+     * to anchor the transition window to the transform, not to a wall-clock guess.
+     */
     sortItems() {
-        let me       = this,
-            deltas   = [],
-            parentId = me.vdom.cn[0].cn[0].id,
-            i        = 0,
-            len      = Math.min(me.maxItems, me.store.getCount());
-
-        for (; i < len; i++) {
-            deltas.push({
-                action: 'moveNode',
-                id    : me.getItemVnodeId(me.getRecordId(me.store.getAt(i))),
-                index : i,
-                parentId
-            })
-        }
-
-        Neo.applyDeltas(me.windowId, deltas).then(() => {
-            me.refresh()
-        });
+        return this.refresh()
     }
 
     /**
      * @protected
      */
     updateCloneTranslate() {
-        let me           = this,
-            afterDeltas  = [],
-            deltas       = [],
+        let me          = this,
+            afterDeltas = [],
+            deltas      = [],
             timeoutId, transform;
 
         if (me.clonedItems.length > 0) {

--- a/test/playwright/unit/component/HelixSortReorder.spec.mjs
+++ b/test/playwright/unit/component/HelixSortReorder.spec.mjs
@@ -1,0 +1,168 @@
+import {setup} from '../../setup.mjs';
+
+const appName = 'HelixSortReorderTest';
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name             : appName,
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../src/Neo.mjs';
+import * as core      from '../../../../src/core/_export.mjs';
+import Helix          from '../../../../src/component/Helix.mjs';
+
+/**
+ * Guards the two structural decisions behind the helix sort regression.
+ *
+ * A single store sort drives BOTH of this component's store listeners: `data.Store.onCollectionSort`
+ * re-fires the sort as a `load`, so `onStoreLoad` rebuilds the item vdom and the differ reorders the
+ * DOM — while `onSort` used to hand-write one `moveNode` delta per item on top of it. Two independent
+ * reorder passes over the same nodes, ~1176 moves where 590 suffice.
+ *
+ * Neither assertion is timing-based. The animation itself cannot be verified from this harness (a
+ * background tab neither composites nor runs transitions), so these pin the SHAPE that made the
+ * animation impossible and leave the visual result to a rendered-tab gate.
+ */
+test.describe('Neo.component.Helix sort reordering', () => {
+    let deltaCalls, realApplyDeltas;
+
+    /**
+     * @summary Builds a Helix stub with the real methods under test and a captured delta boundary.
+     * @param {Number} itemCount Items the fake store reports.
+     * @returns {Object}
+     */
+    function helixStub(itemCount = 4) {
+        // A plain object, invoked via `Helix.prototype.<method>.call`. `Object.create(Helix.prototype)`
+        // does NOT work: Neo's Base keeps config state in a private field, so every property access on
+        // a prototype-only object throws before the method body runs. The methods under test read plain
+        // properties and the module-level `Neo`, so a literal is the honest isolation here.
+        return {
+            deltaY            : 0,
+            flipped           : false,
+            id                : 'helix-1',
+            itemAngle         : 5,
+            matrix            : {items: [], getTransformStyle: () => 'matrix3d(1,0,0,0)'},
+            maxItems          : 300,
+            mounted           : true,
+            radius            : 1500,
+            rotationAngle     : 0,
+            transitionTimeouts: [],
+            translateX        : 0,
+            translateY        : 0,
+            translateZ        : 0,
+            windowId          : 1,
+
+            calculateOpacity: () => 1,
+            getRecordId     : record => record.id,
+            getItemVnodeId  : id => `helix-1__${id}`,
+            // The REAL implementation — `sortItems` delegating to it is the behaviour under test, so
+            // stubbing it would assert the delegation and prove nothing about the deltas it emits.
+            refresh         : Helix.prototype.refresh,
+
+            store: {
+                getCount: () => itemCount,
+                getAt   : index => ({id: index})
+            }
+        }
+    }
+
+    test.beforeEach(() => {
+        deltaCalls      = [];
+        realApplyDeltas = Neo.applyDeltas;
+
+        Neo.applyDeltas = (windowId, deltas) => {
+            deltaCalls.push(Array.isArray(deltas) ? deltas : [deltas]);
+            return Promise.resolve()
+        }
+    });
+
+    test.afterEach(() => {
+        Neo.applyDeltas = realApplyDeltas
+    });
+
+    test('a sort emits NO moveNode deltas — reordering belongs to the differ, once', async () => {
+        await Helix.prototype.sortItems.call(helixStub(4));
+
+        const emitted = deltaCalls.flat();
+
+        // The regression this exists to catch is someone re-adding the manual pass "for immediacy".
+        // It reorders through `Neo.applyDeltas`, which the differ never sees, so the vdom and the real
+        // DOM diverge and the rebuild that follows redoes every move.
+        expect(emitted.filter(delta => delta.action === 'moveNode')).toHaveLength(0);
+
+        // Control: the method must still DO something, or an empty implementation passes the above.
+        expect(emitted.length).toBe(4);
+        expect(emitted.every(delta => delta.style?.transform)).toBe(true)
+    });
+
+    test('sortItems resolves only once its transform deltas are applied', async () => {
+        let applied = false;
+
+        Neo.applyDeltas = () => new Promise(resolve => {
+            setTimeout(() => {
+                applied = true;
+                resolve()
+            }, 10)
+        });
+
+        await Helix.prototype.sortItems.call(helixStub(2));
+
+        // Without the returned promise the caller cannot anchor anything to the transform, which is
+        // what left the transition window timed from an unrelated event.
+        expect(applied).toBe(true)
+    });
+
+    test('the transition window opens only AFTER the callback completes, not after the class is added', async () => {
+        const order = [];
+        let   releaseTransform;
+
+        const instance = helixStub(2);
+
+        Neo.applyDeltas = (windowId, deltas) => {
+            const payload = Array.isArray(deltas) ? deltas : [deltas];
+
+            if (payload[0]?.cls?.add?.length) {
+                order.push('class-added');
+                return Promise.resolve()
+            }
+
+            if (payload[0]?.cls?.remove?.length) {
+                order.push('class-removed');
+                return Promise.resolve()
+            }
+
+            order.push('transform-applied');
+            return Promise.resolve()
+        };
+
+        const slowCallback = () => new Promise(resolve => {
+            releaseTransform = () => {
+                order.push('transform-applied');
+                resolve()
+            }
+        });
+
+        Helix.prototype.applyItemTransitions.call(instance, slowCallback, 10);
+
+        await new Promise(resolve => setTimeout(resolve, 20));
+
+        // The class-removal timer must NOT have been scheduled yet: the callback has not finished, so
+        // the transform has not landed. Against the fire-and-forget form the timer started ~20ms ago
+        // with animationTime 10, and the class would already be gone.
+        expect(order).toEqual(['class-added']);
+        expect(instance.transitionTimeouts).toHaveLength(0);
+
+        releaseTransform();
+        await new Promise(resolve => setTimeout(resolve, 0));
+
+        expect(order).toEqual(['class-added', 'transform-applied']);
+        expect(instance.transitionTimeouts).toHaveLength(1)
+    })
+});


### PR DESCRIPTION
## One store sort was driving two independent reorder passes

Resolves #16538

Evidence: L2 (unit specs over the real methods, mutation-proven, run locally + exact-head CI) → **L3 required and NOT achieved** for the animation AC. Residual: AC 4 [#16538] — smooth animation on 600 items needs a rendered tab and is an operator gate, per the verification bound the ticket carries.

`#16533` / PR #16534 fixed the `DeltaUpdates` half. This is the Helix half, and the mechanism turned out to be findable by static read rather than measurement:

**`data.Store.onCollectionSort` re-fires a sort as a `load`** (`Store.mjs:1094`), and Helix binds *both* events (`Helix.mjs:538-540`). So one sort ran two reorder paths:

| event | handler | what it did |
|---|---|---|
| `sort` | `onSort` → `applyItemTransitions(sortItems)` | hand-wrote one `moveNode` delta per item straight to `Neo.applyDeltas` |
| `load` | `onStoreLoad` | `cn = []` + `createItems()` → `promiseUpdate()` → **the differ reorders everything** |

~1176 moves where 590 suffice, on 590 items. Node reordering is the expensive operation in this component — the transform updates are not (`updateNode` cost 7ms across 1182 calls in the same run, which is why wheel rotation sustains ~70k deltas/sec untouched).

`Store` registers its own `sort` listener in its constructor, before Helix binds, so `onStoreLoad` is *invoked* first — but it goes through the worker while the manual pass used `applyDeltas` directly, which is why the measured batches show the manual moves landing first at ~20ms and the differ's rebuild redoing them at ~50ms.

**The manual pass is also why the vdom and the real DOM diverged across a sort.** It moved nodes through `applyDeltas`, which the differ never sees.

## The three changes

**1. `sortItems` no longer reorders.** It applies transforms and returns the promise. The differ owns reordering, once.

**2. The transition window is anchored to the transform, not to the class add.** `applyItemTransitions` now awaits its callback before scheduling the class removal. Previously the `setTimeout(animationTime + 200)` started when the class was *added*, while the transition can only begin once the transform is *applied*, after unbounded work. Before the heal was batched, the transform landed at 6780ms and the class was removed 13ms later — the animation never ran. It currently wins by ~1134ms of margin, and nothing enforced that.

**3. `neo-transition-600` gets a rule that can actually match — and not the obvious one.** Its `-100` / `-1000` siblings are added to the *container* and cascade down. `-600` is added to an expanded *clone* (`Helix.mjs:747`, `:923-929`, `:1101-1111`). So the natural fix — copying `&.neo-transition-600 { .neo-helix-item {…} }` alongside its siblings — would still have matched nothing. The rule is item-scoped instead.

## Test Evidence

`3 passed` new specs, `56 passed` across `test/playwright/unit/component/`.

**Mutation-proven, three mutations, one test each:**

| mutation | result |
|---|---|
| restore the manual `moveNode` pass | **1 failed** |
| `refresh` stops returning its promise | **1 failed** |
| `applyItemTransitions` back to fire-and-forget | **1 failed** |

**A test caught a real defect I introduced.** Removing the dead `vdomItem` local, I deleted its declaration and left `vdomItem = vdom.cn[0].cn[0].cn[index]` in the loop — `vdom` was no longer destructured, so `refresh()` would have thrown `ReferenceError` on **every** call. The spec failed within two minutes. Recorded because "harmless dead-local cleanup" is exactly the change that ships unguarded.

**Isolation note:** the specs invoke `Helix.prototype.<method>.call(stub)` against a plain object. `Object.create(Helix.prototype)` does not work — Neo's `Base` keeps config state in a private field, so every property access on a prototype-only object throws before the method body runs.

## Post-Merge Validation

- [ ] **AC 4, operator gate:** sort 600 items in `examples/component/helix` on a *visible* tab, twice, with a 10s pause between. The reported failure was "first sort animates but is very slow; wait 10s and resort ⇒ fully broken". This cannot be verified from the agent harness — the browser pane reports `document.hidden: true` even when fronted, and a background tab neither composites nor runs transitions.
- [ ] Confirm the delta batches per sort drop from three to two, and that no batch contains `moveNode` from `sortItems`.

## Deltas

- `src/component/Helix.mjs` — `sortItems` delegates to `refresh`; `refresh` returns its promise and loses a dead local; `applyItemTransitions` awaits the callback.
- `resources/scss/src/component/Helix.scss` — item-scoped `neo-transition-600` rule.
- `test/playwright/unit/component/HelixSortReorder.spec.mjs` — 3 specs.
- **Substrate accretion:** net **−13 lines** of implementation. One new spec file; no new module, config or dependency.

## One drive-by, disclosed

`Helix.mjs:29` carries `@member {String} backgroundColor_='#000000'`, and `check-ticket-archaeology`'s `/#\d{4,}\b/` reads that hex colour as an issue reference — so **any** edit to this file failed the pre-commit hook on a line I never touched. I added the sanctioned `ticket-ref-ok` marker to unblock, which is the wrong layer: the guard's own docblock at `:22-24` claims the trailing `\b` "avoids matching hex colors like `#1234ff`", and it does — but only when letters follow the digits. An all-numeric colour matches. **Three files under `src/` currently fail this check** — `src/app/content/Component.mjs`, `src/collection/Base.mjs`, `src/component/Gallery.mjs` — measured by running the checker over every tracked `src/**/*.mjs`, not by counting pattern matches. (An earlier revision of this line said five; that was files *containing* a hex colour in a comment, which is a different and larger set than files that actually fail.) Filed separately rather than folded in; the marker here is a stopgap and should be removed when the pattern is fixed.

## Review notes

The judgment call worth checking: **is dropping the manual pass the right direction, or should `onStoreLoad` stop firing for a sort?** The alternative is making `Store` distinguish a sort-load from a real load — which fixes the conflation at its source but changes `data.Store` for every consumer. I took the component-local option because the blast radius is one component and the ticket scopes this as component-internal. If you think the Store-level conflation is the real defect, that is a fair push and it would supersede this shape rather than extend it.

Authored by @neo-opus-grace (Claude Opus 5).

