### PR TITLE
fix(ai): FleetManager *StateOptions declared static — the class-as-singleton injection contract (#16786)

### DIFF
--- a/ai/services/fleet/FleetManager.mjs
+++ b/ai/services/fleet/FleetManager.mjs
@@ -78,10 +78,13 @@ class FleetManager extends Base {
      * resolveSubscriptionState}` per the `fleetWakeStateAdapter` contract. `null` ⇒ every source is
      * honestly `unknown`: this service is not a config entrypoint — config resolution belongs to the
      * composing process entrypoint, which resolves the daemon PID path + the identity-bound
-     * subscription read path and injects them here. Plain field, mirroring the sibling seams.
+     * subscription read path and injects them here. Static: the live write is a CLASS-static
+     * assignment from the entrypoint (class-as-singleton injection contract); prototype methods
+     * read it with `this` bound to the class. Declared static so the declaration matches the
+     * write — an instance construction can never shadow the injected value with a field `null`.
      * @member {Object|null} wakeStateOptions=null
      */
-    wakeStateOptions = null
+    static wakeStateOptions = null
     /**
      * Fleet repo-status aggregator seam. Defaults (via {@link getRepoStatusFn}) to `inspectFleetRepos`;
      * inject a recording stub for tests. Plain field.
@@ -93,19 +96,23 @@ class FleetManager extends Base {
      * per the `fleetThrottleStateAdapter` contract. `null` ⇒ every row is honestly `unknown`: no
      * trustworthy throttle truth source exists in the platform yet (the adapter documents the
      * evaluated-and-rejected candidates); the future watchdog-signals producer injects its reader
-     * here. Plain field, mirroring the sibling seams.
+     * here. Static, mirroring the sibling seams: the class-as-singleton injection contract — the
+     * declaration matches the CLASS-static write path, so an instance construction can never
+     * shadow the injected value with a field `null`.
      * @member {Object|null} throttleStateOptions=null
      */
-    throttleStateOptions = null
+    static throttleStateOptions = null
     /**
      * Presence observation options for {@link fleetPresenceStatus} — `{readPresence,
      * presenceIdentityFor}` per the `fleetPresenceStateAdapter` contract. `null` ⇒ every row is
      * honestly `unknown` under a degraded capability: the composing entrypoint injects the
      * identity-proven plane `who_is_online` reader in plane mode and leaves host mode unbound
-     * until a host presence surface lands. Plain field, mirroring the sibling seams.
+     * until a host presence surface lands. Static, mirroring the sibling seams: the
+     * class-as-singleton injection contract — the declaration matches the CLASS-static write
+     * path, so an instance construction can never shadow the injected value with a field `null`.
      * @member {Object|null} presenceStateOptions=null
      */
-    presenceStateOptions = null
+    static presenceStateOptions = null
 
     /**
      * @summary Resolve (field > env > default) the absolute fleet-managed checkout root.

--- a/test/playwright/unit/ai/services/fleet/FleetManager.spec.mjs
+++ b/test/playwright/unit/ai/services/fleet/FleetManager.spec.mjs
@@ -263,3 +263,27 @@ test.describe('Neo.ai.services.fleet.FleetManager — fleetThrottleStatus (roste
         }]);
     });
 });
+
+test.describe('Neo.ai.services.fleet.FleetManager — *StateOptions class-static injection contract', () => {
+    const SEAM_KEYS = ['wakeStateOptions', 'throttleStateOptions', 'presenceStateOptions'];
+
+    test('the seams are DECLARED class statics — the declaration exists where the entrypoint write lands', () => {
+        for (const key of SEAM_KEYS) {
+            expect(Object.hasOwn(FleetManager, key), `${key} must be a declared static`).toBe(true)
+        }
+    });
+
+    test('an instance construction can never shadow the class-static injection — no field initializers remain', () => {
+        const instance = Neo.create(FleetManager);
+
+        for (const key of SEAM_KEYS) {
+            // Pre-statics, the instance field initializer assigned null HERE and silently masked
+            // the class-static injection the entrypoint had placed. The witness: no own field,
+            // and the instance read resolves falsy-degraded (never a stale null that looks set).
+            expect(Object.hasOwn(instance, key), `${key} must not exist as an instance field`).toBe(false);
+            expect(instance[key], `${key} reads falsy-degraded on an instance`).toBeFalsy()
+        }
+
+        instance.destroy?.()
+    });
+});


### PR DESCRIPTION
Resolves #16786

The three telltale injection seams (`wakeStateOptions` / `throttleStateOptions` / `presenceStateOptions`) were declared as INSTANCE fields on FleetManager while the production writer assigns the CLASS property (`devFleetServer.mjs:144` / `:170` / `:186`). The declaration said instance; the write said static. They agreed only because the class is never instantiated on any live path (`FleetControlBridge.getManager()` falls back to the class-as-singleton). A future `Neo.create(FleetManager)` — a second consumer, a real-class test double — would run the field initializers, get `this.presenceStateOptions = null`, and SHADOW the injected class-static reader: the axes silently degrade to honest-`unknown` with green-looking wiring, and the adapters' honesty contract reports "no producer" rather than "shadowed injection". All three seams are now declared `static`, with JSDoc naming the class-as-singleton injection contract — the declaration matches the sanctioned write path, and instance construction resolves falsy-degraded (never a stale `null` that looks configured).

Evidence: L3 (exact-head unit suite incl. the new contract witnesses) → L3 required (the ACs are declaration-level, fully spec-reachable). Residual: none.

## Deltas from ticket
- Behavior-preserving on every live path: class reads resolve identically (the write lands on a DECLARED static now instead of an undeclared expansion); instance reads resolve `undefined` → falsy → the same honest-degraded path as `null` today, and can never shadow.
- Scope boundary held deliberately: `lifecycleService`, `provisionAndStartFn`, and `repoStatusFn` are the same plain-field seam family (`FleetManager.mjs:68` and the spec files' own class-static assignments show the pattern), but they are NOT `*StateOptions` and stay out of this leaf's letter — candidate one-line follow-up if a reviewer wants the family closed in one pass.
- `throttleStateOptions` has no production writer yet (the future watchdog producer per the adapter's own header) — converted for family uniformity, so the trap can never grow in with the producer.
- Origin: filed from my PR #16781 review (the class-as-singleton trace) — the finding's evidence chain is on the ticket.

## Test Evidence
- NEW witness block in `FleetManager.spec` — *StateOptions class-static injection contract: (1) all three seams are DECLARED class statics (`Object.hasOwn(FleetManager, key)`), so the declaration now exists where the entrypoint write lands; (2) `Neo.create(FleetManager)` carries NO instance field for any seam — construction can never shadow the injection, and the instance read is falsy-degraded.
- `npm run test-unit -- ai/services/fleet/FleetManager.spec ai/services/fleet/fleetPresenceStateAdapter.spec ai/services/fleet/fleetWakeRoutesSource.spec ai/services/fleet/FleetControlBridge.spec ai/services/fleet/fleetCockpitStatus.spec` → **100/100 passed** (the full consumer neighborhood of the three seams).
- Surface: ai/services/fleet (Brain-side) — unit suite above; no app surface touched.

## Post-Merge Validation
- [ ] Next plane-mode cockpit boot (`npm run cockpit`) reports wake/presence axes wired exactly as before — the write now lands on declared statics (compose with #16787's PMV line).

Authored by Phoebe (Kimi k3, opencode). Session 3167a938-5173-471d-b8ee-2c5f603f5c92.