### PR TITLE
fix(harness): make plane declaration outrank host ownership (#16693)

### DIFF
--- a/ai/scripts/lifecycle/local-agent-os/README.md
+++ b/ai/scripts/lifecycle/local-agent-os/README.md
@@ -98,6 +98,34 @@ docker compose --env-file .env \
   --profile cloud exec mc-server cat /app/.neo-revision
 ```
 
+## Bind the host Fleet transport to this plane
+
+The local canonical ingress is `http://127.0.0.1:3102`. Declare it in the
+environment that launches the harness, together with a dedicated,
+identity-bound plane credential for that resident:
+
+```sh
+export NEO_FLEET_PLANE_BASE="http://127.0.0.1:3102"
+: "${NEO_FLEET_PLANE_BEARER:?load a dedicated identity-bound plane credential from the external secret store first}"
+export NEO_FLEET_PLANE_BEARER
+```
+
+Persist those two names in the external launcher or secret store when the
+harness must survive a shell restart; never put the bearer in this repository.
+`NEO_FLEET_PLANE_BEARER` is MCP admission for this resident's Fleet transport.
+It is a different credential class from the app-to-Fleet
+`NEO_FLEET_BEARER`, the seat-side MCP slot `NEO_MCP_REMOTE_TOKEN`, and any
+repository-workflow credential such as `GH_TOKEN`; do not copy or alias one of
+those values into it.
+
+A nonempty `NEO_FLEET_PLANE_BASE` is a topology declaration, not a health
+probe. `npm --prefix harness run start:brain` will therefore start or reuse only
+the host Fleet transport. If the ingress is down or the bearer resolves to the
+wrong viewer, the transport's authenticated init fails closed and the harness
+reports the boot failure; it never falls through to a host-native organism.
+Leave the base empty only on a machine intentionally using the host-native
+fresh-install path.
+
 ## Install the host edge (macOS, supervised)
 
 This section is macOS-only: `launchctl` and `plutil` do not exist elsewhere. It

--- a/harness/README.md
+++ b/harness/README.md
@@ -65,24 +65,31 @@ falsified in this repo by the native-ABI split: `better-sqlite3` builds for one 
 shared `node_modules` must keep serving the system-Node dev loop (the verdict + reproduction
 probe live on the hosting-spike ticket).
 
-**`start:brain` is ATTACH-OR-OWN (the dev-machine safety contract).** The orchestrator performs
-single-instance TAKEOVER (on boot it SIGTERMs any PID in its PID file) and its supervisor REAPS
-foreign listeners on supervised singleton ports — a second organism beside a live canonical Brain
-is never safe, and never useful (the Fleet Manager should manage the REAL fleet). So the product
-boot resolves the live state through the config SSOT and:
+**`start:brain` is PLANE-ATTACH / ATTACH / OWN (the dev-machine safety contract).** The topology
+declaration is resolved through the config SSOT before host liveness can select ownership:
 
-- **attach** — a live orchestrator is detected (PID file + command check): the harness starts
-  only what is missing (the fleet transport, when `:8083` is not already listening) and on quit
-  stops exactly what IT started. The canonical Brain is never touched.
-- **own** — nothing is up (the fresh-machine / packaged-app shape): the harness starts the whole
-  organism on the default canonical-layout paths, and quitting tears the full tree down.
+- **plane-attach** — `fleet.planeBase` is nonempty: the harness starts only the missing Fleet
+  transport. Full host own-mode is unreachable even when the configured plane is down; the
+  transport's existing authenticated admission refuses that boot instead of creating a competing
+  organism.
+- **attach** — no plane is declared and a live orchestrator is detected (PID file + command
+  check): the harness starts only the missing Fleet transport and stops exactly what IT started.
+- **own** — no plane is declared and no host orchestrator is live (the true fresh-machine /
+  packaged-app shape): the harness starts the whole organism on the default canonical-layout paths,
+  and quitting tears the full tree down.
+
+This order is the safety property. The orchestrator performs single-instance TAKEOVER and its
+supervisor REAPS foreign listeners on singleton ports; temporary plane unavailability must never
+fall through to a second host organism.
 
 **The smoke runs a fully ISOLATED organism instead.** `brain.mjs#buildBrainProfile` binds every
 mutable path the spawned tree consumes under `harness/.brain/smoke/` (orchestrator data dir, the
 graph sqlite, Chroma persist dir, fleet instance root, backup target, REM run-state), moves every
 exercised listener to a runtime-allocated port, and gates every other lane OFF via its config
 env switch (dev server, Neural Link, embed/message daemons, mlx/ollama/lms, swarm heartbeat, the
-sync + enrichment lanes, deployment-state bridge). The matrix is EXECUTABLE, not documentation:
+sync + enrichment lanes, deployment-state bridge). Both plane-binding leaves are explicitly empty
+in smoke, so machine-level exports cannot redirect its Fleet process into the canonical plane. The
+matrix is EXECUTABLE, not documentation:
 `resolveBrainPaths` re-resolves the leaves through `ai/config.mjs` itself under the profile env,
 and the smoke fails on any leaf escaping the isolation root — by FILESYSTEM IDENTITY (ancestor
 symlinks resolved on both sides), asserting what the tree actually consumes, not what the profile

--- a/harness/brain.mjs
+++ b/harness/brain.mjs
@@ -9,15 +9,15 @@
 //   §2.1.4  port discipline — smoke ports are runtime-allocated by this lifecycle owner
 //   §2.1.5  teardown on quit — process-GROUP SIGINT, bounded grace, group SIGKILL; settle-or-reject
 //
-// ATTACH-OR-OWN (the dev-machine safety contract): the orchestrator daemon performs
-// single-instance TAKEOVER — on boot it SIGTERMs any PID in its PID file — and its supervised
-// children hold singleton ports it reaps foreign listeners from. A second organism beside a live
-// canonical Brain is therefore never safe OR useful (the Fleet Manager should manage the REAL
-// fleet). So the product boot ATTACHES when a Brain is already alive (supervising only the missing
-// fleet transport) and OWNS the full organism only when nothing is up (a fresh machine — the
-// packaged-app shape). Full isolation exists for the SMOKE profile only, where every mutable
-// path/listener the spawned tree consumes is bound under one throwaway root and asserted through
-// the config SSOT itself (resolveBrainPaths) before anything spawns.
+// PLANE-ATTACH / ATTACH / OWN (the dev-machine safety contract): a declared containerized plane
+// outranks host-process observation and admits only the missing Fleet transport. Without that
+// declaration, a live host orchestrator selects attach; only a truly fresh machine selects full
+// ownership. This order matters because the orchestrator daemon performs single-instance TAKEOVER
+// and its supervised children reap foreign singleton listeners — starting a host organism while a
+// declared plane is merely down would be the most destructive fallback. Full isolation exists for
+// the SMOKE profile only, where every mutable path/listener the spawned tree consumes is bound
+// under one throwaway root and asserted through the config SSOT itself (resolveBrainPaths) before
+// anything spawns.
 //
 // Teardown is process-GROUP-based: children spawn `detached` into their own group, so
 // SIGINT/SIGKILL on `-pid` reaches every descendant — including grandchildren the orchestrator's
@@ -94,6 +94,31 @@ export function resolveBrainMode({packaged, env}) {
 }
 
 /**
+ * @summary Resolves the product Brain launch plan from declared topology plus observed local
+ * processes. A configured plane is authority even when its ingress is currently unreachable:
+ * selecting full host ownership at that moment would create the competing organism this guard is
+ * meant to prevent. Readiness remains the Fleet transport's authenticated responsibility.
+ * @param {Object} options
+ * @param {String} options.planeBase Resolved `AiConfig.fleet.planeBase` declaration.
+ * @param {Boolean} options.orchestratorAlive Observed host-orchestrator liveness.
+ * @param {Boolean} options.fleetServing Observed canonical Fleet transport availability.
+ * @returns {{mode: 'plane-attach'|'attach'|'own', planeBase: String|null, startFleet: Boolean, startOrchestrator: Boolean}}
+ */
+export function resolveProductBrainPlan({planeBase, orchestratorAlive, fleetServing}) {
+    const configuredPlaneBase = typeof planeBase === 'string' ? planeBase.trim() : '';
+    const mode                = configuredPlaneBase
+        ? 'plane-attach'
+        : orchestratorAlive ? 'attach' : 'own';
+
+    return {
+        mode,
+        planeBase        : configuredPlaneBase || null,
+        startFleet       : fleetServing !== true,
+        startOrchestrator: mode === 'own'
+    }
+}
+
+/**
  * @summary Allocates a free loopback TCP port via a zero-port listen. The classic race (another
  * process binding between close and child bind) is accepted: the child's own bind failure exits
  * it early, which the readiness contract converts into a deterministic boot rejection.
@@ -146,7 +171,7 @@ export function probePort({port, host = '127.0.0.1', timeoutMs = 1500}) {
  * @param {String} options.repoRoot
  * @param {Object} [options.env] Env fragment merged over process.env for the resolver child.
  * @param {Function} [options.execFileFn=execFile] Injection seam for tests.
- * @returns {Promise<Object>} `{chromaDataDir, chromaPort, dbPath, fleetInstanceRoot, orchestratorDataDir}`
+ * @returns {Promise<Object>} Resolved Brain paths, ports, and `fleetPlaneBase` topology declaration.
  */
 export function resolveBrainPaths({repoRoot, env = {}, execFileFn = execFile}) {
     const script = [
@@ -161,6 +186,7 @@ export function resolveBrainPaths({repoRoot, env = {}, execFileFn = execFile}) {
         "    chromaPort         : AiConfig.engines.chroma.port,",
         "    dbPath             : AiConfig.orchestrator.dbPath,",
         "    fleetInstanceRoot  : AiConfig.fleet.instanceRoot,",
+        "    fleetPlaneBase     : AiConfig.fleet.planeBase,",
         "    orchestratorDataDir: AiConfig.orchestrator.dataDir",
         "}));"
     ].join('\n');
@@ -218,8 +244,10 @@ export function buildBrainProfile({isolationRoot, chromaPort, fleetPort}) {
         NEO_AI_ORCHESTRATOR_AUTHORITY_PROFILE: 'container-plane',
 
         // Listeners the smoke exercises → runtime-allocated ports
-        NEO_CHROMA_PORT_TEST: String(chromaPort),
-        NEO_FLEET_PORT      : String(fleetPort),
+        NEO_CHROMA_PORT_TEST  : String(chromaPort),
+        NEO_FLEET_PLANE_BASE  : '',
+        NEO_FLEET_PLANE_BEARER: '',
+        NEO_FLEET_PORT        : String(fleetPort),
 
         // Every other port-bearing or shared-state lane → OFF. The smoke proves the harness can
         // OWN the organism's lifecycle; it must not double-run swarm lanes or reap live listeners.
@@ -407,7 +435,8 @@ export async function probeFleetServing({
  * PID-file + command-line liveness idiom (read from the RESOLVED dataDir leaf, so an env-shifted
  * setup is honored) plus fleet-transport PROTOCOL identity — `fleetServing` requires a real wire
  * envelope, while `fleetPortHeld` reports raw occupancy so a foreign listener fails the boot
- * closed instead of masquerading as an attach target. Drives the attach-or-own decision.
+ * closed instead of masquerading as an attach target. Supplies observation to the config-first
+ * product launch plan; it never decides whether a declared plane exists.
  * @param {Object} options
  * @param {String} options.orchestratorDataDir Resolved `AiConfig.orchestrator.dataDir`.
  * @param {Number|String} options.fleetPort Fleet transport port to probe.

--- a/harness/main.mjs
+++ b/harness/main.mjs
@@ -50,6 +50,7 @@ import {
     resolveBrainMode,
     resolveUiFleetTransport,
     resolveBrainPaths,
+    resolveProductBrainPlan,
     loadFleetRuntimeContracts,
     startBrainChild,
     stopBrainTree,
@@ -899,11 +900,11 @@ function registerBrainChild(entry) {
 }
 
 /**
- * The product Brain boot — ATTACH-OR-OWN (see brain.mjs): on a machine with a live Brain the
- * harness supervises only the missing fleet transport against the REAL organism; on a fresh
- * machine it owns the whole organism on the default (canonical-layout) paths. It never boots a
- * second organism beside a live one — the daemon's single-instance takeover and the supervisor's
- * singleton-port reaping make that unsafe by construction.
+ * The product Brain boot — PLANE-ATTACH / ATTACH / OWN (see brain.mjs): a declared containerized
+ * plane starts only the missing Fleet transport, a live host Brain is attached, and only a truly
+ * fresh machine owns the full organism. It never boots a second organism beside either declared
+ * authority — the daemon's single-instance takeover and the supervisor's singleton-port reaping
+ * make that unsafe by construction.
  * @summary Boots or attaches the Brain for `start:brain`, supervising only what is missing.
  * @returns {Promise<Object>}
  */
@@ -928,9 +929,14 @@ async function bootProductBrain() {
             orchestratorDataDir: paths.orchestratorDataDir,
             repoRoot           : organismRoot
         }),
-        mode      = live.orchestratorAlive ? 'attach' : 'own';
+        plan      = resolveProductBrainPlan({
+            fleetServing     : live.fleetServing,
+            orchestratorAlive: live.orchestratorAlive,
+            planeBase        : paths.fleetPlaneBase
+        }),
+        {mode}    = plan;
 
-    if (mode === 'own') {
+    if (plan.startOrchestrator) {
         // Coexistence guard (dev machines): a packaged app's own-mode organism runs the DEFAULT
         // ports — a checkout Brain's Chroma already on that port would be REAPED by the spawned
         // supervisor (singleton-port reconciliation). A held Chroma port without a serving fleet
@@ -945,7 +951,7 @@ async function bootProductBrain() {
         await awaitOrchestratorReady({child: orchestrator})
     }
 
-    if (!live.fleetServing) {
+    if (plan.startFleet) {
         // Protocol identity, fail closed: a listener that does NOT answer the fleet wire verb is
         // a foreign server squatting the port — spawning into it would EADDRINUSE, and skipping
         // the spawn would report a Brain that the window cannot actually reach.
@@ -964,8 +970,8 @@ async function bootProductBrain() {
         await awaitFleetReady({bearerToken: fleetBearerToken, child: fleet, port: fleetPort})
     }
 
-    console.log(`HARNESS_BRAIN_MODE ${mode} fleetPort=${fleetPort} started=[${brainState.children.map(entry => entry.label).join(',') || 'none'}]`);
-    return {fleetPort, mode, up: true}
+    console.log(`HARNESS_BRAIN_MODE ${mode}${plan.planeBase ? ` planeBase=${plan.planeBase}` : ''} fleetPort=${fleetPort} started=[${brainState.children.map(entry => entry.label).join(',') || 'none'}]`);
+    return {fleetPort, mode, planeBase: plan.planeBase, up: true}
 }
 
 /**
@@ -1037,6 +1043,8 @@ async function bootSmokeBrain() {
                 ELECTRON_RUN_AS_NODE    : '1',
                 NEO_CHROMA_PORT         : String(chromaPort),
                 NEO_FLEET_BEARER        : fleetBearerToken,
+                NEO_FLEET_PLANE_BASE    : '',
+                NEO_FLEET_PLANE_BEARER  : '',
                 NEO_FLEET_PORT          : String(fleetPort),
                 NEO_HARNESS_ELECTRON_BIN: process.execPath
             }

--- a/test/playwright/unit/harness/brain.spec.mjs
+++ b/test/playwright/unit/harness/brain.spec.mjs
@@ -19,6 +19,7 @@ import {
     probeFleetServing,
     probePort,
     registerOwnedChild,
+    resolveProductBrainPlan,
     resolveRealPath,
     resolveUiFleetTransport,
     startBrainChild,
@@ -106,6 +107,8 @@ test.describe('harness brain lifecycle', () => {
 
         expect(profile.UNIT_TEST_MODE).toBe('1');
         expect(profile.NEO_CHROMA_PORT_TEST).toBe('18500');
+        expect(profile.NEO_FLEET_PLANE_BASE).toBe('');
+        expect(profile.NEO_FLEET_PLANE_BEARER).toBe('');
         expect(profile.NEO_FLEET_PORT).toBe('18501');
 
         // Every gate leaf is OFF — an ungated port-bearing task can reap live listeners
@@ -114,6 +117,46 @@ test.describe('harness brain lifecycle', () => {
 
         expect(gates.length).toBeGreaterThanOrEqual(14);
         gates.forEach(([, value]) => expect(value).toBe('0'))
+    });
+
+    test('resolveProductBrainPlan: a declared plane outranks host liveness and can start only Fleet', () => {
+        // Port 1 is intentionally unreachable. The classifier never probes it: declaration selects
+        // topology, while the spawned Fleet transport owns authenticated readiness and refusal.
+        expect(resolveProductBrainPlan({
+            fleetServing     : false,
+            orchestratorAlive: false,
+            planeBase        : '  http://127.0.0.1:1  '
+        })).toEqual({
+            mode             : 'plane-attach',
+            planeBase        : 'http://127.0.0.1:1',
+            startFleet       : true,
+            startOrchestrator: false
+        });
+
+        expect(resolveProductBrainPlan({
+            fleetServing     : true,
+            orchestratorAlive: true,
+            planeBase        : 'http://127.0.0.1:3102'
+        })).toEqual({
+            mode             : 'plane-attach',
+            planeBase        : 'http://127.0.0.1:3102',
+            startFleet       : false,
+            startOrchestrator: false
+        })
+    });
+
+    test('resolveProductBrainPlan: without a plane, host liveness selects attach else own', () => {
+        expect(resolveProductBrainPlan({
+            fleetServing     : false,
+            orchestratorAlive: true,
+            planeBase        : ''
+        })).toEqual({mode: 'attach', planeBase: null, startFleet: true, startOrchestrator: false});
+
+        expect(resolveProductBrainPlan({
+            fleetServing     : false,
+            orchestratorAlive: false,
+            planeBase        : '   '
+        })).toEqual({mode: 'own', planeBase: null, startFleet: true, startOrchestrator: true})
     });
 
     test('assertIsolatedProfile passes an isolated resolution and names every escape', () => {


### PR DESCRIPTION
Resolves #16693

A declared containerized Agent OS plane now outranks host-process discovery when `start:brain` chooses its ownership posture. The product boot resolves `fleet.planeBase` through the AiConfig SSOT, consumes a pure three-state launch plan, and can start only the missing Fleet transport in `plane-attach`; full host ownership remains available only when neither a plane nor a live host orchestrator exists. Both smoke profiles explicitly clear external plane bindings, and the local Agent OS runbook now supplies the two deployment exports while keeping all three bearer classes distinct.

Evidence: L2 (pure launch-plan witnesses plus the complete 117-test harness unit tree at exact head) + reviewer-supplied L3 (isolated Brain smoke on an Electron-capable host: passed, `brainUp: true`, clean teardown) → L3 required (real configured-plane `start:brain` and down-plane fail-closed receipts). Residual: AC2 [#16693].

## Deltas from ticket

- The config-first classifier is a pure `resolveProductBrainPlan()` composition rather than inline branching, so the down-plane and host-liveness priority table is executable without probing ingress.
- Smoke now blanks `NEO_FLEET_PLANE_BASE` and `NEO_FLEET_PLANE_BEARER` explicitly; otherwise a machine-level export would silently redirect an allegedly isolated Fleet process into the canonical plane.
- The exact packaged product profile remains intact. Product topology is selected from the same resolved AiConfig declaration; smoke applies its isolation override only at the smoke composition boundary.

## Test Evidence

- Harness launch classifier: `npx playwright test test/playwright/unit/harness/brain.spec.mjs test/playwright/unit/harness/pack.spec.mjs -c test/playwright/playwright.config.unit.mjs --workers=1` → 41/41 passed before rebase.
- Integrated harness surface: `npx playwright test test/playwright/unit/harness -c test/playwright/playwright.config.unit.mjs --workers=1` → 117/117 passed at `54b5cfefb0` after rebasing onto `origin/dev` `0fad0c3871`.
- Repository pre-commit chain: whitespace, shorthand, JSDoc types, ticket archaeology, block alignment, parse, AiConfig-test mutation, and derived-domain checks passed.
- Electron smoke: author seat remained NOT_MEASURED because Electron aborted with `SIGABRT` during `probe:preload-esm`; Clio then ran `npm --prefix harness run smoke:brain` on an Electron-capable host at exact head `54b5cfefb0` → `passed: true`, `brainUp: true`, popup + shared-heap evidence present, `rendererErrors: []`, clean teardown. AC4 is measured.
- Existing non-CI runtime coverage for the three-state classifier: isolated own-mode smoke is now measured at exact head; configured-plane and down-plane runtime behavior remain unmeasured outside the pure classifier witnesses.

## Post-Merge Validation

- [ ] On an Electron-capable host with `NEO_FLEET_PLANE_BASE` and its dedicated bearer configured, run `npm --prefix harness run start:brain`; verify `HARNESS_BRAIN_MODE plane-attach planeBase=...`, a Fleet-only started set, and no host orchestrator spawn.
- [ ] Repeat with the configured ingress unavailable; verify the existing authenticated Fleet admission fails closed and no host-native organism starts.
- [x] Isolated `smoke:brain`: reviewer-supplied exact-head receipt passed with both plane leaves blanked, `brainUp: true`, and clean teardown.

## Evolution

Ticket intake changed the classifier authority from runtime health to config declaration: plane unavailability is exactly when health-driven fallback would be most destructive. Implementation archaeology then exposed the adjacent smoke-leak risk, so the same change makes external plane inheritance impossible inside both isolated smoke profiles.

Authored by Emmy (GPT-5.6 Sol Ultra, Codex).
