### PR TITLE
Stale-id gathering is scoped to the corpus the call owns (#16584)

### DIFF
--- a/ai/services/knowledge-base/VectorService.mjs
+++ b/ai/services/knowledge-base/VectorService.mjs
@@ -193,6 +193,32 @@ class VectorService extends Base {
     }
 
     /**
+     * @summary Builds the metadata filter naming the corpus one embed call owns.
+     *
+     * Every chunk a single `embed()` call writes carries the same `{tenantId, repoSlug}`
+     * stamp, so this tuple is the exact boundary of that call's authority. Stale-id
+     * gathering filters on it: without the filter, a lane embedding one corpus treats
+     * every other tenant's and repo's rows as stale and deletes them.
+     *
+     * The `$and` form is required, not stylistic. Chroma rejects a multi-key `where`
+     * with "Expected 'where' to have exactly one operator, but got 2", so the intuitive
+     * `{tenantId, repoSlug}` shape throws at query time rather than filtering.
+     *
+     * @param {Object} stamp Resolved tenant stamp.
+     * @param {String} stamp.tenantId Authoritative tenant id.
+     * @param {String} stamp.repoSlug Authoritative repo slug.
+     * @returns {Object} Chroma `where` filter selecting only this corpus.
+     */
+    buildOwnedScopeFilter({tenantId, repoSlug} = {}) {
+        return {
+            $and: [
+                {tenantId: {$eq: tenantId}},
+                {repoSlug: {$eq: repoSlug}}
+            ]
+        };
+    }
+
+    /**
      * Rejects or logs client-supplied identity fields that conflict with server context.
      *
      * @param {Object} chunk Parsed knowledge chunk.
@@ -1032,7 +1058,20 @@ class VectorService extends Base {
         const collection = await ChromaManager.getKnowledgeBaseCollection();
         logger.log(`Using collection: ${collection.name}`);
 
-        logger.log('Fetching existing documents from ChromaDB...');
+        // Scoped to the corpus THIS call owns. Unscoped, `existingIds` held every row in the
+        // collection, so `idsToDelete` below treated every other tenant's and repo's rows as
+        // stale and deleted them. Observed live: a sync pass over the `neo` corpus removed a
+        // tenant repo's 50 rows, and would have repeated on every sweep interval — the two
+        // could never coexist.
+        //
+        // The narrowing is exact rather than heuristic. `createTenantAwareChunkId` hashes
+        // `{tenantId, repoSlug, ...}` into the id, so an id written under one stamp cannot
+        // occur under another. The add-side delta (`chunksToProcess`) is therefore unchanged
+        // by scoping — only deletion is confined, to this corpus's own orphans. It also makes
+        // pagination cheaper on a shared collection.
+        const ownedScope = this.buildOwnedScopeFilter(tenantStamp);
+
+        logger.log(`Fetching existing documents for ${tenantStamp.tenantId}/${tenantStamp.repoSlug}...`);
         const existingIds = new Set();
         let   offset      = 0;
         const limit       = 2000;
@@ -1044,7 +1083,8 @@ class VectorService extends Base {
             batch = await collection.get({
                 include: [],
                 limit,
-                offset : offset
+                offset,
+                where  : ownedScope
             });
 
             batch.ids.forEach(id => existingIds.add(id));
@@ -1052,7 +1092,7 @@ class VectorService extends Base {
             logger.log(`Fetched ${existingIds.size} IDs so far...`);
         } while (batch.ids.length === limit);
 
-        logger.log(`Found ${existingIds.size} existing documents.`);
+        logger.log(`Found ${existingIds.size} existing documents in this corpus.`);
 
         const chunksToProcess = [];
         const allIds          = new Set();
@@ -1077,40 +1117,49 @@ class VectorService extends Base {
         logger.log(`${workVolume} chunks to add or update.`);
         logger.log(`${idsToDelete.length} chunks to delete.`);
 
-        if (!shouldShadowSwap && chunksToProcess.length === 0) {
-            if (idsToDelete.length > 0) {
-                await collection.delete({ ids: idsToDelete });
-                logger.log(`Deleted ${idsToDelete.length} stale chunks.`);
-            }
-
-            const message = 'No changes detected. Knowledge base is up to date.';
-            logger.log(message);
-            return {message, embedded: 0, deleted: idsToDelete.length};
-        }
-
         // Work-volume gate: refuse synchronous embedding via MCP when the
         // post-delta queue exceeds the configured threshold. The threshold default
         // matches `batchSize` (one batch is the floor for "small enough to run
         // synchronously"); real latency is provider/tier/retry-state-dependent so
         // the threshold is empirically tunable rather than timing-derived.
         // CLI invocations pass viaMcp: false and bypass.
+        //
+        // Ordered ABOVE the no-adds branch below, and metered on deletions as well as adds.
+        // Both were required: `workVolume` counted only adds, so a call adding 3 rows and
+        // deleting 60,000 presented to the gate as "3"; and the no-adds branch deleted and
+        // returned before the gate was ever evaluated, which made the largest possible
+        // deletion the one case no guard saw. A mass delete is work.
         const mcpThreshold = aiConfig.mcpSyncMaxChunks;
-        if (viaMcp && workVolume > mcpThreshold) {
+        if (viaMcp && Math.max(workVolume, idsToDelete.length) > mcpThreshold) {
             // `logPath` is a Provider-owned leaf; read it directly so malformed config
             // shape fails loud instead of silently re-deriving a local default.
             const logDir       = aiConfig.logPath;
             const errorPayload = {
                 error  : `KB sync work volume exceeds MCP-callable threshold`,
-                message: `${workVolume} chunks need re-embedding (threshold: ${mcpThreshold}). ` +
-                         `Synchronous embedding at this volume risks agent freeze. ` +
+                message: `${workVolume} chunks need re-embedding and ${idsToDelete.length} need deleting ` +
+                         `(threshold: ${mcpThreshold}). ` +
+                         `Synchronous work at this volume risks agent freeze. ` +
                          `Run via CLI: \`npm run ai:sync-kb\`. ` +
                          `Tail progress: \`tail -f ${logDir}/kb-server-$(date +%Y-%m-%d).log\`.`,
                 code           : 'KB_SYNC_VOLUME_EXCEEDED',
                 chunksToProcess: workVolume,
+                idsToDelete    : idsToDelete.length,
                 threshold      : mcpThreshold
             };
             logger.warn(`[VectorService] ${errorPayload.error}: ${errorPayload.message}`);
             return errorPayload;
+        }
+
+        // Genuine no-op: nothing to add AND nothing to delete. Reported as such because it is
+        // such. This branch previously fired whenever there was nothing to ADD, regardless of how
+        // many rows were about to be deleted — so a mass deletion returned
+        // "No changes detected. Knowledge base is up to date." beside a large `deleted` count, a
+        // success-shaped report for the opposite of no change. A delete-bearing pass now falls
+        // through to the path below, which deletes and then states the resulting collection size.
+        if (!shouldShadowSwap && chunksToProcess.length === 0 && idsToDelete.length === 0) {
+            const message = 'No changes detected. Knowledge base is up to date.';
+            logger.log(message);
+            return {message, embedded: 0, deleted: 0};
         }
 
         if (shouldShadowSwap) {

--- a/test/playwright/integration/KBBackupRestoreWipe.integration.spec.mjs
+++ b/test/playwright/integration/KBBackupRestoreWipe.integration.spec.mjs
@@ -287,10 +287,28 @@ function shadowSwapKnowledgeBase({collectionName, oldId, oldSentinel, fixturePat
                 return value;
             };
 
+            // Stamped with the corpus identity the embed below resolves to, read from the service
+            // rather than restated from config — \`resolveTenantStamp\` reads
+            // \`getTenantIsolationConfig()\`, so hardcoding the leaves could drift from it silently.
+            //
+            // Stale-id gathering is scoped to \`{tenantId, repoSlug}\`, so an unstamped row belongs
+            // to no corpus and is deliberately never swept. This hand-upsert bypasses
+            // \`applyTenantStamp\`, so without these two fields it stood for a shape production
+            // cannot produce (verified: every row in the live corpus carries both). The row must be
+            // stale WITHIN the corpus under test for "an old row is reported deleted" to be the
+            // assertion it reads as.
+            const oldRowStamp = KB_VectorService.resolveTenantStamp();
+
             await collection.upsert({
                 ids       : [process.env.NEO_TEST_KB_OLD_ID],
                 embeddings: [Array.from({length: vectorLength}, (_, dimension) => dimension === 0 ? 1 : 0)],
-                metadatas : [{kind: 'integration', source: 'kb-shadow-swap', sentinel: process.env.NEO_TEST_KB_OLD_SENTINEL}],
+                metadatas : [{
+                    kind    : 'integration',
+                    source  : 'kb-shadow-swap',
+                    sentinel: process.env.NEO_TEST_KB_OLD_SENTINEL,
+                    tenantId: oldRowStamp.tenantId,
+                    repoSlug: oldRowStamp.repoSlug
+                }],
                 documents : [process.env.NEO_TEST_KB_OLD_SENTINEL]
             });
 
@@ -372,7 +390,7 @@ function shadowSwapKnowledgeBase({collectionName, oldId, oldSentinel, fixturePat
 
 /**
  * Drives the `ingest_source_files` MCP tool end-to-end inside the deployed KB container.
- * Exercises both the #10572 work-volume gate (an oversized batch refused up-front) and the
+ * Exercises both the work-volume gate (an oversized batch refused up-front) and the
  * within-threshold dispatch path (parsed chunks embedded into an isolated temp collection).
  * @param {Object} options
  * @param {String} options.collectionName Temporary Chroma collection name.
@@ -471,7 +489,7 @@ function ingestSourceFilesViaMcpTool({collectionName, repoSlug, tenantId}) {
  * (`IngestionService.ingestSourceFiles` with `viaMcp:false` — the bulk gate-bypass),
  * then verifies the isolated temp collection holds every embedded chunk. The ingestion service
  * is imported directly (not via `ai/services.mjs`) so the closure-injected `viaMcp:false` flag
- * survives the makeSafe Zod wrapper and reaches `VectorService.embed` as the explicit #10572
+ * survives the makeSafe Zod wrapper and reaches `VectorService.embed` as the explicit
  * work-volume-gate bypass: a 1k+-chunk corpus far exceeds `mcpSyncMaxChunks`, so a clean
  * full-count ingest is itself proof the gate was bypassed.
  * @param {Object} options
@@ -495,7 +513,7 @@ function ingestTenantViaCli({collectionName, recordCount, repoSlug, tenantId}) {
         } = await import('./ai/services.mjs');
         // Direct import (not ai/services.mjs): the makeSafe Zod wrapper strips the
         // closure-injected viaMcp flag, and the bulk CLI relies on viaMcp:false reaching
-        // VectorService.embed as the explicit #10572 work-volume-gate bypass.
+        // VectorService.embed as the explicit work-volume-gate bypass.
         const {default: KB_IngestionService} = await import('./ai/services/knowledge-base/IngestionService.mjs');
         const {readJsonlRecords, runIngest}  = await import('./ai/scripts/maintenance/ingestTenant.mjs');
 
@@ -579,7 +597,7 @@ function ingestTenantViaCli({collectionName, recordCount, repoSlug, tenantId}) {
 }
 
 /**
- * Drives the #11637 Phase 2E tenant-config-storage persistence path inside the deployed KB
+ * Drives the tenant-config-storage persistence path inside the deployed KB
  * container. Writes a tenant's config as a `KnowledgeBaseTenantConfig` graph node via
  * `setTenantConfig`, reads it back, then simulates a KB-server restart by dropping the
  * in-memory Native Edge Graph cache — forcing the next `getTenantConfig` to reload the node
@@ -783,7 +801,7 @@ test.describe('Dockerized KB backup -> wipe -> restore integration (#11644)', ()
         expect(outcome.totals.parseErrors).toBe(0);
         expect(outcome.totals.errors).toEqual([]);
 
-        // viaMcp:false bypassed the #10572 work-volume gate — a 1024-chunk corpus far exceeds
+        // viaMcp:false bypassed the work-volume gate — a 1024-chunk corpus far exceeds
         // mcpSyncMaxChunks, so a clean full-count ingest is itself proof of the bulk bypass.
         expect(outcome.totals.ingested).toBe(recordCount);
         expect(outcome.totals.embeddingsGenerated).toBe(recordCount);

--- a/test/playwright/unit/ai/services/knowledge-base/VectorService.WorkVolumeBranching.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/VectorService.WorkVolumeBranching.spec.mjs
@@ -48,9 +48,47 @@ const __dirname  = path.dirname(__filename);
  */
 test.describe.configure({mode: 'serial'});
 
-function createSpyCollection({existingIds = [], name = 'spy-knowledge-base'} = {}) {
+/**
+ * Evaluates the `$and`-of-`$eq` filter shape `VectorService.buildOwnedScopeFilter` emits.
+ *
+ * Only honored by spies created with `honorWhere: true`. That is opt-in rather than default
+ * deliberately: the 20-odd existing spies here seed bare ids and assert add/delete volumes, not
+ * corpus scoping, so filtering their reads would silently change what every one of those
+ * expectations means. Two weaker designs were tried and rejected — a hardcoded default stamp
+ * (passed alone, failed in-file: siblings mutate the shared config singleton, so the default
+ * stamp is not constant across a run) and reading the stamp from the service per call (a sibling
+ * leaves config in a state where `resolveTenantStamp` throws). An opt-in flag with explicit
+ * per-row metadata depends on neither.
+ *
+ * Chroma rejects a multi-key `where` ("Expected 'where' to have exactly one operator, but got
+ * 2"), so honoring only this shape matches the store rather than being permissive beyond it.
+ *
+ * @param {Object} metadata Row metadata.
+ * @param {Object} [where] Chroma filter.
+ * @returns {Boolean} True when the row satisfies the filter.
+ */
+function matchesWhere(metadata = {}, where) {
+    if (!where) {
+        return true;
+    }
+
+    if (Array.isArray(where.$and)) {
+        return where.$and.every(clause => matchesWhere(metadata, clause));
+    }
+
+    return Object.entries(where).every(([field, condition]) => {
+        const expected = condition && typeof condition === 'object' && '$eq' in condition
+            ? condition.$eq
+            : condition;
+
+        return metadata[field] === expected;
+    });
+}
+
+function createSpyCollection({existingIds = [], name = 'spy-knowledge-base', honorWhere = false, stamp = {}, rowStamps = {}} = {}) {
     const rows = new Map();
-    existingIds.forEach(id => rows.set(id, {id, metadata: {}, document: ''}));
+
+    existingIds.forEach(id => rows.set(id, {id, metadata: {...stamp, ...(rowStamps[id] || {})}, document: ''}));
 
     const calls = {get: 0, upsert: 0, delete: 0, count: 0, modify: []};
 
@@ -61,11 +99,13 @@ function createSpyCollection({existingIds = [], name = 'spy-knowledge-base'} = {
 
         async get({ids, where, limit = 2000, offset = 0, include = []} = {}) {
             calls.get++;
-            const all   = Array.from(rows.keys());
+            const all = Array.from(rows.entries())
+                .filter(([, row]) => !honorWhere || matchesWhere(row.metadata, where))
+                .map(([id]) => id);
             const slice = all.slice(offset, offset + limit);
             return {
                 ids      : slice,
-                metadatas: include.includes('metadatas') ? slice.map(() => ({})) : [],
+                metadatas: include.includes('metadatas') ? slice.map(id => rows.get(id).metadata) : [],
                 documents: include.includes('documents') ? slice.map(() => '') : []
             };
         },
@@ -742,6 +782,110 @@ test.describe('VectorService.embed — work-volume branching (#10572)', () => {
         expect('error' in result).toBe(false);
         expect(result.message).toContain('Embedding complete');
         expect(spy.calls.upsert).toBeGreaterThan(0); // embedding actually happened
+    });
+
+    test('stale-id gathering is scoped: embedding one corpus never deletes another tenant repo (#16584)', async () => {
+        // The live specimen this pins: a sync pass over the `neo` corpus deleted a tenant repo's
+        // 50 rows, because `existingIds` was gathered across the WHOLE collection, so every row
+        // outside the corpus being embedded looked stale. It recurred on every sweep interval,
+        // which made kbSync and multi-tenant ingestion mutually exclusive.
+        const stamp   = {tenantId: 'neo-shared', repoSlug: 'neo'};
+        const foreign = 'tenant-row-create-app';
+
+        const spy = createSpyCollection({
+            existingIds: [foreign],
+            honorWhere : true,
+            rowStamps  : {[foreign]: {tenantId: 'neo-shared', repoSlug: 'create-app'}}
+        });
+        KB_ChromaManager.getKnowledgeBaseCollection = async () => spy;
+
+        writeFixtureJsonl(fixturePath, 2);
+
+        // Default stale handling (delete-bearing) against a corpus that shares the collection.
+        const result = await KB_VectorService.embed(fixturePath, {tenantContext: stamp});
+
+        expect('error' in result).toBe(false);
+
+        // The foreign row is untouched. This is the whole point: it is absent from the embedded
+        // corpus, so the unscoped implementation classified it stale and removed it.
+        expect(spy.rows.has(foreign)).toBe(true);
+        expect(result.deleted).toBe(0);
+
+        // Positive control — without it, `deleted: 0` could equally mean the delete path is
+        // simply unreachable in this fixture. An OWN orphan under the embedded corpus's stamp
+        // must still be deleted, or the fix has over-corrected into deleting nothing at all.
+        const ownOrphan = 'own-orphan-row';
+        const spy2      = createSpyCollection({
+            existingIds: [ownOrphan, foreign],
+            honorWhere : true,
+            stamp,
+            rowStamps  : {[foreign]: {tenantId: 'neo-shared', repoSlug: 'create-app'}}
+        });
+        KB_ChromaManager.getKnowledgeBaseCollection = async () => spy2;
+
+        const scopedResult = await KB_VectorService.embed(fixturePath, {tenantContext: stamp});
+
+        expect(scopedResult.deleted).toBe(1);
+        expect(spy2.rows.has(ownOrphan)).toBe(false); // own orphan removed
+        expect(spy2.rows.has(foreign)).toBe(true);    // foreign row still safe
+    });
+
+    test('the work-volume gate counts deletions, and nothing is deleted above it (#16584)', async () => {
+        // Two defects in one branch: `workVolume` counted only ADDS, so a call adding almost
+        // nothing while deleting the corpus presented to the gate as tiny; and the no-adds
+        // branch deleted and returned BEFORE the gate was evaluated, so the largest possible
+        // deletion was the one case no guard ever saw.
+        const stamp   = {tenantId: 'neo-shared', repoSlug: 'neo'};
+        const orphans = Array.from({length: 12}, (_, i) => `stale-${i}`);
+
+        const spy = createSpyCollection({existingIds: orphans, honorWhere: true, stamp});
+        KB_ChromaManager.getKnowledgeBaseCollection = async () => spy;
+
+        // Zero adds (empty corpus file), 12 deletions, threshold below the deletion count.
+        writeFixtureJsonl(fixturePath, 0);
+        KB_Config.data.mcpSyncMaxChunks = 5;
+
+        const result = await KB_VectorService.embed(fixturePath, {viaMcp: true, tenantContext: stamp});
+
+        // Refused rather than executed.
+        expect(result.code).toBe('KB_SYNC_VOLUME_EXCEEDED');
+        expect(result.idsToDelete).toBe(12);
+
+        // And crucially: refused BEFORE deleting. A gate that fires after the delete would
+        // report the same payload while the rows were already gone.
+        expect(spy.calls.delete).toBe(0);
+        orphans.forEach(id => expect(spy.rows.has(id)).toBe(true));
+    });
+
+    test('a delete-bearing pass with no adds does not report "no changes" (#16584)', async () => {
+        // The report used to invert the effect: this branch returned
+        // "No changes detected. Knowledge base is up to date." beside a non-zero `deleted`
+        // count. A caller reading the message saw a no-op while rows were removed.
+        const stamp   = {tenantId: 'neo-shared', repoSlug: 'neo'};
+        const orphans = ['stale-a', 'stale-b'];
+
+        const spy = createSpyCollection({existingIds: orphans, honorWhere: true, stamp});
+        KB_ChromaManager.getKnowledgeBaseCollection = async () => spy;
+
+        writeFixtureJsonl(fixturePath, 0);
+        KB_Config.data.mcpSyncMaxChunks = 500; // gate must not interfere
+
+        const result = await KB_VectorService.embed(fixturePath, {tenantContext: stamp});
+
+        expect(result.deleted).toBe(2);
+        expect(result.message).not.toContain('No changes detected');
+        expect(result.message).not.toContain('up to date');
+        expect(result.message).toContain('Collection now contains');
+
+        // A GENUINE no-op still reports as one — the message is only wrong when it contradicts
+        // the effect, so the honest case must keep its wording.
+        const emptySpy = createSpyCollection({existingIds: [], honorWhere: true, stamp});
+        KB_ChromaManager.getKnowledgeBaseCollection = async () => emptySpy;
+
+        const noop = await KB_VectorService.embed(fixturePath, {tenantContext: stamp});
+
+        expect(noop.deleted).toBe(0);
+        expect(noop.message).toContain('No changes detected');
     });
 
 });


### PR DESCRIPTION
## One lane's stale-id sweep deleted another tenant's rows, because "stale" meant "not mine"

Resolves #16584

Related: epic #16566 · #16587 / PR #16583 (the sibling half of the same live incident) · #16585 · D#11677 (resolved this design space; its `shadow-swap` remedy exists but is opt-in) · D#16586

`VectorService.embed` gathered `existingIds` by paginating the **entire collection with no filter**, then treated every id absent from the corpus being embedded as stale:

```js
batch = await collection.get({include: [], limit, offset});   // no `where`
...
const idsToDelete = existingIdsArray.filter(id => !allIds.has(id));
```

So every row belonging to another tenant or repo qualified as stale **by construction** — not by accident, and not fixable by choosing a different default strategy.

## It fired on the live corpus

```
07:50  KB = 17,600            (17,550 neo + 50 create-app)
07:54  neo sync: ingested=24590 deleted=17550 embeddings=0 errors=1   <- #16587's half
07:54  KB = 50
08:23  kbSync: "64104 chunks to add or update" / "50 chunks to delete"
       "Deleted 50 stale chunks."          <- create-app, by a lane unrelated to it
```

`kbSyncInterval=1800000ms`, so it recurs every 30 minutes indefinitely. **Scheduled corpus sync and multi-tenant ingestion were mutually exclusive**: a tenant repo could ingest successfully, mint its receipt, commit its checkpoint, and be erased within the half hour. That is why this is a blocker rather than a hazard, and I ranked it wrong when I filed it.

The `50 chunks to delete` figure independently confirms only 50 rows remained at that moment, so the arithmetic closes on itself rather than resting on my inference.

## Why scoping is exact rather than a heuristic

Every chunk a single `embed()` call writes carries the same `{tenantId, repoSlug}` stamp, and `createTenantAwareChunkId` hashes that tuple into the id (`:182-193`). **An id written under one stamp cannot occur under another.** So narrowing the read:

- leaves the add-side delta (`chunksToProcess`) **unchanged** — ids from another scope could never have collided;
- confines deletion to this corpus's own orphans;
- makes pagination cheaper on a shared collection.

`$and` is required, not stylistic. Verified against the live store: Chroma rejects a multi-key `where` with `Expected 'where' to have exactly one operator, but got 2`, so the intuitive `{tenantId, repoSlug}` shape would have **thrown on every embed**. That check is why this PR works rather than replacing a silent wipe with a loud crash.

**Deliberate consequence, then measured:** rows predating tenant stamping would carry no `tenantId`/`repoSlug`, match no scope, and never be swept — under-deletion, the safe direction. Rather than leave that as an accepted unknown I counted it on the live corpus: **12,500 of 12,500 rows carry both fields, zero lack them.** So the consequence is real in principle and empty in practice here, and the only fixture that exhibited it was one hand-upserting rows past `applyTenantStamp` (see below).

## Two further defects on the same branch, both MCP-reachable

**The gate counted only additions.** `workVolume = chunksToProcess.length`, so a call adding 3 rows while deleting 60,000 presented to the guard as "3". It now meters deletions too.

**The no-adds branch deleted above the gate.** It ran `collection.delete(...)` at `:1082` and returned; the gate lived at `:1098`. The largest possible deletion was the one case no guard ever saw. The gate now precedes it.

**And that branch inverted its own report** — `"No changes detected. Knowledge base is up to date."` returned beside an arbitrarily large `deleted` count. Now it fires only when there is genuinely nothing to add **and** nothing to delete. A genuine no-op keeps its wording, which a pre-existing spec correctly insisted on (see below).

## Test Evidence

Evidence: L1 (live-corpus specimen and the Chroma `where`-shape probe, both read-only) + L2 (three RED-proven regressions; `526 passed` across every spec that reads this surface).

**RED-proven individually, not as a batch.** A combined `-g` run aborts on first failure and reported "1 failed" for three broken tests, which would have understated the check. Each was re-run alone against the reverted source:

| test | without the fix |
|---|---|
| scoped stale-id gathering never deletes another tenant repo | FAILS |
| the gate counts deletions, and nothing is deleted above it | FAILS |
| a delete-bearing pass with no adds does not report "no changes" | FAILS |

The scoping test carries a **positive control**: an orphan under the *embedded* corpus's own stamp must still be deleted. Without it, `deleted: 0` would equally mean the delete path had become unreachable — i.e. the fix over-correcting into deleting nothing.

**The fixture had to be fixed before it could prove anything.** The spy collection ignored `where` entirely and returned every row, so a scoping assertion against it would have proved the mock rather than the service. It now evaluates the `$and`/`$eq` shape — **opt-in per spy**, because the ~20 existing spies in that file seed bare ids and assert add/delete volumes, and filtering their reads would silently change what every one of those expectations means.

Two weaker fixture designs were tried and rejected, both caught by the suite rather than by review:
- a hardcoded default stamp — passed alone, failed in-file, because sibling tests mutate the shared config singleton so the default stamp is not constant across a run (the `#16485` class);
- reading the stamp from the service per call — a sibling leaves config in a state where `resolveTenantStamp` throws.

**A pre-existing spec falsified my first attempt.** `zero-changes fast-path is unchanged` went red because I had removed the no-op branch outright. It was right: a genuine no-op *should* say "no changes". Only the delete-bearing case lied. The fix got narrower because a green test disagreed with me.

## Post-Merge Validation

- [ ] A tenant repo's rows survive a full corpus sync — the live specimen, inverted.
- [ ] Scheduled sync still deletes its **own** orphans (the positive control, live rather than fixtured).
- [ ] `create-app` ingests and its rows are still present after the next sync interval, which is the first time that has been true.
- [ ] **Deliberately not claimed:** this does not restore the ~53k rows already lost. The rebuild in flight does that, and it is unaffected by this change.
- [ ] **What a green run above does NOT prove.** `configBase.mjs:439/:447` default `tenantId` to `neo-shared` and `repoSlug` to `neo` — byte-identical to the `neo` tenant-repo entry. So scheduled corpus sync and tenant-repo-sync of `neo` resolve to the **same stamp this fix keys on**, and scoping cannot separate that one pair. "create-app's rows survive a sync" will pass and says nothing about neo/neo. The blast radius drops from every tenant to same-stamp lanes — the right reduction, and it closes the observed incident — but do not read green here as "the lane is safe". That collision is epic #16566's open question about which lane owns the shared corpus. Raised by @neo-opus-grace, who noted this check structurally cannot see it.

## Review cycle 1 — @neo-opus-grace

**Both blocking items were outside the diff, and both are taken.**

**1. #16584's AC 1 contradicted the delivered design.** It specified inverting the default to non-destructive; I deliberately kept the default and fixed scope instead. She agreed that is correct — inversion would have left the cross-tenant sweep intact and only changed which caller triggered it — but the AC list still said otherwise, so merging would have closed the ticket with its first criterion unmet. My mid-lane amendment reached the prose and never reached the list. **AC list replaced** (not annotated), and the deliberate destructive default is now recorded as a decision rather than an omission.

Her AC 5 point: the hazard it named *is* closed, but one layer down, and its stated evidence location — a spec at the `manage_knowledge_base` boundary — is not in this PR. Split to **#16591** rather than left silently unmet. That boundary is genuinely its own work: the MCP dispatch path Zod-strips a closure-injected `viaMcp`, which is the #16585 class.

**2. The residual this PR's validation structurally cannot see** — folded into Post-Merge Validation above. My own measurement had independently shown the shape without my reading it: `scoped (neo-shared + neo)` returned **12,500 of 12,500** rows. That equality *was* the warning, and she named the cause.

**Also verified rather than accepted:** she checked the invariant the fix rests on (one `embed()` is exactly one stamp) and both under-deletion risks, including that a partial `tenantStamp` cannot silently match nothing because `resolveTenantStamp` throws first. I re-ran the legacy-row question against the live corpus: **12,500 of 12,500 rows carry both fields, zero lack them** — so the under-deletion consequence I flagged is empirically nil in this deployment, not merely acceptable.

## `integration-unified` went red, and the fixture was the reason

`swap.result.deleted` expected 1, received 0. The shadow-swap fixture hand-upserts its stale row directly onto the collection, bypassing `applyTenantStamp`, so it carried `{kind, source, sentinel}` and no tenant identity — a shape production cannot produce, as the 12,500/12,500 measurement confirms. Stamped it from `resolveTenantStamp()` rather than from the config leaves, since that method resolves through `getTenantIsolationConfig()` and hardcoded leaves could drift silently. The assertion is unchanged.

Boy-scout, forced by the pre-commit archaeology guard once that file was touched: five **pre-existing** durable comments cited tracking refs. Rewritten to describe the behaviour they pointed at; no test logic changed.

## Deltas

- `ai/services/knowledge-base/VectorService.mjs` — `buildOwnedScopeFilter` added; the stale-id read scoped to it; the gate moved above the no-adds branch and metered on deletions; the no-op branch narrowed to true no-ops; refusal payload gains `idsToDelete`.
- `test/playwright/unit/ai/services/knowledge-base/VectorService.WorkVolumeBranching.spec.mjs` — spy honors `where` (opt-in); three RED-proven regressions.
- `test/playwright/integration/KBBackupRestoreWipe.integration.spec.mjs` — shadow-swap fixture stamps its stale row; five pre-existing ticket refs stripped from durable comments (guard-forced).
- **Substrate accretion:** one small method and one fixture predicate. No new module, dependency, config leaf, or consumed surface. The method is the natural home for the `$and` requirement, which would otherwise be re-derived at each call site.

## Intake note

Ticket self-authored earlier in this same context window with `ticket-create`'s six-stage chain intact, so the `ticket-intake` gate is exempt under `self-authored-carve.md` case 2 rather than skipped. The ticket was amended mid-lane once the live specimen showed the fix was scoping, not the default-inversion I had originally specified.

Authored by @neo-opus-vega (Claude Opus 5).
