### PR TITLE
fix: Stack-return adoption keeps the stable projection shell (#16621)

### DIFF
--- a/apps/workstation/view/Workspace.mjs
+++ b/apps/workstation/view/Workspace.mjs
@@ -718,6 +718,16 @@ class Workspace extends Container {
     }
 
     /**
+     * The current projection shell's instance id — the discriminator between the reconciler's
+     * stable-topology fast path (shell retained) and the staged full path (shell replaced).
+     * Pane instances AND their DOM survive either path; only the shell identity flips.
+     * @returns {String|null}
+     */
+    getShellIdentity() {
+        return this.getReference('dock-host')?.items?.[0]?.id ?? null
+    }
+
+    /**
      * Returns one cached pane identity for Neural Link continuity receipts.
      * @param {String} itemId
      * @returns {String|null}
@@ -1747,7 +1757,7 @@ class Workspace extends Container {
                     receipt.phases.push('main-projected');
                     targetState.reconciling = false
                 } else {
-                    await me.refreshDockWorkspace();
+                    await me.refreshDockWorkspace({operation: descriptor?.operation});
                     receipt.phases.push('main-projected');
 
                     if (me.vesselWorkspaces.get(sourceWorkspaceId) === sourceState) {
@@ -2066,7 +2076,9 @@ class Workspace extends Container {
      * header text, FLIP motion, retained-indicator suppression, and the heavy Overflow menu witness.
      * @param {Object} [options={}]
      * @param {Boolean} [options.geometryOnly=false] Explicit stable-topology projection admission.
-     * @param {String|null} [options.operation=null] Committed reducer operation.
+     * @param {String|null} [options.operation=null] Committed reducer operation. `'detachItem'` and
+     *     `'transferNode'` admit the stable-topology fast path (in-place item reconciliation on the
+     *     retained shell) when the reconciler's structural validator proves the shell unchanged.
      * @param {String[]} [options.preserveItemIds=[]] Owner-held panes the reconciler must park
      *     instead of destroy (a terminal-first tear-out vessel owns its pane before it connects).
      * @returns {Promise<void>}
@@ -2111,7 +2123,10 @@ class Workspace extends Container {
             nextConfig,
             placeholders,
             preserveItemIds,
-            retainTopology: operation === 'detachItem',
+            // A transferNode adoption keeps the structural shell (one tabs node's items grow);
+            // the reconciler's stable-topology validator still rejects any transfer that does
+            // mutate structure, so non-stable placements keep the staged full path.
+            retainTopology: operation === 'detachItem' || operation === 'transferNode',
             resolveItem   : itemId => me.resolvePane(itemId, me.dockModel.items[itemId]),
             onProjectionStaged({plans}) {
                 const retainedTabBars = [...plans.values()]

--- a/test/playwright/e2e/workstation/WorkstationFiveBeatNL.spec.mjs
+++ b/test/playwright/e2e/workstation/WorkstationFiveBeatNL.spec.mjs
@@ -668,11 +668,19 @@ test.describe('Workstation — the five-beat multi-window journey', () => {
             ownerResult        = await app.callMethod(wsId, 'executeTearOutStep', [
                 {itemId: 'metrics', sourceNodeId: 'right-top-tabs'},
                 filmPace
-            ]),
+            ]);
+
+        // The step awaits the vessel birth internally, so its receipt is complete here. Asserting
+        // it BEFORE the popup wait converts a silent 90s waitForEvent timeout into the step's own
+        // arming/birth diagnostics — the receipt names the failing gate, the timeout names nothing.
+        expect(ownerResult.errors ?? [], JSON.stringify(ownerResult.proof ?? {})).toEqual([]);
+        expect(ownerResult.applied, 'the metrics tear-out must apply before merge staging continues').toBe(true);
+
+        const
             targetPopup        = await targetPopupPromise,
             sourcePopupPromise = page.waitForEvent('popup', {timeout: 90000}),
-            showCursor          = filmPace.showCursor ?? false,
-            cursorProofPromise  = captureFilmCursorLifecycle({
+            showCursor         = filmPace.showCursor ?? false,
+            cursorProofPromise = captureFilmCursorLifecycle({
                 action: () => app.callMethod(wsId, 'executeCrossWindowDockStep', [
                     {itemId: 'commits', sourceNodeId: 'right-bottom-tabs', targetItemId: 'metrics'},
                     {
@@ -2153,6 +2161,27 @@ test.describe('Workstation — the five-beat multi-window journey', () => {
         expect(dockResult.applied).toBe(true);
         assertFilmCursorLifecycle(cursorEvidence, {expectMigration: true, showCursor});
 
+        // Projection-continuity witnesses. Pane instances AND their DOM nodes survive
+        // EITHER reconciliation path (native reparenting moves them through the common-ancestor
+        // transaction — red-proof measured, not assumed), so the pane tag below is a reparenting
+        // regression guard, NOT the path discriminator. The discriminator is the SHELL identity:
+        // the staged full path replaces the shell instance (its reveal is the measured whole-
+        // workspace blank frame), the stable-topology fast path retains it.
+        const witnessArmed = await page.evaluate(() => {
+            const el = document.querySelector('.workstation-pane-queues');
+
+            if (!el) return false;
+
+            el.__paneContinuityWitness = true;
+            return true
+        });
+
+        expect(witnessArmed, 'the unmoved queues pane must exist to arm the DOM-continuity witness').toBe(true);
+
+        const shellBefore = await app.callMethod(wsId, 'getShellIdentity', []);
+
+        expect(shellBefore, 'the projection shell must be resolvable before the return').toBeTruthy();
+
         const {evidence: returnCursorEvidence, result} = await captureFilmCursorLifecycle({
             action: () => app.callMethod(wsId, 'executeStackReturnStep', [
                 {ownerItemId: 'metrics'},
@@ -2214,6 +2243,23 @@ test.describe('Workstation — the five-beat multi-window journey', () => {
         expect(await app.callMethod(wsId, 'getPaneIdentity', ['metrics'])).toBe(metricsBefore);
         expect(await app.callMethod(wsId, 'getPaneIdentity', ['commits'])).toBe(commitsBefore);
         expect(await readHeartbeat(app, wsId)).toBeGreaterThan(heartbeatBefore);
+
+        const witnessState = await page.evaluate(() => {
+            const el = document.querySelector('.workstation-pane-queues');
+
+            return {present: Boolean(el), retained: el?.__paneContinuityWitness === true}
+        });
+
+        expect(witnessState, 'an unmoved pane DOM node survives the stack-return adoption (native reparenting guard)').toEqual({
+            present : true,
+            retained: true
+        });
+
+        expect(
+            await app.callMethod(wsId, 'getShellIdentity', []),
+            'a topologically stable stack-return adoption retains the projection shell (no staged full re-stage)'
+        ).toBe(shellBefore);
+
         expect(pageErrors).toEqual([])
     });
 

--- a/test/playwright/unit/dashboard/DockProjectionReconciler.spec.mjs
+++ b/test/playwright/unit/dashboard/DockProjectionReconciler.spec.mjs
@@ -402,6 +402,40 @@ test.describe('Neo.dashboard.DockProjectionReconciler', () => {
         }
     });
 
+    test('reconciles an explicit same-topology item arrival without replacing the shell', async () => {
+        // The stack-return adoption shape: the arriving pane exists as a live instance
+        // (it survived its previous workspace), the structural shell is unchanged, and one tabs
+        // node's item set grows. The catalog entry without a node placement models exactly that.
+        const model = createSplitModel();
+
+        model.items.gamma = {componentRef: 'gamma', kind: 'panel', title: 'Gamma'};
+
+        const receipt = await reconcileModel(model, nextModel => {
+            nextModel.nodes['alpha-tabs'].items.push('gamma')
+        }, {
+            retainTopology: true
+        });
+
+        try {
+            const
+                alphaTab = DockProjectionReconciler.collectProjectedTabs(receipt.oldShell)
+                    .get('alpha-tabs'),
+                body     = alphaTab.getCardContainer(),
+                bar      = alphaTab.getTabBar();
+
+            expect(receipt.result.nextShell).toBe(receipt.oldShell);
+            expect(receipt.host.items).toEqual([receipt.oldShell]);
+            expect(body.items).toEqual([receipt.panes.alpha, receipt.panes.gamma]);
+            expect(bar.items.map(button => button.text)).toEqual(['Alpha', 'Gamma']);
+            expect(bar.sortZoneConfig.dockItemIds).toEqual(['alpha', 'gamma']);
+            expect(receipt.panes.gamma.isDestroyed).toBeFalsy();
+            expect(receipt.result.reconciledItems).toBe(true);
+            expect(receipt.stagedCount).toBe(1)
+        } finally {
+            receipt.host.destroy()
+        }
+    });
+
     test('fails an explicit retained-topology admission closed when structure changes', async () => {
         const receipt = await reconcileModel(createSplitModel(), nextModel => {
             nextModel.nodes['root-split'].orientation = 'vertical'


### PR DESCRIPTION
Resolves #16621

The vessel→main stack-return now projects through the reconciler's stable-topology fast path instead of the staged full rebuild: the return-transfer call site threads its committed reducer operation into `refreshDockWorkspace`, and the `retainTopology` admission accepts `'transferNode'` alongside `'detachItem'`. A topologically stable adoption (structural node set unchanged, one tabs node's items grow) now reconciles in place on the retained shell — the measured whole-workspace blank frame (~40ms, every pane un-rendered) and the ghosted landing re-stage at film pace are gone because the shell swap that painted them no longer happens for this operation. The reconciler's structural validator remains the gate: any transfer that genuinely mutates structure still takes the staged full path (existing negative unit case).

New introspection surface: `Workspace#getShellIdentity()` — the worker-side discriminator between the two projection paths (pane instances and their DOM survive BOTH paths via native reparenting; only the shell identity flips). The scene-4 witness set builds on it, and the merge-staging helper now asserts the tear-out receipt BEFORE its popup wait, converting silent 90s timeouts into the step's own arming diagnostics.

Evidence: L3 (headed browser runtime on the film host) → L3 required (close-target ACs are render-truth and film-pace assertions). Residual: none for #16621; parent #16499's S-3 family and the native-input discriminator stay on the parent.

## Deltas from ticket

- The r2 candidate mechanism on the parent (preservation-set asymmetry) was FALSIFIED by the reconciler contract read and corrected in r3 before implementation — the shipped fix is the r3 shape (operation threading + admission widening), strictly smaller than the r2 sketch.
- The originally-planned pane-DOM-continuity witness turned out NOT to discriminate the paths (red-proof run refused to go red: native reparenting preserves pane nodes on BOTH paths — measured, not assumed). It ships as a reparenting regression guard; the discriminating witness is shell identity.
- Suite-stability finding during verification: a pre-existing, roving, suite-load-sensitive gesture instability (arming failures, an uncaught null-`preview` TOCTOU in the dwell chain, proxy-render misses) surfaced in BOTH fix and no-fix arms of a 10-run controlled table — including one face in a beat where this diff provably does not execute. Filed as #16620 with the full evidence; solo runs are 6/6 green and the film pipeline (solo takes) is unaffected.

## Test Evidence

- Unit `test/playwright/unit/dashboard/DockProjectionReconciler.spec.mjs`: 14/14 — includes the NEW same-topology item-ARRIVAL pin (live unplaced pane materialized into the retained shell) beside the existing detachment + structural-negative cases.
- Unit `test/playwright/unit/apps/workstation/Workspace.spec.mjs`: 36/36 at the final head.
- E2e scene 4 (`WorkstationFiveBeatNL`): shell-identity witness RED-PROVEN at the pre-fix behavior (`Expected "neo-container-21", Received "neo-container-28"` — full-path shell replacement) → GREEN with the fix (spec-paced 6.2s and film-paced 12.9s runs).
- Film truth at the fixed head: per-frame YAVG over the entire film-paced scene-4 main-page video shows minimum 68.4 (boot frame) — the pre-fix defect signature was a dip to 36.1 from a 48.2 baseline at the adoption moment. No body-clear frame remains.
- Full five-beat suite: 8 passed / 1 take-gated skip per run, modulo the pre-existing ambient instability now owned by #16620 (one roving red in ~most full-suite runs on this host, both arms of the table).
- Dense tour (`WorkstationNL`, headed): green 27.1s at the fixed head.

## Post-Merge Validation

- [ ] take-19 dense-tour + five-beat capture: no whole-workspace blank at the stack-return beat on real footage (the operator-facing film QA that motivated the parent).
- [ ] #16620's battery (once its receipts land) confirms the ambient roving red rate is unchanged by this merge.

## Commits (if multi-commit)

- single commit: `fix(workstation): stack-return adoption keeps the stable projection shell (#16621)`

## Evolution (optional, only if pivots occurred during implementation)

The witness design pivoted once: pane-DOM continuity was the planned discriminator until its red-proof run stayed green against the reverted fix — the reconciler's full path preserves pane DOM via the common-ancestor transaction, so the discriminator moved up one level to shell identity. The refused red-proof is the reason this PR's witness actually witnesses.

Related: #16499 (parent — classification r1-r3 + receipts), #16500 (shared presentation family + shared instrument candidate), #16620 (ambient suite instability, filed from this lane's table).

Authored by Mnemosyne (Claude Fable 5, Claude Code). Session 84d669f4-2271-4d6a-8878-45e8754be6b3.
