### PR TITLE
feat: a context gate defers wakes into over-budget sessions (#16682)

### DIFF
--- a/ai/daemons/wake/buildReceiverManifest.mjs
+++ b/ai/daemons/wake/buildReceiverManifest.mjs
@@ -55,6 +55,10 @@ import {pathToFileURL} from 'node:url';
 
 import {loadWakeReceiverManifest} from './receiver.mjs';
 import {withOutboxLock}           from './outboxLock.mjs';
+import {
+    DEFAULT_CONTEXT_GATE_MAX_TOKENS,
+    DEFAULT_CONTEXT_GATE_WARN_TOKENS
+} from './contextGatePolicy.mjs';
 
 import {
     isActiveWakeSubscriptionStatus,
@@ -69,6 +73,19 @@ import {
  * @type {Number}
  */
 export const DEFAULT_ATTEMPT_TIMEOUT_MS = 10000;
+
+/**
+ * The per-route context-gate policy stamped on every generated route. The receiver
+ * declares no gate defaults of its own — every route states its policy, mirroring
+ * `attemptTimeoutMs`; a legacy route carried forward without `contextGate` simply delivers
+ * ungated until its identity's routes are rebuilt. Per-route overrides arrive through the
+ * `--adapter-config` map's `contextGate` key and are merged over these defaults.
+ * @type {Object}
+ */
+export const DEFAULT_CONTEXT_GATE = Object.freeze({
+    maxContextTokens : DEFAULT_CONTEXT_GATE_MAX_TOKENS,
+    warnContextTokens: DEFAULT_CONTEXT_GATE_WARN_TOKENS
+});
 
 /**
  * The only `harnessTarget` the Shape-B container path can deliver to.
@@ -261,12 +278,19 @@ export function buildWakeReceiverManifest({
         // Per-route adapter config comes from the caller, keyed by subscription id. The subscription
         // record carries none, so without this a Codex seat could never satisfy the receiver's
         // `codexBinary` requirement from any supported input — the route would be unbuildable rather
-        // than merely unconfigured.
+        // than merely unconfigured. The context gate rides the same channel: every route
+        // states its gate policy explicitly (generator defaults, caller override merged per key).
+        const {contextGate: contextGateOverride, ...adapterConfigExtra} = adapterConfigById[id] || {};
+
         routes[id] = {
             agentIdentity,
             signingKey,
             harnessTargetMetadata: receiverMetadata,
-            adapterConfig        : {attemptTimeoutMs, ...(adapterConfigById[id] || {})}
+            adapterConfig        : {
+                attemptTimeoutMs,
+                contextGate: {...DEFAULT_CONTEXT_GATE, ...(contextGateOverride || {})},
+                ...adapterConfigExtra
+            }
         };
 
         routeSummaries.push({

--- a/ai/daemons/wake/contextGatePolicy.mjs
+++ b/ai/daemons/wake/contextGatePolicy.mjs
@@ -1,0 +1,75 @@
+/**
+ * @summary Pure policy for the wake receiver's delivery-time context gate: whether a
+ * signed wake digest may be injected into the target session NOW, or must wait for the session to
+ * shrink or rotate.
+ *
+ * **The failure mode this guards (the budget cliff):** injecting a wake into a marathon session
+ * starts a turn that re-processes the session's entire context. Measured cross-harness
+ * (cross-harness harness-ledger measurement, 2026-08-08): 61% of one seat's lifetime processed tokens came from turns above
+ * 500K context, and a provider prompt-cache TTL cliff (~30–60 min idle on K3; 5m/1h on Anthropic)
+ * means a stale large session re-bills that context at ~0% cache hits. One wake delivered into a
+ * >1h-idle ~700K session moved a weekly budget 97% → 100% in a single turn. The wake is only a
+ * notification — the A2A mailbox stays the authority — so deferring the notification never loses
+ * the message.
+ *
+ * **Why the policy reads CURRENT state only:** the probe always evaluates the session as it is
+ * NOW, so both flush conditions collapse into the size read — a compacted session reports a small
+ * context, and a rotated (fresh) session reports a fresh boot's context. There is deliberately NO
+ * time-based flush: a session that stays large forever must never receive the deferred wake,
+ * because flushing into a stale large session is precisely the cliff event. The provider warm
+ * window is therefore documented rationale here, not a consumed input: delivering a
+ * sub-threshold wake immediately already beats any warm-window deadline, and a deferred wake must
+ * outlast any window.
+ *
+ * **Unknown context fails OPEN** (deliver + loud warn): a probe that cannot read the session must
+ * never silently withhold coordination — silent non-delivery is the dead-realm failure mode. The gate
+ * exists to shave the cliff, not to become a second mailbox.
+ *
+ * Kept pure (no timers, fs, or fetch) so the policy is unit-testable in isolation, mirroring
+ * `flushDeferPolicy.mjs`.
+ *
+ * @module ai/daemons/wake/contextGatePolicy
+ */
+
+/**
+ * Default size ceiling, in tokens (last assistant turn's `input + cache.read`), above which a
+ * wake defers. Sized from the 2026-08-08 telemetry: sub-250K turns are rounding error (~7.5% of
+ * lifetime processed tokens), while the 500K–1M band alone carried 61% — so the gate sits at the
+ * top of the cheap band, not at the cliff's edge.
+ * @type {Number}
+ */
+export const DEFAULT_CONTEXT_GATE_MAX_TOKENS = 250_000;
+
+/**
+ * Default warn level, in tokens, at which a delivered wake logs that the session is approaching
+ * the gate. A seat that sees this warning should sunset before the next wake defers.
+ * @type {Number}
+ */
+export const DEFAULT_CONTEXT_GATE_WARN_TOKENS = 200_000;
+
+/**
+ * @summary Evaluates one wake against the target session's probed context.
+ *
+ * @param {Object}        opts
+ * @param {Object|null}   opts.probe               Probe result: `{contextTokens, lastActivityAt,
+ *   sessionId}`, or `null` when the adapter cannot read the session.
+ * @param {Number}        opts.maxContextTokens    Defer above this size (T1).
+ * @param {Number}        opts.warnContextTokens   Warn-and-deliver at or above this size (T2).
+ * @returns {{action: 'deliver'|'defer', gateOutcome: 'unknown'|'within'|'warn'|'deferred', contextTokens: Number|null}}
+ */
+export function evaluateContextGate({probe, maxContextTokens, warnContextTokens}) {
+    if (!probe || !Number.isFinite(probe.contextTokens)) {
+        return {action: 'deliver', gateOutcome: 'unknown', contextTokens: null};
+    }
+
+    const {contextTokens} = probe;
+
+    if (contextTokens > maxContextTokens) {
+        return {action: 'defer', gateOutcome: 'deferred', contextTokens};
+    }
+    if (contextTokens >= warnContextTokens) {
+        return {action: 'deliver', gateOutcome: 'warn', contextTokens};
+    }
+
+    return {action: 'deliver', gateOutcome: 'within', contextTokens};
+}

--- a/ai/daemons/wake/localWakeAdapters.mjs
+++ b/ai/daemons/wake/localWakeAdapters.mjs
@@ -739,6 +739,151 @@ async function deliverOsascriptWithRetry(effects, args, subscriptionId) {
 }
 
 /**
+ * @summary Probes the target session's current context occupancy for the receiver's context gate,
+ * without disturbing the session.
+ *
+ * Returns `{contextTokens, lastActivityAt, sessionId}` — the newest assistant turn's
+ * `input + cache.read` (the context the next injected turn would re-process) plus the newest
+ * activity stamp — or `null` when the adapter has no readable local authority. `null` is the
+ * fail-open signal: the gate delivers with a loud warn rather than ever silently withholding a
+ * wake. Probe failures are deliberately swallowed into `null`; the receiver's
+ * warn line carries the subscription id, and the mailbox stays authoritative throughout.
+ *
+ * @param {Object} record Durable receiver record (carries its route snapshot).
+ * @param {Object} [dependencies] Injectable host effects for tests.
+ * @returns {Promise<{contextTokens: Number, lastActivityAt: Number|null, sessionId: String}|null>}
+ */
+export async function probeSessionContext(record, dependencies = {}) {
+    const meta    = record?.route?.harnessTargetMetadata || {};
+    const adapter = meta.adapter || (process.platform === 'darwin' ? 'osascript' : 'tmux');
+    const effects = {
+        fetch  : globalThis.fetch,
+        fs,
+        homedir: os.homedir,
+        ...dependencies
+    };
+
+    try {
+        if (adapter === 'opencode-server') {
+            return await probeOpenCodeSession({effects, meta});
+        }
+        if (adapter === 'kimi-server' || adapter === 'kimi-pull-bridge') {
+            return await probeKimiWireSession({effects, meta});
+        }
+    } catch {
+        return null;
+    }
+
+    return null;
+}
+
+/**
+ * @summary Reads the OpenCode session's context size through its own loopback server — the same
+ * 0600 envelope authority the delivery path uses, so a session rotation automatically re-points
+ * the probe at the fresh (cheap) session.
+ * @private
+ */
+async function probeOpenCodeSession({effects, meta}) {
+    const envelopePath = meta.envelopePath
+        || path.join(effects.homedir(), '.local', 'share', 'opencode', 'wake-envelope.json');
+    const {hostname, port, sessionId, username, password} = await readOpenCodeEnvelope(effects, envelopePath);
+
+    const response = await effects.fetch(
+        `http://${hostname}:${port}/session/${encodeURIComponent(sessionId)}/message?limit=30`,
+        {
+            headers: {'authorization': 'Basic ' + Buffer.from(`${username}:${password}`).toString('base64')},
+            signal : AbortSignal.timeout(4000)
+        }
+    );
+    if (!response.ok) return null;
+
+    const messages = await response.json();
+    if (!Array.isArray(messages) || messages.length === 0) return null;
+
+    let contextTokens  = null,
+        lastActivityAt = null;
+
+    for (let i = messages.length - 1; i >= 0; i--) {
+        const info    = messages[i]?.info || messages[i];
+        const created = info?.time?.created;
+
+        if (lastActivityAt === null && Number.isFinite(created)) lastActivityAt = created;
+
+        const tokens = info?.tokens;
+        if (info?.role === 'assistant' && tokens && Number.isFinite(tokens.input)) {
+            contextTokens = (tokens.input || 0) + (tokens.cache?.read || 0);
+            break;
+        }
+    }
+
+    if (!Number.isFinite(contextTokens)) return null;
+
+    return {contextTokens, lastActivityAt, sessionId};
+}
+
+/**
+ * @summary Reads the Kimi session's context size from the tail of its `wire.jsonl` usage ledger —
+ * the same harness-side telemetry the flatrate forensics were computed from. The session id comes
+ * from the seat's wake envelope (rotation-safe); the working-dir bucket is discovered, never
+ * assumed.
+ * @private
+ */
+async function probeKimiWireSession({effects, meta}) {
+    const envelopePath = meta.envelopePath || path.join(effects.homedir(), '.kimi-code', 'wake-envelope.json');
+    const envelope     = await readJson(effects.fs, envelopePath, 'kimi wake envelope');
+    const {sessionId}  = envelope;
+
+    if (typeof sessionId !== 'string' || sessionId.length === 0) return null;
+
+    const sessionsRoot = path.join(effects.homedir(), '.kimi-code', 'sessions');
+
+    for (const bucket of await effects.fs.readdir(sessionsRoot)) {
+        const wirePath = path.join(sessionsRoot, bucket, sessionId, 'agents', 'main', 'wire.jsonl');
+
+        if (!await effects.fs.pathExists(wirePath)) continue;
+
+        // Tail-read only: these ledgers reach tens of MB inside a single session.
+        const {size} = await effects.fs.stat(wirePath);
+        const start  = Math.max(0, size - 262_144);
+        const handle = await effects.fs.open(wirePath, 'r');
+        let   chunk;
+
+        try {
+            const buffer = Buffer.alloc(size - start);
+            await handle.read(buffer, 0, buffer.length, start);
+            chunk = buffer.toString('utf8');
+        } finally {
+            await handle.close();
+        }
+
+        const lines = chunk.split('\n');
+
+        for (let i = lines.length - 1; i >= 0; i--) {
+            if (!lines[i].includes('"usage"')) continue;
+
+            let parsed;
+            try { parsed = JSON.parse(lines[i]) } catch { continue; } // a tail-sliced first line is partial
+
+            const usage = parsed?.usage;
+            if (!usage || !Number.isFinite(usage.inputOther)) continue;
+
+            let lastActivityAt = parsed.timestamp ?? parsed.time ?? null;
+            if (Number.isFinite(lastActivityAt) && lastActivityAt < 1e11) lastActivityAt *= 1000;
+
+            return {
+                contextTokens : (usage.inputOther || 0) + (usage.inputCacheRead || 0),
+                lastActivityAt: Number.isFinite(lastActivityAt) ? lastActivityAt : null,
+                sessionId
+            };
+        }
+
+        return null; // the located wire ledger has no usable usage line yet
+    }
+
+    return null;
+}
+
+/**
  * @summary Injection-safe child-process wrapper.
  * @private
  */

--- a/ai/daemons/wake/receiver.mjs
+++ b/ai/daemons/wake/receiver.mjs
@@ -16,8 +16,9 @@ import path            from 'node:path';
 import {watch}         from 'node:fs';
 import {pathToFileURL} from 'node:url';
 
-import {WakeReceiverState} from './receiverState.mjs';
-import {dispatchLocalWake} from './localWakeAdapters.mjs';
+import {WakeReceiverState}                      from './receiverState.mjs';
+import {evaluateContextGate}                    from './contextGatePolicy.mjs';
+import {dispatchLocalWake, probeSessionContext} from './localWakeAdapters.mjs';
 
 const DEFAULT_MAX_BODY_BYTES = 256 * 1024;
 /**
@@ -41,7 +42,16 @@ const MANIFEST_RECONCILE_INTERVAL_MS = 30 * 1000;
  */
 const MANIFEST_READ_ATTEMPTS = 3;
 const LOOPBACK_HOSTS         = new Set(['127.0.0.1', 'localhost', '::1']);
-const PRODUCTION_ADAPTERS    = new Set([
+/**
+ * How often the receiver re-drains `pending` records without a new wake arriving. A wake deferred
+ * by the context gate flushes when the target session compacts or rotates — both visible
+ * only on re-evaluation — so deferrals need their own clock; a flush that waited for the next wake
+ * could wait forever on a quiet seat. Sized well under any provider cache warm window so a
+ * legitimately-flushed deferral still lands warm.
+ * @type {Number}
+ */
+const DRAIN_RETRY_INTERVAL_MS = 60 * 1000;
+const PRODUCTION_ADAPTERS     = new Set([
     'osascript',
     'tmux',
     'codex-app-server',
@@ -96,6 +106,20 @@ export async function loadWakeReceiverManifest(manifestPath) {
             route.adapterConfig.attemptTimeoutMs > 300_000
         ) {
             throw new Error(`Wake receiver route '${subscriptionId}' requires positive adapterConfig.attemptTimeoutMs`);
+        }
+        if (route.adapterConfig?.contextGate !== undefined) {
+            const gate = route.adapterConfig.contextGate;
+
+            if (
+                !Number.isInteger(gate?.maxContextTokens)  || gate.maxContextTokens <= 0 ||
+                !Number.isInteger(gate?.warnContextTokens) || gate.warnContextTokens <= 0 ||
+                gate.warnContextTokens > gate.maxContextTokens
+            ) {
+                throw new Error(
+                    `Wake receiver route '${subscriptionId}' has an invalid adapterConfig.contextGate ` +
+                    `(requires positive integers with warnContextTokens <= maxContextTokens)`
+                );
+            }
         }
         if (adapter === 'codex-app-server' && (
             metadata.appName !== 'Codex' ||
@@ -160,6 +184,8 @@ export function verifyWakeSignature(rawBody, signingKey, signature) {
  * @param {Object} options.manifest Loaded route manifest.
  * @param {WakeReceiverState} options.state
  * @param {Function} [options.dispatch=dispatchLocalWake] Local adapter `(record) => outcome`.
+ * @param {Function} [options.contextProbe=probeSessionContext] Session context probe
+ *   `(record) => {contextTokens, lastActivityAt, sessionId}|null` for the delivery-time context gate.
  * @param {Object} [options.logger=console]
  * @param {Number} [options.maxBodyBytes=DEFAULT_MAX_BODY_BYTES]
  * @returns {{server:http.Server,drain:Function}}
@@ -167,8 +193,9 @@ export function verifyWakeSignature(rawBody, signingKey, signature) {
 export function createWakeReceiver({
     manifest,
     state,
-    dispatch = dispatchLocalWake,
-    logger   = console,
+    dispatch     = dispatchLocalWake,
+    contextProbe = probeSessionContext,
+    logger       = console,
     maxBodyBytes = DEFAULT_MAX_BODY_BYTES
 } = {}) {
     if (!manifest?.routes || !(state instanceof WakeReceiverState)) {
@@ -209,6 +236,49 @@ export function createWakeReceiver({
                     dispatchStartedAt: new Date().toISOString()
                 });
                 if (!dispatching) continue;
+
+                // The context gate: after the non-idempotency marker, before the adapter runs.
+                // A defer returns the record to `pending` — the wake waits for the target session
+                // to compact or rotate; the mailbox stays the authority, so nothing is ever lost.
+                const gateConfig = dispatching.route?.adapterConfig?.contextGate;
+
+                if (gateConfig && contextProbe) {
+                    const probe = await contextProbe(dispatching).catch(() => null);
+                    const gate  = evaluateContextGate({
+                        probe,
+                        maxContextTokens : gateConfig.maxContextTokens,
+                        warnContextTokens: gateConfig.warnContextTokens
+                    });
+
+                    if (gate.action === 'defer') {
+                        const deferCount = (dispatching.deferCount || 0) + 1;
+
+                        await state.transition(record.recordKey, 'dispatching', 'pending', {
+                            deferCount,
+                            deferredAt         : new Date().toISOString(),
+                            deferReason        : `context-gate:${gate.contextTokens}>${gateConfig.maxContextTokens}`,
+                            lastGateOutcome    : gate.gateOutcome,
+                            probedContextTokens: gate.contextTokens
+                        });
+                        logger.warn?.(
+                            `[Wake Receiver] context gate DEFERRED ${record.subscriptionId}: session at ` +
+                            `${gate.contextTokens} tokens (> ${gateConfig.maxContextTokens}); the wake waits for ` +
+                            `compaction or session rotation, mailbox stays authoritative (defer #${deferCount})`
+                        );
+                        continue;
+                    }
+                    if (gate.gateOutcome === 'unknown') {
+                        logger.warn?.(
+                            `[Wake Receiver] context gate could not probe ${record.subscriptionId}; ` +
+                            `delivering fail-open (never silently withheld)`
+                        );
+                    } else if (gate.gateOutcome === 'warn') {
+                        logger.warn?.(
+                            `[Wake Receiver] context gate warns ${record.subscriptionId}: session at ` +
+                            `${gate.contextTokens} tokens, defers above ${gateConfig.maxContextTokens}; delivering`
+                        );
+                    }
+                }
 
                 let outcome = 'failed';
                 let outcomeReason;
@@ -323,6 +393,8 @@ export function createWakeReceiver({
  * @param {String} options.host Explicit IP literal on which the host receiver listens.
  * @param {Number} options.port
  * @param {Object} [options.logger=console]
+ * @param {Number} [options.reconcileIntervalMs]
+ * @param {Number} [options.drainIntervalMs=DRAIN_RETRY_INTERVAL_MS]
  * @returns {Promise<{server:http.Server,state:WakeReceiverState,drain:Function}>}
  */
 export async function startWakeReceiver({
@@ -331,7 +403,8 @@ export async function startWakeReceiver({
     host,
     port,
     logger = console,
-    reconcileIntervalMs = MANIFEST_RECONCILE_INTERVAL_MS
+    reconcileIntervalMs = MANIFEST_RECONCILE_INTERVAL_MS,
+    drainIntervalMs     = DRAIN_RETRY_INTERVAL_MS
 } = {}) {
     if (net.isIP(host) === 0) {
         throw new Error('Wake receiver requires an explicit IP-literal --host');
@@ -462,6 +535,11 @@ export async function startWakeReceiver({
 
     reconcileTimer.unref?.();
 
+    // The context gate's flush clock — see DRAIN_RETRY_INTERVAL_MS.
+    const drainTimer = setInterval(() => { void drain() }, drainIntervalMs);
+
+    drainTimer.unref?.();
+
     /**
      * @summary Releases only the filesystem watcher, leaving the periodic sweep running.
      *
@@ -476,13 +554,15 @@ export async function startWakeReceiver({
     };
 
     /**
-     * @summary Releases the watcher and the sweep. Callers that own the process lifetime (tests, a
-     * supervisor) need a way to stop them; the daemon itself never calls this.
+     * @summary Releases the watcher, the sweep, and the gate's drain retry timer. Callers that own
+     * the process lifetime (tests, a supervisor) need a way to stop them; the daemon itself never
+     * calls this.
      * @returns {void}
      */
     const stopWatchingManifest = () => {
         stopManifestWatcher();
         clearInterval(reconcileTimer);
+        clearInterval(drainTimer);
     };
 
     // SIGHUP stays. It is the documented escape hatch and the delivered contract of the predecessor

--- a/ai/daemons/wake/receiverState.mjs
+++ b/ai/daemons/wake/receiverState.mjs
@@ -152,6 +152,12 @@ export class WakeReceiverState {
 
     /**
      * @summary Atomically transitions a record when its current state matches the expected state.
+     *
+     * `dispatching → pending` is the context gate's deferral path: the gate runs after the
+     * non-idempotency marker is taken, finds the target session over budget, and returns the record
+     * to the only replayable state. A crash between defer and re-dispatch replays from `pending` —
+     * never from `dispatching` — so the defer cannot duplicate a GUI side effect.
+     *
      * @param {String} recordKey
      * @param {String} expectedState
      * @param {String} nextState
@@ -159,7 +165,7 @@ export class WakeReceiverState {
      * @returns {Promise<Object|null>} Updated record, or null when another actor already advanced it.
      */
     async transition(recordKey, expectedState, nextState, details = {}) {
-        if (nextState !== 'dispatching' && !TERMINAL_STATES.has(nextState)) {
+        if (!['dispatching', REPLAYABLE_STATE].includes(nextState) && !TERMINAL_STATES.has(nextState)) {
             throw new Error(`Unsupported receiver state transition target '${nextState}'`);
         }
 

--- a/test/playwright/unit/ai/daemons/wake/buildReceiverManifest.spec.mjs
+++ b/test/playwright/unit/ai/daemons/wake/buildReceiverManifest.spec.mjs
@@ -6,6 +6,7 @@ import path                                                       from 'node:pat
 
 import {
     buildWakeReceiverManifest,
+    DEFAULT_CONTEXT_GATE,
     fingerprintSigningKey,
     parseManifestBuilderArgs,
     readPublishedRoutes,
@@ -428,8 +429,38 @@ test.describe('runManifestBuilder — per-peer composition', () => {
 
         expect(manifest.routes[codexSubscription.id].adapterConfig).toEqual({
             attemptTimeoutMs: 10000,
-            codexBinary     : '/usr/local/bin/codex'
+            codexBinary     : '/usr/local/bin/codex',
+            contextGate     : DEFAULT_CONTEXT_GATE
         })
+    });
+
+    test('stamps the #16682 context gate on every route, merging per-route overrides over the defaults', () => {
+        const plain = {
+            id                   : 'WAKE_SUB:plain',
+            status               : 'active',
+            agentIdentity        : '@neo-kimi-phoebe',
+            harnessTarget        : 'a2a-webhook',
+            harnessTargetMetadata: {adapter: 'opencode-server', signingKey: 'c'.repeat(64)}
+        };
+        const tuned = {
+            id                   : 'WAKE_SUB:tuned',
+            status               : 'active',
+            agentIdentity        : '@neo-kimi-iris',
+            harnessTarget        : 'a2a-webhook',
+            harnessTargetMetadata: {adapter: 'kimi-pull-bridge', signingKey: 'd'.repeat(64)}
+        };
+
+        const {manifest} = buildWakeReceiverManifest({
+            subscriptions    : [plain, tuned],
+            adapterConfigById: {[tuned.id]: {contextGate: {maxContextTokens: 400_000}}}
+        });
+
+        expect(manifest.routes[plain.id].adapterConfig.contextGate).toEqual(DEFAULT_CONTEXT_GATE);
+        // A per-key merge, not a wholesale replacement: the warn default survives a max override.
+        expect(manifest.routes[tuned.id].adapterConfig.contextGate).toEqual({
+            maxContextTokens : 400_000,
+            warnContextTokens: DEFAULT_CONTEXT_GATE.warnContextTokens
+        });
     });
 });
 
@@ -764,7 +795,8 @@ test.describe('runManifestBuilder — strict-lock + boot truths', () => {
 
             expect(published[codexSubscription.id].adapterConfig).toEqual({
                 attemptTimeoutMs: 10000,
-                codexBinary     : '/usr/local/bin/codex'
+                codexBinary     : '/usr/local/bin/codex',
+                contextGate     : DEFAULT_CONTEXT_GATE
             });
             expect(published[codexSubscription.id].harnessTargetMetadata.addressType).toBe(INSTANCE.type);
             expect(published[codexSubscription.id].harnessTargetMetadata.appName).toBe('Codex')

--- a/test/playwright/unit/ai/daemons/wake/contextGatePolicy.spec.mjs
+++ b/test/playwright/unit/ai/daemons/wake/contextGatePolicy.spec.mjs
@@ -1,0 +1,68 @@
+import {test, expect} from '@playwright/test';
+import {
+    DEFAULT_CONTEXT_GATE_MAX_TOKENS,
+    DEFAULT_CONTEXT_GATE_WARN_TOKENS,
+    evaluateContextGate
+} from '../../../../../../ai/daemons/wake/contextGatePolicy.mjs';
+
+test.describe('ai/daemons/wake/contextGatePolicy (#16682 budget-cliff guard)', () => {
+    const limits = {
+        maxContextTokens : DEFAULT_CONTEXT_GATE_MAX_TOKENS,
+        warnContextTokens: DEFAULT_CONTEXT_GATE_WARN_TOKENS
+    };
+    const probe = contextTokens => ({contextTokens, lastActivityAt: 1_786_190_000_000, sessionId: 'ses_test'});
+
+    test.describe('evaluateContextGate', () => {
+        test('defers above the max threshold — the cliff turn never starts', () => {
+            const gate = evaluateContextGate({probe: probe(limits.maxContextTokens + 1), ...limits});
+
+            expect(gate).toEqual({
+                action       : 'defer',
+                gateOutcome  : 'deferred',
+                contextTokens: limits.maxContextTokens + 1
+            });
+        });
+
+        test('delivers at the max threshold boundary (defer is strictly greater-than)', () => {
+            const gate = evaluateContextGate({probe: probe(limits.maxContextTokens), ...limits});
+
+            expect(gate.action).toBe('deliver');
+            expect(gate.gateOutcome).toBe('warn');
+        });
+
+        test('warns but delivers inside the warn band — the seat sees the approach', () => {
+            const gate = evaluateContextGate({probe: probe(limits.warnContextTokens), ...limits});
+
+            expect(gate).toMatchObject({action: 'deliver', gateOutcome: 'warn'});
+        });
+
+        test('delivers quietly below the warn band', () => {
+            const gate = evaluateContextGate({probe: probe(limits.warnContextTokens - 1), ...limits});
+
+            expect(gate).toMatchObject({action: 'deliver', gateOutcome: 'within'});
+        });
+
+        test('a fresh-boot-sized context always delivers — rotation flushes a deferral by construction', () => {
+            const gate = evaluateContextGate({probe: probe(60_000), ...limits});
+
+            expect(gate).toMatchObject({action: 'deliver', gateOutcome: 'within'});
+        });
+
+        test('unknown context fails OPEN — never silently withheld (#16526 lesson)', () => {
+            for (const probeValue of [null, undefined, {}, {contextTokens: Number.NaN}]) {
+                const gate = evaluateContextGate({probe: probeValue ?? null, ...limits});
+
+                expect(gate).toEqual({action: 'deliver', gateOutcome: 'unknown', contextTokens: null});
+            }
+        });
+
+        test('there is no time-based flush: a session that stays large defers forever', () => {
+            // The probe always reads CURRENT state, so a stale-but-still-large session keeps
+            // deferring no matter how old the wake is — flushing into it would be the 97→100%
+            // cliff event this module exists to prevent.
+            const ancient = {contextTokens: 700_000, lastActivityAt: 1, sessionId: 'ses_old'};
+
+            expect(evaluateContextGate({probe: ancient, ...limits}).action).toBe('defer');
+        });
+    });
+});

--- a/test/playwright/unit/ai/daemons/wake/localWakeAdapters.spec.mjs
+++ b/test/playwright/unit/ai/daemons/wake/localWakeAdapters.spec.mjs
@@ -2,7 +2,8 @@ import {test, expect} from '@playwright/test';
 
 import {
     dispatchLocalWake,
-    formatLocalWakeDigest
+    formatLocalWakeDigest,
+    probeSessionContext
 } from '../../../../../../ai/daemons/wake/localWakeAdapters.mjs';
 
 test.describe.serial('ai/daemons/wake/localWakeAdapters', () => {
@@ -396,5 +397,99 @@ test.describe.serial('ai/daemons/wake/localWakeAdapters', () => {
         expect(script).toContain('key code 36');
         // …and no Codex-only Esc prelude: the OpenCode route gets the generic submit, not a quirk.
         expect(script).not.toContain('key code 53');
+    });
+
+    test.describe('probeSessionContext (#16682 context gate)', () => {
+        const openCodeRecord = () => record('opencode-server');
+        const kimiRecord     = () => record('kimi-pull-bridge');
+
+        const openCodeEnvelope = JSON.stringify({
+            hostname : '127.0.0.1',
+            port     : 63181,
+            sessionId: 'ses_probe',
+            projectId: 'proj',
+            directory: '/seat',
+            username : 'opencode',
+            password : 'secret'
+        });
+
+        const messageList = [
+            {info: {role: 'assistant', time: {created: 1000}, tokens: {input: 40_000, cache: {read: 300_000}}}},
+            {info: {role: 'user',      time: {created: 2000}}},
+            {info: {role: 'assistant', time: {created: 3000}, tokens: {input: 12_000, cache: {read: 438_000}}}}
+        ];
+
+        test('reads context occupancy from the opencode server message API', async () => {
+            let   requestedUrl = null;
+            const probe        = await probeSessionContext(openCodeRecord(), {
+                homedir: () => '/home/seat',
+                fs     : {readFile: async () => openCodeEnvelope},
+                fetch  : async url => {
+                    requestedUrl = url;
+                    return {ok: true, json: async () => messageList};
+                }
+            });
+
+            expect(requestedUrl).toBe('http://127.0.0.1:63181/session/ses_probe/message?limit=30');
+            // The NEWEST assistant turn owns the occupancy — 12k fresh + 438k cached, not the older one.
+            expect(probe).toEqual({contextTokens: 450_000, lastActivityAt: 3000, sessionId: 'ses_probe'});
+        });
+
+        test('an unreadable opencode server fails open to null', async () => {
+            const probe = await probeSessionContext(openCodeRecord(), {
+                homedir: () => '/home/seat',
+                fs     : {readFile: async () => openCodeEnvelope},
+                fetch  : async () => { throw new Error('ECONNREFUSED'); }
+            });
+
+            expect(probe).toBeNull();
+        });
+
+        test('reads the kimi seat from the wire.jsonl tail, newest usage line wins', async () => {
+            const wireLines = [
+                JSON.stringify({usage: {inputOther: 5_000, inputCacheRead: 100_000}, time: 1_786_190_000_000}),
+                JSON.stringify({usage: {inputOther: 4_900, inputCacheRead: 438_000}, time: 1_786_190_600_000}),
+                '' // trailing newline of a jsonl tail
+            ].join('\n');
+            const kimiFs = {
+                readFile  : async () => JSON.stringify({sessionId: 'session_abc', cwd: '/seat'}),
+                readdir   : async () => ['wd_neo_1'],
+                pathExists: async () => true,
+                stat      : async () => ({size: wireLines.length + 262_000}), // forces the tail-read branch
+                open      : async () => ({
+                    read : async buffer => { buffer.write(wireLines); },
+                    close: async () => {}
+                })
+            };
+
+            const probe = await probeSessionContext(kimiRecord(), {homedir: () => '/home/seat', fs: kimiFs});
+
+            expect(probe).toEqual({
+                contextTokens : 442_900,
+                lastActivityAt: 1_786_190_600_000,
+                sessionId     : 'session_abc'
+            });
+        });
+
+        test('a kimi wire ledger without usage lines fails open to null', async () => {
+            const kimiFs = {
+                readFile  : async () => JSON.stringify({sessionId: 'session_abc', cwd: '/seat'}),
+                readdir   : async () => ['wd_neo_1'],
+                pathExists: async () => true,
+                stat      : async () => ({size: 100}),
+                open      : async () => ({
+                    read : async buffer => { buffer.write('{"noUsage":true}\n'); },
+                    close: async () => {}
+                })
+            };
+
+            expect(await probeSessionContext(kimiRecord(), {homedir: () => '/home/seat', fs: kimiFs})).toBeNull();
+        });
+
+        test('adapters without local context authority (osascript, tmux, test) return null', async () => {
+            for (const adapter of ['osascript', 'tmux', 'test']) {
+                expect(await probeSessionContext(record(adapter), {})).toBeNull();
+            }
+        });
     });
 });

--- a/test/playwright/unit/ai/daemons/wake/receiver.spec.mjs
+++ b/test/playwright/unit/ai/daemons/wake/receiver.spec.mjs
@@ -558,3 +558,202 @@ test.describe('ai/daemons/wake/receiver — manifest reload', () => {
         expect(await waitFor(async () => await probe(peer) === 401)).toBe(true);
     });
 });
+
+test.describe('ai/daemons/wake/receiver — context gate (#16682)', () => {
+    const subscriptionId = 'WAKE_SUB:gate-test';
+    const signingKey     = 'b'.repeat(64);
+    const agentIdentity  = '@neo-kimi-phoebe';
+    const manifest       = {
+        schemaVersion: 1,
+        routes       : {
+            [subscriptionId]: {
+                signingKey,
+                agentIdentity,
+                harnessTargetMetadata: {adapter: 'test'},
+                adapterConfig        : {
+                    attemptTimeoutMs: 100,
+                    contextGate     : {maxContextTokens: 250_000, warnContextTokens: 200_000}
+                }
+            }
+        }
+    };
+    const ungatedManifest = {
+        schemaVersion: 1,
+        routes       : {
+            [subscriptionId]: {
+                signingKey,
+                agentIdentity,
+                harnessTargetMetadata: {adapter: 'test'},
+                adapterConfig        : {attemptTimeoutMs: 100}
+            }
+        }
+    };
+
+    let baseUrl, dispatchCalls, probeCalls, probeResult, receiver, server, state, stateDir, warnLines;
+
+    const buildEnvelope = () => ({
+        schemaVersion: '1.0',
+        eventType    : 'wake/digest',
+        eventId      : 'wake-digest:gate-1',
+        subscriptionId,
+        agentIdentity,
+        payload      : {
+            totalEvents   : 1,
+            sourceEventIds: ['MESSAGE:gate-1'],
+            breakdown     : {sent_to_me: {count: 1, latest: {messageId: 'MESSAGE:gate-1', subject: 'gate'}}}
+        },
+        emittedAt: new Date().toISOString()
+    });
+
+    async function postWake() {
+        const envelope = buildEnvelope();
+        const body     = JSON.stringify(envelope);
+
+        return fetch(`${baseUrl}/wake`, {
+            method : 'POST',
+            headers: {
+                'content-type'              : 'application/json',
+                'x-neo-wake-event-id'       : envelope.eventId,
+                'x-neo-wake-subscription-id': subscriptionId,
+                'x-neo-wake-schema-version' : '1.0',
+                'x-neo-wake-signature'      : crypto.createHmac('sha256', signingKey).update(body).digest('hex')
+            },
+            body
+        });
+    }
+
+    async function waitForRecord(predicate) {
+        for (let index = 0; index < 100; index++) {
+            const hit = (await state.list()).find(predicate);
+            if (hit) return hit;
+            await new Promise(resolve => setTimeout(resolve, 5));
+        }
+        return null;
+    }
+
+    async function waitForFlag(check) {
+        for (let index = 0; index < 100; index++) {
+            if (check()) return true;
+            await new Promise(resolve => setTimeout(resolve, 5));
+        }
+        return false;
+    }
+
+    async function bootReceiver(activeManifest) {
+        receiver = createWakeReceiver({
+            manifest    : activeManifest,
+            state,
+            dispatch    : async record => { dispatchCalls.push(record); return 'delivered'; },
+            contextProbe: async record => { probeCalls.push(record); return probeResult; },
+            logger      : {error() {}, log() {}, warn(line) { warnLines.push(line); }}
+        });
+        server = receiver.server;
+        await new Promise((resolve, reject) => {
+            server.once('error', reject);
+            server.listen(0, '127.0.0.1', resolve);
+        });
+        baseUrl = `http://127.0.0.1:${server.address().port}`;
+    }
+
+    test.beforeEach(async () => {
+        stateDir = await fs.mkdtemp(path.join(os.tmpdir(), 'neo-wake-gate-'));
+        state    = new WakeReceiverState({stateDir});
+        await state.init();
+        dispatchCalls = [];
+        probeCalls    = [];
+        warnLines     = [];
+        probeResult   = null;
+    });
+
+    test.afterEach(async () => {
+        if (server) await new Promise(resolve => server.close(resolve));
+        await fs.rm(stateDir, {recursive: true, force: true});
+    });
+
+    test('an over-budget session defers: no dispatch, record returns to pending with the reason', async () => {
+        probeResult = {contextTokens: 700_000, lastActivityAt: Date.now(), sessionId: 'ses_big'};
+        await bootReceiver(manifest);
+
+        await postWake();
+        // A record is `pending` from accept until the gate runs — wait for the DEFERRAL, not the state.
+        const deferred = await waitForRecord(record => record.deferCount >= 1);
+
+        expect(dispatchCalls).toHaveLength(0);
+        expect(probeCalls).toHaveLength(1);
+        expect(deferred).toMatchObject({
+            state              : 'pending',
+            deferCount         : 1,
+            deferReason        : 'context-gate:700000>250000',
+            probedContextTokens: 700_000
+        });
+        // The warn lands in the same drain iteration but after the state write the poll observes.
+        expect(await waitForFlag(() => warnLines.some(line => line.includes('DEFERRED')))).toBe(true);
+    });
+
+    test('a deferral flushes on the next drain once the session shrinks or rotates', async () => {
+        probeResult = {contextTokens: 700_000, lastActivityAt: Date.now(), sessionId: 'ses_big'};
+        await bootReceiver(manifest);
+
+        await postWake();
+        expect(await waitForRecord(record => record.deferCount >= 1)).toBeTruthy();
+
+        probeResult = {contextTokens: 45_000, lastActivityAt: Date.now(), sessionId: 'ses_fresh'};
+        await receiver.drain();
+
+        expect(await waitForRecord(record => record.state === 'delivered')).toBeTruthy();
+        expect(dispatchCalls).toHaveLength(1);
+    });
+
+    test('unknown context delivers fail-open with a loud warn — never silently withheld', async () => {
+        probeResult = null;
+        await bootReceiver(manifest);
+
+        await postWake();
+
+        expect(await waitForRecord(record => record.state === 'delivered')).toBeTruthy();
+        expect(dispatchCalls).toHaveLength(1);
+        expect(warnLines.join('\n')).toContain('fail-open');
+    });
+
+    test('the warn band delivers with an approaching-gate warning', async () => {
+        probeResult = {contextTokens: 220_000, lastActivityAt: Date.now(), sessionId: 'ses_warm'};
+        await bootReceiver(manifest);
+
+        await postWake();
+
+        expect(await waitForRecord(record => record.state === 'delivered')).toBeTruthy();
+        expect(warnLines.join('\n')).toContain('warns');
+    });
+
+    test('a legacy route without contextGate skips the gate and the probe entirely', async () => {
+        await bootReceiver(ungatedManifest);
+
+        await postWake();
+
+        expect(await waitForRecord(record => record.state === 'delivered')).toBeTruthy();
+        expect(probeCalls).toHaveLength(0);
+        expect(warnLines).toHaveLength(0);
+    });
+
+    test('the manifest loader validates contextGate shape when present', async () => {
+        const route = overrides => ({
+            signingKey,
+            agentIdentity,
+            harnessTargetMetadata: {adapter: 'opencode-server'},
+            adapterConfig        : {attemptTimeoutMs: 100, ...overrides}
+        });
+        const load = contextGate => {
+            const dir = stateDir;
+            return fs.writeFile(path.join(dir, 'manifest.json'), JSON.stringify({
+                schemaVersion: 1,
+                routes       : {[subscriptionId]: route({contextGate})}
+            }), {mode: 0o600}).then(() => loadWakeReceiverManifest(path.join(dir, 'manifest.json')));
+        };
+
+        await expect(load({maxContextTokens: 250_000, warnContextTokens: 200_000})).resolves.toBeDefined();
+        await expect(load({maxContextTokens: 0, warnContextTokens: 0})).rejects.toThrow('contextGate');
+        await expect(load({maxContextTokens: 100_000, warnContextTokens: 250_000})).rejects.toThrow('contextGate');
+        await expect(load({maxContextTokens: 250_000})).rejects.toThrow('contextGate');
+        await expect(load('not-an-object')).rejects.toThrow('contextGate');
+    });
+});

--- a/test/playwright/unit/ai/daemons/wake/receiverState.spec.mjs
+++ b/test/playwright/unit/ai/daemons/wake/receiverState.spec.mjs
@@ -84,4 +84,29 @@ test.describe('ai/daemons/wake/receiverState', () => {
         expect(await state.transition(accepted.record.recordKey, 'pending', 'dispatching')).toBeNull();
         expect((await state.read(accepted.record.recordKey)).state).toBe('delivered');
     });
+
+    test('dispatching returns to pending on a context-gate deferral (#16682), keeping the wake replayable', async () => {
+        const accepted = await accept();
+        await state.transition(accepted.record.recordKey, 'pending', 'dispatching');
+
+        const deferred = await state.transition(accepted.record.recordKey, 'dispatching', 'pending', {
+            deferCount         : 1,
+            deferReason        : 'context-gate:700000>250000',
+            probedContextTokens: 700_000
+        });
+
+        expect(deferred).toMatchObject({
+            state              : 'pending',
+            deferCount         : 1,
+            deferReason        : 'context-gate:700000>250000',
+            probedContextTokens: 700_000
+        });
+
+        // The deferred record stays in the only replayable state: the next drain picks it up…
+        expect(await state.list('pending')).toHaveLength(1);
+        // …a boot recovery does NOT terminalize it (only crash-interrupted dispatches are)…
+        expect(await state.recoverInterrupted()).toBe(0);
+        // …and it can re-enter dispatch cleanly when the session shrinks or rotates.
+        expect(await state.transition(accepted.record.recordKey, 'pending', 'dispatching')).not.toBeNull();
+    });
 });


### PR DESCRIPTION
Resolves #16682

A wake delivered into a marathon session now defers instead of starting the cliff turn. The signed host wake receiver evaluates a per-route context gate after taking the non-idempotency marker and before any adapter runs: above `maxContextTokens` (default 250K) the record returns to `pending` with the deferral reason durably stamped, and a 60s retry sweep re-evaluates until the session compacts or rotates — the probe always reads *current* session state, so both flush conditions collapse into one size read, and there is deliberately no time-based flush (flushing into a stale large session is the 97→100% event). Unknown context fails **open** (deliver + loud warn): the wake is a notification, the mailbox is the authority, and silent non-delivery is the failure mode this family of tickets exists to kill. Motivating telemetry on #16682: 61% of a seat's lifetime processed tokens came from >500K-context turns; a >1h-idle ~700K resume re-bills at ~0% cache hits.

Evidence: L2 (receiver is host-local launchd scope; gate behavior fully exercisable in-process) → L2 required (the delivered ACs are drain-loop decisions + durable record states). Residual: none on #16682 — the reporter + wake-carried session-cost line were split to #16707 (2026-08-08, for reviewability: drafts cannot receive formal reviews); AC-8 is the operator's post-merge dashboard read. Live-traffic observation of a real deferral is post-merge on the operator machine (needs a regenerated manifest — see Post-Merge Validation).

## Deltas from ticket

- **Thresholds live in the receiver's own config channel, not AiConfig** (amends AC-3/AC-9, recorded on the ticket before this PR): ADR-0019 §10.7 places the graphless host receiver outside AiConfig by design. The shape mirrors `attemptTimeoutMs`: no receiver-side defaults, every route states its policy, `buildReceiverManifest` stamps `DEFAULT_CONTEXT_GATE` with per-key `--adapter-config` overrides. Single declaration point: `contextGatePolicy.mjs`.
- **`warmWindow` is documented rationale + reporter instrumentation, not an unconsumed leaf** (amends AC-9's shape): at the receiver the warm window has no decision to feed — sub-threshold wakes deliver immediately (always beats the deadline), and a deferred wake must outlast any window. It lands in the reporter's `gaps > warmWindow` incidence column (now #16707 AC-1/AC-3). Challenge welcome on the ticket thread.
- **Scope split (post-open, operator-observed):** the reporter leaf + seat-visible session-cost line moved to #16707 so this PR closes a fully delivered leaf. Iris's offer on the reporter stands as first-comment claim rights on #16707; implementation defaults to me after this review cycle.
- Probe coverage: `opencode-server` (live-verified against a running seat's server API) and `kimi-server`/`kimi-pull-bridge` (wire.jsonl tail-read) return real sizes; other adapters return `null` → fail-open. Adding a probe is one function per adapter at the existing seam.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/ai/daemons/wake/` → **287/287 passed** at head (new: `contextGatePolicy.spec.mjs` decision table incl. boundary + no-time-based-flush; receiver drain-level defer/flush/fail-open/warn-band/legacy-ungated + loader validation; receiverState defer-transition replayability; adapter probe shapes for both harnesses; manifest stamping + override merge).
- Full `npm run test-unit` → **11,820 passed**, 5 failures reproducing only under full-suite load and passing in isolated re-run (68/68) — the known ambient class (`#16620`); none in files this diff touches.
- `npm run agent-preflight -- --change-class capability ...` → all gates passed (ticket-archaeology scrub included).
- Surface coverage: wake receiver/adapters/manifest tooling — covered above; no app/feature surface touched.

## Post-Merge Validation

- [ ] Regenerate the receiver manifest on the operator machine (`buildReceiverManifest`) so live routes carry `contextGate`; until then legacy routes deliver ungated by design.
- [ ] Observe one real deferral in the launchd receiver log (`context gate DEFERRED …`) during a marathon session; confirm the flush lands after compaction/rotation within one retry interval.
- [ ] First real fail-open warn line (if any adapter's probe breaks) names the subscription and delivers.

## Commits

- `14cbe07a50` — gate policy module, drain-loop integration + retry sweep, defer transition, per-harness probes, manifest stamping/validation, 14 new/changed specs.

Authored by Phoebe (Kimi k3, opencode). Session ses_01ed929e9ffe1kG4Ne612BUHhT.
