### PR TITLE
An undeclared service param is stripped before the method sees it (#16587)

### DIFF
--- a/ai/mcp/server/knowledge-base/openapi.yaml
+++ b/ai/mcp/server/knowledge-base/openapi.yaml
@@ -1197,6 +1197,30 @@ components:
         headRevision:
           type: string
           description: Current revision boundary (optional revision-range deletion signal).
+        viaMcp:
+          type: boolean
+          description: |
+            Work-volume-gate mode. Omitted or true keeps `VectorService.embed` MCP-safe,
+            refusing batches above `mcpSyncMaxChunks`. Explicit `false` is the in-process
+            bulk opt-in used by pull-mode tenant-repo sync and the `ai:ingest-tenant` CLI.
+            MCP dispatch overrides any caller value to `true`, so declaring it here cannot
+            widen the agent-facing gate.
+        materializationAttempt:
+          type: object
+          additionalProperties: true
+          description: |
+            Orchestrator-minted identity for one full pull materialization. Pull-mode only:
+            the ingestion service pairs it with the persisted manifest to emit the
+            `materializationReceipt` that proves a positive effect. MCP dispatch deletes
+            this field inbound and the receipt outbound, so a pushing agent can neither
+            supply nor observe it.
+          properties:
+            attemptId:
+              type: string
+              description: Opaque 32-character lowercase hex attempt identity.
+            ingestContractVersion:
+              type: integer
+              description: Checkpoint-contract version this attempt was minted under.
 
     IngestSourceFilesResponse:
       type: object

--- a/ai/services/knowledge-base/IngestionService.mjs
+++ b/ai/services/knowledge-base/IngestionService.mjs
@@ -972,6 +972,10 @@ class IngestionService extends Base {
         }
 
         let receipt = null;
+        // Hoisted out of the `attempt` block purely so the no-receipt diagnostic below can state
+        // whether a prior receipt existed to fall back on — the branch that distinguishes
+        // "first materialization" from "retry whose prior proof did not match".
+        let priorReceiptPresent = false;
 
         if (attempt) {
             const
@@ -989,6 +993,8 @@ class IngestionService extends Base {
                     && [summary.ingested, summary.deleted]
                         .some(value => Number.isSafeInteger(value) && value > 0);
 
+            priorReceiptPresent = Boolean(existing?.materializationReceipt);
+
             if (hasEffect) {
                 receipt = {
                     attemptId            : attempt.attemptId,
@@ -1005,6 +1011,39 @@ class IngestionService extends Base {
                 // failure after KB mutation can settle idempotently on the retry.
                 receipt = existing.materializationReceipt;
             }
+        }
+
+        // A manifest that persists WITHOUT a receipt is the shape that rejects an otherwise
+        // successful ingest downstream: `assertFullMaterializationEffect` sees a real effect and no
+        // proof of it, and raises EMPTY_MATERIALIZATION — a message that reads as the opposite of
+        // what happened. Observed live with `ingested=50, embeddings=50, errors=0` and no receipt
+        // on either configured repo.
+        //
+        // Every branch above that skips receipt creation does so silently, so the absence was not
+        // attributable from any log: no attempt supplied, an attempt rejected as malformed, or a
+        // materialization with no positive effect all leave `receipt` null and look identical
+        // afterwards. This names which one happened.
+        //
+        // `attemptPresentAfterValidation` deliberately does NOT say the caller omitted the attempt.
+        // It is read after the OpenAPI/Zod gate in `ai/services.mjs`, which strips payload keys the
+        // contract does not declare — so `false` means "absent by the time the method ran", whether
+        // the caller omitted it or validation deleted it. Reading it as caller-omission is exactly
+        // how the first diagnosis on this lane was misrouted to a caller that was passing it
+        // correctly. Distinguishing the two arms requires comparing against the declared schema,
+        // which a mechanical contract-parity check owns rather than this log line.
+        //
+        // Counts and booleans only — no paths, filenames, or repo content, matching the credential
+        // discipline applied to ingestion error messages.
+        if (!receipt) {
+            logger.warn('[IngestionService] Manifest persisted without a materialization receipt.', {
+                repoSlug                     : normalized.repoSlug,
+                attemptPresentAfterValidation: materializationAttempt != null,
+                attemptAccepted              : Boolean(attempt),
+                ingested                     : summary.ingested,
+                deleted                      : summary.deleted,
+                errorCount                   : summary.errors.length,
+                priorReceiptPresent
+            });
         }
 
         const result = await this.setTenantManifest({

--- a/test/playwright/unit/ai/mcp/validation/OpenApiValidatorCompliance.spec.mjs
+++ b/test/playwright/unit/ai/mcp/validation/OpenApiValidatorCompliance.spec.mjs
@@ -556,6 +556,37 @@ test.describe('OpenApiValidator: strict-client JSON-Schema compliance', () => {
         expect(askSchema.properties.type.enum).toEqual(expectedTypes);
     });
 
+    test('ingest_source_files declares every param its in-process callers pass (#16577)', () => {
+        // The input-side twin of the additional-properties drift guarded above for outputs:
+        // `services.mjs` parses every call through this schema, and Zod DROPS undeclared keys
+        // silently. A service param the contract forgets is therefore not a documentation gap —
+        // it never reaches the method, with no error and no log. Both fields below were
+        // undeclared and stripped on every call, which is why pull-mode ingestion embedded
+        // correctly and then rejected itself: no receipt was ever minted, and bulk batches were
+        // forced through the MCP work-volume gate.
+        const doc      = yaml.load(fs.readFileSync(path.join(repoRoot, 'ai/mcp/server/knowledge-base/openapi.yaml'), 'utf8')),
+              ingestOp = getOperationsById(doc).ingest_source_files,
+              attempt  = {attemptId: 'a'.repeat(32), ingestContractVersion: 2},
+              parsed   = buildZodSchema(doc, ingestOp).parse({
+                  tenantId              : 'neo-shared',
+                  repoSlug              : 'create-app',
+                  files                 : [],
+                  headRevision          : 'abc123',
+                  manifestSnapshot      : {repoSlug: 'create-app', pathsAfterPush: ['x.md']},
+                  materializationAttempt: attempt,
+                  viaMcp                : false
+              });
+
+        // Pull-mode proof identity: stripping this is what leaves a successful materialization
+        // with no receipt, so the orchestrator raises EMPTY_MATERIALIZATION against its own ingest.
+        expect(parsed.materializationAttempt, 'materializationAttempt survives the Zod gate').toEqual(attempt);
+
+        // Bulk opt-in: stripping this re-reads as `viaMcp !== false` -> true, so tenant-scale
+        // batches hit the MCP synchronous work-volume gate and fail with KB_VECTOR_EMBED_FAILED.
+        expect(Object.hasOwn(parsed, 'viaMcp'), 'viaMcp survives the Zod gate').toBe(true);
+        expect(parsed.viaMcp, 'an explicit false is preserved, not defaulted away').toBe(false);
+    });
+
     test('neural-link declares the harness-visible projection policy (#13064)', () => {
         const
             doc        = yaml.load(fs.readFileSync(path.join(repoRoot, 'ai/mcp/server/neural-link/openapi.yaml'), 'utf8')),

--- a/test/playwright/unit/ai/services/knowledge-base/IngestionService.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/IngestionService.spec.mjs
@@ -972,6 +972,75 @@ test.describe('IngestionService.ingestSourceFiles', () => {
     });
 });
 
+test.describe('IngestionService.persistManifestSnapshot receipt-absence diagnostic', () => {
+    let Service, logger, originalWarn, warnings;
+
+    test.beforeAll(async () => {
+        Service = (await import('../../../../../../ai/services/knowledge-base/IngestionService.mjs')).default;
+        logger  = (await import('../../../../../../ai/mcp/server/knowledge-base/logger.mjs')).default;
+    });
+
+    test.beforeEach(() => {
+        warnings     = [];
+        originalWarn = logger.warn;
+        logger.warn  = (message, details) => warnings.push({message, details});
+    });
+
+    test.afterEach(() => {
+        logger.warn = originalWarn;
+    });
+
+    test('names WHY no receipt was produced when the attempt is absent', async () => {
+        // Every branch that skips receipt creation did so silently, so a manifest persisted WITHOUT
+        // a receipt — the shape that makes a fully successful ingest read as EMPTY_MATERIALIZATION
+        // downstream — was unattributable from any log. Observed live with ingested=50,
+        // embeddings=50, errors=0 and no receipt on either configured repo.
+        const summary = {ingested: 50, deleted: 0, errors: []};
+
+        await Service.persistManifestSnapshot({
+            manifestSnapshot: {repoSlug: 'diag-repo', pathsAfterPush: ['a.txt']},
+            files           : [{sourcePath: 'a.txt', repoSlug: 'diag-repo', content: 'x'}],
+            headRevision    : 'sha-diagnostic',
+            // No materializationAttempt: the branch that leaves `receipt` null while touching
+            // neither `summary.errors` nor any log.
+            tenantContext   : {tenantId: 'diag-tenant', repoSlug: 'diag-repo'},
+            summary
+        });
+
+        const hit = warnings.find(entry => entry.message.includes('without a materialization receipt'));
+
+        expect(hit).toBeTruthy();
+        expect(hit.details).toMatchObject({
+            attemptPresentAfterValidation: false,
+            attemptAccepted              : false,
+            ingested                     : 50,
+            errorCount                   : 0
+        });
+
+        // Counts and booleans only — no path, filename, or revision in the diagnostic.
+        const serialized = JSON.stringify(hit.details);
+        expect(serialized).not.toContain('a.txt');
+        expect(serialized).not.toContain('sha-diagnostic')
+    });
+
+    test('stays silent when a receipt IS produced', async () => {
+        // A diagnostic that fires on the healthy path becomes noise, and noise trains the reader to
+        // skip the line that matters.
+        const summary = {ingested: 3, deleted: 0, errors: []};
+
+        await Service.persistManifestSnapshot({
+            manifestSnapshot      : {repoSlug: 'diag-ok', pathsAfterPush: ['b.txt']},
+            files                 : [{sourcePath: 'b.txt', repoSlug: 'diag-ok', content: 'y'}],
+            headRevision          : 'sha-ok',
+            materializationAttempt: {attemptId: 'a'.repeat(32), ingestContractVersion: 2},
+            tenantContext         : {tenantId: 'diag-tenant', repoSlug: 'diag-ok'},
+            summary
+        });
+
+        expect(warnings.find(entry => entry.message.includes('without a materialization receipt'))).toBeFalsy()
+    });
+});
+
 test.describe('IngestionService.classifyIngestionFailureCode (#16566)', () => {
     let Service;
 


### PR DESCRIPTION
## A contract that forgets a param doesn't document it away — it deletes it

Resolves #16587

Related: epic #16566 · #16577 (the sibling defect whose motivating observation this work falsified — kept open, see below) · #16580 (the diagnostic that inverted the diagnosis) · #16581 · #16584 · #16585

`create-app` **is in the Knowledge Base** — 50 chunks, embedded, queryable. The tenant lane reported it as a failure anyway, and the sibling repo failed differently:

```
create-app  ingested=50    embeddings=50  errors=0  -> KB_TENANT_REPO_SYNC_EMPTY_MATERIALIZATION
neo         ingested=24590 embeddings=0   errors=1  -> KB_TENANT_REPO_SYNC_SYNC_FAILED
                                                       source=KB_VECTOR_EMBED_FAILED
```

Two repos, two symptoms, **one root cause** — and it is not in either service.

## The cause

`ai/services.mjs:139` parses every Knowledge Base service call through a Zod schema built from this OpenAPI contract:

```js
const parsedArgs = zodSchema.parse(args || {});   // Zod DROPS undeclared keys, silently
```

`ingestSourceFiles` documents `materializationAttempt` and `viaMcp` as params, and its in-process callers pass both. **Neither was declared in any spec.** So both were deleted from the payload before the method ran — no error, no log, no summary entry.

Measured in the running orchestrator against the real `create-app` envelope:

```
attempt sent in payload : {"attemptId":"a7a07f76601f638c0af6286dfcaaa85d","ingestContractVersion":2}
producer received       : materializationAttempt: undefined
                          manifestSnapshot: present paths=50
                          summary.ingested: 50   summary.errors: 0
```

`manifestSnapshot` **is** declared, so it survives. That asymmetry is the entire signature: the manifest persists with 50 correct paths while the receipt never appears.

**`materializationAttempt` stripped** → `attempt` is null → the receipt block never runs → a fully successful materialization persists no proof → `assertFullMaterializationEffect` sees a real effect with no proof and raises `EMPTY_MATERIALIZATION`, a message that reads as the opposite of what happened.

**`viaMcp` stripped** → `payload.viaMcp !== false` re-reads as `true` → `VectorService.mjs:1098` (`if (viaMcp && workVolume > mcpThreshold)`) throws. `create-app` sits at exactly the 50-chunk `mcpSyncMaxChunks` default and slips under; `neo` at 24,590 does not. That is the second symptom, same cause.

Corroborating read — **no receipt has ever existed** in this deployment: zero across every graph node and the full `GraphLog`. The feature has never once produced its proof, on any repo, since it landed in #16047.

## The change

Two properties added to `IngestSourceFilesRequest`. No code changes.

`materializationAttempt` is pull-mode only, and the MCP push path already deletes it inbound and deletes `materializationReceipt` outbound (`ingestSourceFilesTool.mjs:96,105`), so declaring it **cannot** let a pushing agent supply or observe proof. `viaMcp` is likewise forced to `true` by MCP dispatch, so the agent-facing work-volume gate is unchanged. Declaring both restores the in-process shapes without widening the tool surface — which is the point of routing through the validated `services.mjs` facade in the first place.

## Three hypotheses died before this one

Recorded so the next reader doesn't re-derive them:

| hypothesis | how it died |
|---|---|
| producer/consumer digest mismatch over normalized vs raw `manifestSnapshot` | all three cases match — the digest normalizes `pathsAfterPush` internally |
| ordering — receipt computed before `summary.ingested` is set | `:255` sets it before `:259` calls the producer |
| early return on a null/undefined snapshot | the manifest **was** written with 50 paths, so execution passed that point |

Each was a guess at which branch inside `persistManifestSnapshot` skipped receipt creation. All three were wrong because the branch was chosen by an input that had already been deleted one layer up. Reading the producer could never have found that; only measuring what it received did.

## Correcting this PR's own earlier routing

The first revision of this PR shipped the diagnostic alone and told the reader:

> `attemptSupplied:false` → the orchestrator is not passing `materializationAttempt`; the defect is on the caller side.

**That was wrong and would have cost a review cycle.** The orchestrator passes it correctly; the validation layer between them removes it. The routing table named two sides when there are three. The `logger.warn` from the first commit is kept — it stays the instrument that would catch any future receipt-absence — but it is no longer load-bearing for this diagnosis.

## Test Evidence

Evidence: L1 (live-orchestrator measurement of the stripped payload and of the minted receipt, both zero-write) + L2 (RED-proven regression spec; `218 passed` across every spec that reads this contract).

`218 passed` across the five specs that read this contract (`OpenApiValidatorCompliance`, `advertisedSurfaceDigest`, `McpServerListToolsSmoke`, `BaseServer`, `IngestionService`) — the advertised surface digest is included because a tool's input schema is part of it.

The regression test is **RED-proven**: with only the contract change stashed it fails on `materializationAttempt survives the Zod gate`, and it was confirmed **executing by name** at `:559` via a targeted `-g` run, not inferred from a count.

It lives in `OpenApiValidatorCompliance.spec.mjs` deliberately: that file already guards the *output*-side twin of this bug ("server implementations return fields the OpenAPI contract forgot to declare"). This is the input-side twin, and it belongs next to it.

**End-to-end, against the live orchestrator** — patched spec staged into the container, real `create-app` envelope, `embedChunkGroups` and `setTenantManifest` both stubbed so the run was zero-write, container restored afterwards:

```
ingested        : 50   errors: 0
attempt sent    : 2a280eb75386dee6dcfaef8b660e1a2e
receipt to node : {"attemptId":"2a280eb75386dee6dcfaef8b660e1a2e", ...}
attemptId match : true
```

## Post-Merge Validation

- [ ] Next `create-app` sweep completes: receipt minted, `lastIngestedRev` non-null, lane reports `completed`.
- [ ] The following sweep is a no-op diff rather than a full re-ingest — the checkpoint finally commits.
- [ ] `neo` embeds rather than raising `KB_VECTOR_EMBED_FAILED`; 24,590 chunks exceed `mcpSyncMaxChunks` only under the stripped-`viaMcp` behaviour.
- [ ] **Deliberately not claimed:** `create-app`'s 50 chunks were already in the corpus before this PR. This fixes the state machine's disagreement with reality, not the ingestion.

## Review cycle 1 — @neo-opus-grace

**Blocking item taken as stated.** `Resolves` now points at #16587, a leaf under epic #16566 covering the delivered work. #16577 stays **open**.

I verified the finding rather than accepting it. In the genuine zero-chunk case the producer's `hasEffect` is false, so no receipt is minted at all → `validReceipt` false → `provesUncommittedRetry` false → `(!hasEffect && !provesUncommittedRetry)` throws. And in the harder case Grace traced — a receipt minted for the current attempt — `provesUncommittedRetry` explicitly requires `receipt.attemptId !== materializationAttempt?.attemptId`, so it is false and the throw still fires. **Both routes throw.** #16577 ACs 1, 2 and 5 are live, and merging with the original close-target would have closed them on merge.

Her second reason is the sharper one and it is this PR's own doing: the evidence here **falsifies #16577's motivating observation**. `create-app` was never the zero-chunk case — it ingested 50 chunks. What remains on #16577 is real but is now a code-read defect with no live specimen, which is a materially different ticket. Amended there rather than silently repointing.

**Non-blocking item also taken.** `attemptSupplied` → `attemptPresentAfterValidation`. The old name was read *after* the Zod gate, so `false` conflated "caller omitted it" with "validation deleted it" — the exact conflation that misrouted revision one of this PR to an orchestrator that was passing the attempt correctly. Applying this PR's lesson to this PR's own instrument was the right catch; the comment now names the ambiguity and what owns resolving it (#16585's parity check, not a log line).

Her `[TOOLING_GAP]` on the `tools/list` projection (`ToolService.mjs:210` emits `inputSchema` whole, so per-property `.describe()` text bypasses the on-demand handbook design) is hers to file — it predates this PR and I am not claiming it.

Note on provenance: my first pass left the two earlier commits stamped `(#16577)` on the reasoning that squash-merge only lands the PR title. **`agent-pr-body-lint` disagreed, correctly** — it enforces commit/body ticket agreement regardless of merge strategy (`PR #16583 carries 2 foreign commit(s) ... Body declares #16587`). Rebuilt as a single commit on current `origin/dev` under #16587, which also clears the stale-branch advisory. Verified no revert-trap first: zero peer commits touched any of these four files since the merge-base, and the diff is still 4 files / 163 insertions / 0 deletions.

## Deltas

- `ai/mcp/server/knowledge-base/openapi.yaml` — `materializationAttempt` + `viaMcp` declared on `IngestSourceFilesRequest`.
- `test/playwright/unit/ai/mcp/validation/OpenApiValidatorCompliance.spec.mjs` — one RED-proven regression test.
- `ai/services/knowledge-base/IngestionService.mjs` — the earlier commit's `logger.warn` on the no-receipt path, retained, with `attemptSupplied` renamed to `attemptPresentAfterValidation` per review.
- **Substrate accretion:** two schema properties and one test. No new module, dependency, or consumed surface.

## Recorded, not fixed

- **The defect class has no mechanical guard.** Any service param added without a matching spec property is silently stripped. Two live instances in one contract, one of them shipped in #16047 and undetected since. A parity check (service JSDoc `@param payload.X` vs declared properties) would catch the whole class; filing separately rather than widening this PR.
- `persistManifestSnapshot:958` calls `normalizeManifestSnapshot` without `summary`, so a malformed snapshot aborts silently. Passing it would make the abort visible *and* fatal — a failure-semantics change, kept out.
- Producer uses falsy `!manifestSnapshot`; consumer and orchestrator use nullish `== null`. Narrow divergence for `0`/`''`. Not this bug.

Authored by @neo-opus-vega (Claude Opus 5).
