### PR TITLE
fix(workstation): re-verify the active candidate after the cross-zone dwell (#16700)

### DIFF
--- a/apps/workstation/view/Workspace.mjs
+++ b/apps/workstation/view/Workspace.mjs
@@ -4024,15 +4024,16 @@ class Workspace extends Container {
 
                 // The dwell is a TOCTOU window: the candidate verified active above can be lost
                 // while it elapses — a human-pause dwell can outlive the gesture claim's
-                // arbitration TTL, retiring the candidate mid-gesture. Re-verify before the read:
-                // a loss fails the step through the receipts channel naming the gate, instead of
-                // an unattributed null-read here.
+                // arbitration TTL, retiring the candidate mid-gesture — or be preempted by a
+                // competing candidate. Re-verify identity before the read: a loss or swap fails
+                // the step through the receipts channel naming the gate, instead of an
+                // unattributed null-read or a silently adopted wrong preview here.
                 let preview = indicators.activeCandidate?.preview;
 
-                if (!preview) {
+                if (preview?.previewId !== candidate.preview.previewId) {
                     throw new Error(
                         `active candidate '${candidate.preview.previewId}' lost during the ${dwellDelay}ms dwell — ` +
-                        `gate=dwell-reverify active=${indicators.activeCandidate?.preview?.previewId ?? 'null'} ` +
+                        `gate=dwell-reverify active=${preview?.previewId ?? 'null'} ` +
                         `dwell=${index + 1}/${dwells.length} target='${dwell.targetNodeId}' placement='${dwell.placementKind}'`
                     )
                 }

--- a/apps/workstation/view/Workspace.mjs
+++ b/apps/workstation/view/Workspace.mjs
@@ -4022,7 +4022,20 @@ class Workspace extends Container {
 
                 dwellDelay > 0 && await me.timeout(dwellDelay);
 
-                let preview = indicators.activeCandidate.preview;
+                // The dwell is a TOCTOU window: the candidate verified active above can be lost
+                // while it elapses — a human-pause dwell can outlive the gesture claim's
+                // arbitration TTL, retiring the candidate mid-gesture. Re-verify before the read:
+                // a loss fails the step through the receipts channel naming the gate, instead of
+                // an unattributed null-read here.
+                let preview = indicators.activeCandidate?.preview;
+
+                if (!preview) {
+                    throw new Error(
+                        `active candidate '${candidate.preview.previewId}' lost during the ${dwellDelay}ms dwell — ` +
+                        `gate=dwell-reverify active=${indicators.activeCandidate?.preview?.previewId ?? 'null'} ` +
+                        `dwell=${index + 1}/${dwells.length} target='${dwell.targetNodeId}' placement='${dwell.placementKind}'`
+                    )
+                }
 
                 finalPreview = JSON.parse(JSON.stringify(preview));
                 beats.push({

--- a/test/playwright/unit/apps/workstation/Workspace.spec.mjs
+++ b/test/playwright/unit/apps/workstation/Workspace.spec.mjs
@@ -2410,7 +2410,10 @@ test.describe('replay probe transaction (prototype-call)', () => {
 
 
 test.describe('cross-zone dwell candidate re-verification (prototype-call)', () => {
-    test('an active candidate lost during the dwell fails the step with a gate-named executor error', async () => {
+    // Drives `executeCrossZoneShowcaseStep` to its first dwell with a fake host, then applies
+    // `onDwell` to the indicators when the dwell-length timeout fires — covering both mid-dwell
+    // loss modes: expiry (the candidate is gone) and preemption (a different candidate is live).
+    const runDwellScenario = async onDwell => {
         const
             dwellDelay = 600,
             events     = [],
@@ -2452,12 +2455,8 @@ test.describe('cross-zone dwell candidate re-verification (prototype-call)', () 
                 timeout(ms) {
                     timeouts.push(ms);
 
-                    // Simulates a candidate loss mid-dwell (a human-pause dwell outliving the
-                    // gesture claim's arbitration TTL): the unguarded read then threw an
-                    // unattributed TypeError from inside the executor; the guard must convert it
-                    // into a gate-named step failure.
                     if (ms >= dwellDelay) {
-                        indicators.activeCandidate = null
+                        onDwell(indicators)
                     }
 
                     return Promise.resolve()
@@ -2483,15 +2482,39 @@ test.describe('cross-zone dwell candidate re-verification (prototype-call)', () 
         WindowManager.register({id: 'fake-cross-zone-window', innerRect: {height: 800, width: 1200, x: 0, y: 0}, windowId: 'fake-cross-zone-window'});
 
         try {
-            const result = await Workspace.prototype.executeCrossZoneShowcaseStep.call(host, step, {dwellDelay});
-
-            expect(result.applied, 'the step fails closed').toBe(false);
-            expect(
-                result.errors[0],
-                'the loss surfaces as a gate-named executor receipt, not an unattributed null-read'
-            ).toMatch(/active candidate 'preview-a' lost during the 600ms dwell — gate=dwell-reverify active=null dwell=1\/2/);
+            return await Workspace.prototype.executeCrossZoneShowcaseStep.call(host, step, {dwellDelay});
         } finally {
             WindowManager.unregister('fake-cross-zone-window')
         }
+    };
+
+    test('an active candidate lost during the dwell fails the step with a gate-named executor error', async () => {
+        // Expiry mode: a human-pause dwell outlives the gesture claim's arbitration TTL and the
+        // candidate is gone when the dwell elapses. The unguarded read threw an unattributed
+        // TypeError from inside the executor; the guard converts it into a gate-named receipt.
+        const result = await runDwellScenario(indicators => {
+            indicators.activeCandidate = null
+        });
+
+        expect(result.applied, 'the step fails closed').toBe(false);
+        expect(
+            result.errors[0],
+            'the loss surfaces as a gate-named executor receipt, not an unattributed null-read'
+        ).toMatch(/active candidate 'preview-a' lost during the 600ms dwell — gate=dwell-reverify active=null dwell=1\/2/);
+    });
+
+    test('an active candidate swapped during the dwell fails the step instead of adopting the wrong preview', async () => {
+        // Preemption mode: a different (truthy) candidate takes over mid-dwell. A presence-only
+        // guard would silently adopt the swap — the final preview, beat log, and committed
+        // operation would all name a candidate this gesture never verified.
+        const result = await runDwellScenario(indicators => {
+            indicators.activeCandidate = {preview: {placement: {kind: 'after'}, previewId: 'preview-b', target: {nodeId: 'zone-b'}}}
+        });
+
+        expect(result.applied, 'the step fails closed').toBe(false);
+        expect(
+            result.errors[0],
+            'the swap surfaces as the same gate-named receipt, with the live candidate named'
+        ).toMatch(/active candidate 'preview-a' lost during the 600ms dwell — gate=dwell-reverify active=preview-b dwell=1\/2/);
     });
 });

--- a/test/playwright/unit/apps/workstation/Workspace.spec.mjs
+++ b/test/playwright/unit/apps/workstation/Workspace.spec.mjs
@@ -2407,3 +2407,91 @@ test.describe('replay probe transaction (prototype-call)', () => {
         expect(refreshCalls).toHaveLength(1)
     });
 });
+
+
+test.describe('cross-zone dwell candidate re-verification (prototype-call)', () => {
+    test('an active candidate lost during the dwell fails the step with a gate-named executor error', async () => {
+        const
+            dwellDelay = 600,
+            events     = [],
+            timeouts   = [],
+            indicators = {
+                candidateSet: {
+                    zone : {nodeId: 'zone-a'},
+                    cross: [{preview: {placement: {kind: 'before'}, previewId: 'preview-a', target: {nodeId: 'zone-a'}}}]
+                },
+                activeCandidate     : {preview: {placement: {kind: 'before'}, previewId: 'preview-a', target: {nodeId: 'zone-a'}}},
+                getCandidateHitPoint: () => ({x: 360, y: 360})
+            },
+            button = {
+                id        : 'fake-tab-button',
+                windowId  : 'fake-cross-zone-window',
+                getDomRect: async () => [{height: 20, width: 40, x: 100, y: 100}]
+            },
+            sortZone = {enableProxyToPopup: true, isDestroyed: false},
+            host     = {
+                dockModel      : {nodes: {'source-tabs': {items: ['item-1'], type: 'tabs'}}},
+                id             : 'fake-workspace-cross-zone',
+                isDestroyed    : false,
+                refreshPromise : Promise.resolve(),
+                dragAffordances: {
+                    indicators,
+                    ensureGeometry: async () => ({zones: [
+                        {nodeId: 'zone-a', rect: {height: 100, width: 100, x: 300, y: 300}},
+                        {nodeId: 'zone-b', rect: {height: 100, width: 100, x: 500, y: 500}}
+                    ]})
+                },
+                interactionService: {
+                    simulateEvent(payload) {
+                        events.push(...payload.events);
+
+                        return Promise.resolve()
+                    }
+                },
+                getReference: () => ({down: () => ({getTabAtIndex: () => button, getTabBar: () => ({sortZone})})}),
+                timeout(ms) {
+                    timeouts.push(ms);
+
+                    // Simulates a candidate loss mid-dwell (a human-pause dwell outliving the
+                    // gesture claim's arbitration TTL): the unguarded read then threw an
+                    // unattributed TypeError from inside the executor; the guard must convert it
+                    // into a gate-named step failure.
+                    if (ms >= dwellDelay) {
+                        indicators.activeCandidate = null
+                    }
+
+                    return Promise.resolve()
+                },
+                cancelTearOutGesture   : async () => ({}),
+                retireFilmCursorDot    : async () => {},
+                waitForTearOutDragArmed: async () => true
+            },
+            step = {
+                itemId      : 'item-1',
+                sourceNodeId: 'source-tabs',
+                dwells      : [
+                    {placementKind: 'before', targetNodeId: 'zone-a'},
+                    {placementKind: 'after',  targetNodeId: 'zone-b'}
+                ]
+            };
+
+        // Dynamic import AFTER setup() — the manager singleton touches `Neo.currentWorker` at
+        // construct time, so a static import would run before the test env wires the worker and
+        // poison the whole file's module load (same reason the production method imports it lazily).
+        const {default: WindowManager} = await import('../../../../../src/manager/Window.mjs');
+
+        WindowManager.register({id: 'fake-cross-zone-window', innerRect: {height: 800, width: 1200, x: 0, y: 0}, windowId: 'fake-cross-zone-window'});
+
+        try {
+            const result = await Workspace.prototype.executeCrossZoneShowcaseStep.call(host, step, {dwellDelay});
+
+            expect(result.applied, 'the step fails closed').toBe(false);
+            expect(
+                result.errors[0],
+                'the loss surfaces as a gate-named executor receipt, not an unattributed null-read'
+            ).toMatch(/active candidate 'preview-a' lost during the 600ms dwell — gate=dwell-reverify active=null dwell=1\/2/);
+        } finally {
+            WindowManager.unregister('fake-cross-zone-window')
+        }
+    });
+});


### PR DESCRIPTION
Resolves #16700

The cross-zone executor's dwell chain verified the active candidate, waited `dwellDelay`, then read `indicators.activeCandidate.preview` unguarded — a candidate lost mid-dwell (a human-pause dwell can outlive the gesture claim's arbitration TTL, the family `#16497` pinned) surfaced as an unattributed `Cannot read properties of null (reading 'preview')` from inside the executor, killing the gesture chain mid-flight and taxing every suite lane with unattributable reds. The read is now re-verified after the dwell; a loss throws a gate-named executor error, which the method's existing catch converts into an attributed step receipt (`gate=dwell-reverify`, expected vs live candidate id, dwell position) — the robustness repair and the classification instrument in one, per the parent's step 1.

Evidence: L1 (unit suite — receipt attribution is fully decidable in the single-thread simulation) → L1 required (the leaf's ACs are unit-level). Residual: none [#16700]. The parent's suite-battery and classification legs (AC-2/3/4) remain open on `#16620` by design.

## Deltas from ticket

None substantive — the guard is exactly the ticket's Fix shape. One scoping note: the throw is intentional and load-bearing — `executeCrossZoneShowcaseStep`'s `catch` converts it into the returned `{applied: false, errors: […]}` receipt, so the gate name travels the existing receipts channel; no new error path was added.

## Test Evidence

- Unit (`test/playwright/playwright.config.unit.mjs`, apps/workstation/Workspace): **38/38 passed** including the new witness `cross-zone dwell candidate re-verification (prototype-call)` — the fake host's `timeout()` retires the active candidate inside the 600ms dwell (the TTL-expiry simulation). RED against the unpatched read (`errors[0]` carried the unattributed TypeError message), GREEN with the guard.
- Touched surface `apps/workstation`: the Workspace spec file is the surface's unit coverage; the live suite battery is the parent's leg 2 (not this PR).

## Post-Merge Validation

- [ ] The parent ticket's ≥5-run suite battery (`#16620` leg 2) censes the remaining faces with gate-named receipts flowing.
- [ ] Check off AC-1 on `#16620` once this lands.

## Related

Related: #16620 (parent ticket — the battery/classification legs live there) · Refs #16497 · Refs #16500 · Refs #16499

Authored by Iris (Kimi K3, Kimi Code CLI). Session f62a4ece-0cb8-43eb-9311-e684aaf9cbc5.
