### PR TITLE
fix: resident card degrades as a declared unit below content height (#16716)

### DIFF
--- a/resources/scss/src/apps/workstation/Viewport.scss
+++ b/resources/scss/src/apps/workstation/Viewport.scss
@@ -284,8 +284,22 @@
     flex-direction: column;
     height        : 100%;
     min-height    : 0;
+    // The card's own box is a paint boundary: between disclosure tiers a transient layout may
+    // hand the stack less room than its clamp minimums, and the escape hatch must be clipping
+    // at THIS box — not painting over the pane below (#16716's title-below-card finding). The
+    // tiers keep settled states out of this branch; clip only owns the transients.
+    overflow: clip;
     padding : clamp(12px, 2px + 5cqh, 24px);
     position: relative;
+}
+
+// The text rows share the wave's rule: none of them may flex-collapse toward 0 — every
+// disappearance in this card is a declared tier below, never slack math.
+.workstation-resident-kicker,
+.workstation-resident-icon,
+.workstation-resident-metric,
+.workstation-resident-title {
+    flex-shrink: 0;
 }
 
 .workstation-resident-kicker {
@@ -389,6 +403,36 @@
 
 @container workstation-pane (max-height: 145px) {
     .workstation-resident-footer {display: none}
+}
+
+// The ladder continues below the trim tiers, so a pane shorter than the card's content
+// keeps a DECLARED presentation instead of shedding children to slack math or painting past its
+// box. Same fit arithmetic as above, at clamp minimums (padding 24 + kicker 12 + icon 26 +
+// metric 22.8 + title 21): icon visible needs ~106 → 118; title-without-icon ~80 → 92; the
+// compact chip re-pads to 6px 12px and keeps the metric alone — the number IS the card on
+// camera — (~35 → engaged at 64); below 40 the card yields to the pane's shell (gradient +
+// signal line) as the declared empty state, and padding drops to 0 so the box-model floor
+// (2×12px padding) can never make the card taller than its own pane.
+@container workstation-pane (max-height: 118px) {
+    .workstation-resident-icon {display: none}
+}
+
+@container workstation-pane (max-height: 92px) {
+    .workstation-resident-title {display: none}
+}
+
+@container workstation-pane (max-height: 64px) {
+    .workstation-resident-card {
+        justify-content: center;
+        padding        : 6px 12px;
+    }
+
+    .workstation-resident-kicker {display: none}
+}
+
+@container workstation-pane (max-height: 40px) {
+    .workstation-resident-card   {padding: 0}
+    .workstation-resident-metric {display: none}
 }
 
 // ScalePane's grid CELL classes — they ride the pane's own grid, so they travel with it.

--- a/test/playwright/e2e/workstation/WorkstationResidentCardSizingNL.spec.mjs
+++ b/test/playwright/e2e/workstation/WorkstationResidentCardSizingNL.spec.mjs
@@ -141,3 +141,156 @@ test.describe('Workstation resident cards — progressive disclosure at a short 
         ).toBe(true)
     })
 });
+
+/**
+ * Collects the containment and disclosure facts the degradation contract consumes.
+ * @param {Object} page Playwright page
+ * @returns {Promise<Object[]>}
+ */
+function collectDegradation(page) {
+    return page.evaluate(() => [...document.querySelectorAll('.workstation-resident-card')].map(card => {
+        const pane     = card.closest('.workstation-placeholder'),
+              paneRect = pane.getBoundingClientRect(),
+              cardRect = card.getBoundingClientRect(),
+              paneId   = [...pane.classList].find(cls => cls.startsWith('workstation-pane-')) ?? 'workstation-pane-unknown';
+
+        return {
+            cardBottom: cardRect.bottom,
+            cardHeight: cardRect.height,
+            cardTop   : cardRect.top,
+            children  : [...card.children].map(child => {
+                const rect = child.getBoundingClientRect();
+
+                return {
+                    bottom : rect.bottom,
+                    display: getComputedStyle(child).display,
+                    height : rect.height,
+                    name   : [...child.classList].find(cls => cls.startsWith('workstation-resident-')) ?? child.tagName,
+                    top    : rect.top
+                }
+            }),
+            paneHeight: paneRect.height,
+            paneId
+        }
+    }))
+}
+
+/**
+ * Asserts the below-content-height degradation contract on one collected station.
+ *
+ * Three relationships, no threshold values: a visible child never resolves to 0 height
+ * (its disappearance is a declared rule, not slack math), a visible child never paints
+ * outside the card's own box, and the card is never taller than the pane containing it.
+ * @param {Object[]} cards Collected via collectDegradation()
+ * @param {String} station Label for failure messages
+ */
+function assertDegradationContract(cards, station) {
+    expect(cards.length, `${station}: resident cards must be present`).toBeGreaterThan(1);
+
+    cards.forEach(card => {
+        expect(
+            card.cardHeight,
+            `${station} ${card.paneId}: the card must never be taller than its pane (card ${card.cardHeight}, pane ${card.paneHeight})`
+        ).toBeLessThanOrEqual(card.paneHeight + 0.5);
+
+        card.children.forEach(child => {
+            if (child.display !== 'none') {
+                expect(
+                    child.height,
+                    `${station} ${card.paneId}/${child.name}: a visible child must never resolve to 0 height (pane ${card.paneHeight}px)`
+                ).toBeGreaterThan(0);
+
+                expect(
+                    child.bottom,
+                    `${station} ${card.paneId}/${child.name}: a visible child must not paint below the card box (child bottom ${child.bottom}, card bottom ${card.cardBottom}, pane ${card.paneHeight}px)`
+                ).toBeLessThanOrEqual(card.cardBottom + 0.5);
+
+                expect(
+                    child.top,
+                    `${station} ${card.paneId}/${child.name}: a visible child must not paint above the card box`
+                ).toBeGreaterThanOrEqual(card.cardTop - 0.5)
+            }
+        })
+    })
+}
+
+/**
+ * Asserts that disclosure is monotone in pane height across every collected sample:
+ * whatever is visible at a shorter pane must also be visible at a materially taller one.
+ * Binds the ORDER of the ladder, never its threshold values, so a retune stays green.
+ * Pairs closer than the guard band are skipped — they may legitimately straddle a boundary.
+ * @param {Object[]} samples Union of collectDegradation() results across stations
+ */
+function assertMonotoneDisclosure(samples) {
+    const sorted    = [...samples].sort((a, b) => a.paneHeight - b.paneHeight),
+          guardBand = 8,
+          visSet    = card => new Set(card.children.filter(c => c.display !== 'none').map(c => c.name));
+
+    sorted.forEach((short, i) => {
+        const shortVis = visSet(short);
+
+        sorted.slice(i + 1).forEach(tall => {
+            if (tall.paneHeight - short.paneHeight <= guardBand) return;
+
+            const tallVis = visSet(tall);
+
+            shortVis.forEach(name => {
+                expect(
+                    tallVis.has(name),
+                    `${name} is visible at a ${short.paneHeight}px pane (${short.paneId}) but hidden at a taller ` +
+                    `${tall.paneHeight}px pane (${tall.paneId}) — disclosure must shed monotonically with height`
+                ).toBe(true)
+            })
+        })
+    })
+}
+
+test.describe('Workstation resident cards — declared degradation below content height', () => {
+    test.setTimeout(120000);
+    test.use({
+        contextOptions: {screen: {height: 1080, width: 1920}},
+        viewport      : {height: 880, width: 1282}
+    });
+
+    // The three stations walk the reported degradation table (1282×880 / ×560 / ×420): healthy,
+    // below-content-height, and pane-shorter-than-the-box-model-floor. The resize path between
+    // them is the same journey a film-paced window resize sweeps through.
+    test('a card degrades as a declared unit, never by shedding children or escaping its boxes', async ({page}) => {
+        await bootWorkstation(page);
+
+        const settle = async () => {
+            await page.waitForFunction(() => {
+                const panes = [...document.querySelectorAll('.workstation-placeholder')];
+
+                return panes.length > 1 && panes.every(pane => pane.getBoundingClientRect().width > 0)
+            }, {timeout: 30000});
+            await page.waitForTimeout(900)
+        };
+
+        const stations = [];
+
+        stations.push({label: '1282x880', cards: await collectDegradation(page)});
+
+        await page.setViewportSize({height: 560, width: 1282});
+        await settle();
+        stations.push({label: '1282x560', cards: await collectDegradation(page)});
+
+        await page.setViewportSize({height: 420, width: 1282});
+        await settle();
+        stations.push({label: '1282x420', cards: await collectDegradation(page)});
+
+        stations.forEach(({label, cards}) => assertDegradationContract(cards, label));
+
+        assertMonotoneDisclosure(stations.flatMap(({cards}) => cards));
+
+        // The journey must actually reach the below-content-height band, or the contract
+        // assertions above are vacuous: at the shortest station at least one pane must sit
+        // below the taller trim thresholds with its card still bound by the contract.
+        const shortest = stations.at(-1).cards.map(card => card.paneHeight).sort((a, b) => a - b).at(0);
+
+        expect(
+            shortest,
+            `the shortest station must produce a below-content-height pane (measured ${shortest}px)`
+        ).toBeLessThan(100)
+    })
+});


### PR DESCRIPTION
Resolves #16716

The resident card's disclosure ladder ended at 145px, leaving everything below it undeclared: the title painted past its own card box (the reported 256.8 vs 241 at a 78px card — reproduced by the new witness at 255.8 pre-fix), the 2×12px padding floor made the card taller than sub-24px panes (24 vs 10 at the 420 station), and no rule decided what gives between 145px and zero. The ladder now continues on the same fit arithmetic that built the existing 170/145 tiers: the icon yields at ≤118, the title at ≤92, a compact metric-only chip re-pads at ≤64, and at ≤40 the card yields the pane to its shell (gradient + signal line) as the declared empty state with padding 0. `overflow: clip` makes the card box a paint boundary for tier-transition transients, and the text rows join the wave's `flex-shrink: 0` contract, so every disappearance is a declared rule rather than slack math.

Evidence: L3 achieved (headed whitebox e2e at the ticket's three measured stations) — all four close-target ACs exercised in-sandbox, including the AC-4 red-proof against pre-fix styling. Residual: none.

## Deltas from ticket

- Intake premise correction (recorded on the ticket): the footer/wave zero-heights in the report were the designed #16487 disclosure tiers (`display: none` measures 0 to rect instruments), not silent collapse — the live defects were the title escape, the card>pane box-model floor, and the undeclared sub-145 band. The fix therefore extends the declared ladder downward instead of introducing a `min-height`, which would have forced overflow inside dock-owned pane heights.
- The compact chip keeps the metric, not the kicker: the number is the card's on-camera identity, while the kicker duplicates the pane tab's naming.
- The pane-region floor question (should the dock ever hand a pane 10px?) stays deliberately out of scope — that is #16498 AC-2's deliberate-presentation territory on the staging seam, and a layout-behavior change this presentation fix must not smuggle in.

## Test Evidence

- `NEO_E2E_PORT=8152 npx playwright test workstation/WorkstationResidentCardSizingNL -c test/playwright/playwright.config.e2e.mjs --workers=1` — RED pre-fix at the exact reported defect (AC-4): `1282x560 workstation-pane-metrics/workstation-resident-title: child bottom 255.796875, card bottom 241, pane 80px`. GREEN post-fix ×3 runs (3/3 tests each; 11.7s/12.4s/12.9s): containment, card-never-taller-than-pane, visible-implies-nonzero-height, and monotone nested disclosure across the 1282×880/560/420 journey. The two pre-existing tests in the same spec pin that the 170/145 behavior and pane-keyed type sizing are untouched.
- `apps/workstation` surface: `NEO_E2E_PORT=8153 npx playwright test workstation/WorkstationNL.spec -c test/playwright/playwright.config.e2e.mjs --workers=1` — 2/2 green (48.1s): dense tour + theme journey unaffected (the new tiers only engage at ≤118px pane heights).
- Theme build: `npm run build-themes -- -n -t all -e dev` clean.

## Post-Merge Validation

- [ ] Next film take: the scene-1 resize sweep presents declared tier transitions on camera instead of the escaped-title / partial-stack compositions in the take-18 F7 band.

## Commits

- b51a70a816 — the ladder + clip + shrink contract + the three-station witness

Authored by Mnemosyne (Fable 5, Claude Code). Session 7e8a0e84-6733-474e-865e-1757feb4b5f8.
