### PR TITLE
feat(ai): wake poll-digest action derives the caller digest at read time (#16741)

### DIFF
--- a/ai/mcp/server/memory-core/openapi.yaml
+++ b/ai/mcp/server/memory-core/openapi.yaml
@@ -2463,7 +2463,7 @@ paths:
       operationId: manage_wake_subscription
       x-neo-tool-tier: extended
       x-pass-as-object: true
-      description: Subscribe / unsubscribe / update / list / resync / resume / rotate-key agent wake-event subscriptions with trigger types (SENT_TO_ME, TASK_STATE_CHANGED, PERMISSION_GRANTED), optional AND-conjunctive filters, and harness target routing. `fleet-identities` is the fleet-telemetry read — the deduplicated identities holding an ACTIVE subscription, identities only, for any authenticated caller (the `who_is_online` disclosure class).
+      description: Subscribe / unsubscribe / update / list / resync / resume / rotate-key agent wake-event subscriptions with trigger types (SENT_TO_ME, TASK_STATE_CHANGED, PERMISSION_GRANTED), optional AND-conjunctive filters, and harness target routing. `fleet-identities` is the fleet-telemetry read — the deduplicated identities holding an ACTIVE subscription, identities only, for any authenticated caller (the `who_is_online` disclosure class). `poll-digest` derives the caller's wake digest at read time over the same trigger/filter evaluation — the pull half of wake delivery for clients without host-reachable listeners; an empty answer is a closed state carrying its reason, never a verdict.
       tags: [WakeSubscriptions]
       requestBody:
         required: true
@@ -2476,11 +2476,11 @@ paths:
               properties:
                 action:
                   type: string
-                  enum: [bootstrap, subscribe, unsubscribe, update, list, resync, resume, rotate-key, fleet-identities]
+                  enum: [bootstrap, subscribe, unsubscribe, update, list, resync, poll-digest, resume, rotate-key, fleet-identities]
                   description: "Lifecycle action to perform on the subscription. `resume` restores a route that was marked `status: degraded` after repeated delivery failures: it moves the persisted status back to `active` AND clears the in-flight markers in one step, which is what a restore requires - clearing only one half leaves the route skipped."
                 subscriptionId:
                   type: string
-                  description: Required for unsubscribe / update / resync / resume / rotate-key; optional for list (single).
+                  description: Required for unsubscribe / update / resync / poll-digest / resume / rotate-key; optional for list (single).
                 trigger:
                   type: string
                   enum: [SENT_TO_ME, TASK_STATE_CHANGED, PERMISSION_GRANTED]
@@ -2519,7 +2519,7 @@ paths:
                     tmuxSession:      {type: string}
                 sinceLogId:
                   type: integer
-                  description: Required for resync. GraphLog watermark; client-tracked.
+                  description: Required for resync / poll-digest. GraphLog watermark; client-tracked.
       responses:
         '200':
           description: OK

--- a/ai/services/memory-core/WakeSubscriptionService.mjs
+++ b/ai/services/memory-core/WakeSubscriptionService.mjs
@@ -10,6 +10,7 @@ import CoalescingEngineService                                                  
 import TurnPresenceService                                                                      from './TurnPresenceService.mjs';
 import WebhookDeliveryService                                                                   from './WebhookDeliveryService.mjs';
 import {DELIVERABLE_HARNESS_TARGET}                                                             from '../../daemons/wake/buildReceiverManifest.mjs';
+import {buildWakeDigest, getHighestWakePriority}                                                from '../../daemons/wake/wakeDigestBuilder.mjs';
 import {HEARTBEAT_PULSE_ENTITY_PREFIX, HEARTBEAT_PULSE_ENTITY_TYPE, match, matchHeartbeatPulse} from './heartbeatPulseEvaluator.mjs';
 import {resolveResidentFamilyById}                                                              from '../graph/agentFamilyResolution.mjs';
 import {readActiveWakeSubscriptionIdentities}                                                   from './readActiveWakeSubscriptionIdentities.mjs';
@@ -390,7 +391,7 @@ class WakeSubscriptionService extends Base {
      * action-specific handlers per ADR 0002 §6.6. ticket-ref-ok: decision-record authority, not issue archaeology
      *
      * @param {Object} opts
-     * @param {String} opts.action One of 'subscribe' | 'unsubscribe' | 'update' | 'list' | 'resync' | 'resume' | 'rotate-key' | 'fleet-identities'
+     * @param {String} opts.action One of 'subscribe' | 'unsubscribe' | 'update' | 'list' | 'resync' | 'poll-digest' | 'resume' | 'rotate-key' | 'fleet-identities'
      * @param {Object} [opts.rest] Action-specific parameters (see individual methods)
      * @returns {Promise<Object>}
      */
@@ -405,12 +406,13 @@ class WakeSubscriptionService extends Base {
             case 'unsubscribe'     : return this.unsubscribe(rest);
             case 'update'          : return this.update     (rest);
             case 'list'            : return this.list       (rest);
+            case 'poll-digest'     : return this.pollDigest (rest);
             case 'resync'          : return this.resync     (rest);
             case 'resume'          : return this.resume     (rest);
             case 'rotate-key'      : return this.rotateKey  (rest);
             default:
                 throw new Error(
-                    `Invalid action '${action}'. Must be one of: bootstrap, fleet-identities, subscribe, unsubscribe, update, list, resync, resume, rotate-key.`
+                    `Invalid action '${action}'. Must be one of: bootstrap, fleet-identities, subscribe, unsubscribe, update, list, poll-digest, resync, resume, rotate-key.`
                 );
         }
     }
@@ -1483,10 +1485,94 @@ class WakeSubscriptionService extends Base {
             throw new Error(`Permission denied: subscription ${subscriptionId} is owned by ${subscription.agentIdentity}, not ${caller}.`);
         }
 
+        const {events, lastLogId} = this._collectSubscriptionEvents(subscription, sinceLogId);
+
+        return {
+            subscriptionId,
+            events,
+            lastLogId,
+            eventsReplayed: events.length
+        };
+    }
+
+    /**
+     * @summary Derives the caller's wake digest AT READ TIME — the pull half of wake delivery
+     * for clients without host-reachable listeners.
+     *
+     * Composes the daemon's flush semantics from the same shared parts: events above the
+     * client-held `sinceLogId` watermark are collected by the same trigger/filter evaluation
+     * `resync` consumes — whose shared `match()` evaluator already reconciles CURRENT read state
+     * per delivery shape, so a wake for an already-read message never matches — and the
+     * survivors pass through the daemon's own `buildWakeDigest`. Nothing is queued server-side:
+     * a missed poll re-includes anything still unread on the next call, the self-healing
+     * property the push path documents. An empty answer is a CLOSED state carrying its reason,
+     * always distinguishable from a transport failure — absence of signal, never a verdict.
+     *
+     * Per ADR 0002 §6.1.6 + §6.6.2 (resync's authority) + ADR 0038 §2.5.1 row 6. ticket-ref-ok: decision-record authority, not issue archaeology
+     *
+     * @param {Object} opts
+     * @param {String} opts.subscriptionId
+     * @param {Number} [opts.sinceLogId=0] GraphLog watermark; client-tracked, never server-persisted
+     * @returns {Promise<Object>} `{subscriptionId, pending, watermark, reason}` when empty, else
+     * `{subscriptionId, pending, digest, digestPriority, watermark, eventsReplayed}`
+     */
+    async pollDigest({subscriptionId, sinceLogId = 0} = {}) {
+        const caller = RequestContextService.getAgentIdentityNodeId();
+        if (!caller) throw RequestContextService.unboundIdentityError('poll-digest');
+        if (!subscriptionId) throw new Error("Missing 'subscriptionId' parameter.");
+
+        const subscription = this._loadSubscription(subscriptionId);
+        if (!subscription) throw new Error(`Subscription not found: ${subscriptionId}`);
+        if (subscription.agentIdentity !== caller) {
+            throw new Error(`Permission denied: subscription ${subscriptionId} is owned by ${subscription.agentIdentity}, not ${caller}.`);
+        }
+
+        const {events, lastLogId} = this._collectSubscriptionEvents(subscription, sinceLogId);
+
+        const messages = [], tasks = [], permissions = [], heartbeats = [];
+
+        for (const {eventType, payload = {}} of events) {
+            if      (eventType === 'wake/sent_to_me')         messages.push({priority: 'normal', ...payload});
+            else if (eventType === 'wake/task_state_changed') tasks.push(payload);
+            else if (eventType === 'wake/permission_granted') permissions.push(payload);
+            else if (eventType === 'wake/heartbeat_pulse')    heartbeats.push(payload);
+        }
+
+        const pending = messages.length + tasks.length + permissions.length + heartbeats.length;
+
+        if (pending === 0) {
+            return {
+                subscriptionId,
+                pending  : 0,
+                reason   : 'no wake-relevant events above the client watermark in current read state',
+                watermark: lastLogId
+            };
+        }
+
+        return {
+            subscriptionId,
+            pending,
+            digest        : buildWakeDigest(caller, {messages, tasks, permissions, heartbeats}),
+            digestPriority: messages.length > 0 ? getHighestWakePriority(messages) : 'normal',
+            eventsReplayed: events.length,
+            watermark     : lastLogId
+        };
+    }
+
+    /**
+     * Walks GraphLog deltas above a client watermark and evaluates every candidate against the
+     * subscription's trigger+filter spec. Shared by `resync` (replay) and `pollDigest`
+     * (derive-at-read) so the two cannot drift. The watermark is echoed, never persisted.
+     * @protected
+     * @param {Object} subscription The cached WAKE_SUBSCRIPTION entry (id + properties)
+     * @param {Number} sinceLogId Client-held GraphLog watermark
+     * @returns {{events: Object[], lastLogId: Number}}
+     */
+    _collectSubscriptionEvents(subscription, sinceLogId) {
         const storage = GraphService.db.storage;
         if (!storage?.getDeltaLog) {
-            logger.warn('[WakeSubscription] resync called but GraphLog storage unavailable; returning empty replay.');
-            return {subscriptionId, events: [], lastLogId: sinceLogId, eventsReplayed: 0};
+            logger.warn('[WakeSubscription] GraphLog storage unavailable; returning an empty event collection.');
+            return {events: [], lastLogId: sinceLogId};
         }
 
         const delta  = storage.getDeltaLog(sinceLogId);
@@ -1515,12 +1601,7 @@ class WakeSubscriptionService extends Base {
             if (matched) events.push(matched);
         }
 
-        return {
-            subscriptionId,
-            events,
-            lastLogId     : delta.lastLogId,
-            eventsReplayed: events.length
-        };
+        return {events, lastLogId: delta.lastLogId}
     }
 
     /**

--- a/test/playwright/unit/ai/services/memory-core/WakeSubscriptionService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/WakeSubscriptionService.spec.mjs
@@ -1529,6 +1529,112 @@ test.describe('Neo.ai.services.memory-core.WakeSubscriptionService', () => {
         });
     });
 
+    // -----------------------------------------------------------------------------
+    // poll-digest — derive-at-read: the pull half of wake delivery for clients without host listeners
+    // -----------------------------------------------------------------------------
+
+    test('poll-digest derives the digest from GraphLog state above the client watermark (#16741)', async () => {
+        await RequestContextService.run({agentIdentityNodeId: '@alice'}, async () => {
+            const {subscriptionId} = await WakeSubscriptionService.subscribe({
+                trigger      : 'TASK_STATE_CHANGED',
+                harnessTarget: 'mcp-notifications'
+            });
+            const sqlite = GraphService.db.storage.db;
+            const before = sqlite.prepare('SELECT MAX(log_id) AS maxId FROM GraphLog').get().maxId || 0;
+
+            appendTaskEvent({
+                eventId       : 'poll-task-working',
+                previousState : 'Submitted',
+                newState      : 'Working',
+                lastModifiedAt: '2026-08-09T14:00:02.003Z'
+            });
+            appendTaskEvent({
+                eventId       : 'poll-task-input',
+                previousState : 'Working',
+                newState      : 'InputRequired',
+                lastModifiedAt: '2026-08-09T14:00:05.006Z'
+            });
+
+            const res = await WakeSubscriptionService.pollDigest({subscriptionId, sinceLogId: before});
+
+            expect(res.subscriptionId).toBe(subscriptionId);
+            expect(res.pending).toBe(2);
+            expect(res.eventsReplayed).toBe(2);
+            expect(typeof res.digest).toBe('string');
+            expect(res.digest.length).toBeGreaterThan(0);
+            expect(res.digestPriority).toBe('normal');
+            expect(res.watermark).toBeGreaterThan(before);
+        });
+    });
+
+    test('poll-digest empty answer is a closed state carrying its reason — never a verdict', async () => {
+        await RequestContextService.run({agentIdentityNodeId: '@alice'}, async () => {
+            const {subscriptionId} = await WakeSubscriptionService.subscribe({
+                trigger      : 'SENT_TO_ME',
+                harnessTarget: 'mcp-notifications'
+            });
+
+            const res = await WakeSubscriptionService.pollDigest({subscriptionId, sinceLogId: 999999});
+
+            expect(res.pending).toBe(0);
+            expect(res.digest).toBeUndefined();
+            expect(typeof res.reason).toBe('string');
+            expect(res.watermark).toBe(999999);
+        });
+    });
+
+    test('poll-digest watermarks are client-held: advancing past events empties the next poll, replay still sees them', async () => {
+        await RequestContextService.run({agentIdentityNodeId: '@alice'}, async () => {
+            const {subscriptionId} = await WakeSubscriptionService.subscribe({
+                trigger      : 'TASK_STATE_CHANGED',
+                harnessTarget: 'mcp-notifications'
+            });
+            const sqlite = GraphService.db.storage.db;
+            const before = sqlite.prepare('SELECT MAX(log_id) AS maxId FROM GraphLog').get().maxId || 0;
+
+            appendTaskEvent({
+                eventId       : 'poll-watermark-task',
+                previousState : 'Submitted',
+                newState      : 'Working',
+                lastModifiedAt: '2026-08-09T14:05:02.003Z'
+            });
+
+            const first = await WakeSubscriptionService.pollDigest({subscriptionId, sinceLogId: before});
+            expect(first.pending).toBe(1);
+
+            // The client-held watermark advancing past the event empties the next poll —
+            // nothing is queued server-side; the stateless self-healing contract.
+            const second = await WakeSubscriptionService.pollDigest({subscriptionId, sinceLogId: first.watermark});
+            expect(second.pending).toBe(0);
+            expect(second.reason).toBeTruthy();
+
+            // A replay at the original watermark still sees the event — never server-persisted.
+            const replay = await WakeSubscriptionService.pollDigest({subscriptionId, sinceLogId: before});
+            expect(replay.pending).toBe(1);
+        });
+    });
+
+    test('poll-digest rejects a subscription owned by a different identity', async () => {
+        let subscriptionId;
+        await RequestContextService.run({agentIdentityNodeId: '@alice'}, async () => {
+            ({subscriptionId} = await WakeSubscriptionService.subscribe({
+                trigger      : 'SENT_TO_ME',
+                harnessTarget: 'mcp-notifications'
+            }));
+        });
+        await RequestContextService.run({agentIdentityNodeId: '@bob'}, async () => {
+            await expect(WakeSubscriptionService.pollDigest({subscriptionId}))
+                .rejects.toThrow('Permission denied');
+        });
+    });
+
+    test("manage routes the 'poll-digest' action to pollDigest", async () => {
+        await RequestContextService.run({agentIdentityNodeId: '@alice'}, async () => {
+            await expect(WakeSubscriptionService.manage({action: 'poll-digest'}))
+                .rejects.toThrow("Missing 'subscriptionId' parameter.");
+        });
+    });
+
     test('emitHeartbeatPulse writes only a heartbeat GraphLog row and replays through resync', async () => {
         const sqlite           = GraphService.db.storage.db;
         const {subscriptionId} = insertDurableSubscription({


### PR DESCRIPTION
Resolves neomjs/neo#16800

Related: neomjs/neo-agent-brain#50

The first implementation slice of the S7 design (parent thread on neomjs/neo-agent-brain#50: design v1 → v1.1 → implementation plan; neomjs/neo#16800 is the verb-shaped close-target — the parent's AC2 journey slice remains). Delivers the `poll-digest` action on `manage_wake_subscription`: derive-at-read over the authenticated MCP surface — the pull half of wake delivery for clients without host-reachable listeners.

## What shipped

- `WakeSubscriptionService.pollDigest({subscriptionId, sinceLogId})`: caller-bound and ownership-checked (resync's guard verbatim); events above the client-held watermark collected via the extracted `_collectSubscriptionEvents` — the exact walk `resync` uses, so the two cannot drift. Read-state reconcile is INHERITED from the shared `match()` evaluator (a wake for an already-read message never matches — no re-derived filter). The digest is built by the daemon's own `buildWakeDigest`. An empty answer is a closed state carrying its reason (`{pending: 0, reason, watermark}`) — always distinguishable from a transport failure, per design v1.1's honest-degraded AC. The watermark is echoed, never server-persisted.
- `manage()` gains the `poll-digest` case; `openapi.yaml` enum + descriptions updated (the parity surface).
- `resync` refactor: the delta walk extracted verbatim into `_collectSubscriptionEvents`; the public contract is unchanged (full pre-existing wake suite green).

## AC ledger (#16800)

- Digest derived from events above the client watermark + `digestPriority` + echoed watermark: DELIVERED (spec: derivation test).
- Empty answer a closed state carrying its reason; transport failure never representable as empty: DELIVERED (spec: closed-state test).
- Watermark client-held — advancing empties the next poll, replay still sees: DELIVERED (spec: both directions).
- Cross-identity rejection, same guard as resync: DELIVERED (spec: ownership test).
- Full wake suite green: DELIVERED — 115/115 service spec, 119/119 with `wakeDigestBuilder.spec.mjs`.

Parent AC mapping (#16741): AC1/AC3/AC4 delivered here; AC2 (the remote-only journey's working wake story) lands with the C1/C2 consumption slice.

## Deltas from ticket

The plan's working name was a standalone `poll_wake_digest` tool; recon showed the fleet's MCP convention is action dispatch on `manage_wake_subscription` (resync's sibling) — smaller surface, identical semantics. The `ingress-pull` route-class metadata is deferred to the journey slice (the verb does not need it).

## Test Evidence

`UNIT_TEST_MODE=true npx playwright test -c test/playwright/playwright.config.unit.mjs test/playwright/unit/ai/services/memory-core/WakeSubscriptionService.spec.mjs` → **115 passed** (5 new falsifier tests). Full wake suite incl. `wakeDigestBuilder.spec.mjs`: **119/119**, re-verified after the rebase onto `55219f40d8`.

Surface `ai/services/memory-core/WakeSubscriptionService.mjs`: `WakeSubscriptionService.spec.mjs` over the in-memory graph (TestLifecycleHelper) — green. Gates: `agent-preflight` capability class passed; check-ticket-archaeology clean (two refs caught and fixed mid-flight per the gate's printed remediation); all husky pre-commit gates green at `8914b0a2ea`.

Evidence: L3 (service-level spec over the in-memory graph + full wake suite) → L3 required (the verb is fully exercisable in-sandbox; the live-plane poll is post-merge validation). Residual: none for neomjs/neo#16800 (AC2 belongs to neomjs/neo-agent-brain#50's journey slice).

## Post-Merge Validation

- [ ] From a seat session on the live plane: `manage_wake_subscription({action: 'poll-digest', subscriptionId, sinceLogId: 0})` returns a digest or the closed reason.

Authored by Iris (Kimi K3, Kimi Code CLI). Session 6df9925c-e527-496d-9fbf-0a277c175d59.
