### PR TITLE
A materialization states what it materialized, above both guards (#16580)

### DIFF
--- a/ai/daemons/orchestrator/services/TenantRepoSyncService.mjs
+++ b/ai/daemons/orchestrator/services/TenantRepoSyncService.mjs
@@ -1299,7 +1299,7 @@ class TenantRepoSyncService extends Base {
                         !== priorState?.lastCommittedMaterializationAttemptId
                         ? existingManifest.materializationReceipt
                         : null,
-                    ingestResult = assertErrorFreeIngestionSummary(retryReceipt
+                    rawSummary = retryReceipt
                         ? {
                             ingested              : 0,
                             deleted               : 0,
@@ -1310,24 +1310,32 @@ class TenantRepoSyncService extends Base {
                             ...envelope,
                             ...(materializationAttempt ? {materializationAttempt} : {}),
                             viaMcp: false // operator-bulk path
-                        }));
+                        });
 
-                // Emitted BEFORE the effect assertion, so it survives the throw. The failure path
-                // used to log nothing between "Refreshing" and the error, which made an empty
-                // ENVELOPE (nothing matched a Source) indistinguishable from a dropped INGEST
-                // (files present, none materialized) — the two have opposite fixes, and neither
-                // could be told from the log. Measured live: 99 seconds of silence, then
-                // KB_TENANT_REPO_SYNC_EMPTY_MATERIALIZATION with no way to say why.
+                // Emitted before BOTH guards on this path, which is what makes it useful:
+                // `assertErrorFreeIngestionSummary` throws on any error-bearing summary, and
+                // `assertFullMaterializationEffect` throws on a zero-effect one. Between them they
+                // cover the two live failure modes on this lane, and neither used to log anything
+                // between "Refreshing" and the error.
+                //
+                // Placed one statement higher than first written, on review: below the summary
+                // assertion, `errors=` could only ever be 0 (that guard throws when it is not, and
+                // the retry-receipt branch hardcodes an empty array), so the field had a single
+                // possible value AND the error-bearing failure mode — the one the other configured
+                // repo actually hits — still produced total silence.
                 //
                 // Counts only. Paths, file names, and repo content stay out — the same
                 // credential-boundary reasoning that keeps ingestion error messages unprojected.
+                // `repoLabel` is `tenantId/repoSlug`: operator-configured identifiers, not content.
                 writeLog?.('INFO', `[TenantRepoSync] ${repoLabel} materialized: ` +
                     `envelopeFiles=${envelope?.files?.length ?? 0} ` +
                     `envelopeDeleted=${envelope?.deleted?.length ?? 0} ` +
-                    `ingested=${ingestResult?.ingested ?? 0} ` +
-                    `deleted=${ingestResult?.deleted ?? 0} ` +
-                    `embeddings=${ingestResult?.embeddingsGenerated ?? 0} ` +
-                    `errors=${ingestResult?.errors?.length ?? 0}`);
+                    `ingested=${rawSummary?.ingested ?? 0} ` +
+                    `deleted=${rawSummary?.deleted ?? 0} ` +
+                    `embeddings=${rawSummary?.embeddingsGenerated ?? 0} ` +
+                    `errors=${rawSummary?.errors?.length ?? 0}`);
+
+                const ingestResult = assertErrorFreeIngestionSummary(rawSummary);
 
                 const materializationReceipt = assertFullMaterializationEffect(
                     envelope,

--- a/ai/daemons/orchestrator/services/TenantRepoSyncService.mjs
+++ b/ai/daemons/orchestrator/services/TenantRepoSyncService.mjs
@@ -1312,6 +1312,23 @@ class TenantRepoSyncService extends Base {
                             viaMcp: false // operator-bulk path
                         }));
 
+                // Emitted BEFORE the effect assertion, so it survives the throw. The failure path
+                // used to log nothing between "Refreshing" and the error, which made an empty
+                // ENVELOPE (nothing matched a Source) indistinguishable from a dropped INGEST
+                // (files present, none materialized) — the two have opposite fixes, and neither
+                // could be told from the log. Measured live: 99 seconds of silence, then
+                // KB_TENANT_REPO_SYNC_EMPTY_MATERIALIZATION with no way to say why.
+                //
+                // Counts only. Paths, file names, and repo content stay out — the same
+                // credential-boundary reasoning that keeps ingestion error messages unprojected.
+                writeLog?.('INFO', `[TenantRepoSync] ${repoLabel} materialized: ` +
+                    `envelopeFiles=${envelope?.files?.length ?? 0} ` +
+                    `envelopeDeleted=${envelope?.deleted?.length ?? 0} ` +
+                    `ingested=${ingestResult?.ingested ?? 0} ` +
+                    `deleted=${ingestResult?.deleted ?? 0} ` +
+                    `embeddings=${ingestResult?.embeddingsGenerated ?? 0} ` +
+                    `errors=${ingestResult?.errors?.length ?? 0}`);
+
                 const materializationReceipt = assertFullMaterializationEffect(
                     envelope,
                     ingestResult,

--- a/test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncService.spec.mjs
@@ -1222,6 +1222,101 @@ test.describe('TenantRepoSyncService (#11790)', () => {
         })
     }
 
+    test('an EMPTY envelope reads differently from a dropped ingest — the other arm of the discrimination', async () => {
+        // The sibling test pins files=2/ingested=0 (dropped ingest). This pins files=0, which is the
+        // arm the leading hypothesis predicts (a source-config gap yielding nothing to ingest) and
+        // therefore the one the next live run is most likely to produce. Pinning only the arm that
+        // already works would leave the claim "these two read differently" half-evidenced.
+        const
+            taskStateService = createInMemoryTaskStateService(),
+            repoSlug         = 'org/empty-envelope',
+            logs             = [];
+
+        await provisionMirrorDir({tenantId: 't1', repoSlug});
+
+        await TenantRepoSyncService.runTask({
+            reason           : 'manual',
+            taskStateService,
+            tenantReposConfig: {tenantRepos: [
+                {tenantId: 't1', repoSlug, mirrorRoot, cloneUrl: 'https://github.com/neomjs/empty-envelope.git'}
+            ]},
+            gitMirror      : makeFakeGitMirror(),
+            envelopeBuilder: async args => ({
+                tenantId        : args.tenantId,
+                repoSlug        : args.repoSlug,
+                files           : [],
+                deleted         : [],
+                headRevision    : 'sha-empty-envelope',
+                manifestSnapshot: {pathsAfterPush: []}
+            }),
+            knowledgeBaseIngestionService: makeFakeIngestionService({
+                summaryFactory: () => ({ingested: 0, deleted: 0, embeddingsGenerated: 0, errors: []})
+            }),
+            onlyRepoSlugs    : [repoSlug],
+            revisionsFilePath: revisionsFile,
+            writeLog         : (...args) => logs.push(args.join(' '))
+        });
+
+        const logText = logs.join('\n');
+
+        // The discriminating field, and the reason this arm needed its own fixture.
+        expect(logText).toContain('envelopeFiles=0');
+        expect(logText).toContain('ingested=0')
+    });
+
+    test('the diagnostic survives an ERROR-BEARING summary, which throws before the effect guard', async () => {
+        // `assertErrorFreeIngestionSummary` throws ahead of the effect guard, so a log placed below
+        // it could never describe this failure — and this is the mode the other configured repo hits
+        // live. Pinning it here is what keeps the line above BOTH guards; if someone moves it back
+        // down, this test goes red rather than the regression reaching a plane.
+        const
+            taskStateService = createInMemoryTaskStateService(),
+            repoSlug         = 'org/error-bearing-diagnostic',
+            logs             = [];
+
+        await provisionMirrorDir({tenantId: 't1', repoSlug});
+
+        await TenantRepoSyncService.runTask({
+            reason           : 'manual',
+            taskStateService,
+            tenantReposConfig: {tenantRepos: [
+                {tenantId: 't1', repoSlug, mirrorRoot, cloneUrl: 'https://github.com/neomjs/error-bearing.git'}
+            ]},
+            gitMirror      : makeFakeGitMirror(),
+            envelopeBuilder: async args => ({
+                tenantId        : args.tenantId,
+                repoSlug        : args.repoSlug,
+                files           : [{sourcePath: 'a.txt', repoSlug: args.repoSlug, content: 'x'}],
+                deleted         : [],
+                headRevision    : 'sha-error-bearing',
+                manifestSnapshot: {pathsAfterPush: ['a.txt']}
+            }),
+            knowledgeBaseIngestionService: makeFakeIngestionService({
+                summaryFactory: () => ({
+                    ingested           : 0,
+                    deleted            : 0,
+                    embeddingsGenerated: 0,
+                    errors             : [
+                        {code: 'KB_VECTOR_EMBED_FAILED', message: 'credential-must-not-project'},
+                        {code: 'KB_FILE_PARSE_FAILED', message: 'also-must-not-project'}
+                    ]
+                })
+            }),
+            onlyRepoSlugs    : [repoSlug],
+            revisionsFilePath: revisionsFile,
+            writeLog         : (...args) => logs.push(args.join(' '))
+        });
+
+        const logText = logs.join('\n');
+
+        // The diagnostic ran even though the summary assertion threw immediately after it.
+        expect(logText).toContain('envelopeFiles=1');
+        // And `errors=` now has a real range — it was structurally 0 while the line sat lower.
+        expect(logText).toContain('errors=2');
+        // Messages still never project, on either the diagnostic or the failure line.
+        expect(logText).not.toContain('must-not-project')
+    });
+
     test('an empty materialization states envelope vs ingest counts, so the two causes are distinguishable (#16577)', async () => {
         // The failure path threw before any diagnostic was written, so an empty ENVELOPE (nothing
         // matched a Source) and a dropped INGEST (files present, none materialized) produced the

--- a/test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncService.spec.mjs
@@ -1222,6 +1222,69 @@ test.describe('TenantRepoSyncService (#11790)', () => {
         })
     }
 
+    test('an empty materialization states envelope vs ingest counts, so the two causes are distinguishable (#16577)', async () => {
+        // The failure path threw before any diagnostic was written, so an empty ENVELOPE (nothing
+        // matched a Source) and a dropped INGEST (files present, none materialized) produced the
+        // same silence and the same error code — with opposite fixes. Measured live: 99 seconds
+        // of no output, then KB_TENANT_REPO_SYNC_EMPTY_MATERIALIZATION.
+        //
+        // This fixture is deliberately the DROPPED-INGEST arm: two envelope files, zero ingested.
+        // That is the combination the old log could not describe at all.
+        const
+            taskStateService = createInMemoryTaskStateService(),
+            repoSlug         = 'org/empty-materialization',
+            logs             = [];
+
+        await provisionMirrorDir({tenantId: 't1', repoSlug});
+
+        const failed = await TenantRepoSyncService.runTask({
+            reason           : 'manual',
+            taskStateService,
+            tenantReposConfig: {tenantRepos: [
+                {tenantId: 't1', repoSlug, mirrorRoot, cloneUrl: 'https://github.com/neomjs/empty-materialization.git'}
+            ]},
+            gitMirror      : makeFakeGitMirror(),
+            envelopeBuilder: async args => ({
+                tenantId: args.tenantId,
+                repoSlug: args.repoSlug,
+                files   : [
+                    {sourcePath: 'a.txt', repoSlug: args.repoSlug, content: 'x'},
+                    {sourcePath: 'b.txt', repoSlug: args.repoSlug, content: 'y'}
+                ],
+                deleted     : [],
+                headRevision: 'sha-empty',
+                // `pathsAfterPush` is required — materialization identity is derived from it, and a
+                // manifest without it is rejected as KB_INGEST_ENVELOPE_MANIFEST_INVALID before the
+                // effect guard is ever reached.
+                manifestSnapshot: {pathsAfterPush: ['a.txt', 'b.txt']}
+            }),
+            knowledgeBaseIngestionService: makeFakeIngestionService({
+                summaryFactory: () => ({ingested: 0, deleted: 0, embeddingsGenerated: 0, errors: []})
+            }),
+            onlyRepoSlugs    : [repoSlug],
+            revisionsFilePath: revisionsFile,
+            writeLog         : (...args) => logs.push(args.join(' '))
+        });
+
+        const logText = logs.join('\n');
+
+        // The sync still fails — the diagnostic does not weaken any guard.
+        expect(failed.status).toBe('failed');
+
+        // Deliberately NOT asserting which code fired. A zero-effect materialization can be
+        // rejected by more than one guard depending on fixture shape, and the property under test
+        // is that the diagnostic survives the throw REGARDLESS of which one. Pinning a single code
+        // here would make this a test of guard-ordering rather than of the log line.
+        expect(logText).toContain('envelopeFiles=2');
+        expect(logText).toContain('ingested=0');
+        expect(logText).toContain('embeddings=0');
+
+        // Counts only — no paths, names, or repo content cross into the log, matching the same
+        // credential-boundary discipline that keeps ingestion error messages unprojected.
+        expect(logText).not.toContain('a.txt');
+        expect(logText).not.toContain('b.txt')
+    });
+
     test('a multi-cause ingest failure reports every distinct bounded code and the total count, still redacted (#16575)', async () => {
         // Reporting only the FIRST bounded code made a multi-cause failure read as single-cause: an
         // operator fixes the one code they were shown and the lane fails identically next sweep.


### PR DESCRIPTION
## 99 seconds of silence, then an error that cannot say why

Resolves #16580

Related: epic #16566 · #16577 (the disposition defect this makes diagnosable but does not fix) · #16581 (sibling diagnostic leaf) · #16573 / #16574 (registered the tenant that surfaced this)

## Cycle 2 — both required actions applied, and RA1 found a real hole

@neo-opus-grace requested changes. Both were correct; the first was more than a dead field.

**RA1 — the log sat one statement too low.** There are *two* guards on this path, and I had placed the line between them:

| line | guard | throws on |
|---|---|---|
| `:1302` | `assertErrorFreeIngestionSummary` | any error-bearing summary — the mode **`neo-shared/neo`** hits |
| `:1324` | *(my line)* | |
| `:1332` | `assertFullMaterializationEffect` | zero durable effect — the mode **`create-app`** hits |

So `errors=` could only ever be `0` (the first guard throws when it is not, and the retry branch hardcodes `errors: []`) — but the worse consequence is that **the error-bearing failure mode still produced total silence**, and that is the mode the other configured repo actually hits. A PR whose stated purpose is removing that silence did not remove it for the repo that matters most.

Hoisted above both guards: `rawSummary` is computed, logged, then asserted. `errors=` now has a real range and both live failure modes are covered. My PR body's claim *"it makes the next run explain itself"* is true as written now; it was not before.

**RA2 — the `envelopeFiles=0` arm is now pinned.** Two tests added: the empty-envelope arm (the one #16577's leading hypothesis predicts, so the one the next live run most likely produces), and an error-bearing-summary arm that asserts `errors=2` — which is simultaneously the regression guard for the hoist. If anyone moves the line back below `:1302`, that test goes red instead of the regression reaching a plane.

**Close-target — repointed.** `Resolves #16577` would have auto-closed a five-AC ticket on delivery of AC 3, including the backoff loop this PR explicitly does not fix. Grace cited the precedent: #16463 was closed exactly that way by #16558 and sat untracked. Per `agent-pr-body-lint.yml:70-74`, the sanctioned remedy is a split, not a weaker keyword — so #16566 is now an **epic**, with #16577 (disposition) and the two diagnostic leaves #16580 / #16581 as subs. This PR closes the leaf it actually delivers.

Her `[TOOLING_GAP]` is worth carrying forward: `lint-pr-body` verifies a `Resolves` *exists*, never that the target's ACs are delivered — so this whole defect class is invisible to CI. A live instance of CI-green ≠ AC-met.

Measured on the canonical plane during the first live end-to-end tenant-ingestion attempt:

```
00:53:45  Refreshing neo-shared/create-app
          ...99 seconds, no output whatsoever...
00:55:24  ERROR create-app failed: KB_TENANT_REPO_SYNC_EMPTY_MATERIALIZATION
          ("Tenant-repo full materialization produced no durable positive-effect proof.")
```

`assertFullMaterializationEffect` throws **before** the success log at the end of `syncRepo`, so the failure path emitted nothing at all. That makes two states with **opposite fixes** indistinguishable:

| what happened | fix lives in | log today |
|---|---|---|
| envelope was empty — nothing matched a Source | tenant config / source matching | *(identical silence)* |
| envelope had files, ingest materialized none | ingestion code | *(identical silence)* |

This is what stopped the live diagnosis at "unknown". #16577's AC 3, and the prerequisite for the rest of that ticket.

Evidence: L2 (unit spec over the real `runTask` failure path, `94 passed`) → the L1 observation above is what motivated it.

## The change

One `INFO` line emitted immediately before the effect assertion, so it survives the throw:

```
[TenantRepoSync] <tenant>/<repo> materialized: envelopeFiles=N envelopeDeleted=N
                 ingested=N deleted=N embeddings=N errors=N
```

`envelopeFiles` versus `ingested` is the discriminator: `envelopeFiles=0` means nothing matched a Source; `envelopeFiles=2 ingested=0` means the ingest dropped them. Those two now read differently at a glance.

**Counts only — no paths, file names, or repo content.** Same credential-boundary discipline that keeps ingestion error messages unprojected (`TenantRepoSyncService.mjs:229`, `:708`): a count cannot carry a clone URL, a token, or stderr. The spec asserts the leak-absence directly rather than trusting the intent.

## What this does NOT do

- **It does not fix the loop.** #16577's central defect stands: on a first sync there is no prior receipt, so `provesUncommittedRetry` is structurally false and any repo yielding zero chunks fails and backs off exponentially — permanently, because the checkpoint never advances to produce the receipt that would let it pass. That is a design call about disposition, deliberately not bundled with a diagnostic.
- **It does not explain `create-app`.** It makes the next run explain itself. The leading hypothesis — that our tenant entries declare only `cloneUrl`/`credentialRef`/`branchRef` while other deployments carry `useDefaultSources`/`rawRepoSource`/`sourcePaths` — becomes checkable from one log line instead of a code read.
- **No guard is weakened.** The assertion runs unchanged, after the log.

## Test Evidence

`94 passed (4.6s)` — `npx playwright test -c test/playwright/playwright.config.unit.mjs test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncService.spec.mjs --workers=1`. Re-run after the block-alignment fix, so the pass is against committed bytes.

New test fixtures the **dropped-ingest** arm specifically — two envelope files, zero ingested — because that is the combination the old log could not describe at all:

| asserted | why |
|---|---|
| `failed.status === 'failed'` | the guard still rejects it |
| `envelopeFiles=2`, `ingested=0`, `embeddings=0` | the diagnostic survived the throw |
| `a.txt` / `b.txt` absent from the log | counts only; no path leakage |

**Deliberately not asserted: which error code fired.** A zero-effect materialization can be rejected by more than one guard depending on fixture shape, and the property under test is that the diagnostic survives *whichever* one. Pinning a code would make this a test of guard-ordering instead of of the log line.

**Two fixture-fidelity failures worth recording**, because both were the test being wrong rather than the code:

1. First run asserted `lastErrorCode === 'KB_TENANT_REPO_SYNC_EMPTY_MATERIALIZATION'` and got `KB_TENANT_REPO_SYNC_SYNC_FAILED` — the outer code is stable by design and the specific one rides `lastSourceErrorCode` (`:1410`). The assertion, not the behavior, was wrong.
2. The manifest then failed with `KB_INGEST_ENVELOPE_MANIFEST_INVALID` — materialization identity requires **`manifestSnapshot.pathsAfterPush`**, not an arbitrary shape. My fixture never reached the guard it claimed to exercise. Now documented inline so the next author does not repeat it.

A fixture that fails before the code path it is named for is a green test proving nothing; both were caught by reading the failure rather than adjusting the assertion until it passed.

## Post-Merge Validation

- [ ] On the next `create-app` attempt, read `envelopeFiles` — that single number decides whether #16577's follow-up is a config fix or an ingestion-code fix.
- [ ] Confirm the line also appears on a successful sync (it is emitted on both paths).
- [ ] **Not claimed:** no repo ingests as a result of this. It makes the failure legible; the disposition fix is #16577's remaining ACs.

## Deltas

- `ai/daemons/orchestrator/services/TenantRepoSyncService.mjs` — one `INFO` log before `assertFullMaterializationEffect`.
- `test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncService.spec.mjs` — one test covering the dropped-ingest arm and leak-absence.
- **Substrate accretion:** one log line and one test. No new module, config leaf, dependency, or consumed surface; no control flow changed. Sunset: if #16577's disposition fix introduces a structured materialization result, this line's counts should move into it rather than being duplicated.

Authored by @neo-opus-vega (Claude Opus 5).
