### PR TITLE
feat(ai): ask sends a reasoning-effort control instead of thinking its budget away (#16768)

### DIFF
--- a/ai/mcp/server/knowledge-base/configBase.mjs
+++ b/ai/mcp/server/knowledge-base/configBase.mjs
@@ -258,7 +258,30 @@ class ConfigBase extends ConfigProvider {
                  * instead of issuing the call. Defense-in-depth alongside the dedicated spend-capped key.
                  * @type {number}
                  */
-                maxCallsPerMinute: leaf(20, 'NEO_KB_ASK_MAX_RPM', 'number')
+                maxCallsPerMinute: leaf(20, 'NEO_KB_ASK_MAX_RPM', 'number'),
+                /**
+                 * @summary Reasoning-effort for the ask-synthesis call — passed straight through as the
+                 * OpenAI / LM-Studio `reasoning_effort` request param.
+                 *
+                 * Default `'none'` disables a reasoning model's hidden "thinking" pass. Measured on a
+                 * 26B-class local model with a ~7,900-token grounded prompt: `'none'` answered in 33.3s,
+                 * while sending no control took 86.7s and returned an EMPTY answer — 297 of 299
+                 * completion tokens were spent reasoning, leaving nothing for the response. The empty
+                 * answer is the defect the latency merely accompanies: a longer prompt exhausts the
+                 * budget sooner, so a wall-clock-only check would miss it.
+                 *
+                 * This leaf belongs to `askSynthesis` rather than beside `localModels.chat`'s
+                 * `summaryReasoningEffort` / `graphReasoningEffort`, because ask builds its model from
+                 * THIS block (`SearchService.ask`: "the dedicated askSynthesis block, NOT the global")
+                 * and may point at an entirely different provider, model, and endpoint. A leaf on the
+                 * chat model would tune a model the ask path does not use.
+                 *
+                 * Deliberately NOT in `askSynthesisGuard`'s required-leaf set: an overlay predating this
+                 * leaf must keep answering with today's behaviour, not refuse. Refusing to answer is a
+                 * worse failure than answering slowly, and this leaf exists to improve answers.
+                 * @type {string}
+                 */
+                reasoningEffort: leaf('none', 'NEO_KB_ASK_REASONING_EFFORT', 'string')
             },
             /**
              * The path to the generated knowledge base JSONL file.

--- a/ai/scripts/lint/config-leaf-parity.json
+++ b/ai/scripts/lint/config-leaf-parity.json
@@ -471,6 +471,7 @@
         "askSynthesis.maxCallsPerMinute",
         "askSynthesis.model",
         "askSynthesis.provider",
+        "askSynthesis.reasoningEffort",
         "askSynthesis.timeoutMs",
         "askSynthesis.timeoutMsRemote",
         "authMiddleware",

--- a/ai/services/knowledge-base/SearchService.mjs
+++ b/ai/services/knowledge-base/SearchService.mjs
@@ -474,10 +474,15 @@ Instructions:
             // longer) is the safe direction over false-short (a working local model gets cut off).
             const ask = aiConfig.askSynthesis;
 
+            // `reasoning_effort` is omitted when the leaf is empty rather than sent as an empty string:
+            // an overlay predating this leaf must keep the provider's own default, and a provider that
+            // does not understand the param must not receive a value it has to reject. Same `|| undefined`
+            // idiom the summary path uses (`SessionService.summarizeSession`).
             result = await this.model.generateContent(prompt, {
-                timeoutMs     : ask.provider === 'gemini' ? ask.timeoutMsRemote : ask.timeoutMs,
-                operationLabel: 'ask_knowledge_base synthesis',
-                priority      : 'interactive'
+                timeoutMs       : ask.provider === 'gemini' ? ask.timeoutMsRemote : ask.timeoutMs,
+                operationLabel  : 'ask_knowledge_base synthesis',
+                priority        : 'interactive',
+                reasoning_effort: ask.reasoningEffort || undefined
             });
             answer = result.response.text();
         } catch (error) {

--- a/ai/services/memory-core/MemoryService.mjs
+++ b/ai/services/memory-core/MemoryService.mjs
@@ -1711,7 +1711,13 @@ class MemoryService extends Base {
                     operationLabel: 'miniSummary generation',
                     // Batch, not interactive: the only runtime caller is the backfill sweep, so this
                     // queue-jumped real interactive traffic on behalf of a background job.
-                    priority      : 'batch'
+                    priority      : 'batch',
+                    // Same summary-task leaf `SessionService.summarizeSession` reads: both are
+                    // summarization, so a second knob would be two names for one decision. Omitted when
+                    // empty via `|| undefined`, matching that call site exactly — a one-line summary has
+                    // no use for a hidden thinking pass, and without this the model can spend the whole
+                    // completion budget reasoning and return nothing.
+                    reasoning_effort: aiConfig.localModels.chat.summaryReasoningEffort || undefined
                 }),
                 TIMEOUT_MS,
                 'miniSummary generation'

--- a/test/playwright/unit/ai/services/knowledge-base/SearchService.reasoningEffort.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/SearchService.reasoningEffort.spec.mjs
@@ -1,0 +1,156 @@
+import {setup} from '../../../../setup.mjs';
+
+const appName = 'KBSearchServiceReasoningEffortTest';
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name             : appName,
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../../../src/Neo.mjs';
+import * as core      from '../../../../../../src/core/_export.mjs';
+
+/**
+ * `ask` was the only chat-model consumer that sent NO reasoning-effort control.
+ *
+ * `summaryReasoningEffort` and `graphReasoningEffort` ship for the two structured-output consumers and both
+ * default to `'none'`; the ask path had no equivalent, so a reasoning-capable model spent its
+ * completion budget thinking and returned an EMPTY answer. Measured on a 26B-class local model with
+ * a ~7,900-token grounded prompt: `'none'` answered in 33.3s; no control took 86.7s and returned
+ * nothing, with 297 of 299 completion tokens consumed by reasoning.
+ *
+ * **The empty answer is the defect; the latency merely accompanies it.** A regression check written
+ * against wall-clock would pass while a longer prompt still exhausted the budget — so these assert
+ * the control REACHES the provider, which is the property that was absent.
+ *
+ * **Coverage boundary, stated rather than implied:** the `|| undefined` omission branch — an overlay
+ * with no `reasoningEffort` leaf keeping the provider's own default — is NOT unit-covered here.
+ * Reaching it requires an `askSynthesis` block without the leaf, and the only way to produce one in
+ * this process is mutating the shared `AiConfig` singleton, which ADR-0019 B4 forbids outright — ticket-ref-ok: the prohibition is ADR authority, not a preference; without it this reads as an untested branch rather than an unreachable one (it is
+ * the mechanism that bled test state into live stores). The branch is one `||` at the call
+ * site and is verified by reading; asserting it with a test that cannot vary the input would be
+ * theatre. Every assertion below was mutation-proven: removing the call-site line reddens them.
+ */
+test.describe('Neo.ai.services.knowledge-base.SearchService — ask reasoning-effort pass-through', () => {
+    let SearchService, QueryService, GraphService, ChromaManager;
+    let originalModel, originalModelUnavailable, originalQueryDocuments;
+    let originalListNodeRecordsByType, originalReady, originalGetCollection;
+
+    test.beforeAll(async () => {
+        SearchService = (await import('../../../../../../ai/services/knowledge-base/SearchService.mjs')).default;
+        QueryService  = (await import('../../../../../../ai/services/knowledge-base/QueryService.mjs')).default;
+        GraphService  = (await import('../../../../../../ai/services/memory-core/GraphService.mjs')).default;
+        ChromaManager = (await import('../../../../../../ai/services/knowledge-base/ChromaManager.mjs')).default;
+
+        originalModel                 = SearchService.model;
+        originalModelUnavailable      = SearchService.modelUnavailable;
+        originalQueryDocuments        = QueryService.queryDocuments;
+        originalListNodeRecordsByType = GraphService.listNodeRecordsByType;
+        originalReady                 = GraphService.ready;
+        originalGetCollection         = ChromaManager.getKnowledgeBaseCollection;
+    });
+
+    test.afterEach(() => {
+        SearchService.model                      = originalModel;
+        SearchService.modelUnavailable           = originalModelUnavailable;
+        QueryService.queryDocuments              = originalQueryDocuments;
+        GraphService.listNodeRecordsByType       = originalListNodeRecordsByType;
+        GraphService.ready                       = originalReady;
+        ChromaManager.getKnowledgeBaseCollection = originalGetCollection;
+    });
+
+    /**
+     * Isolates retrieval so `ask` reaches the synthesis call, and captures the options it passes.
+     *
+     * The fixture owns the collection count for the reason `SearchService.noModel.spec.mjs` documents
+     * at length: the emptiness probe is a second read straight through to the live plane, so
+     * a spec that stubs only `queryDocuments` still tracks corpus fill rather than the diff.
+     *
+     * @returns {Object[]} The captured `generateContent` option objects, in call order.
+     */
+    function captureSynthesisOptions() {
+        const captured = [];
+
+        ChromaManager.getKnowledgeBaseCollection = async () => ({count: async () => 42});
+        GraphService.ready                       = true;
+        GraphService.listNodeRecordsByType       = async () => [];
+        // `queryDocuments` resolves `{results: [...]}` — a bare array reads as `results: undefined`,
+        // which `ask` treats as an empty flat result and short-circuits to `#emptyFlatResponse()`
+        // before ever reaching synthesis. Each row needs `source` (split for the display name) and
+        // `score` (Number-coerced into the reference).
+        QueryService.queryDocuments              = async () => ({
+            results: [{
+                source : 'learn/guides/Architecture.md',
+                score  : 0.92,
+                content: 'Neo.mjs runs the VDom in a dedicated worker.'
+            }]
+        });
+
+        SearchService.modelUnavailable = false;
+        SearchService.model            = {
+            generateContent: async (prompt, options) => {
+                captured.push(options);
+                return {response: {text: () => 'A grounded answer.'}};
+            }
+        };
+
+        return captured;
+    }
+
+    test('the synthesis call carries reasoning_effort — the control that was absent before #16768', async () => {
+        const captured = captureSynthesisOptions();
+
+        await SearchService.ask({query: 'How does Neo run the VDom?'});
+
+        expect(captured).toHaveLength(1);
+        // Presence is the assertion. Before this change the key was never sent, so the provider applied
+        // its own default and a reasoning model burned the completion budget before answering.
+        expect(captured[0]).toHaveProperty('reasoning_effort');
+    });
+
+    test('the value is the resolved askSynthesis leaf, not a service-local literal', async () => {
+        const captured = captureSynthesisOptions();
+
+        await SearchService.ask({query: 'How does Neo run the VDom?'});
+
+        const aiConfig = (await import('../../../../../../ai/mcp/server/knowledge-base/config.mjs')).default;
+
+        // Reads the SSOT rather than asserting `'none'`: an operator who sets
+        // NEO_KB_ASK_REASONING_EFFORT must see their value reach the provider, and hardcoding the
+        // default here would pass against a service that ignored the leaf entirely.
+        expect(captured[0].reasoning_effort).toBe(aiConfig.askSynthesis.reasoningEffort || undefined);
+    });
+
+    test('the sent value is a non-empty string — never an empty-string placeholder', async () => {
+        const captured = captureSynthesisOptions();
+
+        await SearchService.ask({query: 'How does Neo run the VDom?'});
+
+        // Asserts presence FIRST, deliberately. An earlier revision of this test asserted only
+        // `not.toBe('')`, which passed identically whether the key was sent or absent — mutation-
+        // proven vacuous: removing the call-site line left it green while its two siblings went red.
+        // A test that cannot fail on the defect is not covering it.
+        expect(captured[0]).toHaveProperty('reasoning_effort');
+        expect(typeof captured[0].reasoning_effort).toBe('string');
+        expect(captured[0].reasoning_effort.length).toBeGreaterThan(0);
+    });
+
+    test('the existing synthesis options are untouched — additive change, no displaced key', async () => {
+        const captured = captureSynthesisOptions();
+
+        await SearchService.ask({query: 'How does Neo run the VDom?'});
+
+        // Positive control: without these, the three assertions above would still pass against a
+        // call site that had dropped the timeout budget or the priority class while adding the new key.
+        expect(captured[0]).toHaveProperty('timeoutMs');
+        expect(captured[0].operationLabel).toBe('ask_knowledge_base synthesis');
+        expect(captured[0].priority).toBe('interactive');
+    });
+});

--- a/test/playwright/unit/ai/services/knowledge-base/SearchService.reasoningEffort.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/SearchService.reasoningEffort.spec.mjs
@@ -120,7 +120,11 @@ test.describe('Neo.ai.services.knowledge-base.SearchService — ask reasoning-ef
 
         await SearchService.ask({query: 'How does Neo run the VDom?'});
 
-        const aiConfig = (await import('../../../../../../ai/mcp/server/knowledge-base/config.mjs')).default;
+        // The committed TEMPLATE, never the gitignored `config.mjs` overlay. An overlay-resolving test
+        // asserts against whatever this machine happens to carry, so it can pass here and fail in CI
+        // — or worse, pass in both while measuring a value no other environment has. Defaults resolve
+        // through the same `ConfigBase` either way, so this costs the assertion nothing.
+        const aiConfig = (await import('../../../../../../ai/mcp/server/knowledge-base/config.template.mjs')).default;
 
         // Reads the SSOT rather than asserting `'none'`: an operator who sets
         // NEO_KB_ASK_REASONING_EFFORT must see their value reach the provider, and hardcoding the


### PR DESCRIPTION
Resolves neomjs/neo#16768

`ask` was the only chat-model consumer sending no reasoning-effort control. `summaryReasoningEffort` and `graphReasoningEffort` both ship and both default to `'none'`; the ask path sent nothing, so a reasoning-capable model applied its own default and spent the completion budget thinking.

**Measured by @neo-gpt** — 26B-class local model, ~7,900-token grounded prompt:

| run | latency | outcome |
|---|---|---|
| `reasoning_effort: 'none'` | **33.3 s** | valid answer |
| no control sent (previous behaviour) | **86.7 s** | **empty answer** — 297 of 299 completion tokens spent reasoning |

**The empty answer is the defect; the latency merely accompanies it.** A regression check written against wall-clock would pass while a longer prompt still exhausted the budget — which is why the specs assert the control *reaches the provider* rather than timing anything.

Evidence: L2 (exact-head CI, mutation-proven ask call-site spec, and static mini-summary contract inspection) → L3 required (AC3 live local-model non-empty outcome). Residual: AC3 [#16768]. The real-model reproduction is @neo-gpt's measurement above and is not re-run here.

## Deltas from ticket

The ticket prescribed adding the leaf **beside its two siblings** under `localModels.chat`. **Reading the consumer corrected that**, and the correction is the main architectural content of this PR:

`SearchService.mjs` builds its model from *"the dedicated `askSynthesis` block (NOT the global `modelProvider`)"*, so `ask` may point at an entirely different provider, model and endpoint than the chat model. A leaf on `localModels.chat` would have tuned a model the ask path never uses — the parameter would have looked correct, been documented correctly, and had no effect.

So the leaf lands in `askSynthesis` (`ai/mcp/server/knowledge-base/configBase.mjs`) with the block's own `NEO_KB_ASK_*` env convention, named `reasoningEffort` to match its unprefixed siblings rather than the ticket's `askReasoningEffort`. The ticket body has been corrected.

Second deliberate deviation: the leaf is **not** added to `askSynthesisGuard`'s required set. An overlay predating it must keep answering with today's behaviour rather than refuse — refusing to answer is a worse failure than answering slowly, and this leaf exists to improve answers.

`miniSummary` (`MemoryService.mjs`) reads the **existing** `summaryReasoningEffort` leaf that `SessionService.summarizeSession` already consumes. Both are summarization; a second knob would be two names for one decision. No new leaf.

## Test Evidence

- **New spec:** `test/playwright/unit/ai/services/knowledge-base/SearchService.reasoningEffort.spec.mjs` — 4/4 green at `22a7e1c4df`; exact-head unit CI is green at `098a570111`.
- **Whole KB service directory:** 554/554 green.
- **Mutation-proven, by name.** Removing the ask call-site line reddens **all three** substantive assertions (presence, resolved-leaf value, non-empty string). The fourth is a positive control on the untouched options and correctly stays green.
- **Mini-summary coverage boundary:** no new assertion captures its provider-options object. Exact-head source inspection confirms the established `summaryReasoningEffort || undefined` pass-through; the existing `QueryRecentTurns.spec.mjs` seam covers real `buildMiniSummary` outcomes, not option identity.
- **One assertion was rewritten because the mutation proved it vacuous.** An earlier revision asserted only `not.toBe('')`, which passed identically whether the key was sent or absent — it survived the mutation while its two siblings failed. It now asserts presence first. Recording this because a green suite containing that test would have looked identical to this one.
- **Config gate:** `ai:lint-config-template-ssot` initially FAILED on the new declared path (working as designed); the parity snapshot is recorded via `--update-parity` and committed in the same commit, per the tool's own instruction. Re-run passes.
- **Pre-commit:** `check-ticket-archaeology` flagged 7 refs in durable comments. Six were pointers and were rephrased; **one** carries a `ticket-ref-ok` marker because the ADR-0019 B4 citation is load-bearing — it is what makes an uncovered branch *unreachable by rule* rather than merely untested.

**Local-only, disclosed rather than omitted:** two memory-core specs fail in my local full-directory run. `SessionSummarization.spec.mjs:537` (a real-API latency probe) **fails identically on clean `dev` with my change stashed**, so it is pre-existing and environment-dependent. `MemoryService.Schema.spec.mjs:75` **passes 7/7 in isolation with my change applied** and fails only under the parallel directory run — an ordering artifact of the `#16617` class. CI is the oracle for both.

## Coverage boundary, stated rather than implied

The `|| undefined` omission branch — an overlay with no leaf keeping the provider default — is **not** unit-covered. Reaching it needs an `askSynthesis` block without the leaf, and the only way to produce one in-process is mutating the shared `AiConfig` singleton, which ADR-0019 B4 forbids outright (the mechanism that bled test state into live stores). The branch is one `||` at the call site and is verified by reading. Asserting it with a test that cannot vary its input would be theatre — and the vacuous-test finding above is exactly what that looks like when it slips through.

## Post-Merge Validation

Residual AC3 [#16768]: live non-destructive probe requires an operator-accessible reasoning-capable local model.

- [ ] A grounded `ask_knowledge_base` against a reasoning-capable local model returns a non-empty answer where the same prompt previously returned empty.
- [ ] An operator setting `NEO_KB_ASK_REASONING_EFFORT` sees that value reach the provider.
- [ ] `miniSummary` backfill output is unchanged in shape and no slower.

## Decision Record impact

`aligned-with ADR 0019` — a declarative `leaf(default, env, type)` read at the use site, with three shipped consumers as precedent. No new resolution path, no formula, no threading, no runtime mutation, no defensive `?.`. Nothing amended.

## Related

neomjs/neo#13853 / neomjs/neo#13854 (introduced the control for summary + graph; this is the omitted third consumer) · neomjs/neo-agent-brain#54 (an external plane where `ask` is separately unusable on an empty corpus — two independent failure modes, and this one survives the corpus being fixed)

## Evolution

The implementation changed shape twice under checking rather than preserving the first green version. The leaf moved from the ticket's prescribed parent to the consumer's own block once I read where `ask` builds its model — the ticket's placement would have shipped an inert parameter. And the spec's empty-string assertion was rewritten after mutation showed it could not fail on the defect; the first version would have shipped as coverage while covering nothing.

Authored by Grace (Claude Opus 5, Claude Code) consuming Euclid's measurement — session a641ddac-565a-4fc8-adc1-6c25629bddb7.
