### PR TITLE
feat(ai): a probe timeout says whether the box or the service failed (#16646)

### DIFF
--- a/ai/scripts/diagnostics/mcpHealthcheck.mjs
+++ b/ai/scripts/diagnostics/mcpHealthcheck.mjs
@@ -23,6 +23,88 @@ export const DEFAULT_URL = 'http://127.0.0.1:3000';
 export const DEFAULT_TIMEOUT_MS = 8000;
 
 /**
+ * @summary Separates the two incompatible meanings a probe timeout currently carries: the SERVICE
+ * did not answer, or this PROBE never got enough CPU to ask.
+ *
+ * ## Why one exit code was not enough
+ *
+ * A Docker healthcheck failure is a single bit, and two unrelated causes produce it:
+ *
+ * 1. **The service did not answer.** The process is up and the socket accepts, but no response
+ *    comes — a live-but-unreachable wedge.
+ * 2. **The probe could not run.** Under heavy CPU contention a Node cold start can consume the
+ *    whole wait budget before the request is even issued. The service is fine; the box is not.
+ *
+ * Nothing in the old output distinguished them, so the same red was read as an instrument artifact
+ * on one ticket and as a genuine wedge on another. Telling them apart required leaving the probe
+ * entirely — running a `curl` that spawns no Node and seeing whether IT also hung.
+ *
+ * ## Why the rule is `startupMs >= timeoutMs` and not a tuned fraction
+ *
+ * Measured on an 18-core host, this probe's startup is **0.25–0.36s idle** and only **~1.1s at
+ * `--cpus=0.1`** — one tenth of a single core. Reaching an 8000ms startup therefore takes roughly
+ * `--cpus=0.015`: catastrophic starvation, not ordinary load.
+ *
+ * That deliberately conservative bar is the point. `probe-starved` is claimed ONLY when startup
+ * alone outlasted the entire budget the probe was allowed to wait — an unambiguous fact needing no
+ * tuned constant, and no threshold anyone has to re-derive when hardware changes.
+ *
+ * **The asymmetry is intentional.** Being slow to call a starved probe starved costs a confusing
+ * log line. Being eager would let a real wedge be dismissed as contention — and a live-but-
+ * unreachable Memory Core, observed three times, presents with a healthy listener and a socket
+ * that still accepts. Ambiguity resolves toward `service-unresponsive`, never away from it.
+ * @param {Object} options
+ * @param {Number} options.startupMs How long this process took to become ready to issue the request.
+ * @param {Number} options.timeoutMs The per-operation budget the probe was allowed.
+ * @param {String} options.phase Which bounded operation exceeded its budget.
+ * @returns {Object} `{verdict: 'probe-starved'|'service-unresponsive', startupMs, timeoutMs, phase, reason}`
+ */
+export function classifyProbeFailure({startupMs, timeoutMs, phase}) {
+    const starved = Number.isFinite(startupMs) && Number.isFinite(timeoutMs) && startupMs >= timeoutMs;
+
+    return {
+        verdict: starved ? 'probe-starved' : 'service-unresponsive',
+        startupMs,
+        timeoutMs,
+        phase,
+        reason : starved
+            ? `this probe took ${Math.round(startupMs)}ms just to become ready — longer than the ` +
+              `${timeoutMs}ms it was then allowed to wait. The host could not schedule it; this is ` +
+              'evidence about the BOX, not about the service.'
+            : `this probe was ready after ${Math.round(startupMs)}ms, well inside its ${timeoutMs}ms ` +
+              `budget, and then ${phase} still produced nothing. The service did not answer.`
+    }
+}
+
+/**
+ * @summary Attaches a timing verdict to a TIMEOUT failure, and to nothing else.
+ *
+ * Scoped deliberately narrowly. A 401, a protocol error, a wrong-plane rejection, or a refused
+ * connection are all definite answers — the service replied, it simply replied badly — and
+ * labelling them `service-unresponsive` would blur a diagnosis that is already precise. Only the
+ * budget-exceeded case is ambiguous between the box and the service, so only it is classified.
+ *
+ * The predicate keys off the message `withAbortableTimeout` itself produces, so it cannot
+ * accidentally match an SDK error that merely mentions a timeout in prose.
+ * @param {Error}  error The rejection from a bounded operation.
+ * @param {Object} context `{startupMs, timeoutMs, phase}`.
+ * @returns {Error} The same error, annotated with `.probeTiming` and an extended message when it
+ * was a budget timeout; otherwise returned untouched.
+ */
+export function annotateTimeout(error, {startupMs, timeoutMs, phase}) {
+    if (!error?.message?.includes(`timed out after ${timeoutMs}ms`)) {
+        return error;
+    }
+
+    const timing = classifyProbeFailure({startupMs, timeoutMs, phase});
+
+    error.probeTiming = timing;
+    error.message     = `${error.message}\n[${timing.verdict}] ${timing.reason}`;
+
+    return error
+}
+
+/**
  * @summary Bounds an MCP SDK operation and aborts the underlying HTTP transport on timeout.
  * @param {Promise} promise Operation promise returned by the SDK.
  * @param {Number} timeoutMs Maximum wait time before rejecting.
@@ -276,7 +358,12 @@ export async function runHealthcheck({
     mcpPath               = '/mcp',
     timeoutMs             = DEFAULT_TIMEOUT_MS,
     ClientClass           = Client,
-    TransportClass        = StreamableHTTPClientTransport
+    TransportClass        = StreamableHTTPClientTransport,
+    // Time from process start to "ready to issue the request". `process.uptime()` is the only
+    // source that spans module loading, which is the cost contention actually inflates — a clock
+    // read inside this function would start after the expensive part had already happened.
+    // Injected as a seam so specs can drive starvation without one.
+    uptimeMs              = () => process.uptime() * 1000
 }) {
     const baseUrl         = new URL(url);
     const headers         = buildHeaders({identity, bearerToken});
@@ -296,20 +383,25 @@ export async function runHealthcheck({
         capabilities: {}
     });
 
+    // Captured BEFORE the first bounded operation: everything up to here — interpreter start, the
+    // SDK module graph, arg parsing — is cost the service had no part in, and it is exactly what
+    // CPU contention inflates. Reading it after a failure would be too late; the abort has fired.
+    const startupMs = uptimeMs();
+
     try {
         await withAbortableTimeout(
             client.connect(transport),
             timeoutMs,
             'MCP healthcheck connect',
             abortController
-        );
+        ).catch(error => { throw annotateTimeout(error, {startupMs, timeoutMs, phase: 'connect'}) });
 
         const result = await withAbortableTimeout(
             client.callTool({name: 'healthcheck', arguments: {}}),
             timeoutMs,
             'MCP healthcheck tool call',
             abortController
-        );
+        ).catch(error => { throw annotateTimeout(error, {startupMs, timeoutMs, phase: 'tool call'}) });
 
         if (result?.isError) {
             throw new Error('MCP healthcheck tool returned isError=true.');
@@ -330,7 +422,14 @@ export async function runHealthcheck({
         return {
             status: health.status,
             url   : baseUrl.toString(),
-            ...(plane ? {plane} : {})
+            ...(plane ? {plane} : {}),
+            // Emitted on SUCCESS too, not only on failure. A starvation verdict is only readable
+            // against a baseline, and the baseline has to come from the same probe on the same box
+            // — a healthy run is the only place it can be recorded. Docker keeps the last few
+            // health-log entries, so the passing runs before an incident carry the comparison that
+            // makes the failing one interpretable. Without this, the first evidence of contention
+            // is the failure itself, which is exactly when it can no longer be measured.
+            timings: {startupMs: Math.round(startupMs), timeoutMs}
         };
     } finally {
         await client.close?.();

--- a/test/playwright/unit/ai/scripts/diagnostics/mcpHealthcheck.spec.mjs
+++ b/test/playwright/unit/ai/scripts/diagnostics/mcpHealthcheck.spec.mjs
@@ -190,16 +190,21 @@ test.describe('ai/scripts/diagnostics/mcpHealthcheck (#11725)', () => {
         }
 
         const result = await runHealthcheck({
-            url           : 'http://127.0.0.1:3000',
-            identity      : 'probe',
-            bearerToken   : 'token',
+            url        : 'http://127.0.0.1:3000',
+            identity   : 'probe',
+            bearerToken: 'token',
+            // Injected so the exact-shape assertion below stays exact. Kept as `toEqual` rather
+            // than relaxed to `toMatchObject`: pinning the WHOLE result is what makes an
+            // accidental field addition visible, and the timings field was deliberate.
+            uptimeMs      : () => 120,
             ClientClass   : FakeClient,
             TransportClass: FakeTransport
         });
 
         expect(result).toEqual({
-            status: 'healthy',
-            url   : 'http://127.0.0.1:3000/'
+            status : 'healthy',
+            url    : 'http://127.0.0.1:3000/',
+            timings: {startupMs: 120, timeoutMs: 8000}
         });
         expect(calls).toEqual([
             {type: 'client', identity: {name: 'neo-container-healthcheck', version: '1.0.0'}, options: {capabilities: {}}},
@@ -572,11 +577,13 @@ test.describe('served-plane verification — a healthy status is not an identity
             expectedPlaneId      : 'neo-local-parity',
             expectedPlaneDataRoot: '/app/.neo-ai-data-parity',
             ClientClass          : clientFor(matching),
-            TransportClass       : FakeTransport
+            TransportClass       : FakeTransport,
+            uptimeMs             : () => 120
         })).toEqual({
-            status: 'healthy',
-            url   : 'http://127.0.0.1:8100/',
-            plane : {id: 'neo-local-parity', dataRoot: '/app/.neo-ai-data-parity'}
+            status : 'healthy',
+            url    : 'http://127.0.0.1:8100/',
+            plane  : {id: 'neo-local-parity', dataRoot: '/app/.neo-ai-data-parity'},
+            timings: {startupMs: 120, timeoutMs: 8000}
         });
     });
 });
@@ -738,5 +745,130 @@ test.describe('mcpHealthcheck — a liveness expectation is a SET', () => {
                 expect(command, file).not.toContain('--expected-status');
             }
         }
+    });
+});
+
+/**
+ * A probe timeout carries two incompatible meanings — the SERVICE did not answer, or this PROBE
+ * never got enough CPU to ask — and until now nothing in the output separated them. Telling them
+ * apart required leaving the probe entirely and running a `curl` that spawns no Node.
+ *
+ * The load-bearing arms here are the ones that must NOT reclassify. A rule eager to blame
+ * contention would let a live-but-unreachable wedge be dismissed as host load, and that wedge has
+ * been observed three times presenting with a healthy listener and an accepting socket.
+ */
+test.describe('probe timing verdict — box vs service (#16646)', () => {
+    let classifyProbeFailure, annotateTimeout, runHealthcheck;
+
+    test.beforeAll(async () => {
+        const mod = await import('../../../../../../ai/scripts/diagnostics/mcpHealthcheck.mjs');
+
+        classifyProbeFailure = mod.classifyProbeFailure;
+        annotateTimeout      = mod.annotateTimeout;
+        runHealthcheck       = mod.runHealthcheck;
+    });
+
+    test('a healthy startup that then gets no answer is the SERVICE, never the box', () => {
+        // The measured shape of the real incident: startup 0.36s against an 8s budget, then silence.
+        const verdict = classifyProbeFailure({startupMs: 360, timeoutMs: 8000, phase: 'connect'});
+
+        expect(verdict.verdict).toBe('service-unresponsive');
+        expect(verdict.reason).toContain('The service did not answer');
+    });
+
+    test('only a startup that outlasts the whole budget is called starved', () => {
+        expect(classifyProbeFailure({startupMs: 8000, timeoutMs: 8000, phase: 'connect'}).verdict)
+            .toBe('probe-starved');
+        expect(classifyProbeFailure({startupMs: 9500, timeoutMs: 8000, phase: 'connect'}).verdict)
+            .toBe('probe-starved');
+    });
+
+    // The discriminating band. Every one of these is slow — some absurdly so, 1100ms being the
+    // MEASURED cost at --cpus=0.1 — and none may be blamed on the box, because the probe still had
+    // budget left to wait and the service still said nothing. A tuned fraction (say "startup > 25%
+    // of budget") would misclassify the last two and hide a real wedge.
+    for (const startupMs of [360, 1100, 2000, 4000, 7999]) {
+        test(`startup ${startupMs}ms against an 8000ms budget is NOT starvation`, () => {
+            expect(classifyProbeFailure({startupMs, timeoutMs: 8000, phase: 'connect'}).verdict)
+                .toBe('service-unresponsive');
+        });
+    }
+
+    test('a non-timeout failure is left completely untouched', () => {
+        // A 401, a protocol error, a refused connection: all definite answers. Classifying them
+        // would blur a diagnosis that is already precise.
+        const original = new Error('fetch failed'),
+              returned = annotateTimeout(original, {startupMs: 50, timeoutMs: 8000, phase: 'connect'});
+
+        expect(returned).toBe(original);
+        expect(returned.message).toBe('fetch failed');
+        expect(returned.probeTiming).toBeUndefined();
+    });
+
+    test('a timeout from a DIFFERENT budget is not adopted', () => {
+        // Guards against matching any error that merely mentions a timeout: the message must be the
+        // one this probe's own bounded operation produced, for this budget.
+        const foreign = new Error('upstream timed out after 30000ms'),
+              result  = annotateTimeout(foreign, {startupMs: 50, timeoutMs: 8000, phase: 'connect'});
+
+        expect(result.probeTiming).toBeUndefined();
+    });
+
+    test('the verdict reaches the caller through runHealthcheck, with startup injected', async () => {
+        class FakeTransport {}
+        class FakeClient {
+            connect() { return new Promise(() => {}) }   // never settles — the wedge shape
+            close()   { return Promise.resolve() }
+        }
+
+        const error = await runHealthcheck({
+            url           : 'http://127.0.0.1:3000',
+            timeoutMs     : 40,
+            uptimeMs      : () => 5,                     // probe was ready almost instantly
+            ClientClass   : FakeClient,
+            TransportClass: FakeTransport
+        }).then(() => null, err => err);
+
+        expect(error, 'a never-settling connect must reject').toBeTruthy();
+        expect(error.probeTiming?.verdict).toBe('service-unresponsive');
+        expect(error.message).toContain('[service-unresponsive]');
+    });
+
+    test('a starved probe is reported as starved rather than blamed on the service', async () => {
+        class FakeTransport {}
+        class FakeClient {
+            connect() { return new Promise(() => {}) }
+            close()   { return Promise.resolve() }
+        }
+
+        const error = await runHealthcheck({
+            url           : 'http://127.0.0.1:3000',
+            timeoutMs     : 40,
+            uptimeMs      : () => 5000,                  // startup outlasted the entire budget
+            ClientClass   : FakeClient,
+            TransportClass: FakeTransport
+        }).then(() => null, err => err);
+
+        expect(error.probeTiming?.verdict).toBe('probe-starved');
+        expect(error.message).toContain('evidence about the BOX, not about the service');
+    });
+
+    test('a passing run records the baseline, so a later failure is interpretable', async () => {
+        class FakeTransport {}
+        class FakeClient {
+            connect()  { return Promise.resolve() }
+            callTool() { return Promise.resolve({content: [{type: 'text', text: '{"status":"healthy"}'}]}) }
+            close()    { return Promise.resolve() }
+        }
+
+        const result = await runHealthcheck({
+            url           : 'http://127.0.0.1:3000',
+            uptimeMs      : () => 312,
+            ClientClass   : FakeClient,
+            TransportClass: FakeTransport
+        });
+
+        expect(result.status).toBe('healthy');
+        expect(result.timings).toEqual({startupMs: 312, timeoutMs: 8000});
     });
 });


### PR DESCRIPTION
Resolves #16646

A probe timeout carried two incompatible meanings — *the service did not answer* and *this probe never got enough CPU to ask* — and nothing in the output separated them. Telling them apart required leaving the probe entirely and running a `curl` that spawns no Node to see whether it also hung. `mcpHealthcheck.mjs` now measures its own startup cost, classifies a budget timeout as `service-unresponsive` or `probe-starved`, and records the startup baseline on **passing** runs too, so a later failure is interpretable against the same probe on the same box.

Evidence: L3 (probe timing measured in-container on the live plane and under controlled CPU limits from `--cpus=4` down to `0.1`) → L4 required (a real contention event on a loaded host reproducing a `probe-starved` verdict). Residual: none among #16646's ACs — the L4 arm is confirmation of a classification the unit matrix already pins at both boundaries.

## Deltas from ticket

**The ticket's two stated mechanisms do not survive measurement. The observation does.** @neo-opus-grace has conceded both and reassigned the lane; the ticket body is corrected and its options superseded.

**Mechanism A — "the deadline bounds process startup, not the check."** True as mechanism, but it understates the margin by more than an order of magnitude. Measured in-container, three runs each, `docker exec` overhead included:

| service | probe | idle | budget | headroom |
|---|---|---|---|---|
| orchestrator | 4 dynamic imports + lease inspect | 0.09–0.15s | 5s | ~40× |
| kb-server | `mcpHealthcheck.mjs` + handshake | 0.25–0.27s | 10s | ~38× |
| mc-server | `mcpHealthcheck.mjs` + handshake | 0.36s | 10s | ~28× |

The ticket describes the orchestrator probe as a `statSync`; it now imports `src/Neo.mjs`, `src/core/_export.mjs`, `ai/config.mjs` and `authorityLease.mjs`. I predicted that made it the worst case. It is the **cheapest**. Under controlled scarcity in throwaway containers (18-core host, nothing contending with the live plane):

| `--cpus` | 4 | 2 | 1 | 0.5 | 0.25 | 0.1 |
|---|---|---|---|---|---|---|
| startup | 0.46 / 0.36s | 0.34 / 0.33s | 0.34 / 0.36s | 0.35 / 0.40s | 0.59 / 0.45s | **1.15 / 1.05s** |

At one tenth of one core, startup is 1.1s — 22% of the orchestrator's 5s budget. **Widening the deadline is therefore not the fix**: absorbing that contention would take minutes, at which point the probe is not a health signal.

**Mechanism B — "a 30s canary nested inside a 10s deadline" — was already fixed six days before the ticket was filed.** `HealthService.mjs:1749` reads a cached `producer.gate.snapshot()` and ticks the attempt on its own cadence (`:1927`/`:1932`); the 30000ms leaf bounds the canary's attempt, not the health response. That is the `boundedRetryGate` adoption in `c480d30dbf` (#16222 / PR #16239), landed 2026-08-01 against a ticket filed 08-07. Separately, `DEFAULT_TIMEOUT_MS = 8000` sits *inside* the 10s Docker deadline, so that nesting is correct by construction — the internal deadline fires first and yields a clean error instead of a SIGKILL.

**So the scope changed from "make the probe cheaper" to "make its verdict say which thing happened."** No budget is widened, no probe degrades to TCP-only, and no compose file changes.

## Contract Ledger

| Surface | Before | After |
|---|---|---|
| `runHealthcheck()` return | `{status, url, plane?}` | adds `timings: {startupMs, timeoutMs}` — **additive**; every in-repo consumer is exit-code-only |
| `runHealthcheck()` options | — | adds injectable `uptimeMs` seam (defaults to `process.uptime`) |
| `classifyProbeFailure()` | — | **new export**; pure, `{startupMs, timeoutMs, phase} → {verdict, reason}` |
| `annotateTimeout()` | — | **new export**; annotates budget timeouts only, returns every other error untouched |
| thrown timeout error | `"<phase> timed out after Nms"` | same first line, plus `\n[verdict] reason`, and a structured `.probeTiming` |
| `docker-compose*.yml` | — | **unchanged** |

Consumer sweep: every compose healthcheck invokes the CLI and reads only the exit code; `captureParityLatencyPair.mjs` imports `assertServedPlane` and `readToolJson`, not `runHealthcheck`; `parityComposeWebServer.mjs` execs it fresh. `BaseServer.runHealthcheckAndLogStatus` is an unrelated method on a different module.

## Why the rule is `startupMs >= timeoutMs` and not a tuned fraction

`probe-starved` is claimed only when startup alone outlasted the entire budget the probe was then allowed to wait. Given the measurements above, reaching an 8000ms startup takes roughly `--cpus=0.015` — catastrophic starvation, not ordinary load.

**The conservatism is the point, and the asymmetry is deliberate.** Being slow to call a starved probe starved costs a confusing log line. Being eager would let a real wedge be dismissed as contention — and the live-but-unreachable Memory Core (#16677, three recorded instances) presents with a healthy listener and a socket that still accepts. A TCP-only probe would have reported healthy through all 18 consecutive failures of the 2026-08-08 13:00Z instance. Ambiguity resolves toward `service-unresponsive`, never away from it.

That instance is also the discriminating case proving the classifier is not merely restating the timeout: `curl` to `/mc/mcp` spawns no Node and *also* returned nothing, while KB on the same ingress answered in 2ms. Startup was healthy; the service was not. This change makes that readable from the health log instead of requiring a second tool.

## Test Evidence

`ai/scripts/diagnostics/mcpHealthcheck.mjs` — 9 new tests appended to the existing spec rather than a parallel file.

```bash
npm run test-unit -- test/playwright/unit/ai/scripts/diagnostics/mcpHealthcheck.spec.mjs
# 49 passed (2.6s)

npm run test-unit -- test/playwright/unit/ai/scripts/diagnostics/ test/playwright/unit/ai/deploy/ \
  test/playwright/unit/ai/DeployPipelineRevisionPin.spec.mjs
# 475 passed (9.0s)
```

The load-bearing arms are the ones that must **not** reclassify: a parameterised band at `360`, `1100`, `2000`, `4000` and `7999`ms of startup against an 8000ms budget must all stay `service-unresponsive`. `1100ms` is the *measured* cost at `--cpus=0.1`, so a plausible tuned threshold ("startup > 25% of budget") would misclassify the last two and hide a real wedge. Both boundaries are pinned (`7999` → service, `8000` → starved), plus two negative arms proving a non-timeout error and a foreign-budget timeout are left untouched.

Two pre-existing exact-shape assertions were updated rather than relaxed: they now inject `uptimeMs` and assert the full result including `timings`, keeping `toEqual` so a future accidental field addition stays visible.

Live smoke on the running plane: `{"status":"healthy","url":"http://127.0.0.1:3102/","timings":{"startupMs":100,"timeoutMs":8000}}`.

`agent-preflight --change-class capability --no-fix` → all requested gates passed.

## Post-Merge Validation

- [ ] A real contention event on a loaded host produces a `probe-starved` verdict in `docker inspect --format '{{json .State.Health.Log}}'` rather than a bare timeout.
- [ ] The passing-run `timings.startupMs` baseline is present in the health log entries preceding an incident, and is what makes the failing entry interpretable.
- [ ] #16677's next occurrence reports `service-unresponsive`, confirming the classifier does not absorb a genuine wedge.

## Deferred, not silently dropped

This does **not** change Docker's two-state health model, so a `probe-starved` verdict still exits non-zero and still blocks `depends_on: service_healthy`. That tooth is real (the ticket is right about it) but converting an instrument artifact into a *pass* would mask the wedge class this same change exists to keep visible. The verdict is the prerequisite: nothing can act on the distinction until something records it. Whether a starved verdict should ever exit 0 is a policy question that now has data to argue from, and belongs to a separate ticket rather than being smuggled in here.

Authored by Ada (Claude Opus 5, Claude Code). Session 9b08b9e4-6181-416b-ac68-e9d16636cff0.
