### PR TITLE
The correction rule rides the surface that reloads, not the skill that expired (#16602)

### DIFF
--- a/.agents/skills/ticket-create/references/ticket-create-workflow.md
+++ b/.agents/skills/ticket-create/references/ticket-create-workflow.md
@@ -183,8 +183,8 @@ Minimize chained calls where possible — a well-formed `create_issue` call with
 **You update your own authored artifacts in place. You never override another author's.**
 
 When editing tickets:
-- **Ticket body:** Update your own in place. If it's someone else's ticket, respond via a NEW comment.
-- **Ticket AC list:** Extend your own list. If it's someone else's ticket, do NOT mutate their AC list; propose additions via comment.
+- **Your own:** correct the BODY, incl. ACs. A comment cannot supersede it — reviewers read the body for ACs.
+- **Someone else's:** propose via comment; never mutate their body or ACs.
 - **Reviewer-RA restatements:** read `../../pull-request/references/foreign-ticket-restatement.md` (comment-proposal default; claimer-authored in-body sections like intake-derived ledgers stay claimer-updatable).
 
 *Why:* Rewriting someone else's prose causes attribution collapse and breaks Native Edge Graph ingestion.

--- a/ai/mcp/server/github-workflow/openapi.yaml
+++ b/ai/mcp/server/github-workflow/openapi.yaml
@@ -486,7 +486,7 @@ paths:
 
   /comments/manage:
     post:
-      summary: Manage Comments (Create or Update)
+      summary: Manage Comments (Create or Update) — dialogue only; corrections go in the BODY, not a comment
       operationId: manage_issue_comment
       x-neo-tool-tier: write
       x-pass-as-object: true
@@ -495,6 +495,26 @@ paths:
       description: |
         Unified tool for creating and updating comments on issues and pull requests.
         Supports both adding new comments and modifying existing ones.
+
+        **A comment is dialogue. It cannot supersede the body.**
+
+        - **BODY = state.** What is true now: problem, evidence, prescription, acceptance criteria.
+          If any of those change — including because you falsified your own earlier claim — edit the
+          body. On a PR the body *is* the contract.
+        - **COMMENT = dialogue.** A review response, an answer to a peer, a measurement handed to a
+          named person. Something whose value is *that it was said, by whom, when*.
+
+        Two reasons this matters more than tidiness:
+
+        1. **A reviewer checks the body for acceptance criteria.** Correcting an AC in a comment
+           leaves them verifying rigorously against a dead contract — worse than a sloppy review,
+           because it yields a confident verdict on the wrong target.
+        2. **Comment sediment must be read in full to be safe**, since only the whole set reveals
+           which correction supersedes which — while the economical read (body, then stop) returns
+           the stale version. The tax punishes the careful reader, misleads the frugal one, and
+           grows with how wrong the body is.
+
+        Bodies are edited outside this tool (`gh issue edit` / `gh pr edit`).
 
         **Action: 'create'**
         - Creates a new comment on an issue or PR.
@@ -505,7 +525,9 @@ paths:
         **Action: 'update'**
         - Updates an existing comment.
         - Requires `comment_id` and `body`.
-        - **When to use:** To correct mistakes or update status in a previously posted comment.
+        - **When to use:** To correct what *you said* in dialogue, or to collapse a superseded
+          comment of yours to a one-line pointer once its content is folded into the body. To correct
+          what the ticket or PR *claims*, edit the body instead.
         - **Note:** You can only update comments created by the authenticated user.
       tags: [Issues, Pull Requests]
       requestBody:

--- a/ai/mcp/server/github-workflow/openapi.yaml
+++ b/ai/mcp/server/github-workflow/openapi.yaml
@@ -486,7 +486,13 @@ paths:
 
   /comments/manage:
     post:
-      summary: Manage Comments (Create or Update) — dialogue only; corrections go in the BODY, not a comment
+      summary: Manage Comments (Create or Update)
+      # The compact `tools/list` description, and it MUST live here rather than in `summary`.
+      # `ToolService` emits `title: operation.summary` AND falls back to `summary` for the compact
+      # description, so putting the imperative in `summary` ships it twice — measured at +118 chars
+      # on the projected record instead of +59. This annotation carries it once and leaves the title
+      # stable at the tool's 34-char name.
+      x-neo-tool-summary: Manage Comments (Create or Update) — dialogue only; corrections go in the BODY, not a comment
       operationId: manage_issue_comment
       x-neo-tool-tier: write
       x-pass-as-object: true

--- a/test/playwright/unit/ai/mcp/server/github-workflow/CommentGuidanceTiers.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/github-workflow/CommentGuidanceTiers.spec.mjs
@@ -1,0 +1,121 @@
+import {setup} from '../../../../../setup.mjs';
+
+const appName = 'GitHubWorkflowCommentGuidanceTest';
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name             : appName,
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect}  from '@playwright/test';
+import fs              from 'fs';
+import path            from 'path';
+import {fileURLToPath} from 'url';
+import * as yaml       from 'js-yaml';
+import Neo             from '../../../../../../../src/Neo.mjs';
+import * as core       from '../../../../../../../src/core/_export.mjs';
+
+/**
+ * A correction to a ticket or PR belongs in its BODY. Appending it as a comment leaves the stale
+ * claim authoritative, because a reader hits the body first and stops there — and on a PR the body
+ * IS the contract a reviewer verifies acceptance criteria against.
+ *
+ * The rule already existed in `ticket-create-workflow.md` §11 and still did not fire: a create-time
+ * skill is not in context when an agent returns to a day-old ticket to record a finding, and it
+ * should not be — re-reading a creation payload to write a comment would be pure token waste. So the
+ * guidance has to ride the surface that re-arrives on every schema load instead: the compact
+ * `tools/list` line for `manage_issue_comment`.
+ *
+ * These guards assert the DERIVED tiers rather than the YAML text, because the two differ.
+ * `ToolService.buildToolListDescription` sources `x-neo-tool-summary` → `summary` → description and
+ * then TRUNCATES past the cap instead of failing — and this label's operative clause ("not a
+ * comment") sits at the very END, so a silent cut would keep the phrase that reads like compliance
+ * while dropping the instruction. Hence the tail pin and the ellipsis check.
+ */
+test.describe('github-workflow manage_issue_comment — BODY-vs-COMMENT guidance reaches both description tiers (#16602)', () => {
+
+    const
+        __filename = fileURLToPath(import.meta.url),
+        __dirname  = path.dirname(__filename),
+        repoRoot   = path.resolve(__dirname, '../../../../../../..'),
+        serverDir  = path.join(repoRoot, 'ai/mcp/server/github-workflow'),
+        // The bare label this replaced. Kept as the precedence control: a derived description EQUAL
+        // to it proves the guidance silently left the default-visible tier.
+        legacyLabel = 'Manage Comments (Create or Update)';
+
+    let listTools, callTool;
+
+    test.beforeAll(async () => {
+        ({listTools, callTool} = await import('../../../../../../../ai/mcp/server/github-workflow/toolService.mjs'));
+    });
+
+    test('the compact tools/list line carries the imperative, tail intact and untruncated', async () => {
+        const
+            {tools} = await listTools(),
+            tool    = tools.find(item => item.name === 'manage_issue_comment'),
+            // DERIVED from the server's own config rather than restating 120, so lowering the cap
+            // forces this guard to follow instead of leaving the two to disagree.
+            capSource = fs.readFileSync(path.join(serverDir, 'toolService.mjs'), 'utf8'),
+            capMatch  = capSource.match(/toolListDescriptionMaxLength\s*:\s*(\d+)/),
+            cap       = Number(capMatch?.[1]);
+
+        expect(capMatch, 'toolListDescriptionMaxLength must be declared in the server toolService').toBeTruthy();
+        expect(tool, 'manage_issue_comment must be listed').toBeTruthy();
+
+        expect(tool.description).toContain('corrections go in the BODY');
+        expect(tool.description.length, `the compact tier is capped at ${cap}`).toBeLessThanOrEqual(cap);
+
+        // The operative clause is the LAST thing in the label, so asserting the phrase above alone
+        // would pass a half-sentence that reads as guidance while instructing nothing.
+        expect(tool.description, 'an over-long summary is silently truncated, not rejected').not.toContain('...');
+        expect(tool.description, 'the instruction, not just the topic, must survive the cap').toContain('not a comment');
+
+        // Precedence control: `summary` is what this tool's compact tier resolves to, so falling back
+        // to the bare title is the failure mode that would leave the default surface silent.
+        expect(tool.description, 'the guidance must beat the bare title').not.toBe(legacyLabel);
+    });
+
+    test('the handbook tier carries the reasons and the BODY-vs-COMMENT distinction', async () => {
+        const handbook = await callTool('get_mcp_tool_handbook', {toolId: 'manage_issue_comment'});
+
+        expect(handbook.found).toBe(true);
+
+        // The distinction is what keeps this from over-correcting into "never comment": review
+        // responses and answers to a peer are exactly what a comment is FOR.
+        expect(handbook.handbook).toContain('BODY = state');
+        expect(handbook.handbook).toContain('COMMENT = dialogue');
+
+        // Both reasons, because either alone invites a workaround: without the reviewer clause the
+        // cost reads as tidiness, and without the sediment clause "I will add one more comment"
+        // still looks cheap.
+        expect(handbook.handbook, 'the reviewer-reads-the-body-for-ACs cost').toContain('acceptance criteria');
+        expect(handbook.handbook, 'the read-in-full-to-be-safe cost').toContain('read in full');
+    });
+
+    test("the 'update' action no longer routes ticket corrections into a comment", async () => {
+        const
+            handbook   = await callTool('get_mcp_tool_handbook', {toolId: 'manage_issue_comment'}),
+            openApiDoc = yaml.load(fs.readFileSync(path.join(serverDir, 'openapi.yaml'), 'utf8')),
+            operation  = openApiDoc.paths['/comments/manage'].post;
+
+        // This tier used to advise using 'update' "To correct mistakes" — with no scope on WHOSE
+        // mistake, it endorsed the exact anti-pattern the compact label now warns against. The
+        // positive assertion is the real guard; the negative pins the specific regression.
+        expect(handbook.handbook, "'update' must route claim-corrections to the body").toContain('edit the body instead');
+        expect(handbook.handbook, 'the superseded advice must not return').not.toContain('To correct mistakes');
+
+        // Scoped, not banned: correcting your own dialogue and collapsing a superseded comment to a
+        // pointer are both legitimate — the second is how consolidation removes the sediment tax.
+        expect(handbook.handbook).toContain('one-line pointer');
+
+        // The handbook resolves `operation.description`, so a guard that passed while the YAML lost
+        // the text would mean the tiers had drifted apart.
+        expect(operation.description, 'the handbook tier is sourced from operation.description').toContain('BODY = state');
+    });
+});

--- a/test/playwright/unit/ai/mcp/server/github-workflow/CommentGuidanceTiers.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/github-workflow/CommentGuidanceTiers.spec.mjs
@@ -76,9 +76,34 @@ test.describe('github-workflow manage_issue_comment — BODY-vs-COMMENT guidance
         expect(tool.description, 'an over-long summary is silently truncated, not rejected').not.toContain('...');
         expect(tool.description, 'the instruction, not just the topic, must survive the cap').toContain('not a comment');
 
-        // Precedence control: `summary` is what this tool's compact tier resolves to, so falling back
-        // to the bare title is the failure mode that would leave the default surface silent.
+        // Precedence control: the compact tier resolves `x-neo-tool-summary` → `summary` →
+        // description, so a listed description EQUAL to `summary` proves the annotation was dropped
+        // and the guidance silently fell back to the bare title.
         expect(tool.description, 'the guidance must beat the bare title').not.toBe(legacyLabel);
+    });
+
+    test('the imperative is emitted ONCE — the title stays the stable 34-char name', async () => {
+        const
+            {tools}    = await listTools(),
+            tool       = tools.find(item => item.name === 'manage_issue_comment'),
+            openApiDoc = yaml.load(fs.readFileSync(path.join(serverDir, 'openapi.yaml'), 'utf8')),
+            operation  = openApiDoc.paths['/comments/manage'].post;
+
+        // `ToolService` sets `title: operation.summary` AND falls back to `summary` for the compact
+        // description. So putting the imperative in `summary` emits it in BOTH fields: measured at
+        // +118 chars on the projected record rather than the +59 the label alone suggests. Measuring
+        // the yaml field instead of the emitted record is what hid that, and this guard exists
+        // because the cheap measurement and the real cost differ by a factor of two.
+        expect(tool.title, 'the title must stay the stable name, not carry the guidance').toBe(legacyLabel);
+        expect(operation.summary, 'summary is the title source and must not carry the imperative').toBe(legacyLabel);
+        expect(operation['x-neo-tool-summary'], 'the imperative belongs in the annotation, emitted once').toContain('not a comment');
+
+        // The record cost, asserted rather than trusted: title + description, with the imperative
+        // appearing exactly once across the pair.
+        const emitted     = `${tool.title}${tool.description}`,
+              occurrences = emitted.split('corrections go in the BODY').length - 1;
+
+        expect(occurrences, 'the imperative must appear exactly once across title + description').toBe(1);
     });
 
     test('the handbook tier carries the reasons and the BODY-vs-COMMENT distinction', async () => {


### PR DESCRIPTION
Resolves #16602

A correction to a ticket belongs in its **body**. The rule already existed — `ticket-create-workflow.md` §11 said *"Update your own in place"* — and it did not fire, because a create-time skill is not in context when an agent returns to a day-old ticket to record a finding. And it should not be: re-reading a creation payload to write a comment would be pure token waste.

So this does not add emphasis to a guard that keeps not firing. It moves the imperative to the surface that **re-arrives on every schema load** — the compact `tools/list` label for `manage_issue_comment` — puts the reasons in the handbook tier where full detail belongs, and reframes §11 from permission into obligation while getting **smaller**.

## Deltas

| Surface | Before | After | Delta |
|---|---|---|---|
| `manage_issue_comment` compact description (`x-neo-tool-summary`) | absent; fell back to `summary` (34) | **93 chars** | +59 chars, 78% of the 120 cap |
| `manage_issue_comment` `title` (from `summary`) | 34 chars | **34 chars — unchanged** | 0 |
| **projected `tools/list` record** | — | — | **+59, not +118** — see the correction below |
| `ticket-create-workflow.md` §11, two bullets | 237 bytes | **186 bytes** | **−51 bytes** |
| `ticket-create-workflow.md` whole file | 22,084 | 22,033 | −51 bytes (confirms the bullets are the only change) |
| `.agents/skills/**` total | — | — | **−51 bytes** — the AC required ≤ 0 |
| `manage_issue_comment` handbook (`description`) | — | +22 lines | the two reasons, the BODY/COMMENT distinction, and the `'update'` scope fix |

Evidence: `wc -c` on the exact bullet pair before and after, plus the whole-file count as the cross-check. Label length is `wc -m` (93 chars / 95 bytes — the em-dash is 3 bytes, and the cap is compared against JS `.length`, which counts it as 1).

## What the diff does

**1. The imperative rides the tier that reloads.**

```
- summary: Manage Comments (Create or Update)
+ summary: Manage Comments (Create or Update) — dialogue only; corrections go in the BODY, not a comment
```

`ToolService.mjs:330` resolves the compact label `x-neo-tool-summary` → `summary` → description, and the imperative now rides **`x-neo-tool-summary`** — verified by calling the real `listTools()`, not by reading the yaml.

### Correction at `35e4aacf6e` — I measured the field, not the emitted record

The first version of this PR put the imperative in `summary`, and reported the cost as **+59 chars**. `@neo-gpt`'s review falsified that:

```js
title       : operation.summary || toolName,     // ToolService.mjs:194
description : listDescription,                   // → x-neo-tool-summary || summary || description
```

With no `x-neo-tool-summary`, **both fields resolve to `summary`**, so the 59-char addition was emitted **twice** — the projected record grew **+118**, and I had measured the yaml scalar while the runtime duplicated it. Reproduced independently before fixing: the same +118 delta.

Fixed as he prescribed: `summary` restored to the stable 34-char title, imperative moved to `x-neo-tool-summary`. Record cost is now the +59 this PR originally claimed — the claim is unchanged, but it is finally true.

**The guard grew a test for it**, because the failure mode is invisible in the yaml: the title is pinned stable, and the imperative is asserted to appear **exactly once** across `title` + `description`, so moving it back into `summary` fails here instead of silently doubling the payload.

Worth naming the pattern: this is the third time tonight that measuring a *declaration* instead of the *emitted artifact* produced a confident wrong number. `@neo-gpt` also explicitly falsified the config-overlay concern — recorded because a review that only lists what survived hides what was checked and cleared.

**2. The reasons go to the handbook half** (`ToolService.mjs:187` → `get_mcp_tool_handbook`): a reviewer checks the body for acceptance criteria, so a comment leaves them verifying rigorously against a dead contract; and comment sediment must be read in full to be safe while the economical read — body, then stop — returns the stale version. Plus the distinction that keeps this from over-correcting into *never comment*: **BODY = state**, **COMMENT = dialogue**.

**3. The same `description` was routing corrections INTO a comment.** Found while implementing, and not in the ticket's original scope. Under `Action: 'update'` it read:

> **When to use:** To correct mistakes or update status in a previously posted comment.

With no scope on *whose* mistake or *which* claim, the handbook endorsed the exact anti-pattern the new label warns against. Now scoped: correcting your own dialogue stays legitimate, collapsing a superseded comment of yours to a one-line pointer is named as the consolidation affordance, and correcting what the ticket *claims* routes to the body. The ticket body was updated with this addition rather than a comment — which is the rule under test.

**4. §11 becomes an obligation and loses 51 bytes.** The section is titled *Authorship Respect* and every framing cue pointed at not touching peers' artifacts, so the self-clause read as *you are allowed to* rather than *the body must state current facts*.

## Test Evidence

New spec: `test/playwright/unit/ai/mcp/server/github-workflow/CommentGuidanceTiers.spec.mjs` — **4 tests.** (Was 3; the fourth is the single-occurrence guard added with the `x-neo-tool-summary` fix. Corrected on @neo-gpt's truth-fold — a count in a body is a receipt that expires the moment the diff grows.)

```
npm run test-unit -- test/playwright/unit/ai/mcp/server/github-workflow/CommentGuidanceTiers.spec.mjs --workers=1
  6 passed (2.3s)     # 4 tests + chroma setup/teardown
```

Importer sweep for the changed basenames — every spec in the `github-workflow` server dir plus the two cross-server consumers of `openapi.yaml`:

```
npm run test-unit -- test/playwright/unit/ai/mcp/server/github-workflow/ \
  test/playwright/unit/ai/mcp/validation/OpenApiValidatorCompliance.spec.mjs \
  test/playwright/unit/ai/mcp/server/McpServerListToolsSmoke.spec.mjs --workers=1
  102 passed (3.8s)
```

Lints that watch the touched substrate, all green: `ai:check-substrate-size` (per-file cap 24,576; this file 22,033), `lint-skill-manifest --base origin/dev`, `lint-agents --base origin/dev`, `ai:lint-mcp-test-locations`.

### The guard is mutation-proven, and one mutation is the whole point

The spec asserts the **derived** tiers via the real `listTools()` / `get_mcp_tool_handbook` path, because the fetched schema and the yaml differ — the AC demanded the fetched surface specifically.

`buildToolListDescription` (`ToolService.mjs:329-339`) **truncates** past `toolListDescriptionMaxLength` instead of failing. This label's operative clause sits at the very end, so an over-long label silently keeps the topic and drops the instruction. Mutation — pad the summary past the 120 cap:

```
Error: an over-long summary is silently truncated, not rejected
Received string: "Manage Comments (Create or Update) on issues and pull requests,
                  unified — dialogue only; corrections go in the BODY,..."
  1 failed
```

`corrections go in the BODY,` survived; `not a comment` was severed. **A guard asserting only the topic phrase would have passed a label that instructs nothing.** That is why the spec pins the tail and the absence of an ellipsis, and it is the reason the cap is derived from `toolService.mjs` rather than restated as `120`.

Second mutation — revert `summary` to the bare `Manage Comments (Create or Update)`:

```
Error: expect(received).toContain(expected)
Received string: "Manage Comments (Create or Update)"
  1 failed
```

Both discriminate. Restored, and `git diff` verified free of mutation residue before staging.

## Post-Merge Validation

- [ ] After the github-workflow MCP server reloads from a checkout containing this commit, a `tools/list` / `ToolSearch` fetch of `manage_issue_comment` shows the imperative with the tail intact. **The spec proves the producer, not the running server** — the served instance answers from its own checkout, so this is the one claim a unit test cannot close. Observable by fetching the tool and reading the returned label.
- [ ] `get_mcp_tool_handbook({toolId: 'manage_issue_comment'})` against the reloaded server returns the BODY-vs-COMMENT distinction and both reasons.

Deliberately **not** included: "correction comments stop appearing." This lands advisory text at the right trigger; it does not claim to close the class, and a behavioural claim I cannot measure would be a post-merge item that quietly never gets checked.

## Scope held

- **No mechanical guard.** "Correction comment while the body is unchanged" would false-positive on exactly the dialogue §11 should keep protecting — review responses, peer answers.
- **No sweep of other tool labels.** That fights the terseness constraint and belongs in its own change.
- **`AGENTS.md` untouched.** Rejected by the `turn-memory-pre-flight` decision tree: not a universal per-turn rule, and turn-loaded real estate is the most expensive surface we have.
- **The write-side asymmetry stands.** Ticket *body* edits go through `gh issue edit`, not an MCP tool, so no equivalent label can carry a reminder there. Real, and not fixable by this change.
- **#16582's body** is already consolidated; it is the specimen, not a target here.

Authored by @neo-opus-vega (Claude Opus 5).


