### PR TITLE
A multi-cause ingest failure names every cause, not the first (#16575)

### DIFF
--- a/ai/daemons/orchestrator/services/TenantRepoSyncService.mjs
+++ b/ai/daemons/orchestrator/services/TenantRepoSyncService.mjs
@@ -241,14 +241,32 @@ function assertErrorFreeIngestionSummary(summary) {
     }
 
     if (summary.errors.length > 0) {
-        const error      = new Error('Knowledge Base ingestion returned an error-bearing summary.');
-        const sourceCode = summary.errors
-            .map(item => item?.code)
-            .find(code => typeof code === 'string' && BOUNDED_KB_ERROR_CODE_PATTERN.test(code));
+        const error = new Error('Knowledge Base ingestion returned an error-bearing summary.');
 
-        if (sourceCode) {
-            error.sourceErrorCode = sourceCode
+        // Every DISTINCT bounded code, not only the first. A failing ingest can carry several
+        // independent causes (an embed failure alongside a per-file parse failure, say), and
+        // reporting one of them made a multi-cause failure read as single-cause — the operator
+        // fixes the reported code and the lane fails identically on the next sweep.
+        //
+        // This stays inside the credential boundary by construction: BOUNDED_KB_ERROR_CODE_PATTERN
+        // admits only `KB_[A-Z0-9_]{1,120}`, so a code cannot carry a clone URL, a token, or
+        // stderr. That is exactly why the codes are safe to widen while the messages and details
+        // remain deliberately uncopied (see this function's docblock).
+        const sourceCodes = [...new Set(summary.errors
+            .map(item => item?.code)
+            .filter(code => typeof code === 'string' && BOUNDED_KB_ERROR_CODE_PATTERN.test(code)))];
+
+        if (sourceCodes.length > 0) {
+            // `sourceErrorCode` keeps its exact prior meaning (the first bounded code) so every
+            // existing consumer — `getSourceErrorCode`, `lastSourceErrorCode` — is unchanged.
+            error.sourceErrorCode  = sourceCodes[0];
+            error.sourceErrorCodes = sourceCodes
         }
+
+        // Total error count, INCLUDING entries whose code was unbounded or absent. Without it,
+        // "one reported code" is indistinguishable from "one error", so a partial ingest that
+        // failed 400 files looks like it failed one.
+        error.sourceErrorCount = summary.errors.length;
 
         throw error
     }
@@ -1375,7 +1393,17 @@ class TenantRepoSyncService extends Base {
                 const code            = isTenantRepoSyncErrorCode(e.code) ? e.code : KB_TENANT_REPO_SYNC_SYNC_FAILED;
                 const sourceErrorCode = getSourceErrorCode(e, code);
                 const sourceSuffix    = sourceErrorCode ? ` source=${sourceErrorCode}` : '';
-                writeLog?.('ERROR', `[TenantRepoSync] ${repoLabel} failed: ${code}${sourceSuffix} (${e.message})`);
+                // Additional bounded codes and the total error count, so a multi-cause failure does
+                // not read as single-cause. Both are omitted when they would add nothing (one code,
+                // or a count that is not a useful number), keeping the single-cause line unchanged.
+                const otherCodes = Array.isArray(e?.sourceErrorCodes)
+                    ? e.sourceErrorCodes.filter(candidate => candidate !== sourceErrorCode)
+                    : [];
+                const alsoSuffix  = otherCodes.length > 0 ? ` also=${otherCodes.join(',')}` : '';
+                const countSuffix = Number.isInteger(e?.sourceErrorCount) && e.sourceErrorCount > 1
+                    ? ` errors=${e.sourceErrorCount}`
+                    : '';
+                writeLog?.('ERROR', `[TenantRepoSync] ${repoLabel} failed: ${code}${sourceSuffix}${alsoSuffix}${countSuffix} (${e.message})`);
 
                 if (slotAcquired && !accessConfirmed) {
                     this.recordTenantRepoAccessOutcome({repo, ready: false, error: e, globalCadenceMs});

--- a/test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncService.spec.mjs
@@ -1222,6 +1222,83 @@ test.describe('TenantRepoSyncService (#11790)', () => {
         })
     }
 
+    test('a multi-cause ingest failure reports every distinct bounded code and the total count, still redacted (#16575)', async () => {
+        // Reporting only the FIRST bounded code made a multi-cause failure read as single-cause: an
+        // operator fixes the one code they were shown and the lane fails identically next sweep.
+        // Widening to every distinct bounded code stays inside the credential boundary because
+        // BOUNDED_KB_ERROR_CODE_PATTERN admits only KB_[A-Z0-9_]{1,120} — a code cannot carry a URL,
+        // a token, or stderr. The unbounded code and every message/detail must still never project.
+        const
+            taskStateService = createInMemoryTaskStateService(),
+            repoSlug         = 'org/multi-cause',
+            logs             = [];
+
+        await provisionMirrorDir({tenantId: 't1', repoSlug});
+
+        const ingestionService = makeFakeIngestionService({
+            summaryFactory() {
+                return {
+                    ingested           : 0,
+                    deleted            : 0,
+                    embeddingsGenerated: 0,
+                    errors             : [
+                        {code: 'KB_VECTOR_EMBED_FAILED', message: 'https://user:TOKEN-must-not-project@host/x.git'},
+                        {code: 'KB_GITMIRROR_CLONE_FAILED', message: 'stderr-must-not-project'},
+                        {code: 'KB_VECTOR_EMBED_FAILED', message: 'duplicate-code-must-collapse'},
+                        {code: 'lowercase-unbounded', message: 'unbounded-must-not-project'}
+                    ]
+                }
+            }
+        });
+
+        const failed = await TenantRepoSyncService.runTask({
+            reason           : 'manual',
+            taskStateService,
+            tenantReposConfig: {tenantRepos: [
+                {tenantId: 't1', repoSlug, mirrorRoot, cloneUrl: 'https://github.com/neomjs/multi-cause.git'}
+            ]},
+            gitMirror      : makeFakeGitMirror(),
+            envelopeBuilder: async args => ({
+                tenantId    : args.tenantId,
+                repoSlug    : args.repoSlug,
+                files       : [{sourcePath: 'fake.txt', repoSlug: args.repoSlug, content: 'x'}],
+                deleted     : [],
+                headRevision: 'sha-multi'
+            }),
+            knowledgeBaseIngestionService: ingestionService,
+            onlyRepoSlugs                : [repoSlug],
+            revisionsFilePath            : revisionsFile,
+            writeLog                     : (...args) => logs.push(args.join(' '))
+        });
+
+        const logText = logs.join('\n');
+
+        expect(failed.status).toBe('failed');
+
+        // The stable outer code and the first bounded source code keep their exact prior meaning.
+        expect(failed.details.repos[0]).toMatchObject({
+            lastErrorCode      : 'KB_TENANT_REPO_SYNC_SYNC_FAILED',
+            lastSourceErrorCode: 'KB_VECTOR_EMBED_FAILED'
+        });
+
+        // The SECOND distinct bounded code is now visible — the whole point of the change.
+        expect(logText).toContain('source=KB_VECTOR_EMBED_FAILED');
+        expect(logText).toContain('also=KB_GITMIRROR_CLONE_FAILED');
+
+        // Total counts all four entries, including the unbounded one, so a partial failure cannot
+        // read as a single failure.
+        expect(logText).toContain('errors=4');
+
+        // Duplicate bounded codes collapse rather than repeating.
+        expect(logText.match(/KB_VECTOR_EMBED_FAILED/g)).toHaveLength(1);
+
+        // Redaction holds on every axis: unbounded codes, messages, credentials, stderr.
+        expect(logText).not.toContain('lowercase-unbounded');
+        expect(logText).not.toContain('must-not-project');
+        expect(JSON.stringify(failed)).not.toContain('must-not-project');
+        expect(JSON.stringify(failed)).not.toContain('lowercase-unbounded')
+    });
+
     test('mixed cycle counts an error-bearing summary as failed while preserving per-repo isolation (#15748)', async () => {
         const
             taskStateService = createInMemoryTaskStateService(),


### PR DESCRIPTION
## An operator fixes the one code they were shown, and the lane fails identically next sweep

Resolves #16575

Related: #16566 (the multi-cause failure this makes legible) · #16551 (adjacent reporting defect on the same lane)

`assertErrorFreeIngestionSummary` retained only the **first** bounded `KB_*` code via `.find()`. A single ingest can fail for several independent reasons at once — an embed failure alongside a mirror/clone failure alongside per-file parse failures — so a multi-cause failure was reported as single-cause. The total error count was lost too, which makes `lastSourceErrorCode: KB_VECTOR_EMBED_FAILED` identical between *one* file failing to embed and *every* file failing.

This retains every **distinct** bounded code plus the total count, and surfaces both in the existing failure log line.

Evidence: L2 (unit specs over the real `runTask` failure path, `93 passed` across the service spec) — no L3 claimed; nothing here changes ingestion behavior.

## The constraint this had to respect, and why the fix is safe

Message and detail suppression is **deliberate**, documented at `TenantRepoSyncService.mjs:229` and again at `:708` — *"preserved as `lastSourceErrorCode` without copying raw stderr, URLs, or…"*. An ingestion error message can carry a clone URL with an embedded token, so copying messages would breach the credential contract (#11787: no secrets in logs, manifests, or graph-visible config).

**Nothing here copies a message.** Only codes widen, and codes are safe *by construction*: `BOUNDED_KB_ERROR_CODE_PATTERN` is `/^KB_[A-Z0-9_]{1,120}$/`, which cannot express a URL, a token, or stderr. That is exactly why the codes could widen while the messages stay uncopied — the boundary is enforced by the pattern, not by discipline.

My first framing of this (on #16566) was *"surface the underlying embed error instead of wrapping it"*. That would have breached the boundary. Reading the docblock before implementing is what turned it into a safe change.

## Prior art: `.find()` was designed, and I endorsed it — what changes is the proxy, not the property

**This is not fixing an oversight.** #15748's Contract Ledger specifies the single-code behavior twice — *"first safe `KB_*` summary code is retained as source provenance"* — and I reviewed PR **#15752** approvingly on exactly that basis, calling it the standout: *"projecting only the first bounded `KB_*` code and deliberately dropping messages/details… exactly the right instinct on a tenant path."* I scored its architecture 97 on the strength of it.

Credit to @neo-opus-grace for surfacing this; without it the next reader finding #15748 would reasonably conclude this PR contradicts a settled decision, and re-litigate it.

**The distinction that makes both positions correct:**

| | |
|---|---|
| **Property, preserved** | messages, details, stderr, and credentials are never projected — the credential boundary |
| **Proxy, relaxed** | *"first bounded code only"* was the conservative implementation of that property, not the property itself |

Widening to every **distinct bounded** code preserves the property because `BOUNDED_KB_ERROR_CODE_PATTERN` (`/^KB_[A-Z0-9_]{1,120}$/`) cannot express a URL, token, or stderr — the boundary is enforced by the pattern, not by the count. Grace verified this independently with a third mutation: projecting raw messages through `sourceErrorCodes` fails the spec through **both** the log text and the serialized result.

So #15748's decision stands on its stated rationale; only its cardinality moves, and the reason it can move is that the guard is a regex rather than a discipline.

## What is unchanged

`error.sourceErrorCode` keeps its exact prior meaning — the first bounded code — so `getSourceErrorCode`, `lastSourceErrorCode`, and the persisted per-repo records are untouched. This is purely additive: `sourceErrorCodes` (distinct) and `sourceErrorCount` (total).

The log line is byte-identical for a single-cause failure: both suffixes are omitted when they would add nothing (one code, or a count of 1). Only genuinely multi-cause failures read differently.

## Test Evidence

`93 passed (4.4s)` — `npx playwright test -c test/playwright/playwright.config.unit.mjs test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncService.spec.mjs --workers=1`. Re-run after the block-alignment fix, so the pass is against the committed bytes.

New test: **"a multi-cause ingest failure reports every distinct bounded code and the total count, still redacted"**, fixturing four errors — two bounded and distinct, one a duplicate of the first, one unbounded — each carrying a poisoned message:

| asserted | why |
|---|---|
| `source=KB_VECTOR_EMBED_FAILED` | prior behavior preserved |
| `also=KB_GITMIRROR_CLONE_FAILED` | the second distinct cause is now visible — the point of the change |
| `errors=4` | total counts the unbounded entry too, so partial ≠ total |
| `KB_VECTOR_EMBED_FAILED` appears exactly **once** | duplicates collapse rather than repeat |
| `lowercase-unbounded` absent from log **and** result | unbounded codes still never project |
| `must-not-project` absent from log **and** result | credentials and stderr still never project |

The redaction assertions run against both `logs.join('\n')` and `JSON.stringify(failed)`, so a leak through either surface fails.

**Falsification, reasoned rather than executed** (stated as such): under the previous `.find()` implementation `error.sourceErrorCodes` is `undefined`, so `otherCodes` is `[]`, `alsoSuffix` is `''`, and `expect(logText).toContain('also=KB_GITMIRROR_CLONE_FAILED')` fails. I did not run that mutation — the argument is by construction, and a reviewer wanting the executed proof should say so.

The pre-existing error-bearing-summary tests (#15748) pass unchanged, which is the regression evidence for the single-cause path.

## Post-Merge Validation

- [ ] On the next real tenant-sync failure, confirm the log line carries `errors=<n>` and, where applicable, `also=<codes>`.
- [ ] Confirm a single-cause failure line is unchanged from today's format.
- [ ] **Deliberately not claimed:** this fixes no ingest. #16566's embed failure is untouched — this makes its cause set readable, which is what the "error-bearing summary" wrapper currently hides.

## Deltas

- `ai/daemons/orchestrator/services/TenantRepoSyncService.mjs` — `assertErrorFreeIngestionSummary` retains distinct bounded codes + total count; the per-repo ERROR log line gains conditional `also=` / `errors=` suffixes.
- `test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncService.spec.mjs` — one new test covering multi-cause reporting and redaction on both surfaces.
- **Substrate accretion:** two additive fields on an existing error object and two conditional log suffixes. No new module, config leaf, dependency, or consumed surface. Sunset: if the new fields reach the deployment-state snapshot per-repo entries (named Out of Scope on #16575 because that assembly path needs tracing first), the log suffixes become a redundant second surface and should be reconsidered then.

Authored by @neo-opus-vega (Claude Opus 5).
