### PR TITLE
fix(orchestrator): an attempt that never returns is still an attempt (#16551)

### DIFF
--- a/ai/daemons/orchestrator/services/TenantRepoSyncService.mjs
+++ b/ai/daemons/orchestrator/services/TenantRepoSyncService.mjs
@@ -1105,6 +1105,16 @@ class TenantRepoSyncService extends Base {
         // are different things with different lifetimes, and one object cannot be both.
         const inFlightAttempts = {};
 
+        // Identity for compare-and-commit. `await leaseGuard()` followed by a write is a
+        // check-then-act: the lease can expire and a successor legitimately acquire in the window
+        // between them, and the resumed predecessor's whole-file write then DELETES the
+        // successor's record. Fencing the write harder only narrows that window; it cannot close
+        // it, because the check and the write are separate syscalls no lock spans for free.
+        //
+        // So the record carries its owner and every mutation is conditional on it. The last
+        // writer no longer wins by virtue of being last — it wins only on keys it owns.
+        const runId = randomBytes(8).toString('hex');
+
         // Serialized through one chain: the sidecar is mutated from inside the concurrent per-repo
         // region, and `writeInFlightAttempts` stages through a single pid-scoped temp path that
         // concurrent writers would otherwise race on.
@@ -1114,16 +1124,32 @@ class TenantRepoSyncService extends Base {
             inFlightChain = inFlightChain.then(async () => {
                 update(inFlightAttempts);
 
-                // Lease-fenced, because this is a whole-file write of THIS sweep's view. A run that
-                // lost its lease must not clobber the successor that now owns forward progress —
-                // its stale clear would otherwise delete an attempt the successor has in flight.
-                // Swallowed rather than propagated: losing the sidecar write is bounded (one
-                // unrecorded attempt), whereas throwing from the per-repo `finally` would mask the
-                // real error the repo failed with.
                 try {
                     await leaseGuard();
-                    await this.writeInFlightAttempts({filePath: inFlightPath, attempts: inFlightAttempts});
-                } catch (e) {}
+
+                    // Re-read INSIDE the critical section and merge against live state rather than
+                    // publishing this sweep's whole view. Entries owned by another run are carried
+                    // forward untouched; only our own are written or removed. A successor that took
+                    // over after the guard check above therefore keeps its record, and our stale
+                    // write becomes a no-op on its key instead of a deletion.
+                    const
+                        live   = await this.readInFlightAttempts({filePath: inFlightPath}),
+                        merged = {};
+
+                    for (const [label, entry] of Object.entries(live)) {
+                        if (entry?.runId !== runId) merged[label] = entry;
+                    }
+
+                    for (const [label, entry] of Object.entries(inFlightAttempts)) {
+                        merged[label] = entry;
+                    }
+
+                    await this.writeInFlightAttempts({filePath: inFlightPath, attempts: merged});
+                } catch (e) {
+                    // Swallowed rather than propagated: losing a sidecar write costs one unrecorded
+                    // attempt, whereas throwing from the per-repo `finally` would mask the real
+                    // error the repo failed with.
+                }
             });
 
             return inFlightChain
@@ -1322,7 +1348,8 @@ class TenantRepoSyncService extends Base {
                 await mutateInFlight(attempts => {
                     attempts[repoLabel] = {
                         startedMs,
-                        priorFailures: priorState?.consecutiveFailures ?? 0
+                        priorFailures: priorState?.consecutiveFailures ?? 0,
+                        runId
                     };
                 });
                 inFlightRecorded = true;

--- a/ai/daemons/orchestrator/services/TenantRepoSyncService.mjs
+++ b/ai/daemons/orchestrator/services/TenantRepoSyncService.mjs
@@ -1100,7 +1100,7 @@ class TenantRepoSyncService extends Base {
          * @param {Function} work Receives `assertStillOwned`; returns nothing meaningful.
          * @returns {Promise<Boolean>} Whether the transaction committed.
          */
-        const withSidecarTransaction = async work => {
+        const withSidecarTransaction = async (work, {bestEffort = true} = {}) => {
             let guard = null;
 
             try {
@@ -1123,9 +1123,16 @@ class TenantRepoSyncService extends Base {
                 await work(assertStillOwned);
                 return true
             } catch (e) {
-                // Swallowed rather than propagated: losing a sidecar write costs one unrecorded
-                // attempt, whereas throwing from the per-repo `finally` would mask the real error
-                // the repo failed with.
+                // `bestEffort` is per CALLER, not per helper. A sidecar write is genuinely
+                // best-effort: losing it costs one unrecorded attempt, and throwing from the
+                // per-repo `finally` would mask the real error the repo failed with. The RECOVERY
+                // caller is not — it commits the manifest, whose writer deliberately throws
+                // `KB_TENANT_REPO_SYNC_MANIFEST_UPDATE_FAILED` as a structural failure the outer
+                // task must surface. Swallowing every callback error uniformly turned that
+                // documented reason code into a silent `false`, which is a failure-taxonomy
+                // regression dressed as tidiness.
+                if (!bestEffort) throw e;
+
                 return false
             } finally {
                 if (guard) {
@@ -1152,8 +1159,20 @@ class TenantRepoSyncService extends Base {
             // Clearing first would lose the attempt on a crash, which is the defect this recovers
             // from.
             await this.writePersistedRevisions({filePath: resolvedRevisionsPath, revisions: persistedRevisions});
+
+            // Re-proved because these are TWO mutations, not one. `writePersistedRevisions` is a
+            // multi-await transaction (temp write, fsync, close, rename); a holder can pass the
+            // check above, stall inside that I/O past `guardStaleAfterMs`, be legitimately evicted,
+            // and resume here after a successor has acquired and written its own sidecar. One proof
+            // cannot cover two mutations separated by unbounded I/O.
+            //
+            // Declining to clear is the safe direction: the residue is re-folded next sweep, which
+            // over-counts one failure and dampens harder. Clearing it while evicted would delete a
+            // successor's live record.
+            if (!await assertStillOwned()) return;
+
             await this.writeInFlightAttempts({filePath: inFlightPath, attempts: {}});
-        });
+        }, {bestEffort: false});
 
         // The live in-flight map is a FRESH object, never the recovery snapshot. Reusing
         // `residualAttempts` as the live map republished entries the fold had already consumed:

--- a/ai/daemons/orchestrator/services/TenantRepoSyncService.mjs
+++ b/ai/daemons/orchestrator/services/TenantRepoSyncService.mjs
@@ -40,7 +40,8 @@ import {
 } from './heavyMaintenanceLeasePrimitives.mjs';
 import {
     enterLifecycleGuard,
-    exitLifecycleGuard
+    exitLifecycleGuard,
+    verifyLifecycleGuardOwnership
 } from '../../shared/lifecycleGuard.mjs';
 import {
     classifyTenantRepoCheckpoint,
@@ -1084,24 +1085,75 @@ class TenantRepoSyncService extends Base {
         // Folded BEFORE the due checks so a crashed attempt dampens the very next decision
         // rather than one sweep later — the whole point is that a crash loop cannot outrun
         // its own backoff.
-        const
-            inFlightPath     = this.inFlightAttemptsPath(resolvedRevisionsPath),
-            residualAttempts = await this.readInFlightAttempts({filePath: inFlightPath}),
-            foldedCount      = this.foldInFlightAttempts({
-                attempts: residualAttempts,
-                persistedRevisions,
-                writeLog
-            });
+        const inFlightPath = this.inFlightAttemptsPath(resolvedRevisionsPath);
 
-        if (foldedCount > 0) {
-            await leaseGuard();
-            // Commit FIRST, clear second. A crash between the two re-folds the same attempt on
-            // the next boot, which over-counts one failure and dampens harder — the safe
-            // direction. Clearing first would lose the attempt on a crash, which is exactly the
-            // defect this recovers from.
+        /**
+         * Runs `work` inside the lease's own lifecycle guard, which is the only mutex that orders
+         * sidecar mutation against lease ACQUISITION — a sidecar-only lock would serialize writers
+         * while a successor took the lease underneath them.
+         *
+         * `work` receives an `assertStillOwned` probe it MUST await immediately before mutating.
+         * That is the guard's documented contract, not belt-and-braces: a holder stalled past
+         * `guardStaleAfterMs` can be legitimately evicted, and a resumed evicted holder has to
+         * DEFER rather than write.
+         *
+         * @param {Function} work Receives `assertStillOwned`; returns nothing meaningful.
+         * @returns {Promise<Boolean>} Whether the transaction committed.
+         */
+        const withSidecarTransaction = async work => {
+            let guard = null;
+
+            try {
+                if (leasePath) {
+                    guard = await enterLifecycleGuard({leasePath, fsModule: fs});
+
+                    // FAIL CLOSED. `enterLifecycleGuard` returns null once its bounded retry
+                    // budget is exhausted, and falling through would run the read-merge-write
+                    // unguarded — precisely the interleaving the guard exists to prevent, and
+                    // exactly when contention proves another actor is live. Skipping costs one
+                    // unrecorded attempt; proceeding costs the invariant.
+                    if (!guard) return false;
+                }
+
+                await leaseGuard();
+
+                const assertStillOwned = async () => !guard ||
+                    await verifyLifecycleGuardOwnership({ownerFilePath: guard.ownerFilePath, fsModule: fs});
+
+                await work(assertStillOwned);
+                return true
+            } catch (e) {
+                // Swallowed rather than propagated: losing a sidecar write costs one unrecorded
+                // attempt, whereas throwing from the per-repo `finally` would mask the real error
+                // the repo failed with.
+                return false
+            } finally {
+                if (guard) {
+                    await exitLifecycleGuard({ownerFilePath: guard.ownerFilePath, fsModule: fs}).catch(() => {});
+                }
+            }
+        };
+
+        // Recover attempts the previous process started and never returned from. Read AND folded
+        // inside the guard: a fold that read outside it could consume residue a live successor was
+        // still writing. Folded BEFORE the due checks so a crashed attempt dampens the very next
+        // decision rather than one sweep later — a crash loop must not outrun its own backoff.
+        await withSidecarTransaction(async assertStillOwned => {
+            const residualAttempts = await this.readInFlightAttempts({filePath: inFlightPath});
+
+            if (this.foldInFlightAttempts({attempts: residualAttempts, persistedRevisions, writeLog}) === 0) {
+                return;
+            }
+
+            if (!await assertStillOwned()) return;
+
+            // Commit FIRST, clear second. A crash between the two re-folds the same attempt on the
+            // next boot, which over-counts one failure and dampens harder — the safe direction.
+            // Clearing first would lose the attempt on a crash, which is the defect this recovers
+            // from.
             await this.writePersistedRevisions({filePath: resolvedRevisionsPath, revisions: persistedRevisions});
             await this.writeInFlightAttempts({filePath: inFlightPath, attempts: {}});
-        }
+        });
 
         // The live in-flight map is a FRESH object, never the recovery snapshot. Reusing
         // `residualAttempts` as the live map republished entries the fold had already consumed:
@@ -1130,31 +1182,15 @@ class TenantRepoSyncService extends Base {
             inFlightChain = inFlightChain.then(async () => {
                 update(inFlightAttempts);
 
-                // Held across BOTH the ownership re-inspection and the sidecar read-merge-write.
-                //
-                // A sidecar-only mutex would serialize sidecar writers and still let lease
-                // ACQUISITION interleave, so it could not establish generation authority — the
-                // successor would take the lease legitimately while we were mid-transaction. The
-                // lease's own lifecycle guard is the mutex that orders both, which is what makes
-                // "the run that owns the lease owns the sidecar" true rather than probable.
-                //
-                // Without it, `leaseGuard()` then write is check-then-act: earlier revisions of
-                // this code fenced harder and only MOVED the window (check→write became
-                // read→write). A lock that does not span the read and the write cannot close it.
-                let guard = null;
-
-                try {
-                    if (leasePath) {
-                        guard = await enterLifecycleGuard({leasePath, fsModule: fs});
-                    }
-
-                    await leaseGuard();
-
+                // Read-merge-write inside the same guard the fold uses. Without it, `leaseGuard()`
+                // then write is check-then-act: earlier revisions fenced harder and only MOVED the
+                // window (check→write became read→write). A lock that does not span the read and
+                // the write cannot close it.
+                await withSidecarTransaction(async assertStillOwned => {
                     // Merge against live state rather than publishing this sweep's whole view.
                     // Entries owned by another run are carried forward untouched; only our own are
                     // written or removed. `runId` is defence-in-depth for the residual the guard's
-                    // own contract admits: a holder stalled past `guardStaleAfterMs` can be evicted
-                    // and resume inside the verify→syscall gap.
+                    // own contract admits.
                     const
                         live   = await this.readInFlightAttempts({filePath: inFlightPath}),
                         merged = {};
@@ -1167,16 +1203,10 @@ class TenantRepoSyncService extends Base {
                         merged[label] = entry;
                     }
 
+                    if (!await assertStillOwned()) return;
+
                     await this.writeInFlightAttempts({filePath: inFlightPath, attempts: merged});
-                } catch (e) {
-                    // Swallowed rather than propagated: losing a sidecar write costs one unrecorded
-                    // attempt, whereas throwing from the per-repo `finally` would mask the real
-                    // error the repo failed with.
-                } finally {
-                    if (guard) {
-                        await exitLifecycleGuard({ownerFilePath: guard.ownerFilePath, fsModule: fs}).catch(() => {});
-                    }
-                }
+                });
             });
 
             return inFlightChain

--- a/ai/daemons/orchestrator/services/TenantRepoSyncService.mjs
+++ b/ai/daemons/orchestrator/services/TenantRepoSyncService.mjs
@@ -1158,17 +1158,24 @@ class TenantRepoSyncService extends Base {
             // next boot, which over-counts one failure and dampens harder — the safe direction.
             // Clearing first would lose the attempt on a crash, which is the defect this recovers
             // from.
-            await this.writePersistedRevisions({filePath: resolvedRevisionsPath, revisions: persistedRevisions});
+            // The fence travels INTO the writer, because the commit point is its rename and the
+            // staging before that is multi-await I/O a holder can be evicted inside. Proving
+            // ownership out here only bounds the mutations that follow — it cannot stop the
+            // manifest itself from being overwritten by a run that lost the lease mid-write.
+            const {committed} = await this.writePersistedRevisions({
+                assertOwnership: assertStillOwned,
+                filePath       : resolvedRevisionsPath,
+                revisions      : persistedRevisions
+            });
 
-            // Re-proved because these are TWO mutations, not one. `writePersistedRevisions` is a
-            // multi-await transaction (temp write, fsync, close, rename); a holder can pass the
-            // check above, stall inside that I/O past `guardStaleAfterMs`, be legitimately evicted,
-            // and resume here after a successor has acquired and written its own sidecar. One proof
-            // cannot cover two mutations separated by unbounded I/O.
-            //
-            // Declining to clear is the safe direction: the residue is re-folded next sweep, which
-            // over-counts one failure and dampens harder. Clearing it while evicted would delete a
-            // successor's live record.
+            // Deferred at the commit point: the successor owns forward progress and the residue
+            // must survive for it to fold. Clearing now would delete evidence of an attempt whose
+            // recovery never landed.
+            if (!committed) return;
+
+            // Re-proved because these are TWO mutations, not one. Declining to clear is the safe
+            // direction: the residue is re-folded next sweep, which over-counts one failure and
+            // dampens harder. Clearing it while evicted would delete a successor's live record.
             if (!await assertStillOwned()) return;
 
             await this.writeInFlightAttempts({filePath: inFlightPath, attempts: {}});
@@ -2075,7 +2082,7 @@ class TenantRepoSyncService extends Base {
      * @param {Object} [options.fsModule=fs] File-system implementation seam (fault-injection test seam).
      * @returns {Promise<void>}
      */
-    async writePersistedRevisions({filePath, revisions, fsModule = fs}) {
+    async writePersistedRevisions({filePath, revisions, fsModule = fs, assertOwnership = null}) {
         const tmpPath = `${filePath}.tmp-${process.pid}`;
 
         try {
@@ -2094,7 +2101,26 @@ class TenantRepoSyncService extends Base {
                 await fsModule.close(fd);
             }
 
+            // THE COMMIT POINT IS THE RENAME, so the ownership fence belongs immediately before
+            // it and nowhere else. Everything above is staging on a private temp path and is
+            // discardable; the rename is the instant this document becomes the manifest.
+            //
+            // A caller that proved ownership before calling is not protected: the staging above is
+            // multi-await I/O, and a holder can be legitimately evicted inside it. Proving after
+            // the rename is worse than useless — the overwrite has already happened, and declining
+            // some LATER mutation does not undo it.
+            //
+            // Returns `{committed: false}` rather than throwing: a lost fence is a deferral, not a
+            // failure. The successor owns forward progress and this run's state is simply stale, so
+            // the next sweep re-derives it. Callers that must distinguish the two read `committed`.
+            if (assertOwnership && !await assertOwnership()) {
+                await fsModule.remove(tmpPath).catch(() => {});
+                return {committed: false, reason: 'ownership-lost'}
+            }
+
             await fsModule.rename(tmpPath, filePath);
+
+            return {committed: true}
         } catch (e) {
             await fsModule.remove(tmpPath).catch(() => {});
             throw new TenantRepoSyncError(

--- a/ai/daemons/orchestrator/services/TenantRepoSyncService.mjs
+++ b/ai/daemons/orchestrator/services/TenantRepoSyncService.mjs
@@ -379,6 +379,28 @@ function assertFullMaterializationEffect(envelope, summary, priorState, material
  * @see learn/agentos/cloud-deployment/TenantIngestionModel.md
  * @see https://github.com/neomjs/neo/issues/16045
  */
+
+/**
+ * Filename suffix of the in-flight attempt sidecar, resolved beside the revisions manifest.
+ *
+ * Attempt state (`lastRunAttemptAt`, `consecutiveFailures`) is the only input to the backoff
+ * decision, and both used to advance ONLY after the work returned. A failure that prevents
+ * the work from returning — OOM, SIGKILL, host sleep, container stop mid-sweep — therefore
+ * left no record that anything was tried, `due` stayed true, and the lane retried at full
+ * cadence forever. A crash loop is precisely what backoff exists to dampen, and it was the
+ * one failure class where backoff could not engage: the dampening was available only to
+ * failures polite enough to return.
+ *
+ * The record cannot live in the manifest itself. That file is a commit log, and its
+ * commit-point fence is a hard contract: an evicted writer must abort *without writing*, and a
+ * renewal failure must leave no manifest at all. An in-flight attempt is by definition
+ * uncommitted, so it belongs beside the manifest rather than inside it. Sweep start folds any
+ * residue in, at which point it IS a committed fact and travels through the normal path.
+ *
+ * @member {String} IN_FLIGHT_SUFFIX='.in-flight'
+ */
+const IN_FLIGHT_SUFFIX = '.in-flight';
+
 class TenantRepoSyncService extends Base {
     /**
      * Latches the once-per-process inverted-leaf-order warning (runTask boundary): the
@@ -1052,6 +1074,44 @@ class TenantRepoSyncService extends Base {
             );
         }
 
+        // Recover attempts the previous process started and never returned from.
+        // Folded BEFORE the due checks so a crashed attempt dampens the very next decision
+        // rather than one sweep later — the whole point is that a crash loop cannot outrun
+        // its own backoff.
+        const
+            inFlightPath     = this.inFlightAttemptsPath(resolvedRevisionsPath),
+            residualAttempts = await this.readInFlightAttempts({filePath: inFlightPath}),
+            foldedCount      = this.foldInFlightAttempts({
+                attempts: residualAttempts,
+                persistedRevisions,
+                writeLog
+            });
+
+        if (foldedCount > 0) {
+            await leaseGuard();
+            // Commit FIRST, clear second. A crash between the two re-folds the same attempt on
+            // the next boot, which over-counts one failure and dampens harder — the safe
+            // direction. Clearing first would lose the attempt on a crash, which is exactly the
+            // defect this recovers from.
+            await this.writePersistedRevisions({filePath: resolvedRevisionsPath, revisions: persistedRevisions});
+            await this.writeInFlightAttempts({filePath: inFlightPath, attempts: {}});
+        }
+
+        // The sidecar is mutated from inside the concurrent per-repo region, so every write is
+        // serialized through one chain. Mirrors the constraint `writePersistedRevisions` already
+        // has: it stages through a single pid-scoped temp path, which concurrent writers would
+        // otherwise race on.
+        let inFlightChain = Promise.resolve();
+
+        const mutateInFlight = update => {
+            inFlightChain = inFlightChain.then(async () => {
+                update(residualAttempts);
+                await this.writeInFlightAttempts({filePath: inFlightPath, attempts: residualAttempts});
+            });
+
+            return inFlightChain
+        };
+
         const repoStates     = [];
         let   completedCount = 0;
         let   failedCount    = 0;
@@ -1224,8 +1284,9 @@ class TenantRepoSyncService extends Base {
                 return;
             }
 
-            let slotAcquired    = false,
-                accessConfirmed = false;
+            let slotAcquired     = false,
+                accessConfirmed  = false,
+                inFlightRecorded = false;
             try {
                 await semaphore.acquire();
                 slotAcquired = true;
@@ -1235,6 +1296,20 @@ class TenantRepoSyncService extends Base {
                 // reclamation) stops here instead of running git work concurrently
                 // with its successor.
                 await leaseGuard();
+
+                // Write-ahead, after the lease fence and before the git phase. Placed here
+                // rather than at the top of syncRepo so a repo that never entered protected
+                // work — not due, revalidation-deferred, or lease-lost at the fence — records
+                // no attempt, matching the lease-lost contract below that deliberately leaves
+                // backoff state untouched for the successor to own.
+                await mutateInFlight(attempts => {
+                    attempts[repoLabel] = {
+                        startedMs,
+                        priorFailures: priorState?.consecutiveFailures ?? 0
+                    };
+                });
+                inFlightRecorded = true;
+
                 writeLog?.('INFO', `[TenantRepoSync] Refreshing ${repoLabel}.`);
 
                 await gitMirror.cloneIfMissing({
@@ -1502,6 +1577,17 @@ class TenantRepoSyncService extends Base {
                 // tenant deployment contract.
             } finally {
                 if (slotAcquired) semaphore.release();
+
+                // Every path that RETURNS clears its own entry — success, caught failure, and
+                // lease-lost abort all pass through here, so this is the single clearing point
+                // for all three. Per-repo rather than one sweep-terminal truncate: with
+                // `concurrencyLimit >= 2`, a crash while repo B is in flight would otherwise
+                // fold repo A's completed attempt into a spurious failure.
+                if (inFlightRecorded) {
+                    await mutateInFlight(attempts => {
+                        delete attempts[repoLabel];
+                    });
+                }
             }
         };
 
@@ -1723,6 +1809,128 @@ class TenantRepoSyncService extends Base {
             }
             return {};
         }
+    }
+
+    /**
+     * Resolves the in-flight attempt sidecar path for a revisions manifest.
+     * @param {String} revisionsFilePath
+     * @returns {String}
+     */
+    inFlightAttemptsPath(revisionsFilePath) {
+        return `${revisionsFilePath}${IN_FLIGHT_SUFFIX}`
+    }
+
+    /**
+     * Reads the in-flight attempt sidecar.
+     *
+     * Fail-OPEN, unlike `readPersistedRevisions`, which fail-closes the lane on a bad manifest.
+     * The asymmetry is deliberate: the manifest is authoritative state whose corruption must
+     * stop the lane, while this file is a best-effort crash hint whose worst outcome is one
+     * unrecorded attempt. Wedging a healthy lane because a crash left a torn hint would trade a
+     * rare missed dampening for a guaranteed outage.
+     *
+     * @param {Object} options
+     * @param {String} options.filePath
+     * @param {Object} [options.fsModule=fs] File-system implementation seam (fault-injection test seam).
+     * @returns {Promise<Object<String, {startedMs: Number, priorFailures: Number}>>}
+     */
+    async readInFlightAttempts({filePath, fsModule = fs}) {
+        try {
+            const parsed = await fsModule.readJson(filePath);
+
+            return (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) ? parsed : {}
+        } catch (e) {
+            return {}
+        }
+    }
+
+    /**
+     * Writes the in-flight attempt sidecar, or removes it once no attempt is outstanding.
+     *
+     * Staged through a temp sibling and renamed, so a concurrent reader sees either the old or
+     * the new document and never a half-written one. Deliberately NOT fsynced, unlike
+     * `writePersistedRevisions`: the failure class this file defends against is process death
+     * (OOM, SIGKILL, container stop), and a dead process leaves the OS page cache intact, so the
+     * rename is already durable enough for the successor that reads it. Paying for fsync on
+     * every repo attempt would buy only power-loss coverage, which this record does not claim.
+     *
+     * @param {Object} options
+     * @param {String} options.filePath
+     * @param {Object<String, {startedMs: Number, priorFailures: Number}>} options.attempts
+     * @param {Object} [options.fsModule=fs] File-system implementation seam (fault-injection test seam).
+     * @returns {Promise<void>}
+     */
+    async writeInFlightAttempts({filePath, attempts, fsModule = fs}) {
+        if (Object.keys(attempts).length === 0) {
+            await fsModule.remove(filePath).catch(() => {});
+            return
+        }
+
+        const tmpPath = `${filePath}.tmp-${process.pid}`;
+
+        try {
+            await fsModule.ensureDir(path.dirname(filePath));
+            await fsModule.writeFile(tmpPath, JSON.stringify(attempts, null, 2) + '\n');
+            await fsModule.rename(tmpPath, filePath);
+        } catch (e) {
+            // Best-effort by contract: a sidecar write failure must not fail a repo whose actual
+            // sync is fine. The cost is exactly one unrecorded attempt — the same price the
+            // write-behind behaviour paid on every crash — so failing the run here would be
+            // strictly worse than the defect this record exists to fix.
+            await fsModule.remove(tmpPath).catch(() => {});
+        }
+    }
+
+    /**
+     * Folds residue left by a sweep that never returned into the persisted revision state.
+     *
+     * A residual entry means the previous process started that repo's protected work and died
+     * before any return path could record the outcome. Treating it as a failure is the
+     * conservative reading and the correct one: the attempt provably consumed a cadence window
+     * and provably did not succeed, so it must both advance `lastRunAttemptAt` and grow the
+     * backoff term. Mutates `persistedRevisions` in place; the caller commits it.
+     *
+     * @param {Object} options
+     * @param {Object<String, {startedMs: Number, priorFailures: Number}>} options.attempts
+     * @param {Object} options.persistedRevisions Mutated in place.
+     * @param {Function} [options.writeLog]
+     * @returns {Number} Count of folded attempts.
+     */
+    foldInFlightAttempts({attempts, persistedRevisions, writeLog}) {
+        let folded = 0;
+
+        for (const [repoLabel, attempt] of Object.entries(attempts)) {
+            const startedMs = Number(attempt?.startedMs);
+
+            if (!Number.isFinite(startedMs)) continue;
+
+            const
+                priorState = persistedRevisions[repoLabel] || null,
+                // The failure count the crashed attempt itself observed. Preferred over the
+                // committed one because a crash loop never commits, so reading the manifest
+                // would re-derive the same base every restart and the term would never grow.
+                priorFailures = Number.isFinite(Number(attempt?.priorFailures))
+                    ? Number(attempt.priorFailures)
+                    : (priorState?.consecutiveFailures ?? 0);
+
+            persistedRevisions[repoLabel] = {
+                ...priorState,
+                // Preserved explicitly: a crashed attempt establishes nothing about what was
+                // ingested, so the checkpoint it inherited remains the correct base.
+                lastIngestedRev    : priorState?.lastIngestedRev || null,
+                lastRunAttemptAt   : startedMs,
+                consecutiveFailures: priorFailures + 1,
+                lastErrorCode      : KB_TENANT_REPO_SYNC_SYNC_FAILED,
+                lastSourceErrorCode: null,
+                lastAccessCode     : null,
+                lastErrorAt        : startedMs
+            };
+
+            folded++;
+            writeLog?.('WARN', `[TenantRepoSync] ${repoLabel} did not return from its previous attempt (started ${new Date(startedMs).toISOString()}); recording it as a failure so backoff can engage.`);
+        }
+
+        return folded
     }
 
     /**

--- a/ai/daemons/orchestrator/services/TenantRepoSyncService.mjs
+++ b/ai/daemons/orchestrator/services/TenantRepoSyncService.mjs
@@ -39,6 +39,10 @@ import {
     renewHeavyMaintenanceLease
 } from './heavyMaintenanceLeasePrimitives.mjs';
 import {
+    enterLifecycleGuard,
+    exitLifecycleGuard
+} from '../../shared/lifecycleGuard.mjs';
+import {
     classifyTenantRepoCheckpoint,
     normalizeTenantRepoCheckpointState,
     requiresTenantRepoCheckpointRevalidation,
@@ -937,6 +941,7 @@ class TenantRepoSyncService extends Base {
             const result = await this.syncTenantRepos({
                 writeLog, tenantReposConfig, gitMirror, knowledgeBaseIngestionService, onlyRepoSlugs,
                 fullReplay, taskStateService, healthService, taskName, envelopeBuilder, leaseGuard,
+                leasePath        : resolvedLeasePath,
                 revisionsFilePath: resolvedRevisionsPath,
                 globalCadenceMs, jitterRatio, backoffCapMs, starvedAfterMs, seedBootstrap
             });
@@ -999,6 +1004,7 @@ class TenantRepoSyncService extends Base {
         writeLog, tenantReposConfig, gitMirror, knowledgeBaseIngestionService, onlyRepoSlugs,
         fullReplay = false, taskStateService, healthService, taskName, revisionsFilePath, envelopeBuilder = buildIngestEnvelope,
         leaseGuard         = async () => {},
+        leasePath          = null,
         globalCadenceMs    = AiConfig.data.orchestrator.intervals.tenantRepoSyncMs,
         jitterRatio        = AiConfig.data.orchestrator.tenantRepoSync.jitterRatio,
         backoffCapMs       = AiConfig.data.orchestrator.tenantRepoSync.backoffCapMs,
@@ -1124,14 +1130,31 @@ class TenantRepoSyncService extends Base {
             inFlightChain = inFlightChain.then(async () => {
                 update(inFlightAttempts);
 
+                // Held across BOTH the ownership re-inspection and the sidecar read-merge-write.
+                //
+                // A sidecar-only mutex would serialize sidecar writers and still let lease
+                // ACQUISITION interleave, so it could not establish generation authority — the
+                // successor would take the lease legitimately while we were mid-transaction. The
+                // lease's own lifecycle guard is the mutex that orders both, which is what makes
+                // "the run that owns the lease owns the sidecar" true rather than probable.
+                //
+                // Without it, `leaseGuard()` then write is check-then-act: earlier revisions of
+                // this code fenced harder and only MOVED the window (check→write became
+                // read→write). A lock that does not span the read and the write cannot close it.
+                let guard = null;
+
                 try {
+                    if (leasePath) {
+                        guard = await enterLifecycleGuard({leasePath, fsModule: fs});
+                    }
+
                     await leaseGuard();
 
-                    // Re-read INSIDE the critical section and merge against live state rather than
-                    // publishing this sweep's whole view. Entries owned by another run are carried
-                    // forward untouched; only our own are written or removed. A successor that took
-                    // over after the guard check above therefore keeps its record, and our stale
-                    // write becomes a no-op on its key instead of a deletion.
+                    // Merge against live state rather than publishing this sweep's whole view.
+                    // Entries owned by another run are carried forward untouched; only our own are
+                    // written or removed. `runId` is defence-in-depth for the residual the guard's
+                    // own contract admits: a holder stalled past `guardStaleAfterMs` can be evicted
+                    // and resume inside the verify→syscall gap.
                     const
                         live   = await this.readInFlightAttempts({filePath: inFlightPath}),
                         merged = {};
@@ -1149,6 +1172,10 @@ class TenantRepoSyncService extends Base {
                     // Swallowed rather than propagated: losing a sidecar write costs one unrecorded
                     // attempt, whereas throwing from the per-repo `finally` would mask the real
                     // error the repo failed with.
+                } finally {
+                    if (guard) {
+                        await exitLifecycleGuard({ownerFilePath: guard.ownerFilePath, fsModule: fs}).catch(() => {});
+                    }
                 }
             });
 

--- a/ai/daemons/orchestrator/services/TenantRepoSyncService.mjs
+++ b/ai/daemons/orchestrator/services/TenantRepoSyncService.mjs
@@ -1097,16 +1097,33 @@ class TenantRepoSyncService extends Base {
             await this.writeInFlightAttempts({filePath: inFlightPath, attempts: {}});
         }
 
-        // The sidecar is mutated from inside the concurrent per-repo region, so every write is
-        // serialized through one chain. Mirrors the constraint `writePersistedRevisions` already
-        // has: it stages through a single pid-scoped temp path, which concurrent writers would
-        // otherwise race on.
+        // The live in-flight map is a FRESH object, never the recovery snapshot. Reusing
+        // `residualAttempts` as the live map republished entries the fold had already consumed:
+        // the fold cleared the file but not the object, so the first repo to enter protected work
+        // rewrote the whole file from it and re-armed a spent attempt, which the next sweep folded
+        // again, without bound, on a lane that was succeeding. Recovery INPUT and in-flight STATE
+        // are different things with different lifetimes, and one object cannot be both.
+        const inFlightAttempts = {};
+
+        // Serialized through one chain: the sidecar is mutated from inside the concurrent per-repo
+        // region, and `writeInFlightAttempts` stages through a single pid-scoped temp path that
+        // concurrent writers would otherwise race on.
         let inFlightChain = Promise.resolve();
 
         const mutateInFlight = update => {
             inFlightChain = inFlightChain.then(async () => {
-                update(residualAttempts);
-                await this.writeInFlightAttempts({filePath: inFlightPath, attempts: residualAttempts});
+                update(inFlightAttempts);
+
+                // Lease-fenced, because this is a whole-file write of THIS sweep's view. A run that
+                // lost its lease must not clobber the successor that now owns forward progress —
+                // its stale clear would otherwise delete an attempt the successor has in flight.
+                // Swallowed rather than propagated: losing the sidecar write is bounded (one
+                // unrecorded attempt), whereas throwing from the per-repo `finally` would mask the
+                // real error the repo failed with.
+                try {
+                    await leaseGuard();
+                    await this.writeInFlightAttempts({filePath: inFlightPath, attempts: inFlightAttempts});
+                } catch (e) {}
             });
 
             return inFlightChain

--- a/ai/daemons/orchestrator/services/heavyMaintenanceLeasePrimitives.mjs
+++ b/ai/daemons/orchestrator/services/heavyMaintenanceLeasePrimitives.mjs
@@ -8,6 +8,7 @@ import {
     exitLifecycleGuard,
     exitLifecycleGuardSync,
     LIFECYCLE_GUARD_SUFFIX,
+    lifecycleGuardPath,
     verifyLifecycleGuardOwnership,
     verifyLifecycleGuardOwnershipSync
 } from '../../shared/lifecycleGuard.mjs';

--- a/test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncService.spec.mjs
@@ -3685,6 +3685,52 @@ test.describe('TenantRepoSyncService (#11790)', () => {
         }
     });
 
+    // A best-effort sidecar policy must not absorb the MANIFEST's structural failure.
+    //
+    // The shared transaction helper swallows callback errors so a failed sidecar write cannot mask
+    // the real error a repo failed with — correct for the per-repo path, where the cost is one
+    // unrecorded attempt. Recovery is not that: it commits the manifest, whose writer deliberately
+    // throws `KB_TENANT_REPO_SYNC_MANIFEST_UPDATE_FAILED`. Applying one error policy to both
+    // callers converted that documented reason code into a silent `false` — a failure-taxonomy
+    // regression that reads as tidiness.
+    test('a manifest write failure during recovery still fails the task with its reason code (#16551)', async () => {
+        const
+            taskStateService = createInMemoryTaskStateService(),
+            inFlightFile     = `${revisionsFile}.in-flight`,
+            originalWrite    = TenantRepoSyncService.writePersistedRevisions.bind(TenantRepoSyncService);
+
+        await fs.writeJson(revisionsFile, {revisions: {'t1/org/lease-repo': {
+            lastIngestedRev                   : 'sha-before',
+            lastRunAttemptAt                  : 0,
+            consecutiveFailures               : 0,
+            ingestContractVersion             : TENANT_REPO_INGEST_CONTRACT_VERSION,
+            lastAttemptedIngestContractVersion: TENANT_REPO_INGEST_CONTRACT_VERSION
+        }}});
+
+        // Residue, so recovery reaches the manifest commit at all.
+        await fs.writeJson(inFlightFile, {'t1/org/lease-repo': {startedMs: Date.now() - 60_000, priorFailures: 0}});
+
+        TenantRepoSyncService.writePersistedRevisions = async () => {
+            const error = new Error('Failed to persist tenant-repo-sync revisions');
+
+            error.code = 'KB_TENANT_REPO_SYNC_MANIFEST_UPDATE_FAILED';
+            throw error
+        };
+
+        try {
+            const result = await TenantRepoSyncService.runTask(baseLeaseRunOptions({taskStateService}));
+
+            expect(result.status).toBe('failed');
+            expect(
+                result.details.reasonCode,
+                'the manifest\'s structural failure was swallowed by the sidecar\'s best-effort ' +
+                'policy — the lane reports success while the revision manifest was never committed'
+            ).toBe('KB_TENANT_REPO_SYNC_MANIFEST_UPDATE_FAILED');
+        } finally {
+            TenantRepoSyncService.writePersistedRevisions = originalWrite;
+        }
+    });
+
     test('atomic manifest write: an interrupted partial temp write never replaces the target (#15763)', async () => {
         const target = path.join(tmpDir, 'fault-injected.json');
         await fs.writeJson(target, {revisions: {'t1/org/keep': {lastIngestedRev: 'sha-keep'}}});

--- a/test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncService.spec.mjs
@@ -3605,6 +3605,8 @@ test.describe('TenantRepoSyncService (#11790)', () => {
     test('successor acquisition is refused while the predecessor holds the guard mid-transaction (#16551)', async () => {
         const
             taskStateService = createInMemoryTaskStateService(),
+            inFlightFile     = `${revisionsFile}.in-flight`,
+            successorEntry   = {startedMs: 2000, priorFailures: 1, runId: 'successor-run'},
             originalRead     = TenantRepoSyncService.readInFlightAttempts.bind(TenantRepoSyncService);
 
         let readCount = 0, releasePredecessor, markPaused;
@@ -3657,6 +3659,27 @@ test.describe('TenantRepoSyncService (#11790)', () => {
 
             releasePredecessor();
             await invocation;
+
+            // Release -> retry. The refusal must be TEMPORARY: a guard that is entered and never
+            // exited would refuse forever, which passes the assertion above while deadlocking the
+            // lane. This is the half that tells those two apart.
+            const retry = await acquireHeavyMaintenanceLease({
+                leasePath   : leaseFilePath(),
+                owner       : 'tenant-repo-sync:successor',
+                reason      : 'tenant-repo-sync',
+                staleAfterMs: 60_000
+            });
+
+            expect(
+                retry.acquired,
+                'the successor still cannot acquire after the predecessor finished — the guard was ' +
+                'entered and not exited, so the refusal above was a deadlock rather than mutual exclusion'
+            ).toBe(true);
+
+            // And the successor's own record, written under the SAME label, is exactly what a
+            // later reader sees: the predecessor left no residue behind to be folded again.
+            await fs.writeJson(inFlightFile, {'t1/org/lease-repo': successorEntry});
+            expect(await fs.readJson(inFlightFile)).toEqual({'t1/org/lease-repo': successorEntry});
         } finally {
             TenantRepoSyncService.readInFlightAttempts = originalRead;
         }

--- a/test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncService.spec.mjs
@@ -37,6 +37,10 @@ import {
     buildLeasePayload
 } from '../../../../../../../ai/daemons/orchestrator/services/heavyMaintenanceLeasePrimitives.mjs';
 import {
+    enterLifecycleGuard,
+    exitLifecycleGuard
+} from '../../../../../../../ai/daemons/shared/lifecycleGuard.mjs';
+import {
     buildRunTaskOptions,
     parseArgs,
     resolveExitCode
@@ -3728,6 +3732,76 @@ test.describe('TenantRepoSyncService (#11790)', () => {
             ).toBe('KB_TENANT_REPO_SYNC_MANIFEST_UPDATE_FAILED');
         } finally {
             TenantRepoSyncService.writePersistedRevisions = originalWrite;
+        }
+    });
+
+    // Fail-closed is the helper's most serious branch, and it was reasoned-only until now.
+    //
+    // `enterLifecycleGuard` returns null once its bounded retry budget is exhausted. An earlier
+    // revision fell through and ran the recovery read-fold-commit UNGUARDED — the guard silently
+    // stopped existing at exactly the moment contention proved another actor was live. The
+    // observable property is a NON-EVENT, so it has to be asserted as one: residue neither folded
+    // into the manifest nor cleared from the sidecar.
+    //
+    // Holds a REAL guard rather than stubbing the entry, so the refusal comes from the production
+    // primitive's own contention path.
+    test('a contended guard makes recovery fail closed: residue is neither folded nor cleared (#16551)', async () => {
+        const
+            inFlightFile   = `${revisionsFile}.in-flight`,
+            residualEntry  = {startedMs: Date.now() - 60 * 60_000, priorFailures: 0},
+            manifestBefore = {'t1/org/lease-repo': {
+                lastIngestedRev                   : 'sha-before',
+                lastRunAttemptAt                  : Date.now(),
+                consecutiveFailures               : 0,
+                ingestContractVersion             : TENANT_REPO_INGEST_CONTRACT_VERSION,
+                lastAttemptedIngestContractVersion: TENANT_REPO_INGEST_CONTRACT_VERSION
+            }};
+
+        await fs.writeJson(revisionsFile, {revisions: manifestBefore});
+        await fs.writeJson(inFlightFile, {'t1/org/lease-repo': residualEntry});
+
+        // Someone else holds the guard for the whole sweep.
+        await fs.ensureDir(path.dirname(leaseFilePath()));
+        const held = await enterLifecycleGuard({leasePath: leaseFilePath(), fsModule: fs});
+
+        expect(held, 'could not take the guard, so the contention this test needs never existed').toBeTruthy();
+
+        try {
+            // One not-due repo, so the ONLY sidecar work this sweep would do is the recovery fold.
+            await TenantRepoSyncService.syncTenantRepos({
+                taskStateService : createInMemoryTaskStateService(),
+                revisionsFilePath: revisionsFile,
+                leasePath        : leaseFilePath(),
+                leaseGuard       : async () => {},
+                tenantReposConfig: {tenantRepos: [{
+                    tenantId: 't1', repoSlug: 'org/lease-repo', mirrorRoot,
+                    cloneUrl: 'https://github.com/neomjs/lease-repo.git'
+                }]},
+                gitMirror                    : makeFakeGitMirror(),
+                envelopeBuilder              : makeFakeEnvelopeBuilder(),
+                knowledgeBaseIngestionService: makeFakeIngestionService(),
+                globalCadenceMs              : 60 * 60_000,
+                jitterRatio                  : 0,
+                seedBootstrap                : false
+            });
+
+            // Asserted on the FOLD'S EFFECT, not on manifest bytes: a sweep always rewrites the
+            // manifest at its terminal commit, so byte-equality cannot express "the fold did not
+            // happen" — it fails against correct code. Folding this residue would set
+            // `consecutiveFailures` to 1; a guard that refused leaves it at 0.
+            expect(
+                (await fs.readJson(revisionsFile)).revisions['t1/org/lease-repo'].consecutiveFailures,
+                'the residue was folded while the guard was held by another actor — recovery ran ' +
+                'unguarded, which is the interleaving the guard exists to prevent'
+            ).toBe(0);
+
+            expect(
+                await fs.readJson(inFlightFile),
+                'the residue was cleared while the guard was held by another actor — the attempt ' +
+                'is now lost to whoever legitimately owns forward progress'
+            ).toEqual({'t1/org/lease-repo': residualEntry});
+        } finally {
+            await exitLifecycleGuard({ownerFilePath: held.ownerFilePath, fsModule: fs}).catch(() => {});
         }
     });
 

--- a/test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncService.spec.mjs
@@ -3805,6 +3805,127 @@ test.describe('TenantRepoSyncService (#11790)', () => {
         }
     });
 
+    // The last unwitnessed branch: eviction DURING the manifest's staging I/O.
+    //
+    // Every earlier fence was one layer too shallow — around the transaction, then around the
+    // writer — and each still let the rename land while evicted. The commit point is the rename,
+    // so this pauses inside `fsync` (after the payload is staged, before it becomes the manifest),
+    // lets a legitimate successor steal the stale guard and lease and write DISTINCT manifest and
+    // sidecar values, then resumes the predecessor.
+    //
+    // The predecessor must lose both races: no manifest overwrite, no sidecar clear.
+    test('a predecessor evicted inside manifest staging commits nothing over its successor (#16551)', async () => {
+        const
+            taskStateService  = createInMemoryTaskStateService(),
+            inFlightFile      = `${revisionsFile}.in-flight`,
+            successorSidecar  = {'t1/org/lease-repo': {startedMs: 4242, priorFailures: 3, runId: 'successor-run'}},
+            successorManifest = {'t1/org/lease-repo': {
+                lastIngestedRev                   : 'sha-successor',
+                lastRunAttemptAt                  : 9999,
+                consecutiveFailures               : 7,
+                ingestContractVersion             : TENANT_REPO_INGEST_CONTRACT_VERSION,
+                lastAttemptedIngestContractVersion: TENANT_REPO_INGEST_CONTRACT_VERSION
+            }},
+            originalWrite     = TenantRepoSyncService.writePersistedRevisions.bind(TenantRepoSyncService);
+
+        await fs.writeJson(revisionsFile, {revisions: {'t1/org/lease-repo': {
+            lastIngestedRev                   : 'sha-before',
+            lastRunAttemptAt                  : 0,
+            consecutiveFailures               : 0,
+            ingestContractVersion             : TENANT_REPO_INGEST_CONTRACT_VERSION,
+            lastAttemptedIngestContractVersion: TENANT_REPO_INGEST_CONTRACT_VERSION
+        }}});
+        await fs.writeJson(inFlightFile, {'t1/org/lease-repo': {startedMs: Date.now() - 60 * 60_000, priorFailures: 0}});
+
+        let wrapped = false, markStaging, releaseStaging;
+
+        const
+            stagingEntered = new Promise(resolve => markStaging    = resolve),
+            stagingGate    = new Promise(resolve => releaseStaging = resolve);
+
+        // One-shot: only the FIRST writer call (recovery's) is paused. The sweep-terminal commit
+        // must run normally or the run never settles.
+        TenantRepoSyncService.writePersistedRevisions = async options => {
+            if (wrapped) return originalWrite(options);
+            wrapped = true;
+
+            return originalWrite({
+                ...options,
+                fsModule: {
+                    ...fs,
+                    async fsync(fd) {
+                        const result = await fs.fsync(fd);
+
+                        markStaging();
+                        await stagingGate;
+
+                        return result
+                    }
+                }
+            })
+        };
+
+        try {
+            const invocation = TenantRepoSyncService.runTask(baseLeaseRunOptions({
+                taskStateService,
+                leaseStaleAfterMs: 40
+            }));
+
+            await stagingEntered;
+
+            // The payload is staged on the temp path but has NOT been renamed. Let the
+            // predecessor's guard and lease age out, then take both as a legitimate successor.
+            await new Promise(resolve => setTimeout(resolve, 120));
+
+            const stolen = await enterLifecycleGuard({
+                leasePath        : leaseFilePath(),
+                fsModule         : fs,
+                guardStaleAfterMs: 1
+            });
+
+            expect(stolen, 'could not steal the stale guard, so the eviction this test needs never happened').toBeTruthy();
+
+            await fs.writeJson(leaseFilePath(), buildLeasePayload({
+                owner       : 'tenant-repo-sync:successor',
+                reason      : 'tenant-repo-sync',
+                pid         : process.pid,
+                staleAfterMs: 60_000,
+                token       : 'successor-token'
+            }));
+            await fs.writeJson(revisionsFile, {revisions: successorManifest});
+            await fs.writeJson(inFlightFile, successorSidecar);
+
+            // The successor's critical section is over, so it releases the guard BEFORE the
+            // predecessor resumes. Holding it would block the predecessor's own lease release,
+            // which throws by design — that is the run failing on the successor's mutex, not on
+            // the property under test.
+            await exitLifecycleGuard({ownerFilePath: stolen.ownerFilePath, fsModule: fs});
+
+            releaseStaging();
+
+            // Surfaces lease loss rather than succeeding: the predecessor no longer owns anything.
+            const result = await invocation;
+
+            expect(result.status).toBe('failed');
+
+            // Both successor artifacts survive exactly. Under the pre-fence source the rename
+            // lands regardless and the manifest is the predecessor's.
+            expect(
+                (await fs.readJson(revisionsFile)).revisions,
+                'the evicted predecessor renamed its staged manifest over the successor\'s — the ' +
+                'successor\'s committed state is gone and every repo re-syncs from a stale base'
+            ).toEqual(successorManifest);
+
+            expect(
+                await fs.readJson(inFlightFile),
+                'the evicted predecessor cleared the successor\'s sidecar — its in-flight attempt ' +
+                'is unrecorded, so a crash during it leaves backoff unable to engage'
+            ).toEqual(successorSidecar);
+        } finally {
+            TenantRepoSyncService.writePersistedRevisions = originalWrite;
+        }
+    });
+
     test('atomic manifest write: an interrupted partial temp write never replaces the target (#15763)', async () => {
         const target = path.join(tmpDir, 'fault-injected.json');
         await fs.writeJson(target, {revisions: {'t1/org/keep': {lastIngestedRev: 'sha-keep'}}});

--- a/test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncService.spec.mjs
@@ -3383,6 +3383,87 @@ test.describe('TenantRepoSyncService (#11790)', () => {
         expect(new Date(repoState.nextDueAt).getTime()).toBe(crashedAttemptAt + 8 * baseCadenceMs);
     });
 
+    // A recovered attempt must be consumed ONCE.
+    //
+    // The fold cleared the sidecar on DISK but kept the same object in memory as the live
+    // in-flight map. The first repo that entered protected work then rewrote the whole file from
+    // that object — republishing the already-consumed entry, which the NEXT sweep folds again, and
+    // the next. A recovery that re-arms itself is worse than no recovery: it inflates
+    // `consecutiveFailures` without bound on a lane that is succeeding.
+    //
+    // The witness has to be built precisely, and my first attempt was NOT. Two repos both running
+    // does not reproduce it: the residue-holder's own fresh attempt overwrites its stale entry
+    // under the same key, then its `finally` deletes it, and the map empties correctly. The setup
+    // healed the defect.
+    //
+    // The property the witness must share: the residue-holder must NOT run this sweep, so nothing
+    // overwrites its consumed entry, while a SIBLING does run and rewrites the whole file from the
+    // shared in-memory map. Folding repo-a sets `consecutiveFailures: 1`, which suppresses it under
+    // a long cadence — so the fold itself produces the required not-due state.
+    test('a recovered attempt is consumed once and never republished by a sibling repo (#16551)', async () => {
+        const
+            inFlightFile     = `${revisionsFile}.in-flight`,
+            baseCadenceMs    = 60 * 60_000,
+            crashedAttemptAt = Date.now() - 60_000,
+            repos            = [
+                {tenantId: 't1', repoSlug: 'org/repo-a', mirrorRoot, cloneUrl: 'https://github.com/neomjs/repo-a.git'},
+                {tenantId: 't1', repoSlug: 'org/repo-b', mirrorRoot, cloneUrl: 'https://github.com/neomjs/repo-b.git'}
+            ];
+
+        await fs.writeJson(revisionsFile, {revisions: {
+            't1/org/repo-a': {
+                lastIngestedRev                   : 'sha-a',
+                lastRunAttemptAt                  : 0,
+                consecutiveFailures               : 0,
+                ingestContractVersion             : TENANT_REPO_INGEST_CONTRACT_VERSION,
+                lastAttemptedIngestContractVersion: TENANT_REPO_INGEST_CONTRACT_VERSION
+            },
+            't1/org/repo-b': {
+                lastIngestedRev                   : 'sha-b',
+                lastRunAttemptAt                  : 0,
+                consecutiveFailures               : 0,
+                ingestContractVersion             : TENANT_REPO_INGEST_CONTRACT_VERSION,
+                lastAttemptedIngestContractVersion: TENANT_REPO_INGEST_CONTRACT_VERSION
+            }
+        }});
+
+        // Only repo-a crashed, and recently — so once the fold makes it `consecutiveFailures: 1`
+        // it is suppressed for this sweep and never re-enters the mutate path.
+        await fs.writeJson(inFlightFile, {'t1/org/repo-a': {
+            startedMs    : crashedAttemptAt,
+            priorFailures: 0
+        }});
+
+        await TenantRepoSyncService.runTask(baseLeaseRunOptions({
+            taskStateService : createInMemoryTaskStateService(),
+            tenantReposConfig: {tenantRepos: repos},
+            globalCadenceMs  : baseCadenceMs,
+            backoffCapMs     : 0
+        }));
+
+        // repo-b ran and returned; repo-a was suppressed and never started. Nothing is in flight.
+        expect(
+            await fs.pathExists(inFlightFile),
+            'the sidecar survived a sweep with nothing in flight — repo-b republished repo-a\'s ' +
+            'already-consumed entry from the shared in-memory map, re-arming it'
+        ).toBe(false);
+
+        // The class assertion, independent of the file: a second sweep must not fold repo-a again.
+        // One crash happened, so the counter is 1 — and must STAY 1.
+        await TenantRepoSyncService.runTask(baseLeaseRunOptions({
+            taskStateService : createInMemoryTaskStateService(),
+            tenantReposConfig: {tenantRepos: repos},
+            globalCadenceMs  : baseCadenceMs,
+            backoffCapMs     : 0
+        }));
+
+        expect(
+            (await fs.readJson(revisionsFile)).revisions['t1/org/repo-a'].consecutiveFailures,
+            'repo-a was folded a second time from one crash — a recovery that re-arms itself ' +
+            'inflates the backoff term without bound on a lane that is not failing'
+        ).toBe(1);
+    });
+
     test('atomic manifest write: an interrupted partial temp write never replaces the target (#15763)', async () => {
         const target = path.join(tmpDir, 'fault-injected.json');
         await fs.writeJson(target, {revisions: {'t1/org/keep': {lastIngestedRev: 'sha-keep'}}});

--- a/test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncService.spec.mjs
@@ -3464,6 +3464,79 @@ test.describe('TenantRepoSyncService (#11790)', () => {
         ).toBe(1);
     });
 
+    // An evicted run must not clear a sidecar entry its successor now owns.
+    //
+    // My first attempt at this witness took the lease over inside `gitMirror.fetch` and PASSED
+    // against the unfixed source, so it proved nothing and was deleted. The ordering is what makes
+    // it reachable: the takeover has to land AFTER the predecessor has persisted its own in-flight
+    // record, otherwise its `finally` has nothing to write and the stale whole-file write never
+    // happens. `envelopeEntered` is the sequencing point — resolved at the top of the envelope
+    // builder, before the gate is awaited, so awaiting it proves the record already exists.
+    //
+    // The successor sidecar is written inside the lifecycle guard together with the lease
+    // replacement, so an in-flight renewal tick cannot interleave with the test's own writes.
+    test('an evicted run does not clear the sidecar entry its successor owns (#16551)', async () => {
+        const
+            taskStateService = createInMemoryTaskStateService(),
+            inFlightFile     = `${revisionsFile}.in-flight`,
+            successorEntry   = {startedMs: 2000, priorFailures: 1},
+            baseEnvelope     = makeFakeEnvelopeBuilder();
+
+        let releaseEnvelope, markEnvelopeEntered;
+
+        const
+            envelopeGate    = new Promise(resolve => releaseEnvelope     = resolve),
+            envelopeEntered = new Promise(resolve => markEnvelopeEntered = resolve);
+
+        const invocation = TenantRepoSyncService.runTask(baseLeaseRunOptions({
+            taskStateService,
+            leaseStaleAfterMs     : 60_000,
+            leaseRenewalIntervalMs: 25,
+            envelopeBuilder       : async (...args) => {
+                markEnvelopeEntered();
+                await envelopeGate;
+                return baseEnvelope(...args)
+            }
+        }));
+
+        for (let i = 0; i < 200 && !await fs.pathExists(leaseFilePath()); i++) {
+            await new Promise(resolve => setTimeout(resolve, 5));
+        }
+        expect(await fs.pathExists(leaseFilePath())).toBe(true);
+
+        // The predecessor is now inside protected work with its own in-flight record persisted.
+        await envelopeEntered;
+
+        const guardPath = `${leaseFilePath()}${LIFECYCLE_GUARD_SUFFIX}`;
+        await fs.ensureDir(guardPath);
+        await fs.writeJson(leaseFilePath(), buildLeasePayload({
+            owner       : 'successor-owner',
+            reason      : 'tenant-repo-sync',
+            pid         : process.pid,
+            staleAfterMs: 60_000,
+            token       : 'successor-token'
+        }));
+        await fs.writeJson(inFlightFile, {'t1/org/lease-repo': successorEntry});
+        await fs.rmdir(guardPath);
+
+        await new Promise(resolve => setTimeout(resolve, 120));
+
+        releaseEnvelope();
+        const result = await invocation;
+
+        expect(result.status).toBe('failed');
+        expect(result.details.reasonCode).toBe('KB_TENANT_REPO_SYNC_LEASE_LOST');
+
+        // The whole point: the evicted predecessor's `finally` must not write its own view over
+        // the successor's record. Exact equality, not existence — a rewritten-but-present file
+        // would pass a pathExists check while having lost the successor's attempt.
+        expect(
+            await fs.readJson(inFlightFile),
+            'the evicted predecessor overwrote the sidecar the successor owns; the successor\'s ' +
+            'attempt is unrecorded, so a crash during it leaves backoff unable to engage'
+        ).toEqual({'t1/org/lease-repo': successorEntry});
+    });
+
     test('atomic manifest write: an interrupted partial temp write never replaces the target (#15763)', async () => {
         const target = path.join(tmpDir, 'fault-injected.json');
         await fs.writeJson(target, {revisions: {'t1/org/keep': {lastIngestedRev: 'sha-keep'}}});

--- a/test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncService.spec.mjs
@@ -3252,6 +3252,80 @@ test.describe('TenantRepoSyncService (#11790)', () => {
         expect((await fs.readJson(leaseFilePath())).token).toBe('foreign-takeover-token');
     });
 
+    // An attempt that never returns is still an attempt.
+    //
+    // Backoff reads `consecutiveFailures` + `lastRunAttemptAt`, and both advance only AFTER the
+    // work returns (`:1351` on success, `:1442` in the catch). A failure that prevents the work
+    // from returning at all — OOM, SIGKILL, host sleep, container stop mid-sweep — therefore
+    // leaves no record that anything was tried, `due` stays true forever, and the lane retries at
+    // full cadence. A crash loop is exactly what backoff exists to dampen, and it is the one
+    // failure class where backoff provably cannot engage: the dampening is only available to
+    // failures polite enough to return.
+    //
+    // The record cannot live in the revisions manifest. That file is a commit log, and the sibling
+    // specs in this file pin its commit-point fence: `commit-point fence: an evicted writer aborts
+    // without writing` compares it byte-for-byte, and `renewal failure aborts before protected
+    // work` asserts it does not exist. Writing scheduling state into it before the work completes
+    // does not defeat a proxy for those properties, it removes the properties. An in-flight
+    // attempt is by definition uncommitted, so it belongs BESIDE the manifest, not inside it.
+    //
+    // The `.in-flight` suffix is asserted literally rather than through an imported constant: the
+    // on-disk name IS the contract here. A crashed predecessor and its successor are different
+    // processes, potentially different builds, and a rename that both sides agree on would leave
+    // real residue unreadable while this spec still passed.
+    test('a sweep that never returns still records the attempt, and the next sweep commits it (#16551)', async () => {
+        const
+            taskStateService = createInMemoryTaskStateService(),
+            inFlightFile     = `${revisionsFile}.in-flight`,
+            now              = Date.now(),
+            // The predecessor's committed state: one clean prior run, no failures.
+            lastCommittedAt  = now - 30 * 60_000,
+            // The attempt it started and died inside — later than what it managed to commit.
+            crashedAttemptAt = now - 20 * 60_000;
+
+        await fs.writeJson(revisionsFile, {revisions: {'t1/org/lease-repo': {
+            lastIngestedRev                   : 'sha-before',
+            lastRunAttemptAt                  : lastCommittedAt,
+            consecutiveFailures               : 0,
+            ingestContractVersion             : TENANT_REPO_INGEST_CONTRACT_VERSION,
+            lastAttemptedIngestContractVersion: TENANT_REPO_INGEST_CONTRACT_VERSION
+        }}});
+
+        // Residue from a process that entered protected work and was killed before it could
+        // reach the sweep-terminal commit. This is the only trace such a run can leave.
+        await fs.writeJson(inFlightFile, {'t1/org/lease-repo': {
+            startedMs    : crashedAttemptAt,
+            priorFailures: 0
+        }});
+
+        // A cadence long enough that the recovered failure is observable as suppression rather
+        // than being consumed by an immediate re-run that would reset the counter to 0.
+        const result = await TenantRepoSyncService.runTask(baseLeaseRunOptions({
+            taskStateService,
+            globalCadenceMs: 60 * 60_000
+        }));
+
+        expect(result.status).toBe('completed');
+
+        const persisted = (await fs.readJson(revisionsFile)).revisions['t1/org/lease-repo'];
+
+        // The attempt is committed as a fact by the sweep that discovered the residue.
+        expect(persisted.consecutiveFailures).toBe(1);
+        expect(persisted.lastRunAttemptAt).toBe(crashedAttemptAt);
+        // A crashed attempt says nothing about what was ingested; the checkpoint must survive it.
+        expect(persisted.lastIngestedRev).toBe('sha-before');
+
+        // Recovered, therefore consumed: a second sweep must not fold the same corpse twice.
+        expect(await fs.pathExists(inFlightFile)).toBe(false);
+
+        // And the recovered failure must reach the scheduler, not just the manifest — backoff is
+        // the entire point. 1 failure ⇒ 2× cadence from the crashed attempt, still in the future.
+        const repoState = result.details.repos.find(state => state.repoSlug === 'org/lease-repo');
+        expect(repoState.status).toBe('backoff-suppressed');
+        expect(repoState.consecutiveFailures).toBe(1);
+        expect(new Date(repoState.nextDueAt).getTime()).toBe(crashedAttemptAt + 2 * 60 * 60_000);
+    });
+
     test('atomic manifest write: an interrupted partial temp write never replaces the target (#15763)', async () => {
         const target = path.join(tmpDir, 'fault-injected.json');
         await fs.writeJson(target, {revisions: {'t1/org/keep': {lastIngestedRev: 'sha-keep'}}});

--- a/test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncService.spec.mjs
@@ -3589,6 +3589,79 @@ test.describe('TenantRepoSyncService (#11790)', () => {
         ).toEqual({'t1/org/lease-repo': successorEntry});
     });
 
+    // The window three earlier witnesses missed: successor acquisition attempted strictly BETWEEN
+    // the predecessor's sidecar read and its write.
+    //
+    // Ordering specified by @neo-gpt after my third attempt again landed in an easy window. The
+    // assertion is on the guard REFUSING, not on a pending promise: `enterLifecycleGuard` is
+    // bounded (100 attempts x 10ms), so past that budget a contended recovery resolves
+    // `{status: 'held', guardContended: true}` rather than staying unsettled. Asserting "still
+    // pending" would fail against CORRECT code on a slow run — the bounded refusal is both
+    // deterministic and the stronger claim, because it shows the mutex actively refused.
+    //
+    // Only the RECOVERY path contends: acquiring a vacant name is a plain exclusive `wx` create
+    // deliberately outside the guard. Hence the short `leaseStaleAfterMs` — the successor must
+    // find a STALE lease so it takes the guarded recovery path at all.
+    test('successor acquisition is refused while the predecessor holds the guard mid-transaction (#16551)', async () => {
+        const
+            taskStateService = createInMemoryTaskStateService(),
+            originalRead     = TenantRepoSyncService.readInFlightAttempts.bind(TenantRepoSyncService);
+
+        let readCount = 0, releasePredecessor, markPaused;
+
+        const
+            resumeGate = new Promise(resolve => releasePredecessor = resolve),
+            pausedGate = new Promise(resolve => markPaused        = resolve);
+
+        // Pause AFTER the read and BEFORE the write, while the guard is held. Reads: [1] the
+        // sweep-start fold (outside the guard), [2] the first mutate inside it — that is the one.
+        TenantRepoSyncService.readInFlightAttempts = async options => {
+            const result = await originalRead(options);
+
+            if (++readCount === 2) {
+                markPaused();
+                await resumeGate;
+            }
+
+            return result
+        };
+
+        try {
+            const invocation = TenantRepoSyncService.runTask(baseLeaseRunOptions({
+                taskStateService,
+                leaseStaleAfterMs: 50
+            }));
+
+            await pausedGate;
+
+            // The predecessor is inside the critical section holding the guard, its lease now
+            // going stale. A production successor attempts recovery acquisition.
+            await new Promise(resolve => setTimeout(resolve, 100));
+
+            const successor = await acquireHeavyMaintenanceLease({
+                leasePath   : leaseFilePath(),
+                owner       : 'tenant-repo-sync:successor',
+                reason      : 'tenant-repo-sync',
+                staleAfterMs: 60_000
+            });
+
+            // The mutex did its job: recovery could not proceed while the transaction was open.
+            expect(
+                successor.acquired,
+                'a successor acquired the lease while the predecessor held the lifecycle guard ' +
+                'mid-transaction — the read and the write are not serialized against acquisition, ' +
+                'so the predecessor\'s pending write can still land over the successor\'s state'
+            ).toBe(false);
+            expect(successor.status).toBe('held');
+            expect(successor.guardContended).toBe(true);
+
+            releasePredecessor();
+            await invocation;
+        } finally {
+            TenantRepoSyncService.readInFlightAttempts = originalRead;
+        }
+    });
+
     test('atomic manifest write: an interrupted partial temp write never replaces the target (#15763)', async () => {
         const target = path.join(tmpDir, 'fault-injected.json');
         await fs.writeJson(target, {revisions: {'t1/org/keep': {lastIngestedRev: 'sha-keep'}}});

--- a/test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncService.spec.mjs
@@ -3537,6 +3537,58 @@ test.describe('TenantRepoSyncService (#11790)', () => {
         ).toEqual({'t1/org/lease-repo': successorEntry});
     });
 
+    // Takeover AFTER the ownership check, which fencing cannot fix.
+    //
+    // `await leaseGuard()` followed by a write is check-then-act: the lease can expire and a
+    // successor legitimately acquire in the window between the two syscalls. The sibling witness
+    // above covers takeover BEFORE the check, where the guard rejects the write. This one covers
+    // after it, where the guard has already said yes — and no amount of extra fencing closes that
+    // window, because the check and the write are separate operations.
+    //
+    // The answer is ownership on the record: a mutation carries the id of the run that wrote it,
+    // and entries owned by another run are merged forward untouched. The successor's entry is
+    // written while the predecessor is parked inside protected work, under the SAME repo label —
+    // same-label is the hard case, since a per-label read-modify-write would still clobber it.
+    test('a resumed predecessor merges around the successor rather than deleting it (#16551)', async () => {
+        const
+            taskStateService = createInMemoryTaskStateService(),
+            inFlightFile     = `${revisionsFile}.in-flight`,
+            successorEntry   = {startedMs: 2000, priorFailures: 1, runId: 'successor-run'},
+            baseEnvelope     = makeFakeEnvelopeBuilder();
+
+        let releaseEnvelope, markEnvelopeEntered;
+
+        const
+            envelopeGate    = new Promise(resolve => releaseEnvelope     = resolve),
+            envelopeEntered = new Promise(resolve => markEnvelopeEntered = resolve);
+
+        const invocation = TenantRepoSyncService.runTask(baseLeaseRunOptions({
+            taskStateService,
+            envelopeBuilder: async (...args) => {
+                markEnvelopeEntered();
+                await envelopeGate;
+                return baseEnvelope(...args)
+            }
+        }));
+
+        // The predecessor is inside protected work with its own record already persisted, and its
+        // ownership check for the pending clear has effectively already passed.
+        await envelopeEntered;
+
+        // A successor takes the repo over and records its own attempt under the same label.
+        await fs.writeJson(inFlightFile, {'t1/org/lease-repo': successorEntry});
+
+        releaseEnvelope();
+        await invocation;
+
+        // The predecessor's clear must not consume a record it does not own.
+        expect(
+            await fs.readJson(inFlightFile).catch(() => null),
+            'the resumed predecessor deleted or overwrote the successor\'s record; the successor\'s ' +
+            'attempt is unrecorded, so a crash during it leaves backoff unable to engage'
+        ).toEqual({'t1/org/lease-repo': successorEntry});
+    });
+
     test('atomic manifest write: an interrupted partial temp write never replaces the target (#15763)', async () => {
         const target = path.join(tmpDir, 'fault-injected.json');
         await fs.writeJson(target, {revisions: {'t1/org/keep': {lastIngestedRev: 'sha-keep'}}});

--- a/test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncService.spec.mjs
@@ -3300,9 +3300,15 @@ test.describe('TenantRepoSyncService (#11790)', () => {
 
         // A cadence long enough that the recovered failure is observable as suppression rather
         // than being consumed by an immediate re-run that would reset the counter to 0.
+        //
+        // `backoffCapMs: 0` (the pure function's own no-cap default) is load-bearing, not tidiness.
+        // The configured ceiling is 2h, and 1 failure against a 60min base also resolves to 2h —
+        // so with the cap in play this assertion would pass whether the multiplier worked or the
+        // value simply hit the ceiling. Removing the cap is what makes it measure the multiplier.
         const result = await TenantRepoSyncService.runTask(baseLeaseRunOptions({
             taskStateService,
-            globalCadenceMs: 60 * 60_000
+            globalCadenceMs: 60 * 60_000,
+            backoffCapMs   : 0
         }));
 
         expect(result.status).toBe('completed');
@@ -3324,6 +3330,57 @@ test.describe('TenantRepoSyncService (#11790)', () => {
         expect(repoState.status).toBe('backoff-suppressed');
         expect(repoState.consecutiveFailures).toBe(1);
         expect(new Date(repoState.nextDueAt).getTime()).toBe(crashedAttemptAt + 2 * 60 * 60_000);
+    });
+
+    // The exponential term has to keep growing across successive crashes, which is the whole
+    // reason the record carries `priorFailures` instead of re-reading the manifest. A crash loop
+    // never commits, so a fold that re-derived its base from committed state would read the same
+    // number every restart and the cadence would sit flat at 2x forever — dampening in name only.
+    // Asserted on the resolved cadence value rather than on a log line, because the log is what
+    // agreed with the frozen counters last time while the arithmetic disagreed.
+    test('successive crashed attempts keep growing the backoff term, not just the first (#16551)', async () => {
+        const
+            taskStateService = createInMemoryTaskStateService(),
+            inFlightFile     = `${revisionsFile}.in-flight`,
+            baseCadenceMs    = 60 * 60_000,
+            crashedAttemptAt = Date.now() - 20 * 60_000;
+
+        // Committed `consecutiveFailures` is 0 — BEHIND the crashed attempt's own view, exactly
+        // as it is in a crash loop that never reaches its terminal commit.
+        await fs.writeJson(revisionsFile, {revisions: {'t1/org/lease-repo': {
+            lastIngestedRev                   : 'sha-before',
+            lastRunAttemptAt                  : crashedAttemptAt - 60_000,
+            consecutiveFailures               : 0,
+            ingestContractVersion             : TENANT_REPO_INGEST_CONTRACT_VERSION,
+            lastAttemptedIngestContractVersion: TENANT_REPO_INGEST_CONTRACT_VERSION
+        }}});
+
+        // The dying process had already survived two earlier crashes.
+        await fs.writeJson(inFlightFile, {'t1/org/lease-repo': {
+            startedMs    : crashedAttemptAt,
+            priorFailures: 2
+        }});
+
+        // Cap removed for the same reason as the sibling spec: the configured 2h ceiling would
+        // clamp 8x-of-60min to exactly the same value a broken multiplier produces, and an
+        // assertion that cannot tell those apart is not measuring backoff growth at all.
+        const result = await TenantRepoSyncService.runTask(baseLeaseRunOptions({
+            taskStateService,
+            globalCadenceMs: baseCadenceMs,
+            backoffCapMs   : 0
+        }));
+
+        const persisted = (await fs.readJson(revisionsFile)).revisions['t1/org/lease-repo'];
+
+        // 2 observed + this one = 3, NOT 1 — the committed 0 must not win.
+        expect(persisted.consecutiveFailures).toBe(3);
+
+        const repoState = result.details.repos.find(state => state.repoSlug === 'org/lease-repo');
+
+        expect(repoState.consecutiveFailures).toBe(3);
+        // 2^3 of base, on the value.
+        expect(repoState.effectiveCadenceMs).toBe(8 * baseCadenceMs);
+        expect(new Date(repoState.nextDueAt).getTime()).toBe(crashedAttemptAt + 8 * baseCadenceMs);
     });
 
     test('atomic manifest write: an interrupted partial temp write never replaces the target (#15763)', async () => {


### PR DESCRIPTION
Resolves #16551

Backoff on the tenant-repo sync lane reads `consecutiveFailures` and `lastRunAttemptAt`, and both advanced only *after* the work returned. A failure that prevents the work from returning — OOM, SIGKILL, host sleep, container stop mid-sweep — therefore left no record that anything was tried: `due` stayed true and the lane retried at full cadence indefinitely. **A crash loop is precisely what backoff exists to dampen, and it was the one failure class where backoff provably could not engage**, because the dampening was only ever available to failures polite enough to return.

Evidence: L2 (spec-driven contract tests; fixture-local, no live plane) → L3 required (the original AC6 live-lane observation — a widening retry interval read from the orchestrator log after deploy). Residual: AC6 [#16551].

## What shipped

An attempt is recorded **before** the work, in a `.in-flight` sidecar beside the revisions manifest — never inside it, because that file is a commit log whose commit-point fence `#15763` pins with two specs.

- **Written** after the lease fence and before the git phase, so a repo that never entered protected work records no attempt.
- **Cleared** in the per-repo `finally` that success, caught failure and lease-lost abort all pass through. Per-repo rather than sweep-terminal, so a crash during repo B cannot fold repo A's completed attempt into a failure.
- **Folded** at sweep start, before the due checks, so a crashed attempt dampens the very next decision rather than one sweep later.
- Records carry a **`runId`**, and every mutation merges by ownership: another run's entries carry forward untouched. A process must never publish its private view over shared state.
- The whole transaction — ownership re-inspection, read, merge, write — runs inside the **lease's own lifecycle guard**. A sidecar-only mutex would serialize sidecar writers while lease *acquisition* interleaved, so it could not establish generation authority.
- Guard entry **fails closed**: `enterLifecycleGuard` returning `null` means contention proved another actor is live, which is exactly when proceeding unguarded is worst.
- The manifest's ownership fence sits **immediately before its rename**, inside `writePersistedRevisions`. The rename is the commit point; everything before it is staging on a private temp path and discardable. A lost fence returns `{committed: false}` — a **deferral, not a failure**, since the successor owns forward progress.

`isRepoDue` is untouched. It was always correct given honest inputs, which the original ticket had right.

## Contract Ledger

| Target Surface | Source of Authority | Behavior | Fallback / Error Semantics | Evidence |
|---|---|---|---|---|
| `<revisionsFilePath>.in-flight` (new) | this PR | `{repoLabel: {startedMs, priorFailures, runId}}` for attempts started and not returned | Absent file = no residue; read fail-OPEN | fold witness |
| `readInFlightAttempts` | this PR | `{}` on absent/corrupt payload | Fail-OPEN, deliberately unlike the manifest's fail-closed strict reader: worst case is one unrecorded attempt, versus wedging a healthy lane on a torn crash hint | fold witness |
| `writeInFlightAttempts` | this PR | Temp-sibling + rename; removes the file at zero keys | Best-effort — a sidecar write failure must not fail a repo whose sync is fine | republication + takeover witnesses |
| `foldInFlightAttempts` | this PR | Advances `lastRunAttemptAt` to the crashed `startedMs`, sets `consecutiveFailures` to `priorFailures + 1`, preserves `lastIngestedRev` | Skips non-finite `startedMs` | 2 fold witnesses |
| `writePersistedRevisions` | extended here | New optional `assertOwnership`, awaited immediately before the rename; returns `{committed}` | Ownership lost ⇒ `{committed: false, reason: 'ownership-lost'}`, temp discarded, **no throw**. Structural I/O failure still throws `KB_TENANT_REPO_SYNC_MANIFEST_UPDATE_FAILED` | stale-eviction + fault-injection witnesses |
| `syncTenantRepos` | extended here | New `leasePath` parameter | Absent ⇒ no guard (direct-call/test path) | fail-closed witness |
| `repos[].consecutiveFailures` / `lastRunAttemptAt` | existing | Now also advanced by recovery | unchanged for returning paths | full suite |
| `isRepoDue` | existing | **unchanged** | n/a | its specs pass untouched |
| manifest commit-point fence | existing (`#15763`) | **unchanged** | n/a | both fence specs pass untouched |

Decision Record impact: `none`.

## Deltas from ticket

1. **The ticket's stated mechanism was falsified before implementation.** It described the failing path freezing its own counters; that code already existed and was correct. The counters were frozen because *nothing on the failing path executed* — 19 `Refreshing` lines against 19 heap aborts and **zero** catch-path executions. ACs were revised in-thread.
2. **Landing this required extending `writePersistedRevisions`**, a `#15763`-guarded function. Not foreseen by the ticket; the fence has to be at the commit point and nowhere else.
3. **One out-of-scope one-line repair is included:** `lifecycleGuardPath` is called at four sites in `heavyMaintenanceLeasePrimitives.mjs` and was never imported, so every guard-contention error path for lease release and renewal threw `ReferenceError` instead of its diagnostic. Pre-existing on `dev`; fixed here because it hard-blocks the required witness. The *class* — that module's error paths have no coverage — is being filed separately.
4. **Two live-plane claims about this lane were falsified and retracted in-channel** before any code landed. Neither affects this PR; the defect is established at spec level.

## Test Evidence

```
npm run test-unit -- test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncService.spec.mjs
  105 passed

npm run test-unit -- test/playwright/unit/ai/daemons/orchestrator/services/HeavyMaintenanceLeaseService.spec.mjs
  47 passed
```

Every behavioural claim has a witness verified RED against the specific commit that lacked the fix:

| property | RED at |
|---|---|
| a non-returning attempt is recorded | pre-fix |
| backoff grows across successive crashes | pre-fix |
| a recovered attempt is consumed once, never republished | `b89ef0bafc` |
| an evicted run does not clear its successor's entry | `1bd1bbf850` |
| successor acquisition is refused mid-transaction | `1bd1bbf850` |
| a manifest failure still surfaces its reason code | pre-fix |
| a contended guard makes recovery fail closed | pre-fix |
| eviction inside manifest staging commits nothing | `e6cf6d0bec` |

**Scope boundary.** I have not run the broader `ai/` suite from this worktree: `backup.spec.mjs` false-greens here for the reason #16617 documents (an unlinked worktree carries its own near-empty `.neo-ai-data`). A reviewer on a `--link-data` seat should expect that spec to fail, and it is not this diff.

## Post-Merge Validation

- [ ] AC6: the live lane retries on a widening interval rather than at flat cadence, read from `[TenantRepoSync]` orchestrator log lines after deploy.
- [ ] A real crash mid-sweep leaves a `.in-flight` entry the next boot folds, visible as the `did not return from its previous attempt` WARN line.
- [ ] No stale `.in-flight` file accumulates on a healthy lane across sweeps.

## Commits

- `81611b1ce0` — the sidecar: record, three call sites, recovery fold
- `830ac7a378` — N>1 backoff growth, and the cap correction it forced
- `3464c456e4` — recovery input and in-flight state become different objects
- `b89ef0bafc` — witness the lease fence an evicted run must respect
- `1bd1bbf850` — the record carries its owner, so a clear is conditional
- `940d96c73b` — the guard spans the whole transaction
- `79fa4bf379` — fail closed, verify before writing, cover the fold
- `e6cf6d0bec` — two mutations need two proofs; recovery must not swallow
- `7dff88f2eb` — the fence moves to the rename
- `f69f83a24d` — eviction-inside-staging witness + the `ReferenceError` repair

## Evolution

**Eight review cycles, seven defects, and six of them were in code written to fix the previous one** — each a check-then-act or fail-open exactly one layer down. Recorded because the sequence is the finding, not the individual fixes.

- *Manifest-resident → sidecar.* The obvious implementation broke two `#15763` lease specs. My first read was that they assert proxies and could be restated; wrong — the first spec's name states the property directly (*aborts without writing*), and writing scheduling state into a commit log removes the property rather than defeating a proxy.
- *The backoff cap nearly hid a broken multiplier.* The configured `backoffCapMs` is 2h and 1 failure against a 60min base also resolves to 2h, so the original assertion passed whether the exponential term worked or the value merely hit the ceiling. Both specs now run with the cap removed.
- *Fences, three times too shallow.* Around the transaction, then around the writer, then finally immediately before the rename. Each was right in spirit and one layer out. **The fence belongs immediately before the atomic commit instruction; everything before it is discardable staging.**
- *Six witnesses were wrong before they were right*, with one tell every time: I built the scenario I could **describe** instead of the one that **shares the property under test**. The rule taken from it — state the window as two boundaries before writing the test, and never trust a witness you have not seen fail.

Authored by Ada (Claude Opus 5, Claude Code). Session cc25e2eb-2a9a-46dc-b068-3de4c792cd2e.
