### PR TITLE
Retention keeps recoverability per substrate, not directories (#16614)

### DIFF
--- a/ai/scripts/maintenance/backup.mjs
+++ b/ai/scripts/maintenance/backup.mjs
@@ -1000,11 +1000,14 @@ export async function classifyBundleRecoverability(bundlePath) {
     //   `malformed` — UNKNOWN state. Cannot fill the floor, and is a HARD KEEP: we cannot certify it
     //                 as a recovery source, and we equally cannot certify it as disposable.
     const metaPath  = path.join(bundlePath, 'bundle-meta.json');
-    let   metaState = 'absent';
+    let   metaState = 'absent',
+          parsedMeta = null;
 
     if (await fs.pathExists(metaPath)) {
         try {
             const parsed = await fs.readJson(metaPath);
+
+            parsedMeta = parsed;
             // A JSON scalar parses but is not a receipt. `null` in particular parses cleanly and
             // would otherwise certify a bundle on the strength of the four characters "null".
             // SHAPE is not VALIDITY, and `typeof parsed === 'object'` alone was only a shape test —
@@ -1020,6 +1023,19 @@ export async function classifyBundleRecoverability(bundlePath) {
             metaState = isCompletedBundleReceipt(parsed) ? 'valid' : 'malformed';
         } catch {
             metaState = 'malformed';
+        }
+    }
+
+    // Per-substrate integrity verdicts from the receipt, only trusted when the receipt itself is
+    // valid. `integrity` is an array of `{subsystem, status, sourceCount}`; a substrate absent from it
+    // has no parity claim and therefore cannot be certified.
+    const integrityStatus = {};
+
+    if (metaState === 'valid') {
+        for (const entry of parsedMeta.integrity) {
+            if (entry && typeof entry.subsystem === 'string') {
+                integrityStatus[entry.subsystem] = entry.status;
+            }
         }
     }
 
@@ -1062,7 +1078,19 @@ export async function classifyBundleRecoverability(bundlePath) {
         }
 
         substrates[substrate] = bytes;
-        if (bytes > 0) restorableFor.push(substrate);
+
+        // TWO conditions, and neither is sufficient alone: **bytes establish non-empty, `pass`
+        // establishes parity.** A bundle recording `kb: fail (sourceCount 2, bundleCount 1)` with
+        // non-zero bytes was certified restorable on bytes alone, filled the floor, and deleted the
+        // older `kb: pass` bundle — a partial capture outranking a complete one.
+        //
+        // Per SUBSTRATE, deliberately. A mixed receipt is legitimate and still certifies the
+        // substrates that did pass: `kb: fail` + `mc: pass` is a real bundle that can restore MC and
+        // cannot restore KB, and collapsing that to a whole-bundle verdict would either discard a
+        // usable MC source or certify an unusable KB one.
+        if (bytes > 0 && integrityStatus[substrate] === 'pass') {
+            restorableFor.push(substrate);
+        }
     }
 
     return {hasMeta, metaState, substrates, restorableFor, unreadable: [...new Set(unreadable)]};
@@ -1134,7 +1162,11 @@ export async function cleanOldBackups(backupRoot, logger, retention = {}) {
     const floor = new Set();
 
     for (const substrate of RECOVERY_SUBSTRATES) {
-        for (const entry of classified.filter(candidate => candidate.hasMeta && candidate.substrates[substrate] > 0)
+        // `restorableFor`, NOT raw bytes. The classifier already combines non-empty payload with a
+        // `pass` parity verdict; filtering on bytes here re-derived a weaker predicate one place over
+        // and let a `kb: fail` bundle hold kb's floor slot anyway. Two consumers read this signal and
+        // both must read the SAME one, or fixing the verdict fixes nothing.
+        for (const entry of classified.filter(candidate => candidate.hasMeta && candidate.restorableFor.includes(substrate))
                                       .slice(0, keepMinimum)) {
             floor.add(entry.name);
         }
@@ -1156,7 +1188,7 @@ export async function cleanOldBackups(backupRoot, logger, retention = {}) {
             // capture is not a verified recovery source, and letting one become the protected
             // last-known-good would pin residue in place of a real bundle. Dropping this condition
             // made a meta-less 40d bundle outrank a complete 50d one.
-            const newest = classified.find(entry => entry.hasMeta && entry.substrates[substrate] > 0);
+            const newest = classified.find(entry => entry.hasMeta && entry.restorableFor.includes(substrate));
             if (newest) newestPerSubstrate.add(newest.name);
         }
     }

--- a/ai/scripts/maintenance/backup.mjs
+++ b/ai/scripts/maintenance/backup.mjs
@@ -788,6 +788,22 @@ export function classifyIntegrityStatus(status) {
 }
 
 /**
+ * The substrates whose presence decides whether a bundle is a recovery source at all — and the same
+ * set whose row-count parity `verifyBundleIntegrity` checks, because those are one question, not two:
+ * the receipt's `integrity[]` block exists to answer "does this bundle hold rows a restore could
+ * bring back?", so verifying a substrate and ranking recoverability by it must range over the
+ * identical set. It was written out twice, and two lists that must agree are a list that will not.
+ *
+ * `concepts`, `trajectories`, `mailbox` and `ledgers` are deliberately absent: `copyJsonlSource`
+ * documents them as legitimately optional (a deployment that has never healed has no ledger), so
+ * requiring them would classify correct bundles as unrecoverable.
+ *
+ * Declared above both consumers rather than between them, so neither reads as the authority.
+ * @member {String[]} RECOVERY_SUBSTRATES
+ */
+export const RECOVERY_SUBSTRATES = Object.freeze(['kb', 'mc', 'graph']);
+
+/**
  * Verifies row-count parity between source collections and the JSONL files written into the
  * bundle. For subsystems whose `manageDatabaseBackup({action: 'export'})` SDK call returns a
  * numeric count (KB, MC memories+summaries, MC graph), this function streams the bundle's JSONL
@@ -814,7 +830,7 @@ export function classifyIntegrityStatus(status) {
  * @returns {Promise<Array<{subsystem: String, status: String, sourceCount: Number, bundleCount: Number, reason: String}>>} `status` is one of the frozen {@link INTEGRITY_STATUS} values — `pass` (positive row-count parity) / `empty` (source and bundle both zero — non-fatal, not a usable recovery source) / `fail` (row-count mismatch) / `skipped` (non-numeric source count); count + reason fields present per status.
  */
 export async function verifyBundleIntegrity(layout, subsystems) {
-    const verifiable = ['kb', 'mc', 'graph'];
+    const verifiable = RECOVERY_SUBSTRATES;
     const checks     = [];
 
     for (const subsystem of verifiable) {
@@ -985,16 +1001,6 @@ export async function listPublishedBundles(backupRoot) {
 
     return backups
 }
-
-/**
- * The substrates whose presence decides whether a bundle is a recovery source at all.
- *
- * `concepts`, `trajectories`, `mailbox` and `ledgers` are deliberately absent: `copyJsonlSource`
- * documents them as legitimately optional (a deployment that has never healed has no ledger), so
- * requiring them would classify correct bundles as unrecoverable.
- * @member {String[]} RECOVERY_SUBSTRATES
- */
-export const RECOVERY_SUBSTRATES = Object.freeze(['kb', 'mc', 'graph']);
 
 /**
  * @summary Decides whether a parsed `bundle-meta.json` is a COMPLETED-capture receipt.

--- a/ai/scripts/maintenance/backup.mjs
+++ b/ai/scripts/maintenance/backup.mjs
@@ -963,7 +963,29 @@ export const RECOVERY_SUBSTRATES = Object.freeze(['kb', 'mc', 'graph']);
  * @returns {Promise<{hasMeta: Boolean, substrates: Object, restorableFor: String[]}>}
  */
 export async function classifyBundleRecoverability(bundlePath) {
-    const hasMeta       = await fs.pathExists(path.join(bundlePath, 'bundle-meta.json')),
+    // THREE meta states, not two. `pathExists` alone answered "is there a file", and a corrupt
+    // receipt passed as a valid one: it filled the floor, displaced an older VALID bundle, and that
+    // bundle was then deleted. Data loss caused by the guard written to prevent data loss.
+    //
+    // The asymmetry between the two failure states is deliberate:
+    //   `absent`    — a KNOWN-incomplete capture. Cannot fill the floor, stays age-deletable.
+    //   `malformed` — UNKNOWN state. Cannot fill the floor, and is a HARD KEEP: we cannot certify it
+    //                 as a recovery source, and we equally cannot certify it as disposable.
+    const metaPath  = path.join(bundlePath, 'bundle-meta.json');
+    let   metaState = 'absent';
+
+    if (await fs.pathExists(metaPath)) {
+        try {
+            const parsed = await fs.readJson(metaPath);
+            // A JSON scalar parses but is not a receipt. `null` in particular parses cleanly and
+            // would otherwise certify a bundle on the strength of the four characters "null".
+            metaState = (parsed !== null && typeof parsed === 'object') ? 'valid' : 'malformed';
+        } catch {
+            metaState = 'malformed';
+        }
+    }
+
+    const hasMeta       = metaState === 'valid',
           substrates    = {},
           restorableFor = [],
           unreadable    = [];
@@ -1005,7 +1027,7 @@ export async function classifyBundleRecoverability(bundlePath) {
         if (bytes > 0) restorableFor.push(substrate);
     }
 
-    return {hasMeta, substrates, restorableFor, unreadable: [...new Set(unreadable)]};
+    return {hasMeta, metaState, substrates, restorableFor, unreadable: [...new Set(unreadable)]};
 }
 
 /**
@@ -1118,6 +1140,20 @@ export async function cleanOldBackups(backupRoot, logger, retention = {}) {
                 `[Retention] Keeping ${entry.name} (UNREADABLE payload, age ${ageDays}d) — ` +
                 `could not read: ${entry.unreadable.join(', ')} — ${payload}. Recoverability unknown; ` +
                 `not deleting. Investigate permissions or corruption.`
+            );
+            continue;
+        }
+
+        // A MALFORMED receipt is the same class of unknown as an unreadable payload, and gets the same
+        // hard keep. It is already excluded from the floor by `hasMeta`, which is what stops it
+        // displacing a valid bundle; this stops it being destroyed on an age clock as well. Note the
+        // deliberate asymmetry with an ABSENT receipt, which stays age-deletable: absent is a
+        // known-incomplete capture, malformed is a bundle whose state we cannot determine at all.
+        if (entry.metaState === 'malformed') {
+            logger.warn?.(
+                `[Retention] Keeping ${entry.name} (MALFORMED bundle-meta.json, age ${ageDays}d) — ${payload}. ` +
+                `Cannot certify it as a recovery source, and cannot certify it as disposable; not deleting. ` +
+                `Investigate corruption.`
             );
             continue;
         }

--- a/ai/scripts/maintenance/backup.mjs
+++ b/ai/scripts/maintenance/backup.mjs
@@ -741,6 +741,53 @@ export const INTEGRITY_STATUS = Object.freeze({
 });
 
 /**
+ * The retention-relevant partition of {@link INTEGRITY_STATUS}, and the reason it is a partition
+ * rather than an equality test against `pass`.
+ *
+ * Retention asks two independent questions of a substrate, and only ONE of them is "may I certify
+ * this as a recovery source?". The other is "may I delete this?" — and the answer to the second is
+ * NOT the negation of the first. Three outcomes, not two:
+ *
+ * | status | certify as restorable? | safe to delete? | why |
+ * |---|---|---|---|
+ * | `pass`    | yes | n/a  | positive row-count parity — an evaluated, usable source |
+ * | `fail`    | no  | yes  | row-count mismatch — evaluated, and known torn |
+ * | `empty`   | no  | yes  | evaluated, and known to hold nothing to restore |
+ * | `skipped` | no  | **NO** | the verifier could not evaluate it at all |
+ * | anything else | no | **NO** | a status this reader does not recognize |
+ *
+ * `skipped` is not hypothetical: the producer emits it whenever the SDK returns a non-numeric source
+ * count, meaning parity was never established in either direction. Treating it as "not restorable"
+ * and therefore deletable destroys a bundle whose contents were never examined — the same
+ * unknown-is-not-empty error as trusting `pathExists`, one dimension further in. A status this
+ * reader does not recognize gets the same treatment, so a producer that adds a value later fails
+ * toward keeping rather than toward deleting.
+ * @member {Object} INTEGRITY_STATUS_DISPOSITION
+ */
+export const INTEGRITY_STATUS_DISPOSITION = Object.freeze({
+    certifying: Object.freeze([INTEGRITY_STATUS.pass]),
+    // Evaluated and known unusable. These, and ONLY these, make a substrate reclaimable.
+    evaluatedUnusable: Object.freeze([INTEGRITY_STATUS.fail, INTEGRITY_STATUS.empty])
+});
+
+/**
+ * @summary Classifies one substrate's receipt status into its retention disposition.
+ *
+ * Absent (`undefined`) lands in `indeterminate` deliberately: a substrate missing from the
+ * `integrity` array carries no parity claim in either direction, which is exactly the state that
+ * must not authorize deletion.
+ *
+ * @param {String|undefined} status The receipt's status for one substrate.
+ * @returns {String} `'certifying'`, `'evaluatedUnusable'`, or `'indeterminate'`.
+ */
+export function classifyIntegrityStatus(status) {
+    if (INTEGRITY_STATUS_DISPOSITION.certifying.includes(status))        return 'certifying';
+    if (INTEGRITY_STATUS_DISPOSITION.evaluatedUnusable.includes(status)) return 'evaluatedUnusable';
+
+    return 'indeterminate'
+}
+
+/**
  * Verifies row-count parity between source collections and the JSONL files written into the
  * bundle. For subsystems whose `manageDatabaseBackup({action: 'export'})` SDK call returns a
  * numeric count (KB, MC memories+summaries, MC graph), this function streams the bundle's JSONL
@@ -1042,6 +1089,7 @@ export async function classifyBundleRecoverability(bundlePath) {
     const hasMeta       = metaState === 'valid',
           substrates    = {},
           restorableFor = [],
+          unevaluated   = [],
           unreadable    = [];
 
     for (const substrate of RECOVERY_SUBSTRATES) {
@@ -1088,12 +1136,41 @@ export async function classifyBundleRecoverability(bundlePath) {
         // substrates that did pass: `kb: fail` + `mc: pass` is a real bundle that can restore MC and
         // cannot restore KB, and collapsing that to a whole-bundle verdict would either discard a
         // usable MC source or certify an unusable KB one.
-        if (bytes > 0 && integrityStatus[substrate] === 'pass') {
+        //
+        // Classified against the frozen producer authority rather than compared to the literal
+        // 'pass'. An equality test answers "certify?" and silently answers "delete?" as its
+        // negation — but `skipped` and any unrecognized status are NOT-certifiable and ALSO
+        // not-deletable, so the negation is wrong for exactly the cases we cannot evaluate.
+        const disposition = classifyIntegrityStatus(integrityStatus[substrate]);
+
+        if (bytes > 0 && disposition === 'certifying') {
             restorableFor.push(substrate);
+        }
+
+        // A substrate holding bytes whose parity was never established. Not certified above, and
+        // recorded here so retention hard-keeps the bundle instead of aging it out: deleting a
+        // capture nobody ever verified is the one outcome no recovery policy may choose.
+        //
+        // Gated on `hasMeta`, and the gate is the whole distinction. With NO receipt every status is
+        // trivially absent, so without this gate a meta-less bundle would become permanently
+        // undeletable — an existing test caught exactly that. Absent-receipt is not an unknown: it
+        // is a DECIDED case (a partial capture, never a verified recovery source, age-deletable so
+        // residue cannot accumulate forever). This branch is for the narrower and more deceptive
+        // state: a receipt we successfully read and parsed, which itself reports that the check
+        // never happened.
+        if (hasMeta && bytes > 0 && disposition === 'indeterminate') {
+            unevaluated.push(substrate);
         }
     }
 
-    return {hasMeta, metaState, substrates, restorableFor, unreadable: [...new Set(unreadable)]};
+    return {
+        hasMeta,
+        metaState,
+        substrates,
+        restorableFor,
+        unevaluated: [...new Set(unevaluated)],
+        unreadable : [...new Set(unreadable)]
+    };
 }
 
 /**
@@ -1224,6 +1301,21 @@ export async function cleanOldBackups(backupRoot, logger, retention = {}) {
                 `[Retention] Keeping ${entry.name} (MALFORMED bundle-meta.json, age ${ageDays}d) — ${payload}. ` +
                 `Cannot certify it as a recovery source, and cannot certify it as disposable; not deleting. ` +
                 `Investigate corruption.`
+            );
+            continue;
+        }
+
+        // The THIRD unknown, and the one this guard shipped without: a receipt that is perfectly
+        // valid and reports a status carrying no parity claim — `skipped` (the verifier could not
+        // evaluate) or a value this reader does not recognize. Such a substrate holds bytes nobody
+        // ever checked, so it is neither certifiable nor reclaimable. The two branches above cover
+        // "cannot read it" and "cannot parse it"; this covers "read and parsed it, and it says the
+        // check never happened" — which reads as evaluated precisely because the receipt is intact.
+        if (entry.unevaluated?.length > 0) {
+            logger.warn?.(
+                `[Retention] Keeping ${entry.name} (UNVERIFIED substrate(s): ${entry.unevaluated.join(', ')}, ` +
+                `age ${ageDays}d) — ${payload}. The receipt is valid but claims no parity for these, so their ` +
+                `contents were never verified in either direction; not deleting. Re-run integrity verification.`
             );
             continue;
         }

--- a/ai/scripts/maintenance/backup.mjs
+++ b/ai/scripts/maintenance/backup.mjs
@@ -28,10 +28,10 @@ import {
     resolveHeavyMaintenanceLeasePath,
     withHeavyMaintenanceLease
 } from '../../daemons/orchestrator/services/HeavyMaintenanceLeaseService.mjs';
-import {resolveCloudOnlyDefault}        from '../../daemons/orchestrator/services/deploymentDurabilityPosture.mjs';
+import {resolveCloudOnlyDefault}                from '../../daemons/orchestrator/services/deploymentDurabilityPosture.mjs';
 import {cleanStagingResidue, createStagingRoot} from './backupStagingResidueCore.mjs';
-import {HEAL_LEDGER_DIR_NAME}           from '../../services/memory-core/helpers/healEventLedgerStore.mjs';
-import {INCIDENT_LEDGER_BUNDLE_MEMBERS} from '../../services/memory-core/helpers/incidentLedgerBundle.mjs';
+import {HEAL_LEDGER_DIR_NAME}                   from '../../services/memory-core/helpers/healEventLedgerStore.mjs';
+import {INCIDENT_LEDGER_BUNDLE_MEMBERS}         from '../../services/memory-core/helpers/incidentLedgerBundle.mjs';
 import {
     buildBackupReceipt,
     buildSyncChildEnv,
@@ -940,16 +940,84 @@ export async function listPublishedBundles(backupRoot) {
 }
 
 /**
+ * The substrates whose presence decides whether a bundle is a recovery source at all.
+ *
+ * `concepts`, `trajectories`, `mailbox` and `ledgers` are deliberately absent: `copyJsonlSource`
+ * documents them as legitimately optional (a deployment that has never healed has no ledger), so
+ * requiring them would classify correct bundles as unrecoverable.
+ * @member {String[]} RECOVERY_SUBSTRATES
+ */
+export const RECOVERY_SUBSTRATES = Object.freeze(['kb', 'mc', 'graph']);
+
+/**
+ * @summary Reports, per substrate, whether a published bundle could actually restore anything.
+ *
+ * **Non-empty payload bytes, deliberately — not row counts.** A `wc -l` over a 3.3 GB JSONL on every
+ * sweep would make retention cost scale with corpus size, and it would buy nothing: retention cannot
+ * judge *degraded*, only *empty*. It does not know what a complete corpus is, and the newest bundle
+ * on this plane (900 MB / 16,550 rows against an expected ~60,000) is non-empty by either measure.
+ * Claiming this guards against degradation would be the over-claim; it guards against **nothing to
+ * restore**, which is the failure that produced six such bundles.
+ *
+ * @param {String} bundlePath Absolute path to a published bundle.
+ * @returns {Promise<{hasMeta: Boolean, substrates: Object, restorableFor: String[]}>}
+ */
+export async function classifyBundleRecoverability(bundlePath) {
+    const hasMeta       = await fs.pathExists(path.join(bundlePath, 'bundle-meta.json')),
+          substrates    = {},
+          restorableFor = [];
+
+    for (const substrate of RECOVERY_SUBSTRATES) {
+        const dir   = path.join(bundlePath, substrate);
+        let   bytes = 0;
+
+        if (await fs.pathExists(dir)) {
+            for (const entry of await fs.readdir(dir)) {
+                if (!entry.endsWith('.jsonl')) continue;
+
+                try {
+                    bytes += (await fs.stat(path.join(dir, entry))).size;
+                } catch {
+                    // An unreadable payload is treated as absent for this substrate rather than
+                    // aborting the sweep. Under-counting keeps a bundle, which is the safe error;
+                    // throwing here would leave retention unrun and let the root grow unbounded.
+                }
+            }
+        }
+
+        substrates[substrate] = bytes;
+        if (bytes > 0) restorableFor.push(substrate);
+    }
+
+    return {hasMeta, substrates, restorableFor};
+}
+
+/**
  * Applies retention policy to the backup root.
  *
  * Two-axis policy:
- *   - `keepMinimum` — newest N bundles retained unconditionally regardless of age
+ *   - `keepMinimum` — newest N **restorable** bundles retained unconditionally regardless of age
  *   - `maxDays`     — bundles older than this many days are eligible for deletion
  *
- * A bundle survives if EITHER axis protects it (i.e., it's in the keepMinimum-newest
- * window OR younger than maxDays). Both defaults match the original hardcoded
- * constants (`K=3, N_DAYS=30`) so omitting the `retention` argument preserves
- * existing behavior.
+ * A bundle survives if EITHER axis protects it (i.e., it counts inside the keepMinimum floor OR is
+ * younger than maxDays).
+ *
+ * **`keepMinimum` counts RECOVERABILITY, not directories, and that is the whole point of this
+ * function.** The floor exists to guarantee a recovery path; counting bundles that can restore
+ * nothing toward it makes the guarantee decorative. Measured on the live plane 2026-08-07: six of ten
+ * kept bundles held **zero** KB rows, every one of them carrying a valid `bundle-meta.json`, so the
+ * three newest bundles — the entire "kept minimum" — contained no recoverable KB corpus. The one
+ * 59,754-row bundle survived on age alone, four days inside a thirty-day bound, and nothing in the
+ * policy knew it was the only real one.
+ *
+ * **The newest restorable bundle per substrate is never deleted, `maxDays` notwithstanding.** Age is
+ * the wrong axis for a last-known-good artifact: a 31-day-old bundle holding a full corpus beats a
+ * one-day-old empty one, and on this plane that comparison was concrete rather than hypothetical.
+ *
+ * A bundle with no `bundle-meta.json` cannot count toward the floor — it is a partial capture, and
+ * one such bundle (2,001 rows, no meta) was sitting in the retention set as a peer of complete
+ * captures. It stays age-deletable on purpose: excluding it from deletion as well would let residue
+ * accumulate forever, trading one unbounded-growth bug for another.
  *
  * Enumerates through {@link listPublishedBundles}, so a `.backup-partial-*` staging directory is
  * never a retention candidate and never counts toward `keepMinimum` — an in-flight capture must not
@@ -958,7 +1026,7 @@ export async function listPublishedBundles(backupRoot) {
  * @param {String} backupRoot
  * @param {Object} logger
  * @param {Object} [retention]
- * @param {Number} [retention.keepMinimum=3] Newest N bundles to retain unconditionally.
+ * @param {Number} [retention.keepMinimum=3] Newest N restorable bundles to retain unconditionally.
  * @param {Number} [retention.maxDays=30]    Bundles older than this in days are eligible for deletion.
  */
 export async function cleanOldBackups(backupRoot, logger, retention = {}) {
@@ -966,29 +1034,90 @@ export async function cleanOldBackups(backupRoot, logger, retention = {}) {
 
     const {keepMinimum = 3, maxDays = 30} = retention;
 
-    const backups = await listPublishedBundles(backupRoot);
+    const backups     = await listPublishedBundles(backupRoot),
+          now         = Date.now(),
+          thresholdMs = maxDays * 24 * 60 * 60 * 1000;
 
-    const K           = keepMinimum;
-    const N_DAYS      = maxDays;
-    const now         = Date.now();
-    const thresholdMs = N_DAYS * 24 * 60 * 60 * 1000;
+    // Classify first, decide second. The sweep needs the whole set's recoverability before it can
+    // say which bundles the floor protects — an index-based floor cannot express "the newest three
+    // that can actually restore something".
+    const classified = [];
+
+    for (const backup of backups) {
+        classified.push({...backup, ...await classifyBundleRecoverability(backup.path)});
+    }
+
+    // The floor is PER SUBSTRATE — the newest `keepMinimum` meta-bearing bundles restorable for each
+    // substrate, unioned. Not "restorable for at least one".
+    //
+    // An any-substrate floor looks correct and does not close the defect. Measured on the live set:
+    // the three newest restorable-for-anything bundles were `[kb,mc,graph]`, `[mc,graph]`,
+    // `[mc,graph]` — so the floor held exactly ONE kb-bearing bundle (the degraded newest), and the
+    // only full-corpus bundle was still protected by age alone. Recovery needs every substrate
+    // covered; a floor satisfied by three bundles that all lack `kb` guarantees nothing about kb.
+    const floor = new Set();
+
+    for (const substrate of RECOVERY_SUBSTRATES) {
+        for (const entry of classified.filter(candidate => candidate.hasMeta && candidate.substrates[substrate] > 0)
+                                      .slice(0, keepMinimum)) {
+            floor.add(entry.name);
+        }
+    }
+
+    // Per-substrate last-known-good. Separate from the floor because a bundle can be restorable for
+    // `mc` and empty for `kb`: a floor built from "restorable for anything" could still leave the
+    // only KB-bearing bundle unprotected.
+    //
+    // Gated on a POSITIVE floor, and that boundary is the point. This rule exists to stop an AGE
+    // CLOCK from deleting the last artifact that can restore a substrate — not to override an
+    // operator who explicitly asked for none. `keepMinimum: 0` is a stated intent to keep nothing,
+    // and a purge the tool refuses to perform is a different tool.
+    const newestPerSubstrate = new Set();
+
+    if (keepMinimum > 0) {
+        for (const substrate of RECOVERY_SUBSTRATES) {
+            // `hasMeta` is required here for the same reason it is required for the floor: a partial
+            // capture is not a verified recovery source, and letting one become the protected
+            // last-known-good would pin residue in place of a real bundle. Dropping this condition
+            // made a meta-less 40d bundle outrank a complete 50d one.
+            const newest = classified.find(entry => entry.hasMeta && entry.substrates[substrate] > 0);
+            if (newest) newestPerSubstrate.add(newest.name);
+        }
+    }
 
     let deletedCount = 0;
 
-    for (let i = K; i < backups.length; i++) {
-        const backup = backups[i];
-        const ageMs  = now - backup.time;
-        if (ageMs > thresholdMs) {
-            try {
-                logger.log(`[Retention] Deleting old backup: ${backup.name} (age: ${Math.round(ageMs / 86400000)} days)`);
-                await fs.remove(backup.path);
-                deletedCount++;
-            } catch (err) {
-                if (logger.error) {
-                    logger.error(`[Retention] Failed to delete ${backup.name}: ${err.message}`);
-                } else {
-                    logger.log(`[Retention] Failed to delete ${backup.name}: ${err.message}`);
-                }
+    for (const entry of classified) {
+        const ageMs   = now - entry.time,
+              ageDays = Math.round(ageMs / 86400000),
+              payload = RECOVERY_SUBSTRATES.map(s => `${s}=${entry.substrates[s]}B`).join(' ');
+
+        if (floor.has(entry.name)) {
+            logger.log(`[Retention] Keeping ${entry.name} (restorable floor, age ${ageDays}d) — ${payload}`);
+            continue;
+        }
+
+        if (newestPerSubstrate.has(entry.name)) {
+            // Deliberately independent of `maxDays`. This is the last artifact that can restore the
+            // substrate; deleting it on an age clock is the failure this branch exists to prevent.
+            logger.log(`[Retention] Keeping ${entry.name} (newest restorable per substrate, age ${ageDays}d) — ${payload}`);
+            continue;
+        }
+
+        if (ageMs <= thresholdMs) continue;
+
+        try {
+            // Say WHAT is being dropped, not just its name. Six empty bundles accumulated unnoticed
+            // because the sweep logged names; a per-substrate byte line makes an audit possible after
+            // the fact rather than requiring one to have been watching.
+            logger.log(`[Retention] Deleting old backup: ${entry.name} (age: ${ageDays} days, meta=${entry.hasMeta}) — ${payload}`);
+            await fs.remove(entry.path);
+            deletedCount++;
+        } catch (err) {
+            if (logger.error) {
+                logger.error(`[Retention] Failed to delete ${entry.name}: ${err.message}`);
+            } else {
+                logger.log(`[Retention] Failed to delete ${entry.name}: ${err.message}`);
             }
         }
     }

--- a/ai/scripts/maintenance/backup.mjs
+++ b/ai/scripts/maintenance/backup.mjs
@@ -950,6 +950,34 @@ export async function listPublishedBundles(backupRoot) {
 export const RECOVERY_SUBSTRATES = Object.freeze(['kb', 'mc', 'graph']);
 
 /**
+ * @summary Decides whether a parsed `bundle-meta.json` is a COMPLETED-capture receipt.
+ *
+ * Deliberately a validity check rather than a shape check. `typeof value === 'object'` accepts `{}`
+ * and `{garbage: 1}`, both of which certified a bundle, filled the recovery floor, and caused an
+ * older valid bundle to be deleted — the same defect as trusting `pathExists`, one level in.
+ *
+ * The required pair is measured against a real bundle rather than invented: `completedAt` is what
+ * separates a finished capture from an interrupted one, and `integrity` (an array of
+ * `{subsystem, status, sourceCount}`) is what makes the receipt an assertion about *content* rather
+ * than merely a timestamp. A receipt missing either cannot certify recoverability.
+ *
+ * Deliberately NOT checked here: whether every `integrity` entry says `pass`. A bundle can honestly
+ * record a failed subsystem, and that is a per-substrate question the byte scan already answers.
+ * Requiring all-pass would make an honest partial receipt indistinguishable from a corrupt one.
+ *
+ * @param {*} value Parsed contents of `bundle-meta.json`.
+ * @returns {Boolean}
+ */
+export function isCompletedBundleReceipt(value) {
+    return value !== null
+        && typeof value === 'object'
+        && !Array.isArray(value)
+        && typeof value.completedAt === 'string'
+        && value.completedAt.length > 0
+        && Array.isArray(value.integrity);
+}
+
+/**
  * @summary Reports, per substrate, whether a published bundle could actually restore anything.
  *
  * **Non-empty payload bytes, deliberately — not row counts.** A `wc -l` over a 3.3 GB JSONL on every
@@ -979,7 +1007,17 @@ export async function classifyBundleRecoverability(bundlePath) {
             const parsed = await fs.readJson(metaPath);
             // A JSON scalar parses but is not a receipt. `null` in particular parses cleanly and
             // would otherwise certify a bundle on the strength of the four characters "null".
-            metaState = (parsed !== null && typeof parsed === 'object') ? 'valid' : 'malformed';
+            // SHAPE is not VALIDITY, and `typeof parsed === 'object'` alone was only a shape test —
+            // `{}` and `{garbage: 1}` passed it, filled the floor, and deleted the older valid bundle.
+            // The same defect as `pathExists`, one level in: I checked that something was there rather
+            // than that it was a receipt.
+            //
+            // A completed capture carries `completedAt` and an `integrity` array of per-subsystem
+            // `{subsystem, status, sourceCount}` — verified against a real bundle. Those two are the
+            // load-bearing pair: `completedAt` distinguishes a finished capture from an interrupted
+            // one, and `integrity` is what makes the receipt an assertion about content rather than a
+            // timestamp. Anything else is `malformed`: floor-ineligible AND a hard keep.
+            metaState = isCompletedBundleReceipt(parsed) ? 'valid' : 'malformed';
         } catch {
             metaState = 'malformed';
         }

--- a/ai/scripts/maintenance/backup.mjs
+++ b/ai/scripts/maintenance/backup.mjs
@@ -965,22 +965,38 @@ export const RECOVERY_SUBSTRATES = Object.freeze(['kb', 'mc', 'graph']);
 export async function classifyBundleRecoverability(bundlePath) {
     const hasMeta       = await fs.pathExists(path.join(bundlePath, 'bundle-meta.json')),
           substrates    = {},
-          restorableFor = [];
+          restorableFor = [],
+          unreadable    = [];
 
     for (const substrate of RECOVERY_SUBSTRATES) {
         const dir   = path.join(bundlePath, substrate);
         let   bytes = 0;
 
         if (await fs.pathExists(dir)) {
-            for (const entry of await fs.readdir(dir)) {
+            let entries;
+
+            try {
+                entries = await fs.readdir(dir);
+            } catch {
+                // Cannot enumerate the substrate at all — record it and move on. Unknown is not empty.
+                unreadable.push(substrate);
+                substrates[substrate] = 0;
+                continue;
+            }
+
+            for (const entry of entries) {
                 if (!entry.endsWith('.jsonl')) continue;
 
                 try {
                     bytes += (await fs.stat(path.join(dir, entry))).size;
                 } catch {
-                    // An unreadable payload is treated as absent for this substrate rather than
-                    // aborting the sweep. Under-counting keeps a bundle, which is the safe error;
-                    // throwing here would leave retention unrun and let the root grow unbounded.
+                    // UNREADABLE IS NOT EMPTY, and the first version of this comment claimed the
+                    // opposite: it said "under-counting keeps a bundle, which is the safe error".
+                    // That is exactly backwards. Under-counting makes the bundle non-restorable,
+                    // which excludes it from the floor, which makes it age-DELETABLE — so a bundle we
+                    // merely failed to read would be destroyed by the guard meant to protect
+                    // recovery sources. A stated safety property the code did not have.
+                    unreadable.push(substrate);
                 }
             }
         }
@@ -989,7 +1005,7 @@ export async function classifyBundleRecoverability(bundlePath) {
         if (bytes > 0) restorableFor.push(substrate);
     }
 
-    return {hasMeta, substrates, restorableFor};
+    return {hasMeta, substrates, restorableFor, unreadable: [...new Set(unreadable)]};
 }
 
 /**
@@ -1092,6 +1108,20 @@ export async function cleanOldBackups(backupRoot, logger, retention = {}) {
               ageDays = Math.round(ageMs / 86400000),
               payload = RECOVERY_SUBSTRATES.map(s => `${s}=${entry.substrates[s]}B`).join(' ');
 
+        // UNREADABLE is a hard keep, checked before every other rule. A payload we could not read is
+        // of UNKNOWN recoverability, and the one thing retention must never do is destroy an artifact
+        // it failed to inspect. Without this the classifier's zero-bytes fallback made an unreadable
+        // bundle non-restorable, which excluded it from the floor, which made it age-deletable — the
+        // guard deleting exactly the bundle whose contents it could not verify.
+        if (entry.unreadable?.length > 0) {
+            logger.warn?.(
+                `[Retention] Keeping ${entry.name} (UNREADABLE payload, age ${ageDays}d) — ` +
+                `could not read: ${entry.unreadable.join(', ')} — ${payload}. Recoverability unknown; ` +
+                `not deleting. Investigate permissions or corruption.`
+            );
+            continue;
+        }
+
         if (floor.has(entry.name)) {
             logger.log(`[Retention] Keeping ${entry.name} (restorable floor, age ${ageDays}d) — ${payload}`);
             continue;
@@ -1104,7 +1134,14 @@ export async function cleanOldBackups(backupRoot, logger, retention = {}) {
             continue;
         }
 
-        if (ageMs <= thresholdMs) continue;
+        if (ageMs <= thresholdMs) {
+            // Age-held keeps are logged too. The AC is that the sweep says what it keeps AND drops,
+            // and a silent `continue` here left the largest keep category invisible — so a reader
+            // auditing the log could not tell an age-held bundle from one the sweep never saw. Six
+            // empty bundles accumulated unnoticed precisely because the log was incomplete.
+            logger.log(`[Retention] Keeping ${entry.name} (younger than ${maxDays}d, age ${ageDays}d) — ${payload}`);
+            continue;
+        }
 
         try {
             // Say WHAT is being dropped, not just its name. Six empty bundles accumulated unnoticed

--- a/test/playwright/unit/ai/scripts/maintenance/backup-retention.spec.mjs
+++ b/test/playwright/unit/ai/scripts/maintenance/backup-retention.spec.mjs
@@ -301,6 +301,44 @@ test.describe('cleanOldBackups — configurable retention', () => {
         expect(remaining, 'unknown state must not be destroyed on an age clock either').toContain(newerMalformed);
     });
 
+    test('a per-substrate FAIL cannot certify that substrate — bytes are non-empty, pass is parity', async () => {
+        // @neo-gpt's cycle-4 destructive probe. A newer bundle recording `kb: fail` with NON-ZERO
+        // bytes was certified `restorableFor: [kb, mc]` on bytes alone, filled K=1, and deleted the
+        // older `kb: pass` bundle — a partial capture outranking a complete one.
+        //
+        // Bytes establish non-empty; `pass` establishes parity. Neither is sufficient alone.
+        const {classifyBundleRecoverability} = await import('../../../../../../ai/scripts/maintenance/backup.mjs');
+
+        const newerPartial = await seedBackup(1,  {substrates: ['kb', 'mc']});
+        const olderPass    = await seedBackup(40, {substrates: ['kb', 'mc']});
+
+        // Rewrite the newer receipt so kb FAILS parity while its payload stays non-empty.
+        await fs.writeJson(path.join(tmpRoot, newerPartial, 'bundle-meta.json'), {
+            timestamp  : 'x',
+            completedAt: new Date().toISOString(),
+            integrity  : [
+                {subsystem: 'kb', status: 'fail', sourceCount: 2, bundleCount: 1},
+                {subsystem: 'mc', status: 'pass', sourceCount: 1, bundleCount: 1}
+            ]
+        });
+
+        const verdict = await classifyBundleRecoverability(path.join(tmpRoot, newerPartial));
+
+        // A mixed receipt is legitimate and still certifies what DID pass — collapsing it to a
+        // whole-bundle verdict would either discard a usable MC source or certify an unusable KB one.
+        expect(verdict.metaState, 'a partial receipt is still a valid receipt').toBe('valid');
+        expect(verdict.restorableFor, 'kb failed parity and must not be certified').not.toContain('kb');
+        expect(verdict.restorableFor, 'mc passed and is certified independently').toContain('mc');
+        expect(verdict.substrates.kb, 'the bytes are genuinely non-zero — that is the point').toBeGreaterThan(0);
+
+        await cleanOldBackups(tmpRoot, {log: () => {}, warn: () => {}}, {keepMinimum: 1, maxDays: 30});
+
+        expect(
+            await listBackups(),
+            'the older kb:pass bundle must outrank a newer kb:fail one'
+        ).toContain(olderPass);
+    });
+
     test('an OBJECT-SHAPED invalid receipt cannot certify a bundle either — shape is not validity', async () => {
         // @neo-gpt's cycle-3 probe. My first fix required only `typeof parsed === 'object'`, so `{}`
         // and `{garbage: 1}` still certified a bundle, filled the floor, and deleted the older valid

--- a/test/playwright/unit/ai/scripts/maintenance/backup-retention.spec.mjs
+++ b/test/playwright/unit/ai/scripts/maintenance/backup-retention.spec.mjs
@@ -70,7 +70,7 @@ test.describe('cleanOldBackups — configurable retention', () => {
      * timestamp values are millisecond-unique (ageInDays accepts fractional days), which
      * keeps directory names distinct under rapid-fire seeding.
      */
-    async function seedBackup(ageInDays, {restorable = true, meta = true, substrates = ['kb']} = {}) {
+    async function seedBackup(ageInDays, {restorable = true, meta = true, substrates = ['kb'], statuses = {}} = {}) {
         const ts      = new Date(Date.now() - ageInDays * 86400000);
         const isoTs   = ts.toISOString().replace(/:/g, '-');
         const dirName = `backup-${isoTs}`;
@@ -89,7 +89,13 @@ test.describe('cleanOldBackups — configurable retention', () => {
             await fs.writeJson(path.join(dirPath, 'bundle-meta.json'), {
                 timestamp  : isoTs,
                 completedAt: ts.toISOString(),
-                integrity  : substrates.map(substrate => ({subsystem: substrate, status: 'pass', sourceCount: restorable ? 1 : 0}))
+                // `statuses` overrides one substrate's verdict so a fixture can carry a legitimate
+                // MIXED or UNVERIFIED receipt — the shapes the producer really emits.
+                integrity  : substrates.map(substrate => ({
+                    subsystem  : substrate,
+                    status     : statuses[substrate] ?? 'pass',
+                    sourceCount: restorable ? 1 : 0
+                }))
             });
         }
 
@@ -337,6 +343,83 @@ test.describe('cleanOldBackups — configurable retention', () => {
             await listBackups(),
             'the older kb:pass bundle must outrank a newer kb:fail one'
         ).toContain(olderPass);
+    });
+
+    test('an UNRECOGNIZED status hard-keeps the bundle — not-certifiable is not the same as deletable', async () => {
+        // @neo-gpt's cycle-5 destructive probe, and the fifth reproduction of one mechanism. The
+        // cycle-4 repair certified only on `pass`, which is right — but it left deletion as the
+        // NEGATION of certification. For `fail` that negation is correct. For a status this reader
+        // cannot interpret it is data loss: an aged bundle holding real bytes, whose receipt is
+        // perfectly valid, deleted beside a fresh one because nobody could say what it contained.
+        const olderUnknown = await seedBackup(40, {substrates: ['kb'], statuses: {kb: 'future-v2'}});
+        const newerPass    = await seedBackup(1,  {substrates: ['kb']});
+
+        const {classifyBundleRecoverability} = await import('../../../../../../ai/scripts/maintenance/backup.mjs');
+        const verdict                        = await classifyBundleRecoverability(path.join(tmpRoot, olderUnknown));
+
+        expect(verdict.metaState, 'the receipt is well-formed — that is what makes this dangerous').toBe('valid');
+        expect(verdict.restorableFor, 'an uninterpretable status cannot certify anything').not.toContain('kb');
+        expect(verdict.unevaluated, 'but it MUST be recorded as unevaluated, which is what saves it').toContain('kb');
+        expect(verdict.substrates.kb, 'the payload is real; only the verdict is unknown').toBeGreaterThan(0);
+
+        await cleanOldBackups(tmpRoot, {log: () => {}, warn: () => {}}, {keepMinimum: 1, maxDays: 30});
+
+        const remaining = await listBackups();
+
+        expect(remaining, 'a bundle nobody verified must not be destroyed on an age clock').toContain(olderUnknown);
+        expect(remaining, 'and the pass bundle is of course kept').toContain(newerPass);
+    });
+
+    test('a SKIPPED status hard-keeps too — the producer already emits it, so this is reachable today', async () => {
+        // `skipped` is not a hypothetical future value. `verifyBundleIntegrity` emits it whenever the
+        // SDK returns a non-numeric source count, so parity was never established in either
+        // direction. It was inside the deletable set until this fix.
+        const {INTEGRITY_STATUS} = await import('../../../../../../ai/scripts/maintenance/backup.mjs');
+        const olderSkipped       = await seedBackup(40, {substrates: ['kb'], statuses: {kb: INTEGRITY_STATUS.skipped}});
+
+        await seedBackup(1, {substrates: ['kb']});
+        await cleanOldBackups(tmpRoot, {log: () => {}, warn: () => {}}, {keepMinimum: 1, maxDays: 30});
+
+        expect(await listBackups(), 'an unverified capture is not a disposable one').toContain(olderSkipped);
+    });
+
+    test('DESTRUCTIVE CONTROL: an EMPTY status is evaluated, so it stays reclaimable', async () => {
+        // The control that stops the fix above from degenerating into keep-everything. `empty` and
+        // `fail` are evaluated verdicts — the verifier looked and reported nothing to restore — so
+        // they must remain deletable. Without this test, hard-keeping every non-`pass` status would
+        // pass every assertion above while quietly disabling retention altogether.
+        const {INTEGRITY_STATUS} = await import('../../../../../../ai/scripts/maintenance/backup.mjs');
+        const olderEmpty         = await seedBackup(40, {substrates: ['kb'], statuses: {kb: INTEGRITY_STATUS.empty}});
+
+        await seedBackup(1, {substrates: ['kb']});
+        await cleanOldBackups(tmpRoot, {log: () => {}, warn: () => {}}, {keepMinimum: 1, maxDays: 30});
+
+        expect(
+            await listBackups(),
+            'an EVALUATED "nothing to restore" verdict is still reclaimable — retention must keep working'
+        ).not.toContain(olderEmpty);
+    });
+
+    test('the status partition is derived from the frozen producer enum, not a literal', async () => {
+        const {INTEGRITY_STATUS, INTEGRITY_STATUS_DISPOSITION, classifyIntegrityStatus} =
+            await import('../../../../../../ai/scripts/maintenance/backup.mjs');
+
+        // Every value the producer can emit must have an explicit disposition. A new status added to
+        // the enum without a decision here fails THIS test rather than silently becoming deletable.
+        for (const status of Object.values(INTEGRITY_STATUS)) {
+            expect(
+                ['certifying', 'evaluatedUnusable', 'indeterminate'],
+                `${status} must carry an explicit retention disposition`
+            ).toContain(classifyIntegrityStatus(status));
+        }
+
+        expect(classifyIntegrityStatus(INTEGRITY_STATUS.pass)).toBe('certifying');
+        expect(classifyIntegrityStatus(INTEGRITY_STATUS.fail)).toBe('evaluatedUnusable');
+        expect(classifyIntegrityStatus(INTEGRITY_STATUS.empty)).toBe('evaluatedUnusable');
+        expect(classifyIntegrityStatus(INTEGRITY_STATUS.skipped)).toBe('indeterminate');
+        // Absent carries no parity claim in either direction — the case that must not authorize deletion.
+        expect(classifyIntegrityStatus(undefined)).toBe('indeterminate');
+        expect(Object.isFrozen(INTEGRITY_STATUS_DISPOSITION.certifying)).toBe(true);
     });
 
     test('an OBJECT-SHAPED invalid receipt cannot certify a bundle either — shape is not validity', async () => {

--- a/test/playwright/unit/ai/scripts/maintenance/backup-retention.spec.mjs
+++ b/test/playwright/unit/ai/scripts/maintenance/backup-retention.spec.mjs
@@ -273,6 +273,68 @@ test.describe('cleanOldBackups — configurable retention', () => {
         expect(await listBackups(), 'the last artifact that can restore kb must not age out').toContain(ancientButReal);
     });
 
+    test('an UNREADABLE payload is a hard keep — unknown recoverability is not empty', async () => {
+        // The classifier's zero-bytes fallback once carried a comment claiming "under-counting keeps a
+        // bundle, which is the safe error" — the opposite of what the code did. Under-counting made the
+        // bundle non-restorable, which excluded it from the floor, which made it age-DELETABLE. The
+        // guard would have destroyed exactly the bundle whose contents it could not verify.
+        const {classifyBundleRecoverability} = await import('../../../../../../ai/scripts/maintenance/backup.mjs');
+
+        const unreadable = await seedBackup(400);
+        await seedBackup(1);
+        await seedBackup(2);
+        await seedBackup(3);
+
+        // Make the payload genuinely unreadable rather than mocking the failure: chmod the substrate
+        // directory so `readdir` throws. A stubbed error would test the branch; this tests the path.
+        const kbDir = path.join(tmpRoot, unreadable, 'kb');
+        await fs.chmod(kbDir, 0o000);
+
+        try {
+            const verdict = await classifyBundleRecoverability(path.join(tmpRoot, unreadable));
+
+            // Skip on any environment where the chmod does not actually deny us (e.g. running as
+            // root). Asserting into a non-hazard is how a guard becomes vacuous.
+            test.skip(verdict.unreadable.length === 0, 'chmod did not deny access in this environment');
+
+            expect(verdict.unreadable, 'the failure must be REPORTED, not silently read as empty').toContain('kb');
+
+            await cleanOldBackups(tmpRoot, {log: () => {}, warn: () => {}}, {keepMinimum: 3, maxDays: 30});
+
+            expect(
+                await listBackups(),
+                'a bundle whose payload could not be read must never be deleted'
+            ).toContain(unreadable);
+        } finally {
+            await fs.chmod(kbDir, 0o755);
+        }
+    });
+
+    test('the sweep logs every keep with its REASON, including age-held ones', async () => {
+        // The AC is that the sweep says what it keeps and drops. A silent `continue` on the age branch
+        // left the largest keep category invisible, so an auditor could not distinguish an age-held
+        // bundle from one the sweep never saw — which is how six empty bundles accumulated unnoticed.
+        const lines = [];
+
+        // `keepMinimum: 1` is what makes this discriminate. My first fixture used `keepMinimum: 3`
+        // with two bundles, so BOTH landed in the floor and the age branch never executed — the test
+        // would have passed against a build with no age logging at all. With a floor of one, the
+        // second bundle is outside it, younger than `maxDays`, and therefore genuinely age-held.
+        await seedBackup(1);    // floor-held + newest-restorable
+        await seedBackup(2);    // outside the floor, under maxDays → AGE-held
+
+        await cleanOldBackups(tmpRoot, {log: line => lines.push(line), warn: line => lines.push(line)}, {keepMinimum: 1, maxDays: 30});
+
+        const joined = lines.join('\n');
+
+        expect(joined, 'age-held keeps must be logged').toMatch(/younger than 30d/);
+        expect(joined, 'floor-held keeps must be logged').toMatch(/restorable floor/);
+        // Per-substrate bytes on every line, so the log is auditable after the fact rather than
+        // requiring someone to have been watching.
+        expect(joined).toMatch(/kb=\d+B/);
+        expect(lines.length, 'every bundle gets a line').toBeGreaterThanOrEqual(2);
+    });
+
     test('a bundle with no meta receipt cannot fill the floor, but stays age-deletable', async () => {
         // A real bundle in this shape existed: 2,001 rows, no bundle-meta.json, sitting in the
         // retention set as a peer of complete captures. It must not count toward the recovery floor —

--- a/test/playwright/unit/ai/scripts/maintenance/backup-retention.spec.mjs
+++ b/test/playwright/unit/ai/scripts/maintenance/backup-retention.spec.mjs
@@ -83,7 +83,14 @@ test.describe('cleanOldBackups — configurable retention', () => {
         // directory models the empty bundle rather than the normal one — which is exactly the
         // conflation the policy change removes. `restorable: false` opts into the empty shape.
         if (meta) {
-            await fs.writeJson(path.join(dirPath, 'bundle-meta.json'), {timestamp: isoTs});
+            // The fixture must satisfy the REAL receipt contract, not merely be an object: a completed
+            // capture carries `completedAt` plus an `integrity` array. A `{timestamp}`-only stub used
+            // to pass, which is exactly the object-shaped-but-invalid receipt that certified a bundle.
+            await fs.writeJson(path.join(dirPath, 'bundle-meta.json'), {
+                timestamp  : isoTs,
+                completedAt: ts.toISOString(),
+                integrity  : substrates.map(substrate => ({subsystem: substrate, status: 'pass', sourceCount: restorable ? 1 : 0}))
+            });
         }
 
         for (const substrate of substrates) {
@@ -292,6 +299,46 @@ test.describe('cleanOldBackups — configurable retention', () => {
         // as a recovery source OR as disposable. Deliberately asymmetric with an ABSENT receipt, which
         // stays age-deletable because absent is a known-incomplete capture.
         expect(remaining, 'unknown state must not be destroyed on an age clock either').toContain(newerMalformed);
+    });
+
+    test('an OBJECT-SHAPED invalid receipt cannot certify a bundle either — shape is not validity', async () => {
+        // @neo-gpt's cycle-3 probe. My first fix required only `typeof parsed === 'object'`, so `{}`
+        // and `{garbage: 1}` still certified a bundle, filled the floor, and deleted the older valid
+        // one. Same defect as trusting `pathExists`, one level in: I checked that something was THERE
+        // rather than that it was a RECEIPT.
+        const {classifyBundleRecoverability} = await import('../../../../../../ai/scripts/maintenance/backup.mjs');
+
+        for (const [label, body] of [
+            ['empty object',        {}],
+            ['unrelated keys',      {garbage: 1}],
+            ['timestamp only',      {timestamp: 'x'}],
+            ['completedAt only',    {completedAt: '2026-08-07T00:00:00.000Z'}],
+            ['integrity only',      {integrity: []}],
+            ['integrity not array', {completedAt: '2026-08-07T00:00:00.000Z', integrity: {}}],
+            ['array at the root',   [{completedAt: 'x', integrity: []}]]
+        ]) {
+            const name = await seedBackup(1);
+            await fs.writeJson(path.join(tmpRoot, name, 'bundle-meta.json'), body);
+
+            const verdict = await classifyBundleRecoverability(path.join(tmpRoot, name));
+
+            expect(verdict.metaState, `${label} must not read as a valid receipt`).toBe('malformed');
+            expect(verdict.hasMeta, `${label} must not satisfy hasMeta`).toBe(false);
+        }
+    });
+
+    test('an object-shaped invalid receipt does not delete the older valid bundle', async () => {
+        const newerInvalid = await seedBackup(1);
+        const olderValid   = await seedBackup(40);
+
+        await fs.writeJson(path.join(tmpRoot, newerInvalid, 'bundle-meta.json'), {garbage: 1});
+
+        await cleanOldBackups(tmpRoot, {log: () => {}, warn: () => {}}, {keepMinimum: 1, maxDays: 30});
+
+        const remaining = await listBackups();
+
+        expect(remaining, 'the older VALID bundle must survive an object-shaped invalid receipt').toContain(olderValid);
+        expect(remaining, 'unknown state is still a hard keep').toContain(newerInvalid);
     });
 
     test('a JSON scalar is not a receipt — "null" parses cleanly and must not certify a bundle', async () => {

--- a/test/playwright/unit/ai/scripts/maintenance/backup-retention.spec.mjs
+++ b/test/playwright/unit/ai/scripts/maintenance/backup-retention.spec.mjs
@@ -70,13 +70,32 @@ test.describe('cleanOldBackups — configurable retention', () => {
      * timestamp values are millisecond-unique (ageInDays accepts fractional days), which
      * keeps directory names distinct under rapid-fire seeding.
      */
-    async function seedBackup(ageInDays) {
+    async function seedBackup(ageInDays, {restorable = true, meta = true, substrates = ['kb']} = {}) {
         const ts      = new Date(Date.now() - ageInDays * 86400000);
         const isoTs   = ts.toISOString().replace(/:/g, '-');
         const dirName = `backup-${isoTs}`;
         const dirPath = path.join(tmpRoot, dirName);
         await fs.ensureDir(dirPath);
         await fs.writeFile(path.join(dirPath, 'placeholder'), 'test-marker');
+
+        // A published bundle carries a meta receipt and non-empty substrate payloads. The fixture
+        // defaults to that shape because retention now reads recoverability, and a payload-less
+        // directory models the empty bundle rather than the normal one — which is exactly the
+        // conflation the policy change removes. `restorable: false` opts into the empty shape.
+        if (meta) {
+            await fs.writeJson(path.join(dirPath, 'bundle-meta.json'), {timestamp: isoTs});
+        }
+
+        for (const substrate of substrates) {
+            const dir = path.join(dirPath, substrate);
+            await fs.ensureDir(dir);
+            // An empty DIRECTORY, not an absent one: six real bundles had `kb/` present and empty,
+            // and that is the shape the guard has to classify.
+            if (restorable) {
+                await fs.writeFile(path.join(dir, `${substrate}-backup-${isoTs}.jsonl`), '{"id":"row-1"}\n');
+            }
+        }
+
         return dirName;
     }
 
@@ -102,7 +121,7 @@ test.describe('cleanOldBackups — configurable retention', () => {
         expect(remaining).toHaveLength(3);
         // Survivor set = newest 3
         for (const name of remaining) {
-            const match = name.match(/^backup-(.+?)(-suffix.*)?$/);
+            const match   = name.match(/^backup-(.+?)(-suffix.*)?$/);
             const isoTime = match[1].replace(/T(\d{2})-(\d{2})-(\d{2})/, 'T$1:$2:$3');
             const ageDays = (Date.now() - new Date(isoTime).getTime()) / 86400000;
             expect(ageDays).toBeLessThan(30);
@@ -138,7 +157,7 @@ test.describe('cleanOldBackups — configurable retention', () => {
         const remaining = await listBackups();
         expect(remaining).toHaveLength(2);
         for (const name of remaining) {
-            const match = name.match(/^backup-(.+)$/);
+            const match   = name.match(/^backup-(.+)$/);
             const isoTime = match[1].replace(/T(\d{2})-(\d{2})-(\d{2})/, 'T$1:$2:$3');
             const ageDays = (Date.now() - new Date(isoTime).getTime()) / 86400000;
             expect(ageDays).toBeLessThan(7.1);  // 7 + tiny epsilon for rounding
@@ -198,6 +217,118 @@ test.describe('cleanOldBackups — configurable retention', () => {
         expect(remaining).toHaveLength(1);
     });
 
+    test('the floor counts RESTORABLE bundles — three empty ones do not displace the only real one', async () => {
+        // The live defect, reduced. Measured 2026-08-07: six of ten kept bundles held zero KB rows,
+        // each with a valid bundle-meta.json, so the three newest — the entire "kept minimum" —
+        // could restore nothing, and the one 59,754-row bundle survived on age alone.
+        const populated = await seedBackup(40);                          // old but RESTORABLE
+        await seedBackup(1, {restorable: false});
+        await seedBackup(2, {restorable: false});
+        await seedBackup(3, {restorable: false});
+
+        await cleanOldBackups(tmpRoot, {log: () => {}}, {keepMinimum: 3, maxDays: 30});
+
+        const remaining = await listBackups();
+
+        // Under a directory-counting floor the three empty bundles fill it and the 40d populated one
+        // is age-eligible — the exact displacement the operator called "REPLACED right away".
+        expect(remaining, 'the only restorable bundle must survive').toContain(populated);
+    });
+
+    test('the floor is PER SUBSTRATE — bundles restorable for mc only cannot fill kb\'s slots', async () => {
+        // My first implementation failed exactly here, and a dry-run against the live set caught it.
+        // An any-substrate floor read the three newest as `[kb,mc]`, `[mc]`, `[mc]`, called itself
+        // satisfied while holding ONE kb-bearing bundle, and left the only full corpus on age alone.
+        //
+        // TWO kb bundles is what makes this discriminate, and the first version of this test had one.
+        // With a single kb bundle the newest-per-substrate rule rescues it under BOTH floor designs,
+        // so the assertion passed against the implementation it was written to reject — proven by
+        // mutation. `recentKb` absorbs that rule; `oldKb` can only be saved by the per-substrate floor.
+        const recentKb = await seedBackup(1,  {substrates: ['kb', 'mc']});
+        const oldKb    = await seedBackup(40, {substrates: ['kb', 'mc']});
+        await seedBackup(2, {substrates: ['mc']});
+        await seedBackup(3, {substrates: ['mc']});
+        await seedBackup(4, {substrates: ['mc']});
+
+        await cleanOldBackups(tmpRoot, {log: () => {}}, {keepMinimum: 3, maxDays: 30});
+
+        const remaining = await listBackups();
+
+        // Fixture guard: an any-substrate floor of 3 is entirely consumed by the mc-only bundles plus
+        // `recentKb`, so `oldKb` sits outside it and is past maxDays. If this pair were not both
+        // present the assertion below would be satisfied by the design it exists to reject.
+        expect(remaining, 'the newest kb bundle is the control, held by the per-substrate rule').toContain(recentKb);
+        expect(remaining, 'kb needs its OWN slots; mc-only bundles must not consume them').toContain(oldKb);
+    });
+
+    test('the newest restorable bundle per substrate outlives maxDays', async () => {
+        // Age is the wrong axis for a last-known-good artifact: a 40-day-old full corpus beats a
+        // one-day-old empty one. Nothing else here is restorable, so if this bundle goes, the
+        // substrate has no recovery source at all.
+        const ancientButReal = await seedBackup(400);
+        await seedBackup(1, {restorable: false});
+
+        await cleanOldBackups(tmpRoot, {log: () => {}}, {keepMinimum: 1, maxDays: 30});
+
+        expect(await listBackups(), 'the last artifact that can restore kb must not age out').toContain(ancientButReal);
+    });
+
+    test('a bundle with no meta receipt cannot fill the floor, but stays age-deletable', async () => {
+        // A real bundle in this shape existed: 2,001 rows, no bundle-meta.json, sitting in the
+        // retention set as a peer of complete captures. It must not count toward the recovery floor —
+        // and it must still be reclaimable, or residue accumulates forever and one unbounded-growth
+        // bug is traded for another.
+        const metaless  = await seedBackup(40, {meta: false});
+        const populated = await seedBackup(50);
+
+        await cleanOldBackups(tmpRoot, {log: () => {}}, {keepMinimum: 1, maxDays: 30});
+
+        const remaining = await listBackups();
+
+        expect(remaining, 'the meta-bearing restorable bundle holds the floor').toContain(populated);
+        expect(remaining, 'a partial capture is not a recovery source and is reclaimable').not.toContain(metaless);
+    });
+
+    test('CONTROL — with every bundle restorable, retention prunes exactly as before', async () => {
+        // The negative control, and the reason it matters: every assertion above is satisfied by a
+        // "never delete anything" implementation. This is what proves the change is a re-ranking
+        // rather than a disabling.
+        await seedBackup(1);
+        await seedBackup(10);
+        await seedBackup(25);
+        await seedBackup(40);
+        await seedBackup(60);
+
+        await cleanOldBackups(tmpRoot, {log: () => {}}, {keepMinimum: 3, maxDays: 30});
+
+        // Same outcome as the byte-equivalence anchor above: newest 3 held by the floor, the two
+        // beyond it are under nothing that protects them.
+        expect(await listBackups()).toHaveLength(3);
+    });
+
+    test('classifyBundleRecoverability reports per-substrate payload, and an empty dir is not absent', async () => {
+        const {classifyBundleRecoverability, RECOVERY_SUBSTRATES} =
+            await import('../../../../../../ai/scripts/maintenance/backup.mjs');
+
+        const realName  = await seedBackup(1, {substrates: ['kb', 'mc']}),
+              emptyName = await seedBackup(2, {restorable: false});
+
+        const real  = await classifyBundleRecoverability(path.join(tmpRoot, realName)),
+              empty = await classifyBundleRecoverability(path.join(tmpRoot, emptyName));
+
+        expect(real.hasMeta).toBe(true);
+        expect(real.restorableFor.sort()).toEqual(['kb', 'mc']);
+        expect(real.substrates.kb).toBeGreaterThan(0);
+        expect(real.substrates.graph, 'an absent substrate reads as zero, not undefined').toBe(0);
+
+        // The load-bearing distinction: `kb/` EXISTS and is empty. A presence check would call this
+        // bundle restorable, which is how six of them passed as valid recovery sources.
+        expect(empty.hasMeta).toBe(true);
+        expect(empty.restorableFor, 'a present-but-empty payload is not a recovery source').toEqual([]);
+
+        expect(RECOVERY_SUBSTRATES, 'optional substrates must not gate recoverability').not.toContain('ledgers');
+    });
+
     test('keepMinimum=0 + maxDays=0 deletes everything older than now', async () => {
         await seedBackup(0.001);  // ~86s old
         await seedBackup(1);
@@ -236,7 +367,7 @@ test.describe('cleanOldBackups — configurable retention', () => {
 
     test('loads gitignored top-level AI config only when present', async () => {
         const loadedPaths = [];
-        const aiConfig = {
+        const aiConfig    = {
             async load(configPath) {
                 loadedPaths.push(configPath);
             }

--- a/test/playwright/unit/ai/scripts/maintenance/backup-retention.spec.mjs
+++ b/test/playwright/unit/ai/scripts/maintenance/backup-retention.spec.mjs
@@ -273,6 +273,41 @@ test.describe('cleanOldBackups — configurable retention', () => {
         expect(await listBackups(), 'the last artifact that can restore kb must not age out').toContain(ancientButReal);
     });
 
+    test('a MALFORMED bundle-meta cannot fill the floor — his probe deleted an older VALID bundle', async () => {
+        // @neo-gpt's exact probe, reproduced: newer malformed-meta + older valid, K=1, maxDays=30.
+        // `pathExists` alone answered "is there a file", so a corrupt receipt passed as a valid one,
+        // filled the floor, displaced the older valid bundle — and that bundle was DELETED. Data loss
+        // caused by the guard written to prevent data loss.
+        const newerMalformed = await seedBackup(1);
+        const olderValid     = await seedBackup(40);
+
+        await fs.writeFile(path.join(tmpRoot, newerMalformed, 'bundle-meta.json'), '{ this is not json');
+
+        await cleanOldBackups(tmpRoot, {log: () => {}, warn: () => {}}, {keepMinimum: 1, maxDays: 30});
+
+        const remaining = await listBackups();
+
+        expect(remaining, 'the older VALID bundle must survive a newer corrupt one').toContain(olderValid);
+        // And malformed is a HARD KEEP, not merely floor-ineligible: unknown state cannot be certified
+        // as a recovery source OR as disposable. Deliberately asymmetric with an ABSENT receipt, which
+        // stays age-deletable because absent is a known-incomplete capture.
+        expect(remaining, 'unknown state must not be destroyed on an age clock either').toContain(newerMalformed);
+    });
+
+    test('a JSON scalar is not a receipt — "null" parses cleanly and must not certify a bundle', async () => {
+        const {classifyBundleRecoverability} = await import('../../../../../../ai/scripts/maintenance/backup.mjs');
+
+        const scalarMeta = await seedBackup(1);
+        await fs.writeFile(path.join(tmpRoot, scalarMeta, 'bundle-meta.json'), 'null');
+
+        const verdict = await classifyBundleRecoverability(path.join(tmpRoot, scalarMeta));
+
+        // A try/catch around `readJson` alone would call this valid: `null` parses without throwing,
+        // so the bundle would be certified on the strength of four characters.
+        expect(verdict.metaState).toBe('malformed');
+        expect(verdict.hasMeta, 'a scalar must not satisfy hasMeta').toBe(false);
+    });
+
     test('an UNREADABLE payload is a hard keep — unknown recoverability is not empty', async () => {
         // The classifier's zero-bytes fallback once carried a comment claiming "under-counting keeps a
         // bundle, which is the safe error" — the opposite of what the code did. Under-counting made the


### PR DESCRIPTION
Resolves #16614

Operator asked whether the KB backup gets **KEPT and not REPLACED**, *"as it happened seven times already."* Nothing was deleted — and the measurement is worse than a deletion would have been.

## Observed on the live plane, 2026-08-07

`wc -l` on every bundle's `kb/*.jsonl` in the real backup root (`/Users/tobiasuhlig/.neo-ai/backups`):

| bundle | kb rows | meta |
|---|---|---|
| 07-31T04-57 | **0** | yes |
| 08-01T05-01 | **0** | yes |
| 08-01T12-13 | **61,206** | yes |
| 08-03T08-09 | 2,001 | **NO** |
| 08-03T21-37 | **59,754** | yes |
| 08-04T08-38 | **0** | yes |
| 08-04T08-55 | **0** | yes |
| 08-05T09-39 | **0** | yes |
| 08-05T19-05 | **0** | yes |
| **08-06T13-09 (newest)** | 16,550 | yes |

**Six of ten kept bundles carry zero KB rows, every one with a valid `bundle-meta.json`.** `keepMinimum: 3` counted directories, so the three newest — the entire recovery floor — held no restorable KB corpus. The 59,754-row bundle survived on **age alone**, four days inside a thirty-day bound, and nothing in the policy knew it was the only real one.

That is what the operator's phrase describes: no deletion event, a real bundle **buried behind newer bundles that pass every structural check and contain nothing**, aging toward a clock that has no idea what it is holding. Restore-the-newest — the obvious move — yields 16,550 degraded rows.

## Deltas

| Surface | Change |
|---|---|
| `classifyBundleRecoverability` | new — per-substrate payload bytes **AND** the receipt's own per-substrate integrity verdict |
| `isCompletedBundleReceipt` | new — a receipt is valid only with a non-empty `completedAt` and an `integrity` array |
| `RECOVERY_SUBSTRATES` | new — `kb`, `mc`, `graph`; optional substrates deliberately excluded |
| `cleanOldBackups` floor | directories → **per-substrate restorable bundles, unioned** |
| `cleanOldBackups` age rule | newest restorable per substrate outlives `maxDays` |
| unreadable / malformed bundles | **hard keep** — never age-deletable, never floor-filling |
| retention logging | names → per-substrate byte counts on every keep and drop, including age-held keeps |
| `backup-retention.spec.mjs` | 14 → **27** tests; `seedBackup` now emits real receipts |

Evidence: the table above, plus a dry-run of the new policy against those ten live bundles (below).

## Two design points where the obvious answer is wrong

**1. Bytes, not rows.** `wc -l` over a 3.3 GB JSONL on every sweep makes retention cost scale with corpus size, and buys nothing: **retention cannot judge *degraded*, only *empty*.** It does not know what a complete corpus is. The newest bundle here is 900 MB / 16,550 rows against an expected ~60,000 — non-empty by either measure. Claiming this guards against degradation would be an over-claim; it guards against *nothing to restore*, which is the failure that produced six bundles.

**2. The floor must be PER SUBSTRATE, and an any-substrate floor looks correct.** This is the error my first implementation shipped, and the **live dry-run caught it, not review**:

```
FLOOR (any-substrate, keepMinimum=3):
  KEEP 08-06T13-09  [kb,mc,graph]
  KEEP 08-05T19-05  [mc,graph]      ← no kb
  KEEP 08-05T09-39  [mc,graph]      ← no kb
```

Two of three slots held no `kb`, so the floor still protected exactly one kb-bearing bundle and the only full corpus was *still* on age alone. A floor satisfied by three bundles that all lack `kb` guarantees nothing about `kb`. After the fix:

```
FLOOR (per-substrate, unioned):
  KEEP 08-06T13-09  [kb,mc,graph]
  KEEP 08-05T19-05  [mc,graph]
  KEEP 08-05T09-39  [mc,graph]
  KEEP 08-03T21-37  [kb,mc,graph]   ← 59,754 rows
  KEEP 08-01T12-13  [kb,mc,graph]   ← 61,206 rows
kb-bearing bundles inside the floor: 3
```

Both full-corpus bundles are now protected by **policy** rather than by luck of the calendar — the AC's named pair.

## Two boundaries I chose deliberately

**`keepMinimum: 0` still purges everything.** The newest-restorable-per-substrate rule is gated on a positive floor. It exists to stop an **age clock** from deleting the last artifact that can restore a substrate — not to override an operator who explicitly asked to keep nothing. A purge the tool refuses to perform is a different tool. An existing test asserted exactly this and I treated it as authoritative rather than adjusting it.

**A meta-less bundle stays age-deletable.** It cannot fill the floor and cannot be last-known-good — a partial capture is not a verified recovery source, and one such bundle (2,001 rows, no meta) was sitting in the retention set as a peer of complete captures. But excluding it from *deletion* too would let residue accumulate forever, trading one unbounded-growth bug for another.

## What review moved: four times, one mechanism

@neo-gpt reproduced **deletion of the older good bundle** four times against four successive versions of the same guard. Each of my fixes was one level too shallow, and each one *looked* like the property:

| I certified a bundle on | his probe | what the check missed |
|---|---|---|
| `pathExists('bundle-meta.json')` | corrupt meta filled the floor | a file can exist and be unparseable |
| `typeof parsed === 'object'` | `{}` and `{garbage: 1}` certified | an object can carry no receipt |
| `isCompletedBundleReceipt(parsed)` | `kb: fail` + non-zero bytes certified | bytes prove non-empty, not *correct* |
| `restorableFor` — but only in the classifier | floor + newest-per-substrate still filtered on raw bytes | **fixing a verdict fixes nothing while its readers re-derive it** |

The last row is the one I would have shipped. I fixed `restorableFor`, and the `kb: fail` bundle still held kb's floor slot because two call sites had independently re-derived `substrates[substrate] > 0`. What caught it was that the test asserts the **destructive outcome**, not the classification: all three classification assertions passed and only the retention assertion failed. Had I tested `restorableFor` alone — the natural thing to write immediately after fixing `restorableFor` — I would have reported it done.

His formulation is now the comment on the rule, because it is better than mine: **bytes establish non-empty; `pass` establishes parity.** Neither is sufficient alone.

He also separated my premise from my granularity, which is why the fix kept mixed-receipt behaviour rather than over-correcting: a valid partial receipt need not be all-pass, so `kb: fail` + `mc: pass` still certifies **MC** independently. Collapsing to a whole-bundle verdict would either discard a usable MC source or certify an unusable KB one.

**Unknown is not empty.** The absent/malformed asymmetry is now explicit and has its own branch: absent meta → age-deletable; unreadable payload or malformed meta → **hard keep**, checked before every other rule. An earlier revision of this PR carried a comment claiming *"under-counting keeps a bundle, which is the safe error"* while under-counting made it **deletable** — the prose described the intent and the code did the opposite, and nothing failed.

## Test Evidence

```
npx playwright test test/playwright/unit/ai/scripts/maintenance/backup-retention.spec.mjs --workers=1
  27 passed (4.0s)
```

Directory-wide, the same tree reports `577 passed / 1 failed / 42 did not run`. **The one red is pre-existing on `dev` and host-state-dependent, not from this PR** — `backup.spec.mjs:104` performs a *real* backup of the live 728 MB host graph DB, which currently reports 294,347 rows by count and exports 294,337, so the capture verdict is `partial` and the assertion fails. The 42 are its serial-file siblings, aborted behind it.

Proving that took three attempts, and the first two were invalid controls worth recording:

| control attempt | result | why it proved nothing |
|---|---|---|
| worktree at `origin/dev` | `1 failed` | failed on a missing **gitignored** `config.mjs`, never reaching the export |
| + local configs copied | `1 passed` | `.neo-ai-data` is **repo-relative** — it built its own **4 KB empty** graph DB |
| + symlinked to the real 728 MB DB | `exported 294337/294347 · 1 failed` | valid: same spec, same ref-without-my-change, same database |

The middle row is the dangerous one: a green that would have let me call the failure mine and "fix" a non-defect. Right artifact, right ref, wrong witness. My diff's only touch outside `cleanOldBackups`/classification is import whitespace; `captureBackup`/`exportDatabase` are untouched.

Filed separately, both surfaced by this: the test's dependence on live host data, and the graph DB's 10-row count-vs-export gap (reported as `partial` with `skipped 0 unreadable`, so the rows are lost between count and scan without being classified).

`backup-retention.spec.mjs`: **27 tests**, up from 14. The pre-existing 14 kept their intent — `seedBackup` now produces a *real* bundle (meta + non-empty payload) by default, because a payload-less directory models the **empty** bundle, not the normal one, and that conflation is precisely what this change removes. `{restorable: false}` opts into the empty shape.

New coverage: the floor counting restorable bundles · the per-substrate distinction · newest-restorable outliving `maxDays` · meta-less excluded-but-reclaimable · `classifyBundleRecoverability` reporting an **empty-but-present** directory as not-restorable (a presence check would call those six bundles valid) · and a **control** proving retention still prunes normally when every bundle is restorable.

### The mutation that exposed a vacuous test of mine

I wrote the per-substrate test with **one** kb bundle. Mutating the floor back to any-substrate, it still passed — **22/22 against the implementation it was written to reject.** The single kb bundle was rescued by the newest-per-substrate rule under *both* designs, so the assertion measured nothing.

Fixed to **two** kb bundles: `recentKb` absorbs the newest-per-substrate rule, leaving `oldKb` protectable only by the floor. Re-mutated:

```
Error: kb needs its OWN slots; mc-only bundles must not consume them
  1 failed / 10 passed
```

Left in the spec as a comment rather than quietly corrected. It is the second time in this session that a guard of mine passed under the framing it claimed to reject — the fixture was realistic and therefore did not contain the hazard.

## Post-Merge Validation

- [ ] The next real backup's retention sweep logs **per-substrate byte counts** for each keep and drop. Observable in the run's stdout; this is what makes the six-empty-bundle accumulation auditable rather than requiring someone to have been watching.
- [ ] The two full-corpus bundles (`08-01T12-13`, `08-03T21-37`) are still present after the next sweep, and the log names them as floor-held rather than age-held.
- [ ] A sweep on a root where every bundle is restorable prunes the same set it would have before — the control, confirming a re-ranking rather than a disabling.

Not claimed: that the empty bundles stop being produced. That is #16563 (the export reports success on zero rows). The two are complements — a correct receipt stops producing them, a correct policy stops them from displacing real ones. **This PR assumes they will keep happening.**

## Scope held

- **The zero-row export** — #16563, whose body now carries this 6-of-10 dataset.
- **Why the KB half was empty on those runs** — #16563 / #16561 (backup starvation).
- **Deleting the existing empty bundles.** They are evidence for #16563; disposition is a follow-up.
- **Changing `maxDays`.** The bound is not the defect; what it was allowed to reach is.
- **Restore-side safety** — #16591 (refusal below the agent-facing surface), #16599 (merge identity).

Authored by @neo-opus-vega (Claude Opus 5).

