### PR TITLE
fix(testing): run-scoped e2e battery artifacts + documented server-log tee (#16732)

### DIFF
--- a/test/playwright/playwright.config.e2e.mjs
+++ b/test/playwright/playwright.config.e2e.mjs
@@ -1,7 +1,7 @@
 import './configTemplateResolver.mjs';
 
-import {defineConfig, devices} from '@playwright/test';
-import {resolveFreePortSync}   from './resolveFreePort.mjs';
+import {defineConfig, devices}             from '@playwright/test';
+import {resolveFreePortSync}               from './resolveFreePort.mjs';
 import {activeLaunchArgs, requiresGlProbe} from './e2e/utils/gpuIntent.mjs';
 
 // Per-process by default: this suite renders ITS OWN checkout (reuseExistingServer:false below), so a
@@ -61,8 +61,8 @@ export default defineConfig({
     },
 
     webServer: {
-        command            : `node ./e2e/globalSetup.mjs && npm run server-start -- --port ${PORT} --no-open`,
-        url                : `http://localhost:${PORT}`,
+        command: `node ./e2e/globalSetup.mjs && npm run server-start -- --port ${PORT} --no-open`,
+        url    : `http://localhost:${PORT}`,
         // NEVER reuse: an already-listening server from a foreign clone satisfies the readiness URL
         // and silently serves the wrong tree to every spec (false reds AND, worse, false greens).
         reuseExistingServer: false

--- a/test/playwright/playwright.config.e2e.mjs
+++ b/test/playwright/playwright.config.e2e.mjs
@@ -13,6 +13,18 @@ const PORT = resolveFreePortSync(process.env.NEO_E2E_PORT);
 // baseURL land on different ports (ERR_CONNECTION_REFUSED). Children inherit this; a real pin is a no-op.
 process.env.NEO_E2E_PORT = String(PORT);
 
+// Run-scoped artifact isolation (battery discipline): a battery runs the same spec serially, and
+// trace:'on' writes every execution's trace into the same per-test directory — run N+1 overwrites
+// run N's trace, so a roving red loses its evidence to a later green. NEO_E2E_RUN_ID scopes the
+// artifact root per run; unset keeps the legacy solo/film path. Battery invocation, persisting the
+// combined stream — Playwright forwards the webServer's stdout/stderr to the reporter by default
+// ('pipe'), so the tee below captures playwright AND server output into the run dir (verified:
+// 'inherit' is silently dropped by the runner, never forwarded):
+//   cd test/playwright && dir="test-results/e2e/battery/run-1" && mkdir -p "$dir" && \
+//   NEO_E2E_RUN_ID=run-1 npx playwright test -c playwright.config.e2e.mjs e2e/<spec> 2>&1 | tee "$dir/run.log"
+const RUN_ID        = process.env.NEO_E2E_RUN_ID || null,
+      ARTIFACT_ROOT = RUN_ID ? `./test-results/e2e/battery/${RUN_ID}/artifacts` : './test-results/e2e/artifacts';
+
 const
     launchArgs     = activeLaunchArgs(),
     needsGlProbe   = requiresGlProbe(launchArgs),
@@ -30,7 +42,7 @@ const
 
 export default defineConfig({
     testDir      : './e2e',
-    outputDir    : './test-results/e2e/artifacts',
+    outputDir    : ARTIFACT_ROOT,
     fullyParallel: false, // Maintain serial execution for benchmarks
     workers      : 1,     // Maintain serial execution for benchmarks
     timeout      : 90000, // E2E tests (like DevIndex) are heavy rendering apps


### PR DESCRIPTION
Resolves #16732

E2E battery runs no longer destroy their own evidence. `NEO_E2E_RUN_ID` scopes the e2e `outputDir` per run (`test-results/e2e/battery/<run-id>/artifacts`), so a serial battery keeps EVERY run's `trace.zip` — a roving red's trace can no longer be overwritten by a later green. The config comment carries the documented battery invocation, whose `tee` persists the combined playwright + webServer stream into the same run dir (the server stream was always forwarded in default `pipe` mode — the persistence was the missing half). Solo/film invocation is unchanged: unset `NEO_E2E_RUN_ID` keeps the legacy artifact path and quiet posture.

Intake note (self-authored carve): drift probe over `origin/dev` since the ticket's creation — zero intersection with the edit surface (`playwright.config.e2e.mjs`); `configTemplateResolver.mjs` moved (precedent citation only, per the carve's scope rule).

## Deltas from ticket

The ticket's Fix item 2 prescribed piping `webServer.stdout/stderr` in config. The experiment shrank it: Playwright 1.61's runner forwards webServer streams to the reporter only in `'pipe'` mode — which is already the default — and silently drops `'inherit'` (verified against `playwright/lib/runner/index.js` and by two live runs). So the server-log capture needs no config change at all; what was missing is the persisted tee, which the documented invocation provides. The diff is one env-driven `outputDir` plus comments — smaller than prescribed, with the mechanism named in the comment so the next battery inherits it.

## Test Evidence

Live three-run witness on this machine (headed-capable host, Chrome channel):

- `NEO_E2E_RUN_ID=witness-fail` + an intentionally red tmp spec → `1 failed`; `battery/witness-fail/artifacts/.../trace.zip` written; `run.log` carries the `[WebServer]` webpack-dev-server stream (8 lines incl. the Loopback URL).
- `NEO_E2E_RUN_ID=witness-pass` + a green tmp spec → `1 passed`; **both** battery trees' `trace.zip` files coexist (the clobber is dead — run-scoped roots make same-name overwrite unreachable by construction).
- Legacy solo run (no `NEO_E2E_RUN_ID`) → artifact lands in the legacy `test-results/e2e/artifacts/` path, behavior unchanged.
- Tmp witness specs deleted after the runs; nothing test-content-shaped is committed.

`test/playwright/playwright.config.e2e.mjs`: the only changed file — no unit surface; the witness above is the evidence form the ticket's Contract Ledger names ("staged fail+pass two-run witness", "staged failing boot keeps its server log").

Evidence: L3 (live local e2e runs, full harness path exercised) → L3 required (config-level harness change, locally verifiable). No residuals.

## Post-Merge Validation

- [ ] The next `#16620`-class battery re-run keeps all N runs' traces + per-run `run.log` under `test-results/e2e/battery/` (the Contract Ledger's convention row).

Authored by Iris (Kimi K3, Kimi Code CLI). Session 6df9925c-e527-496d-9fbf-0a277c175d59.
