### PR TITLE
feat(memory-core): persist unfinished tool calls (#16685)

### DIFF
--- a/ai/mcp/server/memory-core/openapi.yaml
+++ b/ai/mcp/server/memory-core/openapi.yaml
@@ -216,8 +216,10 @@ paths:
         readOnlyHint: true
       description: |
         Returns aggregate Memory Core MCP tool-call telemetry without exposing raw tool
-        arguments or results. Use this to diagnose slow or failing tools in long-running
-        local and shared deployments.
+        arguments or results. Completed calls provide latency/failure aggregates; calls that
+        have crossed the start boundary but not the completion boundary are returned separately
+        with redacted operation identity and elapsed time. Use this to diagnose slow, failing,
+        or process-wedging tools in long-running local and shared deployments.
       tags: [Diagnostics]
       requestBody:
         required: false
@@ -2545,7 +2547,9 @@ components:
         - sinceMs
         - limit
         - totalCalls
+        - totalUnfinished
         - tools
+        - unfinishedCalls
       properties:
         status:
           type: string
@@ -2562,8 +2566,12 @@ components:
           example: 50
         totalCalls:
           type: integer
-          description: Total matching tool calls across all tools.
+          description: Total matching completed tool calls across all tools.
           example: 128
+        totalUnfinished:
+          type: integer
+          description: Total matching calls that crossed the start boundary but have no completion boundary yet.
+          example: 1
         tools:
           type: array
           description: Per-tool aggregate rows. Raw arguments and results are intentionally absent.
@@ -2607,6 +2615,35 @@ components:
                 nullable: true
                 description: ISO timestamp of the newest matching call.
                 example: "2026-06-19T03:30:00.000Z"
+        unfinishedCalls:
+          type: array
+          description: Oldest-first unfinished call rows. They may be active or abandoned by a prior process; arguments and results are intentionally absent.
+          items:
+            type: object
+            required:
+              - callId
+              - tool
+              - startedAt
+              - elapsedMs
+            properties:
+              callId:
+                type: string
+                description: Opaque telemetry row id used to correlate the eventual completion.
+                example: "019fe0b3-53bc-7ef2-8665-41a0ef3f7b62"
+              tool:
+                type: string
+                description: MCP operation id.
+                example: add_message
+              startedAt:
+                type: string
+                format: date-time
+                description: ISO timestamp captured immediately before tool dispatch.
+                example: "2026-08-08T11:08:22.000Z"
+              elapsedMs:
+                type: integer
+                minimum: 0
+                description: Elapsed wall-clock time at metrics-read time.
+                example: 474347
 
     RemPipelineStateResponse:
       type: object

--- a/ai/mcp/server/memory-core/toolService.mjs
+++ b/ai/mcp/server/memory-core/toolService.mjs
@@ -340,7 +340,13 @@ const createTransportVisibleToolFacade = ({
      * @returns {Promise<Object>}
      */
     const callTool = async (name, args, options = {}) => {
-        const t0 = Date.now();
+        const
+            t0          = Date.now(),
+            // Keep the diagnostics observer out of its own unfinished snapshot. Its completion
+            // is still recorded below, preserving aggregate latency without a false active row.
+            telemetryId = name === 'get_memory_core_tool_metrics'
+                ? null
+                : MemoryCoreRecorderService.beginToolCall({toolName: name, args, t0});
 
         let result, success = false, error = null;
 
@@ -361,6 +367,7 @@ const createTransportVisibleToolFacade = ({
             throw err;
         } finally {
             MemoryCoreRecorderService.logToolCall({
+                id          : telemetryId || undefined,
                 toolName    : name,
                 args,
                 result,

--- a/ai/services/memory-core/MemoryCoreRecorderService.mjs
+++ b/ai/services/memory-core/MemoryCoreRecorderService.mjs
@@ -17,6 +17,12 @@ const SENSITIVE_PAYLOAD_KEYS = new Set([
 ]);
 
 /**
+ * @summary Maximum SQLite lock wait allowed on the best-effort telemetry path.
+ * @type {Number}
+ */
+export const TOOL_TELEMETRY_BUSY_TIMEOUT_MS = 50;
+
+/**
  * @summary Persists redacted Memory Core MCP tool-call telemetry.
  *
  * This is the Memory Core sibling of the Knowledge Base and Neural Link recorder services,
@@ -70,7 +76,10 @@ class MemoryCoreRecorderService extends Base {
 
             const Database = (await import('better-sqlite3')).default;
 
-            this.db = new Database(dbPath, {verbose: null});
+            this.db = new Database(dbPath, {
+                timeout: TOOL_TELEMETRY_BUSY_TIMEOUT_MS,
+                verbose: null
+            });
             if (dbPath !== ':memory:') {
                 this.db.pragma('journal_mode = WAL');
             }
@@ -100,6 +109,7 @@ class MemoryCoreRecorderService extends Base {
                 tool          TEXT NOT NULL,
                 success       INTEGER DEFAULT 0,
                 duration_ms   INTEGER,
+                completed_at  INTEGER,
                 failure_stage TEXT,
                 error_code    TEXT,
                 error_name    TEXT,
@@ -112,6 +122,38 @@ class MemoryCoreRecorderService extends Base {
             CREATE INDEX IF NOT EXISTS idx_mc_tool_call_log_success   ON mc_tool_call_log(success);
             CREATE INDEX IF NOT EXISTS idx_mc_tool_call_log_session   ON mc_tool_call_log(session_id);
         `);
+
+        const columns = new Set(
+            this.db.prepare('PRAGMA table_info(mc_tool_call_log)').all().map(column => column.name)
+        );
+
+        if (!columns.has('completed_at')) {
+            this.db.exec('ALTER TABLE mc_tool_call_log ADD COLUMN completed_at INTEGER;');
+        }
+
+        this.db.exec(`
+            CREATE INDEX IF NOT EXISTS idx_mc_tool_call_log_completed_at
+                ON mc_tool_call_log(completed_at);
+        `);
+
+        const hasCompletedLegacyRow = this.db.prepare(`
+            SELECT 1
+              FROM mc_tool_call_log
+             WHERE completed_at IS NULL
+               AND duration_ms IS NOT NULL
+             LIMIT 1
+        `).get();
+
+        if (hasCompletedLegacyRow) {
+            // Rows written before the start boundary shipped are completed calls. The existence
+            // probe keeps this idempotent across a crash between ALTER TABLE and the backfill.
+            this.db.prepare(`
+                UPDATE mc_tool_call_log
+                   SET completed_at = timestamp + COALESCE(duration_ms, 0)
+                 WHERE completed_at IS NULL
+                   AND duration_ms IS NOT NULL
+            `).run();
+        }
     }
 
     /**
@@ -172,7 +214,86 @@ class MemoryCoreRecorderService extends Base {
     }
 
     /**
-     * Persists one redacted tool-call telemetry row. Best-effort only.
+     * Builds the shared redacted row shape for both the start and completion boundaries.
+     * @param {Object} entry Tool-call metadata.
+     * @param {Number|null} completedAt Completion timestamp, or null while the call is in flight.
+     * @returns {Object}
+     */
+    buildToolCallRecord(entry = {}, completedAt = null) {
+        const
+            timestamp = Number.isFinite(entry.timestamp) ? entry.timestamp : (Number.isFinite(entry.t0) ? entry.t0 : Date.now()),
+            context   = RequestContextService.get?.() || {},
+            agentId   = context.agentIdentityNodeId || process.env.NEO_AGENT_IDENTITY || process.env.NEO_AGENT_ID || process.env.USER || 'unknown',
+            userId    = context.userId || null,
+            sessionId = entry.args?.sessionId || context.sessionId || process.env.NEO_SESSION_ID || null,
+            duration  = completedAt === null
+                ? null
+                : (Number.isFinite(entry.duration_ms)
+                    ? Math.max(0, entry.duration_ms)
+                    : Math.max(0, completedAt - (entry.t0 || timestamp))),
+            error    = entry.error || null,
+            id       = entry.id || crypto.randomUUID?.() || `${timestamp}-${Math.random()}`,
+            sequence = entry.sequence_id || `${agentId}_${timestamp}_${id}`;
+
+        return {
+            id,
+            agent_id     : agentId,
+            user_id      : userId,
+            session_id   : sessionId,
+            sequence_id  : sequence,
+            timestamp,
+            tool         : entry.toolName || entry.tool || 'unknown',
+            success      : entry.success ? 1 : 0,
+            duration_ms  : duration,
+            completed_at : completedAt,
+            failure_stage: entry.failureStage || entry.failure_stage || null,
+            error_code   : error?.code || null,
+            error_name   : error?.name || null,
+            error_message: this.buildErrorMessage(error, entry.args),
+            args_bytes   : this.measureBytes(entry.args),
+            result_bytes : this.measureBytes(entry.result)
+        };
+    }
+
+    /**
+     * Persists the redacted start boundary before Memory Core begins tool dispatch.
+     *
+     * A call that wedges the process never reaches the existing completion-only recorder. The
+     * unfinished row is therefore the durable evidence: tool identity, start time, and opaque call
+     * id, with arguments measured but never stored. Best-effort failure keeps dispatch available.
+     *
+     * @param {Object} entry Tool-call metadata.
+     * @returns {String|null} Opaque call id used to complete the same row.
+     */
+    beginToolCall(entry = {}) {
+        if (!config.toolTelemetry.enabled || !this.db) return null;
+
+        try {
+            const record = this.buildToolCallRecord(entry);
+
+            this.db.prepare(`
+                INSERT INTO mc_tool_call_log (
+                    id, agent_id, user_id, session_id, sequence_id, timestamp,
+                    tool, success, duration_ms, completed_at, failure_stage, error_code,
+                    error_name, error_message, args_bytes, result_bytes
+                )
+                VALUES (
+                    @id, @agent_id, @user_id, @session_id, @sequence_id, @timestamp,
+                    @tool, @success, @duration_ms, @completed_at, @failure_stage, @error_code,
+                    @error_name, @error_message, @args_bytes, @result_bytes
+                )
+            `).run(record);
+
+            return record.id;
+        } catch (err) {
+            logger.warn('[MemoryCoreRecorderService] Failed to persist tool start telemetry:', err.message);
+            return null;
+        }
+    }
+
+    /**
+     * Persists one redacted tool-call completion, updating its start row when available.
+     * Best-effort only.
      * @param {Object} entry Tool-call metadata.
      * @returns {void}
      */
@@ -180,47 +301,29 @@ class MemoryCoreRecorderService extends Base {
         if (!config.toolTelemetry.enabled || !this.db) return;
 
         try {
-            const
-                timestamp = Number.isFinite(entry.timestamp) ? entry.timestamp : (Number.isFinite(entry.t0) ? entry.t0 : Date.now()),
-                context   = RequestContextService.get?.() || {},
-                agentId   = context.agentIdentityNodeId || process.env.NEO_AGENT_IDENTITY || process.env.NEO_AGENT_ID || process.env.USER || 'unknown',
-                userId    = context.userId || null,
-                sessionId = entry.args?.sessionId || context.sessionId || process.env.NEO_SESSION_ID || null,
-                duration  = Number.isFinite(entry.duration_ms)
-                    ? Math.max(0, entry.duration_ms)
-                    : Math.max(0, Date.now() - (entry.t0 || timestamp)),
-                error    = entry.error || null,
-                id       = entry.id || crypto.randomUUID?.() || `${timestamp}-${Math.random()}`,
-                sequence = entry.sequence_id || `${agentId}_${timestamp}_${id}`;
+            const record = this.buildToolCallRecord(entry, Date.now());
 
             this.db.prepare(`
                 INSERT INTO mc_tool_call_log (
                     id, agent_id, user_id, session_id, sequence_id, timestamp,
-                    tool, success, duration_ms, failure_stage, error_code,
+                    tool, success, duration_ms, completed_at, failure_stage, error_code,
                     error_name, error_message, args_bytes, result_bytes
                 )
                 VALUES (
                     @id, @agent_id, @user_id, @session_id, @sequence_id, @timestamp,
-                    @tool, @success, @duration_ms, @failure_stage, @error_code,
+                    @tool, @success, @duration_ms, @completed_at, @failure_stage, @error_code,
                     @error_name, @error_message, @args_bytes, @result_bytes
                 )
-            `).run({
-                id,
-                agent_id     : agentId,
-                user_id      : userId,
-                session_id   : sessionId,
-                sequence_id  : sequence,
-                timestamp,
-                tool         : entry.toolName || entry.tool || 'unknown',
-                success      : entry.success ? 1 : 0,
-                duration_ms  : duration,
-                failure_stage: entry.failureStage || entry.failure_stage || null,
-                error_code   : error?.code || null,
-                error_name   : error?.name || null,
-                error_message: this.buildErrorMessage(error, entry.args),
-                args_bytes   : this.measureBytes(entry.args),
-                result_bytes : this.measureBytes(entry.result)
-            });
+                ON CONFLICT(id) DO UPDATE SET
+                    success       = excluded.success,
+                    duration_ms   = excluded.duration_ms,
+                    completed_at  = excluded.completed_at,
+                    failure_stage = excluded.failure_stage,
+                    error_code    = excluded.error_code,
+                    error_name    = excluded.error_name,
+                    error_message = excluded.error_message,
+                    result_bytes  = excluded.result_bytes
+            `).run(record);
         } catch (err) {
             logger.warn('[MemoryCoreRecorderService] Failed to persist tool telemetry:', err.message);
         }
@@ -238,11 +341,11 @@ class MemoryCoreRecorderService extends Base {
         limit   = config.toolTelemetry.aggregateLimit
     } = {}) {
         if (!config.toolTelemetry.enabled) {
-            return {status: 'disabled', sinceMs, limit, totalCalls: 0, tools: []};
+            return {status: 'disabled', sinceMs, limit, totalCalls: 0, totalUnfinished: 0, tools: [], unfinishedCalls: []};
         }
 
         if (!this.db) {
-            return {status: 'unavailable', sinceMs, limit, totalCalls: 0, tools: []};
+            return {status: 'unavailable', sinceMs, limit, totalCalls: 0, totalUnfinished: 0, tools: [], unfinishedCalls: []};
         }
 
         this.ensureSchema();
@@ -261,6 +364,7 @@ class MemoryCoreRecorderService extends Base {
                        MAX(timestamp) AS last_seen_at
                   FROM mc_tool_call_log
                  WHERE timestamp >= @sinceTs
+                   AND completed_at IS NOT NULL
                  GROUP BY tool
                  ORDER BY calls DESC, tool ASC
                  LIMIT @limit
@@ -269,13 +373,30 @@ class MemoryCoreRecorderService extends Base {
                 SELECT COUNT(*) AS total
                   FROM mc_tool_call_log
                  WHERE timestamp >= @sinceTs
-            `).get({sinceTs})?.total || 0;
+                   AND completed_at IS NOT NULL
+            `).get({sinceTs})?.total || 0,
+            totalUnfinished = this.db.prepare(`
+                SELECT COUNT(*) AS total
+                  FROM mc_tool_call_log
+                 WHERE timestamp >= @sinceTs
+                   AND completed_at IS NULL
+            `).get({sinceTs})?.total || 0,
+            unfinishedRows = this.db.prepare(`
+                SELECT id, timestamp, tool
+                  FROM mc_tool_call_log
+                 WHERE timestamp >= @sinceTs
+                   AND completed_at IS NULL
+                 ORDER BY timestamp ASC, id ASC
+                 LIMIT @limit
+            `).all({sinceTs, limit: safeLimit}),
+            now = Date.now();
 
         return {
             status    : 'ok',
             sinceMs   : safeSinceMs,
             limit     : safeLimit,
             totalCalls: total,
+            totalUnfinished,
             tools     : rows.map(row => ({
                 tool         : row.tool,
                 calls        : row.calls,
@@ -284,6 +405,12 @@ class MemoryCoreRecorderService extends Base {
                 avgDurationMs: row.avg_duration_ms ?? null,
                 maxDurationMs: row.max_duration_ms ?? null,
                 lastSeenAt   : row.last_seen_at ? new Date(row.last_seen_at).toISOString() : null
+            })),
+            unfinishedCalls: unfinishedRows.map(row => ({
+                callId   : row.id,
+                tool     : row.tool,
+                startedAt: new Date(row.timestamp).toISOString(),
+                elapsedMs: Math.max(0, now - row.timestamp)
             }))
         };
     }

--- a/test/playwright/unit/ai/services/memory-core/MemoryCoreRecorderService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/MemoryCoreRecorderService.spec.mjs
@@ -88,6 +88,122 @@ test.describe('Neo.ai.services.memory-core.MemoryCoreRecorderService', () => {
         `).get();
 
         expect(table.name).toBe('mc_tool_call_log');
+
+        const columns = MemoryCoreRecorderService.db.prepare('PRAGMA table_info(mc_tool_call_log)').all();
+        expect(columns.some(column => column.name === 'completed_at')).toBe(true);
+        expect(MemoryCoreRecorderService.db.pragma('busy_timeout', {simple: true})).toBe(50);
+    });
+
+    test('migrates completed legacy rows without relabeling them as unfinished', async () => {
+        const
+            Database = (await import('better-sqlite3')).default,
+            db       = new Database(':memory:');
+
+        try {
+            db.exec(`
+                CREATE TABLE mc_tool_call_log (
+                    id            TEXT PRIMARY KEY,
+                    agent_id      TEXT,
+                    user_id       TEXT,
+                    session_id    TEXT,
+                    sequence_id   TEXT NOT NULL,
+                    timestamp     INTEGER NOT NULL,
+                    tool          TEXT NOT NULL,
+                    success       INTEGER DEFAULT 0,
+                    duration_ms   INTEGER,
+                    failure_stage TEXT,
+                    error_code    TEXT,
+                    error_name    TEXT,
+                    error_message TEXT,
+                    args_bytes    INTEGER DEFAULT 0,
+                    result_bytes  INTEGER DEFAULT 0
+                );
+                INSERT INTO mc_tool_call_log (
+                    id, sequence_id, timestamp, tool, success, duration_ms
+                ) VALUES ('legacy-call', 'legacy-sequence', 1000, 'healthcheck', 1, 25);
+            `);
+
+            MemoryCoreRecorderService.ensureSchema.call({db});
+
+            const row = db.prepare(`
+                SELECT completed_at
+                  FROM mc_tool_call_log
+                 WHERE id = 'legacy-call'
+            `).get();
+
+            expect(row.completed_at).toBe(1025);
+
+            // Simulate a process dying after ALTER TABLE but before its legacy-row backfill.
+            db.prepare(`
+                UPDATE mc_tool_call_log
+                   SET completed_at = NULL
+                 WHERE id = 'legacy-call'
+            `).run();
+
+            MemoryCoreRecorderService.ensureSchema.call({db});
+
+            expect(db.prepare(`
+                SELECT completed_at
+                  FROM mc_tool_call_log
+                 WHERE id = 'legacy-call'
+            `).get().completed_at).toBe(1025);
+        } finally {
+            db.close();
+        }
+    });
+
+    test('persists an in-flight start boundary and completes the same redacted row', () => {
+        const
+            t0 = Date.now() - 8,
+            id = MemoryCoreRecorderService.beginToolCall({
+                toolName: 'list_messages',
+                args    : {body: secret, status: 'unread'},
+                t0
+            });
+
+        const active = MemoryCoreRecorderService.db.prepare(`
+            SELECT *
+              FROM mc_tool_call_log
+             WHERE id = ?
+        `).get(id);
+
+        expect(id).toBeTruthy();
+        expect(active.tool).toBe('list_messages');
+        expect(active.duration_ms).toBeNull();
+        expect(active.completed_at).toBeNull();
+        expect(JSON.stringify(active)).not.toContain(secret);
+
+        const during = MemoryCoreRecorderService.getMemoryCoreToolMetrics({sinceMs: 60_000, limit: 10});
+        expect(during.totalCalls).toBe(0);
+        expect(during.totalUnfinished).toBe(1);
+        expect(during.unfinishedCalls[0]).toMatchObject({callId: id, tool: 'list_messages'});
+        expect(during.unfinishedCalls[0]).not.toHaveProperty('agentId');
+        expect(during.unfinishedCalls[0]).not.toHaveProperty('sessionId');
+        expect(JSON.stringify(during)).not.toContain(secret);
+
+        MemoryCoreRecorderService.logToolCall({
+            id,
+            toolName: 'list_messages',
+            args    : {body: secret, status: 'unread'},
+            result  : {messages: []},
+            success : true,
+            t0
+        });
+
+        const completed = MemoryCoreRecorderService.db.prepare(`
+            SELECT *
+              FROM mc_tool_call_log
+             WHERE id = ?
+        `).get(id);
+
+        expect(completed.completed_at).toBeGreaterThanOrEqual(t0);
+        expect(completed.duration_ms).toBeGreaterThanOrEqual(0);
+        expect(MemoryCoreRecorderService.db.prepare('SELECT COUNT(*) AS count FROM mc_tool_call_log').get().count).toBe(1);
+
+        const after = MemoryCoreRecorderService.getMemoryCoreToolMetrics({sinceMs: 60_000, limit: 10});
+        expect(after.totalCalls).toBe(1);
+        expect(after.totalUnfinished).toBe(0);
+        expect(after.unfinishedCalls).toEqual([]);
     });
 
     test('records bounded metadata without raw Memory Core payloads', () => {
@@ -108,6 +224,7 @@ test.describe('Neo.ai.services.memory-core.MemoryCoreRecorderService', () => {
         `).get();
 
         expect(row.success).toBe(0);
+        expect(row.completed_at).not.toBeNull();
         expect(row.failure_stage).toBe('dispatch');
         expect(row.args_bytes).toBeGreaterThan(0);
         expect(row.result_bytes).toBeGreaterThan(0);
@@ -148,7 +265,11 @@ test.describe('Neo.ai.services.memory-core.MemoryCoreRecorderService', () => {
     test('captures Memory Core MCP wrapper success and dispatch failure', async () => {
         const {callTool} = await import('../../../../../../ai/mcp/server/memory-core/toolService.mjs');
 
-        await callTool('get_memory_core_tool_metrics', {sinceMs: 60_000, limit: 5});
+        const metrics = await callTool('get_memory_core_tool_metrics', {sinceMs: 60_000, limit: 5});
+
+        expect(metrics.totalUnfinished).toBe(0);
+        expect(metrics.unfinishedCalls).toEqual([]);
+
         await expect(callTool('missing_memory_core_tool', {})).rejects.toThrow(/not found/);
 
         const rows = MemoryCoreRecorderService.db.prepare(`
@@ -202,10 +323,18 @@ test.describe('Neo.ai.services.memory-core.MemoryCoreRecorderService', () => {
                 t0      : Date.now()
             })).not.toThrow();
 
+            expect(MemoryCoreRecorderService.beginToolCall({
+                toolName: 'add_memory',
+                args    : {prompt: secret},
+                t0      : Date.now()
+            })).toBeNull();
+
             expect(MemoryCoreRecorderService.getMemoryCoreToolMetrics()).toMatchObject({
-                status    : 'unavailable',
-                totalCalls: 0,
-                tools     : []
+                status         : 'unavailable',
+                totalCalls     : 0,
+                totalUnfinished: 0,
+                tools          : [],
+                unfinishedCalls: []
             });
         } finally {
             MemoryCoreRecorderService.db = originalDb;


### PR DESCRIPTION
Resolves #16685

Related: #16677

Memory Core now writes a redacted telemetry row before each non-observer MCP tool dispatch, completes that same row on return, and reports bounded oldest-first unfinished calls separately from completed latency/failure aggregates. The diagnostics observer is excluded from its own unfinished snapshot, telemetry storage waits at most 50 ms on SQLite contention, and all failure paths remain fail-open. This gives the parent liveness incident a durable operation identity for the next recurrence without claiming that the CPU/event-loop wedge itself is repaired.

Evidence: L2 (real SQLite row lifecycle, schema migration, and Memory Core facade dispatch tests) → L2 required (all close-target acceptance criteria are deterministic in-process contracts). No residuals.

## Deltas from ticket

None substantive.

## Test Evidence

- Memory Core recorder + public OpenAPI surface: `npx playwright test -c test/playwright/playwright.config.unit.mjs test/playwright/unit/ai/services/memory-core/MemoryCoreRecorderService.spec.mjs test/playwright/unit/ai/mcp/validation/OpenApiValidatorCompliance.spec.mjs` — 57/57 passed before and after rebasing onto current `dev`.
- Staged repository gates: `npx lint-staged --verbose` — whitespace, shorthand, JSDoc types, ticket archaeology, block alignment, parse, AiConfig test mutation, derived-domain, and OpenAPI/service parity all passed.
- Schema/service contract: `node ./ai/scripts/lint/lint-openapi-service-parity.mjs` — 40 wrapped services, 121 operation-bound methods, 142 object-dispatch handlers, zero consumed-but-undeclared parameters.
- Directly touched feature surface coverage: `MemoryCoreRecorderService.spec.mjs` covers legacy/partial migration, start-row redaction, same-row completion, completed/unfinished separation, observer exclusion, wrapper success/failure, health/policy hooks, and unavailable fail-open behavior.

## Post-Merge Validation

- [ ] After the next canonical Memory Core deployment, call `get_memory_core_tool_metrics` once and verify the observer does not report itself as unfinished.
- [ ] On the next `#16677` recurrence, capture the oldest unfinished tool identity and correlate it with event-loop/heap/pulse evidence before assigning a root cause.

## Evolution

Self-review replaced “in-flight” with “unfinished” because a start row may be abandoned by a prior process, removed agent/session identifiers from the public unfinished projection, and made the metrics observer completion-only so a healthy read cannot manufacture its own alert.

Authored by Emmy (GPT-5.6 Sol Ultra, Codex). Session 019fe0b3-53bc-7ef2-8665-41a0ef3f7b62.
