### PR TITLE
fix(knowledge-base): consult the lease yield predicate per provider chunk (#16822)

### DIFF
--- a/ai/services/knowledge-base/VectorService.mjs
+++ b/ai/services/knowledge-base/VectorService.mjs
@@ -1,5 +1,7 @@
 import aiConfig             from '../../mcp/server/knowledge-base/config.mjs';
-import TextEmbeddingService from '../memory-core/TextEmbeddingService.mjs';
+import TextEmbeddingService, {
+    isEmbeddingBatchYieldError
+}                             from '../memory-core/TextEmbeddingService.mjs';
 import mcConfig             from '../../mcp/server/memory-core/config.mjs';
 import Base                 from '../../../src/core/Base.mjs';
 import {
@@ -615,9 +617,15 @@ class VectorService extends Base {
      * @param {Object}   options.collection      Chroma collection target.
      * @param {Object[]} options.chunksToProcess Tenant-stamped chunks to embed.
      * @param {Function} [options.shouldYield]   Cooperative heavy-maintenance-lease yield predicate,
-     *     consulted BETWEEN batches. Returns truthy once the lease holder has exceeded the fairness bound
+     *     consulted BETWEEN batches here AND between provider chunks inside `TextEmbeddingService.embedTexts`.
+     *     Returns truthy once the lease holder has exceeded the fairness bound
      *     (`HeavyMaintenanceLeaseService.shouldYield`); the loop then stops so a starved heavy task can
      *     interleave. Defaults to never-yield, so callers that do not hold the lease are unaffected.
+     *
+     *     The inner consultation is what makes the bound reachable: this loop alone checks at most once per
+     *     `maxRetries * ceil(batchSize / batchEmbeddingChunkSize) * (1 + unloadRetryCount) *
+     *     batchEmbeddingTimeoutMs`, which is 16h40m at stock leaves against a 30-minute `maxActiveHoldMs`.
+     *     Per-chunk consultation caps the interval at one chunk's worst case.
      * @returns {Promise<{embedded: Number, skipped: Number, yielded: Boolean}>}
      */
     async embedChunks({collection, chunksToProcess, shouldYield = () => false}) {
@@ -689,7 +697,8 @@ class VectorService extends Base {
                         operationLabel          : 'knowledge base tenant ingestion embedding',
                         operationStage          : 'kb-tenant-ingestion-embedding',
                         providerActivityRecorder: KBRecorderService,
-                        service                 : 'knowledge-base'
+                        service                 : 'knowledge-base',
+                        shouldYield
                     });
 
                     const metadatas = batchToEmbed.map(chunk => {
@@ -710,6 +719,15 @@ class VectorService extends Base {
                     logger.log(`Processed and embedded batch ${i / batchSize + 1} of ${Math.ceil(chunksToProcess.length / batchSize)} (${batchToEmbed.length} embedded, ${batch.length - batchToEmbed.length} skipped).`);
                     success = true;
                 } catch (err) {
+                    // A cooperative yield is a DECISION, not a failure. Falling through to the retry arm would
+                    // spend every `maxRetries` attempt re-issuing work the lease holder deliberately stopped —
+                    // turning the fairness fix into a maxRetries-fold amplifier of the hold it exists to bound.
+                    if (isEmbeddingBatchYieldError(err)) {
+                        yielded = true;
+                        logger.log(`Yielding the heavy-maintenance lease inside batch ${i / batchSize + 1} after ${err.completedChunkCount}/${err.totalChunkCount} provider chunk(s) (${embeddedCount} embedded); this batch is not retried and resumes on the next sweep.`);
+                        break;
+                    }
+
                     retries++;
                     console.error(`An error occurred during embedding batch ${i / batchSize + 1}. Retrying (${retries}/${maxRetries})...`, err.message);
                     if (retries < maxRetries) {
@@ -719,6 +737,11 @@ class VectorService extends Base {
                     }
                 }
             }
+
+            // The retry loop exits on success, on exhaustion (which throws), or on a yield — only the last
+            // one leaves the outer sweep to stop, so it is named explicitly rather than relying on the next
+            // between-batch checkpoint observing a predicate that may already have flipped back.
+            if (yielded) break;
         }
 
         return {embedded: embeddedCount, skipped: skippedCount, yielded};

--- a/ai/services/memory-core/TextEmbeddingService.mjs
+++ b/ai/services/memory-core/TextEmbeddingService.mjs
@@ -47,6 +47,42 @@ function markEmbeddingModelNotResidentError(error) {
 }
 
 /**
+ * @summary Source-owned code for a batch embedding abandoned at a cooperative lease yield-point.
+ *
+ * A yield MUST be distinguishable from a failure at the consumer boundary: the caller has to release the
+ * heavy-maintenance lease and resume on the next sweep, never spend its retry budget re-attempting work it
+ * deliberately stopped. Returning a partial embedding array cannot express that — it would silently
+ * misalign with the caller's `ids` at upsert time.
+ * @type {String}
+ */
+export const EMBEDDING_BATCH_YIELDED_CODE = 'EMBEDDING_BATCH_YIELDED';
+
+/**
+ * @summary Classifies a cooperative batch-yield abandonment at the consumer boundary.
+ * @param {Error} error The error raised by a batch embedding call.
+ * @returns {Boolean}
+ */
+export function isEmbeddingBatchYieldError(error) {
+    return error?.code === EMBEDDING_BATCH_YIELDED_CODE
+}
+
+/**
+ * @summary Builds the typed abandonment error for a batch stopped at a lease yield-point.
+ * @param {Number} completedChunkCount Provider chunks that completed before the yield.
+ * @param {Number} totalChunkCount Provider chunks the batch would otherwise have issued.
+ * @returns {Error}
+ */
+function createEmbeddingBatchYieldError(completedChunkCount, totalChunkCount) {
+    const error = new Error(`openAiCompatible batch embedding yielded the heavy-maintenance lease after ${completedChunkCount}/${totalChunkCount} provider chunk(s)`);
+
+    error.code                = EMBEDDING_BATCH_YIELDED_CODE;
+    error.completedChunkCount = completedChunkCount;
+    error.totalChunkCount     = totalChunkCount;
+
+    return error
+}
+
+/**
  * @summary Normalizes the additive embedding-call options without widening provider authority.
  * @param {Object} options Caller options.
  * @param {String} defaultOperationLabel Provider-scoped fallback label.
@@ -62,6 +98,7 @@ function normalizeEmbeddingOptions(options, defaultOperationLabel) {
         'operationStage',
         'providerActivityRecorder',
         'service',
+        'shouldYield',
         'signal'
     ];
     const unknownKeys = Object.keys(options).filter(key => !allowedKeys.includes(key));
@@ -88,6 +125,9 @@ function normalizeEmbeddingOptions(options, defaultOperationLabel) {
     if (options.providerActivityRecorder !== undefined && options.providerActivityRecorder !== null && typeof options.providerActivityRecorder !== 'object') {
         throw new TypeError('TextEmbeddingService: options.providerActivityRecorder must be an object or null');
     }
+    if (options.shouldYield !== undefined && typeof options.shouldYield !== 'function') {
+        throw new TypeError('TextEmbeddingService: options.shouldYield must be a function');
+    }
 
     const requestedLabel = options.operationLabel?.trim() || defaultOperationLabel;
 
@@ -97,8 +137,9 @@ function normalizeEmbeddingOptions(options, defaultOperationLabel) {
         providerActivityRecorder: options.providerActivityRecorder === undefined
             ? MemoryCoreRecorderService
             : options.providerActivityRecorder,
-        service: options.service || 'unknown',
-        signal : options.signal
+        service    : options.service || 'unknown',
+        shouldYield: options.shouldYield,
+        signal     : options.signal
     };
 }
 
@@ -1085,6 +1126,7 @@ class TextEmbeddingService extends Base {
      *
      * @param {String[]} texts The texts to embed.
      * @param {Object} options Abort and observability context.
+     * @param {Function} [options.shouldYield] Cooperative heavy-maintenance-lease yield predicate.
      * @returns {Promise<number[][]>}
      * @private
      */
@@ -1094,6 +1136,7 @@ class TextEmbeddingService extends Base {
             operationLabel,
             providerActivity,
             providerActivityRecorder,
+            shouldYield,
             signal
         } = options;
         const {
@@ -1104,11 +1147,29 @@ class TextEmbeddingService extends Base {
         } = aiConfig.openAiCompatible;
         const chunkSize        = Math.max(1, Math.floor(batchEmbeddingChunkSize || texts.length)),
               requestTimeoutMs = assertPositiveTimeoutMs(batchEmbeddingTimeoutMs, 'openAiCompatible.batchEmbeddingTimeoutMs'),
+              totalChunkCount  = Math.ceil(texts.length / chunkSize),
               data             = [];
+
+        let completedChunkCount = 0;
 
         for (let offset = 0; offset < texts.length; offset += chunkSize) {
             operation.phase = 'batch-chunk';
             throwIfEmbeddingAborted(signal, operationLabel);
+
+            // Cooperative heavy-maintenance-lease yield-point: BETWEEN provider chunks, never before the
+            // first — the same forward-progress guarantee `VectorService.embedChunks` makes between its own
+            // batches, so at least one chunk always lands per acquisition and the pair cannot livelock.
+            //
+            // The consultation has to happen HERE and not only one frame up, because the interval between two
+            // consultations up there is `maxRetries * ceil(batchSize / chunkSize) * (1 + unloadRetryCount) *
+            // batchEmbeddingTimeoutMs` — 16h40m at stock leaves, against a 30-minute `maxActiveHoldMs`. A
+            // cooperative bound whose checkpoint interval exceeds the bound is not a bound: the holder's
+            // first chance to honour it can arrive after it has already elapsed. Checking per chunk makes
+            // the worst case `(1 + unloadRetryCount) * batchEmbeddingTimeoutMs`.
+            if (completedChunkCount > 0 && shouldYield?.()) {
+                operation.phase = 'lease-yield';
+                throw createEmbeddingBatchYieldError(completedChunkCount, totalChunkCount)
+            }
 
             const chunk  = texts.slice(offset, offset + chunkSize),
                   result = await this.#enqueueOpenAiCompatiblePost(chunk, {
@@ -1125,6 +1186,8 @@ class TextEmbeddingService extends Base {
                 ...item,
                 index: offset + item.index
             })));
+
+            completedChunkCount++;
 
             if (offset + chunkSize < texts.length) {
                 operation.phase = 'batch-yield';
@@ -1259,6 +1322,10 @@ class TextEmbeddingService extends Base {
      * @param {String} [options.operationStage='unknown'] Stable low-cardinality stage.
      * @param {String} [options.service='unknown'] Stable service owner.
      * @param {Object|null} [options.providerActivityRecorder] Best-effort telemetry sink.
+     * @param {Function} [options.shouldYield] Cooperative heavy-maintenance-lease yield predicate,
+     *     consulted BETWEEN provider chunks (never before the first). When it returns truthy the batch is
+     *     abandoned with an {@link EMBEDDING_BATCH_YIELDED_CODE} error rather than a partial array, so the
+     *     lease holder can release and resume instead of retrying work it deliberately stopped.
      * @returns {Promise<number[][]>}
      */
     async embedTexts(texts, explicitProvider, options = {}) {
@@ -1272,6 +1339,7 @@ class TextEmbeddingService extends Base {
                   operationStage,
                   providerActivityRecorder,
                   service,
+                  shouldYield,
                   signal
               } = normalizeEmbeddingOptions(options, defaultOperationLabel),
               providerActivity          = {
@@ -1294,6 +1362,7 @@ class TextEmbeddingService extends Base {
                     operationLabel,
                     providerActivity,
                     providerActivityRecorder,
+                    shouldYield,
                     signal
                 });
             } else if (explicitProvider === 'ollama') {

--- a/test/playwright/unit/ai/services/knowledge-base/VectorService.leaseYield.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/VectorService.leaseYield.spec.mjs
@@ -60,13 +60,18 @@ function makeChunks(count) {
 }
 
 test.describe('VectorService.embedChunks — cooperative lease yield-point', () => {
-    let SDK, KB_VectorService, KB_Config, TextEmbeddingService;
+    let SDK, KB_VectorService, KB_Config, Memory_Config, TextEmbeddingService, EMBEDDING_BATCH_YIELDED_CODE;
     let originalEmbedTexts, originalBatchConfig;
 
     test.beforeAll(async () => {
         SDK                  = await import('../../../../../../ai/services.mjs');
         KB_Config            = SDK.KB_Config;
+        Memory_Config        = SDK.Memory_Config;
         TextEmbeddingService = SDK.Memory_TextEmbeddingService;
+
+        ({EMBEDDING_BATCH_YIELDED_CODE} = await import(
+            '../../../../../../ai/services/memory-core/TextEmbeddingService.mjs'
+        ));
 
         const VectorServiceModule = await import('../../../../../../ai/services/knowledge-base/VectorService.mjs');
         KB_VectorService          = VectorServiceModule.default;
@@ -89,6 +94,9 @@ test.describe('VectorService.embedChunks — cooperative lease yield-point', () 
 
     test.beforeEach(() => {
         Object.assign(KB_Config.data, {batchSize: 50, batchDelay: 0, maxRetries: 1});
+        // Re-applied per test: the inner-yield cases below swap in their own embedder, and a leaked stub
+        // would silently change what a later test is measuring.
+        TextEmbeddingService.embedTexts = async texts => texts.map(() => new Array(384).fill(0));
     });
 
     test('yields BETWEEN batches — stops the loop, first batch still lands (forward progress)', async () => {
@@ -135,5 +143,143 @@ test.describe('VectorService.embedChunks — cooperative lease yield-point', () 
         expect(result.yielded).toBe(false);
         expect(result.embedded).toBe(150);
         expect(spy.calls.upsert).toBe(3);
+    });
+
+    test('an INNER yield is reported as a yield, and is not retried (#16822)', async () => {
+        const spy    = createSpyCollection();
+        const chunks = makeChunks(150); // 3 batches at batchSize 50
+
+        // 3, not the deployed 5: the retry arm backs off `2 ** retries` seconds, so a maxRetries-5 mutation
+        // run exhausts the 30s test timeout before it exhausts the retries — and a timeout-red would leave
+        // this test looking falsifiable while proving only that something hung.
+        Object.assign(KB_Config.data, {maxRetries: 3});
+
+        let embedCalls = 0;
+
+        TextEmbeddingService.embedTexts = async texts => {
+            embedCalls++;
+            // Batch 1 lands; batch 2 abandons mid-way at a provider-chunk boundary.
+            if (embedCalls === 1) return texts.map(() => new Array(384).fill(0));
+
+            const error = new Error('openAiCompatible batch embedding yielded the heavy-maintenance lease after 3/10 provider chunk(s)');
+            error.code                = EMBEDDING_BATCH_YIELDED_CODE;
+            error.completedChunkCount = 3;
+            error.totalChunkCount     = 10;
+            throw error
+        };
+
+        const result = await KB_VectorService.embedChunks({
+            collection     : spy,
+            chunksToProcess: chunks,
+            shouldYield    : () => false // the OUTER checkpoint never fires: the yield must arrive from within
+        }).then(value => value, error => ({error}));
+
+        // Captured rather than awaited bare, so the failure this test exists to catch reads as its own
+        // sentence. Against the untyped `catch (err)` the yield falls into the retry arm, the batch is
+        // re-attempted until the budget is gone, and `embedChunks` then throws — so the caller sees a
+        // hard ingestion failure where the truth was an orderly, resumable release.
+        expect(result.error, `the yield must not surface as an ingestion failure: ${result.error?.message}`).toBeUndefined();
+
+        // The load-bearing number. Each extra attempt re-issues provider work the holder deliberately
+        // stopped, so the fairness fix becomes a maxRetries-fold amplifier of the hold it exists to bound —
+        // silently, because every attempt looks like an ordinary transient embedding failure.
+        expect(embedCalls, 'a yield is a decision, not a transient failure — exactly one attempt per batch').toBe(2);
+        expect(result.yielded, 'the caller must learn to release the lease').toBe(true);
+
+        // Progress made before the yield is durable and is what `selectResumableChunks` skips next sweep.
+        expect(result.embedded).toBe(50);
+        expect(spy.calls.upsert).toBe(1);
+        expect(spy.upsertedIds).toHaveLength(50);
+    });
+
+    test('an inner yield stops the OUTER sweep even if the predicate flips back to false (#16822)', async () => {
+        const spy    = createSpyCollection();
+        const chunks = makeChunks(200); // 4 batches
+
+        let embedCalls = 0;
+
+        TextEmbeddingService.embedTexts = async texts => {
+            embedCalls++;
+            if (embedCalls !== 2) return texts.map(() => new Array(384).fill(0));
+
+            const error = new Error('openAiCompatible batch embedding yielded the heavy-maintenance lease after 1/10 provider chunk(s)');
+            error.code                = EMBEDDING_BATCH_YIELDED_CODE;
+            error.completedChunkCount = 1;
+            error.totalChunkCount     = 10;
+            throw error
+        };
+
+        const result = await KB_VectorService.embedChunks({
+            collection     : spy,
+            chunksToProcess: chunks,
+            shouldYield    : () => false
+        });
+
+        // Leaving the outer `for` on the strength of the next between-batch checkpoint would work only while
+        // the predicate stays true. It is a lease-expiry predicate consulted across minutes of provider work,
+        // so "still true one batch later" is an assumption, not a property — batches 3 and 4 would resume
+        // under a lease the holder has already decided to release.
+        expect(embedCalls, 'batches 3 and 4 must not run').toBe(2);
+        expect(result.yielded).toBe(true);
+        expect(result.embedded).toBe(50);
+        expect(spy.calls.upsert).toBe(1);
+    });
+
+    test('an ordinary embedding failure is still retried — the yield carve-out did not widen (#16822)', async () => {
+        const spy    = createSpyCollection();
+        const chunks = makeChunks(50); // 1 batch
+
+        Object.assign(KB_Config.data, {maxRetries: 3});
+
+        let embedCalls = 0;
+
+        TextEmbeddingService.embedTexts = async texts => {
+            embedCalls++;
+            if (embedCalls < 3) throw new Error('openAiCompatible embedding error HTTP 503: busy');
+            return texts.map(() => new Array(384).fill(0))
+        };
+
+        const result = await KB_VectorService.embedChunks({
+            collection     : spy,
+            chunksToProcess: chunks,
+            shouldYield    : () => false
+        });
+
+        // A carve-out that quiets a retry path opens a silent channel if it classifies too broadly. Only the
+        // typed yield code may skip the retry arm; everything else keeps the behaviour it had.
+        expect(embedCalls).toBe(3);
+        expect(result.yielded).toBe(false);
+        expect(result.embedded).toBe(50);
+    });
+
+    test('the per-chunk checkpoint interval fits inside the fairness bound it must respect (#16822)', async () => {
+        const {unloadRetryCount, batchEmbeddingTimeoutMs} = Memory_Config.openAiCompatible,
+              {maxActiveHoldMs}                           = Memory_Config.orchestrator.heavyMaintenance;
+
+        // Worst case between two consultations AFTER the repair: one provider chunk, including its unload
+        // retries, each of which carries the full request timeout.
+        const worstCaseCheckpointIntervalMs = (1 + unloadRetryCount) * batchEmbeddingTimeoutMs;
+
+        expect(
+            worstCaseCheckpointIntervalMs,
+            `a cooperative bound is only a bound if the holder can reach a checkpoint inside it: ` +
+            `(1 + unloadRetryCount=${unloadRetryCount}) * batchEmbeddingTimeoutMs=${batchEmbeddingTimeoutMs} ` +
+            `= ${worstCaseCheckpointIntervalMs}ms vs maxActiveHoldMs=${maxActiveHoldMs}ms`
+        ).toBeLessThan(maxActiveHoldMs);
+
+        // The pre-repair interval, kept as an executable record of what was actually wrong: the same three
+        // leaves multiplied by the caller's batch fan-out and its retry budget. This assertion is expected to
+        // hold — it documents that moving the checkpoint, not retuning any leaf, is what closed the gap.
+        //
+        // Read from `originalBatchConfig`, captured before `beforeEach` narrows the harness: reading
+        // `KB_Config` here would measure this spec's own 50/1 fixture and call it the deployment's bound.
+        const preRepairIntervalMs = originalBatchConfig.maxRetries
+            * Math.ceil(originalBatchConfig.batchSize / Memory_Config.openAiCompatible.batchEmbeddingChunkSize)
+            * worstCaseCheckpointIntervalMs;
+
+        expect(
+            preRepairIntervalMs,
+            'the interval this repair removed was multiples of the bound, not a near miss'
+        ).toBeGreaterThan(maxActiveHoldMs);
     });
 });

--- a/test/playwright/unit/ai/services/memory-core/TextEmbeddingService.retry.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/TextEmbeddingService.retry.spec.mjs
@@ -697,6 +697,86 @@ test.describe.serial('TextEmbeddingService #11393/#11402/#12487/#12509 — openA
         ]);
     });
 
+    test('the lease yield predicate is consulted BETWEEN provider chunks, not only between the caller\'s batches (#16822)', async () => {
+        serverBehavior = 'chunked-batch-succeed';
+        aiConfig.openAiCompatible.batchEmbeddingChunkSize = 2;
+
+        const consultations = [];
+        const error         = await TextEmbeddingService
+            .embedTexts(['a', 'b', 'c', 'd', 'e'], 'openAiCompatible', {
+                shouldYield: () => {
+                    consultations.push(requestCount);
+                    return true
+                }
+            })
+            .then(() => null, observed => observed);
+
+        // Without the inner consultation this call issues all three chunks and resolves; the interval between
+        // two consultations would then be the caller's whole batch, which at stock leaves is 16h40m against a
+        // 30-minute fairness bound.
+        expect(error, 'a yielded batch must reject, never resolve with a partial array').toBeInstanceOf(Error);
+        expect(error.code).toBe('EMBEDDING_BATCH_YIELDED');
+        expect(error.completedChunkCount).toBe(1);
+        expect(error.totalChunkCount).toBe(3);
+        expect(error.message).toContain('1/3 provider chunk(s)');
+
+        // One consultation, and it happened AFTER chunk 1 landed — so the second and third were never issued.
+        expect(consultations, 'consulted once, with exactly one chunk already posted').toEqual([1]);
+        expect(requestCount, 'chunks 2 and 3 must not reach the provider').toBe(1);
+        expect(allRequests.map(item => item.body.input)).toEqual([['a', 'b']]);
+    });
+
+    test('the lease yield predicate is never consulted before the first provider chunk — forward progress (#16822)', async () => {
+        serverBehavior = 'chunked-batch-succeed';
+        aiConfig.openAiCompatible.batchEmbeddingChunkSize = 5;
+
+        let   consulted = 0;
+        const result    = await TextEmbeddingService.embedTexts(['a', 'b'], 'openAiCompatible', {
+            shouldYield: () => {
+                consulted++;
+                return true
+            }
+        });
+
+        // A single-chunk batch under an always-true predicate must still land. An acquisition that yields
+        // before doing any work is a livelock, not fairness — the same guarantee `embedChunks` makes at its
+        // own boundary, and the reason the check is guarded on `completedChunkCount > 0`.
+        expect(consulted, 'no consultation can precede the first chunk').toBe(0);
+        expect(requestCount).toBe(1);
+        expect(result).toEqual([[1, 0], [1, 1]]);
+    });
+
+    test('a predicate that never fires leaves batch chunking completely unchanged — negative control (#16822)', async () => {
+        serverBehavior = 'chunked-batch-succeed';
+        aiConfig.openAiCompatible.batchEmbeddingChunkSize = 2;
+
+        let   consulted = 0;
+        const result    = await TextEmbeddingService.embedTexts(['a', 'b', 'c', 'd', 'e'], 'openAiCompatible', {
+            shouldYield: () => {
+                consulted++;
+                return false
+            }
+        });
+
+        // Byte-identical to the sibling test above that passes no predicate at all. A yield-point that alters
+        // legitimate work is worse than none, because it will be switched off within a week.
+        expect(consulted, 'consulted at each of the two inter-chunk boundaries').toBe(2);
+        expect(requestCount).toBe(3);
+        expect(allRequests.map(item => item.body.input)).toEqual([['a', 'b'], ['c', 'd'], ['e']]);
+        expect(result).toEqual([[1, 0], [1, 1], [2, 0], [2, 1], [3, 0]]);
+    });
+
+    test('a non-function shouldYield fails loud rather than silently never yielding (#16822)', async () => {
+        serverBehavior = 'chunked-batch-succeed';
+
+        // The option surface is an explicit allow-list with typed validation; a predicate that is quietly
+        // ignored reads on every surface as a lane that honours the fairness bound and does not.
+        await expect(TextEmbeddingService.embedTexts(['a'], 'openAiCompatible', {shouldYield: true}))
+            .rejects.toThrow('TextEmbeddingService: options.shouldYield must be a function');
+
+        expect(requestCount).toBe(0);
+    });
+
     test('interactive single embeddings queue ahead of subsequent batch chunks and preserve completion', async () => {
         serverBehavior = 'qos-priority';
         aiConfig.openAiCompatible.batchEmbeddingChunkSize = 1;


### PR DESCRIPTION
Resolves neomjs/neo#16822

Refs neomjs/neo#16780 · Refs neomjs/neo-agent-brain#64

> **Premise rewritten 2026-08-09** after @neo-gpt-emmy's Drop+Supersede on `PR neomjs/neo#16818` (`PRR_kwDODSospM8AAAABI5YiTg`). That PR framed neomjs/neo-agent-brain#64's starvation as a lease-level block; source falsifies it, `#16817` is closed as superseded, and this PR now grounds directly in the scheduler. The measured defect below is unchanged — the correction improves *why* it matters. The superseded framing is named rather than quietly rewritten.

## The gate that was actually holding, and what holds it

`#16566` recorded a `kbSync` re-embed starving `tenant-repo-sync` and REM consolidation for 13 hours. The lease is **not** what refused them:

- **`picker.mjs:76-92`** — `filterExclusiveHeavyConflict` drops every conflicting heavy candidate while `runningHeavyTasks` is non-empty.
- **`pipeline.mjs:208-212`** — that set is derived from `getRunningTaskNames(context.state)`, i.e. **persisted task state**, evaluated *before* any lease acquisition.
- **`TaskStateService.mjs:269-275` / `:331`** — `running` clears only on `markCompleted` / `markFailed`, i.e. **when the task returns**.

So the starvation lasts exactly as long as `kbSync` stays marked running, and `kbSync` returns when `embedChunks` returns. **The duration of the gate is the checkpoint interval.**

`VectorService.embedChunks:644` does consult `shouldYield()`, threaded live from `syncKnowledgeBase.mjs:121`, and a yield preserves progress through the resume store. A grep for `shouldYield` shows a correct-looking checkpoint, which is why this sat unexamined behind a ticket read three times.

**The defect is the INTERVAL, which nothing multiplies.** Between two consultations:

```
(1 + unloadRetryCount=3) x batchEmbeddingTimeoutMs=300s  =   20 min   per provider chunk
x ceil(batchSize=50 / batchEmbeddingChunkSize=5) = 10    =  200 min   per embedTexts call
x maxRetries=5 — the catch is bare, so timeouts retry too = 1000 min  = 16 h 40 min
```

against `maxActiveHoldMs = 30 min`. **33×.** `#16566`'s observed 13-hour starvation sits inside that analytic bound.

A cooperative bound whose checkpoint interval exceeds the bound is not a bound: `maxActiveHoldMs` can be tuned to any value under 16 h 40 m and change nothing observable, because the holder's first chance to honour it may arrive after it has already elapsed.

`maxActiveHoldMs` remains the correct thing to measure against after the scheduler correction, and for the right reason rather than by luck: it is what `shouldYieldHeavyMaintenanceLease` compares against, so the inequality states "the holder can reach a **yield decision** inside the bound." What that decision unblocks is picker admission rather than lease acquisition — which changes the consequence, not whether the interval is load-bearing.

Evidence: L3 (deterministic unit execution against the real seam, red-proved per test) → L3 required; every criterion is a property of committed code and fully reachable in-sandbox. Residual: none for this ticket. **`#16780` stays open** for its reporting half (AC-3 re-embed ratio, AC-5 declared concurrency, AC-7 public-surface disproportion) — which is why this PR resolves `#16822` rather than its parent.

## Deltas from ticket

None substantive. One scope note the ticket already anticipated: no leaf is retuned. `maxActiveHoldMs`, `batchSize` and `maxRetries` all keep their values — the defect was that the interval is unbounded *relative to* the bound, not that any single number is wrong, so moving the checkpoint is the whole repair.

## What changed

- **`ai/services/memory-core/TextEmbeddingService.mjs`** — `#embedOpenAiCompatibleBatch` consults an optional `shouldYield` predicate at the provider-chunk boundary that already existed (`operation.phase = 'batch-yield'`), guarded on `completedChunkCount > 0`. `embedTexts` accepts `shouldYield` through the existing typed allow-list. New exports: `EMBEDDING_BATCH_YIELDED_CODE` and `isEmbeddingBatchYieldError`.
- **`ai/services/knowledge-base/VectorService.mjs`** — threads its own `shouldYield` into `embedTexts`, classifies the yield error **ahead of** the retry arm, and leaves the outer sweep explicitly.

Worst case after the repair is one provider chunk: **20 min under a 30 min bound**.

## Two details that carry the correctness

**A yield throws rather than returning a partial array.** `embedChunks` maps the returned embeddings positionally onto `batchToEmbed`'s `ids` at upsert. A short array would not throw there — it would upsert a *prefix* under the right ids and silently drop the rest, which is worse than the hold. The typed error carries `completedChunkCount` / `totalChunkCount` instead.

**`embedChunks` must classify that error before its retry arm.** The `catch (err)` at `:712` is bare, so without the check a yield spends every `maxRetries` attempt re-issuing work the holder deliberately stopped — making the fairness fix a **5× amplifier of the hold it exists to bound**, invisibly, because each attempt logs as an ordinary transient embedding failure. The carve-out is narrow by construction (one source-owned code) and has its own control proving ordinary failures still retry.

## A red-proof finding worth carrying

`VectorService.leaseYield.spec.mjs` is `test.describe.configure({mode: 'serial'})`. **A whole-file mutation run only ever proves its FIRST failing test** — Playwright skips the rest of a serial describe, and the summary reports 5 passed / 1 failed out of 9 without saying which three never ran. My first red-proof pass looked like "2 of 3 predicted failures", and the missing one was not a weak assertion; it was an unobserved one.

So each assertion was red-proved **individually** under `-g`:

| mutation | expected red | result |
|---|---|---|
| inner consultation disabled | per-chunk consultation | ✅ red — `completedChunkCount` 0, chunks 2–3 issued |
| inner consultation disabled | yield not retried | ✅ red — *"the yield must not surface as an ingestion failure: Failed to process batch 2 after 3 retries"* |
| inner consultation disabled | stops the outer sweep | ✅ red |
| inner consultation disabled | ordinary failure still retried | ✅ **green** (control must not depend on it) |
| inner consultation disabled | leaf-arithmetic invariant | ✅ **green** (control must not depend on it) |
| `completedChunkCount > 0` guard removed | forward progress | ✅ red |
| `completedChunkCount > 0` guard removed | negative control | ✅ red — caught the *extra* consultation, so it pins both directions |
| `completedChunkCount > 0` guard removed | non-function validation | ✅ **green** (control must not depend on it) |

One confound was fixed rather than tolerated: at the deployed `maxRetries: 5` the retry arm's `2 ** retries` backoff exceeds the 30 s test timeout, so the mutation run went red on the clock instead of on the assertion. The fixture uses `maxRetries: 3` and captures the outcome, so the failure reads as its own sentence.

## The executable invariant

`(1 + unloadRetryCount) * batchEmbeddingTimeoutMs < maxActiveHoldMs`, asserted against the **resolved** leaves rather than the template, so a deployment override reopening the gap fails too. It reads `originalBatchConfig` — captured in `beforeAll` before `beforeEach` narrows the harness — because reading `KB_Config` at assertion time would measure this spec's own 50/1 fixture and report it as the deployment's bound.

A second assertion records the pre-repair interval as multiples of the bound, not a near miss. Both are expected to hold today; their job is to fail when a future leaf move quietly reopens 16 h 40 m.

## Test Evidence

`npm run test-unit -- test/playwright/unit/ai/services/memory-core/ test/playwright/unit/ai/services/knowledge-base/` → **2118 passed**.

Per directly touched surface:
- `ai/services/memory-core/TextEmbeddingService.mjs`: `TextEmbeddingService.retry.spec.mjs` (+4 tests) and `TextEmbeddingService.spec.mjs`
- `ai/services/knowledge-base/VectorService.mjs`: `VectorService.leaseYield.spec.mjs` (+4 tests), plus the `WorkVolumeBranching` and `tenantStamping` siblings

ADR-0019 gates at the exact head: `check-aiconfig-antipatterns` → 714 files, **0 new violations**; `check-aiconfig-test-mutation` → 1164 files, **0 new violations**. No leaf is added or changed, so there is no parity-census delta.

## Post-Merge Validation

- [ ] On the canonical plane, a `kbSync` sweep that exceeds 30 min should now log `Yielding the heavy-maintenance lease inside batch N after X/Y provider chunk(s)` and release, with the next sweep resuming from the preserved shadow rather than restarting.
- [ ] **The consequence that actually matters:** confirm `runningHeavyTasks` drops `kbSync` at that point and the picker admits a conflicting heavy candidate — the starvation ends when the task *returns*, so a yield that logs but does not reach `markCompleted` would fix nothing observable.
- [ ] Confirm the yield does **not** fire on a healthy full sync that completes inside the bound — the negative controls assert this in fixture, and the plane is the only place the real timing is available.

## Known adjacent gap, deliberately not folded in

`ai/daemons/orchestrator/services/leaseMonitor.mjs` is a force-release monitor with **zero production callers** (surfaced by @neo-gpt-emmy; independently confirmed by census at exact head). It is orphaned substrate, and ADR 0022 anti-anchors hard preemption — so "wire it" is the wrong default and the real question is retire-or-redesign. Named here rather than converted into a reflexive ticket, and out of scope for this PR either way.

## Commits

- `a47ca2c0dd` — consult the predicate per provider chunk; classify the yield ahead of the retry arm

---

Cross-family reviewer: @neo-kimi-iris (Kimi→claude). `PR neomjs/neo#16818` — the witness predecessor — was **closed without merge** on @neo-gpt-emmy's Drop+Supersede, and `#16817` is closed as superseded into `#16822`. Nothing in this PR depends on either; the premise above is grounded in `picker.mjs` / `pipeline.mjs` / `TaskStateService.mjs` at exact head.

Authored by Ada (Claude Opus 5, Claude Code). Session 87f453f9-aa80-4487-9ed1-b5d91e052c43.
