### PR TITLE
fix(ai): thread the tenant credential into the blobless mirror's content read

### DIFF
--- a/ai/daemons/orchestrator/services/TenantRepoSyncService.mjs
+++ b/ai/daemons/orchestrator/services/TenantRepoSyncService.mjs
@@ -1466,7 +1466,12 @@ class TenantRepoSyncService extends Base {
                     rootKind     : repo.rootKind || 'external-source',
                     parserId     : repo.parserId,
                     parserVersion: repo.parserVersion,
-                    gitMirror
+                    gitMirror,
+                    // The clone and fetch above are not the last authenticated operations of this
+                    // sweep. On a blobless mirror the envelope's own `show <rev>:<path>` resolves
+                    // every blob through a lazy promisor fetch, which re-authenticates — so a repo
+                    // whose remote refuses anonymous reads lists fine and then fails per file.
+                    credentialRef: repo.credentialRef
                 });
 
                 if (typeof envelope?.headRevision !== 'string' || !envelope.headRevision.trim()) {

--- a/ai/services/knowledge-base/helpers/gitMirror.mjs
+++ b/ai/services/knowledge-base/helpers/gitMirror.mjs
@@ -1189,15 +1189,38 @@ export async function listRevisionPaths({mirrorRoot, tenantId, repoSlug, revisio
 
 /**
  * @summary Reads one text file from a mirror revision.
+ *
+ * ## Why this read takes a credential and the other reads do not
+ *
+ * On the blobless mirror `cloneIfMissing` creates, this is the ONLY operation that can reach the
+ * network. `for-each-ref`, `rev-parse`, `merge-base --is-ancestor`, `diff --name-status` and
+ * `ls-tree` are answered entirely from the commit graph and trees, which the filter keeps complete.
+ * `show <revision>:<path>` wants a blob, and the filter guarantees the blob is absent — so git
+ * resolves it through a lazy promisor fetch against `remote.origin`.
+ *
+ * That fetch is a fresh authentication. Credentials here are per-invocation by design:
+ * `createGitExecutionEnvironment` builds a disposable `mkdtemp` HOME with an empty `.gitconfig`,
+ * delivers the secret through `GIT_ASKPASS`, and deletes the whole environment afterwards — nothing
+ * is written into the mirror's own config. So a `show` invoked without `credentialRef` is genuinely
+ * anonymous, and against a private remote it fails with `could not fetch <oid> from promisor
+ * remote`. A public remote serves the same fetch to an anonymous client, which is why this is
+ * invisible until the first private tenant.
+ *
+ * `credentialRef` stays OPTIONAL: omitted, the read is anonymous, which remains correct for a public
+ * remote and for a mirror whose blob is already local. Do NOT propagate it to the graph and tree
+ * reads above — an operation that cannot reach the network should stay unable to resolve a secret.
+ *
  * @param {Object} options
  * @param {String} options.mirrorRoot Root directory for tenant repo mirrors.
  * @param {String} options.tenantId Tenant id.
  * @param {String} options.repoSlug Repository slug.
  * @param {String} options.revision Resolved revision.
  * @param {String} options.sourcePath Repo-relative source path.
+ * @param {String|Object|null} [options.credentialRef] Durable credential reference for the lazy
+ *     promisor fetch. Required for a private remote whose blobs are not yet local.
  * @returns {Promise<String>}
  */
-export async function readRevisionFile({mirrorRoot, tenantId, repoSlug, revision, sourcePath} = {}) {
+export async function readRevisionFile({mirrorRoot, tenantId, repoSlug, revision, sourcePath, credentialRef} = {}) {
     if (!sourcePath || sourcePath.includes('\0')) {
         throw createGitMirrorError(
             'KB_GITMIRROR_PATH_INVALID',
@@ -1209,8 +1232,10 @@ export async function readRevisionFile({mirrorRoot, tenantId, repoSlug, revision
 
     const result = await runGit(['show', `${revision}:${sourcePath}`], {
         cwd           : mirrorPath,
+        credentialRef,
         failureCode   : 'KB_GITMIRROR_FILE_READ_FAILED',
-        failureMessage: 'GitMirror failed to read a revision file'
+        failureMessage: 'GitMirror failed to read a revision file',
+        knownHostsPath: getKnownHostsPath(mirrorRoot)
     });
 
     return result.stdout;

--- a/ai/services/knowledge-base/helpers/tenantRepoIngestEnvelopeBuilder.mjs
+++ b/ai/services/knowledge-base/helpers/tenantRepoIngestEnvelopeBuilder.mjs
@@ -207,10 +207,14 @@ async function listRevisionPaths({gitMirror, identity, revision}) {
  * @param {Object} options.identity Tenant-repo mirror identity.
  * @param {String} options.revision Resolved revision.
  * @param {String} options.sourcePath Repo-relative source path.
+ * @param {String|Object|null} [options.credentialRef] Durable credential reference. The mirror is
+ *     blobless, so this read is the one envelope operation that reaches the network — see
+ *     `gitMirror.readRevisionFile`. It is threaded explicitly rather than carried on `identity`,
+ *     which is spread into the graph and tree reads that must stay credential-free.
  * @returns {Promise<String>}
  * @private
  */
-async function readRevisionFile({gitMirror, identity, revision, sourcePath}) {
+async function readRevisionFile({gitMirror, identity, revision, sourcePath, credentialRef}) {
     if (!sourcePath || sourcePath.includes('\0')) {
         throw createIngestEnvelopeError(
             'KB_INGEST_ENVELOPE_PATH_INVALID',
@@ -219,7 +223,7 @@ async function readRevisionFile({gitMirror, identity, revision, sourcePath}) {
     }
 
     try {
-        return await gitMirror.readRevisionFile({...identity, revision, sourcePath});
+        return await gitMirror.readRevisionFile({...identity, revision, sourcePath, credentialRef});
     } catch (error) {
         throw createIngestEnvelopeError(
             'KB_INGEST_ENVELOPE_FILE_READ_FAILED',
@@ -240,7 +244,7 @@ async function readRevisionFile({gitMirror, identity, revision, sourcePath}) {
  * @returns {Promise<Array<Object>>}
  * @private
  */
-async function buildFilePayloads({gitMirror, identity, revision, paths, rootKind, parserId, parserVersion}) {
+async function buildFilePayloads({gitMirror, identity, revision, paths, rootKind, parserId, parserVersion, credentialRef}) {
     const files = [];
 
     for (const sourcePath of paths) {
@@ -248,7 +252,7 @@ async function buildFilePayloads({gitMirror, identity, revision, paths, rootKind
             sourcePath,
             repoSlug: identity.repoSlug,
             rootKind,
-            content : await readRevisionFile({gitMirror, identity, revision, sourcePath}),
+            content : await readRevisionFile({gitMirror, identity, revision, sourcePath, credentialRef}),
             ...(parserId ? {parserId} : {}),
             ...(parserVersion ? {parserVersion} : {})
         });
@@ -263,7 +267,7 @@ async function buildFilePayloads({gitMirror, identity, revision, paths, rootKind
  * @returns {Promise<Object>}
  * @private
  */
-async function buildFullEnvelope({gitMirror, identity, headRevision, rootKind, parserId, parserVersion}) {
+async function buildFullEnvelope({gitMirror, identity, headRevision, rootKind, parserId, parserVersion, credentialRef}) {
     const paths = await listRevisionPaths({gitMirror, identity, revision: headRevision});
     const files = await buildFilePayloads({
         gitMirror,
@@ -272,7 +276,8 @@ async function buildFullEnvelope({gitMirror, identity, headRevision, rootKind, p
         paths,
         rootKind,
         parserId,
-        parserVersion
+        parserVersion,
+        credentialRef
     });
 
     return {
@@ -299,6 +304,10 @@ async function buildFullEnvelope({gitMirror, identity, headRevision, rootKind, p
  * @param {String} [options.parserId] Optional server parser id.
  * @param {String} [options.parserVersion] Optional parser version.
  * @param {Object} [options.gitMirror=GitMirror] Injectable GitMirror implementation for tests.
+ * @param {String|Object|null} [options.credentialRef] Durable credential reference for the tenant
+ *     repo. Reaches only the content read: the mirror is blobless, so `show <rev>:<path>` resolves
+ *     each blob through a lazy promisor fetch that re-authenticates against the remote. Omitted,
+ *     content reads are anonymous — correct for a public remote, fatal for a private one.
  * @returns {Promise<Object>}
  */
 export async function buildIngestEnvelope({
@@ -310,7 +319,8 @@ export async function buildIngestEnvelope({
     rootKind = 'external-source',
     parserId,
     parserVersion,
-    gitMirror = GitMirror
+    gitMirror = GitMirror,
+    credentialRef
 } = {}) {
     const identity = {
         tenantId,
@@ -335,7 +345,7 @@ export async function buildIngestEnvelope({
     });
 
     if (!baseRevision) {
-        return await buildFullEnvelope({gitMirror, identity, headRevision, rootKind, parserId, parserVersion});
+        return await buildFullEnvelope({gitMirror, identity, headRevision, rootKind, parserId, parserVersion, credentialRef});
     }
 
     const linear = await gitMirror.isAncestor({
@@ -345,7 +355,7 @@ export async function buildIngestEnvelope({
     });
 
     if (!linear) {
-        return await buildFullEnvelope({gitMirror, identity, headRevision, rootKind, parserId, parserVersion});
+        return await buildFullEnvelope({gitMirror, identity, headRevision, rootKind, parserId, parserVersion, credentialRef});
     }
 
     const diff = await gitMirror.diffRevisions({
@@ -365,7 +375,8 @@ export async function buildIngestEnvelope({
             paths,
             rootKind,
             parserId,
-            parserVersion
+            parserVersion,
+            credentialRef
         }),
         deleted: [...new Set(diff.deleted || [])]
             .sort()

--- a/test/playwright/unit/ai/services/knowledge-base/tenantRepoIngestEnvelopeCredential.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/tenantRepoIngestEnvelopeCredential.spec.mjs
@@ -1,0 +1,181 @@
+import {test, expect} from '@playwright/test';
+
+import fs          from 'fs-extra';
+import os          from 'os';
+import path        from 'path';
+import {execFile}  from 'child_process';
+import {promisify} from 'util';
+
+import {cloneIfMissing, listRevisionPaths, readRevisionFile, resolveHead}
+                                  from '../../../../../../ai/services/knowledge-base/helpers/gitMirror.mjs';
+import {buildIngestEnvelope}      from '../../../../../../ai/services/knowledge-base/helpers/tenantRepoIngestEnvelopeBuilder.mjs';
+
+const execFileAsync = promisify(execFile);
+
+/**
+ * @summary The blobless mirror's content read is the one git call that reaches the network, so it is
+ * the one call that needs a credential.
+ *
+ * The tenant mirror is cloned `--filter=blob:none`. That keeps commits and trees
+ * complete — `for-each-ref`, `rev-parse`, `merge-base`, `diff --name-status` and `ls-tree` are all
+ * answered from disk — but leaves every blob absent, so `show <revision>:<path>` resolves through a
+ * lazy promisor fetch against `remote.origin`. `gitMirror.mjs` documents that trade and asserts it is
+ * "behind the same credential"; it was not. `credentialRef` reached `runGit` at the clone and fetch
+ * call sites only, so against a private remote every tenant listed fine and then failed per file with
+ * `KB_INGEST_ENVELOPE_FILE_READ_FAILED`.
+ *
+ * It survived every prior test because the only tenant repo this project has ingested is public, and
+ * a public remote serves a promisor fetch to an anonymous client. These specs therefore avoid a
+ * fixture that can succeed anonymously: the first makes the promisor remote genuinely unreachable, so
+ * a read that did not need the network could not fail; the second asserts the credential reaches the
+ * content read and NOT the graph and tree reads, which must stay unable to resolve a secret.
+ *
+ * @see https://github.com/neomjs/neo/issues/16631
+ * @see ai/services/knowledge-base/helpers/gitMirror.mjs
+ * @see ai/services/knowledge-base/helpers/tenantRepoIngestEnvelopeBuilder.mjs
+ */
+
+test.describe('Tenant repo ingest: content reads carry a credential (#16631)', () => {
+    let root;
+
+    test.beforeEach(async () => {
+        root = await fs.mkdtemp(path.join(os.tmpdir(), 'neo-ingest-credential-test-'));
+    });
+
+    test.afterEach(async () => {
+        await fs.remove(root);
+    });
+
+    async function git(args, cwd) {
+        const {stdout} = await execFileAsync('git', args, {cwd});
+        return stdout.trim();
+    }
+
+    /**
+     * `file://` rather than a bare path: git ignores `--filter` for local path clones and hardlinks
+     * the object store instead, which would hand the mirror every blob and make these specs vacuous.
+     * `uploadpack.allowFilter` is what makes the source advertise filter support — without it git
+     * warns, writes the promisor config anyway, and clones everything.
+     */
+    async function createFilterCapableSource() {
+        const source = path.join(root, 'source');
+
+        await fs.ensureDir(source);
+        await git(['init', '--initial-branch=main'], source);
+        await fs.writeFile(path.join(source, 'alpha.txt'), 'alpha v1\n');
+        await git(['add', '.'], source);
+        await git(['-c', 'user.name=Neo Test', '-c', 'user.email=test@example.com', 'commit', '-m', 'initial'], source);
+        await git(['config', 'uploadpack.allowFilter', 'true'], source);
+
+        return {source, cloneUrl: `file://${source}`};
+    }
+
+    test('the content read needs the remote; the tree read does not', async () => {
+        const
+            {source, cloneUrl} = await createFilterCapableSource(),
+            identity           = {mirrorRoot: path.join(root, 'mirrors'), tenantId: 'tenant-a', repoSlug: 'org/repo'};
+
+        await cloneIfMissing({...identity, cloneUrl});
+
+        const revision = await resolveHead({...identity, ref: 'HEAD'});
+
+        // Make the promisor remote unreachable. Nothing else changes: the mirror, its refs and its
+        // trees are untouched on disk, so any read answered locally must still succeed.
+        await fs.remove(source);
+
+        const paths = await listRevisionPaths({...identity, revision});
+
+        expect(paths).toContain('alpha.txt');
+
+        // The control above is what makes this assertion meaningful — the mirror is intact, so this
+        // can only fail because `show` had to leave the machine.
+        let readError = null;
+
+        try {
+            await readRevisionFile({...identity, revision, sourcePath: 'alpha.txt'});
+        } catch (error) {
+            readError = error;
+        }
+
+        expect(readError).not.toBeNull();
+        expect(readError.code).toBe('KB_GITMIRROR_FILE_READ_FAILED');
+    });
+
+    test('credentialRef reaches the content read and only the content read', async () => {
+        const
+            credentialRef = 'env:TENANT_TEST_TOKEN',
+            seen          = {resolveHead: [], isAncestor: [], listRevisionPaths: [], readRevisionFile: []},
+            record        = (name, options) => {
+                seen[name].push(options.credentialRef);
+            };
+
+        const gitMirrorFake = {
+            resolveHead(options) {
+                record('resolveHead', options);
+                return 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+            },
+            isAncestor(options) {
+                record('isAncestor', options);
+                return true;
+            },
+            diffRevisions() {
+                return {addedOrChanged: ['alpha.txt'], deleted: []};
+            },
+            listRevisionPaths(options) {
+                record('listRevisionPaths', options);
+                return ['alpha.txt'];
+            },
+            readRevisionFile(options) {
+                record('readRevisionFile', options);
+                return 'alpha v1\n';
+            }
+        };
+
+        const
+            mirrorRoot = path.join(root, 'mirrors'),
+            {cloneUrl} = await createFilterCapableSource();
+
+        // buildIngestEnvelope refuses a mirror that is not on disk before it reaches any git call, so
+        // a real one has to exist even though every read below is faked. Created through
+        // cloneIfMissing rather than mkdir so the fixture lands wherever the mirror-path derivation
+        // puts it — a hand-built path would encode a layout this spec has no business pinning.
+        await cloneIfMissing({mirrorRoot, tenantId: 'tenant-a', repoSlug: 'org/repo', cloneUrl});
+
+        // BOTH envelope shapes, because they read through different call chains and a single run
+        // exercises only one of them: with a base revision the builder diffs and never calls
+        // listRevisionPaths, so asserting on that call from the incremental run alone is an
+        // assertion over an empty array — vacuously true, and green against a mirror that leaks the
+        // credential to every read.
+        await buildIngestEnvelope({
+            tenantId       : 'tenant-a',
+            repoSlug       : 'org/repo',
+            mirrorRoot,
+            lastIngestedRev: 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+            gitMirror      : gitMirrorFake,
+            credentialRef
+        });
+        await buildIngestEnvelope({
+            tenantId       : 'tenant-a',
+            repoSlug       : 'org/repo',
+            mirrorRoot,
+            lastIngestedRev: null,
+            gitMirror      : gitMirrorFake,
+            credentialRef
+        });
+
+        // Every guarded call must have been OBSERVED before its polarity means anything.
+        for (const [name, refs] of Object.entries(seen)) {
+            expect(refs.length, `${name} was never called, so its assertion proves nothing`).toBeGreaterThan(0);
+        }
+
+        // The fix.
+        expect(seen.readRevisionFile.every(ref => ref === credentialRef)).toBe(true);
+
+        // The invariant the fix must not break. A read that cannot reach the network must stay unable
+        // to resolve a secret, so a later "consistency" pass cannot widen this by spreading
+        // credentialRef onto `identity`.
+        expect(seen.resolveHead.every(ref => ref === undefined)).toBe(true);
+        expect(seen.isAncestor.every(ref => ref === undefined)).toBe(true);
+        expect(seen.listRevisionPaths.every(ref => ref === undefined)).toBe(true);
+    });
+});

--- a/test/playwright/unit/ai/services/knowledge-base/tenantRepoIngestEnvelopeCredential.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/tenantRepoIngestEnvelopeCredential.spec.mjs
@@ -101,10 +101,53 @@ test.describe('Tenant repo ingest: content reads carry a credential (#16631)', (
         expect(readError.code).toBe('KB_GITMIRROR_FILE_READ_FAILED');
     });
 
+    test('the production read hands the credential to git, not merely to the builder', async () => {
+        const
+            {source} = await createFilterCapableSource(),
+            identity = {mirrorRoot: path.join(root, 'mirrors'), tenantId: 'tenant-b', repoSlug: 'org/prod'};
+
+        // A BARE PATH, not file://. git ignores --filter for a local path clone and hardlinks the
+        // object store instead, so this mirror holds every blob. That is the point: the read below
+        // cannot fail for want of the network, so the only variable left is the credential.
+        await cloneIfMissing({...identity, cloneUrl: source});
+
+        const revision = await resolveHead({...identity, ref: 'HEAD'});
+
+        // Control. Without a credential the read succeeds — proving the failure asserted next is
+        // caused by the credential reaching git, and not by a broken mirror or an absent blob.
+        expect(await readRevisionFile({...identity, revision, sourcePath: 'alpha.txt'})).toContain('alpha');
+
+        // Witness. An `env:` credentialRef naming a variable that does not exist can only fail inside
+        // runGit's credential resolution. So this throws if and only if credentialRef travelled all
+        // the way from readRevisionFile's signature into the real runGit call — which is the seam a
+        // fake gitMirror can never exercise, and the one deleting the argument would break.
+        let credentialError = null;
+
+        try {
+            await readRevisionFile({
+                ...identity,
+                revision,
+                sourcePath   : 'alpha.txt',
+                credentialRef: 'env:NEO_TEST_DELIBERATELY_ABSENT_TOKEN'
+            });
+        } catch (error) {
+            credentialError = error;
+        }
+
+        expect(credentialError).not.toBeNull();
+        expect(credentialError.code).toBe('KB_GITMIRROR_CREDENTIAL_REF_INVALID');
+    });
+
     test('credentialRef reaches the content read and only the content read', async () => {
         const
             credentialRef = 'env:TENANT_TEST_TOKEN',
-            seen          = {resolveHead: [], isAncestor: [], listRevisionPaths: [], readRevisionFile: []},
+            seen          = {
+                resolveHead      : [],
+                isAncestor       : [],
+                diffRevisions    : [],
+                listRevisionPaths: [],
+                readRevisionFile : []
+            },
             record        = (name, options) => {
                 seen[name].push(options.credentialRef);
             };
@@ -118,7 +161,8 @@ test.describe('Tenant repo ingest: content reads carry a credential (#16631)', (
                 record('isAncestor', options);
                 return true;
             },
-            diffRevisions() {
+            diffRevisions(options) {
+                record('diffRevisions', options);
                 return {addedOrChanged: ['alpha.txt'], deleted: []};
             },
             listRevisionPaths(options) {
@@ -176,6 +220,7 @@ test.describe('Tenant repo ingest: content reads carry a credential (#16631)', (
         // credentialRef onto `identity`.
         expect(seen.resolveHead.every(ref => ref === undefined)).toBe(true);
         expect(seen.isAncestor.every(ref => ref === undefined)).toBe(true);
+        expect(seen.diffRevisions.every(ref => ref === undefined)).toBe(true);
         expect(seen.listRevisionPaths.every(ref => ref === undefined)).toBe(true);
     });
 });


### PR DESCRIPTION
Resolves #16631

`credentialRef` reached `runGit` at two of its eleven call sites — `clone` and `fetch`. `readRevisionFile` was not one of them, and since the mirror became blobless it is the only read that can leave the machine. This threads the tenant credential through to it, so a private tenant repo can be ingested at all.

Evidence: L3 (unit specs + a real private-remote reproduction of the failing and fixed read) → L4 required (a full envelope built against a private tenant on a live deployment). Residual: the last AC [#16631], which needs a deployment with a private tenant and cannot be reached from a fixture.

## What was wrong

Commits and trees stay complete under `--filter=blob:none`, so `for-each-ref`, `rev-parse`, `merge-base --is-ancestor`, `diff --name-status` and `ls-tree` are answered from disk. `show <revision>:<path>` wants a blob, and the filter guarantees the blob is absent — so git resolves it through a lazy promisor fetch against `remote.origin`.

That fetch is a fresh authentication, and credentials here are per-invocation by design: `createGitExecutionEnvironment` (`gitMirror.mjs:390`) builds a disposable `mkdtemp` HOME with an empty `.gitconfig`, delivers the secret through `GIT_ASKPASS`, and deletes the environment afterwards. Nothing is written into the mirror's own config. So a `show` invoked without `credentialRef` was genuinely anonymous.

Against a private tenant: clone succeeds, list succeeds, and then **every file fails** with `KB_INGEST_ENVELOPE_FILE_READ_FAILED`.

## Why it survived review and every test

Two reasons, both reusable.

**The trade is documented.** `gitMirror.mjs:904` says, in the module's own JSDoc: *"`show` becomes a potentially NETWORKED read. The lane is already a network operation behind the same credential so this adds no new failure domain."* The premise in that last clause does not hold — the lane is behind a credential, `show` is not. A documented risk reads as a discharged one.

**Every test is blind to it.** The only tenant repo this project has ever ingested is public, and a public remote serves a promisor fetch to an anonymous client. #16557's measurements show `show` lazy-fetching happily here — 0.42 s/file, mirror backfilling 36.2 MB → 121.9 MB. The defect is invisible in exactly the visibility class we test in, and fires on every repository in the class we do not. Tenant repos are private by default, so that is the whole feature.

## The change

| file | change |
|---|---|
| `gitMirror.mjs` | `readRevisionFile` accepts `credentialRef`, forwards it to `runGit` with `knownHostsPath` as `clone`/`fetch` already do |
| `tenantRepoIngestEnvelopeBuilder.mjs` | threads it `buildIngestEnvelope` → `buildFullEnvelope` / incremental → `buildFilePayloads` → `readRevisionFile` |
| `TenantRepoSyncService.mjs` | passes `repo.credentialRef` to the envelope builder — already passed to `cloneIfMissing` and `fetch` eight lines above |

**Threaded explicitly, not carried on `identity`.** `identity` is spread into every mirror call including the graph and tree reads. Putting a credential there would work and would be wrong: an operation that cannot reach the network should stay unable to resolve a secret, and a later refactor adding `credentialRef` to those `runGit` options would then silently enable it.

`credentialRef` stays optional — omitted, the read is anonymous, which remains correct for a public remote and for a blob already local.

## Deltas from ticket

The ticket's Fix said "thread the tenant's `credentialRef` into the `identity` object the envelope builder spreads". Implemented as an explicit per-hop parameter instead, because `identity` reaches the credential-free reads and its own AC forbids widening them. Same seam, narrower grant.

## Test Evidence

`test/playwright/unit/ai/services/knowledge-base/tenantRepoIngestEnvelopeCredential.spec.mjs` — new.

```bash
npm run test-unit -- test/playwright/unit/ai/services/knowledge-base/tenantRepoIngestEnvelopeCredential.spec.mjs
  4 passed (2.6s)

npm run test-unit -- test/playwright/unit/ai/services/knowledge-base/ test/playwright/unit/ai/daemons/orchestrator/
  1676 passed (1.1m)
```

**Test 1 — the architectural fact nothing tested.** Blobless-clone a filter-capable `file://` source, then delete the source so the promisor remote is unreachable. Mirror, refs and trees are untouched on disk, so anything answered locally must still succeed:

```
listRevisionPaths → ['alpha.txt']                    ← trees are local
readRevisionFile  → KB_GITMIRROR_FILE_READ_FAILED    ← the blob was not
```

The passing `listRevisionPaths` is the control: it makes the failure attributable to the network rather than to a broken mirror.

**Test 2 — the fix and the invariant.** A fake `gitMirror` records the `credentialRef` each call receives, across both envelope shapes.

**Mutation testing — and it caught my own spec being vacuous:**

| mutation | first spec | after repair |
|---|---|---|
| drop `credentialRef` at the `readRevisionFile` call | 🔴 red | 🔴 red |
| **add** `credentialRef` to the `listRevisionPaths` call | 🟢 **green** | 🔴 red |

The invariant assertion could not fail. Two causes, both mine: the incremental path never calls `listRevisionPaths` (it diffs), so the run I wrote never observed the call — and `[].every(...)` is `true`, so an assertion over zero observations passed as though it had checked something. Repaired by exercising both envelope shapes and asserting every guarded call was *observed* before asserting its polarity.

**Reproduction against a real private remote**, run before the ticket was filed, under a disposable HOME with an empty `.gitconfig`:

```
clone --mirror --filter=blob:none  (with credential)   → exit 0, promisor=true
ls-tree -r --name-only <rev>       (no credential)     → exit 0
show <rev>:<path>                  (no credential)     → exit 128
    fatal: could not fetch 1a0cacca… from promisor remote
show <rev>:<path>                  (with credential)   → exit 0
```

One variable. The probe clone was deleted afterwards; the host is redacted here and in the ticket.

Surfaces touched: tenant-repo ingestion (`tenantRepoIngestEnvelopeBuilder`, `gitMirror`, `TenantRepoSyncService`) — existing non-CI coverage: `tenantRepoIngestEnvelopeBuilder.spec.mjs`, `gitMirror.spec.mjs`, `TenantRepoSyncService.spec.mjs`, all green in the 1676 above.

## Post-Merge Validation

- [ ] A full ingest envelope builds against a **private** tenant repository on a live deployment — the one AC no fixture can reach, since a fixture that succeeds anonymously cannot fail on this defect.
- [ ] The same deployment's tenant-sync leaves `KB_INGEST_ENVELOPE_FILE_READ_FAILED` behind and reaches the embed stage.

## Scope

Not #16557 — that is the *cost* of these fetches (23,931 round trips) and stays held on the declaration model. This sits underneath it: on a private tenant the fetches do not merely cost, they fail. That ticket is untouched.

Not #16566 — a repo that gets past the read still meets the embed stage.

**Decision Record impact:** `none`. Restores an invariant the blobless change assumed rather than altering a decision.

---

Authored by @neo-opus-grace (Claude Opus 5).
Origin Session ID: `9ced67a1-8f21-4da2-a1bf-a2a968c47ed2`
