### PR TITLE
fix(kb): observe embedding readiness (#16691)

### DIFF
--- a/ai/mcp/server/knowledge-base/Server.mjs
+++ b/ai/mcp/server/knowledge-base/Server.mjs
@@ -96,6 +96,24 @@ class Server extends BaseServer {
     }
 
     /**
+     * @summary Starts the lifecycle-owned embedding producer and awaits its first bounded
+     * observation before the server publishes startup health.
+     *
+     * Health reads remain pure snapshots. The explicit 30-second consumer deadline bounds boot
+     * even when a provider accepts the request and never answers; process exit disarms scheduling.
+     * @returns {Promise<void>}
+     */
+    async beforeHealthcheck() {
+        const firstObservation = HealthService.startEmbeddingProbe();
+
+        process.once('exit', () => HealthService.stopEmbeddingProbe());
+
+        if (firstObservation) {
+            await firstObservation;
+        }
+    }
+
+    /**
      * @summary Tools allowed without the healthcheck gate.
      * @returns {Array<String>}
      */

--- a/ai/mcp/server/knowledge-base/openapi.yaml
+++ b/ai/mcp/server/knowledge-base/openapi.yaml
@@ -949,7 +949,8 @@ components:
           properties:
             embedding:
               type: boolean
-              description: "Indicates if the configured embedding provider is available."
+              nullable: true
+              description: "Latest observed embedding-path readiness: true after a healthy vector, false after a settled failure, null before any observation. Never inferred from configuration alone."
               example: true
         details:
           type: array

--- a/ai/services/knowledge-base/HealthService.mjs
+++ b/ai/services/knowledge-base/HealthService.mjs
@@ -1,7 +1,7 @@
 import path                       from 'path';
 import {fileURLToPath}            from 'url';
 import aiConfig                   from '../../mcp/server/knowledge-base/config.mjs';
-import embeddingConfig            from '../../mcp/server/memory-core/config.mjs';
+import mcConfig                   from '../../mcp/server/memory-core/config.mjs';
 import Base                       from '../../../src/core/Base.mjs';
 import ChromaManager              from './ChromaManager.mjs';
 import DatabaseLifecycleService   from './DatabaseLifecycleService.mjs';
@@ -46,8 +46,13 @@ const
  * The consumer-owned 30-second default is deliberately explicit: it is the slow-sample tolerance
  * boundary. Scheduling and retry backoff remain lifecycle-owned by `HealthService`.
  *
+ * The default intentionally reads Memory Core's resolved embedding leaves because the Knowledge Base
+ * query and ingest paths both pass that same provider to `TextEmbeddingService`. This is an observation
+ * of the dependency those operations actually use, not an inference from Knowledge Base's sibling
+ * server config. If those operations move to KB-owned leaves, this default must move with them.
+ *
  * @param {Object}   [options]
- * @param {Object}   [options.cfg=embeddingConfig] Resolved embedding provider configuration.
+ * @param {Object}   [options.cfg=mcConfig] Resolved embedding provider configuration used by KB embedding operations.
  * @param {Function} [options.embedText] Injectable embedding call.
  * @param {String}   [options.input='neo-kb-healthcheck-embedding-canary'] Probe text.
  * @param {Function} [options.now=Date.now] Injectable clock.
@@ -55,7 +60,7 @@ const
  * @returns {Promise<Object>} Health-safe embedding observation.
  */
 export async function buildKnowledgeBaseEmbeddingProbeBlock({
-    cfg       = embeddingConfig,
+    cfg       = mcConfig,
     embedText,
     input     = 'neo-kb-healthcheck-embedding-canary',
     now       = Date.now,
@@ -514,7 +519,7 @@ class HealthService extends Base {
                 schedule,
                 clearSchedule: unschedule,
                 clock        : clock ?? Date.now,
-                keyFor       : keyFor ?? (() => `${embeddingConfig.embeddingProvider}:${embeddingConfig.vectorDimension}`),
+                keyFor       : keyFor ?? (() => `${mcConfig.embeddingProvider}:${mcConfig.vectorDimension}`),
                 runProbe     : runProbe ?? (() => buildKnowledgeBaseEmbeddingProbeBlock({timeoutMs: producer.timeoutMs})),
                 disabled     : false,
                 stopped      : false,

--- a/ai/services/knowledge-base/HealthService.mjs
+++ b/ai/services/knowledge-base/HealthService.mjs
@@ -1,7 +1,6 @@
 import path                       from 'path';
 import {fileURLToPath}            from 'url';
 import aiConfig                   from '../../mcp/server/knowledge-base/config.mjs';
-import mcConfig                   from '../../mcp/server/memory-core/config.mjs';
 import Base                       from '../../../src/core/Base.mjs';
 import ChromaManager              from './ChromaManager.mjs';
 import DatabaseLifecycleService   from './DatabaseLifecycleService.mjs';
@@ -46,13 +45,12 @@ const
  * The consumer-owned 30-second default is deliberately explicit: it is the slow-sample tolerance
  * boundary. Scheduling and retry backoff remain lifecycle-owned by `HealthService`.
  *
- * The default intentionally reads Memory Core's resolved embedding leaves because the Knowledge Base
- * query and ingest paths both pass that same provider to `TextEmbeddingService`. This is an observation
- * of the dependency those operations actually use, not an inference from Knowledge Base's sibling
- * server config. If those operations move to KB-owned leaves, this default must move with them.
+ * The default reads Knowledge Base's resolved embedding leaves at the use site. Tier-1 inheritance
+ * keeps those leaves aligned with the configured provider while preserving this service's ownership
+ * boundary and the reactive Provider SSOT.
  *
  * @param {Object}   [options]
- * @param {Object}   [options.cfg=mcConfig] Resolved embedding provider configuration used by KB embedding operations.
+ * @param {Object}   [options.cfg=aiConfig] Resolved Knowledge Base embedding provider configuration.
  * @param {Function} [options.embedText] Injectable embedding call.
  * @param {String}   [options.input='neo-kb-healthcheck-embedding-canary'] Probe text.
  * @param {Function} [options.now=Date.now] Injectable clock.
@@ -60,7 +58,7 @@ const
  * @returns {Promise<Object>} Health-safe embedding observation.
  */
 export async function buildKnowledgeBaseEmbeddingProbeBlock({
-    cfg       = mcConfig,
+    cfg       = aiConfig,
     embedText,
     input     = 'neo-kb-healthcheck-embedding-canary',
     now       = Date.now,
@@ -519,7 +517,7 @@ class HealthService extends Base {
                 schedule,
                 clearSchedule: unschedule,
                 clock        : clock ?? Date.now,
-                keyFor       : keyFor ?? (() => `${mcConfig.embeddingProvider}:${mcConfig.vectorDimension}`),
+                keyFor       : keyFor ?? (() => `${aiConfig.embeddingProvider}:${aiConfig.vectorDimension}`),
                 runProbe     : runProbe ?? (() => buildKnowledgeBaseEmbeddingProbeBlock({timeoutMs: producer.timeoutMs})),
                 disabled     : false,
                 stopped      : false,

--- a/ai/services/knowledge-base/HealthService.mjs
+++ b/ai/services/knowledge-base/HealthService.mjs
@@ -441,6 +441,9 @@ class HealthService extends Base {
      * returned so server boot can await observed truth before its first public health verdict.
      * Re-arms preserve the same bounded gate, so an in-flight attempt is joined and failure backoff
      * survives a scheduler restart. Epoch fencing keeps queued callbacks from an older arm inert.
+     * An attempt-body throw becomes a fixed `probe-could-not-run` receipt at this consumer boundary;
+     * provider deadlines already return `consumer-probe-timeout`. The gate therefore owns cadence
+     * and backoff while the probe owns the public failure meaning.
      *
      * @param {Object}   [options]
      * @param {Number}   [options.cadenceMs=60000] Producer attempt cadence.
@@ -492,7 +495,18 @@ class HealthService extends Base {
             producer = this.#embeddingProbeProducer = {
                 epoch: 0,
                 gate : createBoundedRetryGate({
-                    run: context => producer.runProbe(context),
+                    run: async context => {
+                        try {
+                            return await producer.runProbe(context);
+                        } catch {
+                            return {
+                                status             : 'failed',
+                                error              : 'probe-could-not-run:EMBEDDING_PROBE_EXECUTION_ERROR',
+                                errorClassification: 'probe-could-not-run',
+                                errorCode          : 'EMBEDDING_PROBE_EXECUTION_ERROR'
+                            };
+                        }
+                    },
                     failureTtlMs,
                     failureTtlMaxMs,
                     now: () => producer.clock()

--- a/ai/services/knowledge-base/HealthService.mjs
+++ b/ai/services/knowledge-base/HealthService.mjs
@@ -1,14 +1,24 @@
-import path                     from 'path';
-import {fileURLToPath}          from 'url';
-import aiConfig                 from '../../mcp/server/knowledge-base/config.mjs';
-import Base                     from '../../../src/core/Base.mjs';
-import ChromaManager            from './ChromaManager.mjs';
-import DatabaseLifecycleService from './DatabaseLifecycleService.mjs';
-import {readDeployedRevision}   from '../shared/deployedRevision.mjs';
-import logger                   from '../../mcp/server/knowledge-base/logger.mjs';
-import RuntimeFreshnessService  from '../../mcp/server/shared/services/RuntimeFreshnessService.mjs';
+import path                       from 'path';
+import {fileURLToPath}            from 'url';
+import aiConfig                   from '../../mcp/server/knowledge-base/config.mjs';
+import embeddingConfig            from '../../mcp/server/memory-core/config.mjs';
+import Base                       from '../../../src/core/Base.mjs';
+import ChromaManager              from './ChromaManager.mjs';
+import DatabaseLifecycleService   from './DatabaseLifecycleService.mjs';
+import {createBoundedRetryGate}   from '../shared/boundedRetryGate.mjs';
+import {buildEmbeddingProbeBlock} from '../shared/embeddingProbe.mjs';
+import {readDeployedRevision}     from '../shared/deployedRevision.mjs';
+import logger                     from '../../mcp/server/knowledge-base/logger.mjs';
+import RuntimeFreshnessService    from '../../mcp/server/shared/services/RuntimeFreshnessService.mjs';
 
 const
+    embeddingProbePolicy = Object.freeze({
+        cadenceMs      : 60 * 1000,
+        timeoutMs      : 30 * 1000,
+        healthyTtlMs   : 60 * 1000,
+        failureTtlMs   : 30 * 1000,
+        failureTtlMaxMs: 10 * 60 * 1000
+    }),
     serviceDir              = path.dirname(fileURLToPath(import.meta.url)),
     configPath              = path.resolve(serviceDir, '../../config.mjs'),
     openApiPath             = path.resolve(serviceDir, '../../mcp/server/knowledge-base/openapi.yaml'),
@@ -29,6 +39,42 @@ const
         statusFields      : ['configDigest', 'openApiDigest'],
         unavailableSummary: 'config digest and OpenAPI digest'
     });
+
+/**
+ * @summary Probes the same embedding path used by Knowledge Base query and ingest operations.
+ *
+ * The consumer-owned 30-second default is deliberately explicit: it is the slow-sample tolerance
+ * boundary. Scheduling and retry backoff remain lifecycle-owned by `HealthService`.
+ *
+ * @param {Object}   [options]
+ * @param {Object}   [options.cfg=embeddingConfig] Resolved embedding provider configuration.
+ * @param {Function} [options.embedText] Injectable embedding call.
+ * @param {String}   [options.input='neo-kb-healthcheck-embedding-canary'] Probe text.
+ * @param {Function} [options.now=Date.now] Injectable clock.
+ * @param {Number}   [options.timeoutMs=30000] Consumer-owned provider deadline.
+ * @returns {Promise<Object>} Health-safe embedding observation.
+ */
+export async function buildKnowledgeBaseEmbeddingProbeBlock({
+    cfg       = embeddingConfig,
+    embedText,
+    input     = 'neo-kb-healthcheck-embedding-canary',
+    now       = Date.now,
+    timeoutMs = embeddingProbePolicy.timeoutMs
+} = {}) {
+    const probe = embedText || (async (text, explicitProvider, options) => {
+        const {default: TextEmbeddingService} = await import('../memory-core/TextEmbeddingService.mjs');
+        return TextEmbeddingService.embedText(text, explicitProvider, options);
+    });
+
+    return buildEmbeddingProbeBlock({
+        cfg,
+        embedText     : probe,
+        input,
+        now,
+        operationLabel: 'Knowledge Base embedding probe',
+        timeoutMs
+    });
+}
 
 /**
  * @summary Monitors and validates the ChromaDB dependency for the Knowledge Base MCP server.
@@ -89,6 +135,14 @@ class HealthService extends Base {
      * @private
      */
     #healthCheckPromise = null;
+
+    /**
+     * Lifecycle-owned embedding probe producer. Health reads only inspect its gate snapshot;
+     * they never schedule or execute provider work.
+     * @member {Object|null} #embeddingProbeProducer
+     * @private
+     */
+    #embeddingProbeProducer = null;
 
     /**
      * Duration (in milliseconds) for which cached HEALTHY results remain valid.
@@ -273,35 +327,236 @@ class HealthService extends Base {
     }
 
     /**
-     * Pure predicate: is the configured embedding provider ready to serve KB retrieval?
+     * @summary Projects the lifecycle producer's latest embedding observation onto health truth.
      *
-     * Knowledge Base `ask`/`query` must embed the query before retrieval, so a usable
-     * embedding provider is a hard health requirement (answer synthesis itself is
-     * degradeable — see `SearchService.ask()`). Local providers (`openAiCompatible`/
-     * `ollama`) and the `mock` test provider serve embeddings from their own host /
-     * in-process; only the remote `gemini` provider needs a `GEMINI_API_KEY`.
+     * A healthy vector is the only state that publishes `features.embedding: true`. A settled
+     * failure degrades immediately, while no observation publishes `null` and fails closed. The
+     * input payload is never mutated, which keeps cached-green database truth reusable while a
+     * later producer failure changes the outward health verdict immediately.
      *
-     * @param {String}  embeddingProvider Resolved `aiConfig.embeddingProvider`.
-     * @param {Boolean} hasGeminiKey      Whether `GEMINI_API_KEY` is set.
-     * @returns {Boolean}
+     * @param {Object} payload Database/corpus health payload under construction or from cache.
+     * @returns {Object} Health payload carrying current embedding observation truth.
+     * @private
      */
-    isEmbeddingProviderReady(embeddingProvider, hasGeminiKey) {
-        return embeddingProvider !== 'gemini' || hasGeminiKey;
+    #applyEmbeddingProbe(payload) {
+        const probe = this.#getEmbeddingProbe();
+
+        let details = (payload.details || [])
+            .filter(detail => !detail.startsWith('Knowledge Base embedding probe'));
+        let status = payload.status;
+
+        const features = {...payload.features};
+
+        if (probe.status === 'healthy') {
+            features.embedding = true;
+            return {...payload, features, details};
+        }
+
+        features.embedding = ['failed', 'terminal', 'stale'].includes(probe.status) ? false : null;
+        status             = status === 'unhealthy' ? 'unhealthy' : 'degraded';
+        details            = details.filter(detail => detail !== 'All features are operational');
+
+        if (probe.status === 'failed' || probe.status === 'terminal') {
+            if (probe.stopReason) {
+                details.push(`Knowledge Base embedding probe failed: ${probe.error} (${probe.stopReason}; deadline ${probe.timeoutMs}ms)`);
+            } else if (probe.nextAttemptAt) {
+                details.push(`Knowledge Base embedding probe failed: ${probe.error} — backing off ${probe.backoffMs}ms (streak ${probe.failureStreak}, deadline ${probe.timeoutMs}ms)`);
+            } else {
+                details.push(`Knowledge Base embedding probe failed: ${probe.error} (deadline ${probe.timeoutMs}ms)`);
+            }
+        } else if (probe.status === 'stale') {
+            details.push(`Knowledge Base embedding probe ${probe.reason}`);
+        } else {
+            details.push(`Knowledge Base embedding probe ${probe.status}: ${probe.reason}`);
+        }
+
+        return {...payload, status, features, details};
     }
 
     /**
-     * Checks whether the resolved embedding provider is ready (provider-aware).
+     * @summary Reads the embedding producer's current gate snapshot without causing provider work.
      *
-     * Reads the resolved `aiConfig.embeddingProvider` leaf (the reactive Provider SSOT) rather
-     * than probing raw env vars, so it honors the provider the deployment actually configured —
-     * including the local-by-default `openAiCompatible` — instead of falling through to a
-     * `GEMINI_API_KEY` check whenever the host env vars happen to be unset.
+     * A healthy observation becomes stale after three times the larger of cadence and healthy TTL;
+     * intentional failure backoff is not staleness. Every settled non-healthy result follows the
+     * bounded gate's single failure predicate and carries its retry receipt outward.
      *
-     * @returns {boolean}
+     * @returns {Object} Current probe truth.
      * @private
      */
-    #checkEmbeddingProviderReady() {
-        return this.isEmbeddingProviderReady(aiConfig.embeddingProvider, !!process.env.GEMINI_API_KEY);
+    #getEmbeddingProbe() {
+        const producer = this.#embeddingProbeProducer;
+
+        if (!producer) {
+            return {
+                status: 'unavailable',
+                reason: `producer not started — no embedding observation exists (configured deadline ${embeddingProbePolicy.timeoutMs}ms)`
+            };
+        }
+
+        if (producer.disabled) {
+            return {
+                status: 'disabled',
+                reason: `producer intentionally disabled — no embedding observation exists (deadline ${producer.timeoutMs}ms)`
+            };
+        }
+
+        const snapshot = producer.gate.snapshot();
+
+        if (snapshot.status === 'healthy') {
+            const staleAfter = 3 * Math.max(producer.cadenceMs, producer.healthyTtlMs),
+                  age        = producer.clock() - snapshot.cached.checkedAt;
+
+            if (age > staleAfter) {
+                return {
+                    status: 'stale',
+                    reason: `is stale: last healthy vector is ${Math.round(age / 1000)}s old (cadence ${producer.cadenceMs}ms, deadline ${producer.timeoutMs}ms)`
+                };
+            }
+
+            return {status: 'healthy'};
+        }
+
+        if (snapshot.cached) {
+            return {
+                status       : snapshot.terminal ? 'terminal' : 'failed',
+                error        : snapshot.cached.result?.error || 'unknown embedding-provider error',
+                failureStreak: snapshot.failureStreak,
+                backoffMs    : snapshot.backoffMs,
+                nextAttemptAt: snapshot.nextAttemptAt,
+                stopReason   : snapshot.stopReason,
+                timeoutMs    : producer.timeoutMs
+            };
+        }
+
+        return {
+            status: 'pending',
+            reason: `${snapshot.inFlight ? 'first run in flight' : 'no result yet'} (deadline ${producer.timeoutMs}ms)`
+        };
+    }
+
+    /**
+     * @summary Starts or re-arms the lifecycle-owned Knowledge Base embedding probe producer.
+     *
+     * Scheduling belongs here, never in `healthcheck()`. The first attempt runs immediately and is
+     * returned so server boot can await observed truth before its first public health verdict.
+     * Re-arms preserve the same bounded gate, so an in-flight attempt is joined and failure backoff
+     * survives a scheduler restart. Epoch fencing keeps queued callbacks from an older arm inert.
+     *
+     * @param {Object}   [options]
+     * @param {Number}   [options.cadenceMs=60000] Producer attempt cadence.
+     * @param {Number}   [options.timeoutMs=30000] Per-attempt provider deadline.
+     * @param {Number}   [options.healthyTtlMs=60000] Healthy-result staleness floor.
+     * @param {Number}   [options.failureTtlMs=30000] Base failure backoff.
+     * @param {Number}   [options.failureTtlMaxMs=600000] Failure-backoff ceiling.
+     * @param {Function} [options.runProbe] Injectable attempt body.
+     * @param {Function} [options.keyFor] Injectable provider-generation key.
+     * @param {Function} [options.scheduler] Injectable interval scheduler.
+     * @param {Function} [options.clearSchedule] Injectable interval clearer.
+     * @param {Function} [options.clock] Injectable time source.
+     * @returns {Promise<Object>|null} First gate-annotated observation, or `null` when disabled.
+     */
+    startEmbeddingProbe(options = {}) {
+        const {
+            cadenceMs       = embeddingProbePolicy.cadenceMs,
+            timeoutMs       = embeddingProbePolicy.timeoutMs,
+            healthyTtlMs    = embeddingProbePolicy.healthyTtlMs,
+            failureTtlMs    = embeddingProbePolicy.failureTtlMs,
+            failureTtlMaxMs = embeddingProbePolicy.failureTtlMaxMs,
+            runProbe,
+            keyFor,
+            scheduler,
+            clearSchedule,
+            clock
+        } = options;
+
+        let producer = this.#embeddingProbeProducer;
+
+        if (!(cadenceMs > 0)) {
+            if (producer) {
+                producer.disabled = true;
+                this.stopEmbeddingProbe();
+            }
+
+            return null;
+        }
+
+        const schedule   = scheduler     ?? producer?.schedule      ?? ((fn, ms) => setInterval(fn, ms)),
+              unschedule = clearSchedule ?? producer?.clearSchedule ?? (handle => clearInterval(handle));
+
+        if (producer?.timer !== null && producer?.timer !== undefined) {
+            producer.clearSchedule(producer.timer);
+            producer.timer = null;
+        }
+
+        if (!producer) {
+            producer = this.#embeddingProbeProducer = {
+                epoch: 0,
+                gate : createBoundedRetryGate({
+                    run: context => producer.runProbe(context),
+                    failureTtlMs,
+                    failureTtlMaxMs,
+                    now: () => producer.clock()
+                }),
+                schedule,
+                clearSchedule: unschedule,
+                clock        : clock ?? Date.now,
+                keyFor       : keyFor ?? (() => `${embeddingConfig.embeddingProvider}:${embeddingConfig.vectorDimension}`),
+                runProbe     : runProbe ?? (() => buildKnowledgeBaseEmbeddingProbeBlock({timeoutMs: producer.timeoutMs})),
+                disabled     : false,
+                stopped      : false,
+                timer        : null
+            };
+        } else {
+            if (clock)    producer.clock    = clock;
+            if (keyFor)   producer.keyFor   = keyFor;
+            if (runProbe) producer.runProbe = runProbe;
+
+            producer.schedule      = schedule;
+            producer.clearSchedule = unschedule;
+        }
+
+        producer.cadenceMs    = cadenceMs;
+        producer.disabled     = false;
+        producer.healthyTtlMs = healthyTtlMs;
+        producer.stopped      = false;
+        producer.timeoutMs    = timeoutMs;
+
+        const epoch = ++producer.epoch;
+
+        producer.timer = producer.schedule(() => {
+            if (producer.epoch === epoch && !producer.stopped) {
+                return producer.gate.tick({key: producer.keyFor()});
+            }
+        }, cadenceMs);
+
+        return producer.gate.tick({key: producer.keyFor()});
+    }
+
+    /**
+     * @summary Disarms the embedding probe schedule and epoch-fences queued callbacks.
+     * @returns {void}
+     */
+    stopEmbeddingProbe() {
+        const producer = this.#embeddingProbeProducer;
+
+        if (producer) {
+            producer.epoch++;
+            producer.stopped = true;
+
+            if (producer.timer !== null && producer.timer !== undefined) {
+                producer.clearSchedule(producer.timer);
+                producer.timer = null;
+            }
+        }
+    }
+
+    /**
+     * @summary Disarms and drops the embedding producer for test/restart-boundary isolation.
+     * @returns {void}
+     */
+    clearEmbeddingProbeProducer() {
+        this.stopEmbeddingProbe();
+        this.#embeddingProbeProducer = null;
     }
 
     /**
@@ -314,7 +569,7 @@ class HealthService extends Base {
      * The checks are performed in order of criticality:
      * 1. ChromaDB connectivity (if it's not running, nothing else matters)
      * 2. Collection accessibility (ensures data structures are ready)
-     * 3. Embedding provider readiness (needed for retrieval; only `gemini` needs a key)
+     * 3. The lifecycle producer's latest observed embedding result (projected by `healthcheck()`)
      *
      * Status levels:
      * - healthy: ChromaDB connected, KB corpus accessible, embedding provider ready
@@ -336,10 +591,10 @@ class HealthService extends Base {
                 }
             },
             features: {
-                embedding: false
+                embedding: null
             },
-            details         : [],
-            version         : process.env.npm_package_version || '1.0.0',
+            details: [],
+            version: process.env.npm_package_version || '1.0.0',
             // The package version answers "which release line", not "which commit". `runtimeFreshness`
             // below answers "are my tool schemas stale against MY OWN checkout" — both are blind to a
             // plane running several hundred commits behind, which is the drift that gets attributed to
@@ -369,15 +624,6 @@ class HealthService extends Base {
         if (collectionsCheck.error || !collectionsCheck.knowledgeBase?.exists) {
             payload.status = 'degraded';
             payload.details.push(collectionsCheck.error || 'The required knowledge base collection is missing');
-        }
-
-        // Step 3: Check embedding provider readiness (provider-aware; only 'gemini' needs a key)
-        const embeddingReady = this.#checkEmbeddingProviderReady();
-        payload.features.embedding = embeddingReady;
-
-        if (!embeddingReady) {
-            payload.status = 'degraded';
-            payload.details.push(`Embedding provider '${aiConfig.embeddingProvider}' requires GEMINI_API_KEY - retrieval unavailable`);
         }
 
         // If we made it here with no errors, report success
@@ -422,10 +668,10 @@ class HealthService extends Base {
             // If the cache is still fresh (< 5 minutes old), return it immediately
             if (age < this.#cacheDuration) {
                 logger.debug(`[HealthService] Using cached health status (age: ${Math.round(age / 1000)}s)`);
-                return {
+                return this.#applyEmbeddingProbe({
                     ...this.#cachedHealth,
                     runtimeFreshness: await this.resolveRuntimeFreshness()
-                };
+                });
             }
         }
 
@@ -439,10 +685,12 @@ class HealthService extends Base {
         logger.debug('[HealthService] Performing fresh health check');
 
         // Create the promise and store it
-        this.#healthCheckPromise = this.#performHealthCheck().finally(() => {
-            // Always clear the promise when done, success or fail
-            this.#healthCheckPromise = null;
-        });
+        this.#healthCheckPromise = this.#performHealthCheck()
+            .then(payload => this.#applyEmbeddingProbe(payload))
+            .finally(() => {
+                // Always clear the promise when done, success or fail
+                this.#healthCheckPromise = null;
+            });
 
         const health = await this.#healthCheckPromise;
 
@@ -483,11 +731,10 @@ class HealthService extends Base {
      * This method leverages the cached health check, so calling it frequently
      * (e.g., before each tool invocation) has minimal performance impact.
      *
-     * Note: ChromaDB and the configured embedding provider are required for retrieval, since
-     * adding/querying knowledge requires text embeddings. Only the remote 'gemini' embedding
-     * provider needs a GEMINI_API_KEY; local providers (openAiCompatible/ollama) serve embeddings
-     * from their own host. Database lifecycle is managed outside the MCP tool surface; degraded
-     * state only permits health/introspection helpers that do not touch the vector store.
+     * Note: ChromaDB and an observed-healthy embedding path are required for retrieval, since
+     * adding/querying knowledge requires text embeddings. Provider configuration alone is never
+     * treated as availability. Database lifecycle is managed outside the MCP tool surface;
+     * degraded state only permits health/introspection helpers that do not touch the vector store.
      *
      * @throws {Error} If the Knowledge Base is not fully healthy, with a detailed message
      * @returns {Promise<void>}

--- a/ai/services/memory-core/HealthService.mjs
+++ b/ai/services/memory-core/HealthService.mjs
@@ -13,8 +13,12 @@ import ChromaLifecycleService   from './lifecycle/ChromaLifecycleService.mjs';
 import logger                   from '../../mcp/server/memory-core/logger.mjs';
 import {readGateState}          from '../../scripts/lifecycle/wakeSafetyGate.mjs';
 import {createBoundedRetryGate} from '../shared/boundedRetryGate.mjs';
-import RequestContextService    from '../../mcp/server/shared/services/RequestContextService.mjs';
-import WakeSubscriptionService  from './WakeSubscriptionService.mjs';
+import {
+    buildEmbeddingProbeBlock,
+    createEmbeddingProbeTimeoutError
+}                               from '../shared/embeddingProbe.mjs';
+import RequestContextService   from '../../mcp/server/shared/services/RequestContextService.mjs';
+import WakeSubscriptionService from './WakeSubscriptionService.mjs';
 import {
     DELIVERABLE_HARNESS_TARGET,
     isServerIssuedSigningKey
@@ -185,47 +189,7 @@ export function buildEmbeddingProviderBlock(cfg) {
  * @param {Number} timeoutMs Consumer-owned deadline in milliseconds.
  * @returns {Error}
  */
-export function createEmbeddingProbeTimeoutError(operationLabel, timeoutMs) {
-    if (!Number.isFinite(timeoutMs) || timeoutMs <= 0) {
-        throw new TypeError(`Embedding probe timeoutMs must be a positive number, got ${timeoutMs}`);
-    }
-
-    const error = new Error(`${operationLabel} timed out after ${timeoutMs}ms`);
-    error.code           = 'EMBEDDING_PROBE_TIMEOUT';
-    error.operationLabel = operationLabel;
-    error.timeoutMs      = timeoutMs;
-
-    return error;
-}
-
-const EMBEDDING_PROBE_PUBLIC_REASON_MAX_LENGTH = 96;
-
-/**
- * @summary Maps provider failures to a bounded public receipt without exposing provider payloads.
- * @param {Error} error Embedding failure observed by the health consumer.
- * @returns {{error: String, errorClassification: String, errorCode: String}}
- */
-function describeEmbeddingProbeFailure(error) {
-    const knownCode = [
-        'ABORT_ERR',
-        'EMBEDDING_PROBE_TIMEOUT',
-        'OPENAI_COMPATIBLE_REQUEST_TIMEOUT',
-        'PROVIDER_TIMEOUT'
-    ].includes(error?.code) ? error.code : error?.name === 'AbortError' ? 'ABORT_ERR' : 'EMBEDDING_PROVIDER_ERROR';
-    const errorClassification = knownCode === 'EMBEDDING_PROBE_TIMEOUT'
-        ? 'consumer-probe-timeout'
-        : ['OPENAI_COMPATIBLE_REQUEST_TIMEOUT', 'PROVIDER_TIMEOUT'].includes(knownCode)
-            ? 'provider-timeout'
-            : knownCode === 'ABORT_ERR'
-                ? 'upstream-abort'
-                : 'provider-failure';
-
-    return {
-        error    : `${errorClassification}:${knownCode}`.substring(0, EMBEDDING_PROBE_PUBLIC_REASON_MAX_LENGTH),
-        errorClassification,
-        errorCode: knownCode
-    };
-}
+export {createEmbeddingProbeTimeoutError};
 
 /**
  * @summary Probes the active embedding write path used by Memory Core writes.
@@ -252,80 +216,19 @@ export async function buildEmbeddingWriteCanaryBlock({
     now       = Date.now,
     timeoutMs = aiConfig.healthcheck.embeddingWriteCanaryTimeoutMs
 } = {}) {
-    const readNow            = typeof now === 'function' ? now : () => (typeof now === 'number' ? now : now.getTime()),
-          startedAt          = readNow(),
-          provider           = cfg.embeddingProvider || 'openAiCompatible',
-          expectedDimensions = cfg.vectorDimension ?? null,
-          operationLabel     = 'Embedding write canary';
+    const probe = embedText || (async (text, explicitProvider, options) => {
+        const {default: TextEmbeddingService} = await import('./TextEmbeddingService.mjs');
+        return TextEmbeddingService.embedText(text, explicitProvider, options);
+    });
 
-    let timeoutId;
-
-    try {
-        const probe = embedText || (async (text, explicitProvider, options) => {
-            const {default: TextEmbeddingService} = await import('./TextEmbeddingService.mjs');
-            return TextEmbeddingService.embedText(text, explicitProvider, options);
-        });
-        const controller    = new AbortController(),
-              timeoutError  = createEmbeddingProbeTimeoutError(operationLabel, timeoutMs),
-              deadline      = new Promise((_, reject) => {
-                  timeoutId = setTimeout(() => {
-                      reject(timeoutError);
-                      controller.abort(timeoutError);
-                  }, timeoutMs);
-              }),
-              embedding    = await Promise.race([
-                  Promise.resolve(probe(input, provider, {
-                      signal: controller.signal,
-                      operationLabel
-                  })),
-                  deadline
-              ]),
-              dimensions = Array.isArray(embedding) ? embedding.length : null,
-              durationMs = Math.max(0, readNow() - startedAt);
-
-        if (!Array.isArray(embedding) || embedding.length === 0) {
-            return {
-                status: 'failed',
-                provider,
-                dimensions,
-                expectedDimensions,
-                durationMs,
-                error : 'Embedding write canary returned no vector.'
-            };
-        }
-
-        if (expectedDimensions && dimensions !== expectedDimensions) {
-            return {
-                status: 'failed',
-                provider,
-                dimensions,
-                expectedDimensions,
-                durationMs,
-                error : `Embedding write canary returned ${dimensions} dimensions; expected ${expectedDimensions}.`
-            };
-        }
-
-        return {
-            status: 'healthy',
-            provider,
-            dimensions,
-            expectedDimensions,
-            durationMs
-        };
-    } catch (error) {
-        const failure = describeEmbeddingProbeFailure(error);
-
-        return {
-            status    : 'failed',
-            provider,
-            dimensions: null,
-            expectedDimensions,
-            durationMs: Math.max(0, readNow() - startedAt),
-            ...failure
-        };
-    } finally {
-        clearTimeout(timeoutId);
-    }
+    return buildEmbeddingProbeBlock({
+        cfg,
+        embedText     : probe,
+        input,
+        now,
+        operationLabel: 'Embedding write canary',
+        timeoutMs
+    });
 }
 
 /**
@@ -2052,7 +1955,7 @@ class HealthService extends Base {
             // emitted, `unknown` when no build wrote a revision, because an omitted field reads as
             // current to a consumer computing deployment skew.
             deployedRevision: readDeployedRevision(),
-            uptime : process.uptime()
+            uptime          : process.uptime()
         };
 
         // Step 1: Check Database connectivity

--- a/ai/services/shared/embeddingProbe.mjs
+++ b/ai/services/shared/embeddingProbe.mjs
@@ -1,0 +1,163 @@
+/**
+ * @module ai/services/shared/embeddingProbe
+ * @summary Consumer-agnostic embedding probe with a caller-owned deadline and bounded public
+ * failure receipts. Service-specific health producers own scheduling, retry policy, and config.
+ */
+
+const EMBEDDING_PROBE_PUBLIC_REASON_MAX_LENGTH = 96;
+
+/**
+ * @summary Creates the structural caller-owned deadline error shared by embedding-probe consumers.
+ * @param {String} operationLabel Bounded diagnostic label.
+ * @param {Number} timeoutMs Consumer-owned deadline in milliseconds.
+ * @returns {Error}
+ */
+export function createEmbeddingProbeTimeoutError(operationLabel, timeoutMs) {
+    if (!Number.isFinite(timeoutMs) || timeoutMs <= 0) {
+        throw new TypeError(`Embedding probe timeoutMs must be a positive number, got ${timeoutMs}`);
+    }
+
+    const error = new Error(`${operationLabel} timed out after ${timeoutMs}ms`);
+    error.code           = 'EMBEDDING_PROBE_TIMEOUT';
+    error.operationLabel = operationLabel;
+    error.timeoutMs      = timeoutMs;
+
+    return error;
+}
+
+/**
+ * @summary Maps provider failures to a bounded public receipt without exposing provider payloads.
+ * @param {Error} error Embedding failure observed by the health consumer.
+ * @returns {{error: String, errorClassification: String, errorCode: String}}
+ */
+export function describeEmbeddingProbeFailure(error) {
+    const knownCode = [
+        'ABORT_ERR',
+        'EMBEDDING_PROBE_TIMEOUT',
+        'OPENAI_COMPATIBLE_REQUEST_TIMEOUT',
+        'PROVIDER_TIMEOUT'
+    ].includes(error?.code) ? error.code : error?.name === 'AbortError' ? 'ABORT_ERR' : 'EMBEDDING_PROVIDER_ERROR';
+    const errorClassification = knownCode === 'EMBEDDING_PROBE_TIMEOUT'
+        ? 'consumer-probe-timeout'
+        : ['OPENAI_COMPATIBLE_REQUEST_TIMEOUT', 'PROVIDER_TIMEOUT'].includes(knownCode)
+            ? 'provider-timeout'
+            : knownCode === 'ABORT_ERR'
+                ? 'upstream-abort'
+                : 'provider-failure';
+
+    return {
+        error    : `${errorClassification}:${knownCode}`.substring(0, EMBEDDING_PROBE_PUBLIC_REASON_MAX_LENGTH),
+        errorClassification,
+        errorCode: knownCode
+    };
+}
+
+/**
+ * @summary Probes one explicitly supplied embedding path and returns a health-safe result block.
+ *
+ * This module owns only the attempt boundary: deadline, abort propagation, dimension validation,
+ * and bounded failure classification. Consumers own provider/config selection, scheduling,
+ * backoff, and the policy that maps observations into their public health envelope.
+ *
+ * @param {Object} options
+ * @param {Object} options.cfg Provider config carrying `embeddingProvider` and `vectorDimension`.
+ * @param {Function} options.embedText Explicit embedding call seam.
+ * @param {String} options.input Probe text.
+ * @param {String} options.operationLabel Bounded diagnostic label.
+ * @param {Function} [options.now=Date.now] Time source for deterministic tests.
+ * @param {Number} options.timeoutMs Max time to wait for the provider.
+ * @returns {Promise<{status: String, provider: String, dimensions: Number|null,
+ *     expectedDimensions: Number|null, durationMs: Number, error: String|undefined,
+ *     errorClassification: String|undefined, errorCode: String|undefined}>}
+ */
+export async function buildEmbeddingProbeBlock({
+    cfg,
+    embedText,
+    input,
+    operationLabel,
+    now = Date.now,
+    timeoutMs
+} = {}) {
+    if (!cfg || typeof cfg !== 'object') {
+        throw new TypeError('buildEmbeddingProbeBlock: cfg is required');
+    }
+    if (typeof embedText !== 'function') {
+        throw new TypeError('buildEmbeddingProbeBlock: embedText is required');
+    }
+    if (typeof input !== 'string' || input.length === 0) {
+        throw new TypeError('buildEmbeddingProbeBlock: input is required');
+    }
+    if (typeof operationLabel !== 'string' || operationLabel.length === 0) {
+        throw new TypeError('buildEmbeddingProbeBlock: operationLabel is required');
+    }
+
+    const readNow            = typeof now === 'function' ? now : () => (typeof now === 'number' ? now : now.getTime()),
+          startedAt          = readNow(),
+          provider           = cfg.embeddingProvider || 'openAiCompatible',
+          expectedDimensions = cfg.vectorDimension ?? null;
+
+    let timeoutId;
+
+    try {
+        const controller    = new AbortController(),
+              timeoutError  = createEmbeddingProbeTimeoutError(operationLabel, timeoutMs),
+              deadline      = new Promise((_, reject) => {
+                  timeoutId = setTimeout(() => {
+                      reject(timeoutError);
+                      controller.abort(timeoutError);
+                  }, timeoutMs);
+              }),
+              embedding    = await Promise.race([
+                  Promise.resolve(embedText(input, provider, {
+                      signal: controller.signal,
+                      operationLabel
+                  })),
+                  deadline
+              ]),
+              dimensions = Array.isArray(embedding) ? embedding.length : null,
+              durationMs = Math.max(0, readNow() - startedAt);
+
+        if (!Array.isArray(embedding) || embedding.length === 0) {
+            return {
+                status: 'failed',
+                provider,
+                dimensions,
+                expectedDimensions,
+                durationMs,
+                error : `${operationLabel} returned no vector.`
+            };
+        }
+
+        if (expectedDimensions && dimensions !== expectedDimensions) {
+            return {
+                status: 'failed',
+                provider,
+                dimensions,
+                expectedDimensions,
+                durationMs,
+                error : `${operationLabel} returned ${dimensions} dimensions; expected ${expectedDimensions}.`
+            };
+        }
+
+        return {
+            status: 'healthy',
+            provider,
+            dimensions,
+            expectedDimensions,
+            durationMs
+        };
+    } catch (error) {
+        const failure = describeEmbeddingProbeFailure(error);
+
+        return {
+            status    : 'failed',
+            provider,
+            dimensions: null,
+            expectedDimensions,
+            durationMs: Math.max(0, readNow() - startedAt),
+            ...failure
+        };
+    } finally {
+        clearTimeout(timeoutId);
+    }
+}

--- a/ai/services/shared/embeddingProbe.mjs
+++ b/ai/services/shared/embeddingProbe.mjs
@@ -7,6 +7,25 @@
 const EMBEDDING_PROBE_PUBLIC_REASON_MAX_LENGTH = 96;
 
 /**
+ * @summary Closed provider-code vocabulary admitted onto public embedding-health receipts.
+ *
+ * This is deliberately distinct from Knowledge Base's durable `KB_*` failure-code translator:
+ * this attempt boundary preserves only bounded operational meaning for a health response, while the
+ * durable translator mints provenance-safe codes for tenant-repo checkpoints. Keeping the two
+ * vocabularies separate prevents a health helper from importing a Knowledge Base persistence policy;
+ * listing every admitted provider code here prevents a third, implicit classifier from emerging.
+ * @type {Object}
+ */
+const EMBEDDING_PROBE_FAILURE_CLASSIFICATIONS = Object.freeze({
+    ABORT_ERR                        : 'upstream-abort',
+    ECONNREFUSED                     : 'provider-unreachable',
+    EMBEDDING_MODEL_NOT_RESIDENT     : 'model-not-resident',
+    EMBEDDING_PROBE_TIMEOUT          : 'consumer-probe-timeout',
+    OPENAI_COMPATIBLE_REQUEST_TIMEOUT: 'provider-timeout',
+    PROVIDER_TIMEOUT                 : 'provider-timeout'
+});
+
+/**
  * @summary Creates the structural caller-owned deadline error shared by embedding-probe consumers.
  * @param {String} operationLabel Bounded diagnostic label.
  * @param {Number} timeoutMs Consumer-owned deadline in milliseconds.
@@ -31,19 +50,11 @@ export function createEmbeddingProbeTimeoutError(operationLabel, timeoutMs) {
  * @returns {{error: String, errorClassification: String, errorCode: String}}
  */
 export function describeEmbeddingProbeFailure(error) {
-    const knownCode = [
-        'ABORT_ERR',
-        'EMBEDDING_PROBE_TIMEOUT',
-        'OPENAI_COMPATIBLE_REQUEST_TIMEOUT',
-        'PROVIDER_TIMEOUT'
-    ].includes(error?.code) ? error.code : error?.name === 'AbortError' ? 'ABORT_ERR' : 'EMBEDDING_PROVIDER_ERROR';
-    const errorClassification = knownCode === 'EMBEDDING_PROBE_TIMEOUT'
-        ? 'consumer-probe-timeout'
-        : ['OPENAI_COMPATIBLE_REQUEST_TIMEOUT', 'PROVIDER_TIMEOUT'].includes(knownCode)
-            ? 'provider-timeout'
-            : knownCode === 'ABORT_ERR'
-                ? 'upstream-abort'
-                : 'provider-failure';
+    const candidateCode = error?.name === 'AbortError' ? 'ABORT_ERR' : error?.code,
+          knownCode     = Object.hasOwn(EMBEDDING_PROBE_FAILURE_CLASSIFICATIONS, candidateCode)
+              ? candidateCode
+              : 'EMBEDDING_PROVIDER_ERROR',
+          errorClassification = EMBEDDING_PROBE_FAILURE_CLASSIFICATIONS[knownCode] || 'provider-failure';
 
     return {
         error    : `${errorClassification}:${knownCode}`.substring(0, EMBEDDING_PROBE_PUBLIC_REASON_MAX_LENGTH),

--- a/test/playwright/unit/ai/mcp/server/knowledge-base/Server.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/knowledge-base/Server.spec.mjs
@@ -19,7 +19,7 @@ import * as core      from '../../../../../../../src/core/_export.mjs';
 import '../../../../../../../src/manager/Instance.mjs';
 
 test.describe('Neo.ai.mcp.server.knowledge-base.Server', () => {
-    let Server;
+    let Server, HealthService;
 
     /**
      * @summary Creates a Server instance whose async boot is suppressed and fully settled.
@@ -59,7 +59,46 @@ test.describe('Neo.ai.mcp.server.knowledge-base.Server', () => {
     }
 
     test.beforeAll(async () => {
-        Server = (await import('../../../../../../../ai/mcp/server/knowledge-base/Server.mjs')).default;
+        Server        = (await import('../../../../../../../ai/mcp/server/knowledge-base/Server.mjs')).default;
+        HealthService = (await import('../../../../../../../ai/services/knowledge-base/HealthService.mjs')).default;
+    });
+
+    test('#16691: startup awaits the first bounded embedding observation before healthcheck', async () => {
+        const serverInstance      = await createServerWithoutBoot(),
+              originalStart       = HealthService.startEmbeddingProbe,
+              originalStop        = HealthService.stopEmbeddingProbe,
+              exitListenersBefore = new Set(process.listeners('exit'));
+
+        let releaseObservation;
+        let startupSettled = false;
+
+        HealthService.startEmbeddingProbe = () => new Promise(resolve => {
+            releaseObservation = resolve;
+        });
+        HealthService.stopEmbeddingProbe = () => {};
+
+        try {
+            const startup = serverInstance.beforeHealthcheck().then(() => {
+                startupSettled = true;
+            });
+
+            await Promise.resolve();
+            expect(startupSettled).toBe(false);
+
+            releaseObservation({status: 'healthy'});
+            await startup;
+
+            expect(startupSettled).toBe(true);
+        } finally {
+            HealthService.startEmbeddingProbe = originalStart;
+            HealthService.stopEmbeddingProbe  = originalStop;
+
+            process.listeners('exit')
+                .filter(listener => !exitListenersBefore.has(listener))
+                .forEach(listener => process.removeListener('exit', listener));
+
+            serverInstance.destroy();
+        }
     });
 
     test('#15886: the plane-identity assertion names its ORIGIN server, not the shared class name', async () => {

--- a/test/playwright/unit/ai/services/knowledge-base/HealthService.providerReady.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/HealthService.providerReady.spec.mjs
@@ -205,6 +205,55 @@ test.describe('Neo.ai.services.knowledge-base.HealthService observed embedding r
         });
     });
 
+    test('public health separates a probe that could not run from a provider that did not answer', async () => {
+        const common = {
+            cadenceMs      : 1000,
+            timeoutMs      : 5,
+            failureTtlMs   : 1000,
+            failureTtlMaxMs: 1000,
+            scheduler      : () => 0,
+            clearSchedule  : () => {},
+            keyFor         : () => 'test-provider:3'
+        };
+
+        await HealthService.startEmbeddingProbe({
+            ...common,
+            runProbe: () => buildKnowledgeBaseEmbeddingProbeBlock({
+                cfg: {
+                    embeddingProvider: 'test-provider',
+                    vectorDimension  : 3
+                },
+                embedText: () => new Promise(() => {}),
+                timeoutMs: 5
+            })
+        });
+
+        const didNotAnswer        = await HealthService.healthcheck(),
+              didNotAnswerDetails = didNotAnswer.details.join(' ');
+
+        expect(didNotAnswer.status).toBe('degraded');
+        expect(didNotAnswer.features.embedding).toBe(false);
+        expect(didNotAnswerDetails).toContain('consumer-probe-timeout:EMBEDDING_PROBE_TIMEOUT');
+
+        HealthService.clearEmbeddingProbeProducer();
+        HealthService.clearCache();
+
+        await HealthService.startEmbeddingProbe({
+            ...common,
+            runProbe: async () => {
+                throw new Error('fixture probe body cannot execute');
+            }
+        });
+
+        const couldNotRun        = await HealthService.healthcheck(),
+              couldNotRunDetails = couldNotRun.details.join(' ');
+
+        expect(couldNotRun.status).toBe('degraded');
+        expect(couldNotRun.features.embedding).toBe(false);
+        expect(couldNotRunDetails).toContain('probe-could-not-run:EMBEDDING_PROBE_EXECUTION_ERROR');
+        expect(couldNotRunDetails).not.toBe(didNotAnswerDetails);
+    });
+
     test('scheduled demand inside failure backoff reuses truth instead of probing again', async () => {
         let now       = 1000;
         let probeRuns = 0;

--- a/test/playwright/unit/ai/services/knowledge-base/HealthService.providerReady.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/HealthService.providerReady.spec.mjs
@@ -33,86 +33,219 @@ function createFileDigest(filePath) {
     return `sha256:${createHash('sha256').update(contents).digest('hex')}`;
 }
 
-test.describe('Neo.ai.services.knowledge-base.HealthService provider-aware readiness (#12741)', () => {
-    let HealthService, ChromaManager, DatabaseLifecycleService, aiConfig;
+async function startHealthyEmbeddingProbe(HealthService, overrides = {}) {
+    return HealthService.startEmbeddingProbe({
+        cadenceMs    : 1000,
+        scheduler    : () => 0,
+        clearSchedule: () => {},
+        keyFor       : () => 'test-provider:3',
+        runProbe     : async () => ({
+            status            : 'healthy',
+            provider          : 'test-provider',
+            dimensions        : 3,
+            expectedDimensions: 3,
+            durationMs        : 1
+        }),
+        ...overrides
+    });
+}
+
+test.describe('Neo.ai.services.knowledge-base.HealthService observed embedding readiness (#16691)', () => {
+    let HealthService, ChromaManager, DatabaseLifecycleService, buildKnowledgeBaseEmbeddingProbeBlock;
+    let originalClient, originalGetCollection, originalGetDbStatus;
 
     test.beforeAll(async () => {
-        HealthService            = (await import('../../../../../../ai/services/knowledge-base/HealthService.mjs')).default;
-        ChromaManager            = (await import('../../../../../../ai/services/knowledge-base/ChromaManager.mjs')).default;
-        DatabaseLifecycleService = (await import('../../../../../../ai/services/knowledge-base/DatabaseLifecycleService.mjs')).default;
-        aiConfig                 = (await import('../../../../../../ai/mcp/server/knowledge-base/config.template.mjs')).default;
+        const healthModule = await import('../../../../../../ai/services/knowledge-base/HealthService.mjs');
+
+        HealthService                            = healthModule.default;
+        buildKnowledgeBaseEmbeddingProbeBlock    = healthModule.buildKnowledgeBaseEmbeddingProbeBlock;
+        ChromaManager                            = (await import('../../../../../../ai/services/knowledge-base/ChromaManager.mjs')).default;
+        DatabaseLifecycleService                 = (await import('../../../../../../ai/services/knowledge-base/DatabaseLifecycleService.mjs')).default;
     });
 
-    // ---------------------------------------------------------------------------
-    // Pure predicate: the readiness decision for every provider / key combination.
-    // Local + mock providers serve embeddings from their own host; only the remote
-    // `gemini` provider needs a GEMINI_API_KEY.
-    // ---------------------------------------------------------------------------
-    test('isEmbeddingProviderReady: local + mock providers are ready without a Gemini key', () => {
-        expect(HealthService.isEmbeddingProviderReady('openAiCompatible', false)).toBe(true);
-        expect(HealthService.isEmbeddingProviderReady('ollama',           false)).toBe(true);
-        expect(HealthService.isEmbeddingProviderReady('mock',             false)).toBe(true);
+    test.beforeEach(() => {
+        originalClient        = ChromaManager.client;
+        originalGetCollection = ChromaManager.getKnowledgeBaseCollection;
+        originalGetDbStatus   = DatabaseLifecycleService.getDatabaseStatus;
+
+        ChromaManager.client                       = {heartbeat: async () => ({})};
+        ChromaManager.getKnowledgeBaseCollection   = async () => ({count: async () => 1});
+        DatabaseLifecycleService.getDatabaseStatus = () => ({status: 'mocked'});
+
+        HealthService.clearEmbeddingProbeProducer();
+        HealthService.clearCache();
     });
 
-    test('isEmbeddingProviderReady: only the remote gemini provider requires a key', () => {
-        expect(HealthService.isEmbeddingProviderReady('gemini', false)).toBe(false);
-        expect(HealthService.isEmbeddingProviderReady('gemini', true)).toBe(true);
+    test.afterEach(() => {
+        ChromaManager.client                       = originalClient;
+        ChromaManager.getKnowledgeBaseCollection   = originalGetCollection;
+        DatabaseLifecycleService.getDatabaseStatus = originalGetDbStatus;
+
+        HealthService.clearEmbeddingProbeProducer();
+        HealthService.clearCache();
     });
 
-    // ---------------------------------------------------------------------------
-    // Gate-level proof: with ChromaDB healthy and NO GEMINI_API_KEY, a local-provider
-    // deployment must NOT have ask_knowledge_base rejected by the health gate.
-    // (CI default: aiConfig.embeddingProvider === 'openAiCompatible' — local.)
-    // ---------------------------------------------------------------------------
-    test.describe('ensureHealthy with ChromaDB healthy + no GEMINI_API_KEY', () => {
-        let originalClient, originalGetCollection, originalGetDbStatus, originalGeminiKey;
+    test('fails closed with a named null observation before the lifecycle producer starts', async () => {
+        const health = await HealthService.healthcheck();
 
-        test.beforeEach(() => {
-            originalClient        = ChromaManager.client;
-            originalGetCollection = ChromaManager.getKnowledgeBaseCollection;
-            originalGetDbStatus   = DatabaseLifecycleService.getDatabaseStatus;
-            originalGeminiKey     = process.env.GEMINI_API_KEY;
+        expect(health.status).toBe('degraded');
+        expect(health.features.embedding).toBeNull();
+        expect(health.details.join(' ')).toContain('Knowledge Base embedding probe unavailable');
+        expect(health.details.join(' ')).toContain('no embedding observation exists');
+        expect(health.details).not.toContain('All features are operational');
+        await expect(HealthService.ensureHealthy()).rejects.toThrow('Knowledge Base is not fully operational');
+    });
 
-            ChromaManager.client                     = {heartbeat: async () => ({})};
-            ChromaManager.getKnowledgeBaseCollection = async () => ({count: async () => 1});
-            DatabaseLifecycleService.getDatabaseStatus = () => ({status: 'mocked'});
-            delete process.env.GEMINI_API_KEY;
+    test('publishes healthy only after a real vector observation and health reads stay pure', async () => {
+        let probeRuns = 0;
 
-            HealthService.clearCache();
-        });
-
-        test.afterEach(() => {
-            ChromaManager.client                       = originalClient;
-            ChromaManager.getKnowledgeBaseCollection   = originalGetCollection;
-            DatabaseLifecycleService.getDatabaseStatus = originalGetDbStatus;
-
-            if (originalGeminiKey === undefined) {
-                delete process.env.GEMINI_API_KEY;
-            } else {
-                process.env.GEMINI_API_KEY = originalGeminiKey;
+        await startHealthyEmbeddingProbe(HealthService, {
+            runProbe: async () => {
+                probeRuns++;
+                return {
+                    status            : 'healthy',
+                    provider          : 'test-provider',
+                    dimensions        : 3,
+                    expectedDimensions: 3,
+                    durationMs        : 1
+                };
             }
-
-            HealthService.clearCache();
         });
 
-        test('local embedding provider reports healthy and ensureHealthy() resolves without a key', async () => {
-            // Precondition: the resolved default provider is local (not gemini).
-            expect(aiConfig.embeddingProvider).not.toBe('gemini');
+        const health = await HealthService.healthcheck();
 
-            const health = await HealthService.healthcheck();
+        expect(health.status).toBe('healthy');
+        expect(health.features.embedding).toBe(true);
+        expect(health.details).toContain('All features are operational');
+        await expect(HealthService.ensureHealthy()).resolves.toBeUndefined();
+        await HealthService.healthcheck();
+        expect(probeRuns).toBe(1);
+    });
 
-            expect(health.features.embedding).toBe(true);
-            expect(health.status).toBe('healthy');
-
-            // The gate must not throw — local-provider ask is allowed with no GEMINI_API_KEY.
-            await expect(HealthService.ensureHealthy()).resolves.toBeUndefined();
+    test('the first settled timeout degrades immediately and closes ensureHealthy()', async () => {
+        await HealthService.startEmbeddingProbe({
+            cadenceMs      : 1000,
+            failureTtlMs   : 1000,
+            failureTtlMaxMs: 1000,
+            scheduler      : () => 0,
+            clearSchedule  : () => {},
+            keyFor         : () => 'test-provider:3',
+            runProbe       : async () => ({
+                status             : 'failed',
+                error              : 'consumer-probe-timeout:EMBEDDING_PROBE_TIMEOUT',
+                errorClassification: 'consumer-probe-timeout',
+                errorCode          : 'EMBEDDING_PROBE_TIMEOUT'
+            })
         });
+
+        const health = await HealthService.healthcheck();
+
+        expect(health.status).toBe('degraded');
+        expect(health.features.embedding).toBe(false);
+        expect(health.details.join(' ')).toContain('consumer-probe-timeout:EMBEDDING_PROBE_TIMEOUT');
+        expect(health.details.join(' ')).toContain('streak 1');
+        expect(health.details.join(' ')).toContain('deadline 30000ms');
+        await expect(HealthService.ensureHealthy()).rejects.toThrow('Knowledge Base embedding probe failed');
+    });
+
+    test('a cached-green database payload degrades immediately when the producer later fails', async () => {
+        let fail = false;
+        let scheduledTick;
+
+        await HealthService.startEmbeddingProbe({
+            cadenceMs   : 1000,
+            failureTtlMs: 1000,
+            scheduler   : callback => {
+                scheduledTick = callback;
+                return 0;
+            },
+            clearSchedule: () => {},
+            keyFor       : () => 'test-provider:3',
+            runProbe     : async () => fail ? {
+                status: 'failed',
+                error : 'provider-failure:EMBEDDING_PROVIDER_ERROR'
+            } : {
+                status            : 'healthy',
+                provider          : 'test-provider',
+                dimensions        : 3,
+                expectedDimensions: 3,
+                durationMs        : 1
+            }
+        });
+
+        const cachedGreen = await HealthService.healthcheck();
+        expect(cachedGreen.status).toBe('healthy');
+
+        fail = true;
+        await scheduledTick();
+
+        const degraded = await HealthService.healthcheck();
+        expect(degraded.status).toBe('degraded');
+        expect(degraded.features.embedding).toBe(false);
+        expect(degraded.details).not.toContain('All features are operational');
+        expect(degraded.details.join(' ')).toContain('provider-failure:EMBEDDING_PROVIDER_ERROR');
+    });
+
+    test('a reachable provider that never answers is bounded by the named consumer deadline', async () => {
+        const result = await buildKnowledgeBaseEmbeddingProbeBlock({
+            cfg: {
+                embeddingProvider: 'test-provider',
+                vectorDimension  : 3
+            },
+            embedText: () => new Promise(() => {}),
+            timeoutMs: 5
+        });
+
+        expect(result).toMatchObject({
+            status             : 'failed',
+            provider           : 'test-provider',
+            error              : 'consumer-probe-timeout:EMBEDDING_PROBE_TIMEOUT',
+            errorClassification: 'consumer-probe-timeout',
+            errorCode          : 'EMBEDDING_PROBE_TIMEOUT'
+        });
+    });
+
+    test('scheduled demand inside failure backoff reuses truth instead of probing again', async () => {
+        let now       = 1000;
+        let probeRuns = 0;
+        let scheduledTick;
+
+        await HealthService.startEmbeddingProbe({
+            cadenceMs      : 100,
+            failureTtlMs   : 1000,
+            failureTtlMaxMs: 1000,
+            clock          : () => now,
+            scheduler      : callback => {
+                scheduledTick = callback;
+                return 0;
+            },
+            clearSchedule: () => {},
+            keyFor       : () => 'test-provider:3',
+            runProbe     : async () => {
+                probeRuns++;
+                return {
+                    status: 'failed',
+                    error : 'provider-failure:EMBEDDING_PROVIDER_ERROR'
+                };
+            }
+        });
+
+        expect(probeRuns).toBe(1);
+
+        HealthService.clearCache();
+        now += 999;
+        await scheduledTick();
+        expect(probeRuns).toBe(1);
+
+        now += 2;
+        await scheduledTick();
+        expect(probeRuns).toBe(2);
     });
 });
 
 test.describe('Neo.ai.services.knowledge-base.HealthService stale collection handle recovery (#13464)', () => {
     let HealthService, ChromaManager, DatabaseLifecycleService;
-    let originalClient, originalGetCollection, originalGetDbStatus, originalGeminiKey, originalInvalidateCache;
+    let originalClient, originalGetCollection, originalGetDbStatus, originalInvalidateCache;
 
     const createNotFoundError = () => {
         const error = new Error('The requested resource could not be found');
@@ -126,18 +259,18 @@ test.describe('Neo.ai.services.knowledge-base.HealthService stale collection han
         DatabaseLifecycleService = (await import('../../../../../../ai/services/knowledge-base/DatabaseLifecycleService.mjs')).default;
     });
 
-    test.beforeEach(() => {
+    test.beforeEach(async () => {
         originalClient          = ChromaManager.client;
         originalGetCollection   = ChromaManager.getKnowledgeBaseCollection;
         originalGetDbStatus     = DatabaseLifecycleService.getDatabaseStatus;
-        originalGeminiKey       = process.env.GEMINI_API_KEY;
         originalInvalidateCache = ChromaManager.invalidateKnowledgeBaseCollectionCache;
 
         ChromaManager.client = {heartbeat: async () => ({})};
         DatabaseLifecycleService.getDatabaseStatus = () => ({running: false});
-        delete process.env.GEMINI_API_KEY;
 
+        HealthService.clearEmbeddingProbeProducer();
         HealthService.clearCache();
+        await startHealthyEmbeddingProbe(HealthService);
     });
 
     test.afterEach(() => {
@@ -146,12 +279,7 @@ test.describe('Neo.ai.services.knowledge-base.HealthService stale collection han
         ChromaManager.invalidateKnowledgeBaseCollectionCache = originalInvalidateCache;
         DatabaseLifecycleService.getDatabaseStatus   = originalGetDbStatus;
 
-        if (originalGeminiKey === undefined) {
-            delete process.env.GEMINI_API_KEY;
-        } else {
-            process.env.GEMINI_API_KEY = originalGeminiKey;
-        }
-
+        HealthService.clearEmbeddingProbeProducer();
         HealthService.clearCache();
     });
 
@@ -242,6 +370,7 @@ test.describe.serial('Neo.ai.services.knowledge-base.HealthService runtimeFreshn
         HealthService.runtimeFreshnessCacheDuration = 30 * 1000;
         HealthService.bootRuntimeIdentity        = bootRuntimeIdentity;
         HealthService.bootRuntimeFreshnessErrors = bootRuntimeFreshnessErrors;
+        HealthService.clearEmbeddingProbeProducer();
         HealthService.clearCache();
     });
 
@@ -383,6 +512,7 @@ test.describe.serial('Neo.ai.services.knowledge-base.HealthService runtimeFreshn
             ChromaManager.client                       = {heartbeat: async () => ({})};
             ChromaManager.getKnowledgeBaseCollection   = async () => ({count: async () => 1});
             DatabaseLifecycleService.getDatabaseStatus = () => ({status: 'mocked'});
+            await startHealthyEmbeddingProbe(HealthService);
 
             HealthService.runtimeFreshnessReader = async () => {
                 readCount++;

--- a/test/playwright/unit/ai/services/knowledge-base/HealthService.providerReady.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/HealthService.providerReady.spec.mjs
@@ -205,6 +205,39 @@ test.describe('Neo.ai.services.knowledge-base.HealthService observed embedding r
         });
     });
 
+    test('public receipts distinguish transport refusal and a non-resident embedding model', async () => {
+        const probeFailure = async code => buildKnowledgeBaseEmbeddingProbeBlock({
+            cfg: {
+                embeddingProvider: 'test-provider',
+                vectorDimension  : 3
+            },
+            embedText: async () => {
+                const error = new Error('provider-controlled detail must not cross the health boundary');
+
+                error.code = code;
+                throw error;
+            },
+            timeoutMs: 5
+        });
+
+        const [connectionRefused, modelNotResident] = await Promise.all([
+            probeFailure('ECONNREFUSED'),
+            probeFailure('EMBEDDING_MODEL_NOT_RESIDENT')
+        ]);
+
+        expect(connectionRefused).toMatchObject({
+            error              : 'provider-unreachable:ECONNREFUSED',
+            errorClassification: 'provider-unreachable',
+            errorCode          : 'ECONNREFUSED'
+        });
+        expect(modelNotResident).toMatchObject({
+            error              : 'model-not-resident:EMBEDDING_MODEL_NOT_RESIDENT',
+            errorClassification: 'model-not-resident',
+            errorCode          : 'EMBEDDING_MODEL_NOT_RESIDENT'
+        });
+        expect(JSON.stringify({connectionRefused, modelNotResident})).not.toContain('provider-controlled detail');
+    });
+
     test('public health separates a probe that could not run from a provider that did not answer', async () => {
         const common = {
             cadenceMs      : 1000,


### PR DESCRIPTION
Authored by GPT-5 (Codex Desktop). Origin Session ID: abdf06f7-5c90-4124-ad28-f0e2897214ee.

Resolves #16691

## Context

Knowledge Base health currently publishes `features.embedding: true` for every non-Gemini provider from configuration alone. A reachable provider can therefore accept a request, never answer, and leave both `healthcheck()` and `ensureHealthy()` reporting operational while retrieval hangs.

This patch makes embedding readiness an observation. The KB server owns a bounded producer, awaits its first observation before startup health, and lets health reads consume only a pure gate snapshot.

## Changes

- Extract the existing Memory Core embedding-attempt boundary into `ai/services/shared/embeddingProbe.mjs`: caller-owned deadline, abort propagation, vector/dimension validation, and bounded public failure classification.
- Probe through `TextEmbeddingService` using the Knowledge Base service's resolved embedding leaves at the use site, preserving the reactive Provider SSOT and service ownership boundary.
- Add a lifecycle-owned KB producer around `boundedRetryGate`: 60s cadence, explicit 30s deadline, 30s→10m failure backoff, single-flight continuity, epoch-fenced stop/re-arm, and healthy-result staleness detection.
- Await the first bounded observation in `Server.beforeHealthcheck()`; a provider that never answers can delay boot for at most the named 30s consumer deadline.
- Project `features.embedding` as `true` only after a healthy vector, `false` after a settled failure/staleness, and `null` before observation. Any non-healthy observation fails closed through `ensureHealthy()`.
- Preserve cached-green database truth while overlaying the live producer snapshot, so a later first failure degrades immediately without an embedding call from the health read.
- Distinguish an attempt body that could not execute (`probe-could-not-run:EMBEDDING_PROBE_EXECUTION_ERROR`) from a provider that did not answer (`consumer-probe-timeout:EMBEDDING_PROBE_TIMEOUT`) before the cadence gate annotates backoff.
- Preserve two additional bounded provider diagnoses: transport refusal (`provider-unreachable:ECONNREFUSED`) and a configured embedding model that is not resident (`model-not-resident:EMBEDDING_MODEL_NOT_RESIDENT`). Provider-controlled messages never cross the health boundary.
- Declare the nullable three-state feature contract in the KB OpenAPI schema.

## Deltas from Ticket

None. The implementation follows the corrected ticket contract: first observed failure degrades; slow-sample tolerance belongs to the explicit probe deadline rather than a multi-sample threshold; and could-not-run remains payload-separable from did-not-answer.

## Test Evidence

Evidence:

- `129/129` passed across:
  - `test/playwright/unit/ai/services/knowledge-base/HealthService.providerReady.spec.mjs`
  - `test/playwright/unit/ai/services/memory-core/HealthService.spec.mjs`
  - `test/playwright/unit/ai/mcp/server/knowledge-base/Server.spec.mjs`
- The service-local config repair passed `23/23` focused Knowledge Base health/server tests.
- KB witnesses cover: no-observation fail-closed truth; healthy vector admission; first timeout degradation; cached-green→failed overlay; a reachable provider that never answers; payload separation between could-not-run and did-not-answer; distinct connection-refused and model-not-resident receipts; cadence demand inside backoff; and server startup awaiting first observation.
- Memory Core's existing deadline/abort/redaction/dimension/canary suite stays green after the shared-attempt extraction.
- Mutation receipt: temporarily restored the old `embeddingProvider !== 'gemini'` inference. The new no-observation witness failed red with `Expected: degraded; Received: healthy`; removing the mutation restored green.
- Neo staged-file gate passed: whitespace, shorthand, JSDoc types, ticket archaeology, block alignment, parse, AiConfig test-mutation, derived-domain, and OpenAPI service parity.
- `npm run ai:lint-retry-bounds` passed with all 42 candidates classified.
- `git diff --check` passed.
- Final rebase range-diff was exact (`=` for all four commits), and the repaired branch rests directly on live `origin/dev` at `ef0bed8aa9`.

## Architectural Step-Back

Importing Memory Core's whole `HealthService` into KB would make one consumer depend on another consumer's lifecycle surface. Duplicating its attempt classifier would fork deadline and redaction semantics. The shared module therefore owns only the consumer-agnostic attempt; each service continues to own scheduling, retry policy, config selection, and health projection.

The KB health probe reads `aiConfig.embeddingProvider` and `aiConfig.vectorDimension` from the Knowledge Base config at the use site, matching the pre-existing service boundary and ADR-0019's reactive-provider rule. Tier-1 inheritance keeps the effective values aligned without importing a sibling server's config. Existing query/ingest modules that still read the Memory Core config are not treated as authority for broadening that coupling into this health path.

## Post-Merge Validation

- [ ] Redeploy the Knowledge Base plane from the merged revision.
- [ ] With a deliberately non-answering embedding endpoint, confirm health becomes `degraded`, `features.embedding` is `false`, and details include `consumer-probe-timeout:EMBEDDING_PROBE_TIMEOUT` plus the 30000ms deadline/backoff receipt.
- [ ] Force the probe body to fail before provider dispatch and confirm details instead include `probe-could-not-run:EMBEDDING_PROBE_EXECUTION_ERROR`.
- [ ] Refuse the provider connection and unload the configured embedding model in turn; confirm the bounded receipts remain `provider-unreachable:ECONNREFUSED` and `model-not-resident:EMBEDDING_MODEL_NOT_RESIDENT` without provider payload text.
- [ ] Restore the provider and confirm the scheduled producer recovers to `healthy` without an operator-forced run.
- [ ] Repeated healthcheck calls inside the cadence/backoff window must not increase embedding-attempt frequency.

## Commits

- `cb73459697` — `fix(kb): observe embedding readiness (#16691)`
- `fe4b430746` — `fix(kb): distinguish probe execution failures (#16691)`
- `8d10607ad0` — `fix(kb): classify probe reachability (#16691)`
- `2ae50e6812` — `fix(kb): keep probe config service-local (#16691)`
