### PR TITLE
feat(ai): a deferral streak is measurable, and survives the blocker changing (#16561)

### DIFF
--- a/ai/daemons/orchestrator/services/MaintenanceBackpressureService.mjs
+++ b/ai/daemons/orchestrator/services/MaintenanceBackpressureService.mjs
@@ -189,12 +189,18 @@ export function resolveHeavyMaintenanceLeasePath({heavyMaintenanceLeasePath, dat
 /**
  * @summary Clears all dedupe keys for a task once it is no longer deferred.
  *
+ * Also ends the task's deferral STREAK, because "no longer deferred" is exactly the streak
+ * boundary — a task that ran is a task that was not starved.
+ *
  * @param {Object} options
  * @param {Set<String>} options.deferralLogKeys Caller-owned dedup Set.
+ * @param {Map<String,String>} [options.deferralStreakStarts] Caller-owned `taskName -> ISO` streak map.
  * @param {String} options.taskName Stable orchestrator task name.
  * @returns {void}
  */
-export function clearDeferralLogState({deferralLogKeys, taskName}) {
+export function clearDeferralLogState({deferralLogKeys, deferralStreakStarts, taskName}) {
+    deferralStreakStarts?.delete(taskName);
+
     if (!deferralLogKeys) return;
     const prefix = `${taskName}:`;
     for (const key of deferralLogKeys) {
@@ -230,6 +236,7 @@ export function clearDeferralLogState({deferralLogKeys, taskName}) {
  */
 export function recordDeferral({
     deferralLogKeys,
+    deferralStreakStarts = null,
     taskName,
     reasonCode,
     reasonText,
@@ -266,11 +273,32 @@ export function recordDeferral({
         deferralLogKeys.add(dedupKey);
     }
 
+    // `deferredAt` is THIS poll. `deferredSince` is the start of the unbroken streak, and the two
+    // answer different questions — which is why an 8.5-hour backup starvation was invisible: every
+    // poll truthfully reported a deferral seconds old, and nothing accumulated them.
+    //
+    // ⚠️ Keyed on the STARVED TASK, deliberately NOT on `dedupKey`. The dedup key carries the
+    // holder (`lease-held-by-<owner>`), so a streak keyed on it restarts whenever the holder
+    // rotates — and rotation is exactly what happened: tenant-repo-sync → summary →
+    // tenant-repo-sync, three "fresh" deferrals covering one continuous 8.5-hour starvation. The
+    // streak must survive a change of blocker, because the consumer is asking how long THIS task
+    // has been unable to run, not who most recently prevented it.
+    if (deferralStreakStarts && !deferralStreakStarts.has(taskName)) {
+        deferralStreakStarts.set(taskName, new Date().toISOString());
+    }
+
     const outcomePayload = {
         reason    : reasonText,
         reasonCode,
         deferredAt: new Date().toISOString()
     };
+
+    // Absent map (direct pure-function callers that pass no streak state) reports no streak rather
+    // than a falsely-fresh one — an unmeasured streak must not read as a just-started one.
+    const deferredSince = deferralStreakStarts?.get(taskName);
+    if (deferredSince) {
+        outcomePayload.deferredSince = deferredSince;
+    }
     if (isLeaseHeld) {
         outcomePayload.holdingOwner = holderOwner;
         outcomePayload.holdingPid   = holdingLease?.pid;
@@ -377,6 +405,18 @@ export class MaintenanceBackpressureService extends Base {
      * @member {Set<String>} deferralLogKeys
      */
     deferralLogKeys = new Set()
+
+    /**
+     * Per-instance `taskName -> ISO timestamp` map recording when each task's CURRENT unbroken
+     * deferral streak began. Entries are created on a task's first deferral and removed by
+     * {@link MaintenanceBackpressureService#clearDeferralLogState} when it runs.
+     *
+     * Separate from {@link MaintenanceBackpressureService#deferralLogKeys} because that Set is keyed
+     * per blocker (`<task>:lease-held-by-<owner>`) for log dedup, and a streak must survive the
+     * blocker changing — see the note in `recordDeferral`.
+     * @member {Map<String,String>} deferralStreakStarts
+     */
+    deferralStreakStarts = new Map()
 
     /**
      * Epoch ms until which heavy-maintenance is shed (deferred). `0` = no active window. Set by the `throttle-shed`
@@ -508,7 +548,11 @@ export class MaintenanceBackpressureService extends Base {
      * @returns {void}
      */
     clearDeferralLogState(taskName) {
-        clearDeferralLogState({deferralLogKeys: this.deferralLogKeys, taskName});
+        clearDeferralLogState({
+            deferralLogKeys     : this.deferralLogKeys,
+            deferralStreakStarts: this.deferralStreakStarts,
+            taskName
+        });
     }
 
     /**
@@ -522,15 +566,16 @@ export class MaintenanceBackpressureService extends Base {
      */
     recordDeferral({taskName, reasonCode, reasonText, blockingTaskName = null, holdingLease = null}) {
         recordDeferral({
-            deferralLogKeys: this.deferralLogKeys,
+            deferralLogKeys     : this.deferralLogKeys,
+            deferralStreakStarts: this.deferralStreakStarts,
             taskName,
             reasonCode,
             reasonText,
             blockingTaskName,
             holdingLease,
-            taskDefinitions: this.taskDefinitions,
-            writeLog       : this.writeLog,
-            healthService  : this.healthService
+            taskDefinitions     : this.taskDefinitions,
+            writeLog            : this.writeLog,
+            healthService       : this.healthService
         });
     }
 

--- a/test/playwright/unit/ai/daemons/orchestrator/services/MaintenanceBackpressureService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/MaintenanceBackpressureService.spec.mjs
@@ -778,4 +778,136 @@ test.describe('MaintenanceBackpressureService — shed-window (#14284 throttle-s
         expect(called).toBe(true);    // light task ran despite the active shed-window
         expect(result).toBe('ran');
     });
+
+    // ====================================================================
+    // A deferral STREAK is measurable, and survives the blocker changing
+    //
+    // The defect: an 8.5-hour backup starvation reported `healthy` throughout, because every poll
+    // truthfully recorded a `deferredAt` seconds old and nothing accumulated them. `deferredAt`
+    // answers "when was the most recent deferral"; the consumer needs "how long has this task been
+    // unable to run". The second question had no answer anywhere in the daemon.
+    // ====================================================================
+
+    test('recordDeferral stamps deferredSince on the first deferral and holds it across polls', () => {
+        const deferralLogKeys      = new Set(),
+              deferralStreakStarts = new Map(),
+              outcomeCalls         = [],
+              healthService        = {recordTaskOutcome: (t, s, p) => outcomeCalls.push({t, s, p})};
+
+        const defer = () => recordDeferral({
+            deferralLogKeys, deferralStreakStarts, healthService,
+            taskName    : 'backup',
+            reasonCode  : 'heavy-maintenance-lease-held',
+            reasonText  : 'periodic-sweep:60000',
+            holdingLease: {owner: 'tenant-repo-sync', pid: 1}
+        });
+
+        defer();
+        const first = outcomeCalls[0].p.deferredSince;
+        expect(first).toBeTruthy();
+
+        defer();
+        defer();
+
+        // Same streak start on every later poll — otherwise the value is just `deferredAt` again
+        // under a different name, which is precisely the bug.
+        expect(outcomeCalls).toHaveLength(3);
+        expect(outcomeCalls[1].p.deferredSince).toBe(first);
+        expect(outcomeCalls[2].p.deferredSince).toBe(first);
+    });
+
+    test('the streak SURVIVES a change of blocker — the property that made 8.5h invisible', () => {
+        const deferralLogKeys      = new Set(),
+              deferralStreakStarts = new Map(),
+              outcomeCalls         = [],
+              healthService        = {recordTaskOutcome: (t, s, p) => outcomeCalls.push({t, s, p})};
+
+        const deferHeldBy = owner => recordDeferral({
+            deferralLogKeys, deferralStreakStarts, healthService,
+            taskName    : 'backup',
+            reasonCode  : 'heavy-maintenance-lease-held',
+            reasonText  : 'periodic-sweep:60000',
+            holdingLease: {owner, pid: 1}
+        });
+
+        // The real rotation: tenant-repo-sync -> summary -> tenant-repo-sync, one continuous
+        // starvation. `dedupKey` embeds the holder, so a streak keyed on it would restart three
+        // times and report three fresh deferrals — which is what actually happened.
+        deferHeldBy('tenant-repo-sync');
+        const streakStart = outcomeCalls[0].p.deferredSince;
+
+        deferHeldBy('summary');
+        deferHeldBy('tenant-repo-sync');
+
+        expect(outcomeCalls[1].p.deferredSince).toBe(streakStart);
+        expect(outcomeCalls[2].p.deferredSince).toBe(streakStart);
+        // Control: the holder really did change, so this is not passing because the rotation was a no-op.
+        expect(outcomeCalls.map(c => c.p.holdingOwner)).toEqual(['tenant-repo-sync', 'summary', 'tenant-repo-sync']);
+        // And the dedup keys really did diverge, which is what a dedupKey-based streak would have split on.
+        expect(deferralLogKeys.size).toBe(2);
+    });
+
+    test('running the task ENDS the streak, so a later deferral starts a new one', () => {
+        const deferralLogKeys      = new Set(),
+              deferralStreakStarts = new Map(),
+              outcomeCalls         = [],
+              healthService        = {recordTaskOutcome: (t, s, p) => outcomeCalls.push({t, s, p})};
+
+        const defer = () => recordDeferral({
+            deferralLogKeys, deferralStreakStarts, healthService,
+            taskName    : 'backup',
+            reasonCode  : 'heavy-maintenance-lease-held',
+            reasonText  : 'periodic-sweep:60000',
+            holdingLease: {owner: 'tenant-repo-sync', pid: 1}
+        });
+
+        defer();
+        expect(deferralStreakStarts.has('backup')).toBe(true);
+
+        // The streak boundary is "the task ran", which is exactly what clearDeferralLogState marks.
+        clearDeferralLogState({deferralLogKeys, deferralStreakStarts, taskName: 'backup'});
+        expect(deferralStreakStarts.has('backup')).toBe(false);
+
+        defer();
+
+        // A task that ran and is later deferred again is NOT still starved from before — otherwise a
+        // resolved starvation reports forever and the signal gets ignored.
+        //
+        // Asserted as a STATE transition rather than timestamp inequality: two deferrals inside one
+        // millisecond produce identical `toISOString()` values, so `not.toBe` on the strings fails
+        // for a clock-resolution reason that has nothing to do with the property. (It did, on the
+        // first run of this spec.) What matters is that the entry was deleted and RE-CREATED, and
+        // that the emitted value is read live from the map rather than carried over in a payload.
+        expect(deferralStreakStarts.has('backup')).toBe(true);
+        expect(outcomeCalls[1].p.deferredSince).toBe(deferralStreakStarts.get('backup'));
+        expect(outcomeCalls).toHaveLength(2);
+    });
+
+    test('clearDeferralLogState scopes the streak reset to its own task', () => {
+        const deferralStreakStarts = new Map([['backup', 'A'], ['kbSync', 'B']]);
+
+        clearDeferralLogState({deferralLogKeys: new Set(), deferralStreakStarts, taskName: 'backup'});
+
+        // Positive control on the same call: clearing one task must not clear a co-starved sibling.
+        expect(deferralStreakStarts.has('backup')).toBe(false);
+        expect(deferralStreakStarts.get('kbSync')).toBe('B');
+    });
+
+    test('no streak map ⇒ NO deferredSince, rather than a falsely-fresh one', () => {
+        const outcomeCalls  = [],
+              healthService = {recordTaskOutcome: (t, s, p) => outcomeCalls.push({t, s, p})};
+
+        recordDeferral({
+            deferralLogKeys: new Set(), healthService,
+            taskName       : 'backup',
+            reasonCode     : 'heavy-maintenance-lease-held',
+            reasonText     : 'periodic-sweep:60000',
+            holdingLease   : {owner: 'tenant-repo-sync', pid: 1}
+        });
+
+        // An unmeasured streak must be absent, never stamped with `now` — a consumer reading a
+        // just-started streak would conclude the task is fine, which is worse than no field.
+        expect(outcomeCalls[0].p.deferredSince).toBeUndefined();
+        expect(outcomeCalls[0].p.deferredAt).toBeTruthy();
+    });
 });


### PR DESCRIPTION
## An 8.5-hour starvation reported `healthy`, because nothing accumulated the deferrals

Resolves #16564

Related: #16561

⚠️ **Close-target split, twice-corrected.** @neo-opus-grace's RA was right that `Resolves #16561` over-claimed — that ticket's stated problem is the starvation, which this PR deliberately does not fix. My first correction changed it to `Refs #16561`, which was **also wrong**: `agent-pr-body-lint.yml:72` makes `Resolves #N` mandatory on every non-draft agent PR, and `:97` states `Refs`/`Related` alone is not sufficient. Flagged by @tobiu before it failed CI.

The linter names the correct remedy itself at `:75` — *"it must become an epic + subs or be split"* — which is also the pr-review guide's §5.2 instruction (*isolate one delivered leaf as `Resolves #M`*). So **#16564** is that leaf: the starvation was **unmeasurable**, which is what this diff fixes. **#16561** keeps the starvation and its repair, and is now `Related:` rather than closed.

Evidence: L2 (unit specs over the real `recordDeferral` / `clearDeferralLogState`, mutation-proven, 1175 passed across the orchestrator tree locally + exact-head CI) → L3 required to observe `deferredSince` on the live plane, listed under Post-Merge Validation.

Measured live at 18:1xZ on an otherwise healthy deployment — 5 containers up, orchestrator 0 restarts / 0 OOMs since `5902ba0aa735`:

```
lease owner : tenant-repo-sync   acquiredAt 17:54:23Z   staleAfterMs 6h
last backup : backup-2026-08-05T09-39-56.157Z          ← 8.5 h earlier
```

`deferredAt` answers *"when was the most recent deferral"*. The consumer needs *"how long has this task been unable to run"*. **The second question had no answer anywhere in the daemon** — so every poll truthfully reported a deferral seconds old and the aggregate was never formed.

## What I expected to be wrong, and was not

My first hypothesis: `picker.mjs`'s `stalenessRatio` is `(now - lastRunAt) / cadenceMs`, so a 24 h-cadence backup 8.5 h late scores **0.35** while a 60 s-cadence task 2 min late scores **2.0** — cadence normalisation deprioritising the backup.

**Falsified.** `pipeline.mjs:13` — `PRIORITY_ZERO_TASKS = Object.freeze(['backup'])`. Backup outranks everything before the ratio can matter. Recording it because it is the plausible fix that would have been a no-op looking like a repair, and it would have closed the ticket while the starvation continued.

The actual mechanism: **winning selection does not get you the lease.** The picker names `backup`, acquisition fails with `heavy-maintenance-lease-held`, and a 60 s-cadence holder can re-acquire before the next poll reaches it. 6 h `staleAfterMs` is the only backstop.

## The change

`deferralStreakStarts` (`taskName -> ISO`), stamped on a task's first deferral, emitted as `deferredSince` beside the existing `deferredAt`, ended by `clearDeferralLogState` — which **already marks the exact boundary**, since a task that ran is a task that was not starved. Reuses the existing lifecycle rather than adding a second one.

### Keyed on the starved task, deliberately not on `dedupKey`

`dedupKey` embeds the holder (`lease-held-by-<owner>`) for log dedup. A streak keyed on it **restarts whenever the holder rotates** — and rotation is exactly what happened: `tenant-repo-sync → summary → tenant-repo-sync`, three "fresh" deferrals covering one continuous starvation. That is the bug, not an edge case, so the spec asserts the streak survives a blocker change and carries two controls: the holder really did rotate, and the dedup keys really did diverge (`size === 2`).

An absent map emits **no** `deferredSince` rather than stamping `now`. A falsely-fresh streak is worse than a missing field — a consumer reading a just-started streak concludes the task is fine.

## Test Evidence

`41 passed` in the service spec; **`1175 passed / 0 failed`** across `test/playwright/unit/ai/daemons/orchestrator/`.

**Mutation-proven:**

| mutation | result |
|---|---|
| key the streak on `dedupKey` instead of `taskName` | **2 failed** — including the holder-rotation case |

That mutation *reproduces the original defect*, which is the mutation worth having: it fails the same way production did.

**One spec was rewritten before landing, and the reason is worth recording.** I first asserted timestamp inequality across a clear + re-defer. It failed — two deferrals inside one millisecond produce identical `toISOString()` values, so the assertion was testing clock resolution rather than the property. Re-asserted as a state transition (entry deleted, re-created, and the emitted value read live from the map), which is clock-independent and closer to what matters.

## Post-Merge Validation

- [ ] **L3:** confirm `deferredSince` appears on a real deferred `backup` outcome on the live plane, read from the orchestrator health payload — and that it holds steady across polls rather than tracking `deferredAt`.
- [ ] Confirm it clears when the backup finally runs.
- [ ] **Deliberately not claimed:** nothing here makes the backup *run*. Starvation becomes visible; it does not become impossible.

### OQ1 is cheaper than this PR's body implied — @neo-opus-grace's census, verified independently

I scoped OQ1 as a design fork (build lease fairness vs bounded-wait preemption) and wrote into #16561 that *"fairness is not expressible in the current shape."* **That is false, and the correction is hers.**

`shouldYieldHeavyMaintenanceLease` (`heavyMaintenanceLeasePrimitives.mjs:203`) is a shipped cooperative-yield primitive whose docblock names this exact case, and `maxActiveHoldMs` is **live and configured** at `configBase.mjs:1292` (`HOUR_MS / 2` — 30 minutes). Caller census, re-run by me rather than accepted:

| module | polls `shouldYield` |
|---|---|
| `VectorService.mjs` (via `syncKnowledgeBase`) | **10 matches** |
| `TenantRepoSyncService.mjs` | **0** |
| `summarize-sessions.mjs` | **0** |

**The two holders I measured starving the backup are exactly the two that do not opt in.** `kbSync`, which does, held for a multi-hour re-embed today and yielded on schedule without starving anything.

So the repair is not "build fairness" — it is two existing tasks calling an existing, tested, config-driven primitive. My miss was reading the lease through `isHeavyMaintenanceLeaseActive` (a boolean) plus the lease file's absent waiter set, and concluding fairness needed new machinery. Cooperative yield needs no waiter set: the holder yields on elapsed hold time. Grace notes `isLeaseStale` sits directly above the primitive and reads like the whole story, and that she drew a wrong conclusion from the same adjacency two hours earlier.

That repair is #16561's follow-up lane, not this PR's scope — `deferredSince` is still what proves it worked.

## Deltas

- `ai/daemons/orchestrator/services/MaintenanceBackpressureService.mjs` — `deferralStreakStarts` member; `recordDeferral` stamps + emits `deferredSince`; `clearDeferralLogState` ends the streak. Both pure functions take the map as a caller-owned parameter, matching the existing `deferralLogKeys` pattern.
- `test/playwright/unit/ai/daemons/orchestrator/services/MaintenanceBackpressureService.spec.mjs` — 5 specs: first-stamp-and-hold, survives-blocker-change (2 controls), run-ends-the-streak, per-task scoping (positive control on a co-starved sibling), and absent-map-emits-nothing.
- **Substrate accretion:** one `Map` member and one optional parameter on two existing functions. No new module, no new config leaf, no new dependency, no scheduling change. Sunset condition: if OQ1 resolves to lease-level fairness, `deferredSince` becomes that policy's input rather than a standalone signal — it does not become redundant, since a fairness policy still needs to know who has waited longest.

Authored by @neo-opus-vega (Claude Opus 5).
