### PR TITLE
docs(ci): name what the parity gate guards, where it would be deleted (#16653)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -280,6 +280,22 @@ jobs:
         include:
           - suite: integration-unified
             run: ${{ needs.changes.outputs.run_integration }}
+          # NOT local-vs-dockerized parity. That comparison ended with the dockerization
+          # cut, and this name is the only thing still describing it — which is why it
+          # reads as retirable to anyone who has not opened the suite. It was nearly
+          # dropped as leftover debt on exactly that reading.
+          #
+          # What it actually guards is MULTI-PLANE ISOLATION: it boots a second, fully
+          # separate dockerized plane and proves the two coexist without contaminating
+          # each other. Not one of its assertions compares two planes for parity; four
+          # of them assert the overlay plane must never resolve or serve the durable
+          # root, one asserts no egress, and one refuses boot when a plane resolves the
+          # canonical root. A second deployment is by definition a second plane, so this
+          # gate's relevance grows rather than shrinks.
+          #
+          # Do not retire this check on the strength of its name. A rename is tracked
+          # separately and is ordering-sensitive: the job name IS the required check
+          # context, so renaming it in one step produces a PR that can never pass.
           - suite: integration-parity
             run: ${{ needs.changes.outputs.run_parity }}
           - suite: unit

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -280,22 +280,22 @@ jobs:
         include:
           - suite: integration-unified
             run: ${{ needs.changes.outputs.run_integration }}
-          # NOT local-vs-dockerized parity. That comparison ended with the dockerization
-          # cut, and this name is the only thing still describing it — which is why it
-          # reads as retirable to anyone who has not opened the suite. It was nearly
-          # dropped as leftover debt on exactly that reading.
+          # A MANDATORY witness for the dev-profile topology + mock-embedding contract.
+          # "Parity" here means DEV-PROFILE parity — does the profile CI runs match the
+          # shape we deploy — which is an ongoing concern, NOT the local-vs-dockerized
+          # comparison that ended with the dockerization cut. It gets misread as the
+          # latter, and was nearly dropped as leftover debt on that reading.
           #
-          # What it actually guards is MULTI-PLANE ISOLATION: it boots a second, fully
-          # separate dockerized plane and proves the two coexist without contaminating
-          # each other. Not one of its assertions compares two planes for parity; four
-          # of them assert the overlay plane must never resolve or serve the durable
-          # root, one asserts no egress, and one refuses boot when a plane resolves the
-          # canonical root. A second deployment is by definition a second plane, so this
-          # gate's relevance grows rather than shrinks.
+          # It boots ONE isolated plane (its own Compose project, its own data root) and
+          # splits evenly: four assertions prove the profile stands up — plane boots,
+          # Neural Link loggers initialize without sink degradation, provider auth
+          # refuses missing/empty secret carriers before listen, and the deterministic
+          # mock provider carries semantic recall end to end. The other four prove that
+          # plane stays contained: served identity never resolves the durable root,
+          # foreign-plane expectations are rejected at the wire, an overlay resolving
+          # the canonical root is refused at boot, and no egress leaves the network.
           #
-          # Do not retire this check on the strength of its name. A rename is tracked
-          # separately and is ordering-sensitive: the job name IS the required check
-          # context, so renaming it in one step produces a PR that can never pass.
+          # Do not retire this check on the strength of its name.
           - suite: integration-parity
             run: ${{ needs.changes.outputs.run_parity }}
           - suite: unit

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -287,7 +287,7 @@ jobs:
           # latter, and was nearly dropped as leftover debt on that reading.
           #
           # It boots ONE isolated plane (its own Compose project, its own data root) and
-          # splits evenly: four assertions prove the profile stands up — plane boots,
+          # splits evenly across 8 test cases: four prove the profile stands up — plane boots,
           # Neural Link loggers initialize without sink degradation, provider auth
           # refuses missing/empty secret carriers before listen, and the deterministic
           # mock provider carries semantic recall end to end. The other four prove that

--- a/test/playwright/playwright.config.integration-parity.mjs
+++ b/test/playwright/playwright.config.integration-parity.mjs
@@ -1,3 +1,19 @@
+/**
+ * @summary Multi-plane ISOLATION suite. The `parity` in its name is historical and misleading.
+ *
+ * It does NOT compare a local plane against a dockerized one — that transition is over. It boots
+ * a SECOND, fully separate dockerized plane (its own Compose project, its own data root) and
+ * proves the two coexist without contaminating each other.
+ *
+ * None of its assertions compare two planes for parity. Four assert the overlay plane must never
+ * resolve or serve the durable root; one refuses boot outright when a plane resolves the canonical
+ * root; one proves no egress. A second deployment is by definition a second plane, so what this
+ * guards grows in relevance rather than shrinking.
+ *
+ * Stated here because the name alone reads as retirable, and the suite was nearly dropped as
+ * leftover debt by a reader who had not opened it. A rename is ordering-sensitive and tracked
+ * separately: this config's sibling job name IS the required check context.
+ */
 import './configTemplateResolver.mjs';
 
 import {defineConfig}        from '@playwright/test';

--- a/test/playwright/playwright.config.integration-parity.mjs
+++ b/test/playwright/playwright.config.integration-parity.mjs
@@ -6,8 +6,8 @@
  * cut, which is how the name gets read by anyone who has not opened the suite; it was nearly
  * dropped as leftover debt on exactly that reading.
  *
- * One isolated plane is booted — its own Compose project, its own data root — and the eight
- * assertions split evenly. Four prove the profile stands up: the plane boots, Neural Link loggers
+ * One isolated plane is booted — its own Compose project, its own data root — and the eight test
+ * cases split evenly. Four prove the profile stands up: the plane boots, Neural Link loggers
  * initialize without sink degradation, provider auth refuses missing and empty secret carriers
  * before listen, and the deterministic mock provider carries semantic recall end to end. Four
  * prove it stays contained: served identity never resolves the durable root, foreign-plane

--- a/test/playwright/playwright.config.integration-parity.mjs
+++ b/test/playwright/playwright.config.integration-parity.mjs
@@ -1,18 +1,20 @@
 /**
- * @summary Multi-plane ISOLATION suite. The `parity` in its name is historical and misleading.
+ * @summary Mandatory witness for the dev-profile topology + mock-embedding contract.
  *
- * It does NOT compare a local plane against a dockerized one — that transition is over. It boots
- * a SECOND, fully separate dockerized plane (its own Compose project, its own data root) and
- * proves the two coexist without contaminating each other.
+ * `parity` here means DEV-PROFILE parity — does the profile CI runs match the shape we deploy.
+ * That is ongoing. It is NOT the local-vs-dockerized comparison that ended with the dockerization
+ * cut, which is how the name gets read by anyone who has not opened the suite; it was nearly
+ * dropped as leftover debt on exactly that reading.
  *
- * None of its assertions compare two planes for parity. Four assert the overlay plane must never
- * resolve or serve the durable root; one refuses boot outright when a plane resolves the canonical
- * root; one proves no egress. A second deployment is by definition a second plane, so what this
- * guards grows in relevance rather than shrinking.
+ * One isolated plane is booted — its own Compose project, its own data root — and the eight
+ * assertions split evenly. Four prove the profile stands up: the plane boots, Neural Link loggers
+ * initialize without sink degradation, provider auth refuses missing and empty secret carriers
+ * before listen, and the deterministic mock provider carries semantic recall end to end. Four
+ * prove it stays contained: served identity never resolves the durable root, foreign-plane
+ * expectations are rejected at the wire, an overlay resolving the canonical root is refused at
+ * boot, and no egress leaves the network.
  *
- * Stated here because the name alone reads as retirable, and the suite was nearly dropped as
- * leftover debt by a reader who had not opened it. A rename is ordering-sensitive and tracked
- * separately: this config's sibling job name IS the required check context.
+ * Isolation is one dimension of the guarantee, not the whole of it.
  */
 import './configTemplateResolver.mjs';
 


### PR DESCRIPTION
Resolves #16653
Refs #16604

A live **required check** is named for a transition that ended, and the statement of what it actually guards lives everywhere except the one place someone decides to delete it.

Evidence: L1 (source-shape — comment placement, plus a YAML re-parse proving the matrix survived). No runtime behaviour changes, so no higher class applies. Residual: none.

## What happened

The 2026-08-06 incident asked whether `integration-parity` could be dropped as leftover debt, now that dockerization is done. Answering it required opening the suite. It survived on that reading.

**The reader deciding to delete a check opens the job list, not the suite.** That entry was two lines with no statement of the guarantee:

```yaml
          - suite: integration-parity
            run: ${{ needs.changes.outputs.run_parity }}
```

## What it actually guards — CORRECTED after review

**My first version of this section was wrong, in the direction of overstating the case.** @neo-gpt falsified it and I re-derived rather than conceding.

I wrote that the suite *"boots a second, fully separate dockerized plane and proves the two coexist."* **It does not.** `parityComposeWebServer.mjs:22` resolves one project name; `:52` runs `compose -p <that one>`. The fixture's own comment reads *"a CI run boots **an** isolated plane"* — singular. I took that claim from #16604's body and repeated it as my own measurement without opening the fixture.

I also gave a 4+1+1 census implying every test case is containment. Counted honestly it is **4/4 across 8 test cases** (36 `expect()` calls in total):

| # | test case | class |
|---|---|---|
| 1 | the complete plane boots: chroma + both MCP servers healthy, orchestrator running | profile function |
| 2 | both imported Neural Link loggers initialize without sink degradation | profile function |
| 3 | served identity: both servers prove the overlay plane, never the durable root | containment |
| 4 | served-identity probe: foreign plane expectations rejected at the wire | containment |
| 5 | canonical provider auth refuses missing and empty secret carriers before listen | profile function |
| 6 | the durable-root invariant: an overlay resolving the canonical root is refused at boot | containment |
| 7 | no egress: external destinations unreachable from inside the parity network | containment |
| 8 | mock-embedding contract: deterministic provider, semantic recall end to end | profile function |

**So the guarantee is what #15807 named when it made this mandatory — *"topology + mock-embedding contract"* — with isolation as ONE dimension.**

**And "parity" is not describing a finished transition.** It means **dev-profile parity**: does the profile CI runs match the shape we deploy. That is ongoing. The name is **underspecified, not false** — which is a weaker claim than I opened with, and the correct one.

## What this PR deliberately does NOT do

**It does not rename anything.** #16604 owns the rename and documents the trap precisely: the workflow job name IS the required check context, encoded in branch protection and in three sites of `PullRequestService.spec.mjs`. Renaming in one step produces a PR waiting forever on a check that can no longer report. Step 1 of that sequence — adding the new context to branch protection alongside the old — is **operator-owned**.

So this lands the half needing no coordination, and puts it where the retirement decision is actually made. A comment inside the suite would have been correct and unread.

## Contract Ledger

| Target Surface | Source of Authority | Behavior | Fallback / Error Semantics | Evidence |
|---|---|---|---|---|
| `test.yml` parity matrix entry | this PR | States the guarantee: topology + mock-embedding contract, isolation as one dimension | n/a — comment only | YAML re-parsed; matrix still holds all four suites |
| `playwright.config.integration-parity.mjs` | this PR | Module header states the full guarantee and that `parity` means dev-profile parity | n/a | — |
| job name / required check context | #16604 | **UNCHANGED** | old context stays required; nothing to fall back from | no diff to job name |
| suite assertions | existing | **UNCHANGED** | n/a | no spec diff |

Decision Record impact: `none`.

## Deltas from ticket

1. **The ticket was split out of #16604 during this work**, so implementation matches its own prescription exactly. #16604 keeps the rename and its operator-gated ordering; nothing was silently rescoped.
2. **This PR was first opened off the wrong base and the lint caught it.** It branched from `ada/16488-defer-chromadb-import` — the branch of the **closed, Drop+Superseded** PR — and therefore carried **10 foreign commits**. Merging it would have resurrected the entire lazy-Chroma rewrite that was deliberately discarded hours earlier. Rebased onto `dev` with `--onto`; the PR now carries exactly one commit and a 2-file / 32-insertion diff, verified against the GitHub API rather than a cached `gh pr view` (which reported a stale `11`).
3. **`## Deltas` was missing on first submission.** Recorded rather than quietly added, because the anchor list is the template contract and a silent fix hides that the body was incomplete when review was requested.

## Test Evidence

```
node -e "YAML.parse(test.yml)"  ->  parsed OK
                                    job: test
                                    matrix suites: integration-unified, integration-parity, unit, components
```

Comment-only in both files; no assertion, job name, or path predicate is touched. I re-parsed the workflow rather than eyeballing indentation, because a mis-indented comment inside a matrix block is exactly the kind of change that looks fine and silently drops a suite.

The parity suite itself runs on this PR — `isParityRelevantPath` matches the config file — so the gate this PR describes also validates it.

## Post-Merge Validation

- [ ] #16604 re-evaluates whether a rename is warranted at all. `parity` read as **dev-profile parity** is defensible, and the proposed `plane-isolation` would name 4 of 8 test cases as the whole guarantee.
- [ ] If a rename does proceed, branch protection is updated **first**, and these comments are re-checked against the new name.

## Evolution

I opened this as the fifth in a family of names meaning something other than what they say — `localOnly`, the `ai` commit scope, `package.brain.json`'s "Body", #16488's "Body install tier". **Review demoted it out of that family.** `parity` is underspecified, not false; dev-profile parity is a live concern and the word is defensible. The four others were genuinely wrong; this one is merely incomplete.

**That distinction cost a review cycle and is worth keeping.** I pattern-matched a new case onto a family I had spent the night building, and the match made the evidence feel already-gathered — so I asserted a characterization I had read in a ticket instead of one I had measured in a fixture. A family you are collecting is a hypothesis, and each new member needs its own falsifier.

The transferable part survives intact and is what the review affirmed: **an explanation is only load-bearing where the decision is made.** The guarantee was explained inside the suite; the reader deciding to delete it was looking at the job list.

Authored by Ada (Claude Opus 5, Claude Code). Session 9b08b9e4-6181-416b-ac68-e9d16636cff0.
