### PR TITLE
fix(orchestrator): surface blocked GraphLog compaction (#16681)

### DIFF
--- a/ai/daemons/orchestrator/services/ProcessSupervisorService.mjs
+++ b/ai/daemons/orchestrator/services/ProcessSupervisorService.mjs
@@ -914,13 +914,13 @@ export class ProcessSupervisorService extends Base {
      * @returns {Object}
      */
     classifySuccessfulChildOutcome(taskName, outcome) {
-        if (!outcome || (taskName !== 'memory-summary-backfill' && taskName !== 'kbSync')) {
+        if (!outcome) {
             return {status: 'completed'};
         }
 
-        // Generic deferred envelope: a child that exited 0 without doing work (lease-held /
-        // no-op) emits `{deferred: true, reason}`. Both kbSync (lease-held → no embedding) and
-        // the summary backfill use it — the false-green case that must NOT refresh lastSuccessAt.
+        // Generic deferred envelope: any structured-outcome child that exited 0 without doing
+        // work emits `{deferred: true, reason}`. The task-specific payload stays observable, but
+        // the false-green attempt must NOT refresh lastSuccessAt.
         if (outcome.deferred === true && outcome.reason) {
             return {status: 'skipped', reasonCode: outcome.reason};
         }

--- a/ai/daemons/orchestrator/taskDefinitions.mjs
+++ b/ai/daemons/orchestrator/taskDefinitions.mjs
@@ -444,10 +444,12 @@ export function buildTaskDefinitions({
             command: nodeBin,
             args   : [
                 path.join(scriptDir, 'maintenance', 'compactGraphLog.mjs'),
-                '--apply'
+                '--apply',
+                '--json'
             ],
-            pidFileName    : 'graphlog-compaction.pid',
-            expectedCommand: 'compactGraphLog.mjs'
+            pidFileName      : 'graphlog-compaction.pid',
+            expectedCommand  : 'compactGraphLog.mjs',
+            captureStdoutJson: true
         },
         // Supervised one-shot: the orchestrator owns cadence + the heavy-maintenance lease and spawns this
         // child per due tick to run ONE temporal-pyramid aggregation cycle (L1 session + L2 daily) and exit.

--- a/ai/scripts/maintenance/compactGraphLog.mjs
+++ b/ai/scripts/maintenance/compactGraphLog.mjs
@@ -24,6 +24,7 @@ import {
  * Usage:
  *   node ai/scripts/maintenance/compactGraphLog.mjs
  *   node ai/scripts/maintenance/compactGraphLog.mjs --apply
+ *   node ai/scripts/maintenance/compactGraphLog.mjs --apply --json
  *   node ai/scripts/maintenance/compactGraphLog.mjs --apply --vacuum
  *   node ai/scripts/maintenance/compactGraphLog.mjs --consumer-watermark remote=123456
  *
@@ -450,6 +451,40 @@ export function runGraphLogCompaction({
 }
 
 /**
+ * @summary Projects a bounded scheduler outcome from a completed GraphLog compaction result.
+ * @param {Object} result Compaction result returned by `runGraphLogCompaction()`.
+ * @param {Object} options
+ * @param {Boolean} [options.apply=false] Whether the invocation requested deletion.
+ * @returns {{success:Boolean, deferred:Boolean, status:String, reason:(String|null), beforeRows:Number, afterRows:Number, cutoffLogId:Number, eligibleRows:Number, deletedRows:Number}}
+ */
+export function buildGraphLogCompactionOutcome(result, {apply = false} = {}) {
+    const {before = {}, after = {}, plan = {}, compaction = {}} = result || {};
+    const safetyBlocked = plan.canApply === false && (
+        plan.reason === 'unknown-consumer-watermark' ||
+        plan.reason === 'no-known-consumer-watermark'
+    );
+    const status = safetyBlocked
+        ? 'safety-blocked'
+        : !apply
+            ? 'dry-run'
+            : compaction.deletedRows > 0
+                ? 'applied'
+                : 'up-to-date';
+
+    return {
+        success     : true,
+        deferred    : safetyBlocked,
+        status,
+        reason      : plan.reason || null,
+        beforeRows  : before.rowCount || 0,
+        afterRows   : after.rowCount || 0,
+        cutoffLogId : plan.cutoffLogId || 0,
+        eligibleRows: compaction.eligibleRows || 0,
+        deletedRows : compaction.deletedRows || 0
+    };
+}
+
+/**
  * @summary Logs a concise human-readable compaction report.
  * @param {Object} result
  * @param {Object} options
@@ -503,6 +538,7 @@ export function createCommand({aiConfig} = {}) {
         .option('--safety-margin <rows>', 'Rows to retain below the minimum known consumer watermark.', String(defaults.safetyMarginRows))
         .option('--consumer-watermark <name=logId>', 'Additional durable consumer watermark. May be repeated.', collect, [])
         .option('--wake-live-cursor <logId>', 'Current WakeSubscriptionService liveCursor when active mcp-notifications consumers exist.')
+        .option('--json', 'Emit one bounded machine-readable outcome on stdout instead of the human report.', false)
         .option('--vacuum', 'Run VACUUM after deletion to physically shrink the SQLite db. Operator-gated heavy maintenance.', false);
 }
 
@@ -533,7 +569,7 @@ export async function runCli(argv = process.argv, {aiConfig = null} = {}) {
 
     const options = command.opts();
 
-    return runGraphLogCompaction({
+    const result = runGraphLogCompaction({
         dbPath           : path.resolve(options.db),
         bridgeStateFile : path.resolve(options.bridgeStateFile),
         wakeStateFile   : path.resolve(options.wakeStateFile),
@@ -542,9 +578,16 @@ export async function runCli(argv = process.argv, {aiConfig = null} = {}) {
         wakeLiveCursor  : options.wakeLiveCursor === undefined
             ? null
             : parseNonNegativeInteger(options.wakeLiveCursor, 'wake-live-cursor'),
-        apply           : options.apply,
-        vacuum          : options.vacuum
+        apply : options.apply,
+        vacuum: options.vacuum,
+        logger: options.json ? {log() {}} : console
     });
+
+    if (options.json) {
+        console.log(JSON.stringify(buildGraphLogCompactionOutcome(result, {apply: options.apply})));
+    }
+
+    return result;
 }
 
 if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {

--- a/ai/scripts/maintenance/compactGraphLog.mjs
+++ b/ai/scripts/maintenance/compactGraphLog.mjs
@@ -250,7 +250,7 @@ export function findExplicitSubscriptionWatermark(subscription, extraWatermarks 
  * @param {Object[]} [options.extraWatermarks=[]]
  * @param {Number} [options.wakeLiveCursor=null]
  * @param {Number} [options.safetyMarginRows=DEFAULT_SAFETY_MARGIN_ROWS]
- * @returns {Object}
+ * @returns {{canApply:Boolean, cutoffLogId:Number, consumers:Object[], disposition:String, minWatermark:(Number|undefined), reason:String, safetyMarginRows:Number, unknownConsumers:Object[]}}
  */
 export function computeCompactionPlan({
     stats,
@@ -306,36 +306,41 @@ export function computeCompactionPlan({
 
     if (unknownConsumers.length > 0) {
         return {
-            canApply        : false,
-            cutoffLogId     : 0,
+            canApply   : false,
+            cutoffLogId: 0,
             consumers,
+            disposition: 'safety-blocked',
             unknownConsumers,
-            reason          : 'unknown-consumer-watermark',
+            reason     : 'unknown-consumer-watermark',
             safetyMarginRows
         };
     }
 
     if (consumers.length === 0) {
         return {
-            canApply        : false,
-            cutoffLogId     : 0,
+            canApply   : false,
+            cutoffLogId: 0,
             consumers,
+            disposition: 'safety-blocked',
             unknownConsumers,
-            reason          : 'no-known-consumer-watermark',
+            reason     : 'no-known-consumer-watermark',
             safetyMarginRows
         };
     }
 
     const minWatermark = Math.min(...consumers.map(entry => entry.watermark));
     const cutoffLogId  = Math.max(0, Math.min(stats.maxLogId, minWatermark - safetyMarginRows));
+    const canApply     = cutoffLogId > 0;
+    const upToDate     = !canApply && stats.maxLogId <= safetyMarginRows;
 
     return {
-        canApply        : cutoffLogId > 0,
+        canApply,
         cutoffLogId,
         consumers,
+        disposition: canApply ? 'ready' : upToDate ? 'up-to-date' : 'safety-blocked',
         unknownConsumers,
         minWatermark,
-        reason          : cutoffLogId > 0 ? 'ready' : 'cutoff-not-positive',
+        reason     : canApply ? 'ready' : upToDate ? 'nothing-to-compact' : 'no-safe-cutoff',
         safetyMarginRows
     };
 }
@@ -459,10 +464,7 @@ export function runGraphLogCompaction({
  */
 export function buildGraphLogCompactionOutcome(result, {apply = false} = {}) {
     const {before = {}, after = {}, plan = {}, compaction = {}} = result || {};
-    const safetyBlocked = plan.canApply === false && (
-        plan.reason === 'unknown-consumer-watermark' ||
-        plan.reason === 'no-known-consumer-watermark'
-    );
+    const safetyBlocked = plan.disposition === 'safety-blocked';
     const status = safetyBlocked
         ? 'safety-blocked'
         : !apply

--- a/test/playwright/unit/ai/daemons/orchestrator/Orchestrator.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/Orchestrator.spec.mjs
@@ -1411,12 +1411,13 @@ test.describe('Neo.ai.daemons.Orchestrator (#11009)', () => {
         });
 
         expect(taskDefinitions['graphlog-compaction']).toEqual({
-            label          : 'GraphLog compaction',
-            command        : '/node',
-            args           : ['/repo/ai/scripts/maintenance/compactGraphLog.mjs', '--apply'],
-            pidFileName    : 'graphlog-compaction.pid',
-            expectedCommand: 'compactGraphLog.mjs',
-            authorityClass : 'container-plane'
+            label            : 'GraphLog compaction',
+            command          : '/node',
+            args             : ['/repo/ai/scripts/maintenance/compactGraphLog.mjs', '--apply', '--json'],
+            pidFileName      : 'graphlog-compaction.pid',
+            expectedCommand  : 'compactGraphLog.mjs',
+            captureStdoutJson: true,
+            authorityClass   : 'container-plane'
         });
 
         const orchestrator = createTestOrchestrator({
@@ -1429,6 +1430,7 @@ test.describe('Neo.ai.daemons.Orchestrator (#11009)', () => {
         })['graphlog-compaction'].args).toEqual([
             '/repo/ai/scripts/maintenance/compactGraphLog.mjs',
             '--apply',
+            '--json',
             '--vacuum'
         ]);
     });

--- a/test/playwright/unit/ai/daemons/orchestrator/daemon.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/daemon.spec.mjs
@@ -125,9 +125,11 @@ test.describe('ai/daemons/orchestrator/daemon.mjs (#11006/#11009)', () => {
         expect(tasks['graphlog-compaction'].command).toBe('/test/node');
         expect(tasks['graphlog-compaction'].args).toEqual([
             path.join(scriptDir, 'maintenance', 'compactGraphLog.mjs'),
-            '--apply'
+            '--apply',
+            '--json'
         ]);
         expect(tasks['graphlog-compaction'].expectedCommand).toBe('compactGraphLog.mjs');
+        expect(tasks['graphlog-compaction'].captureStdoutJson).toBe(true);
     });
 
     test('memory-summary backfill CLI is guarded by the shared heavy-maintenance lease', () => {

--- a/test/playwright/unit/ai/daemons/orchestrator/services/ProcessSupervisorService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/ProcessSupervisorService.spec.mjs
@@ -35,6 +35,14 @@ function createTestService() {
             pidFileName      : 'kb-sync.pid',
             expectedCommand  : 'syncKnowledgeBase.mjs',
             captureStdoutJson: true
+        },
+        'graphlog-compaction': {
+            label            : 'GraphLog compaction',
+            command          : 'node',
+            args             : ['compactGraphLog.mjs', '--apply', '--json'],
+            pidFileName      : 'graphlog-compaction.pid',
+            expectedCommand  : 'compactGraphLog.mjs',
+            captureStdoutJson: true
         }
     };
 
@@ -457,6 +465,42 @@ test.describe('Neo.ai.daemons.services.ProcessSupervisorService', () => {
             status  : 'completed',
             taskName: 'kbSync',
             details : expect.objectContaining({added: 2566, deleted: 1513})
+        }));
+    });
+
+    test('#16681: GraphLog safety-blocked stdout records skipped, not false-green completed', () => {
+        const { service, stateCalls, taskOutcomes } = createTestService();
+        const manualChild                           = createManualChild();
+
+        service.spawnFn = () => manualChild.child;
+
+        expect(service.runTask('graphlog-compaction', 'periodic-graphlog-compaction:86400000')).toBe(true);
+        manualChild.writeStdout(JSON.stringify({
+            success     : true,
+            deferred    : true,
+            status      : 'safety-blocked',
+            reason      : 'unknown-consumer-watermark',
+            beforeRows  : 3200403,
+            afterRows   : 3200403,
+            cutoffLogId : 0,
+            eligibleRows: 0,
+            deletedRows : 0
+        }));
+        manualChild.close(0);
+
+        expect(stateCalls).toContainEqual({action: 'skipped', taskName: 'graphlog-compaction'});
+        expect(stateCalls).not.toContainEqual({action: 'completed', taskName: 'graphlog-compaction'});
+        expect(taskOutcomes).toContainEqual(expect.objectContaining({
+            status  : 'skipped',
+            taskName: 'graphlog-compaction',
+            details : expect.objectContaining({
+                reasonCode : 'unknown-consumer-watermark',
+                childReason: 'unknown-consumer-watermark',
+                status     : 'safety-blocked',
+                deferred   : true,
+                beforeRows : 3200403,
+                afterRows  : 3200403
+            })
         }));
     });
 

--- a/test/playwright/unit/ai/scripts/maintenance/compactGraphLog.spec.mjs
+++ b/test/playwright/unit/ai/scripts/maintenance/compactGraphLog.spec.mjs
@@ -15,6 +15,7 @@ import fs             from 'fs-extra';
 import path           from 'path';
 
 import {
+    buildGraphLogCompactionOutcome,
     compactGraphLogRows,
     computeCompactionPlan,
     createCommand,
@@ -291,6 +292,56 @@ test.describe('compactGraphLog maintenance guard', () => {
         expect(plan.canApply).toBe(true);
         expect(plan.minWatermark).toBe(15);
         expect(plan.cutoffLogId).toBe(13);
+    });
+
+    test('#16681: distinguishes a consumer-blocked cutoff from a retained short log', () => {
+        const blockedPlan = computeCompactionPlan({
+            stats              : {maxLogId: 20},
+            wakeDaemonWatermark: null,
+            extraWatermarks    : [parseConsumerWatermark('remote-worker=1')],
+            safetyMarginRows   : 2
+        });
+        const blockedOutcome = buildGraphLogCompactionOutcome({
+            before    : {rowCount: 20},
+            after     : {rowCount: 20},
+            plan      : blockedPlan,
+            compaction: {eligibleRows: 0, deletedRows: 0}
+        }, {apply: true});
+
+        expect(blockedPlan).toEqual(expect.objectContaining({
+            canApply   : false,
+            disposition: 'safety-blocked',
+            reason     : 'no-safe-cutoff'
+        }));
+        expect(blockedOutcome).toEqual(expect.objectContaining({
+            deferred: true,
+            status  : 'safety-blocked',
+            reason  : 'no-safe-cutoff'
+        }));
+
+        const upToDatePlan = computeCompactionPlan({
+            stats              : {maxLogId: 2},
+            wakeDaemonWatermark: null,
+            extraWatermarks    : [parseConsumerWatermark('remote-worker=2')],
+            safetyMarginRows   : 2
+        });
+        const upToDateOutcome = buildGraphLogCompactionOutcome({
+            before    : {rowCount: 2},
+            after     : {rowCount: 2},
+            plan      : upToDatePlan,
+            compaction: {eligibleRows: 0, deletedRows: 0}
+        }, {apply: true});
+
+        expect(upToDatePlan).toEqual(expect.objectContaining({
+            canApply   : false,
+            disposition: 'up-to-date',
+            reason     : 'nothing-to-compact'
+        }));
+        expect(upToDateOutcome).toEqual(expect.objectContaining({
+            deferred: false,
+            status  : 'up-to-date',
+            reason  : 'nothing-to-compact'
+        }));
     });
 
     test('dry-run reports eligible rows without deleting; apply deletes only through cutoff', () => {

--- a/test/playwright/unit/ai/scripts/maintenance/compactGraphLog.spec.mjs
+++ b/test/playwright/unit/ai/scripts/maintenance/compactGraphLog.spec.mjs
@@ -150,7 +150,7 @@ test.describe('compactGraphLog maintenance guard', () => {
         });
     });
 
-    test('standalone CLI bootstraps the Neo realm before loading runtime config', async () => {
+    test('#16681: standalone CLI boots runtime config and distinguishes structured apply outcomes', async () => {
         insertGraphLogRows(3);
         db.close();
         db = null;
@@ -163,24 +163,88 @@ test.describe('compactGraphLog maintenance guard', () => {
             await fs.copy(templateConfigPath, runtimeConfigPath);
         }
 
-        try {
-            const result = spawnSync('node', [
-                'ai/scripts/maintenance/compactGraphLog.mjs',
-                '--db', dbPath,
-                '--bridge-state-file', bridgeStateFile,
-                '--wake-state-file', wakeStateFile,
-                '--safety-margin', '1',
-                '--consumer-watermark', 'test=3'
-            ], {
-                cwd     : process.cwd(),
-                encoding: 'utf8',
-                env     : {...process.env, UNIT_TEST_MODE: 'true'}
-            });
+        const pathArgs = [
+            '--db', dbPath,
+            '--bridge-state-file', bridgeStateFile,
+            '--wake-state-file', wakeStateFile,
+            '--safety-margin', '1',
+            '--consumer-watermark', 'test=3'
+        ];
+        const run = flags => spawnSync('node', [
+            'ai/scripts/maintenance/compactGraphLog.mjs',
+            ...flags,
+            ...pathArgs
+        ], {
+            cwd     : process.cwd(),
+            encoding: 'utf8',
+            env     : {...process.env, UNIT_TEST_MODE: 'true'}
+        });
 
-            expect(result.status).toBe(0);
-            expect(result.stderr).not.toContain('ReferenceError: Neo is not defined');
-            expect(result.stdout).toContain('GraphLog compaction DRY-RUN');
-            expect(result.stdout).toContain('eligible rows: 2');
+        try {
+            const humanReadable = run([]);
+
+            expect(humanReadable.status).toBe(0);
+            expect(humanReadable.stderr).not.toContain('ReferenceError: Neo is not defined');
+            expect(humanReadable.stdout).toContain('GraphLog compaction DRY-RUN');
+            expect(humanReadable.stdout).toContain('eligible rows: 2');
+
+            const applied = run(['--apply', '--json']);
+
+            expect(applied.status).toBe(0);
+            expect(JSON.parse(applied.stdout)).toEqual(expect.objectContaining({
+                success     : true,
+                deferred    : false,
+                status      : 'applied',
+                reason      : 'ready',
+                beforeRows  : 3,
+                afterRows   : 1,
+                cutoffLogId : 2,
+                eligibleRows: 2,
+                deletedRows : 2
+            }));
+
+            const upToDate = run(['--apply', '--json']);
+
+            expect(upToDate.status).toBe(0);
+            expect(JSON.parse(upToDate.stdout)).toEqual(expect.objectContaining({
+                success     : true,
+                deferred    : false,
+                status      : 'up-to-date',
+                reason      : 'ready',
+                beforeRows  : 1,
+                afterRows   : 1,
+                cutoffLogId : 2,
+                eligibleRows: 0,
+                deletedRows : 0
+            }));
+
+            const mutationDb = new Database(dbPath);
+            mutationDb.prepare('INSERT INTO Nodes(id, data) VALUES (?, ?)').run('WAKE_SUB:mcp', JSON.stringify({
+                id        : 'WAKE_SUB:mcp',
+                label     : 'WAKE_SUBSCRIPTION',
+                properties: {
+                    agentIdentity: '@neo-gpt-emmy',
+                    harnessTarget: 'mcp-notifications',
+                    status       : 'active',
+                    trigger      : 'SENT_TO_ME'
+                }
+            }));
+            mutationDb.close();
+
+            const blocked = run(['--apply', '--json']);
+
+            expect(blocked.status).toBe(0);
+            expect(JSON.parse(blocked.stdout)).toEqual(expect.objectContaining({
+                success     : true,
+                deferred    : true,
+                status      : 'safety-blocked',
+                reason      : 'unknown-consumer-watermark',
+                beforeRows  : 1,
+                afterRows   : 1,
+                cutoffLogId : 0,
+                eligibleRows: 0,
+                deletedRows : 0
+            }));
         } finally {
             if (!hadRuntimeConfig) {
                 await fs.remove(runtimeConfigPath);


### PR DESCRIPTION
Resolves #16681

Related: #12329, #12394, #13755, #16677

Scheduled GraphLog compaction now exposes the maintenance outcome the child actually reached. The CLI retains its human-readable default and gains an explicit one-document JSON mode for `applied`, `up-to-date`, and `safety-blocked`; the scheduled task captures that bounded outcome; and the supervisor maps a fail-closed `{deferred: true, reason}` result to `skipped` without refreshing `lastSuccessAt`. The existing cutoff authority and deletion safety remain unchanged.

Evidence: L2 (real CLI subprocesses over a temporary SQLite GraphLog plus exact supervisor/task wiring tests) → L2 required (all close-target acceptance criteria are deterministic local contracts). No residuals.

## Deltas from ticket

- None after the pre-implementation scope correction. Durable `mcp-notifications` / `a2a-webhook` watermark authority remains explicitly out of scope; this diff does not synthesize or weaken any cursor.
- Decision Record impact: aligned with ADR 0014; `graphlog-compaction` remains container-plane and gains truthful task outcome telemetry only.

## Test Evidence

- Compactor + supervisor outcome contract: `npm run test-unit -- test/playwright/unit/ai/scripts/maintenance/compactGraphLog.spec.mjs test/playwright/unit/ai/daemons/orchestrator/services/ProcessSupervisorService.spec.mjs` — 64/64 passed.
- Daemon task-definition contract: `npm run test-unit -- test/playwright/unit/ai/daemons/orchestrator/daemon.spec.mjs` — 23/23 passed.
- Full Orchestrator suite on exact head: `npm run test-unit -- test/playwright/unit/ai/daemons/orchestrator/Orchestrator.spec.mjs` — 79/79 passed.
- Staged repository gates: `npx lint-staged --verbose` — whitespace, shorthand, AiConfig test mutation, derived-domain, JSDoc types, ticket archaeology, block alignment, and parse checks passed.
- Patch hygiene: `git diff --check` and `git diff --cached --check` — passed before commit.

## Post-Merge Validation

- [ ] After the next canonical Agent OS deployment, inspect the next scheduled `graphlog-compaction` receipt: an unknown consumer watermark must record `skipped` / `safety-blocked` with reason and bounded counts, not `completed`.
- [ ] If the consumer cutoff is authoritative, verify the receipt distinguishes `applied` from genuinely `up-to-date` and preserves the measured before/after/deleted counts.
- [ ] Confirm no GraphLog deletion or container restart is attributed to this pre-merge change; live deployment remains operator-sequenced.

## Evolution

Pre-execution intake split one broad ticket into the coherent scheduler-outcome leaf implemented here and a separately owned watermark-authority problem. The implementation then reused the supervisor's existing generic deferred envelope instead of creating a GraphLog-specific status path, making structured no-work outcomes truthful for every opted-in child.

Authored by Emmy (GPT-5.6 Sol Ultra, Codex). Session 019fe0b3-53bc-7ef2-8665-41a0ef3f7b62.
