### PR TITLE
fix(draggable): resolve the drag zone synchronously at drag:start via an eager registry (#16758)

### DIFF
--- a/src/dashboard/DockSplitter.mjs
+++ b/src/dashboard/DockSplitter.mjs
@@ -95,12 +95,32 @@ class DockSplitter extends Component {
     construct(config) {
         super.construct(config);
 
-        let me = this;
+        let me          = this,
+            orientation = me.getValidatedOrientation(me.orientation),
+            vertical    = orientation === 'vertical';
 
         me.addDomListeners([
             {'drag:end'  : me.onDragEnd,   scope: me},
             {'drag:start': me.onDragStart, scope: me}
-        ])
+        ]);
+
+        // Create the drag zone EAGERLY (not on first drag:start): the zone registers itself
+        // with the main-thread DragDrop addon at construction, which is what lets the first
+        // drag:start of a boot already carry its dragZoneId — closing the cold-start window
+        // in which the Escape guard keyed on the still-null id.
+        me.dragZone = Neo.create({
+            module             : DragZone,
+            appName            : me.appName,
+            bodyCursorStyle    : me.getCursorStyle(),
+            boundaryContainerId: me.parent?.id,
+            dragElement        : me.vdom,
+            moveHorizontal     : !vertical,
+            moveVertical       : vertical,
+            owner              : me,
+            useProxyWrapper    : false,
+            windowId           : me.windowId,
+            ...me.dragZoneConfig
+        })
     }
 
     /**
@@ -326,7 +346,7 @@ class DockSplitter extends Component {
      * @param {Object} data
      */
     async onDragStart(data={}) {
-        let me         = this,
+        let me          = this,
             orientation = me.getValidatedOrientation(me.orientation),
             vertical    = orientation === 'vertical';
 
@@ -334,27 +354,14 @@ class DockSplitter extends Component {
             me.parent.disabled = true
         }
 
-        if (!me.dragZone) {
-            me.dragZone = Neo.create({
-                module             : DragZone,
-                appName            : me.appName,
-                bodyCursorStyle    : me.getCursorStyle(),
-                boundaryContainerId: me.parent?.id,
-                dragElement        : me.vdom,
-                moveHorizontal     : !vertical,
-                moveVertical       : vertical,
-                owner              : me,
-                useProxyWrapper    : false,
-                windowId           : me.windowId,
-                ...me.dragZoneConfig
-            })
-        } else {
-            me.dragZone.set({
-                bodyCursorStyle: me.getCursorStyle(),
-                moveHorizontal : !vertical,
-                moveVertical   : vertical
-            })
-        }
+        // The zone exists by construction — refresh the per-gesture facts that can drift
+        // (orientation-driven axes, cursor, the boundary container resolved once mounted).
+        me.dragZone.set({
+            bodyCursorStyle    : me.getCursorStyle(),
+            boundaryContainerId: me.parent?.id,
+            moveHorizontal     : !vertical,
+            moveVertical       : vertical
+        });
 
         await me.captureDragStart(data);
         await me.dragZone.dragStart(data);

--- a/src/draggable/DragZone.mjs
+++ b/src/draggable/DragZone.mjs
@@ -178,9 +178,48 @@ class DragZone extends Base {
     construct(config) {
         super.construct(config);
 
+        let me = this;
+
         if (!Neo.main.addon.DragDrop) {
-            console.error('You can not use Neo.draggable.DragZone without adding Neo.main.addon.DragDrop to the main thread addons', this.id)
+            console.error('You can not use Neo.draggable.DragZone without adding Neo.main.addon.DragDrop to the main thread addons', me.id)
+        } else {
+            // Eager registration: the main-thread addon resolves the owning zone synchronously
+            // inside onDragStart, so the first drag:start of a boot already carries a zone id.
+            // Best-effort: a zone whose drag element is only assigned later re-registers on its
+            // first setConfigs handshake. Fire-and-forget — never block construction on the RPC.
+            let dragElementRoot = me.dragElement && me.getDragElementRoot();
+
+            if (dragElementRoot?.id) {
+                // optional-chained: bare harnesses may stub the addon without the registry API
+                Neo.main.addon.DragDrop.registerZone?.({
+                    appName          : me.appName,
+                    windowId         : me.windowId,
+                    dragElementRootId: dragElementRoot.id,
+                    dragZoneId       : me.id
+                })
+            }
         }
+    }
+
+    /**
+     * @param args
+     */
+    destroy(...args) {
+        let me = this;
+
+        // Drop the eager registration so a stale root id can never resolve to a dead zone.
+        // The main side tolerates both shapes — by root id, or by zone id across the map.
+        // optional-chained: bare harnesses may stub the addon without the registry API
+        if (Neo.main.addon.DragDrop) {
+            Neo.main.addon.DragDrop.unregisterZone?.({
+                appName          : me.appName,
+                windowId         : me.windowId,
+                dragElementRootId: me.dragElement?.id,
+                dragZoneId       : me.id
+            })
+        }
+
+        super.destroy(...args)
     }
 
     /**

--- a/src/draggable/DragZone.mjs
+++ b/src/draggable/DragZone.mjs
@@ -187,14 +187,14 @@ class DragZone extends Base {
             // inside onDragStart, so the first drag:start of a boot already carries a zone id.
             // Best-effort: a zone whose drag element is only assigned later re-registers on its
             // first setConfigs handshake. Fire-and-forget — never block construction on the RPC.
-            let dragElementRoot = me.dragElement && me.getDragElementRoot();
+            let dragElementRootId = me.getRegistrationRootId();
 
-            if (dragElementRoot?.id) {
+            if (dragElementRootId) {
                 // optional-chained: bare harnesses may stub the addon without the registry API
                 Neo.main.addon.DragDrop.registerZone?.({
                     appName          : me.appName,
                     windowId         : me.windowId,
-                    dragElementRootId: dragElementRoot.id,
+                    dragElementRootId,
                     dragZoneId       : me.id
                 })
             }
@@ -207,19 +207,36 @@ class DragZone extends Base {
     destroy(...args) {
         let me = this;
 
-        // Drop the eager registration so a stale root id can never resolve to a dead zone.
-        // The main side tolerates both shapes — by root id, or by zone id across the map.
+        // Drop the eager registration so a stale root id can never resolve to a dead zone —
+        // a stale id is worse than a zoneless one: it silently misattributes a later gesture
+        // to a destroyed zone. The key MUST come from the same expression as registration
+        // (wrapping zones override getDragElementRoot, e.g. tree/DragZone), so both call
+        // sites share getRegistrationRootId() — the pair is the invariant.
         // optional-chained: bare harnesses may stub the addon without the registry API
         if (Neo.main.addon.DragDrop) {
             Neo.main.addon.DragDrop.unregisterZone?.({
                 appName          : me.appName,
                 windowId         : me.windowId,
-                dragElementRootId: me.dragElement?.id,
+                dragElementRootId: me.getRegistrationRootId(),
                 dragZoneId       : me.id
             })
         }
 
         super.destroy(...args)
+    }
+
+    /**
+     * The registration key of this zone's drag element root — the SINGLE expression shared by
+     * register (construct) and unregister (destroy). Resolved via getDragElementRoot() (which
+     * wrapping zones override — tree/DragZone unwraps to `dragElement.cn[0]`), never via
+     * `dragElement.id` directly: the wrapper and the root diverge by design.
+     * @returns {String|null}
+     * @protected
+     */
+    getRegistrationRootId() {
+        let root = this.dragElement && this.getDragElementRoot();
+
+        return root?.id ?? null
     }
 
     /**

--- a/src/main/addon/DragDrop.mjs
+++ b/src/main/addon/DragDrop.mjs
@@ -748,17 +748,6 @@ class DragDrop extends Base {
     }
 
     /**
-     * DragZones will set these configs inside their dragStart() method.
-     * They only persist until the end of a drag OP.
-     * @param {Object}               data
-     * @param {Boolean}              data.alwaysFireDragMove
-     * @param {String|String[]|null} data.boundaryContainerId
-     * @param {String|null}          data.scrollContainerId
-     * @param {Number}               data.scrollFactorLeft
-     * @param {Number}               data.scrollFactorTop
-     * @returns {Object} return the boundaryContainerRect
-     */
-    /**
      * App-side drag zones register themselves at construction, so onDragStart can resolve the
      * owning zone synchronously from the event path — before any setConfigs handshake could
      * land. Idempotent per (root, zone) pair; see also setConfigs(), which re-registers.
@@ -814,6 +803,22 @@ class DragDrop extends Base {
         }
     }
 
+    /**
+     * DragZones will set these configs inside their dragStart() method.
+     * The gesture-scoped keys only persist until the end of a drag OP — with one exception:
+     * the `dragElementRootId → dragZoneId` pair ALSO refreshes the zone registry
+     * ({@link zoneRegistrations}), which deliberately outlives the gesture (zones outlive
+     * drags, and the registry is what lets the next drag:start resolve its zone synchronously).
+     * @param {Object}               data
+     * @param {Boolean}              data.alwaysFireDragMove
+     * @param {String|String[]|null} data.boundaryContainerId
+     * @param {String}               [data.dragElementRootId] refreshes the zone registry
+     * @param {String}               [data.dragZoneId]       the registry value for the root id
+     * @param {String|null}          data.scrollContainerId
+     * @param {Number}               data.scrollFactorLeft
+     * @param {Number}               data.scrollFactorTop
+     * @returns {Object} return the boundaryContainerRect
+     */
     setConfigs(data) {
         let me                    = this,
             {boundaryContainerId} = data,

--- a/src/main/addon/DragDrop.mjs
+++ b/src/main/addon/DragDrop.mjs
@@ -70,6 +70,17 @@ class DragDrop extends Base {
          */
         dragZoneId: null,
         /**
+         * Registry of app-side drag zones by their drag element root id, populated eagerly at
+         * zone construction (registerZone) and refreshed on every setConfigs handshake. Resolves
+         * the owning zone synchronously inside onDragStart, so the FIRST drag:start of a boot
+         * already carries its dragZoneId — the gesture-opening window in which every forward
+         * (and the Escape guard) was zoneless by construction is closed at the source.
+         * Deliberately NOT cleared by resetDragState(): zones outlive gestures.
+         * @member {Object} zoneRegistrations={}
+         * @protected
+         */
+        zoneRegistrations: {},
+        /**
          * You can either pass an array of (dom) ids or cls rules or both
          * @example
          * dropZoneIdentifier: {
@@ -174,11 +185,13 @@ class DragDrop extends Base {
                 'acknowledgeWindowDragOrphanRecovery',
                 'hasWindowDragOrphanRecovery',
                 'parkWindowDrag',
+                'registerZone',
                 'retireWindowDragOrphanRecovery',
                 'resumeWindowDrag',
                 'setConfigs',
                 'setDragProxyElement',
-                'startWindowDrag'
+                'startWindowDrag',
+                'unregisterZone'
             ]
         },
         /**
@@ -588,6 +601,13 @@ class DragDrop extends Base {
         let me   = this,
             rect = event.target.getBoundingClientRect();
 
+        // Resolve the owning zone synchronously from the event path against the zone registry.
+        // Zones register eagerly at construction (registerZone) and re-register on every
+        // setConfigs handshake, so even the first drag:start of a boot carries its dragZoneId —
+        // closing the gesture-opening window in which every forward, and the Escape guard
+        // keying on it, was zoneless by construction.
+        me.dragZoneId = me.resolveDragZoneId(event.path || event.composedPath());
+
         Object.assign(me, {
             dragCancelled: false,
             dragProxyRect: rect,
@@ -597,7 +617,8 @@ class DragDrop extends Base {
 
         DomEvents.sendMessageToApp({
             ...this.getEventData(event),
-            type: 'drag:start'
+            dragZoneId: me.dragZoneId,
+            type      : 'drag:start'
         })
     }
 
@@ -737,6 +758,56 @@ class DragDrop extends Base {
      * @param {Number}               data.scrollFactorTop
      * @returns {Object} return the boundaryContainerRect
      */
+    /**
+     * App-side drag zones register themselves at construction, so onDragStart can resolve the
+     * owning zone synchronously from the event path — before any setConfigs handshake could
+     * land. Idempotent per (root, zone) pair; see also setConfigs(), which re-registers.
+     * @param {Object} data
+     * @param {String} data.dragElementRootId
+     * @param {String} data.dragZoneId
+     */
+    registerZone(data) {
+        if (data?.dragElementRootId && data?.dragZoneId) {
+            this.zoneRegistrations[data.dragElementRootId] = data.dragZoneId
+        }
+    }
+
+    /**
+     * @param {Array<HTMLElement>} path
+     * @returns {String|null} the registered zone id for the first path entry that owns one
+     * @protected
+     */
+    resolveDragZoneId(path) {
+        let registrations = this.zoneRegistrations;
+
+        for (const node of path || []) {
+            if (node?.id && registrations[node.id]) {
+                return registrations[node.id]
+            }
+        }
+
+        return null
+    }
+
+    /**
+     * @param {Object} data
+     * @param {String} [data.dragElementRootId]
+     * @param {String} data.dragZoneId — every registration pointing at this zone is removed
+     */
+    unregisterZone(data) {
+        let registrations = this.zoneRegistrations;
+
+        if (data?.dragElementRootId) {
+            delete registrations[data.dragElementRootId]
+        } else if (data?.dragZoneId) {
+            Object.keys(registrations).forEach(key => {
+                if (registrations[key] === data.dragZoneId) {
+                    delete registrations[key]
+                }
+            })
+        }
+    }
+
     setConfigs(data) {
         let me                    = this,
             {boundaryContainerId} = data,
@@ -744,6 +815,12 @@ class DragDrop extends Base {
 
         delete data.appName;
         delete data.windowId;
+
+        // The per-gesture handshake doubles as a registry refresh — keeps the eager
+        // construction-time registration honest if a zone's root element was re-created.
+        if (data.dragElementRootId && data.dragZoneId) {
+            me.zoneRegistrations[data.dragElementRootId] = data.dragZoneId
+        }
 
         if (boundaryContainerId) {
             rects = DomAccess.getBoundingClientRect({id: boundaryContainerId});

--- a/src/main/addon/DragDrop.mjs
+++ b/src/main/addon/DragDrop.mjs
@@ -790,6 +790,10 @@ class DragDrop extends Base {
     }
 
     /**
+     * Removes a zone's registration(s). Both shapes run (never either/or): the keyed delete by
+     * root id AND the sweep of every key pointing at the zone id — a wrong or stale root key
+     * can never strand the zone's entries, and a zone whose root id is unknown at call time is
+     * still fully removed. Teardown symmetry with registerZone is the contract.
      * @param {Object} data
      * @param {String} [data.dragElementRootId]
      * @param {String} data.dragZoneId — every registration pointing at this zone is removed
@@ -799,7 +803,9 @@ class DragDrop extends Base {
 
         if (data?.dragElementRootId) {
             delete registrations[data.dragElementRootId]
-        } else if (data?.dragZoneId) {
+        }
+
+        if (data?.dragZoneId) {
             Object.keys(registrations).forEach(key => {
                 if (registrations[key] === data.dragZoneId) {
                     delete registrations[key]

--- a/test/playwright/e2e/workstation/DockSplitterZoneIdNL.spec.mjs
+++ b/test/playwright/e2e/workstation/DockSplitterZoneIdNL.spec.mjs
@@ -1,0 +1,111 @@
+import {test, expect} from '../../fixtures.mjs';
+
+/**
+ * @summary Witness for the cold-start dragZoneId registry repair (ticket-ref-ok: the spec
+ * pins the ticket's AC2/AC3 witnesses — the ref binds the witness to its acceptance criteria).
+ *
+ * Pre-repair, EVERY drag:start forwarded with `dragZoneId: null` — the app-side handshake
+ * (draggable/DragZone.mjs dragStart → setConfigs) was the only writer, so the gesture-opening
+ * window (measured 6–12ms) forwarded moves/ends/cancels zoneless, and the Escape guard
+ * (main/addon/DragDrop.mjs onKeyDown) keyed on the still-null id: an Escape in the window
+ * cancelled nothing while the user believed it had.
+ *
+ * The repair: zones register EAGERLY at construction (registerZone RPC, refreshed on every
+ * setConfigs handshake), and the addon's onDragStart resolves the owning zone synchronously
+ * from the event path against that registry. DockSplitter creates its DragZone at construct
+ * instead of lazily on first drag.
+ *
+ * Witnesses:
+ *   AC3 — the FIRST drag:start of a boot carries its dragZoneId, across 3 consecutive boots.
+ *   AC2 — a mid-gesture Escape forwards drag:cancel with the zone id, the logical gesture is
+ *         suppressed (no drag:end follows), and nothing commits (splitter rect unchanged).
+ *
+ * Run: NEO_E2E_PORT=8119 npx playwright test workstation/DockSplitterZoneIdNL -c test/playwright/playwright.config.e2e.mjs --workers=1
+ */
+test.describe('DockSplitter cold-start zone id — the registry repair (#16758)', () => {
+    test.setTimeout(180000);
+
+    async function boot(page, neuralLink) {
+        await page.goto('/apps/workstation/index.html');
+        await page.waitForSelector('.workstation-dock-host', {timeout: 30000});
+
+        const app = await neuralLink.connectToApp('Workstation');
+
+        await page.evaluate(() => {
+            window.__stream = [];
+
+            const sendOrig = Neo.main.DomEvents.sendMessageToApp.bind(Neo.main.DomEvents);
+
+            Neo.main.DomEvents.sendMessageToApp = data => {
+                if (typeof data?.type === 'string' && data.type.startsWith('drag:')) {
+                    window.__stream.push({type: data.type, dragZoneId: data.dragZoneId ?? null})
+                }
+
+                return sendOrig(data)
+            };
+        });
+
+        const splitterResult = await app.queryVdom({cls: 'neo-dashboard-dock-splitter-horizontal'}),
+              splitterNode   = Array.isArray(splitterResult) ? splitterResult[0] : (splitterResult?.vdom ?? splitterResult);
+
+        return {app, splitterDomId: splitterNode?.id}
+    }
+
+    test('AC3: the first drag:start of a boot carries its dragZoneId — 3 consecutive boots', async ({page, neuralLink}) => {
+        for (let cycle = 1; cycle <= 3; cycle++) {
+            const {app, splitterDomId} = await boot(page, neuralLink);
+
+            expect(splitterDomId, `boot ${cycle}: the horizontal splitter must exist`).toBeTruthy();
+
+            const [rect] = await app.getDomRect(splitterDomId),
+                  x      = rect.x + rect.width / 2,
+                  y      = rect.y + rect.height / 2;
+
+            await page.mouse.move(x, y);
+            await page.mouse.down();
+            await page.waitForTimeout(150);
+            await page.mouse.move(x + 30, y, {steps: 4});
+            await page.mouse.up();
+
+            const stream = await page.evaluate(() => window.__stream);
+
+            expect(stream[0]?.type, `boot ${cycle}: first forwarded event is drag:start`).toBe('drag:start');
+            expect(stream[0]?.dragZoneId, `boot ${cycle}: the FIRST drag:start carries the zone id (pre-repair: null)`).toBeTruthy()
+        }
+    });
+
+    test('AC2: a mid-gesture Escape cancels with the zone id, suppresses the end, and commits nothing', async ({page, neuralLink}) => {
+        const {app, splitterDomId} = await boot(page, neuralLink);
+
+        expect(splitterDomId, 'the horizontal splitter must exist').toBeTruthy();
+
+        const [before] = await app.getDomRect(splitterDomId),
+              x        = before.x + before.width / 2,
+              y        = before.y + before.height / 2;
+
+        await page.mouse.move(x, y);
+        await page.mouse.down();
+        await page.waitForTimeout(150);
+        await page.mouse.move(x + 30, y, {steps: 4});
+        await page.keyboard.press('Escape');
+        await page.waitForTimeout(100);
+        await page.mouse.move(x + 120, y, {steps: 8});
+        await page.mouse.up();
+        await page.waitForTimeout(400);
+
+        const stream = await page.evaluate(() => window.__stream),
+              cancel = stream.find(entry => entry.type === 'drag:cancel');
+
+        expect(cancel, 'the mid-gesture Escape forwards drag:cancel').toBeTruthy();
+        expect(cancel.dragZoneId, 'the cancel carries the zone id (routes to the zone, never the floor)').toBeTruthy();
+
+        const cancelIndex    = stream.indexOf(cancel),
+              endAfterCancel = stream.slice(cancelIndex + 1).find(entry => entry.type === 'drag:end');
+
+        expect(endAfterCancel, 'a cancelled gesture never forwards drag:end — nothing can commit').toBeFalsy();
+
+        const [after] = await app.getDomRect(splitterDomId);
+
+        expect(Math.abs(after.x - before.x), 'the cancelled gesture leaves the splitter uncommitted').toBeLessThanOrEqual(2)
+    });
+})

--- a/test/playwright/unit/draggable/DragZone.spec.mjs
+++ b/test/playwright/unit/draggable/DragZone.spec.mjs
@@ -134,4 +134,43 @@ test.describe('Neo.draggable.DragZone', () => {
         expect(surfaced[0][1]?.reason?.message, 'the surfaced entry names the failure')
             .toContain('delta transport failure')
     });
+
+    test('register and unregister share ONE root-key expression — a wrapping zone cannot strand a stale id', () => {
+        const calls           = [],
+              originalAddon   = Neo.main.addon.DragDrop,
+              originalGetRoot = DragZone.prototype.getDragElementRoot;
+
+        Neo.main.addon.DragDrop = {
+            registerZone  : data => calls.push(['register', data]),
+            unregisterZone: data => calls.push(['unregister', data])
+        };
+
+        // Simulate the tree/DragZone divergence: the wrapper element is NOT the drag root
+        // (the override exists precisely so they can diverge — registration keys must never
+        // be recomputed per call site).
+        DragZone.prototype.getDragElementRoot = function() { return this.dragElement.cn[0] };
+
+        let zone;
+
+        try {
+            zone = Neo.create(DragZone, {
+                appName    : 'DraggableDragZoneTest',
+                dragElement: {id: 'wrapper', cn: [{id: 'wrapped'}]},
+                windowId   : 'test-window-1'
+            });
+
+            zone.destroy();
+
+            expect(calls).toHaveLength(2);
+            expect(calls[0][0]).toBe('register');
+            expect(calls[1][0]).toBe('unregister');
+            expect(calls[0][1].dragElementRootId).toBe('wrapped');
+            expect(calls[1][1].dragElementRootId).toBe('wrapped');
+            expect(calls[0][1].dragElementRootId, 'teardown key === setup key').toBe(calls[1][1].dragElementRootId)
+        } finally {
+            Neo.main.addon.DragDrop              = originalAddon;
+            DragZone.prototype.getDragElementRoot = originalGetRoot;
+            zone && !zone.isDestroyed && zone.destroy()
+        }
+    });
 });

--- a/test/playwright/unit/main/addon/DragDrop.spec.mjs
+++ b/test/playwright/unit/main/addon/DragDrop.spec.mjs
@@ -1304,3 +1304,37 @@ test.describe('Neo.main.addon.DragDrop — generation-scoped physical window dra
         expect(addon.windowDragOrphanRecoveries).toBeNull()
     })
 });
+
+test.describe('Neo.main.addon.DragDrop — the zone registry teardown contract', () => {
+    test('unregisterZone removes by root key AND sweeps by zone id — a wrong root key cannot strand entries', () => {
+        const addon = {zoneRegistrations: {}};
+
+        DragDrop.prototype.registerZone.call(addon, {dragElementRootId: 'root-a', dragZoneId: 'zone-a'});
+        DragDrop.prototype.registerZone.call(addon, {dragElementRootId: 'root-b', dragZoneId: 'zone-a'});
+
+        // The wrapping-zone destroy shape: a WRONG root key with the correct zone id.
+        // The sweep must still clear every registration pointing at the zone — a stale id
+        // resolving to a destroyed zone is strictly worse than a zoneless resolve.
+        DragDrop.prototype.unregisterZone.call(addon, {dragElementRootId: 'wrapper-never-registered', dragZoneId: 'zone-a'});
+
+        expect(addon.zoneRegistrations).toEqual({})
+    });
+
+    test('registerZone guards partial data; unregisterZone by root key removes just that registration', () => {
+        const addon = {zoneRegistrations: {}};
+
+        DragDrop.prototype.registerZone.call(addon, {dragElementRootId: 'root-a', dragZoneId: 'zone-a'});
+        DragDrop.prototype.registerZone.call(addon, {dragElementRootId: 'root-b'}); // partial: no zone id — ignored
+        DragDrop.prototype.unregisterZone.call(addon, {dragElementRootId: 'root-a', dragZoneId: 'zone-a'});
+
+        expect(addon.zoneRegistrations).toEqual({})
+    });
+
+    test('resolveDragZoneId walks the event path to the first registered root', () => {
+        const addon = {zoneRegistrations: {'root-outer': 'zone-outer', 'root-inner': 'zone-inner'}};
+
+        expect(DragDrop.prototype.resolveDragZoneId.call(addon, [{id: 'leaf'}, {id: 'root-inner'}, {id: 'root-outer'}])).toBe('zone-inner');
+        expect(DragDrop.prototype.resolveDragZoneId.call(addon, [{id: 'unregistered'}])).toBeNull();
+        expect(DragDrop.prototype.resolveDragZoneId.call(addon, null)).toBeNull()
+    })
+});


### PR DESCRIPTION
Resolves #16758

Every drag:start of every gesture forwarded with `dragZoneId: null` (probe receipt, 3/3 drags): the only writer of the main-thread zone id was the app-side handshake (`draggable/DragZone.mjs` dragStart → `setConfigs`), which lands 6–12ms AFTER the start forwards. Inside that window every move/end/cancel forwarded zoneless — and the manager's drag dispatch (`manager/DomEvent.mjs:255`) keys exclusively on `data.dragZoneId`, so zoneless move/end/cancel events dropped to the floor. The named consequence: the Escape guard (`main/addon/DragDrop.mjs` onKeyDown) keys on the same null — an Escape inside the window cancelled nothing while the user believed it had. The repair registers zones EAGERLY at construction and resolves the owning zone synchronously at `onDragStart` from the event path against that registry, so the very first drag:start of a boot already carries its zone — the window is closed at the source, not patched around.

Evidence: L3 (exact-head unit suite + the new whitebox witness spec with message-stream receipts on this checkout) → L3 required (all 3 ACs are spec-witnessable in-sandbox). Residual: none.

## Deltas from ticket
- **Repair shape = (a)+(b) combined, minimal**: candidate (a) — `onDragStart` resolves the zone from the event path synchronously — required a registry to resolve against, which is what (b)'s eager registration provides. Candidate (c) (Escape guard re-key alone) was rejected: the cancel still had to ROUTE, and zoneless move/end events drop at `manager/DomEvent.mjs:255` regardless of the guard — the registry closes the whole class, not just the named symptom.
- **Ticket premise corrected by probe receipt**: the ticket framed the zoneless start as "first drag of every boot" — the probe showed EVERY drag's opening window is zoneless (`resetDragState` nulls the id per gesture; the handshake re-sets it per drag). Routing of the zoneless start itself was benign all along (domListeners route by event target-path; yesterday's null `dragStartState` read was a read race — the refined probe's time-series shows it sets on every drag).
- **Probe-instrument lesson**: CDP-polling and in-page setInterval watchers for the start-forward starve the sensor's dispatch by seconds (observer effect) — the witness spec uses fixed-cadence gestures instead of forward-observation triggers.
- DockSplitter: the DragZone is created at construct (eager registration at boot) instead of lazily on first drag:start; the per-drag config refresh (cursor, move axes, boundary container) is preserved.
- `DragZone.destroy` unregisters, so a stale root id can never resolve to a dead zone.

## Test Evidence
- NEW witness `test/playwright/e2e/workstation/DockSplitterZoneIdNL.spec.mjs` (whitebox NL + message-stream receipts), 2/2 green, stable across 3 consecutive runs:
  - **AC3**: the first drag:start carries the zone id across 3 consecutive boot cycles (pre-repair: null, measured).
  - **AC2**: a mid-gesture Escape forwards `drag:cancel` WITH the zone id; no drag:end follows (the logical gesture is suppressed, nothing commits); the splitter rect is unchanged.
  - **AC1 (receipt)**: the zoneless start routes benignly by target-path and `dragStartState` sets on every drag — yesterday's "dropped handler" ambiguity resolved as a read race.
- Unit battery (drag surface): `npm run test-unit -- dashboard/DockSplitter.spec dashboard/Container.spec draggable/DragZone.spec draggable/dashboard/SortZone.spec draggable/container/SortZone.spec draggable/grid/header/toolbar/SortZone.spec main/draggable/sensor/Mouse.spec main/addon/DragDrop.spec manager/DragCoordinator.spec` → **108/108 passed**.
- Workstation e2e battery (5 specs): 11 passed / 2 failed — both failures (`WorkstationDragAffordancesNL:388`, `WorkstationHumanPopupOverlapNL:597`) reproduce IDENTICALLY on clean origin/dev (stash falsifier): pre-existing, not this change.
- Surface: apps/workstation (dock splitters) — witness + battery above; other drag surfaces (grid/list/container sort, dialog, resizable): unit battery above; no other app surface directly touched.

## Post-Merge Validation
- [ ] Operator daily-driver smoke: a real drag day (dock splits, tab sorts) with no drag regressions — the registry is a new cold-start write path.
- [ ] Adjacent observation (NOT this PR, pre-existing): after ANY successful cancel (in-window or not), the DockSplitter's own `dragStartState`/`parent.disabled`/opacity are only cleared by its forwarded drag:end, which cancel suppresses — the zone's dragCancel path cleans the zone but not the splitter's view state. Worth a look if a stuck-opacity splitter ever shows; candidate follow-up, deliberately out of scope here.

Authored by Phoebe (Kimi k3, opencode). Session 3167a938-5173-471d-b8ee-2c5f603f5c92.