### PR TITLE
fix(memory-core): converge mailbox repair candidates (#16767)

### DIFF
--- a/ai/services/memory-core/MailboxService.mjs
+++ b/ai/services/memory-core/MailboxService.mjs
@@ -19,12 +19,12 @@ import {
     getMessageWalGraphProjectionStats,
     getMessageWalSegmentKey,
     getMissingMessageWalLeaves,
-    readWalMessages,
     readWalMessagesByIds,
     readPendingMessageWalRecords
 } from './helpers/messageWalStore.mjs';
 import {IDENTITIES}                   from '../../graph/identityRoots.mjs';
 import {normalizeAgentIdentityNodeId} from '../../graph/normalizeAgentIdentityNodeId.mjs';
+import {SQLITE_IN_CLAUSE_BATCH_SIZE}  from '../../graph/storage/constants.mjs';
 import {resolveResidentFamilyById}    from '../graph/agentFamilyResolution.mjs';
 import {getMissingMemoryWalLeaves}    from './helpers/memoryWalStore.mjs';
 import {
@@ -37,14 +37,17 @@ import {promisify} from 'util';
 import crypto      from 'crypto';
 
 const
-    execFileAsync                        = promisify(execFile),
-    RELATED_PULL_REQUEST_CACHE_TTL_MS    = 30 * 1000,
-    RELATED_PULL_REQUEST_PATTERN         = /^#(\d+)$/,
-    relatedPullRequestStateCache         = new Map(),
-    WAKE_SUPPRESSION_ALLOWED_TAGS        = new Set(['sunset-protocol-handover', 'lead-role-baton']),
-    MESSAGE_GRAPH_REPAIR_LIMIT           = 250,
-    IDENTITY_ROOTS_BY_ID                 = new Map(IDENTITIES.map(identity => [identity.id, identity])),
-    WAKE_SUPPRESSION_ACTIONABLE_SUBJECTS = [
+    execFileAsync                         = promisify(execFile),
+    RELATED_PULL_REQUEST_CACHE_TTL_MS     = 30 * 1000,
+    RELATED_PULL_REQUEST_PATTERN          = /^#(\d+)$/,
+    relatedPullRequestStateCache          = new Map(),
+    WAKE_SUPPRESSION_ALLOWED_TAGS         = new Set(['sunset-protocol-handover', 'lead-role-baton']),
+    MESSAGE_GRAPH_REPAIR_LIMIT            = 250,
+    MESSAGE_GRAPH_REPAIR_FAILURE_RETRY_MS = 30 * 1000,
+    MESSAGE_WAL_CANDIDATE_CACHE_LIMIT     = 512,
+    MESSAGE_WAL_UNREADABLE_RETRY_MS       = 30 * 1000,
+    IDENTITY_ROOTS_BY_ID                  = new Map(IDENTITIES.map(identity => [identity.id, identity])),
+    WAKE_SUPPRESSION_ACTIONABLE_SUBJECTS  = [
         /^\[re-review/i,
         /^\[review/i,
         /^\[review-response/i,
@@ -54,6 +57,15 @@ const
         /\bCHANGES_REQUESTED\b/i,
         /\blane-override\b/i
     ];
+
+const graphProjectionRepairCursorByView    = new Map(),
+    graphProjectionRepairFailureById       = new Map(),
+    graphProjectionRepairPromiseById       = new Map(),
+    messageWalCandidateRecordCacheById     = new Map(),
+    messageWalCandidateSegmentLoadByKey    = new Map(),
+    messageWalCandidateMetadataCacheById   = new Map(),
+    unreadableMessageWalCandidateStateById = new Map();
+let graphProjectionCandidateScanPromise = null;
 
 // Collision-class substrate: claim signals are STATUS, not interrupts — their broadcasts default to
 // quiet at the `addMessage` resolution seam (operator-directed 2026-07-26; peers read claims at their
@@ -481,6 +493,69 @@ function getCanonicalMessageWalRouting(record) {
         sentBy,
         to
     };
+}
+
+/**
+ * @summary Derives the immutable broadcast-cohort marker from one accepted WAL record.
+ *
+ * Presence of `routing.broadcastRecipients` is itself evidence: an explicit empty array is the
+ * valid zero-audience snapshot, while an absent historical field cannot prove zero and receives
+ * the compatibility disposition `legacy-unknown`. Direct messages have no broadcast cohort.
+ *
+ * @param {Object} record Accepted message WAL record.
+ * @returns {{disposition: 'known', intendedRecipientCount: Number}|{disposition: 'legacy-unknown'}|null}
+ * @private
+ */
+function getMessageWalBroadcastCohort(record) {
+    const {broadcastRecipients, to} = getCanonicalMessageWalRouting(record);
+
+    if (to !== 'AGENT:*') return null;
+
+    return Array.isArray(record?.routing?.broadcastRecipients)
+        ? {disposition: 'known', intendedRecipientCount: broadcastRecipients.length}
+        : {disposition: 'legacy-unknown'}
+}
+
+/**
+ * @summary Derives the immutable canonical sender/destination marker for one accepted WAL record.
+ *
+ * Broadcast cohort knowledge is intentionally separate: a historical broadcast can retain a
+ * trustworthy route while lacking the later recipient snapshot. Invalid historical routes are
+ * explicitly quarantined instead of being re-read and reinterpreted on every mailbox list.
+ *
+ * @param {Object} record Accepted message WAL record.
+ * @returns {{disposition: 'known', sentBy: String, to: String}|{disposition: 'legacy-unknown'}}
+ * @private
+ */
+function getMessageWalMailboxRouting(record) {
+    const {invalidDirectIdentities, sentBy, to} = getCanonicalMessageWalRouting(record);
+
+    return sentBy && to && invalidDirectIdentities.length === 0
+        ? {disposition: 'known', sentBy, to}
+        : {disposition: 'legacy-unknown'}
+}
+
+/**
+ * @summary Checks whether a compact canonical routing marker can affect one mailbox view.
+ * @param {Object} mailboxRouting Projection-marker route fact.
+ * @param {Object} options
+ * @param {String} [options.box='all'] Mailbox box being queried.
+ * @param {String} [options.target] Target identity being queried.
+ * @returns {Boolean}
+ * @private
+ */
+function mailboxRoutingMatchesMailboxView(mailboxRouting, {box = 'all', target} = {}) {
+    if (mailboxRouting?.disposition !== 'known') return false;
+    if (!target) return true;
+
+    const {sentBy, to} = mailboxRouting;
+
+    if (box === 'outbox') return sameMailboxIdentity(sentBy, target);
+
+    const inboxMatch = sameMailboxIdentity(to, target) || to === 'AGENT:*';
+    if (box === 'inbox') return inboxMatch;
+
+    return sameMailboxIdentity(sentBy, target) || inboxMatch
 }
 
 function buildTaggedConceptFilterGroups(values = []) {
@@ -950,54 +1025,491 @@ export function getWakeDeliverySeries({since = null, until = null} = {}) {
 }
 
 /**
- * @summary Checks whether the graph projection is damaged relative to the projected WAL count OR a
- * broadcast has lost its whole delivery cohort — the mailbox read-path guard.
- *
- * Healthy reads use cheap SQLite counts plus the compact graph-marker index and avoid parsing
- * accepted message WAL records. A mismatch means the graph projection may be damaged, so callers
- * should run the full WAL-backed repair path.
- *
- * Two damage classes are detected. (1) The count trio (MESSAGE / SENT_BY / SENT_TO falling below
- * projectedCount) catches a lost message or send-edge. (2) The broadcast-cohort term catches a
- * `SENT_TO → AGENT:*` broadcast whose entire per-recipient `DELIVERED_TO` cohort was lost — invisible
- * to the trio because the MESSAGE node, SENT_BY, and SENT_TO all survive, so all three counts still
- * match projectedCount. Without term (2) a pure read (list/count with no prior mark) of such a
- * broadcast never self-heals, since the read routes through this gate.
- *
- * @returns {Promise<Boolean>}
+ * @summary Stores one process-local fact in a bounded insertion-ordered cache.
+ * @param {Map<String,*>} cache Target cache.
+ * @param {String} key Cache key.
+ * @param {*} value Cached value.
+ * @returns {void}
  * @private
  */
-async function hasMailboxGraphProjectionGap() {
+function setBoundedMessageWalCandidateCache(cache, key, value) {
+    cache.delete(key);
+    cache.set(key, value);
+
+    while (cache.size > MESSAGE_WAL_CANDIDATE_CACHE_LIMIT) {
+        cache.delete(cache.keys().next().value);
+    }
+}
+
+/**
+ * @summary Checks whether two payload signatures still describe the same append-only generation.
+ *
+ * Ordinary growth of today's active segment cannot repair an older missing/corrupt accepted row,
+ * so it must not defeat the retry cooldown. Replacement, file-kind change, or truncation can
+ * change that row and therefore wakes the residual immediately.
+ *
+ * @param {String} previous Previous payload signature.
+ * @param {String} current Current payload signature.
+ * @returns {Boolean}
+ * @private
+ */
+function isSameMessageWalPayloadGeneration(previous, current) {
+    if (previous === current) return true;
+
+    const parse = value => {
+        const [kind, dev, ino, size] = String(value).split(':');
+        return {kind, dev, ino, size: Number(size)}
+    };
+    const before = parse(previous),
+        after    = parse(current);
+
+    if (before.kind !== after.kind || before.dev !== after.dev || before.ino !== after.ino) return false;
+    if (before.kind !== 'file') return true;
+
+    return Number.isFinite(before.size) && Number.isFinite(after.size) && after.size > before.size
+}
+
+/**
+ * @summary Records one unreadable accepted-WAL candidate with generation-aware retry state.
+ * @param {String} id Message id.
+ * @param {String} signature Current payload-segment signature.
+ * @param {String} reason Read failure detail.
+ * @returns {void}
+ * @private
+ */
+function deferUnreadableMessageWalCandidate(id, signature, reason) {
+    const previous = unreadableMessageWalCandidateStateById.get(id),
+        logged     = previous && isSameMessageWalPayloadGeneration(previous.signature, signature) && previous.logged;
+
+    setBoundedMessageWalCandidateCache(unreadableMessageWalCandidateStateById, id, {
+        signature,
+        retryAfter: Date.now() + MESSAGE_WAL_UNREADABLE_RETRY_MS,
+        logged    : true
+    });
+
+    if (!logged) {
+        logger.warn(`[MailboxService] deferred unreadable message WAL candidate ${id}: ${reason}`);
+    }
+}
+
+/**
+ * @summary Returns one shared physical payload load for a WAL segment generation.
+ *
+ * `readWalMessagesByIds()` parses a whole JSONL segment even for one requested id. Keying the
+ * transient promise by segment, payload signature, and projected-id cohort lets global mailbox
+ * views and explicit-id repair calls share that physical work while retaining independent record
+ * selection afterward. The cohort digest is load-bearing: a projection marker can land after the
+ * payload append without changing the payload signature, and that later id must not join a result
+ * filtered through the first caller's older marker snapshot.
+ * The promise resolves to an error envelope so one unreadable segment never rejects unrelated
+ * mailbox reads.
+ *
+ * @param {Object} options
+ * @param {String} options.segmentKey Segment coordinate.
+ * @param {Map<String,String>} options.segmentById Complete projected id-to-segment index.
+ * @param {Map<String,String>} options.payloadSignatureBySegment Payload signatures.
+ * @returns {{joined: Boolean, pending: Promise<{recordById: Map<String,Object>, error: Error|null}>, signature: String}}
+ * @private
+ */
+function getMessageWalCandidateSegmentLoad({segmentKey, segmentById, payloadSignatureBySegment}) {
+    const signature = payloadSignatureBySegment.get(segmentKey) || 'payload-unavailable',
+        segmentIds  = [];
+
+    for (const [id, indexedSegmentKey] of segmentById) {
+        if (indexedSegmentKey === segmentKey) segmentIds.push(id);
+    }
+
+    segmentIds.sort();
+
+    const cohortDigest = crypto.createHash('sha256').update(segmentIds.join('\u0000')).digest('hex'),
+        loadKey        = `${segmentKey}\u0000${signature}\u0000${cohortDigest}`;
+    let pending = messageWalCandidateSegmentLoadByKey.get(loadKey),
+        joined  = Boolean(pending);
+
+    if (!pending) {
+        pending = (async () => {
+            try {
+                const records = await readWalMessagesByIds({
+                    dir: aiConfig.messageWal.dir,
+                    ids: segmentIds
+                });
+                return {recordById: new Map(records.map(record => [record.id, record])), error: null}
+            } catch (error) {
+                return {recordById: new Map(), error}
+            }
+        })();
+
+        messageWalCandidateSegmentLoadByKey.set(loadKey, pending);
+        pending.then(() => {
+            if (messageWalCandidateSegmentLoadByKey.get(loadKey) === pending) {
+                messageWalCandidateSegmentLoadByKey.delete(loadKey);
+            }
+        });
+    }
+
+    return {joined, pending, signature}
+}
+
+/**
+ * @summary Reads exact candidate records by segment while containing unreadable rows behind a
+ * signature-aware retry boundary.
+ *
+ * A stable unreadable segment is retried after a bounded interval and once after process restart.
+ * Replacement, truncation, or file-kind change retries immediately; ordinary append growth keeps
+ * an older missing row behind the same cooldown.
+ * Segment failures are isolated so one corrupt historical file cannot fail unrelated mailbox
+ * reads or hide readable candidates from other segments.
+ *
+ * @param {Object} options
+ * @param {String[]} options.ids Candidate message ids.
+ * @param {Map<String,String>} options.segmentById Marker id-to-segment index.
+ * @param {Map<String,String>} options.payloadSignatureBySegment Payload signatures.
+ * @param {Boolean} [options.bypassUnreadableBackoff=false] True for an explicit-id retry.
+ * @returns {Promise<{recordsById: Map<String,Object>, unreadableIds: Set<String>, deferredIds: Set<String>}>}
+ * @private
+ */
+async function readMessageWalCandidateRecords({
+    ids,
+    segmentById,
+    payloadSignatureBySegment,
+    bypassUnreadableBackoff = false
+}) {
+    const recordsById   = new Map(),
+        unreadableIds   = new Set(),
+        deferredIds     = new Set(),
+        idsBySegment    = new Map(),
+        pendingLoadById = new Map(),
+        joinedLoadIds   = new Set(),
+        signatureById   = new Map(),
+        now             = Date.now();
+
+    for (const id of ids) {
+        const cachedRecord = messageWalCandidateRecordCacheById.get(id);
+
+        if (cachedRecord) {
+            recordsById.set(id, cachedRecord);
+            setBoundedMessageWalCandidateCache(messageWalCandidateRecordCacheById, id, cachedRecord);
+            unreadableMessageWalCandidateStateById.delete(id);
+            continue;
+        }
+
+        const segmentKey = segmentById.get(id),
+            signature    = segmentKey
+                ? payloadSignatureBySegment.get(segmentKey) || 'payload-unavailable'
+                : 'segment-coordinate-missing',
+            deferred     = unreadableMessageWalCandidateStateById.get(id);
+
+        signatureById.set(id, signature);
+
+        if (
+            !bypassUnreadableBackoff &&
+            deferred &&
+            isSameMessageWalPayloadGeneration(deferred.signature, signature) &&
+            deferred.retryAfter > now
+        ) {
+            unreadableIds.add(id);
+            deferredIds.add(id);
+            continue;
+        }
+
+        if (!segmentKey) {
+            unreadableIds.add(id);
+            deferUnreadableMessageWalCandidate(id, signature, 'projection marker has no WAL segment coordinate');
+            continue;
+        }
+
+        if (!idsBySegment.has(segmentKey)) idsBySegment.set(segmentKey, []);
+        idsBySegment.get(segmentKey).push(id);
+    }
+
+    for (const [segmentKey, segmentIds] of idsBySegment) {
+        const {joined, pending: groupLoad, signature} = getMessageWalCandidateSegmentLoad({
+            segmentKey,
+            segmentById,
+            payloadSignatureBySegment
+        });
+
+        for (const id of segmentIds) {
+            if (joined) joinedLoadIds.add(id);
+
+            const idLoad = groupLoad.then(({recordById, error}) => {
+                const record = recordById.get(id);
+
+                if (record) {
+                    setBoundedMessageWalCandidateCache(messageWalCandidateRecordCacheById, id, record);
+                    unreadableMessageWalCandidateStateById.delete(id);
+                    return {record, error: null}
+                }
+
+                deferUnreadableMessageWalCandidate(
+                    id,
+                    signature,
+                    error?.message || 'indexed accepted WAL record was not readable'
+                );
+                return {record: null, error}
+            });
+
+            pendingLoadById.set(id, idLoad);
+        }
+    }
+
+    const loaded = await Promise.all([...pendingLoadById].map(async ([id, pending]) => {
+        return [id, await pending]
+    }));
+
+    for (const [id, {record}] of loaded) {
+        if (record) {
+            recordsById.set(id, record);
+        } else {
+            unreadableIds.add(id);
+            const state   = unreadableMessageWalCandidateStateById.get(id),
+                signature = signatureById.get(id);
+            if (
+                joinedLoadIds.has(id) &&
+                state &&
+                isSameMessageWalPayloadGeneration(state.signature, signature) &&
+                state.retryAfter > now
+            ) {
+                // A joined caller consumed the same failed load; it is deferred from any second
+                // payload attempt in this wave even though this call did not enter through the
+                // pre-existing backoff branch above.
+                deferredIds.add(id);
+            }
+        }
+    }
+
+    return {recordsById, unreadableIds, deferredIds}
+}
+
+/**
+ * @summary Classifies exact projected-WAL ids whose required graph carriers may be damaged.
+ *
+ * The compact graph-marker index is the bounded source population. SQLite supplies exact damaged
+ * ids. Canonical sender/destination facts then filter those ids before accepted payloads are read,
+ * replacing the former global count Boolean and its repeated deployment-age WAL scan.
+ *
+ * Historical markers are enriched once from their indexed record. Route knowledge and broadcast
+ * cohort knowledge stay separate: a legacy broadcast can have a valid route but an unknown
+ * audience. Marker persistence is best-effort serving metadata; a failed append remains observable
+ * but cannot fail the mailbox read, while an in-process immutable-record cache prevents immediate
+ * re-taxing. Zero-audience broadcasts are healthy; known-positive total cohort loss is repairable.
+ *
+ * @returns {Promise<Object>} Exact candidates, compact routes, reusable records, and residuals.
+ * @private
+ */
+async function classifyMailboxGraphProjectionCandidates() {
     const sqlite = GraphService.db?.storage?.db;
+    const stats  = await getMessageWalGraphProjectionStats({dir: aiConfig.messageWal.dir});
+    const {
+        projectedCount,
+        projectedIds,
+        segmentById,
+        markerConflicts,
+        payloadSignatureBySegment
+    } = stats;
+    const mailboxRoutingById  = new Map(stats.mailboxRoutingById),
+        broadcastCohortById   = new Map(stats.broadcastCohortById),
+        reasonsById           = new Map(),
+        enrichedRecordsById   = new Map(),
+        unreadableIds         = new Set(),
+        deferredUnreadableIds = new Set(),
+        compatibility         = {
+            backfilled              : 0,
+            cached                  : 0,
+            knownZero               : 0,
+            legacyUnknown           : 0,
+            routingLegacyUnknown    : 0,
+            unresolved              : 0,
+            unreadableDeferred      : 0,
+            persistenceFailed       : 0,
+            mailboxRoutingConflicts : markerConflicts.mailboxRoutingIds.size,
+            broadcastCohortConflicts: markerConflicts.broadcastCohortIds.size
+        };
 
-    if (!sqlite) return true;
+    for (const id of unreadableMessageWalCandidateStateById.keys()) {
+        if (!projectedIds.has(id)) unreadableMessageWalCandidateStateById.delete(id);
+    }
 
-    const {projectedCount} = await getMessageWalGraphProjectionStats({dir: aiConfig.messageWal.dir});
+    const addReason = (id, reason) => {
+        if (!reasonsById.has(id)) reasonsById.set(id, new Set());
+        reasonsById.get(id).add(reason);
+    };
 
-    if (projectedCount === 0) return false;
+    for (const id of projectedIds) {
+        const cached = messageWalCandidateMetadataCacheById.get(id);
 
-    const row = sqlite.prepare(`
-        SELECT
-            (SELECT COUNT(*) FROM Nodes WHERE id LIKE 'MESSAGE:%' AND json_extract(data, '$.label') = 'MESSAGE') AS messageCount,
-            (SELECT COUNT(DISTINCT source) FROM Edges WHERE source LIKE 'MESSAGE:%' AND type = 'SENT_BY') AS sentByCount,
-            (SELECT COUNT(DISTINCT source) FROM Edges WHERE source LIKE 'MESSAGE:%' AND type = 'SENT_TO') AS sentToCount,
-            (SELECT COUNT(*) FROM Edges b
-                 WHERE b.source LIKE 'MESSAGE:%' AND b.type = 'SENT_TO' AND b.target = 'AGENT:*'
-                   AND NOT EXISTS (SELECT 1 FROM Edges d WHERE d.source = b.source AND d.type = 'DELIVERED_TO')) AS brokenBroadcastCount
-    `).get();
+        if (!cached) continue;
+        if (!mailboxRoutingById.has(id) && cached.mailboxRouting) {
+            mailboxRoutingById.set(id, cached.mailboxRouting);
+            compatibility.cached++;
+        }
+        if (!broadcastCohortById.has(id) && cached.broadcastCohort) {
+            broadcastCohortById.set(id, cached.broadcastCohort);
+            compatibility.cached++;
+        }
+    }
 
-    // The first three are count-vs-projectedCount comparisons. The broadcast cohort term is
-    // DELIBERATELY an absolute `> 0`, NOT `deliveredToCount < projectedCount`: projectedCount counts
-    // ALL messages while the delivery-cohort spans broadcasts only, so a single DM would make a
-    // `< projectedCount` term permanently true and force a full WAL scan on every list. This term
-    // instead asks the precise question — a broadcast (`SENT_TO → AGENT:*`) that lost its WHOLE
-    // per-recipient delivery cohort (zero `DELIVERED_TO` rows) — which the count trio cannot see
-    // (its MESSAGE / SENT_BY / SENT_TO all still match projectedCount), so a pure read of it never
-    // self-healed until now.
-    return (row?.messageCount ?? 0) < projectedCount ||
-        (row?.sentByCount ?? 0) < projectedCount ||
-        (row?.sentToCount ?? 0) < projectedCount ||
-        (row?.brokenBroadcastCount ?? 0) > 0;
+    const result = () => ({
+        reasonsById,
+        mailboxRoutingById,
+        enrichedRecordsById,
+        unreadableIds,
+        deferredUnreadableIds,
+        segmentById,
+        payloadSignatureBySegment,
+        compatibility
+    });
+
+    if (projectedCount === 0) return result();
+
+    if (!sqlite) {
+        for (const id of projectedIds) addReason(id, 'graph-storage-unavailable');
+        return result()
+    }
+
+    const orderedProjectedIds    = [...projectedIds],
+        messageIds               = new Set(),
+        edgeStateById            = new Map(),
+        zeroDeliveryBroadcastIds = [];
+
+    for (let index = 0; index < orderedProjectedIds.length; index += SQLITE_IN_CLAUSE_BATCH_SIZE) {
+        const chunk      = orderedProjectedIds.slice(index, index + SQLITE_IN_CLAUSE_BATCH_SIZE),
+            placeholders = chunk.map(() => '?').join(', ');
+
+        for (const row of sqlite.prepare(`
+            SELECT id
+              FROM Nodes
+             WHERE id IN (${placeholders})
+               AND json_extract(data, '$.label') = 'MESSAGE'
+        `).all(...chunk)) {
+            messageIds.add(row.id);
+        }
+
+        for (const row of sqlite.prepare(`
+            SELECT source AS id,
+                   MAX(CASE WHEN type = 'SENT_BY' THEN 1 ELSE 0 END) AS hasSentBy,
+                   MAX(CASE WHEN type = 'SENT_TO' THEN 1 ELSE 0 END) AS hasSentTo,
+                   MAX(CASE WHEN type = 'SENT_TO' AND target = 'AGENT:*' THEN 1 ELSE 0 END) AS isBroadcast,
+                   MAX(CASE WHEN type = 'DELIVERED_TO' THEN 1 ELSE 0 END) AS hasDelivery
+              FROM Edges
+             WHERE source IN (${placeholders})
+               AND type IN ('SENT_BY', 'SENT_TO', 'DELIVERED_TO')
+             GROUP BY source
+        `).all(...chunk)) {
+            edgeStateById.set(row.id, row);
+        }
+    }
+
+    for (const id of orderedProjectedIds) {
+        const edgeState = edgeStateById.get(id);
+
+        if (!messageIds.has(id)) addReason(id, 'missing-message-node');
+        if (!edgeState?.hasSentBy) addReason(id, 'missing-sent-by');
+        if (!edgeState?.hasSentTo) addReason(id, 'missing-sent-to');
+        if (edgeState?.isBroadcast && !edgeState?.hasDelivery) zeroDeliveryBroadcastIds.push(id);
+    }
+
+    const metadataIds = new Set([
+        ...[...reasonsById.keys()].filter(id => !mailboxRoutingById.has(id)),
+        ...zeroDeliveryBroadcastIds.filter(id => !broadcastCohortById.has(id) || !mailboxRoutingById.has(id))
+    ]);
+
+    if (metadataIds.size > 0) {
+        const loaded = await readMessageWalCandidateRecords({
+            ids: [...metadataIds],
+            segmentById,
+            payloadSignatureBySegment
+        });
+
+        loaded.recordsById.forEach((record, id) => enrichedRecordsById.set(id, record));
+        loaded.unreadableIds.forEach(id => unreadableIds.add(id));
+        loaded.deferredIds.forEach(id => deferredUnreadableIds.add(id));
+        compatibility.unreadableDeferred += loaded.deferredIds.size;
+
+        for (const id of metadataIds) {
+            const record = loaded.recordsById.get(id);
+
+            if (!record) {
+                addReason(id, 'unreadable-wal-record');
+                compatibility.unresolved++;
+                continue;
+            }
+
+            const mailboxRouting = getMessageWalMailboxRouting(record),
+                broadcastCohort  = getMessageWalBroadcastCohort(record) || undefined,
+                cachedMetadata   = {mailboxRouting, ...(broadcastCohort ? {broadcastCohort} : {})};
+
+            mailboxRoutingById.set(id, mailboxRouting);
+            if (broadcastCohort) broadcastCohortById.set(id, broadcastCohort);
+
+            try {
+                await appendMessageWalGraphProjectionMarker({
+                    id,
+                    segmentKey: record.segmentKey || segmentById.get(id),
+                    mailboxRouting,
+                    broadcastCohort
+                }, {dir: aiConfig.messageWal.dir});
+                messageWalCandidateMetadataCacheById.delete(id);
+                compatibility.backfilled++;
+            } catch (error) {
+                setBoundedMessageWalCandidateCache(messageWalCandidateMetadataCacheById, id, cachedMetadata);
+                compatibility.persistenceFailed++;
+                logger.warn(`[MailboxService] projection-marker metadata persistence failed for ${id}: ${error.message}`);
+            }
+        }
+    }
+
+    for (const routing of mailboxRoutingById.values()) {
+        if (routing.disposition === 'legacy-unknown') compatibility.routingLegacyUnknown++;
+    }
+
+    for (const id of zeroDeliveryBroadcastIds) {
+        const cohort = broadcastCohortById.get(id);
+
+        if (cohort?.disposition === 'known') {
+            if (cohort.intendedRecipientCount > 0) {
+                addReason(id, 'missing-delivery-cohort');
+            } else {
+                compatibility.knownZero++;
+            }
+        } else if (cohort?.disposition === 'legacy-unknown') {
+            compatibility.legacyUnknown++;
+        } else {
+            addReason(id, 'unreadable-broadcast-intent');
+        }
+    }
+
+    for (const id of enrichedRecordsById.keys()) {
+        if (
+            !reasonsById.has(id) ||
+            mailboxRoutingById.get(id)?.disposition === 'legacy-unknown'
+        ) {
+            messageWalCandidateRecordCacheById.delete(id);
+        }
+    }
+
+    return result()
+}
+
+/**
+ * @summary Coalesces concurrent exact-candidate scans so historical cohort enrichment appends at
+ * most one compatibility marker per process wave.
+ * @returns {Promise<Object>}
+ * @private
+ */
+async function getMailboxGraphProjectionRepairCandidates() {
+    if (graphProjectionCandidateScanPromise) return graphProjectionCandidateScanPromise;
+
+    const pending = classifyMailboxGraphProjectionCandidates();
+    graphProjectionCandidateScanPromise = pending;
+
+    try {
+        return await pending
+    } finally {
+        if (graphProjectionCandidateScanPromise === pending) {
+            graphProjectionCandidateScanPromise = null;
+        }
+    }
 }
 
 /**
@@ -1924,8 +2436,10 @@ class MailboxService extends Base {
 
         if (appendMarker) {
             await appendMessageWalGraphProjectionMarker({
-                id        : messageId,
-                segmentKey: record.segmentKey || getMessageWalSegmentKey(record.timestamp ?? Date.now())
+                id             : messageId,
+                segmentKey     : record.segmentKey || getMessageWalSegmentKey(record.timestamp ?? Date.now()),
+                mailboxRouting : getMessageWalMailboxRouting(record),
+                broadcastCohort: getMessageWalBroadcastCohort(record) || undefined
             }, {dir: aiConfig.messageWal.dir});
         }
 
@@ -1962,8 +2476,10 @@ class MailboxService extends Base {
 
                 if (issues.length === 0) {
                     await appendMessageWalGraphProjectionMarker({
-                        id        : record.id,
-                        segmentKey: record.segmentKey || getMessageWalSegmentKey(record.timestamp ?? Date.now())
+                        id             : record.id,
+                        segmentKey     : record.segmentKey || getMessageWalSegmentKey(record.timestamp ?? Date.now()),
+                        mailboxRouting : getMessageWalMailboxRouting(record),
+                        broadcastCohort: getMessageWalBroadcastCohort(record) || undefined
                     }, {dir: aiConfig.messageWal.dir});
                 } else if (issues.includes('missing-message-node')) {
                     await this._projectMessageWalRecord(record);
@@ -1992,10 +2508,38 @@ class MailboxService extends Base {
      * @param {String} [options.target] Optional mailbox identity whose view is being queried.
      * @param {String} [options.box='all'] Mailbox box being queried.
      * @param {Number} [options.limit=250] Maximum matching accepted WAL records to inspect.
-     * @returns {Promise<{scanned: Number, intact: Number, repaired: Number, failed: Number, issues: Object}>}
+     * @returns {Promise<Object>} Bounded repair summary with exact candidate and residual counts.
      */
     async repairMessageGraphIntegrity({ids, target, box = 'all', limit = MESSAGE_GRAPH_REPAIR_LIMIT} = {}) {
-        const summary = {scanned: 0, intact: 0, repaired: 0, failed: 0, issues: {}};
+        const summary = {
+            scanned                         : 0,
+            intact                          : 0,
+            repaired                        : 0,
+            failed                          : 0,
+            coalescedCandidateCount         : 0,
+            issues                          : {},
+            candidateCount                  : 0,
+            matchedCandidateCount           : 0,
+            deferredCandidateCount          : 0,
+            deferredFailedCandidateCount    : 0,
+            quarantinedCandidateCount       : 0,
+            unreadableCandidateCount        : 0,
+            deferredUnreadableCandidateCount: 0,
+            cursorStart                     : 0,
+            cursorNext                      : 0,
+            compatibility                   : {
+                backfilled              : 0,
+                cached                  : 0,
+                knownZero               : 0,
+                legacyUnknown           : 0,
+                routingLegacyUnknown    : 0,
+                unresolved              : 0,
+                unreadableDeferred      : 0,
+                persistenceFailed       : 0,
+                mailboxRoutingConflicts : 0,
+                broadcastCohortConflicts: 0
+            }
+        };
 
         if (getMissingMessageWalLeaves(aiConfig.messageWal, ['dir']).length > 0) {
             return summary;
@@ -2004,40 +2548,197 @@ class MailboxService extends Base {
         const idFilter   = Array.isArray(ids) ? new Set(ids) : null,
             boundedLimit = Number.isFinite(Number(limit)) && Number(limit) > 0 ? Number(limit) : MESSAGE_GRAPH_REPAIR_LIMIT;
 
-        if (!idFilter && !await hasMailboxGraphProjectionGap()) {
-            return summary;
+        const candidateState = idFilter ? null : await getMailboxGraphProjectionRepairCandidates(),
+            repairIds        = idFilter || new Set(candidateState.reasonsById.keys());
+
+        summary.candidateCount = repairIds.size;
+        if (candidateState) summary.compatibility = candidateState.compatibility;
+        if (repairIds.size === 0) {
+            if (!idFilter) {
+                graphProjectionRepairCursorByView.clear();
+                graphProjectionRepairFailureById.clear();
+            }
+            return summary
         }
 
-        const acceptedRecords = idFilter
-            ? await readWalMessagesByIds({dir: aiConfig.messageWal.dir, ids: [...idFilter], limit: boundedLimit})
-            : await readWalMessages({dir: aiConfig.messageWal.dir});
+        if (!idFilter) {
+            for (const id of graphProjectionRepairFailureById.keys()) {
+                if (!repairIds.has(id)) graphProjectionRepairFailureById.delete(id);
+            }
+        }
 
-        for (const record of acceptedRecords) {
-            if (summary.scanned >= boundedLimit) break;
-            if (record?.graphProjectionVersion !== 1) continue;
-            if (idFilter && !idFilter.has(record.id)) continue;
-            if (!messageWalRecordMatchesMailboxView(record, {box, target})) continue;
+        const candidateOrder = new Map([...repairIds].map((id, index) => [id, index]));
+        let selectedIds;
 
-            summary.scanned++;
+        if (idFilter) {
+            selectedIds = [...repairIds].slice(0, boundedLimit);
+            summary.matchedCandidateCount  = selectedIds.length;
+            summary.deferredCandidateCount = Math.max(0, repairIds.size - selectedIds.length);
+        } else {
+            const viewMatchingIds = [...repairIds].filter(id => mailboxRoutingMatchesMailboxView(
+                candidateState.mailboxRoutingById.get(id),
+                {box, target}
+            ));
+            const now       = Date.now(),
+                matchingIds = viewMatchingIds.filter(id => {
+                    const failure = graphProjectionRepairFailureById.get(id);
+                    return !failure || failure.retryAfter <= now
+                });
+            const cursorKey = `${target || '*'}\u0000${box}`;
 
-            const issues = getMessageGraphProjectionIssues(record);
-            if (issues.length === 0) {
-                summary.intact++;
+            summary.matchedCandidateCount         = viewMatchingIds.length;
+            summary.deferredFailedCandidateCount  = viewMatchingIds.length - matchingIds.length;
+            summary.deferredCandidateCount        = summary.deferredFailedCandidateCount +
+                Math.max(0, matchingIds.length - boundedLimit);
+            summary.quarantinedCandidateCount = [...repairIds].filter(id => {
+                return candidateState.mailboxRoutingById.get(id)?.disposition !== 'known'
+            }).length;
+
+            if (matchingIds.length === 0) {
+                graphProjectionRepairCursorByView.delete(cursorKey);
+                selectedIds = [];
+            } else {
+                const start   = (graphProjectionRepairCursorByView.get(cursorKey) || 0) % matchingIds.length;
+                const rotated = [
+                    ...matchingIds.slice(start),
+                    ...matchingIds.slice(0, start)
+                ];
+
+                selectedIds = rotated.slice(0, boundedLimit);
+                summary.cursorStart = start;
+                summary.cursorNext  = (start + selectedIds.length) % matchingIds.length;
+                setBoundedMessageWalCandidateCache(
+                    graphProjectionRepairCursorByView,
+                    cursorKey,
+                    summary.cursorNext
+                );
+            }
+        }
+
+        if (selectedIds.length === 0) {
+            if (candidateState) {
+                summary.unreadableCandidateCount = candidateState.unreadableIds.size;
+                summary.deferredUnreadableCandidateCount = candidateState.deferredUnreadableIds.size;
+            }
+            return summary
+        }
+
+        const recordById = new Map();
+
+        if (candidateState) {
+            for (const id of selectedIds) {
+                const record = candidateState.enrichedRecordsById.get(id);
+                if (record) recordById.set(id, record);
+            }
+
+            const missingIds = selectedIds.filter(id => !recordById.has(id));
+            if (missingIds.length > 0) {
+                const loaded = await readMessageWalCandidateRecords({
+                    ids                      : missingIds,
+                    segmentById              : candidateState.segmentById,
+                    payloadSignatureBySegment: candidateState.payloadSignatureBySegment
+                });
+
+                loaded.recordsById.forEach((record, id) => recordById.set(id, record));
+                loaded.unreadableIds.forEach(id => candidateState.unreadableIds.add(id));
+                loaded.deferredIds.forEach(id => candidateState.deferredUnreadableIds.add(id));
+            }
+
+            summary.unreadableCandidateCount = candidateState.unreadableIds.size;
+            summary.deferredUnreadableCandidateCount = candidateState.deferredUnreadableIds.size;
+        } else {
+            const missingIds = [];
+
+            for (const id of selectedIds) {
+                const cachedRecord = messageWalCandidateRecordCacheById.get(id);
+
+                if (cachedRecord) {
+                    recordById.set(id, cachedRecord);
+                    setBoundedMessageWalCandidateCache(messageWalCandidateRecordCacheById, id, cachedRecord);
+                } else {
+                    missingIds.push(id);
+                }
+            }
+
+            if (missingIds.length > 0) {
+                const stats  = await getMessageWalGraphProjectionStats({dir: aiConfig.messageWal.dir});
+                const loaded = await readMessageWalCandidateRecords({
+                    ids                      : missingIds,
+                    segmentById              : stats.segmentById,
+                    payloadSignatureBySegment: stats.payloadSignatureBySegment,
+                    bypassUnreadableBackoff  : true
+                });
+                loaded.recordsById.forEach(record => {
+                    recordById.set(record.id, record);
+                    setBoundedMessageWalCandidateCache(messageWalCandidateRecordCacheById, record.id, record);
+                });
+            }
+        }
+
+        const selectedRecords = selectedIds
+            .map(id => recordById.get(id))
+            .filter(record => record?.graphProjectionVersion === 1 && repairIds.has(record.id))
+            .filter(record => idFilter || messageWalRecordMatchesMailboxView(record, {box, target}))
+            .sort((a, b) => candidateOrder.get(a.id) - candidateOrder.get(b.id));
+
+        for (const record of selectedRecords) {
+            let pending   = graphProjectionRepairPromiseById.get(record.id),
+                coalesced = Boolean(pending);
+
+            if (!pending) {
+                // The canonical topology has one Memory Core service process. This per-id map
+                // single-flights concurrent list/get callers inside that write owner; the
+                // storage-level issue recheck remains the idempotence boundary before mutation.
+                pending = (async () => {
+                    const issues = getMessageGraphProjectionIssues(record);
+
+                    if (issues.length === 0) {
+                        graphProjectionRepairFailureById.delete(record.id);
+                        messageWalCandidateRecordCacheById.delete(record.id);
+                        return {status: 'intact', issues}
+                    }
+
+                    try {
+                        // Surgical mode: rebuild ONLY the flagged-missing pieces. A full
+                        // re-projection here resurrects the WAL's send-time `readAt: null` over
+                        // committed reads on every INTACT node/edge.
+                        await this._projectMessageWalRecord(record, {pumpWake: false, onlyIssues: issues});
+                        graphProjectionRepairFailureById.delete(record.id);
+                        messageWalCandidateRecordCacheById.delete(record.id);
+                        return {status: 'repaired', issues}
+                    } catch (error) {
+                        setBoundedMessageWalCandidateCache(graphProjectionRepairFailureById, record.id, {
+                            retryAfter: Date.now() + MESSAGE_GRAPH_REPAIR_FAILURE_RETRY_MS
+                        });
+                        logger.warn(`[MailboxService] message graph integrity repair failed for ${record.id}: ${error.message}`);
+                        return {status: 'failed', issues, error}
+                    }
+                })();
+
+                graphProjectionRepairPromiseById.set(record.id, pending);
+                pending.then(() => {
+                    if (graphProjectionRepairPromiseById.get(record.id) === pending) {
+                        graphProjectionRepairPromiseById.delete(record.id);
+                    }
+                }, () => {
+                    if (graphProjectionRepairPromiseById.get(record.id) === pending) {
+                        graphProjectionRepairPromiseById.delete(record.id);
+                    }
+                });
+            }
+
+            const outcome = await pending;
+
+            if (outcome.issues.length > 0) summary.issues[record.id] = outcome.issues;
+            if (coalesced) {
+                summary.coalescedCandidateCount++;
                 continue;
             }
 
-            summary.issues[record.id] = issues;
-
-            try {
-                // Surgical mode: rebuild ONLY the flagged-missing pieces. A full re-projection
-                // here resurrects the WAL's send-time `readAt: null` over committed reads on
-                // every INTACT node/edge — the read-state-rollback defect this repair once was.
-                await this._projectMessageWalRecord(record, {pumpWake: false, onlyIssues: issues});
-                summary.repaired++;
-            } catch (error) {
-                summary.failed++;
-                logger.warn(`[MailboxService] message graph integrity repair failed for ${record.id}: ${error.message}`);
-            }
+            summary.scanned++;
+            if (outcome.status === 'intact') summary.intact++;
+            if (outcome.status === 'repaired') summary.repaired++;
+            if (outcome.status === 'failed') summary.failed++;
         }
 
         return summary;

--- a/ai/services/memory-core/helpers/messageWalStore.mjs
+++ b/ai/services/memory-core/helpers/messageWalStore.mjs
@@ -18,8 +18,92 @@ import {withAppendLock}                    from './walAppendLock.mjs';
  * @module ai/services/memory-core/helpers/messageWalStore
  */
 
-const MESSAGE_WAL_SEGMENT_RE = /^message-wal-(\d{4}-\d{2}-\d{2})\.jsonl$/;
-const projectionStatsCache   = new Map();
+const MESSAGE_WAL_SEGMENT_RE    = /^message-wal-(\d{4}-\d{2}-\d{2})\.jsonl$/,
+    MESSAGE_WAL_GRAPH_MARKER_RE = /^message-wal-(\d{4}-\d{2}-\d{2})\.graph\.jsonl$/;
+const projectionStatsCache = new Map();
+
+/**
+ * @summary Normalizes the immutable sender/destination fact stored beside a graph marker.
+ *
+ * Recipient-cohort knowledge is deliberately not part of this value. Historical broadcasts can
+ * have a trustworthy `sentBy` / `to: 'AGENT:*'` route while lacking the later send-time audience
+ * snapshot, so route and cohort evidence must remain independently upgradeable.
+ *
+ * @param {*} value Candidate marker value.
+ * @returns {{disposition: 'known', sentBy: String, to: String}|{disposition: 'legacy-unknown'}|null}
+ * @private
+ */
+function normalizeMailboxRoutingMarker(value) {
+    if (
+        value?.disposition === 'known' &&
+        typeof value.sentBy === 'string' && value.sentBy.length > 0 &&
+        typeof value.to === 'string' && value.to.length > 0
+    ) {
+        return {disposition: 'known', sentBy: value.sentBy, to: value.to}
+    }
+
+    if (value?.disposition === 'legacy-unknown') {
+        return {disposition: 'legacy-unknown'}
+    }
+
+    return null
+}
+
+/**
+ * @summary Normalizes the immutable broadcast-cohort fact stored beside a graph marker.
+ *
+ * `known` means the accepted WAL carried a send-time audience snapshot, including the valid
+ * zero-recipient case. `legacy-unknown` is an explicit compatibility disposition for historical
+ * rows that predate that snapshot; it is deliberately distinct from known zero so read-path
+ * integrity checks never manufacture recipients or repeatedly parse the same legacy WAL row.
+ *
+ * @param {*} value Candidate marker value.
+ * @returns {{disposition: 'known', intendedRecipientCount: Number}|{disposition: 'legacy-unknown'}|null}
+ * @private
+ */
+function normalizeBroadcastCohortMarker(value) {
+    if (value?.disposition === 'known' && Number.isSafeInteger(value.intendedRecipientCount) && value.intendedRecipientCount >= 0) {
+        return {disposition: 'known', intendedRecipientCount: value.intendedRecipientCount}
+    }
+
+    if (value?.disposition === 'legacy-unknown') {
+        return {disposition: 'legacy-unknown'}
+    }
+
+    return null
+}
+
+/**
+ * @summary Merges append-only projection-marker evidence without allowing later weaker facts to
+ * downgrade known evidence.
+ *
+ * The first known fact is authoritative because the initial projection marker is written from the
+ * accepted WAL record. A later unknown can never erase it. A later conflicting known fact is kept
+ * out of the serving value and surfaced through the conflict set instead of silently winning by
+ * file position.
+ *
+ * @param {Map<String,Object>} factsById Resolved monotonic facts.
+ * @param {Set<String>} conflictIds Ids carrying conflicting known facts.
+ * @param {String} id Message id.
+ * @param {Object|null} incoming Normalized incoming fact.
+ * @param {Function} equalKnown Compares two known facts.
+ * @returns {void}
+ * @private
+ */
+function mergeProjectionMarkerFact(factsById, conflictIds, id, incoming, equalKnown) {
+    if (!incoming) return;
+
+    const current = factsById.get(id);
+
+    if (!current || (current.disposition === 'legacy-unknown' && incoming.disposition === 'known')) {
+        factsById.set(id, incoming);
+        return
+    }
+
+    if (current.disposition === 'known' && incoming.disposition === 'known' && !equalKnown(current, incoming)) {
+        conflictIds.add(id);
+    }
+}
 
 /**
  * @summary Names the `messageWal` config leaves missing from a config slice.
@@ -112,11 +196,19 @@ export async function appendWalMessage(record, {dir, planeId, now, lockOptions} 
  * @param {String} marker.id Stable `MESSAGE:*` id.
  * @param {String} marker.segmentKey WAL segment key containing the accepted record.
  * @param {Number} [marker.projectedAt] Epoch-ms projection completion time.
+ * @param {Object} [marker.mailboxRouting] Immutable canonical sender/destination fact.
+ * @param {Object} [marker.broadcastCohort] Immutable intended-cohort fact for broadcasts.
  * @param {Object} options
  * @param {String} options.dir Message WAL directory.
  * @returns {Promise<String>} Written markers file path.
  */
-export async function appendMessageWalGraphProjectionMarker({id, segmentKey, projectedAt}, {dir} = {}) {
+export async function appendMessageWalGraphProjectionMarker({
+    id,
+    segmentKey,
+    projectedAt,
+    mailboxRouting,
+    broadcastCohort
+}, {dir} = {}) {
     if (!dir) {
         throw new TypeError('appendMessageWalGraphProjectionMarker: dir is required');
     }
@@ -124,11 +216,32 @@ export async function appendMessageWalGraphProjectionMarker({id, segmentKey, pro
         throw new TypeError('appendMessageWalGraphProjectionMarker: id and segmentKey are required');
     }
 
+    const normalizedMailboxRouting = mailboxRouting === undefined
+        ? undefined
+        : normalizeMailboxRoutingMarker(mailboxRouting);
+    const normalizedBroadcastCohort = broadcastCohort === undefined
+        ? undefined
+        : normalizeBroadcastCohortMarker(broadcastCohort);
+
+    if (mailboxRouting !== undefined && !normalizedMailboxRouting) {
+        throw new TypeError('appendMessageWalGraphProjectionMarker: mailboxRouting must be known with sentBy/to or legacy-unknown');
+    }
+    if (broadcastCohort !== undefined && !normalizedBroadcastCohort) {
+        throw new TypeError('appendMessageWalGraphProjectionMarker: broadcastCohort must be known with a non-negative integer count or legacy-unknown');
+    }
+
     await fs.mkdir(dir, {recursive: true});
 
     const filePath = path.join(dir, getMessageWalGraphMarkersFileName(segmentKey));
 
-    await fs.appendFile(filePath, `${JSON.stringify({id, projectedAt: projectedAt ?? Date.now()})}\n`, 'utf8');
+    const marker = {
+        id,
+        projectedAt: projectedAt ?? Date.now(),
+        ...(normalizedMailboxRouting ? {mailboxRouting: normalizedMailboxRouting} : {}),
+        ...(normalizedBroadcastCohort ? {broadcastCohort: normalizedBroadcastCohort} : {})
+    };
+
+    await fs.appendFile(filePath, `${JSON.stringify(marker)}\n`, 'utf8');
 
     return filePath;
 }
@@ -241,7 +354,47 @@ async function getGraphMarkerFileStats(dir, segmentKeys) {
 }
 
 /**
- * @summary Lists message WAL segment keys newest first.
+ * @summary Builds change-sensitive signatures for accepted-message payload segments.
+ *
+ * Read-path repair uses these signatures only to bound retries for an unreadable indexed record.
+ * File kind is included so replacing an accidental directory with the expected JSONL file wakes a
+ * deferred candidate immediately, even if coarse filesystem timestamps happen to coincide.
+ *
+ * @param {String} dir Message WAL directory.
+ * @param {String[]} segmentKeys Segment keys newest first.
+ * @returns {Promise<Map<String,String>>}
+ * @private
+ */
+async function getPayloadSignaturesBySegment(dir, segmentKeys) {
+    const signatures = new Map();
+
+    for (const segmentKey of segmentKeys) {
+        const filePath = path.join(dir, getMessageWalRecordsFileName(segmentKey));
+
+        try {
+            const stat = await fs.stat(filePath);
+            signatures.set(segmentKey, [
+                stat.isFile() ? 'file' : 'non-file',
+                stat.dev,
+                stat.ino,
+                stat.size,
+                stat.mtimeMs
+            ].join(':'));
+        } catch (e) {
+            signatures.set(segmentKey, `unavailable:${e?.code || 'unknown'}`);
+        }
+    }
+
+    return signatures
+}
+
+/**
+ * @summary Lists the union of accepted-payload and graph-marker segment keys newest first.
+ *
+ * Graph markers remain the durable projected-id index even when a payload segment is temporarily
+ * missing or unreadable. Deriving this population from payload names alone made those ids vanish
+ * as false-healthy before the unreadable-candidate boundary could observe them.
+ *
  * @param {String} dir Message WAL directory.
  * @returns {Promise<String[]>}
  * @private
@@ -257,8 +410,9 @@ async function listMessageWalSegmentKeys(dir) {
     }
 
     return names
-        .map(name => name.match(MESSAGE_WAL_SEGMENT_RE)?.[1])
+        .map(name => name.match(MESSAGE_WAL_SEGMENT_RE)?.[1] || name.match(MESSAGE_WAL_GRAPH_MARKER_RE)?.[1])
         .filter(Boolean)
+        .filter((segmentKey, index, keys) => keys.indexOf(segmentKey) === index)
         .sort((a, b) => b.localeCompare(a));
 }
 
@@ -320,30 +474,58 @@ export async function readWalMessages({dir} = {}) {
  *
  * @param {Object} options
  * @param {String} options.dir Message WAL directory.
- * @returns {Promise<{projectedCount: Number, projectedIds: Set<String>, segmentById: Map<String,String>}>}
+ * @returns {Promise<{projectedCount: Number, projectedIds: Set<String>, segmentById: Map<String,String>, mailboxRoutingById: Map<String,Object>, broadcastCohortById: Map<String,Object>, markerConflicts: Object, payloadSignatureBySegment: Map<String,String>}>}
  */
 export async function getMessageWalGraphProjectionStats({dir} = {}) {
     if (!dir) {
         throw new TypeError('getMessageWalGraphProjectionStats: dir is required');
     }
 
-    const segmentKeys = await listMessageWalSegmentKeys(dir);
-    const markerStats = await getGraphMarkerFileStats(dir, segmentKeys);
-    const signature   = markerStats.map(item => item.signature).join('|');
-    const cached      = projectionStatsCache.get(dir);
+    const segmentKeys               = await listMessageWalSegmentKeys(dir);
+    const markerStats               = await getGraphMarkerFileStats(dir, segmentKeys);
+    const payloadSignatureBySegment = await getPayloadSignaturesBySegment(dir, segmentKeys);
+    const signature                 = [
+        ...markerStats.map(item => item.signature),
+        ...[...payloadSignatureBySegment].map(([segmentKey, value]) => `payload:${segmentKey}:${value}`)
+    ].join('|');
+    const cached = projectionStatsCache.get(dir);
 
     if (cached?.signature === signature) {
         return cached.stats;
     }
 
-    const segmentById = new Map();
+    const segmentById       = new Map(),
+        mailboxRoutingById  = new Map(),
+        broadcastCohortById = new Map(),
+        markerConflicts     = {
+            mailboxRoutingIds : new Set(),
+            broadcastCohortIds: new Set()
+        };
 
     for (const {filePath, segmentKey} of markerStats) {
         for (const entry of await readJsonlEntries(filePath)) {
-            const id = entry?.id;
+            const id            = entry?.id,
+                mailboxRouting  = normalizeMailboxRoutingMarker(entry?.mailboxRouting),
+                broadcastCohort = normalizeBroadcastCohortMarker(entry?.broadcastCohort);
 
             if (typeof id === 'string' && id.startsWith('MESSAGE:') && !segmentById.has(id)) {
                 segmentById.set(id, segmentKey);
+            }
+            if (typeof id === 'string' && id.startsWith('MESSAGE:')) {
+                mergeProjectionMarkerFact(
+                    mailboxRoutingById,
+                    markerConflicts.mailboxRoutingIds,
+                    id,
+                    mailboxRouting,
+                    (current, incoming) => current.sentBy === incoming.sentBy && current.to === incoming.to
+                );
+                mergeProjectionMarkerFact(
+                    broadcastCohortById,
+                    markerConflicts.broadcastCohortIds,
+                    id,
+                    broadcastCohort,
+                    (current, incoming) => current.intendedRecipientCount === incoming.intendedRecipientCount
+                );
             }
         }
     }
@@ -351,7 +533,11 @@ export async function getMessageWalGraphProjectionStats({dir} = {}) {
     const stats = {
         projectedCount: segmentById.size,
         projectedIds  : new Set(segmentById.keys()),
-        segmentById
+        segmentById,
+        mailboxRoutingById,
+        broadcastCohortById,
+        markerConflicts,
+        payloadSignatureBySegment
     };
 
     projectionStatsCache.set(dir, {signature, stats});

--- a/test/playwright/unit/ai/services/memory-core/MailboxService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/MailboxService.spec.mjs
@@ -15,6 +15,7 @@ setup({
 
 import {test, expect} from '@playwright/test';
 import fs             from 'fs-extra';
+import fsPromises     from 'fs/promises';
 import path           from 'path';
 import Neo            from '../../../../../../src/Neo.mjs';
 import * as core      from '../../../../../../src/core/_export.mjs';
@@ -193,6 +194,28 @@ test.describe('Neo.ai.services.memory-core.MailboxService', () => {
         GraphService.db.lastAccessMap.clear();
 
         return edges.length
+    }
+
+    /**
+     * @summary Counts accepted-message payload reads while excluding compact `.graph.jsonl`
+     * marker reads. The returned restore closure keeps the worker-global built-in module clean.
+     * @returns {{getCount: Function, restore: Function}}
+     */
+    function instrumentMessageWalPayloadReads() {
+        const originalReadFile = fsPromises.readFile;
+        let   count            = 0;
+
+        fsPromises.readFile = async (filePath, ...args) => {
+            if (/message-wal-\d{4}-\d{2}-\d{2}\.jsonl$/.test(String(filePath))) count++;
+            return originalReadFile(filePath, ...args)
+        };
+
+        return {
+            getCount: () => count,
+            restore : () => {
+                fsPromises.readFile = originalReadFile;
+            }
+        }
     }
 
     test('addMessage enforces identity and routes correctly', async () => {
@@ -566,9 +589,14 @@ test.describe('Neo.ai.services.memory-core.MailboxService', () => {
     });
 
     test('listMessages repairs a broadcast whose WHOLE DELIVERED_TO cohort was lost — read-path, no prior mark (#15369)', async () => {
-        // @bob authorizes @alice; @alice broadcasts to AGENT:* (bob is in the send-time audience).
+        // @bob authorizes @alice; @alice broadcasts to AGENT:* (bob + charlie are the immutable
+        // send-time audience). Multi-recipient intent proves a whole-cohort repair, not a one-edge
+        // special case.
         await RequestContextService.run({agentIdentityNodeId: '@bob'}, async () => {
             await PermissionService.grantPermission({to: '@alice', scope: 'CAN_REPLY_TO'});
+        });
+        GraphService.upsertNode({
+            id: '@charlie', type: 'AgentIdentity', name: 'Charlie', properties: {accountType: 'agent'}
         });
 
         const res = await RequestContextService.run({agentIdentityNodeId: '@alice'}, async () => {
@@ -577,13 +605,14 @@ test.describe('Neo.ai.services.memory-core.MailboxService', () => {
 
         // WAL truth is committed BEFORE we damage the projection — the repair source is real.
         expect(await readPendingMessageWalRecords({dir: messageWalDir, ids: [res.messageId]})).toHaveLength(0);
+        expect((await readWalMessages({dir: messageWalDir}))[0].routing.broadcastRecipients).toEqual(['@bob', '@charlie']);
 
         // TOTAL cohort loss: strip every DELIVERED_TO edge (cache AND storage) while the MESSAGE node,
         // SENT_BY, and SENT_TO → AGENT:* all survive. The count trio (MESSAGE/SENT_BY/SENT_TO) therefore
         // still matches projectedCount, so the pre-fix gate is BLIND — this is the exact silent damage
         // class the read-gate could not see, and the only signal is the zero-DELIVERED_TO broadcast term.
         const removed = damageEdgeProjection(res.messageId, 'DELIVERED_TO');
-        expect(removed, 'the broadcast must have had a delivery cohort to lose').toBeGreaterThan(0);
+        expect(removed, 'the broadcast must have had the full two-recipient cohort to lose').toBe(2);
         expect(
             GraphService.db.storage.db.prepare("SELECT COUNT(*) AS c FROM Edges WHERE source = ? AND type = 'DELIVERED_TO'").get(res.messageId).c,
             'storage cohort is truly gone — not a cache-only eviction that self-heals on reload'
@@ -594,16 +623,722 @@ test.describe('Neo.ai.services.memory-core.MailboxService', () => {
         // (delivery + read-state) is gone. Pre-fix the blind gate early-returns at scanned:0, so the list
         // leaves the cohort broken; post-fix the broadcast-cohort term flips the gate and the WAL-backed
         // repair rebuilds it during the read.
-        const bobInbox = await RequestContextService.run({agentIdentityNodeId: '@bob'}, async () => {
-            return await MailboxService.listMessages({status: 'all'});
-        });
-        expect(bobInbox.messages.map(message => message.messageId)).toContain(res.messageId);
+        const bogusSegment = path.join(messageWalDir, 'message-wal-2001-01-01.jsonl');
+        fs.ensureDirSync(bogusSegment);
+
+        try {
+            const bobInbox = await RequestContextService.run({agentIdentityNodeId: '@bob'}, async () => {
+                return await MailboxService.listMessages({status: 'all'});
+            });
+            expect(bobInbox.messages.map(message => message.messageId)).toContain(res.messageId);
+        } finally {
+            fs.removeSync(bogusSegment);
+        }
+
+        expect(GraphService.db.storage.db.prepare(`
+            SELECT target
+              FROM Edges
+             WHERE source = ?
+               AND type = 'DELIVERED_TO'
+             ORDER BY target
+        `).all(res.messageId).map(row => row.target)).toEqual(['@bob', '@charlie']);
 
         // THE discriminating assertion (red-proof confirmed by disabling the new term): a follow-up
         // integrity scan finds the cohort already rebuilt by the read. Without the fix the list never
         // repairs, so this scan reports `repaired: 1` — the exact never-self-heals defect this closes.
         const repairCheck = await MailboxService.repairMessageGraphIntegrity({ids: [res.messageId]});
         expect(repairCheck).toMatchObject({scanned: 1, intact: 1, repaired: 0, failed: 0});
+    });
+
+    test('a legitimate zero-audience broadcast stays converged across repeated lists (#16767)', async () => {
+        GraphService.removeNodes(['@bob']);
+
+        const res = await RequestContextService.run({agentIdentityNodeId: '@alice'}, async () => {
+            return await MailboxService.addMessage({
+                to     : 'AGENT:*',
+                subject: 'zero audience',
+                body   : 'legitimate single-resident broadcast'
+            });
+        });
+        const [record] = await readWalMessages({dir: messageWalDir});
+
+        expect(record.id).toBe(res.messageId);
+        expect(record.routing.broadcastRecipients).toEqual([]);
+        expect(GraphService.db.storage.db.prepare(`
+            SELECT COUNT(*) AS count
+              FROM Edges
+             WHERE source = ?
+               AND type = 'DELIVERED_TO'
+        `).get(res.messageId).count).toBe(0);
+
+        const bogusSegment = path.join(messageWalDir, 'message-wal-2001-01-01.jsonl');
+        const reads        = instrumentMessageWalPayloadReads();
+        fs.ensureDirSync(bogusSegment);
+
+        try {
+            for (let attempt = 0; attempt < 2; attempt++) {
+                const outbox = await RequestContextService.run({agentIdentityNodeId: '@alice'}, async () => {
+                    return await MailboxService.listMessages({box: 'outbox', status: 'all'});
+                });
+                expect(outbox.messages.map(message => message.messageId)).toContain(res.messageId);
+            }
+
+            // Known zero lives in the compact projection marker. Neither the first nor second
+            // list reopens an accepted payload, and the corrupt unrelated segment stays untouched.
+            expect(reads.getCount()).toBe(0);
+        } finally {
+            reads.restore();
+            fs.removeSync(bogusSegment);
+        }
+    });
+
+    test('a historical broadcast without cohort evidence receives one durable compatibility disposition (#16767)', async () => {
+        GraphService.removeNodes(['@bob']);
+
+        const res = await RequestContextService.run({agentIdentityNodeId: '@alice'}, async () => {
+            return await MailboxService.addMessage({
+                to     : 'AGENT:*',
+                subject: 'legacy audience',
+                body   : 'accepted before cohort markers'
+            });
+        });
+        const [record]    = await readWalMessages({dir: messageWalDir});
+        const segmentKey  = record.segmentKey;
+        const payloadPath = path.join(messageWalDir, `message-wal-${segmentKey}.jsonl`);
+        const markerPath  = path.join(messageWalDir, `message-wal-${segmentKey}.graph.jsonl`);
+
+        delete record.routing.broadcastRecipients;
+        fs.writeFileSync(payloadPath, `${JSON.stringify(record)}\n`, 'utf8');
+
+        const originalMarker = JSON.parse(fs.readFileSync(markerPath, 'utf8').trim());
+        delete originalMarker.broadcastCohort;
+        fs.writeFileSync(markerPath, `${JSON.stringify(originalMarker)}\n`, 'utf8');
+
+        const bogusSegment = path.join(messageWalDir, 'message-wal-2001-01-01.jsonl');
+        const reads        = instrumentMessageWalPayloadReads();
+        fs.ensureDirSync(bogusSegment);
+
+        try {
+            const first = await RequestContextService.run({agentIdentityNodeId: '@alice'}, async () => {
+                return await MailboxService.listMessages({box: 'outbox', status: 'all'});
+            });
+            expect(first.messages.map(message => message.messageId)).toContain(res.messageId);
+            expect(reads.getCount()).toBe(1);
+
+            const markerEntries = fs.readFileSync(markerPath, 'utf8').trim().split('\n').map(line => JSON.parse(line));
+            expect(markerEntries.at(-1).broadcastCohort).toEqual({disposition: 'legacy-unknown'});
+
+            const second = await RequestContextService.run({agentIdentityNodeId: '@alice'}, async () => {
+                return await MailboxService.listMessages({box: 'outbox', status: 'all'});
+            });
+            expect(second.messages.map(message => message.messageId)).toContain(res.messageId);
+            expect(reads.getCount(), 'the second list must consume the compatibility marker, not reread WAL').toBe(1);
+        } finally {
+            reads.restore();
+            fs.removeSync(bogusSegment);
+        }
+    });
+
+    test('a global discrepancy outside the caller view does not consume the bounded repair window (#16767)', async () => {
+        GraphService.upsertNode({
+            id: '@charlie', type: 'AgentIdentity', name: 'Charlie', properties: {accountType: 'agent'}
+        });
+        await RequestContextService.run({agentIdentityNodeId: '@bob'}, async () => {
+            await PermissionService.grantPermission({to: '@alice', scope: 'CAN_REPLY_TO'});
+        });
+
+        const res = await RequestContextService.run({agentIdentityNodeId: '@alice'}, async () => {
+            return await MailboxService.addMessage({to: '@bob', subject: 'bob only', body: 'unrelated to charlie'});
+        });
+        expect(damageEdgeProjection(res.messageId, 'SENT_BY')).toBe(1);
+
+        // Simulate a marker from before routing metadata was persisted. The first unrelated list may perform the one-time indexed
+        // route migration read; the enriched marker must make every later unrelated list payload-free.
+        const markerPath = fs.readdirSync(messageWalDir)
+            .map(name => path.join(messageWalDir, name))
+            .find(filePath => filePath.endsWith('.graph.jsonl'));
+        const markerEntry = JSON.parse(fs.readFileSync(markerPath, 'utf8').trim());
+        delete markerEntry.mailboxRouting;
+        fs.writeFileSync(markerPath, `${JSON.stringify(markerEntry)}\n`, 'utf8');
+
+        const bogusSegment = path.join(messageWalDir, 'message-wal-2001-01-01.jsonl');
+        const reads        = instrumentMessageWalPayloadReads();
+        fs.ensureDirSync(bogusSegment);
+
+        try {
+            const repair = await MailboxService.repairMessageGraphIntegrity({
+                target: '@charlie', box: 'inbox', limit: 1
+            });
+
+            expect(repair).toMatchObject({
+                candidateCount: 1, matchedCandidateCount: 0, scanned: 0, repaired: 0, failed: 0
+            });
+            expect(reads.getCount()).toBe(1);
+
+            const charlieInbox = await RequestContextService.run({agentIdentityNodeId: '@charlie'}, async () => {
+                return await MailboxService.listMessages({status: 'all'});
+            });
+            expect(charlieInbox.messages).toEqual([]);
+            expect(reads.getCount(), 'route migration must retire the unrelated candidate WAL tax').toBe(1);
+        } finally {
+            reads.restore();
+            fs.removeSync(bogusSegment);
+        }
+    });
+
+    test('a route-marker append failure remains an observable residual, never a list failure or repeated WAL tax (#16767)', async () => {
+        GraphService.upsertNode({
+            id: '@charlie', type: 'AgentIdentity', name: 'Charlie', properties: {accountType: 'agent'}
+        });
+        await RequestContextService.run({agentIdentityNodeId: '@bob'}, async () => {
+            await PermissionService.grantPermission({to: '@alice', scope: 'CAN_REPLY_TO'});
+        });
+
+        const res = await RequestContextService.run({agentIdentityNodeId: '@alice'}, async () => {
+            return await MailboxService.addMessage({to: '@bob', subject: 'marker append failure', body: 'bounded'});
+        });
+        expect(damageEdgeProjection(res.messageId, 'SENT_BY')).toBe(1);
+
+        const markerPath = fs.readdirSync(messageWalDir)
+            .map(name => path.join(messageWalDir, name))
+            .find(filePath => filePath.endsWith('.graph.jsonl'));
+        const markerEntry = JSON.parse(fs.readFileSync(markerPath, 'utf8').trim());
+        delete markerEntry.mailboxRouting;
+        fs.writeFileSync(markerPath, `${JSON.stringify(markerEntry)}\n`, 'utf8');
+
+        const originalAppendFile = fsPromises.appendFile,
+            reads                = instrumentMessageWalPayloadReads();
+
+        fsPromises.appendFile = async (filePath, ...args) => {
+            if (String(filePath).endsWith('.graph.jsonl')) throw new Error('injected marker EIO');
+            return originalAppendFile(filePath, ...args)
+        };
+
+        try {
+            const first = await MailboxService.repairMessageGraphIntegrity({
+                target: '@charlie', box: 'inbox', limit: 1
+            });
+            expect(first).toMatchObject({
+                candidateCount       : 1,
+                matchedCandidateCount: 0,
+                scanned              : 0,
+                failed               : 0,
+                compatibility        : {persistenceFailed: 1}
+            });
+            expect(reads.getCount()).toBe(1);
+
+            const second = await MailboxService.repairMessageGraphIntegrity({
+                target: '@charlie', box: 'inbox', limit: 1
+            });
+            expect(second).toMatchObject({
+                candidateCount       : 1,
+                matchedCandidateCount: 0,
+                scanned              : 0,
+                failed               : 0,
+                compatibility        : {cached: 1, persistenceFailed: 0}
+            });
+            expect(reads.getCount(), 'the immutable in-process route cache bounds a failed append').toBe(1);
+        } finally {
+            fsPromises.appendFile = originalAppendFile;
+            reads.restore();
+        }
+    });
+
+    test('an unreadable candidate segment backs off until its payload signature changes (#16767)', async () => {
+        await RequestContextService.run({agentIdentityNodeId: '@bob'}, async () => {
+            await PermissionService.grantPermission({to: '@alice', scope: 'CAN_REPLY_TO'});
+        });
+
+        const res = await RequestContextService.run({agentIdentityNodeId: '@alice'}, async () => {
+            return await MailboxService.addMessage({to: '@bob', subject: 'unreadable candidate', body: 'retry on change'});
+        });
+        expect(damageEdgeProjection(res.messageId, 'SENT_BY')).toBe(1);
+
+        const [record]  = await readWalMessages({dir: messageWalDir}),
+            payloadPath = path.join(messageWalDir, `message-wal-${record.segmentKey}.jsonl`),
+            payloadText = fs.readFileSync(payloadPath, 'utf8'),
+            reads       = instrumentMessageWalPayloadReads();
+
+        fs.removeSync(payloadPath);
+        fs.ensureDirSync(payloadPath);
+
+        try {
+            const first = await MailboxService.repairMessageGraphIntegrity({
+                target: '@bob', box: 'inbox', limit: 1
+            });
+            expect(first).toMatchObject({
+                candidateCount          : 1, matchedCandidateCount: 1, scanned: 0,
+                unreadableCandidateCount: 1, deferredUnreadableCandidateCount: 0
+            });
+            expect(reads.getCount()).toBe(1);
+
+            const second = await MailboxService.repairMessageGraphIntegrity({
+                target: '@bob', box: 'inbox', limit: 1
+            });
+            expect(second).toMatchObject({
+                candidateCount          : 1, matchedCandidateCount: 1, scanned: 0,
+                unreadableCandidateCount: 1, deferredUnreadableCandidateCount: 1
+            });
+            expect(reads.getCount(), 'unchanged unreadable payload must stay behind backoff').toBe(1);
+
+            fs.removeSync(payloadPath);
+            fs.writeFileSync(payloadPath, payloadText, 'utf8');
+
+            const third = await MailboxService.repairMessageGraphIntegrity({
+                target: '@bob', box: 'inbox', limit: 1
+            });
+            expect(third).toMatchObject({
+                candidateCount: 1, matchedCandidateCount: 1, scanned: 1,
+                repaired      : 1, failed: 0, unreadableCandidateCount: 0
+            });
+            expect(reads.getCount(), 'file-kind/signature change must retry immediately').toBe(2);
+        } finally {
+            reads.restore();
+            if (fs.existsSync(payloadPath) && fs.statSync(payloadPath).isDirectory()) {
+                fs.removeSync(payloadPath);
+                fs.writeFileSync(payloadPath, payloadText, 'utf8');
+            }
+        }
+    });
+
+    test('an unreadable candidate is retried after its durable marker leaves and re-enters the index (#16767)', async () => {
+        await RequestContextService.run({agentIdentityNodeId: '@bob'}, async () => {
+            await PermissionService.grantPermission({to: '@alice', scope: 'CAN_REPLY_TO'});
+        });
+
+        const res = await RequestContextService.run({agentIdentityNodeId: '@alice'}, async () => {
+            return await MailboxService.addMessage({to: '@bob', subject: 'marker generation', body: 'prune stale cooldown'});
+        });
+        expect(damageEdgeProjection(res.messageId, 'SENT_BY')).toBe(1);
+
+        const [record]  = await readWalMessages({dir: messageWalDir}),
+            payloadPath = path.join(messageWalDir, `message-wal-${record.segmentKey}.jsonl`),
+            markerPath  = path.join(messageWalDir, `message-wal-${record.segmentKey}.graph.jsonl`),
+            payloadText = fs.readFileSync(payloadPath, 'utf8'),
+            markerText  = fs.readFileSync(markerPath, 'utf8'),
+            reads       = instrumentMessageWalPayloadReads();
+
+        // Keep the payload generation stable and unreadable for this id while removing only the
+        // durable projection marker. The empty marker population must retire its old cooldown.
+        fs.writeFileSync(payloadPath, '', 'utf8');
+
+        try {
+            const first = await MailboxService.repairMessageGraphIntegrity({
+                target: '@bob', box: 'inbox', limit: 1
+            });
+            expect(first).toMatchObject({scanned: 0, unreadableCandidateCount: 1});
+            expect(reads.getCount()).toBe(1);
+
+            fs.removeSync(markerPath);
+            const absent = await MailboxService.repairMessageGraphIntegrity({
+                target: '@bob', box: 'inbox', limit: 1
+            });
+            expect(absent).toMatchObject({candidateCount: 0, scanned: 0});
+
+            fs.writeFileSync(markerPath, markerText, 'utf8');
+            const restored = await MailboxService.repairMessageGraphIntegrity({
+                target: '@bob', box: 'inbox', limit: 1
+            });
+            expect(restored).toMatchObject({
+                candidateCount          : 1, scanned: 0,
+                unreadableCandidateCount: 1, deferredUnreadableCandidateCount: 0
+            });
+            expect(reads.getCount(), 'a marker generation change must retire stale candidate state').toBe(2);
+        } finally {
+            reads.restore();
+            fs.writeFileSync(payloadPath, payloadText, 'utf8');
+            fs.writeFileSync(markerPath, markerText, 'utf8');
+        }
+    });
+
+    test('ordinary active-segment growth does not wake an older unreadable candidate (#16767)', async () => {
+        await RequestContextService.run({agentIdentityNodeId: '@bob'}, async () => {
+            await PermissionService.grantPermission({to: '@alice', scope: 'CAN_REPLY_TO'});
+        });
+
+        const res = await RequestContextService.run({agentIdentityNodeId: '@alice'}, async () => {
+            return await MailboxService.addMessage({to: '@bob', subject: 'missing row', body: 'append-safe backoff'});
+        });
+        expect(damageEdgeProjection(res.messageId, 'SENT_BY')).toBe(1);
+
+        const [record]      = await readWalMessages({dir: messageWalDir}),
+            payloadPath     = path.join(messageWalDir, `message-wal-${record.segmentKey}.jsonl`),
+            replacementPath = `${payloadPath}.replacement`,
+            payloadText     = fs.readFileSync(payloadPath, 'utf8'),
+            reads           = instrumentMessageWalPayloadReads();
+
+        // Truncate in place so the marker survives but its indexed accepted row is absent.
+        fs.writeFileSync(payloadPath, '', 'utf8');
+
+        try {
+            const first = await MailboxService.repairMessageGraphIntegrity({
+                target: '@bob', box: 'inbox', limit: 1
+            });
+            expect(first).toMatchObject({scanned: 0, unreadableCandidateCount: 1});
+            expect(reads.getCount()).toBe(1);
+
+            // A different accepted-looking row grows the same inode. It cannot repair the older
+            // id, so the cooldown must survive this ordinary active-day append.
+            const unrelated = {
+                ...record,
+                id     : 'MESSAGE:unrelated-append',
+                message: {...record.message, id: 'MESSAGE:unrelated-append'}
+            };
+            fs.appendFileSync(payloadPath, `${JSON.stringify(unrelated)}\n`, 'utf8');
+
+            const second = await MailboxService.repairMessageGraphIntegrity({
+                target: '@bob', box: 'inbox', limit: 1
+            });
+            expect(second).toMatchObject({
+                scanned: 0, unreadableCandidateCount: 1, deferredUnreadableCandidateCount: 1
+            });
+            expect(reads.getCount(), 'monotonic segment growth must not defeat the backoff').toBe(1);
+
+            fs.writeFileSync(replacementPath, payloadText, 'utf8');
+            fs.renameSync(replacementPath, payloadPath);
+
+            const third = await MailboxService.repairMessageGraphIntegrity({
+                target: '@bob', box: 'inbox', limit: 1
+            });
+            expect(third).toMatchObject({scanned: 1, repaired: 1, failed: 0});
+            expect(reads.getCount(), 'inode replacement must retry immediately').toBe(2);
+        } finally {
+            reads.restore();
+            fs.removeSync(replacementPath);
+            fs.removeSync(payloadPath);
+            fs.writeFileSync(payloadPath, payloadText, 'utf8');
+        }
+    });
+
+    test('an equal-size in-place payload correction wakes an unreadable candidate immediately (#16767)', async () => {
+        await RequestContextService.run({agentIdentityNodeId: '@bob'}, async () => {
+            await PermissionService.grantPermission({to: '@alice', scope: 'CAN_REPLY_TO'});
+        });
+
+        const res = await RequestContextService.run({agentIdentityNodeId: '@alice'}, async () => {
+            return await MailboxService.addMessage({to: '@bob', subject: 'same-size correction', body: 'mtime is evidence'});
+        });
+        expect(damageEdgeProjection(res.messageId, 'SENT_BY')).toBe(1);
+
+        const [record]    = await readWalMessages({dir: messageWalDir}),
+            payloadPath   = path.join(messageWalDir, `message-wal-${record.segmentKey}.jsonl`),
+            payloadText   = fs.readFileSync(payloadPath, 'utf8'),
+            replacementId = 'MESSAGE:00000000-0000-4000-8000-000000000000',
+            missingText   = payloadText.split(res.messageId).join(replacementId),
+            originalStat  = fs.statSync(payloadPath),
+            reads         = instrumentMessageWalPayloadReads();
+
+        expect(replacementId.length).toBe(res.messageId.length);
+        expect(Buffer.byteLength(missingText)).toBe(Buffer.byteLength(payloadText));
+        fs.writeFileSync(payloadPath, missingText, 'utf8');
+
+        try {
+            const first = await MailboxService.repairMessageGraphIntegrity({
+                target: '@bob', box: 'inbox', limit: 1
+            });
+            expect(first).toMatchObject({scanned: 0, unreadableCandidateCount: 1});
+            expect(reads.getCount()).toBe(1);
+
+            fs.writeFileSync(payloadPath, payloadText, 'utf8');
+            const changedTime = new Date(Date.now() + 2000);
+            fs.utimesSync(payloadPath, changedTime, changedTime);
+
+            const correctedStat = fs.statSync(payloadPath);
+            expect(correctedStat.ino).toBe(originalStat.ino);
+            expect(correctedStat.size).toBe(originalStat.size);
+
+            const second = await MailboxService.repairMessageGraphIntegrity({
+                target: '@bob', box: 'inbox', limit: 1
+            });
+            expect(second).toMatchObject({scanned: 1, repaired: 1, failed: 0});
+            expect(reads.getCount(), 'changed evidence at equal size must bypass the cooldown').toBe(2);
+        } finally {
+            reads.restore();
+            fs.writeFileSync(payloadPath, payloadText, 'utf8');
+        }
+    });
+
+    test('concurrent same-id repairs await one projection mutation (#16767)', async () => {
+        await RequestContextService.run({agentIdentityNodeId: '@bob'}, async () => {
+            await PermissionService.grantPermission({to: '@alice', scope: 'CAN_REPLY_TO'});
+        });
+
+        const res = await RequestContextService.run({agentIdentityNodeId: '@alice'}, async () => {
+            return await MailboxService.addMessage({to: '@bob', subject: 'single flight', body: 'one writer'});
+        });
+        expect(damageEdgeProjection(res.messageId, 'SENT_BY')).toBe(1);
+
+        const originalProject = MailboxService._projectMessageWalRecord,
+            originalReadFile  = fsPromises.readFile;
+        let   projectCalls = 0,
+            payloadReads   = 0,
+            releasePayloadRead,
+            announceReadEntered;
+        const payloadReadGate = new Promise(resolve => {
+            releasePayloadRead = resolve;
+        });
+        const readEntered = new Promise(resolve => {
+            announceReadEntered = resolve;
+        });
+
+        fsPromises.readFile = async (filePath, ...args) => {
+            if (/message-wal-\d{4}-\d{2}-\d{2}\.jsonl$/.test(String(filePath))) {
+                payloadReads++;
+                announceReadEntered();
+                await payloadReadGate;
+            }
+            return originalReadFile(filePath, ...args)
+        };
+
+        MailboxService._projectMessageWalRecord = async function(record, options) {
+            projectCalls++;
+            return originalProject.call(this, record, options)
+        };
+
+        try {
+            const first  = MailboxService.repairMessageGraphIntegrity({target: '@bob', box: 'inbox', limit: 1});
+            const second = MailboxService.repairMessageGraphIntegrity({target: '@bob', box: 'inbox', limit: 1});
+
+            await readEntered;
+            // The first caller is parked inside the payload read. Give the second caller several
+            // turns to reach the same id; without the load promise it opens the segment too.
+            for (let turn = 0; turn < 3; turn++) {
+                await new Promise(resolve => setImmediate(resolve));
+            }
+            expect(payloadReads).toBe(1);
+            releasePayloadRead();
+
+            const results = await Promise.all([first, second]);
+            expect(projectCalls).toBe(1);
+            expect(payloadReads, 'record loading and mutation must share the single-flight pipeline').toBe(1);
+            expect(results.map(item => item.repaired).sort()).toEqual([0, 1]);
+            expect(results.map(item => item.coalescedCandidateCount).sort()).toEqual([0, 1]);
+            expect(results.every(item => item.failed === 0)).toBe(true);
+        } finally {
+            releasePayloadRead();
+            fsPromises.readFile = originalReadFile;
+            MailboxService._projectMessageWalRecord = originalProject;
+        }
+    });
+
+    test('concurrent global and explicit repairs share one physical segment load (#16767)', async () => {
+        GraphService.upsertNode({
+            id: '@charlie', type: 'AgentIdentity', name: 'Charlie', properties: {accountType: 'agent'}
+        });
+        for (const recipient of ['@bob', '@charlie']) {
+            await RequestContextService.run({agentIdentityNodeId: recipient}, async () => {
+                await PermissionService.grantPermission({to: '@alice', scope: 'CAN_REPLY_TO'});
+            });
+        }
+
+        const [bobMessage, charlieMessage] = await RequestContextService.run({agentIdentityNodeId: '@alice'}, async () => {
+            return await Promise.all([
+                MailboxService.addMessage({to: '@bob', subject: 'segment one', body: 'global path'}),
+                MailboxService.addMessage({to: '@charlie', subject: 'segment two', body: 'explicit path'})
+            ])
+        });
+        expect(damageEdgeProjection(bobMessage.messageId, 'SENT_BY')).toBe(1);
+        expect(damageEdgeProjection(charlieMessage.messageId, 'SENT_BY')).toBe(1);
+
+        const originalProject = MailboxService._projectMessageWalRecord,
+            originalReadFile  = fsPromises.readFile;
+        let   projectCalls = 0,
+            payloadReads   = 0,
+            releasePayloadRead,
+            announceReadEntered;
+        const payloadReadGate = new Promise(resolve => {
+            releasePayloadRead = resolve;
+        });
+        const readEntered = new Promise(resolve => {
+            announceReadEntered = resolve;
+        });
+
+        fsPromises.readFile = async (filePath, ...args) => {
+            if (/message-wal-\d{4}-\d{2}-\d{2}\.jsonl$/.test(String(filePath))) {
+                payloadReads++;
+                announceReadEntered();
+                await payloadReadGate;
+            }
+            return originalReadFile(filePath, ...args)
+        };
+
+        MailboxService._projectMessageWalRecord = async function(record, options) {
+            projectCalls++;
+            return originalProject.call(this, record, options)
+        };
+
+        try {
+            const globalRepair = MailboxService.repairMessageGraphIntegrity({
+                target: '@bob', box: 'inbox', limit: 1
+            });
+            const explicitRepair = MailboxService.repairMessageGraphIntegrity({
+                ids: [charlieMessage.messageId], limit: 1
+            });
+
+            await readEntered;
+            for (let turn = 0; turn < 3; turn++) {
+                await new Promise(resolve => setImmediate(resolve));
+            }
+            expect(payloadReads, 'different ids in one segment must join before either read completes').toBe(1);
+            releasePayloadRead();
+
+            const results = await Promise.all([globalRepair, explicitRepair]);
+            expect(payloadReads).toBe(1);
+            expect(projectCalls).toBe(2);
+            expect(results.map(item => item.repaired)).toEqual([1, 1]);
+            expect(results.every(item => item.failed === 0)).toBe(true);
+        } finally {
+            releasePayloadRead();
+            fsPromises.readFile = originalReadFile;
+            MailboxService._projectMessageWalRecord = originalProject;
+        }
+    });
+
+    test('a marker-cohort change starts a new segment-load generation (#16767)', async () => {
+        GraphService.upsertNode({
+            id: '@charlie', type: 'AgentIdentity', name: 'Charlie', properties: {accountType: 'agent'}
+        });
+        for (const recipient of ['@bob', '@charlie']) {
+            await RequestContextService.run({agentIdentityNodeId: recipient}, async () => {
+                await PermissionService.grantPermission({to: '@alice', scope: 'CAN_REPLY_TO'});
+            });
+        }
+
+        const bobMessage = await RequestContextService.run({agentIdentityNodeId: '@alice'}, async () => {
+            return await MailboxService.addMessage({to: '@bob', subject: 'old marker cohort', body: 'first load'});
+        });
+        const charlieMessage = await RequestContextService.run({agentIdentityNodeId: '@alice'}, async () => {
+            return await MailboxService.addMessage({to: '@charlie', subject: 'new marker cohort', body: 'second load'});
+        });
+        expect(damageEdgeProjection(bobMessage.messageId, 'SENT_BY')).toBe(1);
+        expect(damageEdgeProjection(charlieMessage.messageId, 'SENT_BY')).toBe(1);
+
+        const markerPath = fs.readdirSync(messageWalDir)
+                .map(name => path.join(messageWalDir, name))
+                .find(filePath => filePath.endsWith('.graph.jsonl')),
+            markerText   = fs.readFileSync(markerPath, 'utf8'),
+            markerLines  = markerText.trim().split('\n'),
+            oldCohort    = markerLines.filter(line => JSON.parse(line).id !== charlieMessage.messageId);
+
+        expect(oldCohort.length).toBe(markerLines.length - 1);
+        fs.writeFileSync(markerPath, `${oldCohort.join('\n')}\n`, 'utf8');
+
+        const originalReadFile = fsPromises.readFile;
+        let   payloadReads     = 0,
+            releasePayloadRead,
+            announceReadEntered;
+        const payloadReadGate = new Promise(resolve => {
+            releasePayloadRead = resolve;
+        });
+        const readEntered = new Promise(resolve => {
+            announceReadEntered = resolve;
+        });
+
+        fsPromises.readFile = async (filePath, ...args) => {
+            if (/message-wal-\d{4}-\d{2}-\d{2}\.jsonl$/.test(String(filePath))) {
+                payloadReads++;
+                announceReadEntered();
+                await payloadReadGate;
+            }
+            return originalReadFile(filePath, ...args)
+        };
+
+        try {
+            const oldGeneration = MailboxService.repairMessageGraphIntegrity({
+                target: '@bob', box: 'inbox', limit: 1
+            });
+            await readEntered;
+
+            // The payload is unchanged. Only its durable marker cohort grows while generation one
+            // is parked in readFile; generation two must not join the old cohort-filtered result.
+            fs.writeFileSync(markerPath, markerText, 'utf8');
+            const newGeneration = MailboxService.repairMessageGraphIntegrity({
+                ids: [charlieMessage.messageId], limit: 1
+            });
+
+            for (let turn = 0; turn < 50 && payloadReads < 2; turn++) {
+                await new Promise(resolve => setImmediate(resolve));
+            }
+            expect(payloadReads, 'a marker-only cohort change needs an independent segment result').toBe(2);
+            releasePayloadRead();
+
+            const results = await Promise.all([oldGeneration, newGeneration]);
+            expect(results.map(item => item.repaired)).toEqual([1, 1]);
+            expect(results.every(item => item.failed === 0)).toBe(true);
+        } finally {
+            releasePayloadRead();
+            fsPromises.readFile = originalReadFile;
+            fs.writeFileSync(markerPath, markerText, 'utf8');
+        }
+    });
+
+    test('bounded repair advances past a persistent failed candidate instead of starving the next id (#16767)', async () => {
+        GraphService.upsertNode({
+            id: '@cursor-bob', type: 'AgentIdentity', name: 'Cursor Bob', properties: {accountType: 'agent'}
+        });
+        await RequestContextService.run({agentIdentityNodeId: '@cursor-bob'}, async () => {
+            await PermissionService.grantPermission({to: '@alice', scope: 'CAN_REPLY_TO'});
+        });
+
+        const ids = [];
+        await RequestContextService.run({agentIdentityNodeId: '@alice'}, async () => {
+            ids.push((await MailboxService.addMessage({to: '@cursor-bob', subject: 'first', body: 'fails'})).messageId);
+            ids.push((await MailboxService.addMessage({to: '@cursor-bob', subject: 'second', body: 'must advance'})).messageId);
+        });
+        ids.forEach(id => expect(damageEdgeProjection(id, 'SENT_BY')).toBe(1));
+
+        const originalProject = MailboxService._projectMessageWalRecord,
+            reads             = instrumentMessageWalPayloadReads();
+        MailboxService._projectMessageWalRecord = async function(record, options) {
+            if (record.id === ids[0]) throw new Error('deterministic first-candidate failure');
+            return await originalProject.call(this, record, options)
+        };
+
+        try {
+            const first = await MailboxService.repairMessageGraphIntegrity({
+                target: '@cursor-bob', box: 'inbox', limit: 1
+            });
+            expect(first).toMatchObject({
+                candidateCount: 2, matchedCandidateCount: 2, scanned: 1, repaired: 0, failed: 1,
+                cursorStart   : 0, cursorNext: 1
+            });
+
+            const second = await MailboxService.repairMessageGraphIntegrity({
+                target: '@cursor-bob', box: 'inbox', limit: 1
+            });
+            expect(second).toMatchObject({
+                candidateCount              : 2, matchedCandidateCount: 2, scanned: 1, repaired: 1, failed: 0,
+                deferredFailedCandidateCount: 1, cursorStart: 0, cursorNext: 0
+            });
+
+            const third = await MailboxService.repairMessageGraphIntegrity({
+                target: '@cursor-bob', box: 'inbox', limit: 1
+            });
+            expect(third).toMatchObject({
+                candidateCount              : 1, matchedCandidateCount: 1, scanned: 0, repaired: 0, failed: 0,
+                deferredFailedCandidateCount: 1
+            });
+
+            const explicitRetry = await MailboxService.repairMessageGraphIntegrity({ids: [ids[0]], limit: 1});
+            expect(explicitRetry).toMatchObject({scanned: 1, repaired: 0, failed: 1});
+            expect(reads.getCount(), 'cooldown + explicit retry must reuse the immutable accepted record').toBe(2);
+
+            expect(GraphService.db.storage.db.prepare(`
+                SELECT COUNT(*) AS count
+                  FROM Edges
+                 WHERE source = ?
+                   AND type = 'SENT_BY'
+            `).get(ids[0]).count).toBe(0);
+            expect(GraphService.db.storage.db.prepare(`
+                SELECT COUNT(*) AS count
+                  FROM Edges
+                 WHERE source = ?
+                   AND type = 'SENT_BY'
+            `).get(ids[1]).count).toBe(1);
+        } finally {
+            reads.restore();
+            MailboxService._projectMessageWalRecord = originalProject;
+        }
     });
 
     test('a healthy DB of a DM + an INTACT broadcast reports no gap — the fix does NOT false-positive on DMs (#15369)', async () => {
@@ -1695,7 +2430,7 @@ test.describe('Neo.ai.services.memory-core.MailboxService', () => {
         expect(await readPendingMessageWalRecords({dir: messageWalDir, ids: [msgId]})).toHaveLength(0);
     });
 
-    test('surgical repair does not duplicate the projection marker — the marker index stays 1:1 with accepted records (#14992)', async () => {
+    test('surgical repair does not append a second marker; only bounded metadata enrichment may do so (#14992, #16767)', async () => {
         await RequestContextService.run({ agentIdentityNodeId: '@bob' }, async () => {
             await PermissionService.grantPermission({ to: '@alice', scope: 'CAN_REPLY_TO' });
         });
@@ -1713,8 +2448,10 @@ test.describe('Neo.ai.services.memory-core.MailboxService', () => {
 
         expect(countMarkerLines()).toBe(1);
 
-        // post-marker damage: repair restores the edge; the pre-existing marker must NOT be
-        // re-appended (observed inflation: 499 markers over 70 accepted records on 2026-07-09)
+        // Post-marker graph damage repairs the edge without another receipt (observed historical
+        // inflation: 499 markers over 70 accepted records). One-time route/cohort compatibility
+        // enrichment is the bounded exception: it appends metadata only when the original marker
+        // predates those facts, never for ordinary surgical graph repair.
         GraphService.db.storage.db.prepare('DELETE FROM Edges WHERE source = ? AND target = ? AND type = ?')
             .run(msgId, '@bob', 'SENT_TO');
         clearGraphCacheWithoutStorageMutation();

--- a/test/playwright/unit/ai/services/memory-core/helpers/messageWalStore.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/helpers/messageWalStore.spec.mjs
@@ -9,6 +9,7 @@ import path           from 'path';
 import {
     appendMessageWalGraphProjectionMarker,
     appendWalMessage,
+    getMessageWalGraphProjectionStats,
     getMessageWalGraphMarkersFileName,
     getMessageWalRecordsFileName,
     getMessageWalSegmentKey,
@@ -48,6 +49,97 @@ test.describe('Neo.ai.services.memory-core.helpers.messageWalStore', () => {
         expect(getMessageWalSegmentKey(DAY)).toBe('2026-07-30');
         expect(getMessageWalRecordsFileName('2026-07-30')).toBe('message-wal-2026-07-30.jsonl');
         expect(getMessageWalGraphMarkersFileName('2026-07-30')).toBe('message-wal-2026-07-30.graph.jsonl');
+    });
+
+    test('projection markers preserve monotonic route/cohort evidence and surface conflicts (#16767)', async () => {
+        const segmentKey = getMessageWalSegmentKey(DAY);
+
+        await appendWalMessage(record('MESSAGE:known-zero'), {dir: tmpDir, planeId: PLANE_ID});
+        await appendWalMessage(record('MESSAGE:legacy'), {dir: tmpDir, planeId: PLANE_ID});
+        await appendWalMessage(record('MESSAGE:conflict'), {dir: tmpDir, planeId: PLANE_ID});
+
+        await appendMessageWalGraphProjectionMarker({id: 'MESSAGE:known-zero', segmentKey}, {dir: tmpDir});
+
+        let stats = await getMessageWalGraphProjectionStats({dir: tmpDir});
+        expect(stats.broadcastCohortById.has('MESSAGE:known-zero')).toBe(false);
+
+        // One later marker enriches the historical projection receipt without changing its
+        // unique projected-id count or accepted-WAL segment coordinate.
+        await appendMessageWalGraphProjectionMarker({
+            id             : 'MESSAGE:known-zero',
+            segmentKey,
+            mailboxRouting : {disposition: 'known', sentBy: '@alice', to: 'AGENT:*'},
+            broadcastCohort: {disposition: 'known', intendedRecipientCount: 0}
+        }, {dir: tmpDir});
+        await appendMessageWalGraphProjectionMarker({
+            id             : 'MESSAGE:legacy',
+            segmentKey,
+            mailboxRouting : {disposition: 'legacy-unknown'},
+            broadcastCohort: {disposition: 'legacy-unknown'}
+        }, {dir: tmpDir});
+        await appendMessageWalGraphProjectionMarker({
+            id             : 'MESSAGE:conflict',
+            segmentKey,
+            mailboxRouting : {disposition: 'known', sentBy: '@alice', to: 'AGENT:*'},
+            broadcastCohort: {disposition: 'known', intendedRecipientCount: 2}
+        }, {dir: tmpDir});
+        await appendMessageWalGraphProjectionMarker({
+            id             : 'MESSAGE:conflict',
+            segmentKey,
+            mailboxRouting : {disposition: 'legacy-unknown'},
+            broadcastCohort: {disposition: 'legacy-unknown'}
+        }, {dir: tmpDir});
+        await appendMessageWalGraphProjectionMarker({
+            id             : 'MESSAGE:conflict',
+            segmentKey,
+            mailboxRouting : {disposition: 'known', sentBy: '@mallory', to: 'AGENT:*'},
+            broadcastCohort: {disposition: 'known', intendedRecipientCount: 0}
+        }, {dir: tmpDir});
+
+        stats = await getMessageWalGraphProjectionStats({dir: tmpDir});
+
+        expect(stats.projectedCount).toBe(3);
+        expect(stats.segmentById.get('MESSAGE:known-zero')).toBe(segmentKey);
+        expect(stats.mailboxRoutingById.get('MESSAGE:known-zero')).toEqual({
+            disposition: 'known', sentBy: '@alice', to: 'AGENT:*'
+        });
+        expect(stats.broadcastCohortById.get('MESSAGE:known-zero')).toEqual({
+            disposition           : 'known',
+            intendedRecipientCount: 0
+        });
+        expect(stats.mailboxRoutingById.get('MESSAGE:legacy')).toEqual({disposition: 'legacy-unknown'});
+        expect(stats.broadcastCohortById.get('MESSAGE:legacy')).toEqual({disposition: 'legacy-unknown'});
+        expect(stats.mailboxRoutingById.get('MESSAGE:conflict')).toEqual({
+            disposition: 'known', sentBy: '@alice', to: 'AGENT:*'
+        });
+        expect(stats.broadcastCohortById.get('MESSAGE:conflict')).toEqual({
+            disposition           : 'known',
+            intendedRecipientCount: 2
+        });
+        expect([...stats.markerConflicts.mailboxRoutingIds]).toEqual(['MESSAGE:conflict']);
+        expect([...stats.markerConflicts.broadcastCohortIds]).toEqual(['MESSAGE:conflict']);
+    });
+
+    test('a surviving marker keeps a missing payload segment in the projected candidate population (#16767)', async () => {
+        const durable   = await appendWalMessage(record('MESSAGE:missing-payload'), {dir: tmpDir, planeId: PLANE_ID}),
+            payloadPath = path.join(tmpDir, getMessageWalRecordsFileName(durable.segmentKey));
+
+        await appendMessageWalGraphProjectionMarker({
+            id            : 'MESSAGE:missing-payload',
+            segmentKey    : durable.segmentKey,
+            mailboxRouting: {disposition: 'known', sentBy: '@alice', to: '@bob'}
+        }, {dir: tmpDir});
+
+        expect((await getMessageWalGraphProjectionStats({dir: tmpDir})).projectedCount).toBe(1);
+
+        await fs.rm(payloadPath);
+
+        const stats = await getMessageWalGraphProjectionStats({dir: tmpDir});
+        expect(stats.projectedCount).toBe(1);
+        expect(stats.projectedIds.has('MESSAGE:missing-payload')).toBe(true);
+        expect(stats.segmentById.get('MESSAGE:missing-payload')).toBe(durable.segmentKey);
+        expect(stats.payloadSignatureBySegment.get(durable.segmentKey)).toBe('unavailable:ENOENT');
+        expect(await readWalMessagesByIds({dir: tmpDir, ids: ['MESSAGE:missing-payload']})).toEqual([]);
     });
 
     test('server plane provenance overrides a caller spoof and survives every read path', async () => {


### PR DESCRIPTION
Resolves #16767

Mailbox list repair now consumes an exact, caller-relevant candidate index instead of reopening the accepted message WAL behind a global Boolean on every read. Compact projection markers preserve independent route and broadcast-cohort evidence, historical ambiguity converges to an explicit compatibility disposition, and genuine positive-cohort loss still self-heals without changing the public MCP schema or authorization boundary.

Related: #15369

Related: #16677

Evidence: L3 (the production service path on a writable clone of one canonical SQLite + message-WAL snapshot, with 20-call same-store before/after distributions and a fresh-process operation counter) → L3 required (production-shaped empty/populated latency and restart-durable convergence). No #16767 close-target residuals; the remaining 2.8–3.1s list floor remains unattributed under #16677.

## Deltas from ticket

- The gap predicate is now an exact SQLite classifier over compact projected IDs, with reasoned candidates for missing MESSAGE, SENT_BY, SENT_TO, and known-positive zero-delivery cohorts.
- Projection markers carry independent, monotonic mailbox-route and broadcast-cohort facts. Unknown evidence cannot erase known evidence; conflicting known facts remain observable.
- Candidate work is filtered by caller route before payload reads, bounded by progress cursors and retry cooldowns, and coalesced by segment + payload + projected-cohort generation.
- Unreadable payload state and immutable record/metadata/failure caches are bounded and pruned; equal-size replacement wakes retry while ordinary append growth preserves cooldown.
- Historical route/cohort enrichment is durable and non-blocking. A fresh process consumes the converged markers without reopening payload segments.
- Causal boundary: this removes the repeated list-specific repair tax. It does not explain the shared wait cohorts in the related server-wide incident; fast get_message counter-evidence rules out claiming a global event-loop monopoly.

## Test Evidence

- Mailbox service + message-WAL helper:
    npm run test-unit -- test/playwright/unit/ai/services/memory-core/MailboxService.spec.mjs test/playwright/unit/ai/services/memory-core/helpers/messageWalStore.spec.mjs
  Result: **159 passed**.
- Syntax: node --check on both implementation files and both specs → **4/4 passed**.
- Workflow gate: agent-preflight in restoration/no-fix mode over the four touched files → **all requested gates passed**.
- Red-first controls covered legitimate zero audience, historical unknown disposition, unrelated caller starvation, unreadable retry generations, persistent-failure progress, same-ID mutation singleflight, shared physical segment loads, and marker-only cohort growth. All are green at c6597402.
- Public MCP contract: openapi.yaml is unchanged; existing identity, get_message, mark_read, archive, retraction, broadcast, pagination, and count/list suites remain green inside the 159-test surface.

Same-store benchmark: one online SQLite backup and one message-WAL copy from the healthy canonical plane were cloned per scenario. Baseline is exact origin/dev@71ddfd498e; patched is c6597402. Each row measures MailboxService.listMessages() only (process boot and HTTP transport excluded); no timeout changed. Elapsed-time rows are directional: each baseline arm ran before its patched arm, so OS-cache and host-load effects were not counterbalanced. The causal receipt is the physical payload-segment count and restart-durable convergence, not the exact millisecond delta.

| scenario | variant | n | p50 | p95 | max | rows |
|---|---:|---:|---:|---:|---:|---:|
| empty-result control (threadId miss) | baseline | 20 | 4,669.583 ms | 5,930.747 ms | 6,246.618 ms | 0 |
| empty-result control (threadId miss) | patched | 20 | 2,848.726 ms | 3,507.327 ms | 4,815.061 ms | 0 |
| populated inbox (limit: 5) | baseline | 20 | 4,512.835 ms | 4,909.664 ms | 5,480.736 ms | 5 |
| populated inbox (limit: 5) | patched | 20 | 3,096.791 ms | 3,566.044 ms | 5,099.382 ms | 5 |

The production-shaped operation counter is the convergence receipt: baseline empty calls reopened all 10 payload segments on call 1 and call 2 (10 → 10). Patched historical classification converged 10 → 1; after those markers were durable, a fresh process performed 0 → 0 → 0 payload reads across three lists. The remaining 2.8–3.1 s steady list traversal is measured but deliberately unattributed here.

## Post-Merge Validation

- [ ] Confirm the deployed Memory Core revision includes c6597402 before comparing live latency.
- [ ] Capture a post-deploy 20-call distribution as an operational observation; keep any remaining shared-wait attribution with the related server-wide incident.

## Evolution

Hostile falsifiers changed the implementation in three material ways: one route/cohort field became two monotonic evidence axes; per-ID I/O coalescing became physical segment-generation coalescing; and payload generation now distinguishes strict append growth from equal-size replacement. Vega's concurrent get_message negative also narrowed the final causal claim from scheduler-wide blocking to the exact list repair path.

Authored by Emmy (GPT-5.6 Sol Ultra, Codex). Session b93c021e-d387-4c4f-8ae5-4d7d2d007303.