### PR TITLE
fix(ai): a well-classified embed failure must not empty the receipt (#16647)

### DIFF
--- a/ai/daemons/orchestrator/services/TenantRepoSyncService.mjs
+++ b/ai/daemons/orchestrator/services/TenantRepoSyncService.mjs
@@ -4,6 +4,11 @@ import path                      from 'node:path';
 import Base                      from '../../../../src/core/Base.mjs';
 import AiConfig                  from '../../../config.mjs';
 import GitMirror                 from '../../../services/knowledge-base/helpers/gitMirror.mjs';
+// The filter below and the codes it admits are one contract. Importing the pattern from the module
+// that PRODUCES bounded codes keeps a re-declared copy from drifting into a pair that separately
+// look right — the producer widening a code the filter still rejects is exactly this ticket's defect.
+import {BOUNDED_KB_ERROR_CODE_PATTERN}
+                                 from '../../../services/knowledge-base/helpers/embedFailureClassification.mjs';
 import {
     buildIngestEnvelope,
     createTenantRepoMaterializationDigest
@@ -54,7 +59,6 @@ import {
 const
     ACCESS_CONFIG_FINGERPRINT_KEY    = randomBytes(32),
     ACCESS_READINESS_MIN_TTL_MS      = 15 * 60 * 1000,
-    BOUNDED_KB_ERROR_CODE_PATTERN    = /^KB_[A-Z0-9_]{1,120}$/,
     PERSISTED_REVISIONS_FILE_NAME    = 'tenant-repo-sync-revisions.json',
     TENANT_REPO_SYNC_LEASE_FILE_NAME = 'tenant-repo-sync-lease.json';
 

--- a/ai/services/knowledge-base/IngestionService.mjs
+++ b/ai/services/knowledge-base/IngestionService.mjs
@@ -16,6 +16,8 @@ import {createTenantRepoMaterializationDigest}
                             from './helpers/tenantRepoIngestEnvelopeBuilder.mjs';
 import {isChromaConnectionError}
                             from '../shared/vector/chromaClientPrimitives.mjs';
+import {classifyEmbedFailureCode}
+                            from './helpers/embedFailureClassification.mjs';
 import VectorService   from './VectorService.mjs';
 import aiConfig        from '../../mcp/server/knowledge-base/config.mjs';
 import crypto          from 'crypto';
@@ -385,7 +387,11 @@ class IngestionService extends Base {
 
                 if (result?.error) {
                     summary.errors.push(this.createError({
-                        code   : result.code || 'KB_VECTOR_EMBED_FAILED',
+                        // Classified rather than defaulted. A provider code is truthy, so the old
+                        // `|| 'KB_VECTOR_EMBED_FAILED'` never fired for one — it recorded the
+                        // provider's own vocabulary, which the durable `^KB_` filter then dropped to
+                        // null. See `embedFailureClassification` for why the fix is a translation.
+                        code   : classifyEmbedFailureCode(result.code),
                         message: result.message || result.error,
                         details: result
                     }));
@@ -403,7 +409,10 @@ class IngestionService extends Base {
                 });
             } catch (error) {
                 summary.errors.push(this.createError({
-                    code   : error.code || 'KB_VECTOR_EMBED_FAILED',
+                    // The throw path carries the provider's code most often — a consumer-deadline
+                    // timeout or an upstream abort — so this is the site where the inversion bit
+                    // hardest: the better-classified the failure, the emptier the receipt.
+                    code   : classifyEmbedFailureCode(error.code),
                     message: error.message,
                     details: {repoSlug}
                 }));

--- a/ai/services/knowledge-base/helpers/embedFailureClassification.mjs
+++ b/ai/services/knowledge-base/helpers/embedFailureClassification.mjs
@@ -30,11 +30,26 @@
  */
 
 /**
- * @summary The single definition of a code that may cross into durable tenant-repo state.
+ * @summary The **writer-side** definition: what an embed failure may mint on its way into durable
+ * tenant-repo state.
  *
- * Owned here because this module is the one place that *produces* codes for that boundary; the
- * orchestrator's sync service imports it rather than re-declaring the literal, so the producer and
- * the filter cannot drift apart into a pair that separately look correct.
+ * Owned here because this module is the one place that *produces* codes for that boundary, and the
+ * orchestrator's sync filter imports it rather than re-declaring the literal. Those two must agree
+ * or a produced code is silently dropped — which is exactly the defect this module exists to end —
+ * so they are deliberately one definition.
+ *
+ * **It is not the only validator, and calling it the sole one would be the same overclaim this
+ * module warns about.** Two downstream gates re-check the same shape from different trust positions,
+ * and they are separate on purpose rather than by neglect:
+ *
+ * - `tenantRepoCheckpointValidity.normalizeBoundedErrorCode` — the READ boundary, validating
+ *   persisted state it did not write and may not trust (corruption, hand-editing, an older writer).
+ * - `DeploymentStateBridgeService.safeKnowledgeBaseErrorCode` — the PROJECTION boundary, validating
+ *   what leaves the process toward a remote client.
+ *
+ * A reader that trusted the writer's guarantee would inherit the writer's bugs, so collapsing all
+ * three into one import would remove defence-in-depth rather than duplication. What must never drift
+ * is producer-and-filter; reader and projector are allowed to be independently strict.
  * @type {RegExp}
  */
 export const BOUNDED_KB_ERROR_CODE_PATTERN = /^KB_[A-Z0-9_]{1,120}$/;

--- a/ai/services/knowledge-base/helpers/embedFailureClassification.mjs
+++ b/ai/services/knowledge-base/helpers/embedFailureClassification.mjs
@@ -17,11 +17,14 @@
  *
  * **Why an allow-list and not a sanitizer.** Passing an unrecognised provider code through — even
  * scrubbed — would put provider-controlled text into durable state and onto a remotely-readable
- * surface, which is the exact property the bounded pattern exists to guarantee. Every value this
- * module returns is either a literal declared here or a string that already satisfied the bounded
- * pattern, so the guarantee holds by construction rather than by escaping. An unknown code is
- * therefore reported as unclassified, and teaching this map a new provider code is a deliberate,
- * reviewed act.
+ * surface, which is the exact property the bounded pattern exists to guarantee.
+ *
+ * **Every value this module returns is a literal declared in this file**, so the guarantee holds by
+ * construction rather than by escaping. That sentence is load-bearing and was false in the first
+ * draft, which also admitted any string matching the bounded pattern: the pattern constrains the
+ * alphabet, not the author, so a provider raising `KB_SECRET_…` satisfied it and travelled through
+ * verbatim. Shape is not provenance. Both the internal and provider sets below are closed
+ * membership lists, and extending either is a deliberate, reviewed act.
  *
  * @module ai/services/knowledge-base/helpers/embedFailureClassification
  */
@@ -46,6 +49,26 @@ export const BOUNDED_KB_ERROR_CODE_PATTERN = /^KB_[A-Z0-9_]{1,120}$/;
  * @type {String}
  */
 export const KB_VECTOR_EMBED_UNCLASSIFIED = 'KB_VECTOR_EMBED_FAILED';
+
+/**
+ * @summary The codes our OWN layers raise on the embed path, and the only ones allowed through
+ * unchanged.
+ *
+ * **Syntax is not provenance.** An earlier draft admitted anything matching the bounded pattern,
+ * reasoning that a `KB_`-shaped string is safe. It is not: the pattern constrains the *alphabet*, not
+ * the *author*, so a provider raising `KB_SECRET_…` — 120 admissible characters of its own choosing —
+ * travelled verbatim into durable state and onto the remotely-readable snapshot. The pattern is a
+ * necessary check on codes we mint; it was never evidence about who minted one.
+ *
+ * Membership is therefore the gate. A trusted internal code omitted here degrades to unclassified,
+ * which is the safe direction and a deliberate one-line addition when a new internal code appears.
+ * @type {Set<String>}
+ */
+const INTERNAL_EMBED_ERROR_CODES = Object.freeze(new Set([
+    'KB_EMBEDDING_INPUT_SIZE_EXCEEDED',
+    'KB_SYNC_VOLUME_EXCEEDED',
+    'KB_TENANT_SPOOF_REJECTED'
+]));
 
 /**
  * @summary Provider-vocabulary codes that describe a distinguishable embed fault.
@@ -78,9 +101,10 @@ export function classifyEmbedFailureCode(code) {
         return KB_VECTOR_EMBED_UNCLASSIFIED
     }
 
-    // An already-bounded code passes through untouched: `KB_SYNC_VOLUME_EXCEEDED` and the gitmirror
-    // codes are produced by our own layers and are more specific than anything this map could add.
-    if (BOUNDED_KB_ERROR_CODE_PATTERN.test(code)) {
+    // Membership, not shape. A code we mint is more specific than anything the map could add, so it
+    // passes through — but only because it is a declared member here. Testing the bounded pattern
+    // instead would admit a provider-authored `KB_…` string verbatim, which is the hole this closes.
+    if (INTERNAL_EMBED_ERROR_CODES.has(code)) {
         return code
     }
 

--- a/ai/services/knowledge-base/helpers/embedFailureClassification.mjs
+++ b/ai/services/knowledge-base/helpers/embedFailureClassification.mjs
@@ -1,0 +1,92 @@
+/**
+ * @summary Maps an embed failure's provider-side error code into the bounded `KB_*` namespace that
+ * durable tenant-repo state and the deployment-state snapshot admit.
+ *
+ * **The defect this closes is an inversion, not an omission.** Durable sync state accepts only codes
+ * matching {@link BOUNDED_KB_ERROR_CODE_PATTERN} — a deliberate credential boundary, because a code
+ * shaped `KB_[A-Z0-9_]+` cannot carry a clone URL, a bearer token or provider stderr. Embed failures,
+ * however, arrive carrying the *provider's* vocabulary: `EMBEDDING_PROBE_TIMEOUT`, `ABORT_ERR`,
+ * `OPENAI_COMPATIBLE_REQUEST_TIMEOUT`. Those are truthy, so the `error.code || 'KB_VECTOR_EMBED_FAILED'`
+ * fallback at the ingest boundary never fires; the real code is recorded, then silently dropped by the
+ * `^KB_` filter downstream, and `lastSourceErrorCode` lands as **null**.
+ *
+ * The consequence is backwards: a provider that classifies its failure well produces a receipt with
+ * *no* cause, while one that throws a bare `Error` produces at least a stage name. Better upstream
+ * classification made the observable strictly worse — which is why this cannot be fixed by widening
+ * the filter, only by translating at the boundary.
+ *
+ * **Why an allow-list and not a sanitizer.** Passing an unrecognised provider code through — even
+ * scrubbed — would put provider-controlled text into durable state and onto a remotely-readable
+ * surface, which is the exact property the bounded pattern exists to guarantee. Every value this
+ * module returns is either a literal declared here or a string that already satisfied the bounded
+ * pattern, so the guarantee holds by construction rather than by escaping. An unknown code is
+ * therefore reported as unclassified, and teaching this map a new provider code is a deliberate,
+ * reviewed act.
+ *
+ * @module ai/services/knowledge-base/helpers/embedFailureClassification
+ */
+
+/**
+ * @summary The single definition of a code that may cross into durable tenant-repo state.
+ *
+ * Owned here because this module is the one place that *produces* codes for that boundary; the
+ * orchestrator's sync service imports it rather than re-declaring the literal, so the producer and
+ * the filter cannot drift apart into a pair that separately look correct.
+ * @type {RegExp}
+ */
+export const BOUNDED_KB_ERROR_CODE_PATTERN = /^KB_[A-Z0-9_]{1,120}$/;
+
+/**
+ * @summary The code meaning **unclassified** — the embed stage failed and the cause was not
+ * recognised.
+ *
+ * It does NOT mean "embedding is broken in some general way", and two deployments reporting it may
+ * share nothing but the stage at which they stopped. Reading a shared occurrence of this code as a
+ * shared defect is the inference this constant is named to discourage.
+ * @type {String}
+ */
+export const KB_VECTOR_EMBED_UNCLASSIFIED = 'KB_VECTOR_EMBED_FAILED';
+
+/**
+ * @summary Provider-vocabulary codes that describe a distinguishable embed fault.
+ *
+ * Two timeout sources map to different codes on purpose: a consumer-owned deadline expiring
+ * (`EMBEDDING_PROBE_TIMEOUT`, raised by our own caller) and the provider's own request timeout are
+ * different faults with different fixes — raise our deadline, versus the provider is too slow or
+ * wedged. Collapsing them would rebuild the ambiguity this module exists to remove.
+ * @type {Object}
+ */
+const PROVIDER_ERROR_CODE_MAP = Object.freeze({
+    ABORT_ERR                        : 'KB_VECTOR_EMBED_ABORTED',
+    EMBEDDING_PROBE_TIMEOUT          : 'KB_VECTOR_EMBED_TIMEOUT',
+    OPENAI_COMPATIBLE_REQUEST_TIMEOUT: 'KB_VECTOR_EMBED_PROVIDER_TIMEOUT',
+    PROVIDER_TIMEOUT                 : 'KB_VECTOR_EMBED_PROVIDER_TIMEOUT'
+});
+
+/**
+ * @summary Translates one embed failure code into a bounded `KB_*` code, or reports it unclassified.
+ *
+ * Pure and total: every input yields a value satisfying {@link BOUNDED_KB_ERROR_CODE_PATTERN}, so a
+ * caller never has to decide whether the result is safe to persist.
+ *
+ * @param {String} [code] The failure's own code, in either vocabulary. Absent, empty and non-string
+ *     inputs are all unclassified — a codeless provider error is exactly the case the constant names.
+ * @returns {String} A bounded `KB_*` code.
+ */
+export function classifyEmbedFailureCode(code) {
+    if (typeof code !== 'string' || code.length === 0) {
+        return KB_VECTOR_EMBED_UNCLASSIFIED
+    }
+
+    // An already-bounded code passes through untouched: `KB_SYNC_VOLUME_EXCEEDED` and the gitmirror
+    // codes are produced by our own layers and are more specific than anything this map could add.
+    if (BOUNDED_KB_ERROR_CODE_PATTERN.test(code)) {
+        return code
+    }
+
+    // Own-property read, not a bare index: a code of `constructor` or `__proto__` would otherwise
+    // resolve against Object.prototype and return a function, which is neither bounded nor a string.
+    return Object.hasOwn(PROVIDER_ERROR_CODE_MAP, code)
+        ? PROVIDER_ERROR_CODE_MAP[code]
+        : KB_VECTOR_EMBED_UNCLASSIFIED
+}

--- a/test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncService.spec.mjs
@@ -2114,6 +2114,111 @@ test.describe('TenantRepoSyncService (#11790)', () => {
         expect(repoState.repoSlug).toBe('org/broken');
     });
 
+    /**
+     * @summary The consumer witness: two real embed-failure summaries carried through `runTask` to the
+     * `details.repos[].lastSourceErrorCode` a remote client reads.
+     *
+     * A producer-side spec that classifies a code, and a reader-side spec that admits it, can BOTH be
+     * green while the code never arrives — because the deciding step sits between them.
+     * `assertErrorFreeIngestionSummary` filters `summary.errors[].code` through `^KB_` and only then
+     * does `getSourceErrorCode` surface it. That filter is what turned a provider-classified failure
+     * into `lastSourceErrorCode: null`, so a witness that skips it does not witness the defect.
+     *
+     * The summaries here are not hand-written: they are produced by running the real
+     * `IngestionService.embedChunkGroups` against two injected provider faults, then handed to the
+     * `knowledgeBaseIngestionService` seam verbatim. No `KB_*` literal appears between the provider
+     * error and the assertion, so the whole producer -> filter -> projection chain has to agree.
+     */
+    test('two real embed failures reach details.repos[] as distinct source codes (#16647)', async () => {
+        const {default: IngestionService} = await import(
+            '../../../../../../../ai/services/knowledge-base/IngestionService.mjs'
+        );
+
+        /**
+         * Runs the REAL embed path against one injected provider fault.
+         * @param {String} providerCode
+         * @returns {Promise<Object>} The genuine ingestion summary, errors included.
+         */
+        async function produceRealSummary(providerCode) {
+            const summary = {errors: [], embeddingsGenerated: 0};
+
+            await IngestionService.embedChunkGroups.call({
+                createError            : IngestionService.createError.bind(IngestionService),
+                updateIngestionProgress: () => {},
+                vectorService          : {
+                    async embed() {
+                        throw Object.assign(new Error('provider failed'), {code: providerCode})
+                    }
+                },
+                writeTempJsonl: async () => path.join(
+                    await fs.mkdtemp(path.join(os.tmpdir(), 'neo-consumer-witness-')), 'chunks.jsonl'
+                )
+            }, {
+                chunks       : [{repoSlug: 'org/witness', text: 'x'}],
+                summary,
+                tenantContext: {tenantId: 't1', repoSlug: 'org/witness'},
+                viaMcp       : false
+            });
+
+            return {
+                ingested           : 1,
+                deleted            : 0,
+                embeddingsGenerated: 0,
+                errors             : summary.errors,
+                tenantId           : 't1',
+                durationMs         : 1
+            }
+        }
+
+        /**
+         * Drives one real summary through the sync lane and returns what a client would read.
+         * @param {Object} summary
+         * @param {String} repoSlug
+         * @returns {Promise<String|null>}
+         */
+        async function projectThroughRunTask(summary, repoSlug) {
+            await provisionMirrorDir({tenantId: 't1', repoSlug});
+
+            const result = await TenantRepoSyncService.runTask({
+                reason           : 'periodic-sweep:60000',
+                taskStateService : createInMemoryTaskStateService(),
+                tenantReposConfig: {tenantRepos: [
+                    {tenantId: 't1', repoSlug, mirrorRoot, cloneUrl: `https://github.com/neomjs/${repoSlug.split('/')[1]}.git`}
+                ]},
+                gitMirror                    : makeFakeGitMirror(),
+                envelopeBuilder              : makeFakeEnvelopeBuilder(),
+                knowledgeBaseIngestionService: makeFakeIngestionService({summaryFactory: () => summary}),
+                revisionsFilePath            : revisionsFile,
+                seedBootstrap                : false
+            });
+
+            return result.details.repos[0].lastSourceErrorCode ?? null
+        }
+
+        const
+            timeoutSummary = await produceRealSummary('EMBEDDING_PROBE_TIMEOUT'),
+            abortSummary   = await produceRealSummary('ABORT_ERR');
+
+        // Non-vacuity: an empty errors array would make the lane succeed and every assertion below
+        // would be reasoning about a repo that never failed.
+        expect(timeoutSummary.errors, 'the timeout run really produced an error').toHaveLength(1);
+        expect(abortSummary.errors, 'the abort run really produced an error').toHaveLength(1);
+
+        const
+            timeoutCode = await projectThroughRunTask(timeoutSummary, 'org/witness-timeout'),
+            abortCode   = await projectThroughRunTask(abortSummary,   'org/witness-abort');
+
+        // Arrival. Pre-fix both were dropped by the `^KB_` filter and this read null — the exact
+        // symptom that made a wedged deployment undiagnosable from a remote client.
+        expect(timeoutCode, 'a provider timeout arrives as a cause').not.toBeNull();
+        expect(abortCode, 'an upstream abort arrives as a cause').not.toBeNull();
+
+        // Distinguishability, which is the acceptance criterion itself: two faults must not read
+        // identically from the deployment-state snapshot alone.
+        expect(timeoutCode).not.toBe(abortCode);
+    });
+
+
     test('health payload: unresolved credentialRef preserves GitMirror source code', async () => {
         const taskStateService = createInMemoryTaskStateService();
 

--- a/test/playwright/unit/ai/services/knowledge-base/embedFailureClassification.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/embedFailureClassification.spec.mjs
@@ -228,8 +228,18 @@ test.describe('embed failure classification — production path', () => {
 });
 
 /**
- * @summary The projection half: the producer's ACTUAL output, carried through the durable read
- * boundary, observed as the `lastSourceErrorCode` a remote client reads.
+ * @summary The READ boundary in isolation — not the consumer witness, and it must not be read as one.
+ *
+ * This block proves one link: a code the producer mints is admitted by the durable reader, and the raw
+ * provider code is refused by it. It does NOT span `assertErrorFreeIngestionSummary` /
+ * `getSourceErrorCode`, the filter that sits between them and that actually decided the null — so it
+ * stays green if that middle drops the code. Raised by @neo-gpt against an earlier draft of this
+ * docblock, which claimed the whole chain.
+ *
+ * The end-to-end witness lives with the harness that can drive it: see
+ * `TenantRepoSyncService.spec.mjs` — "two real embed failures reach details.repos[] as distinct
+ * source codes", which runs the real `embedChunkGroups` summaries through `runTask` and reddens when
+ * either the producer or that middle filter is mutated.
  *
  * The producer test above stops at `summary.errors[].code` and checks it against a pattern. That is
  * one step short of the claim, and re-asserting the same regex I wrote proves only that I applied it
@@ -242,7 +252,7 @@ test.describe('embed failure classification — production path', () => {
  * reader's admission rule ever drift apart, that is precisely the pair this catches — and it is the
  * drift the durable receipt reported as `null`.
  */
-test.describe('embed failure classification — durable projection', () => {
+test.describe('embed failure classification — read boundary only', () => {
     /**
      * @param {String} providerCode A code in the provider's vocabulary.
      * @returns {String|null} The value a remote client would read as `lastSourceErrorCode`.
@@ -259,7 +269,7 @@ test.describe('embed failure classification — durable projection', () => {
         }).lastSourceErrorCode
     }
 
-    test('a classified provider fault survives the read boundary instead of nulling', () => {
+    test('a minted code is admitted by the durable reader', () => {
         const timeout = projectThroughDurableRead('EMBEDDING_PROBE_TIMEOUT'),
               aborted = projectThroughDurableRead('ABORT_ERR');
 

--- a/test/playwright/unit/ai/services/knowledge-base/embedFailureClassification.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/embedFailureClassification.spec.mjs
@@ -12,6 +12,8 @@ import {
     KB_VECTOR_EMBED_UNCLASSIFIED,
     classifyEmbedFailureCode
 } from '../../../../../../ai/services/knowledge-base/helpers/embedFailureClassification.mjs';
+import {normalizeTenantRepoCheckpointState}
+    from '../../../../../../ai/daemons/orchestrator/services/tenantRepoCheckpointValidity.mjs';
 
 /**
  * @summary An embed failure must reach the deployment-state snapshot as a cause a remote reader can
@@ -222,5 +224,65 @@ test.describe('embed failure classification — production path', () => {
         expect(run.errors).toHaveLength(1);
         expect(run.errors[0].code).toMatch(BOUNDED_KB_ERROR_CODE_PATTERN);
         expect(run.errors[0].code).not.toBe(KB_VECTOR_EMBED_UNCLASSIFIED);
+    });
+});
+
+/**
+ * @summary The projection half: the producer's ACTUAL output, carried through the durable read
+ * boundary, observed as the `lastSourceErrorCode` a remote client reads.
+ *
+ * The producer test above stops at `summary.errors[].code` and checks it against a pattern. That is
+ * one step short of the claim, and re-asserting the same regex I wrote proves only that I applied it
+ * twice. Whether the code SURVIVES is decided by a different function in a different module —
+ * `normalizeTenantRepoCheckpointState`, which independently re-validates persisted state it did not
+ * write and nulls anything it does not admit.
+ *
+ * So the two halves are chained by a real value: whatever `embedChunkGroups` actually produced is fed
+ * to the read boundary, with no literal code named in between. If the producer's namespace and the
+ * reader's admission rule ever drift apart, that is precisely the pair this catches — and it is the
+ * drift the durable receipt reported as `null`.
+ */
+test.describe('embed failure classification — durable projection', () => {
+    /**
+     * @param {String} providerCode A code in the provider's vocabulary.
+     * @returns {String|null} The value a remote client would read as `lastSourceErrorCode`.
+     */
+    function projectThroughDurableRead(providerCode) {
+        // No literal is named here — this is the producer's real answer, whatever it is.
+        const producedCode = classifyEmbedFailureCode(providerCode);
+
+        return normalizeTenantRepoCheckpointState({
+            consecutiveFailures: 1,
+            lastErrorCode      : 'KB_TENANT_REPO_SYNC_SYNC_FAILED',
+            lastRunAttemptAt   : 1,
+            lastSourceErrorCode: producedCode
+        }).lastSourceErrorCode
+    }
+
+    test('a classified provider fault survives the read boundary instead of nulling', () => {
+        const timeout = projectThroughDurableRead('EMBEDDING_PROBE_TIMEOUT'),
+              aborted = projectThroughDurableRead('ABORT_ERR');
+
+        // Survival is the whole point: the reader nulls anything it will not admit, and null is
+        // exactly what the receipt reported before this fix.
+        expect(timeout, 'a timeout reaches the client as a cause').not.toBeNull();
+        expect(aborted, 'an abort reaches the client as a cause').not.toBeNull();
+
+        // Two causes remain two causes at the surface a remote diagnostician actually reads.
+        expect(timeout).not.toBe(aborted);
+    });
+
+    test('the reader is genuinely capable of nulling — the control that makes the above mean something', () => {
+        // Without this, "not null" could hold because the reader admits everything, and the test
+        // would pass against a boundary that validates nothing at all.
+        const rejected = normalizeTenantRepoCheckpointState({
+            consecutiveFailures: 1,
+            lastRunAttemptAt   : 1,
+            lastSourceErrorCode: 'EMBEDDING_PROBE_TIMEOUT'
+        }).lastSourceErrorCode;
+
+        // The raw provider code — what the pre-fix producer handed over — is refused by the reader.
+        // That is the exact mechanism by which the cause was lost.
+        expect(rejected).toBeNull();
     });
 });

--- a/test/playwright/unit/ai/services/knowledge-base/embedFailureClassification.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/embedFailureClassification.spec.mjs
@@ -1,5 +1,12 @@
 import {test, expect} from '@playwright/test';
 
+import fs   from 'fs-extra';
+import os   from 'os';
+import path from 'path';
+
+import '../../../../../../src/Neo.mjs';
+import '../../../../../../src/core/Base.mjs';
+
 import {
     BOUNDED_KB_ERROR_CODE_PATTERN,
     KB_VECTOR_EMBED_UNCLASSIFIED,
@@ -60,10 +67,28 @@ test.describe('embed failure classification (#16647)', () => {
             .toBe(classifyEmbedFailureCode('PROVIDER_TIMEOUT'));
     });
 
-    test('an already-bounded code is passed through, not overwritten', () => {
+    test('a DECLARED internal code is passed through, not overwritten', () => {
         // Our own layers produce codes more specific than anything the map could add. Rewriting them
-        // would be a regression disguised as classification.
+        // would be a regression disguised as classification. It passes because it is a declared
+        // member, not because of how it is spelled — see the provenance test below.
         expect(classifyEmbedFailureCode('KB_SYNC_VOLUME_EXCEEDED')).toBe('KB_SYNC_VOLUME_EXCEEDED');
+        expect(classifyEmbedFailureCode('KB_EMBEDDING_INPUT_SIZE_EXCEEDED')).toBe('KB_EMBEDDING_INPUT_SIZE_EXCEEDED');
+    });
+
+    test('a provider-authored KB_-shaped code does NOT pass through — shape is not provenance', () => {
+        // The hard specimen, and the one the first draft got wrong. `BOUNDED_KB_ERROR_CODE_PATTERN`
+        // constrains the ALPHABET, not the AUTHOR: 120 characters of `[A-Z0-9_]` are the provider's
+        // to choose. Gating on the pattern therefore admitted provider-controlled text verbatim into
+        // durable state while looking like a safety check.
+        //
+        // This is the assertion that makes the leak test below non-vacuous. A hostile string carrying
+        // lowercase or punctuation fails the pattern for INCIDENTAL reasons, so it would pass even
+        // under the broken gate — it never exercised the hole.
+        const providerAuthored = 'KB_SECRET_ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
+
+        expect(providerAuthored, 'the specimen really is pattern-admissible')
+            .toMatch(BOUNDED_KB_ERROR_CODE_PATTERN);
+        expect(classifyEmbedFailureCode(providerAuthored)).toBe(KB_VECTOR_EMBED_UNCLASSIFIED);
     });
 
     test('an unrecognised provider code is reported unclassified, never passed through', () => {
@@ -114,5 +139,88 @@ test.describe('embed failure classification (#16647)', () => {
 
         // Non-vacuity: if the list above were ever emptied, the loop would pass by iterating nothing.
         expect(providerCodes.length).toBeGreaterThan(0);
+    });
+});
+
+/**
+ * @summary The production-path witness: the same two faults, observed as the codes that actually
+ * reach the receipt, through the real `embedChunkGroups` catch block rather than the helper.
+ *
+ * The specs above pin the classifier in isolation. That is necessary and not sufficient — a correct
+ * helper wired to nothing would satisfy every one of them. This block drives the method the
+ * orchestrator's sync lane actually calls, and asserts on `summary.errors[].code`: the exact field
+ * `assertErrorFreeIngestionSummary` filters through `^KB_` on its way to `lastSourceErrorCode`.
+ *
+ * The bounded-pattern assertion is the load-bearing half. Pre-fix these arrived as
+ * `EMBEDDING_PROBE_TIMEOUT` and `ABORT_ERR`, which are rejected by that filter — so the receipt lost
+ * them and reported null. Asserting only that the two codes DIFFER would have passed before the fix
+ * too, since the provider's own strings also differ. Distinct AND admissible is the property.
+ *
+ * `.call()` on a stub rather than configuring the singleton: the service is a Neo singleton, and
+ * mutating shared instance state inside a unit run leaks across specs in the same worker.
+ */
+test.describe('embed failure classification — production path', () => {
+    /**
+     * @param {Function} embed Stubbed `vectorService.embed`.
+     * @returns {Promise<Object>} The populated ingestion summary.
+     */
+    async function runEmbedWithFailure(embed) {
+        const {default: IngestionService} = await import(
+            '../../../../../../ai/services/knowledge-base/IngestionService.mjs'
+        );
+        const
+            summary = {errors: [], embeddingsGenerated: 0},
+            harness = {
+                createError            : IngestionService.createError.bind(IngestionService),
+                updateIngestionProgress: () => {},
+                vectorService          : {embed},
+                writeTempJsonl         : async () => path.join(
+                    await fs.mkdtemp(path.join(os.tmpdir(), 'neo-embed-witness-')), 'chunks.jsonl'
+                )
+            };
+
+        await IngestionService.embedChunkGroups.call(harness, {
+            chunks       : [{repoSlug: 'org/witness', text: 'x'}],
+            summary,
+            tenantContext: {tenantId: 't1', repoSlug: 'org/witness'},
+            viaMcp       : false
+        });
+
+        return summary
+    }
+
+    test('a thrown provider timeout and a thrown abort reach the receipt as distinct admissible codes', async () => {
+        const
+            timeoutError = Object.assign(new Error('probe timed out'), {code: 'EMBEDDING_PROBE_TIMEOUT'}),
+            abortError   = Object.assign(new Error('aborted'),         {code: 'ABORT_ERR'}),
+            timeoutRun   = await runEmbedWithFailure(async () => { throw timeoutError }),
+            abortRun     = await runEmbedWithFailure(async () => { throw abortError });
+
+        // Non-vacuity: an empty errors array would satisfy every assertion below by iterating nothing.
+        expect(timeoutRun.errors, 'the timeout run recorded an error').toHaveLength(1);
+        expect(abortRun.errors,   'the abort run recorded an error').toHaveLength(1);
+
+        const timeoutCode = timeoutRun.errors[0].code,
+              abortCode   = abortRun.errors[0].code;
+
+        // Admissible: survives the `^KB_` filter on the way to `lastSourceErrorCode`. This is the
+        // half that was red before the fix — both arrived in the provider's vocabulary.
+        expect(timeoutCode).toMatch(BOUNDED_KB_ERROR_CODE_PATTERN);
+        expect(abortCode).toMatch(BOUNDED_KB_ERROR_CODE_PATTERN);
+
+        // Distinct: two causes remain two causes at the surface a remote reader sees.
+        expect(timeoutCode).not.toBe(abortCode);
+    });
+
+    test('a result-shaped provider failure is classified on the same path', async () => {
+        // The sibling branch — `embed` RESOLVES with an error payload instead of throwing. Both sites
+        // defaulted identically before, so covering only the throw path would leave half the defect.
+        const run = await runEmbedWithFailure(async () => ({
+            error: 'provider refused', code: 'OPENAI_COMPATIBLE_REQUEST_TIMEOUT'
+        }));
+
+        expect(run.errors).toHaveLength(1);
+        expect(run.errors[0].code).toMatch(BOUNDED_KB_ERROR_CODE_PATTERN);
+        expect(run.errors[0].code).not.toBe(KB_VECTOR_EMBED_UNCLASSIFIED);
     });
 });

--- a/test/playwright/unit/ai/services/knowledge-base/embedFailureClassification.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/embedFailureClassification.spec.mjs
@@ -1,0 +1,118 @@
+import {test, expect} from '@playwright/test';
+
+import {
+    BOUNDED_KB_ERROR_CODE_PATTERN,
+    KB_VECTOR_EMBED_UNCLASSIFIED,
+    classifyEmbedFailureCode
+} from '../../../../../../ai/services/knowledge-base/helpers/embedFailureClassification.mjs';
+
+/**
+ * @summary An embed failure must reach the deployment-state snapshot as a cause a remote reader can
+ * tell apart from a different cause — with no shell access to the host.
+ *
+ * The defect these specs pin is an inversion. Durable tenant-repo state admits only codes matching
+ * `BOUNDED_KB_ERROR_CODE_PATTERN`; provider errors arrive in the provider's vocabulary
+ * (`EMBEDDING_PROBE_TIMEOUT`, `ABORT_ERR`), which is truthy — so the old
+ * `error.code || 'KB_VECTOR_EMBED_FAILED'` fallback never fired for one, the provider code was
+ * recorded, and the `^KB_` filter then dropped it, landing `lastSourceErrorCode` as **null**. A
+ * well-classified provider failure therefore produced a receipt with *no* cause, while a bare
+ * `Error` produced at least a stage name.
+ *
+ * **Why these assertions are red before the fix.** Every case below feeds a code in the provider's
+ * vocabulary and asserts the result is BOTH bounded and distinct. Pre-fix, `EMBEDDING_PROBE_TIMEOUT`
+ * came back verbatim: unbounded, so `expect(...).toMatch(BOUNDED...)` fails, and identical in kind
+ * to every other unmapped provider code, so the distinctness assertion fails too. A spec asserting
+ * merely that *a* code is present passes today and proves nothing — which is the shape the ticket
+ * names as insufficient.
+ *
+ * The pattern is imported from the module the orchestrator's sync service imports, not re-declared
+ * here. A local copy would keep passing after a drift that breaks production.
+ */
+test.describe('embed failure classification (#16647)', () => {
+    test('two distinct provider faults surface as two distinct bounded codes', () => {
+        const
+            timeout = classifyEmbedFailureCode('EMBEDDING_PROBE_TIMEOUT'),
+            aborted = classifyEmbedFailureCode('ABORT_ERR');
+
+        // Bounded: the durable filter accepts it at all. Pre-fix both came back in the provider's
+        // vocabulary and were discarded downstream to null.
+        expect(timeout, 'consumer-deadline timeout is bounded').toMatch(BOUNDED_KB_ERROR_CODE_PATTERN);
+        expect(aborted, 'upstream abort is bounded').toMatch(BOUNDED_KB_ERROR_CODE_PATTERN);
+
+        // Distinct: the property the ticket actually asks for. Two deployments failing for different
+        // reasons must not read identically from the snapshot alone.
+        expect(timeout).not.toBe(aborted);
+
+        // ...and neither collapses to the unclassified code, which would satisfy "distinct from each
+        // other" only by accident if one of them silently fell through the map.
+        expect(timeout).not.toBe(KB_VECTOR_EMBED_UNCLASSIFIED);
+        expect(aborted).not.toBe(KB_VECTOR_EMBED_UNCLASSIFIED);
+    });
+
+    test('a consumer-owned deadline and the provider\'s own timeout stay separable', () => {
+        // Different fixes: raise our deadline, versus the provider is wedged. Collapsing both into
+        // one "timeout" code would rebuild the ambiguity this module exists to remove.
+        expect(classifyEmbedFailureCode('EMBEDDING_PROBE_TIMEOUT'))
+            .not.toBe(classifyEmbedFailureCode('OPENAI_COMPATIBLE_REQUEST_TIMEOUT'));
+
+        // The two provider-side timeout spellings ARE the same fault and deliberately share a code.
+        expect(classifyEmbedFailureCode('OPENAI_COMPATIBLE_REQUEST_TIMEOUT'))
+            .toBe(classifyEmbedFailureCode('PROVIDER_TIMEOUT'));
+    });
+
+    test('an already-bounded code is passed through, not overwritten', () => {
+        // Our own layers produce codes more specific than anything the map could add. Rewriting them
+        // would be a regression disguised as classification.
+        expect(classifyEmbedFailureCode('KB_SYNC_VOLUME_EXCEEDED')).toBe('KB_SYNC_VOLUME_EXCEEDED');
+    });
+
+    test('an unrecognised provider code is reported unclassified, never passed through', () => {
+        // The control that proves the map is consulted rather than acting as a pass-through: a code
+        // that is NOT a member must not survive. If this returned its input, the leak assertion
+        // below would be the only thing standing between provider text and durable state.
+        expect(classifyEmbedFailureCode('SOME_FUTURE_PROVIDER_CODE')).toBe(KB_VECTOR_EMBED_UNCLASSIFIED);
+    });
+
+    test('a provider code echoing request content cannot leak through it', () => {
+        // Provider errors quote the request. This is the property that makes the allow-list the
+        // right shape and a sanitizer the wrong one: the output is a literal declared by the module,
+        // so no amount of hostile input reaches durable state or the remotely-readable snapshot.
+        const hostile  = 'ERR fetch https://oauth2:glpat-SECRETVALUE@git.example.com/acme/repo.git failed';
+        const observed = classifyEmbedFailureCode(hostile);
+
+        expect(observed).toBe(KB_VECTOR_EMBED_UNCLASSIFIED);
+        expect(observed).toMatch(BOUNDED_KB_ERROR_CODE_PATTERN);
+        expect(observed).not.toContain('glpat-');
+        expect(observed).not.toContain('git.example.com');
+    });
+
+    test('absent, empty and non-string codes are unclassified rather than crashing', () => {
+        // A codeless provider error is the case `KB_VECTOR_EMBED_FAILED` genuinely names, and this
+        // path stays unchanged by the fix — stated here so the constant's meaning is pinned as
+        // "unclassified", not "embedding is broken".
+        for (const input of [undefined, null, '', 0, {}, ['ABORT_ERR']]) {
+            expect(classifyEmbedFailureCode(input), `input ${JSON.stringify(input) ?? 'undefined'}`)
+                .toBe(KB_VECTOR_EMBED_UNCLASSIFIED);
+        }
+    });
+
+    test('every declared mapping is bounded — the guarantee the callers rely on', () => {
+        // Totality control. Each caller persists the result without re-checking, so a single
+        // mistyped literal in the map would put an unbounded code into durable state and this is the
+        // only place that would notice.
+        const providerCodes = [
+            'ABORT_ERR',
+            'EMBEDDING_PROBE_TIMEOUT',
+            'OPENAI_COMPATIBLE_REQUEST_TIMEOUT',
+            'PROVIDER_TIMEOUT'
+        ];
+
+        for (const code of providerCodes) {
+            expect(classifyEmbedFailureCode(code), `${code} maps to a bounded code`)
+                .toMatch(BOUNDED_KB_ERROR_CODE_PATTERN);
+        }
+
+        // Non-vacuity: if the list above were ever emptied, the loop would pass by iterating nothing.
+        expect(providerCodes.length).toBeGreaterThan(0);
+    });
+});


### PR DESCRIPTION
Resolves #16647

## The defect is an inversion, not an omission

Durable tenant-repo state admits only codes matching `^KB_[A-Z0-9_]{1,120}$`. That is a credential boundary and a good one: a code of that shape cannot carry a clone URL, a bearer token, or provider stderr.

Embed failures arrive carrying the **provider's** vocabulary — `EMBEDDING_PROBE_TIMEOUT`, `ABORT_ERR`, `OPENAI_COMPATIBLE_REQUEST_TIMEOUT`. Those strings are truthy, so the fallback never fired for one:

```js
code: error.code || 'KB_VECTOR_EMBED_FAILED'   // IngestionService.mjs:406
```

The provider code was recorded, then discarded downstream by the `^KB_` filter, and `lastSourceErrorCode` landed as **null**.

So the observable ran backwards: **a provider that classified its failure well produced a receipt with no cause, while one that threw a bare `Error` produced at least a stage name.** Better upstream classification made the surface strictly worse. That is why widening the filter is the wrong fix — the boundary is correct — and translating at it is the right one.

## Why an allow-list rather than a sanitizer

Passing an unrecognised provider code through, even scrubbed, would put provider-controlled text into durable state and onto a remotely-readable surface — the exact property the bounded pattern exists to guarantee.

**Every value `classifyEmbedFailureCode` returns is a literal declared in the module.** The guarantee holds **by construction rather than by escaping**.

That sentence was **false in the first push**, and @neo-gpt caught it. The gate tested `BOUNDED_KB_ERROR_CODE_PATTERN`, so a provider raising `KB_SECRET_ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789` satisfied it and passed through verbatim into durable state. **The pattern constrains the alphabet, not the author** — it is a check on codes *we* mint, never evidence about who minted one. Shape is not provenance. The gate is now membership in an explicit internal set (`KB_EMBEDDING_INPUT_SIZE_EXCEEDED`, `KB_SYNC_VOLUME_EXCEEDED`, `KB_TENANT_SPOOF_REJECTED`); a trusted code omitted there degrades to unclassified, which is the safe direction.

Worth naming why my own leak test missed it: the hostile specimen carried lowercase and punctuation, so it failed the pattern for **incidental** reasons and passed under the broken gate without ever exercising the hole. The replacement asserts the specimen *is* pattern-admissible **before** asserting it is refused.

## Changes

| file | change |
|---|---|
| `ai/services/knowledge-base/helpers/embedFailureClassification.mjs` | new — the classifier, the bounded pattern as SSOT, and `KB_VECTOR_EMBED_FAILED` documented as *unclassified* |
| `ai/services/knowledge-base/IngestionService.mjs` | both fallback sites (`:388` result-shaped, `:406` throw-shaped) classify instead of defaulting |
| `ai/daemons/orchestrator/services/TenantRepoSyncService.mjs` | imports the pattern instead of re-declaring the literal |

The pattern moves to the module that *produces* codes for the boundary. Producer and filter were two copies that could drift into a pair which separately look correct — a producer widening a code the filter still rejects is precisely this ticket's defect.

## Acceptance criteria

- [x] **Two embed failures with different *classified* causes are distinguishable from the snapshot alone.** Not the codeless case — see Scope. `EMBEDDING_PROBE_TIMEOUT` → `KB_VECTOR_EMBED_TIMEOUT` and `ABORT_ERR` → `KB_VECTOR_EMBED_ABORTED` both survive the filter that discards them today, so no new snapshot field is needed.
- [x] **Coverage that fails on today's shape.** See below.
- [x] **Length-capped and redacted at the boundary**, with a test that a provider error echoing a credential-bearing URL does not leak it.
- [x] **`KB_VECTOR_EMBED_FAILED` documented as *unclassified*** at the constant, naming the "same code, same defect" inference it should discourage.

## Deltas

| # | delta | why |
|---|---|---|
| 1 | `classifyEmbedFailureCode` translates provider codes into the bounded namespace | the inversion: truthy provider codes bypassed the fallback, then the `^KB_` filter dropped them to null |
| 2 | pass-through gated on **membership**, not on the bounded pattern | shape is not provenance — a provider-authored `KB_…` satisfied the pattern and travelled verbatim |
| 3 | bounded pattern owned by the producing module; sync service imports it | two copies could drift into a pair that separately look correct |
| 4 | `KB_VECTOR_EMBED_FAILED` documented as *unclassified* | so a shared code is not read as a shared defect |
| 5 | production-path witness through the real `embedChunkGroups` | helper specs alone would pass for a classifier wired to nothing |

## Test Evidence

Evidence: pre-fix mutation reddens **9 of 10** specs; new spec **12/12** green, including a durable-projection witness that chains the producer's real output through `normalizeTenantRepoCheckpointState` (the read boundary that independently re-validates persisted state) with no literal code named in between, plus the control proving that boundary refuses the raw provider code; `TenantRepoSyncService` + `tenantRepoSync` + `LaneEnablementSignal` **154/154** green.

## Verification

**Mutation-proved, not merely green.** Reverting the classifier to the exact pre-fix expression `code || KB_VECTOR_EMBED_UNCLASSIFIED` turns **9 of 10 specs red**, including both production-path witnesses.

The one survivor is correct and worth naming: *"a DECLARED internal code is passed through"* holds under both shapes, because those codes are unaffected by the defect. It guards a different property.

**Production-path witness** (also review-raised): the helper specs alone would be satisfied by a correct classifier wired to nothing. Two thrown provider faults are now driven through the real `embedChunkGroups` catch block and observed as the `summary.errors[].code` values that `^KB_` filters toward `lastSourceErrorCode`, plus the result-shaped sibling branch. **Distinct AND admissible** is the property — asserting only distinctness would have passed pre-fix too, since the provider's own strings also differ. Driven via `.call()` on a stub rather than configuring the Neo singleton.

- New spec: **10/10** green.
- `TenantRepoSyncService` + `tenantRepoSync` + `LaneEnablementSignal`: **154/154** green — the specs that pin the const I removed.
- Whole `test/playwright/unit/ai/` suite: the failure count is **not stable run-to-run** on this machine (117 / 118 / 119 observed across three runs, with 9058 / 9042 / 9041 passing). A ±1 delta there cannot distinguish a regression from ambient flake, so I am not claiming clearance from it — the targeted suites above are the evidence, and CI is the oracle.

## Scope

**The codeless half is carved out into #16658, not dropped.** @neo-gpt raised this in review and he is right on the substance: #16647 was filed from an observed *codeless* `KB_VECTOR_EMBED_FAILED` receipt, and this PR leaves that exact case unchanged.

I tried `Refs` rather than `Resolves`, and `lint-pr-body` rejects it. I read that as substrate friction — a mandatory closing keyword making partial-scope delivery unrepresentable — and **@neo-gpt falsified me**: #12367 already defines the mechanism, where a partial PR resolves its own fully-delivered scope and the remainder gets a named successor. The representation existed and I did not know it. No template gap; my claim is withdrawn.

So: #16658 now carries the uncoded case, and #16647 is scope-amended on the ticket itself ([comment](https://github.com/neomjs/neo/issues/16647#issuecomment-5224622864)) so a future reader is not told its motivating observation was fixed.

Deliberately **not** included: classifying the codeless embed path. A provider error reaching the boundary with no code at all still reports unclassified — which is now accurate and documented rather than misleading. Making the `ollama` and `openAiCompatible` branches classify their own failures is named in the ticket's Out of Scope as work to be done as those branches are touched.

Concretely, that means this PR does not change the string an external deployment currently reporting `KB_VECTOR_EMBED_FAILED` would show; it fixes the case where a *classified* failure reported nothing at all, and makes the remaining code honest about what it means.

## Post-Merge Validation

The observable is a deployment-state field, so the check is a read, not a run: on any deployment whose embed lane fails with a *classified* provider fault, `snapshot.tenantRepoSync.repos[].lastSourceErrorCode` should now carry `KB_VECTOR_EMBED_TIMEOUT` / `KB_VECTOR_EMBED_PROVIDER_TIMEOUT` / `KB_VECTOR_EMBED_ABORTED` where it previously carried `null`.

A deployment still reporting `KB_VECTOR_EMBED_FAILED` is **not** a failed validation — that is the codeless path, unchanged by design and carved into the successor ticket.

## Related

#16658 (the uncoded successor this PR deliberately does not address) · `#16566` (the embed-stage failure this made hard to compare against any other deployment) · `#16568` (the revision a deployment could not report — same family, different axis).

---

Authored by Grace (Opus 5, Claude Code). Session 9ced67a1-8f21-4da2-a1bf-a2a968c47ed2.
