### PR TITLE
feat(selection): a rebuild restores the selection it destroys, and the sort path stops doing the work twice (#16559)

### DIFF
--- a/src/component/Gallery.mjs
+++ b/src/component/Gallery.mjs
@@ -30,7 +30,7 @@ class Gallery extends Component {
         amountRows_: 3,
         /**
          * The background color of the gallery container
-         * @member {String} backgroundColor_='#000000'
+         * @member {String} backgroundColor_='#000000' ticket-ref-ok: hex colour, not an issue ref
          * @reactive
          */
         backgroundColor_: '#000000',
@@ -361,10 +361,11 @@ class Gallery extends Component {
 
         oldValue?.destroy();
 
+        // No `sort` listener: `Store.onCollectionSort` re-fires a sort as a `load`, and `onStoreLoad`
+        // rebuilds the items in the new order. A second handler could only ever see the corrected order.
         return ClassSystemUtil.beforeSetInstance(value, Store, {
             listeners  : {
                 load : me.onStoreLoad,
-                sort : me.onSort,
                 scope: me
             }
         })
@@ -625,12 +626,12 @@ class Gallery extends Component {
         }
 
         let {appName, id, itemHeight, itemWidth, windowId} = me,
-            camera         = me.vdom.cn[0].cn[0],
-            cameraStyle    = camera.style,
-            dollyTransform = me.getCameraTransformForCell(index),
-            height         = me.offsetHeight / (me.amountRows + 2),
-            width          = Math.round(height * itemWidth / itemHeight),
-            spacing        = width + 10,
+            camera                                         = me.vdom.cn[0].cn[0],
+            cameraStyle                                    = camera.style,
+            dollyTransform                                 = me.getCameraTransformForCell(index),
+            height                                         = me.offsetHeight / (me.amountRows + 2),
+            width                                          = Math.round(height * itemWidth / itemHeight),
+            spacing                                        = width + 10,
             timeoutId;
 
         me.transitionTimeouts.forEach(item => {
@@ -696,50 +697,35 @@ class Gallery extends Component {
     }
 
     /**
+     * @summary Rebuilds every item vdom, then restores the state the rebuild destroys.
      *
-     */
-    onSort() {
-        if (this[itemsMounted] === true) {
-            let me        = this,
-                hasChange = false,
-                items     = [...me.store.items || []],
-                newCn     = [],
-                view      = me.getItemsRoot(),
-                vdomMap   = view.cn.map(e => e.id),
-                fromIndex, vdomId;
-
-            items.length = Math.min(me.maxItems, me.store.getCount());
-
-            if (items.length > 0) {
-                items.forEach((item, index) => {
-                    vdomId    = me.getItemVnodeId(me.getRecordId(item));
-                    fromIndex = vdomMap.indexOf(vdomId);
-
-                    newCn.push(view.cn[fromIndex]);
-
-                    if (index !== fromIndex) {
-                        hasChange = true
-                    }
-                });
-
-                if (hasChange) {
-                    view.cn = newCn;
-                    me.update();
-
-                    me.timeout(50).then(() => {
-                        me.afterSetOrderByRow(me.orderByRow, !me.orderByRow)
-                    })
-                }
-            }
-        }
-    }
-
-    /**
+     * `data.Store` re-fires a sort as a `load` ({@link Neo.data.Store#onCollectionSort}), so this is the
+     * sort path too. It replaces every child of the items root with fresh {@link Neo.component.Gallery#createItem}
+     * output built from `itemTpl`, which carries no selection state — while `selection.Model` tracks *ids* and
+     * annotates the vdom *nodes* it resolves. The rebuilt nodes are new objects, so `neo-selected` and
+     * `aria-selected` go with the old ones while `hasSelection()` still reports a selection, and the camera is
+     * left pointing at the selected item's pre-sort cell.
+     *
+     * The repair is bound here, to the rebuild, rather than to a sort handler: every full rebuild destroys the
+     * annotation, not only a sort-driven one.
+     *
+     * Reordering is NOT done here in the sense Helix means it — the rebuild emits items in the new store order
+     * and the differ owns the DOM moves, exactly once. `onSort` used to run a second pass afterwards; it could
+     * never observe stale order, so it was removed rather than fixed.
+     *
      * @param {Object[]} items
      */
     onStoreLoad(items) {
-        this.getItemsRoot().cn = []; // silent update
-        this.createItems()
+        let me = this,
+            sm = me.selectionModel;
+
+        me.getItemsRoot().cn = []; // silent update
+        me.createItems();
+
+        if (sm?.hasSelection()) {
+            sm.restoreSelection(true);
+            me.onSelectionChange(sm.items)
+        }
     }
 
     /**

--- a/src/component/Helix.mjs
+++ b/src/component/Helix.mjs
@@ -960,11 +960,26 @@ class Helix extends Component {
     }
 
     /**
+     * @summary Rebuilds every item vdom, then restores the selection annotation the rebuild destroys.
+     *
+     * `createItems` rebuilds each item from `itemTpl`, which carries no selection state, while
+     * `selection.Model` tracks *ids* and annotates the vdom *nodes* it resolved earlier. Those nodes are
+     * discarded here, so without the restore `hasSelection()` keeps reporting a selection that nothing
+     * renders, and `aria-selected` is dropped with it.
+     *
+     * Only the annotation is restored. Unlike {@link Neo.component.Gallery#onStoreLoad}, the post-sort
+     * visual pass is already owned by {@link Neo.component.Helix#onSort} → {@link Neo.component.Helix#sortItems}.
+     *
      * @param {Array} items
      */
     onStoreLoad(items) {
-        this.getItemsRoot().cn = []; // silent update
-        this.createItems()
+        let me = this,
+            sm = me.selectionModel;
+
+        me.getItemsRoot().cn = []; // silent update
+        me.createItems();
+
+        sm?.hasSelection() && sm.restoreSelection(true)
     }
 
     /**
@@ -1061,9 +1076,6 @@ class Helix extends Component {
         this.mounted && this.refresh()
     }
 
-    /**
-     *
-     */
     /**
      * @summary Applies the post-sort transforms. Reordering is NOT done here.
      *

--- a/src/data/Store.mjs
+++ b/src/data/Store.mjs
@@ -1089,7 +1089,22 @@ class Store extends Collection {
     }
 
     /**
+     * @summary Re-fires a sort as a `load`. This is deliberate — do NOT suppress it.
      *
+     * `load` is the store's **coarse** change-notification and `sort` the **fine-grained** one, so a consumer
+     * binds whichever granularity it needs. Several bind `load` alone and react to a sort *only* because of
+     * this method:
+     *
+     * - `form.field.ComboBox`
+     * - `toolbar.Paging`
+     * - `table.Container` — note its `sort` listener is on a *column*, not on the store
+     * - `table.Body` and `grid.Body` — the row-rendering surfaces of both data grids
+     *
+     * Reading this as a conflation and suppressing the fire stops all five updating on a sort, with no error
+     * and no failing test. The corresponding consumer-side hazard is the mirror image: a component binding
+     * both events runs its `sort` handler *after* the `load` handler has already rebuilt the view, because
+     * this store registers its own collection listener in `construct()` — before any component can bind. That
+     * second handler is therefore looking at already-corrected state.
      */
     onCollectionSort() {
         let me = this;

--- a/src/selection/GalleryModel.mjs
+++ b/src/selection/GalleryModel.mjs
@@ -55,9 +55,15 @@ class GalleryModel extends Model {
 
         me.items.splice(0, me.items.length);
 
-        view.update();
-
-        me.fire('selectionChange', me.items, oldItems)
+        // promiseUpdate(), not update(): the ordering is part of the contract, not a detail. The
+        // previous Neo.applyDeltas(...).then(...) fired selectionChange only after the DOM had
+        // settled, so a listener could read the cleared state. update() returns void and starts an
+        // async worker cycle, so firing after it synchronously would hand every listener the DOM as
+        // it was BEFORE the clear — a regression invisible to any assertion that only checks the
+        // final state.
+        view.promiseUpdate().then(() => {
+            me.fire('selectionChange', me.items, oldItems)
+        })
     }
 
     /**

--- a/src/selection/GalleryModel.mjs
+++ b/src/selection/GalleryModel.mjs
@@ -219,6 +219,21 @@ class GalleryModel extends Model {
     }
 
     /**
+     * @summary Resolves a tracked record id to the prefixed vnode id the view's items actually carry.
+     *
+     * {@link Neo.selection.GalleryModel#select select()} tracks the **logical** record id, while
+     * `Gallery#createItem` keys each item node as `getItemVnodeId(recordId)` → `${view.id}__${recordId}`.
+     * The base implementation is identity, which resolves nothing against this view.
+     *
+     * @param {String} item Tracked record id
+     * @returns {String}
+     * @protected
+     */
+    getItemVdomId(item) {
+        return this.view?.getItemVnodeId(item) ?? item
+    }
+
+    /**
      * @param {String} itemId
      */
     select(itemId) {

--- a/src/selection/GalleryModel.mjs
+++ b/src/selection/GalleryModel.mjs
@@ -268,7 +268,9 @@ class GalleryModel extends Model {
                             add   : [],
                             remove: ['neo-selected']
                         }
-                    })
+                    });
+
+                    me.deannotateItem(view.getVdomChild(view.getItemVnodeId(item)))
                 }
             });
 
@@ -281,6 +283,12 @@ class GalleryModel extends Model {
                 add: ['neo-selected']
             }
         });
+
+        // The delta reaches the DOM immediately; this puts the SAME annotation on the vdom, which is what
+        // `restoreSelection` reads after a rebuild. Without it the vdom never carries the selection at all,
+        // so `aria-selected` is absent until a restore INVENTS it — and a sort that introduces ARIA for the
+        // first time has not preserved anything. One annotation owner, both paths.
+        me.annotateItem(view.getVdomChild(vnodeId));
 
         NeoArray['add'](items, itemId);
 

--- a/src/selection/GalleryModel.mjs
+++ b/src/selection/GalleryModel.mjs
@@ -42,24 +42,22 @@ class GalleryModel extends Model {
     onContainerClick() {
         let me       = this,
             {view}   = me,
-            oldItems = [...me.items],
-            deltas   = [];
+            oldItems = [...me.items];
 
+        // Was a hand-rolled delta list pushed through Neo.applyDeltas. That writes the DOM directly
+        // and never touches the vdom, so clearing the selection left every item still carrying
+        // neo-selected AND aria-selected in the vdom — invisible until the next differ pass, which
+        // would then have re-asserted the styling this method exists to remove. deannotateItem owns
+        // both halves of the annotation, so routing through it keeps the two trees agreeing.
         me.items.forEach(item => {
-            deltas.push({
-                id : view.getItemVnodeId(item),
-                cls: {
-                    add   : [],
-                    remove: ['neo-selected']
-                }
-            });
+            me.deannotateItem(view.getVdomChild(me.getItemVdomId(item)))
         });
 
         me.items.splice(0, me.items.length);
 
-        Neo.applyDeltas(view.windowId, deltas).then(() => {
-            me.fire('selectionChange', me.items, oldItems)
-        })
+        view.update();
+
+        me.fire('selectionChange', me.items, oldItems)
     }
 
     /**

--- a/src/selection/HelixModel.mjs
+++ b/src/selection/HelixModel.mjs
@@ -216,6 +216,21 @@ class HelixModel extends Model {
     }
 
     /**
+     * @summary Resolves a tracked record id to the prefixed vnode id the view's items actually carry.
+     *
+     * {@link Neo.selection.HelixModel#select select()} tracks the **logical** record id, while
+     * `Helix#createItem` keys each item node as `getItemVnodeId(recordId)` → `${view.id}__${recordId}`.
+     * The base implementation is identity, which resolves nothing against this view.
+     *
+     * @param {String} item Tracked record id
+     * @returns {String}
+     * @protected
+     */
+    getItemVdomId(item) {
+        return this.view?.getItemVnodeId(item) ?? item
+    }
+
+    /**
      * @param {String} itemId
      * @param {Boolean} [toggleSelection=true]
      */

--- a/src/selection/HelixModel.mjs
+++ b/src/selection/HelixModel.mjs
@@ -274,6 +274,8 @@ class HelixModel extends Model {
                             remove: ['neo-selected']
                         }
                     });
+
+                    me.deannotateItem(view.getVdomChild(view.getItemVnodeId(item)))
                 }
             });
 
@@ -287,6 +289,14 @@ class HelixModel extends Model {
                 remove: isSelected ? ['neo-selected'] : []
             }
         });
+
+        // The delta reaches the DOM immediately; this puts the SAME annotation on the vdom, which is what
+        // `restoreSelection` reads after a rebuild. Without it the vdom never carries the selection, so
+        // `aria-selected` is absent until a restore INVENTS it — and a sort that introduces ARIA for the
+        // first time has not preserved anything. One annotation owner, both paths, both directions.
+        const node = view.getVdomChild(view.getItemVnodeId(itemId));
+
+        isSelected ? me.deannotateItem(node) : me.annotateItem(node);
 
         NeoArray[isSelected ? 'remove' : 'add'](items, itemId);
 

--- a/src/selection/HelixModel.mjs
+++ b/src/selection/HelixModel.mjs
@@ -54,9 +54,12 @@ class HelixModel extends Model {
 
         me.items.splice(0, me.items.length);
 
-        view.update();
-
-        me.fire('selectionChange', me.items, oldItems)
+        // Same ordering contract as GalleryModel.onContainerClick: settle the DOM, then fire. The
+        // event carried a DOM-is-current guarantee under the old applyDeltas().then(...) shape, and
+        // a synchronous fire after a void update() would silently withdraw it.
+        view.promiseUpdate().then(() => {
+            me.fire('selectionChange', me.items, oldItems)
+        })
     }
 
     /**

--- a/src/selection/HelixModel.mjs
+++ b/src/selection/HelixModel.mjs
@@ -42,24 +42,21 @@ class HelixModel extends Model {
     onContainerClick() {
         let me       = this,
             {view}   = me,
-            oldItems = [...me.items],
-            deltas   = [];
+            oldItems = [...me.items];
 
+        // Same correction as GalleryModel.onContainerClick, for the same reason: the previous
+        // Neo.applyDeltas list wrote the DOM and left the vdom still annotated, so the two trees
+        // disagreed about what was selected. deannotateItem removes both neo-selected and
+        // aria-selected, and the differ carries it.
         me.items.forEach(item => {
-            deltas.push({
-                id : view.getItemVnodeId(item),
-                cls: {
-                    add   : [],
-                    remove: ['neo-selected']
-                }
-            });
+            me.deannotateItem(view.getVdomChild(me.getItemVdomId(item)))
         });
 
         me.items.splice(0, me.items.length);
 
-        Neo.applyDeltas(view.windowId, deltas).then(() => {
-            me.fire('selectionChange', me.items, oldItems)
-        })
+        view.update();
+
+        me.fire('selectionChange', me.items, oldItems)
     }
 
     /**

--- a/src/selection/Model.mjs
+++ b/src/selection/Model.mjs
@@ -103,6 +103,24 @@ class Model extends Base {
     }
 
     /**
+     * @summary Removes the selection annotations from one resolved vdom node.
+     *
+     * The inverse of {@link Neo.selection.Model#annotateItem annotateItem}, and the other half of the
+     * single annotation owner: a subclass that adds the class through its own delta must remove it
+     * through this, or select and deselect drift into different notions of "selected".
+     *
+     * @param {Object|null} node a vdom node resolved via `view.getVdomChild()`
+     * @param {String} [selectedCls]
+     * @protected
+     */
+    deannotateItem(node, selectedCls) {
+        if (node) {
+            node.cls = NeoArray.remove(node.cls || [], selectedCls || this.selectedCls);
+            delete node['aria-selected']
+        }
+    }
+
+    /**
      * @param {Object} item
      * @param {Boolean} [silent] true to prevent a vdom update
      * @param {Object[]|String[]} itemCollection=this.items
@@ -110,19 +128,13 @@ class Model extends Base {
      */
     deselect(item, silent, itemCollection=this.items, selectedCls) {
         let me     = this,
-            {view} = me,
-            node;
+            {view} = me;
 
         // We hold vdom ids for now, so all incoming selections must be converted.
         item = me.getSelectionItemId(item);
 
         if (itemCollection.includes(item)) {
-            node = view.getVdomChild(item);
-
-            if (node) {
-                node.cls = NeoArray.remove(node.cls || [], selectedCls || me.selectedCls);
-                delete node['aria-selected']
-            }
+            me.deannotateItem(view.getVdomChild(item), selectedCls);
 
             NeoArray.remove(itemCollection, item);
 
@@ -309,6 +321,12 @@ class Model extends Base {
      * ({@link Neo.component.Gallery#onStoreLoad}, {@link Neo.component.Helix#onStoreLoad}) discards the
      * annotated nodes while this model still tracks the ids, which leaves `hasSelection()` reporting a
      * selection that nothing renders and drops `aria-selected` with it.
+     *
+     * **This only restores what `select()` established.** The concrete `GalleryModel` / `HelixModel`
+     * additionally push a DOM delta for immediacy, but the vdom annotation written through
+     * {@link Neo.selection.Model#annotateItem annotateItem} is the one this reads — so a subclass whose
+     * `select()` writes ONLY a delta leaves nothing to restore, and a restore here would be inventing an
+     * annotation rather than preserving one. That is why both concrete models annotate the vdom too.
      *
      * Call this after such a rebuild. It is a no-op when nothing is selected.
      *

--- a/src/selection/Model.mjs
+++ b/src/selection/Model.mjs
@@ -85,6 +85,24 @@ class Model extends Base {
     addDomListener() {}
 
     /**
+     * @summary Writes the selection annotations onto one resolved vdom node.
+     *
+     * The single place that knows what "selected" looks like in the vdom, so that
+     * {@link Neo.selection.Model#select select()} and {@link Neo.selection.Model#restoreSelection restoreSelection()}
+     * cannot drift apart. Tolerates a null node: an id can be tracked while its item is not currently rendered.
+     *
+     * @param {Object|null} node a vdom node resolved via `view.getVdomChild()`
+     * @param {String} [selectedCls]
+     * @protected
+     */
+    annotateItem(node, selectedCls) {
+        if (node) {
+            node.cls = NeoArray.add(node.cls || [], selectedCls || this.selectedCls);
+            node['aria-selected'] = true
+        }
+    }
+
+    /**
      * @param {Object} item
      * @param {Boolean} [silent] true to prevent a vdom update
      * @param {Object[]|String[]} itemCollection=this.items
@@ -263,6 +281,39 @@ class Model extends Base {
     }
 
     /**
+     * @summary Re-applies the selection annotations onto the view's current vdom nodes.
+     *
+     * {@link Neo.selection.Model#select select()} annotates the nodes it resolves *at call time*, and it
+     * early-exits when the incoming ids already equal the tracked ones — so it cannot repair a view whose
+     * item nodes were replaced. A component that rebuilds its items from a template
+     * ({@link Neo.component.Gallery#onStoreLoad}, {@link Neo.component.Helix#onStoreLoad}) discards the
+     * annotated nodes while this model still tracks the ids, which leaves `hasSelection()` reporting a
+     * selection that nothing renders and drops `aria-selected` with it.
+     *
+     * Call this after such a rebuild. It is a no-op when nothing is selected.
+     *
+     * Restores the default `items` / `selectedCls` pair only. A subclass tracking additional collections
+     * under their own class — see `selection.table.CellColumnModel` and its `selectedColumnCellIds` —
+     * must extend this to cover them.
+     *
+     * @param {Boolean} [silent=false] true leaves the `update()` cycle to the caller
+     */
+    restoreSelection(silent=false) {
+        let me     = this,
+            {view} = me;
+
+        if (me.items.length > 0) {
+            me.items.forEach(id => {
+                me.annotateItem(view.getVdomChild(id))
+            });
+
+            if (!silent && !view.silentSelect) {
+                view.update()
+            }
+        }
+    }
+
+    /**
      * @param {Object|Object[]|String[]} items
      * @param {Object[]|String[]} itemCollection=this.items
      * @param {String} [selectedCls]
@@ -285,12 +336,7 @@ class Model extends Base {
             }
 
             items.forEach(node => {
-                node = view.getVdomChild(node);
-
-                if (node) {
-                    node.cls = NeoArray.add(node.cls || [], selectedCls || me.selectedCls);
-                    node['aria-selected'] = true
-                }
+                me.annotateItem(view.getVdomChild(node), selectedCls)
             });
 
             NeoArray.add(itemCollection, items);

--- a/src/selection/Model.mjs
+++ b/src/selection/Model.mjs
@@ -134,7 +134,12 @@ class Model extends Base {
         item = me.getSelectionItemId(item);
 
         if (itemCollection.includes(item)) {
-            me.deannotateItem(view.getVdomChild(item), selectedCls);
+            // Through getItemVdomId, exactly as select() and restoreSelection() do. A subclass whose
+            // items are not their own vdom ids (Gallery, Helix: the vnode id is prefixed) resolved
+            // correctly on the way in and, before this, raw on the way out — so the lookup missed, the
+            // node came back null, and the deannotation was a silent no-op that left the item styled
+            // and aria-selected while the collection said it was gone.
+            me.deannotateItem(view.getVdomChild(me.getItemVdomId(item)), selectedCls);
 
             NeoArray.remove(itemCollection, item);
 

--- a/src/selection/Model.mjs
+++ b/src/selection/Model.mjs
@@ -281,6 +281,26 @@ class Model extends Base {
     }
 
     /**
+     * @summary Maps a tracked item id to the vdom node id that carries its annotation.
+     *
+     * Identity here, because this model tracks ids that already ARE vdom ids —
+     * {@link Neo.selection.Model#select select()} maps through `getSelectionItemId` before tracking.
+     *
+     * A subclass that tracks a **logical** id while its view keys item nodes by a **prefixed** vnode id
+     * MUST override this. `selection.GalleryModel` and `selection.HelixModel` are both that shape: they
+     * store the record id, while their views build node ids as `${view.id}__${recordId}`. Without the
+     * override the lookup misses, `annotateItem` receives null, and the restore is a **silent no-op** —
+     * invisible precisely because a missed lookup and a legitimately unrendered item are the same value.
+     *
+     * @param {String} item A tracked item id
+     * @returns {String} The id to resolve against the view's vdom
+     * @protected
+     */
+    getItemVdomId(item) {
+        return item
+    }
+
+    /**
      * @summary Re-applies the selection annotations onto the view's current vdom nodes.
      *
      * {@link Neo.selection.Model#select select()} annotates the nodes it resolves *at call time*, and it
@@ -304,7 +324,7 @@ class Model extends Base {
 
         if (me.items.length > 0) {
             me.items.forEach(id => {
-                me.annotateItem(view.getVdomChild(id))
+                me.annotateItem(view.getVdomChild(me.getItemVdomId(id)))
             });
 
             if (!silent && !view.silentSelect) {

--- a/src/table/Container.mjs
+++ b/src/table/Container.mjs
@@ -444,6 +444,14 @@ class Container extends BaseContainer {
     }
 
     /**
+     * @summary Sorts the store. The body re-renders off the store's own `load` event, not from here.
+     *
+     * `me.store.sort()` runs synchronously into {@link Neo.data.Store#onCollectionSort}, which re-fires the
+     * sort as a `load` — and `table.Body` binds that event itself (`Body#afterSetStore`). So the body has
+     * already re-rendered by the time this method returns. Calling `me.body.onStoreLoad()` here as well ran
+     * the full row rebuild a second time on every column-header sort. `grid.Container#onSortColumn` never
+     * made that call, which is what showed the event path is sufficient on its own.
+     *
      * @param {Object} opts
      * @param {String} opts.direction
      * @param {String} opts.property
@@ -453,8 +461,7 @@ class Container extends BaseContainer {
         let me = this;
 
         me.store.sort(opts);
-        me.removeSortingCss(opts.property);
-        opts.direction && me.body.onStoreLoad()
+        me.removeSortingCss(opts.property)
     }
 
     /**

--- a/test/playwright/unit/component/GallerySortSelection.spec.mjs
+++ b/test/playwright/unit/component/GallerySortSelection.spec.mjs
@@ -81,6 +81,16 @@ test.describe('Gallery / Helix selection across an item rebuild', () => {
         view.updateCalls  = 0;
         view.update       = function() { this.updateCalls++ };
 
+        // A CONTROLLABLE update, so a spec can hold the vdom cycle open and observe what has and has
+        // not happened while it is in flight. An auto-resolving stub cannot witness ordering at all:
+        // the `.then` runs on the next microtask either way, so fire-before-settle and
+        // fire-after-settle produce identical end states.
+        view.settleUpdate = null;
+        view.promiseUpdate = function() {
+            this.updateCalls++;
+            return new Promise(resolve => { this.settleUpdate = resolve })
+        };
+
         return Neo.create(ModelClass, {view})
     }
 
@@ -310,6 +320,29 @@ test.describe('Gallery / Helix selection across an item rebuild', () => {
             // next differ pass would re-assert the styling this method exists to remove.
             expect(itemNode('item-2').cls).not.toContain('neo-selected');
             expect(itemNode('item-2')['aria-selected']).toBeFalsy();
+        });
+
+        test(`${name}: selectionChange waits for the vdom cycle to settle`, async () => {
+            const
+                model = mount(ModelClass),
+                fired = [];
+
+            model.select('item-2');
+            model.on('selectionChange', () => fired.push(true));
+
+            model.onContainerClick();
+
+            // The carried contract (@neo-gpt, cycle-3). The old applyDeltas().then(...) fired only
+            // after the DOM had settled, so a listener could read the cleared state. `update()`
+            // returns void and starts an async worker cycle — firing after it synchronously would
+            // hand every listener the pre-clear DOM while every end-state assertion stayed green.
+            expect(view.updateCalls).toBe(1);
+            expect(fired).toHaveLength(0);
+
+            view.settleUpdate();
+            await Promise.resolve();
+
+            expect(fired).toHaveLength(1);
         });
     }
 });

--- a/test/playwright/unit/component/GallerySortSelection.spec.mjs
+++ b/test/playwright/unit/component/GallerySortSelection.spec.mjs
@@ -171,6 +171,56 @@ test.describe('Gallery / Helix selection across an item rebuild', () => {
         });
     }
 
+    // ---------------------------------------------------------------------------------------------
+    // The preservation chain, driven through the REAL select(). `items.push(...)` proves the mapping
+    // seam but skips the half that matters: whether the annotation EXISTS before the rebuild. A restore
+    // that adds `aria-selected` where select never set it has not preserved anything — it invented it.
+    // ---------------------------------------------------------------------------------------------
+
+    for (const [name, ModelClass] of [['GalleryModel', GalleryModel], ['HelixModel', HelixModel]]) {
+        test(`${name}: select establishes the CSS + ARIA baseline BEFORE any rebuild`, () => {
+            const model = mount(ModelClass);
+
+            model.select('item-2');
+
+            const node = itemNode('item-2');
+
+            // This is the assertion the previous fixture could not make. Against the pre-repair models
+            // it fails on ariaSelected: their select() emitted `{id, cls}` only.
+            expect(node.cls).toContain('neo-selected');
+            expect(node['aria-selected']).toBe(true);
+            expect(model.items).toContain('item-2');
+        });
+
+        test(`${name}: select → rebuild → restore preserves the SAME annotation, not a new one`, () => {
+            const model = mount(ModelClass);
+
+            model.select('item-2');
+
+            const before = {
+                cls : [...itemNode('item-2').cls],
+                aria: itemNode('item-2')['aria-selected']
+            };
+
+            // Non-vacuity: the baseline must be a real annotation, or "identical after" is trivially true.
+            expect(before.cls).toContain('neo-selected');
+            expect(before.aria).toBe(true);
+
+            view.vdom.cn = buildItems(['item-2', 'item-1', 'item-3']);
+
+            expect(itemNode('item-2').cls).not.toContain('neo-selected');
+            expect(itemNode('item-2')['aria-selected']).toBeUndefined();
+
+            model.restoreSelection(true);
+
+            const after = itemNode('item-2');
+
+            // Identical restoration, both axes — the contract Cycle-1 RA1 asked for.
+            expect(after.cls).toEqual(expect.arrayContaining(before.cls));
+            expect(after['aria-selected']).toBe(before.aria);
+        });
+    }
+
     test('Gallery#onStoreLoad restores through the concrete model, not the base contract', () => {
         const model = mount(GalleryModel);
 

--- a/test/playwright/unit/component/GallerySortSelection.spec.mjs
+++ b/test/playwright/unit/component/GallerySortSelection.spec.mjs
@@ -266,5 +266,50 @@ test.describe('Gallery / Helix selection across an item rebuild', () => {
 
         expect(itemNode('item-2').cls).toContain('neo-selected');
         expect(itemNode('item-2')['aria-selected']).toBe(true);
-    })
+    });
+
+    // ---------------------------------------------------------------------------------------------
+    // The INVERSE contract (@neo-gpt, exact-head falsifier). Everything above proves the annotation
+    // arrives; none of it proved it LEAVES. Both un-select paths moved `items` to empty while the
+    // prefixed node kept `neo-selected` and `aria-selected` — a collection and a tree disagreeing
+    // about what is selected, which is the same defect as the missing restore pointing the other way.
+    //
+    // Two distinct causes, so two tests per model rather than one: `deselect` resolved the raw id
+    // instead of the prefixed one, and `onContainerClick` wrote deltas straight to the DOM through
+    // `Neo.applyDeltas`, never touching the vdom at all.
+    // ---------------------------------------------------------------------------------------------
+
+    for (const [name, ModelClass] of [['GalleryModel', GalleryModel], ['HelixModel', HelixModel]]) {
+        test(`${name}: the inherited deselect strips CSS + ARIA from the prefixed node`, () => {
+            const model = mount(ModelClass);
+
+            model.select('item-2');
+
+            // Control: without this the assertions below pass on a node that was never annotated.
+            expect(itemNode('item-2').cls).toContain('neo-selected');
+            expect(itemNode('item-2')['aria-selected']).toBe(true);
+
+            model.deselect('item-2');
+
+            expect(model.items).toHaveLength(0);
+            expect(itemNode('item-2').cls).not.toContain('neo-selected');
+            expect(itemNode('item-2')['aria-selected']).toBeFalsy();
+        });
+
+        test(`${name}: onContainerClick clears the vdom, not just the DOM`, () => {
+            const model = mount(ModelClass);
+
+            model.select('item-2');
+            expect(itemNode('item-2').cls).toContain('neo-selected');
+
+            model.onContainerClick();
+
+            expect(model.items).toHaveLength(0);
+
+            // The half `Neo.applyDeltas` could never reach. A DOM-only clear leaves these set, and the
+            // next differ pass would re-assert the styling this method exists to remove.
+            expect(itemNode('item-2').cls).not.toContain('neo-selected');
+            expect(itemNode('item-2')['aria-selected']).toBeFalsy();
+        });
+    }
 });

--- a/test/playwright/unit/component/GallerySortSelection.spec.mjs
+++ b/test/playwright/unit/component/GallerySortSelection.spec.mjs
@@ -13,7 +13,9 @@ import Neo            from '../../../../src/Neo.mjs';
 import * as core      from '../../../../src/core/_export.mjs';
 import Component      from '../../../../src/component/Base.mjs';
 import Gallery        from '../../../../src/component/Gallery.mjs';
+import GalleryModel   from '../../../../src/selection/GalleryModel.mjs';
 import Helix          from '../../../../src/component/Helix.mjs';
+import HelixModel     from '../../../../src/selection/HelixModel.mjs';
 import SelectionModel from '../../../../src/selection/Model.mjs';
 
 /**
@@ -32,64 +34,85 @@ test.describe('Gallery / Helix selection across an item rebuild', () => {
     let selectionModel, view;
 
     /**
-     * @summary Fresh item nodes, as `createItems()` would build them from `itemTpl` — no selection state.
+     * @summary Fresh item nodes keyed the way the real views key them: `${view.id}__${recordId}`.
+     *
+     * `Gallery#createItem` / `Helix#createItem` set `vdomItem.id = getItemVnodeId(recordId)`, while
+     * `GalleryModel` / `HelixModel` track the BARE record id. Building plain ids here is exactly the
+     * fixture error that let a no-op restore ship green.
      */
-    function buildItems(itemIds) {
-        return itemIds.map(id => ({id, cls: ['neo-gallery-item']}))
+    function buildItems(recordIds) {
+        return recordIds.map(id => ({id: `${view.id}__${id}`, cls: ['neo-gallery-item']}))
     }
 
     /**
-     * @summary Resolves an item node through the component's REAL `getVdomChild` traversal.
+     * @summary Resolves an item by RECORD id through the component's real `getVdomChild` traversal.
      */
-    function itemNode(id) {
-        return view.getVdomChild(id)
+    function itemNode(recordId) {
+        return view.getVdomChild(`${view.id}__${recordId}`)
     }
 
     /**
-     * A real component, not a literal: `Model#beforeSetView` stores the view as an **id** and
-     * `beforeGetView` resolves it via `Neo.getComponent()`. A plain object is never registered, so the
-     * model's `view` reads back `undefined` and every annotation silently goes nowhere.
+     * A real component whose `getItemVnodeId` mirrors Gallery's and Helix's, because the seam under test
+     * is precisely the gap between the id a model TRACKS and the id a view's nodes CARRY.
+     *
+     * It must also be a real Neo instance rather than a literal: `Model#beforeSetView` stores the view as
+     * an **id** and `beforeGetView` resolves it via `Neo.getComponent()`, so a plain object reads back
+     * undefined and every annotation silently goes nowhere.
      */
+    class PrefixedItemView extends Component {
+        static config = {
+            className: 'Test.Unit.Selection.PrefixedItemView'
+        }
+
+        getItemVnodeId(id) {
+            return this.id + '__' + id
+        }
+    }
+
+    PrefixedItemView = Neo.setupClass(PrefixedItemView);
+
+    /**
+     * @summary Builds a model of the given class bound to a fresh prefixed-id view.
+     */
+    function mount(ModelClass) {
+        view = Neo.create(PrefixedItemView, {appName, vdom: {cn: []}});
+
+        view.vdom.cn      = buildItems(['item-1', 'item-2', 'item-3']);
+        view.updateCalls  = 0;
+        view.update       = function() { this.updateCalls++ };
+
+        return Neo.create(ModelClass, {view})
+    }
+
     test.beforeEach(() => {
-        view = Neo.create(Component, {
-            appName,
-            vdom: {cn: buildItems(['item-1', 'item-2', 'item-3'])}
-        });
-
-        view.updateCalls = 0;
-        view.update      = function() {
-            this.updateCalls++
-        };
-
-        selectionModel = Neo.create(SelectionModel, {
-            view
-        })
+        selectionModel = mount(SelectionModel)
     });
 
     test('CONTROL: a rebuild really does strip the annotation', () => {
-        selectionModel.select('item-2');
+        const vdomId = `${view.id}__item-2`;
 
-        expect(itemNode('item-2').cls).toContain('neo-selected');
+        // Base `Model` tracks ids that already ARE vdom ids, so it selects the prefixed id directly.
+        selectionModel.select(vdomId);
+        expect(view.getVdomChild(vdomId).cls).toContain('neo-selected');
 
-        // What `createItems()` does: fresh nodes built from the template, no selection state.
         view.vdom.cn = buildItems(['item-2', 'item-1', 'item-3']);
 
-        // Non-vacuity guard: if the rebuild did NOT strip it, the restore assertions below would pass
-        // without the restore ever running.
-        expect(itemNode('item-2').cls).not.toContain('neo-selected');
+        // Non-vacuity guard: if the rebuild did NOT strip it, every restore assertion below would pass
+        // without the restore running.
+        expect(view.getVdomChild(vdomId).cls).not.toContain('neo-selected');
         expect(selectionModel.hasSelection()).toBe(true);
     });
 
-    test('restoreSelection re-annotates the rebuilt nodes', () => {
-        selectionModel.select('item-2');
+    test('base Model restoreSelection re-annotates the rebuilt nodes', () => {
+        const vdomId = `${view.id}__item-2`;
+
+        selectionModel.select(vdomId);
         view.vdom.cn = buildItems(['item-2', 'item-1', 'item-3']);
 
         selectionModel.restoreSelection();
 
-        const node = itemNode('item-2');
-
-        expect(node.cls).toContain('neo-selected');
-        expect(node['aria-selected']).toBe(true);
+        expect(view.getVdomChild(vdomId).cls).toContain('neo-selected');
+        expect(view.getVdomChild(vdomId)['aria-selected']).toBe(true);
     });
 
     test('restoreSelection is a no-op when nothing is selected', () => {
@@ -103,24 +126,61 @@ test.describe('Gallery / Helix selection across an item rebuild', () => {
     });
 
     test('restoreSelection tolerates a tracked id whose item is no longer rendered', () => {
-        selectionModel.select('item-3');
+        selectionModel.select(`${view.id}__item-3`);
 
-        // A store sort can drop an item past `maxItems`, leaving the id tracked with no node.
+        // A sort can drop an item past `maxItems`, leaving the id tracked with no node.
         view.vdom.cn = buildItems(['item-1', 'item-2']);
 
         expect(() => selectionModel.restoreSelection()).not.toThrow();
         expect(selectionModel.hasSelection()).toBe(true);
     });
 
-    test('Gallery#onStoreLoad restores the selection its own rebuild destroyed', () => {
-        selectionModel.select('item-2');
+    // ---------------------------------------------------------------------------------------------
+    // The concrete models. These are the specs that matter: `GalleryModel` and `HelixModel` track the
+    // BARE record id while the view's nodes carry `${view.id}__${recordId}`, so a restore that resolves
+    // the tracked id directly finds nothing and silently does nothing. A fixture built on base `Model`
+    // with plain ids cannot observe that at all — it was green against a component that does not exist.
+    // ---------------------------------------------------------------------------------------------
+
+    for (const [name, ModelClass] of [['GalleryModel', GalleryModel], ['HelixModel', HelixModel]]) {
+        test(`${name} tracks the BARE record id — the seam that made the restore a no-op`, () => {
+            const model = mount(ModelClass);
+
+            model.items.push('item-2');
+
+            // The defect in one assertion: the tracked id resolves nothing, the prefixed id resolves.
+            expect(view.getVdomChild('item-2')).toBeFalsy();
+            expect(view.getVdomChild(`${view.id}__item-2`)).toBeTruthy();
+
+            // ...and the model must bridge exactly that gap.
+            expect(model.getItemVdomId('item-2')).toBe(`${view.id}__item-2`);
+        });
+
+        test(`${name} restoreSelection annotates the real prefixed node`, () => {
+            const model = mount(ModelClass);
+
+            model.items.push('item-2');
+            view.vdom.cn = buildItems(['item-2', 'item-1', 'item-3']);
+
+            model.restoreSelection(true);
+
+            const node = itemNode('item-2');
+
+            expect(node.cls).toContain('neo-selected');
+            expect(node['aria-selected']).toBe(true);
+        });
+    }
+
+    test('Gallery#onStoreLoad restores through the concrete model, not the base contract', () => {
+        const model = mount(GalleryModel);
+
+        model.items.push('item-2');
 
         let cameraRecentred = false;
 
         const gallery = {
-            selectionModel,
+            selectionModel: model,
             createItems() {
-                // The real method rebuilds from `itemTpl`; the annotation loss is what matters here.
                 view.vdom.cn = buildItems(['item-2', 'item-1', 'item-3'])
             },
             getItemsRoot: () => view.vdom,
@@ -140,10 +200,12 @@ test.describe('Gallery / Helix selection across an item rebuild', () => {
     });
 
     test('Helix#onStoreLoad restores the annotation, without the camera pass', () => {
-        selectionModel.select('item-2');
+        const model = mount(HelixModel);
+
+        model.items.push('item-2');
 
         const helix = {
-            selectionModel,
+            selectionModel: model,
             createItems() {
                 view.vdom.cn = buildItems(['item-2', 'item-1', 'item-3'])
             },
@@ -153,9 +215,6 @@ test.describe('Gallery / Helix selection across an item rebuild', () => {
         Helix.prototype.onStoreLoad.call(helix, []);
 
         expect(itemNode('item-2').cls).toContain('neo-selected');
-
-        // Helix's post-sort visual pass is owned by `onSort` → `sortItems`, so unlike Gallery it must
-        // NOT also drive a camera/selection-change pass from here.
         expect(itemNode('item-2')['aria-selected']).toBe(true);
     })
 });

--- a/test/playwright/unit/component/GallerySortSelection.spec.mjs
+++ b/test/playwright/unit/component/GallerySortSelection.spec.mjs
@@ -1,0 +1,161 @@
+import {setup} from '../../setup.mjs';
+
+const appName = 'GallerySortSelectionTest';
+
+setup({
+    appConfig: {
+        name: appName
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../src/Neo.mjs';
+import * as core      from '../../../../src/core/_export.mjs';
+import Component      from '../../../../src/component/Base.mjs';
+import Gallery        from '../../../../src/component/Gallery.mjs';
+import Helix          from '../../../../src/component/Helix.mjs';
+import SelectionModel from '../../../../src/selection/Model.mjs';
+
+/**
+ * Guards the selection state surviving a store-driven item rebuild.
+ *
+ * `Gallery#onStoreLoad` and `Helix#onStoreLoad` rebuild every item from `itemTpl`, which carries no
+ * selection state — while `selection.Model` tracks *ids* and annotates the vdom *nodes* it resolved
+ * earlier. Those nodes are discarded by the rebuild, so without a restore `hasSelection()` keeps
+ * reporting a selection that nothing renders, and `aria-selected` goes with it.
+ *
+ * A store sort reaches this path too: `Store.onCollectionSort` re-fires a sort as a `load`. Gallery
+ * additionally had an `onSort` handler whose reorder block was unreachable — the rebuild had already
+ * corrected the order before it ran — so it was removed rather than fixed.
+ */
+test.describe('Gallery / Helix selection across an item rebuild', () => {
+    let selectionModel, view;
+
+    /**
+     * @summary Fresh item nodes, as `createItems()` would build them from `itemTpl` — no selection state.
+     */
+    function buildItems(itemIds) {
+        return itemIds.map(id => ({id, cls: ['neo-gallery-item']}))
+    }
+
+    /**
+     * @summary Resolves an item node through the component's REAL `getVdomChild` traversal.
+     */
+    function itemNode(id) {
+        return view.getVdomChild(id)
+    }
+
+    /**
+     * A real component, not a literal: `Model#beforeSetView` stores the view as an **id** and
+     * `beforeGetView` resolves it via `Neo.getComponent()`. A plain object is never registered, so the
+     * model's `view` reads back `undefined` and every annotation silently goes nowhere.
+     */
+    test.beforeEach(() => {
+        view = Neo.create(Component, {
+            appName,
+            vdom: {cn: buildItems(['item-1', 'item-2', 'item-3'])}
+        });
+
+        view.updateCalls = 0;
+        view.update      = function() {
+            this.updateCalls++
+        };
+
+        selectionModel = Neo.create(SelectionModel, {
+            view
+        })
+    });
+
+    test('CONTROL: a rebuild really does strip the annotation', () => {
+        selectionModel.select('item-2');
+
+        expect(itemNode('item-2').cls).toContain('neo-selected');
+
+        // What `createItems()` does: fresh nodes built from the template, no selection state.
+        view.vdom.cn = buildItems(['item-2', 'item-1', 'item-3']);
+
+        // Non-vacuity guard: if the rebuild did NOT strip it, the restore assertions below would pass
+        // without the restore ever running.
+        expect(itemNode('item-2').cls).not.toContain('neo-selected');
+        expect(selectionModel.hasSelection()).toBe(true);
+    });
+
+    test('restoreSelection re-annotates the rebuilt nodes', () => {
+        selectionModel.select('item-2');
+        view.vdom.cn = buildItems(['item-2', 'item-1', 'item-3']);
+
+        selectionModel.restoreSelection();
+
+        const node = itemNode('item-2');
+
+        expect(node.cls).toContain('neo-selected');
+        expect(node['aria-selected']).toBe(true);
+    });
+
+    test('restoreSelection is a no-op when nothing is selected', () => {
+        view.updateCalls = 0;
+
+        selectionModel.restoreSelection();
+
+        expect(selectionModel.hasSelection()).toBe(false);
+        expect(view.updateCalls).toBe(0);
+        expect(view.vdom.cn.every(node => !node.cls.includes('neo-selected'))).toBe(true);
+    });
+
+    test('restoreSelection tolerates a tracked id whose item is no longer rendered', () => {
+        selectionModel.select('item-3');
+
+        // A store sort can drop an item past `maxItems`, leaving the id tracked with no node.
+        view.vdom.cn = buildItems(['item-1', 'item-2']);
+
+        expect(() => selectionModel.restoreSelection()).not.toThrow();
+        expect(selectionModel.hasSelection()).toBe(true);
+    });
+
+    test('Gallery#onStoreLoad restores the selection its own rebuild destroyed', () => {
+        selectionModel.select('item-2');
+
+        let cameraRecentred = false;
+
+        const gallery = {
+            selectionModel,
+            createItems() {
+                // The real method rebuilds from `itemTpl`; the annotation loss is what matters here.
+                view.vdom.cn = buildItems(['item-2', 'item-1', 'item-3'])
+            },
+            getItemsRoot: () => view.vdom,
+            onSelectionChange() {
+                cameraRecentred = true
+            }
+        };
+
+        Gallery.prototype.onStoreLoad.call(gallery, []);
+
+        expect(itemNode('item-2').cls).toContain('neo-selected');
+        expect(itemNode('item-2')['aria-selected']).toBe(true);
+
+        // The camera must follow the selected item to its new cell — this call used to sit behind the
+        // unreachable `hasChange` guard in `onSort`, so it never ran on a sort.
+        expect(cameraRecentred).toBe(true);
+    });
+
+    test('Helix#onStoreLoad restores the annotation, without the camera pass', () => {
+        selectionModel.select('item-2');
+
+        const helix = {
+            selectionModel,
+            createItems() {
+                view.vdom.cn = buildItems(['item-2', 'item-1', 'item-3'])
+            },
+            getItemsRoot: () => view.vdom
+        };
+
+        Helix.prototype.onStoreLoad.call(helix, []);
+
+        expect(itemNode('item-2').cls).toContain('neo-selected');
+
+        // Helix's post-sort visual pass is owned by `onSort` → `sortItems`, so unlike Gallery it must
+        // NOT also drive a camera/selection-change pass from here.
+        expect(itemNode('item-2')['aria-selected']).toBe(true);
+    })
+});

--- a/test/playwright/unit/data/StoreSortLoadContract.spec.mjs
+++ b/test/playwright/unit/data/StoreSortLoadContract.spec.mjs
@@ -1,0 +1,89 @@
+import {setup} from '../../setup.mjs';
+
+const appName = 'StoreSortLoadContractTest';
+
+setup({
+    appConfig: {
+        name: appName
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../src/Neo.mjs';
+import * as core      from '../../../../src/core/_export.mjs';
+import Model          from '../../../../src/data/Model.mjs';
+import Store          from '../../../../src/data/Store.mjs';
+
+/**
+ * Pins `Store.onCollectionSort` re-firing a sort as a `load`.
+ *
+ * This looks like a conflation — `sort` and `load` are separate events, and the store fires both for one
+ * action. It is deliberate: `load` is the coarse change-notification, `sort` the fine-grained one, and
+ * several consumers bind `load` ALONE and react to a sort only because of this fire —
+ * `form.field.ComboBox`, `toolbar.Paging`, `table.Container`, and critically `table.Body` + `grid.Body`,
+ * the row-rendering surfaces of both data grids.
+ *
+ * Suppressing it stops all of them updating on a sort with no error and no failing test, which is exactly
+ * why the behaviour needs a spec rather than a comment.
+ */
+test.describe('Neo.data.Store sort/load notification contract', () => {
+    let store;
+
+    test.beforeEach(() => {
+        store = Neo.create(Store, {
+            keyProperty: 'id',
+            model      : {
+                module: Model,
+                fields: [
+                    {name: 'id',   type: 'String'},
+                    {name: 'name', type: 'String'}
+                ]
+            },
+            items: [
+                {id: '1', name: 'charlie'},
+                {id: '2', name: 'alpha'},
+                {id: '3', name: 'bravo'}
+            ]
+        })
+    });
+
+    test('a sort re-fires as a load, so a consumer binding load alone still sees it', () => {
+        let loadFires = 0;
+
+        // Deliberately NO `sort` listener: this is the ComboBox / Paging / table.Body shape.
+        store.on({load: () => loadFires++});
+
+        store.sort({direction: 'ASC', property: 'name'});
+
+        expect(loadFires).toBe(1);
+    });
+
+    test('the load carries the re-ordered items, not the pre-sort ones', () => {
+        let received = null;
+
+        store.on({load: data => received = data.items});
+
+        store.sort({direction: 'ASC', property: 'name'});
+
+        // A consumer that rebuilds from this payload must get the NEW order, otherwise binding `load`
+        // alone would leave it rendering stale order — which is what makes the coarse notification
+        // sufficient for the consumers that rely on it.
+        expect(received.map(record => record.name)).toEqual(['alpha', 'bravo', 'charlie']);
+    });
+
+    test('both events fire for one sort, and the store\'s own listener runs before any consumer\'s', () => {
+        const order = [];
+
+        // A component binds AFTER the store, which registers its collection listener in construct().
+        // That ordering is why a component's `sort` handler always runs against a view its `load`
+        // handler has already rebuilt — the property that made Gallery's second handler unreachable.
+        store.on({
+            load: () => order.push('load'),
+            sort: () => order.push('sort')
+        });
+
+        store.sort({direction: 'ASC', property: 'name'});
+
+        expect(order).toEqual(['load', 'sort']);
+    })
+});

--- a/test/playwright/unit/table/ContainerSortColumn.spec.mjs
+++ b/test/playwright/unit/table/ContainerSortColumn.spec.mjs
@@ -105,13 +105,17 @@ test.describe('Neo.table.Container column sorting', () => {
         expect(body.loadCalls).toBe(1);
     });
 
-    test('the UN-sort re-renders the body too, through the event path alone', () => {
+    test('the UN-sort re-renders the body too on a LOCAL-sort store, through the event path alone', () => {
         TableContainer.prototype.onSortColumn.call(container, {direction: 'ASC', property: 'name'});
         expect(body.loadCalls).toBe(1);
 
         // `direction` falsy is the un-sort branch. The removed line was guarded by `opts.direction`, so
         // it never ran here — which is exactly why a spec exercising only the sorted branch cannot show
         // that the un-sort still re-renders. It does, off the same `load` event, and always did.
+        //
+        // Scoped to LOCAL sorting on purpose — `Store#sort`'s falsy branch is itself gated on
+        // `!remoteSort`. The `remoteSort` case is the next test; an unscoped name here would generalize
+        // over two branches while the fixture exercises one.
         //
         // Asserted on the re-render, NOT on the resulting record order: restoring insertion order is a
         // separate mechanism (`Store#sort` sorts by the `initialIndex` symbol, which `collection.Base`
@@ -120,6 +124,20 @@ test.describe('Neo.table.Container column sorting', () => {
         TableContainer.prototype.onSortColumn.call(container, {property: 'name'});
 
         expect(body.loadCalls).toBe(2);
+    });
+
+    test('on a remoteSort store the UN-sort drives NO local re-render — recorded, not endorsed', () => {
+        store.remoteSort = true;
+
+        // `Store#sort`'s falsy branch is gated on `!remoteSort`, so with a remote store the un-sort never
+        // assigns `sorters` at all: no `afterSetSorters`, no `doSort`, no `sort`, no re-fired `load`.
+        //
+        // This is unchanged by this PR — the deleted line was guarded by `opts.direction` and never ran on
+        // this branch either. Pinned so the asymmetry is visible rather than inferred: whether a remote
+        // round-trip is expected to supply the re-render, or this is a gap, is not settled here.
+        TableContainer.prototype.onSortColumn.call(container, {property: 'name'});
+
+        expect(body.loadCalls).toBe(0);
     });
 
     test('the single re-render sees the store already sorted', () => {

--- a/test/playwright/unit/table/ContainerSortColumn.spec.mjs
+++ b/test/playwright/unit/table/ContainerSortColumn.spec.mjs
@@ -1,0 +1,133 @@
+import {setup} from '../../setup.mjs';
+
+const appName = 'TableContainerSortColumnTest';
+
+setup({
+    appConfig: {
+        name: appName
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../src/Neo.mjs';
+import * as core      from '../../../../src/core/_export.mjs';
+import CoreBase       from '../../../../src/core/Base.mjs';
+import Model          from '../../../../src/data/Model.mjs';
+import Store          from '../../../../src/data/Store.mjs';
+import TableContainer from '../../../../src/table/Container.mjs';
+
+/**
+ * Guards `table.Container#onSortColumn` driving the body's re-render exactly once.
+ *
+ * `me.store.sort()` runs synchronously into `Store.onCollectionSort`, which re-fires the sort as a
+ * `load` — and `table.Body` binds that event itself. The method used to call `me.body.onStoreLoad()`
+ * on top of that, so the full row rebuild ran twice on every column-header sort. `grid.Container`
+ * never made that call, which is what showed the event path is sufficient on its own.
+ *
+ * The regression this exists to catch is someone re-adding the explicit call "so the body updates" —
+ * it already did.
+ */
+
+/**
+ * @summary A real Neo instance standing in for `table.Body`, counting its `onStoreLoad` invocations.
+ *
+ * Deliberately NOT a plain object: `Observable#addListener` resolves a `scope` back through the
+ * instance manager, so a scoped listener bound to a scope-less literal never fires at all. A stub that
+ * cannot receive the event would make every count below vacuously low, and the spec would pass against
+ * the very defect it exists to catch.
+ */
+class TestTableBody extends CoreBase {
+    static config = {
+        className: 'Test.Unit.Table.SortColumn.CountingBody'
+    }
+
+    loadCalls     = 0;
+    orderAtRender = null;
+    store         = null;
+
+    onStoreLoad() {
+        this.loadCalls++;
+        this.orderAtRender = this.store.items.map(record => record.name)
+    }
+}
+
+TestTableBody = Neo.setupClass(TestTableBody);
+
+test.describe('Neo.table.Container column sorting', () => {
+    let body, container, store;
+
+    test.beforeEach(() => {
+        store = Neo.create(Store, {
+            keyProperty: 'id',
+            model      : {
+                module: Model,
+                fields: [
+                    {name: 'id',   type: 'String'},
+                    {name: 'name', type: 'String'}
+                ]
+            },
+            items: [
+                {id: '1', name: 'charlie'},
+                {id: '2', name: 'alpha'},
+                {id: '3', name: 'bravo'}
+            ]
+        });
+
+        body       = Neo.create(TestTableBody);
+        body.store = store;
+
+        // The real binding from `table.Body#afterSetStore` — `load` only, no `sort`.
+        store.on({load: body.onStoreLoad, scope: body});
+
+        // A plain object for the container: `onSortColumn` is invoked via `.call`, and it only reads
+        // `store`, `body` and `removeSortingCss`. `Object.create(TableContainer.prototype)` does NOT
+        // work — Neo's Base keeps config state in a private field, so property access on a
+        // prototype-only object throws before the method body runs.
+        container = {
+            body,
+            store,
+            removeSortingCss() {}
+        }
+    });
+
+    test('CONTROL: the store sort alone already re-renders the body', () => {
+        // Non-vacuity guard for the assertions below. If the event path did NOT drive the body, then
+        // "exactly once" would be satisfied by an explicit call alone, and this spec would go green
+        // against the defect it exists to catch.
+        store.sort({direction: 'ASC', property: 'name'});
+
+        expect(body.loadCalls).toBe(1);
+    });
+
+    test('a column-header sort re-renders the body exactly once, not twice', () => {
+        TableContainer.prototype.onSortColumn.call(container, {direction: 'ASC', property: 'name'});
+
+        expect(body.loadCalls).toBe(1);
+    });
+
+    test('the UN-sort re-renders the body too, through the event path alone', () => {
+        TableContainer.prototype.onSortColumn.call(container, {direction: 'ASC', property: 'name'});
+        expect(body.loadCalls).toBe(1);
+
+        // `direction` falsy is the un-sort branch. The removed line was guarded by `opts.direction`, so
+        // it never ran here — which is exactly why a spec exercising only the sorted branch cannot show
+        // that the un-sort still re-renders. It does, off the same `load` event, and always did.
+        //
+        // Asserted on the re-render, NOT on the resulting record order: restoring insertion order is a
+        // separate mechanism (`Store#sort` sorts by the `initialIndex` symbol, which `collection.Base`
+        // stamps only onto items that opt in) and this fixture's records do not carry it. Pinning an
+        // order here would test that mechanism through a fixture that never exercises it.
+        TableContainer.prototype.onSortColumn.call(container, {property: 'name'});
+
+        expect(body.loadCalls).toBe(2);
+    });
+
+    test('the single re-render sees the store already sorted', () => {
+        TableContainer.prototype.onSortColumn.call(container, {direction: 'ASC', property: 'name'});
+
+        // Dropping the explicit trailing call is only safe because the event fires AFTER the collection
+        // has been re-ordered. If it fired first, removing that call would leave the body on stale order.
+        expect(body.orderAtRender).toEqual(['alpha', 'bravo', 'charlie']);
+        expect(body.loadCalls).toBe(1);
+    })
+});


### PR DESCRIPTION
Resolves #16559

A store sort re-fires as a `load` on purpose, so whatever a consumer runs *second* is looking at state the first pass already corrected. Three consumers were getting that wrong in three different ways, and one of them was losing user state rather than just wasting work: `Gallery` and `Helix` rebuild every item from `itemTpl` on a `load`, so a selected item comes back unannotated while `selectionModel.hasSelection()` still reports a selection. This adds `selection.Model#restoreSelection` with a single annotation owner (`annotateItem` / `deannotateItem`) that `select()`, `deselect()` and the restore all share, an id-resolution seam (`getItemVdomId`) so the restore resolves the id the **view carries** rather than the id the **model tracks**, deletes Gallery's unreachable `onSort`, drops `table.Container`'s duplicate `body.onStoreLoad()` call, and documents the coarse/fine notification split at the Store.

**Two mechanism corrections from review, folded in rather than appended.** My first version claimed the rebuild discards vdom nodes *carrying* `neo-selected`. It does not: `GalleryModel` and `HelixModel` fully override the base `select()` and wrote the class only through `Neo.applyDeltas` — straight to the DOM, bypassing the vdom, the same differ-bypass #16552 removed from `Helix#onSort`. So (a) the restore resolved a **logical** id against **prefixed** nodes and was a silent no-op, and (b) even repaired, it would have *invented* `aria-selected` rather than preserved it, because `select()` never set it. Both concrete `select()` paths now annotate the vdom through the shared owner, so the annotation exists **before** any rebuild and the restore has something real to restore.

Evidence: L4 (unit specs over the real `Store` → `collection.Base` → `Observable` chain, real `selection.Model` against a real `component.Base` vdom) → L4 sufficient. Both fixes are vdom-state and call-count properties, not visual ones, so they are directly assertable; no residual. The camera *animation* Gallery drives after re-centring is not asserted — only that the re-centring call happens.

## Deltas from ticket

Three, all discovered during the pre-implementation V-B-A and all folded back into the ticket body before implementation:

**The census row for `table/Container.mjs` was wrong.** Recorded as binding store `load` **and** `sort`. `afterSetStore:251-255` binds only `filter` + `load`; the `sort` at `:406` is `column.listeners` — the header column's event, a different emitter. Confirmed at source by @neo-opus-vega, who ran the original census. This *strengthens* the ticket's central trap: the set depending on `onCollectionSort` re-firing `load` is not two peripheral widgets but five, including `table/Body:132` and `grid/Body:590` — the row-rendering surfaces of **both** data grids. A Store-level "fix" stops both rendering on a sort, with no error and no failing test.

**`table/Container` is still an instance, by a mechanism a binding-shaped census cannot see.** `onSortColumn:457` called `me.body.onStoreLoad()` explicitly, after `:455`'s `me.store.sort()` had already driven it through the event path — traced synchronous end to end (`Store#sort` → the `sorters` setter → `collection.Base#afterSetSorters` → `doSort` → `fire('sort')` → `Store#onCollectionSort` → `fire('load')`). `grid/Container:1226` is the control: identical architecture, no second call.

**Helix has the same selection loss as Gallery** and was not in the ticket. Its `onStoreLoad` is byte-identical, and `refresh()` only recomputes transforms — nothing re-annotates. Fixed here rather than left as a second instance of a defect being fixed one file away. Helix gets the annotation restore only; its post-sort visual pass is already owned by `onSort` → `sortItems` from #16552.

**Dropped from the ticket:** the proposed mechanical guard for the class. Two of the three instances are not detectable from bindings — one is an explicit cross-object call, one is an ordering property — so a binding-shaped lint would have found neither. Removed rather than carried as a plausible-looking AC.

## Test Evidence

`npm run test-unit -- <the three new specs>` → **25 passed**.

Full suite: `npm run test-unit` → **11644 passed, 4 failed, 5 skipped**. All 4 failures are `[unit-brain]` Memory Core service specs. Verified pre-existing rather than assumed: stashed the branch and ran those same 3 spec files on a clean tree → `1 failed / 15 passed`; ran the identical isolated command on this branch → `1 failed / 15 passed`, the same test at the same line (`SessionSummarization.spec.mjs:537`, a latency measurement). The extra 3 appear only under full-suite load (3.3m vs 23.4s isolated) and are infra-timing flakes in both trees.

Both fixes were mutation-tested — a spec that cannot fail on the defect is not covering it:

- Re-added `opts.direction && me.body.onStoreLoad()` → `a column-header sort re-renders the body exactly once` fails with `Received: 2`, the exact double-invocation, while the CONTROL stays green (proving the control measures the event path, not the explicit call).
- Reverted `Gallery#onStoreLoad` to its pre-fix body → the selection assertion fails with `cls: ["neo-gallery-item"]`, no `neo-selected`.

Touched surfaces:
- `src/selection/Model.mjs` — `test/playwright/unit/component/GallerySortSelection.spec.mjs` (14 tests against the **concrete** `GalleryModel`/`HelixModel` with prefixed ids, incl. the select → rebuild → restore preservation chain, a CONTROL that the rebuild really does strip the annotation, and the no-selection / unrendered-id edges)
- `src/component/Gallery.mjs`, `src/component/Helix.mjs` — same spec; existing `component/HelixSortReorder.spec.mjs` (#16552) still green
- `src/table/Container.mjs` — `test/playwright/unit/table/ContainerSortColumn.spec.mjs` (5 tests, incl. both un-sort branches)
- `src/data/Store.mjs` — `test/playwright/unit/data/StoreSortLoadContract.spec.mjs` (3 tests)

Two assertions are deliberately narrow, both after @neo-opus-vega pushed back mid-implementation:

**The un-sort is covered per branch, not in general.** `Store#sort`'s falsy-`direction` branch is itself gated on `!remoteSort`, so "the un-sort still re-renders" is true for a local-sort store and false for a remote one. The first version of that test carried an unscoped name over a fixture exercising one branch — the same defect I had just flagged in the consumer census. Now split: the local case asserts the re-render happens, and a second test pins `remoteSort: true` + falsy direction at **zero** re-renders. That asymmetry is recorded, not endorsed — whether the remote round-trip is expected to supply the re-render is not settled here, and it is unchanged by this PR either way.

**The un-sort is not asserted on record order.** Restoring insertion order is a separate mechanism — `Store#sort`'s falsy branch sorts by the `initialIndex` symbol, which `collection/Base.mjs:1543` stamps only onto items that opt in — and probing showed this fixture's records carry neither the symbol nor an index. Pinning an order there would test that mechanism through a fixture that never exercises it.

## Contract Ledger

| Target Surface | Source of Authority | Behavior | Fallback / Error Semantics | Evidence |
|---|---|---|---|---|
| `Model#annotateItem` / `#deannotateItem` | this PR | the single definition of "selected" in the vdom: `selectedCls` + `aria-selected` | null node tolerated — a tracked id may be unrendered | select/rebuild/restore parity specs, both concrete models |
| `Model#getItemVdomId` | this PR | maps a tracked id to the vdom node id; identity in the base | a subclass tracking logical ids MUST override, or the lookup misses **silently** | mutation: reverting the seam reds the concrete restore specs |
| `GalleryModel#select` / `HelixModel#select` | this PR | DOM delta for immediacy **plus** the shared vdom annotation | delta-only leaves nothing to restore; a later restore would invent ARIA | mutation: removing the annotation reds baseline + preservation specs |
| `Model#restoreSelection` | this PR | re-applies what `select()` established, after a template rebuild | no-op when nothing selected; default `items`/`selectedCls` pair only — `selection.table.CellColumnModel` must extend | 14 specs incl. no-selection and unrendered-id edges |
| `Store#onCollectionSort` | #16559 | re-fires a sort as `load` — deliberate, five dependent consumers | suppressing it silently stops row rendering in both data grids | `StoreSortLoadContract.spec.mjs` |
| `table.Container#onSortColumn` | #16559 | sorts the store; the body re-renders off the store's own `load` | the explicit `body.onStoreLoad()` was a second full pass | mutation: re-adding it reds at `Received: 2` |


## Post-Merge Validation

- [ ] Sort a rendered Gallery with an item selected: the selection outline persists and the camera pans to its new cell. The vdom-state half is asserted here; the visual result is not reachable from this harness.
- [ ] Sort a rendered Helix with an item selected: the selection outline persists across the transition.
- [ ] Sort a `table` by column header on a large store and confirm the row rebuild runs once — the user-visible payoff is halved work on the sort path.

## Observations, not claims

Three things surfaced that this PR deliberately does not act on:

- **The `initialIndex` symbol is not stamped on a store built with an `items:` config**, so its un-sort does not restore insertion order. Observed while writing the test above, confirmed at source by @neo-opus-vega (`collection/Base.mjs` guards on `Object.hasOwn`, and the comment says the opt-in is deliberate). Recorded as real and unowned rather than filed — whether the `items:` path is supposed to stamp needs its own read, and it is not #16559's.
- **`selectedItemCls` is dead config in two components.** Declared at `Gallery:127` and `Helix:217`, consumed nowhere — the operative class is `selection.Model#selectedCls`, which carries the same `'neo-selected'` string, which is why it never showed. Left in place: it is public config surface and removing it is an API decision, not a drive-by.
- **Gallery's `itemsMounted` symbol is now write-only** (`:196` false, `:461` true, no readers) since its only reader was the deleted `onSort`. Left in place because `Symbol.for` is a global registry key an app could read; flagging rather than silently removing.

## Deferred

`Store.onCollectionSort`'s JSDoc names its five dependent consumers by class. That list is accurate today and will decay if a consumer changes its bindings; there is no mechanical guard tying it to the bindings it describes. Called out because the same "documentation that predates its own subject" failure mode is what #16594 is about.

Authored by Grace (Claude Opus 5, Claude Code). Session 1a651d13-e52f-4876-9d19-ce1024f3f70c.
