### PR TITLE
chore: Theme-deferral gates carry the true import-order story (#16506)

### DIFF
--- a/src/mixin/VdomLifecycle.mjs
+++ b/src/mixin/VdomLifecycle.mjs
@@ -6,9 +6,12 @@ import VDomUpdate       from '../manager/VDomUpdate.mjs';
 import VNodeUtil        from '../util/VNode.mjs';
 import {isDescriptor}   from '../core/ConfigSymbols.mjs';
 
-// Load-time binding: safe ONLY for per-process environment constants (e.g. `isSharedWorker`).
-// Mutable worker state (counters, event registration) must read `Neo.currentWorker` live — test
-// runners reuse worker processes across spec files and reassign the world between them.
+// Load-time binding: may capture `undefined` — a spec file's static imports can evaluate this
+// module BEFORE its top-level harness setup() assigns `Neo.currentWorker` (the assignment is
+// `??=`, never a replacement, and a surviving SharedWorker realm keeps the SAME worker object
+// on reconnect — no world is ever reassigned under a live binding). Safe here ONLY for
+// optional-chained per-process environment constants (e.g. `isSharedWorker`); anything mutable
+// (counters, event registration) must resolve `Neo.currentWorker` at call time.
 const {currentWorker} = Neo;
 
 /**
@@ -562,14 +565,16 @@ class VdomLifecycle extends Base {
         // any caller-side single-flight latch — tracks the REAL mount attempt instead of a
         // wrapper that resolves before the work begins. Rejections propagate through the chain
         // for the same reason.
-        // Read `Neo.currentWorker` LIVE, never the module-load binding: this gate consults MUTABLE
-        // worker state, and under test-runner worker-process reuse a later spec file's setup builds
-        // a fresh app world and reassigns `Neo.currentWorker` — a load-time binding then reads the
-        // PREVIOUS world's counter (0) while the live world is mid-load, silently skipping the
-        // deferral. One worker world per real runtime process makes both reads identical there.
-        if (!unitTestMode && autoMount && Neo.currentWorker.countLoadingThemeFiles !== 0) {
+        // Resolve `Neo.currentWorker` at CALL time, never via the module-load binding: import
+        // order can evaluate this module before the harness setup() assigns the worker, so the
+        // load-time capture may be `undefined` — a binding-read here then throws through the
+        // caller's catch and presents as a silently skipped deferral. One method-local read also
+        // keeps the count consult and the listener registration on one coherent owner.
+        const worker = Neo.currentWorker;
+
+        if (!unitTestMode && autoMount && worker.countLoadingThemeFiles !== 0) {
             return new Promise((resolve, reject) => {
-                Neo.currentWorker.on('themeFilesLoaded', function() {
+                worker.on('themeFilesLoaded', function() {
                     me.mounted ? resolve() : me.initVnode(mount).then(resolve, reject)
                 }, me, {once: true})
             })
@@ -1030,9 +1035,12 @@ class VdomLifecycle extends Base {
                     // }
 
                     // Verify that the critical rendering path => CSS files for the new tree is in place.
-                    // Live `Neo.currentWorker` read — mutable state; see the initVnode deferral gate.
-                    if (!config.isMiddleware && !config.unitTestMode && Neo.currentWorker.countLoadingThemeFiles !== 0) {
-                        Neo.currentWorker.on('themeFilesLoaded', function() {
+                    // Call-time `Neo.currentWorker` resolution, one read per invocation — the
+                    // initVnode deferral gate documents the import-order mechanism.
+                    const worker = Neo.currentWorker;
+
+                    if (!config.isMiddleware && !config.unitTestMode && worker.countLoadingThemeFiles !== 0) {
+                        worker.on('themeFilesLoaded', function() {
                             me.updateVdom(resolve, reject)
                         }, me, {once: true})
                     } else {


### PR DESCRIPTION
Resolves #16506

The three `VdomLifecycle.mjs` surfaces that carried the falsified worker-reassignment story now state the true mechanism, and both theme-deferral gates read `Neo.currentWorker` exactly once per invocation through a method-local. The corrected story: a spec file's static imports can evaluate the module BEFORE its top-level harness `setup()` assigns the worker (`??=`, never a replacement; a surviving SharedWorker realm keeps the SAME worker object on reconnect), so the module-load binding may capture `undefined` — the old binding-read threw through a caller's catch and presented as a silently skipped deferral. No "test runners reassign the world between spec files" claim survives; the module-header comment now also explains WHY the load-time binding stays safe for its optional-chained environment-constant reads. This is the Approve+Follow-Up obligation from PR #16504's review (the reviewer's Depth Floor falsified the shipped causal story while approving the seam; her single-read shape suggestion is adopted verbatim).

Evidence: L2 (node unit runtime) → L2 sufficient (the close-target ACs are comment-truth + shape + suites-stay-green; behavior is required byte-identical, and the single-read is semantically identical — same tick, same object, same two member accesses).

## Deltas from ticket

- The optional cold-import-order witness is NOT included, per the ticket's own "if cheap" clause: both gates short-circuit on `unitTestMode` before any worker read, so the unit harness cannot reach the read the witness would pin — a faithful witness needs a non-unit harness variant, which is not cheap. The mechanism remains pinned textually at all three surfaces and by #16503's close-out record.
- One new comment sentence at the binding site states that no world reassignment exists ("no world is ever reassigned under a live binding") — this is the negation the AC's spirit wants, not a surviving claim of reassignment.

## Test Evidence

- `test/playwright/unit/tab/` + `test/playwright/unit/component/` at the edited head: 87/87 passed — includes `BodyContainer.spec.mjs`, the original import-order casualty, and the tab plugin suites (the ticket's 31/26 sub-counts are folded into this current-head total).
- mixin surface e2e: `None found` beyond the #16434 five-beats journey cited by the ticket as the behavioral contract's own witness (unchanged behavior, not re-run here).

## Post-Merge Validation

- [ ] None — all ACs are pre-merge verifiable; no runtime surface changes.

## Commits (if multi-commit)

- single commit: `chore(mixin): theme-deferral gates carry the true import-order story, one worker read (#16506)`

Related: #16503 / PR #16504 (the shipped seam + the review carrying the falsification), #16434 (the contract's origin).

Authored by Mnemosyne (Claude Fable 5, Claude Code). Session 84d669f4-2271-4d6a-8878-45e8754be6b3.
