### PR TITLE
feat: The returning vessel departs behind a theme-ground overlay (#16626)

### DIFF
--- a/apps/workstation/view/Workspace.mjs
+++ b/apps/workstation/view/Workspace.mjs
@@ -1743,9 +1743,14 @@ class Workspace extends Container {
             // away and its window closes within the second — the departing overlay fades in over
             // the un-projection so the terminal window never presents a raw yank. No phase or
             // ordering change rides this; the close still dispatches through the refresh chain.
+            // The dispatch owns its terminal outcome: a vessel that already closed rejects with
+            // bare `undefined` (worker.Base closed-port) — moot presentation, silent settle;
+            // reasoned rejections are live-window delta failures and stay visible.
             Neo.applyDeltas(sourceState.windowId, [
                 {cls: {add: ['workstation-vessel-departing']}, id: 'document.body'}
-            ])
+            ]).catch(reason => {
+                reason !== undefined && console.error('Workspace: departing overlay dispatch failed', {reason})
+            })
         }
 
         me.refreshPromise = (me.refreshPromise || Promise.resolve())

--- a/apps/workstation/view/Workspace.mjs
+++ b/apps/workstation/view/Workspace.mjs
@@ -1738,16 +1738,19 @@ class Workspace extends Container {
             topologyExited: false
         };
 
-        if (!mainToVessel && sourceState.windowId) {
+        if (!mainToVessel && sourceState.windowId && sourceState.app?.mainView && !sourceState.app.mainView.isDestroyed) {
             // Presentation only, fire-and-forget: the source vessel's content was just adopted
             // away and its window closes within the second — the departing overlay fades in over
             // the un-projection so the terminal window never presents a raw yank. No phase or
             // ordering change rides this; the close still dispatches through the refresh chain.
+            // The class mounts on the vessel's VIEWPORT, never `document.body`: retheming fans to
+            // each vessel's mainView while the body keeps its BOOT theme class, so only the
+            // viewport resolves the LIVE `--workstation-ground` (see setWorkspaceTheme).
             // The dispatch owns its terminal outcome: a vessel that already closed rejects with
             // bare `undefined` (worker.Base closed-port) — moot presentation, silent settle;
             // reasoned rejections are live-window delta failures and stay visible.
             Neo.applyDeltas(sourceState.windowId, [
-                {cls: {add: ['workstation-vessel-departing']}, id: 'document.body'}
+                {cls: {add: ['workstation-vessel-departing']}, id: sourceState.app.mainView.id}
             ]).catch(reason => {
                 reason !== undefined && console.error('Workspace: departing overlay dispatch failed', {reason})
             })

--- a/apps/workstation/view/Workspace.mjs
+++ b/apps/workstation/view/Workspace.mjs
@@ -1738,6 +1738,16 @@ class Workspace extends Container {
             topologyExited: false
         };
 
+        if (!mainToVessel && sourceState.windowId) {
+            // Presentation only, fire-and-forget: the source vessel's content was just adopted
+            // away and its window closes within the second — the departing overlay fades in over
+            // the un-projection so the terminal window never presents a raw yank. No phase or
+            // ordering change rides this; the close still dispatches through the refresh chain.
+            Neo.applyDeltas(sourceState.windowId, [
+                {cls: {add: ['workstation-vessel-departing']}, id: 'document.body'}
+            ])
+        }
+
         me.refreshPromise = (me.refreshPromise || Promise.resolve())
             .then(() => me.timeout(0))
             .then(async () => {

--- a/resources/scss/src/apps/workstation/Viewport.scss
+++ b/resources/scss/src/apps/workstation/Viewport.scss
@@ -84,13 +84,19 @@
 }
 
 // Terminal presentation for a vessel whose stack was just adopted home: the workspace applies this
-// to the vessel window's body the moment the documents transfer, and the window closes shortly
-// after. The overlay fades IN over the un-projected content (a body-opacity fade would flash the
-// html underlay), covers any residual gesture artifacts, and holds the theme ground until the OS
-// close — the exit reads as deliberate instead of a raw content yank. Lives in THIS sheet because
-// the `?popout=` vessel never loads `Workspace.css` (sheet gate above).
-.workstation-vessel-departing::after {
-    animation : workstation-vessel-depart 250ms ease-out forwards;
+// to the vessel's VIEWPORT the moment the documents transfer, and the window closes shortly after.
+// The overlay fades IN over the un-projected content (a body-opacity fade would flash the html
+// underlay), covers any residual gesture artifacts, and holds the theme ground until the OS close —
+// the exit reads as deliberate instead of a raw content yank. Two placement constraints, both
+// load-bearing: it lives in THIS sheet because the `?popout=` vessel never loads `Workspace.css`
+// (sheet gate above), and it anchors on `.workstation-viewport` because retheming fans to each
+// vessel's mainView while `document.body` keeps its BOOT theme — only the viewport resolves the
+// LIVE `--workstation-ground`. Motion comes from the vocabulary (`--ease-in-soft`: exits), at the
+// `--motion-panel` tier: the vessel's post-adoption lifetime is bounded (~450ms — the fast-path
+// projection shortened it), and the fade must COMPLETE and hold before the OS close; the stage
+// tier measures ~0.66 opacity at window death. Reduced-motion collapse inherited.
+.workstation-viewport.workstation-vessel-departing::after {
+    animation : workstation-vessel-depart var(--motion-panel) var(--ease-in-soft) forwards;
     background: var(--workstation-ground);
     content   : '';
     inset     : 0;

--- a/resources/scss/src/apps/workstation/Viewport.scss
+++ b/resources/scss/src/apps/workstation/Viewport.scss
@@ -83,6 +83,28 @@
     opacity: .7;
 }
 
+// Terminal presentation for a vessel whose stack was just adopted home: the workspace applies this
+// to the vessel window's body the moment the documents transfer, and the window closes shortly
+// after. The overlay fades IN over the un-projected content (a body-opacity fade would flash the
+// html underlay), covers any residual gesture artifacts, and holds the theme ground until the OS
+// close — the exit reads as deliberate instead of a raw content yank. Lives in THIS sheet because
+// the `?popout=` vessel never loads `Workspace.css` (sheet gate above).
+.workstation-vessel-departing::after {
+    animation : workstation-vessel-depart 250ms ease-out forwards;
+    background: var(--workstation-ground);
+    content   : '';
+    inset     : 0;
+    opacity   : 0;
+    position  : fixed;
+    z-index   : 9999;
+}
+
+@keyframes workstation-vessel-depart {
+    to {
+        opacity: 1;
+    }
+}
+
 // Pane SKIN — everything a pane keeps when it is torn out of the workspace.
 //
 // The token bridge above made a vessel-hosted pane resolve the right colours; these rules are

--- a/test/playwright/e2e/workstation/WorkstationFiveBeatNL.spec.mjs
+++ b/test/playwright/e2e/workstation/WorkstationFiveBeatNL.spec.mjs
@@ -2188,8 +2188,53 @@ test.describe('Workstation — the five-beat multi-window journey', () => {
         // rethemed light must depart behind the LIGHT ground (document.body keeps its BOOT theme,
         // so a body-mounted consumer would close in the stale color). Each sample compares the
         // overlay's computed background against a same-context probe resolving the LIVE token.
+        // Cross-window authority kills the circularity: the MAIN page resolves the expected
+        // ground per theme, so a stale vessel cascade cannot satisfy the assertion by agreeing
+        // with itself. The pre-flip capture also witnesses the flip's authority (the two
+        // expectations must differ, or the retheme never landed anywhere).
+        const readMainGround = () => page.evaluate(() => {
+            const probe = document.createElement('div');
+
+            probe.style.background = 'var(--workstation-ground)';
+            document.querySelector('.workstation-viewport').appendChild(probe);
+
+            const ground = getComputedStyle(probe).backgroundColor;
+
+            probe.remove();
+            return ground
+        });
+
+        const expectedDarkGround = await readMainGround();
+
+        // Reduced-motion witness: the vocabulary collapses every duration at its root, and the
+        // departing rule must inherit that collapse THROUGH the vessel's loaded sheet. Probed on
+        // an in-vessel element under emulation BEFORE the real return (which needs normal motion
+        // for the fade-progression samples below).
+        await targetPopup.emulateMedia({reducedMotion: 'reduce'});
+
+        const reducedMotionDuration = await targetPopup.evaluate(() => {
+            const probe = document.createElement('div');
+
+            probe.className = 'workstation-viewport workstation-vessel-departing';
+            document.body.appendChild(probe);
+
+            const duration = getComputedStyle(probe, '::after').animationDuration;
+
+            probe.remove();
+            return duration
+        });
+
+        expect(reducedMotionDuration, 'the vocabulary reduced-motion collapse reaches the departing rule').toBe('0s');
+
+        await targetPopup.emulateMedia({reducedMotion: null});
+
         await app.callMethod(wsId, 'setWorkspaceTheme', ['neo-theme-neo-light']);
         await new Promise(resolve => setTimeout(resolve, 600));
+
+        const expectedLightGround = await readMainGround();
+
+        expect(expectedLightGround, 'the theme flip must change the resolved ground (flip authority)')
+            .not.toBe(expectedDarkGround);
 
         const departingSamples = (async () => {
             const samples = [];
@@ -2249,7 +2294,9 @@ test.describe('Workstation — the five-beat multi-window journey', () => {
 
         samples.forEach(sample => {
             expect(sample.background, 'the overlay resolves the LIVE theme ground, never the boot theme')
-                .toBe(sample.ground)
+                .toBe(sample.ground);
+            expect(sample.background, 'the vessel ground matches the MAIN window authority for the flipped theme')
+                .toBe(expectedLightGround)
         });
 
         expect(result.errors, JSON.stringify({

--- a/test/playwright/e2e/workstation/WorkstationFiveBeatNL.spec.mjs
+++ b/test/playwright/e2e/workstation/WorkstationFiveBeatNL.spec.mjs
@@ -2182,23 +2182,45 @@ test.describe('Workstation — the five-beat multi-window journey', () => {
 
         expect(shellBefore, 'the projection shell must be resolvable before the return').toBeTruthy();
 
-        // The departing-state witness must observe DURING the return: the source vessel's body
-        // gains the terminal class between the adoption and the OS close, and the window is gone
-        // by the time the step resolves. Poll in parallel; the popup closing ends the poll.
-        const departingSeen = (async () => {
+        // The departing-state witness observes DURING the return at RENDERED depth: the terminal
+        // presentation is a claim about live-theme paint, not class dispatch. The retheme before
+        // the return is the falsifier for the stale-carrier class of bug — a vessel born dark and
+        // rethemed light must depart behind the LIGHT ground (document.body keeps its BOOT theme,
+        // so a body-mounted consumer would close in the stale color). Each sample compares the
+        // overlay's computed background against a same-context probe resolving the LIVE token.
+        await app.callMethod(wsId, 'setWorkspaceTheme', ['neo-theme-neo-light']);
+        await new Promise(resolve => setTimeout(resolve, 600));
+
+        const departingSamples = (async () => {
+            const samples = [];
+
             for (let attempt = 0; attempt < 600; attempt++) {
-                if (targetPopup.isClosed()) return false;
+                if (targetPopup.isClosed()) break;
 
-                const seen = await targetPopup.evaluate(() =>
-                    document.body.classList.contains('workstation-vessel-departing')
-                ).catch(() => false);
+                const sample = await targetPopup.evaluate(() => {
+                    const root = document.querySelector('.workstation-viewport.workstation-vessel-departing');
 
-                if (seen) return true;
+                    if (!root) return null;
 
+                    const
+                        after = getComputedStyle(root, '::after'),
+                        probe = document.createElement('div');
+
+                    probe.style.background = 'var(--workstation-ground)';
+                    root.appendChild(probe);
+
+                    const groundNow = getComputedStyle(probe).backgroundColor;
+
+                    probe.remove();
+
+                    return {background: after.backgroundColor, ground: groundNow, opacity: Number(after.opacity)}
+                }).catch(() => null);
+
+                sample && samples.push(sample);
                 await new Promise(resolve => setTimeout(resolve, 16))
             }
 
-            return false
+            return samples
         })();
 
         const {evidence: returnCursorEvidence, result} = await captureFilmCursorLifecycle({
@@ -2216,7 +2238,19 @@ test.describe('Workstation — the five-beat multi-window journey', () => {
             targetPage         : page
         });
 
-        expect(await departingSeen, 'the source vessel presents the departing state before it closes').toBe(true);
+        const samples = await departingSamples;
+
+        console.log('[departing-witness]', JSON.stringify({count: samples.length, first: samples[0], last: samples.at(-1)}));
+
+        expect(samples.length, 'the departing overlay must render during the close window').toBeGreaterThan(0);
+        expect(samples.some(sample => sample.opacity > 0 && sample.opacity < 1),
+            'at least one intermediate fade state must render — motion, not a class toggle').toBe(true);
+        expect(samples.at(-1).opacity, 'the overlay settles opaque before the close').toBeGreaterThan(.9);
+
+        samples.forEach(sample => {
+            expect(sample.background, 'the overlay resolves the LIVE theme ground, never the boot theme')
+                .toBe(sample.ground)
+        });
 
         expect(result.errors, JSON.stringify({
             closeReceipt    : result.proof?.closeReceipt,

--- a/test/playwright/e2e/workstation/WorkstationFiveBeatNL.spec.mjs
+++ b/test/playwright/e2e/workstation/WorkstationFiveBeatNL.spec.mjs
@@ -2182,6 +2182,25 @@ test.describe('Workstation — the five-beat multi-window journey', () => {
 
         expect(shellBefore, 'the projection shell must be resolvable before the return').toBeTruthy();
 
+        // The departing-state witness must observe DURING the return: the source vessel's body
+        // gains the terminal class between the adoption and the OS close, and the window is gone
+        // by the time the step resolves. Poll in parallel; the popup closing ends the poll.
+        const departingSeen = (async () => {
+            for (let attempt = 0; attempt < 600; attempt++) {
+                if (targetPopup.isClosed()) return false;
+
+                const seen = await targetPopup.evaluate(() =>
+                    document.body.classList.contains('workstation-vessel-departing')
+                ).catch(() => false);
+
+                if (seen) return true;
+
+                await new Promise(resolve => setTimeout(resolve, 16))
+            }
+
+            return false
+        })();
+
         const {evidence: returnCursorEvidence, result} = await captureFilmCursorLifecycle({
             action: () => app.callMethod(wsId, 'executeStackReturnStep', [
                 {ownerItemId: 'metrics'},
@@ -2196,6 +2215,8 @@ test.describe('Workstation — the five-beat multi-window journey', () => {
             sourcePage         : targetPopup,
             targetPage         : page
         });
+
+        expect(await departingSeen, 'the source vessel presents the departing state before it closes').toBe(true);
 
         expect(result.errors, JSON.stringify({
             closeReceipt    : result.proof?.closeReceipt,


### PR DESCRIPTION
Resolves #16626

The stack-return's source vessel presents a deliberate terminal state instead of a raw content yank — and after review cycle 1, the presentation is bound to the LIVE theme and proven at rendered depth. At `documents-adopted` the commit handler fires one presentation-only `applyDeltas` at the source vessel's **viewport** (never `document.body`: retheming fans to each vessel's `mainView` while the body keeps its BOOT theme class — `setWorkspaceTheme`'s own contract — so only the viewport resolves the live `--workstation-ground`). The overlay's motion comes from the product vocabulary: `--motion-panel` duration with `--ease-in-soft` (the exits easing), reduced-motion collapse inherited from the vocabulary root. The panel tier is a measured choice: the vessel's post-adoption lifetime is ~450ms (the #16621 fast path shortened it), and the stage tier's 400ms measured only 0.66 opacity at window death — the fade must complete and hold before the OS close, and at the panel tier it measures 1.0. The dispatch owns its terminal transport outcome (bare-`undefined` closed-port rejection settles silently; reasoned rejections surface), mirroring the #16624 contract.

Evidence: L3 (headed browser runtime, real popup windows, computed-style reads inside the closing vessel) → L3 required (the close-target ACs are rendered cross-window truth). Residual: none on this leaf — the live-theme, rendered-motion, and completion claims are all measured in-run; the whole-film QA remains #16499's gate.

## Deltas from ticket

- **Review cycle 1 (all findings adopted):** (1) the body-mounted carrier was falsified by the reviewer's retheme challenge — the class now mounts on the vessel's viewport, and the witness FLIPS THE THEME before the return so the stale-carrier bug class stays red-provable forever; (2) the hard-coded `250ms ease-out` violated the motion vocabulary — replaced with `--motion-panel` + `--ease-in-soft`, with the tier choice justified by measurement at the call site; (3) the class-only witness proved dispatch, not rendering — replaced by a computed-style sampler that reads the `::after`'s opacity progression and compares its background against a same-context probe resolving the live token, every sample.
- The witness poll cadence (16ms) is bounded by the popup's own close rather than a wall-clock guess.

## Test Evidence

- Scene 4 (`WorkstationFiveBeatNL`, film-paced headed): the upgraded witness RED-PROVEN against the body-mounted implementation (zero samples — the viewport-anchored selector never matches a body-mounted class) → GREEN with the fix: **20 samples, opacity 0 → 1.0 terminal, `background === ground` on every sample at the LIGHT theme's values** (`rgb(242, 245, 249)`) after an in-test `setWorkspaceTheme('neo-theme-neo-light')` flip — the reviewer's exact falsifier, running as a permanent witness. Intermediate fade states asserted (motion rendered, not a class toggle). The stage-tier variant was additionally measured red (terminal opacity 0.657) before the panel tier landed.
- `test/playwright/unit/apps/workstation/Workspace.spec.mjs`: 36/36 at the final head.
- Themes rebuilt (`build-themes -n -t all -e dev`) before every headed verification.
- Ambient note: two runs in this cycle hit the pre-existing #16620 arming race at the FIRST tear-out (before this diff's code executes), failing fast with the named `armed:false` receipt — the unmasking this lane added earlier. Attribution unchanged.

## Post-Merge Validation

- [ ] Next staged take on #16499: the departing exit at film pace on real footage, both themes (the whole-film gate; the mechanism-level claims are already measured in-run).

## Commits (if multi-commit)

- `feat(workstation): the returning vessel departs behind a theme-ground overlay (#16626)` — the original overlay + during-step class witness.
- `feat(workstation): the departing dispatch owns its terminal outcome (#16626)` — transport-contract ownership (pre-review, from the #16624 cycle's finding).
- `feat(workstation): the departing overlay rides the live theme carrier (#16626)` — review cycle 1: viewport carrier + motion vocabulary + rendered-depth witness with the retheme falsifier.

## Evolution (optional, only if pivots occurred during implementation)

The reviewer's retheme challenge converted directly into the witness's strongest assertion: the test now flips the theme before every return and proves the overlay resolves the live ground sample-by-sample. The motion-tier choice also inverted once on measurement — the semantically-obvious stage tier cannot complete inside the window my own earlier fix shortened; the call-site comment carries that measurement so the next reader doesn't "fix" it back.

Related: #16499 (parent), #16623 / PR #16624 (transport contract + the grip attribution correction), #16621 / PR #16622 (merged — the fast path that bounds the fade budget).

Authored by Mnemosyne (Claude Fable 5, Claude Code). Session 84d669f4-2271-4d6a-8878-45e8754be6b3.
