### PR TITLE
feat(ai): the deployment-state snapshot carries the revision that produced it (#16791)

### DIFF
--- a/ai/daemons/orchestrator/services/DeploymentStateBridgeService.mjs
+++ b/ai/daemons/orchestrator/services/DeploymentStateBridgeService.mjs
@@ -17,6 +17,7 @@ import {
     readBackupReceipt,
     validateOffHostSyncConfig
 } from '../../../services/memory-core/helpers/offHostSyncStore.mjs';
+import {readDeployedRevision}        from '../../../services/shared/deployedRevision.mjs';
 import {describeBackupRetryState}    from '../scheduling/backup.mjs';
 import {resolveDurabilityPosture}    from './deploymentDurabilityPosture.mjs';
 import {summarizeStagingResidue}     from '../../../scripts/maintenance/backupStagingResidueCore.mjs';
@@ -262,7 +263,12 @@ export class DeploymentStateBridgeService extends Base {
             recoveryRuns,
             selfHeal,
             tenantRepoSync,
-            maintenance
+            maintenance,
+            // Read here rather than inside the store: the store stays pure and every other
+            // collection in this method is likewise an I/O boundary owned by the service. The same
+            // reader already backs both MCP healthchecks, so a plane cannot report two different
+            // revisions for itself depending on which surface is asked.
+            deployedRevision: readDeployedRevision()
         });
     }
 

--- a/ai/services/memory-core/helpers/deploymentStateBridgeStore.mjs
+++ b/ai/services/memory-core/helpers/deploymentStateBridgeStore.mjs
@@ -40,6 +40,7 @@ const CURRENT_PRODUCER_METADATA = Object.freeze({
  * @param {Object|null} [options.recoveryRuns=null] Bounded recovery-run ledger snapshot.
  * @param {Object|null} [options.selfHeal=null] Bounded self-heal immune-system status (heal-ledger summary + recent events).
  * @param {Object|null} [options.tenantRepoSync=null] Bounded tenant-repo-sync scheduler/task/config snapshot.
+ * @param {String|null} [options.deployedRevision=null] The revision that produced this snapshot.
  * @param {Object} [options.producer=CURRENT_PRODUCER_METADATA] Bounded snapshot producer metadata.
  * @returns {Object}
  */
@@ -52,6 +53,7 @@ export function createDeploymentStateSnapshot({
     selfHeal = null,
     tenantRepoSync = null,
     maintenance = null,
+    deployedRevision = null,
     producer = CURRENT_PRODUCER_METADATA
 } = {}) {
     if (!Number.isFinite(generatedAt)) {
@@ -67,7 +69,13 @@ export function createDeploymentStateSnapshot({
         recordType   : 'deployment-state-snapshot',
         generatedAt,
         source,
-        producer     : sanitizeProducerMetadata(producer),
+        // ALWAYS present, `null` included. A snapshot says what a plane observed; without the
+        // revision that produced it, none of the observations can be re-read against the code that
+        // made them — a recovery decision, a diagnosis and a heal event all become uninterpretable
+        // once the image moves. Omitting the key when unknown would be worse than reporting null,
+        // because an absent field reads as "current" to anyone checking for skew.
+        deployedRevision: typeof deployedRevision === 'string' && deployedRevision.trim() ? deployedRevision.trim() : null,
+        producer        : sanitizeProducerMetadata(producer),
         services,
         bridgeDiagnostics,
         recoveryRuns,

--- a/test/playwright/unit/ai/services/memory-core/helpers/deploymentStateBridgeStore.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/helpers/deploymentStateBridgeStore.spec.mjs
@@ -51,6 +51,27 @@ test.describe('deploymentStateBridgeStore', () => {
         expect(createDeploymentStateSnapshot({generatedAt: 1}).selfHeal).toBeNull(); // additive + back-compat (omitted → null)
     });
 
+    test('carries the revision that produced the snapshot, and reports null rather than omitting it', () => {
+        const withRevision = createDeploymentStateSnapshot({
+            generatedAt     : 1710000000000,
+            deployedRevision: '55219f40d8d1766ba44bd5b40708a3e0c8f2fec4'
+        });
+
+        expect(withRevision.deployedRevision).toBe('55219f40d8d1766ba44bd5b40708a3e0c8f2fec4');
+
+        // The load-bearing half. A snapshot whose revision is unknown must still CARRY the key:
+        // an absent field reads as "current" to anyone checking for skew, so omitting it turns
+        // "we do not know what produced this" into "this is fine".
+        const unknown = createDeploymentStateSnapshot({generatedAt: 1710000000000});
+
+        expect(Object.hasOwn(unknown, 'deployedRevision')).toBe(true);
+        expect(unknown.deployedRevision).toBeNull();
+
+        // A blank or non-string marker is unknown, not a revision — it must never travel as one.
+        expect(createDeploymentStateSnapshot({deployedRevision: '  '}).deployedRevision).toBeNull();
+        expect(createDeploymentStateSnapshot({deployedRevision: 12345}).deployedRevision).toBeNull();
+    });
+
     test('degrades fresh legacy snapshots without producer metadata (#14408)', async () => {
         const dir      = await fs.mkdtemp(path.join(os.tmpdir(), 'deployment-state-bridge-')),
               filePath = path.join(dir, 'snapshot.json'),


### PR DESCRIPTION
Resolves neomjs/neo#16791

The deployment-state snapshot publishes inspect summaries, stats, log tails, service classification, `selfHeal`, `recoveryRuns`, `tenantRepoSync` and `maintenance` — and did not say which code produced any of it. Once the image moves, a recovery decision, a diagnosis and a heal event all become unreadable against the code that made them. The snapshot now carries `deployedRevision`, read through `readDeployedRevision()` — the same reader already behind both MCP healthchecks, so a plane cannot report two different revisions for itself depending on which surface is asked.

Evidence: L3 (unit, mutation-convicted) → L5 required (a running orchestrator writing a snapshot that carries its own revision). Residual: the post-merge item below [#16791].

## Deltas from ticket

**The ticket's headline premise was falsified by measurement, by me, before implementation — and the ticket was narrowed rather than quietly implemented as filed.**

I filed neomjs/neo#16791 this morning claiming *"nothing an agent or operator continuously reads ever reports it."* Measured on the canonical plane after today's rebuild to `dev` head `55219f40d8`: **both** MCP healthchecks already publish `deployedRevision`, plus `runtimeFreshness.status: "current"`. A healthcheck is exactly the continuously-read published surface the ticket claimed did not exist.

The original `.neo-revision` consumer table was accurate and was **the wrong population to reason from** — it enumerated *file readers*, not *published surfaces*, so the search could not have found the field that already existed. The ticket title and body are corrected in place, struck rather than rewritten.

What survived is this PR: the **deployment-state snapshot** — the artifact the container-health and recovery lanes actually consume — carried no revision. Verified against a live snapshot: no revision field at any level.

Scope deliberately not taken: no schema-version bump. The field is additive and scalar, not a section; `CURRENT_SNAPSHOT_SECTIONS` and the additive-section tolerance are untouched, so older consumers are unaffected and older snapshots are not degraded by its absence.

## Test Evidence

```
UNIT_TEST_MODE=true npx playwright test --config=test/playwright/playwright.config.unit.mjs \
  test/playwright/unit/ai/services/memory-core/ test/playwright/unit/ai/daemons/orchestrator/
→ 2870 passed, 1 failed

npm run agent-preflight -- --change-class capability --commit-subject "..." <3 files>
→ all requested gates passed
```

**The one failure is not this diff and I am not asserting it away:** `SessionSummarization.spec.mjs:543 — "SessionService performance: measure latency for 1 session via API"`. Re-run in isolation it **passes in 15.3s**; it is a latency assertion that failed under full-suite parallel load. This diff adds one scalar field to a snapshot object and cannot influence session-summarization latency. CI is the oracle.

**Mutation-convicted, checked to redden the expected test:**

| mutation | expected red | result |
|---|---|---|
| omit `deployedRevision` when unknown (`...(rev ? {rev} : {})`) | `carries the revision that produced the snapshot, and reports null rather than omitting it` | ✅ red |

That is the load-bearing half. **An absent field reads as "current" to anyone checking for skew**, so omitting the key when the revision is unknown turns *"we do not know what produced this"* into *"this is fine"*. The control also proves a blank or non-string marker never travels as a revision — a gap my first implementation had, caught by writing the assertion before trusting the code.

Surfaces touched: `ai/services/memory-core/helpers/` — `deploymentStateBridgeStore.spec.mjs` (extended here). `ai/daemons/orchestrator/services/DeploymentStateBridgeService.mjs` — no dedicated snapshot-revision spec; covered at the store, which owns the schema.

## Post-Merge Validation

- [ ] On a running orchestrator, `get_deployment_state_snapshot().snapshot.deployedRevision` equals the plane's `/app/.neo-revision`, and matches `deployedRevision` from both MCP healthchecks.
- [ ] A local (non-image) run reports `deployedRevision: null` rather than omitting the key.

Related: neomjs/neo-agent-brain#54 (parent Epic)

Authored by Grace (Claude Opus 5, Claude Code). Session d8332b13-5d97-4839-ac11-d2de4602a989.
