### PR TITLE
refactor(fleet): split workspace plan from host apply (#16715)

### DIFF
--- a/ai/services/fleet/managedAgentWorkspacePlan.mjs
+++ b/ai/services/fleet/managedAgentWorkspacePlan.mjs
@@ -1,0 +1,400 @@
+import path from 'node:path';
+import {
+    MCP_SERVERS,
+    REMOTE_MCP_CREDENTIAL_ENV_VAR,
+    supportsTenantMcpTarget
+} from './mcpServers.mjs';
+import {LAUNCHABLE_HARNESS_TYPES} from './deriveHarnessLaunchSpec.mjs';
+
+const NEO_MCP_NAME_PREFIX = 'neo-mjs-';
+
+/**
+ * @summary Curated, installed-checkout-relative MCP execution vocabulary. The Body-safe catalog remains the
+ * durable key/default authority; this pure sibling adds no host binding, environment read, command,
+ * or credential value. The host apply edge consumes the relative entrypoint only after validating a
+ * logical plan produced here.
+ * @type {Readonly<Object<String, Object>>}
+ */
+export const MANAGED_WORKSPACE_MCP_SERVER_DESCRIPTORS = Object.freeze({
+    'memory-core': Object.freeze({
+        entrypoint: 'ai/mcp/server/memory-core/mcp-server.mjs',
+        runtimeEnv: Object.freeze([
+            'NEO_AGENT_IDENTITY',
+            'NEO_CHROMA_EMBEDDING_PROVIDER',
+            'NEO_CHROMA_UNIFIED',
+            'NEO_EMBEDDING_PROVIDER',
+            'NEO_MEM_AUTO_START_DATABASE',
+            'NEO_MEM_AUTO_START_INFERENCE',
+            'NEO_MODEL_PROVIDER',
+            'NEO_OPENAI_COMPATIBLE_API_KEY',
+            'NEO_OPENAI_COMPATIBLE_EMBEDDING_MODEL',
+            'NEO_OPENAI_COMPATIBLE_HOST',
+            'NEO_OPENAI_COMPATIBLE_MODEL'
+        ]),
+        requiredRuntimeEnv: Object.freeze(['NEO_AGENT_IDENTITY'])
+    }),
+    'knowledge-base': Object.freeze({
+        entrypoint: 'ai/mcp/server/knowledge-base/mcp-server.mjs',
+        runtimeEnv: Object.freeze([
+            'NEO_AGENT_IDENTITY',
+            'NEO_CHROMA_EMBEDDING_PROVIDER',
+            'NEO_CHROMA_UNIFIED',
+            'NEO_EMBEDDING_PROVIDER',
+            'NEO_KB_ASK_API_KEY',
+            'NEO_KB_AUTO_START_DATABASE',
+            'NEO_OPENAI_COMPATIBLE_API_KEY',
+            'NEO_OPENAI_COMPATIBLE_EMBEDDING_MODEL',
+            'NEO_OPENAI_COMPATIBLE_HOST',
+            'NEO_OPENAI_COMPATIBLE_MODEL'
+        ]),
+        requiredRuntimeEnv: Object.freeze(['NEO_AGENT_IDENTITY'])
+    }),
+    'neural-link': Object.freeze({
+        entrypoint: 'ai/mcp/server/neural-link/mcp-server.mjs',
+        runtimeEnv: Object.freeze([
+            'NEO_AGENT_IDENTITY',
+            'NEO_FLEET_BRIDGE_TOKEN',
+            'NEO_NL_TOOL_PROJECTION_MODE'
+        ]),
+        requiredRuntimeEnv: Object.freeze([
+            'NEO_AGENT_IDENTITY',
+            'NEO_NL_TOOL_PROJECTION_MODE'
+        ]),
+        secretEnv: Object.freeze(['NEO_FLEET_BRIDGE_TOKEN'])
+    }),
+    'github-workflow': Object.freeze({
+        entrypoint        : 'ai/mcp/server/github-workflow/mcp-server.mjs',
+        runtimeEnv        : Object.freeze(['GH_TOKEN', 'GITHUB_TOKEN', 'NEO_AGENT_IDENTITY']),
+        requiredRuntimeEnv: Object.freeze(['GH_TOKEN', 'NEO_AGENT_IDENTITY']),
+        secretEnv         : Object.freeze(['GH_TOKEN'])
+    }),
+    'gitlab-workflow': Object.freeze({
+        entrypoint        : 'ai/mcp/server/gitlab-workflow/mcp-server.mjs',
+        runtimeEnv        : Object.freeze(['NEO_AGENT_IDENTITY', 'NEO_GITLAB_HOST', 'NEO_GITLAB_PAT', 'NEO_GITLAB_PROJECT']),
+        requiredRuntimeEnv: Object.freeze(['NEO_AGENT_IDENTITY', 'NEO_GITLAB_PAT']),
+        secretEnv         : Object.freeze(['NEO_GITLAB_PAT']),
+        unsupportedReason : 'FleetLifecycleService has no GitLab credential injection contract'
+    })
+});
+
+{
+    const catalogKeys = new Set(MCP_SERVERS.map(entry => entry.key));
+
+    for (const key of catalogKeys) {
+        if (!MANAGED_WORKSPACE_MCP_SERVER_DESCRIPTORS[key]) {
+            throw new Error(`managedAgentWorkspacePlan: MCP catalog key '${key}' has no executable descriptor.`)
+        }
+    }
+    for (const key of Object.keys(MANAGED_WORKSPACE_MCP_SERVER_DESCRIPTORS)) {
+        if (!catalogKeys.has(key)) {
+            throw new Error(`managedAgentWorkspacePlan: executable descriptor '${key}' is absent from the shared MCP catalog.`)
+        }
+    }
+}
+
+/**
+ * @typedef {Object} ManagedAgentWorkspacePlanInput
+ * @property {{id: String, harnessType: String}} agent Closed opaque seat + harness intent.
+ * @property {Object<String, Boolean>} mcpMatrix Complete canonical MCP enablement matrix.
+ * @property {Object|null} [mcpTarget=null] Closed non-secret tenant resource intent.
+ */
+
+/**
+ * @typedef {Object} ManagedAgentWorkspaceMcpPlan
+ * @property {String} key Canonical MCP catalog key.
+ * @property {String} name Curated harness-facing server name.
+ * @property {Boolean} enabled Whether the server is enabled for this seat.
+ * @property {'resident'|'tenant'} target Resource ownership intent.
+ * @property {'stdio'|'streamable-http'} transport Curated transport intent.
+ * @property {String|null} entrypoint Repository-relative curated entrypoint.
+ * @property {String|null} url Public remote resource URL.
+ * @property {String|null} credentialEnvVar Credential slot name, never its value.
+ * @property {String[]} runtimeEnv Child-runtime environment slot names.
+ * @property {String[]} requiredRuntimeEnv Required child-runtime environment slot names.
+ * @property {String[]} secretEnv Secret-bearing child-runtime environment slot names.
+ */
+
+/**
+ * @typedef {Object} ManagedAgentWorkspacePlan
+ * @property {{id: String, harnessType: String}} agent Closed opaque seat + harness intent.
+ * @property {String} artifactProfile Curated harness artifact profile.
+ * @property {Object<String, Boolean>} mcpMatrix Complete canonical MCP enablement matrix.
+ * @property {ManagedAgentWorkspaceMcpPlan[]} mcpServers Closed logical MCP plan.
+ */
+
+const
+    LOGICAL_INPUT_KEYS       = Object.freeze(['agent', 'mcpMatrix', 'mcpTarget']),
+    LOGICAL_AGENT_KEYS       = Object.freeze(['id', 'harnessType']),
+    MCP_TARGET_KEYS          = Object.freeze(['kind', 'credentialEnvVar', 'resources']),
+    MCP_TARGET_RESOURCE_KEYS = Object.freeze(['memory-core', 'knowledge-base']),
+    MCP_RESOURCE_KEYS        = Object.freeze(['url']),
+    FORBIDDEN_LOGICAL_FIELDS = new Set([
+        'args',
+        'auth',
+        'authorization',
+        'bearer',
+        'command',
+        'credential',
+        'cwd',
+        'grant',
+        'grants',
+        'instanceRoot',
+        'mainCheckout',
+        'nodePath',
+        'owner',
+        'ownerPrincipal',
+        'repoPath',
+        'secret',
+        'token'
+    ].map(key => key.toLowerCase()));
+
+/**
+ * @summary Create the deterministic, host-path-free workspace intent consumed by the Fleet host
+ * apply edge. Input and output are closed schemas: this module imports no filesystem, environment,
+ * process, or global configuration and the function emits no owner/grant, command, absolute path,
+ * or credential value. Every returned array and object is recursively frozen.
+ * @param {ManagedAgentWorkspacePlanInput} [input]
+ * @returns {ManagedAgentWorkspacePlan}
+ * @throws {TypeError} For missing, unknown, malformed, accessor, forbidden, or absolute-path input.
+ * @throws {RangeError} For unsupported harness, MCP, or transport combinations.
+ */
+export function createManagedAgentWorkspacePlan(input={}) {
+    assertSafeLogicalTree(input, 'input');
+    assertExactRecord(input, 'input', LOGICAL_INPUT_KEYS, ['agent', 'mcpMatrix']);
+
+    const
+        agent      = normalizeLogicalAgent(input.agent),
+        mcpMatrix  = normalizeLogicalMcpMatrix(input.mcpMatrix),
+        mcpTarget  = normalizeLogicalMcpTarget(Object.hasOwn(input, 'mcpTarget') ? input.mcpTarget : null),
+        mcpServers = MCP_SERVERS.map(entry => {
+            const
+                descriptor = MANAGED_WORKSPACE_MCP_SERVER_DESCRIPTORS[entry.key],
+                resource   = mcpTarget?.resources[entry.key];
+
+            return {
+                key               : entry.key,
+                name              : `${NEO_MCP_NAME_PREFIX}${entry.key}`,
+                enabled           : mcpMatrix[entry.key],
+                target            : resource ? 'tenant' : 'resident',
+                transport         : resource ? 'streamable-http' : 'stdio',
+                entrypoint        : descriptor.entrypoint ?? null,
+                url               : resource?.url ?? null,
+                credentialEnvVar  : resource ? mcpTarget.credentialEnvVar : null,
+                runtimeEnv        : [...descriptor.runtimeEnv],
+                requiredRuntimeEnv: [...descriptor.requiredRuntimeEnv],
+                secretEnv         : [...(descriptor.secretEnv || [])]
+            }
+        });
+
+    assertLogicalHarnessSupported({agent, mcpServers});
+
+    return freezeRecursively({
+        agent,
+        artifactProfile: agent.harnessType,
+        mcpMatrix,
+        mcpServers
+    })
+}
+
+/** @private */
+function normalizeLogicalAgent(agent) {
+    assertExactRecord(agent, 'agent', LOGICAL_AGENT_KEYS);
+    assertLogicalString(agent.id, 'agent.id');
+    assertLogicalString(agent.harnessType, 'agent.harnessType');
+
+    return {id: agent.id, harnessType: agent.harnessType}
+}
+
+/** @private */
+function normalizeLogicalMcpMatrix(matrix) {
+    const keys = MCP_SERVERS.map(entry => entry.key);
+
+    assertExactRecord(matrix, 'mcpMatrix', keys);
+
+    const result = {};
+    for (const key of keys) {
+        if (typeof matrix[key] !== 'boolean') {
+            throw new TypeError(`createManagedAgentWorkspacePlan: 'mcpMatrix.${key}' must be boolean.`)
+        }
+        result[key] = matrix[key]
+    }
+
+    return result
+}
+
+/** @private */
+function normalizeLogicalMcpTarget(target) {
+    if (target === null) return null;
+
+    assertExactRecord(target, 'mcpTarget', MCP_TARGET_KEYS);
+    if (target.kind !== 'tenant') {
+        throw new TypeError("createManagedAgentWorkspacePlan: 'mcpTarget.kind' must be 'tenant'.")
+    }
+    if (target.credentialEnvVar !== REMOTE_MCP_CREDENTIAL_ENV_VAR) {
+        throw new TypeError(`createManagedAgentWorkspacePlan: 'mcpTarget.credentialEnvVar' must name '${REMOTE_MCP_CREDENTIAL_ENV_VAR}'.`)
+    }
+    assertExactRecord(target.resources, 'mcpTarget.resources', MCP_TARGET_RESOURCE_KEYS);
+
+    const
+        suffixes = {
+            'memory-core'   : '/mc/mcp',
+            'knowledge-base': '/kb/mcp'
+        },
+        resources = {};
+    let deploymentBase = null;
+
+    for (const key of MCP_TARGET_RESOURCE_KEYS) {
+        const resource = target.resources[key];
+        let   url;
+
+        assertExactRecord(resource, `mcpTarget.resources.${key}`, MCP_RESOURCE_KEYS);
+        assertLogicalString(resource.url, `mcpTarget.resources.${key}.url`);
+
+        try {
+            url = new URL(resource.url)
+        } catch {
+            throw new TypeError(`createManagedAgentWorkspacePlan: remote MCP resource '${key}' has a malformed URL.`)
+        }
+
+        const suffix = suffixes[key];
+        if (!['http:', 'https:'].includes(url.protocol) ||
+            url.username ||
+            url.password ||
+            url.search ||
+            url.hash ||
+            !url.pathname.endsWith(suffix)) {
+            throw new TypeError(`createManagedAgentWorkspacePlan: remote MCP resource '${key}' has a malformed URL.`)
+        }
+
+        const candidateBase = `${url.origin}${url.pathname.slice(0, -suffix.length)}`;
+        if (deploymentBase !== null && deploymentBase !== candidateBase) {
+            throw new TypeError('createManagedAgentWorkspacePlan: remote MCP resources must share one canonical deployment base.')
+        }
+
+        deploymentBase = candidateBase;
+        resources[key] = {url: resource.url}
+    }
+
+    return {
+        kind            : 'tenant',
+        credentialEnvVar: target.credentialEnvVar,
+        resources
+    }
+}
+
+/** @private */
+function assertLogicalHarnessSupported({agent, mcpServers}) {
+    if (!LAUNCHABLE_HARNESS_TYPES.includes(agent.harnessType)) {
+        throw new RangeError(`createManagedAgentWorkspacePlan: harness '${agent.harnessType}' has no launch/workspace adapter.`)
+    }
+
+    if (mcpServers.some(server => server.target === 'tenant') &&
+        !supportsTenantMcpTarget(agent.harnessType)) {
+        throw new RangeError(`createManagedAgentWorkspacePlan: harness '${agent.harnessType}' has no proven secret-safe tenant MCP grammar.`)
+    }
+
+    const catalogUnsupported = mcpServers.find(server =>
+        server.enabled && MANAGED_WORKSPACE_MCP_SERVER_DESCRIPTORS[server.key].unsupportedReason);
+    if (catalogUnsupported) {
+        throw new RangeError(
+            `createManagedAgentWorkspacePlan: MCP server '${catalogUnsupported.key}' is enabled but unsupported: ` +
+            MANAGED_WORKSPACE_MCP_SERVER_DESCRIPTORS[catalogUnsupported.key].unsupportedReason
+        )
+    }
+
+    if (agent.harnessType === 'antigravity') {
+        throw new RangeError('createManagedAgentWorkspacePlan: Antigravity 2.x exposes no proven contained per-resident MCP configuration root.')
+    }
+
+    if (agent.harnessType === 'claude-desktop') {
+        const secretServer = mcpServers.find(server => server.enabled &&
+            server.requiredRuntimeEnv.some(name => server.secretEnv.includes(name)));
+        if (secretServer) {
+            throw new RangeError(
+                `createManagedAgentWorkspacePlan: Claude Desktop cannot represent startup-required Fleet secret env for enabled MCP server '${secretServer.key}' without persisting secret bytes.`
+            )
+        }
+    }
+}
+
+/** @private */
+function assertSafeLogicalTree(value, label, ancestors=new WeakSet()) {
+    if (typeof value === 'string') {
+        if (isPortableAbsolutePath(value)) {
+            throw new TypeError(`createManagedAgentWorkspacePlan: '${label}' must not contain an absolute host path.`)
+        }
+        return
+    }
+
+    if (value === null || value === undefined || typeof value !== 'object') return;
+
+    const prototype = Object.getPrototypeOf(value);
+    if (!Array.isArray(value) && prototype !== Object.prototype && prototype !== null) {
+        throw new TypeError(`createManagedAgentWorkspacePlan: '${label}' must contain plain data only.`)
+    }
+    if (Object.getOwnPropertySymbols(value).length) {
+        throw new TypeError(`createManagedAgentWorkspacePlan: '${label}' must not contain symbol fields.`)
+    }
+    if (ancestors.has(value)) {
+        throw new TypeError(`createManagedAgentWorkspacePlan: '${label}' must not contain a reference cycle.`)
+    }
+
+    ancestors.add(value);
+
+    try {
+        for (const key of Object.keys(value)) {
+            const descriptor = Object.getOwnPropertyDescriptor(value, key);
+
+            if (!descriptor || descriptor.get || descriptor.set) {
+                throw new TypeError(`createManagedAgentWorkspacePlan: '${label}.${key}' must be a data field, not an accessor.`)
+            }
+            if (FORBIDDEN_LOGICAL_FIELDS.has(key.toLowerCase())) {
+                throw new TypeError(`createManagedAgentWorkspacePlan: forbidden logical field '${key}'.`)
+            }
+
+            assertSafeLogicalTree(descriptor.value, `${label}.${key}`, ancestors)
+        }
+    } finally {
+        ancestors.delete(value)
+    }
+}
+
+/** @private */
+function assertExactRecord(value, label, allowedKeys, requiredKeys=allowedKeys) {
+    if (!value || typeof value !== 'object' || Array.isArray(value)) {
+        throw new TypeError(`createManagedAgentWorkspacePlan: '${label}' must be an object.`)
+    }
+
+    const
+        unknown = Object.keys(value).find(key => !allowedKeys.includes(key)),
+        missing = requiredKeys.find(key => !Object.hasOwn(value, key));
+
+    if (unknown) {
+        throw new TypeError(`createManagedAgentWorkspacePlan: unknown field '${label}.${unknown}'.`)
+    }
+    if (missing) {
+        throw new TypeError(`createManagedAgentWorkspacePlan: missing field '${label}.${missing}'.`)
+    }
+}
+
+/** @private */
+function assertLogicalString(value, label) {
+    if (typeof value !== 'string' || value.length === 0) {
+        throw new TypeError(`createManagedAgentWorkspacePlan: '${label}' must be a non-empty string.`)
+    }
+}
+
+/** @private */
+function isPortableAbsolutePath(value) {
+    return path.isAbsolute(value) || /^[A-Za-z]:[\\/]/.test(value) || /^\\\\/.test(value)
+}
+
+/** @private */
+function freezeRecursively(value) {
+    if (!value || typeof value !== 'object' || Object.isFrozen(value)) return value;
+
+    Object.values(value).forEach(freezeRecursively);
+    return Object.freeze(value)
+}
+
+export default createManagedAgentWorkspacePlan;

--- a/ai/services/fleet/prepareManagedAgentWorkspace.mjs
+++ b/ai/services/fleet/prepareManagedAgentWorkspace.mjs
@@ -115,7 +115,15 @@ const
         'token'
     ].map(key => key.toLowerCase()));
 
-/** @private */
+/**
+ * @summary Prove that one closed logical plan is internally coherent by re-deriving its canonical
+ * projection from the plan's own agent, MCP-matrix, and tenant-resource inputs. This is a coherence
+ * gate, not a provenance gate: it does not prove that a registry authorized those logical inputs.
+ * A future cross-process plan/apply seam must authenticate that origin independently.
+ * @param {ManagedAgentWorkspacePlan} plan Candidate logical plan.
+ * @returns {ManagedAgentWorkspacePlan} The recursively frozen canonical projection.
+ * @private
+ */
 function validateManagedAgentWorkspacePlan(plan) {
     assertSafeLogicalTree(plan, 'plan');
     assertExactRecord(plan, 'plan', LOGICAL_PLAN_KEYS);
@@ -212,8 +220,12 @@ function bindManagedAgentWorkspacePlan({logicalPlan, repoPath, mainCheckout, nod
  *
  * The sole production caller remains `startAgentProvisioned()` through the compatibility composer
  * below. Renderers and convergence helpers consume the same host-bound plan shape as before.
+ * Canonical re-derivation proves internal coherence with the plan's own logical inputs; it does not
+ * prove registry authorization or cross-process provenance. That belongs to the later authenticated
+ * plan/apply envelope rather than this host edge.
  * @param {Object} options
- * @param {ManagedAgentWorkspacePlan} options.plan Closed logical plan; structural clones accepted.
+ * @param {ManagedAgentWorkspacePlan} options.plan Closed logical plan; structural clones accepted
+ *     after schema and canonical-projection coherence validation.
  * @param {String} options.repoPath Absolute provisioned checkout path.
  * @param {String} options.instanceRoot Absolute Fleet harness-home root.
  * @param {String} [options.mainCheckout] Installed canonical checkout.

--- a/ai/services/fleet/prepareManagedAgentWorkspace.mjs
+++ b/ai/services/fleet/prepareManagedAgentWorkspace.mjs
@@ -1,19 +1,20 @@
-import {constants as fsConstants} from 'node:fs';
-import fs                         from 'node:fs/promises';
-import path                       from 'node:path';
-import crypto                     from 'node:crypto';
-import {fileURLToPath}            from 'node:url';
-import {hydrateCurrentWorktree}   from '../../scripts/migrations/bootstrapWorktree.mjs';
+import {constants as fsConstants}                  from 'node:fs';
+import fs                                          from 'node:fs/promises';
+import path                                        from 'node:path';
+import crypto                                      from 'node:crypto';
+import {fileURLToPath}                             from 'node:url';
+import {isDeepStrictEqual}                         from 'node:util';
+import {hydrateCurrentWorktree}                    from '../../scripts/migrations/bootstrapWorktree.mjs';
+import {MCP_SERVERS, resolveMcpMatrix}             from './mcpServers.mjs';
+import {deriveAgentInstanceHome}                   from './deriveAgentInstanceHome.mjs';
+import {KIMI_SEAT_SERVERS, generateKimiSeatConfig} from './generateKimiSeatConfig.mjs';
 import {
-    MCP_SERVERS,
-    REMOTE_MCP_CREDENTIAL_ENV_VAR,
-    resolveMcpMatrix,
-    supportsTenantMcpTarget
-} from './mcpServers.mjs';
-import {deriveAgentInstanceHome}                           from './deriveAgentInstanceHome.mjs';
-import {LAUNCHABLE_HARNESS_TYPES}                          from './deriveHarnessLaunchSpec.mjs';
-import {KIMI_SEAT_SERVERS, generateKimiSeatConfig}         from './generateKimiSeatConfig.mjs';
+    MANAGED_WORKSPACE_MCP_SERVER_DESCRIPTORS as MCP_SERVER_DESCRIPTORS,
+    createManagedAgentWorkspacePlan
+} from './managedAgentWorkspacePlan.mjs';
 import {OPENCODE_SEAT_SERVERS, generateOpenCodeSeatConfig} from './generateOpenCodeSeatConfig.mjs';
+
+export {createManagedAgentWorkspacePlan} from './managedAgentWorkspacePlan.mjs';
 
 const
     __filename               = fileURLToPath(import.meta.url),
@@ -36,87 +37,6 @@ export const WORKSPACE_ARTIFACT_STATES = Object.freeze({
     DIVERGENT: 'DIVERGENT'
 });
 
-// One executable descriptor per shared catalog key. The catalog remains the durable key/default
-// authority; these Node-only leaves add the installed-checkout-relative entrypoint + environment
-// transport facts the Body-safe catalog deliberately cannot carry. Import-time lockstep below turns catalog drift into a
-// loud failure rather than silently omitting a newly registered server.
-const MCP_SERVER_DESCRIPTORS = Object.freeze({
-    'memory-core': Object.freeze({
-        entrypoint: 'ai/mcp/server/memory-core/mcp-server.mjs',
-        runtimeEnv: Object.freeze([
-            'NEO_AGENT_IDENTITY',
-            'NEO_CHROMA_EMBEDDING_PROVIDER',
-            'NEO_CHROMA_UNIFIED',
-            'NEO_EMBEDDING_PROVIDER',
-            'NEO_MEM_AUTO_START_DATABASE',
-            'NEO_MEM_AUTO_START_INFERENCE',
-            'NEO_MODEL_PROVIDER',
-            'NEO_OPENAI_COMPATIBLE_API_KEY',
-            'NEO_OPENAI_COMPATIBLE_EMBEDDING_MODEL',
-            'NEO_OPENAI_COMPATIBLE_HOST',
-            'NEO_OPENAI_COMPATIBLE_MODEL'
-        ]),
-        requiredRuntimeEnv: Object.freeze(['NEO_AGENT_IDENTITY'])
-    }),
-    'knowledge-base': Object.freeze({
-        entrypoint: 'ai/mcp/server/knowledge-base/mcp-server.mjs',
-        runtimeEnv: Object.freeze([
-            'NEO_AGENT_IDENTITY',
-            'NEO_CHROMA_EMBEDDING_PROVIDER',
-            'NEO_CHROMA_UNIFIED',
-            'NEO_EMBEDDING_PROVIDER',
-            'NEO_KB_ASK_API_KEY',
-            'NEO_KB_AUTO_START_DATABASE',
-            'NEO_OPENAI_COMPATIBLE_API_KEY',
-            'NEO_OPENAI_COMPATIBLE_EMBEDDING_MODEL',
-            'NEO_OPENAI_COMPATIBLE_HOST',
-            'NEO_OPENAI_COMPATIBLE_MODEL'
-        ]),
-        requiredRuntimeEnv: Object.freeze(['NEO_AGENT_IDENTITY'])
-    }),
-    'neural-link': Object.freeze({
-        entrypoint: 'ai/mcp/server/neural-link/mcp-server.mjs',
-        runtimeEnv: Object.freeze([
-            'NEO_AGENT_IDENTITY',
-            'NEO_FLEET_BRIDGE_TOKEN',
-            'NEO_NL_TOOL_PROJECTION_MODE'
-        ]),
-        requiredRuntimeEnv: Object.freeze([
-            'NEO_AGENT_IDENTITY',
-            'NEO_NL_TOOL_PROJECTION_MODE'
-        ]),
-        secretEnv: Object.freeze(['NEO_FLEET_BRIDGE_TOKEN'])
-    }),
-    'github-workflow': Object.freeze({
-        entrypoint        : 'ai/mcp/server/github-workflow/mcp-server.mjs',
-        runtimeEnv        : Object.freeze(['GH_TOKEN', 'GITHUB_TOKEN', 'NEO_AGENT_IDENTITY']),
-        requiredRuntimeEnv: Object.freeze(['GH_TOKEN', 'NEO_AGENT_IDENTITY']),
-        secretEnv         : Object.freeze(['GH_TOKEN'])
-    }),
-    'gitlab-workflow': Object.freeze({
-        entrypoint        : 'ai/mcp/server/gitlab-workflow/mcp-server.mjs',
-        runtimeEnv        : Object.freeze(['NEO_AGENT_IDENTITY', 'NEO_GITLAB_HOST', 'NEO_GITLAB_PAT', 'NEO_GITLAB_PROJECT']),
-        requiredRuntimeEnv: Object.freeze(['NEO_AGENT_IDENTITY', 'NEO_GITLAB_PAT']),
-        secretEnv         : Object.freeze(['NEO_GITLAB_PAT']),
-        unsupportedReason : 'FleetLifecycleService has no GitLab credential injection contract'
-    })
-});
-
-{
-    const catalogKeys = new Set(MCP_SERVERS.map(entry => entry.key));
-
-    for (const key of catalogKeys) {
-        if (!MCP_SERVER_DESCRIPTORS[key]) {
-            throw new Error(`prepareManagedAgentWorkspace: MCP catalog key '${key}' has no executable descriptor.`);
-        }
-    }
-    for (const key of Object.keys(MCP_SERVER_DESCRIPTORS)) {
-        if (!catalogKeys.has(key)) {
-            throw new Error(`prepareManagedAgentWorkspace: executable descriptor '${key}' is absent from the shared MCP catalog.`);
-        }
-    }
-}
-
 /**
  * @summary Error for a fail-closed workspace preparation result. `code` is stable for callers;
  * `artifact` contains paths, owned-key names, and state only — never file contents or secret values.
@@ -131,9 +51,299 @@ export class ManagedWorkspacePreparationError extends Error {
 }
 
 /**
- * @summary Hydrate and converge one Fleet-managed checkout plus its isolated harness home before
- * process spawn. This is the missing lifecycle seam between `ensureAgentRepo` and
- * `FleetLifecycleService.start`: no install/build, no operator-dotfile reads, no secret rendering.
+ * @typedef {Object} ManagedAgentWorkspacePlanInput
+ * @property {{id: String, harnessType: String}} agent Closed opaque seat + harness intent.
+ * @property {Object<String, Boolean>} mcpMatrix Complete canonical MCP enablement matrix.
+ * @property {Object|null} [mcpTarget=null] Closed non-secret tenant resource intent.
+ */
+
+/**
+ * @typedef {Object} ManagedAgentWorkspaceMcpPlan
+ * @property {String} key Canonical MCP catalog key.
+ * @property {String} name Curated harness-facing server name.
+ * @property {Boolean} enabled Whether the server is enabled for this seat.
+ * @property {'resident'|'tenant'} target Resource ownership intent.
+ * @property {'stdio'|'streamable-http'} transport Curated transport intent.
+ * @property {String|null} entrypoint Repository-relative curated entrypoint.
+ * @property {String|null} url Public remote resource URL.
+ * @property {String|null} credentialEnvVar Credential slot name, never its value.
+ * @property {String[]} runtimeEnv Child-runtime environment slot names.
+ * @property {String[]} requiredRuntimeEnv Required child-runtime environment slot names.
+ * @property {String[]} secretEnv Secret-bearing child-runtime environment slot names.
+ */
+
+/**
+ * @typedef {Object} ManagedAgentWorkspacePlan
+ * @property {{id: String, harnessType: String}} agent Closed opaque seat + harness intent.
+ * @property {String} artifactProfile Curated harness artifact profile.
+ * @property {Object<String, Boolean>} mcpMatrix Complete canonical MCP enablement matrix.
+ * @property {ManagedAgentWorkspaceMcpPlan[]} mcpServers Closed logical MCP plan.
+ */
+
+const
+    LOGICAL_PLAN_KEYS   = Object.freeze(['agent', 'artifactProfile', 'mcpMatrix', 'mcpServers']),
+    LOGICAL_SERVER_KEYS = Object.freeze([
+        'key',
+        'name',
+        'enabled',
+        'target',
+        'transport',
+        'entrypoint',
+        'url',
+        'credentialEnvVar',
+        'runtimeEnv',
+        'requiredRuntimeEnv',
+        'secretEnv'
+    ]),
+    FORBIDDEN_LOGICAL_FIELDS = new Set([
+        'args',
+        'auth',
+        'authorization',
+        'bearer',
+        'command',
+        'credential',
+        'cwd',
+        'grant',
+        'grants',
+        'instanceRoot',
+        'mainCheckout',
+        'nodePath',
+        'owner',
+        'ownerPrincipal',
+        'repoPath',
+        'secret',
+        'token'
+    ].map(key => key.toLowerCase()));
+
+/** @private */
+function validateManagedAgentWorkspacePlan(plan) {
+    assertSafeLogicalTree(plan, 'plan');
+    assertExactRecord(plan, 'plan', LOGICAL_PLAN_KEYS);
+    assertLogicalString(plan.artifactProfile, 'plan.artifactProfile');
+
+    if (!Array.isArray(plan.mcpServers) ||
+        plan.mcpServers.length !== MCP_SERVERS.length ||
+        Object.keys(plan.mcpServers).some((key, index) => key !== String(index))) {
+        throw new TypeError('applyManagedAgentWorkspacePlan: plan.mcpServers must be a dense canonical array.')
+    }
+
+    for (const [index, server] of plan.mcpServers.entries()) {
+        const label = `plan.mcpServers[${index}]`;
+
+        assertExactRecord(server, label, LOGICAL_SERVER_KEYS);
+        assertLogicalString(server.key, `${label}.key`);
+        assertLogicalString(server.name, `${label}.name`);
+        if (typeof server.enabled !== 'boolean') {
+            throw new TypeError(`applyManagedAgentWorkspacePlan: '${label}.enabled' must be boolean.`)
+        }
+        if (!['resident', 'tenant'].includes(server.target)) {
+            throw new TypeError(`applyManagedAgentWorkspacePlan: '${label}.target' is malformed.`)
+        }
+        if (!['stdio', 'streamable-http'].includes(server.transport)) {
+            throw new TypeError(`applyManagedAgentWorkspacePlan: '${label}.transport' is malformed.`)
+        }
+        if (server.entrypoint !== null) assertLogicalString(server.entrypoint, `${label}.entrypoint`);
+        if (server.url !== null) assertLogicalString(server.url, `${label}.url`);
+        if (server.credentialEnvVar !== null) assertLogicalString(server.credentialEnvVar, `${label}.credentialEnvVar`);
+        assertLogicalStringArray(server.runtimeEnv, `${label}.runtimeEnv`);
+        assertLogicalStringArray(server.requiredRuntimeEnv, `${label}.requiredRuntimeEnv`);
+        assertLogicalStringArray(server.secretEnv, `${label}.secretEnv`)
+    }
+
+    const tenantRows = plan.mcpServers.filter(server => server.target === 'tenant');
+    let   mcpTarget  = null;
+
+    if (tenantRows.length) {
+        const
+            memoryCore    = tenantRows.find(server => server.key === 'memory-core'),
+            knowledgeBase = tenantRows.find(server => server.key === 'knowledge-base');
+
+        if (!memoryCore || !knowledgeBase || memoryCore.credentialEnvVar !== knowledgeBase.credentialEnvVar) {
+            throw new TypeError('applyManagedAgentWorkspacePlan: tenant plan must bind both canonical resources through one credential slot.')
+        }
+
+        mcpTarget = {
+            kind            : 'tenant',
+            credentialEnvVar: memoryCore.credentialEnvVar,
+            resources       : {
+                'memory-core'   : {url: memoryCore.url},
+                'knowledge-base': {url: knowledgeBase.url}
+            }
+        }
+    }
+
+    const expected = createManagedAgentWorkspacePlan({
+        agent    : plan.agent,
+        mcpMatrix: plan.mcpMatrix,
+        mcpTarget
+    });
+
+    if (!isDeepStrictEqual(plan, expected)) {
+        throw new TypeError('applyManagedAgentWorkspacePlan: plan does not match the canonical logical projection.')
+    }
+
+    return expected
+}
+
+/** @private */
+function bindManagedAgentWorkspacePlan({logicalPlan, repoPath, mainCheckout, nodePath}) {
+    return logicalPlan.mcpServers.map(server => ({
+        ...server,
+        command   : nodePath,
+        sourceRoot: mainCheckout,
+        args      : [
+            path.join(mainCheckout, server.entrypoint),
+            ...(server.key === 'neural-link' ? ['--cwd', repoPath] : [])
+        ],
+        runtimeEnv        : [...server.runtimeEnv],
+        requiredRuntimeEnv: [...server.requiredRuntimeEnv],
+        secretEnv         : [...server.secretEnv],
+        unsupportedReason : MCP_SERVER_DESCRIPTORS[server.key].unsupportedReason || null
+    }))
+}
+
+/**
+ * @summary Bind and apply one validated logical workspace plan at the host-only effect edge. This
+ * function alone introduces absolute repo/home/main-checkout/Node paths, then preserves the existing
+ * bounded effect census: `stat`/`lstat`/`access`, checkout hydration, bounded reads, `mkdir`,
+ * create-only and temporary writes, atomic `rename`, `chmod(0600)`, and receipt `unlink`. It never
+ * spawns a process. Completed hydration or atomic/create-only artifacts may remain after a later
+ * failure; retry converges that honest partial state without exposing partial file bytes.
+ *
+ * The sole production caller remains `startAgentProvisioned()` through the compatibility composer
+ * below. Renderers and convergence helpers consume the same host-bound plan shape as before.
+ * @param {Object} options
+ * @param {ManagedAgentWorkspacePlan} options.plan Closed logical plan; structural clones accepted.
+ * @param {String} options.repoPath Absolute provisioned checkout path.
+ * @param {String} options.instanceRoot Absolute Fleet harness-home root.
+ * @param {String} [options.mainCheckout] Installed canonical checkout.
+ * @param {String} [options.nodePath] Node executable used for installed MCP entrypoints.
+ * @param {Object} [options.remoteMcpCapability] Existing non-secret installed-adapter proof.
+ * @param {Function} [options.hydrateWorkspace] Import-safe checkout hydration seam.
+ * @param {Function} [options.deriveInstanceHome] Per-agent home derivation seam.
+ * @param {Object} [options.fileSystem] Promise filesystem seam.
+ * @param {Function} [options.log] Hydration logger.
+ * @returns {Promise<{repoPath: String, instanceHome: String, mcpMatrix: Object, mcpPlan: Object[], hydration: Object, artifacts: Object[]}>}
+ * @throws {ManagedWorkspacePreparationError} For invalid plans/bindings, unsafe paths, unsupported
+ *     capabilities, divergent content, or effect failures.
+ */
+export async function applyManagedAgentWorkspacePlan(options={}) {
+    try {
+        return await applyManagedAgentWorkspacePlanUnchecked(options)
+    } catch (error) {
+        if (error instanceof ManagedWorkspacePreparationError) throw error;
+        if (error instanceof RangeError) throw unsupported(error.message);
+
+        const wrapped = new ManagedWorkspacePreparationError(
+            error instanceof TypeError
+                ? `prepareManagedAgentWorkspace: host apply rejected its logical plan (${error.message}).`
+                : 'prepareManagedAgentWorkspace: host apply effect failed.'
+        );
+
+        wrapped.cause = error;
+        throw wrapped
+    }
+}
+
+/** @private */
+async function applyManagedAgentWorkspacePlanUnchecked({
+    plan: inputPlan,
+    repoPath,
+    instanceRoot,
+    mainCheckout = DEFAULT_MAIN_CHECKOUT,
+    nodePath = process.execPath,
+    remoteMcpCapability = null,
+    hydrateWorkspace = hydrateCurrentWorktree,
+    deriveInstanceHome = deriveAgentInstanceHome,
+    fileSystem = fs,
+    log = () => {}
+} = {}) {
+    const logicalPlan = validateManagedAgentWorkspacePlan(inputPlan);
+
+    assertAbsolutePath(repoPath, 'repoPath');
+    assertAbsolutePath(instanceRoot, 'instanceRoot');
+    assertAbsolutePath(mainCheckout, 'mainCheckout');
+    assertAbsolutePath(nodePath, 'nodePath');
+
+    const
+        canonicalRepoPath     = path.resolve(repoPath),
+        canonicalInstanceRoot = path.resolve(instanceRoot),
+        installedRoot         = path.resolve(mainCheckout),
+        agent                 = logicalPlan.agent,
+        instanceHome          = deriveInstanceHome({
+            instanceRoot: canonicalInstanceRoot,
+            agentId     : agent.id,
+            harnessType : agent.harnessType
+        }),
+        plan = bindManagedAgentWorkspacePlan({
+            logicalPlan,
+            repoPath    : canonicalRepoPath,
+            mainCheckout: installedRoot,
+            nodePath
+        });
+
+    assertAbsolutePath(instanceHome, 'instanceHome');
+    await assertRemoteBridgeCapability({
+        agent,
+        plan,
+        capability  : remoteMcpCapability,
+        mainCheckout: installedRoot,
+        nodePath,
+        fileSystem
+    });
+    await assertNoSymlinkSegments({
+        rootPath  : canonicalInstanceRoot,
+        targetPath: instanceHome,
+        fileSystem,
+        label     : 'resident home'
+    });
+
+    const hydration = await hydrateWorkspace({
+        mainCheckout: installedRoot,
+        projectRoot : canonicalRepoPath,
+        log
+    });
+
+    await assertRealDirectory(canonicalRepoPath, 'repoPath', fileSystem);
+    await assertExecutablePlan({plan, nodePath, fileSystem});
+    await assertNoSymlinkSegments({
+        rootPath  : canonicalInstanceRoot,
+        targetPath: instanceHome,
+        fileSystem,
+        label     : 'resident home'
+    });
+
+    const artifacts = await prepareHarnessArtifacts({
+        agent,
+        repoPath    : canonicalRepoPath,
+        instanceHome,
+        mainCheckout: installedRoot,
+        plan,
+        remoteMcpCapability,
+        fileSystem
+    });
+
+    return {
+        repoPath : canonicalRepoPath,
+        instanceHome,
+        mcpMatrix: {...logicalPlan.mcpMatrix},
+        mcpPlan  : plan.map(server => ({
+            ...server,
+            args              : [...server.args],
+            runtimeEnv        : [...server.runtimeEnv],
+            requiredRuntimeEnv: [...server.requiredRuntimeEnv],
+            secretEnv         : [...server.secretEnv]
+        })),
+        hydration,
+        artifacts
+    }
+}
+
+/**
+ * @summary Compatibility composer for the existing Fleet workspace preparation surface: resolve
+ * the sparse-at-rest MCP matrix once, project the closed logical input, plan once, then apply once.
+ * It preserves the established option names, six-field return, artifact bytes, safety gates, and
+ * local/remote transition behavior while exposing the plan/apply seam for later container ownership.
  *
  * Executable MCP entrypoints deliberately resolve from the installed `mainCheckout`: fresh managed
  * clones have no dependencies, dependency installation/build is outside this composer, and sharing
@@ -166,6 +376,8 @@ export class ManagedWorkspacePreparationError extends Error {
  * @param {Function}[options.log]                 Hydration logger.
  * @returns {Promise<{repoPath: String, instanceHome: String, mcpMatrix: Object, mcpPlan: Object[], hydration: Object, artifacts: Object[]}>}
  * @throws {ManagedWorkspacePreparationError} for unsupported adapters or divergent owned content.
+ * @see createManagedAgentWorkspacePlan
+ * @see applyManagedAgentWorkspacePlan
  */
 export async function prepareManagedAgentWorkspace({
     agent,
@@ -187,211 +399,115 @@ export async function prepareManagedAgentWorkspace({
 
     assertNonEmptyString(agent.id, 'agent.id');
     assertNonEmptyString(agent.harnessType, 'agent.harnessType');
-    assertAbsolutePath(repoPath, 'repoPath');
-    assertAbsolutePath(instanceRoot, 'instanceRoot');
-    assertAbsolutePath(mainCheckout, 'mainCheckout');
-    assertAbsolutePath(nodePath, 'nodePath');
-
-    const
-        canonicalRepoPath = path.resolve(repoPath),
-        installedRoot     = path.resolve(mainCheckout),
-        mcpMatrix         = resolveMatrix(agent.mcpServers),
-        plan              = createMcpPlan({mcpMatrix, repoPath: canonicalRepoPath, mainCheckout: installedRoot, nodePath, mcpTarget}),
-        instanceHome      = deriveInstanceHome({instanceRoot, agentId: agent.id, harnessType: agent.harnessType});
-
-    // Hardest/unsupported adapter gate runs before hydration or artifact writes. A failed product
-    // authority proof cannot leave a checkout looking partially resident-ready.
-    assertHarnessSupported({agent, plan});
-    await assertRemoteBridgeCapability({
-        agent,
-        plan,
-        capability  : remoteMcpCapability,
-        mainCheckout: installedRoot,
-        nodePath,
-        fileSystem
-    });
-    await assertNoSymlinkSegments({
-        rootPath  : path.resolve(instanceRoot),
-        targetPath: instanceHome,
-        fileSystem,
-        label     : 'resident home'
-    });
-
-    const hydration = await hydrateWorkspace({
-        mainCheckout: installedRoot,
-        projectRoot : canonicalRepoPath,
-        log
-    });
-
-    await assertRealDirectory(canonicalRepoPath, 'repoPath', fileSystem);
-    await assertExecutablePlan({plan, nodePath, fileSystem});
-
-    await assertNoSymlinkSegments({
-        rootPath  : path.resolve(instanceRoot),
-        targetPath: instanceHome,
-        fileSystem,
-        label     : 'resident home'
-    });
-
-    const artifacts = await prepareHarnessArtifacts({
-        agent,
-        repoPath    : canonicalRepoPath,
-        instanceHome,
-        mainCheckout: installedRoot,
-        plan,
-        remoteMcpCapability,
-        fileSystem
-    });
-
-    // The logical plan contains executable paths, public URLs, and ENV-SLOT NAMES only — never
-    // values. Direct-HTTP adapters return their exact renderer input for installed readback;
-    // Claude Desktop's command-only bridge is independently bound by the capability proof plus
-    // generated-artifact/real-transport tests, while this plan retains the transport intent.
-    return {
-        repoPath: canonicalRepoPath,
-        instanceHome,
-        mcpMatrix,
-        mcpPlan : plan.map(server => ({
-            ...server,
-            args              : [...server.args],
-            runtimeEnv        : [...server.runtimeEnv],
-            requiredRuntimeEnv: [...server.requiredRuntimeEnv],
-            secretEnv         : [...server.secretEnv]
-        })),
-        hydration,
-        artifacts
-    };
-}
-
-/** @private */
-function createMcpPlan({mcpMatrix, repoPath, mainCheckout, nodePath, mcpTarget}) {
-    assertMcpTargetPlan(mcpTarget);
-
-    return MCP_SERVERS.map(entry => {
-        const
-            descriptor = MCP_SERVER_DESCRIPTORS[entry.key],
-            resource   = mcpTarget?.kind === 'tenant' && mcpTarget.resources[entry.key];
-
-        return {
-            key             : entry.key,
-            name            : `${NEO_MCP_NAME_PREFIX}${entry.key}`,
-            enabled         : mcpMatrix[entry.key] === true,
-            target          : resource ? 'tenant' : 'resident',
-            transport       : resource ? 'streamable-http' : 'stdio',
-            url             : resource?.url ?? null,
-            credentialEnvVar: resource ? mcpTarget.credentialEnvVar : null,
-            command         : nodePath,
-            sourceRoot      : mainCheckout,
-            args            : [
-                path.join(mainCheckout, descriptor.entrypoint),
-                ...(entry.key === 'neural-link' ? ['--cwd', repoPath] : [])
-            ],
-            runtimeEnv        : [...descriptor.runtimeEnv],
-            requiredRuntimeEnv: [...descriptor.requiredRuntimeEnv],
-            secretEnv         : [...(descriptor.secretEnv || [])],
-            unsupportedReason : descriptor.unsupportedReason || null
-        };
-    });
-}
-
-/** @private */
-function assertMcpTargetPlan(target) {
-    if (target === null) return;
-
-    const topLevelKeys = new Set(['kind', 'credentialEnvVar', 'resources']);
-
-    if (!target ||
-        typeof target !== 'object' ||
-        Array.isArray(target) ||
-        Object.keys(target).some(key => !topLevelKeys.has(key)) ||
-        target.kind !== 'tenant' ||
-        target.credentialEnvVar !== REMOTE_MCP_CREDENTIAL_ENV_VAR ||
-        !target.resources ||
-        typeof target.resources !== 'object' ||
-        Array.isArray(target.resources)) {
-        throw unsupported('tenant MCP target plan is malformed')
-    }
-
-    const
-        allowed  = new Set(['memory-core', 'knowledge-base']),
-        suffixes = {
-            'memory-core'   : '/mc/mcp',
-            'knowledge-base': '/kb/mcp'
-        };
-    let deploymentBase = null;
-
-    for (const [key, resource] of Object.entries(target.resources)) {
-        let url;
-
-        try {
-            url = new URL(resource?.url)
-        } catch {
-            throw unsupported(`remote MCP resource '${key}' is malformed`)
-        }
-
-        const suffix = suffixes[key];
-
-        if (!allowed.has(key) ||
-            !resource ||
-            typeof resource !== 'object' ||
-            Array.isArray(resource) ||
-            Object.keys(resource).some(field => field !== 'url') ||
-            typeof resource.url !== 'string' ||
-            !resource.url ||
-            !['http:', 'https:'].includes(url.protocol) ||
-            url.username ||
-            url.password ||
-            url.search ||
-            url.hash ||
-            !url.pathname.endsWith(suffix)) {
-            throw unsupported(`remote MCP resource '${key}' is malformed`)
-        }
-
-        const candidateBase = `${url.origin}${url.pathname.slice(0, -suffix.length)}`;
-
-        if (deploymentBase !== null && deploymentBase !== candidateBase) {
-            throw unsupported('remote MCP resources do not share one canonical deployment base')
-        }
-
-        deploymentBase = candidateBase
-    }
-
-    if (![...allowed].every(key => target.resources[key])) {
-        throw unsupported('tenant MCP target requires both memory-core and knowledge-base resources')
-    }
-}
-
-/** @private */
-function assertHarnessSupported({agent, plan}) {
     if (agent.metadata?.launch) {
         throw unsupported('raw metadata.launch overrides bypass curated resident-home and MCP preparation');
     }
 
-    if (!LAUNCHABLE_HARNESS_TYPES.includes(agent.harnessType)) {
-        throw unsupported(`harness '${agent.harnessType}' has no launch/workspace adapter`);
+    let plan;
+    try {
+        plan = createManagedAgentWorkspacePlan({
+            agent    : {id: agent.id, harnessType: agent.harnessType},
+            mcpMatrix: resolveMatrix(agent.mcpServers),
+            mcpTarget
+        })
+    } catch (error) {
+        if (error instanceof ManagedWorkspacePreparationError) throw error;
+        throw unsupported(error.message)
     }
 
-    if (plan.some(server => server.target === 'tenant') &&
-        !supportsTenantMcpTarget(agent.harnessType)) {
-        throw unsupported(`harness '${agent.harnessType}' has no proven secret-safe tenant MCP grammar`)
-    }
+    return applyManagedAgentWorkspacePlan({
+        plan,
+        repoPath,
+        instanceRoot,
+        mainCheckout,
+        nodePath,
+        remoteMcpCapability,
+        hydrateWorkspace,
+        deriveInstanceHome,
+        fileSystem,
+        log
+    })
+}
 
-    const catalogUnsupported = plan.find(server => server.enabled && server.unsupportedReason);
-    if (catalogUnsupported) {
-        throw unsupported(`MCP server '${catalogUnsupported.key}' is enabled but unsupported: ${catalogUnsupported.unsupportedReason}`);
-    }
-
-    if (agent.harnessType === 'antigravity') {
-        throw unsupported('Antigravity 2.x exposes no proven contained per-resident MCP configuration root');
-    }
-
-    if (agent.harnessType === 'claude-desktop') {
-        const secretServer = plan.find(server => server.enabled &&
-            server.requiredRuntimeEnv.some(name => server.secretEnv.includes(name)));
-        if (secretServer) {
-            throw unsupported(`Claude Desktop cannot represent startup-required Fleet secret env for enabled MCP server '${secretServer.key}' without persisting secret bytes`);
+/** @private */
+function assertSafeLogicalTree(value, label, ancestors=new WeakSet()) {
+    if (typeof value === 'string') {
+        if (isPortableAbsolutePath(value)) {
+            throw new TypeError(`createManagedAgentWorkspacePlan: '${label}' must not contain an absolute host path.`)
         }
+        return
     }
+
+    if (value === null || value === undefined || typeof value !== 'object') return;
+
+    const prototype = Object.getPrototypeOf(value);
+    if (!Array.isArray(value) && prototype !== Object.prototype && prototype !== null) {
+        throw new TypeError(`createManagedAgentWorkspacePlan: '${label}' must contain plain data only.`)
+    }
+    if (Object.getOwnPropertySymbols(value).length) {
+        throw new TypeError(`createManagedAgentWorkspacePlan: '${label}' must not contain symbol fields.`)
+    }
+    if (ancestors.has(value)) {
+        throw new TypeError(`createManagedAgentWorkspacePlan: '${label}' must not contain a reference cycle.`)
+    }
+
+    ancestors.add(value);
+
+    try {
+        for (const key of Object.keys(value)) {
+            const descriptor = Object.getOwnPropertyDescriptor(value, key);
+
+            if (!descriptor || descriptor.get || descriptor.set) {
+                throw new TypeError(`createManagedAgentWorkspacePlan: '${label}.${key}' must be a data field, not an accessor.`)
+            }
+            if (FORBIDDEN_LOGICAL_FIELDS.has(key.toLowerCase())) {
+                throw new TypeError(`createManagedAgentWorkspacePlan: forbidden logical field '${key}'.`)
+            }
+
+            assertSafeLogicalTree(descriptor.value, `${label}.${key}`, ancestors)
+        }
+    } finally {
+        ancestors.delete(value)
+    }
+}
+
+/** @private */
+function assertExactRecord(value, label, allowedKeys, requiredKeys=allowedKeys) {
+    if (!value || typeof value !== 'object' || Array.isArray(value)) {
+        throw new TypeError(`createManagedAgentWorkspacePlan: '${label}' must be an object.`)
+    }
+
+    const
+        unknown = Object.keys(value).find(key => !allowedKeys.includes(key)),
+        missing = requiredKeys.find(key => !Object.hasOwn(value, key));
+
+    if (unknown) {
+        throw new TypeError(`createManagedAgentWorkspacePlan: unknown field '${label}.${unknown}'.`)
+    }
+    if (missing) {
+        throw new TypeError(`createManagedAgentWorkspacePlan: missing field '${label}.${missing}'.`)
+    }
+}
+
+/** @private */
+function assertLogicalString(value, label) {
+    if (typeof value !== 'string' || value.length === 0) {
+        throw new TypeError(`createManagedAgentWorkspacePlan: '${label}' must be a non-empty string.`)
+    }
+}
+
+/** @private */
+function assertLogicalStringArray(value, label) {
+    if (!Array.isArray(value) ||
+        Object.keys(value).some((key, index) => key !== String(index)) ||
+        value.some(item => typeof item !== 'string' || item.length === 0)) {
+        throw new TypeError(`applyManagedAgentWorkspacePlan: '${label}' must be a dense string array.`)
+    }
+}
+
+/** @private */
+function isPortableAbsolutePath(value) {
+    return path.isAbsolute(value) || /^[A-Za-z]:[\\/]/.test(value) || /^\\\\/.test(value)
 }
 
 /**

--- a/test/playwright/unit/ai/services/fleet/prepareManagedAgentWorkspace.spec.mjs
+++ b/test/playwright/unit/ai/services/fleet/prepareManagedAgentWorkspace.spec.mjs
@@ -4,14 +4,17 @@ import {StdioClientTransport}          from '@modelcontextprotocol/sdk/client/st
 import {createMcpExpressApp}           from '@modelcontextprotocol/sdk/server/express.js';
 import {McpServer}                     from '@modelcontextprotocol/sdk/server/mcp.js';
 import {StreamableHTTPServerTransport} from '@modelcontextprotocol/sdk/server/streamableHttp.js';
+import {spawnSync}                     from 'node:child_process';
 import crypto                          from 'node:crypto';
 import fs                              from 'node:fs/promises';
 import os                              from 'node:os';
 import path                            from 'node:path';
-import {fileURLToPath}                 from 'node:url';
+import {fileURLToPath, pathToFileURL}  from 'node:url';
 import {
     ManagedWorkspacePreparationError,
     WORKSPACE_ARTIFACT_STATES,
+    applyManagedAgentWorkspacePlan,
+    createManagedAgentWorkspacePlan,
     prepareManagedAgentWorkspace
 } from '../../../../../../ai/services/fleet/prepareManagedAgentWorkspace.mjs';
 
@@ -42,6 +45,19 @@ const MCP_ENTRYPOINTS = [
     'ai/mcp/server/github-workflow/mcp-server.mjs',
     'ai/mcp/server/gitlab-workflow/mcp-server.mjs'
 ];
+
+const BOUNDED_APPLY_EFFECTS = new Set([
+    'access',
+    'chmod',
+    'hydrateWorkspace',
+    'lstat',
+    'mkdir',
+    'readFile',
+    'rename',
+    'stat',
+    'unlink',
+    'writeFile'
+]);
 
 let root, mainCheckout, repoRoot, instanceRoot, hydrationCalls;
 
@@ -115,6 +131,22 @@ function claudeDesktopRemoteCapability(checkout, nodePath=NODE_PATH) {
 
 async function read(filePath) {
     return fs.readFile(filePath, 'utf8');
+}
+
+async function sourceFiles(directoryPath) {
+    const result = [];
+
+    for (const entry of await fs.readdir(directoryPath, {withFileTypes: true})) {
+        const filePath = path.join(directoryPath, entry.name);
+
+        if (entry.isDirectory()) {
+            result.push(...await sourceFiles(filePath))
+        } else if (entry.isFile() && entry.name.endsWith('.mjs')) {
+            result.push(filePath)
+        }
+    }
+
+    return result
 }
 
 /**
@@ -198,6 +230,44 @@ function tenantTarget(endpoint='https://tenant.example.com/agentos') {
     }
 }
 
+function canonicalMcpMatrix(overrides={}) {
+    return {
+        'memory-core'    : true,
+        'knowledge-base' : true,
+        'neural-link'    : true,
+        'github-workflow': false,
+        'gitlab-workflow': false,
+        ...overrides
+    }
+}
+
+function logicalInput({harnessType='codex', mcpMatrix=canonicalMcpMatrix(), mcpTarget=null}={}) {
+    return {
+        agent: {id: 'agent-a', harnessType},
+        mcpMatrix,
+        mcpTarget
+    }
+}
+
+function recursivelyFrozen(value) {
+    if (!value || typeof value !== 'object' || !Object.isFrozen(value)) return false;
+
+    return Object.values(value).every(child =>
+        !child || typeof child !== 'object' || recursivelyFrozen(child))
+}
+
+function collectStrings(value, result=[]) {
+    if (typeof value === 'string') {
+        result.push(value)
+    } else if (Array.isArray(value)) {
+        value.forEach(child => collectStrings(child, result))
+    } else if (value && typeof value === 'object') {
+        Object.values(value).forEach(child => collectStrings(child, result))
+    }
+
+    return result
+}
+
 function parseJsonc(content) {
     return JSON.parse(content.split(/\r?\n/).filter(line => !line.trimStart().startsWith('//')).join('\n'))
 }
@@ -211,6 +281,325 @@ function tomlMcpTable(content, name) {
 
     return start < 0 ? '' : marker + (next < 0 ? tail : tail.slice(0, next))
 }
+
+test.describe('managed workspace logical plan → host apply boundary', () => {
+    test('the compatibility composer has one production caller', async () => {
+        const callers = [];
+
+        for (const rootName of ['ai', 'apps', 'buildScripts', 'src']) {
+            for (const filePath of await sourceFiles(path.join(PROJECT_ROOT, rootName))) {
+                if ((await read(filePath)).includes('prepareManagedAgentWorkspace.mjs')) {
+                    callers.push(path.relative(PROJECT_ROOT, filePath))
+                }
+            }
+        }
+
+        expect(callers.sort()).toEqual(['ai/services/fleet/startAgentProvisioned.mjs'])
+    });
+
+    test('planner module loads and executes with filesystem, process, and config authority denied', () => {
+        const
+            moduleUrl = pathToFileURL(path.join(PROJECT_ROOT, 'ai/services/fleet/managedAgentWorkspacePlan.mjs')).href,
+            loader    = `
+                const denied = new Set(['fs', 'fs/promises', 'fs-extra', 'node:fs', 'node:fs/promises']);
+                const configFiles = ['config.mjs', 'config.template.mjs', 'configBase.mjs', 'ConfigProvider.mjs'];
+
+                export async function resolve(specifier, context, nextResolve) {
+                    if (denied.has(specifier) || configFiles.some(name =>
+                        specifier === name || specifier.endsWith('/' + name))) {
+                        throw new Error('denied planner import: ' + specifier)
+                    }
+                    return nextResolve(specifier, context)
+                }
+            `,
+            childScript = `
+                import {register} from 'node:module';
+
+                const realProcess = globalThis.process;
+                register('data:text/javascript,' + encodeURIComponent(${JSON.stringify(loader)}), import.meta.url);
+                Object.defineProperty(globalThis, 'process', {
+                    configurable: true,
+                    get() {
+                        throw new Error('denied planner process access')
+                    }
+                });
+                for (const name of ['AiConfig', 'Config', 'Neo']) {
+                    Object.defineProperty(globalThis, name, {
+                        configurable: true,
+                        get() {
+                            throw new Error('denied planner global config access: ' + name)
+                        }
+                    })
+                }
+
+                const {createManagedAgentWorkspacePlan} = await import(${JSON.stringify(`${moduleUrl}?deny-authority=1`)});
+                const plan = createManagedAgentWorkspacePlan({
+                    agent: {id: 'deny-authority-seat', harnessType: 'codex'},
+                    mcpMatrix: {
+                        'memory-core': true,
+                        'knowledge-base': true,
+                        'neural-link': true,
+                        'github-workflow': false,
+                        'gitlab-workflow': false
+                    }
+                });
+
+                realProcess.stdout.write(JSON.stringify({
+                    artifactProfile: plan.artifactProfile,
+                    frozen: Object.isFrozen(plan),
+                    serverCount: plan.mcpServers.length
+                }))
+            `,
+            result = spawnSync(NODE_PATH, ['--input-type=module', '--eval', childScript], {
+                encoding: 'utf8'
+            });
+
+        expect(result.status, result.stderr).toBe(0);
+        expect(JSON.parse(result.stdout)).toEqual({
+            artifactProfile: 'codex',
+            frozen         : true,
+            serverCount    : 5
+        })
+    });
+
+    test('pure planning is deterministic, recursively frozen, closed, and path-free', () => {
+        const
+            input  = logicalInput({mcpTarget: tenantTarget()}),
+            first  = createManagedAgentWorkspacePlan(input),
+            second = createManagedAgentWorkspacePlan(structuredClone(input));
+
+        expect(first).toEqual(second);
+        expect(first).not.toBe(second);
+        expect(recursivelyFrozen(first)).toBe(true);
+        expect(Object.keys(first)).toEqual(['agent', 'artifactProfile', 'mcpMatrix', 'mcpServers']);
+        expect(Object.keys(first.agent)).toEqual(['id', 'harnessType']);
+        expect(first.artifactProfile).toBe('codex');
+        expect(first.mcpServers).toHaveLength(5);
+        expect(Object.keys(first.mcpServers[0])).toEqual([
+            'key',
+            'name',
+            'enabled',
+            'target',
+            'transport',
+            'entrypoint',
+            'url',
+            'credentialEnvVar',
+            'runtimeEnv',
+            'requiredRuntimeEnv',
+            'secretEnv'
+        ]);
+        expect(first.mcpServers.filter(server => server.target === 'tenant').map(server => server.key))
+            .toEqual(['memory-core', 'knowledge-base']);
+        expect(first.mcpServers.find(server => server.key === 'neural-link')).toMatchObject({
+            target   : 'resident',
+            transport: 'stdio',
+            url      : null
+        });
+        expect(first.mcpServers.every(server => server.entrypoint && !path.isAbsolute(server.entrypoint))).toBe(true);
+        expect(collectStrings(first).filter(value => !/^https?:/.test(value)).every(value => !path.isAbsolute(value))).toBe(true);
+        expect(JSON.stringify(first)).not.toMatch(/"(?:args|command|cwd|mainCheckout|nodePath|owner|grant|authorization)"/);
+    });
+
+    test('planner rejects forbidden/unknown/absolute fields without evaluating effectful accessors', () => {
+        const forbidden = [{
+            name  : 'owner',
+            mutate: input => { input.owner = '@someone' }
+        }, {
+            name  : 'nested repoPath',
+            mutate: input => { input.agent.repoPath = '/tmp/repo' }
+        }, {
+            name  : 'bearer value',
+            mutate: input => { input.mcpTarget = {...tenantTarget(), bearer: 'secret-value'} }
+        }, {
+            name  : 'authorization field',
+            mutate: input => { input.mcpTarget = {...tenantTarget(), authorization: {grant: 'admin'}} }
+        }, {
+            name  : 'resource headers',
+            mutate: input => {
+                input.mcpTarget = tenantTarget();
+                input.mcpTarget.resources['memory-core'].headers = {Authorization: 'Bearer secret'}
+            }
+        }, {
+            name  : 'absolute opaque id',
+            mutate: input => { input.agent.id = '/tmp/agent-a' }
+        }];
+
+        for (const entry of forbidden) {
+            const input = logicalInput();
+
+            entry.mutate(input);
+            expect(() => createManagedAgentWorkspacePlan(input), entry.name).toThrow(TypeError)
+        }
+
+        const cyclic = logicalInput();
+        cyclic.agent.loop = cyclic.agent;
+
+        expect(() => createManagedAgentWorkspacePlan(cyclic)).toThrow(TypeError);
+
+        for (const field of ['fileSystem', 'env', 'process', 'globalConfig']) {
+            const input = logicalInput();
+            let   reads = 0;
+
+            Object.defineProperty(input, field, {
+                enumerable: true,
+                get() {
+                    reads++;
+                    throw new Error(`${field} getter was evaluated`)
+                }
+            });
+
+            expect(() => createManagedAgentWorkspacePlan(input), field).toThrow(TypeError);
+            expect(reads, field).toBe(0)
+        }
+    });
+
+    test('unsupported harness, MCP, and transport combinations are RangeErrors', () => {
+        expect(() => createManagedAgentWorkspacePlan(logicalInput({harnessType: 'unknown'}))).toThrow(RangeError);
+        expect(() => createManagedAgentWorkspacePlan(logicalInput({harnessType: 'antigravity'}))).toThrow(RangeError);
+        expect(() => createManagedAgentWorkspacePlan(logicalInput({
+            mcpMatrix: canonicalMcpMatrix({'gitlab-workflow': true})
+        }))).toThrow(RangeError);
+        expect(() => createManagedAgentWorkspacePlan(logicalInput({
+            harnessType: 'claude-desktop',
+            mcpMatrix  : canonicalMcpMatrix({'github-workflow': true})
+        }))).toThrow(RangeError);
+    });
+
+    test('host apply accepts a structural clone and records only the bounded effect vocabulary', async () => {
+        const
+            plan       = createManagedAgentWorkspacePlan(logicalInput()),
+            operations = [],
+            fileSystem = new Proxy(fs, {
+                get(target, property, receiver) {
+                    const value = Reflect.get(target, property, receiver);
+
+                    return typeof value !== 'function'
+                        ? value
+                        : async (...args) => {
+                            operations.push(String(property));
+                            return value.call(target, ...args)
+                        }
+                }
+            });
+
+        expect(operations).toEqual([]);
+
+        const result = await applyManagedAgentWorkspacePlan({
+            plan            : structuredClone(plan),
+            repoPath        : path.join(repoRoot, 'direct-apply'),
+            instanceRoot,
+            mainCheckout,
+            nodePath        : NODE_PATH,
+            hydrateWorkspace: async args => {
+                operations.push('hydrateWorkspace');
+                await fs.mkdir(args.projectRoot, {recursive: true});
+                return {hydrated: true}
+            },
+            fileSystem
+        });
+
+        expect([...new Set(operations)].every(operation => BOUNDED_APPLY_EFFECTS.has(operation))).toBe(true);
+        expect(operations).toContain('hydrateWorkspace');
+        expect(operations).toContain('writeFile');
+        expect(Object.keys(result)).toEqual([
+            'repoPath',
+            'instanceHome',
+            'mcpMatrix',
+            'mcpPlan',
+            'hydration',
+            'artifacts'
+        ]);
+        expect(result.mcpPlan[0].args[0]).toBe(path.join(mainCheckout, MCP_ENTRYPOINTS[0]));
+        expect(path.isAbsolute(result.mcpPlan[0].args[0])).toBe(true)
+    });
+
+    test('invalid host input is normalized and a completed artifact converges after a mid-apply failure', async () => {
+        const
+            plan     = createManagedAgentWorkspacePlan(logicalInput()),
+            badPlan  = structuredClone(plan),
+            repoPath = path.join(repoRoot, 'partial-apply');
+
+        badPlan.agent.id = '/tmp/escaped-agent';
+
+        await expect(applyManagedAgentWorkspacePlan({
+            plan            : badPlan,
+            repoPath,
+            instanceRoot,
+            mainCheckout,
+            nodePath        : NODE_PATH,
+            hydrateWorkspace: makeHydrate()
+        })).rejects.toBeInstanceOf(ManagedWorkspacePreparationError);
+        expect(hydrationCalls).toEqual([]);
+
+        let   writes            = 0;
+        const failingFileSystem = new Proxy(fs, {
+            get(target, property, receiver) {
+                const value = Reflect.get(target, property, receiver);
+
+                if (property !== 'writeFile') return typeof value === 'function' ? value.bind(target) : value;
+
+                return async (...args) => {
+                    writes++;
+                    if (writes === 2) throw Object.assign(new Error('injected mid-apply failure'), {code: 'EIO'});
+                    return value.call(target, ...args)
+                }
+            }
+        });
+        const applyOptions = {
+            plan,
+            repoPath,
+            instanceRoot,
+            mainCheckout,
+            nodePath        : NODE_PATH,
+            hydrateWorkspace: makeHydrate()
+        };
+
+        await expect(applyManagedAgentWorkspacePlan({...applyOptions, fileSystem: failingFileSystem}))
+            .rejects.toBeInstanceOf(ManagedWorkspacePreparationError);
+        expect(await read(path.join(repoPath, '.codex', 'config.toml'))).toContain('neo-mjs-memory-core');
+
+        const retry = await applyManagedAgentWorkspacePlan(applyOptions);
+
+        expect(retry.artifacts.map(item => item.status)).toEqual([
+            WORKSPACE_ARTIFACT_STATES.MATCH,
+            WORKSPACE_ARTIFACT_STATES.CREATED,
+            WORKSPACE_ARTIFACT_STATES.CREATED
+        ])
+    });
+
+    test('compatibility composer resolves once before entering one host apply sequence', async () => {
+        const
+            events = [],
+            agent  = makeAgent('codex'),
+            result = await prepareManagedAgentWorkspace({
+                ...options(agent, 'compatibility-composer'),
+                resolveMatrix(overrides) {
+                    events.push('resolve');
+                    expect(overrides).toBe(agent.mcpServers);
+                    return canonicalMcpMatrix()
+                },
+                deriveInstanceHome({instanceRoot: rootPath, agentId, harnessType}) {
+                    events.push('apply:derive');
+                    return path.join(rootPath, agentId, harnessType)
+                },
+                hydrateWorkspace: async args => {
+                    events.push('apply:hydrate');
+                    await fs.mkdir(args.projectRoot, {recursive: true});
+                    return {hydrated: true}
+                }
+            });
+
+        expect(events).toEqual(['resolve', 'apply:derive', 'apply:hydrate']);
+        expect(Object.keys(result)).toEqual([
+            'repoPath',
+            'instanceHome',
+            'mcpMatrix',
+            'mcpPlan',
+            'hydration',
+            'artifacts'
+        ])
+    });
+});
 
 test.describe('prepareManagedAgentWorkspace', () => {
     test('Codex: hydrate → project MCP projection + isolated home policy, all CREATED', async () => {

--- a/test/playwright/unit/ai/services/fleet/prepareManagedAgentWorkspace.spec.mjs
+++ b/test/playwright/unit/ai/services/fleet/prepareManagedAgentWorkspace.spec.mjs
@@ -513,6 +513,48 @@ test.describe('managed workspace logical plan → host apply boundary', () => {
         expect(path.isAbsolute(result.mcpPlan[0].args[0])).toBe(true)
     });
 
+    test('host apply rejects projection drift while accepting a coherent clone without proving provenance', async () => {
+        const
+            plan           = createManagedAgentWorkspacePlan(logicalInput()),
+            divergentPlan  = structuredClone(plan),
+            coherentPlan   = structuredClone(plan),
+            hydrationCalls = [];
+
+        divergentPlan.mcpServers.find(server => server.key === 'memory-core').transport = 'streamable-http';
+
+        await expect(applyManagedAgentWorkspacePlan({
+            plan            : divergentPlan,
+            repoPath        : path.join(repoRoot, 'divergent-plan'),
+            instanceRoot,
+            mainCheckout,
+            nodePath        : NODE_PATH,
+            hydrateWorkspace: async args => {
+                hydrationCalls.push(args);
+                return {hydrated: true}
+            }
+        })).rejects.toThrow(
+            'host apply rejected its logical plan (applyManagedAgentWorkspacePlan: plan does not match the canonical logical projection.)'
+        );
+        expect(hydrationCalls).toEqual([]);
+
+        // This gate proves coherence with the plan's OWN logical inputs, not that a registry
+        // authorized them. Cross-process provenance belongs to the later signed envelope.
+        coherentPlan.mcpMatrix['memory-core'] = false;
+        coherentPlan.mcpServers.find(server => server.key === 'memory-core').enabled = false;
+
+        const result = await applyManagedAgentWorkspacePlan({
+            plan            : coherentPlan,
+            repoPath        : path.join(repoRoot, 'coherent-plan'),
+            instanceRoot,
+            mainCheckout,
+            nodePath        : NODE_PATH,
+            hydrateWorkspace: makeHydrate()
+        });
+
+        expect(result.mcpMatrix['memory-core']).toBe(false);
+        expect(result.mcpPlan.find(server => server.key === 'memory-core').enabled).toBe(false)
+    });
+
     test('invalid host input is normalized and a completed artifact converges after a mid-apply failure', async () => {
         const
             plan     = createManagedAgentWorkspacePlan(logicalInput()),

--- a/test/playwright/unit/ai/startAgentProvisioned.spec.mjs
+++ b/test/playwright/unit/ai/startAgentProvisioned.spec.mjs
@@ -488,19 +488,22 @@ test.describe('startAgentProvisioned (Fleet Manager spawn-time repo provisioning
         expect(lifecycle.calls.start).toHaveLength(0);
     });
 
-    test('a preparation rejection propagates and start is NEVER called (fail-closed)', async () => {
-        const lifecycle        = makeLifecycle({agents: repoAgent('a')}),
-              prepareWorkspace = async () => { throw new Error('DIVERGENT: owned MCP keys'); };
+    test('planner and apply rejections both propagate before start (fail-closed)', async () => {
+        for (const stage of ['planner', 'apply']) {
+            const
+                lifecycle        = makeLifecycle({agents: repoAgent('a')}),
+                prepareWorkspace = async () => { throw new Error(`${stage} rejected workspace preparation`); };
 
-        await expect(startAgentProvisioned({
-            lifecycleService: lifecycle,
-            agentId         : 'a',
-            managedRoot     : '/managed',
-            ensureRepo      : makeEnsureRepo('/managed/a/neomjs-neo'),
-            prepareWorkspace
-        })).rejects.toThrow('DIVERGENT: owned MCP keys');
+            await expect(startAgentProvisioned({
+                lifecycleService: lifecycle,
+                agentId         : 'a',
+                managedRoot     : '/managed',
+                ensureRepo      : makeEnsureRepo('/managed/a/neomjs-neo'),
+                prepareWorkspace
+            }), stage).rejects.toThrow(`${stage} rejected workspace preparation`);
 
-        expect(lifecycle.calls.start).toHaveLength(0);
+            expect(lifecycle.calls.start, stage).toHaveLength(0)
+        }
     });
 
     test('an installed-adapter readback rejection propagates after preparation and before spawn', async () => {


### PR DESCRIPTION
Resolves #16715

This separates Fleet workspace preparation into a deterministic logical planner and a host-owned apply edge. `createManagedAgentWorkspacePlan()` now lives in a pure sibling module with a closed, recursively frozen, path-free schema; `applyManagedAgentWorkspacePlan()` validates structural clones before introducing absolute bindings and running the existing bounded effects. `prepareManagedAgentWorkspace()` remains the one-call compatibility composer, and `startAgentProvisioned()` still reaches spawn only after successful preparation.

Evidence: L2 (deny-loader subprocess, temp-filesystem apply/convergence, real child-process MCP bridge fixture, and explicit no-spawn ordering) → L2 required (all #16715 close-target ACs are internal plan/apply contracts). No residuals.

Related: #16168

## Deltas from ticket

None substantive. The pure planner was extracted into `managedAgentWorkspacePlan.mjs` rather than remaining lexically inside the effectful host module; that placement is what makes the ticket's module-load filesystem/process/config denial mechanically honest. Malformed cyclic input is also normalized to the promised `TypeError` contract.

## Signal Ledger (sourced from Discussion #16176)

- `gpt`: `[AUTHOR_SIGNAL]` by @neo-gpt at [`DC_kwDODSospM4BEc4V`](https://github.com/neomjs/neo/discussions/16176#discussioncomment-17944085), bound to body `2026-08-08T14:04:19Z`.
- `claude`: `STEP_BACK` + `[GRADUATION_APPROVED]` by @neo-fable-clio at [`DC_kwDODSospM4BEc5Y`](https://github.com/neomjs/neo/discussions/16176#discussioncomment-17944152), bound to the same body. The sweep recorded zero blockers and named the caller/effect census this leaf now supplies.

## Unresolved Dissent

None. The source Discussion's final Step-Back records zero blockers.

## Unresolved Liveness

- Docker Desktop reachability/exposure remains unclaimed in the parent host-actuator lane. Its `revalidationTrigger` is availability of that runtime or a deployment support-matrix change, followed by one container-positive request to the intended host binding and one negative request to every LAN-reachable interface; failure selects durable pull/outbox for that runtime.
- This liveness clause does not leave a #16715 residual: this leaf introduces no actuator transport or runtime support claim.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/ai/services/fleet/prepareManagedAgentWorkspace.spec.mjs test/playwright/unit/ai/startAgentProvisioned.spec.mjs test/playwright/unit/ai/services/fleet/FleetRegistryService.spec.mjs` — 79 passed at `719e74c64e`.
- `npx lint-staged --no-stash` — whitespace, shorthand, JSDoc types, ticket archaeology, block alignment, parse, derived-domain, AiConfig-test-mutation, and OpenAPI parity gates passed.
- `npm run ai:lint-fleet-vocabulary-parity` — Brain/Body Fleet vocabulary parity passed.
- Fleet workspace plan/apply surface: module-load authority denial, deterministic/deeply immutable output, closed-schema rejection table, structural-clone validation, canonical-projection drift rejection plus coherent-clone acceptance (coherence, not provenance), bounded operation recorder, partial-state retry convergence, unchanged adapter/receipt transitions, and no-spawn failure ordering all passed.
- UI/app surface: None touched.

## Post-Merge Validation

None required. This internal seam has no operator-only or merge-only acceptance criterion.

Authored by Emmy (GPT-5.6 Sol Ultra, Codex) consuming Euclid's ticket contract — session A abdf06f7-5c90-4124-ad28-f0e2897214ee, session B 019fe0b3-53bc-7ef2-8665-41a0ef3f7b62.
