### PR TITLE
A store at its memory ceiling is diagnosed and told to raise it (#16596)

### DIFF
--- a/ai/daemons/orchestrator/services/ContainerHealthDiagnosisService.mjs
+++ b/ai/daemons/orchestrator/services/ContainerHealthDiagnosisService.mjs
@@ -27,20 +27,75 @@ export const CONTAINER_HEALTH_ACTION_CLASSES = Object.freeze({
 });
 
 /**
- * @summary Services whose memory footprint is a function of STORED data rather than arrival rate.
+ * @summary The two service classes a heal decision can be reasoned about.
  *
- * The distinction decides which heal is coherent. For a transient-work process, memory pressure
- * comes from what is arriving, so shedding load relieves it. For a store, the corpus IS the
- * workload: resident memory is a near-deterministic function of rows already persisted, nothing
- * can be shed, and a restart frees nothing durable — the pressure returns as soon as the data is
- * reloaded. Prescribing `throttle-shed` to a store is therefore not merely ineffective; it is the
- * one class of service for which no available action could have worked.
- *
- * Keyed by service key rather than by image so a deployment that swaps the store implementation
- * keeps the classification. Unlisted services are treated as transient, which preserves the
- * previous behaviour for everything that is not named here.
+ * Keyed by service key rather than by image, so a deployment that swaps the store implementation
+ * keeps its classification.
  */
-export const STORE_BACKED_SERVICE_KEYS = Object.freeze(new Set(['chroma']));
+export const SERVICE_CLASSES = Object.freeze({store: 'store', transient: 'transient'});
+
+/**
+ * @summary EXHAUSTIVE service classification, declared per key rather than inferred from absence.
+ *
+ * Covers every key in `orchestrator.deploymentRuntimeAccess.allowedServices`, which is the roster
+ * the bridge actually iterates (`DeploymentStateBridgeService.getServiceKeys()` falls back to it).
+ * A spec asserts that coverage, so adding a service to the roster without classifying it fails a
+ * test instead of silently inheriting a policy.
+ *
+ * The previous shape was a `Set` of store keys, and absence meant transient. Two defects followed.
+ * **It was not total:** only `chroma` and a non-existent `'model'` were ever exercised, while
+ * `kb-server` and `mc-server` were unclassified, so a future store-backed service would silently
+ * receive the 90% transient threshold it cannot survive. **And it was not immutable:**
+ * `Object.freeze` on a `Set` locks own properties while `add`/`delete` mutate an internal slot, so
+ * `Object.isFrozen` returned `true` on a set whose membership was still writable — a
+ * false-assurance guarantee, which is worse than none. A frozen plain object genuinely resists
+ * writes, and the spec proves it by attempting them rather than by asserting the predicate.
+ */
+export const SERVICE_CLASS_BY_KEY = Object.freeze({
+    // The corpus IS the workload: resident memory tracks rows already persisted, so nothing can be
+    // shed and a restart frees nothing durable.
+    'chroma'     : SERVICE_CLASSES.store,
+    'kb-server'  : SERVICE_CLASSES.transient,
+    'mc-server'  : SERVICE_CLASSES.transient,
+    'local-model': SERVICE_CLASSES.transient
+});
+
+/**
+ * @summary Classifies a service key, reporting whether the classification was DECLARED.
+ *
+ * `validateServiceKey` accepts any safe string rather than a roster member, so the key space is
+ * unbounded and an unknown key must not silently acquire transient policy. It still defaults to
+ * transient — that preserves existing behaviour and refusing would make the diagnosis path fail on
+ * an unrecognised deployment — but `declared: false` travels with it so the guess is recorded in
+ * the emitted evidence instead of disappearing.
+ *
+ * @param {String} serviceKey
+ * @returns {Object} `{serviceClass, declared}`
+ */
+export function classifyServiceKey(serviceKey) {
+    const declaredClass = Object.hasOwn(SERVICE_CLASS_BY_KEY, serviceKey)
+        ? SERVICE_CLASS_BY_KEY[serviceKey]
+        : null;
+
+    return {
+        serviceClass: declaredClass ?? SERVICE_CLASSES.transient,
+        declared    : declaredClass !== null
+    };
+}
+
+/**
+ * @summary True when the service's memory footprint is a function of STORED data.
+ *
+ * The distinction decides which heal is coherent. For transient work, pressure comes from arrival
+ * rate, so shedding relieves it. For a store, prescribing `throttle-shed` is not merely
+ * ineffective — it is the one class of service for which no available action could have worked.
+ *
+ * @param {String} serviceKey
+ * @returns {Boolean}
+ */
+export function isStoreBackedService(serviceKey) {
+    return classifyServiceKey(serviceKey).serviceClass === SERVICE_CLASSES.store;
+}
 
 export const DEFAULT_CONTAINER_HEALTH_DIAGNOSIS_CONFIG = Object.freeze({
     cpuSaturationPercent   : 90,
@@ -381,7 +436,8 @@ export class ContainerHealthDiagnosisService extends Base {
             // A store crosses its ceiling by growing, so it needs the earlier threshold: see
             // `storeMemorySaturationPercent`. CPU keeps the single threshold — compute pressure is
             // not monotonic in stored data, so a store has no special claim on it.
-            memoryThreshold = STORE_BACKED_SERVICE_KEYS.has(serviceKey)
+            serviceClassification = classifyServiceKey(serviceKey),
+            memoryThreshold = serviceClassification.serviceClass === SERVICE_CLASSES.store
                 ? this.configValues.storeMemorySaturationPercent
                 : this.configValues.memorySaturationPercent,
             cpuPercents     = samples.map(calculateDockerCpuPercent).filter(Number.isFinite),
@@ -433,9 +489,14 @@ export class ContainerHealthDiagnosisService extends Base {
                     sampleCount     : samples.length,
                     observedWindowMs: memoryWindow.observedWindowMs,
                     requiredWindowMs: this.configValues.sampleWindowMs,
-                    minPercent      : memoryWindow.min,
-                    maxPercent      : memoryWindow.max,
-                    meanPercent     : memoryWindow.mean
+                    // The class the threshold came from, and whether it was DECLARED. An unrostered
+                    // key still defaults to transient, but recording the guess keeps it out of the
+                    // silent path: "unlisted" used to be indistinguishable from "classified".
+                    serviceClass        : serviceClassification.serviceClass,
+                    serviceClassDeclared: serviceClassification.declared,
+                    minPercent          : memoryWindow.min,
+                    maxPercent          : memoryWindow.max,
+                    meanPercent         : memoryWindow.mean
                 }
             }));
         }
@@ -652,7 +713,7 @@ export class ContainerHealthDiagnosisService extends Base {
         const storeMemoryFacts = resourceFacts.filter(fact =>
             fact.type === CONTAINER_HEALTH_FACT_TYPES.memorySaturation &&
             fact.authoritative &&
-            STORE_BACKED_SERVICE_KEYS.has(fact.serviceKey)
+            isStoreBackedService(fact.serviceKey)
         );
 
         if (storeMemoryFacts.length > 0) {

--- a/ai/daemons/orchestrator/services/ContainerHealthDiagnosisService.mjs
+++ b/ai/daemons/orchestrator/services/ContainerHealthDiagnosisService.mjs
@@ -19,15 +19,38 @@ export const CONTAINER_HEALTH_FACT_TYPES = Object.freeze({
 });
 
 export const CONTAINER_HEALTH_ACTION_CLASSES = Object.freeze({
+    raiseCeiling: 'raise-ceiling',
     record      : 'record',
     restart     : 'restart',
     throttleShed: 'throttle-shed',
     warmProvider: 'warm-provider'
 });
 
+/**
+ * @summary Services whose memory footprint is a function of STORED data rather than arrival rate.
+ *
+ * The distinction decides which heal is coherent. For a transient-work process, memory pressure
+ * comes from what is arriving, so shedding load relieves it. For a store, the corpus IS the
+ * workload: resident memory is a near-deterministic function of rows already persisted, nothing
+ * can be shed, and a restart frees nothing durable — the pressure returns as soon as the data is
+ * reloaded. Prescribing `throttle-shed` to a store is therefore not merely ineffective; it is the
+ * one class of service for which no available action could have worked.
+ *
+ * Keyed by service key rather than by image so a deployment that swaps the store implementation
+ * keeps the classification. Unlisted services are treated as transient, which preserves the
+ * previous behaviour for everything that is not named here.
+ */
+export const STORE_BACKED_SERVICE_KEYS = Object.freeze(new Set(['chroma']));
+
 export const DEFAULT_CONTAINER_HEALTH_DIAGNOSIS_CONFIG = Object.freeze({
     cpuSaturationPercent   : 90,
     memorySaturationPercent: 90,
+    // Stores cross their ceiling by GROWING, monotonically and predictably, so the transient
+    // threshold is late for them: at sustained 90% the remaining headroom is smaller than one
+    // ingestion batch, and the store exits cleanly rather than being OOM-killed — no crash
+    // signature, no second chance. 80% leaves room to raise the ceiling before the next batch
+    // rather than after the corpus has already stopped being able to complete.
+    storeMemorySaturationPercent: 80,
     minAuthoritativeFacts  : 2,
     minResourceSamples     : 2,
     // Restarts within the window, on one container generation, before churn is reported. Three is
@@ -354,11 +377,17 @@ export class ContainerHealthDiagnosisService extends Base {
         if (samples.length < this.configValues.minResourceSamples) return [];
 
         const
-            facts          = [],
-            cpuPercents    = samples.map(calculateDockerCpuPercent).filter(Number.isFinite),
-            memoryPercents = samples.map(calculateDockerMemoryPercent).filter(Number.isFinite),
-            cpuWindow      = summarizeSustainedWindow(cpuPercents, this.configValues.cpuSaturationPercent, samples.length),
-            memoryWindow   = summarizeSustainedWindow(memoryPercents, this.configValues.memorySaturationPercent, samples.length);
+            facts           = [],
+            // A store crosses its ceiling by growing, so it needs the earlier threshold: see
+            // `storeMemorySaturationPercent`. CPU keeps the single threshold — compute pressure is
+            // not monotonic in stored data, so a store has no special claim on it.
+            memoryThreshold = STORE_BACKED_SERVICE_KEYS.has(serviceKey)
+                ? this.configValues.storeMemorySaturationPercent
+                : this.configValues.memorySaturationPercent,
+            cpuPercents     = samples.map(calculateDockerCpuPercent).filter(Number.isFinite),
+            memoryPercents  = samples.map(calculateDockerMemoryPercent).filter(Number.isFinite),
+            cpuWindow       = summarizeSustainedWindow(cpuPercents, this.configValues.cpuSaturationPercent, samples.length),
+            memoryWindow    = summarizeSustainedWindow(memoryPercents, memoryThreshold, samples.length);
 
         if (cpuWindow.sustained) {
             facts.push(this.createFact({
@@ -388,7 +417,10 @@ export class ContainerHealthDiagnosisService extends Base {
                 authoritative: true,
                 details      : {
                     metric        : 'memory',
-                    threshold     : this.configValues.memorySaturationPercent,
+                    // The threshold ACTUALLY applied, not the transient default — a store trips at
+                    // `storeMemorySaturationPercent`, and reporting the other number would put a
+                    // falsehood inside the evidence a heal decision is made from.
+                    threshold     : memoryThreshold,
                     sampleCount   : samples.length,
                     sampleWindowMs: this.configValues.sampleWindowMs,
                     minPercent    : memoryWindow.min,
@@ -587,6 +619,42 @@ export class ContainerHealthDiagnosisService extends Base {
             fact.type === CONTAINER_HEALTH_FACT_TYPES.resourceSaturation ||
             fact.type === CONTAINER_HEALTH_FACT_TYPES.memorySaturation
         );
+        // A store at its MEMORY ceiling is the one exhaustion case `throttle-shed` cannot serve: its
+        // footprint tracks rows already persisted, so there is no arrival rate to reduce and a restart
+        // frees nothing durable. Raising the ceiling is the only coherent heal, and the condition is
+        // derived from the evidence's own `serviceKey` rather than a caller-supplied hint, so a
+        // diagnosis cannot claim a class its facts do not support.
+        //
+        // Evaluated BEFORE `hasAuthoritativeEvidence` deliberately, and this is the half that made the
+        // condition undiagnosable rather than merely mis-healed. That gate needs
+        // `minAuthoritativeFacts` (2) corroborating facts, but a store crossing its ceiling saturates
+        // memory while its CPU sits idle — measured live at `mem=81.40% cpu=0.00%` — so it produces
+        // exactly ONE authoritative fact, forever. The floor suppressed the diagnosis entirely, which
+        // is why a store at its ceiling never surfaced at all.
+        //
+        // Single-fact sufficiency is safe HERE and nowhere else: the floor exists to stop action on one
+        // noisy signal, and a sustained-window ratio against a hard limit is not noisy. The window is
+        // already the corroboration the second fact was standing in for, so requiring a second one asks
+        // for a coincidence rather than evidence.
+        //
+        // Scoped to memory on purpose. CPU saturation on a store still routes through the normal
+        // exhaustion path — more room for resident data does not relieve compute pressure.
+        const storeMemoryFacts = resourceFacts.filter(fact =>
+            fact.type === CONTAINER_HEALTH_FACT_TYPES.memorySaturation &&
+            fact.authoritative &&
+            STORE_BACKED_SERVICE_KEYS.has(fact.serviceKey)
+        );
+
+        if (storeMemoryFacts.length > 0) {
+            return {
+                recoveryClass: 'exhaustion',
+                actionClass  : CONTAINER_HEALTH_ACTION_CLASSES.raiseCeiling,
+                confidence   : 0.8,
+                evidenceFacts: this.selectEvidenceFacts(facts, storeMemoryFacts),
+                reason       : 'store-ceiling-exhaustion'
+            };
+        }
+
         if (this.hasAuthoritativeEvidence(resourceFacts, facts)) {
             return {
                 recoveryClass: 'exhaustion',

--- a/ai/daemons/orchestrator/services/ContainerHealthDiagnosisService.mjs
+++ b/ai/daemons/orchestrator/services/ContainerHealthDiagnosisService.mjs
@@ -1144,17 +1144,34 @@ function summarizeSustainedWindow({values, threshold, expectedCount, timestamps 
         ? Math.max(...finiteStamps) - Math.min(...finiteStamps)
         : 0;
 
+    // FULL coverage, not merely two stamps. Filtering non-finite entries out silently narrowed the
+    // claim: three values carrying two stamps 30s apart produced `observedWindowMs = 30000` and
+    // passed a 30s floor, while the third sample was never timed at all. The span was then asserted
+    // over samples no clock had witnessed — the same defect this window was added to close, one
+    // level in. A partial-coverage span is UNKNOWN, and an unknown span cannot satisfy a floor.
+    const stampCoverage = finiteStamps.length / values.length;
+
+    // `minWindowMs <= 0` keeps the count-only semantics unstamped callers rely on, so the coverage
+    // requirement binds exactly where a temporal claim is actually being made.
+    const windowSatisfied = minWindowMs <= 0
+        ? true
+        : stampCoverage === 1 && observedWindowMs >= minWindowMs;
+
     const
         min  = Math.min(...values),
         max  = Math.max(...values),
         mean = values.reduce((sum, value) => sum + value, 0) / values.length;
 
     return {
-        sustained: values.every(value => value >= threshold) && observedWindowMs >= minWindowMs,
+        sustained: values.every(value => value >= threshold) && windowSatisfied,
         min      : roundMetric(min),
         max      : roundMetric(max),
         mean     : roundMetric(mean),
-        observedWindowMs
+        observedWindowMs,
+        // Reported so a fact can say WHY a window failed: an under-length span and a partially
+        // stamped one are different conditions, and collapsing them would make the next diagnosis
+        // of this exact bug start from scratch.
+        stampCoverage: roundMetric(stampCoverage)
     };
 }
 

--- a/ai/daemons/orchestrator/services/ContainerHealthDiagnosisService.mjs
+++ b/ai/daemons/orchestrator/services/ContainerHealthDiagnosisService.mjs
@@ -51,8 +51,8 @@ export const DEFAULT_CONTAINER_HEALTH_DIAGNOSIS_CONFIG = Object.freeze({
     // signature, no second chance. 80% leaves room to raise the ceiling before the next batch
     // rather than after the corpus has already stopped being able to complete.
     storeMemorySaturationPercent: 80,
-    minAuthoritativeFacts  : 2,
-    minResourceSamples     : 2,
+    minAuthoritativeFacts       : 2,
+    minResourceSamples          : 2,
     // Restarts within the window, on one container generation, before churn is reported. Three is
     // chosen to sit above ordinary transients (one restart is noise; two can be a slow dependency
     // coming up) and far below a real loop, which reached 977. The window bounds it to RECENT churn:
@@ -386,8 +386,13 @@ export class ContainerHealthDiagnosisService extends Base {
                 : this.configValues.memorySaturationPercent,
             cpuPercents     = samples.map(calculateDockerCpuPercent).filter(Number.isFinite),
             memoryPercents  = samples.map(calculateDockerMemoryPercent).filter(Number.isFinite),
-            cpuWindow       = summarizeSustainedWindow(cpuPercents, this.configValues.cpuSaturationPercent, samples.length),
-            memoryWindow    = summarizeSustainedWindow(memoryPercents, memoryThreshold, samples.length);
+            // Per-sample observation times, stamped by `rememberStatsSample` when each sample was
+            // taken. The window is now MEASURED from these rather than asserted from config, so
+            // back-to-back samples cannot satisfy a sustained-window claim.
+            timestamps      = samples.map(sample => sample?.observedAtMs).filter(Number.isFinite),
+            minWindowMs     = this.configValues.sampleWindowMs,
+            cpuWindow       = summarizeSustainedWindow({values: cpuPercents, threshold: this.configValues.cpuSaturationPercent, expectedCount: samples.length, timestamps, minWindowMs}),
+            memoryWindow    = summarizeSustainedWindow({values: memoryPercents, threshold: memoryThreshold, expectedCount: samples.length, timestamps, minWindowMs});
 
         if (cpuWindow.sustained) {
             facts.push(this.createFact({
@@ -397,13 +402,17 @@ export class ContainerHealthDiagnosisService extends Base {
                 severity     : 'critical',
                 authoritative: true,
                 details      : {
-                    metric        : 'cpu',
-                    threshold     : this.configValues.cpuSaturationPercent,
-                    sampleCount   : samples.length,
-                    sampleWindowMs: this.configValues.sampleWindowMs,
-                    minPercent    : cpuWindow.min,
-                    maxPercent    : cpuWindow.max,
-                    meanPercent   : cpuWindow.mean
+                    metric     : 'cpu',
+                    threshold  : this.configValues.cpuSaturationPercent,
+                    sampleCount: samples.length,
+                    // The window as MEASURED, beside the minimum enforced. Reporting only the
+                    // configured value put an unobserved claim inside the evidence a heal decision
+                    // reads -- the same defect as reporting the wrong threshold, one field over.
+                    observedWindowMs: cpuWindow.observedWindowMs,
+                    requiredWindowMs: this.configValues.sampleWindowMs,
+                    minPercent      : cpuWindow.min,
+                    maxPercent      : cpuWindow.max,
+                    meanPercent     : cpuWindow.mean
                 }
             }));
         }
@@ -420,12 +429,13 @@ export class ContainerHealthDiagnosisService extends Base {
                     // The threshold ACTUALLY applied, not the transient default — a store trips at
                     // `storeMemorySaturationPercent`, and reporting the other number would put a
                     // falsehood inside the evidence a heal decision is made from.
-                    threshold     : memoryThreshold,
-                    sampleCount   : samples.length,
-                    sampleWindowMs: this.configValues.sampleWindowMs,
-                    minPercent    : memoryWindow.min,
-                    maxPercent    : memoryWindow.max,
-                    meanPercent   : memoryWindow.mean
+                    threshold       : memoryThreshold,
+                    sampleCount     : samples.length,
+                    observedWindowMs: memoryWindow.observedWindowMs,
+                    requiredWindowMs: this.configValues.sampleWindowMs,
+                    minPercent      : memoryWindow.min,
+                    maxPercent      : memoryWindow.max,
+                    meanPercent     : memoryWindow.mean
                 }
             }));
         }
@@ -1035,10 +1045,43 @@ function normalizeStatsSamples({stats, statsSamples}) {
     return stats && typeof stats === 'object' ? [stats] : [];
 }
 
-function summarizeSustainedWindow(values, threshold, expectedCount) {
+/**
+ * @summary Summarizes a sample window, requiring a MEASURED elapsed span rather than a sample count.
+ *
+ * This previously took no timestamps: `sustained` was `every(value >= threshold)` gated only on how
+ * MANY samples arrived, while the emitted evidence stamped `sampleWindowMs` from config as though it
+ * had been observed. Two samples collected milliseconds apart therefore satisfied a "sustained
+ * 30-second window" and the fact said so.
+ *
+ * That matters beyond tidiness because single-fact sufficiency for a store's memory saturation is
+ * justified by the window doing the corroboration a second fact would otherwise provide. An
+ * unenforced window cannot discharge that argument — the reasoning was sound and the implementation
+ * had not earned it.
+ *
+ * @param {Object}   options
+ * @param {Number[]} options.values Metric percentages, one per sample.
+ * @param {Number}   options.threshold Percentage every sample must meet.
+ * @param {Number}   options.expectedCount Sample count floor.
+ * @param {Number[]} [options.timestamps=[]] Per-sample observation times in epoch ms. Absent or
+ *     single-valued yields a zero span, which cannot satisfy a positive `minWindowMs` — unstamped
+ *     samples fail closed rather than inheriting a window they never demonstrated.
+ * @param {Number}   [options.minWindowMs=0] Minimum measured span. `0` preserves count-only
+ *     behaviour for callers that have no temporal claim to make.
+ * @returns {Object} `{sustained, min, max, mean, observedWindowMs}` — the span is returned so the
+ *     caller reports what was measured instead of what was configured.
+ */
+function summarizeSustainedWindow({values, threshold, expectedCount, timestamps = [], minWindowMs = 0}) {
     if (values.length < expectedCount || values.length === 0) {
-        return {sustained: false, min: null, max: null, mean: null};
+        return {sustained: false, min: null, max: null, mean: null, observedWindowMs: null};
     }
+
+    const finiteStamps = timestamps.filter(Number.isFinite);
+
+    // A span needs two distinct observations. One stamp (or none) is zero elapsed time, not an
+    // unknown one, so it must not pass a positive floor.
+    const observedWindowMs = finiteStamps.length > 1
+        ? Math.max(...finiteStamps) - Math.min(...finiteStamps)
+        : 0;
 
     const
         min  = Math.min(...values),
@@ -1046,10 +1089,11 @@ function summarizeSustainedWindow(values, threshold, expectedCount) {
         mean = values.reduce((sum, value) => sum + value, 0) / values.length;
 
     return {
-        sustained: values.every(value => value >= threshold),
+        sustained: values.every(value => value >= threshold) && observedWindowMs >= minWindowMs,
         min      : roundMetric(min),
         max      : roundMetric(max),
-        mean     : roundMetric(mean)
+        mean     : roundMetric(mean),
+        observedWindowMs
     };
 }
 

--- a/ai/daemons/orchestrator/services/DeploymentStateBridgeService.mjs
+++ b/ai/daemons/orchestrator/services/DeploymentStateBridgeService.mjs
@@ -385,7 +385,7 @@ export class DeploymentStateBridgeService extends Base {
         }
 
         if (stats) {
-            this.rememberStatsSample(serviceKey, stats);
+            this.rememberStatsSample(serviceKey, stats, observedAt);
         }
 
         providerResidency = await this.collectProviderResidency({serviceKey, observedAt});
@@ -690,14 +690,25 @@ export class DeploymentStateBridgeService extends Base {
 
     /**
      * Stores a bounded stats sample window per service.
+     *
+     * Each sample is stamped with its observation time, because the consumer's sustained-window
+     * check measures the elapsed span across the window rather than counting samples. Without the
+     * stamp there is no span to measure, and two samples taken milliseconds apart would satisfy a
+     * "sustained 30 seconds" claim — which is what let single-fact sufficiency rest on a window
+     * nothing had observed.
+     *
      * @param {String} serviceKey Service key.
      * @param {Object} stats Docker stats sample.
+     * @param {Number} [observedAt] Epoch ms for this sample. Omitted leaves the sample unstamped,
+     *     which fails the span check closed rather than inheriting an unearned window.
      * @returns {void}
      */
-    rememberStatsSample(serviceKey, stats) {
+    rememberStatsSample(serviceKey, stats, observedAt) {
         const samples = this.statsSamplesByService.get(serviceKey) || [];
 
-        samples.push(stats);
+        // Shallow copy with an additive key: the percent calculators read specific Docker fields and
+        // ignore anything else, so this cannot alter their arithmetic.
+        samples.push(Number.isFinite(observedAt) ? {...stats, observedAtMs: observedAt} : stats);
 
         this.statsSamplesByService.set(serviceKey, samples.slice(-AiConfig.orchestrator.deploymentStateBridge.statsSampleWindow));
     }

--- a/ai/deploy/docker-compose.yml
+++ b/ai/deploy/docker-compose.yml
@@ -43,8 +43,26 @@ services:
       - neo-mcp-network
     deploy:
       resources:
+        # Parameterised so the ceiling is REACHABLE — a hardcoded literal cannot be raised by a
+        # controller, which is why a store at its limit had no available heal. Same form
+        # `local-model` already uses below.
+        #
+        # The default is derived, not preferred. Chroma holds its vectors resident (HNSW is a
+        # memory-resident index; sqlite keeps documents on disk), so the requirement is arithmetic:
+        # measured 2026-08-06 at 77,044 rows / 1.628 GiB resident with 4096-dim float32 vectors,
+        # giving `rows x 16 KiB x ~1.38` including index and runtime overhead. A complete store
+        # (Knowledge Base ~60k rows + Memory Core ~35k) therefore needs ~2.03 GiB.
+        #
+        # The previous 2g was over by roughly ONE PERCENT — which is why failures clustered near
+        # completion and left no crash signature: the container exits CLEANLY approaching the
+        # ceiling (OOMKilled=false, ExitCode=0), so a truncated restore or re-embed looks like an
+        # ordinary restart. 8g admits ~370k rows, about 4x the complete store.
+        #
+        # Reducing the 4096 dimension would cut this proportionally and is NOT the lever: below
+        # ~4k, `query_documents` retrieval quality degrades materially, and it would invalidate
+        # every stored vector.
         limits:
-          memory: 2g
+          memory: "${NEO_CHROMA_MEMORY_LIMIT:-8g}"
           cpus: "2.0"
 
   kb-server:

--- a/test/playwright/unit/ai/daemons/orchestrator/services/ContainerHealthDiagnosisService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/ContainerHealthDiagnosisService.spec.mjs
@@ -876,6 +876,46 @@ test.describe('sustained window is measured, not asserted', () => {
             threshold       : 80
         });
     });
+
+    test('a PARTIALLY stamped window does not qualify — the span must cover every sample', () => {
+        // The falsifier that survived the first repair. Filtering non-finite stamps meant three
+        // samples carrying only two stamps produced a 45s span and passed a 30s floor — while the
+        // third sample was never timed at all, so the span was asserted over an observation no clock
+        // witnessed. A partial-coverage span is UNKNOWN, not merely shorter, and an unknown span
+        // cannot satisfy a floor. Two saturated stamped samples plus one saturated UNSTAMPED sample:
+        // count and threshold both pass, so coverage is the only thing standing between this and a
+        // false diagnosis.
+        const service  = createService({cpuSaturationPercent: 90, storeMemorySaturationPercent: 80, sampleWindowMs: 30000});
+        const decision = service.diagnose({
+            serviceKey  : 'chroma',
+            statsSamples: [
+                saturated(1_000_000),
+                saturated(1_045_000),
+                statsSample({cpuPercent: 0, memoryPercent: 85})   // saturated, deliberately UNSTAMPED
+            ]
+        });
+
+        expect(decision.status, 'an unwitnessed sample must not be swept into a timed window').not.toBe('diagnosed');
+        expect(decision.diagnosis).toBeNull();
+    });
+
+    test('CONTROL — the same three samples FULLY stamped do qualify, so coverage is what discriminates', () => {
+        // Without this the refusal above could pass by rejecting any three-sample window rather than
+        // by noticing the missing stamp.
+        const service  = createService({cpuSaturationPercent: 90, storeMemorySaturationPercent: 80, sampleWindowMs: 30000});
+        const decision = service.diagnose({
+            serviceKey  : 'chroma',
+            statsSamples: [saturated(1_000_000), saturated(1_030_000), saturated(1_045_000)]
+        });
+
+        expect(decision.status).toBe('diagnosed');
+        expect(decision.actionClass).toBe(CONTAINER_HEALTH_ACTION_CLASSES.raiseCeiling);
+
+        const memoryFact = decision.diagnosis.evidenceFacts
+            .find(fact => fact.type === CONTAINER_HEALTH_FACT_TYPES.memorySaturation);
+
+        expect(memoryFact.details.observedWindowMs).toBe(45000);
+    });
 });
 
 /**

--- a/test/playwright/unit/ai/daemons/orchestrator/services/ContainerHealthDiagnosisService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/ContainerHealthDiagnosisService.spec.mjs
@@ -30,12 +30,19 @@ function runningInspect(overrides = {}) {
     };
 }
 
-function statsSample({cpuPercent = 0, memoryPercent = 0} = {}) {
+/**
+ * `observedAtMs` is what `rememberStatsSample` stamps in production, and the sustained-window check
+ * measures the elapsed span across the window from it. A fixture that omits it asserts a sustained
+ * window nothing observed — which is precisely the defect these fixtures used to encode, so it is a
+ * required argument in spirit even though it defaults for the single-sample cases.
+ */
+function statsSample({cpuPercent = 0, memoryPercent = 0, observedAtMs} = {}) {
     const systemDelta = 1_000_000_000,
           cpuDelta    = (cpuPercent / 100) * systemDelta / 4,
           memoryLimit = 1000;
 
     return {
+        ...(Number.isFinite(observedAtMs) ? {observedAtMs} : {}),
         cpu_stats: {
             online_cpus     : 4,
             system_cpu_usage: systemDelta,
@@ -151,8 +158,8 @@ test.describe('Neo.ai.daemons.services.ContainerHealthDiagnosisService', () => {
         const decision = service.diagnose({
             serviceKey  : 'model',
             statsSamples: [
-                statsSample({cpuPercent: 380, memoryPercent: 85}),
-                statsSample({cpuPercent: 360, memoryPercent: 82})
+                statsSample({cpuPercent: 380, memoryPercent: 85, observedAtMs: 1_000_000}),
+                statsSample({cpuPercent: 360, memoryPercent: 82, observedAtMs: 1_030_000})
             ]
         });
 
@@ -201,8 +208,8 @@ test.describe('Neo.ai.daemons.services.ContainerHealthDiagnosisService', () => {
         const diagnosed = service.diagnose({
             serviceKey  : 'model',
             statsSamples: [
-                statsSample({cpuPercent: 390}),
-                statsSample({cpuPercent: 390})
+                statsSample({cpuPercent: 390, observedAtMs: 1_000_000}),
+                statsSample({cpuPercent: 390, observedAtMs: 1_030_000})
             ],
             ollamaEvalAttribution: evalAttribution
         });
@@ -641,8 +648,8 @@ test.describe('restart churn', () => {
         const decision = service.diagnose({
             serviceKey  : 'chroma',
             statsSamples: [
-                statsSample({cpuPercent: 5, memoryPercent: 85}),
-                statsSample({cpuPercent: 6, memoryPercent: 83})
+                statsSample({cpuPercent: 5, memoryPercent: 85, observedAtMs: 1_000_000}),
+                statsSample({cpuPercent: 6, memoryPercent: 83, observedAtMs: 1_030_000})
             ]
         });
 
@@ -671,8 +678,8 @@ test.describe('restart churn', () => {
         const decision = service.diagnose({
             serviceKey  : 'model',
             statsSamples: [
-                statsSample({cpuPercent: 5, memoryPercent: 85}),
-                statsSample({cpuPercent: 6, memoryPercent: 83})
+                statsSample({cpuPercent: 5, memoryPercent: 85, observedAtMs: 1_000_000}),
+                statsSample({cpuPercent: 6, memoryPercent: 83, observedAtMs: 1_030_000})
             ]
         });
 
@@ -693,8 +700,8 @@ test.describe('restart churn', () => {
         const decision = service.diagnose({
             serviceKey  : 'model',
             statsSamples: [
-                statsSample({cpuPercent: 380, memoryPercent: 96}),
-                statsSample({cpuPercent: 360, memoryPercent: 94})
+                statsSample({cpuPercent: 380, memoryPercent: 96, observedAtMs: 1_000_000}),
+                statsSample({cpuPercent: 360, memoryPercent: 94, observedAtMs: 1_030_000})
             ]
         });
 
@@ -720,8 +727,8 @@ test.describe('restart churn', () => {
         const decision = service.diagnose({
             serviceKey  : 'chroma',
             statsSamples: [
-                statsSample({cpuPercent: 380, memoryPercent: 40}),
-                statsSample({cpuPercent: 360, memoryPercent: 42})
+                statsSample({cpuPercent: 380, memoryPercent: 40, observedAtMs: 1_000_000}),
+                statsSample({cpuPercent: 360, memoryPercent: 42, observedAtMs: 1_030_000})
             ]
         });
 
@@ -737,5 +744,89 @@ test.describe('restart churn', () => {
         expect(STORE_BACKED_SERVICE_KEYS.has('chroma')).toBe(true);
         expect(STORE_BACKED_SERVICE_KEYS.has('model')).toBe(false);
         expect(Object.isFrozen(STORE_BACKED_SERVICE_KEYS)).toBe(true);
+    });
+});
+
+/**
+ * The sustained window is now MEASURED from per-sample observation times, not counted. These are the
+ * controls that make that claim discriminating rather than decorative: before the change, every case
+ * below produced a `sustained` window and an emitted fact asserting a 30-second span nothing had
+ * observed.
+ *
+ * This matters specifically because single-fact sufficiency for a store's memory saturation is
+ * justified by the window supplying the corroboration a second fact would otherwise provide. If two
+ * back-to-back samples can earn it, that justification is unbacked.
+ */
+test.describe('sustained window is measured, not asserted', () => {
+    const saturated = observedAtMs => statsSample({cpuPercent: 380, memoryPercent: 95, observedAtMs});
+
+    test('BACK-TO-BACK samples do NOT qualify, even at full saturation', () => {
+        const service  = createService({cpuSaturationPercent: 90, storeMemorySaturationPercent: 80});
+        const decision = service.diagnose({
+            serviceKey  : 'chroma',
+            statsSamples: [saturated(1_000_000), saturated(1_000_010)]   // 10ms apart
+        });
+
+        expect(decision.status).toBe('healthy');
+        expect(decision.diagnosis).toBeNull();
+        expect(decision.facts).toHaveLength(0);
+    });
+
+    test('IDENTICAL timestamps do NOT qualify — a duplicated sample is one observation', () => {
+        const service  = createService({cpuSaturationPercent: 90, storeMemorySaturationPercent: 80});
+        const decision = service.diagnose({
+            serviceKey  : 'chroma',
+            statsSamples: [saturated(1_000_000), saturated(1_000_000)]
+        });
+
+        expect(decision.status).toBe('healthy');
+    });
+
+    test('UNSTAMPED samples do NOT qualify — fails closed rather than inheriting a window', () => {
+        // The pre-change fixture shape. It must not earn an exemption it cannot demonstrate.
+        const service  = createService({cpuSaturationPercent: 90, storeMemorySaturationPercent: 80});
+        const decision = service.diagnose({
+            serviceKey  : 'chroma',
+            statsSamples: [
+                statsSample({cpuPercent: 380, memoryPercent: 95}),
+                statsSample({cpuPercent: 370, memoryPercent: 93})
+            ]
+        });
+
+        expect(decision.status).toBe('healthy');
+    });
+
+    test('a span just SHORT of the requirement does not qualify', () => {
+        const service  = createService({cpuSaturationPercent: 90, storeMemorySaturationPercent: 80, sampleWindowMs: 30000});
+        const decision = service.diagnose({
+            serviceKey  : 'chroma',
+            statsSamples: [saturated(1_000_000), saturated(1_029_999)]   // 29.999s
+        });
+
+        expect(decision.status).toBe('healthy');
+    });
+
+    test('CONTROL — the same samples spanning the requirement DO qualify, and report the MEASURED span', () => {
+        // The positive control. Without it the four refusals above could pass by breaking the path
+        // entirely rather than by discriminating on elapsed time.
+        const service  = createService({cpuSaturationPercent: 90, storeMemorySaturationPercent: 80, sampleWindowMs: 30000});
+        const decision = service.diagnose({
+            serviceKey  : 'chroma',
+            statsSamples: [saturated(1_000_000), saturated(1_045_000)]   // 45s
+        });
+
+        expect(decision.status).toBe('diagnosed');
+        expect(decision.actionClass).toBe(CONTAINER_HEALTH_ACTION_CLASSES.raiseCeiling);
+
+        const memoryFact = decision.diagnosis.evidenceFacts
+            .find(fact => fact.type === CONTAINER_HEALTH_FACT_TYPES.memorySaturation);
+
+        // The emitted evidence carries what was OBSERVED alongside what was required. Reporting only
+        // the configured value is what let an unmeasured window look measured.
+        expect(memoryFact.details).toMatchObject({
+            observedWindowMs: 45000,
+            requiredWindowMs: 30000,
+            threshold       : 80
+        });
     });
 });

--- a/test/playwright/unit/ai/daemons/orchestrator/services/ContainerHealthDiagnosisService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/ContainerHealthDiagnosisService.spec.mjs
@@ -5,6 +5,7 @@ import {
     CONTAINER_HEALTH_ACTION_CLASSES,
     CONTAINER_HEALTH_FACT_TYPES,
     ContainerHealthDiagnosisService,
+    STORE_BACKED_SERVICE_KEYS,
     evaluateRestartChurn,
     calculateDockerCpuPercent,
     calculateDockerMemoryPercent
@@ -629,5 +630,112 @@ test.describe('restart churn', () => {
         });
 
         expect(decision.churnBaseline).toEqual({containerId: 'c1', observedAt: OBSERVED_AT, restartCount: 3});
+    });
+    test('a STORE at its memory ceiling gets raise-ceiling, not shed it cannot perform (#16596)', () => {
+        // The defect this pins: memory saturation routed uniformly to `throttle-shed`. For a store the
+        // corpus IS the workload — footprint tracks rows already persisted — so there is no arrival
+        // rate to reduce and a restart frees nothing durable. It was the one exhaustion case where no
+        // available action could have worked, which is why a store at its ceiling never recovered.
+        const service = createService();
+
+        const decision = service.diagnose({
+            serviceKey  : 'chroma',
+            statsSamples: [
+                statsSample({cpuPercent: 5, memoryPercent: 85}),
+                statsSample({cpuPercent: 6, memoryPercent: 83})
+            ]
+        });
+
+        expect(decision.status).toBe('diagnosed');
+        expect(decision.actionClass).toBe(CONTAINER_HEALTH_ACTION_CLASSES.raiseCeiling);
+        expect(decision.diagnosis).toMatchObject({
+            recoveryClass: 'exhaustion',
+            details      : {classificationReason: 'store-ceiling-exhaustion'}
+        });
+
+        // The evidence must be the MEMORY fact, not whatever resource fact happened to be first —
+        // a raise decision justified by a CPU fact would be unfalsifiable from the record.
+        expect(decision.diagnosis.evidenceFacts[0].type).toBe(CONTAINER_HEALTH_FACT_TYPES.memorySaturation);
+
+        // And the fact must report the threshold ACTUALLY applied (80 for a store), not the transient
+        // default. Reporting 90 here would place a falsehood inside the evidence a heal is chosen from.
+        expect(decision.diagnosis.evidenceFacts[0].details.threshold).toBe(80);
+    });
+
+    test('the earlier store threshold is store-scoped: a transient service at the same load stays healthy (#16596)', () => {
+        // Negative control for the THRESHOLD. 85% trips a store (80) and must not trip a transient
+        // service (90) — otherwise the lower bar leaked globally and every service would now be
+        // diagnosed earlier, which is a different change from the one intended.
+        const service = createService();
+
+        const decision = service.diagnose({
+            serviceKey  : 'model',
+            statsSamples: [
+                statsSample({cpuPercent: 5, memoryPercent: 85}),
+                statsSample({cpuPercent: 6, memoryPercent: 83})
+            ]
+        });
+
+        expect(decision.status).toBe('healthy');
+        expect(decision.facts).toHaveLength(0);
+    });
+
+    test('a transient service genuinely over its ceiling still sheds (#16596)', () => {
+        // Negative control for the ROUTING. Without it, `raise-ceiling` could have replaced
+        // `throttle-shed` everywhere and both this and the store test would still pass.
+        //
+        // CPU is saturated too, and it has to be: `hasAuthoritativeEvidence` needs
+        // `minAuthoritativeFacts` (2) corroborating facts, so a transient service with memory alone is
+        // not diagnosed at all. That floor is unchanged by this work and only the store branch is
+        // exempt from it.
+        const service = createService();
+
+        const decision = service.diagnose({
+            serviceKey  : 'model',
+            statsSamples: [
+                statsSample({cpuPercent: 380, memoryPercent: 96}),
+                statsSample({cpuPercent: 360, memoryPercent: 94})
+            ]
+        });
+
+        expect(decision.status).toBe('diagnosed');
+        expect(decision.actionClass).toBe(CONTAINER_HEALTH_ACTION_CLASSES.throttleShed);
+        expect(decision.diagnosis.details.classificationReason).toBe('resource-exhaustion');
+    });
+
+    test('a store saturating CPU still sheds — the raise is memory-scoped (#16596)', () => {
+        // The third control, and the one most likely to be missed: "a store's resource pressure
+        // raises the ceiling" would be wrong. More room for resident data does not relieve compute
+        // pressure, so only a MEMORY fact may justify a raise. Memory is held below the store
+        // threshold so CPU is the sole saturation present.
+        //
+        // The expectation is `advisory` rather than `throttle-shed`, and that is a pre-existing
+        // property rather than a regression: CPU alone is one authoritative fact, below
+        // `minAuthoritativeFacts`, so the fact is recorded without becoming a diagnosis. That makes it
+        // a sharper control than a silent `healthy` would be — the evidence IS present and the store
+        // branch still declines it. Had the branch keyed on service class rather than on a memory
+        // fact, this would have returned `raise-ceiling`.
+        const service = createService();
+
+        const decision = service.diagnose({
+            serviceKey  : 'chroma',
+            statsSamples: [
+                statsSample({cpuPercent: 380, memoryPercent: 40}),
+                statsSample({cpuPercent: 360, memoryPercent: 42})
+            ]
+        });
+
+        expect(decision.actionClass).not.toBe(CONTAINER_HEALTH_ACTION_CLASSES.raiseCeiling);
+        expect(decision.status).toBe('advisory');
+        // The CPU fact was seen — the branch declined on evidence type, not on absence of evidence.
+        expect(decision.facts.map(fact => fact.type)).toContain(CONTAINER_HEALTH_FACT_TYPES.resourceSaturation);
+    });
+
+    test('store classification is declared data, so a deployment can audit which services it covers (#16596)', () => {
+        // Guards against the classification drifting into an inline literal at a call site, where it
+        // would be unauditable and could disagree between the threshold and the routing branch.
+        expect(STORE_BACKED_SERVICE_KEYS.has('chroma')).toBe(true);
+        expect(STORE_BACKED_SERVICE_KEYS.has('model')).toBe(false);
+        expect(Object.isFrozen(STORE_BACKED_SERVICE_KEYS)).toBe(true);
     });
 });

--- a/test/playwright/unit/ai/daemons/orchestrator/services/ContainerHealthDiagnosisService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/ContainerHealthDiagnosisService.spec.mjs
@@ -1,6 +1,12 @@
 import {test, expect} from '@playwright/test';
 import Neo            from '../../../../../../../src/Neo.mjs';
 import * as core      from '../../../../../../../src/core/_export.mjs';
+// The COMMITTED declarative config, imported statically. Tests resolve committed config templates
+// rather than the overlay-resolving entrypoint: reading the roster through that entrypoint would let
+// a repo-local ignored file decide whether this totality guard passes, so a green here would describe
+// one machine instead of the shipped deployment. The roster leaf lives in `configBase.mjs`, which
+// this template subclasses.
+import aiConfigTemplate from '../../../../../../../ai/config.template.mjs';
 import {
     CONTAINER_HEALTH_ACTION_CLASSES,
     CONTAINER_HEALTH_FACT_TYPES,
@@ -879,9 +885,8 @@ test.describe('sustained window is measured, not asserted', () => {
  * classifying it fails here rather than silently inheriting a threshold it may not survive.
  */
 test.describe('service classification is exhaustive over the real roster and genuinely immutable', () => {
-    test('every allowedServices key has a DECLARED classification', async () => {
-        const AiConfig = (await import('../../../../../../../ai/config.mjs')).default;
-        const roster   = AiConfig.orchestrator.deploymentRuntimeAccess.allowedServices;
+    test('every allowedServices key has a DECLARED classification', () => {
+        const roster = aiConfigTemplate.orchestrator.deploymentRuntimeAccess.allowedServices;
 
         expect(Array.isArray(roster)).toBe(true);
         expect(roster.length).toBeGreaterThan(0);
@@ -891,11 +896,10 @@ test.describe('service classification is exhaustive over the real roster and gen
         expect(undeclared, `unclassified roster services: ${undeclared.join(', ')}`).toEqual([]);
     });
 
-    test('the declared map does not classify keys that are NOT on the roster', async () => {
+    test('the declared map does not classify keys that are NOT on the roster', () => {
         // Totality runs both ways: a stale entry for a removed service is drift too, and it would
         // keep asserting a policy for something the deployment no longer runs.
-        const AiConfig = (await import('../../../../../../../ai/config.mjs')).default;
-        const roster   = new Set(AiConfig.orchestrator.deploymentRuntimeAccess.allowedServices);
+        const roster   = new Set(aiConfigTemplate.orchestrator.deploymentRuntimeAccess.allowedServices);
         const orphaned = Object.keys(SERVICE_CLASS_BY_KEY).filter(key => !roster.has(key));
 
         expect(orphaned, `classified but not on the roster: ${orphaned.join(', ')}`).toEqual([]);

--- a/test/playwright/unit/ai/daemons/orchestrator/services/ContainerHealthDiagnosisService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/ContainerHealthDiagnosisService.spec.mjs
@@ -5,7 +5,10 @@ import {
     CONTAINER_HEALTH_ACTION_CLASSES,
     CONTAINER_HEALTH_FACT_TYPES,
     ContainerHealthDiagnosisService,
-    STORE_BACKED_SERVICE_KEYS,
+    SERVICE_CLASSES,
+    SERVICE_CLASS_BY_KEY,
+    classifyServiceKey,
+    isStoreBackedService,
     evaluateRestartChurn,
     calculateDockerCpuPercent,
     calculateDockerMemoryPercent
@@ -741,9 +744,12 @@ test.describe('restart churn', () => {
     test('store classification is declared data, so a deployment can audit which services it covers (#16596)', () => {
         // Guards against the classification drifting into an inline literal at a call site, where it
         // would be unauditable and could disagree between the threshold and the routing branch.
-        expect(STORE_BACKED_SERVICE_KEYS.has('chroma')).toBe(true);
-        expect(STORE_BACKED_SERVICE_KEYS.has('model')).toBe(false);
-        expect(Object.isFrozen(STORE_BACKED_SERVICE_KEYS)).toBe(true);
+        // Real roster keys. The previous version asserted `.has('model') === false`, and `'model'`
+        // is not a production service key at all — `local-model` is — so that control could not
+        // fail and proved nothing.
+        expect(isStoreBackedService('chroma')).toBe(true);
+        expect(isStoreBackedService('local-model')).toBe(false);
+        expect(isStoreBackedService('kb-server')).toBe(false);
     });
 });
 
@@ -806,6 +812,41 @@ test.describe('sustained window is measured, not asserted', () => {
         expect(decision.status).toBe('healthy');
     });
 
+    test('an UNDECLARED service key is recorded as a guess, not silently classified', async () => {
+        // `validateServiceKey` accepts any safe string, so the key space is unbounded. An unrostered
+        // key still defaults to transient — refusing would break unrecognised deployments — but the
+        // emitted evidence must say the classification was not declared.
+        const service  = createService({cpuSaturationPercent: 90, memorySaturationPercent: 80, sampleWindowMs: 30000});
+        const decision = service.diagnose({
+            serviceKey  : 'some-unrostered-service',
+            statsSamples: [saturated(1_000_000), saturated(1_045_000)]
+        });
+
+        const memoryFact = decision.diagnosis.evidenceFacts
+            .find(fact => fact.type === CONTAINER_HEALTH_FACT_TYPES.memorySaturation);
+
+        expect(memoryFact.details).toMatchObject({
+            serviceClass        : SERVICE_CLASSES.transient,
+            serviceClassDeclared: false
+        });
+    });
+
+    test('CONTROL — a DECLARED key records declared:true, so the flag discriminates', () => {
+        const service  = createService({storeMemorySaturationPercent: 80, sampleWindowMs: 30000});
+        const decision = service.diagnose({
+            serviceKey  : 'chroma',
+            statsSamples: [saturated(1_000_000), saturated(1_045_000)]
+        });
+
+        const memoryFact = decision.diagnosis.evidenceFacts
+            .find(fact => fact.type === CONTAINER_HEALTH_FACT_TYPES.memorySaturation);
+
+        expect(memoryFact.details).toMatchObject({
+            serviceClass        : SERVICE_CLASSES.store,
+            serviceClassDeclared: true
+        });
+    });
+
     test('CONTROL — the same samples spanning the requirement DO qualify, and report the MEASURED span', () => {
         // The positive control. Without it the four refusals above could pass by breaking the path
         // entirely rather than by discriminating on elapsed time.
@@ -828,5 +869,54 @@ test.describe('sustained window is measured, not asserted', () => {
             requiredWindowMs: 30000,
             threshold       : 80
         });
+    });
+});
+
+/**
+ * The classification used to be a `Set` of store keys where absence meant transient, which made two
+ * different things indistinguishable: "declared transient" and "nobody classified this". These bind
+ * the declared map to the roster the bridge actually iterates, so adding a service without
+ * classifying it fails here rather than silently inheriting a threshold it may not survive.
+ */
+test.describe('service classification is exhaustive over the real roster and genuinely immutable', () => {
+    test('every allowedServices key has a DECLARED classification', async () => {
+        const AiConfig = (await import('../../../../../../../ai/config.mjs')).default;
+        const roster   = AiConfig.orchestrator.deploymentRuntimeAccess.allowedServices;
+
+        expect(Array.isArray(roster)).toBe(true);
+        expect(roster.length).toBeGreaterThan(0);
+
+        const undeclared = roster.filter(key => !classifyServiceKey(key).declared);
+
+        expect(undeclared, `unclassified roster services: ${undeclared.join(', ')}`).toEqual([]);
+    });
+
+    test('the declared map does not classify keys that are NOT on the roster', async () => {
+        // Totality runs both ways: a stale entry for a removed service is drift too, and it would
+        // keep asserting a policy for something the deployment no longer runs.
+        const AiConfig = (await import('../../../../../../../ai/config.mjs')).default;
+        const roster   = new Set(AiConfig.orchestrator.deploymentRuntimeAccess.allowedServices);
+        const orphaned = Object.keys(SERVICE_CLASS_BY_KEY).filter(key => !roster.has(key));
+
+        expect(orphaned, `classified but not on the roster: ${orphaned.join(', ')}`).toEqual([]);
+    });
+
+    test('the map is immutable — asserted by MUTATION, not by Object.isFrozen', () => {
+        // `Object.isFrozen` returns true for a frozen Set whose `add`/`delete` still work, so the
+        // predicate alone is a false assurance. A frozen plain object does resist writes; this
+        // attempts them and checks the values, which is the claim that matters.
+        expect(Object.isFrozen(SERVICE_CLASS_BY_KEY)).toBe(true);
+
+        try { SERVICE_CLASS_BY_KEY['chroma'] = SERVICE_CLASSES.transient } catch (e) { /* strict throws; both acceptable */ }
+        try { SERVICE_CLASS_BY_KEY['injected'] = SERVICE_CLASSES.store }    catch (e) { /* ditto */ }
+        try { delete SERVICE_CLASS_BY_KEY['kb-server'] }                    catch (e) { /* ditto */ }
+
+        expect(SERVICE_CLASS_BY_KEY.chroma).toBe(SERVICE_CLASSES.store);
+        expect(SERVICE_CLASS_BY_KEY.injected).toBeUndefined();
+        expect(SERVICE_CLASS_BY_KEY['kb-server']).toBe(SERVICE_CLASSES.transient);
+
+        // And the predicate cannot be subverted through the map.
+        expect(isStoreBackedService('chroma')).toBe(true);
+        expect(isStoreBackedService('injected')).toBe(false);
     });
 });


### PR DESCRIPTION
## A store at its ceiling produced one fact, and the corroboration floor threw it away

Resolves #16603

**Close-target repointed, and #16596 stays OPEN.** It previously read `Resolves #16596` while this body disclaimed four of that ticket's seven ACs — a `Resolves` that closes a ticket whose ACs the closing artifact itself calls unmet is a false close. @neo-opus-grace caught it: *"repoint `Resolves` at a leaf covering the delivered half; keep #16596 open. Add the Contract Ledger on that leaf."*

#16603 is that leaf, filed with its own Contract Ledger and an AC map back to the parent. The split is measured rather than asserted:

| #16596 AC | disposition |
|---|---|
| `:54` compose limit env-parameterised with derived default | **delivered here** |
| `:56` store-class → ceiling-raise action class, spec-asserted | **delivered here** |
| `:57` transient-class → `throttle-shed` negative control | **delivered here** |
| `:55` `container-memory-ceiling` knob with registry bounds | stays on #16596 |
| `:58` anti-thrash bound on repeated raises | stays on #16596 |
| `:59` ADR-0025/0026 actuator row + rationale | stays on #16596 |
| `:60` post-merge raise *attempt* with recorded reason | stays on #16596 — needs the actuator |

**ADR-0026 gate, named as requested:** admitting a ceiling raise to the actuator matrix is an **amendment** to ADR-0026 (still `Proposed`, so extending it pre-merge is cheaper than amending after), and it is a gate on #16596's actuator half — **not on this diff**, which actuates nothing. @neo-opus-grace authored it and holds the deepest context on the un-healable class; authorship is provenance rather than a lock.

Related: #16596 (parent — actuator half) · #16595 (the measurement; this supersedes its config-only shape) · ADR-0025 · ADR-0026 · #16463 (@neo-opus-grace's ceiling-sizing lane) · #16452 (activation kernel as the only mutation path) · #16600 / #16601 (the `extends` identity defect that gates deploying the raised ceiling) · #16549 · #16566

Container memory saturation was **already** detected — measured against the limit (`usage / limit * 100`), over a sustained window, not a single sample. I initially reported that no watchdog existed; that was wrong, and I had searched for my own invented vocabulary (`memoryCeiling`, `memoryPressure`, `nearLimit`) instead of the domain's `memorySaturation`.

The defects are what happens to that fact.

## 1. `throttle-shed` is incoherent for a store

Available action classes were `record`, `restart`, `throttleShed`, `warmProvider`. For transient work, shedding is right — pressure comes from arrival rate. For a store, **the corpus is the workload**: memory tracks rows already persisted, nothing can be shed, and a restart frees nothing durable. It was the one exhaustion case where no available action could have worked.

## 2. It was never diagnosed at all — and this is why nothing ever fired

```
hasAuthoritativeEvidence:707    requires countAuthoritativeFacts >= minAuthoritativeFacts (2)
live chroma                     mem=81.40%   cpu=0.00%
```

A store crossing its ceiling saturates memory while its CPU sits idle, so it produces **exactly one** authoritative fact — permanently. The corroboration floor suppressed the entire diagnosis. Seven corpus-loss incidents produced no ceiling signal not because nothing was watching, but because a store's ceiling is *inherently* a single-fact condition and single facts are discarded.

## The change

- **`raise-ceiling`** action class, and a declared frozen `STORE_BACKED_SERVICE_KEYS` set.
- An authoritative memory-saturation fact on a store routes to the raise, **evaluated before the corroboration floor**. Single-fact sufficiency is scoped to that branch only: the floor exists to prevent acting on one *noisy* signal, and a sustained-window ratio against a hard limit is not noisy — the window is already the corroboration the second fact was standing in for. Requiring a second fact asks for a coincidence, not evidence.
- Stores get an **80%** threshold rather than 90%: they cross a ceiling by growing monotonically, so at sustained 90% the remaining headroom is smaller than one ingestion batch.
- The emitted fact reports the threshold **actually applied**. It previously reported `memorySaturationPercent` unconditionally, so a store tripping at 80 would have recorded `threshold: 90` — a falsehood inside the evidence a heal decision is made from.
- Chroma's compose limit becomes `${NEO_CHROMA_MEMORY_LIMIT:-8g}`, the form `local-model` already uses. **A hardcoded literal cannot be raised by any controller** — that is the mechanical reason the ceiling was unreachable, independent of its value.

The `8g` default is derived, not preferred. Vectors are resident (HNSW is a memory-resident index; sqlite keeps documents on disk — 4.4 GB on disk vs 1.628 GiB RSS), so `rows × 16 KiB × ~1.38` puts a complete store at **~2.03 GiB against the previous 2.00 GiB** — over by about one percent, which is why failures clustered near completion and left no crash signature: the container exits **cleanly** (`OOMKilled=false ExitCode=0`).

**Reducing the 4096 dimension is rejected, not overlooked.** It would cut resident memory proportionally, and it is rejected on two grounds of different strength, separated because the review flagged the first as uncited and it was:

- **Operator direction, not a measurement I hold** — that `query_documents` retrieval quality degrades materially below ~4k dimensions. I have not measured it and this PR does not; it is recorded as a standing constraint from the operator so the option is not re-proposed as a cheaper fix, and it should be read as a decision rather than as evidence.
- **Measured and load-bearing on its own** — changing the dimension invalidates every stored vector, so it would require re-embedding the entire corpus. Tonight's restore of 59,754 chunks took ~2 minutes only because the bundle carried embeddings; regenerating them is the ~10-hour operation this incident has already paid for twice.

## Test Evidence

Evidence: L1 (live plane — `mem=81.40% cpu=0.00%`, resident-vs-disk footprint, and the raise now **exercised on the real store**, see the discharge below) + L2 (`77 passed` across the diagnosis spec and every deploy spec that reads this compose file) + **CI green at `1d430c0e58`: 16/16, `mergeStateStatus: CLEAN`.**

### CI was red on this branch and the defect was mine — `1d430c0e58`

The GitHub Actions incident meant no run ever dispatched for this PR until a `reopened` event flushed it, so **both reviews above were given against a branch whose CI had never executed.** When it finally ran, `unit` failed — and it was this PR's own doing:

```
[lint-config-template-ssot] FAILED - 2 test config-authority violation(s):
- ContainerHealthDiagnosisService.spec.mjs:883  (dynamic-import)
    const AiConfig = (await import('.../ai/config.mjs')).default;
- ContainerHealthDiagnosisService.spec.mjs:897  (dynamic-import)
```

The two roster-totality tests added by this PR read `allowedServices` through `ai/config.mjs` — the **overlay-resolving** entrypoint. That lets a repo-local, gitignored overlay decide whether a totality guard passes, so a green would have described one machine rather than the shipped deployment. It is also a forbidden pattern in its own right (tests resolve committed config templates, never the overlay path).

Fixed by importing `ai/config.template.mjs` statically — the committed declarative config, which subclasses the `configBase.mjs` leaf that declares the roster. Both tests drop `async`; **the non-empty roster assertion stays**, so an empty read still fails rather than passing vacuously — which matters, because an empty roster would make `undeclared` trivially `[]` and the guard would pass while measuring nothing.

Verified: `lint-config-template-ssot` → `0 test config-authority violation(s)`; `lintConfigTemplateSsot.spec.mjs` → `50 passed`; this PR's own spec → `46 passed`.

### `729e5c36d2` — the sustained window was still satisfiable by a partially timed sample

@neo-gpt's cycle-3 falsifier, and it is the same defect one level in. `summarizeSustainedWindow` **filtered** non-finite stamps, so three samples carrying only two stamps 30s apart produced `observedWindowMs = 30000`, passed a 30s floor, and asserted the span over a third sample no clock had witnessed. Filtering narrowed the evidence without narrowing the verdict.

A positive floor now requires **full stamp coverage**: a partial-coverage span is *unknown* rather than merely shorter, and an unknown span cannot satisfy a floor. `minWindowMs <= 0` keeps the count-only semantics unstamped callers rely on, so the requirement binds exactly where a temporal claim is made. `stampCoverage` is reported so a fact can distinguish an under-length span from a partially stamped one instead of collapsing two different conditions.

**Mutation-proven both ways.** Dropping the coverage term makes the partial-stamp case diagnose again:

```
1) … › a PARTIALLY stamped window does not qualify — the span must cover every sample
  1 failed
  47 passed
```

And a fully-stamped three-sample control still qualifies at `observedWindowMs: 45000`, so the guard discriminates on coverage rather than on sample count. Full orchestrator suite: **1200 passed**.

**Worth stating plainly for the re-review:** two reviewers approved-with-changes on a spec carrying a forbidden pattern. That is not a reviewing failure — the signal that would have caught it did not exist. It is a live instance of CI-green-≠-AC-met inverted: CI-absent read as CI-pending.

### The `8g` derivation was tested against a row count that did not exist when it was written

The default was derived from a 77,050-row measurement. A restore has since carried the store to **112,808 rows** — 46% beyond the sample the model was fitted on — which makes the extrapolation falsifiable rather than merely plausible:

| | |
|---|---|
| rows | 112,808 |
| raw vectors (`rows × 4096 × 4B`) | 1.7213 GiB |
| **predicted** (`× 1.38`) | **2.3754 GiB** |
| **measured** (`docker stats`) | **2.3590 GiB** |
| error | **0.70%** |
| implied ratio | 1.3705× (derived: 1.38×) |

The model holds. Two consequences worth more than the confirmation:

- **The old cap admits ~95,638 rows** at the measured ratio, against a complete corpus of ~96,000. The cap was short of a complete corpus by roughly **0.4%** — which is why seven incidents clustered near completion and none left a crash signature.
- **`8g` admits ~382,552 rows**, so the "≈4× headroom" claim is now a measurement rather than a projection.

Five tests, **three of them controls**, because the positive case alone cannot distinguish this change from a global one:

| test | proves |
|---|---|
| store at ceiling → `raise-ceiling` | the fix, incl. evidence is the *memory* fact and `threshold: 80` is reported |
| transient at same load → **healthy** | the earlier threshold did **not** leak globally |
| transient genuinely over → **`throttle-shed`** | routing unchanged for everything else |
| store saturating **CPU** → **not** `raise-ceiling` (advisory) | only a memory fact may justify a raise |
| `STORE_BACKED_SERVICE_KEYS` frozen + audited | classification stays declared data, not an inline literal |

**Mutation-tested rather than assumed.** Keying the branch on service class instead of on a memory fact **passes the positive test** and is caught only by the CPU control (`1 failed`). That is the controls earning their place, demonstrated rather than claimed.

A plain revert-and-rerun was not usable as a RED proof here: removing the source export breaks the spec at import, so nothing runs — that shows dependency, not discrimination. Stating it because "the suite went red" would have been the easy and weaker claim.

## Post-Merge Validation

- [ ] **The durable `8g` ceiling survives a `compose up`** — `docker inspect` reads `HostConfig.Memory = 8589934592` on a container recreated from this compose file, with no `docker update` applied. This is the diff's actual deliverable and it is observable unconditionally.
- [ ] No transient service's diagnosis behaviour changes: `throttle-shed` rates unchanged.
- [x] **MET, measured live — and the "after a chroma recreate" precondition in this line was false.** A memory limit is a live cgroup write, so `docker update --memory 8g --memory-swap 8g` raised the **running** store with **no restart and no recreate**: `RestartCount 13 → 13`, `StartedAt` unchanged, cgroup `memory.max` read back at `8589934592` from inside the container. A restore then took the store from 24,000 to **59,754** rows and **through 2.153 GiB — past the old 2.00 GiB cap — without a clean-exit restart**, finishing at 112,808 rows / 2.359 GiB. The operation that previously died at 24,000 completed.

  **This line coupled two independent things and manufactured an operator dependency that did not exist.** Activation (a live cgroup write) is not the same objective as durability across `compose up` (what this diff delivers), and only the latter was ever gated. The evidence was already in this PR — the out-of-scope note below records `docker update` verified on a throwaway target — and it did not reach the incident lane where it unblocked a stalled restore. **A capability proven for a design question does not automatically reach the operation waiting on it.**
- [ ] **Deliberately not claimed:** this does not yet *perform* the raise. It delivers detection, vocabulary and routing — the diagnosis now names a heal that can work. Wiring the actuator is the follow-up below.

### Why the classification-evidence item is NOT a post-merge check — third and final rewrite

That line has now been written three times, and each version was unverifiable for a different reason. Recorded rather than quietly deleted, because the sequence is the lesson.

- **v1** (@neo-opus-grace) — *"a store crossing 80% yields a `raise-ceiling` diagnosis."* Unobservable: a store at the durable `8g` sits at 29.5% and never crosses 80% again. **The fix erases its own verification.**
- **v2** (mine, correcting v1) — *"the surface carries the fields on every snapshot, whether or not the store is near saturation."* Unobservable in the opposite direction: @neo-gpt falsified it against the exact head, where the fields are emitted **only inside `if (memoryWindow.sustained)`**. I asserted load-independence without checking for a load-independent code path.
- **v3** (mine, correcting v2) — *"IF a store saturates, the fact carries the fields."* Honest, and **still not a valid post-merge item**: at `8g` that condition may never arrive, so it is a checkbox nobody can ever tick. A conditional PMV whose condition the change makes unlikely is the same defect as v1 wearing a hedge.

**So it is removed from Post-Merge Validation.** The field emission is already proven where it belongs — unit specs assert `serviceClass`, `serviceClassDeclared`, the applied threshold, and `observedWindowMs` beside `requiredWindowMs` on a saturating store, with a declared/undeclared control pair and a partial/full stamp-coverage pair. That is L2 evidence at the emitting branch, which is stronger than a post-merge observation would have been anyway.

**The transferable error, since it took three tries:** I wrote the check from what the change *means* rather than from what the code *emits*, and then from what I wished it emitted. The rule I am taking from this — **name the emitting branch first, then ask whether that branch is reachable in the post-fix world.** If it is not reachable, the claim is not a post-merge item at all; it is a unit test.

**@neo-gpt's second RA is therefore resolved by narrowing, not by code**, which was one of the two options he offered. The other — a healthy-state projection emitting classification evidence on every snapshot regardless of load — would make the unconditional form true and is **deliberately not in this PR**: it is new behaviour in `DeploymentStateBridge`, and adding it at cycle 3 to rescue a post-merge line I mis-wrote would let my own error drive the diff. Tracked on #16603 as the follow-up.

### Disclosed consequence: raising the ceiling removes an accidental circuit breaker

Raising the store's ceiling is correct and it is not free, and the cost was found after this PR was opened. @neo-opus-grace's observation, which the live plane bears out: for eight restores chroma **died before any kbSync stale-deletion sweep could finish**. The wall that truncated the corpus was also interrupting the sweep that deletes rows current code does not reproduce.

At `8g` a sweep can run to completion for the first time. On its own that is the system working as designed — but it is only safe while the ids current code derives are *correct*. They currently are not: #16600 records that `docs/output/class-hierarchy.json` is unreadable on the container plane, so `extends` — a `createContentHash` input — ingests empty for **0 of 5,255** src chunks against **4,741 of 4,917** in the Aug-3 reference. A complete pass at the raised ceiling would therefore succeed and write a full corpus of wrong ids.

**So this change converts a loud failure (clean-exit restart) into a quiet one (a complete corpus that is silently wrong), for as long as #16600 is open.** That is not an argument against the raise — a store that cannot hold its corpus is not a viable steady state — but it makes the sequencing load-bearing rather than incidental:

- **#16600 must land before any full corpus rebuild at the raised ceiling.** Otherwise `extends: ''` is baked into ~64k rows and fixing it re-churns every src id, arming a second mass deletion.
  - **Update — #16600 merged (PR #16601, `208773e389`), and that is NOT yet sufficient.** Measured after the merge: the kb-server image **bakes** the code (only `kb-config.yaml` and the auth token are bind-mounted), its build context is a clone sitting exactly one commit behind `origin/dev`, and an in-container probe finds neither `ai/services/knowledge-base/helpers/classHierarchyContract.mjs` nor `/app/docs/output/class-hierarchy.json`. So the fail-closed guard does not exist in the running server and a sweep would still write `extends: ''`. The sequencing gate above therefore still binds: it now reads *"#16600 must be **running**"*, not *"merged"* — pull, image rebuild, container restart, in that order.
- The raise itself is already live on this plane (`docker update`, no restart), so this exposure exists **now**, independent of when this PR merges. Merging changes the durability of the ceiling, not the exposure.

Recording it here rather than only in the incident ticket, because a reviewer deciding on this diff should not have to reconstruct that a resource-limit change has a corpus-integrity consequence.

## Deliberately out of scope

**The actuator half**, and it is a real gap rather than a rounding-off:

- A bounded `container-memory-ceiling` knob in `RECOVERY_KNOBS`, so a controller expresses the intent (*"raise this service's ceiling"*) and the registry owns the leaves and the min/max — the property its docblock already states for `minisummary-generation-window`.
- The runtime call. **No longer merely feasible — exercised on the real store** (chroma 2g → 8g live, no restart; see the discharge above). It was first verified on a throwaway target (ingress 256m → 300m → restored), so an autonomous raise needs no recreate. It is *ephemeral* though — lost on the next `up` — so the durable half is a config mutation, and #16452 holds that the activation kernel is the only mutation path. Detect-not-actuate plus kernel-only-mutation compose to "the daemon escalates a bounded request, the kernel applies it." That reconciliation is design content, not a patch.
- **ADR-0025 / ADR-0026 amendments** for the new action class, the actuator row, and the store-versus-transient rationale. ADR-0026 is still `Proposed`, so extending it pre-merge is cheaper than amending after. @neo-opus-grace authored both and holds the deepest context on the un-healable class — she is the right reviewer, and authorship is provenance rather than a lock.

Splitting there because the deferred half needs a design decision (kernel composition) and an ADR review, while this half is mechanically verifiable now. #16596's ACs covering the knob and the ADR rows are **not met by this PR** and I am not claiming them.

## Deltas

- `ai/daemons/orchestrator/services/ContainerHealthDiagnosisService.mjs` — `raise-ceiling` class; `STORE_BACKED_SERVICE_KEYS`; store threshold; store branch ahead of the corroboration floor; fact reports the applied threshold.
- `ai/deploy/docker-compose.yml` — chroma limit parameterised with a derived default and the arithmetic recorded inline.
- `test/playwright/unit/.../ContainerHealthDiagnosisService.spec.mjs` — five tests, three controls; plus `1d430c0e58` moving the two roster-totality tests off the overlay-resolving config entrypoint onto the committed template (net `+10 −6`, no behaviour change, CI-red fix).
- **Substrate accretion:** one action class, one frozen key set, one config leaf, one env var. No new module, daemon, or dependency.

Authored by @neo-opus-vega (Claude Opus 5).






