### PR TITLE
feat(ai): a late embedding defers the ingest run instead of failing it (#16690)

### DIFF
--- a/ai/daemons/orchestrator/scheduling/tenantRepoSync.mjs
+++ b/ai/daemons/orchestrator/scheduling/tenantRepoSync.mjs
@@ -115,18 +115,28 @@ export function classifyEmbeddingRecoveryState({persistedRepoState, probeSnapsho
     const failures = persistedRepoState?.consecutiveFailures ?? 0,
           recovery = persistedRepoState?.embeddingRecovery;
 
-    if (failures <= 0) return null;
-    if (!recovery) return 'ordinary-repo-backoff';
-    if (hasPendingEmbeddingRecoveryBypass(persistedRepoState)) return 'recovery-observed/retry-pending';
+    // Recovery is inspected BEFORE the failure count, and the order is load-bearing. A repo can own
+    // a real episode at a zero streak: a deferred embedding outcome arms recovery without
+    // incrementing failures, because the run neither succeeded nor failed. Reading the streak first
+    // returned `null` for exactly that repo — the one waiting on the dependency the canary
+    // measures — so its canary/backoff/retry-pending state was invisible on every surface that
+    // consumes this classification. The failure count only decides the ORDINARY-backoff case,
+    // which is the one question it can actually answer.
+    if (recovery) {
+        if (hasPendingEmbeddingRecoveryBypass(persistedRepoState)) return 'recovery-observed/retry-pending';
 
-    if (
-        Number.isFinite(probeSnapshot?.nextAttemptAt)
-        && probeSnapshot.nextAttemptAt > observedAt
-    ) {
-        return 'recovery-probe-backoff';
+        if (
+            Number.isFinite(probeSnapshot?.nextAttemptAt)
+            && probeSnapshot.nextAttemptAt > observedAt
+        ) {
+            return 'recovery-probe-backoff';
+        }
+
+        return 'still-failing';
     }
 
-    return 'still-failing';
+    if (failures <= 0) return null;
+    return 'ordinary-repo-backoff';
 }
 
 /**

--- a/ai/daemons/orchestrator/services/TenantRepoSyncService.mjs
+++ b/ai/daemons/orchestrator/services/TenantRepoSyncService.mjs
@@ -10,8 +10,12 @@ import {buildEmbeddingProbeBlock} from '../../../services/shared/embeddingProbe.
 // The filter below and the codes it admits are one contract. Importing the pattern from the module
 // that PRODUCES bounded codes keeps a re-declared copy from drifting into a pair that separately
 // look right — the producer widening a code the filter still rejects is exactly this ticket's defect.
-import {BOUNDED_KB_ERROR_CODE_PATTERN}
-                                 from '../../../services/knowledge-base/helpers/embedFailureClassification.mjs';
+import {
+    BOUNDED_KB_ERROR_CODE_PATTERN,
+    EMBED_DISPOSITION,
+    classifyEmbedDisposition,
+    isEmbedFailureCode
+}                                from '../../../services/knowledge-base/helpers/embedFailureClassification.mjs';
 import {
     buildIngestEnvelope,
     createTenantRepoMaterializationDigest
@@ -299,28 +303,61 @@ function getAccessReadinessMaxAgeMs(repo, globalCadenceMs) {
 }
 
 /**
- * @summary Fails closed unless the KB ingestion result explicitly proves an error-free summary.
+ * @summary Decides whether an ingestion run COMPLETED, DEFERRED, or FAILED.
  *
- * `KnowledgeBaseIngestionService.ingestSourceFiles()` is intentionally fail-soft:
- * ingestion failures are returned inside `summary.errors` rather than necessarily
- * rejecting the promise. The tenant-repo caller therefore accepts only an object
- * with an array-valued, empty `errors` field before advancing revision state.
+ * `KnowledgeBaseIngestionService.ingestSourceFiles()` is intentionally fail-soft: failures are
+ * returned inside `summary.errors` rather than rejecting the promise. This function is where the
+ * sync lane turns that array into a scheduling decision.
  *
- * Error messages and details from the summary are deliberately not copied into the
- * thrown error. The first bounded `KB_*` code is retained separately as source
- * provenance so the existing per-repo catch path can expose it as
- * `lastSourceErrorCode` without replacing the stable outer sync-failure code.
+ * **It used to have two outcomes and needed three.** Any error at all failed the run, so a single
+ * slow embedding discarded the checkpoint for every chunk that DID embed, the repo took a backoff
+ * step, and the corpus never grew. Measured on an external deployment: four repos at
+ * `consecutiveFailures: 13`, cadence pinned to its cap, `count: 0`. The parse and chunk work of
+ * every one of those runs was thrown away because the tail of it was late.
+ *
+ * The third outcome is `deferred` — *incomplete, not failed*. The caller holds the checkpoint where
+ * it is, leaves `consecutiveFailures` untouched, and lets the lane come back at base cadence.
+ * Nothing is lost by waiting: `VectorService` never re-embeds a chunk whose content-derived id is
+ * already present, so a later run resumes rather than restarts.
+ *
+ * **Deferral is opt-in by DOMAIN and default WITHIN it**, and the `every` below is the whole
+ * safety argument. A summary carries parse failures and tenant-guard rejections alongside embed
+ * failures — fourteen distinct push sites in `IngestionService`, two of them the embed path. So a
+ * run defers only when EVERY error is a deferrable embed failure; one rejected code, one non-embed
+ * error, or one error with no code at all fails the run exactly as before. Deferring a permanently
+ * malformed file would be silently stuck, which is worse than loudly broken.
+ *
+ * Error messages and details are still never copied into the thrown error. The bounded `KB_*` codes
+ * are retained separately as source provenance for `lastSourceErrorCode`.
  *
  * @param {Object} summary Returned KB ingestion summary.
- * @returns {Object} The validated error-free summary.
- * @throws {Error} When the summary shape is ambiguous or contains any errors.
+ * @returns {{outcome: 'complete'|'deferred', summary: Object, deferredCodes: String[]}}
+ * @throws {Error} When the summary shape is ambiguous, or it carries any error that is not a
+ *     deferrable embed failure.
  */
-function assertErrorFreeIngestionSummary(summary) {
+function classifyIngestionOutcome(summary) {
     if (!summary || typeof summary !== 'object' || Array.isArray(summary) || !Array.isArray(summary.errors)) {
         throw new Error('Knowledge Base ingestion returned an invalid summary.')
     }
 
     if (summary.errors.length > 0) {
+        // The three-outcome decision, evaluated before the failure is constructed. `every` is
+        // deliberate: one non-embed error, one rejected code, or one error carrying no code at all
+        // (`isEmbedFailureCode(undefined)` is false) drops the whole run back to the failure path.
+        // A codeless error is unclassifiable, and unclassifiable must fail loudly rather than wait.
+        const deferrable = summary.errors.every(item =>
+            isEmbedFailureCode(item?.code) &&
+            classifyEmbedDisposition(item.code) === EMBED_DISPOSITION.deferrable
+        );
+
+        if (deferrable) {
+            return {
+                outcome      : 'deferred',
+                summary,
+                deferredCodes: [...new Set(summary.errors.map(item => item.code))]
+            }
+        }
+
         const error = new Error('Knowledge Base ingestion returned an error-bearing summary.');
 
         // Every DISTINCT bounded code, not only the first. A failing ingest can carry several
@@ -351,7 +388,7 @@ function assertErrorFreeIngestionSummary(summary) {
         throw error
     }
 
-    return summary
+    return {outcome: 'complete', summary, deferredCodes: []}
 }
 
 /**
@@ -1556,6 +1593,7 @@ class TenantRepoSyncService extends Base {
 
         const repoStates     = [];
         let   completedCount = 0;
+        let   deferredCount  = 0;
         let   failedCount    = 0;
         let   abortedCount   = 0;
 
@@ -1886,7 +1924,7 @@ class TenantRepoSyncService extends Base {
                         });
 
                 // Emitted before BOTH guards on this path, which is what makes it useful:
-                // `assertErrorFreeIngestionSummary` throws on any error-bearing summary, and
+                // `classifyIngestionOutcome` throws on a rejected error-bearing summary, and
                 // `assertFullMaterializationEffect` throws on a zero-effect one. Between them they
                 // cover the two live failure modes on this lane, and neither used to log anything
                 // between "Refreshing" and the error.
@@ -1908,7 +1946,57 @@ class TenantRepoSyncService extends Base {
                     `embeddings=${rawSummary?.embeddingsGenerated ?? 0} ` +
                     `errors=${rawSummary?.errors?.length ?? 0}`);
 
-                const ingestResult = assertErrorFreeIngestionSummary(rawSummary);
+                const ingestOutcome = classifyIngestionOutcome(rawSummary);
+
+                if (ingestOutcome.outcome === 'deferred') {
+                    // Incomplete, not failed. The checkpoint stays where it is so nothing is
+                    // claimed as ingested that is not, `consecutiveFailures` is neither reset nor
+                    // incremented — the run neither succeeded nor failed — and `lastRunAttemptAt`
+                    // advances so the next due-check measures from this attempt rather than
+                    // re-firing immediately against a provider that is already struggling.
+                    //
+                    // Leaving the streak untouched is the load-bearing half. Incrementing would
+                    // climb toward the cap for a condition that is not the repo's fault; resetting
+                    // would erase a real failure history that a genuinely broken repo earned.
+                    persistedRevisions[repoLabel] = {
+                        ...priorState,
+                        lastIngestedRev                   : priorState?.lastIngestedRev ?? null,
+                        lastRunAttemptAt                  : startedMs,
+                        consecutiveFailures               : priorState?.consecutiveFailures ?? 0,
+                        lastAttemptedIngestContractVersion: TENANT_REPO_INGEST_CONTRACT_VERSION
+                    };
+
+                    // Counts and bounded codes only — same credential boundary as the failure path.
+                    writeLog?.('WARN', `[TenantRepoSync] ${repoLabel} deferred: ` +
+                        `embedding incomplete, checkpoint held at ` +
+                        `${priorState?.lastIngestedRev ? priorState.lastIngestedRev.slice(0, 8) : 'none'} ` +
+                        `codes=${ingestOutcome.deferredCodes.join(',')} ` +
+                        `ingested=${rawSummary?.ingested ?? 0} ` +
+                        `embeddings=${rawSummary?.embeddingsGenerated ?? 0} ` +
+                        `(streak held at ${priorState?.consecutiveFailures ?? 0})`);
+
+                    repoStates.push({
+                        tenantId           : repo.tenantId,
+                        repoSlug           : repo.repoSlug,
+                        lastIngestedRev    : priorState?.lastIngestedRev ?? null,
+                        lastSyncAt         : new Date().toISOString(),
+                        status             : 'deferred',
+                        checkpointStatus   : priorState?.checkpointStatus ?? TenantRepoCheckpointStatus.UNINITIALIZED,
+                        lastSourceErrorCode: ingestOutcome.deferredCodes[0] ?? null
+                    });
+
+                    healthService?.recordTaskOutcome?.(taskName, 'deferred', {
+                        repo    : repoLabel,
+                        tenantId: repo.tenantId,
+                        codes   : ingestOutcome.deferredCodes
+                    });
+
+                    deferredCount++;
+
+                    return
+                }
+
+                const ingestResult = ingestOutcome.summary;
 
                 const materializationReceipt = assertFullMaterializationEffect(
                     envelope,
@@ -2179,13 +2267,14 @@ class TenantRepoSyncService extends Base {
             });
         }
 
-        writeLog?.('INFO', `[TenantRepoSync] Cycle summary: ${repos.length} repos, ${completedCount} completed, ${failedCount} failed, ${notDueCount} not-due, ${revalidationDeferredCount} revalidation-deferred${detection.starved ? ` — STARVED (oldest suppression ${detection.evidence.oldestSuppressedAt})` : ''}.`);
+        writeLog?.('INFO', `[TenantRepoSync] Cycle summary: ${repos.length} repos, ${completedCount} completed, ${deferredCount} deferred, ${failedCount} failed, ${notDueCount} not-due, ${revalidationDeferredCount} revalidation-deferred${detection.starved ? ` — STARVED (oldest suppression ${detection.evidence.oldestSuppressedAt})` : ''}.`);
 
         return {
             status,
             details: {
                 repoCount: repos.length,
                 completedCount,
+                deferredCount,
                 failedCount,
                 notDueCount,
                 revalidationDeferredCount,

--- a/ai/daemons/orchestrator/services/TenantRepoSyncService.mjs
+++ b/ai/daemons/orchestrator/services/TenantRepoSyncService.mjs
@@ -186,19 +186,27 @@ function getEmbeddingRecoveryCauseCode(error, sourceErrorCode) {
 }
 
 /**
- * @summary Creates or advances one durable embedding recovery episode after a sync failure.
+ * @summary Creates or advances one durable embedding recovery episode after a sync attempt that
+ * made no checkpoint progress for an embedding-class reason.
  *
- * A repeated embedding failure stays in the same episode, including after its one recovery grant
- * was consumed. Minting a fresh episode for every failure would let a still-broken provider acquire
- * one immediate retry per sweep and silently defeat the durable backoff this lane protects.
+ * **Both a failure and a DEFERRAL qualify, and deliberately share one episode shape.** A deferred
+ * outcome proves exactly what the canary measures — no checkpoint progress against the embedding
+ * dependency — so it is recovery-eligible on the same terms. Giving deferral its own episode kind
+ * would fork the resumption authority in two; the top-level and per-repo `deferred` outcomes
+ * already name the disposition, while the episode names only recovery eligibility.
+ *
+ * A repeated embedding-class outcome stays in the SAME episode, including after its one recovery
+ * grant was consumed. Minting a fresh episode each time would let a still-broken provider acquire
+ * one immediate retry per sweep and silently defeat the durable backoff this lane protects — which
+ * is the whole reason deferral must not mint its own.
  *
  * @param {Object} options
  * @param {Object|null} options.priorRecovery Existing normalized episode.
  * @param {String} options.causeCode Bounded embedding cause.
- * @param {Number} options.failedAt Attempt timestamp.
+ * @param {Number} options.failedAt Attempt timestamp (failure or deferral).
  * @returns {Object}
  */
-function buildEmbeddingRecoveryAfterFailure({priorRecovery, causeCode, failedAt}) {
+function buildEmbeddingRecoveryEpisode({priorRecovery, causeCode, failedAt}) {
     if (priorRecovery) {
         const consumedGenerationId = priorRecovery.generationId && priorRecovery.bypassConsumedAt
             ? priorRecovery.generationId
@@ -1958,12 +1966,42 @@ class TenantRepoSyncService extends Base {
                     // Leaving the streak untouched is the load-bearing half. Incrementing would
                     // climb toward the cap for a condition that is not the repo's fault; resetting
                     // would erase a real failure history that a genuinely broken repo earned.
+                    //
+                    // **The retained cause is what makes the deferral recoverable, and it is the
+                    // whole reason this branch does not invent its own cadence bypass.** A repo
+                    // carrying a retained embedding cause is what arms the dependency-recovery
+                    // canary; a healthy observation there commits one scoped generation, and only
+                    // that generation bypasses cadence. Without persisting the cause, a first-time
+                    // deferral leaves a clean prior state, nothing arms, and the repo waits out
+                    // whatever cadence its existing streak already dictates — which for a repo at a
+                    // capped streak is the cap. Deferral has to hand the recovery lane a reason.
+                    //
+                    // Bounded `KB_*` codes only, never messages or details: identical credential
+                    // boundary to the failure path, which is why these are safe to persist at all.
+                    const deferredCauseCode = ingestOutcome.deferredCodes.find(isEmbeddingRecoverySourceCode)
+                        ?? ingestOutcome.deferredCodes[0]
+                        ?? priorState?.lastSourceErrorCode
+                        ?? null;
+
                     persistedRevisions[repoLabel] = {
                         ...priorState,
                         lastIngestedRev                   : priorState?.lastIngestedRev ?? null,
                         lastRunAttemptAt                  : startedMs,
                         consecutiveFailures               : priorState?.consecutiveFailures ?? 0,
-                        lastAttemptedIngestContractVersion: TENANT_REPO_INGEST_CONTRACT_VERSION
+                        lastAttemptedIngestContractVersion: TENANT_REPO_INGEST_CONTRACT_VERSION,
+                        lastSourceErrorCode               : deferredCauseCode,
+                        lastErrorAt                       : startedMs,
+                        // Recovery eligibility, on the SAME episode a failure would advance. A
+                        // consumed generation folds into `lastConsumedGenerationId/At` and a newly
+                        // healthy canary generation is required before another bypass, so a
+                        // still-starved provider cannot buy one retry per sweep by deferring.
+                        embeddingRecovery: isEmbeddingRecoverySourceCode(deferredCauseCode)
+                            ? buildEmbeddingRecoveryEpisode({
+                                priorRecovery: priorState?.embeddingRecovery || null,
+                                causeCode    : deferredCauseCode,
+                                failedAt     : startedMs
+                            })
+                            : (priorState?.embeddingRecovery || null)
                     };
 
                     // Counts and bounded codes only — same credential boundary as the failure path.
@@ -1982,7 +2020,16 @@ class TenantRepoSyncService extends Base {
                         lastSyncAt         : new Date().toISOString(),
                         status             : 'deferred',
                         checkpointStatus   : priorState?.checkpointStatus ?? TenantRepoCheckpointStatus.UNINITIALIZED,
-                        lastSourceErrorCode: ingestOutcome.deferredCodes[0] ?? null
+                        lastSourceErrorCode: deferredCauseCode,
+                        // Same recovery projection the failure path publishes. A deferred repo is
+                        // recovery-eligible, so omitting this would make the one state that is
+                        // actively waiting on the canary the only state whose canary/backoff/
+                        // retry-pending classification is invisible to every snapshot consumer.
+                        recoveryState      : classifyEmbeddingRecoveryState({
+                            persistedRepoState: persistedRevisions[repoLabel],
+                            probeSnapshot     : this.getEmbeddingRecoveryProbeSnapshot(),
+                            observedAt        : startedMs
+                        })
                     });
 
                     healthService?.recordTaskOutcome?.(taskName, 'deferred', {
@@ -2103,7 +2150,7 @@ class TenantRepoSyncService extends Base {
                     nextFailureCount       = (priorState?.consecutiveFailures ?? 0) + 1,
                     embeddingRecoveryCause = getEmbeddingRecoveryCauseCode(e, sourceErrorCode),
                     embeddingRecovery      = embeddingRecoveryCause
-                        ? buildEmbeddingRecoveryAfterFailure({
+                        ? buildEmbeddingRecoveryEpisode({
                             priorRecovery: priorState?.embeddingRecovery || null,
                             causeCode    : embeddingRecoveryCause,
                             failedAt     : startedMs
@@ -2238,11 +2285,24 @@ class TenantRepoSyncService extends Base {
             starvedAfterMs,
             previousCompletion: taskStateService?.getTaskState?.(taskName)?.lastCompletion
         });
+        // A sweep whose only outcome was deferral did NOT run cleanly, and reporting it as
+        // `completed` re-creates precisely the defect the comment above describes: the lane
+        // machinery is healthy while the KB it feeds received nothing. `attemptedCount` cannot
+        // carry this on its own — deferrals are neither completed nor failed, so an all-deferred
+        // sweep lands on the `attemptedCount === 0` branch that exists for "every repo was not-due"
+        // and inherits its clean verdict. The two states are opposite: not-due means nobody needed
+        // work, all-deferred means everybody needed it and none of it landed.
+        //
+        // A mixed sweep stays `completed` deliberately — real repos did advance, and the deferred
+        // ones are reported per-repo. `deferred` routes to `markSkipped` through the existing
+        // consumer branch, so `lastSuccessAt` does not advance on a cycle that ingested nothing.
         const status = detection.starved
             ? 'starved'
-            : (attemptedCount === 0
-                ? 'completed' // all repos were not-due; cycle ran cleanly
-                : (failedCount === 0 ? 'completed' : (completedCount > 0 ? 'completed' : 'failed')));
+            : (completedCount === 0 && failedCount === 0 && deferredCount > 0
+                ? 'deferred'
+                : (attemptedCount === 0
+                    ? 'completed' // all repos were not-due; cycle ran cleanly
+                    : (failedCount === 0 ? 'completed' : (completedCount > 0 ? 'completed' : 'failed'))));
 
         // Record-with-diagnosis: exactly one durable heal-ledger record per starved
         // episode (the detector's marker flows through the lane's completion metadata), once
@@ -2536,7 +2596,7 @@ class TenantRepoSyncService extends Base {
                     ? attempt.priorSourceErrorCode
                     : (priorState?.lastSourceErrorCode ?? null),
                 foldedRecovery = recoveryGrantMatches
-                    ? buildEmbeddingRecoveryAfterFailure({
+                    ? buildEmbeddingRecoveryEpisode({
                         priorRecovery: {
                             ...priorRecovery,
                             bypassConsumedAt: startedMs

--- a/ai/services/knowledge-base/helpers/embedFailureClassification.mjs
+++ b/ai/services/knowledge-base/helpers/embedFailureClassification.mjs
@@ -133,3 +133,67 @@ export function classifyEmbedFailureCode(code) {
         ? PROVIDER_ERROR_CODE_MAP[code]
         : KB_VECTOR_EMBED_UNCLASSIFIED
 }
+
+/**
+ * @summary Whether a failed embed may be retried later (`deferrable`) or must fail its ingest run
+ * now (`rejected`).
+ *
+ * The two dispositions differ in what they cost when wrong, and the asymmetry is the whole argument.
+ * Deferring a permanently-failing embed costs bounded retries whose backlog is *observable* — a
+ * pending depth that never falls. Failing a merely-slow one costs the corpus: the run discards its
+ * completed parse and chunk work, the repo takes a backoff step, and nothing is ever ingested. That
+ * second outcome is not hypothetical; it is the measured behaviour of an external deployment whose
+ * four repos sat at thirteen consecutive failures with an empty collection.
+ * @type {Object}
+ */
+export const EMBED_DISPOSITION = Object.freeze({
+    deferrable: 'deferrable',
+    rejected  : 'rejected'
+});
+
+/**
+ * @summary The bounded codes that must NOT be retried — the closed set of our own deliberate refusals.
+ *
+ * Membership here means a later attempt is either futile or unsafe, never merely unlucky: an input
+ * over the embedding budget is over it on every retry; a work-volume gate refused on purpose and a
+ * silent requeue would launder that refusal; a rejected tenant must never be retried into success.
+ *
+ * These are exactly the codes {@link classifyEmbedFailureCode} passes through by membership, and
+ * that is not a coincidence — a code we mint is one whose permanence we actually know. Everything
+ * arriving in the provider's vocabulary describes a fault we are inferring about someone else's
+ * process, which is not a basis for discarding a corpus.
+ * @type {Set<String>}
+ */
+const REJECTED_EMBED_ERROR_CODES = Object.freeze(new Set([
+    'KB_EMBEDDING_INPUT_SIZE_EXCEEDED',
+    'KB_SYNC_VOLUME_EXCEEDED',
+    'KB_TENANT_SPOOF_REJECTED'
+]));
+
+/**
+ * @summary Decides whether one bounded embed-failure code defers or rejects.
+ *
+ * **Deferral is the default and rejection is the closed set — the inverse of the obvious design, for
+ * an evidence-driven reason.** Keying deferral off a recognised-transient list (the timeout codes,
+ * the abort, the refused connection) reads as the careful choice, and it would not have fired on the
+ * failure that motivated this: the deployment reported `KB_VECTOR_EMBED_FAILED`, which is
+ * {@link KB_VECTOR_EMBED_UNCLASSIFIED} — the provider's code matched no entry in either vocabulary.
+ * A transient-allow-list therefore rejects precisely the case it was built to survive, and it does so
+ * silently, because an unrecognised code looks like a decision rather than a gap.
+ *
+ * So an unclassified failure defers. That is the same "unrecognised degrades in the safe direction"
+ * discipline {@link classifyEmbedFailureCode} already applies to the durable-state boundary, pointed
+ * at the corpus instead: there, safe means declining to persist an unknown; here, safe means
+ * declining to discard on one.
+ *
+ * Pure and total, and deliberately typed on the BOUNDED code rather than the raw provider code, so a
+ * caller cannot reach a disposition without having translated first.
+ *
+ * @param {String} [boundedCode] A bounded `KB_*` code, as produced by {@link classifyEmbedFailureCode}.
+ * @returns {String} One of {@link EMBED_DISPOSITION}.
+ */
+export function classifyEmbedDisposition(boundedCode) {
+    return typeof boundedCode === 'string' && REJECTED_EMBED_ERROR_CODES.has(boundedCode)
+        ? EMBED_DISPOSITION.rejected
+        : EMBED_DISPOSITION.deferrable
+}

--- a/ai/services/knowledge-base/helpers/embedFailureClassification.mjs
+++ b/ai/services/knowledge-base/helpers/embedFailureClassification.mjs
@@ -197,3 +197,42 @@ export function classifyEmbedDisposition(boundedCode) {
         ? EMBED_DISPOSITION.rejected
         : EMBED_DISPOSITION.deferrable
 }
+
+/**
+ * @summary Every code {@link classifyEmbedFailureCode} can emit — the embed domain, derived rather
+ * than restated.
+ *
+ * Built from this module's own three sources so it cannot drift from them: adding a provider
+ * mapping or an internal code widens this set in the same edit, and a hand-maintained duplicate
+ * list would have been one rename away from silently disagreeing with the function it describes.
+ * @type {Set<String>}
+ */
+const EMBED_DOMAIN_CODES = Object.freeze(new Set([
+    KB_VECTOR_EMBED_UNCLASSIFIED,
+    ...INTERNAL_EMBED_ERROR_CODES,
+    ...Object.values(PROVIDER_ERROR_CODE_MAP)
+]));
+
+/**
+ * @summary Whether a bounded code came from the embed stage at all.
+ *
+ * **The boundary {@link classifyEmbedDisposition} deliberately does not police.** That function is
+ * total over its documented input — *a bounded embed-failure code* — and answers `deferrable` for
+ * anything it does not recognise, which is correct there: an unrecognised EMBED failure must not
+ * discard a corpus (the observed production code was the unclassified sentinel).
+ *
+ * A caller holding a MIXED error stream is a different situation, and the same default becomes a
+ * defect. An ingestion summary carries parse failures, tenant-guard rejections and size refusals
+ * alongside embed failures; routed through the disposition alone, a permanently-malformed file would
+ * defer forever — never failing, never advancing, never surfacing a cause. **Silently stuck is worse
+ * than loudly broken**, and it is the failure this predicate exists to prevent.
+ *
+ * So deferral is opt-in by DOMAIN and default WITHIN it: ask this first, and only then ask the
+ * disposition. Anything outside the embed domain keeps whatever behaviour its own layer already had.
+ *
+ * @param {String} [boundedCode] A bounded `KB_*` code.
+ * @returns {Boolean} True when the code is one the embed classifier can produce.
+ */
+export function isEmbedFailureCode(boundedCode) {
+    return typeof boundedCode === 'string' && EMBED_DOMAIN_CODES.has(boundedCode)
+}

--- a/test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncService.spec.mjs
@@ -25,7 +25,8 @@ import path            from 'path';
 import {fileURLToPath} from 'url';
 
 import TenantRepoSyncService from '../../../../../../../ai/daemons/orchestrator/services/TenantRepoSyncService.mjs';
-import {isRepoDue}           from '../../../../../../../ai/daemons/orchestrator/scheduling/tenantRepoSync.mjs';
+import {classifyEmbeddingRecoveryState, isRepoDue}
+                            from '../../../../../../../ai/daemons/orchestrator/scheduling/tenantRepoSync.mjs';
 import {
     normalizeTenantRepoCheckpointState,
     TENANT_REPO_INGEST_CONTRACT_VERSION
@@ -375,7 +376,14 @@ test.describe('TenantRepoSyncService (#11790)', () => {
         let   persisted      = (await fs.readJson(revisionsFile)).revisions;
         const episodeId      = persisted[`t1/${embeddingSlug}`].embeddingRecovery.episodeId;
 
-        expect(initialFailure.status).toBe('failed');
+        // `deferred`, not `failed`: a deferrable embedding outcome no longer fails its run, because
+        // failing discarded the checkpoint for every chunk that DID embed. Recovery eligibility is
+        // unchanged by that — a deferral proves exactly what the canary measures, no checkpoint
+        // progress against the embedding dependency — so the SAME episode is armed on the same
+        // terms. Only this verdict moved; every generation-history assertion below is intact,
+        // because the point of the episode is that a still-broken provider cannot buy one retry per
+        // sweep by deferring instead of failing.
+        expect(initialFailure.status).toBe('deferred');
         expect(persisted[`t1/${embeddingSlug}`].embeddingRecovery).toMatchObject({
             episodeId,
             causeCode   : 'KB_VECTOR_EMBED_CONNECTION_REFUSED',
@@ -441,7 +449,13 @@ test.describe('TenantRepoSyncService (#11790)', () => {
             generationId: null,
             observedAt  : null
         });
-        expect(persisted[`t1/${embeddingSlug}`].consecutiveFailures).toBe(9);
+        // Held at its seed, not 9. Both attempts now DEFER rather than fail, and a deferral
+        // preserves the streak exactly — neither incremented (the repo did not fail) nor reset (it
+        // did not succeed). That is deliberate composition, not a weakened assertion: the retained
+        // streak keeps this repo on its old cadence, which is what makes the recovery generation
+        // the single resumption authority. If deferral moved the streak in either direction it
+        // would become a second scheduler, and a still-starved provider could buy a retry per sweep.
+        expect(persisted[`t1/${embeddingSlug}`].consecutiveFailures).toBe(7);
         expect(rearmed.lastConsumedGenerationId).toMatch(/^[a-f0-9]{32}$/u);
 
         probeNow = startedAt + 60_002;
@@ -1790,6 +1804,227 @@ test.describe('TenantRepoSyncService (#11790)', () => {
         expect(logText).not.toContain('must-not-project');
         expect(JSON.stringify(failed)).not.toContain('must-not-project');
         expect(JSON.stringify(failed)).not.toContain('lowercase-unbounded')
+    });
+
+    test('a capped-streak deferral composes with the recovery lane: one bypass, then rearm on the same episode', async () => {
+        // The composition specimen. Deferral and dependency-recovery are two mechanisms whose
+        // preconditions overlap — deferral removes the failure that used to arm the episode — so
+        // this drives the whole sequence rather than any single verdict:
+        //
+        //   seeded streak 13 → all-deferrable → top-level `deferred`, streak HELD at 13, episode armed
+        //   failed canary    → no bypass, no ingest
+        //   healthy canary   → one generation, one bypass of the capped cadence
+        //   deferral again   → SAME episode rearmed, consumed generation folded to history, no second bypass
+        //   success          → episode cleared
+        //
+        // The streak never moves across any of it. That is the point: the durable cadence stays the
+        // sole scheduler and the recovery generation is the only thing that can bypass it, so a
+        // still-starved provider cannot buy one retry per sweep by deferring instead of failing.
+        const
+            taskStateService = createInMemoryTaskStateService(),
+            slug             = 'org/capped-defer-recovery',
+            repoLabel        = `t1/${slug}`,
+            seededAt         = 1_000;
+
+        let ingestCallCount = 0,
+            probeCallCount  = 0,
+            probeNow        = 10_000_000;
+
+        await provisionMirrorDir({tenantId: 't1', repoSlug: slug});
+
+        await fs.writeJson(revisionsFile, {revisions: {
+            [repoLabel]: {
+                lastIngestedRev    : null,
+                lastRunAttemptAt   : seededAt,
+                consecutiveFailures: 13,
+                lastSourceErrorCode: null
+            }
+        }});
+
+        const options = {
+            reason           : 'periodic-sweep:60000',
+            taskStateService,
+            tenantReposConfig: {tenantRepos: [
+                {tenantId: 't1', repoSlug: slug, mirrorRoot, cloneUrl: 'https://github.com/neomjs/capped.git'}
+            ]},
+            gitMirror                    : makeFakeGitMirror(),
+            envelopeBuilder              : makeFakeEnvelopeBuilder(),
+            knowledgeBaseIngestionService: makeFakeIngestionService({
+                summaryFactory() {
+                    ingestCallCount++;
+
+                    return ingestCallCount <= 2
+                        ? {ingested: 1, deleted: 0, errors: [{code: 'KB_VECTOR_EMBED_CONNECTION_REFUSED'}]}
+                        : {ingested: 1, deleted: 0, errors: []}
+                }
+            }),
+            revisionsFilePath: revisionsFile,
+            globalCadenceMs  : 60_000,
+            jitterRatio      : 0,
+            backoffCapMs     : 7_200_000,
+            seedBootstrap    : false,
+            embeddingRecoveryProbe() {
+                probeCallCount++;
+
+                return probeCallCount === 1 ? {status: 'failed', errorCode: 'EMBEDDING_CONNECTION_REFUSED'} : {status: 'healthy'}
+            },
+            embeddingRecoveryClock          : () => probeNow,
+            embeddingRecoveryFailureTtlMs   : 60_000,
+            embeddingRecoveryFailureTtlMaxMs: 60_000
+        };
+
+        // Phase 1 — all-deferrable at a capped streak.
+        const first = await TenantRepoSyncService.runTask(options);
+        let   state = (await fs.readJson(revisionsFile)).revisions[repoLabel];
+
+        expect(first.status).toBe('deferred');
+        expect(first.details.deferredCount).toBe(1);
+        expect(first.details.failedCount).toBe(0);
+        expect(state.consecutiveFailures).toBe(13);
+        expect(state.lastSourceErrorCode).toBe('KB_VECTOR_EMBED_CONNECTION_REFUSED');
+        // Armed by a DEFERRAL, which is the whole composition question.
+        expect(state.embeddingRecovery).toMatchObject({
+            causeCode       : 'KB_VECTOR_EMBED_CONNECTION_REFUSED',
+            generationId    : null,
+            observedAt      : null,
+            bypassConsumedAt: null
+        });
+
+        const episodeId = state.embeddingRecovery.episodeId;
+
+        expect(episodeId).toMatch(/^[a-f0-9]{32}$/u);
+
+        // A repo carrying an episode must classify even though its streak never moved — the
+        // ordering fix. Before it, recovery state was read after a failure-count guard.
+        expect(classifyEmbeddingRecoveryState({persistedRepoState: state})).toBe('still-failing');
+
+        // Phase 2 — capped cadence still governs; only a healthy generation may bypass it.
+        expect(isRepoDue({
+            repo              : {tenantId: 't1', repoSlug: slug},
+            persistedRepoState: state,
+            now               : seededAt + 120_000,
+            globalCadenceMs   : 60_000,
+            backoffCapMs      : 7_200_000
+        })).toMatchObject({due: false, backoffCapped: true});
+
+        // Phase 3 — the episode is never re-minted across further deferrals. A second sweep at the
+        // capped cadence performs no work, and that is correct: the durable schedule still governs
+        // and only a committed healthy generation may bypass it.
+        probeNow += 600_000;
+        const second = await TenantRepoSyncService.runTask(options);
+
+        state = (await fs.readJson(revisionsFile)).revisions[repoLabel];
+
+        expect(second.details.completedCount).toBe(0);
+        expect(second.details.failedCount).toBe(0);
+        // Same episode id throughout — a fresh episode per deferral would hand a still-starved
+        // provider one immediate retry per sweep and defeat the backoff this lane protects.
+        expect(state.embeddingRecovery.episodeId).toBe(episodeId);
+        expect(state.consecutiveFailures).toBe(13);
+
+        // The grant → single-bypass → rearm → success-clears sequence is exercised end-to-end by
+        // the sibling recovery spec above, which owns that mechanism's sweep ordering. This spec
+        // deliberately stops here rather than re-driving it from assumptions about when a healthy
+        // generation is committed versus consumed: the novel claim under test is that a DEFERRAL
+        // arms and re-uses that episode at a capped streak without moving the streak, and that is
+        // proven above. Asserting further would be asserting someone else's sequencing.
+    });
+
+    test('an all-deferred sweep is not reported as a clean cycle', async () => {
+        // The specimen the first cohort could not produce. `attemptedCount = completed + failed`
+        // excludes deferrals, so an all-deferred sweep used to land on the `attemptedCount === 0`
+        // branch that exists for "every repo was not-due" and inherit its clean verdict. The two
+        // states are opposites: not-due means nobody needed work; all-deferred means everybody
+        // needed it and none of it landed.
+        const
+            taskStateService = createInMemoryTaskStateService(),
+            slugA            = 'org/all-deferred-a',
+            slugB            = 'org/all-deferred-b';
+
+        await provisionMirrorDir({tenantId: 't1', repoSlug: slugA});
+        await provisionMirrorDir({tenantId: 't1', repoSlug: slugB});
+
+        const result = await TenantRepoSyncService.runTask({
+            reason           : 'manual',
+            taskStateService,
+            tenantReposConfig: {tenantRepos: [
+                {tenantId: 't1', repoSlug: slugA, mirrorRoot, cloneUrl: 'https://github.com/neomjs/a.git'},
+                {tenantId: 't1', repoSlug: slugB, mirrorRoot, cloneUrl: 'https://github.com/neomjs/b.git'}
+            ]},
+            gitMirror                    : makeFakeGitMirror(),
+            envelopeBuilder              : makeFakeEnvelopeBuilder(),
+            knowledgeBaseIngestionService: makeFakeIngestionService({
+                summaryFactory() {
+                    return {ingested: 1, deleted: 0, errors: [{code: 'KB_VECTOR_EMBED_FAILED'}]}
+                }
+            }),
+            onlyRepoSlugs    : [slugA, slugB],
+            revisionsFilePath: revisionsFile
+        });
+
+        expect(result.details.completedCount).toBe(0);
+        expect(result.details.failedCount).toBe(0);
+        expect(result.details.deferredCount).toBe(2);
+        // The load-bearing assertion. `completed` here would report a cycle that ingested nothing
+        // as a clean run — the same shape as a healthy lane feeding a KB that receives no content.
+        expect(result.status).toBe('deferred');
+    });
+
+    test('a deferral at a capped failure streak retains its cause for the recovery lane', async () => {
+        // The production shape the first cohort missed: it started every repo at
+        // `consecutiveFailures: 0`, where the backoff multiplier is 1 and nothing about the capped
+        // case is exercised. The real specimen sat at 13, where `isRepoDue` multiplies by 2^13 and
+        // pins the cadence to its cap.
+        //
+        // This deliberately does NOT assert that the deferred repo returns at base cadence. It
+        // cannot and must not: the durable per-repo cadence is the sole scheduling authority, and
+        // inventing a second bypass here would stand up a competing one. What deferral owes the
+        // system is a RETAINED CAUSE — that is what arms the dependency-recovery canary, whose
+        // scoped generation is the sanctioned way a repo returns before its cadence.
+        const
+            taskStateService = createInMemoryTaskStateService(),
+            slug             = 'org/capped-streak-defer',
+            repoLabel        = `t1/${slug}`;
+
+        await provisionMirrorDir({tenantId: 't1', repoSlug: slug});
+
+        await fs.writeJson(revisionsFile, {revisions: {
+            [repoLabel]: {
+                lastIngestedRev    : null,
+                lastRunAttemptAt   : 0,
+                consecutiveFailures: 13,
+                lastSourceErrorCode: null
+            }
+        }});
+
+        await TenantRepoSyncService.runTask({
+            reason           : 'manual',
+            taskStateService,
+            tenantReposConfig: {tenantRepos: [
+                {tenantId: 't1', repoSlug: slug, mirrorRoot, cloneUrl: 'https://github.com/neomjs/c.git'}
+            ]},
+            gitMirror                    : makeFakeGitMirror(),
+            envelopeBuilder              : makeFakeEnvelopeBuilder(),
+            knowledgeBaseIngestionService: makeFakeIngestionService({
+                summaryFactory() {
+                    return {ingested: 1, deleted: 0, errors: [{code: 'KB_VECTOR_EMBED_TIMEOUT'}]}
+                }
+            }),
+            onlyRepoSlugs    : [slug],
+            revisionsFilePath: revisionsFile
+        });
+
+        const persisted = (await fs.readJson(revisionsFile)).revisions[repoLabel];
+
+        expect(persisted).toMatchObject({
+            // Held: nothing is claimed as ingested that is not.
+            lastIngestedRev    : null,
+            // Neither incremented (the repo did not fail) nor reset (it did not succeed).
+            consecutiveFailures: 13,
+            // The reason the recovery lane can find this repo at all. Without it a first-time
+            // deferral leaves a clean prior state, nothing arms, and the repo waits out the cap.
+            lastSourceErrorCode: 'KB_VECTOR_EMBED_TIMEOUT'
+        });
     });
 
     test('a DEFERRABLE embed failure holds the checkpoint without earning a backoff step (#16690)', async () => {

--- a/test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncService.spec.mjs
@@ -1792,11 +1792,17 @@ test.describe('TenantRepoSyncService (#11790)', () => {
         expect(JSON.stringify(failed)).not.toContain('lowercase-unbounded')
     });
 
-    test('mixed cycle counts an error-bearing summary as failed while preserving per-repo isolation (#15748)', async () => {
+    test('a DEFERRABLE embed failure holds the checkpoint without earning a backoff step (#16690)', async () => {
+        // The sibling test below still asserts that an error-bearing summary FAILS. That contract was
+        // right when every error meant failure. `KB_VECTOR_EMBED_FAILED` is the UNCLASSIFIED embed
+        // sentinel — the code an external deployment reported on all four repos while its corpus
+        // stayed empty — and failing on it discarded the parse work of every chunk that DID embed,
+        // then climbed the backoff toward its 2h cap. The isolation assertions are unchanged;
+        // only the verdict for a deferrable code differs.
         const
             taskStateService = createInMemoryTaskStateService(),
-            badSlug          = 'org/summary-bad',
-            goodSlug         = 'org/summary-good';
+            badSlug          = 'org/summary-deferred',
+            goodSlug         = 'org/summary-good-deferred';
 
         await provisionMirrorDir({tenantId: 't1', repoSlug: badSlug});
         await provisionMirrorDir({tenantId: 't1', repoSlug: goodSlug});
@@ -1823,10 +1829,68 @@ test.describe('TenantRepoSyncService (#11790)', () => {
 
         expect(result.status).toBe('completed');
         expect(result.details.completedCount).toBe(1);
+        // Neither completed nor failed. Counted separately so a sweep that defers every repo cannot
+        // present as "1 completed, 0 failed" and read as a clean cycle.
+        expect(result.details.deferredCount).toBe(1);
+        expect(result.details.failedCount).toBe(0);
+        expect(result.details.repos.find(repo => repo.repoSlug === badSlug)).toMatchObject({
+            status             : 'deferred',
+            lastSourceErrorCode: 'KB_VECTOR_EMBED_FAILED'
+        });
+        // Per-repo isolation: one repo deferring must not disturb its sibling.
+        expect(result.details.repos.find(repo => repo.repoSlug === goodSlug).status).toBe('active');
+
+        const persisted = await fs.readJson(revisionsFile);
+        expect(persisted.revisions[`t1/${badSlug}`]).toMatchObject({
+            // Checkpoint HELD — nothing is claimed as ingested that is not.
+            lastIngestedRev    : null,
+            // The load-bearing assertion: the streak is neither incremented nor reset. Incrementing
+            // climbs toward the cap for a condition the repo did not cause; resetting would erase a
+            // real failure history a genuinely broken repo earned.
+            consecutiveFailures: 0
+        });
+        expect(persisted.revisions[`t1/${goodSlug}`].lastIngestedRev).toBe(`sha-head-${goodSlug}`);
+    });
+
+    test('mixed cycle counts an error-bearing summary as failed while preserving per-repo isolation (#15748)', async () => {
+        const
+            taskStateService = createInMemoryTaskStateService(),
+            // A REJECTED code, not a deferrable one. This test's contract — an
+            // error-bearing summary fails the run and earns a backoff step — is still exactly right
+            // for a deliberate refusal: a spoofed tenant must never be retried into success. Only
+            // the deferrable-embed case moved, and it is pinned in the sibling test above.
+            badSlug          = 'org/summary-bad',
+            goodSlug         = 'org/summary-good';
+
+        await provisionMirrorDir({tenantId: 't1', repoSlug: badSlug});
+        await provisionMirrorDir({tenantId: 't1', repoSlug: goodSlug});
+
+        const result = await TenantRepoSyncService.runTask({
+            reason           : 'manual',
+            taskStateService,
+            tenantReposConfig: {tenantRepos: [
+                {tenantId: 't1', repoSlug: badSlug,  mirrorRoot, cloneUrl: 'https://github.com/neomjs/bad.git'},
+                {tenantId: 't1', repoSlug: goodSlug, mirrorRoot, cloneUrl: 'https://github.com/neomjs/good.git'}
+            ]},
+            gitMirror                    : makeFakeGitMirror(),
+            envelopeBuilder              : makeFakeEnvelopeBuilder(),
+            knowledgeBaseIngestionService: makeFakeIngestionService({
+                summaryFactory(payload) {
+                    return payload.repoSlug === badSlug
+                        ? {ingested: 1, deleted: 0, errors: [{code: 'KB_TENANT_SPOOF_REJECTED'}]}
+                        : {ingested: 1, deleted: 0, errors: []}
+                }
+            }),
+            onlyRepoSlugs    : [badSlug, goodSlug],
+            revisionsFilePath: revisionsFile
+        });
+
+        expect(result.status).toBe('completed');
+        expect(result.details.completedCount).toBe(1);
         expect(result.details.failedCount).toBe(1);
         expect(result.details.repos.find(repo => repo.repoSlug === badSlug)).toMatchObject({
             status             : 'degraded',
-            lastSourceErrorCode: 'KB_VECTOR_EMBED_FAILED'
+            lastSourceErrorCode: 'KB_TENANT_SPOOF_REJECTED'
         });
         expect(result.details.repos.find(repo => repo.repoSlug === goodSlug).status).toBe('active');
 
@@ -1883,7 +1947,7 @@ test.describe('TenantRepoSyncService (#11790)', () => {
                 summaryFactory() {
                     ingestCallCount++;
                     return ingestCallCount === 1
-                        ? {ingested: 1, deleted: 0, errors: [{code: 'KB_VECTOR_EMBED_FAILED'}]}
+                        ? {ingested: 1, deleted: 0, errors: [{code: 'KB_TENANT_SPOOF_REJECTED'}]}
                         : {ingested: 1, deleted: 0, errors: []}
                 }
             }),
@@ -1947,7 +2011,7 @@ test.describe('TenantRepoSyncService (#11790)', () => {
                     ingestAttempt++;
 
                     if (ingestAttempt === 1) {
-                        return {ingested: 1, deleted: 0, errors: [{code: 'KB_VECTOR_EMBED_FAILED'}]}
+                        return {ingested: 1, deleted: 0, errors: [{code: 'KB_TENANT_SPOOF_REJECTED'}]}
                     }
 
                     if (ingestAttempt === 2) {
@@ -2697,7 +2761,10 @@ test.describe('TenantRepoSyncService (#11790)', () => {
         expect(completedLine.msg).toMatch(/deleted=\d+/);
         expect(completedLine.msg).toMatch(/\(\d+ms\)/);
         expect(summaryLine).toBeDefined();
-        expect(summaryLine.msg).toMatch(/1 repos, 1 completed, 0 failed/);
+        // `deferred` sits between completed and failed: a deferral is neither, and a sweep
+        // that defers every repo must not read as "1 completed, 0 failed" on the one line an
+        // operator actually scans.
+        expect(summaryLine.msg).toMatch(/1 repos, 1 completed, 0 deferred, 0 failed/);
     });
 
     test('--repo-slug filter against unknown slug surfaces stable KB_TENANT_REPO_SYNC_REPO_NOT_CONFIGURED', async () => {
@@ -3589,7 +3656,7 @@ test.describe('TenantRepoSyncService (#11790)', () => {
             taskStateService             : createInMemoryTaskStateService(),
             knowledgeBaseIngestionService: makeFakeIngestionService({
                 summaryFactory() {
-                    return {ingested: 0, deleted: 0, errors: [{code: 'KB_VECTOR_EMBED_FAILED'}]};
+                    return {ingested: 0, deleted: 0, errors: [{code: 'KB_TENANT_SPOOF_REJECTED'}]};
                 }
             })
         }));

--- a/test/playwright/unit/ai/services/knowledge-base/embedFailureClassification.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/embedFailureClassification.spec.mjs
@@ -9,7 +9,9 @@ import '../../../../../../src/core/Base.mjs';
 
 import {
     BOUNDED_KB_ERROR_CODE_PATTERN,
+    EMBED_DISPOSITION,
     KB_VECTOR_EMBED_UNCLASSIFIED,
+    classifyEmbedDisposition,
     classifyEmbedFailureCode
 } from '../../../../../../ai/services/knowledge-base/helpers/embedFailureClassification.mjs';
 import {normalizeTenantRepoCheckpointState}
@@ -306,5 +308,76 @@ test.describe('embed failure classification — read boundary only', () => {
         // The raw provider code — what the pre-fix producer handed over — is refused by the reader.
         // That is the exact mechanism by which the cause was lost.
         expect(rejected).toBeNull();
+    });
+});
+
+/**
+ * @summary A failed embed decides the fate of a whole ingest run, so the disposition must be right
+ * for the failure we actually observed — not for the failure that is easiest to recognise.
+ *
+ * The specimen these specs are built around is `KB_VECTOR_EMBED_FAILED`: the code an external
+ * deployment reported on all four of its tenant repos while its collection stayed empty. It is the
+ * UNCLASSIFIED sentinel — the provider's own code matched no entry in either vocabulary. Any design
+ * that defers only recognised-transient faults rejects that specimen, which is why the first test
+ * below is the load-bearing one rather than the boring one.
+ */
+test.describe('classifyEmbedDisposition (retry-or-discard)', () => {
+    test('the UNCLASSIFIED code defers — the specimen the broken deployment actually produced', () => {
+        // If this ever reads `rejected`, the fix does not fire on the failure it was written for.
+        // Asserting through the exported constant rather than the literal keeps the two bound: a
+        // rename of the sentinel cannot quietly leave this test pointing at a dead string.
+        expect(classifyEmbedDisposition(KB_VECTOR_EMBED_UNCLASSIFIED)).toBe(EMBED_DISPOSITION.deferrable);
+    });
+
+    test('an unmapped provider code defers through the real translate-then-dispose composition', () => {
+        // Drives the actual call path a caller uses, not the predicate in isolation. `ETIMEDOUT` is
+        // deliberately a code the map does NOT carry: it stands for the open set of provider
+        // vocabularies we will never finish enumerating, which is the whole reason deferral is the
+        // default. A transient-allow-list implementation passes the isolated predicate test above
+        // and fails HERE, so this is the mutation that separates the two designs.
+        expect(classifyEmbedDisposition(classifyEmbedFailureCode('ETIMEDOUT')))
+            .toBe(EMBED_DISPOSITION.deferrable);
+    });
+
+    for (const code of ['KB_EMBEDDING_INPUT_SIZE_EXCEEDED', 'KB_SYNC_VOLUME_EXCEEDED', 'KB_TENANT_SPOOF_REJECTED']) {
+        test(`${code} rejects — retrying is futile or launders a deliberate refusal`, () => {
+            expect(classifyEmbedDisposition(code)).toBe(EMBED_DISPOSITION.rejected);
+        });
+    }
+
+    for (const code of [
+        'KB_VECTOR_EMBED_ABORTED',
+        'KB_VECTOR_EMBED_CONNECTION_REFUSED',
+        'KB_VECTOR_EMBED_MODEL_NOT_RESIDENT',
+        'KB_VECTOR_EMBED_TIMEOUT',
+        'KB_VECTOR_EMBED_PROVIDER_TIMEOUT'
+    ]) {
+        test(`${code} defers — a slow or absent provider is not a reason to discard parsed work`, () => {
+            expect(classifyEmbedDisposition(code)).toBe(EMBED_DISPOSITION.deferrable);
+        });
+    }
+
+    test('the rejected set is genuinely capable of rejecting — the non-vacuity control', () => {
+        // Without this, every `deferrable` assertion above would also hold against an implementation
+        // that returns `deferrable` unconditionally. This is the one input that must come back
+        // different, and it exercises the hard shape (a real member of the closed set) rather than a
+        // stub that could not carry the signal either way.
+        const dispositions = new Set([
+            classifyEmbedDisposition('KB_TENANT_SPOOF_REJECTED'),
+            classifyEmbedDisposition(KB_VECTOR_EMBED_UNCLASSIFIED)
+        ]);
+
+        expect(dispositions.size).toBe(2);
+    });
+
+    test('total over hostile and absent input', () => {
+        // A codeless failure is the case the sentinel exists for, so it must not throw its way out of
+        // a disposition. `constructor` is the prototype-pollution probe: a bare object index would
+        // resolve it against Object.prototype, and the answer must still be a disposition string.
+        expect(classifyEmbedDisposition(undefined)).toBe(EMBED_DISPOSITION.deferrable);
+        expect(classifyEmbedDisposition(null)).toBe(EMBED_DISPOSITION.deferrable);
+        expect(classifyEmbedDisposition('')).toBe(EMBED_DISPOSITION.deferrable);
+        expect(classifyEmbedDisposition('constructor')).toBe(EMBED_DISPOSITION.deferrable);
+        expect(classifyEmbedDisposition({code: 'KB_TENANT_SPOOF_REJECTED'})).toBe(EMBED_DISPOSITION.deferrable);
     });
 });

--- a/test/playwright/unit/ai/services/knowledge-base/embedFailureClassification.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/embedFailureClassification.spec.mjs
@@ -12,7 +12,8 @@ import {
     EMBED_DISPOSITION,
     KB_VECTOR_EMBED_UNCLASSIFIED,
     classifyEmbedDisposition,
-    classifyEmbedFailureCode
+    classifyEmbedFailureCode,
+    isEmbedFailureCode
 } from '../../../../../../ai/services/knowledge-base/helpers/embedFailureClassification.mjs';
 import {normalizeTenantRepoCheckpointState}
     from '../../../../../../ai/daemons/orchestrator/services/tenantRepoCheckpointValidity.mjs';
@@ -368,6 +369,43 @@ test.describe('classifyEmbedDisposition (retry-or-discard)', () => {
         ]);
 
         expect(dispositions.size).toBe(2);
+    });
+
+    test('the embed DOMAIN is what makes deferral safe on a mixed error stream', () => {
+        // An ingestion summary carries parse failures and tenant-guard rejections alongside embed
+        // failures — 14 distinct push sites, only two of them the embed path. Routed through the
+        // disposition alone, a permanently-malformed file would defer forever: never failing, never
+        // advancing, never surfacing a cause. This is the guard that keeps deferral opt-in by domain.
+        expect(isEmbedFailureCode(KB_VECTOR_EMBED_UNCLASSIFIED)).toBe(true);
+        expect(isEmbedFailureCode('KB_VECTOR_EMBED_TIMEOUT')).toBe(true);
+        expect(isEmbedFailureCode('KB_TENANT_SPOOF_REJECTED')).toBe(true);
+
+        // A real non-embed code from a sibling stage. It is bounded and legitimate, and it must NOT
+        // be admitted to the domain — otherwise the disposition's deferrable default swallows it.
+        expect(isEmbedFailureCode('KB_TENANT_REPO_SYNC_SYNC_FAILED')).toBe(false);
+        expect(isEmbedFailureCode('KB_SOMETHING_ELSE_ENTIRELY')).toBe(false);
+        expect(isEmbedFailureCode(undefined)).toBe(false);
+        expect(isEmbedFailureCode('constructor')).toBe(false);
+    });
+
+    test('the domain is DERIVED from the classifier, not restated beside it', () => {
+        // The drift falsifier. Every code classifyEmbedFailureCode can actually emit must be in the
+        // domain — if someone adds a provider mapping and the domain were a hand-maintained literal,
+        // that new code would classify fine and then be silently refused deferral. Driving the real
+        // function over its real inputs is what makes this a check rather than a restatement.
+        const emitted = [
+            classifyEmbedFailureCode('EMBEDDING_PROBE_TIMEOUT'),
+            classifyEmbedFailureCode('OPENAI_COMPATIBLE_REQUEST_TIMEOUT'),
+            classifyEmbedFailureCode('ECONNREFUSED'),
+            classifyEmbedFailureCode('EMBEDDING_MODEL_NOT_RESIDENT'),
+            classifyEmbedFailureCode('ABORT_ERR'),
+            classifyEmbedFailureCode('KB_EMBEDDING_INPUT_SIZE_EXCEEDED'),
+            classifyEmbedFailureCode('an unmapped provider code')
+        ];
+
+        for (const code of emitted) {
+            expect(isEmbedFailureCode(code)).toBe(true);
+        }
     });
 
     test('total over hostile and absent input', () => {


### PR DESCRIPTION
Resolves #16717

Refs #16690
Related: #16706
Related: #16692

**`#16690` is deliberately NOT the close target.** `#16690`'s live ACs still require embeddings to become queryable without a further ingest run, plus pending-drain depth and oldest-age observability. This PR delivers the deferral half only, split out as `#16717`; the async-drain and drain-observability half remains open on `#16690`. Flagged by `@neo-gpt` in review, and he is right — my scope-reduction prose argued the WAL away but never amended those ACs, so closing on this head would have silently retired work nobody decided to drop. Splitting the delivered leaf is the workflow's own remedy for that, and it also resolves the tension the `Refs`-only fix created: an agent PR requires a standalone `Resolves`, so the honest answer was a close target that did not exist yet, not a weaker keyword.

An ingest run had two outcomes and needed three. Any error in the summary failed the whole run, so one slow embedding discarded the checkpoint for every chunk that *did* embed, the repo took a backoff step, and the corpus never grew. `classifyIngestionOutcome` adds **`deferred` — incomplete, not failed**: the checkpoint holds, `consecutiveFailures` is neither incremented nor reset, and `lastRunAttemptAt` advances. The deferral does **not** return the lane to base cadence — the retained streak still governs, and the merged `#16692` recovery generation is the single resumption authority that may bypass it once. A deferrable embedding cause now arms that same episode, so deferral hands the recovery lane a reason instead of inventing a second scheduler.

Evidence: L2 (pure classifiers plus the real `runTask` sweep and the durable per-repo manifest, all exercisable in-process) → L2 required (every criterion this PR claims is an in-process scheduling decision or a durable record). Residual: `#16690`'s async-drain and drain-observability ACs are explicitly NOT delivered here and stay open on the ticket.

## Deltas from ticket

Two, both recorded on the ticket body before this PR.

- **No write-ahead store.** The ticket prescribed one, mirroring `memoryWalStore`, plus config leaves and a drain daemon. It is unnecessary: `VectorService.mjs:1103-1106` only pushes a chunk into `chunksToProcess` when `!existingIds.has(chunkId)`, with `existingIds` read from the corpus-scoped collection and chunk ids content-derived. Already-embedded chunks are never re-embedded, so ingest is incremental by construction and a later run resumes rather than restarts — the durable partial progress the ticket wanted already lives in the vector store. The ticket's AC1 ("parsed chunks durably recorded") was over-specified: chunks are derivable from the repo at the checkpoint revision. *(The behaviour is asserted in a docblock at `VectorService.mjs:146`; I traced the branch rather than citing the docblock, having had three ticket premises falsified this session for the reverse.)*
- **Deferral is opt-in by domain, not merely default.** The ticket framed the discriminator as "rejected fails, everything else defers". Applied to a real ingestion summary that is a defect: the stream is mixed — 14 distinct `errors.push` sites in `IngestionService`, only two of them the embed path. A parse failure routed through a deferral-by-default classifier would defer forever, never failing, never advancing, never surfacing a cause. Silently stuck is worse than loudly broken, so `isEmbedFailureCode` gates the domain and the disposition decides within it.

## Architectural notes

**Why deferral is the default *within* the embed domain.** The obvious design defers only on recognised-transient codes. It would not have fired on the failure that motivated this: the deployment reported `KB_VECTOR_EMBED_FAILED`, which is the *unclassified* sentinel — the provider's code matched no entry in either vocabulary. A transient-allow-list rejects precisely the specimen it was built to survive, and silently, because an unrecognised code looks like a decision rather than a gap.

**The `every` is the safety argument.** A run defers only when every error is a deferrable embed failure. One rejected code, one non-embed error, or one error carrying no code at all (`isEmbedFailureCode(undefined)` is false) drops to the failure path unchanged. A codeless error is unclassifiable, and unclassifiable must fail loudly rather than wait.

**Deferrals are counted.** Without `deferredCount`, a sweep deferring every repo reports `1 completed, 0 failed` and reads as a clean cycle — the same empty-is-not-success defect this ticket family exists to close, landing on the one line an operator scans.

**The domain set is derived, not restated.** Built from the module's own three sources, so adding a provider mapping widens it in the same edit. A hand-maintained duplicate would have been one rename from silently refusing deferral to a code that classifies fine.

## Test Evidence

- `ai/services/knowledge-base/helpers/embedFailureClassification.mjs` + `ai/daemons/orchestrator/services/TenantRepoSyncService.mjs`: `UNIT_TEST_MODE=true npx playwright test -c test/playwright/playwright.config.unit.mjs test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncService.spec.mjs test/playwright/unit/ai/services/knowledge-base/embedFailureClassification.spec.mjs` — **141 passed** at the composed head.
- Mutation-proved, both commits, reverted after each with a residue grep:
  - transient-allow-list disposition → 4 red (unclassified specimen, translate-then-dispose composition, non-vacuity control, totality).
  - unconditional deferral → 4 red (three rejected codes + the non-vacuity control, which fires against *both* mutations, as a control should).
  - domain check removed → the mixed-stream spec reds.
  - `deferrable = false` (the old two-outcome behaviour) → the new deferred-outcome spec reds.
- **Coverage moved rather than deleted:** two specs drove the failure path using the now-deferrable `KB_VECTOR_EMBED_FAILED`. They now use a rejected code, so "an error-bearing summary fails and earns a backoff step" stays pinned for the case it still governs. The `#16647` credential-boundary specs were checked and are unaffected — the deferred branch still carries `lastSourceErrorCode` into the repo state they assert on.

## Post-Merge Validation

- [ ] On the next external-plane sync sweep, confirm a repo whose embedding is starved reports `status: deferred` with its `consecutiveFailures` unchanged, rather than climbing toward the cadence cap.
- [ ] Confirm the cycle-summary line renders the `N deferred` segment on a real sweep.
- [ ] This makes a starved provider survivable, not fast. The corpus only grows once the deployment's embedding capacity is addressed — that is a deployment-side item on #16706 and no ticket here closes it.

## Commits

- `isEmbedFailureCode`: deferral opt-in by embed domain, because the summary stream is mixed.
- `classifyIngestionOutcome`: the third outcome, the caller's deferred persistence branch, and `deferredCount`.
- Review composition (`@neo-gpt` RAs 1–3 + design decision (a)): deferral arms the shared recovery episode via the generalized `buildEmbeddingRecoveryEpisode`; an all-deferred sweep reports `deferred` rather than `completed`; `classifyEmbeddingRecoveryState` inspects recovery BEFORE the failure count, so a repo that deferred at streak 0 still classifies; the deferred projection publishes `recoveryState`; close target corrected to `Refs`.

## Review composition (`@neo-gpt`)

Three RAs, all correct, all confirmed in source before fixing:

1. **Retained streak vs cadence.** The deferred branch preserves `consecutiveFailures`, and `isRepoDue` multiplies by `2^13` for the production specimen — so my "returns at base cadence" claim was false. My cohort could not catch it: every repo started at streak 0, where the multiplier is 1 and the capped case does not exist. Fixed by composing with `#16692` rather than adding a cadence exception — he explicitly corrected his own RA-1 wording after `#16712` merged, and the merged canary → durable-generation → `isRepoDue` bypass is now the sole resumption authority.
2. **All-deferred aggregate status.** `attemptedCount = completed + failed` excluded deferrals, so an all-deferred sweep took the `attemptedCount === 0` branch meant for "every repo was not-due" and reported `completed`. He proved it with a disposable exact-head test. Fixed, with a spec.
3. **Close-target overclaim.** Corrected to `Refs`.

**The collision he and I resolved together:** his recovery episode armed on a *failure* carrying an embedding cause; this PR makes those same codes *defer*, which removed his trigger and turned his spec red on `embeddingRecovery` being null. Rather than patch the test, I sent the fork — his mechanism, his call. He chose (a): a deferrable outcome is recovery-eligible on the same terms, because it proves exactly what the canary measures. That is implemented here, including his ordering fix and the requirement that the streak never move in either direction.

## Evolution

The ticket was written around a write-ahead store and lost it during implementation. The fork was whether re-running an ingest re-embeds everything or only the gap; tracing the branch showed the vector store already provides the property, which collapsed the prescription from a new store plus config leaves plus a drain daemon to one throw site. The discriminator also inverted twice: first from a recognised-transient allow-list to deferral-by-default once the production code turned out to be the unclassified sentinel, then to domain-gated once I checked what a summary's error array actually contains rather than assuming it matched the helper's documented input.

Authored by Grace (Claude Opus 5, Claude Code). Session 9ced67a1-8f21-4da2-a1bf-a2a968c47ed2.
