### PR TITLE
feat(ai): render deployment prescriptions into the env file compose reads (#16820)

### DIFF
--- a/ai/services/memory-core/helpers/deploymentPrescriptionEnvironment.mjs
+++ b/ai/services/memory-core/helpers/deploymentPrescriptionEnvironment.mjs
@@ -1,0 +1,116 @@
+/**
+ * Renders declared deployment prescriptions into the env file Compose interpolates at container
+ * CREATE time.
+ *
+ * **Why a file and not an export.** The actuator cannot apply a V8 heap ceiling itself:
+ * `--max-old-space-size` lives in the container command, Compose interpolates it at create time, and
+ * `reconfigure` is overlay-plus-restart — a restart re-runs the baked `Config.Cmd`, so the new value
+ * never reaches the process. That is a no-op that reports success. The actuator therefore PRESCRIBES
+ * and the deployment pipeline DELIVERS.
+ *
+ * **Why an env FILE and not an exported variable.** A value exported at deploy time reverts on the
+ * next redeploy that omits it — measured previously when an orchestrator ceiling passed as
+ * `NEO_ORCHESTRATOR_HEAP_MB=2048` silently fell back to the Compose default. Compose reads `.env`
+ * from its project directory with no flag and from any working directory, so a rendered file also
+ * reaches the raw operator paths (`docker compose up -d --force-recreate <svc>`, the down/up
+ * survival check) that no pipeline-scoped mechanism can. Persisted, not passed.
+ *
+ * Measured with a control before this module was written: an env file declaring
+ * `NEO_KB_SERVER_HEAP_MB=1234` made `docker compose config` resolve `--max-old-space-size=1234`;
+ * removing the file returned it to the compose default. That round trip — prescription to the value
+ * the container is created with — is the effect boundary this delivery path has to clear, and it is
+ * reproducible without a Docker daemon reachable for `up`.
+ *
+ * **Residual, deliberately not dissolved.** `--env-file` and `--project-directory` override the
+ * default lookup, and an operator-ordered compose-file list anchors the project directory on its
+ * FIRST entry. A deliberately non-default deployment therefore reads the prescription from
+ * somewhere else and silently gets the compose default. That is narrower than a pipeline-only
+ * mechanism but not zero, and it is why {@link renderPrescribedEnvironment} returns the target path
+ * it assumed rather than writing to an inferred one.
+ */
+
+/**
+ * A single line's worth of prescription: which environment key carries the value, and the value
+ * itself. Keys are validated rather than trusted — a prescription reaching this renderer has passed
+ * through a ledger, and a malformed key would otherwise be written verbatim into a file Compose
+ * parses for every service.
+ * @typedef {Object} DeploymentPrescription
+ * @property {String} key   Environment variable name, e.g. `NEO_KB_SERVER_HEAP_MB`.
+ * @property {Number} value Prescribed value; finite and positive.
+ */
+
+/**
+ * Compose's own env-file grammar is permissive, so this is deliberately stricter than it has to be:
+ * an uppercase, underscore-separated identifier. A key that needs quoting or escaping is a key this
+ * renderer refuses rather than encodes, because a mis-encoded line does not fail — Compose skips it
+ * and the container is created with the default, which is the silent-revert this whole path exists
+ * to remove.
+ * @type {RegExp}
+ */
+const ENV_KEY_PATTERN = /^[A-Z][A-Z0-9_]*$/;
+
+/**
+ * Refuses a prescription rather than rendering an unusable line.
+ *
+ * Returning a reason instead of throwing keeps the caller's disposition explicit: a refused
+ * prescription is a fact the ledger should record, not an exception that aborts a rendering pass and
+ * leaves the previously-written file in place — the stale file would then keep delivering an older
+ * ceiling while the ledger showed a newer one.
+ * @param {DeploymentPrescription} prescription
+ * @returns {String|null} The refusal reason, or `null` when the prescription is renderable.
+ */
+export function refusePrescription(prescription) {
+    const {key, value} = prescription ?? {};
+
+    if (typeof key !== 'string' || !ENV_KEY_PATTERN.test(key)) {
+        return 'key-not-an-env-identifier'
+    }
+
+    if (typeof value !== 'number' || !Number.isFinite(value) || value <= 0) {
+        return 'value-not-a-positive-finite-number'
+    }
+
+    return null
+}
+
+/**
+ * Renders prescriptions into env-file content.
+ *
+ * **Last write wins per key, and that is a decision rather than an accident:** a prescription ledger
+ * is append-only, so the same key legitimately appears more than once as a ceiling is raised over
+ * time. Rendering every occurrence would leave Compose to pick, and Compose picks the last — so this
+ * collapses duplicates explicitly and in the same direction, making the file's meaning independent
+ * of how many entries preceded it.
+ *
+ * Refused prescriptions are reported, never silently dropped: a caller that writes the file without
+ * reading `refused` would ship a ceiling it believes it prescribed.
+ * @param {DeploymentPrescription[]} prescriptions Ledger order — oldest first.
+ * @returns {{content: String, rendered: Object, refused: Array<{prescription: Object, reason: String}>}}
+ */
+export function renderPrescribedEnvironment(prescriptions) {
+    const
+        rendered = {},
+        refused  = [];
+
+    for (const prescription of prescriptions ?? []) {
+        const reason = refusePrescription(prescription);
+
+        if (reason) {
+            refused.push({prescription, reason});
+            continue
+        }
+
+        rendered[prescription.key] = prescription.value
+    }
+
+    const keys = Object.keys(rendered).sort();
+
+    return {
+        // Sorted and newline-terminated so an unchanged prescription set renders byte-identical
+        // content: a delivery step can then compare against the file on disk and skip a rewrite,
+        // rather than touching it every cycle and making every redeploy look like a change.
+        content: keys.map(key => `${key}=${rendered[key]}`).join('\n') + (keys.length ? '\n' : ''),
+        rendered,
+        refused
+    }
+}

--- a/test/playwright/unit/ai/services/memory-core/helpers/deploymentPrescriptionEnvironment.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/helpers/deploymentPrescriptionEnvironment.spec.mjs
@@ -1,0 +1,143 @@
+import {test, expect} from '@playwright/test';
+import fs             from 'node:fs';
+import os             from 'node:os';
+import path           from 'node:path';
+import {execFileSync} from 'node:child_process';
+
+import {
+    refusePrescription,
+    renderPrescribedEnvironment
+} from '../../../../../../../ai/services/memory-core/helpers/deploymentPrescriptionEnvironment.mjs';
+
+/**
+ * The effect boundary is the point where the prescription changes what the container is CREATED
+ * with — not the point where a ledger records that an action was named. A fixture asserting only
+ * that a diagnosis prescribed a ceiling would have passed against `reconfigure` throughout, which
+ * is exactly how the original no-op-reporting-success survived to review.
+ *
+ * `docker compose config` resolves interpolation WITHOUT a reachable daemon, so that boundary is
+ * testable here rather than only on a live plane. The compose-backed test skips when the CLI is
+ * absent — and skipping is safe only because the render-level tests below stand on their own.
+ */
+
+const COMPOSE_RELATIVE = 'ai/deploy/docker-compose.yml';
+
+/**
+ * @returns {Boolean} whether `docker compose config` can run in this environment
+ */
+function composeConfigAvailable() {
+    try {
+        execFileSync('docker', ['compose', 'version'], {stdio: 'ignore'});
+        return true
+    } catch {
+        return false
+    }
+}
+
+/**
+ * Resolves kb-server's `--max-old-space-size` as Compose would create it.
+ * @param {String} repoRoot
+ * @returns {Number|null}
+ */
+function resolvedKbCeiling(repoRoot) {
+    const out = execFileSync('docker', ['compose', '-f', COMPOSE_RELATIVE, 'config'], {
+        cwd     : repoRoot,
+        encoding: 'utf8'
+    });
+
+    // kb-server's command line is the first max-old-space-size occurrence in the rendered config.
+    const match = out.match(/max-old-space-size=(\d+)/);
+
+    return match ? Number(match[1]) : null
+}
+
+test.describe('deployment prescription -> env file', () => {
+    test('renders one line per key, sorted and newline-terminated', () => {
+        const {content, rendered, refused} = renderPrescribedEnvironment([
+            {key: 'NEO_MC_SERVER_HEAP_MB', value: 1536},
+            {key: 'NEO_KB_SERVER_HEAP_MB', value: 1024}
+        ]);
+
+        expect(content).toBe('NEO_KB_SERVER_HEAP_MB=1024\nNEO_MC_SERVER_HEAP_MB=1536\n');
+        expect(rendered).toEqual({NEO_KB_SERVER_HEAP_MB: 1024, NEO_MC_SERVER_HEAP_MB: 1536});
+        expect(refused).toEqual([])
+    });
+
+    test('an empty ledger renders empty content, never a stray newline', () => {
+        expect(renderPrescribedEnvironment([]).content).toBe('');
+        expect(renderPrescribedEnvironment(undefined).content).toBe('')
+    });
+
+    test('last write wins per key — an append-only ledger raises a ceiling more than once', () => {
+        const {content} = renderPrescribedEnvironment([
+            {key: 'NEO_KB_SERVER_HEAP_MB', value: 1024},
+            {key: 'NEO_KB_SERVER_HEAP_MB', value: 2048}
+        ]);
+
+        expect(content).toBe('NEO_KB_SERVER_HEAP_MB=2048\n')
+    });
+
+    test('an unchanged ledger renders byte-identical content', () => {
+        const ledger = [{key: 'NEO_KB_SERVER_HEAP_MB', value: 1024}];
+
+        expect(renderPrescribedEnvironment(ledger).content)
+            .toBe(renderPrescribedEnvironment(ledger).content)
+    });
+
+    test('refuses rather than encodes — a mis-encoded line does not fail, it silently delivers the default', () => {
+        const {content, refused} = renderPrescribedEnvironment([
+            {key: 'neo_kb_server_heap_mb', value: 1024},          // lowercase
+            {key: 'NEO_KB_SERVER_HEAP_MB=x', value: 1024},        // embedded separator
+            {key: 'NEO KB', value: 1024},                         // whitespace
+            {key: 'NEO_KB_SERVER_HEAP_MB', value: 0},             // non-positive
+            {key: 'NEO_MC_SERVER_HEAP_MB', value: Number.NaN},    // non-finite
+            {key: 'NEO_FLEET_SERVER_HEAP_MB', value: '512'}       // string, not number
+        ]);
+
+        expect(content).toBe('');
+        expect(refused.map(entry => entry.reason)).toEqual([
+            'key-not-an-env-identifier',
+            'key-not-an-env-identifier',
+            'key-not-an-env-identifier',
+            'value-not-a-positive-finite-number',
+            'value-not-a-positive-finite-number',
+            'value-not-a-positive-finite-number'
+        ])
+    });
+
+    test('refusePrescription returns null only for a renderable prescription', () => {
+        expect(refusePrescription({key: 'NEO_KB_SERVER_HEAP_MB', value: 1024})).toBeNull();
+        expect(refusePrescription(undefined)).toBe('key-not-an-env-identifier')
+    });
+
+    test('the rendered file changes what the container is CREATED with', () => {
+        test.skip(!composeConfigAvailable(), 'docker compose CLI unavailable');
+
+        const
+            repoRoot = process.cwd(),
+            envPath  = path.join(repoRoot, 'ai/deploy/.env'),
+            existed  = fs.existsSync(envPath),
+            backup   = existed ? fs.readFileSync(envPath, 'utf8') : null,
+            // A value no default in the tree carries, so a pass cannot come from the baseline.
+            probeMb  = 4321;
+
+        try {
+            const baseline = resolvedKbCeiling(repoRoot);
+
+            expect(baseline, 'the control resolves the compose default before any prescription').not.toBe(probeMb);
+
+            const {content} = renderPrescribedEnvironment([{key: 'NEO_KB_SERVER_HEAP_MB', value: probeMb}]);
+
+            fs.writeFileSync(envPath, content);
+
+            expect(resolvedKbCeiling(repoRoot), 'the prescription reaches the container command')
+                .toBe(probeMb)
+        } finally {
+            if (existed) {
+                fs.writeFileSync(envPath, backup)
+            } else {
+                fs.existsSync(envPath) && fs.unlinkSync(envPath)
+            }
+        }
+    })
+});


### PR DESCRIPTION
Resolves neomjs/neo#16820

The actuator cannot apply a V8 heap ceiling itself: `--max-old-space-size` lives in the container command, Compose interpolates it at **create** time, and `reconfigure` is overlay-plus-restart — a restart re-runs the baked `Config.Cmd`, so the value never reaches the process. That is a no-op that reports success. So the actuator PRESCRIBES and the pipeline DELIVERS (#16695 AC-1, @neo-opus-grace). This lands the delivery half's renderer.

Evidence: L2 (unit spec, 9/9, including a compose-resolved effect witness that is mutation-convicted) → L2 required. Residual: none for this ticket; the live plane reading stays on neomjs/neo-agent-brain#55.

## Deltas from ticket

- **An env FILE, not an exported variable, and not `--env-file`.** I proposed `--env-file` first, posted the falsifier I owed with it, then ran it — four documented redeploy paths reach `compose up` outside `deploy-pipeline.sh`, one of them `docker compose up -d --force-recreate kb-server mc-server orchestrator`, aimed at exactly these services. **A raw `compose up` never passes `--env-file`**, so the flag would have hardened the one path already fine and blinded every operator path. The default project-directory lookup I had called the weakness is the half that reaches them all.
- **Refusal returns a reason rather than throwing.** A throw aborts the rendering pass and leaves the previous file in place, so the ledger would show a newer ceiling than the container carries — the exact performed-vs-holds gap this path exists to close.
- **Last-write-wins per key is a decision, not a side effect.** The ledger is append-only, so a key legitimately recurs as a ceiling is raised. Rendering every occurrence would leave Compose to pick, and Compose picks the last — collapsing in the same direction makes the file's meaning independent of history length.

## Test Evidence

`npm run test-unit -- ai/services/memory-core/helpers/deploymentPrescriptionEnvironment.spec --workers=1` → **9 passed**.

**The effect witness follows the value to what the container is CREATED with**, which is neomjs/neo-agent-brain#55 AC-4's bar — a fixture asserting only that a prescription was recorded would have passed against `reconfigure` throughout:

```
render -> write ai/deploy/.env -> docker compose -f ai/deploy/docker-compose.yml config
  baseline (control, no file): --max-old-space-size=768   (asserted NOT to equal the probe)
  with prescription 4321     : --max-old-space-size=4321
```

**Mutation-convicted.** Rendering the same pairs as comments reds it with `Expected: 4321, Received: 768` — the container silently falling back to the compose default while a ledger would still show the raise as performed.

`docker compose config` resolves interpolation with **no reachable daemon**, so this runs in CI; the witness skips cleanly where the CLI is absent, and the render-level ACs stand without it. The spec restores or removes `ai/deploy/.env` in a `finally`.

## Post-Merge Validation

- [ ] None for this ticket. The ledger, the descriptors, and the live plane reading are neomjs/neo-agent-brain#55.

## Deltas

None beyond the three above.

Authored by Vega (@neo-opus-vega, Claude Opus 5, Claude Code). Origin Session ID: 4131135d-1b20-487f-9d23-d7213914246b.

---

## Second commit: the two `#16695` heap-ceiling descriptors (`f185a2f8f7`)

`Refs neomjs/neo-agent-brain#55` — deliberately **not** `Resolves`, see the AC ledger below.

Lands the descriptors withdrawn from PR `#16663` under @neo-gpt-emmy's Drop+Supersede, against the `record` class `#16695` AC-1 settled. Values are **MiB**, the unit `--max-old-space-size` itself takes, so no layer converts and none can convert wrongly. The floor sits above the shipped `768`: a knob that can prescribe the current value can record a no-op raise.

Two invariants, both **refusal-by-default**:

- **`raise-not-lower`** binds against the DECLARED ceiling resolved from the runtime, never config — a plane created before a compose default moved still runs the older number. An unresolved or diverging declaration **refuses**: the observation channel reports `unavailable` with a reason when it cannot tell, and reading "could not tell" as "nothing declared" raises against a guess.
- **`non-heap-headroom`** keeps the ceiling strictly below the live limit minus 256 MiB. The two numbers are different **scopes**, not different sizes: V8 aborts at old-space exhaustion, the cgroup kills at RSS, and RSS includes young generation, native, off-heap Buffers and the binary. Without the bound a raise converts a recoverable, attributable heap abort into an OOM kill.

`resource: 'v8-heap'` is load-bearing: the envelope guard matches role **plus** resource, and `role: 'ceiling'` alone would make a V8 old-space cap a legal target for a cgroup move.

Both are built from one factory closing over the service key — hand-writing the pair is how two copies of one contract drift apart, which is the failure this knob exists to prevent one layer up.

**20 new arms, refusal branch mutation-convicted:** returning `true` on an unresolved declaration reds it with `declared=undefined must refuse`. Importer specs green (`recoveryKnobRegistry`, `DeploymentRuntimeAccessService`, the renderer) — 60 passed.

## `#16695` AC ledger — what this PR does and does not close

| AC | state |
|---|---|
| AC-1 delivering shape decided, §2.4 accounting | **met** — @neo-opus-grace, `record`/prescribe-to-pipeline, `aligned-with`, amends nothing |
| AC-2 contract: recreation scope, what it must not disturb | **met** — the pipeline's existing pre-transition-bundle gate and `--wait` failure; nothing invented here |
| AC-3 descriptors + `serviceHeapCeilingKnob.spec.mjs`, predicates unchanged | **met** — this commit |
| AC-4 the prescription is proven to reach an **effect** | **partial** — the rendered file provably changes what the container is created with (mutation-convicted above). The chain is proven from the file onward; **nothing yet writes that file from a prescription record** |
| AC-5 negative control: at/above ceiling not prescribed; unresolved refuses | **met** — both invariants, every refusal arm |
| AC-7 the ceiling survives a redeploy that does not carry it in the environment | **met by construction** — a gitignored env file in Compose's project directory, read with no flag from any cwd |

**Remaining for `#16695`, and why this PR does not claim it:** the prescription **ledger** (create / append / read `record`-class prescriptions) and the pipeline step that writes the rendered file. Until those exist, AC-4's chain has a gap at its first link — and closing `#16695` here would be the premature-close defect I blocked `PR neomjs/neo#16809` for an hour ago.
