### PR TITLE
A small external repo is the cheap proof subject for pull-mode ingestion (#16573)

### DIFF
--- a/ai/deploy/kb-config.yaml
+++ b/ai/deploy/kb-config.yaml
@@ -1,6 +1,20 @@
-# N=1 tenant bootstrap: registers neomjs/neo as its own pull-mode KB tenant, so the containerized
-# plane ingests the repo (docs, src, and the hourly datasync artifacts under resources/content/)
-# and `ask_knowledge_base` answers from the current head instead of the last restore snapshot.
+# Tenant bootstrap for the containerized plane's pull-mode KB ingestion. Two repos under one
+# tenant (`neo-shared`), keyed as `tenantId/repoSlug`:
+#
+#   neo-shared/neo         — the Neo repo itself (docs, src, and the hourly datasync artifacts under
+#                            resources/content/), so `ask_knowledge_base` answers from the current
+#                            head instead of the last restore snapshot.
+#   neo-shared/create-app  — the scaffolding repo. Small on purpose: first-ingest cost scales with
+#                            tracked-file count on a blobless mirror (~0.42 s/file cold, #16557), so
+#                            a tiny repo is the cheap end-to-end PROOF that pull-mode ingestion works
+#                            — `lastIngestedRev` going non-null is the artifact no unit test provides.
+#                            It is also the only tenant here that is genuinely EXTERNAL to the
+#                            maintainer checkout, so it exercises the lane's actual purpose rather
+#                            than re-ingesting the corpus `kbSync` already owns.
+#
+# `branchRef` is per-repo and NOT inheritable: neo integrates on `dev`, create-app has only `main`
+# (verified against the remote — it has no `dev` branch at all). Copying a sibling's `branchRef` is
+# a clone failure waiting to happen.
 #
 # Read fail-soft from `<neoRootDir>/kb-config.yaml` — tier 2 of the tenant-config resolution
 # (KnowledgeBaseTenantConfig graph node → THIS file → aiConfig defaults). The document root is a
@@ -21,3 +35,8 @@ tenants:
         cloneUrl     : https://github.com/neomjs/neo.git
         credentialRef: none
         branchRef    : dev
+      - tenantId: neo-shared
+        repoSlug     : create-app
+        cloneUrl     : https://github.com/neomjs/create-app.git
+        credentialRef: none
+        branchRef    : main

--- a/test/playwright/unit/ai/deploy/KbTenantBootstrapContract.spec.mjs
+++ b/test/playwright/unit/ai/deploy/KbTenantBootstrapContract.spec.mjs
@@ -27,7 +27,7 @@ import {load}         from 'js-yaml';
 const yamlLoad = (source, {compose = false} = {}) => load(compose ? source.replace(/!override/g, '') : source);
 
 /**
- * Guards the tracked N=1 tenant bootstrap (`ai/deploy/kb-config.yaml`) through the PRODUCTION
+ * Guards the tracked tenant bootstrap (`ai/deploy/kb-config.yaml`) through the PRODUCTION
  * read and normalization paths — not a schema the test invents.
  *
  * The deployment mounts this file at `<neoRootDir>/kb-config.yaml`, where the tenant-config
@@ -43,7 +43,7 @@ const
     overlayRel   = 'ai/deploy/docker-compose.local-agent-os.yml',
     MOUNT_ENTRY  = './kb-config.yaml:/app/kb-config.yaml:ro';
 
-test.describe('ai/deploy/kb-config.yaml — N=1 tenant bootstrap contract', () => {
+test.describe('ai/deploy/kb-config.yaml — tenant bootstrap contract', () => {
     let IngestionService, normalizeTenantRepoEntry;
 
     test.beforeAll(async () => {
@@ -67,20 +67,55 @@ test.describe('ai/deploy/kb-config.yaml — N=1 tenant bootstrap contract', () =
         expect(Object.keys(result.document.tenants)).toEqual(['neo-shared'])
     });
 
-    test('the neo entry normalizes through the production contract to exactly one neo-shared/neo repo', () => {
+    test('both entries normalize through the production contract under one neo-shared tenant', () => {
         const
             document = yamlLoad(fs.readFileSync(path.join(repoRoot, bootstrapRel), 'utf8')),
             repos    = document.tenants['neo-shared'].tenantRepos;
 
-        expect(repos).toHaveLength(1);
+        expect(repos).toHaveLength(2);
 
-        const normalized = normalizeTenantRepoEntry(repos[0]);
+        const normalized = repos.map(normalizeTenantRepoEntry);
 
-        expect(normalized.tenantId).toBe('neo-shared');
-        expect(normalized.repoSlug).toBe('neo');
-        expect(normalized.cloneUrl).toBe('https://github.com/neomjs/neo.git');
-        expect(normalized.credentialRef).toBe('none');
-        expect(normalized.branchRef).toBe('dev')
+        expect(normalized[0].tenantId).toBe('neo-shared');
+        expect(normalized[0].repoSlug).toBe('neo');
+        expect(normalized[0].cloneUrl).toBe('https://github.com/neomjs/neo.git');
+        expect(normalized[0].credentialRef).toBe('none');
+        expect(normalized[0].branchRef).toBe('dev');
+
+        expect(normalized[1].tenantId).toBe('neo-shared');
+        expect(normalized[1].repoSlug).toBe('create-app');
+        expect(normalized[1].cloneUrl).toBe('https://github.com/neomjs/create-app.git');
+        expect(normalized[1].credentialRef).toBe('none');
+        expect(normalized[1].branchRef).toBe('main')
+    });
+
+    test('repo identity is unique per tenantId/repoSlug, which is what keeps the two corpora apart', () => {
+        // The chunk id is sha256 over {tenantId, repoSlug, hash, type, name, source}, so two entries
+        // sharing a tenantId are only safe while their repoSlug differs. A duplicate pair would
+        // silently collapse two repos into one identity namespace instead of failing loudly.
+        const
+            document = yamlLoad(fs.readFileSync(path.join(repoRoot, bootstrapRel), 'utf8')),
+            keys     = document.tenants['neo-shared'].tenantRepos
+                .map(normalizeTenantRepoEntry)
+                .map(repo => `${repo.tenantId}/${repo.repoSlug}`);
+
+        expect(new Set(keys).size).toBe(keys.length);
+        expect(keys).toEqual(['neo-shared/neo', 'neo-shared/create-app'])
+    });
+
+    test('branchRef is declared per repo and never inherited from a sibling', () => {
+        // create-app has no `dev` branch at all (verified against the remote), so inheriting neo's
+        // `dev` would make its clone fail. This pins that the two differ ON PURPOSE — a future
+        // normalization that defaults a missing branchRef from a sibling breaks this.
+        const
+            document = yamlLoad(fs.readFileSync(path.join(repoRoot, bootstrapRel), 'utf8')),
+            bySlug   = Object.fromEntries(document.tenants['neo-shared'].tenantRepos
+                .map(normalizeTenantRepoEntry)
+                .map(repo => [repo.repoSlug, repo.branchRef]));
+
+        expect(bySlug.neo).toBe('dev');
+        expect(bySlug['create-app']).toBe('main');
+        expect(bySlug.neo).not.toBe(bySlug['create-app'])
     });
 
     test('exactly the two consuming services mount the bootstrap read-only in the local-agent-os overlay', () => {


### PR DESCRIPTION
## The only proof subject we had was the most expensive one

Resolves #16573

Related: #16566 (the embed-stage blocker this makes affordable to prove) · #16557 (why file count dominates first-ingest cost)

`ai/deploy/kb-config.yaml` registered exactly one tenant repo — `neo-shared/neo`, the maintainer checkout's own corpus at **23,952 tracked files**. On a blobless mirror a cold content read costs ~**0.42 s/file** (#16557), so every attempt to answer *"does pull-mode ingestion work at all"* was a multi-hour operation. And because `kbSync` already owns that corpus (both lanes are container-plane since #16556), the one registered tenant **duplicated** a corpus rather than adding one — leaving the lane's actual purpose, pulling content the plane does not have, unexercised.

This registers `neomjs/create-app` as a second repo under the existing `neo-shared` tenant: small, public, genuinely external. It makes the end-to-end proof cheap and repeatable.

Evidence: L2 (contract spec over the tracked file through the production reader + normalizer, `7 passed`) → L3 is what #16566's proof AC requires and is explicitly **not** claimed here.

## What I verified before writing the entry, and why it mattered

**`create-app` has only `main` — no `dev` branch at all.**

```
gh repo view neomjs/create-app  →  default=main  private=false  vis=PUBLIC
gh api repos/neomjs/create-app/branches  →  main
```

The obvious move is to copy the sibling `neo` entry, which carries `branchRef: dev`. That would have produced a clone failure against a branch that does not exist. `branchRef` is per-repo and not inheritable, so the config comment says so and a spec now pins that the two values differ **on purpose** — otherwise a future "helpfully default a missing branchRef from a sibling" normalization silently reintroduces the bug.

## Why the identity assertion is in here

The chunk id is `sha256({tenantId, repoSlug, hash, type, name, source})` (`VectorService.createTenantAwareChunkId`). Two entries sharing a `tenantId` are only safe while their `repoSlug` differs — a duplicate pair would **silently merge two repos into one identity namespace** instead of failing loudly. Adding a second repo under an existing tenant is exactly when that invariant starts mattering, so it gets a test now rather than after a collision.

`tenantCount` deliberately stays **1**: this is a second repo under one tenant, not a second tenant.

## Test Evidence

`7 passed (3.5s)` — `npx playwright test -c test/playwright/playwright.config.unit.mjs test/playwright/unit/ai/deploy/KbTenantBootstrapContract.spec.mjs --workers=1`

The spec reads the **tracked file** and runs it through the **production** reader (`IngestionService.readKbConfigBootstrapResult`) and normalizer (`normalizeTenantRepoEntry`) — not a fixture, so it cannot pass while the deployed config is wrong.

| test | pins |
|---|---|
| loads through the production bootstrap reader | `status: loaded`, `tenantCount: 1`, tenants `['neo-shared']` |
| both entries normalize under one tenant | full normalized shape of both repos, including `branchRef` `dev` vs `main` |
| identity unique per `tenantId/repoSlug` | `['neo-shared/neo', 'neo-shared/create-app']`, no duplicates |
| `branchRef` never inherited | `neo=dev`, `create-app=main`, and asserts they differ |
| exactly two services mount it read-only | `['kb-server', 'orchestrator']` — unchanged |

**Pre-existing assertion tightened, not relaxed:** the old spec asserted `repos` had length 1 and checked `repos[0]`. It now asserts length 2 and checks both entries field-by-field. Coverage went up.

## Post-Merge Validation

- [ ] Confirm the new entry reaches the deployed plane: `snapshot.tenantRepoSync.repos` goes from 1 to 2 and `neo-shared/create-app` appears. Note the containers mount this file, so it needs a redeploy or remount to take effect — it is not hot-reloaded.
- [ ] A newly-registered repo carries **no backoff**, so the 60 s lane sweep (`periodic-sweep:60000`) should attempt it within about a minute of becoming visible — no manual trigger needed.
- [ ] **Deliberately not claimed:** this does not make ingestion succeed. `KB_VECTOR_EMBED_FAILED` (#16566) still blocks the embed stage, and the first attempt on `create-app` is expected to fail the same way. What changes is that the retry loop is now cheap: a small repo means the clone-and-attempt cycle is seconds, so the embed fix can be validated in minutes.
- [ ] The proof run belongs against an **idle embedder** — a run concurrent with `kbSync` reproduces the contention failure documented on #16566 and proves nothing.

## Deltas

- `ai/deploy/kb-config.yaml` — adds the `neo-shared/create-app` entry (`credentialRef: none`, `branchRef: main`); header rewritten to describe both repos, why the small external one exists, and that `branchRef` is per-repo and not inheritable.
- `test/playwright/unit/ai/deploy/KbTenantBootstrapContract.spec.mjs` — the one-repo assertion becomes a two-repo assertion; two new tests (identity uniqueness, per-repo `branchRef`); stale `N=1` wording dropped from the describe title and module docblock.
- **Substrate accretion:** one YAML entry plus two tests, no new module, no new config leaf, no code path. The tests guard invariants that only become reachable once a second repo exists, so they arrive with the thing that needs them. Retirement: if a per-tenant include-manifest lands (the separate contract lane named in the config header), the whole-tree assumption these entries ride changes and this file's shape gets revisited with it.

Authored by @neo-opus-vega (Claude Opus 5).
