### PR TITLE
feat(ai): refuse a public write carrying a confidential token (#16535)

### DIFF
--- a/.github/workflows/agent-pr-body-lint.yml
+++ b/.github/workflows/agent-pr-body-lint.yml
@@ -242,3 +242,24 @@ jobs:
                 ? `A follow-up comment on PR #${pr.number} carries the full guidance.`
                 : `(No follow-up comment is posted on \`${context.payload.action}\` events — this annotation is the diagnostic.)`
             ].join('\n'));
+
+  confidentiality:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+      # Body and denylist travel by ENV, never argv or `${{ }}` interpolation into a shell:
+      # an interpolated body is a script-injection vector and a denylist on a command line is
+      # visible in the process table.
+      #
+      # On a fork `pull_request` run the secret is absent, so the script reports NOT ENFORCED and
+      # exits 0. That is deliberate and stated in its output rather than passing silently — a green
+      # check that never ran is the failure mode this lane exists to end.
+      - name: Scan PR body for confidential tokens
+        env:
+          NEO_PUBLIC_BODY:                  ${{ github.event.pull_request.body }}
+          NEO_PUBLIC_BODY_LABEL:            'PR body'
+          NEO_CONFIDENTIAL_TOKEN_DENYLIST:  ${{ secrets.NEO_CONFIDENTIAL_TOKEN_DENYLIST }}
+        run: node ai/scripts/lint/lintPublicBodyConfidentiality.mjs

--- a/.github/workflows/agent-pr-review-body-lint.yml
+++ b/.github/workflows/agent-pr-review-body-lint.yml
@@ -437,3 +437,24 @@ jobs:
             });
 
             core.setFailed(`Agent review body missing required template anchors. See follow-up comment on PR #${pr.number}.`);
+
+  confidentiality:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+      # Body and denylist travel by ENV, never argv or `${{ }}` interpolation into a shell:
+      # an interpolated body is a script-injection vector and a denylist on a command line is
+      # visible in the process table.
+      #
+      # On a fork `pull_request` run the secret is absent, so the script reports NOT ENFORCED and
+      # exits 0. That is deliberate and stated in its output rather than passing silently — a green
+      # check that never ran is the failure mode this lane exists to end.
+      - name: Scan review body for confidential tokens
+        env:
+          NEO_PUBLIC_BODY:                  ${{ github.event.review.body }}
+          NEO_PUBLIC_BODY_LABEL:            'review body'
+          NEO_CONFIDENTIAL_TOKEN_DENYLIST:  ${{ secrets.NEO_CONFIDENTIAL_TOKEN_DENYLIST }}
+        run: node ai/scripts/lint/lintPublicBodyConfidentiality.mjs

--- a/ai/mcp/server/github-workflow/configBase.mjs
+++ b/ai/mcp/server/github-workflow/configBase.mjs
@@ -80,7 +80,30 @@ class ConfigBase extends ConfigProvider {
              */
             minGhVersion: leaf('2.0.0'),
             /**
+             * Confidential tokens — client and partner names — that must never reach a public
+             * artifact. Scanned at the public-write boundary before publication.
+             *
+             * **Empty here on purpose, and empty is NOT permission to publish.** Committing the list
+             * would publish the exact names the check exists to protect, so values are supplied by
+             * local/env config only. The `productNameDenylist` sibling below uses the same storage for
+             * the opposite direction — it sanitizes content coming IN, where an empty list is a safe
+             * no-op. On this outbound path an empty list means *enforcement did not run*, and the
+             * scanner reports `unchecked` rather than a pass so the two are never confused.
+             *
+             * Hashing the entries instead would not let them be committed either: an unkeyed hash of a
+             * company name is brute-forceable from any wordlist of company names, so committed hashes
+             * publish the list to anyone willing to spend an afternoon.
+             * @type {string[]}
+             */
+            confidentialTokenDenylist: leaf([], 'NEO_CONFIDENTIAL_TOKEN_DENYLIST', 'csv'),
+            /**
              * The owner of the GitHub repository.
+             *
+             * Overridable, which is why the public-write access class cannot stand in for "targets a
+             * public repository": that class states what a TOOL mutates on github.com, not what the
+             * TARGET is. A deployment repointing this at a private repo is the sanctioned place for
+             * client specifics, so the confidentiality scan resolves the target's visibility rather
+             * than assuming it from the tool.
              * @type {string}
              */
             owner: leaf('neomjs'),

--- a/ai/mcp/server/github-workflow/toolService.mjs
+++ b/ai/mcp/server/github-workflow/toolService.mjs
@@ -14,6 +14,11 @@ import ToolService                                                              
 import {assertExpectedIdentity as assertExpectedGitHubIdentity, IdentityAssertionCode} from '../../../graph/assertExpectedIdentity.mjs';
 import RequestContextService                                                           from '../shared/services/RequestContextService.mjs';
 import config                                                                          from './config.mjs';
+import {
+    SCAN_REASON,
+    isPublishBlocked,
+    scanForConfidentialTokens
+}                                                                                      from '../../../services/shared/confidentiality/confidentialTokenScanner.mjs';
 
 const execFileAsync   = promisify(execFile);
 const __filename      = fileURLToPath(import.meta.url);
@@ -312,6 +317,82 @@ function isPublicGitHubWriteTool(toolName) {
 }
 
 /**
+ * @summary Collects every string an argument tree could publish.
+ *
+ * Deliberately not a field allow-list (`body`, `title`, …). A denylist of *fields* has the same
+ * failure mode as the hand-written surface list this guard replaces: the field added next year is
+ * unscanned and silent. Walking every string is the only version whose coverage does not decay, and
+ * the cost is a shallow walk over an argument object.
+ *
+ * @param {*} value Argument tree.
+ * @param {Number} [depth=0] Recursion bound; argument trees are shallow and a cycle must not hang a write.
+ * @returns {String[]}
+ * @private
+ */
+function collectPublishableStrings(value, depth = 0) {
+    if (depth > 6) return [];
+    if (typeof value === 'string') return [value];
+    if (Array.isArray(value)) return value.flatMap(item => collectPublishableStrings(item, depth + 1));
+
+    if (value && typeof value === 'object') {
+        return Object.values(value).flatMap(item => collectPublishableStrings(item, depth + 1));
+    }
+
+    return []
+}
+
+/**
+ * @summary Refuses a public write whose payload carries a confidential token.
+ *
+ * Sits on the SAME derived set as the identity guard, which is the point: `PUBLIC_GITHUB_WRITE_TOOLS`
+ * is computed from the access classification, and `assertNoUnclassifiedGitHubTools` already fails
+ * closed on a tool that forgets to classify itself. So a public-write tool added later is scanned
+ * automatically. Wiring this into each service by hand would leave the next surface unguarded and
+ * silent — the same recurrence mechanism this guard exists to end, one level up.
+ *
+ * The scan resolves the TARGET's visibility rather than reading it off the tool class. `owner` is an
+ * overridable leaf, so "mutates public GitHub state" describes what the tool does to github.com, not
+ * whether the repository is public — and a private repository is the sanctioned home for client
+ * specifics. Blocking there would refuse the one surface allowed to carry them.
+ *
+ * @param {Function} delegate Wrapped handler.
+ * @param {Object} [options]
+ * @param {Function} [options.resolveDenylist] Injectable for tests.
+ * @param {Function} [options.resolveVisibility] Injectable for tests.
+ * @returns {Function}
+ * @private
+ */
+function buildConfidentialContentGuard(delegate, {
+    resolveDenylist   = () => config.confidentialTokenDenylist,
+    resolveVisibility = () => RepositoryService.getRepositoryVisibility()
+} = {}) {
+    return async function confidentialContentGuard(...args) {
+        const result = scanForConfidentialTokens(collectPublishableStrings(args).join('\n'), {
+            denylist        : resolveDenylist(),
+            targetVisibility: resolveVisibility()
+        });
+
+        if (isPublishBlocked(result)) {
+            return {
+                error: 'Confidential content',
+                code : 'CONFIDENTIAL_TOKEN_IN_PUBLIC_WRITE',
+                // The reason, not just the verdict. `target-unknown` means visibility never resolved
+                // — a token scope or authorization fault several layers away — and an operator told
+                // only "token matched" would redact a legitimate name and be blocked again on the
+                // next one, with nothing pointing at the real cause.
+                reason : result.reason,
+                matches: result.matches,
+                message: result.reason === SCAN_REASON.targetUnknown
+                    ? 'Refused: a confidential token is present and the target repository\'s visibility could not be resolved, so it is treated as public. If this deployment targets a private repository, fix the repository-metadata fetch rather than redacting.'
+                    : 'Refused: the payload contains a confidential token and the target repository is public. Scrub the named token before publishing.'
+            };
+        }
+
+        return delegate(...args);
+    };
+}
+
+/**
  * @summary Applies the GitHub write-boundary identity guard to mutating tool handlers only.
  * @param {Object} mapping Operation id to handler function.
  * @param {Object} [guardOptions] Resolver injection for tests.
@@ -323,8 +404,14 @@ function guardGitHubWriteTools(mapping, guardOptions) {
     return Object.fromEntries(
         Object.entries(mapping).map(([toolName, handler]) => [
             toolName,
+            // Confidentiality is the OUTER guard: a body carrying a client name must be refused
+            // before an identity assertion can make a network call on its behalf. Both key on the
+            // same derived set, so neither can drift from the other's coverage.
             isPublicGitHubWriteTool(toolName)
-                ? buildGitHubWriteIdentityGuard(handler, guardOptions)
+                ? buildConfidentialContentGuard(
+                    buildGitHubWriteIdentityGuard(handler, guardOptions),
+                    guardOptions
+                )
                 : handler
         ])
     );
@@ -455,7 +542,9 @@ export {
     GITHUB_TOOL_ACCESS,
     assertCompleteGitHubToolAccessPolicy,
     assertNoUnclassifiedGitHubTools,
+    buildConfidentialContentGuard,
     buildGitHubWriteIdentityGuard,
+    collectPublishableStrings,
     getConversationRouter,
     guardGitHubWriteTools,
     isPublicGitHubWriteTool,

--- a/ai/scripts/lint/config-leaf-parity.json
+++ b/ai/scripts/lint/config-leaf-parity.json
@@ -382,6 +382,7 @@
         "wakeDaemonHeartbeatAlivePath"
     ],
     "ai/mcp/server/github-workflow/config.template.mjs": [
+        "confidentialTokenDenylist",
         "debug",
         "healthCheckCacheDuration",
         "issueSync",

--- a/ai/scripts/lint/lintPublicBodyConfidentiality.mjs
+++ b/ai/scripts/lint/lintPublicBodyConfidentiality.mjs
@@ -1,0 +1,59 @@
+#!/usr/bin/env node
+/**
+ * @summary Fails a CI run when a PR or review body carries a confidential token — without printing it.
+ *
+ * The MCP dispatch guard cannot see this surface: a body written with `gh pr create --body-file`
+ * reaches no MCP tool. This is that gap, and its disclosure contract is INVERTED relative to every
+ * other caller — a workflow log on a public repository is world-readable, so naming the matched token
+ * here would publish the value the scan exists to protect.
+ *
+ * Reads the body and denylist from the ENVIRONMENT, never argv: a body interpolated into a shell
+ * command is a script-injection vector, and a denylist on a command line is visible in the process
+ * table.
+ *
+ * Exit codes: 0 clean, unchecked or skipped · 1 blocked · 2 usage error.
+ * @module ai/scripts/lint/lintPublicBodyConfidentiality
+ */
+import {
+    SCAN_OUTCOME,
+    TARGET_VISIBILITY,
+    projectScanForPublicLog,
+    scanForConfidentialTokens
+} from '../../services/shared/confidentiality/confidentialTokenScanner.mjs';
+
+const
+    body     = process.env.NEO_PUBLIC_BODY ?? '',
+    rawList  = process.env.NEO_CONFIDENTIAL_TOKEN_DENYLIST ?? '',
+    label    = process.env.NEO_PUBLIC_BODY_LABEL || 'body',
+    denylist = rawList.split(',').map(token => token.trim()).filter(Boolean);
+
+// The target is this repository, which is public. Stated rather than resolved: a workflow has no
+// cheap visibility lookup, and assuming public is the fail-toward-scanning direction anyway.
+const
+    result    = scanForConfidentialTokens(body, {denylist, targetVisibility: TARGET_VISIBILITY.public}),
+    projected = projectScanForPublicLog(result);
+
+console.log(`[confidentiality] ${label}: ${JSON.stringify(projected)}`);
+
+if (projected.outcome === SCAN_OUTCOME.unchecked) {
+    // Not a pass. A run with no configured denylist scanned nothing, and a green check that never
+    // ran is the exact shape this whole lane exists to end — so it is stated, loudly, every time.
+    console.log(
+        `[confidentiality] NOT ENFORCED: no denylist configured for this run. ` +
+        `Fork pull_request runs receive no secrets, so this is expected on fork contributions and ` +
+        `a misconfiguration on internal ones.`
+    );
+    process.exit(0)
+}
+
+if (projected.outcome === SCAN_OUTCOME.blocked) {
+    console.error(
+        `[confidentiality] REFUSED: the ${label} contains ${projected.matchCount} confidential ` +
+        `token occurrence(s) at character offset(s) ${projected.offsets.join(', ')}.\n` +
+        `The matched value is deliberately NOT printed — this log is public. ` +
+        `Open the body at those offsets and scrub before re-running.`
+    );
+    process.exit(1)
+}
+
+process.exit(0)

--- a/ai/services/github-workflow/PullRequestService.mjs
+++ b/ai/services/github-workflow/PullRequestService.mjs
@@ -9,6 +9,11 @@ import aiConfig             from '../../mcp/server/github-workflow/config.mjs';
 import logger               from '../../mcp/server/github-workflow/logger.mjs';
 import {validateMergeReady} from '../../scripts/lifecycle/validateMergeReady.mjs';
 import {
+    SCAN_OUTCOME,
+    scanForConfidentialTokens
+}                           from '../shared/confidentiality/confidentialTokenScanner.mjs';
+import RepositoryService    from './RepositoryService.mjs';
+import {
     ADD_PULL_REQUEST_REVIEW,
     GET_PULL_REQUEST_ID,
     GET_PULL_REQUEST_REVIEW,
@@ -2374,9 +2379,34 @@ class PullRequestService extends Base {
             };
         }
 
+        // The confidentiality scan, BEFORE publication. Enforcement lives at the public-write
+        // boundary, where nothing can route around it; this copy is advisory and exists because
+        // an author wants the diagnosis while they still hold the draft, not after posting.
+        //
+        // Its outcome is reported as its own field rather than folded into `valid`. Collapsing them
+        // is the defect this ticket exists to end: a body that was never scanned returned the same
+        // bare pass as one that was scanned and was safe.
+        const confidentiality = scanForConfidentialTokens(body, {
+            denylist        : aiConfig.confidentialTokenDenylist,
+            targetVisibility: RepositoryService.getRepositoryVisibility()
+        });
+
+        if (confidentiality.outcome === SCAN_OUTCOME.blocked) {
+            return {
+                valid  : false,
+                error  : 'Confidential content',
+                code   : 'CONFIDENTIAL_TOKEN_IN_REVIEW_BODY',
+                confidentiality,
+                message: 'The review body contains a confidential token. Scrub it before posting; the public-write boundary will refuse it otherwise.'
+            };
+        }
+
         return {
-            valid   : true,
-            message : 'Review body matches the pr-review template structure.',
+            valid  : true,
+            message: 'Review body matches the pr-review template structure.',
+            // Never a bare pass. `unchecked` here means no denylist was configured, and the caller
+            // must be able to tell that from a body that was actually examined.
+            confidentiality,
             skill   : '.agents/skills/pr-review/SKILL.md',
             template: PR_REVIEW_TEMPLATE_PATH
         };

--- a/ai/services/github-workflow/RepositoryService.mjs
+++ b/ai/services/github-workflow/RepositoryService.mjs
@@ -38,8 +38,25 @@ class RepositoryService extends Base {
     viewerPermission = null;
 
     /**
+     * Resolved visibility of the configured repository: `'private'`, `'public'`, or `'unknown'`.
+     *
+     * `unknown` is a real, persistent state rather than a startup placeholder. The fetch below can
+     * fail structurally — a token without repository-metadata scope, a deployment where the query is
+     * unauthorized — in which case it never resolves. Consumers must therefore treat it explicitly
+     * instead of defaulting it, and the confidentiality scan resolves it toward *scanning*: a
+     * needless scan on a private repo costs an author a redaction, while a skipped scan on a public
+     * one is the exposure the scan exists to prevent.
+     * @member {String} repositoryVisibility='unknown'
+     */
+    repositoryVisibility = 'unknown';
+
+    /**
      * Fetches the current user's permission level from the API and caches it.
      * This method is intended for internal use at startup but can be called on demand.
+     *
+     * Also caches repository visibility, which rides the SAME query: `repository` was already the
+     * selection root, so `isPrivate` costs one field on a call that already happens once at boot,
+     * not a lookup per write.
      * @returns {Promise<string|null>} The permission string or null on failure.
      */
     async fetchAndCacheViewerPermission() {
@@ -51,12 +68,29 @@ class RepositoryService extends Base {
         try {
             const data = await GraphqlService.query(GET_VIEWER_PERMISSION, variables);
             this.viewerPermission = data.repository.viewerPermission;
+
+            // Only a definite boolean resolves visibility. A missing or non-boolean field leaves it
+            // `unknown`, which the confidentiality boundary handles as fail-toward-scanning — reading
+            // an absent field as `public` would be right by accident, and as `private` would be the
+            // permissive default that makes a guard stop guarding.
+            if (typeof data.repository.isPrivate === 'boolean') {
+                this.repositoryVisibility = data.repository.isPrivate ? 'private' : 'public';
+            }
+
             logger.info(`Fetched and cached viewer permission: ${this.viewerPermission}`);
             return this.viewerPermission;
         } catch (error) {
             logger.error('Error fetching viewer permission via GraphQL:', error);
             return null;
         }
+    }
+
+    /**
+     * @summary Returns the cached repository visibility, never throwing and never guessing.
+     * @returns {String} `'private'`, `'public'`, or `'unknown'`.
+     */
+    getRepositoryVisibility() {
+        return this.repositoryVisibility
     }
 
     /**

--- a/ai/services/github-workflow/queries/repositoryQueries.mjs
+++ b/ai/services/github-workflow/queries/repositoryQueries.mjs
@@ -20,6 +20,7 @@ export const GET_VIEWER_PERMISSION = `
     $repo: String!
   ) {
     repository(owner: $owner, name: $repo) {
+      isPrivate
       viewerPermission
     }
   }

--- a/ai/services/shared/confidentiality/confidentialTokenScanner.mjs
+++ b/ai/services/shared/confidentiality/confidentialTokenScanner.mjs
@@ -197,3 +197,27 @@ export function scanForConfidentialTokens(text, {
 export function isPublishBlocked(result) {
     return result?.outcome === SCAN_OUTCOME.blocked
 }
+
+/**
+ * @summary Projects a scan result for a WORLD-READABLE sink, dropping the matched tokens.
+ *
+ * The local contract returns `matches[].token` so an author can scrub. In a public CI log that same
+ * field publishes the confidential value to exactly the audience the scan protects — the guard
+ * committing the harm. Offsets and a count are enough to act on and disclose nothing.
+ *
+ * The token key is REMOVED rather than blanked: an empty-string field invites a caller to render
+ * `token: ""` beside an offset and read it as "no token here".
+ *
+ * @param {Object} result From {@link scanForConfidentialTokens}.
+ * @returns {{outcome: String, reason: String, matchCount: Number, offsets: Number[]}}
+ */
+export function projectScanForPublicLog(result) {
+    const matches = Array.isArray(result?.matches) ? result.matches : [];
+
+    return {
+        outcome   : result?.outcome ?? SCAN_OUTCOME.unchecked,
+        reason    : result?.reason ?? SCAN_REASON.listUnconfigured,
+        matchCount: matches.length,
+        offsets   : matches.map(match => match.offset)
+    }
+}

--- a/ai/services/shared/confidentiality/confidentialTokenScanner.mjs
+++ b/ai/services/shared/confidentiality/confidentialTokenScanner.mjs
@@ -1,0 +1,199 @@
+/**
+ * @summary Scans outbound content for confidential tokens before it reaches a public surface, and
+ * reports *why* it did or did not scan.
+ *
+ * Client names must never appear in public artifacts. The harm is transitive and legal rather than
+ * competitive: a client's own customers search the client name, reach a public bugfix artifact in this
+ * repository, and read our defect as theirs. The damaged party is neither us nor our counterparty,
+ * which is what makes it actionable.
+ *
+ * **Why a scanner and not a checklist.** The rule and a pre-publish grep step were both already
+ * written down, and the mechanism still recurred three times across three different agents. The
+ * leaking token is not decoration — it is load-bearing in the private rationale that motivated the
+ * change, so it travels with the reasoning into the public artifact. Generic framing ("an external
+ * deployment") carries identical force, which is exactly why the substitution is safe to automate and
+ * easy to forget.
+ *
+ * **Four outcomes, because three of them are not "pass".** The defect this replaces was a validator
+ * returning a bare pass on a body it had never examined. Every non-blocking outcome here therefore
+ * states the reason it did not block, and a caller cannot treat "did not block" as "was checked"
+ * without discarding a field:
+ *
+ * | outcome | meaning |
+ * |---|---|
+ * | `blocked` | a token matched — with token and offset, so the author scrubs before posting |
+ * | `clean` | scanned against a configured list, nothing matched |
+ * | `unchecked` | no denylist configured — enforcement did not run, and says so |
+ * | `skipped` | the target is private, where client specifics legitimately live |
+ *
+ * `reason` further separates `target-public` from `target-unknown` on the scanning path. Those two
+ * behave identically and diagnose oppositely: an operator on a private deployment seeing a block would
+ * otherwise read a content problem, when the cause is an unresolved visibility fetch several layers
+ * away — they would redact a legitimate name, be blocked again on the next one, and have nothing
+ * pointing at the real fault. Behaviour identical, diagnosis opposite, is precisely when two states
+ * must stay separate.
+ *
+ * **The matched token is returned to the author, never emitted onward.** It is the confidential value
+ * itself; it belongs in a local tool response so the author can act, and in no log, artifact, or
+ * telemetry surface that outlives the call.
+ *
+ * @module ai/services/shared/confidentiality/confidentialTokenScanner
+ */
+
+/**
+ * @summary Scan outcomes. Only `clean` means "examined and safe".
+ * @type {Object}
+ */
+export const SCAN_OUTCOME = Object.freeze({
+    blocked  : 'blocked',
+    clean    : 'clean',
+    skipped  : 'skipped',
+    unchecked: 'unchecked'
+});
+
+/**
+ * @summary Why the scanner reached its outcome. Load-bearing for diagnosis, not decoration.
+ * @type {Object}
+ */
+export const SCAN_REASON = Object.freeze({
+    listUnconfigured: 'list-unconfigured',
+    targetPrivate   : 'target-private',
+    targetPublic    : 'target-public',
+    targetUnknown   : 'target-unknown'
+});
+
+/**
+ * @summary Resolved visibility of the write target.
+ *
+ * `unknown` is a real state, not a placeholder: the boot metadata fetch can fail structurally — a
+ * token without repository-metadata scope, a deployment where the query is unauthorized — in which
+ * case it never resolves. It must therefore be handled explicitly rather than defaulted away.
+ * @type {Object}
+ */
+export const TARGET_VISIBILITY = Object.freeze({
+    private: 'private',
+    public : 'public',
+    unknown: 'unknown'
+});
+
+/**
+ * @summary Folds a string to its match key: lowercase, alphanumerics only.
+ *
+ * Separator-insensitivity is required rather than convenient. One recorded leak carried an engagement
+ * through a config-entry prefix with no prose around it, so `AcmeCorp`, `acme-corp`, `acme_corp` and
+ * `Acme Corp` must all match one denylist entry. Case folding alone would have missed every one of
+ * those but the last.
+ * @param {String} value
+ * @returns {String}
+ * @private
+ */
+function foldForMatch(value) {
+    return value.toLowerCase().replace(/[^a-z0-9]+/gu, '')
+}
+
+/**
+ * @summary Folds text while retaining, for each folded character, its index in the original string.
+ *
+ * Folding collapses separators, so a match offset in folded space does not address the original text.
+ * Reporting a shifted offset would send an author to the wrong place in their own body, which is worse
+ * than reporting none — so the map is built once and the offset reported is always the original one.
+ * @param {String} text
+ * @returns {{folded: String, offsets: Number[]}}
+ * @private
+ */
+function foldWithOffsets(text) {
+    const
+        folded  = [],
+        offsets = [];
+
+    for (let i = 0; i < text.length; i++) {
+        const character = text[i].toLowerCase();
+
+        if (/[a-z0-9]/u.test(character)) {
+            folded.push(character);
+            offsets.push(i)
+        }
+    }
+
+    return {folded: folded.join(''), offsets}
+}
+
+/**
+ * @summary Scans one outbound body against the confidential denylist.
+ *
+ * Pure and total: never throws, never mutates its inputs, and always returns an outcome naming why it
+ * reached it. Precedence is deliberate — a private target needs no list, so it is answered before the
+ * list is consulted and an unconfigured list on a private deployment is not reported as a gap.
+ *
+ * @param {String} text The outbound content.
+ * @param {Object} [options]
+ * @param {String[]} [options.denylist=[]] Confidential tokens. Empty means unconfigured, NOT safe.
+ * @param {String} [options.targetVisibility=TARGET_VISIBILITY.unknown] Resolved visibility of the
+ *     write target. Anything other than `private` or `public` is treated as `unknown`, so a
+ *     malformed value fails toward scanning rather than toward silence.
+ * @returns {{outcome: String, reason: String, matches: Array<{token: String, offset: Number}>}}
+ */
+export function scanForConfidentialTokens(text, {
+    denylist         = [],
+    targetVisibility = TARGET_VISIBILITY.unknown
+} = {}) {
+    // A private repository is where client specifics are SANCTIONED, so this is the one path that
+    // legitimately does not scan. Answered first: consulting the list here would report an
+    // unconfigured denylist as a gap on a deployment that does not need one.
+    if (targetVisibility === TARGET_VISIBILITY.private) {
+        return {outcome: SCAN_OUTCOME.skipped, reason: SCAN_REASON.targetPrivate, matches: []}
+    }
+
+    // Anything that is not explicitly public is unknown. A malformed or absent visibility must fail
+    // toward scanning: the two errors are not symmetric, and only one of them is unrecoverable.
+    const visibilityReason = targetVisibility === TARGET_VISIBILITY.public
+        ? SCAN_REASON.targetPublic
+        : SCAN_REASON.targetUnknown;
+
+    const tokens = Array.isArray(denylist)
+        ? denylist.filter(token => typeof token === 'string' && foldForMatch(token).length > 0)
+        : [];
+
+    // No list means enforcement did not run. Returning `clean` here would reproduce the exact defect
+    // this module exists to end: a bare pass on a body nothing examined.
+    if (tokens.length === 0) {
+        return {outcome: SCAN_OUTCOME.unchecked, reason: SCAN_REASON.listUnconfigured, matches: []}
+    }
+
+    if (typeof text !== 'string' || text.length === 0) {
+        return {outcome: SCAN_OUTCOME.clean, reason: visibilityReason, matches: []}
+    }
+
+    const
+        {folded, offsets} = foldWithOffsets(text),
+        matches           = [];
+
+    for (const token of tokens) {
+        const
+            foldedToken = foldForMatch(token);
+        let searchFrom = folded.indexOf(foldedToken);
+
+        while (searchFrom !== -1) {
+            // The ORIGINAL offset, mapped back through the fold. An author given a folded-space index
+            // would be pointed at the wrong character of their own body.
+            matches.push({token, offset: offsets[searchFrom]});
+            searchFrom = folded.indexOf(foldedToken, searchFrom + 1)
+        }
+    }
+
+    return matches.length > 0
+        ? {outcome: SCAN_OUTCOME.blocked, reason: visibilityReason, matches}
+        : {outcome: SCAN_OUTCOME.clean, reason: visibilityReason, matches: []}
+}
+
+/**
+ * @summary True when the scan result must stop a publish.
+ *
+ * Exists so callers branch on one named predicate rather than each re-deciding which outcomes are
+ * permissive — the re-decision being where a permissive default would creep back in.
+ * @param {Object} result From {@link scanForConfidentialTokens}.
+ * @returns {Boolean}
+ */
+export function isPublishBlocked(result) {
+    return result?.outcome === SCAN_OUTCOME.blocked
+}

--- a/test/playwright/unit/ai/mcp/server/github-workflow/ConfidentialWriteGuard.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/github-workflow/ConfidentialWriteGuard.spec.mjs
@@ -1,0 +1,172 @@
+import {setup} from '../../../../../setup.mjs';
+
+const appName = 'ConfidentialWriteGuardTest';
+
+setup({
+    neoConfig: {
+        allowVdomUpdatesInTests: false,
+        unitTestMode           : true,
+        useDomApiRenderer      : false
+    },
+    appConfig: {
+        name             : appName,
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../../../../src/Neo.mjs';
+import * as core      from '../../../../../../../src/core/_export.mjs';
+
+import {
+    GITHUB_TOOL_ACCESS,
+    buildConfidentialContentGuard,
+    collectPublishableStrings,
+    guardGitHubWriteTools,
+    isPublicGitHubWriteTool
+} from '../../../../../../../ai/mcp/server/github-workflow/toolService.mjs';
+
+const DENYLIST = ['Acme Corp'];
+
+/**
+ * @summary The confidentiality guard must sit on every public-write surface, and must refuse before
+ * the write happens rather than after.
+ *
+ * The defect it replaces was caught by an operator on a body that a mandatory validator had already
+ * passed. So the assertions that matter most are not "a token is caught" — they are that the guard
+ * covers a surface set nobody maintains by hand, and that it never silently declines to run.
+ */
+test.describe('confidential write guard — coverage', () => {
+    test('every public-write tool is guarded, from the DERIVED set', () => {
+        // The coverage argument: this set is computed from the access classification, so a
+        // public-write tool added later inherits the guard. A hand-written surface list is what let
+        // three recurrences through.
+        const publicWriteTools = Object.entries(GITHUB_TOOL_ACCESS)
+            .filter(([, access]) => access === 'public-write')
+            .map(([toolName]) => toolName);
+
+        expect(publicWriteTools.length, 'the derived set is non-empty').toBeGreaterThan(0);
+
+        for (const toolName of publicWriteTools) {
+            expect(isPublicGitHubWriteTool(toolName), toolName).toBe(true);
+        }
+
+        // The surfaces the ticket named by hand must all be in it — and the set is allowed to be
+        // WIDER than that list, which is the whole point.
+        for (const named of [
+            'create_discussion', 'create_issue', 'manage_discussion',
+            'manage_discussion_comment', 'manage_issue_comment', 'manage_pr_review'
+        ]) {
+            expect(isPublicGitHubWriteTool(named), named).toBe(true);
+        }
+    });
+
+    test('guardGitHubWriteTools wraps public writes and leaves reads alone', async () => {
+        let readCalls = 0, writeCalls = 0;
+
+        const guarded = guardGitHubWriteTools({
+            create_issue: async () => { writeCalls++; return {ok: true} },
+            list_issues : async () => { readCalls++;  return {ok: true} }
+        }, {
+            assertExpectedIdentity: async () => {},
+            resolveDenylist       : () => DENYLIST,
+            resolveVisibility     : () => 'public'
+        });
+
+        await guarded.list_issues({});
+        expect(readCalls, 'a read tool is untouched').toBe(1);
+
+        const blocked = await guarded.create_issue({body: 'Shipped for Acme Corp.'});
+
+        expect(blocked.code).toBe('CONFIDENTIAL_TOKEN_IN_PUBLIC_WRITE');
+        expect(writeCalls, 'the write handler never ran').toBe(0);
+    });
+});
+
+test.describe('confidential write guard — refusal semantics', () => {
+    /**
+     * @param {Object} options
+     * @returns {Promise<Object>}
+     */
+    async function runGuard({args, denylist = DENYLIST, visibility = 'public'}) {
+        let   delegated = false;
+        const guarded   = buildConfidentialContentGuard(async () => { delegated = true; return {ok: true} }, {
+            resolveDenylist  : () => denylist,
+            resolveVisibility: () => visibility
+        });
+        const result = await guarded(args);
+
+        return {result, delegated}
+    }
+
+    test('a public write carrying a token is refused before the delegate runs', async () => {
+        const {result, delegated} = await runGuard({args: {body: 'Rolled out for Acme Corp.'}});
+
+        expect(delegated, 'refused BEFORE the write, not after').toBe(false);
+        expect(result.code).toBe('CONFIDENTIAL_TOKEN_IN_PUBLIC_WRITE');
+        expect(result.matches[0].token).toBe('Acme Corp');
+    });
+
+    test('unknown visibility refuses AND names the assumption, not just the match', async () => {
+        const {result} = await runGuard({args: {body: 'Rolled out for Acme Corp.'}, visibility: 'unknown'});
+
+        expect(result.code).toBe('CONFIDENTIAL_TOKEN_IN_PUBLIC_WRITE');
+        expect(result.reason).toBe('target-unknown');
+
+        // The diagnosis, which is the difference between fixing a token scope and redacting a
+        // legitimate name forever. An operator told only "token matched" would do the latter.
+        expect(result.message).toContain('visibility could not be resolved');
+        expect(result.message).toContain('treated as public');
+    });
+
+    test('a private target lets the write through — client specifics belong there', async () => {
+        const {result, delegated} = await runGuard({
+            args      : {body: 'Rolled out for Acme Corp.'},
+            visibility: 'private'
+        });
+
+        expect(delegated, 'the sanctioned surface is not refused').toBe(true);
+        expect(result.ok).toBe(true);
+    });
+
+    test('a clean public write passes — the inverse control', async () => {
+        // Without this, a guard that refused everything would satisfy every refusal assertion above.
+        const {result, delegated} = await runGuard({args: {body: 'Rolled out for an external deployment.'}});
+
+        expect(delegated).toBe(true);
+        expect(result.ok).toBe(true);
+    });
+
+    test('an unconfigured denylist does NOT block, and does not pretend it checked', async () => {
+        // Enforcement cannot run without a list. It must not block every write either — that would
+        // make an unconfigured deployment unusable and get the guard disabled.
+        const {delegated} = await runGuard({args: {body: 'Rolled out for Acme Corp.'}, denylist: []});
+
+        expect(delegated).toBe(true);
+    });
+});
+
+test.describe('confidential write guard — payload reach', () => {
+    test('a token is found in ANY string field, not only in `body`', async () => {
+        // A field allow-list has the same decay as a surface allow-list: the field added next year
+        // is unscanned and silent.
+        for (const args of [
+            {title: 'Fix for Acme Corp'},
+            {body: 'clean', details: {note: 'Acme Corp asked'}},
+            {items: ['clean', 'Acme Corp']},
+            {deeply: {nested: {value: 'acme-corp'}}}
+        ]) {
+            expect(collectPublishableStrings(args).join('\n'), JSON.stringify(args)).toContain('cme');
+        }
+    });
+
+    test('collection terminates on a cyclic argument tree', () => {
+        // A guard on every write must not hang one. The depth bound is the reason this returns.
+        const cyclic = {body: 'Acme Corp'};
+        cyclic.self  = cyclic;
+
+        expect(() => collectPublishableStrings(cyclic)).not.toThrow();
+        expect(collectPublishableStrings(cyclic).some(value => value.includes('Acme Corp'))).toBe(true);
+    });
+});

--- a/test/playwright/unit/ai/services/shared/confidentialTokenScanner.spec.mjs
+++ b/test/playwright/unit/ai/services/shared/confidentialTokenScanner.spec.mjs
@@ -5,6 +5,7 @@ import {
     SCAN_REASON,
     TARGET_VISIBILITY,
     isPublishBlocked,
+    projectScanForPublicLog,
     scanForConfidentialTokens
 } from '../../../../../../ai/services/shared/confidentiality/confidentialTokenScanner.mjs';
 
@@ -203,5 +204,48 @@ test.describe('confidential token scanner — totality', () => {
         expect(isPublishBlocked(null)).toBe(false);
         expect(isPublishBlocked({})).toBe(false);
         expect(isPublishBlocked({outcome: SCAN_OUTCOME.blocked})).toBe(true);
+    });
+});
+
+test.describe('public-log projection', () => {
+    test('the matched token is REMOVED, not blanked', () => {
+        const projected = projectScanForPublicLog(scanForConfidentialTokens('for Acme Corp', {
+            denylist        : DENYLIST,
+            targetVisibility: TARGET_VISIBILITY.public
+        }));
+
+        // The whole point: this shape reaches a world-readable CI log. Serialising it must not
+        // disclose the value, and asserting on the serialised form is what proves it — an assertion
+        // on `projected.token` being undefined would pass for a `{token: ""}` field that still
+        // renders beside an offset and reads as "no token here".
+        const serialised = JSON.stringify(projected);
+
+        expect(serialised).not.toContain('Acme');
+        expect(serialised).not.toContain('token');
+        expect(Object.keys(projected)).not.toContain('token');
+
+        // Still actionable: enough to find and scrub it.
+        expect(projected.matchCount).toBe(1);
+        expect(projected.offsets).toEqual([4]);
+        expect(projected.outcome).toBe(SCAN_OUTCOME.blocked);
+    });
+
+    test('an unchecked scan projects as unchecked, never as clean', () => {
+        const projected = projectScanForPublicLog(scanForConfidentialTokens('for Acme Corp', {
+            denylist        : [],
+            targetVisibility: TARGET_VISIBILITY.public
+        }));
+
+        expect(projected.outcome).toBe(SCAN_OUTCOME.unchecked);
+        expect(projected.matchCount).toBe(0);
+    });
+
+    test('a malformed result degrades to unchecked rather than throwing on a public surface', () => {
+        // This runs in CI against whatever the scanner returned. A throw here fails the job for the
+        // wrong reason and teaches people to disable the step.
+        for (const input of [null, undefined, {}, {matches: 'nope'}]) {
+            expect(() => projectScanForPublicLog(input)).not.toThrow();
+            expect(projectScanForPublicLog(input).outcome).toBe(SCAN_OUTCOME.unchecked);
+        }
     });
 });

--- a/test/playwright/unit/ai/services/shared/confidentialTokenScanner.spec.mjs
+++ b/test/playwright/unit/ai/services/shared/confidentialTokenScanner.spec.mjs
@@ -1,0 +1,207 @@
+import {test, expect} from '@playwright/test';
+
+import {
+    SCAN_OUTCOME,
+    SCAN_REASON,
+    TARGET_VISIBILITY,
+    isPublishBlocked,
+    scanForConfidentialTokens
+} from '../../../../../../ai/services/shared/confidentiality/confidentialTokenScanner.mjs';
+
+const DENYLIST = ['Acme Corp', 'Northwind'];
+
+/**
+ * @summary A confidentiality guard is only worth having if every non-blocking answer says why it did
+ * not block.
+ *
+ * The defect being replaced is a validator that returned a bare pass on a body it never examined, so
+ * the assertions below are weighted toward the paths that do NOT block. A spec that only proved
+ * "a token is caught" would pass against a guard that is permissive everywhere else — which is the
+ * shape that already shipped once.
+ */
+test.describe('confidential token scanner — blocking', () => {
+    test('a token in a public body is blocked with its ORIGINAL offset', () => {
+        const text   = 'Rolled out for Acme Corp last week.',
+              result = scanForConfidentialTokens(text, {
+                  denylist        : DENYLIST,
+                  targetVisibility: TARGET_VISIBILITY.public
+              });
+
+        expect(result.outcome).toBe(SCAN_OUTCOME.blocked);
+        expect(result.reason).toBe(SCAN_REASON.targetPublic);
+        expect(isPublishBlocked(result)).toBe(true);
+
+        // The offset must address the ORIGINAL string. Folding collapses separators, so a
+        // folded-space index would point the author at the wrong character of their own body — and
+        // `indexOf` here is an independent derivation, not the scanner's own arithmetic echoed back.
+        expect(result.matches[0].offset).toBe(text.indexOf('Acme Corp'));
+        expect(text.slice(result.matches[0].offset)).toContain('Acme Corp');
+    });
+
+    test('separator and case variants all match one entry — the config-prefix leak shape', () => {
+        // A recorded leak carried an engagement through a config-entry prefix with no prose at all,
+        // so case folding alone would have caught only the last of these.
+        for (const variant of ['acme-corp', 'ACME_CORP', 'AcmeCorp', 'acme corp', 'acme.corp']) {
+            const result = scanForConfidentialTokens(`key: ${variant}-tenant`, {
+                denylist        : DENYLIST,
+                targetVisibility: TARGET_VISIBILITY.public
+            });
+
+            expect(result.outcome, `variant ${variant}`).toBe(SCAN_OUTCOME.blocked);
+        }
+    });
+
+    test('every occurrence is reported, not just the first', () => {
+        const result = scanForConfidentialTokens('Acme Corp and later Acme Corp again', {
+            denylist        : DENYLIST,
+            targetVisibility: TARGET_VISIBILITY.public
+        });
+
+        // Reporting one match invites a scrub-and-repost loop: the author fixes the named occurrence,
+        // reposts, and is blocked again by the one the tool already knew about.
+        expect(result.matches).toHaveLength(2);
+        expect(result.matches[0].offset).not.toBe(result.matches[1].offset);
+    });
+});
+
+test.describe('confidential token scanner — the paths that do NOT block', () => {
+    test('a clean public body is clean, and says it was scanned against a real list', () => {
+        // The inverse control. Without it, a scanner that blocked everything would satisfy every
+        // blocking assertion above and be worse than useless.
+        const result = scanForConfidentialTokens('Rolled out for an external deployment.', {
+            denylist        : DENYLIST,
+            targetVisibility: TARGET_VISIBILITY.public
+        });
+
+        expect(result.outcome).toBe(SCAN_OUTCOME.clean);
+        expect(result.reason).toBe(SCAN_REASON.targetPublic);
+        expect(isPublishBlocked(result)).toBe(false);
+    });
+
+    test('an unconfigured list is UNCHECKED, never clean', () => {
+        const result = scanForConfidentialTokens('Rolled out for Acme Corp.', {
+            denylist        : [],
+            targetVisibility: TARGET_VISIBILITY.public
+        });
+
+        // This is the whole defect restated: a body containing a real token, with no list to catch it.
+        // Reporting `clean` would be indistinguishable from a body that was examined and was safe.
+        expect(result.outcome).toBe(SCAN_OUTCOME.unchecked);
+        expect(result.outcome).not.toBe(SCAN_OUTCOME.clean);
+        expect(result.reason).toBe(SCAN_REASON.listUnconfigured);
+    });
+
+    test('a list of only blank entries is unconfigured, not a configured list that matches nothing', () => {
+        // `['']` would fold to an empty key and match at every position, blocking every body. Treating
+        // it as unconfigured is both correct and the safer of the two failure modes.
+        const result = scanForConfidentialTokens('anything at all', {
+            denylist        : ['', '   ', '---'],
+            targetVisibility: TARGET_VISIBILITY.public
+        });
+
+        expect(result.outcome).toBe(SCAN_OUTCOME.unchecked);
+    });
+
+    test('a private target is SKIPPED and named as such — client specifics belong there', () => {
+        const result = scanForConfidentialTokens('Rolled out for Acme Corp.', {
+            denylist        : DENYLIST,
+            targetVisibility: TARGET_VISIBILITY.private
+        });
+
+        expect(result.outcome).toBe(SCAN_OUTCOME.skipped);
+        expect(result.reason).toBe(SCAN_REASON.targetPrivate);
+        expect(isPublishBlocked(result)).toBe(false);
+    });
+
+    test('a private target is answered BEFORE the list is consulted', () => {
+        // Precedence matters: an unconfigured list on a private deployment is not a gap, and reporting
+        // `unchecked` there would send an operator chasing a denylist they do not need.
+        const result = scanForConfidentialTokens('Rolled out for Acme Corp.', {
+            denylist        : [],
+            targetVisibility: TARGET_VISIBILITY.private
+        });
+
+        expect(result.outcome).toBe(SCAN_OUTCOME.skipped);
+        expect(result.outcome).not.toBe(SCAN_OUTCOME.unchecked);
+    });
+});
+
+test.describe('confidential token scanner — unknown visibility', () => {
+    test('unknown visibility scans, and is DISTINGUISHABLE from public', () => {
+        const result = scanForConfidentialTokens('Rolled out for Acme Corp.', {
+            denylist        : DENYLIST,
+            targetVisibility: TARGET_VISIBILITY.unknown
+        });
+
+        // Behaviour identical to public — it must block.
+        expect(result.outcome).toBe(SCAN_OUTCOME.blocked);
+
+        // Diagnosis opposite. An operator on a private deployment whose metadata fetch fails
+        // structurally would otherwise read this as a content problem, redact a legitimate name, and
+        // be blocked again on the next one with nothing pointing at the token scope.
+        expect(result.reason).toBe(SCAN_REASON.targetUnknown);
+        expect(result.reason).not.toBe(SCAN_REASON.targetPublic);
+    });
+
+    test('an absent or malformed visibility fails toward scanning, never toward silence', () => {
+        for (const visibility of [undefined, null, '', 'PUBLIC', 'internal', 42]) {
+            const result = scanForConfidentialTokens('Rolled out for Acme Corp.', {
+                denylist: DENYLIST,
+                ...(visibility === undefined ? {} : {targetVisibility: visibility})
+            });
+
+            // A permissive default here would be the whole defect wearing a different hat: the
+            // guard silently not running because an input it did not recognise looked like a skip.
+            expect(result.outcome, `visibility ${JSON.stringify(visibility)}`).toBe(SCAN_OUTCOME.blocked);
+            expect(result.reason).toBe(SCAN_REASON.targetUnknown);
+        }
+    });
+
+    test('unknown visibility with no list is unchecked — it does not silently become clean', () => {
+        const result = scanForConfidentialTokens('Rolled out for Acme Corp.', {
+            denylist        : [],
+            targetVisibility: TARGET_VISIBILITY.unknown
+        });
+
+        // Both signals absent at once is the worst case and the one most likely in a broken
+        // deployment. It must still not report a pass.
+        expect(result.outcome).toBe(SCAN_OUTCOME.unchecked);
+        expect(isPublishBlocked(result)).toBe(false);
+    });
+});
+
+test.describe('confidential token scanner — totality', () => {
+    test('never throws, whatever it is handed', () => {
+        // The guard sits on every public write. A throw here fails the write for the wrong reason and
+        // teaches authors to route around the guard.
+        for (const text of [undefined, null, '', 0, {}, [], 'ordinary text']) {
+            expect(() => scanForConfidentialTokens(text, {denylist: DENYLIST}), `text ${JSON.stringify(text)}`)
+                .not.toThrow();
+        }
+
+        expect(() => scanForConfidentialTokens('x', {denylist: null})).not.toThrow();
+        expect(() => scanForConfidentialTokens('x', {denylist: 'Acme Corp'})).not.toThrow();
+        expect(() => scanForConfidentialTokens('x')).not.toThrow();
+    });
+
+    test('a non-array denylist is unconfigured, not silently iterated as characters', () => {
+        // A bare string would otherwise iterate per character, folding each to a one-letter key that
+        // matches nearly every body — a guard that blocks everything and gets disabled by lunchtime.
+        const result = scanForConfidentialTokens('ordinary text', {
+            denylist        : 'Acme Corp',
+            targetVisibility: TARGET_VISIBILITY.public
+        });
+
+        expect(result.outcome).toBe(SCAN_OUTCOME.unchecked);
+    });
+
+    test('isPublishBlocked is false for every non-blocking outcome, including malformed input', () => {
+        for (const outcome of [SCAN_OUTCOME.clean, SCAN_OUTCOME.unchecked, SCAN_OUTCOME.skipped]) {
+            expect(isPublishBlocked({outcome}), outcome).toBe(false);
+        }
+
+        expect(isPublishBlocked(null)).toBe(false);
+        expect(isPublishBlocked({})).toBe(false);
+        expect(isPublishBlocked({outcome: SCAN_OUTCOME.blocked})).toBe(true);
+    });
+});


### PR DESCRIPTION
Resolves #16535
Resolves #16660

## The guard sits one layer up from where the ticket put it

The ticket asks for the check in `validate_pr_review_body` plus the PR-body lint plus each public surface. `toolService.mjs` already classifies every GitHub tool, and the public set is **derived**, not hand-listed:

```js
const PUBLIC_GITHUB_WRITE_TOOLS = Object.freeze(new Set(
    Object.entries(GITHUB_TOOL_ACCESS)
        .filter(([, access]) => access === PUBLIC_GITHUB_WRITE_ACCESS)
        .map(([toolName]) => toolName)));
```

It resolves to exactly the surfaces the AC names, plus siblings a hand-list misses (`signal_state_transition`, `update_issue_relationship`), and `assertNoUnclassifiedGitHubTools` **already fails closed** on a tool that forgets to classify itself.

So the guard composes into `guardGitHubWriteTools` and inherits a completeness guarantee per-service wiring cannot have: **a public-write tool added next year is scanned automatically.** Wiring six services by hand would leave surface seven unguarded and silent — the ticket's own recurrence mechanism, one level up. This is its keystone rule (*fix the generator, not the output*) applied where it bites: the generator is dispatch, not the validator.

Confidentiality is the **outer** guard — a body carrying a client name is refused before an identity assertion makes a network call on its behalf.

## Target visibility, not tool class

@neo-opus-vega's review catch, and it decides a condition: `owner` is an **overridable leaf**, so `public-write` describes what a tool mutates *on github.com*, not whether the repository is public. They coincide only while the leaf holds its default — and a **private repo is the sanctioned home for client specifics**. An unconditional block would refuse the one surface allowed to carry them.

`isPrivate` rides the **existing** boot query. `repository` was already the selection root, so this costs one field on a call that already happens once — not a lookup per write. That was the probe that decided it; the alternative "already cached for free" turned out to be false in one direction and "a network call per write" false in the other.

## Four outcomes, because three of them are not a pass

| outcome | meaning |
|---|---|
| `blocked` | matched — token and **original** offset, so the author scrubs |
| `clean` | scanned against a configured list, nothing matched |
| `unchecked` | no denylist configured — enforcement did not run |
| `skipped` | target is private |

The replaced defect was a validator returning a bare pass on a body it never examined, so every non-blocking outcome names its reason and a caller cannot read *did not block* as *was checked* without discarding a field.

`reason` further separates `target-public` from `target-unknown`. **Behaviour identical, diagnosis opposite** — unknown visibility is persistent, not a startup blip (a token without repo-metadata scope never resolves it), and an operator told only "token matched" would redact a legitimate name, be blocked again on the next one, and have nothing pointing at the token scope. The refusal message names the assumption.

## OQ1 — resolved

**Config leaf, empty in-repo, env-populated.** Committing the list publishes the names it protects. Hashing does not rescue that: an unkeyed hash of a company name is brute-forceable from any wordlist of company names, and a keyed HMAC reintroduces the env dependency, collapsing into the chosen option with extra machinery.

The leaf's `csv` type is load-bearing and I got it wrong first: I wrote `'stringArray'`, which is **not a registered parser**. The registry documents that an unknown token *validates as true and passes through* — so the env var would never parse, the denylist would be permanently empty, and the guard would report `unchecked` forever **while looking configured**. That is this ticket's defect, reintroduced by a typo. Caught by reading the parser registry rather than trusting a grep that matched only my own line.

## Deltas

| # | delta |
|---|---|
| 1 | `confidentialTokenScanner.mjs` — four outcomes, case/separator-insensitive matching, offsets mapped back through the fold |
| 2 | guard composed into `guardGitHubWriteTools`, keyed on the derived set |
| 3 | `isPrivate` on the existing boot query; `repositoryVisibility` cached beside permission |
| 4 | `confidentialTokenDenylist` leaf — empty in-repo, `csv`, env-populated |
| 5 | `validate_pr_review_body` carries the scan as a pre-publication advisory, outcome in its own field |
| 6 | `projectScanForPublicLog` — REMOVES the matched token for world-readable sinks (#16660) |
| 7 | `lintPublicBodyConfidentiality.mjs` + a job on both body-lint workflows — the one surface MCP dispatch cannot see |

## Config surface change — clone-sync guidance

`config.template.mjs` derives from `configBase`, so the new leaf reaches the template surface automatically; `ai/scripts/lint/config-leaf-parity.json` records it in the same commit, which is what makes a config surface change reviewable rather than silent.

| item | answer |
|---|---|
| **Changed config key** | `confidentialTokenDenylist` — `ai/mcp/server/github-workflow/configBase.mjs`, `leaf([], 'NEO_CONFIDENTIAL_TOKEN_DENYLIST', 'csv')` |
| **Local `config.mjs` follow-up** | **None required.** Local configs subclass the same `ConfigBase`, so they inherit the leaf. No hand-edit, and no gitignored `config.mjs` is committed here. |
| **Harness restart** | **Recommended, not required.** Nothing breaks without one — the leaf defaults empty, so the guard is inert and reports `unchecked`. A restart is what makes the surface exist in a running clone. |
| **Live MCP behaviour in other clones** | Unchanged until an operator sets the env var. The one visible difference is `validate_pr_review_body` reporting `confidentiality.outcome`. |

Peer A2A sent, per the MCP config template change guide.

## Test Evidence

Evidence: **26/26** green — 17 scanner (incl. 3 public-log projection), 9 guard.

The CI half covers the surface MCP dispatch structurally cannot: a body written with `gh pr create --body-file` reaches no MCP tool. Its disclosure contract is **inverted** — a public workflow log means the matched token must NOT be printed, the opposite of the local rule — so `projectScanForPublicLog` removes the token key rather than blanking it, and the spec asserts on the **serialised** shape. Mutation: making the projection carry the token reddens it.

Fork `pull_request` runs receive no secrets, so the scan reports NOT ENFORCED and exits 0 there, stated in the output on every such run rather than passing silently.

**Mutation-proved on all three safety properties**, since a green confidentiality test that cannot fail on the defect is worse than none:

| mutation | reddens |
|---|---|
| `unchecked` collapses into `clean` (the original defect) | **4** |
| unknown visibility resolves permissively (skip instead of scan) | **3** |
| `target-unknown` reason collapses into `target-public` | **2** |

Inverse controls present throughout: a clean public body passes, a private target delegates, an unconfigured list does not block. Without them a guard that refused everything would satisfy every blocking assertion.

`ConfigCompleteness.spec.mjs` has one failing logger-priority assertion — **pre-existing**, verified by stashing: 1 failed / 5 passed identically with and without this branch.

## Post-Merge Validation

With no `NEO_CONFIDENTIAL_TOKEN_DENYLIST` set, behaviour is unchanged except that `validate_pr_review_body` now reports `confidentiality.outcome: "unchecked"` — the intended visible signal that enforcement is not yet configured. Setting the env var activates it; a public write carrying a listed token is then refused with the token, its offset, and the reason.

## Out of Scope

- **`resources/content/` mirrors.** Git-tracked and a public surface in their own right, reached by the sync pipeline rather than MCP dispatch. *Plausibly* covered transitively — content that never reaches GitHub cannot be mirrored back — but that is an inference about the pipeline's only source. **Neither @neo-opus-vega nor I verified it**, and it is stated that way rather than upgraded to a covered surface by whoever reads this next.
- Historical remediation and revision-history residue — operator-directed sweeps, per the ticket.

## Related

#16520 (the review body where this surfaced).

---

Authored by Grace (Opus 5, Claude Code). Session 9ced67a1-8f21-4da2-a1bf-a2a968c47ed2.
