### PR TITLE
test(ai): correct the blast-radius count — 4 principal coordinates, not 5 (#16782)

### DIFF
--- a/test/playwright/unit/ai/mcp/server/memory-core/Server.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/memory-core/Server.spec.mjs
@@ -37,7 +37,8 @@ test.describe('Neo.ai.mcp.server.memory-core.Server', () => {
         '@github-outsider-15990',
         '@existing-gitlab-agent-14388',
         '@colliding-gitlab-agent-14388',
-        '@concurrent-gitlab-agent-14388'
+        '@concurrent-gitlab-agent-14388',
+        '@xprovider-shared-login'
     ]);
 
     async function createServerWithoutBoot({autoProvisionIdentitySources} = {}) {
@@ -233,6 +234,67 @@ test.describe('Neo.ai.mcp.server.memory-core.Server', () => {
         expect(boundId).toBe('@neo-opus-4-7');
 
         serverInstance.destroy();
+    });
+
+    test('a second provider sharing one login overwrites the first identity on ONE persisted node', async () => {
+        // The durable half of the owner-principal question, executed rather than read from source.
+        // The graph node id derives from the authenticated login, so two accounts that share a
+        // handle across DIFFERENT providers do not merely resolve alike — the later first-write
+        // lands on the same row and REWRITES the stored provider coordinates, because an existing
+        // auto-provisioned node is refreshed with the full property set.
+        await GraphService.initAsync();
+
+        const serverInstance = await createServerWithoutBoot({
+            autoProvisionIdentitySources: ['gitlab-pat', 'github-pat']
+        });
+
+        try {
+            await serverInstance.buildRequestContext({
+                token              : 'glpat-xprovider',
+                userId             : 'xprovider-shared-login',
+                username           : 'GitLab Holder',
+                source             : 'gitlab-pat',
+                authProvider       : 'gitlab',
+                authSource         : 'gitlab-pat',
+                providerBaseUrl    : 'https://gitlab.example.com',
+                providerUserId     : 4242,
+                providerUsername   : 'xprovider-shared-login',
+                providerDisplayName: 'GitLab Holder'
+            });
+
+            const afterFirst = rawGraphNode('@xprovider-shared-login');
+
+            expect(afterFirst.properties.authProvider,    'the first write owns the row').toBe('gitlab');
+            expect(afterFirst.properties.providerUserId,  '…with its own immutable id').toBe('4242');
+
+            // A different human, on a different provider, who happens to hold the same handle.
+            await serverInstance.buildRequestContext({
+                token              : 'ghp-xprovider',
+                userId             : 'xprovider-shared-login',
+                username           : 'GitHub Holder',
+                source             : 'github-pat',
+                authProvider       : 'github',
+                authSource         : 'github-pat',
+                providerBaseUrl    : 'https://api.github.com',
+                providerUserId     : 777001,
+                providerUsername   : 'xprovider-shared-login',
+                providerDisplayName: 'GitHub Holder'
+            });
+
+            const afterSecond = rawGraphNode('@xprovider-shared-login');
+
+            // Same row — not a second identity.
+            expect(afterSecond.properties.createdAt, 'no second node was created').toBe(afterFirst.properties.createdAt);
+
+            // …and the first principal's coordinates are gone. This is the concrete damage behind
+            // the login-keyed identity: not just a shared key, but silent takeover of a stored
+            // identity record by whoever authenticates next under the same handle.
+            expect(afterSecond.properties.authProvider,   'the second provider overwrote the first').toBe('github');
+            expect(afterSecond.properties.providerBaseUrl, 'the instance coordinate was overwritten').toBe('https://api.github.com');
+            expect(afterSecond.properties.providerUserId,  'the immutable id was overwritten').toBe('777001')
+        } finally {
+            serverInstance.destroy();
+        }
     });
 
     test('#14388: GitLab-PAT request context auto-provisions a missing AgentIdentity', async () => {

--- a/test/playwright/unit/ai/mcp/server/memory-core/Server.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/memory-core/Server.spec.mjs
@@ -41,6 +41,10 @@ test.describe('Neo.ai.mcp.server.memory-core.Server', () => {
         '@xprovider-shared-login'
     ]);
 
+    const silentLogger = {info: () => {}, warn: () => {}, error: () => {}};
+
+    class FakeInvalidTokenError extends Error {}
+
     async function createServerWithoutBoot({autoProvisionIdentitySources} = {}) {
         const originalBoot = Server.prototype.boot;
 
@@ -236,6 +240,50 @@ test.describe('Neo.ai.mcp.server.memory-core.Server', () => {
         serverInstance.destroy();
     });
 
+    /**
+     * @summary Produces a real AuthInfo from a real PAT verifier — no hand-written literal.
+     *
+     * The point is continuity: the envelope handed to `buildRequestContext()` must be the one the
+     * verifier actually builds. A constructed literal keeps two tests green while the producer and
+     * the persistence path drift apart on field naming, value type, or omission.
+     * @param {Object}  options
+     * @param {String}  options.provider `'gitlab'` or `'github'`
+     * @param {String}  options.login Handle the provider API returns
+     * @param {Number}  options.providerId Immutable provider id
+     * @param {String}  options.baseUrl Configured API base URL
+     * @param {String}  options.token Unique per call — the verifier caches by token hash
+     * @returns {Promise<Object>} The produced AuthInfo
+     */
+    async function produceRealAuthInfo({provider, login, providerId, baseUrl, token}) {
+        const
+            AuthService   = (await import('../../../../../../../ai/mcp/server/shared/services/AuthService.mjs')).default,
+            originalFetch = globalThis.fetch,
+            isGitlab      = provider === 'gitlab';
+
+        globalThis.fetch = async () => ({
+            ok     : true,
+            status : 200,
+            headers: {get: () => 'repo, read:user'},
+            json   : async () => isGitlab
+                ? {id: providerId, username: login, name: login}
+                : {id: providerId, login, name: login}
+        });
+
+        try {
+            const auth = isGitlab
+                ? {gitlabApiBaseUrl: baseUrl, patCacheTtlSeconds: 300, patValidationTimeoutMs: 5000}
+                : {githubApiBaseUrl: baseUrl, patCacheTtlSeconds: 300, patValidationTimeoutMs: 5000, allowedUsers: []};
+
+            const verifier = isGitlab
+                ? AuthService.createGitlabPatVerifier({aiConfig: {auth}, logger: silentLogger, InvalidTokenError: FakeInvalidTokenError})
+                : AuthService.createGithubPatVerifier({aiConfig: {auth}, logger: silentLogger, InvalidTokenError: FakeInvalidTokenError});
+
+            return await verifier.verifyAccessToken(token)
+        } finally {
+            globalThis.fetch = originalFetch
+        }
+    }
+
     test('a second provider sharing one login overwrites the first identity on ONE persisted node', async () => {
         // The durable half of the owner-principal question, executed rather than read from source.
         // The graph node id derives from the authenticated login, so two accounts that share a
@@ -249,37 +297,33 @@ test.describe('Neo.ai.mcp.server.memory-core.Server', () => {
         });
 
         try {
-            await serverInstance.buildRequestContext({
-                token              : 'glpat-xprovider',
-                userId             : 'xprovider-shared-login',
-                username           : 'GitLab Holder',
-                source             : 'gitlab-pat',
-                authProvider       : 'gitlab',
-                authSource         : 'gitlab-pat',
-                providerBaseUrl    : 'https://gitlab.example.com',
-                providerUserId     : 4242,
-                providerUsername   : 'xprovider-shared-login',
-                providerDisplayName: 'GitLab Holder'
+            // PRODUCED, not constructed. Both envelopes come out of the real verifiers, so the
+            // chain producer → request → persist is continuous: a drift in verifier field naming
+            // or value type breaks this test instead of leaving two disconnected greens.
+            const gitlabAuth = await produceRealAuthInfo({
+                provider: 'gitlab', login: 'xprovider-shared-login', providerId: 4242,
+                baseUrl : 'https://gitlab.example.com', token: 'glpat-xprovider'
             });
+
+            await serverInstance.buildRequestContext(gitlabAuth);
 
             const afterFirst = rawGraphNode('@xprovider-shared-login');
 
-            expect(afterFirst.properties.authProvider,    'the first write owns the row').toBe('gitlab');
-            expect(afterFirst.properties.providerUserId,  '…with its own immutable id').toBe('4242');
+            expect(afterFirst.properties.authProvider,   'the first write owns the row').toBe('gitlab');
+            expect(afterFirst.properties.providerUserId, '…with its own immutable id').toBe('4242');
 
             // A different human, on a different provider, who happens to hold the same handle.
-            await serverInstance.buildRequestContext({
-                token              : 'ghp-xprovider',
-                userId             : 'xprovider-shared-login',
-                username           : 'GitHub Holder',
-                source             : 'github-pat',
-                authProvider       : 'github',
-                authSource         : 'github-pat',
-                providerBaseUrl    : 'https://api.github.com',
-                providerUserId     : 777001,
-                providerUsername   : 'xprovider-shared-login',
-                providerDisplayName: 'GitHub Holder'
+            const githubAuth = await produceRealAuthInfo({
+                provider: 'github', login: 'xprovider-shared-login', providerId: 777001,
+                baseUrl : 'https://api.github.com', token: 'ghp-xprovider'
             });
+
+            // The produced envelopes disagree on every stable coordinate before either is persisted.
+            expect(gitlabAuth.authProvider,    'produced provider differs').not.toBe(githubAuth.authProvider);
+            expect(gitlabAuth.providerUserId,  'produced immutable id differs').not.toBe(githubAuth.providerUserId);
+            expect(gitlabAuth.userId,          'and yet the login they key on is identical').toBe(githubAuth.userId);
+
+            await serverInstance.buildRequestContext(githubAuth);
 
             const afterSecond = rawGraphNode('@xprovider-shared-login');
 

--- a/test/playwright/unit/ai/mcp/server/memory-core/Server.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/memory-core/Server.spec.mjs
@@ -309,8 +309,12 @@ test.describe('Neo.ai.mcp.server.memory-core.Server', () => {
 
             const afterFirst = rawGraphNode('@xprovider-shared-login');
 
-            expect(afterFirst.properties.authProvider,   'the first write owns the row').toBe('gitlab');
-            expect(afterFirst.properties.providerUserId, '…with its own immutable id').toBe('4242');
+            // All three stable coordinates are captured BEFORE the second write, so "overwritten"
+            // below is a measured transition rather than inferred from a final value. Asserting
+            // only the end state would let a coordinate that never changed read as if it had.
+            expect(afterFirst.properties.authProvider,    'the first write owns the row').toBe('gitlab');
+            expect(afterFirst.properties.providerUserId,  '…with its own immutable id').toBe('4242');
+            expect(afterFirst.properties.providerBaseUrl, '…and its own instance coordinate').toBe('https://gitlab.example.com');
 
             // A different human, on a different provider, who happens to hold the same handle.
             const githubAuth = await produceRealAuthInfo({

--- a/test/playwright/unit/ai/mcp/server/shared/services/ownerPrincipalNormalizationAxes.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/shared/services/ownerPrincipalNormalizationAxes.spec.mjs
@@ -1,6 +1,4 @@
 import {test, expect} from '@playwright/test';
-import fs             from 'fs/promises';
-import path           from 'path';
 import Neo            from '../../../../../../../../src/Neo.mjs';
 import '../../../../../../../../src/core/_export.mjs';
 import ConfigProvider, {createConfigProxy} from '../../../../../../../../ai/ConfigProvider.mjs';
@@ -31,8 +29,7 @@ import RootConfigBase                      from '../../../../../../../../ai/conf
  */
 
 const
-    AUTH_SERVICE_REL = 'ai/mcp/server/shared/services/AuthService.mjs',
-    ENV_NAME         = 'NEO_AUTH_GITLAB_API_BASE_URL',
+    ENV_NAME = 'NEO_AUTH_GITLAB_API_BASE_URL',
 
     /**
      * Spellings a maintainer would call "the same GitLab host". Each is a legal value for
@@ -281,26 +278,24 @@ test.describe('ownerPrincipal normalization axes — OQ9 witness matrix (#16738)
         ).not.toBe(normalizeAgentIdentityNodeId(gitlabInfo.userId))
     });
 
-    test('the same leaf yields TWO spellings, because the trailing-slash strip lives at the consumer', async () => {
+    test('the same configured value yields TWO spellings — leaf vs produced AuthInfo, both executed', async () => {
+        // Both sides are now run rather than read. An earlier revision counted `.replace(...)`
+        // occurrences in AuthService source, which proved the strip was DECLARED and nothing about
+        // what a request produces.
         const
-            leafSpelling = resolveLeafUnderEnv(EQUIVALENT_SPELLINGS.trailingSlash),
-            source       = await fs.readFile(path.join(process.cwd(), AUTH_SERVICE_REL), 'utf8'),
-            // Source-anchored rather than imported: AuthService builds its verifiers inside a
-            // factory and exports no pure normalizer, and the unit-test workflow forbids
-            // importing a service singleton merely to reach its logic. BOUND, stated so the
-            // next reader does not over-read this: matching the literal proves the strip is
-            // declared at the consumer, NOT that every code path executes it.
-            stripSites   = source.match(/ApiBaseUrl\.replace\(\/\\\/\+\$\/, ''\)/g) || [];
+            leafSpelling     = resolveLeafUnderEnv(EQUIVALENT_SPELLINGS.trailingSlash),
+            producedSpelling = await produceProviderBaseUrl({
+                baseUrl: EQUIVALENT_SPELLINGS.trailingSlash,
+                token  : 'glpat-two-spellings'
+            });
 
-        expect(stripSites.length, 'both forge verifiers strip at the use site').toBe(2);
-
-        // The sanctioned pattern is to read the resolved leaf at the use site. Doing exactly
-        // that yields the slash-bearing spelling, while `AuthInfo.providerBaseUrl` carries the
-        // stripped one — so a principal keyed on this coordinate takes a different value
-        // depending on which reader supplies it.
-        expect(leafSpelling).toBe('https://gitlab.example.com/');
-        expect(leafSpelling.replace(/\/+$/, '')).toBe('https://gitlab.example.com');
-        expect(leafSpelling).not.toBe(leafSpelling.replace(/\/+$/, ''))
+        // The sanctioned pattern is to read the resolved leaf at the use site — that yields the
+        // slash-bearing spelling. The verifier's produced envelope carries the stripped one. So a
+        // principal keyed on this coordinate takes a different value depending on which reader
+        // supplies it, and both values are observed here rather than inferred.
+        expect(leafSpelling,     'the leaf keeps the configured slash').toBe('https://gitlab.example.com/');
+        expect(producedSpelling, 'the produced coordinate drops it').toBe('https://gitlab.example.com');
+        expect(leafSpelling,     'one configured value, two live spellings').not.toBe(producedSpelling)
     });
 
     test('MECHANISM REACH: a leaf `parse` normalizes the env layer ONLY — default and runtime override bypass it', async () => {
@@ -344,28 +339,26 @@ test.describe('ownerPrincipal normalization axes — OQ9 witness matrix (#16738)
         expect(createConfigProxy(overridden).probe, 'runtime override bypasses parse').toBe(slashy)
     });
 
-    test('MIGRATION SURFACE: the admission pin keys on the mutable login while the stable id sits beside it', async () => {
-        const source = await fs.readFile(path.join(process.cwd(), AUTH_SERVICE_REL), 'utf8');
+    test('MIGRATION SURFACE: both produced envelopes key identity on the login while carrying the stable id', async () => {
+        // Executed on both provider axes rather than counted in source. The migration question is
+        // not "does the file say `user.login`" but "does a produced envelope key on the handle
+        // while already carrying the immutable id" — which is what makes the eventual re-key
+        // derivable from data the system already has.
+        const
+            gitlab = await produceAuthInfo({baseUrl: EQUIVALENT_SPELLINGS.canonical, login: 'octocat', providerId: 4242, token: 'glpat-surface'}),
+            github = await produceGithubAuthInfo({login: 'octocat', providerId: 777001, token: 'ghp-surface'});
 
-        // Source-anchored for the same reason as the strip above: the verifiers and their pin
-        // live inside factories and export nothing pure. BOUND: this proves what the file
-        // DECLARES, not what a given request executes.
+        // The caller identity IS the mutable handle, on both providers.
+        expect(gitlab.userId, 'GitLab keys identity on the handle').toBe('octocat');
+        expect(github.userId, 'GitHub keys identity on the handle').toBe('octocat');
 
-        // Both AuthInfo builders derive the caller identity from a mutable provider handle.
-        expect(source.match(/^\s+userId\s+: user\.(login|username),$/gm) || [],
-            'exactly two login-derived userId assignments').toHaveLength(2);
+        // …while the immutable provider id rides in the same envelope. The stable coordinate is
+        // not missing and needs no new plumbing — it is present and simply not what ownership
+        // keys on, which is precisely why a re-key can be derived from stored data.
+        expect(gitlab.providerUserId, 'GitLab carries its stable id').toBe('4242');
+        expect(github.providerUserId, 'GitHub carries its stable id').toBe('777001');
 
-        // …while the IMMUTABLE provider id is resolved in the very same object literal. The
-        // stable coordinate is not missing and does not need plumbing — it is present and
-        // simply not the thing ownership keys on.
-        expect(source.match(/^\s+providerUserId\s+: user\.id == null \? undefined : String\(user\.id\),$/gm) || [],
-            'both builders already resolve the stable provider id').toHaveLength(2);
-
-        // The single ownership decision that compares identities compares the login-derived
-        // field, so a provider-side rename refuses admission even though the stable id — and
-        // therefore any principal backed by it — is unchanged.
-        expect(source).toContain('pinnedProviderSubject = info.userId');
-        expect(source).toContain('if (info.userId !== pinnedProviderSubject)')
+        expect(gitlab.providerUserId, 'the stable ids distinguish what the handles cannot').not.toBe(github.providerUserId)
     });
 
     test('FIRST WRITE: the durable graph key is the mutable login, and the stable id rides along as a property', async () => {

--- a/test/playwright/unit/ai/mcp/server/shared/services/ownerPrincipalNormalizationAxes.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/shared/services/ownerPrincipalNormalizationAxes.spec.mjs
@@ -119,6 +119,42 @@ async function produceProviderBaseUrl({baseUrl, token}) {
     return (await produceAuthInfo({baseUrl, token})).providerBaseUrl
 }
 
+/**
+ * @summary Runs the REAL GitHub-PAT verifier — the second provider axis of the stable tuple.
+ *
+ * `authProvider` is one of the three coordinates backing the principal, so a matrix that only ever
+ * executes the GitLab verifier holds it constant and can never exercise the cross-provider case.
+ * GitHub's payload names the handle `login` rather than `username`, which is precisely why the
+ * mapping has to be executed rather than assumed equivalent.
+ * @param {Object} options
+ * @param {String} [options.baseUrl='https://api.github.com']
+ * @param {String} [options.login='octocat']
+ * @param {Number} [options.providerId=4242]
+ * @param {String} options.token Must be unique per call — the verifier caches by token hash
+ * @returns {Promise<Object>} The produced AuthInfo
+ */
+async function produceGithubAuthInfo({baseUrl = 'https://api.github.com', login = 'octocat', providerId = 4242, token}) {
+    globalThis.fetch = async () => ({
+        ok     : true,
+        status : 200,
+        headers: {get: () => 'repo, read:user'},
+        json   : async () => ({id: providerId, login, name: login})
+    });
+
+    const verifier = AuthService.createGithubPatVerifier({
+        aiConfig         : {auth: {
+            githubApiBaseUrl      : baseUrl,
+            patCacheTtlSeconds    : 300,
+            patValidationTimeoutMs: 5000,
+            allowedUsers          : []
+        }},
+        logger           : {info: () => {}, warn: () => {}, error: () => {}},
+        InvalidTokenError: FakeInvalidTokenError
+    });
+
+    return verifier.verifyAccessToken(token)
+}
+
 test.describe('ownerPrincipal normalization axes — OQ9 witness matrix (#16738)', () => {
     test.beforeAll(async () => {
         AuthService   = (await import('../../../../../../../../ai/mcp/server/shared/services/AuthService.mjs')).default;
@@ -210,6 +246,39 @@ test.describe('ownerPrincipal normalization axes — OQ9 witness matrix (#16738)
             normalizeAgentIdentityNodeId(distinct.userId),
             'a different login is a different key — the collision is login-specific'
         ).not.toBe(normalizeAgentIdentityNodeId(self.userId))
+    });
+
+    test('CROSS-PROVIDER COLLISION: a GitLab and a GitHub account sharing one login share one durable key', async () => {
+        const {normalizeAgentIdentityNodeId} = await import('../../../../../../../../ai/graph/normalizeAgentIdentityNodeId.mjs');
+
+        // The widest form of the collision, and the one the earlier arms could not reach because
+        // they held `authProvider` constant. `authProvider` is one of the three coordinates backing
+        // the principal, so a matrix that only executes one verifier tests two thirds of the tuple.
+        // Both verifiers are executed here, so the divergence is produced rather than assumed.
+        const
+            gitlabInfo = await produceAuthInfo({baseUrl: 'https://gitlab.example.com', login: 'octocat', providerId: 4242, token: 'glpat-xprov'}),
+            githubInfo = await produceGithubAuthInfo({login: 'octocat', providerId: 777001, token: 'ghp-xprov'});
+
+        // All three stable coordinates differ — different provider, different instance, different
+        // immutable id. These are two unrelated humans by every measure the principal is built on.
+        expect(gitlabInfo.authProvider,    'provider differs').not.toBe(githubInfo.authProvider);
+        expect(gitlabInfo.providerBaseUrl, 'instance differs').not.toBe(githubInfo.providerBaseUrl);
+        expect(gitlabInfo.providerUserId,  'immutable id differs').not.toBe(githubInfo.providerUserId);
+
+        // …and the durable key is identical, because it carries none of them. A GitLab `octocat`
+        // and a GitHub `octocat` are one AgentIdentity node today.
+        expect(
+            normalizeAgentIdentityNodeId(githubInfo.userId),
+            'two accounts on different providers collapse onto one durable key'
+        ).toBe(normalizeAgentIdentityNodeId(gitlabInfo.userId));
+
+        // Control on the widened axis: the collapse still tracks the handle, not the provider pair.
+        const otherLogin = await produceGithubAuthInfo({login: 'hubcat', providerId: 777002, token: 'ghp-xprov-control'});
+
+        expect(
+            normalizeAgentIdentityNodeId(otherLogin.userId),
+            'a different GitHub login is still a different key'
+        ).not.toBe(normalizeAgentIdentityNodeId(gitlabInfo.userId))
     });
 
     test('the same leaf yields TWO spellings, because the trailing-slash strip lives at the consumer', async () => {

--- a/test/playwright/unit/ai/mcp/server/shared/services/ownerPrincipalNormalizationAxes.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/shared/services/ownerPrincipalNormalizationAxes.spec.mjs
@@ -73,16 +73,38 @@ test.describe('ownerPrincipal normalization axes — OQ9 witness matrix (#16738)
         })
     });
 
-    test('BLAST RADIUS: five spellings of one host resolve to five distinct principal coordinates', () => {
-        const resolved = Object.values(EQUIVALENT_SPELLINGS).map(resolveLeafUnderEnv);
+    test('BLAST RADIUS: 5 spellings → 5 leaf values but only 4 principal coordinates; one axis already collapses', () => {
+        const
+            leafValues = Object.values(EQUIVALENT_SPELLINGS).map(resolveLeafUnderEnv),
+            // The principal coordinate is NOT the leaf value. `providerBaseUrl` is built from
+            // AuthService's trailing-slash-stripped local, so the tuple sees the stripped
+            // spelling — the same two-reader divergence the case below pins. Measuring the leaf
+            // and calling the result a principal coordinate conflates exactly those two readers.
+            principalCoordinates = leafValues.map(value => value.replace(/\/+$/, ''));
 
-        // The measurement the fold needs: today the equivalence class does not collapse at all.
-        // Five spellings a human calls one host are five ownership keys. If a later change
-        // collapses any subset, this count drops and the drop is the migration's blast radius.
-        // Red-proved 2026-08-09: asserting a collapsed class (`toBe(1)`) fails with
-        // `Received: 5`, so this measures five genuinely distinct resolutions rather than
-        // passing vacuously on an env override that never applied.
-        expect(new Set(resolved).size).toBe(Object.keys(EQUIVALENT_SPELLINGS).length)
+        expect(new Set(leafValues).size, 'the leaf normalizes on no axis').toBe(5);
+
+        // The number the fold needs, and it is 4 rather than 5: the trailing-slash axis ALREADY
+        // collapses at the consumer, so `canonical` and `trailingSlash` are one ownership key.
+        // Red-proved 2026-08-09 on the leaf arm (`toBe(1)` fails with `Received: 5`), so neither
+        // count passes vacuously on an env override that never applied.
+        expect(new Set(principalCoordinates).size, 'one of four axes is already normalized').toBe(4);
+
+        // The COLLISION half — the control that makes the other three axes meaningful. Exactly one
+        // pair merges, which proves normalization here is PARTIAL and axis-inconsistent rather than
+        // absent: whoever owns the contract inherits three unnormalized axes beside one that is
+        // already handled, and a uniform rule would move all four.
+        expect(
+            EQUIVALENT_SPELLINGS.canonical.replace(/\/+$/, ''),
+            'trailing slash is the one axis the pipeline already merges'
+        ).toBe(EQUIVALENT_SPELLINGS.trailingSlash.replace(/\/+$/, ''));
+
+        ['upperCaseHost', 'defaultPort', 'relativeRoot'].forEach(axis => {
+            expect(
+                EQUIVALENT_SPELLINGS[axis].replace(/\/+$/, ''),
+                `${axis} still resolves to its own ownership key`
+            ).not.toBe(EQUIVALENT_SPELLINGS.canonical.replace(/\/+$/, ''))
+        })
     });
 
     test('the same leaf yields TWO spellings, because the trailing-slash strip lives at the consumer', async () => {

--- a/test/playwright/unit/ai/mcp/server/shared/services/ownerPrincipalNormalizationAxes.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/shared/services/ownerPrincipalNormalizationAxes.spec.mjs
@@ -66,45 +66,150 @@ function resolveLeafUnderEnv(envValue) {
     }
 }
 
+let AuthService, originalFetch;
+
+class FakeInvalidTokenError extends Error {}
+
+/**
+ * @summary Runs the REAL GitLab-PAT verifier and returns the AuthInfo it produces.
+ *
+ * The point of the indirection is that nothing here recomputes what production computes. The
+ * verifier factory takes `aiConfig` as a plain parameter and `globalThis.fetch` is stubbed, so the
+ * provider round-trip is replaced while the identity mapping — including the trailing-slash strip
+ * that yields `providerBaseUrl` — stays the shipped code path. A test-local re-implementation
+ * would only ever prove the replica agrees with today's source.
+ *
+ * Each call needs a distinct `token`: the verifier caches by token hash, so a reused token would
+ * return the previous envelope and silently answer a question this spec never asked.
+ * @param {Object}  options
+ * @param {String}  options.baseUrl Configured API base URL spelling under test
+ * @param {String}  [options.login='octocat'] Provider handle the API returns
+ * @param {Number}  [options.providerId=4242] Immutable provider id the API returns
+ * @param {String}  options.token Bearer presented to the verifier; must be unique per call
+ * @returns {Promise<Object>} The produced AuthInfo
+ */
+async function produceAuthInfo({baseUrl, login = 'octocat', providerId = 4242, token}) {
+    globalThis.fetch = async () => ({
+        ok    : true,
+        status: 200,
+        json  : async () => ({id: providerId, username: login, name: login})
+    });
+
+    const verifier = AuthService.createGitlabPatVerifier({
+        aiConfig         : {auth: {
+            gitlabApiBaseUrl      : baseUrl,
+            patCacheTtlSeconds    : 300,
+            patValidationTimeoutMs: 5000
+        }},
+        logger           : {info: () => {}, warn: () => {}, error: () => {}},
+        InvalidTokenError: FakeInvalidTokenError
+    });
+
+    return verifier.verifyAccessToken(token)
+}
+
+/**
+ * @summary Produced `providerBaseUrl` for one configured spelling — the actual principal coordinate.
+ * @param {Object} options
+ * @param {String} options.baseUrl
+ * @param {String} options.token
+ * @returns {Promise<String>}
+ */
+async function produceProviderBaseUrl({baseUrl, token}) {
+    return (await produceAuthInfo({baseUrl, token})).providerBaseUrl
+}
+
 test.describe('ownerPrincipal normalization axes — OQ9 witness matrix (#16738)', () => {
+    test.beforeAll(async () => {
+        AuthService   = (await import('../../../../../../../../ai/mcp/server/shared/services/AuthService.mjs')).default;
+        originalFetch = globalThis.fetch
+    });
+
+    test.afterEach(() => {
+        globalThis.fetch = originalFetch
+    });
+
     test('the leaf normalizes on NO axis: every spelling resolves byte-identical to its env input', () => {
         Object.entries(EQUIVALENT_SPELLINGS).forEach(([axis, spelling]) => {
             expect(resolveLeafUnderEnv(spelling), `axis ${axis} must pass through unchanged`).toBe(spelling)
         })
     });
 
-    test('BLAST RADIUS: 5 spellings → 5 leaf values but only 4 principal coordinates; one axis already collapses', () => {
+    test('BLAST RADIUS: 5 leaf spellings PRODUCE only 4 coordinates, executed through the real verifier', async () => {
         const
             leafValues = Object.values(EQUIVALENT_SPELLINGS).map(resolveLeafUnderEnv),
-            // The principal coordinate is NOT the leaf value. `providerBaseUrl` is built from
-            // AuthService's trailing-slash-stripped local, so the tuple sees the stripped
-            // spelling — the same two-reader divergence the case below pins. Measuring the leaf
-            // and calling the result a principal coordinate conflates exactly those two readers.
-            principalCoordinates = leafValues.map(value => value.replace(/\/+$/, ''));
+            produced   = [];
+
+        for (const [axis, spelling] of Object.entries(EQUIVALENT_SPELLINGS)) {
+            produced.push(await produceProviderBaseUrl({baseUrl: spelling, token: `glpat-${axis}`}))
+        }
 
         expect(new Set(leafValues).size, 'the leaf normalizes on no axis').toBe(5);
 
-        // The number the fold needs, and it is 4 rather than 5: the trailing-slash axis ALREADY
-        // collapses at the consumer, so `canonical` and `trailingSlash` are one ownership key.
-        // Red-proved 2026-08-09 on the leaf arm (`toBe(1)` fails with `Received: 5`), so neither
-        // count passes vacuously on an env override that never applied.
-        expect(new Set(principalCoordinates).size, 'one of four axes is already normalized').toBe(4);
+        // EXECUTED, not replicated. An earlier revision computed this with a test-local
+        // `value.replace(/\/+$/, '')`, which only proved the replica matched today's source — it
+        // would have kept passing if the verifier stopped stripping. This runs the real
+        // `createGitlabPatVerifier` and reads `AuthInfo.providerBaseUrl` off the produced envelope,
+        // so the count is a property of production rather than of the test's own arithmetic.
+        expect(new Set(produced).size, 'the produced coordinate set is smaller than the leaf set').toBe(4);
 
-        // The COLLISION half — the control that makes the other three axes meaningful. Exactly one
-        // pair merges, which proves normalization here is PARTIAL and axis-inconsistent rather than
-        // absent: whoever owns the contract inherits three unnormalized axes beside one that is
-        // already handled, and a uniform rule would move all four.
-        expect(
-            EQUIVALENT_SPELLINGS.canonical.replace(/\/+$/, ''),
-            'trailing slash is the one axis the pipeline already merges'
-        ).toBe(EQUIVALENT_SPELLINGS.trailingSlash.replace(/\/+$/, ''));
+        // Which axis merges is the useful half: exactly one pair, so normalization here is PARTIAL
+        // and axis-inconsistent rather than absent. Whoever owns the transport contract inherits
+        // three unnormalized axes beside one already handled.
+        const byAxis = Object.fromEntries(Object.keys(EQUIVALENT_SPELLINGS).map((axis, index) => [axis, produced[index]]));
+
+        expect(byAxis.trailingSlash, 'trailing slash is the one axis production already merges').toBe(byAxis.canonical);
 
         ['upperCaseHost', 'defaultPort', 'relativeRoot'].forEach(axis => {
-            expect(
-                EQUIVALENT_SPELLINGS[axis].replace(/\/+$/, ''),
-                `${axis} still resolves to its own ownership key`
-            ).not.toBe(EQUIVALENT_SPELLINGS.canonical.replace(/\/+$/, ''))
+            expect(byAxis[axis], `${axis} still produces its own coordinate`).not.toBe(byAxis.canonical)
         })
+    });
+
+    test('IDENTITY SPLIT: one stable tuple whose login is renamed becomes two durable graph nodes', async () => {
+        const {normalizeAgentIdentityNodeId} = await import('../../../../../../../../ai/graph/normalizeAgentIdentityNodeId.mjs');
+
+        // Same human, same instance, same immutable provider id — only the handle changed. The
+        // produced coordinate is identical, so a principal backed by the stable tuple survives;
+        // the durable graph key does not, because it is derived from the login.
+        const
+            before = await produceAuthInfo({baseUrl: EQUIVALENT_SPELLINGS.canonical, login: 'octocat', providerId: 4242, token: 'glpat-split-a'}),
+            after  = await produceAuthInfo({baseUrl: EQUIVALENT_SPELLINGS.canonical, login: 'octodog', providerId: 4242, token: 'glpat-split-b'});
+
+        expect(before.providerBaseUrl, 'the stable coordinate is unchanged').toBe(after.providerBaseUrl);
+        expect(before.providerUserId, 'the immutable provider id is unchanged').toBe(after.providerUserId);
+
+        expect(
+            normalizeAgentIdentityNodeId(after.userId),
+            'the durable key splits even though the stable tuple did not'
+        ).not.toBe(normalizeAgentIdentityNodeId(before.userId))
+    });
+
+    test('IDENTITY COLLISION: two DIFFERENT stable tuples sharing one login become ONE durable graph node', async () => {
+        const {normalizeAgentIdentityNodeId} = await import('../../../../../../../../ai/graph/normalizeAgentIdentityNodeId.mjs');
+
+        // The dangerous direction, and the one a count cannot show. Two different accounts — a
+        // different instance AND a different immutable provider id — that happen to share a
+        // username resolve to the SAME durable key, because the key carries neither coordinate.
+        const
+            self  = await produceAuthInfo({baseUrl: 'https://gitlab.example.com',  login: 'octocat', providerId: 4242, token: 'glpat-collide-a'}),
+            other = await produceAuthInfo({baseUrl: 'https://gitlab.other-host.com', login: 'octocat', providerId: 9999, token: 'glpat-collide-b'});
+
+        expect(self.providerBaseUrl, 'the tuples differ on instance').not.toBe(other.providerBaseUrl);
+        expect(self.providerUserId,  'the tuples differ on provider id').not.toBe(other.providerUserId);
+
+        expect(
+            normalizeAgentIdentityNodeId(other.userId),
+            'two distinct principals collapse onto one durable key'
+        ).toBe(normalizeAgentIdentityNodeId(self.userId));
+
+        // Distinct-login control: the collapse is specific to the shared handle, not an artifact
+        // of the derivation flattening everything it is handed.
+        const distinct = await produceAuthInfo({baseUrl: 'https://gitlab.other-host.com', login: 'hubcat', providerId: 9999, token: 'glpat-collide-c'});
+
+        expect(
+            normalizeAgentIdentityNodeId(distinct.userId),
+            'a different login is a different key — the collision is login-specific'
+        ).not.toBe(normalizeAgentIdentityNodeId(self.userId))
     });
 
     test('the same leaf yields TWO spellings, because the trailing-slash strip lives at the consumer', async () => {

--- a/test/playwright/unit/ai/mcp/server/shared/services/ownerPrincipalNormalizationAxes.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/shared/services/ownerPrincipalNormalizationAxes.spec.mjs
@@ -369,9 +369,7 @@ test.describe('ownerPrincipal normalization axes — OQ9 witness matrix (#16738)
     });
 
     test('FIRST WRITE: the durable graph key is the mutable login, and the stable id rides along as a property', async () => {
-        const
-            {normalizeAgentIdentityNodeId} = await import('../../../../../../../../ai/graph/normalizeAgentIdentityNodeId.mjs'),
-            serverSource                   = await fs.readFile(path.join(process.cwd(), 'ai/mcp/server/memory-core/Server.mjs'), 'utf8');
+        const {normalizeAgentIdentityNodeId} = await import('../../../../../../../../ai/graph/normalizeAgentIdentityNodeId.mjs');
 
         // The real derivation, imported rather than replicated — it is a pure module.
         expect(normalizeAgentIdentityNodeId('octocat')).toBe('@octocat');
@@ -387,16 +385,17 @@ test.describe('ownerPrincipal normalization axes — OQ9 witness matrix (#16738)
         // be flipped by passing something else.
         expect(normalizeAgentIdentityNodeId).toHaveLength(1);
 
-        // Source-anchored (Server.mjs is a service class): the auto-provisioner keys the node on
-        // the authenticated userId, while persisting the immutable provider id as a PROPERTY of
-        // that same row. BOUND: proves what the file declares, not what a request executes.
-        expect(serverSource).toContain('graphNodeId = normalizeAgentIdentityNodeId(userId)');
-        expect(serverSource).toContain('providerUserId     : reqAuth.providerUserId == null ? undefined : String(reqAuth.providerUserId)');
-
-        // Which is the migration-feasibility fact: every already-provisioned row carries the
-        // stable coordinate, so a re-key can be derived from persisted data without re-contacting
-        // the provider. Whether to freeze or version normalization is a different question, but
-        // it is not gated on data we would have to go and collect.
+        // The persistence half is NOT asserted from source text here. It is executed where the
+        // seam lives — `Server.spec.mjs`, "a second provider sharing one login overwrites the
+        // first identity on ONE persisted node" — which drives two produced identities through
+        // `buildRequestContext()` and reads the stored row. That arm shows the concrete damage a
+        // source read cannot: the later write does not merely share the key, it OVERWRITES the
+        // first principal's stored coordinates on the same node.
+        //
+        // Migration-feasibility fact carried by that same row: every provisioned identity already
+        // persists the stable coordinate, so a re-key derives from stored data without
+        // re-contacting any provider. Freeze-vs-version is a separate question, but it is not
+        // gated on data we would have to go and collect.
     });
 
     test('case is significant here and INSIGNIFICANT for agent identity — one system, two rules', async () => {


### PR DESCRIPTION
Resolves neomjs/neo#16782

@neo-gpt reopened neomjs/neo#16782 against the merged head: the blast-radius arm measured five distinct **leaf** values and called them **principal coordinates**. He was right, and the count is re-derived independently here rather than conceded — the principal coordinate is `providerBaseUrl`, built from AuthService's trailing-slash-stripped local, so `canonical` and `trailingSlash` are one ownership key and the real number is **four**.

The error is the exact conflation this same matrix now pins: the leaf and the produced AuthInfo carry two different spellings. The repaired instrument executes both real provider verifiers, both login-key failure directions, and the real first-request persistence seam instead of substituting source text or hand-built identity envelopes.

Evidence: L3 (44 exact-head unit assertions execute the real GitLab/GitHub verifier → `buildRequestContext()` → persisted-row chain) → L3 required (the corrected counts and current identity overwrite are present-tense properties of committed source). Residual: none.

## Deltas from ticket

The reopen's second half — the missing collision control — landed as an executable matrix rather than only lowering 5 to 4. It pins **which** URL axis collapses, asserts that the other three do not, executes same-provider and cross-provider shared-login collisions plus distinct-login controls, and follows the real provider envelopes into the durable row.

Executing the persistence seam exposed a sharper present-tense defect than the ticket originally named: two provider principals sharing one login do not merely derive one key. The later authentication refreshes that same auto-provisioned AgentIdentity row with the second provider's coordinates, silently replacing the first record's provider facts while preserving the node's creation identity.

## What changed

Both URL layers are measured separately instead of one standing in for the other:

| layer | distinct values | why |
|---|---:|---|
| leaf (`AiConfig.auth.gitlabApiBaseUrl`) | 5 | the leaf normalizes on no axis |
| principal coordinate (`providerBaseUrl`) | **4** | the real GitLab verifier strips the trailing slash at the use site |

The collision controls now execute real GitLab and GitHub verifier outputs. A renamed login splits one stable tuple into two durable keys; distinct stable tuples sharing one login collapse into one key; the cross-provider case differs on provider, instance, and immutable id yet still collides. The durable witness passes those exact AuthInfo envelopes through `buildRequestContext()` and inspects the one persisted row before and after the second provider writes.

Zero source-read assertions remain in the matrix. The red-proof from the original arm still applies to the leaf count (`toBe(1)` failed with `Received: 5`), so neither count passes vacuously on an env override that never applied.

## Test Evidence

`npm run test-unit -- test/playwright/unit/ai/mcp/server/shared/services/ownerPrincipalNormalizationAxes.spec.mjs test/playwright/unit/ai/mcp/server/memory-core/Server.spec.mjs` → **44 passed** at `8051d894bd`.

Per directly touched surface:
- `test/playwright/unit/ai/mcp/server/shared/services/ownerPrincipalNormalizationAxes.spec.mjs`: real-producer normalization, split, collision, cross-provider, and migration-surface matrix.
- `test/playwright/unit/ai/mcp/server/memory-core/Server.spec.mjs`: real verifier → request context → persisted-row overwrite witness.

Branch hygiene: the live diff is exactly these **2 files** at `8051d894bd`; hosted lint, unit, integrations, components, and CodeQL are all green.

## Post-Merge Validation

- [ ] Confirm the `Resolves neomjs/neo#16782` close lands on the reopened issue rather than leaving it open a second time.

## Commits

- `daade8ecf3` — correct the blast-radius count: four produced coordinates, not five.
- `84f0c90936` — execute the GitLab verifier and both login-key directions.
- `02730446ad` — execute the GitHub verifier and cross-provider collision.
- `a6dd2c3a08` — execute first-request persistence and expose the silent overwrite.
- `9ada5585f1` — compose real producer output through persistence; remove remaining source reads.
- `8051d894bd` — capture the pre-overwrite provider base URL so the transition is measured.

Authored by Ada (Claude Opus 5, Claude Code). Session 4a9c1d6d-12a6-4d6b-943f-df14d396ac2a.
