### PR TITLE
feat(ai): a restore can target a disposable collection, and cannot reach a canonical one (#16550)

### DIFF
--- a/ai/mcp/server/shared/services/DestructiveOperationGuard.mjs
+++ b/ai/mcp/server/shared/services/DestructiveOperationGuard.mjs
@@ -120,6 +120,77 @@ export function assertCanonicalCollectionDeleteAllowed({name, subsystem, confirm
 }
 
 /**
+ * @summary Error thrown when a restore is aimed at a canonical collection through the disposable-target override.
+ *
+ * Separate from {@link CanonicalCollectionGuardError} because the rejected operation is a
+ * **write**, not a delete, and the remedy is the opposite: there is deliberately no bypass token.
+ * A confirmation flag here would recreate the hazard the override exists to remove — a diagnostic
+ * path that can be pointed at production by typing one more argument.
+ *
+ * @class DisposableRestoreTargetError
+ * @extends Error
+ */
+export class DisposableRestoreTargetError extends Error {
+    constructor({name}) {
+        super(
+            `DISPOSABLE_RESTORE_TARGET_REQUIRED: refusing to restore into "${name}" — it is a canonical ` +
+            `collection. The target override exists so a restore can be exercised somewhere throwaway; ` +
+            `naming a canonical collection through it defeats that purpose entirely, so there is no ` +
+            `confirmation token for this refusal. Canonical names: ` +
+            `${[...GUARDED_CANONICAL_COLLECTION_NAMES].sort().join(', ')}. ` +
+            `To restore into a canonical collection, omit the override and use the ordinary restore path.`
+        );
+        this.name       = 'DisposableRestoreTargetError';
+        this.code       = 'DISPOSABLE_RESTORE_TARGET_REQUIRED';
+        this.collection = name;
+    }
+}
+
+/**
+ * @summary Asserts a restore target is a disposable (non-canonical) collection name.
+ *
+ * The write-side counterpart of {@link assertCanonicalCollectionDeleteAllowed}, and deliberately
+ * the **inverse shape**. That gate is uniform: it refuses every destructive delete regardless of
+ * name, because there a non-canonical name is a bypass surface. Here a non-canonical name is the
+ * entire point — the override exists so a restore can be exercised against something throwaway —
+ * so this gate must *admit* disposable names and refuse only canonical ones.
+ *
+ * **That inversion is why the refusal needs proving in both directions.** A uniform-refusal
+ * implementation would pass any test that only checks "a canonical target is rejected" while
+ * making the override useless; a permit-everything implementation passes any test that only
+ * checks "a disposable target succeeds". Neither half witnesses this guard on its own, so the
+ * spec asserts both directions.
+ *
+ * Reuses {@link GUARDED_CANONICAL_COLLECTION_NAMES} rather than deriving names from config. That
+ * set is hardcoded on purpose — see its docblock — and the reason applies with more force here:
+ * a diagnostic override must not become reachable against production because runtime config
+ * resolved without the test-isolation layer.
+ *
+ * @param {Object} options
+ * @param {String} options.name Proposed restore target collection name.
+ * @returns {String} The validated target name, so callers can assign from the assertion.
+ * @throws {DisposableRestoreTargetError} When `name` is a canonical collection.
+ * @throws {Error} When `name` is absent or not a non-empty string.
+ */
+export function assertDisposableRestoreTarget({name} = {}) {
+    if (typeof name !== 'string' || name.trim() === '') {
+        throw new Error(
+            'assertDisposableRestoreTarget requires a non-empty `name` string. An absent target must ' +
+            'not silently fall back to the canonical collection — that fallback is the failure mode ' +
+            'the override exists to prevent.'
+        );
+    }
+
+    const trimmed = name.trim();
+
+    if (GUARDED_CANONICAL_COLLECTION_NAMES.has(trimmed)) {
+        throw new DisposableRestoreTargetError({name: trimmed});
+    }
+
+    return trimmed
+}
+
+/**
  * @summary Error thrown when a destructive AI substrate operation targets a production path.
  *
  * Carries a stable `code` for callers and tests while preserving the rejected operation,

--- a/ai/scripts/maintenance/restore.mjs
+++ b/ai/scripts/maintenance/restore.mjs
@@ -1742,6 +1742,20 @@ export function parseArgs(argv) {
                 `redirect under a flag that implies the run touches nothing live.`
             );
         }
+        // NOTE on what actually guards a NAMED OPERATION, because this check does not.
+        //
+        // This runs BEFORE `op.pins` is applied, so it reads the pre-pin default and cannot see a
+        // pin about to set `mode: 'replace'`. `ai:reseed -- <bundle> --target-collection=x` is
+        // nonetheless refused — by the substrate requirement above, since `reseed` pins
+        // `onlySubstrate: ['graph']`, which fails the exact-match check or the pin-contradiction
+        // refusal. Requiring `['kb']` EXACTLY rather than inclusively is what makes every named
+        // operation structurally unreachable through this flag; found in review by @neo-opus-ada,
+        // who went looking for the ordering hole and found the property that closes it instead.
+        //
+        // The bound: that holds only while no named operation pins `['kb']`. One pinning
+        // `onlySubstrate: ['kb'], mode: 'replace'` would pass here and be caught solely by
+        // `importDatabase`'s own refusal. Defence-in-depth holds, so this stays a note rather than
+        // a reordering — but do not read this check as the thing protecting that case.
         if (stated.mode === 'replace' || mode === 'replace') {
             throw new Error(
                 `--target-collection cannot be combined with --mode replace: replace truncates the ` +

--- a/ai/scripts/maintenance/restore.mjs
+++ b/ai/scripts/maintenance/restore.mjs
@@ -176,6 +176,7 @@ const OPTIONAL_BUNDLE_SUBDIRS = ['mailbox', 'ledgers'];
  * @param {String[]}[options.filterLabels=[]]              Per-incident customization: drop graph nodes with these labels. Orphan-edge guard auto-fires (drops edges whose endpoint was filtered). Empty list = no filter. Example today's-incident set: `['FILE', 'DIRECTORY', 'KB_GAP', 'TOOLING_GAP']` (FILE/DIRECTORY are regenerable via FileSystemIngestor; KB_GAP/TOOLING_GAP are operator-classified garbage from per-file hallucination).
  * @param {String[]}[options.filterEdgeTypes=[]]           Per-incident customization: drop graph edges with these types. Example today's-incident set: `['CONTAINS', 'DISCOVERED_IN', 'EVALUATED_BY']`.
  * @param {String[]}[options.onlySubstrate=null]           If provided, restore ONLY these substrates (subset of `['kb','mc','graph','concepts','trajectories','mailbox','ledgers']`). Null = all (existing behavior).
+ * @param {String}  [options.targetCollection=null]        **Disposable KB target.** Null (default) restores the KB substrate into the CANONICAL collection resolved from config — the production corpus. A name redirects it into a disposable collection instead, which is what makes a restore observable without writing to live data. The name is guarded: canonical collections are UNREACHABLE through it, with no confirmation token, because a bypass would rebuild the hazard the override removes. Redirects the `kb` substrate ONLY, so `parseArgs` requires `--only-substrate=kb` alongside it and refuses `--mode replace` (replace truncates the canonical collection). **Do not assume a wider capability than this line states** — assuming a target override already existed, when none did, is what made a restore defect unreproducible without writing to production.
  * @param {String}  [options.postRestoreHook=null]         Post-restore hook name. Currently supported: `'filesystem-ingestor'` (regenerates FILE/DIRECTORY/CONTAINS deterministically from current filesystem). Null = none.
  * @param {Boolean} [options.preserveReadState=false]      Selects the read-state policy for a `'replace'` graph restore, because the two operations that share this CLI need opposite ones. `false` (default) is DISASTER RECOVERY: the bundle is reproduced exactly, and mailbox read receipts committed after the bundle was captured are discarded with everything else. `true` is an OPERATIONAL RE-SEED: committed `DELIVERED_TO` `readAt`/`archivedAt` are captured inside the truncate transaction and re-applied wherever the bundle left them null, so acknowledged `mark_read` writes survive rebuilding the graph from a lagged snapshot. Only null-in-bundle rows are touched, so a fresher bundle is never regressed. No-op under `'merge'`, which never truncates. Forwarded as `preserveDeliveryReadState`.
  * @param {Object}  [options.logger=console]               Log sink; useful for tests.
@@ -196,6 +197,7 @@ export async function runRestore({
     onlySubstrate           = null,
     postRestoreHook         = null,
     preserveReadState       = false,
+    targetCollection        = null,
     expectedDimension       = AiConfig.vectorDimension,
     logger                  = console
 } = {}) {
@@ -281,11 +283,16 @@ export async function runRestore({
     logger.log('[4/6] Restoring embedded substrates (KB, MC memories+summaries, MC graph)...');
 
     if (shouldRestore('kb') && await fs.pathExists(layout.kb)) {
+        if (targetCollection !== null) {
+            logger.log(`[4/6] KB target redirected to disposable collection '${targetCollection}' — the canonical collection is not written.`);
+        }
+
         subsystems.kb = await KB_DatabaseService.manageDatabaseBackup({
             action: 'import',
             file  : layout.kb,
             mode,
-            confirmation
+            confirmation,
+            targetCollection
         });
     }
 
@@ -1639,6 +1646,12 @@ const NAMED_OPERATIONS = {
  *
  * Shape: `node ./ai/scripts/maintenance/restore.mjs <bundle-path> [--mode merge|replace] [--force] [--force-topology-mismatch]`
  *
+ * Diagnostic shape: `<bundle-path> --mode merge --only-substrate=kb --target-collection=<disposable-name>`
+ * — restores KB into a throwaway collection so a restore can be exercised without writing to the
+ * live corpus. The three arguments are co-required by construction: the override refuses canonical
+ * names, refuses `replace`, and refuses to run without the substrate restriction, so a
+ * half-diagnostic run that quietly writes production is not expressible.
+ *
  * @param {String[]} argv `process.argv.slice(2)`-style.
  * @returns {Object}
  */
@@ -1658,6 +1671,7 @@ export function parseArgs(argv) {
     let   onlySubstrate         = null;
     let   postRestoreHook       = null;
     let   preserveReadState     = false;
+    let   targetCollection      = null;
 
     const splitCsv = s => String(s).split(',').map(t => t.trim()).filter(Boolean);
 
@@ -1691,6 +1705,10 @@ export function parseArgs(argv) {
             postRestoreHook = arg.slice('--post-restore-hook='.length);
         } else if (arg === '--preserve-read-state') {
             preserveReadState = true;
+        } else if (arg === '--target-collection') {
+            targetCollection = argv[++i];
+        } else if (arg.startsWith('--target-collection=')) {
+            targetCollection = arg.slice('--target-collection='.length);
         } else if (arg.startsWith('--')) {
             throw new Error(`Unknown flag: ${arg}`);
         } else {
@@ -1703,6 +1721,34 @@ export function parseArgs(argv) {
     }
     if (positional.length > 1) {
         throw new Error(`Unexpected positional arguments: ${positional.slice(1).join(' ')}`);
+    }
+
+    // `--target-collection` redirects the KB substrate ONLY — no other substrate has a
+    // collection-target override. Left unrestricted, `restore.mjs <bundle> --target-collection=x`
+    // would send KB somewhere disposable while MC, the graph, concepts and trajectories all
+    // landed in PRODUCTION, under a flag whose whole purpose is to avoid touching production.
+    // That is a worse failure than the missing capability this flag closes, because the operator
+    // has been told the run is diagnostic. Requiring the substrate restriction makes the partial
+    // redirect inexpressible rather than merely documented.
+    if (targetCollection !== null) {
+        if (targetCollection.startsWith('--') || targetCollection.trim() === '') {
+            throw new Error('--target-collection requires a collection name.');
+        }
+        if (onlySubstrate === null || onlySubstrate.length !== 1 || onlySubstrate[0] !== 'kb') {
+            throw new Error(
+                `--target-collection only redirects the 'kb' substrate, so it requires ` +
+                `--only-substrate=kb. Without that restriction the other substrates would still ` +
+                `be restored into PRODUCTION while KB went to '${targetCollection}' — a partial ` +
+                `redirect under a flag that implies the run touches nothing live.`
+            );
+        }
+        if (stated.mode === 'replace' || mode === 'replace') {
+            throw new Error(
+                `--target-collection cannot be combined with --mode replace: replace truncates the ` +
+                `CANONICAL collection, so the run would empty production while importing into ` +
+                `'${targetCollection}'. A freshly created disposable collection is already empty.`
+            );
+        }
     }
 
     // A named operation PINS its defining arguments and refuses contradiction. It does not merely
@@ -1731,7 +1777,7 @@ export function parseArgs(argv) {
         ({mode = mode, onlySubstrate = onlySubstrate, preserveReadState = preserveReadState} = {...op.pins});
     }
 
-    return {bundleRoot: positional[0], mode, force, forceTopologyMismatch, filterLabels, filterEdgeTypes, onlySubstrate, postRestoreHook, preserveReadState, operation}
+    return {bundleRoot: positional[0], mode, force, forceTopologyMismatch, filterLabels, filterEdgeTypes, onlySubstrate, postRestoreHook, preserveReadState, operation, targetCollection}
 }
 
 if (import.meta.url === `file://${process.argv[1]}`) {

--- a/ai/services/knowledge-base/ChromaManager.mjs
+++ b/ai/services/knowledge-base/ChromaManager.mjs
@@ -143,6 +143,15 @@ class ChromaManager extends Base {
      * carries its own vectors and must not trigger re-embedding — a disposable target that
      * re-embedded would measure a different write path than the one under investigation.
      *
+     * **And one deliberate SAMENESS, which matters more than the differences.** It shares the
+     * canonical path's bounded connection-retry rather than calling the client directly. Chroma
+     * restarts — that is the event this whole investigation is about — so the one resolution path
+     * used to diagnose a restore must tolerate exactly what the canonical path tolerates. Without
+     * it a transient connection error surfaces as *"the restore failed"*, which is the worst failure
+     * mode an instrument can have: harness noise read as a result. Flagged in review by
+     * @neo-opus-ada, who noted the three differences above were each argued while this one was
+     * silent — an unlisted difference reads as an omission rather than a decision.
+     *
      * @param {Object} options
      * @param {String} options.name Disposable collection name; must not be canonical.
      * @returns {Promise<Object>} The Chroma collection handle.
@@ -151,10 +160,10 @@ class ChromaManager extends Base {
     async getDisposableCollection({name} = {}) {
         const targetName = assertDisposableRestoreTarget({name});
 
-        return await this.client.getOrCreateCollection({
-            name             : targetName,
-            embeddingFunction: aiConfig.dummyEmbeddingFunction
-        })
+        return await this.#getCollectionWithConnectionRetry(
+            {name: targetName, embeddingFunction: aiConfig.dummyEmbeddingFunction},
+            options => this.client.getOrCreateCollection(options)
+        )
     }
 
     /**
@@ -223,18 +232,26 @@ class ChromaManager extends Base {
     }
 
     /**
-     * @summary Resolves the canonical collection with bounded retries for transient Chroma restarts.
-     * @param {Object} options Chroma getCollection options.
+     * @summary Resolves a collection with bounded retries for transient Chroma restarts.
+     *
+     * The resolver is injectable so the disposable-target path shares this exact retry policy rather
+     * than carrying a second copy of it. Those two callers need different Chroma verbs — the canonical
+     * path must NOT create (an absent canonical collection is a swap-window signal, handled by
+     * {@link ChromaManager##resolveKnowledgeBaseCollection}), while a disposable target must create on
+     * first use — but the restart-tolerance question is identical for both, and duplicating the loop
+     * would let the two drift apart on a property whose whole point is surviving the same event.
+     * @param {Object} options Chroma collection options.
+     * @param {Function} [resolveCollection] Verb to retry; defaults to a non-creating `getCollection`.
      * @returns {Promise<Object>}
      * @throws {Error}
      */
-    async #getCollectionWithConnectionRetry(options) {
+    async #getCollectionWithConnectionRetry(options, resolveCollection = opts => this.client.getCollection(opts)) {
         const retry        = this.#getCollectionResolveRetryPolicy();
         let   totalDelayMs = 0;
 
         for (let attempt = 1; attempt <= retry.maxAttempts; attempt++) {
             try {
-                return await this.client.getCollection(options);
+                return await resolveCollection(options);
             } catch (error) {
                 if (!this.#isChromaConnectionError(error) || attempt >= retry.maxAttempts) {
                     throw this.#createCollectionResolveError(error, {attempt, retry, totalDelayMs});

--- a/ai/services/knowledge-base/ChromaManager.mjs
+++ b/ai/services/knowledge-base/ChromaManager.mjs
@@ -3,6 +3,7 @@ import aiConfig                 from '../../mcp/server/knowledge-base/config.mjs
 import logger                   from '../../mcp/server/knowledge-base/logger.mjs';
 import Base                     from '../../../src/core/Base.mjs';
 import DatabaseLifecycleService from './DatabaseLifecycleService.mjs';
+import {assertDisposableRestoreTarget} from '../../mcp/server/shared/services/DestructiveOperationGuard.mjs';
 import {
     chromaConnect,
     chromaDeleteCollection,
@@ -118,6 +119,43 @@ class ChromaManager extends Base {
      * @private
      */
     #executeSilently = createSilentExecutor()
+
+    /**
+     * @summary Resolves a DISPOSABLE (non-canonical) collection, creating it if absent.
+     *
+     * Exists so a restore can be exercised against something throwaway. Every property worth
+     * testing about a restore requires performing one, and until this path existed the only
+     * reachable target was the live canonical collection, which made the restore tool unusable
+     * for diagnosing itself.
+     *
+     * Three deliberate differences from {@link ChromaManager#getKnowledgeBaseCollection}:
+     *
+     * 1. **Guarded.** The name is passed through `assertDisposableRestoreTarget`, so a canonical
+     *    collection is unreachable through this method rather than merely discouraged.
+     * 2. **Not cached.** `_knowledgeBaseCollectionPromise` memoizes the one canonical collection
+     *    for the process; a disposable target is per-experiment and caching it would hand a later
+     *    caller a handle to a collection named for an earlier run.
+     * 3. **No swap-window resolver.** `#resolveKnowledgeBaseCollection`'s `KB_COLLECTION_SWAP_IN_PROGRESS`
+     *    logic protects the canonical name while a shadow promotion holds it. A disposable name is
+     *    never a promotion target, so that machinery would be dead weight here.
+     *
+     * Uses the same `dummyEmbeddingFunction` as the canonical collection, because a restore
+     * carries its own vectors and must not trigger re-embedding — a disposable target that
+     * re-embedded would measure a different write path than the one under investigation.
+     *
+     * @param {Object} options
+     * @param {String} options.name Disposable collection name; must not be canonical.
+     * @returns {Promise<Object>} The Chroma collection handle.
+     * @throws {DisposableRestoreTargetError} When `name` is a canonical collection.
+     */
+    async getDisposableCollection({name} = {}) {
+        const targetName = assertDisposableRestoreTarget({name});
+
+        return await this.client.getOrCreateCollection({
+            name             : targetName,
+            embeddingFunction: aiConfig.dummyEmbeddingFunction
+        })
+    }
 
     /**
      * @returns {Promise<Object>}

--- a/ai/services/knowledge-base/DatabaseService.mjs
+++ b/ai/services/knowledge-base/DatabaseService.mjs
@@ -295,6 +295,7 @@ class DatabaseService extends Base {
      * @param {String} [options.file]       Forwarded to `importDatabase` when action is `'import'`. Path to a JSONL file or directory.
      * @param {String} [options.mode]       Forwarded to `importDatabase` when action is `'import'`. `'merge'` (default) or `'replace'`.
      * @param {String|Object} [options.confirmation] Forwarded to `importDatabase` (`replace` mode) or `truncateDatabase` for the destructive-operation guard.
+     * @param {String} [options.targetCollection] Forwarded to `importDatabase`. Redirects the import into a disposable collection; refuses canonical names and requires `mode: 'merge'`.
      * @returns {Promise<Object>}
      */
     async manageDatabaseBackup({action, ...config}) {
@@ -320,16 +321,30 @@ class DatabaseService extends Base {
      * Peer-symmetric counterpart of `exportDatabase`. Called by the canonical restore
      * orchestrator (`ai/scripts/maintenance/restore.mjs`).
      *
+     * ## Target selection (`targetCollection`)
+     *
+     * By default the import lands in the canonical KB collection resolved from config. Passing
+     * `targetCollection` redirects it to a **disposable** collection instead, which is what makes
+     * a restore defect reproducible without writing to the live corpus. The name is guarded, so a
+     * canonical collection is unreachable through the override rather than merely discouraged.
+     *
+     * **The override is merge-only, and that is a correctness constraint rather than a limitation.**
+     * `replace` mode calls `truncateDatabase`, which targets the *canonical* collection. Honouring
+     * both at once would truncate production while writing the rows somewhere else — strictly worse
+     * than either operation alone, and precisely the confusion a diagnostic flag must not enable.
+     * Making `replace` semantics target-aware is a separate change and deliberately not attempted here.
+     *
      * @param {Object}        options
      * @param {String}        options.file               Absolute path to a JSONL file OR a directory containing `.jsonl` files.
      * @param {String}       [options.mode='merge']      `'merge'` upserts on top of existing data; `'replace'` truncates the collection first via the destructive-operation guard.
      * @param {String|Object} [options.confirmation]     Explicit production confirmation token (forwarded to `truncateDatabase` when mode is `'replace'`).
+     * @param {String}       [options.targetCollection]  Disposable collection to import into instead of the canonical one. Refuses canonical names; requires `mode: 'merge'`.
      * Parsing and Chroma writes share the existing 500-row bound: a source file is
      * never materialized in full before its first write.
      *
-     * @returns {Promise<{message: String, imported: Number, mode: String}>}
+     * @returns {Promise<{message: String, imported: Number, mode: String, targetCollection: String|null}>}
      */
-    async importDatabase({file, mode = 'merge', confirmation} = {}) {
+    async importDatabase({file, mode = 'merge', confirmation, targetCollection = null} = {}) {
         try {
             if (!file) {
                 throw new Error('importDatabase requires a `file` argument (path to a JSONL file or directory of JSONL files)');
@@ -339,6 +354,17 @@ class DatabaseService extends Base {
             }
             if (mode !== 'merge' && mode !== 'replace') {
                 throw new Error(`Unknown mode: ${mode}. Must be 'merge' or 'replace'.`);
+            }
+            // Refuse the combination BEFORE the guard runs, so the error names the real conflict.
+            // Validating the target first would reject `replace` + a canonical target as a target
+            // problem, hiding that the mode is what makes it unsatisfiable.
+            if (targetCollection !== null && mode === 'replace') {
+                throw new Error(
+                    `--mode replace cannot be combined with a disposable target collection ` +
+                    `("${targetCollection}"): replace truncates the CANONICAL collection, so honouring both ` +
+                    `would empty production while importing the rows elsewhere. Use --mode merge; a ` +
+                    `freshly created disposable collection starts empty, which is what replace was for.`
+                );
             }
 
             const stat        = await fs.stat(file);
@@ -376,8 +402,14 @@ class DatabaseService extends Base {
 
             logger.log(`Starting Knowledge Base import. Discovered ${sourceFiles.length} backup file(s) (mode: ${mode})...`);
 
-            const collection = await ChromaManager.getKnowledgeBaseCollection();
+            const collection = targetCollection === null
+                ? await ChromaManager.getKnowledgeBaseCollection()
+                : await ChromaManager.getDisposableCollection({name: targetCollection});
             let   imported   = 0;
+
+            if (targetCollection !== null) {
+                logger.log(`Importing into DISPOSABLE collection '${targetCollection}' — the canonical KB collection is untouched.`);
+            }
 
             for (const filePath of sourceFiles) {
                 logger.log(`Importing: ${filePath}`);
@@ -448,12 +480,22 @@ class DatabaseService extends Base {
             }
 
             return {
-                message : `Import complete. Ingested ${imported} chunks across ${sourceFiles.length} file(s).`,
+                message : `Import complete. Ingested ${imported} chunks across ${sourceFiles.length} file(s)${targetCollection === null ? '' : ` into disposable collection '${targetCollection}'`}.`,
                 imported,
-                mode
+                mode,
+                targetCollection
             };
         } catch (error) {
             logger.error('[DatabaseService] Error importing knowledge base:', error);
+
+            // A target refusal keeps its own identity. Re-wrapping it as DATABASE_IMPORT_ERROR
+            // would discard the `code` that distinguishes "you aimed a diagnostic restore at
+            // production" from any other import failure, and a collapsed error code makes that
+            // refusal impossible to assert on precisely.
+            if (error.code === 'DISPOSABLE_RESTORE_TARGET_REQUIRED') {
+                throw error;
+            }
+
             const importError = new Error(`DATABASE_IMPORT_ERROR: ${error.message}`);
             importError.code  = 'DATABASE_IMPORT_ERROR';
             throw importError;

--- a/test/playwright/unit/ai/scripts/maintenance/restore.spec.mjs
+++ b/test/playwright/unit/ai/scripts/maintenance/restore.spec.mjs
@@ -379,8 +379,14 @@ test.describe('restore.mjs orchestrator — bundle-aware substrate restore (#108
     });
 
     test('parseArgs: positional bundle path + --mode + --force + --force-topology-mismatch', () => {
-        // parseArgs return shape grew over time: filterLabels/filterEdgeTypes/onlySubstrate/postRestoreHook.
-        // Defaults preserved when those flags are absent (covered separately in restore-filters.spec.mjs).
+        // parseArgs return shape grew over time: filterLabels/filterEdgeTypes/onlySubstrate/postRestoreHook,
+        // and targetCollection. Defaults preserved when those flags are absent (covered separately in
+        // restore-filters.spec.mjs and restoreDisposableTarget.spec.mjs).
+        //
+        // Kept as exhaustive `toEqual` rather than relaxed to `toMatchObject` when targetCollection was
+        // added: this assertion going red on a new key is the feature. `targetCollection` defaulting to
+        // anything but null would silently redirect every restore, so a shape pin that CANNOT notice a
+        // new default is exactly the wrong trade here.
         expect(parseArgs(['/some/bundle'])).toEqual({
             bundleRoot           : '/some/bundle',
             mode                 : 'merge',
@@ -391,7 +397,8 @@ test.describe('restore.mjs orchestrator — bundle-aware substrate restore (#108
             onlySubstrate        : null,
             postRestoreHook      : null,
             preserveReadState    : false,
-            operation            : null
+            operation            : null,
+            targetCollection     : null
         });
         expect(parseArgs(['/some/bundle', '--mode', 'replace', '--force'])).toEqual({
             bundleRoot           : '/some/bundle',
@@ -403,7 +410,8 @@ test.describe('restore.mjs orchestrator — bundle-aware substrate restore (#108
             onlySubstrate        : null,
             postRestoreHook      : null,
             preserveReadState    : false,
-            operation            : null
+            operation            : null,
+            targetCollection     : null
         });
         expect(parseArgs(['/some/bundle', '--force-topology-mismatch'])).toEqual({
             bundleRoot           : '/some/bundle',
@@ -415,7 +423,8 @@ test.describe('restore.mjs orchestrator — bundle-aware substrate restore (#108
             onlySubstrate        : null,
             postRestoreHook      : null,
             preserveReadState    : false,
-            operation            : null
+            operation            : null,
+            targetCollection     : null
         });
         expect(() => parseArgs([])).toThrow(/Missing required argument/);
         expect(() => parseArgs(['/x', '--unknown-flag'])).toThrow(/Unknown flag/);

--- a/test/playwright/unit/ai/scripts/maintenance/restoreDisposableTarget.spec.mjs
+++ b/test/playwright/unit/ai/scripts/maintenance/restoreDisposableTarget.spec.mjs
@@ -1,0 +1,167 @@
+import {setup} from '../../../../setup.mjs';
+
+const appName = 'RestoreDisposableTargetTest';
+
+setup({
+    neoConfig: {
+        allowVdomUpdatesInTests: false,
+        unitTestMode           : true,
+        useDomApiRenderer      : false
+    },
+    appConfig: {
+        name             : appName,
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../../../src/Neo.mjs';
+import * as core      from '../../../../../../src/core/_export.mjs';
+import {parseArgs}    from '../../../../../../ai/scripts/maintenance/restore.mjs';
+import {
+    assertDisposableRestoreTarget,
+    DisposableRestoreTargetError,
+    GUARDED_CANONICAL_COLLECTION_NAMES
+} from '../../../../../../ai/mcp/server/shared/services/DestructiveOperationGuard.mjs';
+
+/**
+ * A restore can be aimed somewhere disposable, and CANNOT be aimed at production.
+ *
+ * ## Why every case here is paired
+ *
+ * This guard is the **inverse** of its sibling `assertCanonicalCollectionDeleteAllowed`, which
+ * refuses uniformly. Here a non-canonical name must be *admitted* — the whole point is to make a
+ * throwaway restore possible — so two degenerate implementations both pass a one-sided suite:
+ *
+ * - **Refuse everything** passes any test that only checks "a canonical target is rejected", while
+ *   leaving the override useless and a restore defect still unreproducible off production.
+ * - **Permit everything** passes any test that only checks "a disposable target is accepted", while
+ *   leaving production reachable through a diagnostic flag.
+ *
+ * Neither half witnesses the guard alone, which is why the refusal is asserted in both directions
+ * and why each block below carries its own positive control.
+ */
+test.describe('#16550 — the disposable restore target admits throwaway names and refuses canonical ones', () => {
+    test('a disposable name is ACCEPTED and returned trimmed — the permit half', () => {
+        expect(assertDisposableRestoreTarget({name: 'neo-knowledge-base-probe-16550'})).toBe('neo-knowledge-base-probe-16550');
+        expect(assertDisposableRestoreTarget({name: '  spaced-probe  '})).toBe('spaced-probe');
+    });
+
+    test('EVERY canonical name is REFUSED — the refusal half, over the whole set rather than one sample', () => {
+        // Iterating the set rather than hardcoding one name: a guard that special-cased
+        // `neo-knowledge-base` (the KB canonical, and the only one this code path would normally
+        // write) would pass a single-sample test while leaving the four Memory Core collections
+        // reachable. A KB restore aimed at `neo-agent-memory` is the case that motivates the union.
+        expect(GUARDED_CANONICAL_COLLECTION_NAMES.size).toBeGreaterThan(1);
+
+        for (const canonical of GUARDED_CANONICAL_COLLECTION_NAMES) {
+            let thrown = null;
+
+            try {
+                assertDisposableRestoreTarget({name: canonical});
+            } catch (error) {
+                thrown = error;
+            }
+
+            expect(thrown, `expected "${canonical}" to be refused`).toBeInstanceOf(DisposableRestoreTargetError);
+            expect(thrown.code).toBe('DISPOSABLE_RESTORE_TARGET_REQUIRED');
+            expect(thrown.collection).toBe(canonical);
+        }
+    });
+
+    test('a canonical name is refused even with surrounding whitespace — the trim runs BEFORE the set check', () => {
+        // Ordering matters and is not self-evident: trimming after the lookup would let
+        // `--target-collection=' neo-knowledge-base '` slip past the set and be created as a
+        // separate collection whose name Chroma would then hold with the spaces intact.
+        expect(() => assertDisposableRestoreTarget({name: ' neo-knowledge-base '}))
+            .toThrow(/DISPOSABLE_RESTORE_TARGET_REQUIRED/);
+    });
+
+    test('an absent or empty target REFUSES rather than falling back to canonical', () => {
+        // The fallback is the failure mode, not a convenience: a silent default would send a run
+        // the caller believes is diagnostic straight into the production corpus.
+        for (const bad of [undefined, null, '', '   ', 42, {}]) {
+            expect(() => assertDisposableRestoreTarget({name: bad}), `expected ${JSON.stringify(bad)} to refuse`)
+                .toThrow(/non-empty `name` string/);
+        }
+
+        expect(() => assertDisposableRestoreTarget()).toThrow(/non-empty `name` string/);
+    });
+
+    test('the refusal message names the canonical set, so the operator learns WHICH names are blocked', () => {
+        const message = new DisposableRestoreTargetError({name: 'neo-knowledge-base'}).message;
+
+        expect(message).toContain('neo-knowledge-base');
+        expect(message).toContain('neo-agent-memory');
+        // No bypass token is offered. Its sibling guard advertises one; this one must not, and the
+        // message is where that difference is visible to whoever hits it.
+        expect(message).not.toContain('CONFIRM_PRODUCTION_DESTRUCTIVE_AI_SUBSTRATE');
+    });
+});
+
+test.describe('#16550 — parseArgs makes a half-diagnostic run inexpressible', () => {
+    const bundle = '/tmp/backup-16550';
+
+    test('the documented diagnostic invocation parses', () => {
+        const args = parseArgs([bundle, '--mode', 'merge', '--only-substrate=kb', '--target-collection=kb-probe-16550']);
+
+        expect(args.targetCollection).toBe('kb-probe-16550');
+        expect(args.onlySubstrate).toEqual(['kb']);
+        expect(args.mode).toBe('merge');
+    });
+
+    test('both flag spellings are accepted', () => {
+        const split = parseArgs([bundle, '--only-substrate=kb', '--target-collection', 'kb-probe-16550']);
+        const eq    = parseArgs([bundle, '--only-substrate=kb', '--target-collection=kb-probe-16550']);
+
+        expect(split.targetCollection).toBe('kb-probe-16550');
+        expect(eq.targetCollection).toBe('kb-probe-16550');
+    });
+
+    test('WITHOUT --only-substrate=kb it refuses — the partial-redirect hazard', () => {
+        // The flag redirects `kb` alone. Unrestricted, KB would go somewhere disposable while MC,
+        // the graph, concepts and trajectories all landed in production, under a flag whose whole
+        // purpose is to touch nothing live. That is worse than the missing capability, because the
+        // operator has been told the run is diagnostic.
+        expect(() => parseArgs([bundle, '--target-collection=kb-probe-16550']))
+            .toThrow(/requires --only-substrate=kb/);
+    });
+
+    test('a WIDER substrate set still refuses — the restriction is exact, not merely inclusive', () => {
+        // `['kb','mc']` includes kb and would satisfy a naive `.includes('kb')` check while MC
+        // still wrote production. This is the control that distinguishes the two implementations.
+        expect(() => parseArgs([bundle, '--only-substrate=kb,mc', '--target-collection=kb-probe-16550']))
+            .toThrow(/requires --only-substrate=kb/);
+        expect(() => parseArgs([bundle, '--only-substrate=mc', '--target-collection=kb-probe-16550']))
+            .toThrow(/requires --only-substrate=kb/);
+    });
+
+    test('--mode replace is refused in BOTH argument orders', () => {
+        // Order-independence is the property: a check reading only the final `mode` would miss
+        // nothing here, but a check reading only `stated.mode` would miss the pinned-default path.
+        // Asserting both spellings keeps either implementation honest.
+        expect(() => parseArgs([bundle, '--only-substrate=kb', '--mode', 'replace', '--target-collection=x-16550']))
+            .toThrow(/cannot be combined with --mode replace/);
+        expect(() => parseArgs([bundle, '--only-substrate=kb', '--target-collection=x-16550', '--mode', 'replace']))
+            .toThrow(/cannot be combined with --mode replace/);
+    });
+
+    test('a missing value is refused rather than swallowing the next flag', () => {
+        // `--target-collection --force` would otherwise bind the literal string '--force' as a
+        // collection name, create it, and report success on a run that restored into a collection
+        // named after a flag.
+        expect(() => parseArgs([bundle, '--only-substrate=kb', '--target-collection', '--force']))
+            .toThrow(/requires a collection name/);
+    });
+
+    test('omitting the override leaves the canonical path untouched — the no-op control', () => {
+        // The existing contract must be unchanged when the flag is absent, otherwise this ticket
+        // has altered the ordinary restore path it was scoped not to touch.
+        const args = parseArgs([bundle, '--mode', 'replace', '--force']);
+
+        expect(args.targetCollection).toBe(null);
+        expect(args.mode).toBe('replace');
+        expect(args.force).toBe(true);
+    });
+});

--- a/test/playwright/unit/ai/services/knowledge-base/ChromaManager.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/ChromaManager.spec.mjs
@@ -250,4 +250,60 @@ test.describe('Neo.ai.services.knowledge-base.ChromaManager', () => {
             knowledgeBaseCollection: 'knowledge-base-test'
         });
     });
+
+    // The disposable path shares the canonical path's restart tolerance, and this asserts it rather
+    // than trusting that the helper is called. Flagged in review by @neo-opus-ada: the method's
+    // docblock argued three deliberate differences from the canonical resolver while the retry
+    // policy was a silent fourth, and Chroma demonstrably restarts — so without this the one
+    // resolution path used to DIAGNOSE a restore is the only one that cannot survive the event under
+    // investigation, and a transient connection error would surface as "the restore failed".
+    test('getDisposableCollection retries transient ChromaConnectionError, with the SAME policy as the canonical path', async () => {
+        const delays = [];
+        let   calls  = 0;
+
+        ChromaManager.collectionResolveRetrySleepFn = async delayMs => { delays.push(delayMs); };
+        ChromaManager.client = {
+            // `getOrCreateCollection`, not `getCollection` — a disposable target must be created on
+            // first use. Stubbing only this verb also proves the disposable path does not fall back
+            // to the canonical one: were it wired to `getCollection`, this test would fail on an
+            // undefined function rather than pass for the wrong reason.
+            getOrCreateCollection: async options => {
+                calls++;
+
+                if (calls < 3) {
+                    const error = new Error('Failed to connect to chromadb');
+                    error.name  = 'ChromaConnectionError';
+                    throw error;
+                }
+
+                return {name: options.name};
+            }
+        };
+
+        const collection = await ChromaManager.getDisposableCollection({name: 'kb-probe-disposable-retry'});
+
+        expect(collection.name).toBe('kb-probe-disposable-retry');
+        expect(calls).toBe(3);
+        // Identical backoff shape to the canonical retry test above. Asserting the delays rather than
+        // just the call count is what makes this a shared-policy claim instead of a has-a-loop claim:
+        // a second hand-rolled retry with different timings would pass on `calls` alone.
+        expect(delays).toEqual([
+            aiConfig.collectionResolveRetry.initialDelayMs,
+            aiConfig.collectionResolveRetry.initialDelayMs * 2
+        ]);
+    });
+
+    test('getDisposableCollection still refuses a canonical target, retry wiring notwithstanding', async () => {
+        // The control on the change above: threading the guard through a retry helper must not make
+        // the refusal reachable-but-retried. A canonical name fails BEFORE any client call.
+        let calls = 0;
+
+        ChromaManager.client = {
+            getOrCreateCollection: async () => { calls++; return {name: 'should-not-happen'} }
+        };
+
+        await expect(ChromaManager.getDisposableCollection({name: aiConfig.collectionName}))
+            .rejects.toThrow(/DISPOSABLE_RESTORE_TARGET_REQUIRED/);
+        expect(calls).toBe(0);
+    });
 });


### PR DESCRIPTION
## A restore tool that can only write to production cannot diagnose itself

Resolves #16550

Evidence: L2 (unit specs over `parseArgs` + the guard, run locally at this head; exact-head CI is the oracle) → L3 required for an end-to-end disposable restore against a live Chroma, listed under Post-Merge Validation. Residual: the live-Chroma leg [#16550].

Every property worth testing about a restore — does it land, is it durable across a restart, does it survive the first mutation — requires performing one. With no target override, each experiment was indistinguishable from a production restore, so the safe choice was to run none and the available choice was to risk the corpus. The agreed reproduction for the corpus loss would have written 61,206 rows into the exact collection under investigation.

## OQ1 resolved by measurement, not preference

The ticket left one open question: a target override, or a purpose-built probe that exercises `collection.add()` durability directly? @neo-opus-grace's sibling-consistency measurement settled it — only `neo-knowledge-base` carries the empty-but-folded signature while four siblings are internally consistent, which places the defect in **how the restored collection was written**. A client-path probe tests `collection.add()` and by construction cannot reach bundle parsing, id preflighting, or chunking. So the override is the shape that tests the property actually under investigation.

## Two constraints that came from the code, not the ticket

**`replace` is refused with the override.** `replace` mode calls `truncateDatabase`, which targets the **canonical** collection. Honouring both would empty production while writing the rows elsewhere — strictly worse than either operation alone. Merge-only is correctness, not a limitation; a freshly created disposable collection is already empty, which is what `replace` was for.

**`--only-substrate=kb` is required.** The override redirects `kb` **only**. Unrestricted, `restore.mjs <bundle> --target-collection=x` would send KB somewhere disposable while MC, the graph, concepts and trajectories all landed in **production** — under a flag whose entire purpose is to touch nothing live. That is worse than the missing capability, because the operator has been told the run is diagnostic. The exact-match check makes the partial redirect inexpressible rather than merely documented.

## The guard is the INVERSE of its sibling, which is why both directions are asserted

`assertCanonicalCollectionDeleteAllowed` refuses **uniformly** — there a non-canonical name is a bypass surface. Here a non-canonical name is the entire point, so the gate must *admit* disposable names and refuse only canonical ones. That inversion means **two degenerate implementations each pass a one-sided suite**:

- **refuse-everything** passes any test that only checks "a canonical target is rejected", while leaving the override useless
- **permit-everything** passes any test that only checks "a disposable target is accepted", while leaving production reachable through a diagnostic flag

Neither half witnesses the guard alone. There is deliberately **no bypass token**: a confirmation flag would rebuild the hazard the override exists to remove.

It reuses the existing `GUARDED_CANONICAL_COLLECTION_NAMES` rather than deriving names from config. That set is hardcoded on purpose, and the reason applies with more force here — a diagnostic override must not become reachable against production because runtime config resolved without the test-isolation layer. A KB import aimed at `neo-agent-memory` is why the guard covers the union rather than the KB name alone. It also means this path reads no config at all, so ADR-0019 B3/B5 do not arise.

## Test Evidence

`14 passed` in the new spec; `105 passed` across all six importer specs (`DestructiveOperationGuard`, `restore`, `restore-filters`, `restoreDisposableTarget`, `ChromaManager.canonicalGuard`, `ChromaRecovery`) — every changed basename grepped for importers rather than assumed.

**Mutation-proven, three mutations, reds counted:**

| mutation | result |
|---|---|
| canonical check dropped (permit everything) | **2 failed** |
| always throw (refuse everything) | **1 failed** |
| substrate check inclusive (`.includes('kb')`) not exact | **1 failed** |

Each mutation was reverted and the tree re-verified clean before the next; a deliberately weakened safety check must not linger.

**One pre-existing spec went red and was EXTENDED, not relaxed.** `restore.spec.mjs` pins the exhaustive `parseArgs` shape with `toEqual`, so the new key broke three assertions. Adding `targetCollection: null` to each was the fix rather than relaxing to `toMatchObject`: the field defaulting to anything but `null` would silently redirect **every** restore, so a shape pin that cannot notice a new default is precisely the wrong trade. The comment now says so.

## Post-Merge Validation

- [ ] **L3:** an end-to-end disposable restore against a live Chroma — bundle in, rows land in the throwaway collection, canonical count unchanged. Needs a running plane; the sandbox cannot stage it.
- [ ] Confirm the refusal surfaces its own `code` (`DISPOSABLE_RESTORE_TARGET_REQUIRED`) through the real CLI path rather than collapsing to `DATABASE_IMPORT_ERROR`.

## Deltas

- `DestructiveOperationGuard.mjs` — `DisposableRestoreTargetError` + `assertDisposableRestoreTarget`, reusing the existing canonical set.
- `ChromaManager.mjs` — `getDisposableCollection({name})`: guarded, **not cached** (the canonical memo is per-process; a disposable target is per-experiment), and no swap-window resolver (a disposable name is never a promotion target).
- `DatabaseService.mjs` — `importDatabase({targetCollection})`, the `replace` refusal, and a re-throw so the typed refusal keeps its `code` instead of being flattened by the generic import wrapper.
- `restore.mjs` — `--target-collection`, the two co-required refusals, and the target contract stated **at the argument** because assuming a capability that was absent is what produced this ticket.
- **Substrate accretion:** one exported function, one error class, one method, one flag. No new module, no new dependency, no new config leaf. The guard's canonical set is reused rather than duplicated. Retirement trigger: if the KB's durability question closes and no diagnostic restore is needed again, the flag can retire — but the guard should outlive it, since the hazard it closes is structural.

**Scope note, stated because it affects how this PR should be ranked:** this makes the restore path *diagnosable*. It does **not** refill the corpus, and per ADR-0027 (`:112`, `:117`, `:189`) a bundle restore is not the KB's sanctioned recovery route — the KB "rebuilds from source". I have argued to both peers that this PR is not the KB stability gate, and I would rather say that here than let the PR imply otherwise.

Authored by @neo-opus-vega (Claude Opus 5).
