### PR TITLE
test: the continuity guard red-control fires on a staged whole-body clear (#16507)

### DIFF
--- a/test/playwright/e2e/workstation/WorkstationFiveBeatNL.spec.mjs
+++ b/test/playwright/e2e/workstation/WorkstationFiveBeatNL.spec.mjs
@@ -1585,6 +1585,11 @@ test.describe('Workstation — the five-beat multi-window journey', () => {
                 'run with --headed because CDP screencast compositor frames are required'
             );
 
+            // Instrument-integrity fixture, never a scene: a film take runs this whole file
+            // with cameras rolling, and a staged whole-body clear must not enter take footage
+            // (frame audits sweep the take for exactly this signature).
+            test.skip(filmTake, 'the staged clear is excluded from film takes by design');
+
             const {pageErrors} = await boot({page, neuralLink});
 
             // The action IS the fixture: hold the dock host fully transparent across enough

--- a/test/playwright/e2e/workstation/WorkstationFiveBeatNL.spec.mjs
+++ b/test/playwright/e2e/workstation/WorkstationFiveBeatNL.spec.mjs
@@ -938,6 +938,11 @@ test.describe('Workstation — the five-beat multi-window journey', () => {
         expect(continuity.frameCount,
             `${label} must expose consecutive compositor frames`).toBeGreaterThan(2);
 
+        // Floor provenance, measured not chosen: confirmed whole-body clears measure ~0.08x
+        // baseline (the repaired tour-entry blank: 0.4088 against 5.30-5.35 baselines), while
+        // healthy film-paced minima hold >=0.93x baseline (5.30/5.31 on the same stages). 0.65
+        // separates the measured populations with >=8x margin on the red side and >=1.4x on the
+        // green side; retune it only against fresh measured receipts of both populations.
         const entropyFloor = continuity.baselineEntropy * 0.65;
 
         if (continuity.minEntropy < entropyFloor) {
@@ -1567,6 +1572,66 @@ test.describe('Workstation — the five-beat multi-window journey', () => {
             });
             expect(ownerResult.errors).toEqual([]);
             expect(ownerResult.applied, 'the continuity guard must still complete its first tear-out commit').toBe(true);
+            expect(pageErrors).toEqual([])
+        }
+    );
+
+    test('continuity guard red-control: a deliberate whole-body clear reds the guard',
+        async ({page, neuralLink}, testInfo) => {
+            const userAgent = await page.evaluate(() => navigator.userAgent);
+
+            test.skip(
+                userAgent.includes('HeadlessChrome'),
+                'run with --headed because CDP screencast compositor frames are required'
+            );
+
+            const {pageErrors} = await boot({page, neuralLink});
+
+            // The action IS the fixture: hold the dock host fully transparent across enough
+            // compositor frames for the screencast to capture the exposed backdrop, then
+            // restore. A red-control direction that has never fired is instrument theater —
+            // this run proves the guard can convict the exact state it exists to catch.
+            const continuity = await captureWorkspaceContinuity(page, () =>
+                page.evaluate(() => new Promise(resolve => {
+                    const host = document.querySelector('.workstation-dock-host');
+
+                    host.style.opacity = '0';
+
+                    let held = 0;
+
+                    const step = () => {
+                        if (++held >= 10) {
+                            host.style.opacity = '';
+                            resolve()
+                        } else {
+                            requestAnimationFrame(step)
+                        }
+                    };
+
+                    requestAnimationFrame(step)
+                }))
+            );
+
+            // Discrimination needs both directions on one capture: the baseline must read as a
+            // healthy dense room, so the red below is the staged clear's doing — never a broken
+            // instrument measuring an empty stage.
+            expect(continuity.baselineEntropy,
+                'the red-control baseline must be a healthy dense workspace')
+                .toBeGreaterThan(2);
+
+            await assertWorkspaceContinuity({
+                continuity,
+                expectedCleared: true,
+                label          : 'red-control-staged-whole-body-clear',
+                receipt        : {stagedClear: 'dock-host opacity 0 held across 10 rAF frames'},
+                testInfo
+            });
+
+            const restoredOpacity = await page.evaluate(() =>
+                getComputedStyle(document.querySelector('.workstation-dock-host')).opacity
+            );
+
+            expect(restoredOpacity, 'the staged clear must leave no residue on the host').toBe('1');
             expect(pageErrors).toEqual([])
         }
     );


### PR DESCRIPTION
Resolves #16507

The continuity guard's `expectedCleared` red-control direction had zero call sites since authoring — written, branched on, never exercised. This PR gives it a real one: a headed test stages a deliberate whole-body clear (the dock host held fully transparent across 10 rAF frames mid-screencast) and proves the guard convicts it through the red branch — baseline 5.3006 (the healthy dense-room population exactly), staged-clear minimum 1.4576 at frame 1 against the 3.445 floor, and a residue-free restore assertion. The `0.65` floor constant gains measured provenance documentation next to its definition (red population ~0.08× baseline, green ≥0.93×, with the retune rule), completing the ticket as narrowed per @neo-gpt-emmy's intake.

Evidence: L3 achieved (headed whitebox run, CDP screencast compositor frames, real staged clear) — both close-target ACs runtime-exercised; AC-3 covered by the headless spec-paced lane. Residual: none.

## Deltas from ticket

- The staged fixture measures 0.275× baseline (1.46) rather than the defect population's ~0.08× (0.41) — the exposed backdrop behind the host carries a gradient the app's own cleared-body state does not. Both sit deep inside the red side of the 0.65 separator; the fixture's own receipt logs its number, and the provenance comment describes the defect population, not the fixture.
- Discrimination is asserted on one capture: a healthy-baseline precondition (>2) guarantees the red verdict is the staged clear's doing, never a broken instrument measuring an empty stage.

## Test Evidence

- Headed: `NEO_E2E_PORT=8154 npx playwright test workstation/WorkstationFiveBeatNL -c test/playwright/playwright.config.e2e.mjs --workers=1 --headed -g "red-control"` — 1/1 green (7.1s); receipt line: `baselineEntropy 5.300634, minEntropy 1.457634, minFrameIndex 1`.
- Headless spec-paced regression (the CI lane's shape): same command unheaded, un-grepped — **8 passed / 3 skipped** (53.6s; the skips are the headed-gated CDP tests, including the new one, exactly as before this change).
- `apps/workstation` surface: the five-beat suite above is the surface's own coverage; no app source touched.

## Post-Merge Validation

- [ ] CI's headless matrix confirms the new test self-skips cleanly (headed-gated) with no flake introduced across runners.

## Commits

- 342ec62ef9 — the red-control call site + floor provenance documentation

Authored by Mnemosyne (Fable 5, Claude Code). Session 7e8a0e84-6733-474e-865e-1757feb4b5f8.
