### PR TITLE
feat: cockpit connection truth — reconnect affordance + topology-aware banner (#16699)

### DIFF
--- a/apps/agentos/view/fleet/FleetCockpit.mjs
+++ b/apps/agentos/view/fleet/FleetCockpit.mjs
@@ -341,6 +341,18 @@ class FleetCockpit extends Container {
      */
     daemonState = null
     /**
+     * The shell's transport-boot fact for the spine banner's cold-case guidance — the
+     * `{phase, mode, up, fleetPort, reason, error}` snapshot the lifecycle owner attaches to the
+     * brain-health wire payload (`transport`), or `null` where no shell fact exists (the plain
+     * browser, or a shell the pull could not reach — an unreachable shell has no standing to keep
+     * asserting one). `null` deliberately renders the browser copy: absence of a shell is not a
+     * shell fault. Written only by {@link #applyBrainHealth}; render-only truth like its daemon
+     * siblings.
+     * @member {Object|null} shellTransport=null
+     * @protected
+     */
+    shellTransport = null
+    /**
      * The grid's held `adapterState` — absent-item materialization reads from HERE, so a committed
      * layout change can never reset a live grid back to its sample badge.
      * @member {String} gridAdapterState='sample'
@@ -1014,6 +1026,18 @@ class FleetCockpit extends Container {
                     hidden   : true,
                     reference: 'fleet-spine-banner',
                     role     : 'status'
+                }, {
+                    // the banner's manual recovery affordance: one click re-drives every liveness
+                    // seam through the existing authenticated bridge — no reload, no new transport.
+                    // Visibility is the banner's verdict (synced by syncSpineBanner); a live spine
+                    // hides both.
+                    module   : Button,
+                    cls      : ['fm-reconnect-button'],
+                    handler  : me.reconnectFleet.bind(me),
+                    hidden   : true,
+                    iconCls  : 'fa-solid fa-rotate',
+                    reference: 'fleet-reconnect-button',
+                    text     : 'Reconnect'
                 },
                 '->', {
                     // The fleet-start outcome summary — written by the controller after the
@@ -2246,6 +2270,14 @@ class FleetCockpit extends Container {
             // snapshot made the surface live, empty regains its ordinary authoritative meaning
             // (the real fleet may genuinely drain).
             if (!me.rosterWired && mapped.length === 0 && !bridge?.selected && me.rosterSourceMode !== 'selected') {
+                // The server ANSWERED — but an answer is not silence (the activity twin's not-wired
+                // discipline): retain the cause so the spine banner names "connected · registry
+                // empty" instead of falling back to "server offline · start it" — advice to restart
+                // a process that just replied, and the exact reachable-server case the spineBanner
+                // module documents as needing a retained reason. Cleared by the ordinary paths: a
+                // populated snapshot clears it below; a transport failure retracts it in
+                // {@link #degradeWiredSurface} (the claim must not outlive the connection).
+                me.gridDegradedReason = 'server connected · fleet registry empty — define agents to go live';
                 return
             }
 
@@ -2731,6 +2763,24 @@ class FleetCockpit extends Container {
     }
 
     /**
+     * @summary The Reconnect affordance's one-click re-drive: every liveness seam, immediately.
+     *
+     * Deliberately NOT gated on {@link #maxReadsInFlight} — per that cap's contract, only the
+     * cadence honours it; a direct call is operator-meant and never suppressed. Recovery needs no
+     * new machinery beyond this: the reads route through the same authenticated bridge, the same
+     * generation fences drop stale answers, and the same routing matrices write the state — the
+     * button only collapses the up-to-one-cadence wait into "now". Works identically in both
+     * topologies (the browser flow has the same stale-offline problem after a late server start).
+     */
+    reconnectFleet() {
+        let me = this;
+
+        me.loadActivity();
+        me.loadRoster();
+        me.loadBrainHealth()
+    }
+
+    /**
      * @summary Applies one Brain-health wire answer onto the owner-held daemon surface, then re-syncs.
      *
      * The vocabulary check keeps the documented member contract honest: anything that is not a
@@ -2746,11 +2796,23 @@ class FleetCockpit extends Container {
 
         if (me.isDestroyed) return;
 
+        // The shell transport fact rides the same wire but is ITS OWN truth, valid on a payload
+        // whose daemon state never validates — and dropped back to `null` when the pull failed
+        // (an unreachable shell has no standing to keep asserting a boot fact). The banner's cold
+        // fallback is the only consumer.
+        const transport        = Neo.isObject(response?.transport) ? response.transport : null,
+              transportChanged = !Neo.isEqual(transport, me.shellTransport ?? null);
+
+        me.shellTransport = transport;
+
         if (!state) {
             // Transport truth is not daemon truth in EITHER direction: a rejection, timeout,
             // unavailable envelope, or malformed payload must not fabricate a fault — and it must
             // not ERASE a last-known one. A visible fault stays visible until the lifecycle owner
-            // itself answers otherwise; only a valid answer moves this surface.
+            // itself answers otherwise; only a valid answer moves this surface. A CHANGED transport
+            // fact still re-renders (it moved independently of the daemon verdict — e.g. the boot
+            // settling, or the fact dropping with a dead shell); an unchanged one repaints nothing.
+            transportChanged && me.syncSpineBanner();
             return
         }
 
@@ -2817,8 +2879,14 @@ class FleetCockpit extends Container {
             field  = surface === 'grid' ? 'gridAdapterState' : 'streamAdapterState',
             reason = surface === 'grid' ? 'gridDegradedReason' : 'streamDegradedReason';
 
-        // never-wired stays cold-honest: 'sample' already says "this is fixture data"
-        if (me[field] === 'sample') return;
+        // never-wired stays cold-honest: 'sample' already says "this is fixture data" — and a
+        // transport failure RETRACTS any answered-state cause this surface retained (the
+        // "connected · registry empty" claim must not outlive the connection it describes; back
+        // on silence, the banner's generic cold copy is the honest line again).
+        if (me[field] === 'sample') {
+            me[reason] = null;
+            return
+        }
 
         me[field]  = 'stale';
         // this surface's cause, on this surface's field — never a shared slot a sibling can clear
@@ -2856,8 +2924,9 @@ class FleetCockpit extends Container {
      * @protected
      */
     syncSpineBanner() {
-        let me     = this,
-            banner = me.getReference('fleet-spine-banner');
+        let me        = this,
+            banner    = me.getReference('fleet-spine-banner'),
+            reconnect = me.getReference('fleet-reconnect-button');
 
         if (banner) {
             // each state travels WITH its own cause: the derivation reports the reason of the
@@ -2868,8 +2937,16 @@ class FleetCockpit extends Container {
                 // Silent while `daemonState` is null — absence is unknown, never nominal.
                 daemon: {state: me.daemonState,        reason: me.daemonDegradedReason},
                 grid  : {state: me.gridAdapterState,   reason: me.gridDegradedReason},
-                stream: {state: me.streamAdapterState, reason: me.streamDegradedReason}
+                stream: {state: me.streamAdapterState, reason: me.streamDegradedReason},
+                // the shell's boot fact (null outside the shell) — only the cold fallback reads it
+                transport: me.shellTransport
             });
+
+            // The manual recovery affordance shares the banner's visibility verdict: a fully live
+            // spine earns zero pixels from BOTH; any visible verdict (cold or degraded) offers the
+            // one-click re-drive. Same control in both topologies — the browser flow has the
+            // identical stale-offline problem after a late server start.
+            reconnect?.set({hidden});
 
             // `text`, never `html`. The line now interpolates a RETAINED TRANSPORT STRING — the
             // adapter's own `capability.reason`, which arrives over the fleet wire — and `html`

--- a/apps/agentos/view/fleet/FleetCockpit.mjs
+++ b/apps/agentos/view/fleet/FleetCockpit.mjs
@@ -2135,7 +2135,14 @@ class FleetCockpit extends Container {
         const generation = ++me.streamReadGeneration;
 
         if (!stream || typeof bridge?.fleetActivity !== 'function') {
-            // no bridge/verb IS the cold truth — the spine banner must say so
+            // no bridge/verb IS the cold truth — the spine banner must say so. Same retraction
+            // duty as the roster twin's absence exit: a never-wired surface's retained
+            // producer-answered cause ("activity source not wired") must not outlive the bridge
+            // that answered it; wired surfaces keep their stale/live semantics.
+            if (me.streamAdapterState === 'sample') {
+                me.streamDegradedReason = null
+            }
+
             me.syncSpineBanner();
             return
         }
@@ -2220,8 +2227,10 @@ class FleetCockpit extends Container {
      * - absent bridge / no verb / a MALFORMED answer (`rows` not an Array) / a thrown source →
      *   keep the last-known roster; fail closed rather than blanking the fleet. A resolved call is
      *   mechanically distinguishable from a failed one — only failures preserve last-known state.
-     *   (The grid's `stale` render remains reserved for a real degraded signal once a producer
-     *   emits one.)
+     *   Absence and thrown calls are DISTINCT transitions with one shared retraction duty: a
+     *   never-wired surface's retained answered cause is withdrawn on either (the claim must not
+     *   outlive its producer), while a wired surface keeps its stale/live semantics. (The grid's
+     *   `stale` render remains reserved for a real degraded signal once a producer emits one.)
      * @protected
      */
     async loadRoster() {
@@ -2234,7 +2243,15 @@ class FleetCockpit extends Container {
         const generation = ++me.gridReadGeneration;
 
         if (!grid?.store || typeof bridge?.fleetRoster !== 'function') {
-            // no bridge/verb IS the cold truth — the spine banner must say so
+            // no bridge/verb IS the cold truth — the spine banner must say so. Absence is a
+            // DISTINCT transition from a thrown call, and it owns the same retraction duty: a
+            // never-wired surface's retained ANSWERED cause ("server connected · registry
+            // empty") must not outlive the bridge that said it. A wired surface keeps its
+            // stale/live semantics — this exit only speaks for cold truth.
+            if (me.gridAdapterState === 'sample') {
+                me.gridDegradedReason = null
+            }
+
             me.syncSpineBanner();
             return
         }

--- a/apps/agentos/view/fleet/FleetGrid.mjs
+++ b/apps/agentos/view/fleet/FleetGrid.mjs
@@ -302,7 +302,11 @@ class FleetGrid extends Container {
 
         // header — updated in place (the health bar is store-bound and tallies itself)
         me.getReference('fleet-title').text = `Fleet · ${rank.total} agents`;
-        me.getReference('fleet-stale').text = adapterState === 'stale' ? 'stale — reconnecting' : adapterState === 'sample' ? 'static roster · offline' : '';
+        // 'static roster' without an offline claim: sample only proves WHICH data renders, never
+        // WHY — the transport may be answering (empty registry) or silent, and the spine banner is
+        // the surface that knows which. A badge asserting "offline" against a replying server lies
+        // one level below the banner that used to tell the same lie.
+        me.getReference('fleet-stale').text = adapterState === 'stale' ? 'stale — reconnecting' : adapterState === 'sample' ? 'static roster' : '';
         me.getReference('fleet-head').cls   = ['fm-fleet-head', `is-${adapterState}`];
 
         // card set — rebuilt (the visible cards change with the roster)

--- a/apps/agentos/view/fleet/spineBanner.mjs
+++ b/apps/agentos/view/fleet/spineBanner.mjs
@@ -75,6 +75,42 @@ function reasonFor(surfaces, state) {
 const DAEMON_FAULT_STATES = Object.freeze(['degraded', 'stopped']);
 
 /**
+ * @summary Picks the cold-case fallback line for SILENCE, from the topology that owns the truth.
+ *
+ * The generic "start it: npm run ai:fleet-server" advice is only ever right in the plain-browser
+ * flow. Inside the shell it is actively wrong in every branch: the shell SELF-SUPPLIES its
+ * transport, so a manual start is what CAUSES the foreign-listener refusal — the fact object the
+ * lifecycle owner hands over on the brain-health wire names which shell case is live instead.
+ * `null` (no shell fact — plain browser, or an unreachable shell with no standing to assert one)
+ * keeps the classic copy: there, silence really does imply a server the operator must start.
+ * @param {Object|null} transport The shell transport-boot fact
+ *     `{phase: 'starting'|'settled', mode, up, fleetPort, reason, error}`, or `null` outside the shell.
+ * @returns {String}
+ * @private
+ */
+function coldFallbackFor(transport) {
+    if (!transport) {
+        return 'Fleet server offline — showing the static roster · start it: npm run ai:fleet-server'
+    }
+
+    if (transport.phase === 'starting') {
+        return 'Fleet transport starting — the cockpit connects automatically'
+    }
+
+    if (transport.mode === 'foreign-listener') {
+        const port = transport.fleetPort ?? 'the fleet port';
+
+        return `another fleet server holds port ${port} — quit it, then Reconnect · ${transport.reason || 'listener did not prove canonical Fleet identity'}`
+    }
+
+    if (transport.up !== true) {
+        return `Fleet transport failed to start — showing the static roster${transport.error ? ` · ${transport.error}` : ''}`
+    }
+
+    return 'Fleet transport ready — cockpit loading · use Reconnect if this persists'
+}
+
+/**
  * @summary Derives the spine banner from the owner-held surface truths.
  * @param {Object} options
  * @param {{state: String, reason: ?String}} options.grid The roster surface: `'sample'|'stale'|'live'`
@@ -83,10 +119,13 @@ const DAEMON_FAULT_STATES = Object.freeze(['degraded', 'stopped']);
  * @param {{state: String, reason: ?String}} [options.daemon] Brain daemon health:
  *     `'running'|'degraded'|'stopped'`, with the diagnosis pointer as its reason. Optional — a caller
  *     that has not pulled daemon truth passes nothing rather than guessing `running`.
+ * @param {Object|null} [options.transport] The shell transport-boot fact (see {@link coldFallbackFor}).
+ *     Optional and `null`-safe — only the cold fallback consults it, so a retained surface reason
+ *     still outranks any topology guess.
  * @returns {{hidden: Boolean, kind: String, text: String}} `kind` is `'live'|'cold'|'degraded'`
  *     — the class hook; `hidden` is `true` only for the fully live spine.
  */
-export function deriveSpineBanner({daemon, grid, stream}) {
+export function deriveSpineBanner({daemon, grid, stream, transport = null}) {
     const surfaces = [grid, stream],
           states   = surfaces.map(surface => surface?.state);
 
@@ -99,12 +138,12 @@ export function deriveSpineBanner({daemon, grid, stream}) {
             // Same discipline the `stale` line follows: name the retained cause when the owner HAS
             // one, guess only when it does not. A reachable server whose source is unconfigured
             // answers `not-wired` — the seed stays, so the data really is sample, but "start the
-            // server" would be advice to restart a process that just replied. The generic copy is
-            // the fallback for SILENCE, which is the only state that actually implies an offline
-            // server.
+            // server" would be advice to restart a process that just replied. The fallback for
+            // SILENCE is topology-owned: the shell's transport fact picks the honest line, and
+            // only the plain-browser flow keeps the classic "start the server" advice.
             text: reason
                 ? `Fleet data unavailable — showing the static roster · ${reason}`
-                : 'Fleet server offline — showing the static roster · start it: npm run ai:fleet-server'
+                : coldFallbackFor(transport)
         }
     }
 

--- a/harness/adapterWitness.mjs
+++ b/harness/adapterWitness.mjs
@@ -37,7 +37,7 @@ export const ADAPTER_STATES = Object.freeze(['live', 'sample', 'stale', 'degrade
  * @type {Object}
  */
 export const ROSTER_STATE_LABELS = Object.freeze({
-    live: '', sample: 'static roster · offline', stale: 'stale — reconnecting', degraded: ''
+    live: '', sample: 'static roster', stale: 'stale — reconnecting', degraded: ''
 });
 
 /**

--- a/harness/brain.mjs
+++ b/harness/brain.mjs
@@ -824,7 +824,8 @@ export function registerOwnedChild({children, entry, watch, onUnobservedExit = n
  * - **reuse** (port held + canonical same-bearer/viewer proof): adopt; `spawn`/`registerChild`
  *   are NEVER invoked.
  * - **foreign-listener** (port held, proof refused): `up: false` with the named refusal routed to
- *   `onOutcome`; NEVER adopt, NEVER spawn — and never throw: a UI window must not brick on a
+ *   `onOutcome` AND carried on the outcome's `reason` (the cockpit banner renders the named
+ *   case); NEVER adopt, NEVER spawn — and never throw: a UI window must not brick on a
  *   squatted port.
  * - **spawn** (port free): the child registers `observeBrain: false` BY THE COMPOSITION — the
  *   ownership≠observation invariant is wired here, not left to the caller — then real wire
@@ -840,7 +841,7 @@ export function registerOwnedChild({children, entry, watch, onUnobservedExit = n
  * @param {Function} options.registerChild Owner registration (`registerOwnedChild` wiring).
  * @param {Function} options.awaitReady Real wire-readiness gate.
  * @param {Function} [options.onOutcome] Diagnostic sink, one line per outcome.
- * @returns {Promise<{fleetPort: Number, mode: 'reuse'|'spawn'|'foreign-listener', up: Boolean}>}
+ * @returns {Promise<{fleetPort: Number, mode: 'reuse'|'spawn'|'foreign-listener', reason?: String, up: Boolean}>}
  */
 export async function resolveUiFleetTransport({
     bearerToken,
@@ -862,8 +863,13 @@ export async function resolveUiFleetTransport({
             return {fleetPort, mode: 'reuse', up: true}
         }
 
-        onOutcome(`foreign-listener fleetPort=${fleetPort} reason=${probe.reason || 'listener did not prove canonical Fleet identity'}`);
-        return {fleetPort, mode: 'foreign-listener', up: false}
+        const reason = probe.reason || 'listener did not prove canonical Fleet identity';
+
+        onOutcome(`foreign-listener fleetPort=${fleetPort} reason=${reason}`);
+        // The refusal travels IN the outcome, not only the log: the cockpit's banner renders the
+        // named case ("another fleet server holds the port"), so the shell log must not be the
+        // only place the reason exists.
+        return {fleetPort, mode: 'foreign-listener', reason, up: false}
     }
 
     const child = spawn({fleetPort});

--- a/harness/main.mjs
+++ b/harness/main.mjs
@@ -93,7 +93,35 @@ const
 
 let
     brainBootPromise = Promise.resolve(null),
-    resolveHarnessAsset;
+    resolveHarnessAsset,
+    // The shell's transport-boot fact for the cockpit banner — attached to every brain-health
+    // answer so the renderer can name WHICH shell case is live instead of guessing "offline".
+    // `null` = no transport story this run (plain UI-only smoke spawns nothing by isolation
+    // contract); `{phase: 'starting'}` while a boot is in flight; the normalized settle after.
+    uiTransportFact = null;
+
+/**
+ * @summary Normalizes a settled transport/Brain boot outcome into the wire-safe banner fact.
+ *
+ * Every boot path resolves a slightly different shape (`bootUiFleetTransport`'s three-outcome
+ * plan, `bootProductBrain`'s plan modes, `bootSmokeBrain`'s profile record, the catch handlers'
+ * `{error, up: false}`); the cockpit needs ONE shape. Deliberately no bearer, no paths — ports and
+ * harness-authored refusal/error strings only, rendered through the banner's text sink.
+ * @param {Object|null} boot The settled boot outcome, or `null` (no transport story).
+ * @returns {Object|null}
+ */
+function normalizeTransportFact(boot) {
+    if (!boot) return null;
+
+    return {
+        error    : boot.error     ?? null,
+        fleetPort: boot.fleetPort ?? null,
+        mode     : boot.mode      ?? null,
+        phase    : 'settled',
+        reason   : boot.reason    ?? null,
+        up       : boot.up === true
+    }
+}
 
 // Packaged mode: every parent-side child spawn (Brain children, the config resolver) runs on the
 // bundled Electron runtime — the packaged env fragments add ELECTRON_RUN_AS_NODE per child.
@@ -936,6 +964,12 @@ async function bootProductBrain() {
         }),
         {mode}    = plan;
 
+    // The selected plan goes on record BEFORE anything spawns: a boot that fails past this point
+    // logs HARNESS_BRAIN_BOOT_FAILED with no plan context of its own, and diagnosing "which mode
+    // was it attempting" from silence cost a live iteration run. Success keeps the richer
+    // HARNESS_BRAIN_MODE line below.
+    console.log(`HARNESS_BRAIN_PLAN ${JSON.stringify({fleetPort, mode, planeBase: plan.planeBase ?? null, startFleet: !!plan.startFleet, startOrchestrator: !!plan.startOrchestrator})}`);
+
     if (plan.startOrchestrator) {
         // Coexistence guard (dev machines): a packaged app's own-mode organism runs the DEFAULT
         // ports — a checkout Brain's Chroma already on that port would be REAPED by the spawned
@@ -1114,7 +1148,11 @@ app.whenReady().then(async () => {
             throw new Error('brain-health: untrusted sender')
         }
 
-        return appLifecycle.brainHealth
+        // Daemon truth plus the shell's transport-boot fact on one pull: the cockpit's banner
+        // needs BOTH — the organism's health for the daemon line, the transport fact for honest
+        // cold-case guidance (never "start it: npm run ai:fleet-server" inside a shell that
+        // self-supplies). No new channel: the fact rides the wire that already crosses.
+        return {...appLifecycle.brainHealth, transport: uiTransportFact}
     });
 
     const win1 = createHarnessWindow(APP_URL);
@@ -1128,6 +1166,13 @@ app.whenReady().then(async () => {
         appLifecycle.setBrainState('degraded')
     }
 
+    // The banner fact enters 'starting' exactly when a transport boot is actually in flight —
+    // brain mode boots the organism's fleet leg, UI-only product self-supplies. Plain UI-only
+    // smoke spawns nothing by isolation contract and keeps `null`: no transport story to tell.
+    if (brainMode || !diagnosticMode) {
+        uiTransportFact = {phase: 'starting'}
+    }
+
     brainBootPromise = brainMode
         ? (diagnosticMode ? bootSmokeBrain() : bootProductBrain())
             .catch(error => {
@@ -1136,6 +1181,7 @@ app.whenReady().then(async () => {
             })
             .then(boot => {
                 appLifecycle.settleBrainBoot(boot.up === true);
+                uiTransportFact = normalizeTransportFact(boot);
                 return boot
             })
         : (diagnosticMode
@@ -1144,10 +1190,15 @@ app.whenReady().then(async () => {
             ? Promise.resolve(null)
             // UI-only product path: self-supply the transport. Tray Brain state is deliberately
             // untouched — a fleet transport is not a Brain claim.
-            : bootUiFleetTransport().catch(error => {
-                console.log('HARNESS_UI_FLEET_BOOT_FAILED ' + error.message);
-                return {error: error.message, up: false}
-            }));
+            : bootUiFleetTransport()
+                .catch(error => {
+                    console.log('HARNESS_UI_FLEET_BOOT_FAILED ' + error.message);
+                    return {error: error.message, up: false}
+                })
+                .then(boot => {
+                    uiTransportFact = normalizeTransportFact(boot);
+                    return boot
+                }));
 
     if (!smokeMode) {
         try {

--- a/resources/scss/src/apps/agentos/fleet/FleetCockpit.scss
+++ b/resources/scss/src/apps/agentos/fleet/FleetCockpit.scss
@@ -53,9 +53,13 @@
            same-weight blue slab never reaches the bar. Mirrors the chrome's agent-button pair
            (Viewport.scss); only the primary action reaches for the signal. The shell-owned pop-out
            toggle joins the quiet base here: windowing a pane is a secondary cockpit action, while
-           Start fleet remains the sole signal/primary on the bar (operator hierarchy direction). */
+           Start fleet remains the sole signal/primary on the bar (operator hierarchy direction).
+           The spine banner's Reconnect remedy joins the same quiet base: it appears only when the
+           banner speaks (exception-only chrome), and a recovery affordance must read as calm, not
+           as a second alarm beside the line that already carries the severity. */
         .neo-button.fm-preset-button,
-        .neo-button.fm-detail-window-toggle {
+        .neo-button.fm-detail-window-toggle,
+        .neo-button.fm-reconnect-button {
             border       : 1px solid var(--fm-line);
             border-radius: 6px;
             background: var(--fm-panel-2);

--- a/test/playwright/unit/apps/agentos/view/fleet/fleetCockpit.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/fleetCockpit.spec.mjs
@@ -336,6 +336,34 @@ test.describe('Fleet cockpit — Store-backed roster (loadRoster)', () => {
         expect(cockpit.gridDegradedReason).toBe(null)
     });
 
+    test('answered-empty → bridge ABSENT also retracts — absence is its own transition, not a thrown-call proxy', async () => {
+        // the exact-head reviewer falsifier: an answered producer-specific cause survived the
+        // no-bridge early return while the surface stayed sample — "server connected" rendering
+        // against NO bridge at all. Absence must withdraw the answered cause exactly like a
+        // thrown call does.
+        const {cockpit} = await routeLoadRoster({fleetRoster: async () => ({rows: []})});
+
+        expect(cockpit.gridDegradedReason).toContain('registry empty');
+
+        clearBridge();
+        await FleetCockpit.prototype.loadRoster.call(cockpit);
+
+        expect(cockpit.gridAdapterState).toBe('sample');
+        expect(cockpit.gridDegradedReason).toBe(null)
+    });
+
+    test('answered-empty → verb ABSENT retracts too — a bridge without the verb is the same cold truth', async () => {
+        const {cockpit} = await routeLoadRoster({fleetRoster: async () => ({rows: []})});
+
+        expect(cockpit.gridDegradedReason).toContain('registry empty');
+
+        (globalThis.AgentOS ??= {}).fleet = {registryBridge: {}};
+        await FleetCockpit.prototype.loadRoster.call(cockpit);
+
+        expect(cockpit.gridAdapterState).toBe('sample');
+        expect(cockpit.gridDegradedReason).toBe(null)
+    });
+
     test('a resolved EMPTY first snapshot is authoritative after explicit source selection', async () => {
         const {cockpit, grid} = await routeLoadRoster(
             {fleetRoster: async () => ({rows: []})},
@@ -1593,6 +1621,42 @@ test.describe('Fleet cockpit — the spine-banner slot sync (syncSpineBanner)', 
         // 'stale' would tell the operator we are showing last-known data that never existed
         expect(host.streamAdapterState).toBe('sample');
         expect(host.streamDegradedReason).toBe(null)
+    });
+
+    test('not-wired → bridge ABSENT retracts the activity cause — the answer must not outlive its producer', async () => {
+        // the activity half of the reviewer falsifier: the producer ANSWERED not-wired (reason
+        // retained, honest sample), then the bridge vanished — the retained cause must go with it.
+        const banner = makeBanner(),
+              host   = makeLivenessHost(banner);
+
+        host.streamAdapterState = 'sample';
+
+        await withBridge(async () => ({capability: {state: 'not-wired', reason: 'activity source not wired'}, events: []}), host);
+        expect(host.streamDegradedReason).toBe('activity source not wired');
+        expect(host.streamAdapterState).toBe('sample');
+
+        // withBridge already removed the bridge in its finally — this drive hits the absence exit
+        await host.loadActivity();
+
+        expect(host.streamAdapterState).toBe('sample');
+        expect(host.streamDegradedReason).toBe(null)
+    });
+
+    test('CONTROL — a wired surface keeps its stale reason through bridge absence (last-known truth survives)', async () => {
+        // the retraction is scoped to never-wired ANSWERED causes; a surface that reached live and
+        // degraded holds last-known data, and its cause explains exactly that — absence must not
+        // erase it (the per-surface-reason doctrine's other half).
+        const banner = makeBanner(),
+              host   = makeLivenessHost(banner);
+
+        await withBridge(async () => { throw new Error('transport lost') }, host);
+        expect(host.streamAdapterState).toBe('stale');
+        expect(host.streamDegradedReason).toBe('transport lost');
+
+        await host.loadActivity();
+
+        expect(host.streamAdapterState).toBe('stale');
+        expect(host.streamDegradedReason).toBe('transport lost')
     });
 
     test('the degraded reason is redacted + bounded before it reaches operator-visible chrome', async () => {

--- a/test/playwright/unit/apps/agentos/view/fleet/fleetCockpit.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/fleetCockpit.spec.mjs
@@ -314,7 +314,26 @@ test.describe('Fleet cockpit — Store-backed roster (loadRoster)', () => {
         expect(grid.store.added).toEqual([]);
         expect(grid.adapterState).toBe('sample');
         expect(cockpit.rosterSourceMode).toBe('sample');
-        expect(cockpit.rosterWired).toBe(false)
+        expect(cockpit.rosterWired).toBe(false);
+        // the ANSWERED-empty retention: the sample stays, but the cause is on record — the banner
+        // names "connected · registry empty" instead of claiming "server offline" against a
+        // transport that just replied
+        expect(cockpit.gridDegradedReason).toBe('server connected · fleet registry empty — define agents to go live')
+    });
+
+    test('the answered-empty reason is RETRACTED on silence — the claim must not outlive the connection', async () => {
+        // empty answer retains the cause…
+        const {cockpit} = await routeLoadRoster({fleetRoster: async () => ({rows: []})});
+
+        expect(cockpit.gridDegradedReason).toContain('registry empty');
+
+        // …then the transport dies: back on silence, the generic cold copy is the honest line
+        // again, so the never-wired loss edge must drop the retained answered-state cause.
+        (globalThis.AgentOS ??= {}).fleet = {registryBridge: {fleetRoster: async () => { throw new Error('transport lost') }}};
+        await FleetCockpit.prototype.loadRoster.call(cockpit);
+
+        expect(cockpit.gridAdapterState).toBe('sample');
+        expect(cockpit.gridDegradedReason).toBe(null)
     });
 
     test('a resolved EMPTY first snapshot is authoritative after explicit source selection', async () => {
@@ -1417,6 +1436,67 @@ test.describe('Fleet cockpit — the spine-banner slot sync (syncSpineBanner)', 
         makeHost('live', 'live', banner).syncSpineBanner();
 
         expect(banner.calls[0]).toEqual({cls: ['fm-spine-banner', 'fm-spine-banner-live'], hidden: true, text: ''})
+    });
+
+    test('the Reconnect affordance shares the banner verdict: visible on any spoken line, hidden on live', () => {
+        const banner    = makeBanner(),
+              reconnect = makeBanner(),
+              host      = {
+                  ...makeHost('sample', 'sample', banner),
+                  getReference: reference =>
+                      reference === 'fleet-spine-banner'     ? banner :
+                      reference === 'fleet-reconnect-button' ? reconnect : null
+              };
+
+        host.syncSpineBanner();
+        expect(reconnect.calls[0]).toEqual({hidden: false});
+
+        host.gridAdapterState   = 'live';
+        host.streamAdapterState = 'live';
+        host.syncSpineBanner();
+        expect(reconnect.calls[1]).toEqual({hidden: true})
+    });
+
+    test('reconnectFleet re-drives every liveness seam immediately — the one-click recovery', () => {
+        const driven = [];
+
+        FleetCockpit.prototype.reconnectFleet.call({
+            loadActivity   : () => driven.push('activity'),
+            loadBrainHealth: () => driven.push('brainHealth'),
+            loadRoster     : () => driven.push('roster')
+        });
+
+        expect(driven.sort()).toEqual(['activity', 'brainHealth', 'roster'])
+    });
+
+    test('⭐ the shell transport fact reaches the cold copy through the health pull — daemon truth untouched', () => {
+        const banner  = makeBanner(),
+              cockpit = {
+                  ...makeHost('sample', 'live', banner),
+                  applyBrainHealth    : FleetCockpit.prototype.applyBrainHealth,
+                  daemonDegradedReason: null,
+                  daemonState         : null
+              };
+
+        // a state-less payload carrying only the fact: the daemon surface stays unfed (absence
+        // claims nothing), while the cold copy moves to the shell's honest line
+        cockpit.applyBrainHealth({state: null, transport: {phase: 'starting'}});
+
+        expect(cockpit.daemonState).toBeNull();
+        expect(cockpit.shellTransport).toEqual({phase: 'starting'});
+        expect(banner.calls.at(-1).text).toContain('Fleet transport starting');
+
+        // the boot settles foreign — the SAME wire moves the copy to the named case
+        cockpit.applyBrainHealth({state: null, transport: {fleetPort: 8083, mode: 'foreign-listener', phase: 'settled', reason: 'viewer mismatch', up: false}});
+
+        expect(banner.calls.at(-1).text).toContain('another fleet server holds port 8083');
+
+        // an UNCHANGED fact repaints nothing — the same no-visible-change discipline the daemon
+        // surface holds for transport-failure answers
+        const paints = banner.calls.length;
+
+        cockpit.applyBrainHealth({state: null, transport: {fleetPort: 8083, mode: 'foreign-listener', phase: 'settled', reason: 'viewer mismatch', up: false}});
+        expect(banner.calls.length).toBe(paints)
     });
 
     /**

--- a/test/playwright/unit/apps/agentos/view/fleet/fleetGrid.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/fleetGrid.spec.mjs
@@ -318,7 +318,10 @@ test.describe('Fleet cockpit FleetGrid + HealthBar — Store-backed density-rank
         const grid = Neo.create(FleetGrid, {appName, adapterState: 'sample', store: makeStore(roster(['ok']))});
 
         expect(head(grid).cls).toContain('is-sample');
-        expect(head(grid).items.find(i => i.cls.includes('fm-fleet-stale')).text).toBe('static roster · offline');
+        // provenance only, no offline claim: sample proves WHICH data renders, never WHY — the
+        // spine banner owns the why; a badge asserting "offline" against a replying server would
+        // repeat the lie the banner used to tell
+        expect(head(grid).items.find(i => i.cls.includes('fm-fleet-stale')).text).toBe('static roster');
         expect(agentCards(grid).length).toBe(1);
 
         grid.destroy()

--- a/test/playwright/unit/apps/agentos/view/fleet/spineBanner.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/spineBanner.spec.mjs
@@ -173,5 +173,92 @@ test.describe('fleet/spineBanner — the per-spine honesty derivation', () => {
         const result = deriveSpineBanner({grid: {state: 'live'}, stream: {state: 'live'}});
 
         expect(result).toEqual({hidden: true, kind: 'live', text: ''})
+    });
+
+    // ⭐ The topology-owned cold fallback: the generic "start it: npm run ai:fleet-server"
+    // advice was actively wrong inside the shell — the shell SELF-SUPPLIES its transport, so that
+    // advice CAUSES the foreign-listener refusal it then mislabels as "offline". The shell's boot
+    // fact (riding the brain-health wire) picks the honest line for SILENCE; a retained surface
+    // reason still outranks any topology guess; the plain browser (no fact) keeps the classic copy.
+    test.describe('⭐ transport-aware cold fallback — the shell fact picks the honest line', () => {
+        const coldSpine = {grid: {state: 'sample'}, stream: {state: 'live'}};
+
+        test('no shell fact (plain browser, or an unreachable shell) keeps the classic offline copy', () => {
+            for (const transport of [undefined, null]) {
+                const {text} = deriveSpineBanner({...coldSpine, transport});
+
+                expect(text, JSON.stringify(transport)).toContain('Fleet server offline');
+                expect(text, JSON.stringify(transport)).toContain('npm run ai:fleet-server')
+            }
+        });
+
+        test('a boot in flight names itself — and never advises a manual start', () => {
+            const {kind, text} = deriveSpineBanner({...coldSpine, transport: {phase: 'starting'}});
+
+            expect(kind).toBe('cold');
+            expect(text).toContain('Fleet transport starting');
+            expect(text).not.toContain('npm run ai:fleet-server')
+        });
+
+        test('foreign-listener renders the named refusal, the port, and the Reconnect remedy', () => {
+            // The exact case the old copy inverted: "start it" is what CREATES this state.
+            const {text} = deriveSpineBanner({...coldSpine, transport: {
+                fleetPort: 8083, mode: 'foreign-listener', phase: 'settled', reason: 'viewer mismatch on the reuse probe', up: false
+            }});
+
+            expect(text).toContain('another fleet server holds port 8083');
+            expect(text).toContain('quit it, then Reconnect');
+            expect(text).toContain('viewer mismatch on the reuse probe');
+            expect(text).not.toContain('npm run ai:fleet-server')
+        });
+
+        test('foreign-listener without a carried reason falls back to the generic refusal line', () => {
+            const {text} = deriveSpineBanner({...coldSpine, transport: {fleetPort: 8083, mode: 'foreign-listener', phase: 'settled', up: false}});
+
+            expect(text).toContain('another fleet server holds port 8083');
+            expect(text).toContain('listener did not prove canonical Fleet identity')
+        });
+
+        test('a settled failed boot names the failure — with and without an error detail', () => {
+            const withDetail = deriveSpineBanner({...coldSpine, transport: {mode: 'spawn', phase: 'settled', up: false, error: 'fleet readiness timed out'}}),
+                  bareFail   = deriveSpineBanner({...coldSpine, transport: {mode: 'spawn', phase: 'settled', up: false}});
+
+            expect(withDetail.text).toContain('Fleet transport failed to start');
+            expect(withDetail.text).toContain('fleet readiness timed out');
+            expect(bareFail.text).toContain('Fleet transport failed to start');
+            expect(bareFail.text).not.toContain('npm run ai:fleet-server')
+        });
+
+        test('a ready transport with cold surfaces points at Reconnect — the server just answered', () => {
+            for (const mode of ['spawn', 'reuse']) {
+                const {text} = deriveSpineBanner({...coldSpine, transport: {fleetPort: 8083, mode, phase: 'settled', up: true}});
+
+                expect(text, mode).toContain('Fleet transport ready');
+                expect(text, mode).toContain('Reconnect');
+                expect(text, mode).not.toContain('npm run ai:fleet-server')
+            }
+        });
+
+        test('⭐ a retained surface reason OUTRANKS the fact — the producer spoke, the topology only guesses', () => {
+            // The roster's answered-empty retention (loadRoster's empty-unselected path) must win
+            // over any transport-derived guess: what the producer SAID beats what the boot implies.
+            const {text} = deriveSpineBanner({
+                grid     : {state: 'sample', reason: 'server connected · fleet registry empty — define agents to go live'},
+                stream   : {state: 'live'},
+                transport: {mode: 'foreign-listener', phase: 'settled', up: false}
+            });
+
+            expect(text).toContain('Fleet data unavailable');
+            expect(text).toContain('fleet registry empty');
+            expect(text).not.toContain('another fleet server holds')
+        });
+
+        test('the fact never reaches non-cold branches: stale, daemon and live verdicts ignore it', () => {
+            const transport = {mode: 'foreign-listener', phase: 'settled', up: false};
+
+            expect(deriveSpineBanner({grid: {state: 'live'}, stream: {state: 'stale'}, transport}).text).toContain('last-known');
+            expect(deriveSpineBanner({grid: {state: 'live'}, stream: {state: 'live'}, daemon: {state: 'stopped'}, transport}).text).toContain('Agent OS stopped');
+            expect(deriveSpineBanner({grid: {state: 'live'}, stream: {state: 'live'}, transport})).toEqual({hidden: true, kind: 'live', text: ''})
+        })
     })
 });

--- a/test/playwright/unit/harness/adapterWitness.spec.mjs
+++ b/test/playwright/unit/harness/adapterWitness.spec.mjs
@@ -24,7 +24,7 @@ const report = (overrides = {}) => ({
     cockpitVisible  : true,
     cardCount       : 10,
     rosterState     : 'sample',
-    rosterLabel     : 'static roster · offline',
+    rosterLabel     : 'static roster',
     streamState     : 'sample',
     activityLabel   : 'sample · live feed pending',
     firstPaintMs    : 800,

--- a/test/playwright/unit/harness/brain.spec.mjs
+++ b/test/playwright/unit/harness/brain.spec.mjs
@@ -711,7 +711,9 @@ test.describe('resolveUiFleetTransport — the reuse|spawn|foreign OWNER COMPOSI
             spawn         : () => { calls.spawned++; throw new Error('spawn must not run on foreign') }
         });
 
-        expect(result).toEqual({fleetPort: 18083, mode: 'foreign-listener', up: false});
+        // the refusal travels IN the outcome: the cockpit banner renders the named case, so the
+        // shell log must not be the only place the reason exists
+        expect(result).toEqual({fleetPort: 18083, mode: 'foreign-listener', reason: 'bearer subject mismatch', up: false});
         expect(calls.spawned).toBe(0);
         expect(calls.registered).toEqual([]);
         expect(outcome).toEqual(['foreign-listener fleetPort=18083 reason=bearer subject mismatch'])

--- a/test/playwright/unit/harness/preload.spec.mjs
+++ b/test/playwright/unit/harness/preload.spec.mjs
@@ -115,7 +115,7 @@ function adapterHead(state, labelText, labelSelector) {
  * @param {Object} options
  * @returns {Object}
  */
-function cockpitDom({rosterState='sample', rosterLabel='static roster · offline', streamState='sample', streamLabel='sample · live feed pending', cards=[{getClientRects: () => [{}]}], tourControls=[], cockpit={getClientRects: () => [{}]}} = {}) {
+function cockpitDom({rosterState='sample', rosterLabel='static roster', streamState='sample', streamLabel='sample · live feed pending', cards=[{getClientRects: () => [{}]}], tourControls=[], cockpit={getClientRects: () => [{}]}} = {}) {
     return {
         selectors: {
             '.fm-fleet-cockpit'                : cockpit,
@@ -174,7 +174,7 @@ test.describe('Electron harness preload capability', () => {
             cards              = [{getClientRects: () => [{}]}, {getClientRects: () => [{}]}],
             {intervals, sends} = await loadPreload({
                 clock,
-                dom                      : cockpitDom({cards, cockpit, rosterLabel: ' static roster · offline ', streamLabel: ' sample · live feed pending '}),
+                dom                      : cockpitDom({cards, cockpit, rosterLabel: ' static roster ', streamLabel: ' sample · live feed pending '}),
                 precedeWithUnrelatedTimer: true
             }),
             firstPaintReporter = getFirstPaintReporter(intervals);
@@ -188,7 +188,7 @@ test.describe('Electron harness preload capability', () => {
             cardCount           : 2,
             cockpitVisible      : true,
             rendererFirstPaintMs: 0,
-            rosterLabel         : 'static roster · offline',
+            rosterLabel         : 'static roster',
             rosterState         : 'sample',
             streamState         : 'sample',
             timedOut            : false,
@@ -219,7 +219,7 @@ test.describe('Electron harness preload capability', () => {
             cardCount           : 1,
             cockpitVisible      : true,
             rendererFirstPaintMs: null,
-            rosterLabel         : 'static roster · offline',
+            rosterLabel         : 'static roster',
             rosterState         : 'sample',
             streamState         : 'sample',
             timedOut            : true,


### PR DESCRIPTION
Resolves #16699

The cockpit now tells the truth about its fleet connection and can recover it in one click. The root cause landed differently than the claim comment's fork: the renderer DOES call (the 15s liveness cadence re-drives continuously — the ticket's "nothing re-queries" premise was falsified at `FleetCockpit#startLiveness`), and the server DOES answer — `{rows: []}`, because the shell-spawned transport reads host `.neo-ai-data/fleet/registry.json`, which does not exist post-hard-cut. The view's designed empty-unselected guard then kept the sample seed while recording NO cause, so the spine banner fell through to "Fleet server offline — start it: npm run ai:fleet-server" — a false claim carrying actively harmful shell advice (a manual start is what CREATES the foreign-listener refusal).

Five truth surfaces plus one affordance:

1. `loadRoster`'s answered-empty path retains a grid reason (mirroring the activity twin's not-wired discipline) — the banner names "server connected · fleet registry empty — define agents to go live" instead of guessing offline.
2. **The full answer → loss matrix withdraws answered causes** (cycle-1 repair): a never-wired surface's producer-answered cause ("server connected · registry empty" / "activity source not wired") is retracted on BOTH loss transitions — a thrown call (`degradeWiredSurface`) AND an absent bridge/verb (both early exits) — so the claim can never outlive its producer; wired surfaces keep their stale/live semantics (last-known truth survives absence).
3. The shell's transport-boot fact rides the EXISTING brain-health wire (`{phase, mode, up, fleetPort, reason, error}` — no new IPC channel): `deriveSpineBanner`'s cold fallback becomes topology-owned — "transport starting", the named foreign-listener case ("another fleet server holds port N — quit it, then Reconnect"), settled-failure, ready-but-cold. The `npm run ai:fleet-server` advice renders ONLY when no shell fact exists (plain browser), which is the one topology where it is true.
4. `resolveUiFleetTransport` carries the foreign-listener refusal in its OUTCOME (`reason` field), not only the diagnostic log.
5. The grid badge drops its unproven claim: `static roster · offline` → `static roster` (provenance only; the banner owns the why). The `adapterWitness` label map and preload-observer fixtures move in the same commit, keeping state-vs-label agreement the contract.
6. A Reconnect button on the cockpit bar (both topologies) shares the banner's visibility verdict; `reconnectFleet()` re-drives all three liveness seams immediately. The ticket's part-3 dedicated `fleet-ready` push is DROPPED as redundant plumbing: the cadence is the shipped auto-transition MECHANISM, the button collapses the worst-case one-cadence wait to "now" — the observable live-transition itself remains L3-deferred (see Evidence).

Fold-in from the plane-classifier review cycle: `HARNESS_BRAIN_PLAN` logs the selected plan BEFORE any child spawns, so a failed product-brain boot is no longer plan-silent.

Contract authority: #16699 now carries the canonical **Contract Ledger** for the two additive consumed surfaces (`resolveUiFleetTransport().reason`; `brain-health.transport`), plus the Verified Root Cause and Decision Ledger sections — the ticket and this PR describe one disposition.

Context: D#16720 (FM-as-client — fleet surface into the composition, PAT-grade auth) reframes registry ownership at the architecture level; this leaf describes the SHIPPED topology honestly and its copy moves with a follow-up leaf if D#16720's OQ1 resolves registry ownership plane-side.

Evidence: L2 (scoped unit suite green + isolated-organism `smoke:brain` at head — the checkout smoke's empty registry cannot exercise a live-roster transition) → L3 required (AC1 click-to-live + AC3 auto-live against a populated reachable transport — the operator renderer receipt tracked on #16694; both ACs carry `[L3-deferred — operator handoff needed → #16694]` on #16699). Residual: AC1/AC3 live-transition receipts [#16694].

## Deltas from ticket

- Part 3 (`fleet-ready` push) replaced by cadence + button with falsified-premise rationale: the ticket's "nothing re-queries" predates `startLiveness`. The cadence ships the auto-transition mechanism; the observable transition is L3-deferred per the Evidence line (ticket ACs annotated accordingly).
- Added: the answered-cause retention + FULL-matrix retraction (thrown AND absent transitions) — the actual root-cause surface; the ticket predates the empty-registry finding. The absence half landed in the cycle-1 repair after the reviewer's exact-head falsifier.
- Added: grid badge truth (`static roster · offline` → `static roster`) — the same lie one level below the banner, and the smoke's own `rosterLabel` observable.
- Added: `HARNESS_BRAIN_PLAN` pre-spawn plan log (review fold-in named in the claim comment).

## Test Evidence

- `npm run test-unit -- <the six changed specs>` → **192/192 passed** at `db9507c4e9` (the pre-repair figure of 201 included the unchanged 13-test `harness/appLifecycle.spec.mjs` run as an extra regression guard — transcription corrected per review; the six-spec surface is 188 pre-repair + 4 new transition witnesses).
- New coverage this head: answered-empty → bridge ABSENT retracts (roster); answered-empty → verb ABSENT retracts (roster); not-wired → bridge ABSENT retracts (activity); CONTROL — a stale surface's last-known reason SURVIVES bridge absence.
- Prior coverage: `spineBanner.spec.mjs` transport-fallback matrix (8 tests); `fleetCockpit.spec.mjs` answered-empty retention + thrown-call retraction + Reconnect visibility verdict + `reconnectFleet` re-drive + transport-fact-through-health-pull (incl. unchanged-fact repaints-nothing); `brain.spec.mjs` foreign-listener `reason` in outcome; label fixtures in `fleetGrid.spec.mjs`, `adapterWitness.spec.mjs`, `preload.spec.mjs`.
- `npm --prefix harness run smoke:brain` at the fix head: first-paint leg `passed: true`, `rosterLabel: "static roster"` proven end-to-end (product render → preload observer → witness map), `adaptersCoherent: true`, `brainUp: true`. The run's overall exit 1 is the PRE-EXISTING baseline condition (`chromaListening: false` + `surfaceExact: false`, byte-identical in the pre-change baseline run at `0d5f8172d8`) — flagged for separate investigation, untouched by this diff.
- apps/agentos surface: `fleetCockpit.spec.mjs`, `fleetGrid.spec.mjs`, `spineBanner.spec.mjs` · harness surface: `brain.spec.mjs`, `adapterWitness.spec.mjs`, `preload.spec.mjs`.

## Post-Merge Validation

- [ ] Operator live run (`npm start` in `harness/`): banner reads "server connected · fleet registry empty — define agents to go live" instead of "Fleet server offline"; Reconnect visible beside it.
- [ ] After defining ≥1 agent (Accounts pane or `onboardPeer`): cockpit transitions live within one 15s cadence, or immediately via Reconnect (the AC1/AC3 L3 receipts → #16694).
- [ ] Foreign-listener drill (manual `ai:fleet-server` on :8083, then `npm start`): banner names the port holder + Reconnect, never the start advice.

## Commits

- 13f1e1f39e — the full leaf (initial head)
- db9507c4e9 — cycle-1 repair: withdraw answered causes on bridge/verb absence (RA-1) + 4 transition witnesses

Related: #16694 · #16720 · #16711

Authored by Clio (Claude Fable 5, Claude Code). Session e64d1a11-324a-465f-9c6d-ce59c72f790a.
