### PR TITLE
fix(kb): preserve durable embed failure causes (#16658)

### DIFF
--- a/ai/services/knowledge-base/helpers/embedFailureClassification.mjs
+++ b/ai/services/knowledge-base/helpers/embedFailureClassification.mjs
@@ -59,8 +59,9 @@ export const BOUNDED_KB_ERROR_CODE_PATTERN = /^KB_[A-Z0-9_]{1,120}$/;
  * recognised.
  *
  * It does NOT mean "embedding is broken in some general way", and two deployments reporting it may
- * share nothing but the stage at which they stopped. Reading a shared occurrence of this code as a
- * shared defect is the inference this constant is named to discourage.
+ * share nothing but the stage at which they stopped. It remains reachable only for genuinely
+ * unclassifiable inputs: absent/empty/non-string codes, or strings outside both closed vocabularies
+ * below. Reading a shared occurrence as a shared defect is the inference this constant discourages.
  * @type {String}
  */
 export const KB_VECTOR_EMBED_UNCLASSIFIED = 'KB_VECTOR_EMBED_FAILED';
@@ -86,16 +87,19 @@ const INTERNAL_EMBED_ERROR_CODES = Object.freeze(new Set([
 ]));
 
 /**
- * @summary Provider-vocabulary codes that describe a distinguishable embed fault.
+ * @summary Upstream-vocabulary codes that describe a distinguishable embed fault.
  *
  * Two timeout sources map to different codes on purpose: a consumer-owned deadline expiring
  * (`EMBEDDING_PROBE_TIMEOUT`, raised by our own caller) and the provider's own request timeout are
  * different faults with different fixes — raise our deadline, versus the provider is too slow or
- * wedged. Collapsing them would rebuild the ambiguity this module exists to remove.
+ * wedged. The map also translates a source-owned model-residency code and Node's foreign transport
+ * refusal code; neither is echoed. Collapsing them would rebuild the ambiguity this module removes.
  * @type {Object}
  */
 const PROVIDER_ERROR_CODE_MAP = Object.freeze({
     ABORT_ERR                        : 'KB_VECTOR_EMBED_ABORTED',
+    ECONNREFUSED                     : 'KB_VECTOR_EMBED_CONNECTION_REFUSED',
+    EMBEDDING_MODEL_NOT_RESIDENT     : 'KB_VECTOR_EMBED_MODEL_NOT_RESIDENT',
     EMBEDDING_PROBE_TIMEOUT          : 'KB_VECTOR_EMBED_TIMEOUT',
     OPENAI_COMPATIBLE_REQUEST_TIMEOUT: 'KB_VECTOR_EMBED_PROVIDER_TIMEOUT',
     PROVIDER_TIMEOUT                 : 'KB_VECTOR_EMBED_PROVIDER_TIMEOUT'

--- a/ai/services/memory-core/TextEmbeddingService.mjs
+++ b/ai/services/memory-core/TextEmbeddingService.mjs
@@ -20,6 +20,28 @@ const OPENAI_COMPATIBLE_CONTENTION_HTTP_ERROR_RE   = /openAiCompatible embedding
 const EMBEDDING_OPERATION_LABEL_MAX_LENGTH         = 120;
 
 /**
+ * @summary Source-owned code for an embedding request whose configured model is not resident.
+ *
+ * This shared Memory Core service must not mint a downstream Knowledge Base `KB_*` code. The KB
+ * ingestion boundary translates this provider-neutral cause into its own durable vocabulary.
+ * @type {String}
+ */
+export const EMBEDDING_MODEL_NOT_RESIDENT_CODE = 'EMBEDDING_MODEL_NOT_RESIDENT';
+
+/**
+ * @summary Carries a known model-residency cause separately from its diagnostic message.
+ *
+ * Model-load messages include configured model identifiers, observed resident ids and provider
+ * payloads, so consumers must classify on this owned code rather than persist or project the text.
+ * @param {Error} error The model-load failure recognized at the source boundary.
+ * @returns {Error} The same error with its source-owned cause code.
+ */
+function markEmbeddingModelNotResidentError(error) {
+    error.code = EMBEDDING_MODEL_NOT_RESIDENT_CODE;
+    return error
+}
+
+/**
  * @summary Normalizes the additive embedding-call options without widening provider authority.
  * @param {Object} options Caller options.
  * @param {String} defaultOperationLabel Provider-scoped fallback label.
@@ -571,7 +593,9 @@ class TextEmbeddingService extends Base {
 
         if (!loadedModel) {
             const observedIds = loadedModels.map(item => item.id).filter(Boolean).slice(0, 5).join(', ') || 'none';
-            throw new Error(`TextEmbeddingService: LM Studio embedding model '${model}' is not resident under its configured identifier; observed=${observedIds}`);
+            throw markEmbeddingModelNotResidentError(
+                new Error(`TextEmbeddingService: LM Studio embedding model '${model}' is not resident under its configured identifier; observed=${observedIds}`)
+            );
         }
         if (!Neo.isNumber(loadedModel.contextLength)) {
             throw new Error(`TextEmbeddingService: LM Studio embedding model '${model}' has unknown loaded context; configured>=${configuredContextLength}`);
@@ -783,6 +807,10 @@ class TextEmbeddingService extends Base {
                 (err.message.includes('Failed to load model') &&            // Shape B — JIT-warm-load-canceled
                  err.message.includes('Operation canceled'))
             )) || err.message.includes('HTTP 404');                         // Shape C — model not resident
+
+            if (isModelLoadError) {
+                markEmbeddingModelNotResidentError(err)
+            }
 
             if (unloadRetriesLeft > 0 && isModelLoadError) {
                 logger.log(`[TextEmbeddingService] embedding-provider model-load failure detected (Shape ${err.message.includes('Model was unloaded') ? 'A' : err.message.includes('HTTP 404') ? 'C' : 'B'}), retrying (remaining retries: ${unloadRetriesLeft})`);

--- a/test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncService.spec.mjs
@@ -2115,7 +2115,7 @@ test.describe('TenantRepoSyncService (#11790)', () => {
     });
 
     /**
-     * @summary The consumer witness: two real embed-failure summaries carried through `runTask` to the
+     * @summary The consumer witness: real embed-failure summaries carried through `runTask` to the
      * `details.repos[].lastSourceErrorCode` a remote client reads.
      *
      * A producer-side spec that classifies a code, and a reader-side spec that admits it, can BOTH be
@@ -2125,21 +2125,21 @@ test.describe('TenantRepoSyncService (#11790)', () => {
      * into `lastSourceErrorCode: null`, so a witness that skips it does not witness the defect.
      *
      * The summaries here are not hand-written: they are produced by running the real
-     * `IngestionService.embedChunkGroups` against two injected provider faults, then handed to the
+     * `IngestionService.embedChunkGroups` against source-shaped failures, then handed to the
      * `knowledgeBaseIngestionService` seam verbatim. No `KB_*` literal appears between the provider
      * error and the assertion, so the whole producer -> filter -> projection chain has to agree.
      */
-    test('two real embed failures reach details.repos[] as distinct source codes (#16647)', async () => {
+    test('real embed failures reach details.repos[] as distinct source codes (#16647, #16658)', async () => {
         const {default: IngestionService} = await import(
             '../../../../../../../ai/services/knowledge-base/IngestionService.mjs'
         );
 
         /**
          * Runs the REAL embed path against one injected provider fault.
-         * @param {String} providerCode
+         * @param {Error} sourceError Error emitted by the source boundary.
          * @returns {Promise<Object>} The genuine ingestion summary, errors included.
          */
-        async function produceRealSummary(providerCode) {
+        async function produceRealSummary(sourceError) {
             const summary = {errors: [], embeddingsGenerated: 0};
 
             await IngestionService.embedChunkGroups.call({
@@ -2147,7 +2147,7 @@ test.describe('TenantRepoSyncService (#11790)', () => {
                 updateIngestionProgress: () => {},
                 vectorService          : {
                     async embed() {
-                        throw Object.assign(new Error('provider failed'), {code: providerCode})
+                        throw sourceError
                     }
                 },
                 writeTempJsonl: async () => path.join(
@@ -2174,7 +2174,7 @@ test.describe('TenantRepoSyncService (#11790)', () => {
          * Drives one real summary through the sync lane and returns what a client would read.
          * @param {Object} summary
          * @param {String} repoSlug
-         * @returns {Promise<String|null>}
+         * @returns {Promise<Object>} The remotely-readable repository state.
          */
         async function projectThroughRunTask(summary, repoSlug) {
             await provisionMirrorDir({tenantId: 't1', repoSlug});
@@ -2192,30 +2192,102 @@ test.describe('TenantRepoSyncService (#11790)', () => {
                 seedBootstrap                : false
             });
 
-            return result.details.repos[0].lastSourceErrorCode ?? null
+            return result.details.repos[0]
+        }
+
+        /**
+         * Captures one rejected embedding call without replacing the production error object.
+         * @param {Promise<*>} promise Embedding operation expected to fail.
+         * @returns {Promise<Error>} The exact source error.
+         */
+        async function captureFailure(promise) {
+            return promise.then(
+                () => null,
+                error => error
+            )
         }
 
         const
-            timeoutSummary = await produceRealSummary('EMBEDDING_PROBE_TIMEOUT'),
-            abortSummary   = await produceRealSummary('ABORT_ERR');
+            {default: TextEmbeddingService} = await import(
+                '../../../../../../../ai/services/memory-core/TextEmbeddingService.mjs'
+            ),
+            {default: embeddingConfig} = await import(
+                '../../../../../../../ai/mcp/server/memory-core/config.template.mjs'
+            ),
+            originalHost               = embeddingConfig.openAiCompatible.host,
+            originalUnloadRetryCount   = embeddingConfig.openAiCompatible.unloadRetryCount,
+            originalProbe              = TextEmbeddingService.openAiCompatibleLoadedModelsProbe;
+
+        let connectionRefusedError, modelNotResidentError;
+
+        try {
+            TextEmbeddingService.openAiCompatibleLoadedModelsProbe = async () => [];
+            modelNotResidentError = await captureFailure(
+                TextEmbeddingService.embedText('model-marker-must-not-project', 'openAiCompatible')
+            );
+
+            const {default: http} = await import('node:http');
+            const closedServer    = http.createServer();
+            await new Promise(resolve => closedServer.listen(0, '127.0.0.1', resolve));
+            const closedPort = closedServer.address().port;
+            await new Promise(resolve => closedServer.close(resolve));
+
+            embeddingConfig.openAiCompatible.host             = `http://127.0.0.1:${closedPort}`;
+            embeddingConfig.openAiCompatible.unloadRetryCount = 0;
+            TextEmbeddingService.openAiCompatibleLoadedModelsProbe = async () => [{
+                id           : embeddingConfig.openAiCompatible.embeddingModel,
+                contextLength: embeddingConfig.localModels.embedding.contextLimitTokens
+            }];
+            connectionRefusedError = await captureFailure(
+                TextEmbeddingService.embedText('connection-marker-must-not-project', 'openAiCompatible')
+            );
+        } finally {
+            embeddingConfig.openAiCompatible.host             = originalHost;
+            embeddingConfig.openAiCompatible.unloadRetryCount = originalUnloadRetryCount;
+            TextEmbeddingService.openAiCompatibleLoadedModelsProbe = originalProbe;
+        }
+
+        expect(connectionRefusedError).toBeInstanceOf(Error);
+        expect(connectionRefusedError.code).toBe('ECONNREFUSED');
+        expect(modelNotResidentError).toBeInstanceOf(Error);
+        expect(modelNotResidentError.code).toBe('EMBEDDING_MODEL_NOT_RESIDENT');
+
+        const
+            timeoutSummary     = await produceRealSummary(Object.assign(new Error('provider timed out'), {code: 'EMBEDDING_PROBE_TIMEOUT'})),
+            abortSummary       = await produceRealSummary(Object.assign(new Error('provider aborted'),   {code: 'ABORT_ERR'})),
+            refusedSummary     = await produceRealSummary(connectionRefusedError),
+            nonResidentSummary = await produceRealSummary(modelNotResidentError);
 
         // Non-vacuity: an empty errors array would make the lane succeed and every assertion below
         // would be reasoning about a repo that never failed.
         expect(timeoutSummary.errors, 'the timeout run really produced an error').toHaveLength(1);
         expect(abortSummary.errors, 'the abort run really produced an error').toHaveLength(1);
+        expect(refusedSummary.errors, 'the refusal run really produced an error').toHaveLength(1);
+        expect(nonResidentSummary.errors, 'the residency run really produced an error').toHaveLength(1);
 
         const
-            timeoutCode = await projectThroughRunTask(timeoutSummary, 'org/witness-timeout'),
-            abortCode   = await projectThroughRunTask(abortSummary,   'org/witness-abort');
+            timeoutState     = await projectThroughRunTask(timeoutSummary,     'org/witness-timeout'),
+            abortState       = await projectThroughRunTask(abortSummary,       'org/witness-abort'),
+            refusedState     = await projectThroughRunTask(refusedSummary,     'org/witness-refused'),
+            nonResidentState = await projectThroughRunTask(nonResidentSummary, 'org/witness-non-resident');
 
         // Arrival. Pre-fix both were dropped by the `^KB_` filter and this read null — the exact
         // symptom that made a wedged deployment undiagnosable from a remote client.
-        expect(timeoutCode, 'a provider timeout arrives as a cause').not.toBeNull();
-        expect(abortCode, 'an upstream abort arrives as a cause').not.toBeNull();
+        expect(timeoutState.lastSourceErrorCode, 'a provider timeout arrives as a cause').not.toBeNull();
+        expect(abortState.lastSourceErrorCode, 'an upstream abort arrives as a cause').not.toBeNull();
 
         // Distinguishability, which is the acceptance criterion itself: two faults must not read
         // identically from the deployment-state snapshot alone.
-        expect(timeoutCode).not.toBe(abortCode);
+        expect(timeoutState.lastSourceErrorCode).not.toBe(abortState.lastSourceErrorCode);
+        expect(refusedState.lastSourceErrorCode).toBe('KB_VECTOR_EMBED_CONNECTION_REFUSED');
+        expect(nonResidentState.lastSourceErrorCode).toBe('KB_VECTOR_EMBED_MODEL_NOT_RESIDENT');
+        expect(refusedState.lastSourceErrorCode).not.toBe(nonResidentState.lastSourceErrorCode);
+
+        const projected = JSON.stringify([refusedState, nonResidentState]);
+        expect(projected).not.toContain('connection-marker-must-not-project');
+        expect(projected).not.toContain('model-marker-must-not-project');
+        expect(projected).not.toContain(connectionRefusedError.message);
+        expect(projected).not.toContain(modelNotResidentError.message);
     });
 
 

--- a/test/playwright/unit/ai/services/knowledge-base/embedFailureClassification.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/embedFailureClassification.spec.mjs
@@ -69,6 +69,16 @@ test.describe('embed failure classification (#16647)', () => {
             .toBe(classifyEmbedFailureCode('PROVIDER_TIMEOUT'));
     });
 
+    test('a connection refusal and a known model-residency failure stay distinguishable', () => {
+        const
+            refused     = classifyEmbedFailureCode('ECONNREFUSED'),
+            nonResident = classifyEmbedFailureCode('EMBEDDING_MODEL_NOT_RESIDENT');
+
+        expect(refused).toBe('KB_VECTOR_EMBED_CONNECTION_REFUSED');
+        expect(nonResident).toBe('KB_VECTOR_EMBED_MODEL_NOT_RESIDENT');
+        expect(refused).not.toBe(nonResident);
+    });
+
     test('a DECLARED internal code is passed through, not overwritten', () => {
         // Our own layers produce codes more specific than anything the map could add. Rewriting them
         // would be a regression disguised as classification. It passes because it is a declared
@@ -129,6 +139,8 @@ test.describe('embed failure classification (#16647)', () => {
         // only place that would notice.
         const providerCodes = [
             'ABORT_ERR',
+            'ECONNREFUSED',
+            'EMBEDDING_MODEL_NOT_RESIDENT',
             'EMBEDDING_PROBE_TIMEOUT',
             'OPENAI_COMPATIBLE_REQUEST_TIMEOUT',
             'PROVIDER_TIMEOUT'

--- a/test/playwright/unit/ai/services/memory-core/TextEmbeddingService.retry.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/TextEmbeddingService.retry.spec.mjs
@@ -90,7 +90,7 @@ function buildMinimalGguf({tokens, eosTokenId, eotTokenId, addEosToken = true}) 
 }
 
 test.describe.serial('TextEmbeddingService #11393/#11402/#12487/#12509 — openAiCompatible retry, QoS, and lms server start support', () => {
-    let SDK, TextEmbeddingService, server;
+    let TextEmbeddingService, server;
     let requestCount   = 0;
     let serverBehavior = 'succeed';
     let lastRequest;
@@ -105,8 +105,9 @@ test.describe.serial('TextEmbeddingService #11393/#11402/#12487/#12509 — openA
     let originalLoadedModelsProbe;
 
     test.beforeAll(async () => {
-        SDK = await import('../../../../../../ai/services.mjs');
-        TextEmbeddingService = SDK.Memory_TextEmbeddingService;
+        ({default: TextEmbeddingService} = await import(
+            '../../../../../../ai/services/memory-core/TextEmbeddingService.mjs'
+        ));
 
         server = http.createServer((req, res) => {
             requestCount++;
@@ -298,7 +299,7 @@ test.describe.serial('TextEmbeddingService #11393/#11402/#12487/#12509 — openA
         serverBehavior = 'succeed';
         const result = await TextEmbeddingService.embedText('hello', 'openAiCompatible');
         expect(result).toEqual([0.1, 0.2, 0.3]);
-        expect(requestCount).toBe(1);
+        expect(requestCount, `observed requests=${JSON.stringify(allRequests)}`).toBe(1);
     });
 
     test('lms server start-compatible single embedding uses the standard OpenAI-compatible endpoint', async () => {
@@ -438,6 +439,18 @@ test.describe.serial('TextEmbeddingService #11393/#11402/#12487/#12509 — openA
         expect(requestCount).toBe(0);
     });
 
+    test('model-not-resident preflight mints a source-owned cause code before the provider request (#16658)', async () => {
+        TextEmbeddingService.openAiCompatibleLoadedModelsProbe = async () => [];
+
+        const error = await TextEmbeddingService.embedText('hello', 'openAiCompatible')
+            .then(() => null, observed => observed);
+
+        expect(error).toBeInstanceOf(Error);
+        expect(error.code).toBe('EMBEDDING_MODEL_NOT_RESIDENT');
+        expect(error.message).toContain('is not resident under its configured identifier');
+        expect(requestCount, 'the resident-model preflight fails before transport').toBe(0);
+    });
+
     test('openAiCompatible skips LM Studio context probe for non-LMS endpoints (#13944)', async () => {
         serverBehavior = 'succeed';
 
@@ -469,8 +482,12 @@ test.describe.serial('TextEmbeddingService #11393/#11402/#12487/#12509 — openA
         serverBehavior = 'fail-all';
         aiConfig.openAiCompatible.unloadRetryCount = 2; // N=2
 
-        await expect(TextEmbeddingService.embedText('hello', 'openAiCompatible'))
-            .rejects.toThrow(/Model was unloaded/);
+        const error = await TextEmbeddingService.embedText('hello', 'openAiCompatible')
+            .then(() => null, observed => observed);
+
+        expect(error).toBeInstanceOf(Error);
+        expect(error.message).toMatch(/Model was unloaded/);
+        expect(error.code).toBe('EMBEDDING_MODEL_NOT_RESIDENT');
 
         // Initial request + 2 retries = 3 total requests
         expect(requestCount).toBe(3);
@@ -514,8 +531,12 @@ test.describe.serial('TextEmbeddingService #11393/#11402/#12487/#12509 — openA
         serverBehavior = 'fail-all-404';
         aiConfig.openAiCompatible.unloadRetryCount = 2; // N=2
 
-        await expect(TextEmbeddingService.embedText('hello', 'openAiCompatible'))
-            .rejects.toThrow(/HTTP 404/);
+        const error = await TextEmbeddingService.embedText('hello', 'openAiCompatible')
+            .then(() => null, observed => observed);
+
+        expect(error).toBeInstanceOf(Error);
+        expect(error.message).toMatch(/HTTP 404/);
+        expect(error.code).toBe('EMBEDDING_MODEL_NOT_RESIDENT');
 
         // Initial request + 2 bounded retries = 3 total requests (no infinite loop on a permanent 404)
         expect(requestCount).toBe(3);


### PR DESCRIPTION
Resolves #16658

Known model-residency and connection-refusal failures now survive the complete embedding-to-tenant-state path as distinct, bounded codes without exposing provider messages. `TextEmbeddingService` stamps the source-owned model-residency cause at both the preflight and existing retry-recognition seams; the Knowledge Base boundary translates that cause and Node's `ECONNREFUSED` into its own durable vocabulary while retaining the honest unclassified fallback.

Evidence: L3 (real source errors composed through ingestion, tenant sync, and the remotely readable repository state) → L4 required (deployed-plane receipt after merge). Residual: operational confirmation for AC1 and AC5 [#16658].

## Deltas from ticket

- Preserved ownership across the shared-service boundary: Memory Core mints `EMBEDDING_MODEL_NOT_RESIDENT`; Knowledge Base translates it to `KB_VECTOR_EMBED_MODEL_NOT_RESIDENT`. The downstream `INTERNAL_EMBED_ERROR_CODES` set remains limited to codes already owned by KB layers.
- The retry spec now imports the raw service module instead of the broad `ai/services.mjs` barrel. A combined-spec run falsified the barrel's isolation here by producing duplicate requests from a wrapped singleton; the direct import restores the unit boundary without changing runtime exports.
- Retry policy is unchanged. Existing model-load recognition only gains a separate machine-readable cause carrier.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/ai/services/memory-core/TextEmbeddingService.retry.spec.mjs test/playwright/unit/ai/services/knowledge-base/embedFailureClassification.spec.mjs` — 38 passed.
- `npm run test-unit -- test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncService.spec.mjs --grep "real embed failures reach details.repos" --workers=1` — 3 passed after both mutation probes were reverted.
- Mint mutation: temporarily restored the bare model-not-resident `Error`; the composed witness failed with expected `EMBEDDING_MODEL_NOT_RESIDENT`, received `undefined`.
- Middle mutation: temporarily forced `getSourceErrorCode()` to drop bounded causes; the same witness failed because independently classified causes both projected as `undefined`.
- `npm run test-unit` — 11,802 passed, 5 skipped, 2 did not run; 6 failures outside the touched files and changed-symbol paths: one ResizeObserver timing assertion, four wake-delivery timing/outbox assertions, and one live summarization latency timeout.
- `npm run agent-preflight -- --change-class restoration --commit-subject "fix(kb): preserve durable embed failure causes (#16658)" --no-fix <five changed files>` — passed.
- Pre-commit hooks — whitespace, shorthand, AiConfig test mutation, OpenAPI parity, JSDoc types, derived-domain, ticket archaeology, block alignment, and parse checks passed.
- Memory Core `TextEmbeddingService`: full retry/provider spec, 23 production-path tests plus run-scoped setup/teardown, passed within the 38-test focused run.
- Knowledge Base classification: full helper spec, 13 production/read-boundary tests plus run-scoped setup/teardown, passed within the 38-test focused run.
- Tenant repository durable state: real source failures → real `IngestionService.embedChunkGroups()` → real `TenantRepoSyncService.runTask()` → `details.repos[].lastSourceErrorCode`, 3/3 passed and both message markers stayed absent.

## Post-Merge Validation

- [ ] On a controlled deployed MC/KB plane, exercise one closed embedding endpoint and one non-resident configured model; confirm the remote tenant-repo snapshot reports `KB_VECTOR_EMBED_CONNECTION_REFUSED` and `KB_VECTOR_EMBED_MODEL_NOT_RESIDENT` respectively, with no provider message text.
- [ ] Restore the provider, run a successful sync, and confirm the retained cause clears on recovery.

## Evolution

The ticket's initial prescription placed a source-minted cause in the KB-internal vocabulary. Implementation review exposed that as reversed ownership: the shared Memory Core service now emits a provider-neutral code, and the downstream Knowledge Base boundary performs the durable translation. The live ticket body was corrected before this PR.

Authored by Euclid (GPT-5, Codex Desktop). Session abdf06f7-5c90-4124-ad28-f0e2897214ee.
