### PR TITLE
fix(draggable): remove debug console residue from the dashboard sort zone (#16725)

### DIFF
--- a/src/draggable/dashboard/SortZone.mjs
+++ b/src/draggable/dashboard/SortZone.mjs
@@ -93,13 +93,6 @@ class DashboardSortZone extends SortZone {
 
             me.adjustProxyRectToParent?.(rect, me.ownerRect);
 
-            console.log('applyAbsolutePositioning', {
-                height: `${rect.height}px`,
-                left  : `${rect.left}px`,
-                top   : `${rect.top}px`,
-                width : `${rect.width}px`
-            });
-
             item.wrapperStyle = Object.assign(itemStyle, {
                 flex    : 'none',
                 height  : `${rect.height}px`,
@@ -499,15 +492,6 @@ class DashboardSortZone extends SortZone {
 
         itemRects = await owner.getDomRect([owner.id].concat(sortableItems.map(e => e.id)));
 
-        itemRects.forEach(rect => {
-            console.log('itemRect', {
-                height: `${rect.height}px`,
-                left  : `${rect.left}px`,
-                top   : `${rect.top}px`,
-                width : `${rect.width}px`
-            });
-        });
-
         me.ownerRect = itemRects.shift();
         me.boundaryContainerRect = me.ownerRect;
 
@@ -517,8 +501,6 @@ class DashboardSortZone extends SortZone {
             minWidth: `${me.ownerRect.width}px`,
             width   : `${me.ownerRect.width}px`
         };
-
-        console.log('adjustItemRectsToParent', adjustItemRectsToParent);
 
         adjustItemRectsToParent && itemRects.forEach(rect => {
             rect.x -= me.ownerRect.x;
@@ -553,8 +535,6 @@ class DashboardSortZone extends SortZone {
         // Update dragged item to target app context
         draggedItem.appName = me.appName;
 
-        console.log('startRemoteDrag', draggedItem.id, draggedItem.windowId, draggedItem.parentId, draggedItem.parentComponent);
-
         // Break the parent chain to prevent circular config lookups during handover
         draggedItem.parentId        = null;
         draggedItem.parentComponent = null;
@@ -564,21 +544,13 @@ class DashboardSortZone extends SortZone {
         draggedItem.vnode            = null;
         draggedItem.vnodeInitialized = false;
 
-        console.log('parent cleared:', draggedItem.parentId, draggedItem.parentComponent);
-
         // 1. Get Owner Rect (needed for proxy positioning)
         let rects = await owner.getDomRect([owner.id]);
         me.ownerRect = rects[0];
 
-        console.log('ownerRect', me.ownerRect);
-
         // Assign the drag offsets to the instance, so that the DragZone onDragMove logic works
         me.offsetX = data.offsetX;
         me.offsetY = data.offsetY;
-
-        console.log('startRemoteDrag: ownerRect', me.ownerRect);
-        console.log('startRemoteDrag: local coords', data.localX, data.localY);
-        console.log('startRemoteDrag: calculated coords', data.localX - me.offsetX, data.localY - me.offsetY);
 
         // 2. Create a local DragProxy manually (using DragProxyContainer to hold the live widget)
         // We use DragProxyContainer to ensure the widget remains active/connected.
@@ -596,11 +568,7 @@ class DashboardSortZone extends SortZone {
             }
         };
 
-        console.log('Creating local drag proxy', config);
-
         me.dragProxy = Neo.create(config);
-
-        console.log('Created local drag proxy', me.dragProxy);
 
         // 3. Create Placeholder
         me.dragPlaceholder = Neo.create({


### PR DESCRIPTION
Resolves #16725

Eleven unguarded `console.log` calls were sitting in shipped framework source, so every application using dashboard drag printed eleven lines into its console per interaction — `src/dashboard/Container.mjs:146` lazy-imports this class, so the reach is any consumer, not a demo. This deletes them. Pure subtraction: **32 deletions, zero additions**, no logic, config, or control-flow touched.

Evidence: L2 (static enumeration of the file and its directory, plus the exact-head unit suite for every consumer of the touched class) → L2 required (AC1-AC3 and AC5 are static or unit-observable). Residual: AC4 [#16725] — see Post-Merge Validation.

## Deltas from ticket

None substantive. One judgement the ticket authorized but did not enumerate: the `itemRects.forEach` block at the old `:502` existed **solely** to hold its `console.log`, so the block went with the statement rather than leaving an empty iteration over `itemRects`. The ticket's Fix section covers this ("where a statement is the sole body of a block that exists only to hold it, remove the block too"); recording it because it is the only place the diff removes more than a single line.

## Why deleted rather than routed to a logger

The tempting move is "don't lose the diagnostics". It is wrong twice, and I checked both before choosing:

- **No logger to route to.** No file in `src/draggable/` imports or uses `Neo.util.Logger` — verified by grep across the tree. Conversion would introduce a dependency the directory does not otherwise have, purely to preserve output.
- **The content is not worth preserving.** The old `:573` and `:579` both printed `me.ownerRect`, six lines apart, with nothing mutating it in between. That is a print added twice by someone scrolling, not a trace anyone reads.

Memory Core places their origin: a `query_raw_memories` sweep returns December-2025 sessions debugging this exact file's drag-proxy width and placeholder flex defects, whose transcripts contain these very strings (`itemRect`, `adjustItemRectsToParent false`, `applyAbsolutePositioning`) as the diagnostic output being read at the time. The debugging concluded; the prints stayed, through three subsequent PRs that touched this file (91ff528, 3f526bd, 81e9045) and left every one in place.

## The negative control

`console.error` in `DragZone.mjs:182` and `:347` is **untouched** and verified so after the edit. Those are genuine failure reporting — a missing main-thread `DragDrop` addon, and a proxy-removal delta failure. A sweep that removed them would have overshot while a green diff-stat still said "cleanup", which is exactly the failure mode this control exists to catch. `container/SortZone.mjs:637` holds one already-commented-out `console.log`, left alone as harmless.

## Test Evidence

- `src/draggable/dashboard/SortZone.mjs` (the touched class) + every dashboard/drag consumer: `UNIT_TEST_MODE=true npx playwright test -c test/playwright/playwright.config.unit.mjs test/playwright/unit/draggable/ test/playwright/unit/dashboard/` — **560 passed, 0 failed** at the committed head. Tallied with a full `grep -E '^\s*[0-9]+ (passed|failed|skipped|flaky)'` rather than `tail`, because a `N failed` line above a cut is how a truncated sweep reads as green.
- `node --check src/draggable/dashboard/SortZone.mjs` — syntax clean. (A bare `import()` of the module reports `Neo is not defined`; that is the module requiring the Neo runtime, not a parse error, and is the wrong instrument for this question.)
- AC1: `grep -n 'console\.log' src/draggable/dashboard/SortZone.mjs` — no matches.
- AC2 negative control: `console.error` at both `DragZone.mjs` sites still present post-edit.
- AC3: `git diff -U0 | grep -E '^\+[^+]'` — zero added lines.

## Post-Merge Validation

- [ ] **AC4 — a dashboard drag produces no framework-emitted console output.** I did **not** drive a live drag. What is proven is narrower: this file now has zero `console.log`, and the only other `console.*` in `src/draggable/` is `console.error` on failure paths plus one commented-out line. AC4 follows from those two facts *if* no module outside `src/draggable/` on the drag path logs — which I did not enumerate. Stated as an inference rather than a measurement, and left for a real drag on a dashboard app to confirm.

## Follow-up noted, deliberately not bundled

There is **no mechanical guard** for this class: the repo has no ESLint config and no `no-console` rule anywhere; the `lint` CI jobs are bespoke `buildScripts/util/check-*.mjs` scripts. That is why three PRs passed through this file and left the residue. A guard is the right long-term answer and is recorded in #16725's Out of Scope rather than bundled here — it needs a new check script (structural-pre-flight) *and* a policy decision on the ~50 other `console.log` sites across `src/`, which I have not audited and will not assert are residue. Bundling an unaudited 50-site policy call into a verified eleven-line deletion would trade a provable cleanup for an unprovable one.

Not to be confused with #16684 (`Lint workflows must watch every surface their rules scan`) — that concerns CI path coverage for rules that exist; I checked, and no `no-console` rule exists to have coverage of.

🖖 Authored by Grace (Claude Opus 5, Claude Code). Session 51a81224-c5d4-4b3f-b0ed-764af44d572f.
