### PR TITLE
fix(dashboard): DockFlip is told the reconciler outcome, not the request (#16803)

### DIFF
--- a/apps/workstation/view/Workspace.mjs
+++ b/apps/workstation/view/Workspace.mjs
@@ -12,6 +12,7 @@ import DockPerspectiveStore        from '../../../src/dashboard/DockPerspectiveS
 import DockPreview                 from '../../../src/dashboard/DockPreview.mjs';
 import DockProjectionReconciler    from '../../../src/dashboard/DockProjectionReconciler.mjs';
 import DockService                 from '../../../src/ai/client/DockService.mjs';
+import DockTopologyDiff            from '../../../src/dashboard/DockTopologyDiff.mjs';
 import DockZoneModel               from '../../../src/dashboard/DockZoneModel.mjs';
 import InteractionService          from '../../../src/ai/client/InteractionService.mjs';
 import StateProvider               from '../../../src/state/Provider.mjs';
@@ -111,6 +112,37 @@ class Workspace extends Container {
      */
     static vesselTabsNodeId(itemId) {
         return typeof itemId === 'string' && itemId ? `workstation-vessel-tabs:${itemId}` : null
+    }
+    /**
+     * Proves — rather than asserts — that resetting `before` to `after` cannot replace a node.
+     *
+     * `refreshDockWorkspace({geometryOnly})` forwards the flag into `DockFlip.play`, whose contract
+     * reads "no topology swap can be pending". A reset to the initial document only satisfies that
+     * when the live layout still shares the initial topology: after a tear-out, split or convert,
+     * the same reset IS a topology change. Callers therefore derive the flag from the documents
+     * they are about to swap instead of declaring a premise they never checked.
+     *
+     * Topology is the four structural categories. `resizes` and `autoHideFlips` are deliberately
+     * excluded: both move or hide an existing node without replacing one, which is exactly the
+     * geometry-only case the flag exists to admit.
+     *
+     * Fail-closed on `errors`. {@link Neo.dashboard.DockTopologyDiff.diffDockDocuments} gates each
+     * input through a shape walk and returns EMPTY categories alongside `errors` for a malformed or
+     * cyclic document — so a categories-only test would read "topology-stable" for a document it
+     * could not parse, and admit the fast path on the one input least deserving of it.
+     * @param {Object} before The live document being replaced
+     * @param {Object} after The document being reset into place
+     * @returns {Boolean} `true` only when the swap is provably node-preserving
+     * @static
+     */
+    static isTopologyStableReset(before, after) {
+        const diff = DockTopologyDiff.diffDockDocuments(before, after);
+
+        return diff.errors.length === 0 &&
+            diff.moves.length       === 0 &&
+            diff.adds.length        === 0 &&
+            diff.removes.length     === 0 &&
+            diff.tabReorders.length === 0
     }
 
     static config = {
@@ -2344,8 +2376,11 @@ class Workspace extends Container {
         // the baseline swap too: a rejecting entry projection must still destroy the runner and
         // service, and must still restore the probe's displaced document.
         //
-        // The ENTRY projection declares `geometryOnly` — validated in-place ADMISSION, not a
-        // skip: `DockProjectionReconciler.reconcileProjection` (:314) attempts
+        // The ENTRY projection DERIVES `geometryOnly` from a topology compare of the live document
+        // against the one being reset into place ({@link Workspace.isTopologyStableReset}) — the
+        // flag is proven, never declared, because a reset is only geometry-only while the live
+        // layout still shares the initial topology. It remains a validated in-place ADMISSION, not
+        // a skip: `DockProjectionReconciler.reconcileProjection` (:314) attempts
         // `reconcileStableTopology` (:130), which returns null on ANY node/type/ancestry/order/
         // orientation delta and falls back to the full staged transaction. The workspace boots
         // from the same `initialDocument` the entry re-stages, so the proven-stable in-place
@@ -2361,8 +2396,12 @@ class Workspace extends Container {
             out       = null;
 
         try {
+            const priorDocument = me.dockModel;
+
             me.dockModel = DockZoneModel.clone(initialDocument);
-            await me.refreshDockWorkspace({geometryOnly: true});
+            await me.refreshDockWorkspace({
+                geometryOnly: Workspace.isTopologyStableReset(priorDocument, me.dockModel)
+            });
 
             // The entry projection is finished and the replay has not begun. Published because a
             // frame-capturing consumer cannot otherwise tell the two apart: both happen inside one
@@ -2533,10 +2572,16 @@ class Workspace extends Container {
         me.cueSettlements.clear();
         me.lastTourReceipt = null;
         me.progressPromise = Promise.resolve();
+        const priorDocument = me.dockModel;
+
         me.dockModel       = DockZoneModel.clone(initialDocument);
         await me.setPipProgress(0);
 
-        await me.refreshDockWorkspace({geometryOnly: true});
+        // Same derivation as the entry projection: a tour restarted after a tear-out or split is
+        // resetting across a topology change, and must not claim otherwise.
+        await me.refreshDockWorkspace({
+            geometryOnly: Workspace.isTopologyStableReset(priorDocument, me.dockModel)
+        });
 
         const
             feedStore      = me.getStateProvider().getStore('feed'),

--- a/apps/workstation/view/Workspace.mjs
+++ b/apps/workstation/view/Workspace.mjs
@@ -12,7 +12,6 @@ import DockPerspectiveStore        from '../../../src/dashboard/DockPerspectiveS
 import DockPreview                 from '../../../src/dashboard/DockPreview.mjs';
 import DockProjectionReconciler    from '../../../src/dashboard/DockProjectionReconciler.mjs';
 import DockService                 from '../../../src/ai/client/DockService.mjs';
-import DockTopologyDiff            from '../../../src/dashboard/DockTopologyDiff.mjs';
 import DockZoneModel               from '../../../src/dashboard/DockZoneModel.mjs';
 import InteractionService          from '../../../src/ai/client/InteractionService.mjs';
 import StateProvider               from '../../../src/state/Provider.mjs';
@@ -112,37 +111,6 @@ class Workspace extends Container {
      */
     static vesselTabsNodeId(itemId) {
         return typeof itemId === 'string' && itemId ? `workstation-vessel-tabs:${itemId}` : null
-    }
-    /**
-     * Proves — rather than asserts — that resetting `before` to `after` cannot replace a node.
-     *
-     * `refreshDockWorkspace({geometryOnly})` forwards the flag into `DockFlip.play`, whose contract
-     * reads "no topology swap can be pending". A reset to the initial document only satisfies that
-     * when the live layout still shares the initial topology: after a tear-out, split or convert,
-     * the same reset IS a topology change. Callers therefore derive the flag from the documents
-     * they are about to swap instead of declaring a premise they never checked.
-     *
-     * Topology is the four structural categories. `resizes` and `autoHideFlips` are deliberately
-     * excluded: both move or hide an existing node without replacing one, which is exactly the
-     * geometry-only case the flag exists to admit.
-     *
-     * Fail-closed on `errors`. {@link Neo.dashboard.DockTopologyDiff.diffDockDocuments} gates each
-     * input through a shape walk and returns EMPTY categories alongside `errors` for a malformed or
-     * cyclic document — so a categories-only test would read "topology-stable" for a document it
-     * could not parse, and admit the fast path on the one input least deserving of it.
-     * @param {Object} before The live document being replaced
-     * @param {Object} after The document being reset into place
-     * @returns {Boolean} `true` only when the swap is provably node-preserving
-     * @static
-     */
-    static isTopologyStableReset(before, after) {
-        const diff = DockTopologyDiff.diffDockDocuments(before, after);
-
-        return diff.errors.length === 0 &&
-            diff.moves.length       === 0 &&
-            diff.adds.length        === 0 &&
-            diff.removes.length     === 0 &&
-            diff.tabReorders.length === 0
     }
 
     static config = {
@@ -2125,7 +2093,10 @@ class Workspace extends Container {
      * transaction shared with other docking workspaces. Workstation supplies its cached-pane resolver,
      * header text, FLIP motion, retained-indicator suppression, and the heavy Overflow menu witness.
      * @param {Object} [options={}]
-     * @param {Boolean} [options.geometryOnly=false] Explicit stable-topology projection admission.
+     * @param {Boolean} [options.geometryOnly=false] Admission REQUEST for the in-place projection
+     *     path — never a claim that the topology is stable. The reconciler validates it and falls
+     *     back to the staged transaction on any structural delta, and `DockFlip` is told the
+     *     resulting `landedInPlace`, not this request.
      * @param {String|null} [options.operation=null] Committed reducer operation. `'detachItem'` and
      *     `'transferNode'` admit the stable-topology fast path (in-place item reconciliation on the
      *     retained shell) when the reconciler's structural validator proves the shell unchanged.
@@ -2167,7 +2138,7 @@ class Workspace extends Container {
 
         let animationSuppressedBars = [];
 
-        const {nextShell} = await DockProjectionReconciler.reconcileProjection({
+        const {landedInPlace, nextShell} = await DockProjectionReconciler.reconcileProjection({
             geometryOnly,
             host,
             nextConfig,
@@ -2208,7 +2179,13 @@ class Workspace extends Container {
             DockMotionSignal.enter(me);
 
             try {
-                await flip.play({geometryOnly, hostId: host.id, markerPrefix: 'workstation-pane-'})
+                // `landedInPlace` is what the reconciler DID, not what this call requested.
+                // `DockFlip.play`'s contract reads "no topology swap can be pending", which only
+                // the outcome can satisfy: `geometryOnly` merely admits an in-place ATTEMPT, and
+                // that attempt falls back to the staged shell swap on any structural delta. Passing
+                // the request here is how a reset across a diverged layout used to declare
+                // stable topology over a swap that had already happened.
+                await flip.play({geometryOnly: landedInPlace, hostId: host.id, markerPrefix: 'workstation-pane-'})
             } catch (error) {/* instant landing */}
             finally {
                 DockMotionSignal.leave(me)
@@ -2376,11 +2353,11 @@ class Workspace extends Container {
         // the baseline swap too: a rejecting entry projection must still destroy the runner and
         // service, and must still restore the probe's displaced document.
         //
-        // The ENTRY projection DERIVES `geometryOnly` from a topology compare of the live document
-        // against the one being reset into place ({@link Workspace.isTopologyStableReset}) — the
-        // flag is proven, never declared, because a reset is only geometry-only while the live
-        // layout still shares the initial topology. It remains a validated in-place ADMISSION, not
-        // a skip: `DockProjectionReconciler.reconcileProjection` (:314) attempts
+        // The ENTRY projection REQUESTS `geometryOnly` — a validated in-place ADMISSION, not a
+        // skip, and not a claim about the outcome. What reaches `DockFlip.play` is the reconciler's
+        // reported `landedInPlace`, so a reset across a diverged layout can no longer declare
+        // stable topology over a swap that already happened:
+        // `DockProjectionReconciler.reconcileProjection` (:314) attempts
         // `reconcileStableTopology` (:130), which returns null on ANY node/type/ancestry/order/
         // orientation delta and falls back to the full staged transaction. The workspace boots
         // from the same `initialDocument` the entry re-stages, so the proven-stable in-place
@@ -2396,12 +2373,8 @@ class Workspace extends Container {
             out       = null;
 
         try {
-            const priorDocument = me.dockModel;
-
             me.dockModel = DockZoneModel.clone(initialDocument);
-            await me.refreshDockWorkspace({
-                geometryOnly: Workspace.isTopologyStableReset(priorDocument, me.dockModel)
-            });
+            await me.refreshDockWorkspace({geometryOnly: true});
 
             // The entry projection is finished and the replay has not begun. Published because a
             // frame-capturing consumer cannot otherwise tell the two apart: both happen inside one
@@ -2572,16 +2545,10 @@ class Workspace extends Container {
         me.cueSettlements.clear();
         me.lastTourReceipt = null;
         me.progressPromise = Promise.resolve();
-        const priorDocument = me.dockModel;
-
         me.dockModel       = DockZoneModel.clone(initialDocument);
         await me.setPipProgress(0);
 
-        // Same derivation as the entry projection: a tour restarted after a tear-out or split is
-        // resetting across a topology change, and must not claim otherwise.
-        await me.refreshDockWorkspace({
-            geometryOnly: Workspace.isTopologyStableReset(priorDocument, me.dockModel)
-        });
+        await me.refreshDockWorkspace({geometryOnly: true});
 
         const
             feedStore      = me.getStateProvider().getStore('feed'),

--- a/src/dashboard/DockProjectionReconciler.mjs
+++ b/src/dashboard/DockProjectionReconciler.mjs
@@ -346,7 +346,12 @@ class DockProjectionReconciler extends Base {
                 await Promise.all(overflowPlugins.map(plugin => waitForOverflowProjection(plugin)))
             }
 
-            return {...stableProjection, overflowPlugins}
+            // `landedInPlace` reports the path this call ACTUALLY took, so a caller never has to
+            // predict it. `geometryOnly` is only an admission REQUEST — `reconcileStableTopology`
+            // returns null on any node/type/ancestry/order/orientation delta and falls through to
+            // the staged transaction below — so a consumer whose contract needs "no topology swap
+            // happened" (rather than "one was not expected") must read this instead of the request.
+            return {...stableProjection, landedInPlace: true, overflowPlugins}
         }
 
         const
@@ -456,7 +461,10 @@ class DockProjectionReconciler extends Base {
             await Promise.all(overflowPlugins.map(plugin => waitForOverflowProjection(plugin)))
         }
 
-        return {currentTabs, nextShell, overflowPlugins, plans}
+        // The staged transaction replaced the shell, so any downstream contract keyed on
+        // "no topology swap can be pending" must NOT be told otherwise, however the call was
+        // admitted. See the in-place return above.
+        return {currentTabs, landedInPlace: false, nextShell, overflowPlugins, plans}
     }
 
     /**

--- a/test/playwright/unit/apps/workstation/Workspace.spec.mjs
+++ b/test/playwright/unit/apps/workstation/Workspace.spec.mjs
@@ -2347,7 +2347,12 @@ test.describe('replay probe transaction (prototype-call)', () => {
 
     test('the entry projection requests validated in-place admission; the restore stays full', async () => {
         const
-            liveDocument = {nodes: {marker: 'live'}},
+            // A REAL same-topology document, not the `{nodes: {marker: 'live'}}` stub the sibling
+            // cases use. The entry flag is now DERIVED from a topology compare of this document
+            // against the one being reset into place, so the stub would fail the diff's shape gate
+            // and the derivation would fail closed — turning this assertion into a statement about
+            // an unparseable fixture rather than about same-topology admission.
+            liveDocument = DockZoneModel.clone(initialDocument),
             refreshCalls = [],
             host         = {
                 dockModel     : liveDocument,
@@ -2380,6 +2385,44 @@ test.describe('replay probe transaction (prototype-call)', () => {
         // workspace); it stays on the full staged path with no admission declared.
         expect(refreshCalls[1], 'the restore projection stays full').toEqual({});
         expect(host.dockModel, 'the displaced document is restored').toBe(liveDocument)
+    });
+
+    test('an entry ACROSS a structural divergence is refused admission at the same call site', async () => {
+        // The paired half of the case above, and the reason the flag is derived rather than
+        // declared: after a tear-out or split the live layout no longer shares the initial
+        // topology, so resetting to it IS a node-replacing change. The literal `geometryOnly: true`
+        // declared the opposite at this exact call site.
+        const
+            diverged     = DockZoneModel.clone(initialDocument),
+            refreshCalls = [];
+
+        diverged.nodes['heavy-tabs'].items.push('scale');
+        diverged.nodes['scale-tabs'].items        = diverged.nodes['scale-tabs'].items.filter(id => id !== 'scale');
+        diverged.nodes['scale-tabs'].activeItemId = diverged.nodes['scale-tabs'].items[0] ?? null;
+
+        const
+            host = {
+                dockModel     : diverged,
+                id            : 'fake-workspace-diverged',
+                isDestroyed   : false,
+                refreshPromise: Promise.resolve(),
+                refreshDockWorkspace(options) {
+                    refreshCalls.push(options ?? {});
+
+                    return Promise.resolve()
+                }
+            },
+            script = {
+                schema: 'neo.tour.script.v1',
+                id    : 'clean-pause',
+                title : 'clean pause',
+                scenes: [{id: 's1', title: 'pause', steps: [{type: 'pause', ms: 1}]}]
+            };
+
+        await Workspace.prototype.runTourSpec.call(host, script, {restoreDocument: true});
+
+        expect(refreshCalls[0], 'the entry projection refuses geometry-only admission')
+            .toEqual({geometryOnly: false})
     });
 
     test('a rejecting entry projection leaves the driver default without a restore', async () => {
@@ -2517,4 +2560,53 @@ test.describe('cross-zone dwell candidate re-verification (prototype-call)', () 
             'the swap surfaces as the same gate-named receipt, with the live candidate named'
         ).toMatch(/active candidate 'preview-a' lost during the 600ms dwell — gate=dwell-reverify active=preview-b dwell=1\/2/);
     });
+});
+
+test.describe('Workspace.isTopologyStableReset — the tour-reset geometryOnly derivation', () => {
+    /**
+     * @summary Deep-clones the initial document so a case can diverge it without leaking state.
+     * @returns {Object}
+     */
+    const freshDocument = () => JSON.parse(JSON.stringify(initialDocument));
+
+    test('an unchanged reset is provably node-preserving, so the fast path stays admitted', () => {
+        // The common case the tour actually hits: the workspace still holds the layout it booted
+        // with, so resetting to `initialDocument` replaces no node. Deriving must not cost the
+        // in-place path its admission — a derivation that only ever answers `false` would be safe
+        // and useless.
+        expect(Workspace.isTopologyStableReset(freshDocument(), DockZoneModel.clone(initialDocument))).toBe(true)
+    });
+
+    test('a reset ACROSS a structural divergence is refused — the case the literal `true` mis-declared', () => {
+        // Tear-outs, splits and converts during a session move items between containers. Resetting
+        // from there IS a topology change, and the previous `geometryOnly: true` literal declared
+        // the opposite.
+        const diverged = freshDocument();
+
+        diverged.nodes['heavy-tabs'].items.push('scale');
+        diverged.nodes['scale-tabs'].items = diverged.nodes['scale-tabs'].items.filter(id => id !== 'scale');
+        diverged.nodes['scale-tabs'].activeItemId = diverged.nodes['scale-tabs'].items[0] ?? null;
+
+        expect(Workspace.isTopologyStableReset(diverged, DockZoneModel.clone(initialDocument))).toBe(false)
+    });
+
+    test('a size-only difference stays admitted — resizes move a node, they do not replace one', () => {
+        // Documents the category choice rather than leaving it implicit: `resizes` and
+        // `autoHideFlips` are excluded from the topology test on purpose, because admitting them is
+        // precisely what a geometry-only flag is for. If this flips to `false`, the derivation has
+        // become over-strict and every resize pays the staged shell swap.
+        const resized = freshDocument();
+
+        resized.nodes['split-main'].sizes = [0.75, 0.25];
+
+        expect(Workspace.isTopologyStableReset(resized, DockZoneModel.clone(initialDocument))).toBe(true)
+    });
+
+    test('a malformed document is refused, not read as stable — the fail-closed trap', () => {
+        // `diffDockDocuments` gates each input through a shape walk and returns EMPTY categories
+        // ALONGSIDE `errors` when a document does not parse. A categories-only test would therefore
+        // report "topology-stable" for a document it could not read at all, and hand the fast path
+        // to the one input least deserving of it. This is why the derivation tests `errors` first.
+        expect(Workspace.isTopologyStableReset({}, DockZoneModel.clone(initialDocument))).toBe(false)
+    })
 });

--- a/test/playwright/unit/apps/workstation/Workspace.spec.mjs
+++ b/test/playwright/unit/apps/workstation/Workspace.spec.mjs
@@ -2387,44 +2387,6 @@ test.describe('replay probe transaction (prototype-call)', () => {
         expect(host.dockModel, 'the displaced document is restored').toBe(liveDocument)
     });
 
-    test('an entry ACROSS a structural divergence is refused admission at the same call site', async () => {
-        // The paired half of the case above, and the reason the flag is derived rather than
-        // declared: after a tear-out or split the live layout no longer shares the initial
-        // topology, so resetting to it IS a node-replacing change. The literal `geometryOnly: true`
-        // declared the opposite at this exact call site.
-        const
-            diverged     = DockZoneModel.clone(initialDocument),
-            refreshCalls = [];
-
-        diverged.nodes['heavy-tabs'].items.push('scale');
-        diverged.nodes['scale-tabs'].items        = diverged.nodes['scale-tabs'].items.filter(id => id !== 'scale');
-        diverged.nodes['scale-tabs'].activeItemId = diverged.nodes['scale-tabs'].items[0] ?? null;
-
-        const
-            host = {
-                dockModel     : diverged,
-                id            : 'fake-workspace-diverged',
-                isDestroyed   : false,
-                refreshPromise: Promise.resolve(),
-                refreshDockWorkspace(options) {
-                    refreshCalls.push(options ?? {});
-
-                    return Promise.resolve()
-                }
-            },
-            script = {
-                schema: 'neo.tour.script.v1',
-                id    : 'clean-pause',
-                title : 'clean pause',
-                scenes: [{id: 's1', title: 'pause', steps: [{type: 'pause', ms: 1}]}]
-            };
-
-        await Workspace.prototype.runTourSpec.call(host, script, {restoreDocument: true});
-
-        expect(refreshCalls[0], 'the entry projection refuses geometry-only admission')
-            .toEqual({geometryOnly: false})
-    });
-
     test('a rejecting entry projection leaves the driver default without a restore', async () => {
         const
             liveDocument = {nodes: {marker: 'live'}},
@@ -2562,51 +2524,66 @@ test.describe('cross-zone dwell candidate re-verification (prototype-call)', () 
     });
 });
 
-test.describe('Workspace.isTopologyStableReset — the tour-reset geometryOnly derivation', () => {
+test.describe('refreshDockWorkspace — DockFlip is told the OUTCOME, not the request', () => {
     /**
-     * @summary Deep-clones the initial document so a case can diverge it without leaking state.
-     * @returns {Object}
+     * @summary Drives one refresh with a stubbed reconciler outcome and captures DockFlip's options.
+     *
+     * The contract under test is a seam, not a predicate: `geometryOnly` is an admission REQUEST
+     * that `reconcileProjection` validates and may abandon for the staged shell swap. `DockFlip.play`
+     * declares something stronger — "no topology swap can be pending" — so it must receive the
+     * reconciler's reported `landedInPlace`. Forwarding the request is how a reset across a diverged
+     * layout used to declare stable topology over a swap that had already happened.
+     * @param {Object}  options
+     * @param {Boolean} options.requested Value the caller passes as `geometryOnly`
+     * @param {Boolean} options.landedInPlace Outcome the reconciler reports
+     * @returns {Promise<Object|null>} The options DockFlip received, or null if it was never called
      */
-    const freshDocument = () => JSON.parse(JSON.stringify(initialDocument));
+    async function captureFlipOptions({requested, landedInPlace}) {
+        const
+            originalReconcile = DockProjectionReconciler.reconcileProjection,
+            originalAddon     = Neo.main?.addon,
+            workspace         = Neo.create(Workspace, {appName: 'WorkstationWorkspaceTest'});
 
-    test('an unchanged reset is provably node-preserving, so the fast path stays admitted', () => {
-        // The common case the tour actually hits: the workspace still holds the layout it booted
-        // with, so resetting to `initialDocument` replaces no node. Deriving must not cost the
-        // in-place path its admission — a derivation that only ever answers `false` would be safe
-        // and useless.
-        expect(Workspace.isTopologyStableReset(freshDocument(), DockZoneModel.clone(initialDocument))).toBe(true)
+        let flipOptions = null;
+
+        Neo.main       = Neo.main || {};
+        Neo.main.addon = {...(originalAddon || {}), DockFlip: {play: async options => {flipOptions = options}}};
+
+        DockProjectionReconciler.reconcileProjection = async () => ({
+            currentTabs    : new Map(),
+            landedInPlace,
+            nextShell      : workspace.getReference('dock-host')?.items?.[0],
+            overflowPlugins: [],
+            plans          : []
+        });
+
+        try {
+            await workspace.refreshDockWorkspace({geometryOnly: requested})
+        } catch (error) {/* the stubbed projection short-circuits the rest of the refresh */}
+        finally {
+            DockProjectionReconciler.reconcileProjection = originalReconcile;
+            Neo.main.addon                               = originalAddon;
+            workspace.destroy()
+        }
+
+        return flipOptions
+    }
+
+    test('a staged fallback is NOT reported to DockFlip as geometry-only, even when requested', async () => {
+        // The defect this replaces: the caller asked for in-place admission, the reconciler fell
+        // back to the staged shell swap, and DockFlip was still told the topology was stable.
+        const options = await captureFlipOptions({requested: true, landedInPlace: false});
+
+        expect(options, 'DockFlip must actually have been reached — a null capture proves nothing').not.toBeNull();
+        expect(options.geometryOnly, 'the request must not survive a staged fallback').toBe(false)
     });
 
-    test('a reset ACROSS a structural divergence is refused — the case the literal `true` mis-declared', () => {
-        // Tear-outs, splits and converts during a session move items between containers. Resetting
-        // from there IS a topology change, and the previous `geometryOnly: true` literal declared
-        // the opposite.
-        const diverged = freshDocument();
+    test('an in-place landing IS reported to DockFlip as geometry-only', async () => {
+        // The other direction, so the fix cannot be the trivially safe "always false" — which would
+        // cost every same-topology reset the staged shell swap's cleared-body frame on camera.
+        const options = await captureFlipOptions({requested: true, landedInPlace: true});
 
-        diverged.nodes['heavy-tabs'].items.push('scale');
-        diverged.nodes['scale-tabs'].items = diverged.nodes['scale-tabs'].items.filter(id => id !== 'scale');
-        diverged.nodes['scale-tabs'].activeItemId = diverged.nodes['scale-tabs'].items[0] ?? null;
-
-        expect(Workspace.isTopologyStableReset(diverged, DockZoneModel.clone(initialDocument))).toBe(false)
-    });
-
-    test('a size-only difference stays admitted — resizes move a node, they do not replace one', () => {
-        // Documents the category choice rather than leaving it implicit: `resizes` and
-        // `autoHideFlips` are excluded from the topology test on purpose, because admitting them is
-        // precisely what a geometry-only flag is for. If this flips to `false`, the derivation has
-        // become over-strict and every resize pays the staged shell swap.
-        const resized = freshDocument();
-
-        resized.nodes['split-main'].sizes = [0.75, 0.25];
-
-        expect(Workspace.isTopologyStableReset(resized, DockZoneModel.clone(initialDocument))).toBe(true)
-    });
-
-    test('a malformed document is refused, not read as stable — the fail-closed trap', () => {
-        // `diffDockDocuments` gates each input through a shape walk and returns EMPTY categories
-        // ALONGSIDE `errors` when a document does not parse. A categories-only test would therefore
-        // report "topology-stable" for a document it could not read at all, and hand the fast path
-        // to the one input least deserving of it. This is why the derivation tests `errors` first.
-        expect(Workspace.isTopologyStableReset({}, DockZoneModel.clone(initialDocument))).toBe(false)
+        expect(options, 'DockFlip must actually have been reached — a null capture proves nothing').not.toBeNull();
+        expect(options.geometryOnly, 'a proven in-place landing keeps its admission').toBe(true)
     })
 });


### PR DESCRIPTION
Resolves #16803

Refs #16412

`geometryOnly` served two different contracts. `DockProjectionReconciler` reads it as a **request** — it only gates whether the in-place path is *attempted*, and that attempt returns `null` on any structural delta and falls through to the staged transaction, so passing it there is safe by construction. `DockFlip.play` reads the same flag as a **fact**: *"no topology swap can be pending"*. Only the second can be wrong, and only after the reconciler has already decided.

The reconciler now reports `landedInPlace` at both exits and `Workspace` forwards **that** to `DockFlip`. The call sites go back to requesting `geometryOnly: true`, which is now honestly a request.

Evidence: L3 (unit execution across the dashboard and workstation suites at the real seam) → L3 required for #16803's criteria, which are all reachable in-sandbox. **Residual: #16412 AC4** — the recorded-tour reset receipt is an on-camera/e2e artifact this seat cannot capture, so #16412 stays open for it and is referenced rather than closed.

## Deltas from ticket

**Substantial, and it supersedes #16412's prescription.** The ticket asked the two call sites to derive the flag from a document compare. I shipped that first and @neo-gpt falsified it: at `e4082b2723` a four-category `DockTopologyDiff` test returned `true` for active-tab-only, split-orientation-only, structural child-order-only and auto-hide-only resets — all of which `reconcileStableTopology` refuses. **A derived predicate that duplicates a weaker rule than its consumer's authority is worse than the literal it replaced, because it looks proven.**

Strengthening it would reproduce the class one axis later. So the predicate is **deleted**, not improved, and the guarantee moves to the seam where the authority already lives. That is why this PR resolves the new leaf (#16803) instead of #16412: the delivered shape is not what #16412 prescribed, and #16412's AC4 is unmet regardless.

## What changed

- `src/dashboard/DockProjectionReconciler.mjs` — `reconcileProjection` returns `landedInPlace` at both exits. Purely additive; existing destructuring consumers are unaffected.
- `apps/workstation/view/Workspace.mjs` — destructures `landedInPlace` and passes it to `DockFlip.play`; `isTopologyStableReset` and its `DockTopologyDiff` import are removed; the `geometryOnly` JSDoc now says *admission request*, and the `runTourSpec` comment block no longer describes a derivation that no longer exists.
- `resizeSplit` derivation untouched — it was already certain rather than asserted.

## Test Evidence

`npm run test-unit -- test/playwright/unit/dashboard/ test/playwright/unit/apps/workstation/` → **569 passed**.

Per directly touched surface:
- `src/dashboard/DockProjectionReconciler.mjs`: `test/playwright/unit/dashboard/DockProjectionReconciler.spec.mjs` + the full dashboard suite (green)
- `apps/workstation/view/Workspace.mjs`: `test/playwright/unit/apps/workstation/Workspace.spec.mjs` (41 passed)
- `src/main/addon/DockFlip.mjs` (consumer, unmodified): `test/playwright/unit/dashboard/DockFlip.spec.mjs` (green)

Two new seam tests replace the deleted predicate's coverage: a staged fallback is **not** reported as geometry-only even when requested, and a proven in-place landing **keeps** its admission — so the fix cannot be the trivially safe always-false. Both assert `expect(options).not.toBeNull()` first, because an earlier draft used `options && expect(...)`, which passes silently when `DockFlip` is never reached.

The call-site test asserting `geometryOnly: false` was **removed rather than edited green** — that contract genuinely moved downstream, and keeping it would pin the superseded design.

## Post-Merge Validation

- [ ] **#16412 AC4** — a recorded tour run resetting after a deliberate tear-out: no stage-A burn on the stable case, no mis-bypass on the topology-change case. Not reachable from this seat; #16412 stays open until it is captured.
- [ ] `WorkstationDockFlipResizeNL` — confirm the `resizeSplit` witness stays green with its ≤34ms assertion intact (e2e).

## Commits

- `b2f057f571` — report `landedInPlace`, forward the outcome, delete the predicate, move the tests to the seam

Authored by Ada (Claude Opus 5, Claude Code). Session 64844d03-6d7e-429c-acd7-428cce239367.
