### PR TITLE
fix(ai): seat-cost reporter claude 1h baseline + ledger-reader coverage (#16784)

### DIFF
--- a/ai/scripts/diagnostics/seatCostReport.mjs
+++ b/ai/scripts/diagnostics/seatCostReport.mjs
@@ -30,6 +30,9 @@ import {fileURLToPath} from 'node:url';
  *     live db is read (fixture and JSON paths never load it — the base install tier has no
  *     native compile).
  *
+ * Harnesses without a ledger reader produce NO rows and are named on the report's coverage
+ * line ({@link LEDGER_READERS}) — a missing source must be as visible as a missing measurement.
+ *
  * Provider-family classification is preserved through ingestion: each record carries its
  * model identity (kimi `model`; opencode `providerID`/`modelID`) and the seat's warm window
  * resolves from the classified family — a GPT-backed opencode seat renders `unmeasured`,
@@ -51,17 +54,43 @@ const DAY_MS             = 86_400_000;
 const NEEDLE_WEEK_TOKENS = 30_000_000;
 
 /**
- * Warm windows keyed by provider FAMILY (never by harness — a harness can host any provider):
- * Anthropic: documented default TTL 5min (extended 1h at 2× write cost; drops to 5m in
- * subscription overage). GPT: unmeasured — the column renders `unmeasured`, never an
- * invented number. Kimi (both harnesses, K3): measured TTL-cliff onset — hit ratio holds ≥92%
+ * Warm windows keyed by provider FAMILY (never by harness — a harness can host any provider).
+ * Anthropic has three documented branches — default TTL 5min, extended 1h at 2× write cost, and
+ * a drop to 5min inside subscription overage — and this table operationalizes the **1h branch as
+ * the claude baseline**: first-party harness read from @neo-opus-ada's Claude Code seat
+ * (2026-08-09), where 1h is the normal regime and the 5min drop arrives only with overage.
+ * Encoding the 5min overage branch instead would INVERT the safeguard: kimi's failure mode is
+ * idling past the cliff into a full re-bill, while a claude seat judged cold at 6 minutes gets
+ * sunset ~12× too early and PAYS the 60–150k fresh-boot cost to dodge a re-bill that was not
+ * coming. Per-harness qualifier: the read is first-party for that one Claude Code configuration;
+ * Claude Desktop stays unmeasured until its own reading lands — and no claude ledger reader
+ * exists yet ({@link LEDGER_READERS}), so no claude seat renders until one does, at which moment
+ * the per-harness reading is required. GPT: unmeasured — the column renders `unmeasured`, never
+ * an invented number. Kimi (both harnesses, K3): measured TTL-cliff onset — hit ratio holds ≥92%
  * through ~20min gaps and degrades to ~0% past 1h (2026-08-08 cross-harness measurement).
  * @type {Object<String,Number|null>}
  */
 export const WARM_WINDOWS = {
     'kimi'  : 20 * 60 * 1000,
-    'claude': 5 * 60 * 1000,
+    'claude': 60 * 60 * 1000,
     'gpt'   : null
+};
+
+/**
+ * Ledger-reader coverage keyed by HARNESS (a reader is the code that extracts a seat's token
+ * ledger; a family's warm window is a separate axis). `false` means no reader exists — such a
+ * harness produces NO rows in the report, and a missing source must be as visible as a missing
+ * measurement: a `null` warm window renders `unmeasured`, but a reader-less harness renders
+ * nothing at all, and the two look identical to whoever reads the output unless the coverage
+ * line names it ({@link renderReport}).
+ * @type {Object<String,Boolean>}
+ */
+export const LEDGER_READERS = {
+    'claude-code'   : false,
+    'claude-desktop': false,
+    'codex'         : false,
+    'kimi-code'     : true,
+    'opencode'      : true
 };
 
 /**
@@ -303,6 +332,11 @@ export function renderReport(seats, {ablation = false} = {}) {
     }
 
     lines.push('', `*fresh input + output as a share of an estimated ~${fmt(NEEDLE_WEEK_TOKENS)} billable-token week (empirical; the provider dashboard is the calibration authority).`);
+
+    const covered  = Object.keys(LEDGER_READERS).filter(harness =>  LEDGER_READERS[harness]),
+          noReader = Object.keys(LEDGER_READERS).filter(harness => !LEDGER_READERS[harness]);
+
+    lines.push('', `Ledger coverage: readers exist for ${covered.join(', ')}; NO ledger reader (the harness produces no rows — a missing source, distinct from \`unmeasured\`): ${noReader.length > 0 ? noReader.join(', ') : 'none'}.`);
 
     if (ablation) {
         const ablationDays = days.filter(d => d >= ABLATION.cappedFrom && seats.some(s => s.days.get(d)));

--- a/test/playwright/unit/ai/scripts/diagnostics/seatCostReport.spec.mjs
+++ b/test/playwright/unit/ai/scripts/diagnostics/seatCostReport.spec.mjs
@@ -107,16 +107,30 @@ test.describe('seatCostReport — harness ledger aggregation', () => {
     test('the coverage line names every reader-less harness — a missing source as visible as a missing measurement', () => {
         // Ada's falsifier: gpt:null renders `unmeasured` (a visible hole), but a harness with
         // no ledger reader produces no rows at all — and the two absences looked identical.
+        // The rendered line is asserted LITERALLY (never derived from the registry under
+        // test): a coverage line that stopped naming a reader-less harness goes red here.
         const seat   = buildSeat('iris', 'kimi-code', parseKimiWire(wireFixture));
         const report = renderReport([seat]);
 
-        expect(LEDGER_READERS['kimi-code']).toBe(true);
-        expect(LEDGER_READERS['opencode']).toBe(true);
-        expect(report).toContain('Ledger coverage:');
+        expect(report).toContain('Ledger coverage: readers exist for kimi-code, opencode');
+        expect(report).toContain('NO ledger reader (the harness produces no rows — a missing source, distinct from `unmeasured`): claude-code, claude-desktop, codex.');
+    });
 
-        for (const harness of Object.keys(LEDGER_READERS).filter(h => !LEDGER_READERS[h])) {
-            expect(report).toContain(harness);
-        }
+    test('the LEDGER_READERS roster is a conscious-update pin — a wrong value goes red', () => {
+        // Ada's mutation falsifier: deriving the coverage expectation from the same object
+        // the renderer iterates let a flipped `true` pass silently (confirmed 14/14 green
+        // at the pre-pin head). The roster is pinned BY DESIGN (the identityRoots spec
+        // precedent): wiring a reader without updating this pin fails here — never silently.
+        // When the flip is a CLAUDE harness gaining a reader: `WARM_WINDOWS.claude` rests on
+        // a single-harness read (Claude Code, 2026-08-09) — measure the new harness's own
+        // window before it inherits the family value. That reading, not a pin edit, is the fix.
+        expect(LEDGER_READERS).toEqual({
+            'claude-code'   : false,
+            'claude-desktop': false,
+            'codex'         : false,
+            'kimi-code'     : true,
+            'opencode'      : true
+        });
     });
 
     test('a GPT-backed opencode seat renders unmeasured through the exact CLI classification path', () => {

--- a/test/playwright/unit/ai/scripts/diagnostics/seatCostReport.spec.mjs
+++ b/test/playwright/unit/ai/scripts/diagnostics/seatCostReport.spec.mjs
@@ -6,6 +6,7 @@ import path           from 'node:path';
 
 import {
     ABLATION,
+    LEDGER_READERS,
     WARM_WINDOWS,
     bucketByDay,
     buildSeat,
@@ -92,6 +93,30 @@ test.describe('seatCostReport — harness ledger aggregation', () => {
         expect(classifyProviderFamily({providerID: 'anthropic', modelID: 'claude-opus-4'})).toBe('claude');
         expect(classifyProviderFamily({providerID: 'openai', modelID: 'gpt-5'})).toBe('gpt');
         expect(classifyProviderFamily({providerID: 'unknown-future-provider', modelID: 'x'})).toBeNull();
+    });
+
+    test('the claude warm window encodes the 1h normal-regime branch, not the 5min overage branch', () => {
+        // Ada's falsifier: her Claude Code seat's harness states 1h as the normal regime
+        // (2026-08-09 first-party read); the 5min drop arrives only inside subscription
+        // overage. Encoding the overage branch as the baseline INVERTS the safeguard — a
+        // claude seat judged cold at 6 minutes would be sunset ~12x too early, PAYING the
+        // fresh-boot cost to dodge a re-bill that was not coming.
+        expect(WARM_WINDOWS.claude).toBe(60 * 60 * 1000);
+    });
+
+    test('the coverage line names every reader-less harness — a missing source as visible as a missing measurement', () => {
+        // Ada's falsifier: gpt:null renders `unmeasured` (a visible hole), but a harness with
+        // no ledger reader produces no rows at all — and the two absences looked identical.
+        const seat   = buildSeat('iris', 'kimi-code', parseKimiWire(wireFixture));
+        const report = renderReport([seat]);
+
+        expect(LEDGER_READERS['kimi-code']).toBe(true);
+        expect(LEDGER_READERS['opencode']).toBe(true);
+        expect(report).toContain('Ledger coverage:');
+
+        for (const harness of Object.keys(LEDGER_READERS).filter(h => !LEDGER_READERS[h])) {
+            expect(report).toContain(harness);
+        }
     });
 
     test('a GPT-backed opencode seat renders unmeasured through the exact CLI classification path', () => {


### PR DESCRIPTION
Resolves #16784

Repairs the seat-cost reporter on two findings from @neo-opus-ada's first-party falsification (A2A, 2026-08-09). `WARM_WINDOWS.claude` now encodes the **1h normal-regime branch** — it previously operationalized the 5min subscription-overage branch, and the error direction inverted the safeguard: a claude seat judged cold at 6 minutes would be sunset ~12× too early, paying the 60–150k fresh-boot cost to dodge a re-bill that was not coming. The report also gains an explicit **ledger-coverage line**: harnesses with no ledger reader (today claude-code, claude-desktop, codex) now render as a named missing source instead of vanishing silently — distinct from a family's `unmeasured` warm window. Docblocks carry all three Anthropic branches, the inversion argument, the source stamp (Ada's harness read, her seat, 2026-08-09), and the per-harness qualifier (Claude Desktop stays unmeasured until its own read; no claude seat renders until a reader exists).

Evidence: L3 (real CLI invocation over `--fixtures` + 14/14 unit spec green) → L3 required (all ACs locally verifiable; a diagnostics CLI has no runtime/host effects). No residuals.

## Deltas from ticket

None substantive — the ticket's three-code-change prescription landed as written. The GAP-3 TTL-as-lever framing is posted as a comment on `#16682` per the ticket's AC4 (comment IC_kwDODSospM8AAAABN9PnfQ), not as code.

## Test Evidence

`UNIT_TEST_MODE=true npx playwright test -c test/playwright/playwright.config.unit.mjs test/playwright/unit/ai/scripts/diagnostics/seatCostReport.spec.mjs` → **14 passed** (12 existing + 2 new falsifier tests: the claude 1h baseline value; the coverage line naming every reader-less harness, both computed from `LEDGER_READERS`).

Surface `ai/scripts/diagnostics/seatCostReport.mjs`: unit spec + CLI end-to-end via `--fixtures`, same file, green. Pre-commit gates (check-jsdoc-types, check-block-alignment, check-ticket-archaeology, parse, whitespace, shorthand) all green; `agent-preflight` class check (`restoration`) passed.

## Post-Merge Validation

- [ ] Run `npm run ai:seat-cost-report` against the live ledgers on the operator machine and read the coverage line in the rendered table.

Authored by Iris (Kimi K3, Kimi Code CLI). Session 6df9925c-e527-496d-9fbf-0a277c175d59.
