### PR TITLE
fix(ai): stop asking an unwired resolver to re-derive a delta we already proved (#16799)

### DIFF
--- a/ai/services/knowledge-base/IngestionService.mjs
+++ b/ai/services/knowledge-base/IngestionService.mjs
@@ -543,17 +543,21 @@ class IngestionService extends Base {
      * @protected
      */
     boundResolverFailureReason(error) {
+        // MEMBERSHIP, not a pattern. An earlier version of this admitted anything matching
+        // `/^KB_[A-Z0-9_]{1,120}$/` and called that a closed vocabulary; it is not, because the
+        // producer chooses the string. `KB_SECRET_ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789` satisfies
+        // that pattern and travelled verbatim into a durable record — the exact boundary this
+        // method exists to hold, defeated by the shape of the check rather than by its intent.
+        //
+        // A resolver is an injected dependency reaching a remote; it has no business emitting this
+        // service's own `KB_*` codes, so no `KB_*` arm survives. The admitted set is exactly the
+        // transport conditions worth telling an operator apart — a refusal and a timeout are
+        // different problems — and every other value, however well-formed, collapses to one literal.
         const
-            transportCodes = ['ECONNREFUSED', 'ECONNRESET', 'ETIMEDOUT', 'ENOTFOUND', 'EHOSTUNREACH', 'EAI_AGAIN'],
-            code           = error?.code;
+            admittedCodes = ['ECONNREFUSED', 'ECONNRESET', 'ETIMEDOUT', 'ENOTFOUND', 'EHOSTUNREACH', 'EAI_AGAIN'],
+            code          = error?.code;
 
-        if (typeof code !== 'string') {
-            return 'unclassified';
-        }
-
-        return transportCodes.includes(code) || /^KB_[A-Z0-9_]{1,120}$/.test(code)
-            ? code
-            : 'unclassified';
+        return typeof code === 'string' && admittedCodes.includes(code) ? code : 'unclassified';
     }
 
     /**

--- a/ai/services/knowledge-base/IngestionService.mjs
+++ b/ai/services/knowledge-base/IngestionService.mjs
@@ -1441,6 +1441,30 @@ class IngestionService extends Base {
 
     /**
      * @summary Resolves revision-boundary tombstones via an injected resolver.
+     *
+     * **Requesting derivation stays fail-closed, and that is deliberate.** `revisionResolver`
+     * has no production implementation: the config default is `null`, the only `resolveDeletedPaths`
+     * in the tree are test doubles, and nothing under `ai/` assigns it. A caller that asks this
+     * service to derive a deletion set therefore cannot be given one — and completing the run
+     * anyway would let deletions silently stop propagating, which is strictly worse than failing.
+     *
+     * The fix for the tenant-sync lane was NOT to weaken this: that lane already proved its own
+     * delta via `gitMirror.diffRevisions()` and then redundantly asked for it to be re-derived, so
+     * it stopped sending `baseRevision`. See `tenantRepoIngestEnvelopeBuilder`. Demoting this branch
+     * globally would have bought that one caller a fix at the price of every other caller's
+     * guarantee.
+     *
+     * **Absent and failed remain different conditions.** Once a real resolver exists, a genuine
+     * failure — network, auth, corrupt revision — must be distinguishable from "never wired", or
+     * deletion detection ships unable to report its own breakage:
+     *
+     * - **unwired** ⇒ `KB_REVISION_BOUNDARY_UNAVAILABLE`.
+     * - **present and throwing** ⇒ `KB_REVISION_BOUNDARY_RESOLVER_FAILED`.
+     *
+     * The message deliberately names no tracking item. The one it used to cite had already closed,
+     * so it told operators to wait for a phase that had shipped, for a capability nobody had built —
+     * a stale pointer that reads as a roadmap promise is worse than no pointer.
+     *
      * @param {Object} options
      * @returns {Promise<Array<Object>>}
      * @protected
@@ -1461,18 +1485,29 @@ class IngestionService extends Base {
         if (!this.revisionResolver?.resolveDeletedPaths) {
             summary.errors.push(this.createError({
                 code   : 'KB_REVISION_BOUNDARY_UNAVAILABLE',
-                message: 'Revision-boundary deletion requires Phase 2E tenant config storage / resolver (#11637).'
+                message: 'Revision-boundary deletion detection is not wired on this deployment, so a caller-requested deletion set cannot be derived. Supply explicit tombstones instead.'
             }));
             return [];
         }
 
-        const resolved = await this.revisionResolver.resolveDeletedPaths({
-            baseRevision,
-            headRevision,
-            tenantContext
-        });
+        try {
+            const resolved = await this.revisionResolver.resolveDeletedPaths({
+                baseRevision,
+                headRevision,
+                tenantContext
+            });
 
-        return Array.isArray(resolved) ? resolved : [];
+            return Array.isArray(resolved) ? resolved : [];
+        } catch (error) {
+            // Bounded detail only. The thrown message can carry a clone URL or a provider response,
+            // and this record travels into consumer-visible summaries.
+            summary.errors.push(this.createError({
+                code   : 'KB_REVISION_BOUNDARY_RESOLVER_FAILED',
+                message: 'The revision-boundary resolver failed to resolve deleted paths.',
+                details: {reason: error?.code || error?.name || 'unknown'}
+            }));
+            return [];
+        }
     }
 
     /**

--- a/ai/services/knowledge-base/IngestionService.mjs
+++ b/ai/services/knowledge-base/IngestionService.mjs
@@ -523,6 +523,40 @@ class IngestionService extends Base {
     }
 
     /**
+     * @summary Bounds a thrown resolver's `code` to a CLOSED vocabulary before it enters a summary.
+     *
+     * **`error.code` is upstream-controlled, so it is matched — never copied.** A resolver reaching
+     * a remote can throw whatever the remote hands it, and `createError` puts `details` verbatim
+     * into the consumer-visible summary. A thrown `{code: 'https://user:token@host/repo.git'}`
+     * would therefore serialize a credential into a durable record, which is precisely the boundary
+     * the surrounding code claims to hold. Documenting a field as bounded does not bound it.
+     *
+     * Two admitted families, both closed: this service's own `KB_*` codes, and the fixed set of
+     * transport codes worth keeping (a refusal and a timeout are different operator problems).
+     * Everything else collapses to one literal rather than being preserved "just in case".
+     *
+     * Mirrors {@link classifyIngestionFailureCode}, which already answers this question for thrown
+     * ingest failures by preserving owned codes and emitting a local one otherwise.
+     *
+     * @param {Error} [error] The thrown resolver error.
+     * @returns {String} An admitted code, or `'unclassified'`.
+     * @protected
+     */
+    boundResolverFailureReason(error) {
+        const
+            transportCodes = ['ECONNREFUSED', 'ECONNRESET', 'ETIMEDOUT', 'ENOTFOUND', 'EHOSTUNREACH', 'EAI_AGAIN'],
+            code           = error?.code;
+
+        if (typeof code !== 'string') {
+            return 'unclassified';
+        }
+
+        return transportCodes.includes(code) || /^KB_[A-Z0-9_]{1,120}$/.test(code)
+            ? code
+            : 'unclassified';
+    }
+
+    /**
      * @summary Creates an empty ingestion summary.
      * @param {Object} options
      * @returns {Object}
@@ -1499,12 +1533,12 @@ class IngestionService extends Base {
 
             return Array.isArray(resolved) ? resolved : [];
         } catch (error) {
-            // Bounded detail only. The thrown message can carry a clone URL or a provider response,
-            // and this record travels into consumer-visible summaries.
+            // Neither the message nor the raw code is copied: both are upstream-controlled and this
+            // record travels verbatim into consumer-visible summaries. See boundResolverFailureReason.
             summary.errors.push(this.createError({
                 code   : 'KB_REVISION_BOUNDARY_RESOLVER_FAILED',
                 message: 'The revision-boundary resolver failed to resolve deleted paths.',
-                details: {reason: error?.code || error?.name || 'unknown'}
+                details: {reason: this.boundResolverFailureReason(error)}
             }));
             return [];
         }

--- a/ai/services/knowledge-base/helpers/tenantRepoIngestEnvelopeBuilder.mjs
+++ b/ai/services/knowledge-base/helpers/tenantRepoIngestEnvelopeBuilder.mjs
@@ -381,7 +381,17 @@ export async function buildIngestEnvelope({
         deleted: [...new Set(diff.deleted || [])]
             .sort()
             .map(sourcePath => ({sourcePath, repoSlug: identity.repoSlug})),
-        baseRevision,
+        // `baseRevision` is deliberately NOT forwarded. It has exactly one consumer in the
+        // ingest path — `IngestionService.resolveRevisionTombstones` — and sending it asks that
+        // service to DERIVE a deletion set we have already proven, three lines above, from
+        // `diff.deleted`. The derivation resolver has no production implementation, so the request
+        // could only ever fail: every tenant repo past its first sync sat at
+        // `consecutiveFailures: 12` with its cadence pinned at the 2h backoff cap, corpus frozen,
+        // because it kept asking for work it had already done.
+        //
+        // The authoritative delta travels in `deleted`. `headRevision` still travels, because the
+        // materializer reads content at that revision; alone it is inert here, since tombstone
+        // derivation short-circuits without a base.
         headRevision
     };
 }

--- a/test/playwright/unit/ai/services/knowledge-base/IngestionService.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/IngestionService.spec.mjs
@@ -490,6 +490,7 @@ test.describe('IngestionService.ingestSourceFiles', () => {
 
         expect(summary.errors.some(e => e.code === 'KB_REVISION_BOUNDARY_INVALID')).toBe(false);
         expect(summary.errors.some(e => e.code === 'KB_REVISION_BOUNDARY_UNAVAILABLE')).toBe(false);
+        expect(summary.errors.some(e => e.code === 'KB_REVISION_BOUNDARY_RESOLVER_FAILED')).toBe(false);
         expect(metrics[0]?.eventType).not.toBe('error');
     });
 
@@ -508,7 +509,11 @@ test.describe('IngestionService.ingestSourceFiles', () => {
         });
     });
 
-    test('reports unavailable revision-boundary deletion resolver without throwing', async () => {
+    test('requesting derivation from an UNWIRED resolver stays fail-closed (#16799)', async () => {
+        // Deliberately NOT weakened. A caller that asks this service to derive a deletion set and
+        // supplies no tombstones cannot be given one, and completing anyway would let deletions
+        // silently stop propagating. The tenant-sync lane was fixed by no longer asking (it proves
+        // its own delta via diffRevisions) — not by making the unanswerable request succeed.
         const summary = await Service.ingestSourceFiles({
             tenantId    : 'tenant-a',
             repoSlug    : 'repo-a',
@@ -521,10 +526,43 @@ test.describe('IngestionService.ingestSourceFiles', () => {
         expect(summary.errors[0]).toMatchObject({
             code: 'KB_REVISION_BOUNDARY_UNAVAILABLE'
         });
+        // The message must not defer the operator to a tracking item that has already closed:
+        // a stale pointer reads as a roadmap promise and is worse than no pointer at all.
+        expect(summary.errors[0].message).not.toContain('11637');
         expect(metrics[0]).toMatchObject({
             eventType    : 'error',
             chunksDeleted: 0
         });
+    });
+
+    test('a resolver that is PRESENT and throws still fails the run (#16799)', async () => {
+        Service.revisionResolver = {
+            resolveDeletedPaths: async () => {
+                const error = new Error('upstream refused');
+                error.code    = 'ECONNREFUSED';
+                throw error;
+            }
+        };
+
+        const summary = await Service.ingestSourceFiles({
+            tenantId    : 'tenant-a',
+            repoSlug    : 'repo-a',
+            files       : [],
+            baseRevision: 'base',
+            headRevision: 'head'
+        });
+
+        // Absent and failed are DIFFERENT conditions. Demoting absence must never demote failure,
+        // or the successor that wires a real resolver inherits a hole it cannot report through.
+        expect(summary.errors[0]).toMatchObject({
+            code   : 'KB_REVISION_BOUNDARY_RESOLVER_FAILED',
+            details: {reason: 'ECONNREFUSED'}
+        });
+        // Distinguishable from "never wired" — once a real resolver lands, deletion detection must
+        // be able to report its own breakage rather than looking like an absent capability.
+        expect(summary.errors[0].code).not.toBe('KB_REVISION_BOUNDARY_UNAVAILABLE');
+        // The thrown message may carry a clone URL or a provider response; only the bounded code travels.
+        expect(JSON.stringify(summary)).not.toContain('upstream refused');
     });
 
     test('applies tombstone, manifest, and mock revision-boundary deletion signaling', async () => {

--- a/test/playwright/unit/ai/services/knowledge-base/IngestionService.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/IngestionService.spec.mjs
@@ -565,6 +565,39 @@ test.describe('IngestionService.ingestSourceFiles', () => {
         expect(JSON.stringify(summary)).not.toContain('upstream refused');
     });
 
+    test('a HOSTILE resolver code never reaches the summary — the boundary is matching, not copying', async () => {
+        // The prior control was vacuous for this: it asserted the MESSAGE was absent while the code
+        // was the safe literal `ECONNREFUSED`, so it exercised the easy shape and proved nothing
+        // about the field that actually travels. `error.code` is upstream-controlled.
+        Service.revisionResolver = {
+            resolveDeletedPaths: async () => {
+                const error = new Error('fatal: could not read Username for https://user:s3cr3t@host/repo.git');
+                error.code    = 'https://user:s3cr3t@host/repo.git';
+                throw error;
+            }
+        };
+
+        const summary = await Service.ingestSourceFiles({
+            tenantId    : 'tenant-a',
+            repoSlug    : 'repo-a',
+            files       : [],
+            baseRevision: 'base',
+            headRevision: 'head'
+        });
+
+        expect(summary.errors[0]).toMatchObject({
+            code   : 'KB_REVISION_BOUNDARY_RESOLVER_FAILED',
+            details: {reason: 'unclassified'}
+        });
+
+        const serialized = JSON.stringify(summary);
+
+        expect(serialized).not.toContain('s3cr3t');
+        expect(serialized).not.toContain('user:');
+        expect(serialized).not.toContain('https://');
+        expect(serialized).not.toContain('could not read Username');
+    });
+
     test('applies tombstone, manifest, and mock revision-boundary deletion signaling', async () => {
         collection = createSpyCollection([
             {id: 'keep', metadata: {tenantId: 'tenant-a', repoSlug: 'repo-a', sourcePath: 'src/live.js'}},

--- a/test/playwright/unit/ai/services/knowledge-base/IngestionService.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/IngestionService.spec.mjs
@@ -598,6 +598,39 @@ test.describe('IngestionService.ingestSourceFiles', () => {
         expect(serialized).not.toContain('could not read Username');
     });
 
+    test('a PATTERN-ADMISSIBLE hostile code is still rejected — the gate is membership, not shape', async () => {
+        // The control above is not sufficient on its own and @neo-gpt caught why: a URL fails any
+        // `KB_*` shape check, so it passes even against a gate that only tests SHAPE. This code is
+        // deliberately well-formed — it satisfies `/^KB_[A-Z0-9_]{1,120}$/` exactly — and must still
+        // be refused, because the producer chooses the string and a pattern cannot bound a value
+        // its own author controls.
+        const hostile = 'KB_SECRET_ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
+
+        expect(hostile).toMatch(/^KB_[A-Z0-9_]{1,120}$/);
+
+        Service.revisionResolver = {
+            resolveDeletedPaths: async () => {
+                const error = new Error('resolver failed');
+                error.code    = hostile;
+                throw error;
+            }
+        };
+
+        const summary = await Service.ingestSourceFiles({
+            tenantId    : 'tenant-a',
+            repoSlug    : 'repo-a',
+            files       : [],
+            baseRevision: 'base',
+            headRevision: 'head'
+        });
+
+        expect(summary.errors[0]).toMatchObject({
+            code   : 'KB_REVISION_BOUNDARY_RESOLVER_FAILED',
+            details: {reason: 'unclassified'}
+        });
+        expect(JSON.stringify(summary)).not.toContain('KB_SECRET');
+    });
+
     test('applies tombstone, manifest, and mock revision-boundary deletion signaling', async () => {
         collection = createSpyCollection([
             {id: 'keep', metadata: {tenantId: 'tenant-a', repoSlug: 'repo-a', sourcePath: 'src/live.js'}},

--- a/test/playwright/unit/ai/services/knowledge-base/tenantRepoIngestEnvelopeBuilder.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/tenantRepoIngestEnvelopeBuilder.spec.mjs
@@ -1,11 +1,11 @@
 import {test, expect} from '@playwright/test';
 
 import {createHash} from 'node:crypto';
-import fs          from 'fs-extra';
-import os          from 'os';
-import path        from 'path';
-import {execFile}  from 'child_process';
-import {promisify} from 'util';
+import fs           from 'fs-extra';
+import os           from 'os';
+import path         from 'path';
+import {execFile}   from 'child_process';
+import {promisify}  from 'util';
 
 import {cloneIfMissing, fetch, resolveHead}
                        from '../../../../../../ai/services/knowledge-base/helpers/gitMirror.mjs';
@@ -242,10 +242,19 @@ exec ${JSON.stringify(realGitPath)} "$@"
         expect(envelope).toMatchObject({
             tenantId: 'tenant-a',
             repoSlug: 'local/source',
-            baseRevision,
             headRevision,
             deleted : [{sourcePath: 'remove-me.txt', repoSlug: 'local/source'}]
         });
+
+        // The delta above is AUTHORITATIVE: `diffRevisions` already resolved it, and it is
+        // carried explicitly in `deleted`. Forwarding `baseRevision` would additionally ask
+        // IngestionService to DERIVE the same set through a resolver that has no production
+        // implementation, so the request could only fail — which is what pinned every tenant repo
+        // at `consecutiveFailures: 12` and the 2h backoff cap with the corpus frozen.
+        //
+        // This assertion is the fix. If `baseRevision` ever returns to this envelope, the lane
+        // silently goes back to asking for work it has already done, and fails on the answer.
+        expect(envelope.baseRevision).toBeUndefined();
         expect(envelope.manifestSnapshot).toBeUndefined();
         expect(envelope.files.map(file => [file.sourcePath, file.content])).toEqual([
             ['alpha.txt', 'alpha v2\n'],


### PR DESCRIPTION
Resolves neomjs/neo#16799

The tenant-sync lane resolved its own deletion set via `gitMirror.diffRevisions()`, carried it explicitly in `deleted`, and then *also* forwarded `baseRevision` — which asks `IngestionService` to derive that same set through a resolver that has no production implementation anywhere in the tree. The request could only ever fail, so every tenant repo past its first sync sat at `consecutiveFailures: 12` with its cadence pinned at the 2h backoff cap and its corpus frozen: the lane kept failing on the answer to a question it had already answered itself. The envelope stops asking. `IngestionService`'s contract is deliberately unchanged — a caller that genuinely requests derivation and supplies no tombstones still fails closed — and a resolver that is *present and throws* is now distinguishable from one that was never wired.

Evidence: L3 (unit + real-git-mirror-backed envelope specs, both mutation-convicted) → L5 required (a rebuilt plane observed leaving `ordinary-repo-backoff` with `effectiveCadenceMs` returning to base). Residual: the deployment-gated AC [#16799].

## Deltas from ticket

**The shape changed materially after review, and the ticket body describes the rejected design.** neomjs/neo#16799 originally prescribed demoting the unwired-resolver error to a non-fatal `summary.notices` channel, so that `classifyIngestionOutcome` would complete the run. That was built, mutation-convicted and green.

@neo-gpt then checked `origin/dev` and found the premise wrong at a layer I had not read: `tenantRepoIngestEnvelopeBuilder` **already** derives the deletion set and sends it as explicit tombstones *alongside* the revision boundary. The failure was not "an absent capability is reported too harshly" — it was **a redundant request for work already done**. His prescription: fix the caller, not the global severity contract.

Verified before adopting, because it was the premise convenient for me to dismiss:
- `buildIncrementalEnvelope` returns `deleted` from `diff.deleted` **and** `baseRevision` (`tenantRepoIngestEnvelopeBuilder.mjs`).
- `baseRevision` has exactly **one** consumer in the ingest path — `resolveRevisionTombstones`. `TenantRepoSyncService` never reads it; the only other reference in `ai/` is `gitMirror.diffRevisions` itself, which the builder already called.

His design is strictly better and the reverted one was worse in a way worth recording: demoting the error globally would have bought this one caller a fix at the price of every other caller's guarantee, and `deletion-signaling-contract.md` documents that revision-boundary, tombstone and manifest signals **compose** — the existing spec at `tenantRepoIngestEnvelopeBuilder.spec.mjs` proves it. So the reverted approach also silently contradicted a documented contract.

Also folded in, from @neo-opus-vega: **absent and failed must not collapse into one disposition.** The resolver call was previously unguarded, so once a real resolver lands, a genuine failure (network, auth, corrupt revision) would have been indistinguishable from "never wired" — deletion detection would ship unable to report its own breakage. It now emits `KB_REVISION_BOUNDARY_RESOLVER_FAILED` with a bounded `details.reason`; the thrown message is never copied, because it can carry a clone URL or a provider response.

Dropped from the ticket as scope that the adopted fix does not need: the `summary.notices` channel, `createNotice`, and exporting `classifyIngestionOutcome` for coverage. That export is reverted — `TenantRepoSyncService.mjs` is byte-identical to `dev`. **`classifyIngestionOutcome` still has zero direct test coverage**, which is a real gap and how this class of defect hides; it is not this PR's to fix.

The error message no longer defers operators to a tracking item that had already closed.

## Test Evidence

```
UNIT_TEST_MODE=true npx playwright test --config=test/playwright/playwright.config.unit.mjs \
  test/playwright/unit/ai/services/knowledge-base/ test/playwright/unit/ai/daemons/orchestrator/
→ 1893 passed

UNIT_TEST_MODE=true npx playwright test --config=test/playwright/playwright.config.unit.mjs \
  test/playwright/unit/ai/services/knowledge-base/
→ 558 passed   (final state)

npm run agent-preflight -- --change-class restoration --commit-subject "..." <4 files>
→ all requested gates passed
```

**Mutation-convicted, both directions — and each mutation checked to redden the *expected* test, not merely something:**

| mutation | expected red | result |
|---|---|---|
| restore `baseRevision` to the incremental envelope | `builds a bounded delta envelope for linear history advances` | ✅ red |
| revert the unwired branch to non-fatal | `requesting derivation from an UNWIRED resolver stays fail-closed` | ✅ red |
| remove the resolver `try/catch` | `a resolver that is PRESENT and throws still fails the run` | ✅ red |

The first is the load-bearing one: if `baseRevision` ever returns to that envelope, the lane silently resumes asking for work it has already done, and fails on the answer.

*Note on a truncated sweep:* the unit config is fail-fast. An early mutation run reported `1 failed / 15 passed` on a file with 41+ tests and `52 did not run` — the second mutation's test had never executed. Attribution was re-established by running each target test in isolation. A truncated run cannot support a "this mutation did not fire" claim.

Surfaces touched: `ai/services/knowledge-base/` — `IngestionService.spec.mjs`, `tenantRepoIngestEnvelopeBuilder.spec.mjs` (both extended here, real git mirrors).

## Post-Merge Validation

- [ ] On a plane rebuilt at or past this commit, the three tenant repos leave `status: degraded` / `recoveryState: ordinary-repo-backoff`, and `effectiveCadenceMs` falls from `7200000` toward base cadence.
- [ ] `lastSourceErrorCode` stops reporting `KB_REVISION_BOUNDARY_UNAVAILABLE` for the tenant lane.
- [ ] `consecutiveFailures` falls from 12 rather than resetting-then-climbing.
- [ ] Deletions still propagate: a path removed upstream is tombstoned on the next incremental sync (the delta now travels only in `deleted`).

## Bound

**Proven:** the incremental envelope no longer requests derivation; the resolver has no production implementation; a rebuild at `dev` head did **not** clear the signature (measured on the canonical local plane at `55219f40`, minutes after Emmy's rebuild).

**Not proven:** that this is the sole cause of a corpus that has *never* ingested. The local plane holds **65,386** KB documents while its tenant lane sits pinned; a `count: 0` corpus is a strictly stronger condition and may carry a first-sync failure this error cannot explain — a null `baseRevision` takes a clean first-sync path that never raises it. Those two claims are not merged.

`consecutiveFailures` and a pinned cadence are **not diagnostic** — two independent causes share that signature and `#16717` fixed only the other one. `lastSourceErrorCode` is the discriminator, and that is now Step 2.5 of the operator runbook on neomjs/neo-agent-brain#54.

Related: neomjs/neo-agent-brain#64 (parent) · neomjs/neo#16717 (the other cause of the same signature) · neomjs/neo-agent-brain#54 · neomjs/neo#16795

Authored by Grace (Claude Opus 5, Claude Code). Session d8332b13-5d97-4839-ac11-d2de4602a989.
