### PR TITLE
feat(fleet): the roster carries the plane's presence band as its own axis (#16737)

### DIFF
--- a/ai/services/fleet/FleetControlBridge.mjs
+++ b/ai/services/fleet/FleetControlBridge.mjs
@@ -713,9 +713,10 @@ class FleetControlBridge extends Base {
         // without the producer method at all — yields not-wired/unknown, never a guessed state.
         // Read concurrently: the axes share no state, so serializing them would just add the
         // slower one's latency to every roster read.
-        const [wake, throttle] = await Promise.all([
+        const [wake, throttle, presence] = await Promise.all([
             manager.fleetWakeStatus?.()     ?? null,
-            manager.fleetThrottleStatus?.() ?? null
+            manager.fleetThrottleStatus?.() ?? null,
+            manager.fleetPresenceStatus?.() ?? null
         ]);
 
         return createFleetCockpitStatus({
@@ -724,6 +725,7 @@ class FleetControlBridge extends Base {
             runtimeStatus : manager.fleetRuntimeStatus() ?? [],
             wakeStatus    : wake?.states ?? [],
             throttleStatus: throttle?.states ?? [],
+            presenceStatus: presence?.states ?? [],
             capabilities  : {
                 activity: createNotWiredCapability(FLEET_COCKPIT_SOURCES.activity, 'activity rides the dedicated fleetActivity verb'),
                 runtime : {
@@ -732,7 +734,8 @@ class FleetControlBridge extends Base {
                     confidence: 'observed'
                 },
                 wake    : wake?.capability     ?? createNotWiredCapability(FLEET_COCKPIT_SOURCES.wake, 'wake-state producer not wired'),
-                throttle: throttle?.capability ?? createNotWiredCapability(FLEET_COCKPIT_SOURCES.throttle, 'throttle-state producer not wired')
+                throttle: throttle?.capability ?? createNotWiredCapability(FLEET_COCKPIT_SOURCES.throttle, 'throttle-state producer not wired'),
+                presence: presence?.capability ?? createNotWiredCapability(FLEET_COCKPIT_SOURCES.presence, 'presence producer not wired')
             }
         });
     }

--- a/ai/services/fleet/FleetManager.mjs
+++ b/ai/services/fleet/FleetManager.mjs
@@ -3,6 +3,7 @@ import {fileURLToPath}                  from 'url';
 import Base                             from '../../../src/core/Base.mjs';
 import FleetLifecycleService            from './FleetLifecycleService.mjs';
 import {inspectFleetRepos}              from './inspectFleetRepos.mjs';
+import {readFleetPresenceSnapshot}      from './fleetPresenceStateAdapter.mjs';
 import {readFleetThrottleStateSnapshot} from './fleetThrottleStateAdapter.mjs';
 import {readFleetWakeStateSnapshot}     from './fleetWakeStateAdapter.mjs';
 import {startAgentProvisioned}          from './startAgentProvisioned.mjs';
@@ -96,6 +97,15 @@ class FleetManager extends Base {
      * @member {Object|null} throttleStateOptions=null
      */
     throttleStateOptions = null
+    /**
+     * Presence observation options for {@link fleetPresenceStatus} — `{readPresence,
+     * presenceIdentityFor}` per the `fleetPresenceStateAdapter` contract. `null` ⇒ every row is
+     * honestly `unknown` under a degraded capability: the composing entrypoint injects the
+     * identity-proven plane `who_is_online` reader in plane mode and leaves host mode unbound
+     * until a host presence surface lands. Plain field, mirroring the sibling seams.
+     * @member {Object|null} presenceStateOptions=null
+     */
+    presenceStateOptions = null
 
     /**
      * @summary Resolve (field > env > default) the absolute fleet-managed checkout root.
@@ -250,6 +260,28 @@ class FleetManager extends Base {
         return readFleetThrottleStateSnapshot({
             agents: this.getLifecycleService().getRegistry().listAgents(),
             ...(this.throttleStateOptions || {})
+        });
+    }
+
+    /**
+     * @summary Turnkey presence observability: the per-agent presence axis of the truth-preserving
+     * presence contract across the registered roster — the THIRD independent signal
+     * beside {@link fleetWakeStatus} (wake routes) and {@link fleetThrottleStatus} (throttle),
+     * none inferring another.
+     *
+     * Delegates to `fleetPresenceStateAdapter.readFleetPresenceSnapshot` with the registry roster
+     * (one row per REGISTERED agent, the sibling views' one-agent-set rule) plus the injected
+     * {@link #member-presenceStateOptions}. Fail-honest: with no injected reader every row reads
+     * `unknown` under a `degraded/none` capability — "we cannot see presence" stays distinguishable
+     * from "the fleet is dark"; a band is never invented.
+     * @returns {Promise<{capability: Object, states: Object[]}>} Adapter snapshot: per-agent
+     * `{agentId, presence, lastSeenAt, confidence, source}` rows (+ `reason` on `unknown`) and the
+     * capability envelope.
+     */
+    fleetPresenceStatus() {
+        return readFleetPresenceSnapshot({
+            agents: this.getLifecycleService().getRegistry().listAgents(),
+            ...(this.presenceStateOptions || {})
         });
     }
 

--- a/ai/services/fleet/devFleetServer.mjs
+++ b/ai/services/fleet/devFleetServer.mjs
@@ -179,6 +179,14 @@ async function boot() {
         console.log('[fleet] wake-state seam stays host-local (host plane: daemon PID file + host graph subscription scan)')
     }
 
+    // The roster's presence AXIS rides the same proven plane reader as the decomposed
+    // routes verb below — one producer contract, two consumers, never a second authority. Host
+    // mode stays null ⇒ the adapter renders every row honestly `unknown` under a degraded
+    // capability until a host presence surface lands.
+    FleetManager.presenceStateOptions = planeClient
+        ? {readPresence: createPlaneWhoIsOnlineReader(planeClient)}
+        : null;
+
     // The decomposed wake-routes verb rides the SAME per-mode truth the fused wake axis was bound
     // to above — one authority per axis, never a second source. Presence joins plane-side over the
     // proven client; host mode wraps the daemon PID-file liveness read and leaves presence and

--- a/ai/services/fleet/fleetCockpitStatus.mjs
+++ b/ai/services/fleet/fleetCockpitStatus.mjs
@@ -11,7 +11,8 @@ const WIRE_SOURCES = Object.freeze({
         runtime    : 'fleet:runtimeStatus',
         lifecycle  : 'fleet:lifecycle',
         wake       : 'fleet:wakeState',
-        throttle   : 'fleet:throttleState'
+        throttle   : 'fleet:throttleState',
+        presence   : 'fleet:presenceState'
     })
 
 export const FLEET_COCKPIT_EVENT_TYPES = Object.freeze([
@@ -74,7 +75,7 @@ function githubAvatarUrl(githubUsername) {
  * @param {Object}   options.capabilities  Optional source-capability overrides from wired adapters.
  * @returns {Object} serializable cockpit DTO `{sources, capabilities, rows, events}`.
  */
-export function createFleetCockpitStatus({agents = [], fleetStatus = [], runtimeStatus = [], wakeStatus = [], throttleStatus = [], events = [], capabilities = {}} = {}) {
+export function createFleetCockpitStatus({agents = [], fleetStatus = [], runtimeStatus = [], wakeStatus = [], throttleStatus = [], presenceStatus = [], events = [], capabilities = {}} = {}) {
     const suppliedCapabilities = capabilities || {}
 
     const statusByAgentId = new Map(
@@ -93,6 +94,10 @@ export function createFleetCockpitStatus({agents = [], fleetStatus = [], runtime
         throttleStatus.map(entry => [entry.agentId || entry.id, sanitizePayload(entry)])
     )
 
+    const presenceByAgentId = new Map(
+        presenceStatus.map(entry => [entry.agentId || entry.id, sanitizePayload(entry)])
+    )
+
     return {
         sources     : FLEET_COCKPIT_SOURCES,
         capabilities: {
@@ -105,7 +110,12 @@ export function createFleetCockpitStatus({agents = [], fleetStatus = [], runtime
             // The throttle telltale axis (S2), same contract as wake: `none | overage |
             // rate-limited | unknown`. No trustworthy platform source exists yet, so this axis is
             // expected to sit degraded — which is the honest report, not a gap to paper over.
-            throttle: suppliedCapabilities.throttle || createNotWiredCapability(FLEET_COCKPIT_SOURCES.throttle, 'throttle-state producer not wired')
+            throttle: suppliedCapabilities.throttle || createNotWiredCapability(FLEET_COCKPIT_SOURCES.throttle, 'throttle-state producer not wired'),
+            // The presence axis: the plane's who_is_online band embryo (`online |
+            // idle | dark | benched | neverConnected | unknown`), the third independent signal —
+            // presence-fresh ≠ wake-route-healthy ≠ identity-bound. Not-wired is the honest
+            // default until the assembler passes a snapshot; a band is never guessed.
+            presence: suppliedCapabilities.presence || createNotWiredCapability(FLEET_COCKPIT_SOURCES.presence, 'presence producer not wired')
         },
         rows: agents.map(agent => {
             const publicAgent = sanitizePayload(agent),
@@ -113,7 +123,8 @@ export function createFleetCockpitStatus({agents = [], fleetStatus = [], runtime
                   repoStatus  = statusByAgentId.get(agentId) || null,
                   runtime     = runtimeByAgentId.get(agentId) || null,
                   wake        = wakeByAgentId.get(agentId) || null,
-                  throttle    = throttleByAgentId.get(agentId) || null
+                  throttle    = throttleByAgentId.get(agentId) || null,
+                  presence    = presenceByAgentId.get(agentId) || null
 
             return {
                 id            : agentId,
@@ -184,6 +195,25 @@ export function createFleetCockpitStatus({agents = [], fleetStatus = [], runtime
                         confidence: 'none',
                         reason    : 'throttle-state producer not wired'
                     },
+                // The presence axis, same closed-enum discipline as its siblings:
+                // `state` never leaves the plane's band embryo + `unknown`, absence of a producer
+                // included. `lastSeenAt` carries the producer's per-seat recency verbatim — the
+                // tier-degradation contract forbids deriving a finer band here than was emitted.
+                presence: presence
+                    ? {
+                        source    : FLEET_COCKPIT_SOURCES.presence,
+                        state     : presence.presence ?? 'unknown',
+                        confidence: presence.confidence ?? 'none',
+                        lastSeenAt: presence.lastSeenAt ?? null,
+                        ...(presence.reason != null && {reason: presence.reason})
+                    }
+                    : {
+                        source    : FLEET_COCKPIT_SOURCES.presence,
+                        state     : 'unknown',
+                        confidence: 'none',
+                        lastSeenAt: null,
+                        reason    : 'presence producer not wired'
+                    },
                 sources: {
                     roster: {
                         source    : FLEET_COCKPIT_SOURCES.roster,
@@ -209,6 +239,11 @@ export function createFleetCockpitStatus({agents = [], fleetStatus = [], runtime
                         source    : FLEET_COCKPIT_SOURCES.throttle,
                         state     : throttle ? 'wired' : 'not-wired',
                         confidence: throttle ? (throttle.confidence ?? 'none') : 'none'
+                    },
+                    presence: {
+                        source    : FLEET_COCKPIT_SOURCES.presence,
+                        state     : presence ? 'wired' : 'not-wired',
+                        confidence: presence ? (presence.confidence ?? 'none') : 'none'
                     }
                 }
             }

--- a/ai/services/fleet/fleetPresenceStateAdapter.mjs
+++ b/ai/services/fleet/fleetPresenceStateAdapter.mjs
@@ -60,7 +60,11 @@ export const PRESENCE_SOURCE_LABEL = 'fleet:presenceState'
  *     honestly `unknown` under a degraded capability (host mode's documented truth until a host
  *     presence surface lands).
  * @param {Function} [options.presenceIdentityFor] `(agent) => String` roster row → presence report
- *     identity. Defaults to the wake seam's identity shape: `@<githubUsername ?? id>`.
+ *     identity. The default canonicalizes into the report's `@<login>` shape while accepting the
+ *     registry's FULL production input domain: `defineAgent` stores `githubUsername` unchanged and
+ *     requires only truthiness, so a persisted `@neo-gpt` and a bare `neo-gpt` are BOTH accepted
+ *     spellings of one seat — leading `@`s are stripped before the single canonical prefix, so an
+ *     answered plane row is never converted into a fabricated `seat absent` by spelling alone.
  * @param {Date|String} [options.capturedAt] Capture timestamp — the observation-time bound above.
  * @returns {Promise<{capability: Object, states: Object[]}>} `states` rows:
  *     `{agentId, presence, lastSeenAt, confidence, source}` (+ `reason` when `presence` is
@@ -69,7 +73,7 @@ export const PRESENCE_SOURCE_LABEL = 'fleet:presenceState'
 export async function readFleetPresenceSnapshot({
     agents = [],
     readPresence = null,
-    presenceIdentityFor = agent => `@${agent.githubUsername ?? agent.id}`,
+    presenceIdentityFor = presenceIdentityForAgent,
     capturedAt = new Date()
 } = {}) {
     const hasReader = typeof readPresence === 'function',
@@ -155,6 +159,21 @@ export async function readFleetPresenceSnapshot({
         },
         states
     }
+}
+
+/**
+ * @summary The default registry-row → presence-report identity join, canonicalized over the
+ * registry's production input domain: `FleetRegistryService.defineAgent` stores `githubUsername`
+ * unchanged (truthiness is its only requirement), so `neo-gpt` and `@neo-gpt` are both accepted
+ * persisted spellings of one seat. Leading `@`s are stripped before the single canonical prefix —
+ * a spelling variant must never convert an ANSWERED plane row into a fabricated `seat absent`.
+ * Exported so the wake-routes sibling (and the family repair of the shared join pattern) can adopt
+ * the same canonicalization instead of growing a second divergent one.
+ * @param {Object} agent Registry roster row.
+ * @returns {String} `@<login>` — the presence report's identity shape.
+ */
+export function presenceIdentityForAgent(agent) {
+    return `@${String(agent.githubUsername ?? agent.id).replace(/^@+/, '')}`
 }
 
 function asArray(value) {

--- a/ai/services/fleet/fleetPresenceStateAdapter.mjs
+++ b/ai/services/fleet/fleetPresenceStateAdapter.mjs
@@ -1,0 +1,176 @@
+/**
+ * @module ai/services/fleet/fleetPresenceStateAdapter
+ * @summary Maps the plane's roster-presence report onto the Fleet roster DTO — the presence axis
+ * of the truth-preserving presence contract, the THIRD independent signal beside the
+ * wake and throttle telltales: presence-fresh ≠ wake-route-healthy ≠ identity-bound, and no axis
+ * ever infers another.
+ *
+ * The truth source is the identity-proven plane client's `who_is_online` report (the shipped band
+ * embryo: `online | idle | dark | benched | neverConnected`, plus per-row activity recency),
+ * injected through the SAME bulk `readPresence` seam the decomposed wake-routes source consumes —
+ * one producer contract, two consumers, never a second authority. Host mode has no presence
+ * surface yet: an absent reader leaves every row honestly `unknown` under a `degraded/none`
+ * capability. That is the tier-degradation rendering contract at the producer boundary: *a
+ * liveness tier a deployment cannot emit produces ABSENCE OF SIGNAL, never a verdict* — "we cannot
+ * see presence" stays mechanically distinguishable from "the fleet is dark".
+ *
+ * Row-local honesty mirrors the wake-routes presence axis exactly: a seat missing from a HEALTHY
+ * report answers `unknown` for itself (with its own reason) without degrading its siblings or the
+ * capability — the producer answered in-contract; absence of one seat is that row's truth. Only a
+ * missing, throwing, or out-of-contract PRODUCER degrades the capability envelope.
+ *
+ * Band refinement residual (deliberate): the ticket's full beacon-horizon vocabulary
+ * (`active-turn / fresh / recent / dark` from `freshUntil`/`expiresAt`) lands when the plane's
+ * verbose rows vouch those horizons per seat; until then this axis carries the plane's emitted
+ * band set plus `lastSeenAt` recency verbatim — rendered tiers are named, absent tiers stay
+ * absent, and nothing here manufactures a finer band than the producer emitted.
+ */
+
+import {redactCredentials} from './redactCredentials.mjs'
+
+/**
+ * The closed presence band vocabulary — the plane's shipped `who_is_online` embryo. This adapter
+ * is the vocabulary's ONE exporting home; the decomposed wake-routes source imports it for its own
+ * presence axis so the two consumers can never drift.
+ * @type {String[]}
+ */
+export const PRESENCE_STATES = Object.freeze(['online', 'idle', 'dark', 'benched', 'neverConnected'])
+
+export const PRESENCE_SOURCE_LABEL = 'fleet:presenceState'
+
+/**
+ * @summary Reads the fleet-wide presence snapshot: one band row per registered agent plus a
+ * capability envelope declaring whether the presence producer answered.
+ *
+ * Capability semantics: `wired/observed` when the bulk reader answered in-contract (individual
+ * seats absent from the report stay row-local `unknown` — the producer still answered);
+ * `degraded/none` when no reader exists for this mode or the reader threw / answered out of
+ * contract. There is no `partial` tier here by design: the producer is ONE bulk report, so it
+ * either vouched the snapshot or it did not — per-seat gaps are row truth, not producer health.
+ *
+ * **Freshness bound (the reader contract):** the reader runs synchronously *within* this snapshot,
+ * so the envelope's `capturedAt` IS the observation-time bound for every row. `lastSeenAt` carries
+ * the producer's per-seat activity recency verbatim; staleness beyond the snapshot bound is the
+ * producer's residual to declare, never this adapter's to hide.
+ * @param {Object} options={}
+ * @param {Object[]} [options.agents] Registry roster rows; each needs an `id`.
+ * @param {Function|null} [options.readPresence] `() => Promise<Object>` resolving the
+ *     roster-presence report (`who_is_online` payload shape: `{agents: [{identity, state, reason,
+ *     signals}]}` — the same seam `wireFleetWakeRoutesSource` consumes). Absent ⇒ every row is
+ *     honestly `unknown` under a degraded capability (host mode's documented truth until a host
+ *     presence surface lands).
+ * @param {Function} [options.presenceIdentityFor] `(agent) => String` roster row → presence report
+ *     identity. Defaults to the wake seam's identity shape: `@<githubUsername ?? id>`.
+ * @param {Date|String} [options.capturedAt] Capture timestamp — the observation-time bound above.
+ * @returns {Promise<{capability: Object, states: Object[]}>} `states` rows:
+ *     `{agentId, presence, lastSeenAt, confidence, source}` (+ `reason` when `presence` is
+ *     `unknown`).
+ */
+export async function readFleetPresenceSnapshot({
+    agents = [],
+    readPresence = null,
+    presenceIdentityFor = agent => `@${agent.githubUsername ?? agent.id}`,
+    capturedAt = new Date()
+} = {}) {
+    const hasReader = typeof readPresence === 'function',
+          states    = []
+
+    let byIdentity = null,
+        readReason = hasReader
+            ? null
+            : 'no presence truth source exists for this mode: plane mode injects the who_is_online reader; a host presence surface has not landed'
+
+    if (hasReader) {
+        try {
+            const payload = await readPresence()
+
+            if (!Array.isArray(payload?.agents)) {
+                readReason = 'presence answer unreadable'
+            } else {
+                byIdentity = new Map()
+
+                for (const row of payload.agents) {
+                    // Out-of-vocabulary rows are skipped, not admitted: a producer emitting a band
+                    // this contract does not know must not leak an open enum to every consumer —
+                    // the affected seat answers `unknown` via the absent-row path below instead.
+                    if (typeof row?.identity !== 'string' || !PRESENCE_STATES.includes(row.state)) continue
+
+                    byIdentity.set(row.identity, {
+                        state     : row.state,
+                        lastSeenAt: row.signals?.activityRecency?.lastActivityAt ?? null,
+                        reason    : typeof row.reason === 'string' ? redactReason(row.reason) : null
+                    })
+                }
+            }
+        } catch (error) {
+            readReason = redactReason(error) || 'presence read failed'
+        }
+    }
+
+    for (const agent of asArray(agents)) {
+        const agentId = agent?.id
+
+        if (!agentId) continue
+
+        let presence   = 'unknown',
+            lastSeenAt = null,
+            rowReason  = readReason
+
+        if (byIdentity) {
+            const row = byIdentity.get(presenceIdentityFor(agent))
+
+            if (row) {
+                presence   = row.state
+                lastSeenAt = row.lastSeenAt
+                rowReason  = row.reason
+            } else {
+                rowReason = 'seat absent from the presence report'
+            }
+        }
+
+        const entry = {
+            agentId,
+            presence,
+            lastSeenAt,
+            confidence: presence === 'unknown' ? 'none' : 'observed',
+            source    : PRESENCE_SOURCE_LABEL
+        }
+
+        if (presence === 'unknown') {
+            entry.reason = rowReason || 'presence unreadable'
+        }
+
+        states.push(entry)
+    }
+
+    const producerAnswered = Boolean(byIdentity)
+
+    return {
+        capability: {
+            source    : PRESENCE_SOURCE_LABEL,
+            state     : producerAnswered ? 'wired' : 'degraded',
+            confidence: producerAnswered ? 'observed' : 'none',
+            capturedAt: toIsoString(capturedAt),
+            reason    : producerAnswered ? null : readReason
+        },
+        states
+    }
+}
+
+function asArray(value) {
+    return Array.isArray(value) ? value : []
+}
+
+function redactReason(value) {
+    if (value == null) return null
+
+    const text = String(value?.message || value || '').replace(/\s+/g, ' ').trim().slice(0, 240)
+
+    return text ? redactCredentials(text) : null
+}
+
+function toIsoString(value) {
+    const date = value instanceof Date ? value : new Date(value)
+
+    return Number.isNaN(date.getTime()) ? new Date().toISOString() : date.toISOString()
+}

--- a/ai/services/fleet/fleetWakeRoutesSource.mjs
+++ b/ai/services/fleet/fleetWakeRoutesSource.mjs
@@ -1,4 +1,5 @@
 import {createSeatArmingReader} from './seatArmingReader.mjs';
+import {PRESENCE_STATES}        from './fleetPresenceStateAdapter.mjs';
 import {redactCredentials}      from './redactCredentials.mjs'
 
 /**
@@ -26,7 +27,7 @@ export const WAKE_ROUTES_SOURCE_LABEL = 'fleet:wakeRoutes'
 
 const
     DELIVERY_STATES  = Object.freeze(['alive', 'down', 'unknown']),
-    PRESENCE_STATES  = Object.freeze(['online', 'idle', 'dark', 'benched', 'neverConnected']),
+    // PRESENCE_STATES imports from the adapter sibling — the vocabulary's one exporting home.
     ARMED_UNOBSERVED = Object.freeze({
         state : 'unobserved',
         // The absent-reader branch, not a structural gap: a deployment with no local wake lane

--- a/ai/services/fleet/fleetWakeRoutesSource.mjs
+++ b/ai/services/fleet/fleetWakeRoutesSource.mjs
@@ -1,6 +1,6 @@
-import {createSeatArmingReader} from './seatArmingReader.mjs';
-import {PRESENCE_STATES}        from './fleetPresenceStateAdapter.mjs';
-import {redactCredentials}      from './redactCredentials.mjs'
+import {createSeatArmingReader}                    from './seatArmingReader.mjs';
+import {PRESENCE_STATES, presenceIdentityForAgent} from './fleetPresenceStateAdapter.mjs';
+import {redactCredentials}                         from './redactCredentials.mjs'
 
 /**
  * @module ai/services/fleet/fleetWakeRoutesSource
@@ -62,7 +62,10 @@ const
  *     roster-presence report (`who_is_online` payload shape: `{agents: [{identity, state,
  *     reason, signals}]}`). Absent ⇒ the presence axis is a typed `unobserved`.
  * @param {Function} [options.wakeIdentityFor] `(agent) => String` roster row → wake identity.
- *     Default: `'@' + (githubUsername ?? id)` — the swarm's mailbox-identity convention.
+ *     Default: the exported presence canonicalizer — ONE registry→plane identity boundary for
+ *     both live presence consumers, accepting the registry's full production spelling domain
+ *     (`defineAgent` persists `githubUsername` unchanged, so `@`-prefixed rows are accepted
+ *     spellings; blind prefixing would fabricate `seat absent` for them on every axis).
  * @param {Function} [options.now] Clock override for tests.
  * @returns {{readWakeRoutes: Function}}
  */
@@ -75,7 +78,7 @@ export function createFleetWakeRoutesSource({
     resolveSeatArming = null,
     wakeReceiverManifestPath = null,
     readPresence = null,
-    wakeIdentityFor = agent => `@${agent.githubUsername ?? agent.id}`,
+    wakeIdentityFor = presenceIdentityForAgent,
     now = () => new Date()
 } = {}) {
     if (typeof listAgents !== 'function') {

--- a/apps/agentos/config/cockpitSources.mjs
+++ b/apps/agentos/config/cockpitSources.mjs
@@ -24,5 +24,6 @@ export const FLEET_COCKPIT_SOURCES = Object.freeze({
     runtime    : 'fleet:runtimeStatus',
     lifecycle  : 'fleet:lifecycle',
     wake       : 'fleet:wakeState',
-    throttle   : 'fleet:throttleState'
+    throttle   : 'fleet:throttleState',
+    presence   : 'fleet:presenceState'
 });

--- a/apps/agentos/model/FleetAgent.mjs
+++ b/apps/agentos/model/FleetAgent.mjs
@@ -83,6 +83,14 @@ class FleetAgent extends Model {
             name        : 'throttle',
             defaultValue: null
         }, {
+            // The presence axis, same passthrough contract as `wake`/`throttle`: the
+            // roster row's `{source, state, confidence, lastSeenAt, reason?}` observation, where
+            // `state` is the plane's who_is_online band embryo (`online | idle | dark | benched |
+            // neverConnected | unknown`). The THIRD independent signal — presence-fresh ≠
+            // wake-route-healthy ≠ identity-bound — and the view never re-derives or fuses it.
+            name        : 'presence',
+            defaultValue: null
+        }, {
             // the launch seam's derived launchability truth (a launch template exists for the
             // family), stamped Brain-side on the roster row; tri-state — true / false / null
             // (not read back yet) — so the field carries no type coercion

--- a/apps/agentos/view/fleet/AgentCard.mjs
+++ b/apps/agentos/view/fleet/AgentCard.mjs
@@ -5,6 +5,20 @@ import FamilyRail             from './FamilyRail.mjs';
 import Image                  from '../../../../src/component/Image.mjs';
 import StateDot, {stateLabel} from './StateDot.mjs';
 
+/**
+ * The closed presence-band → label map (the plane's who_is_online embryo). Only these render; an
+ * out-of-set or `unknown` state keeps the presence element hidden — the closed-set discipline the
+ * session-state label already follows.
+ * @type {Object}
+ */
+const PRESENCE_BAND_LABEL = Object.freeze({
+    online        : 'online',
+    idle          : 'idle',
+    dark          : 'dark',
+    benched       : 'benched',
+    neverConnected: 'never connected'
+});
+
 import {normalizeFleetSources, resolveFleetDisplayState, summarizeFleetSources} from './sourceHealth.mjs';
 
 import {describeNameProvenance, resolveNameSlot} from './nameSlot.mjs';
@@ -167,6 +181,15 @@ class AgentCard extends Container {
                         cls      : ['fm-card-state'],
                         flex     : 'none',
                         reference: 'card-state'
+                    }, {
+                        // the presence band: the plane's who_is_online observation, the THIRD
+                        // independent axis — never fused into the session-state word. Hidden unless
+                        // an OBSERVED band exists: absence of signal, never a verdict.
+                        ntype    : 'component',
+                        cls      : ['fm-card-presence'],
+                        flex     : 'none',
+                        hidden   : true,
+                        reference: 'card-presence'
                     }, {
                         // the open-lane count badge (openLaneCount ONLY — never the engine); right-pinned
                         // in the state-line (SCSS margin-left:auto). null count = no badge (never "0 lanes").
@@ -343,6 +366,21 @@ class AgentCard extends Container {
         me.getReference('card-state').set({
             cls : hot ? ['fm-card-state', 'fm-state-hot'] : ['fm-card-state'],
             text: stateLabel(displayState)
+        });
+
+        // The presence band: session state says what the resident's PROCESS does;
+        // presence says whether the SEAT is alive anywhere (the plane's who_is_online graph
+        // observation). Kept separate by construction — rendered only when the producer OBSERVED
+        // a band; unknown/absent stays hidden (tier-degradation: absence of signal, never a
+        // verdict, never a fabricated offline).
+        const
+            presence         = record.presence ?? null,
+            presenceObserved = presence?.confidence === 'observed' &&
+                Object.hasOwn(PRESENCE_BAND_LABEL, presence?.state);
+
+        me.getReference('card-presence').set({
+            hidden: !presenceObserved,
+            text  : presenceObserved ? `◉ ${PRESENCE_BAND_LABEL[presence.state]}` : ''
         });
 
         // the name slot: the folded display name as MUTABLE DISPLAY STATE over the durable id

--- a/apps/agentos/view/fleet/FleetCockpit.mjs
+++ b/apps/agentos/view/fleet/FleetCockpit.mjs
@@ -3030,6 +3030,7 @@ class FleetCockpit extends Container {
             // a PRODUCED fact (null resolver, unreadable source, unwired producer). Re-deriving it
             // here would make "we looked and cannot see" indistinguishable from "we never asked" —
             // the DTO's own discipline, the same reason `openLaneCount` is a passthrough.
+            presence: row.presence ?? null,
             throttle: row.throttle ?? null,
             wake    : row.wake ?? null
         }

--- a/resources/scss/src/apps/agentos/fleet/AgentCard.scss
+++ b/resources/scss/src/apps/agentos/fleet/AgentCard.scss
@@ -158,6 +158,18 @@
         }
     }
 
+    /* the presence band: the plane's who_is_online observation — text-only, --fm-ink-dim,
+       the third axis beside the state word + telltale. Hidden entirely unless OBSERVED: absence
+       of signal, never a verdict. */
+    .fm-card-presence {
+        flex       : none;
+        font-family: var(--fm-font-mono);
+        font-size  : 10px;
+        line-height: 1;
+        white-space: nowrap;
+        color      : var(--fm-ink-dim);
+    }
+
     /* the open-lane count badge — right-pinned; openLaneCount ONLY, never the engine */
     .fm-card-lane-count {
         flex         : none;

--- a/test/playwright/unit/ai/services/fleet/fleetCockpitStatus.spec.mjs
+++ b/test/playwright/unit/ai/services/fleet/fleetCockpitStatus.spec.mjs
@@ -268,6 +268,46 @@ test.describe('fleetCockpitStatus - Body-side cockpit DTO contract', () => {
         expect(snapshot.capabilities.wake).toMatchObject({state: 'not-wired'})
     })
 
+    // The presence row holds the identical closed-enum discipline: absence of a producer is
+    // `unknown` in the observation field; the wiring fact lives only in capability + sources.
+    test('an unwired presence producer reads unknown/none in the ROW, and not-wired only in the wiring axes', () => {
+        const snapshot = createFleetCockpitStatus({agents: [{id: 'clio', githubUsername: 'neo-fable-clio'}]}),
+              row      = snapshot.rows[0]
+
+        expect(row.presence).toEqual({
+            source    : FLEET_COCKPIT_SOURCES.presence,
+            state     : 'unknown',
+            confidence: 'none',
+            lastSeenAt: null,
+            reason    : 'presence producer not wired'
+        })
+        expect(row.sources.presence).toMatchObject({state: 'not-wired', confidence: 'none'})
+        expect(snapshot.capabilities.presence).toMatchObject({state: 'not-wired'})
+    })
+
+    test('a wired presence row travels WHOLE — band, recency, confidence, never re-derived', () => {
+        const snapshot = createFleetCockpitStatus({
+            agents        : [{id: 'clio', githubUsername: 'neo-fable-clio'}],
+            presenceStatus: [{
+                agentId   : 'clio',
+                presence  : 'online',
+                lastSeenAt: '2026-08-09T11:00:00.000Z',
+                confidence: 'observed',
+                source    : FLEET_COCKPIT_SOURCES.presence
+            }],
+            capabilities: {presence: {source: FLEET_COCKPIT_SOURCES.presence, state: 'wired', confidence: 'observed'}}
+        })
+
+        expect(snapshot.rows[0].presence).toEqual({
+            source    : FLEET_COCKPIT_SOURCES.presence,
+            state     : 'online',
+            confidence: 'observed',
+            lastSeenAt: '2026-08-09T11:00:00.000Z'
+        })
+        expect(snapshot.rows[0].sources.presence).toMatchObject({state: 'wired', confidence: 'observed'})
+        expect(snapshot.capabilities.presence).toMatchObject({state: 'wired'})
+    })
+
     test('an unwired throttle producer reads unknown/none in the ROW, not-wired only in the wiring axes', () => {
         const snapshot = createFleetCockpitStatus({agents: [{id: 'grace'}]}),
               row      = snapshot.rows[0]

--- a/test/playwright/unit/ai/services/fleet/fleetPresenceStateAdapter.spec.mjs
+++ b/test/playwright/unit/ai/services/fleet/fleetPresenceStateAdapter.spec.mjs
@@ -20,6 +20,7 @@ import * as core      from '../../../../../../src/core/_export.mjs'
 import {
     PRESENCE_SOURCE_LABEL,
     PRESENCE_STATES,
+    presenceIdentityForAgent,
     readFleetPresenceSnapshot
 } from '../../../../../../ai/services/fleet/fleetPresenceStateAdapter.mjs'
 
@@ -159,6 +160,42 @@ test.describe('fleetPresenceStateAdapter — healthy report (band join)', () => 
             {states} = await readFleetPresenceSnapshot({agents: roster, readPresence: () => payload})
 
         expect(states.map(row => row.presence)).toEqual([...PRESENCE_STATES])
+    })
+
+    test('the default join accepts the registry\'s FULL production spelling domain — a persisted leading @ never fabricates absence', async () => {
+        // defineAgent stores githubUsername unchanged (truthiness is its only requirement), so a
+        // persisted '@neo-gpt' is an ACCEPTED production spelling of the same seat as 'neo-gpt'.
+        const {capability, states} = await readFleetPresenceSnapshot({
+            agents: [
+                {id: 'prefixed', githubUsername: '@neo-gpt'},
+                {id: 'bare',     githubUsername: 'neo-fable-clio'}
+            ],
+            readPresence: () => ({agents: [
+                {identity: '@neo-gpt',        state: 'online'},
+                {identity: '@neo-fable-clio', state: 'idle'}
+            ]})
+        })
+
+        expect(capability.state).toBe('wired')
+        expect(states.find(row => row.agentId === 'prefixed').presence).toBe('online')
+        expect(states.find(row => row.agentId === 'bare').presence).toBe('idle')
+
+        // the canonicalizer itself: one prefix, degenerate stacking stripped, id fallback covered
+        expect(presenceIdentityForAgent({githubUsername: '@neo-gpt'})).toBe('@neo-gpt')
+        expect(presenceIdentityForAgent({githubUsername: '@@weird'})).toBe('@weird')
+        expect(presenceIdentityForAgent({id: '@already'})).toBe('@already')
+    })
+
+    test('two registry instances sharing one identity both receive the band — the intentional cardinality', async () => {
+        const {states} = await readFleetPresenceSnapshot({
+            agents: [
+                {id: 'seat-a', githubUsername: 'neo-gpt'},
+                {id: 'seat-b', githubUsername: 'neo-gpt'}
+            ],
+            readPresence: () => ({agents: [{identity: '@neo-gpt', state: 'online'}]})
+        })
+
+        expect(states.map(row => row.presence)).toEqual(['online', 'online'])
     })
 
     test('a custom presenceIdentityFor overrides the identity join', async () => {

--- a/test/playwright/unit/ai/services/fleet/fleetPresenceStateAdapter.spec.mjs
+++ b/test/playwright/unit/ai/services/fleet/fleetPresenceStateAdapter.spec.mjs
@@ -1,0 +1,183 @@
+import {setup} from '../../../../setup.mjs'
+
+const appName = 'FleetPresenceStateAdapterTest'
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name             : appName,
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+})
+
+import {test, expect} from '@playwright/test'
+import Neo            from '../../../../../../src/Neo.mjs'
+import * as core      from '../../../../../../src/core/_export.mjs'
+
+import {
+    PRESENCE_SOURCE_LABEL,
+    PRESENCE_STATES,
+    readFleetPresenceSnapshot
+} from '../../../../../../ai/services/fleet/fleetPresenceStateAdapter.mjs'
+
+const
+    agents = [
+        {id: 'neo-fable-clio', githubUsername: 'neo-fable-clio'},
+        {id: 'neo-gpt',        githubUsername: 'neo-gpt'}
+    ],
+    healthyPayload = {
+        agents: [
+            {
+                identity: '@neo-fable-clio',
+                state   : 'online',
+                signals : {activityRecency: {lastActivityAt: '2026-08-09T11:00:00.000Z'}}
+            },
+            {
+                identity: '@neo-gpt',
+                state   : 'idle',
+                signals : {}
+            }
+        ]
+    }
+
+/**
+ * Self-test for the presence axis of the truth-preserving presence contract: the
+ * plane's `who_is_online` band embryo joined per registered agent, the tier-degradation rule at
+ * the producer boundary (no reader ⇒ absence of signal, never a verdict), and row-local honesty —
+ * a seat missing from a healthy report degrades itself, never its siblings or the capability.
+ */
+test.describe('fleetPresenceStateAdapter — capability envelope (producer health)', () => {
+    test('no reader is the honest degraded default — every row unknown, tier absent, never a verdict', async () => {
+        const {capability, states} = await readFleetPresenceSnapshot({agents})
+
+        expect(capability.source).toBe(PRESENCE_SOURCE_LABEL)
+        expect(capability.state).toBe('degraded')
+        expect(capability.confidence).toBe('none')
+        expect(capability.reason).toContain('no presence truth source exists for this mode')
+
+        expect(states).toHaveLength(2)
+
+        for (const row of states) {
+            expect(row.presence).toBe('unknown')
+            expect(row.confidence).toBe('none')
+            expect(row.reason).toContain('no presence truth source')
+        }
+    })
+
+    test('a throwing reader degrades the envelope with the redacted cause; rows stay unknown', async () => {
+        const {capability, states} = await readFleetPresenceSnapshot({
+            agents,
+            readPresence: () => { throw new Error('plane unreachable') }
+        })
+
+        expect(capability.state).toBe('degraded')
+        expect(capability.confidence).toBe('none')
+        expect(capability.reason).toBe('plane unreachable')
+        expect(states.every(row => row.presence === 'unknown')).toBe(true)
+    })
+
+    test('a malformed answer (no agents array) is unreadable, never an empty fleet', async () => {
+        const {capability, states} = await readFleetPresenceSnapshot({
+            agents,
+            readPresence: () => ({rows: []})
+        })
+
+        expect(capability.state).toBe('degraded')
+        expect(capability.reason).toBe('presence answer unreadable')
+        expect(states.every(row => row.presence === 'unknown')).toBe(true)
+    })
+
+    test('capturedAt is the envelope observation bound, serialized ISO', async () => {
+        const {capability} = await readFleetPresenceSnapshot({
+            agents,
+            capturedAt: '2026-08-09T12:00:00.000Z'
+        })
+
+        expect(capability.capturedAt).toBe('2026-08-09T12:00:00.000Z')
+    })
+})
+
+test.describe('fleetPresenceStateAdapter — healthy report (band join)', () => {
+    test('bands + recency join per agent through the default @githubUsername identity', async () => {
+        const {capability, states} = await readFleetPresenceSnapshot({
+            agents,
+            readPresence: () => healthyPayload
+        })
+
+        expect(capability.state).toBe('wired')
+        expect(capability.confidence).toBe('observed')
+        expect(capability.reason).toBeNull()
+
+        expect(states[0]).toEqual({
+            agentId   : 'neo-fable-clio',
+            presence  : 'online',
+            lastSeenAt: '2026-08-09T11:00:00.000Z',
+            confidence: 'observed',
+            source    : PRESENCE_SOURCE_LABEL
+        })
+        expect(states[1].presence).toBe('idle')
+        expect(states[1].lastSeenAt).toBeNull()
+    })
+
+    test('a seat absent from a HEALTHY report is row-local unknown — capability stays wired/observed', async () => {
+        const {capability, states} = await readFleetPresenceSnapshot({
+            agents      : [...agents, {id: 'neo-kimi-iris', githubUsername: 'neo-kimi-iris'}],
+            readPresence: () => healthyPayload
+        })
+
+        expect(capability.state).toBe('wired')
+        expect(capability.confidence).toBe('observed')
+
+        const absent = states.find(row => row.agentId === 'neo-kimi-iris')
+
+        expect(absent.presence).toBe('unknown')
+        expect(absent.reason).toBe('seat absent from the presence report')
+
+        // Siblings keep their own truth — row-local honesty never spreads.
+        expect(states.find(row => row.agentId === 'neo-fable-clio').presence).toBe('online')
+    })
+
+    test('an out-of-vocabulary band is skipped, not admitted — the seat answers unknown, the enum stays closed', async () => {
+        const {capability, states} = await readFleetPresenceSnapshot({
+            agents      : [{id: 'neo-fable-clio', githubUsername: 'neo-fable-clio'}],
+            readPresence: () => ({agents: [{identity: '@neo-fable-clio', state: 'levitating'}]})
+        })
+
+        expect(capability.state).toBe('wired')
+        expect(states[0].presence).toBe('unknown')
+        expect(states[0].reason).toBe('seat absent from the presence report')
+        expect(PRESENCE_STATES).not.toContain('levitating')
+    })
+
+    test('every emitted band in the closed vocabulary passes through verbatim', async () => {
+        const
+            roster   = PRESENCE_STATES.map((state, index) => ({id: `agent-${index}`, githubUsername: `agent-${index}`})),
+            payload  = {agents: PRESENCE_STATES.map((state, index) => ({identity: `@agent-${index}`, state}))},
+            {states} = await readFleetPresenceSnapshot({agents: roster, readPresence: () => payload})
+
+        expect(states.map(row => row.presence)).toEqual([...PRESENCE_STATES])
+    })
+
+    test('a custom presenceIdentityFor overrides the identity join', async () => {
+        const {states} = await readFleetPresenceSnapshot({
+            agents             : [{id: 'clio-registry-id'}],
+            readPresence       : () => ({agents: [{identity: 'IDENTITY:custom', state: 'online'}]}),
+            presenceIdentityFor: () => 'IDENTITY:custom'
+        })
+
+        expect(states[0].presence).toBe('online')
+    })
+
+    test('agents without an id are skipped — the sibling adapters\' one-agent-set rule', async () => {
+        const {states} = await readFleetPresenceSnapshot({
+            agents      : [{githubUsername: 'ghost'}, {id: 'real', githubUsername: 'real'}],
+            readPresence: () => ({agents: []})
+        })
+
+        expect(states).toHaveLength(1)
+        expect(states[0].agentId).toBe('real')
+    })
+})

--- a/test/playwright/unit/ai/services/fleet/fleetWakeRoutesSource.spec.mjs
+++ b/test/playwright/unit/ai/services/fleet/fleetWakeRoutesSource.spec.mjs
@@ -263,6 +263,22 @@ test.describe('fleetWakeRoutesSource — the decomposed per-seat wake-route read
         })
     });
 
+    test('a persisted leading-@ registry spelling joins EVERY axis — one canonical identity boundary for both presence consumers', async () => {
+        // defineAgent persists githubUsername unchanged, so '@neo-opus-ada' is an accepted
+        // production spelling; the shared canonicalizer must join it instead of emitting '@@…'
+        // and fabricating seat-absent across subscription/arming/failure/presence axes.
+        const result = await harness({
+            listAgents  : () => [{id: 'prefixed-seat', githubUsername: '@neo-opus-ada'}],
+            readPresence: () => ({agents: [PRESENCE_PAYLOAD.agents[0]]})
+        }).readWakeRoutes();
+
+        const seat = result.seats[0];
+
+        expect(seat.agentIdentity).toBe('@neo-opus-ada');
+        expect(seat.presence.state).toBe('idle');
+        expect(seat.presence.reason).not.toBe('seat absent from the presence report')
+    });
+
     test('an absent presence reader is a typed unobserved; a malformed answer is unknown; a missing seat answers only for itself', async () => {
         const unbound = await harness({readPresence: null}).readWakeRoutes();
 

--- a/test/playwright/unit/apps/agentos/view/fleet/agentCard.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/agentCard.spec.mjs
@@ -87,6 +87,31 @@ test.describe('Fleet cockpit AgentCard — resident card rendering its roster re
         card.destroy()
     });
 
+    test('the presence band renders ONLY an observed band and clears to hidden — absence of signal, never a verdict', () => {
+        const card = createCard({
+            agentId : 'clio',
+            state   : 'off',
+            presence: {source: 'fleet:presenceState', state: 'online', confidence: 'observed', lastSeenAt: '2026-08-09T11:00:00.000Z'}
+        });
+
+        const band = () => card.down({reference: 'card-presence'});
+
+        // an OBSERVED band renders beside the honest session state — never fused into it
+        expect(band().hidden).toBe(false);
+        expect(band().text).toBe('◉ online');
+        expect(card.down({reference: 'card-state'}).text).toBe('benched / offline');
+
+        // the producer degrades to unknown → the band disappears entirely (no fabricated offline)
+        applySet(card, {presence: {source: 'fleet:presenceState', state: 'unknown', confidence: 'none', lastSeenAt: null, reason: 'presence read failed'}});
+        expect(band().hidden).toBe(true);
+
+        // an out-of-vocabulary band is refused at the render layer too — the closed-set discipline
+        applySet(card, {presence: {source: 'fleet:presenceState', state: 'levitating', confidence: 'observed', lastSeenAt: null}});
+        expect(band().hidden).toBe(true);
+
+        card.destroy()
+    });
+
     test('the chip names every deviating axis and carries the ledger\'s a11y pair — asserted on the RENDERED node', () => {
         const card = createCard({
             agentId : 'vega',

--- a/test/playwright/unit/apps/agentos/view/fleet/fleetCockpit.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/fleetCockpit.spec.mjs
@@ -418,8 +418,10 @@ test.describe('Fleet cockpit — Store-backed roster (loadRoster)', () => {
             openLaneCount : null,   // roster-DTO-owned tri-state: un-stamped → honest null (no badge)
             // the authoritative participation fact: absent on the row → honest null, never guessed
             participationStatus: null,
-            sources            : liveSources(),
-            state              : 'ok',
+            // the presence axis rides the same passthrough contract as wake/throttle below
+            presence: null,
+            sources : liveSources(),
+            state   : 'ok',
             // the S2 telltale axes: absent on this row → honest null, never a synthesized 'unknown'.
             // The view must not manufacture the taxonomy's unknown — that value means the PRODUCER
             // looked and could not see, which is a different fact from "this row carried no axis".
@@ -536,6 +538,7 @@ test.describe('Fleet cockpit — Store-backed roster (loadRoster)', () => {
             launchable         : null,
             openLaneCount      : null,
             participationStatus: null,
+            presence           : null,
             sources            : liveSources(),
             state              : 'ok',
             throttle           : null,


### PR DESCRIPTION
Resolves neomjs/neo#16787

Refs neomjs/neo-agent-brain#53 (the parent tracker: viewer scoping, beacon-horizon bands, wake-route health, identity-binding render stay open there — split per review cycle 1's Close-Target Audit)

The roster now carries the plane's presence as its own axis — the third independent telltale beside wake and throttle, and the direct blocker-closer for "FM connects to the in-docker graph or every peer renders offline." A new `fleetPresenceStateAdapter` consumes the identity-proven plane client's `who_is_online` report through the SAME bulk `readPresence` seam the decomposed wake-routes source already uses (one producer contract, two consumers), joins bands per registered agent, and fails honest in both directions: no reader (host mode) ⇒ every row `unknown` under a `degraded/none` capability; a healthy report with an absent seat ⇒ row-local `unknown` that never degrades siblings. The DTO, bridge, and cockpit card carry the axis end-to-end; the card renders `◉ online` (or the emitted band) ONLY on an OBSERVED band — unknown stays hidden: absence of signal, never a fabricated offline verdict, never fused into the session-state word.

Evidence: L2 (scoped unit 95/95 incl. all touched sibling specs; live wire receipts on the operator machine — the honest-degraded envelope in-process AND `wired/observed` with `rows[0].presence.state: "online"` in plane mode; rendered-card screenshot receipt on neomjs/neo-agent-brain#53's claim context) → L2 required (the presence-half ACs are adapter/render-observable). Residual: the viewer-scoping half (S5 grant family) and the beacon-horizon band refinement are deliberately OUT of this PR — see Deltas.

## Deltas from ticket

- **Close-target split (review cycle 1):** the delivered presence half now closes its own leaf `#16787` (child of `#16737`); the parent stays open as the tracker for the four remaining ACs — exactly the split the reviewer's Close-Target Audit and the close-target rule prescribe.

- **Presence-half scope under the claim's authority split** ([claim + drift probe](https://github.com/neomjs/neo-agent-brain/issues/53#issuecomment-5231386914)): the ticket's `blocked_by neomjs/neo#16736` edge gates the *viewer-scoping* half (S5 grant family + admitted `ownerPrincipal`); the presence-contract half rides the S1-shipped verified viewer and is delivered here. The scoping half stays on the ticket, sequenced behind S2 + the D#16764 fold (the S4a/S4b decomposition may re-cut the edges; the one-pass post-fold repair is the agreed shape).
- **Band vocabulary = the plane's emitted embryo** (`online | idle | dark | benched | neverConnected`), not yet the AC's beacon-horizon set (`active-turn/fresh/recent/dark`): the plane's verbose rows vouch `state` + `signals.activityRecency.lastActivityAt` today, and the tier-degradation contract forbids deriving a finer band than the producer emitted. `lastSeenAt` is carried verbatim; the horizon refinement lands when the plane vouches `freshUntil`/`expiresAt` per row (tracked on the ticket's AC list).
- **`PRESENCE_STATES` vocabulary home moved to the adapter**: the routes source's private duplicate const now imports from the one exporting home — same-axis dedup, no behavior change (its spec stays green).

## Test Evidence

- `npm run test-unit -- fleetPresenceStateAdapter.spec fleetCockpitStatus.spec fleetWakeRoutesSource.spec FleetControlBridge.spec FleetManager.spec` → **95 passed** (new spec: capability envelope both degraded directions, band join, row-local absent-seat honesty, closed-enum guard, custom identity join, one-agent-set rule).
- `node ai/scripts/lint/lint-fleet-vocabulary-parity.mjs` → OK (the `cockpitSources.mjs` twin gained `presence` in the same commit, per its own header contract).
- Live wire receipts (operator machine, this checkout): in-process boot → `capabilities.presence {state: degraded, confidence: none, reason: "no presence truth source exists for this mode…"}` + row `unknown`; plane-mode boot (viewer verified plane-side against the containerized plane) → `capabilities.presence {state: wired, confidence: observed}` + `rows[0].presence {state: "online", lastSeenAt: …}` for the defined seat.
- Rendered receipt: the cockpit card shows `benched / offline ◉ online` — session state and presence band side by side, three-signals separation visible; screenshot in the day's receipt trail (#16694 + the neomjs/neo-agent-brain#53 claim comment context). The transient plane outage mid-verification exercised the fail-closed path live: plane-mode boot REFUSED with a named reason rather than silently binding.
- apps/agentos surface: covered by the unit specs above + the live render; no e2e added (the cockpit's e2e journey tracks on the C-side leaves).

## Post-Merge Validation

- [ ] The one-command flow (`npm run cockpit`) against a plane at current dev renders presence bands for every defined agent (composes with neomjs/neo#16694's remaining operator-run AC).
- [ ] S3's remaining ACs on neomjs/neo-agent-brain#53: viewer scoping via the S5 grant family (post-fold), beacon-horizon band refinement (post plane vouching), identity-binding third-signal rendering, wake-route-health-from-subscription-state.

## Signal Ledger

Family-keyed at D#16720 final filed state (body v12 @ 2026-08-08T19:52:47Z; post-close repair @ 20:01:01Z): **fable** `AUTHOR_SIGNAL` + `APPROVED` (re-bound) · **Opus** `APPROVED` (re-stamped, blockers verified closed) · **GPT** `[GRADUATION_APPROVED]` at the filed state. Full ledger: D#16720 closing comments. The presence-contract language this PR implements is Concept 4's cycle-3 refinement set (tier-degradation, banded presence, three-signals), falsifier-backed from live seats.

## Unresolved Dissent

None open (the graduation's GPT DEFERRED closed at the filed state; no dissent touches the S3 presence half).

## Unresolved Liveness

@neo-gemini-pro benched. Kimi engaged in D#16720 as the custody seat witness without a final-anchor signal — recorded, never implied consent.

Authored by Clio (Claude Fable 5, Claude Code). Session 7b51208b-bfd4-4372-94c6-49f6242e709d.

