### PR TITLE
feat(memory-core): retain recent slow call timelines (#16723)

### DIFF
--- a/ai/mcp/server/memory-core/configBase.mjs
+++ b/ai/mcp/server/memory-core/configBase.mjs
@@ -305,7 +305,8 @@ class ConfigBase extends ConfigProvider {
                 enabled          : leaf(true, 'NEO_MC_TOOL_TELEMETRY_ENABLED', 'boolean'),
                 errorMaxChars    : leaf(512, 'NEO_MC_TOOL_TELEMETRY_ERROR_MAX_CHARS', 'number'),
                 aggregateWindowMs: leaf(DAY_MS, 'NEO_MC_TOOL_TELEMETRY_WINDOW_MS', 'number'),
-                aggregateLimit   : leaf(50, 'NEO_MC_TOOL_TELEMETRY_LIMIT', 'number')
+                aggregateLimit   : leaf(50, 'NEO_MC_TOOL_TELEMETRY_LIMIT', 'number'),
+                slowAfterMs      : leaf(60_000, 'NEO_MC_TOOL_TELEMETRY_SLOW_AFTER_MS', 'number')
             },
             /**
              * Data Schema/Table Names

--- a/ai/mcp/server/memory-core/openapi.yaml
+++ b/ai/mcp/server/memory-core/openapi.yaml
@@ -216,10 +216,11 @@ paths:
         readOnlyHint: true
       description: |
         Returns aggregate Memory Core MCP tool-call telemetry without exposing raw tool
-        arguments or results. Completed calls provide latency/failure aggregates; calls that
-        have crossed the start boundary but not the completion boundary are returned separately
-        with redacted operation identity and elapsed time. Use this to diagnose slow, failing,
-        or process-wedging tools in long-running local and shared deployments.
+        arguments, results, or caller identity. Completed calls provide latency/failure aggregates;
+        calls that have crossed the start boundary but not the completion boundary are returned
+        separately with redacted operation identity and elapsed time; recent completed calls above
+        a caller-selected duration retain their exact redacted timeline after recovery. Use this to
+        diagnose slow, failing, or process-wedging tools in long-running local and shared deployments.
       tags: [Diagnostics]
       requestBody:
         required: false
@@ -235,7 +236,11 @@ paths:
                 limit:
                   type: integer
                   minimum: 1
-                  description: Maximum number of per-tool aggregate rows. Defaults to the Memory Core telemetry config leaf.
+                  description: Maximum rows per aggregate/unfinished/slow projection. Defaults to the Memory Core telemetry config leaf.
+                slowAfterMs:
+                  type: integer
+                  minimum: 1
+                  description: Minimum completed-call duration included in recentSlowCalls. Defaults to the canonical 60000 ms MCP request deadline.
       responses:
         '200':
           description: Aggregate Memory Core MCP tool-call metrics.
@@ -2546,10 +2551,12 @@ components:
         - status
         - sinceMs
         - limit
+        - slowAfterMs
         - totalCalls
         - totalUnfinished
         - tools
         - unfinishedCalls
+        - recentSlowCalls
       properties:
         status:
           type: string
@@ -2562,8 +2569,13 @@ components:
           example: 86400000
         limit:
           type: integer
-          description: Effective maximum number of grouped tool rows.
+          description: Effective maximum number of rows per projection.
           example: 50
+        slowAfterMs:
+          type: integer
+          minimum: 1
+          description: Effective completed-call duration threshold in milliseconds.
+          example: 60000
         totalCalls:
           type: integer
           description: Total matching completed tool calls across all tools.
@@ -2644,6 +2656,46 @@ components:
                 minimum: 0
                 description: Elapsed wall-clock time at metrics-read time.
                 example: 474347
+        recentSlowCalls:
+          type: array
+          description: Newest-completed calls whose completion falls inside sinceMs and whose duration is at or above slowAfterMs. Server completion does not prove a timed-out client received the response; arguments, results, and caller identity are intentionally absent.
+          items:
+            type: object
+            additionalProperties: false
+            required:
+              - callId
+              - tool
+              - startedAt
+              - completedAt
+              - durationMs
+              - success
+              - failureStage
+            properties:
+              callId:
+                type: string
+                description: Opaque telemetry row id shared with the unfinished-call projection.
+              tool:
+                type: string
+                description: MCP operation id.
+              startedAt:
+                type: string
+                format: date-time
+                description: ISO timestamp captured immediately before tool dispatch.
+              completedAt:
+                type: string
+                format: date-time
+                description: ISO timestamp captured when server-side tool execution returned.
+              durationMs:
+                type: integer
+                minimum: 0
+                description: Server-side elapsed wall-clock duration.
+              success:
+                type: boolean
+                description: Whether server-side tool execution completed successfully.
+              failureStage:
+                type: string
+                nullable: true
+                description: Redacted recorder stage when the call failed, or null on success.
 
     RemPipelineStateResponse:
       type: object

--- a/ai/scripts/lint/config-leaf-parity.json
+++ b/ai/scripts/lint/config-leaf-parity.json
@@ -626,6 +626,7 @@
         "toolTelemetry.aggregateWindowMs",
         "toolTelemetry.enabled",
         "toolTelemetry.errorMaxChars",
+        "toolTelemetry.slowAfterMs",
         "transport",
         "turnPresence",
         "turnPresence.freshMs",

--- a/ai/services/memory-core/MemoryCoreRecorderService.mjs
+++ b/ai/services/memory-core/MemoryCoreRecorderService.mjs
@@ -23,6 +23,13 @@ const SENSITIVE_PAYLOAD_KEYS = new Set([
 export const TOOL_TELEMETRY_BUSY_TIMEOUT_MS = 50;
 
 /**
+ * @summary Default completed-call threshold for incident correlation. It matches the canonical MCP
+ * client request deadline: a server call at or above this duration may have outlived its caller.
+ * @type {Number}
+ */
+export const DEFAULT_SLOW_CALL_THRESHOLD_MS = 60_000;
+
+/**
  * @summary Persists redacted Memory Core MCP tool-call telemetry.
  *
  * This is the Memory Core sibling of the Knowledge Base and Neural Link recorder services,
@@ -330,22 +337,52 @@ class MemoryCoreRecorderService extends Base {
     }
 
     /**
-     * Returns aggregate Memory Core MCP tool-call metrics without exposing raw payloads.
+     * @summary Returns aggregate, unfinished, and recent-slow Memory Core MCP tool-call metrics without
+     * exposing raw payloads or caller identity. A completed slow row preserves the exact timeline
+     * after it disappears from `unfinishedCalls`; it proves server code returned, never that a
+     * timed-out client received the response.
      * @param {Object} options
      * @param {Number} [options.sinceMs=config.toolTelemetry.aggregateWindowMs] Lookback window.
-     * @param {Number} [options.limit=config.toolTelemetry.aggregateLimit] Max grouped tools.
+     * @param {Number} [options.limit=config.toolTelemetry.aggregateLimit] Max rows per projection.
+     * @param {Number} [options.slowAfterMs=DEFAULT_SLOW_CALL_THRESHOLD_MS] Minimum completed-call
+     *     duration included in `recentSlowCalls`.
      * @returns {Object}
      */
     getMemoryCoreToolMetrics({
-        sinceMs = config.toolTelemetry.aggregateWindowMs,
-        limit   = config.toolTelemetry.aggregateLimit
+        sinceMs     = config.toolTelemetry.aggregateWindowMs,
+        limit       = config.toolTelemetry.aggregateLimit,
+        slowAfterMs = DEFAULT_SLOW_CALL_THRESHOLD_MS
     } = {}) {
+        const safeSlowAfterMs = Number.isFinite(slowAfterMs) && slowAfterMs > 0
+            ? slowAfterMs
+            : DEFAULT_SLOW_CALL_THRESHOLD_MS;
+
         if (!config.toolTelemetry.enabled) {
-            return {status: 'disabled', sinceMs, limit, totalCalls: 0, totalUnfinished: 0, tools: [], unfinishedCalls: []};
+            return {
+                status         : 'disabled',
+                sinceMs,
+                limit,
+                slowAfterMs    : safeSlowAfterMs,
+                totalCalls     : 0,
+                totalUnfinished: 0,
+                tools          : [],
+                unfinishedCalls: [],
+                recentSlowCalls: []
+            };
         }
 
         if (!this.db) {
-            return {status: 'unavailable', sinceMs, limit, totalCalls: 0, totalUnfinished: 0, tools: [], unfinishedCalls: []};
+            return {
+                status         : 'unavailable',
+                sinceMs,
+                limit,
+                slowAfterMs    : safeSlowAfterMs,
+                totalCalls     : 0,
+                totalUnfinished: 0,
+                tools          : [],
+                unfinishedCalls: [],
+                recentSlowCalls: []
+            };
         }
 
         this.ensureSchema();
@@ -389,15 +426,25 @@ class MemoryCoreRecorderService extends Base {
                  ORDER BY timestamp ASC, id ASC
                  LIMIT @limit
             `).all({sinceTs, limit: safeLimit}),
+            slowRows = this.db.prepare(`
+                SELECT id, timestamp, completed_at, duration_ms, tool, success, failure_stage
+                  FROM mc_tool_call_log
+                 WHERE completed_at >= @sinceTs
+                   AND completed_at IS NOT NULL
+                   AND duration_ms >= @slowAfterMs
+                 ORDER BY completed_at DESC, id ASC
+                 LIMIT @limit
+            `).all({sinceTs, slowAfterMs: safeSlowAfterMs, limit: safeLimit}),
             now = Date.now();
 
         return {
-            status    : 'ok',
-            sinceMs   : safeSinceMs,
-            limit     : safeLimit,
-            totalCalls: total,
+            status     : 'ok',
+            sinceMs    : safeSinceMs,
+            limit      : safeLimit,
+            slowAfterMs: safeSlowAfterMs,
+            totalCalls : total,
             totalUnfinished,
-            tools     : rows.map(row => ({
+            tools      : rows.map(row => ({
                 tool         : row.tool,
                 calls        : row.calls,
                 failures     : row.failures || 0,
@@ -411,6 +458,15 @@ class MemoryCoreRecorderService extends Base {
                 tool     : row.tool,
                 startedAt: new Date(row.timestamp).toISOString(),
                 elapsedMs: Math.max(0, now - row.timestamp)
+            })),
+            recentSlowCalls: slowRows.map(row => ({
+                callId      : row.id,
+                tool        : row.tool,
+                startedAt   : new Date(row.timestamp).toISOString(),
+                completedAt : new Date(row.completed_at).toISOString(),
+                durationMs  : row.duration_ms,
+                success     : row.success === 1,
+                failureStage: row.failure_stage ?? null
             }))
         };
     }

--- a/ai/services/memory-core/MemoryCoreRecorderService.mjs
+++ b/ai/services/memory-core/MemoryCoreRecorderService.mjs
@@ -23,13 +23,6 @@ const SENSITIVE_PAYLOAD_KEYS = new Set([
 export const TOOL_TELEMETRY_BUSY_TIMEOUT_MS = 50;
 
 /**
- * @summary Default completed-call threshold for incident correlation. It matches the canonical MCP
- * client request deadline: a server call at or above this duration may have outlived its caller.
- * @type {Number}
- */
-export const DEFAULT_SLOW_CALL_THRESHOLD_MS = 60_000;
-
-/**
  * @summary Persists redacted Memory Core MCP tool-call telemetry.
  *
  * This is the Memory Core sibling of the Knowledge Base and Neural Link recorder services,
@@ -344,18 +337,19 @@ class MemoryCoreRecorderService extends Base {
      * @param {Object} options
      * @param {Number} [options.sinceMs=config.toolTelemetry.aggregateWindowMs] Lookback window.
      * @param {Number} [options.limit=config.toolTelemetry.aggregateLimit] Max rows per projection.
-     * @param {Number} [options.slowAfterMs=DEFAULT_SLOW_CALL_THRESHOLD_MS] Minimum completed-call
-     *     duration included in `recentSlowCalls`.
+     * @param {Number} [options.slowAfterMs=config.toolTelemetry.slowAfterMs] Minimum completed-call
+     *     duration included in `recentSlowCalls`; the resolved leaf defaults to the canonical MCP
+     *     client request deadline, so a matching server call may have outlived its caller.
      * @returns {Object}
      */
     getMemoryCoreToolMetrics({
         sinceMs     = config.toolTelemetry.aggregateWindowMs,
         limit       = config.toolTelemetry.aggregateLimit,
-        slowAfterMs = DEFAULT_SLOW_CALL_THRESHOLD_MS
+        slowAfterMs = config.toolTelemetry.slowAfterMs
     } = {}) {
         const safeSlowAfterMs = Number.isFinite(slowAfterMs) && slowAfterMs > 0
             ? slowAfterMs
-            : DEFAULT_SLOW_CALL_THRESHOLD_MS;
+            : config.toolTelemetry.slowAfterMs;
 
         if (!config.toolTelemetry.enabled) {
             return {

--- a/test/playwright/unit/ai/services/memory-core/MemoryCoreRecorderService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/MemoryCoreRecorderService.spec.mjs
@@ -26,6 +26,7 @@ test.describe('Neo.ai.services.memory-core.MemoryCoreRecorderService', () => {
 
     let originalEnv;
     let testDbPath;
+    let memoryCoreConfig;
     let MemoryCoreRecorderService;
 
     test.beforeAll(async () => {
@@ -52,6 +53,7 @@ test.describe('Neo.ai.services.memory-core.MemoryCoreRecorderService', () => {
             try { fs.unlinkSync(`${testDbPath}${suffix}`); } catch (e) {}
         }
 
+        memoryCoreConfig          = (await import('../../../../../../ai/mcp/server/memory-core/config.template.mjs')).default;
         MemoryCoreRecorderService = (await import('../../../../../../ai/services/memory-core/MemoryCoreRecorderService.mjs')).default;
         await MemoryCoreRecorderService.initAsync();
     });
@@ -262,6 +264,107 @@ test.describe('Neo.ai.services.memory-core.MemoryCoreRecorderService', () => {
         expect(JSON.stringify(metrics)).not.toContain('safe');
     });
 
+    test('returns bounded recent slow completions without caller identity or payloads', () => {
+        const
+            now    = Date.now(),
+            insert = MemoryCoreRecorderService.db.prepare(`
+                INSERT INTO mc_tool_call_log (
+                    id, agent_id, user_id, session_id, sequence_id, timestamp,
+                    tool, success, duration_ms, completed_at, failure_stage,
+                    error_message, args_bytes, result_bytes
+                ) VALUES (
+                    @id, @agentId, @userId, @sessionId, @sequenceId, @timestamp,
+                    @tool, @success, @durationMs, @completedAt, @failureStage,
+                    @errorMessage, @argsBytes, @resultBytes
+                )
+            `),
+            identity = '@private-agent',
+            payload  = 'PRIVATE_PAYLOAD';
+
+        for (const row of [
+            {
+                id        : 'slow-older', timestamp: now - 9_000, completedAt: now - 7_000,
+                durationMs: 2_000, tool: 'list_messages', success: 1, failureStage: null
+            },
+            {
+                id        : 'slow-newer-b', timestamp: now - 2_600, completedAt: now - 1_000,
+                durationMs: 1_600, tool: 'healthcheck', success: 1, failureStage: null
+            },
+            {
+                id        : 'slow-newer-a', timestamp: now - 2_500, completedAt: now - 1_000,
+                durationMs: 1_500, tool: 'add_message', success: 0, failureStage: 'dispatch'
+            },
+            {
+                id        : 'fast', timestamp: now - 900, completedAt: now - 850,
+                durationMs: 50, tool: 'get_message', success: 1, failureStage: null
+            },
+            {
+                id        : 'outside-window', timestamp: now - 120_000, completedAt: now - 118_000,
+                durationMs: 2_000, tool: 'query_summaries', success: 1, failureStage: null
+            },
+            {
+                id        : 'slow-cross-window', timestamp: now - 120_000, completedAt: now - 500,
+                durationMs: 119_500, tool: 'add_message', success: 1, failureStage: null
+            }
+        ]) {
+            insert.run({
+                ...row,
+                agentId     : identity,
+                userId      : 'private-user',
+                sessionId   : 'private-session',
+                sequenceId  : `sequence-${row.id}`,
+                errorMessage: payload,
+                argsBytes   : payload.length,
+                resultBytes : payload.length
+            });
+        }
+
+        const metrics = MemoryCoreRecorderService.getMemoryCoreToolMetrics({
+            sinceMs    : 60_000,
+            limit      : 10,
+            slowAfterMs: 1_000
+        });
+
+        expect(metrics.slowAfterMs).toBe(1_000);
+        expect(metrics.recentSlowCalls.map(row => row.callId)).toEqual([
+            'slow-cross-window',
+            'slow-newer-a',
+            'slow-newer-b',
+            'slow-older'
+        ]);
+        expect(metrics.recentSlowCalls[1]).toEqual({
+            callId      : 'slow-newer-a',
+            tool        : 'add_message',
+            startedAt   : new Date(now - 2_500).toISOString(),
+            completedAt : new Date(now - 1_000).toISOString(),
+            durationMs  : 1_500,
+            success     : false,
+            failureStage: 'dispatch'
+        });
+        expect(Object.keys(metrics.recentSlowCalls[0])).toEqual([
+            'callId',
+            'tool',
+            'startedAt',
+            'completedAt',
+            'durationMs',
+            'success',
+            'failureStage'
+        ]);
+        expect(JSON.stringify(metrics.recentSlowCalls)).not.toContain(identity);
+        expect(JSON.stringify(metrics.recentSlowCalls)).not.toContain(payload);
+
+        const bounded = MemoryCoreRecorderService.getMemoryCoreToolMetrics({
+            sinceMs    : 60_000,
+            limit      : 2,
+            slowAfterMs: 1_000
+        });
+
+        expect(bounded.recentSlowCalls.map(row => row.callId)).toEqual([
+            'slow-cross-window',
+            'slow-newer-a'
+        ]);
+    });
+
     test('captures Memory Core MCP wrapper success and dispatch failure', async () => {
         const {callTool} = await import('../../../../../../ai/mcp/server/memory-core/toolService.mjs');
 
@@ -311,6 +414,28 @@ test.describe('Neo.ai.services.memory-core.MemoryCoreRecorderService', () => {
         expect(JSON.stringify(rows)).not.toContain(secret);
     });
 
+    test('returns the bounded empty projection when telemetry is disabled', () => {
+        const originalEnabled = process.env.NEO_MC_TOOL_TELEMETRY_ENABLED;
+
+        try {
+            process.env.NEO_MC_TOOL_TELEMETRY_ENABLED = 'false';
+            memoryCoreConfig.refreshEnv();
+
+            expect(MemoryCoreRecorderService.getMemoryCoreToolMetrics({slowAfterMs: 1_000})).toMatchObject({
+                status         : 'disabled',
+                slowAfterMs    : 1_000,
+                totalCalls     : 0,
+                totalUnfinished: 0,
+                tools          : [],
+                unfinishedCalls: [],
+                recentSlowCalls: []
+            });
+        } finally {
+            process.env.NEO_MC_TOOL_TELEMETRY_ENABLED = originalEnabled;
+            memoryCoreConfig.refreshEnv();
+        }
+    });
+
     test('fails open when telemetry storage is unavailable', () => {
         const originalDb = MemoryCoreRecorderService.db;
         MemoryCoreRecorderService.db = null;
@@ -331,10 +456,17 @@ test.describe('Neo.ai.services.memory-core.MemoryCoreRecorderService', () => {
 
             expect(MemoryCoreRecorderService.getMemoryCoreToolMetrics()).toMatchObject({
                 status         : 'unavailable',
+                slowAfterMs    : 60_000,
                 totalCalls     : 0,
                 totalUnfinished: 0,
                 tools          : [],
-                unfinishedCalls: []
+                unfinishedCalls: [],
+                recentSlowCalls: []
+            });
+
+            expect(MemoryCoreRecorderService.getMemoryCoreToolMetrics({slowAfterMs: 0})).toMatchObject({
+                slowAfterMs    : 60_000,
+                recentSlowCalls: []
             });
         } finally {
             MemoryCoreRecorderService.db = originalDb;

--- a/test/playwright/unit/ai/services/memory-core/MemoryCoreRecorderService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/MemoryCoreRecorderService.spec.mjs
@@ -33,6 +33,7 @@ test.describe('Neo.ai.services.memory-core.MemoryCoreRecorderService', () => {
         originalEnv = {
             NEO_MC_TOOL_TELEMETRY_ENABLED        : process.env.NEO_MC_TOOL_TELEMETRY_ENABLED,
             NEO_MC_TOOL_TELEMETRY_ERROR_MAX_CHARS: process.env.NEO_MC_TOOL_TELEMETRY_ERROR_MAX_CHARS,
+            NEO_MC_TOOL_TELEMETRY_SLOW_AFTER_MS  : process.env.NEO_MC_TOOL_TELEMETRY_SLOW_AFTER_MS,
             NEO_MEMORY_DB_PATH_TEST              : process.env.NEO_MEMORY_DB_PATH_TEST,
             UNIT_TEST_MODE                       : process.env.UNIT_TEST_MODE
         };
@@ -363,6 +364,36 @@ test.describe('Neo.ai.services.memory-core.MemoryCoreRecorderService', () => {
             'slow-cross-window',
             'slow-newer-a'
         ]);
+    });
+
+    test('reads the default slow threshold from the resolved leaf and validates caller overrides', () => {
+        const originalSlowAfterMs = process.env.NEO_MC_TOOL_TELEMETRY_SLOW_AFTER_MS;
+
+        try {
+            process.env.NEO_MC_TOOL_TELEMETRY_SLOW_AFTER_MS = '1234';
+            memoryCoreConfig.refreshEnv();
+
+            expect(MemoryCoreRecorderService.getMemoryCoreToolMetrics()).toMatchObject({
+                status         : 'ok',
+                slowAfterMs    : 1_234,
+                recentSlowCalls: []
+            });
+            expect(MemoryCoreRecorderService.getMemoryCoreToolMetrics({slowAfterMs: 0})).toMatchObject({
+                slowAfterMs    : 1_234,
+                recentSlowCalls: []
+            });
+            expect(MemoryCoreRecorderService.getMemoryCoreToolMetrics({slowAfterMs: 500})).toMatchObject({
+                slowAfterMs    : 500,
+                recentSlowCalls: []
+            })
+        } finally {
+            if (originalSlowAfterMs === undefined) {
+                delete process.env.NEO_MC_TOOL_TELEMETRY_SLOW_AFTER_MS
+            } else {
+                process.env.NEO_MC_TOOL_TELEMETRY_SLOW_AFTER_MS = originalSlowAfterMs
+            }
+            memoryCoreConfig.refreshEnv()
+        }
     });
 
     test('captures Memory Core MCP wrapper success and dispatch failure', async () => {


### PR DESCRIPTION
Resolves #16723

Related: #16677
Related: #16685

Memory Core now retains a bounded, redacted timeline for calls that completed at or above a caller-selected duration. The existing `get_memory_core_tool_metrics` observer adds `slowAfterMs` plus newest-completed `recentSlowCalls` rows carrying only opaque call id, tool, start/completion timestamps, duration, success, and failure stage. This preserves the exact incident correlation after an unfinished call self-recovers and collapses into the aggregate.

The lookback is completion-based for this projection: a seven-minute call that began before a short incident window but completed inside it remains visible. Existing completed aggregates, unfinished rows, recorder storage, and best-effort failure behavior are unchanged.

Evidence: L2 (real SQLite row lifecycle + strict OpenAPI contract) → L3 pending deployment. The deterministic close target is fully covered; the live exact-row receipt is `NOT_YET_MEASURED` until this head reaches the canonical plane.

## Deltas from ticket

One implementation refinement: `sinceMs` applies to `completedAt` for `recentSlowCalls`, not `startedAt`. That is the incident-correct boundary for a long call that starts before a short lookback and completes after recovery; a dedicated cross-window fixture proves it. No scope expansion.

## Test Evidence

- Red control against pre-change source: focused recorder suite produced 10 passes / 1 failure, solely because `slowAfterMs` was absent.
- Exact-final unit + public schema: `npx playwright test -c test/playwright/playwright.config.unit.mjs test/playwright/unit/ai/services/memory-core/MemoryCoreRecorderService.spec.mjs test/playwright/unit/ai/mcp/validation/OpenApiValidatorCompliance.spec.mjs` — 59/59 passed.
- Staged repository gates: `npx lint-staged --verbose` — whitespace, shorthand, AiConfig test mutation, derived-domain, JSDoc, ticket archaeology, block alignment, parse, and OpenAPI/service parity all passed.
- Direct parity: `node ./ai/scripts/lint/lint-openapi-service-parity.mjs` — 40 wrapped services, 121 operation-bound methods, 142 object-dispatch handlers, zero consumed-but-undeclared parameters.
- Live premise receipt on deployed prior revision: 2,672 completed calls / zero unfinished; maxima `add_message=474347ms`, `healthcheck=283564ms`, `list_messages=283526ms`, `query_raw_memories=71886ms`.

## Post-Merge Validation

- [ ] After canonical MC deploys this head, call `get_memory_core_tool_metrics({sinceMs: 21600000, limit: 30, slowAfterMs: 60000})`.
- [ ] Confirm the previous aggregate-only maxima appear as exact redacted rows if they remain inside the retained deployment epoch; otherwise record `NOT_YET_MEASURED` rather than synthesizing a receipt.
- [ ] On the next #16677 recurrence, correlate `unfinishedCalls.callId` with the eventual `recentSlowCalls.callId` before assigning a cause.
- [ ] Preserve the distinction: server completion does not prove client response delivery; recorder absence does not prove no dispatch.

## Evolution

Stepping back after the first green exposed the cross-window case: filtering slow rows by start time would discard exactly the long-running call this projection exists to recover. The final contract therefore uses completion time while leaving the established aggregate window untouched. The change extends one observer instead of spending another MCP tool slot, reuses the existing row schema, and adds no new persistence or authority surface.

Authored by Emmy (GPT-5.6 Sol Ultra, Codex). Session 019fe0b3-53bc-7ef2-8665-41a0ef3f7b62.