### PR TITLE
fix(ci): the C3 test-overlay lint fires on the files it scans (#16628)

### DIFF
--- a/.github/workflows/config-template-ssot-lint.yml
+++ b/.github/workflows/config-template-ssot-lint.yml
@@ -15,6 +15,13 @@ on:
       - 'ai/scripts/lint/config-leaf-parity.json'
       - 'ai/scripts/lint/lint-config-template-ssot.mjs'
       - '.github/workflows/config-template-ssot-lint.yml'
+      # The invariant is scanned ⊆ watched: the lint's implementation/capture rules walk every
+      # `ai/**/*.mjs` and its test config-authority (C3) rule walks every `test/**/*.mjs`, so a
+      # filter without these lets an introducing PR land ungated and turns the NEXT unrelated
+      # template-touching run red — late, misattributed enforcement (#16628; the configBase
+      # comment above already names the class: guard present, correct, and never run).
+      - 'ai/**/*.mjs'
+      - 'test/**/*.mjs'
   push:
     branches: [dev]
     paths:
@@ -29,6 +36,13 @@ on:
       - 'ai/scripts/lint/config-leaf-parity.json'
       - 'ai/scripts/lint/lint-config-template-ssot.mjs'
       - '.github/workflows/config-template-ssot-lint.yml'
+      # The invariant is scanned ⊆ watched: the lint's implementation/capture rules walk every
+      # `ai/**/*.mjs` and its test config-authority (C3) rule walks every `test/**/*.mjs`, so a
+      # filter without these lets an introducing PR land ungated and turns the NEXT unrelated
+      # template-touching run red — late, misattributed enforcement (#16628; the configBase
+      # comment above already names the class: guard present, correct, and never run).
+      - 'ai/**/*.mjs'
+      - 'test/**/*.mjs'
 
 concurrency:
   group: config-template-ssot-lint-${{ github.run_attempt == '1' && github.ref || github.run_id }}

--- a/learn/agentos/decisions/0019-aiconfig-reactive-provider-ssot.md
+++ b/learn/agentos/decisions/0019-aiconfig-reactive-provider-ssot.md
@@ -69,7 +69,7 @@ A reviewer checks a config-touching diff against this list; the lint (sub #2) me
 |---|---|---|---|
 | C1 ⛔ | **NEO imports ONLY in thread-entrypoints** (ZERO tolerance — `import Neo`/`_export`/`AiConfig` in a *non-entrypoint* script can BREAK things) | `[live: TaskDefinitions.mjs]` | keep the non-entrypoint Neo-free; it takes pure FUNCTIONS from a shared module, and any LITERAL it needs must earn §5.5's anchor reason — being a non-entrypoint is never itself the reason, and it must not carry a resolver for anything a leaf already binds |
 | C2 | duplicated primitives (`chromaClientPrimitives` re-implements the embedding dummy-fn; `chromaTestIsolation` hidden default DB names) | `[live-on-dev]` | fold into the SSOT leaves |
-| C3 | tests import `config.mjs` (overlay) not `config.template.mjs` (canonical) | `[live: #11976]` | tests import the canonical template |
+| C3 | tests import `config.mjs` (overlay) not `config.template.mjs` (canonical) | `[guarded: the lint's test config-authority rule (AST-resolved, scans `test/`), 0 on dev — #11976 repaired the backlog; #16628 wired the CI trigger to the scanned surface]` | tests import the canonical template |
 
 > **V-B-A classification correction (@neo-opus-4-7, `dev` line-evidence — Discussion #12453 `DC_kwDODSospM4BBgm5`):** the `ai/` daemon *entrypoints* (`bridge/daemon.mjs:3-6`, `orchestrator/daemon.mjs:25-27`) **legitimately `import Neo`/`_export`/`AiConfig`** — they ARE entrypoints, so their path re-derivation is **A1** (re-derivation with AiConfig already in scope), NOT a C1 violation; the "can BREAK things" framing applies to *non-entrypoints* only. The **single genuine C1×B5 site is `TaskDefinitions.mjs`** (no Neo import; `export const DEFAULT_DB_PATH`). The fan-out census MUST tag `A1-with-AiConfig-imported` vs `genuine-C1` so daemons are not over-counted as C1.
 
@@ -117,7 +117,7 @@ Before authoring or reviewing any `ai/` config work, you MUST:
 ## 7. Codification stack & sequencing
 
 1. **This ADR** (authority) + **the one-line AGENTS.md turn-loaded trigger** — sub #1 (#12457), **merge first** (per ADR 0007: high-frequency trigger in the turn-loaded layer, depth here; net loaded-bytes negative — one line replaces a 3-file read).
-2. **The fail-build lint** — sub #2, encodes §3's flaggable subset (A1·A4·A5·A6·A7·B1·B3·**B4**·B5 partial·C1; merges #12451).
+2. **The fail-build lint** — sub #2, encodes §3's flaggable subset (A1·A4·A5·A6·A7·B1·B3·**B4**·B5 partial·C1·C3; merges #12451). The C3 half is the test config-authority rule: AST-resolved overlay-import detection over `test/**/*.mjs`, precise against fixture strings and comments (its own spec red-proves both directions). Its CI workflow watches every surface the rules scan — `ai/**/*.mjs` + `test/**/*.mjs` — per the scanned ⊆ watched invariant (#16628; a filter narrower than the scan set produces late, misattributed enforcement on unrelated PRs).
 3. **Fan-out inventory** (Diamond 1) — AFTER this ADR merges (operator-gated), parallel Claude-family subagents sweep `ai/` against this ADR → exhaustive `[live-on-dev]` instance census.
 4. **Cleanup subs** (Diamond 2) — scoped from the census, each citing this ADR; folds in #12435, #12438, #11976, #12452.
 


### PR DESCRIPTION
Resolves #16628

The C3 guard was present, correct, and unable to fire on the files it guards: `lint-config-template-ssot.mjs` scans `ai/**/*.mjs` (implementation + module-scope-capture rules) and `test/**/*.mjs` (the test config-authority rule — exactly ADR-0019's C3), but the workflow's path filters watched only templates/bases/parity-JSON/lint-self, so a PR introducing a real overlay import in a test triggered nothing and the violation would surface late and misattributed on the next unrelated template-touching run. This PR makes the watched surface a superset of the scanned surface on both triggers (`ai/**/*.mjs` + `test/**/*.mjs`, with the invariant documented in-file) and truth-folds ADR-0019, whose §7 lint-coverage record omitted the shipped C3 rule and whose §3 C3 row still carried the stale `[live: #11976]` tag. The ticket body carries the full intake correction: the originally-claimed "7 re-accumulated instances" were a string-grep artifact (fixtures/comments/assertions in specs whose *subject* is the overlay machinery); the AST-precise lint reports 0 at head, so no test repairs or annotations were needed — the entire delivered delta is the trigger fix plus the record fix.

Evidence: L2 (local red/green lint cycle + static YAML diff; GitHub evaluates path filters server-side, so the trigger firing on an introducing PR is unreachable pre-merge) → L3 required (AC-2 "the introducing PR runs the lint"). Residual: AC-2 post-merge observation [#16628].

## Deltas from ticket

The ticket was re-scoped in-body during intake (same author, disclosed, original preserved in edit history): the premise "C3 re-accumulated, no mechanical guard" was falsified — the guard has existed since #12451 (2026-06-04) and is AST-precise. What remained real is exactly what this PR ships: the trigger gap and the ADR drift. One probe lesson banked in the ticket thread's spirit: the first red-proof attempt used a 3-level relative path that resolved to a non-existent `test/ai/config.mjs` and correctly did NOT flag — the rule resolves specifiers rather than string-matching, which is precisely why the census string-grep overcounted and why a positive control must be a known-must-register input.

## Test Evidence

- `npm run ai:lint-config-template-ssot` at head `ac1c197648`: `OK — … 0 test config-authority violation(s)` (green baseline).
- Red arm: synthetic `test/playwright/unit/ai/c3RedProof.scratch.spec.mjs` with `import AiConfig from '../../../../ai/config.mjs'` → `FAILED - 1 test config-authority violation(s)`, exit 1 (true exit captured un-piped).
- Green arm after probe removal: `OK`, exit 0; `git status` clean except the two delivered files.
- Lint's own spec suite: `npx playwright test lintConfigTemplateSsot -c test/playwright/playwright.config.unit.mjs` → 50 passed (12.1s).
- CI workflow surface: static YAML change; both trigger blocks verified updated (`replace_all` across `pull_request` + `push`).

## Post-Merge Validation

- [ ] A PR touching only `test/**/*.mjs` or non-config `ai/**/*.mjs` shows the `Config Template SSOT Lint` workflow in its check list (AC-2).

## Slot rationale (ADR-0019 — trigger-loaded via §critical_gates gate 10)

Modified sections only, disposition `keep`: §3's C3 row tag and §7's item-2 coverage list are truth-folds of existing rows to shipped reality (the ADR self-describes its lint coverage; letting it drift re-creates the census confusion this ticket documents). Net added bytes ≈ 90 words inside two existing anchors; no new always-loaded surface; decay mitigation is intrinsic — both rows now cite #16628 as their revalidation provenance and the lint output line remains the runtime truth the text defers to.

## Related

Refs #16515 (the census — instrument-error correction to follow there) · Refs #12451 (the lint's origin) · Refs #11976 (closed predecessor)

Authored by Mnemosyne (Claude Fable 5, Claude Code). Session e7da18d8-1563-4ab8-9b88-75afc13aa74e.
