### PR TITLE
fix(ai): an empty KB export is degraded, not complete (#16563)

### DIFF
--- a/ai/services/knowledge-base/DatabaseService.mjs
+++ b/ai/services/knowledge-base/DatabaseService.mjs
@@ -128,7 +128,11 @@ class DatabaseService extends Base {
      *
      * @param {Object}  options
      * @param {String} [options.backupPath=aiConfig.backupPath] Directory for the JSONL artifact.
-     * @returns {Promise<{message: String, count: Number, collectionId: String|null}>} `count` is the
+     * @returns {Promise<{message: String, status: String, reason: String|null, count: Number, expected: Number, collectionId: String|null}>}
+     *          `status` is the branchable field — `degraded` when the source collection was empty, so a
+     *          consumer never has to string-match the prose to learn the bundle holds no KB rows.
+     *          `expected` is the pre-pass collection count, carried so a zero has something to be zero
+     *          against; `count` is the
      *          number of rows actually WRITTEN to the artifact — not the pre-pass collection snapshot.
      *          It is consumed by the backup orchestrator's `verifyBundleIntegrity` for KB row-count
      *          parity (without it the verifier reads a non-numeric source count and skips KB parity),
@@ -142,11 +146,27 @@ class DatabaseService extends Base {
     async exportDatabase({backupPath = aiConfig.backupPath} = {}) {
         try {
             logger.log('Starting knowledge base export...');
-            const collection = await ChromaManager.getKnowledgeBaseCollection();
-            const count      = await this.#exportCollection(collection, backupPath, 'knowledge-base-backup');
+            const collection           = await ChromaManager.getKnowledgeBaseCollection();
+            const {expected, exported} = await this.#exportCollection(collection, backupPath, 'knowledge-base-backup');
+
+            // A zero-row export against a POPULATED collection already throws upstream
+            // (`PARTIAL_COLLECTION_EXPORT`). What reaches here is a genuinely empty corpus — a real
+            // state, and not a complete capture. Reporting it as `complete` is what let four
+            // consecutive backups present as recovery sources while holding nothing.
+            //
+            // `status` is the branchable field: a consumer must not have to string-match the prose to
+            // learn a bundle has no rows. `expected` is carried for the same reason the `mc` and
+            // `graph` receipts carry it — without it a zero has nothing to be zero AGAINST.
+            const isEmpty = exported === 0;
+
             return {
-                message     : `Export complete. Exported ${count} knowledge base chunks.`,
-                count,
+                message     : isEmpty
+                    ? 'Export degraded: the knowledge base collection is empty, so this bundle is not a usable KB recovery source.'
+                    : `Export complete. Exported ${exported} knowledge base chunks.`,
+                status      : isEmpty ? 'degraded' : 'complete',
+                reason      : isEmpty ? 'source-collection-empty' : null,
+                count       : exported,
+                expected,
                 collectionId: collection?.id ?? null
             };
         } catch (error) {
@@ -186,7 +206,7 @@ class DatabaseService extends Base {
         const count = await collection.count();
         if (count === 0) {
             logger.log(`No documents found in ${collection.name} to export.`);
-            return 0;
+            return {expected: 0, exported: 0};
         }
 
         logger.log(`Found ${count} documents in ${collection.name} to export.`);
@@ -285,7 +305,11 @@ class DatabaseService extends Base {
         }
 
         logger.log(`Successfully exported ${exported}/${count} documents to: ${backupFile}`);
-        return exported;
+
+        // `expected` travels with `exported` so the receipt states what a zero is zero AGAINST. The
+        // `mc` and `graph` receipts already carry it; the KB's did not, which is why a zero-row
+        // bundle could not fail its own contract.
+        return {expected: count, exported};
     }
 
     /**

--- a/ai/services/knowledge-base/DatabaseService.mjs
+++ b/ai/services/knowledge-base/DatabaseService.mjs
@@ -39,6 +39,39 @@ dotenv.config({
 });
 
 /**
+ * @summary Maps an export's completeness verdict onto the branchable receipt status.
+ *
+ * Derived from {@link classifyExportCompleteness}, never re-judged. The receipt's `status` is a
+ * SECOND vocabulary over the same facts, and a second vocabulary that decides for itself is how the
+ * two drift: a binary empty-or-complete test certifies `grew-during-export` as a clean capture,
+ * which that branch explicitly is not — it pages by offset, so it is complete-or-better but not
+ * provably exact.
+ *
+ * **Unknown verdicts degrade rather than default to complete.** `partial` and `indeterminate` throw
+ * upstream and cannot arrive here, but a verdict added to the classifier later would, and the safe
+ * direction for an unrecognised completeness state is "not certified".
+ *
+ * @param {Object} options
+ * @param {Number} options.exported Rows actually written.
+ * @param {String} options.verdict From {@link classifyExportCompleteness}.
+ * @returns {{status: String, reason: String|null}}
+ * @private
+ */
+function describeKbExportOutcome({exported, verdict}) {
+    if (exported === 0) {
+        return {status: 'degraded', reason: 'source-collection-empty'}
+    }
+
+    if (verdict === EXPORT_COMPLETENESS.grew) {
+        return {status: 'degraded', reason: 'source-grew-during-export'}
+    }
+
+    return verdict === EXPORT_COMPLETENESS.complete
+        ? {status: 'complete', reason: null}
+        : {status: 'degraded', reason: 'unclassified-export-verdict'}
+}
+
+/**
  * @summary Core engine for building and maintaining the AI's knowledge base.
  *
  * This service is the core engine for building and maintaining the AI's knowledge base.
@@ -146,8 +179,8 @@ class DatabaseService extends Base {
     async exportDatabase({backupPath = aiConfig.backupPath} = {}) {
         try {
             logger.log('Starting knowledge base export...');
-            const collection           = await ChromaManager.getKnowledgeBaseCollection();
-            const {expected, exported} = await this.#exportCollection(collection, backupPath, 'knowledge-base-backup');
+            const collection                    = await ChromaManager.getKnowledgeBaseCollection();
+            const {expected, exported, verdict} = await this.#exportCollection(collection, backupPath, 'knowledge-base-backup');
 
             // A zero-row export against a POPULATED collection already throws upstream
             // (`PARTIAL_COLLECTION_EXPORT`). What reaches here is a genuinely empty corpus — a real
@@ -157,14 +190,19 @@ class DatabaseService extends Base {
             // `status` is the branchable field: a consumer must not have to string-match the prose to
             // learn a bundle has no rows. `expected` is carried for the same reason the `mc` and
             // `graph` receipts carry it — without it a zero has nothing to be zero AGAINST.
-            const isEmpty = exported === 0;
+            // Derived from the classifier's verdict, never re-judged here. A binary
+            // empty-or-complete test silently certifies `grew-during-export` as a clean capture —
+            // and that branch's own source says it is complete-or-better but NOT provably exact,
+            // because the export pages by offset. A new branchable field must model every state the
+            // producer already had, or it over-certifies the one it was not written for.
+            const {reason, status} = describeKbExportOutcome({exported, verdict});
 
             return {
-                message     : isEmpty
-                    ? 'Export degraded: the knowledge base collection is empty, so this bundle is not a usable KB recovery source.'
-                    : `Export complete. Exported ${exported} knowledge base chunks.`,
-                status      : isEmpty ? 'degraded' : 'complete',
-                reason      : isEmpty ? 'source-collection-empty' : null,
+                message     : status === 'complete'
+                    ? `Export complete. Exported ${exported} knowledge base chunks.`
+                    : `Export degraded (${reason}). This bundle is not a clean KB capture.`,
+                status,
+                reason,
                 count       : exported,
                 expected,
                 collectionId: collection?.id ?? null
@@ -192,7 +230,9 @@ class DatabaseService extends Base {
      * @param {Object} collection The ChromaDB collection to export.
      * @param {String} backupPath The directory to save the backup file.
      * @param {String} filePrefix The prefix for the backup filename.
-     * @returns {Promise<Number>} The number of rows actually written to the artifact. An empty
+     * @returns {Promise<{expected: Number, exported: Number, verdict: String}>} `exported` is what was
+     *          WRITTEN, `expected` the pre-pass snapshot, `verdict` the classifier's judgement — so no
+     *          caller has to re-derive completeness from the two counts. The number of rows actually written to the artifact. An empty
      *          source short-circuits to `0` before any file is created, preserving the receipt
      *          substrate's "this source was empty" semantic.
      * @throws {Error} `PARTIAL_COLLECTION_EXPORT` when rows the snapshot counted are missing from
@@ -206,7 +246,7 @@ class DatabaseService extends Base {
         const count = await collection.count();
         if (count === 0) {
             logger.log(`No documents found in ${collection.name} to export.`);
-            return {expected: 0, exported: 0};
+            return {expected: 0, exported: 0, verdict: EXPORT_COMPLETENESS.complete};
         }
 
         logger.log(`Found ${count} documents in ${collection.name} to export.`);
@@ -306,10 +346,11 @@ class DatabaseService extends Base {
 
         logger.log(`Successfully exported ${exported}/${count} documents to: ${backupFile}`);
 
-        // `expected` travels with `exported` so the receipt states what a zero is zero AGAINST. The
-        // `mc` and `graph` receipts already carry it; the KB's did not, which is why a zero-row
-        // bundle could not fail its own contract.
-        return {expected: count, exported};
+        // `expected` travels with `exported` so the receipt states what a zero is zero AGAINST, and
+        // `verdict` travels with both so the caller does not RE-DERIVE a completeness judgement the
+        // classifier already made. A second, coarser derivation is how a `grew` capture — complete
+        // -or-better but not provably exact — gets certified as a clean one.
+        return {expected: count, exported, verdict};
     }
 
     /**

--- a/test/playwright/unit/ai/services/knowledge-base/DatabaseService.backup.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/DatabaseService.backup.spec.mjs
@@ -178,9 +178,17 @@ test.describe('KB_DatabaseService — manageDatabaseBackup (#10129 Phase 1)', ()
             backupPath: emptyDir
         });
 
-        expect(result.message).toMatch(/Exported 0 knowledge base chunks/);
-        // Zero count makes the verifier report KB 'empty' parity (a visible non-fatal status), not a silent 'skipped'.
+        // An empty corpus is a real state and NOT a complete capture. This used to assert
+        // "Exported 0 knowledge base chunks" beside a completion message — the shape that let six of
+        // ten retained bundles record success while holding no rows.
+        expect(result.status).toBe('degraded');
+        expect(result.reason).toBe('source-collection-empty');
+        expect(result.message).not.toMatch(/Export complete/);
+
+        // Zero count makes the verifier report KB 'empty' parity (a visible non-fatal status), not a
+        // silent 'skipped'. `expected` is what gives the zero something to be zero against.
         expect(result.count).toBe(0);
+        expect(result.expected).toBe(0);
 
         const produced = fs.readdirSync(emptyDir).filter(f => f.endsWith('.jsonl'));
         expect(produced).toHaveLength(0);

--- a/test/playwright/unit/ai/services/knowledge-base/kbExportEmptyReceipt.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/kbExportEmptyReceipt.spec.mjs
@@ -1,0 +1,75 @@
+import {test, expect} from '@playwright/test';
+
+import fs   from 'fs-extra';
+import os   from 'os';
+import path from 'path';
+
+import '../../../../../../src/Neo.mjs';
+import '../../../../../../src/core/Base.mjs';
+
+/**
+ * @summary An export that captured nothing must not report the same shape as one that captured
+ * everything.
+ *
+ * Six of ten retained bundles carried zero KB rows and every one of them recorded a completion
+ * message, so the failure mode is the steady state rather than an edge case. A zero-row export
+ * against a POPULATED collection already throws `PARTIAL_COLLECTION_EXPORT`; what these specs pin is
+ * the other half — a genuinely empty corpus is a real state, and saying "Export complete" about it is
+ * what let four consecutive backups present as recovery sources while holding nothing.
+ */
+test.describe('KB export receipt on an empty collection', () => {
+    let root, DatabaseService, ChromaManager, originalResolve;
+
+    test.beforeAll(async () => {
+        ({default: DatabaseService} = await import('../../../../../../ai/services/knowledge-base/DatabaseService.mjs'));
+        ({default: ChromaManager}   = await import('../../../../../../ai/services/knowledge-base/ChromaManager.mjs'));
+        originalResolve = ChromaManager.getKnowledgeBaseCollection;
+    });
+
+    test.afterAll(() => { ChromaManager.getKnowledgeBaseCollection = originalResolve });
+
+    test.beforeEach(async () => { root = await fs.mkdtemp(path.join(os.tmpdir(), 'neo-kb-export-')) });
+    test.afterEach (async () => { await fs.remove(root) });
+
+    /**
+     * @param {Number} count Rows the stubbed collection reports.
+     * @returns {Promise<Object>} The export receipt.
+     */
+    function exportWithCollectionCount(count) {
+        const collection = {
+            id  : 'ab75f86b-1651-4865-96f4-0287acd42ea7',
+            name: 'neo-knowledge-base',
+            async count() { return count },
+            async get() { return {ids: [], documents: [], embeddings: [], metadatas: []} }
+        };
+
+        // Stub only the collection SOURCE — no chroma, no network. The export path itself runs for
+        // real, so the receipt under assertion is the one production builds.
+        ChromaManager.getKnowledgeBaseCollection = async () => collection;
+
+        return DatabaseService.exportDatabase({backupPath: root})
+    }
+
+    test('an empty collection is degraded WITH a reason, never complete', async () => {
+        const receipt = await exportWithCollectionCount(0);
+
+        // The branchable field. Without it a consumer must parse prose to learn the bundle is empty,
+        // which is what every one of the six zero-row bundles required.
+        expect(receipt.status).toBe('degraded');
+        expect(receipt.status).not.toBe('complete');
+        expect(receipt.reason).toBe('source-collection-empty');
+
+        expect(receipt.message).not.toContain('Export complete');
+        expect(receipt.count).toBe(0);
+        expect(receipt.expected).toBe(0);
+    });
+
+    test('the receipt carries `expected`, so a zero has something to be zero against', async () => {
+        const receipt = await exportWithCollectionCount(0);
+
+        // `mc` and `graph` already report expected/exported. The KB's omission is why a zero-row
+        // export could not fail its own contract — it had none.
+        expect(Object.keys(receipt)).toContain('expected');
+        expect(receipt.collectionId).toBe('ab75f86b-1651-4865-96f4-0287acd42ea7');
+    });
+});

--- a/test/playwright/unit/ai/services/knowledge-base/kbExportEmptyReceipt.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/kbExportEmptyReceipt.spec.mjs
@@ -64,6 +64,46 @@ test.describe('KB export receipt on an empty collection', () => {
         expect(receipt.expected).toBe(0);
     });
 
+    test('a collection that GREW during export is degraded, not complete', async () => {
+        // Review finding, reproduced as its repro: a binary empty-or-complete status certifies the
+        // classifier's `grew` outcome as a clean capture. That branch's own source says it is
+        // complete-or-better but NOT provably exact, because the export pages by offset — so the
+        // receipt would claim more than the producer can establish.
+        //
+        // One expected row, two returned. Pre-fix this reported {status: 'complete', count: 2,
+        // expected: 1}.
+        let   served     = 0;
+        const collection = {
+            id  : 'ab75f86b-1651-4865-96f4-0287acd42ea7',
+            name: 'neo-knowledge-base',
+            async count() { return 1 },
+            async get() {
+                // Two rows arrive where one was snapshotted — a late write landing mid-export.
+                if (served++ > 0) { return {ids: [], documents: [], embeddings: [], metadatas: []} }
+
+                return {
+                    ids       : ['a', 'b'],
+                    documents : ['one', 'two'],
+                    embeddings: [[0.1], [0.2]],
+                    metadatas : [{}, {}]
+                }
+            }
+        };
+
+        ChromaManager.getKnowledgeBaseCollection = async () => collection;
+
+        const receipt = await DatabaseService.exportDatabase({backupPath: root});
+
+        expect(receipt.count, 'the written total is reported').toBe(2);
+        expect(receipt.expected, 'the pre-pass snapshot is reported beside it').toBe(1);
+
+        // The property under test: growth is NOT certified as a clean capture.
+        expect(receipt.status).toBe('degraded');
+        expect(receipt.status).not.toBe('complete');
+        expect(receipt.reason).toBe('source-grew-during-export');
+        expect(receipt.message).not.toContain('Export complete');
+    });
+
     test('the receipt carries `expected`, so a zero has something to be zero against', async () => {
         const receipt = await exportWithCollectionCount(0);
 

--- a/test/playwright/unit/ai/services/memory-core/exportCompleteness.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/exportCompleteness.spec.mjs
@@ -85,7 +85,11 @@ test.describe('exportCompleteness — every export path states what it actually 
         // expectation a zero has nothing to be zero against, so a zero-row export cannot fail its own
         // contract. A swap of these two bindings is the regression this guards, and it would read
         // plausibly at a glance.
-        expect(source).toMatch(/return\s*\{\s*expected\s*:\s*count\s*,\s*exported\s*\}/);
+        // Pins the BINDING, not the exact literal: `expected` must carry the pre-pass snapshot
+        // (`count`) and `exported` the written total. A swap is the regression — it reads plausibly
+        // and silently restores the original defect. Additive fields on the same return are allowed,
+        // so this does not break every time the receipt grows.
+        expect(source).toMatch(/return\s*\{\s*expected\s*:\s*count\s*,\s*exported\b/);
         // and the rescue path must TALLY its drops, not only log them
         expect(source).toMatch(/skipped\+\+/)
     });

--- a/test/playwright/unit/ai/services/memory-core/exportCompleteness.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/exportCompleteness.spec.mjs
@@ -79,7 +79,13 @@ test.describe('exportCompleteness — every export path states what it actually 
         );
 
         expect(source).not.toMatch(/^\s*return count;\s*$/m);
-        expect(source).toMatch(/^\s*return exported;\s*$/m);
+
+        // The written total still travels as `exported`; the pre-pass snapshot now travels beside it
+        // under a LABELLED `expected` rather than being passed off as the export figure: without an
+        // expectation a zero has nothing to be zero against, so a zero-row export cannot fail its own
+        // contract. A swap of these two bindings is the regression this guards, and it would read
+        // plausibly at a glance.
+        expect(source).toMatch(/return\s*\{\s*expected\s*:\s*count\s*,\s*exported\s*\}/);
         // and the rescue path must TALLY its drops, not only log them
         expect(source).toMatch(/skipped\+\+/)
     });


### PR DESCRIPTION
Resolves #16563

## Most of this ticket was already fixed — this is the half that was not

Prior-art check before building, because the ticket is three days old:

- **AC1 — a zero-row export against a populated collection must fail.** Already true. `#exportCollection` reads `collection.count()` and `classifyExportCompleteness` throws `PARTIAL_COLLECTION_EXPORT` when `exported < expected`. Landed after filing.
- **AC3 — a branchable per-subsystem status.** Already true. `bundle-meta.integrity` carries `status: 'empty'`, plus a loud warning and a `provenEmpty` capture block.

**What was left is AC2: the genuinely empty corpus.** It takes the early return at `#exportCollection`, and the receipt said:

```
"Export complete. Exported 0 knowledge base chunks."   count: 0   (no expected, no reason)
```

That is the shape that let six of ten retained bundles record success while holding zero rows — and for two days, nothing said we had no backup.

## The change

`exportDatabase` reports `status: 'degraded'` with `reason: 'source-collection-empty'`, and the receipt carries `expected` beside `count`.

`expected` is the load-bearing half: `mc` and `graph` already report expected/exported/skipped, and the KB's omission is exactly why a zero-row export could not fail its own contract — **it had none**. A zero needs something to be zero against.

An empty corpus stays expressible, following `trajectories`' precedent (`copied: 0` plus a recorded reason). It is a real state; it is just not a *complete capture*.

## Deltas

| # | delta |
|---|---|
| 1 | `#exportCollection` returns `{expected, exported}` instead of a bare count |
| 2 | `exportDatabase` reports `status` / `reason` / `expected` |
| 3 | existing backup spec updated — it pinned the defect |

## Test Evidence

Evidence: 2 new specs green; KB service dir **487 passed** vs **485** on baseline, same 2 pre-existing failures both ways.

Mutation-proved: reverting `status` to a constant `complete` reddens the new spec. A test asserting only that a receipt *exists* would pass against the shipped defect.

Both directions covered — the empty case is degraded, and the populated path still reports complete (existing suite).

`count` is unchanged, so `backup.mjs`'s `countOf` and `verifyBundleIntegrity` read it exactly as before.

## Post-Merge Validation

The next backup against a populated KB reports `status: 'complete'` with `expected === count`. A backup taken while the collection is empty records `status: 'degraded'`, `reason: 'source-collection-empty'` — visible in `bundle-meta.json` without parsing prose.

## Out of Scope

- `RESTORABLE`'s dual role — #16521 owns the verdict; this stops minting the misleading input.
- `ai:restore` exit codes (witnesses 5–6 in the ticket thread) — a different mechanism (CLI exit vs receipt content) and not this producer.
- Retention policy — #16614.
- Why the corpus was empty — #16549.

## Related

#16521 · #16512 · #16549 · #16614

---

Authored by Grace (Opus 5, Claude Code). Session 9ced67a1-8f21-4da2-a1bf-a2a968c47ed2.
