### PR TITLE
The tenant roster drops neo and gains two external proof repos (#16592)

### DIFF
--- a/ai/deploy/kb-config.yaml
+++ b/ai/deploy/kb-config.yaml
@@ -1,20 +1,31 @@
-# Tenant bootstrap for the containerized plane's pull-mode KB ingestion. Two repos under one
-# tenant (`neo-shared`), keyed as `tenantId/repoSlug`:
+# Tenant bootstrap for the containerized plane's pull-mode KB ingestion. Three repos under one
+# tenant (`neo-shared`), keyed as `tenantId/repoSlug` — all genuinely EXTERNAL to the maintainer
+# checkout, which is the lane's actual purpose:
 #
-#   neo-shared/neo         — the Neo repo itself (docs, src, and the hourly datasync artifacts under
-#                            resources/content/), so `ask_knowledge_base` answers from the current
-#                            head instead of the last restore snapshot.
-#   neo-shared/create-app  — the scaffolding repo. Small on purpose: first-ingest cost scales with
-#                            tracked-file count on a blobless mirror (~0.42 s/file cold, #16557), so
-#                            a tiny repo is the cheap end-to-end PROOF that pull-mode ingestion works
-#                            — `lastIngestedRev` going non-null is the artifact no unit test provides.
-#                            It is also the only tenant here that is genuinely EXTERNAL to the
-#                            maintainer checkout, so it exercises the lane's actual purpose rather
-#                            than re-ingesting the corpus `kbSync` already owns.
+#   neo-shared/create-app        — the scaffolding repo. Small on purpose: first-ingest cost scales
+#                                  with tracked-file count on a blobless mirror, so a tiny repo is
+#                                  the cheap end-to-end PROOF that pull-mode ingestion works —
+#                                  `lastIngestedRev` going non-null is the artifact no unit test
+#                                  provides.
+#   neo-shared/devindex-opt-in   — 4 tracked files.
+#   neo-shared/devindex-opt-out  — 3 tracked files. Together with create-app these give the lane a
+#                                  MULTI-repo witness: per-repo scheduling, jitter, independent
+#                                  backoff and per-repo checkpointing had only ever been exercised
+#                                  against a single viable entry.
 #
-# `branchRef` is per-repo and NOT inheritable: neo integrates on `dev`, create-app has only `main`
-# (verified against the remote — it has no `dev` branch at all). Copying a sibling's `branchRef` is
-# a clone failure waiting to happen.
+# The Neo repo itself is deliberately NOT registered here. `kbSync` already ingests neo's content
+# through 10 source extractors, producing TYPED chunks (`type`, `kind`) that `query_documents` and
+# `get_class_hierarchy` consume. A pull-mode entry for the same repo declares no parser, so it falls
+# through to `RawRepoSource` and yields untyped raw-file chunks — a second, weaker corpus under the
+# SAME `{tenantId, repoSlug}` stamp that `kbSync` resolves to by default. Each lane then classifies
+# the other's rows as stale and deletes them. Neo returns as a tenant once sources and parsers are
+# declarable per tenant, so it can use our own extractors instead of the raw-file fallback; that is
+# sequencing, not a retreat from the goal.
+#
+# `branchRef` is per-repo and NOT inheritable: every entry above has only `main` (verified against
+# each remote). Copying a sibling's `branchRef` is a clone failure waiting to happen — and note that
+# no entry currently differs from its `default_branch`, so the resolution path has no live witness
+# until a non-default-branch tenant is added.
 #
 # Read fail-soft from `<neoRootDir>/kb-config.yaml` — tier 2 of the tenant-config resolution
 # (KnowledgeBaseTenantConfig graph node → THIS file → aiConfig defaults). The document root is a
@@ -31,12 +42,17 @@ tenants:
   neo-shared:
     tenantRepos:
       - tenantId: neo-shared
-        repoSlug     : neo
-        cloneUrl     : https://github.com/neomjs/neo.git
-        credentialRef: none
-        branchRef    : dev
-      - tenantId: neo-shared
         repoSlug     : create-app
         cloneUrl     : https://github.com/neomjs/create-app.git
+        credentialRef: none
+        branchRef    : main
+      - tenantId: neo-shared
+        repoSlug     : devindex-opt-in
+        cloneUrl     : https://github.com/neomjs/devindex-opt-in.git
+        credentialRef: none
+        branchRef    : main
+      - tenantId: neo-shared
+        repoSlug     : devindex-opt-out
+        cloneUrl     : https://github.com/neomjs/devindex-opt-out.git
         credentialRef: none
         branchRef    : main

--- a/test/playwright/unit/ai/deploy/KbTenantBootstrapContract.spec.mjs
+++ b/test/playwright/unit/ai/deploy/KbTenantBootstrapContract.spec.mjs
@@ -72,21 +72,29 @@ test.describe('ai/deploy/kb-config.yaml — tenant bootstrap contract', () => {
             document = yamlLoad(fs.readFileSync(path.join(repoRoot, bootstrapRel), 'utf8')),
             repos    = document.tenants['neo-shared'].tenantRepos;
 
-        expect(repos).toHaveLength(2);
+        expect(repos).toHaveLength(3);
 
         const normalized = repos.map(normalizeTenantRepoEntry);
 
-        expect(normalized[0].tenantId).toBe('neo-shared');
-        expect(normalized[0].repoSlug).toBe('neo');
-        expect(normalized[0].cloneUrl).toBe('https://github.com/neomjs/neo.git');
-        expect(normalized[0].credentialRef).toBe('none');
-        expect(normalized[0].branchRef).toBe('dev');
+        const expected = [
+            {repoSlug: 'create-app',       cloneUrl: 'https://github.com/neomjs/create-app.git'},
+            {repoSlug: 'devindex-opt-in',  cloneUrl: 'https://github.com/neomjs/devindex-opt-in.git'},
+            {repoSlug: 'devindex-opt-out', cloneUrl: 'https://github.com/neomjs/devindex-opt-out.git'}
+        ];
 
-        expect(normalized[1].tenantId).toBe('neo-shared');
-        expect(normalized[1].repoSlug).toBe('create-app');
-        expect(normalized[1].cloneUrl).toBe('https://github.com/neomjs/create-app.git');
-        expect(normalized[1].credentialRef).toBe('none');
-        expect(normalized[1].branchRef).toBe('main')
+        expected.forEach((entry, index) => {
+            expect(normalized[index].tenantId).toBe('neo-shared');
+            expect(normalized[index].repoSlug).toBe(entry.repoSlug);
+            expect(normalized[index].cloneUrl).toBe(entry.cloneUrl);
+            expect(normalized[index].credentialRef).toBe('none');
+            expect(normalized[index].branchRef).toBe('main');
+        });
+
+        // The Neo repo is deliberately absent: `kbSync` already ingests it through the source
+        // extractors, and a pull-mode entry for the same repo declares no parser, so it produced a
+        // second untyped corpus under the same `{tenantId, repoSlug}` stamp `kbSync` defaults to —
+        // after which each lane deleted the other's rows as stale.
+        expect(normalized.some(repo => repo.repoSlug === 'neo')).toBe(false)
     });
 
     test('repo identity is unique per tenantId/repoSlug, which is what keeps the two corpora apart', () => {
@@ -100,22 +108,45 @@ test.describe('ai/deploy/kb-config.yaml — tenant bootstrap contract', () => {
                 .map(repo => `${repo.tenantId}/${repo.repoSlug}`);
 
         expect(new Set(keys).size).toBe(keys.length);
-        expect(keys).toEqual(['neo-shared/neo', 'neo-shared/create-app'])
+        expect(keys).toEqual([
+            'neo-shared/create-app',
+            'neo-shared/devindex-opt-in',
+            'neo-shared/devindex-opt-out'
+        ])
     });
 
-    test('branchRef is declared per repo and never inherited from a sibling', () => {
-        // create-app has no `dev` branch at all (verified against the remote), so inheriting neo's
-        // `dev` would make its clone fail. This pins that the two differ ON PURPOSE — a future
-        // normalization that defaults a missing branchRef from a sibling breaks this.
+    test('every repo declares its own branchRef rather than relying on a sibling or a default', () => {
+        // This asserts the actual invariant — each entry declares `branchRef` EXPLICITLY — rather
+        // than the older proxy for it, "neo says dev and create-app says main, so they differ".
+        //
+        // That proxy had to be replaced rather than updated. With the neo entry removed,
+        // `bySlug.neo` becomes undefined and `undefined !== 'main'` still passes, so the old
+        // assertion would have gone VACUOUS instead of red — a green test proving nothing.
+        //
+        // Coverage regression stated on purpose: neo was the only entry whose branchRef differed
+        // from its `default_branch`, so nothing here currently exercises resolving a NON-default
+        // branch. A future non-default-branch tenant should restore that, and this comment is the
+        // pointer for whoever adds one.
         const
             document = yamlLoad(fs.readFileSync(path.join(repoRoot, bootstrapRel), 'utf8')),
-            bySlug   = Object.fromEntries(document.tenants['neo-shared'].tenantRepos
-                .map(normalizeTenantRepoEntry)
-                .map(repo => [repo.repoSlug, repo.branchRef]));
+            entries  = document.tenants['neo-shared'].tenantRepos;
 
-        expect(bySlug.neo).toBe('dev');
+        expect(entries.length).toBeGreaterThan(1);
+
+        entries.forEach(entry => {
+            // Read the RAW yaml entry, not the normalized one: a normalizer that defaults a
+            // missing branchRef would hide the omission this test exists to catch.
+            expect(typeof entry.branchRef, `${entry.repoSlug} declares branchRef`).toBe('string');
+            expect(entry.branchRef.trim().length).toBeGreaterThan(0);
+        });
+
+        const bySlug = Object.fromEntries(entries
+            .map(normalizeTenantRepoEntry)
+            .map(repo => [repo.repoSlug, repo.branchRef]));
+
         expect(bySlug['create-app']).toBe('main');
-        expect(bySlug.neo).not.toBe(bySlug['create-app'])
+        expect(bySlug['devindex-opt-in']).toBe('main');
+        expect(bySlug['devindex-opt-out']).toBe('main')
     });
 
     test('exactly the two consuming services mount the bootstrap read-only in the local-agent-os overlay', () => {

--- a/test/playwright/unit/ai/deploy/KbTenantBootstrapContract.spec.mjs
+++ b/test/playwright/unit/ai/deploy/KbTenantBootstrapContract.spec.mjs
@@ -127,6 +127,13 @@ test.describe('ai/deploy/kb-config.yaml — tenant bootstrap contract', () => {
         // from its `default_branch`, so nothing here currently exercises resolving a NON-default
         // branch. A future non-default-branch tenant should restore that, and this comment is the
         // pointer for whoever adds one.
+        //
+        // Note this is a DEPLOYMENT POLICY on top of the access contract, not a restatement of it:
+        // `tenantRepoAccessContract` documents `branchRef` as present only when configured, so an
+        // entry that omits it is contract-legal and fails this test on purpose. Silent inheritance
+        // from a sibling is the failure the config comment warns about, so this bootstrap requires
+        // what the contract merely permits. A future author hitting this is looking at a policy
+        // decision, not a contract break.
         const
             document = yamlLoad(fs.readFileSync(path.join(repoRoot, bootstrapRel), 'utf8')),
             entries  = document.tenants['neo-shared'].tenantRepos;


### PR DESCRIPTION
## Two lanes, one identity, different content — so each deleted the other

Resolves #16592

Related: epic #16566 · the acquisition-vs-extraction lane on D#15605 (hub, incl. the overdue N=1 point-3 receipt) · #16584 / PR #16590 (scoping — fixes cross-repo deletion, cannot separate same-stamp lanes) · #16587 / PR #16583 · #16557 (held) · D#12034

`kbSync` ingests neo through 10 source extractors and emits **typed** chunks — `type: src|adr`, `kind: method|class-config|module-context|class-properties` — which is what `query_documents({type})` and `get_class_hierarchy` consume. The pull-mode `neo` tenant entry declared **no `parserId`**, so it fell through to `RawRepoSource` and emitted untyped raw-file chunks.

Both stamp `{tenantId: neo-shared, repoSlug: neo}` — `configBase.mjs:439/:447` default the stamp to exactly that tuple. **Same identity, different chunk populations**, so each lane classified the other's rows as stale.

Live, 2026-08-06:

```
07:54  neo tenant sync: deleted=17550  embeddings=0     <- delete succeeded, embed refused
08:23  kbSync: "50 chunks to delete" / "Deleted 50 stale chunks."   <- create-app, unrelated lane
```

## Why removing the entry loses nothing

The corpus it produced was **strictly weaker** than the one `kbSync` already provides for the same repo: untyped chunks cannot serve the typed-retrieval contract. It also cost ~24k blob fetches per fresh mirror — confirmed at the provider as **24,834 clones on 2026-08-05** against a ~1k/day baseline, uniques *falling* to 78 because it was one cloner.

**Sequencing, not a retreat.** Neo returns as a tenant once sources and parsers are declarable per tenant, using our own extractors instead of the raw-file fallback — which is what D#15605's N=1 slice was reaching for. `SourceRegistry` already promises that surface and `parserId` is already plumbed per repo; nothing is declared yet.

## What the two additions buy

| repo | visibility | branches | blobs | size |
|---|---|---|---|---|
| `devindex-opt-in` | public | **main only** | 4 | 3 KB |
| `devindex-opt-out` | public | **main only** | 3 | 1 KB |

Verified against each remote, so `branchRef: main` is read rather than copied — the config's own comment warns that `branchRef` is per-repo and not inheritable.

With create-app that gives the lane its **first multi-repo witness**: per-repo scheduling, jitter, independent backoff and per-repo checkpointing had only ever run against one viable entry. Combined ~7 tracked files, so the full sweep is seconds and cannot reproduce the clone cost.

## Test Evidence

Evidence: L1 (live collision logs, per-repo corpus counts, and remote verification of both additions) + L2 (`234 passed` across every spec that reads this roster; the contract spec RED-proven against the reverted config).

`KbTenantBootstrapContract.spec.mjs` exists to guard these tracked bytes through the production reader/normalizer, so it moves with them. **RED-proven:** with only the config reverted it goes **3 failed / 4 passed** — it tracks the bytes rather than restating them.

**One test had to be replaced rather than updated, and this is the part worth reviewing.** `branchRef is declared per repo and never inherited` asserted *"neo says `dev`, create-app says `main`, so they differ"*. With the neo entry gone, `bySlug.neo` is `undefined` and `undefined !== 'main'` **still passes** — it would have gone **vacuous instead of red**, a green test proving nothing. It now asserts the actual invariant: every entry declares `branchRef` explicitly, read from the **raw yaml** rather than the normalized entry, so a normalizer that defaults a missing `branchRef` cannot hide the omission the test exists to catch.

## Post-Merge Validation

- [ ] Three repos resolve; a cycle summary reports 3 rather than 2, each with an independent checkpoint.
- [ ] `create-app` mints a receipt and commits its checkpoint — `lastIngestedRev` non-null, lane `completed`.
- [ ] Its rows **survive the following `kbSync`**. First time both have been true.
- [ ] Per-`repoSlug` counts non-zero for all three after a full sweep plus one `kbSync` — no lane deletes another's rows.
- [ ] No clone spike: the combined tenant surface is ~7 files.
- [ ] **Deliberately not claimed:** this does not make neo's content reachable via pull-mode, and does not restore rows already lost. `kbSync` covers neo, and the in-flight rebuild covers the rows.

## Dependency — satisfied, and stated because nothing stated it

**This change requires #16584 / PR #16590 (scoped stale-deletion) to be present.** Without it, `kbSync` sweeps stale ids across the whole collection, so a roster of three exposes three corpora to being wiped every interval instead of one — and ACs 3/4/5 would fail reading as *"the new roster does not work"*, which is the wrong diagnosis and costs a cycle.

**Already satisfied, verified rather than assumed:** #16590 merged at `2026-08-06T11:54:28Z`, and `git merge-base --is-ancestor 742021bf58 origin/agent/16592-tenant-roster-swap` returns true — it is in this branch's **base**, not a sibling PR, and `buildOwnedScopeFilter` plus the scoped read are present in the branch itself. So the ordering hazard cannot occur as things stand.

Recorded anyway because a **revert of #16590, or a cherry-pick of this change onto an older base, reinstates it silently** — the failure mode is a wiped corpus with a misleading diagnosis, and nothing in this body previously named the dependency. Raised by @neo-opus-grace, who was right that "probably fine" is not a merge instruction on a live plane.

**And the ordering matters more than it looks**, for a reason discovered after this PR was opened: until #16587 / PR #16583 landed, the `viaMcp` strip made the neo tenant lane fail at embed on every attempt, so the untyped duplicate corpus **never actually existed** — a full-corpus census of all 15,950 rows shows `rootKind: undefined` and `parserId: undefined` throughout, i.e. 100% typed `kbSync` output. #16583 removed the bug that was suppressing the duplicate. So the next deploy *without* this PR would let the neo tenant lane succeed for the first time and inject ~24,590 untyped chunks under `{neo-shared, neo}`, manufacturing the duplicate that has so far only been theoretical.

## Known coverage regression this accepts

neo was the **only** entry whose `branchRef` differed from its `default_branch`. Every remaining entry is `main`-on-`main`, so nothing exercises resolving a **non-default** branch — precisely the path whose "not inheritable" lesson the config comment records. Stated in the config comment and in the spec so whoever adds a non-default-branch tenant restores it, rather than leaving it to be rediscovered.

## Deltas

- `ai/deploy/kb-config.yaml` — `neo` removed; `devindex-opt-in` + `devindex-opt-out` added; header comment rewritten to explain why neo is absent and to name live entries in the `branchRef` lesson.
- `test/playwright/unit/ai/deploy/KbTenantBootstrapContract.spec.mjs` — roster assertions updated; the vacuity-prone `branchRef` test replaced with the real invariant, and its requirement named as a deployment policy on top of `tenantRepoAccessContract` rather than a restatement of it (an entry omitting `branchRef` is contract-legal and fails here on purpose).
- **Substrate accretion:** net two config entries and no new surface. The removed entry takes a duplicate corpus and a recurring ~24k-fetch cost with it.

Authored by @neo-opus-vega (Claude Opus 5).
