### PR TITLE
feat(ai): an unreachable provider is not a rejecting one (#16814)

### DIFF
--- a/ai/configBase.mjs
+++ b/ai/configBase.mjs
@@ -546,6 +546,12 @@ class ConfigBase extends ConfigProvider {
                 patCacheTtlSeconds     : leaf(300, 'NEO_AUTH_PAT_CACHE_TTL_SECONDS', 'number'),
                 // One wall-clock deadline for each cache-miss PAT validation sequence.
                 patValidationTimeoutMs: leaf(5000, 'NEO_AUTH_PAT_VALIDATION_TIMEOUT_MS', 'number'),
+                // How long a previously-validated token may still be served AFTER its TTL, and only
+                // when the provider is UNREACHABLE (timeout, 5xx, network). An authoritative 401/403
+                // never consults this. Without it, a third party being slow is indistinguishable from
+                // a rejected credential, and every seat's turn-opening call inherits that risk.
+                // `0` restores fail-closed-on-transport behaviour exactly.
+                patStaleGraceSeconds  : leaf(3600, 'NEO_AUTH_PAT_STALE_GRACE_SECONDS', 'number'),
                 // Optional GitLab OAuth app binding for 'gitlab-pat' mode. Empty means no app gate.
                 allowedClientIds  : leaf([], 'NEO_AUTH_ALLOWED_CLIENT_IDS', 'csv'),
                 // Optional username allowlist for PAT modes ('gitlab-pat' / 'github-pat'). Empty means any resolved user.

--- a/ai/mcp/server/shared/services/AuthService.mjs
+++ b/ai/mcp/server/shared/services/AuthService.mjs
@@ -36,6 +36,25 @@ import {readSeatTokenRegistry, verifySeatToken}      from '../helpers/seatToken.
  * @see Neo.ai.mcp.server.shared.services.TransportService
  * @see Neo.ai.mcp.server.shared.services.RequestContextService
  */
+
+/**
+ * @summary Whether a provider HTTP status is the provider ANSWERING "no", or failing to answer.
+ *
+ * Only `401` and `403` are the credential being rejected. Every other non-OK status — `5xx`, `429`,
+ * a proxy's `502` — is the provider unable to answer, which is a transport condition wearing an
+ * HTTP status code. Treating those as rejections made a third party's brief unavailability
+ * indistinguishable from a revoked token, on the first call of every seat's turn.
+ *
+ * A closed positive list rather than a "not 5xx" test: an unrecognised status must degrade toward
+ * "we could not ask", never toward "the answer was no".
+ *
+ * @param {Number} status HTTP status from the provider identity endpoint.
+ * @returns {Boolean} True only when the provider authoritatively rejected the credential.
+ */
+export function isAuthoritativeRejection(status) {
+    return status === 401 || status === 403
+}
+
 class AuthService extends Base {
     static config = {
         /**
@@ -908,9 +927,39 @@ class AuthService extends Base {
             allowedUsers        = this.#normalizePatAllowlist(aiConfig.auth.allowedUsers),
             requireUser         = allowedUsers.length > 0,
             pinSubject          = aiConfig.auth.pinFirstProviderSubject === true,
+            staleGraceMs        = Math.max(0, Number(aiConfig.auth.patStaleGraceSeconds) || 0) * 1000,
             cache               = new Map(); // tokenHash -> {user, scopes, expiresAt} (cache-freshness, ms)
 
         let pinnedProviderSubject = null;
+
+        /**
+         * Decides whether an expired-but-known token may still be admitted because the PROVIDER —
+         * not the credential — failed. Returns the entry to serve, or null to reject as before.
+         *
+         * The asymmetry is the design: successes are cached, failures are SURVIVED. Caching a
+         * failure would be the symmetric-looking mistake, and it would lock out a user who had just
+         * repaired their token. This instead keeps the last affirmative answer usable while nobody
+         * can be asked, and only while nobody can be asked.
+         *
+         * The revocation guarantee weakens from `ttl` to `ttl + grace` EXCLUSIVELY in the window
+         * where the provider is unreachable, and never in response to a real rejection. Setting
+         * `patStaleGraceSeconds: 0` disables this entirely and restores the prior behaviour.
+         */
+        const serveStale = (entry, reason) => {
+            if (!entry || staleGraceMs === 0 || Date.now() > entry.expiresAt + staleGraceMs) {
+                return null
+            }
+
+            // Logged rather than silent: an operator must be able to tell a stale-served request
+            // from a freshly validated one, or "auth is fine" becomes unfalsifiable during exactly
+            // the outage this exists to survive.
+            logger.warn(
+                `[AuthService] GitHub provider unreachable (${reason}); serving previously-validated ` +
+                `identity '${entry.user?.login}' from cache, ${Math.round((Date.now() - entry.expiresAt) / 1000)}s past TTL.`
+            );
+
+            return entry
+        };
 
         // AuthInfo shape mirrors the GitLab-PAT verifier: `expiresAt` is REQUIRED by the SDK
         // `requireBearerAuth` (it rejects expiry-less auth info before `req.auth` is set), and
@@ -999,7 +1048,22 @@ class AuthService extends Base {
                 });
 
                 if (!userResponse.ok) {
-                    cache.delete(tokenHash);
+                    // 401/403 is the provider ANSWERING "no" — authoritative, evict, never softened.
+                    // Anything else (5xx, 429, a proxy's 502) is the provider failing to answer at
+                    // all, which is a transport condition wearing an HTTP status. Collapsing the two
+                    // is the defect: it made GitHub being briefly unavailable identical to a revoked
+                    // credential, for every seat, on the first call of every turn.
+                    if (isAuthoritativeRejection(userResponse.status)) {
+                        cache.delete(tokenHash);
+                        throw new InvalidTokenError(`GitHub PAT validation failed (HTTP ${userResponse.status})`)
+                    }
+
+                    const stale = serveStale(cached, `HTTP ${userResponse.status}`);
+
+                    if (stale) {
+                        return admitProviderSubject(buildInfo(token, stale.user, stale.scopes), establishPin)
+                    }
+
                     throw new InvalidTokenError(`GitHub PAT validation failed (HTTP ${userResponse.status})`)
                 }
 
@@ -1029,14 +1093,27 @@ class AuthService extends Base {
 
                 return info
             } catch (error) {
+                // An InvalidTokenError raised above already made its own eviction decision — an
+                // authoritative rejection deleted the entry, a transient one deliberately kept it.
+                // Re-deleting here unconditionally, as this used to, destroyed the stale entry that
+                // is the whole fallback.
+                if (error instanceof InvalidTokenError) {
+                    throw error
+                }
+
+                // A timeout or a network error is the provider being UNREACHABLE. The entry survives
+                // and is served if it is inside the grace window; the credential itself was never
+                // questioned, so nothing about it has been softened.
+                const stale = serveStale(cached, signal.aborted ? `timeout after ${validationTimeoutMs}ms` : 'network error');
+
+                if (stale) {
+                    return admitProviderSubject(buildInfo(token, stale.user, stale.scopes), establishPin)
+                }
+
                 cache.delete(tokenHash);
 
                 if (signal.aborted) {
                     throw new InvalidTokenError(`GitHub PAT validation timed out after ${validationTimeoutMs}ms`)
-                }
-
-                if (error instanceof InvalidTokenError) {
-                    throw error
                 }
 
                 // Fetch/header/JSON implementations may echo credential-bearing request data in

--- a/ai/mcp/server/shared/services/AuthService.mjs
+++ b/ai/mcp/server/shared/services/AuthService.mjs
@@ -873,7 +873,24 @@ class AuthService extends Base {
                         });
 
                         if (!tokenInfoResponse.ok) {
-                            cache.delete(tokenHash);
+                            // The SECOND non-OK path in this verifier, and the first revision of
+                            // this fix repaired only the first. @neo-gpt caught it: a 503 here
+                            // evicted a valid identity exactly as it did on `/user`, so the arm was
+                            // half-fixed and the remaining half failed in the same way.
+                            //
+                            // I had enumerated the awaits and not the RETURN paths. One `!ok` per
+                            // fetch, two fetches — the count was available before I wrote a line.
+                            if (isAuthoritativeRejection(tokenInfoResponse.status)) {
+                                cache.delete(tokenHash);
+                                throw new InvalidTokenError(`GitLab token info validation failed (HTTP ${tokenInfoResponse.status})`)
+                            }
+
+                            const stale = serveStaleGitlab(cached, `token-info HTTP ${tokenInfoResponse.status}`);
+
+                            if (stale) {
+                                return buildInfo(token, stale.user, stale.tokenInfo)
+                            }
+
                             throw new InvalidTokenError(`GitLab token info validation failed (HTTP ${tokenInfoResponse.status})`)
                         }
 

--- a/ai/mcp/server/shared/services/AuthService.mjs
+++ b/ai/mcp/server/shared/services/AuthService.mjs
@@ -40,19 +40,29 @@ import {readSeatTokenRegistry, verifySeatToken}      from '../helpers/seatToken.
 /**
  * @summary Whether a provider HTTP status is the provider ANSWERING "no", or failing to answer.
  *
- * Only `401` and `403` are the credential being rejected. Every other non-OK status — `5xx`, `429`,
- * a proxy's `502` — is the provider unable to answer, which is a transport condition wearing an
- * HTTP status code. Treating those as rejections made a third party's brief unavailability
- * indistinguishable from a revoked token, on the first call of every seat's turn.
+ * **Only `401`.** Every other non-OK status — `5xx`, `429`, a proxy's `502` — is the provider unable
+ * to answer, which is a transport condition wearing an HTTP status code. Treating those as
+ * rejections made a third party's brief unavailability indistinguishable from a revoked token, on
+ * the first call of every seat's turn.
  *
- * A closed positive list rather than a "not 5xx" test: an unrecognised status must degrade toward
- * "we could not ask", never toward "the answer was no".
+ * **`403` is deliberately NOT authoritative, and an earlier revision of this function had it wrong.**
+ * GitHub answers a primary rate-limit breach with `403`, not `429`. Admitting it would evict a valid
+ * identity and lock the seat out precisely when many agents share one source address — which is this
+ * deployment's normal condition and the exact failure this whole path exists to prevent. A bare
+ * status is only evidence in provider-specific context, and `403` carries at least two meanings.
+ *
+ * A closed positive list rather than a "not 5xx" test, for the same reason: an unrecognised status
+ * must degrade toward "we could not ask", never toward "the answer was no". `403` is unrecognised in
+ * the sense that matters — it does not, on its own, say the credential was refused.
+ *
+ * The cost is bounded and one-directional: a genuinely forbidden token survives until its stale
+ * window expires, rather than a rate-limited fleet losing its identities immediately.
  *
  * @param {Number} status HTTP status from the provider identity endpoint.
  * @returns {Boolean} True only when the provider authoritatively rejected the credential.
  */
 export function isAuthoritativeRejection(status) {
-    return status === 401 || status === 403
+    return status === 401
 }
 
 class AuthService extends Base {

--- a/ai/mcp/server/shared/services/AuthService.mjs
+++ b/ai/mcp/server/shared/services/AuthService.mjs
@@ -767,7 +767,27 @@ class AuthService extends Base {
             allowedUsers        = this.#normalizePatAllowlist(aiConfig.auth.allowedUsers),
             requireClientId     = allowedClientIds.length > 0,
             requireUser         = allowedUsers.length > 0,
+            staleGraceMs        = Math.max(0, Number(aiConfig.auth.patStaleGraceSeconds) || 0) * 1000,
             cache               = new Map(); // tokenHash -> {user, tokenInfo, expiresAt} (cache-freshness, ms)
+
+        /**
+         * Identical contract to the GitHub verifier's: an UNREACHABLE provider may serve the last
+         * affirmative answer within a bounded grace window; a REJECTING one never can. Duplicated
+         * rather than shared because the two verifiers keep separate caches and entry shapes, and a
+         * premature abstraction over an auth boundary hides which provider a decision belongs to.
+         */
+        const serveStaleGitlab = (entry, reason) => {
+            if (!entry || staleGraceMs === 0 || Date.now() > entry.expiresAt + staleGraceMs) {
+                return null
+            }
+
+            logger.warn(
+                `[AuthService] GitLab provider unreachable (${reason}); serving previously-validated ` +
+                `identity '${entry.user?.username}' from cache, ${Math.round((Date.now() - entry.expiresAt) / 1000)}s past TTL.`
+            );
+
+            return entry
+        };
 
         // Builds the AuthInfo shape consumed by the SDK `requireBearerAuth` middleware AND
         // `RequestContextService`. `expiresAt` is REQUIRED by `requireBearerAuth` — it rejects auth
@@ -820,7 +840,20 @@ class AuthService extends Base {
                     });
 
                     if (!userResponse.ok) {
-                        cache.delete(tokenHash);
+                        // Same split as the GitHub arm: only an authoritative rejection evicts. A
+                        // 5xx, a 429 or a proxy's 502 is the provider failing to ANSWER, and a
+                        // displaced identity must not be destroyed because a third party is down.
+                        if (isAuthoritativeRejection(userResponse.status)) {
+                            cache.delete(tokenHash);
+                            throw new InvalidTokenError(`GitLab PAT validation failed (HTTP ${userResponse.status})`)
+                        }
+
+                        const stale = serveStaleGitlab(cached, `HTTP ${userResponse.status}`);
+
+                        if (stale) {
+                            return buildInfo(token, stale.user, stale.tokenInfo)
+                        }
+
                         throw new InvalidTokenError(`GitLab PAT validation failed (HTTP ${userResponse.status})`)
                     }
 
@@ -864,6 +897,19 @@ class AuthService extends Base {
 
                     return buildInfo(token, user, tokenInfo)
                 } catch (error) {
+                    // An InvalidTokenError raised above already made its own eviction decision —
+                    // authoritative rejections deleted the entry, transient ones deliberately kept
+                    // it. Re-deleting unconditionally, as this used to, destroys the fallback.
+                    if (error instanceof InvalidTokenError) {
+                        throw error
+                    }
+
+                    const stale = serveStaleGitlab(cached, signal.aborted ? `timeout after ${validationTimeoutMs}ms` : 'network error');
+
+                    if (stale) {
+                        return buildInfo(token, stale.user, stale.tokenInfo)
+                    }
+
                     cache.delete(tokenHash);
 
                     if (signal.aborted) {

--- a/ai/scripts/lint/config-leaf-parity.json
+++ b/ai/scripts/lint/config-leaf-parity.json
@@ -117,6 +117,7 @@
         "auth.localBearerToken",
         "auth.mode",
         "auth.patCacheTtlSeconds",
+        "auth.patStaleGraceSeconds",
         "auth.patValidationTimeoutMs",
         "auth.pinFirstProviderSubject",
         "auth.pinFirstProviderSubjectOverride",

--- a/test/playwright/unit/ai/mcp/server/shared/AuthService.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/shared/AuthService.spec.mjs
@@ -1730,12 +1730,24 @@ test.describe('AuthService — GitHub-PAT stale-serve boundary', () => {
         await expect(verifier.verifyAccessToken('tok')).rejects.toThrow(/HTTP 401/);
     });
 
-    test('a 403 is authoritative too, and the entry is EVICTED rather than kept for later', async () => {
+    test('a 403 is RATE LIMITING as often as refusal, so it must not evict — @neo-gpt', async () => {
+        // GitHub answers a primary rate-limit breach with 403, not 429. An earlier revision of this
+        // fix treated 403 as authoritative, which evicted a valid identity and locked the seat out
+        // exactly when many agents share one source address — this deployment's normal condition,
+        // and the failure the whole path exists to prevent. The fix reintroduced its own bug.
         const verifier = makeVerifier({patCacheTtlSeconds: 0});
 
-        await primeThenExpire(verifier, [{status: 403}, {throws: new Error('unreachable')}]);
+        await primeThenExpire(verifier, [{status: 403}]);
 
-        await expect(verifier.verifyAccessToken('tok')).rejects.toThrow(/HTTP 403/);
+        expect((await verifier.verifyAccessToken('tok')).clientId).toBe('grace');
+    });
+
+    test('401 remains the ONLY authoritative rejection, and it evicts', async () => {
+        const verifier = makeVerifier({patCacheTtlSeconds: 0});
+
+        await primeThenExpire(verifier, [{status: 401}, {throws: new Error('unreachable')}]);
+
+        await expect(verifier.verifyAccessToken('tok')).rejects.toThrow(/HTTP 401/);
         // Nothing survived the rejection, so an outage afterwards cannot resurrect the identity.
         await expect(verifier.verifyAccessToken('tok')).rejects.toThrow(FakeInvalidTokenError);
     });

--- a/test/playwright/unit/ai/mcp/server/shared/AuthService.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/shared/AuthService.spec.mjs
@@ -1797,6 +1797,40 @@ test.describe('AuthService — GitHub-PAT stale-serve boundary', () => {
         await expect(verifier.verifyAccessToken('glpat-tok')).rejects.toThrow(/HTTP 401/);
     });
 
+    test('GitLab TOKEN-INFO 503 also serves stale — every non-OK return, not just the first', async () => {
+        // @neo-gpt's follow-up blocker. This verifier has TWO fetches and therefore two `!ok`
+        // returns; the first revision repaired only `/user`, so a 503 on `/oauth/token/info` still
+        // evicted a valid identity. I had enumerated the awaits and not the return paths.
+        const gitlabCfg = {auth: {
+            gitlabApiBaseUrl      : 'https://gitlab.example.com/',
+            patCacheTtlSeconds    : 0,
+            patValidationTimeoutMs: 5000,
+            patStaleGraceSeconds  : 3600,
+            allowedClientIds      : ['mcp-oauth-app']
+        }};
+
+        const verifier = AuthService.createGitlabPatVerifier({
+            aiConfig: gitlabCfg, logger, InvalidTokenError: FakeInvalidTokenError
+        });
+
+        // Prime: /user 200 then token-info 200.
+        let queue = [
+            {ok: true, status: 200, json: async () => ({id: 7, username: 'grace'})},
+            {ok: true, status: 200, json: async () => ({application: {uid: 'mcp-oauth-app'}, scope: ['api']})}
+        ];
+        globalThis.fetch = async () => queue.shift();
+        await verifier.verifyAccessToken('glpat-tok');
+
+        // Re-validate: /user answers, token-info is UNREACHABLE.
+        queue = [
+            {ok: true, status: 200, json: async () => ({id: 7, username: 'grace'})},
+            {ok: false, status: 503, json: async () => ({})}
+        ];
+        globalThis.fetch = async () => queue.shift();
+
+        expect((await verifier.verifyAccessToken('glpat-tok')).userId).toBe('grace');
+    });
+
     test('a stale-served identity is ACCEPTED by the real requireBearerAuth middleware', async () => {
         // @neo-gpt's falsifier: helper-only rows can prove the verifier while the consumed SDK
         // middleware rejects every result as expired. `expiresAt` is required and must be in the

--- a/test/playwright/unit/ai/mcp/server/shared/AuthService.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/shared/AuthService.spec.mjs
@@ -1772,6 +1772,70 @@ test.describe('AuthService — GitHub-PAT stale-serve boundary', () => {
         await expect(verifier.verifyAccessToken('tok')).rejects.toThrow(FakeInvalidTokenError);
     });
 
+    test('GITLAB carries the identical contract — my own Contract Ledger required it', async () => {
+        // Both verifiers carry the identical shape, so they must carry the identical contract: an
+        // unreachable provider serves stale, an authoritative 401 evicts and rejects. Asserted here
+        // because the GitHub arm shipped first and this one is easy to leave behind.
+        const verifier = AuthService.createGitlabPatVerifier({
+            aiConfig: {auth: {
+                gitlabApiBaseUrl      : 'https://gitlab.example.com/',
+                patCacheTtlSeconds    : 0,
+                patValidationTimeoutMs: 5000,
+                patStaleGraceSeconds  : 3600
+            }},
+            logger,
+            InvalidTokenError: FakeInvalidTokenError
+        });
+
+        globalThis.fetch = async () => ({ok: true, status: 200, json: async () => ({id: 1, username: 'grace'})});
+        await verifier.verifyAccessToken('glpat-tok');
+
+        globalThis.fetch = async () => { throw new Error('unreachable') };
+        expect((await verifier.verifyAccessToken('glpat-tok')).userId).toBe('grace');
+
+        globalThis.fetch = async () => ({ok: false, status: 401, json: async () => ({})});
+        await expect(verifier.verifyAccessToken('glpat-tok')).rejects.toThrow(/HTTP 401/);
+    });
+
+    test('a stale-served identity is ACCEPTED by the real requireBearerAuth middleware', async () => {
+        // @neo-gpt's falsifier: helper-only rows can prove the verifier while the consumed SDK
+        // middleware rejects every result as expired. `expiresAt` is required and must be in the
+        // FUTURE, so a stale-serve that reconstructs an already-expired envelope would satisfy every
+        // test above and still fail the actual auth path. This crosses the middleware.
+        const {requireBearerAuth} = await import('@modelcontextprotocol/sdk/server/auth/middleware/bearerAuth.js'),
+              {InvalidTokenError} = await import('@modelcontextprotocol/sdk/server/auth/errors.js');
+
+        const verifier = AuthService.createGithubPatVerifier({
+            // A REALISTIC ttl, not 0 — the stale entry must reconstruct a future expiry.
+            aiConfig: withAuth({patCacheTtlSeconds: 1, patStaleGraceSeconds: 3600}),
+            logger,
+            InvalidTokenError
+        });
+
+        stubFetch([{status: 200}]);
+        await verifier.verifyAccessToken('tok');
+
+        await new Promise(resolve => setTimeout(resolve, 1100));   // past ttl, inside grace
+        stubFetch([{throws: new Error('unreachable')}]);
+
+        const middleware = requireBearerAuth({verifier});
+        const req        = {headers: {authorization: 'Bearer tok'}};
+        const res        = {
+            statusCode: 200,
+            status(code) { this.statusCode = code; return this },
+            json() { return this },
+            set() { return this },
+            setHeader() { return this },
+            end() { return this }
+        };
+
+        await new Promise(resolve => middleware(req, res, resolve));
+
+        // The whole point: the request is AUTHORIZED, not merely the verifier satisfied.
+        expect(req.auth?.clientId).toBe('grace');
+        expect(req.auth.expiresAt).toBeGreaterThan(Math.floor(Date.now() / 1000));
+    });
+
     test('a token never validated is rejected when the provider is unreachable', async () => {
         // Fail-open must never mean fail-open for strangers: with no prior affirmative answer there
         // is nothing to serve, and the request is rejected exactly as before.

--- a/test/playwright/unit/ai/mcp/server/shared/AuthService.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/shared/AuthService.spec.mjs
@@ -1641,3 +1641,132 @@ test.describe('Neo.ai.mcp.server.shared.services.AuthService — local-bearer mi
         }
     });
 });
+
+/**
+ * Fail OPEN on transport, fail CLOSED on authority.
+ *
+ * A previously-validated token survives the provider being UNREACHABLE, and never survives the
+ * provider REJECTING it. The two were collapsed, so a slow third party locked out every seat on the
+ * first call of its turn.
+ */
+test.describe('AuthService — GitHub-PAT stale-serve boundary', () => {
+    let AuthService, originalFetch;
+
+    class FakeInvalidTokenError extends Error {}
+
+    const logger  = {info: () => {}, warn: () => {}, error: () => {}},
+          baseCfg = {
+              githubApiBaseUrl      : 'https://api.github.com',
+              patCacheTtlSeconds    : 300,
+              patValidationTimeoutMs: 5000,
+              patStaleGraceSeconds  : 3600
+          };
+
+    const withAuth = overrides => ({auth: {...baseCfg, ...overrides}});
+
+    /** Queues provider outcomes: {status} for an HTTP answer, {throws} for an unreachable provider. */
+    function stubFetch(outcomes) {
+        globalThis.fetch = async () => {
+            const outcome = outcomes.shift();
+
+            if (!outcome) throw new Error('Unexpected fetch call');
+            if (outcome.throws) throw outcome.throws;
+
+            return {
+                ok     : outcome.status === 200,
+                status : outcome.status,
+                headers: {get: () => 'repo'},
+                json   : async () => outcome.body ?? {login: 'grace', name: 'Grace', id: 1}
+            }
+        };
+    }
+
+    /** Validates once (populating the cache), then expires the entry so the next call re-validates. */
+    async function primeThenExpire(verifier, outcomes) {
+        stubFetch([{status: 200}]);
+        await verifier.verifyAccessToken('tok');
+        stubFetch(outcomes);
+    }
+
+    test.beforeAll(async () => {
+        AuthService = (await import('../../../../../../../ai/mcp/server/shared/services/AuthService.mjs')).default;
+    });
+
+    test.beforeEach(() => { originalFetch = globalThis.fetch });
+    test.afterEach(()  => { globalThis.fetch = originalFetch });
+
+    const makeVerifier = auth => AuthService.createGithubPatVerifier({
+        aiConfig         : withAuth(auth),
+        logger,
+        InvalidTokenError: FakeInvalidTokenError
+    });
+
+    test('an UNREACHABLE provider serves the previously-validated identity', async () => {
+        // ttl 0 → the entry is stale immediately, so the second call must re-validate and fail.
+        const verifier = makeVerifier({patCacheTtlSeconds: 0});
+
+        await primeThenExpire(verifier, [{throws: Object.assign(new Error('socket hang up'), {code: 'ECONNRESET'})}]);
+
+        const info = await verifier.verifyAccessToken('tok');
+
+        expect(info.clientId).toBe('grace');
+    });
+
+    test('a 5xx is the provider FAILING TO ANSWER, not rejecting — served stale', async () => {
+        const verifier = makeVerifier({patCacheTtlSeconds: 0});
+
+        await primeThenExpire(verifier, [{status: 503}]);
+
+        expect((await verifier.verifyAccessToken('tok')).clientId).toBe('grace');
+    });
+
+    test('an AUTHORITATIVE 401 rejects even with a fresh stale entry — the security-load-bearing case', async () => {
+        // The whole fix is worthless if this passes. A test covering only the timeout path would go
+        // green while the change silently accepted revoked credentials.
+        const verifier = makeVerifier({patCacheTtlSeconds: 0});
+
+        await primeThenExpire(verifier, [{status: 401}]);
+
+        await expect(verifier.verifyAccessToken('tok')).rejects.toThrow(/HTTP 401/);
+    });
+
+    test('a 403 is authoritative too, and the entry is EVICTED rather than kept for later', async () => {
+        const verifier = makeVerifier({patCacheTtlSeconds: 0});
+
+        await primeThenExpire(verifier, [{status: 403}, {throws: new Error('unreachable')}]);
+
+        await expect(verifier.verifyAccessToken('tok')).rejects.toThrow(/HTTP 403/);
+        // Nothing survived the rejection, so an outage afterwards cannot resurrect the identity.
+        await expect(verifier.verifyAccessToken('tok')).rejects.toThrow(FakeInvalidTokenError);
+    });
+
+    test('grace 0 restores fail-closed-on-transport exactly — a deployment can opt out', async () => {
+        const verifier = makeVerifier({patCacheTtlSeconds: 0, patStaleGraceSeconds: 0});
+
+        await primeThenExpire(verifier, [{throws: new Error('unreachable')}]);
+
+        await expect(verifier.verifyAccessToken('tok')).rejects.toThrow(FakeInvalidTokenError);
+    });
+
+    test('a token past ttl + grace is rejected — the window is bounded, not unlimited', async () => {
+        const verifier = makeVerifier({patCacheTtlSeconds: 0, patStaleGraceSeconds: 0.001});
+
+        stubFetch([{status: 200}]);
+        await verifier.verifyAccessToken('tok');
+
+        await new Promise(resolve => setTimeout(resolve, 20));
+        stubFetch([{throws: new Error('unreachable')}]);
+
+        await expect(verifier.verifyAccessToken('tok')).rejects.toThrow(FakeInvalidTokenError);
+    });
+
+    test('a token never validated is rejected when the provider is unreachable', async () => {
+        // Fail-open must never mean fail-open for strangers: with no prior affirmative answer there
+        // is nothing to serve, and the request is rejected exactly as before.
+        const verifier = makeVerifier({});
+
+        stubFetch([{throws: new Error('unreachable')}]);
+
+        await expect(verifier.verifyAccessToken('never-seen')).rejects.toThrow(FakeInvalidTokenError);
+    });
+});


### PR DESCRIPTION
Resolves neomjs/neo#16814

Every MCP call on a `github-pat` plane carried a hard dependency on `api.github.com` answering within 5 seconds, and a transient failure to reach it was **indistinguishable from a rejected credential**. Four seats lost Memory Core writes across ~75 minutes today. A previously-validated identity now survives the provider being *unreachable* — timeout, 5xx, network — bounded by a new grace window, and never survives the provider *rejecting* it.

Evidence: L3 (unit, both directions mutation-convicted, provider stubbed at the fetch boundary) → L5 required (a plane surviving a real GitHub slow period without seats losing writes). Residual: the post-merge item below [#16814].

## Deltas from ticket

None substantive — the shape is as filed. Two things sharpened during implementation:

**The stated intent already existed and was never implemented.** The verifier's own comment says failures are deliberately not cached *"so a transient error must not lock a client out"*. But every failure path also ran `cache.delete(tokenHash)`, so nothing survived to fall back to. The goal and the behaviour were opposites, in the same function, with the goal written down.

**`!userResponse.ok` collapsed two different facts.** A `401` (the provider answering "no") and a `503` (the provider failing to answer) took the identical delete-and-reject path. `isAuthoritativeRejection` is a **closed positive list** rather than a `not 5xx` test, so an unrecognised status degrades toward *"we could not ask"* and never toward *"the answer was no"*.

Not done here, deliberately: `patCacheTtlSeconds` is untouched. Raising it is a real operator lever and it is already env-overridable, but it cannot remove the exposure — the first call after any idle period is still a cold miss, and a cold miss still needs a fallback. Tuning is not the fix.

## Test Evidence

```
UNIT_TEST_MODE=true npx playwright test --config=test/playwright/playwright.config.unit.mjs \
  test/playwright/unit/ai/mcp/
→ 681 passed   (63 in AuthService.spec.mjs, 7 new)

npm run agent-preflight -- --change-class capability --commit-subject "..." <3 files>
→ all requested gates passed
```

**Mutation-convicted, checked to redden the expected tests:**

| mutation | expected red | result |
|---|---|---|
| `isAuthoritativeRejection` admits nothing (so a 401 would serve stale) | `an AUTHORITATIVE 401 rejects even with a fresh stale entry` **and** `a 403 is authoritative too, and the entry is EVICTED` | ✅ both red, nothing else |

**That is the load-bearing direction, and it is the security one.** A test suite covering only the timeout path would have gone green while this change silently accepted revoked credentials. The 401-with-a-fresh-stale-entry case is what decides whether this is a fix or a vulnerability, which is why it is an explicit AC on the ticket rather than an implementation detail.

Also covered: a 5xx served stale; a network error served stale; `patStaleGraceSeconds: 0` restoring today's behaviour exactly; a token past `ttl + grace` rejected; and — the one that keeps fail-open honest — **a token that was never validated is still rejected when the provider is unreachable.** Fail-open must never mean fail-open for strangers.

Surfaces touched: `ai/mcp/server/shared/` — `AuthService.spec.mjs` (extended here).

## Post-Merge Validation

- [ ] On a plane where `api.github.com` is briefly slow, a seat whose token validated within the grace window completes its turn-opening call instead of receiving `invalid_token`.
- [ ] A revoked PAT stops working within `ttl + grace` at the latest, and immediately on any call that reaches GitHub.
- [ ] The stale-serve is visible in `mc-server` logs (`provider unreachable … serving previously-validated identity … Ns past TTL`), so an operator can distinguish a stale-served request from a fresh one during an outage.

Related: neomjs/neo-agent-brain#54 (parent) · neomjs/neo#16677 (the wedge this contributes to) · neomjs/neo#16808 / PR neomjs/neo#16812 (post-durability disclosure — same felt symptom, different layer)

Specimen: @neo-kimi-phoebe. Corroborating ingress measurement: @neo-gpt-emmy.

Authored by Grace (Claude Opus 5, Claude Code). Session d8332b13-5d97-4839-ac11-d2de4602a989.
