### PR TITLE
feat(ai): list_issues resolves the `@me` assignee alias on the read path (#16806)

### DIFF
--- a/ai/mcp/server/github-workflow/openapi.yaml
+++ b/ai/mcp/server/github-workflow/openapi.yaml
@@ -1159,7 +1159,7 @@ paths:
         - name: assignee
           in: query
           required: false
-          description: Filter issues by a single assignee login. Applied server-side, so `limit` bounds the MATCHES returned rather than the rows searched — check `truncated` before treating the result as this agent's complete ownership.
+          description: Filter issues by a single assignee login. Applied server-side, so `limit` bounds the MATCHES returned rather than the rows searched — check `truncated` before treating the result as this agent's complete ownership. `@me` resolves to the authenticated viewer login (the same contract `manage_issue_assignees` honors).
           schema:
             type: string
         - name: projection

--- a/ai/services/github-workflow/IssueService.mjs
+++ b/ai/services/github-workflow/IssueService.mjs
@@ -1282,7 +1282,7 @@ class IssueService extends Base {
      * @param {number}          [options.limit=30]          The maximum number of issues to return
      * @param {string}          [options.state='open']      Filter issues by state (open, closed)
      * @param {string[]|string} [options.labels]            Labels to filter by; an issue must carry ALL of them. Applied to this page's rows, so `totalCount` is null when set
-     * @param {string}          [options.assignee]          Filter issues by a single assignee login
+     * @param {string}          [options.assignee]          Filter issues by a single assignee login; `@me` resolves to the authenticated viewer (same contract as `manage_issue_assignees`)
      * @param {'full'|'summary'|'title'|'title_only'} [options.projection='full'] Response shape projection
      * @param {string}          [options.cursor]            Cursor for pagination; pass a prior `endCursor`
      * @param {'updated'|'created'} [options.sort='updated'] Order field: `updated` (default) or `created` — creation order is the freshness-sweep evidence (updated-desc buries untouched fresh filings below recently-updated older issues)
@@ -1326,6 +1326,22 @@ class IssueService extends Base {
         const labelList = labels
             ? (Array.isArray(labels) ? labels : String(labels).split(',').map(part => part.trim())).filter(Boolean)
             : null;
+
+        // The `@me` alias resolves to the authenticated viewer login — the same contract the write
+        // path honors (`create_issue`, `manage_issue_assignees`; `#resolveAssigneeAliases`). Concrete
+        // logins pass through untouched, and a failed resolution maps to the same structured error a
+        // failed mutation returns — never a raw GraphQL rejection for a login that does not exist.
+        if (assignee === '@me') {
+            try {
+                [assignee] = await this.#resolveAssigneeAliases([assignee]);
+            } catch (error) {
+                return {
+                    error  : 'GitHub API request failed',
+                    message: error.message,
+                    code   : 'GITHUB_API_ERROR'
+                };
+            }
+        }
 
         // `filterBy: {assignee: null}` routes GitHub's issues connection to a stale, hours-lagged
         // read path (measured live 2026-07-22, #15603; ticket-ref-ok: measured-quirk evidence ledger): a controlled assignment stayed invisible on

--- a/test/playwright/unit/ai/services/github-workflow/IssueService.spec.mjs
+++ b/test/playwright/unit/ai/services/github-workflow/IssueService.spec.mjs
@@ -1728,3 +1728,102 @@ test.describe('Neo.ai.services.github-workflow.IssueService — createIssue REST
         expect(result.message).toContain('issue number');
     });
 });
+
+test.describe('Neo.ai.services.github-workflow.IssueService — listIssues @me assignee alias (#16806)', () => {
+    let IssueService;
+    let GraphqlService;
+    let originalQuery;
+    let originalRest;
+
+    test.beforeAll(async () => {
+        GraphqlService = (await import('../../../../../../ai/services/github-workflow/GraphqlService.mjs')).default;
+        IssueService   = (await import('../../../../../../ai/services/github-workflow/IssueService.mjs')).default;
+
+        originalQuery = GraphqlService.query.bind(GraphqlService);
+        originalRest  = GraphqlService.rest.bind(GraphqlService);
+    });
+
+    test.afterAll(() => {
+        GraphqlService.query = originalQuery;
+        GraphqlService.rest  = originalRest;
+    });
+
+    // Hermetic guard: the alias path routes the viewer lookup through GraphqlService.rest. Any test
+    // that reaches it MUST stub rest explicitly; an unstubbed reach throws loudly here rather than
+    // hitting real GitHub.
+    test.beforeEach(() => {
+        GraphqlService.rest = async (method, path) => {
+            throw new Error(`Unexpected GraphqlService.rest call in listIssues @me test: ${method} ${path}`);
+        };
+    });
+
+    function installIssueListStub(capture = {}) {
+        GraphqlService.query = async (query, variables) => {
+            capture.query     = query;
+            capture.variables = variables;
+
+            return {repository: {issues: {nodes: []}}};
+        };
+    }
+
+    test('resolves the @me alias to the viewer login before the GraphQL query', async () => {
+        const capture = {};
+        installIssueListStub(capture);
+
+        let restCalls = 0;
+        GraphqlService.rest = async (method, path) => {
+            restCalls++;
+
+            if (method === 'GET' && path === '/user') {
+                return {login: 'neo-kimi-iris'};
+            }
+
+            throw new Error(`Unexpected GraphqlService.rest call: ${method} ${path}`);
+        };
+
+        const result = await IssueService.listIssues({limit: 10, state: 'open', assignee: '@me'});
+
+        expect(restCalls).toBe(1);
+        expect(capture.variables.assignee).toBe('neo-kimi-iris');
+        expect(result.count).toBe(0);
+    });
+
+    test('passes concrete logins through with no viewer round-trip', async () => {
+        const capture = {};
+        installIssueListStub(capture);
+
+        // The beforeEach hermetic guard makes any rest reach throw, so reaching the query with the
+        // login unchanged proves the short-circuit: no GET /user happens for a concrete login.
+        const result = await IssueService.listIssues({limit: 10, state: 'open', assignee: 'neo-gpt'});
+
+        expect(capture.variables.assignee).toBe('neo-gpt');
+        expect(result.count).toBe(0);
+    });
+
+    test('returns GITHUB_API_ERROR and issues no GraphQL query when the viewer lookup fails', async () => {
+        let queryIssued = false;
+        GraphqlService.query = async () => {
+            queryIssued = true;
+            return {repository: {issues: {nodes: []}}};
+        };
+
+        GraphqlService.rest = async () => {
+            throw new Error('GET /user failed');
+        };
+
+        const result = await IssueService.listIssues({limit: 10, state: 'open', assignee: '@me'});
+
+        expect(result.error).toBe('GitHub API request failed');
+        expect(result.code).toBe('GITHUB_API_ERROR');
+        expect(queryIssued).toBe(false);
+    });
+
+    test('returns GITHUB_API_ERROR naming @me when the viewer response carries no login', async () => {
+        GraphqlService.rest = async () => ({});
+
+        const result = await IssueService.listIssues({limit: 10, state: 'open', assignee: '@me'});
+
+        expect(result.code).toBe('GITHUB_API_ERROR');
+        expect(result.message).toContain('@me');
+    });
+});


### PR DESCRIPTION
Resolves #16828

Refs #16806

**Close disposition (review RA-1, cycle 2):** the L2-leaf split per the `#16776` pattern. This PR resolves `#16828` — the delivered subset (parent AC-2/3/4, all discharged by the receipts below). The parent `#16806` stays open for AC-1 alone — live behavioural equivalence against the merged server, structurally unreachable from a stubbed-transport suite — and the Post-Merge Validation box below is that criterion, verbatim. Cycle 1 used `Refs`-only, which CI rejected: `agent-pr-body-lint.yml` enforces the operator's `#12367` rule (a non-draft agent PR must carry `Resolves #N`), so `Refs`-only was never an available shape — the leaf is the only form satisfying the lint, the close-target audit, and the review at once.

`list_issues({assignee: '@me'})` no longer dies on a raw GraphQL rejection. The read path now resolves the alias through the same in-file mechanism the write path has always used (`#resolveAssigneeAliases`, cached-token `GET /user`, one round-trip only when the alias is present): `IssueService.listIssues` maps `@me` to the authenticated viewer login before building the server-side `filterBy`, and a failed resolution returns the structured `GITHUB_API_ERROR` shape a failed mutation returns — never GitHub's "Could not find an assignee" for a login that does not exist. Concrete logins pass through with zero added round-trips. The `openapi.yaml` description now advertises the alias, matching `manage_issue_assignees`.

Intake note (self-authored carve): authored this session; the six-stage chain ran at creation time per `ticket-create` — exemption per `self-authored-carve.md`, no drift probe required.

## Deltas from ticket

None substantive — the ticket prescribed exactly this shape (reuse `#resolveAssigneeAliases`; named error on failure; advertise in the tool description). One naming choice folded at implementation: the failure shape reuses the sibling `createIssue` precedent (`GITHUB_API_ERROR` + the resolver's `@me`-naming message) rather than minting a new error code, so the read and write surfaces fail identically.

## Test Evidence

`UNIT_TEST_MODE=true npx playwright test -c test/playwright/playwright.config.unit.mjs test/playwright/unit/ai/services/github-workflow/IssueService.spec.mjs` → **71 passed** (67 pre-existing + 4 new falsifiers): the alias resolves to the viewer login pre-query with exactly one rest round-trip; a concrete login passes through with no rest call (the hermetic guard throws on any reach); a viewer-lookup failure returns `GITHUB_API_ERROR` with NO GraphQL query issued; a login-less viewer response returns `GITHUB_API_ERROR` naming `@me`.

`npm run ai:lint-openapi-service-parity` → OK (40 wrapped services, 0 consumed-but-undeclared parameters). Full pre-commit gate battery green on the commit (whitespace, shorthand, jsdoc-types, ticket-archaeology, block-alignment, parse, aiconfig-test-mutation, derived-domain).

`ai/services/github-workflow/IssueService.mjs` + `test/playwright/unit/ai/services/github-workflow/IssueService.spec.mjs`: covered by the touched spec (71/71). `ai/mcp/server/github-workflow/openapi.yaml`: description-only change; the parity lint is the covering surface.

Evidence: L2 (mock-transport unit suite, 71/71) → L3 required (live `list_issues({assignee: '@me'})` equivalence against the merged server). Residual: L3 [#16806] — held open on the ticket as its home.

## Post-Merge Validation

- [ ] `list_issues({assignee: '@me'})` against the merged server returns the caller's open lanes — identical set to `list_issues({assignee: '<caller login>'})`. (= #16806 AC-1, verbatim; the ticket stays open for it.)

Authored by Iris (Kimi K3, Kimi Code CLI). Session 5d15190b-c9da-4dfe-b448-2e67e2fdb9f6.
