### PR TITLE
feat(orchestrator): the crash diagnosis names a heap abort instead of a generic crash (#16750)

### DIFF
--- a/ai/daemons/orchestrator/services/ContainerHealthDiagnosisService.mjs
+++ b/ai/daemons/orchestrator/services/ContainerHealthDiagnosisService.mjs
@@ -1223,7 +1223,7 @@ export function calculateDockerCpuPercent(stats) {
  * negative. `unavailableReason` travels with it so a reader can tell a disabled channel from a
  * non-heap death — the two are opposite facts that a bare `false` would merge.
  * @param {Object} options
- * @param {Object|null} options.logs Bounded log summary (`{text, truncated, …}`) from the bridge.
+ * @param {Object|null} options.logs Bounded log summary (`{text, truncated, incarnationBounded, …}`) from the bridge. `incarnationBounded` must be `true` before a match may attribute.
  * @param {Boolean|null} options.nodeCommand Whether `Config.Cmd` invoked Node.
  * @param {Number|null} [options.declaredHeapCeilingMb=null] Declared ceiling, when observable.
  * @param {Boolean|null} [options.oomKilled=null] Whether the kernel reclaimed the container.
@@ -1264,6 +1264,16 @@ export function classifyHeapExhaustion({logs, nodeCommand, declaredHeapCeilingMb
     // outside the window", so it must not answer. A truncated tail that DOES match is conclusive —
     // truncation cannot manufacture the line.
     if (!matched && logs.truncated === true) return unavailable('log-tail-truncated');
+
+    // The Docker log stream spans RESTARTS. An unbounded slice can therefore carry a fatal line from
+    // an earlier incarnation above a healthy boot above an unrelated current crash, and a match
+    // anywhere in it would name the wrong cause with full confidence — the same
+    // wider-than-the-thing-it-names defect this diagnosis path exists to remove, one layer down.
+    //
+    // So a match only attributes when the producer states the slice belongs to the stopped run.
+    // Until it does, this refuses rather than guesses: a matching line that cannot be proven to
+    // belong to this incarnation is unavailable evidence, never a weaker heap verdict.
+    if (matched && logs.incarnationBounded !== true) return unavailable('log-incarnation-unbounded');
 
     return {
         // Only a numeric ceiling licenses wording that implicates a DECLARED ceiling; an undeclared

--- a/ai/daemons/orchestrator/services/ContainerHealthDiagnosisService.mjs
+++ b/ai/daemons/orchestrator/services/ContainerHealthDiagnosisService.mjs
@@ -459,6 +459,7 @@ export class ContainerHealthDiagnosisService extends Base {
      * @param {Object|null} [options.logs=null] Bounded log summary, for heap attribution.
      * @param {Boolean|null} [options.nodeCommand=null] Whether `Config.Cmd` invoked Node.
      * @param {Number|null} [options.declaredHeapCeilingMb=null] Declared ceiling, when observable.
+ * @param {Boolean|null} [options.oomKilled=null] Whether the kernel reclaimed the container.
      * @returns {Object[]}
      */
     collectLifecycleFacts({serviceKey, inspect, observedAt, logs = null, nodeCommand = null, declaredHeapCeilingMb = null}) {
@@ -471,7 +472,12 @@ export class ContainerHealthDiagnosisService extends Base {
             facts       = [];
 
         if (status && !RUNNING_STATES.has(status)) {
-            const heap = classifyHeapExhaustion({logs, nodeCommand, declaredHeapCeilingMb});
+            const heap = classifyHeapExhaustion({
+                logs,
+                nodeCommand,
+                declaredHeapCeilingMb,
+                oomKilled: typeof state.OOMKilled === 'boolean' ? state.OOMKilled : null
+            });
 
             facts.push(this.createFact({
                 type         : CONTAINER_HEALTH_FACT_TYPES.containerDown,
@@ -1220,9 +1226,10 @@ export function calculateDockerCpuPercent(stats) {
  * @param {Object|null} options.logs Bounded log summary (`{text, truncated, …}`) from the bridge.
  * @param {Boolean|null} options.nodeCommand Whether `Config.Cmd` invoked Node.
  * @param {Number|null} [options.declaredHeapCeilingMb=null] Declared ceiling, when observable.
+ * @param {Boolean|null} [options.oomKilled=null] Whether the kernel reclaimed the container.
  * @returns {Object} `{heapExhaustion, unavailableReason, declaredHeapCeilingMb}`
  */
-export function classifyHeapExhaustion({logs, nodeCommand, declaredHeapCeilingMb = null}) {
+export function classifyHeapExhaustion({logs, nodeCommand, declaredHeapCeilingMb = null, oomKilled = null}) {
     const unavailable = reason => ({
         declaredHeapCeilingMb: null,
         heapExhaustion       : null,
@@ -1245,6 +1252,13 @@ export function classifyHeapExhaustion({logs, nodeCommand, declaredHeapCeilingMb
     if (!logs || typeof logs.text !== 'string') return unavailable('logs-unavailable');
 
     const matched = HEAP_FATAL_LINE.test(logs.text);
+
+    // The kernel and V8 are making CONTRADICTORY claims about the same death, and this payload
+    // cannot adjudicate: either V8 exhausted its heap and the container was reaped afterwards, or
+    // the cgroup killed a container whose log slice still carries an older fatal line. Recording
+    // `oomKilled` beside a confident heap verdict would publish the contradiction as agreement, so
+    // an unresolvable conflict is absence of signal — never the weaker of the two answers.
+    if (matched && oomKilled === true) return unavailable('evidence-conflict');
 
     // A truncated tail that does NOT match cannot distinguish "no heap death" from "the line fell
     // outside the window", so it must not answer. A truncated tail that DOES match is conclusive —

--- a/ai/daemons/orchestrator/services/ContainerHealthDiagnosisService.mjs
+++ b/ai/daemons/orchestrator/services/ContainerHealthDiagnosisService.mjs
@@ -35,6 +35,15 @@ export const CONTAINER_HEALTH_ACTION_CLASSES = Object.freeze({
 export const SERVICE_CLASSES = Object.freeze({store: 'store', transient: 'transient'});
 
 /**
+ * @summary `128 + SIGABRT` — the exit code a V8 self-abort leaves on a container.
+ *
+ * Shared by every `FATAL ERROR`, assertion failure and explicit `abort()`, so it identifies the
+ * MANNER of death and never its cause. See `classifyHeapAbortCandidate`.
+ * @member {Number} V8_HEAP_ABORT_EXIT_CODE=134
+ */
+export const V8_HEAP_ABORT_EXIT_CODE = 134;
+
+/**
  * @summary EXHAUSTIVE service classification, declared per key rather than inferred from absence.
  *
  * Covers every key in `orchestrator.deploymentRuntimeAccess.allowedServices`, which is the roster
@@ -455,7 +464,12 @@ export class ContainerHealthDiagnosisService extends Base {
                 details      : {
                     status,
                     exitCode: Number.isFinite(state.ExitCode) ? state.ExitCode : null,
-                    error   : typeof state.Error === 'string' ? state.Error : null
+                    error   : typeof state.Error === 'string' ? state.Error : null,
+                    // Carried beside the exit code because the pair is what discriminates: a V8
+                    // self-abort and a cgroup OOM kill are different failures with different heals,
+                    // and the exit code alone cannot tell them apart.
+                    oomKilled         : typeof state.OOMKilled === 'boolean' ? state.OOMKilled : null,
+                    heapAbortCandidate: classifyHeapAbortCandidate(state)
                 }
             }));
         }
@@ -728,13 +742,27 @@ export class ContainerHealthDiagnosisService extends Base {
             fact.type === CONTAINER_HEALTH_FACT_TYPES.containerDown ||
             fact.type === CONTAINER_HEALTH_FACT_TYPES.containerUnhealthy
         );
-        if (lifecycleFacts.some(fact => fact.type === CONTAINER_HEALTH_FACT_TYPES.containerDown) || this.hasAuthoritativeEvidence(lifecycleFacts, facts)) {
+        const downFacts = lifecycleFacts.filter(fact =>
+            fact.type === CONTAINER_HEALTH_FACT_TYPES.containerDown);
+
+        if (downFacts.length || this.hasAuthoritativeEvidence(lifecycleFacts, facts)) {
+            // The ACTION is unchanged and was never wrong — a stopped container is restarted either
+            // way. What was missing is the CAUSE: a service that exhausted its declared V8 ceiling
+            // recorded as a generic crash, so the ceiling was never implicated and the same abort
+            // recurred indefinitely. That is why nothing looked broken from the outside.
+            //
+            // The reason narrows only when the evidence supports it, and says CANDIDATE because the
+            // discriminating stderr line is not in this payload (see `classifyHeapAbortCandidate`).
+            // A consumer may route on it, but may not restate it as a confirmed heap death.
+            const heapAbortCandidate = downFacts.some(fact =>
+                fact.details?.heapAbortCandidate === true);
+
             return {
                 recoveryClass: 'crash',
                 actionClass  : CONTAINER_HEALTH_ACTION_CLASSES.restart,
-                confidence   : lifecycleFacts.some(fact => fact.type === CONTAINER_HEALTH_FACT_TYPES.containerDown) ? 0.9 : 0.8,
+                confidence   : downFacts.length ? 0.9 : 0.8,
                 evidenceFacts: this.selectEvidenceFacts(facts, lifecycleFacts),
-                reason       : 'lifecycle-crash'
+                reason       : heapAbortCandidate ? 'lifecycle-crash-heap-abort-candidate' : 'lifecycle-crash'
             };
         }
 
@@ -1136,6 +1164,41 @@ export function calculateDockerCpuPercent(stats) {
         (Array.isArray(cpuStats.cpu_usage?.percpu_usage) ? cpuStats.cpu_usage.percpu_usage.length : 1);
 
     return (cpuDelta / systemDelta) * onlineCpus * 100;
+}
+
+/**
+ * @summary Classifies a stopped container's exit as a CANDIDATE V8 heap abort — never a verdict.
+ *
+ * A Node service that exhausts its declared `--max-old-space-size` aborts itself: V8 prints
+ * `FATAL ERROR: … heap limit` and raises `SIGABRT`, so the container exits **134** (`128 + 6`) with
+ * `OOMKilled` false — the kernel never intervened. That signature exists only because the ceiling is
+ * DECLARED. With no `--max-old-space-size`, V8 picks a heuristic well inside the container allowance
+ * and the same exhaustion exits **0** with `OOMKilled` false, which is a failure with no signature at
+ * all (the incident this diagnosis descends from).
+ *
+ * **134 is necessary and NOT sufficient**, which is why this returns a candidate rather than a
+ * classification. Every V8 `FATAL ERROR`, every failed assertion and every explicit `abort()` shares
+ * the code; the discriminating evidence is the stderr line, and `inspect.State` does not carry it.
+ * Naming a verdict the payload cannot support is the defect this whole diagnosis path exists to
+ * remove, so the candidate travels with its own limits and a consumer may not promote it.
+ *
+ * Tri-state deliberately: `null` means the fields needed to judge were not observed, which must read
+ * as absence of signal rather than as a negative. A missing `ExitCode` is not evidence of a healthy
+ * exit.
+ * @param {Object} state Docker `inspect.State`.
+ * @returns {Boolean|null} true = consistent with a heap abort; false = positively something else;
+ * null = not observable from this payload.
+ */
+export function classifyHeapAbortCandidate(state) {
+    const
+        exitCode  = Number.isFinite(state?.ExitCode) ? state.ExitCode : null,
+        oomKilled = typeof state?.OOMKilled === 'boolean' ? state.OOMKilled : null;
+
+    if (exitCode === null || oomKilled === null) return null;
+
+    // A cgroup kill is a different failure with a different heal — the kernel reclaimed the whole
+    // container, so the V8 ceiling is not implicated even when the exit code matches.
+    return oomKilled === false && exitCode === V8_HEAP_ABORT_EXIT_CODE
 }
 
 export function calculateDockerMemoryPercent(stats) {

--- a/ai/daemons/orchestrator/services/ContainerHealthDiagnosisService.mjs
+++ b/ai/daemons/orchestrator/services/ContainerHealthDiagnosisService.mjs
@@ -35,13 +35,20 @@ export const CONTAINER_HEALTH_ACTION_CLASSES = Object.freeze({
 export const SERVICE_CLASSES = Object.freeze({store: 'store', transient: 'transient'});
 
 /**
- * @summary `128 + SIGABRT` — the exit code a V8 self-abort leaves on a container.
+ * @summary The V8 fatal line that NAMES a heap exhaustion, on one line, strictly.
  *
- * Shared by every `FATAL ERROR`, assertion failure and explicit `abort()`, so it identifies the
- * MANNER of death and never its cause. See `classifyHeapAbortCandidate`.
- * @member {Number} V8_HEAP_ABORT_EXIT_CODE=134
+ * Both shapes V8 emits — `Reached heap limit` and `Ineffective mark-compacts near heap limit` —
+ * carry `JavaScript heap out of memory` on the same `FATAL ERROR:` line, so requiring the pair is
+ * strict without enumerating V8's wording variants.
+ *
+ * **This replaced an exit-code discriminator, and the reason generalises.** No abort code carries
+ * heap semantics: it names the manner of death, never its cause, and its value is not even stable
+ * across base images — the canonical `mc-server` image exits `139` where a host Node exits `134`,
+ * and it exits `139` whether or not a ceiling was declared. The log line is the only observation
+ * that says *heap*.
+ * @member {RegExp} HEAP_FATAL_LINE
  */
-export const V8_HEAP_ABORT_EXIT_CODE = 134;
+export const HEAP_FATAL_LINE = /FATAL ERROR:[^\n]*JavaScript heap out of memory/;
 
 /**
  * @summary EXHAUSTIVE service classification, declared per key rather than inferred from absence.
@@ -254,6 +261,12 @@ export class ContainerHealthDiagnosisService extends Base {
         churnBaseline = null,
         inspectReadFailed = false,
         plannedRestarts = 0,
+        // Summarized ONCE by the bridge from the same `Config.Cmd` and the same allowlisted log
+        // read it already performs — passed in rather than re-derived here, so there is exactly one
+        // place that decides what "a Node service" and "the log tail" mean.
+        logs = null,
+        nodeCommand = null,
+        declaredHeapCeilingMb = null,
         observedAt = this.now()
     } = {}) {
         this.validateServiceKey(serviceKey);
@@ -280,7 +293,7 @@ export class ContainerHealthDiagnosisService extends Base {
                 details      : {operation: 'inspect'}
             })] : []),
             ...this.collectRestartChurnFacts({serviceKey, churn, observedAt}),
-            ...this.collectLifecycleFacts({serviceKey, inspect, observedAt}),
+            ...this.collectLifecycleFacts({serviceKey, inspect, observedAt, logs, nodeCommand, declaredHeapCeilingMb}),
             ...this.collectStatsFacts({serviceKey, stats, statsSamples, observedAt}),
             ...this.collectEndpointProbeFacts({serviceKey, endpointProbe, observedAt}),
             ...this.collectConfigFacts({serviceKey, configCheck, observedAt}),
@@ -443,9 +456,12 @@ export class ContainerHealthDiagnosisService extends Base {
     /**
      * Collects container lifecycle facts from Docker inspect data.
      * @param {Object} options
+     * @param {Object|null} [options.logs=null] Bounded log summary, for heap attribution.
+     * @param {Boolean|null} [options.nodeCommand=null] Whether `Config.Cmd` invoked Node.
+     * @param {Number|null} [options.declaredHeapCeilingMb=null] Declared ceiling, when observable.
      * @returns {Object[]}
      */
-    collectLifecycleFacts({serviceKey, inspect, observedAt}) {
+    collectLifecycleFacts({serviceKey, inspect, observedAt, logs = null, nodeCommand = null, declaredHeapCeilingMb = null}) {
         if (!inspect || typeof inspect !== 'object') return [];
 
         const
@@ -455,6 +471,8 @@ export class ContainerHealthDiagnosisService extends Base {
             facts       = [];
 
         if (status && !RUNNING_STATES.has(status)) {
+            const heap = classifyHeapExhaustion({logs, nodeCommand, declaredHeapCeilingMb});
+
             facts.push(this.createFact({
                 type         : CONTAINER_HEALTH_FACT_TYPES.containerDown,
                 serviceKey,
@@ -465,11 +483,13 @@ export class ContainerHealthDiagnosisService extends Base {
                     status,
                     exitCode: Number.isFinite(state.ExitCode) ? state.ExitCode : null,
                     error   : typeof state.Error === 'string' ? state.Error : null,
-                    // Carried beside the exit code because the pair is what discriminates: a V8
-                    // self-abort and a cgroup OOM kill are different failures with different heals,
-                    // and the exit code alone cannot tell them apart.
-                    oomKilled         : typeof state.OOMKilled === 'boolean' ? state.OOMKilled : null,
-                    heapAbortCandidate: classifyHeapAbortCandidate(state)
+                    // RAW EVIDENCE, not attribution inputs. Both are worth recording — a cgroup kill
+                    // and a self-abort are different failures — but neither says *heap*, and the
+                    // exit code's value is not even stable across base images.
+                    oomKilled: typeof state.OOMKilled === 'boolean' ? state.OOMKilled : null,
+                    // The attribution, with its own limits attached. `unavailableReason` is what
+                    // keeps a disabled log channel distinguishable from a non-heap death.
+                    ...heap
                 }
             }));
         }
@@ -751,18 +771,25 @@ export class ContainerHealthDiagnosisService extends Base {
             // recorded as a generic crash, so the ceiling was never implicated and the same abort
             // recurred indefinitely. That is why nothing looked broken from the outside.
             //
-            // The reason narrows only when the evidence supports it, and says CANDIDATE because the
-            // discriminating stderr line is not in this payload (see `classifyHeapAbortCandidate`).
-            // A consumer may route on it, but may not restate it as a confirmed heap death.
-            const heapAbortCandidate = downFacts.some(fact =>
-                fact.details?.heapAbortCandidate === true);
+            // The reason narrows only on evidence that NAMES a heap — the strict fatal line on a
+            // Node command. It is an attribution, not a candidate: when the log channel is open the
+            // evidence is conclusive, and when it is not the reason simply stays generic rather
+            // than asserting a weaker version of a claim nothing supports.
+            const heapFact = downFacts.find(fact => fact.details?.heapExhaustion === true);
 
             return {
                 recoveryClass: 'crash',
                 actionClass  : CONTAINER_HEALTH_ACTION_CLASSES.restart,
                 confidence   : downFacts.length ? 0.9 : 0.8,
                 evidenceFacts: this.selectEvidenceFacts(facts, lifecycleFacts),
-                reason       : heapAbortCandidate ? 'lifecycle-crash-heap-abort-candidate' : 'lifecycle-crash'
+                // Only a numeric declared ceiling licenses the wording that implicates one. An
+                // undeclared Node service still attributes the heap death — that population is
+                // precisely where this class was first observed.
+                reason       : heapFact
+                    ? (Number.isFinite(heapFact.details.declaredHeapCeilingMb)
+                        ? 'lifecycle-crash-heap-exhaustion-declared-ceiling'
+                        : 'lifecycle-crash-heap-exhaustion')
+                    : 'lifecycle-crash'
             };
         }
 
@@ -1167,38 +1194,70 @@ export function calculateDockerCpuPercent(stats) {
 }
 
 /**
- * @summary Classifies a stopped container's exit as a CANDIDATE V8 heap abort — never a verdict.
+ * @summary Attributes a container death to V8 heap exhaustion from evidence that NAMES a heap.
  *
- * A Node service that exhausts its declared `--max-old-space-size` aborts itself: V8 prints
- * `FATAL ERROR: … heap limit` and raises `SIGABRT`, so the container exits **134** (`128 + 6`) with
- * `OOMKilled` false — the kernel never intervened. That signature exists only because the ceiling is
- * DECLARED. With no `--max-old-space-size`, V8 picks a heuristic well inside the container allowance
- * and the same exhaustion exits **0** with `OOMKilled` false, which is a failure with no signature at
- * all (the incident this diagnosis descends from).
+ * Two observations, both already produced by `DeploymentStateBridgeService` from the same
+ * `Config.Cmd` and the same allowlisted log read — this re-derives neither:
  *
- * **134 is necessary and NOT sufficient**, which is why this returns a candidate rather than a
- * classification. Every V8 `FATAL ERROR`, every failed assertion and every explicit `abort()` shares
- * the code; the discriminating evidence is the stderr line, and `inspect.State` does not carry it.
- * Naming a verdict the payload cannot support is the defect this whole diagnosis path exists to
- * remove, so the candidate travels with its own limits and a consumer may not promote it.
+ * - **the strict fatal line** (`HEAP_FATAL_LINE`) — the only evidence that says *heap*;
+ * - **`nodeCommand`** — whether the process had a V8 heap to exhaust at all.
  *
- * Tri-state deliberately: `null` means the fields needed to judge were not observed, which must read
- * as absence of signal rather than as a negative. A missing `ExitCode` is not evidence of a healthy
- * exit.
- * @param {Object} state Docker `inspect.State`.
- * @returns {Boolean|null} true = consistent with a heap abort; false = positively something else;
- * null = not observable from this payload.
+ * Both are required. The line alone would attribute a tail that captured another container's
+ * output, or a service that merely logs the phrase; `nodeCommand` alone says nothing about how the
+ * process died.
+ *
+ * **`declaredHeapCeilingMb` is deliberately NOT part of the discriminator.** A missing
+ * `--max-old-space-size` proves the ceiling is UNDECLARED, never that the process is non-Node — and
+ * undeclared-Node is exactly the population the originating incident came from, so scoping to the
+ * ceiling would blind this to the case it exists for. The ceiling is a supporting fact that
+ * licenses stronger *wording*, never the attribution itself.
+ *
+ * Tri-state, and `null` is load-bearing: logs disabled, an unreadable command, or a divergent
+ * command means the question was never asked, which must read as absence of signal rather than as a
+ * negative. `unavailableReason` travels with it so a reader can tell a disabled channel from a
+ * non-heap death — the two are opposite facts that a bare `false` would merge.
+ * @param {Object} options
+ * @param {Object|null} options.logs Bounded log summary (`{text, truncated, …}`) from the bridge.
+ * @param {Boolean|null} options.nodeCommand Whether `Config.Cmd` invoked Node.
+ * @param {Number|null} [options.declaredHeapCeilingMb=null] Declared ceiling, when observable.
+ * @returns {Object} `{heapExhaustion, unavailableReason, declaredHeapCeilingMb}`
  */
-export function classifyHeapAbortCandidate(state) {
-    const
-        exitCode  = Number.isFinite(state?.ExitCode) ? state.ExitCode : null,
-        oomKilled = typeof state?.OOMKilled === 'boolean' ? state.OOMKilled : null;
+export function classifyHeapExhaustion({logs, nodeCommand, declaredHeapCeilingMb = null}) {
+    const unavailable = reason => ({
+        declaredHeapCeilingMb: null,
+        heapExhaustion       : null,
+        unavailableReason    : reason
+    });
 
-    if (exitCode === null || oomKilled === null) return null;
+    // The command decides whether the question is even meaningful, so an unreadable one cannot
+    // produce a negative — a non-Node VERDICT and an unread command are different facts.
+    if (nodeCommand === null || nodeCommand === undefined) return unavailable('command-unreadable');
 
-    // A cgroup kill is a different failure with a different heal — the kernel reclaimed the whole
-    // container, so the V8 ceiling is not implicated even when the exit code matches.
-    return oomKilled === false && exitCode === V8_HEAP_ABORT_EXIT_CODE
+    if (nodeCommand === false) {
+        return {
+            declaredHeapCeilingMb: null,
+            // A positive negative: the process had no V8 heap, so it cannot have exhausted one.
+            heapExhaustion   : false,
+            unavailableReason: null
+        }
+    }
+
+    if (!logs || typeof logs.text !== 'string') return unavailable('logs-unavailable');
+
+    const matched = HEAP_FATAL_LINE.test(logs.text);
+
+    // A truncated tail that does NOT match cannot distinguish "no heap death" from "the line fell
+    // outside the window", so it must not answer. A truncated tail that DOES match is conclusive —
+    // truncation cannot manufacture the line.
+    if (!matched && logs.truncated === true) return unavailable('log-tail-truncated');
+
+    return {
+        // Only a numeric ceiling licenses wording that implicates a DECLARED ceiling; an undeclared
+        // Node service still attributes, without claiming a bound it never had.
+        declaredHeapCeilingMb: matched && Number.isFinite(declaredHeapCeilingMb) ? declaredHeapCeilingMb : null,
+        heapExhaustion       : matched,
+        unavailableReason    : null
+    }
 }
 
 export function calculateDockerMemoryPercent(stats) {

--- a/ai/daemons/orchestrator/services/DeploymentRuntimeAccessService.mjs
+++ b/ai/daemons/orchestrator/services/DeploymentRuntimeAccessService.mjs
@@ -654,14 +654,23 @@ export class DeploymentRuntimeAccessService extends Base {
             // `since` removes that poison, and `until` additionally excludes output from an
             // auto-restart that races after the inspect this interval was derived from. Both
             // bounds or none: a half-bounded slice is not the run the stopped fact names.
-            sinceSeconds  = toUnixSeconds(since),
-            untilSeconds  = toUnixSeconds(until),
-            bounded       = sinceSeconds !== null && untilSeconds !== null && untilSeconds >= sinceSeconds,
+            // The endpoints travel at FULL precision. Docker accepts RFC3339Nano, so flooring to
+            // whole seconds is a choice the transport never imposed — and it is wrong in both
+            // directions: a floored `since` reaches back into the previous incarnation, and a
+            // floored `until` cuts the final sub-second, which is exactly when V8 writes its fatal
+            // line. Truncating the upper edge can therefore discard the evidence being sought.
+            sinceStamp    = normalizeDockerTime(since),
+            untilStamp    = normalizeDockerTime(until),
+            bounded       = sinceStamp !== null && untilStamp !== null &&
+                            Date.parse(untilStamp) >= Date.parse(sinceStamp),
             query         = [
                 'stdout=1',
                 'stderr=1',
                 `tail=${encodeURIComponent(String(tailCount))}`,
-                ...(bounded ? [`since=${sinceSeconds}`, `until=${untilSeconds}`] : [])
+                ...(bounded ? [
+                    `since=${encodeURIComponent(sinceStamp)}`,
+                    `until=${encodeURIComponent(untilStamp)}`
+                ] : [])
             ].join('&'),
             response      = await this.dockerRequest({
                 method: 'GET',
@@ -674,11 +683,18 @@ export class DeploymentRuntimeAccessService extends Base {
             // slice as incarnation-bounded on the strength of this receipt — a caller-supplied
             // boolean would let the claim originate at the layer that wants it to be true.
             data : {
-                appliedSince: bounded ? sinceSeconds : null,
-                appliedUntil: bounded ? untilSeconds : null,
+                // The receipt echoes exactly what was SENT, at the precision it was sent — a
+                // rounded echo would let a consumer believe an endpoint it never got.
+                appliedSince: bounded ? sinceStamp : null,
+                appliedUntil: bounded ? untilStamp : null,
                 bounded,
-                logs        : response.body,
-                tail        : tailCount
+                // The container this slice actually came from. `readObserve` resolves a target per
+                // call, so inspect and logs can land on DIFFERENT containers across a recreate;
+                // without this the consumer cannot tell whether the interval was applied to the
+                // container whose death it is attributing.
+                containerId: target.containerId ?? null,
+                logs       : response.body,
+                tail       : tailCount
             },
             proof     : this.createProofMetadata({envelope: 'read-observe', operation: 'logs', target}),
             statusCode: response.statusCode
@@ -999,21 +1015,26 @@ function createRuntimeAccessError({Type = Error, reason, message, code = null, d
 export default Neo.setupClass(DeploymentRuntimeAccessService);
 
 /**
- * @summary Converts a Docker timestamp to whole Unix seconds, or null when it cannot be trusted.
+ * @summary Validates a Docker timestamp and returns it UNROUNDED, or null when it cannot be trusted.
  *
  * Docker reports an unset time as the zero instant (`0001-01-01T00:00:00Z`), which parses to a
  * valid but meaningless epoch — so a naive parse would hand the log query a bound that looks real.
  * Anything non-positive is therefore refused rather than passed through, which is what keeps the
  * interval fail-closed instead of silently unbounded.
+ *
+ * The value is validated but NOT rounded: Docker accepts RFC3339Nano, and truncating the upper
+ * endpoint would cut the final sub-second in which a fatal line is written.
  * @param {String|Number|null} value
- * @returns {Number|null}
+ * @returns {String|null}
  */
-function toUnixSeconds(value) {
+function normalizeDockerTime(value) {
     if (value === null || value === undefined) return null;
 
-    const parsed = typeof value === 'number' ? value * 1000 : Date.parse(value);
+    const
+        stamp  = typeof value === 'number' ? new Date(value * 1000).toISOString() : String(value),
+        parsed = Date.parse(stamp);
 
     if (!Number.isFinite(parsed) || parsed <= 0) return null;
 
-    return Math.floor(parsed / 1000)
+    return stamp
 }

--- a/ai/daemons/orchestrator/services/DeploymentRuntimeAccessService.mjs
+++ b/ai/daemons/orchestrator/services/DeploymentRuntimeAccessService.mjs
@@ -223,9 +223,11 @@ export class DeploymentRuntimeAccessService extends Base {
      * @param {String} options.serviceKey Allowlisted compose service key.
      * @param {'inspect'|'logs'|'stats'} options.operation Read operation.
      * @param {Number} [options.tail] Log tail count for `logs`.
+     * @param {String|Number} [options.since] Lower bound of the incarnation interval for `logs`.
+     * @param {String|Number} [options.until] Upper bound of the incarnation interval for `logs`.
      * @returns {Promise<Object>} Observation payload plus structured proof metadata.
      */
-    async readObserve({serviceKey, operation = 'inspect', tail} = {}) {
+    async readObserve({serviceKey, operation = 'inspect', tail, since, until} = {}) {
         this.assertEnabled();
         this.assertMechanismSupported();
         this.assertOperationAllowed('read-observe', operation);
@@ -237,7 +239,7 @@ export class DeploymentRuntimeAccessService extends Base {
         }
 
         if (operation === 'logs') {
-            return this.readTargetLogs(target, {tail});
+            return this.readTargetLogs(target, {tail, since, until});
         }
 
         if (operation === 'stats') {
@@ -644,16 +646,40 @@ export class DeploymentRuntimeAccessService extends Base {
      * @param {Number} [options.tail] Log tail count.
      * @returns {Promise<Object>}
      */
-    async readTargetLogs(target, {tail} = {}) {
-        const tailCount = tail ?? this.configValues.logTail ?? 200,
-              response  = await this.dockerRequest({
-                  method: 'GET',
-                  path  : `/containers/${encodeURIComponent(target.containerId)}/logs?stdout=1&stderr=1&tail=${encodeURIComponent(String(tailCount))}`
-              });
+    async readTargetLogs(target, {tail, since, until} = {}) {
+        const
+            tailCount     = tail ?? this.configValues.logTail ?? 200,
+            // The interval is what makes the slice attributable. Docker's log stream spans
+            // restarts, so an unbounded tail can carry a fatal line from a PREVIOUS incarnation —
+            // `since` removes that poison, and `until` additionally excludes output from an
+            // auto-restart that races after the inspect this interval was derived from. Both
+            // bounds or none: a half-bounded slice is not the run the stopped fact names.
+            sinceSeconds  = toUnixSeconds(since),
+            untilSeconds  = toUnixSeconds(until),
+            bounded       = sinceSeconds !== null && untilSeconds !== null && untilSeconds >= sinceSeconds,
+            query         = [
+                'stdout=1',
+                'stderr=1',
+                `tail=${encodeURIComponent(String(tailCount))}`,
+                ...(bounded ? [`since=${sinceSeconds}`, `until=${untilSeconds}`] : [])
+            ].join('&'),
+            response      = await this.dockerRequest({
+                method: 'GET',
+                path  : `/containers/${encodeURIComponent(target.containerId)}/logs?${query}`
+            });
 
         return {
-            ok        : true,
-            data      : {logs: response.body, tail: tailCount},
+            ok   : true,
+            // The APPLIED bounds are echoed, never the requested ones. A consumer may only treat a
+            // slice as incarnation-bounded on the strength of this receipt — a caller-supplied
+            // boolean would let the claim originate at the layer that wants it to be true.
+            data : {
+                appliedSince: bounded ? sinceSeconds : null,
+                appliedUntil: bounded ? untilSeconds : null,
+                bounded,
+                logs        : response.body,
+                tail        : tailCount
+            },
             proof     : this.createProofMetadata({envelope: 'read-observe', operation: 'logs', target}),
             statusCode: response.statusCode
         };
@@ -971,3 +997,23 @@ function createRuntimeAccessError({Type = Error, reason, message, code = null, d
 }
 
 export default Neo.setupClass(DeploymentRuntimeAccessService);
+
+/**
+ * @summary Converts a Docker timestamp to whole Unix seconds, or null when it cannot be trusted.
+ *
+ * Docker reports an unset time as the zero instant (`0001-01-01T00:00:00Z`), which parses to a
+ * valid but meaningless epoch — so a naive parse would hand the log query a bound that looks real.
+ * Anything non-positive is therefore refused rather than passed through, which is what keeps the
+ * interval fail-closed instead of silently unbounded.
+ * @param {String|Number|null} value
+ * @returns {Number|null}
+ */
+function toUnixSeconds(value) {
+    if (value === null || value === undefined) return null;
+
+    const parsed = typeof value === 'number' ? value * 1000 : Date.parse(value);
+
+    if (!Number.isFinite(parsed) || parsed <= 0) return null;
+
+    return Math.floor(parsed / 1000)
+}

--- a/ai/daemons/orchestrator/services/DeploymentStateBridgeService.mjs
+++ b/ai/daemons/orchestrator/services/DeploymentStateBridgeService.mjs
@@ -408,6 +408,15 @@ export class DeploymentStateBridgeService extends Base {
         const inspectReadFailed = inspect === null &&
             errors.some(entry => entry?.operation === 'inspect' || entry?.detail?.operation === 'inspect');
 
+        // Summarized ONCE, here, and reused by both the diagnosis and the published snapshot below.
+        // The heap attribution needs the same two `Config.Cmd` observations this service already
+        // derives (`nodeCommand`, `declaredHeapCeilingMb`) plus the same bounded tail it already
+        // reads — so diagnosis consumes them rather than re-deriving, and there stays exactly one
+        // place that decides what "a Node service" and "the log tail" mean.
+        const
+            inspectSummary = summarizeInspect(inspect),
+            logSummary     = summarizeLogs(logs, bridgeConfig.logMaxBytes);
+
         const diagnosis = this.diagnosisService?.diagnose
             ? this.diagnosisService.diagnose({
                 inspectReadFailed,
@@ -418,6 +427,11 @@ export class DeploymentStateBridgeService extends Base {
                 providerResidency,
                 churnBaseline  : churnBaseline?.unreadable ? undefined : churnBaseline,
                 plannedRestarts: await this.countPlannedRestarts({serviceKey, observedAt}),
+                // `null` when `includeLogs` is off — which must surface as an UNAVAILABLE
+                // attribution, never as "not a heap death". A disabled channel is not evidence.
+                logs                 : logSummary,
+                nodeCommand          : inspectSummary?.nodeCommand ?? null,
+                declaredHeapCeilingMb: inspectSummary?.declaredHeapCeilingMb ?? null,
                 observedAt
             })
             : null;
@@ -444,9 +458,9 @@ export class DeploymentStateBridgeService extends Base {
             targetIdentity: {kind: 'compose-service', id: serviceKey},
             observedAt,
             status        : errors.length > 0 ? 'degraded' : 'available',
-            inspect       : summarizeInspect(inspect),
+            inspect       : inspectSummary,
             stats         : summarizeStats(stats),
-            logs          : summarizeLogs(logs, bridgeConfig.logMaxBytes),
+            logs          : logSummary,
             providerResidency,
             // EVERY snapshot, independent of load. The classification, the threshold that applies to
             // it, and the measured window state used to live only inside a sustained-saturation fact,

--- a/ai/daemons/orchestrator/services/DeploymentStateBridgeService.mjs
+++ b/ai/daemons/orchestrator/services/DeploymentStateBridgeService.mjs
@@ -389,7 +389,15 @@ export class DeploymentStateBridgeService extends Base {
         const bridgeConfig = AiConfig.orchestrator.deploymentStateBridge;
 
         if (bridgeConfig.includeLogs) {
-            logs = await read('logs', {tail: bridgeConfig.logTail});
+            // The interval is derived from the SAME inspect this snapshot publishes, so the slice
+            // and the stopped fact describe one incarnation. A running container has no
+            // `FinishedAt`, so it yields no interval and the read stays unbounded — correct, since
+            // there is no death to attribute yet.
+            logs = await read('logs', {
+                since: inspect?.State?.StartedAt  ?? null,
+                tail : bridgeConfig.logTail,
+                until: inspect?.State?.FinishedAt ?? null
+            });
         }
 
         if (stats) {
@@ -1169,10 +1177,17 @@ function summarizeLogs(logs, maxBytes) {
     const bounded = boundUtf8Tail(logs.logs, maxBytes);
 
     return {
-        tail     : Number.isFinite(logs.tail) ? logs.tail : null,
-        text     : bounded.text,
-        truncated: bounded.truncated,
-        maxBytes : bounded.maxBytes
+        // `incarnationBounded` is set ONLY from the producer's echoed receipt — never from a
+        // caller-supplied flag and never inferred here. A consumer that attributes a death to this
+        // slice is trusting that the daemon actually applied the interval, so the claim has to
+        // originate where it was applied rather than where it is wanted.
+        appliedSince      : Number.isFinite(logs.appliedSince) ? logs.appliedSince : null,
+        appliedUntil      : Number.isFinite(logs.appliedUntil) ? logs.appliedUntil : null,
+        incarnationBounded: logs.bounded === true,
+        maxBytes          : bounded.maxBytes,
+        tail              : Number.isFinite(logs.tail) ? logs.tail : null,
+        text              : bounded.text,
+        truncated         : bounded.truncated
     };
 }
 

--- a/ai/daemons/orchestrator/services/DeploymentStateBridgeService.mjs
+++ b/ai/daemons/orchestrator/services/DeploymentStateBridgeService.mjs
@@ -372,10 +372,17 @@ export class DeploymentStateBridgeService extends Base {
             logs              = null,
             providerResidency = null;
 
+        // Retained per operation because target IDENTITY, not just the payload, decides whether two
+        // reads describe the same container. `readObserve` resolves a target per call, so a compose
+        // recreate between inspect and logs lands them on different containers — and the payloads
+        // alone cannot show it.
+        const proofByOperation = {};
+
         const read = async (operation, args = {}) => {
             try {
                 const result = await this.runtimeAccessService.readObserve({serviceKey, operation, ...args});
                 proofs.push(result.proof);
+                proofByOperation[operation] = result.proof;
                 return result.data;
             } catch (error) {
                 errors.push(summarizeRuntimeAccessError(error, {operation}));
@@ -423,7 +430,15 @@ export class DeploymentStateBridgeService extends Base {
         // place that decides what "a Node service" and "the log tail" mean.
         const
             inspectSummary = summarizeInspect(inspect),
-            logSummary     = summarizeLogs(logs, bridgeConfig.logMaxBytes);
+            // The interval proves a TIME RANGE; this proves it was applied to the container whose
+            // inspect produced the stopped fact. Both are required before a slice may be called
+            // incarnation-bounded — a matching range on a different container is not this run.
+            sameTarget     = Boolean(
+                proofByOperation.logs?.target?.containerId &&
+                proofByOperation.inspect?.target?.containerId &&
+                proofByOperation.logs.target.containerId === proofByOperation.inspect.target.containerId
+            ),
+            logSummary     = summarizeLogs(logs, bridgeConfig.logMaxBytes, {sameTarget});
 
         const diagnosis = this.diagnosisService?.diagnose
             ? this.diagnosisService.diagnose({
@@ -1171,7 +1186,7 @@ function summarizeStats(stats) {
     };
 }
 
-function summarizeLogs(logs, maxBytes) {
+function summarizeLogs(logs, maxBytes, {sameTarget = false} = {}) {
     if (!logs || typeof logs !== 'object') return null;
 
     const bounded = boundUtf8Tail(logs.logs, maxBytes);
@@ -1181,9 +1196,11 @@ function summarizeLogs(logs, maxBytes) {
         // caller-supplied flag and never inferred here. A consumer that attributes a death to this
         // slice is trusting that the daemon actually applied the interval, so the claim has to
         // originate where it was applied rather than where it is wanted.
-        appliedSince      : Number.isFinite(logs.appliedSince) ? logs.appliedSince : null,
-        appliedUntil      : Number.isFinite(logs.appliedUntil) ? logs.appliedUntil : null,
-        incarnationBounded: logs.bounded === true,
+        appliedSince: typeof logs.appliedSince === 'string' ? logs.appliedSince : null,
+        appliedUntil: typeof logs.appliedUntil === 'string' ? logs.appliedUntil : null,
+        // BOTH proofs or nothing: the producer applied a real interval, AND it applied it to the
+        // same container the stopped fact describes.
+        incarnationBounded: logs.bounded === true && sameTarget === true,
         maxBytes          : bounded.maxBytes,
         tail              : Number.isFinite(logs.tail) ? logs.tail : null,
         text              : bounded.text,

--- a/test/playwright/unit/ai/daemons/orchestrator/services/ContainerHealthDiagnosisService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/ContainerHealthDiagnosisService.spec.mjs
@@ -125,7 +125,7 @@ test.describe('Neo.ai.daemons.services.ContainerHealthDiagnosisService', () => {
     });
 
     test('heap attribution needs BOTH the fatal line and a Node command', () => {
-        const fatal = {text: 'FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of memory', truncated: false};
+        const fatal = {text: 'FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of memory', truncated: false, incarnationBounded: true};
 
         expect(classifyHeapExhaustion({logs: fatal, nodeCommand: true}).heapExhaustion,
             'the line names a heap and the command proves there was one to exhaust').toBe(true);
@@ -140,7 +140,7 @@ test.describe('Neo.ai.daemons.services.ContainerHealthDiagnosisService', () => {
     });
 
     test('the declared ceiling licenses WORDING, never the attribution itself', () => {
-        const fatal = {text: 'FATAL ERROR: Ineffective mark-compacts near heap limit Allocation failed - JavaScript heap out of memory', truncated: false};
+        const fatal = {text: 'FATAL ERROR: Ineffective mark-compacts near heap limit Allocation failed - JavaScript heap out of memory', truncated: false, incarnationBounded: true};
 
         // The population the originating incident came from: Node, no declared ceiling, dead of a
         // heap. Scoping attribution to the ceiling would blind this to exactly that case.
@@ -152,7 +152,7 @@ test.describe('Neo.ai.daemons.services.ContainerHealthDiagnosisService', () => {
     });
 
     test('a kernel OOM kill alongside a matching tail is an unresolvable conflict, not a verdict', () => {
-        const fatal = {text: 'FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of memory', truncated: false};
+        const fatal = {text: 'FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of memory', truncated: false, incarnationBounded: true};
 
         // The kernel and V8 make CONTRADICTORY claims about the same death and this payload cannot
         // adjudicate: either V8 exhausted its heap and the container was reaped afterwards, or the
@@ -168,6 +168,31 @@ test.describe('Neo.ai.daemons.services.ContainerHealthDiagnosisService', () => {
         expect(classifyHeapExhaustion({logs: fatal, nodeCommand: true}).heapExhaustion).toBe(true);
     });
 
+    test('an unbounded slice refuses to attribute — the tail spans restarts', () => {
+        const fatal = 'FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of memory';
+
+        // Emmy's specimen: an old fatal line, a healthy boot, then an unrelated current crash. A
+        // match anywhere in an unbounded slice would name the wrong cause with full confidence.
+        const stale = {
+            text     : `${fatal}\n[restart] healthy boot\nTypeError: unrelated current crash`,
+            truncated: false
+        };
+
+        expect(classifyHeapExhaustion({logs: stale, nodeCommand: true}))
+            .toMatchObject({heapExhaustion: null, unavailableReason: 'log-incarnation-unbounded'});
+
+        // Absent the producer's bound, even a clean single-line slice must refuse — the classifier
+        // cannot tell a current death from a historical one without being told.
+        expect(classifyHeapExhaustion({logs: {text: fatal, truncated: false}, nodeCommand: true}).unavailableReason)
+            .toBe('log-incarnation-unbounded');
+
+        // With the bound stated, the same evidence attributes.
+        expect(classifyHeapExhaustion({
+            logs       : {text: fatal, truncated: false, incarnationBounded: true},
+            nodeCommand: true
+        }).heapExhaustion).toBe(true);
+    });
+
     test('unavailable is null WITH a reason — a disabled channel is not a negative', () => {
         expect(classifyHeapExhaustion({logs: null, nodeCommand: true}))
             .toMatchObject({heapExhaustion: null, unavailableReason: 'logs-unavailable'});
@@ -180,10 +205,19 @@ test.describe('Neo.ai.daemons.services.ContainerHealthDiagnosisService', () => {
         expect(classifyHeapExhaustion({logs: {text: 'nothing here', truncated: true}, nodeCommand: true}))
             .toMatchObject({heapExhaustion: null, unavailableReason: 'log-tail-truncated'});
 
+        // Truncation cannot manufacture the line, so a matching truncated tail stays conclusive
+        // ABOUT TRUNCATION — but it still needs the incarnation bound, because a surviving line can
+        // belong to an earlier run. Both conditions, not either.
+        expect(classifyHeapExhaustion({
+            logs       : {text: 'FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of memory', truncated: true, incarnationBounded: true},
+            nodeCommand: true
+        }).heapExhaustion, 'a truncated but incarnation-bounded match is conclusive').toBe(true);
+
         expect(classifyHeapExhaustion({
             logs       : {text: 'FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of memory', truncated: true},
             nodeCommand: true
-        }).heapExhaustion, 'a truncated tail that DOES match is still conclusive').toBe(true);
+        }).unavailableReason, 'truncation-conclusiveness does not substitute for the incarnation bound')
+            .toBe('log-incarnation-unbounded');
     });
 
     test('the crash diagnosis names the heap exhaustion without changing the action', () => {
@@ -192,7 +226,7 @@ test.describe('Neo.ai.daemons.services.ContainerHealthDiagnosisService', () => {
         const decision = service.diagnose({
             serviceKey           : 'memory',
             inspect              : runningInspect({Status: 'exited', ExitCode: 139, OOMKilled: false}),
-            logs                 : {text: 'FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of memory', truncated: false},
+            logs                 : {text: 'FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of memory', truncated: false, incarnationBounded: true},
             nodeCommand          : true,
             declaredHeapCeilingMb: 768
         });
@@ -222,7 +256,7 @@ test.describe('Neo.ai.daemons.services.ContainerHealthDiagnosisService', () => {
         const decision = service.diagnose({
             serviceKey : 'memory',
             inspect    : runningInspect({Status: 'exited', ExitCode: 139, OOMKilled: false}),
-            logs       : {text: 'FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of memory', truncated: false},
+            logs       : {text: 'FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of memory', truncated: false, incarnationBounded: true},
             nodeCommand: true
         });
 

--- a/test/playwright/unit/ai/daemons/orchestrator/services/ContainerHealthDiagnosisService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/ContainerHealthDiagnosisService.spec.mjs
@@ -151,6 +151,23 @@ test.describe('Neo.ai.daemons.services.ContainerHealthDiagnosisService', () => {
             .toMatchObject({heapExhaustion: true, declaredHeapCeilingMb: 768});
     });
 
+    test('a kernel OOM kill alongside a matching tail is an unresolvable conflict, not a verdict', () => {
+        const fatal = {text: 'FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of memory', truncated: false};
+
+        // The kernel and V8 make CONTRADICTORY claims about the same death and this payload cannot
+        // adjudicate: either V8 exhausted its heap and the container was reaped afterwards, or the
+        // cgroup killed a container whose slice still carries an older fatal line.
+        expect(classifyHeapExhaustion({logs: fatal, nodeCommand: true, oomKilled: true}))
+            .toMatchObject({heapExhaustion: null, unavailableReason: 'evidence-conflict'});
+
+        // No conflict when the kernel did not intervene — the attribution stands.
+        expect(classifyHeapExhaustion({logs: fatal, nodeCommand: true, oomKilled: false}).heapExhaustion)
+            .toBe(true);
+
+        // And an unobserved oomKilled must not manufacture a conflict.
+        expect(classifyHeapExhaustion({logs: fatal, nodeCommand: true}).heapExhaustion).toBe(true);
+    });
+
     test('unavailable is null WITH a reason — a disabled channel is not a negative', () => {
         expect(classifyHeapExhaustion({logs: null, nodeCommand: true}))
             .toMatchObject({heapExhaustion: null, unavailableReason: 'logs-unavailable'});

--- a/test/playwright/unit/ai/daemons/orchestrator/services/ContainerHealthDiagnosisService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/ContainerHealthDiagnosisService.spec.mjs
@@ -18,8 +18,7 @@ import {
     evaluateRestartChurn,
     calculateDockerCpuPercent,
     calculateDockerMemoryPercent,
-    classifyHeapAbortCandidate,
-    V8_HEAP_ABORT_EXIT_CODE
+    classifyHeapExhaustion
 } from '../../../../../../../ai/daemons/orchestrator/services/ContainerHealthDiagnosisService.mjs';
 
 const OBSERVED_AT = 1710000000000;
@@ -125,46 +124,60 @@ test.describe('Neo.ai.daemons.services.ContainerHealthDiagnosisService', () => {
             .toContain(CONTAINER_HEALTH_FACT_TYPES.containerDown);
     });
 
-    test('a heap-abort candidate needs BOTH the abort code and a kernel that did not intervene', () => {
-        // 134 is `128 + SIGABRT`, shared by every V8 FATAL ERROR and assertion failure, so it names
-        // the manner of death and not its cause. The pair is the discriminator.
-        expect(classifyHeapAbortCandidate({ExitCode: V8_HEAP_ABORT_EXIT_CODE, OOMKilled: false}),
-            'a self-abort the kernel did not cause is consistent with a heap ceiling').toBe(true);
+    test('heap attribution needs BOTH the fatal line and a Node command', () => {
+        const fatal = {text: 'FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of memory', truncated: false};
 
-        expect(classifyHeapAbortCandidate({ExitCode: V8_HEAP_ABORT_EXIT_CODE, OOMKilled: true}),
-            'a cgroup kill reclaimed the whole container, so the V8 ceiling is not implicated').toBe(false);
+        expect(classifyHeapExhaustion({logs: fatal, nodeCommand: true}).heapExhaustion,
+            'the line names a heap and the command proves there was one to exhaust').toBe(true);
 
-        expect(classifyHeapAbortCandidate({ExitCode: 137, OOMKilled: true}),
-            'SIGKILL under an OOM kill is the cgroup path, not a V8 self-abort').toBe(false);
+        // The scoping red control. A non-Node process cannot exhaust a V8 heap, so a tail carrying
+        // the phrase (another container's output, or a service logging the text) must not attribute.
+        expect(classifyHeapExhaustion({logs: fatal, nodeCommand: false}).heapExhaustion,
+            'a non-Node service has no V8 heap, whatever the tail contains').toBe(false);
 
-        // The incident this diagnosis descends from: with NO declared ceiling, V8 picks a heuristic
-        // inside the container allowance and the same exhaustion exits 0 — a failure with no
-        // signature. Declaring the ceiling is what produced a signature to read at all.
-        expect(classifyHeapAbortCandidate({ExitCode: 0, OOMKilled: false}),
-            'an undeclared-ceiling exhaustion leaves no signature and must not be inferred').toBe(false);
+        expect(classifyHeapExhaustion({logs: {text: 'ECONNREFUSED, exiting', truncated: false}, nodeCommand: true}).heapExhaustion,
+            'a Node service that died of something else is a positive negative').toBe(false);
     });
 
-    test('an unobservable exit is null, never a negative — absence of signal is not evidence of health', () => {
-        expect(classifyHeapAbortCandidate({ExitCode: V8_HEAP_ABORT_EXIT_CODE}),
-            'no OOMKilled field means the discriminator was not observed').toBeNull();
+    test('the declared ceiling licenses WORDING, never the attribution itself', () => {
+        const fatal = {text: 'FATAL ERROR: Ineffective mark-compacts near heap limit Allocation failed - JavaScript heap out of memory', truncated: false};
 
-        expect(classifyHeapAbortCandidate({OOMKilled: false}),
-            'no ExitCode means there is nothing to classify').toBeNull();
+        // The population the originating incident came from: Node, no declared ceiling, dead of a
+        // heap. Scoping attribution to the ceiling would blind this to exactly that case.
+        expect(classifyHeapExhaustion({logs: fatal, nodeCommand: true, declaredHeapCeilingMb: null}))
+            .toMatchObject({heapExhaustion: true, declaredHeapCeilingMb: null});
 
-        expect(classifyHeapAbortCandidate({}), 'an empty state observes neither field').toBeNull();
-        expect(classifyHeapAbortCandidate(undefined), 'a missing state must not throw').toBeNull();
+        expect(classifyHeapExhaustion({logs: fatal, nodeCommand: true, declaredHeapCeilingMb: 768}))
+            .toMatchObject({heapExhaustion: true, declaredHeapCeilingMb: 768});
     });
 
-    test('the crash diagnosis names a heap-abort candidate without changing the action', () => {
+    test('unavailable is null WITH a reason — a disabled channel is not a negative', () => {
+        expect(classifyHeapExhaustion({logs: null, nodeCommand: true}))
+            .toMatchObject({heapExhaustion: null, unavailableReason: 'logs-unavailable'});
+
+        expect(classifyHeapExhaustion({logs: {text: 'x', truncated: false}, nodeCommand: null}))
+            .toMatchObject({heapExhaustion: null, unavailableReason: 'command-unreadable'});
+
+        // A truncated tail that does not match cannot separate "no heap death" from "the line fell
+        // outside the window" — but truncation cannot manufacture the line, so a match still counts.
+        expect(classifyHeapExhaustion({logs: {text: 'nothing here', truncated: true}, nodeCommand: true}))
+            .toMatchObject({heapExhaustion: null, unavailableReason: 'log-tail-truncated'});
+
+        expect(classifyHeapExhaustion({
+            logs       : {text: 'FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of memory', truncated: true},
+            nodeCommand: true
+        }).heapExhaustion, 'a truncated tail that DOES match is still conclusive').toBe(true);
+    });
+
+    test('the crash diagnosis names the heap exhaustion without changing the action', () => {
         const service = createService();
 
         const decision = service.diagnose({
-            serviceKey: 'memory',
-            inspect   : runningInspect({
-                Status   : 'exited',
-                ExitCode : V8_HEAP_ABORT_EXIT_CODE,
-                OOMKilled: false
-            })
+            serviceKey           : 'memory',
+            inspect              : runningInspect({Status: 'exited', ExitCode: 139, OOMKilled: false}),
+            logs                 : {text: 'FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of memory', truncated: false},
+            nodeCommand          : true,
+            declaredHeapCeilingMb: 768
         });
 
         // The action was never wrong — a stopped container is restarted either way. The cause is
@@ -172,35 +185,46 @@ test.describe('Neo.ai.daemons.services.ContainerHealthDiagnosisService', () => {
         expect(decision.actionClass, 'attribution must not change the heal')
             .toBe(CONTAINER_HEALTH_ACTION_CLASSES.restart);
 
-        expect(decision.diagnosis.details.classificationReason,
-            'the reason must name the candidate cause rather than a generic crash')
-            .toBe('lifecycle-crash-heap-abort-candidate');
+        expect(decision.diagnosis.details.classificationReason)
+            .toBe('lifecycle-crash-heap-exhaustion-declared-ceiling');
 
         const downFact = decision.facts.find(fact =>
             fact.type === CONTAINER_HEALTH_FACT_TYPES.containerDown);
 
-        expect(downFact.details, 'the fact carries the evidence its reason rests on').toMatchObject({
-            exitCode          : V8_HEAP_ABORT_EXIT_CODE,
-            heapAbortCandidate: true,
-            oomKilled         : false
+        expect(downFact.details, 'raw evidence and attribution travel together').toMatchObject({
+            declaredHeapCeilingMb: 768,
+            exitCode             : 139,
+            heapExhaustion       : true,
+            oomKilled            : false
         });
     });
 
-    test('a cgroup OOM kill keeps the generic crash reason', () => {
+    test('an undeclared Node service still attributes, without claiming a ceiling it never had', () => {
         const service = createService();
 
         const decision = service.diagnose({
-            serviceKey: 'memory',
-            inspect   : runningInspect({Status: 'exited', ExitCode: 137, OOMKilled: true})
+            serviceKey : 'memory',
+            inspect    : runningInspect({Status: 'exited', ExitCode: 139, OOMKilled: false}),
+            logs       : {text: 'FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of memory', truncated: false},
+            nodeCommand: true
         });
 
-        // The red control for the narrowing: a memory-related death that is NOT a V8 ceiling must not
-        // acquire the heap reason, or the attribution is decoration rather than discrimination.
+        expect(decision.diagnosis.details.classificationReason).toBe('lifecycle-crash-heap-exhaustion');
+    });
+
+    test('a non-heap death keeps the generic crash reason', () => {
+        const service = createService();
+
+        const decision = service.diagnose({
+            serviceKey : 'memory',
+            inspect    : runningInspect({Status: 'exited', ExitCode: 137, OOMKilled: true}),
+            logs       : {text: 'terminated', truncated: false},
+            nodeCommand: true
+        });
+
+        // The narrowing must discriminate rather than decorate.
         expect(decision.diagnosis.details.classificationReason).toBe('lifecycle-crash');
         expect(decision.actionClass).toBe(CONTAINER_HEALTH_ACTION_CLASSES.restart);
-        expect(decision.facts.find(fact =>
-            fact.type === CONTAINER_HEALTH_FACT_TYPES.containerDown).details.heapAbortCandidate)
-            .toBe(false);
     });
 
     test('requires multi-fact evidence before diagnosing unhealthy probe-like states', () => {

--- a/test/playwright/unit/ai/daemons/orchestrator/services/ContainerHealthDiagnosisService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/ContainerHealthDiagnosisService.spec.mjs
@@ -17,7 +17,9 @@ import {
     isStoreBackedService,
     evaluateRestartChurn,
     calculateDockerCpuPercent,
-    calculateDockerMemoryPercent
+    calculateDockerMemoryPercent,
+    classifyHeapAbortCandidate,
+    V8_HEAP_ABORT_EXIT_CODE
 } from '../../../../../../../ai/daemons/orchestrator/services/ContainerHealthDiagnosisService.mjs';
 
 const OBSERVED_AT = 1710000000000;
@@ -121,6 +123,84 @@ test.describe('Neo.ai.daemons.services.ContainerHealthDiagnosisService', () => {
         });
         expect(decision.diagnosis.evidenceFacts.map(fact => fact.type))
             .toContain(CONTAINER_HEALTH_FACT_TYPES.containerDown);
+    });
+
+    test('a heap-abort candidate needs BOTH the abort code and a kernel that did not intervene', () => {
+        // 134 is `128 + SIGABRT`, shared by every V8 FATAL ERROR and assertion failure, so it names
+        // the manner of death and not its cause. The pair is the discriminator.
+        expect(classifyHeapAbortCandidate({ExitCode: V8_HEAP_ABORT_EXIT_CODE, OOMKilled: false}),
+            'a self-abort the kernel did not cause is consistent with a heap ceiling').toBe(true);
+
+        expect(classifyHeapAbortCandidate({ExitCode: V8_HEAP_ABORT_EXIT_CODE, OOMKilled: true}),
+            'a cgroup kill reclaimed the whole container, so the V8 ceiling is not implicated').toBe(false);
+
+        expect(classifyHeapAbortCandidate({ExitCode: 137, OOMKilled: true}),
+            'SIGKILL under an OOM kill is the cgroup path, not a V8 self-abort').toBe(false);
+
+        // The incident this diagnosis descends from: with NO declared ceiling, V8 picks a heuristic
+        // inside the container allowance and the same exhaustion exits 0 — a failure with no
+        // signature. Declaring the ceiling is what produced a signature to read at all.
+        expect(classifyHeapAbortCandidate({ExitCode: 0, OOMKilled: false}),
+            'an undeclared-ceiling exhaustion leaves no signature and must not be inferred').toBe(false);
+    });
+
+    test('an unobservable exit is null, never a negative — absence of signal is not evidence of health', () => {
+        expect(classifyHeapAbortCandidate({ExitCode: V8_HEAP_ABORT_EXIT_CODE}),
+            'no OOMKilled field means the discriminator was not observed').toBeNull();
+
+        expect(classifyHeapAbortCandidate({OOMKilled: false}),
+            'no ExitCode means there is nothing to classify').toBeNull();
+
+        expect(classifyHeapAbortCandidate({}), 'an empty state observes neither field').toBeNull();
+        expect(classifyHeapAbortCandidate(undefined), 'a missing state must not throw').toBeNull();
+    });
+
+    test('the crash diagnosis names a heap-abort candidate without changing the action', () => {
+        const service = createService();
+
+        const decision = service.diagnose({
+            serviceKey: 'memory',
+            inspect   : runningInspect({
+                Status   : 'exited',
+                ExitCode : V8_HEAP_ABORT_EXIT_CODE,
+                OOMKilled: false
+            })
+        });
+
+        // The action was never wrong — a stopped container is restarted either way. The cause is
+        // what was missing, and a restart that never implicates the ceiling repeats forever.
+        expect(decision.actionClass, 'attribution must not change the heal')
+            .toBe(CONTAINER_HEALTH_ACTION_CLASSES.restart);
+
+        expect(decision.diagnosis.details.classificationReason,
+            'the reason must name the candidate cause rather than a generic crash')
+            .toBe('lifecycle-crash-heap-abort-candidate');
+
+        const downFact = decision.facts.find(fact =>
+            fact.type === CONTAINER_HEALTH_FACT_TYPES.containerDown);
+
+        expect(downFact.details, 'the fact carries the evidence its reason rests on').toMatchObject({
+            exitCode          : V8_HEAP_ABORT_EXIT_CODE,
+            heapAbortCandidate: true,
+            oomKilled         : false
+        });
+    });
+
+    test('a cgroup OOM kill keeps the generic crash reason', () => {
+        const service = createService();
+
+        const decision = service.diagnose({
+            serviceKey: 'memory',
+            inspect   : runningInspect({Status: 'exited', ExitCode: 137, OOMKilled: true})
+        });
+
+        // The red control for the narrowing: a memory-related death that is NOT a V8 ceiling must not
+        // acquire the heap reason, or the attribution is decoration rather than discrimination.
+        expect(decision.diagnosis.details.classificationReason).toBe('lifecycle-crash');
+        expect(decision.actionClass).toBe(CONTAINER_HEALTH_ACTION_CLASSES.restart);
+        expect(decision.facts.find(fact =>
+            fact.type === CONTAINER_HEALTH_FACT_TYPES.containerDown).details.heapAbortCandidate)
+            .toBe(false);
     });
 
     test('requires multi-fact evidence before diagnosing unhealthy probe-like states', () => {

--- a/test/playwright/unit/ai/daemons/orchestrator/services/DeploymentRuntimeAccessService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/DeploymentRuntimeAccessService.spec.mjs
@@ -168,12 +168,69 @@ test.describe('Neo.ai.daemons.services.DeploymentRuntimeAccessService', () => {
         const logs  = await service.readObserve({serviceKey: 'mc-server', operation: 'logs', tail: 25});
         const stats = await service.readObserve({serviceKey: 'mc-server', operation: 'stats'});
 
-        expect(logs.data).toEqual({logs: 'service booted', tail: 25});
+        // No interval requested, so the receipt must say so — `bounded: false` is what keeps a
+        // consumer from treating an unbounded slice as attributable to one incarnation.
+        expect(logs.data).toEqual({
+            appliedSince: null,
+            appliedUntil: null,
+            bounded     : false,
+            logs        : 'service booted',
+            tail        : 25
+        });
         expect(logs.proof.auditLabel).toBe('read-observe:logs');
         expect(stats.data).toEqual({memory_stats: {usage: 42}});
         expect(stats.proof.auditLabel).toBe('read-observe:stats');
         expect(calls.some(call => call.path === '/containers/container-abc/logs?stdout=1&stderr=1&tail=25')).toBe(true);
         expect(calls.some(call => call.path === '/containers/container-abc/stats?stream=false')).toBe(true);
+    });
+
+    test('a valid incarnation interval reaches the Docker query AND is echoed as applied', async () => {
+        const {service, calls} = createService({logText: 'FATAL ERROR'});
+
+        const logs = await service.readObserve({
+            serviceKey: 'mc-server',
+            operation : 'logs',
+            since     : '2026-08-08T20:00:00.000Z',
+            tail      : 25,
+            until     : '2026-08-08T20:05:00.000Z'
+        });
+
+        // The URL carries the interval — the bound is applied by the daemon, not simulated here.
+        expect(calls.some(call => call.path.includes('since=1786219200') && call.path.includes('until=1786219500')))
+            .toBe(true);
+
+        // And the receipt proves what was applied, which is the ONLY thing a consumer may trust.
+        expect(logs.data).toMatchObject({
+            appliedSince: 1786219200,
+            appliedUntil: 1786219500,
+            bounded     : true
+        });
+    });
+
+    test('an unusable bound stays unbounded rather than half-applied', async () => {
+        const {service, calls} = createService({logText: 'x'});
+
+        // Docker reports an unset time as the zero instant, which parses to a valid but meaningless
+        // epoch. Passing that through would hand the query a bound that looks real.
+        const zeroInstant = await service.readObserve({
+            serviceKey: 'mc-server',
+            operation : 'logs',
+            since     : '0001-01-01T00:00:00Z',
+            until     : '0001-01-01T00:00:00Z'
+        });
+
+        expect(zeroInstant.data.bounded, 'the zero instant is not a usable bound').toBe(false);
+
+        // A running container has a start but no finish — half an interval is not the incarnation.
+        const halfOpen = await service.readObserve({
+            serviceKey: 'mc-server',
+            operation : 'logs',
+            since     : '2026-08-08T20:00:00.000Z',
+            until     : null
+        });
+
+        expect(halfOpen.data.bounded, 'a missing upper bound cannot exclude a racing restart').toBe(false);
+        expect(calls.every(call => !call.path.includes('since=')), 'no partial interval reaches the query').toBe(true);
     });
 
     test('applyLifecycle restart uses the lifecycle-write envelope and POSTs to Docker restart', async () => {

--- a/test/playwright/unit/ai/daemons/orchestrator/services/DeploymentRuntimeAccessService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/DeploymentRuntimeAccessService.spec.mjs
@@ -174,6 +174,7 @@ test.describe('Neo.ai.daemons.services.DeploymentRuntimeAccessService', () => {
             appliedSince: null,
             appliedUntil: null,
             bounded     : false,
+            containerId : 'container-abc',
             logs        : 'service booted',
             tail        : 25
         });
@@ -196,15 +197,40 @@ test.describe('Neo.ai.daemons.services.DeploymentRuntimeAccessService', () => {
         });
 
         // The URL carries the interval — the bound is applied by the daemon, not simulated here.
-        expect(calls.some(call => call.path.includes('since=1786219200') && call.path.includes('until=1786219500')))
+        expect(calls.some(call => call.path.includes('since=') && call.path.includes('until=')))
             .toBe(true);
 
         // And the receipt proves what was applied, which is the ONLY thing a consumer may trust.
         expect(logs.data).toMatchObject({
-            appliedSince: 1786219200,
-            appliedUntil: 1786219500,
-            bounded     : true
+            appliedSince: '2026-08-08T20:00:00.000Z',
+            appliedUntil: '2026-08-08T20:05:00.000Z',
+            bounded     : true,
+            containerId : 'container-abc'
         });
+    });
+
+    test('sub-second precision survives — a floored upper bound would cut the fatal line', async () => {
+        const {service, calls} = createService({logText: 'FATAL ERROR'});
+
+        // V8 writes its fatal line in the final moments before the process dies. Flooring
+        // `until` to whole seconds discards up to a second of output at exactly that edge —
+        // the evidence being sought — while flooring `since` reaches back into the previous
+        // incarnation. Docker accepts RFC3339Nano, so neither rounding is imposed by transport.
+        const logs = await service.readObserve({
+            serviceKey: 'mc-server',
+            operation : 'logs',
+            since     : '2026-08-08T20:00:00.900Z',
+            until     : '2026-08-08T20:05:00.900Z'
+        });
+
+        const path = calls.find(call => call.path.includes('until='))?.path ?? '';
+
+        expect(decodeURIComponent(path), 'the endpoints reach Docker unrounded')
+            .toContain('until=2026-08-08T20:05:00.900Z');
+        expect(decodeURIComponent(path)).toContain('since=2026-08-08T20:00:00.900Z');
+
+        expect(logs.data.appliedUntil, 'the receipt echoes the precision it actually sent')
+            .toBe('2026-08-08T20:05:00.900Z');
     });
 
     test('an unusable bound stays unbounded rather than half-applied', async () => {

--- a/test/playwright/unit/ai/daemons/orchestrator/services/DeploymentStateBridgeService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/DeploymentStateBridgeService.spec.mjs
@@ -204,6 +204,64 @@ test.describe('Neo.ai.daemons.services.DeploymentStateBridgeService', () => {
         });
     });
 
+    test('a logs read that landed on a DIFFERENT container is never incarnation-bounded', async () => {
+        // `readObserve` resolves a target per call, so a compose recreate between inspect and logs
+        // lands them on different containers. A legitimately-applied interval on the WRONG container
+        // is not this incarnation — and the payloads alone cannot show it, only the proof targets can.
+        const runtimeAccessService = {
+            async readObserve({operation}) {
+                if (operation === 'inspect') {
+                    return {
+                        data: {
+                            Config: {Cmd: ['node', 'server.mjs']},
+                            State : {
+                                FinishedAt: '2026-08-08T20:05:00.900Z',
+                                Health    : {Status: 'unhealthy'},
+                                StartedAt : '2026-08-08T20:00:00.900Z',
+                                Status    : 'exited'
+                            }
+                        },
+                        proof: {operation: 'inspect', target: {containerId: 'container-A'}}
+                    };
+                }
+
+                if (operation === 'logs') {
+                    return {
+                        data: {
+                            appliedSince: '2026-08-08T20:00:00.900Z',
+                            appliedUntil: '2026-08-08T20:05:00.900Z',
+                            bounded     : true,
+                            containerId : 'container-B',
+                            logs        : 'FATAL ERROR: Reached heap limit - JavaScript heap out of memory',
+                            tail        : 25
+                        },
+                        proof: {operation: 'logs', target: {containerId: 'container-B'}}
+                    };
+                }
+
+                return {data: null, proof: {operation}};
+            }
+        };
+
+        let diagnoseArgs = null;
+
+        const service = createService({
+            diagnosisService: {
+                diagnose(args) {
+                    diagnoseArgs = args;
+                    return {status: 'diagnosed'}
+                }
+            },
+            runtimeAccessService
+        });
+
+        const snapshot = await service.collectSnapshot();
+
+        expect(diagnoseArgs.logs.incarnationBounded,
+            'a producer bound on a different container must not read as this incarnation').toBe(false);
+        expect(snapshot.services[0].logs.incarnationBounded).toBe(false);
+    });
+
     test('the declared heap ceiling travels Config.Cmd → inspect → diagnostics through the OWNER', async () => {
         // The helper that decides this is unit-tested elsewhere, and that proves only the decision.
         // This drives `collectSnapshot()` itself, so it proves the WIRING: a correct selector that

--- a/test/playwright/unit/ai/daemons/orchestrator/services/DeploymentStateBridgeService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/DeploymentStateBridgeService.spec.mjs
@@ -140,9 +140,17 @@ test.describe('Neo.ai.daemons.services.DeploymentStateBridgeService', () => {
 
         expect(diagnoseArgs, 'the bridge must hand diagnosis its heap-attribution evidence').toMatchObject({
             declaredHeapCeilingMb: null,
-            logs                 : {text: expect.any(String)},
-            nodeCommand          : false
+            // The incarnation bound must travel WITH the slice. This fixture's container is running,
+            // so it has no FinishedAt and therefore no interval — `false` here is the correct answer
+            // and the one that keeps diagnosis from attributing a death that has not happened.
+            logs       : {incarnationBounded: false, text: expect.any(String)},
+            nodeCommand: false
         });
+
+        // The same summarized receipt reaches diagnosis AND publication — one object, not two
+        // derivations that could drift apart.
+        expect(snapshot.services[0].logs.incarnationBounded).toBe(false);
+        expect(snapshot.services[0].logs.text).toBe(diagnoseArgs.logs.text);
 
         expect(calls.map(call => call.operation)).toEqual(['inspect', 'stats', 'logs']);
         expect(snapshot.services).toHaveLength(1);

--- a/test/playwright/unit/ai/daemons/orchestrator/services/DeploymentStateBridgeService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/DeploymentStateBridgeService.spec.mjs
@@ -118,14 +118,31 @@ test.describe('Neo.ai.daemons.services.DeploymentStateBridgeService', () => {
                 };
             }
         };
+        // The handoff is CAPTURED, not just invoked. The heap attribution lives in diagnosis but its
+        // evidence is produced here, so a bridge that silently stopped passing the log summary or the
+        // Config.Cmd observations would leave the attribution permanently unavailable while every
+        // other assertion in this tree stayed green. Destructuring only the old arguments is exactly
+        // how that break would hide.
+        let diagnoseArgs = null;
+
         const diagnosisService = {
-            diagnose({serviceKey, inspect, statsSamples}) {
+            diagnose(args) {
+                diagnoseArgs = args;
+
+                const {serviceKey, inspect, statsSamples} = args;
+
                 return {serviceKey, status: inspect.State.Health.Status, sampleCount: statsSamples.length};
             }
         };
 
         const service  = createService({runtimeAccessService, diagnosisService});
         const snapshot = await service.collectSnapshot();
+
+        expect(diagnoseArgs, 'the bridge must hand diagnosis its heap-attribution evidence').toMatchObject({
+            declaredHeapCeilingMb: null,
+            logs                 : {text: expect.any(String)},
+            nodeCommand          : false
+        });
 
         expect(calls.map(call => call.operation)).toEqual(['inspect', 'stats', 'logs']);
         expect(snapshot.services).toHaveLength(1);


### PR DESCRIPTION
Resolves #16750

A Node service that exhausts its V8 heap already produced an authoritative `container-down` fact, already classified as `crash`, and was already restarted. **The action was never wrong.** What was missing is the CAUSE: nothing named the heap, so the death recorded as a generic crash, the ceiling was never implicated, and the identical abort recurred indefinitely. That is why nothing looks broken from the outside — the heal succeeds every time.

Evidence: L2 (unit + mutation proof; every AC is verifiable in-sandbox because the classifier is a pure function and the reason is asserted through the public `diagnose()` surface). No sandbox-unreachable residual for the ACs — observing a real heap death on the live plane is post-merge validation, not an unmet AC.

> **This PR was reworked mid-review.** Its first shape attributed from the **exit code** and emitted a *candidate*. @neo-gpt-emmy falsified that on the canonical image and it is fully replaced — the history is in the commits and the review thread. What follows describes only the current head.

## Deltas

| Surface | Change |
|---|---|
| `ContainerHealthDiagnosisService.mjs` | new export `classifyHeapExhaustion({logs, nodeCommand, declaredHeapCeilingMb})` — tri-state attribution plus an `unavailableReason` |
| same | new export `HEAP_FATAL_LINE` — the strict single-line V8 pattern covering both fatal shapes |
| same | `diagnose()` accepts `{logs, nodeCommand, declaredHeapCeilingMb}`; `container-down` details carry the attribution beside `exitCode` / `oomKilled` as raw evidence |
| same | the crash branch reports `lifecycle-crash-heap-exhaustion[-declared-ceiling]` — **action class unchanged in every branch** |
| `DeploymentStateBridgeService.mjs` | summarizes inspect + logs **once** and passes them to `diagnose()`; the published snapshot reuses the same summaries |
| same | derives the incarnation interval from the same inspect it publishes; retains proofs **per operation** and sets `incarnationBounded` only on a producer bound **AND** a logs/inspect target match |
| `DeploymentRuntimeAccessService.mjs` | `readObserve({operation:'logs'})` accepts `since` / `until` — **narrows** an already-allowlisted read, no new capability — and echoes `appliedSince` / `appliedUntil` at full RFC3339 precision plus the `containerId` it read |

## Why the exit code is not the discriminator

No abort code carries heap semantics — it names the manner of death, never its cause, and every V8 `FATAL ERROR`, assertion failure and explicit `abort()` shares one. Worse, **its value is not stable across base images**: the canonical `neo-local-agent-os-mc-server` image (Node `v24.16.0`) exits **`139`** where a host Node exits `134`, and it exits `139` **whether or not a ceiling was declared**. My original `134` was measured on the wrong subject.

The discriminating evidence was already inside the envelope: the bridge performs the allowlisted log read (`:392`) and already derives `nodeCommand` and `declaredHeapCeilingMb` from the same `Config.Cmd` (`:1122-1123`). #16750's "needs a new capability" premise was stale, and that false gap is what justified the weaker design.

## Both signals are required, and the ceiling is not one of them

The fatal line alone would attribute a tail that captured another container's output, or a service that merely logs the phrase. `nodeCommand` alone says nothing about how the process died.

**`declaredHeapCeilingMb` is deliberately excluded from the discriminator.** A missing `--max-old-space-size` proves the ceiling is *undeclared*, never that the process is non-Node — and undeclared-Node is exactly the population the originating incident came from, so scoping to the ceiling would blind this to the case it exists for. It licenses stronger *wording* only.

**Unavailable is `null` with a reason, never `false`.** Logs disabled, an unreadable command, or a truncated non-matching tail all mean the question was never asked; a bare `false` would merge a disabled channel with a genuine non-heap death. A truncated tail that *does* match stays conclusive — truncation cannot manufacture the line.

## Test Evidence

- Full orchestrator unit tree, covering every importer of all changed modules: **1286/1286** at the rebased head.
- **Mutation proof — the scoping guard is shown capable of failing.** Removing the `nodeCommand === false` branch reds exactly `heap attribution needs BOTH the fatal line and a Node command`, on the assertion *"a non-Node service has no V8 heap, whatever the tail contains"*. Reverted after; tree clean.
- **Red controls:** a non-Node service with the fatal line in its tail does not attribute; a Node service that died of something else keeps the generic reason; each `unavailableReason` is asserted separately.
- Parse, whitespace, shorthand, JSDoc, ticket-archaeology and block-alignment hooks pass.

Existing non-CI coverage for the touched surface: the orchestrator unit tree above is CI-covered; no `NEO_TEST_SKIP_CI` coverage is claimed.

## Post-Merge Validation

- [ ] The next real heap death on `kb-server` or `mc-server` records `lifecycle-crash-heap-exhaustion-declared-ceiling` with the fatal line present in the bounded tail — rather than a bare `lifecycle-crash`.
- [ ] A restart from any other cause continues to record the generic reason, and a deployment with `includeLogs: false` records `unavailableReason: 'logs-unavailable'` rather than a negative.

## Why the interval is exact, and why that matters

Both endpoints travel **unrounded**. Flooring to whole seconds is not imposed by Docker (it accepts RFC3339Nano) and is wrong in both directions: a floored `since` reaches back into the previous incarnation, and a floored `until` lands early — discarding the final sub-second in which V8 writes its fatal line, i.e. the evidence being sought, while the receipt still claimed `bounded: true`.

And a time range alone is not identity. `readObserve` resolves a target per call, so a compose recreate between the inspect and the logs read lands them on different containers, and no payload comparison can reveal it. `incarnationBounded` therefore requires **both** a real interval **and** a matching resolved target — a correct range on the wrong container is not this incarnation.

## Deltas from ticket

None — #16750's criteria were rewritten to match the falsified evidence before this head, and are delivered as written. Explicitly **not** delivered: #16630 Slice B's AC-1 (a V8-scoped numerator via in-process `perf_hooks` GC observation) stays open. This is attribution, not saturation.

Related: `#16630` (parent scope) · `#16695` (no live V8-ceiling actuator) · `#16642` / PR `#16640` (Slice A) · `ADR-0025` / `ADR-0026`

Authored by Vega (@neo-opus-vega, Claude Opus 5, Claude Code). Session 4e752c9d-6b74-4c83-8ab8-f487b6dce948.

