### PR TITLE
feat(fleet): version the client wire contract (#16743)

### DIFF
--- a/ai/scripts/fleet/onboardPeer.mjs
+++ b/ai/scripts/fleet/onboardPeer.mjs
@@ -240,7 +240,9 @@ export function createOnboardingFleetBridge({url = 'http://127.0.0.1:8083/fleet'
         }
     };
 
-    return createFleetRegistryBridge(send)
+    return createFleetRegistryBridge(send, {
+        transportFailureMessage: "onboardPeer: long-lived Fleet owner is unreachable; start it with 'npm run ai:fleet-server' and re-run"
+    })
 }
 
 /**

--- a/ai/scripts/lint/lint-fleet-vocabulary-parity.mjs
+++ b/ai/scripts/lint/lint-fleet-vocabulary-parity.mjs
@@ -73,6 +73,11 @@ export function compareFleetVocabulary({authority, twin}) {
         ['HARNESS_TYPES',            authority.harness.HARNESS_TYPES,         twin.harness.HARNESS_TYPES],
         ['FLEET_WIRE_METHODS',       authority.wire.FLEET_WIRE_METHODS,       twin.wire.FLEET_WIRE_METHODS],
         ['FLEET_CREDENTIAL_METHODS', authority.wire.FLEET_CREDENTIAL_METHODS, twin.wire.FLEET_CREDENTIAL_METHODS],
+        ['FLEET_WIRE_PROTOCOL_VERSIONS', authority.wire.FLEET_WIRE_PROTOCOL_VERSIONS, twin.wire.FLEET_WIRE_PROTOCOL_VERSIONS],
+        ['FLEET_WIRE_CAPABILITIES', authority.wire.FLEET_WIRE_CAPABILITIES, twin.wire.FLEET_WIRE_CAPABILITIES],
+        ['FLEET_WIRE_REQUIRED_CAPABILITIES', authority.wire.FLEET_WIRE_REQUIRED_CAPABILITIES, twin.wire.FLEET_WIRE_REQUIRED_CAPABILITIES],
+        ['FLEET_WIRE_RESPONSE_STATES', authority.wire.FLEET_WIRE_RESPONSE_STATES, twin.wire.FLEET_WIRE_RESPONSE_STATES],
+        ['FLEET_WIRE_ENVELOPE_SCHEMA', authority.wire.FLEET_WIRE_ENVELOPE_SCHEMA, twin.wire.FLEET_WIRE_ENVELOPE_SCHEMA],
         ['FLEET_COCKPIT_SOURCES',    authority.cockpit.FLEET_COCKPIT_SOURCES, twin.sources.FLEET_COCKPIT_SOURCES]
     ];
 
@@ -110,6 +115,63 @@ export function compareFleetVocabulary({authority, twin}) {
         ['resolveHarnessType(...)',                authority.harness.resolveHarnessType,  twin.harness.resolveHarnessType,  [
             ...authority.harness.HARNESS_TYPES.map(entry => [entry.type]),
             ['unregistered-harness']
+        ]],
+        ['createFleetWireOffer()',                 authority.wire.createFleetWireOffer, twin.wire.createFleetWireOffer, [
+            []
+        ]],
+        ['createFleetWireProtocolStamp(...)',      authority.wire.createFleetWireProtocolStamp, twin.wire.createFleetWireProtocolStamp, [
+            [],
+            [1, ['method-schema-v1']]
+        ]],
+        ['selectFleetWireContract(...)',           authority.wire.selectFleetWireContract, twin.wire.selectFleetWireContract, [
+            [authority.wire.createFleetWireOffer()],
+            [{versions: [0], capabilities: [...authority.wire.FLEET_WIRE_CAPABILITIES]}],
+            [{versions: [1], capabilities: []}],
+            [{versions: '1', capabilities: []}]
+        ]],
+        ['createFleetWireRequest(...)',            authority.wire.createFleetWireRequest, twin.wire.createFleetWireRequest, [
+            ['listAgents', undefined],
+            ['listAgents', {page: 1}, {versions: [1], capabilities: [...authority.wire.FLEET_WIRE_CAPABILITIES]}],
+            ['getManager', null]
+        ]],
+        ['createFleetWireResponse(...)',           authority.wire.createFleetWireResponse, twin.wire.createFleetWireResponse, [
+            [authority.wire.FLEET_WIRE_RESPONSE_STATES.ok, {result: []}],
+            [authority.wire.FLEET_WIRE_RESPONSE_STATES.ok, {}],
+            [authority.wire.FLEET_WIRE_RESPONSE_STATES.unsupportedProtocol, {error: 'fleet: unsupported wire protocol'}],
+            ['invented-state', {}]
+        ]],
+        ['inspectFleetWireResponse(...)',          authority.wire.inspectFleetWireResponse, twin.wire.inspectFleetWireResponse, [
+            [authority.wire.createFleetWireResponse(
+                authority.wire.FLEET_WIRE_RESPONSE_STATES.ok,
+                {result: []}
+            )],
+            [{ok: true, state: 'invented', protocol: {version: 1, capabilities: []}}],
+            [{
+                ok      : true,
+                protocol: authority.wire.createFleetWireProtocolStamp(),
+                state   : authority.wire.FLEET_WIRE_RESPONSE_STATES.ok
+            }],
+            [authority.wire.createFleetWireResponse(authority.wire.FLEET_WIRE_RESPONSE_STATES.ok, {
+                protocol: authority.wire.createFleetWireProtocolStamp(2),
+                result  : []
+            }), authority.wire.createFleetWireOffer()],
+            [authority.wire.createFleetWireResponse(authority.wire.FLEET_WIRE_RESPONSE_STATES.ok, {
+                protocol: authority.wire.createFleetWireProtocolStamp(1, [
+                    ...authority.wire.FLEET_WIRE_CAPABILITIES,
+                    'server-only'
+                ]),
+                result: []
+            }), authority.wire.createFleetWireOffer()],
+            [{
+                ...authority.wire.createFleetWireResponse(
+                    authority.wire.FLEET_WIRE_RESPONSE_STATES.ok,
+                    {result: []}
+                ),
+                protocol: {
+                    ...authority.wire.createFleetWireProtocolStamp(),
+                    ownerPrincipal: 'must-never-cross'
+                }
+            }, authority.wire.createFleetWireOffer()]
         ]]
     ];
 

--- a/ai/services/fleet/createFleetRegistryBridge.mjs
+++ b/ai/services/fleet/createFleetRegistryBridge.mjs
@@ -1,12 +1,18 @@
-import {FLEET_WIRE_METHODS} from './fleetWireMethods.mjs';
+import {
+    createFleetWireOffer,
+    createFleetWireRequest,
+    FLEET_WIRE_METHODS,
+    FLEET_WIRE_RESPONSE_STATES,
+    inspectFleetWireResponse
+} from './fleetWireMethods.mjs';
 
 /**
  * @summary Build the pane-facing fleet registry bridge from a transport `send`. Given a request
  * sender, returns the exact object the agentos pane resolves at
  * `globalThis.AgentOS.fleet.registryBridge` (`apps/agentos/view/Accounts.mjs:260`) — one async method
- * per wire-allowlisted operation ({@link FLEET_WIRE_METHODS}), each forwarding `{method, params}`
- * through `send` and unwrapping the `{ok, result|error}` envelope (resolving `result`, throwing on
- * `error`).
+ * per wire-allowlisted operation ({@link FLEET_WIRE_METHODS}). Each operation sends a fresh
+ * version/capability offer, then accepts result data only after the response selects a contract the
+ * client offered — the operable-cold contract's Node-client half.
  *
  * The NODE-side client factory (CLI tools like `ai/scripts/fleet/onboardPeer.mjs`, integration
  * specs), binding the same {@link FLEET_WIRE_METHODS} authority `dispatchFleetRequest` validates
@@ -16,7 +22,7 @@ import {FLEET_WIRE_METHODS} from './fleetWireMethods.mjs';
  * **Dependency-light by design** — it imports only the dep-free wire-method list, never
  * the Node-only FleetControlBridge / crypto / fs chain.
  *
- * @param {Function} send A transport sender: `({method, params}) => Promise<{ok:Boolean, result?:*, error?:String}>`.
+ * @param {Function} send A transport sender for versioned Fleet request/response envelopes.
  * @returns {Object} the registry bridge — one async method per {@link FLEET_WIRE_METHODS} entry
  *                   (`defineAgent(payload)`, `startAgent(id)`, `listAgents()`, …).
  */
@@ -26,9 +32,29 @@ export function createFleetRegistryBridge(send) {
     }
 
     const request = async (method, params) => {
-        const envelope = await send({method, params});
+        const
+            offer       = createFleetWireOffer(),
+            wireRequest = createFleetWireRequest(method, params, offer);
 
-        if (!envelope?.ok) {
+        let envelope, inspection;
+
+        try {
+            envelope = await send(wireRequest)
+        } catch {
+            throw new Error('fleet: request transport failed')
+        }
+
+        try {
+            inspection = inspectFleetWireResponse(envelope, offer)
+        } catch {
+            throw new Error('fleet: malformed wire response')
+        }
+
+        if (!inspection.ok) {
+            throw new Error(inspection.error)
+        }
+
+        if (envelope.state !== FLEET_WIRE_RESPONSE_STATES.ok) {
             throw new Error(envelope?.error || `fleet: '${method}' failed`);
         }
 

--- a/ai/services/fleet/createFleetRegistryBridge.mjs
+++ b/ai/services/fleet/createFleetRegistryBridge.mjs
@@ -23,12 +23,20 @@ import {
  * the Node-only FleetControlBridge / crypto / fs chain.
  *
  * @param {Function} send A transport sender for versioned Fleet request/response envelopes.
+ * @param {Object} [options]
+ * @param {String} [options.transportFailureMessage='fleet: request transport failed'] Static,
+ *                 caller-owned remediation used when `send` rejects. The rejected error is never
+ *                 interpolated or exposed across the client boundary.
  * @returns {Object} the registry bridge — one async method per {@link FLEET_WIRE_METHODS} entry
  *                   (`defineAgent(payload)`, `startAgent(id)`, `listAgents()`, …).
  */
-export function createFleetRegistryBridge(send) {
+export function createFleetRegistryBridge(send, {transportFailureMessage = 'fleet: request transport failed'} = {}) {
     if (typeof send !== 'function') {
         throw new Error('createFleetRegistryBridge: a transport send(request) function is required');
+    }
+
+    if (typeof transportFailureMessage !== 'string' || !transportFailureMessage.trim() || transportFailureMessage.length > 512 || /[\r\n]/.test(transportFailureMessage)) {
+        throw new Error('createFleetRegistryBridge: transportFailureMessage must be a non-empty single-line string no longer than 512 characters');
     }
 
     const request = async (method, params) => {
@@ -41,7 +49,7 @@ export function createFleetRegistryBridge(send) {
         try {
             envelope = await send(wireRequest)
         } catch {
-            throw new Error('fleet: request transport failed')
+            throw new Error(transportFailureMessage)
         }
 
         try {

--- a/ai/services/fleet/dispatchFleetRequest.mjs
+++ b/ai/services/fleet/dispatchFleetRequest.mjs
@@ -1,39 +1,61 @@
-import FleetControlBridge   from './FleetControlBridge.mjs';
-import {FLEET_WIRE_METHODS} from './fleetWireMethods.mjs';
+import FleetControlBridge from './FleetControlBridge.mjs';
+import {
+    createFleetWireResponse,
+    FLEET_WIRE_METHODS,
+    FLEET_WIRE_RESPONSE_STATES,
+    selectFleetWireContract
+} from './fleetWireMethods.mjs';
 
 /**
- * @summary Route one transport-delivered fleet request to the {@link FleetControlBridge} allowlist —
- * the single choke-point every app↔fleet transport (the dev-server WebSocket, or the Electron shell's
- * in-process inject) funnels through. It enforces the wire-level method allowlist, forwards the single
- * `params` argument, and normalizes success / failure into a serializable envelope.
+ * @summary Negotiate one transport-delivered Fleet request, then route it through the
+ * {@link FleetControlBridge} allowlist. This is the single choke-point shared by the HTTP transport
+ * and Electron injection: protocol selection happens before method lookup, unknown methods fail as
+ * their own closed state, and bridge execution returns one finite response state.
  *
- * **Never throws to the transport.** A rejected method name, a thrown operation, or a rejected promise
- * all return an `{ok:false, error}` envelope, so the calling pane sees a fail-closed result rather than
- * a crashed connection — mirroring the fail-closed discipline the pane already applies when no bridge
- * is injected (`apps/agentos/view/Accounts.mjs`).
+ * **Never throws to the transport.** Unsupported protocol/capability offers, rejected method names,
+ * and thrown operations all return a versioned closed envelope. No legacy unversioned request can
+ * masquerade as an operation failure or empty result.
  *
- * @param {Object}  request
+ * @param {Object}  request Versioned `{method, params, protocol}` request.
  * @param {String}  request.method   One of {@link FLEET_WIRE_METHODS}.
  * @param {*}      [request.params]  The single argument forwarded to the operation — a definition
  *                                   object for `defineAgent`, an id string for the lifecycle ops,
  *                                   omitted for `listAgents` / `fleetStatus`.
  * @param {Object} [bridge=FleetControlBridge] The control surface; inject a stub in tests.
- * @returns {Promise<Object>} `{ok:true, result}` on success; `{ok:false, error}` on a non-allowlisted
- *                            method or a thrown / rejected operation.
+ * @returns {Promise<Object>} Versioned finite-state response envelope.
  */
-export async function dispatchFleetRequest({method, params} = {}, bridge = FleetControlBridge) {
+export async function dispatchFleetRequest(request = {}, bridge = FleetControlBridge) {
+    const
+        {method, params} = request || {},
+        selection        = selectFleetWireContract(request?.protocol);
+
+    if (!selection.ok) {
+        return createFleetWireResponse(selection.state, selection)
+    }
+
     if (!FLEET_WIRE_METHODS.includes(method)) {
-        return {ok: false, error: `fleet: method '${method}' is not on the control surface`};
+        return createFleetWireResponse(FLEET_WIRE_RESPONSE_STATES.unsupportedMethod, {
+            error   : "fleet: method '" + method + "' is not on the control surface",
+            protocol: selection.protocol
+        })
     }
 
     try {
         const result = await bridge[method](params);
-        return {ok: true, result};
+
+        return createFleetWireResponse(FLEET_WIRE_RESPONSE_STATES.ok, {
+            protocol: selection.protocol,
+            result
+        })
     } catch (error) {
         // Never expose the raw error across the wire — it can carry a stack trace / internal paths.
         // Log it server-side; return a sanitized, method-scoped failure the pane can act on.
         console.error(`[fleet] dispatch of '${method}' failed:`, error);
-        return {ok: false, error: `fleet: '${method}' failed`};
+
+        return createFleetWireResponse(FLEET_WIRE_RESPONSE_STATES.operationFailed, {
+            error   : "fleet: '" + method + "' failed",
+            protocol: selection.protocol
+        })
     }
 }
 

--- a/ai/services/fleet/fleetBridgeServer.mjs
+++ b/ai/services/fleet/fleetBridgeServer.mjs
@@ -1,6 +1,10 @@
 import http                      from 'http';
 import {dispatchFleetRequest}    from './dispatchFleetRequest.mjs';
 import {createFleetIngressGuard} from './fleetIngressAuth.mjs';
+import {
+    createFleetWireResponse,
+    FLEET_WIRE_RESPONSE_STATES
+} from './fleetWireMethods.mjs';
 import {isLocalBearerToken}      from '../../mcp/server/shared/helpers/localBearer.mjs';
 
 /**
@@ -26,9 +30,10 @@ import {isLocalBearerToken}      from '../../mcp/server/shared/helpers/localBear
  * reusing an existing process — an unknown or mismatched process yields a named refusal upstream,
  * never silent reuse.
  *
- * Deliberately transport-swappable: the browser side only needs `send({method, params})`, so this
- * HTTP channel can be replaced by the Electron shell's in-process inject (Option A) without touching
- * the pane — the guard + context-stamp contract travels with whichever transport hosts the wire.
+ * Deliberately transport-swappable: the browser side only needs a sender for versioned Fleet
+ * envelopes, so HTTP can be replaced by Electron's in-process injection without touching the pane.
+ * `/fleet/probe` is an out-of-band launch receipt; every `/fleet` refusal or dispatch result uses
+ * the finite C2 response vocabulary.
  *
  * @param {Object}   opts
  * @param {Number}   [opts.port=8083]            `0` selects an ephemeral port (tests).
@@ -115,7 +120,12 @@ export function startFleetBridgeServer({
         // socket an unauthenticated caller could keep streaming into.
         if (!decision.admitted) {
             res.setHeader('Connection', 'close');
-            respond(res, decision.status, {ok: false, error: decision.error}, decision.corsOrigin);
+            respond(
+                res,
+                decision.status,
+                createFleetWireResponse(FLEET_WIRE_RESPONSE_STATES.refused, {error: decision.error}),
+                decision.corsOrigin
+            );
             return req.resume()
         }
 
@@ -152,7 +162,12 @@ export function startFleetBridgeServer({
         }
 
         if (req.method !== 'POST' || pathname !== '/fleet') {
-            return respond(res, 404, {ok: false, error: 'fleet: POST /fleet only'}, decision.corsOrigin)
+            return respond(
+                res,
+                404,
+                createFleetWireResponse(FLEET_WIRE_RESPONSE_STATES.refused, {error: 'fleet: POST /fleet only'}),
+                decision.corsOrigin
+            )
         }
 
         let body = '';
@@ -168,7 +183,12 @@ export function startFleetBridgeServer({
             try {
                 request = JSON.parse(body || '{}')
             } catch {
-                return respond(res, 400, {ok: false, error: 'fleet: invalid JSON body'}, decision.corsOrigin)
+                return respond(
+                    res,
+                    400,
+                    createFleetWireResponse(FLEET_WIRE_RESPONSE_STATES.refused, {error: 'fleet: invalid JSON body'}),
+                    decision.corsOrigin
+                )
             }
 
             // The identity stamp: the SERVER's boot-resolved viewer, never anything the request
@@ -182,7 +202,9 @@ export function startFleetBridgeServer({
                 envelope = await runInContext({...viewerContext, source: 'fleet-ingress'}, () => dispatch(request))
             } catch (error) {
                 console.error('[fleet] request dispatch threw:', error);
-                envelope = {ok: false, error: 'fleet: request failed'}
+                envelope = createFleetWireResponse(FLEET_WIRE_RESPONSE_STATES.operationFailed, {
+                    error: 'fleet: request failed'
+                })
             }
 
             respond(res, 200, envelope, decision.corsOrigin)

--- a/ai/services/fleet/fleetServer.mjs
+++ b/ai/services/fleet/fleetServer.mjs
@@ -22,6 +22,11 @@ import RequestContextService    from '../../mcp/server/shared/services/RequestCo
 import TransportService         from '../../mcp/server/shared/services/TransportService.mjs';
 import FleetControlBridge       from './FleetControlBridge.mjs';
 import {dispatchFleetS1Request} from './fleetServerPolicy.mjs';
+import {
+    createFleetWireResponse,
+    FLEET_WIRE_RESPONSE_STATES,
+    inspectFleetWireResponse
+} from './fleetWireMethods.mjs';
 
 const
     REPO_ROOT             = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../..'),
@@ -142,10 +147,104 @@ export function resolveFleetResourceUrl(aiConfig=AiConfig) {
 }
 
 /**
+ * @summary Adapts third-party pre-dispatch `json` / `send` / `end` error bodies onto Fleet's finite
+ * wire contract without changing the status code or security headers. The adapter is exact-route
+ * scoped: `/fleet/probe` remains the explicitly out-of-band launch receipt.
+ * @param {Object} req Express request.
+ * @param {Object} res Express response.
+ * @param {Function} next Express continuation.
+ * @returns {*} Continuation result.
+ */
+function adaptFleetWireErrorResponse(req, res, next) {
+    if (req.path !== '/fleet') return next();
+
+    const
+        end  = res.end.bind(res),
+        send = res.send.bind(res);
+
+    let sending = false;
+
+    const normalize = body => {
+        if (res.statusCode < 400) return null;
+
+        let candidate = body;
+
+        try {
+            if (Buffer.isBuffer(candidate)) {
+                candidate = candidate.toString('utf8')
+            }
+
+            if (typeof candidate === 'string') {
+                candidate = JSON.parse(candidate)
+            }
+
+            if (inspectFleetWireResponse(candidate).ok === true && candidate.ok === false) {
+                return null
+            }
+        } catch {/* hostile middleware output is normalized below */}
+
+        return JSON.stringify(createFleetWireResponse(FLEET_WIRE_RESPONSE_STATES.refused, {
+            error: 'fleet: request not admitted'
+        }))
+    };
+
+    const prepareJson = body => {
+        res.removeHeader('Content-Length');
+        res.type('application/json');
+
+        return body
+    };
+
+    res.send = body => {
+        if (sending) return send(body);
+
+        const normalized = normalize(body);
+
+        if (normalized !== null) {
+            body = prepareJson(normalized)
+        }
+
+        sending = true;
+
+        try {
+            return send(body)
+        } finally {
+            sending = false
+        }
+    };
+
+    res.end = (chunk, encoding, callback) => {
+        if (sending) return end(chunk, encoding, callback);
+
+        if (typeof chunk === 'function') {
+            callback = chunk;
+            chunk    = undefined;
+            encoding = undefined
+        } else if (typeof encoding === 'function') {
+            callback = encoding;
+            encoding = undefined
+        }
+
+        const normalized = normalize(chunk);
+
+        if (normalized === null) {
+            return end(chunk, encoding, callback)
+        }
+
+        return end(prepareJson(normalized), 'utf8', callback)
+    };
+
+    return next()
+}
+
+/**
  * @summary Compose the authenticated S1 Fleet HTTP application. Ordering is security-significant:
- * Host guard -> AuthService pre-CORS guard -> canonical CORS -> AuthService -> identity projection
- * -> JSON parser -> exact routes. Authentication therefore refuses an anonymous malformed body
- * before parsing, while the request context is a frozen copy rather than the SDK's mutable AuthInfo.
+ * wire-error adapter -> Host guard -> AuthService pre-CORS guard -> canonical CORS -> AuthService ->
+ * identity projection -> JSON parser -> exact routes. Authentication therefore refuses an anonymous
+ * malformed body before parsing, while the request context is a frozen copy rather than the SDK's
+ * mutable AuthInfo.
+ * `/fleet` returns the negotiated finite wire envelope; `/fleet/probe` remains an out-of-band
+ * liveness probe and never stands in for client-contract readiness.
  * @param {Object} [options]
  * @param {Object} [options.aiConfig=AiConfig] Resolved Tier-1 config tree.
  * @param {Object} [options.authService=AuthService] Auth boundary collaborator.
@@ -175,6 +274,7 @@ export async function createFleetServerApp({
 
     app.enable('strict routing');
     app.disable('x-powered-by');
+    app.use(adaptFleetWireErrorResponse);
     app.use(hostHeaderValidation(transportService.computeAllowedHosts(aiConfig)));
 
     authService.setupPreCors({app, aiConfig});
@@ -184,7 +284,9 @@ export async function createFleetServerApp({
         aiConfig,
         corsMiddleware: cors,
         resourceUrl   : mcpServerUrl,
-        errorBody     : {ok: false, error: 'fleet: origin not admitted'}
+        errorBody     : createFleetWireResponse(FLEET_WIRE_RESPONSE_STATES.refused, {
+            error: 'fleet: origin not admitted'
+        })
     });
 
     await authService.setup({
@@ -201,7 +303,9 @@ export async function createFleetServerApp({
         const context = createFleetRequestContext(req.auth);
 
         if (!context) {
-            res.status(401).json({ok: false, error: 'fleet: authenticated provider identity required'});
+            res.status(401).json(createFleetWireResponse(FLEET_WIRE_RESPONSE_STATES.refused, {
+                error: 'fleet: authenticated provider identity required'
+            }));
             return
         }
 
@@ -230,30 +334,40 @@ export async function createFleetServerApp({
             envelope = await runInContext(req.fleetRequestContext, () => dispatch(req.body ?? {}))
         } catch (error) {
             logger.error('[FleetServer] dispatch failed');
-            envelope = {ok: false, error: 'fleet: request failed'}
+            envelope = createFleetWireResponse(FLEET_WIRE_RESPONSE_STATES.operationFailed, {
+                error: 'fleet: request failed'
+            })
         }
 
         res.status(200).json(envelope)
     });
 
     app.use((req, res) => {
-        res.status(404).json({ok: false, error: 'fleet: route not found'})
+        res.status(404).json(createFleetWireResponse(FLEET_WIRE_RESPONSE_STATES.refused, {
+            error: 'fleet: route not found'
+        }))
     });
 
     // Express body-parser errors carry raw parser text; collapse them to stable Fleet envelopes.
     app.use((error, req, res, next) => {
         if (error?.type === 'entity.too.large') {
-            res.status(413).json({ok: false, error: 'fleet: request body too large'});
+            res.status(413).json(createFleetWireResponse(FLEET_WIRE_RESPONSE_STATES.refused, {
+                error: 'fleet: request body too large'
+            }));
             return
         }
 
         if (error instanceof SyntaxError) {
-            res.status(400).json({ok: false, error: 'fleet: invalid JSON body'});
+            res.status(400).json(createFleetWireResponse(FLEET_WIRE_RESPONSE_STATES.refused, {
+                error: 'fleet: invalid JSON body'
+            }));
             return
         }
 
         logger.error('[FleetServer] request middleware failed');
-        res.status(500).json({ok: false, error: 'fleet: request failed'})
+        res.status(500).json(createFleetWireResponse(FLEET_WIRE_RESPONSE_STATES.operationFailed, {
+            error: 'fleet: request failed'
+        }))
     });
 
     return app

--- a/ai/services/fleet/fleetServerPolicy.mjs
+++ b/ai/services/fleet/fleetServerPolicy.mjs
@@ -1,5 +1,10 @@
 import {dispatchFleetRequest} from './dispatchFleetRequest.mjs';
-import {FLEET_WIRE_METHODS}   from './fleetWireMethods.mjs';
+import {
+    createFleetWireResponse,
+    FLEET_WIRE_METHODS,
+    FLEET_WIRE_RESPONSE_STATES,
+    selectFleetWireContract
+} from './fleetWireMethods.mjs';
 
 /**
  * @summary The complete S1 wire policy for the composed Fleet service. Authentication makes the
@@ -57,24 +62,30 @@ export const FLEET_S1_READY_METHODS = Object.freeze(
 );
 
 /**
- * @summary Dispatch one composed-service request through the S1 availability boundary.
- * Unknown verbs retain the canonical wire refusal; known future-slice verbs return a top-level
- * degradation envelope naming their owning semantic slice and never touch `FleetControlBridge`.
- * @param {Object} request Fleet wire request (`{method, params}`).
+ * @summary Negotiate one composed-service request before applying the S1 availability boundary.
+ * Unknown verbs retain the canonical `unsupported-method` state; known future-slice verbs return a
+ * versioned `degraded` state naming their semantic owner and never touch `FleetControlBridge`.
+ * @param {Object} request Versioned Fleet wire request (`{method, params, protocol}`).
  * @param {Object} [bridge] Injectable bridge used by the canonical dispatcher.
- * @returns {Promise<Object>} Canonical success/failure envelope or named-slice degradation.
+ * @returns {Promise<Object>} Versioned finite-state response or named-slice degradation.
  */
 export async function dispatchFleetS1Request(request={}, bridge) {
-    const disposition = Object.hasOwn(FLEET_S1_METHOD_POLICY, request?.method)
+    const
+        selection   = selectFleetWireContract(request?.protocol),
+        disposition = Object.hasOwn(FLEET_S1_METHOD_POLICY, request?.method)
         ? FLEET_S1_METHOD_POLICY[request.method]
         : null;
 
+    if (!selection.ok) {
+        return createFleetWireResponse(selection.state, selection)
+    }
+
     if (disposition?.startsWith('awaiting-')) {
-        return {
-            ok      : false,
+        return createFleetWireResponse(FLEET_WIRE_RESPONSE_STATES.degraded, {
             degraded: disposition,
-            error   : `fleet: '${request.method}' awaits ${SLICE_LABELS[disposition]}`
-        }
+            error   : `fleet: '${request.method}' awaits ${SLICE_LABELS[disposition]}`,
+            protocol: selection.protocol
+        })
     }
 
     return dispatchFleetRequest(request, bridge)

--- a/ai/services/fleet/fleetWireMethods.mjs
+++ b/ai/services/fleet/fleetWireMethods.mjs
@@ -1,11 +1,12 @@
 /**
- * @summary The app↔fleet wire-level capability allowlist AUTHORITY — the EXACT method names a
+ * @summary The dependency-free app↔fleet client-contract AUTHORITY — the exact operation names,
+ * envelope schema, protocol versions, capability vocabulary, and finite response states a
  * transport may carry between the agentos pane and {@link Neo.ai.services.fleet.FleetControlBridge}.
  * The Node side binds it directly: `dispatchFleetRequest` rejects anything off this list, and
  * `createFleetRegistryBridge` (the Node-side client factory) generates exactly these methods. The
  * browser binds the operable-cold twin (`apps/agentos/config/fleetWireMethods.mjs`) instead of
  * importing across the realm boundary — `ai/scripts/lint/lint-fleet-vocabulary-parity.mjs`
- * deep-equals the two lists, so the ends of the wire cannot drift.
+ * compares every constant and pure helper outcome, so the ends of the wire cannot drift.
  *
  * Deliberately **narrower than FleetControlBridge's class surface**: it excludes the `getRegistry` /
  * `getManager` resolver seams (which return the lifecycle-powerful singletons) and every inherited
@@ -71,3 +72,329 @@ export const FLEET_WIRE_METHODS = Object.freeze([
 export const FLEET_CREDENTIAL_METHODS = Object.freeze(
     FLEET_WIRE_METHODS.filter(method => method === 'defineAgent' || method === 'connectTenant')
 );
+
+/**
+ * @summary Protocol versions this Fleet service can select, newest first. A client offers one or
+ * more versions and the server selects the first common member before method policy or bridge
+ * execution. Version 1 introduces explicit capability offers and closed response states.
+ * @type {Number[]}
+ */
+export const FLEET_WIRE_PROTOCOL_VERSIONS = Object.freeze([1]);
+
+/**
+ * @summary Client-safe protocol capabilities implemented by this authority. These are wire
+ * mechanics only — never identity, bearer, ownership, authorization, or lifecycle policy.
+ * @type {String[]}
+ */
+export const FLEET_WIRE_CAPABILITIES = Object.freeze([
+    'method-schema-v1',
+    'closed-response-states-v1'
+]);
+
+/**
+ * @summary Capabilities a client must offer for the current server contract to be usable.
+ * Kept distinct from the full capability catalog so future additive capabilities can remain
+ * optional without silently widening the minimum client contract.
+ * @type {String[]}
+ */
+export const FLEET_WIRE_REQUIRED_CAPABILITIES = Object.freeze([
+    'method-schema-v1',
+    'closed-response-states-v1'
+]);
+
+/**
+ * @summary The finite top-level response-state vocabulary. Domain outcomes such as an admission
+ * rejection remain inside result; these states describe only the wire/dispatch layer.
+ * @type {Readonly<Record<String, String>>}
+ */
+export const FLEET_WIRE_RESPONSE_STATES = Object.freeze({
+    degraded             : 'degraded',
+    ok                   : 'ok',
+    operationFailed      : 'operation-failed',
+    refused              : 'refused',
+    unsupportedCapability: 'unsupported-capability',
+    unsupportedMethod    : 'unsupported-method',
+    unsupportedProtocol  : 'unsupported-protocol'
+});
+
+/**
+ * @summary Executable vocabulary for the request offer, selected contract, and response envelope.
+ * It is intentionally structural rather than a duplicate of server-side domain validators.
+ * @type {Readonly<Object>}
+ */
+export const FLEET_WIRE_ENVELOPE_SCHEMA = Object.freeze({
+    offer: Object.freeze({
+        required: Object.freeze(['versions', 'capabilities'])
+    }),
+    request: Object.freeze({
+        required: Object.freeze(['method', 'protocol']),
+        optional: Object.freeze(['params'])
+    }),
+    response: Object.freeze({
+        required       : Object.freeze(['ok', 'state', 'protocol']),
+        successRequired: Object.freeze(['result']),
+        failureRequired: Object.freeze(['error']),
+        optional       : Object.freeze(['degraded'])
+    }),
+    selection: Object.freeze({
+        required: Object.freeze(['version', 'capabilities'])
+    })
+});
+
+const
+    MAX_PROTOCOL_CAPABILITIES = 64,
+    MAX_PROTOCOL_TOKEN_LENGTH = 100,
+    MAX_PROTOCOL_VERSIONS     = 16,
+    MAX_WIRE_DEGRADED_LENGTH  = 100,
+    MAX_WIRE_ERROR_LENGTH     = 300,
+    responseStates            = new Set(Object.values(FLEET_WIRE_RESPONSE_STATES));
+
+/**
+ * @summary Identifies a plain record-shaped wire value without accepting arrays or null.
+ * @param {*} value
+ * @returns {Boolean}
+ * @private
+ */
+function isRecord(value) {
+    return Boolean(value) && typeof value === 'object' && !Array.isArray(value)
+}
+
+/**
+ * @summary Creates the current client offer. Fresh arrays keep callers from mutating the frozen
+ * authority or sharing mutable offer state between concurrent requests.
+ * @returns {{capabilities: String[], versions: Number[]}}
+ */
+export function createFleetWireOffer() {
+    return {
+        capabilities: [...FLEET_WIRE_CAPABILITIES],
+        versions    : [...FLEET_WIRE_PROTOCOL_VERSIONS]
+    }
+}
+
+/**
+ * @summary Creates the server's selected-contract stamp.
+ * @param {Number} [version=FLEET_WIRE_PROTOCOL_VERSIONS[0]]
+ * @param {String[]} [capabilities=FLEET_WIRE_CAPABILITIES]
+ * @returns {{capabilities: String[], version: Number}}
+ */
+export function createFleetWireProtocolStamp(
+    version = FLEET_WIRE_PROTOCOL_VERSIONS[0],
+    capabilities = FLEET_WIRE_CAPABILITIES
+) {
+    return {
+        capabilities: [...capabilities],
+        version
+    }
+}
+
+/**
+ * @summary Selects one compatible Fleet wire contract from a client offer. Unknown additive
+ * capabilities are ignored; every required capability must be present. The result is bounded and
+ * carries no caller-authored values except a selected member of the server-owned catalogs.
+ * @param {Object} offer
+ * @returns {{ok: Boolean, protocol: Object, state: String, error: (String|undefined)}}
+ */
+export function selectFleetWireContract(offer) {
+    const
+        versionsValid = Array.isArray(offer?.versions) &&
+            offer.versions.length > 0 &&
+            offer.versions.length <= MAX_PROTOCOL_VERSIONS &&
+            offer.versions.every(version => Number.isInteger(version) && version > 0),
+        version = versionsValid
+            ? FLEET_WIRE_PROTOCOL_VERSIONS.find(candidate => offer.versions.includes(candidate))
+            : undefined;
+
+    if (version === undefined) {
+        return {
+            error   : 'fleet: unsupported wire protocol',
+            ok      : false,
+            protocol: createFleetWireProtocolStamp(),
+            state   : FLEET_WIRE_RESPONSE_STATES.unsupportedProtocol
+        }
+    }
+
+    const capabilitiesValid = Array.isArray(offer?.capabilities) &&
+        offer.capabilities.length <= MAX_PROTOCOL_CAPABILITIES &&
+        offer.capabilities.every(capability => typeof capability === 'string' &&
+            capability.length > 0 && capability.length <= MAX_PROTOCOL_TOKEN_LENGTH) &&
+        new Set(offer.capabilities).size === offer.capabilities.length;
+
+    if (!capabilitiesValid) {
+        return {
+            error   : 'fleet: unsupported wire capability offer',
+            ok      : false,
+            protocol: createFleetWireProtocolStamp(version),
+            state   : FLEET_WIRE_RESPONSE_STATES.unsupportedCapability
+        }
+    }
+
+    const
+        offered = new Set(offer.capabilities),
+        missing = FLEET_WIRE_REQUIRED_CAPABILITIES.filter(capability => !offered.has(capability));
+
+    if (missing.length > 0) {
+        return {
+            error   : 'fleet: missing required wire capabilities: ' + missing.join(', '),
+            ok      : false,
+            protocol: createFleetWireProtocolStamp(version),
+            state   : FLEET_WIRE_RESPONSE_STATES.unsupportedCapability
+        }
+    }
+
+    return {
+        ok      : true,
+        protocol: createFleetWireProtocolStamp(
+            version,
+            FLEET_WIRE_CAPABILITIES.filter(capability => offered.has(capability))
+        ),
+        state: FLEET_WIRE_RESPONSE_STATES.ok
+    }
+}
+
+/**
+ * @summary Creates a client request with a main/client-owned protocol offer. The method must come
+ * from the public operation vocabulary; callers cannot use this helper to mint a wider surface.
+ * @param {String} method
+ * @param {*} params
+ * @param {Object} [protocol=createFleetWireOffer()]
+ * @returns {{method: String, params: *, protocol: Object}}
+ */
+export function createFleetWireRequest(method, params, protocol = createFleetWireOffer()) {
+    if (!FLEET_WIRE_METHODS.includes(method)) {
+        throw new TypeError("fleet: method '" + method + "' is not on the client contract")
+    }
+
+    return {
+        method,
+        params,
+        protocol: {
+            capabilities: Array.isArray(protocol?.capabilities) ? [...protocol.capabilities] : protocol?.capabilities,
+            versions    : Array.isArray(protocol?.versions) ? [...protocol.versions] : protocol?.versions
+        }
+    }
+}
+
+/**
+ * @summary Creates one finite Fleet wire response. Success is derived from the state rather than
+ * accepted as a second caller-controlled truth.
+ * @param {String} state One of {@link FLEET_WIRE_RESPONSE_STATES}.
+ * @param {Object} [options]
+ * @param {String} [options.degraded]
+ * @param {String} [options.error]
+ * @param {Object} [options.protocol=createFleetWireProtocolStamp()]
+ * @param {*} [options.result]
+ * @returns {Object}
+ */
+export function createFleetWireResponse(state, {
+    degraded,
+    error,
+    protocol = createFleetWireProtocolStamp(),
+    result
+} = {}) {
+    if (!responseStates.has(state)) {
+        throw new TypeError("fleet: unknown wire response state '" + state + "'")
+    }
+
+    if (!isRecord(protocol) ||
+        !Number.isInteger(protocol.version) || protocol.version < 1 ||
+        !Array.isArray(protocol.capabilities) ||
+        protocol.capabilities.length > MAX_PROTOCOL_CAPABILITIES ||
+        !protocol.capabilities.every(capability => typeof capability === 'string' &&
+            capability.length > 0 && capability.length <= MAX_PROTOCOL_TOKEN_LENGTH) ||
+        new Set(protocol.capabilities).size !== protocol.capabilities.length) {
+        throw new TypeError('fleet: invalid selected wire protocol stamp')
+    }
+
+    const
+        ok       = state === FLEET_WIRE_RESPONSE_STATES.ok,
+        envelope = {
+            ok,
+            state,
+            protocol: createFleetWireProtocolStamp(protocol.version, protocol.capabilities)
+        };
+
+    if (ok) {
+        if (result === undefined) {
+            throw new TypeError('fleet: successful wire response requires a result')
+        }
+
+        envelope.result = result
+    } else {
+        envelope.error = typeof error === 'string' && error
+            ? error.slice(0, MAX_WIRE_ERROR_LENGTH)
+            : 'fleet: request failed';
+
+        if (typeof degraded === 'string' && degraded) {
+            envelope.degraded = degraded.slice(0, MAX_WIRE_DEGRADED_LENGTH)
+        }
+    }
+
+    return envelope
+}
+
+/**
+ * @summary Validates a server envelope against the offer this client sent. Unsupported
+ * version/capability states may advertise the server's current stamp; every other state must carry
+ * a contract the client actually offered.
+ * @param {Object} envelope
+ * @param {Object} [offer=createFleetWireOffer()]
+ * @returns {{error: (String|undefined), ok: Boolean}}
+ */
+export function inspectFleetWireResponse(envelope, offer = createFleetWireOffer()) {
+    const
+        responseKeys  = new Set(Object.values(FLEET_WIRE_ENVELOPE_SCHEMA.response).flat()),
+        selectionKeys = new Set(FLEET_WIRE_ENVELOPE_SCHEMA.selection.required),
+        state         = envelope?.state;
+
+    if (!isRecord(envelope) ||
+        Object.keys(envelope).some(key => !responseKeys.has(key)) ||
+        !responseStates.has(state) ||
+        envelope.ok !== (state === FLEET_WIRE_RESPONSE_STATES.ok) ||
+        (state === FLEET_WIRE_RESPONSE_STATES.ok &&
+            (!Object.hasOwn(envelope, 'result') || envelope.result === undefined ||
+                Object.hasOwn(envelope, 'error') || Object.hasOwn(envelope, 'degraded'))) ||
+        (state !== FLEET_WIRE_RESPONSE_STATES.ok &&
+            (typeof envelope.error !== 'string' || envelope.error.length === 0 ||
+                envelope.error.length > MAX_WIRE_ERROR_LENGTH || Object.hasOwn(envelope, 'result'))) ||
+        (state === FLEET_WIRE_RESPONSE_STATES.degraded &&
+            (typeof envelope.degraded !== 'string' || envelope.degraded.length === 0 ||
+                envelope.degraded.length > MAX_WIRE_DEGRADED_LENGTH)) ||
+        (state !== FLEET_WIRE_RESPONSE_STATES.degraded && Object.hasOwn(envelope, 'degraded')) ||
+        !isRecord(envelope.protocol) ||
+        Object.keys(envelope.protocol).some(key => !selectionKeys.has(key)) ||
+        !Number.isInteger(envelope.protocol.version) || envelope.protocol.version < 1 ||
+        !Array.isArray(envelope.protocol.capabilities) ||
+        envelope.protocol.capabilities.length > MAX_PROTOCOL_CAPABILITIES ||
+        !envelope.protocol.capabilities.every(capability => typeof capability === 'string' &&
+            capability.length > 0 && capability.length <= MAX_PROTOCOL_TOKEN_LENGTH) ||
+        new Set(envelope.protocol.capabilities).size !== envelope.protocol.capabilities.length) {
+        return {error: 'fleet: malformed wire response', ok: false}
+    }
+
+    const negotiationRefusal = [
+        FLEET_WIRE_RESPONSE_STATES.unsupportedCapability,
+        FLEET_WIRE_RESPONSE_STATES.unsupportedProtocol
+    ].includes(envelope.state);
+
+    if (!negotiationRefusal) {
+        if (!Array.isArray(offer?.versions) ||
+            !Array.isArray(offer?.capabilities) ||
+            !offer.versions.includes(envelope.protocol.version)) {
+            return {error: 'fleet: response selected an unoffered wire protocol', ok: false}
+        }
+
+        const
+            offeredCapabilities = new Set(offer?.capabilities),
+            selected            = new Set(envelope.protocol.capabilities);
+
+        if (FLEET_WIRE_REQUIRED_CAPABILITIES.some(capability => !selected.has(capability))) {
+            return {error: 'fleet: response omitted a required wire capability', ok: false}
+        }
+
+        if (envelope.protocol.capabilities.some(capability => !offeredCapabilities.has(capability))) {
+            return {error: 'fleet: response selected an unoffered wire capability', ok: false}
+        }
+    }
+
+    return {ok: true}
+}

--- a/apps/agentos/app.mjs
+++ b/apps/agentos/app.mjs
@@ -1,5 +1,5 @@
 import Viewport             from './view/Viewport.mjs';
-import {installFleetBridge} from './fleet/installFleetBridge.mjs';
+import {FLEET_LOCAL_TRANSPORT_ERRORS, installFleetBridge} from './fleet/installFleetBridge.mjs';
 import WindowManager        from '../../src/manager/Window.mjs';
 
 /**
@@ -60,7 +60,7 @@ export const onStart = () => {
 
                 return windowId
                     ? Neo.Main.fleetRequest({request, windowId})
-                    : Promise.resolve({ok: false, error: 'fleet: no live shell window'})
+                    : Promise.reject(new Error(FLEET_LOCAL_TRANSPORT_ERRORS.noLiveWindow))
             }
         })
     } else {

--- a/apps/agentos/config/fleetWireMethods.mjs
+++ b/apps/agentos/config/fleetWireMethods.mjs
@@ -1,13 +1,12 @@
 /**
- * The app↔fleet wire-method vocabulary — the Body-side TWIN of the Brain authority
- * (`ai/services/fleet/fleetWireMethods.mjs`). The browser-side `createFleetRegistryBridge`
- * generates EXACTLY these proxy methods; the Node-side `dispatchFleetRequest` validates against
- * the authority list — and `ai/scripts/lint/lint-fleet-vocabulary-parity.mjs` deep-equals the two,
- * so the ends of the wire cannot drift. A new verb is ONE registration in the authority,
- * mirrored here in the same commit; the semantic contract of every verb (read-observe vs write,
- * credential classification, the R3 seam) is documented ON the authority module, not duplicated
- * here.
- * @summary Operable-cold wire-method twin: the browser's proxy-generation list.
+ * The app↔fleet client-contract vocabulary — the operable-cold Body-side TWIN of the Brain authority
+ * (`ai/services/fleet/fleetWireMethods.mjs`). Browser-side `installFleetBridge` generates exactly
+ * these proxy methods; Node-side `dispatchFleetRequest` validates against the authority — and
+ * `ai/scripts/lint/lint-fleet-vocabulary-parity.mjs` compares every constant and pure helper
+ * outcome, so the ends of the wire cannot drift. A new client-safe contract element is registered
+ * in the authority and mirrored here in the same commit; trust semantics stay documented only on
+ * the authority rather than crossing into this no-checkout realm.
+ * @summary Operable-cold Fleet client-contract twin: methods, schema, negotiation, and responses.
  */
 
 /**
@@ -28,3 +27,311 @@ export const FLEET_WIRE_METHODS = Object.freeze([
 export const FLEET_CREDENTIAL_METHODS = Object.freeze(
     FLEET_WIRE_METHODS.filter(method => method === 'defineAgent' || method === 'connectTenant')
 );
+
+/**
+ * @summary Protocol versions the operable-cold client can offer, newest first.
+ * @type {Number[]}
+ */
+export const FLEET_WIRE_PROTOCOL_VERSIONS = Object.freeze([1]);
+
+/**
+ * @summary Client-safe wire mechanics — never trust or authorization policy.
+ * @type {String[]}
+ */
+export const FLEET_WIRE_CAPABILITIES = Object.freeze([
+    'method-schema-v1',
+    'closed-response-states-v1'
+]);
+
+/**
+ * @summary Capabilities required for a usable selected contract.
+ * @type {String[]}
+ */
+export const FLEET_WIRE_REQUIRED_CAPABILITIES = Object.freeze([
+    'method-schema-v1',
+    'closed-response-states-v1'
+]);
+
+/**
+ * @summary The finite top-level wire response states mirrored from the Brain authority.
+ * @type {Readonly<Record<String, String>>}
+ */
+export const FLEET_WIRE_RESPONSE_STATES = Object.freeze({
+    degraded             : 'degraded',
+    ok                   : 'ok',
+    operationFailed      : 'operation-failed',
+    refused              : 'refused',
+    unsupportedCapability: 'unsupported-capability',
+    unsupportedMethod    : 'unsupported-method',
+    unsupportedProtocol  : 'unsupported-protocol'
+});
+
+/**
+ * @summary Operable-cold request/offer/selection/response envelope schema.
+ * @type {Readonly<Object>}
+ */
+export const FLEET_WIRE_ENVELOPE_SCHEMA = Object.freeze({
+    offer: Object.freeze({
+        required: Object.freeze(['versions', 'capabilities'])
+    }),
+    request: Object.freeze({
+        required: Object.freeze(['method', 'protocol']),
+        optional: Object.freeze(['params'])
+    }),
+    response: Object.freeze({
+        required       : Object.freeze(['ok', 'state', 'protocol']),
+        successRequired: Object.freeze(['result']),
+        failureRequired: Object.freeze(['error']),
+        optional       : Object.freeze(['degraded'])
+    }),
+    selection: Object.freeze({
+        required: Object.freeze(['version', 'capabilities'])
+    })
+});
+
+const
+    MAX_PROTOCOL_CAPABILITIES = 64,
+    MAX_PROTOCOL_TOKEN_LENGTH = 100,
+    MAX_PROTOCOL_VERSIONS     = 16,
+    MAX_WIRE_DEGRADED_LENGTH  = 100,
+    MAX_WIRE_ERROR_LENGTH     = 300,
+    responseStates            = new Set(Object.values(FLEET_WIRE_RESPONSE_STATES));
+
+/**
+ * @summary Identifies a plain record-shaped wire value without accepting arrays or null.
+ * @param {*} value
+ * @returns {Boolean}
+ * @private
+ */
+function isRecord(value) {
+    return Boolean(value) && typeof value === 'object' && !Array.isArray(value)
+}
+
+/**
+ * @summary Creates a fresh current client offer.
+ * @returns {{capabilities: String[], versions: Number[]}}
+ */
+export function createFleetWireOffer() {
+    return {
+        capabilities: [...FLEET_WIRE_CAPABILITIES],
+        versions    : [...FLEET_WIRE_PROTOCOL_VERSIONS]
+    }
+}
+
+/**
+ * @summary Creates a selected-contract stamp.
+ * @param {Number} [version=FLEET_WIRE_PROTOCOL_VERSIONS[0]]
+ * @param {String[]} [capabilities=FLEET_WIRE_CAPABILITIES]
+ * @returns {{capabilities: String[], version: Number}}
+ */
+export function createFleetWireProtocolStamp(
+    version = FLEET_WIRE_PROTOCOL_VERSIONS[0],
+    capabilities = FLEET_WIRE_CAPABILITIES
+) {
+    return {
+        capabilities: [...capabilities],
+        version
+    }
+}
+
+/**
+ * @summary Selects one compatible contract from an offer; pure parity twin of the Brain helper.
+ * @param {Object} offer
+ * @returns {{ok: Boolean, protocol: Object, state: String, error: (String|undefined)}}
+ */
+export function selectFleetWireContract(offer) {
+    const
+        versionsValid = Array.isArray(offer?.versions) &&
+            offer.versions.length > 0 &&
+            offer.versions.length <= MAX_PROTOCOL_VERSIONS &&
+            offer.versions.every(version => Number.isInteger(version) && version > 0),
+        version = versionsValid
+            ? FLEET_WIRE_PROTOCOL_VERSIONS.find(candidate => offer.versions.includes(candidate))
+            : undefined;
+
+    if (version === undefined) {
+        return {
+            error   : 'fleet: unsupported wire protocol',
+            ok      : false,
+            protocol: createFleetWireProtocolStamp(),
+            state   : FLEET_WIRE_RESPONSE_STATES.unsupportedProtocol
+        }
+    }
+
+    const capabilitiesValid = Array.isArray(offer?.capabilities) &&
+        offer.capabilities.length <= MAX_PROTOCOL_CAPABILITIES &&
+        offer.capabilities.every(capability => typeof capability === 'string' &&
+            capability.length > 0 && capability.length <= MAX_PROTOCOL_TOKEN_LENGTH) &&
+        new Set(offer.capabilities).size === offer.capabilities.length;
+
+    if (!capabilitiesValid) {
+        return {
+            error   : 'fleet: unsupported wire capability offer',
+            ok      : false,
+            protocol: createFleetWireProtocolStamp(version),
+            state   : FLEET_WIRE_RESPONSE_STATES.unsupportedCapability
+        }
+    }
+
+    const
+        offered = new Set(offer.capabilities),
+        missing = FLEET_WIRE_REQUIRED_CAPABILITIES.filter(capability => !offered.has(capability));
+
+    if (missing.length > 0) {
+        return {
+            error   : 'fleet: missing required wire capabilities: ' + missing.join(', '),
+            ok      : false,
+            protocol: createFleetWireProtocolStamp(version),
+            state   : FLEET_WIRE_RESPONSE_STATES.unsupportedCapability
+        }
+    }
+
+    return {
+        ok      : true,
+        protocol: createFleetWireProtocolStamp(
+            version,
+            FLEET_WIRE_CAPABILITIES.filter(capability => offered.has(capability))
+        ),
+        state: FLEET_WIRE_RESPONSE_STATES.ok
+    }
+}
+
+/**
+ * @summary Creates a versioned request for one public Fleet operation.
+ * @param {String} method
+ * @param {*} params
+ * @param {Object} [protocol=createFleetWireOffer()]
+ * @returns {{method: String, params: *, protocol: Object}}
+ */
+export function createFleetWireRequest(method, params, protocol = createFleetWireOffer()) {
+    if (!FLEET_WIRE_METHODS.includes(method)) {
+        throw new TypeError("fleet: method '" + method + "' is not on the client contract")
+    }
+
+    return {
+        method,
+        params,
+        protocol: {
+            capabilities: Array.isArray(protocol?.capabilities) ? [...protocol.capabilities] : protocol?.capabilities,
+            versions    : Array.isArray(protocol?.versions) ? [...protocol.versions] : protocol?.versions
+        }
+    }
+}
+
+/**
+ * @summary Creates a finite Fleet wire response.
+ * @param {String} state
+ * @param {Object} [options]
+ * @returns {Object}
+ */
+export function createFleetWireResponse(state, {
+    degraded,
+    error,
+    protocol = createFleetWireProtocolStamp(),
+    result
+} = {}) {
+    if (!responseStates.has(state)) {
+        throw new TypeError("fleet: unknown wire response state '" + state + "'")
+    }
+
+    if (!isRecord(protocol) ||
+        !Number.isInteger(protocol.version) || protocol.version < 1 ||
+        !Array.isArray(protocol.capabilities) ||
+        protocol.capabilities.length > MAX_PROTOCOL_CAPABILITIES ||
+        !protocol.capabilities.every(capability => typeof capability === 'string' &&
+            capability.length > 0 && capability.length <= MAX_PROTOCOL_TOKEN_LENGTH) ||
+        new Set(protocol.capabilities).size !== protocol.capabilities.length) {
+        throw new TypeError('fleet: invalid selected wire protocol stamp')
+    }
+
+    const
+        ok       = state === FLEET_WIRE_RESPONSE_STATES.ok,
+        envelope = {
+            ok,
+            state,
+            protocol: createFleetWireProtocolStamp(protocol.version, protocol.capabilities)
+        };
+
+    if (ok) {
+        if (result === undefined) {
+            throw new TypeError('fleet: successful wire response requires a result')
+        }
+
+        envelope.result = result
+    } else {
+        envelope.error = typeof error === 'string' && error
+            ? error.slice(0, MAX_WIRE_ERROR_LENGTH)
+            : 'fleet: request failed';
+
+        if (typeof degraded === 'string' && degraded) {
+            envelope.degraded = degraded.slice(0, MAX_WIRE_DEGRADED_LENGTH)
+        }
+    }
+
+    return envelope
+}
+
+/**
+ * @summary Validates a server response against the client offer.
+ * @param {Object} envelope
+ * @param {Object} [offer=createFleetWireOffer()]
+ * @returns {{error: (String|undefined), ok: Boolean}}
+ */
+export function inspectFleetWireResponse(envelope, offer = createFleetWireOffer()) {
+    const
+        responseKeys  = new Set(Object.values(FLEET_WIRE_ENVELOPE_SCHEMA.response).flat()),
+        selectionKeys = new Set(FLEET_WIRE_ENVELOPE_SCHEMA.selection.required),
+        state         = envelope?.state;
+
+    if (!isRecord(envelope) ||
+        Object.keys(envelope).some(key => !responseKeys.has(key)) ||
+        !responseStates.has(state) ||
+        envelope.ok !== (state === FLEET_WIRE_RESPONSE_STATES.ok) ||
+        (state === FLEET_WIRE_RESPONSE_STATES.ok &&
+            (!Object.hasOwn(envelope, 'result') || envelope.result === undefined ||
+                Object.hasOwn(envelope, 'error') || Object.hasOwn(envelope, 'degraded'))) ||
+        (state !== FLEET_WIRE_RESPONSE_STATES.ok &&
+            (typeof envelope.error !== 'string' || envelope.error.length === 0 ||
+                envelope.error.length > MAX_WIRE_ERROR_LENGTH || Object.hasOwn(envelope, 'result'))) ||
+        (state === FLEET_WIRE_RESPONSE_STATES.degraded &&
+            (typeof envelope.degraded !== 'string' || envelope.degraded.length === 0 ||
+                envelope.degraded.length > MAX_WIRE_DEGRADED_LENGTH)) ||
+        (state !== FLEET_WIRE_RESPONSE_STATES.degraded && Object.hasOwn(envelope, 'degraded')) ||
+        !isRecord(envelope.protocol) ||
+        Object.keys(envelope.protocol).some(key => !selectionKeys.has(key)) ||
+        !Number.isInteger(envelope.protocol.version) || envelope.protocol.version < 1 ||
+        !Array.isArray(envelope.protocol.capabilities) ||
+        envelope.protocol.capabilities.length > MAX_PROTOCOL_CAPABILITIES ||
+        !envelope.protocol.capabilities.every(capability => typeof capability === 'string' &&
+            capability.length > 0 && capability.length <= MAX_PROTOCOL_TOKEN_LENGTH) ||
+        new Set(envelope.protocol.capabilities).size !== envelope.protocol.capabilities.length) {
+        return {error: 'fleet: malformed wire response', ok: false}
+    }
+
+    const negotiationRefusal = [
+        FLEET_WIRE_RESPONSE_STATES.unsupportedCapability,
+        FLEET_WIRE_RESPONSE_STATES.unsupportedProtocol
+    ].includes(envelope.state);
+
+    if (!negotiationRefusal) {
+        if (!Array.isArray(offer?.versions) ||
+            !Array.isArray(offer?.capabilities) ||
+            !offer.versions.includes(envelope.protocol.version)) {
+            return {error: 'fleet: response selected an unoffered wire protocol', ok: false}
+        }
+
+        const
+            offeredCapabilities = new Set(offer?.capabilities),
+            selected            = new Set(envelope.protocol.capabilities);
+
+        if (FLEET_WIRE_REQUIRED_CAPABILITIES.some(capability => !selected.has(capability))) {
+            return {error: 'fleet: response omitted a required wire capability', ok: false}
+        }
+
+        if (envelope.protocol.capabilities.some(capability => !offeredCapabilities.has(capability))) {
+            return {error: 'fleet: response selected an unoffered wire capability', ok: false}
+        }
+    }
+
+    return {ok: true}
+}

--- a/apps/agentos/fleet/installFleetBridge.mjs
+++ b/apps/agentos/fleet/installFleetBridge.mjs
@@ -1,4 +1,10 @@
-import {FLEET_WIRE_METHODS} from '../config/fleetWireMethods.mjs';
+import {
+    createFleetWireOffer,
+    createFleetWireRequest,
+    FLEET_WIRE_METHODS,
+    FLEET_WIRE_RESPONSE_STATES,
+    inspectFleetWireResponse
+} from '../config/fleetWireMethods.mjs';
 
 /**
  * Canonical shape of the Fleet process bearer: 32 random bytes as unpadded base64url (43 chars).
@@ -18,6 +24,17 @@ const FLEET_BEARER_PATTERN = /^[A-Za-z0-9_-]{43}$/;
 const FORBIDDEN_URL_CREDENTIAL_PARAMS = ['bearer', 'bearerToken', 'fleetBearer', 'token', 'authorization'];
 
 /**
+ * Bounded local launch-state errors that may cross the injected shell transport verbatim. Every
+ * other rejection collapses to the generic transport failure before reaching the pane.
+ * @type {Readonly<Object>}
+ */
+export const FLEET_LOCAL_TRANSPORT_ERRORS = Object.freeze({
+    noBearer       : 'fleet bearer not injected — launch the cockpit through the authenticated Fleet boot path; the pane stays fail-closed until the launch contract supplies the process bearer in memory',
+    noLiveWindow   : 'fleet: no live shell window',
+    shellCapability: 'fleet: shell request capability unavailable'
+});
+
+/**
  * @summary Wire one topology-owned app↔fleet transport into the App Worker. Direct-browser mode
  * builds a `fetch`-backed `send` against the Fleet URL; the packaged Electron shell injects a named
  * preload/main `send` whose bearer never enters this realm. Both feed the proxy map generated here
@@ -28,6 +45,10 @@ const FORBIDDEN_URL_CREDENTIAL_PARAMS = ['bearer', 'bearerToken', 'fleetBearer',
  * The Node-side dual (`ai/services/fleet/createFleetRegistryBridge.mjs`, consumed by CLI tools)
  * binds the AUTHORITY list; the vocabulary-parity lint keeps the two lists identical, so the ends
  * of the wire cannot drift while neither realm imports across the boundary.
+ * Every call creates a fresh version/capability offer and validates the server-selected contract
+ * before returning operation data. Direct-browser mode emits that offer itself; shell mode keeps
+ * the IPC message at `{method, params}` so Electron main can attach its independently loaded,
+ * main-owned offer — the operable-cold contract's browser-client half.
  *
  * **The Fleet ingress trust boundary, client half.** Direct-browser requests carry
  * `Authorization: Bearer <token>` — the process-lifetime secret its launch path injects as an
@@ -48,8 +69,8 @@ const FORBIDDEN_URL_CREDENTIAL_PARAMS = ['bearer', 'bearerToken', 'fleetBearer',
  *     base64url). `null` installs a fail-closed bridge that rejects every call locally with the
  *     launch-contract remediation — never a network call without credentials.
  * @param {Function} [opts.fetchImpl=globalThis.fetch]     Injectable fetch for tests.
- * @param {Function} [opts.send=null]                      Packaged-shell transport; mutually exclusive
- *     with `url` / `bearerToken`.
+ * @param {Function} [opts.send=null]                      Packaged-shell intent transport; receives
+ *     only `{method, params}` and is mutually exclusive with `url` / `bearerToken`.
  * @param {'worker'|'shell'} [opts.credentialIngress='worker'] Public credential-custody fact.
  * @param {Boolean}  [opts.selected=false]                 Whether this install is an explicit source
  *     selection (the injector path) versus the boot default. Selected bridges render an empty
@@ -67,7 +88,7 @@ export function installFleetBridge({
     target = globalThis
 } = {}) {
     const endpointError = 'installFleetBridge requires an absolute loopback HTTP(S) fleet URL';
-    let fleetUrl, transportSend;
+    let fleetUrl, shellTransport, transportSend;
 
     if (!['shell', 'worker'].includes(credentialIngress)) {
         throw new TypeError("installFleetBridge: credentialIngress must be 'shell' or 'worker'")
@@ -82,8 +103,11 @@ export function installFleetBridge({
             throw new TypeError('installFleetBridge: injected send is mutually exclusive with url and bearerToken')
         }
 
-        transportSend = send
+        shellTransport = true;
+        transportSend  = send
     } else {
+        shellTransport = false;
+
         if (credentialIngress === 'shell') {
             throw new TypeError('installFleetBridge: shell credential ingress requires an injected send')
         }
@@ -112,7 +136,7 @@ export function installFleetBridge({
 
         transportSend = bearerToken === null
             ? async () => {
-                throw new Error('fleet bearer not injected — launch the cockpit through the authenticated Fleet boot path; the pane stays fail-closed until the launch contract supplies the process bearer in memory')
+                throw new Error(FLEET_LOCAL_TRANSPORT_ERRORS.noBearer)
             }
             : async request => {
                 const response = await fetchImpl(fleetUrl.href, {
@@ -129,11 +153,38 @@ export function installFleetBridge({
     }
 
     // The browser's half of the wire contract: one async proxy per twin-listed verb, unwrapping the
-    // `{ok, result|error}` envelope — resolve `result`, throw on `error`.
+    // finite response envelope only after its selection matches this realm's offer. Browser mode
+    // sends that offer directly; shell mode relies on parity with main's independently owned offer.
     const request = async (method, params) => {
-        const envelope = await transportSend({method, params});
+        const
+            offer       = createFleetWireOffer(),
+            wireRequest = createFleetWireRequest(method, params, offer);
 
-        if (!envelope?.ok) {
+        let envelope, inspection;
+
+        try {
+            envelope = await transportSend(shellTransport
+                ? {method: wireRequest.method, params: wireRequest.params}
+                : wireRequest)
+        } catch (error) {
+            const safeError = Object.values(FLEET_LOCAL_TRANSPORT_ERRORS).includes(error?.message)
+                ? error.message
+                : 'fleet: request transport failed';
+
+            throw new Error(safeError)
+        }
+
+        try {
+            inspection = inspectFleetWireResponse(envelope, offer)
+        } catch {
+            throw new Error('fleet: malformed wire response')
+        }
+
+        if (!inspection.ok) {
+            throw new Error(inspection.error)
+        }
+
+        if (envelope.state !== FLEET_WIRE_RESPONSE_STATES.ok) {
             throw new Error(envelope?.error || `fleet: '${method}' failed`);
         }
 

--- a/harness/brain.mjs
+++ b/harness/brain.mjs
@@ -64,6 +64,11 @@ export function loadFleetRuntimeContracts(repoRoot = DEFAULT_REPO_ROOT) {
         ]).then(([identityContract, fleetContract, wireContract]) => ({
             FLEET_CREDENTIAL_METHODS    : wireContract.FLEET_CREDENTIAL_METHODS,
             FLEET_WIRE_METHODS          : wireContract.FLEET_WIRE_METHODS,
+            FLEET_WIRE_RESPONSE_STATES  : wireContract.FLEET_WIRE_RESPONSE_STATES,
+            createFleetWireOffer        : wireContract.createFleetWireOffer,
+            createFleetWireRequest      : wireContract.createFleetWireRequest,
+            createFleetWireResponse     : wireContract.createFleetWireResponse,
+            inspectFleetWireResponse    : wireContract.inspectFleetWireResponse,
             normalizeAgentIdentityNodeId: identityContract.normalizeAgentIdentityNodeId,
             probeExistingFleetServer    : fleetContract.probeExistingFleetServer,
             resolveFleetBearer          : fleetContract.resolveFleetBearer
@@ -632,18 +637,28 @@ export function awaitOrchestratorReady({child, timeoutMs = 30000}) {
 }
 
 /**
- * @summary Awaits the fleet transport's genuine readiness: a REAL wire verb round-trip
- * (`POST /fleet {method:'listAgents'}`) answering `{ok:true}` — the same surface the Fleet
- * Manager window consumes. Rejects on child exit/spawn error or timeout.
+ * @summary Awaits the Fleet transport's genuine readiness through a versioned `listAgents`
+ * round-trip — the same negotiated surface the Fleet Manager consumes. An unversioned, malformed,
+ * or skewed response never counts as ready.
  * @param {Object} options
  * @param {import('node:child_process').ChildProcess} options.child
  * @param {Number|String} options.port
  * @param {String} options.bearerToken Main-owned process bearer.
+ * @param {String} [options.repoRoot=DEFAULT_REPO_ROOT] Authoritative organism carrying the wire contract.
  * @param {Number} [options.timeoutMs=15000]
  * @param {Function} [options.fetchFn=fetch] Injection seam for tests.
  * @returns {Promise<void>}
  */
-export function awaitFleetReady({child, port, bearerToken, timeoutMs = 15000, fetchFn = fetch}) {
+export function awaitFleetReady({
+    child,
+    port,
+    bearerToken,
+    repoRoot = DEFAULT_REPO_ROOT,
+    timeoutMs = 15000,
+    fetchFn = fetch
+}) {
+    const wireContract = loadFleetRuntimeContracts(repoRoot);
+
     return new Promise((resolve, reject) => {
         let settled = false;
 
@@ -666,8 +681,14 @@ export function awaitFleetReady({child, port, bearerToken, timeoutMs = 15000, fe
 
         const probe = async () => {
             try {
+                const {
+                    createFleetWireRequest,
+                    FLEET_WIRE_RESPONSE_STATES,
+                    inspectFleetWireResponse
+                } = await wireContract;
+                const request  = createFleetWireRequest('listAgents', {});
                 const response = await fetchFn(`http://127.0.0.1:${port}/fleet`, {
-                    body   : JSON.stringify({method: 'listAgents', params: {}}),
+                    body   : JSON.stringify(request),
                     headers: {
                         Authorization : `Bearer ${bearerToken}`,
                         'content-type': 'application/json'
@@ -677,7 +698,8 @@ export function awaitFleetReady({child, port, bearerToken, timeoutMs = 15000, fe
 
                 const body = await response.json();
 
-                if (body?.ok === true) {
+                if (inspectFleetWireResponse(body, request.protocol).ok &&
+                    body.state === FLEET_WIRE_RESPONSE_STATES.ok) {
                     finish()
                 }
             } catch (error) {
@@ -690,6 +712,7 @@ export function awaitFleetReady({child, port, bearerToken, timeoutMs = 15000, fe
 
         child.once('exit', onExit);
         child.once('error', onExit);
+        wireContract.catch(() => finish(new Error('fleet wire contract unavailable')));
         probe()
     })
 }

--- a/harness/fleetCapability.mjs
+++ b/harness/fleetCapability.mjs
@@ -5,6 +5,31 @@ function isRecord(value) {
 }
 
 /**
+ * @summary Finds a sensitive string in any JSON-shaped key or value without relying on serialized
+ * spelling. Direct value comparison remains correct when quotes, slashes, or control characters are
+ * escaped by JSON serialization.
+ * @param {*} value Candidate response subtree.
+ * @param {String[]} sensitiveValues Non-empty secrets that must not cross into the renderer.
+ * @param {WeakSet<Object>} [visited=new WeakSet()] Cycle guard for injected/custom transports.
+ * @returns {Boolean}
+ */
+function containsSensitiveValue(value, sensitiveValues, visited=new WeakSet()) {
+    if (typeof value === 'string') {
+        return sensitiveValues.some(sensitive => value.includes(sensitive))
+    }
+
+    if (!value || typeof value !== 'object') return false;
+    if (visited.has(value)) return false;
+
+    visited.add(value);
+
+    return Object.entries(value).some(([key, child]) =>
+        sensitiveValues.some(sensitive => key.includes(sensitive)) ||
+        containsSensitiveValue(child, sensitiveValues, visited)
+    )
+}
+
+/**
  * @summary Projects the Body-authored Add-Peer intent onto the shell's explicit public field set.
  * Unknown fields are dropped by construction: command, args, env, executable paths, viewer claims,
  * and credential-shaped extras therefore have no route into the Brain request.
@@ -56,9 +81,14 @@ export function projectPublicCredentialIntent(method, params) {
  * positively censused against both the bearer and (for Add-Peer) the submitted credential.
  * @param {Object} options
  * @param {String} options.bearerToken Main-owned per-boot Fleet bearer.
+ * @param {Function} options.createWireOffer Creates the main-owned version/capability offer.
+ * @param {Function} options.createWireRequest Creates the outbound versioned request.
+ * @param {Function} options.createWireResponse Creates closed local refusal envelopes.
  * @param {String[]} options.credentialMethods Canonical credential-bearing Fleet methods.
  * @param {Function} options.getBrain Resolves the main-owned Brain boot receipt.
+ * @param {Function} options.inspectWireResponse Validates the selected server contract.
  * @param {Function} options.isTrustedSender Validates a real Electron IPC event.
+ * @param {Object} options.responseStates Canonical finite response-state vocabulary.
  * @param {String[]} options.wireMethods Canonical app↔Fleet method allowlist.
  * @param {Function|null} [options.credentialProvider=null] Main-owned async credential ingress. It
  * receives only `{event, intent, method}` after all public validation; Body-supplied secret fields
@@ -70,34 +100,54 @@ export function projectPublicCredentialIntent(method, params) {
  */
 export function createFleetCapability({
     bearerToken,
+    createWireOffer,
+    createWireRequest,
+    createWireResponse,
     credentialMethods,
     credentialProvider = null,
     fetchImpl = globalThis.fetch,
     getBrain,
+    inspectWireResponse,
     isTrustedSender,
     onAdmitted = null,
+    responseStates,
     wireMethods
 } = {}) {
     const
         validCredentialMethods = Array.isArray(credentialMethods) && credentialMethods.every(method => typeof method === 'string'),
         validWireMethods       = Array.isArray(wireMethods) && wireMethods.every(method => typeof method === 'string');
 
-    if (typeof bearerToken !== 'string' || typeof getBrain !== 'function' ||
+    if (typeof bearerToken !== 'string' ||
+        typeof createWireOffer !== 'function' ||
+        typeof createWireRequest !== 'function' ||
+        typeof createWireResponse !== 'function' ||
+        typeof getBrain !== 'function' ||
+        typeof inspectWireResponse !== 'function' ||
         typeof isTrustedSender !== 'function' || typeof fetchImpl !== 'function' ||
         !validCredentialMethods || !validWireMethods ||
         credentialMethods.some(method => !wireMethods.includes(method)) ||
+        !isRecord(responseStates) ||
+        typeof responseStates.ok !== 'string' ||
+        typeof responseStates.refused !== 'string' ||
         !(credentialProvider === null || typeof credentialProvider === 'function') ||
         !(onAdmitted === null || typeof onAdmitted === 'function')) {
-        throw new TypeError('createFleetCapability requires bearerToken, canonical method allowlists, getBrain, isTrustedSender, fetchImpl, and optional credentialProvider/onAdmitted hooks')
+        throw new TypeError('createFleetCapability requires the canonical wire contract, bearerToken, method allowlists, getBrain, isTrustedSender, fetchImpl, and optional credentialProvider/onAdmitted hooks')
     }
 
     const
         credentialMethodSet = new Set(credentialMethods),
         wireMethodSet       = new Set(wireMethods),
-        reject              = error => ({ok: false, error});
+        reject              = error => createWireResponse(responseStates.refused, {error});
 
-    const send = async (request, sensitiveValues = []) => {
-        let boot, envelope;
+    const send = async (method, params, sensitiveValues = []) => {
+        let boot, envelope, offer, request;
+
+        try {
+            offer   = createWireOffer();
+            request = createWireRequest(method, params, offer)
+        } catch {
+            return reject('fleet: client wire contract failed')
+        }
 
         try {
             boot = await getBrain()
@@ -124,27 +174,38 @@ export function createFleetCapability({
             return reject('fleet: request transport failed')
         }
 
-        let serialized;
+        const protectedValues = [...new Set([bearerToken, ...sensitiveValues]
+            .flatMap(value => typeof value === 'string' ? [value, value.trim()] : [])
+            .filter(Boolean))];
+
+        let containsSecret;
 
         try {
-            serialized = JSON.stringify(envelope)
+            JSON.stringify(envelope);
+            containsSecret = containsSensitiveValue(envelope, protectedValues)
         } catch {
             return reject('fleet: invalid response')
         }
 
-        if ([bearerToken, ...sensitiveValues].some(value => value && serialized.includes(value))) {
+        if (containsSecret) {
             return reject('fleet: secret-bearing response rejected')
         }
 
-        if (envelope?.ok !== true) {
-            return reject(typeof envelope?.error === 'string' ? envelope.error.slice(0, 300) : 'fleet: request failed')
+        const inspection = inspectWireResponse(envelope, offer);
+
+        if (!inspection?.ok) {
+            return reject(inspection?.error || 'fleet: malformed wire response')
+        }
+
+        if (envelope.state !== responseStates.ok) {
+            return envelope
         }
 
         try {
             onAdmitted?.({method: request.method})
         } catch {/* receipt instrumentation never owns the product response */}
 
-        return {ok: true, result: envelope.result}
+        return envelope
     };
 
     return {
@@ -181,13 +242,10 @@ export function createFleetCapability({
                     return reject(`fleet: shell credential ingress canceled for '${request.method}'`)
                 }
 
-                return send({
-                    method: request.method,
-                    params: {...intent, credential}
-                }, [credential])
+                return send(request.method, {...intent, credential}, [credential])
             }
 
-            return send({method: request.method, params: request.params})
+            return send(request.method, request.params)
         }
     }
 }

--- a/harness/main.mjs
+++ b/harness/main.mjs
@@ -439,13 +439,18 @@ h1{font-size:20px;margin:0 0 16px}p{color:#b9c4d8;margin:8px 0}.hint{color:#8ea4
 // promise is read at call time so an early-rendering UI receives a named not-ready envelope while a
 // later call joins the exact boot the lifecycle owner retained.
 const fleetCapability = createFleetCapability({
-    bearerToken       : fleetBearerToken,
-    credentialMethods : fleetRuntimeContracts.FLEET_CREDENTIAL_METHODS,
-    credentialProvider: promptFleetCredential,
-    getBrain          : () => brainBootPromise,
-    isTrustedSender   : isTrustedIpcSender,
-    onAdmitted        : ({method}) => diagnosticMode && smokeState.fleetMethods.push(method),
-    wireMethods       : fleetRuntimeContracts.FLEET_WIRE_METHODS
+    bearerToken        : fleetBearerToken,
+    createWireOffer    : fleetRuntimeContracts.createFleetWireOffer,
+    createWireRequest  : fleetRuntimeContracts.createFleetWireRequest,
+    createWireResponse : fleetRuntimeContracts.createFleetWireResponse,
+    credentialMethods  : fleetRuntimeContracts.FLEET_CREDENTIAL_METHODS,
+    credentialProvider : promptFleetCredential,
+    getBrain           : () => brainBootPromise,
+    inspectWireResponse: fleetRuntimeContracts.inspectFleetWireResponse,
+    isTrustedSender    : isTrustedIpcSender,
+    onAdmitted         : ({method}) => diagnosticMode && smokeState.fleetMethods.push(method),
+    responseStates     : fleetRuntimeContracts.FLEET_WIRE_RESPONSE_STATES,
+    wireMethods        : fleetRuntimeContracts.FLEET_WIRE_METHODS
 });
 
 /**
@@ -1001,7 +1006,7 @@ async function bootProductBrain() {
         });
 
         registerBrainChild({child: fleet, label: 'fleet'});
-        await awaitFleetReady({bearerToken: fleetBearerToken, child: fleet, port: fleetPort})
+        await awaitFleetReady({bearerToken: fleetBearerToken, child: fleet, port: fleetPort, repoRoot: organismRoot})
     }
 
     console.log(`HARNESS_BRAIN_MODE ${mode}${plan.planeBase ? ` planeBase=${plan.planeBase}` : ''} fleetPort=${fleetPort} started=[${brainState.children.map(entry => entry.label).join(',') || 'none'}]`);
@@ -1108,7 +1113,7 @@ async function bootSmokeBrain() {
 
     await Promise.all([
         awaitOrchestratorReady({child: orchestrator}),
-        awaitFleetReady({bearerToken: fleetBearerToken, child: fleet, port: fleetPort})
+        awaitFleetReady({bearerToken: fleetBearerToken, child: fleet, port: fleetPort, repoRoot: organismRoot})
     ]);
 
     return {

--- a/src/Main.mjs
+++ b/src/Main.mjs
@@ -285,7 +285,7 @@ class Main extends core.Base {
     fleetRequest({request} = {}) {
         return globalThis.neoShell?.fleetRequest
             ? globalThis.neoShell.fleetRequest(request)
-            : {ok: false, error: 'fleet: shell request capability unavailable'}
+            : Promise.reject(new Error('fleet: shell request capability unavailable'))
     }
 
     /**

--- a/test/playwright/e2e/agentos/AddAgentJourneyNL.spec.mjs
+++ b/test/playwright/e2e/agentos/AddAgentJourneyNL.spec.mjs
@@ -1,6 +1,12 @@
-import {test, expect}                                                          from '../../fixtures.mjs';
-import {NeuralLink_DataService}                                                from '../../../../ai/services.mjs';
-import {authenticatedFleetOptions, reloadRoster, wireAuthenticatedFleetBridge} from './authenticatedFleetHarness.mjs';
+import {test, expect}           from '../../fixtures.mjs';
+import {NeuralLink_DataService} from '../../../../ai/services.mjs';
+import {
+    authenticatedFleetOptions,
+    fleetE2EFailure,
+    fleetE2ESuccess,
+    reloadRoster,
+    wireAuthenticatedFleetBridge
+} from './authenticatedFleetHarness.mjs';
 
 const
     TEST_AGENT_ID   = 'nl-journey-agent',
@@ -48,27 +54,27 @@ async function startJourneyFleetBridge() {
 
                 defined.push(agent);
 
-                return {ok: true, result: agent}
+                return fleetE2ESuccess(agent)
             }
 
             if (request.method === 'startAgent') {
                 running.add(request.params);
-                return {ok: true, result: {id: request.params, state: 'running'}}
+                return fleetE2ESuccess({id: request.params, state: 'running'})
             }
 
             if (request.method === 'fleetRoster') {
-                return {ok: true, result: {rows: defined.map(rosterRow)}}
+                return fleetE2ESuccess({rows: defined.map(rosterRow)})
             }
 
             if (request.method === 'fleetActivity') {
-                return {ok: true, result: {capability: {source: 'fleet:test', state: 'wired', confidence: 'observed'}, events: []}}
+                return fleetE2ESuccess({capability: {source: 'fleet:test', state: 'wired', confidence: 'observed'}, events: []})
             }
 
             if (['listAgents', 'fleetStatus', 'fleetRuntimeStatus'].includes(request.method)) {
-                return {ok: true, result: []}
+                return fleetE2ESuccess([])
             }
 
-            return {ok: false, error: `fleet: unexpected test method '${request.method}'`}
+            return fleetE2EFailure(`fleet: unexpected test method '${request.method}'`)
         }
     });
 

--- a/test/playwright/e2e/agentos/FleetCardLifecycleNL.spec.mjs
+++ b/test/playwright/e2e/agentos/FleetCardLifecycleNL.spec.mjs
@@ -1,7 +1,13 @@
-import {test, expect}                                                          from '../../fixtures.mjs';
-import {NeuralLink_DataService}                                                from '../../../../ai/services.mjs';
-import {FLEET_WIRE_METHODS}                                                    from '../../../../apps/agentos/config/fleetWireMethods.mjs';
-import {authenticatedFleetOptions, reloadRoster, wireAuthenticatedFleetBridge} from './authenticatedFleetHarness.mjs';
+import {test, expect}           from '../../fixtures.mjs';
+import {NeuralLink_DataService} from '../../../../ai/services.mjs';
+import {FLEET_WIRE_METHODS}     from '../../../../apps/agentos/config/fleetWireMethods.mjs';
+import {
+    authenticatedFleetOptions,
+    fleetE2EFailure,
+    fleetE2ESuccess,
+    reloadRoster,
+    wireAuthenticatedFleetBridge
+} from './authenticatedFleetHarness.mjs';
 
 const TEST_AGENT_ID = 'nl-lifecycle-agent';
 
@@ -52,31 +58,31 @@ async function startLifecycleFleetBridge({rejectStart = false} = {}) {
 
             if (request.method === 'startAgent') {
                 if (rejectStart) {
-                    return {ok: false, error: 'fleet: start rejected by lifecycle witness'}
+                    return fleetE2EFailure('fleet: start rejected by lifecycle witness')
                 }
 
                 running.add(request.params);
-                return {ok: true, result: {id: request.params, state: 'running'}}
+                return fleetE2ESuccess({id: request.params, state: 'running'})
             }
 
             if (request.method === 'stopAgent') {
                 running.delete(request.params);
-                return {ok: true, result: {id: request.params, state: 'stopped'}}
+                return fleetE2ESuccess({id: request.params, state: 'stopped'})
             }
 
             if (request.method === 'fleetRoster') {
-                return {ok: true, result: {rows: [rosterRow(running.has(TEST_AGENT_ID) ? 'running' : 'stopped')]}}
+                return fleetE2ESuccess({rows: [rosterRow(running.has(TEST_AGENT_ID) ? 'running' : 'stopped')]})
             }
 
             if (request.method === 'fleetActivity') {
-                return {ok: true, result: {capability: {source: 'fleet:test', state: 'wired', confidence: 'observed'}, events: []}}
+                return fleetE2ESuccess({capability: {source: 'fleet:test', state: 'wired', confidence: 'observed'}, events: []})
             }
 
             if (['listAgents', 'fleetStatus', 'fleetRuntimeStatus'].includes(request.method)) {
-                return {ok: true, result: []}
+                return fleetE2ESuccess([])
             }
 
-            return {ok: false, error: `fleet: unexpected test method '${request.method}'`}
+            return fleetE2EFailure(`fleet: unexpected test method '${request.method}'`)
         }
     });
 

--- a/test/playwright/e2e/agentos/FleetCatchUpNL.spec.mjs
+++ b/test/playwright/e2e/agentos/FleetCatchUpNL.spec.mjs
@@ -1,5 +1,10 @@
 import {expect, test}                                            from '../../fixtures.mjs';
-import {authenticatedFleetOptions, wireAuthenticatedFleetBridge} from './authenticatedFleetHarness.mjs';
+import {
+    authenticatedFleetOptions,
+    fleetE2EFailure,
+    fleetE2ESuccess,
+    wireAuthenticatedFleetBridge
+} from './authenticatedFleetHarness.mjs';
 
 const WINDOW = {
     semantics  : 'half-open',
@@ -84,19 +89,19 @@ async function startCatchUpFleet() {
 
                   switch (request.method) {
                       case 'resolveViewerIdentity':
-                          return {ok: true, result: {ok: true, agentIdentityNodeId: '@e2e-operator'}};
+                          return fleetE2ESuccess({ok: true, agentIdentityNodeId: '@e2e-operator'});
                       case 'fleetRoster':
-                          return {ok: true, result: {rows: rosterRows}};
+                          return fleetE2ESuccess({rows: rosterRows});
                       case 'fleetActivity':
-                          return {ok: true, result: {capability: {state: 'wired'}, events: []}};
+                          return fleetE2ESuccess({capability: {state: 'wired'}, events: []});
                       case 'fleetHistory':
-                          return {ok: true, result: historyResult(request.params)};
+                          return fleetE2ESuccess(historyResult(request.params));
                       case 'markFleetCaughtUp':
-                          return {ok: true, result: {status: 'advanced', lastSeen: request.params.windowEnd}};
+                          return fleetE2ESuccess({status: 'advanced', lastSeen: request.params.windowEnd});
                       case 'getBootIdentity':
-                          return {ok: true, result: {fact: null, classification: 'unknown', advisory: true}};
+                          return fleetE2ESuccess({fact: null, classification: 'unknown', advisory: true});
                       default:
-                          return {ok: false, error: `unexpected catch-up method: ${request.method}`}
+                          return fleetE2EFailure(`unexpected catch-up method: ${request.method}`)
                   }
               }
           }),

--- a/test/playwright/e2e/agentos/FleetCockpitNWindowNL.spec.mjs
+++ b/test/playwright/e2e/agentos/FleetCockpitNWindowNL.spec.mjs
@@ -1,6 +1,11 @@
-import {test, expect}                                            from '../../fixtures.mjs';
-import {createFleetMailboxMirrorSnapshot}                        from '../../../../ai/services/fleet/fleetMailboxMirrorAdapter.mjs';
-import {authenticatedFleetOptions, wireAuthenticatedFleetBridge} from './authenticatedFleetHarness.mjs';
+import {test, expect}                     from '../../fixtures.mjs';
+import {createFleetMailboxMirrorSnapshot} from '../../../../ai/services/fleet/fleetMailboxMirrorAdapter.mjs';
+import {
+    authenticatedFleetOptions,
+    fleetE2EFailure,
+    fleetE2ESuccess,
+    wireAuthenticatedFleetBridge
+} from './authenticatedFleetHarness.mjs';
 
 const FILM_HOLD_MS = Math.max(0, Number(process.env.NEO_FILM_HOLD_MS) || 0);
 
@@ -21,11 +26,9 @@ async function startNWindowFleet() {
 
                   switch (request.method) {
                       case 'resolveViewerIdentity':
-                          return {ok: true, result: {ok: true, agentIdentityNodeId: '@e2e-operator'}};
+                          return fleetE2ESuccess({ok: true, agentIdentityNodeId: '@e2e-operator'});
                       case 'fleetRoster':
-                          return {
-                              ok    : true,
-                              result: {
+                          return fleetE2ESuccess({
                                   rows: [{
                                       id                 : 'neo-fable',
                                       githubUsername     : 'neo-fable',
@@ -67,12 +70,9 @@ async function startNWindowFleet() {
                                           }
                                       }
                                   }]
-                              }
-                          };
+                              });
                       case 'fleetActivity':
-                          return {
-                              ok    : true,
-                              result: {
+                          return fleetE2ESuccess({
                                   capability: {state: 'wired'},
                                   events    : [{
                                       type      : 'a2a-activity',
@@ -80,12 +80,9 @@ async function startNWindowFleet() {
                                       occurredAt: refreshed ? '2026-08-02T00:00:02.000Z' : '2026-08-02T00:00:01.000Z',
                                       payload   : {text: refreshed ? 'Three-window hold live' : 'Film stage ready'}
                                   }]
-                              }
-                          };
+                              });
                       case 'fleetMailboxMirror':
-                          return {
-                              ok    : true,
-                              result: createFleetMailboxMirrorSnapshot({
+                          return fleetE2ESuccess(createFleetMailboxMirrorSnapshot({
                                   messages: [{
                                       messageId: `film-message-${generation}`,
                                       subject  : refreshed ? 'Mailbox vessel live' : 'Mailbox stage ready',
@@ -97,10 +94,9 @@ async function startNWindowFleet() {
                                   page   : {limit: 50, offset: request.params?.offset ?? 0},
                                   subject: '@e2e-operator',
                                   viewer : '@e2e-operator'
-                              })
-                          };
+                              }));
                       default:
-                          return {ok: false, error: `unexpected N-window fixture method: ${request.method}`}
+                          return fleetE2EFailure(`unexpected N-window fixture method: ${request.method}`)
                   }
               }
           }),

--- a/test/playwright/e2e/agentos/FleetGridKeyboardA11y.spec.mjs
+++ b/test/playwright/e2e/agentos/FleetGridKeyboardA11y.spec.mjs
@@ -1,6 +1,12 @@
 import {test, expect}           from '../../fixtures.mjs';
 import {NeuralLink_DataService} from '../../../../ai/services.mjs';
-import {authenticatedFleetOptions, reloadRoster, wireAuthenticatedFleetBridge} from './authenticatedFleetHarness.mjs';
+import {
+    authenticatedFleetOptions,
+    fleetE2EFailure,
+    fleetE2ESuccess,
+    reloadRoster,
+    wireAuthenticatedFleetBridge
+} from './authenticatedFleetHarness.mjs';
 
 const KEYBOARD_SOURCES = {
     roster    : {source: 'fleet:listAgents',    state: 'wired', confidence: 'observed'},
@@ -50,24 +56,21 @@ async function startRejectingFleetBridge() {
                 requests.push(request);
 
                 if (request.method === 'stopAgent') {
-                    return {ok: false, error: 'fleet: stop rejected by keyboard witness'}
+                    return fleetE2EFailure('fleet: stop rejected by keyboard witness')
                 }
 
                 if (request.method === 'fleetRoster') {
-                    return {ok: true, result: {rows: rosterRows}}
+                    return fleetE2ESuccess({rows: rosterRows})
                 }
 
                 if (request.method === 'fleetActivity') {
-                    return {
-                        ok    : true,
-                        result: {
-                            capability: {source: 'fleet:test', state: 'wired', confidence: 'observed'},
-                            events    : []
-                        }
-                    }
+                    return fleetE2ESuccess({
+                        capability: {source: 'fleet:test', state: 'wired', confidence: 'observed'},
+                        events    : []
+                    })
                 }
 
-                return {ok: false, error: `fleet: unexpected keyboard-witness method '${request.method}'`}
+                return fleetE2EFailure(`fleet: unexpected keyboard-witness method '${request.method}'`)
             }
         });
 

--- a/test/playwright/e2e/agentos/FleetMemoriesNL.spec.mjs
+++ b/test/playwright/e2e/agentos/FleetMemoriesNL.spec.mjs
@@ -1,5 +1,10 @@
 import {expect, test}                                            from '../../fixtures.mjs';
-import {authenticatedFleetOptions, wireAuthenticatedFleetBridge} from './authenticatedFleetHarness.mjs';
+import {
+    authenticatedFleetOptions,
+    fleetE2EFailure,
+    fleetE2ESuccess,
+    wireAuthenticatedFleetBridge
+} from './authenticatedFleetHarness.mjs';
 
 const CAPTURED_AT = '2026-08-03T08:00:00.000Z';
 
@@ -91,17 +96,17 @@ async function startMemoriesFleet() {
 
                   switch (request.method) {
                       case 'resolveViewerIdentity':
-                          return {ok: true, result: {ok: true, agentIdentityNodeId: '@e2e-operator'}};
+                          return fleetE2ESuccess({ok: true, agentIdentityNodeId: '@e2e-operator'});
                       case 'fleetRoster':
-                          return {ok: true, result: {rows: rosterRows}};
+                          return fleetE2ESuccess({rows: rosterRows});
                       case 'fleetActivity':
-                          return {ok: true, result: {capability: {state: 'wired'}, events: []}};
+                          return fleetE2ESuccess({capability: {state: 'wired'}, events: []});
                       case 'fleetMemories':
-                          return {ok: true, result: memoriesResult(request.params)};
+                          return fleetE2ESuccess(memoriesResult(request.params));
                       case 'getBootIdentity':
-                          return {ok: true, result: {fact: null, classification: 'unknown', advisory: true}};
+                          return fleetE2ESuccess({fact: null, classification: 'unknown', advisory: true});
                       default:
-                          return {ok: false, error: `unexpected memories method: ${request.method}`}
+                          return fleetE2EFailure(`unexpected memories method: ${request.method}`)
                   }
               }
           }),

--- a/test/playwright/e2e/agentos/OperatorMailboxNL.spec.mjs
+++ b/test/playwright/e2e/agentos/OperatorMailboxNL.spec.mjs
@@ -1,6 +1,11 @@
-import {test, expect} from '../../fixtures.mjs';
+import {test, expect}                     from '../../fixtures.mjs';
 import {createFleetMailboxMirrorSnapshot} from '../../../../ai/services/fleet/fleetMailboxMirrorAdapter.mjs';
-import {authenticatedFleetOptions, wireAuthenticatedFleetBridge} from './authenticatedFleetHarness.mjs';
+import {
+    authenticatedFleetOptions,
+    fleetE2EFailure,
+    fleetE2ESuccess,
+    wireAuthenticatedFleetBridge
+} from './authenticatedFleetHarness.mjs';
 
 const rosterRows = [
     {id: 'review-a', githubUsername: 'review-peer-a', displayName: 'Review Peer A', engineTag: 'fixture', family: 'gpt'},
@@ -16,27 +21,24 @@ async function startOperatorMailboxFleet() {
 
                   switch (request.method) {
                       case 'resolveViewerIdentity':
-                          return {ok: true, result: {ok: true, agentIdentityNodeId: '@e2e-operator'}};
+                          return fleetE2ESuccess({ok: true, agentIdentityNodeId: '@e2e-operator'});
                       case 'fleetRoster':
-                          return {ok: true, result: {rows: rosterRows}};
+                          return fleetE2ESuccess({rows: rosterRows});
                       case 'fleetActivity':
-                          return {ok: true, result: {capability: {state: 'wired'}, events: []}};
+                          return fleetE2ESuccess({capability: {state: 'wired'}, events: []});
                       case 'fleetMailboxMirror':
-                          return {
-                              ok    : true,
-                              result: createFleetMailboxMirrorSnapshot({
+                          return fleetE2ESuccess(createFleetMailboxMirrorSnapshot({
                                   messages: [],
                                   page    : {limit: 50, offset: request.params?.offset ?? 0},
                                   subject : '@e2e-operator',
                                   viewer  : '@e2e-operator'
-                              })
-                          };
+                              }));
                       case 'composeOperatorMessage':
                           return request.params?.to === '@review-peer-b'
-                              ? {ok: true, result: {status: 'rejected', reason: 'fixture rejection'}}
-                              : {ok: true, result: {messageId: `fixture-${requests.length}`, sentAt: new Date().toISOString()}};
+                              ? fleetE2ESuccess({status: 'rejected', reason: 'fixture rejection'})
+                              : fleetE2ESuccess({messageId: `fixture-${requests.length}`, sentAt: new Date().toISOString()});
                       default:
-                          return {ok: false, error: `unexpected operator-mailbox method: ${request.method}`}
+                          return fleetE2EFailure(`unexpected operator-mailbox method: ${request.method}`)
                   }
               }
           }),
@@ -83,12 +85,12 @@ test.describe('AgentOS operator mailbox mounted delivery journey (#15377)', () =
             expect(mailbox.properties.snapshot.admission).toMatchObject({state: 'granted', subjectAgentId: '@e2e-operator'});
             expect(form.properties.recipientOptions.map(row => row.id)).toEqual(['AGENT:*', '@review-peer-a', '@review-peer-b']);
 
-            const listState       = await app.getComponent(list.properties.id, ['selectionModel']),
+            const listState        = await app.getComponent(list.properties.id, ['selectionModel']),
                   selectionModelId = listState.selectionModel.id,
-                  subject         = page.getByRole('textbox', {name: 'Subject'}),
-                  message         = page.getByRole('textbox', {name: 'Message'}),
-                  send            = page.getByRole('button', {name: 'Send'}),
-                  choose          = async name => {
+                  subject          = page.getByRole('textbox', {name: 'Subject'}),
+                  message          = page.getByRole('textbox', {name: 'Message'}),
+                  send             = page.getByRole('button', {name: 'Send'}),
+                  choose           = async name => {
                       const row = overlay
                           .locator('.fm-operator-compose-recipients-list')
                           .getByRole('listitem')

--- a/test/playwright/e2e/agentos/authenticatedFleetHarness.mjs
+++ b/test/playwright/e2e/agentos/authenticatedFleetHarness.mjs
@@ -1,5 +1,9 @@
 import {generateLocalBearerToken} from '../../../../ai/mcp/server/shared/helpers/localBearer.mjs';
 import RequestContextService      from '../../../../ai/mcp/server/shared/services/RequestContextService.mjs';
+import {
+    createFleetWireResponse,
+    FLEET_WIRE_RESPONSE_STATES
+} from '../../../../ai/services/fleet/fleetWireMethods.mjs';
 
 /**
  * @summary The authenticated Fleet e2e harness — the test-side composition of the ingress trust
@@ -25,6 +29,24 @@ export const E2E_FLEET_VIEWER = Object.freeze({
     username           : 'E2E Operator',
     agentIdentityNodeId: '@e2e-operator'
 });
+
+/**
+ * @summary Creates the canonical successful Fleet wire envelope for a spec-owned dispatcher.
+ * @param {*} result
+ * @returns {Object}
+ */
+export function fleetE2ESuccess(result) {
+    return createFleetWireResponse(FLEET_WIRE_RESPONSE_STATES.ok, {result})
+}
+
+/**
+ * @summary Creates a bounded operation-failure Fleet wire envelope for a spec-owned dispatcher.
+ * @param {String} error
+ * @returns {Object}
+ */
+export function fleetE2EFailure(error) {
+    return createFleetWireResponse(FLEET_WIRE_RESPONSE_STATES.operationFailed, {error})
+}
 
 /**
  * @summary Builds the authenticated option set for `startFleetBridgeServer` in e2e specs.

--- a/test/playwright/unit/ai/scripts/fleet/onboardPeer.spec.mjs
+++ b/test/playwright/unit/ai/scripts/fleet/onboardPeer.spec.mjs
@@ -594,12 +594,16 @@ test.describe('onboardPeer — long-lived Fleet owner transport', () => {
     });
 
     test('an unreachable long-lived owner fails closed with the operator recovery command', async () => {
+        const endpointSecret = 'credential-shaped-endpoint-secret';
         const bridge = createOnboardingFleetBridge({
             bearerToken: generateLocalBearerToken(),
-            fetchImpl  : async () => { throw new Error('ECONNREFUSED') }
+            fetchImpl  : async () => { throw new Error('raw-upstream-transport-secret') },
+            url        : `http://127.0.0.1:8083/fleet?token=${endpointSecret}`
         });
 
         await expect(bridge.getAgent('neo-gpt-2')).rejects.toThrow(/npm run ai:fleet-server/);
+        await expect(bridge.getAgent('neo-gpt-2')).rejects.not.toThrow(endpointSecret);
+        await expect(bridge.getAgent('neo-gpt-2')).rejects.not.toThrow('raw-upstream-transport-secret')
     });
 
     test('a missing process bearer fails closed at construction with the launch-contract remedy', () => {

--- a/test/playwright/unit/ai/services/fleet/FleetTenantService.spec.mjs
+++ b/test/playwright/unit/ai/services/fleet/FleetTenantService.spec.mjs
@@ -28,7 +28,12 @@ import FleetTenantService, {
 import FleetRegistryService   from '../../../../../../ai/services/fleet/FleetRegistryService.mjs'
 import FleetControlBridge     from '../../../../../../ai/services/fleet/FleetControlBridge.mjs'
 import {dispatchFleetRequest} from '../../../../../../ai/services/fleet/dispatchFleetRequest.mjs'
-import {FLEET_WIRE_METHODS}   from '../../../../../../ai/services/fleet/fleetWireMethods.mjs'
+import {
+    createFleetWireOffer,
+    createFleetWireRequest,
+    FLEET_WIRE_METHODS,
+    FLEET_WIRE_RESPONSE_STATES
+} from '../../../../../../ai/services/fleet/fleetWireMethods.mjs'
 
 const PAT = 'glpat-SUPER-SECRET-tenant-credential-42'
 
@@ -1032,10 +1037,18 @@ test.describe.serial('FleetControlBridge + wire — the remote-tenant surface', 
         expect(FLEET_WIRE_METHODS).not.toContain('getCredential')
         expect(FLEET_WIRE_METHODS).not.toContain('resolveMcpCredential')
 
-        await expect(dispatchFleetRequest({method: 'getCredential', params: 't'})).resolves
-            .toEqual({ok: false, error: "fleet: method 'getCredential' is not on the control surface"})
-        await expect(dispatchFleetRequest({method: 'resolveMcpCredential', params: 't'})).resolves
-            .toEqual({ok: false, error: "fleet: method 'resolveMcpCredential' is not on the control surface"})
+        await expect(dispatchFleetRequest({method: 'getCredential', params: 't', protocol: createFleetWireOffer()})).resolves
+            .toMatchObject({
+                error: "fleet: method 'getCredential' is not on the control surface",
+                ok   : false,
+                state: FLEET_WIRE_RESPONSE_STATES.unsupportedMethod
+            })
+        await expect(dispatchFleetRequest({method: 'resolveMcpCredential', params: 't', protocol: createFleetWireOffer()})).resolves
+            .toMatchObject({
+                error: "fleet: method 'resolveMcpCredential' is not on the control surface",
+                ok   : false,
+                state: FLEET_WIRE_RESPONSE_STATES.unsupportedMethod
+            })
     })
 
     test('a connectTenant dispatched over the wire returns the fail-closed envelope on service rejection', async () => {
@@ -1043,8 +1056,15 @@ test.describe.serial('FleetControlBridge + wire — the remote-tenant surface', 
             connectTenant: async () => ({status: 'rejected', reason: 'tenant rejected the credential'})
         }
 
-        const result = await dispatchFleetRequest({method: 'connectTenant', params: {tenantUrl: 'https://t', credential: 'bad'}})
+        const result = await dispatchFleetRequest(createFleetWireRequest(
+            'connectTenant',
+            {tenantUrl: 'https://t', credential: 'bad'}
+        ))
 
-        expect(result).toEqual({ok: true, result: {status: 'rejected', reason: 'tenant rejected the credential'}})
+        expect(result).toMatchObject({
+            ok    : true,
+            result: {status: 'rejected', reason: 'tenant rejected the credential'},
+            state : FLEET_WIRE_RESPONSE_STATES.ok
+        })
     })
 })

--- a/test/playwright/unit/ai/services/fleet/createFleetRegistryBridge.spec.mjs
+++ b/test/playwright/unit/ai/services/fleet/createFleetRegistryBridge.spec.mjs
@@ -118,6 +118,18 @@ test.describe('createFleetRegistryBridge — the browser-side pane bridge factor
         await expect(bridge.listAgents()).rejects.not.toThrow(secret)
     });
 
+    test('a caller-owned transport remedy stays bounded without relaying the rejected error', async () => {
+        const
+            secret = 'raw-upstream-credential-shaped-secret',
+            remedy = "onboardPeer: Fleet owner is unreachable; start it with 'npm run ai:fleet-server' and re-run",
+            bridge = createFleetRegistryBridge(async () => {
+                throw new Error(secret)
+            }, {transportFailureMessage: remedy});
+
+        await expect(bridge.listAgents()).rejects.toThrow(remedy);
+        await expect(bridge.listAgents()).rejects.not.toThrow(secret)
+    });
+
     test('requires a transport send function', () => {
         expect(() => createFleetRegistryBridge()).toThrow('send(request) function is required');
         expect(() => createFleetRegistryBridge({})).toThrow();

--- a/test/playwright/unit/ai/services/fleet/createFleetRegistryBridge.spec.mjs
+++ b/test/playwright/unit/ai/services/fleet/createFleetRegistryBridge.spec.mjs
@@ -17,7 +17,14 @@ import {test, expect}              from '@playwright/test';
 import Neo                         from '../../../../../../src/Neo.mjs';
 import * as core                   from '../../../../../../src/core/_export.mjs';
 import {createFleetRegistryBridge} from '../../../../../../ai/services/fleet/createFleetRegistryBridge.mjs';
-import {FLEET_WIRE_METHODS}        from '../../../../../../ai/services/fleet/fleetWireMethods.mjs';
+import {
+    createFleetWireProtocolStamp,
+    createFleetWireRequest,
+    createFleetWireResponse,
+    FLEET_WIRE_CAPABILITIES,
+    FLEET_WIRE_METHODS,
+    FLEET_WIRE_RESPONSE_STATES
+} from '../../../../../../ai/services/fleet/fleetWireMethods.mjs';
 
 // createFleetRegistryBridge is the browser-side (App-Worker) factory: given a transport `send`, it
 // returns the object the agentos pane resolves at globalThis.AgentOS.fleet.registryBridge. No live
@@ -26,25 +33,31 @@ import {FLEET_WIRE_METHODS}        from '../../../../../../ai/services/fleet/fle
 
 test.describe('createFleetRegistryBridge — the browser-side pane bridge factory', () => {
     test('exposes exactly the wire-allowlisted operations — no more, no less', () => {
-        const bridge = createFleetRegistryBridge(async () => ({ok: true, result: null}));
+        const bridge = createFleetRegistryBridge(async () => createFleetWireResponse(FLEET_WIRE_RESPONSE_STATES.ok, {result: null}));
         expect(Object.keys(bridge).sort()).toEqual([...FLEET_WIRE_METHODS].sort());
     });
 
-    test('defineAgent forwards {method, params} through send + resolves the envelope result', async () => {
+    test('defineAgent forwards a versioned offer through send + resolves the validated result', async () => {
         const sent   = [];
-        const bridge = createFleetRegistryBridge(async req => { sent.push(req); return {ok: true, result: {id: 'alice'}}; });
-        const res    = await bridge.defineAgent({githubUsername: 'alice', harnessType: 'codex'});
+        const bridge = createFleetRegistryBridge(async req => {
+            sent.push(req);
+            return createFleetWireResponse(FLEET_WIRE_RESPONSE_STATES.ok, {result: {id: 'alice'}})
+        });
+        const res = await bridge.defineAgent({githubUsername: 'alice', harnessType: 'codex'});
 
-        expect(sent).toEqual([{method: 'defineAgent', params: {githubUsername: 'alice', harnessType: 'codex'}}]);
+        expect(sent).toEqual([createFleetWireRequest('defineAgent', {githubUsername: 'alice', harnessType: 'codex'})]);
         expect(res).toEqual({id: 'alice'});
     });
 
     test('a lifecycle op forwards its id as params', async () => {
         const sent   = [];
-        const bridge = createFleetRegistryBridge(async req => { sent.push(req); return {ok: true, result: {id: 'alice', state: 'running'}}; });
+        const bridge = createFleetRegistryBridge(async req => {
+            sent.push(req);
+            return createFleetWireResponse(FLEET_WIRE_RESPONSE_STATES.ok, {result: {id: 'alice', state: 'running'}})
+        });
 
         await bridge.startAgent('alice');
-        expect(sent).toEqual([{method: 'startAgent', params: 'alice'}]);
+        expect(sent).toEqual([createFleetWireRequest('startAgent', 'alice')]);
     });
 
     test('configureAgent forwards its ONE curated intent as params', async () => {
@@ -53,16 +66,56 @@ test.describe('createFleetRegistryBridge — the browser-side pane bridge factor
             intent = {id: 'alice', harnessType: 'claude-code', mcpServers: {'memory-core': false}},
             bridge = createFleetRegistryBridge(async req => {
                 sent.push(req);
-                return {ok: true, result: {status: 'accepted', agent: {id: 'alice'}}}
+                return createFleetWireResponse(FLEET_WIRE_RESPONSE_STATES.ok, {
+                    result: {status: 'accepted', agent: {id: 'alice'}}
+                })
             });
 
         await expect(bridge.configureAgent(intent)).resolves.toEqual({status: 'accepted', agent: {id: 'alice'}});
-        expect(sent).toEqual([{method: 'configureAgent', params: intent}])
+        expect(sent).toEqual([createFleetWireRequest('configureAgent', intent)])
     });
 
-    test('an {ok:false} envelope rejects with the transport error (fail-closed for the pane)', async () => {
-        const bridge = createFleetRegistryBridge(async () => ({ok: false, error: 'spawn failed'}));
+    test('a finite failure envelope rejects with the transport error (fail-closed for the pane)', async () => {
+        const bridge = createFleetRegistryBridge(async () => createFleetWireResponse(
+            FLEET_WIRE_RESPONSE_STATES.operationFailed,
+            {error: 'spawn failed'}
+        ));
         await expect(bridge.startAgent('alice')).rejects.toThrow('spawn failed');
+    });
+
+    test('malformed, version-skewed, and capability-skewed server responses never become data', async () => {
+        const responses = [
+            {ok: true, state: 'invented', protocol: createFleetWireProtocolStamp(), result: []},
+            {ok: true, state: FLEET_WIRE_RESPONSE_STATES.ok, protocol: createFleetWireProtocolStamp()},
+            createFleetWireResponse(FLEET_WIRE_RESPONSE_STATES.ok, {
+                protocol: createFleetWireProtocolStamp(2),
+                result  : []
+            }),
+            createFleetWireResponse(FLEET_WIRE_RESPONSE_STATES.ok, {
+                protocol: createFleetWireProtocolStamp(1, [...FLEET_WIRE_CAPABILITIES, 'server-only']),
+                result  : []
+            }),
+            {
+                ...createFleetWireResponse(FLEET_WIRE_RESPONSE_STATES.ok, {result: []}),
+                protocol: {...createFleetWireProtocolStamp(), ownerPrincipal: 'must-never-cross'}
+            }
+        ];
+
+        for (const response of responses) {
+            const bridge = createFleetRegistryBridge(async () => response);
+
+            await expect(bridge.listAgents()).rejects.toThrow(/malformed|unoffered/)
+        }
+    });
+
+    test('transport rejection text is never relayed through the pane client', async () => {
+        const secret = 'raw-upstream-transport-secret';
+        const bridge = createFleetRegistryBridge(async () => {
+            throw new Error(secret)
+        });
+
+        await expect(bridge.listAgents()).rejects.toThrow('fleet: request transport failed');
+        await expect(bridge.listAgents()).rejects.not.toThrow(secret)
     });
 
     test('requires a transport send function', () => {

--- a/test/playwright/unit/ai/services/fleet/dispatchFleetRequest.spec.mjs
+++ b/test/playwright/unit/ai/services/fleet/dispatchFleetRequest.spec.mjs
@@ -17,11 +17,19 @@ import {test, expect}                             from '@playwright/test';
 import Neo                                        from '../../../../../../src/Neo.mjs';
 import * as core                                  from '../../../../../../src/core/_export.mjs';
 import {dispatchFleetRequest, FLEET_WIRE_METHODS} from '../../../../../../ai/services/fleet/dispatchFleetRequest.mjs';
+import {
+    createFleetWireOffer,
+    createFleetWireProtocolStamp,
+    createFleetWireRequest,
+    FLEET_WIRE_CAPABILITIES,
+    FLEET_WIRE_RESPONSE_STATES
+} from '../../../../../../ai/services/fleet/fleetWireMethods.mjs';
 
-// dispatchFleetRequest is the pure app↔fleet wire choke-point: it takes a {method, params} request,
-// enforces the wire-level allowlist, forwards to an injected bridge stub, and normalizes to an
-// {ok, result|error} envelope. No socket / transport needed to exercise it — the transport is a thin
-// wrapper that only carries the request in + the envelope out.
+// dispatchFleetRequest is the pure app↔fleet wire choke-point: it selects a client-offered contract
+// before method policy, forwards to an injected bridge stub, and emits one finite response state.
+// No socket / transport is needed to exercise that ordering.
+
+const wireRequest = (method, params) => createFleetWireRequest(method, params);
 
 test.describe('dispatchFleetRequest — the app↔fleet wire allowlist + routing choke-point', () => {
     let calls, bridge;
@@ -47,49 +55,60 @@ test.describe('dispatchFleetRequest — the app↔fleet wire allowlist + routing
     });
 
     test('routes an allowlisted method, forwards params, wraps {ok:true, result}', async () => {
-        const res = await dispatchFleetRequest({method: 'defineAgent', params: {githubUsername: 'alice', harnessType: 'codex'}}, bridge);
-        expect(res).toEqual({ok: true, result: {id: 'alice'}});
+        const res = await dispatchFleetRequest(wireRequest('defineAgent', {githubUsername: 'alice', harnessType: 'codex'}), bridge);
+        expect(res).toEqual({
+            ok      : true,
+            protocol: createFleetWireProtocolStamp(),
+            result  : {id: 'alice'},
+            state   : FLEET_WIRE_RESPONSE_STATES.ok
+        });
         expect(calls).toEqual([['defineAgent', {githubUsername: 'alice', harnessType: 'codex'}]]);
     });
 
     test('awaits async lifecycle operations', async () => {
-        const res = await dispatchFleetRequest({method: 'startAgent', params: 'alice'}, bridge);
-        expect(res).toEqual({ok: true, result: {id: 'alice', state: 'running'}});
+        const res = await dispatchFleetRequest(wireRequest('startAgent', 'alice'), bridge);
+        expect(res).toMatchObject({ok: true, result: {id: 'alice', state: 'running'}, state: FLEET_WIRE_RESPONSE_STATES.ok});
         expect(calls).toEqual([['startAgent', 'alice']]);
     });
 
     test('routes setRepo, forwarding the single payload to the bridge (wire-compatible single-params)', async () => {
         const payload = {id: 'alice', cloneUrl: 'https://github.com/x/y.git', repoSlug: 'x/y'},
-              res     = await dispatchFleetRequest({method: 'setRepo', params: payload}, bridge);
+              res     = await dispatchFleetRequest(wireRequest('setRepo', payload), bridge);
 
-        expect(res).toEqual({ok: true, result: {id: 'alice', metadata: {repo: payload}}});
+        expect(res).toMatchObject({ok: true, result: {id: 'alice', metadata: {repo: payload}}, state: FLEET_WIRE_RESPONSE_STATES.ok});
         expect(calls).toEqual([['setRepo', payload]]);
     });
 
     test('routes configureAgent as one payload and preserves the domain outcome', async () => {
         const
             payload = {id: 'alice', harnessType: 'claude-code', mcpServers: {'memory-core': false}},
-            res     = await dispatchFleetRequest({method: 'configureAgent', params: payload}, bridge);
+            res     = await dispatchFleetRequest(wireRequest('configureAgent', payload), bridge);
 
-        expect(res).toEqual({
+        expect(res).toMatchObject({
             ok    : true,
-            result: {status: 'accepted', agent: {id: 'alice', harnessType: 'claude-code'}}
+            result: {status: 'accepted', agent: {id: 'alice', harnessType: 'claude-code'}},
+            state : FLEET_WIRE_RESPONSE_STATES.ok
         });
         expect(calls).toEqual([['configureAgent', payload]])
     });
 
     test('routes setAvatar, forwarding the single payload to the bridge', async () => {
         const payload = {id: 'alice', avatarUrl: 'https://cdn/x.png'},
-              res     = await dispatchFleetRequest({method: 'setAvatar', params: payload}, bridge);
+              res     = await dispatchFleetRequest(wireRequest('setAvatar', payload), bridge);
 
-        expect(res).toEqual({ok: true, result: {id: 'alice', metadata: {avatarUrl: 'https://cdn/x.png'}}});
+        expect(res).toMatchObject({
+            ok    : true,
+            result: {id: 'alice', metadata: {avatarUrl: 'https://cdn/x.png'}},
+            state : FLEET_WIRE_RESPONSE_STATES.ok
+        });
         expect(calls).toEqual([['setAvatar', payload]]);
     });
 
     test('rejects a method NOT on the wire allowlist without ever calling the bridge', async () => {
         for (const method of ['getManager', 'getRegistry', 'constructor', 'toString', '__proto__', 'resolveCredential', 'nope']) {
-            const res = await dispatchFleetRequest({method, params: 'x'}, bridge);
+            const res = await dispatchFleetRequest({method, params: 'x', protocol: createFleetWireOffer()}, bridge);
             expect(res.ok).toBe(false);
+            expect(res.state).toBe(FLEET_WIRE_RESPONSE_STATES.unsupportedMethod);
             expect(res.error).toContain('not on the control surface');
         }
         // the dangerous resolver seams were never invoked — the wire allowlist stopped them first
@@ -98,9 +117,10 @@ test.describe('dispatchFleetRequest — the app↔fleet wire allowlist + routing
 
     test('fails closed on a thrown op WITHOUT leaking the raw error / stack (sanitized, method-scoped)', async () => {
         const throwing = {startAgent: async () => { throw new Error('spawn failed at /internal/secret/path.mjs:42'); }};
-        const res      = await dispatchFleetRequest({method: 'startAgent', params: 'alice'}, throwing);
+        const res      = await dispatchFleetRequest(wireRequest('startAgent', 'alice'), throwing);
 
         expect(res.ok).toBe(false);
+        expect(res.state).toBe(FLEET_WIRE_RESPONSE_STATES.operationFailed);
         expect(res.error).toBe("fleet: 'startAgent' failed");
         expect(res.error).not.toContain('spawn failed');       // the raw message never crosses the wire
         expect(res.error).not.toContain('/internal/secret')    // no stack / internal-path leak
@@ -109,6 +129,30 @@ test.describe('dispatchFleetRequest — the app↔fleet wire allowlist + routing
     test('an absent request object fails closed, not throws', async () => {
         const res = await dispatchFleetRequest(undefined, bridge);
         expect(res.ok).toBe(false);
+        expect(res.state).toBe(FLEET_WIRE_RESPONSE_STATES.unsupportedProtocol);
+        expect(calls).toEqual([])
+    });
+
+    test('version or required-capability skew closes before method lookup or bridge execution', async () => {
+        const requests = [
+            {method: 'listAgents', protocol: {versions: [999], capabilities: [...FLEET_WIRE_CAPABILITIES]}},
+            {method: 'listAgents', protocol: {versions: [1], capabilities: ['method-schema-v1']}}
+        ];
+
+        const states = [];
+
+        for (const request of requests) {
+            const response = await dispatchFleetRequest(request, bridge);
+
+            states.push(response.state);
+            expect(response.ok).toBe(false)
+        }
+
+        expect(states).toEqual([
+            FLEET_WIRE_RESPONSE_STATES.unsupportedProtocol,
+            FLEET_WIRE_RESPONSE_STATES.unsupportedCapability
+        ]);
+        expect(calls).toEqual([])
     });
 
     test('resolveViewerIdentity routes over the wire — the whoami identity-bootstrap is a real pane-callable verb', async () => {
@@ -117,7 +161,7 @@ test.describe('dispatchFleetRequest — the app↔fleet wire allowlist + routing
             return {ok: true, agentIdentityNodeId: '@stamped-viewer'}
         };
 
-        const res = await dispatchFleetRequest({method: 'resolveViewerIdentity'}, bridge);
+        const res = await dispatchFleetRequest(wireRequest('resolveViewerIdentity'), bridge);
 
         expect(res.ok).toBe(true);
         expect(res.result).toEqual({ok: true, agentIdentityNodeId: '@stamped-viewer'});

--- a/test/playwright/unit/ai/services/fleet/fleetBridgeServer.spec.mjs
+++ b/test/playwright/unit/ai/services/fleet/fleetBridgeServer.spec.mjs
@@ -13,12 +13,16 @@ setup({
     }
 });
 
-import {test, expect}             from '@playwright/test';
-import http                       from 'node:http';
-import {AsyncLocalStorage}        from 'node:async_hooks';
-import Neo                        from '../../../../../../src/Neo.mjs';
-import * as core                  from '../../../../../../src/core/_export.mjs';
-import {startFleetBridgeServer}   from '../../../../../../ai/services/fleet/fleetBridgeServer.mjs';
+import {test, expect}           from '@playwright/test';
+import http                     from 'node:http';
+import {AsyncLocalStorage}      from 'node:async_hooks';
+import Neo                      from '../../../../../../src/Neo.mjs';
+import * as core                from '../../../../../../src/core/_export.mjs';
+import {startFleetBridgeServer} from '../../../../../../ai/services/fleet/fleetBridgeServer.mjs';
+import {
+    createFleetWireResponse,
+    FLEET_WIRE_RESPONSE_STATES
+} from '../../../../../../ai/services/fleet/fleetWireMethods.mjs';
 import {generateLocalBearerToken} from '../../../../../../ai/mcp/server/shared/helpers/localBearer.mjs';
 
 /**
@@ -44,7 +48,10 @@ test.describe('fleetBridgeServer — the authenticated Fleet ingress', () => {
             bearerToken  : bearer,
             viewerContext: viewer,
             runInContext : (context, fn) => { contexts.push(context); return fn() },
-            dispatch     : async req => { seen.push(req); return {ok: true, result: {echoed: req}} },
+            dispatch     : async req => {
+                seen.push(req);
+                return createFleetWireResponse(FLEET_WIRE_RESPONSE_STATES.ok, {result: {echoed: req}})
+            },
             ...overrides
         });
         url = `http://127.0.0.1:${server.address().port}`
@@ -104,7 +111,11 @@ test.describe('fleetBridgeServer — the authenticated Fleet ingress', () => {
         const res = await fetch(`${url}/fleet`, {method: 'POST', headers: authHeaders(), body: JSON.stringify({method: 'listAgents'})});
 
         expect(res.status).toBe(200);
-        expect(await res.json()).toEqual({ok: true, result: {echoed: {method: 'listAgents'}}});
+        expect(await res.json()).toMatchObject({
+            ok    : true,
+            result: {echoed: {method: 'listAgents'}},
+            state : FLEET_WIRE_RESPONSE_STATES.ok
+        });
         expect(seen).toEqual([{method: 'listAgents'}]);
         expect(contexts).toEqual([{...viewer, source: 'fleet-ingress'}])
     });
@@ -266,7 +277,7 @@ test.describe('fleetBridgeServer — the authenticated Fleet ingress', () => {
         const mkDispatch = (tag, delayMs) => async () => {
             await new Promise(resolve => setTimeout(resolve, delayMs));
             results[tag] = storage.getStore()?.agentIdentityNodeId;
-            return {ok: true, result: tag}
+            return createFleetWireResponse(FLEET_WIRE_RESPONSE_STATES.ok, {result: tag})
         };
 
         const bearerA = generateLocalBearerToken(),

--- a/test/playwright/unit/ai/services/fleet/fleetServer.spec.mjs
+++ b/test/playwright/unit/ai/services/fleet/fleetServer.spec.mjs
@@ -13,6 +13,7 @@ import {test, expect}                  from '@playwright/test';
 import Neo                             from '../../../../../../src/Neo.mjs';
 import * as core                       from '../../../../../../src/core/_export.mjs';
 import {mkdir, mkdtemp, rm, writeFile} from 'node:fs/promises';
+import {request as httpRequest}        from 'node:http';
 import os                              from 'node:os';
 import path                            from 'node:path';
 import RequestContextService           from '../../../../../../ai/mcp/server/shared/services/RequestContextService.mjs';
@@ -29,11 +30,18 @@ import {
     FLEET_S1_METHOD_POLICY,
     FLEET_S1_READY_METHODS
 }                                  from '../../../../../../ai/services/fleet/fleetServerPolicy.mjs';
-import {FLEET_WIRE_METHODS}        from '../../../../../../ai/services/fleet/fleetWireMethods.mjs';
+import {
+    createFleetWireResponse,
+    createFleetWireRequest,
+    FLEET_WIRE_METHODS,
+    FLEET_WIRE_RESPONSE_STATES
+}                                  from '../../../../../../ai/services/fleet/fleetWireMethods.mjs';
 
 const
     nativeFetch = globalThis.fetch,
     logger      = {info() {}, warn() {}, error() {}};
+
+const wireBody = (method, params) => JSON.stringify(createFleetWireRequest(method, params));
 
 function createConfig({authMiddleware=null, auth={}}={}) {
     return {
@@ -78,6 +86,33 @@ async function startApp(options={}) {
         baseUrl: `http://127.0.0.1:${server.address().port}`,
         close  : () => new Promise((resolve, reject) => server.close(error => error ? reject(error) : resolve()))
     }
+}
+
+async function rawHttpRequest(baseUrl, {body='', headers={}, method='GET', pathname='/fleet'}={}) {
+    const url = new URL(baseUrl);
+
+    return new Promise((resolve, reject) => {
+        const request = httpRequest({
+            headers,
+            host: url.hostname,
+            method,
+            path: pathname,
+            port: url.port
+        }, response => {
+            let responseBody = '';
+
+            response.setEncoding('utf8');
+            response.on('data', chunk => { responseBody += chunk });
+            response.on('end', () => resolve({
+                body   : JSON.parse(responseBody),
+                headers: response.headers,
+                status : response.statusCode
+            }))
+        });
+
+        request.once('error', reject);
+        request.end(body)
+    })
 }
 
 test.describe.configure({mode: 'serial'});
@@ -145,6 +180,167 @@ test.describe('composed Fleet S1 server', () => {
         }
     });
 
+    test('the exact Fleet route adapts the SDK Host refusal without admitting auth or dispatch', async () => {
+        const calls  = {auth: 0, dispatch: 0};
+        const server = await startApp({
+            authMiddleware(req, res, next) {
+                calls.auth++;
+                req.auth = {userId: 'alice', source: 'test-provider'};
+                next()
+            },
+            serverOptions: {
+                dispatch() {
+                    calls.dispatch++;
+                    return createFleetWireResponse(FLEET_WIRE_RESPONSE_STATES.ok, {result: []})
+                }
+            }
+        });
+
+        try {
+            const response = await rawHttpRequest(server.baseUrl, {
+                body   : wireBody('listAgents'),
+                headers: {
+                    'Content-Type': 'application/json',
+                    Host          : 'evil.example'
+                },
+                method: 'POST'
+            });
+
+            expect(response.status).toBe(403);
+            expect(response.body).toEqual(createFleetWireResponse(FLEET_WIRE_RESPONSE_STATES.refused, {
+                error: 'fleet: request not admitted'
+            }));
+            expect(response.body).not.toHaveProperty('jsonrpc');
+            expect(JSON.stringify(response.body)).not.toContain('evil.example');
+            expect(calls).toEqual({auth: 0, dispatch: 0})
+        } finally {
+            await server.close()
+        }
+    });
+
+    test('built-in bearer refusals retain HTTP auth semantics but expose only the Fleet envelope', async () => {
+        const invalidToken = 'invalid-provider-secret';
+
+        globalThis.fetch = async (input, init) => {
+            if (String(input) === 'https://api.github.test/user') {
+                expect(init.headers.Authorization).toBe(`Bearer ${invalidToken}`);
+
+                return new Response(JSON.stringify({message: 'provider denied the secret'}), {
+                    status : 401,
+                    headers: {'content-type': 'application/json'}
+                })
+            }
+
+            return nativeFetch(input, init)
+        };
+
+        const server = await startApp();
+
+        try {
+            for (const headers of [
+                {'Content-Type': 'application/json'},
+                {Authorization: `Bearer ${invalidToken}`, 'Content-Type': 'application/json'}
+            ]) {
+                const response = await nativeFetch(`${server.baseUrl}/fleet`, {
+                    body  : wireBody('listAgents'),
+                    headers,
+                    method: 'POST'
+                });
+                const payload = await response.json();
+
+                expect(response.status).toBe(401);
+                expect(response.headers.get('www-authenticate')).toContain('Bearer error="invalid_token"');
+                expect(payload).toEqual(createFleetWireResponse(FLEET_WIRE_RESPONSE_STATES.refused, {
+                    error: 'fleet: request not admitted'
+                }));
+                expect(payload).not.toHaveProperty('error_description');
+                expect(JSON.stringify(payload)).not.toContain(invalidToken);
+                expect(JSON.stringify(payload)).not.toContain('provider denied')
+            }
+        } finally {
+            await server.close()
+        }
+    });
+
+    test('custom auth send and end terminals are normalized onto the same finite refusal', async () => {
+        const terminals = [
+            ['string send', res => res.status(401).send('Unauthorized private detail')],
+            ['object send', res => res.status(401).send({error: 'private auth detail'})],
+            ['direct end',  res => { res.status(401); res.end('Unauthorized private detail') }],
+            ['success envelope', res => res.status(401).json(createFleetWireResponse(
+                FLEET_WIRE_RESPONSE_STATES.ok,
+                {result: ['must-not-cross']}
+            ))]
+        ];
+
+        for (const [name, terminate] of terminals) {
+            let   dispatchCalls = 0;
+            const server        = await startApp({
+                authMiddleware(req, res) {
+                    terminate(res)
+                },
+                serverOptions: {
+                    dispatch() {
+                        dispatchCalls++;
+                        return createFleetWireResponse(FLEET_WIRE_RESPONSE_STATES.ok, {result: []})
+                    }
+                }
+            });
+
+            try {
+                const response = await nativeFetch(`${server.baseUrl}/fleet`, {
+                    body   : wireBody('listAgents'),
+                    headers: {'Content-Type': 'application/json'},
+                    method : 'POST'
+                });
+
+                expect(response.status, name).toBe(401);
+                expect(response.headers.get('content-type'), name).toContain('application/json');
+                expect(await response.json(), name).toEqual(createFleetWireResponse(
+                    FLEET_WIRE_RESPONSE_STATES.refused,
+                    {error: 'fleet: request not admitted'}
+                ));
+                expect(dispatchCalls, name).toBe(0)
+            } finally {
+                await server.close()
+            }
+        }
+    });
+
+    test('custom auth end overload callbacks survive finite-envelope normalization', async () => {
+        for (const withChunk of [false, true]) {
+            let   callbackCalls = 0;
+            const server        = await startApp({
+                authMiddleware(req, res) {
+                    res.status(401);
+
+                    if (withChunk) {
+                        res.end('private auth detail', () => { callbackCalls++ })
+                    } else {
+                        res.end(() => { callbackCalls++ })
+                    }
+                }
+            });
+
+            try {
+                const response = await nativeFetch(`${server.baseUrl}/fleet`, {
+                    body   : wireBody('listAgents'),
+                    headers: {'Content-Type': 'application/json'},
+                    method : 'POST'
+                });
+
+                expect(response.status, String(withChunk)).toBe(401);
+                expect(await response.json(), String(withChunk)).toEqual(createFleetWireResponse(
+                    FLEET_WIRE_RESPONSE_STATES.refused,
+                    {error: 'fleet: request not admitted'}
+                ));
+                expect(callbackCalls, String(withChunk)).toBe(1)
+            } finally {
+                await server.close()
+            }
+        }
+    });
+
     test('the plural-local posture authenticates two provider subjects but exposes no roster or tenant data', async () => {
         const subjects = new Map([
             ['alice-provider-token', {id: 7, login: 'alice', name: 'Alice'}],
@@ -186,7 +382,7 @@ test.describe('composed Fleet S1 server', () => {
                     const response = await nativeFetch(`${server.baseUrl}/fleet`, {
                         method: 'POST',
                         headers,
-                        body  : JSON.stringify({method, params: method === 'getAgent' ? subject.login : undefined})
+                        body  : wireBody(method, method === 'getAgent' ? subject.login : undefined)
                     });
 
                     expect(response.status, `${subject.login}:${method}`).toBe(200);
@@ -300,7 +496,11 @@ test.describe('composed Fleet S1 server', () => {
                 body: '{'
             });
             expect(admitted.status).toBe(400);
-            expect(await admitted.json()).toEqual({ok: false, error: 'fleet: invalid JSON body'})
+            expect(await admitted.json()).toMatchObject({
+                error: 'fleet: invalid JSON body',
+                ok   : false,
+                state: FLEET_WIRE_RESPONSE_STATES.refused
+            })
         } finally {
             await server.close()
         }
@@ -333,7 +533,11 @@ test.describe('composed Fleet S1 server', () => {
 
                 expect(response.status, origin).toBe(403);
                 expect(response.headers.get('access-control-allow-origin'), origin).toBeNull();
-                expect(await response.json()).toEqual({ok: false, error: 'fleet: origin not admitted'})
+                expect(await response.json()).toMatchObject({
+                    error: 'fleet: origin not admitted',
+                    ok   : false,
+                    state: FLEET_WIRE_RESPONSE_STATES.refused
+                })
             }
 
             const preflight = await nativeFetch(`${server.baseUrl}/fleet`, {
@@ -376,7 +580,11 @@ test.describe('composed Fleet S1 server', () => {
             });
 
             expect(response.status).toBe(413);
-            expect(await response.json()).toEqual({ok: false, error: 'fleet: request body too large'})
+            expect(await response.json()).toMatchObject({
+                error: 'fleet: request body too large',
+                ok   : false,
+                state: FLEET_WIRE_RESPONSE_STATES.refused
+            })
         } finally {
             await server.close()
         }
@@ -408,7 +616,11 @@ test.describe('composed Fleet S1 server', () => {
             const payload = await response.json();
 
             expect(response.status).toBe(200);
-            expect(payload).toEqual({ok: false, error: 'fleet: request failed'});
+            expect(payload).toMatchObject({
+                error: 'fleet: request failed',
+                ok   : false,
+                state: FLEET_WIRE_RESPONSE_STATES.operationFailed
+            });
             expect(logs).toEqual(['[FleetServer] dispatch failed']);
             expect(JSON.stringify({payload, logs})).not.toContain(secret)
         } finally {
@@ -491,7 +703,13 @@ test.describe('composed Fleet S1 server', () => {
                 dispatch: async request => {
                     await new Promise(resolve => setTimeout(resolve, request.params.delay));
                     const context = RequestContextService.get();
-                    return {ok: true, result: {userId: context.userId, frozen: Object.isFrozen(context)}}
+                    return createFleetWireResponse(FLEET_WIRE_RESPONSE_STATES.ok, {
+                        protocol: {
+                            version     : request.protocol.versions[0],
+                            capabilities: request.protocol.capabilities
+                        },
+                        result: {userId: context.userId, frozen: Object.isFrozen(context)}
+                    })
                 }
             }
         });
@@ -500,7 +718,7 @@ test.describe('composed Fleet S1 server', () => {
             const call = (userId, delay) => nativeFetch(`${server.baseUrl}/fleet`, {
                 method : 'POST',
                 headers: {'Content-Type': 'application/json', 'X-Test-User': userId},
-                body   : JSON.stringify({method: 'listAgents', params: {delay}})
+                body   : wireBody('listAgents', {delay})
             }).then(response => response.json());
 
             const [alice, bob] = await Promise.all([call('alice', 25), call('bob', 1)]);
@@ -566,7 +784,7 @@ test.describe('composed Fleet S1 server', () => {
                 },
                 engines        : {chroma: {dataDirProd: member('chroma/unified')}},
                 heapObservation: {dir: member('heap-observation')},
-                orchestrator: {
+                orchestrator   : {
                     dataDir              : member('orchestrator-daemon'),
                     dbPath               : member('orchestrator-daemon/orchestrator.sqlite'),
                     deploymentStateBridge: {snapshotPath: member('deployment-state/snapshot.json')},
@@ -633,8 +851,8 @@ test.describe('Fleet S1 wire policy', () => {
         }]));
 
         for (const method of FLEET_S1_READY_METHODS) {
-            expect(await dispatchFleetS1Request({method, params: 'x'}, bridge))
-                .toEqual({ok: true, result: method})
+            expect(await dispatchFleetS1Request(createFleetWireRequest(method, 'x'), bridge))
+                .toMatchObject({ok: true, result: method, state: FLEET_WIRE_RESPONSE_STATES.ok})
         }
 
         const expectedSlices = {
@@ -665,8 +883,9 @@ test.describe('Fleet S1 wire policy', () => {
         };
 
         for (const [method, degraded] of Object.entries(expectedSlices)) {
-            expect(await dispatchFleetS1Request({method, params: 'x'}, bridge)).toMatchObject({
-                ok: false,
+            expect(await dispatchFleetS1Request(createFleetWireRequest(method, 'x'), bridge)).toMatchObject({
+                ok   : false,
+                state: FLEET_WIRE_RESPONSE_STATES.degraded,
                 degraded
             })
         }
@@ -678,9 +897,13 @@ test.describe('Fleet S1 wire policy', () => {
 
     test('unknown methods retain the canonical fail-closed wire envelope', async () => {
         for (const method of ['futureUnclassifiedVerb', 'constructor', 'toString', '__proto__']) {
-            expect(await dispatchFleetS1Request({method}, {})).toEqual({
+            expect(await dispatchFleetS1Request({
+                method,
+                protocol: createFleetWireRequest('listAgents').protocol
+            }, {})).toMatchObject({
+                error: `fleet: method '${method}' is not on the control surface`,
                 ok   : false,
-                error: `fleet: method '${method}' is not on the control surface`
+                state: FLEET_WIRE_RESPONSE_STATES.unsupportedMethod
             })
         }
     })

--- a/test/playwright/unit/apps/agentos/config/fleetVocabularyParity.spec.mjs
+++ b/test/playwright/unit/apps/agentos/config/fleetVocabularyParity.spec.mjs
@@ -1,4 +1,6 @@
 import {expect, test} from '@playwright/test';
+import {parse}        from 'acorn';
+import {readFileSync} from 'node:fs';
 
 import {compareFleetVocabulary} from '../../../../../../ai/scripts/lint/lint-fleet-vocabulary-parity.mjs';
 
@@ -63,5 +65,151 @@ test.describe('FM vocabulary parity — the realm boundary carries no imports, s
         const violations = compareFleetVocabulary({authority, twin: forkedTwin});
 
         expect(violations.join('\n')).toContain('resolveMcpMatrix')
+    });
+
+    test('protocol-version and capability drift each redden with the exact surface named', () => {
+        const
+            versionDrift = compareFleetVocabulary({
+                authority,
+                twin: {
+                    ...twin,
+                    wire: {...twin.wire, FLEET_WIRE_PROTOCOL_VERSIONS: [999]}
+                }
+            }),
+            capabilityDrift = compareFleetVocabulary({
+                authority,
+                twin: {
+                    ...twin,
+                    wire: {...twin.wire, FLEET_WIRE_CAPABILITIES: [...twin.wire.FLEET_WIRE_CAPABILITIES, 'rogue']}
+                }
+            });
+
+        expect(versionDrift.join('\n')).toContain('FLEET_WIRE_PROTOCOL_VERSIONS');
+        expect(capabilityDrift.join('\n')).toContain('FLEET_WIRE_CAPABILITIES')
+    });
+
+    test('the comparator red-proves a wire-inspector fork that accepts version skew', () => {
+        const forkedTwin = {
+            ...twin,
+            wire: {
+                ...twin.wire,
+                inspectFleetWireResponse: (envelope, offer) => envelope?.protocol?.version === 2
+                    ? {ok: true}
+                    : twin.wire.inspectFleetWireResponse(envelope, offer)
+            }
+        };
+
+        expect(compareFleetVocabulary({authority, twin: forkedTwin}).join('\n'))
+            .toContain('inspectFleetWireResponse')
+    });
+
+    test('the authority selects compatible offers and names both skew classes before dispatch', () => {
+        const compatible = authorityWire.selectFleetWireContract(authorityWire.createFleetWireOffer());
+
+        expect(compatible).toEqual({
+            ok      : true,
+            protocol: authorityWire.createFleetWireProtocolStamp(),
+            state   : authorityWire.FLEET_WIRE_RESPONSE_STATES.ok
+        });
+        expect(authorityWire.selectFleetWireContract({
+            versions    : [999],
+            capabilities: [...authorityWire.FLEET_WIRE_CAPABILITIES]
+        }).state).toBe(authorityWire.FLEET_WIRE_RESPONSE_STATES.unsupportedProtocol);
+        expect(authorityWire.selectFleetWireContract({
+            versions    : [1],
+            capabilities: ['method-schema-v1']
+        }).state).toBe(authorityWire.FLEET_WIRE_RESPONSE_STATES.unsupportedCapability)
+    });
+
+    test('the finite response vocabulary is exhaustive and malformed or unoffered selections fail closed', () => {
+        const
+            offer  = authorityWire.createFleetWireOffer(),
+            states = Object.values(authorityWire.FLEET_WIRE_RESPONSE_STATES);
+
+        expect(new Set(states).size).toBe(states.length);
+        expect(states.sort()).toEqual([
+            'degraded',
+            'ok',
+            'operation-failed',
+            'refused',
+            'unsupported-capability',
+            'unsupported-method',
+            'unsupported-protocol'
+        ]);
+        expect(authorityWire.inspectFleetWireResponse(
+            authorityWire.createFleetWireResponse(authorityWire.FLEET_WIRE_RESPONSE_STATES.ok, {result: []}),
+            offer
+        )).toEqual({ok: true});
+        expect(() => authorityWire.createFleetWireResponse(authorityWire.FLEET_WIRE_RESPONSE_STATES.ok))
+            .toThrow(/requires a result/);
+
+        for (const envelope of [
+            {ok: true, result: []},
+            {ok: true, state: 'invented', protocol: authorityWire.createFleetWireProtocolStamp(), result: []},
+            {
+                ok      : true,
+                state   : authorityWire.FLEET_WIRE_RESPONSE_STATES.ok,
+                protocol: authorityWire.createFleetWireProtocolStamp()
+            },
+            authorityWire.createFleetWireResponse(authorityWire.FLEET_WIRE_RESPONSE_STATES.ok, {
+                protocol: authorityWire.createFleetWireProtocolStamp(2),
+                result  : []
+            }),
+            authorityWire.createFleetWireResponse(authorityWire.FLEET_WIRE_RESPONSE_STATES.ok, {
+                protocol: authorityWire.createFleetWireProtocolStamp(1, [...offer.capabilities, 'server-only']),
+                result  : []
+            }),
+            {
+                ...authorityWire.createFleetWireResponse(authorityWire.FLEET_WIRE_RESPONSE_STATES.ok, {result: []}),
+                ownerPrincipal: 'must-never-cross'
+            },
+            {
+                ...authorityWire.createFleetWireResponse(authorityWire.FLEET_WIRE_RESPONSE_STATES.ok, {result: []}),
+                protocol: {
+                    ...authorityWire.createFleetWireProtocolStamp(),
+                    authorization: {admin: true},
+                    bearer       : 'must-never-cross'
+                }
+            },
+            {
+                ...authorityWire.createFleetWireResponse(authorityWire.FLEET_WIRE_RESPONSE_STATES.operationFailed),
+                error: 'x'.repeat(301)
+            },
+            authorityWire.createFleetWireResponse(authorityWire.FLEET_WIRE_RESPONSE_STATES.degraded),
+            {
+                ...authorityWire.createFleetWireResponse(authorityWire.FLEET_WIRE_RESPONSE_STATES.ok, {result: []}),
+                protocol: authorityWire.createFleetWireProtocolStamp(1, [
+                    ...offer.capabilities,
+                    offer.capabilities[0]
+                ])
+            }
+        ]) {
+            expect(authorityWire.inspectFleetWireResponse(envelope, offer).ok).toBe(false)
+        }
+    });
+
+    test('the operable-cold app contract imports no ai or server trust authority', () => {
+        const sources = [
+            ['fleetWireMethods', new URL('../../../../../../apps/agentos/config/fleetWireMethods.mjs', import.meta.url)],
+            ['installFleetBridge', new URL('../../../../../../apps/agentos/fleet/installFleetBridge.mjs', import.meta.url)]
+        ];
+
+        for (const [label, url] of sources) {
+            const
+                ast     = parse(readFileSync(url, 'utf8'), {ecmaVersion: 'latest', sourceType: 'module'}),
+                imports = ast.body
+                    .filter(node => node.type === 'ImportDeclaration')
+                    .map(node => node.source.value);
+
+            expect(imports.every(source => !source.includes('/ai/') &&
+                !/fleetIngressAuth|FleetControlBridge|localBearer|Identity|ownership|authorization/i.test(source)), label)
+                .toBe(true);
+
+            if (label === 'fleetWireMethods') {
+                expect(imports, 'the app vocabulary twin must remain operable-cold').toEqual([])
+            } else {
+                expect(imports).toEqual(['../config/fleetWireMethods.mjs'])
+            }
+        }
     })
 });

--- a/test/playwright/unit/apps/agentos/fleet/fleetTransport.integration.spec.mjs
+++ b/test/playwright/unit/apps/agentos/fleet/fleetTransport.integration.spec.mjs
@@ -13,11 +13,16 @@ setup({
     }
 });
 
-import {test, expect}             from '@playwright/test';
-import Neo                        from '../../../../../../src/Neo.mjs';
-import * as core                  from '../../../../../../src/core/_export.mjs';
-import FleetRegistryService       from '../../../../../../ai/services/fleet/FleetRegistryService.mjs';
-import {startFleetBridgeServer}   from '../../../../../../ai/services/fleet/fleetBridgeServer.mjs';
+import {test, expect}           from '@playwright/test';
+import Neo                      from '../../../../../../src/Neo.mjs';
+import * as core                from '../../../../../../src/core/_export.mjs';
+import FleetRegistryService     from '../../../../../../ai/services/fleet/FleetRegistryService.mjs';
+import {startFleetBridgeServer} from '../../../../../../ai/services/fleet/fleetBridgeServer.mjs';
+import {
+    createFleetWireOffer,
+    createFleetWireRequest,
+    FLEET_WIRE_RESPONSE_STATES
+} from '../../../../../../ai/services/fleet/fleetWireMethods.mjs';
 import {installFleetBridge}       from '../../../../../../apps/agentos/fleet/installFleetBridge.mjs';
 import {generateLocalBearerToken} from '../../../../../../ai/mcp/server/shared/helpers/localBearer.mjs';
 import RequestContextService      from '../../../../../../ai/mcp/server/shared/services/RequestContextService.mjs';
@@ -146,7 +151,7 @@ test.describe('fleet transport — full-chain integration (real server + real re
 
     test('an off-allowlist method is rejected in layers: 401 unauthenticated, allowlist-refused authenticated', async () => {
         const url  = `http://127.0.0.1:${server.address().port}/fleet`,
-              body = JSON.stringify({method: 'getManager', params: 'x'});
+              body = JSON.stringify({method: 'getManager', params: 'x', protocol: createFleetWireOffer()});
 
         // Layer 1 (ingress): without the process bearer the request dies at the ingress guard —
         // the resolver-seam probe never even reaches the method allowlist.
@@ -165,6 +170,7 @@ test.describe('fleet transport — full-chain integration (real server + real re
         const envelope = await authenticated.json();
 
         expect(envelope.ok).toBe(false);
+        expect(envelope.state).toBe(FLEET_WIRE_RESPONSE_STATES.unsupportedMethod);
         expect(envelope.error).toContain('not on the control surface')
     });
 
@@ -187,7 +193,7 @@ test.describe('fleet transport — full-chain integration (real server + real re
             const admitted = await fetch(url, {
                 method : 'POST',
                 headers: {'Content-Type': 'application/json', Authorization: `Bearer ${bearerToken}`},
-                body   : JSON.stringify({method: 'resolveViewerIdentity'})
+                body   : JSON.stringify(createFleetWireRequest('resolveViewerIdentity'))
             });
             const {ok, result} = await admitted.json();
 
@@ -206,7 +212,7 @@ test.describe('fleet transport — full-chain integration (real server + real re
             const denied = await fetch(url, {
                 method : 'POST',
                 headers: {'Content-Type': 'application/json'},
-                body   : JSON.stringify({method: 'resolveViewerIdentity'})
+                body   : JSON.stringify(createFleetWireRequest('resolveViewerIdentity'))
             });
             expect(denied.status).toBe(401)
         } finally {
@@ -243,7 +249,10 @@ test.describe('fleet transport — full-chain integration (real server + real re
             const admitted = await fetch(url, {
                 method : 'POST',
                 headers: {'Content-Type': 'application/json', Authorization: `Bearer ${bearerToken}`},
-                body   : JSON.stringify({method: 'fleetMailboxMirror', params: {subjectAgentId: '@integration-viewer'}})
+                body   : JSON.stringify(createFleetWireRequest(
+                    'fleetMailboxMirror',
+                    {subjectAgentId: '@integration-viewer'}
+                ))
             });
             const {ok, result} = await admitted.json();
 
@@ -259,7 +268,10 @@ test.describe('fleet transport — full-chain integration (real server + real re
             const spoofed = await fetch(url, {
                 method : 'POST',
                 headers: {'Content-Type': 'application/json', Authorization: `Bearer ${bearerToken}`},
-                body   : JSON.stringify({method: 'fleetMailboxMirror', params: {subjectAgentId: '@integration-viewer', viewerIdentity: '@evil'}})
+                body   : JSON.stringify(createFleetWireRequest(
+                    'fleetMailboxMirror',
+                    {subjectAgentId: '@integration-viewer', viewerIdentity: '@evil'}
+                ))
             });
             const spoofEnvelope = await spoofed.json();
 
@@ -271,7 +283,10 @@ test.describe('fleet transport — full-chain integration (real server + real re
             const denied = await fetch(url, {
                 method : 'POST',
                 headers: {'Content-Type': 'application/json'},
-                body   : JSON.stringify({method: 'fleetMailboxMirror', params: {subjectAgentId: '@integration-viewer'}})
+                body   : JSON.stringify(createFleetWireRequest(
+                    'fleetMailboxMirror',
+                    {subjectAgentId: '@integration-viewer'}
+                ))
             });
 
             expect(denied.status).toBe(401);

--- a/test/playwright/unit/apps/agentos/fleet/installFleetBridge.spec.mjs
+++ b/test/playwright/unit/apps/agentos/fleet/installFleetBridge.spec.mjs
@@ -13,11 +13,25 @@ setup({
     }
 });
 
-import {test, expect}       from '@playwright/test';
-import Neo                  from '../../../../../../src/Neo.mjs';
-import * as core            from '../../../../../../src/core/_export.mjs';
-import {installFleetBridge} from '../../../../../../apps/agentos/fleet/installFleetBridge.mjs';
-import {FLEET_WIRE_METHODS} from '../../../../../../apps/agentos/config/fleetWireMethods.mjs';
+import {test, expect}          from '@playwright/test';
+import Neo                     from '../../../../../../src/Neo.mjs';
+import * as core               from '../../../../../../src/core/_export.mjs';
+import {createFleetCapability} from '../../../../../../harness/fleetCapability.mjs';
+import {
+    FLEET_LOCAL_TRANSPORT_ERRORS,
+    installFleetBridge
+} from '../../../../../../apps/agentos/fleet/installFleetBridge.mjs';
+import {
+    createFleetWireOffer,
+    createFleetWireProtocolStamp,
+    createFleetWireRequest,
+    createFleetWireResponse,
+    FLEET_CREDENTIAL_METHODS,
+    FLEET_WIRE_CAPABILITIES,
+    FLEET_WIRE_METHODS,
+    FLEET_WIRE_RESPONSE_STATES,
+    inspectFleetWireResponse
+} from '../../../../../../apps/agentos/config/fleetWireMethods.mjs';
 
 // installFleetBridge is the App-Worker wiring that publishes globalThis.AgentOS.fleet.registryBridge.
 // Tests inject a `target` object (instead of the real globalThis) + a stub `fetchImpl`, so the global
@@ -25,7 +39,9 @@ import {FLEET_WIRE_METHODS} from '../../../../../../apps/agentos/config/fleetWir
 
 const fleetUrl   = 'http://127.0.0.1:8083/fleet',
       testBearer = 'A'.repeat(43), // canonical FORMAT (client checks shape only; the server owns real verification)
-      okFetch    = () => async () => ({json: async () => ({ok: true, result: null})});
+      okFetch    = () => async () => ({
+          json: async () => createFleetWireResponse(FLEET_WIRE_RESPONSE_STATES.ok, {result: null})
+      });
 
 test.describe('installFleetBridge — App-Worker wiring of the dev-server app<->fleet HTTP transport', () => {
     test('the selected flag: default install is unselected; the injector-style install stamps selected', () => {
@@ -60,7 +76,7 @@ test.describe('installFleetBridge — App-Worker wiring of the dev-server app<->
                 credentialIngress: 'shell',
                 send             : async request => {
                     calls.push(request);
-                    return {ok: true, result: [{id: 'alice'}]}
+                    return createFleetWireResponse(FLEET_WIRE_RESPONSE_STATES.ok, {result: [{id: 'alice'}]})
                 },
                 target
             }),
@@ -77,18 +93,64 @@ test.describe('installFleetBridge — App-Worker wiring of the dev-server app<->
         })
     });
 
+    test('the packaged App Worker to Electron-main composition keeps protocol metadata main-owned', async () => {
+        const
+            event          = {sender: 'trusted'},
+            ipcRequests    = [],
+            serverRequests = [],
+            capability     = createFleetCapability({
+                bearerToken       : testBearer,
+                createWireOffer   : createFleetWireOffer,
+                createWireRequest : createFleetWireRequest,
+                createWireResponse: createFleetWireResponse,
+                credentialMethods : FLEET_CREDENTIAL_METHODS,
+                fetchImpl         : async (url, init) => {
+                    serverRequests.push({request: JSON.parse(init.body), url});
+
+                    return {
+                        json: async () => createFleetWireResponse(FLEET_WIRE_RESPONSE_STATES.ok, {
+                            result: [{id: 'alice'}]
+                        })
+                    }
+                },
+                getBrain           : async () => ({fleetPort: 9191, up: true}),
+                inspectWireResponse: inspectFleetWireResponse,
+                isTrustedSender    : candidate => candidate === event,
+                responseStates     : FLEET_WIRE_RESPONSE_STATES,
+                wireMethods        : FLEET_WIRE_METHODS
+            }),
+            bridge = installFleetBridge({
+                credentialIngress: 'shell',
+                send             : request => {
+                    ipcRequests.push(request);
+                    return capability.request(event, request)
+                },
+                target: {}
+            });
+
+        await expect(bridge.listAgents()).resolves.toEqual([{id: 'alice'}]);
+        expect(ipcRequests).toEqual([{method: 'listAgents', params: undefined}]);
+        expect(serverRequests).toEqual([{
+            request: createFleetWireRequest('listAgents', undefined),
+            url    : 'http://127.0.0.1:9191/fleet'
+        }])
+    });
+
     test('rejects mixed direct-browser and injected-shell transport ownership', () => {
-        const send = async () => ({ok: true, result: null});
+        const send = async () => createFleetWireResponse(FLEET_WIRE_RESPONSE_STATES.ok, {result: null});
 
         expect(() => installFleetBridge({send, target: {}, url: fleetUrl})).toThrow(/mutually exclusive/);
         expect(() => installFleetBridge({bearerToken: testBearer, send, target: {}})).toThrow(/mutually exclusive/);
         expect(() => installFleetBridge({credentialIngress: 'shell', target: {}, url: fleetUrl})).toThrow(/requires an injected send/)
     });
 
-    test('defineAgent POSTs {method, params} with the Authorization bearer + resolves the envelope result', async () => {
+    test('defineAgent POSTs a main-owned protocol offer with the bearer + resolves the validated result', async () => {
         const calls     = [];
-        const fetchImpl = async (url, init) => { calls.push({url, init}); return {json: async () => ({ok: true, result: {id: 'alice'}})} };
-        const target    = {};
+        const fetchImpl = async (url, init) => {
+            calls.push({url, init});
+            return {json: async () => createFleetWireResponse(FLEET_WIRE_RESPONSE_STATES.ok, {result: {id: 'alice'}})}
+        };
+        const target = {};
 
         installFleetBridge({url: 'http://localhost:9191/fleet', bearerToken: testBearer, fetchImpl, target});
         const res = await target.AgentOS.fleet.registryBridge.defineAgent({githubUsername: 'alice', harnessType: 'codex'});
@@ -98,13 +160,18 @@ test.describe('installFleetBridge — App-Worker wiring of the dev-server app<->
         expect(calls[0].url).toBe('http://localhost:9191/fleet');
         expect(calls[0].init.method).toBe('POST');
         expect(calls[0].init.headers.Authorization).toBe(`Bearer ${testBearer}`);
-        expect(JSON.parse(calls[0].init.body)).toEqual({method: 'defineAgent', params: {githubUsername: 'alice', harnessType: 'codex'}})
+        expect(JSON.parse(calls[0].init.body)).toEqual(
+            createFleetWireRequest('defineAgent', {githubUsername: 'alice', harnessType: 'codex'})
+        )
     });
 
     test('without a bearer every call rejects LOCALLY — the fail-closed unlaunched state sends no network traffic', async () => {
         const calls     = [];
-        const fetchImpl = async (...args) => { calls.push(args); return {json: async () => ({ok: true, result: null})} };
-        const target    = {};
+        const fetchImpl = async (...args) => {
+            calls.push(args);
+            return {json: async () => createFleetWireResponse(FLEET_WIRE_RESPONSE_STATES.ok, {result: null})}
+        };
+        const target = {};
 
         installFleetBridge({url: fleetUrl, fetchImpl, target});
 
@@ -140,6 +207,67 @@ test.describe('installFleetBridge — App-Worker wiring of the dev-server app<->
         installFleetBridge({url: fleetUrl, fetchImpl: okFetch(), target});
         const second = installFleetBridge({url: fleetUrl, fetchImpl: okFetch(), target});
         expect(target.AgentOS.fleet.registryBridge).toBe(second)
+    });
+
+    test('malformed, version-skewed, and capability-skewed replies never become pane data', async () => {
+        const responses = [
+            {ok: true, state: 'invented', protocol: createFleetWireProtocolStamp(), result: []},
+            {ok: true, state: FLEET_WIRE_RESPONSE_STATES.ok, protocol: createFleetWireProtocolStamp()},
+            createFleetWireResponse(FLEET_WIRE_RESPONSE_STATES.ok, {
+                protocol: createFleetWireProtocolStamp(2),
+                result  : []
+            }),
+            createFleetWireResponse(FLEET_WIRE_RESPONSE_STATES.ok, {
+                protocol: createFleetWireProtocolStamp(1, [...FLEET_WIRE_CAPABILITIES, 'server-only']),
+                result  : []
+            }),
+            {
+                ...createFleetWireResponse(FLEET_WIRE_RESPONSE_STATES.ok, {result: []}),
+                protocol: {...createFleetWireProtocolStamp(), ownerPrincipal: 'must-never-cross'}
+            }
+        ];
+
+        for (const response of responses) {
+            const bridge = installFleetBridge({
+                credentialIngress: 'shell',
+                send             : async () => response,
+                target           : {}
+            });
+
+            await expect(bridge.listAgents()).rejects.toThrow(/malformed|unoffered/)
+        }
+    });
+
+    test('transport and JSON-parser rejection text is never relayed into the pane', async () => {
+        const secret  = 'raw-upstream-transport-secret';
+        const bridges = [
+            installFleetBridge({
+                credentialIngress: 'shell',
+                send             : async () => { throw new Error(secret) },
+                target           : {}
+            }),
+            installFleetBridge({
+                bearerToken: testBearer,
+                fetchImpl  : async () => ({json: async () => { throw new Error(secret) }}),
+                target     : {},
+                url        : fleetUrl
+            })
+        ];
+
+        for (const bridge of bridges) {
+            await expect(bridge.listAgents()).rejects.toThrow('fleet: request transport failed');
+            await expect(bridge.listAgents()).rejects.not.toThrow(secret)
+        }
+    });
+
+    test('known local launch-state errors retain their bounded remediation', async () => {
+        const bridge = installFleetBridge({
+            credentialIngress: 'shell',
+            send             : async () => { throw new Error(FLEET_LOCAL_TRANSPORT_ERRORS.noLiveWindow) },
+            target           : {}
+        });
+
+        await expect(bridge.listAgents()).rejects.toThrow(FLEET_LOCAL_TRANSPORT_ERRORS.noLiveWindow)
     });
 
     test('fails loud before publishing when the fleet endpoint is missing or invalid', () => {

--- a/test/playwright/unit/harness/brain.spec.mjs
+++ b/test/playwright/unit/harness/brain.spec.mjs
@@ -6,6 +6,10 @@ import net                                                  from 'node:net';
 import {tmpdir}                                             from 'node:os';
 import path                                                 from 'node:path';
 import {
+    createFleetWireResponse,
+    FLEET_WIRE_RESPONSE_STATES
+} from '../../../../ai/services/fleet/fleetWireMethods.mjs';
+import {
     allocatePort,
     assertIsolatedProfile,
     awaitFleetReady,
@@ -293,7 +297,7 @@ test.describe('harness brain lifecycle', () => {
             .rejects.toThrow(/not ready within 120ms/)
     });
 
-    test('awaitFleetReady polls through failures and requires a real ok:true wire envelope', async () => {
+    test('awaitFleetReady polls through failures and refuses a legacy ok:true envelope', async () => {
         const child = createFakeChild();
 
         let calls = 0;
@@ -303,17 +307,26 @@ test.describe('harness brain lifecycle', () => {
             expect(url).toContain('/fleet');
             expect(url).not.toContain(bearerToken);
             expect(init.headers.Authorization).toBe(`Bearer ${bearerToken}`);
-            expect(JSON.parse(init.body).method).toBe('listAgents');
+            expect(JSON.parse(init.body)).toMatchObject({
+                method  : 'listAgents',
+                protocol: {versions: [1]}
+            });
 
             if (calls < 3) {
                 throw new Error('ECONNREFUSED')
             }
 
-            return {json: async () => ({ok: true, result: []})}
+            if (calls === 3) {
+                return {json: async () => ({ok: true, result: []})}
+            }
+
+            return {
+                json: async () => createFleetWireResponse(FLEET_WIRE_RESPONSE_STATES.ok, {result: []})
+            }
         };
 
         await expect(awaitFleetReady({bearerToken, child, fetchFn, port: 18501, timeoutMs: 5000})).resolves.toBeUndefined();
-        expect(calls).toBeGreaterThanOrEqual(3)
+        expect(calls).toBeGreaterThanOrEqual(4)
     });
 
     test('awaitFleetReady rejects when the transport child dies first', async () => {
@@ -323,6 +336,23 @@ test.describe('harness brain lifecycle', () => {
 
         child.exit(1);
         await expect(ready).rejects.toThrow(/fleet transport exited before ready/)
+    });
+
+    test('awaitFleetReady fails closed when the authoritative wire contract cannot load', async () => {
+        const
+            child    = createFakeChild(),
+            repoRoot = await mkdtemp(path.join(tmpdir(), 'neo-fleet-wire-missing-'));
+
+        await rm(repoRoot, {recursive: true});
+
+        await expect(awaitFleetReady({
+            bearerToken,
+            child,
+            fetchFn  : async () => { throw new Error('fetch must not run') },
+            port     : 18501,
+            repoRoot,
+            timeoutMs: 5000
+        })).rejects.toThrow(/fleet wire contract unavailable/)
     });
 
     // SIGINT is the graceful rung by measurement: the chromadb npm wrapper ignores group-SIGTERM

--- a/test/playwright/unit/harness/fleetCapability.spec.mjs
+++ b/test/playwright/unit/harness/fleetCapability.spec.mjs
@@ -4,14 +4,27 @@ import {
     projectPublicAgentIntent,
     projectPublicCredentialIntent
 } from '../../../../harness/fleetCapability.mjs';
-import {FLEET_CREDENTIAL_METHODS, FLEET_WIRE_METHODS} from '../../../../ai/services/fleet/fleetWireMethods.mjs';
+import {
+    createFleetWireOffer,
+    createFleetWireRequest,
+    createFleetWireResponse,
+    FLEET_CREDENTIAL_METHODS,
+    FLEET_WIRE_METHODS,
+    FLEET_WIRE_RESPONSE_STATES,
+    inspectFleetWireResponse
+} from '../../../../ai/services/fleet/fleetWireMethods.mjs';
 
 const bearerToken = 'B'.repeat(43);
 
 const createCapability = options => createFleetCapability({
     bearerToken,
-    credentialMethods: FLEET_CREDENTIAL_METHODS,
-    wireMethods      : FLEET_WIRE_METHODS,
+    createWireOffer    : createFleetWireOffer,
+    createWireRequest  : createFleetWireRequest,
+    createWireResponse : createFleetWireResponse,
+    credentialMethods  : FLEET_CREDENTIAL_METHODS,
+    inspectWireResponse: inspectFleetWireResponse,
+    responseStates     : FLEET_WIRE_RESPONSE_STATES,
+    wireMethods        : FLEET_WIRE_METHODS,
     ...options
 });
 
@@ -22,15 +35,16 @@ test.describe('harness Fleet capability', () => {
             getBrain         : async () => ({fleetPort: 8083, up: true}),
             isTrustedSender  : () => true,
             wireMethods      : ['defineAgent']
-        })).toThrow(/canonical method allowlists/);
+        })).toThrow(/canonical wire contract/);
 
         const
             credentialMethods = [],
             wireMethods       = ['listAgents'],
-            capability        = createFleetCapability({
-                bearerToken,
+            capability        = createCapability({
                 credentialMethods,
-                fetchImpl      : async () => ({json: async () => ({ok: true, result: []})}),
+                fetchImpl      : async () => ({
+                    json: async () => createFleetWireResponse(FLEET_WIRE_RESPONSE_STATES.ok, {result: []})
+                }),
                 getBrain       : async () => ({fleetPort: 8083, up: true}),
                 isTrustedSender: () => true,
                 wireMethods
@@ -39,7 +53,11 @@ test.describe('harness Fleet capability', () => {
         credentialMethods.push('listAgents');
         wireMethods.length = 0;
 
-        await expect(capability.request({}, {method: 'listAgents', params: {}})).resolves.toEqual({ok: true, result: []})
+        await expect(capability.request({}, {method: 'listAgents', params: {}})).resolves.toMatchObject({
+            ok    : true,
+            result: [],
+            state : FLEET_WIRE_RESPONSE_STATES.ok
+        })
     });
 
     test('checks sender trust before inspecting the request or touching credential, readiness, and network seams', async () => {
@@ -61,9 +79,10 @@ test.describe('harness Fleet capability', () => {
                 isTrustedSender   : () => false
             });
 
-        await expect(capability.request({sender: 'untrusted'}, request)).resolves.toEqual({
+        await expect(capability.request({sender: 'untrusted'}, request)).resolves.toMatchObject({
             error: 'fleet: untrusted shell sender',
-            ok   : false
+            ok   : false,
+            state: FLEET_WIRE_RESPONSE_STATES.refused
         });
         expect(calls).toEqual({brain: 0, credential: 0, fetch: 0})
     });
@@ -84,6 +103,7 @@ test.describe('harness Fleet capability', () => {
                 {method: 42},
                 {method: 'getManager'},
                 {extra: true, method: 'listAgents'},
+                {method: 'listAgents', protocol: createFleetWireOffer()},
                 {method: 'defineAgent', params: {githubUsername: '', harnessType: 'codex'}},
                 {method: 'connectTenant', params: {tenantUrl: ''}}
             ];
@@ -110,16 +130,18 @@ test.describe('harness Fleet capability', () => {
         await expect(capability.request({}, {
             method: 'defineAgent',
             params: {githubUsername: 'alice', harnessType: 'codex'}
-        })).resolves.toEqual({
+        })).resolves.toMatchObject({
             error: "fleet: shell credential ingress unavailable for 'defineAgent'",
-            ok   : false
+            ok   : false,
+            state: FLEET_WIRE_RESPONSE_STATES.refused
         });
         await expect(capability.request({}, {
             method: 'connectTenant',
             params: {tenantUrl: 'https://tenant.example.com'}
-        })).resolves.toEqual({
+        })).resolves.toMatchObject({
             error: "fleet: shell credential ingress unavailable for 'connectTenant'",
-            ok   : false
+            ok   : false,
+            state: FLEET_WIRE_RESPONSE_STATES.refused
         });
 
         expect(calls).toEqual({brain: 0, fetch: 0})
@@ -136,7 +158,12 @@ test.describe('harness Fleet capability', () => {
                 credentialProvider: async input => { calls.credential.push(input); return mainCredential },
                 fetchImpl         : async (url, init) => {
                     calls.fetch.push({init, url});
-                    return {json: async () => ({ok: true, result: {id: 'agent-alice'}})}
+                    return {
+                        json: async () => createFleetWireResponse(
+                            FLEET_WIRE_RESPONSE_STATES.ok,
+                            {result: {id: 'agent-alice'}}
+                        )
+                    }
                 },
                 getBrain       : async () => ({fleetPort: 9191, up: true}),
                 isTrustedSender: candidate => candidate === event
@@ -156,7 +183,11 @@ test.describe('harness Fleet capability', () => {
                 }
             });
 
-        expect(result).toEqual({ok: true, result: {id: 'agent-alice'}});
+        expect(result).toMatchObject({
+            ok    : true,
+            result: {id: 'agent-alice'},
+            state : FLEET_WIRE_RESPONSE_STATES.ok
+        });
         expect(calls.credential).toEqual([{
             event,
             intent: {
@@ -179,7 +210,8 @@ test.describe('harness Fleet capability', () => {
                 githubUsername: 'alice',
                 harnessType   : 'codex',
                 id            : 'agent-alice'
-            }
+            },
+            protocol: createFleetWireOffer()
         });
         expect(JSON.stringify(outbound)).not.toContain(rendererCredential);
         expect(JSON.stringify(outbound)).not.toContain('renderer-command');
@@ -204,7 +236,12 @@ test.describe('harness Fleet capability', () => {
                 credentialProvider: async input => { calls.credential.push(input); return mainCredential },
                 fetchImpl         : async (url, init) => {
                     calls.fetch.push({init, url});
-                    return {json: async () => ({ok: true, result: {status: 'connected'}})}
+                    return {
+                        json: async () => createFleetWireResponse(
+                            FLEET_WIRE_RESPONSE_STATES.ok,
+                            {result: {status: 'connected'}}
+                        )
+                    }
                 },
                 getBrain       : async () => ({fleetPort: 8083, up: true}),
                 isTrustedSender: candidate => candidate === event
@@ -218,7 +255,11 @@ test.describe('harness Fleet capability', () => {
                 }
             });
 
-        expect(result).toEqual({ok: true, result: {status: 'connected'}});
+        expect(result).toMatchObject({
+            ok    : true,
+            result: {status: 'connected'},
+            state : FLEET_WIRE_RESPONSE_STATES.ok
+        });
         expect(calls.credential).toEqual([{
             event,
             intent: {tenantUrl: 'https://tenant.example.com/agentos/'},
@@ -230,7 +271,8 @@ test.describe('harness Fleet capability', () => {
             params: {
                 credential: mainCredential,
                 tenantUrl : 'https://tenant.example.com/agentos/'
-            }
+            },
+            protocol: createFleetWireOffer()
         });
         expect(projectPublicCredentialIntent('connectTenant', {
             credential: 'discard-me',
@@ -252,9 +294,10 @@ test.describe('harness Fleet capability', () => {
         await expect(capability.request({}, {
             method: 'defineAgent',
             params: {githubUsername: 'alice', harnessType: 'codex'}
-        })).resolves.toEqual({
+        })).resolves.toMatchObject({
             error: "fleet: shell credential ingress canceled for 'defineAgent'",
-            ok   : false
+            ok   : false,
+            state: FLEET_WIRE_RESPONSE_STATES.refused
         });
         expect(calls).toEqual({brain: 0, fetch: 0})
     });
@@ -267,7 +310,9 @@ test.describe('harness Fleet capability', () => {
                     bearerToken,
                     credentialProvider: async () => mainCredential,
                     fetchImpl         : async () => ({
-                        json: async () => ({ok: false, error: `upstream reflected ${reflectedSecret}`})
+                        json: async () => createFleetWireResponse(FLEET_WIRE_RESPONSE_STATES.operationFailed, {
+                            error: `upstream reflected ${reflectedSecret}`
+                        })
                     }),
                     getBrain       : async () => ({fleetPort: 8083, up: true}),
                     isTrustedSender: () => true
@@ -277,8 +322,86 @@ test.describe('harness Fleet capability', () => {
                     params: {githubUsername: 'alice', harnessType: 'codex'}
                 });
 
-            expect(result).toEqual({error: 'fleet: secret-bearing response rejected', ok: false});
+            expect(result).toMatchObject({
+                error: 'fleet: secret-bearing response rejected',
+                ok   : false,
+                state: FLEET_WIRE_RESPONSE_STATES.refused
+            });
             expect(JSON.stringify(result)).not.toContain(reflectedSecret)
+        }
+    });
+
+    test('censuses escaped provider credentials from failure text and nested success data', async () => {
+        const credentials = [
+            'github_pat_quote_"_value',
+            'github_pat_backslash_\\_value',
+            'github_pat_newline_\n_value',
+            '  github_pat_trimmed_value  '
+        ];
+
+        for (const credential of credentials) {
+            for (const reflection of new Set([credential, credential.trim()])) {
+                for (const envelope of [
+                    createFleetWireResponse(FLEET_WIRE_RESPONSE_STATES.operationFailed, {
+                        error: `upstream reflected ${reflection}`
+                    }),
+                    createFleetWireResponse(FLEET_WIRE_RESPONSE_STATES.ok, {
+                        result: {nested: {credential: reflection}}
+                    }),
+                    createFleetWireResponse(FLEET_WIRE_RESPONSE_STATES.ok, {
+                        result: {nested: {[reflection]: 'reflected key'}}
+                    })
+                ]) {
+                    const capability = createCapability({
+                            bearerToken,
+                            credentialProvider: async () => credential,
+                            fetchImpl         : async () => ({json: async () => envelope}),
+                            getBrain          : async () => ({fleetPort: 8083, up: true}),
+                            isTrustedSender   : () => true
+                        }),
+                        result = await capability.request({}, {
+                            method: 'defineAgent',
+                            params: {githubUsername: 'alice', harnessType: 'codex'}
+                        });
+
+                    expect(result).toEqual(createFleetWireResponse(FLEET_WIRE_RESPONSE_STATES.refused, {
+                        error: 'fleet: secret-bearing response rejected'
+                    }))
+                }
+            }
+        }
+    });
+
+    test('a skewed or malformed server reply is returned only as a closed local refusal', async () => {
+        const replies = [
+            {ok: true, result: []},
+            {ok: true, state: FLEET_WIRE_RESPONSE_STATES.ok, protocol: createFleetWireResponse(
+                FLEET_WIRE_RESPONSE_STATES.ok,
+                {result: []}
+            ).protocol},
+            createFleetWireResponse(FLEET_WIRE_RESPONSE_STATES.ok, {
+                protocol: {version: 2, capabilities: createFleetWireOffer().capabilities},
+                result  : []
+            }),
+            {
+                ...createFleetWireResponse(FLEET_WIRE_RESPONSE_STATES.ok, {result: []}),
+                protocol: {
+                    ...createFleetWireResponse(FLEET_WIRE_RESPONSE_STATES.ok, {result: []}).protocol,
+                    bearer: 'must-never-cross'
+                }
+            }
+        ];
+
+        for (const reply of replies) {
+            const capability = createCapability({
+                fetchImpl      : async () => ({json: async () => reply}),
+                getBrain       : async () => ({fleetPort: 8083, up: true}),
+                isTrustedSender: () => true
+            });
+            const result = await capability.request({}, {method: 'listAgents'});
+
+            expect(result).toMatchObject({ok: false, state: FLEET_WIRE_RESPONSE_STATES.refused});
+            expect(result.error).toMatch(/malformed|unoffered/)
         }
     })
 });


### PR DESCRIPTION
Resolves neomjs/neo#16743
Related: neomjs/neo#13015
Related: neomjs/neo#16747

Publishes the complete client-safe Fleet wire contract across the Brain authority and operable-cold app twin: protocol/version offers, required capabilities, finite response states, exact envelope validation, and composition through Node, browser, Electron, and Brain readiness consumers. Server trust decisions stay server-side; the Body receives only selected-contract envelopes and public results.

Evidence: L2 (194 focused unit/integration tests at `42fc7a769e`, including real in-process HTTP, App Worker -> IPC -> Electron-main composition, and the onboarding transport-remediation seam) -> L2 required (all neomjs/neo#16743 close criteria are executable contract criteria). No known product residuals. The seven headed Fleet journeys remain `NOT_MEASURED` on this host because Chromium aborted before any app assertion; they are retained as post-merge/CI validation rather than presented as evidence.

## Deltas from ticket

- The packaged-shell composition exposed an ownership mismatch not named explicitly in the ledger: the App Worker must send only `{method, params}`, while Electron main owns the version/capability offer and bearer. The change now proves that real composition rather than each half in isolation.
- Pre-dispatch Host and authentication middleware can terminate before Fleet dispatch. The exact `/fleet` response boundary now normalizes every error-status body shape into the finite Fleet refusal envelope while preserving status and security headers. `/fleet/probe` remains explicitly out of band.
- Electron main now performs a recursive, cycle-safe census of response keys and string values against bearer/provider credentials, including escaped and whitespace-normalized forms, before anything can cross to the renderer.
- Raw transport and JSON-parser rejection text is collapsed at both client factories into stable local remediation; upstream details never become pane-visible errors. A trusted Node caller may select one static bounded recovery string without interpolating the rejected error or endpoint.
- Seven existing Fleet E2E fixtures emitted the legacy unversioned `{ok, result|error}` shape. They now use the canonical versioned success/failure envelopes so their eventual headed assertions exercise the production client contract.
- No Fleet vocabulary moved into `ai/services.host.mjs`: neomjs/neo#16728 remains the host executable-plane barrel precedent, while this ticket publishes through the existing dependency-free authority plus mechanically bound app twin exactly as its live dependency correction specifies.

## Test Evidence

- `npm run test-unit -- <11 Fleet contract/composition/onboarding specs>` at `42fc7a769e` — **194 passed**.
- `npm run --silent ai:lint-fleet-vocabulary-parity` — passed; constants and shared helper behavior match across the realm boundary.
- `npm run --silent ai:lint-openapi-service-parity` — passed; 40 services, 121 operation-bound methods, 142 object-dispatch handlers, zero consumed-but-undeclared parameters.
- `git diff --check origin/dev...HEAD` — passed.
- Independent adversarial falsification at pre-CI head `1fd5197f82` over `origin/dev@55219f40d8` found zero remaining required-action defects. The follow-up CI repair is limited to preserving a caller-owned static onboarding recovery string while keeping raw exception and endpoint data censored; the exact-head 194-test battery includes positive recovery and negative secret-reflection witnesses.

The focused battery covers compatible negotiation; protocol/capability skew; malformed and nested-smuggling envelopes; every finite state; bridge non-dispatch on incompatible offers; packaged shell composition; hostile Host and built-in/custom authentication terminations; direct `send`/`end` response shapes and callbacks; success envelopes on HTTP error status; quote, slash, newline, and trimmed secret reflections in errors, nested values, and nested keys; raw transport/parser failures; and bounded caller-owned transport remediation without raw exception or endpoint disclosure.

**Honest boundary:** the explicit headed Agent OS Fleet run launched no product assertion on this host: seven Chromium processes aborted with `SIGABRT`, and one spec encountered an unrelated occupied port at `8083`. This is infrastructure `NOT_MEASURED`, not a product pass or product failure.

## Post-Merge Validation

Owner: @neo-gpt-emmy.

- [ ] Run the seven Fleet journeys on a Chromium-capable CI/host and confirm the application assertions against the canonical envelopes.
- [ ] Verify packaged Electron App Worker -> IPC -> main -> Fleet composition in a packaged build, beyond the real-function in-process composition witness.

Decision Record: REQUIRED -> neomjs/neo#16747.

## Signal Ledger

- `fable`: `AUTHOR_SIGNAL` + `APPROVED`; D#16720 final close ledger `DC_kwDODSospM4BEdYr`, approval `DC_kwDODSospM4BEdXe`.
- `opus`: `APPROVED` by Vega at `DC_kwDODSospM4BEdXn`.
- `gpt`: `[GRADUATION_APPROVED]` at filed-state anchor `DC_kwDODSospM4BEdZK`.

## Unresolved Dissent

None at the filed state. Earlier deferrals were repaired and re-stamped before graduation.

## Unresolved Liveness

Gemini was operator-benched. Kimi contributed a substantive production witness without a final-anchor signal; no consent is implied.

## Discussion Criteria Mapping

- D#16720 Concept 6 / OQ7 protocol-contract carriage -> neomjs/neo#16743: complete client-safe method/schema/version/capability/state vocabulary, negotiation before policy/dispatch, and fail-closed clients.
- D#16720 criterion 7 remote-only journey -> neomjs/neo#16743: the cockpit imports no Brain trust authority and accepts no unselected or malformed server result.
- D#16720 criterion 9 release binding -> neomjs/neo#16743: v13.2 milestone retained.
- D#16720 decision-record requirement -> neomjs/neo#16747: unchanged and explicitly linked above.
- S7 neomjs/neo-agent-brain#50 continues to own wake delivery over ingress; this PR makes no wake-delivery claim.

Authored by Emmy (GPT-5.6 Sol Ultra, Codex). Session 524c5eaf-d48b-48ac-872d-5e9cdb5fe9a4.
