### PR TITLE
feat: plain harness start self-supplies the fleet transport (#16694)

### DIFF
--- a/harness/brain.mjs
+++ b/harness/brain.mjs
@@ -758,6 +758,37 @@ export async function stopBrainChild(child, {graceMs = 10000, pollMs = 200, kill
 }
 
 /**
+ * @summary Registers one owned child for teardown, routing Brain-health observation by the
+ * entry's `observeBrain` flag. Teardown ownership is UNCONDITIONAL — every registered entry
+ * joins the drain list (§2.1.1 one lifecycle owner) — while tray/whole-Brain-health observation
+ * attaches only for organism children (`observeBrain !== false`). A UI-mode fleet transport is
+ * drain-owned but never a Brain claim: its faults surface through the diagnostic sink and the
+ * cockpit's own fail-closed reads, never through whole-Brain health — the tray reports the
+ * organism, not the UI's transport convenience.
+ * @param {Object} options
+ * @param {Object[]} options.children The owner's drain list.
+ * @param {Object} options.entry `{child, label, observeBrain=true, ...}` — the child record.
+ * @param {Function} options.watch Attaches Brain-health observation (error/exit → degraded).
+ * @param {Function} [options.onUnobservedExit] Diagnostic-only sink for unobserved children's
+ *     error/exit — visibility without health mutation.
+ * @returns {Object} The registered entry.
+ */
+export function registerOwnedChild({children, entry, watch, onUnobservedExit = null}) {
+    children.push(entry);
+
+    if (entry.observeBrain === false) {
+        if (onUnobservedExit) {
+            entry.child.once('error', error => onUnobservedExit(`${entry.label ?? 'child'}: error ${String(error?.message ?? error ?? 'unknown')}`));
+            entry.child.once('exit', (code, signal) => onUnobservedExit(`${entry.label ?? 'child'}: ${signal ? `exit signal ${signal}` : `exit code ${code}`}`))
+        }
+    } else {
+        watch(entry.child, entry.label)
+    }
+
+    return entry
+}
+
+/**
  * @summary Tears down every supervised child (fleet first — it consumes the orchestrator's
  * organism, so reverse-dependency order) and reports per-child.
  * @param {Object[]} children `{label, child}` entries.

--- a/harness/brain.mjs
+++ b/harness/brain.mjs
@@ -789,6 +789,63 @@ export function registerOwnedChild({children, entry, watch, onUnobservedExit = n
 }
 
 /**
+ * @summary The UI-only transport composition: probe-then-route across the three fail-honest
+ * outcomes, with every collaborator injectable so the OWNER COMPOSITION itself is witnessable —
+ * not just its parts. The routing invariants this function owns:
+ * - **reuse** (port held + canonical same-bearer/viewer proof): adopt; `spawn`/`registerChild`
+ *   are NEVER invoked.
+ * - **foreign-listener** (port held, proof refused): `up: false` with the named refusal routed to
+ *   `onOutcome`; NEVER adopt, NEVER spawn — and never throw: a UI window must not brick on a
+ *   squatted port.
+ * - **spawn** (port free): the child registers `observeBrain: false` BY THE COMPOSITION — the
+ *   ownership≠observation invariant is wired here, not left to the caller — then real wire
+ *   readiness gates `up: true`.
+ * @param {Object} options
+ * @param {String} options.bearerToken The shell-held process bearer the spawned/probed transport must match.
+ * @param {Number} options.fleetPort Loopback fleet port.
+ * @param {String|null} [options.agentIdentityNodeId] Viewer claim for the reuse probe.
+ * @param {String} [options.repoRoot=DEFAULT_REPO_ROOT]
+ * @param {Function} [options.probePortFn=probePort] Raw occupancy probe (cheap, first).
+ * @param {Function} [options.probeServingFn=probeFleetServing] Canonical-identity reuse probe.
+ * @param {Function} options.spawn `({fleetPort}) => child` — starts the owned transport.
+ * @param {Function} options.registerChild Owner registration (`registerOwnedChild` wiring).
+ * @param {Function} options.awaitReady Real wire-readiness gate.
+ * @param {Function} [options.onOutcome] Diagnostic sink, one line per outcome.
+ * @returns {Promise<{fleetPort: Number, mode: 'reuse'|'spawn'|'foreign-listener', up: Boolean}>}
+ */
+export async function resolveUiFleetTransport({
+    bearerToken,
+    fleetPort,
+    agentIdentityNodeId = null,
+    repoRoot = DEFAULT_REPO_ROOT,
+    probePortFn = probePort,
+    probeServingFn = probeFleetServing,
+    spawn,
+    registerChild,
+    awaitReady,
+    onOutcome = () => {}
+}) {
+    if (await probePortFn({port: fleetPort})) {
+        const probe = await probeServingFn({agentIdentityNodeId, bearerToken, port: fleetPort, repoRoot});
+
+        if (probe.reusable === true) {
+            onOutcome(`reuse fleetPort=${fleetPort}`);
+            return {fleetPort, mode: 'reuse', up: true}
+        }
+
+        onOutcome(`foreign-listener fleetPort=${fleetPort} reason=${probe.reason || 'listener did not prove canonical Fleet identity'}`);
+        return {fleetPort, mode: 'foreign-listener', up: false}
+    }
+
+    const child = spawn({fleetPort});
+
+    registerChild({child, label: 'fleet', observeBrain: false});
+    await awaitReady({bearerToken, child, port: fleetPort});
+    onOutcome(`spawn fleetPort=${fleetPort}`);
+    return {fleetPort, mode: 'spawn', up: true}
+}
+
+/**
  * @summary Tears down every supervised child (fleet first — it consumes the orchestrator's
  * organism, so reverse-dependency order) and reports per-child.
  * @param {Object[]} children `{label, child}` entries.

--- a/harness/main.mjs
+++ b/harness/main.mjs
@@ -47,6 +47,7 @@ import {
     ORCHESTRATOR_ENTRY,
     probeFleetServing,
     probePort,
+    registerOwnedChild,
     resolveBrainMode,
     resolveBrainPaths,
     loadFleetRuntimeContracts,
@@ -881,14 +882,20 @@ const appLifecycle = createAppLifecycle({
 });
 
 /**
- * @summary Registers one owned Brain child for both teardown and event-derived tray degradation.
- * @param {Object} entry The existing brainState child record.
+ * @summary Registers one owned child: teardown ownership unconditionally, Brain-health
+ * observation only for organism children — the split lives in {@link registerOwnedChild}
+ * (brain.mjs), where its owner-coverage witness also lives. `observeBrain: false` (the UI-mode
+ * fleet transport) is drain-owned with diagnostic-log-only fault visibility.
+ * @param {Object} entry The brainState child record (`{child, label, observeBrain?, ...}`).
  * @returns {Object}
  */
 function registerBrainChild(entry) {
-    brainState.children.push(entry);
-    appLifecycle.watchBrainChild(entry.child, entry.label);
-    return entry
+    return registerOwnedChild({
+        children        : brainState.children,
+        entry,
+        onUnobservedExit: summary => console.log(`HARNESS_UI_FLEET_CHILD ${summary}`),
+        watch           : appLifecycle.watchBrainChild
+    })
 }
 
 /**
@@ -974,7 +981,10 @@ async function bootProductBrain() {
  * - **spawn** — the port is free: the shell starts `devFleetServer` as an OWNED child with the
  *   bearer it already holds (zero coordination — the packaged topology's behavior), awaits real
  *   wire readiness, and the existing quit drain tears it down (`brainState.children` is the one
- *   ownership set; the drain keys on membership, not on Brain mode).
+ *   ownership set; the drain keys on membership, not on Brain mode). Ownership ≠ observation:
+ *   the child registers `observeBrain: false`, so its death logs diagnostically and renders as
+ *   the cockpit's honest offline — never as whole-Brain `degraded` (the tray reports the
+ *   organism, not the UI's transport convenience).
  * - **foreign-listener** — something else holds the port: the WINDOW must not brick (contrast:
  *   organism boot fails closed), so the cockpit keeps its honest offline state and the named
  *   refusal lands in the shell log.
@@ -1010,7 +1020,11 @@ async function bootUiFleetTransport() {
         repoRoot: organismRoot
     });
 
-    registerBrainChild({child: fleet, label: 'fleet'});
+    // Drain-owned, NOT Brain-observed: a UI-mode transport death must never move whole-Brain
+    // health (the cycle-1 falsifier — registerBrainChild's default watcher flipped the tray to
+    // degraded where no Brain exists). Faults stay visible: the diagnostic sink logs the exit,
+    // and the cockpit's fail-closed reads render the honest offline state.
+    registerBrainChild({child: fleet, label: 'fleet', observeBrain: false});
     await awaitFleetReady({bearerToken: fleetBearerToken, child: fleet, port: fleetPort});
     console.log(`HARNESS_UI_FLEET spawn fleetPort=${fleetPort}`);
     return {fleetPort, mode: 'spawn', up: true}

--- a/harness/main.mjs
+++ b/harness/main.mjs
@@ -45,6 +45,7 @@ import {
     detectLiveBrain,
     FLEET_SERVER_ENTRY,
     ORCHESTRATOR_ENTRY,
+    probeFleetServing,
     probePort,
     resolveBrainMode,
     resolveBrainPaths,
@@ -961,6 +962,61 @@ async function bootProductBrain() {
 }
 
 /**
+ * The UI-only transport boot: plain `npm start` self-supplies the fleet transport instead of
+ * demanding a hand-carried `NEO_FLEET_BEARER` across two terminals (the first live operator run
+ * proved that coordination model unusable — and `fleetCapability` gates every renderer request on
+ * this boot receipt, so WITHOUT it the UI-only window could never reach a transport at all, even
+ * a perfectly-coordinated external one).
+ *
+ * Three outcomes, fail-honest:
+ * - **reuse** — a listener on the port proves canonical Fleet identity for THIS bearer + viewer
+ *   (the same-token-same-viewer probe): the shell adopts it and spawns nothing.
+ * - **spawn** — the port is free: the shell starts `devFleetServer` as an OWNED child with the
+ *   bearer it already holds (zero coordination — the packaged topology's behavior), awaits real
+ *   wire readiness, and the existing quit drain tears it down (`brainState.children` is the one
+ *   ownership set; the drain keys on membership, not on Brain mode).
+ * - **foreign-listener** — something else holds the port: the WINDOW must not brick (contrast:
+ *   organism boot fails closed), so the cockpit keeps its honest offline state and the named
+ *   refusal lands in the shell log.
+ * @summary Probes-then-spawns the app↔fleet transport for UI-only mode; never touches tray Brain state.
+ * @returns {Promise<Object>} `{fleetPort, mode: 'reuse'|'spawn'|'foreign-listener', up: Boolean}`
+ */
+async function bootUiFleetTransport() {
+    const
+        fleetPort = Number(process.env.NEO_FLEET_PORT) || 8083,
+        held      = await probePort({port: fleetPort});
+
+    if (held) {
+        const probe = await probeFleetServing({
+            agentIdentityNodeId: process.env.NEO_AGENT_IDENTITY,
+            bearerToken        : fleetBearerToken,
+            port               : fleetPort,
+            repoRoot           : organismRoot
+        });
+
+        if (probe.reusable === true) {
+            console.log(`HARNESS_UI_FLEET reuse fleetPort=${fleetPort}`);
+            return {fleetPort, mode: 'reuse', up: true}
+        }
+
+        console.log(`HARNESS_UI_FLEET foreign-listener fleetPort=${fleetPort} reason=${probe.reason || 'listener did not prove canonical Fleet identity'}`);
+        return {fleetPort, mode: 'foreign-listener', up: false}
+    }
+
+    const fleet = startBrainChild({
+        entry   : FLEET_SERVER_ENTRY,
+        env     : {NEO_FLEET_BEARER: fleetBearerToken, NEO_FLEET_PORT: String(fleetPort)},
+        onLog   : brainLog,
+        repoRoot: organismRoot
+    });
+
+    registerBrainChild({child: fleet, label: 'fleet'});
+    await awaitFleetReady({bearerToken: fleetBearerToken, child: fleet, port: fleetPort});
+    console.log(`HARNESS_UI_FLEET spawn fleetPort=${fleetPort}`);
+    return {fleetPort, mode: 'spawn', up: true}
+}
+
+/**
  * The smoke Brain boot. TWO profile shapes, deliberately distinct:
  * - **Packaged:** the EXACT product profile (`buildPackagedBrainEnv` — the artifact's lane and
  *   resource closure, unreduced), shifted only in COORDINATES: allocated Chroma/fleet ports and a
@@ -1078,7 +1134,16 @@ app.whenReady().then(async () => {
                 appLifecycle.settleBrainBoot(boot.up === true);
                 return boot
             })
-        : Promise.resolve(null);
+        : (diagnosticMode
+            // Plain smoke keeps its isolation contract: UI-only legs spawn nothing (a dev machine
+            // may carry a live transport); the fleet leg's evidence lives in smoke:brain.
+            ? Promise.resolve(null)
+            // UI-only product path: self-supply the transport. Tray Brain state is deliberately
+            // untouched — a fleet transport is not a Brain claim.
+            : bootUiFleetTransport().catch(error => {
+                console.log('HARNESS_UI_FLEET_BOOT_FAILED ' + error.message);
+                return {error: error.message, up: false}
+            }));
 
     if (!smokeMode) {
         try {

--- a/harness/main.mjs
+++ b/harness/main.mjs
@@ -45,10 +45,10 @@ import {
     detectLiveBrain,
     FLEET_SERVER_ENTRY,
     ORCHESTRATOR_ENTRY,
-    probeFleetServing,
     probePort,
     registerOwnedChild,
     resolveBrainMode,
+    resolveUiFleetTransport,
     resolveBrainPaths,
     loadFleetRuntimeContracts,
     startBrainChild,
@@ -992,42 +992,24 @@ async function bootProductBrain() {
  * @returns {Promise<Object>} `{fleetPort, mode: 'reuse'|'spawn'|'foreign-listener', up: Boolean}`
  */
 async function bootUiFleetTransport() {
-    const
-        fleetPort = Number(process.env.NEO_FLEET_PORT) || 8083,
-        held      = await probePort({port: fleetPort});
-
-    if (held) {
-        const probe = await probeFleetServing({
-            agentIdentityNodeId: process.env.NEO_AGENT_IDENTITY,
-            bearerToken        : fleetBearerToken,
-            port               : fleetPort,
-            repoRoot           : organismRoot
-        });
-
-        if (probe.reusable === true) {
-            console.log(`HARNESS_UI_FLEET reuse fleetPort=${fleetPort}`);
-            return {fleetPort, mode: 'reuse', up: true}
-        }
-
-        console.log(`HARNESS_UI_FLEET foreign-listener fleetPort=${fleetPort} reason=${probe.reason || 'listener did not prove canonical Fleet identity'}`);
-        return {fleetPort, mode: 'foreign-listener', up: false}
-    }
-
-    const fleet = startBrainChild({
-        entry   : FLEET_SERVER_ENTRY,
-        env     : {NEO_FLEET_BEARER: fleetBearerToken, NEO_FLEET_PORT: String(fleetPort)},
-        onLog   : brainLog,
-        repoRoot: organismRoot
-    });
-
-    // Drain-owned, NOT Brain-observed: a UI-mode transport death must never move whole-Brain
-    // health (the cycle-1 falsifier — registerBrainChild's default watcher flipped the tray to
-    // degraded where no Brain exists). Faults stay visible: the diagnostic sink logs the exit,
-    // and the cockpit's fail-closed reads render the honest offline state.
-    registerBrainChild({child: fleet, label: 'fleet', observeBrain: false});
-    await awaitFleetReady({bearerToken: fleetBearerToken, child: fleet, port: fleetPort});
-    console.log(`HARNESS_UI_FLEET spawn fleetPort=${fleetPort}`);
-    return {fleetPort, mode: 'spawn', up: true}
+    // The three-outcome routing AND the ownership≠observation invariant live in the witnessable
+    // composition (brain.mjs#resolveUiFleetTransport); this wrapper only binds the real
+    // collaborators: env coordinates, the shell bearer, the child spawner, and the owner registry.
+    return resolveUiFleetTransport({
+        agentIdentityNodeId: process.env.NEO_AGENT_IDENTITY,
+        awaitReady         : awaitFleetReady,
+        bearerToken        : fleetBearerToken,
+        fleetPort          : Number(process.env.NEO_FLEET_PORT) || 8083,
+        onOutcome          : summary => console.log(`HARNESS_UI_FLEET ${summary}`),
+        registerChild      : registerBrainChild,
+        repoRoot           : organismRoot,
+        spawn              : ({fleetPort}) => startBrainChild({
+            entry   : FLEET_SERVER_ENTRY,
+            env     : {NEO_FLEET_BEARER: fleetBearerToken, NEO_FLEET_PORT: String(fleetPort)},
+            onLog   : brainLog,
+            repoRoot: organismRoot
+        })
+    })
 }
 
 /**

--- a/test/playwright/unit/harness/brain.spec.mjs
+++ b/test/playwright/unit/harness/brain.spec.mjs
@@ -20,6 +20,7 @@ import {
     probePort,
     registerOwnedChild,
     resolveRealPath,
+    resolveUiFleetTransport,
     startBrainChild,
     stopBrainChild,
     stopBrainTree,
@@ -625,5 +626,76 @@ test.describe('registerOwnedChild — teardown ownership is unconditional; Brain
 
         expect(watched).toEqual(['orchestrator']);
         expect(logged).toEqual([])
+    })
+});
+
+test.describe('resolveUiFleetTransport — the reuse|spawn|foreign OWNER COMPOSITION is witnessed, not just its parts', () => {
+    test('reuse: a canonical same-bearer listener is adopted — spawn and registration are NEVER invoked', async () => {
+        const
+            calls   = {registered: [], spawned: 0},
+            outcome = [];
+
+        const result = await resolveUiFleetTransport({
+            awaitReady    : async () => { throw new Error('awaitReady must not run on reuse') },
+            bearerToken   : 'shell-held-bearer',
+            fleetPort     : 18083,
+            onOutcome     : line => outcome.push(line),
+            probePortFn   : async () => true,
+            probeServingFn: async () => ({reusable: true}),
+            registerChild : entry => calls.registered.push(entry),
+            spawn         : () => { calls.spawned++; throw new Error('spawn must not run on reuse') }
+        });
+
+        expect(result).toEqual({fleetPort: 18083, mode: 'reuse', up: true});
+        expect(calls.spawned).toBe(0);
+        expect(calls.registered).toEqual([]);
+        expect(outcome).toEqual(['reuse fleetPort=18083'])
+    });
+
+    test('foreign listener: refusal is named, up stays false, the window path never throws — and nothing spawns', async () => {
+        const
+            calls   = {registered: [], spawned: 0},
+            outcome = [];
+
+        const result = await resolveUiFleetTransport({
+            awaitReady    : async () => { throw new Error('awaitReady must not run on foreign') },
+            bearerToken   : 'shell-held-bearer',
+            fleetPort     : 18083,
+            onOutcome     : line => outcome.push(line),
+            probePortFn   : async () => true,
+            probeServingFn: async () => ({reusable: false, reason: 'bearer subject mismatch'}),
+            registerChild : entry => calls.registered.push(entry),
+            spawn         : () => { calls.spawned++; throw new Error('spawn must not run on foreign') }
+        });
+
+        expect(result).toEqual({fleetPort: 18083, mode: 'foreign-listener', up: false});
+        expect(calls.spawned).toBe(0);
+        expect(calls.registered).toEqual([]);
+        expect(outcome).toEqual(['foreign-listener fleetPort=18083 reason=bearer subject mismatch'])
+    });
+
+    test('spawn: the composition itself registers observeBrain:false and gates up:true on real readiness', async () => {
+        const
+            child    = new EventEmitter(),
+            sequence = [],
+            calls    = {registered: []};
+
+        const result = await resolveUiFleetTransport({
+            awaitReady    : async ({bearerToken, port}) => sequence.push(`ready:${bearerToken}:${port}`),
+            bearerToken   : 'shell-held-bearer',
+            fleetPort     : 18083,
+            onOutcome     : line => sequence.push(line),
+            probePortFn   : async () => false,
+            probeServingFn: async () => { throw new Error('serving probe must not run on a free port') },
+            registerChild : entry => { calls.registered.push(entry); sequence.push('registered') },
+            spawn         : ({fleetPort}) => { sequence.push(`spawn:${fleetPort}`); return child }
+        });
+
+        expect(result).toEqual({fleetPort: 18083, mode: 'spawn', up: true});
+        // The cycle-1 invariant is wired IN the composition: ownership without Brain observation.
+        expect(calls.registered).toEqual([{child, label: 'fleet', observeBrain: false}]);
+        // Registration precedes readiness (an early quit must find the owner non-empty), and
+        // readiness precedes the up:true outcome line.
+        expect(sequence).toEqual(['spawn:18083', 'registered', 'ready:shell-held-bearer:18083', 'spawn fleetPort=18083'])
     })
 });

--- a/test/playwright/unit/harness/brain.spec.mjs
+++ b/test/playwright/unit/harness/brain.spec.mjs
@@ -18,6 +18,7 @@ import {
     ORCHESTRATOR_ENTRY,
     probeFleetServing,
     probePort,
+    registerOwnedChild,
     resolveRealPath,
     startBrainChild,
     stopBrainChild,
@@ -565,5 +566,64 @@ test.describe('harness brain lifecycle', () => {
 
         expect(JSON.parse(readFileSync(path.join(workDir, 'run-state.json'), 'utf8')))
             .toEqual({children: [{entry, ownershipToken: 'token-111', pgid: 111}]})
+    })
+});
+
+test.describe('registerOwnedChild — teardown ownership is unconditional; Brain observation routes by flag', () => {
+    test('owner coverage is deterministic: observed AND unobserved children BOTH join the drain list', () => {
+        const
+            children = [],
+            watched  = [],
+            organism = new EventEmitter(),
+            uiFleet  = new EventEmitter(),
+            watch    = (child, label) => watched.push(label);
+
+        registerOwnedChild({children, entry: {child: organism, label: 'orchestrator'}, watch});
+        registerOwnedChild({children, entry: {child: uiFleet, label: 'fleet', observeBrain: false}, watch, onUnobservedExit: () => {}});
+
+        // The cycle-1 falsifier's inverse, pinned: the drain list carries EVERY registered child
+        // regardless of observation routing — ownership never narrows with the watcher.
+        expect(children.map(entry => entry.label)).toEqual(['orchestrator', 'fleet']);
+        expect(watched).toEqual(['orchestrator'])
+    });
+
+    test('an unobserved child\'s death reaches the diagnostic sink — and ONLY the sink', () => {
+        const
+            children = [],
+            logged   = [],
+            watched  = [],
+            uiFleet  = new EventEmitter();
+
+        registerOwnedChild({
+            children,
+            entry           : {child: uiFleet, label: 'fleet', observeBrain: false},
+            onUnobservedExit: summary => logged.push(summary),
+            watch           : (child, label) => watched.push(label)
+        });
+
+        uiFleet.emit('exit', null, 'SIGKILL');
+
+        // Fault visibility WITHOUT health mutation: the sink names the child and the signal,
+        // while the Brain-health watcher was never attached (a UI transport is not a Brain).
+        expect(logged).toEqual(['fleet: exit signal SIGKILL']);
+        expect(watched).toEqual([])
+    });
+
+    test('an observed child routes to the Brain watcher and never to the sink', () => {
+        const
+            children = [],
+            logged   = [],
+            watched  = [],
+            organism = new EventEmitter();
+
+        registerOwnedChild({
+            children,
+            entry           : {child: organism, label: 'orchestrator'},
+            onUnobservedExit: summary => logged.push(summary),
+            watch           : (child, label) => watched.push(label)
+        });
+
+        expect(watched).toEqual(['orchestrator']);
+        expect(logged).toEqual([])
     })
 });


### PR DESCRIPTION
Resolves #16708

Refs #16694 — the umbrella stays OPEN for its renderer-side live receipt (restructured in review cycle 2 per the close-target rule: #16708 is the pre-merge leaf carrying exactly what this PR delivers, with its Contract Ledger; #16694 closes only on the operator-machine live-roster receipt).

Plain `cd harness && npm start` now self-supplies the app↔fleet transport: the shell probes the fleet port, **reuses** a listener that proves canonical Fleet identity for its own bearer+viewer, **spawns** `devFleetServer` as an owned child with the bearer the shell already holds when the port is free (the packaged topology's behavior — zero coordination, zero env vars, one command), and on a **foreign listener** keeps the window booting into the honest offline state with the named refusal in the shell log. The spawned child joins `brainState.children`, so the existing quit drain owns its teardown; ownership is SPLIT from Brain observation (`registerOwnedChild`, cycle 1 — see the review-delta section), so tray Brain state genuinely stays untouched: a fleet transport is not a Brain claim; plain smoke stays spawn-free by its isolation contract.

The premise carries TWO empirical defects from the first live operator run (2026-08-08, receipts on #16693/#16694): (1) the shell and an externally-started transport each self-generate ephemeral bearers → guaranteed 401s → honest offline cockpit; (2) deeper, found during implementation: `fleetCapability.send` gates every renderer request on the brain-boot receipt (`boot?.up === true` + `boot.fleetPort`), and UI-only mode resolved that promise to `null` — **so the UI-only window could never reach any transport, even a perfectly-coordinated external one.** The interim "shared env export" recipe was structurally impossible, not merely inconvenient. This PR feeds the capability gate its receipt from the new UI transport boot.

Evidence: L3-class on the operator machine — live spawn-branch run: `HARNESS_UI_FLEET spawn fleetPort=18083`, transport up with `bearer: supplied` + viewer resolved, unauthenticated `POST /fleet` → 401 (auth enforced); quit intent → owned child GONE, port RELEASED. Residual: the reuse branch is exercised by the existing probe semantics' unit coverage rather than a live same-bearer second server (see Test Evidence); the operator's live cockpit click-through is the Lane-B receipt → Post-Merge Validation.

## Review cycle 2 delta (@neo-gpt-emmy — ledger/composition + close-target truth)

- **Close-target truth:** `Resolves` now targets the new pre-merge sub-leaf **#16708** (native child of #16694), which carries the Contract Ledger Matrix for every delivered surface (`resolveUiFleetTransport`, `registerOwnedChild`, the boot receipt → capability-gate seam, the log markers, the smoke invariant). #16694 remains open as the umbrella whose one remaining AC is the renderer-side live-roster receipt — it can no longer be auto-closed past its post-merge proof.
- **The composition is now witnessable, not just its parts:** `bootUiFleetTransport`'s three-outcome routing moved into `brain.mjs#resolveUiFleetTransport` (the `detectLiveBrain` injectable pattern; `registerOwnedChild` untouched per the review). Three new composition witnesses pin: reuse NEVER spawns/registers; foreign NEVER spawns/adopts/throws and names the refusal; spawn registers `observeBrain: false` INSIDE the composition (the cycle-1 invariant is wired, not caller-trusted) with registration-before-readiness-before-up ordering asserted. `main.mjs` keeps only the real-collaborator binding.

## Review cycle 1 delta (@neo-gpt-emmy REQUEST_CHANGES → closed at 23081cc499)

The cycle-1 falsifier was exact and the PR's own claim was wrong at head: `registerBrainChild` unconditionally attached `watchBrainChild`, so a UI-only fleet exit moved `brainHealth` stopped→degraded (a Brain claim where no Brain exists), asymmetrically to the reuse path — contradicting the "tray untouched" JSDoc. Closed by splitting the concerns rather than widening the claim:

- **`registerOwnedChild` (brain.mjs, testable):** teardown ownership is UNCONDITIONAL — every registered entry joins the drain list; Brain-health observation attaches only for organism children (`observeBrain !== false`). The UI transport registers `observeBrain: false` with a diagnostic-only exit/error sink (`HARNESS_UI_FLEET_CHILD …`) — fault visibility without health mutation; the cockpit's fail-closed reads render the honest offline. Spawn and reuse are now SYMMETRIC on health semantics: neither is Brain-observed.
- **Deterministic owner coverage, witnessed:** three new specs in `brain.spec.mjs` pin the split — observed AND unobserved children both join the drain list; an unobserved death reaches ONLY the sink (named child + signal); an observed child routes ONLY to the watcher. The cycle-1 falsifier's inverse is now red-provable.
- **The Resolves fork, resolved by precision (in the open):** #16694's AC-1 bundled the pre-merge-provable transport mechanics with the renderer-side live-roster receipt, which requires an interactive operator session and was always post-merge-class. The ticket's AC section is amended (annotated with this cycle's date and rationale — no silent goalpost move): mechanics + observation-split are in-PR ACs; the renderer receipt is an explicit post-merge item riding the operator run and/or `#16699`'s auto-recheck. `Resolves` stands on the amended, honest AC set.

## Deltas from ticket

- **Foreign-listener detection order:** the implementation probes raw port occupancy first (`probePort`) and only then runs the identity probe — mirroring `detectLiveBrain`'s fleet half — so a free port never pays the probe timeout.
- **Signal-quit nuance, observed and accepted:** a signal-driven quit (`SIGINT` to the shell) drains the owned child and releases the port on the FIRST intent; the shell process itself completes exit on the second. Interactive quit paths (tray Quit, Cmd-Q) carry the explicit intent in one step. The owned-resource half — the AC's substance — settles on intent one; noted here rather than hidden.
- None otherwise — the three-outcome shape, smoke exemption, and drain ownership land exactly as ticketed.

## Test Evidence

- `harness npm run smoke` at head: `"passed": true`, and **zero `HARNESS_UI_FLEET` lines** — the spawn-free smoke AC holds.
- Live spawn branch (operator machine, alternate port so the operator's own external transport on `:8083` stayed untouched): marker line emitted, transport serving, 401 on unauthenticated POST, child+port drained on quit intent (`18083: RELEASED`, `child GONE`).
- Reuse/foreign branches ride `probeFleetServing` / `probeExistingFleetServer` — the same-token-same-viewer semantics covered by `test/playwright/unit/harness/brain.spec.mjs` (`probeFleetServing reuses only the canonical same-bearer, same-viewer probe` — green at head).
- `harness/main.mjs` has no direct unit spec (Electron entry) — per repo convention its evidence is the smoke + live runs above; `None found` for a main.mjs spec surface.

## Post-Merge Validation

- [ ] The Lane-B receipt: operator runs `cd harness && npm start` with no fleet transport up — live cockpit (roster over the wire), then quits — port released. The §04 PoC-bar precondition (no hand-carried env) is thereby met.
- [ ] With the operator's own external same-bearer transport running, the shell reuses instead of double-spawning.

## Evolution

The ticket was filed on defect (1); reading `fleetCapability` for the wiring surfaced defect (2), which converts this from convenience to correctness: the capability gate's design ("an early-rendering UI receives a named not-ready envelope") was always waiting for a UI-mode boot receipt that nothing produced. The fix supplies the receipt rather than weakening the gate.

Authored by Clio (Claude Fable 5, Claude Code). Session 9b6352cd-0db2-4a10-8254-36e710c67e1d.

