### PR TITLE
A parameter a service reads must be declared, or the facade strips it silently (#16585)

### DIFF
--- a/.github/workflows/openapi-service-parity-lint.yml
+++ b/.github/workflows/openapi-service-parity-lint.yml
@@ -31,10 +31,22 @@ on:
       - '.github/workflows/openapi-service-parity-lint.yml'
   push:
     branches: [dev]
+    # MUST stay identical to `pull_request.paths` above. GitHub Actions does not reliably expand YAML
+    # anchors in workflow files, so this is a second copy of one list — and two lists that must agree
+    # are a list that will not. `OpenApiServiceParityTriggerReachability.spec.mjs` asserts set-equality
+    # between the two, because that is the only thing standing between them and silent divergence.
+    #
+    # It already happened once: the three ToolService authorities were added above and not here, so
+    # `push` never ran the guard on the mapping table the join derives its handler list from.
+    # @neo-gpt caught it with micromatch, and the same shape is the defect I had removed from
+    # `backup.mjs` hours earlier — two substrate lists drifted apart as separate literals.
     paths:
       - 'ai/services/**/*.mjs'
       - 'ai/mcp/server/**/openapi.yaml'
       - 'ai/services.mjs'
+      - 'ai/mcp/server/**/toolService.mjs'
+      - 'ai/mcp/server/**/*.mjs'
+      - 'ai/mcp/ToolService.mjs'
       - 'ai/scripts/diagnostics/mcpHandlerSignatureCensus.mjs'
       - 'ai/scripts/lint/lint-openapi-service-parity.mjs'
       - '.github/workflows/openapi-service-parity-lint.yml'

--- a/.github/workflows/openapi-service-parity-lint.yml
+++ b/.github/workflows/openapi-service-parity-lint.yml
@@ -1,0 +1,52 @@
+name: OpenAPI Service Parity Lint
+
+on:
+  pull_request:
+    branches: [dev]
+    paths:
+      # The service implementations: a method that starts reading a new parameter is the defect's
+      # origin, so any change under here must re-run the check.
+      - 'ai/services/**/*.mjs'
+      # The contracts. A parameter can also become undeclared by being REMOVED from a schema, which
+      # leaves the service reading a key nothing declares any more — same defect, opposite direction.
+      - 'ai/mcp/server/**/openapi.yaml'
+      # The wiring table the checker derives its service list from. If a service stops being wrapped
+      # here it silently leaves the guard's scope, so editing this must re-run it.
+      - 'ai/services.mjs'
+      # The shared AST helpers. The checker imports them rather than re-deriving, so a change there
+      # changes what the checker can see.
+      - 'ai/scripts/diagnostics/mcpHandlerSignatureCensus.mjs'
+      - 'ai/scripts/lint/lint-openapi-service-parity.mjs'
+      - '.github/workflows/openapi-service-parity-lint.yml'
+  push:
+    branches: [dev]
+    paths:
+      - 'ai/services/**/*.mjs'
+      - 'ai/mcp/server/**/openapi.yaml'
+      - 'ai/services.mjs'
+      - 'ai/scripts/diagnostics/mcpHandlerSignatureCensus.mjs'
+      - 'ai/scripts/lint/lint-openapi-service-parity.mjs'
+      - '.github/workflows/openapi-service-parity-lint.yml'
+
+concurrency:
+  group: openapi-service-parity-lint-${{ github.run_attempt == '1' && github.ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci --ignore-scripts
+
+      - name: Lint service methods for parameters their OpenAPI operation does not declare
+        run: node ai/scripts/lint/lint-openapi-service-parity.mjs

--- a/.github/workflows/openapi-service-parity-lint.yml
+++ b/.github/workflows/openapi-service-parity-lint.yml
@@ -13,6 +13,17 @@ on:
       # The wiring table the checker derives its service list from. If a service stops being wrapped
       # here it silently leaves the guard's scope, so editing this must re-run it.
       - 'ai/services.mjs'
+      # The SECOND wiring table, for the ToolService dispatch join. A `serviceMapping` entry is the
+      # authority for which handler answers an operation, so rebinding, removing or repointing one
+      # changes that join's scope exactly as editing `ai/services.mjs` changes the other's. Without
+      # this the join could exist and never RUN on the change that broke it — a guard whose absence
+      # from a PR reads as a pass.
+      - 'ai/mcp/server/**/toolService.mjs'
+      # Handler implementations that do NOT live under `ai/services/`. The dispatch join resolves
+      # mapping values into whatever module owns them, and several land here (the ingest facade, the
+      # dispatcher itself) rather than in the service tree the filter above covers.
+      - 'ai/mcp/server/**/*.mjs'
+      - 'ai/mcp/ToolService.mjs'
       # The shared AST helpers. The checker imports them rather than re-deriving, so a change there
       # changes what the checker can see.
       - 'ai/scripts/diagnostics/mcpHandlerSignatureCensus.mjs'

--- a/ai/scripts/diagnostics/mcpHandlerSignatureCensus.mjs
+++ b/ai/scripts/diagnostics/mcpHandlerSignatureCensus.mjs
@@ -208,10 +208,16 @@ export function collectImports(ast) {
             continue;
         }
         for (const specifier of node.specifiers) {
-            imports.set(specifier.local.name, {
-                source  : node.source.value,
-                imported: specifier.type === 'ImportDefaultSpecifier' ? 'default' : specifier.imported.name
-            });
+            // Three specifier kinds, and only two carry `.imported`. `import * as yaml from …`
+            // is an ImportNamespaceSpecifier with no `imported` node at all, so reading
+            // `.imported.name` throws — which made this helper unusable on any module using a
+            // namespace import. It went unnoticed because the census only ever parsed
+            // `toolService.mjs` files, none of which have one.
+            const imported = specifier.type === 'ImportDefaultSpecifier'   ? 'default'
+                           : specifier.type === 'ImportNamespaceSpecifier' ? '*'
+                           : specifier.imported.name;
+
+            imports.set(specifier.local.name, {source: node.source.value, imported});
         }
     }
 

--- a/ai/scripts/diagnostics/mcpHandlerSignatureCensus.mjs
+++ b/ai/scripts/diagnostics/mcpHandlerSignatureCensus.mjs
@@ -292,6 +292,26 @@ function walkNodes(root) {
  * @returns {Object[]|null}
  */
 export function findCallableParams(ast, name) {
+    return findCallableNode(ast, name)?.params ?? null;
+}
+
+/**
+ * @summary Finds the callable NODE for `name` — the same search `findCallableParams` performs, one
+ * step earlier.
+ *
+ * Exists because a parameter LIST is not enough for every consumer. The signature-census only needs
+ * the params, but a contract-parity check must read the BODY: a handler that takes an opaque bag
+ * (`doThing(options)`) consumes its parameters through destructuring and member reads inside the
+ * function, so its signature carries no names at all. Returning the node serves both, and keeping
+ * `findCallableParams` as a delegation keeps ONE traversal deciding what a callable is — two copies
+ * of this search would be two definitions of "the handler", free to disagree about class members,
+ * property-definition arrows, or the declaration forms below.
+ *
+ * @param {Object} ast parsed module
+ * @param {String} name method or function name
+ * @returns {Object|null} the function/arrow node, or null when not found
+ */
+export function findCallableNode(ast, name) {
     const nodes = walkNodes(ast);
 
     for (const node of nodes) {
@@ -303,7 +323,7 @@ export function findCallableParams(ast, name) {
                     (member.key.name === name || member.key.value === name) &&
                     member.value?.params
                 ) {
-                    return member.value.params;
+                    return member.value;
                 }
             }
         }
@@ -311,13 +331,13 @@ export function findCallableParams(ast, name) {
 
     for (const node of nodes) {
         if (node.type === 'FunctionDeclaration' && node.id?.name === name) {
-            return node.params;
+            return node;
         }
         if (
             node.type === 'VariableDeclarator' && node.id?.name === name &&
             (node.init?.type === 'ArrowFunctionExpression' || node.init?.type === 'FunctionExpression')
         ) {
-            return node.init.params;
+            return node.init;
         }
     }
 
@@ -380,7 +400,7 @@ export function extractServiceMapping(ast) {
 }
 
 /**
- * Resolves one serviceMapping value node to its handler parameter descriptors.
+ * Resolves one serviceMapping value node to its handler CALLABLE NODE.
  * Shapes handled: `Service.method.bind(Service)`, inline arrows/functions, local identifiers
  * (function declarations and const arrows, e.g. github-workflow's `getConversationRouter`), and
  * imported identifiers (one hop into the source module, e.g. knowledge-base's
@@ -388,9 +408,9 @@ export function extractServiceMapping(ast) {
  * named, never dropped.
  * @param {Object} valueNode ESTree node of the mapping value
  * @param {Object} ctx {imports, filePath, root, fileCache}
- * @returns {{params: Object[], via: String}|{unresolved: String}}
+ * @returns {{node: Object, via: String}|{unresolved: String}}
  */
-export function resolveHandlerParams(valueNode, ctx) {
+export function resolveHandlerNode(valueNode, ctx) {
     // Service.method.bind(Service) — possibly with extra bound args (none in-repo; noted if seen)
     if (valueNode.type === 'CallExpression' && valueNode.callee?.type === 'MemberExpression' &&
         valueNode.callee.property?.name === 'bind' && valueNode.callee.object?.type === 'MemberExpression') {
@@ -405,11 +425,11 @@ export function resolveHandlerParams(valueNode, ctx) {
         }
 
         const servicePath = path.resolve(path.dirname(ctx.filePath), importInfo.source);
-        const params      = findCallableParams(loadModule(servicePath, ctx.fileCache), methodName);
+        const node        = findCallableNode(loadModule(servicePath, ctx.fileCache), methodName);
 
-        if (params) {
+        if (node) {
             const via = `${serviceName}.${methodName}` + (boundExtra > 0 ? ` (bind carries ${boundExtra} extra arg(s))` : '');
-            return {params: describeParams(params), via};
+            return {node, via};
         }
 
         // One superclass hop: inherited handlers (e.g. a shared HealthService base)
@@ -417,11 +437,11 @@ export function resolveHandlerParams(valueNode, ctx) {
         const superInfo = superName && ctx.imports.get(superName);
 
         if (superInfo) {
-            const superPath   = path.resolve(path.dirname(ctx.filePath), superInfo.source);
-            const superParams = findCallableParams(loadModule(superPath, ctx.fileCache), methodName);
+            const superPath = path.resolve(path.dirname(ctx.filePath), superInfo.source);
+            const superNode = findCallableNode(loadModule(superPath, ctx.fileCache), methodName);
 
-            if (superParams) {
-                return {params: describeParams(superParams), via: `${superName}.${methodName} (inherited by ${serviceName})`};
+            if (superNode) {
+                return {node: superNode, via: `${superName}.${methodName} (inherited by ${serviceName})`};
             }
         }
 
@@ -430,26 +450,26 @@ export function resolveHandlerParams(valueNode, ctx) {
 
     // Inline arrow / function expression: the dispatcher binds against THIS signature
     if (valueNode.type === 'ArrowFunctionExpression' || valueNode.type === 'FunctionExpression') {
-        return {params: describeParams(valueNode.params), via: 'inline handler in serviceMapping'};
+        return {node: valueNode, via: 'inline handler in serviceMapping'};
     }
 
     // Local or imported identifier
     if (valueNode.type === 'Identifier') {
-        const localParams = findCallableParams(ctx.ast, valueNode.name);
+        const localNode = findCallableNode(ctx.ast, valueNode.name);
 
-        if (localParams) {
-            return {params: describeParams(localParams), via: `${valueNode.name} (local)`};
+        if (localNode) {
+            return {node: localNode, via: `${valueNode.name} (local)`};
         }
 
         const importInfo = ctx.imports.get(valueNode.name);
 
         if (importInfo) {
             const targetPath = path.resolve(path.dirname(ctx.filePath), importInfo.source);
-            const params     = findCallableParams(loadModule(targetPath, ctx.fileCache),
+            const node       = findCallableNode(loadModule(targetPath, ctx.fileCache),
                 importInfo.imported === 'default' ? valueNode.name : importInfo.imported);
 
-            if (params) {
-                return {params: describeParams(params), via: `${valueNode.name} (imported from ${importInfo.source})`};
+            if (node) {
+                return {node, via: `${valueNode.name} (imported from ${importInfo.source})`};
             }
         }
 
@@ -457,6 +477,24 @@ export function resolveHandlerParams(valueNode, ctx) {
     }
 
     return {unresolved: `unhandled mapping value shape: ${valueNode.type}`};
+}
+
+/**
+ * @summary The parameter-descriptor view of {@link resolveHandlerNode}.
+ *
+ * Kept as a delegation rather than a second resolver: the `.bind()` unwrapping, superclass hop,
+ * local-vs-imported identifier rules and unresolved-naming all live in ONE place, so a new mapping
+ * shape is taught to the resolver once and both consumers learn it. The signature-census reads
+ * params; the contract-parity lint reads the node.
+ *
+ * @param {Object} valueNode ESTree node of the mapping value
+ * @param {Object} ctx {imports, filePath, root, fileCache, ast}
+ * @returns {{params: Object[], via: String}|{unresolved: String}}
+ */
+export function resolveHandlerParams(valueNode, ctx) {
+    const resolved = resolveHandlerNode(valueNode, ctx);
+
+    return resolved.node ? {params: describeParams(resolved.node.params), via: resolved.via} : resolved
 }
 
 /**

--- a/ai/scripts/lint/lint-openapi-service-parity.mjs
+++ b/ai/scripts/lint/lint-openapi-service-parity.mjs
@@ -74,11 +74,19 @@
  * cannot drift into disagreeing about what a parameter is.
  */
 
-import fs                                        from 'node:fs';
-import path                                      from 'node:path';
-import {fileURLToPath}                           from 'node:url';
-import * as yaml                                 from 'js-yaml';
-import {collectImports, parseModule, resolveRef} from '../diagnostics/mcpHandlerSignatureCensus.mjs';
+import fs              from 'node:fs';
+import path            from 'node:path';
+import {fileURLToPath} from 'node:url';
+import * as yaml       from 'js-yaml';
+import {
+    collectImports,
+    extractOperations,
+    extractServiceMapping,
+    parseModule,
+    resolveHandlerNode,
+    resolveRef,
+    SERVERS
+} from '../diagnostics/mcpHandlerSignatureCensus.mjs';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname  = path.dirname(__filename);
@@ -111,7 +119,24 @@ export const PARITY_BASELINE = Object.freeze({
     'knowledge-base.manage_knowledge_base.viaMcp'       : 'Work-volume-gate selector, always false. Third live instance of this parameter name; disposition under #16611 citing #16577.',
     'knowledge-base.manage_knowledge_base.staleStrategy': 'Stale-row handling strategy, always undefined. Disposition under #16611; adjacent to #16590 stale-id scoping.',
     'knowledge-base.query_documents.includeMetadata'    : 'Metadata unreachable through the tool, always false. Disposition under #16611; interacts with #16588 payload size.',
-    'memory-core.get_context_frontier.depth'            : 'Frontier depth permanently 2. Disposition under #16611; needs a maximum if declared, or an agent can request an arbitrarily deep walk.'
+    'memory-core.get_context_frontier.depth'            : 'Frontier depth permanently 2. Disposition under #16611; needs a maximum if declared, or an agent can request an arbitrarily deep walk.',
+
+    // ── First findings from the ToolService dispatch join (the 142-operation object-dispatch path) ──
+    // PERMANENT — both are the `now` class: an injected test seam with a working default, where the
+    // JSDoc states the intent outright ("Test seam for bounding Chroma metadata reads"). Declaring a
+    // timeout would let a caller set an arbitrary bound on a Chroma read — either starving it or
+    // removing the bound that exists to stop a slow metadata fetch from hanging the call. A test
+    // seam and an input are different things, and the default resolving from config
+    // (`aiConfig.memoryService.chromaFetchTimeoutMs`) rather than from a literal is what says so.
+    'memory-core.get_session_memories.chromaTimeoutMs': 'Injected Chroma-read timeout seam with a config-resolved default; agent-settable would mean an arbitrary or absent bound on a metadata read. Deliberately internal, same class as who_is_online.now.',
+    'memory-core.resume_session.chromaTimeoutMs'      : 'Injected Chroma-read timeout seam with a constant default (CHROMA_SESSION_READ_TIMEOUT_MS); same reason as the sibling row above. Deliberately internal.',
+
+    // DEBT — a genuine caller-facing capability, and NOT one to fix by widening the schema on sight.
+    // `memorySharing` is a TENANT-ISOLATION policy override, already declared on two other
+    // memory-core operations, so precedent says exposing it is acceptable somewhere. Whether it is
+    // acceptable HERE is a security disposition, and a lint PR is the wrong place to silently widen
+    // a memory-visibility surface — the row's reason names where that decision is tracked.
+    'memory-core.get_session_memories.memorySharing': 'Tenant-isolation policy override, unreachable on this operation while declared on two siblings. Real capability gap; disposition under #16611 because declaring it changes which memories an agent can read.'
 });
 
 /**
@@ -506,6 +531,114 @@ export function lintOpenApiServiceParity({rootDir = ROOT_DIR} = {}) {
 }
 
 /**
+ * @summary The same parity check over the **ToolService dispatch** path.
+ *
+ * `lintOpenApiServiceParity` above joins an operation to a method on a service `ai/services.mjs`
+ * wraps. That join reaches 121 methods and leaves the larger surface uncovered: most operations are
+ * dispatched through their server's `serviceMapping` table, whose handlers are `.bind()` chains,
+ * inline arrows and imported functions rather than wrapped-service methods. Same Zod strip, same
+ * silent-`undefined` read, different join — so the gate needs both or it reports a partial sweep as
+ * a clean one.
+ *
+ * ## Object dispatch ONLY, and that is a correctness bound rather than a scoping convenience
+ *
+ * `ToolService#callTool` has two modes. With `x-pass-as-object: true` the handler receives the whole
+ * validated bag, so its first parameter genuinely IS the args object and `consumedNames` is reading
+ * the right thing. Without it, arguments arrive **positionally**: `handler(...argNames.map(...))`, so
+ * the first parameter is `argNames[0]` — one specific value, not a bag.
+ *
+ * Running the bag analysis over a positional handler would be actively wrong, not merely
+ * incomplete: `doThing(prNumber, file)` would be read as `bagParam = 'prNumber'`, and any
+ * `prNumber.something` member access would be reported as a consumed *parameter* named
+ * `something`. That is a fabricated violation, and a gate that invents findings gets ignored — so
+ * positional operations are skipped here and counted, with the signature-census owning them (its
+ * classes 2 / 2M / 3 are exactly the positional-dispatch failure modes).
+ *
+ * Unresolved handlers are REPORTED, never silently dropped: a handler this cannot locate is a
+ * contract nobody checked, and its absence from the output would read as a pass.
+ *
+ * @param {Object} [options]
+ * @param {String} [options.rootDir=ROOT_DIR]
+ * @returns {{violations: Object[], unresolved: Object[], operationsChecked: Number, positionalSkipped: Number}}
+ */
+export function lintToolServiceParity({rootDir = ROOT_DIR} = {}) {
+    const violations = [],
+          unresolved = [];
+
+    let operationsChecked = 0,
+        positionalSkipped = 0;
+
+    for (const server of SERVERS) {
+        const specPath = path.join(rootDir, server.openApi),
+              toolPath = path.join(rootDir, server.toolService);
+
+        if (!fs.existsSync(specPath) || !fs.existsSync(toolPath)) continue;
+
+        const doc                     = yaml.load(fs.readFileSync(specPath, 'utf8')),
+              toolAst                 = parseModule(fs.readFileSync(toolPath, 'utf8')),
+              {entries, imports, ast} = extractServiceMapping(toolAst),
+              fileCache               = new Map();
+
+        for (const operation of extractOperations(doc)) {
+            const valueNode = entries.get(operation.operationId);
+
+            // No binding at all is the census's finding, not this one — it reports `no-binding`
+            // per operation. Duplicating it here would mean two instruments disagreeing about the
+            // same absence.
+            if (!valueNode) continue;
+
+            if (!operation.passAsObject) {
+                positionalSkipped++;
+                continue;
+            }
+
+            const resolved = resolveHandlerNode(valueNode, {imports, filePath: toolPath, root: rootDir, fileCache, ast});
+
+            if (resolved.unresolved) {
+                unresolved.push({serverId: server.id, operationId: operation.operationId, reason: resolved.unresolved});
+                continue;
+            }
+
+            operationsChecked++;
+
+            const declared         = declaredNames(doc, findOperationById(doc, operation.operationId)),
+                  {consumed, rest} = consumedNames(resolved.node);
+
+            // A rest element re-admits every key, so absence cannot be proven — the same
+            // suppression the services.mjs join applies, for the same reason.
+            if (rest) continue;
+
+            for (const name of consumed) {
+                if (declared.has(name)) continue;
+                if (PARITY_BASELINE[`${server.id}.${operation.operationId}.${name}`]) continue;
+
+                violations.push({
+                    operationId: operation.operationId,
+                    param      : name,
+                    serverId   : server.id,
+                    via        : resolved.via,
+                    spec       : path.relative(rootDir, specPath)
+                });
+            }
+        }
+    }
+
+    return {violations, unresolved, operationsChecked, positionalSkipped};
+}
+
+/**
+ * Finds the raw operation object for an id, since `extractOperations` returns the runtime-mirror
+ * projection (`{operationId, args, passAsObject}`) rather than the document node `declaredNames`
+ * needs for its one-level `$ref` resolution.
+ * @param {Object} doc
+ * @param {String} operationId
+ * @returns {Object|undefined}
+ */
+function findOperationById(doc, operationId) {
+    return indexOperations(doc).get(operationId);
+}
+
+/**
  * Indexes a document's operations by `operationId`.
  * @param {Object} doc
  * @returns {Map<String,Object>}
@@ -553,10 +686,25 @@ export function reportUnusedDeclarations(unusedDeclarations, io = console) {
 
 if (import.meta.url === `file://${process.argv[1]}`) {
     const result = lintOpenApiServiceParity();
+    const tool   = lintToolServiceParity();
 
     // Printed BEFORE the failing arm, so a run that exits 1 still surfaces both directions rather
     // than hiding the advisory behind the abort.
     reportUnusedDeclarations(result.unusedDeclarations);
+
+    // An unresolved handler is a contract nobody checked. Reported loudly and counted in the OK line
+    // rather than dropped, because silence here is indistinguishable from coverage.
+    if (tool.unresolved.length > 0) {
+        console.warn(`[lint-openapi-service-parity] ${tool.unresolved.length} ToolService handler(s) could not be resolved — NOT checked:\n`);
+        for (const row of tool.unresolved) {
+            console.warn(`- ${row.serverId}.${row.operationId}: ${row.reason}`);
+        }
+        console.warn('');
+    }
+
+    // The two joins fail as one gate: a violation on either path is the same defect reaching the
+    // same Zod strip, and reporting them separately would let a green on one read as a green overall.
+    result.violations.push(...tool.violations);
 
     if (result.violations.length > 0) {
         console.error(`[lint-openapi-service-parity] FAILED — ${result.violations.length} consumed-but-undeclared parameter(s):\n`);
@@ -577,7 +725,8 @@ if (import.meta.url === `file://${process.argv[1]}`) {
 
     console.log(
         `[lint-openapi-service-parity] OK — ${result.servicesScanned} wrapped service(s), ` +
-        `${result.operationsMatched} operation-bound method(s), 0 consumed-but-undeclared parameter(s), ` +
-        `${result.unusedDeclarations.length} declared-but-unused (advisory).`
+        `${result.operationsMatched} operation-bound method(s) + ${tool.operationsChecked} object-dispatch handler(s), ` +
+        `0 consumed-but-undeclared parameter(s), ${result.unusedDeclarations.length} declared-but-unused (advisory), ` +
+        `${tool.positionalSkipped} positional handler(s) owned by the signature census.`
     );
 }

--- a/ai/scripts/lint/lint-openapi-service-parity.mjs
+++ b/ai/scripts/lint/lint-openapi-service-parity.mjs
@@ -116,10 +116,10 @@ export const PARITY_BASELINE = Object.freeze({
     // exists in the service and is unreachable from outside it, and declaring a parameter makes it
     // agent-settable, which is a per-parameter design decision (bounds for traversal knobs, payload
     // cost for response-widening flags).
-    'knowledge-base.manage_knowledge_base.viaMcp'       : 'Work-volume-gate selector, always false. Third live instance of this parameter name; disposition under #16611 citing #16577.',
-    'knowledge-base.manage_knowledge_base.staleStrategy': 'Stale-row handling strategy, always undefined. Disposition under #16611; adjacent to #16590 stale-id scoping.',
-    'knowledge-base.query_documents.includeMetadata'    : 'Metadata unreachable through the tool, always false. Disposition under #16611; interacts with #16588 payload size.',
-    'memory-core.get_context_frontier.depth'            : 'Frontier depth permanently 2. Disposition under #16611; needs a maximum if declared, or an agent can request an arbitrarily deep walk.',
+    'knowledge-base.manage_knowledge_base.viaMcp'       : 'PERMANENT. Not a gap: MCP dispatch forces true after Zod strips any caller value, and the services.mjs/CLI path correctly defaults to false (the documented long-running-work bypass). Declaring it would let a caller disable the work-volume gate through a public surface. Withdrawn from #16611.',
+    'knowledge-base.manage_knowledge_base.staleStrategy': 'PERMANENT. One of its two values (delete-upfront) removes stale rows BEFORE embedding, so a failure between the two loses both; the operator surface already exists as NEO_KB_STALE_STRATEGY. Declaring it would only add remote selection of the destructive branch. Dispositioned on #16611.',
+    'knowledge-base.query_documents.includeMetadata'    : 'PERMANENT. An internal RAG-synthesis hydration flag with exactly one caller (SearchService), not a caller-facing capability — the surface that needs metadata is ask_knowledge_base, which sets it. Nothing is unreachable. Dispositioned on #16611.',
+    'memory-core.get_context_frontier.depth'            : 'TRANSITIONAL. Measured DEAD by AST: zero occurrences in getContextFrontier body, destructured and never read. Declaring it would advertise a knob that silently does nothing; the disposition on #16611 is to DELETE the parameter, which removes this row with it.',
 
     // ── First findings from the ToolService dispatch join (the 142-operation object-dispatch path) ──
     // PERMANENT — both are the `now` class: an injected test seam with a working default, where the
@@ -148,7 +148,7 @@ export const PARITY_BASELINE = Object.freeze({
     // Baselined so the gate stays clean while the disposition is decided — wire it through to a
     // filter, or remove it from the contract and point callers at `query_summaries`. That is a
     // behaviour change, not a lint fix.
-    'memory-core.get_all_summaries.category': 'Declared with a "Filter by category" description that listSummaries never reads; capability exists on querySummaries. Disposition tracked with the other unreachable-parameter rows.',
+    'memory-core.get_all_summaries.category': 'Declared with a "Filter by category" description that listSummaries never reads, while the capability exists on querySummaries. Owned by #16611 as an added ledger row; the fix is to wire the filter or remove the declaration, both behaviour changes rather than lint edits.',
 
     'memory-core.get_session_memories.memorySharing': 'Tenant-isolation policy override, unreachable on this operation while declared on two siblings. Real capability gap; disposition under #16611 because declaring it changes which memories an agent can read.'
 });

--- a/ai/scripts/lint/lint-openapi-service-parity.mjs
+++ b/ai/scripts/lint/lint-openapi-service-parity.mjs
@@ -136,6 +136,20 @@ export const PARITY_BASELINE = Object.freeze({
     // memory-core operations, so precedent says exposing it is acceptable somewhere. Whether it is
     // acceptable HERE is a security disposition, and a lint PR is the wrong place to silently widen
     // a memory-visibility surface — the row's reason names where that decision is tracked.
+    // ── First finding from the ADVISORY direction on the ToolService path ──────────────────────
+    // Not a stripped read — the inverse. `get_all_summaries` DECLARES `category` with the
+    // description "Filter by category", and its operation description tells an agent to "find
+    // sessions related to a specific category of work". The bound handler is
+    // `SummaryService.listSummaries({limit, offset, agentIdentity})`, which never reads it. So an
+    // agent filtering by category receives unfiltered results and no error, while the capability
+    // genuinely exists on the sibling `querySummaries`. Documentation actively instructing callers to
+    // use a parameter that does nothing is worse than an undocumented gap.
+    //
+    // Baselined so the gate stays clean while the disposition is decided — wire it through to a
+    // filter, or remove it from the contract and point callers at `query_summaries`. That is a
+    // behaviour change, not a lint fix.
+    'memory-core.get_all_summaries.category': 'Declared with a "Filter by category" description that listSummaries never reads; capability exists on querySummaries. Disposition tracked with the other unreachable-parameter rows.',
+
     'memory-core.get_session_memories.memorySharing': 'Tenant-isolation policy override, unreachable on this operation while declared on two siblings. Real capability gap; disposition under #16611 because declaring it changes which memories an agent can read.'
 });
 
@@ -309,7 +323,8 @@ export function consumedNames(fnNode) {
     // support an absence claim. Tracking it here rather than in the caller keeps the one walker as
     // the single authority on what it can and cannot see.
     let bagOccurrences = 0,
-        bagAccounted   = 0;
+        bagAccounted   = 0,
+        dynamicRead    = false;
 
     if (bagParam) {
         walk(fnNode.body, node => {
@@ -345,6 +360,24 @@ export function consumedNames(fnNode) {
             if (node.computed && node.property?.type === 'Literal' && typeof node.property.value === 'string') {
                 consumed.add(node.property.value);
             }
+
+            // 4. DYNAMIC computed read: `options[someVar]`. Undecidable, and it must clear
+            //    `complete` rather than merely be absent from `consumed`.
+            //
+            //    This module's blind-spot list already named dynamic access — but named it for the
+            //    FAILING direction, where it is harmless: that direction needs `consumed` to be a
+            //    lower bound, and an unseen read simply keeps it lower. Carrying the same caveat into
+            //    the advisory direction is NOT harmless, because there the claim is the complement.
+            //    Without this branch `m(o, k) { return o[k] }` reported `complete: true` with
+            //    `consumed: []` — a read that happened, cannot be named, and was certified as a full
+            //    view. Every declared parameter on such an operation would have been reported unused.
+            //
+            //    The lesson generalises past this line: a documented blind spot's harmlessness is
+            //    DIRECTION-SPECIFIC, so reusing a helper in the opposite direction re-opens every
+            //    caveat its docs had already retired.
+            if (node.computed && !(node.property?.type === 'Literal' && typeof node.property.value === 'string')) {
+                dynamicRead = true;
+            }
         });
     }
 
@@ -354,7 +387,7 @@ export function consumedNames(fnNode) {
     // destructured it (there is no bag left to forward), or when the bag exists and every one of its
     // occurrences was a read we recorded. Consumed by the advisory direction ONLY; the failing
     // direction is sound without it.
-    const complete = destructured || (bagParam ? bagOccurrences === bagAccounted : true);
+    const complete = !dynamicRead && (destructured || (bagParam ? bagOccurrences === bagAccounted : true));
 
     return {consumed, bagParam, destructured, complete};
 }
@@ -559,11 +592,12 @@ export function lintOpenApiServiceParity({rootDir = ROOT_DIR} = {}) {
  *
  * @param {Object} [options]
  * @param {String} [options.rootDir=ROOT_DIR]
- * @returns {{violations: Object[], unresolved: Object[], operationsChecked: Number, positionalSkipped: Number}}
+ * @returns {{violations: Object[], unresolved: Object[], unusedDeclarations: Object[], operationsChecked: Number, positionalSkipped: Number}}
  */
 export function lintToolServiceParity({rootDir = ROOT_DIR} = {}) {
-    const violations = [],
-          unresolved = [];
+    const violations         = [],
+          unresolved         = [],
+          unusedDeclarations = [];
 
     let operationsChecked = 0,
         positionalSkipped = 0;
@@ -601,8 +635,8 @@ export function lintToolServiceParity({rootDir = ROOT_DIR} = {}) {
 
             operationsChecked++;
 
-            const declared         = declaredNames(doc, findOperationById(doc, operation.operationId)),
-                  {consumed, rest} = consumedNames(resolved.node);
+            const declared                   = declaredNames(doc, findOperationById(doc, operation.operationId)),
+                  {complete, consumed, rest} = consumedNames(resolved.node);
 
             // A rest element re-admits every key, so absence cannot be proven — the same
             // suppression the services.mjs join applies, for the same reason.
@@ -620,10 +654,35 @@ export function lintToolServiceParity({rootDir = ROOT_DIR} = {}) {
                     spec       : path.relative(rootDir, specPath)
                 });
             }
+
+            // The inverse direction on this path too, gated on `complete` for the same reason as its
+            // sibling: `consumed` is a lower bound, so its complement cannot support an absence
+            // claim unless every read was visible.
+            //
+            // No per-operation union is needed here, unlike the services.mjs join. There, several
+            // same-named methods on different services bind to ONE operationId and each destructures
+            // only its own keys, so the union across contributors is the only sound denominator.
+            // A `serviceMapping` is keyed BY operationId, so an operation has exactly one handler and
+            // this loop already sees the whole denominator. Stating that rather than leaving the
+            // asymmetry to look like an oversight.
+            if (!complete) continue;
+
+            for (const name of declared) {
+                if (consumed.has(name)) continue;
+                if (PARITY_BASELINE[`${server.id}.${operation.operationId}.${name}`]) continue;
+
+                unusedDeclarations.push({
+                    operationId: operation.operationId,
+                    param      : name,
+                    serverId   : server.id,
+                    methods    : [resolved.via],
+                    spec       : path.relative(rootDir, specPath)
+                });
+            }
         }
     }
 
-    return {violations, unresolved, operationsChecked, positionalSkipped};
+    return {violations, unresolved, unusedDeclarations, operationsChecked, positionalSkipped};
 }
 
 /**

--- a/ai/scripts/lint/lint-openapi-service-parity.mjs
+++ b/ai/scripts/lint/lint-openapi-service-parity.mjs
@@ -743,9 +743,62 @@ export function reportUnusedDeclarations(unusedDeclarations, io = console) {
     );
 }
 
+/**
+ * @summary The PRODUCTION COMPOSITION of both joins — the gate's actual verdict.
+ *
+ * Extracted from the CLI block, and the extraction is the point rather than tidiness. While this
+ * lived inside `if (import.meta.url === …)` the composition itself was unreachable from any test:
+ * both child analyses were covered, and the step that merges them into one fatal result was not. So
+ * deleting the ToolService append would have left every child test green while the gate silently
+ * stopped failing on half its surface — a false green in the seam *between* two well-tested parts,
+ * which is the one place per-part coverage cannot look.
+ *
+ * The two joins fail as ONE gate: a violation on either path is the same defect reaching the same
+ * Zod strip, so reporting them separately would let a green on one read as a green overall.
+ * Advisory, unresolved and coverage counts are all preserved through the merge rather than
+ * recomputed, so the CLI renders exactly what a test can assert on.
+ *
+ * @param {Object} [options]
+ * @param {String} [options.rootDir=ROOT_DIR]
+ * @returns {{violations: Object[], unusedDeclarations: Object[], unresolved: Object[], servicesScanned: Number, operationsMatched: Number, operationsChecked: Number, positionalSkipped: Number}}
+ */
+export function lintParity({rootDir = ROOT_DIR} = {}) {
+    const service = lintOpenApiServiceParity({rootDir}),
+          tool    = lintToolServiceParity({rootDir});
+
+    return {
+        violations        : [...service.violations, ...tool.violations],
+        unusedDeclarations: [...service.unusedDeclarations, ...tool.unusedDeclarations],
+        unresolved        : tool.unresolved,
+        servicesScanned   : service.servicesScanned,
+        operationsMatched : service.operationsMatched,
+        operationsChecked : tool.operationsChecked,
+        positionalSkipped : tool.positionalSkipped
+    };
+}
+
+/**
+ * @summary Renders one violation, from either join, with the coordinates that join actually carries.
+ *
+ * The two joins describe a handler differently and neither is a superset: the `services.mjs` join
+ * knows `module` + `method`, while the ToolService join knows `serverId` + `via` (the resolution
+ * path — `.bind` chain, inline arrow, imported identifier). Rendering both through the first shape
+ * printed `undefined → undefined()` for every ToolService row, which is a finding a reader cannot
+ * act on.
+ *
+ * @param {Object} violation
+ * @returns {String[]} the lines to print
+ */
+export function describeViolation(violation) {
+    const where = violation.via
+        ? `    ${violation.serverId} serviceMapping → ${violation.via}`
+        : `    ${violation.module} → ${violation.method}()`;
+
+    return [`- ${violation.operationId} reads \`${violation.param}\` — not declared in ${violation.spec}`, where];
+}
+
 if (import.meta.url === `file://${process.argv[1]}`) {
-    const result = lintOpenApiServiceParity();
-    const tool   = lintToolServiceParity();
+    const result = lintParity();
 
     // Printed BEFORE the failing arm, so a run that exits 1 still surfaces both directions rather
     // than hiding the advisory behind the abort.
@@ -753,24 +806,19 @@ if (import.meta.url === `file://${process.argv[1]}`) {
 
     // An unresolved handler is a contract nobody checked. Reported loudly and counted in the OK line
     // rather than dropped, because silence here is indistinguishable from coverage.
-    if (tool.unresolved.length > 0) {
-        console.warn(`[lint-openapi-service-parity] ${tool.unresolved.length} ToolService handler(s) could not be resolved — NOT checked:\n`);
-        for (const row of tool.unresolved) {
+    if (result.unresolved.length > 0) {
+        console.warn(`[lint-openapi-service-parity] ${result.unresolved.length} ToolService handler(s) could not be resolved — NOT checked:\n`);
+        for (const row of result.unresolved) {
             console.warn(`- ${row.serverId}.${row.operationId}: ${row.reason}`);
         }
         console.warn('');
     }
 
-    // The two joins fail as one gate: a violation on either path is the same defect reaching the
-    // same Zod strip, and reporting them separately would let a green on one read as a green overall.
-    result.violations.push(...tool.violations);
-
     if (result.violations.length > 0) {
         console.error(`[lint-openapi-service-parity] FAILED — ${result.violations.length} consumed-but-undeclared parameter(s):\n`);
 
         for (const violation of result.violations) {
-            console.error(`- ${violation.operationId} reads \`${violation.param}\` — not declared in ${violation.spec}`);
-            console.error(`    ${violation.module} → ${violation.method}()`);
+            for (const line of describeViolation(violation)) console.error(line);
         }
 
         console.error(
@@ -784,8 +832,8 @@ if (import.meta.url === `file://${process.argv[1]}`) {
 
     console.log(
         `[lint-openapi-service-parity] OK — ${result.servicesScanned} wrapped service(s), ` +
-        `${result.operationsMatched} operation-bound method(s) + ${tool.operationsChecked} object-dispatch handler(s), ` +
+        `${result.operationsMatched} operation-bound method(s) + ${result.operationsChecked} object-dispatch handler(s), ` +
         `0 consumed-but-undeclared parameter(s), ${result.unusedDeclarations.length} declared-but-unused (advisory), ` +
-        `${tool.positionalSkipped} positional handler(s) owned by the signature census.`
+        `${result.positionalSkipped} positional handler(s) owned by the signature census.`
     );
 }

--- a/ai/scripts/lint/lint-openapi-service-parity.mjs
+++ b/ai/scripts/lint/lint-openapi-service-parity.mjs
@@ -142,8 +142,17 @@ export function extractWrappedServices(rootDir) {
           wrapped      = [];
 
     // `const ghSpec = safeLoadYaml(path.join(__dirname, 'mcp/server/…/openapi.yaml'))`
-    for (const node of ast.body) {
-        if (node.type !== 'VariableDeclaration') continue;
+    //
+    // `export const X = makeSafe(…)` is unwrapped rather than skipped. Today every one of the 40
+    // live bindings is a bare `const` with a separate export, so this branch is unreachable on the
+    // current tree — which is exactly why it is here. Discovery that silently ignores a declaration
+    // form means a service written that way disappears from the gate and its absence reads as a
+    // pass, and a false green from a silent skip is the precise failure this whole lint exists to
+    // make loud. Cheaper to accept the form than to rely on nobody ever typing it.
+    for (const outer of ast.body) {
+        const node = outer.type === 'ExportNamedDeclaration' ? outer.declaration : outer;
+
+        if (node?.type !== 'VariableDeclaration') continue;
 
         for (const declarator of node.declarations) {
             const init = declarator.init;

--- a/ai/scripts/lint/lint-openapi-service-parity.mjs
+++ b/ai/scripts/lint/lint-openapi-service-parity.mjs
@@ -1,0 +1,396 @@
+#!/usr/bin/env node
+/**
+ * @module ai/scripts/lint/lint-openapi-service-parity
+ * @summary Fails when a service method CONSUMES a parameter its OpenAPI operation does not declare,
+ * because `ai/services.mjs` routes every such call through a Zod facade that silently strips it.
+ *
+ * ## The failure this exists to make loud
+ *
+ * `ai/services.mjs#makeSafe` wraps each MCP-backed service in a validating Proxy:
+ *
+ * ```js
+ * const parsedArgs = zodSchema.parse(args || {});
+ * ```
+ *
+ * The schema is built from the server's `openapi.yaml`, and Zod object parsing **strips keys the
+ * schema does not declare**. So a method that gains a parameter without a matching spec property
+ * still compiles, still lints, and still passes every unit test that constructs the service
+ * directly — then silently never receives that parameter in production, where the call goes through
+ * the Proxy. There is no throw, no warning, and nothing in the returned summary. The parameter is
+ * simply absent, and the method reads `undefined`.
+ *
+ * Two live instances shipped this way on `ingest_source_files`: `materializationAttempt` (no
+ * receipt ever minted, so every full pull materialization was rejected as `EMPTY_MATERIALIZATION`)
+ * and `viaMcp` (`payload.viaMcp !== false` re-read as `true`, forcing in-process bulk paths through
+ * the MCP work-volume gate). The first went undetected for weeks. Diagnosing one of them cost about
+ * a session, and the defect was a line of YAML that did not exist.
+ *
+ * ## Why CONSUMPTION is the signal, not JSDoc
+ *
+ * `ingestSourceFiles(payload = {})` takes a bag and destructures nothing, so its signature carries
+ * no parameter names at all — a signature-based check finds nothing on the very operation that
+ * motivated this guard. The names appear only as member reads (`payload.viaMcp`) in the body, and
+ * that read *is* the failure site. Keying on JSDoc instead would false-positive on a documented but
+ * unused param (harmless) while missing a read with no JSDoc at all (the worst case, undeclared
+ * everywhere). Consumption also subsumes destructuring, since destructured names are reads.
+ *
+ * Detection is therefore: **destructured parameter names ∪ `<bagParam>.X` member reads**, compared
+ * against the operation's declared parameters and request-body properties.
+ *
+ * ## Known blind spots, stated rather than discovered
+ *
+ * - **Dynamic access** (`payload[key]`) is undecidable here and is not reported.
+ * - **Wholesale forwarding** (`helper(payload)`) hides consumption in the callee; only direct reads
+ *   on the bound parameter are seen.
+ *
+ * Both are narrower than the JSDoc approach's blind spot, not wider. A guard that overstated its
+ * coverage would be worse than one that names its edges.
+ *
+ * ## Relationship to the sibling instrument
+ *
+ * `ai/scripts/diagnostics/mcpHandlerSignatureCensus.mjs` covers the **ToolService** dispatch path —
+ * whether a handler's signature matches its dispatch mode. This covers the **`services.mjs` Proxy**
+ * path — whether the contract is complete with respect to what the method reads. Same pair of
+ * artifacts, different join and different failure mode; the coverage is complementary rather than
+ * overlapping, which is why both exist. Shared AST helpers are imported from that module so the two
+ * cannot drift into disagreeing about what a parameter is.
+ */
+
+import fs                                        from 'node:fs';
+import path                                      from 'node:path';
+import {fileURLToPath}                           from 'node:url';
+import * as yaml                                 from 'js-yaml';
+import {collectImports, parseModule, resolveRef} from '../diagnostics/mcpHandlerSignatureCensus.mjs';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname  = path.dirname(__filename);
+const ROOT_DIR   = path.resolve(__dirname, '../../..');
+
+/**
+ * Suppression entries for parameters a method legitimately reads without the contract declaring
+ * them. Each row must state WHY, so a suppression is a visible decision rather than an omission.
+ * Keyed `<operationId>.<paramName>`.
+ * @type {Object<String,String>}
+ */
+export const PARITY_BASELINE = Object.freeze({
+    // PERMANENT — correct as designed, and declaring it would be a regression. `now` is an injected
+    // clock with a working default (`now = new Date()`), used identically across `bootstrap`,
+    // `retireStaleHarnessPresence` and `whoIsOnline`. Exposing it in the contract would let a caller
+    // supply an arbitrary "current time" to a liveness computation — i.e. lie about whether a peer is
+    // online. Do not "fix" this by widening the schema.
+    'who_is_online.now': 'Injected clock (test seam) with a working default; agent-settable time would let a caller falsify peer liveness. Deliberately internal.',
+
+    // DEBT — genuine contract gaps awaiting individual disposition; each row's reason names the
+    // tracking ticket, which is where a decay-prone reference belongs. Not suppressed: the capability
+    // exists in the service and is unreachable from outside it, and declaring a parameter makes it
+    // agent-settable, which is a per-parameter design decision (bounds for traversal knobs, payload
+    // cost for response-widening flags).
+    'manage_knowledge_base.viaMcp'       : 'Work-volume-gate selector, always false. Third live instance of this parameter name; disposition under #16611 citing #16577.',
+    'manage_knowledge_base.staleStrategy': 'Stale-row handling strategy, always undefined. Disposition under #16611; adjacent to #16590 stale-id scoping.',
+    'query_documents.includeMetadata'    : 'Metadata unreachable through the tool, always false. Disposition under #16611; interacts with #16588 payload size.',
+    'get_context_frontier.depth'         : 'Frontier depth permanently 2. Disposition under #16611; needs a maximum if declared, or an agent can request an arbitrarily deep walk.'
+});
+
+/**
+ * Mirrors `ai/services.mjs#camelToSnake` — the in-process join from method name to `operationId`.
+ * @param {String} str
+ * @returns {String}
+ */
+export function camelToSnake(str) {
+    return str.replace(/[A-Z]/g, letter => `_${letter.toLowerCase()}`);
+}
+
+/**
+ * @summary Reads the `makeSafe(service, spec)` declaration table out of `ai/services.mjs`.
+ *
+ * Derived from the source rather than restated, so adding a service to the SDK brings it under this
+ * guard automatically. A hand-maintained list would silently exempt exactly the newest code, which
+ * is the code most likely to carry the defect.
+ *
+ * @param {String} rootDir Repository root.
+ * @returns {Array<{serviceName: String, modulePath: String, specPath: String}>}
+ */
+export function extractWrappedServices(rootDir) {
+    const servicesPath = path.join(rootDir, 'ai/services.mjs'),
+          source       = fs.readFileSync(servicesPath, 'utf8'),
+          ast          = parseModule(source),
+          imports      = collectImports(ast),
+          specPaths    = new Map(),
+          wrapped      = [];
+
+    // `const ghSpec = safeLoadYaml(path.join(__dirname, 'mcp/server/…/openapi.yaml'))`
+    for (const node of ast.body) {
+        if (node.type !== 'VariableDeclaration') continue;
+
+        for (const declarator of node.declarations) {
+            const init = declarator.init;
+
+            if (init?.type === 'CallExpression' && init.callee?.name === 'safeLoadYaml') {
+                const literal = findFirstStringLiteral(init);
+                if (literal) {
+                    specPaths.set(declarator.id.name, path.join(rootDir, 'ai', literal));
+                }
+            }
+
+            if (init?.type === 'CallExpression' && init.callee?.name === 'makeSafe') {
+                const [serviceArg, specArg] = init.arguments;
+
+                if (serviceArg?.type === 'Identifier' && specArg?.type === 'Identifier') {
+                    wrapped.push({
+                        serviceName  : declarator.id.name,
+                        importedAs   : serviceArg.name,
+                        importBinding: imports.get(serviceArg.name) ?? null,
+                        specPathToken: specArg.name
+                    });
+                }
+            }
+        }
+    }
+
+    // `collectImports` returns `{source, imported}` per binding, not a bare path — reading it as a
+    // string would silently produce `undefined` module paths and a guard that scanned nothing.
+    return wrapped.map(entry => {
+        const source = entry.importBinding?.source ?? null;
+
+        return {
+            serviceName: entry.serviceName,
+            modulePath : source ? path.join(rootDir, 'ai', source.replace(/^\.\//, '')) : null,
+            specPath   : specPaths.get(entry.specPathToken) ?? null
+        };
+    }).filter(entry => entry.modulePath && entry.specPath);
+}
+
+/**
+ * Walks a call expression for its first string literal — `path.join(__dirname, '<here>')`.
+ * @param {Object} node
+ * @returns {String|null}
+ */
+function findFirstStringLiteral(node) {
+    for (const arg of node.arguments ?? []) {
+        if (arg.type === 'Literal' && typeof arg.value === 'string') return arg.value;
+        if (arg.type === 'CallExpression') {
+            const nested = findFirstStringLiteral(arg);
+            if (nested) return nested;
+        }
+    }
+    return null;
+}
+
+/**
+ * @summary The names an operation DECLARES: query/path parameters plus request-body properties.
+ *
+ * `$ref` is resolved one level, matching `openApiValidator.mjs#resolveRef`, because the runtime
+ * schema resolves it — a guard that stopped at the `$ref` would report a declared param as missing.
+ *
+ * @param {Object} doc       Parsed OpenAPI document.
+ * @param {Object} operation
+ * @returns {Set<String>}
+ */
+export function declaredNames(doc, operation) {
+    const names = new Set();
+
+    for (const parameter of operation.parameters ?? []) {
+        if (parameter.name) names.add(parameter.name);
+    }
+
+    const bodySchema = operation.requestBody?.content?.['application/json']?.schema;
+
+    if (bodySchema) {
+        const resolved = bodySchema.$ref ? resolveRef(doc, bodySchema.$ref) : bodySchema;
+
+        for (const key of Object.keys(resolved?.properties ?? {})) {
+            names.add(key);
+        }
+    }
+
+    return names;
+}
+
+/**
+ * @summary The names a method CONSUMES: destructured parameter keys plus member reads on its bag.
+ *
+ * @param {Object} fnNode Function/method AST node.
+ * @returns {{consumed: Set<String>, bagParam: String|null, destructured: Boolean}}
+ */
+export function consumedNames(fnNode) {
+    const consumed     = new Set();
+    const first        = fnNode.params?.[0];
+    let   bagParam     = null;
+    let   destructured = false;
+
+    if (first) {
+        // `foo({a, b})` and `foo({a, b} = {})` — the destructured keys ARE the reads.
+        const pattern = first.type === 'AssignmentPattern' ? first.left : first;
+
+        if (pattern.type === 'ObjectPattern') {
+            destructured = true;
+            for (const property of pattern.properties) {
+                if (property.type === 'Property' && property.key?.name) consumed.add(property.key.name);
+                // A rest element re-exposes everything, so nothing can be proven absent.
+                if (property.type === 'RestElement') return {consumed, bagParam: null, destructured, rest: true};
+            }
+        } else if (pattern.type === 'Identifier') {
+            bagParam = pattern.name;
+        }
+    }
+
+    // `payload.viaMcp` — the read that evaluates `undefined` once Zod has stripped the key.
+    if (bagParam) {
+        walk(fnNode.body, node => {
+            if (node.type === 'MemberExpression' &&
+                node.object?.type === 'Identifier' && node.object.name === bagParam &&
+                !node.computed && node.property?.type === 'Identifier') {
+                consumed.add(node.property.name);
+            }
+        });
+    }
+
+    return {consumed, bagParam, destructured};
+}
+
+/**
+ * Minimal AST walk. Deliberately local and shape-agnostic: it visits every object with a `type`
+ * rather than switching on node kinds, so a syntax form this file has not anticipated is traversed
+ * instead of silently skipped — an unvisited branch would read as "no reads found".
+ * @param {Object} root
+ * @param {Function} visit
+ */
+function walk(root, visit) {
+    if (!root || typeof root !== 'object') return;
+
+    if (Array.isArray(root)) {
+        for (const item of root) walk(item, visit);
+        return;
+    }
+
+    if (typeof root.type === 'string') visit(root);
+
+    for (const key of Object.keys(root)) {
+        if (key === 'type' || key === 'start' || key === 'end' || key === 'loc') continue;
+        walk(root[key], visit);
+    }
+}
+
+/**
+ * @summary Collects every class method / assigned function in a module, keyed by name.
+ * @param {Object} ast
+ * @returns {Map<String,Object>}
+ */
+export function collectMethods(ast) {
+    const methods = new Map();
+
+    walk(ast, node => {
+        if (node.type === 'MethodDefinition' && node.key?.name && node.value) {
+            if (!methods.has(node.key.name)) methods.set(node.key.name, node.value);
+        }
+    });
+
+    return methods;
+}
+
+/**
+ * @summary Runs the parity check over every service `ai/services.mjs` wraps.
+ * @param {Object}  [options]
+ * @param {String}  [options.rootDir=ROOT_DIR]
+ * @returns {{violations: Object[], checked: Number, operationsMatched: Number, servicesScanned: Number}}
+ */
+export function lintOpenApiServiceParity({rootDir = ROOT_DIR} = {}) {
+    const services   = extractWrappedServices(rootDir),
+          violations = [],
+          specCache  = new Map();
+
+    let operationsMatched = 0;
+
+    for (const service of services) {
+        if (!fs.existsSync(service.modulePath) || !fs.existsSync(service.specPath)) continue;
+
+        if (!specCache.has(service.specPath)) {
+            specCache.set(service.specPath, yaml.load(fs.readFileSync(service.specPath, 'utf8')));
+        }
+
+        const doc     = specCache.get(service.specPath),
+              ast     = parseModule(fs.readFileSync(service.modulePath, 'utf8')),
+              methods = collectMethods(ast),
+              byId    = indexOperations(doc);
+
+        for (const [methodName, fnNode] of methods) {
+            const operationId = camelToSnake(methodName),
+                  operation   = byId.get(operationId);
+
+            if (!operation) continue;
+
+            operationsMatched++;
+
+            const declared         = declaredNames(doc, operation),
+                  {consumed, rest} = consumedNames(fnNode);
+
+            // A rest element re-admits every key, so absence cannot be proven and silence here
+            // would be a false green rather than a pass.
+            if (rest) continue;
+
+            for (const name of consumed) {
+                if (declared.has(name)) continue;
+                if (PARITY_BASELINE[`${operationId}.${name}`]) continue;
+
+                violations.push({
+                    operationId,
+                    param  : name,
+                    method : methodName,
+                    service: service.serviceName,
+                    module : path.relative(rootDir, service.modulePath),
+                    spec   : path.relative(rootDir, service.specPath)
+                });
+            }
+        }
+    }
+
+    return {
+        violations,
+        checked        : services.length,
+        operationsMatched,
+        servicesScanned: services.length
+    };
+}
+
+/**
+ * Indexes a document's operations by `operationId`.
+ * @param {Object} doc
+ * @returns {Map<String,Object>}
+ */
+function indexOperations(doc) {
+    const byId = new Map();
+
+    for (const pathItem of Object.values(doc?.paths ?? {})) {
+        for (const operation of Object.values(pathItem ?? {})) {
+            if (operation?.operationId) byId.set(operation.operationId, operation);
+        }
+    }
+
+    return byId;
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+    const result = lintOpenApiServiceParity();
+
+    if (result.violations.length > 0) {
+        console.error(`[lint-openapi-service-parity] FAILED — ${result.violations.length} consumed-but-undeclared parameter(s):\n`);
+
+        for (const violation of result.violations) {
+            console.error(`- ${violation.operationId} reads \`${violation.param}\` — not declared in ${violation.spec}`);
+            console.error(`    ${violation.module} → ${violation.method}()`);
+        }
+
+        console.error(
+            `\nThe Zod facade in ai/services.mjs STRIPS undeclared keys, so each of these reads ` +
+            `\`undefined\` in production while every direct-construction unit test passes. Declare the ` +
+            `parameter in the operation's schema, or add an explicit PARITY_BASELINE row stating why ` +
+            `the read is legitimate.\n`
+        );
+        process.exit(1);
+    }
+
+    console.log(
+        `[lint-openapi-service-parity] OK — ${result.servicesScanned} wrapped service(s), ` +
+        `${result.operationsMatched} operation-bound method(s), 0 consumed-but-undeclared parameter(s).`
+    );
+}

--- a/ai/scripts/lint/lint-openapi-service-parity.mjs
+++ b/ai/scripts/lint/lint-openapi-service-parity.mjs
@@ -34,17 +34,35 @@
  * unused param (harmless) while missing a read with no JSDoc at all (the worst case, undeclared
  * everywhere). Consumption also subsumes destructuring, since destructured names are reads.
  *
- * Detection is therefore: **destructured parameter names ∪ `<bagParam>.X` member reads**, compared
- * against the operation's declared parameters and request-body properties.
+ * Detection covers **four statically decidable forms**, unioned, and compared against the operation's
+ * declared parameters and request-body properties:
+ *
+ * 1. **Parameter destructuring** — `foo({a, b})`, `foo({a, b} = {})`.
+ * 2. **Dotted bag read** — `payload.viaMcp`.
+ * 3. **Body destructuring** — `const {a, b} = bag`, `= bag || {}`, `= bag ?? {}`.
+ * 4. **Literal computed read** — `options['file']`.
+ *
+ * Forms 3 and 4 were missing from the first version, and their absence was a **false green on real
+ * production code**: `PullRequestService#getPullRequestDiff(options)` does
+ * `const {pr_number, file, sha, files_only} = options || {}`, and the checker reported ZERO consumed
+ * names for it while CI was fully green. A guard that claims an invariant and misses the most common
+ * production shape is worse than no guard, because its green is read as coverage.
+ *
+ * A `...rest` element in either destructuring position re-admits every key, so absence cannot be
+ * proven and the bundle is skipped rather than passed.
  *
  * ## Known blind spots, stated rather than discovered
  *
- * - **Dynamic access** (`payload[key]`) is undecidable here and is not reported.
+ * - **Dynamic access with a NON-LITERAL key** (`payload[someVar]`) is undecidable and not reported.
+ *   The earlier wording said "dynamic access" without separating a string literal from a variable
+ *   key, which let a fully decidable form hide behind an honest-sounding caveat — the caveat is real,
+ *   it was just wider than the truth.
  * - **Wholesale forwarding** (`helper(payload)`) hides consumption in the callee; only direct reads
  *   on the bound parameter are seen.
  *
  * Both are narrower than the JSDoc approach's blind spot, not wider. A guard that overstated its
- * coverage would be worse than one that names its edges.
+ * coverage would be worse than one that names its edges — which is why this list is now shorter than
+ * it was, rather than longer.
  *
  * ## Relationship to the sibling instrument
  *
@@ -69,7 +87,12 @@ const ROOT_DIR   = path.resolve(__dirname, '../../..');
 /**
  * Suppression entries for parameters a method legitimately reads without the contract declaring
  * them. Each row must state WHY, so a suppression is a visible decision rather than an omission.
- * Keyed `<operationId>.<paramName>`.
+ *
+ * Keyed **`<serverId>.<operationId>.<paramName>`** — three coordinates, because `operationId` is
+ * unique per document and NOT repository-global. `healthcheck` and `get_mcp_tool_handbook` already
+ * exist on several servers, so an operation-scoped key would let a suppression on one server silently
+ * absolve the same-named operation on another; a param-only key is worse still, since `viaMcp` has
+ * three live instances across two operations and one row would have hidden all of them.
  * @type {Object<String,String>}
  */
 export const PARITY_BASELINE = Object.freeze({
@@ -78,17 +101,17 @@ export const PARITY_BASELINE = Object.freeze({
     // `retireStaleHarnessPresence` and `whoIsOnline`. Exposing it in the contract would let a caller
     // supply an arbitrary "current time" to a liveness computation — i.e. lie about whether a peer is
     // online. Do not "fix" this by widening the schema.
-    'who_is_online.now': 'Injected clock (test seam) with a working default; agent-settable time would let a caller falsify peer liveness. Deliberately internal.',
+    'memory-core.who_is_online.now': 'Injected clock (test seam) with a working default; agent-settable time would let a caller falsify peer liveness. Deliberately internal.',
 
     // DEBT — genuine contract gaps awaiting individual disposition; each row's reason names the
     // tracking ticket, which is where a decay-prone reference belongs. Not suppressed: the capability
     // exists in the service and is unreachable from outside it, and declaring a parameter makes it
     // agent-settable, which is a per-parameter design decision (bounds for traversal knobs, payload
     // cost for response-widening flags).
-    'manage_knowledge_base.viaMcp'       : 'Work-volume-gate selector, always false. Third live instance of this parameter name; disposition under #16611 citing #16577.',
-    'manage_knowledge_base.staleStrategy': 'Stale-row handling strategy, always undefined. Disposition under #16611; adjacent to #16590 stale-id scoping.',
-    'query_documents.includeMetadata'    : 'Metadata unreachable through the tool, always false. Disposition under #16611; interacts with #16588 payload size.',
-    'get_context_frontier.depth'         : 'Frontier depth permanently 2. Disposition under #16611; needs a maximum if declared, or an agent can request an arbitrarily deep walk.'
+    'knowledge-base.manage_knowledge_base.viaMcp'       : 'Work-volume-gate selector, always false. Third live instance of this parameter name; disposition under #16611 citing #16577.',
+    'knowledge-base.manage_knowledge_base.staleStrategy': 'Stale-row handling strategy, always undefined. Disposition under #16611; adjacent to #16590 stale-id scoping.',
+    'knowledge-base.query_documents.includeMetadata'    : 'Metadata unreachable through the tool, always false. Disposition under #16611; interacts with #16588 payload size.',
+    'memory-core.get_context_frontier.depth'            : 'Frontier depth permanently 2. Disposition under #16611; needs a maximum if declared, or an agent can request an arbitrarily deep walk.'
 });
 
 /**
@@ -234,16 +257,46 @@ export function consumedNames(fnNode) {
         }
     }
 
-    // `payload.viaMcp` — the read that evaluates `undefined` once Zod has stripped the key.
+    // Three consuming forms on the bag, all statically decidable. The first version recognised only
+    // the second and reported ZERO consumed names for `getPullRequestDiff(options)` —
+    // `const {pr_number, file, sha, files_only} = options || {}` — a real wrapped method consuming
+    // four parameters. A guard that claims an invariant while missing the most common production
+    // shape is worse than no guard, because its green is read as coverage.
+    let rest = false;
+
     if (bagParam) {
         walk(fnNode.body, node => {
-            if (node.type === 'MemberExpression' &&
-                node.object?.type === 'Identifier' && node.object.name === bagParam &&
-                !node.computed && node.property?.type === 'Identifier') {
+            // 1. BODY destructuring: `const {a, b} = bag`, `= bag || {}`, `= bag ?? {}`.
+            if (node.type === 'VariableDeclarator' && node.id?.type === 'ObjectPattern' && node.init) {
+                const source = node.init.type === 'LogicalExpression' ? node.init.left : node.init;
+
+                if (source?.type === 'Identifier' && source.name === bagParam) {
+                    for (const property of node.id.properties) {
+                        if (property.type === 'Property' && property.key?.name) consumed.add(property.key.name);
+                        // `...rest` re-exposes every key, so no name can be proven absent.
+                        if (property.type === 'RestElement') rest = true;
+                    }
+                }
+            }
+
+            if (node.type !== 'MemberExpression') return;
+            if (node.object?.type !== 'Identifier' || node.object.name !== bagParam) return;
+
+            // 2. Dotted read: `payload.viaMcp` — evaluates `undefined` once Zod has stripped the key.
+            if (!node.computed && node.property?.type === 'Identifier') {
                 consumed.add(node.property.name);
+            }
+
+            // 3. LITERAL computed read: `options['file']`. Decidable, and previously invisible —
+            //    the blind-spot list named dynamic access without distinguishing a string literal
+            //    from a variable key, so a whole decidable form hid behind an honest-sounding caveat.
+            if (node.computed && node.property?.type === 'Literal' && typeof node.property.value === 'string') {
+                consumed.add(node.property.value);
             }
         });
     }
+
+    if (rest) return {consumed, bagParam, destructured, rest: true};
 
     return {consumed, bagParam, destructured};
 }
@@ -311,7 +364,11 @@ export function lintOpenApiServiceParity({rootDir = ROOT_DIR} = {}) {
         const doc     = specCache.get(service.specPath),
               ast     = parseModule(fs.readFileSync(service.modulePath, 'utf8')),
               methods = collectMethods(ast),
-              byId    = indexOperations(doc);
+              byId    = indexOperations(doc),
+              // The owning server directory — `ai/mcp/server/<serverId>/openapi.yaml`. Derived from
+              // the spec path rather than restated, so a new server is scoped correctly without a
+              // list to forget to update.
+              serverId = path.basename(path.dirname(service.specPath));
 
         for (const [methodName, fnNode] of methods) {
             const operationId = camelToSnake(methodName),
@@ -330,7 +387,13 @@ export function lintOpenApiServiceParity({rootDir = ROOT_DIR} = {}) {
 
             for (const name of consumed) {
                 if (declared.has(name)) continue;
-                if (PARITY_BASELINE[`${operationId}.${name}`]) continue;
+                // SERVER-SCOPED, because `operationId` is unique per document and NOT repository-global.
+                // Six servers each own an `openapi.yaml`, and `healthcheck` / `get_mcp_tool_handbook`
+                // already exist on several of them — so a bare `<operationId>.<param>` key would let a
+                // suppression on one server silently absolve the same-named operation on another. That
+                // is the identical failure the `viaMcp` rows warn about (three live instances of one
+                // parameter name), one coordinate up.
+                if (PARITY_BASELINE[`${serverId}.${operationId}.${name}`]) continue;
 
                 violations.push({
                     operationId,

--- a/ai/scripts/lint/lint-openapi-service-parity.mjs
+++ b/ai/scripts/lint/lint-openapi-service-parity.mjs
@@ -264,13 +264,29 @@ export function consumedNames(fnNode) {
     // shape is worse than no guard, because its green is read as coverage.
     let rest = false;
 
+    // Occurrences of the bag identifier we can ACCOUNT for (a named read or a destructuring source)
+    // versus every occurrence of it. A surplus means the bag itself travelled somewhere this walker
+    // cannot follow — `this.resolveTenantContext(payload)`, `{...payload}`, `return payload`. Those
+    // are real reads of names we never see, so `consumed` stops being a complete view.
+    //
+    // This distinction does not matter for the FAILING direction, which only needs `consumed` to be
+    // a lower bound: every name it does see is genuinely read. It is decisive for the advisory
+    // direction, whose claim is the complement — "no method reads this" — and a lower bound cannot
+    // support an absence claim. Tracking it here rather than in the caller keeps the one walker as
+    // the single authority on what it can and cannot see.
+    let bagOccurrences = 0,
+        bagAccounted   = 0;
+
     if (bagParam) {
         walk(fnNode.body, node => {
+            if (node.type === 'Identifier' && node.name === bagParam) bagOccurrences++;
+
             // 1. BODY destructuring: `const {a, b} = bag`, `= bag || {}`, `= bag ?? {}`.
             if (node.type === 'VariableDeclarator' && node.id?.type === 'ObjectPattern' && node.init) {
                 const source = node.init.type === 'LogicalExpression' ? node.init.left : node.init;
 
                 if (source?.type === 'Identifier' && source.name === bagParam) {
+                    bagAccounted++;
                     for (const property of node.id.properties) {
                         if (property.type === 'Property' && property.key?.name) consumed.add(property.key.name);
                         // `...rest` re-exposes every key, so no name can be proven absent.
@@ -281,6 +297,8 @@ export function consumedNames(fnNode) {
 
             if (node.type !== 'MemberExpression') return;
             if (node.object?.type !== 'Identifier' || node.object.name !== bagParam) return;
+
+            bagAccounted++;
 
             // 2. Dotted read: `payload.viaMcp` — evaluates `undefined` once Zod has stripped the key.
             if (!node.computed && node.property?.type === 'Identifier') {
@@ -298,7 +316,13 @@ export function consumedNames(fnNode) {
 
     if (rest) return {consumed, bagParam, destructured, rest: true};
 
-    return {consumed, bagParam, destructured};
+    // `complete` = every read of this parameter is visible in `consumed`. True when the signature
+    // destructured it (there is no bag left to forward), or when the bag exists and every one of its
+    // occurrences was a read we recorded. Consumed by the advisory direction ONLY; the failing
+    // direction is sound without it.
+    const complete = destructured || (bagParam ? bagOccurrences === bagAccounted : true);
+
+    return {consumed, bagParam, destructured, complete};
 }
 
 /**
@@ -348,9 +372,11 @@ export function collectMethods(ast) {
  * @returns {{violations: Object[], checked: Number, operationsMatched: Number, servicesScanned: Number}}
  */
 export function lintOpenApiServiceParity({rootDir = ROOT_DIR} = {}) {
-    const services   = extractWrappedServices(rootDir),
-          violations = [],
-          specCache  = new Map();
+    const services           = extractWrappedServices(rootDir),
+          violations         = [],
+          unusedDeclarations = [],
+          perOperation       = new Map(),
+          specCache          = new Map();
 
     let operationsMatched = 0;
 
@@ -378,8 +404,8 @@ export function lintOpenApiServiceParity({rootDir = ROOT_DIR} = {}) {
 
             operationsMatched++;
 
-            const declared         = declaredNames(doc, operation),
-                  {consumed, rest} = consumedNames(fnNode);
+            const declared                   = declaredNames(doc, operation),
+                  {complete, consumed, rest} = consumedNames(fnNode);
 
             // A rest element re-admits every key, so absence cannot be proven and silence here
             // would be a false green rather than a pass.
@@ -404,11 +430,66 @@ export function lintOpenApiServiceParity({rootDir = ROOT_DIR} = {}) {
                     spec   : path.relative(rootDir, service.specPath)
                 });
             }
+
+            // ── Accumulate for the inverse direction; it CANNOT be decided here ─────────────────
+            // One operation is frequently served by SEVERAL same-named methods on different
+            // services — `get_conversation` is implemented by DiscussionService, IssueService and
+            // PullRequestService, each destructuring only the keys it owns. Deciding "unused" inside
+            // this per-method loop reported every sibling's parameters as dead: 14 findings, all
+            // false. So the union across every method bound to an operationId is the only sound
+            // denominator, and it is not available until every service has been walked.
+            const key   = `${serverId}.${operationId}`;
+            let   entry = perOperation.get(key);
+
+            if (!entry) {
+                entry = {serverId, operationId, declared, consumed: new Set(), complete: true, methods: [], specs: new Set()};
+                perOperation.set(key, entry);
+            }
+
+            for (const name of consumed) entry.consumed.add(name);
+
+            // AND across contributors: one un-analysable implementation makes the whole operation's
+            // absence claim unprovable, because the names it hides could be exactly these.
+            entry.complete &&= complete === true;
+            entry.methods.push(`${service.serviceName}.${methodName}`);
+            entry.specs.add(path.relative(rootDir, service.specPath));
+        }
+    }
+
+    // ── The inverse direction, and deliberately NON-FAILING ─────────────────────────────────────
+    // A declared parameter nothing reads is the mirror of the failing defect and NOT its equal: the
+    // failing direction silently destroys input a caller supplied, while this one costs an agent a
+    // plausible parameter that does nothing. Real, worth surfacing, and usually a contract that
+    // outlived a refactor.
+    //
+    // Non-failing is a judgement about incentives rather than importance: a gate that fails the
+    // build on stale declarations earns an exemption row per stale declaration, and the baseline
+    // then documents debt instead of the invariant. The failing arm stays reserved for data loss.
+    //
+    // `complete` is the load-bearing gate. `consumedNames` is a LOWER BOUND on reads by
+    // construction — sound for "consumed but undeclared", useless for its complement. An operation
+    // whose implementation forwards its whole bag (`this.resolveTenantContext(payload)`) reads names
+    // this walker never sees, so claiming they are unused would be a fabricated absence. Staying
+    // silent there is the same discipline the failing direction applies to a `rest` element.
+    for (const entry of perOperation.values()) {
+        if (!entry.complete) continue;
+
+        for (const name of entry.declared) {
+            if (entry.consumed.has(name)) continue;
+            if (PARITY_BASELINE[`${entry.serverId}.${entry.operationId}.${name}`]) continue;
+
+            unusedDeclarations.push({
+                operationId: entry.operationId,
+                param      : name,
+                methods    : entry.methods,
+                spec       : [...entry.specs].join(', ')
+            });
         }
     }
 
     return {
         violations,
+        unusedDeclarations,
         checked        : services.length,
         operationsMatched,
         servicesScanned: services.length
@@ -432,8 +513,41 @@ function indexOperations(doc) {
     return byId;
 }
 
+/**
+ * @summary Prints the non-failing declared-but-unused report.
+ *
+ * Separated from the CLI block so the wording is testable without spawning the process, and so the
+ * failing arm below stays a single unbroken read.
+ *
+ * @param {Object[]} unusedDeclarations Rows from `lintOpenApiServiceParity`.
+ * @param {Object}   [io=console] Injectable sink for tests.
+ */
+export function reportUnusedDeclarations(unusedDeclarations, io = console) {
+    if (unusedDeclarations.length === 0) return;
+
+    io.warn(
+        `[lint-openapi-service-parity] ${unusedDeclarations.length} declared-but-unused parameter(s) ` +
+        `— NOT a failure:\n`
+    );
+
+    for (const row of unusedDeclarations) {
+        io.warn(`- ${row.operationId} declares \`${row.param}\` — read by none of: ${row.methods.join(', ')}`);
+    }
+
+    io.warn(
+        `\nEach of these is a contract an agent can send and the service will ignore. That is the ` +
+        `mirror of the failing direction and not its equal: nothing a caller supplies is destroyed, ` +
+        `so this reports rather than blocks. Most are declarations that outlived a refactor — remove ` +
+        `the parameter, or start reading it.\n`
+    );
+}
+
 if (import.meta.url === `file://${process.argv[1]}`) {
     const result = lintOpenApiServiceParity();
+
+    // Printed BEFORE the failing arm, so a run that exits 1 still surfaces both directions rather
+    // than hiding the advisory behind the abort.
+    reportUnusedDeclarations(result.unusedDeclarations);
 
     if (result.violations.length > 0) {
         console.error(`[lint-openapi-service-parity] FAILED — ${result.violations.length} consumed-but-undeclared parameter(s):\n`);
@@ -454,6 +568,7 @@ if (import.meta.url === `file://${process.argv[1]}`) {
 
     console.log(
         `[lint-openapi-service-parity] OK — ${result.servicesScanned} wrapped service(s), ` +
-        `${result.operationsMatched} operation-bound method(s), 0 consumed-but-undeclared parameter(s).`
+        `${result.operationsMatched} operation-bound method(s), 0 consumed-but-undeclared parameter(s), ` +
+        `${result.unusedDeclarations.length} declared-but-unused (advisory).`
     );
 }

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
         "ai:lint-identity-engine-coherence"    : "node ./ai/scripts/lint/lint-identity-engine-coherence.mjs",
         "ai:lint-identity-vocabulary"          : "node ./ai/scripts/lint/lint-identity-vocabulary.mjs",
         "ai:lint-mcp-test-locations"           : "node ./ai/scripts/lint/lint-mcp-test-locations.mjs",
+        "ai:lint-openapi-service-parity"       : "node ./ai/scripts/lint/lint-openapi-service-parity.mjs",
         "ai:lint-retry-bounds"                 : "node ./ai/scripts/lint/lint-retry-bounds.mjs",
         "ai:lint-skill-manifest"               : "node ./ai/scripts/lint/lint-skill-manifest.mjs",
         "ai:lint-tree-json"                    : "node ./ai/scripts/lint/lint-tree-json.mjs",
@@ -257,6 +258,12 @@
         "test/**/*.mjs": [
             "node ./buildScripts/util/check-aiconfig-test-mutation.mjs",
             "node ./buildScripts/util/check-derived-domain.mjs"
+        ],
+        "ai/{services,services.mjs}/**": [
+            "node ./ai/scripts/lint/lint-openapi-service-parity.mjs"
+        ],
+        "ai/mcp/server/**/openapi.yaml": [
+            "node ./ai/scripts/lint/lint-openapi-service-parity.mjs"
         ],
         "resources/content/archive/**/*.md": [
             "node ./buildScripts/util/check-content-logical-identity.mjs"

--- a/package.json
+++ b/package.json
@@ -262,6 +262,15 @@
         "ai/{services,services.mjs}/**": [
             "node ./ai/scripts/lint/lint-openapi-service-parity.mjs"
         ],
+        "ai/mcp/server/**/{toolService.mjs,*.mjs}": [
+            "node ./ai/scripts/lint/lint-openapi-service-parity.mjs"
+        ],
+        "ai/mcp/ToolService.mjs": [
+            "node ./ai/scripts/lint/lint-openapi-service-parity.mjs"
+        ],
+        "ai/scripts/{lint/lint-openapi-service-parity.mjs,diagnostics/mcpHandlerSignatureCensus.mjs}": [
+            "node ./ai/scripts/lint/lint-openapi-service-parity.mjs"
+        ],
         "ai/mcp/server/**/openapi.yaml": [
             "node ./ai/scripts/lint/lint-openapi-service-parity.mjs"
         ],

--- a/test/playwright/unit/ai/mcp/validation/OpenApiServiceParityEndToEnd.spec.mjs
+++ b/test/playwright/unit/ai/mcp/validation/OpenApiServiceParityEndToEnd.spec.mjs
@@ -1,0 +1,303 @@
+import {test, expect} from '@playwright/test';
+import fs             from 'node:fs';
+import os             from 'node:os';
+import path           from 'node:path';
+
+import {lintOpenApiServiceParity} from '../../../../../../ai/scripts/lint/lint-openapi-service-parity.mjs';
+
+/**
+ * End-to-end fixtures for the OpenAPI ↔ service parity lint: a synthetic repo root is built on
+ * disk, the real `lintOpenApiServiceParity` runs against it, and the assertion is on its verdict.
+ *
+ * **Why this file exists separately from the helper specs.** The sibling suite proves
+ * `consumedNames` and `declaredNames` behave on AST nodes handed to them directly. That is
+ * necessary and it is not sufficient: it cannot fail if the *lint* stops discovering services,
+ * stops resolving module paths, stops joining method names to operation ids, or stops reporting
+ * what it found. Every one of those is a silent-pass failure mode, and a helper-only suite would
+ * stay green through all of them.
+ *
+ * The fixtures are deliberately built from the outside in: `ai/services.mjs` with a `safeLoadYaml`
+ * + `makeSafe` pair, a spec under `ai/mcp/server/<id>/openapi.yaml`, and a service module under
+ * `ai/services/<id>/`. That is the real discovery contract, so a change to it fails here rather
+ * than silently narrowing what the gate covers.
+ *
+ * Every positive fixture is paired with a **negative control**. A fixture that only proves the
+ * lint fails on bad input cannot distinguish a working gate from one that fails on everything.
+ */
+
+let tmpRoot;
+
+test.beforeEach(() => {
+    tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), `parity-e2e-${process.pid}-`));
+});
+
+test.afterEach(() => {
+    if (tmpRoot && fs.existsSync(tmpRoot)) fs.rmSync(tmpRoot, {recursive: true, force: true});
+});
+
+/**
+ * Builds a synthetic repo root the lint can discover.
+ *
+ * @param {Object} options
+ * @param {String} options.serverId    Owning server directory name.
+ * @param {String} options.operationId The operation the method must join to.
+ * @param {Object} options.operation   The OpenAPI operation object (parameters / requestBody).
+ * @param {String} options.methodSrc   The service method source, e.g. `async doThing(options) {...}`.
+ * @param {Boolean} [options.exported=false] Emit `export const X = makeSafe(…)` instead of the bare
+ *     `const X = makeSafe(…)`. Defaults to the BARE form because that is what all 40 live bindings
+ *     use — a fixture built on the other shape would exercise a branch production never takes, and
+ *     prove the fixture rather than the gate.
+ * @returns {String} The fixture root path.
+ */
+function seedRoot({serverId, operationId, operation, methodSrc, exported = false}) {
+    const serviceDir = path.join(tmpRoot, 'ai', 'services', serverId),
+          serverDir  = path.join(tmpRoot, 'ai', 'mcp', 'server', serverId);
+
+    fs.mkdirSync(serviceDir, {recursive: true});
+    fs.mkdirSync(serverDir, {recursive: true});
+
+    // The discovery shape the lint actually parses: a `safeLoadYaml` binding whose first string
+    // literal is the spec path, and a `makeSafe(service, spec)` pair. Written as real source rather
+    // than mocked, so a change to `extractWrappedServices` is caught here.
+    fs.writeFileSync(path.join(tmpRoot, 'ai', 'services.mjs'), [
+        `import FixtureService from './services/${serverId}/FixtureService.mjs';`,
+        `const fixtureSpec = safeLoadYaml(path.join(__dirname, 'mcp/server/${serverId}/openapi.yaml'));`,
+        `${exported ? 'export ' : ''}const Fixture_Service = makeSafe(FixtureService, fixtureSpec);`,
+        exported ? '' : 'export {Fixture_Service};',
+        ''
+    ].join('\n'));
+
+    fs.writeFileSync(path.join(serviceDir, 'FixtureService.mjs'), [
+        'class FixtureService {',
+        `    ${methodSrc}`,
+        '}',
+        'export default FixtureService;',
+        ''
+    ].join('\n'));
+
+    fs.writeFileSync(path.join(serverDir, 'openapi.yaml'), JSON.stringify({
+        openapi: '3.0.0',
+        info   : {title: 'fixture', version: '1.0.0'},
+        paths  : {'/fixture': {post: {operationId, ...operation}}}
+    }, null, 2));
+
+    return tmpRoot;
+}
+
+/** A request body declaring the given property names. */
+const bodyWith = (...names) => ({
+    requestBody: {content: {'application/json': {schema: {
+        type      : 'object',
+        properties: Object.fromEntries(names.map(name => [name, {type: 'string'}]))
+    }}}}
+});
+
+test.describe('parity lint end-to-end — the FAILING direction', () => {
+    test('a dotted bag read of an undeclared key is reported as a violation', async () => {
+        const rootDir = seedRoot({
+            serverId   : 'fixture-server',
+            operationId: 'do_thing',
+            operation  : bodyWith('declaredOne'),
+            // Reads `secretKey`, which the spec does not declare — the exact production shape that
+            // shipped twice on `ingest_source_files`.
+            methodSrc  : 'async doThing(payload) { return payload.declaredOne + payload.secretKey }'
+        });
+
+        const result = lintOpenApiServiceParity({rootDir});
+
+        expect(result.servicesScanned, 'the fixture service must be DISCOVERED — a zero here means the lint scanned nothing and would pass on anything').toBe(1);
+        expect(result.operationsMatched, 'the method must JOIN to its operation via camelToSnake').toBe(1);
+        expect(result.violations).toHaveLength(1);
+        expect(result.violations[0].param).toBe('secretKey');
+        expect(result.violations[0].operationId).toBe('do_thing');
+    });
+
+    test('NEGATIVE CONTROL: declaring the same key makes the identical fixture clean', async () => {
+        // Byte-identical to the fixture above except that `secretKey` is declared. Without this the
+        // suite could not distinguish a working gate from one that reports a violation for every
+        // fixture it is handed.
+        const rootDir = seedRoot({
+            serverId   : 'fixture-server',
+            operationId: 'do_thing',
+            operation  : bodyWith('declaredOne', 'secretKey'),
+            methodSrc  : 'async doThing(payload) { return payload.declaredOne + payload.secretKey }'
+        });
+
+        const result = lintOpenApiServiceParity({rootDir});
+
+        expect(result.servicesScanned).toBe(1);
+        expect(result.operationsMatched).toBe(1);
+        expect(result.violations, 'a fully-declared contract must produce no violation').toHaveLength(0);
+    });
+
+    test('body destructuring is reached too — the form whose absence was a false green on real code', async () => {
+        // `PullRequestService#getPullRequestDiff` uses exactly this shape and the first walker
+        // reported ZERO consumed names for it while CI was green. Asserted end-to-end so the
+        // regression cannot come back through the lint even if the helper keeps passing.
+        const rootDir = seedRoot({
+            serverId   : 'fixture-server',
+            operationId: 'do_thing',
+            operation  : bodyWith('declaredOne'),
+            methodSrc  : 'async doThing(options) { const {declaredOne, undeclaredTwo} = options || {}; return declaredOne ?? undeclaredTwo }'
+        });
+
+        const result = lintOpenApiServiceParity({rootDir});
+
+        expect(result.violations.map(v => v.param)).toEqual(['undeclaredTwo']);
+    });
+
+    test('an EXPORTED makeSafe binding is discovered too — a form no live service uses yet', async () => {
+        // Every one of the 40 live bindings is a bare `const` with a separate export, so this shape
+        // is currently unreachable in production. It is covered because discovery that silently
+        // skipped a declaration form would drop a whole service from the gate and report the
+        // omission as a pass — the exact false-green class this lint exists to close, one layer
+        // below the parameters it checks.
+        //
+        // Found by writing this fixture in the wrong shape: the suite reported clean on a method
+        // that reads an undeclared key, and the only tell was that `servicesScanned` was 0.
+        const rootDir = seedRoot({
+            serverId   : 'fixture-server',
+            operationId: 'do_thing',
+            operation  : bodyWith('declaredOne'),
+            methodSrc  : 'async doThing(payload) { return payload.declaredOne + payload.secretKey }',
+            exported   : true
+        });
+
+        const result = lintOpenApiServiceParity({rootDir});
+
+        expect(result.servicesScanned, 'the exported form must not vanish from discovery').toBe(1);
+        expect(result.violations.map(v => v.param)).toEqual(['secretKey']);
+    });
+
+    test('a rest element suppresses the verdict rather than passing it', async () => {
+        // A rest element re-admits every key, so absence cannot be proven. The requirement is that
+        // the lint stays SILENT, not that it reports clean for a good reason — the operation is
+        // still matched, it simply yields no claim.
+        const rootDir = seedRoot({
+            serverId   : 'fixture-server',
+            operationId: 'do_thing',
+            operation  : bodyWith('declaredOne'),
+            methodSrc  : 'async doThing({declaredOne, ...rest}) { return declaredOne ?? rest }'
+        });
+
+        const result = lintOpenApiServiceParity({rootDir});
+
+        expect(result.operationsMatched, 'the operation is matched — the suppression is about provability, not discovery').toBe(1);
+        expect(result.violations).toHaveLength(0);
+    });
+});
+
+test.describe('parity lint end-to-end — the ADVISORY direction', () => {
+    test('a declared key nothing reads is reported as advisory, and does NOT become a violation', async () => {
+        // The emission path for the non-failing direction. Verified end-to-end because the live tree
+        // currently reports ZERO advisory rows: without this fixture a permanently-silent advisory
+        // would be indistinguishable from a working one.
+        const rootDir = seedRoot({
+            serverId   : 'fixture-server',
+            operationId: 'do_thing',
+            operation  : bodyWith('usedOne', 'strandedTwo'),
+            methodSrc  : 'async doThing({usedOne}) { return usedOne }'
+        });
+
+        const result = lintOpenApiServiceParity({rootDir});
+
+        expect(result.unusedDeclarations.map(row => row.param)).toEqual(['strandedTwo']);
+        expect(result.violations, 'the advisory direction must never escalate into the failing one').toHaveLength(0);
+    });
+
+    test('a FORWARDED bag yields no advisory — a lower bound cannot support an absence claim', async () => {
+        // `consumedNames` is a lower bound on reads by construction, which is what makes it sound
+        // for the failing direction and useless for its complement. Here the bag travels into a
+        // helper, so `strandedTwo` may well be read where no AST walk can see it. Claiming it unused
+        // would be a fabricated absence — the defect that produced 14 false findings before the
+        // completeness gate existed.
+        const rootDir = seedRoot({
+            serverId   : 'fixture-server',
+            operationId: 'do_thing',
+            operation  : bodyWith('usedOne', 'strandedTwo'),
+            methodSrc  : 'async doThing(payload) { return this.helper(payload) + payload.usedOne }'
+        });
+
+        const result = lintOpenApiServiceParity({rootDir});
+
+        expect(result.unusedDeclarations, 'a forwarded bag must silence the advisory entirely').toHaveLength(0);
+        // And the failing direction is unaffected: `usedOne` is declared, so still no violation.
+        expect(result.violations).toHaveLength(0);
+    });
+
+    test('the advisory is decided per OPERATION, not per method — a sibling read counts', async () => {
+        // `get_conversation` is served by three services, each destructuring only its own keys.
+        // Judged per method, every sibling's parameters looked dead: this is that shape, minimised.
+        // `secondOnly` is read by the second method alone, so nothing here is unused.
+        const serviceDir = path.join(tmpRoot, 'ai', 'services', 'fixture-server'),
+              serverDir  = path.join(tmpRoot, 'ai', 'mcp', 'server', 'fixture-server');
+
+        fs.mkdirSync(serviceDir, {recursive: true});
+        fs.mkdirSync(serverDir, {recursive: true});
+
+        fs.writeFileSync(path.join(tmpRoot, 'ai', 'services.mjs'), [
+            `import AlphaService from './services/fixture-server/AlphaService.mjs';`,
+            `import BetaService  from './services/fixture-server/BetaService.mjs';`,
+            `const fixtureSpec = safeLoadYaml(path.join(__dirname, 'mcp/server/fixture-server/openapi.yaml'));`,
+            `const Alpha = makeSafe(AlphaService, fixtureSpec);`,
+            `const Beta  = makeSafe(BetaService,  fixtureSpec);`,
+            `export {Alpha, Beta};`,
+            ''
+        ].join('\n'));
+
+        fs.writeFileSync(path.join(serviceDir, 'AlphaService.mjs'),
+            'class AlphaService {\n    async doThing({firstOnly}) { return firstOnly }\n}\nexport default AlphaService;\n');
+        fs.writeFileSync(path.join(serviceDir, 'BetaService.mjs'),
+            'class BetaService {\n    async doThing({secondOnly}) { return secondOnly }\n}\nexport default BetaService;\n');
+
+        fs.writeFileSync(path.join(serverDir, 'openapi.yaml'), JSON.stringify({
+            openapi: '3.0.0',
+            info   : {title: 'fixture', version: '1.0.0'},
+            paths  : {'/fixture': {post: {operationId: 'do_thing', ...bodyWith('firstOnly', 'secondOnly')}}}
+        }, null, 2));
+
+        const result = lintOpenApiServiceParity({rootDir: tmpRoot});
+
+        expect(result.operationsMatched, 'both methods bind to the one operation').toBe(2);
+        expect(
+            result.unusedDeclarations,
+            'each key is read by exactly one implementation, so the UNION covers both and nothing is unused'
+        ).toHaveLength(0);
+    });
+
+    test('POSITIVE CONTROL for the union: a key NO sibling reads is still reported', async () => {
+        // The control for the test above. Without it, "per-operation union" would be
+        // indistinguishable from "advisory permanently disabled whenever two methods share an id".
+        const serviceDir = path.join(tmpRoot, 'ai', 'services', 'fixture-server'),
+              serverDir  = path.join(tmpRoot, 'ai', 'mcp', 'server', 'fixture-server');
+
+        fs.mkdirSync(serviceDir, {recursive: true});
+        fs.mkdirSync(serverDir, {recursive: true});
+
+        fs.writeFileSync(path.join(tmpRoot, 'ai', 'services.mjs'), [
+            `import AlphaService from './services/fixture-server/AlphaService.mjs';`,
+            `import BetaService  from './services/fixture-server/BetaService.mjs';`,
+            `const fixtureSpec = safeLoadYaml(path.join(__dirname, 'mcp/server/fixture-server/openapi.yaml'));`,
+            `const Alpha = makeSafe(AlphaService, fixtureSpec);`,
+            `const Beta  = makeSafe(BetaService,  fixtureSpec);`,
+            `export {Alpha, Beta};`,
+            ''
+        ].join('\n'));
+
+        fs.writeFileSync(path.join(serviceDir, 'AlphaService.mjs'),
+            'class AlphaService {\n    async doThing({firstOnly}) { return firstOnly }\n}\nexport default AlphaService;\n');
+        fs.writeFileSync(path.join(serviceDir, 'BetaService.mjs'),
+            'class BetaService {\n    async doThing({secondOnly}) { return secondOnly }\n}\nexport default BetaService;\n');
+
+        fs.writeFileSync(path.join(serverDir, 'openapi.yaml'), JSON.stringify({
+            openapi: '3.0.0',
+            info   : {title: 'fixture', version: '1.0.0'},
+            paths  : {'/fixture': {post: {operationId: 'do_thing', ...bodyWith('firstOnly', 'secondOnly', 'readByNobody')}}}
+        }, null, 2));
+
+        const result = lintOpenApiServiceParity({rootDir: tmpRoot});
+
+        expect(result.unusedDeclarations.map(row => row.param)).toEqual(['readByNobody']);
+        expect(result.unusedDeclarations[0].methods, 'the row names every contributor, so a reader can see the denominator').toHaveLength(2);
+    });
+});

--- a/test/playwright/unit/ai/mcp/validation/OpenApiServiceParityEndToEnd.spec.mjs
+++ b/test/playwright/unit/ai/mcp/validation/OpenApiServiceParityEndToEnd.spec.mjs
@@ -402,3 +402,40 @@ test.describe('parity lint end-to-end — the TOOLSERVICE dispatch join', () => 
         expect(result.violations).toHaveLength(0);
     });
 });
+
+test.describe('parity lint end-to-end — undecidable reads must silence the advisory', () => {
+    test('a DYNAMIC computed key clears completeness, so no absence is claimed', async () => {
+        // `payload[someVar]` is a read whose NAME cannot be determined. The module's blind-spot list
+        // already named dynamic access — but named it for the FAILING direction, where it is harmless
+        // because an unseen read merely keeps a lower bound lower. In the advisory direction the claim
+        // is the complement, so an unnameable read must clear `complete` rather than simply be absent
+        // from `consumed`. Before this, the shape reported `complete: true` with `consumed: []` and
+        // every declared parameter would have been called unused.
+        const rootDir = seedRoot({
+            serverId   : 'fixture-server',
+            operationId: 'do_thing',
+            operation  : bodyWith('alpha', 'beta'),
+            methodSrc  : 'async doThing(payload, key) { return payload[key] }'
+        });
+
+        const result = lintOpenApiServiceParity({rootDir});
+
+        expect(result.unusedDeclarations, 'an unnameable read must silence the advisory entirely').toHaveLength(0);
+        expect(result.violations, 'and it must not fabricate a violation either').toHaveLength(0);
+    });
+
+    test('CONTROL: a LITERAL computed key stays decidable and the advisory still speaks', async () => {
+        // The control that keeps the fix above from degenerating into "any computed access disables
+        // the advisory". `payload['alpha']` is a decidable read, so `beta` is still provably unused.
+        const rootDir = seedRoot({
+            serverId   : 'fixture-server',
+            operationId: 'do_thing',
+            operation  : bodyWith('alpha', 'beta'),
+            methodSrc  : "async doThing(payload) { return payload['alpha'] }"
+        });
+
+        const result = lintOpenApiServiceParity({rootDir});
+
+        expect(result.unusedDeclarations.map(row => row.param)).toEqual(['beta']);
+    });
+});

--- a/test/playwright/unit/ai/mcp/validation/OpenApiServiceParityEndToEnd.spec.mjs
+++ b/test/playwright/unit/ai/mcp/validation/OpenApiServiceParityEndToEnd.spec.mjs
@@ -3,7 +3,7 @@ import fs             from 'node:fs';
 import os             from 'node:os';
 import path           from 'node:path';
 
-import {lintOpenApiServiceParity, lintToolServiceParity} from '../../../../../../ai/scripts/lint/lint-openapi-service-parity.mjs';
+import {describeViolation, lintOpenApiServiceParity, lintParity, lintToolServiceParity} from '../../../../../../ai/scripts/lint/lint-openapi-service-parity.mjs';
 
 /**
  * End-to-end fixtures for the OpenAPI ↔ service parity lint: a synthetic repo root is built on
@@ -437,5 +437,90 @@ test.describe('parity lint end-to-end — undecidable reads must silence the adv
         const result = lintOpenApiServiceParity({rootDir});
 
         expect(result.unusedDeclarations.map(row => row.param)).toEqual(['beta']);
+    });
+});
+
+test.describe('parity lint — the COMPOSITE seam that merges both joins', () => {
+    /**
+     * Seeds a root carrying BOTH a `makeSafe` service defect and a `serviceMapping` handler defect,
+     * so the composite's merge is what the assertion depends on rather than either child.
+     * @returns {String} fixture root
+     */
+    function seedBothDefects() {
+        const serverDir  = path.join(tmpRoot, 'ai', 'mcp', 'server', 'knowledge-base'),
+              serviceDir = path.join(tmpRoot, 'ai', 'services', 'knowledge-base');
+
+        fs.mkdirSync(serverDir, {recursive: true});
+        fs.mkdirSync(serviceDir, {recursive: true});
+
+        // services.mjs join defect: a wrapped method reading an undeclared key.
+        fs.writeFileSync(path.join(tmpRoot, 'ai', 'services.mjs'), [
+            `import FixtureService from './services/knowledge-base/FixtureService.mjs';`,
+            `const fixtureSpec = safeLoadYaml(path.join(__dirname, 'mcp/server/knowledge-base/openapi.yaml'));`,
+            `const Fixture_Service = makeSafe(FixtureService, fixtureSpec);`,
+            `export {Fixture_Service};`,
+            ''
+        ].join('\n'));
+        fs.writeFileSync(path.join(serviceDir, 'FixtureService.mjs'),
+            'class FixtureService {\n    async doThing(p) { return p.serviceOnlyLeak }\n}\nexport default FixtureService;\n');
+
+        // ToolService join defect: an object-dispatch handler reading a different undeclared key.
+        fs.writeFileSync(path.join(serverDir, 'toolService.mjs'), [
+            'const serviceMapping = {',
+            '    do_other: args => run(args.dispatchOnlyLeak)',
+            '};',
+            'export {serviceMapping};',
+            ''
+        ].join('\n'));
+
+        fs.writeFileSync(path.join(serverDir, 'openapi.yaml'), JSON.stringify({
+            openapi: '3.0.0',
+            info   : {title: 'fixture', version: '1.0.0'},
+            paths  : {
+                '/a': {post: {operationId: 'do_thing', ...bodyWith('declared')}},
+                '/b': {post: {operationId: 'do_other', 'x-pass-as-object': true, ...bodyWith('declared')}}
+            }
+        }, null, 2));
+
+        return tmpRoot;
+    }
+
+    test('the composite merges BOTH joins into one fatal result', async () => {
+        // The witness for the seam itself. Both child analyses are covered above; the step that
+        // merges them was previously unreachable, living inside the CLI's `import.meta.url` guard.
+        // Deleting the ToolService append would have left every child test green while the gate
+        // silently stopped failing on half its surface — a false green BETWEEN two tested parts,
+        // which is the one place per-part coverage cannot look.
+        const result = lintParity({rootDir: seedBothDefects()});
+        const params = result.violations.map(v => v.param).sort();
+
+        expect(params, 'a violation from EACH join must reach the fatal result').toEqual(['dispatchOnlyLeak', 'serviceOnlyLeak']);
+    });
+
+    test('the composite preserves advisory, unresolved and coverage counts through the merge', async () => {
+        // Recomputing these in the CLI instead of carrying them would let the printed summary drift
+        // from the verdict a test can assert on. `do_thing` declares `declared` and the method never
+        // reads it, so the advisory is non-empty and proves the field survives rather than being
+        // dropped to an empty array.
+        const result = lintParity({rootDir: seedBothDefects()});
+
+        expect(result.unusedDeclarations.length, 'advisory rows must survive the merge').toBeGreaterThan(0);
+        expect(result.operationsMatched, 'services.mjs coverage count preserved').toBe(1);
+        expect(result.operationsChecked, 'ToolService coverage count preserved').toBe(1);
+        expect(Array.isArray(result.unresolved), 'unresolved must be carried, not dropped').toBe(true);
+    });
+
+    test('a ToolService finding renders with its OWN coordinates, not undefined', async () => {
+        // The two joins describe a handler differently and neither is a superset: `services.mjs`
+        // knows module + method, the dispatch join knows serverId + via. Rendering both through the
+        // first shape printed `undefined → undefined()` for every ToolService row — a finding a
+        // reader cannot act on.
+        const result = lintParity({rootDir: seedBothDefects()}),
+              row    = result.violations.find(v => v.param === 'dispatchOnlyLeak'),
+              lines  = describeViolation(row).join('\n');
+
+        expect(lines).not.toContain('undefined');
+        expect(lines).toContain('knowledge-base');
+        expect(lines, 'the resolution path is what makes a dispatch finding actionable').toContain('serviceMapping');
     });
 });

--- a/test/playwright/unit/ai/mcp/validation/OpenApiServiceParityEndToEnd.spec.mjs
+++ b/test/playwright/unit/ai/mcp/validation/OpenApiServiceParityEndToEnd.spec.mjs
@@ -3,7 +3,7 @@ import fs             from 'node:fs';
 import os             from 'node:os';
 import path           from 'node:path';
 
-import {lintOpenApiServiceParity} from '../../../../../../ai/scripts/lint/lint-openapi-service-parity.mjs';
+import {lintOpenApiServiceParity, lintToolServiceParity} from '../../../../../../ai/scripts/lint/lint-openapi-service-parity.mjs';
 
 /**
  * End-to-end fixtures for the OpenAPI ↔ service parity lint: a synthetic repo root is built on
@@ -299,5 +299,106 @@ test.describe('parity lint end-to-end — the ADVISORY direction', () => {
 
         expect(result.unusedDeclarations.map(row => row.param)).toEqual(['readByNobody']);
         expect(result.unusedDeclarations[0].methods, 'the row names every contributor, so a reader can see the denominator').toHaveLength(2);
+    });
+});
+
+test.describe('parity lint end-to-end — the TOOLSERVICE dispatch join', () => {
+    /**
+     * Seeds a server whose `toolService.mjs` carries a `serviceMapping` binding, which is the join
+     * this direction walks — distinct from the `ai/services.mjs` `makeSafe` table above.
+     *
+     * @param {Object}  options
+     * @param {Object}  options.operation      OpenAPI operation object.
+     * @param {String}  options.handlerSrc     Handler source bound in the mapping.
+     * @param {Boolean} [options.passAsObject] Emit `x-pass-as-object: true`.
+     * @returns {String} fixture root
+     */
+    function seedToolService({operation, handlerSrc, passAsObject = true}) {
+        // The census's SERVERS list is a fixed set of repo-relative paths, so the fixture must sit at
+        // the coordinates of a real server id for the join to discover it.
+        const serverDir = path.join(tmpRoot, 'ai', 'mcp', 'server', 'knowledge-base');
+
+        fs.mkdirSync(serverDir, {recursive: true});
+        fs.mkdirSync(path.join(tmpRoot, 'ai'), {recursive: true});
+        fs.writeFileSync(path.join(tmpRoot, 'ai', 'services.mjs'), '// no makeSafe bindings in this fixture\n');
+
+        fs.writeFileSync(path.join(serverDir, 'toolService.mjs'), [
+            `const serviceMapping = {`,
+            `    do_thing: ${handlerSrc}`,
+            `};`,
+            `export {serviceMapping};`,
+            ''
+        ].join('\n'));
+
+        fs.writeFileSync(path.join(serverDir, 'openapi.yaml'), JSON.stringify({
+            openapi: '3.0.0',
+            info   : {title: 'fixture', version: '1.0.0'},
+            paths  : {'/fixture': {post: {
+                operationId: 'do_thing',
+                ...(passAsObject ? {'x-pass-as-object': true} : {}),
+                ...operation
+            }}}
+        }, null, 2));
+
+        return tmpRoot;
+    }
+
+    test('an inline object-dispatch handler reading an undeclared key is reported', async () => {
+        const rootDir = seedToolService({
+            operation : bodyWith('declaredOne'),
+            handlerSrc: 'args => svc.run({...args, extra: args.undeclaredTwo})'
+        });
+
+        const result = lintToolServiceParity({rootDir});
+
+        expect(result.operationsChecked, 'the handler must be resolved and checked').toBe(1);
+        expect(result.violations.map(v => v.param)).toEqual(['undeclaredTwo']);
+    });
+
+    test('NEGATIVE CONTROL: the identical handler is clean once the key is declared', async () => {
+        const rootDir = seedToolService({
+            operation : bodyWith('declaredOne', 'undeclaredTwo'),
+            handlerSrc: 'args => svc.run({...args, extra: args.undeclaredTwo})'
+        });
+
+        const result = lintToolServiceParity({rootDir});
+
+        expect(result.operationsChecked).toBe(1);
+        expect(result.violations).toHaveLength(0);
+    });
+
+    test('a POSITIONAL handler is skipped and counted — the bag analysis would fabricate findings', async () => {
+        // Without `x-pass-as-object`, arguments arrive positionally, so the first parameter is
+        // `argNames[0]` rather than the args bag. Treating it as a bag would report `prNumber.detail`
+        // as a consumed PARAMETER named `detail` — an invented violation. The requirement is that the
+        // operation is skipped AND counted, so the omission is visible rather than silent.
+        const rootDir = seedToolService({
+            operation   : bodyWith('prNumber'),
+            handlerSrc  : 'prNumber => svc.run(prNumber.detail)',
+            passAsObject: false
+        });
+
+        const result = lintToolServiceParity({rootDir});
+
+        expect(result.violations, 'no fabricated finding from positional dispatch').toHaveLength(0);
+        expect(result.operationsChecked).toBe(0);
+        expect(result.positionalSkipped, 'skipped operations are COUNTED, never silently dropped').toBe(1);
+    });
+
+    test('an UNRESOLVABLE handler is reported, not passed over', async () => {
+        // A bare identifier with no local declaration and no import cannot be located. Silence here
+        // would be indistinguishable from "checked and clean" — the false-green shape this whole
+        // gate exists to remove, applied to its own coverage.
+        const rootDir = seedToolService({
+            operation : bodyWith('declaredOne'),
+            handlerSrc: 'handlerDefinedNowhere'
+        });
+
+        const result = lintToolServiceParity({rootDir});
+
+        expect(result.operationsChecked).toBe(0);
+        expect(result.unresolved).toHaveLength(1);
+        expect(result.unresolved[0].operationId).toBe('do_thing');
+        expect(result.violations).toHaveLength(0);
     });
 });

--- a/test/playwright/unit/ai/mcp/validation/OpenApiServiceParityGate.spec.mjs
+++ b/test/playwright/unit/ai/mcp/validation/OpenApiServiceParityGate.spec.mjs
@@ -1,0 +1,123 @@
+import {test, expect} from '@playwright/test';
+import * as acorn     from 'acorn';
+
+import {
+    PARITY_BASELINE,
+    camelToSnake,
+    consumedNames,
+    declaredNames,
+    lintOpenApiServiceParity
+} from '../../../../../../ai/scripts/lint/lint-openapi-service-parity.mjs';
+
+/**
+ * @summary The gate for the silent-strip bug class: a service method that CONSUMES a parameter its
+ * OpenAPI operation does not DECLARE gets that parameter stripped by the Zod facade in
+ * `ai/services.mjs`, and reads `undefined` in production while every direct-construction unit test
+ * passes.
+ *
+ * The detection mechanism is the thing most worth pinning. `ingest_source_files` — the operation that
+ * motivated this guard — is `ingestSourceFiles(payload = {})`: a bag that destructures nothing, so
+ * its signature carries no parameter names at all. A signature-based checker finds nothing there.
+ * Consumption (`payload.X` member reads) is the signal, and the bag-style test below is the negative
+ * control for the mechanism itself rather than for one operation.
+ */
+test.describe('openapi ↔ service parity — a consumed parameter must be declared (#16585)', () => {
+
+    const fnFrom = source => acorn.parse(source, {ecmaVersion: 'latest', sourceType: 'module'})
+        .body[0].declarations[0].init;
+
+    test('a BAG-style method with no destructured params still reveals its reads', () => {
+        // The negative control for the detection mechanism. This shape is exactly
+        // `ingestSourceFiles(payload = {})`, and it is the shape a signature-only checker misses.
+        const fn = fnFrom(`const f = async (payload = {}) => {
+            const a = payload.materializationAttempt;
+            return {viaMcp: payload.viaMcp !== false, a};
+        }`);
+
+        const {consumed, bagParam, destructured} = consumedNames(fn);
+
+        expect(destructured, 'this shape destructures nothing — the point of the test').toBe(false);
+        expect(bagParam).toBe('payload');
+        expect([...consumed].sort()).toEqual(['materializationAttempt', 'viaMcp']);
+    });
+
+    test('a destructured method reveals its keys, and a rest element disables the claim', () => {
+        const destructuredFn = fnFrom(`const f = async ({query, limit = 25, includeMetadata = false}) => query`);
+
+        expect([...consumedNames(destructuredFn).consumed].sort()).toEqual(['includeMetadata', 'limit', 'query']);
+
+        // `...rest` re-admits every key, so no name can be proven absent. Reporting nothing here is
+        // correct; reporting a violation would be a false positive, and silently treating it as
+        // "no reads" would be a false green — hence the explicit flag.
+        const restFn = fnFrom(`const f = async ({query, ...rest}) => query`);
+
+        expect(consumedNames(restFn).rest, 'a rest element must disable the absence claim').toBe(true);
+    });
+
+    test('member reads on something OTHER than the bag are not attributed to it', () => {
+        // Without this, any `foo.bar` in the body would be read as a consumed parameter and the
+        // checker would drown in false positives on its first real service.
+        const fn = fnFrom(`const f = async (payload = {}) => {
+            const other = {nope: 1};
+            return other.nope + payload.real;
+        }`);
+
+        expect([...consumedNames(fn).consumed]).toEqual(['real']);
+    });
+
+    test('declaredNames unions parameters with request-body properties and resolves $ref', () => {
+        const doc = {
+            components: {schemas: {Body: {properties: {fromBody: {type: 'string'}}}}}
+        };
+        const operation = {
+            parameters : [{name: 'fromParam'}],
+            requestBody: {content: {'application/json': {schema: {$ref: '#/components/schemas/Body'}}}}
+        };
+
+        // A guard that stopped at the `$ref` would report a declared param as missing — the runtime
+        // schema resolves it, so the guard must too.
+        expect([...declaredNames(doc, operation)].sort()).toEqual(['fromBody', 'fromParam']);
+    });
+
+    test('the method→operationId join mirrors the runtime transform', () => {
+        expect(camelToSnake('ingestSourceFiles')).toBe('ingest_source_files');
+        expect(camelToSnake('whoIsOnline')).toBe('who_is_online');
+    });
+
+    test('THE GATE: the live tree has no unbaselined consumed-but-undeclared parameter', () => {
+        const result = lintOpenApiServiceParity();
+
+        // Positive control FIRST. A checker that resolved zero methods would report zero violations
+        // and look identical to a clean tree — the green has to prove it measured something.
+        expect(result.servicesScanned, 'zero wrapped services means the resolver broke, not that the tree is clean').toBeGreaterThan(30);
+        expect(result.operationsMatched, 'zero operation-bound methods means nothing was actually compared').toBeGreaterThan(100);
+
+        const formatted = result.violations.map(v => `${v.operationId} reads \`${v.param}\` (${v.module} → ${v.method})`);
+
+        expect(formatted, formatted.join('\n')).toEqual([]);
+    });
+
+    test('every baseline row carries a stated reason, so no suppression is silent', () => {
+        const rows = Object.entries(PARITY_BASELINE);
+
+        expect(rows.length, 'an empty baseline would make this vacuous').toBeGreaterThan(0);
+
+        for (const [key, reason] of rows) {
+            expect(typeof reason, `${key} must carry a reason string`).toBe('string');
+            expect(reason.length, `${key}'s reason is too thin to audit`).toBeGreaterThan(40);
+        }
+
+        // The one permanent row, pinned by content: `now` is an injected clock, and a future sweep
+        // "helpfully" declaring it would let a caller falsify peer liveness. The rationale has to
+        // survive in the file, not only in the ticket that decided it.
+        expect(PARITY_BASELINE['who_is_online.now']).toMatch(/clock|liveness/i);
+    });
+
+    test('the baseline suppresses by exact operation+param, never by param name alone', () => {
+        // `viaMcp` is baselined for `manage_knowledge_base`. If suppression keyed on the bare param
+        // name, the same defect on a DIFFERENT operation would be silently absorbed — which is how a
+        // recurring parameter (this one has three live instances) stops being visible.
+        expect(PARITY_BASELINE['manage_knowledge_base.viaMcp']).toBeTruthy();
+        expect(PARITY_BASELINE['viaMcp'], 'a bare param key would suppress across operations').toBeUndefined();
+    });
+});

--- a/test/playwright/unit/ai/mcp/validation/OpenApiServiceParityGate.spec.mjs
+++ b/test/playwright/unit/ai/mcp/validation/OpenApiServiceParityGate.spec.mjs
@@ -9,8 +9,10 @@ const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../
 import {
     PARITY_BASELINE,
     camelToSnake,
+    collectMethods,
     consumedNames,
     declaredNames,
+    extractWrappedServices,
     lintOpenApiServiceParity
 } from '../../../../../../ai/scripts/lint/lint-openapi-service-parity.mjs';
 
@@ -125,16 +127,41 @@ test.describe('openapi ↔ service parity — a consumed parameter must be decla
         // eslint-disable-next-line no-new-func
         const runtimeCamelToSnake = new Function('str', match[1]);
 
-        // Equality across every method name the wrapped services actually expose, plus edge shapes.
-        // A corpus drawn from reality, so a divergence on any real method fails here rather than
-        // waiting for a literal to be added to a list.
-        const corpus = [
-            'ingestSourceFiles', 'whoIsOnline', 'getPullRequestDiff', 'manageKnowledgeBase',
-            'queryDocuments', 'getContextFrontier', 'healthcheck', 'getMcpToolHandbook',
-            'a', 'ABC', 'alreadysnake', 'endsWithCapitalX'
-        ];
+        // ── The corpus is now ACTUALLY drawn from reality ────────────────────────────────────────
+        //
+        // This block previously held a hardcoded twelve-name array under a comment claiming "a corpus
+        // drawn from reality, so a divergence on any real method fails here rather than waiting for a
+        // literal to be added to a list." The prose asserted a property the code did not have: a
+        // divergence on the 400-odd method names NOT in that list passed silently, and the comment
+        // made it worse than a plainly-fixed list would have been by telling a reader it was derived.
+        // @neo-gpt flagged it as a still-fixed corpus and was right.
+        //
+        // Every method name on every wrapped service, harvested the same way the lint harvests them,
+        // so the corpus grows and shrinks with the tree instead of with someone remembering to edit an
+        // array. A new service method is covered the moment it exists.
+        const realNames = new Set();
 
-        for (const name of corpus) {
+        for (const service of extractWrappedServices(repoRoot)) {
+            if (!fs.existsSync(service.modulePath)) continue;
+
+            for (const methodName of collectMethods(
+                acorn.parse(fs.readFileSync(service.modulePath, 'utf8'), {ecmaVersion: 'latest', sourceType: 'module'})
+            ).keys()) {
+                realNames.add(methodName);
+            }
+        }
+
+        // A derived corpus can silently become empty — the exact false-green this test exists to
+        // prevent, one level up. Asserted against a floor well below the ~400 observed, so an ordinary
+        // refactor does not trip it but a broken harvest does.
+        expect(realNames.size, 'the derived corpus must be non-trivial, or this guard proves nothing').toBeGreaterThan(100);
+
+        // Synthetic EDGE shapes kept deliberately and labelled as synthetic: single char, all-caps,
+        // already-snake, trailing capital. These are shapes the live tree may not contain, and their
+        // absence from it is not evidence they transform correctly.
+        const edgeShapes = ['a', 'ABC', 'alreadysnake', 'endsWithCapitalX', 'aB', 'ABc'];
+
+        for (const name of [...realNames, ...edgeShapes]) {
             expect(camelToSnake(name), `divergence on ${name}`).toBe(runtimeCamelToSnake(name));
         }
 

--- a/test/playwright/unit/ai/mcp/validation/OpenApiServiceParityGate.spec.mjs
+++ b/test/playwright/unit/ai/mcp/validation/OpenApiServiceParityGate.spec.mjs
@@ -1,5 +1,10 @@
-import {test, expect} from '@playwright/test';
-import * as acorn     from 'acorn';
+import {test, expect}  from '@playwright/test';
+import * as acorn      from 'acorn';
+import fs              from 'node:fs';
+import path            from 'node:path';
+import {fileURLToPath} from 'node:url';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../../../../..');
 
 import {
     PARITY_BASELINE,
@@ -41,6 +46,34 @@ test.describe('openapi ↔ service parity — a consumed parameter must be decla
         expect([...consumed].sort()).toEqual(['materializationAttempt', 'viaMcp']);
     });
 
+    test('BODY destructuring is consumption — the shape that made the first version a false green', () => {
+        // @neo-gpt's exact-head falsification. `PullRequestService#getPullRequestDiff(options)` does
+        // `const {pr_number, file, sha, files_only} = options || {}` and the first walker returned
+        // ZERO consumed names for it — a real wrapped method consuming four parameters, invisible
+        // while CI was fully green. Only parameter-position destructuring and dotted reads were seen.
+        const viaOr      = fnFrom(`const f = async (options) => { const {pr_number, file} = options || {}; return pr_number + file; }`),
+              viaBare    = fnFrom(`const f = async (options) => { const {sha} = options; return sha; }`),
+              viaNullish = fnFrom(`const f = async (options) => { const {files_only} = options ?? {}; return files_only; }`);
+
+        expect([...consumedNames(viaOr).consumed].sort()).toEqual(['file', 'pr_number']);
+        expect([...consumedNames(viaBare).consumed]).toEqual(['sha']);
+        expect([...consumedNames(viaNullish).consumed]).toEqual(['files_only']);
+
+        // A rest element in a BODY destructure re-admits every key, exactly as in parameter position.
+        expect(consumedNames(fnFrom(`const f = async (o) => { const {a, ...rest} = o || {}; return rest; }`)).rest).toBe(true);
+    });
+
+    test('a LITERAL computed read is consumption — decidable, and previously hidden behind "dynamic access"', () => {
+        // The blind-spot list named "dynamic access" without separating a string literal from a
+        // variable key, so a fully decidable form sat behind an honest-sounding caveat.
+        const literal = fnFrom(`const f = async (payload = {}) => payload['file']`),
+              dynamic = fnFrom(`const f = async (payload = {}) => { const k = 'x'; return payload[k]; }`);
+
+        expect([...consumedNames(literal).consumed]).toEqual(['file']);
+        // Still undecidable, and still unreported — the caveat is real, just narrower than claimed.
+        expect([...consumedNames(dynamic).consumed], 'a variable key stays undecidable').toEqual([]);
+    });
+
     test('a destructured method reveals its keys, and a rest element disables the claim', () => {
         const destructuredFn = fnFrom(`const f = async ({query, limit = 25, includeMetadata = false}) => query`);
 
@@ -79,9 +112,34 @@ test.describe('openapi ↔ service parity — a consumed parameter must be decla
         expect([...declaredNames(doc, operation)].sort()).toEqual(['fromBody', 'fromParam']);
     });
 
-    test('the method→operationId join mirrors the runtime transform', () => {
+    test('the method→operationId join is DERIVED from the runtime authority, not restated', () => {
+        // Two copied literals is what this asserted first, and @neo-gpt was right that it proves
+        // nothing about agreement: both sides could drift together or the mirror could diverge on any
+        // input not literally listed. `services.mjs#camelToSnake` is module-private and importing that
+        // module boots the whole SDK, so the authority is read from its SOURCE and executed.
+        const source = fs.readFileSync(path.join(repoRoot, 'ai/services.mjs'), 'utf8'),
+              match  = source.match(/function camelToSnake\(str\)\s*\{([\s\S]*?)\n\}/);
+
+        expect(match, 'the runtime transform must be locatable, or this guard is vacuous').toBeTruthy();
+
+        // eslint-disable-next-line no-new-func
+        const runtimeCamelToSnake = new Function('str', match[1]);
+
+        // Equality across every method name the wrapped services actually expose, plus edge shapes.
+        // A corpus drawn from reality, so a divergence on any real method fails here rather than
+        // waiting for a literal to be added to a list.
+        const corpus = [
+            'ingestSourceFiles', 'whoIsOnline', 'getPullRequestDiff', 'manageKnowledgeBase',
+            'queryDocuments', 'getContextFrontier', 'healthcheck', 'getMcpToolHandbook',
+            'a', 'ABC', 'alreadysnake', 'endsWithCapitalX'
+        ];
+
+        for (const name of corpus) {
+            expect(camelToSnake(name), `divergence on ${name}`).toBe(runtimeCamelToSnake(name));
+        }
+
+        // And the anchor value, so a mirror that agreed with a BROKEN authority still fails.
         expect(camelToSnake('ingestSourceFiles')).toBe('ingest_source_files');
-        expect(camelToSnake('whoIsOnline')).toBe('who_is_online');
     });
 
     test('THE GATE: the live tree has no unbaselined consumed-but-undeclared parameter', () => {
@@ -110,14 +168,23 @@ test.describe('openapi ↔ service parity — a consumed parameter must be decla
         // The one permanent row, pinned by content: `now` is an injected clock, and a future sweep
         // "helpfully" declaring it would let a caller falsify peer liveness. The rationale has to
         // survive in the file, not only in the ticket that decided it.
-        expect(PARITY_BASELINE['who_is_online.now']).toMatch(/clock|liveness/i);
+        expect(PARITY_BASELINE['memory-core.who_is_online.now']).toMatch(/clock|liveness/i);
     });
 
-    test('the baseline suppresses by exact operation+param, never by param name alone', () => {
-        // `viaMcp` is baselined for `manage_knowledge_base`. If suppression keyed on the bare param
-        // name, the same defect on a DIFFERENT operation would be silently absorbed — which is how a
-        // recurring parameter (this one has three live instances) stops being visible.
-        expect(PARITY_BASELINE['manage_knowledge_base.viaMcp']).toBeTruthy();
+    test('the baseline key is SERVER-scoped, not operation-scoped and never param-only', () => {
+        // Three coordinates, each closing a different leak. `operationId` is unique per document, not
+        // repository-global — `healthcheck` and `get_mcp_tool_handbook` exist on several servers — so
+        // an operation-scoped key lets a suppression on one server absolve the same-named operation on
+        // another. A param-only key is worse still: `viaMcp` has three live instances across two
+        // operations, and one row would have hidden all of them.
+        expect(PARITY_BASELINE['knowledge-base.manage_knowledge_base.viaMcp']).toBeTruthy();
+
+        expect(PARITY_BASELINE['manage_knowledge_base.viaMcp'], 'an operation-scoped key crosses servers').toBeUndefined();
         expect(PARITY_BASELINE['viaMcp'], 'a bare param key would suppress across operations').toBeUndefined();
+
+        // Every key carries all three coordinates, so a future row cannot be added at the wrong depth.
+        for (const key of Object.keys(PARITY_BASELINE)) {
+            expect(key.split('.').length, `${key} must be <server>.<operationId>.<param>`).toBe(3);
+        }
     });
 });

--- a/test/playwright/unit/ai/mcp/validation/OpenApiServiceParityTriggerReachability.spec.mjs
+++ b/test/playwright/unit/ai/mcp/validation/OpenApiServiceParityTriggerReachability.spec.mjs
@@ -1,0 +1,80 @@
+import {test, expect}     from '@playwright/test';
+import fs                 from 'node:fs';
+import path               from 'node:path';
+import {fileURLToPath}    from 'node:url';
+import {load as yamlLoad} from 'js-yaml';
+import micromatch         from 'micromatch';
+
+import {SERVERS} from '../../../../../../ai/scripts/diagnostics/mcpHandlerSignatureCensus.mjs';
+
+const repoRoot     = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../../../../..'),
+      workflowPath = path.join(repoRoot, '.github/workflows/openapi-service-parity-lint.yml');
+
+/**
+ * TRIGGER REACHABILITY for the parity gate: does the guard actually RUN on the files it reads?
+ *
+ * A correct checker that never executes on the change which broke it is worth less than no checker,
+ * because its absence from a PR's check list reads as coverage. That is not a hypothetical: the three
+ * ToolService authorities were added to `pull_request.paths` and omitted from `push.paths`, so pushes
+ * to `dev` never re-ran the guard on the mapping table its dispatch join derives every handler from.
+ * @neo-gpt found it with micromatch after the code fixes had already been accepted.
+ *
+ * Two distinct properties are asserted, and the second is the one that stops a recurrence:
+ *
+ * 1. Every source authority the lint READS matches at least one path filter.
+ * 2. `push.paths` and `pull_request.paths` are SET-EQUAL. GitHub Actions does not reliably expand
+ *    YAML anchors in workflow files, so the workflow necessarily holds two copies of one list — and
+ *    the only thing between two copies and silent divergence is a mechanical equality check. Adding
+ *    an authority to one block and not the other is precisely the mistake that occurred, and reviewer
+ *    attention is the wrong layer for it: the omission is invisible in a diff that shows the addition.
+ */
+
+const workflow  = yamlLoad(fs.readFileSync(workflowPath, 'utf8')),
+      prPaths   = workflow.on.pull_request.paths,
+      pushPaths = workflow.on.push.paths;
+
+test.describe('parity gate trigger reachability', () => {
+    test('push.paths and pull_request.paths are SET-EQUAL', () => {
+        // Sorted comparison rather than index-wise, so a reordering is not a failure while a missing
+        // or extra entry is. Order carries no meaning to GitHub; membership carries all of it.
+        expect([...pushPaths].sort(), 'a filter present on one trigger and absent on the other is the live defect this guards')
+            .toEqual([...prPaths].sort());
+    });
+
+    test('every source authority the lint reads is matched by a path filter', () => {
+        // Derived from SERVERS rather than listed, so a new MCP server is covered the moment it is
+        // registered — the same reason the transform corpus is harvested instead of enumerated.
+        const authorities = [
+            'ai/services.mjs',
+            'ai/mcp/ToolService.mjs',
+            'ai/scripts/lint/lint-openapi-service-parity.mjs',
+            'ai/scripts/diagnostics/mcpHandlerSignatureCensus.mjs',
+            ...SERVERS.map(server => server.toolService),
+            ...SERVERS.map(server => server.openApi)
+        ];
+
+        for (const file of authorities) {
+            expect(micromatch.isMatch(file, prPaths),  `pull_request must trigger on ${file}`).toBe(true);
+            expect(micromatch.isMatch(file, pushPaths), `push must trigger on ${file}`).toBe(true);
+        }
+    });
+
+    test('a handler module OUTSIDE the service tree is matched — the omission that was live', () => {
+        // `ingestSourceFilesTool.mjs` is a real resolved handler that lives under `ai/mcp/server/**`
+        // and NOT under `ai/services/**`, so the original `ai/services/**/*.mjs` filter missed it.
+        const handler = 'ai/mcp/server/knowledge-base/ingestSourceFilesTool.mjs';
+
+        expect(fs.existsSync(path.join(repoRoot, handler)), 'the fixture must name a REAL file, or it proves nothing').toBe(true);
+        expect(micromatch.isMatch(handler, prPaths)).toBe(true);
+        expect(micromatch.isMatch(handler, pushPaths)).toBe(true);
+    });
+
+    test('NEGATIVE CONTROL: an unrelated file does NOT trigger the gate', () => {
+        // Without this, a filter of `**` would satisfy every assertion above while making the gate
+        // run on every commit in the repo — passing the letter of reachability and destroying its point.
+        for (const unrelated of ['src/component/Base.mjs', 'README.md', 'apps/portal/view/Viewport.mjs']) {
+            expect(micromatch.isMatch(unrelated, prPaths),  `${unrelated} must not trigger`).toBe(false);
+            expect(micromatch.isMatch(unrelated, pushPaths), `${unrelated} must not trigger`).toBe(false);
+        }
+    });
+});


### PR DESCRIPTION
Resolves #16585

`ai/services.mjs` wraps every MCP-backed service in a Zod facade, and Zod object parsing **strips keys the schema does not declare**. So a method that gains a parameter without a matching spec property compiles, lints, and passes every unit test that constructs the service directly — then reads `undefined` in production, where the call goes through the Proxy. No throw, no warning, nothing in the receipt. Diagnosing one instance (#16577) cost about a session, and the defect was a line of YAML that did not exist.

## Deltas

| Surface | Change |
|---|---|
| `ai/scripts/lint/lint-openapi-service-parity.mjs` | new — the instrument |
| `test/.../validation/OpenApiServiceParityGate.spec.mjs` | new — 10 direct mechanism + live-tree pins |
| `test/.../validation/OpenApiServiceParityEndToEnd.spec.mjs` | new — 18 two-join + composite fixture tests |
| `test/.../validation/OpenApiServiceParityTriggerReachability.spec.mjs` | new — 4 workflow-authority reachability controls |
| `ai/scripts/diagnostics/mcpHandlerSignatureCensus.mjs` | **latent crash fixed** in the shared `collectImports` helper |
| `package.json` | `ai:lint-openapi-service-parity` + five lint-staged path groups |
| `.github/workflows/openapi-service-parity-lint.yml` | new — CI on service, contract, wiring-table and helper changes |

Evidence: `[lint-openapi-service-parity] OK — 40 wrapped service(s), 121 operation-bound method(s) + 142 object-dispatch handler(s), 0 consumed-but-undeclared parameter(s), 0 declared-but-unused (advisory), 17 positional handler(s) owned by the signature census.`

## The design decision worth reviewing: consumption, not JSDoc

The ticket originally proposed parsing JSDoc `@param [payload.X]` / destructured signature names. **Verified against the actual defect, that would have found nothing on the very operation that motivated the guard:**

```js
async ingestSourceFiles(payload = {}) {              // a bag — destructures NOTHING
    …
    viaMcp: payload.viaMcp !== false                 // ← the consuming read
    materializationAttempt: payload.materializationAttempt
}
```

The signature carries no parameter names at all. So detection is **destructured names ∪ `<bag>.X` member reads**, because:

1. **The read is the failure site.** `payload.viaMcp` evaluating `undefined` *is* the bug; JSDoc is a claim about it.
2. **JSDoc keying gets both directions wrong** — false-positive on a documented-but-unused param (harmless), and blind to a read with no JSDoc at all (the worst case, undeclared everywhere).
3. **It subsumes destructuring**, since destructured names are reads.

Blind spots stated rather than left to be discovered: non-literal dynamic access (`payload[key]`) is undecidable and unreported, while literal computed reads are covered; wholesale forwarding (`helper(payload)`) hides consumption in the callee. Both are narrower than the JSDoc approach's blind spot, not wider.

## Built ON the sibling instrument, not beside it

`mcpHandlerSignatureCensus.mjs` already resolves operations to handlers and reads params via acorn. This instrument now reuses that resolver for the **ToolService object-dispatch** join and independently covers the **`services.mjs` Proxy** join. The census owns positional/unresolved signature discipline; this parity lint owns consumed-versus-declared violations plus the non-failing inverse advisory for object bags. Shared AST helpers are **imported** so the two cannot drift into disagreeing about what a parameter is.

**That reuse immediately surfaced a latent crash in `collectImports`:** it read `.imported.name` on every non-default specifier, so `import * as yaml` (an `ImportNamespaceSpecifier`, which has no `imported` node) threw. The helper was therefore unusable on any module with a namespace import. Unnoticed because the census only ever parsed `toolService.mjs` files, none of which have one. Fixed with the three-way branch; the census's own gate spec and diagnostics suite still pass (364 tests).

## First run found 5 — and one of them is NOT a defect

```
[lint-openapi-service-parity] FAILED — 5 consumed-but-undeclared parameter(s)
```

| operation | param | consequence |
|---|---|---|
| ~~`manage_knowledge_base`~~ | ~~`viaMcp`~~ | **WITHDRAWN — correct as designed** (dispatch forces `true`; the CLI default is the documented bypass) |
| `manage_knowledge_base` | `staleStrategy` | always `undefined` — and its operator surface already exists as `NEO_KB_STALE_STRATEGY` |
| `query_documents` | `includeMetadata` | always `false` — an internal RAG-hydration flag with one caller, **not** a lost capability |
| `get_context_frontier` | `depth` | **dead, not pinned**: AST-measured zero occurrences in the method body |

Filed as #16611 for individual disposition, because declaring a parameter makes it agent-settable and that is a per-parameter decision.

**The dispositions have since been researched, and this table's original readings were wrong three times out of four** — corrected above rather than left standing, since a reviewer checks the shipped behaviour against these rows:

- **`viaMcp` withdrawn.** MCP dispatch Zod-strips any caller value and the mapping re-adds `viaMcp: true` after validation; the `services.mjs`/CLI path correctly defaults to `false`, the documented long-running-work bypass. Both paths already get the right value and neither takes it from the caller. Declaring it would let a caller switch the work-volume gate **off** through a public surface.
- **`depth` is dead, not throttled.** Zero occurrences in `getContextFrontier`'s 2484-char body. Declaring it would be the worst option available: an agent sets `depth: 5`, gets no error, gets depth-2 results. It gets deleted.
- **`includeMetadata` loses nothing.** *"Internal hydration flag for RAG synthesis callers"*, one caller repo-wide; the surface that needs metadata is `ask_knowledge_base`, which sets it itself.
- **`staleStrategy` stands**, and is baselined permanent rather than declared: `delete-upfront` removes stale rows *before* embedding, and the operator control already exists as an env var.

Two further rows arrived from the ToolService join, both baselined with owners on #16611: `get_session_memories.memorySharing` (a tenant-isolation override, declared on two siblings) and `get_all_summaries.category` (declared with a *"Filter by category"* description its handler never reads).

**The fifth is correct as designed**, and this is the part I want checked hardest:

```js
async whoIsOnline({family, verbose = false, now = new Date()} = {}) {
```

`now` is an injected clock with a working default, used identically across `bootstrap`, `retireStaleHarnessPresence` and `whoIsOnline`. **Declaring it would be a regression** — it would let a caller supply an arbitrary "current time" to a liveness computation, i.e. lie about whether a peer is online. It is baselined *permanently* with that rationale in the file, so a future sweep does not helpfully "fix" it.

Stating it because the tempting read of a 5-row failure is "5 defects," and a checker's output is a list of findings, not verdicts. Getting that wrong here would have shipped a security-relevant widening as a cleanup.

## Test Evidence

```
npm run test-unit -- test/playwright/unit/ai/mcp/validation/ --workers=1
  86 passed (3.7s)        # 84 validation tests + Chroma setup/teardown; reviewer exact-head run

npm run test-unit -- test/playwright/unit/ai/mcp/validation/McpHandlerSignatureGate.spec.mjs \
  test/playwright/unit/ai/scripts/diagnostics/ --workers=1
  364 passed (12.0s)        # the census's own gate, after the collectImports fix
```

**The gate asserts coverage BEFORE cleanliness**, and that ordering is the point:

```js
expect(result.servicesScanned).toBeGreaterThan(30);
expect(result.operationsMatched).toBeGreaterThan(100);
expect(violations).toEqual([]);
```

A resolver that broke would report zero violations and be **indistinguishable from a clean tree**. The green has to prove it measured something first — the same false-green shape this whole PR exists to close, applied to the instrument itself.

Other mechanism pins, each there because its absence would make the guard quietly weaker:

- **A bag-style method with no destructured params** still reveals its reads — the negative control for the detection mechanism, not for one operation.
- **A rest element disables the absence claim** rather than reading as "no reads found."
- **Member reads on something other than the bag are not attributed to it** — without this, any `foo.bar` in a body becomes a false positive.
- **`$ref` is resolved** in `declaredNames`, or a declared param reads as missing.
- **Every baseline row carries a reason >40 chars**, and suppression keys on `operation.param` — never a bare param name, or the same recurring parameter (`viaMcp` has three live instances) would be absorbed silently across operations.

## Post-Merge Validation

- [ ] The CI job runs on the next PR touching `ai/services/**`, `ai/mcp/server/**/openapi.yaml`, `ai/services.mjs`, or either helper — observable as a check named on that PR.
- [ ] A commit staging a service or contract file triggers the lint-staged entry. **Note the limit honestly:** the entries fire on those paths, but the check is whole-tree, so it validates everything regardless of what was staged. That is correct for an invariant and worth knowing before someone tries to make it incremental.
- [ ] #16611's dispositions land and their TRANSITIONAL baseline rows are removed. The permanent rows stay by design: `who_is_online.now`, `manage_knowledge_base.viaMcp`, `manage_knowledge_base.staleStrategy`, `query_documents.includeMetadata`, and both `chromaTimeoutMs` rows — each a value that must never be caller-supplied.

Not claimed: that the gaps are fixed. This PR delivers the instrument and files what it found, per the ticket's own scope split. Also not claimed: that the advisory direction is complete — a forwarded bag or a dynamic computed key silences it by design, because `consumed` is a lower bound and its complement cannot support an absence claim.

## Scope held

- **Dispositioning the discovered contract gaps** — #16611, deliberately separate: each is a design decision about agent-settability, not a mechanical YAML addition.
- **Making the declared-but-unused inverse fatal.** The inverse is implemented as a non-failing advisory; intentional forward-compat remains legitimate, so automatically treating every advisory as an error would fight a real pattern.
- **Moving `camelToSnake` / `findOperation` into `openApiValidator.mjs`.** The ticket proposed it so a lint script could reuse them without booting the SDK. Not needed: `camelToSnake` is two lines and the operation index is derived locally, so importing them would have coupled a lint script to the SDK's module graph for no gain. Mirrored with a comment naming `ai/services.mjs#camelToSnake` as the authority instead; the gate reads and executes that source authority across every live wrapped-service method name plus labelled synthetic edge shapes. **Flagging this as a deviation from the ticket's Contract Ledger** rather than silently taking the shortcut.

Authored by @neo-opus-vega (Claude Opus 5).

