### PR TITLE
test(orchestrator): the heavy-maintenance fairness bound cannot preempt a stuck holder (#16817)

### DIFF
--- a/test/playwright/unit/ai/daemons/orchestrator/services/HeavyMaintenanceLeaseService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/HeavyMaintenanceLeaseService.spec.mjs
@@ -1822,3 +1822,76 @@ test.describe('#16262 — bootId: cross-boot staleness regardless of pid livenes
         expect(injected.bootId).toBe('injected-boot');
     });
 });
+
+test.describe('the fairness bound is COOPERATIVE — a task that never checkpoints is never preempted', () => {
+    /**
+     * Executes the mechanism behind the observed 13-hour lease hold rather than reading it.
+     *
+     * `maxActiveHoldMs` is enforced by `shouldYield()`, a pure predicate the HOLDER must choose to
+     * call between batches. `withHeavyMaintenanceLease` is `await task(...)` inside a try/finally
+     * with no timer, no abort signal and no watchdog. So a holder blocked inside ONE request that
+     * never settles never reaches a checkpoint, never asks, and nothing asks for it.
+     *
+     * The two bounds are deliberately set to production's ratio (6h TTL vs 30min yield) so the
+     * assertions cannot be satisfied by staleness instead: at the observation point the lease is
+     * comfortably inside its TTL, so "still held" means held, not merely not-yet-reclaimed.
+     */
+    test('the hold outlives maxActiveHoldMs while shouldYield already says yield, and only the task settling releases it', async () => {
+        const
+            leasePath       = createLeasePath('non-terminating-embed'),
+            acquiredAt      = new Date('2026-08-09T00:00:00.000Z'),
+            maxActiveHoldMs = 30 * 60 * 1000,
+            staleAfterMs    = 6 * 60 * 60 * 1000,
+            pastBound       = new Date(acquiredAt.getTime() + maxActiveHoldMs + 1);
+
+        let settleTask, taskStarted;
+
+        // The observed shape: a single embedding submission that has not returned.
+        const
+            neverSettlesUntilWeSaySo = new Promise(resolve => {settleTask  = resolve}),
+            taskIsRunning            = new Promise(resolve => {taskStarted = resolve});
+
+        const inFlight = _rawWithHeavyMaintenanceLease(() => {
+            // The task only runs once acquisition succeeded, so awaiting this is a deterministic
+            // "the lease is held" signal — a fixed tick would race the async acquire and observe
+            // a lease that does not exist yet, which is a broken fixture rather than a finding.
+            taskStarted();
+            return neverSettlesUntilWeSaySo
+        }, {
+            leasePath,
+            owner: 'kbSync',
+            now  : acquiredAt,
+            token: 'kb-sync-stuck',
+            staleAfterMs
+        });
+
+        await taskIsRunning;
+
+        const duringHold = await inspectHeavyMaintenanceLease({leasePath, now: pastBound});
+
+        expect(duringHold.active, 'the lease is held and NOT stale at the observation point').toBe(true);
+
+        // The fairness bound is exceeded — the predicate agrees the holder should yield…
+        expect(
+            shouldYieldHeavyMaintenanceLease(duringHold.lease, {now: pastBound, maxActiveHoldMs}),
+            'shouldYield reports the bound as exceeded'
+        ).toBe(true);
+
+        // …and the lease is still held anyway, because nothing consulted it. This is the gap: the
+        // bound is advisory to a holder that has no opportunity to read it.
+        const stillHeld = await inspectHeavyMaintenanceLease({leasePath, now: pastBound});
+
+        expect(stillHeld.active, 'nothing preempted the holder despite the bound being exceeded').toBe(true);
+        expect(stillHeld.lease.token, 'the same holder still owns it').toBe('kb-sync-stuck');
+
+        // Only the task settling releases it — which is exactly what a non-terminating request
+        // never does, and why an effective request deadline is the enabling fix rather than one
+        // option among several: a deadline is what manufactures the missing checkpoint.
+        settleTask('done');
+        await inFlight;
+
+        const afterSettle = await inspectHeavyMaintenanceLease({leasePath, now: pastBound});
+
+        expect(afterSettle.active, 'release happens on task settle, never on the bound').toBe(false)
+    })
+});


### PR DESCRIPTION
Resolves neomjs/neo#16817

Refs neomjs/neo#16780

`#16561` established that the heavy-maintenance lease had **no fairness**, and `maxActiveHoldMs` was added in response. This proves the residual: **the bound is cooperative**, so it cannot reach a holder that never gets control back — which is the shape behind `#16566`'s `kbSync` re-embed holding the slot **13 hours**, past both the 30-minute yield and the 6-hour TTL.

`shouldYield()` is a pure `now - acquiredAt > maxActiveHoldMs` predicate the **holder must choose to call**, documented as consumed between batches and never mid-batch. `withHeavyMaintenanceLease` is `await task(...)` in a `try/finally` with no timer, no abort signal and no watchdog. `staleAfterMs` targets an *abandoned* lease; a holder stuck inside a live call is not abandoned.

Evidence: L3 (deterministic unit execution against the real lease primitives) → L3 required (the claim is a property of committed code, fully reachable in-sandbox). Residual: none.

## Deltas from ticket

None substantive. Scope note: this is the **witness only**. It deliberately does not implement a fix, and it explicitly does not propose preemption at the lease layer — that would abandon a holder mid-batch with no resumable checkpoint, the exact hazard `maxActiveHoldMs` was designed around. The enabling repair is a deadline on the *held operation*, which manufactures the missing checkpoint; `#16780` AC-4 owns that for the embedding path.

## What it proves

With a task that never settles, at `acquiredAt + maxActiveHoldMs + 1ms`:

| observation | result |
|---|---|
| lease state | **still held**, same holder token |
| `shouldYieldHeavyMaintenanceLease` at that instant | **`true`** — the bound is already exceeded |
| release | occurs only when the task settles, never on the bound |

`#16566`'s 13-hour hold, reproduced deterministically in about four seconds.

## Two fixture properties that are load-bearing

**The bounds use production's ratio** — 6h TTL against a 30min yield — so `active` cannot be satisfied by staleness instead of by holding. With the spec's default 60s TTL the lease would read inactive at the observation point for the *wrong reason*, and the assertion would pass while meaning nothing.

**The task signals its own start.** My first attempt waited a fixed tick after `withLease` and observed `status: 'missing'` — the async acquire had not landed yet. That reads as "no lease" rather than "held", so the fixture would have been reporting a race as a finding. The task now resolves a promise from inside itself, which only runs after acquisition succeeded, making "the lease is held" a fact rather than a timing bet. I printed what the assertion actually saw rather than theorising about why it failed, which is what surfaced it.

## Test Evidence

`npm run test-unit -- test/playwright/unit/ai/daemons/orchestrator/services/HeavyMaintenanceLeaseService.spec.mjs` → **52 passed** (51 pre-existing + this one).

Per directly touched surface:
- `ai/daemons/orchestrator/services/heavyMaintenanceLeasePrimitives.mjs` (exercised, unmodified): this spec
- `ai/daemons/orchestrator/services/HeavyMaintenanceLeaseService.mjs` (exercised, unmodified): this spec

No production file is modified by this PR.

## Post-Merge Validation

- [ ] When `#16780` AC-4's deadline lands, confirm this fixture still passes — it should, because it asserts the *lease's* behaviour, not the operation's. If a deadline makes it fail, the deadline has been placed at the mutex rather than at the operation.

## Commits

- `00d94107eb` — the executed witness

Authored by Ada (Claude Opus 5, Claude Code). Session da404637-9dd0-4d84-bdfe-1f6f831a6b41.
