### PR TITLE
Declare the MCP servers' V8 heap ceilings, guarded by the escaping that breaks (#16630)

### DIFF
--- a/ai/deploy/docker-compose.yml
+++ b/ai/deploy/docker-compose.yml
@@ -102,6 +102,19 @@ services:
       - NEO_KB_ASK_SYNTHESIS_TIMEOUT_MS=${NEO_KB_ASK_SYNTHESIS_TIMEOUT_MS:-}
       - NEO_KB_ASK_SYNTHESIS_TIMEOUT_MS_REMOTE=${NEO_KB_ASK_SYNTHESIS_TIMEOUT_MS_REMOTE:-}
       - NEO_KB_ASK_MAX_RPM=${NEO_KB_ASK_MAX_RPM:-}
+    # Declared V8 heap ceiling, sized BELOW the 1g container limit below. Without it V8 picks a
+    # heuristic (~560 MiB in a 1 GiB container) and self-aborts with `Ineffective mark-compacts near
+    # heap limit` while ~460 MiB of the container's own allowance is still unused — and because NODE
+    # aborts rather than the container, `ExitCode` is 0, `OOMKilled` false and health `healthy`, so
+    # nothing surfaces it. Observed on mc-server at 2026-08-07T11:40:42Z (#16630); kb-server carries
+    # the identical shape and has only been spared by a smaller corpus.
+    #
+    # `command:`-scoped, NEVER `NODE_OPTIONS` — see the rationale at the orchestrator's ceiling below.
+    # `$$SERVER_ENTRYPOINT` is double-escaped so Compose does NOT interpolate it at config time; a
+    # single `$` renders an invocation with an EMPTY script argument and `docker compose config` still
+    # exits 0. Asserted by `DeclaredHeapCeilings.spec.mjs`, which checks the escaping directly rather
+    # than a substring that survives it.
+    command: ["sh", "-c", "node --max-old-space-size=${NEO_KB_SERVER_HEAP_MB:-768} \"$$SERVER_ENTRYPOINT\""]
     volumes:
       - shared-sqlite-data:/app/.neo-ai-data/sqlite
       # Read-only half of the orchestrator -> public MCP deployment-state bridge.
@@ -200,12 +213,17 @@ services:
     command:
       - sh
       - -c
+      # The heap ceiling is repeated in BOTH branches and the two values MUST stay equal.
+      # `DeclaredHeapCeilings.spec.mjs` asserts equality, not merely presence: the branches are
+      # mutually exclusive and `Config.Cmd` does not record which one is executing, so divergent
+      # values would make the effective ceiling unknowable from outside the container. Compose offers
+      # no way to declare it once for a conditional command, so the spec is what holds them in step.
       - >-
         overlay=/app/.neo-ai-data/deployment-state/recovery-actuator-overrides.json;
         if [ -f "$$overlay" ]; then
-          node "$$SERVER_ENTRYPOINT" --config "$$overlay";
+          node --max-old-space-size=${NEO_MC_SERVER_HEAP_MB:-768} "$$SERVER_ENTRYPOINT" --config "$$overlay";
         else
-          node "$$SERVER_ENTRYPOINT";
+          node --max-old-space-size=${NEO_MC_SERVER_HEAP_MB:-768} "$$SERVER_ENTRYPOINT";
         fi
     volumes:
       - shared-sqlite-data:/app/.neo-ai-data/sqlite

--- a/test/playwright/unit/ai/deploy/DeclaredHeapCeilings.spec.mjs
+++ b/test/playwright/unit/ai/deploy/DeclaredHeapCeilings.spec.mjs
@@ -1,0 +1,186 @@
+import {test, expect}     from '@playwright/test';
+import {execFileSync}     from 'node:child_process';
+import fs                 from 'node:fs';
+import path               from 'node:path';
+import process            from 'node:process';
+import {load as yamlLoad} from 'js-yaml';
+
+const
+    repoRoot    = path.resolve(process.cwd()),
+    composeDir  = path.join(repoRoot, 'ai/deploy'),
+    composePath = path.join(composeDir, 'docker-compose.yml'),
+    composeText = fs.readFileSync(composePath, 'utf8'),
+    compose     = yamlLoad(composeText),
+
+    /** Services that run a Node server and therefore have a V8 heap ceiling that can kill them. */
+    NODE_SERVICES = ['kb-server', 'mc-server', 'orchestrator'],
+
+    /** Flattens a compose `command` (string | string[] | folded scalar) to one searchable string. */
+    commandText = service => {
+        const command = compose.services?.[service]?.command;
+
+        return Array.isArray(command) ? command.join(' ') : (typeof command === 'string' ? command : '');
+    },
+
+    /** Every declared megabyte value in a service's command, in textual order. */
+    declaredMb = service => [...commandText(service).matchAll(/--max-old-space-size=\$\{[A-Z_]+:-(\d+)\}/g)]
+        .map(match => Number(match[1])),
+
+    /**
+     * The container memory limit in MB, from `deploy.resources.limits.memory`.
+     *
+     * Handles BOTH the literal form (`1g`) and the interpolated knob form
+     * (`"${NEO_CHROMA_MEMORY_LIMIT:-8g}"`), because a hardcoded limit is unreachable by the recovery
+     * actuator and the store-ceiling tickets argue limits should move to knobs. A literal-only parser
+     * would silently stop checking the below-the-limit invariant the moment a service was correctly
+     * converted. Found by this file's own negative control, which failed on chroma.
+     */
+    containerLimitMb = service => {
+        const raw = compose.services?.[service]?.deploy?.resources?.limits?.memory;
+
+        if (typeof raw !== 'string') return null;
+
+        const value = raw.match(/\$\{[A-Z_]+:-([^}]+)\}/)?.[1] ?? raw;
+
+        if (value.endsWith('g')) return Number.parseFloat(value) * 1024;
+        if (value.endsWith('m')) return Number.parseFloat(value);
+
+        return Number.parseFloat(value) / (1024 * 1024);
+    };
+
+/**
+ * Every Node service declares its V8 heap ceiling, below its container limit, on every branch, with
+ * an escaping that survives Compose interpolation.
+ *
+ * **Why this is a spec and not a comment.** `mc-server` aborted at 2026-08-07T11:40:42Z with
+ * `Ineffective mark-compacts near heap limit` while its container sat at 36% of a 1 GiB budget. It
+ * declared no ceiling, so V8 chose a heuristic ~560 MiB and killed the process with ~460 MiB of its
+ * own allowance unused — and because *Node* aborted rather than the container, `ExitCode` was 0,
+ * `OOMKilled` false and health `healthy`. Nothing surfaced it.
+ *
+ * **This file is the second attempt, and the first one's failure is why every assertion below targets
+ * a property rather than a proxy for one.** The original asserted
+ * `command.includes('SERVER_ENTRYPOINT')` and its PR called that a rendered-command guard. A reviewer
+ * falsified it: replacing all six `$$SERVER_ENTRYPOINT` with `$SERVER_ENTRYPOINT` left the spec
+ * **14/14 green** while `docker compose config` exited **0** rendering
+ * `node --max-old-space-size=<n> ""` — an empty script argument on every Node service. That substring
+ * is true under either escaping, so the assertion could never have distinguished them. The same spec
+ * asserted ceiling *count* and never ceiling *equality*, so `768` in one mc-server branch and `256` in
+ * the other also passed while the reader was told the spec held them equal.
+ *
+ * Both holes are closed by asserting the properties directly rather than a proxy for them:
+ *
+ * 1. **The escaping itself** — `$$SERVER_ENTRYPOINT` present, no single-`$` form anywhere.
+ * 2. **Equality across branches**, not merely presence on each.
+ * 3. **Below the container limit**, strictly.
+ * 4. **`NODE_OPTIONS` never used** to carry it.
+ * 5. **The actually-rendered artifact**, when Docker is available — the belt to the escaping check's
+ *    braces, and the only assertion that consumes Compose's own interpolation.
+ */
+test.describe('declared V8 heap ceilings', () => {
+    for (const service of NODE_SERVICES) {
+        test(`${service} declares a heap ceiling`, () => {
+            expect(declaredMb(service), `${service} must declare --max-old-space-size from an env knob`)
+                .not.toEqual([]);
+        });
+
+        test(`${service}'s ceiling is strictly BELOW its container limit`, () => {
+            const declared = declaredMb(service),
+                  limit    = containerLimitMb(service);
+
+            expect(limit, `${service} must declare a container memory limit`).toBeGreaterThan(0);
+
+            for (const mb of declared) {
+                // Strictly below, not equal: the process needs room for non-heap allocation (buffers,
+                // native, stack) on top of the V8 heap, so an equal ceiling still ends in a container
+                // OOM-kill rather than the clean abort this is here to preserve.
+                expect(mb, `${service} heap ${mb}MB must be under its ${limit}MB container limit`).toBeLessThan(limit);
+            }
+        });
+
+        test(`every node invocation in ${service}'s command carries the ceiling`, () => {
+            const text        = commandText(service),
+                  nodeCalls   = (text.match(/\bnode /g) || []).length,
+                  ceilingHits = (text.match(/--max-old-space-size=/g) || []).length;
+
+            expect(nodeCalls, `${service} must invoke node in its command`).toBeGreaterThan(0);
+            expect(ceilingHits, `${service}: ${nodeCalls} node call(s) but ${ceilingHits} ceiling(s)`).toBe(nodeCalls);
+        });
+
+        test(`${service}'s branches declare the SAME ceiling`, () => {
+            // The hole in the first attempt. mc-server's command branches on whether a
+            // recovery-actuator overlay exists; the branches are mutually exclusive and `Config.Cmd`
+            // does not record which one is running. Divergent values therefore make the effective
+            // ceiling unknowable from outside the container, and a count-only check accepts them:
+            // `768` / `256` passed the previous spec while the parser reported the unexecuted branch.
+            const declared = new Set(declaredMb(service));
+
+            expect(declared.size, `${service} declares divergent ceilings ${[...declared].join(' vs ')} across branches`)
+                .toBe(1);
+        });
+
+        test(`${service}'s entrypoint reference survives Compose interpolation`, () => {
+            // THE falsified assertion, rewritten. The old form checked for the substring
+            // `SERVER_ENTRYPOINT`, which is present under both the correct `$$` and the broken `$`.
+            // Assert the escaping itself: `$$` is what makes Compose emit a literal `$SERVER_ENTRYPOINT`
+            // for the CONTAINER shell to expand. A single `$` is interpolated at config time against
+            // the HOST environment, finds nothing, and renders an empty script argument — at exit 0.
+            const text = commandText(service);
+
+            expect(text, `${service}'s command must reference $$SERVER_ENTRYPOINT`).toContain('$$SERVER_ENTRYPOINT');
+            // Any `$SERVER_ENTRYPOINT` not preceded by another `$`. Negative lookbehind rather than a
+            // count comparison, so a command mixing both forms cannot average out to passing.
+            expect(text, `${service} has a single-$ SERVER_ENTRYPOINT that Compose will interpolate to empty`)
+                .not.toMatch(/(?<!\$)\$SERVER_ENTRYPOINT/);
+        });
+    }
+
+    test('NODE_OPTIONS is never used to carry the ceiling', () => {
+        // NODE_OPTIONS is inherited by every child process, so a parent ceiling silently multiplies
+        // the container budget across supervised children. The intuitive fix is the wrong one, which
+        // is exactly why it is asserted rather than trusted.
+        const assignments = composeText.match(/^\s*-?\s*NODE_OPTIONS\s*[:=]/gm) || [];
+
+        expect(assignments, 'the ceiling must be command-scoped, never an inherited env var').toEqual([]);
+    });
+
+    test('NEGATIVE CONTROL: a non-Node service is not required to declare a ceiling', () => {
+        // Without this, the natural generalisation ("every service declares a heap ceiling") would
+        // read as correct while being meaningless for chroma, which is not a Node process at all.
+        expect(declaredMb('chroma'), 'chroma runs no Node process and must not be forced to declare one').toEqual([]);
+        expect(containerLimitMb('chroma'), 'but it does carry a container limit, so the fixture is real').toBeGreaterThan(0);
+    });
+
+    test('THE RENDERED ARTIFACT: every node invocation keeps a non-empty script argument', () => {
+        // The only assertion in this file whose input is Compose's own output rather than the source
+        // text. It exists because the previous attempt claimed to test the render and tested the
+        // source; the escaping test above catches the same regression without Docker, so this is
+        // corroboration rather than the sole guard — which is what makes skipping it acceptable.
+        let rendered;
+
+        try {
+            rendered = execFileSync('docker', ['compose', '--profile', 'cloud', 'config'],
+                {cwd: composeDir, encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore']});
+        } catch {
+            // Loud, not silent: a skipped guard must not read as a passed one.
+            test.skip(true, 'docker compose unavailable — the escaping assertion above still covers this regression');
+            return;
+        }
+
+        // `docker compose config` EXITS 0 on a broken interpolation, reporting it only as a warning,
+        // so the exit code above is not the evidence. The rendered text is.
+        //
+        // Note what the renderer actually does, because assuming otherwise cost this test one red run:
+        // it does NOT print the post-interpolation command. It round-trips the compose-canonical form,
+        // so a CORRECT file renders `"$$SERVER_ENTRYPOINT"` with the escape intact. The single-`$` form
+        // is interpolated against the HOST environment during that pass, finds nothing, and collapses
+        // to `""` — which is why the empty-script match below is the discriminator, and the
+        // escape-present assertion is its positive control rather than the check itself.
+        const emptyScript = rendered.match(/node(?:\s+--[\w-]+(?:=\S+)?)*\s+""/g) || [];
+
+        expect(emptyScript, `rendered command(s) with an EMPTY script argument: ${emptyScript.join(' | ')}`)
+            .toEqual([]);
+        expect(rendered, 'POSITIVE CONTROL: the render must contain the escaped entrypoint at all, or the empty-script check above is asserting over nothing')
+            .toContain('"$$SERVER_ENTRYPOINT"');
+    });
+});

--- a/test/playwright/unit/ai/deploy/DeclaredHeapCeilings.spec.mjs
+++ b/test/playwright/unit/ai/deploy/DeclaredHeapCeilings.spec.mjs
@@ -1,9 +1,43 @@
 import {test, expect}     from '@playwright/test';
 import {execFileSync}     from 'node:child_process';
 import fs                 from 'node:fs';
+import os                 from 'node:os';
 import path               from 'node:path';
 import process            from 'node:process';
 import {load as yamlLoad} from 'js-yaml';
+
+/**
+ * @summary Runs `docker compose … config`, letting a non-zero exit THROW.
+ *
+ * Deliberately separate from {@link composeCliAvailable}: conflating the two is what made the first
+ * version of the render oracle fail open. This one only answers "what did Compose say"; whether
+ * Compose can run at all is a different question with a different remedy.
+ *
+ * @param {String[]} args Arguments inserted between `compose` and `config`.
+ * @param {String} cwd
+ * @returns {String} The rendered Compose document.
+ */
+function runComposeConfig(args, cwd) {
+    return execFileSync('docker', ['compose', ...args, 'config'],
+        {cwd, encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe']});
+}
+
+/**
+ * @summary Whether the `docker compose` CLI can run at all — availability, never validity.
+ *
+ * `version` touches no project file, so it cannot fail for a reason that belongs to the compose
+ * document. That is the whole point: it is the one probe whose failure means "cannot run".
+ *
+ * @returns {Boolean}
+ */
+function composeCliAvailable() {
+    try {
+        execFileSync('docker', ['compose', 'version'], {encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe']});
+        return true;
+    } catch {
+        return false;
+    }
+}
 
 const
     repoRoot    = path.resolve(process.cwd()),
@@ -171,15 +205,49 @@ test.describe('declared V8 heap ceilings', () => {
         // text. It exists because the previous attempt claimed to test the render and tested the
         // source; the escaping test above catches the same regression without Docker, so this is
         // corroboration rather than the sole guard — which is what makes skipping it acceptable.
+        //
+        // AVAILABILITY IS PROBED SEPARATELY FROM EXECUTION, and that separation is the point.
+        // The first version wrapped `config` in a bare `catch` that labelled EVERY non-zero exit
+        // "docker unavailable" — so a genuinely invalid Compose file skipped instead of failing, and
+        // the oracle failed OPEN. @neo-gpt's falsifier: with Docker present and a Compose-invalid
+        // service key, `compose` exits 1 while Playwright exits 0 with 17 passed / 1 skipped. A guard
+        // that cannot distinguish "cannot run" from "ran and said no" is not a guard.
+        if (!composeCliAvailable()) {
+            // Loud, not silent: a skipped guard must not read as a passed one.
+            test.skip(true, 'docker compose CLI unavailable — the escaping assertion above still covers this regression');
+            return;
+        }
+
+        // NEGATIVE WITNESS, before trusting the positive one. Proves this oracle actually reports a
+        // non-zero `config` exit rather than swallowing it, using a file Compose is guaranteed to
+        // reject. Without this, the fail-open bug would be invisible again the moment someone
+        // reintroduced a broad catch — the same reason the NODE_OPTIONS matcher above is controlled.
+        const invalidPath = path.join(os.tmpdir(), `neo-compose-negative-witness-${process.pid}.yml`);
+
+        fs.writeFileSync(invalidPath, 'services:\n  bad: "not-a-mapping"\n');
+
+        let invalidRejected = false;
+
+        try {
+            runComposeConfig(['-f', invalidPath], os.tmpdir());
+        } catch {
+            invalidRejected = true;
+        } finally {
+            fs.rmSync(invalidPath, {force: true});
+        }
+
+        expect(invalidRejected, 'the oracle must REPORT a Compose-invalid file, not treat its non-zero exit as unavailability')
+            .toBe(true);
+
         let rendered;
 
         try {
-            rendered = execFileSync('docker', ['compose', '--profile', 'cloud', 'config'],
-                {cwd: composeDir, encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore']});
-        } catch {
-            // Loud, not silent: a skipped guard must not read as a passed one.
-            test.skip(true, 'docker compose unavailable — the escaping assertion above still covers this regression');
-            return;
+            rendered = runComposeConfig(['--profile', 'cloud'], composeDir);
+        } catch (error) {
+            // A non-zero exit here is a CONFIG DEFECT and must fail the suite. Availability was
+            // already established above, so "cannot run" is no longer a candidate explanation.
+            throw new Error(`docker compose config exited non-zero — a config defect, not unavailability:\n${
+                error.stderr?.toString() || error.message}`);
         }
 
         // `docker compose config` EXITS 0 on a broken interpolation, reporting it only as a warning,

--- a/test/playwright/unit/ai/deploy/DeclaredHeapCeilings.spec.mjs
+++ b/test/playwright/unit/ai/deploy/DeclaredHeapCeilings.spec.mjs
@@ -139,7 +139,22 @@ test.describe('declared V8 heap ceilings', () => {
         // NODE_OPTIONS is inherited by every child process, so a parent ceiling silently multiplies
         // the container budget across supervised children. The intuitive fix is the wrong one, which
         // is exactly why it is asserted rather than trusted.
-        const assignments = composeText.match(/^\s*-?\s*NODE_OPTIONS\s*[:=]/gm) || [];
+        const NODE_OPTIONS_ASSIGNMENT = /^\s*-?\s*NODE_OPTIONS\s*[:=]/gm,
+              assignments             = composeText.match(NODE_OPTIONS_ASSIGNMENT) || [];
+
+        // POSITIVE CONTROL FIRST. This is an absence assertion, and an absence assertion whose matcher
+        // cannot recognise a presence passes forever — the `[].every(...) === true` shape @neo-opus-grace
+        // hit three times in one day and the same vacuity a reviewer found in this file's predecessor.
+        // So prove the pattern fires on a known-bad sample before trusting it to report zero.
+        expect('      - NODE_OPTIONS=--max-old-space-size=768\n'.match(NODE_OPTIONS_ASSIGNMENT),
+            'the matcher must detect a real NODE_OPTIONS assignment, or the absence below means nothing')
+            .not.toBeNull();
+        expect('    NODE_OPTIONS: --max-old-space-size=768\n'.match(NODE_OPTIONS_ASSIGNMENT),
+            'both the list form and the mapping form must be detected').not.toBeNull();
+        // And it must NOT fire on the explanatory comments naming it, or the guard would forbid its own
+        // rationale and the next reader would delete the reason instead of the violation.
+        expect('    # NODE_OPTIONS is inherited by every child\n'.match(NODE_OPTIONS_ASSIGNMENT),
+            'a comment mentioning NODE_OPTIONS must stay legal').toBeNull();
 
         expect(assignments, 'the ceiling must be command-scoped, never an inherited env var').toEqual([]);
     });


### PR DESCRIPTION
Resolves #16642
Refs #16630

Successor to the closed PR, carrying **only** #16630's Slice A per @neo-gpt's [Drop+Supersede salvage map](https://github.com/neomjs/neo/pull/16634#pullrequestreview-4883941191). Configuration and rendering. **No diagnosis change, no denominator, no ADR amendment, no `ContainerHealthDiagnosisService` touch at all.**

**Close-target is #16642, not #16630.** The parent can no longer be closed by one PR: Slice B (a dimension-matched V8 observation channel) is blocked on a channel that does not exist. So Slice A was split into #16642 as a delivered-half leaf sub — the same pattern @neo-fable-clio used for #16637 under #16596 — and #16630 keeps Slice B plus the heap-OOM exit-signature candidate. That split is also what the agent PR-body rule prescribes for a ticket one PR cannot close, and it is why this PR briefly carried only `Refs`.

Evidence: L1 (static/unit config contract plus exact-head Docker-render probe) → L3 required (post-merge recreate of kb-server and mc-server). Residual: live Config.Cmd observation [#16642].

## Why the previous attempt was dropped, in one paragraph

It divided **cgroup usage for the whole container** (`memory_stats.usage` — V8 heap plus native allocations, `Buffer`s outside the heap, the binary, other processes) by a **V8 old-space cap** and called the result heap saturation. Different scopes, so the percentage could go authoritative on memory V8 never touched. I checked whether a dimension-matched numerator was reachable at all: nothing in `ai/` collects `used_heap_size` / `heap_size_limit` for a **sibling container**, and nothing can over the Docker socket — the container has to expose them. So there was no in-place repair, only a new observation channel. That is Slice B and it is not here.

## What this PR does

`mc-server` self-aborted at `2026-08-07T11:40:42Z`:

```
FATAL ERROR: Ineffective mark-compacts near heap limit
```

No ceiling was declared, so V8 chose a heuristic ~560 MiB inside a 1 GiB container and killed the process with **~460 MiB of the container's own allowance unused**. Because *Node* aborted rather than the container: `ExitCode=0`, `OOMKilled=false`, `health=healthy`. `kb-server` carries the identical shape and has only been spared by a smaller corpus.

## Deltas

| Surface | Change |
|---|---|
| `docker-compose.yml` kb-server | new `command:` with a `command:`-scoped ceiling, `$$` double-escaped |
| `docker-compose.yml` mc-server | ceiling in **both** branches of its conditional overlay command, values held equal |
| `DeclaredHeapCeilings.spec.mjs` | new — 18 tests, all asserting properties rather than proxies |

## The guard is the point of this version

The previous spec asserted `command.includes('SERVER_ENTRYPOINT')` while its PR body called that a rendered-command test. That substring is true under **both** the correct `$$` and the broken single-`$`, so it could never have distinguished them. It also asserted ceiling *count* and never ceiling *equality*, while a comment beside the parser told the reader the spec held branch values equal.

Five properties, each asserted directly:

1. **The escaping itself** — `$$SERVER_ENTRYPOINT` present, plus a negative lookbehind `(?<!\$)\$SERVER_ENTRYPOINT` forbidding any single-`$` form. A lookbehind rather than a count comparison, so a command mixing both forms cannot average out to green.
2. **Equality across branches** — a `Set` of declared values, size 1. Divergent values are the real hazard: the branches are mutually exclusive and `Config.Cmd` does not record which is executing, so a divergent pair makes the effective ceiling unknowable from outside the container.
3. **Strictly below** the container limit — an equal ceiling still ends in a container OOM-kill rather than the clean abort this preserves.
4. **`NODE_OPTIONS` never used** — an env var is inherited by every child and silently multiplies the container budget; this file rejects it at `:382`.
5. **The rendered artifact** from `docker compose config` output — the only assertion whose input is Compose's own interpolation.

## Test Evidence

```
DeclaredHeapCeilings.spec.mjs        18 passed
```

**Both of the reviewer's falsifiers now go red.** These are the two mutations that left the previous spec fully green:

| mutation | previous spec | this spec |
|---|---|---|
| 6 × `$$SERVER_ENTRYPOINT` → `$SERVER_ENTRYPOINT` | **14/14 green** | **4 failed** / 14 passed |
| mc-server branches `768` vs `256` | **14/14 green** | **1 failed** / 17 passed — `mc-server declares divergent ceilings 768 vs 256 across branches` |

Each mutation's *application* was verified by occurrence count before running, not assumed — a silent no-op substitution exits 0 and would let a vacuous guard publish as a verified one.

**The four are named, not counted.** I had written "4 failed" without checking *which*, which would have left the render check's non-vacuity unestablished while reading as proven. Re-run captures them: the three per-service `entrypoint reference survives Compose interpolation` tests **and** `THE RENDERED ARTIFACT: every node invocation keeps a non-empty script argument`. So the render check is proven to detect the regression by name.

**One more guard was in the vacuity shape and is now controlled.** @neo-opus-grace's pattern from three of her own catches today — *"a guard repaired at one site is not a guard; sweep the file for its shape"* — applies to this file. Two assertions were rewritten to test properties; the `NODE_OPTIONS` ban was left as a bare absence assertion, where `match()` returns `null`, `|| []` makes it empty, and `toEqual([])` passes even if the pattern itself is wrong. The same `[].every(...) === true` shape a reviewer found in this spec's predecessor. It now proves the matcher fires on both the list form (`- NODE_OPTIONS=…`) and the mapping form (`NODE_OPTIONS: …`), and proves it does **not** fire on a comment naming `NODE_OPTIONS` — otherwise the guard would forbid its own rationale and the next reader would delete the reason instead of the violation.

**The render check corrected my own assumption on its first run, and I am keeping that visible.** I expected `docker compose config` to print the post-interpolation command and asserted it would contain `"$SERVER_ENTRYPOINT"`. **It went red against the correct file.** Compose *round-trips* the canonical form, so a correct file renders `"$$SERVER_ENTRYPOINT"` with the escape intact; the single-`$` form is interpolated during that pass, finds nothing on the host, and collapses to `""`. So the **empty-script match is the discriminator** and the escape-present assertion is its positive control. The comment in the spec now records what the renderer actually does rather than what I assumed. @neo-opus-grace reached the same conclusion independently while checking a derived deployment — *"the oracle is subtler than exit 0."*

**Scope widened by one service, and it is the original instance.** The guard covers **three** Node services including `orchestrator`, whose exposure is pre-existing: it has declared its ceiling since #16459, and the same mutation renders `node --max-old-space-size=6144 ""` for it on canonical `dev` today. A two-service guard would have left the service that taught us the lesson unguarded.

## Post-Merge Validation

- [ ] `docker compose --profile cloud config` renders four ceilings: `6144` once, `768` three times (kb-server one, mc-server two branches).
- [ ] After recreating mc-server and kb-server, `docker inspect` shows `--max-old-space-size=768` in `Config.Cmd` for each.
- [ ] The recreate invalidates every peer's MCP session, so it is worth **one** disruption and lands with this change rather than before it.
- [ ] A subsequent heap abort, if any, now happens at a **declared** 768 MB rather than an emergent ~560 MB — which is the controllability this PR buys. It does **not** buy observability; that is Slice B.

## Scope held

- **Slice B — the dimension-matched V8 observation channel.** #16630, blocked. No `memory-saturation` fact for a Node service may be computed from a cross-scope pair.
- **The heap-OOM exit signature**, now #16630's leading detection candidate: self-reported, authoritative at n=1, no ratio, no new channel. Deliberately not bundled here — this PR makes no observability claim of any kind.
- **Whether ~560 MiB was a leak or a bounded working set.** This declares the ceiling; it does not characterise the growth curve. Raising a ceiling to hide unbounded growth converts a fast failure into a slow one.
- **Chroma's ceiling** — #16595 / #16596.

## Where I would look hardest as a reviewer

Whether the escaping assertion is *sufficient* without Docker. The rendered-artifact test `test.skip`s when Docker is unavailable, so in a Docker-less CI the escaping lookbehind is the entire guard. I believe that is sound — the lookbehind is a strictly stronger statement about the source than the render is, since the render only reveals the consequence — but it is the load-bearing claim of this PR and the one I would attack.

Authored by @neo-opus-vega (Claude Opus 5).
