### PR TITLE
The declared heap ceiling becomes observable, and the envelope guard names its resource (#16636)

### DIFF
--- a/ai/daemons/orchestrator/services/DeploymentRuntimeAccessService.mjs
+++ b/ai/daemons/orchestrator/services/DeploymentRuntimeAccessService.mjs
@@ -1,5 +1,5 @@
-import http from 'http';
-import Base from '../../../../src/core/Base.mjs';
+import http             from 'http';
+import Base             from '../../../../src/core/Base.mjs';
 import {RECOVERY_KNOBS} from '../../../services/memory-core/helpers/recoveryKnobRegistry.mjs';
 
 export const DEPLOYMENT_RUNTIME_MECHANISMS = Object.freeze([
@@ -750,17 +750,30 @@ export class DeploymentRuntimeAccessService extends Base {
         // 1. Only a service some ceiling knob DECLARES is resizable at all. The registry's closed
         //    set is the sanctioned-target list; a transient or unknown service has no knob, so the
         //    op cannot address it.
-        // 2. The value must sit inside that knob's band. The cap that terminates the autonomous
+        // 2. That knob must govern THIS resource. `role: 'ceiling'` says a leaf is an upper bound; it
+        //    does not say of WHAT. This op widens the cgroup envelope (`HostConfig.Memory`), and a
+        //    ceiling over any other resource — a process-internal V8 old-space cap, say — is a
+        //    different authority that happens to share the word. Matching on the role alone would let
+        //    such a leaf sanction an envelope move for a service that declares no envelope knob, so
+        //    the resource is required rather than inferred. Fail-closed by construction: a leaf that
+        //    omits `resource` matches nothing here instead of defaulting to envelope.
+        // 3. The value must sit inside that knob's band. The cap that terminates the autonomous
         //    ratchet holds here too — a caller with L0 access cannot express what the knob forbids.
+        //    A knob with no finite band therefore sanctions NOTHING: comparing a value against an
+        //    absent bound is NaN-false in BOTH directions, so an unbanded knob would silently delete
+        //    the cap rather than tighten it, leaving raise-only as the only surviving bound.
+        const containerCeilingLeafOf = knob => knob.leaves.find(
+            leaf => leaf.role === 'ceiling' && leaf.resource === 'container-memory'
+        );
+
         const ceilingKnob = Object.values(RECOVERY_KNOBS).find(knob =>
-            knob.serviceKey === target.serviceKey &&
-            knob.leaves.some(leaf => leaf.role === 'ceiling')
+            knob.serviceKey === target.serviceKey && containerCeilingLeafOf(knob)
         );
 
         if (!ceilingKnob) {
             throw createRuntimeAccessError({
                 reason : 'runtime-memory-limit-unsanctioned-target',
-                message: `update-memory-limit refuses '${target.serviceKey}': no ceiling knob in the closed registry declares this service`,
+                message: `update-memory-limit refuses '${target.serviceKey}': no container-memory ceiling knob in the closed registry declares this service`,
                 details: {
                     ...this.createEffectiveConfigSummary(),
                     serviceKey: target.serviceKey
@@ -768,7 +781,18 @@ export class DeploymentRuntimeAccessService extends Base {
             });
         }
 
-        const ceilingLeaf = ceilingKnob.leaves.find(leaf => leaf.role === 'ceiling');
+        const ceilingLeaf = containerCeilingLeafOf(ceilingKnob);
+
+        if (!Number.isFinite(ceilingLeaf.min) || !Number.isFinite(ceilingLeaf.max)) {
+            throw createRuntimeAccessError({
+                reason : 'runtime-memory-limit-unbanded-knob',
+                message: `update-memory-limit refuses '${target.serviceKey}': its container-memory ceiling knob declares no finite band, so it sanctions no value`,
+                details: {
+                    ...this.createEffectiveConfigSummary(),
+                    serviceKey: target.serviceKey
+                }
+            });
+        }
 
         if (memoryLimitBytes < ceilingLeaf.min || memoryLimitBytes > ceilingLeaf.max) {
             throw createRuntimeAccessError({

--- a/ai/daemons/orchestrator/services/DeploymentStateBridgeService.mjs
+++ b/ai/daemons/orchestrator/services/DeploymentStateBridgeService.mjs
@@ -998,6 +998,33 @@ function resolveConfiguredDurabilityPosture() {
     })
 }
 
+/**
+ * @summary Reads the V8 old-space ceiling a container was STARTED with, from its command.
+ *
+ * Three states, and the third is the point. `Config.Cmd` records the argument the container was
+ * launched with; when a command has several `node` invocations (the overlay/no-overlay branches the
+ * MCP servers carry) it does NOT say which branch is executing. So a divergent pair is not a
+ * value to choose between — reporting either one would be a guess with a number attached. It
+ * reports `'unknown'` instead, and the caller treats that as "not observable", never as a reading.
+ *
+ * This is what the container was TOLD, never what V8 enforces. No V8-scoped metric exists for a
+ * sibling container anywhere in `ai/`, so the field name says `declared` and means it.
+ *
+ * @param {String[]|String} cmd `Config.Cmd`, as Docker returns it.
+ * @returns {Number|String|null} the agreed ceiling in MB · `'unknown'` when declarations diverge ·
+ * `null` when none is declared.
+ */
+export function parseDeclaredHeapCeilingMb(cmd) {
+    const
+        text     = Array.isArray(cmd) ? cmd.join(' ') : typeof cmd === 'string' ? cmd : '',
+        declared = [...text.matchAll(/--max-old-space-size=(\d+)/g)].map(match => Number(match[1]));
+
+    if (declared.length === 0)               return null;
+    if (new Set(declared).size > 1)          return 'unknown';
+
+    return declared[0]
+}
+
 function summarizeInspect(inspect) {
     if (!inspect || typeof inspect !== 'object') return null;
 
@@ -1007,6 +1034,10 @@ function summarizeInspect(inspect) {
         name        : inspect.Name || null,
         image       : inspect.Config?.Image || inspect.Image || null,
         restartCount: Number.isFinite(inspect.RestartCount) ? inspect.RestartCount : null,
+        // Admitted by this ticket's Contract Ledger. Paired with `stats.memoryLimitBytes`, which is
+        // already published, it lets a reader see a ceiling declared BELOW the container's own
+        // allowance — the shape that aborts Node while the cgroup still looks half-idle.
+        declaredHeapCeilingMb: parseDeclaredHeapCeilingMb(inspect.Config?.Cmd),
         state       : {
             status    : state.Status || null,
             health    : state.Health?.Status || null,

--- a/ai/daemons/orchestrator/services/DeploymentStateBridgeService.mjs
+++ b/ai/daemons/orchestrator/services/DeploymentStateBridgeService.mjs
@@ -472,6 +472,7 @@ export class DeploymentStateBridgeService extends Base {
             failureReasonCounts    = countBy(serviceList.flatMap(service => (service.errors || []).map(error => error.reason || 'unknown'))),
             operationFailureCounts = countBy(serviceList.flatMap(service => (service.errors || []).map(error => error.operation || 'unknown'))),
             lookupFailureCount     = serviceList.filter(hasLookupFailure).length,
+            undeclaredHeapCeilingServices = selectUndeclaredHeapCeilingServices(serviceList),
             allServicesDegraded    = serviceList.length > 0 && degradedServices.length === serviceList.length,
             broadLookupFailure     = serviceList.length > 0 && lookupFailureCount === serviceList.length,
             reason                 = broadLookupFailure
@@ -510,7 +511,18 @@ export class DeploymentStateBridgeService extends Base {
                 lookupFailureCount,
                 failureReasonCounts,
                 operationFailureCounts,
-                services            : serviceFailureStates
+                services            : serviceFailureStates,
+                // Observe-only, `record`-terminal: no action, no privilege, no restart. It states
+                // that a Node service was started with no `--max-old-space-size`, which is the
+                // condition under which V8 picks a heuristic well below the container's allowance
+                // and self-aborts with ExitCode 0 and OOMKilled false — a failure with no signature.
+                //
+                // Deliberately NOT a member of the `facts` array. `selectEvidenceFacts(facts, …)`
+                // is called with the WHOLE array at every classification branch, so anything added
+                // there becomes candidate evidence for every diagnosis. That is what the earlier
+                // attempt got wrong, and an observability statement is the wrong shape for an
+                // evidence array regardless.
+                undeclaredHeapCeilingServices
             },
             hints: buildBridgeHints({reason, failureReasonCounts})
         };
@@ -1016,13 +1028,64 @@ function resolveConfiguredDurabilityPosture() {
  */
 export function parseDeclaredHeapCeilingMb(cmd) {
     const
-        text     = Array.isArray(cmd) ? cmd.join(' ') : typeof cmd === 'string' ? cmd : '',
+        text     = commandText(cmd),
         declared = [...text.matchAll(/--max-old-space-size=(\d+)/g)].map(match => Number(match[1]));
 
     if (declared.length === 0)               return null;
     if (new Set(declared).size > 1)          return 'unknown';
 
     return declared[0]
+}
+
+/**
+ * @summary Flattens `Config.Cmd` to searchable text, tolerating the array and string forms Docker uses.
+ * @param {String[]|String} cmd
+ * @returns {String}
+ */
+function commandText(cmd) {
+    return Array.isArray(cmd) ? cmd.join(' ') : typeof cmd === 'string' ? cmd : ''
+}
+
+/**
+ * @summary Whether a container's command launches Node at all.
+ *
+ * A missing heap ceiling only means something for a **Node** service — `chroma` runs
+ * `["run", "/config.yaml"]` and has no V8 to bound, so an undeclared-ceiling finding against it
+ * would be noise the reader has to learn to ignore.
+ *
+ * Derived from the command rather than inferred from the image name. The image is a **proxy** for
+ * runtime — it holds until someone adds a Node service on a different base or a non-Node entrypoint
+ * to the shared image, and then it holds silently and wrongly. The command is the direct
+ * observation.
+ *
+ * @param {String[]|String} cmd `Config.Cmd`, as Docker returns it.
+ * @returns {Boolean}
+ */
+export function isNodeCommand(cmd) {
+    return /(^|[\s;&|"'`(])node(\s|$)/.test(commandText(cmd))
+}
+
+/**
+ * @summary Names the Node services that were started with no declared heap ceiling.
+ *
+ * Pure on purpose — the enclosing `collectBridgeDiagnostics` reads `AiConfig` and runtime-holder
+ * state, so folding this inline would make the rule testable only through a live service. The rule
+ * is the part worth guarding.
+ *
+ * Three populations are deliberately NOT findings:
+ * - **non-Node** services — nothing with a V8 heap to bound.
+ * - **`'unknown'`** — divergent declarations mean the ceiling could not be OBSERVED. Listing it
+ *   would publish *observed an absence* where the truth is *could not observe*.
+ * - an **unreadable `inspect`** — a failed read is already reported as a degraded service.
+ *
+ * @param {Object[]} services Per-service snapshots carrying `summarizeInspect()` output.
+ * @returns {String[]} service keys, in input order.
+ */
+export function selectUndeclaredHeapCeilingServices(services) {
+    return (Array.isArray(services) ? services : [])
+        .filter(service => service?.inspect?.nodeCommand === true &&
+                           service?.inspect?.declaredHeapCeilingMb === null)
+        .map(service => service.serviceKey)
 }
 
 function summarizeInspect(inspect) {
@@ -1037,7 +1100,13 @@ function summarizeInspect(inspect) {
         // Admitted by this ticket's Contract Ledger. Paired with `stats.memoryLimitBytes`, which is
         // already published, it lets a reader see a ceiling declared BELOW the container's own
         // allowance — the shape that aborts Node while the cgroup still looks half-idle.
+        //
+        // `nodeCommand` travels WITH it because the two are only meaningful together: a null ceiling
+        // is a finding on a Node service and a non-event on anything else. Publishing the ceiling
+        // alone would make every reader re-derive the qualifier, and re-derivation is where the
+        // image-name proxy gets invented.
         declaredHeapCeilingMb: parseDeclaredHeapCeilingMb(inspect.Config?.Cmd),
+        nodeCommand          : isNodeCommand(inspect.Config?.Cmd),
         state       : {
             status    : state.Status || null,
             health    : state.Health?.Status || null,

--- a/ai/deploy/docker-compose.yml
+++ b/ai/deploy/docker-compose.yml
@@ -140,7 +140,12 @@ services:
     deploy:
       resources:
         limits:
-          memory: 1g
+          # Parameterised for the same reason chroma's is: a hardcoded limit is unreachable by the
+          # recovery actuator. The declared heap ceiling above must stay strictly below this value,
+          # and that bound has to be expressed as a RELATIONSHIP against this leaf rather than as a
+          # constant — a constant goes stale the moment this moves. A YAML literal is reachable by
+          # neither config nor the overlay, so it cannot serve as the bound at all.
+          memory: "${NEO_KB_SERVER_MEMORY_LIMIT:-1g}"
           cpus: "1.0"
 
   mc-server:
@@ -263,7 +268,10 @@ services:
     deploy:
       resources:
         limits:
-          memory: 1g
+          # Parameterised for the same reason chroma's is — see the kb-server note above. The
+          # strictly-below bound on the heap ceiling is a relationship against this leaf, so this
+          # value must be reachable by something other than a YAML literal.
+          memory: "${NEO_MC_SERVER_MEMORY_LIMIT:-1g}"
           cpus: "1.0"
 
   # The Agent OS maintenance orchestrator (ADR 0014 §2.3). Built from the shared

--- a/ai/services/memory-core/helpers/recoveryKnobRegistry.mjs
+++ b/ai/services/memory-core/helpers/recoveryKnobRegistry.mjs
@@ -81,13 +81,20 @@ export const RECOVERY_KNOBS = Object.freeze({
          */
         requires: Object.freeze(['runtime.chroma.liveMemoryLimitBytes']),
         leaves  : Object.freeze([
+            // `resource` is load-bearing rather than descriptive. `role: 'ceiling'` says a leaf is an
+            // upper bound; it does not say of WHAT. The envelope boundary in
+            // `DeploymentRuntimeAccessService` matched on the role alone, so any future ceiling leaf
+            // governing a different resource — a process-internal V8 old-space cap, say — would have
+            // silently become a legal target for a cgroup move. Declared here so that guard can
+            // REQUIRE it; a leaf omitting it matches nothing rather than defaulting to envelope.
             Object.freeze({
-                path: 'deploy.chroma.memoryCeilingBytes',
-                env : 'NEO_CHROMA_MEMORY_LIMIT',
-                role: 'ceiling',
-                type: 'number',
-                min : CONTAINER_MEMORY_CEILING_MIN_BYTES,
-                max : CONTAINER_MEMORY_CEILING_MAX_BYTES
+                path    : 'deploy.chroma.memoryCeilingBytes',
+                env     : 'NEO_CHROMA_MEMORY_LIMIT',
+                role    : 'ceiling',
+                resource: 'container-memory',
+                type    : 'number',
+                min     : CONTAINER_MEMORY_CEILING_MIN_BYTES,
+                max     : CONTAINER_MEMORY_CEILING_MAX_BYTES
             })
         ]),
         invariants: Object.freeze([

--- a/test/playwright/unit/ai/daemons/orchestrator/ActionClassAdrAccounting.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/ActionClassAdrAccounting.spec.mjs
@@ -1,0 +1,146 @@
+import {setup} from '../../../../setup.mjs';
+
+// The diagnosis module pulls in the Neo class system at load, so the harness must be armed before the
+// dynamic import in `beforeAll` — otherwise the import fails with `Neo is not defined` and the spec
+// reports a red that is about the fixture rather than about the ADR.
+setup({
+    neoConfig: {unitTestMode: true},
+    appConfig: {name: 'ActionClassAdrAccountingTest', isMounted: () => true, vnodeInitialising: false}
+});
+
+import {test, expect} from '@playwright/test';
+import fs             from 'node:fs';
+import path           from 'node:path';
+import process        from 'node:process';
+import Neo            from '../../../../../../src/Neo.mjs';
+import * as core      from '../../../../../../src/core/_export.mjs';
+
+const
+    repoRoot = path.resolve(process.cwd()),
+    adrPath  = path.join(repoRoot, 'learn/agentos/decisions/0026-recovery-actuator.md'),
+    adrText  = fs.readFileSync(adrPath, 'utf8'),
+
+    /** The dispositions an emitted action class may hold against ADR-0026 §2.4. */ // ticket-ref-ok: the ADR this spec's subject IS
+    DISPOSITIONS = Object.freeze(['admitted', 'terminal', 'disclosed-unimplemented']),
+
+    /**
+     * The curated enum → ADR accounting. **Deliberately hand-written, not derived.**
+     *
+     * A grep cannot do this job: the ADR spells `throttle` and `shed` as two separate specified-but-
+     * unimplemented actions while the diagnosis enum carries one hyphenated `throttle-shed`, so a
+     * string search reports a naming difference as a divergence and a real divergence as a match.
+     * The curation IS the content; the two assertions below stop it from drifting in either direction.
+     *
+     * `anchor` must be text actually present in the ADR — that is what keeps a stale mapping from
+     * claiming an accounting the ADR does not give.
+     */
+    ACTION_CLASS_ACCOUNTING = Object.freeze({
+        'raise-ceiling': {
+            disposition: 'admitted',
+            anchor     : 'raise-ceiling',
+            note       : 'Admitted for store-classed compose services only (§2.4 matrix + AC-12). ' +
+                         'Executor shipped in #16637.'
+        },
+        'record': {
+            disposition: 'terminal',
+            anchor     : 'record-with-diagnosis',
+            note       : 'Not a lifecycle action at all — the durable async-audit terminal (AC-6, ' +
+                         'amended #14191). Correctly absent from the admitted-action matrix.'
+        },
+        'restart': {
+            disposition: 'admitted',
+            anchor     : 'restart',
+            note       : 'Admitted for every target kind that has a lifecycle.'
+        },
+        'throttle-shed': {
+            disposition: 'disclosed-unimplemented',
+            anchor     : 'recycle`, `throttle` and `shed` remain specified but UNIMPLEMENTED',
+            note       : 'The LIFECYCLE actuator has no throttle/shed operation. The only shipped ' +
+                         'implementation of that name is collection-keyed in ADR-0027\'s ' +
+                         'data-recovery world, so a lifecycle `throttle-shed` diagnosis is a ' +
+                         'forward declaration consumed by nothing. Disclosed in §2.4.'
+        },
+        'warm-provider': {
+            disposition: 'admitted',
+            anchor     : 'warm-provider',
+            note       : 'Admitted for supervised tasks and compose services (config/readiness repair).'
+        }
+    });
+
+/**
+ * Every action class the container-health diagnosis can emit is accounted for in the recovery-actuator ADR's admitted-action matrix.
+ *
+ * **Why this exists.** That matrix was amended specifically so that *"a reader of this section must be
+ * able to tell which of the listed actions they can actually call"* — and when this guard's ticket was
+ * filed, **two of the five emitted classes appeared nowhere in the ADR at all**:
+ * `grep -rn 'raiseCeiling' learn/` returned zero while the enum shipped it, and `throttle-shed`'s only
+ * implementation turned out to live in a different ADR's world entirely. The section could not do the
+ * job it was amended to do.
+ *
+ * The gap is now closed in the ADR. **This spec is what stops the next one opening**, and it guards
+ * the general property rather than the two instances that motivated it: an action class added to the
+ * enum without an ADR disposition fails here, at the moment it is added, rather than being found by a
+ * reviewer's grep months later.
+ *
+ * Two assertions, and each closes a different drift direction:
+ *
+ * 1. **Enum totality** — every emitted class has an accounting entry. Adding an enum member without
+ *    deciding its ADR status fails.
+ * 2. **Anchor liveness** — every accounting entry's `anchor` is text actually present in that ADR.
+ *    A mapping cannot claim an accounting the ADR does not give, and an ADR rewrite that drops the
+ *    text a disposition rests on fails here too.
+ */
+test.describe('container-health action classes are accounted for in ADR-0026', () => {
+    let CONTAINER_HEALTH_ACTION_CLASSES;
+
+    test.beforeAll(async () => {
+        ({CONTAINER_HEALTH_ACTION_CLASSES} =
+            await import('../../../../../../ai/daemons/orchestrator/services/ContainerHealthDiagnosisService.mjs'));
+    });
+
+    test('ENUM TOTALITY: every emitted action class has an ADR accounting entry', () => {
+        const emitted      = Object.values(CONTAINER_HEALTH_ACTION_CLASSES).sort(),
+              accountedFor = Object.keys(ACTION_CLASS_ACCOUNTING).sort();
+
+        // Set-equality in BOTH directions. A missing entry is an unaccounted action class; a surplus
+        // entry is a mapping that outlived the enum member it describes, which would let a deleted
+        // class keep a green accounting forever.
+        expect(emitted, 'an action class is emitted with no ADR-0026 disposition — decide it, do not add it here blindly')
+            .toEqual(accountedFor);
+    });
+
+    test('ANCHOR LIVENESS: every disposition rests on text actually present in ADR-0026', () => {
+        const missing = Object.entries(ACTION_CLASS_ACCOUNTING)
+            .filter(([, entry]) => !adrText.includes(entry.anchor))
+            .map(([name, entry]) => `${name} → "${entry.anchor}"`);
+
+        expect(missing, 'a disposition claims ADR text that is not in the ADR — the mapping has drifted or the ADR was rewritten')
+            .toEqual([]);
+    });
+
+    test('every disposition is one of the closed set', () => {
+        for (const [name, entry] of Object.entries(ACTION_CLASS_ACCOUNTING)) {
+            expect(DISPOSITIONS, `${name} carries an unrecognised disposition "${entry.disposition}"`)
+                .toContain(entry.disposition);
+        }
+    });
+
+    test('POSITIVE CONTROL: the totality check detects an unaccounted class', () => {
+        // Without this, the totality assertion could be vacuous — it would pass just as green if the
+        // enum import silently yielded an empty object, or if `Object.values` were pointed at the
+        // wrong symbol. Prove the comparison actually discriminates before trusting its silence.
+        const withExtra = [...Object.values(CONTAINER_HEALTH_ACTION_CLASSES), 'invented-action'].sort();
+
+        expect(withExtra).not.toEqual(Object.keys(ACTION_CLASS_ACCOUNTING).sort());
+        // And the enum must be non-empty, or "every member is accounted for" is trivially true.
+        expect(Object.values(CONTAINER_HEALTH_ACTION_CLASSES).length,
+            'an empty enum would make the totality assertion vacuous').toBeGreaterThan(0);
+    });
+
+    test('POSITIVE CONTROL: the anchor check detects text absent from the ADR', () => {
+        // Same discipline for the second assertion: prove `adrText.includes` can say no.
+        expect(adrText.includes('this sentence is not in ADR-0026'),
+            'the anchor check must be able to report an absent anchor').toBe(false);
+        expect(adrText.length, 'the ADR must actually have been read').toBeGreaterThan(1000);
+    });
+});

--- a/test/playwright/unit/ai/daemons/orchestrator/DeclaredHeapCeilingObservation.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/DeclaredHeapCeilingObservation.spec.mjs
@@ -32,11 +32,22 @@ const LIVE = Object.freeze({
     chroma: Object.freeze(['run', '/config.yaml'])
 });
 
-let parseDeclaredHeapCeilingMb;
+let parseDeclaredHeapCeilingMb, isNodeCommand, selectUndeclaredHeapCeilingServices, CONTAINER_HEALTH_FACT_TYPES;
+
+/** Builds a per-service snapshot in the shape `collectBridgeDiagnostics` consumes. */
+const snapshot = (serviceKey, inspect) => ({serviceKey, status: 'available', errors: [], inspect});
 
 test.beforeAll(async () => {
-    ({parseDeclaredHeapCeilingMb} = await import(
-        '../../../../../../ai/daemons/orchestrator/services/DeploymentStateBridgeService.mjs'));
+    const bridge = await import('../../../../../../ai/daemons/orchestrator/services/DeploymentStateBridgeService.mjs');
+
+    // The rule is tested through the extracted pure helper, NOT through `collectBridgeDiagnostics`.
+    // I first wrote this spec calling that method off the prototype, on the assumption it read only
+    // its arguments. Running it falsified that in one line — it reaches `AiConfig` and the runtime
+    // holder, so it threw on `this` being null. The assumption was never checked, only read.
+    ({parseDeclaredHeapCeilingMb, isNodeCommand, selectUndeclaredHeapCeilingServices} = bridge);
+
+    ({CONTAINER_HEALTH_FACT_TYPES} = await import(
+        '../../../../../../ai/daemons/orchestrator/services/ContainerHealthDiagnosisService.mjs'));
 });
 
 test.describe('declared heap ceiling — observed from Config.Cmd, fail-closed on ambiguity', () => {
@@ -84,11 +95,78 @@ test.describe('declared heap ceiling — observed from Config.Cmd, fail-closed o
         expect(parseDeclaredHeapCeilingMb({})).toBe(null);
     });
 
+    test('node detection reads the COMMAND, never the image name', () => {
+        expect(isNodeCommand(LIVE.kbServer)).toBe(true);
+        expect(isNodeCommand(LIVE.mcServer)).toBe(true);
+        expect(isNodeCommand(LIVE.chroma)).toBe(false);
+
+        // The image name is a proxy that holds until it does not: a Node entrypoint on a different
+        // base, or a non-Node entrypoint on the shared image, breaks it SILENTLY. These two rows
+        // are the cases an image check would get wrong in each direction.
+        expect(isNodeCommand(['sh', '-c', 'exec node server.mjs'])).toBe(true);
+        expect(isNodeCommand(['sh', '-c', '/usr/bin/nodemon watch'])).toBe(false);
+    });
+
     test('the value is what the container was TOLD — the name may not imply an enforced ceiling', () => {
         // Guard against a future rename toward "effective"/"actual". No V8-scoped metric exists for
         // a sibling container anywhere in `ai/`, so a name promising one would recreate the
         // cross-scope conflation the heap-ceiling work exists to prevent.
         expect(parseDeclaredHeapCeilingMb(LIVE.kbServer)).toBe(768);
         expect(typeof parseDeclaredHeapCeilingMb(LIVE.kbServer)).toBe('number');
+    });
+});
+
+test.describe('the undeclared-ceiling observation — record-terminal, and never evidence', () => {
+    const
+        nodeUndeclared = snapshot('mc-server',  {nodeCommand: true,  declaredHeapCeilingMb: null}),
+        nodeDeclared   = snapshot('kb-server',  {nodeCommand: true,  declaredHeapCeilingMb: 768}),
+        nonNode        = snapshot('chroma',     {nodeCommand: false, declaredHeapCeilingMb: null}),
+        ambiguous      = snapshot('orchestr',   {nodeCommand: true,  declaredHeapCeilingMb: 'unknown'}),
+        unreadable     = snapshot('ingress',    null);
+
+    test('a Node service with no declared ceiling is named', () => {
+        expect(selectUndeclaredHeapCeilingServices([nodeUndeclared, nodeDeclared])).toEqual(['mc-server']);
+    });
+
+    test('a NON-Node service with no ceiling is not a finding', () => {
+        // chroma has no V8 to bound. Reporting it would be noise the reader learns to ignore, and a
+        // reader who learns to ignore a field stops reading it when it matters.
+        expect(selectUndeclaredHeapCeilingServices([nonNode])).toEqual([]);
+    });
+
+    test('AMBIGUOUS is not the same as ABSENT — `unknown` is not a finding', () => {
+        // The discriminating case. `unknown` means the command carried divergent declarations, so
+        // the ceiling could not be OBSERVED. Listing it here would publish "observed an absence"
+        // where the truth is "could not observe" — the same conflation that makes a null result
+        // read as a clean one.
+        expect(selectUndeclaredHeapCeilingServices([ambiguous])).toEqual([]);
+    });
+
+    test('an unreadable inspect is not a finding either', () => {
+        expect(selectUndeclaredHeapCeilingServices([unreadable])).toEqual([]);
+    });
+
+    test('NEGATIVE CONTROL: every service declared and inside its ceiling yields no finding', () => {
+        expect(selectUndeclaredHeapCeilingServices([nodeDeclared, nonNode])).toEqual([]);
+    });
+
+    test('POSITIVE CONTROL for the four negatives above', () => {
+        // Each negative row asserts an empty array, and an empty array is what a permanently broken
+        // filter returns too. This proves the filter can still produce a finding when the mixed
+        // population includes one — without it, the four rows above are vacuous together.
+        expect(selectUndeclaredHeapCeilingServices([nodeDeclared, nonNode, ambiguous, unreadable, nodeUndeclared]))
+            .toEqual(['mc-server']);
+    });
+
+    test('it is NOT a container-health fact type — the array that feeds every branch', () => {
+        // AC-6, asserted structurally rather than per-branch. `selectEvidenceFacts(facts, …)` is
+        // called with the WHOLE facts array at every classification branch, so the only way to be
+        // absent from all of them is to not be a fact at all. Owning it in the bridge record makes
+        // that true by construction; this guards the construction.
+        const factTypes = Object.values(CONTAINER_HEALTH_FACT_TYPES);
+
+        expect(factTypes.length).toBeGreaterThan(0);                                  // control: the enum loaded
+        expect(factTypes.some(type => /undeclared|declared-ceiling/.test(type))).toBe(false);
+        expect(factTypes).toContain('memory-saturation');                             // control: this IS a fact type
     });
 });

--- a/test/playwright/unit/ai/daemons/orchestrator/DeclaredHeapCeilingObservation.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/DeclaredHeapCeilingObservation.spec.mjs
@@ -1,0 +1,94 @@
+import {setup} from '../../../../setup.mjs';
+
+// The bridge module pulls in the Neo class system at load, so the harness must be armed before the
+// dynamic import in `beforeAll` — otherwise the import fails with `Neo is not defined` and the spec
+// reports a red that is about the fixture rather than about the parser.
+setup({
+    neoConfig: {unitTestMode: true},
+    appConfig: {name: 'DeclaredHeapCeilingObservationTest', isMounted: () => true, vnodeInitialising: false}
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../../../src/Neo.mjs';
+import * as core      from '../../../../../../src/core/_export.mjs';
+
+/**
+ * `Config.Cmd` values COPIED FROM THE LIVE PLANE on 2026-08-08, not invented. An invented fixture
+ * would be shaped by what the parser already does; these were shaped by the deployment.
+ */
+const LIVE = Object.freeze({
+    // One `node` invocation — the simple case.
+    kbServer: Object.freeze(['sh', '-c', 'node --max-old-space-size=768 "$SERVER_ENTRYPOINT"']),
+
+    // TWO invocations, overlay and no-overlay, and the compose spec holds their values equal. This
+    // is the case a naive first-match parser ALSO passes, which is exactly why the divergent
+    // fixture below has to exist — without it this row proves nothing about the agreement rule.
+    mcServer: Object.freeze(['sh', '-c',
+        'overlay=/app/.neo-ai-data/deployment-state/recovery-actuator-overrides.json; if [ -f "$overlay" ]; then\n' +
+        '  node --max-old-space-size=768 "$SERVER_ENTRYPOINT" --config "$overlay";\nelse\n' +
+        '  node --max-old-space-size=768 "$SERVER_ENTRYPOINT";\nfi']),
+
+    // A non-Node service. Its `null` is the one assertion a BROKEN matcher would also satisfy.
+    chroma: Object.freeze(['run', '/config.yaml'])
+});
+
+let parseDeclaredHeapCeilingMb;
+
+test.beforeAll(async () => {
+    ({parseDeclaredHeapCeilingMb} = await import(
+        '../../../../../../ai/daemons/orchestrator/services/DeploymentStateBridgeService.mjs'));
+});
+
+test.describe('declared heap ceiling — observed from Config.Cmd, fail-closed on ambiguity', () => {
+    test('a single declaration is read', () => {
+        expect(parseDeclaredHeapCeilingMb(LIVE.kbServer)).toBe(768);
+    });
+
+    test('two AGREEING declarations resolve to the agreed value', () => {
+        expect(parseDeclaredHeapCeilingMb(LIVE.mcServer)).toBe(768);
+    });
+
+    test('DIVERGENT declarations report `unknown` — never a pick', () => {
+        // Mutated from the live mc-server command by changing ONE branch. `Config.Cmd` does not say
+        // which branch is executing, so returning either number would be a guess with a number
+        // attached. This is the discriminating case: a first-match parser returns 768 and a
+        // last-match parser returns 512, and both are wrong for the same reason.
+        const divergent = LIVE.mcServer.map(part =>
+            part.replace('--max-old-space-size=768 "$SERVER_ENTRYPOINT";', '--max-old-space-size=512 "$SERVER_ENTRYPOINT";'));
+
+        expect(divergent.join(' ')).toContain('--max-old-space-size=512');   // the mutation applied
+        expect(divergent.join(' ')).toContain('--max-old-space-size=768');   // and did not erase its sibling
+
+        expect(parseDeclaredHeapCeilingMb(divergent)).toBe('unknown');
+    });
+
+    test('no declaration reads null — with the positive control that makes that meaningful', () => {
+        // A matcher that never matches would satisfy this line too. The control proves the
+        // instrument can see a present case, so the null below is an observation and not a silence.
+        expect(parseDeclaredHeapCeilingMb(LIVE.chroma)).toBe(null);
+        expect(parseDeclaredHeapCeilingMb(LIVE.kbServer)).toBe(768);
+    });
+
+    test('null and `unknown` are DIFFERENT observations and must not collapse', () => {
+        // "declares none" and "declares ambiguously" route differently: the first is the
+        // undeclared-ceiling case, the second is not observable at all. Conflating them would let
+        // an ambiguous command be reported as an absent ceiling.
+        expect(parseDeclaredHeapCeilingMb(LIVE.chroma)).not.toBe('unknown');
+        expect(parseDeclaredHeapCeilingMb(['node --max-old-space-size=1 x', 'node --max-old-space-size=2 y'])).not.toBe(null);
+    });
+
+    test('a string command is accepted, and junk degrades to null rather than throwing', () => {
+        expect(parseDeclaredHeapCeilingMb('node --max-old-space-size=256 server.mjs')).toBe(256);
+        expect(parseDeclaredHeapCeilingMb(null)).toBe(null);
+        expect(parseDeclaredHeapCeilingMb(undefined)).toBe(null);
+        expect(parseDeclaredHeapCeilingMb({})).toBe(null);
+    });
+
+    test('the value is what the container was TOLD — the name may not imply an enforced ceiling', () => {
+        // Guard against a future rename toward "effective"/"actual". No V8-scoped metric exists for
+        // a sibling container anywhere in `ai/`, so a name promising one would recreate the
+        // cross-scope conflation the heap-ceiling work exists to prevent.
+        expect(parseDeclaredHeapCeilingMb(LIVE.kbServer)).toBe(768);
+        expect(typeof parseDeclaredHeapCeilingMb(LIVE.kbServer)).toBe('number');
+    });
+});

--- a/test/playwright/unit/ai/daemons/orchestrator/services/DeploymentRuntimeAccessService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/DeploymentRuntimeAccessService.spec.mjs
@@ -6,6 +6,7 @@ import {
     DeploymentRuntimeAccessService,
     DEPLOYMENT_RUNTIME_SELF_SERVICE_KEY
 } from '../../../../../../../ai/daemons/orchestrator/services/DeploymentRuntimeAccessService.mjs';
+import {RECOVERY_KNOBS} from '../../../../../../../ai/services/memory-core/helpers/recoveryKnobRegistry.mjs';
 
 const BASE_CONFIG = {
     enabled                     : true,
@@ -613,6 +614,28 @@ test.describe('Neo.ai.daemons.services.DeploymentRuntimeAccessService', () => {
             expect(error.reason).toBe('runtime-memory-limit-unsanctioned-target');
             expect(calls).toHaveLength(1);
             expect(calls.some(call => String(call.path).endsWith('/update'))).toBe(false);
+        });
+
+        test('every container-memory ceiling leaf declares a FINITE band — an unbanded one would delete the cap', () => {
+            // Asserted on the DATA rather than on the branch, deliberately. The boundary's unbanded
+            // refusal is unreachable while chroma is the only envelope knob, so a branch test would
+            // need a synthetic registry and would prove only that the fixture was built correctly.
+            // The hazard is a FUTURE leaf, and it is silent: `value < undefined || value > undefined`
+            // is NaN-false in both directions, so an unbanded envelope knob does not tighten the cap,
+            // it removes it — leaving raise-only as the sole surviving bound and the autonomous
+            // ratchet unterminated.
+            const envelopeLeaves = Object.values(RECOVERY_KNOBS).flatMap(knob =>
+                knob.leaves.filter(leaf => leaf.role === 'ceiling' && leaf.resource === 'container-memory')
+            );
+
+            // Guards the guard: if the discriminator were ever dropped from the registry this would
+            // silently become a vacuous loop over an empty array.
+            expect(envelopeLeaves.length).toBeGreaterThan(0);
+
+            for (const leaf of envelopeLeaves) {
+                expect(Number.isFinite(leaf.min), leaf.path).toBe(true);
+                expect(Number.isFinite(leaf.max), leaf.path).toBe(true);
+            }
         });
 
         test('a value outside the registry band is refused BEFORE any Docker read — the cap holds at L0 too', async () => {

--- a/test/playwright/unit/ai/daemons/orchestrator/services/DeploymentStateBridgeService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/DeploymentStateBridgeService.spec.mjs
@@ -178,6 +178,63 @@ test.describe('Neo.ai.daemons.services.DeploymentStateBridgeService', () => {
         });
     });
 
+    test('the declared heap ceiling travels Config.Cmd → inspect → diagnostics through the OWNER', async () => {
+        // The helper that decides this is unit-tested elsewhere, and that proves only the decision.
+        // This drives `collectSnapshot()` itself, so it proves the WIRING: a correct selector that
+        // was never reached would pass every helper test and publish nothing. Both halves of the
+        // contract are asserted from one snapshot — the per-service `inspect` fields a consumer
+        // reads, and the diagnostics record that names who declared nothing.
+        Object.assign(AiConfig.orchestrator.deploymentStateBridge, {
+            allowedServices: ['kb-server', 'mc-server'],
+            includeLogs    : false
+        });
+        Object.assign(AiConfig.orchestrator.deploymentRuntimeAccess, {
+            enabled        : true,
+            composeProject : null,
+            allowedServices: ['kb-server', 'mc-server'],
+            readOperations : ['inspect', 'stats']
+        });
+
+        // kb-server declares a ceiling; mc-server is Node with none. A third shape is deliberately
+        // absent: a NON-Node command is covered by the helper spec, and duplicating it here would
+        // add a row without adding a wire.
+        const commands = {
+            'kb-server': ['sh', '-c', 'node --max-old-space-size=768 /app/server.mjs'],
+            'mc-server': ['sh', '-c', 'node /app/server.mjs']
+        };
+
+        const runtimeAccessService = {
+            async readObserve(request) {
+                if (request.operation === 'inspect') {
+                    return {
+                        data: {
+                            Name  : `/${request.serviceKey}`,
+                            State : {Status: 'running', Health: {Status: 'healthy'}},
+                            Config: {Image: 'neo', Cmd: commands[request.serviceKey]}
+                        },
+                        proof: {operation: 'inspect'}
+                    };
+                }
+
+                return {data: statsSample({cpuPercent: 5, memoryPercent: 40}), proof: {operation: 'stats'}};
+            }
+        };
+
+        const snapshot = await createService({
+            runtimeAccessService,
+            diagnosisService: {diagnose: () => null}
+        }).collectSnapshot();
+
+        const byKey = Object.fromEntries(snapshot.services.map(entry => [entry.serviceKey, entry]));
+
+        expect(byKey['kb-server'].inspect).toMatchObject({declaredHeapCeilingMb: 768, nodeCommand: true});
+        expect(byKey['mc-server'].inspect).toMatchObject({declaredHeapCeilingMb: null, nodeCommand: true});
+
+        // The published record, read at the exact path a consumer would read it.
+        expect(snapshot.bridgeDiagnostics.serviceResolution.undeclaredHeapCeilingServices)
+            .toEqual(['mc-server']);
+    });
+
     test('adds bridge-level diagnosis when every service lookup fails', async () => {
         Object.assign(AiConfig.orchestrator.deploymentStateBridge, {
             allowedServices: ['kb-server', 'mc-server'],


### PR DESCRIPTION
Resolves #16636

Salvage of PR #16663, closed unmerged under @neo-gpt-emmy's Drop+Supersede (`ticket-prescription-off`). This branch carries the four pieces her Cycle-1 salvage map named as reusable and **withholds the two service-heap knob descriptors** plus `serviceHeapCeilingKnob.spec.mjs`, which moved to #16695.

Evidence: L1 unit — 68/68 across the runtime-access boundary, the knob registry, the declared-ceiling observation and the ADR action-class accounting, plus a rendered-compose check. No runtime-effect AC, so no L3 residual.

## Deltas

| Surface | Change |
|---|---|
| `DeploymentStateBridgeService.mjs` | publishes `inspect.declaredHeapCeilingMb` + `nodeCommand`; emits `undeclaredHeapCeilingServices`, `record`-terminal |
| `docker-compose.yml` | both server container limits parameterised (`NEO_KB_SERVER_MEMORY_LIMIT` / `NEO_MC_SERVER_MEMORY_LIMIT`, default `1g`) |
| `DeploymentRuntimeAccessService.mjs` | envelope guard requires the **resource** a ceiling governs, and refuses a bandless envelope knob |
| `recoveryKnobRegistry.mjs` | chroma's ceiling leaf declares `resource: 'container-memory'` |
| `ActionClassAdrAccounting.spec.mjs` | every emitted action class is accounted for in ADR-0026 |
| 2 specs | 15 declared-ceiling/record tests, 23 lines of boundary coverage |

## What is deliberately NOT here

The two heap knobs. They are written, reviewed and undeliverable: `--max-old-space-size` is baked into `Config.Cmd` at container-create time, and `reconfigure` restarts rather than recreates, so prescribing it would have been **a no-op reporting success**. #16695 owns the descriptors, their tests and the recreation-class delivery question; #16636's knob AC moved there rather than being marked done.

That is also why this PR is worth reviewing on its own terms: everything here takes effect today.

## The guard hardening, restated without its original motive

The resource discriminator arrived in #16663 *because* the heap knobs had made both servers legal targets for a cgroup move. With the knobs withheld that specific hazard is gone, so the rationale is rewritten rather than carried over:

- `role: 'ceiling'` says a leaf is an upper bound; it does not say of **what**. `update-memory-limit` widens the cgroup envelope, so the guard requires `resource: 'container-memory'` instead of inferring it. A leaf omitting the field matches nothing rather than defaulting to envelope.
- A container-memory ceiling leaf with no finite band now refuses (`runtime-memory-limit-unbanded-knob`) instead of comparing against an absent bound — `value < undefined || value > undefined` is NaN-false in both directions, so an unbanded knob would **delete** the cap rather than tighten it.

The band clause is unreachable while chroma is the only envelope knob, so it is proven as a **data invariant** over every `container-memory` leaf, with a non-empty assertion first so the loop cannot go vacuous if the discriminator is ever dropped.

## Test Evidence

- `DeploymentRuntimeAccessService.spec.mjs`, `recoveryKnobRegistry.spec.mjs`, `DeclaredHeapCeilingObservation.spec.mjs`, `ActionClassAdrAccounting.spec.mjs` — **68/68** under `-c test/playwright/playwright.config.mjs`.
- The four salvaged commits cherry-picked onto `origin/dev` without conflict; the guard hardening reapplied by hand so its prose could be rewritten rather than diffed.
- Two pre-existing import lines in `DeploymentRuntimeAccessService.mjs` aligned: the block-alignment hook fires on staged files, and the drift predates this branch — verified by re-running the check against a stashed tree.

## Post-Merge Validation

- [ ] `deploy.kbServer.heapCeilingMb` / `deploy.mcServer.heapCeilingMb` do not exist as knobs on this branch. If #16695 concludes no recreation-class action is acceptable, the bridge's `undeclaredHeapCeilingServices` record stays the whole deliverable — which is a legitimate end state, not a gap.
- [ ] `nodeCommand` reads the command, not the image name. Revisit if a Node service ever ships on a different base.

## Deltas from ticket

#16636's knob AC was moved to #16695 rather than checked off, so this PR's `Resolves` is honest: every remaining AC on that ticket is delivered here. Its finding-2 rationale and `Decision Record impact` were truth-folded first, so nothing downstream reads the falsified `reconfigure` claim.

Authored by @neo-opus-vega (Claude Opus 5).
