### PR TITLE
feat(ai): attribute provider activity to operation stages (#16770)

### DIFF
--- a/ai/daemons/embed/drainCycle.mjs
+++ b/ai/daemons/embed/drainCycle.mjs
@@ -4,9 +4,10 @@ import {
     pruneReconciledWalSegments,
     readPendingWalRecords
 } from '../../services/memory-core/helpers/memoryWalStore.mjs';
-import {classifyRowVector, VECTOR_REJECTION_REASONS} from '../../services/memory-core/helpers/vectorWriteInvariant.mjs';
-import {createDrainDispositionTracker}               from '../shared/drainDisposition.mjs';
+import {classifyRowVector, VECTOR_REJECTION_REASONS}                   from '../../services/memory-core/helpers/vectorWriteInvariant.mjs';
+import {createDrainDispositionTracker}                                 from '../shared/drainDisposition.mjs';
 import {OPENAI_COMPATIBLE_REQUEST_TIMEOUT_CODE, PROVIDER_TIMEOUT_CODE} from '../../provider/createTimeoutError.mjs';
+import {runWithProviderActivityContext}                                from '../../services/shared/providerActivityLedger.mjs';
 
 /**
  * @summary One durable drain pass over the `add_memory` write-ahead log.
@@ -66,6 +67,19 @@ export const MAX_RECORD_COOLDOWN_MS = 3600000;
  * @type {Number}
  */
 export const DEFAULT_MAX_IN_CYCLE_MS = 120000;
+
+/**
+ * @summary Runs one WAL-owned collection write with exact provider-stage attribution.
+ * @param {Object} collection Memory collection.
+ * @param {Object} payload Chroma add payload.
+ * @returns {Promise<*>}
+ */
+function addWalRecords(collection, payload) {
+    return runWithProviderActivityContext({
+        operationStage: 'mc-wal-drain-embedding',
+        service       : 'memory-core'
+    }, () => collection.add(payload));
+}
 
 /**
  * @summary Computes the exponential backoff delay for a retry attempt.
@@ -183,7 +197,7 @@ export async function embedBatch({
 
     for (let attempt = 0; attempt <= maxRetries; attempt++) {
         try {
-            await collection.add(payload);
+            await addWalRecords(collection, payload);
             return {succeeded: [...records], failed: []};
         } catch (error) {
             if (isContentionError(error)) {
@@ -240,7 +254,7 @@ export async function embedBatch({
         }
 
         try {
-            await collection.add({ids: [record.id], metadatas: [record.metadata], documents: [record.document]});
+            await addWalRecords(collection, {ids: [record.id], metadatas: [record.metadata], documents: [record.document]});
             succeeded.push(record);
         } catch (error) {
             failed.push({record, error});

--- a/ai/mcp/server/memory-core/openapi.yaml
+++ b/ai/mcp/server/memory-core/openapi.yaml
@@ -219,8 +219,11 @@ paths:
         arguments, results, or caller identity. Completed calls provide latency/failure aggregates;
         calls that have crossed the start boundary but not the completion boundary are returned
         separately with redacted operation identity and elapsed time; recent completed calls above
-        a caller-selected duration retain their exact redacted timeline after recovery. Use this to
-        diagnose slow, failing, or process-wedging tools in long-running local and shared deployments.
+        a caller-selected duration retain their exact redacted timeline after recovery. The
+        providerActivity field separately attributes bounded chat/embedding stages and distinguishes
+        measured Neo queue wait from provider execution without retaining prompts, labels, or caller
+        identity. Use this to diagnose slow, failing, or process-wedging work in long-running local
+        and shared deployments.
       tags: [Diagnostics]
       requestBody:
         required: false
@@ -2557,6 +2560,7 @@ components:
         - tools
         - unfinishedCalls
         - recentSlowCalls
+        - providerActivity
       properties:
         status:
           type: string
@@ -2696,6 +2700,145 @@ components:
                 type: string
                 nullable: true
                 description: Redacted recorder stage when the call failed, or null on success.
+        providerActivity:
+          $ref: '#/components/schemas/ProviderActivityResponse'
+
+    ProviderActivityResponse:
+      type: object
+      required:
+        - status
+        - totalActivities
+        - totalInFlight
+        - aggregates
+        - inFlight
+        - recentCompletions
+      properties:
+        status:
+          type: string
+          enum: [ok, partial, disabled, unavailable]
+          description: Availability of the bounded provider-stage projection.
+        totalActivities:
+          type: integer
+          minimum: 0
+          description: Activities admitted inside the effective lookback window.
+        totalInFlight:
+          type: integer
+          minimum: 0
+          description: Activities without a completion boundary inside the effective lookback window.
+        aggregates:
+          type: array
+          description: Low-cardinality stage/service/provider/model aggregates.
+          items:
+            $ref: '#/components/schemas/ProviderActivityAggregate'
+        inFlight:
+          type: array
+          description: Oldest-first incomplete activities. Payloads, raw labels, and caller identity are absent.
+          items:
+            $ref: '#/components/schemas/ProviderActivityInFlight'
+        recentCompletions:
+          type: array
+          description: Newest-first completed provider activities inside the effective lookback window.
+          items:
+            $ref: '#/components/schemas/ProviderActivityCompletion'
+
+    ProviderActivityAggregate:
+      type: object
+      required:
+        - service
+        - operationStage
+        - role
+        - provider
+        - model
+        - priority
+        - queueDisposition
+        - calls
+        - failures
+        - inFlight
+        - avgQueueWaitMs
+        - maxQueueWaitMs
+        - avgExecutionMs
+        - maxExecutionMs
+        - lastSeenAt
+      properties:
+        service:          {type: string, enum: [knowledge-base, memory-core, dream-pipeline, orchestrator, unknown]}
+        operationStage:   {type: string, enum: [kb-query-embedding, kb-ask-synthesis, kb-tenant-ingestion-embedding, mc-wal-drain-embedding, mc-mini-summary, mc-session-summary, rem-tri-vector, rem-topology, embedding-canary, unknown]}
+        role:             {type: string, enum: [chat, embedding, unknown]}
+        provider:         {type: string, enum: [gemini, ollama, openAiCompatible, unknown]}
+        model:            {type: string, maxLength: 160}
+        priority:         {type: string, enum: [interactive, batch, unknown]}
+        queueDisposition: {type: string, enum: [neo-queued, not-applicable, unknown]}
+        calls:            {type: integer, minimum: 0}
+        failures:         {type: integer, minimum: 0}
+        inFlight:         {type: integer, minimum: 0}
+        avgQueueWaitMs:   {type: number, nullable: true, minimum: 0}
+        maxQueueWaitMs:   {type: integer, nullable: true, minimum: 0}
+        avgExecutionMs:   {type: number, nullable: true, minimum: 0}
+        maxExecutionMs:   {type: integer, nullable: true, minimum: 0}
+        lastSeenAt:       {type: string, format: date-time, nullable: true}
+
+    ProviderActivityInFlight:
+      type: object
+      required:
+        - activityId
+        - service
+        - operationStage
+        - role
+        - provider
+        - model
+        - priority
+        - enqueuedAt
+        - startedAt
+        - queueDisposition
+        - queueWaitMs
+        - elapsedMs
+      properties:
+        activityId:       {type: string}
+        service:          {type: string, enum: [knowledge-base, memory-core, dream-pipeline, orchestrator, unknown]}
+        operationStage:   {type: string, enum: [kb-query-embedding, kb-ask-synthesis, kb-tenant-ingestion-embedding, mc-wal-drain-embedding, mc-mini-summary, mc-session-summary, rem-tri-vector, rem-topology, embedding-canary, unknown]}
+        role:             {type: string, enum: [chat, embedding, unknown]}
+        provider:         {type: string, enum: [gemini, ollama, openAiCompatible, unknown]}
+        model:            {type: string, maxLength: 160}
+        priority:         {type: string, enum: [interactive, batch, unknown]}
+        enqueuedAt:       {type: string, format: date-time}
+        startedAt:        {type: string, format: date-time, nullable: true}
+        queueDisposition: {type: string, enum: [neo-queued, not-applicable, unknown]}
+        queueWaitMs:      {type: integer, nullable: true, minimum: 0}
+        elapsedMs:        {type: integer, minimum: 0}
+
+    ProviderActivityCompletion:
+      type: object
+      required:
+        - activityId
+        - service
+        - operationStage
+        - role
+        - provider
+        - model
+        - priority
+        - enqueuedAt
+        - startedAt
+        - completedAt
+        - queueDisposition
+        - queueWaitMs
+        - executionMs
+        - success
+        - failureStage
+      properties:
+        activityId:       {type: string}
+        service:          {type: string, enum: [knowledge-base, memory-core, dream-pipeline, orchestrator, unknown]}
+        operationStage:   {type: string, enum: [kb-query-embedding, kb-ask-synthesis, kb-tenant-ingestion-embedding, mc-wal-drain-embedding, mc-mini-summary, mc-session-summary, rem-tri-vector, rem-topology, embedding-canary, unknown]}
+        role:             {type: string, enum: [chat, embedding, unknown]}
+        provider:         {type: string, enum: [gemini, ollama, openAiCompatible, unknown]}
+        model:            {type: string, maxLength: 160}
+        priority:         {type: string, enum: [interactive, batch, unknown]}
+        enqueuedAt:       {type: string, format: date-time}
+        startedAt:        {type: string, format: date-time, nullable: true}
+        completedAt:      {type: string, format: date-time}
+        queueDisposition: {type: string, enum: [neo-queued, not-applicable, unknown]}
+        queueWaitMs:      {type: integer, nullable: true, minimum: 0}
+        executionMs:      {type: integer, nullable: true, minimum: 0}
+        success:          {type: boolean}
+        failureStage:     {type: string, enum: [provider, queue, unknown], nullable: true}
 
     RemPipelineStateResponse:
       type: object

--- a/ai/provider/InteractiveBatchQueue.mjs
+++ b/ai/provider/InteractiveBatchQueue.mjs
@@ -25,7 +25,7 @@
  */
 export default class InteractiveBatchQueue {
     /**
-     * Pending tasks, each `{task, priority, resolve, reject}`.
+     * Pending tasks, each carrying the task/promise controls plus bounded lifecycle timing state.
      * @member {Object[]} #queue=[]
      * @private
      */
@@ -36,16 +36,40 @@ export default class InteractiveBatchQueue {
      * @private
      */
     #active = false;
+    /**
+     * Injectable monotonic-enough wall clock for deterministic lifecycle receipts.
+     * @member {Function} #now=Date.now
+     * @private
+     */
+    #now = Date.now;
+
+    /**
+     * @summary Creates an isolated queue with an optional deterministic clock seam.
+     * @param {Object} [options]
+     * @param {Function} [options.now=Date.now] Timestamp provider.
+     */
+    constructor({now = Date.now} = {}) {
+        if (typeof now !== 'function') {
+            throw new TypeError('InteractiveBatchQueue: options.now must be a function');
+        }
+
+        this.#now = now;
+    }
 
     /**
      * @summary Enqueue an async task under a priority lane; resolves / rejects with the task's result.
      * @param {Function} task An async thunk `() => Promise<*>`, executed when the lane is free.
      * @param {'interactive'|'batch'} [priority='interactive'] Lane priority; interactive is preferred.
+     * @param {Object} [lifecycle] Optional synchronous `onEnqueued/onStarted/onSettled` observer.
      * @returns {Promise<*>}
      */
-    enqueue(task, priority = 'interactive') {
+    enqueue(task, priority = 'interactive', lifecycle = null) {
+        const enqueuedAt = this.#now();
+
+        this.#notify(lifecycle, 'onEnqueued', {enqueuedAt, priority});
+
         return new Promise((resolve, reject) => {
-            this.#queue.push({task, priority, resolve, reject});
+            this.#queue.push({task, priority, resolve, reject, lifecycle, enqueuedAt});
             this.#drain()
         })
     }
@@ -68,9 +92,40 @@ export default class InteractiveBatchQueue {
                 const index = this.#nextIndex(),
                       item  = this.#queue.splice(index, 1)[0];
 
+                const startedAt = this.#now();
+
+                this.#notify(item.lifecycle, 'onStarted', {
+                    enqueuedAt : item.enqueuedAt,
+                    priority   : item.priority,
+                    queueWaitMs: Math.max(0, startedAt - item.enqueuedAt),
+                    startedAt
+                });
+
                 try {
-                    item.resolve(await item.task())
+                    const result      = await item.task(),
+                          completedAt = this.#now();
+
+                    this.#notify(item.lifecycle, 'onSettled', {
+                        completedAt,
+                        enqueuedAt : item.enqueuedAt,
+                        executionMs: Math.max(0, completedAt - startedAt),
+                        priority   : item.priority,
+                        startedAt,
+                        success    : true
+                    });
+                    item.resolve(result)
                 } catch (error) {
+                    const completedAt = this.#now();
+
+                    this.#notify(item.lifecycle, 'onSettled', {
+                        completedAt,
+                        enqueuedAt : item.enqueuedAt,
+                        error,
+                        executionMs: Math.max(0, completedAt - startedAt),
+                        priority   : item.priority,
+                        startedAt,
+                        success    : false
+                    });
                     item.reject(error)
                 }
             }
@@ -95,5 +150,21 @@ export default class InteractiveBatchQueue {
         }
 
         return best
+    }
+
+    /**
+     * @summary Invokes one lifecycle callback without letting telemetry affect queue behavior.
+     * @param {Object|null} lifecycle Optional lifecycle observer.
+     * @param {String} method Observer method name.
+     * @param {Object} event Bounded timing event.
+     * @returns {void}
+     * @private
+     */
+    #notify(lifecycle, method, event) {
+        try {
+            lifecycle?.[method]?.(event);
+        } catch {
+            // Observability is best-effort and cannot alter admission or task results.
+        }
     }
 }

--- a/ai/provider/buildChatModel.mjs
+++ b/ai/provider/buildChatModel.mjs
@@ -1,4 +1,8 @@
 import InteractiveBatchQueue from './InteractiveBatchQueue.mjs';
+import {
+    createProviderActivityLifecycle,
+    observeUnqueuedProviderActivity
+}                            from '../services/shared/providerActivityLedger.mjs';
 
 let GoogleGenerativeAIClass,
     OllamaProviderClass,
@@ -89,6 +93,8 @@ function toGeminiEnvelope(result) {
  * @param {Function} [options.openAiCompatibleProviderFactory] Test seam — if omitted, lazily imports `./OpenAiCompatible.mjs` and calls `Neo.create(...)`.
  * @param {Function} [options.geminiClientFactory] Test seam — if omitted, lazily imports `@google/generative-ai` on first `generateContent()`.
  * @param {InteractiveBatchQueue} [options.chatRequestQueue] Test seam — the serializing queue the local providers route through; defaults to the process-wide {@link sharedLocalChatRequestQueue}.
+ * @param {Object} [options.providerActivityRecorder] Best-effort bounded provider telemetry sink.
+ * @param {String} [options.providerActivityService='unknown'] Stable service owner for emitted activity.
  * @returns {Object|null} Gemini-shaped `{generateContent}` model, OR `null` for gemini without an API key.
  * @throws {Error} When `modelProvider` is not in the supported set.
  */
@@ -101,7 +107,9 @@ export function buildChatModel({
     ollamaProviderFactory,
     openAiCompatibleProviderFactory,
     geminiClientFactory,
-    chatRequestQueue = sharedLocalChatRequestQueue
+    chatRequestQueue = sharedLocalChatRequestQueue,
+    providerActivityRecorder,
+    providerActivityService = 'unknown'
 } = {}) {
     if (modelProvider === 'openAiCompatible') {
         const cfg = openAiCompatibleConfig || {};
@@ -129,23 +137,40 @@ export function buildChatModel({
 
         return {
             generateContent: (promptText, generationOptions = {}) => {
-                const {priority = 'interactive', ...providerOptions} = generationOptions;
+                const {
+                    operationStage = 'unknown',
+                    priority       = 'interactive',
+                    ...providerOptions
+                } = generationOptions;
+                const lifecycle = createProviderActivityLifecycle({
+                    recorder: providerActivityRecorder,
+                    activity: {
+                        model   : 'unknown',
+                        operationStage,
+                        priority,
+                        provider: 'openAiCompatible',
+                        role    : 'chat',
+                        service : providerActivityService
+                    }
+                });
 
                 // Serialize through the shared local-endpoint queue so a heavy `batch` summary cannot
                 // block an `interactive` request. `priority` is a queue-control param — stripped here
                 // so it never leaks into the provider request.
                 return chatRequestQueue.enqueue(async () => {
-                    const provider = await getProvider();
+                    const provider      = await getProvider(),
+                          dispatchModel = cfg.model;
 
                     provider.apiKey    = cfg.apiKey;
                     provider.host      = cfg.host;
-                    provider.modelName = cfg.model;
+                    provider.modelName = dispatchModel;
                     if (cfg.keep_alive !== undefined) {
                         provider.keepAlive = cfg.keep_alive;
                     }
 
+                    lifecycle.onDispatch({model: dispatchModel});
                     return toGeminiEnvelope(await provider.generate(promptText, providerOptions));
-                }, priority);
+                }, priority, lifecycle);
             }
         };
     }
@@ -176,20 +201,37 @@ export function buildChatModel({
 
         return {
             generateContent: (promptText, generationOptions = {}) => {
-                const {priority = 'interactive', ...providerOptions} = generationOptions;
+                const {
+                    operationStage = 'unknown',
+                    priority       = 'interactive',
+                    ...providerOptions
+                } = generationOptions;
+                const lifecycle = createProviderActivityLifecycle({
+                    recorder: providerActivityRecorder,
+                    activity: {
+                        model   : 'unknown',
+                        operationStage,
+                        priority,
+                        provider: 'ollama',
+                        role    : 'chat',
+                        service : providerActivityService
+                    }
+                });
 
                 // Serialize through the shared local-endpoint queue (see the openAiCompatible branch).
                 return chatRequestQueue.enqueue(async () => {
-                    const provider = await getProvider();
+                    const provider      = await getProvider(),
+                          dispatchModel = cfg.model;
 
                     provider.host      = cfg.host;
-                    provider.modelName = cfg.model;
+                    provider.modelName = dispatchModel;
                     if (cfg.keep_alive !== undefined) {
                         provider.keepAlive = cfg.keep_alive;
                     }
 
+                    lifecycle.onDispatch({model: dispatchModel});
                     return toGeminiEnvelope(await provider.generate(promptText, providerOptions));
-                }, priority);
+                }, priority, lifecycle);
             }
         };
     }
@@ -197,12 +239,18 @@ export function buildChatModel({
     if (modelProvider === 'gemini') {
         if (!geminiApiKey) return null;
 
-        if (geminiClientFactory) {
-            return geminiClientFactory(geminiApiKey, geminiModelName);
+        const customModel = geminiClientFactory
+            ? geminiClientFactory(geminiApiKey, geminiModelName)
+            : null;
+
+        if (customModel && !providerActivityRecorder) {
+            return customModel;
         }
 
         let modelPromise;
         const getModel = () => {
+            if (customModel) return Promise.resolve(customModel);
+
             modelPromise ||= Promise.resolve((async () => {
                 const GoogleGenerativeAI = await getGoogleGenerativeAIClass();
                 return new GoogleGenerativeAI(geminiApiKey).getGenerativeModel({model: geminiModelName});
@@ -216,9 +264,26 @@ export function buildChatModel({
                 // Remote gemini is high-concurrency → never queued. Strip the queue-control `priority`
                 // so it never reaches the SDK; the remaining options forward unchanged (when no
                 // priority is passed, `rest` equals the original options — preserving prior behavior).
-                const {priority, ...rest} = generationOptions;
+                const {
+                    operationStage = 'unknown',
+                    priority       = 'interactive',
+                    ...providerOptions
+                } = generationOptions;
+
                 const model = await getModel();
-                return model.generateContent(promptText, rest);
+
+                return observeUnqueuedProviderActivity({
+                    recorder: providerActivityRecorder,
+                    activity: {
+                        model   : model.model || 'unknown',
+                        operationStage,
+                        priority,
+                        provider: 'gemini',
+                        role    : 'chat',
+                        service : providerActivityService
+                    },
+                    task: () => model.generateContent(promptText, providerOptions)
+                });
             }
         };
     }

--- a/ai/services/graph/SemanticGraphExtractor.mjs
+++ b/ai/services/graph/SemanticGraphExtractor.mjs
@@ -21,6 +21,7 @@ import {
 } from './conceptSpineCanonicalization.mjs';
 import {buildGraphProvider, resolveGraphModelProvider} from './providerDispatch.mjs';
 import {chunkSession}                                  from './sessionChunker.mjs';
+import MemoryCoreRecorderService                       from '../memory-core/MemoryCoreRecorderService.mjs';
 
 /**
  * @class Neo.ai.daemons.services.SemanticGraphExtractor
@@ -180,7 +181,9 @@ class SemanticGraphExtractor extends Base {
                 host      : AiConfig.openAiCompatible.host,
                 keep_alive: AiConfig.openAiCompatible.keep_alive,
                 model     : AiConfig.openAiCompatible.model
-            }
+            },
+            providerActivityRecorder: MemoryCoreRecorderService,
+            providerActivityService : 'dream-pipeline'
         });
     }
 
@@ -594,7 +597,8 @@ class SemanticGraphExtractor extends Base {
                 responseSchema     : triVectorSchema,
                 responseSchemaName : 'triVector',
                 maxCompletionTokens: graphOutputLimitTokens,
-                operationLabel     : `REM Tri-Vector ${session.meta.sessionId} ${assetRef} attempt ${attempt}/${maxRetries}`
+                operationLabel     : `REM Tri-Vector ${session.meta.sessionId} ${assetRef} attempt ${attempt}/${maxRetries}`,
+                operationStage     : 'rem-tri-vector'
             };
 
             logger.info(

--- a/ai/services/graph/TopologyInferenceEngine.mjs
+++ b/ai/services/graph/TopologyInferenceEngine.mjs
@@ -11,6 +11,7 @@ import {
 }                                                       from '../memory-core/helpers/consumerFrictionHelper.mjs';
 import {buildGraphProvider, resolveGraphModelProvider} from './providerDispatch.mjs';
 import {chunkSession}                                  from './sessionChunker.mjs';
+import MemoryCoreRecorderService                       from '../memory-core/MemoryCoreRecorderService.mjs';
 
 const
     conflictEntryRegex          = /^- \*\*\[(SUPERSEDES|OBSOLETES|DUPLICATE)\]\*\* `([^`]+)`: (.*?) \(Source Session: ([^)]+)\)$/gm,
@@ -125,7 +126,9 @@ class TopologyInferenceEngine extends Base {
                 host      : AiConfig.openAiCompatible.host,
                 keep_alive: AiConfig.openAiCompatible.keep_alive,
                 model     : AiConfig.openAiCompatible.model
-            }
+            },
+            providerActivityRecorder: MemoryCoreRecorderService,
+            providerActivityService : 'dream-pipeline'
         });
     }
 
@@ -360,7 +363,8 @@ ${contextText}
                 const guardrailed = await invokeWithGuardrail({
                     invocationFn             : () => provider.generate(prompt, {
                         ...providerOptions,
-                        operationLabel: `REM topology ${sessionId} chunk ${chunkLabel}`
+                        operationLabel: `REM topology ${sessionId} chunk ${chunkLabel}`,
+                        operationStage: 'rem-topology'
                     }),
                     inputPayload             : prompt,
                     model                    : consumerModel,

--- a/ai/services/graph/providerDispatch.mjs
+++ b/ai/services/graph/providerDispatch.mjs
@@ -1,5 +1,6 @@
-import Ollama           from '../../provider/Ollama.mjs';
-import OpenAiCompatible from '../../provider/OpenAiCompatible.mjs';
+import Ollama                            from '../../provider/Ollama.mjs';
+import OpenAiCompatible                  from '../../provider/OpenAiCompatible.mjs';
+import {observeUnqueuedProviderActivity} from '../shared/providerActivityLedger.mjs';
 
 export const GRAPH_MODEL_PROVIDERS = Object.freeze(['ollama', 'openAiCompatible']);
 
@@ -59,6 +60,8 @@ export function isGraphModelProviderSupported(provider) {
  * @param {Object} [options.openAiCompatibleConfig] `{host, model, apiKey, keep_alive, ...}` config block.
  * @param {Function} [options.ollamaProviderFactory] Test seam — defaults to `Neo.create(Ollama, cfg)`.
  * @param {Function} [options.openAiCompatibleProviderFactory] Test seam — defaults to `Neo.create(OpenAiCompatible, cfg)`.
+ * @param {Object} [options.providerActivityRecorder] Best-effort bounded provider telemetry sink.
+ * @param {String} [options.providerActivityService='unknown'] Stable service owner.
  * @returns {{generate: Function}} Provider instance with `generate(prompt, options)` method.
  *     Both native Ollama and OpenAI-compatible providers expose this shape.
  * @throws {Error} For unsupported `modelProvider` values.
@@ -68,8 +71,12 @@ export function buildGraphProvider({
     ollamaConfig,
     openAiCompatibleConfig,
     ollamaProviderFactory          = (cfg) => Neo.create(Ollama, cfg),
-    openAiCompatibleProviderFactory = (cfg) => Neo.create(OpenAiCompatible, cfg)
+    openAiCompatibleProviderFactory = (cfg) => Neo.create(OpenAiCompatible, cfg),
+    providerActivityRecorder,
+    providerActivityService = 'unknown'
 }) {
+    let provider, model;
+
     switch (modelProvider) {
         case 'ollama': {
             const ollamaProviderConfig = {
@@ -80,7 +87,9 @@ export function buildGraphProvider({
             if (ollamaConfig?.keep_alive !== undefined) {
                 ollamaProviderConfig.keepAlive = ollamaConfig.keep_alive;
             }
-            return ollamaProviderFactory(ollamaProviderConfig);
+            provider = ollamaProviderFactory(ollamaProviderConfig);
+            model    = ollamaConfig?.model;
+            break;
         }
 
         case 'openAiCompatible': {
@@ -92,7 +101,9 @@ export function buildGraphProvider({
             if (openAiCompatibleConfig?.keep_alive !== undefined) {
                 openAiCompatibleProviderConfig.keepAlive = openAiCompatibleConfig.keep_alive;
             }
-            return openAiCompatibleProviderFactory(openAiCompatibleProviderConfig);
+            provider = openAiCompatibleProviderFactory(openAiCompatibleProviderConfig);
+            model    = openAiCompatibleConfig?.model;
+            break;
         }
 
         default:
@@ -101,4 +112,29 @@ export function buildGraphProvider({
                 `Expected one of: 'ollama', 'openAiCompatible'.`
             );
     }
+
+    if (!providerActivityRecorder) return provider;
+
+    return {
+        generate(prompt, options = {}) {
+            const {
+                operationStage = 'unknown',
+                priority       = 'batch',
+                ...providerOptions
+            } = options;
+
+            return observeUnqueuedProviderActivity({
+                recorder: providerActivityRecorder,
+                activity: {
+                    model,
+                    operationStage,
+                    priority,
+                    provider: modelProvider,
+                    role    : 'chat',
+                    service : providerActivityService
+                },
+                task: () => provider.generate(prompt, providerOptions)
+            });
+        }
+    };
 }

--- a/ai/services/knowledge-base/HealthService.mjs
+++ b/ai/services/knowledge-base/HealthService.mjs
@@ -9,6 +9,7 @@ import {buildEmbeddingProbeBlock} from '../shared/embeddingProbe.mjs';
 import {readDeployedRevision}     from '../shared/deployedRevision.mjs';
 import logger                     from '../../mcp/server/knowledge-base/logger.mjs';
 import RuntimeFreshnessService    from '../../mcp/server/shared/services/RuntimeFreshnessService.mjs';
+import KBRecorderService          from './KBRecorderService.mjs';
 
 const
     embeddingProbePolicy = Object.freeze({
@@ -69,9 +70,16 @@ export async function buildKnowledgeBaseEmbeddingProbeBlock({
         return TextEmbeddingService.embedText(text, explicitProvider, options);
     });
 
+    const attributedProbe = (text, explicitProvider, options) => probe(text, explicitProvider, {
+        ...options,
+        operationStage          : 'embedding-canary',
+        providerActivityRecorder: KBRecorderService,
+        service                 : 'knowledge-base'
+    });
+
     return buildEmbeddingProbeBlock({
         cfg,
-        embedText     : probe,
+        embedText     : attributedProbe,
         input,
         now,
         operationLabel: 'Knowledge Base embedding probe',

--- a/ai/services/knowledge-base/KBRecorderService.mjs
+++ b/ai/services/knowledge-base/KBRecorderService.mjs
@@ -5,6 +5,15 @@ import Base           from '../../../src/core/Base.mjs';
 import ConceptService from '../ConceptService.mjs';
 import config         from '../../mcp/server/knowledge-base/config.mjs';
 import logger         from '../../mcp/server/knowledge-base/logger.mjs';
+import {
+    beginProviderActivity,
+    completeProviderActivity,
+    ensureProviderActivitySchema,
+    PROVIDER_ACTIVITY_BUSY_TIMEOUT_MS,
+    refineProviderActivity,
+    startProviderActivity
+}                     from '../shared/providerActivityLedger.mjs';
+import {createProviderActivityStatusWriter} from '../shared/providerActivityStatusStore.mjs';
 
 /**
  * @summary Captures Knowledge Base query telemetry and materializes Agent FAQ demand clusters.
@@ -38,7 +47,13 @@ class KBRecorderService extends Base {
          * @summary SQLite connection to the shared Memory Core database.
          * @protected
          */
-        db: null
+        db: null,
+        /**
+         * @member {Object|null} providerActivityStatusWriter=null
+         * @summary Recorder-owned atomic failure-status sidecar writer.
+         * @protected
+         */
+        providerActivityStatusWriter: null
     }
 
     /**
@@ -62,11 +77,19 @@ class KBRecorderService extends Base {
                 return;
             }
 
+            this.providerActivityStatusWriter = createProviderActivityStatusWriter({
+                dbPath,
+                recorder: 'knowledge-base'
+            });
+
             await fs.ensureDir(path.dirname(dbPath));
 
             const Database = (await import('better-sqlite3')).default;
 
-            this.db = new Database(dbPath, {verbose: null});
+            this.db = new Database(dbPath, {
+                timeout: PROVIDER_ACTIVITY_BUSY_TIMEOUT_MS,
+                verbose: null
+            });
             this.db.pragma('journal_mode = WAL');
             this.db.exec(`
                 CREATE TABLE IF NOT EXISTS kb_query_log (
@@ -125,8 +148,12 @@ class KBRecorderService extends Base {
                 CREATE INDEX IF NOT EXISTS idx_kb_ingestion_metrics_event     ON kb_ingestion_metrics(event_type);
             `);
 
+            ensureProviderActivitySchema(this.db);
+            await this.providerActivityStatusWriter.publishSuccess(Date.now());
+
             logger.info('[KBRecorderService] Connected to Memory Core kb_query_log / kb_query_faqs.');
         } catch (err) {
+            await this.providerActivityStatusWriter?.publishFailure(Date.now());
             logger.warn('[KBRecorderService] Failed to initialize SQLite connection:', err.message);
         }
     }
@@ -251,8 +278,8 @@ class KBRecorderService extends Base {
     /**
      * @summary Persists a per-tenant ingestion telemetry event into `kb_ingestion_metrics`.
      *
-     * Phase 4A (#11665) write-API. This is the durable contract the Phase 2 cross-tenant
-     * ingestion service (#11626) calls after each push / tombstone / reconcile / error event.
+     * This is the durable per-tenant contract the cross-tenant ingestion service calls after
+     * each push / tombstone / reconcile / error event.
      * Like {@link log}, persistence is a best-effort observability side channel — it never
      * throws back into the ingestion path, preserving ingestion availability even when the
      * telemetry store is unavailable or temporarily locked.
@@ -263,7 +290,7 @@ class KBRecorderService extends Base {
      * this write path O(1) and contention-free.
      *
      * @param {Object}  entry
-     * @param {String}  entry.tenantId        Authoritative tenant id (server-stamped, per #11631).
+     * @param {String}  entry.tenantId        Authoritative server-stamped tenant id.
      * @param {String}  entry.repoSlug        Authoritative repo slug.
      * @param {String} [entry.originAgentIdentity] Authenticated agent identity that triggered the event.
      * @param {String}  entry.eventType       One of `'ingest'`, `'tombstone'`, `'reconcile'`, `'error'`.
@@ -315,10 +342,102 @@ class KBRecorderService extends Base {
     }
 
     /**
+     * @summary Persists one bounded provider admission boundary in the shared telemetry artifact.
+     * @param {Object} entry Provider activity descriptor.
+     * @returns {String|null}
+     */
+    beginProviderActivity(entry = {}) {
+        if (!this.db) {
+            this.providerActivityStatusWriter?.publishFailure(Date.now());
+            return null;
+        }
+
+        try {
+            return beginProviderActivity(this.db, entry);
+        } catch (error) {
+            this.providerActivityStatusWriter?.publishFailure(Date.now());
+            logger.warn('[KBRecorderService] Failed to persist provider admission telemetry:', error.message);
+            return null;
+        }
+    }
+
+    /**
+     * @summary Persists the execution-start boundary for one provider activity.
+     * @param {String} activityId Opaque activity id.
+     * @param {Number} startedAt Provider-start timestamp.
+     * @returns {void}
+     */
+    startProviderActivity(activityId, startedAt) {
+        if (!activityId) return;
+        if (!this.db) {
+            this.providerActivityStatusWriter?.publishFailure(Date.now());
+            return;
+        }
+
+        try {
+            startProviderActivity(this.db, activityId, startedAt);
+        } catch (error) {
+            this.providerActivityStatusWriter?.publishFailure(Date.now());
+            logger.warn('[KBRecorderService] Failed to persist provider-start telemetry:', error.message);
+        }
+    }
+
+    /**
+     * @summary Persists the model selected by provider-owned dispatch code.
+     * @param {String} activityId Opaque activity id.
+     * @param {Object} activity Dispatch-bound activity refinement.
+     * @returns {void}
+     */
+    refineProviderActivity(activityId, activity) {
+        if (!activityId) return;
+        if (!this.db) {
+            this.providerActivityStatusWriter?.publishFailure(Date.now());
+            return;
+        }
+
+        try {
+            refineProviderActivity(this.db, activityId, activity);
+        } catch (error) {
+            this.providerActivityStatusWriter?.publishFailure(Date.now());
+            logger.warn('[KBRecorderService] Failed to persist provider-dispatch telemetry:', error.message);
+        }
+    }
+
+    /**
+     * @summary Persists the bounded completion outcome for one provider activity.
+     * @param {String} activityId Opaque activity id.
+     * @param {Object} outcome Completion metadata.
+     * @returns {void}
+     */
+    completeProviderActivity(activityId, outcome = {}) {
+        if (!activityId) return;
+        if (!this.db) {
+            this.providerActivityStatusWriter?.publishFailure(Date.now());
+            return;
+        }
+
+        try {
+            completeProviderActivity(this.db, activityId, outcome);
+            this.providerActivityStatusWriter?.publishSuccess(Date.now());
+        } catch (error) {
+            this.providerActivityStatusWriter?.publishFailure(Date.now());
+            logger.warn('[KBRecorderService] Failed to persist provider completion telemetry:', error.message);
+        }
+    }
+
+    /**
+     * @summary Awaits queued atomic provider-status publication for deterministic tests and shutdowns.
+     * @returns {Promise<void>}
+     */
+    async flushProviderActivityStatus() {
+        await this.providerActivityStatusWriter?.flush();
+    }
+
+    /**
      * @summary Rolls up `kb_ingestion_metrics` rows into per-tenant aggregate counters.
      *
-     * Phase 4A (#11665) read-API. Consumed by the Phase 4A-β observability daemon (rollup +
-     * persist) and Phase 4D alerting (threshold checks). Returns one aggregate row per tenant
+     * Consumed by the observability daemon (rollup + persist) and alerting threshold checks.
+     * Returns one aggregate row per tenant
      * for events within the `sinceMs` window — push/tombstone/reconcile/error event counts,
      * total chunk volumes, and error rate.
      *
@@ -478,21 +597,21 @@ class KBRecorderService extends Base {
             .slice(0, limit)
             .map(group => {
                 const
-                    firstSeen          = group.rows[0].timestamp,
-                    lastSeen           = group.rows.at(-1).timestamp,
-                    variants           = [...group.variants],
-                    canonicalQuery     = variants.sort((a, b) => b.length - a.length)[0],
-                    relatedConceptIds  = this.resolveRelatedConceptIds(canonicalQuery),
-                    guideCoverage      = this.hasStrongGuideCoverage(relatedConceptIds),
-                    clusterId          = crypto.createHash('sha256').update(group.normalized).digest('hex');
+                    firstSeen         = group.rows[0].timestamp,
+                    lastSeen          = group.rows.at(-1).timestamp,
+                    variants          = [...group.variants],
+                    canonicalQuery    = variants.sort((a, b) => b.length - a.length)[0],
+                    relatedConceptIds = this.resolveRelatedConceptIds(canonicalQuery),
+                    guideCoverage     = this.hasStrongGuideCoverage(relatedConceptIds),
+                    clusterId         = crypto.createHash('sha256').update(group.normalized).digest('hex');
 
                 return {
                     clusterId,
                     canonicalQuery,
-                    normalizedQuery: group.normalized,
+                    normalizedQuery       : group.normalized,
                     variants,
-                    count          : group.rows.length,
-                    failureCount   : group.failureCount,
+                    count                 : group.rows.length,
+                    failureCount          : group.failureCount,
                     firstSeen,
                     lastSeen,
                     relatedConceptIds,
@@ -575,17 +694,17 @@ class KBRecorderService extends Base {
         `).all(minCount, limit);
 
         const faqs = rows.map(row => ({
-            clusterId              : row.cluster_id,
-            canonicalQuery         : row.canonical_query,
-            normalizedQuery        : row.normalized_query,
-            variants               : this.safeParse(row.variants) || [],
-            count                  : row.occurrence_count,
-            failureCount           : row.failure_count,
-            firstSeen              : row.first_seen,
-            lastSeen               : row.last_seen,
-            relatedConceptIds      : this.safeParse(row.related_concept_ids) || [],
+            clusterId             : row.cluster_id,
+            canonicalQuery        : row.canonical_query,
+            normalizedQuery       : row.normalized_query,
+            variants              : this.safeParse(row.variants) || [],
+            count                 : row.occurrence_count,
+            failureCount          : row.failure_count,
+            firstSeen             : row.first_seen,
+            lastSeen              : row.last_seen,
+            relatedConceptIds     : this.safeParse(row.related_concept_ids) || [],
             hasStrongGuideCoverage: !!row.has_strong_guide_coverage,
-            similarityThreshold    : row.similarity_threshold
+            similarityThreshold   : row.similarity_threshold
         }));
 
         return {

--- a/ai/services/knowledge-base/QueryService.mjs
+++ b/ai/services/knowledge-base/QueryService.mjs
@@ -8,6 +8,7 @@ import {describeRetrievalProvenance}            from './retrievalProvenance.mjs'
 import RequestContextService, {normalizeUserId} from '../../mcp/server/shared/services/RequestContextService.mjs';
 import dotenv                                   from 'dotenv';
 import path                                     from 'path';
+import KBRecorderService                        from './KBRecorderService.mjs';
 
 const {queryScoreWeights} = aiConfig;
 
@@ -143,8 +144,13 @@ class QueryService extends Base {
         }
 
         const collection           = await ChromaManager.getKnowledgeBaseCollection();
-        const queryEmbeddingValues = await TextEmbeddingService.embedText(query, mcConfig.embeddingProvider);
-        const queryLower           = query.toLowerCase();
+        const queryEmbeddingValues = await TextEmbeddingService.embedText(query, mcConfig.embeddingProvider, {
+            operationLabel          : 'knowledge base query embedding',
+            operationStage          : 'kb-query-embedding',
+            providerActivityRecorder: KBRecorderService,
+            service                 : 'knowledge-base'
+        });
+        const queryLower = query.toLowerCase();
 
         // Read-side tenant filter: a requester retrieves its own tenant's chunks plus
         // Neo's curated `neo-shared` corpus. The requester is derived server-side from the

--- a/ai/services/knowledge-base/SearchService.mjs
+++ b/ai/services/knowledge-base/SearchService.mjs
@@ -13,6 +13,7 @@ import {getMissingAskSynthesisLeaves}                                           
 import GraphService                                                                  from '../memory-core/GraphService.mjs';
 import {CONCEPT_EXPANSION_EDGE_TYPES, KB_TERMINAL_EDGE_TYPES, enrichWithConceptWalk} from '../graph/conceptAnchoredRetrieval.mjs';
 import {buildKbFileResolveCandidate}                                                 from './conceptWalkKbFileGate.mjs';
+import KBRecorderService                                                             from './KBRecorderService.mjs';
 
 const LOCAL_EMPTY_COLLECTION_ANSWER  = "The knowledge base collection is empty. Populate it with the release artifact via 'npm run ai:download-kb' (or build locally with 'npm run ai:sync-kb').";
 const REMOTE_EMPTY_COLLECTION_ANSWER = "The knowledge base collection is empty. In a cloud or remote tenant-ingestion deployment, inspect ingestion state first: call get_ingestion_progress(), then inspect_deployment or get_deployment_state_snapshot for tenantRepoSync / deployment-state details. For push-mode tenants, run the configured ingest_source_files or bulk tenant-ingest path before retrying the query.";
@@ -108,11 +109,13 @@ class SearchService extends Base {
         const ask = aiConfig.askSynthesis;
 
         this.model = buildChatModel({
-            modelProvider         : ask.provider,
-            openAiCompatibleConfig: {...aiConfig.openAiCompatible, ...(ask.baseUrl ? {host: ask.baseUrl} : {}), model: ask.model},
-            ollamaConfig          : {...aiConfig.ollama, ...(ask.baseUrl ? {host: ask.baseUrl} : {}), model: ask.model},
-            geminiApiKey          : ask.apiKey,
-            geminiModelName       : ask.model
+            modelProvider           : ask.provider,
+            openAiCompatibleConfig  : {...aiConfig.openAiCompatible, ...(ask.baseUrl ? {host: ask.baseUrl} : {}), model: ask.model},
+            ollamaConfig            : {...aiConfig.ollama, ...(ask.baseUrl ? {host: ask.baseUrl} : {}), model: ask.model},
+            geminiApiKey            : ask.apiKey,
+            geminiModelName         : ask.model,
+            providerActivityRecorder: KBRecorderService,
+            providerActivityService : 'knowledge-base'
         });
     }
 
@@ -481,6 +484,7 @@ Instructions:
             result = await this.model.generateContent(prompt, {
                 timeoutMs       : ask.provider === 'gemini' ? ask.timeoutMsRemote : ask.timeoutMs,
                 operationLabel  : 'ask_knowledge_base synthesis',
+                operationStage  : 'kb-ask-synthesis',
                 priority        : 'interactive',
                 reasoning_effort: ask.reasoningEffort || undefined
             });

--- a/ai/services/knowledge-base/VectorService.mjs
+++ b/ai/services/knowledge-base/VectorService.mjs
@@ -15,6 +15,7 @@ import readline                                                        from 'rea
 import DestructiveOperationGuard                                       from '../../mcp/server/shared/services/DestructiveOperationGuard.mjs';
 import {computeCorpusFingerprint, decideResume, selectResumableChunks} from './helpers/resumableEmbedding.mjs';
 import {clearResumeState, readResumeState, writeResumeState}           from './helpers/kbEmbeddingResumeStore.mjs';
+import KBRecorderService                                               from './KBRecorderService.mjs';
 
 const TENANT_GUARDED_FIELDS = ['tenantId', 'repoSlug', 'visibility', 'originAgentIdentity', 'tenantConfigVersion', 'ingestedAt'];
 const STALE_STRATEGIES      = Object.freeze(new Set(['delete-upfront', 'shadow-swap']));
@@ -684,7 +685,12 @@ class VectorService extends Base {
 
             while (retries < maxRetries && !success) {
                 try {
-                    const embeddings = await TextEmbeddingService.embedTexts(textsToEmbed, mcConfig.embeddingProvider);
+                    const embeddings = await TextEmbeddingService.embedTexts(textsToEmbed, mcConfig.embeddingProvider, {
+                        operationLabel          : 'knowledge base tenant ingestion embedding',
+                        operationStage          : 'kb-tenant-ingestion-embedding',
+                        providerActivityRecorder: KBRecorderService,
+                        service                 : 'knowledge-base'
+                    });
 
                     const metadatas = batchToEmbed.map(chunk => {
                         const metadata = {};

--- a/ai/services/memory-core/HealthService.mjs
+++ b/ai/services/memory-core/HealthService.mjs
@@ -32,6 +32,7 @@ import {buildSqliteHolderDiagnostics}   from './helpers/harnessClassifier.mjs';
 import {readRecentRemRunStates}         from './helpers/remRunStateStore.mjs';
 import {withTimeout}                    from './helpers/withTimeout.mjs';
 import {isActiveWakeSubscriptionStatus} from './wakeSubscriptionStatusPolicy.mjs';
+import MemoryCoreRecorderService        from './MemoryCoreRecorderService.mjs';
 import {
     LOOPBACK_PROBE_HEALTH_KEY,
     LOOPBACK_PROBE_TIMEOUT_MS,
@@ -221,9 +222,16 @@ export async function buildEmbeddingWriteCanaryBlock({
         return TextEmbeddingService.embedText(text, explicitProvider, options);
     });
 
+    const attributedProbe = (text, explicitProvider, options) => probe(text, explicitProvider, {
+        ...options,
+        operationStage          : 'embedding-canary',
+        providerActivityRecorder: MemoryCoreRecorderService,
+        service                 : 'memory-core'
+    });
+
     return buildEmbeddingProbeBlock({
         cfg,
-        embedText     : probe,
+        embedText     : attributedProbe,
         input,
         now,
         operationLabel: 'Embedding write canary',

--- a/ai/services/memory-core/MemoryCoreRecorderService.mjs
+++ b/ai/services/memory-core/MemoryCoreRecorderService.mjs
@@ -5,6 +5,19 @@ import Base                  from '../../../src/core/Base.mjs';
 import config                from '../../mcp/server/memory-core/config.mjs';
 import logger                from '../../mcp/server/memory-core/logger.mjs';
 import RequestContextService from '../../mcp/server/shared/services/RequestContextService.mjs';
+import {
+    beginProviderActivity,
+    completeProviderActivity,
+    ensureProviderActivitySchema,
+    getProviderActivityMetrics,
+    PROVIDER_ACTIVITY_BUSY_TIMEOUT_MS,
+    refineProviderActivity,
+    startProviderActivity
+}                            from '../shared/providerActivityLedger.mjs';
+import {
+    createProviderActivityStatusWriter,
+    inspectProviderActivityStatus
+}                            from '../shared/providerActivityStatusStore.mjs';
 
 const SENSITIVE_PAYLOAD_KEYS = new Set([
     'body',
@@ -20,7 +33,23 @@ const SENSITIVE_PAYLOAD_KEYS = new Set([
  * @summary Maximum SQLite lock wait allowed on the best-effort telemetry path.
  * @type {Number}
  */
-export const TOOL_TELEMETRY_BUSY_TIMEOUT_MS = 50;
+export const TOOL_TELEMETRY_BUSY_TIMEOUT_MS = PROVIDER_ACTIVITY_BUSY_TIMEOUT_MS;
+
+/**
+ * @summary Builds an explicit empty provider-activity observer state.
+ * @param {'disabled'|'unavailable'|'partial'} status Availability state.
+ * @returns {Object}
+ */
+function emptyProviderActivity(status) {
+    return {
+        status,
+        totalActivities  : 0,
+        totalInFlight    : 0,
+        aggregates       : [],
+        inFlight         : [],
+        recentCompletions: []
+    };
+}
 
 /**
  * @summary Persists redacted Memory Core MCP tool-call telemetry.
@@ -51,7 +80,13 @@ class MemoryCoreRecorderService extends Base {
          * @summary SQLite connection to the Memory Core graph database.
          * @protected
          */
-        db: null
+        db: null,
+        /**
+         * @member {Object|null} providerActivityStatusWriter=null
+         * @summary Recorder-owned atomic failure-status sidecar writer.
+         * @protected
+         */
+        providerActivityStatusWriter: null
     }
 
     /**
@@ -70,6 +105,11 @@ class MemoryCoreRecorderService extends Base {
                 return;
             }
 
+            this.providerActivityStatusWriter = createProviderActivityStatusWriter({
+                dbPath,
+                recorder: 'memory-core'
+            });
+
             if (dbPath !== ':memory:') {
                 await fs.ensureDir(path.dirname(dbPath));
             }
@@ -85,8 +125,10 @@ class MemoryCoreRecorderService extends Base {
             }
 
             this.ensureSchema();
+            await this.providerActivityStatusWriter.publishSuccess(Date.now());
             logger.info('[MemoryCoreRecorderService] Connected to Memory Core mc_tool_call_log.');
         } catch (err) {
+            await this.providerActivityStatusWriter?.publishFailure(Date.now());
             logger.warn('[MemoryCoreRecorderService] Failed to initialize SQLite connection:', err.message);
         }
     }
@@ -154,6 +196,8 @@ class MemoryCoreRecorderService extends Base {
                    AND duration_ms IS NOT NULL
             `).run();
         }
+
+        ensureProviderActivitySchema(this.db);
     }
 
     /**
@@ -330,10 +374,103 @@ class MemoryCoreRecorderService extends Base {
     }
 
     /**
-     * @summary Returns aggregate, unfinished, and recent-slow Memory Core MCP tool-call metrics without
-     * exposing raw payloads or caller identity. A completed slow row preserves the exact timeline
-     * after it disappears from `unfinishedCalls`; it proves server code returned, never that a
-     * timed-out client received the response.
+     * @summary Persists one bounded provider admission boundary in the shared telemetry artifact.
+     * @param {Object} entry Provider activity descriptor.
+     * @returns {String|null}
+     */
+    beginProviderActivity(entry = {}) {
+        if (!config.toolTelemetry.enabled) return null;
+        if (!this.db) {
+            this.providerActivityStatusWriter?.publishFailure(Date.now());
+            return null;
+        }
+
+        try {
+            return beginProviderActivity(this.db, entry);
+        } catch (error) {
+            this.providerActivityStatusWriter?.publishFailure(Date.now());
+            logger.warn('[MemoryCoreRecorderService] Failed to persist provider admission telemetry:', error.message);
+            return null;
+        }
+    }
+
+    /**
+     * @summary Persists the execution-start boundary for one provider activity.
+     * @param {String} activityId Opaque activity id.
+     * @param {Number} startedAt Provider-start timestamp.
+     * @returns {void}
+     */
+    startProviderActivity(activityId, startedAt) {
+        if (!config.toolTelemetry.enabled || !activityId) return;
+        if (!this.db) {
+            this.providerActivityStatusWriter?.publishFailure(Date.now());
+            return;
+        }
+
+        try {
+            startProviderActivity(this.db, activityId, startedAt);
+        } catch (error) {
+            this.providerActivityStatusWriter?.publishFailure(Date.now());
+            logger.warn('[MemoryCoreRecorderService] Failed to persist provider-start telemetry:', error.message);
+        }
+    }
+
+    /**
+     * @summary Persists the model selected by provider-owned dispatch code.
+     * @param {String} activityId Opaque activity id.
+     * @param {Object} activity Dispatch-bound activity refinement.
+     * @returns {void}
+     */
+    refineProviderActivity(activityId, activity) {
+        if (!config.toolTelemetry.enabled || !activityId) return;
+        if (!this.db) {
+            this.providerActivityStatusWriter?.publishFailure(Date.now());
+            return;
+        }
+
+        try {
+            refineProviderActivity(this.db, activityId, activity);
+        } catch (error) {
+            this.providerActivityStatusWriter?.publishFailure(Date.now());
+            logger.warn('[MemoryCoreRecorderService] Failed to persist provider-dispatch telemetry:', error.message);
+        }
+    }
+
+    /**
+     * @summary Persists the bounded completion outcome for one provider activity.
+     * @param {String} activityId Opaque activity id.
+     * @param {Object} outcome Completion metadata.
+     * @returns {void}
+     */
+    completeProviderActivity(activityId, outcome = {}) {
+        if (!config.toolTelemetry.enabled || !activityId) return;
+        if (!this.db) {
+            this.providerActivityStatusWriter?.publishFailure(Date.now());
+            return;
+        }
+
+        try {
+            completeProviderActivity(this.db, activityId, outcome);
+            this.providerActivityStatusWriter?.publishSuccess(Date.now());
+        } catch (error) {
+            this.providerActivityStatusWriter?.publishFailure(Date.now());
+            logger.warn('[MemoryCoreRecorderService] Failed to persist provider completion telemetry:', error.message);
+        }
+    }
+
+    /**
+     * @summary Awaits queued atomic provider-status publication for deterministic tests and shutdowns.
+     * @returns {Promise<void>}
+     */
+    async flushProviderActivityStatus() {
+        await this.providerActivityStatusWriter?.flush();
+    }
+
+    /**
+     * @summary Returns tool-call and bounded provider-stage metrics without exposing raw payloads or
+     * caller identity. A completed slow tool row preserves the exact timeline after it disappears
+     * from `unfinishedCalls`; it proves server code returned, never that a timed-out client received
+     * the response. Provider rows independently separate Neo-owned queue wait from execution.
      * @param {Object} options
      * @param {Number} [options.sinceMs=config.toolTelemetry.aggregateWindowMs] Lookback window.
      * @param {Number} [options.limit=config.toolTelemetry.aggregateLimit] Max rows per projection.
@@ -353,33 +490,33 @@ class MemoryCoreRecorderService extends Base {
 
         if (!config.toolTelemetry.enabled) {
             return {
-                status         : 'disabled',
+                status          : 'disabled',
                 sinceMs,
                 limit,
-                slowAfterMs    : safeSlowAfterMs,
-                totalCalls     : 0,
-                totalUnfinished: 0,
-                tools          : [],
-                unfinishedCalls: [],
-                recentSlowCalls: []
+                slowAfterMs     : safeSlowAfterMs,
+                totalCalls      : 0,
+                totalUnfinished : 0,
+                tools           : [],
+                unfinishedCalls : [],
+                recentSlowCalls : [],
+                providerActivity: emptyProviderActivity('disabled')
             };
         }
 
         if (!this.db) {
             return {
-                status         : 'unavailable',
+                status          : 'unavailable',
                 sinceMs,
                 limit,
-                slowAfterMs    : safeSlowAfterMs,
-                totalCalls     : 0,
-                totalUnfinished: 0,
-                tools          : [],
-                unfinishedCalls: [],
-                recentSlowCalls: []
+                slowAfterMs     : safeSlowAfterMs,
+                totalCalls      : 0,
+                totalUnfinished : 0,
+                tools           : [],
+                unfinishedCalls : [],
+                recentSlowCalls : [],
+                providerActivity: emptyProviderActivity('unavailable')
             };
         }
-
-        this.ensureSchema();
 
         const
             safeSinceMs = Number.isFinite(sinceMs) && sinceMs > 0 ? sinceMs : config.toolTelemetry.aggregateWindowMs,
@@ -431,6 +568,30 @@ class MemoryCoreRecorderService extends Base {
             `).all({sinceTs, slowAfterMs: safeSlowAfterMs, limit: safeLimit}),
             now = Date.now();
 
+        let providerActivity;
+
+        try {
+            providerActivity = getProviderActivityMetrics(this.db, {
+                limit  : safeLimit,
+                now,
+                sinceTs
+            });
+        } catch (error) {
+            logger.warn('[MemoryCoreRecorderService] Failed to read provider activity telemetry:', error.message);
+            providerActivity = emptyProviderActivity('partial');
+        }
+
+        const sidecarStatus = inspectProviderActivityStatus({
+            dbPath: config.storagePaths.graph,
+            sinceTs
+        }).status;
+
+        if (sidecarStatus === 'unavailable') {
+            providerActivity = emptyProviderActivity('unavailable');
+        } else if (sidecarStatus === 'partial' && providerActivity.status === 'ok') {
+            providerActivity.status = 'partial';
+        }
+
         return {
             status     : 'ok',
             sinceMs    : safeSinceMs,
@@ -461,7 +622,8 @@ class MemoryCoreRecorderService extends Base {
                 durationMs  : row.duration_ms,
                 success     : row.success === 1,
                 failureStage: row.failure_stage ?? null
-            }))
+            })),
+            providerActivity
         };
     }
 }

--- a/ai/services/memory-core/MemoryService.mjs
+++ b/ai/services/memory-core/MemoryService.mjs
@@ -31,6 +31,7 @@ import {normalizeAgentIdentityNodeId}                           from '../../grap
 
 import {CONCEPT_EXPANSION_EDGE_TYPES, MEMORY_TERMINAL_EDGE_TYPES, enrichWithConceptWalk} from '../graph/conceptAnchoredRetrieval.mjs';
 import {buildMemoryResolveCandidate}                                                     from './conceptWalkMemoryGate.mjs';
+import MemoryCoreRecorderService                                                         from './MemoryCoreRecorderService.mjs';
 
 /**
  * The `add_memory` success message. Deliberately says ACCEPTED rather than "successfully added":
@@ -1687,11 +1688,13 @@ class MemoryService extends Base {
         const TIMEOUT_MS = aiConfig.memoryService.generateMiniSummaryTimeoutMs;
         try {
             const model = buildModel({
-                modelProvider         : aiConfig.modelProvider,
-                openAiCompatibleConfig: aiConfig.openAiCompatible,
-                ollamaConfig          : aiConfig.ollama,
-                geminiApiKey          : aiConfig.geminiApiKey,
-                geminiModelName       : aiConfig.modelName
+                modelProvider           : aiConfig.modelProvider,
+                openAiCompatibleConfig  : aiConfig.openAiCompatible,
+                ollamaConfig            : aiConfig.ollama,
+                geminiApiKey            : aiConfig.geminiApiKey,
+                geminiModelName         : aiConfig.modelName,
+                providerActivityRecorder: MemoryCoreRecorderService,
+                providerActivityService : 'memory-core'
             });
             if (!model) return {summary: null, cause: 'no-model'};
 
@@ -1709,6 +1712,7 @@ class MemoryService extends Base {
                 model.generateContent(promptText, {
                     timeoutMs     : TIMEOUT_MS,
                     operationLabel: 'miniSummary generation',
+                    operationStage: 'mc-mini-summary',
                     // Batch, not interactive: the only runtime caller is the backfill sweep, so this
                     // queue-jumped real interactive traffic on behalf of a background job.
                     priority      : 'batch',

--- a/ai/services/memory-core/SessionService.mjs
+++ b/ai/services/memory-core/SessionService.mjs
@@ -34,6 +34,7 @@ import RequestContextService, {
     normalizeUserId,
     resolveSummaryVisibilityUserId
 } from '../../mcp/server/shared/services/RequestContextService.mjs';
+import MemoryCoreRecorderService from './MemoryCoreRecorderService.mjs';
 
 const CHROMA_SESSION_READ_TIMEOUT_MS = 10000;
 
@@ -185,11 +186,13 @@ class SessionService extends Base {
         }
 
         this.model = buildChatModel({
-            modelProvider         : aiConfig.modelProvider,
-            openAiCompatibleConfig: aiConfig.openAiCompatible,
-            ollamaConfig          : aiConfig.ollama,
-            geminiApiKey          : aiConfig.geminiApiKey,
-            geminiModelName       : aiConfig.modelName
+            modelProvider           : aiConfig.modelProvider,
+            openAiCompatibleConfig  : aiConfig.openAiCompatible,
+            ollamaConfig            : aiConfig.ollama,
+            geminiApiKey            : aiConfig.geminiApiKey,
+            geminiModelName         : aiConfig.modelName,
+            providerActivityRecorder: MemoryCoreRecorderService,
+            providerActivityService : 'memory-core'
         });
     }
 
@@ -708,7 +711,7 @@ ${sessionContent}
         // friction symptom, which the degraded fallback below treats like an oversize skip.
         const runGuardrailed = (prompt, note) => invokeWithGuardrail({
             invocationFn             : () => withTimeout(
-                this.model.generateContent(prompt, {timeoutMs: summaryTimeoutMs, operationLabel: 'session summarization', priority: 'batch', reasoning_effort: summaryReasoningEffort || undefined, responseSchema: summarySchema, responseSchemaName: 'sessionSummary'}),
+                this.model.generateContent(prompt, {timeoutMs: summaryTimeoutMs, operationLabel: 'session summarization', operationStage: 'mc-session-summary', priority: 'batch', reasoning_effort: summaryReasoningEffort || undefined, responseSchema: summarySchema, responseSchemaName: 'sessionSummary'}),
                 summaryTimeoutMs,
                 'session summarization'
             ),

--- a/ai/services/memory-core/TextEmbeddingService.mjs
+++ b/ai/services/memory-core/TextEmbeddingService.mjs
@@ -9,6 +9,11 @@ import OllamaProvider from '../../provider/Ollama.mjs';
 import {
     withLmsEmbeddingInputSuffix
 }                           from '../shared/vector/lmsEmbeddingInputSuffix.mjs';
+import {
+    createProviderActivityLifecycle,
+    observeUnqueuedProviderActivity
+}                           from '../shared/providerActivityLedger.mjs';
+import MemoryCoreRecorderService                                       from './MemoryCoreRecorderService.mjs';
 import {OPENAI_COMPATIBLE_REQUEST_TIMEOUT_CODE, PROVIDER_TIMEOUT_CODE} from '../../provider/createTimeoutError.mjs';
 import {
     bytesToTokens,
@@ -45,14 +50,21 @@ function markEmbeddingModelNotResidentError(error) {
  * @summary Normalizes the additive embedding-call options without widening provider authority.
  * @param {Object} options Caller options.
  * @param {String} defaultOperationLabel Provider-scoped fallback label.
- * @returns {{signal: AbortSignal|undefined, operationLabel: String}}
+ * @returns {Object}
  */
 function normalizeEmbeddingOptions(options, defaultOperationLabel) {
     if (!options || typeof options !== 'object' || Array.isArray(options)) {
-        throw new TypeError('TextEmbeddingService: options must be an object containing only signal and operationLabel');
+        throw new TypeError('TextEmbeddingService: options must be an object');
     }
 
-    const unknownKeys = Object.keys(options).filter(key => !['signal', 'operationLabel'].includes(key));
+    const allowedKeys = [
+        'operationLabel',
+        'operationStage',
+        'providerActivityRecorder',
+        'service',
+        'signal'
+    ];
+    const unknownKeys = Object.keys(options).filter(key => !allowedKeys.includes(key));
 
     if (unknownKeys.length > 0) {
         throw new TypeError(`TextEmbeddingService: unsupported embedding option(s): ${unknownKeys.join(', ')}`);
@@ -67,13 +79,40 @@ function normalizeEmbeddingOptions(options, defaultOperationLabel) {
     if (options.operationLabel !== undefined && typeof options.operationLabel !== 'string') {
         throw new TypeError('TextEmbeddingService: options.operationLabel must be a string');
     }
+    if (options.operationStage !== undefined && typeof options.operationStage !== 'string') {
+        throw new TypeError('TextEmbeddingService: options.operationStage must be a string');
+    }
+    if (options.service !== undefined && typeof options.service !== 'string') {
+        throw new TypeError('TextEmbeddingService: options.service must be a string');
+    }
+    if (options.providerActivityRecorder !== undefined && options.providerActivityRecorder !== null && typeof options.providerActivityRecorder !== 'object') {
+        throw new TypeError('TextEmbeddingService: options.providerActivityRecorder must be an object or null');
+    }
 
     const requestedLabel = options.operationLabel?.trim() || defaultOperationLabel;
 
     return {
-        signal        : options.signal,
-        operationLabel: requestedLabel.substring(0, EMBEDDING_OPERATION_LABEL_MAX_LENGTH)
+        operationLabel          : requestedLabel.substring(0, EMBEDDING_OPERATION_LABEL_MAX_LENGTH),
+        operationStage          : options.operationStage || 'unknown',
+        providerActivityRecorder: options.providerActivityRecorder === undefined
+            ? MemoryCoreRecorderService
+            : options.providerActivityRecorder,
+        service: options.service || 'unknown',
+        signal : options.signal
     };
+}
+
+/**
+ * @summary Resolves the configured model identifier for one explicit embedding provider.
+ * @param {String} provider Explicit embedding provider.
+ * @returns {String}
+ */
+function getEmbeddingModel(provider) {
+    if (provider === 'openAiCompatible') return aiConfig.openAiCompatible.embeddingModel;
+    if (provider === 'ollama') return aiConfig.ollama.embeddingModel || aiConfig.ollama.model;
+    if (provider === 'gemini') return aiConfig.embeddingModel;
+
+    return 'unknown';
 }
 
 /**
@@ -343,9 +382,26 @@ class TextEmbeddingService extends Base {
      * @private
      */
     #enqueueOpenAiCompatiblePost(inputData, options, priority) {
-        const {operation, operationLabel, signal} = options;
+        const {
+            operation,
+            operationLabel,
+            providerActivity,
+            providerActivityRecorder,
+            signal
+        } = options;
+        const lifecycle = createProviderActivityLifecycle({
+            recorder: providerActivityRecorder,
+            activity: {
+                ...providerActivity,
+                model: 'unknown',
+                priority
+            }
+        });
+        options.providerActivityLifecycle = lifecycle;
+        const enqueuedAt = Date.now();
 
         throwIfEmbeddingAborted(signal, operationLabel);
+        lifecycle.onEnqueued({enqueuedAt});
 
         return new Promise((resolve, reject) => {
             const task = {
@@ -353,6 +409,8 @@ class TextEmbeddingService extends Base {
                 inputData,
                 options,
                 priority,
+                lifecycle,
+                enqueuedAt,
                 settled   : false
             };
 
@@ -377,6 +435,11 @@ class TextEmbeddingService extends Base {
                     this.#openAiCompatiblePostQueue.splice(taskIndex, 1);
                 }
 
+                task.lifecycle.onSettled({
+                    completedAt : Date.now(),
+                    failureStage: 'queue',
+                    success     : false
+                });
                 task.reject(getEmbeddingAbortError(signal, operationLabel));
             };
             task.markDispatched = () => {
@@ -415,9 +478,17 @@ class TextEmbeddingService extends Base {
 
                 task.markDispatched();
 
+                const startedAt = Date.now();
+
+                task.lifecycle.onStarted({startedAt});
+
                 try {
-                    task.resolve(await this.#postOpenAiCompatible(task.inputData, task.options));
+                    const result = await this.#postOpenAiCompatible(task.inputData, task.options);
+
+                    task.lifecycle.onSettled({completedAt: Date.now(), success: true});
+                    task.resolve(result);
                 } catch (err) {
+                    task.lifecycle.onSettled({completedAt: Date.now(), success: false});
                     task.reject(err);
                 }
             }
@@ -696,15 +767,16 @@ class TextEmbeddingService extends Base {
             requestTimeoutMs      = DEFAULT_OPENAI_COMPATIBLE_REQUEST_TIMEOUT_MS,
             signal,
             operationLabel,
-            operation
+            operation,
+            providerActivityLifecycle
         } = options;
         const {
             host,
-            embeddingModel,
             apiKey,
             unloadRetryDelayMs    = 500,
             contentionRetryDelayMs = 1000
         } = aiConfig.openAiCompatible;
+        const embeddingModel = aiConfig.openAiCompatible.embeddingModel;
 
         try {
             operation.phase = 'transport-setup';
@@ -789,6 +861,7 @@ class TextEmbeddingService extends Base {
             if (signal?.aborted) {
                 abortHandler();
             } else {
+                providerActivityLifecycle?.onDispatch({model: embeddingModel});
                 req.write(JSON.stringify({ model: embeddingModel, input: inputData }));
                 req.end();
             }
@@ -822,7 +895,8 @@ class TextEmbeddingService extends Base {
                     requestTimeoutMs,
                     signal,
                     operationLabel,
-                    operation
+                    operation,
+                    providerActivityLifecycle
                 });
             }
 
@@ -836,11 +910,12 @@ class TextEmbeddingService extends Base {
                     requestTimeoutMs,
                     signal,
                     operationLabel,
-                    operation
+                    operation,
+                    providerActivityLifecycle
                 });
             }
             if (isOpenAiCompatibleContentionTimeoutError(err)) {
-                this.#emitOpenAiCompatibleTimeoutFriction(inputData, requestTimeoutMs, err);
+                this.#emitOpenAiCompatibleTimeoutFriction(inputData, requestTimeoutMs, err, embeddingModel);
             }
             logger.error(`[TextEmbeddingService] Failed to generate embedding from openAiCompatible:`, err.message);
             throw err;
@@ -852,13 +927,13 @@ class TextEmbeddingService extends Base {
      * @param {String|String[]} inputData Text input that timed out.
      * @param {Number} requestTimeoutMs Request timeout in milliseconds.
      * @param {Error} err Timeout error.
+     * @param {String} embeddingModel Model captured at the provider dispatch boundary.
      * @returns {void}
      * @private
      */
-    #emitOpenAiCompatibleTimeoutFriction(inputData, requestTimeoutMs, err) {
+    #emitOpenAiCompatibleTimeoutFriction(inputData, requestTimeoutMs, err, embeddingModel) {
         const
-            {embeddingModel} = aiConfig.openAiCompatible,
-            estimate         = this.#getOpenAiCompatibleInputEstimate(inputData);
+            estimate = this.#getOpenAiCompatibleInputEstimate(inputData);
 
         try {
             emitConsumerFriction({
@@ -958,24 +1033,34 @@ class TextEmbeddingService extends Base {
      * @param {String} operationLabel Safe diagnostic label for timeout errors.
      * @param {AbortSignal|undefined} signal Upstream cancellation signal.
      * @param {Object} operation Mutable local-phase observability record.
+     * @param {Object|null} providerActivityRecorder Best-effort telemetry sink.
+     * @param {Object} providerActivity Bounded provider activity descriptor.
      * @returns {Promise<Object>}
      * @private
      */
-    async #embedOllama(inputData, operationLabel, signal, operation) {
+    async #embedOllama(inputData, operationLabel, signal, operation, providerActivityRecorder, providerActivity) {
         const
             provider         = this.#getOllamaProvider(),
+            dispatchModel    = provider.embeddingModel || provider.modelName || 'unknown',
             requestTimeoutMs = this.#getOllamaEmbeddingTimeoutMs();
 
         try {
             operation.phase = 'in-flight';
             throwIfEmbeddingAborted(signal, operationLabel);
 
-            return await provider.embed(inputData, {
-                num_ctx : aiConfig.localModels.embedding.contextLimitTokens,
-                operationLabel,
-                ...(signal ? {signal} : {}),
-                timeoutMs: requestTimeoutMs,
-                truncate : false
+            return await observeUnqueuedProviderActivity({
+                recorder: providerActivityRecorder,
+                activity: {
+                    ...providerActivity,
+                    model: dispatchModel
+                },
+                task    : () => provider.embed(inputData, {
+                    num_ctx : aiConfig.localModels.embedding.contextLimitTokens,
+                    operationLabel,
+                    ...(signal ? {signal} : {}),
+                    timeoutMs: requestTimeoutMs,
+                    truncate : false
+                })
             });
         } catch (err) {
             if (isCallerAbortError(err, signal)) {
@@ -1004,7 +1089,13 @@ class TextEmbeddingService extends Base {
      * @private
      */
     async #embedOpenAiCompatibleBatch(texts, options) {
-        const {operation, operationLabel, signal} = options;
+        const {
+            operation,
+            operationLabel,
+            providerActivity,
+            providerActivityRecorder,
+            signal
+        } = options;
         const {
             unloadRetryCount        = 3,
             batchEmbeddingChunkSize = 5,
@@ -1025,7 +1116,9 @@ class TextEmbeddingService extends Base {
                       requestTimeoutMs,
                       signal,
                       operationLabel,
-                      operation
+                      operation,
+                      providerActivity,
+                      providerActivityRecorder
                   }, 'batch');
 
             data.push(...(result.data || []).map(item => ({
@@ -1054,6 +1147,9 @@ class TextEmbeddingService extends Base {
      * @param {Object} [options={}] Abort/diagnostic options.
      * @param {AbortSignal} [options.signal] Caller-owned cancellation signal.
      * @param {String} [options.operationLabel] Bounded diagnostic label.
+     * @param {String} [options.operationStage='unknown'] Stable low-cardinality stage.
+     * @param {String} [options.service='unknown'] Stable service owner.
+     * @param {Object|null} [options.providerActivityRecorder] Best-effort telemetry sink.
      * @returns {Promise<number[]>}
      */
     async embedText(text, explicitProvider, options = {}) {
@@ -1062,7 +1158,21 @@ class TextEmbeddingService extends Base {
         const defaultOperationLabel = explicitProvider === 'ollama'
                   ? 'TextEmbeddingService.embedText native Ollama embedding'
                   : `TextEmbeddingService.embedText ${explicitProvider} embedding`,
-              {signal, operationLabel} = normalizeEmbeddingOptions(options, defaultOperationLabel),
+              {
+                  operationLabel,
+                  operationStage,
+                  providerActivityRecorder,
+                  service,
+                  signal
+              } = normalizeEmbeddingOptions(options, defaultOperationLabel),
+              providerActivity          = {
+                  model   : getEmbeddingModel(explicitProvider),
+                  operationStage,
+                  priority: 'interactive',
+                  provider: explicitProvider,
+                  role    : 'embedding',
+                  service
+              },
               operation                = {operationLabel, phase: 'entry', startedAt: Date.now()};
 
         try {
@@ -1081,13 +1191,22 @@ class TextEmbeddingService extends Base {
                     requestTimeoutMs     : contentionTimeoutMs,
                     signal,
                     operationLabel,
-                    operation
+                    operation,
+                    providerActivity,
+                    providerActivityRecorder
                 }, 'interactive');
                 return result.data?.[0]?.embedding;
             } else if (explicitProvider === 'ollama') {
                 // Native Ollama returns `{embeddings: [[...]]}` even for single-input;
                 // project the single inner array since this method is the per-text variant.
-                const result = await this.#embedOllama(text, operationLabel, signal, operation);
+                const result = await this.#embedOllama(
+                    text,
+                    operationLabel,
+                    signal,
+                    operation,
+                    providerActivityRecorder,
+                    providerActivity
+                );
                 return result.embeddings?.[0];
             } else if (explicitProvider === 'gemini') {
                 const geminiKey = aiConfig.geminiApiKey;
@@ -1099,7 +1218,15 @@ class TextEmbeddingService extends Base {
                 }
 
                 operation.phase = 'in-flight';
-                const result = await this.embeddingModel.embedContent(text, signal ? {signal} : undefined);
+                const dispatchModel = this.embeddingModel.model || 'unknown';
+                const result        = await observeUnqueuedProviderActivity({
+                    recorder: providerActivityRecorder,
+                    activity: {
+                        ...providerActivity,
+                        model: dispatchModel
+                    },
+                    task    : () => this.embeddingModel.embedContent(text, signal ? {signal} : undefined)
+                });
                 return result.embedding.values;
             } else {
                 // Unknown provider names fail loudly rather than silently fall back to
@@ -1129,6 +1256,9 @@ class TextEmbeddingService extends Base {
      * @param {Object} [options={}] Abort/diagnostic options.
      * @param {AbortSignal} [options.signal] Caller-owned cancellation signal.
      * @param {String} [options.operationLabel] Bounded diagnostic label.
+     * @param {String} [options.operationStage='unknown'] Stable low-cardinality stage.
+     * @param {String} [options.service='unknown'] Stable service owner.
+     * @param {Object|null} [options.providerActivityRecorder] Best-effort telemetry sink.
      * @returns {Promise<number[][]>}
      */
     async embedTexts(texts, explicitProvider, options = {}) {
@@ -1137,7 +1267,21 @@ class TextEmbeddingService extends Base {
         const defaultOperationLabel = explicitProvider === 'ollama'
                   ? 'TextEmbeddingService.embedTexts native Ollama embedding'
                   : `TextEmbeddingService.embedTexts ${explicitProvider} embedding`,
-              {signal, operationLabel} = normalizeEmbeddingOptions(options, defaultOperationLabel),
+              {
+                  operationLabel,
+                  operationStage,
+                  providerActivityRecorder,
+                  service,
+                  signal
+              } = normalizeEmbeddingOptions(options, defaultOperationLabel),
+              providerActivity          = {
+                  model   : getEmbeddingModel(explicitProvider),
+                  operationStage,
+                  priority: 'batch',
+                  provider: explicitProvider,
+                  role    : 'embedding',
+                  service
+              },
               operation                = {operationLabel, phase: 'entry', startedAt: Date.now()};
 
         try {
@@ -1145,11 +1289,24 @@ class TextEmbeddingService extends Base {
 
             if (explicitProvider === 'openAiCompatible') {
                 const requestTexts = await this.#prepareOpenAiCompatibleEmbeddingInput(texts, signal, operationLabel, operation);
-                return this.#embedOpenAiCompatibleBatch(requestTexts, {signal, operationLabel, operation});
+                return this.#embedOpenAiCompatibleBatch(requestTexts, {
+                    operation,
+                    operationLabel,
+                    providerActivity,
+                    providerActivityRecorder,
+                    signal
+                });
             } else if (explicitProvider === 'ollama') {
                 // Ollama's `/api/embed` accepts array-of-strings natively + returns
                 // a parallel embeddings array — no per-text fan-out needed.
-                const result = await this.#embedOllama(texts, operationLabel, signal, operation);
+                const result = await this.#embedOllama(
+                    texts,
+                    operationLabel,
+                    signal,
+                    operation,
+                    providerActivityRecorder,
+                    providerActivity
+                );
                 return result.embeddings || [];
             } else if (explicitProvider === 'gemini') {
                 const geminiKey = aiConfig.geminiApiKey;
@@ -1161,8 +1318,18 @@ class TextEmbeddingService extends Base {
                 }
 
                 operation.phase = 'in-flight';
-                const requests = texts.map(text => ({model: aiConfig.embeddingModel, content: {parts: [{text}]}}));
-                const result   = await this.embeddingModel.batchEmbedContents({requests}, signal ? {signal} : undefined);
+                const endpointModel = this.embeddingModel.model;
+                const requestModel  = aiConfig.embeddingModel;
+                const dispatchModel = endpointModel || 'unknown';
+                const requests      = texts.map(text => ({model: requestModel, content: {parts: [{text}]}}));
+                const result        = await observeUnqueuedProviderActivity({
+                    recorder: providerActivityRecorder,
+                    activity: {
+                        ...providerActivity,
+                        model: dispatchModel
+                    },
+                    task    : () => this.embeddingModel.batchEmbedContents({requests}, signal ? {signal} : undefined)
+                });
                 return result.embeddings.map(e => e.values);
             } else {
                 // Unknown provider names fail loudly (matches `embedText`).

--- a/ai/services/memory-core/managers/ChromaManager.mjs
+++ b/ai/services/memory-core/managers/ChromaManager.mjs
@@ -223,7 +223,8 @@ class ChromaManager extends AbstractVectorManager {
      */
     #createEmbeddingFunction() {
         return createDynamicTextEmbeddingFunction({
-            providerResolver: () => aiConfig.embeddingProvider
+            providerResolver: () => aiConfig.embeddingProvider,
+            service         : 'memory-core'
         })
     }
 

--- a/ai/services/shared/providerActivityLedger.mjs
+++ b/ai/services/shared/providerActivityLedger.mjs
@@ -1,0 +1,445 @@
+import crypto              from 'crypto';
+import {AsyncLocalStorage} from 'node:async_hooks';
+
+const providerActivityContext = new AsyncLocalStorage();
+
+/**
+ * @summary Stable low-cardinality operation stages allowed in provider activity telemetry.
+ * @type {ReadonlyArray<String>}
+ */
+export const PROVIDER_ACTIVITY_STAGES = Object.freeze([
+    'embedding-canary',
+    'kb-ask-synthesis',
+    'kb-query-embedding',
+    'kb-tenant-ingestion-embedding',
+    'mc-mini-summary',
+    'mc-session-summary',
+    'mc-wal-drain-embedding',
+    'rem-topology',
+    'rem-tri-vector',
+    'unknown'
+]);
+
+/**
+ * @summary Maximum SQLite lock wait allowed on provider-activity telemetry writes.
+ * @type {Number}
+ */
+export const PROVIDER_ACTIVITY_BUSY_TIMEOUT_MS = 50;
+
+/**
+ * @summary Runs one collection operation with source-owned provider attribution in async context.
+ * @param {Object} activity Stable stage/service attribution.
+ * @param {Function} task Collection-operation thunk.
+ * @returns {*}
+ */
+export function runWithProviderActivityContext(activity, task) {
+    if (typeof task !== 'function') {
+        throw new TypeError('providerActivityLedger: task must be a function');
+    }
+
+    return providerActivityContext.run({
+        operationStage: activity?.operationStage || 'unknown',
+        service       : activity?.service || 'unknown'
+    }, task);
+}
+
+/**
+ * @summary Returns the current source-owned collection attribution without inferring one.
+ * @returns {Object|null}
+ */
+export function getProviderActivityContext() {
+    return providerActivityContext.getStore() || null;
+}
+
+const ACTIVITY_ROLES       = new Set(['chat', 'embedding', 'unknown']);
+const FAILURE_STAGES       = new Set(['provider', 'queue', 'unknown']);
+const PRIORITIES           = new Set(['batch', 'interactive', 'unknown']);
+const PROVIDERS            = new Set(['gemini', 'ollama', 'openAiCompatible', 'unknown']);
+const QUEUE_DISPOSITIONS   = new Set(['neo-queued', 'not-applicable', 'unknown']);
+const SERVICES             = new Set(['dream-pipeline', 'knowledge-base', 'memory-core', 'orchestrator', 'unknown']);
+const STAGES               = new Set(PROVIDER_ACTIVITY_STAGES);
+const MAX_MODEL_NAME_CHARS = 160;
+
+/**
+ * @summary Normalizes one value against a closed telemetry vocabulary.
+ * @param {*} value Candidate value.
+ * @param {Set<String>} allowed Allowed values.
+ * @returns {String}
+ */
+function normalizeEnum(value, allowed) {
+    return typeof value === 'string' && allowed.has(value) ? value : 'unknown';
+}
+
+/**
+ * @summary Retains only a bounded non-secret model identifier.
+ * @param {*} value Candidate model identifier.
+ * @returns {String}
+ */
+function normalizeModel(value) {
+    if (typeof value !== 'string') return 'unknown';
+
+    const trimmed        = value.trim(),
+          slashCount     = (trimmed.match(/\//g) || []).length,
+          credentialLike = /^(?:sk-|ghp_|github_pat_|glpat-|AIza)/i.test(trimmed),
+          endpointLike   = /^(?:localhost|\d{1,3}(?:\.\d{1,3}){3}|\[[0-9a-f:]+\]|[a-z0-9.-]+\.[a-z]{2,}):\d+$/i.test(trimmed),
+          pathLike       = /^(?:\/|[A-Za-z]:[\\/])/.test(trimmed) || trimmed.includes('..');
+
+    return trimmed
+        && trimmed.length <= MAX_MODEL_NAME_CHARS
+        && !trimmed.includes('://')
+        && !trimmed.includes('@')
+        && slashCount <= 1
+        && !credentialLike
+        && !endpointLike
+        && !pathLike
+        && /^[A-Za-z0-9._:+/-]+$/.test(trimmed)
+        ? trimmed
+        : 'unknown';
+}
+
+/**
+ * @summary Creates the bounded provider-activity table and its observer indexes.
+ * @param {Object} db Open better-sqlite3 database.
+ * @returns {void}
+ */
+export function ensureProviderActivitySchema(db) {
+    if (!db) return;
+
+    db.exec(`
+        CREATE TABLE IF NOT EXISTS provider_activity_log (
+            activity_id       TEXT PRIMARY KEY,
+            service           TEXT NOT NULL,
+            operation_stage   TEXT NOT NULL,
+            role              TEXT NOT NULL,
+            provider          TEXT NOT NULL,
+            model             TEXT NOT NULL,
+            priority          TEXT NOT NULL,
+            enqueued_at       INTEGER NOT NULL,
+            started_at        INTEGER,
+            completed_at      INTEGER,
+            queue_disposition TEXT NOT NULL,
+            queue_wait_ms     INTEGER,
+            execution_ms      INTEGER,
+            success           INTEGER,
+            failure_stage     TEXT
+        );
+        CREATE INDEX IF NOT EXISTS idx_provider_activity_enqueued
+            ON provider_activity_log(enqueued_at);
+        CREATE INDEX IF NOT EXISTS idx_provider_activity_completed
+            ON provider_activity_log(completed_at);
+        CREATE INDEX IF NOT EXISTS idx_provider_activity_stage
+            ON provider_activity_log(operation_stage);
+    `);
+}
+
+/**
+ * @summary Persists one provider activity admission boundary without retaining payloads or identity.
+ * @param {Object} db Open better-sqlite3 database.
+ * @param {Object} entry Bounded activity descriptor.
+ * @returns {String} Opaque activity id.
+ */
+export function beginProviderActivity(db, entry = {}) {
+    const
+        activityId       = crypto.randomUUID(),
+        enqueuedAt       = Number.isFinite(entry.enqueuedAt) ? entry.enqueuedAt : Date.now(),
+        queueDisposition = normalizeEnum(entry.queueDisposition, QUEUE_DISPOSITIONS),
+        startedAt        = Number.isFinite(entry.startedAt) ? entry.startedAt : null,
+        queueWaitMs      = queueDisposition === 'neo-queued' && startedAt !== null
+            ? Math.max(0, startedAt - enqueuedAt)
+            : null;
+
+    db.prepare(`
+        INSERT INTO provider_activity_log (
+            activity_id, service, operation_stage, role, provider, model, priority,
+            enqueued_at, started_at, completed_at, queue_disposition, queue_wait_ms,
+            execution_ms, success, failure_stage
+        ) VALUES (
+            @activity_id, @service, @operation_stage, @role, @provider, @model, @priority,
+            @enqueued_at, @started_at, NULL, @queue_disposition, @queue_wait_ms,
+            NULL, NULL, NULL
+        )
+    `).run({
+        activity_id      : activityId,
+        service          : normalizeEnum(entry.service, SERVICES),
+        operation_stage  : normalizeEnum(entry.operationStage, STAGES),
+        role             : normalizeEnum(entry.role, ACTIVITY_ROLES),
+        provider         : normalizeEnum(entry.provider, PROVIDERS),
+        model            : normalizeModel(entry.model),
+        priority         : normalizeEnum(entry.priority, PRIORITIES),
+        enqueued_at      : enqueuedAt,
+        started_at       : startedAt,
+        queue_disposition: queueDisposition,
+        queue_wait_ms    : queueWaitMs
+    });
+
+    return activityId;
+}
+
+/**
+ * @summary Marks the provider execution boundary for an admitted queued activity.
+ * @param {Object} db Open better-sqlite3 database.
+ * @param {String} activityId Opaque activity id.
+ * @param {Number} [startedAt=Date.now()] Provider-start timestamp.
+ * @returns {void}
+ */
+export function startProviderActivity(db, activityId, startedAt = Date.now()) {
+    if (!activityId || !Number.isFinite(startedAt)) return;
+
+    db.prepare(`
+        UPDATE provider_activity_log
+           SET started_at = @startedAt,
+               queue_wait_ms = CASE
+                   WHEN queue_disposition = 'neo-queued' THEN MAX(0, @startedAt - enqueued_at)
+                   ELSE NULL
+               END
+         WHERE activity_id = @activityId
+           AND completed_at IS NULL
+    `).run({activityId, startedAt});
+}
+
+/**
+ * @summary Refines one admitted row with the model selected by provider-owned dispatch code.
+ * @param {Object} db Open better-sqlite3 database.
+ * @param {String} activityId Opaque activity id.
+ * @param {Object} activity Dispatch-bound activity refinement.
+ * @returns {void}
+ */
+export function refineProviderActivity(db, activityId, activity = {}) {
+    if (!activityId || !Object.hasOwn(activity, 'model')) return;
+
+    db.prepare(`
+        UPDATE provider_activity_log
+           SET model = @model
+         WHERE activity_id = @activityId
+           AND completed_at IS NULL
+    `).run({
+        activityId,
+        model: normalizeModel(activity.model)
+    });
+}
+
+/**
+ * @summary Completes one provider activity lifecycle with bounded structural outcome data.
+ * @param {Object} db Open better-sqlite3 database.
+ * @param {String} activityId Opaque activity id.
+ * @param {Object} outcome Completion data.
+ * @returns {void}
+ */
+export function completeProviderActivity(db, activityId, outcome = {}) {
+    if (!activityId) return;
+
+    const completedAt = Number.isFinite(outcome.completedAt) ? outcome.completedAt : Date.now();
+
+    db.prepare(`
+        UPDATE provider_activity_log
+           SET completed_at = @completedAt,
+               execution_ms = CASE
+                   WHEN started_at IS NULL THEN NULL
+                   ELSE MAX(0, @completedAt - started_at)
+               END,
+               success = @success,
+               failure_stage = @failureStage
+         WHERE activity_id = @activityId
+           AND completed_at IS NULL
+    `).run({
+        activityId,
+        completedAt,
+        success     : outcome.success === true ? 1 : 0,
+        failureStage: outcome.success === true ? null : normalizeEnum(outcome.failureStage, FAILURE_STAGES)
+    });
+}
+
+/**
+ * @summary Creates queue lifecycle callbacks that forward only bounded activity metadata to a recorder.
+ * Recorder failures are swallowed so diagnostics cannot change provider scheduling or results.
+ * @param {Object} options Lifecycle configuration.
+ * @returns {Object}
+ */
+export function createProviderActivityLifecycle({recorder, activity = {}, queueDisposition = 'neo-queued'} = {}) {
+    let activityId              = null,
+        dispatchedModel         = null,
+        dispatchModelConflicted = false;
+
+    const invoke = (method, ...args) => {
+        try {
+            return recorder?.[method]?.(...args);
+        } catch {
+            return null;
+        }
+    };
+
+    return {
+        onEnqueued({enqueuedAt}) {
+            activityId = invoke('beginProviderActivity', {
+                ...activity,
+                enqueuedAt,
+                queueDisposition
+            }) || null;
+        },
+
+        onStarted({startedAt}) {
+            invoke('startProviderActivity', activityId, startedAt);
+        },
+
+        onDispatch(dispatchActivity = {}) {
+            if (!Object.hasOwn(dispatchActivity, 'model')) return;
+
+            const model = dispatchActivity.model;
+
+            if (dispatchModelConflicted) return;
+            if (dispatchedModel === null) {
+                dispatchedModel = model;
+            } else if (model !== dispatchedModel) {
+                dispatchModelConflicted = true;
+            } else {
+                return;
+            }
+
+            invoke('refineProviderActivity', activityId, {
+                model: dispatchModelConflicted ? 'unknown' : model
+            });
+        },
+
+        onSettled({completedAt, failureStage = 'provider', success}) {
+            invoke('completeProviderActivity', activityId, {
+                completedAt,
+                failureStage,
+                success
+            });
+        }
+    };
+}
+
+/**
+ * @summary Executes a provider call that has no Neo-owned queue while recording a truthful null wait.
+ * @param {Object} options Activity wrapper options.
+ * @param {Function} options.task Provider-call thunk.
+ * @param {Object} [options.recorder] Best-effort provider activity recorder.
+ * @param {Object} [options.activity] Bounded activity descriptor.
+ * @param {Function} [options.now=Date.now] Clock seam.
+ * @returns {Promise<*>}
+ */
+export async function observeUnqueuedProviderActivity({task, recorder, activity = {}, now = Date.now}) {
+    const lifecycle = createProviderActivityLifecycle({
+        recorder,
+        activity,
+        queueDisposition: 'not-applicable'
+    });
+    const startedAt = now();
+
+    lifecycle.onEnqueued({enqueuedAt: startedAt});
+    lifecycle.onStarted({startedAt});
+
+    try {
+        const result = await task();
+
+        lifecycle.onSettled({completedAt: now(), success: true});
+        return result;
+    } catch (error) {
+        lifecycle.onSettled({completedAt: now(), success: false});
+        throw error;
+    }
+}
+
+/**
+ * @summary Returns bounded aggregate, in-flight, and recent provider activity projections.
+ * @param {Object} db Open better-sqlite3 database.
+ * @param {Object} options Observer bounds.
+ * @returns {Object}
+ */
+export function getProviderActivityMetrics(db, {sinceTs, limit, now = Date.now()} = {}) {
+    const
+        aggregates = db.prepare(`
+            SELECT service, operation_stage, role, provider, model, priority, queue_disposition,
+                   COUNT(*) AS calls,
+                   SUM(CASE WHEN success = 0 THEN 1 ELSE 0 END) AS failures,
+                   SUM(CASE WHEN completed_at IS NULL THEN 1 ELSE 0 END) AS in_flight,
+                   ROUND(AVG(queue_wait_ms), 2) AS avg_queue_wait_ms,
+                   MAX(queue_wait_ms) AS max_queue_wait_ms,
+                   ROUND(AVG(execution_ms), 2) AS avg_execution_ms,
+                   MAX(execution_ms) AS max_execution_ms,
+                   MAX(COALESCE(completed_at, started_at, enqueued_at)) AS last_seen_at
+              FROM provider_activity_log
+             WHERE enqueued_at >= @sinceTs
+             GROUP BY service, operation_stage, role, provider, model, priority, queue_disposition
+             ORDER BY calls DESC, operation_stage ASC
+             LIMIT @limit
+        `).all({sinceTs, limit}),
+        totalActivities = db.prepare(`
+            SELECT COUNT(*) AS total
+              FROM provider_activity_log
+             WHERE enqueued_at >= @sinceTs
+        `).get({sinceTs})?.total || 0,
+        totalInFlight = db.prepare(`
+            SELECT COUNT(*) AS total
+              FROM provider_activity_log
+             WHERE enqueued_at >= @sinceTs
+               AND completed_at IS NULL
+        `).get({sinceTs})?.total || 0,
+        inFlightRows = db.prepare(`
+            SELECT activity_id, service, operation_stage, role, provider, model, priority,
+                   enqueued_at, started_at, queue_disposition, queue_wait_ms
+              FROM provider_activity_log
+             WHERE enqueued_at >= @sinceTs
+               AND completed_at IS NULL
+             ORDER BY enqueued_at ASC, activity_id ASC
+             LIMIT @limit
+        `).all({sinceTs, limit}),
+        recentRows = db.prepare(`
+            SELECT activity_id, service, operation_stage, role, provider, model, priority,
+                   enqueued_at, started_at, completed_at, queue_disposition, queue_wait_ms,
+                   execution_ms, success, failure_stage
+              FROM provider_activity_log
+             WHERE completed_at >= @sinceTs
+             ORDER BY completed_at DESC, activity_id ASC
+             LIMIT @limit
+        `).all({sinceTs, limit});
+
+    const projectBase = row => ({
+        activityId      : row.activity_id,
+        service         : row.service,
+        operationStage  : row.operation_stage,
+        role            : row.role,
+        provider        : row.provider,
+        model           : row.model,
+        priority        : row.priority,
+        enqueuedAt      : new Date(row.enqueued_at).toISOString(),
+        startedAt       : row.started_at === null ? null : new Date(row.started_at).toISOString(),
+        queueDisposition: row.queue_disposition,
+        queueWaitMs     : row.queue_wait_ms ?? null
+    });
+
+    return {
+        status    : 'ok',
+        totalActivities,
+        totalInFlight,
+        aggregates: aggregates.map(row => ({
+            service         : row.service,
+            operationStage  : row.operation_stage,
+            role            : row.role,
+            provider        : row.provider,
+            model           : row.model,
+            priority        : row.priority,
+            queueDisposition: row.queue_disposition,
+            calls           : row.calls,
+            failures        : row.failures || 0,
+            inFlight        : row.in_flight || 0,
+            avgQueueWaitMs  : row.avg_queue_wait_ms ?? null,
+            maxQueueWaitMs  : row.max_queue_wait_ms ?? null,
+            avgExecutionMs  : row.avg_execution_ms ?? null,
+            maxExecutionMs  : row.max_execution_ms ?? null,
+            lastSeenAt      : row.last_seen_at === null ? null : new Date(row.last_seen_at).toISOString()
+        })),
+        inFlight: inFlightRows.map(row => ({
+            ...projectBase(row),
+            elapsedMs: Math.max(0, now - row.enqueued_at)
+        })),
+        recentCompletions: recentRows.map(row => ({
+            ...projectBase(row),
+            completedAt : new Date(row.completed_at).toISOString(),
+            executionMs : row.execution_ms ?? null,
+            success     : row.success === 1,
+            failureStage: row.failure_stage ?? null
+        }))
+    };
+}

--- a/ai/services/shared/providerActivityStatusStore.mjs
+++ b/ai/services/shared/providerActivityStatusStore.mjs
@@ -1,0 +1,213 @@
+import fs      from 'node:fs';
+import fsExtra from 'fs-extra';
+import path    from 'node:path';
+import {
+    enterLifecycleGuard,
+    exitLifecycleGuard,
+    verifyLifecycleGuardOwnership
+} from '../../daemons/shared/lifecycleGuard.mjs';
+
+const
+    STATUS_SCHEMA_VERSION       = 1,
+    STATUS_GUARD_STALE_AFTER_MS = 2000,
+    STATUS_PUBLICATION_ATTEMPTS = 3,
+    STATUS_PUBLICATION_RETRY_MS = 25,
+    RECORDER_KEYS               = Object.freeze(['knowledge-base', 'memory-core']),
+    RECORDER_SET                = new Set(RECORDER_KEYS);
+
+/**
+ * @summary Resolves one allowlisted recorder's bounded status sidecar beside the shared SQLite artifact.
+ * @param {String} dbPath Shared telemetry database path.
+ * @param {'knowledge-base'|'memory-core'} recorder Recorder owner.
+ * @returns {String|null}
+ */
+export function resolveProviderActivityStatusFile(dbPath, recorder) {
+    if (!RECORDER_SET.has(recorder)) {
+        throw new TypeError(`providerActivityStatusStore: unsupported recorder '${recorder}'`);
+    }
+    if (typeof dbPath !== 'string' || !dbPath.trim() || dbPath === ':memory:') return null;
+
+    return `${dbPath}.provider-activity-${recorder}.json`;
+}
+
+/**
+ * @summary Validates the exact non-sensitive status payload shape.
+ * @param {*} value Candidate decoded payload.
+ * @param {String} recorder Expected recorder owner.
+ * @returns {Boolean}
+ */
+function isValidStatus(value, recorder) {
+    if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
+
+    const keys = Object.keys(value).sort();
+
+    return keys.join(',') === 'lastFailureAt,lastSuccessAt,recorder,schemaVersion'
+        && value.schemaVersion === STATUS_SCHEMA_VERSION
+        && value.recorder === recorder
+        && (value.lastSuccessAt === null || Number.isFinite(value.lastSuccessAt))
+        && (value.lastFailureAt === null || Number.isFinite(value.lastFailureAt));
+}
+
+/**
+ * @summary Loads one existing status payload without creating or repairing any artifact.
+ * @param {String|null} file Status sidecar path.
+ * @param {String} recorder Expected recorder owner.
+ * @returns {Object|null}
+ */
+function loadStatus(file, recorder) {
+    if (!file || !fs.existsSync(file)) return null;
+
+    try {
+        const value = JSON.parse(fs.readFileSync(file, 'utf8'));
+
+        return isValidStatus(value, recorder) ? value : null;
+    } catch {
+        return null;
+    }
+}
+
+/**
+ * @summary Creates one serialized atomic writer for a recorder-owned provider status sidecar.
+ *
+ * Provider calls never await routine status publication. The writer retains monotonic pending maxima,
+ * re-reads and merges the shared payload inside Neo's owner-token lifecycle guard, then replaces a 0600
+ * temporary sibling atomically. The guard is PID-independent across container namespaces; a failed
+ * publication therefore remains pending for the next attempt instead of being erased by later success.
+ * No exception message, path, payload, label, or caller identity enters the sidecar.
+ *
+ * @param {Object} options Writer options.
+ * @param {String} options.dbPath Shared telemetry database path.
+ * @param {'knowledge-base'|'memory-core'} options.recorder Recorder owner.
+ * @param {Function} [options.now=Date.now] Clock seam.
+ * @returns {Object}
+ */
+export function createProviderActivityStatusWriter({dbPath, recorder, now = Date.now} = {}) {
+    const file    = resolveProviderActivityStatusFile(dbPath, recorder);
+    const pending = {
+        lastSuccessAt: null,
+        lastFailureAt: null
+    };
+    let writeChain = Promise.resolve(),
+        sequence   = 0;
+
+    const publish = (field, timestamp = now()) => {
+        if (!file || !Number.isFinite(timestamp)) return Promise.resolve();
+
+        pending[field] = Math.max(pending[field] ?? 0, timestamp);
+
+        writeChain = writeChain.then(async () => {
+            let lastError;
+
+            for (let attempt = 0; attempt < STATUS_PUBLICATION_ATTEMPTS; attempt++) {
+                try {
+                    await fs.promises.mkdir(path.dirname(file), {recursive: true});
+
+                    const guard = await enterLifecycleGuard({
+                        leasePath        : file,
+                        fsModule         : fsExtra,
+                        guardStaleAfterMs: STATUS_GUARD_STALE_AFTER_MS
+                    });
+
+                    if (!guard) {
+                        throw new Error('providerActivityStatusStore: status merge guard unavailable');
+                    }
+
+                    try {
+                        const current = loadStatus(file, recorder) || {
+                                  schemaVersion: STATUS_SCHEMA_VERSION,
+                                  recorder,
+                                  lastSuccessAt: null,
+                                  lastFailureAt: null
+                              },
+                              snapshot = {
+                                  ...current,
+                                  lastSuccessAt: Math.max(current.lastSuccessAt ?? 0, pending.lastSuccessAt ?? 0) || null,
+                                  lastFailureAt: Math.max(current.lastFailureAt ?? 0, pending.lastFailureAt ?? 0) || null
+                              },
+                              temp = `${file}.${process.pid}.${++sequence}.tmp`;
+
+                        try {
+                            await fs.promises.writeFile(temp, JSON.stringify(snapshot), {encoding: 'utf8', mode: 0o600});
+
+                            if (!await verifyLifecycleGuardOwnership({
+                                ownerFilePath: guard.ownerFilePath,
+                                fsModule     : fsExtra
+                            })) {
+                                throw new Error('providerActivityStatusStore: status merge guard ownership lost');
+                            }
+
+                            await fs.promises.rename(temp, file);
+                        } finally {
+                            await fs.promises.unlink(temp).catch(() => {});
+                        }
+                    } finally {
+                        await exitLifecycleGuard({
+                            ownerFilePath: guard.ownerFilePath,
+                            fsModule     : fsExtra
+                        });
+                    }
+
+                    return;
+                } catch (error) {
+                    lastError = error;
+                }
+
+                if (attempt + 1 < STATUS_PUBLICATION_ATTEMPTS) {
+                    await new Promise(resolve => setTimeout(resolve, STATUS_PUBLICATION_RETRY_MS));
+                }
+            }
+
+            throw lastError || new Error('providerActivityStatusStore: status publication failed');
+        }).catch(() => {
+            // Retain pending maxima for the next publication attempt. The shared recorder file is
+            // another process's authority too, so a writer that never acquired (or lost) the guard
+            // must not delete it outside the owner-token critical section.
+        });
+
+        return writeChain;
+    };
+
+    return {
+        file,
+        flush         : () => writeChain,
+        publishFailure: timestamp => publish('lastFailureAt', timestamp),
+        publishSuccess: timestamp => publish('lastSuccessAt', timestamp)
+    };
+}
+
+/**
+ * @summary Reads recorder-owned status sidecars without creating, repairing, or updating them.
+ * @param {Object} options Observer options.
+ * @param {String} options.dbPath Shared telemetry database path.
+ * @param {Number} options.sinceTs Effective observer-window start timestamp.
+ * @param {String[]} [options.requiredRecorders=RECORDER_KEYS] Sidecars required for availability.
+ * @returns {{status: 'ok'|'partial'|'unavailable'}}
+ */
+export function inspectProviderActivityStatus({
+    dbPath,
+    sinceTs,
+    requiredRecorders = RECORDER_KEYS
+} = {}) {
+    if (dbPath === ':memory:') return {status: 'ok'};
+
+    let recentFailure = false;
+
+    for (const recorder of RECORDER_KEYS) {
+        const file     = resolveProviderActivityStatusFile(dbPath, recorder),
+              required = requiredRecorders.includes(recorder);
+
+        if (!file || !fs.existsSync(file)) {
+            if (required) return {status: 'unavailable'};
+            continue;
+        }
+
+        const status = loadStatus(file, recorder);
+
+        if (!status) return {status: required ? 'unavailable' : 'partial'};
+        if (Number.isFinite(status.lastFailureAt) && status.lastFailureAt >= sinceTs) {
+            recentFailure = true;
+        }
+    }
+
+    return {status: recentFailure ? 'partial' : 'ok'};
+}

--- a/ai/services/shared/vector/chromaClientPrimitives.mjs
+++ b/ai/services/shared/vector/chromaClientPrimitives.mjs
@@ -1,4 +1,5 @@
 import {knownEmbeddingFunctions, registerEmbeddingFunction} from 'chromadb';
+import {getProviderActivityContext}                         from '../providerActivityLedger.mjs';
 
 export const CHROMA_DYNAMIC_TEXT_EMBEDDING_FUNCTION_NAME = 'dynamic_text_embedding_service';
 const CHROMA_COLLECTION_NOT_FOUND_RE = /does not exist|not found|not be found|could not be found|404/i;
@@ -41,26 +42,41 @@ class NeoDummyEmbeddingFunction {
  *
  * @param {Object} [options]
  * @param {Function} [options.providerResolver] Returns the active embedding provider.
+ * @param {String} [options.operationStage='unknown'] Stable provider activity stage.
+ * @param {String} [options.service='unknown'] Stable service owner.
  * @returns {Object}
  */
-export function createDynamicTextEmbeddingFunction({providerResolver = null} = {}) {
+export function createDynamicTextEmbeddingFunction({
+    providerResolver = null,
+    operationStage   = 'unknown',
+    service          = 'unknown'
+} = {}) {
     const embeddingFunction = {
         generate: async (texts) => {
             const {default: TextEmbeddingService} = await import('../../memory-core/TextEmbeddingService.mjs');
             const {default: aiConfig}             = await import('../../../mcp/server/memory-core/config.mjs');
             const provider                        = providerResolver?.() ?? aiConfig.embeddingProvider;
+            const activity                        = getProviderActivityContext();
 
             // Route the whole batch through embedTexts (the batch path: 1h request timeout,
             // sequential chunks of batchEmbeddingChunkSize) — NOT per-text embedText fan-out. The
             // interactive embedText path applies the 15s contentionTimeoutMs, and a Promise.all over
             // the batch storms the single local embedder into self-contention, cutting bulk adds
             // (WAL drain / graph ingestion) short with spurious timeouts.
-            return TextEmbeddingService.embedTexts(texts, provider)
+            return TextEmbeddingService.embedTexts(texts, provider, {
+                operationLabel: 'Chroma dynamic text embedding',
+                operationStage: activity?.operationStage || operationStage,
+                service       : activity?.service || service
+            })
         },
         name       : CHROMA_DYNAMIC_TEXT_EMBEDDING_FUNCTION_NAME,
         getConfig  : () => ({}),
         constructor: {
-            buildFromConfig: () => createDynamicTextEmbeddingFunction({providerResolver})
+            buildFromConfig: () => createDynamicTextEmbeddingFunction({
+                providerResolver,
+                operationStage,
+                service
+            })
         }
     };
 

--- a/test/playwright/unit/ai/daemons/embed/drainCycle.spec.mjs
+++ b/test/playwright/unit/ai/daemons/embed/drainCycle.spec.mjs
@@ -17,8 +17,9 @@ import {
     startDrainLoop,
     MAX_RECORD_COOLDOWN_MS
 } from '../../../../../../ai/daemons/embed/drainCycle.mjs';
-import {createDrainDispositionTracker} from '../../../../../../ai/daemons/shared/drainDisposition.mjs';
+import {createDrainDispositionTracker}          from '../../../../../../ai/daemons/shared/drainDisposition.mjs';
 import {OPENAI_COMPATIBLE_REQUEST_TIMEOUT_CODE} from '../../../../../../ai/provider/createTimeoutError.mjs';
+import {getProviderActivityContext}             from '../../../../../../ai/services/shared/providerActivityLedger.mjs';
 
 /**
  * Embed-daemon drain cycle (`ai/daemons/embed/drainCycle.mjs`) — falsifier coverage for the
@@ -379,6 +380,29 @@ test.describe('Neo.ai.daemons.embed.drainCycle', () => {
         expect(failed).toHaveLength(1);
         expect(failed[0].record.id).toBe('y');
         expect(failed[0].error.message).toContain('poison');
+    });
+
+    test('embedBatch owns WAL attribution only around its collection writes', async () => {
+        const records    = [{...record('x', Date.now()), segmentKey: 'unused'}];
+        const collection = createFakeCollection();
+        const contexts   = [];
+
+        collection.onAdd = () => contexts.push(getProviderActivityContext());
+
+        await embedBatch({
+            collection,
+            records,
+            maxRetries   : 0,
+            backoffBaseMs: 1,
+            sleep        : async () => {},
+            log          : () => {}
+        });
+
+        expect(contexts).toEqual([{
+            operationStage: 'mc-wal-drain-embedding',
+            service       : 'memory-core'
+        }]);
+        expect(getProviderActivityContext()).toBeNull();
     });
 
     test('embedBatch: provider contention yields the cycle — one attempt, no isolation pass (#16012)', async () => {

--- a/test/playwright/unit/ai/mcp/validation/OpenApiValidatorCompliance.spec.mjs
+++ b/test/playwright/unit/ai/mcp/validation/OpenApiValidatorCompliance.spec.mjs
@@ -538,6 +538,79 @@ test.describe('OpenApiValidator: strict-client JSON-Schema compliance', () => {
         expect(() => new Ajv({strict: false}).compile(schema)).not.toThrow();
     });
 
+    test('memory-core provider activity output is bounded, nullable where unmeasured, and AJV-compatible (#16770)', () => {
+        const
+            doc        = yaml.load(fs.readFileSync(path.join(repoRoot, 'ai/mcp/server/memory-core/openapi.yaml'), 'utf8')),
+            operation  = doc.paths['/diagnostics/tool-metrics'].post,
+            schema     = toOpenApiJsonSchema(buildOutputZodSchema(doc, operation)),
+            response   = doc.components.schemas.ProviderActivityResponse,
+            aggregate  = doc.components.schemas.ProviderActivityAggregate,
+            inFlight   = doc.components.schemas.ProviderActivityInFlight,
+            completion = doc.components.schemas.ProviderActivityCompletion;
+
+        expect(doc.components.schemas.MemoryCoreToolMetricsResponse.required).toContain('providerActivity');
+        expect(response.properties.status.enum).toEqual(['ok', 'partial', 'disabled', 'unavailable']);
+        expect(response.required).toEqual([
+            'status',
+            'totalActivities',
+            'totalInFlight',
+            'aggregates',
+            'inFlight',
+            'recentCompletions'
+        ]);
+        expect(Object.keys(aggregate.properties)).toEqual([
+            'service',
+            'operationStage',
+            'role',
+            'provider',
+            'model',
+            'priority',
+            'queueDisposition',
+            'calls',
+            'failures',
+            'inFlight',
+            'avgQueueWaitMs',
+            'maxQueueWaitMs',
+            'avgExecutionMs',
+            'maxExecutionMs',
+            'lastSeenAt'
+        ]);
+        expect(Object.keys(inFlight.properties)).toEqual([
+            'activityId',
+            'service',
+            'operationStage',
+            'role',
+            'provider',
+            'model',
+            'priority',
+            'enqueuedAt',
+            'startedAt',
+            'queueDisposition',
+            'queueWaitMs',
+            'elapsedMs'
+        ]);
+        expect(Object.keys(completion.properties)).toEqual([
+            'activityId',
+            'service',
+            'operationStage',
+            'role',
+            'provider',
+            'model',
+            'priority',
+            'enqueuedAt',
+            'startedAt',
+            'completedAt',
+            'queueDisposition',
+            'queueWaitMs',
+            'executionMs',
+            'success',
+            'failureStage'
+        ]);
+        expect(completion.properties.queueDisposition.enum).toContain('not-applicable');
+        expect(completion.properties.queueWaitMs.nullable).toBe(true);
+        expect(() => new Ajv({strict: false}).compile(schema)).not.toThrow();
+    });
+
     test('knowledge-base query schemas expose skill, adr, and concept content types', async () => {
         const expectedTypes = ['all', 'blog', 'guide', 'src', 'example', 'ticket', 'release', 'test', 'skill', 'adr', 'concept'],
               doc           = yaml.load(fs.readFileSync(path.join(repoRoot, 'ai/mcp/server/knowledge-base/openapi.yaml'), 'utf8')),

--- a/test/playwright/unit/ai/provider/InteractiveBatchQueue.spec.mjs
+++ b/test/playwright/unit/ai/provider/InteractiveBatchQueue.spec.mjs
@@ -13,9 +13,9 @@ setup({
     }
 });
 
-import {test, expect}    from '@playwright/test';
-import Neo               from '../../../../../src/Neo.mjs';
-import * as core         from '../../../../../src/core/_export.mjs';
+import {test, expect}        from '@playwright/test';
+import Neo                   from '../../../../../src/Neo.mjs';
+import * as core             from '../../../../../src/core/_export.mjs';
 import InteractiveBatchQueue from '../../../../../ai/provider/InteractiveBatchQueue.mjs';
 
 /**
@@ -79,8 +79,8 @@ test.describe('Neo.ai.provider.InteractiveBatchQueue', () => {
     });
 
     test('never runs two tasks concurrently (one-at-a-time on the serialized lane)', async () => {
-        const queue   = new InteractiveBatchQueue();
-        let inFlight  = 0,
+        const queue    = new InteractiveBatchQueue();
+        let   inFlight = 0,
             maxInFlight = 0;
 
         const task = () => async () => {
@@ -109,5 +109,49 @@ test.describe('Neo.ai.provider.InteractiveBatchQueue', () => {
         await expect(failing).rejects.toThrow('boom');
         await expect(after).resolves.toBe('ok');
         expect(ran).toEqual(['after']); // the lane kept draining after the rejection
+    });
+
+    test('records deterministic queue wait and execution without changing interactive-first order', async () => {
+        const ticks     = [0, 10, 20, 30, 40, 50, 60, 70, 80];
+        const queue     = new InteractiveBatchQueue({now: () => ticks.shift()});
+        const ran       = [];
+        const events    = [];
+        const gate      = deferred();
+        const lifecycle = label => ({
+            onEnqueued: event => events.push({label, type: 'enqueued', ...event}),
+            onStarted : event => events.push({label, type: 'started',  ...event}),
+            onSettled : event => events.push({label, type: 'settled',  ...event})
+        });
+
+        const p1 = queue.enqueue(async () => { ran.push('B1'); await gate.promise }, 'batch', lifecycle('B1'));
+        const p2 = queue.enqueue(async () => { ran.push('B2') }, 'batch', lifecycle('B2'));
+        const p3 = queue.enqueue(async () => { ran.push('I1') }, 'interactive', lifecycle('I1'));
+
+        gate.resolve();
+        await Promise.all([p1, p2, p3]);
+
+        expect(ran).toEqual(['B1', 'I1', 'B2']);
+        expect(events.filter(event => event.label === 'I1')).toEqual([
+            {label: 'I1', type: 'enqueued', enqueuedAt: 30, priority: 'interactive'},
+            {label: 'I1', type: 'started', enqueuedAt: 30, priority: 'interactive', queueWaitMs: 20, startedAt: 50},
+            {label: 'I1', type: 'settled', completedAt: 60, enqueuedAt: 30, executionMs: 10, priority: 'interactive', startedAt: 50, success: true}
+        ]);
+    });
+
+    test('lifecycle observer failures cannot alter task results or lane draining', async () => {
+        const queue             = new InteractiveBatchQueue();
+        const throwingLifecycle = {
+            onEnqueued() { throw new Error('observer enqueue failed') },
+            onStarted()  { throw new Error('observer start failed') },
+            onSettled()  { throw new Error('observer settle failed') }
+        };
+
+        const first  = queue.enqueue(async () => 'ok', 'interactive', throwingLifecycle);
+        const second = queue.enqueue(async () => { throw new Error('task failed') }, 'batch', throwingLifecycle);
+        const third  = queue.enqueue(async () => 'after', 'batch', throwingLifecycle);
+
+        await expect(first).resolves.toBe('ok');
+        await expect(second).rejects.toThrow('task failed');
+        await expect(third).resolves.toBe('after');
     });
 });

--- a/test/playwright/unit/ai/services/graph/SemanticGraphExtractor.spec.mjs
+++ b/test/playwright/unit/ai/services/graph/SemanticGraphExtractor.spec.mjs
@@ -442,7 +442,8 @@ test.describe('Neo.ai.daemons.services.SemanticGraphExtractor', () => {
     });
 
     test('REM marathon raw-turn path exposes active diagnostics and output budget before provider return (#13984)', async () => {
-        const originalOverrides = {
+        const MemoryCoreRecorderService = (await import('../../../../../../ai/services/memory-core/MemoryCoreRecorderService.mjs')).default;
+        const originalOverrides         = {
                   [ENV.GRAPH_PROVIDER]   : aiConfig.graphProvider,
                   [ENV.REM_RUN_STATE_DIR]: aiConfig.remRunStateDir
               },
@@ -451,6 +452,7 @@ test.describe('Neo.ai.daemons.services.SemanticGraphExtractor', () => {
               expectedGraphOutputLimit     = aiConfig.localModels.chat.graphOutputLimitTokens,
               expectedGraphModel           = aiConfig.openAiCompatible.model,
               baseGenerate                 = OpenAiCompatible.prototype.generate,
+              baseBeginProviderActivity    = MemoryCoreRecorderService.beginProviderActivity,
               remRunStateDir                = path.resolve(process.cwd(), 'tmp', `active-rem-call-${process.pid}-${Date.now()}`),
               turnDocuments                 = Array.from(
                   {length: 192},
@@ -458,13 +460,19 @@ test.describe('Neo.ai.daemons.services.SemanticGraphExtractor', () => {
               );
 
         let activeOnDiskAfterCall, result;
-        const providerCalls = [];
+        const providerCalls      = [];
+        const providerActivities = [];
 
         try {
             setConfigOverrides({
                 [ENV.GRAPH_PROVIDER]   : 'openAiCompatible',
                 [ENV.REM_RUN_STATE_DIR]: remRunStateDir
             });
+
+            MemoryCoreRecorderService.beginProviderActivity = entry => {
+                providerActivities.push(entry);
+                return null;
+            };
 
             OpenAiCompatible.prototype.generate = async function(messages, options) {
                 const activeDuringCall       = {...SemanticGraphExtractor.activeTriVectorCall},
@@ -494,6 +502,7 @@ test.describe('Neo.ai.daemons.services.SemanticGraphExtractor', () => {
             activeOnDiskAfterCall = await readActiveRemCallState({dir: remRunStateDir});
         } finally {
             OpenAiCompatible.prototype.generate = baseGenerate;
+            MemoryCoreRecorderService.beginProviderActivity = baseBeginProviderActivity;
             setConfigOverrides(originalOverrides);
             fs.rmSync(remRunStateDir, {recursive: true, force: true});
         }
@@ -509,6 +518,11 @@ test.describe('Neo.ai.daemons.services.SemanticGraphExtractor', () => {
             maxCompletionTokens: expectedGraphOutputLimit,
             operationLabel     : expect.stringContaining('2d993feb-ea2f-4468-8fbd-c53e62365f4d')
         });
+        expect(secondCall.options).not.toHaveProperty('operationStage');
+        expect(providerActivities).toContainEqual(expect.objectContaining({
+            operationStage: 'rem-tri-vector',
+            service       : 'dream-pipeline'
+        }));
         expect(secondCall.activeDuringCall).toMatchObject({
             phase                    : 'triVector',
             sessionId                : '2d993feb-ea2f-4468-8fbd-c53e62365f4d',

--- a/test/playwright/unit/ai/services/graph/providerDispatch.spec.mjs
+++ b/test/playwright/unit/ai/services/graph/providerDispatch.spec.mjs
@@ -29,18 +29,18 @@ test.describe('buildGraphProvider (#11965 Sub-2 cycle-3)', () => {
 
     test('returns configured graph provider without generic modelProvider fallback (#12059)', () => {
         expect(resolveGraphModelProvider({
-            modelProvider : 'gemini',
-            graphProvider : 'openAiCompatible'
+            modelProvider: 'gemini',
+            graphProvider: 'openAiCompatible'
         })).toBe('openAiCompatible');
 
         expect(resolveGraphModelProvider({
-            modelProvider : 'gemini',
-            graphProvider : 'ollama'
+            modelProvider: 'gemini',
+            graphProvider: 'ollama'
         })).toBe('ollama');
 
         expect(resolveGraphModelProvider({
-            modelProvider : 'ollama',
-            graphProvider : 'openAiCompatible'
+            modelProvider: 'ollama',
+            graphProvider: 'openAiCompatible'
         })).toBe('openAiCompatible');
 
         expect(resolveGraphModelProvider({
@@ -48,8 +48,8 @@ test.describe('buildGraphProvider (#11965 Sub-2 cycle-3)', () => {
         })).toBeUndefined();
 
         expect(resolveGraphModelProvider({
-            modelProvider : 'openAiCompatible',
-            graphProvider : 'bogus-provider'
+            modelProvider: 'openAiCompatible',
+            graphProvider: 'bogus-provider'
         })).toBe('bogus-provider');
     });
 
@@ -157,5 +157,55 @@ test.describe('buildGraphProvider (#11965 Sub-2 cycle-3)', () => {
 
         const result = await provider.generate('hello world');
         expect(result.content).toBe('oai-generated');
+    });
+
+    test('records REM stages as unqueued and strips attribution controls before dispatch', async () => {
+        const calls    = [];
+        const activity = [];
+        const provider = buildGraphProvider({
+            modelProvider                  : 'openAiCompatible',
+            openAiCompatibleConfig         : {host: 'http://oai.test', model: 'graph-model'},
+            openAiCompatibleProviderFactory: () => ({
+                async generate(prompt, options) {
+                    calls.push({prompt, options});
+                    return {content: 'graph-result'};
+                }
+            }),
+            providerActivityRecorder: {
+                beginProviderActivity(entry) { activity.push({type: 'begin', entry}); return 'rem-1' },
+                startProviderActivity(id, startedAt) { activity.push({type: 'start', id, startedAt}) },
+                completeProviderActivity(id, outcome) { activity.push({type: 'complete', id, outcome}) }
+            },
+            providerActivityService: 'dream-pipeline'
+        });
+
+        const result = await provider.generate('hello graph', {
+            operationLabel: 'REM topology private-session',
+            operationStage: 'rem-topology',
+            priority      : 'batch',
+            timeoutMs     : 100
+        });
+
+        expect(result.content).toBe('graph-result');
+        expect(calls).toEqual([{
+            prompt : 'hello graph',
+            options: {
+                operationLabel: 'REM topology private-session',
+                timeoutMs     : 100
+            }
+        }]);
+        expect(activity[0]).toEqual({
+            type : 'begin',
+            entry: expect.objectContaining({
+                model           : 'graph-model',
+                operationStage  : 'rem-topology',
+                priority        : 'batch',
+                provider        : 'openAiCompatible',
+                queueDisposition: 'not-applicable',
+                role            : 'chat',
+                service         : 'dream-pipeline'
+            })
+        });
+        expect(activity.map(item => item.type)).toEqual(['begin', 'start', 'complete']);
     });
 });

--- a/test/playwright/unit/ai/services/knowledge-base/HealthService.providerReady.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/HealthService.providerReady.spec.mjs
@@ -187,12 +187,16 @@ test.describe('Neo.ai.services.knowledge-base.HealthService observed embedding r
     });
 
     test('a reachable provider that never answers is bounded by the named consumer deadline', async () => {
+        let observedOptions;
         const result = await buildKnowledgeBaseEmbeddingProbeBlock({
             cfg: {
                 embeddingProvider: 'test-provider',
                 vectorDimension  : 3
             },
-            embedText: () => new Promise(() => {}),
+            embedText: (input, provider, options) => {
+                observedOptions = options;
+                return new Promise(() => {});
+            },
             timeoutMs: 5
         });
 
@@ -202,6 +206,10 @@ test.describe('Neo.ai.services.knowledge-base.HealthService observed embedding r
             error              : 'consumer-probe-timeout:EMBEDDING_PROBE_TIMEOUT',
             errorClassification: 'consumer-probe-timeout',
             errorCode          : 'EMBEDDING_PROBE_TIMEOUT'
+        });
+        expect(observedOptions).toMatchObject({
+            operationStage: 'embedding-canary',
+            service       : 'knowledge-base'
         });
     });
 

--- a/test/playwright/unit/ai/services/knowledge-base/KBRecorderService.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/KBRecorderService.spec.mjs
@@ -13,10 +13,11 @@ setup({
     }
 });
 
-import {test, expect} from '@playwright/test';
-import Neo            from '../../../../../../src/Neo.mjs';
-import * as core      from '../../../../../../src/core/_export.mjs';
-import crypto         from 'crypto';
+import {test, expect}                  from '@playwright/test';
+import Neo                             from '../../../../../../src/Neo.mjs';
+import * as core                       from '../../../../../../src/core/_export.mjs';
+import crypto                          from 'crypto';
+import {inspectProviderActivityStatus} from '../../../../../../ai/services/shared/providerActivityStatusStore.mjs';
 
 test.describe('Neo.ai.services.knowledge-base.KBRecorderService', () => {
     let KBRecorderService;
@@ -27,7 +28,7 @@ test.describe('Neo.ai.services.knowledge-base.KBRecorderService', () => {
     });
 
     test.beforeEach(() => {
-        KBRecorderService.db.exec('DELETE FROM kb_query_log; DELETE FROM kb_query_faqs;');
+        KBRecorderService.db.exec('DELETE FROM kb_query_log; DELETE FROM kb_query_faqs; DELETE FROM provider_activity_log;');
     });
 
     test.afterAll(() => {
@@ -43,10 +44,108 @@ test.describe('Neo.ai.services.knowledge-base.KBRecorderService', () => {
             SELECT name
               FROM sqlite_master
              WHERE type = 'table'
-               AND name IN ('kb_query_log', 'kb_query_faqs')
+               AND name IN ('kb_query_log', 'kb_query_faqs', 'provider_activity_log')
         `).all();
 
-        expect(tables.map(row => row.name).sort()).toEqual(['kb_query_faqs', 'kb_query_log']);
+        expect(tables.map(row => row.name).sort()).toEqual(['kb_query_faqs', 'kb_query_log', 'provider_activity_log']);
+        expect(KBRecorderService.db.pragma('busy_timeout', {simple: true})).toBe(50);
+    });
+
+    test('writes bounded Knowledge Base provider activity into the shared ledger shape', () => {
+        const id = KBRecorderService.beginProviderActivity({
+            activityId      : 'kb-provider-activity',
+            service         : 'knowledge-base',
+            operationStage  : 'kb-query-embedding',
+            role            : 'embedding',
+            provider        : 'ollama',
+            model           : 'qwen3-embedding',
+            priority        : 'interactive',
+            enqueuedAt      : 100,
+            queueDisposition: 'not-applicable',
+            prompt          : 'must-not-persist'
+        });
+
+        KBRecorderService.startProviderActivity(id, 100);
+        KBRecorderService.completeProviderActivity(id, {completedAt: 125, success: true});
+
+        const row = KBRecorderService.db.prepare(`
+            SELECT *
+              FROM provider_activity_log
+             WHERE activity_id = ?
+        `).get(id);
+
+        expect(row).toMatchObject({
+            service          : 'knowledge-base',
+            operation_stage  : 'kb-query-embedding',
+            role             : 'embedding',
+            provider         : 'ollama',
+            queue_disposition: 'not-applicable',
+            queue_wait_ms    : null,
+            execution_ms     : 25,
+            success          : 1
+        });
+        expect(JSON.stringify(row)).not.toContain('must-not-persist');
+    });
+
+    test('keeps provider work live and discloses a locked ledger as partial', async () => {
+        const
+            Database = (await import('better-sqlite3')).default,
+            dbPath   = KBRecorderService.db.prepare('PRAGMA database_list').all()
+                .find(row => row.name === 'main').file,
+            lockDb = new Database(dbPath, {timeout: 50}),
+            sinceTs = Date.now();
+
+        try {
+            lockDb.exec('BEGIN IMMEDIATE;');
+
+            const startedAt = Date.now();
+            const id        = KBRecorderService.beginProviderActivity({
+                service         : 'knowledge-base',
+                operationStage  : 'kb-query-embedding',
+                role            : 'embedding',
+                provider        : 'ollama',
+                model           : 'qwen3-embedding',
+                priority        : 'interactive',
+                enqueuedAt      : startedAt,
+                queueDisposition: 'not-applicable'
+            });
+
+            expect(id).toBeNull();
+            expect(Date.now() - startedAt).toBeLessThan(250);
+            await KBRecorderService.flushProviderActivityStatus();
+
+            expect(KBRecorderService.db.prepare('SELECT COUNT(*) AS count FROM provider_activity_log').get().count).toBe(0);
+            expect(inspectProviderActivityStatus({
+                dbPath,
+                sinceTs,
+                requiredRecorders: ['knowledge-base']
+            })).toEqual({status: 'partial'});
+        } finally {
+            try { lockDb.exec('ROLLBACK;'); } catch (e) {}
+            lockDb.close();
+        }
+
+        const id = KBRecorderService.beginProviderActivity({
+            service         : 'knowledge-base',
+            operationStage  : 'kb-query-embedding',
+            role            : 'embedding',
+            provider        : 'ollama',
+            model           : 'qwen3-embedding',
+            priority        : 'interactive',
+            enqueuedAt      : Date.now(),
+            queueDisposition: 'not-applicable'
+        });
+
+        KBRecorderService.startProviderActivity(id, Date.now());
+        KBRecorderService.completeProviderActivity(id, {completedAt: Date.now(), success: true});
+        await KBRecorderService.flushProviderActivityStatus();
+
+        expect(id).toBeTruthy();
+        expect(inspectProviderActivityStatus({
+            dbPath,
+            sinceTs,
+            requiredRecorders: ['knowledge-base']
+        })).toEqual({status: 'partial'});
     });
 
     test('captures KB MCP tool calls through the per-server wrapper', async () => {

--- a/test/playwright/unit/ai/services/knowledge-base/QueryService.queryDocuments.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/QueryService.queryDocuments.spec.mjs
@@ -56,8 +56,12 @@ test.describe('Neo.ai.services.knowledge-base.QueryService#queryDocuments', () =
     });
 
     function installQueryStub(metadatasOrFactory, capture) {
-        capture.options = [];
-        TextEmbeddingService.embedText = async () => [0.1, 0.2, 0.3];
+        capture.options        = [];
+        capture.embeddingCalls = [];
+        TextEmbeddingService.embedText = async (...args) => {
+            capture.embeddingCalls.push(args);
+            return [0.1, 0.2, 0.3];
+        };
 
         ChromaManager.getKnowledgeBaseCollection = async () => ({
             query: async options => {
@@ -95,6 +99,10 @@ test.describe('Neo.ai.services.knowledge-base.QueryService#queryDocuments', () =
 
         expect(capture.options[0].queryEmbeddings).toEqual([[0.1, 0.2, 0.3]]);
         expect(capture.options[0].where).toEqual({type: 'guide'});
+        expect(capture.embeddingCalls[0][2]).toMatchObject({
+            operationStage: 'kb-query-embedding',
+            service       : 'knowledge-base'
+        });
         expect(result.topResult).toBe('learn/guides/testing/UnitTesting.md');
         expect(result.results).toHaveLength(1);
     });

--- a/test/playwright/unit/ai/services/knowledge-base/SearchService.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/SearchService.spec.mjs
@@ -298,6 +298,7 @@ test.describe('Neo.ai.services.knowledge-base.SearchService', () => {
         // Wiring: ask must pass the interactive budget + a safe operation label to the provider.
         expect(capturedOptions).toBeTruthy();
         expect(capturedOptions.operationLabel).toBe('ask_knowledge_base synthesis');
+        expect(capturedOptions.operationStage).toBe('kb-ask-synthesis');
         expect(Object.prototype.hasOwnProperty.call(capturedOptions, 'timeoutMs')).toBe(true);
 
         // Degraded envelope: references preserved, bounded timeout reason, never collapses to "no documents".
@@ -335,12 +336,78 @@ test.describe('Neo.ai.services.knowledge-base.SearchService', () => {
         expect(result.degradedCode).toBe('synthesis_timeout');
     });
 
+    test('composes query embedding before synthesis and skips synthesis on an empty result', async () => {
+        const
+            ChromaManager                  = (await import('../../../../../../ai/services/knowledge-base/ChromaManager.mjs')).default,
+            TextEmbeddingService           = (await import('../../../../../../ai/services/memory-core/TextEmbeddingService.mjs')).default,
+            originalGetCollection          = ChromaManager.getKnowledgeBaseCollection,
+            originalEmbedText              = TextEmbeddingService.embedText,
+            originalAddLexicalRescueScores = QueryService.addLexicalRescueScores;
+
+        let metadatas = [{
+                source          : tmpFileRelativeToRoot,
+                type            : 'src',
+                name            : 'fixture-source',
+                inheritanceChain: '[]'
+            }],
+            stages         = [],
+            synthesisCalls = 0;
+
+        QueryService.queryDocuments = originalQueryDocuments;
+        QueryService.addLexicalRescueScores = async () => {};
+        TextEmbeddingService.embedText = async (query, provider, options) => {
+            stages.push(options.operationStage);
+            return [0.1, 0.2, 0.3];
+        };
+        ChromaManager.getKnowledgeBaseCollection = async () => ({
+            count: async () => 1,
+            query: async () => ({metadatas: [metadatas]})
+        });
+        SearchService.model = {
+            generateContent: async (prompt, options) => {
+                synthesisCalls++;
+                stages.push(options.operationStage);
+                return {response: {text: () => 'composed-answer'}};
+            }
+        };
+
+        try {
+            const withReferences = await SearchService.ask({query: 'composed fixture', type: 'src'});
+
+            expect(withReferences.answer).toBe('composed-answer');
+            expect(stages).toEqual(['kb-query-embedding', 'kb-ask-synthesis']);
+            expect(synthesisCalls).toBe(1);
+
+            stages    = [];
+            metadatas = [];
+
+            const empty = await SearchService.ask({query: 'empty composed fixture', type: 'src'});
+
+            expect(empty.references).toEqual([]);
+            expect(stages).toEqual(['kb-query-embedding']);
+            expect(synthesisCalls).toBe(1);
+        } finally {
+            QueryService.queryDocuments = originalQueryDocuments;
+            QueryService.addLexicalRescueScores = originalAddLexicalRescueScores;
+            TextEmbeddingService.embedText = originalEmbedText;
+            ChromaManager.getKnowledgeBaseCollection = originalGetCollection;
+            SearchService.model = originalModel;
+        }
+    });
+
     test('ask names the download/sync one-liners when the collection is EMPTY (post npm-prepare decouple cold-start)', async () => {
         const ChromaManager         = (await import('../../../../../../ai/services/knowledge-base/ChromaManager.mjs')).default;
         const originalGetCollection = ChromaManager.getKnowledgeBaseCollection;
+        let   synthesisCalls        = 0;
 
         QueryService.queryDocuments = async () => ({results: []});
         ChromaManager.getKnowledgeBaseCollection = async () => ({count: async () => 0});
+        SearchService.model = {
+            async generateContent() {
+                synthesisCalls++;
+                return {response: {text: () => 'must not run'}};
+            }
+        };
 
         try {
             const result = await SearchService.ask({query: 'anything'});
@@ -348,6 +415,7 @@ test.describe('Neo.ai.services.knowledge-base.SearchService', () => {
             expect(result.answer).toContain('npm run ai:download-kb');
             expect(result.answer).toContain('npm run ai:sync-kb');
             expect(result.references).toEqual([]);
+            expect(synthesisCalls).toBe(0);
         } finally {
             ChromaManager.getKnowledgeBaseCollection = originalGetCollection;
         }

--- a/test/playwright/unit/ai/services/knowledge-base/VectorService.tenantStamping.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/VectorService.tenantStamping.spec.mjs
@@ -15,19 +15,19 @@ setup({
     }
 });
 
-import {test, expect} from '@playwright/test';
-import Neo            from '../../../../../../src/Neo.mjs';
-import * as core      from '../../../../../../src/core/_export.mjs';
-import fs             from 'fs';
-import path           from 'path';
-import os             from 'os';
+import {test, expect}  from '@playwright/test';
+import Neo             from '../../../../../../src/Neo.mjs';
+import * as core       from '../../../../../../src/core/_export.mjs';
+import fs              from 'fs';
+import path            from 'path';
+import os              from 'os';
 import {fileURLToPath} from 'url';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname  = path.dirname(__filename);
 
 /**
- * Write-side tenant isolation coverage for `VectorService.embed` (#11631).
+ * Write-side tenant isolation coverage for `VectorService.embed`.
  *
  * The tests replace ChromaDB with an in-memory spy collection and stub the embedding
  * provider, so they verify only the write-boundary contract: authoritative tenant
@@ -98,6 +98,7 @@ test.describe('VectorService.embed — tenant stamping (#11631)', () => {
     let originalConfig;
     let tmpDir, fixturePath;
     let warnCalls;
+    let embeddingCalls;
 
     test.beforeAll(async () => {
         SDK              = await import('../../../../../../ai/services.mjs');
@@ -117,18 +118,21 @@ test.describe('VectorService.embed — tenant stamping (#11631)', () => {
         originalEmbedTexts    = TextEmbeddingService.embedTexts.bind(TextEmbeddingService);
         originalWarn          = Logger.warn.bind(Logger);
         originalConfig        = {
-            batchSize              : KB_Config.data.batchSize,
-            batchDelay             : KB_Config.data.batchDelay,
-            maxRetries             : KB_Config.data.maxRetries,
-            defaultTenantId        : KB_Config.data.defaultTenantId,
-            defaultRepoSlug        : KB_Config.data.defaultRepoSlug,
-            defaultVisibility      : KB_Config.data.defaultVisibility,
-            spoofRejectionMode     : KB_Config.data.spoofRejectionMode,
-            knowledgeBase          : KB_Config.data.knowledgeBase,
-            mcpSyncMaxChunks       : KB_Config.data.mcpSyncMaxChunks
+            batchSize         : KB_Config.data.batchSize,
+            batchDelay        : KB_Config.data.batchDelay,
+            maxRetries        : KB_Config.data.maxRetries,
+            defaultTenantId   : KB_Config.data.defaultTenantId,
+            defaultRepoSlug   : KB_Config.data.defaultRepoSlug,
+            defaultVisibility : KB_Config.data.defaultVisibility,
+            spoofRejectionMode: KB_Config.data.spoofRejectionMode,
+            knowledgeBase     : KB_Config.data.knowledgeBase,
+            mcpSyncMaxChunks  : KB_Config.data.mcpSyncMaxChunks
         };
 
-        TextEmbeddingService.embedTexts = async texts => texts.map(() => new Array(384).fill(0));
+        TextEmbeddingService.embedTexts = async (...args) => {
+            embeddingCalls.push(args);
+            return args[0].map(() => new Array(384).fill(0));
+        };
 
         tmpDir      = path.resolve(os.tmpdir(), `kb-tenant-stamping-test-${process.pid}-${Date.now()}`);
         fs.mkdirSync(tmpDir, {recursive: true});
@@ -167,6 +171,7 @@ test.describe('VectorService.embed — tenant stamping (#11631)', () => {
         });
 
         warnCalls   = [];
+        embeddingCalls = [];
         Logger.warn = (...args) => warnCalls.push(args);
     });
 
@@ -195,6 +200,10 @@ test.describe('VectorService.embed — tenant stamping (#11631)', () => {
         expect(row.metadata.visibility).toBe('team');
         expect('originAgentIdentity' in row.metadata).toBe(false);
         expect(row.metadata.tenantConfigVersion).toBe(0);
+        expect(embeddingCalls[0][2]).toMatchObject({
+            operationStage: 'kb-tenant-ingestion-embedding',
+            service       : 'knowledge-base'
+        });
         expect(warnCalls).toHaveLength(0);
     });
 
@@ -244,7 +253,7 @@ test.describe('VectorService.embed — tenant stamping (#11631)', () => {
             }
         });
 
-        const row = getOnlyRow(spy);
+        const row          = getOnlyRow(spy);
         const warnedFields = warnCalls.map(([, details]) => details.field).sort();
 
         expect(row.metadata.tenantId).toBe('server-tenant');
@@ -372,7 +381,7 @@ test.describe('VectorService.embed — tenant stamping (#11631)', () => {
             tenantId: 'tenant-b',
             repoSlug: 'repo'
         });
-        const defaultHash = KB_DatabaseService.createContentHash(baseChunk);
+        const defaultHash         = KB_DatabaseService.createContentHash(baseChunk);
         const explicitDefaultHash = KB_DatabaseService.createContentHash({
             ...baseChunk,
             tenantId: 'neo-shared',
@@ -398,7 +407,7 @@ test.describe('VectorService.embed — tenant stamping (#11631)', () => {
 
         const before = Date.now();
         await KB_VectorService.embed(fixturePath);
-        const after  = Date.now();
+        const after = Date.now();
 
         const {ingestedAt} = getOnlyRow(spy).metadata;
 

--- a/test/playwright/unit/ai/services/memory-core/HealthService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/HealthService.spec.mjs
@@ -1446,6 +1446,8 @@ test.describe('HealthService #12487 — buildEmbeddingWriteCanaryBlock', () => {
                 expect(input).toBe('neo-healthcheck-embedding-write-canary');
                 expect(provider).toBe('openAiCompatible');
                 expect(options.operationLabel).toBe('Embedding write canary');
+                expect(options.operationStage).toBe('embedding-canary');
+                expect(options.service).toBe('memory-core');
                 expect(options.signal).toBeInstanceOf(AbortSignal);
                 probeSignal = options.signal;
                 return [0.1, 0.2, 0.3];

--- a/test/playwright/unit/ai/services/memory-core/MemoryCoreRecorderService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/MemoryCoreRecorderService.spec.mjs
@@ -18,14 +18,21 @@ import Neo            from '../../../../../../src/Neo.mjs';
 import * as core      from '../../../../../../src/core/_export.mjs';
 import fs             from 'fs';
 import path           from 'path';
+import {
+    createProviderActivityStatusWriter,
+    resolveProviderActivityStatusFile
+} from '../../../../../../ai/services/shared/providerActivityStatusStore.mjs';
 
 test.describe('Neo.ai.services.memory-core.MemoryCoreRecorderService', () => {
+    test.describe.configure({mode: 'serial'});
+
     const
         secret     = 'SENTINEL_SECRET_13506',
         testDbName = `mc-recorder-test-${process.pid}-${Date.now()}.sqlite`;
 
     let originalEnv;
     let testDbPath;
+    let kbStatusWriter;
     let memoryCoreConfig;
     let MemoryCoreRecorderService;
 
@@ -54,16 +61,35 @@ test.describe('Neo.ai.services.memory-core.MemoryCoreRecorderService', () => {
             try { fs.unlinkSync(`${testDbPath}${suffix}`); } catch (e) {}
         }
 
-        memoryCoreConfig          = (await import('../../../../../../ai/mcp/server/memory-core/config.template.mjs')).default;
+        memoryCoreConfig = (await import('../../../../../../ai/mcp/server/memory-core/config.template.mjs')).default;
+        memoryCoreConfig.refreshEnv();
         MemoryCoreRecorderService = (await import('../../../../../../ai/services/memory-core/MemoryCoreRecorderService.mjs')).default;
+
+        // A Playwright worker can reuse this singleton after another spec imported it. Rebind it to
+        // this fixture's explicit database instead of letting initAsync() return on the stale handle.
+        await MemoryCoreRecorderService.flushProviderActivityStatus();
+        try { MemoryCoreRecorderService.db?.close(); } catch (e) {}
+        MemoryCoreRecorderService.db = null;
+        MemoryCoreRecorderService.providerActivityStatusWriter = null;
+
         await MemoryCoreRecorderService.initAsync();
+
+        kbStatusWriter = createProviderActivityStatusWriter({
+            dbPath  : testDbPath,
+            recorder: 'knowledge-base'
+        });
+        await kbStatusWriter.publishSuccess(Date.now());
     });
 
     test.beforeEach(() => {
         MemoryCoreRecorderService.db.exec('DELETE FROM mc_tool_call_log;');
+        MemoryCoreRecorderService.db.exec('DELETE FROM provider_activity_log;');
     });
 
-    test.afterAll(() => {
+    test.afterAll(async () => {
+        await kbStatusWriter?.flush();
+        await MemoryCoreRecorderService?.flushProviderActivityStatus();
+
         if (MemoryCoreRecorderService?.db) {
             try { MemoryCoreRecorderService.db.close(); } catch (e) {}
             MemoryCoreRecorderService.db = null;
@@ -73,6 +99,11 @@ test.describe('Neo.ai.services.memory-core.MemoryCoreRecorderService', () => {
             try { fs.unlinkSync(`${testDbPath}${suffix}`); } catch (e) {}
         }
 
+        for (const recorder of ['knowledge-base', 'memory-core']) {
+            const file = resolveProviderActivityStatusFile(testDbPath, recorder);
+            try { fs.unlinkSync(file); } catch (e) {}
+        }
+
         for (const [key, value] of Object.entries(originalEnv || {})) {
             if (value === undefined) {
                 delete process.env[key];
@@ -80,6 +111,7 @@ test.describe('Neo.ai.services.memory-core.MemoryCoreRecorderService', () => {
                 process.env[key] = value;
             }
         }
+        memoryCoreConfig?.refreshEnv();
     });
 
     test('initializes the redacted Memory Core tool telemetry schema', () => {
@@ -94,6 +126,12 @@ test.describe('Neo.ai.services.memory-core.MemoryCoreRecorderService', () => {
 
         const columns = MemoryCoreRecorderService.db.prepare('PRAGMA table_info(mc_tool_call_log)').all();
         expect(columns.some(column => column.name === 'completed_at')).toBe(true);
+        expect(MemoryCoreRecorderService.db.prepare(`
+            SELECT name
+              FROM sqlite_master
+             WHERE type = 'table'
+               AND name = 'provider_activity_log'
+        `).get().name).toBe('provider_activity_log');
         expect(MemoryCoreRecorderService.db.pragma('busy_timeout', {simple: true})).toBe(50);
     });
 
@@ -263,6 +301,95 @@ test.describe('Neo.ai.services.memory-core.MemoryCoreRecorderService', () => {
         expect(metrics.tools[0].calls).toBe(2);
         expect(metrics.tools[0].failures).toBe(1);
         expect(JSON.stringify(metrics)).not.toContain('safe');
+    });
+
+    test('projects bounded provider activity beside unchanged tool metrics', () => {
+        const now      = Date.now();
+        const queuedId = MemoryCoreRecorderService.beginProviderActivity({
+            activityId      : 'queued-activity',
+            service         : 'memory-core',
+            operationStage  : 'mc-session-summary',
+            role            : 'chat',
+            provider        : 'ollama',
+            model           : 'gemma4:26b',
+            priority        : 'batch',
+            enqueuedAt      : now - 100,
+            queueDisposition: 'neo-queued',
+            prompt          : secret,
+            operationLabel  : `session/${secret}`,
+            sessionId       : secret
+        });
+
+        MemoryCoreRecorderService.startProviderActivity(queuedId, now - 75);
+        MemoryCoreRecorderService.completeProviderActivity(queuedId, {completedAt: now - 25, success: true});
+
+        const inFlightId = MemoryCoreRecorderService.beginProviderActivity({
+            activityId      : 'in-flight-activity',
+            service         : 'knowledge-base',
+            operationStage  : 'kb-query-embedding',
+            role            : 'embedding',
+            provider        : 'openAiCompatible',
+            model           : 'qwen3-embedding',
+            priority        : 'interactive',
+            enqueuedAt      : now - 50,
+            queueDisposition: 'neo-queued'
+        });
+
+        const remoteId = MemoryCoreRecorderService.beginProviderActivity({
+            activityId      : 'remote-activity',
+            service         : 'dream-pipeline',
+            operationStage  : 'rem-topology',
+            role            : 'chat',
+            provider        : 'gemini',
+            model           : 'gemini-2.5-flash',
+            priority        : 'batch',
+            enqueuedAt      : now - 40,
+            startedAt       : now - 40,
+            queueDisposition: 'not-applicable'
+        });
+
+        MemoryCoreRecorderService.completeProviderActivity(remoteId, {
+            completedAt : now - 10,
+            failureStage: 'provider',
+            success     : false
+        });
+
+        const metrics = MemoryCoreRecorderService.getMemoryCoreToolMetrics({sinceMs: 60_000, limit: 10});
+
+        expect(Object.keys(metrics)).toEqual([
+            'status',
+            'sinceMs',
+            'limit',
+            'slowAfterMs',
+            'totalCalls',
+            'totalUnfinished',
+            'tools',
+            'unfinishedCalls',
+            'recentSlowCalls',
+            'providerActivity'
+        ]);
+        expect(metrics.providerActivity).toMatchObject({
+            status         : 'ok',
+            totalActivities: 3,
+            totalInFlight  : 1
+        });
+        expect(metrics.providerActivity.inFlight).toEqual([
+            expect.objectContaining({activityId: inFlightId, operationStage: 'kb-query-embedding'})
+        ]);
+        expect(metrics.providerActivity.recentCompletions.find(row => row.activityId === queuedId)).toMatchObject({
+            queueDisposition: 'neo-queued',
+            queueWaitMs     : 25,
+            executionMs     : 50,
+            success         : true
+        });
+        expect(metrics.providerActivity.recentCompletions.find(row => row.activityId === remoteId)).toMatchObject({
+            queueDisposition: 'not-applicable',
+            queueWaitMs     : null,
+            executionMs     : 30,
+            success         : false,
+            failureStage    : 'provider'
+        });
+        expect(JSON.stringify(metrics.providerActivity)).not.toContain(secret);
     });
 
     test('returns bounded recent slow completions without caller identity or payloads', () => {
@@ -453,13 +580,19 @@ test.describe('Neo.ai.services.memory-core.MemoryCoreRecorderService', () => {
             memoryCoreConfig.refreshEnv();
 
             expect(MemoryCoreRecorderService.getMemoryCoreToolMetrics({slowAfterMs: 1_000})).toMatchObject({
-                status         : 'disabled',
-                slowAfterMs    : 1_000,
-                totalCalls     : 0,
-                totalUnfinished: 0,
-                tools          : [],
-                unfinishedCalls: [],
-                recentSlowCalls: []
+                status          : 'disabled',
+                slowAfterMs     : 1_000,
+                totalCalls      : 0,
+                totalUnfinished : 0,
+                tools           : [],
+                unfinishedCalls : [],
+                recentSlowCalls : [],
+                providerActivity: {
+                    status           : 'disabled',
+                    aggregates       : [],
+                    inFlight         : [],
+                    recentCompletions: []
+                }
             });
         } finally {
             process.env.NEO_MC_TOOL_TELEMETRY_ENABLED = originalEnabled;
@@ -486,18 +619,111 @@ test.describe('Neo.ai.services.memory-core.MemoryCoreRecorderService', () => {
             })).toBeNull();
 
             expect(MemoryCoreRecorderService.getMemoryCoreToolMetrics()).toMatchObject({
-                status         : 'unavailable',
-                slowAfterMs    : 60_000,
-                totalCalls     : 0,
-                totalUnfinished: 0,
-                tools          : [],
-                unfinishedCalls: [],
-                recentSlowCalls: []
+                status          : 'unavailable',
+                slowAfterMs     : memoryCoreConfig.toolTelemetry.slowAfterMs,
+                totalCalls      : 0,
+                totalUnfinished : 0,
+                tools           : [],
+                unfinishedCalls : [],
+                recentSlowCalls : [],
+                providerActivity: {
+                    status           : 'unavailable',
+                    aggregates       : [],
+                    inFlight         : [],
+                    recentCompletions: []
+                }
             });
 
             expect(MemoryCoreRecorderService.getMemoryCoreToolMetrics({slowAfterMs: 0})).toMatchObject({
-                slowAfterMs    : 60_000,
+                slowAfterMs    : memoryCoreConfig.toolTelemetry.slowAfterMs,
                 recentSlowCalls: []
+            });
+        } finally {
+            MemoryCoreRecorderService.db = originalDb;
+        }
+    });
+
+    test('reports a partial provider projection when only that observer query fails', () => {
+        const originalDb = MemoryCoreRecorderService.db;
+        const proxyDb    = {
+            exec: originalDb.exec.bind(originalDb),
+            prepare(sql) {
+                if (String(sql).includes('FROM provider_activity_log')) {
+                    throw new Error('provider projection unavailable');
+                }
+
+                return originalDb.prepare(sql);
+            }
+        };
+
+        MemoryCoreRecorderService.db = proxyDb;
+
+        try {
+            const metrics = MemoryCoreRecorderService.getMemoryCoreToolMetrics({sinceMs: 60_000, limit: 5});
+
+            expect(metrics.status).toBe('ok');
+            expect(metrics.providerActivity).toEqual({
+                status           : 'partial',
+                totalActivities  : 0,
+                totalInFlight    : 0,
+                aggregates       : [],
+                inFlight         : [],
+                recentCompletions: []
+            });
+        } finally {
+            MemoryCoreRecorderService.db = originalDb;
+        }
+    });
+
+    test('returns no provider rows when one required recorder status is unavailable', () => {
+        const
+            id = MemoryCoreRecorderService.beginProviderActivity({
+                activityId      : 'unverifiable-provider-row',
+                service         : 'memory-core',
+                operationStage  : 'mc-mini-summary',
+                role            : 'chat',
+                provider        : 'ollama',
+                model           : 'gemma4:26b',
+                priority        : 'batch',
+                enqueuedAt      : Date.now() - 10,
+                queueDisposition: 'neo-queued'
+            }),
+            kbFile       = resolveProviderActivityStatusFile(testDbPath, 'knowledge-base'),
+            withheldFile = `${kbFile}.withheld`;
+
+        MemoryCoreRecorderService.startProviderActivity(id, Date.now() - 8);
+        MemoryCoreRecorderService.completeProviderActivity(id, {completedAt: Date.now(), success: true});
+        fs.renameSync(kbFile, withheldFile);
+
+        try {
+            expect(MemoryCoreRecorderService.getMemoryCoreToolMetrics({sinceMs: 60_000, limit: 5}).providerActivity).toEqual({
+                status           : 'unavailable',
+                totalActivities  : 0,
+                totalInFlight    : 0,
+                aggregates       : [],
+                inFlight         : [],
+                recentCompletions: []
+            });
+        } finally {
+            fs.renameSync(withheldFile, kbFile);
+        }
+    });
+
+    test('keeps the metrics observer read-only after recorder initialization', () => {
+        const originalDb = MemoryCoreRecorderService.db;
+        const proxyDb    = {
+            exec() {
+                throw new Error('observer attempted schema DDL');
+            },
+            prepare: originalDb.prepare.bind(originalDb)
+        };
+
+        MemoryCoreRecorderService.db = proxyDb;
+
+        try {
+            expect(MemoryCoreRecorderService.getMemoryCoreToolMetrics({sinceMs: 60_000, limit: 5})).toMatchObject({
+                status          : 'ok',
+                providerActivity: {status: 'ok'}
             });
         } finally {
             MemoryCoreRecorderService.db = originalDb;

--- a/test/playwright/unit/ai/services/memory-core/MemoryService.WriteAhead.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/MemoryService.WriteAhead.spec.mjs
@@ -18,6 +18,7 @@ import Neo                                           from '../../../../../../src
 import RequestContextService                         from '../../../../../../ai/mcp/server/shared/services/RequestContextService.mjs';
 import {appendWalEmbedMarker, readPendingWalRecords} from '../../../../../../ai/services/memory-core/helpers/memoryWalStore.mjs';
 import {drainMemoryWal}                              from './util.mjs';
+import {getProviderActivityContext}                  from '../../../../../../ai/services/shared/providerActivityLedger.mjs';
 
 /**
  * add_memory never-fail write path (write-ahead decouple) — falsifier coverage:
@@ -534,5 +535,83 @@ test.describe('Neo.ai.services.memory-core.MemoryService.writeAhead', () => {
         expect(summary.embedded).toBe(1);
         expect(memStore.has(result.id)).toBe(true);
         expect((await readPendingWalRecords({dir: testWalDir, ids: [result.id]})).length).toBe(0);
+    });
+
+    test('attributes deferred provider work to the WAL drain and mini-summary instead of add_memory', async () => {
+        const
+            originalSchedule     = MemoryService._scheduleMemoryGraphProjection,
+            originalBuildSummary = MemoryService.buildMiniSummary,
+            events               = [],
+            touchesBefore        = collectionTouches;
+
+        MemoryService._scheduleMemoryGraphProjection = () => {};
+        MemoryService.buildMiniSummary = async () => {
+            events.push({kind: 'unexpected-inline-summary'});
+            return {summary: null, cause: 'unexpected-inline-summary'};
+        };
+
+        try {
+            const result = await asTenant(() => MemoryService.addMemory({
+                prompt  : 'stage prompt',
+                thought : 'stage thought',
+                response: 'stage response'
+            }));
+
+            await new Promise(resolve => setImmediate(resolve));
+
+            expect(result.id).toBeTruthy();
+            expect(collectionTouches).toBe(touchesBefore);
+            expect(memStore.has(result.id)).toBe(false);
+            expect(events).toEqual([]);
+            expect(getProviderActivityContext()).toBeNull();
+
+            const drain = await drainMemoryWal({
+                ids       : [result.id],
+                collection: {
+                    add: async ({ids = [], metadatas = []}) => {
+                        events.push({kind: 'embedding', ...getProviderActivityContext()});
+                        ids.forEach((id, index) => memStore.set(id, metadatas[index] || {}));
+                    }
+                }
+            });
+
+            expect(drain.embedded).toBe(1);
+            expect(memStore.has(result.id)).toBe(true);
+            expect(events).toEqual([{
+                kind          : 'embedding',
+                operationStage: 'mc-wal-drain-embedding',
+                service       : 'memory-core'
+            }]);
+            expect(getProviderActivityContext()).toBeNull();
+
+            const summary = await originalBuildSummary.call(MemoryService, {
+                prompt    : 'stage prompt',
+                response  : 'stage response',
+                buildModel: () => ({
+                    generateContent: async (providerPrompt, options) => {
+                        events.push({
+                            kind          : 'chat',
+                            operationStage: options.operationStage,
+                            priority      : options.priority
+                        });
+                        return {response: {text: () => 'provider-stage summary'}};
+                    }
+                })
+            });
+
+            expect(summary).toEqual({summary: 'provider-stage summary', cause: null});
+            expect(events).toEqual([{
+                kind          : 'embedding',
+                operationStage: 'mc-wal-drain-embedding',
+                service       : 'memory-core'
+            }, {
+                kind          : 'chat',
+                operationStage: 'mc-mini-summary',
+                priority      : 'batch'
+            }]);
+        } finally {
+            MemoryService._scheduleMemoryGraphProjection = originalSchedule;
+            MemoryService.buildMiniSummary               = originalBuildSummary;
+        }
     });
 });

--- a/test/playwright/unit/ai/services/memory-core/QueryRecentTurns.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/QueryRecentTurns.spec.mjs
@@ -344,12 +344,20 @@ test.describe('Neo.ai.services.memory-core.queryRecentTurns', () => {
 
         // A genuine one-line answer must still succeed, or the three assertions above would also pass
         // against a producer that had stopped summarizing at all.
+        let usableOptions;
         const usable = await MemoryService.buildMiniSummary({
             prompt    : 'p', response: 'r',
-            buildModel: () => ({generateContent: async () => ({response: {text: () => '  a real   summary  '}})})
+            buildModel: () => ({generateContent: async (prompt, options) => {
+                usableOptions = options;
+                return {response: {text: () => '  a real   summary  '}};
+            }})
         });
 
         expect(usable).toEqual({summary: 'a real summary', cause: null});
+        expect(usableOptions).toMatchObject({
+            operationStage: 'mc-mini-summary',
+            priority      : 'batch'
+        });
 
         const providerError = await MemoryService.buildMiniSummary({
             prompt    : 'p', response: 'r',

--- a/test/playwright/unit/ai/services/memory-core/SessionService.buildChatModel.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/SessionService.buildChatModel.spec.mjs
@@ -48,7 +48,7 @@ test.describe('buildChatModel provider selector (#11965 Sub-2)', () => {
     });
 
     test('modelProvider=ollama returns generateContent wrapping native Ollama provider', async () => {
-        const captured = [];
+        const captured   = [];
         const fakeOllama = {
             host     : 'fake://injected',
             modelName: 'fake-injected',
@@ -90,7 +90,7 @@ test.describe('buildChatModel provider selector (#11965 Sub-2)', () => {
     });
 
     test('modelProvider=ollama refreshes provider host/model/keepAlive per invocation', async () => {
-        const captured = [];
+        const captured   = [];
         const fakeOllama = {
             host     : null,
             modelName: null,
@@ -103,7 +103,7 @@ test.describe('buildChatModel provider selector (#11965 Sub-2)', () => {
 
         // Pass a mutable ollamaConfig ref so we can change it between invocations.
         const ollamaConfig = {host: 'http://v1.test', model: 'model-v1', keep_alive: -1};
-        const model = buildChatModel({
+        const model        = buildChatModel({
             modelProvider        : 'ollama',
             ollamaConfig,
             ollamaProviderFactory: () => fakeOllama
@@ -122,7 +122,7 @@ test.describe('buildChatModel provider selector (#11965 Sub-2)', () => {
     });
 
     test('modelProvider=openAiCompatible returns generateContent wrapping OpenAi-compatible provider', async () => {
-        const captured = [];
+        const captured     = [];
         const fakeProvider = {
             host     : null,
             modelName: null,
@@ -206,7 +206,8 @@ test.describe('buildChatModel provider selector (#11965 Sub-2)', () => {
     });
 
     test('routes local requests through the injected queue and strips priority from provider options (#12748)', async () => {
-        const captured = [];
+        const captured     = [];
+        const activity     = [];
         const fakeProvider = {
             async generate(promptText, generationOptions) {
                 captured.push({promptText, generationOptions});
@@ -218,14 +219,127 @@ test.describe('buildChatModel provider selector (#11965 Sub-2)', () => {
             modelProvider                  : 'openAiCompatible',
             openAiCompatibleConfig         : {host: 'http://oai.test', model: 'm'},
             openAiCompatibleProviderFactory: () => fakeProvider,
-            chatRequestQueue               : queue
+            chatRequestQueue               : queue,
+            providerActivityRecorder       : {
+                beginProviderActivity(entry) { activity.push({type: 'begin', entry}); return 'activity-1' },
+                startProviderActivity(id, startedAt) { activity.push({type: 'start', id, startedAt}) },
+                refineProviderActivity(id, dispatchActivity) {
+                    activity.push({type: 'refine', id, dispatchActivity});
+                },
+                completeProviderActivity(id, outcome) { activity.push({type: 'complete', id, outcome}) }
+            },
+            providerActivityService: 'memory-core'
         });
 
-        const response = await model.generateContent('hi', {timeoutMs: 100, priority: 'batch'});
+        const response = await model.generateContent('hi', {
+            operationLabel: 'identity-bearing-label/session-123',
+            operationStage: 'mc-session-summary',
+            priority      : 'batch',
+            timeoutMs     : 100
+        });
 
         expect(response.response.text()).toBe('r:hi');
         // `priority` is a queue-control param — it MUST NOT leak into the provider request.
-        expect(captured[0].generationOptions).toEqual({timeoutMs: 100});
+        expect(captured[0].generationOptions).toEqual({
+            operationLabel: 'identity-bearing-label/session-123',
+            timeoutMs     : 100
+        });
+        expect(activity[0]).toEqual({
+            type : 'begin',
+            entry: expect.objectContaining({
+                model           : 'unknown',
+                operationStage  : 'mc-session-summary',
+                priority        : 'batch',
+                provider        : 'openAiCompatible',
+                queueDisposition: 'neo-queued',
+                role            : 'chat',
+                service         : 'memory-core'
+            })
+        });
+        expect(activity.map(item => item.type)).toEqual(['begin', 'start', 'refine', 'complete']);
+        expect(activity[2].dispatchActivity).toEqual({model: 'm'});
+        expect(activity[3]).toMatchObject({type: 'complete', id: 'activity-1', outcome: {success: true}});
+    });
+
+    test('records the same runtime model snapshot the queued local provider dispatches', async () => {
+        const config      = {host: 'http://oai.test', model: 'model-a'};
+        const routed      = [];
+        const refinements = [];
+        let queued;
+        const queue = {
+            enqueue(task, priority, lifecycle) {
+                lifecycle.onEnqueued({enqueuedAt: 10, priority});
+
+                return new Promise((resolve, reject) => {
+                    queued = {task, lifecycle, resolve, reject};
+                });
+            }
+        };
+        const model = buildChatModel({
+            modelProvider                  : 'openAiCompatible',
+            openAiCompatibleConfig         : config,
+            openAiCompatibleProviderFactory: () => ({
+                async generate() {
+                    routed.push(this.modelName);
+                    return {content: 'ok'};
+                }
+            }),
+            chatRequestQueue        : queue,
+            providerActivityRecorder: {
+                beginProviderActivity() { return 'runtime-model-activity' },
+                startProviderActivity() {},
+                refineProviderActivity(id, dispatchActivity) {
+                    refinements.push({id, dispatchActivity});
+                },
+                completeProviderActivity() {}
+            }
+        });
+
+        const pending = model.generateContent('hello', {operationStage: 'mc-session-summary'});
+
+        config.model = 'model-b';
+        queued.lifecycle.onStarted({startedAt: 20});
+
+        try {
+            const result = await queued.task();
+
+            queued.lifecycle.onSettled({completedAt: 30, success: true});
+            queued.resolve(result);
+        } catch (error) {
+            queued.lifecycle.onSettled({completedAt: 30, success: false});
+            queued.reject(error);
+        }
+
+        expect((await pending).response.text()).toBe('ok');
+        expect(routed).toEqual(['model-b']);
+        expect(refinements).toEqual([{
+            id              : 'runtime-model-activity',
+            dispatchActivity: {model: 'model-b'}
+        }]);
+    });
+
+    test('keeps provider routing independent of an injected queue that ignores lifecycle callbacks', async () => {
+        const factoryModels = [];
+        const routedModels  = [];
+        const model         = buildChatModel({
+            modelProvider         : 'openAiCompatible',
+            openAiCompatibleConfig: {host: 'http://oai.test', model: 'actual-model'},
+            chatRequestQueue      : {enqueue(task) { return task() }},
+            openAiCompatibleProviderFactory(config) {
+                factoryModels.push(config.modelName);
+
+                return {
+                    async generate() {
+                        routedModels.push(this.modelName);
+                        return {content: 'ok'};
+                    }
+                };
+            }
+        });
+
+        expect((await model.generateContent('hello')).response.text()).toBe('ok');
+        expect(factoryModels).toEqual(['actual-model']);
+        expect(routedModels).toEqual(['actual-model']);
     });
 
     test('modelProvider=gemini returns null when geminiApiKey is missing', () => {
@@ -237,9 +351,9 @@ test.describe('buildChatModel provider selector (#11965 Sub-2)', () => {
     });
 
     test('modelProvider=gemini delegates to geminiClientFactory when key present', () => {
-        const fakeGemini = {generateContent: async () => ({response: {text: () => 'gemini-mock'}})};
+        const fakeGemini   = {generateContent: async () => ({response: {text: () => 'gemini-mock'}})};
         const factoryCalls = [];
-        const model = buildChatModel({
+        const model        = buildChatModel({
             modelProvider      : 'gemini',
             geminiApiKey       : 'gem-key',
             geminiModelName    : 'gemini-pro',
@@ -250,6 +364,46 @@ test.describe('buildChatModel provider selector (#11965 Sub-2)', () => {
         });
         expect(model).toBe(fakeGemini);
         expect(factoryCalls).toEqual([{apiKey: 'gem-key', modelName: 'gemini-pro'}]);
+    });
+
+    test('records Gemini as unqueued and strips attribution controls before provider dispatch', async () => {
+        const calls    = [];
+        const activity = [];
+        const model    = buildChatModel({
+            modelProvider      : 'gemini',
+            geminiApiKey       : 'gem-key',
+            geminiModelName    : 'gemini-pro',
+            geminiClientFactory: () => ({
+                async generateContent(prompt, options) {
+                    calls.push({prompt, options});
+                    return {response: {text: () => 'ok'}};
+                }
+            }),
+            providerActivityRecorder: {
+                beginProviderActivity(entry) { activity.push({type: 'begin', entry}); return 'remote-1' },
+                startProviderActivity(id, startedAt) { activity.push({type: 'start', id, startedAt}) },
+                completeProviderActivity(id, outcome) { activity.push({type: 'complete', id, outcome}) }
+            },
+            providerActivityService: 'knowledge-base'
+        });
+
+        await model.generateContent('hello', {
+            operationStage: 'kb-ask-synthesis',
+            priority      : 'interactive',
+            timeoutMs     : 500
+        });
+
+        expect(calls).toEqual([{prompt: 'hello', options: {timeoutMs: 500}}]);
+        expect(activity[0]).toEqual({
+            type : 'begin',
+            entry: expect.objectContaining({
+                operationStage  : 'kb-ask-synthesis',
+                provider        : 'gemini',
+                queueDisposition: 'not-applicable',
+                service         : 'knowledge-base'
+            })
+        });
+        expect(activity.map(item => item.type)).toEqual(['begin', 'start', 'complete']);
     });
 });
 
@@ -263,6 +417,7 @@ test.describe('SessionService summary provenance (#10292)', () => {
     let originalMemoryCollection;
     let originalModel;
     let originalSessionsCollection;
+    let originalStageSessionSummaryReceipt;
     let originalUpsertNode;
 
     let linkNodesCalls;
@@ -286,6 +441,7 @@ test.describe('SessionService summary provenance (#10292)', () => {
         originalMemoryCollection           = SessionService.memoryCollection;
         originalModel                      = SessionService.model;
         originalSessionsCollection         = SessionService.sessionsCollection;
+        originalStageSessionSummaryReceipt = SessionService.stageSessionSummaryReceipt;
         originalLinkNodes                  = GraphService.linkNodes;
         originalUpsertNode                 = GraphService.upsertNode;
 
@@ -320,6 +476,7 @@ test.describe('SessionService summary provenance (#10292)', () => {
                 sessionUpserts.push(payload);
             }
         };
+        SessionService.stageSessionSummaryReceipt = () => {};
         SessionService.model = {
             async generateContent() {
                 return {
@@ -352,6 +509,7 @@ test.describe('SessionService summary provenance (#10292)', () => {
         SessionService.memoryCollection           = originalMemoryCollection;
         SessionService.model                      = originalModel;
         SessionService.sessionsCollection         = originalSessionsCollection;
+        SessionService.stageSessionSummaryReceipt = originalStageSessionSummaryReceipt;
         GraphService.linkNodes                    = originalLinkNodes;
         GraphService.upsertNode                   = originalUpsertNode;
     });

--- a/test/playwright/unit/ai/services/memory-core/SessionSummarization.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/SessionSummarization.spec.mjs
@@ -287,10 +287,12 @@ test.describe('Memory Core Offline Summarization', () => {
         // Mock the model.generateContent to avoid actual LLM calls and verify the exact prompt content
         const originalModel   = SDK.Memory_SessionService.model;
         let   capturedPrompts = [];
+        let   capturedOptions = [];
 
         SDK.Memory_SessionService.model = {
-            generateContent: async (prompt) => {
+            generateContent: async (prompt, options) => {
                 capturedPrompts.push(prompt);
+                capturedOptions.push(options);
 
                 return {
                     response: {
@@ -319,6 +321,10 @@ test.describe('Memory Core Offline Summarization', () => {
 
         // Verify ONLY ONE generation payload happened
         expect(capturedPrompts.length).toBe(1);
+        expect(capturedOptions[0]).toMatchObject({
+            operationStage: 'mc-session-summary',
+            priority      : 'batch'
+        });
 
         // Output should be massive implicitly mapped correctly
         const finalPrompt = capturedPrompts[0];

--- a/test/playwright/unit/ai/services/memory-core/TextEmbeddingService.retry.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/TextEmbeddingService.retry.spec.mjs
@@ -98,7 +98,7 @@ test.describe.serial('TextEmbeddingService #11393/#11402/#12487/#12509 — openA
     let inFlightRequests;
     let maxInFlightRequests;
     let testPort;
-    let originalHost, originalRetryCount, originalRetryDelay;
+    let originalEmbeddingModel, originalHost, originalRetryCount, originalRetryDelay;
     let originalContentionRetryCount, originalContentionRetryDelay, originalContentionTimeout;
     let originalBatchEmbeddingChunkSize, originalBatchEmbeddingTimeoutMs, originalBatchEmbeddingYieldMs;
     let originalLmsPort;
@@ -141,6 +141,15 @@ test.describe.serial('TextEmbeddingService #11393/#11402/#12487/#12509 — openA
                     }));
                 } else if (serverBehavior === 'fail-then-succeed') {
                     if (requestCount === 1) {
+                        res.writeHead(400, { 'Content-Type': 'application/json' });
+                        res.end(JSON.stringify({ error: 'Model was unloaded while the request was still in queue..' }));
+                    } else {
+                        res.writeHead(200, { 'Content-Type': 'application/json' });
+                        res.end(JSON.stringify({ data: [{ embedding: [0.4, 0.5, 0.6] }] }));
+                    }
+                } else if (serverBehavior === 'fail-then-change-model') {
+                    if (requestCount === 1) {
+                        aiConfig.openAiCompatible.embeddingModel = 'runtime-retry-model-b';
                         res.writeHead(400, { 'Content-Type': 'application/json' });
                         res.end(JSON.stringify({ error: 'Model was unloaded while the request was still in queue..' }));
                     } else {
@@ -231,7 +240,7 @@ test.describe.serial('TextEmbeddingService #11393/#11402/#12487/#12509 — openA
                           };
 
                     if (Array.isArray(inputs) && inputs[0] === 'a') {
-                        setTimeout(respond, 25);
+                        setTimeout(respond, 100);
                     } else {
                         respond();
                     }
@@ -254,6 +263,7 @@ test.describe.serial('TextEmbeddingService #11393/#11402/#12487/#12509 — openA
         inFlightRequests = 0;
         maxInFlightRequests = 0;
         originalHost = aiConfig.openAiCompatible.host;
+        originalEmbeddingModel = aiConfig.openAiCompatible.embeddingModel;
         originalRetryCount = aiConfig.openAiCompatible.unloadRetryCount;
         originalRetryDelay = aiConfig.openAiCompatible.unloadRetryDelayMs;
         originalContentionRetryCount = aiConfig.openAiCompatible.contentionRetryCount;
@@ -282,6 +292,7 @@ test.describe.serial('TextEmbeddingService #11393/#11402/#12487/#12509 — openA
 
     test.afterEach(() => {
         aiConfig.openAiCompatible.host = originalHost;
+        aiConfig.openAiCompatible.embeddingModel = originalEmbeddingModel;
         aiConfig.openAiCompatible.unloadRetryCount = originalRetryCount;
         aiConfig.openAiCompatible.unloadRetryDelayMs = originalRetryDelay;
         aiConfig.openAiCompatible.contentionRetryCount = originalContentionRetryCount;
@@ -473,9 +484,34 @@ test.describe.serial('TextEmbeddingService #11393/#11402/#12487/#12509 — openA
 
     test('first-call-fails-second-call-succeeds path with mock client', async () => {
         serverBehavior = 'fail-then-succeed';
-        const result = await TextEmbeddingService.embedText('hello', 'openAiCompatible');
+        const activities = [];
+        const recorder   = {
+            beginProviderActivity(entry) { activities.push({type: 'begin', id: 'retry-1', entry}); return 'retry-1' },
+            startProviderActivity(id, startedAt) { activities.push({type: 'start', id, startedAt}) },
+            refineProviderActivity(id, dispatchActivity) {
+                activities.push({type: 'refine', id, dispatchActivity});
+            },
+            completeProviderActivity(id, outcome) { activities.push({type: 'complete', id, outcome}) }
+        };
+        const result = await TextEmbeddingService.embedText('hello', 'openAiCompatible', {
+            operationStage          : 'kb-query-embedding',
+            providerActivityRecorder: recorder,
+            service                 : 'knowledge-base'
+        });
+
         expect(result).toEqual([0.4, 0.5, 0.6]);
         expect(requestCount).toBe(2);
+        expect(activities.map(item => item.type)).toEqual(['begin', 'start', 'refine', 'complete']);
+        expect(activities[0].entry).toMatchObject({
+            operationStage  : 'kb-query-embedding',
+            priority        : 'interactive',
+            provider        : 'openAiCompatible',
+            queueDisposition: 'neo-queued',
+            role            : 'embedding',
+            service         : 'knowledge-base'
+        });
+        expect(activities[2].dispatchActivity).toEqual({model: lastRequest.body.model});
+        expect(activities[3]).toMatchObject({id: 'retry-1', outcome: {success: true}});
     });
 
     test('exhausted-retry-final-failure path', async () => {
@@ -491,6 +527,33 @@ test.describe.serial('TextEmbeddingService #11393/#11402/#12487/#12509 — openA
 
         // Initial request + 2 retries = 3 total requests
         expect(requestCount).toBe(3);
+    });
+
+    test('preserves per-attempt model routing and degrades a cross-model retry row to unknown', async () => {
+        serverBehavior = 'fail-then-change-model';
+        const refinements = [];
+        const recorder    = {
+            beginProviderActivity() { return 'model-retry-activity' },
+            startProviderActivity() {},
+            refineProviderActivity(id, activity) { refinements.push({id, activity}) },
+            completeProviderActivity() {}
+        };
+
+        const result = await TextEmbeddingService.embedText('hello', 'openAiCompatible', {
+            operationStage          : 'kb-query-embedding',
+            providerActivityRecorder: recorder,
+            service                 : 'knowledge-base'
+        });
+
+        expect(result).toEqual([0.4, 0.5, 0.6]);
+        expect(allRequests.map(item => item.body.model)).toEqual([
+            originalEmbeddingModel,
+            'runtime-retry-model-b'
+        ]);
+        expect(refinements).toEqual([
+            {id: 'model-retry-activity', activity: {model: originalEmbeddingModel}},
+            {id: 'model-retry-activity', activity: {model: 'unknown'}}
+        ]);
     });
 
     test('first-call-fails-shape-b-second-call-succeeds path with mock client', async () => {
@@ -639,11 +702,51 @@ test.describe.serial('TextEmbeddingService #11393/#11402/#12487/#12509 — openA
         aiConfig.openAiCompatible.batchEmbeddingChunkSize = 1;
         aiConfig.openAiCompatible.batchEmbeddingYieldMs = 0;
 
-        const batchPromise = TextEmbeddingService.embedTexts(['a', 'b', 'c'], 'openAiCompatible');
+        const activityById = new Map();
+        const starts       = [];
+        const refinements  = [];
+        let   activityId   = 0;
+        const recorder     = {
+            beginProviderActivity(entry) {
+                const id = `activity-${++activityId}`;
+                activityById.set(id, entry);
+                return id;
+            },
+            startProviderActivity(id) {
+                starts.push(activityById.get(id).operationStage);
+            },
+            refineProviderActivity(id, dispatchActivity) {
+                refinements.push({
+                    model         : dispatchActivity.model,
+                    operationStage: activityById.get(id).operationStage
+                });
+            },
+            completeProviderActivity() {}
+        };
+
+        const batchPromise = TextEmbeddingService.embedTexts(['a', 'b', 'c'], 'openAiCompatible', {
+            operationStage          : 'kb-tenant-ingestion-embedding',
+            providerActivityRecorder: recorder,
+            service                 : 'knowledge-base'
+        });
 
         await waitForCondition(() => allRequests.length === 1, 'first batch chunk request');
 
-        const interactivePromise               = TextEmbeddingService.embedText('urgent', 'openAiCompatible');
+        const interactivePromise = TextEmbeddingService.embedText('urgent', 'openAiCompatible', {
+            operationStage          : 'kb-query-embedding',
+            providerActivityRecorder: recorder,
+            service                 : 'knowledge-base'
+        });
+
+        await waitForCondition(() => {
+            return [...activityById.values()].some(entry => entry.operationStage === 'kb-query-embedding');
+        }, 'interactive embedding queue admission');
+
+        const runtimeModel = 'runtime-embedding-model-b';
+
+        expect(starts).toHaveLength(1);
+        aiConfig.openAiCompatible.embeddingModel = runtimeModel;
+
         const [batchResult, interactiveResult] = await Promise.all([batchPromise, interactivePromise]);
 
         expect(maxInFlightRequests).toBe(1);
@@ -653,6 +756,25 @@ test.describe.serial('TextEmbeddingService #11393/#11402/#12487/#12509 — openA
             ['b'],
             ['c']
         ]);
+        expect(starts).toEqual([
+            'kb-tenant-ingestion-embedding',
+            'kb-query-embedding',
+            'kb-tenant-ingestion-embedding',
+            'kb-tenant-ingestion-embedding'
+        ]);
+        expect(refinements).toEqual([
+            {model: originalEmbeddingModel, operationStage: 'kb-tenant-ingestion-embedding'},
+            {model: runtimeModel, operationStage: 'kb-query-embedding'},
+            {model: runtimeModel, operationStage: 'kb-tenant-ingestion-embedding'},
+            {model: runtimeModel, operationStage: 'kb-tenant-ingestion-embedding'}
+        ]);
+        expect(allRequests.map(item => item.body.model)).toEqual([
+            originalEmbeddingModel,
+            runtimeModel,
+            runtimeModel,
+            runtimeModel
+        ]);
+        expect(activityById.size).toBe(4);
         expect(interactiveResult).toEqual([2, 0]);
         expect(batchResult).toEqual([
             [1, 0],

--- a/test/playwright/unit/ai/services/memory-core/TextEmbeddingService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/TextEmbeddingService.spec.mjs
@@ -165,6 +165,83 @@ test.describe('TextEmbeddingService #11965 Sub-2 — native Ollama dispatch', ()
         }]);
     });
 
+    test('records native Ollama as unqueued without leaking attribution controls to the provider', async () => {
+        const captured   = [];
+        const activities = [];
+        const recorder   = {
+            beginProviderActivity(entry) { activities.push({type: 'begin', entry}); return `activity-${activities.length}` },
+            startProviderActivity(id, startedAt) { activities.push({type: 'start', id, startedAt}) },
+            completeProviderActivity(id, outcome) { activities.push({type: 'complete', id, outcome}) }
+        };
+
+        TextEmbeddingService.ollamaProvider = {
+            async embed(input, options) {
+                captured.push({input, options});
+                return {embeddings: [[0.1, 0.2]]};
+            }
+        };
+
+        await TextEmbeddingService.embedText('hello', 'ollama', {
+            operationLabel          : 'session/private-123',
+            operationStage          : 'embedding-canary',
+            providerActivityRecorder: recorder,
+            service                 : 'memory-core'
+        });
+        await TextEmbeddingService.embedText('unknown-stage', 'ollama', {
+            operationLabel          : 'asset/private-456',
+            providerActivityRecorder: recorder,
+            service                 : 'memory-core'
+        });
+
+        expect(captured[0].options).toEqual({
+            num_ctx       : aiConfig.localModels.embedding.contextLimitTokens,
+            operationLabel: 'session/private-123',
+            timeoutMs     : aiConfig.ollama.embeddingTimeoutMs,
+            truncate      : false
+        });
+        expect(activities.filter(item => item.type === 'begin').map(item => item.entry)).toEqual([
+            expect.objectContaining({
+                operationStage  : 'embedding-canary',
+                priority        : 'interactive',
+                provider        : 'ollama',
+                queueDisposition: 'not-applicable',
+                role            : 'embedding',
+                service         : 'memory-core'
+            }),
+            expect.objectContaining({
+                operationStage  : 'unknown',
+                queueDisposition: 'not-applicable'
+            })
+        ]);
+        expect(activities.filter(item => item.type === 'complete')).toHaveLength(2);
+    });
+
+    test('attributes native Ollama to the cached provider model without changing its request shape', async () => {
+        const activities = [];
+        const captured   = [];
+
+        TextEmbeddingService.ollamaProvider = {
+            embeddingModel: 'cached-ollama-model-a',
+            async embed(input, options) {
+                captured.push({input, options});
+                return {embeddings: [[0.1, 0.2]]};
+            }
+        };
+
+        await TextEmbeddingService.embedText('hello', 'ollama', {
+            operationStage          : 'embedding-canary',
+            providerActivityRecorder: {
+                beginProviderActivity(entry) { activities.push(entry); return 'cached-ollama-activity' },
+                startProviderActivity() {},
+                completeProviderActivity() {}
+            },
+            service: 'memory-core'
+        });
+
+        expect(activities[0].model).toBe('cached-ollama-model-a');
+        expect(captured[0].options).not.toHaveProperty('model');
+    });
+
     test('native Ollama timeout errors emit provider-scoped ConsumerFriction (#14052)', async () => {
         aiConfig.ollama.embeddingTimeoutMs = 25;
         TextEmbeddingService.ollamaProvider = {
@@ -461,6 +538,59 @@ test.describe.serial('TextEmbeddingService #15694 — provider-neutral cancellat
             },
             liveWrapperPreserved: true,
             liveSignalAborted   : false
+        });
+    });
+
+    test('attributes Gemini embeddings to the cached SDK endpoint model under config drift', async () => {
+        const evidence = await runIsolatedEmbeddingProbe(async () => {
+            const {default: Service}  = await import('./ai/services/memory-core/TextEmbeddingService.mjs');
+            const {default: aiConfig} = await import('./ai/mcp/server/memory-core/config.template.mjs');
+            const activities          = [];
+            const requestModels       = [];
+            const recorder            = {
+                beginProviderActivity(entry) { activities.push(entry); return `activity-${activities.length}` },
+                startProviderActivity() {},
+                completeProviderActivity() {}
+            };
+
+            aiConfig.embeddingModel = 'live-config-model-b';
+            Service.embeddingModel = {
+                model: 'models/cached-sdk-model-a',
+                async embedContent() {
+                    return {embedding: {values: [0.1]}};
+                },
+                async batchEmbedContents({requests}) {
+                    requestModels.push(...requests.map(request => request.model));
+                    return {embeddings: requests.map(() => ({values: [0.2]}))};
+                }
+            };
+
+            await Service.embedText('one', 'gemini', {
+                operationStage          : 'kb-query-embedding',
+                providerActivityRecorder: recorder,
+                service                 : 'knowledge-base'
+            });
+            await Service.embedTexts(['two', 'three'], 'gemini', {
+                operationStage          : 'kb-tenant-ingestion-embedding',
+                providerActivityRecorder: recorder,
+                service                 : 'knowledge-base'
+            });
+
+            console.log(JSON.stringify({
+                models: activities.map(entry => entry.model),
+                requestModels
+            }));
+        }, {GEMINI_API_KEY: 'unit-test-key'});
+
+        expect(evidence).toEqual({
+            models: [
+                'models/cached-sdk-model-a',
+                'models/cached-sdk-model-a'
+            ],
+            requestModels: [
+                'live-config-model-b',
+                'live-config-model-b'
+            ]
         });
     });
 

--- a/test/playwright/unit/ai/services/shared/providerActivityLedger.spec.mjs
+++ b/test/playwright/unit/ai/services/shared/providerActivityLedger.spec.mjs
@@ -1,0 +1,223 @@
+import {setup} from '../../../../setup.mjs';
+
+const appName = 'ProviderActivityLedgerTest';
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name             : appName,
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Database       from 'better-sqlite3';
+import Neo            from '../../../../../../src/Neo.mjs';
+import * as core      from '../../../../../../src/core/_export.mjs';
+import {
+    beginProviderActivity,
+    completeProviderActivity,
+    createProviderActivityLifecycle,
+    ensureProviderActivitySchema,
+    getProviderActivityMetrics,
+    refineProviderActivity,
+    startProviderActivity
+} from '../../../../../../ai/services/shared/providerActivityLedger.mjs';
+
+test.describe('providerActivityLedger', () => {
+    let db;
+
+    test.beforeEach(() => {
+        db = new Database(':memory:');
+        ensureProviderActivitySchema(db);
+    });
+
+    test.afterEach(() => {
+        db.close();
+    });
+
+    test('persists only bounded structural fields and separates queue wait from execution', () => {
+        const localId = beginProviderActivity(db, {
+            activityId      : 'caller-controlled-id-must-not-persist',
+            service         : 'knowledge-base',
+            operationStage  : 'kb-ask-synthesis',
+            role            : 'chat',
+            provider        : 'openAiCompatible',
+            model           : 'google/gemma-4-26b-a4b',
+            priority        : 'interactive',
+            enqueuedAt      : 100,
+            queueDisposition: 'neo-queued',
+            prompt          : 'secret prompt',
+            operationLabel  : 'session-123 asset-456',
+            tenantId        : 'private-tenant',
+            userId          : 'private-user',
+            endpoint        : 'https://token@example.invalid'
+        });
+
+        startProviderActivity(db, localId, 125);
+        refineProviderActivity(db, localId, {model: 'dispatch-model'});
+        completeProviderActivity(db, localId, {completedAt: 175, success: true});
+
+        const remoteId = beginProviderActivity(db, {
+            activityId      : 'remote-caller-id',
+            service         : 'memory-core',
+            operationStage  : 'mc-session-summary',
+            role            : 'chat',
+            provider        : 'gemini',
+            model           : 'gemini-2.5-flash',
+            priority        : 'batch',
+            enqueuedAt      : 200,
+            startedAt       : 200,
+            queueDisposition: 'not-applicable'
+        });
+
+        completeProviderActivity(db, remoteId, {completedAt: 250, success: false, failureStage: 'provider'});
+
+        const unknownId = beginProviderActivity(db, {
+            activityId      : 'unknown-caller-id',
+            service         : 'not-a-service',
+            operationStage  : 'session-identity/private',
+            role            : 'embedding',
+            provider        : 'ollama',
+            model           : 'https://credential@example.invalid/model',
+            priority        : 'interactive',
+            enqueuedAt      : 300,
+            queueDisposition: 'not-applicable'
+        });
+
+        const rejectedModelIds = [
+            'user:secret@host/model',
+            'localhost:11434',
+            'sk-private-token',
+            '/Users/private/model'
+        ].map((model, index) => beginProviderActivity(db, {
+            service         : 'memory-core',
+            operationStage  : 'unknown',
+            role            : 'chat',
+            provider        : 'ollama',
+            model,
+            priority        : 'batch',
+            enqueuedAt      : 301 + index,
+            queueDisposition: 'not-applicable'
+        }));
+
+        const columns = db.prepare('PRAGMA table_info(provider_activity_log)').all().map(column => column.name);
+        const rows    = db.prepare('SELECT * FROM provider_activity_log ORDER BY activity_id').all();
+        const metrics = getProviderActivityMetrics(db, {sinceTs: 0, limit: 10, now: 350});
+
+        expect(columns).toEqual([
+            'activity_id',
+            'service',
+            'operation_stage',
+            'role',
+            'provider',
+            'model',
+            'priority',
+            'enqueued_at',
+            'started_at',
+            'completed_at',
+            'queue_disposition',
+            'queue_wait_ms',
+            'execution_ms',
+            'success',
+            'failure_stage'
+        ]);
+        expect(JSON.stringify(rows)).not.toContain('secret prompt');
+        expect(JSON.stringify(rows)).not.toContain('session-123');
+        expect(JSON.stringify(rows)).not.toContain('private-tenant');
+        expect(JSON.stringify(rows)).not.toContain('private-user');
+        expect(JSON.stringify(rows)).not.toContain('example.invalid');
+        expect(JSON.stringify(rows)).not.toContain('caller-controlled-id');
+        expect(JSON.stringify(rows)).not.toContain('user:secret@host/model');
+        expect(JSON.stringify(rows)).not.toContain('localhost:11434');
+        expect(JSON.stringify(rows)).not.toContain('sk-private-token');
+        expect(JSON.stringify(rows)).not.toContain('/Users/private/model');
+        expect(rows.find(row => row.activity_id === localId)).toMatchObject({
+            model        : 'dispatch-model',
+            queue_wait_ms: 25,
+            execution_ms : 50,
+            success      : 1
+        });
+        expect(rows.find(row => row.activity_id === remoteId)).toMatchObject({
+            queue_disposition: 'not-applicable',
+            queue_wait_ms    : null,
+            execution_ms     : 50,
+            success          : 0,
+            failure_stage    : 'provider'
+        });
+        expect(rows.find(row => row.activity_id === unknownId)).toMatchObject({
+            service        : 'unknown',
+            operation_stage: 'unknown',
+            model          : 'unknown'
+        });
+        expect(rows.filter(row => rejectedModelIds.includes(row.activity_id)).every(row => {
+            return row.model === 'unknown';
+        })).toBe(true);
+        expect(metrics).toMatchObject({
+            status         : 'ok',
+            totalActivities: 7,
+            totalInFlight  : 5
+        });
+        expect(metrics.recentCompletions.find(row => row.activityId === remoteId)).toMatchObject({
+            queueDisposition: 'not-applicable',
+            queueWaitMs     : null,
+            executionMs     : 50,
+            success         : false,
+            failureStage    : 'provider'
+        });
+        expect(metrics.inFlight[0]).toMatchObject({
+            activityId    : unknownId,
+            operationStage: 'unknown',
+            elapsedMs     : 50
+        });
+        expect(metrics.inFlight.filter(row => rejectedModelIds.includes(row.activityId)).every(row => {
+            return row.model === 'unknown';
+        })).toBe(true);
+    });
+
+    test('swallows recorder failures so lifecycle observation stays behavior-neutral', () => {
+        const lifecycle = createProviderActivityLifecycle({
+            recorder: {
+                beginProviderActivity()    { throw new Error('begin failed') },
+                startProviderActivity()    { throw new Error('start failed') },
+                refineProviderActivity()   { throw new Error('refine failed') },
+                completeProviderActivity() { throw new Error('complete failed') }
+            },
+            activity: {
+                operationStage: 'unknown'
+            }
+        });
+
+        expect(() => lifecycle.onEnqueued({enqueuedAt: 10})).not.toThrow();
+        expect(() => lifecycle.onStarted({startedAt: 20})).not.toThrow();
+        expect(() => lifecycle.onDispatch({model: 'safe-model'})).not.toThrow();
+        expect(() => lifecycle.onSettled({completedAt: 30, success: true})).not.toThrow();
+    });
+
+    test('deduplicates retry attribution and degrades a multi-model activity to unknown', () => {
+        const refinements = [];
+        const lifecycle   = createProviderActivityLifecycle({
+            recorder: {
+                beginProviderActivity() { return 'retry-activity' },
+                refineProviderActivity(id, activity) { refinements.push({id, activity}) }
+            },
+            activity: {
+                model: 'unknown'
+            }
+        });
+
+        lifecycle.onEnqueued({enqueuedAt: 10});
+        lifecycle.onDispatch({model: 'model-a'});
+        lifecycle.onDispatch({model: 'model-a'});
+        lifecycle.onDispatch({model: 'model-b'});
+        lifecycle.onDispatch({model: 'model-b'});
+
+        expect(refinements).toEqual([
+            {id: 'retry-activity', activity: {model: 'model-a'}},
+            {id: 'retry-activity', activity: {model: 'unknown'}}
+        ]);
+    });
+});

--- a/test/playwright/unit/ai/services/shared/providerActivityStatusStore.spec.mjs
+++ b/test/playwright/unit/ai/services/shared/providerActivityStatusStore.spec.mjs
@@ -1,0 +1,237 @@
+import {setup} from '../../../../setup.mjs';
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name             : 'ProviderActivityStatusStoreTest',
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../../../src/Neo.mjs';
+import * as core      from '../../../../../../src/core/_export.mjs';
+import fs             from 'node:fs/promises';
+import os             from 'node:os';
+import path           from 'node:path';
+import {
+    createProviderActivityStatusWriter,
+    inspectProviderActivityStatus,
+    resolveProviderActivityStatusFile
+} from '../../../../../../ai/services/shared/providerActivityStatusStore.mjs';
+import {lifecycleGuardPath} from '../../../../../../ai/daemons/shared/lifecycleGuard.mjs';
+
+test.describe('providerActivityStatusStore', () => {
+    let tmpDir;
+
+    test.beforeEach(async () => {
+        tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'provider-activity-status-'));
+    });
+
+    test.afterEach(async () => {
+        await fs.rm(tmpDir, {recursive: true, force: true});
+    });
+
+    test('retains an in-window write failure after later success without exposing sensitive fields', async () => {
+        const dbPath = path.join(tmpDir, 'shared.sqlite');
+        const writer = createProviderActivityStatusWriter({dbPath, recorder: 'memory-core'});
+
+        await writer.publishSuccess(100);
+        await writer.publishFailure(200);
+        await writer.publishSuccess(300);
+        await writer.flush();
+
+        const payload = JSON.parse(await fs.readFile(writer.file, 'utf8'));
+
+        expect(payload).toEqual({
+            schemaVersion: 1,
+            recorder     : 'memory-core',
+            lastSuccessAt: 300,
+            lastFailureAt: 200
+        });
+        expect(Object.keys(payload).sort()).toEqual([
+            'lastFailureAt',
+            'lastSuccessAt',
+            'recorder',
+            'schemaVersion'
+        ]);
+        expect(inspectProviderActivityStatus({
+            dbPath,
+            sinceTs          : 150,
+            requiredRecorders: ['memory-core']
+        })).toEqual({status: 'partial'});
+        expect(inspectProviderActivityStatus({
+            dbPath,
+            sinceTs          : 250,
+            requiredRecorders: ['memory-core']
+        })).toEqual({status: 'ok'});
+    });
+
+    test('keeps inspection read-only and reports a missing required owner as unavailable', async () => {
+        const dbPath = path.join(tmpDir, 'shared.sqlite');
+
+        expect(inspectProviderActivityStatus({dbPath, sinceTs: 0})).toEqual({status: 'unavailable'});
+
+        const
+            memoryWriter = createProviderActivityStatusWriter({dbPath, recorder: 'memory-core'}),
+            kbWriter     = createProviderActivityStatusWriter({dbPath, recorder: 'knowledge-base'});
+
+        await memoryWriter.publishSuccess(100);
+
+        expect(inspectProviderActivityStatus({dbPath, sinceTs: 0})).toEqual({status: 'unavailable'});
+
+        await kbWriter.publishSuccess(100);
+
+        const beforeFiles   = await fs.readdir(tmpDir);
+        const beforePayload = await fs.readFile(memoryWriter.file, 'utf8');
+
+        expect(inspectProviderActivityStatus({dbPath, sinceTs: 0})).toEqual({status: 'ok'});
+        expect(await fs.readdir(tmpDir)).toEqual(beforeFiles);
+        expect(await fs.readFile(memoryWriter.file, 'utf8')).toBe(beforePayload);
+        expect(resolveProviderActivityStatusFile(dbPath, 'knowledge-base')).toBe(kbWriter.file);
+    });
+
+    test('merges two pre-created process writers without erasing an earlier failure', async () => {
+        const
+            dbPath  = path.join(tmpDir, 'shared.sqlite'),
+            writerA = createProviderActivityStatusWriter({dbPath, recorder: 'memory-core'}),
+            writerB = createProviderActivityStatusWriter({dbPath, recorder: 'memory-core'});
+
+        await writerA.publishFailure(200);
+        await writerB.publishSuccess(300);
+
+        expect(inspectProviderActivityStatus({
+            dbPath,
+            sinceTs          : 150,
+            requiredRecorders: ['memory-core']
+        })).toEqual({status: 'partial'});
+        expect(JSON.parse(await fs.readFile(writerA.file, 'utf8'))).toEqual({
+            schemaVersion: 1,
+            recorder     : 'memory-core',
+            lastSuccessAt: 300,
+            lastFailureAt: 200
+        });
+    });
+
+    test('retries a pending failure after live cross-process guard contention', async () => {
+        const dbPath = path.join(tmpDir, 'shared.sqlite');
+        const writer = createProviderActivityStatusWriter({dbPath, recorder: 'memory-core'});
+
+        await writer.publishSuccess(100);
+
+        const guardPath = lifecycleGuardPath(writer.file);
+
+        const ownerPath = path.join(guardPath, 'owner-live-container-peer');
+
+        await fs.mkdir(guardPath);
+        await fs.writeFile(ownerPath, '');
+        writer.publishFailure(200);
+
+        expect(JSON.parse(await fs.readFile(writer.file, 'utf8'))).toEqual({
+            schemaVersion: 1,
+            recorder     : 'memory-core',
+            lastSuccessAt: 100,
+            lastFailureAt: null
+        });
+
+        await new Promise((resolve, reject) => {
+            setTimeout(async () => {
+                try {
+                    await fs.unlink(ownerPath);
+                    await fs.rmdir(guardPath);
+                    resolve();
+                } catch (error) {
+                    reject(error);
+                }
+            }, 1100);
+        });
+        await writer.flush();
+
+        expect(inspectProviderActivityStatus({
+            dbPath,
+            sinceTs          : 150,
+            requiredRecorders: ['memory-core']
+        })).toEqual({status: 'partial'});
+        expect(JSON.parse(await fs.readFile(writer.file, 'utf8'))).toEqual({
+            schemaVersion: 1,
+            recorder     : 'memory-core',
+            lastSuccessAt: 100,
+            lastFailureAt: 200
+        });
+    });
+
+    test('never deletes a foreign failure after exhausting guard acquisition', async () => {
+        const dbPath = path.join(tmpDir, 'shared.sqlite');
+        const writer = createProviderActivityStatusWriter({dbPath, recorder: 'memory-core'});
+
+        await writer.publishSuccess(100);
+
+        const guardPath = lifecycleGuardPath(writer.file);
+
+        const ownerPath = path.join(guardPath, 'owner-foreign-container');
+
+        await fs.mkdir(guardPath);
+        await fs.writeFile(ownerPath, '');
+        await fs.writeFile(writer.file, JSON.stringify({
+            schemaVersion: 1,
+            recorder     : 'memory-core',
+            lastSuccessAt: 100,
+            lastFailureAt: 200
+        }));
+
+        writer.publishSuccess(300);
+        await new Promise((resolve, reject) => {
+            setTimeout(async () => {
+                try {
+                    await fs.unlink(ownerPath);
+                    await fs.rmdir(guardPath);
+                    resolve();
+                } catch (error) {
+                    reject(error);
+                }
+            }, 1100);
+        });
+        await writer.flush();
+
+        expect(JSON.parse(await fs.readFile(writer.file, 'utf8'))).toEqual({
+            schemaVersion: 1,
+            recorder     : 'memory-core',
+            lastSuccessAt: 300,
+            lastFailureAt: 200
+        });
+        expect(inspectProviderActivityStatus({
+            dbPath,
+            sinceTs          : 150,
+            requiredRecorders: ['memory-core']
+        })).toEqual({status: 'partial'});
+    });
+
+    test('recovers an abandoned guard beyond the writer stale horizon without a second publication', async () => {
+        const dbPath = path.join(tmpDir, 'shared.sqlite');
+        const writer = createProviderActivityStatusWriter({dbPath, recorder: 'memory-core'});
+
+        await writer.publishSuccess(100);
+
+        const guardPath = lifecycleGuardPath(writer.file);
+
+        await fs.mkdir(guardPath);
+        await fs.writeFile(path.join(guardPath, 'owner-abandoned-container'), '');
+        writer.publishFailure(200);
+        await writer.flush();
+
+        expect(JSON.parse(await fs.readFile(writer.file, 'utf8'))).toEqual({
+            schemaVersion: 1,
+            recorder     : 'memory-core',
+            lastSuccessAt: 100,
+            lastFailureAt: 200
+        });
+        expect(inspectProviderActivityStatus({
+            dbPath,
+            sinceTs          : 150,
+            requiredRecorders: ['memory-core']
+        })).toEqual({status: 'partial'});
+    });
+});

--- a/test/playwright/unit/ai/services/shared/vector/chromaClientPrimitives.spec.mjs
+++ b/test/playwright/unit/ai/services/shared/vector/chromaClientPrimitives.spec.mjs
@@ -16,6 +16,7 @@ import Neo                                  from '../../../../../../../src/Neo.m
 import * as core                            from '../../../../../../../src/core/_export.mjs';
 import {createDynamicTextEmbeddingFunction} from '../../../../../../../ai/services/shared/vector/chromaClientPrimitives.mjs';
 import TextEmbeddingService                 from '../../../../../../../ai/services/memory-core/TextEmbeddingService.mjs';
+import {runWithProviderActivityContext}     from '../../../../../../../ai/services/shared/providerActivityLedger.mjs';
 
 test.describe('Neo.ai.services.shared.vector.chromaClientPrimitives — dynamic embedding function (#13692)', () => {
     test('generate() routes a batch through embedTexts (1h batch path), not per-text embedText (interactive 15s path)', async () => {
@@ -24,12 +25,12 @@ test.describe('Neo.ai.services.shared.vector.chromaClientPrimitives — dynamic 
         // INTERACTIVE embeds. That applied the 15s contentionTimeoutMs to bulk work AND stormed
         // the single local embedder into self-contention. It must instead make ONE embedTexts
         // batch call (the path with the 1h timeout + sequential chunks).
-        const calls    = {embedTexts: [], embedText: []},
+        const calls     = {embedTexts: [], embedText: []},
               origTexts = TextEmbeddingService.embedTexts,
               origText  = TextEmbeddingService.embedText;
 
-        TextEmbeddingService.embedTexts = async (texts, provider) => {
-            calls.embedTexts.push({texts, provider});
+        TextEmbeddingService.embedTexts = async (texts, provider, options) => {
+            calls.embedTexts.push({texts, provider, options});
             return texts.map((_, i) => [i]); // ordered number[][], Chroma's generate contract
         };
         TextEmbeddingService.embedText = async (text, provider) => {
@@ -38,14 +39,33 @@ test.describe('Neo.ai.services.shared.vector.chromaClientPrimitives — dynamic 
         };
 
         try {
-            const fn     = createDynamicTextEmbeddingFunction({providerResolver: () => 'openAiCompatible'}),
-                  result = await fn.generate(['a', 'b', 'c']);
+            const fn = createDynamicTextEmbeddingFunction({
+                      providerResolver: () => 'openAiCompatible',
+                      service         : 'memory-core'
+                  }),
+                  unknownResult = await fn.generate(['a']),
+                  walResult     = await runWithProviderActivityContext({
+                      operationStage: 'mc-wal-drain-embedding',
+                      service       : 'memory-core'
+                  }, () => fn.generate(['b', 'c']));
 
             expect(calls.embedText.length).toBe(0);              // never fan out to the interactive path
-            expect(calls.embedTexts.length).toBe(1);             // exactly one batch call
-            expect(calls.embedTexts[0].texts).toEqual(['a', 'b', 'c']);
+            expect(calls.embedTexts.length).toBe(2);             // exactly one batch call per generate
+            expect(calls.embedTexts[0].texts).toEqual(['a']);
             expect(calls.embedTexts[0].provider).toBe('openAiCompatible');
-            expect(result).toEqual([[0], [1], [2]]);             // ordered embeddings flow back through
+            expect(calls.embedTexts[0].options).toEqual({
+                operationLabel: 'Chroma dynamic text embedding',
+                operationStage: 'unknown',
+                service       : 'memory-core'
+            });
+            expect(calls.embedTexts[1].options).toEqual({
+                operationLabel: 'Chroma dynamic text embedding',
+                operationStage: 'mc-wal-drain-embedding',
+                service       : 'memory-core'
+            });
+            expect(fn.getConfig()).toEqual({});
+            expect(unknownResult).toEqual([[0]]);
+            expect(walResult).toEqual([[0], [1]]);               // ordered embeddings flow back through
         } finally {
             TextEmbeddingService.embedTexts = origTexts;
             TextEmbeddingService.embedText  = origText;


### PR DESCRIPTION
Resolves #16770

Neo now records bounded provider activity at the provider boundary, preserving the distinction between queue wait and execution while attributing work to stable operation stages. The existing `get_memory_core_tool_metrics` observer gains aggregate, in-flight, and recent-completion projections without retaining prompts, raw operation labels, endpoint URLs, credentials, vectors, results, or caller identity.

Evidence: L2 (deterministic queue/provider fixtures, real SQLite lifecycle tests, and strict OpenAPI validation) → L3 required (two concurrent known workloads observed on the deployed shared plane). Residual: AC12 [#16770].

Decision Record impact: aligned with ADR 0019 and ADR 0025. The change adds no config leaf, provider-selection authority, health verdict, diagnosis class, or recovery action.

## Deltas from ticket

- Activity IDs are generated inside the ledger so caller-controlled identifiers cannot enter storage.
- Model identifiers are length/grammar bounded; endpoint-, credential-, userinfo-, and path-shaped values degrade to `unknown`. Model attribution is refined only after provider-owned dispatch code chooses the route; conflicting models across retries conservatively collapse to `unknown`.
- Providers without a Neo-owned queue report `queueDisposition: not-applicable` and a null queue wait. OpenAI-compatible embedding retries remain inside the activity that owns the queued provider slot.
- Best-effort SQLite write loss is disclosed across the Knowledge Base, Memory Core, and orchestrator processes through recorder-owned bounded status sidecars. Atomic max-merge runs under the existing cross-namespace owner-token guard; recent failure stays `partial`, and a missing required recorder stays `unavailable` with empty projections.

## Test Evidence

- Provider queue and chat boundary: `InteractiveBatchQueue.spec.mjs` and `SessionService.buildChatModel.spec.mjs` prove interactive-first ordering, separate wait/execution timing, remote null-wait semantics, stripped controls, and fail-open observers.
- Embedding boundary: `TextEmbeddingService.spec.mjs` and `TextEmbeddingService.retry.spec.mjs` prove native and queued providers, one activity per chunk, retries within one activity, cancellation, and unchanged request ordering.
- Storage and observer: `providerActivityLedger.spec.mjs`, `providerActivityStatusStore.spec.mjs`, `MemoryCoreRecorderService.spec.mjs`, and `KBRecorderService.spec.mjs` use real SQLite and filesystem artifacts to prove the exact safe-column schema, cross-process sticky partial/unavailable states, bounded projections, lock-contention behavior neutrality, and negative sensitive-data fixtures.
- Stage ownership: Knowledge Base query/ask/ingestion, Memory Core WAL/mini/session work, REM, and canary specs assert the stable source-owned stage keys, including no synthesis on an empty-reference ask.
- API contract: `OpenApiValidatorCompliance.spec.mjs` proves the new nested response schemas compile and retain nullable unmeasured waits.
- Focused changed-surface matrix: 399 passed, 7 intentionally skipped.
- `npm run ai:lint-openapi-service-parity`: passed (40 services; 0 consumed-but-undeclared parameters).
- `npm run ai:lint-config-template-ssot`: passed (0 inline-env defaults; all config authority checks baselined).
- `npm run ai:lint-mcp-test-locations` and `npm run ai:lint-retry-bounds`: passed.
- `npm run agent-preflight -- --no-fix <42 changed files>`: passed; ticket archaeology reported 0 violations.
- `git diff --check`, `node --check` over 41 changed `.mjs` files, and block-alignment validation: passed.

## Post-Merge Validation

- [ ] Run two concurrent known workloads against the deployed shared plane and verify `get_memory_core_tool_metrics.providerActivity` distinguishes both operation stages.
- [ ] Confirm the deployed observer separates measured Neo queue wait from provider execution and keeps unqueued-provider wait null without shell or log inference.

Authored by Euclid (GPT-5, Codex Desktop). Session 0473b65d-090b-412a-a926-b90e5851f58a.
