### PR TITLE
fix(workstation): the tour entry projection admits the validated in-place path (#16683)

### DIFF
--- a/apps/workstation/view/Workspace.mjs
+++ b/apps/workstation/view/Workspace.mjs
@@ -2342,15 +2342,27 @@ class Workspace extends Container {
         // As a PROBE (`restoreDocument: true`), the displaced live document is restored after
         // the replay, so a replay can never edit the surface it measures. The transaction owns
         // the baseline swap too: a rejecting entry projection must still destroy the runner and
-        // service, and must still restore the probe's displaced document. Both projections are
-        // full — the swap and the restore can each change topology, so neither may declare a
-        // geometry-only projection over the transition.
+        // service, and must still restore the probe's displaced document.
+        //
+        // The ENTRY projection declares `geometryOnly` — validated in-place ADMISSION, not a
+        // skip: `DockProjectionReconciler.reconcileProjection` (:314) attempts
+        // `reconcileStableTopology` (:130), which returns null on ANY node/type/ancestry/order/
+        // orientation delta and falls back to the full staged transaction. The workspace boots
+        // from the same `initialDocument` the entry re-stages, so the proven-stable in-place
+        // path applies and the staged shell swap — whose intermediate state presents a cleared
+        // workspace body on camera (one compositor frame, measured at capture minFrameIndex
+        // 7/59, minEntropy 0.41 vs baseline 5.30) — never runs on the same-topology path. A
+        // genuinely changed topology still takes the staged path unchanged (the residual blank
+        // for that branch is documented on the ticket; present-no-intermediate-state is the
+        // deferred stronger shape). The RESTORE projection stays full deliberately: at
+        // probe-restore time the shell typically diverges from the displaced document, so
+        // admission would validate-and-fall-back with no gain.
         let completed = false,
             out       = null;
 
         try {
             me.dockModel = DockZoneModel.clone(initialDocument);
-            await me.refreshDockWorkspace();
+            await me.refreshDockWorkspace({geometryOnly: true});
 
             const result = await runner.start();
 

--- a/test/playwright/unit/apps/workstation/Workspace.spec.mjs
+++ b/test/playwright/unit/apps/workstation/Workspace.spec.mjs
@@ -2345,6 +2345,43 @@ test.describe('replay probe transaction (prototype-call)', () => {
         expect(refreshCalls, 'the rejecting restore projection ran and was recorded').toHaveLength(2)
     });
 
+    test('the entry projection requests validated in-place admission; the restore stays full', async () => {
+        const
+            liveDocument = {nodes: {marker: 'live'}},
+            refreshCalls = [],
+            host         = {
+                dockModel     : liveDocument,
+                id            : 'fake-workspace',
+                isDestroyed   : false,
+                refreshPromise: Promise.resolve(),
+                refreshDockWorkspace(options) {
+                    refreshCalls.push(options ?? {});
+
+                    return Promise.resolve()
+                }
+            },
+            script = {
+                schema: 'neo.tour.script.v1',
+                id    : 'clean-pause',
+                title : 'clean pause',
+                scenes: [{id: 's1', title: 'pause', steps: [{type: 'pause', ms: 1}]}]
+            };
+
+        await Workspace.prototype.runTourSpec.call(host, script, {restoreDocument: true});
+
+        // Entry declares admission to the validated in-place path (reconcileStableTopology
+        // null-falls-back to the staged transaction on any topology delta — the fallback
+        // contract is pinned in DockProjectionReconciler.spec.mjs). The staged shell swap's
+        // cleared-body intermediate frame must never ride the same-topology entry.
+        expect(refreshCalls[0], 'the entry projection requests geometry-only admission')
+            .toEqual({geometryOnly: true});
+
+        // The restore transition can genuinely change topology (the replay edited the
+        // workspace); it stays on the full staged path with no admission declared.
+        expect(refreshCalls[1], 'the restore projection stays full').toEqual({});
+        expect(host.dockModel, 'the displaced document is restored').toBe(liveDocument)
+    });
+
     test('a rejecting entry projection leaves the driver default without a restore', async () => {
         const
             liveDocument = {nodes: {marker: 'live'}},


### PR DESCRIPTION
Resolves #16683

The tour-entry cleared-body blank is repaired at its named seam: `runTourSpec`'s entry projection now declares `geometryOnly` — validated in-place **admission**, not a skip. `DockProjectionReconciler.reconcileProjection` (`src/dashboard/DockProjectionReconciler.mjs:314`) treats the flag as admission-to-attempt `reconcileStableTopology` (`:130`), which returns null on ANY node/type/ancestry/order/orientation delta and falls back to the full staged transaction — so the same-topology entry (the workspace re-staging its own `initialDocument`, i.e. every film run) takes the in-place path and the staged shell swap's cleared-body intermediate frame never presents, while a genuinely changed topology still gets the staged path unchanged. The stale call-site comment claiming "neither may declare a geometry-only projection over the transition" was wrong about the flag's semantics and is truth-folded with the contract citations; the restore projection stays full deliberately (at probe-restore time the shell typically diverges from the displaced document, so admission would validate-and-fall-back with no gain) — an explicit non-change, documented in-code with the residual (changed-topology entries can still blank; present-no-intermediate-state is the deferred stronger shape, per the ticket's Avoided Traps).

Evidence: L3 (headed film-mode runs on the isolated-display stage + headed dense tour) — the full requirement for every AC; no sandbox-unreachable residual. Residual: none [#16683].

## Deltas from ticket

None substantive. One scope note: AC-2's fallback half is pinned by existing src-side coverage rather than a new test — `DockProjectionReconciler.spec.mjs:452` ("falls back when a geometry-only projection changes split orientation") plus its staged-count assertions already red-prove the null-fallback contract, so the new unit witness pins only the call-site contract (entry admission + restore-stays-full), avoiding duplicate coverage of the reconciler's own guarantee.

## Test Evidence

- Unit (`test/playwright/playwright.config.unit.mjs`, apps/workstation/Workspace): **37/37 passed** incl. the new witness — `refreshCalls[0]` equals `{geometryOnly: true}`, `refreshCalls[1]` equals `{}` (restore full), displaced document restored.
- Film-mode scene 1 (`WorkstationFiveBeatNL`, `NEO_FILM_TAKE=1`, isolated-display stage `2632,-249,1200,1040`), **×3 consecutive green** at this head: minEntropy **5.3038 / 5.3126 / 5.3100** vs baselines ~5.35 (floor 3.48-class), `minFrameIndex` moved from **7** (the entry defect, this morning's red-control at `0.4088`) to **26** (ordinary mid-capture variance) on all three runs.
- Same-day red-control at the pre-fix head (falsifier-1 on `#16500`, receipts at `#16500` issuecomment-5225908387): control RED `0.4088` minFrame 7/59; treatment (this exact change as an uncommitted probe) GREEN `5.3480` — the red/green pair that named this seam.
- Driver-path regression: dense tour (`WorkstationNL` "the real tour keeps density…") headed **GREEN 25.6s** at this head — every runTourSpec driver consumer exercises the changed entry.
- Touched surface `apps/workstation`: the two suites above are the surface's own coverage.

## Post-Merge Validation

- [ ] The next five-beat film take's scene-1 entropy receipt stays green with Vega's per-step oracle once `#16500`'s instrument refactor lands (the agreed joint witness run).

## Related

Refs #16500 (Vega's oracle instrument — the ownership split and falsifier receipts live there) · Refs #16473 (origin of the full entry projection; its correctness contract is preserved via the validated fallback) · Refs #16412 (the hazard the stale comment cited) · Related: #15252 (film epic — this is one of the three v1-gate legs)

Authored by Mnemosyne (Claude Fable 5, Claude Code). Session e7da18d8-1563-4ab8-9b88-75afc13aa74e.
