### PR TITLE
fix: The proxy removal delta outlives its zone (#16623)

### DIFF
--- a/src/draggable/DragZone.mjs
+++ b/src/draggable/DragZone.mjs
@@ -337,7 +337,15 @@ class DragZone extends Base {
         // orphan the proxy's DOM node in the source window with no owner left to remove it.
         me.timeout(me.moveInMainThread ? 0 : 30)
             .catch(() => null)
-            .then(() => Neo.applyDeltas(windowId, [{action: 'removeNode', id}]));
+            .then(() => Neo.applyDeltas(windowId, [{action: 'removeNode', id}]))
+            .catch(reason => {
+                // The dispatch owns its terminal outcome: worker.Base's closed-port branch
+                // rejects with bare `undefined` when the destination window is already gone —
+                // the node died with its window, the cleanup is moot, settle silently. A
+                // REASONED rejection is a live-window delta failure; this detached chain has
+                // no caller to propagate to, so the console is the honest terminal surface.
+                reason !== undefined && console.error('DragZone: proxy removal delta failed', {id, reason, windowId})
+            });
 
         me.dragProxy.destroy()
     }

--- a/src/draggable/DragZone.mjs
+++ b/src/draggable/DragZone.mjs
@@ -327,12 +327,17 @@ class DragZone extends Base {
      * Override for using custom animations
      */
     destroyDragProxy() {
-        let me = this,
-            id = me.dragProxy.id;
+        let me         = this,
+            id         = me.dragProxy.id,
+            {windowId} = me;
 
-        me.timeout(me.moveInMainThread ? 0 : 30).then(() => {
-            Neo.applyDeltas(me.windowId, [{action: 'removeNode', id}])
-        });
+        // The cleanup delta must outlive this zone: core.Base#destroy() clears and rejects
+        // pending timeouts, and a zone torn down inside the deferral window (e.g. a closing
+        // dock vessel's chrome un-projection racing a cross-window drop) would otherwise
+        // orphan the proxy's DOM node in the source window with no owner left to remove it.
+        me.timeout(me.moveInMainThread ? 0 : 30)
+            .catch(() => null)
+            .then(() => Neo.applyDeltas(windowId, [{action: 'removeNode', id}]));
 
         me.dragProxy.destroy()
     }

--- a/test/playwright/unit/draggable/DragZone.spec.mjs
+++ b/test/playwright/unit/draggable/DragZone.spec.mjs
@@ -14,13 +14,19 @@ import DragZone       from '../../../../src/draggable/DragZone.mjs';
 import '../../../../src/manager/Instance.mjs';
 
 /**
- * Runs one proxy-teardown scenario against a spied `Neo.applyDeltas` and returns the
- * recorded dispatches. The spy is installed per call and always restored: the delta
- * surface is global, so a leaked recorder would poison sibling specs.
+ * Runs one proxy-teardown scenario against a spied `Neo.applyDeltas` and returns the recorded
+ * dispatches plus the proxy id captured BEFORE teardown — the id assertions must compare against
+ * an independently held value, never against the recorded payload itself. The spy is installed
+ * per call and always restored: the delta surface is global, so a leaked recorder would poison
+ * sibling specs.
  * @param {Function} scenario Receives the created zone; drives teardown timing.
- * @returns {Promise<Object[]>} The recorded `applyDeltas` calls as {windowId, deltas}.
+ * @param {Object} [options]
+ * @param {Function} [options.deltaResult] Maps a recorded call to the spy's returned promise —
+ *     the seam for simulating the transport's terminal outcomes (a vanished destination rejects
+ *     with bare `undefined`; live-window failures reject with a reason).
+ * @returns {Promise<{proxyId: String, recorded: Object[]}>}
  */
-async function recordProxyRemoval(scenario) {
+async function recordProxyRemoval(scenario, {deltaResult}={}) {
     const
         originalApplyDeltas = Neo.applyDeltas,
         recorded            = [],
@@ -30,31 +36,35 @@ async function recordProxyRemoval(scenario) {
         });
 
     Neo.applyDeltas = (windowId, deltas) => {
-        recorded.push({windowId, deltas});
-        return Promise.resolve()
+        const call = {deltas, windowId};
+
+        recorded.push(call);
+
+        return deltaResult ? deltaResult(call) : Promise.resolve()
     };
+
+    let proxyId;
 
     try {
         zone.dragProxy = Neo.create(Component, {appName: 'DraggableDragZoneTest'});
+        proxyId        = zone.dragProxy.id;
 
         await scenario(zone);
 
         // Both teardown paths resolve within the deferral ceiling (30ms) plus microtasks;
-        // one settled wait keeps the assertion race-free for the fixed AND the broken shape.
+        // one settled wait keeps the assertions race-free for the fixed AND the broken shape.
         await new Promise(resolve => setTimeout(resolve, 60))
     } finally {
         Neo.applyDeltas = originalApplyDeltas;
         !zone.isDestroyed && zone.destroy()
     }
 
-    return recorded
+    return {proxyId, recorded}
 }
 
 test.describe('Neo.draggable.DragZone', () => {
     test('the proxy removal delta survives a zone destroyed inside the deferral window', async () => {
-        const recorded = await recordProxyRemoval(zone => {
-            const proxyId = zone.dragProxy.id;
-
+        const {proxyId, recorded} = await recordProxyRemoval(zone => {
             zone.destroyDragProxy();
 
             // The dying-window race: the zone's owner chain is torn down before the deferred
@@ -65,21 +75,63 @@ test.describe('Neo.draggable.DragZone', () => {
 
             expect(zone.isDestroyed).toBe(true);
 
-            return Promise.resolve(proxyId)
+            return Promise.resolve()
         });
 
         expect(recorded, 'exactly one removal dispatch despite the destroyed zone').toHaveLength(1);
         expect(recorded[0].windowId).toBe('test-window-1');
-        expect(recorded[0].deltas[0].action).toBe('removeNode')
+        expect(recorded[0].deltas).toEqual([{action: 'removeNode', id: proxyId}])
     });
 
     test('the undisturbed teardown dispatches exactly one deferred removal', async () => {
-        const recorded = await recordProxyRemoval(zone => {
+        const {proxyId, recorded} = await recordProxyRemoval(zone => {
             zone.destroyDragProxy();
             return Promise.resolve()
         });
 
         expect(recorded, 'one dispatch, no duplicates from the survival guard').toHaveLength(1);
-        expect(recorded[0].deltas).toEqual([{action: 'removeNode', id: recorded[0].deltas[0].id}])
+        expect(recorded[0].deltas).toEqual([{action: 'removeNode', id: proxyId}])
+    });
+
+    test('a vanished destination settles silently — the closed-port rejection is owned, not unhandled', async () => {
+        // worker.Base's closed-port branch rejects the request promise with bare `undefined`
+        // (a vanished SharedWorker port). The detached teardown chain must observe that terminal
+        // outcome: an unowned rejection escapes as unhandledRejection, which this runner converts
+        // into a test failure — the unrepaired chain fails this test by construction.
+        const {recorded} = await recordProxyRemoval(zone => {
+            zone.destroyDragProxy();
+            zone.destroy();
+            return Promise.resolve()
+        }, {
+            deltaResult: () => Promise.reject(undefined)
+        });
+
+        expect(recorded, 'the dispatch is still attempted at the vanished destination').toHaveLength(1)
+    });
+
+    test('a reasoned delta failure in a live window stays visible instead of being swallowed', async () => {
+        const
+            originalConsoleError = console.error,
+            surfaced             = [];
+
+        console.error = (...args) => surfaced.push(args);
+
+        let outcome;
+
+        try {
+            outcome = await recordProxyRemoval(zone => {
+                zone.destroyDragProxy();
+                return Promise.resolve()
+            }, {
+                deltaResult: () => Promise.reject(new Error('delta transport failure'))
+            })
+        } finally {
+            console.error = originalConsoleError
+        }
+
+        expect(outcome.recorded).toHaveLength(1);
+        expect(surfaced, 'a reasoned rejection must surface exactly once').toHaveLength(1);
+        expect(surfaced[0][1]?.reason?.message, 'the surfaced entry names the failure')
+            .toContain('delta transport failure')
     });
 });

--- a/test/playwright/unit/draggable/DragZone.spec.mjs
+++ b/test/playwright/unit/draggable/DragZone.spec.mjs
@@ -1,0 +1,85 @@
+import {setup} from '../../setup.mjs';
+
+setup({
+    appConfig: {
+        name: 'DraggableDragZoneTest'
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../src/Neo.mjs';
+import * as core      from '../../../../src/core/_export.mjs';
+import Component      from '../../../../src/component/Base.mjs';
+import DragZone       from '../../../../src/draggable/DragZone.mjs';
+import '../../../../src/manager/Instance.mjs';
+
+/**
+ * Runs one proxy-teardown scenario against a spied `Neo.applyDeltas` and returns the
+ * recorded dispatches. The spy is installed per call and always restored: the delta
+ * surface is global, so a leaked recorder would poison sibling specs.
+ * @param {Function} scenario Receives the created zone; drives teardown timing.
+ * @returns {Promise<Object[]>} The recorded `applyDeltas` calls as {windowId, deltas}.
+ */
+async function recordProxyRemoval(scenario) {
+    const
+        originalApplyDeltas = Neo.applyDeltas,
+        recorded            = [],
+        zone                = Neo.create(DragZone, {
+            appName : 'DraggableDragZoneTest',
+            windowId: 'test-window-1'
+        });
+
+    Neo.applyDeltas = (windowId, deltas) => {
+        recorded.push({windowId, deltas});
+        return Promise.resolve()
+    };
+
+    try {
+        zone.dragProxy = Neo.create(Component, {appName: 'DraggableDragZoneTest'});
+
+        await scenario(zone);
+
+        // Both teardown paths resolve within the deferral ceiling (30ms) plus microtasks;
+        // one settled wait keeps the assertion race-free for the fixed AND the broken shape.
+        await new Promise(resolve => setTimeout(resolve, 60))
+    } finally {
+        Neo.applyDeltas = originalApplyDeltas;
+        !zone.isDestroyed && zone.destroy()
+    }
+
+    return recorded
+}
+
+test.describe('Neo.draggable.DragZone', () => {
+    test('the proxy removal delta survives a zone destroyed inside the deferral window', async () => {
+        const recorded = await recordProxyRemoval(zone => {
+            const proxyId = zone.dragProxy.id;
+
+            zone.destroyDragProxy();
+
+            // The dying-window race: the zone's owner chain is torn down before the deferred
+            // dispatch fires (a closing dock vessel's un-projection lands in the same tick as
+            // the drop). destroy() clears and rejects the pending timeout — the removal must
+            // dispatch anyway, or the proxy DOM is orphaned in the source window.
+            zone.destroy();
+
+            expect(zone.isDestroyed).toBe(true);
+
+            return Promise.resolve(proxyId)
+        });
+
+        expect(recorded, 'exactly one removal dispatch despite the destroyed zone').toHaveLength(1);
+        expect(recorded[0].windowId).toBe('test-window-1');
+        expect(recorded[0].deltas[0].action).toBe('removeNode')
+    });
+
+    test('the undisturbed teardown dispatches exactly one deferred removal', async () => {
+        const recorded = await recordProxyRemoval(zone => {
+            zone.destroyDragProxy();
+            return Promise.resolve()
+        });
+
+        expect(recorded, 'one dispatch, no duplicates from the survival guard').toHaveLength(1);
+        expect(recorded[0].deltas).toEqual([{action: 'removeNode', id: recorded[0].deltas[0].id}])
+    });
+});


### PR DESCRIPTION
Resolves #16623

The drag proxy's main-thread DOM removal now survives its zone's destruction AND owns its terminal dispatch outcome. `destroyDragProxy()` deferred the `removeNode` delta through the instance-scoped `core.Base#timeout()` — which `destroy()` clears and rejects — so any zone torn down inside the deferral window silently cancelled its own cleanup (deterministic in-process: a synchronous `destroy()` always beats the deferral timer). The repair binds the dispatch inputs locally, routes the delta through the rejection-surviving chain, and closes the transport contract the first cut missed: `Neo.applyDeltas()` returns `promiseMessage()`, and `worker.Base`'s closed-port branch rejects with bare `undefined` when the destination window is already gone — that vanished-destination rejection settles silently (the node died with its window; the cleanup is moot), while any REASONED rejection is a live-window delta failure surfaced via the console (the detached chain has no caller to propagate to). Engine-inherited: every `DragZone` consumer gets the same teardown guarantees.

Evidence: L2 (node unit runtime with a controllable delta-transport spy) → L2 sufficient for the close-target ACs (the race and BOTH terminal outcomes are fully reproducible in-process). Residual: none — the ticket's original filmed-receipt AC was retired by the review-cycle attribution correction recorded on #16623 (the on-camera chip is the static `neo-dock-stack-handle` toolbar grip, not this proxy; its presentation remedy is #16626 with the frame receipt on PR #16627).

## Deltas from ticket

- **Review cycle 1 falsified two of my claims and both corrections are in:** (1) the PR's original "harmless no-op" framing was wrong — the transport REJECTS on a vanished destination (bare `undefined`, unsuppressed by the global `isDestroyed` filter); the dispatch now owns that outcome and two new witnesses pin both terminal behaviors. (2) Attempting the exact-head visual receipt for the original AC3 falsified the ticket's filmed-chip attribution: an instrumented run proved every removal dispatches and settles, and a DOM identity probe named the on-camera survivor as the static stack grip (`neo-dock-stack-handle-metrics`) — legitimate toolbar chrome until window close. The ticket body carries the correction; the engine defect this PR fixes stands on its own unit-proven merits.

## Test Evidence

- `test/playwright/unit/draggable/DragZone.spec.mjs` — four witnesses, each red-proven at its target defect: destroy-race dispatch survival (`Expected 1, Received 0` pre-fix), undisturbed single dispatch, vanished-destination rejection owned (the runner converts an unhandled rejection into failure — the pre-repair chain fails this test by construction; verified failing before the terminal handler landed), reasoned failure surfaced exactly once with its message. Proxy-id assertions compare against the independently captured id (review RA: the prior self-referential assertion could not catch a wrong id).
- Adjacent consumer suites: `unit/dashboard/` + `unit/container/` — 537/537.
- Instrumented film-run receipts (probe reverted, zero commits): three `destroyDragProxy` events, all `moveInMainThread: true`, dispatch same-millisecond, `dispatch-settled` +20-40ms — transport-confirmed delivery in the live multi-window journey.

## Post-Merge Validation

- [ ] None — all delivered ACs are pre-merge verifiable at the unit layer; the filmed-surface obligations live on #16626/#16499.

## Commits (if multi-commit)

- `fix(draggable): the proxy removal delta outlives its zone (#16623)` — the survival guard + first unit coverage.
- `fix(draggable): the removal dispatch owns its terminal outcome (#16623)` — review cycle 1: transport-contract ownership + the two terminal-outcome witnesses + exact-id assertions.

## Evolution (optional, only if pivots occurred during implementation)

The review cycle's demand for the visual receipt is what exposed the mis-attribution: the receipt attempt showed the chip surviving a proven-delivered removal, the identity probe named the real element, and the ticket narrowed to the true engine defect while the filmed symptom's remedy was confirmed already-shipped elsewhere. The reviewer's falsifier did exactly what falsifiers are for.

Related: #16499 (parent lane), #16621 / PR #16622 (merged sibling), #16626 / PR #16627 (the filmed chip's actual remedy).

Authored by Mnemosyne (Claude Fable 5, Claude Code). Session 84d669f4-2271-4d6a-8878-45e8754be6b3.
