### PR TITLE
feat(deploy): a mutable NEO_REF is refused, because it freezes the source layer (#16635)

### DIFF
--- a/ai/deploy/Dockerfile
+++ b/ai/deploy/Dockerfile
@@ -40,9 +40,15 @@ WORKDIR /neo
 # What this guard does NOT buy, stated rather than implied: it constrains the ref, not the
 # cache. `NEO_ALLOW_MUTABLE_REF=1` re-admits a channel for a hand-run build and re-admits the
 # freeze with it — that build is only fresh if it also passes `--no-cache`.
+#
+# The override is EXACT EQUALITY to `1`, never shell truthiness. An escape hatch is a tiny
+# authorization parser, and `[ -n "$VAR" ]` would make `0`, `false`, a stray space, and any
+# typo all mean YES — so misspelling a safety override would silently admit the cache-frozen
+# layer this guard exists to refuse. A near-miss value must fail the same way an absent one
+# does; `NEO_ALLOW_MUTABLE_REF=0` meaning "allow" is the specific absurdity being avoided.
 RUN neo_ref_is_sha=0; \
     printf '%s' "${NEO_REF}" | grep -Eq '^[0-9a-f]{40}$' && neo_ref_is_sha=1; \
-    if [ "${neo_ref_is_sha}" -eq 0 ] && [ -z "${NEO_ALLOW_MUTABLE_REF}" ]; then \
+    if [ "${neo_ref_is_sha}" -eq 0 ] && [ "${NEO_ALLOW_MUTABLE_REF}" != "1" ]; then \
         echo "[deploy] FATAL: NEO_REF='${NEO_REF}' is not a full 40-hex commit SHA." >&2; \
         echo "[deploy] A mutable ref freezes this layer: a second build reuses the first" >&2; \
         echo "[deploy]   build's commit forever, and reports success while doing it." >&2; \
@@ -50,8 +56,9 @@ RUN neo_ref_is_sha=0; \
         echo "[deploy]   export NEO_REVISION=\$(git ls-remote ${NEO_REPO_URL} <channel> | cut -f1)" >&2; \
         echo "[deploy]   (Compose maps that one pin to both NEO_REF and NEO_REVISION.)" >&2; \
         echo "[deploy] Dev iteration instead: --build-arg NEO_SOURCE=local" >&2; \
-        echo "[deploy] Deliberate exception: --build-arg NEO_ALLOW_MUTABLE_REF=1, which accepts" >&2; \
-        echo "[deploy]   a FROZEN layer unless the build also passes --no-cache." >&2; \
+        echo "[deploy] Deliberate exception: --build-arg NEO_ALLOW_MUTABLE_REF=1 exactly (no" >&2; \
+        echo "[deploy]   other value opts in), which accepts a FROZEN layer unless the build" >&2; \
+        echo "[deploy]   also passes --no-cache." >&2; \
         exit 1; \
     fi
 

--- a/ai/deploy/Dockerfile
+++ b/ai/deploy/Dockerfile
@@ -5,7 +5,9 @@
 # `--build-arg NEO_SOURCE=local` (the build context must then be the neo repo root). A
 # published npm package supersedes this after the v13 release.
 #   NEO_SOURCE   : 'git' (default) | 'local'
-#   NEO_REF      : git ref to clone (default 'dev'; pin to a tag/SHA for full reproducibility)
+#   NEO_REF      : git ref to fetch. MUST be a full 40-hex commit SHA — a mutable ref is
+#                  refused, because it does not merely cost reproducibility, it costs
+#                  FRESHNESS (see the source-git stage). Resolve a channel to a SHA first.
 #   NEO_REPO_URL : neo repository (MIT-licensed) to clone from
 # ---------------------------------------------------------------------------------------
 ARG NEO_SOURCE=git
@@ -15,9 +17,46 @@ ARG NEO_REPO_URL=https://github.com/neomjs/neo.git
 FROM alpine/git AS source-git
 ARG NEO_REF
 ARG NEO_REPO_URL
+ARG NEO_ALLOW_MUTABLE_REF=
 WORKDIR /neo
-# fetch + checkout (NOT `clone --branch`, which rejects raw SHAs) so NEO_REF accepts a
-# branch, a tag, OR a full commit SHA (the reproducible pin). GitHub serves reachable SHAs.
+# FAIL CLOSED on a ref that is not content-addressed.
+#
+# The fetch below is ONE cache-keyed RUN. Its cache key is the command string plus the ARG
+# values it consumes, so with a channel name like `dev` that key is byte-identical on every
+# build: Docker reuses the layer and THE FETCH NEVER RUNS AGAIN. The image then packages
+# whatever the channel pointed at the first time the layer was built, and the build log still
+# prints the fetch command, because printing a cached layer's command is what Docker does.
+#
+# This is measured, not theorised. D#16304 records a `docker compose up -d --build --wait`
+# against this stack that was a full cache hit: no image built, containers recreated from
+# three-week-old images, and the running revision moved BACKWARDS (cf5f366344 -> c2304ea118)
+# while `redeployPreflight`, `--wait` health, and exit code zero all reported success. `--wait`
+# proves health; it never proves revision.
+#
+# So a SHA is not "for reproducibility" with freshness assumed. Without a SHA there is no
+# freshness at all, and the two options are not `pinned` versus `tracking` — they are pinned
+# deliberately versus pinned accidentally, at an arbitrary past commit.
+#
+# What this guard does NOT buy, stated rather than implied: it constrains the ref, not the
+# cache. `NEO_ALLOW_MUTABLE_REF=1` re-admits a channel for a hand-run build and re-admits the
+# freeze with it — that build is only fresh if it also passes `--no-cache`.
+RUN neo_ref_is_sha=0; \
+    printf '%s' "${NEO_REF}" | grep -Eq '^[0-9a-f]{40}$' && neo_ref_is_sha=1; \
+    if [ "${neo_ref_is_sha}" -eq 0 ] && [ -z "${NEO_ALLOW_MUTABLE_REF}" ]; then \
+        echo "[deploy] FATAL: NEO_REF='${NEO_REF}' is not a full 40-hex commit SHA." >&2; \
+        echo "[deploy] A mutable ref freezes this layer: a second build reuses the first" >&2; \
+        echo "[deploy]   build's commit forever, and reports success while doing it." >&2; \
+        echo "[deploy] Resolve the channel once, then pin once:" >&2; \
+        echo "[deploy]   export NEO_REVISION=\$(git ls-remote ${NEO_REPO_URL} <channel> | cut -f1)" >&2; \
+        echo "[deploy]   (Compose maps that one pin to both NEO_REF and NEO_REVISION.)" >&2; \
+        echo "[deploy] Dev iteration instead: --build-arg NEO_SOURCE=local" >&2; \
+        echo "[deploy] Deliberate exception: --build-arg NEO_ALLOW_MUTABLE_REF=1, which accepts" >&2; \
+        echo "[deploy]   a FROZEN layer unless the build also passes --no-cache." >&2; \
+        exit 1; \
+    fi
+
+# fetch + checkout (NOT `clone --branch`, which rejects raw SHAs) so NEO_REF accepts a full
+# commit SHA — the only value that is its own content. GitHub serves reachable SHAs.
 RUN git init -q && git remote add origin "${NEO_REPO_URL}" \
     && git fetch --depth 1 origin "${NEO_REF}" \
     && git checkout -q --detach FETCH_HEAD \
@@ -116,9 +155,24 @@ ARG NEO_REVISION=
 # The label is an assertion, while /app/.neo-revision is measured artifact truth.
 # Fail the build before stamping a non-empty assertion that disagrees with the source
 # stage. This also rejects a revision claim on `NEO_SOURCE=local` (`local-build`).
+#
+# The SECOND clause exists because the first is OFF in the configuration most likely to be
+# wrong: `NEO_REVISION` is empty by default, so an unpinned build asserted nothing and this
+# gate — the one mechanism that could catch a stale package — was a no-op exactly there.
+# Now that the source stage refuses a non-SHA `NEO_REF`, that ARG is itself a checkable claim
+# and needs no caller to supply one: a SHA-shaped `NEO_REF` must equal what was packaged.
+# It stays silent for `NEO_SOURCE=local` (whose `NEO_REF` is the non-SHA global default) and
+# fires if a local build is handed a SHA — a revision claim over `local-build` is the
+# fabrication the note above already forbids.
 RUN actual_revision="$(cat /app/.neo-revision)" \
     && if [ -n "${NEO_REVISION}" ] && [ "${NEO_REVISION}" != "${actual_revision}" ]; then \
         echo "[deploy] FATAL: NEO_REVISION integrity mismatch: asserted '${NEO_REVISION}', packaged '${actual_revision}'." >&2; \
+        exit 1; \
+    fi \
+    && if printf '%s' "${NEO_REF}" | grep -Eq '^[0-9a-f]{40}$' && [ "${NEO_REF}" != "${actual_revision}" ]; then \
+        echo "[deploy] FATAL: NEO_REF integrity mismatch: requested '${NEO_REF}', packaged '${actual_revision}'." >&2; \
+        echo "[deploy] A SHA-pinned build that packaged a different commit means the source layer" >&2; \
+        echo "[deploy]   was served from cache. Rebuild with --no-cache." >&2; \
         exit 1; \
     fi
 

--- a/ai/scripts/lifecycle/local-agent-os/README.md
+++ b/ai/scripts/lifecycle/local-agent-os/README.md
@@ -61,9 +61,16 @@ silent. Declare a role explicitly if you need that entrypoint directly.
 ## Start the container plane
 
 Run from the repository root after provisioning `.env` and the mode-0600
-`.neo-ai-secrets/mcp-auth-token`:
+`.neo-ai-secrets/mcp-auth-token`.
+
+**Resolve the channel to a commit first.** Compose maps one operator pin to both
+internal Docker arguments, and the source stage refuses a mutable ref (#16635) —
+a branch name makes the fetch layer cache-stable, so the build would package
+whatever `dev` pointed at the first time it ran and report success doing it:
 
 ```sh
+export NEO_REVISION=$(git ls-remote https://github.com/neomjs/neo.git dev | cut -f1)
+
 docker compose --env-file .env \
   -f ai/deploy/docker-compose.yml \
   -f ai/deploy/docker-compose.local-agent-os.yml \
@@ -72,6 +79,24 @@ docker compose --env-file .env \
 
 The canonical project is `neo-local-agent-os` unless
 `NEO_LOCAL_AGENT_OS_PROJECT_NAME` explicitly overrides it.
+
+### Updating an already-running plane
+
+Same resolve step, then `--build`. Do not trust the build log or `--wait`: the
+log prints a cached layer's command exactly as it prints an executed one, and
+`--wait` proves *health*, never *revision*. `D#16304` records this path running
+as a full cache hit — containers recreated from three-week-old images with the
+running revision moving **backwards** — while every gate in the stack reported
+success. With `NEO_REVISION` exported, the build now fails closed instead.
+
+Verify what actually shipped by reading the artifact rather than the graph:
+
+```sh
+docker compose --env-file .env \
+  -f ai/deploy/docker-compose.yml \
+  -f ai/deploy/docker-compose.local-agent-os.yml \
+  --profile cloud exec mc-server cat /app/.neo-revision
+```
 
 ## Install the host edge (macOS, supervised)
 

--- a/learn/agentos/cloud-deployment/Day0Tutorial.md
+++ b/learn/agentos/cloud-deployment/Day0Tutorial.md
@@ -46,11 +46,14 @@ npm install
 ```
 
 > **Deploy images source neo independently.** The `ai/deploy` images build by
-> cloning neo at a pinned ref (`NEO_REF`, default `dev`), so they do **not** require a
+> cloning neo at a pinned ref (`NEO_REF`), so they do **not** require a
 > co-located checkout — any operator or CI host can build them. This local checkout is for
 > running the tutorial's commands and for dev iteration (`--build-arg NEO_SOURCE=local`,
-> with the neo repo root as the build context). Pin `NEO_REF` to a tag/SHA for a fully
-> reproducible deployment.
+> with the neo repo root as the build context). `NEO_REF` must be a **full commit SHA**:
+> a channel name makes the source layer cache-stable, so the build would silently package
+> the commit that channel pointed at the first time it ran (#16635). Resolve once with
+> `export NEO_REVISION=$(git ls-remote https://github.com/neomjs/neo.git dev | cut -f1)`;
+> Compose maps that single pin to both internal Docker arguments.
 
 Required local tools:
 

--- a/learn/agentos/cloud-deployment/PipelineWiring.md
+++ b/learn/agentos/cloud-deployment/PipelineWiring.md
@@ -88,7 +88,7 @@ Read the requested selector against the resolved commit — the *direction* of a
 
 | Requested | Resolved (file) | Reading |
 |---|---|---|
-| a channel, e.g. `dev` | some commit | Expected. No pin was given, so the resolved commit is the sole identity — and `org.opencontainers.image.revision` will be empty, correctly asserting nothing. |
+| a channel, e.g. `dev` | some commit | **Only reachable via the `NEO_ALLOW_MUTABLE_REF=1` exception** — an ordinary unpinned build now refuses at the source stage (#16635). Where the exception was used, the resolved commit is the sole identity and `org.opencontainers.image.revision` is empty, correctly asserting nothing. Treat the commit as *whenever that layer was last built*, not as `dev`'s current tip. |
 | a pinned SHA | the same SHA | The pin held. Promote this image. |
 | a pinned SHA | a **different** SHA | **Build-integrity failure.** Not an oddity — the build did not produce what was asked for. Do not promote; rebuild and investigate. |
 

--- a/learn/agentos/cloud-deployment/PipelineWiring.md
+++ b/learn/agentos/cloud-deployment/PipelineWiring.md
@@ -58,9 +58,9 @@ docker compose -f ai/deploy/docker-compose.yml [--profile …] build
 
 Compose maps that one full SHA to both Docker arguments for `kb-server`, `mc-server`, and `orchestrator`. The reference pipeline keeps `NEO_REF` as its pre-resolution selector input, resolves it once, then removes it before handing the canonical `NEO_REVISION` to Compose.
 
-Left unset, the internal `NEO_REF` defaults to `dev` and `NEO_REVISION` stays empty — the pre-existing behaviour, with no revision asserted.
+Left unset, the internal `NEO_REF` falls back to `dev`, and **the source stage refuses to build** (#16635). That refusal replaced the prior behaviour, which was worse than "no revision asserted": a channel name makes the fetch layer cache-stable, so an unpinned rebuild silently packaged the commit `dev` pointed at the *first* time that layer was built. `D#16304` records exactly this — a full cache hit that recreated containers from three-week-old images and moved the running revision backwards, while `redeployPreflight`, `--wait` health, and exit code zero all reported success.
 
-**Pass the full 40-character SHA.** An abbreviated SHA fails closed at `git fetch`, before any checkout — correct behaviour, since an abbreviated ref is not a reproducible pin, but the error surfaces as a fetch failure rather than as anything mentioning provenance. Observed in a live rehearsal run against a 12-character SHA. The `git ls-remote` form above avoids this by construction, which is why it is the documented path rather than prose asking you to be careful.
+**Pass the full 40-character SHA.** An abbreviated SHA is refused by the source-stage guard, before the fetch and therefore before any network access, with a message that names the freeze and the `ls-remote` resolve command. Previously it surfaced deeper, as a bare `git fetch` failure mentioning nothing about provenance — observed in a live rehearsal run against a 12-character SHA. The `git ls-remote` form above avoids the situation by construction, which is why it is the documented path rather than prose asking you to be careful.
 
 Prefer a resolved SHA over a branch name for two independent reasons. Docker does **not** automatically invalidate a `RUN` layer when remote content changes, so re-running `build` against a mutable branch does not mechanically prove the branch was re-fetched — a changing build argument gives the cache a changing input. And a mutable channel is *policy input*, never a build identity: resolving it yourself, once, before the build is the only way the image can honestly state what it contains.
 
@@ -74,8 +74,8 @@ docker compose -f ai/deploy/docker-compose.yml --profile cloud config | grep -E 
 
 | Fact | Surface | Contract |
 |---|---|---|
-| Requested source ref | `org.neomjs.image.requested-ref` label | What the Docker source stage was *asked* to fetch: `dev` on the unpinned path, or the same full SHA as `NEO_REVISION` on the pinned path. Vendor-namespaced because no OCI standard key means "what was asked for". |
-| Packaged revision | `org.opencontainers.image.revision` label | The OCI-specified source-control revision of the packaged software. Caller-supplied once via `NEO_REVISION`; **empty when not supplied**, which reads as *not asserted*. It must never contain a channel name, and the Docker build fails if it differs from `/app/.neo-revision`. |
+| Requested source ref | `org.neomjs.image.requested-ref` label | What the Docker source stage was *asked* to fetch — since #16635 that is the same full SHA as `NEO_REVISION`, because a mutable ref no longer builds. It still reads `dev` on a `NEO_SOURCE=local` image (which fetched nothing) or under the explicit `NEO_ALLOW_MUTABLE_REF=1` opt-in. Vendor-namespaced because no OCI standard key means "what was asked for". |
+| Packaged revision | `org.opencontainers.image.revision` label | The OCI-specified source-control revision of the packaged software. Caller-supplied once via `NEO_REVISION`; **empty when not supplied**, which reads as *not asserted*. It must never contain a channel name, and the Docker build fails if it differs from `/app/.neo-revision`. Since #16635 a SHA-shaped `NEO_REF` is checked against `/app/.neo-revision` too, so a cache-served source layer fails the build even when the caller asserted nothing. |
 | Resolved commit | `/app/.neo-revision` | The commit the build actually checked out, written at build time. Always populated, always true — so this is the **primary** provenance fact; the label above is its machine-readable echo when the caller resolved properly. |
 
 ```bash

--- a/test/playwright/unit/ai/deploy/SourceRefFreezeGuard.spec.mjs
+++ b/test/playwright/unit/ai/deploy/SourceRefFreezeGuard.spec.mjs
@@ -1,0 +1,226 @@
+import {test, expect} from '@playwright/test';
+import {spawnSync}    from 'node:child_process';
+import fs             from 'node:fs/promises';
+import os             from 'node:os';
+import path           from 'node:path';
+import process        from 'node:process';
+
+/**
+ * Guards the source-acquisition ref contract of `ai/deploy/Dockerfile`.
+ *
+ * ## The defect this exists to keep closed
+ *
+ * The source stage's fetch is ONE cache-keyed `RUN`. With a channel name like `dev`, its cache key is
+ * byte-identical on every build, so Docker reuses the layer and the fetch never runs again — the image
+ * packages whatever the channel pointed at the FIRST time the layer was built, and the build log still
+ * prints the fetch command, because that is what Docker prints for a cached layer.
+ *
+ * Not hypothetical (ticket-ref-ok: D#16304 is the incident RECORD this spec encodes, not a tracking
+ * ref — it holds the measured SHA pair below and stays true after the Discussion closes): a
+ * `docker compose up -d --build --wait` against this stack was a full cache hit and moved the running
+ * plane BACKWARDS (`cf5f366344` -> `c2304ea118`) while `redeployPreflight`, `--wait` health, and exit
+ * code zero all reported success.
+ *
+ * ## Why this is a unit spec, and what it therefore does NOT establish
+ *
+ * Every assertion here runs the Dockerfile's OWN shell text — extracted from the file that ships and
+ * executed under `sh` — so it cannot drift from a paraphrase. It needs no Docker daemon and no network,
+ * matching the sibling contract in `DeployPipelineRevisionPin.spec.mjs`.
+ *
+ * The boundary, stated rather than implied: this proves the guard's LOGIC and its POSITION in the
+ * stage. It does not prove Docker executes it, because that is a property of the builder, not of the
+ * text. That half is covered by real `docker build --target source-git` receipts recorded on the PR;
+ * if the two ever disagree, the daemon is authoritative and this spec is the thing that is wrong.
+ *
+ * The load-bearing arms are the NEGATIVE ones. A guard that only proves a full SHA is accepted passes
+ * on the pre-fix Dockerfile too and proves nothing — the shape that must fail is an UNCHANGED mutable
+ * ref, which is exactly the shape that used to succeed.
+ */
+
+const
+    repoRoot       = path.resolve(process.cwd()),
+    dockerfilePath = path.join(repoRoot, 'ai/deploy/Dockerfile'),
+
+    REPO_URL       = 'https://github.com/neomjs/neo.git',
+    SHA_A          = '6b52663db329aa90df52d0b5d64d9a9bac07312e',
+    SHA_B          = 'cdad885348aa1f2e3b4c5d6e7f8091a2b3c4d5e6';
+
+/**
+ * @summary Lifts one `RUN` instruction's shell body out of the shipping Dockerfile.
+ *
+ * The body is taken verbatim and only line-continuations are folded, so what executes here is the same
+ * text Docker hands to `/bin/sh`. Re-typing the condition into the spec would let the two drift, and
+ * the drifting copy is the one nobody is testing.
+ * @param {String} source    Full Dockerfile text.
+ * @param {String} startsWith Unique opening of the RUN instruction.
+ * @returns {String} Shell-ready command body, `RUN ` stripped.
+ */
+function extractRunBody(source, startsWith) {
+    const start = source.indexOf(startsWith);
+
+    expect(start, `Dockerfile is missing the "${startsWith}" instruction`).toBeGreaterThan(-1);
+
+    // A RUN block is one paragraph; the next blank line ends it.
+    const end = source.indexOf('\n\n', start);
+
+    expect(end, `"${startsWith}" has no paragraph boundary`).toBeGreaterThan(start);
+
+    return source.slice(start + 4, end).replace(/\\\n\s*/g, ' ')
+}
+
+/**
+ * @summary Runs the extracted ref guard under `sh` with a controlled build-arg environment.
+ * @param {Object} env `NEO_REF`, and optionally `NEO_ALLOW_MUTABLE_REF`.
+ * @returns {Object} `{status, stderr}` from the spawn.
+ */
+async function runRefGuard(env) {
+    const command = extractRunBody(await fs.readFile(dockerfilePath, 'utf8'), 'RUN neo_ref_is_sha=');
+
+    return spawnSync('sh', ['-c', command], {
+        encoding: 'utf8',
+        // A build ARG reaches the RUN as an environment variable, so this is the real delivery path.
+        env  : {...process.env, NEO_ALLOW_MUTABLE_REF: '', NEO_REPO_URL: REPO_URL, ...env},
+        stdio: ['ignore', 'pipe', 'pipe']
+    })
+}
+
+/**
+ * @summary Runs the extracted final-stage integrity gate against a stand-in revision receipt.
+ * @param {Object} env       `NEO_REF` / `NEO_REVISION` as the build would supply them.
+ * @param {String} packaged  Contents of the stand-in `/app/.neo-revision`.
+ * @returns {Object} `{status, stderr}` from the spawn.
+ */
+async function runIntegrityGate(env, packaged) {
+    const
+        source = await fs.readFile(dockerfilePath, 'utf8'),
+        start  = source.indexOf('RUN actual_revision='),
+        end    = source.indexOf('\nLABEL org.neomjs.image.requested-ref', start);
+
+    expect(start, 'Dockerfile revision-integrity RUN instruction is missing').toBeGreaterThan(-1);
+    expect(end, 'Dockerfile revision-integrity RUN instruction has no label boundary').toBeGreaterThan(start);
+
+    const
+        tempDir      = await fs.mkdtemp(path.join(os.tmpdir(), 'neo-ref-freeze-')),
+        revisionFile = path.join(tempDir, '.neo-revision'),
+        command      = source.slice(start + 4, end)
+            .replace(/\\\n\s*/g, ' ')
+            .replace('/app/.neo-revision', JSON.stringify(revisionFile));
+
+    await fs.writeFile(revisionFile, packaged);
+
+    const result = spawnSync('sh', ['-c', command], {
+        encoding: 'utf8',
+        env     : {...process.env, NEO_REF: '', NEO_REVISION: '', ...env},
+        stdio   : ['ignore', 'pipe', 'pipe']
+    });
+
+    await fs.rm(tempDir, {force: true, recursive: true});
+
+    return result
+}
+
+test.describe('source ref freeze guard (#16635)', () => {
+    test('a mutable ref is refused, because it freezes the source layer', async () => {
+        const result = await runRefGuard({NEO_REF: 'dev'});
+
+        expect(result.status, '`dev` must not reach the fetch — it is the shape that freezes').toBe(1);
+        expect(result.stderr).toContain("NEO_REF='dev' is not a full 40-hex commit SHA");
+    });
+
+    test('the refusal explains the freeze and names the resolve command, not just the rule', async () => {
+        const {stderr} = await runRefGuard({NEO_REF: 'dev'});
+
+        // A refusal that only states the rule sends the reader looking for the reason, and the reason
+        // is the whole point: the cost is freshness, not merely reproducibility.
+        expect(stderr).toContain('freezes this layer');
+        expect(stderr).toContain('reports success while doing it');
+        // The way out has to be copy-pasteable, with the real repository substituted in.
+        expect(stderr).toContain(`git ls-remote ${REPO_URL}`);
+        expect(stderr).toContain('NEO_SOURCE=local');
+        // And the escape hatch must advertise what it does NOT buy.
+        expect(stderr).toContain('NEO_ALLOW_MUTABLE_REF=1');
+        expect(stderr).toContain('FROZEN layer unless the build also passes --no-cache');
+    });
+
+    // Positive control sharing the property under test: these are all HEX, differing only in the
+    // dimension the guard claims to police. A control that failed for an unrelated reason (a URL, a
+    // path) would pass against a guard that merely rejected non-refs.
+    for (const [label, ref] of [
+        ['an abbreviated 12-char SHA', SHA_A.slice(0, 12)],
+        ['a 39-char SHA',              SHA_A.slice(0, 39)],
+        ['a 41-char SHA',              `${SHA_A}0`],
+        ['an uppercased SHA',          SHA_A.toUpperCase()]
+    ]) {
+        test(`${label} is refused — a ref must be exactly a full lowercase commit SHA`, async () => {
+            const result = await runRefGuard({NEO_REF: ref});
+
+            expect(result.status).toBe(1);
+        });
+    }
+
+    test('an empty ref is refused rather than defaulting to anything', async () => {
+        expect((await runRefGuard({NEO_REF: ''})).status).toBe(1);
+    });
+
+    test('a full commit SHA is admitted — the guard constrains the ref, it does not block builds', async () => {
+        const result = await runRefGuard({NEO_REF: SHA_A});
+
+        expect(result.status, 'a content-addressed ref is the sanctioned input').toBe(0);
+        expect(result.stderr).toBe('');
+    });
+
+    test('the explicit opt-in re-admits a channel for a hand-run build', async () => {
+        const result = await runRefGuard({NEO_ALLOW_MUTABLE_REF: '1', NEO_REF: 'dev'});
+
+        expect(result.status).toBe(0);
+    });
+
+    test('the guard runs BEFORE the fetch, so a refused ref never reaches the network', async () => {
+        const
+            source     = await fs.readFile(dockerfilePath, 'utf8'),
+            guardIndex = source.indexOf('RUN neo_ref_is_sha='),
+            fetchIndex = source.indexOf('RUN git init -q');
+
+        expect(guardIndex).toBeGreaterThan(-1);
+        expect(fetchIndex).toBeGreaterThan(-1);
+        // Reordering these would leave the guard technically present and practically absent: the fetch
+        // layer would already be cached by the time the refusal ran.
+        expect(guardIndex, 'the ref guard must precede the fetch it protects').toBeLessThan(fetchIndex);
+    });
+});
+
+test.describe('revision integrity is asserted without a caller (#16635 AC4)', () => {
+    test('a SHA-pinned build that packaged a different commit fails — the cache-hit catch', async () => {
+        // This is the arm that was a no-op before: NEO_REVISION defaults to empty, so the original
+        // gate's `[ -n "$NEO_REVISION" ]` guard switched the whole check off in exactly the
+        // configuration that produces a stale package.
+        const result = await runIntegrityGate({NEO_REF: SHA_A}, SHA_B);
+
+        expect(result.status).toBe(1);
+        expect(result.stderr).toContain('NEO_REF integrity mismatch');
+        expect(result.stderr).toContain('served from cache');
+    });
+
+    test('a SHA-pinned build that packaged that commit passes, with no caller assertion', async () => {
+        const result = await runIntegrityGate({NEO_REF: SHA_A}, SHA_A);
+
+        expect(result.status, 'NEO_REF alone is now a sufficient, checkable claim').toBe(0);
+    });
+
+    test('a NEO_SOURCE=local build stays silent — its non-SHA ref asserts nothing', async () => {
+        const result = await runIntegrityGate({NEO_REF: 'dev'}, 'local-build');
+
+        expect(result.status).toBe(0);
+    });
+
+    test('a local build handed a SHA fails — a revision claim over `local-build` is a fabrication', async () => {
+        const result = await runIntegrityGate({NEO_REF: SHA_A}, 'local-build');
+
+        expect(result.status).toBe(1);
+    });
+
+    test('the pre-existing caller-supplied assertion still governs', async () => {
+        expect((await runIntegrityGate({NEO_REVISION: SHA_A}, SHA_B)).status).toBe(1);
+        expect((await runIntegrityGate({NEO_REVISION: SHA_A}, SHA_A)).status).toBe(0);
+    });
+});

--- a/test/playwright/unit/ai/deploy/SourceRefFreezeGuard.spec.mjs
+++ b/test/playwright/unit/ai/deploy/SourceRefFreezeGuard.spec.mjs
@@ -137,9 +137,12 @@ test.describe('source ref freeze guard (#16635)', () => {
         // The way out has to be copy-pasteable, with the real repository substituted in.
         expect(stderr).toContain(`git ls-remote ${REPO_URL}`);
         expect(stderr).toContain('NEO_SOURCE=local');
-        // And the escape hatch must advertise what it does NOT buy.
-        expect(stderr).toContain('NEO_ALLOW_MUTABLE_REF=1');
-        expect(stderr).toContain('FROZEN layer unless the build also passes --no-cache');
+        // And the escape hatch must advertise both its exact spelling and what it does NOT buy.
+        expect(stderr).toContain('NEO_ALLOW_MUTABLE_REF=1 exactly');
+        expect(stderr).toContain('no');
+        expect(stderr).toContain('other value opts in');
+        expect(stderr).toContain('FROZEN layer');
+        expect(stderr).toContain('--no-cache');
     });
 
     // Positive control sharing the property under test: these are all HEX, differing only in the
@@ -174,6 +177,33 @@ test.describe('source ref freeze guard (#16635)', () => {
 
         expect(result.status).toBe(0);
     });
+
+    // The override is an authorization parser, so it is tested like one. The arm above supplies the
+    // documented value, which is the arm where exact-equality and shell-truthiness agree BY
+    // CONSTRUCTION — it passed against a `[ -n "$VAR" ]` predicate that admitted every non-empty
+    // value, including `0`. These are the cells that separate the two readings; without them, green
+    // cannot distinguish "opts in on 1" from "opts in on anything at all".
+    for (const [label, value] of [
+        ['0',                '0'],
+        ['false',            'false'],
+        ['true',             'true'],
+        ['yes',              'yes'],
+        ['TRUE',             'TRUE'],
+        ['a single space',   ' '],
+        ['1 with a trailing space', '1 '],
+        ['1 with a leading space',  ' 1'],
+        ['11',               '11'],
+        ['a typo',           'allow']
+    ]) {
+        test(`NEO_ALLOW_MUTABLE_REF=${label} does NOT opt in — only the exact value 1 does`, async () => {
+            const result = await runRefGuard({NEO_ALLOW_MUTABLE_REF: value, NEO_REF: 'dev'});
+
+            expect(
+                result.status,
+                `"${value}" admitted a mutable ref; misspelling a safety override must fail closed, not open`
+            ).toBe(1);
+        });
+    }
 
     test('the guard runs BEFORE the fetch, so a refused ref never reaches the network', async () => {
         const


### PR DESCRIPTION
Resolves #16635

`ai/deploy/Dockerfile`'s source stage now refuses a `NEO_REF` that is not a full 40-hex commit SHA, because a mutable ref does not merely cost reproducibility — it costs **freshness**, and costs it silently. The fetch is one cache-keyed `RUN`; with a channel name its cache key is byte-identical on every build, so Docker reuses the layer, the fetch never re-executes, and the image packages whatever that channel pointed at the first time the layer was built. The build log still prints the fetch command, because printing a cached layer's command is what Docker does. Alongside the guard, the final-stage integrity gate stopped being a no-op in the configuration most likely to be wrong, and the three documents that taught the now-refused path were corrected.

Evidence: L3 (seven real `docker build --target source-git` runs against the shipping Dockerfile, covering refuse/admit/abbreviated and the exact-value override matrix) → L4 required (a live container-plane rebuild through the corrected runbook). Residual: none among #16635's ACs; the L4 item is the operation this unblocks, not an unmet criterion.

## Deltas from ticket

**The ticket offered A/B/C; this ships B + C + A, which the ticket noted compose.** Three deviations worth naming:

1. **No mutable-ref tolerance beyond the explicit opt-in.** The ticket's Option B proposed `NEO_ALLOW_MUTABLE_REF=1` as the escape hatch, which is implemented — but the hatch re-admits the freeze along with the channel. Rather than imply otherwise, the guard's own message and the Dockerfile comment state it outright: the opt-in buys a **frozen** layer unless the build also passes `--no-cache`. A stated limit, not a hidden one.

2. **A tag is refused too, not just a branch.** The pre-existing contract said "pin to a tag/SHA". A git tag is movable, so it has the identical cache-key property; only a full SHA is its own content. **This breaks nothing measured**: `deploy-pipeline.sh:181-182` already does `unset NEO_REF; export NEO_REVISION="$resolved_revision"`, so the documented `NEO_REF="$CI_COMMIT_TAG"` pipeline entry point resolves the tag to a commit before Compose ever sees it.

3. **AC4 is addressed by making `NEO_REF` itself the assertion.** The ticket asked that `NEO_REVISION`'s default-empty behaviour be revisited. It cannot be defaulted — a `LABEL` can only read a build ARG, and Docker cannot populate a later-stage ARG from a file an earlier stage wrote. But now that `NEO_REF` is guaranteed SHA-shaped, it is itself a checkable claim needing no caller, so the integrity gate gained a second clause: a SHA-shaped `NEO_REF` must equal `/app/.neo-revision`. A cache-served source layer now fails the build even when the caller asserted nothing.

**Scope note:** the runbook and doc edits are not adjacent cleanup. The guard makes the canonical local start command (`ai/scripts/lifecycle/local-agent-os/README.md:67`) fail as written — shipping the guard without the resolve step would ship a broken runbook.

## Contract Ledger

| Surface | Before | After |
|---|---|---|
| `NEO_REF` build ARG | any git ref; `dev` default | full 40-hex lowercase SHA, or explicit opt-in |
| `NEO_ALLOW_MUTABLE_REF` build ARG | — | **new**; empty default. **Exactly** `1` re-admits a channel; every other value (including `0`, `false`, a typo, whitespace) refuses |
| final-stage integrity gate | fires only when `NEO_REVISION` non-empty | also fires when `NEO_REF` is SHA-shaped and disagrees with `/app/.neo-revision` |
| `org.neomjs.image.requested-ref` label | `dev` on the unpinned path | the resolved SHA, except on `NEO_SOURCE=local` or under the opt-in |
| `docker-compose*.yml` | — | **unchanged.** See the blast-radius table below |

Blast radius, measured across every compose file rather than inferred:

| file | shape | affected? |
|---|---|---|
| `docker-compose.yml` (base, ×3 services) | `NEO_REF: ${NEO_REVISION:-dev}` | **yes — the only exposed path** |
| `docker-compose.dev.yml` (×3), `docker-compose.test.yml` (×4) | `NEO_SOURCE: local` | no — the git stage is never built |
| `docker-compose.parity-capture.yml` (×2) | `NEO_REF: ${…:?capture source head required}` | no — already fail-closed on a required SHA, and the in-tree precedent for this idiom |
| `parity-ci.yml`, `local-agent-os.yml` | no build args | inherit base |

So the guard breaks exactly one path: a base-compose build with `NEO_REVISION` unset, which is the silently-wrong shape itself.

## Test Evidence

`ai/deploy/Dockerfile` — new `test/playwright/unit/ai/deploy/SourceRefFreezeGuard.spec.mjs`, 25 tests. It extracts the Dockerfile's **own shell text** and executes it under `sh`, so it cannot drift from a paraphrase; same idiom as the sibling `DeployPipelineRevisionPin.spec.mjs:229`.

```bash
npm run test-unit -- test/playwright/unit/ai/deploy/ test/playwright/unit/ai/DeployPipelineRevisionPin.spec.mjs
# 105 passed (5.8s)
```

**RED proof.** Green alone would be worthless here — the load-bearing arms are negative. Reverting only `ai/deploy/Dockerfile` to the branch base and re-running:

```
22 failed, 5 passed   (2 of the 27 are Chroma setup/teardown, so 22 of 25 real tests)
Error: Dockerfile is missing the "RUN neo_ref_is_sha=" instruction
```

The 3 survivors are exactly the pre-existing integrity arms, which is the correct partition. A second, narrower mutation isolates the override defect on its own: restoring only the fail-open `[ -z "$NEO_ALLOW_MUTABLE_REF" ]` predicate fails **precisely the 10 near-miss arms** (`0`, `false`, `true`, `yes`, `TRUE`, space, `1 `, ` 1`, `11`, typo) and no pre-existing arm.

**L3 — real builds against the shipping Dockerfile** (Docker 29.2.1, `--target source-git`, empty build context):

| arm | `NEO_REF` | opt-in | exit |
|---|---|---|---|
| the shape that used to succeed | `dev` | — | **1** |
| positive control | `6b52663db329aa90df52d0b5d64d9a9bac07312e` | — | 0 |
| explicit hatch, exact value | `dev` | `1` | 0 |
| override `0` — the absurdity | `dev` | `0` | **1** |
| override `false` | `dev` | `false` | **1** |
| abbreviated SHA (#15782 class) | `6b52663db329` | — | **1** |

All nine `[deploy]` refusal lines render in the build output with `NEO_REPO_URL` expanded to the real repository, so the resolve command is copy-pasteable rather than a template.

Regression surface — every spec that reads a file this PR touches:

```bash
npm run test-unit -- test/playwright/unit/ai/deploy/ \
  test/playwright/unit/ai/DeployPipelineRevisionPin.spec.mjs \
  test/playwright/unit/ai/DeployPipelineComposeFileList.spec.mjs \
  test/playwright/unit/ai/scripts/maintenance/deploymentMigrationCore.spec.mjs \
  test/playwright/unit/ai/services/neural-link/RecorderServiceDefaultOff.spec.mjs \
  test/playwright/unit/ai/scripts/diagnostics/mcpHealthcheck.spec.mjs
# 206 passed (21.5s)
```

`npm run ai:lint-guides` → OK, 0 hard. `npm run ai:lint-mcp-test-locations` → OK. `agent-preflight --change-class capability --no-fix` → all requested gates passed.

## Post-Merge Validation

- [ ] The container update runs through the corrected runbook: `export NEO_REVISION=$(git ls-remote … dev | cut -f1)`, then `up -d --build --wait`, and the built image is **new** rather than cache-served.
- [ ] `docker compose … exec mc-server cat /app/.neo-revision` equals the exported `NEO_REVISION` on all three neo services — the L4 arm this PR cannot reach from a sandbox.
- [ ] A deliberate cache-hit attempt (rebuild without changing the pin) now fails the second integrity clause instead of recreating containers from stale images.

## Deferred, not silently dropped

Nothing in this PR detects a **cache-served layer whose commit happens to match the pin** — that case is indistinguishable from a correct build and is also harmless. It is named so a reader does not infer a stronger guarantee than the gate provides.

Authored by Ada (Claude Opus 5, Claude Code). Session 9b08b9e4-6181-416b-ac68-e9d16636cff0.
