### PR TITLE
fix(ai): the plane assertion states what it cannot detect (#16662)

### DIFF
--- a/ai/daemons/orchestrator/daemon.mjs
+++ b/ai/daemons/orchestrator/daemon.mjs
@@ -256,6 +256,10 @@ export function assertOrchestratorPlane({aiConfig = AiConfig, rootDir = REPO_ROO
         throw new Error('[Orchestrator] booted without a resolved `plane` subtree — Tier-1 config not loaded?');
     }
 
+    // Guards overlay-onto-durable mutation. It does NOT guard against serving the wrong store:
+    // `canonicalDataRoot` is derived from this module's own location, so a daemon booted from the
+    // wrong checkout computes a canonical that agrees with itself and passes. See the CANNOT-detect
+    // section on `assertPlaneCoherence` — divergence needs a served-root fact from outside.
     const observed = assertPlaneCoherence({
         planeId          : plane.id,
         dataRoot         : plane.dataRoot,

--- a/ai/mcp/server/BaseServer.mjs
+++ b/ai/mcp/server/BaseServer.mjs
@@ -665,6 +665,9 @@ class BaseServer extends Base {
                 `[${this.className}] declared plane member resolved no \`plane\` subtree — Tier-1 config not loaded?`
             );
         }
+        // Guards overlay-onto-durable mutation, NOT wrong-store service: a server booted from a
+        // different checkout resolves a self-consistent canonical and passes this. See the
+        // CANNOT-detect section on `assertPlaneCoherence`.
         const observed = assertPlaneCoherence({
             planeId : plane.id,
             dataRoot: plane.dataRoot,

--- a/ai/planeConfig.mjs
+++ b/ai/planeConfig.mjs
@@ -152,6 +152,35 @@ function realpathOrResolve(p) {
  * 3. A NON-canonical `planeId` (a declared overlay) must not resolve — symlink-transparently —
  *    to the canonical durable root: identity-without-isolation would mutate the durable plane.
  *
+ * ## What this CANNOT detect — read before treating a call site as protected
+ *
+ * Clause 3 is a **collision** test: a non-canonical identity resolving ONTO the canonical root.
+ * It is not, and cannot be, a **divergence** test — a canonical identity resolving AWAY from the
+ * root the deployment actually serves.
+ *
+ * Two structural reasons, both load-bearing:
+ *
+ * 1. `planeId !== canonicalPlaneId` short-circuits before the root comparison, so a process
+ *    claiming the canonical identity never reaches clause 3 at all.
+ * 2. There is no served-root fact here to compare against. Callers derive `canonicalDataRoot`
+ *    from their own module location, so a process booted from the wrong checkout computes a
+ *    canonical that agrees with itself perfectly and passes. Supplying the true served root as
+ *    `canonicalDataRoot` does NOT help: clause 3 still never runs for a canonical identity.
+ *
+ * The measured shapes:
+ *
+ * ```
+ * THROWS  overlay id + dataRoot collides with canonical root   <- the hazard it was built for
+ * PASS    canonical id, dataRoot = orphan, canonical = orphan  <- what a wrong-checkout boot passes
+ * PASS    canonical id, dataRoot = orphan, canonical = SERVED  <- injecting the true root does not help
+ * PASS    overlay id,   roots DIVERGE                          <- divergence is not expressible
+ * ```
+ *
+ * **Consequence:** a caller that runs this at boot is protected against overlay-onto-durable
+ * mutation and is NOT protected against serving the wrong store. Do not read a call to this as
+ * coverage for the second. Detecting divergence requires a served-root fact supplied from OUTSIDE
+ * the process — never re-derived from `import.meta.url`, since that self-derivation is the defect.
+ *
  * Pure and injectable (no Neo import): entrypoints assert provider-resolved values;
  * non-entrypoints may assert twin-resolved values.
  * @param {Object} options

--- a/ai/scripts/diagnostics/walSnapshotClone.mjs
+++ b/ai/scripts/diagnostics/walSnapshotClone.mjs
@@ -148,8 +148,8 @@ export function planSnapshotClone({
         return refuse(
             `overlayPlaneId "${overlayPlaneId}" is the canonical plane identity — a snapshot clone must ` +
             'declare a DISTINCT overlay identity. Reusing it would leave two planes claiming to be ' +
-            'canonical, which planeConfig.assertPlaneCoherence cannot detect: its overlay clause only ' +
-            'inspects non-canonical identities.'
+            'canonical, which planeConfig.assertPlaneCoherence cannot detect — see the CANNOT-detect ' +
+            'section there, which now owns this limitation for all callers.'
         );
     }
 

--- a/ai/scripts/diagnostics/walSnapshotClone.mjs
+++ b/ai/scripts/diagnostics/walSnapshotClone.mjs
@@ -148,8 +148,8 @@ export function planSnapshotClone({
         return refuse(
             `overlayPlaneId "${overlayPlaneId}" is the canonical plane identity — a snapshot clone must ` +
             'declare a DISTINCT overlay identity. Reusing it would leave two planes claiming to be ' +
-            'canonical, which planeConfig.assertPlaneCoherence cannot detect — see the CANNOT-detect ' +
-            'section there, which now owns this limitation for all callers.'
+            'canonical, which planeConfig.assertPlaneCoherence cannot detect: its overlay clause only ' +
+            'inspects non-canonical identities. Its CANNOT-detect section carries the full boundary.'
         );
     }
 

--- a/test/playwright/unit/ai/planeConfig.spec.mjs
+++ b/test/playwright/unit/ai/planeConfig.spec.mjs
@@ -583,3 +583,65 @@ test.describe('⭐ one env ⇒ one resolved default across every declaring confi
         expect(new Set(converged.map(entry => entry.default)).size).toBe(1);
     })
 });
+
+test.describe('assertPlaneCoherence — the boundary of the clause, stated as tests', () => {
+    // The rationale on this function names "identity without isolation" as the hazard, and three
+    // write-path callers run it at boot. That reads as protection against serving the wrong store.
+    // It is not. Clause 3 is a COLLISION test (a non-canonical identity landing ON the canonical
+    // root); the wrong-checkout hazard is DIVERGENCE (a canonical identity landing AWAY from the
+    // root the deployment serves). These four rows pin that boundary so a future change cannot
+    // quietly widen the claim — or make the guard vacuous — without failing here.
+    const
+        SERVED = '/served/.neo-ai-data',
+        ORPHAN = '/wrong-checkout/.neo-ai-data',
+        // Identity resolver: no symlink layer, so realpath is identity. Injected rather than
+        // touching the filesystem — the clause compares resolved paths, not file contents.
+        idRealpath = value => value;
+
+    test('POSITIVE CONTROL: a non-canonical overlay resolving the canonical root still THROWS', () => {
+        // If this ever stops throwing the guard has become vacuous and the three rows below
+        // would pass for the wrong reason.
+        expect(() => assertPlaneCoherence({
+            planeId          : 'pilot',
+            dataRoot         : SERVED,
+            canonicalDataRoot: SERVED,
+            realpathFn       : idRealpath
+        })).toThrow(/resolves the durable root/);
+    });
+
+    test('a canonical identity on an orphan root PASSES — the wrong-checkout boot shape', () => {
+        // What a process booted from the wrong checkout actually passes: it claims the canonical
+        // identity and derives its canonical root from its own location, so both agree.
+        expect(assertPlaneCoherence({
+            planeId          : CANONICAL_PLANE_ID,
+            dataRoot         : ORPHAN,
+            canonicalDataRoot: ORPHAN,
+            realpathFn       : idRealpath
+        })).toEqual({planeId: CANONICAL_PLANE_ID, dataRoot: ORPHAN});
+    });
+
+    test('injecting the TRUE served root does NOT make it detectable', () => {
+        // The decisive row. A reader might assume the clause would fire if only it were handed the
+        // real served root. It does not: `planeId !== canonicalPlaneId` short-circuits first, so a
+        // canonical identity never reaches the root comparison at all. Direction-1 fixes therefore
+        // need a new clause, not better arguments to this one.
+        expect(assertPlaneCoherence({
+            planeId          : CANONICAL_PLANE_ID,
+            dataRoot         : ORPHAN,
+            canonicalDataRoot: SERVED,
+            realpathFn       : idRealpath
+        })).toEqual({planeId: CANONICAL_PLANE_ID, dataRoot: ORPHAN});
+    });
+
+    test('divergence is not expressible even for an overlay identity', () => {
+        // An overlay whose root DIVERGES from canonical passes — correctly, since divergence is
+        // not what clause 3 asks. Recorded so "it only fails for canonical ids" is not mistaken
+        // for the boundary; the boundary is collision-vs-divergence, not which identity.
+        expect(assertPlaneCoherence({
+            planeId          : 'host-edge',
+            dataRoot         : ORPHAN,
+            canonicalDataRoot: SERVED,
+            realpathFn       : idRealpath
+        })).toEqual({planeId: 'host-edge', dataRoot: ORPHAN});
+    })
+});


### PR DESCRIPTION
Resolves #16662

Three write-path callers run `assertPlaneCoherence` at boot and read as protected against serving the wrong store. They are not. Filed by @neo-opus-vega after he falsified my claim that this primitive covered #16526's hazard.

Evidence: L2 (the clause exercised directly across four shapes with an injected resolver; positive control verified RED against a stubbed clause). Residual: none.

## The finding

Clause 3 is a **collision** test — a non-canonical identity landing ON the canonical root. The wrong-checkout hazard is **divergence** — a canonical identity landing AWAY from the root the deployment serves. Different questions.

`planeId !== canonicalPlaneId` short-circuits before the root comparison, so a process claiming the canonical identity never reaches clause 3. **Injecting the true served root does not help.** Cannot-fail, not cannot-be-asked.

The mechanism, and the part worth carrying: callers derive `canonicalDataRoot` from their own module location, so **a process booted from the wrong checkout computes a canonical that agrees with itself perfectly.** Nothing is missing; everything resolves correctly into the wrong tree.

## Direction taken, since the ticket deliberately left it open

**Direction 2 — make it honest.** Direction 1 needs an externally-supplied served-root fact, and AC-4 rightly forbids re-deriving it from `import.meta.url` because a self-derived canonical *is* the defect. Whether such a fact exists at boot is a design question I should not settle alone. Meanwhile the ticket names the current state — three callers reading as protected — as the worst of the three. **This does not foreclose direction 1**; it removes the false coverage while that is decided.

## Contract Ledger

| Target Surface | Source of Authority | Behavior | Fallback / Error Semantics | Evidence |
|---|---|---|---|---|
| `assertPlaneCoherence` JSDoc | this PR | Gains a CANNOT-detect section: collision vs divergence, both structural reasons, the four measured shapes | **no behaviour change** — no clause added or altered | 4-row spec |
| `daemon.mjs:259` rationale | this PR | States it guards overlay-onto-durable, not wrong-store service | n/a | — |
| `BaseServer.mjs:668` rationale | this PR | Same | n/a | — |
| `walSnapshotClone.mjs` note | #16662 AC-3 | **Reconciled** — points at the primitive instead of restating the limitation | n/a | one place, not three |
| clause behaviour | existing | **UNCHANGED** | n/a | 43/43 spec green |

Decision Record impact: `none` — ADR-0019 §10.4's clause is described more completely, not amended.

## Deltas from ticket

1. **AC-3 resolved toward the primitive, not the call sites.** The ticket asks for the knowledge in one place; `walSnapshotClone` already had a copy, so the limitation moved *up* to `planeConfig.mjs` and that copy now points at it. Adding it to two more callers would have made three.
2. **AC-5's specimen is cited in the commit and PR rather than in durable comments** — the archaeology lint bans ticket refs in JSDoc, and the mechanism is stated in full where a reader meets it, so nothing depends on resolving an issue number.
3. **No divergence clause added.** That is direction 1 and needs the served-root fact.

## Test Evidence

```
npm run test-unit -- test/playwright/unit/ai/planeConfig.spec.mjs
  43 passed
```

Four rows, matching @neo-opus-vega's independent measurements exactly:

| shape | result |
|---|---|
| overlay id + collides with canonical root | **THROWS** — positive control |
| canonical id, dataRoot = orphan, canonical = orphan | PASS — the wrong-checkout boot |
| canonical id, dataRoot = orphan, canonical = **SERVED** | PASS — injecting the true root does not help |
| overlay id, roots **diverge** | PASS — divergence is not expressible |

**Positive control verified RED:** stubbing clause 3's condition to `false` fails it. So a future change cannot make the guard vacuous without the suite noticing — which is the whole point of retaining a passing-today control.

## Post-Merge Validation

- [ ] Direction 1 gets its own disposition: is a served-root fact available at boot from outside the process?
- [ ] If it lands, this CANNOT-detect section shrinks to the residual rather than being deleted wholesale.

Authored by Ada (Claude Opus 5, Claude Code). Session 9b08b9e4-6181-416b-ac68-e9d16636cff0.
