### PR TITLE
fix(deploy): require explicit composition (#16671)

### DIFF
--- a/ai/examples/cloud-deployment/deploy-pipeline.sh
+++ b/ai/examples/cloud-deployment/deploy-pipeline.sh
@@ -17,25 +17,20 @@
 #
 set -euo pipefail
 
-# Resolve the compose file from this script's location so the deployment is not
-# tied to the caller's working directory. Deploy from a STABLE host checkout —
-# the backup-bundle bind-mount is a relative path; see PipelineWiring.md.
+# Resolve sibling maintenance paths from the script location. This is not a Compose default: the
+# caller still has to name the deployment composition explicitly below.
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-# `$SCRIPT_DIR` is `ai/examples/cloud-deployment`, so `../..` is ALREADY `ai/` — re-adding `ai/`
-# here produced `ai/ai/deploy/...`, a path that has never existed. It went unnoticed because the
-# spec fakes `docker`, and a fake docker ignores `-f`, so a wrong compose path could not fail a
-# test. Any operator who did not set NEO_DEPLOY_COMPOSE_FILE was relying on a broken default.
-# UNSET and EXPLICITLY-EMPTY are different inputs and must not collapse. `${VAR:-default}` treats an
-# empty string as absent, so `NEO_DEPLOY_COMPOSE_FILE=""` would silently fall back to the base file —
-# deploying the base contract to a plane that needs an overlay, which is the exact failure the
-# zero-entry abort below exists to prevent. `${VAR+set}` tests whether the operator SUPPLIED the
-# variable, independent of its value, so an unset caller keeps the compatible default while a supplied
-# value is always honoured — and, when it resolves to nothing, refused rather than replaced.
-if [ -n "${NEO_DEPLOY_COMPOSE_FILE+set}" ]; then
-    COMPOSE_FILE="$NEO_DEPLOY_COMPOSE_FILE"
-else
-    COMPOSE_FILE="$SCRIPT_DIR/../../deploy/docker-compose.yml"
-fi
+
+# The reference pipeline cannot infer which deployment composition it owns. The base Compose file
+# supplies shared topology, but concrete planes add the auth/provider profile that makes that topology
+# runnable. Selecting the base file when the caller omitted this input therefore chooses an incomplete
+# security posture rather than a compatible default.
+#
+# Collapse UNSET and EXPLICITLY-EMPTY intentionally: both mean the caller named no deployment. The
+# zero-entry guard below rejects them before revision resolution, preflight, or Docker. A caller must
+# supply the plane's explicit file set, discovered from its Compose labels as described in
+# PipelineWiring.md.
+COMPOSE_FILE="${NEO_DEPLOY_COMPOSE_FILE:-}"
 
 # A real plane is rarely ONE compose file. The canonical local Agent OS runs `docker-compose.yml`
 # plus `docker-compose.local-agent-os.yml`, and a single `-f` silently drops the overlay — so the
@@ -46,7 +41,7 @@ fi
 # `NEO_DEPLOY_COMPOSE_FILE` therefore accepts a `:`-delimited LIST, matching Docker's own COMPOSE_FILE
 # convention, and expands to repeated `-f` in declaration order (later files override earlier ones,
 # which is Compose's merge order — reordering them changes the result). A single path is unchanged,
-# so every existing caller and every downstream adaptation keeps its exact behaviour.
+# so every explicit single-file caller and downstream adaptation keeps its exact behaviour.
 # `compose_file_count` is tracked separately because `${#compose_file_args[@]}` counts ARRAY ELEMENTS
 # — each file contributes both a `-f` and a path — so using it as a file count reports double. Caught
 # by the rehearsal witness printing "(4 file(s))" for two files.
@@ -60,7 +55,7 @@ while IFS= read -r compose_file_entry; do
 done <<< "$(printf '%s' "$COMPOSE_FILE" | tr ':' '\n')"
 
 if [ "$compose_file_count" -eq 0 ]; then
-    echo "[deploy] FATAL: NEO_DEPLOY_COMPOSE_FILE resolved to no usable path. Docker was NOT invoked." >&2
+    echo "[deploy] FATAL: NEO_DEPLOY_COMPOSE_FILE must name an ordered, auth-complete Compose file set. Docker was NOT invoked." >&2
     exit 1
 fi
 

--- a/learn/agentos/cloud-deployment/PipelineWiring.md
+++ b/learn/agentos/cloud-deployment/PipelineWiring.md
@@ -39,6 +39,7 @@ Avoid "deploy on every push to `dev`": it couples MCP availability to ordinary d
 
 ```bash
 # tag-triggered job: deploy the tag that fired it, not the default channel
+NEO_DEPLOY_COMPOSE_FILE="<base>.yml:<overlay>.yml" \
 NEO_REF="$CI_COMMIT_TAG" ai/examples/cloud-deployment/deploy-pipeline.sh
 ```
 

--- a/learn/agentos/cloud-deployment/PipelineWiring.md
+++ b/learn/agentos/cloud-deployment/PipelineWiring.md
@@ -154,9 +154,9 @@ The script is CI-neutral: it is meant to be invoked by a deployment's own job, a
 
 What *is* verifiable is a capability gap: until the change below, **no correct invocation against a multi-file plane existed at all.**
 
-`NEO_DEPLOY_COMPOSE_FILE` accepts a `:`-delimited list (Docker's own `COMPOSE_FILE` convention) and expands to repeated `-f` in merge order — later files override earlier ones, so reordering them changes the result. A single path behaves exactly as before; a value resolving to zero paths aborts before Docker runs.
+`NEO_DEPLOY_COMPOSE_FILE` is mandatory. It accepts a `:`-delimited list (Docker's own `COMPOSE_FILE` convention) and expands to repeated `-f` in merge order — later files override earlier ones, so reordering them changes the result. A single explicit path behaves exactly as before. An unset, empty, or delimiter-only value aborts before revision resolution, preflight, or Docker.
 
-This is not a convenience. A real plane is rarely one file — the canonical local Agent OS runs `docker-compose.yml` plus `docker-compose.local-agent-os.yml` under project `neo-local-agent-os` — and a single `-f` drops the overlay **silently**. Measured read-only on that plane, the two renderings differ by 80 lines: without the overlay, `NEO_AUTH_MODE` is absent, `NEO_MODEL_PROVIDER` is empty rather than `openAiCompatible`, and `NEO_MCP_HEALTHCHECK_TOKEN_FILE` is gone — under a *different* project name, so on fresh volumes.
+This is not a convenience. A real plane is rarely one file — the canonical local Agent OS runs `docker-compose.yml` plus `docker-compose.local-agent-os.yml` under project `neo-local-agent-os` — and a single `-f` drops the overlay **silently**. Measured read-only on that plane, the two renderings differ by 80 lines: without the overlay, `NEO_AUTH_MODE` is absent, `NEO_MODEL_PROVIDER` is empty rather than `openAiCompatible`, and `NEO_MCP_HEALTHCHECK_TOKEN_FILE` is gone — under a *different* project name, so on fresh volumes. The reference pipeline therefore has no base-only fallback: a caller must name the complete deployment composition it intends to operate.
 
 So a caller must pass three things, and the script infers none of them:
 

--- a/test/playwright/unit/ai/DeployPipelineComposeFileList.spec.mjs
+++ b/test/playwright/unit/ai/DeployPipelineComposeFileList.spec.mjs
@@ -31,15 +31,16 @@ const execFileAsync = promisify(execFile),
  */
 
 /**
- * Runs the pipeline with recording stubs for `docker` and `node`.
+ * Runs the pipeline with recording stubs for `docker`, `node`, and optionally `git`.
  * @param {Object}  config
  * @param {String}  [config.composeFileValue] Value for `NEO_DEPLOY_COMPOSE_FILE`.
- * @param {Boolean} [config.omitComposeFile]  Leave the variable UNSET rather than setting it — the only
- * way to exercise the default path, since an empty string is a *supplied* value with different meaning.
+ * @param {Boolean} [config.omitComposeFile]  Leave the variable UNSET rather than setting it.
+ * @param {Boolean} [config.failIfGitCalled]  Install a recording `git` stub that fails if the pipeline
+ * reaches revision resolution. Used only for missing-composition cases, which must stop first.
  * @param {String}  [config.revision]         Selector for `NEO_REF`; defaults to this checkout's `HEAD`.
- * @returns {Promise<Object>} `{code, stdout, calls, dockerCalls, composeArgs, preflightCallIndex, firstDockerIndex}`
+ * @returns {Promise<Object>} `{code, stdout, calls, dockerCalls, gitCalls, composeArgs, preflightCallIndex, firstDockerIndex}`
  */
-async function runPipeline({composeFileValue, omitComposeFile, revision}) {
+async function runPipeline({composeFileValue, omitComposeFile, failIfGitCalled, revision}) {
     const workDir = await fs.mkdtemp(path.join(repoRoot, 'test/playwright/test-results/compose-list-')),
           binDir  = path.join(workDir, 'bin'),
           logPath = path.join(workDir, 'calls.log');
@@ -53,6 +54,13 @@ async function runPipeline({composeFileValue, omitComposeFile, revision}) {
 
         await fs.writeFile(stubPath, `#!/usr/bin/env bash\nprintf '${name} %s\\n' "$*" >> "$CALL_LOG"\nexit 0\n`);
         await fs.chmod(stubPath, 0o755)
+    }
+
+    if (failIfGitCalled) {
+        const gitStubPath = path.join(binDir, 'git');
+
+        await fs.writeFile(gitStubPath, '#!/usr/bin/env bash\nprintf \'git %s\\n\' "$*" >> "$CALL_LOG"\nexit 97\n');
+        await fs.chmod(gitStubPath, 0o755)
     }
 
     const selector = revision || (await execFileAsync('git', ['rev-parse', 'HEAD'], {cwd: repoRoot})).stdout.trim();
@@ -88,6 +96,7 @@ async function runPipeline({composeFileValue, omitComposeFile, revision}) {
 
     const calls       = (await fs.readFile(logPath, 'utf8')).split('\n').filter(Boolean),
           dockerCalls = calls.filter(line => line.startsWith('docker ')),
+          gitCalls    = calls.filter(line => line.startsWith('git ')),
           firstUp     = dockerCalls.find(line => line.includes(' up ')) || '';
 
     await fs.remove(workDir);
@@ -99,6 +108,7 @@ async function runPipeline({composeFileValue, omitComposeFile, revision}) {
         stdout,
         calls,
         dockerCalls,
+        gitCalls,
         composeArgs       : firstUp,
         preflightCallIndex: calls.findIndex(line => line.startsWith('node ') && line.includes('redeployPreflight')),
         firstDockerIndex  : calls.findIndex(line => line.startsWith('docker '))
@@ -158,14 +168,29 @@ test.describe('deploy-pipeline.sh — ordered Compose-file set', () => {
         expect(orderedComposeFiles(result.composeArgs)).toEqual([base, overlay])
     });
 
-    test('a zero-entry value aborts with Docker NEVER invoked', async () => {
-        // The guarantee is "stopped before touching containers", not merely "stopped". A non-zero exit
-        // alone would not distinguish the two.
-        const result = await runPipeline({composeFileValue: ':::'});
+    test('unset, empty, and delimiter-only values abort BEFORE external transaction work', async () => {
+        // A non-zero exit alone would not prove the boundary. The failing git stub is the mutation
+        // witness for revision lookup: reaching it would leave a recorded call and change the exit code.
+        const missingCompositionCases = [
+            {omitComposeFile: true},
+            {composeFileValue: ''},
+            {composeFileValue: ':::'}
+        ];
 
-        expect(result.code).not.toBe(0);
-        expect(result.dockerCalls).toEqual([]);
-        expect(result.stdout).toContain('no usable path')
+        for (const missingComposition of missingCompositionCases) {
+            const result = await runPipeline({
+                ...missingComposition,
+                failIfGitCalled: true,
+                revision       : '0'.repeat(40)
+            });
+
+            expect(result.code).not.toBe(0);
+            expect(result.gitCalls).toEqual([]);
+            expect(result.preflightCallIndex).toBe(-1);
+            expect(result.dockerCalls).toEqual([]);
+            expect(result.stdout).toContain('NEO_DEPLOY_COMPOSE_FILE');
+            expect(result.stdout).toContain('auth-complete')
+        }
     });
 
     test('the operator-facing count reports FILES, not argv elements', async () => {
@@ -198,25 +223,4 @@ test.describe('deploy-pipeline.sh — ordered Compose-file set', () => {
         expect(result.dockerCalls.some(line => line.includes(' down '))).toBe(false)
     });
 
-    test('an EXPLICIT empty value aborts; an UNSET variable keeps the compatible default', async () => {
-        // These are different inputs and `${VAR:-default}` collapses them: an explicit empty string
-        // would fall back to the base compose file, deploying the base contract to a plane that needs
-        // an overlay — precisely what the zero-entry abort exists to prevent. Unset must still default,
-        // or every existing caller breaks.
-        const explicitEmpty = await runPipeline({composeFileValue: ''});
-
-        expect(explicitEmpty.code).not.toBe(0);
-        expect(explicitEmpty.dockerCalls).toEqual([]);
-        expect(explicitEmpty.stdout).toContain('no usable path');
-
-        const unset      = await runPipeline({omitComposeFile: true}),
-              unsetFiles = orderedComposeFiles(unset.composeArgs);
-
-        expect(unset.code).toBe(0);
-        expect(unsetFiles).toHaveLength(1);
-        // Compared on what the path RESOLVES to, not on its spelling: the script builds the default
-        // from `$SCRIPT_DIR/../..`, so the literal argv contains `../..` un-normalized. Asserting the
-        // string would pin an incidental spelling rather than the file being addressed.
-        expect(path.resolve(unsetFiles[0])).toBe(path.join(repoRoot, 'ai/deploy/docker-compose.yml'))
-    });
 });

--- a/test/playwright/unit/ai/DeployPipelineRevisionPin.spec.mjs
+++ b/test/playwright/unit/ai/DeployPipelineRevisionPin.spec.mjs
@@ -133,6 +133,9 @@ function preflightEnv(fake, declareInitialization, projectName) {
         // It also made the suite non-idempotent in a way a single local run cannot show: the first run
         // passed because the marker did not exist yet, and created the state that failed the second.
         NEO_BACKUP_PATH        : path.join(fake.bin, 'preflight-backups'),
+        // Revision tests need a valid explicit composition so the mandatory caller-owned boundary does
+        // not stop them before their actual subject. The fake Docker never starts this base file.
+        NEO_DEPLOY_COMPOSE_FILE: composePath,
         NEO_DEPLOY_INITIALIZE  : declareInitialization ? '1' : '0',
         NEO_DEPLOY_PROJECT_NAME: projectName
     }
@@ -331,10 +334,9 @@ test.describe('deploy-pipeline.sh revision pinning (#15792)', () => {
 
     test('every SCRIPT_DIR-relative path in the script actually RESOLVES', async () => {
         // Both instances of one bug shipped here: `$SCRIPT_DIR` is `ai/examples/cloud-deployment`, so
-        // `../..` is ALREADY `ai/`, and two lines re-added `ai/` on top of it. Mine broke CI loudly.
-        // The pre-existing `COMPOSE_FILE` default pointed at `ai/ai/deploy/docker-compose.yml` and broke
-        // NOTHING — because the spec fakes `docker`, and a fake docker ignores `-f`. A path that only a
-        // real deployment would exercise is exactly the path a faked harness cannot witness.
+        // `../..` is ALREADY `ai/`, and two lines re-added `ai/` on top of it. The old `COMPOSE_FILE`
+        // default was removed because composition is caller-owned; the maintenance preflight remains
+        // the script's sole sibling-path reference.
         //
         // So this asserts resolution directly rather than trusting the next author to count `../`.
         const source    = await fs.readFile(scriptPath, 'utf8'),
@@ -342,8 +344,9 @@ test.describe('deploy-pipeline.sh revision pinning (#15792)', () => {
               refs      = [...source.matchAll(/\$SCRIPT_DIR\/([A-Za-z0-9/._-]+)/g)].map(match => match[1]),
               unique    = [...new Set(refs)];
 
-        // Positive control: if the regex stops matching, this test silently asserts nothing.
-        expect(unique.length).toBeGreaterThan(1);
+        // Positive control: pin the one intended script-relative dependency so removal or accidental
+        // reintroduction of an implicit Compose path changes this contract loudly.
+        expect(unique).toEqual(['../../scripts/maintenance/redeployPreflight.mjs']);
 
         for (const ref of unique) {
             const resolved = path.resolve(scriptRel, ref);


### PR DESCRIPTION
Resolves #16671

The reference deploy pipeline now requires callers to name their ordered deployment composition instead of silently selecting the auth-incomplete base file. Unset, empty, and delimiter-only inputs fail before revision lookup, survivability preflight, or Docker; explicit single-file and ordered multi-file behavior remains unchanged.

Related: #16206
Refs #16458

Evidence: L2 (recording Git, preflight, and Docker stubs plus adjacent deploy-contract tests) → L2 required (all close-target ACs). No residuals.

## Deltas from ticket

- The adjacent revision-pinning fixture now supplies an explicit Compose path so its own revision and preflight contracts remain independently testable.
- The script-relative-path assertion now pins the sole intended maintenance dependency after removal of the implicit Compose path.
- Decision Record impact: aligned with ADR 0014 and ADR 0019; the pipeline consumes caller-owned composition rather than inventing runtime/auth configuration.

## Test Evidence

- Deploy pipeline: `npm run test-unit -- test/playwright/unit/ai/DeployPipelineComposeFileList.spec.mjs test/playwright/unit/ai/DeployPipelineRevisionPin.spec.mjs test/playwright/unit/ai/scripts/maintenance/redeployPreflight.spec.mjs` — 47/47 passed.
- Shell syntax: `bash -n ai/examples/cloud-deployment/deploy-pipeline.sh` — passed.
- Guide surface: `npm run ai:lint-guides` — 0 hard failures; existing repository warnings only.
- Patch hygiene: `git diff --check` — passed.

## Post-Merge Validation

- [ ] Exact-head CI confirms the same deployment contract on the merge candidate.
- [ ] Deployment operators continue to supply each plane's labeled ordered Compose set; this PR performs no live redeploy.

## Evolution

The broader contract run initially failed because its revision fixture still relied on the removed implicit Compose input. Supplying an explicit fixture composition restored the intended isolation and turned the remaining `SCRIPT_DIR` dependency into a precise positive-control assertion.

Authored by Emmy (GPT-5.6 Sol Ultra, Codex). Session 019fe0b3-53bc-7ef2-8665-41a0ef3f7b62.
