### PR TITLE
feat(ai): a starved tenant repo publishes how much work is outstanding (#16690)

### DIFF
--- a/ai/daemons/orchestrator/services/DeploymentStateBridgeService.mjs
+++ b/ai/daemons/orchestrator/services/DeploymentStateBridgeService.mjs
@@ -1697,11 +1697,16 @@ function summarizeTenantRepoState({
                 || normalizedCheckpoint?.lastErrorCode
                 || null)
             : null,
-        lastErrorCode                     : failures > 0 ? (normalizedCheckpoint?.lastErrorCode ?? null) : null,
-        lastSourceErrorCode               : failures > 0 ? (normalizedCheckpoint?.lastSourceErrorCode ?? null) : null,
-        lastAccessCode                    : failures > 0 ? (normalizedCheckpoint?.lastAccessCode ?? null) : null,
+        lastErrorCode      : failures > 0 ? (normalizedCheckpoint?.lastErrorCode ?? null) : null,
+        lastSourceErrorCode: failures > 0 ? (normalizedCheckpoint?.lastSourceErrorCode ?? null) : null,
+        lastAccessCode     : failures > 0 ? (normalizedCheckpoint?.lastAccessCode ?? null) : null,
         recoveryState,
         checkpointStatus,
+        // Published unconditionally, NOT gated on `failures > 0` like the cause codes above. A repo
+        // deferring against a slow provider holds its streak at zero by design, so gating this on the
+        // failure count would hide the backlog in precisely the state it was built to explain. It
+        // carries no identity and no message — a count, a state, and two timestamps.
+        corpusOutstanding                 : normalizedCheckpoint?.corpusOutstanding ?? null,
         ingestContractVersion             : normalizedCheckpoint?.ingestContractVersion ?? null,
         lastAttemptedIngestContractVersion: normalizedCheckpoint?.lastAttemptedIngestContractVersion ?? null,
         effectiveCadenceMs                : dueState.effectiveCadenceMs,

--- a/ai/daemons/orchestrator/services/TenantRepoSyncService.mjs
+++ b/ai/daemons/orchestrator/services/TenantRepoSyncService.mjs
@@ -426,10 +426,9 @@ function classifyIngestionOutcome(summary) {
  * @param {Object}      options.summary   Ingestion summary returned by the run.
  * @param {Object|null} options.priorState Previously persisted per-repo state, for the movement stamp.
  * @param {Number}      options.observedAt Epoch ms for this observation.
- * @param {Number}      [options.stuckThresholdMs] Age past which a non-decreasing backlog reads `stuck`.
  * @returns {Object} The `describeCorpusOutstanding` observation.
  */
-function buildCorpusOutstandingObservation({summary, priorState, observedAt, stuckThresholdMs}) {
+function buildCorpusOutstandingObservation({summary, priorState, observedAt}) {
     const
         accepted = summary?.ingested,
         skipped  = summary?.skippedOversized ?? 0,
@@ -442,8 +441,7 @@ function buildCorpusOutstandingObservation({summary, priorState, observedAt, stu
     return describeCorpusOutstanding({
         outstanding: deriveOutstanding({total, embedded, skipped}),
         observedAt,
-        previous   : priorState?.corpusOutstanding ?? null,
-        stuckThresholdMs
+        previous   : priorState?.corpusOutstanding ?? null
     })
 }
 

--- a/ai/daemons/orchestrator/services/TenantRepoSyncService.mjs
+++ b/ai/daemons/orchestrator/services/TenantRepoSyncService.mjs
@@ -1,10 +1,17 @@
-import fs                         from 'fs-extra';
-import {createHmac, randomBytes}  from 'node:crypto';
-import path                       from 'node:path';
-import Base                       from '../../../../src/core/Base.mjs';
-import AiConfig                   from '../../../config.mjs';
-import GitMirror                  from '../../../services/knowledge-base/helpers/gitMirror.mjs';
-import TextEmbeddingService       from '../../../services/memory-core/TextEmbeddingService.mjs';
+import fs                        from 'fs-extra';
+import {createHmac, randomBytes} from 'node:crypto';
+import path                      from 'node:path';
+import Base                      from '../../../../src/core/Base.mjs';
+import AiConfig                  from '../../../config.mjs';
+import GitMirror                 from '../../../services/knowledge-base/helpers/gitMirror.mjs';
+import TextEmbeddingService      from '../../../services/memory-core/TextEmbeddingService.mjs';
+// The outstanding-chunk observable is derived from the run's OWN totals rather than recomputed here.
+// A second implementation of "which chunks are missing" can disagree with the embedder that produced
+// them, and a backlog figure that disagrees with the embedder is worse than none.
+import {
+    deriveOutstanding,
+    describeCorpusOutstanding
+}                                from '../../../services/knowledge-base/helpers/corpusOutstanding.mjs';
 import {createBoundedRetryGate}   from '../../../services/shared/boundedRetryGate.mjs';
 import {buildEmbeddingProbeBlock} from '../../../services/shared/embeddingProbe.mjs';
 // The filter below and the codes it admits are one contract. Importing the pattern from the module
@@ -397,6 +404,47 @@ function classifyIngestionOutcome(summary) {
     }
 
     return {outcome: 'complete', summary, deferredCodes: []}
+}
+
+/**
+ * @summary Builds one repo's corpus-outstanding observation from the run's own ingestion summary.
+ *
+ * ## Why the mapping is not one-to-one with the summary's field names
+ *
+ * The summary carries primitives, not the derived pair: `ingested` (chunks accepted into the run),
+ * `skippedOversized` (guardrail rejections that will never embed), and `embeddingsGenerated` (chunks
+ * that actually landed). The progress projection derives `totalChunks` / `embeddedChunks` from those,
+ * but that projection is a KB-server-process surface and cannot answer for this lane — so the mapping
+ * happens here, from the primitives, once.
+ *
+ * `skippedOversized` appears on BOTH sides — inside the total and as the skip — so it cancels, and the
+ * remainder is exactly "accepted minus embedded". Passing it explicitly rather than pre-subtracting it
+ * keeps the intent legible: an oversized chunk is declined work, not outstanding work, and a backlog
+ * that silently counted it could never reach zero.
+ *
+ * @param {Object}      options
+ * @param {Object}      options.summary   Ingestion summary returned by the run.
+ * @param {Object|null} options.priorState Previously persisted per-repo state, for the movement stamp.
+ * @param {Number}      options.observedAt Epoch ms for this observation.
+ * @param {Number}      [options.stuckThresholdMs] Age past which a non-decreasing backlog reads `stuck`.
+ * @returns {Object} The `describeCorpusOutstanding` observation.
+ */
+function buildCorpusOutstandingObservation({summary, priorState, observedAt, stuckThresholdMs}) {
+    const
+        accepted = summary?.ingested,
+        skipped  = summary?.skippedOversized ?? 0,
+        embedded = summary?.embeddingsGenerated,
+        // Number.isFinite guards rather than `?? 0`: a summary missing these fields is UNMEASURED, and
+        // defaulting it to zero would publish "nothing outstanding" for a run nobody observed — the
+        // empty-is-not-success defect this observable exists to close.
+        total    = Number.isFinite(accepted) && Number.isFinite(skipped) ? accepted + skipped : undefined;
+
+    return describeCorpusOutstanding({
+        outstanding: deriveOutstanding({total, embedded, skipped}),
+        observedAt,
+        previous   : priorState?.corpusOutstanding ?? null,
+        stuckThresholdMs
+    })
 }
 
 /**
@@ -1983,6 +2031,18 @@ class TenantRepoSyncService extends Base {
                         ?? priorState?.lastSourceErrorCode
                         ?? null;
 
+                    // The deferred branch is the one an operator stares at on a starved provider, and
+                    // until now it published a held checkpoint with no sense of scale: `count: 0` for
+                    // hours reads identically whether 40k chunks are outstanding or none are. The
+                    // observation is derived from this run's own totals and carries the prior movement
+                    // stamp forward, so a backlog that is shrinking is distinguishable from one that is
+                    // stuck at the same depth sweep after sweep.
+                    const deferredOutstanding = buildCorpusOutstandingObservation({
+                        summary   : rawSummary,
+                        priorState,
+                        observedAt: startedMs
+                    });
+
                     persistedRevisions[repoLabel] = {
                         ...priorState,
                         lastIngestedRev                   : priorState?.lastIngestedRev ?? null,
@@ -1991,6 +2051,7 @@ class TenantRepoSyncService extends Base {
                         lastAttemptedIngestContractVersion: TENANT_REPO_INGEST_CONTRACT_VERSION,
                         lastSourceErrorCode               : deferredCauseCode,
                         lastErrorAt                       : startedMs,
+                        corpusOutstanding                 : deferredOutstanding,
                         // Recovery eligibility, on the SAME episode a failure would advance. A
                         // consumed generation folds into `lastConsumedGenerationId/At` and a newly
                         // healthy canary generation is required before another bypass, so a
@@ -2029,7 +2090,8 @@ class TenantRepoSyncService extends Base {
                             persistedRepoState: persistedRevisions[repoLabel],
                             probeSnapshot     : this.getEmbeddingRecoveryProbeSnapshot(),
                             observedAt        : startedMs
-                        })
+                        }),
+                        corpusOutstanding  : deferredOutstanding
                     });
 
                     healthService?.recordTaskOutcome?.(taskName, 'deferred', {
@@ -2044,6 +2106,12 @@ class TenantRepoSyncService extends Base {
                 }
 
                 const ingestResult = ingestOutcome.summary;
+
+                const completedOutstanding = buildCorpusOutstandingObservation({
+                    summary   : ingestResult,
+                    priorState,
+                    observedAt: startedMs
+                });
 
                 const materializationReceipt = assertFullMaterializationEffect(
                     envelope,
@@ -2072,7 +2140,13 @@ class TenantRepoSyncService extends Base {
                     lastErrorCode      : null,
                     lastSourceErrorCode: null,
                     lastAccessCode     : null,
-                    lastErrorAt        : null
+                    lastErrorAt        : null,
+                    // Written on the success path too, and this is the negative control rather than
+                    // bookkeeping: a completed run must report zero outstanding, so a genuinely finished
+                    // corpus is distinguishable from one whose delta was never computed. Omitting it here
+                    // would leave `corpusOutstanding` absent on exactly the state that proves the
+                    // observable can reach zero, and an absent field reads as unknown.
+                    corpusOutstanding  : completedOutstanding
                 };
 
                 const durationMs = Date.now() - startedMs;
@@ -2089,7 +2163,8 @@ class TenantRepoSyncService extends Base {
                     lastSyncAt          : new Date().toISOString(),
                     status              : 'active',
                     checkpointStatus    : TenantRepoCheckpointStatus.COMPLETE,
-                    lastSyncDeletedCount: deleted
+                    lastSyncDeletedCount: deleted,
+                    corpusOutstanding   : completedOutstanding
                 });
                 completedCount++;
                 healthService?.recordTaskOutcome?.(taskName, 'completed', {

--- a/ai/daemons/orchestrator/services/tenantRepoCheckpointValidity.mjs
+++ b/ai/daemons/orchestrator/services/tenantRepoCheckpointValidity.mjs
@@ -11,6 +11,11 @@
  * @see https://github.com/neomjs/neo/issues/16045
  */
 
+// The state vocabulary is imported from the PRODUCER rather than re-declared. A reader holding its own
+// copy of a closed set is one rename away from silently accepting a state the writer no longer emits,
+// or rejecting one it does — the drift this normalizer exists to catch.
+import {OUTSTANDING_STATE} from '../../../services/knowledge-base/helpers/corpusOutstanding.mjs';
+
 /**
  * @summary Current success contract for tenant-repo ingestion checkpoints.
  *
@@ -164,9 +169,18 @@ function normalizeCorpusOutstanding(value) {
     }
 
     const
+        {state}     = value,
         observable  = value.observable === true,
         outstanding = normalizeNonNegativeNumber(value.outstanding),
         observedAt  = normalizeNonNegativeNumber(value.observedAt);
+
+    // CLOSED vocabulary. An arbitrary string was previously admitted, which let a hand-edited or
+    // partially-migrated record name a state no writer emits and still project as authoritative.
+    if (state !== OUTSTANDING_STATE.complete
+        && state !== OUTSTANDING_STATE.outstanding
+        && state !== OUTSTANDING_STATE.unobservable) {
+        return null;
+    }
 
     // An observation claiming to be observable must carry both the count and the moment it was taken;
     // one without the other cannot support either the number or its staleness, so it degrades whole.
@@ -174,12 +188,22 @@ function normalizeCorpusOutstanding(value) {
         return null;
     }
 
-    if (typeof value.state !== 'string' || !value.state) {
+    // COHERENCE, not merely presence. Each state admits exactly one tuple, so a record whose fields
+    // contradict each other degrades WHOLE rather than being published field-by-field. The dangerous
+    // specimen is `{state:'complete', observable:true, outstanding:42}`: every field is individually
+    // well-typed, and together they assert a finished corpus with 42 chunks left. Repairing that to a
+    // count would invent an observation; rejecting it is the only honest reading.
+    const coherent = state === OUTSTANDING_STATE.unobservable
+        ? (!observable && !Number.isFinite(outstanding))
+        : (observable && Number.isFinite(outstanding)
+            && (state === OUTSTANDING_STATE.complete ? outstanding === 0 : outstanding > 0));
+
+    if (!coherent) {
         return null;
     }
 
     return {
-        state          : value.state,
+        state,
         observable,
         outstanding    : observable ? outstanding : null,
         lastDecreasedAt: normalizeNonNegativeNumber(value.lastDecreasedAt) || null,

--- a/ai/daemons/orchestrator/services/tenantRepoCheckpointValidity.mjs
+++ b/ai/daemons/orchestrator/services/tenantRepoCheckpointValidity.mjs
@@ -168,11 +168,17 @@ function normalizeCorpusOutstanding(value) {
         return null;
     }
 
+    // RAW reads, deliberately NOT `normalizeNonNegativeNumber` — that helper collapses
+    // null/undefined/negative to `0`, which destroys the exact distinction this field exists to carry.
+    // Built on it, the coherence check below could neither DETECT a missing count (a torn
+    // `{state:'complete', observable:true}` laundered to `complete/0` — a finished corpus asserted from
+    // an absent number) nor RECOGNISE a legitimate `outstanding: null`, so every valid `unobservable`
+    // the producer emits was rejected and could never round-trip. One helper, both residuals.
     const
         {state}     = value,
         observable  = value.observable === true,
-        outstanding = normalizeNonNegativeNumber(value.outstanding),
-        observedAt  = normalizeNonNegativeNumber(value.observedAt);
+        outstanding = Number.isFinite(value.outstanding) && value.outstanding >= 0 ? value.outstanding : null,
+        observedAt  = Number.isFinite(value.observedAt)  && value.observedAt  >  0 ? value.observedAt  : null;
 
     // CLOSED vocabulary. An arbitrary string was previously admitted, which let a hand-edited or
     // partially-migrated record name a state no writer emits and still project as authoritative.
@@ -184,7 +190,7 @@ function normalizeCorpusOutstanding(value) {
 
     // An observation claiming to be observable must carry both the count and the moment it was taken;
     // one without the other cannot support either the number or its staleness, so it degrades whole.
-    if (observable && !(Number.isFinite(outstanding) && observedAt > 0)) {
+    if (observable && !(outstanding !== null && observedAt !== null)) {
         return null;
     }
 
@@ -194,8 +200,8 @@ function normalizeCorpusOutstanding(value) {
     // well-typed, and together they assert a finished corpus with 42 chunks left. Repairing that to a
     // count would invent an observation; rejecting it is the only honest reading.
     const coherent = state === OUTSTANDING_STATE.unobservable
-        ? (!observable && !Number.isFinite(outstanding))
-        : (observable && Number.isFinite(outstanding)
+        ? (!observable && outstanding === null)
+        : (observable && outstanding !== null
             && (state === OUTSTANDING_STATE.complete ? outstanding === 0 : outstanding > 0));
 
     if (!coherent) {
@@ -206,8 +212,8 @@ function normalizeCorpusOutstanding(value) {
         state,
         observable,
         outstanding    : observable ? outstanding : null,
-        lastDecreasedAt: normalizeNonNegativeNumber(value.lastDecreasedAt) || null,
-        observedAt     : observedAt || null
+        lastDecreasedAt: Number.isFinite(value.lastDecreasedAt) && value.lastDecreasedAt > 0 ? value.lastDecreasedAt : null,
+        observedAt
     };
 }
 

--- a/ai/daemons/orchestrator/services/tenantRepoCheckpointValidity.mjs
+++ b/ai/daemons/orchestrator/services/tenantRepoCheckpointValidity.mjs
@@ -102,7 +102,10 @@ export function normalizeTenantRepoCheckpointState(value) {
             lastSourceErrorCode: null,
             lastAccessCode     : null,
             lastErrorAt        : null,
-            embeddingRecovery  : null
+            embeddingRecovery  : null,
+            // A bare SHA also predates the outstanding-work observable. Null means "never measured",
+            // which is the honest reading — not a corpus with nothing left to do.
+            corpusOutstanding  : null
         };
     }
 
@@ -135,7 +138,52 @@ export function normalizeTenantRepoCheckpointState(value) {
         lastSourceErrorCode: normalizeBoundedErrorCode(value.lastSourceErrorCode),
         lastAccessCode     : normalizeBoundedErrorCode(value.lastAccessCode),
         lastErrorAt        : normalizeNonNegativeNumber(value.lastErrorAt) || null,
-        embeddingRecovery  : normalizeEmbeddingRecovery(value.embeddingRecovery)
+        embeddingRecovery  : normalizeEmbeddingRecovery(value.embeddingRecovery),
+        corpusOutstanding  : normalizeCorpusOutstanding(value.corpusOutstanding)
+    };
+}
+
+/**
+ * @summary Normalizes one persisted corpus-outstanding observation without manufacturing one.
+ *
+ * The whole value of this field is the distinction between "N chunks still to embed", "nothing left",
+ * and "nobody measured". A normalizer that repaired a torn record into a zero would erase the third
+ * case at the exact layer meant to protect it — a hand-edited or half-written record would read as a
+ * finished corpus. So a record that does not carry a coherent observation degrades to `null`
+ * (unmeasured), never to a count.
+ *
+ * An unobservable observation is legitimate and passes through with null counts: that is the producer
+ * honestly reporting its own blindness, which only the producer has standing to do.
+ *
+ * @param {*} value Candidate persisted observation.
+ * @returns {Object|null}
+ */
+function normalizeCorpusOutstanding(value) {
+    if (!value || typeof value !== 'object' || Array.isArray(value)) {
+        return null;
+    }
+
+    const
+        observable  = value.observable === true,
+        outstanding = normalizeNonNegativeNumber(value.outstanding),
+        observedAt  = normalizeNonNegativeNumber(value.observedAt);
+
+    // An observation claiming to be observable must carry both the count and the moment it was taken;
+    // one without the other cannot support either the number or its staleness, so it degrades whole.
+    if (observable && !(Number.isFinite(outstanding) && observedAt > 0)) {
+        return null;
+    }
+
+    if (typeof value.state !== 'string' || !value.state) {
+        return null;
+    }
+
+    return {
+        state          : value.state,
+        observable,
+        outstanding    : observable ? outstanding : null,
+        lastDecreasedAt: normalizeNonNegativeNumber(value.lastDecreasedAt) || null,
+        observedAt     : observedAt || null
     };
 }
 

--- a/ai/services/knowledge-base/helpers/corpusOutstanding.mjs
+++ b/ai/services/knowledge-base/helpers/corpusOutstanding.mjs
@@ -1,7 +1,8 @@
 /**
  * @module ai/services/knowledge-base/helpers/corpusOutstanding
  * @summary Pure decision for the corpus-outstanding observable — how many chunks of a corpus are known
- * but not yet embedded, and whether that backlog is converging or stuck. The number this answers with
+ * but not yet embedded, plus the movement stamp a consumer needs to judge whether that backlog is moving.
+ * It reports a state, never a trend. The number this answers with
  * already exists inside every ingest run (`VectorService` derives `chunksToProcess` from the parsed corpus
  * against the ids present in Chroma, and the lease-yield path logs the remainder) and is then discarded
  * when the run returns. THIS is the placement-independent decision; persisting the observation and putting
@@ -32,16 +33,30 @@
  */
 
 /**
- * States a corpus-outstanding observation can carry.
+ * The CLOSED state vocabulary a corpus-outstanding observation may carry.
  *
- * `converging` and `stuck` both mean "there is a backlog"; they differ only in whether it has moved, which
- * is the question an operator staring at `count: 0` actually has.
+ * Deliberately three states, and deliberately NOT a motion claim. An earlier revision carried
+ * `converging` / `stuck`, discriminated by an age threshold — but no production caller could supply a
+ * semantically owned threshold, so `stuck` was unreachable and `converging` degraded to "positive count,
+ * forever": a claim about movement made by something that never observed movement.
+ *
+ * `outstanding` is therefore neutral. Whether a backlog is converging or stalled is the CONSUMER's
+ * question, answerable from `lastDecreasedAt` against `observedAt` — the honest companions, which do
+ * carry motion. A producer that cannot see cadence must not name a trend.
+ *
+ * Each state has exactly one coherent tuple, enforced at both trust boundaries:
+ *
+ * | state          | outstanding | observable |
+ * |----------------|-------------|------------|
+ * | `complete`     | `0`         | `true`     |
+ * | `outstanding`  | `> 0`       | `true`     |
+ * | `unobservable` | `null`      | `false`    |
+ *
  * @type {Object}
  */
 export const OUTSTANDING_STATE = Object.freeze({
     complete    : 'complete',
-    converging  : 'converging',
-    stuck       : 'stuck',
+    outstanding : 'outstanding',
     unobservable: 'unobservable'
 });
 
@@ -73,45 +88,49 @@ export function deriveOutstanding({total, embedded, skipped = 0} = {}) {
         return null;
     }
 
-    // Clamped at zero rather than allowed negative: a caller that over-reports `embedded` (a retry counted
-    // twice, say) would otherwise produce a negative backlog, which reads as nonsense on a surface and would
-    // sort below `complete` in any comparison. Clamping degrades toward "nothing outstanding", which is the
-    // claim the numbers are closest to supporting.
-    return Math.max(0, total - embedded - skipped);
+    // INCOHERENT INPUTS ARE UNMEASURABLE, NOT COMPLETE. An earlier revision clamped this with
+    // `Math.max(0, …)` and justified it as "degrading toward the claim the numbers are closest to
+    // supporting". That was wrong, and it built the exact defect this module exists to prevent: a run
+    // reporting more embedded-plus-skipped than it ever accepted is a run whose numbers disagree with
+    // themselves, and `0` would publish that as a FINISHED corpus. There is no reading of contradictory
+    // arithmetic that supports "nothing left to do" — only "this cannot be trusted".
+    if (embedded + skipped > total) {
+        return null;
+    }
+
+    return total - embedded - skipped;
 }
 
 /**
- * @summary Composes the durable corpus-outstanding observation, carrying forward when the backlog last moved.
+* @summary Composes the durable corpus-outstanding observation, carrying forward when the backlog last moved.
  *
  * The staleness companion is deliberately "when did the outstanding set last DECREASE" rather than "when was
  * this last observed". Observation is cheap and frequent; movement is the signal. A backlog re-observed every
- * minute at the same depth for six hours is stuck, and a `lastObservedAt` that advances every minute would
- * describe it as fresh.
+ * minute at the same depth for six hours has not moved, and a `lastObservedAt` that advances every minute
+ * would describe it as fresh.
+ *
+ * **This function names a state, never a trend.** `lastDecreasedAt` and `observedAt` are published so a
+ * consumer that knows the lane's cadence can decide whether a backlog is converging or stalled. Deciding
+ * that here would require a threshold no producer on this path can own.
  *
  * @param {Object}      options
- * @param {Number|null} options.outstanding    Current outstanding count (from `deriveOutstanding`).
- * @param {Number}      options.observedAt     Epoch ms for this observation — passed in, never read from a
+ * @param {Number|null} options.outstanding Current outstanding count (from `deriveOutstanding`).
+ * @param {Number}      options.observedAt  Epoch ms for this observation — passed in, never read from a
  *     clock here, so the decision stays pure and testable.
- * @param {Object|null} [options.previous]     The previously persisted observation, if any.
- * @param {Number}      [options.stuckThresholdMs] How long a non-decreasing backlog may sit before it is
- *     called `stuck`. Omitted → a backlog is `converging` regardless of age.
+ * @param {Object|null} [options.previous]  The previously persisted observation, if any.
  * @returns {{state: String, outstanding: Number|null, observable: Boolean, lastDecreasedAt: Number|null,
- *     observedAt: Number, stuckThresholdMs: Number|null}}
+ *     observedAt: Number|null}}
  */
-export function describeCorpusOutstanding({outstanding, observedAt, previous = null, stuckThresholdMs} = {}) {
-    const hasThreshold = Number.isFinite(stuckThresholdMs) && stuckThresholdMs > 0,
-          threshold    = hasThreshold ? stuckThresholdMs : null;
-
+export function describeCorpusOutstanding({outstanding, observedAt, previous = null} = {}) {
     if (!Number.isFinite(observedAt)) {
         // Without a timestamp there is no movement axis at all, so the observation cannot be composed even
         // if the count itself is sound. Reported as unobservable rather than dated with a substitute clock.
         return {
-            state           : OUTSTANDING_STATE.unobservable,
-            outstanding     : null,
-            observable      : false,
-            lastDecreasedAt : null,
-            observedAt      : null,
-            stuckThresholdMs: threshold
+            state          : OUTSTANDING_STATE.unobservable,
+            outstanding    : null,
+            observable     : false,
+            lastDecreasedAt: null,
+            observedAt     : null
         };
     }
 
@@ -121,10 +140,9 @@ export function describeCorpusOutstanding({outstanding, observedAt, previous = n
             outstanding: null,
             observable : false,
             // The previous movement stamp survives an unobservable reading. Losing it would let a single
-            // failed measurement reset a six-hour-stuck backlog's clock to "just moved".
-            lastDecreasedAt : Number.isFinite(previous?.lastDecreasedAt) ? previous.lastDecreasedAt : null,
-            observedAt,
-            stuckThresholdMs: threshold
+            // failed measurement reset a six-hour-stalled backlog's clock to "just moved".
+            lastDecreasedAt: Number.isFinite(previous?.lastDecreasedAt) ? previous.lastDecreasedAt : null,
+            observedAt
         };
     }
 
@@ -134,15 +152,11 @@ export function describeCorpusOutstanding({outstanding, observedAt, previous = n
               ? observedAt
               : (Number.isFinite(previous?.lastDecreasedAt) ? previous.lastDecreasedAt : observedAt);
 
-    let state;
-
-    if (outstanding === 0) {
-        state = OUTSTANDING_STATE.complete;
-    } else if (threshold !== null && (observedAt - lastDecreasedAt) >= threshold) {
-        state = OUTSTANDING_STATE.stuck;
-    } else {
-        state = OUTSTANDING_STATE.converging;
-    }
-
-    return {state, outstanding, observable: true, lastDecreasedAt, observedAt, stuckThresholdMs: threshold};
+    return {
+        state     : outstanding === 0 ? OUTSTANDING_STATE.complete : OUTSTANDING_STATE.outstanding,
+        outstanding,
+        observable: true,
+        lastDecreasedAt,
+        observedAt
+    };
 }

--- a/ai/services/knowledge-base/helpers/corpusOutstanding.mjs
+++ b/ai/services/knowledge-base/helpers/corpusOutstanding.mjs
@@ -1,0 +1,148 @@
+/**
+ * @module ai/services/knowledge-base/helpers/corpusOutstanding
+ * @summary Pure decision for the corpus-outstanding observable — how many chunks of a corpus are known
+ * but not yet embedded, and whether that backlog is converging or stuck. The number this answers with
+ * already exists inside every ingest run (`VectorService` derives `chunksToProcess` from the parsed corpus
+ * against the ids present in Chroma, and the lease-yield path logs the remainder) and is then discarded
+ * when the run returns. THIS is the placement-independent decision; persisting the observation and putting
+ * it on a surface is the caller's concern.
+ *
+ * ## Why the observable exists
+ *
+ * On a starved embedding provider a corpus reports `count: 0` for hours. That is indistinguishable, at the
+ * surface, from a corpus at rest with nothing to do — and it is the difference between a deployment that is
+ * dead and one that is visibly converging. This is deliberately NOT a queue depth: `VectorService` never
+ * re-embeds a chunk already present in the corpus-scoped collection, so ingest is incremental by
+ * construction and no pending queue exists to measure. A derived outstanding count replaces the depth, and
+ * "when the outstanding set last decreased" replaces an oldest-pending age.
+ *
+ * ## Where this must NOT be consumed
+ *
+ * Not on `health.status`. `ai/mcp/server/knowledge-base/describeCollectionStats.mjs` settled that boundary
+ * for exactly this family of observation: the MCP healthcheck accepts only `healthy`, and both ingress and
+ * the orchestrator gate on `service_healthy`, so degrading a corpus that is merely behind stops a fresh
+ * plane from booting at all. This reports; it never gates.
+ *
+ * ## The unknown/zero distinction is the whole safety property
+ *
+ * An unmeasurable backlog MUST NOT render as `0`. A zero means "every known chunk is embedded"; an unknown
+ * means "nobody asked". Collapsing them recreates the empty-is-not-success defect one layer up — a caller
+ * trusting a number that actually means nothing was observed. `observable: false` carries null counts and
+ * its own state rather than a reassuring number.
+ */
+
+/**
+ * States a corpus-outstanding observation can carry.
+ *
+ * `converging` and `stuck` both mean "there is a backlog"; they differ only in whether it has moved, which
+ * is the question an operator staring at `count: 0` actually has.
+ * @type {Object}
+ */
+export const OUTSTANDING_STATE = Object.freeze({
+    complete    : 'complete',
+    converging  : 'converging',
+    stuck       : 'stuck',
+    unobservable: 'unobservable'
+});
+
+/**
+ * @summary Derives the outstanding-chunk count for a completed ingest run from the delta the run already had.
+ *
+ * Deliberately takes the run's own numbers rather than recomputing a delta: a second implementation of
+ * "which chunks are missing" can disagree with the one that did the embedding, and a backlog figure that
+ * disagrees with the embedder is worse than none. `total` is the post-delta work volume the run started with
+ * (`chunksToProcess.length`), not the corpus size.
+ *
+ * A run that yields its lease mid-way leaves a real remainder; a run that completes leaves zero, because the
+ * next sweep's delta is recomputed from scratch against Chroma.
+ *
+ * @param {Object}  options
+ * @param {Number}  options.total     Chunks this run set out to embed (the post-delta work volume).
+ * @param {Number}  options.embedded  Chunks this run durably embedded.
+ * @param {Number} [options.skipped=0] Chunks the run deliberately declined (guardrail rejections) — these are
+ *     NOT outstanding: nothing further will embed them, and counting them as backlog produces a figure that
+ *     never reaches zero.
+ * @returns {Number|null} Remaining chunks, or null when the inputs cannot support a count.
+ */
+export function deriveOutstanding({total, embedded, skipped = 0} = {}) {
+    if (!Number.isFinite(total) || !Number.isFinite(embedded) || !Number.isFinite(skipped)) {
+        return null;
+    }
+
+    if (total < 0 || embedded < 0 || skipped < 0) {
+        return null;
+    }
+
+    // Clamped at zero rather than allowed negative: a caller that over-reports `embedded` (a retry counted
+    // twice, say) would otherwise produce a negative backlog, which reads as nonsense on a surface and would
+    // sort below `complete` in any comparison. Clamping degrades toward "nothing outstanding", which is the
+    // claim the numbers are closest to supporting.
+    return Math.max(0, total - embedded - skipped);
+}
+
+/**
+ * @summary Composes the durable corpus-outstanding observation, carrying forward when the backlog last moved.
+ *
+ * The staleness companion is deliberately "when did the outstanding set last DECREASE" rather than "when was
+ * this last observed". Observation is cheap and frequent; movement is the signal. A backlog re-observed every
+ * minute at the same depth for six hours is stuck, and a `lastObservedAt` that advances every minute would
+ * describe it as fresh.
+ *
+ * @param {Object}      options
+ * @param {Number|null} options.outstanding    Current outstanding count (from `deriveOutstanding`).
+ * @param {Number}      options.observedAt     Epoch ms for this observation — passed in, never read from a
+ *     clock here, so the decision stays pure and testable.
+ * @param {Object|null} [options.previous]     The previously persisted observation, if any.
+ * @param {Number}      [options.stuckThresholdMs] How long a non-decreasing backlog may sit before it is
+ *     called `stuck`. Omitted → a backlog is `converging` regardless of age.
+ * @returns {{state: String, outstanding: Number|null, observable: Boolean, lastDecreasedAt: Number|null,
+ *     observedAt: Number, stuckThresholdMs: Number|null}}
+ */
+export function describeCorpusOutstanding({outstanding, observedAt, previous = null, stuckThresholdMs} = {}) {
+    const hasThreshold = Number.isFinite(stuckThresholdMs) && stuckThresholdMs > 0,
+          threshold    = hasThreshold ? stuckThresholdMs : null;
+
+    if (!Number.isFinite(observedAt)) {
+        // Without a timestamp there is no movement axis at all, so the observation cannot be composed even
+        // if the count itself is sound. Reported as unobservable rather than dated with a substitute clock.
+        return {
+            state           : OUTSTANDING_STATE.unobservable,
+            outstanding     : null,
+            observable      : false,
+            lastDecreasedAt : null,
+            observedAt      : null,
+            stuckThresholdMs: threshold
+        };
+    }
+
+    if (!Number.isFinite(outstanding) || outstanding < 0) {
+        return {
+            state      : OUTSTANDING_STATE.unobservable,
+            outstanding: null,
+            observable : false,
+            // The previous movement stamp survives an unobservable reading. Losing it would let a single
+            // failed measurement reset a six-hour-stuck backlog's clock to "just moved".
+            lastDecreasedAt : Number.isFinite(previous?.lastDecreasedAt) ? previous.lastDecreasedAt : null,
+            observedAt,
+            stuckThresholdMs: threshold
+        };
+    }
+
+    const previousOutstanding = Number.isFinite(previous?.outstanding) ? previous.outstanding : null,
+          decreased           = previousOutstanding === null || outstanding < previousOutstanding,
+          lastDecreasedAt     = decreased
+              ? observedAt
+              : (Number.isFinite(previous?.lastDecreasedAt) ? previous.lastDecreasedAt : observedAt);
+
+    let state;
+
+    if (outstanding === 0) {
+        state = OUTSTANDING_STATE.complete;
+    } else if (threshold !== null && (observedAt - lastDecreasedAt) >= threshold) {
+        state = OUTSTANDING_STATE.stuck;
+    } else {
+        state = OUTSTANDING_STATE.converging;
+    }
+
+    return {state, outstanding, observable: true, lastDecreasedAt, observedAt, stuckThresholdMs: threshold};
+}

--- a/test/playwright/unit/ai/daemons/orchestrator/services/DeploymentStateBridgeService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/DeploymentStateBridgeService.spec.mjs
@@ -984,6 +984,87 @@ test.describe('Neo.ai.daemons.services.DeploymentStateBridgeService', () => {
         service.destroy();
     });
 
+    test('the outstanding-work count reaches the snapshot, and an unmeasured repo does not read as finished', async () => {
+        // AC-4: the count must reach the DEPLOYMENT SNAPSHOT, which builds `repos[]` from PERSISTED
+        // state through two independent whitelists (the checkpoint normalizer, then this summarizer).
+        // A test against `runTask`'s own return would pass while the snapshot silently dropped the
+        // field — different projection, same-looking number.
+        const
+            makeService = checkpoint => createService({
+                taskStateService     : {getTaskState: () => ({running: false, lastCompletion: null})},
+                tenantRepoSyncService: {
+                    async resolveTenantReposConfig() {
+                        return {tenantRepos: [{
+                            tenantId  : 'tenant-outstanding',
+                            repoSlug  : 'private/outstanding',
+                            cloneUrl  : 'https://git.example/private/outstanding.git',
+                            cadenceMs : 60_000,
+                            configTier: 'yaml'
+                        }]};
+                    },
+                    defaultRevisionsFilePath: () => '/state/revisions.json',
+                    async readPersistedRevisions() {
+                        return {'tenant-outstanding/private/outstanding': checkpoint};
+                    },
+                    getTenantRepoAccessReadiness     : () => null,
+                    getEmbeddingRecoveryProbeSnapshot: () => null
+                },
+                tenantRepoSyncEnabledReader: () => true
+            }),
+            baseCheckpoint = {
+                lastIngestedRev : null,
+                lastRunAttemptAt: OBSERVED_AT - 1_000,
+                // Zero, deliberately: a repo deferring against a slow provider holds its streak by
+                // design. If this field were gated on `failures > 0` like the cause codes are, the
+                // backlog would be invisible in exactly the state it exists to explain.
+                consecutiveFailures               : 0,
+                ingestContractVersion             : TENANT_REPO_INGEST_CONTRACT_VERSION,
+                lastAttemptedIngestContractVersion: TENANT_REPO_INGEST_CONTRACT_VERSION
+            };
+
+        const measured = makeService({
+            ...baseCheckpoint,
+            corpusOutstanding: {
+                state          : 'converging',
+                observable     : true,
+                outstanding    : 40_000,
+                lastDecreasedAt: OBSERVED_AT - 5_000,
+                observedAt     : OBSERVED_AT - 1_000
+            }
+        });
+
+        const measuredSnapshot = await measured.collectTenantRepoSyncSnapshot({observedAt: OBSERVED_AT});
+
+        expect(measuredSnapshot.repos[0].corpusOutstanding).toEqual({
+            state          : 'converging',
+            observable     : true,
+            outstanding    : 40_000,
+            lastDecreasedAt: OBSERVED_AT - 5_000,
+            observedAt     : OBSERVED_AT - 1_000
+        });
+        expect(measuredSnapshot.repos[0].consecutiveFailures).toBe(0);
+        measured.destroy();
+
+        // A repo whose observation was never written must not present as a finished corpus. This is
+        // the same empty-is-not-success discrimination, at the outermost surface a client reads.
+        const unmeasured         = makeService({...baseCheckpoint}),
+              unmeasuredSnapshot = await unmeasured.collectTenantRepoSyncSnapshot({observedAt: OBSERVED_AT});
+
+        expect(unmeasuredSnapshot.repos[0].corpusOutstanding).toBeNull();
+        unmeasured.destroy();
+
+        // A torn record degrades WHOLE rather than being repaired into a number — a half-written or
+        // hand-edited observation must never surface as a count.
+        const torn = makeService({
+                  ...baseCheckpoint,
+                  corpusOutstanding: {state: 'converging', observable: true, outstanding: 12}
+              }),
+              tornSnapshot = await torn.collectTenantRepoSyncSnapshot({observedAt: OBSERVED_AT});
+
+        expect(tornSnapshot.repos[0].corpusOutstanding).toBeNull();
+        torn.destroy();
+    });
+
     test('collectTenantRepoSyncSnapshot projects mixed access readiness through a deep allowlist', async () => {
         const repos = [
             {

--- a/test/playwright/unit/ai/daemons/orchestrator/services/DeploymentStateBridgeService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/DeploymentStateBridgeService.spec.mjs
@@ -1025,7 +1025,7 @@ test.describe('Neo.ai.daemons.services.DeploymentStateBridgeService', () => {
         const measured = makeService({
             ...baseCheckpoint,
             corpusOutstanding: {
-                state          : 'converging',
+                state          : 'outstanding',
                 observable     : true,
                 outstanding    : 40_000,
                 lastDecreasedAt: OBSERVED_AT - 5_000,
@@ -1036,7 +1036,7 @@ test.describe('Neo.ai.daemons.services.DeploymentStateBridgeService', () => {
         const measuredSnapshot = await measured.collectTenantRepoSyncSnapshot({observedAt: OBSERVED_AT});
 
         expect(measuredSnapshot.repos[0].corpusOutstanding).toEqual({
-            state          : 'converging',
+            state          : 'outstanding',
             observable     : true,
             outstanding    : 40_000,
             lastDecreasedAt: OBSERVED_AT - 5_000,
@@ -1057,12 +1057,28 @@ test.describe('Neo.ai.daemons.services.DeploymentStateBridgeService', () => {
         // hand-edited observation must never surface as a count.
         const torn = makeService({
                   ...baseCheckpoint,
-                  corpusOutstanding: {state: 'converging', observable: true, outstanding: 12}
+                  corpusOutstanding: {state: 'outstanding', observable: true, outstanding: 12}
               }),
               tornSnapshot = await torn.collectTenantRepoSyncSnapshot({observedAt: OBSERVED_AT});
 
         expect(tornSnapshot.repos[0].corpusOutstanding).toBeNull();
         torn.destroy();
+
+        // RA-1 (@neo-gpt): every field individually well-typed, TOGETHER asserting a finished corpus
+        // with 42 chunks left. Presence-validation admits this; only coherence rejects it. Repairing it
+        // to a count would invent an observation nobody made, so it degrades WHOLE.
+        for (const incoherent of [
+            {state: 'complete',     observable: true,  outstanding: 42, observedAt: OBSERVED_AT - 1_000},
+            {state: 'outstanding',  observable: true,  outstanding: 0,  observedAt: OBSERVED_AT - 1_000},
+            {state: 'unobservable', observable: true,  outstanding: 7,  observedAt: OBSERVED_AT - 1_000},
+            {state: 'converging',   observable: true,  outstanding: 7,  observedAt: OBSERVED_AT - 1_000}
+        ]) {
+            const svc  = makeService({...baseCheckpoint, corpusOutstanding: incoherent}),
+                  snap = await svc.collectTenantRepoSyncSnapshot({observedAt: OBSERVED_AT});
+
+            expect(snap.repos[0].corpusOutstanding, `must reject ${JSON.stringify(incoherent)}`).toBeNull();
+            svc.destroy();
+        }
     });
 
     test('collectTenantRepoSyncSnapshot projects mixed access readiness through a deep allowlist', async () => {

--- a/test/playwright/unit/ai/daemons/orchestrator/services/DeploymentStateBridgeService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/DeploymentStateBridgeService.spec.mjs
@@ -1,3 +1,4 @@
+import {describeCorpusOutstanding}       from '../../../../../../../ai/services/knowledge-base/helpers/corpusOutstanding.mjs';
 import {test, expect}                    from '@playwright/test';
 import fs                                from 'fs';
 import os                                from 'os';
@@ -1079,6 +1080,45 @@ test.describe('Neo.ai.daemons.services.DeploymentStateBridgeService', () => {
             expect(snap.repos[0].corpusOutstanding, `must reject ${JSON.stringify(incoherent)}`).toBeNull();
             svc.destroy();
         }
+
+        // @neo-gpt's two named residuals at d632, both from ONE root: the shared
+        // `normalizeNonNegativeNumber` collapsed null/undefined to 0, so the coherence check above was
+        // reading laundered values and could not see either case.
+
+        // tornCompleteMissingCount — a record claiming `complete` with NO count at all. Laundered to 0,
+        // it read as coherent and published a FINISHED corpus asserted from an absent number.
+        const tornMissing = makeService({
+                  ...baseCheckpoint,
+                  corpusOutstanding: {state: 'complete', observable: true, observedAt: OBSERVED_AT - 1_000}
+              }),
+              tornMissingSnap = await tornMissing.collectTenantRepoSyncSnapshot({observedAt: OBSERVED_AT});
+
+        expect(tornMissingSnap.repos[0].corpusOutstanding).toBeNull();
+        tornMissing.destroy();
+
+        // readerOfProducerBlind — the ROUND TRIP. A valid `unobservable` straight from the producer was
+        // rejected, because `outstanding: null` laundered to 0 and `Number.isFinite(0)` is true. The
+        // reader was blind to its own writer's output, which no amount of incoherent-input testing finds.
+        const producerUnobservable = describeCorpusOutstanding({outstanding: null, observedAt: OBSERVED_AT - 1_000}),
+              roundTrip            = makeService({...baseCheckpoint, corpusOutstanding: producerUnobservable}),
+              roundTripSnap        = await roundTrip.collectTenantRepoSyncSnapshot({observedAt: OBSERVED_AT});
+
+        expect(roundTripSnap.repos[0].corpusOutstanding).toMatchObject({
+            state      : 'unobservable',
+            observable : false,
+            outstanding: null
+        });
+        roundTrip.destroy();
+
+        // …and the positive round trip, so the reader is not merely permissive.
+        const producerOutstanding = describeCorpusOutstanding({outstanding: 618, observedAt: OBSERVED_AT - 1_000}),
+              positive            = makeService({...baseCheckpoint, corpusOutstanding: producerOutstanding}),
+              positiveSnap        = await positive.collectTenantRepoSyncSnapshot({observedAt: OBSERVED_AT});
+
+        expect(positiveSnap.repos[0].corpusOutstanding).toMatchObject({
+            state: 'outstanding', observable: true, outstanding: 618
+        });
+        positive.destroy();
     });
 
     test('collectTenantRepoSyncSnapshot projects mixed access readiness through a deep allowlist', async () => {

--- a/test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncService.spec.mjs
@@ -5198,6 +5198,135 @@ test.describe('TenantRepoSyncService (#11790)', () => {
             }
         });
     });
+
+    test('a deferred repo publishes how much work is outstanding, and a completed one publishes zero', async () => {
+        // The discrimination this observable exists for. On a starved provider a repo sits `deferred`
+        // with `count: 0` for hours, and that is indistinguishable at the surface from a repo with
+        // nothing to do — the difference between a deployment that looks dead and one that is visibly
+        // converging. Driven through the real `runTask` sweep rather than the pure helper, because the
+        // helper is already covered and what is unproven here is that the number REACHES a surface.
+        const
+            taskStateService = createInMemoryTaskStateService(),
+            slug             = 'org/outstanding-observable',
+            repoLabel        = `t1/${slug}`;
+
+        let ingestCallCount = 0;
+
+        await provisionMirrorDir({tenantId: 't1', repoSlug: slug});
+
+        const options = {
+            reason           : 'periodic-sweep:60000',
+            taskStateService,
+            tenantReposConfig: {tenantRepos: [
+                {tenantId: 't1', repoSlug: slug, mirrorRoot, cloneUrl: 'https://github.com/neomjs/outstanding.git'}
+            ]},
+            gitMirror                    : makeFakeGitMirror(),
+            envelopeBuilder              : makeFakeEnvelopeBuilder(),
+            knowledgeBaseIngestionService: makeFakeIngestionService({
+                summaryFactory() {
+                    ingestCallCount++;
+
+                    // Run 1: 100 embeddable accepted, 10 DISJOINT guardrail rejections, 30 embedded
+                    // before the provider gave out -> 70 outstanding. Run 2: the corpus fully embedded.
+                    //
+                    // 110 total - 30 embedded - 10 declined = 70, which is identically 100 - 30:
+                    // `ingested` and `skippedOversized` are disjoint (the progress projection sums
+                    // them for its total), so the declined chunks cancel out instead of inflating a
+                    // backlog that could never reach zero.
+                    return ingestCallCount === 1
+                        ? {
+                            ingested           : 100,
+                            skippedOversized   : 10,
+                            embeddingsGenerated: 30,
+                            deleted            : 0,
+                            errors             : [{code: 'KB_VECTOR_EMBED_CONNECTION_REFUSED'}]
+                        }
+                        : {
+                            ingested           : 100,
+                            skippedOversized   : 10,
+                            embeddingsGenerated: 100,
+                            deleted            : 0,
+                            errors             : []
+                        }
+                }
+            }),
+            revisionsFilePath: revisionsFile,
+            globalCadenceMs  : 0,
+            jitterRatio      : 0,
+            backoffCapMs     : 7_200_000,
+            seedBootstrap    : false
+        };
+
+        const deferredRun   = await TenantRepoSyncService.runTask(options),
+              deferredState = (await fs.readJson(revisionsFile)).revisions[repoLabel];
+
+        expect(deferredRun.status).toBe('deferred');
+
+        expect(deferredState.corpusOutstanding.outstanding).toBe(70);
+        expect(deferredState.corpusOutstanding.observable).toBe(true);
+        expect(deferredState.corpusOutstanding.state).toBe('converging');
+
+        const deferredProjection = deferredRun.details.repos.find(row => row.repoSlug === slug);
+
+        expect(deferredProjection.status).toBe('deferred');
+        expect(deferredProjection.corpusOutstanding.outstanding).toBe(70);
+
+        // NEGATIVE CONTROL: a completed run must reach zero. Without this, "outstanding" could be a
+        // number that only ever grows, and a genuinely finished corpus would be indistinguishable
+        // from one still working.
+        const completedRun   = await TenantRepoSyncService.runTask(options),
+              completedState = (await fs.readJson(revisionsFile)).revisions[repoLabel];
+
+        expect(completedRun.status).toBe('completed');
+        expect(completedState.corpusOutstanding.outstanding).toBe(0);
+        expect(completedState.corpusOutstanding.state).toBe('complete');
+
+        const completedProjection = completedRun.details.repos.find(row => row.repoSlug === slug);
+
+        expect(completedProjection.corpusOutstanding.outstanding).toBe(0);
+    });
+
+    test('a summary that never reported embeddings publishes UNKNOWN, never a reassuring zero', async () => {
+        // The empty-is-not-success guard, at the surface rather than in the helper. A run whose
+        // summary omits `embeddingsGenerated` was not measured; publishing `0` there would claim a
+        // finished corpus on the strength of a missing field, which is the exact defect this ticket
+        // family exists to close — and it would be indistinguishable from the completed case above.
+        const
+            taskStateService = createInMemoryTaskStateService(),
+            slug             = 'org/unmeasured-outstanding',
+            repoLabel        = `t1/${slug}`;
+
+        await provisionMirrorDir({tenantId: 't1', repoSlug: slug});
+
+        const run = await TenantRepoSyncService.runTask({
+            reason           : 'periodic-sweep:60000',
+            taskStateService,
+            tenantReposConfig: {tenantRepos: [
+                {tenantId: 't1', repoSlug: slug, mirrorRoot, cloneUrl: 'https://github.com/neomjs/unmeasured.git'}
+            ]},
+            gitMirror      : makeFakeGitMirror(),
+            envelopeBuilder: makeFakeEnvelopeBuilder(),
+            // No `embeddingsGenerated` — the shape every pre-existing fixture in this file uses.
+            knowledgeBaseIngestionService: makeFakeIngestionService({
+                summaryFactory: () => ({ingested: 5, deleted: 0, errors: [{code: 'KB_VECTOR_EMBED_CONNECTION_REFUSED'}]})
+            }),
+            revisionsFilePath: revisionsFile,
+            globalCadenceMs  : 0,
+            jitterRatio      : 0,
+            backoffCapMs     : 7_200_000,
+            seedBootstrap    : false
+        });
+
+        const state = (await fs.readJson(revisionsFile)).revisions[repoLabel];
+
+        expect(run.status).toBe('deferred');
+        expect(state.corpusOutstanding.observable).toBe(false);
+        expect(state.corpusOutstanding.outstanding).toBeNull();
+        expect(state.corpusOutstanding.state).toBe('unobservable');
+        // The discrimination stated as a comparison, so a future change that collapses unknown into
+        // zero fails here rather than passing quietly on a plausible-looking number.
+        expect(state.corpusOutstanding.outstanding).not.toBe(0);
+    });
 });
 
 test.describe('the persisted cause DISCRIMINATES, and still leaks nothing (#16056)', () => {

--- a/test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncService.spec.mjs
@@ -5264,7 +5264,7 @@ test.describe('TenantRepoSyncService (#11790)', () => {
 
         expect(deferredState.corpusOutstanding.outstanding).toBe(70);
         expect(deferredState.corpusOutstanding.observable).toBe(true);
-        expect(deferredState.corpusOutstanding.state).toBe('converging');
+        expect(deferredState.corpusOutstanding.state).toBe('outstanding');
 
         const deferredProjection = deferredRun.details.repos.find(row => row.repoSlug === slug);
 

--- a/test/playwright/unit/ai/services/knowledge-base/helpers/corpusOutstanding.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/helpers/corpusOutstanding.spec.mjs
@@ -1,0 +1,171 @@
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../../../../src/Neo.mjs';
+import * as core      from '../../../../../../../src/core/_export.mjs';
+import {
+    OUTSTANDING_STATE,
+    deriveOutstanding,
+    describeCorpusOutstanding
+} from '../../../../../../../ai/services/knowledge-base/helpers/corpusOutstanding.mjs';
+
+/**
+ * Corpus-outstanding observable coverage.
+ *
+ * The property under test is a discrimination, not a number: `count: 0` at rest must be distinguishable from
+ * `count: 0` with a backlog, and BOTH must be distinguishable from `count: 0` that was never measured. The
+ * third case is the one that recreates the original defect if it collapses into the first.
+ */
+
+test.describe('deriveOutstanding — the run leaves a real remainder', () => {
+    test('a completed run leaves nothing outstanding', () => {
+        expect(deriveOutstanding({total: 868, embedded: 868})).toBe(0);
+    });
+
+    test('a lease-yielded run leaves exactly what it did not reach', () => {
+        // The specimen from the live plane: 18 batches of 50, yielded after 5.
+        expect(deriveOutstanding({total: 868, embedded: 250})).toBe(618);
+    });
+
+    test('deliberately skipped chunks are NOT outstanding', () => {
+        // Guardrail rejections will never embed. Counting them as backlog produces a figure that can never
+        // reach zero, so `complete` would become unreachable for any corpus carrying one oversized chunk.
+        expect(deriveOutstanding({total: 100, embedded: 90, skipped: 10})).toBe(0);
+
+        // …and the skip must subtract exactly once. Asserted at a NON-ZERO remainder because the zero case
+        // above passes identically against a stub that ignores its inputs and returns 0 — which a mutation
+        // run proved: `return 0` survived four of the five cases in this block.
+        expect(deriveOutstanding({total: 100, embedded: 60, skipped: 10})).toBe(30);
+    });
+
+    test('ARITHMETIC PIN: the remainder tracks each input independently', () => {
+        // Every case here has a distinct non-zero expectation, so no constant-returning implementation and
+        // no single-input implementation can satisfy the set.
+        expect(deriveOutstanding({total: 868, embedded: 0}))              .toBe(868);
+        expect(deriveOutstanding({total: 868, embedded: 50}))             .toBe(818);
+        expect(deriveOutstanding({total: 868, embedded: 0,  skipped: 8})) .toBe(860);
+        expect(deriveOutstanding({total: 500, embedded: 100, skipped: 25})).toBe(375);
+        expect(deriveOutstanding({total: 1,   embedded: 0}))              .toBe(1);
+    });
+
+    test('over-reported progress clamps to zero rather than going negative', () => {
+        expect(deriveOutstanding({total: 10, embedded: 12})).toBe(0);
+    });
+
+    test('unusable inputs return null, never a reassuring zero', () => {
+        expect(deriveOutstanding({total: NaN, embedded: 0})).toBeNull();
+        expect(deriveOutstanding({total: 10, embedded: undefined})).toBeNull();
+        expect(deriveOutstanding({total: -1, embedded: 0})).toBeNull();
+        expect(deriveOutstanding({})).toBeNull();
+    });
+});
+
+test.describe('describeCorpusOutstanding — empty-at-rest vs empty-mid-progress vs never-measured', () => {
+    test('zero outstanding is complete', () => {
+        const result = describeCorpusOutstanding({outstanding: 0, observedAt: 1_000});
+
+        expect(result.state).toBe(OUTSTANDING_STATE.complete);
+        expect(result.observable).toBe(true);
+        expect(result.outstanding).toBe(0);
+    });
+
+    test('a backlog with no prior observation is converging, not stuck', () => {
+        const result = describeCorpusOutstanding({outstanding: 618, observedAt: 1_000, stuckThresholdMs: 500});
+
+        expect(result.state).toBe(OUTSTANDING_STATE.converging);
+        expect(result.lastDecreasedAt).toBe(1_000);
+    });
+
+    test('THE DISCRIMINATION: an unmeasurable backlog is not a complete corpus', () => {
+        const unknown  = describeCorpusOutstanding({outstanding: null, observedAt: 1_000}),
+              complete = describeCorpusOutstanding({outstanding: 0,    observedAt: 1_000});
+
+        expect(unknown.state).toBe(OUTSTANDING_STATE.unobservable);
+        expect(unknown.observable).toBe(false);
+        expect(unknown.outstanding).toBeNull();
+
+        // The two must not be confusable on any field a caller would branch on.
+        expect(unknown.state).not.toBe(complete.state);
+        expect(unknown.outstanding).not.toBe(complete.outstanding);
+        expect(unknown.observable).not.toBe(complete.observable);
+    });
+
+    test('a shrinking backlog stamps the movement and stays converging', () => {
+        const previous = describeCorpusOutstanding({outstanding: 618, observedAt: 1_000, stuckThresholdMs: 500}),
+              next     = describeCorpusOutstanding({
+                  outstanding: 300, observedAt: 9_000, previous, stuckThresholdMs: 500
+              });
+
+        expect(next.state).toBe(OUTSTANDING_STATE.converging);
+        expect(next.lastDecreasedAt).toBe(9_000); // it moved, so the clock restarts
+    });
+
+    test('a backlog that has not moved past the threshold is stuck', () => {
+        const previous = describeCorpusOutstanding({outstanding: 618, observedAt: 1_000, stuckThresholdMs: 500}),
+              next     = describeCorpusOutstanding({
+                  outstanding: 618, observedAt: 2_000, previous, stuckThresholdMs: 500
+              });
+
+        expect(next.state).toBe(OUTSTANDING_STATE.stuck);
+        expect(next.lastDecreasedAt).toBe(1_000); // the ORIGINAL stamp, not the re-observation
+    });
+
+    test('re-observing a stuck backlog does not refresh its movement stamp', () => {
+        // The reason the companion measures DECREASE and not observation: a stuck backlog polled every
+        // minute for six hours would otherwise report as freshly-moved on every single poll.
+        let state = describeCorpusOutstanding({outstanding: 618, observedAt: 1_000, stuckThresholdMs: 500});
+
+        for (const observedAt of [2_000, 3_000, 4_000, 5_000]) {
+            state = describeCorpusOutstanding({outstanding: 618, observedAt, previous: state, stuckThresholdMs: 500});
+        }
+
+        expect(state.state).toBe(OUTSTANDING_STATE.stuck);
+        expect(state.lastDecreasedAt).toBe(1_000);
+        expect(state.observedAt).toBe(5_000);
+    });
+
+    test('a growing backlog is not a decrease', () => {
+        const previous = describeCorpusOutstanding({outstanding: 100, observedAt: 1_000, stuckThresholdMs: 500}),
+              next     = describeCorpusOutstanding({
+                  outstanding: 400, observedAt: 2_000, previous, stuckThresholdMs: 500
+              });
+
+        expect(next.lastDecreasedAt).toBe(1_000);
+        expect(next.state).toBe(OUTSTANDING_STATE.stuck);
+    });
+
+    test('a failed measurement preserves the prior movement stamp', () => {
+        // Otherwise one unreadable poll resets a long-stuck backlog's clock, and the next successful read
+        // reports it as recently-moved.
+        const previous = describeCorpusOutstanding({outstanding: 618, observedAt: 1_000, stuckThresholdMs: 500}),
+              failed   = describeCorpusOutstanding({outstanding: null, observedAt: 2_000, previous});
+
+        expect(failed.state).toBe(OUTSTANDING_STATE.unobservable);
+        expect(failed.lastDecreasedAt).toBe(1_000);
+    });
+
+    test('without a threshold a backlog never claims to be stuck', () => {
+        const previous = describeCorpusOutstanding({outstanding: 618, observedAt: 1_000}),
+              next     = describeCorpusOutstanding({outstanding: 618, observedAt: 9_999_000, previous});
+
+        expect(next.state).toBe(OUTSTANDING_STATE.converging);
+        expect(next.stuckThresholdMs).toBeNull();
+    });
+
+    test('a missing observedAt is unobservable rather than dated with a substitute clock', () => {
+        const result = describeCorpusOutstanding({outstanding: 618});
+
+        expect(result.state).toBe(OUTSTANDING_STATE.unobservable);
+        expect(result.observedAt).toBeNull();
+    });
+
+    test('NON-VACUITY CONTROL: the composed shape carries every field a surface branches on', () => {
+        // Guards against a stub that returns a plausible-looking object with fields absent — which would let
+        // every assertion above pass against a decision that reports nothing.
+        const result = describeCorpusOutstanding({outstanding: 42, observedAt: 7_000, stuckThresholdMs: 500});
+
+        for (const key of ['state', 'outstanding', 'observable', 'lastDecreasedAt', 'observedAt', 'stuckThresholdMs']) {
+            expect(result).toHaveProperty(key);
+        }
+        expect(result.outstanding).toBe(42);
+        expect(result.stuckThresholdMs).toBe(500);
+    });
+});

--- a/test/playwright/unit/ai/services/knowledge-base/helpers/corpusOutstanding.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/helpers/corpusOutstanding.spec.mjs
@@ -46,8 +46,17 @@ test.describe('deriveOutstanding — the run leaves a real remainder', () => {
         expect(deriveOutstanding({total: 1,   embedded: 0}))              .toBe(1);
     });
 
-    test('over-reported progress clamps to zero rather than going negative', () => {
-        expect(deriveOutstanding({total: 10, embedded: 12})).toBe(0);
+    test('THE RA-1 SPECIMEN: contradictory arithmetic is UNMEASURABLE, never complete', () => {
+        // This spec previously asserted the defect. It expected `0` and called it "clamping toward the
+        // claim the numbers are closest to supporting" — publishing a FINISHED corpus for a run whose
+        // own numbers disagree with themselves. There is no reading of `embedded + skipped > total`
+        // that supports "nothing left to do"; the only honest answer is "this cannot be trusted".
+        expect(deriveOutstanding({total: 10, embedded: 12})).toBeNull();
+        expect(deriveOutstanding({total: 10, embedded: 5, skipped: 8})).toBeNull();
+        expect(deriveOutstanding({total: 0,  embedded: 1})).toBeNull();
+
+        // The boundary itself stays measurable — exact exhaustion is a real, coherent zero.
+        expect(deriveOutstanding({total: 10, embedded: 6, skipped: 4})).toBe(0);
     });
 
     test('unusable inputs return null, never a reassuring zero', () => {
@@ -67,10 +76,10 @@ test.describe('describeCorpusOutstanding — empty-at-rest vs empty-mid-progress
         expect(result.outstanding).toBe(0);
     });
 
-    test('a backlog with no prior observation is converging, not stuck', () => {
-        const result = describeCorpusOutstanding({outstanding: 618, observedAt: 1_000, stuckThresholdMs: 500});
+    test('a backlog with no prior observation reports outstanding and stamps its first observation', () => {
+        const result = describeCorpusOutstanding({outstanding: 618, observedAt: 1_000});
 
-        expect(result.state).toBe(OUTSTANDING_STATE.converging);
+        expect(result.state).toBe(OUTSTANDING_STATE.outstanding);
         expect(result.lastDecreasedAt).toBe(1_000);
     });
 
@@ -88,66 +97,70 @@ test.describe('describeCorpusOutstanding — empty-at-rest vs empty-mid-progress
         expect(unknown.observable).not.toBe(complete.observable);
     });
 
-    test('a shrinking backlog stamps the movement and stays converging', () => {
-        const previous = describeCorpusOutstanding({outstanding: 618, observedAt: 1_000, stuckThresholdMs: 500}),
+    test('a shrinking backlog stamps the movement and stays outstanding', () => {
+        const previous = describeCorpusOutstanding({outstanding: 618, observedAt: 1_000}),
               next     = describeCorpusOutstanding({
-                  outstanding: 300, observedAt: 9_000, previous, stuckThresholdMs: 500
+                  outstanding: 300, observedAt: 9_000, previous
               });
 
-        expect(next.state).toBe(OUTSTANDING_STATE.converging);
+        expect(next.state).toBe(OUTSTANDING_STATE.outstanding);
         expect(next.lastDecreasedAt).toBe(9_000); // it moved, so the clock restarts
     });
 
-    test('a backlog that has not moved past the threshold is stuck', () => {
-        const previous = describeCorpusOutstanding({outstanding: 618, observedAt: 1_000, stuckThresholdMs: 500}),
+    test('a non-decreasing backlog keeps its ORIGINAL movement stamp', () => {
+        const previous = describeCorpusOutstanding({outstanding: 618, observedAt: 1_000}),
               next     = describeCorpusOutstanding({
-                  outstanding: 618, observedAt: 2_000, previous, stuckThresholdMs: 500
+                  outstanding: 618, observedAt: 2_000, previous
               });
 
-        expect(next.state).toBe(OUTSTANDING_STATE.stuck);
+        expect(next.state).toBe(OUTSTANDING_STATE.outstanding);
         expect(next.lastDecreasedAt).toBe(1_000); // the ORIGINAL stamp, not the re-observation
     });
 
-    test('re-observing a stuck backlog does not refresh its movement stamp', () => {
+    test('re-observing an unmoved backlog does not refresh its movement stamp', () => {
         // The reason the companion measures DECREASE and not observation: a stuck backlog polled every
         // minute for six hours would otherwise report as freshly-moved on every single poll.
-        let state = describeCorpusOutstanding({outstanding: 618, observedAt: 1_000, stuckThresholdMs: 500});
+        let state = describeCorpusOutstanding({outstanding: 618, observedAt: 1_000});
 
         for (const observedAt of [2_000, 3_000, 4_000, 5_000]) {
-            state = describeCorpusOutstanding({outstanding: 618, observedAt, previous: state, stuckThresholdMs: 500});
+            state = describeCorpusOutstanding({outstanding: 618, observedAt, previous: state});
         }
 
-        expect(state.state).toBe(OUTSTANDING_STATE.stuck);
+        expect(state.state).toBe(OUTSTANDING_STATE.outstanding);
         expect(state.lastDecreasedAt).toBe(1_000);
         expect(state.observedAt).toBe(5_000);
     });
 
     test('a growing backlog is not a decrease', () => {
-        const previous = describeCorpusOutstanding({outstanding: 100, observedAt: 1_000, stuckThresholdMs: 500}),
+        const previous = describeCorpusOutstanding({outstanding: 100, observedAt: 1_000}),
               next     = describeCorpusOutstanding({
-                  outstanding: 400, observedAt: 2_000, previous, stuckThresholdMs: 500
+                  outstanding: 400, observedAt: 2_000, previous
               });
 
         expect(next.lastDecreasedAt).toBe(1_000);
-        expect(next.state).toBe(OUTSTANDING_STATE.stuck);
+        expect(next.state).toBe(OUTSTANDING_STATE.outstanding);
     });
 
     test('a failed measurement preserves the prior movement stamp', () => {
         // Otherwise one unreadable poll resets a long-stuck backlog's clock, and the next successful read
         // reports it as recently-moved.
-        const previous = describeCorpusOutstanding({outstanding: 618, observedAt: 1_000, stuckThresholdMs: 500}),
+        const previous = describeCorpusOutstanding({outstanding: 618, observedAt: 1_000}),
               failed   = describeCorpusOutstanding({outstanding: null, observedAt: 2_000, previous});
 
         expect(failed.state).toBe(OUTSTANDING_STATE.unobservable);
         expect(failed.lastDecreasedAt).toBe(1_000);
     });
 
-    test('without a threshold a backlog never claims to be stuck', () => {
+    test('RA-2: a long-unmoved backlog still reports the NEUTRAL state — the producer never claims a trend', () => {
         const previous = describeCorpusOutstanding({outstanding: 618, observedAt: 1_000}),
               next     = describeCorpusOutstanding({outstanding: 618, observedAt: 9_999_000, previous});
 
-        expect(next.state).toBe(OUTSTANDING_STATE.converging);
-        expect(next.stuckThresholdMs).toBeNull();
+        // RA-2 (@neo-gpt): a 618 backlog observed nearly three hours later still reports the NEUTRAL
+        // state — the producer makes no motion claim. The honest companion is that `lastDecreasedAt`
+        // stayed at 1_000 while `observedAt` moved to 9_999_000, so a consumer that knows this lane's
+        // cadence can compute the stall itself. That is the distinction the old `converging` erased.
+        expect(next.lastDecreasedAt).toBe(1_000);
+        expect(next.observedAt).toBe(9_999_000);
     });
 
     test('a missing observedAt is unobservable rather than dated with a substitute clock', () => {
@@ -160,12 +173,12 @@ test.describe('describeCorpusOutstanding — empty-at-rest vs empty-mid-progress
     test('NON-VACUITY CONTROL: the composed shape carries every field a surface branches on', () => {
         // Guards against a stub that returns a plausible-looking object with fields absent — which would let
         // every assertion above pass against a decision that reports nothing.
-        const result = describeCorpusOutstanding({outstanding: 42, observedAt: 7_000, stuckThresholdMs: 500});
+        const result = describeCorpusOutstanding({outstanding: 42, observedAt: 7_000});
 
-        for (const key of ['state', 'outstanding', 'observable', 'lastDecreasedAt', 'observedAt', 'stuckThresholdMs']) {
+        for (const key of ['state', 'outstanding', 'observable', 'lastDecreasedAt', 'observedAt']) {
             expect(result).toHaveProperty(key);
         }
         expect(result.outstanding).toBe(42);
-        expect(result.stuckThresholdMs).toBe(500);
+        expect(result.state).toBe(OUTSTANDING_STATE.outstanding);
     });
 });


### PR DESCRIPTION
Resolves #16690

A tenant repo deferring against a slow embedding provider reported a held checkpoint and nothing about scale, so `count: 0` for hours was indistinguishable from a repo with nothing left to do. Each sync run now derives an outstanding-chunk count from its **own** ingestion summary, persists it beside `consecutiveFailures`, and publishes it on the deployment snapshot's per-repo projection — the difference between a deployment that looks dead and one that is visibly converging.

Evidence: L2 (pure decision helpers, the real `runTask` sweep, the durable per-repo record, and the snapshot projection — all exercisable in-process) → L2 required (every restated AC is an in-process derivation or a durable record). Residual: none blocking; one post-merge observation listed below.

## Deltas from ticket

Two, both recorded on the ticket body before this PR.

- **The reporting surface named in the original AC was wrong, and I falsified it before building on it.** The AC said *"the KB surface reports…"*. `IngestionService.mjs:36-48` declares `INGESTION_PROGRESS_OBSERVED_SCOPE = 'this-process-only'` and states that pull-mode tenant-repo ingestion runs in the **orchestrator** process. The measured failure *is* that lane, so the KB server's progress and health surfaces can never answer for it — a declared scope boundary, not a gap. Building there would have shipped a number accurately computed about the wrong process, which reads as coverage. AC-6 is now an explicit scope control: nothing is added to `get_ingestion_progress` or `healthcheck`, and their `this-process-only` disclosure stays honest.
- **No durable store, for the second time on this ticket.** The original prescription wanted a WAL; implementation falsified that. Once the surface moved, the *implicit* second store — somewhere to keep the count — dissolved too: the per-repo tenant-sync record is already durable. Wrong placement had been inflating the build.

## Two whitelists sat between the record and the snapshot

The count is persisted by `TenantRepoSyncService`, but the deployment snapshot builds `repos[]` from **persisted** state, not from `runTask`'s return — through two independent field whitelists. Both were widened, and this is the part a test against `runTask`'s own `details.repos` would have missed while looking green:

- `normalizeTenantRepoCheckpointState` — a **torn observation degrades whole**, never repaired into a count. A half-written record that normalized to `0` would erase the unknown/zero distinction at the exact layer meant to protect it.
- `summarizeTenantRepoState` — published **ungated on `consecutiveFailures`**, unlike the cause codes beside it. A deferring repo holds its streak at zero by design, so gating would hide the backlog in precisely the state it exists to explain.

## Why the arithmetic is what it is

The summary carries primitives, not the derived pair: `ingested`, `skippedOversized`, `embeddingsGenerated`. `ingested` and `skippedOversized` are **disjoint** (the progress projection sums them for its total), so passing the skip explicitly makes it cancel, and the remainder is exactly *accepted minus embedded*. Pre-subtracting would have hidden the intent; counting the skip as backlog would have produced a figure that could never reach zero for any corpus carrying one oversized chunk.

The staleness companion measures when the backlog last **decreased**, not when it was last observed — a stuck backlog polled every minute would otherwise report as freshly-moved on every poll.

## Unknown never renders as zero

At every layer, and asserted as a comparison rather than a value so a future collapse fails loudly: an unmeasured summary, an absent record, and a torn record all report `null` with `observable: false`. A corpus nobody measured must not read as a corpus with nothing left to do — the same empty-is-not-success defect this ticket family exists to close.

## Test Evidence

- `ai/services/knowledge-base/helpers/corpusOutstanding.mjs`, `ai/daemons/orchestrator/services/{TenantRepoSyncService,DeploymentStateBridgeService,tenantRepoCheckpointValidity}.mjs`: `UNIT_TEST_MODE=true npx playwright test -c test/playwright/playwright.config.unit.mjs test/playwright/unit/ai/daemons/orchestrator/ test/playwright/unit/ai/services/knowledge-base/helpers/` — **1307 passed** at the rebased head. Tallied with an anchored `grep -E '^\s*[0-9]+ (passed|failed)'` rather than `tail`, because a `N failed` line above a cut is how a truncated sweep reads as green.
- **Mutation-proved, every claim, reverted after each:**
  - `embeddingsGenerated ?? 0` (unmeasured becomes a number) → the unknown-never-zero spec reds.
  - drop the field from the run projection → the deferred/completed spec reds.
  - drop it from the snapshot summarizer → the snapshot spec reds.
  - `deriveOutstanding` returning a constant `0` → 3 red **after** an arithmetic pin was added; only 1 red before, because four of five cases expected zero. That first run is a finding about the **spec**, not a pass for the source, and the pin is why it stays honest.
- **A test caught my own arithmetic:** I expected 60 outstanding and the code produced 70. The code was right — 110 total − 30 embedded − 10 declined is identically 100 − 30. The expectation was corrected, not the implementation.

## Post-Merge Validation

- [ ] On the next external-plane sweep, confirm a starved repo publishes a non-zero `corpusOutstanding.outstanding` with `state: converging`, and that the value falls across consecutive sweeps as the provider drains. This makes a starved provider **legible**, not fast — the corpus only grows once embedding capacity is addressed, which is a deployment-side item and no ticket here closes it.

🖖 Authored by Grace (Claude Opus 5, Claude Code). Session 51a81224-c5d4-4b3f-b0ed-764af44d572f.
