### PR TITLE
fix(deploy): give the heap-observation channel a shared mount (#16810)

### DIFF
--- a/ai/deploy/docker-compose.dev.yml
+++ b/ai/deploy/docker-compose.dev.yml
@@ -195,6 +195,10 @@ services:
       # which two parity projects resolve to the same directory. That is the exact
       # duplicate-stacks-on-one-plane failure the named-volume election was chosen to prevent.
       - parity-plane:/app/.neo-ai-data-parity
+      # Heap-observation channel, parity half: the env pin relocates the channel under the parity
+      # root (x-plane-env NEO_HEAP_OBSERVATION_DIR), so this dedicated volume shadows that subdir.
+      # Without it the writer still shares via the rw plane root — but the reader would too.
+      - parity-heap-observation:/app/.neo-ai-data-parity/heap-observation
       # Anonymous volume: the image's linux-built node_modules must not be shadowed by the
       # host bind (darwin/arm64 natives → exec format error; AC5 live-run defect 2, #15803).
       - /app/node_modules
@@ -259,6 +263,8 @@ services:
       # which two parity projects resolve to the same directory. That is the exact
       # duplicate-stacks-on-one-plane failure the named-volume election was chosen to prevent.
       - parity-plane:/app/.neo-ai-data-parity
+      # Heap-observation channel, parity half — see the kb-server mount. Writer side stays rw.
+      - parity-heap-observation:/app/.neo-ai-data-parity/heap-observation
       # Anonymous volume: same node_modules shadowing guard as kb-server (AC5 defect 2).
       - /app/node_modules
     # Served identity, same contract as kb-server above — both servers declare `plane {id, dataRoot}`
@@ -334,6 +340,10 @@ services:
       # which two parity projects resolve to the same directory. That is the exact
       # duplicate-stacks-on-one-plane failure the named-volume election was chosen to prevent.
       - parity-plane:/app/.neo-ai-data-parity
+      # Heap-observation channel, parity half — READ side, read-only on purpose: the record
+      # carries provenance self-reported, and the bridge must never author what it publishes.
+      # Without this shadow the rw plane root above would leave the parity reader writable.
+      - parity-heap-observation:/app/.neo-ai-data-parity/heap-observation:ro
       # Same node_modules shadowing guard as the servers (AC5 defect 2).
       - /app/node_modules
       - /var/run/docker.sock:/var/run/docker.sock
@@ -359,6 +369,10 @@ networks:
 volumes:
   parity-chroma: {}
   parity-plane: {}
+  # Heap-observation channel on the parity root: writers are the MCP servers declaring
+  # getHeapObservationServiceKey(), the orchestrator reads it :ro — mirrors the canonical
+  # shared-heap-observation-data one profile over, at the env-pinned parity path.
+  parity-heap-observation: {}
 
 # Environment-backed secret: the host exports the PAT once, Compose materializes it as a mounted
 # file only for the two MCP servers, and rendered config retains the env VAR NAME rather than its

--- a/ai/deploy/docker-compose.yml
+++ b/ai/deploy/docker-compose.yml
@@ -122,6 +122,14 @@ services:
       # A dedicated volume keeps this graph-independent receipt visible without
       # granting the KB container Docker/runtime authority.
       - shared-deployment-state-data:/app/.neo-ai-data/deployment-state:ro
+      # WRITE half of the heap-observation channel, which runs the OPPOSITE
+      # direction to the bridge above: this service reports its own V8 heap and the
+      # orchestrator reads it. Without this mount the reporter writes into the
+      # container's own layer and the orchestrator reads its own empty one, so every
+      # observation surfaces as `unavailable/absent` forever — a silent no-op, because
+      # the reporter is deliberately non-fatal and a successful local write looks
+      # identical to a delivered one.
+      - shared-heap-observation-data:/app/.neo-ai-data/heap-observation
     depends_on:
       chroma:
         condition: service_healthy
@@ -237,6 +245,9 @@ services:
       # Read-only half of the orchestrator -> public MCP deployment-state bridge, and the mount the
       # recovery actuator publishes its config overlay onto.
       - shared-deployment-state-data:/app/.neo-ai-data/deployment-state:ro
+      # WRITE half of the heap-observation channel — see the kb-server mount for why the
+      # absence of this line produced a channel that reported success and delivered nothing.
+      - shared-heap-observation-data:/app/.neo-ai-data/heap-observation
     depends_on:
       chroma:
         condition: service_healthy
@@ -345,6 +356,10 @@ services:
       # Sole writer for the graph-independent deployment-state bridge consumed
       # read-only by KB/MC.
       - shared-deployment-state-data:/app/.neo-ai-data/deployment-state
+      # READ half of the heap-observation channel. Read-only on purpose: the
+      # services vouch for their own heap, and the bridge must never be able to author
+      # an observation it then publishes as `provenance: self-reported`.
+      - shared-heap-observation-data:/app/.neo-ai-data/heap-observation:ro
       - tenant-repo-mirrors:/app/.neo-ai-data/tenant-repos
       # The `golden-path` scheduler lane writes the handoff and its derived
       # route artifacts here; mc-server mounts the same directory read-side.
@@ -607,6 +622,9 @@ volumes:
   shared-sqlite-data:
   shared-deployment-state-data:
   shared-handoff-data:
+  # Heap-observation channel: written by every MCP server declaring
+  # `getHeapObservationServiceKey()`, read by the orchestrator's deployment-state bridge.
+  shared-heap-observation-data:
   tenant-repo-mirrors:
   caddy-data:
   caddy-config:

--- a/test/playwright/unit/ai/deploy/HeapObservationChannelMount.spec.mjs
+++ b/test/playwright/unit/ai/deploy/HeapObservationChannelMount.spec.mjs
@@ -64,41 +64,152 @@ const
     devCompose      = yamlLoad(fs.readFileSync(devComposePath, 'utf8')),
     configBaseText  = fs.readFileSync(configBasePath, 'utf8'),
     planeConfigText = fs.readFileSync(planeConfigPath, 'utf8'),
+    configBaseAst   = acorn.parse(configBaseText,  {ecmaVersion: 'latest', sourceType: 'module'}),
+    planeConfigAst  = acorn.parse(planeConfigText, {ecmaVersion: 'latest', sourceType: 'module'}),
     READER_SERVICE  = 'orchestrator',
     PARITY_VOLUME   = 'parity-heap-observation';
 
 /**
- * The config-authoritative channel path pieces, proved to definition level: the
- * `heapObservation.dir` leaf's resolve expression (anchor name AND segment), the anchor's
- * DEFINITION (a name-pin alone stays green when the definition moves the runtime path — the
- * cycle-3 residual), the `neoRootDir` definition beneath it, and `planeConfig`'s relative root.
- * Every link fails closed.
+ * Collects every AST node of a given type (recursive walk over the structural tree).
+ * @param {*} node
+ * @param {String} type
+ * @param {Object[]} [hits]
+ * @returns {Object[]}
+ */
+function collectByType(node, type, hits=[]) {
+    if (!node || typeof node !== 'object') return hits;
+
+    if (node.type === type) {
+        hits.push(node)
+    }
+
+    for (const value of Object.values(node)) {
+        if (Array.isArray(value)) {
+            value.forEach(item => { item?.type && collectByType(item, type, hits) })
+        } else if (value?.type) {
+            collectByType(value, type, hits)
+        }
+    }
+
+    return hits
+}
+
+/**
+ * Finds a module-scope `const <name> = …` declarator.
+ * @param {Object} ast
+ * @param {String} name
+ * @returns {Object|undefined}
+ */
+function findModuleConst(ast, name) {
+    for (const node of ast.body) {
+        if (node.type === 'VariableDeclaration') {
+            const declarator = node.declarations.find(d => d.id?.name === name);
+
+            if (declarator) return declarator
+        }
+    }
+
+    return undefined
+}
+
+/**
+ * True when the node is `path.resolve(__dirname, '../')` (the repo-root anchor).
+ * @param {*} node
+ * @returns {Boolean}
+ */
+function isPathResolveDirnameParent(node) {
+    return node?.type === 'CallExpression' &&
+        node.callee?.type === 'MemberExpression' &&
+        node.callee.object?.name === 'path' &&
+        node.callee.property?.name === 'resolve' &&
+        node.arguments.length === 2 &&
+        node.arguments[0].type === 'Identifier' && node.arguments[0].name === '__dirname' &&
+        node.arguments[1].type === 'Literal' && /^'\.\.\/?'$/.test(node.arguments[1].raw || '') // '../' or '..'
+}
+
+/**
+ * The config-authoritative channel path pieces, proved STRUCTURALLY to binding level: a regex
+ * pins a spelling, but a substituted import binding (`import {resolvePlaneDataRoot as X}` plus a
+ * local shadow) keeps every spelling while moving the runtime path — so the chain is verified in
+ * the AST: the unaliased import from `./planeConfig.mjs`, no module-scope shadow, the anchor's
+ * definition, the repo-root definition, and the leaf's call shape. Every link fails closed.
  * @returns {{dirSegment: String, dataRootRelative: String}}
  */
 function readChannelPathAuthorities() {
-    const dirExpr = configBaseText.match(/heapObservation:\s*\{[\s\S]*?dir\s*:\s*leaf\(path\.resolve\(([A-Za-z]+),\s*'([^']+)'\)/);
+    // 1. The resolver binding: imported from ./planeConfig.mjs, unaliased, unshadowed.
+    const importDecl = configBaseAst.body.find(
+        node => node.type === 'ImportDeclaration' && node.source.value === './planeConfig.mjs'
+    );
 
-    // Fail closed: an unmatched regex must not silently assert nothing.
-    expect(dirExpr, 'ai/configBase.mjs still declares heapObservation.dir as a leaf(path.resolve(anchor, segment))').toBeTruthy();
-    expect(
-        dirExpr[1],
-        'the heapObservation.dir leaf still anchors on planeDataRootDefault — an anchor move changes the runtime path and must red here'
-    ).toBe('planeDataRootDefault');
+    expect(importDecl, 'ai/configBase.mjs still imports from ./planeConfig.mjs').toBeTruthy();
+
+    const specifier = importDecl.specifiers.find(
+        s => s.type === 'ImportSpecifier' && s.imported?.name === 'resolvePlaneDataRoot'
+    );
 
     expect(
-        /const planeDataRootDefault\s*=\s*resolvePlaneDataRoot\(\{rootDir:\s*neoRootDir\}\)/.test(configBaseText),
+        specifier?.local?.name === 'resolvePlaneDataRoot',
+        'resolvePlaneDataRoot is imported UNALIASED — an alias plus a local shadow would move the runtime path behind an unchanged call spelling'
+    ).toBe(true);
+
+    const shadow = configBaseAst.body.find(node =>
+        (node.type === 'VariableDeclaration' && node.declarations.some(d => d.id?.name === 'resolvePlaneDataRoot')) ||
+        (node.type === 'FunctionDeclaration' && node.id?.name === 'resolvePlaneDataRoot')
+    );
+
+    expect(shadow, 'no module-scope shadow of the imported resolver').toBeFalsy();
+
+    // 2. The anchor's definition: planeDataRootDefault = resolvePlaneDataRoot({rootDir: neoRootDir}).
+    const anchorDef = findModuleConst(configBaseAst, 'planeDataRootDefault'),
+          init      = anchorDef?.init;
+
+    expect(
+        init?.type === 'CallExpression' &&
+        init.callee?.type === 'Identifier' && init.callee.name === 'resolvePlaneDataRoot' &&
+        init.arguments.length === 1 &&
+        init.arguments[0].type === 'ObjectExpression' &&
+        init.arguments[0].properties.some(p =>
+            p.key?.name === 'rootDir' && p.value?.type === 'Identifier' && p.value.name === 'neoRootDir'
+        ),
         'planeDataRootDefault is still DEFINED as resolvePlaneDataRoot({rootDir: neoRootDir}) — a definition-level move changes the runtime path and must red here'
     ).toBe(true);
+
+    // 3. The repo-root definition beneath it.
     expect(
-        /const neoRootDir\s*=\s*path\.resolve\(__dirname,\s*'\.\.\/?'\)/.test(configBaseText),
+        isPathResolveDirnameParent(findModuleConst(configBaseAst, 'neoRootDir')?.init),
         'neoRootDir is still defined as the configBase-relative repository root'
     ).toBe(true);
 
-    const relative = planeConfigText.match(/dataRootRelative:\s*'([^']+)'/);
+    // 4. The leaf call itself: dir = leaf(path.resolve(planeDataRootDefault, '<segment>'), …).
+    const heapProperty = collectByType(configBaseAst, 'Property').find(p => p.key?.name === 'heapObservation'),
+          dirProperty  = heapProperty?.value?.properties?.find(p => p.key?.name === 'dir'),
+          leafCall     = dirProperty?.value;
 
-    expect(relative, 'ai/planeConfig.mjs still declares PLANE_DEFAULTS.dataRootRelative').toBeTruthy();
+    expect(
+        leafCall?.type === 'CallExpression' && leafCall.callee?.name === 'leaf',
+        'heapObservation.dir is still a leaf(…) declaration'
+    ).toBe(true);
 
-    return {dirSegment: dirExpr[2], dataRootRelative: relative[1]}
+    const resolveCall = leafCall.arguments[0];
+
+    expect(
+        resolveCall?.type === 'CallExpression' &&
+        resolveCall.callee?.type === 'MemberExpression' &&
+        resolveCall.callee.object?.name === 'path' && resolveCall.callee.property?.name === 'resolve' &&
+        resolveCall.arguments[0]?.type === 'Identifier' && resolveCall.arguments[0].name === 'planeDataRootDefault' &&
+        resolveCall.arguments[1]?.type === 'Literal' && typeof resolveCall.arguments[1].value === 'string',
+        'the dir leaf still resolves path.resolve(planeDataRootDefault, \'<segment>\') — anchor and segment are bound, not assumed'
+    ).toBe(true);
+
+    // 5. planeConfig's relative root, structurally.
+    const relativeProperty = collectByType(planeConfigAst, 'Property').find(p => p.key?.name === 'dataRootRelative');
+
+    expect(
+        relativeProperty?.value?.type === 'Literal' && typeof relativeProperty.value.value === 'string',
+        'ai/planeConfig.mjs still declares PLANE_DEFAULTS.dataRootRelative'
+    ).toBe(true);
+
+    return {dirSegment: resolveCall.arguments[1].value, dataRootRelative: relativeProperty.value.value}
 }
 
 /**
@@ -118,17 +229,55 @@ function readComposePlaneRoot(composeDoc) {
 }
 
 /**
+ * Classifies one class element's key: public exact name, private name, or unresolvable computed.
+ * A computed key is resolvable only as a string Literal or a no-expression TemplateLiteral —
+ * anything else means the census cannot prove the element is not a producer, so it must red.
+ * @param {Object} element
+ * @returns {{name: String|null, pub: Boolean|null}}
+ */
+function classifyElementKey(element) {
+    const key = element.key;
+
+    if (element.computed) {
+        if (key?.type === 'Literal' && typeof key.value === 'string') {
+            return {name: key.value, pub: true}
+        }
+
+        if (key?.type === 'TemplateLiteral' && key.expressions.length === 0 && key.quasis.length === 1) {
+            return {name: key.quasis[0].value.cooked, pub: true}
+        }
+
+        return {name: null, pub: null} // unresolvable — fail closed upstream
+    }
+
+    if (key?.type === 'PrivateIdentifier') {
+        return {name: `#${key.name}`, pub: false}
+    }
+
+    if (key?.type === 'Identifier') {
+        return {name: key.name, pub: true}
+    }
+
+    if (key?.type === 'Literal' && typeof key.value === 'string') {
+        return {name: key.value, pub: true} // quoted member name — public
+    }
+
+    return {name: null, pub: null}
+}
+
+/**
  * Every MCP-server override of `getHeapObservationServiceKey()`, as `{serverDir, key}` pairs —
  * identity-preserving by construction, enumerated STRUCTURALLY (acorn), never by regex shape.
  * A regex recognizes the spelling it expects and silently drops or miscounts every other valid
- * spelling (a space before `()`, a `static async` modifier stack); a class-body walk recognizes
- * the ELEMENT and can refuse its shape. Discovery rules, all fail-closed:
+ * spelling (a space before `()`, a modifier stack); a class-body walk recognizes the ELEMENT and
+ * can refuse its shape. Discovery rules, all fail-closed:
  *
- * - the elected convention is a plain public, non-static, non-async, non-generator, non-computed
- *   instance method whose body is one direct literal `return '<service-label>'`;
- * - every class element whose semantic name matches in ANY other shape (static / async /
- *   generator / getter / setter / private / computed / class-field / multi-statement body) reds
- *   with a named reason — it is never silently counted OR silently skipped;
+ * - the elected convention is a plain public, non-static, non-async, non-generator instance
+ *   method whose body is one direct literal `return '<service-label>'`;
+ * - a PRIVATE same-named method is never an override (the public BaseServer default still
+ *   answers `null`) — it reds as a shadow-trap, it does not count;
+ * - a computed element whose key cannot be structurally resolved reds — the census cannot prove
+ *   it is not a producer;
  * - a comment mention is not a class element and does not count.
  *
  * `BaseServer` (the null default) lives outside the per-server directories and is not scanned.
@@ -148,26 +297,35 @@ function readReportingRoster() {
 
         for (const classBody of collectClassBodies(ast)) {
             for (const element of classBody.body) {
-                const name = element.key?.type === 'PrivateIdentifier'
-                    ? `#${element.key.name}`
-                    : element.computed
-                        ? (element.key?.type === 'Literal' ? element.key.value : null)
-                        : (element.key?.name ?? element.key?.value);
+                const keyInfo = classifyElementKey(element);
 
-                if (name !== 'getHeapObservationServiceKey' && name !== '#getHeapObservationServiceKey') continue;
+                expect(
+                    keyInfo.pub !== null,
+                    `${entry.name}/Server.mjs carries a computed class element whose key cannot be structurally resolved — ` +
+                    'the census cannot prove it is not a getHeapObservationServiceKey producer; resolve it literally or remove it'
+                ).toBe(true);
+
+                if (keyInfo.name === '#getHeapObservationServiceKey') {
+                    expect(
+                        false,
+                        `${entry.name} defines a PRIVATE #getHeapObservationServiceKey — a private method never overrides the public ` +
+                        'BaseServer default (which still returns null), so this shape reports nothing while looking like a producer'
+                    ).toBe(true)
+                }
+
+                if (keyInfo.name !== 'getHeapObservationServiceKey') continue;
 
                 const isElectedShape =
                     element.type === 'MethodDefinition' &&
                     element.kind === 'method' &&
                     element.static === false &&
-                    element.computed === false &&
                     element.value?.type === 'FunctionExpression' &&
                     element.value.async === false &&
                     element.value.generator === false;
 
                 expect(
                     isElectedShape,
-                    `${entry.name} defines getHeapObservationServiceKey in a non-elected shape (static/async/generator/accessor/private/computed/class-field) — ` +
+                    `${entry.name} defines getHeapObservationServiceKey in a non-elected shape (static/async/generator/accessor/class-field) — ` +
                     'the census refuses it rather than guessing its semantics'
                 ).toBe(true);
 

--- a/test/playwright/unit/ai/deploy/HeapObservationChannelMount.spec.mjs
+++ b/test/playwright/unit/ai/deploy/HeapObservationChannelMount.spec.mjs
@@ -5,15 +5,15 @@ import process            from 'node:process';
 import {load as yamlLoad} from 'js-yaml';
 
 /**
- * Guards the heap-observation channel's TRANSPORT.
+ * Guards the heap-observation channel's TRANSPORT, per deployment profile.
  *
  * The channel is a file written by each MCP server about its own V8 heap and read by the
  * orchestrator's deployment-state bridge. Both ends resolve the identical expression —
  * `path.resolve(AiConfig.heapObservation.dir, `${serviceKey}.json`)` — so the code looks
  * symmetric and every in-process witness passes. It shipped anyway with **no shared mount**:
  * each container wrote into its own layer and the orchestrator read its own empty one, so
- * every observation surfaced as `unavailable/absent` on every containerized plane from the
- * day it merged.
+ * every observation surfaced as `unavailable/absent` on planes deployed from the canonical
+ * compose file from the day the channel merged.
  *
  * WHY no existing test could see it. Every witness for this channel runs in ONE process on
  * ONE filesystem, so the write and the read were always the same directory. The failure is
@@ -29,21 +29,34 @@ import {load as yamlLoad} from 'js-yaml';
  *
  * WHY the writer roster is DERIVED and never listed. A hardcoded pair silently excludes the
  * third server someone adds next — which is the same defect one layer out. The roster comes
- * from the servers that actually declare `getHeapObservationServiceKey()`.
+ * from the servers that actually declare `getHeapObservationServiceKey()`, and discovery
+ * REFUSES an override it cannot resolve: an indirect producer (`const key = 'x'; return key`)
+ * must red here, never sail past the regex into an unasserted mount.
  *
- * WHY static parsing rather than `docker compose config`: no agent sandbox has a reachable
- * Docker daemon, and the mount lines ARE the invariant. Reading them from source is a
- * complete test of the property, not a proxy for one.
+ * WHY targets bind EXACTLY, per profile. A shared final path segment proves nothing: swapping
+ * every mount target to a coordinated wrong path leaves a suffix-check green. The expected
+ * base target is derived from two independent authorities — the compose file's own plane-root
+ * convention (read off the deployment-state mount) and the config leaf's directory segment —
+ * and the parity profile's target comes from its `NEO_HEAP_OBSERVATION_DIR` pin, because the
+ * resolved path differs per profile by design.
+ *
+ * WHY static parsing rather than only `docker compose config`: the mount lines ARE the
+ * invariant, and reading them from source is a complete hermetic test of the property. The
+ * rendered-config probe is the per-profile complement the repair cycle used; it is not a
+ * CI-runnable guard, which is what this file is.
  */
 
 const
     repoRoot       = path.resolve(process.cwd()),
     composePath    = path.join(repoRoot, 'ai/deploy/docker-compose.yml'),
+    devComposePath = path.join(repoRoot, 'ai/deploy/docker-compose.dev.yml'),
     configBasePath = path.join(repoRoot, 'ai/configBase.mjs'),
     mcpServerRoot  = path.join(repoRoot, 'ai/mcp/server'),
     compose        = yamlLoad(fs.readFileSync(composePath, 'utf8')),
+    devCompose     = yamlLoad(fs.readFileSync(devComposePath, 'utf8')),
     configBaseText = fs.readFileSync(configBasePath, 'utf8'),
-    READER_SERVICE = 'orchestrator';
+    READER_SERVICE = 'orchestrator',
+    PARITY_VOLUME  = 'parity-heap-observation';
 
 /**
  * The directory segment `AiConfig.heapObservation.dir` appends to the plane data root. Read from
@@ -61,8 +74,25 @@ function readObservationDirSegment() {
 }
 
 /**
+ * The canonical plane root as the COMPOSE file holds it, derived from a sibling channel's mount
+ * rather than restated: the orchestrator's `shared-deployment-state-data` target minus its last
+ * segment. A coordinated wrong-target mutation on the heap channel cannot move this anchor, so
+ * exact binding against it is what a suffix check could never prove.
+ * @returns {String}
+ */
+function readBasePlaneRoot() {
+    const anchor = mountsOf(compose, READER_SERVICE).find(entry => entry.volume === 'shared-deployment-state-data');
+
+    expect(anchor, 'the orchestrator still mounts shared-deployment-state-data — the plane-root anchor').toBeTruthy();
+
+    return anchor.target.replace(/\/[^/]+$/, '')
+}
+
+/**
  * Service keys of every MCP server that reports an observation, derived from the source that
- * decides it. `BaseServer` returns null; a server opts in by overriding.
+ * decides it — and hardened against the two census failure modes: an override written in a shape
+ * this guard cannot resolve (refused, not skipped) and a duplicate key (a second reporter
+ * impersonating an existing one). `BaseServer` returns null; a server opts in by overriding.
  * @returns {String[]}
  */
 function readReportingServiceKeys() {
@@ -75,42 +105,68 @@ function readReportingServiceKeys() {
 
         if (!fs.existsSync(serverPath)) continue;
 
-        const match = fs.readFileSync(serverPath, 'utf8')
-            .match(/getHeapObservationServiceKey\(\)\s*\{\s*return\s*'([^']+)'/);
+        const override = fs.readFileSync(serverPath, 'utf8')
+            .match(/getHeapObservationServiceKey\(\)\s*\{([\s\S]*?)\}/);
 
-        match && keys.push(match[1])
+        if (!override) continue; // no override — the BaseServer null default stands
+
+        const literal = override[1].match(/return\s*'([^']+)'/);
+
+        expect(
+            literal,
+            `${entry.name} overrides getHeapObservationServiceKey() in a shape this guard cannot resolve — ` +
+            'use a direct literal return or extend the resolver; an unresolvable producer must red, not vanish'
+        ).toBeTruthy();
+
+        keys.push(literal[1])
     }
 
     return keys.sort()
 }
 
 /**
- * Parses one service's `volumes:` entries into `{volume, target, readOnly}` triples.
+ * Parses one service's `volumes:` entries into `{volume, target, readOnly}` triples. Short-syntax
+ * strings and long-syntax objects both resolve; anything else fails closed upstream.
+ * @param {Object} composeDoc
  * @param {String} serviceKey
  * @returns {Object[]}
  */
-function mountsOf(serviceKey) {
-    return (compose.services?.[serviceKey]?.volumes || []).map(entry => {
-        const [source, target, mode] = String(entry).split(':');
+function mountsOf(composeDoc, serviceKey) {
+    return (composeDoc.services?.[serviceKey]?.volumes || []).map(entry => {
+        if (typeof entry === 'string') {
+            const [source, target, mode] = entry.split(':');
 
-        return {volume: source, target, readOnly: mode === 'ro'}
+            return {volume: source, target, readOnly: mode === 'ro'}
+        }
+
+        return {volume: entry.source, target: entry.target, readOnly: entry.read_only === true}
     })
 }
 
 test.describe('the heap-observation channel crosses a container boundary', () => {
-    test('every reporting server shares ONE named volume with the bridge that reads it', () => {
+    test('every reporting server shares ONE named volume with the bridge that reads it, at the exact resolved path', () => {
         const
-            dirSegment    = readObservationDirSegment(),
-            reportingKeys = readReportingServiceKeys(),
-            mountTarget   = entry => entry.target?.endsWith(`/${dirSegment}`);
+            dirSegment     = readObservationDirSegment(),
+            expectedTarget = `${readBasePlaneRoot()}/${dirSegment}`,
+            reportingKeys  = readReportingServiceKeys();
 
         // A roster that derived to nothing would make every assertion below vacuous.
         expect(reportingKeys.length, 'at least one MCP server declares getHeapObservationServiceKey()')
             .toBeGreaterThan(0);
 
-        const readerMounts = mountsOf(READER_SERVICE).filter(mountTarget);
+        // One key, one service, one mount: a duplicate key means a second reporter impersonates an
+        // existing one and its own service never gets a mount — the roster must be a set, and every
+        // key must name a real Compose service.
+        expect(new Set(reportingKeys).size, 'reporting service keys are unique').toBe(reportingKeys.length);
 
-        expect(readerMounts, `${READER_SERVICE} mounts exactly one heap-observation volume`)
+        for (const serviceKey of reportingKeys) {
+            expect(compose.services, `${serviceKey} names a service in the canonical compose file`)
+                .toHaveProperty(serviceKey)
+        }
+
+        const readerMounts = mountsOf(compose, READER_SERVICE).filter(entry => entry.target === expectedTarget);
+
+        expect(readerMounts, `${READER_SERVICE} mounts exactly one heap-observation volume at ${expectedTarget}`)
             .toHaveLength(1);
 
         const sharedVolume = readerMounts[0].volume;
@@ -119,14 +175,12 @@ test.describe('the heap-observation channel crosses a container boundary', () =>
             .toHaveProperty(sharedVolume);
 
         for (const serviceKey of reportingKeys) {
-            const writerMounts = mountsOf(serviceKey).filter(mountTarget);
+            const writerMounts = mountsOf(compose, serviceKey).filter(entry => entry.target === expectedTarget);
 
-            expect(writerMounts, `${serviceKey} reports a heap observation, so it must mount the channel`)
+            expect(writerMounts, `${serviceKey} reports a heap observation, so it must mount the channel at the resolved path`)
                 .toHaveLength(1);
             expect(writerMounts[0].volume, `${serviceKey} shares the bridge's volume — a private one delivers nothing`)
                 .toBe(sharedVolume);
-            expect(writerMounts[0].target, `${serviceKey} mounts the channel at the reader's path`)
-                .toBe(readerMounts[0].target);
             expect(writerMounts[0].readOnly, `${serviceKey} WRITES its observation; a :ro mount is a silent no-op`)
                 .toBe(false)
         }
@@ -134,11 +188,44 @@ test.describe('the heap-observation channel crosses a container boundary', () =>
 
     test('the bridge reads the channel read-only — it may never author what it publishes as self-reported', () => {
         const
-            dirSegment  = readObservationDirSegment(),
-            readerMount = mountsOf(READER_SERVICE).find(entry => entry.target?.endsWith(`/${dirSegment}`));
+            expectedTarget = `${readBasePlaneRoot()}/${readObservationDirSegment()}`,
+            readerMount    = mountsOf(compose, READER_SERVICE).find(entry => entry.target === expectedTarget);
 
         expect(readerMount, `${READER_SERVICE} mounts the heap-observation channel`).toBeTruthy();
         expect(readerMount.readOnly, 'the record carries provenance "self-reported"; the reader must not be able to write one')
             .toBe(true)
+    });
+
+    test('the parity profile carries the same invariant at its pinned path — writers rw, reader :ro', () => {
+        const
+            dirSegment    = readObservationDirSegment(),
+            reportingKeys = readReportingServiceKeys(),
+            // The parity profile relocates the channel by env pin, so its target is authoritative
+            // from the profile file — never the base literal. Fail closed when the pin vanishes.
+            parityDir     = devCompose['x-plane-env']?.NEO_HEAP_OBSERVATION_DIR;
+
+        expect(parityDir, 'docker-compose.dev.yml still pins NEO_HEAP_OBSERVATION_DIR in x-plane-env').toBeTruthy();
+        expect(parityDir.endsWith(`/${dirSegment}`), 'the parity pin ends at the same leaf directory segment')
+            .toBe(true);
+
+        expect(devCompose.volumes, 'the parity channel volume is declared').toHaveProperty(PARITY_VOLUME);
+
+        // The parity participants also inherit the base-path mount through Compose merge; nothing
+        // reads it on this profile (the env pin moved the dir), so it is inert — the LIVE path is
+        // the pinned one, and that is the one this arm constrains.
+        for (const serviceKey of [...reportingKeys, READER_SERVICE]) {
+            const mounts = mountsOf(devCompose, serviceKey).filter(entry => entry.target === parityDir);
+
+            expect(mounts, `${serviceKey} runs the parity profile, so it must mount the channel at the pinned path`)
+                .toHaveLength(1);
+            expect(mounts[0].volume, `${serviceKey} shares the one parity channel volume`)
+                .toBe(PARITY_VOLUME);
+            expect(
+                mounts[0].readOnly,
+                serviceKey === READER_SERVICE
+                    ? 'the parity reader is read-only too — a rw plane root must not leave the bridge able to author a self-reported record'
+                    : `${serviceKey} WRITES its observation on parity as well`
+            ).toBe(serviceKey === READER_SERVICE)
+        }
     })
 });

--- a/test/playwright/unit/ai/deploy/HeapObservationChannelMount.spec.mjs
+++ b/test/playwright/unit/ai/deploy/HeapObservationChannelMount.spec.mjs
@@ -1,0 +1,144 @@
+import {test, expect}     from '@playwright/test';
+import fs                 from 'node:fs';
+import path               from 'node:path';
+import process            from 'node:process';
+import {load as yamlLoad} from 'js-yaml';
+
+/**
+ * Guards the heap-observation channel's TRANSPORT.
+ *
+ * The channel is a file written by each MCP server about its own V8 heap and read by the
+ * orchestrator's deployment-state bridge. Both ends resolve the identical expression —
+ * `path.resolve(AiConfig.heapObservation.dir, `${serviceKey}.json`)` — so the code looks
+ * symmetric and every in-process witness passes. It shipped anyway with **no shared mount**:
+ * each container wrote into its own layer and the orchestrator read its own empty one, so
+ * every observation surfaced as `unavailable/absent` on every containerized plane from the
+ * day it merged.
+ *
+ * WHY no existing test could see it. Every witness for this channel runs in ONE process on
+ * ONE filesystem, so the write and the read were always the same directory. The failure is
+ * not expressible in a fixture that does not cross a container boundary — the property is a
+ * topology fact, and the topology lives here.
+ *
+ * WHY it failed silently rather than loudly. The reporter is deliberately total: a write
+ * failure returns `false` rather than escaping, because a service must not die because it
+ * could not describe its own heap. But the write did not fail — writing into the container's
+ * own layer SUCCEEDS. A successful local write and a delivered one are indistinguishable from
+ * the writer's side, so the fail-closed metric (`unavailable/absent`) was published while the
+ * envelope reported a healthy reporter.
+ *
+ * WHY the writer roster is DERIVED and never listed. A hardcoded pair silently excludes the
+ * third server someone adds next — which is the same defect one layer out. The roster comes
+ * from the servers that actually declare `getHeapObservationServiceKey()`.
+ *
+ * WHY static parsing rather than `docker compose config`: no agent sandbox has a reachable
+ * Docker daemon, and the mount lines ARE the invariant. Reading them from source is a
+ * complete test of the property, not a proxy for one.
+ */
+
+const
+    repoRoot       = path.resolve(process.cwd()),
+    composePath    = path.join(repoRoot, 'ai/deploy/docker-compose.yml'),
+    configBasePath = path.join(repoRoot, 'ai/configBase.mjs'),
+    mcpServerRoot  = path.join(repoRoot, 'ai/mcp/server'),
+    compose        = yamlLoad(fs.readFileSync(composePath, 'utf8')),
+    configBaseText = fs.readFileSync(configBasePath, 'utf8'),
+    READER_SERVICE = 'orchestrator';
+
+/**
+ * The directory segment `AiConfig.heapObservation.dir` appends to the plane data root. Read from
+ * the config source rather than restated, so renaming the leaf reds this spec instead of silently
+ * leaving the mount pointing at a directory nothing writes.
+ * @returns {String}
+ */
+function readObservationDirSegment() {
+    const match = configBaseText.match(/heapObservation:\s*\{[\s\S]*?dir\s*:\s*leaf\(path\.resolve\([^,]+,\s*'([^']+)'\)/);
+
+    // Fail closed: an unmatched regex must not silently assert nothing.
+    expect(match, 'ai/configBase.mjs still declares heapObservation.dir as a plane-root-relative leaf').toBeTruthy();
+
+    return match[1]
+}
+
+/**
+ * Service keys of every MCP server that reports an observation, derived from the source that
+ * decides it. `BaseServer` returns null; a server opts in by overriding.
+ * @returns {String[]}
+ */
+function readReportingServiceKeys() {
+    const keys = [];
+
+    for (const entry of fs.readdirSync(mcpServerRoot, {withFileTypes: true})) {
+        if (!entry.isDirectory()) continue;
+
+        const serverPath = path.join(mcpServerRoot, entry.name, 'Server.mjs');
+
+        if (!fs.existsSync(serverPath)) continue;
+
+        const match = fs.readFileSync(serverPath, 'utf8')
+            .match(/getHeapObservationServiceKey\(\)\s*\{\s*return\s*'([^']+)'/);
+
+        match && keys.push(match[1])
+    }
+
+    return keys.sort()
+}
+
+/**
+ * Parses one service's `volumes:` entries into `{volume, target, readOnly}` triples.
+ * @param {String} serviceKey
+ * @returns {Object[]}
+ */
+function mountsOf(serviceKey) {
+    return (compose.services?.[serviceKey]?.volumes || []).map(entry => {
+        const [source, target, mode] = String(entry).split(':');
+
+        return {volume: source, target, readOnly: mode === 'ro'}
+    })
+}
+
+test.describe('the heap-observation channel crosses a container boundary', () => {
+    test('every reporting server shares ONE named volume with the bridge that reads it', () => {
+        const
+            dirSegment    = readObservationDirSegment(),
+            reportingKeys = readReportingServiceKeys(),
+            mountTarget   = entry => entry.target?.endsWith(`/${dirSegment}`);
+
+        // A roster that derived to nothing would make every assertion below vacuous.
+        expect(reportingKeys.length, 'at least one MCP server declares getHeapObservationServiceKey()')
+            .toBeGreaterThan(0);
+
+        const readerMounts = mountsOf(READER_SERVICE).filter(mountTarget);
+
+        expect(readerMounts, `${READER_SERVICE} mounts exactly one heap-observation volume`)
+            .toHaveLength(1);
+
+        const sharedVolume = readerMounts[0].volume;
+
+        expect(compose.volumes, 'the channel volume is declared in the top-level volumes block')
+            .toHaveProperty(sharedVolume);
+
+        for (const serviceKey of reportingKeys) {
+            const writerMounts = mountsOf(serviceKey).filter(mountTarget);
+
+            expect(writerMounts, `${serviceKey} reports a heap observation, so it must mount the channel`)
+                .toHaveLength(1);
+            expect(writerMounts[0].volume, `${serviceKey} shares the bridge's volume — a private one delivers nothing`)
+                .toBe(sharedVolume);
+            expect(writerMounts[0].target, `${serviceKey} mounts the channel at the reader's path`)
+                .toBe(readerMounts[0].target);
+            expect(writerMounts[0].readOnly, `${serviceKey} WRITES its observation; a :ro mount is a silent no-op`)
+                .toBe(false)
+        }
+    });
+
+    test('the bridge reads the channel read-only — it may never author what it publishes as self-reported', () => {
+        const
+            dirSegment  = readObservationDirSegment(),
+            readerMount = mountsOf(READER_SERVICE).find(entry => entry.target?.endsWith(`/${dirSegment}`));
+
+        expect(readerMount, `${READER_SERVICE} mounts the heap-observation channel`).toBeTruthy();
+        expect(readerMount.readOnly, 'the record carries provenance "self-reported"; the reader must not be able to write one')
+            .toBe(true)
+    })
+});

--- a/test/playwright/unit/ai/deploy/HeapObservationChannelMount.spec.mjs
+++ b/test/playwright/unit/ai/deploy/HeapObservationChannelMount.spec.mjs
@@ -1,8 +1,11 @@
 import {test, expect}     from '@playwright/test';
+import * as acorn         from 'acorn';
 import fs                 from 'node:fs';
 import path               from 'node:path';
 import process            from 'node:process';
 import {load as yamlLoad} from 'js-yaml';
+
+import {resolvePlaneDataRoot} from '../../../../../ai/planeConfig.mjs';
 
 /**
  * Guards the heap-observation channel's TRANSPORT, per deployment profile.
@@ -65,9 +68,11 @@ const
     PARITY_VOLUME   = 'parity-heap-observation';
 
 /**
- * The config-authoritative channel path pieces: the `heapObservation.dir` leaf's resolve
- * expression (anchor name AND segment — moving the anchor must red, not silently re-derive)
- * crossed with `planeConfig`'s relative root.
+ * The config-authoritative channel path pieces, proved to definition level: the
+ * `heapObservation.dir` leaf's resolve expression (anchor name AND segment), the anchor's
+ * DEFINITION (a name-pin alone stays green when the definition moves the runtime path — the
+ * cycle-3 residual), the `neoRootDir` definition beneath it, and `planeConfig`'s relative root.
+ * Every link fails closed.
  * @returns {{dirSegment: String, dataRootRelative: String}}
  */
 function readChannelPathAuthorities() {
@@ -79,6 +84,15 @@ function readChannelPathAuthorities() {
         dirExpr[1],
         'the heapObservation.dir leaf still anchors on planeDataRootDefault — an anchor move changes the runtime path and must red here'
     ).toBe('planeDataRootDefault');
+
+    expect(
+        /const planeDataRootDefault\s*=\s*resolvePlaneDataRoot\(\{rootDir:\s*neoRootDir\}\)/.test(configBaseText),
+        'planeDataRootDefault is still DEFINED as resolvePlaneDataRoot({rootDir: neoRootDir}) — a definition-level move changes the runtime path and must red here'
+    ).toBe(true);
+    expect(
+        /const neoRootDir\s*=\s*path\.resolve\(__dirname,\s*'\.\.\/?'\)/.test(configBaseText),
+        'neoRootDir is still defined as the configBase-relative repository root'
+    ).toBe(true);
 
     const relative = planeConfigText.match(/dataRootRelative:\s*'([^']+)'/);
 
@@ -105,12 +119,17 @@ function readComposePlaneRoot(composeDoc) {
 
 /**
  * Every MCP-server override of `getHeapObservationServiceKey()`, as `{serverDir, key}` pairs —
- * identity-preserving by construction. Discovery rules, all fail-closed:
+ * identity-preserving by construction, enumerated STRUCTURALLY (acorn), never by regex shape.
+ * A regex recognizes the spelling it expects and silently drops or miscounts every other valid
+ * spelling (a space before `()`, a `static async` modifier stack); a class-body walk recognizes
+ * the ELEMENT and can refuse its shape. Discovery rules, all fail-closed:
  *
- * - the elected convention is a PLAIN instance method with a direct literal return;
- * - any other definitional shape (static / async / generator / getter / private / computed /
- *   class-field) reds with a named reason — it is never silently counted OR silently skipped;
- * - a comment mention is not a definition and does not count.
+ * - the elected convention is a plain public, non-static, non-async, non-generator, non-computed
+ *   instance method whose body is one direct literal `return '<service-label>'`;
+ * - every class element whose semantic name matches in ANY other shape (static / async /
+ *   generator / getter / setter / private / computed / class-field / multi-statement body) reds
+ *   with a named reason — it is never silently counted OR silently skipped;
+ * - a comment mention is not a class element and does not count.
  *
  * `BaseServer` (the null default) lives outside the per-server directories and is not scanned.
  * @returns {Array<{serverDir: String, key: String}>}
@@ -125,32 +144,78 @@ function readReportingRoster() {
 
         if (!fs.existsSync(serverPath)) continue;
 
-        const text  = fs.readFileSync(serverPath, 'utf8'),
-              plain = text.match(/^ {4}getHeapObservationServiceKey\(\)\s*\{([\s\S]*?)\}/m);
+        const ast = acorn.parse(fs.readFileSync(serverPath, 'utf8'), {ecmaVersion: 'latest', sourceType: 'module'});
 
-        if (plain) {
-            const literal = plain[1].match(/return\s*'([^']+)'/);
+        for (const classBody of collectClassBodies(ast)) {
+            for (const element of classBody.body) {
+                const name = element.key?.type === 'PrivateIdentifier'
+                    ? `#${element.key.name}`
+                    : element.computed
+                        ? (element.key?.type === 'Literal' ? element.key.value : null)
+                        : (element.key?.name ?? element.key?.value);
 
-            expect(
-                literal,
-                `${entry.name} overrides getHeapObservationServiceKey() without a direct literal return — ` +
-                'an unresolvable producer must red, not vanish'
-            ).toBeTruthy();
+                if (name !== 'getHeapObservationServiceKey' && name !== '#getHeapObservationServiceKey') continue;
 
-            roster.push({serverDir: entry.name, key: literal[1]});
-            continue
+                const isElectedShape =
+                    element.type === 'MethodDefinition' &&
+                    element.kind === 'method' &&
+                    element.static === false &&
+                    element.computed === false &&
+                    element.value?.type === 'FunctionExpression' &&
+                    element.value.async === false &&
+                    element.value.generator === false;
+
+                expect(
+                    isElectedShape,
+                    `${entry.name} defines getHeapObservationServiceKey in a non-elected shape (static/async/generator/accessor/private/computed/class-field) — ` +
+                    'the census refuses it rather than guessing its semantics'
+                ).toBe(true);
+
+                const statements = element.value.body.body,
+                      isLiteralReturn =
+                          statements.length === 1 &&
+                          statements[0].type === 'ReturnStatement' &&
+                          statements[0].argument?.type === 'Literal' &&
+                          typeof statements[0].argument.value === 'string';
+
+                expect(
+                    isLiteralReturn,
+                    `${entry.name} overrides getHeapObservationServiceKey() without a direct literal return — ` +
+                    'an unresolvable producer must red, not vanish'
+                ).toBe(true);
+
+                roster.push({serverDir: entry.name, key: statements[0].argument.value})
+            }
         }
-
-        const variant = text.match(/^ *(?:static|async)\s+getHeapObservationServiceKey|^ *\*\s*getHeapObservationServiceKey|^ *get\s+getHeapObservationServiceKey|^ *#getHeapObservationServiceKey|^ *\[['"]getHeapObservationServiceKey['"]\]\s*\(|^ *getHeapObservationServiceKey\s*=/m);
-
-        expect(
-            variant,
-            `${entry.name} defines getHeapObservationServiceKey in a non-plain shape (static/async/generator/getter/private/computed/class-field) — ` +
-            'that is not the elected override convention and this guard refuses it rather than guessing its semantics'
-        ).toBeNull()
     }
 
     return roster
+}
+
+/**
+ * Yields every ClassBody in an AST (declarations, expressions, default exports, call arguments).
+ * @param {*} node
+ * @returns {Generator<Object>}
+ */
+function* collectClassBodies(node) {
+    if (!node || typeof node !== 'object') return;
+
+    if (node.type === 'ClassBody') {
+        yield node;
+        return // a class body does not nest another class body outside its elements' values
+    }
+
+    for (const value of Object.values(node)) {
+        if (Array.isArray(value)) {
+            for (const item of value) {
+                if (item && typeof item === 'object' && item.type) {
+                    yield* collectClassBodies(item)
+                }
+            }
+        } else if (value && typeof value === 'object' && value.type) {
+            yield* collectClassBodies(value)
+        }
+    }
 }
 
 /**
@@ -210,6 +275,16 @@ test.describe('the heap-observation channel crosses a container boundary', () =>
         expect(composePlaneRoot.endsWith(`/${dataRootRelative}`),
             `the compose plane root (${composePlaneRoot}) still ends at the config-declared ${dataRootRelative}`
         ).toBe(true);
+
+        // Definition-level authority: run the compose-declared container root through the REAL
+        // resolver the config itself uses — the expected path is computed by the substrate, not
+        // re-derived by the guard, so a resolver-behavior change reds here too.
+        const containerRoot = composePlaneRoot.slice(0, -(dataRootRelative.length + 1));
+
+        expect(
+            resolvePlaneDataRoot({rootDir: containerRoot}),
+            'the compose-declared plane root must equal the config resolver applied to the container root'
+        ).toBe(composePlaneRoot);
 
         const
             expectedTarget = `${composePlaneRoot}/${dirSegment}`,

--- a/test/playwright/unit/ai/deploy/HeapObservationChannelMount.spec.mjs
+++ b/test/playwright/unit/ai/deploy/HeapObservationChannelMount.spec.mjs
@@ -27,18 +27,22 @@ import {load as yamlLoad} from 'js-yaml';
  * the writer's side, so the fail-closed metric (`unavailable/absent`) was published while the
  * envelope reported a healthy reporter.
  *
- * WHY the writer roster is DERIVED and never listed. A hardcoded pair silently excludes the
- * third server someone adds next — which is the same defect one layer out. The roster comes
- * from the servers that actually declare `getHeapObservationServiceKey()`, and discovery
- * REFUSES an override it cannot resolve: an indirect producer (`const key = 'x'; return key`)
- * must red here, never sail past the regex into an unasserted mount.
+ * WHY the writer roster is DERIVED, identity-preserving, and never listed. A hardcoded pair
+ * silently excludes the third server someone adds next; a key-unpreserving roster cannot tell
+ * which SERVER declared which label, so a sibling-attributed key (`knowledge-base` returning
+ * `'mc-server'`) would mount the wrong service and pass. Discovery therefore pairs every
+ * declaring server directory with its literal key, refuses any override shape it cannot
+ * resolve (an indirect or non-plain-method producer must red, never vanish), and binds each
+ * declaration to the compose service whose `TARGET_SERVER` build arg names that directory.
  *
- * WHY targets bind EXACTLY, per profile. A shared final path segment proves nothing: swapping
- * every mount target to a coordinated wrong path leaves a suffix-check green. The expected
- * base target is derived from two independent authorities — the compose file's own plane-root
- * convention (read off the deployment-state mount) and the config leaf's directory segment —
- * and the parity profile's target comes from its `NEO_HEAP_OBSERVATION_DIR` pin, because the
- * resolved path differs per profile by design.
+ * WHY targets bind EXACTLY, across two independent authorities. A shared final path segment
+ * proves nothing: swapping every mount target to a coordinated wrong path leaves a suffix
+ * check green. The expected target is built from the config-authoritative chain — the
+ * `heapObservation.dir` leaf's own resolve expression (anchor name AND segment, so moving
+ * the anchor reds) crossed against `planeConfig`'s relative root — and the compose file's
+ * declared in-container plane root (read off a sibling channel's mount). The two must agree,
+ * so a mutation on EITHER side fails: config-anchor move, relative-root rename, or a
+ * coordinated compose-only target shift.
  *
  * WHY static parsing rather than only `docker compose config`: the mount lines ARE the
  * invariant, and reading them from source is a complete hermetic test of the property. The
@@ -47,56 +51,72 @@ import {load as yamlLoad} from 'js-yaml';
  */
 
 const
-    repoRoot       = path.resolve(process.cwd()),
-    composePath    = path.join(repoRoot, 'ai/deploy/docker-compose.yml'),
-    devComposePath = path.join(repoRoot, 'ai/deploy/docker-compose.dev.yml'),
-    configBasePath = path.join(repoRoot, 'ai/configBase.mjs'),
-    mcpServerRoot  = path.join(repoRoot, 'ai/mcp/server'),
-    compose        = yamlLoad(fs.readFileSync(composePath, 'utf8')),
-    devCompose     = yamlLoad(fs.readFileSync(devComposePath, 'utf8')),
-    configBaseText = fs.readFileSync(configBasePath, 'utf8'),
-    READER_SERVICE = 'orchestrator',
-    PARITY_VOLUME  = 'parity-heap-observation';
+    repoRoot        = path.resolve(process.cwd()),
+    composePath     = path.join(repoRoot, 'ai/deploy/docker-compose.yml'),
+    devComposePath  = path.join(repoRoot, 'ai/deploy/docker-compose.dev.yml'),
+    configBasePath  = path.join(repoRoot, 'ai/configBase.mjs'),
+    planeConfigPath = path.join(repoRoot, 'ai/planeConfig.mjs'),
+    mcpServerRoot   = path.join(repoRoot, 'ai/mcp/server'),
+    compose         = yamlLoad(fs.readFileSync(composePath, 'utf8')),
+    devCompose      = yamlLoad(fs.readFileSync(devComposePath, 'utf8')),
+    configBaseText  = fs.readFileSync(configBasePath, 'utf8'),
+    planeConfigText = fs.readFileSync(planeConfigPath, 'utf8'),
+    READER_SERVICE  = 'orchestrator',
+    PARITY_VOLUME   = 'parity-heap-observation';
 
 /**
- * The directory segment `AiConfig.heapObservation.dir` appends to the plane data root. Read from
- * the config source rather than restated, so renaming the leaf reds this spec instead of silently
- * leaving the mount pointing at a directory nothing writes.
- * @returns {String}
+ * The config-authoritative channel path pieces: the `heapObservation.dir` leaf's resolve
+ * expression (anchor name AND segment — moving the anchor must red, not silently re-derive)
+ * crossed with `planeConfig`'s relative root.
+ * @returns {{dirSegment: String, dataRootRelative: String}}
  */
-function readObservationDirSegment() {
-    const match = configBaseText.match(/heapObservation:\s*\{[\s\S]*?dir\s*:\s*leaf\(path\.resolve\([^,]+,\s*'([^']+)'\)/);
+function readChannelPathAuthorities() {
+    const dirExpr = configBaseText.match(/heapObservation:\s*\{[\s\S]*?dir\s*:\s*leaf\(path\.resolve\(([A-Za-z]+),\s*'([^']+)'\)/);
 
     // Fail closed: an unmatched regex must not silently assert nothing.
-    expect(match, 'ai/configBase.mjs still declares heapObservation.dir as a plane-root-relative leaf').toBeTruthy();
+    expect(dirExpr, 'ai/configBase.mjs still declares heapObservation.dir as a leaf(path.resolve(anchor, segment))').toBeTruthy();
+    expect(
+        dirExpr[1],
+        'the heapObservation.dir leaf still anchors on planeDataRootDefault — an anchor move changes the runtime path and must red here'
+    ).toBe('planeDataRootDefault');
 
-    return match[1]
+    const relative = planeConfigText.match(/dataRootRelative:\s*'([^']+)'/);
+
+    expect(relative, 'ai/planeConfig.mjs still declares PLANE_DEFAULTS.dataRootRelative').toBeTruthy();
+
+    return {dirSegment: dirExpr[2], dataRootRelative: relative[1]}
 }
 
 /**
- * The canonical plane root as the COMPOSE file holds it, derived from a sibling channel's mount
- * rather than restated: the orchestrator's `shared-deployment-state-data` target minus its last
- * segment. A coordinated wrong-target mutation on the heap channel cannot move this anchor, so
- * exact binding against it is what a suffix check could never prove.
+ * The in-container plane root as the COMPOSE file declares it, read off a sibling channel's
+ * mount (the orchestrator's `shared-deployment-state-data` target minus its last segment) —
+ * never restated here. Cross-asserted against the config-side relative root by the caller, so
+ * neither side can drift alone.
+ * @param {Object} composeDoc
  * @returns {String}
  */
-function readBasePlaneRoot() {
-    const anchor = mountsOf(compose, READER_SERVICE).find(entry => entry.volume === 'shared-deployment-state-data');
+function readComposePlaneRoot(composeDoc) {
+    const anchor = mountsOf(composeDoc, READER_SERVICE).find(entry => entry.volume === 'shared-deployment-state-data');
 
-    expect(anchor, 'the orchestrator still mounts shared-deployment-state-data — the plane-root anchor').toBeTruthy();
+    expect(anchor, 'the orchestrator still mounts shared-deployment-state-data — the compose-side plane-root anchor').toBeTruthy();
 
     return anchor.target.replace(/\/[^/]+$/, '')
 }
 
 /**
- * Service keys of every MCP server that reports an observation, derived from the source that
- * decides it — and hardened against the two census failure modes: an override written in a shape
- * this guard cannot resolve (refused, not skipped) and a duplicate key (a second reporter
- * impersonating an existing one). `BaseServer` returns null; a server opts in by overriding.
- * @returns {String[]}
+ * Every MCP-server override of `getHeapObservationServiceKey()`, as `{serverDir, key}` pairs —
+ * identity-preserving by construction. Discovery rules, all fail-closed:
+ *
+ * - the elected convention is a PLAIN instance method with a direct literal return;
+ * - any other definitional shape (static / async / generator / getter / private / computed /
+ *   class-field) reds with a named reason — it is never silently counted OR silently skipped;
+ * - a comment mention is not a definition and does not count.
+ *
+ * `BaseServer` (the null default) lives outside the per-server directories and is not scanned.
+ * @returns {Array<{serverDir: String, key: String}>}
  */
-function readReportingServiceKeys() {
-    const keys = [];
+function readReportingRoster() {
+    const roster = [];
 
     for (const entry of fs.readdirSync(mcpServerRoot, {withFileTypes: true})) {
         if (!entry.isDirectory()) continue;
@@ -105,23 +125,58 @@ function readReportingServiceKeys() {
 
         if (!fs.existsSync(serverPath)) continue;
 
-        const override = fs.readFileSync(serverPath, 'utf8')
-            .match(/getHeapObservationServiceKey\(\)\s*\{([\s\S]*?)\}/);
+        const text  = fs.readFileSync(serverPath, 'utf8'),
+              plain = text.match(/^ {4}getHeapObservationServiceKey\(\)\s*\{([\s\S]*?)\}/m);
 
-        if (!override) continue; // no override — the BaseServer null default stands
+        if (plain) {
+            const literal = plain[1].match(/return\s*'([^']+)'/);
 
-        const literal = override[1].match(/return\s*'([^']+)'/);
+            expect(
+                literal,
+                `${entry.name} overrides getHeapObservationServiceKey() without a direct literal return — ` +
+                'an unresolvable producer must red, not vanish'
+            ).toBeTruthy();
+
+            roster.push({serverDir: entry.name, key: literal[1]});
+            continue
+        }
+
+        const variant = text.match(/^ *(?:static|async)\s+getHeapObservationServiceKey|^ *\*\s*getHeapObservationServiceKey|^ *get\s+getHeapObservationServiceKey|^ *#getHeapObservationServiceKey|^ *\[['"]getHeapObservationServiceKey['"]\]\s*\(|^ *getHeapObservationServiceKey\s*=/m);
 
         expect(
-            literal,
-            `${entry.name} overrides getHeapObservationServiceKey() in a shape this guard cannot resolve — ` +
-            'use a direct literal return or extend the resolver; an unresolvable producer must red, not vanish'
-        ).toBeTruthy();
-
-        keys.push(literal[1])
+            variant,
+            `${entry.name} defines getHeapObservationServiceKey in a non-plain shape (static/async/generator/getter/private/computed/class-field) — ` +
+            'that is not the elected override convention and this guard refuses it rather than guessing its semantics'
+        ).toBeNull()
     }
 
-    return keys.sort()
+    return roster
+}
+
+/**
+ * The compose-side producer identity map: service label → the server directory its image builds
+ * (`build.args.TARGET_SERVER`). This is what makes a declared key checkable against the DECLARING
+ * server's own compose label instead of any label that happens to exist.
+ * @param {Object} composeDoc
+ * @returns {Object<String, String>}
+ */
+function readServerLabels(composeDoc) {
+    const map = {};
+
+    for (const [label, service] of Object.entries(composeDoc.services || {})) {
+        const target = service.build?.args?.TARGET_SERVER;
+
+        if (target) {
+            expect(
+                Object.values(map).includes(target),
+                `two compose services build the same server directory ${target} — the identity census cannot attribute a declaration`
+            ).toBe(false);
+
+            map[label] = target
+        }
+    }
+
+    return map
 }
 
 /**
@@ -144,24 +199,42 @@ function mountsOf(composeDoc, serviceKey) {
 }
 
 test.describe('the heap-observation channel crosses a container boundary', () => {
-    test('every reporting server shares ONE named volume with the bridge that reads it, at the exact resolved path', () => {
+    test('every reporting server shares ONE named volume with the bridge that reads it, at the config-authoritative path', () => {
         const
-            dirSegment     = readObservationDirSegment(),
-            expectedTarget = `${readBasePlaneRoot()}/${dirSegment}`,
-            reportingKeys  = readReportingServiceKeys();
+            {dirSegment, dataRootRelative} = readChannelPathAuthorities(),
+            composePlaneRoot               = readComposePlaneRoot(compose);
+
+        // The cross-domain coherence assertion: the compose-declared in-container root and the
+        // config-declared relative root must agree — a rename on EITHER side reds here, even when
+        // every mount inside one file stays mutually consistent.
+        expect(composePlaneRoot.endsWith(`/${dataRootRelative}`),
+            `the compose plane root (${composePlaneRoot}) still ends at the config-declared ${dataRootRelative}`
+        ).toBe(true);
+
+        const
+            expectedTarget = `${composePlaneRoot}/${dirSegment}`,
+            roster         = readReportingRoster(),
+            serverLabels   = readServerLabels(compose);
 
         // A roster that derived to nothing would make every assertion below vacuous.
-        expect(reportingKeys.length, 'at least one MCP server declares getHeapObservationServiceKey()')
+        expect(roster.length, 'at least one MCP server declares getHeapObservationServiceKey()')
             .toBeGreaterThan(0);
 
-        // One key, one service, one mount: a duplicate key means a second reporter impersonates an
-        // existing one and its own service never gets a mount — the roster must be a set, and every
-        // key must name a real Compose service.
-        expect(new Set(reportingKeys).size, 'reporting service keys are unique').toBe(reportingKeys.length);
+        // One key, one service, one mount: keys unique, each naming a real compose service, and
+        // each declared by the server directory THAT service builds — sibling attribution reds.
+        expect(new Set(roster.map(entry => entry.key)).size, 'reporting service keys are unique')
+            .toBe(roster.length);
 
-        for (const serviceKey of reportingKeys) {
-            expect(compose.services, `${serviceKey} names a service in the canonical compose file`)
-                .toHaveProperty(serviceKey)
+        for (const {serverDir, key} of roster) {
+            expect(compose.services, `${key} names a service in the canonical compose file`).toHaveProperty(key);
+
+            const declaringLabel = Object.keys(serverLabels).find(label => serverLabels[label] === serverDir);
+
+            expect(declaringLabel, `${serverDir} is built by exactly one compose service (TARGET_SERVER)`).toBeTruthy();
+            expect(
+                key,
+                `${serverDir}/Server.mjs declares '${key}' but runs as '${declaringLabel}' — a reporter must declare its OWN compose label; sibling attribution misattributes the observation`
+            ).toBe(declaringLabel)
         }
 
         const readerMounts = mountsOf(compose, READER_SERVICE).filter(entry => entry.target === expectedTarget);
@@ -174,21 +247,22 @@ test.describe('the heap-observation channel crosses a container boundary', () =>
         expect(compose.volumes, 'the channel volume is declared in the top-level volumes block')
             .toHaveProperty(sharedVolume);
 
-        for (const serviceKey of reportingKeys) {
-            const writerMounts = mountsOf(compose, serviceKey).filter(entry => entry.target === expectedTarget);
+        for (const {key} of roster) {
+            const writerMounts = mountsOf(compose, key).filter(entry => entry.target === expectedTarget);
 
-            expect(writerMounts, `${serviceKey} reports a heap observation, so it must mount the channel at the resolved path`)
+            expect(writerMounts, `${key} reports a heap observation, so it must mount the channel at the resolved path`)
                 .toHaveLength(1);
-            expect(writerMounts[0].volume, `${serviceKey} shares the bridge's volume — a private one delivers nothing`)
+            expect(writerMounts[0].volume, `${key} shares the bridge's volume — a private one delivers nothing`)
                 .toBe(sharedVolume);
-            expect(writerMounts[0].readOnly, `${serviceKey} WRITES its observation; a :ro mount is a silent no-op`)
+            expect(writerMounts[0].readOnly, `${key} WRITES its observation; a :ro mount is a silent no-op`)
                 .toBe(false)
         }
     });
 
     test('the bridge reads the channel read-only — it may never author what it publishes as self-reported', () => {
         const
-            expectedTarget = `${readBasePlaneRoot()}/${readObservationDirSegment()}`,
+            {dirSegment}   = readChannelPathAuthorities(),
+            expectedTarget = `${readComposePlaneRoot(compose)}/${dirSegment}`,
             readerMount    = mountsOf(compose, READER_SERVICE).find(entry => entry.target === expectedTarget);
 
         expect(readerMount, `${READER_SERVICE} mounts the heap-observation channel`).toBeTruthy();
@@ -198,11 +272,11 @@ test.describe('the heap-observation channel crosses a container boundary', () =>
 
     test('the parity profile carries the same invariant at its pinned path — writers rw, reader :ro', () => {
         const
-            dirSegment    = readObservationDirSegment(),
-            reportingKeys = readReportingServiceKeys(),
+            {dirSegment} = readChannelPathAuthorities(),
+            roster       = readReportingRoster(),
             // The parity profile relocates the channel by env pin, so its target is authoritative
             // from the profile file — never the base literal. Fail closed when the pin vanishes.
-            parityDir     = devCompose['x-plane-env']?.NEO_HEAP_OBSERVATION_DIR;
+            parityDir    = devCompose['x-plane-env']?.NEO_HEAP_OBSERVATION_DIR;
 
         expect(parityDir, 'docker-compose.dev.yml still pins NEO_HEAP_OBSERVATION_DIR in x-plane-env').toBeTruthy();
         expect(parityDir.endsWith(`/${dirSegment}`), 'the parity pin ends at the same leaf directory segment')
@@ -213,19 +287,19 @@ test.describe('the heap-observation channel crosses a container boundary', () =>
         // The parity participants also inherit the base-path mount through Compose merge; nothing
         // reads it on this profile (the env pin moved the dir), so it is inert — the LIVE path is
         // the pinned one, and that is the one this arm constrains.
-        for (const serviceKey of [...reportingKeys, READER_SERVICE]) {
-            const mounts = mountsOf(devCompose, serviceKey).filter(entry => entry.target === parityDir);
+        for (const key of [...roster.map(entry => entry.key), READER_SERVICE]) {
+            const mounts = mountsOf(devCompose, key).filter(entry => entry.target === parityDir);
 
-            expect(mounts, `${serviceKey} runs the parity profile, so it must mount the channel at the pinned path`)
+            expect(mounts, `${key} runs the parity profile, so it must mount the channel at the pinned path`)
                 .toHaveLength(1);
-            expect(mounts[0].volume, `${serviceKey} shares the one parity channel volume`)
+            expect(mounts[0].volume, `${key} shares the one parity channel volume`)
                 .toBe(PARITY_VOLUME);
             expect(
                 mounts[0].readOnly,
-                serviceKey === READER_SERVICE
+                key === READER_SERVICE
                     ? 'the parity reader is read-only too — a rw plane root must not leave the bridge able to author a self-reported record'
-                    : `${serviceKey} WRITES its observation on parity as well`
-            ).toBe(serviceKey === READER_SERVICE)
+                    : `${key} WRITES its observation on parity as well`
+            ).toBe(key === READER_SERVICE)
         }
     })
 });


### PR DESCRIPTION
Resolves neomjs/neo#16810

The heap-observation channel shipped with **no shared volume**. Both ends resolve the identical expression — `path.resolve(AiConfig.heapObservation.dir, ${serviceKey}.json)` — so the code reads symmetric, but `/app/.neo-ai-data/heap-observation` appeared nowhere in `ai/deploy/docker-compose.yml`. `kb-server` and `mc-server` wrote into their own container layers and the orchestrator read its own empty one, so every reporting service surfaced `unavailable/absent` on every containerized plane from the day the channel merged.

**The failure was silent because writing into a container's own layer SUCCEEDS.** The reporter is deliberately total — a write failure returns `false` rather than killing a service that merely could not describe its own heap — but no failure occurred, so nothing was even swallowed. A successful local write and a delivered one are indistinguishable from the writer's side, so the metric failed closed (`absent`) while the envelope reported a healthy reporter.

Evidence: L2 (topology change + a mutation-convicted guard over the compose source) → L2 required. The live `status: available` reading is `#16763` AC-9 and is **deliberately not** closed here: the plane must first be recreated with the new volume, which no implementation PR can supply. Residual: L3 on `#16763`.

## Deltas from ticket

- **Direction is inverted from the precedent it copies.** `shared-deployment-state-data` is orchestrator-writes / KB-MC-read. This channel is services-write / bridge-reads, so the `:ro` sits on the **orchestrator**. That is not symmetry for its own sake: the record carries `provenance: "self-reported"`, and a bridge able to write the file could author a record it then publishes as the service's own claim.
- **`fleet-server` and `orchestrator` are deliberately not REPORTERS.** Neither declares `getHeapObservationServiceKey()` — only `kb-server` and `mc-server` do — so their `absent` is the honest answer, not a symptom. (The orchestrator IS mounted — read-only — as the channel's reader; `fleet-server` is not mounted at all. This line previously said "NOT mounted", which contradicted the diff's deliberate `:ro` reader mount.) An earlier read of mine called all four services defective; that was wrong and is corrected here.
- **The writer roster is derived, never listed.** A hardcoded `['kb-server', 'mc-server']` reproduces the defect for the third server someone adds next. The guard reads the servers that actually declare the key, and fails closed if that derivation returns an empty roster — otherwise every assertion below it would be vacuous.
- **The directory segment is read from `ai/configBase.mjs`, not restated.** Renaming the leaf reds the guard instead of leaving the mount pointing at a directory nothing writes. The regex asserts its own match first, so a config-shape change cannot silently turn the guard into a no-op.
- **Ticket refs were removed from the durable comments** after `check-ticket-archaeology` flagged the spec JSDoc. The compose comments were not flagged (YAML is outside the checked set) but carried the same decay, so they were cleaned too rather than left to rot.

## Test Evidence

- **New guard** `test/playwright/unit/ai/deploy/HeapObservationChannelMount.spec.mjs`, 3 tests (base channel at the config-authoritative path / reader `:ro` / parity profile at its pinned path), green at `7d041fe733`.
- **Mutation-convicted, thirteen arms** (each run at the current head; a guard that cannot red against the defect class is not evidence):

| mutation | result |
|---|---|
| remove `kb-server`'s mount (the shipped state) | **RED** |
| make the base orchestrator mount writable | **RED** |
| coordinated wrong-target: every base heap mount → `/tmp/heap-observation` | **RED** (both base arms) |
| config-anchor move: the `dir` leaf resolves `neoRootDir` instead of `planeDataRootDefault` | **RED** (all 3 arms — the anchor name is pinned) |
| **definition-level move: `planeDataRootDefault = neoRootDir` (anchor name untouched)** | **RED** (all 3 arms — the definition chain is pinned) |
| `planeConfig.dataRootRelative` rename without a compose move | **RED** (cross-domain coherence; the real `resolvePlaneDataRoot` is consumed, not reparsed) |
| sibling attribution: `knowledge-base` declares `'mc-server'` | **RED** (key must equal the declaring server's own compose label via `TARGET_SERVER`) |
| duplicate key: `memory-core` declares `'kb-server'` | **RED** (uniqueness) |
| indirect override (`const key = …; return key`) or a `static` / `static async` method shape | **RED** (acorn structural census refuses, never skips) |
| **spacing variant `getHeapObservationServiceKey ()` — the silent-drop case** | **GREEN with the producer counted** (structural enumeration: a valid spelling is the same element) |
| **import-binding substitution: aliased import + local shadow of `resolvePlaneDataRoot`** | **RED** (the unaliased-binding + no-shadow assertions are structural, acorn-level) |
| **private `#getHeapObservationServiceKey` shadow-trap** (never overrides the public default) | **RED** (private keys red, never count) |
| **computed ``[`getHeapObservationServiceKey`]()`` — resolvable key** | **GREEN with the producer counted** (computed keys fail closed only when structurally unresolvable) |
| parity orchestrator loses its `:ro` shadow mount | **RED** (parity arm) |

- **Sibling compose specs, exact head, all green (99 passed across `test/playwright/unit/ai/deploy/`):** `ParityPlaneVolumeScoping`, `DeclaredHeapCeilings`, `daemon.spec` (incl. `#15759` *"cloud Compose gives the AiConfig data dir one dedicated, sole-owner volume"*), `FleetServerComposition`, `ChromaPersistPathContract`, `DeploymentTrustDefaults`, `HostEdgePosture`, `LaneEnablementSignal`, `DeploymentRuntimeAccessService`, `DeployPipelineRevisionPin`.
- **Parity branch settled by render:** `docker compose -f docker-compose.yml -f docker-compose.dev.yml config` pre-repair showed the live channel path riding the rw `parity-plane` root (reader writable); post-repair render gives kb/mc rw + orchestrator `:ro` on `parity-heap-observation` at the pinned path.
- **Why there is no in-process witness:** every existing fixture for this channel runs in one process on one filesystem, so the write and the read were always the same directory. The failure is a topology fact and is not expressible without crossing a container boundary — which is why the suite was green throughout and could only ever have been.

## Post-Merge Validation

- [ ] The plane is recreated (`compose up -d`, not `restart` — a restart re-runs the baked container config and never attaches a new volume). Deployment authority, not this PR's.
- [ ] `get_deployment_state_snapshot` reports `heapObservation.status: "available"` for `kb-server` and `mc-server`, stated with its environment (cgroup limit, declared ceiling, node version). **This is `#16763` AC-9 and closes that ticket, not this one.**
- [ ] `pairable: true` in steady state at the 10 s write cadence against the 15 s skew bound. `false` in steady state means the bound is mis-sized rather than the channel broken — different repairs, and the reading tells them apart.
- [ ] `ceilingSources` reads `['exec-argv']` for both servers. A `node-options` entry would mean a ceiling arrived through the channel `docker-compose.yml` deliberately forbids, because `ProcessSupervisorService` spawns children with `{...process.env}` and would multiply the container budget per concurrent Node process.

## Evolution

- Cycle 2 (`4a3fb533e5`, corrective rotation under Vega's `[author-yield]`): the guard now binds mount targets EXACTLY per profile (base target derived from the compose file's own plane-root anchor × the configBase leaf segment; parity target from the `NEO_HEAP_OBSERVATION_DIR` pin) instead of suffix-matching; producer discovery refuses unresolvable override syntax and rejects duplicate keys; the parity profile gains the channel at its pinned path (`parity-heap-observation`, writers rw / reader `:ro` — previously the rw plane root left the parity reader unconstrained); the spec JSDoc's "no agent sandbox has a reachable Docker daemon" universal was corrected (the rendered-config probe settled the parity branch).

Authored by Vega (@neo-opus-vega, Claude Opus 5, Claude Code). Origin Session ID: 4131135d-1b20-487f-9d23-d7213914246b.
Cycle-2 corrective commits by Phoebe (Kimi for Coding k3, opencode), under the author's explicit `[author-yield]` (PR scoping comment, 2026-08-09T18:10Z).




