### PR TITLE
fix(draggable): the lost-release recovery fires on trusted streams only — synthetic drags survive (#16365)

### DIFF
--- a/src/main/draggable/sensor/Mouse.mjs
+++ b/src/main/draggable/sensor/Mouse.mjs
@@ -72,11 +72,7 @@ class Mouse extends Base {
         let me = this;
 
         if (me.currentElement) {
-            // Lost-release recovery: the gesture's own move stream observes the primary button
-            // gone, so its mouseup happened off-document — terminate as the release never
-            // received. The delay-timeout re-entry passes a plain coords object with no
-            // `buttons` to inspect, so it skips this check by construction.
-            if (event.buttons !== undefined && (event.buttons & 1) === 0) {
+            if (me.isLostReleaseSignal(event)) {
                 me.endGesture(event);
                 return
             }
@@ -93,6 +89,28 @@ class Mouse extends Base {
                 me.startDrag()
             }
         }
+    }
+
+    /**
+     * Lost-release recovery predicate: a move reporting the primary button gone means the
+     * gesture's mouseup happened off-document — terminate as the release never received.
+     *
+     * TRUSTED streams only. Synthetic dispatches (EventSimulator, InteractionService) construct
+     * MouseEvents without the buttons bitmask — `buttons` reads 0 by default — and always
+     * deliver their own explicit mouseup, so there is no lost release to recover from; reading
+     * buttons=0 as a released button would kill every synthetic gesture on its first move
+     * (the synthetic drag-start wedge). The delay-timeout re-entry passes a plain coords object
+     * with no `buttons` to inspect, so it skips the recovery by construction.
+     *
+     * A named seam rather than an inline condition so unit specs can stub the trust boundary
+     * (JS-constructed events always carry `isTrusted === false`) while still exercising the
+     * terminal contract the predicate gates.
+     * @param {MouseEvent|Object} event
+     * @returns {Boolean}
+     * @protected
+     */
+    isLostReleaseSignal(event) {
+        return Boolean(event.isTrusted) && event.buttons !== undefined && (event.buttons & 1) === 0
     }
 
     /**
@@ -146,7 +164,7 @@ class Mouse extends Base {
         let me = this;
 
         // Same lost-release recovery for an engaged drag (see onDistanceChange).
-        if (event.buttons !== undefined && (event.buttons & 1) === 0) {
+        if (me.isLostReleaseSignal(event)) {
             me.endGesture(event);
             return
         }

--- a/src/main/draggable/sensor/Mouse.mjs
+++ b/src/main/draggable/sensor/Mouse.mjs
@@ -92,6 +92,19 @@ class Mouse extends Base {
     }
 
     /**
+     * The trust read, isolated as its own seam so unit specs can stub ONLY the boundary and
+     * keep the shipped buttons logic under test. JS-constructed events can never forge
+     * `isTrusted` (read-only, and absent entirely in the unit harness), so the positive branch
+     * of {@link #isLostReleaseSignal} is sandbox-unreachable without this seam.
+     * @param {MouseEvent|Object} event
+     * @returns {Boolean}
+     * @protected
+     */
+    isTrustedEvent(event) {
+        return Boolean(event.isTrusted)
+    }
+
+    /**
      * Lost-release recovery predicate: a move reporting the primary button gone means the
      * gesture's mouseup happened off-document — terminate as the release never received.
      *
@@ -102,15 +115,15 @@ class Mouse extends Base {
      * (the synthetic drag-start wedge). The delay-timeout re-entry passes a plain coords object
      * with no `buttons` to inspect, so it skips the recovery by construction.
      *
-     * A named seam rather than an inline condition so unit specs can stub the trust boundary
-     * (JS-constructed events always carry `isTrusted === false`) while still exercising the
-     * terminal contract the predicate gates.
+     * Named seams rather than an inline condition: `isTrusted` cannot be forged in the unit
+     * harness (it is `undefined` there, not even `false`), so specs stub {@link #isTrustedEvent}
+     * and drive the REAL buttons branch — a dead predicate reds the recovery tests.
      * @param {MouseEvent|Object} event
      * @returns {Boolean}
      * @protected
      */
     isLostReleaseSignal(event) {
-        return Boolean(event.isTrusted) && event.buttons !== undefined && (event.buttons & 1) === 0
+        return this.isTrustedEvent(event) && event.buttons !== undefined && (event.buttons & 1) === 0
     }
 
     /**

--- a/test/playwright/unit/main/draggable/sensor/Mouse.spec.mjs
+++ b/test/playwright/unit/main/draggable/sensor/Mouse.spec.mjs
@@ -120,7 +120,9 @@ function mouseDown() {
  * the gesture's own move stream observes the primary button gone (a release that happened
  * off-document never reaches onMouseUp, so the move stream is the independent terminal
  * witness). The delay-timeout's coords-only re-entry carries no `buttons` and must never
- * trigger the recovery.
+ * trigger the recovery. The recovery fires on TRUSTED streams only: synthetic dispatches
+ * carry `isTrusted === false` and no buttons bitmask, so the terminal-contract tests stub
+ * the `isLostReleaseSignal` seam while the trust boundary gets its own pinning test.
  */
 test.describe('Neo.main.draggable.sensor.Mouse — selection-guard terminal contract', () => {
     test.beforeEach(() => {
@@ -149,6 +151,10 @@ test.describe('Neo.main.draggable.sensor.Mouse — selection-guard terminal cont
     test('pre-threshold lost release: a move reporting the primary button gone retires the guard', () => {
         const sensor = createSensor();
 
+        // Stub the trust boundary (JS-constructed events always carry isTrusted === false) so
+        // the terminal contract is exercised against the buttons signal alone.
+        sensor.isLostReleaseSignal = event => event.buttons !== undefined && (event.buttons & 1) === 0;
+
         Mouse.prototype.attach.call(sensor);
 
         documentRef.dispatchEvent(mouseDown());
@@ -167,6 +173,9 @@ test.describe('Neo.main.draggable.sensor.Mouse — selection-guard terminal cont
     test('mid-drag lost release emits exactly one drag:end, retires the guard, and ignores a later mouseup', () => {
         const ends   = [],
               sensor = createSensor();
+
+        // Same trust-boundary stub as the pre-threshold sibling.
+        sensor.isLostReleaseSignal = event => event.buttons !== undefined && (event.buttons & 1) === 0;
 
         Mouse.prototype.attach.call(sensor);
         documentRef.addEventListener('drag:end', event => ends.push(event.detail));
@@ -205,6 +214,28 @@ test.describe('Neo.main.draggable.sensor.Mouse — selection-guard terminal cont
 
         expect(bodyClasses.has('neo-drag-active')).toBe(true);
         expect(sensor.dragging).toBe(false);
+
+        clearTimeout(sensor.mouseDownTimeout);
+        sensor.detach()
+    });
+
+    test('trust boundary: an untrusted (JS-constructed) buttons=0 move never triggers the recovery', () => {
+        const sensor = createSensor();
+
+        // The REAL predicate, no stub: synthetic streams (EventSimulator, InteractionService)
+        // construct events without the buttons bitmask — buttons reads 0 by default — and
+        // isTrusted is false by construction. Reading that as a lost release wedged every
+        // synthetic drag on its first move.
+        Mouse.prototype.attach.call(sensor);
+
+        documentRef.dispatchEvent(mouseDown());
+        expect(bodyClasses.has('neo-drag-active')).toBe(true);
+
+        documentRef.dispatchEvent(mouseEvent('mousemove', {buttons: 0, clientX: 30, clientY: 30, pageX: 30, pageY: 30}));
+
+        // The gesture must SURVIVE: guard held, no termination, delay/distance path still open.
+        expect(bodyClasses.has('neo-drag-active')).toBe(true);
+        expect(sensor.currentElement).not.toBe(null);
 
         clearTimeout(sensor.mouseDownTimeout);
         sensor.detach()

--- a/test/playwright/unit/main/draggable/sensor/Mouse.spec.mjs
+++ b/test/playwright/unit/main/draggable/sensor/Mouse.spec.mjs
@@ -121,8 +121,10 @@ function mouseDown() {
  * off-document never reaches onMouseUp, so the move stream is the independent terminal
  * witness). The delay-timeout's coords-only re-entry carries no `buttons` and must never
  * trigger the recovery. The recovery fires on TRUSTED streams only: synthetic dispatches
- * carry `isTrusted === false` and no buttons bitmask, so the terminal-contract tests stub
- * the `isLostReleaseSignal` seam while the trust boundary gets its own pinning test.
+ * carry `isTrusted` undefined in this harness (never forgeable), so the recovery tests stub
+ * ONLY the `isTrustedEvent` seam — the shipped buttons logic of `isLostReleaseSignal` stays
+ * under test, and a constant-false mutation on the real predicate turns them red. The trust
+ * boundary itself gets its own pinning test with the real predicate.
  */
 test.describe('Neo.main.draggable.sensor.Mouse — selection-guard terminal contract', () => {
     test.beforeEach(() => {
@@ -151,9 +153,10 @@ test.describe('Neo.main.draggable.sensor.Mouse — selection-guard terminal cont
     test('pre-threshold lost release: a move reporting the primary button gone retires the guard', () => {
         const sensor = createSensor();
 
-        // Stub the trust boundary (JS-constructed events always carry isTrusted === false) so
-        // the terminal contract is exercised against the buttons signal alone.
-        sensor.isLostReleaseSignal = event => event.buttons !== undefined && (event.buttons & 1) === 0;
+        // Stub ONLY the trust bit (isTrusted is undefined in this harness, never forgeable), so
+        // the shipped buttons logic of isLostReleaseSignal stays under test — a dead predicate
+        // turns this test red.
+        sensor.isTrustedEvent = () => true;
 
         Mouse.prototype.attach.call(sensor);
 
@@ -174,8 +177,8 @@ test.describe('Neo.main.draggable.sensor.Mouse — selection-guard terminal cont
         const ends   = [],
               sensor = createSensor();
 
-        // Same trust-boundary stub as the pre-threshold sibling.
-        sensor.isLostReleaseSignal = event => event.buttons !== undefined && (event.buttons & 1) === 0;
+        // Same trust-bit-only stub as the pre-threshold sibling: the real predicate must fire.
+        sensor.isTrustedEvent = () => true;
 
         Mouse.prototype.attach.call(sensor);
         documentRef.addEventListener('drag:end', event => ends.push(event.detail));
@@ -224,8 +227,8 @@ test.describe('Neo.main.draggable.sensor.Mouse — selection-guard terminal cont
 
         // The REAL predicate, no stub: synthetic streams (EventSimulator, InteractionService)
         // construct events without the buttons bitmask — buttons reads 0 by default — and
-        // isTrusted is false by construction. Reading that as a lost release wedged every
-        // synthetic drag on its first move.
+        // isTrusted is undefined in this harness (never forgeable). Reading that as a lost
+        // release wedged every synthetic drag on its first move.
         Mouse.prototype.attach.call(sensor);
 
         documentRef.dispatchEvent(mouseDown());


### PR DESCRIPTION
Resolves #16365

The deterministic DockSplitter drag-start wedge at head, mechanism-named by per-segment probe and repaired at its owning segment. **Every synthetic `MouseEvent` defaults `buttons=0`, and the #16381 lost-release recovery read `buttons & 1 === 0` as a released primary button — so any gesture driven through `EventSimulator` (or any JS-constructed stream) was terminated by its own first move, +60ms in, before the 100ms sensor delay could ever elapse.** The repair: the recovery fires on trusted streams only (`isLostReleaseSignal` — real pointer brackets own lost releases; synthetic gestures always deliver their own explicit `mouseup`). Real CDP streams (`buttons=1` on every move) were healthy throughout — which is why the wedge discriminated by event ORIGIN and evaded every drag-family sweep that rode trusted input.

Evidence: L3 achieved (headed + headless Chromium, synthetic + trusted CDP paths, the failing witness turned green by the repair) → L3 required (rendered-lifecycle defect). Residual: the unit harness cannot forge isTrusted (it is undefined there, never settable) — the recovery's positive branch is sandbox-unreachable in unit lane, so specs stub only the isTrustedEvent seam and drive the shipped buttons logic; the trusted-path recovery is pinned by the e2e CDP witness (DragTextSelectionNL test 3).

## Deltas from ticket

- **The mechanism is my own #16381's recovery over-firing** — merged 2026-08-02 20:06Z, an ancestor of the deterministic-wedge head (`3a39616cd3`, #16365 comment thread). The 08-02 14:05–14:55Z transient is a DIFFERENT, earlier instance (predates #16381; trusted CDP wedged too) — spun out to #16754 as the intermittent tracker rather than stretching this ticket's ACs into a vigil.
- Probe ladder receipts (per-segment, not inferred): DOM `mousedown` fires every attempt; the sensor listener stays ALIVE (`DomEvents.testPathInclusion` invoked per attempt — the "dead listener" reading was an artifact of `Neo.bindMethods` own-binding shadowing prototype patches); the dead segment is the recovery gate inside `onDistanceChange`/`onMouseMove`, not the delegation.
- The recovery splits into two named protected seams: `isTrustedEvent` (the trust read) + `isLostReleaseSignal` (the buttons logic) — JS-constructed events carry `isTrusted` undefined and can never forge it, so the recovery unit specs stub ONLY the trust bit and the shipped buttons logic stays under test. The two-direction mutation matrix convicts the suite: constant-false on the real predicate reds 2 tests, constant-true reds 3; one further test pins the trust boundary with the real predicate (untrusted `buttons=0` move never terminates).
- Parked observation (NOT this PR, needs a second witness before it graduates): a first-gesture `drag:start` forwards with `dragZoneId: null` while the first move already carries the zone — the app-side start flag never sets though the resize commits via moves. Recorded on #16754.

## Test Evidence

- `NEO_E2E_PORT=8119 npx playwright test workstation/WorkstationGridRepaintNL -c test/playwright/playwright.config.e2e.mjs --workers=1` — **2/2 green** (deterministic red at dev pre-repair: both tests, "the resizeSplit document must commit with new sizes"; the ticket's named witness).
- `workstation/WorkstationDragTextSelectionNL` — **3/3 green** (the #16381 witness rides trusted CDP; the recovery's lost-release purpose survives the gate — test 3 exercises it directly).
- `npm run test-unit -- test/playwright/unit/main/draggable/sensor/Mouse.spec.mjs` — **5/5 green** (2 recovery tests re-seamed + 1 new trust-boundary pin + 2 standing).
- Probe spec (diagnostic, uncommitted): CDP attempt engaged fully (60/60 moves `buttons=1`, zone'd `drag:move`/`drag:end` forwarded); synthetic histograms confirmed `buttons=0` kill pre-repair.

## Post-Merge Validation

- [ ] `WorkstationGridRepaintNL` green in the first e2e CI lane run on dev.

## Commits

- single commit — `Mouse.mjs` seam + gate, `Mouse.spec.mjs` re-seam + trust-boundary pin

Authored by Phoebe (Kimi k3, opencode). Session 94296ece-1e77-47de-b74c-d1f3b63d8265.
