### PR TITLE
fix(deploy): size the orchestrator heap ceilings for stability, not the observed minimum (#16463)

### DIFF
--- a/ai/configBase.mjs
+++ b/ai/configBase.mjs
@@ -990,9 +990,17 @@ class ConfigBase extends ConfigProvider {
                  * it, `-1` reaches Node, which reports the flag out of bounds, **exits 0**, and
                  * continues with a ~4.5 GB heap limit — above the cgroup, converting a catchable
                  * heap error into an uncatchable kernel OOM kill with no diagnostic.
+                 *
+                 * Sized with the orchestrator container limit and the parent ceiling as one decision
+                 * — see `ai/deploy/docker-compose.yml`, the orchestrator `deploy.resources` block.
+                 * Raising this alone overruns the container; raising the container alone lifts the
+                 * implicit ceiling of any child that lacks an explicit one. Lowering it is an
+                 * optimization gated on a plane that has run unbroken long enough to show a real
+                 * steady-state maximum, not on the next incident: a crash loop wipes the logs that
+                 * would diagnose it, so an under-provisioned ceiling destroys its own evidence.
                  * @type {Number}
                  */
-                supervisedTaskHeapMb: leaf(384, 'NEO_SUPERVISED_TASK_HEAP_MB', 'number', {
+                supervisedTaskHeapMb: leaf(1024, 'NEO_SUPERVISED_TASK_HEAP_MB', 'number', {
                     parse: parseSupervisedTaskHeapMb
                 }),
                 /**

--- a/ai/deploy/docker-compose.yml
+++ b/ai/deploy/docker-compose.yml
@@ -364,36 +364,50 @@ services:
     # NODE_OPTIONS is inherited by every child and the container budget is silently multiplied by
     # the number of concurrent Node processes rather than spent once.
     #
-    # The daemon died at ~500 MB of heap, so 1024 is 2x its observed need.
-    #
-    # The concurrent-process count is NOT established, and the budget below says so rather than
-    # implying precision it does not have. What WAS observed here is 2 concurrent Node processes
-    # with two task types ever started — from a plane dying every ~3 minutes, which never reaches
-    # steady state, so hourly and daily tasks had never started at all. An idle or crash-looping
-    # plane cannot show its maximum. #16463 owns measuring it.
+    # The ceiling is NOT sized to the observed minimum. The previous 1024 was "2x the ~500 MB the
+    # daemon died at" — a sample taken while the plane crash-looped every ~3 minutes and never
+    # reached steady state, so hourly and daily tasks had never started at all. An idle or
+    # crash-looping plane cannot show its maximum, which makes that observation unable to bound the
+    # thing it was used to bound. The concurrent-process count remains unestablished; the budget
+    # below is headroom, not precision, and says so.
     #
     # `$$SERVER_ENTRYPOINT` is escaped so Compose does NOT interpolate it. It is a CONTAINER env set
     # by the Dockerfile, so config-time interpolation resolves it against the HOST environment, finds
-    # nothing, and renders `node --max-old-space-size=1024 ` — a node invocation with no script.
+    # nothing, and renders a bare `node --max-old-space-size=<n> ` — an invocation with no script.
     # `docker compose config` reports that as a warning and still exits 0, so an exit-code check
     # passes while the rendered command is broken. `$$` defers expansion to the container's own sh.
     # `${NEO_ORCHESTRATOR_HEAP_MB}` is deliberately NOT escaped: it is a deployment override and is
     # meant to resolve from the operator's environment at config time.
-    command: ["sh", "-c", "node --max-old-space-size=${NEO_ORCHESTRATOR_HEAP_MB:-1024} \"$$SERVER_ENTRYPOINT\""]
+    command: ["sh", "-c", "node --max-old-space-size=${NEO_ORCHESTRATOR_HEAP_MB:-6144} \"$$SERVER_ENTRYPOINT\""]
     deploy:
       resources:
-        # Budget, stated rather than inherited: parent 1024 + up to TWO concurrent children at 384 =
-        # 1792 MB of V8, leaving ~1.2g for native footprint across the tree. Deliberately provisional
-        # — the true concurrent maximum cannot be observed until the plane survives long enough to
-        # reach steady state, and establishing it is a gate on #16463 rather than a number guessed
-        # here. If it proves higher, the child ceiling comes down before the limit goes up.
+        # Budget, stated rather than inherited: parent 6144 + up to TWO concurrent children at 1024 =
+        # 8192 MB of V8, leaving ~3.8g for native footprint across the tree.
         #
-        # The container limit cannot be raised on its own. Node sizes its DEFAULT old-space from the
-        # cgroup, so a bigger container silently raises the implicit ceiling of every child that has
-        # no explicit one — which is the same leak in a different direction. The limit and both
-        # explicit ceilings only make sense together.
+        # These three numbers move TOGETHER and cannot be tuned independently. Node sizes its DEFAULT
+        # old-space from the cgroup, so raising the container alone silently raises the implicit
+        # ceiling of every child that has no explicit one — the same leak in a different direction.
+        # The limit, the parent ceiling, and `NEO_SUPERVISED_TASK_HEAP_MB` are one decision.
+        #
+        # ## Why these are sized for headroom rather than for the observed minimum
+        #
+        # The previous budget (3g / 1024 / 384) was derived as "2x the ~500 MB the daemon died at."
+        # That sample came from a plane crash-looping every ~3 minutes, which never reached steady
+        # state — hourly and daily tasks had never started at all, so the observation could not
+        # contain the maximum it was used to bound. A ceiling derived from a plane too broken to
+        # generate load is not a measurement of load.
+        #
+        # Deliberately generous while stability is the priority. Under-provisioning costs a crash
+        # loop, and a crash loop WIPES the orchestrator logs that would diagnose it — the failure
+        # destroys its own evidence, which is why the previous number could never be corrected from
+        # its own incidents. Over-provisioning costs reserved RAM on a host that has it: the Docker
+        # VM is 47g and the entire plane's caps summed to 7.2g against ~1.6g in actual use.
+        #
+        # Reducing these is an OPTIMIZATION, and it is gated on the plane running unbroken long
+        # enough to show a real steady-state maximum — not on the next incident. #16463 owns that
+        # measurement and now, for the first time, has a plane that can produce it.
         limits:
-          memory: 3g
+          memory: 12g
           cpus: "1.0"
 
   # Reverse proxy + TLS termination — the public ingress for the cloud Agent OS

--- a/test/playwright/unit/ai/configBase.spec.mjs
+++ b/test/playwright/unit/ai/configBase.spec.mjs
@@ -70,7 +70,12 @@ test.describe('ai/configBase — delta-only subclass overlays (overlay-drift roo
 
             // Unset resolves the leaf default — the branch a value-signature parser would have
             // thrown on, which is how the backwards first draft was caught.
-            expect(fixture.proxy.orchestrator.supervisedTaskHeapMb).toBe(384);
+            //
+            // Deliberately NOT `FALLBACK_SUPERVISED_TASK_HEAP_MB`. The two were both 384, and
+            // `Orchestrator.spec.mjs`'s injection test documents why that collision is a hazard:
+            // an assertion on the shared value passes with the injection deleted. They now differ,
+            // so this pins the leaf and only the leaf.
+            expect(fixture.proxy.orchestrator.supervisedTaskHeapMb).toBe(1024);
 
             process.env[envName] = '512';
             fixture.instance.refreshEnv();


### PR DESCRIPTION
## The ceiling was sized by a plane too broken to generate load

Resolves #16463

Evidence: L2 (config-leaf specs + exact-head CI) → **L3 achieved for the deploy half**: the running plane carries the raised parent ceiling, verified on PID 1. Residual: the steady-state maximum this ticket asks for is still being sampled — the measurement's precondition (a plane that does not crash every 5 minutes) only existed as of today.

Operator, repeatedly, while I quoted `1009 MB` as a "death point" in three separate tickets: **1 GB cannot be enough, especially multi-tenant.**

### What the number is

Not a Node default — an explicit cap at `docker-compose.yml:382`:

```yaml
node --max-old-space-size=${NEO_ORCHESTRATOR_HEAP_MB:-1024}
```

I measured `1728 MB` earlier with `docker exec … node -e`, which spawns a **fresh** node without the flag. Wrong process; the daemon is PID 1 and carries it. Recording that because it makes a decision look like an inherited default.

### Why its derivation does not hold

The comment above it is explicit about its own limits:

> *"The daemon died at ~500 MB of heap, so 1024 is 2x its observed need… from a plane dying every ~3 minutes, which never reaches steady state, so hourly and daily tasks had never started at all. **An idle or crash-looping plane cannot show its maximum.**"*

1024 = 2 × a sample from a plane that could not produce load. And the failure is **self-perpetuating**: a crash loop wipes the orchestrator logs that would diagnose it, so an under-provisioned ceiling destroys the evidence needed to correct it. That is why this number survived every incident it caused.

### Measured headroom, not a guess

| | |
|---|---|
| Docker VM | **47 g** |
| sum of all five container caps | 7.2 g |
| actual use across the whole plane | **~1.6 g** |
| orchestrator container | 3 g, **heap capped at 1 g** |
| kb-server / mc-server | 1 g containers, 560 MB heaps — proportionate |

The orchestrator's container is 3× its siblings' with a cap set as though it were the same size.

## The change

**12 g container / 6144 parent / 1024 child.** The three move together by construction — Node sizes its default old-space from the cgroup, so raising the container alone lifts the implicit ceiling of every child that lacks an explicit one. That is the inverse leak the existing comment already names, and it is why this is one commit rather than three.

Budget: 6144 + 2 × 1024 = 8192 MB of V8 inside 12 g, leaving ~3.8 g native across the tree.

**Deliberately generous while stability is the priority.** Under-provisioning costs a crash loop and its own diagnostics; over-provisioning costs reserved RAM on a host with 128 g and a 47 g VM. Reducing these is an optimization gated on the plane running unbroken long enough to show a real steady-state maximum — not on the next incident.

## `FALLBACK_SUPERVISED_TASK_HEAP_MB` stays 384, deliberately

It is documented as fallback-only for direct unit construction; the deployment value resolves through the leaf and is injected. Two reasons not to move it:

1. `Orchestrator.spec.mjs:2549` documents the two-384s collision as a **hazard** — *"asserting the default would pass with the injection line deleted… a test that cannot fail on the deletion is not covering it."* It uses `777` to escape that. Divergence removes the collision rather than relocating it.
2. `ProcessSupervisorService.spec.mjs:1134` asserts a child given `--max-old-space-size=1024` in `baseEnv` receives **384** and `.not.toContain('1024')`. Moving the fallback to 1024 would have made that assertion self-contradictory while still passing the first half.

## Test Evidence

`1100 passed` across `configBase.spec.mjs` + the orchestrator tree.

**74 failures in that tree are pre-existing on `dev`.** Established by stashing all three files and re-running the identical scope: **74 failed on the baseline, 74 with the change** — no new failures. They are unrelated to heap sizing (chroma max-runtime recycle and neighbours) and are surfaced here rather than absorbed; they deserve their own ticket.

Only one assertion changed — the leaf default in `configBase.spec.mjs`, which is precisely the value this PR changes. The ProcessSupervisor fallback specs are untouched and still pass, which is the check that the fallback decision above is real rather than asserted.

**ADR-0019:** read before authoring, per `§critical_gates` #10. The change is a default value on an existing leaf plus JSDoc — no re-derivation (A1/A3), no formula (A2/A7/A9), no hidden default or env-read (A4/A5), no export/pointer/defensive-read (B1–B3), no runtime mutation (B4), no threading (B5), no new Neo import (C1). The leaf still owns its env binding.

## Post-Merge Validation

- [ ] The raised ceilings survive a redeploy **without** `NEO_ORCHESTRATOR_HEAP_MB` in the environment — the live plane currently carries 2048 as an ephemeral deploy-time override, which reverts without this change.
- [ ] Sample steady-state orchestrator RSS over a multi-hour window now that hourly and daily tasks can start, and record it on #16463 as the first real load observation.
- [ ] Multi-tenant remains unmeasured: this plane has one tenant repo, so any number it produces is a floor for `N × ingestion`, not an answer to it.

## Deltas

- `ai/deploy/docker-compose.yml` — orchestrator `limits.memory` 3g → 12g; `NEO_ORCHESTRATOR_HEAP_MB` default 1024 → 6144; the budget comment rewritten to state why it is headroom rather than precision.
- `ai/configBase.mjs` — `supervisedTaskHeapMb` leaf 384 → 1024, with the coupling to the container limit and the parent ceiling stated at the leaf.
- `test/playwright/unit/ai/configBase.spec.mjs` — the leaf-default assertion, with a note on why it is deliberately not the fallback constant.
- **Substrate accretion:** no new module, config leaf, or dependency — three values and their rationale. Sunset condition: these come down when #16463's steady-state measurement exists, which is the ticket this resolves the blocking half of.

## Review notes

The judgment call worth checking: **is 12 g the right container size, or is it over-corrected?** I sized for the operator's explicit direction — stability first, optimize after a week of unbroken running — against a 47 g VM where the whole plane uses 1.6 g. A tighter number is defensible; what is not defensible is the previous one, whose own comment says it could not see the maximum it was bounding.

Authored by @neo-opus-grace (Claude Opus 5).
