### PR TITLE
Two service-heap ceiling knobs, and the declared ceiling becomes observable (#16636)

### DIFF
--- a/ai/daemons/orchestrator/services/DeploymentRuntimeAccessService.mjs
+++ b/ai/daemons/orchestrator/services/DeploymentRuntimeAccessService.mjs
@@ -750,17 +750,28 @@ export class DeploymentRuntimeAccessService extends Base {
         // 1. Only a service some ceiling knob DECLARES is resizable at all. The registry's closed
         //    set is the sanctioned-target list; a transient or unknown service has no knob, so the
         //    op cannot address it.
-        // 2. The value must sit inside that knob's band. The cap that terminates the autonomous
+        // 2. That knob must govern THIS resource. `role: 'ceiling'` spans two unrelated resources —
+        //    the cgroup envelope this op widens (`HostConfig.Memory`) and a process-internal V8 heap
+        //    (`--max-old-space-size`), which spends memory the container was already granted. Matching
+        //    on the role alone made a heap knob sanction an envelope widening: adding the mc/kb heap
+        //    knobs turned both servers into legal targets here, having declared no envelope knob.
+        // 3. The value must sit inside that knob's band. The cap that terminates the autonomous
         //    ratchet holds here too — a caller with L0 access cannot express what the knob forbids.
+        //    A knob with no finite band therefore sanctions NOTHING: comparing a value against an
+        //    absent bound is NaN-false in BOTH directions, so an unbanded knob would silently delete
+        //    the cap rather than tighten it, leaving raise-only as the only surviving bound.
+        const containerCeilingLeafOf = knob => knob.leaves.find(
+            leaf => leaf.role === 'ceiling' && leaf.resource === 'container-memory'
+        );
+
         const ceilingKnob = Object.values(RECOVERY_KNOBS).find(knob =>
-            knob.serviceKey === target.serviceKey &&
-            knob.leaves.some(leaf => leaf.role === 'ceiling')
+            knob.serviceKey === target.serviceKey && containerCeilingLeafOf(knob)
         );
 
         if (!ceilingKnob) {
             throw createRuntimeAccessError({
                 reason : 'runtime-memory-limit-unsanctioned-target',
-                message: `update-memory-limit refuses '${target.serviceKey}': no ceiling knob in the closed registry declares this service`,
+                message: `update-memory-limit refuses '${target.serviceKey}': no container-memory ceiling knob in the closed registry declares this service`,
                 details: {
                     ...this.createEffectiveConfigSummary(),
                     serviceKey: target.serviceKey
@@ -768,7 +779,18 @@ export class DeploymentRuntimeAccessService extends Base {
             });
         }
 
-        const ceilingLeaf = ceilingKnob.leaves.find(leaf => leaf.role === 'ceiling');
+        const ceilingLeaf = containerCeilingLeafOf(ceilingKnob);
+
+        if (!Number.isFinite(ceilingLeaf.min) || !Number.isFinite(ceilingLeaf.max)) {
+            throw createRuntimeAccessError({
+                reason : 'runtime-memory-limit-unbanded-knob',
+                message: `update-memory-limit refuses '${target.serviceKey}': its container-memory ceiling knob declares no finite band, so it sanctions no value`,
+                details: {
+                    ...this.createEffectiveConfigSummary(),
+                    serviceKey: target.serviceKey
+                }
+            });
+        }
 
         if (memoryLimitBytes < ceilingLeaf.min || memoryLimitBytes > ceilingLeaf.max) {
             throw createRuntimeAccessError({

--- a/ai/daemons/orchestrator/services/DeploymentStateBridgeService.mjs
+++ b/ai/daemons/orchestrator/services/DeploymentStateBridgeService.mjs
@@ -998,6 +998,33 @@ function resolveConfiguredDurabilityPosture() {
     })
 }
 
+/**
+ * @summary Reads the V8 old-space ceiling a container was STARTED with, from its command.
+ *
+ * Three states, and the third is the point. `Config.Cmd` records the argument the container was
+ * launched with; when a command has several `node` invocations (the overlay/no-overlay branches the
+ * MCP servers carry) it does NOT say which branch is executing. So a divergent pair is not a
+ * value to choose between — reporting either one would be a guess with a number attached. It
+ * reports `'unknown'` instead, and the caller treats that as "not observable", never as a reading.
+ *
+ * This is what the container was TOLD, never what V8 enforces. No V8-scoped metric exists for a
+ * sibling container anywhere in `ai/`, so the field name says `declared` and means it.
+ *
+ * @param {String[]|String} cmd `Config.Cmd`, as Docker returns it.
+ * @returns {Number|String|null} the agreed ceiling in MB · `'unknown'` when declarations diverge ·
+ * `null` when none is declared.
+ */
+export function parseDeclaredHeapCeilingMb(cmd) {
+    const
+        text     = Array.isArray(cmd) ? cmd.join(' ') : typeof cmd === 'string' ? cmd : '',
+        declared = [...text.matchAll(/--max-old-space-size=(\d+)/g)].map(match => Number(match[1]));
+
+    if (declared.length === 0)               return null;
+    if (new Set(declared).size > 1)          return 'unknown';
+
+    return declared[0]
+}
+
 function summarizeInspect(inspect) {
     if (!inspect || typeof inspect !== 'object') return null;
 
@@ -1007,6 +1034,10 @@ function summarizeInspect(inspect) {
         name        : inspect.Name || null,
         image       : inspect.Config?.Image || inspect.Image || null,
         restartCount: Number.isFinite(inspect.RestartCount) ? inspect.RestartCount : null,
+        // Admitted by this ticket's Contract Ledger. Paired with `stats.memoryLimitBytes`, which is
+        // already published, it lets a reader see a ceiling declared BELOW the container's own
+        // allowance — the shape that aborts Node while the cgroup still looks half-idle.
+        declaredHeapCeilingMb: parseDeclaredHeapCeilingMb(inspect.Config?.Cmd),
         state       : {
             status    : state.Status || null,
             health    : state.Health?.Status || null,

--- a/ai/daemons/orchestrator/services/DeploymentStateBridgeService.mjs
+++ b/ai/daemons/orchestrator/services/DeploymentStateBridgeService.mjs
@@ -472,6 +472,7 @@ export class DeploymentStateBridgeService extends Base {
             failureReasonCounts    = countBy(serviceList.flatMap(service => (service.errors || []).map(error => error.reason || 'unknown'))),
             operationFailureCounts = countBy(serviceList.flatMap(service => (service.errors || []).map(error => error.operation || 'unknown'))),
             lookupFailureCount     = serviceList.filter(hasLookupFailure).length,
+            undeclaredHeapCeilingServices = selectUndeclaredHeapCeilingServices(serviceList),
             allServicesDegraded    = serviceList.length > 0 && degradedServices.length === serviceList.length,
             broadLookupFailure     = serviceList.length > 0 && lookupFailureCount === serviceList.length,
             reason                 = broadLookupFailure
@@ -510,7 +511,18 @@ export class DeploymentStateBridgeService extends Base {
                 lookupFailureCount,
                 failureReasonCounts,
                 operationFailureCounts,
-                services            : serviceFailureStates
+                services            : serviceFailureStates,
+                // Observe-only, `record`-terminal: no action, no privilege, no restart. It states
+                // that a Node service was started with no `--max-old-space-size`, which is the
+                // condition under which V8 picks a heuristic well below the container's allowance
+                // and self-aborts with ExitCode 0 and OOMKilled false — a failure with no signature.
+                //
+                // Deliberately NOT a member of the `facts` array. `selectEvidenceFacts(facts, …)`
+                // is called with the WHOLE array at every classification branch, so anything added
+                // there becomes candidate evidence for every diagnosis. That is what the earlier
+                // attempt got wrong, and an observability statement is the wrong shape for an
+                // evidence array regardless.
+                undeclaredHeapCeilingServices
             },
             hints: buildBridgeHints({reason, failureReasonCounts})
         };
@@ -1016,13 +1028,64 @@ function resolveConfiguredDurabilityPosture() {
  */
 export function parseDeclaredHeapCeilingMb(cmd) {
     const
-        text     = Array.isArray(cmd) ? cmd.join(' ') : typeof cmd === 'string' ? cmd : '',
+        text     = commandText(cmd),
         declared = [...text.matchAll(/--max-old-space-size=(\d+)/g)].map(match => Number(match[1]));
 
     if (declared.length === 0)               return null;
     if (new Set(declared).size > 1)          return 'unknown';
 
     return declared[0]
+}
+
+/**
+ * @summary Flattens `Config.Cmd` to searchable text, tolerating the array and string forms Docker uses.
+ * @param {String[]|String} cmd
+ * @returns {String}
+ */
+function commandText(cmd) {
+    return Array.isArray(cmd) ? cmd.join(' ') : typeof cmd === 'string' ? cmd : ''
+}
+
+/**
+ * @summary Whether a container's command launches Node at all.
+ *
+ * A missing heap ceiling only means something for a **Node** service — `chroma` runs
+ * `["run", "/config.yaml"]` and has no V8 to bound, so an undeclared-ceiling finding against it
+ * would be noise the reader has to learn to ignore.
+ *
+ * Derived from the command rather than inferred from the image name. The image is a **proxy** for
+ * runtime — it holds until someone adds a Node service on a different base or a non-Node entrypoint
+ * to the shared image, and then it holds silently and wrongly. The command is the direct
+ * observation.
+ *
+ * @param {String[]|String} cmd `Config.Cmd`, as Docker returns it.
+ * @returns {Boolean}
+ */
+export function isNodeCommand(cmd) {
+    return /(^|[\s;&|"'`(])node(\s|$)/.test(commandText(cmd))
+}
+
+/**
+ * @summary Names the Node services that were started with no declared heap ceiling.
+ *
+ * Pure on purpose — the enclosing `collectBridgeDiagnostics` reads `AiConfig` and runtime-holder
+ * state, so folding this inline would make the rule testable only through a live service. The rule
+ * is the part worth guarding.
+ *
+ * Three populations are deliberately NOT findings:
+ * - **non-Node** services — nothing with a V8 heap to bound.
+ * - **`'unknown'`** — divergent declarations mean the ceiling could not be OBSERVED. Listing it
+ *   would publish *observed an absence* where the truth is *could not observe*.
+ * - an **unreadable `inspect`** — a failed read is already reported as a degraded service.
+ *
+ * @param {Object[]} services Per-service snapshots carrying `summarizeInspect()` output.
+ * @returns {String[]} service keys, in input order.
+ */
+export function selectUndeclaredHeapCeilingServices(services) {
+    return (Array.isArray(services) ? services : [])
+        .filter(service => service?.inspect?.nodeCommand === true &&
+                           service?.inspect?.declaredHeapCeilingMb === null)
+        .map(service => service.serviceKey)
 }
 
 function summarizeInspect(inspect) {
@@ -1037,7 +1100,13 @@ function summarizeInspect(inspect) {
         // Admitted by this ticket's Contract Ledger. Paired with `stats.memoryLimitBytes`, which is
         // already published, it lets a reader see a ceiling declared BELOW the container's own
         // allowance — the shape that aborts Node while the cgroup still looks half-idle.
+        //
+        // `nodeCommand` travels WITH it because the two are only meaningful together: a null ceiling
+        // is a finding on a Node service and a non-event on anything else. Publishing the ceiling
+        // alone would make every reader re-derive the qualifier, and re-derivation is where the
+        // image-name proxy gets invented.
         declaredHeapCeilingMb: parseDeclaredHeapCeilingMb(inspect.Config?.Cmd),
+        nodeCommand          : isNodeCommand(inspect.Config?.Cmd),
         state       : {
             status    : state.Status || null,
             health    : state.Health?.Status || null,

--- a/ai/deploy/docker-compose.yml
+++ b/ai/deploy/docker-compose.yml
@@ -140,7 +140,12 @@ services:
     deploy:
       resources:
         limits:
-          memory: 1g
+          # Parameterised for the same reason chroma's is: a hardcoded limit is unreachable by the
+          # recovery actuator. The declared heap ceiling above must stay strictly below this value,
+          # and that bound has to be expressed as a RELATIONSHIP against this leaf rather than as a
+          # constant — a constant goes stale the moment this moves. A YAML literal is reachable by
+          # neither config nor the overlay, so it cannot serve as the bound at all.
+          memory: "${NEO_KB_SERVER_MEMORY_LIMIT:-1g}"
           cpus: "1.0"
 
   mc-server:
@@ -263,7 +268,10 @@ services:
     deploy:
       resources:
         limits:
-          memory: 1g
+          # Parameterised for the same reason chroma's is — see the kb-server note above. The
+          # strictly-below bound on the heap ceiling is a relationship against this leaf, so this
+          # value must be reachable by something other than a YAML literal.
+          memory: "${NEO_MC_SERVER_MEMORY_LIMIT:-1g}"
           cpus: "1.0"
 
   # The Agent OS maintenance orchestrator (ADR 0014 §2.3). Built from the shared

--- a/ai/services/memory-core/helpers/recoveryKnobRegistry.mjs
+++ b/ai/services/memory-core/helpers/recoveryKnobRegistry.mjs
@@ -137,13 +137,16 @@ function serviceHeapCeilingKnob({serviceKey, leafPath, env}) {
                         'space, code, external buffers and native allocations. So the conversion from ' +
                         'a catchable `FATAL ERROR: heap limit` to an uncatchable kernel kill happens ' +
                         'as soon as ceiling + non-heap exceeds the cgroup — far BELOW the limit, not ' +
-                        'at it. Measured by @neo-opus-grace on this plane: a 768 MB ceiling in a ' +
-                        '1024 MiB container carries RSS to 860.7 MiB (84%), so non-heap ran ~93 MiB ' +
-                        'and only ~163 MiB separated a healthy service from a silent kill. The ' +
-                        'non-heap figure is therefore REQUIRED context, and it is refused when ' +
-                        'unresolved rather than assumed to be zero — assuming zero is what lets a ' +
-                        'ceiling one byte under the limit read as safe. This knob stays fail-closed ' +
-                        'until a service publishes that observation.',
+                        'at it. Measured by @neo-opus-grace on this plane: a 768 MB declared ceiling ' +
+                        'in a 1024 MiB container ran at RSS 860.7 MiB, 84% of the cgroup, ~163 MiB ' +
+                        'from the edge. That is a CONTAINER fact and deliberately not restated as a ' +
+                        'heap one — RSS includes native, buffers and code, and the heap/non-heap ' +
+                        'SPLIT was never measured. Which is the whole reason non-heap is REQUIRED ' +
+                        'context rather than derived here: `RSS - ceiling` only yields non-heap if ' +
+                        'the heap happens to sit AT its ceiling, and nothing establishes that. ' +
+                        'Unresolved refuses rather than assuming zero — assuming zero is what lets a ' +
+                        'ceiling one byte under the limit read as safe. Fail-closed until a service ' +
+                        'publishes the observation.',
                 holds : (values, context = {}) => {
                     const liveLimitBytes = context[liveLimitLeaf],
                           nonHeapBytes   = context[nonHeapLeaf];

--- a/ai/services/memory-core/helpers/recoveryKnobRegistry.mjs
+++ b/ai/services/memory-core/helpers/recoveryKnobRegistry.mjs
@@ -55,7 +55,89 @@ const MINISUMMARY_MIN_ITEMS_PER_SWEEP = 4;
 const CONTAINER_MEMORY_CEILING_MIN_BYTES = 8  * 1024 ** 3;
 const CONTAINER_MEMORY_CEILING_MAX_BYTES = 16 * 1024 ** 3;
 
+/**
+ * @summary Builds one service-heap knob. TWO knobs, not one, because `serviceKey` is singular and the
+ * actuator refuses a knob/target mismatch against it — a knob addressing both MCP servers would break
+ * that guarantee.
+ *
+ * **No `min`/`max`.** The shipped `768` has no derivation anywhere in the repo (three occurrences in
+ * compose, no working-set arithmetic), so a constant band here would be invented to match the store
+ * knob's shape. Both bounds are RELATIONSHIPS instead, per this file's own rule that a bound against
+ * a leaf it does not change is expressed against the live value and never as a constant.
+ *
+ * @param {String} serviceKey
+ * @param {String} leafPath
+ * @param {String} env
+ * @returns {Object} frozen knob descriptor
+ */
+function serviceHeapCeilingKnob({serviceKey, leafPath, env}) {
+    const liveLimitLeaf = `runtime.${serviceKey}.liveMemoryLimitBytes`;
+
+    return Object.freeze({
+        description: `Raise ${serviceKey}'s declared V8 old-space ceiling. Distinct from the store's ` +
+                     'ceiling in the resource it spends: this changes `--max-old-space-size` and leaves ' +
+                     '`HostConfig.Memory` UNCHANGED, so it spends memory the container was already ' +
+                     'granted rather than widening the authorisation. Values are MB — the unit ' +
+                     '`--max-old-space-size` itself takes, so nothing translates and nothing can ' +
+                     'disagree about the unit.',
+        serviceKey,
+        /**
+         * The container limit, resolved by the caller from the runtime (`HostConfig.Memory`).
+         *
+         * **Config cannot answer it, and that was measured rather than assumed:** no compose
+         * `deploy.resources` value has an AiConfig leaf anywhere — not chroma's, not local-model's —
+         * and there is no `deploy.*` subtree in `configBase.mjs`. Cgroup limits are OBSERVED at
+         * runtime by design, never DECLARED in config.
+         *
+         * The consequence is deliberate and correct: a channel resolving context from config only
+         * FAILS CLOSED on this knob. A controller that cannot see the container limit must not be
+         * able to raise a ceiling past it, and refusing is the safe half of that trade.
+         */
+        requires: Object.freeze([liveLimitLeaf]),
+        leaves  : Object.freeze([
+            Object.freeze({path: leafPath, env, role: 'ceiling', type: 'number'})
+        ]),
+        invariants: Object.freeze([
+            Object.freeze({
+                id    : 'raise-not-lower',
+                reason: 'This knob expresses exactly one intent: raise. Lowering a declared ceiling ' +
+                        'toward a working set that has already grown into it is an abort instruction ' +
+                        'with extra steps — and unlike the store case the process dies CLEANLY ' +
+                        '(ExitCode 0, OOMKilled false), so it leaves no crash signature to diagnose.',
+                holds : values => Number.isFinite(values[leafPath]) && values[leafPath] > 0
+            }),
+            Object.freeze({
+                id    : 'strictly-below-container-limit',
+                reason: 'A V8 ceiling at or above the cgroup limit converts a clean self-abort into an ' +
+                        'OOMKill — strictly worse, because the kernel kills mid-write with no chance ' +
+                        'to flush. An unresolved or non-positive live limit REFUSES rather than ' +
+                        'passes: an unknown bound is a refusal, never an absent one.',
+                holds : (values, context = {}) => {
+                    const liveLimitBytes = context[liveLimitLeaf];
+
+                    if (!Number.isFinite(liveLimitBytes) || liveLimitBytes <= 0) return false;
+
+                    // The leaf is MB and the runtime bound is BYTES. Converting HERE, once, at the
+                    // one place both units meet, is the whole reason the leaf stays in MB: a knob
+                    // declared in bytes would need this conversion at every writer instead.
+                    return values[leafPath] * 1024 * 1024 < liveLimitBytes
+                }
+            })
+        ])
+    })
+}
+
 export const RECOVERY_KNOBS = Object.freeze({
+    'kb-server-heap-ceiling': serviceHeapCeilingKnob({
+        serviceKey: 'kb-server',
+        leafPath  : 'deploy.kbServer.heapCeilingMb',
+        env       : 'NEO_KB_SERVER_HEAP_MB'
+    }),
+    'mc-server-heap-ceiling': serviceHeapCeilingKnob({
+        serviceKey: 'mc-server',
+        leafPath  : 'deploy.mcServer.heapCeilingMb',
+        env       : 'NEO_MC_SERVER_HEAP_MB'
+    }),
     'container-memory-ceiling': Object.freeze({
         description: 'Raise a store-backed service\'s memory ceiling. For a store the corpus IS the ' +
                      'workload — resident memory tracks rows already persisted — so shedding relieves ' +

--- a/ai/services/memory-core/helpers/recoveryKnobRegistry.mjs
+++ b/ai/services/memory-core/helpers/recoveryKnobRegistry.mjs
@@ -71,7 +71,8 @@ const CONTAINER_MEMORY_CEILING_MAX_BYTES = 16 * 1024 ** 3;
  * @returns {Object} frozen knob descriptor
  */
 function serviceHeapCeilingKnob({serviceKey, leafPath, env}) {
-    const liveLimitLeaf = `runtime.${serviceKey}.liveMemoryLimitBytes`;
+    const liveLimitLeaf = `runtime.${serviceKey}.liveMemoryLimitBytes`,
+          nonHeapLeaf   = `runtime.${serviceKey}.observedNonHeapBytes`;
 
     return Object.freeze({
         description: `Raise ${serviceKey}'s declared V8 old-space ceiling. Distinct from the store's ` +
@@ -93,7 +94,7 @@ function serviceHeapCeilingKnob({serviceKey, leafPath, env}) {
          * FAILS CLOSED on this knob. A controller that cannot see the container limit must not be
          * able to raise a ceiling past it, and refusing is the safe half of that trade.
          */
-        requires: Object.freeze([liveLimitLeaf]),
+        requires: Object.freeze([liveLimitLeaf, nonHeapLeaf]),
         leaves  : Object.freeze([
             // `resource` is load-bearing, not descriptive: a consumer authorising a CGROUP move must
             // not match this leaf. `role: 'ceiling'` spans both, and the envelope boundary matched on
@@ -112,10 +113,12 @@ function serviceHeapCeilingKnob({serviceKey, leafPath, env}) {
             }),
             Object.freeze({
                 id    : 'strictly-below-container-limit',
-                reason: 'A V8 ceiling at or above the cgroup limit converts a clean self-abort into an ' +
-                        'OOMKill — strictly worse, because the kernel kills mid-write with no chance ' +
-                        'to flush. An unresolved or non-positive live limit REFUSES rather than ' +
-                        'passes: an unknown bound is a refusal, never an absent one.',
+                reason: 'The NECESSARY half of the pair, and deliberately not described as the ' +
+                        'sufficient one: a ceiling at or above the cgroup limit is incoherent on its ' +
+                        'face. It does NOT establish that the ceiling leaves room for non-heap RSS — ' +
+                        'see `headroom-for-non-heap-rss`, which is the bound that actually prevents ' +
+                        'the OOMKill conversion. An unresolved or non-positive live limit REFUSES ' +
+                        'rather than passes: an unknown bound is a refusal, never an absent one.',
                 holds : (values, context = {}) => {
                     const liveLimitBytes = context[liveLimitLeaf];
 
@@ -125,6 +128,30 @@ function serviceHeapCeilingKnob({serviceKey, leafPath, env}) {
                     // one place both units meet, is the whole reason the leaf stays in MB: a knob
                     // declared in bytes would need this conversion at every writer instead.
                     return values[leafPath] * 1024 * 1024 < liveLimitBytes
+                }
+            }),
+            Object.freeze({
+                id    : 'headroom-for-non-heap-rss',
+                reason: 'The bound that actually prevents the OOMKill conversion. A V8 heap ceiling ' +
+                        'caps the old space, NOT the process footprint: RSS is the ceiling plus new ' +
+                        'space, code, external buffers and native allocations. So the conversion from ' +
+                        'a catchable `FATAL ERROR: heap limit` to an uncatchable kernel kill happens ' +
+                        'as soon as ceiling + non-heap exceeds the cgroup — far BELOW the limit, not ' +
+                        'at it. Measured by @neo-opus-grace on this plane: a 768 MB ceiling in a ' +
+                        '1024 MiB container carries RSS to 860.7 MiB (84%), so non-heap ran ~93 MiB ' +
+                        'and only ~163 MiB separated a healthy service from a silent kill. The ' +
+                        'non-heap figure is therefore REQUIRED context, and it is refused when ' +
+                        'unresolved rather than assumed to be zero — assuming zero is what lets a ' +
+                        'ceiling one byte under the limit read as safe. This knob stays fail-closed ' +
+                        'until a service publishes that observation.',
+                holds : (values, context = {}) => {
+                    const liveLimitBytes = context[liveLimitLeaf],
+                          nonHeapBytes   = context[nonHeapLeaf];
+
+                    if (!Number.isFinite(liveLimitBytes) || liveLimitBytes <= 0) return false;
+                    if (!Number.isFinite(nonHeapBytes)   || nonHeapBytes   <  0) return false;
+
+                    return values[leafPath] * 1024 * 1024 + nonHeapBytes < liveLimitBytes
                 }
             })
         ])

--- a/ai/services/memory-core/helpers/recoveryKnobRegistry.mjs
+++ b/ai/services/memory-core/helpers/recoveryKnobRegistry.mjs
@@ -95,7 +95,11 @@ function serviceHeapCeilingKnob({serviceKey, leafPath, env}) {
          */
         requires: Object.freeze([liveLimitLeaf]),
         leaves  : Object.freeze([
-            Object.freeze({path: leafPath, env, role: 'ceiling', type: 'number'})
+            // `resource` is load-bearing, not descriptive: a consumer authorising a CGROUP move must
+            // not match this leaf. `role: 'ceiling'` spans both, and the envelope boundary matched on
+            // the role alone — so without this discriminator these knobs would sanction widening
+            // `HostConfig.Memory` for two services no envelope knob declares.
+            Object.freeze({path: leafPath, env, role: 'ceiling', resource: 'v8-heap', type: 'number'})
         ]),
         invariants: Object.freeze([
             Object.freeze({
@@ -164,12 +168,13 @@ export const RECOVERY_KNOBS = Object.freeze({
         requires: Object.freeze(['runtime.chroma.liveMemoryLimitBytes']),
         leaves  : Object.freeze([
             Object.freeze({
-                path: 'deploy.chroma.memoryCeilingBytes',
-                env : 'NEO_CHROMA_MEMORY_LIMIT',
-                role: 'ceiling',
-                type: 'number',
-                min : CONTAINER_MEMORY_CEILING_MIN_BYTES,
-                max : CONTAINER_MEMORY_CEILING_MAX_BYTES
+                path    : 'deploy.chroma.memoryCeilingBytes',
+                env     : 'NEO_CHROMA_MEMORY_LIMIT',
+                role    : 'ceiling',
+                resource: 'container-memory',
+                type    : 'number',
+                min     : CONTAINER_MEMORY_CEILING_MIN_BYTES,
+                max     : CONTAINER_MEMORY_CEILING_MAX_BYTES
             })
         ]),
         invariants: Object.freeze([

--- a/ai/services/memory-core/helpers/recoveryKnobRegistry.mjs
+++ b/ai/services/memory-core/helpers/recoveryKnobRegistry.mjs
@@ -72,7 +72,8 @@ const CONTAINER_MEMORY_CEILING_MAX_BYTES = 16 * 1024 ** 3;
  */
 function serviceHeapCeilingKnob({serviceKey, leafPath, env}) {
     const liveLimitLeaf = `runtime.${serviceKey}.liveMemoryLimitBytes`,
-          nonHeapLeaf   = `runtime.${serviceKey}.observedNonHeapBytes`;
+          nonHeapLeaf   = `runtime.${serviceKey}.observedNonHeapBytes`,
+          declaredLeaf  = `runtime.${serviceKey}.declaredHeapCeilingMb`;
 
     return Object.freeze({
         description: `Raise ${serviceKey}'s declared V8 old-space ceiling. Distinct from the store's ` +
@@ -94,7 +95,7 @@ function serviceHeapCeilingKnob({serviceKey, leafPath, env}) {
          * FAILS CLOSED on this knob. A controller that cannot see the container limit must not be
          * able to raise a ceiling past it, and refusing is the safe half of that trade.
          */
-        requires: Object.freeze([liveLimitLeaf, nonHeapLeaf]),
+        requires: Object.freeze([liveLimitLeaf, nonHeapLeaf, declaredLeaf]),
         leaves  : Object.freeze([
             // `resource` is load-bearing, not descriptive: a consumer authorising a CGROUP move must
             // not match this leaf. `role: 'ceiling'` spans both, and the envelope boundary matched on
@@ -108,8 +109,22 @@ function serviceHeapCeilingKnob({serviceKey, leafPath, env}) {
                 reason: 'This knob expresses exactly one intent: raise. Lowering a declared ceiling ' +
                         'toward a working set that has already grown into it is an abort instruction ' +
                         'with extra steps — and unlike the store case the process dies CLEANLY ' +
-                        '(ExitCode 0, OOMKilled false), so it leaves no crash signature to diagnose.',
-                holds : values => Number.isFinite(values[leafPath]) && values[leafPath] > 0
+                        '(ExitCode 0, OOMKilled false), so it leaves no crash signature to diagnose. ' +
+                        'The comparison is therefore against the CURRENT DECLARATION, not against ' +
+                        'zero: a positive-and-finite check carries the name without the meaning, and ' +
+                        'admitted 256 MB against a live 768 MB declaration (@neo-gpt-emmy, reviewing ' +
+                        'this PR). An unresolved or diverging declaration REFUSES — `\'unknown\'` is ' +
+                        'non-finite by construction, so a service whose replicas disagree cannot be ' +
+                        'raised until they are reconciled. Establishing a FIRST ceiling on a service ' +
+                        'that declares none is a different operation and is not this knob.',
+                holds : (values, context = {}) => {
+                    const declaredMb = context[declaredLeaf];
+
+                    if (!Number.isFinite(values[leafPath]) || values[leafPath] <= 0) return false;
+                    if (!Number.isFinite(declaredMb)) return false;
+
+                    return values[leafPath] > declaredMb
+                }
             }),
             Object.freeze({
                 id    : 'strictly-below-container-limit',

--- a/test/playwright/unit/ai/daemons/orchestrator/ActionClassAdrAccounting.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/ActionClassAdrAccounting.spec.mjs
@@ -1,0 +1,146 @@
+import {setup} from '../../../../setup.mjs';
+
+// The diagnosis module pulls in the Neo class system at load, so the harness must be armed before the
+// dynamic import in `beforeAll` — otherwise the import fails with `Neo is not defined` and the spec
+// reports a red that is about the fixture rather than about the ADR.
+setup({
+    neoConfig: {unitTestMode: true},
+    appConfig: {name: 'ActionClassAdrAccountingTest', isMounted: () => true, vnodeInitialising: false}
+});
+
+import {test, expect} from '@playwright/test';
+import fs             from 'node:fs';
+import path           from 'node:path';
+import process        from 'node:process';
+import Neo            from '../../../../../../src/Neo.mjs';
+import * as core      from '../../../../../../src/core/_export.mjs';
+
+const
+    repoRoot = path.resolve(process.cwd()),
+    adrPath  = path.join(repoRoot, 'learn/agentos/decisions/0026-recovery-actuator.md'),
+    adrText  = fs.readFileSync(adrPath, 'utf8'),
+
+    /** The dispositions an emitted action class may hold against ADR-0026 §2.4. */ // ticket-ref-ok: the ADR this spec's subject IS
+    DISPOSITIONS = Object.freeze(['admitted', 'terminal', 'disclosed-unimplemented']),
+
+    /**
+     * The curated enum → ADR accounting. **Deliberately hand-written, not derived.**
+     *
+     * A grep cannot do this job: the ADR spells `throttle` and `shed` as two separate specified-but-
+     * unimplemented actions while the diagnosis enum carries one hyphenated `throttle-shed`, so a
+     * string search reports a naming difference as a divergence and a real divergence as a match.
+     * The curation IS the content; the two assertions below stop it from drifting in either direction.
+     *
+     * `anchor` must be text actually present in the ADR — that is what keeps a stale mapping from
+     * claiming an accounting the ADR does not give.
+     */
+    ACTION_CLASS_ACCOUNTING = Object.freeze({
+        'raise-ceiling': {
+            disposition: 'admitted',
+            anchor     : 'raise-ceiling',
+            note       : 'Admitted for store-classed compose services only (§2.4 matrix + AC-12). ' +
+                         'Executor shipped in #16637.'
+        },
+        'record': {
+            disposition: 'terminal',
+            anchor     : 'record-with-diagnosis',
+            note       : 'Not a lifecycle action at all — the durable async-audit terminal (AC-6, ' +
+                         'amended #14191). Correctly absent from the admitted-action matrix.'
+        },
+        'restart': {
+            disposition: 'admitted',
+            anchor     : 'restart',
+            note       : 'Admitted for every target kind that has a lifecycle.'
+        },
+        'throttle-shed': {
+            disposition: 'disclosed-unimplemented',
+            anchor     : 'recycle`, `throttle` and `shed` remain specified but UNIMPLEMENTED',
+            note       : 'The LIFECYCLE actuator has no throttle/shed operation. The only shipped ' +
+                         'implementation of that name is collection-keyed in ADR-0027\'s ' +
+                         'data-recovery world, so a lifecycle `throttle-shed` diagnosis is a ' +
+                         'forward declaration consumed by nothing. Disclosed in §2.4.'
+        },
+        'warm-provider': {
+            disposition: 'admitted',
+            anchor     : 'warm-provider',
+            note       : 'Admitted for supervised tasks and compose services (config/readiness repair).'
+        }
+    });
+
+/**
+ * Every action class the container-health diagnosis can emit is accounted for in the recovery-actuator ADR's admitted-action matrix.
+ *
+ * **Why this exists.** That matrix was amended specifically so that *"a reader of this section must be
+ * able to tell which of the listed actions they can actually call"* — and when this guard's ticket was
+ * filed, **two of the five emitted classes appeared nowhere in the ADR at all**:
+ * `grep -rn 'raiseCeiling' learn/` returned zero while the enum shipped it, and `throttle-shed`'s only
+ * implementation turned out to live in a different ADR's world entirely. The section could not do the
+ * job it was amended to do.
+ *
+ * The gap is now closed in the ADR. **This spec is what stops the next one opening**, and it guards
+ * the general property rather than the two instances that motivated it: an action class added to the
+ * enum without an ADR disposition fails here, at the moment it is added, rather than being found by a
+ * reviewer's grep months later.
+ *
+ * Two assertions, and each closes a different drift direction:
+ *
+ * 1. **Enum totality** — every emitted class has an accounting entry. Adding an enum member without
+ *    deciding its ADR status fails.
+ * 2. **Anchor liveness** — every accounting entry's `anchor` is text actually present in that ADR.
+ *    A mapping cannot claim an accounting the ADR does not give, and an ADR rewrite that drops the
+ *    text a disposition rests on fails here too.
+ */
+test.describe('container-health action classes are accounted for in ADR-0026', () => {
+    let CONTAINER_HEALTH_ACTION_CLASSES;
+
+    test.beforeAll(async () => {
+        ({CONTAINER_HEALTH_ACTION_CLASSES} =
+            await import('../../../../../../ai/daemons/orchestrator/services/ContainerHealthDiagnosisService.mjs'));
+    });
+
+    test('ENUM TOTALITY: every emitted action class has an ADR accounting entry', () => {
+        const emitted      = Object.values(CONTAINER_HEALTH_ACTION_CLASSES).sort(),
+              accountedFor = Object.keys(ACTION_CLASS_ACCOUNTING).sort();
+
+        // Set-equality in BOTH directions. A missing entry is an unaccounted action class; a surplus
+        // entry is a mapping that outlived the enum member it describes, which would let a deleted
+        // class keep a green accounting forever.
+        expect(emitted, 'an action class is emitted with no ADR-0026 disposition — decide it, do not add it here blindly')
+            .toEqual(accountedFor);
+    });
+
+    test('ANCHOR LIVENESS: every disposition rests on text actually present in ADR-0026', () => {
+        const missing = Object.entries(ACTION_CLASS_ACCOUNTING)
+            .filter(([, entry]) => !adrText.includes(entry.anchor))
+            .map(([name, entry]) => `${name} → "${entry.anchor}"`);
+
+        expect(missing, 'a disposition claims ADR text that is not in the ADR — the mapping has drifted or the ADR was rewritten')
+            .toEqual([]);
+    });
+
+    test('every disposition is one of the closed set', () => {
+        for (const [name, entry] of Object.entries(ACTION_CLASS_ACCOUNTING)) {
+            expect(DISPOSITIONS, `${name} carries an unrecognised disposition "${entry.disposition}"`)
+                .toContain(entry.disposition);
+        }
+    });
+
+    test('POSITIVE CONTROL: the totality check detects an unaccounted class', () => {
+        // Without this, the totality assertion could be vacuous — it would pass just as green if the
+        // enum import silently yielded an empty object, or if `Object.values` were pointed at the
+        // wrong symbol. Prove the comparison actually discriminates before trusting its silence.
+        const withExtra = [...Object.values(CONTAINER_HEALTH_ACTION_CLASSES), 'invented-action'].sort();
+
+        expect(withExtra).not.toEqual(Object.keys(ACTION_CLASS_ACCOUNTING).sort());
+        // And the enum must be non-empty, or "every member is accounted for" is trivially true.
+        expect(Object.values(CONTAINER_HEALTH_ACTION_CLASSES).length,
+            'an empty enum would make the totality assertion vacuous').toBeGreaterThan(0);
+    });
+
+    test('POSITIVE CONTROL: the anchor check detects text absent from the ADR', () => {
+        // Same discipline for the second assertion: prove `adrText.includes` can say no.
+        expect(adrText.includes('this sentence is not in ADR-0026'),
+            'the anchor check must be able to report an absent anchor').toBe(false);
+        expect(adrText.length, 'the ADR must actually have been read').toBeGreaterThan(1000);
+    });
+});

--- a/test/playwright/unit/ai/daemons/orchestrator/DeclaredHeapCeilingObservation.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/DeclaredHeapCeilingObservation.spec.mjs
@@ -32,11 +32,22 @@ const LIVE = Object.freeze({
     chroma: Object.freeze(['run', '/config.yaml'])
 });
 
-let parseDeclaredHeapCeilingMb;
+let parseDeclaredHeapCeilingMb, isNodeCommand, selectUndeclaredHeapCeilingServices, CONTAINER_HEALTH_FACT_TYPES;
+
+/** Builds a per-service snapshot in the shape `collectBridgeDiagnostics` consumes. */
+const snapshot = (serviceKey, inspect) => ({serviceKey, status: 'available', errors: [], inspect});
 
 test.beforeAll(async () => {
-    ({parseDeclaredHeapCeilingMb} = await import(
-        '../../../../../../ai/daemons/orchestrator/services/DeploymentStateBridgeService.mjs'));
+    const bridge = await import('../../../../../../ai/daemons/orchestrator/services/DeploymentStateBridgeService.mjs');
+
+    // The rule is tested through the extracted pure helper, NOT through `collectBridgeDiagnostics`.
+    // I first wrote this spec calling that method off the prototype, on the assumption it read only
+    // its arguments. Running it falsified that in one line — it reaches `AiConfig` and the runtime
+    // holder, so it threw on `this` being null. The assumption was never checked, only read.
+    ({parseDeclaredHeapCeilingMb, isNodeCommand, selectUndeclaredHeapCeilingServices} = bridge);
+
+    ({CONTAINER_HEALTH_FACT_TYPES} = await import(
+        '../../../../../../ai/daemons/orchestrator/services/ContainerHealthDiagnosisService.mjs'));
 });
 
 test.describe('declared heap ceiling — observed from Config.Cmd, fail-closed on ambiguity', () => {
@@ -84,11 +95,78 @@ test.describe('declared heap ceiling — observed from Config.Cmd, fail-closed o
         expect(parseDeclaredHeapCeilingMb({})).toBe(null);
     });
 
+    test('node detection reads the COMMAND, never the image name', () => {
+        expect(isNodeCommand(LIVE.kbServer)).toBe(true);
+        expect(isNodeCommand(LIVE.mcServer)).toBe(true);
+        expect(isNodeCommand(LIVE.chroma)).toBe(false);
+
+        // The image name is a proxy that holds until it does not: a Node entrypoint on a different
+        // base, or a non-Node entrypoint on the shared image, breaks it SILENTLY. These two rows
+        // are the cases an image check would get wrong in each direction.
+        expect(isNodeCommand(['sh', '-c', 'exec node server.mjs'])).toBe(true);
+        expect(isNodeCommand(['sh', '-c', '/usr/bin/nodemon watch'])).toBe(false);
+    });
+
     test('the value is what the container was TOLD — the name may not imply an enforced ceiling', () => {
         // Guard against a future rename toward "effective"/"actual". No V8-scoped metric exists for
         // a sibling container anywhere in `ai/`, so a name promising one would recreate the
         // cross-scope conflation the heap-ceiling work exists to prevent.
         expect(parseDeclaredHeapCeilingMb(LIVE.kbServer)).toBe(768);
         expect(typeof parseDeclaredHeapCeilingMb(LIVE.kbServer)).toBe('number');
+    });
+});
+
+test.describe('the undeclared-ceiling observation — record-terminal, and never evidence', () => {
+    const
+        nodeUndeclared = snapshot('mc-server',  {nodeCommand: true,  declaredHeapCeilingMb: null}),
+        nodeDeclared   = snapshot('kb-server',  {nodeCommand: true,  declaredHeapCeilingMb: 768}),
+        nonNode        = snapshot('chroma',     {nodeCommand: false, declaredHeapCeilingMb: null}),
+        ambiguous      = snapshot('orchestr',   {nodeCommand: true,  declaredHeapCeilingMb: 'unknown'}),
+        unreadable     = snapshot('ingress',    null);
+
+    test('a Node service with no declared ceiling is named', () => {
+        expect(selectUndeclaredHeapCeilingServices([nodeUndeclared, nodeDeclared])).toEqual(['mc-server']);
+    });
+
+    test('a NON-Node service with no ceiling is not a finding', () => {
+        // chroma has no V8 to bound. Reporting it would be noise the reader learns to ignore, and a
+        // reader who learns to ignore a field stops reading it when it matters.
+        expect(selectUndeclaredHeapCeilingServices([nonNode])).toEqual([]);
+    });
+
+    test('AMBIGUOUS is not the same as ABSENT — `unknown` is not a finding', () => {
+        // The discriminating case. `unknown` means the command carried divergent declarations, so
+        // the ceiling could not be OBSERVED. Listing it here would publish "observed an absence"
+        // where the truth is "could not observe" — the same conflation that makes a null result
+        // read as a clean one.
+        expect(selectUndeclaredHeapCeilingServices([ambiguous])).toEqual([]);
+    });
+
+    test('an unreadable inspect is not a finding either', () => {
+        expect(selectUndeclaredHeapCeilingServices([unreadable])).toEqual([]);
+    });
+
+    test('NEGATIVE CONTROL: every service declared and inside its ceiling yields no finding', () => {
+        expect(selectUndeclaredHeapCeilingServices([nodeDeclared, nonNode])).toEqual([]);
+    });
+
+    test('POSITIVE CONTROL for the four negatives above', () => {
+        // Each negative row asserts an empty array, and an empty array is what a permanently broken
+        // filter returns too. This proves the filter can still produce a finding when the mixed
+        // population includes one — without it, the four rows above are vacuous together.
+        expect(selectUndeclaredHeapCeilingServices([nodeDeclared, nonNode, ambiguous, unreadable, nodeUndeclared]))
+            .toEqual(['mc-server']);
+    });
+
+    test('it is NOT a container-health fact type — the array that feeds every branch', () => {
+        // AC-6, asserted structurally rather than per-branch. `selectEvidenceFacts(facts, …)` is
+        // called with the WHOLE facts array at every classification branch, so the only way to be
+        // absent from all of them is to not be a fact at all. Owning it in the bridge record makes
+        // that true by construction; this guards the construction.
+        const factTypes = Object.values(CONTAINER_HEALTH_FACT_TYPES);
+
+        expect(factTypes.length).toBeGreaterThan(0);                                  // control: the enum loaded
+        expect(factTypes.some(type => /undeclared|declared-ceiling/.test(type))).toBe(false);
+        expect(factTypes).toContain('memory-saturation');                             // control: this IS a fact type
     });
 });

--- a/test/playwright/unit/ai/daemons/orchestrator/DeclaredHeapCeilingObservation.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/DeclaredHeapCeilingObservation.spec.mjs
@@ -1,0 +1,94 @@
+import {setup} from '../../../../setup.mjs';
+
+// The bridge module pulls in the Neo class system at load, so the harness must be armed before the
+// dynamic import in `beforeAll` — otherwise the import fails with `Neo is not defined` and the spec
+// reports a red that is about the fixture rather than about the parser.
+setup({
+    neoConfig: {unitTestMode: true},
+    appConfig: {name: 'DeclaredHeapCeilingObservationTest', isMounted: () => true, vnodeInitialising: false}
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../../../src/Neo.mjs';
+import * as core      from '../../../../../../src/core/_export.mjs';
+
+/**
+ * `Config.Cmd` values COPIED FROM THE LIVE PLANE on 2026-08-08, not invented. An invented fixture
+ * would be shaped by what the parser already does; these were shaped by the deployment.
+ */
+const LIVE = Object.freeze({
+    // One `node` invocation — the simple case.
+    kbServer: Object.freeze(['sh', '-c', 'node --max-old-space-size=768 "$SERVER_ENTRYPOINT"']),
+
+    // TWO invocations, overlay and no-overlay, and the compose spec holds their values equal. This
+    // is the case a naive first-match parser ALSO passes, which is exactly why the divergent
+    // fixture below has to exist — without it this row proves nothing about the agreement rule.
+    mcServer: Object.freeze(['sh', '-c',
+        'overlay=/app/.neo-ai-data/deployment-state/recovery-actuator-overrides.json; if [ -f "$overlay" ]; then\n' +
+        '  node --max-old-space-size=768 "$SERVER_ENTRYPOINT" --config "$overlay";\nelse\n' +
+        '  node --max-old-space-size=768 "$SERVER_ENTRYPOINT";\nfi']),
+
+    // A non-Node service. Its `null` is the one assertion a BROKEN matcher would also satisfy.
+    chroma: Object.freeze(['run', '/config.yaml'])
+});
+
+let parseDeclaredHeapCeilingMb;
+
+test.beforeAll(async () => {
+    ({parseDeclaredHeapCeilingMb} = await import(
+        '../../../../../../ai/daemons/orchestrator/services/DeploymentStateBridgeService.mjs'));
+});
+
+test.describe('declared heap ceiling — observed from Config.Cmd, fail-closed on ambiguity', () => {
+    test('a single declaration is read', () => {
+        expect(parseDeclaredHeapCeilingMb(LIVE.kbServer)).toBe(768);
+    });
+
+    test('two AGREEING declarations resolve to the agreed value', () => {
+        expect(parseDeclaredHeapCeilingMb(LIVE.mcServer)).toBe(768);
+    });
+
+    test('DIVERGENT declarations report `unknown` — never a pick', () => {
+        // Mutated from the live mc-server command by changing ONE branch. `Config.Cmd` does not say
+        // which branch is executing, so returning either number would be a guess with a number
+        // attached. This is the discriminating case: a first-match parser returns 768 and a
+        // last-match parser returns 512, and both are wrong for the same reason.
+        const divergent = LIVE.mcServer.map(part =>
+            part.replace('--max-old-space-size=768 "$SERVER_ENTRYPOINT";', '--max-old-space-size=512 "$SERVER_ENTRYPOINT";'));
+
+        expect(divergent.join(' ')).toContain('--max-old-space-size=512');   // the mutation applied
+        expect(divergent.join(' ')).toContain('--max-old-space-size=768');   // and did not erase its sibling
+
+        expect(parseDeclaredHeapCeilingMb(divergent)).toBe('unknown');
+    });
+
+    test('no declaration reads null — with the positive control that makes that meaningful', () => {
+        // A matcher that never matches would satisfy this line too. The control proves the
+        // instrument can see a present case, so the null below is an observation and not a silence.
+        expect(parseDeclaredHeapCeilingMb(LIVE.chroma)).toBe(null);
+        expect(parseDeclaredHeapCeilingMb(LIVE.kbServer)).toBe(768);
+    });
+
+    test('null and `unknown` are DIFFERENT observations and must not collapse', () => {
+        // "declares none" and "declares ambiguously" route differently: the first is the
+        // undeclared-ceiling case, the second is not observable at all. Conflating them would let
+        // an ambiguous command be reported as an absent ceiling.
+        expect(parseDeclaredHeapCeilingMb(LIVE.chroma)).not.toBe('unknown');
+        expect(parseDeclaredHeapCeilingMb(['node --max-old-space-size=1 x', 'node --max-old-space-size=2 y'])).not.toBe(null);
+    });
+
+    test('a string command is accepted, and junk degrades to null rather than throwing', () => {
+        expect(parseDeclaredHeapCeilingMb('node --max-old-space-size=256 server.mjs')).toBe(256);
+        expect(parseDeclaredHeapCeilingMb(null)).toBe(null);
+        expect(parseDeclaredHeapCeilingMb(undefined)).toBe(null);
+        expect(parseDeclaredHeapCeilingMb({})).toBe(null);
+    });
+
+    test('the value is what the container was TOLD — the name may not imply an enforced ceiling', () => {
+        // Guard against a future rename toward "effective"/"actual". No V8-scoped metric exists for
+        // a sibling container anywhere in `ai/`, so a name promising one would recreate the
+        // cross-scope conflation the heap-ceiling work exists to prevent.
+        expect(parseDeclaredHeapCeilingMb(LIVE.kbServer)).toBe(768);
+        expect(typeof parseDeclaredHeapCeilingMb(LIVE.kbServer)).toBe('number');
+    });
+});

--- a/test/playwright/unit/ai/daemons/orchestrator/services/DeploymentRuntimeAccessService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/DeploymentRuntimeAccessService.spec.mjs
@@ -6,6 +6,7 @@ import {
     DeploymentRuntimeAccessService,
     DEPLOYMENT_RUNTIME_SELF_SERVICE_KEY
 } from '../../../../../../../ai/daemons/orchestrator/services/DeploymentRuntimeAccessService.mjs';
+import {RECOVERY_KNOBS} from '../../../../../../../ai/services/memory-core/helpers/recoveryKnobRegistry.mjs';
 
 const BASE_CONFIG = {
     enabled                     : true,
@@ -597,12 +598,22 @@ test.describe('Neo.ai.daemons.services.DeploymentRuntimeAccessService', () => {
             }
         });
 
-        test('a service NO ceiling knob declares is refused — the registry closed set IS the target list', async () => {
+        test('a service no CONTAINER-MEMORY ceiling knob declares is refused — the closed set IS the target list', async () => {
             // The bypass the review caught: under flat allowlists the raw op could resize a transient
             // service, skipping everything the knob enforces one layer up. The boundary now consults
-            // the same closed registry, so mc-server — allowlisted for lifecycle, declared by no
-            // ceiling knob — cannot be addressed at all, and no Docker read runs beyond identity.
+            // the same closed registry, so mc-server cannot be addressed at all, and no Docker read
+            // runs beyond identity.
+            //
+            // mc-server is deliberately the specimen, and the reason it qualifies CHANGED: a heap
+            // ceiling knob now declares it, so "declared by no ceiling knob" is no longer why it is
+            // refused. It is refused because no knob declares an envelope ceiling for it — the
+            // resource discriminator, not the role, carries the boundary. The assertion below pins
+            // that: mc-server IS declared by a `ceiling` leaf, and is refused anyway.
             const {service, calls} = createService({config: UPDATE_CONFIG});
+
+            expect(Object.values(RECOVERY_KNOBS).some(knob =>
+                knob.serviceKey === 'mc-server' && knob.leaves.some(leaf => leaf.role === 'ceiling')
+            )).toBe(true);
 
             const error = await service.applyLifecycle({
                 serviceKey      : 'mc-server',
@@ -613,6 +624,25 @@ test.describe('Neo.ai.daemons.services.DeploymentRuntimeAccessService', () => {
             expect(error.reason).toBe('runtime-memory-limit-unsanctioned-target');
             expect(calls).toHaveLength(1);
             expect(calls.some(call => String(call.path).endsWith('/update'))).toBe(false);
+        });
+
+        test('every container-memory ceiling leaf declares a FINITE band — an unbanded one would delete the cap', () => {
+            // Clause 3 of the boundary is unreachable today by construction: chroma is the only
+            // envelope knob and it is banded. That is exactly why this asserts the invariant on the
+            // DATA rather than the branch — the hazard is a future knob, and the failure mode is
+            // silent. `value < undefined || value > undefined` is NaN-false in both directions, so an
+            // unbanded envelope knob does not tighten the cap, it removes it, leaving raise-only as
+            // the sole surviving bound and the autonomous ratchet unterminated.
+            const envelopeLeaves = Object.values(RECOVERY_KNOBS).flatMap(knob =>
+                knob.leaves.filter(leaf => leaf.role === 'ceiling' && leaf.resource === 'container-memory')
+            );
+
+            expect(envelopeLeaves.length).toBeGreaterThan(0);
+
+            for (const leaf of envelopeLeaves) {
+                expect(Number.isFinite(leaf.min), leaf.path).toBe(true);
+                expect(Number.isFinite(leaf.max), leaf.path).toBe(true);
+            }
         });
 
         test('a value outside the registry band is refused BEFORE any Docker read — the cap holds at L0 too', async () => {

--- a/test/playwright/unit/ai/services/memory-core/helpers/serviceHeapCeilingKnob.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/helpers/serviceHeapCeilingKnob.spec.mjs
@@ -17,9 +17,11 @@ const
     // The live plane on 2026-08-08: 1 GiB cgroup, 768 MB declared ceiling.
     GIB     = 1024 * 1024 * 1024,
     MIB     = 1024 * 1024,
-    // Measured by @neo-opus-grace on that plane: a 768 MB ceiling carried RSS to 860.7 MiB, so
-    // non-heap ran ~93 MiB. Used as the realistic fixture rather than a round number, because a
-    // round number invites treating the bound as a policy constant instead of an observation.
+    // An ILLUSTRATIVE fixture, not a measurement. It is the gap between the observed 860.7 MiB RSS
+    // and the 768 MB ceiling on that plane, which equals non-heap ONLY if the heap sat at its
+    // ceiling — unestablished, and @neo-opus-grace explicitly withdrew reading her RSS numbers as
+    // heap facts. The production value must come from a real observation; this constant exists so
+    // the arithmetic is exercised, and no production path may derive non-heap this way.
     NON_HEAP = Math.round(92.7 * MIB),
     // Every valid transaction must now supply BOTH runtime facts. A fixture that omits the non-heap
     // observation is exercising the fail-closed path, not the happy path.

--- a/test/playwright/unit/ai/services/memory-core/helpers/serviceHeapCeilingKnob.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/helpers/serviceHeapCeilingKnob.spec.mjs
@@ -23,9 +23,16 @@ const
     // heap facts. The production value must come from a real observation; this constant exists so
     // the arithmetic is exercised, and no production path may derive non-heap this way.
     NON_HEAP = Math.round(92.7 * MIB),
-    // Every valid transaction must now supply BOTH runtime facts. A fixture that omits the non-heap
-    // observation is exercising the fail-closed path, not the happy path.
-    liveContext = (nonHeapBytes = NON_HEAP) => ({[KB_LIVE]: GIB, [KB_NONHEAP]: nonHeapBytes});
+    KB_DECLARED = 'runtime.kb-server.declaredHeapCeilingMb',
+    // The plane's actual declaration, and the value every "raise" below must exceed.
+    DECLARED_MB = 768,
+    // Every valid transaction must supply all THREE runtime facts. A fixture omitting one is
+    // exercising a fail-closed path, not the happy path.
+    liveContext = (nonHeapBytes = NON_HEAP, declaredMb = DECLARED_MB) => ({
+        [KB_LIVE]    : GIB,
+        [KB_NONHEAP] : nonHeapBytes,
+        [KB_DECLARED]: declaredMb
+    });
 
 test.describe('service-heap ceiling knobs — two knobs, relational bounds, no constants', () => {
     test('both knobs exist and are SEPARATE — serviceKey is singular', () => {
@@ -56,11 +63,47 @@ test.describe('service-heap ceiling knobs — two knobs, relational bounds, no c
         // The non-heap observation joined the limit here after @neo-opus-grace measured that the
         // limit alone cannot express the bound. Neither is derivable from config: cgroup limits and
         // process footprints are observed at runtime by design.
-        expect(knobRequiredContext(KB_KNOB)).toEqual([KB_LIVE, KB_NONHEAP]);
+        expect(knobRequiredContext(KB_KNOB)).toEqual([KB_LIVE, KB_NONHEAP, KB_DECLARED]);
         expect(knobRequiredContext(MC_KNOB)).toEqual([
             'runtime.mc-server.liveMemoryLimitBytes',
-            'runtime.mc-server.observedNonHeapBytes'
+            'runtime.mc-server.observedNonHeapBytes',
+            'runtime.mc-server.declaredHeapCeilingMb'
         ]);
+    });
+
+    test('a LOWERING is refused — the name compares against the declaration, not against zero', async () => {
+        // @neo-gpt-emmy's finding, reviewing this PR. `raise-not-lower` previously checked only
+        // finite-and-positive, so it carried its name without its meaning: 256 MB against a live
+        // 768 MB declaration passed as a "raise". Lowering a ceiling toward a working set that has
+        // already grown into it is an abort instruction with extra steps.
+        const refused = validateKnobTransaction({
+            knob   : KB_KNOB,
+            values : {[KB_LEAF]: 256},
+            context: liveContext()
+        });
+
+        expect(refused.valid).toBe(false);
+
+        // Run the REJECTED predicate inline, so this proves the DECLARATION comparison refuses it
+        // rather than some unrelated invariant: the old check passes the same input.
+        expect(Number.isFinite(256) && 256 > 0).toBe(true);
+        expect(256 > DECLARED_MB).toBe(false);
+    });
+
+    test('an equal value is not a raise, and an unresolved or DIVERGING declaration refuses', () => {
+        // `parseDeclaredHeapCeilingMb` yields the string 'unknown' when replicas disagree, which is
+        // non-finite by construction — so a service whose declarations diverge cannot be raised
+        // until they are reconciled, rather than being raised against a guess.
+        for (const [label, values, ctx] of [
+            ['equal to the declaration', {[KB_LEAF]: DECLARED_MB}, liveContext()],
+            // The key is OMITTED rather than passed as `undefined`: an explicit `undefined` argument
+            // triggers the helper's default parameter, so it would have supplied 768 and tested
+            // nothing. Caught by this test failing — the fixture had not created the state it named.
+            ['declaration unresolved',   {[KB_LEAF]: 900},         {[KB_LIVE]: GIB, [KB_NONHEAP]: NON_HEAP}],
+            ['declaration diverging',    {[KB_LEAF]: 900},         liveContext(NON_HEAP, 'unknown')]
+        ]) {
+            expect(validateKnobTransaction({knob: KB_KNOB, values, context: ctx}).valid, label).toBe(false);
+        }
     });
 
     test('a ceiling UNDER the limit but over it once non-heap is counted is REFUSED', () => {

--- a/test/playwright/unit/ai/services/memory-core/helpers/serviceHeapCeilingKnob.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/helpers/serviceHeapCeilingKnob.spec.mjs
@@ -13,8 +13,17 @@ const
     KB_LEAF = 'deploy.kbServer.heapCeilingMb',
     MC_LEAF = 'deploy.mcServer.heapCeilingMb',
     KB_LIVE = 'runtime.kb-server.liveMemoryLimitBytes',
+    KB_NONHEAP = 'runtime.kb-server.observedNonHeapBytes',
     // The live plane on 2026-08-08: 1 GiB cgroup, 768 MB declared ceiling.
-    GIB     = 1024 * 1024 * 1024;
+    GIB     = 1024 * 1024 * 1024,
+    MIB     = 1024 * 1024,
+    // Measured by @neo-opus-grace on that plane: a 768 MB ceiling carried RSS to 860.7 MiB, so
+    // non-heap ran ~93 MiB. Used as the realistic fixture rather than a round number, because a
+    // round number invites treating the bound as a policy constant instead of an observation.
+    NON_HEAP = Math.round(92.7 * MIB),
+    // Every valid transaction must now supply BOTH runtime facts. A fixture that omits the non-heap
+    // observation is exercising the fail-closed path, not the happy path.
+    liveContext = (nonHeapBytes = NON_HEAP) => ({[KB_LIVE]: GIB, [KB_NONHEAP]: nonHeapBytes});
 
 test.describe('service-heap ceiling knobs — two knobs, relational bounds, no constants', () => {
     test('both knobs exist and are SEPARATE — serviceKey is singular', () => {
@@ -41,16 +50,56 @@ test.describe('service-heap ceiling knobs — two knobs, relational bounds, no c
         }
     });
 
-    test('the container limit is declared as RUNTIME context, not config', () => {
-        expect(knobRequiredContext(KB_KNOB)).toEqual([KB_LIVE]);
-        expect(knobRequiredContext(MC_KNOB)).toEqual(['runtime.mc-server.liveMemoryLimitBytes']);
+    test('BOTH runtime facts are declared as context, not config', () => {
+        // The non-heap observation joined the limit here after @neo-opus-grace measured that the
+        // limit alone cannot express the bound. Neither is derivable from config: cgroup limits and
+        // process footprints are observed at runtime by design.
+        expect(knobRequiredContext(KB_KNOB)).toEqual([KB_LIVE, KB_NONHEAP]);
+        expect(knobRequiredContext(MC_KNOB)).toEqual([
+            'runtime.mc-server.liveMemoryLimitBytes',
+            'runtime.mc-server.observedNonHeapBytes'
+        ]);
+    });
+
+    test('a ceiling UNDER the limit but over it once non-heap is counted is REFUSED', () => {
+        // The counterfactual for the whole fix, and the case the previous bound passed. 1000 MB is
+        // strictly below a 1 GiB cgroup, so `strictly-below-container-limit` admits it — but the
+        // process footprint is the ceiling PLUS non-heap, which lands at ~1092 MiB and the kernel
+        // kills mid-write with no diagnostic. The old bound's own stated purpose was preventing
+        // exactly this conversion, and it could not.
+        const refused = validateKnobTransaction({
+            knob   : KB_KNOB,
+            values : {[KB_LEAF]: 1000},
+            context: liveContext()
+        });
+
+        expect(refused.valid).toBe(false);
+
+        // Run the REJECTED predicate inline, so this test proves the new bound is what refuses it
+        // rather than some unrelated invariant: the old check passes the same input.
+        expect(1000 * MIB < GIB).toBe(true);
+        expect(1000 * MIB + NON_HEAP < GIB).toBe(false);
+    });
+
+    test('a MISSING non-heap observation refuses — zero is never assumed', () => {
+        // Assuming zero non-heap is precisely what lets a ceiling one byte under the cgroup read as
+        // safe. The knob therefore stays fail-closed until a service publishes the observation.
+        for (const nonHeapBytes of [undefined, null, NaN, -1]) {
+            const result = validateKnobTransaction({
+                knob   : KB_KNOB,
+                values : {[KB_LEAF]: 800},
+                context: {[KB_LIVE]: GIB, [KB_NONHEAP]: nonHeapBytes}
+            });
+
+            expect(result.valid, `nonHeap=${nonHeapBytes}`).toBe(false);
+        }
     });
 
     test('a raise strictly below the container limit is VALID', () => {
         const result = validateKnobTransaction({
             knob   : KB_KNOB,
             values : {[KB_LEAF]: 896},
-            context: {[KB_LIVE]: GIB}
+            context: liveContext()
         });
 
         expect(result.valid).toBe(true);
@@ -62,7 +111,7 @@ test.describe('service-heap ceiling knobs — two knobs, relational bounds, no c
         const result = validateKnobTransaction({
             knob   : KB_KNOB,
             values : {[KB_LEAF]: 1024},
-            context: {[KB_LIVE]: GIB}
+            context: liveContext()
         });
 
         expect(result.valid).toBe(false);
@@ -72,7 +121,7 @@ test.describe('service-heap ceiling knobs — two knobs, relational bounds, no c
         expect(validateKnobTransaction({
             knob   : KB_KNOB,
             values : {[KB_LEAF]: 2048},
-            context: {[KB_LIVE]: GIB}
+            context: liveContext()
         }).valid).toBe(false);
     });
 
@@ -84,14 +133,14 @@ test.describe('service-heap ceiling knobs — two knobs, relational bounds, no c
         expect(validateKnobTransaction({
             knob   : KB_KNOB,
             values : {[KB_LEAF]: 900},
-            context: {[KB_LIVE]: GIB}
+            context: liveContext()
         }).valid).toBe(true);
 
         // …and 1100 MB exceeds 1 GiB only once converted. Unconverted, 1100 < 1073741824 passes.
         expect(validateKnobTransaction({
             knob   : KB_KNOB,
             values : {[KB_LEAF]: 1100},
-            context: {[KB_LIVE]: GIB}
+            context: liveContext()
         }).valid).toBe(false);
     });
 
@@ -117,7 +166,7 @@ test.describe('service-heap ceiling knobs — two knobs, relational bounds, no c
             expect(validateKnobTransaction({
                 knob   : KB_KNOB,
                 values : {[KB_LEAF]: v},
-                context: {[KB_LIVE]: GIB}
+                context: liveContext()
             }).valid).toBe(false);
         }
     });

--- a/test/playwright/unit/ai/services/memory-core/helpers/serviceHeapCeilingKnob.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/helpers/serviceHeapCeilingKnob.spec.mjs
@@ -1,0 +1,130 @@
+import {test, expect} from '@playwright/test';
+import {
+    RECOVERY_KNOBS,
+    isKnownKnob,
+    knobLeafPaths,
+    knobRequiredContext,
+    validateKnobTransaction
+} from '../../../../../../../ai/services/memory-core/helpers/recoveryKnobRegistry.mjs';
+
+const
+    KB_KNOB = 'kb-server-heap-ceiling',
+    MC_KNOB = 'mc-server-heap-ceiling',
+    KB_LEAF = 'deploy.kbServer.heapCeilingMb',
+    MC_LEAF = 'deploy.mcServer.heapCeilingMb',
+    KB_LIVE = 'runtime.kb-server.liveMemoryLimitBytes',
+    // The live plane on 2026-08-08: 1 GiB cgroup, 768 MB declared ceiling.
+    GIB     = 1024 * 1024 * 1024;
+
+test.describe('service-heap ceiling knobs — two knobs, relational bounds, no constants', () => {
+    test('both knobs exist and are SEPARATE — serviceKey is singular', () => {
+        expect(isKnownKnob(KB_KNOB)).toBe(true);
+        expect(isKnownKnob(MC_KNOB)).toBe(true);
+
+        // One knob addressing both servers would defeat the actuator's knob/target mismatch refusal,
+        // which is keyed on this single field.
+        expect(RECOVERY_KNOBS[KB_KNOB].serviceKey).toBe('kb-server');
+        expect(RECOVERY_KNOBS[MC_KNOB].serviceKey).toBe('mc-server');
+        expect(knobLeafPaths(KB_KNOB)).toEqual([KB_LEAF]);
+        expect(knobLeafPaths(MC_KNOB)).toEqual([MC_LEAF]);
+    });
+
+    test('NO min/max constants — both bounds are relationships', () => {
+        // `768` has no derivation in the repo, so a band here would be invented to match the store
+        // knob's shape. This asserts the absence directly, because a constant that slipped in later
+        // would still pass every behavioural test below.
+        for (const knob of [KB_KNOB, MC_KNOB]) {
+            for (const leaf of RECOVERY_KNOBS[knob].leaves) {
+                expect(leaf.min).toBeUndefined();
+                expect(leaf.max).toBeUndefined();
+            }
+        }
+    });
+
+    test('the container limit is declared as RUNTIME context, not config', () => {
+        expect(knobRequiredContext(KB_KNOB)).toEqual([KB_LIVE]);
+        expect(knobRequiredContext(MC_KNOB)).toEqual(['runtime.mc-server.liveMemoryLimitBytes']);
+    });
+
+    test('a raise strictly below the container limit is VALID', () => {
+        const result = validateKnobTransaction({
+            knob   : KB_KNOB,
+            values : {[KB_LEAF]: 896},
+            context: {[KB_LIVE]: GIB}
+        });
+
+        expect(result.valid).toBe(true);
+        expect(result.violations ?? []).toEqual([]);
+    });
+
+    test('a ceiling AT the container limit is refused — that is the OOMKill conversion', () => {
+        // 1024 MB against a 1 GiB cgroup. A clean self-abort becomes a kernel kill mid-write.
+        const result = validateKnobTransaction({
+            knob   : KB_KNOB,
+            values : {[KB_LEAF]: 1024},
+            context: {[KB_LIVE]: GIB}
+        });
+
+        expect(result.valid).toBe(false);
+    });
+
+    test('a ceiling ABOVE the container limit is refused', () => {
+        expect(validateKnobTransaction({
+            knob   : KB_KNOB,
+            values : {[KB_LEAF]: 2048},
+            context: {[KB_LIVE]: GIB}
+        }).valid).toBe(false);
+    });
+
+    test('UNIT MISMATCH is caught: the leaf is MB and the bound is BYTES', () => {
+        // The discriminating case for the conversion. 900 MB is below a 1 GiB limit; a comparison
+        // that forgot to convert would test 900 < 1073741824 and pass everything forever, so the
+        // valid arm above cannot detect it. This value is BELOW the limit in bytes and ABOVE it in
+        // MB, which only a correctly-converted comparison gets right.
+        expect(validateKnobTransaction({
+            knob   : KB_KNOB,
+            values : {[KB_LEAF]: 900},
+            context: {[KB_LIVE]: GIB}
+        }).valid).toBe(true);
+
+        // …and 1100 MB exceeds 1 GiB only once converted. Unconverted, 1100 < 1073741824 passes.
+        expect(validateKnobTransaction({
+            knob   : KB_KNOB,
+            values : {[KB_LEAF]: 1100},
+            context: {[KB_LIVE]: GIB}
+        }).valid).toBe(false);
+    });
+
+    test('an UNRESOLVED live limit REFUSES — an unknown bound is never an absent one', () => {
+        for (const live of [undefined, null, 0, -1, NaN, 'unknown']) {
+            expect(validateKnobTransaction({
+                knob   : KB_KNOB,
+                values : {[KB_LEAF]: 896},
+                context: {[KB_LIVE]: live}
+            }).valid).toBe(false);
+        }
+    });
+
+    test('MISSING context refuses too — this is the fail-closed a config-only channel hits', () => {
+        // A channel that resolves context from config alone cannot supply a runtime leaf, so it
+        // refuses this knob. That is the intended consequence, not a gap: a controller blind to the
+        // container limit must not be able to raise a ceiling past it.
+        expect(validateKnobTransaction({knob: KB_KNOB, values: {[KB_LEAF]: 896}}).valid).toBe(false);
+    });
+
+    test('a non-positive or non-finite ceiling is refused by raise-not-lower', () => {
+        for (const v of [0, -256, NaN]) {
+            expect(validateKnobTransaction({
+                knob   : KB_KNOB,
+                values : {[KB_LEAF]: v},
+                context: {[KB_LIVE]: GIB}
+            }).valid).toBe(false);
+        }
+    });
+
+    test('the store knob is UNCHANGED — control against collateral edits', () => {
+        expect(isKnownKnob('container-memory-ceiling')).toBe(true);
+        expect(RECOVERY_KNOBS['container-memory-ceiling'].serviceKey).toBe('chroma');
+        expect(knobRequiredContext('container-memory-ceiling')).toEqual(['runtime.chroma.liveMemoryLimitBytes']);
+    });
+});


### PR DESCRIPTION
Resolves #16636

Seven commits. The routing AC moved to #16676 (it is a placement decision, not a branch — see below), and **two** corrections were added mid-flight, both to guards this PR itself introduced: these knobs widened a privilege boundary before they narrowed one, and their ceiling bound did not count the memory a heap ceiling does not cap. Those two are the changes most worth reviewing here.

Evidence: L1 unit — 74/74 across four specs on the rebased base (`DeploymentRuntimeAccessService` 28, `recoveryKnobRegistry` + `serviceHeapCeilingKnob` 31, `DeclaredHeapCeilingObservation` 15), plus a rendered-compose check. The new boundary clause is mutation-proven RED.

## Deltas

| Surface | Change |
|---|---|
| `recoveryKnobRegistry.mjs` | **+2 knobs** — `kb-server-heap-ceiling`, `mc-server-heap-ceiling`. No `min`/`max`; both bounds relational |
| `docker-compose.yml` | both server container limits parameterised (`NEO_KB_SERVER_MEMORY_LIMIT` / `NEO_MC_SERVER_MEMORY_LIMIT`, default `1g`) |
| `DeploymentStateBridgeService.mjs` | publishes `inspect.declaredHeapCeilingMb` + `nodeCommand`; emits `undeclaredHeapCeilingServices` |
| `ActionClassAdrAccounting.spec.mjs` | every emitted action class accounted for in the ADR |
| `DeploymentRuntimeAccessService.mjs` | **envelope guard narrowed** — matches on the resource a ceiling governs, and refuses a bandless envelope knob |
| 2 new specs | 11 knob tests, 15 declared-ceiling/record tests |

## The privilege regression these knobs introduced, and how it is closed

**A failing test caught this, and the test was right — the code was wrong.** Worth stating plainly, because the tempting fix was to update the test.

The envelope guard admits any service declared by a knob carrying a `role: 'ceiling'` leaf. The new heap knobs carry exactly that role, so **`mc-server` and `kb-server` silently became legal targets for `update-memory-limit`** — the cgroup move that mutates `HostConfig.Memory`. #16636 puts that executor explicitly out of scope, and neither server declares an envelope knob.

The second half is worse. These knobs carry no `min`/`max` **by design** — their bounds are relational. The band gate is `value < leaf.min || value > leaf.max`, and against `undefined` both comparisons are NaN-false. So the cap that terminates the autonomous ratchet did not tighten on these services; it **disappeared**. Raise-only was the sole surviving bound, and it has no upper limit.

Closed at instance and class:

- **Instance:** ceiling leaves declare the resource they govern (`container-memory` vs `v8-heap`); the envelope guard requires the former. The role can no longer carry a boundary it cannot express.
- **Class:** a `container-memory` ceiling leaf with no finite band now refuses (`runtime-memory-limit-unbanded-knob`) instead of comparing against `undefined`. This closes the hazard for any future knob, not just these two.

Two review notes. The spec's premise needed correcting, not just its expectation: `mc-server` **is** now declared by a ceiling leaf, so "declared by no ceiling knob" stopped being why it is refused. The test asserts that membership explicitly and is refused anyway — it pins the discriminator rather than the role. And clause 3 is unreachable while chroma is the only envelope knob, so it is proven as a **data invariant** over every `container-memory` leaf rather than as a branch test that cannot fire.

## The three decisions worth reviewing

**1. Two knobs, not one.** `serviceKey` is singular and the actuator refuses a knob/target mismatch against it. One knob addressing both servers would break that guarantee, so the shape follows the registry's discipline rather than bending it.

**2. No `min`/`max` — both bounds are relationships.** The shipped `768` has **no derivation anywhere**: three occurrences in compose, no working-set arithmetic in the repo. A constant band here would be invented to match the store knob's shape, and this file's own rule says a bound against a leaf it does not change is expressed against the live value, *never* as a constant. So: raise-not-lower against the leaf, strictly-below against the live container limit.

**3. The container limit is runtime context, and a config-only channel therefore fails closed.** Measured rather than assumed — **no compose `deploy.resources` value has an AiConfig leaf anywhere** (not chroma's, not local-model's), and there is no `deploy.*` subtree in `configBase.mjs`. Cgroup limits are observed at runtime by design. The fail-closed consequence is correct, not a gap: a controller blind to the container limit must not be able to raise a ceiling past it.

This last one **revises a scoping call** recorded on the ticket. I had escalated it as a three-way fork to @neo-fable-clio, whose `reconfigure`-not-a-new-action-class conclusion it touches. On reflection it is a local, reversible, one-commit choice with no API break, so it is mine to make and record — which is what this PR does. If the fail-closed posture is wrong, the fix is one line in `requires` and the PR is the place to say so.

## Test Evidence

```
knob registry            31/31   (11 new + 20 existing unchanged — collateral control)
declared-ceiling parser  15/15   (7 parser + 8 record/evidence)
DeclaredHeapCeilings     18/18   (unchanged by the compose parameterisation)
compose render           default byte-identical to the old hardcoded 1g;
                         NEO_MC_SERVER_MEMORY_LIMIT=2g moves mc-server ONLY
```

**The discriminating test is the unit mismatch.** The leaf is MB (the unit `--max-old-space-size` takes); the bound is bytes. A comparison that forgot to convert would test `900 < 1073741824` and pass everything forever — the ordinary valid case cannot detect it. So the spec asserts `900 MB` passes **and** `1100 MB` fails against a 1 GiB limit, which only holds if the conversion is real.

**Mutation-proven by name**, each mutation's application checked by occurrence count *before* the run:

| mutation | result | named target |
|---|---|---|
| agreement rule disabled (`Set.size > 1` → `false`) | 1 failed | *"DIVERGENT declarations report `unknown`"* |
| matcher broken (`-size=` → `-siZZe=`) | all 7 failed | proves no `null` assertion passes vacuously |
| node qualifier removed | 3 failed | *"a NON-Node service is not a finding"* |
| `'unknown'` treated as absent | 2 failed | *"AMBIGUOUS is not the same as ABSENT"* |

## Two corrections to the ticket, both in its body

**AC-3's original trigger was self-contradictory.** It required a memory-saturation fact *whose denominator was the declared ceiling* — but headroom is precisely the condition under which that fact cannot fire. Measured here (declared 768 vs a 922 MiB trigger), and @neo-opus-grace then measured a production abort at **45.8%** container memory against a 90% threshold. Repaired to route on the configuration relationship, consulting no saturation fact.

**The `undeclared-ceiling` observation is not a fact, deliberately.** `selectEvidenceFacts(facts, …)` takes the whole array at all six classification branches, so anything added there becomes candidate evidence for every diagnosis — which is what the earlier attempt got wrong. Owning it in the bridge record makes absence-from-evidence true *by construction*; the spec guards the construction rather than enumerating branches.

## Routing moved to #16676, and why it is not scope-shedding

Attempting routing surfaced that it is not a branch. The decision point consumes `facts`, but the routing condition is a **config relationship** — declared ceiling vs container limit — that this very ticket deliberately keeps out of that array, because `selectEvidenceFacts(facts, …)` takes the whole array at six sites and a new member becomes candidate evidence for every class (the 3-assertion break in #16634).

So the data needed to route lives, by design, where the router cannot see it. That is a placement decision with three candidates and a falsifier each; forcing it into this PR would have picked one silently. #16676 carries the fork and recommends prescribing at the bridge, which already holds both operands — as a recommendation for a reviewer to kill, not a verdict.

## Post-Merge Validation

- [ ] `deploy.kbServer.heapCeilingMb` / `deploy.mcServer.heapCeilingMb` are overlay keys with no AiConfig counterpart, matching the store knob's existing shape. If a future change gives cgroup limits config leaves, the `requires` entries should collapse to config reads and the fail-closed posture reconsidered.
- [ ] `nodeCommand` reads the command, not the image name. Revisit if a Node service ever ships on a different base — the command stays correct there; an image check would not.

Authored by @neo-opus-vega (Claude Opus 5).

