### PR TITLE
feat(ai): a plane can say degraded-but-serving (#16792)

### DIFF
--- a/ai/daemons/orchestrator/services/DeploymentStateBridgeService.mjs
+++ b/ai/daemons/orchestrator/services/DeploymentStateBridgeService.mjs
@@ -1351,10 +1351,19 @@ function summarizeInspect(inspect) {
  *     or `null` when the container declares no healthcheck at all.
  */
 export function summarizeProbeReliability(health) {
-    const log = Array.isArray(health?.Log) ? health.Log : null;
+    // NOT-APPLICABLE and UNAVAILABLE are different facts and must not collapse. A container that
+    // declares no healthcheck has nothing to report; one that declares a healthcheck and has not
+    // been sampled yet has something to report and does not know it. Returning the same value for
+    // both makes an unsampled service read as an unprobeable one — which is how "no data" gets
+    // mistaken for "no concern".
+    if (!health || typeof health !== 'object') {
+        return {status: 'not-applicable', reason: 'no-healthcheck-declared'};
+    }
 
-    if (!log?.length) {
-        return null;
+    const log = Array.isArray(health.Log) ? health.Log : [];
+
+    if (log.length === 0) {
+        return {status: 'unavailable', reason: 'no-samples-yet'};
     }
 
     // A probe passes on exit 0 and fails on anything else, INCLUDING -1 — which is how a runtime
@@ -1363,21 +1372,23 @@ export function summarizeProbeReliability(health) {
     const sampleCount  = log.length,
           failureCount = log.filter(entry => entry?.ExitCode !== 0).length;
 
+    // RAW FACTS ONLY — deliberately no verdict. An earlier revision published a `disposition`
+    // naming the service `nominal` / `degraded-but-serving` / `failing`, and that was an unlicensed
+    // classification: a bounded observation of probe outcomes cannot decide whether a service is
+    // serving. It also produced wrong answers — an already-unhealthy container with one pass and one
+    // failure read as "degraded-but-serving", and a single old failure followed by four passes read
+    // identically to an actively-degrading one, because a flat ring carries no recency.
+    //
+    // The rate is the fact the healthy/unhealthy binary cannot express; who is serving is the
+    // consumer's decision, made with the runtime's own verdict alongside.
     return {
+        status       : 'available',
         sampleCount,
         failureCount,
         // Rounded to three places: this is read by humans and compared across polls, and an
         // unrounded ratio invites a false precision the 5-entry ring cannot support.
         failureRate  : Math.round((failureCount / sampleCount) * 1000) / 1000,
-        failingStreak: Number.isFinite(health.FailingStreak) ? health.FailingStreak : null,
-        // The vocabulary the binary lacks. `degraded-but-serving` is the whole point: some probes
-        // fail, some pass, the service is answering, and no consecutive-failure threshold will ever
-        // be crossed.
-        disposition  : failureCount === 0
-            ? 'nominal'
-            : failureCount === sampleCount
-                ? 'failing'
-                : 'degraded-but-serving'
+        failingStreak: Number.isFinite(health.FailingStreak) ? health.FailingStreak : null
     };
 }
 

--- a/ai/daemons/orchestrator/services/DeploymentStateBridgeService.mjs
+++ b/ai/daemons/orchestrator/services/DeploymentStateBridgeService.mjs
@@ -1315,8 +1315,69 @@ function summarizeInspect(inspect) {
             finishedAt: state.FinishedAt || null,
             exitCode  : Number.isFinite(state.ExitCode) ? state.ExitCode : null,
             oomKilled : typeof state.OOMKilled === 'boolean' ? state.OOMKilled : null,
-            error     : state.Error || null
+            error     : state.Error || null,
+            // Published BESIDE `health`, never folded into it. `health` remains the runtime's own
+            // verdict — consumers and the recovery lane depend on that meaning being untouched —
+            // while this carries the rate that verdict cannot express.
+            probeReliability: summarizeProbeReliability(state.Health)
         }
+    };
+}
+
+/**
+ * @summary Derives a probe FAILURE RATE from the health-check ring, so degraded-but-serving is sayable.
+ *
+ * **A container runtime flips to `unhealthy` only after `retries` CONSECUTIVE failures.** At
+ * `retries: 12` that is two unbroken minutes, so a service failing a third of its probes
+ * indefinitely resets the streak on every success and is *structurally incapable* of ever being
+ * marked unhealthy. The layer can say **dead** and it can say **healthy**; it has no way to say
+ * **degraded-but-serving**, which is the state a saturated or contended plane actually occupies.
+ *
+ * A binary derived from consecutiveness cannot express a rate, and degradation is a rate. The
+ * evidence was already being fetched and thrown away: `State.Health.Log` is a ring of recent probe
+ * results carrying each `ExitCode`. Nothing here probes anything new — it reads what the existing
+ * `inspect` already returned.
+ *
+ * Observed on the canonical plane while every surface reported `healthy`: four failures and one
+ * success in the ring, with `FailingStreak` oscillating 4 → 0. Both numbers were true; neither was
+ * reportable as degradation, and two maintainer seats worked in that state for hours.
+ *
+ * `failingStreak` travels alongside deliberately — the streak measures PHASE (how far into the
+ * current run of failures we are), the rate measures HEALTH. Publishing the streak alone is what
+ * made an oscillating service look recovered every time it happened to be observed after a pass.
+ *
+ * @param {Object} [health] The `State.Health` object from a container inspect.
+ * @returns {Object|null} `{sampleCount, failureCount, failureRate, failingStreak, disposition}`,
+ *     or `null` when the container declares no healthcheck at all.
+ */
+export function summarizeProbeReliability(health) {
+    const log = Array.isArray(health?.Log) ? health.Log : null;
+
+    if (!log?.length) {
+        return null;
+    }
+
+    // A probe passes on exit 0 and fails on anything else, INCLUDING -1 — which is how a runtime
+    // reports "the check exceeded its own timeout". Treating a non-finite or negative code as
+    // "not a failure" would discard exactly the timeouts this summary exists to count.
+    const sampleCount  = log.length,
+          failureCount = log.filter(entry => entry?.ExitCode !== 0).length;
+
+    return {
+        sampleCount,
+        failureCount,
+        // Rounded to three places: this is read by humans and compared across polls, and an
+        // unrounded ratio invites a false precision the 5-entry ring cannot support.
+        failureRate  : Math.round((failureCount / sampleCount) * 1000) / 1000,
+        failingStreak: Number.isFinite(health.FailingStreak) ? health.FailingStreak : null,
+        // The vocabulary the binary lacks. `degraded-but-serving` is the whole point: some probes
+        // fail, some pass, the service is answering, and no consecutive-failure threshold will ever
+        // be crossed.
+        disposition  : failureCount === 0
+            ? 'nominal'
+            : failureCount === sampleCount
+                ? 'failing'
+                : 'degraded-but-serving'
     };
 }
 

--- a/test/playwright/unit/ai/daemons/orchestrator/services/DeploymentStateBridgeService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/DeploymentStateBridgeService.spec.mjs
@@ -2115,67 +2115,136 @@ test.describe('Neo.ai.daemons.services.DeploymentStateBridgeService — heap obs
 });
 
 /**
- * Degraded-but-serving: the state a binary derived from consecutiveness cannot express.
+ * The rate a healthy/unhealthy binary cannot express — as RAW FACTS, not as a verdict.
  */
-test.describe('summarizeProbeReliability — a rate the healthy/unhealthy binary cannot say', () => {
+test.describe('summarizeProbeReliability — bounded facts, and no unlicensed verdict', () => {
     const probe = exitCode => ({Start: '2026-08-09T14:36:23Z', End: '2026-08-09T14:36:31Z', ExitCode: exitCode});
 
     test('the EXACT observed shape: four failures, one pass, and the runtime still says healthy', () => {
         // Measured on the canonical plane. Every surface reported `healthy` while two maintainer
-        // seats lost Memory Core writes for hours. `FailingStreak` had already reset to 0 on the
+        // seats lost Memory Core writes for hours; `FailingStreak` had already reset to 0 on the
         // pass, so both published numbers were true and neither was reportable as degradation.
-        const summary = summarizeProbeReliability({
+        expect(summarizeProbeReliability({
             Status       : 'healthy',
             FailingStreak: 0,
             Log          : [probe(1), probe(1), probe(1), probe(-1), probe(0)]
-        });
-
-        expect(summary).toEqual({
+        })).toEqual({
+            status       : 'available',
             sampleCount  : 5,
             failureCount : 4,
             failureRate  : 0.8,
-            failingStreak: 0,
-            disposition  : 'degraded-but-serving'
+            failingStreak: 0
         });
+    });
+
+    test('NO VERDICT is published — the observation does not decide whether the service is serving', () => {
+        // @neo-gpt's Required Action 1. An earlier revision named the service
+        // `degraded-but-serving`, which a bounded probe observation cannot license: an ALREADY
+        // UNHEALTHY container with one pass and one failure got that label, and one old failure
+        // followed by four passes got it too, because a flat ring carries no recency.
+        const unhealthyMixed = summarizeProbeReliability({Status: 'unhealthy', FailingStreak: 1, Log: [probe(1), probe(0)]}),
+              oldFailure     = summarizeProbeReliability({Status: 'healthy', FailingStreak: 0, Log: [probe(1), probe(0), probe(0), probe(0), probe(0)]});
+
+        for (const summary of [unhealthyMixed, oldFailure]) {
+            expect(summary).not.toHaveProperty('disposition');
+            expect(JSON.stringify(summary)).not.toContain('serving');
+        }
+
+        // The facts still discriminate — dropping the verdict did not drop the signal.
+        expect(unhealthyMixed.failureRate).toBe(0.5);
+        expect(oldFailure.failureRate).toBe(0.2);
     });
 
     test('a health-check TIMEOUT (-1) counts as a failure — the case the surface most needs', () => {
         // A runtime reports "the check exceeded its own timeout" as -1. Counting only positive exit
-        // codes would discard precisely the probes that were too slow to answer, which is the
-        // failure mode a contended plane actually exhibits.
+        // codes would discard precisely the probes that were too slow to answer.
         expect(summarizeProbeReliability({FailingStreak: 1, Log: [probe(-1), probe(0)]})).toMatchObject({
             failureCount: 1,
-            failureRate : 0.5,
-            disposition : 'degraded-but-serving'
+            failureRate : 0.5
         });
     });
 
-    test('nominal and failing stay distinguishable at the ends', () => {
-        expect(summarizeProbeReliability({FailingStreak: 0, Log: [probe(0), probe(0)]})).toMatchObject({
-            failureRate: 0,
-            disposition: 'nominal'
-        });
-        expect(summarizeProbeReliability({FailingStreak: 2, Log: [probe(1), probe(1)]})).toMatchObject({
-            failureRate: 1,
-            disposition: 'failing'
-        });
+    test('NOT-APPLICABLE and UNAVAILABLE stay distinct — no healthcheck is not an unsampled one', () => {
+        // Collapsing both to null makes a declared-but-unsampled service indistinguishable from an unprobeable
+        // one, so "no data" reads as "no concern".
+        expect(summarizeProbeReliability(undefined)).toMatchObject({status: 'not-applicable'});
+        expect(summarizeProbeReliability({Status: 'starting', Log: []})).toMatchObject({status: 'unavailable'});
+        expect(summarizeProbeReliability(undefined).status)
+            .not.toBe(summarizeProbeReliability({Log: []}).status);
     });
 
-    test('a container with no healthcheck reports null, never a fabricated clean rate', () => {
-        // `failureRate: 0` on a service nobody probes would read as evidence of health.
-        expect(summarizeProbeReliability(undefined)).toBeNull();
-        expect(summarizeProbeReliability({})).toBeNull();
-        expect(summarizeProbeReliability({Log: []})).toBeNull();
+    test('a never-probed service reports NO rate — absence is never a clean zero', () => {
+        // `failureRate: 0` on a service nobody probed would read as evidence of health.
+        expect(summarizeProbeReliability({Log: []})).not.toHaveProperty('failureRate');
     });
 
-    test('the streak alone cannot discriminate — which is why the rate is published beside it', () => {
-        // POSITIVE CONTROL for the ticket's premise. Both of these carry `FailingStreak: 0`, the
-        // value an oscillating service shows every time it is observed just after a pass. Any
-        // consumer keying on the streak sees one number; the rate separates them.
+    test('the streak alone cannot discriminate — which is why the rate travels beside it', () => {
+        // POSITIVE CONTROL for the ticket's premise. Both carry `FailingStreak: 0`, the value an
+        // oscillating service shows whenever it is observed just after a pass.
         const oscillating = summarizeProbeReliability({FailingStreak: 0, Log: [probe(1), probe(1), probe(1), probe(0)]}),
               healthy     = summarizeProbeReliability({FailingStreak: 0, Log: [probe(0), probe(0), probe(0), probe(0)]});
 
         expect(oscillating.failingStreak).toBe(healthy.failingStreak);
-        expect(oscillating.disposition).not.toBe(healthy.disposition);
+        expect(oscillating.failureRate).not.toBe(healthy.failureRate);
+    });
+});
+
+/**
+ * The WRITER seam, not the helper.
+ *
+ * @neo-gpt's falsifier: every test above stays green if the production assignment in
+ * `summarizeInspect` is deleted, because they exercise the pure function and never witness the field
+ * reaching the record an operator reads. Helper coverage is not a writer witness.
+ */
+test.describe('probeReliability reaches the service record', () => {
+    let dir;
+
+    const runtimeWithHealth = Health => ({
+        async readObserve({operation}) {
+            if (operation === 'inspect') {
+                return {
+                    data : {Id: 'c1', RestartCount: 0, Name: '/mc-server', State: {Status: 'running', Health}},
+                    proof: {operation}
+                };
+            }
+            return {data: null, proof: {operation}};
+        }
+    });
+
+    const bridgeFor = Health => createService({
+        diagnosisService    : Neo.create(ContainerHealthDiagnosisService, {}),
+        healLedgerDir       : dir,
+        runtimeAccessService: runtimeWithHealth(Health)
+    });
+
+    test.beforeEach(() => {dir = fs.mkdtempSync(path.join(os.tmpdir(), 'probe-writer-'))});
+    test.afterEach(() => {fs.rmSync(dir, {recursive: true, force: true})});
+
+    test('an oscillating container publishes its RATE in the record, beside the runtime verdict', async () => {
+        const snapshot = await bridgeFor({
+            Status       : 'healthy',
+            FailingStreak: 0,
+            Log          : [{ExitCode: 1}, {ExitCode: 1}, {ExitCode: 1}, {ExitCode: -1}, {ExitCode: 0}]
+        }).collectServiceSnapshot({serviceKey: 'mc-server', observedAt: OBSERVED_AT});
+
+        // Deleting the production assignment turns THIS red; the helper tests would not notice.
+        expect(snapshot.inspect.state.probeReliability).toMatchObject({
+            status      : 'available',
+            sampleCount : 5,
+            failureCount: 4,
+            failureRate : 0.8
+        });
+
+        // Published BESIDE the runtime's own verdict, never folded into it — the recovery lane and
+        // the two-channel evidence pairing both depend on `health` keeping its exact prior meaning.
+        expect(snapshot.inspect.state.health).toBe('healthy');
+    });
+
+    test('a container with no declared healthcheck records not-applicable, not silence', async () => {
+        const snapshot = await bridgeFor(undefined)
+            .collectServiceSnapshot({serviceKey: 'mc-server', observedAt: OBSERVED_AT});
+
+        expect(snapshot.inspect.state.probeReliability).toMatchObject({status: 'not-applicable'});
+        expect(snapshot.inspect.state.health).toBeNull();
     });
 });

--- a/test/playwright/unit/ai/daemons/orchestrator/services/DeploymentStateBridgeService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/DeploymentStateBridgeService.spec.mjs
@@ -1,12 +1,15 @@
-import {describeCorpusOutstanding}       from '../../../../../../../ai/services/knowledge-base/helpers/corpusOutstanding.mjs';
-import {test, expect}                    from '@playwright/test';
-import fs                                from 'fs';
-import os                                from 'os';
-import path                              from 'path';
-import Neo                               from '../../../../../../../src/Neo.mjs';
-import * as core                         from '../../../../../../../src/core/_export.mjs';
-import AiConfig                          from '../../../../../../../ai/config.template.mjs';
-import {DeploymentStateBridgeService}    from '../../../../../../../ai/daemons/orchestrator/services/DeploymentStateBridgeService.mjs';
+import {describeCorpusOutstanding} from '../../../../../../../ai/services/knowledge-base/helpers/corpusOutstanding.mjs';
+import {test, expect}              from '@playwright/test';
+import fs                          from 'fs';
+import os                          from 'os';
+import path                        from 'path';
+import Neo                         from '../../../../../../../src/Neo.mjs';
+import * as core                   from '../../../../../../../src/core/_export.mjs';
+import AiConfig                    from '../../../../../../../ai/config.template.mjs';
+import {
+    DeploymentStateBridgeService,
+    summarizeProbeReliability
+} from '../../../../../../../ai/daemons/orchestrator/services/DeploymentStateBridgeService.mjs';
 import {ContainerHealthDiagnosisService} from '../../../../../../../ai/daemons/orchestrator/services/ContainerHealthDiagnosisService.mjs';
 import {appendHealEvent, readHealLedger} from '../../../../../../../ai/services/memory-core/helpers/healEventLedgerStore.mjs';
 import {
@@ -2108,5 +2111,71 @@ test.describe('Neo.ai.daemons.services.DeploymentStateBridgeService — heap obs
             expect(result.pairable).toBe(false);
             expect(result.unavailableReason).toBeTruthy();
         }
+    });
+});
+
+/**
+ * Degraded-but-serving: the state a binary derived from consecutiveness cannot express.
+ */
+test.describe('summarizeProbeReliability — a rate the healthy/unhealthy binary cannot say', () => {
+    const probe = exitCode => ({Start: '2026-08-09T14:36:23Z', End: '2026-08-09T14:36:31Z', ExitCode: exitCode});
+
+    test('the EXACT observed shape: four failures, one pass, and the runtime still says healthy', () => {
+        // Measured on the canonical plane. Every surface reported `healthy` while two maintainer
+        // seats lost Memory Core writes for hours. `FailingStreak` had already reset to 0 on the
+        // pass, so both published numbers were true and neither was reportable as degradation.
+        const summary = summarizeProbeReliability({
+            Status       : 'healthy',
+            FailingStreak: 0,
+            Log          : [probe(1), probe(1), probe(1), probe(-1), probe(0)]
+        });
+
+        expect(summary).toEqual({
+            sampleCount  : 5,
+            failureCount : 4,
+            failureRate  : 0.8,
+            failingStreak: 0,
+            disposition  : 'degraded-but-serving'
+        });
+    });
+
+    test('a health-check TIMEOUT (-1) counts as a failure — the case the surface most needs', () => {
+        // A runtime reports "the check exceeded its own timeout" as -1. Counting only positive exit
+        // codes would discard precisely the probes that were too slow to answer, which is the
+        // failure mode a contended plane actually exhibits.
+        expect(summarizeProbeReliability({FailingStreak: 1, Log: [probe(-1), probe(0)]})).toMatchObject({
+            failureCount: 1,
+            failureRate : 0.5,
+            disposition : 'degraded-but-serving'
+        });
+    });
+
+    test('nominal and failing stay distinguishable at the ends', () => {
+        expect(summarizeProbeReliability({FailingStreak: 0, Log: [probe(0), probe(0)]})).toMatchObject({
+            failureRate: 0,
+            disposition: 'nominal'
+        });
+        expect(summarizeProbeReliability({FailingStreak: 2, Log: [probe(1), probe(1)]})).toMatchObject({
+            failureRate: 1,
+            disposition: 'failing'
+        });
+    });
+
+    test('a container with no healthcheck reports null, never a fabricated clean rate', () => {
+        // `failureRate: 0` on a service nobody probes would read as evidence of health.
+        expect(summarizeProbeReliability(undefined)).toBeNull();
+        expect(summarizeProbeReliability({})).toBeNull();
+        expect(summarizeProbeReliability({Log: []})).toBeNull();
+    });
+
+    test('the streak alone cannot discriminate — which is why the rate is published beside it', () => {
+        // POSITIVE CONTROL for the ticket's premise. Both of these carry `FailingStreak: 0`, the
+        // value an oscillating service shows every time it is observed just after a pass. Any
+        // consumer keying on the streak sees one number; the rate separates them.
+        const oscillating = summarizeProbeReliability({FailingStreak: 0, Log: [probe(1), probe(1), probe(1), probe(0)]}),
+              healthy     = summarizeProbeReliability({FailingStreak: 0, Log: [probe(0), probe(0), probe(0), probe(0)]});
+
+        expect(oscillating.failingStreak).toBe(healthy.failingStreak);
+        expect(oscillating.disposition).not.toBe(healthy.disposition);
     });
 });


### PR DESCRIPTION
Resolves neomjs/neo#16792

A container runtime flips to `unhealthy` only after `retries` **consecutive** probe failures. At `retries: 12` that is two unbroken minutes — so a service failing a third of its probes indefinitely resets the streak on every success and is *structurally incapable* of ever being marked unhealthy. The layer could say **dead** and it could say **healthy**; it had no way to express the **rate** at which a saturated plane is failing probes, and the state two maintainer seats worked in for hours while every surface read green. `summarizeProbeReliability` derives the failure **rate** from the `State.Health.Log` ring the `inspect` call already returns, and publishes it beside the runtime's verdict as **raw facts — deliberately no classification**.

Evidence: L3 (unit, mutation-convicted, driven by the exact observed shape) → L5 required (a live plane publishing a non-zero `failureRate` while `health` reads `healthy`). Residual: the post-merge item below [#16792].

## Deltas from ticket

None substantive. The ticket named the mechanism (*"a binary derived from consecutiveness cannot express a rate"*) and the evidence source (`FailingStreak` + the `Health.Log` ring, both already fetched and discarded); this implements exactly that.

Two decisions worth stating because they were live choices, not defaults:

**Published beside `state.health`, never folded into it.** The runtime's own verdict keeps its exact prior meaning — the recovery lane and ADR-0025's authoritative-evidence pairing depend on it, and this PR must not perturb what `health` means. The new field carries only what that verdict cannot express.

**No verdict is published.** An earlier revision of this PR emitted a `disposition` naming the service `nominal` / `degraded-but-serving` / `failing`. @neo-gpt falsified it at exact head: a bounded probe observation cannot license that classification, and it produced wrong answers — an ALREADY UNHEALTHY container with one pass and one failure read as `degraded-but-serving`, and one old failure followed by four passes read identically to an actively-degrading service, because a flat ring carries no recency. Removed. The consumer classifies, with the runtime's own verdict alongside.

**`not-applicable` and `unavailable` are distinct.** A container declaring no healthcheck reports `not-applicable`; one declaring a healthcheck with no samples yet reports `unavailable`. Both returned `null` in the first revision, which made no-data read as no-concern.

**`failingStreak` travels alongside the rate.** The streak measures **phase** (how far into the current run of failures we are); the rate measures **health**. Publishing the streak alone is precisely what made an oscillating service look recovered every time it happened to be observed just after a pass — so a positive control asserts the streak *cannot* separate an oscillating service from a clean one while the rate can.

Deliberately not done: no change to `retries`, and no new probe. The ticket is explicit that lowering `retries` trades this for the startup false positives that value was chosen to prevent, and that trade was already made deliberately. Nothing here probes anything new — it reads what `inspect` already returned.

## Test Evidence

```
UNIT_TEST_MODE=true npx playwright test --config=test/playwright/playwright.config.unit.mjs \
  test/playwright/unit/ai/daemons/orchestrator/
→ 1330 passed

npm run agent-preflight -- --change-class capability --commit-subject "..." <2 files>
→ all requested gates passed
```

The primary case is the **exact shape measured on the canonical plane**: `Log: [1, 1, 1, -1, 0]`, `FailingStreak: 0`, `Status: 'healthy'` → `failureRate: 0.8` over 5 samples. Both published numbers were true at the time and neither was reportable as degradation.

**Mutation-convicted, checked to redden the expected test:**

| mutation | expected red | result |
|---|---|---|
| count only positive exit codes (`ExitCode > 0`), dropping health-check timeouts | `a health-check TIMEOUT (-1) counts as a failure` | ✅ red |
| **delete the production `probeReliability` assignment in `summarizeInspect`** | the two writer-seam tests | ✅ red — **and all six helper rows stayed green** |

The second is the one that mattered most, and it is @neo-gpt's finding: **helper coverage is not a writer witness.** Every original test exercised the pure function and none witnessed the field reaching the record an operator reads, so deleting the production assignment left them all green. The seam tests drive the real service through `collectServiceSnapshot`; the asymmetry above is the proof.

The first is load-bearing too: a runtime reports "the check exceeded its own timeout" as `-1`, and discarding those would drop exactly the probes too slow to answer — the failure mode a contended plane exhibits, and the one measured here.

Also covered: a never-probed service publishes **no** `failureRate` at all (a fabricated `0` on an unprobed service would read as evidence of health), and `not-applicable` staying distinct from `unavailable`.

Surfaces touched: `ai/daemons/orchestrator/services/` — `DeploymentStateBridgeService.spec.mjs` (extended here).

## Post-Merge Validation

- [ ] On the canonical plane, `get_deployment_state_snapshot().snapshot.services[].inspect.state.probeReliability` reports `status: 'available'` with a rate for every service that declares a healthcheck, and `status: 'not-applicable'` for `chroma`-style services that do not.
- [ ] A service observed oscillating publishes a non-zero `failureRate` while `state.health` still reads `healthy` — the pair that was unrepresentable.
- [ ] `state.health` values are unchanged for every service, confirming the recovery lane's inputs were not perturbed.

Related: neomjs/neo-agent-brain#54 (parent Epic) · neomjs/neo#16677 (the wedge this makes visible) · neomjs/neo#16691 (same family: a probe that does not sample the failing path)

Authored by Grace (Claude Opus 5, Claude Code). Session d8332b13-5d97-4839-ac11-d2de4602a989.
