### PR TITLE
fix(orchestrator): rearm tenant sync after embedding recovery (#16692)

### DIFF
--- a/ai/daemons/orchestrator/scheduling/tenantRepoSync.mjs
+++ b/ai/daemons/orchestrator/scheduling/tenantRepoSync.mjs
@@ -83,6 +83,53 @@ export function computeDeterministicJitter({tenantId, repoSlug, baseCadenceMs, j
 }
 
 /**
+ * @summary Returns whether durable recovery evidence grants one immediate sync attempt.
+ *
+ * This stays inside the existing per-repo due computation: the persisted scheduler remains the sole
+ * authority, while the process-local canary can only write a generation receipt for it to consume.
+ * A generation with a consumption timestamp is spent and can never bypass cadence again.
+ *
+ * @param {Object|null} persistedRepoState Normalized durable checkpoint state.
+ * @returns {Boolean}
+ */
+export function hasPendingEmbeddingRecoveryBypass(persistedRepoState) {
+    const recovery = persistedRepoState?.embeddingRecovery;
+
+    return Boolean(
+        recovery?.episodeId
+        && recovery.generationId
+        && recovery.observedAt
+        && !recovery.bypassConsumedAt
+    );
+}
+
+/**
+ * @summary Classifies the recovery dimension of one backoff-suppressed repository.
+ * @param {Object} options
+ * @param {Object|null} options.persistedRepoState Normalized durable checkpoint state.
+ * @param {Object|null} [options.probeSnapshot] Process-owned canary snapshot.
+ * @param {Number} [options.observedAt=Date.now()] Observation epoch.
+ * @returns {String|null}
+ */
+export function classifyEmbeddingRecoveryState({persistedRepoState, probeSnapshot = null, observedAt = Date.now()} = {}) {
+    const failures = persistedRepoState?.consecutiveFailures ?? 0,
+          recovery = persistedRepoState?.embeddingRecovery;
+
+    if (failures <= 0) return null;
+    if (!recovery) return 'ordinary-repo-backoff';
+    if (hasPendingEmbeddingRecoveryBypass(persistedRepoState)) return 'recovery-observed/retry-pending';
+
+    if (
+        Number.isFinite(probeSnapshot?.nextAttemptAt)
+        && probeSnapshot.nextAttemptAt > observedAt
+    ) {
+        return 'recovery-probe-backoff';
+    }
+
+    return 'still-failing';
+}
+
+/**
  * @summary Decides whether a per-repo sync attempt is currently due.
  *
  * Per-repo due-check applies to each `tenantRepos[]` entry independently. The
@@ -108,7 +155,8 @@ export function computeDeterministicJitter({tenantId, repoSlug, baseCadenceMs, j
  * @param {Number} options.globalCadenceMs Global cadence fallback when repo has no override.
  * @param {Number} [options.jitterRatio=0] Caller (typically `TenantRepoSyncService`) passes the value from `aiConfig.orchestrator.tenantRepoSync.jitterRatio`. Default `0` (no jitter) keeps the pure function config-free.
  * @param {Number} [options.backoffCapMs=0] Caller passes the value from `aiConfig.orchestrator.tenantRepoSync.backoffCapMs`. Default `0` (no cap) keeps pure-function behavior config-free. Must exceed the repo's base cadence to bind only on failure streaks.
- * @returns {{due: Boolean, effectiveCadenceMs: Number, jitterMs: Number, backoffMultiplier: Number, backoffCapped: Boolean, lastRunAttemptAt: Number}}
+ * @returns {{due: Boolean, dueReason: String, recoveryBypass: Boolean, effectiveCadenceMs: Number,
+ *     jitterMs: Number, backoffMultiplier: Number, backoffCapped: Boolean, lastRunAttemptAt: Number}}
  */
 export function isRepoDue({repo, persistedRepoState, now, globalCadenceMs, jitterRatio = 0, backoffCapMs = 0}) {
     const baseCadenceMs       = Number.isFinite(repo?.cadenceMs) && repo.cadenceMs > 0 ? repo.cadenceMs : globalCadenceMs;
@@ -124,9 +172,21 @@ export function isRepoDue({repo, persistedRepoState, now, globalCadenceMs, jitte
     const uncappedCadenceMs  = (baseCadenceMs + jitterMs) * backoffMultiplier;
     const backoffCapped      = Number.isFinite(backoffCapMs) && backoffCapMs > 0 && uncappedCadenceMs > backoffCapMs;
     const effectiveCadenceMs = backoffCapped ? backoffCapMs : uncappedCadenceMs;
-    const due                = (now - lastRunAttemptAt) >= effectiveCadenceMs;
+    const recoveryBypass     = hasPendingEmbeddingRecoveryBypass(persistedRepoState),
+          cadenceDue     = (now - lastRunAttemptAt) >= effectiveCadenceMs,
+          due            = recoveryBypass || cadenceDue,
+          dueReason      = recoveryBypass ? 'embedding-recovery' : (cadenceDue ? 'cadence' : 'not-due');
 
-    return {due, effectiveCadenceMs, jitterMs, backoffMultiplier, backoffCapped, lastRunAttemptAt};
+    return {
+        due,
+        dueReason,
+        recoveryBypass,
+        effectiveCadenceMs,
+        jitterMs,
+        backoffMultiplier,
+        backoffCapped,
+        lastRunAttemptAt
+    };
 }
 
 /**

--- a/ai/daemons/orchestrator/services/DeploymentStateBridgeService.mjs
+++ b/ai/daemons/orchestrator/services/DeploymentStateBridgeService.mjs
@@ -32,6 +32,7 @@ import {
 } from './ContainerHealthDiagnosisService.mjs';
 import {
     buildTenantRepoSyncTrigger,
+    classifyEmbeddingRecoveryState,
     isRepoDue
 } from '../scheduling/tenantRepoSync.mjs';
 import {
@@ -70,6 +71,13 @@ const KB_CONFIG_BOOTSTRAP_FAILURE_STATUSES = new Set([
     'read-failed',
     'parse-failed',
     'invalid-shape'
+]);
+const EMBEDDING_RECOVERY_PROBE_STATUSES = new Set([
+    'never-started',
+    'pending',
+    'healthy',
+    'failed',
+    'terminal'
 ]);
 
 /**
@@ -933,6 +941,10 @@ export class DeploymentStateBridgeService extends Base {
             errors.push(summarizeDiagnosticError(error, 'tenant-repo-revision-state-read-failed'));
         }
 
+        const embeddingRecoveryProbe = summarizeEmbeddingRecoveryProbe(
+            readEmbeddingRecoveryProbeSnapshot(this.tenantRepoSyncService)
+        );
+
         const repoStates = repos.map(repo => summarizeTenantRepoState({
             repo,
             observedAt,
@@ -942,11 +954,12 @@ export class DeploymentStateBridgeService extends Base {
             globalCadenceMs   : scheduler.globalCadenceMs,
             jitterRatio       : scheduler.jitterRatio,
             backoffCapMs      : scheduler.backoffCapMs,
-            accessReadiness   : readTenantRepoAccessReadiness(this.tenantRepoSyncService, repo, observedAt)
+            accessReadiness   : readTenantRepoAccessReadiness(this.tenantRepoSyncService, repo, observedAt),
+            embeddingRecoveryProbe
         }));
 
         return {
-            schemaVersion: 2,
+            schemaVersion: 3,
             recordType   : 'tenant-repo-sync-deployment-state',
             source,
             observedAt,
@@ -970,7 +983,8 @@ export class DeploymentStateBridgeService extends Base {
                 repoStates,
                 stateAvailable: configEnumerationAvailable
             }),
-            repos : repoStates,
+            embeddingRecoveryProbe,
+            repos                 : repoStates,
             errors
         };
     }
@@ -1107,7 +1121,7 @@ function summarizeInspect(inspect) {
         // image-name proxy gets invented.
         declaredHeapCeilingMb: parseDeclaredHeapCeilingMb(inspect.Config?.Cmd),
         nodeCommand          : isNodeCommand(inspect.Config?.Cmd),
-        state       : {
+        state                : {
             status    : state.Status || null,
             health    : state.Health?.Status || null,
             startedAt : state.StartedAt || null,
@@ -1459,6 +1473,72 @@ function readTenantRepoAccessReadiness(service, repo, observedAt) {
 }
 
 /**
+ * @summary Reads process-local embedding evidence without letting diagnostics perturb the lane.
+ * @param {Object|null} service TenantRepoSyncService-compatible source.
+ * @returns {Object|null}
+ */
+function readEmbeddingRecoveryProbeSnapshot(service) {
+    if (typeof service?.getEmbeddingRecoveryProbeSnapshot !== 'function') {
+        return null;
+    }
+
+    try {
+        return service.getEmbeddingRecoveryProbeSnapshot();
+    } catch {
+        return null;
+    }
+}
+
+/**
+ * @summary Reduces one recovery-probe snapshot to its strict public allowlist.
+ * @param {Object|null} candidate Process-owned canary snapshot.
+ * @returns {Object}
+ */
+function summarizeEmbeddingRecoveryProbe(candidate) {
+    const
+        status = EMBEDDING_RECOVERY_PROBE_STATUSES.has(candidate?.status)
+            ? candidate.status
+            : 'unavailable',
+        checkedAt = Number.isFinite(candidate?.checkedAt) && candidate.checkedAt >= 0
+            ? candidate.checkedAt
+            : null,
+        nextAttemptAt = Number.isFinite(candidate?.nextAttemptAt) && candidate.nextAttemptAt >= 0
+            ? candidate.nextAttemptAt
+            : null,
+        stopReason = typeof candidate?.stopReason === 'string'
+            && /^attempt budget exhausted \(streak \d+, budget \d+\)$/u.test(candidate.stopReason)
+                ? candidate.stopReason
+                : null,
+        errorClassification = typeof candidate?.errorClassification === 'string'
+            && /^[a-z][a-z-]{0,63}$/u.test(candidate.errorClassification)
+                ? candidate.errorClassification
+                : null,
+        errorCode = typeof candidate?.errorCode === 'string'
+            && /^[A-Z][A-Z0-9_]{0,95}$/u.test(candidate.errorCode)
+                ? candidate.errorCode
+                : null;
+
+    return {
+        status,
+        checkedAt,
+        lastDemandCached: typeof candidate?.lastDemandCached === 'boolean'
+            ? candidate.lastDemandCached
+            : null,
+        failureStreak: Number.isSafeInteger(candidate?.failureStreak) && candidate.failureStreak >= 0
+            ? candidate.failureStreak
+            : 0,
+        backoffMs: Number.isFinite(candidate?.backoffMs) && candidate.backoffMs >= 0
+            ? candidate.backoffMs
+            : 0,
+        nextAttemptAt,
+        terminal: status === 'terminal' && candidate?.terminal === true,
+        stopReason,
+        errorClassification,
+        errorCode
+    };
+}
+
+/**
  * @summary Reduces one cached access result to its strict public allowlist.
  * @param {Object|null} candidate Process-local readiness candidate.
  * @param {Boolean} disabled Whether the repository is disabled.
@@ -1560,6 +1640,7 @@ function summarizeTenantRepoAccessReadiness({repoStates, stateAvailable}) {
  * @param {Number} options.jitterRatio Deterministic jitter ratio.
  * @param {Number} [options.backoffCapMs] Failure-backoff ceiling (the `tenantRepoSync.backoffCapMs` leaf); keeps the observed due-state identical to the lane's own computation.
  * @param {Object|null} options.accessReadiness Process-local access evidence.
+ * @param {Object|null} options.embeddingRecoveryProbe Process-owned embedding canary snapshot.
  * @returns {Object}
  */
 function summarizeTenantRepoState({
@@ -1571,7 +1652,8 @@ function summarizeTenantRepoState({
     globalCadenceMs,
     jitterRatio,
     backoffCapMs,
-    accessReadiness
+    accessReadiness,
+    embeddingRecoveryProbe
 }) {
     const
         normalizedCheckpoint = normalizeTenantRepoCheckpointState(persistedRepoState),
@@ -1582,26 +1664,43 @@ function summarizeTenantRepoState({
         dueState              = disabled
             ? {due: false, effectiveCadenceMs: null, jitterMs: null, backoffMultiplier: null, lastRunAttemptAt: normalizedCheckpoint?.lastRunAttemptAt || 0}
             : isRepoDue({repo, persistedRepoState: normalizedCheckpoint, now: observedAt, globalCadenceMs, jitterRatio, backoffCapMs}),
-        nextDueAtMs           = Number.isFinite(dueState.effectiveCadenceMs)
-            ? ((dueState.lastRunAttemptAt || 0) > 0 ? dueState.lastRunAttemptAt + dueState.effectiveCadenceMs : observedAt)
-            : null,
+        nextDueAtMs           = dueState.recoveryBypass
+            ? observedAt
+            : (Number.isFinite(dueState.effectiveCadenceMs)
+                ? ((dueState.lastRunAttemptAt || 0) > 0 ? dueState.lastRunAttemptAt + dueState.effectiveCadenceMs : observedAt)
+                : null),
         lastOutcome           = findTenantRepoOutcome(taskState?.lastCompletion, repo),
         lastAttempt           = normalizedCheckpoint?.lastRunAttemptAt || 0,
-        failures              = normalizedCheckpoint?.consecutiveFailures ?? 0;
+        failures              = normalizedCheckpoint?.consecutiveFailures ?? 0,
+        recoveryState         = classifyEmbeddingRecoveryState({
+            persistedRepoState: normalizedCheckpoint,
+            probeSnapshot     : embeddingRecoveryProbe,
+            observedAt
+        });
 
     return {
-        identityHash                      : hashTenantRepoIdentity(repo),
-        tenantHash                        : hashValue(repo.tenantId),
-        repoHash                          : hashValue(repo.repoSlug),
-        configTier                        : repo.configTier || 'unreported',
+        identityHash       : hashTenantRepoIdentity(repo),
+        tenantHash         : hashValue(repo.tenantId),
+        repoHash           : hashValue(repo.repoSlug),
+        configTier         : repo.configTier || 'unreported',
         disabled,
-        accessReadiness                   : summarizeTenantRepoAccessState(accessReadiness, disabled),
-        status                            : classifyTenantRepoState({disabled, due: dueState.due, persistedRepoState: normalizedCheckpoint, lastOutcome}),
-        due                               : disabled ? false : dueState.due,
-        nextDueAt                         : Number.isFinite(nextDueAtMs) ? new Date(nextDueAtMs).toISOString() : null,
-        lastIngestedRev                   : shortRevision(normalizedCheckpoint?.lastIngestedRev),
-        lastRunAttemptAt                  : lastAttempt > 0 ? new Date(lastAttempt).toISOString() : null,
-        consecutiveFailures               : failures,
+        accessReadiness    : summarizeTenantRepoAccessState(accessReadiness, disabled),
+        status             : classifyTenantRepoState({disabled, due: dueState.due, persistedRepoState: normalizedCheckpoint, lastOutcome}),
+        due                : disabled ? false : dueState.due,
+        nextDueAt          : Number.isFinite(nextDueAtMs) ? new Date(nextDueAtMs).toISOString() : null,
+        lastIngestedRev    : shortRevision(normalizedCheckpoint?.lastIngestedRev),
+        lastRunAttemptAt   : lastAttempt > 0 ? new Date(lastAttempt).toISOString() : null,
+        consecutiveFailures: failures,
+        stopReasonCode     : failures > 0
+            ? (normalizedCheckpoint?.embeddingRecovery?.causeCode
+                || normalizedCheckpoint?.lastSourceErrorCode
+                || normalizedCheckpoint?.lastErrorCode
+                || null)
+            : null,
+        lastErrorCode                     : failures > 0 ? (normalizedCheckpoint?.lastErrorCode ?? null) : null,
+        lastSourceErrorCode               : failures > 0 ? (normalizedCheckpoint?.lastSourceErrorCode ?? null) : null,
+        lastAccessCode                    : failures > 0 ? (normalizedCheckpoint?.lastAccessCode ?? null) : null,
+        recoveryState,
         checkpointStatus,
         ingestContractVersion             : normalizedCheckpoint?.ingestContractVersion ?? null,
         lastAttemptedIngestContractVersion: normalizedCheckpoint?.lastAttemptedIngestContractVersion ?? null,

--- a/ai/daemons/orchestrator/services/TenantRepoSyncService.mjs
+++ b/ai/daemons/orchestrator/services/TenantRepoSyncService.mjs
@@ -1,9 +1,12 @@
-import fs                        from 'fs-extra';
-import {createHmac, randomBytes} from 'node:crypto';
-import path                      from 'node:path';
-import Base                      from '../../../../src/core/Base.mjs';
-import AiConfig                  from '../../../config.mjs';
-import GitMirror                 from '../../../services/knowledge-base/helpers/gitMirror.mjs';
+import fs                         from 'fs-extra';
+import {createHmac, randomBytes}  from 'node:crypto';
+import path                       from 'node:path';
+import Base                       from '../../../../src/core/Base.mjs';
+import AiConfig                   from '../../../config.mjs';
+import GitMirror                  from '../../../services/knowledge-base/helpers/gitMirror.mjs';
+import TextEmbeddingService       from '../../../services/memory-core/TextEmbeddingService.mjs';
+import {createBoundedRetryGate}   from '../../../services/shared/boundedRetryGate.mjs';
+import {buildEmbeddingProbeBlock} from '../../../services/shared/embeddingProbe.mjs';
 // The filter below and the codes it admits are one contract. Importing the pattern from the module
 // that PRODUCES bounded codes keeps a re-declared copy from drifting into a pair that separately
 // look right — the producer widening a code the filter still rejects is exactly this ticket's defect.
@@ -20,7 +23,13 @@ import {
     TenantRepoAccessCode,
     TenantRepoAccessStatus
 } from '../../../services/knowledge-base/helpers/tenantRepoAccessContract.mjs';
-import {detectStarvedTenantSync, isRepoDue, isStarvedOrderInverted} from '../scheduling/tenantRepoSync.mjs';
+import {
+    classifyEmbeddingRecoveryState,
+    detectStarvedTenantSync,
+    hasPendingEmbeddingRecoveryBypass,
+    isRepoDue,
+    isStarvedOrderInverted
+} from '../scheduling/tenantRepoSync.mjs';
 import {
     KB_TENANT_REPO_SYNC_EMPTY_MATERIALIZATION,
     KB_TENANT_REPO_SYNC_SYNC_FAILED,
@@ -50,6 +59,7 @@ import {
 } from '../../shared/lifecycleGuard.mjs';
 import {
     classifyTenantRepoCheckpoint,
+    isEmbeddingRecoverySourceCode,
     normalizeTenantRepoCheckpointState,
     requiresTenantRepoCheckpointRevalidation,
     TENANT_REPO_INGEST_CONTRACT_VERSION,
@@ -57,10 +67,13 @@ import {
 } from './tenantRepoCheckpointValidity.mjs';
 
 const
-    ACCESS_CONFIG_FINGERPRINT_KEY    = randomBytes(32),
-    ACCESS_READINESS_MIN_TTL_MS      = 15 * 60 * 1000,
-    PERSISTED_REVISIONS_FILE_NAME    = 'tenant-repo-sync-revisions.json',
-    TENANT_REPO_SYNC_LEASE_FILE_NAME = 'tenant-repo-sync-lease.json';
+    ACCESS_CONFIG_FINGERPRINT_KEY         = randomBytes(32),
+    ACCESS_READINESS_MIN_TTL_MS           = 15 * 60 * 1000,
+    EMBEDDING_RECOVERY_FAILURE_TTL_MS     = 30 * 1000,
+    EMBEDDING_RECOVERY_FAILURE_TTL_MAX_MS = 10 * 60 * 1000,
+    EMBEDDING_RECOVERY_PROBE_TIMEOUT_MS   = 30 * 1000,
+    PERSISTED_REVISIONS_FILE_NAME         = 'tenant-repo-sync-revisions.json',
+    TENANT_REPO_SYNC_LEASE_FILE_NAME      = 'tenant-repo-sync-lease.json';
 
 /**
  * @summary In-memory async semaphore with optional slot-acquisition timeout.
@@ -155,6 +168,64 @@ function getSourceErrorCode(error, outerCode) {
     }
 
     return BOUNDED_KB_ERROR_CODE_PATTERN.test(sourceCode) ? sourceCode : null;
+}
+
+/**
+ * @summary Selects the first bounded embedding cause from one failed ingestion attempt.
+ * @param {Error} error Failed operation.
+ * @param {String|null} sourceErrorCode Existing first-source compatibility code.
+ * @returns {String|null}
+ */
+function getEmbeddingRecoveryCauseCode(error, sourceErrorCode) {
+    return [sourceErrorCode, ...(Array.isArray(error?.sourceErrorCodes) ? error.sourceErrorCodes : [])]
+        .find(isEmbeddingRecoverySourceCode) || null;
+}
+
+/**
+ * @summary Creates or advances one durable embedding recovery episode after a sync failure.
+ *
+ * A repeated embedding failure stays in the same episode, including after its one recovery grant
+ * was consumed. Minting a fresh episode for every failure would let a still-broken provider acquire
+ * one immediate retry per sweep and silently defeat the durable backoff this lane protects.
+ *
+ * @param {Object} options
+ * @param {Object|null} options.priorRecovery Existing normalized episode.
+ * @param {String} options.causeCode Bounded embedding cause.
+ * @param {Number} options.failedAt Attempt timestamp.
+ * @returns {Object}
+ */
+function buildEmbeddingRecoveryAfterFailure({priorRecovery, causeCode, failedAt}) {
+    if (priorRecovery) {
+        const consumedGenerationId = priorRecovery.generationId && priorRecovery.bypassConsumedAt
+            ? priorRecovery.generationId
+            : null;
+
+        return {
+            episodeId               : priorRecovery.episodeId,
+            causeCode,
+            detectedAt              : priorRecovery.detectedAt,
+            generationId            : null,
+            observedAt              : null,
+            bypassConsumedAt        : null,
+            lastConsumedGenerationId: consumedGenerationId
+                || priorRecovery.lastConsumedGenerationId
+                || null,
+            lastConsumedAt: consumedGenerationId
+                ? priorRecovery.bypassConsumedAt
+                : (priorRecovery.lastConsumedAt || null)
+        };
+    }
+
+    return {
+        episodeId               : randomBytes(16).toString('hex'),
+        causeCode,
+        detectedAt              : failedAt,
+        generationId            : null,
+        observedAt              : null,
+        bypassConsumedAt        : null,
+        lastConsumedGenerationId: null,
+        lastConsumedAt          : null
+    };
 }
 
 /**
@@ -463,6 +534,35 @@ class TenantRepoSyncService extends Base {
     accessReadinessCache = new Map()
 
     /**
+     * Process-owned cadence gate for the embedding recovery canary. Never replaces or hydrates the
+     * durable per-repo scheduler.
+     * @member {Object|null} embeddingRecoveryGate
+     * @protected
+     */
+    embeddingRecoveryGate = null
+
+    /**
+     * Latest bounded canary delivery, retained only for deployment-state classification.
+     * @member {Object|null} embeddingRecoveryLastResult
+     * @protected
+     */
+    embeddingRecoveryLastResult = null
+
+    /**
+     * Mutable attempt seam read by the stable gate closure; tests replace it without replacing the gate.
+     * @member {Function|null} embeddingRecoveryProbeFn
+     * @protected
+     */
+    embeddingRecoveryProbeFn = null
+
+    /**
+     * Clock seam read by the stable gate closure.
+     * @member {Function} embeddingRecoveryClock
+     * @protected
+     */
+    embeddingRecoveryClock = Date.now
+
+    /**
      * Rejects non-positive-integer `concurrencyLimit` values. `0` would create a
      * never-acquirable semaphore; negatives and fractional values produce ambiguous
      * `active < limit` semantics (1.5 admits two slots, etc.). Invalid values fall
@@ -526,6 +626,114 @@ class TenantRepoSyncService extends Base {
      */
     clearTenantRepoAccessReadiness() {
         this.accessReadinessCache.clear();
+    }
+
+    /**
+     * @summary Clears process-local recovery-probe state, mirroring an orchestrator restart.
+     * @returns {void}
+     * @protected
+     */
+    clearEmbeddingRecoveryProbeState() {
+        this.embeddingRecoveryGate       = null;
+        this.embeddingRecoveryLastResult = null;
+        this.embeddingRecoveryProbeFn    = null;
+        this.embeddingRecoveryClock      = Date.now;
+    }
+
+    /**
+     * @summary Returns a bounded, read-only recovery canary projection for deployment diagnostics.
+     * @returns {Object}
+     */
+    getEmbeddingRecoveryProbeSnapshot() {
+        const snapshot = this.embeddingRecoveryGate?.snapshot?.() || {
+                  status       : 'never-started',
+                  failureStreak: 0,
+                  backoffMs    : 0,
+                  nextAttemptAt: null,
+                  terminal     : false,
+                  stopReason   : null,
+                  cached       : null
+              },
+              delivered = this.embeddingRecoveryLastResult,
+              failure   = delivered?.status === 'healthy'
+                  ? null
+                  : (delivered || snapshot.cached?.result || null);
+
+        return {
+            status             : snapshot.status,
+            checkedAt          : delivered?.gate?.checkedAt ?? snapshot.cached?.checkedAt ?? null,
+            lastDemandCached   : delivered?.gate?.cached ?? null,
+            failureStreak      : snapshot.failureStreak,
+            backoffMs          : snapshot.backoffMs,
+            nextAttemptAt      : snapshot.nextAttemptAt,
+            terminal           : snapshot.terminal,
+            stopReason         : snapshot.stopReason,
+            errorClassification: failure?.errorClassification || null,
+            errorCode          : failure?.errorCode || null
+        };
+    }
+
+    /**
+     * @summary Runs or reuses one process-owned embedding recovery canary generation.
+     *
+     * The cohort's durable episode ids participate in the gate key, so a later outage rotates to a
+     * fresh process generation even when the configured provider is unchanged. Gate state governs
+     * probe cadence/backoff only; callers decide whether a healthy observation can be committed.
+     *
+     * @param {Object} options
+     * @param {String[]} options.episodeKeys Awaiting durable episode/generation-history keys.
+     * @param {Function} [options.runProbe] Attempt seam.
+     * @param {Function} [options.clock=Date.now] Clock seam.
+     * @param {Number} [options.timeoutMs=30000] Consumer-owned provider deadline.
+     * @param {Number} [options.failureTtlMs=30000] Probe failure backoff floor.
+     * @param {Number} [options.failureTtlMaxMs=600000] Probe failure backoff ceiling.
+     * @returns {Promise<Object|null>}
+     */
+    async probeEmbeddingRecovery({
+        episodeKeys,
+        runProbe,
+        clock = Date.now,
+        timeoutMs = EMBEDDING_RECOVERY_PROBE_TIMEOUT_MS,
+        failureTtlMs = EMBEDDING_RECOVERY_FAILURE_TTL_MS,
+        failureTtlMaxMs = EMBEDDING_RECOVERY_FAILURE_TTL_MAX_MS
+    } = {}) {
+        if (!Array.isArray(episodeKeys) || episodeKeys.length === 0) return null;
+
+        this.embeddingRecoveryClock = clock;
+        this.embeddingRecoveryProbeFn = runProbe || (() => buildEmbeddingProbeBlock({
+            cfg      : AiConfig,
+            embedText: (text, explicitProvider, options) =>
+                TextEmbeddingService.embedText(text, explicitProvider, options),
+            input         : 'neo-tenant-repo-sync-embedding-recovery-canary',
+            operationLabel: 'Tenant repo sync embedding recovery probe',
+            now           : this.embeddingRecoveryClock,
+            timeoutMs
+        }));
+
+        if (!this.embeddingRecoveryGate) {
+            this.embeddingRecoveryGate = createBoundedRetryGate({
+                run: async context => {
+                    try {
+                        return await this.embeddingRecoveryProbeFn(context);
+                    } catch {
+                        return {
+                            status             : 'failed',
+                            error              : 'probe-could-not-run:EMBEDDING_PROBE_EXECUTION_ERROR',
+                            errorClassification: 'probe-could-not-run',
+                            errorCode          : 'EMBEDDING_PROBE_EXECUTION_ERROR'
+                        };
+                    }
+                },
+                failureTtlMs,
+                failureTtlMaxMs,
+                now: () => this.embeddingRecoveryClock()
+            });
+        }
+
+        const key = `${AiConfig.embeddingProvider}:${AiConfig.vectorDimension}:${[...episodeKeys].sort().join(',')}`;
+
+        this.embeddingRecoveryLastResult = await this.embeddingRecoveryGate.tick({key});
+        return this.embeddingRecoveryLastResult;
     }
 
     /**
@@ -781,6 +989,11 @@ class TenantRepoSyncService extends Base {
      * @param {Number} [options.leaseStaleAfterMs] Override the cross-process lease TTL (test seam). Defaults to the `orchestrator.tenantRepoSync.leaseStaleAfterMs` leaf. Crashed owners recover immediately via pid-liveness; the TTL only bounds a live-but-wedged owner.
      * @param {Number} [options.leaseRenewalIntervalMs] Override the lease renewal cadence (test seam). Defaults to `max(5000, floor(leaseStaleAfterMs / 3))` — a live, renewing run never reaches its TTL deadline, so a replacement owner cannot start repo work while this one is still making progress.
      * @param {Function} [options.envelopeBuilder=buildIngestEnvelope] Injectable envelope-builder (test seam). Production callers omit; unit tests pass a fake that returns canned envelope shape.
+     * @param {Function} [options.embeddingRecoveryProbe] Injectable embedding recovery canary.
+     * @param {Function} [options.embeddingRecoveryClock=Date.now] Recovery gate clock seam.
+     * @param {Number} [options.embeddingRecoveryProbeTimeoutMs=30000] Canary provider deadline.
+     * @param {Number} [options.embeddingRecoveryFailureTtlMs=30000] Canary backoff floor.
+     * @param {Number} [options.embeddingRecoveryFailureTtlMaxMs=600000] Canary backoff ceiling.
      * @returns {Promise<Object>} `{status, details}` — status ∈ {`completed`, `failed`, `skipped`, `starved`}.
      */
     async runTask({
@@ -802,7 +1015,12 @@ class TenantRepoSyncService extends Base {
         backoffCapMs      = AiConfig.data.orchestrator.tenantRepoSync.backoffCapMs,
         starvedAfterMs    = AiConfig.data.orchestrator.tenantRepoSync.starvedAfterMs,
         leaseRenewalIntervalMs,
-        seedBootstrap     = true
+        seedBootstrap     = true,
+        embeddingRecoveryProbe,
+        embeddingRecoveryClock           = Date.now,
+        embeddingRecoveryProbeTimeoutMs  = EMBEDDING_RECOVERY_PROBE_TIMEOUT_MS,
+        embeddingRecoveryFailureTtlMs    = EMBEDDING_RECOVERY_FAILURE_TTL_MS,
+        embeddingRecoveryFailureTtlMaxMs = EMBEDDING_RECOVERY_FAILURE_TTL_MAX_MS
     } = {}) {
         // One-time deployment sanity check on the two tuning leaves' RELATIONSHIP (never a
         // throw — a noisy alert beats a dead lane): an inverted floor makes ordinary capped
@@ -887,35 +1105,43 @@ class TenantRepoSyncService extends Base {
         //    in-flight work is bounded to at most one fenced step.
         // 3. TTL BACKSTOP — pid-liveness + the (renewal-refreshed) deadline
         //    still bound a crashed or fully wedged owner for successors.
-        let leaseLost      = false,
-            renewalStopped = false,
-            renewalTimer   = null;
+        let leaseLost       = false,
+            renewalStopped  = false,
+            renewalTimer    = null,
+            renewalInFlight = Promise.resolve();
 
         const renewalIntervalMsResolved = leaseRenewalIntervalMs ?? Math.max(5000, Math.floor(leaseStaleAfterMs / 3));
 
         const scheduleRenewal = () => {
-            renewalTimer = setTimeout(async () => {
-                try {
-                    const renewal = await renewHeavyMaintenanceLease({
-                        token       : acquisition.lease.token,
-                        leasePath   : resolvedLeasePath,
-                        staleAfterMs: leaseStaleAfterMs
-                    });
+            renewalTimer = setTimeout(() => {
+                // A timer already queued when the run settles cannot be canceled reliably. Refuse
+                // it before it enters the lifecycle guard, and retain every started promise so the
+                // finalizer can join it before releasing the lease and returning to the caller.
+                if (renewalStopped) return;
 
-                    if (!renewal.renewed) {
+                renewalInFlight = (async () => {
+                    try {
+                        const renewal = await renewHeavyMaintenanceLease({
+                            token       : acquisition.lease.token,
+                            leasePath   : resolvedLeasePath,
+                            staleAfterMs: leaseStaleAfterMs
+                        });
+
+                        if (!renewal.renewed) {
+                            leaseLost = true;
+                            writeLog?.('WARN', `[TenantRepoSync] Lease renewal lost ownership (${renewal.status}); aborting at the next fence.`);
+                            return;
+                        }
+                    } catch (e) {
                         leaseLost = true;
-                        writeLog?.('WARN', `[TenantRepoSync] Lease renewal lost ownership (${renewal.status}); aborting at the next fence.`);
+                        writeLog?.('WARN', `[TenantRepoSync] Lease renewal failed (${e.message}); aborting at the next fence.`);
                         return;
                     }
-                } catch (e) {
-                    leaseLost = true;
-                    writeLog?.('WARN', `[TenantRepoSync] Lease renewal failed (${e.message}); aborting at the next fence.`);
-                    return;
-                }
 
-                if (!renewalStopped) {
-                    scheduleRenewal();
-                }
+                    if (!renewalStopped) {
+                        scheduleRenewal();
+                    }
+                })();
             }, renewalIntervalMsResolved);
             renewalTimer.unref?.();
         };
@@ -948,7 +1174,12 @@ class TenantRepoSyncService extends Base {
                 fullReplay, taskStateService, healthService, taskName, envelopeBuilder, leaseGuard,
                 leasePath        : resolvedLeasePath,
                 revisionsFilePath: resolvedRevisionsPath,
-                globalCadenceMs, jitterRatio, backoffCapMs, starvedAfterMs, seedBootstrap
+                globalCadenceMs, jitterRatio, backoffCapMs, starvedAfterMs, seedBootstrap,
+                embeddingRecoveryProbe,
+                embeddingRecoveryClock,
+                embeddingRecoveryProbeTimeoutMs,
+                embeddingRecoveryFailureTtlMs,
+                embeddingRecoveryFailureTtlMaxMs
             });
             const status         = result.status;
             const lastCompletion = {
@@ -995,6 +1226,7 @@ class TenantRepoSyncService extends Base {
             if (renewalTimer) {
                 clearTimeout(renewalTimer);
             }
+            await renewalInFlight;
             await releaseHeavyMaintenanceLease({token: acquisition.lease.token, leasePath: resolvedLeasePath});
         }
     }
@@ -1015,7 +1247,12 @@ class TenantRepoSyncService extends Base {
         backoffCapMs       = AiConfig.data.orchestrator.tenantRepoSync.backoffCapMs,
         starvedAfterMs     = AiConfig.data.orchestrator.tenantRepoSync.starvedAfterMs,
         healEventLedgerDir = revisionsFilePath ? path.join(path.dirname(revisionsFilePath), 'heal-events') : null,
-        seedBootstrap      = true
+        seedBootstrap      = true,
+        embeddingRecoveryProbe,
+        embeddingRecoveryClock           = Date.now,
+        embeddingRecoveryProbeTimeoutMs  = EMBEDDING_RECOVERY_PROBE_TIMEOUT_MS,
+        embeddingRecoveryFailureTtlMs    = EMBEDDING_RECOVERY_FAILURE_TTL_MS,
+        embeddingRecoveryFailureTtlMaxMs = EMBEDDING_RECOVERY_FAILURE_TTL_MAX_MS
     }) {
         if (fullReplay && (!Array.isArray(onlyRepoSlugs) || onlyRepoSlugs.length === 0)) {
             throw new TenantRepoSyncError(
@@ -1185,6 +1422,75 @@ class TenantRepoSyncService extends Base {
             await this.writeInFlightAttempts({filePath: inFlightPath, attempts: {}});
         }, {bestEffort: false});
 
+        // A retained embedding-class failure is the ONLY thing that arms this canary. The gate is
+        // process-local and paces provider work; it never becomes a scheduler. A healthy result must
+        // first become a durable generation on the existing checkpoint manifest, under the same
+        // commit-point ownership fence as every other scheduler fact. Until that commit succeeds,
+        // `isRepoDue()` has no recovery evidence and the ordinary backoff remains authoritative.
+        const
+            configuredRepoLabels    = new Set(repos.map(repo => `${repo.tenantId}/${repo.repoSlug}`)),
+            awaitingRecoveryEntries = onlyRepoSlugs
+                ? []
+                : Object.entries(persistedRevisions)
+                    .filter(([label, state]) =>
+                        configuredRepoLabels.has(label)
+                        && state?.embeddingRecovery
+                        && !state.embeddingRecovery.generationId
+                    );
+
+        if (awaitingRecoveryEntries.length > 0) {
+            const observation = await this.probeEmbeddingRecovery({
+                episodeKeys: awaitingRecoveryEntries.map(([, state]) => {
+                    const recovery = state.embeddingRecovery;
+
+                    return `${recovery.episodeId}:${recovery.lastConsumedGenerationId || 'initial'}`;
+                }),
+                runProbe       : embeddingRecoveryProbe,
+                clock          : embeddingRecoveryClock,
+                timeoutMs      : embeddingRecoveryProbeTimeoutMs,
+                failureTtlMs   : embeddingRecoveryFailureTtlMs,
+                failureTtlMaxMs: embeddingRecoveryFailureTtlMaxMs
+            });
+
+            if (observation?.status === 'healthy') {
+                const
+                    generationId = randomBytes(16).toString('hex'),
+                    observedAt   = observation.gate?.checkedAt ?? embeddingRecoveryClock(),
+                    previous     = new Map();
+
+                for (const [label, state] of awaitingRecoveryEntries) {
+                    previous.set(label, state.embeddingRecovery);
+                    state.embeddingRecovery = {
+                        ...state.embeddingRecovery,
+                        generationId,
+                        observedAt,
+                        bypassConsumedAt: null
+                    };
+                }
+
+                let   manifestCommitted    = false;
+                const transactionCommitted = await withSidecarTransaction(async assertStillOwned => {
+                    const result = await this.writePersistedRevisions({
+                        assertOwnership: assertStillOwned,
+                        filePath       : resolvedRevisionsPath,
+                        revisions      : persistedRevisions
+                    });
+
+                    manifestCommitted = result.committed;
+                }, {bestEffort: false});
+
+                if (!transactionCommitted || !manifestCommitted) {
+                    for (const [label, recovery] of previous) {
+                        persistedRevisions[label].embeddingRecovery = recovery;
+                    }
+                } else {
+                    writeLog?.('INFO', `[TenantRepoSync] Embedding recovery observed; committed one due-bypass generation for ${awaitingRecoveryEntries.length} scoped repo(s).`);
+                }
+            } else if (observation) {
+                writeLog?.('INFO', `[TenantRepoSync] Embedding recovery not yet observed (${observation.errorCode || 'EMBEDDING_PROVIDER_ERROR'}; ${observation.gate?.cached ? 'probe backoff retained' : 'provider still failing'}).`);
+            }
+        }
+
         // The live in-flight map is a FRESH object, never the recovery snapshot. Reusing
         // `residualAttempts` as the live map republished entries the fold had already consumed:
         // the fold cleared the file but not the object, so the first repo to enter protected work
@@ -1216,7 +1522,8 @@ class TenantRepoSyncService extends Base {
                 // then write is check-then-act: earlier revisions fenced harder and only MOVED the
                 // window (check→write became read→write). A lock that does not span the read and
                 // the write cannot close it.
-                await withSidecarTransaction(async assertStillOwned => {
+                let   sidecarCommitted     = false;
+                const transactionCommitted = await withSidecarTransaction(async assertStillOwned => {
                     // Merge against live state rather than publishing this sweep's whole view.
                     // Entries owned by another run are carried forward untouched; only our own are
                     // written or removed. `runId` is defence-in-depth for the residual the guard's
@@ -1235,8 +1542,13 @@ class TenantRepoSyncService extends Base {
 
                     if (!await assertStillOwned()) return;
 
-                    await this.writeInFlightAttempts({filePath: inFlightPath, attempts: merged});
+                    sidecarCommitted = await this.writeInFlightAttempts({
+                        filePath: inFlightPath,
+                        attempts: merged
+                    });
                 });
+
+                return transactionCommitted && sidecarCommitted;
             });
 
             return inFlightChain
@@ -1388,7 +1700,12 @@ class TenantRepoSyncService extends Base {
                             lastAccessCode     : priorState?.lastAccessCode ?? null,
                             lastErrorAt        : priorState?.lastErrorAt
                                 ? new Date(priorState.lastErrorAt).toISOString()
-                                : null
+                                : null,
+                            recoveryState: classifyEmbeddingRecoveryState({
+                                persistedRepoState: priorState,
+                                probeSnapshot     : this.getEmbeddingRecoveryProbeSnapshot(),
+                                observedAt        : startedMs
+                            })
                         } : {})
                     });
                     return; // skip semaphore + work entirely
@@ -1414,9 +1731,17 @@ class TenantRepoSyncService extends Base {
                 return;
             }
 
+            const recoveryGrant = hasPendingEmbeddingRecoveryBypass(priorState)
+                ? {
+                    episodeId   : priorState.embeddingRecovery.episodeId,
+                    generationId: priorState.embeddingRecovery.generationId
+                }
+                : null;
+
             let slotAcquired     = false,
                 accessConfirmed  = false,
-                inFlightRecorded = false;
+                inFlightRecorded = false,
+                workStarted      = false;
             try {
                 await semaphore.acquire();
                 slotAcquired = true;
@@ -1432,16 +1757,53 @@ class TenantRepoSyncService extends Base {
                 // work — not due, revalidation-deferred, or lease-lost at the fence — records
                 // no attempt, matching the lease-lost contract below that deliberately leaves
                 // backoff state untouched for the successor to own.
-                await mutateInFlight(attempts => {
+                const inFlightPersisted = await mutateInFlight(attempts => {
                     attempts[repoLabel] = {
                         startedMs,
-                        priorFailures: priorState?.consecutiveFailures ?? 0,
+                        priorFailures       : priorState?.consecutiveFailures ?? 0,
+                        priorSourceErrorCode: priorState?.lastSourceErrorCode ?? null,
+                        priorAccessCode     : priorState?.lastAccessCode ?? null,
+                        recoveryEpisodeId   : recoveryGrant?.episodeId ?? null,
+                        recoveryGenerationId: recoveryGrant?.generationId ?? null,
                         runId
                     };
                 });
-                inFlightRecorded = true;
 
-                writeLog?.('INFO', `[TenantRepoSync] Refreshing ${repoLabel}.`);
+                // A recovery grant is exactly-once only if its attempt has a durable write-ahead
+                // witness. Ordinary attempts retain the sidecar's historical best-effort contract;
+                // a recovery attempt without a receipt is deferred before provider work and leaves
+                // the generation unconsumed for the next sweep.
+                if (recoveryGrant && !inFlightPersisted) {
+                    delete inFlightAttempts[repoLabel];
+                    notDueCount++;
+                    writeLog?.('WARN', `[TenantRepoSync] ${repoLabel} recovery retry deferred because its write-ahead receipt could not be committed.`);
+                    repoStates.push({
+                        tenantId           : repo.tenantId,
+                        repoSlug           : repo.repoSlug,
+                        lastIngestedRev    : priorState?.lastIngestedRev ? priorState.lastIngestedRev.slice(0, 8) : null,
+                        lastSyncAt         : priorState?.lastRunAttemptAt ? new Date(priorState.lastRunAttemptAt).toISOString() : null,
+                        status             : 'recovery-receipt-deferred',
+                        checkpointStatus,
+                        consecutiveFailures: priorState?.consecutiveFailures ?? 0,
+                        recoveryState      : 'recovery-observed/retry-pending'
+                    });
+                    return;
+                }
+
+                // Ordinary attempts keep the historical best-effort sidecar contract: even when
+                // the first write misses, `finally` must remove this process-local entry so a later
+                // concurrent repo mutation cannot publish it after the work has already returned.
+                inFlightRecorded = recoveryGrant ? inFlightPersisted : true;
+
+                if (recoveryGrant) {
+                    priorState.embeddingRecovery = {
+                        ...priorState.embeddingRecovery,
+                        bypassConsumedAt: startedMs
+                    };
+                }
+
+                workStarted = true;
+                writeLog?.('INFO', `[TenantRepoSync] Refreshing ${repoLabel}${recoveryGrant ? ' (embedding recovery generation)' : ''}.`);
 
                 await gitMirror.cloneIfMissing({
                     tenantId     : repo.tenantId,
@@ -1649,7 +2011,17 @@ class TenantRepoSyncService extends Base {
                 // ingested revision so the next successful run starts from the correct base.
                 // lastRunAttemptAt advances even on failure (backoff measures from attempt
                 // start, not last-success).
-                const nextFailureCount = (priorState?.consecutiveFailures ?? 0) + 1;
+                const
+                    nextFailureCount       = (priorState?.consecutiveFailures ?? 0) + 1,
+                    embeddingRecoveryCause = getEmbeddingRecoveryCauseCode(e, sourceErrorCode),
+                    embeddingRecovery      = embeddingRecoveryCause
+                        ? buildEmbeddingRecoveryAfterFailure({
+                            priorRecovery: priorState?.embeddingRecovery || null,
+                            causeCode    : embeddingRecoveryCause,
+                            failedAt     : startedMs
+                        })
+                        : (!workStarted ? (priorState?.embeddingRecovery || null) : null);
+
                 persistedRevisions[repoLabel] = {
                     lastIngestedRev                      : priorState?.lastIngestedRev || null,
                     lastRunAttemptAt                     : startedMs,
@@ -1679,7 +2051,8 @@ class TenantRepoSyncService extends Base {
                     lastErrorCode      : code ?? null,
                     lastSourceErrorCode: sourceErrorCode ?? null,
                     lastAccessCode     : classifySyncFailure(e),
-                    lastErrorAt        : Date.now()
+                    lastErrorAt        : Date.now(),
+                    embeddingRecovery
                 };
 
                 const failedRepoState = {
@@ -1690,7 +2063,12 @@ class TenantRepoSyncService extends Base {
                     status             : 'degraded',
                     checkpointStatus   : classifyTenantRepoCheckpoint(persistedRevisions[repoLabel]),
                     lastErrorCode      : code,
-                    consecutiveFailures: nextFailureCount
+                    consecutiveFailures: nextFailureCount,
+                    recoveryState      : classifyEmbeddingRecoveryState({
+                        persistedRepoState: persistedRevisions[repoLabel],
+                        probeSnapshot     : this.getEmbeddingRecoveryProbeSnapshot(),
+                        observedAt        : startedMs
+                    })
                 };
 
                 if (sourceErrorCode) {
@@ -1968,7 +2346,9 @@ class TenantRepoSyncService extends Base {
      * @param {Object} options
      * @param {String} options.filePath
      * @param {Object} [options.fsModule=fs] File-system implementation seam (fault-injection test seam).
-     * @returns {Promise<Object<String, {startedMs: Number, priorFailures: Number}>>}
+     * @returns {Promise<Object<String, {startedMs: Number, priorFailures: Number,
+     *     priorSourceErrorCode: String|null, priorAccessCode: String|null,
+     *     recoveryEpisodeId: String|null, recoveryGenerationId: String|null}>>}
      */
     async readInFlightAttempts({filePath, fsModule = fs}) {
         try {
@@ -1992,14 +2372,16 @@ class TenantRepoSyncService extends Base {
      *
      * @param {Object} options
      * @param {String} options.filePath
-     * @param {Object<String, {startedMs: Number, priorFailures: Number}>} options.attempts
+     * @param {Object<String, {startedMs: Number, priorFailures: Number,
+     *     priorSourceErrorCode: String|null, priorAccessCode: String|null,
+     *     recoveryEpisodeId: String|null, recoveryGenerationId: String|null}>} options.attempts
      * @param {Object} [options.fsModule=fs] File-system implementation seam (fault-injection test seam).
-     * @returns {Promise<void>}
+     * @returns {Promise<Boolean>} Whether the sidecar mutation committed.
      */
     async writeInFlightAttempts({filePath, attempts, fsModule = fs}) {
         if (Object.keys(attempts).length === 0) {
             await fsModule.remove(filePath).catch(() => {});
-            return
+            return true
         }
 
         const tmpPath = `${filePath}.tmp-${process.pid}`;
@@ -2008,12 +2390,14 @@ class TenantRepoSyncService extends Base {
             await fsModule.ensureDir(path.dirname(filePath));
             await fsModule.writeFile(tmpPath, JSON.stringify(attempts, null, 2) + '\n');
             await fsModule.rename(tmpPath, filePath);
+            return true
         } catch (e) {
             // Best-effort by contract: a sidecar write failure must not fail a repo whose actual
             // sync is fine. The cost is exactly one unrecorded attempt — the same price the
             // write-behind behaviour paid on every crash — so failing the run here would be
             // strictly worse than the defect this record exists to fix.
             await fsModule.remove(tmpPath).catch(() => {});
+            return false
         }
     }
 
@@ -2027,7 +2411,9 @@ class TenantRepoSyncService extends Base {
      * backoff term. Mutates `persistedRevisions` in place; the caller commits it.
      *
      * @param {Object} options
-     * @param {Object<String, {startedMs: Number, priorFailures: Number}>} options.attempts
+     * @param {Object<String, {startedMs: Number, priorFailures: Number,
+     *     priorSourceErrorCode: String|null, priorAccessCode: String|null,
+     *     recoveryEpisodeId: String|null, recoveryGenerationId: String|null}>} options.attempts
      * @param {Object} options.persistedRevisions Mutated in place.
      * @param {Function} [options.writeLog]
      * @returns {Number} Count of folded attempts.
@@ -2047,7 +2433,29 @@ class TenantRepoSyncService extends Base {
                 // would re-derive the same base every restart and the term would never grow.
                 priorFailures = Number.isFinite(Number(attempt?.priorFailures))
                     ? Number(attempt.priorFailures)
-                    : (priorState?.consecutiveFailures ?? 0);
+                    : (priorState?.consecutiveFailures ?? 0),
+                priorRecovery = priorState?.embeddingRecovery || null,
+                recoveryGrantMatches = Boolean(
+                    priorRecovery
+                    && attempt?.recoveryEpisodeId === priorRecovery.episodeId
+                    && attempt?.recoveryGenerationId === priorRecovery.generationId
+                ),
+                retainedSourceErrorCode = (
+                    typeof attempt?.priorSourceErrorCode === 'string'
+                    && BOUNDED_KB_ERROR_CODE_PATTERN.test(attempt.priorSourceErrorCode)
+                )
+                    ? attempt.priorSourceErrorCode
+                    : (priorState?.lastSourceErrorCode ?? null),
+                foldedRecovery = recoveryGrantMatches
+                    ? buildEmbeddingRecoveryAfterFailure({
+                        priorRecovery: {
+                            ...priorRecovery,
+                            bypassConsumedAt: startedMs
+                        },
+                        causeCode: priorRecovery.causeCode,
+                        failedAt : startedMs
+                    })
+                    : priorRecovery;
 
             persistedRevisions[repoLabel] = {
                 ...priorState,
@@ -2057,9 +2465,13 @@ class TenantRepoSyncService extends Base {
                 lastRunAttemptAt   : startedMs,
                 consecutiveFailures: priorFailures + 1,
                 lastErrorCode      : KB_TENANT_REPO_SYNC_SYNC_FAILED,
-                lastSourceErrorCode: null,
-                lastAccessCode     : null,
-                lastErrorAt        : startedMs
+                lastSourceErrorCode: retainedSourceErrorCode,
+                // The manifest reader already applied the bounded-code allowlist. The sidecar is
+                // only a crash witness, never a second authority for diagnostic vocabulary: a
+                // torn or hand-edited sidecar must not project arbitrary text into durable state.
+                lastAccessCode   : priorState?.lastAccessCode ?? null,
+                lastErrorAt      : startedMs,
+                embeddingRecovery: foldedRecovery
             };
 
             folded++;

--- a/ai/daemons/orchestrator/services/tenantRepoCheckpointValidity.mjs
+++ b/ai/daemons/orchestrator/services/tenantRepoCheckpointValidity.mjs
@@ -23,7 +23,19 @@
  */
 export const TENANT_REPO_INGEST_CONTRACT_VERSION = 2;
 
-const MATERIALIZATION_ATTEMPT_ID_PATTERN = /^[a-f0-9]{32}$/u;
+const
+    EMBEDDING_RECOVERY_ID_PATTERN      = /^[a-f0-9]{32}$/u,
+    MATERIALIZATION_ATTEMPT_ID_PATTERN = /^[a-f0-9]{32}$/u;
+
+/**
+ * @summary Closed source-code family that can arm an embedding-recovery episode.
+ *
+ * These codes are minted by the Knowledge Base embed-failure boundary. The prefix is both bounded
+ * by the checkpoint's general `KB_*` reader gate and specific enough that a Git/access/parser fault
+ * cannot accidentally inherit an embedding recovery grant.
+ * @type {RegExp}
+ */
+export const EMBEDDING_RECOVERY_SOURCE_CODE_PATTERN = /^KB_VECTOR_EMBED_[A-Z0-9_]{1,100}$/u;
 
 /**
  * Bounded diagnostic-code vocabulary for the retained failure cause.
@@ -89,7 +101,8 @@ export function normalizeTenantRepoCheckpointState(value) {
             lastErrorCode      : null,
             lastSourceErrorCode: null,
             lastAccessCode     : null,
-            lastErrorAt        : null
+            lastErrorAt        : null,
+            embeddingRecovery  : null
         };
     }
 
@@ -121,7 +134,79 @@ export function normalizeTenantRepoCheckpointState(value) {
         lastErrorCode      : normalizeBoundedErrorCode(value.lastErrorCode),
         lastSourceErrorCode: normalizeBoundedErrorCode(value.lastSourceErrorCode),
         lastAccessCode     : normalizeBoundedErrorCode(value.lastAccessCode),
-        lastErrorAt        : normalizeNonNegativeNumber(value.lastErrorAt) || null
+        lastErrorAt        : normalizeNonNegativeNumber(value.lastErrorAt) || null,
+        embeddingRecovery  : normalizeEmbeddingRecovery(value.embeddingRecovery)
+    };
+}
+
+/**
+ * @summary Returns whether a bounded checkpoint cause belongs to the embedding dependency.
+ * @param {*} value Candidate retained source code.
+ * @returns {Boolean}
+ */
+export function isEmbeddingRecoverySourceCode(value) {
+    return typeof value === 'string' && EMBEDDING_RECOVERY_SOURCE_CODE_PATTERN.test(value);
+}
+
+/**
+ * @summary Normalizes one durable embedding recovery episode without manufacturing an observation.
+ *
+ * An episode requires its own opaque id, embedding-class cause, and detected timestamp. A recovery
+ * generation exists only when both its opaque id and observed timestamp are present; consumption
+ * exists only behind that proved generation. Any partial or malformed branch degrades by omission,
+ * so a restart can never synthesize a due-bypass from torn or hand-edited state.
+ *
+ * @param {*} value Candidate persisted episode.
+ * @returns {Object|null}
+ * @private
+ */
+function normalizeEmbeddingRecovery(value) {
+    if (!value || typeof value !== 'object' || Array.isArray(value)) {
+        return null;
+    }
+
+    const
+        episodeId  = normalizeEmbeddingRecoveryId(value.episodeId),
+        causeCode  = isEmbeddingRecoverySourceCode(value.causeCode) ? value.causeCode : null,
+        detectedAt = normalizeNonNegativeNumber(value.detectedAt) || null;
+
+    if (!episodeId || !causeCode || !detectedAt) {
+        return null;
+    }
+
+    const
+        candidateGenerationId = normalizeEmbeddingRecoveryId(value.generationId),
+        candidateObservedAt   = normalizeNonNegativeNumber(value.observedAt) || null,
+        generationProved      = Boolean(candidateGenerationId && candidateObservedAt),
+        candidateConsumedAt   = generationProved
+            ? (normalizeNonNegativeNumber(value.bypassConsumedAt) || null)
+            : null,
+        historyGenerationId   = normalizeEmbeddingRecoveryId(value.lastConsumedGenerationId),
+        historyConsumedAt     = normalizeNonNegativeNumber(value.lastConsumedAt) || null,
+        historyProved         = Boolean(historyGenerationId && historyConsumedAt);
+
+    // A consumed current generation is stable history, not a pending grant. Canonicalizing it here
+    // makes a restart re-arm the canary generation while retaining the exact receipt that rotates
+    // the process-local gate key; it can never reuse the consumed bypass.
+    const
+        generationId             = generationProved && !candidateConsumedAt ? candidateGenerationId : null,
+        observedAt               = generationProved && !candidateConsumedAt ? candidateObservedAt : null,
+        lastConsumedGenerationId = candidateConsumedAt
+            ? candidateGenerationId
+            : (historyProved ? historyGenerationId : null),
+        lastConsumedAt = candidateConsumedAt
+            ? candidateConsumedAt
+            : (historyProved ? historyConsumedAt : null);
+
+    return {
+        episodeId,
+        causeCode,
+        detectedAt,
+        generationId,
+        observedAt,
+        bypassConsumedAt: null,
+        lastConsumedGenerationId,
+        lastConsumedAt
     };
 }
 
@@ -248,6 +333,17 @@ function normalizeContractVersion(value) {
  */
 function normalizeMaterializationAttemptId(value) {
     return typeof value === 'string' && MATERIALIZATION_ATTEMPT_ID_PATTERN.test(value)
+        ? value
+        : null;
+}
+
+/**
+ * @summary Accepts only opaque ids minted for embedding recovery episodes and generations.
+ * @param {*} value Candidate id.
+ * @returns {String|null}
+ */
+function normalizeEmbeddingRecoveryId(value) {
+    return typeof value === 'string' && EMBEDDING_RECOVERY_ID_PATTERN.test(value)
         ? value
         : null;
 }

--- a/test/playwright/unit/ai/daemons/orchestrator/scheduling/tenantRepoSync.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/scheduling/tenantRepoSync.spec.mjs
@@ -1,9 +1,11 @@
 import {test, expect} from '@playwright/test';
 import {
     buildTenantRepoSyncTrigger,
+    classifyEmbeddingRecoveryState,
     computeDeterministicJitter,
     detectStarvedTenantSync,
     getDueTask,
+    hasPendingEmbeddingRecoveryBypass,
     isRepoDue,
     isStarvedOrderInverted
 } from '../../../../../../../ai/daemons/orchestrator/scheduling/tenantRepoSync.mjs';
@@ -258,6 +260,93 @@ test.describe('isRepoDue backoff cap (#16224 AC1)', () => {
 
         expect(result.backoffCapped).toBe(false);
         expect(result.effectiveCadenceMs).toBe((60000 + result.jitterMs) * 256);
+    });
+});
+
+test.describe('embedding recovery bypass (#16692)', () => {
+    const
+        episodeId    = 'a'.repeat(32),
+        generationId = 'b'.repeat(32),
+        repo         = {tenantId: 'tenant-a', repoSlug: 'neomjs/create-app'},
+        recovery     = {
+            episodeId,
+            causeCode               : 'KB_VECTOR_EMBED_CONNECTION_REFUSED',
+            detectedAt              : 100,
+            generationId,
+            observedAt              : 200,
+            bypassConsumedAt        : null,
+            lastConsumedGenerationId: null,
+            lastConsumedAt          : null
+        },
+        suppressedState = {
+            lastRunAttemptAt   : 1_000,
+            consecutiveFailures: 8
+        };
+
+    test('one durable unconsumed generation bypasses cadence without rewriting backoff truth', () => {
+        const baseline = isRepoDue({
+            repo,
+            persistedRepoState: suppressedState,
+            now               : 1_001,
+            globalCadenceMs   : 60_000,
+            backoffCapMs      : 120_000
+        });
+        const recovered = isRepoDue({
+            repo,
+            persistedRepoState: {...suppressedState, embeddingRecovery: recovery},
+            now               : 1_001,
+            globalCadenceMs   : 60_000,
+            backoffCapMs      : 120_000
+        });
+
+        expect(baseline.due).toBe(false);
+        expect(recovered).toMatchObject({
+            due               : true,
+            dueReason         : 'embedding-recovery',
+            recoveryBypass    : true,
+            backoffMultiplier : baseline.backoffMultiplier,
+            effectiveCadenceMs: baseline.effectiveCadenceMs
+        });
+    });
+
+    test('a consumed generation is history, never another due-bypass', () => {
+        const consumed = {
+            ...suppressedState,
+            embeddingRecovery: {...recovery, bypassConsumedAt: 300}
+        };
+        const due = isRepoDue({
+            repo,
+            persistedRepoState: consumed,
+            now               : 1_001,
+            globalCadenceMs   : 60_000,
+            backoffCapMs      : 120_000
+        });
+
+        expect(hasPendingEmbeddingRecoveryBypass(consumed)).toBe(false);
+        expect(due).toMatchObject({due: false, dueReason: 'not-due', recoveryBypass: false});
+    });
+
+    test('classifies the four failing-repo recovery states from scheduler and probe evidence', () => {
+        const withRecovery  = {...suppressedState, embeddingRecovery: recovery};
+        const awaitingProbe = {
+            ...suppressedState,
+            embeddingRecovery: {...recovery, generationId: null, observedAt: null}
+        };
+
+        expect(classifyEmbeddingRecoveryState({persistedRepoState: suppressedState}))
+            .toBe('ordinary-repo-backoff');
+        expect(classifyEmbeddingRecoveryState({persistedRepoState: withRecovery}))
+            .toBe('recovery-observed/retry-pending');
+        expect(classifyEmbeddingRecoveryState({
+            persistedRepoState: awaitingProbe,
+            probeSnapshot     : {nextAttemptAt: 2_000},
+            observedAt        : 1_500
+        })).toBe('recovery-probe-backoff');
+        expect(classifyEmbeddingRecoveryState({
+            persistedRepoState: awaitingProbe,
+            probeSnapshot     : {nextAttemptAt: 1_000},
+            observedAt        : 1_500
+        })).toBe('still-failing');
     });
 });
 

--- a/test/playwright/unit/ai/daemons/orchestrator/services/DeploymentStateBridgeService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/DeploymentStateBridgeService.spec.mjs
@@ -830,7 +830,7 @@ test.describe('Neo.ai.daemons.services.DeploymentStateBridgeService', () => {
         const tenantRepoSync = await service.collectTenantRepoSyncSnapshot({observedAt: OBSERVED_AT});
 
         expect(tenantRepoSync.status).toBe('not-due');
-        expect(tenantRepoSync.schemaVersion).toBe(2);
+        expect(tenantRepoSync.schemaVersion).toBe(3);
         expect(tenantRepoSync.config).toMatchObject({
             repoCount : 1,
             tierCounts: {yaml: 1}
@@ -861,6 +861,127 @@ test.describe('Neo.ai.daemons.services.DeploymentStateBridgeService', () => {
         expect(JSON.stringify(tenantRepoSync)).not.toContain('private/repo');
         expect(JSON.stringify(tenantRepoSync)).not.toContain('TOKEN');
         expect(JSON.stringify(tenantRepoSync)).not.toContain('must-not-cross-the-bridge');
+    });
+
+    test('collectTenantRepoSyncSnapshot projects bounded embedding-recovery state without durable ids (#16692)', async () => {
+        const
+            episodeId     = '0123456789abcdef'.repeat(2),
+            generationId  = 'fedcba9876543210'.repeat(2),
+            probeSnapshot = {
+                status             : 'failed',
+                checkedAt          : OBSERVED_AT - 1_000,
+                lastDemandCached   : true,
+                failureStreak      : 2,
+                backoffMs          : 60_000,
+                nextAttemptAt      : OBSERVED_AT + 60_000,
+                terminal           : false,
+                stopReason         : null,
+                errorClassification: 'connection-refused',
+                errorCode          : 'ECONNREFUSED',
+                credential         : 'must-not-cross-the-bridge'
+            },
+            checkpoint = {
+                lastIngestedRev                   : null,
+                lastRunAttemptAt                  : OBSERVED_AT - 1_000,
+                consecutiveFailures               : 8,
+                ingestContractVersion             : TENANT_REPO_INGEST_CONTRACT_VERSION,
+                lastAttemptedIngestContractVersion: TENANT_REPO_INGEST_CONTRACT_VERSION,
+                lastErrorCode                     : 'KB_TENANT_REPO_SYNC_SYNC_FAILED',
+                lastSourceErrorCode               : 'KB_VECTOR_EMBED_CONNECTION_REFUSED',
+                lastAccessCode                    : 'KB_TENANT_REPO_ACCESS_TRANSPORT_FAILED',
+                lastErrorAt                       : OBSERVED_AT - 1_000,
+                embeddingRecovery                 : {
+                    episodeId,
+                    causeCode               : 'KB_VECTOR_EMBED_CONNECTION_REFUSED',
+                    detectedAt              : OBSERVED_AT - 10_000,
+                    generationId            : null,
+                    observedAt              : null,
+                    bypassConsumedAt        : null,
+                    lastConsumedGenerationId: generationId,
+                    lastConsumedAt          : OBSERVED_AT - 2_000
+                }
+            },
+            service = createService({
+                taskStateService: {
+                    getTaskState() {
+                        return {running: false, lastCompletion: null};
+                    }
+                },
+                tenantRepoSyncService: {
+                    async resolveTenantReposConfig() {
+                        return {tenantRepos: [{
+                            tenantId  : 'tenant-recovery',
+                            repoSlug  : 'private/recovery',
+                            cloneUrl  : 'https://git.example/private/recovery.git',
+                            cadenceMs : 60_000,
+                            configTier: 'yaml'
+                        }]};
+                    },
+                    defaultRevisionsFilePath() {
+                        return '/state/revisions.json';
+                    },
+                    async readPersistedRevisions() {
+                        return {'tenant-recovery/private/recovery': checkpoint};
+                    },
+                    getTenantRepoAccessReadiness() {
+                        return null;
+                    },
+                    getEmbeddingRecoveryProbeSnapshot() {
+                        return probeSnapshot;
+                    }
+                },
+                tenantRepoSyncEnabledReader: () => true
+            });
+
+        const snapshot = await service.collectTenantRepoSyncSnapshot({observedAt: OBSERVED_AT});
+
+        expect(snapshot.schemaVersion).toBe(3);
+        expect(snapshot.embeddingRecoveryProbe).toEqual({
+            status             : 'failed',
+            checkedAt          : OBSERVED_AT - 1_000,
+            lastDemandCached   : true,
+            failureStreak      : 2,
+            backoffMs          : 60_000,
+            nextAttemptAt      : OBSERVED_AT + 60_000,
+            terminal           : false,
+            stopReason         : null,
+            errorClassification: 'connection-refused',
+            errorCode          : 'ECONNREFUSED'
+        });
+        expect(snapshot.repos[0]).toMatchObject({
+            status             : 'not-due',
+            stopReasonCode     : 'KB_VECTOR_EMBED_CONNECTION_REFUSED',
+            lastErrorCode      : 'KB_TENANT_REPO_SYNC_SYNC_FAILED',
+            lastSourceErrorCode: 'KB_VECTOR_EMBED_CONNECTION_REFUSED',
+            lastAccessCode     : 'KB_TENANT_REPO_ACCESS_TRANSPORT_FAILED',
+            recoveryState      : 'recovery-probe-backoff'
+        });
+
+        const serialized = JSON.stringify(snapshot);
+
+        expect(serialized).not.toContain(episodeId);
+        expect(serialized).not.toContain(generationId);
+        expect(serialized).not.toContain('tenant-recovery');
+        expect(serialized).not.toContain('private/recovery');
+        expect(serialized).not.toContain('must-not-cross-the-bridge');
+
+        checkpoint.embeddingRecovery = {
+            ...checkpoint.embeddingRecovery,
+            generationId,
+            observedAt              : OBSERVED_AT - 500,
+            lastConsumedGenerationId: null,
+            lastConsumedAt          : null
+        };
+
+        const retryPendingSnapshot = await service.collectTenantRepoSyncSnapshot({observedAt: OBSERVED_AT});
+
+        expect(retryPendingSnapshot.repos[0]).toMatchObject({
+            due          : true,
+            nextDueAt    : new Date(OBSERVED_AT).toISOString(),
+            recoveryState: 'recovery-observed/retry-pending'
+        });
+        expect(JSON.stringify(retryPendingSnapshot)).not.toContain(generationId);
+        service.destroy();
     });
 
     test('collectTenantRepoSyncSnapshot projects mixed access readiness through a deep allowlist', async () => {

--- a/test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncService.spec.mjs
@@ -24,8 +24,10 @@ import os              from 'os';
 import path            from 'path';
 import {fileURLToPath} from 'url';
 
-import TenantRepoSyncService        from '../../../../../../../ai/daemons/orchestrator/services/TenantRepoSyncService.mjs';
+import TenantRepoSyncService from '../../../../../../../ai/daemons/orchestrator/services/TenantRepoSyncService.mjs';
+import {isRepoDue}           from '../../../../../../../ai/daemons/orchestrator/scheduling/tenantRepoSync.mjs';
 import {
+    normalizeTenantRepoCheckpointState,
     TENANT_REPO_INGEST_CONTRACT_VERSION
 } from '../../../../../../../ai/daemons/orchestrator/services/tenantRepoCheckpointValidity.mjs';
 import {deriveTenantRepoMirrorPath} from '../../../../../../../ai/services/knowledge-base/helpers/tenantRepoAccessContract.mjs';
@@ -199,6 +201,335 @@ test.describe('TenantRepoSyncService (#11790)', () => {
         TenantRepoSyncService.concurrencyLimit         = 2;
         TenantRepoSyncService.concurrencyGateTimeoutMs = 30000;
         TenantRepoSyncService.clearTenantRepoAccessReadiness();
+        TenantRepoSyncService.clearEmbeddingRecoveryProbeState();
+    });
+
+    test('embedding recovery checkpoints degrade by omission, retain restart truth, and consumed grants become history (#16692)', async () => {
+        const
+            episodeId    = 'a'.repeat(32),
+            generationId = 'b'.repeat(32),
+            recovery     = {
+                episodeId,
+                causeCode               : 'KB_VECTOR_EMBED_CONNECTION_REFUSED',
+                detectedAt              : 100,
+                generationId,
+                observedAt              : 200,
+                bypassConsumedAt        : null,
+                lastConsumedGenerationId: null,
+                lastConsumedAt          : null
+            };
+
+        expect(normalizeTenantRepoCheckpointState({
+            embeddingRecovery: {...recovery, episodeId: 'not-an-opaque-id'}
+        }).embeddingRecovery).toBeNull();
+        expect(normalizeTenantRepoCheckpointState({
+            embeddingRecovery: {...recovery, causeCode: 'KB_GITMIRROR_FETCH_FAILED'}
+        }).embeddingRecovery).toBeNull();
+        expect(normalizeTenantRepoCheckpointState({
+            embeddingRecovery: {...recovery, observedAt: null}
+        }).embeddingRecovery).toMatchObject({
+            episodeId,
+            generationId: null,
+            observedAt  : null
+        });
+
+        const normalized = normalizeTenantRepoCheckpointState({
+            embeddingRecovery: {...recovery, bypassConsumedAt: 300}
+        }).embeddingRecovery;
+
+        expect(normalized).toEqual({
+            episodeId,
+            causeCode               : recovery.causeCode,
+            detectedAt              : 100,
+            generationId            : null,
+            observedAt              : null,
+            bypassConsumedAt        : null,
+            lastConsumedGenerationId: generationId,
+            lastConsumedAt          : 300
+        });
+
+        await TenantRepoSyncService.writePersistedRevisions({
+            filePath : revisionsFile,
+            revisions: {'t1/org/restart-boundary': {
+                lastIngestedRev                   : null,
+                lastRunAttemptAt                  : 1_000,
+                consecutiveFailures               : 13,
+                ingestContractVersion             : TENANT_REPO_INGEST_CONTRACT_VERSION,
+                lastAttemptedIngestContractVersion: TENANT_REPO_INGEST_CONTRACT_VERSION,
+                lastErrorCode                     : 'KB_TENANT_REPO_SYNC_SYNC_FAILED',
+                lastSourceErrorCode               : recovery.causeCode,
+                lastErrorAt                       : 1_000,
+                embeddingRecovery                 : {
+                    ...recovery,
+                    generationId    : null,
+                    observedAt      : null,
+                    bypassConsumedAt: null
+                }
+            }}
+        });
+        TenantRepoSyncService.clearEmbeddingRecoveryProbeState();
+
+        const restarted = (await TenantRepoSyncService.readPersistedRevisions({
+            filePath: revisionsFile,
+            strict  : true
+        }))['t1/org/restart-boundary'];
+
+        expect(restarted).toMatchObject({
+            consecutiveFailures: 13,
+            lastSourceErrorCode: recovery.causeCode,
+            embeddingRecovery  : {
+                episodeId,
+                causeCode   : recovery.causeCode,
+                generationId: null,
+                observedAt  : null
+            }
+        });
+        expect(isRepoDue({
+            repo              : {tenantId: 't1', repoSlug: 'org/restart-boundary'},
+            persistedRepoState: restarted,
+            now               : 1_001,
+            globalCadenceMs   : 60_000,
+            backoffCapMs      : 120_000
+        })).toMatchObject({due: false, recoveryBypass: false});
+        expect(TenantRepoSyncService.getEmbeddingRecoveryProbeSnapshot().status).toBe('never-started');
+    });
+
+    test('embedding recovery releases only the affected repo once, then rearms after a failed retry (#16692)', async () => {
+        const
+            taskStateService = createInMemoryTaskStateService(),
+            embeddingSlug    = 'org/embedding-recovery',
+            ordinarySlug     = 'org/ordinary-backoff',
+            mirrorCalls      = [],
+            probeKeys        = [],
+            removedEpisodeId = 'c'.repeat(32),
+            startedAt        = Date.now();
+        let ingestCallCount = 0,
+            probeCallCount  = 0,
+            probeNow        = startedAt;
+
+        await provisionMirrorDir({tenantId: 't1', repoSlug: embeddingSlug});
+        await TenantRepoSyncService.writePersistedRevisions({
+            filePath : revisionsFile,
+            revisions: {
+                [`t1/${embeddingSlug}`]: {
+                    lastIngestedRev                   : null,
+                    lastRunAttemptAt                  : startedAt - 120_000,
+                    consecutiveFailures               : 7,
+                    ingestContractVersion             : TENANT_REPO_INGEST_CONTRACT_VERSION,
+                    lastAttemptedIngestContractVersion: TENANT_REPO_INGEST_CONTRACT_VERSION
+                },
+                [`t1/${ordinarySlug}`]: {
+                    lastIngestedRev                   : null,
+                    lastRunAttemptAt                  : startedAt,
+                    consecutiveFailures               : 7,
+                    ingestContractVersion             : TENANT_REPO_INGEST_CONTRACT_VERSION,
+                    lastAttemptedIngestContractVersion: TENANT_REPO_INGEST_CONTRACT_VERSION,
+                    lastErrorCode                     : 'KB_TENANT_REPO_SYNC_SYNC_FAILED',
+                    lastSourceErrorCode               : 'KB_GITMIRROR_FETCH_FAILED',
+                    lastAccessCode                    : 'KB_TENANT_REPO_ACCESS_TRANSPORT_FAILED',
+                    lastErrorAt                       : startedAt
+                }
+            }
+        });
+
+        const options = {
+            reason           : 'periodic-sweep:60000',
+            taskStateService,
+            tenantReposConfig: {tenantRepos: [embeddingSlug, ordinarySlug].map(repoSlug => ({
+                tenantId: 't1', repoSlug, mirrorRoot, cloneUrl: `https://github.com/neomjs/${repoSlug.split('/')[1]}.git`
+            }))},
+            gitMirror                    : makeFakeGitMirror({captureCalls: mirrorCalls}),
+            envelopeBuilder              : makeFakeEnvelopeBuilder(),
+            knowledgeBaseIngestionService: makeFakeIngestionService({
+                summaryFactory() {
+                    ingestCallCount++;
+
+                    return ingestCallCount <= 2
+                        ? {ingested: 1, deleted: 0, errors: [{code: 'KB_VECTOR_EMBED_CONNECTION_REFUSED'}]}
+                        : {ingested: 1, deleted: 0, errors: []}
+                }
+            }),
+            revisionsFilePath: revisionsFile,
+            globalCadenceMs  : 60_000,
+            jitterRatio      : 0,
+            backoffCapMs     : 60_000,
+            seedBootstrap    : false,
+            embeddingRecoveryProbe({key}) {
+                probeCallCount++;
+                probeKeys.push(key);
+
+                return probeCallCount === 1
+                    ? {
+                        status             : 'failed',
+                        errorClassification: 'connection-refused',
+                        errorCode          : 'EMBEDDING_CONNECTION_REFUSED'
+                    }
+                    : {status: 'healthy'}
+            },
+            embeddingRecoveryClock          : () => probeNow,
+            embeddingRecoveryFailureTtlMs   : 60_000,
+            embeddingRecoveryFailureTtlMaxMs: 60_000
+        };
+
+        const initialFailure = await TenantRepoSyncService.runTask(options);
+        let   persisted      = (await fs.readJson(revisionsFile)).revisions;
+        const episodeId      = persisted[`t1/${embeddingSlug}`].embeddingRecovery.episodeId;
+
+        expect(initialFailure.status).toBe('failed');
+        expect(persisted[`t1/${embeddingSlug}`].embeddingRecovery).toMatchObject({
+            episodeId,
+            causeCode   : 'KB_VECTOR_EMBED_CONNECTION_REFUSED',
+            generationId: null,
+            observedAt  : null
+        });
+        expect(persisted[`t1/${ordinarySlug}`].embeddingRecovery).toBeNull();
+        expect(ingestCallCount).toBe(1);
+
+        persisted['t1/org/removed-repo'] = {
+            lastIngestedRev                   : null,
+            lastRunAttemptAt                  : startedAt,
+            consecutiveFailures               : 4,
+            ingestContractVersion             : TENANT_REPO_INGEST_CONTRACT_VERSION,
+            lastAttemptedIngestContractVersion: TENANT_REPO_INGEST_CONTRACT_VERSION,
+            lastErrorCode                     : 'KB_TENANT_REPO_SYNC_SYNC_FAILED',
+            lastSourceErrorCode               : 'KB_VECTOR_EMBED_CONNECTION_REFUSED',
+            lastErrorAt                       : startedAt,
+            embeddingRecovery                 : {
+                episodeId               : removedEpisodeId,
+                causeCode               : 'KB_VECTOR_EMBED_CONNECTION_REFUSED',
+                detectedAt              : startedAt,
+                generationId            : null,
+                observedAt              : null,
+                bypassConsumedAt        : null,
+                lastConsumedGenerationId: null,
+                lastConsumedAt          : null
+            }
+        };
+        await TenantRepoSyncService.writePersistedRevisions({
+            filePath : revisionsFile,
+            revisions: persisted
+        });
+
+        const failedCanary = await TenantRepoSyncService.runTask(options);
+
+        expect(probeCallCount).toBe(1);
+        expect(probeKeys[0]).toContain(episodeId);
+        expect(probeKeys[0]).not.toContain(removedEpisodeId);
+        expect(ingestCallCount).toBe(1);
+        expect(failedCanary.details.repos.find(repo => repo.repoSlug === embeddingSlug).recoveryState)
+            .toBe('recovery-probe-backoff');
+        expect(failedCanary.details.repos.find(repo => repo.repoSlug === ordinarySlug).recoveryState)
+            .toBe('ordinary-repo-backoff');
+
+        probeNow = startedAt + 30_000;
+        await TenantRepoSyncService.runTask(options);
+        expect(probeCallCount, 'the failed canary is cached inside its bounded backoff').toBe(1);
+        expect(ingestCallCount).toBe(1);
+
+        probeNow = startedAt + 60_001;
+        const failedRecoveryRetry = await TenantRepoSyncService.runTask(options);
+
+        persisted = (await fs.readJson(revisionsFile)).revisions;
+        const rearmed = persisted[`t1/${embeddingSlug}`].embeddingRecovery;
+
+        expect(probeCallCount).toBe(2);
+        expect(ingestCallCount).toBe(2);
+        expect(failedRecoveryRetry.details.repos.find(repo => repo.repoSlug === embeddingSlug).recoveryState)
+            .toBe('still-failing');
+        expect(rearmed).toMatchObject({
+            episodeId,
+            generationId: null,
+            observedAt  : null
+        });
+        expect(persisted[`t1/${embeddingSlug}`].consecutiveFailures).toBe(9);
+        expect(rearmed.lastConsumedGenerationId).toMatch(/^[a-f0-9]{32}$/u);
+
+        probeNow = startedAt + 60_002;
+        const recovered = await TenantRepoSyncService.runTask(options);
+
+        persisted = (await fs.readJson(revisionsFile)).revisions;
+
+        expect(recovered.status).toBe('completed');
+        expect(probeCallCount, 'consumption history rotates the gate key immediately').toBe(3);
+        expect(ingestCallCount).toBe(3);
+        expect(persisted[`t1/${embeddingSlug}`].consecutiveFailures).toBe(0);
+        expect(persisted[`t1/${embeddingSlug}`].embeddingRecovery).toBeUndefined();
+        expect(persisted[`t1/${ordinarySlug}`].consecutiveFailures).toBe(7);
+        expect(mirrorCalls.filter(call => call.args.repoSlug === ordinarySlug)).toHaveLength(0);
+    });
+
+    test('a recovery bypass without a durable write-ahead receipt is deferred unconsumed (#16692)', async () => {
+        const
+            taskStateService      = createInMemoryTaskStateService(),
+            repoSlug              = 'org/recovery-receipt',
+            mirrorCalls           = [],
+            episodeId             = 'a'.repeat(32),
+            generationId          = 'b'.repeat(32),
+            originalWriteInFlight = TenantRepoSyncService.writeInFlightAttempts.bind(TenantRepoSyncService);
+
+        await TenantRepoSyncService.writePersistedRevisions({
+            filePath : revisionsFile,
+            revisions: {
+                [`t1/${repoSlug}`]: {
+                    lastIngestedRev                   : null,
+                    lastRunAttemptAt                  : Date.now(),
+                    consecutiveFailures               : 8,
+                    ingestContractVersion             : TENANT_REPO_INGEST_CONTRACT_VERSION,
+                    lastAttemptedIngestContractVersion: TENANT_REPO_INGEST_CONTRACT_VERSION,
+                    lastErrorCode                     : 'KB_TENANT_REPO_SYNC_SYNC_FAILED',
+                    lastSourceErrorCode               : 'KB_VECTOR_EMBED_CONNECTION_REFUSED',
+                    lastErrorAt                       : Date.now(),
+                    embeddingRecovery                 : {
+                        episodeId,
+                        causeCode               : 'KB_VECTOR_EMBED_CONNECTION_REFUSED',
+                        detectedAt              : Date.now() - 10_000,
+                        generationId,
+                        observedAt              : Date.now() - 1_000,
+                        bypassConsumedAt        : null,
+                        lastConsumedGenerationId: null,
+                        lastConsumedAt          : null
+                    }
+                }
+            }
+        });
+
+        TenantRepoSyncService.writeInFlightAttempts = async options =>
+            Object.keys(options.attempts).length > 0 ? false : originalWriteInFlight(options);
+
+        let result;
+        try {
+            result = await TenantRepoSyncService.runTask({
+                reason           : 'periodic-sweep:60000',
+                taskStateService,
+                tenantReposConfig: {tenantRepos: [{
+                    tenantId: 't1', repoSlug, mirrorRoot, cloneUrl: 'https://github.com/neomjs/recovery-receipt.git'
+                }]},
+                gitMirror                    : makeFakeGitMirror({captureCalls: mirrorCalls}),
+                envelopeBuilder              : makeFakeEnvelopeBuilder(),
+                knowledgeBaseIngestionService: makeFakeIngestionService(),
+                revisionsFilePath            : revisionsFile,
+                globalCadenceMs              : 60_000,
+                jitterRatio                  : 0,
+                backoffCapMs                 : 120_000,
+                seedBootstrap                : false
+            });
+        } finally {
+            TenantRepoSyncService.writeInFlightAttempts = originalWriteInFlight;
+        }
+
+        const persisted = (await fs.readJson(revisionsFile)).revisions[`t1/${repoSlug}`];
+
+        expect(result.details.repos[0]).toMatchObject({
+            status       : 'recovery-receipt-deferred',
+            recoveryState: 'recovery-observed/retry-pending'
+        });
+        expect(mirrorCalls).toHaveLength(0);
+        expect(persisted.embeddingRecovery).toMatchObject({
+            episodeId,
+            generationId,
+            bypassConsumedAt: null
+        });
+        expect(persisted.consecutiveFailures).toBe(8);
     });
 
     test('skipped when no tenantRepos configured', async () => {
@@ -2707,7 +3038,8 @@ test.describe('TenantRepoSyncService (#11790)', () => {
             lastErrorCode      : 'KB_TENANT_REPO_SYNC_SYNC_FAILED',
             lastSourceErrorCode: null,
             lastAccessCode     : 'KB_TENANT_REPO_ACCESS_SYNC_FAILED',
-            lastErrorAt        : expect.any(Number)
+            lastErrorAt        : expect.any(Number),
+            embeddingRecovery  : null
         });
     });
 
@@ -3511,6 +3843,82 @@ test.describe('TenantRepoSyncService (#11790)', () => {
         expect(repoState.status).toBe('backoff-suppressed');
         expect(repoState.consecutiveFailures).toBe(1);
         expect(new Date(repoState.nextDueAt).getTime()).toBe(crashedAttemptAt + 2 * 60 * 60_000);
+    });
+
+    test('a crashed recovery retry consumes its generation without synthesizing another bypass (#16692)', async () => {
+        const
+            taskStateService = createInMemoryTaskStateService(),
+            inFlightFile     = `${revisionsFile}.in-flight`,
+            crashedAttemptAt = Date.now(),
+            episodeId        = 'a'.repeat(32),
+            generationId     = 'b'.repeat(32);
+
+        TenantRepoSyncService.clearEmbeddingRecoveryProbeState();
+
+        await fs.writeJson(revisionsFile, {revisions: {'t1/org/lease-repo': {
+            lastIngestedRev                   : null,
+            lastRunAttemptAt                  : crashedAttemptAt - 120_000,
+            consecutiveFailures               : 7,
+            ingestContractVersion             : TENANT_REPO_INGEST_CONTRACT_VERSION,
+            lastAttemptedIngestContractVersion: TENANT_REPO_INGEST_CONTRACT_VERSION,
+            lastErrorCode                     : 'KB_TENANT_REPO_SYNC_SYNC_FAILED',
+            lastSourceErrorCode               : 'KB_VECTOR_EMBED_CONNECTION_REFUSED',
+            lastAccessCode                    : 'KB_TENANT_REPO_ACCESS_TRANSPORT_FAILED',
+            lastErrorAt                       : crashedAttemptAt - 120_000,
+            embeddingRecovery                 : {
+                episodeId,
+                causeCode               : 'KB_VECTOR_EMBED_CONNECTION_REFUSED',
+                detectedAt              : crashedAttemptAt - 120_000,
+                generationId,
+                observedAt              : crashedAttemptAt - 60_000,
+                bypassConsumedAt        : null,
+                lastConsumedGenerationId: null,
+                lastConsumedAt          : null
+            }
+        }}});
+        await fs.writeJson(inFlightFile, {'t1/org/lease-repo': {
+            startedMs           : crashedAttemptAt,
+            priorFailures       : 7,
+            priorSourceErrorCode: 'KB_VECTOR_EMBED_CONNECTION_REFUSED',
+            priorAccessCode     : 'credential=must-not-cross-the-sidecar-boundary',
+            recoveryEpisodeId   : episodeId,
+            recoveryGenerationId: generationId
+        }});
+
+        const result = await TenantRepoSyncService.runTask(baseLeaseRunOptions({
+            taskStateService,
+            globalCadenceMs       : 60_000,
+            backoffCapMs          : 120_000,
+            embeddingRecoveryProbe: async () => ({
+                status             : 'failed',
+                errorClassification: 'connection-refused',
+                errorCode          : 'EMBEDDING_CONNECTION_REFUSED'
+            }),
+            embeddingRecoveryClock          : () => crashedAttemptAt,
+            embeddingRecoveryFailureTtlMs   : 60_000,
+            embeddingRecoveryFailureTtlMaxMs: 60_000
+        }));
+        const persisted = (await fs.readJson(revisionsFile)).revisions['t1/org/lease-repo'];
+
+        expect(persisted).toMatchObject({
+            consecutiveFailures: 8,
+            lastRunAttemptAt   : crashedAttemptAt,
+            lastSourceErrorCode: 'KB_VECTOR_EMBED_CONNECTION_REFUSED',
+            lastAccessCode     : 'KB_TENANT_REPO_ACCESS_TRANSPORT_FAILED',
+            embeddingRecovery  : {
+                episodeId,
+                generationId            : null,
+                observedAt              : null,
+                lastConsumedGenerationId: generationId,
+                lastConsumedAt          : crashedAttemptAt
+            }
+        });
+        expect(result.details.repos[0]).toMatchObject({
+            status       : 'backoff-suppressed',
+            recoveryState: 'recovery-probe-backoff'
+        });
+        expect(JSON.stringify(persisted)).not.toContain('must-not-cross-the-sidecar-boundary');
+        expect(await fs.pathExists(inFlightFile)).toBe(false);
     });
 
     // The exponential term has to keep growing across successive crashes, which is the whole


### PR DESCRIPTION
Resolves #16692

The tenant-repo scheduler now keeps its durable per-repo cadence and failure streak as the sole scheduling authority while adding the missing dependency-recovery path. A retained `KB_VECTOR_EMBED_*` cause arms a process-owned embedding canary paced by `boundedRetryGate`; a healthy observation is committed as one scoped durable generation, and only that generation can bypass cadence once. The retry is write-ahead witnessed, crash-folded, and observable through a bounded deployment-state projection without leaking repository identities, durable episode IDs, or credentials.

Evidence: L2 (182 focused scheduler/service/bridge tests, including restart, crash, write-ahead failure, sustained-failure rearm, cohort scoping, and redaction falsifiers) → L3 required (deployed orchestrator observes a repaired embedding provider and advances the affected repo before its prior cadence deadline). Residual: AC1 deployment receipt [#16692].

## Deltas from ticket

None substantive. The implementation follows the corrected ticket prescription and makes two implicit safety boundaries explicit: a recovery grant is not consumed unless its attempt has a durable in-flight receipt, and stale checkpoints for no-longer-configured repositories do not join the process canary cohort. A lease-renewal promise is also joined before release so a queued renewal cannot outlive the run it protects.

## Test Evidence

- `NEO_TEST_SKIP_CI=true npm run test-unit -- test/playwright/unit/ai/daemons/orchestrator/scheduling/tenantRepoSync.spec.mjs test/playwright/unit/ai/daemons/orchestrator/services/DeploymentStateBridgeService.spec.mjs test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncService.spec.mjs` — 182 passed after the final rebase.
- `npx lint-staged` — all seven staged files passed whitespace, shorthand, JSDoc-type, ticket-archaeology, block-alignment, parse, AiConfig-test-mutation, and derived-domain gates.
- `git diff --cached --check` — clean before commit.
- Scheduler surface: unit coverage proves the durable one-generation due-bypass preserves the exponential streak and classifies all four recovery states.
- Sync-service surface: unit coverage proves configured-cohort scoping, failed-canary backoff, exactly-once write-ahead consumption, same-episode rearm after a failed recovery retry, restart persistence, and crash folding.
- Deployment bridge surface: unit coverage proves bounded status/error projection, immediate `nextDueAt` for a committed recovery generation, and omission of credentials plus durable episode/generation IDs.

## Post-Merge Validation

- [ ] On a deployment with retained `KB_VECTOR_EMBED_*` failures, repair the embedding provider and observe `recovery-probe-backoff` → `recovery-observed/retry-pending` → successful affected-repo sync before the previous cadence deadline.
- [ ] Restart the orchestrator before recovery is observed and confirm the durable failure streak and cause survive without synthesizing a generation.
- [ ] Confirm an unrelated repo in ordinary Git/access backoff remains suppressed when the embedding canary recovers.

## Evolution

Ticket intake rejected a literal replacement of the durable scheduler with `boundedRetryGate`, because that primitive is intentionally process-local. The delivered composition instead uses it only for canary cadence; durable checkpoint state owns the recovery episode, generation, consumption history, and every scheduling decision.

Origin Session ID: abdf06f7-5c90-4124-ad28-f0e2897214ee

Authored by Euclid (GPT-5, Codex Desktop). Session abdf06f7-5c90-4124-ad28-f0e2897214ee.
