### PR TITLE
Every lint-staged guard must have a CI mirror or a recorded reason (#16753)

### DIFF
--- a/.github/workflows/guard-ci-parity-lint.yml
+++ b/.github/workflows/guard-ci-parity-lint.yml
@@ -5,14 +5,16 @@ name: Guard CI Parity Lint
 # that audits CI coverage while having none itself would be the joke it is meant to prevent.
 #
 # Path coverage MUST span every input the predicate reads: the lint-staged config that defines the
-# guard population, the workflow directory that defines their mirrors, and the registry that records
-# accepted exceptions. A narrower filter would let the population or its coverage change without the
-# gate running — the "reaches no surface" failure this guard is about, merely scoped smaller.
+# guard population, the Git hook that makes lint-staged commit-time reachable, the workflow directory
+# that defines CI mirrors, and the registry that records accepted exceptions. A narrower filter would
+# let the population or its coverage change without the gate running — the "reaches no surface"
+# failure this guard is about, merely scoped smaller.
 on:
   pull_request:
     branches: [dev]
     paths:
       - 'package.json'
+      - '.husky/pre-commit'
       - '.github/workflows/**'
       - 'ai/scripts/lint/lint-guard-ci-parity.mjs'
       - 'ai/scripts/lint/guard-ci-parity-registry.json'
@@ -21,6 +23,7 @@ on:
     branches: [dev]
     paths:
       - 'package.json'
+      - '.husky/pre-commit'
       - '.github/workflows/**'
       - 'ai/scripts/lint/lint-guard-ci-parity.mjs'
       - 'ai/scripts/lint/guard-ci-parity-registry.json'
@@ -37,7 +40,7 @@ jobs:
           node-version: '22'
 
       # --ignore-scripts skips the heavy prepare lifecycle (Husky + generated local configs) the
-      # predicate does not need — it reads package.json, the workflow directory, and the registry.
+      # predicate does not need — it reads package.json, the hook, workflows, and the registry.
       - name: Install dependencies
         run: npm ci --ignore-scripts
 

--- a/.github/workflows/guard-ci-parity-lint.yml
+++ b/.github/workflows/guard-ci-parity-lint.yml
@@ -1,0 +1,45 @@
+name: Guard CI Parity Lint
+
+# CI mirror of the .husky/pre-commit `lint-guard-ci-parity` guard, so `git commit --no-verify`
+# cannot bypass it — the same convention this guard exists to enforce on everything else. A guard
+# that audits CI coverage while having none itself would be the joke it is meant to prevent.
+#
+# Path coverage MUST span every input the predicate reads: the lint-staged config that defines the
+# guard population, the workflow directory that defines their mirrors, and the registry that records
+# accepted exceptions. A narrower filter would let the population or its coverage change without the
+# gate running — the "reaches no surface" failure this guard is about, merely scoped smaller.
+on:
+  pull_request:
+    branches: [dev]
+    paths:
+      - 'package.json'
+      - '.github/workflows/**'
+      - 'ai/scripts/lint/lint-guard-ci-parity.mjs'
+      - 'ai/scripts/lint/guard-ci-parity-registry.json'
+      - 'test/playwright/unit/ai/scripts/lint/lintGuardCiParity.spec.mjs'
+  push:
+    branches: [dev]
+    paths:
+      - 'package.json'
+      - '.github/workflows/**'
+      - 'ai/scripts/lint/lint-guard-ci-parity.mjs'
+      - 'ai/scripts/lint/guard-ci-parity-registry.json'
+      - 'test/playwright/unit/ai/scripts/lint/lintGuardCiParity.spec.mjs'
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      # --ignore-scripts skips the heavy prepare lifecycle (Husky + generated local configs) the
+      # predicate does not need — it reads package.json, the workflow directory, and the registry.
+      - name: Install dependencies
+        run: npm ci --ignore-scripts
+
+      - name: Lint guard CI parity (every lint-staged guard is mirrored or registered)
+        run: node ./ai/scripts/lint/lint-guard-ci-parity.mjs

--- a/.github/workflows/ticket-archaeology-lint.yml
+++ b/.github/workflows/ticket-archaeology-lint.yml
@@ -37,7 +37,7 @@ jobs:
           cache: 'npm'
 
       - name: Fetch base branch
-        run: git fetch origin ${{ github.base_ref }}
+        run: git fetch origin dev
 
       # The guard parses argv with Commander (a declared dependency). --ignore-scripts skips the heavy
       # postinstall (KB pull / server-config setup) we don't need — only node_modules must be present.
@@ -45,4 +45,4 @@ jobs:
         run: npm ci --ignore-scripts
 
       - name: Lint ticket-archaeology (boy-scout — whole touched-file vs base)
-        run: node buildScripts/util/check-ticket-archaeology.mjs --base origin/${{ github.base_ref || 'dev' }}
+        run: node buildScripts/util/check-ticket-archaeology.mjs --base origin/dev

--- a/ai/scripts/lint/guard-ci-parity-registry.json
+++ b/ai/scripts/lint/guard-ci-parity-registry.json
@@ -1,34 +1,34 @@
 {
     "$schema": {
         "purpose": "Explicitly accepted CLIENT-ONLY lint-staged guards — those invoked by no CI workflow. A guard absent from `clientOnly` and mirrored by no workflow is a FAILURE, not an unknown: the population is read exactly from package.json's lint-staged config, so there is no false-positive family to absorb.",
-        "whyThisExistsRatherThanFiveWorkflows": "A cold CI mirror for these guards reds on 593 pre-existing lines (measured 2026-08-08). Gating new violations from day one beats blocking every merger on a 593-line migration. This registry is the baseline; shrinking it is a visible lane rather than archaeology.",
+        "whyThisExistsRatherThanSixWorkflows": "A cold CI mirror for these guards reds on 593 pre-existing lines (measured 2026-08-08). Gating new violations from day one beats blocking every merger on a 593-line migration. This registry is the baseline; shrinking it is a visible lane rather than archaeology.",
         "reason": "REQUIRED. Why this guard has no CI mirror TODAY. Not 'because it doesn't' — the cost or blocker that keeps it client-only.",
         "witness": "REQUIRED. The measurement or artifact that substantiates the reason. An entry without one is a suppression, not an acceptance.",
         "baselineAtIntroduction": 6,
         "outOfScope": "The `ai/scripts/lint/lint-*.mjs` family has its own coverage question and is NOT governed here. Recorded so the boundary is explicit rather than implied by omission."
     },
     "clientOnly": {
-        "check-block-alignment.mjs": {
+        "buildScripts/util/check-block-alignment.mjs": {
             "reason": "A CI mirror reds on pre-existing drift across the tree; the two known files are repaired in this ticket, but the guard checks whole files rather than changed lines, so a merge stages files the author never touched.",
             "witness": "compactGraphLog.mjs 17 violations and HeavyMaintenanceLeaseService.spec.mjs 14 at origin/dev 14c8f7dccb, with src/Neo.mjs at 0 as a firing control; PR #16703's merge required --no-verify."
         },
-        "check-derived-domain.mjs": {
+        "buildScripts/util/check-derived-domain.mjs": {
             "reason": "Scoped to test/**/*.mjs only; no measurement yet of how many existing specs a cold mirror would red.",
             "witness": "package.json lint-staged: listed under the `test/**/*.mjs` glob, not the repo-wide `*.mjs` one."
         },
-        "check-parse.mjs": {
+        "buildScripts/util/check-parse.mjs": {
             "reason": "HIGHEST PRIORITY to mirror — a syntax guard with no CI backstop. Held only because the mirror should land with the shared workflow scaffolding rather than as a one-off.",
             "witness": "package.json lint-staged `*.mjs` array; no .github/workflows file invokes check-parse.mjs (verified across every spelling, comments excluded)."
         },
-        "check-shorthand.mjs": {
+        "buildScripts/util/check-shorthand.mjs": {
             "reason": "Part of the 593-line pre-existing population a cold mirror would red.",
             "witness": "Measured 2026-08-08 across the lint-* family: 593 pre-existing lines total."
         },
-        "check-whitespace.mjs": {
+        "buildScripts/util/check-whitespace.mjs": {
             "reason": "Runs on the `*` glob, so a cold mirror covers every file type in the repo; the pre-existing population is the largest and unmeasured per-guard.",
             "witness": "package.json lint-staged: the only guard under the repo-wide `*` glob."
         },
-        "lint-fleet-vocabulary-parity.mjs": {
+        "ai/scripts/lint/lint-fleet-vocabulary-parity.mjs": {
             "reason": "Found by this guard's FIRST RUN, not by the hand census that motivated the ticket — that census matched `check-*` only and was structurally blind to the `lint-*` family. Held pending the same shared workflow scaffolding as the others.",
             "witness": "package.json lint-staged invokes it under the `{ai/services/fleet/...,apps/agentos/config/...}` glob; no .github/workflows file invokes it (comments excluded). @neo-opus-grace reported 6/11 including the lint-* family before this ticket was filed; her count was the complete one."
         }

--- a/ai/scripts/lint/guard-ci-parity-registry.json
+++ b/ai/scripts/lint/guard-ci-parity-registry.json
@@ -4,7 +4,7 @@
         "whyThisExistsRatherThanFiveWorkflows": "A cold CI mirror for these guards reds on 593 pre-existing lines (measured 2026-08-08). Gating new violations from day one beats blocking every merger on a 593-line migration. This registry is the baseline; shrinking it is a visible lane rather than archaeology.",
         "reason": "REQUIRED. Why this guard has no CI mirror TODAY. Not 'because it doesn't' — the cost or blocker that keeps it client-only.",
         "witness": "REQUIRED. The measurement or artifact that substantiates the reason. An entry without one is a suppression, not an acceptance.",
-        "baselineAtIntroduction": 5,
+        "baselineAtIntroduction": 6,
         "outOfScope": "The `ai/scripts/lint/lint-*.mjs` family has its own coverage question and is NOT governed here. Recorded so the boundary is explicit rather than implied by omission."
     },
     "clientOnly": {

--- a/ai/scripts/lint/guard-ci-parity-registry.json
+++ b/ai/scripts/lint/guard-ci-parity-registry.json
@@ -1,0 +1,36 @@
+{
+    "$schema": {
+        "purpose": "Explicitly accepted CLIENT-ONLY lint-staged guards — those invoked by no CI workflow. A guard absent from `clientOnly` and mirrored by no workflow is a FAILURE, not an unknown: the population is read exactly from package.json's lint-staged config, so there is no false-positive family to absorb.",
+        "whyThisExistsRatherThanFiveWorkflows": "A cold CI mirror for these guards reds on 593 pre-existing lines (measured 2026-08-08). Gating new violations from day one beats blocking every merger on a 593-line migration. This registry is the baseline; shrinking it is a visible lane rather than archaeology.",
+        "reason": "REQUIRED. Why this guard has no CI mirror TODAY. Not 'because it doesn't' — the cost or blocker that keeps it client-only.",
+        "witness": "REQUIRED. The measurement or artifact that substantiates the reason. An entry without one is a suppression, not an acceptance.",
+        "baselineAtIntroduction": 5,
+        "outOfScope": "The `ai/scripts/lint/lint-*.mjs` family has its own coverage question and is NOT governed here. Recorded so the boundary is explicit rather than implied by omission."
+    },
+    "clientOnly": {
+        "check-block-alignment.mjs": {
+            "reason": "A CI mirror reds on pre-existing drift across the tree; the two known files are repaired in this ticket, but the guard checks whole files rather than changed lines, so a merge stages files the author never touched.",
+            "witness": "compactGraphLog.mjs 17 violations and HeavyMaintenanceLeaseService.spec.mjs 14 at origin/dev 14c8f7dccb, with src/Neo.mjs at 0 as a firing control; PR #16703's merge required --no-verify."
+        },
+        "check-derived-domain.mjs": {
+            "reason": "Scoped to test/**/*.mjs only; no measurement yet of how many existing specs a cold mirror would red.",
+            "witness": "package.json lint-staged: listed under the `test/**/*.mjs` glob, not the repo-wide `*.mjs` one."
+        },
+        "check-parse.mjs": {
+            "reason": "HIGHEST PRIORITY to mirror — a syntax guard with no CI backstop. Held only because the mirror should land with the shared workflow scaffolding rather than as a one-off.",
+            "witness": "package.json lint-staged `*.mjs` array; no .github/workflows file invokes check-parse.mjs (verified across every spelling, comments excluded)."
+        },
+        "check-shorthand.mjs": {
+            "reason": "Part of the 593-line pre-existing population a cold mirror would red.",
+            "witness": "Measured 2026-08-08 across the lint-* family: 593 pre-existing lines total."
+        },
+        "check-whitespace.mjs": {
+            "reason": "Runs on the `*` glob, so a cold mirror covers every file type in the repo; the pre-existing population is the largest and unmeasured per-guard.",
+            "witness": "package.json lint-staged: the only guard under the repo-wide `*` glob."
+        },
+        "lint-fleet-vocabulary-parity.mjs": {
+            "reason": "Found by this guard's FIRST RUN, not by the hand census that motivated the ticket — that census matched `check-*` only and was structurally blind to the `lint-*` family. Held pending the same shared workflow scaffolding as the others.",
+            "witness": "package.json lint-staged invokes it under the `{ai/services/fleet/...,apps/agentos/config/...}` glob; no .github/workflows file invokes it (comments excluded). @neo-opus-grace reported 6/11 including the lint-* family before this ticket was filed; her count was the complete one."
+        }
+    }
+}

--- a/ai/scripts/lint/lint-guard-ci-parity.mjs
+++ b/ai/scripts/lint/lint-guard-ci-parity.mjs
@@ -10,7 +10,7 @@
  *
  * > *CI mirror of the `.husky/pre-commit` guard, so `git commit --no-verify` cannot bypass it.*
  *
- * Five guards follow it. Six do not, and one of those is a **syntax** check. This guard makes the
+ * Six guards follow it. Six do not, and one of those is a **syntax** check. This guard makes the
  * convention mechanical so the next unmirrored guard fails on arrival instead of being discovered
  * by someone whose merge needed `--no-verify`.
  *
@@ -24,20 +24,12 @@
  * either is or is not invoked by a workflow. So "unmirrored" is a defect claim, and the registry
  * exists to record *accepted* ones with a reason — not to absorb false positives.
  *
- * ## Why comment lines are stripped before matching
+ * ## Why only parsed `run:` commands count
  *
- * A workflow that merely *names* a guard in prose does not invoke it, and counting it would be a
- * false green inside the guard whose entire purpose is catching false greens.
- *
- * Stated precisely, because the tempting version is overstated: `ticket-archaeology-lint.yml`
- * does mention `block-alignment` in a comment, but as the bare phrase — **not** as
- * `check-block-alignment.mjs`. Matching on the full basename, as this file does, would therefore
- * NOT have been fooled by that particular comment. Measured, not assumed.
- *
- * The stripping is kept anyway, as a guard against the real class rather than a fix for an
- * observed failure: a comment naming a full script path is entirely ordinary — *"we deliberately
- * do not run `buildScripts/util/check-parse.mjs` here"* would read as invocation to any substring
- * match. A spec pins the behaviour so the next person to "simplify" this knows what it protects.
+ * A workflow that merely *names* a guard in prose, `on.paths`, an environment value, or a shell
+ * argument does not invoke it. Workflows are parsed as YAML, then only `jobs.*.steps[].run` strings
+ * are inspected for direct `node … <script>.mjs` commands. Counting any wider YAML or shell-token
+ * population would create a false green inside the guard whose purpose is catching false greens.
  *
  * ## Scope
  *
@@ -46,16 +38,20 @@
  * the boundary is recorded rather than implied.
  */
 
-import fs   from 'fs';
-import path from 'path';
-import url  from 'url';
+import fs        from 'fs';
+import path      from 'path';
+import url       from 'url';
+import * as yaml from 'js-yaml';
 
 const
-    __filename   = url.fileURLToPath(import.meta.url),
-    __dirname    = path.dirname(__filename),
-    REPO_ROOT    = path.resolve(__dirname, '../../..'),
+    __filename = url.fileURLToPath(import.meta.url),
+    __dirname  = path.dirname(__filename),
+    REPO_ROOT  = process.env.NEO_GUARD_CI_PARITY_REPO_ROOT
+        ? path.resolve(process.env.NEO_GUARD_CI_PARITY_REPO_ROOT)
+        : path.resolve(__dirname, '../../..'),
     WORKFLOW_DIR = path.join(REPO_ROOT, '.github/workflows'),
     REGISTRY_REL = 'ai/scripts/lint/guard-ci-parity-registry.json',
+    SELF_REL     = 'ai/scripts/lint/lint-guard-ci-parity.mjs',
     PKG_PATH     = path.join(REPO_ROOT, 'package.json'),
 
     /**
@@ -90,6 +86,61 @@ export const SCAN_SURFACE = Object.freeze([
 ]);
 
 /**
+ * @summary Resolves a statically named Node script to one normalized repo-relative identity.
+ *
+ * Full paths are load-bearing: two different guards may share a basename, and a workflow that
+ * executes one must never be credited as the other's mirror. Dynamic or outside-repo paths remain
+ * unclassified rather than being collapsed into a reassuring false match.
+ *
+ * @param {String} script
+ * @param {String} [workingDirectory='.']
+ * @returns {String|null}
+ */
+function normalizeScriptPath(script, workingDirectory = '.') {
+    const
+        scriptPath  = `${script}`.replaceAll('\\', '/'),
+        workingPath = `${workingDirectory || '.'}`.replaceAll('\\', '/');
+
+    if (
+        scriptPath.startsWith('/') ||
+        workingPath.startsWith('/') ||
+        scriptPath.includes('${{') ||
+        workingPath.includes('${{')
+    ) {
+        return null
+    }
+
+    const normalized = path.posix.normalize(path.posix.join(workingPath, scriptPath)).replace(/^\.\//, '');
+
+    return normalized === '..' || normalized.startsWith('../') ? null : normalized
+}
+
+/**
+ * @summary Extracts only scripts directly executed by static `node … <script>.mjs` commands.
+ *
+ * Other `.mjs` tokens inside the shell body are arguments or prose, not execution evidence. The
+ * global match supports multiple Node commands in one `run:` block without treating arbitrary YAML
+ * mentions as mirrors.
+ *
+ * @param {String} command
+ * @param {String} [workingDirectory='.']
+ * @returns {String[]}
+ */
+function executedNodeScripts(command, workingDirectory = '.') {
+    const scripts = [];
+
+    for (const match of `${command}`.matchAll(
+        /\bnode\s+(?:(?:--[\w-]+)(?:=[^\s]+)?\s+)*(['"]?)([\w./-]+\.mjs)\1/g
+    )) {
+        const script = normalizeScriptPath(match[2], workingDirectory);
+
+        script && scripts.push(script)
+    }
+
+    return scripts
+}
+
+/**
  * @summary Every distinct guard script invoked by `lint-staged`, derived — never hardcoded.
  *
  * Deriving is the point: adding a tenth guard with no workflow must fail without anyone editing
@@ -110,10 +161,7 @@ function discoverGuards() {
         scripts  = new Set();
 
     commands.forEach(command => {
-        // `node ./path/to/whatever.mjs …` — the executed script, whatever it is called.
-        const match = `${command}`.match(/\bnode\s+(?:--[\w-]+(?:=\S+)?\s+)*([\w./-]+\.mjs)/);
-
-        match && scripts.add(match[1].replace(/^\.\//, ''))
+        executedNodeScripts(command).forEach(script => scripts.add(script))
     });
 
     return [...scripts].sort()
@@ -134,9 +182,10 @@ function discoverGuards() {
  * revision stripped comments to stop prose counting as coverage, and left the larger hole open —
  * trigger filters are not executions either.
  *
- * Comments are still stripped, because a commented-out `run:` is not an execution.
+ * YAML comments, path filters, environment values, and non-Node shell arguments are outside that
+ * boundary by construction.
  *
- * @returns {Object[]} `{file, executed:Set<String>}` per workflow, keyed by script basename
+ * @returns {Object[]} `{file, executed:Set<String>}` per workflow, keyed by repo-relative path
  */
 function workflowExecutions() {
     if (!fs.existsSync(WORKFLOW_DIR)) {
@@ -147,27 +196,23 @@ function workflowExecutions() {
         .filter(file => /\.ya?ml$/.test(file))
         .map(file => {
             const
-                lines    = fs.readFileSync(path.join(WORKFLOW_DIR, file), 'utf8').split('\n'),
+                workflow = yaml.load(fs.readFileSync(path.join(WORKFLOW_DIR, file), 'utf8')) || {},
                 executed = new Set();
 
-            let inRun = false;
+            const workflowDirectory = workflow.defaults?.run?.['working-directory'] || '.';
 
-            lines.forEach(line => {
-                if (line.trim().startsWith('#')) {
-                    return
-                }
+            Object.values(workflow.jobs || {}).forEach(job => {
+                const jobDirectory = job?.defaults?.run?.['working-directory'] || workflowDirectory;
 
-                // A `run:` step opens a shell block; its continuation lines are indented further.
-                /^\s*(-\s*)?run\s*:/.test(line) && (inRun = true);
-
-                if (inRun) {
-                    for (const m of line.matchAll(/([\w./-]+\.mjs)/g)) {
-                        executed.add(path.basename(m[1]))
+                (job?.steps || []).forEach(step => {
+                    if (typeof step?.run !== 'string') {
+                        return
                     }
-                }
 
-                // Any new key at step level closes the run block.
-                /^\s*(-\s*)?(name|uses|with|env|if|id)\s*:/.test(line) && (inRun = false)
+                    const stepDirectory = step['working-directory'] || jobDirectory;
+
+                    executedNodeScripts(step.run, stepDirectory).forEach(script => executed.add(script))
+                })
             });
 
             return {file, executed}
@@ -180,9 +225,7 @@ function workflowExecutions() {
  * @returns {String[]} workflow filenames whose `run:` steps execute `script`
  */
 function mirrorsOf(script, workflows) {
-    const basename = path.basename(script);
-
-    return workflows.filter(({executed}) => executed.has(basename)).map(({file}) => file)
+    return workflows.filter(({executed}) => executed.has(script)).map(({file}) => file)
 }
 
 /**
@@ -199,7 +242,7 @@ function runLint() {
 
     guards.forEach(script => {
         const
-            key     = path.basename(script),
+            key     = script,
             mirrors = mirrorsOf(script, workflows);
 
         if (mirrors.length === 0) {
@@ -212,13 +255,17 @@ function runLint() {
     // A registry entry for a guard that left `lint-staged` is also stale: it would quietly widen the
     // accepted set if that guard ever returned.
     [...accepted.keys()].forEach(key => {
-        !guards.some(script => path.basename(script) === key) &&
+        !guards.includes(key) &&
             stale.push(`${key} — no longer a lint-staged guard; remove its registry entry`)
     });
 
     const invalid = [...accepted.entries()]
         .filter(([, entry]) => !entry || !entry.reason || !entry.witness)
         .map(([key]) => `${key} — every entry needs BOTH a reason and a witness; one without them is a suppression, not an acceptance`);
+
+    !guards.includes(SELF_REL) && invalid.push(
+        `${SELF_REL} — commit-time carrier missing from package.json lint-staged`
+    );
 
     // The registry is a RATCHET: it may shrink freely and may not grow silently.
     //

--- a/ai/scripts/lint/lint-guard-ci-parity.mjs
+++ b/ai/scripts/lint/lint-guard-ci-parity.mjs
@@ -27,9 +27,10 @@
  * ## Why only parsed `run:` commands count
  *
  * A workflow that merely *names* a guard in prose, `on.paths`, an environment value, or a shell
- * argument does not invoke it. Workflows are parsed as YAML, then only `jobs.*.steps[].run` strings
- * are inspected for direct `node … <script>.mjs` commands. Counting any wider YAML or shell-token
- * population would create a false green inside the guard whose purpose is catching false greens.
+ * argument does not invoke it. Eligible `*-lint.yml/.yaml` workflows must gate `dev` pull requests;
+ * their YAML is parsed, then only unmasked `jobs.*.steps[].run` strings are inspected for direct
+ * `node … <script>.mjs` commands. Counting any wider population would create a false green inside the
+ * guard whose purpose is catching false greens.
  *
  * ## Scope
  *
@@ -52,6 +53,8 @@ const
     WORKFLOW_DIR = path.join(REPO_ROOT, '.github/workflows'),
     REGISTRY_REL = 'ai/scripts/lint/guard-ci-parity-registry.json',
     SELF_REL     = 'ai/scripts/lint/lint-guard-ci-parity.mjs',
+    HOOK_REL     = '.husky/pre-commit',
+    HOOK_PATH    = path.join(REPO_ROOT, HOOK_REL),
     PKG_PATH     = path.join(REPO_ROOT, 'package.json'),
 
     /**
@@ -81,6 +84,7 @@ const
  */
 export const SCAN_SURFACE = Object.freeze([
     'package.json',
+    HOOK_REL,
     '.github/workflows/**',
     REGISTRY_REL
 ]);
@@ -116,34 +120,116 @@ function normalizeScriptPath(script, workingDirectory = '.') {
 }
 
 /**
- * @summary Extracts only scripts directly executed by static `node … <script>.mjs` commands.
+ * @summary Extracts only scripts directly executed by standalone static `node … <script>.mjs` lines.
  *
- * Other `.mjs` tokens inside the shell body are arguments or prose, not execution evidence. The
- * global match supports multiple Node commands in one `run:` block without treating arbitrary YAML
- * mentions as mirrors.
+ * Other `.mjs` tokens inside the shell body are arguments or prose, not execution evidence. Shell
+ * control operators, runtime expressions, directory changes, and masked commands remain unclassified
+ * rather than being credited optimistically. Declarative workflow `working-directory` is the supported
+ * path carrier; the execution step itself must not override its environment.
  *
  * @param {String} command
  * @param {String} [workingDirectory='.']
  * @returns {String[]}
  */
 function executedNodeScripts(command, workingDirectory = '.') {
-    const scripts = [];
+    const statements = `${command}`.split('\n')
+        .map(line => line.trim())
+        .filter(line => line && !line.startsWith('#'));
 
-    for (const match of `${command}`.matchAll(
-        /\bnode\s+(?:(?:--[\w-]+)(?:=[^\s]+)?\s+)*(['"]?)([\w./-]+\.mjs)\1/g
-    )) {
-        const script = normalizeScriptPath(match[2], workingDirectory);
-
-        script && scripts.push(script)
+    if (statements.length !== 1) {
+        return []
     }
 
-    return scripts
+    const classifiedStatement = statements[0];
+
+    if (classifiedStatement.includes('${{') || /&&|\|\||[;|&]/.test(classifiedStatement)) {
+        return []
+    }
+
+    const match = classifiedStatement.match(
+        /^node\s+(['"]?)([\w./-]+\.mjs)\1(?:\s+[^#;&|]*)?(?:\s+#.*)?$/
+    );
+
+    const script = match && normalizeScriptPath(match[2], workingDirectory);
+
+    return script ? [script] : []
+}
+
+/**
+ * @summary Proves the configured lint-staged guard remains reachable from the real Git hook.
+ *
+ * The hook carrier is intentionally exact and unmasked: lint-staged must be the terminal substantive
+ * command, and only standalone Node pre-checks may precede it. If the project changes this sequence,
+ * the predicate and its witness must change together instead of silently assuming reach.
+ *
+ * @returns {Boolean}
+ */
+function hasLintStagedHookCarrier() {
+    if (!fs.existsSync(HOOK_PATH)) {
+        return false
+    }
+
+    const statements = fs.readFileSync(HOOK_PATH, 'utf8')
+        .split('\n')
+        .map(line => line.trim())
+        .filter(line => line && !line.startsWith('#'));
+
+    if (statements.pop() !== 'npx lint-staged') {
+        return false
+    }
+
+    return statements.every(statement => executedNodeScripts(statement).length === 1)
+}
+
+/**
+ * @summary Returns whether a workflow is an unconditional pull-request gate for the `dev` branch.
+ *
+ * Manual, post-close, ignored-path, and other-branch workflows may execute a guard eventually, but
+ * they cannot prevent a no-verify change from merging. Complex branch patterns stay unclassified;
+ * literal `dev` or an unfiltered pull-request trigger are the reviewable merge-gate shapes.
+ *
+ * @param {Object} workflow
+ * @returns {Boolean}
+ */
+function hasDevPullRequestGate(workflow) {
+    const triggers = workflow.on ?? workflow[true];
+
+    if (triggers === 'pull_request' || Array.isArray(triggers) && triggers.includes('pull_request')) {
+        return true
+    }
+
+    if (!triggers || typeof triggers !== 'object' || !Object.hasOwn(triggers, 'pull_request')) {
+        return false
+    }
+
+    const pullRequest = triggers.pull_request;
+
+    if (pullRequest == null) {
+        return true
+    }
+
+    if (
+        typeof pullRequest !== 'object' ||
+        Object.hasOwn(pullRequest, 'branches-ignore') ||
+        Object.hasOwn(pullRequest, 'paths-ignore') ||
+        Object.hasOwn(pullRequest, 'types')
+    ) {
+        return false
+    }
+
+    if (!Object.hasOwn(pullRequest, 'branches')) {
+        return true
+    }
+
+    const branches = [pullRequest.branches].flat();
+
+    return branches.includes('dev') && !branches.some(branch => `${branch}`.startsWith('!'))
 }
 
 /**
  * @summary Every distinct guard script invoked by `lint-staged`, derived — never hardcoded.
  *
- * Deriving is the point: adding a tenth guard with no workflow must fail without anyone editing
+ * Deriving is the point: adding another guard with no workflow must fail without anyone editing
  * this file. A hardcoded list would answer today's question and rot.
  *
  * **No naming allowlist.** An earlier revision matched `check-*` / `lint-*`, which is a filter on the
@@ -193,19 +279,43 @@ function workflowExecutions() {
     }
 
     return fs.readdirSync(WORKFLOW_DIR)
-        .filter(file => /\.ya?ml$/.test(file))
+        .filter(file => /-lint\.ya?ml$/.test(file))
         .map(file => {
             const
                 workflow = yaml.load(fs.readFileSync(path.join(WORKFLOW_DIR, file), 'utf8')) || {},
                 executed = new Set();
 
+            if (
+                !hasDevPullRequestGate(workflow) ||
+                Object.hasOwn(workflow, 'env') ||
+                Object.hasOwn(workflow.defaults?.run || {}, 'shell')
+            ) {
+                return {file, executed}
+            }
+
             const workflowDirectory = workflow.defaults?.run?.['working-directory'] || '.';
 
             Object.values(workflow.jobs || {}).forEach(job => {
+                if (
+                    !job ||
+                    Object.hasOwn(job, 'env') ||
+                    Object.hasOwn(job, 'if') ||
+                    Object.hasOwn(job.defaults?.run || {}, 'shell') ||
+                    job['continue-on-error']
+                ) {
+                    return
+                }
+
                 const jobDirectory = job?.defaults?.run?.['working-directory'] || workflowDirectory;
 
                 (job?.steps || []).forEach(step => {
-                    if (typeof step?.run !== 'string') {
+                    if (
+                        typeof step?.run !== 'string' ||
+                        Object.hasOwn(step, 'env') ||
+                        Object.hasOwn(step, 'if') ||
+                        Object.hasOwn(step, 'shell') ||
+                        step['continue-on-error']
+                    ) {
                         return
                     }
 
@@ -265,6 +375,10 @@ function runLint() {
 
     !guards.includes(SELF_REL) && invalid.push(
         `${SELF_REL} — commit-time carrier missing from package.json lint-staged`
+    );
+
+    !hasLintStagedHookCarrier() && invalid.push(
+        `${HOOK_REL} — direct \`npx lint-staged\` carrier missing; configured guards are not commit-time reachable`
     );
 
     // The registry is a RATCHET: it may shrink freely and may not grow silently.

--- a/ai/scripts/lint/lint-guard-ci-parity.mjs
+++ b/ai/scripts/lint/lint-guard-ci-parity.mjs
@@ -51,7 +51,8 @@ import path from 'path';
 import url  from 'url';
 
 const
-    __dirname    = path.dirname(url.fileURLToPath(import.meta.url)),
+    __filename   = url.fileURLToPath(import.meta.url),
+    __dirname    = path.dirname(__filename),
     REPO_ROOT    = path.resolve(__dirname, '../../..'),
     WORKFLOW_DIR = path.join(REPO_ROOT, '.github/workflows'),
     REGISTRY_REL = 'ai/scripts/lint/guard-ci-parity-registry.json',
@@ -67,6 +68,26 @@ const
     REGISTRY_PATH = process.env.NEO_GUARD_CI_PARITY_REGISTRY
         ? path.resolve(process.env.NEO_GUARD_CI_PARITY_REGISTRY)
         : path.join(REPO_ROOT, REGISTRY_REL);
+
+/**
+ * @summary Every surface whose contents can change this lint's verdict — the SSOT its CI workflow's
+ * path filter must cover.
+ *
+ * Exported so the sibling `scanned ⊆ watched` spec takes it as authority rather than a hand-copied
+ * duplicate: widening what this predicate reads widens this array in the same edit, and an unwidened
+ * workflow filter then fails that spec without anyone remembering to update a registry.
+ *
+ * That is the `scanned ⊆ watched` invariant, and this lint is subject to it like any other — which
+ * is how it should be, since a guard exempting itself from a coverage rule is the joke it exists to
+ * prevent.
+ *
+ * @type {String[]}
+ */
+export const SCAN_SURFACE = Object.freeze([
+    'package.json',
+    '.github/workflows/**',
+    REGISTRY_REL
+]);
 
 /**
  * @summary Every distinct guard script invoked by `lint-staged`, derived — never hardcoded.
@@ -245,4 +266,9 @@ function runLint() {
     return {exitCode: 1}
 }
 
-process.exit(runLint().exitCode);
+// Import-safe, per the house pattern in `lint-retry-bounds.mjs` and `lint-config-template-ssot.mjs`:
+// the sibling `scanned ⊆ watched` spec imports SCAN_SURFACE from this module, and a bare
+// `process.exit()` at module scope would terminate the test process on import.
+if (process.argv[1] && path.resolve(process.argv[1]) === __filename) {
+    process.exit(runLint().exitCode)
+}

--- a/ai/scripts/lint/lint-guard-ci-parity.mjs
+++ b/ai/scripts/lint/lint-guard-ci-parity.mjs
@@ -1,0 +1,182 @@
+#!/usr/bin/env node
+/**
+ * @summary Requires every `lint-staged` guard to be invoked by some CI workflow, or to carry an
+ * explicit registry entry saying why it is client-only. A guard nobody mirrors is bypassed by
+ * `git commit --no-verify` with nothing downstream.
+ *
+ * ## The rule, and where it comes from
+ *
+ * This repo already states the convention, in the header of `ticket-archaeology-lint.yml`:
+ *
+ * > *CI mirror of the `.husky/pre-commit` guard, so `git commit --no-verify` cannot bypass it.*
+ *
+ * Four guards follow it. Five do not, and one of those is a **syntax** check. This guard makes the
+ * convention mechanical so the next unmirrored guard fails on arrival instead of being discovered
+ * by someone whose merge needed `--no-verify`.
+ *
+ * ## Why this reports a DEFECT, where `lint-retry-bounds` reports `unclassified`
+ *
+ * Its sibling deliberately never says "unbounded", because its discovery patterns have a larger
+ * false-positive family than true-positive set, and a guard that cries wolf gets suppressed.
+ *
+ * This guard is the opposite case and the distinction matters. The population is **exact**: it is
+ * read from `package.json`'s `lint-staged` config, not inferred from syntax. A guard listed there
+ * either is or is not invoked by a workflow. So "unmirrored" is a defect claim, and the registry
+ * exists to record *accepted* ones with a reason — not to absorb false positives.
+ *
+ * ## Why comment lines are stripped before matching
+ *
+ * A workflow that merely *names* a guard in prose does not invoke it, and counting it would be a
+ * false green inside the guard whose entire purpose is catching false greens.
+ *
+ * Stated precisely, because the tempting version is overstated: `ticket-archaeology-lint.yml`
+ * does mention `block-alignment` in a comment, but as the bare phrase — **not** as
+ * `check-block-alignment.mjs`. Matching on the full basename, as this file does, would therefore
+ * NOT have been fooled by that particular comment. Measured, not assumed.
+ *
+ * The stripping is kept anyway, as a guard against the real class rather than a fix for an
+ * observed failure: a comment naming a full script path is entirely ordinary — *"we deliberately
+ * do not run `buildScripts/util/check-parse.mjs` here"* would read as invocation to any substring
+ * match. A spec pins the behaviour so the next person to "simplify" this knows what it protects.
+ *
+ * ## Scope
+ *
+ * The population is `lint-staged` only. The `ai/scripts/lint/lint-*.mjs` family has its own
+ * coverage question and is a separate lane; it is named in the registry's `$schema.outOfScope` so
+ * the boundary is recorded rather than implied.
+ */
+
+import fs   from 'fs';
+import path from 'path';
+import url  from 'url';
+
+const
+    __dirname     = path.dirname(url.fileURLToPath(import.meta.url)),
+    REPO_ROOT     = path.resolve(__dirname, '../../..'),
+    WORKFLOW_DIR  = path.join(REPO_ROOT, '.github/workflows'),
+    REGISTRY_REL  = 'ai/scripts/lint/guard-ci-parity-registry.json',
+    REGISTRY_PATH = path.join(REPO_ROOT, REGISTRY_REL),
+    PKG_PATH      = path.join(REPO_ROOT, 'package.json');
+
+/**
+ * @summary Every distinct guard script invoked by `lint-staged`, derived — never hardcoded.
+ *
+ * Deriving is the point: adding a tenth guard with no workflow must fail without anyone editing
+ * this file. A hardcoded list would answer today's question and rot.
+ *
+ * @returns {String[]} script paths as written in `lint-staged`, e.g. `buildScripts/util/check-parse.mjs`
+ */
+function discoverGuards() {
+    const
+        pkg      = JSON.parse(fs.readFileSync(PKG_PATH, 'utf8')),
+        commands = Object.values(pkg['lint-staged'] || {}).flat(),
+        scripts  = new Set();
+
+    commands.forEach(command => {
+        const match = `${command}`.match(/([\w./-]*(?:check|lint)-[\w.-]+\.mjs)/);
+
+        match && scripts.add(match[1].replace(/^\.\//, ''))
+    });
+
+    return [...scripts].sort()
+}
+
+/**
+ * @summary Workflow YAML with comment lines removed, so a guard NAMED in prose is not counted as
+ * a guard INVOKED by the workflow.
+ *
+ * @returns {Object[]} `{file, body}` per workflow
+ */
+function workflowBodies() {
+    if (!fs.existsSync(WORKFLOW_DIR)) {
+        return []
+    }
+
+    return fs.readdirSync(WORKFLOW_DIR)
+        .filter(file => /\.ya?ml$/.test(file))
+        .map(file => ({
+            file,
+            body: fs.readFileSync(path.join(WORKFLOW_DIR, file), 'utf8')
+                .split('\n')
+                .filter(line => !line.trim().startsWith('#'))
+                .join('\n')
+        }))
+}
+
+/**
+ * @param {String}   script
+ * @param {Object[]} workflows
+ * @returns {String[]} workflow filenames that invoke `script`
+ */
+function mirrorsOf(script, workflows) {
+    const basename = path.basename(script);
+
+    return workflows.filter(({body}) => body.includes(basename)).map(({file}) => file)
+}
+
+/**
+ * @returns {Object} `{exitCode}`
+ */
+function runLint() {
+    const
+        guards     = discoverGuards(),
+        workflows  = workflowBodies(),
+        registry   = JSON.parse(fs.readFileSync(REGISTRY_PATH, 'utf8')),
+        accepted   = new Map(Object.entries(registry.clientOnly || {})),
+        unmirrored = [],
+        stale      = [];
+
+    guards.forEach(script => {
+        const
+            key     = path.basename(script),
+            mirrors = mirrorsOf(script, workflows);
+
+        if (mirrors.length === 0) {
+            !accepted.has(key) && unmirrored.push(key)
+        } else if (accepted.has(key)) {
+            stale.push(`${key} — now mirrored by ${mirrors.join(', ')}; remove its registry entry`)
+        }
+    });
+
+    // A registry entry for a guard that left `lint-staged` is also stale: it would quietly widen the
+    // accepted set if that guard ever returned.
+    [...accepted.keys()].forEach(key => {
+        !guards.some(script => path.basename(script) === key) &&
+            stale.push(`${key} — no longer a lint-staged guard; remove its registry entry`)
+    });
+
+    const invalid = [...accepted.entries()]
+        .filter(([, entry]) => !entry || !entry.reason || !entry.witness)
+        .map(([key]) => `${key} — every entry needs BOTH a reason and a witness; one without them is a suppression, not an acceptance`);
+
+    if (unmirrored.length === 0 && stale.length === 0 && invalid.length === 0) {
+        console.log(`[lint-guard-ci-parity] OK (${guards.length} lint-staged guards, ${accepted.size} accepted client-only)`);
+        return {exitCode: 0}
+    }
+
+    console.error('[lint-guard-ci-parity] FAILED');
+
+    if (unmirrored.length) {
+        console.error(`\n  ${unmirrored.length} guard(s) invoked by lint-staged but by NO workflow:\n`);
+        unmirrored.forEach(key => console.error(`    ${key}`));
+        console.error(`\n  A guard with no CI mirror is skipped entirely by \`git commit --no-verify\`, and a merge`);
+        console.error('  commit stages files the author never touched — so the bypass is routine, not careless.');
+        console.error(`  Add a workflow that invokes it, or record it in ${REGISTRY_REL} with a reason and a witness.\n`)
+    }
+
+    if (stale.length) {
+        console.error(`  ${stale.length} STALE registry entr(ies):\n`);
+        stale.forEach(problem => console.error(`    ${problem}`));
+        console.error('\n  The registry must shrink visibly. A stale entry silently widens the accepted set.\n')
+    }
+
+    if (invalid.length) {
+        console.error(`  ${invalid.length} INVALID registry entr(ies):\n`);
+        invalid.forEach(problem => console.error(`    ${problem}`));
+        console.error('')
+    }
+
+    return {exitCode: 1}
+}
+
+process.exit(runLint().exitCode);

--- a/ai/scripts/lint/lint-guard-ci-parity.mjs
+++ b/ai/scripts/lint/lint-guard-ci-parity.mjs
@@ -51,12 +51,22 @@ import path from 'path';
 import url  from 'url';
 
 const
-    __dirname     = path.dirname(url.fileURLToPath(import.meta.url)),
-    REPO_ROOT     = path.resolve(__dirname, '../../..'),
-    WORKFLOW_DIR  = path.join(REPO_ROOT, '.github/workflows'),
-    REGISTRY_REL  = 'ai/scripts/lint/guard-ci-parity-registry.json',
-    REGISTRY_PATH = path.join(REPO_ROOT, REGISTRY_REL),
-    PKG_PATH      = path.join(REPO_ROOT, 'package.json');
+    __dirname    = path.dirname(url.fileURLToPath(import.meta.url)),
+    REPO_ROOT    = path.resolve(__dirname, '../../..'),
+    WORKFLOW_DIR = path.join(REPO_ROOT, '.github/workflows'),
+    REGISTRY_REL = 'ai/scripts/lint/guard-ci-parity-registry.json',
+    PKG_PATH     = path.join(REPO_ROOT, 'package.json'),
+
+    /**
+     * The committed registry, unless a spec points this at a fixture.
+     *
+     * The override exists so the sibling spec can prove this guard goes RED without mutating the
+     * real registry — a red-proof that edits the tree it is proving things about would leave the
+     * repo dirty on failure and could not run in parallel. Production never sets it.
+     */
+    REGISTRY_PATH = process.env.NEO_GUARD_CI_PARITY_REGISTRY
+        ? path.resolve(process.env.NEO_GUARD_CI_PARITY_REGISTRY)
+        : path.join(REPO_ROOT, REGISTRY_REL);
 
 /**
  * @summary Every distinct guard script invoked by `lint-staged`, derived — never hardcoded.

--- a/ai/scripts/lint/lint-guard-ci-parity.mjs
+++ b/ai/scripts/lint/lint-guard-ci-parity.mjs
@@ -10,7 +10,7 @@
  *
  * > *CI mirror of the `.husky/pre-commit` guard, so `git commit --no-verify` cannot bypass it.*
  *
- * Four guards follow it. Five do not, and one of those is a **syntax** check. This guard makes the
+ * Five guards follow it. Six do not, and one of those is a **syntax** check. This guard makes the
  * convention mechanical so the next unmirrored guard fails on arrival instead of being discovered
  * by someone whose merge needed `--no-verify`.
  *
@@ -74,6 +74,12 @@ const
  * Deriving is the point: adding a tenth guard with no workflow must fail without anyone editing
  * this file. A hardcoded list would answer today's question and rot.
  *
+ * **No naming allowlist.** An earlier revision matched `check-*` / `lint-*`, which is a filter on the
+ * NAME rather than on the configuration — so a guard called `validate-json.mjs`, or any existing one
+ * renamed, would vanish from the population silently. That is the exact failure this ticket exists to
+ * fix, reproduced inside the fix: the hand census that motivated it missed the `lint-*` family for
+ * precisely this reason. The population is now every `.mjs` a configured command executes.
+ *
  * @returns {String[]} script paths as written in `lint-staged`, e.g. `buildScripts/util/check-parse.mjs`
  */
 function discoverGuards() {
@@ -83,7 +89,8 @@ function discoverGuards() {
         scripts  = new Set();
 
     commands.forEach(command => {
-        const match = `${command}`.match(/([\w./-]*(?:check|lint)-[\w.-]+\.mjs)/);
+        // `node ./path/to/whatever.mjs …` — the executed script, whatever it is called.
+        const match = `${command}`.match(/\bnode\s+(?:--[\w-]+(?:=\S+)?\s+)*([\w./-]+\.mjs)/);
 
         match && scripts.add(match[1].replace(/^\.\//, ''))
     });
@@ -92,36 +99,69 @@ function discoverGuards() {
 }
 
 /**
- * @summary Workflow YAML with comment lines removed, so a guard NAMED in prose is not counted as
- * a guard INVOKED by the workflow.
+ * @summary Per workflow, the set of scripts its `run:` steps actually EXECUTE.
  *
- * @returns {Object[]} `{file, body}` per workflow
+ * ## Why execution and not mention
+ *
+ * A workflow can name a guard without running it, and the commonest way is `on.paths`: a trigger
+ * filter listing the guard so edits to it re-run the workflow. `aiconfig-antipattern-lint.yml` lists
+ * `check-aiconfig-test-mutation.mjs` in `on.paths` twice while its `run:` step executes
+ * `check-aiconfig-antipatterns.mjs` — a different guard.
+ *
+ * A mention-based match therefore credits coverage that does not exist. That is the **same
+ * false-green class this lint audits, reproduced one layer above the guards it governs**: an earlier
+ * revision stripped comments to stop prose counting as coverage, and left the larger hole open —
+ * trigger filters are not executions either.
+ *
+ * Comments are still stripped, because a commented-out `run:` is not an execution.
+ *
+ * @returns {Object[]} `{file, executed:Set<String>}` per workflow, keyed by script basename
  */
-function workflowBodies() {
+function workflowExecutions() {
     if (!fs.existsSync(WORKFLOW_DIR)) {
         return []
     }
 
     return fs.readdirSync(WORKFLOW_DIR)
         .filter(file => /\.ya?ml$/.test(file))
-        .map(file => ({
-            file,
-            body: fs.readFileSync(path.join(WORKFLOW_DIR, file), 'utf8')
-                .split('\n')
-                .filter(line => !line.trim().startsWith('#'))
-                .join('\n')
-        }))
+        .map(file => {
+            const
+                lines    = fs.readFileSync(path.join(WORKFLOW_DIR, file), 'utf8').split('\n'),
+                executed = new Set();
+
+            let inRun = false;
+
+            lines.forEach(line => {
+                if (line.trim().startsWith('#')) {
+                    return
+                }
+
+                // A `run:` step opens a shell block; its continuation lines are indented further.
+                /^\s*(-\s*)?run\s*:/.test(line) && (inRun = true);
+
+                if (inRun) {
+                    for (const m of line.matchAll(/([\w./-]+\.mjs)/g)) {
+                        executed.add(path.basename(m[1]))
+                    }
+                }
+
+                // Any new key at step level closes the run block.
+                /^\s*(-\s*)?(name|uses|with|env|if|id)\s*:/.test(line) && (inRun = false)
+            });
+
+            return {file, executed}
+        })
 }
 
 /**
  * @param {String}   script
  * @param {Object[]} workflows
- * @returns {String[]} workflow filenames that invoke `script`
+ * @returns {String[]} workflow filenames whose `run:` steps execute `script`
  */
 function mirrorsOf(script, workflows) {
     const basename = path.basename(script);
 
-    return workflows.filter(({body}) => body.includes(basename)).map(({file}) => file)
+    return workflows.filter(({executed}) => executed.has(basename)).map(({file}) => file)
 }
 
 /**
@@ -130,7 +170,7 @@ function mirrorsOf(script, workflows) {
 function runLint() {
     const
         guards     = discoverGuards(),
-        workflows  = workflowBodies(),
+        workflows  = workflowExecutions(),
         registry   = JSON.parse(fs.readFileSync(REGISTRY_PATH, 'utf8')),
         accepted   = new Map(Object.entries(registry.clientOnly || {})),
         unmirrored = [],
@@ -158,6 +198,22 @@ function runLint() {
     const invalid = [...accepted.entries()]
         .filter(([, entry]) => !entry || !entry.reason || !entry.witness)
         .map(([key]) => `${key} — every entry needs BOTH a reason and a witness; one without them is a suppression, not an acceptance`);
+
+    // The registry is a RATCHET: it may shrink freely and may not grow silently.
+    //
+    // Asserting equality would be the obvious check and the wrong one — it would fail the moment
+    // someone mirrors a guard and removes its entry, i.e. it would block the shrinkage this registry
+    // exists to enable. `baselineAtIntroduction` is a historical high-water mark, not a current count.
+    //
+    // Enforced rather than documented because it was documented, and went stale: the baseline read 5
+    // beside six entries until a reviewer noticed. A number no predicate checks is a census.
+    const baseline = registry.$schema?.baselineAtIntroduction;
+
+    Number.isInteger(baseline) && accepted.size > baseline && invalid.push(
+        `the registry GREW: ${accepted.size} accepted entries against a baseline of ${baseline}. ` +
+        'Adding an accepted client-only guard is a deliberate act — mirror it instead, or raise ' +
+        '`baselineAtIntroduction` in the same commit with the reason in the PR body.'
+    );
 
     if (unmirrored.length === 0 && stale.length === 0 && invalid.length === 0) {
         console.log(`[lint-guard-ci-parity] OK (${guards.length} lint-staged guards, ${accepted.size} accepted client-only)`);

--- a/ai/scripts/maintenance/compactGraphLog.mjs
+++ b/ai/scripts/maintenance/compactGraphLog.mjs
@@ -1,12 +1,12 @@
 // Bootstrap Neo namespace BEFORE importing runtime config; `ConfigProvider` consumes core utilities
 // through `Neo.gatekeep()` / `Neo.isObject()` once the config module is loaded.
-import Neo                            from '../../../src/Neo.mjs';
-import * as core                      from '../../../src/core/_export.mjs';
-import {Command}                      from 'commander';
-import Database                       from 'better-sqlite3';
-import fs                             from 'fs-extra';
-import path                           from 'path';
-import {pathToFileURL}                from 'url';
+import Neo             from '../../../src/Neo.mjs';
+import * as core       from '../../../src/core/_export.mjs';
+import {Command}       from 'commander';
+import Database        from 'better-sqlite3';
+import fs              from 'fs-extra';
+import path            from 'path';
+import {pathToFileURL} from 'url';
 import {
     activeWakeSubscriptionStatusSql,
     WAKE_SUBSCRIPTION_DEFAULT_STATUS
@@ -55,8 +55,8 @@ export function getDefaultGraphLogCompactionOptions({aiConfig}) {
 
     return {
         dbPath          : aiConfig.storagePaths.graph,
-        bridgeStateFile: aiConfig.wakeDaemon.bridgeLastSyncIdPath,
-        wakeStateFile  : aiConfig.wakeDaemon.wakeSubscriptionLiveCursorPath,
+        bridgeStateFile : aiConfig.wakeDaemon.bridgeLastSyncIdPath,
+        wakeStateFile   : aiConfig.wakeDaemon.wakeSubscriptionLiveCursorPath,
         safetyMarginRows: DEFAULT_SAFETY_MARGIN_ROWS
     };
 }
@@ -123,9 +123,9 @@ export function getGraphLogStats({db, dbPath = null, fsModule = fs}) {
     `).get()?.bytes ?? null;
 
     return {
-        rowCount    : row.rowCount || 0,
-        minLogId    : row.minLogId || 0,
-        maxLogId    : row.maxLogId || 0,
+        rowCount: row.rowCount || 0,
+        minLogId: row.minLogId || 0,
+        maxLogId: row.maxLogId || 0,
         pageSize,
         pageCount,
         freelist,
@@ -411,8 +411,8 @@ export function runGraphLogCompaction({
         db.pragma('journal_mode = WAL');
         db.pragma('busy_timeout = 5000');
 
-        const before          = getGraphLogStats({db, dbPath, fsModule});
-        const subscriptions   = listActiveWakeSubscriptions({db});
+        const before              = getGraphLogStats({db, dbPath, fsModule});
+        const subscriptions       = listActiveWakeSubscriptions({db});
         const wakeDaemonWatermark = readWakeDaemonWatermark({
             stateFile  : bridgeStateFile,
             latestLogId: before.maxLogId,
@@ -444,7 +444,7 @@ export function runGraphLogCompaction({
             db.exec('VACUUM');
         }
 
-        const after = getGraphLogStats({db, dbPath, fsModule});
+        const after  = getGraphLogStats({db, dbPath, fsModule});
         const result = {before, after, subscriptions, wakeDaemonWatermark, wakeWatermark, plan, compaction, checkpointResult};
 
         logCompactionResult(result, {apply, vacuum, logger});
@@ -465,7 +465,7 @@ export function runGraphLogCompaction({
 export function buildGraphLogCompactionOutcome(result, {apply = false} = {}) {
     const {before = {}, after = {}, plan = {}, compaction = {}} = result || {};
     const safetyBlocked = plan.disposition === 'safety-blocked';
-    const status = safetyBlocked
+    const status        = safetyBlocked
         ? 'safety-blocked'
         : !apply
             ? 'dry-run'
@@ -572,7 +572,7 @@ export async function runCli(argv = process.argv, {aiConfig = null} = {}) {
     const options = command.opts();
 
     const result = runGraphLogCompaction({
-        dbPath           : path.resolve(options.db),
+        dbPath          : path.resolve(options.db),
         bridgeStateFile : path.resolve(options.bridgeStateFile),
         wakeStateFile   : path.resolve(options.wakeStateFile),
         safetyMarginRows: parseNonNegativeInteger(options.safetyMargin, 'safety-margin'),

--- a/package.json
+++ b/package.json
@@ -261,7 +261,7 @@
             "node ./buildScripts/util/check-aiconfig-test-mutation.mjs",
             "node ./buildScripts/util/check-derived-domain.mjs"
         ],
-        "{package.json,.github/workflows/*.yml,.github/workflows/*.yaml,ai/scripts/lint/lint-guard-ci-parity.mjs,ai/scripts/lint/guard-ci-parity-registry.json}": [
+        "{package.json,.husky/pre-commit,.github/workflows/*.yml,.github/workflows/*.yaml,ai/scripts/lint/lint-guard-ci-parity.mjs,ai/scripts/lint/guard-ci-parity-registry.json}": [
             "node ./ai/scripts/lint/lint-guard-ci-parity.mjs"
         ],
         "ai/{services,services.mjs}/**": [

--- a/package.json
+++ b/package.json
@@ -261,7 +261,7 @@
             "node ./buildScripts/util/check-aiconfig-test-mutation.mjs",
             "node ./buildScripts/util/check-derived-domain.mjs"
         ],
-        "{package.json,.github/workflows/*.yml,ai/scripts/lint/guard-ci-parity-registry.json}": [
+        "{package.json,.github/workflows/*.yml,.github/workflows/*.yaml,ai/scripts/lint/lint-guard-ci-parity.mjs,ai/scripts/lint/guard-ci-parity-registry.json}": [
             "node ./ai/scripts/lint/lint-guard-ci-parity.mjs"
         ],
         "ai/{services,services.mjs}/**": [

--- a/package.json
+++ b/package.json
@@ -261,6 +261,9 @@
             "node ./buildScripts/util/check-aiconfig-test-mutation.mjs",
             "node ./buildScripts/util/check-derived-domain.mjs"
         ],
+        "{package.json,.github/workflows/*.yml,ai/scripts/lint/guard-ci-parity-registry.json}": [
+            "node ./ai/scripts/lint/lint-guard-ci-parity.mjs"
+        ],
         "ai/{services,services.mjs}/**": [
             "node ./ai/scripts/lint/lint-openapi-service-parity.mjs"
         ],

--- a/test/playwright/unit/ai/daemons/orchestrator/services/HeavyMaintenanceLeaseService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/HeavyMaintenanceLeaseService.spec.mjs
@@ -1414,9 +1414,9 @@ test.describe('Neo.ai.daemons.services.HeavyMaintenanceLeaseService (#11505)', (
         await withHeldLifecycleGuard(leasePath, async () => {
             await expect(releaseHeavyMaintenanceLease({
                 leasePath,
-                token             : 'release-token',
-                guardStaleAfterMs : 60000,
-                fsModule          : contentionFs
+                token            : 'release-token',
+                guardStaleAfterMs: 60000,
+                fsModule         : contentionFs
             })).rejects.toThrow(guardPath);
         });
     });
@@ -1428,10 +1428,10 @@ test.describe('Neo.ai.daemons.services.HeavyMaintenanceLeaseService (#11505)', (
         await withHeldLifecycleGuard(leasePath, async () => {
             await expect(renewHeavyMaintenanceLease({
                 leasePath,
-                token             : 'renew-token',
-                staleAfterMs      : TEST_LEASE_STALE_MS,
-                guardStaleAfterMs : 60000,
-                fsModule          : contentionFs
+                token            : 'renew-token',
+                staleAfterMs     : TEST_LEASE_STALE_MS,
+                guardStaleAfterMs: 60000,
+                fsModule         : contentionFs
             })).rejects.toThrow(guardPath);
         });
     });
@@ -1443,9 +1443,9 @@ test.describe('Neo.ai.daemons.services.HeavyMaintenanceLeaseService (#11505)', (
         withHeldLifecycleGuardSync(leasePath, () => {
             expect(() => releaseHeavyMaintenanceLeaseSync({
                 leasePath,
-                token             : 'release-token',
-                guardStaleAfterMs : 60000,
-                fsModule          : contentionFs
+                token            : 'release-token',
+                guardStaleAfterMs: 60000,
+                fsModule         : contentionFs
             })).toThrow(guardPath);
         });
     });
@@ -1457,10 +1457,10 @@ test.describe('Neo.ai.daemons.services.HeavyMaintenanceLeaseService (#11505)', (
         withHeldLifecycleGuardSync(leasePath, () => {
             expect(() => renewHeavyMaintenanceLeaseSync({
                 leasePath,
-                token             : 'renew-token',
-                staleAfterMs      : TEST_LEASE_STALE_MS,
-                guardStaleAfterMs : 60000,
-                fsModule          : contentionFs
+                token            : 'renew-token',
+                staleAfterMs     : TEST_LEASE_STALE_MS,
+                guardStaleAfterMs: 60000,
+                fsModule         : contentionFs
             })).toThrow(guardPath);
         });
     });

--- a/test/playwright/unit/ai/scripts/lint/lintGuardCiParity.spec.mjs
+++ b/test/playwright/unit/ai/scripts/lint/lintGuardCiParity.spec.mjs
@@ -72,21 +72,32 @@ function runLint({mutate} = {}) {
  *
  * @param {Object} config
  * @param {Object} config.lintStaged
- * @param {Object<String, String>} config.workflows
+ * @param {Object<String, String|Object>} config.workflows String source, or `{source, defaultTrigger}`
  * @param {Object} [config.clientOnly={}]
+ * @param {String} [config.preCommit='npx lint-staged\n']
  * @returns {Object} `{code, output}`
  */
-function runFixture({lintStaged, workflows, clientOnly = {}}) {
+function runFixture({lintStaged, workflows, clientOnly = {}, preCommit = 'npx lint-staged\n'}) {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'neo-guard-parity-root-'));
 
     try {
         fs.writeJsonSync(path.join(dir, 'package.json'), {'lint-staged': lintStaged}, {spaces: 4});
 
-        Object.entries(workflows).forEach(([file, source]) => {
+        fs.ensureDirSync(path.join(dir, '.husky'));
+        fs.writeFileSync(path.join(dir, '.husky/pre-commit'), preCommit);
+
+        Object.entries(workflows).forEach(([file, workflow]) => {
+            const
+                source         = typeof workflow === 'string' ? workflow : workflow.source,
+                defaultTrigger = typeof workflow === 'string' || workflow.defaultTrigger !== false,
+                renderedSource = defaultTrigger && !/^on:/m.test(source)
+                    ? `on:\n  pull_request:\n    branches: [dev]\n${source}`
+                    : source;
+
             const filePath = path.join(dir, '.github/workflows', file);
 
             fs.ensureDirSync(path.dirname(filePath));
-            fs.writeFileSync(filePath, source)
+            fs.writeFileSync(filePath, renderedSource)
         });
 
         const registryPath = path.join(dir, 'ai/scripts/lint/guard-ci-parity-registry.json');
@@ -134,13 +145,17 @@ test.describe('every lint-staged guard has a CI mirror or a recorded reason', ()
 
         [
             'package.json',
+            '.husky/pre-commit',
             '.github/workflows/specimen.yml',
             '.github/workflows/specimen.yaml',
             SELF_REL,
             'ai/scripts/lint/guard-ci-parity-registry.json'
         ].forEach(source => {
             expect(path.matchesGlob(source, pattern), `${source} must trigger the local carrier`).toBe(true)
-        })
+        });
+
+        expect(fs.readFileSync(path.join(REPO_ROOT, '.husky/pre-commit'), 'utf8').trim())
+            .toMatch(/npx lint-staged$/)
     });
 
     test('RED: an unmirrored guard missing from the registry fails, and is NAMED', () => {
@@ -187,8 +202,8 @@ test.describe('every lint-staged guard has a CI mirror or a recorded reason', ()
 
     test('a guard NAMED in a workflow comment is not counted as INVOKED by it', () => {
         // The detection trap. `ticket-archaeology-lint.yml` mentions block-alignment in prose while
-        // not invoking it. Comment stripping is what keeps a prose mention from reading as coverage;
-        // this pins the behaviour so a later "simplification" cannot quietly remove it.
+        // not invoking it. Structural YAML traversal plus direct-command classification keeps that
+        // prose outside execution evidence; this pins the boundary against later simplification.
         const workflow = fs.readFileSync(
             path.join(REPO_ROOT, '.github/workflows/ticket-archaeology-lint.yml'), 'utf8'
         );
@@ -215,13 +230,35 @@ test.describe('every lint-staged guard has a CI mirror or a recorded reason', ()
                 '*.mjs': ['node ./tools/arbitrary-name.mjs']
             },
             workflows: {
-                'arbitrary.yml': `jobs:\n  lint:\n    steps:\n      - run: node ./tools/arbitrary-name.mjs\n`
+                'arbitrary-lint.yml': `jobs:\n  lint:\n    steps:\n      - run: node ./tools/arbitrary-name.mjs\n`
             }
         });
 
         expect(code, `the guard must not disappear with its own carrier.\n\n${output}`).toBe(1);
         expect(output).toContain(SELF_REL);
         expect(output).toMatch(/commit-time carrier missing/i)
+    });
+
+    test('RED: missing or unreachable Git hook lint-staged carriers are detected directly', () => {
+        [
+            {label: 'missing', preCommit: ''},
+            {label: 'early exit', preCommit: 'exit 0\nnpx lint-staged\n'},
+            {label: 'dead branch', preCommit: 'if false; then\n  npx lint-staged\nfi\n'}
+        ].forEach(({label, preCommit}) => {
+            const {code, output} = runFixture({
+                lintStaged: {
+                    '*.mjs': [`node ./${SELF_REL}`]
+                },
+                workflows: {
+                    'guard-lint.yml': `jobs:\n  lint:\n    steps:\n      - run: node ./${SELF_REL}\n`
+                },
+                preCommit
+            });
+
+            expect(code, `${label} hook must not certify commit-time reachability.\n\n${output}`).toBe(1);
+            expect(output).toContain('.husky/pre-commit');
+            expect(output).toMatch(/npx lint-staged.*carrier missing/i)
+        })
     });
 
     test('RED: a same-basename workflow execution does not mirror a different path', () => {
@@ -234,8 +271,8 @@ test.describe('every lint-staged guard has a CI mirror or a recorded reason', ()
                 ]
             },
             workflows: {
-                'guard.yml': `jobs:\n  lint:\n    steps:\n      - run: node ./${SELF_REL}\n`,
-                'alpha.yml': `jobs:\n  lint:\n    steps:\n      - run: node ./alpha/shared-name.mjs\n`
+                'guard-lint.yml': `jobs:\n  lint:\n    steps:\n      - run: node ./${SELF_REL}\n`,
+                'alpha-lint.yml': `jobs:\n  lint:\n    steps:\n      - run: node ./alpha/shared-name.mjs\n`
             }
         });
 
@@ -244,21 +281,115 @@ test.describe('every lint-staged guard has a CI mirror or a recorded reason', ()
         expect(output).not.toMatch(/alpha\/shared-name\.mjs\s*$/m)
     });
 
-    test('RED: an mjs argument inside run is a mention, not a Node execution', () => {
+    test('RED: shell mentions, dead commands, and masked commands are not execution evidence', () => {
+        [
+            {label: 'echo', step: '      - run: "echo node ./tools/mentioned-only.mjs"\n'},
+            {label: 'comment', step: '      - run: "# node ./tools/mentioned-only.mjs"\n'},
+            {label: 'prefixed executable', step: '      - run: fake-node ./tools/mentioned-only.mjs\n'},
+            {label: 'path prefix', step: '      - run: node ./tools/mentioned-only.mjsx\n'},
+            {label: 'Node check mode', step: '      - run: node --check ./tools/mentioned-only.mjs\n'},
+            {label: 'dead branch', step: '      - run: "if false; then node ./tools/mentioned-only.mjs; fi"\n'},
+            {label: 'masked failure', step: '      - run: "node ./tools/mentioned-only.mjs || true"\n'},
+            {
+                label: 'expression injection',
+                step : '      - run: node ./tools/mentioned-only.mjs ${{ matrix.suffix }}\n'
+            },
+            {label: 'shell directory change', step: '      - run: "cd nested && node ./tools/mentioned-only.mjs"\n'},
+            {label: 'continue-on-error', step: '      - continue-on-error: true\n        run: node ./tools/mentioned-only.mjs\n'},
+            {label: 'conditional step', step: '      - if: false\n        run: node ./tools/mentioned-only.mjs\n'},
+            {
+                label   : 'conditional job',
+                workflow: 'jobs:\n  lint:\n    if: false\n    steps:\n      - run: node ./tools/mentioned-only.mjs\n'
+            },
+            {label: 'custom shell', step: '      - shell: "echo {0}"\n        run: node ./tools/mentioned-only.mjs\n'},
+            {
+                label   : 'inherited workflow shell',
+                workflow: 'defaults:\n  run:\n    shell: "echo {0}"\njobs:\n  lint:\n    steps:\n      - run: node ./tools/mentioned-only.mjs\n'
+            },
+            {
+                label   : 'inherited job shell',
+                workflow: 'jobs:\n  lint:\n    defaults:\n      run:\n        shell: "echo {0}"\n    steps:\n      - run: node ./tools/mentioned-only.mjs\n'
+            },
+            {
+                label: 'execution-sensitive environment',
+                step : '      - env:\n          NODE_OPTIONS: --import=data:text/javascript,process.exit(0)\n        run: node ./tools/mentioned-only.mjs\n'
+            },
+            {label: 'later status mask', step: '      - run: |\n          node ./tools/mentioned-only.mjs\n          echo masked\n'}
+        ].forEach(({label, step, workflow}) => {
+            const {code, output} = runFixture({
+                lintStaged: {
+                    '*.mjs': [
+                        `node ./${SELF_REL}`,
+                        'node ./tools/mentioned-only.mjs'
+                    ]
+                },
+                workflows: {
+                    'guard-lint.yml'  : `jobs:\n  lint:\n    steps:\n      - run: node ./${SELF_REL}\n`,
+                    'mention-lint.yml': workflow || `jobs:\n  lint:\n    steps:\n${step}`
+                }
+            });
+
+            expect(code, `${label} must not certify a CI mirror.\n\n${output}`).toBe(1);
+            expect(output).toContain('tools/mentioned-only.mjs')
+        })
+    });
+
+    test('declarative working-directory preserves the executed script full path', () => {
         const {code, output} = runFixture({
             lintStaged: {
                 '*.mjs': [
                     `node ./${SELF_REL}`,
-                    'node ./tools/mentioned-only.mjs'
+                    'node ./nested/tools/scoped.mjs'
                 ]
             },
             workflows: {
-                'guard.yml'  : `jobs:\n  lint:\n    steps:\n      - run: node ./${SELF_REL}\n`,
-                'mention.yml': `jobs:\n  lint:\n    steps:\n      - run: echo ./tools/mentioned-only.mjs\n`
+                'guard-lint.yml' : `jobs:\n  lint:\n    steps:\n      - run: node ./${SELF_REL}\n`,
+                'scoped-lint.yml': 'jobs:\n  lint:\n    steps:\n      - working-directory: nested\n        run: node ./tools/scoped.mjs\n'
             }
         });
 
-        expect(code, `echoing a path is not executing its guard.\n\n${output}`).toBe(1);
-        expect(output).toContain('tools/mentioned-only.mjs')
+        expect(code, `declarative working-directory should resolve the full-path mirror.\n\n${output}`).toBe(0);
+        expect(output).toMatch(/\[lint-guard-ci-parity\] OK/)
+    });
+
+    test('RED: workflows that do not gate dev pull requests are not mirrors', () => {
+        [
+            {
+                label   : 'triggerless',
+                workflow: {source: 'jobs:\n  lint:\n    steps:\n      - run: node ./tools/dead.mjs\n', defaultTrigger: false}
+            },
+            {
+                label   : 'dispatch only',
+                workflow: 'on:\n  workflow_dispatch:\njobs:\n  lint:\n    steps:\n      - run: node ./tools/dead.mjs\n'
+            },
+            {
+                label   : 'other branch',
+                workflow: 'on:\n  pull_request:\n    branches: [main]\njobs:\n  lint:\n    steps:\n      - run: node ./tools/dead.mjs\n'
+            },
+            {
+                label   : 'post-close only',
+                workflow: 'on:\n  pull_request:\n    branches: [dev]\n    types: [closed]\njobs:\n  lint:\n    steps:\n      - run: node ./tools/dead.mjs\n'
+            },
+            {
+                label   : 'ignored paths',
+                workflow: 'on:\n  pull_request:\n    branches: [dev]\n    paths-ignore: ["**"]\njobs:\n  lint:\n    steps:\n      - run: node ./tools/dead.mjs\n'
+            }
+        ].forEach(({label, workflow}) => {
+            const {code, output} = runFixture({
+                lintStaged: {
+                    '*.mjs': [
+                        `node ./${SELF_REL}`,
+                        'node ./tools/dead.mjs'
+                    ]
+                },
+                workflows: {
+                    'guard-lint.yml': `jobs:\n  lint:\n    steps:\n      - run: node ./${SELF_REL}\n`,
+                    'dead-lint.yml' : workflow
+                }
+            });
+
+            expect(code, `${label} must not certify a dev merge gate.\n\n${output}`).toBe(1);
+            expect(output).toContain('tools/dead.mjs')
+        })
     })
 });

--- a/test/playwright/unit/ai/scripts/lint/lintGuardCiParity.spec.mjs
+++ b/test/playwright/unit/ai/scripts/lint/lintGuardCiParity.spec.mjs
@@ -10,7 +10,8 @@ const
     // lint -> scripts -> ai -> unit -> playwright -> test -> repo root
     REPO_ROOT  = path.resolve(__dirname, '../../../../../..'),
     LINT       = path.join(REPO_ROOT, 'ai/scripts/lint/lint-guard-ci-parity.mjs'),
-    REGISTRY   = path.join(REPO_ROOT, 'ai/scripts/lint/guard-ci-parity-registry.json');
+    REGISTRY   = path.join(REPO_ROOT, 'ai/scripts/lint/guard-ci-parity-registry.json'),
+    SELF_REL   = 'ai/scripts/lint/lint-guard-ci-parity.mjs';
 
 /**
  * @summary Proves the guard-CI-parity lint actually fails, and fails for the stated reason.
@@ -62,6 +63,56 @@ function runLint({mutate} = {}) {
     }
 }
 
+/**
+ * @summary Runs the production lint against an isolated synthetic repository.
+ *
+ * Classifier falsifiers need to control all three authorities together: configured commands,
+ * workflow executions, and accepted client-only paths. The production entrypoint remains the code
+ * under test; only its repo root is redirected to the bounded fixture.
+ *
+ * @param {Object} config
+ * @param {Object} config.lintStaged
+ * @param {Object<String, String>} config.workflows
+ * @param {Object} [config.clientOnly={}]
+ * @returns {Object} `{code, output}`
+ */
+function runFixture({lintStaged, workflows, clientOnly = {}}) {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'neo-guard-parity-root-'));
+
+    try {
+        fs.writeJsonSync(path.join(dir, 'package.json'), {'lint-staged': lintStaged}, {spaces: 4});
+
+        Object.entries(workflows).forEach(([file, source]) => {
+            const filePath = path.join(dir, '.github/workflows', file);
+
+            fs.ensureDirSync(path.dirname(filePath));
+            fs.writeFileSync(filePath, source)
+        });
+
+        const registryPath = path.join(dir, 'ai/scripts/lint/guard-ci-parity-registry.json');
+
+        fs.ensureDirSync(path.dirname(registryPath));
+        fs.writeJsonSync(registryPath, {
+            $schema: {baselineAtIntroduction: Object.keys(clientOnly).length},
+            clientOnly
+        }, {spaces: 4});
+
+        const result = spawnSync(process.execPath, [LINT], {
+            cwd     : dir,
+            encoding: 'utf8',
+            env     : {
+                ...process.env,
+                NEO_GUARD_CI_PARITY_REGISTRY : registryPath,
+                NEO_GUARD_CI_PARITY_REPO_ROOT: dir
+            }
+        });
+
+        return {code: result.status, output: `${result.stdout || ''}${result.stderr || ''}`}
+    } finally {
+        fs.removeSync(dir)
+    }
+}
+
 test.describe('every lint-staged guard has a CI mirror or a recorded reason', () => {
     test('the committed registry is GREEN — the population is fully classified today', () => {
         const {code, output} = runLint();
@@ -70,11 +121,33 @@ test.describe('every lint-staged guard has a CI mirror or a recorded reason', ()
         expect(output).toMatch(/\[lint-guard-ci-parity\] OK/)
     });
 
+    test('the commit-time carrier covers both workflow suffixes and every local authority', () => {
+        const
+            pkg     = fs.readJsonSync(path.join(REPO_ROOT, 'package.json')),
+            carrier = Object.entries(pkg['lint-staged']).find(([, commands]) => {
+                return [commands].flat().some(command => `${command}`.includes(SELF_REL))
+            });
+
+        expect(carrier, 'package.json must retain the local parity-guard carrier').toBeTruthy();
+
+        const [pattern] = carrier;
+
+        [
+            'package.json',
+            '.github/workflows/specimen.yml',
+            '.github/workflows/specimen.yaml',
+            SELF_REL,
+            'ai/scripts/lint/guard-ci-parity-registry.json'
+        ].forEach(source => {
+            expect(path.matchesGlob(source, pattern), `${source} must trigger the local carrier`).toBe(true)
+        })
+    });
+
     test('RED: an unmirrored guard missing from the registry fails, and is NAMED', () => {
         // The load-bearing case. `check-parse` is a SYNTAX guard with no workflow; dropping its
         // acceptance entry must fail rather than pass silently.
         const {code, output} = runLint({
-            mutate: registry => { delete registry.clientOnly['check-parse.mjs'] }
+            mutate: registry => { delete registry.clientOnly['buildScripts/util/check-parse.mjs'] }
         });
 
         expect(code, `removing an accepted entry must FAIL.\n\n${output}`).toBe(1);
@@ -88,7 +161,7 @@ test.describe('every lint-staged guard has a CI mirror or a recorded reason', ()
         // set. Shrinking the registry has to be enforced, not merely encouraged.
         const {code, output} = runLint({
             mutate: registry => {
-                registry.clientOnly['check-jsdoc-types.mjs'] = {
+                registry.clientOnly['buildScripts/util/check-jsdoc-types.mjs'] = {
                     reason : 'fixture — this guard IS mirrored',
                     witness: 'fixture'
                 }
@@ -102,7 +175,9 @@ test.describe('every lint-staged guard has a CI mirror or a recorded reason', ()
 
     test('RED: an entry without a reason or witness is a suppression, not an acceptance', () => {
         const {code, output} = runLint({
-            mutate: registry => { registry.clientOnly['check-parse.mjs'] = {reason: 'x'} }
+            mutate: registry => {
+                registry.clientOnly['buildScripts/util/check-parse.mjs'] = {reason: 'x'}
+            }
         });
 
         expect(code, `an entry missing its witness must FAIL.\n\n${output}`).toBe(1);
@@ -129,8 +204,61 @@ test.describe('every lint-staged guard has a CI mirror or a recorded reason', ()
 
         expect(output).toMatch(/\[lint-guard-ci-parity\] OK/);
         expect(
-            fs.readJsonSync(REGISTRY).clientOnly['check-block-alignment.mjs'],
+            fs.readJsonSync(REGISTRY).clientOnly['buildScripts/util/check-block-alignment.mjs'],
             'block-alignment must still be classified client-only despite being named in a comment'
         ).toBeTruthy()
+    })
+
+    test('RED: removing this guard commit-time carrier is detected directly', () => {
+        const {code, output} = runFixture({
+            lintStaged: {
+                '*.mjs': ['node ./tools/arbitrary-name.mjs']
+            },
+            workflows: {
+                'arbitrary.yml': `jobs:\n  lint:\n    steps:\n      - run: node ./tools/arbitrary-name.mjs\n`
+            }
+        });
+
+        expect(code, `the guard must not disappear with its own carrier.\n\n${output}`).toBe(1);
+        expect(output).toContain(SELF_REL);
+        expect(output).toMatch(/commit-time carrier missing/i)
+    });
+
+    test('RED: a same-basename workflow execution does not mirror a different path', () => {
+        const {code, output} = runFixture({
+            lintStaged: {
+                '*.mjs': [
+                    `node ./${SELF_REL}`,
+                    'node ./alpha/shared-name.mjs',
+                    'node ./beta/shared-name.mjs'
+                ]
+            },
+            workflows: {
+                'guard.yml': `jobs:\n  lint:\n    steps:\n      - run: node ./${SELF_REL}\n`,
+                'alpha.yml': `jobs:\n  lint:\n    steps:\n      - run: node ./alpha/shared-name.mjs\n`
+            }
+        });
+
+        expect(code, `beta/shared-name.mjs has no mirror and must not alias alpha.\n\n${output}`).toBe(1);
+        expect(output).toContain('beta/shared-name.mjs');
+        expect(output).not.toMatch(/alpha\/shared-name\.mjs\s*$/m)
+    });
+
+    test('RED: an mjs argument inside run is a mention, not a Node execution', () => {
+        const {code, output} = runFixture({
+            lintStaged: {
+                '*.mjs': [
+                    `node ./${SELF_REL}`,
+                    'node ./tools/mentioned-only.mjs'
+                ]
+            },
+            workflows: {
+                'guard.yml'  : `jobs:\n  lint:\n    steps:\n      - run: node ./${SELF_REL}\n`,
+                'mention.yml': `jobs:\n  lint:\n    steps:\n      - run: echo ./tools/mentioned-only.mjs\n`
+            }
+        });
+
+        expect(code, `echoing a path is not executing its guard.\n\n${output}`).toBe(1);
+        expect(output).toContain('tools/mentioned-only.mjs')
     })
 });

--- a/test/playwright/unit/ai/scripts/lint/lintGuardCiParity.spec.mjs
+++ b/test/playwright/unit/ai/scripts/lint/lintGuardCiParity.spec.mjs
@@ -1,0 +1,136 @@
+import {test, expect}  from '@playwright/test';
+import {spawnSync}     from 'node:child_process';
+import fs              from 'fs-extra';
+import os              from 'node:os';
+import path            from 'node:path';
+import {fileURLToPath} from 'node:url';
+
+const
+    __dirname  = path.dirname(fileURLToPath(import.meta.url)),
+    // lint -> scripts -> ai -> unit -> playwright -> test -> repo root
+    REPO_ROOT  = path.resolve(__dirname, '../../../../../..'),
+    LINT       = path.join(REPO_ROOT, 'ai/scripts/lint/lint-guard-ci-parity.mjs'),
+    REGISTRY   = path.join(REPO_ROOT, 'ai/scripts/lint/guard-ci-parity-registry.json');
+
+/**
+ * @summary Proves the guard-CI-parity lint actually fails, and fails for the stated reason.
+ *
+ * ## Why this file exists at all
+ *
+ * The lint it exercises asserts that every `lint-staged` guard is invoked by some workflow — it
+ * exists because a guard nobody mirrors is skipped entirely by `git commit --no-verify`. A
+ * coverage guard that has never been observed RED is exactly the thing that guard is about, so
+ * shipping it on a green run alone would reproduce the defect one level up.
+ *
+ * Each case therefore drives the real script in a spawned process and asserts **the exit code and
+ * the reason**, never merely that something failed. A lint that dies of a missing file also exits
+ * non-zero.
+ *
+ * ## Why a fixture registry rather than editing the real one
+ *
+ * The lint reads `NEO_GUARD_CI_PARITY_REGISTRY` when set. A red-proof that mutated the committed
+ * registry would leave the repo dirty if an assertion threw, and could not run in parallel. The
+ * override exists for this file; production never sets it.
+ *
+ * @param {Object} [config]
+ * @param {Function} [config.mutate] receives the parsed registry and edits it in place
+ * @returns {Object} `{code, output}`
+ */
+function runLint({mutate} = {}) {
+    const registry = fs.readJsonSync(REGISTRY);
+
+    let registryPath = REGISTRY,
+        dir          = null;
+
+    if (mutate) {
+        mutate(registry);
+        dir          = fs.mkdtempSync(path.join(os.tmpdir(), 'neo-guard-parity-'));
+        registryPath = path.join(dir, 'registry.json');
+        fs.writeJsonSync(registryPath, registry, {spaces: 4})
+    }
+
+    try {
+        const result = spawnSync(process.execPath, [LINT], {
+            cwd     : REPO_ROOT,
+            encoding: 'utf8',
+            env     : {...process.env, NEO_GUARD_CI_PARITY_REGISTRY: registryPath}
+        });
+
+        return {code: result.status, output: `${result.stdout || ''}${result.stderr || ''}`}
+    } finally {
+        dir && fs.removeSync(dir)
+    }
+}
+
+test.describe('every lint-staged guard has a CI mirror or a recorded reason', () => {
+    test('the committed registry is GREEN — the population is fully classified today', () => {
+        const {code, output} = runLint();
+
+        expect(code, `the guard should pass against the committed registry.\n\n${output}`).toBe(0);
+        expect(output).toMatch(/\[lint-guard-ci-parity\] OK/)
+    });
+
+    test('RED: an unmirrored guard missing from the registry fails, and is NAMED', () => {
+        // The load-bearing case. `check-parse` is a SYNTAX guard with no workflow; dropping its
+        // acceptance entry must fail rather than pass silently.
+        const {code, output} = runLint({
+            mutate: registry => { delete registry.clientOnly['check-parse.mjs'] }
+        });
+
+        expect(code, `removing an accepted entry must FAIL.\n\n${output}`).toBe(1);
+        expect(output, 'the failure must name the guard, or it is not actionable').toMatch(/check-parse\.mjs/);
+        expect(output).toMatch(/no workflow/i)
+    });
+
+    test('RED: registering an already-mirrored guard fails as STALE, naming its workflow', () => {
+        // The other direction. Without this, the registry could only grow: an entry for a guard
+        // that has since gained a mirror would sit there forever, silently widening the accepted
+        // set. Shrinking the registry has to be enforced, not merely encouraged.
+        const {code, output} = runLint({
+            mutate: registry => {
+                registry.clientOnly['check-jsdoc-types.mjs'] = {
+                    reason : 'fixture — this guard IS mirrored',
+                    witness: 'fixture'
+                }
+            }
+        });
+
+        expect(code, `a stale entry must FAIL.\n\n${output}`).toBe(1);
+        expect(output).toMatch(/STALE/);
+        expect(output, 'the failure must name the workflow that already mirrors it').toMatch(/jsdoc-type-lint\.yml/)
+    });
+
+    test('RED: an entry without a reason or witness is a suppression, not an acceptance', () => {
+        const {code, output} = runLint({
+            mutate: registry => { registry.clientOnly['check-parse.mjs'] = {reason: 'x'} }
+        });
+
+        expect(code, `an entry missing its witness must FAIL.\n\n${output}`).toBe(1);
+        expect(output).toMatch(/INVALID/);
+        expect(output).toMatch(/suppression/)
+    });
+
+    test('a guard NAMED in a workflow comment is not counted as INVOKED by it', () => {
+        // The detection trap. `ticket-archaeology-lint.yml` mentions block-alignment in prose while
+        // not invoking it. Comment stripping is what keeps a prose mention from reading as coverage;
+        // this pins the behaviour so a later "simplification" cannot quietly remove it.
+        const workflow = fs.readFileSync(
+            path.join(REPO_ROOT, '.github/workflows/ticket-archaeology-lint.yml'), 'utf8'
+        );
+
+        const commentedMention = workflow
+            .split('\n')
+            .some(line => line.trim().startsWith('#') && line.includes('block-alignment'));
+
+        expect(commentedMention, 'fixture drift: the prose mention this case pins is gone').toBe(true);
+
+        // …and with that mention present, the guard is still reported as client-only.
+        const {output} = runLint();
+
+        expect(output).toMatch(/\[lint-guard-ci-parity\] OK/);
+        expect(
+            fs.readJsonSync(REGISTRY).clientOnly['check-block-alignment.mjs'],
+            'block-alignment must still be classified client-only despite being named in a comment'
+        ).toBeTruthy()
+    })
+});

--- a/test/playwright/unit/ai/scripts/lint/lintWorkflowScanRootParity.spec.mjs
+++ b/test/playwright/unit/ai/scripts/lint/lintWorkflowScanRootParity.spec.mjs
@@ -224,7 +224,7 @@ function readWorkflowPaths(workflowName) {
 }
 
 test.describe('lint workflow scan-root parity (scanned ⊆ watched, mechanically)', () => {
-    const lintWorkflows = fs.readdirSync(WORKFLOWS_DIR).filter(name => name.endsWith('-lint.yml'));
+    const lintWorkflows = fs.readdirSync(WORKFLOWS_DIR).filter(name => /-lint\.ya?ml$/.test(name));
 
     test('completeness: every path-filtered lint workflow is registered; no registry entry is stale', () => {
         const pathFiltered = lintWorkflows.filter(name => {

--- a/test/playwright/unit/ai/scripts/lint/lintWorkflowScanRootParity.spec.mjs
+++ b/test/playwright/unit/ai/scripts/lint/lintWorkflowScanRootParity.spec.mjs
@@ -4,6 +4,7 @@ import * as yaml      from 'js-yaml';
 import path           from 'node:path';
 
 import {SCAN_SURFACE as CONFIG_TEMPLATE_SURFACE} from '../../../../../../ai/scripts/lint/lint-config-template-ssot.mjs';
+import {SCAN_SURFACE as GUARD_CI_PARITY_SURFACE} from '../../../../../../ai/scripts/lint/lint-guard-ci-parity.mjs';
 import {SCAN_SURFACE as MCP_LOCATION_SURFACE}    from '../../../../../../ai/scripts/lint/lint-mcp-test-locations.mjs';
 import {SCAN_SURFACE as RETRY_BOUND_SURFACE}     from '../../../../../../ai/scripts/lint/lint-retry-bounds.mjs';
 import {DEFAULT_SCAN_PATHS as ARCHAEOLOGY_PATHS} from '../../../../../../buildScripts/util/check-ticket-archaeology.mjs';
@@ -69,6 +70,11 @@ const REGISTRY = Object.freeze({
         scriptRel: 'buildScripts/util/check-content-logical-identity.mjs',
         source   : 'declared',
         surface  : ['resources/content/archive/**']
+    },
+    'guard-ci-parity-lint.yml': {
+        scriptRel: 'ai/scripts/lint/lint-guard-ci-parity.mjs',
+        source   : 'imported',
+        surface  : GUARD_CI_PARITY_SURFACE
     },
     'identity-engine-coherence-lint.yml': {
         scriptRel: 'ai/scripts/lint/lint-identity-engine-coherence.mjs',


### PR DESCRIPTION
Resolves #16753

The repo states the convention in `ticket-archaeology-lint.yml`'s own header — a CI mirror exists **so `git commit --no-verify` cannot bypass the guard**. Six of twelve `lint-staged` guards follow it; the other six remain explicitly registered client-only. This makes the convention mechanical, so the next unmirrored guard fails on arrival instead of being discovered by someone whose merge needed `--no-verify`.

Evidence: L3 — eleven tests drive the real predicate as a spawned process, including eight RED directions; a twelfth pins every local carrier surface. The two `dev` repairs are verified by a whitespace-only diff control plus a full unit run, not by the guard's own green.

## Deltas

**1. The population is DERIVED, never hardcoded** — read from `package.json`'s `lint-staged`. Adding a guard with no workflow must fail without editing the lint.

That mattered immediately, against its author. The hand census that motivated the ticket said **5 of 9**. The predicate's *first run* reported **6 of 11**: it saw `lint-fleet-vocabulary-parity.mjs`, invisible to a census whose regex matched `check-*` and was structurally blind to the `lint-*` family. @neo-opus-grace had already reported 6/11; hers was the complete count and I filed the smaller one anyway. The ticket body is corrected with the strike retained. The guard's own commit-time carrier makes the current population twelve: six mirrored, six registered client-only.

**A census answers today and rots. A predicate classifies the population as a side effect and runs at commit time** — the ticket's own thesis, demonstrated against the person who wrote it.

**2. Why this reports a DEFECT where `lint-retry-bounds` reports `unclassified`.** Its sibling deliberately never says "unbounded", because its discovery patterns have a larger false-positive family than true-positive set. This is the opposite case: the population is **exact**, read from config rather than inferred from syntax. So "unmirrored" is a defect claim, and the registry records *accepted* ones — it is not there to absorb false positives.

**3. Workflow enforcement is parsed, not inferred from mentions.** Only `*-lint.yml/.yaml` workflows that gate `dev` pull requests qualify. YAML is read structurally, and only one direct, unmasked `node <script>.mjs` command with no runtime options, expressions, custom shell, environment override, conditional, or `continue-on-error` counts. Paths stay normalized and repo-relative, so same-basename guards cannot alias; declarative `working-directory` is resolved explicitly.

**4. The two `dev` repairs** @neo-opus-vega correctly refused to absorb into her merge commit.

## Test Evidence

New: `test/playwright/unit/ai/scripts/lint/lintGuardCiParity.spec.mjs` — 12 tests. Eleven drive the real script in spawned processes and assert the exit code **and** the reason; the twelfth pins the local carrier's hook, `.yml`, `.yaml`, implementation, package, and registry surfaces. A lint that dies of a missing file also exits non-zero.

```
GREEN   the committed registry classifies the whole population today
PINNED  the local carrier covers hook, .yml, .yaml, implementation, package, and registry
RED     an unmirrored guard missing from the registry fails, and is NAMED
RED     registering an already-mirrored guard fails as STALE, naming its workflow
RED     an entry lacking a reason or witness fails as a suppression
PINNED  a guard named in a workflow COMMENT is not counted as invoked by it
RED     removing the guard's own lint-staged carrier is detected
RED     missing, early-exit, and dead-branch Git-hook carriers are rejected
RED     one same-basename execution does not mirror a different path
RED     mentions, dead commands, runtime masks, custom shells, and env overrides are rejected
GREEN   declarative working-directory resolves the full path
RED     triggerless, dispatch-only, wrong-branch, post-close, and paths-ignore workflows are rejected
```

```bash
NEO_TEST_SKIP_CI=true npm run test-unit -- \
  test/playwright/unit/ai/scripts/lint/lintGuardCiParity.spec.mjs \
  test/playwright/unit/ai/scripts/lint/lintWorkflowScanRootParity.spec.mjs  # 50/50
node ai/scripts/lint/lint-guard-ci-parity.mjs                               # OK (12 guards, 6 accepted)
```

**The stale-entry case is what keeps the registry shrinkable.** Without it the registry could only grow: an entry for a guard that later gained a mirror would sit there forever, silently widening the accepted set.

**The comment case asserts its own fixture first** — it checks the prose mention still exists before relying on it, so fixture drift fails loudly rather than turning the test vacuous.

**Repair verification, and the control is the load-bearing part:**

| | |
|---|---|
| `compactGraphLog.mjs` | 17 violations → 0 |
| `HeavyMaintenanceLeaseService.spec.mjs` | 14 violations → 0 |
| `src/Neo.mjs` *(control)* | 0 violations, untouched |
| `git diff -w` | **empty** — whitespace-only, no code moved |
| `node --check` | passes on both committed files |
| lease spec unit run | **51/51** |

`--fix` was used, and it is the tool my own notes warn corrupts destructuring — these two files carry 10 and 6 destructuring patterns. **The `diff -w` control is why the result is trustworthy: a parse check alone would accept a file whose destructuring had been silently rewritten into something still syntactically valid.**

## Post-Merge Validation

- The registry's `baselineAtIntroduction` is the number to watch. It should only ever shrink; a PR that grows it needs a reason in review.
- `check-parse` is the highest-priority mirror to add next — a **syntax** guard with no CI backstop. Deliberately out of scope here: adding mirrors cold reds **593 pre-existing lines** (measured by @neo-opus-grace), which is the migration this PR exists to make incremental, not perform.
- Sibling lane: `#16684` / PR #16730 enforces `scanned ⊆ watched`. The predicates compose rather than duplicate: that parity spec needs a workflow scan set, while this guard proves the workflow exists in the first place.

Reviewer polish at `d354ce8465` and `b2af9fcd21` by @neo-gpt closes the retained full-path identity, exact execution, self-carrier, `.yaml`, Git-hook reachability, unmasked-command, and dev-PR trigger edges from Cycle 1. The second head is independently re-audited clean.

Authored by @neo-opus-ada (Ada) · Claude Opus 5
