### PR TITLE
feat(agentos): the spine banner types the remote-connection states — wait apart from investigate (#16744)

### DIFF
--- a/apps/agentos/view/fleet/spineBanner.mjs
+++ b/apps/agentos/view/fleet/spineBanner.mjs
@@ -41,6 +41,24 @@
  * the exact lie the retained reason exists to prevent. Pairing each state with its own reason makes
  * that unrepresentable rather than merely fixed: the line reports the cause of the surface that
  * actually decided the verdict.
+ *
+ * ## The connection axis — typed remote-connection states
+ *
+ * A cockpit is a CLIENT of its fleet truth, and the connection itself has states the generic
+ * ladder could not name: `connecting` (a read is in flight and nothing has answered yet — never
+ * "server offline"), `refused` (the plane NAMED a refusal — never a generic offline), `slow`
+ * (the plane answers, past the read bound — a wait, not an incident), `unreachable` (no route —
+ * investigate the plane, not the cockpit), and `failed-upstream` (the plane's own surface is
+ * failing — investigate plane-side). The vocabulary types them because the operator action
+ * differs per state, and "degraded" alone cannot carry "wait" apart from "investigate".
+ * `refused` ships contract-first: the render row and its discipline land here, the refusal
+ * producer arrives with the admission layer (S2) — same contract-before-producer shape as the
+ * throttle axis.
+ *
+ * **The banner never summarizes seat presence, and presence cards never summarize the
+ * connection.** They answer different questions — connection-level truth here, seat-level truth
+ * on the cards — so a "live" banner over all-unknown presence rows is not a contradiction, and
+ * neither is the reverse. The two surfaces render side by side and neither derives from the other.
  */
 
 /**
@@ -111,6 +129,65 @@ function coldFallbackFor(transport) {
 }
 
 /**
+ * @summary Picks the connection-axis line for the COLD verdict — the typed remote-connection
+ * states, consulted before any topology guess.
+ *
+ * `connecting` and `refused` outrank every generic fallback: a read in flight is not "server
+ * offline", and a NAMED refusal must never render as one either. `unreachable` types "no route"
+ * apart from the shell's local boot cases (its own ladder below) — the operator investigates the
+ * plane, not the cockpit. `null` (no connection fact — the caller has not classified one) falls
+ * through to the topology-owned fallback, unchanged.
+ * @param {Object|null} connection The owner-held connection fact `{state, reason}`.
+ * @param {Object|null} transport The shell transport-boot fact (see {@link coldFallbackFor}).
+ * @returns {String}
+ * @private
+ */
+function coldLineFor(connection, transport) {
+    if (connection?.state === 'connecting') {
+        return 'Connecting to the fleet plane — roster loading'
+    }
+
+    if (connection?.state === 'refused') {
+        return `The fleet plane refused this viewer${connection.reason ? ` · ${connection.reason}` : ''}`
+    }
+
+    if (connection?.state === 'unreachable') {
+        return `The fleet plane is unreachable${connection.reason ? ` · ${connection.reason}` : ' — no route answered'}`
+    }
+
+    return coldFallbackFor(transport)
+}
+
+/**
+ * @summary Picks the connection-axis line for the DEGRADED verdict — typing "wait" apart from
+ * "investigate". The deciding surface's retained reason ALWAYS rides the line (it is the
+ * cause); the connection state sets the PREFIX — a plane that answers past the read bound is
+ * slow (the operator waits), a plane whose own surface fails is a plane-side incident, and
+ * "no route" is named apart from both.
+ * @param {Object|null} connection The owner-held connection fact `{state, reason}`.
+ * @param {String|null} reason The deciding surface's retained reason.
+ * @returns {String}
+ * @private
+ */
+function degradedLineFor(connection, reason) {
+    const suffix = reason ? ` · ${reason}` : '';
+
+    if (connection?.state === 'slow') {
+        return `The fleet plane is slow — showing last-known data${suffix}${reason ? ' · safe to wait' : ' — the read beat its bound; safe to wait'}`
+    }
+
+    if (connection?.state === 'unreachable') {
+        return `The fleet plane is unreachable — showing last-known data${suffix || ' — no route answered'}`
+    }
+
+    if (connection?.state === 'failed-upstream') {
+        return `The fleet plane's surface is failing — showing last-known data${suffix}`
+    }
+
+    return `Fleet feed degraded — showing last-known data${suffix}`
+}
+
+/**
  * @summary Derives the spine banner from the owner-held surface truths.
  * @param {Object} options
  * @param {{state: String, reason: ?String}} options.grid The roster surface: `'sample'|'stale'|'live'`
@@ -122,10 +199,14 @@ function coldFallbackFor(transport) {
  * @param {Object|null} [options.transport] The shell transport-boot fact (see {@link coldFallbackFor}).
  *     Optional and `null`-safe — only the cold fallback consults it, so a retained surface reason
  *     still outranks any topology guess.
+ * @param {{state: String, reason: ?String}|null} [options.connection] The owner-held connection
+ *     fact: `'connecting'|'refused'|'unreachable'|'slow'|'failed-upstream'` plus its cause.
+ *     Optional and `null`-safe — types the remote-connection states the generic ladder cannot
+ *     name; never summarizes seat presence (the cards' axis, not this one's).
  * @returns {{hidden: Boolean, kind: String, text: String}} `kind` is `'live'|'cold'|'degraded'`
  *     — the class hook; `hidden` is `true` only for the fully live spine.
  */
-export function deriveSpineBanner({daemon, grid, stream, transport = null}) {
+export function deriveSpineBanner({connection = null, daemon, grid, stream, transport = null}) {
     const surfaces = [grid, stream],
           states   = surfaces.map(surface => surface?.state);
 
@@ -139,11 +220,12 @@ export function deriveSpineBanner({daemon, grid, stream, transport = null}) {
             // one, guess only when it does not. A reachable server whose source is unconfigured
             // answers `not-wired` — the seed stays, so the data really is sample, but "start the
             // server" would be advice to restart a process that just replied. The fallback for
-            // SILENCE is topology-owned: the shell's transport fact picks the honest line, and
-            // only the plain-browser flow keeps the classic "start the server" advice.
+            // SILENCE is connection-typed first (connecting/refused/unreachable), then
+            // topology-owned: the shell's transport fact picks the honest line, and only the
+            // plain-browser flow keeps the classic "start the server" advice.
             text: reason
                 ? `Fleet data unavailable — showing the static roster · ${reason}`
-                : coldFallbackFor(transport)
+                : coldLineFor(connection, transport)
         }
     }
 
@@ -178,9 +260,7 @@ export function deriveSpineBanner({daemon, grid, stream, transport = null}) {
         return {
             hidden: false,
             kind  : 'degraded',
-            text  : reason
-                ? `Fleet feed degraded — showing last-known data · ${reason}`
-                : 'Fleet feed degraded — showing last-known data'
+            text  : degradedLineFor(connection, reason)
         }
     }
 

--- a/test/playwright/unit/apps/agentos/view/fleet/spineBanner.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/spineBanner.spec.mjs
@@ -260,5 +260,114 @@ test.describe('fleet/spineBanner — the per-spine honesty derivation', () => {
             expect(deriveSpineBanner({grid: {state: 'live'}, stream: {state: 'live'}, daemon: {state: 'stopped'}, transport}).text).toContain('Agent OS stopped');
             expect(deriveSpineBanner({grid: {state: 'live'}, stream: {state: 'live'}, transport})).toEqual({hidden: true, kind: 'live', text: ''})
         })
+    });
+
+    // ⭐ The connection axis: a cockpit is a CLIENT of its fleet truth, and the connection itself
+    // has states the generic ladder cannot name. Typed because the operator action differs per
+    // state — "wait" (slow) is not "investigate" (unreachable), and a NAMED refusal must never
+    // render as a generic offline. Consulted BEFORE any topology guess; a retained producer reason
+    // still outranks every connection state. Wire-named per FLEET_WIRE_RESPONSE_STATES. `refused`
+    // ships contract-first — the render row lands here, the refusal producer arrives with the
+    // admission layer (S2).
+    test.describe('⭐ connection axis — typed remote-connection states, before any topology guess', () => {
+        const coldSpine  = {grid: {state: 'sample'}, stream: {state: 'live'}},
+              staleSpine = {grid: {state: 'live'},   stream: {state: 'stale', reason: 'feed went quiet'}};
+
+        test('connecting: a read in flight is never "server offline"', () => {
+            const {kind, text} = deriveSpineBanner({...coldSpine, connection: {state: 'connecting'}});
+
+            expect(kind).toBe('cold');
+            expect(text).toContain('Connecting to the fleet plane');
+            expect(text).not.toContain('Fleet server offline');
+            expect(text).not.toContain('npm run ai:fleet-server')
+        });
+
+        test('refused: a NAMED refusal outranks every fallback — and carries its cause', () => {
+            const withReason = deriveSpineBanner({...coldSpine, connection: {state: 'refused', reason: 'token scope insufficient'}}),
+                  bare       = deriveSpineBanner({...coldSpine, connection: {state: 'refused'}});
+
+            expect(withReason.text).toContain('The fleet plane refused this viewer');
+            expect(withReason.text).toContain('token scope insufficient');
+            expect(bare.text).toBe('The fleet plane refused this viewer');
+            // never collapsed into the generic offline guess — the remedy differs categorically
+            expect(withReason.text).not.toContain('Fleet server offline');
+            expect(bare.text).not.toContain('npm run ai:fleet-server')
+        });
+
+        test('unreachable types "no route" apart from the shell boot cases — investigate the plane, not the cockpit', () => {
+            const bare       = deriveSpineBanner({...coldSpine, connection: {state: 'unreachable'}}),
+                  withReason = deriveSpineBanner({...coldSpine, connection: {state: 'unreachable', reason: 'ingress 502'}});
+
+            expect(bare.text).toBe('The fleet plane is unreachable — no route answered');
+            expect(withReason.text).toContain('ingress 502');
+            expect(bare.text).not.toContain('Fleet server offline')
+        });
+
+        test('absent or unknown connection facts fall through to the topology-owned fallback, unchanged', () => {
+            const transport = {mode: 'foreign-listener', phase: 'settled', fleetPort: 8083, up: false};
+
+            for (const connection of [undefined, null, {}, {state: null}, {state: 'connected'}, {state: 'unknown'}]) {
+                const {text} = deriveSpineBanner({...coldSpine, connection, transport});
+
+                expect(text, JSON.stringify(connection)).toContain('another fleet server holds port 8083')
+            }
+        });
+
+        test('⭐ a retained producer reason OUTRANKS every connection state — what the producer SAID beats the connection\'s guess', () => {
+            // The roster answered not-wired while a read was still in flight elsewhere: the surface
+            // reason is the truth that DECIDED the verdict, so the connecting line must not speak.
+            const {text} = deriveSpineBanner({
+                grid      : {state: 'sample', reason: 'fleet activity source not wired'},
+                stream    : {state: 'live'},
+                connection: {state: 'connecting'}
+            });
+
+            expect(text).toContain('fleet activity source not wired');
+            expect(text).not.toContain('Connecting to the fleet plane')
+        });
+
+        test('stale branch: slow reads as a WAIT, failed-upstream as PLANE-SIDE, unreachable named apart from both', () => {
+            const slow     = deriveSpineBanner({...staleSpine, connection: {state: 'slow'}}),
+                  upstream = deriveSpineBanner({...staleSpine, connection: {state: 'failed-upstream'}}),
+                  noRoute  = deriveSpineBanner({...staleSpine, connection: {state: 'unreachable'}});
+
+            expect(slow.text).toContain('The fleet plane is slow — showing last-known data');
+            expect(slow.text).toContain('safe to wait');
+            expect(upstream.text).toContain('The fleet plane\'s surface is failing — showing last-known data');
+            expect(noRoute.text).toContain('The fleet plane is unreachable — showing last-known data');
+            // "wait" and "investigate" must never blur into one another
+            expect(upstream.text).not.toContain('safe to wait')
+        });
+
+        test('the deciding surface\'s retained reason ALWAYS rides the degraded line — the connection state only sets the prefix', () => {
+            for (const state of ['slow', 'unreachable', 'failed-upstream']) {
+                const {text} = deriveSpineBanner({...staleSpine, connection: {state}});
+
+                expect(text, state).toContain('feed went quiet')
+            }
+
+            // and without a retained reason each state still names its own honest fallback
+            const bare = {grid: {state: 'live'}, stream: {state: 'stale'}};
+
+            expect(deriveSpineBanner({...bare, connection: {state: 'slow'}}).text).toContain('the read beat its bound');
+            expect(deriveSpineBanner({...bare, connection: {state: 'unreachable'}}).text).toContain('no route answered')
+        });
+
+        test('no connection fact keeps the shipped generic degraded line byte-identical', () => {
+            const {text} = deriveSpineBanner(staleSpine);
+
+            expect(text).toBe('Fleet feed degraded — showing last-known data · feed went quiet')
+        });
+
+        test('the connection fact never reaches the daemon or live verdicts', () => {
+            const connection = {state: 'refused', reason: 'token scope insufficient'};
+
+            expect(deriveSpineBanner({
+                grid: {state: 'live'}, stream: {state: 'live'}, daemon: {state: 'stopped'}, connection
+            }).text).toContain('Agent OS stopped');
+            expect(deriveSpineBanner({
+                grid: {state: 'live'}, stream: {state: 'live'}, connection
+            })).toEqual({hidden: true, kind: 'live', text: ''})
+        })
     })
 });


### PR DESCRIPTION
Resolves neomjs/neo-agent-institution#18

Related: neomjs/neo-agent-institution#15, neomjs/neo#16824

The cockpit's per-SPINE honesty line gains the **connection axis** — typed remote-connection states the generic `sample`/`stale`/`live` ladder could not name. On the cold branch, consulted before any topology guess: `connecting` (a read in flight — never "server offline"), `refused` (the plane NAMED a refusal — never a generic offline), `unreachable` (no route — investigate the plane, not the cockpit). On the stale branch: `slow` (a wait, not an incident — "safe to wait"), `unreachable`, and `failed-upstream` (the plane's own surface is failing — investigate plane-side). The vocabulary is typed because the operator action differs per state, and "degraded" alone cannot carry "wait" apart from "investigate". `refused` ships contract-first: the render row and its discipline land here, the refusal producer arrives with the S2 admission layer — the same contract-before-producer shape as the shipped throttle axis. State names are wire-named per `FLEET_WIRE_RESPONSE_STATES` (`apps/agentos/config/fleetWireMethods.mjs:59-67`).

Evidence: L2 (unit matrix over the pure derivation — the render contract is fully reachable in-sandbox) → L2 required (the close-target ACs are render-contract ACs). Residual: none for neomjs/neo-agent-institution#18.

## Deltas from ticket

This PR is the **delivered slice** of neomjs/neo-agent-institution#15, re-targeted per the one-PR-resolvable rule and the operator's no-draft-PRs directive:

- **#16744's AC-2 (scoped-empty-with-reason) lives in neomjs/neo#16824** — the roster read result is `{rows}` only (`FleetCockpit.mjs:2264`), so "N operators present" has no wire source until S3's projection lands. neomjs/neo#16824 carries the contract-ledger row the wire must meet.
- **Vocabulary mapping (prose → wire):** `auth-refused` → `refused`, `plane-unreachable` → `unreachable`; `connected-empty` is PR neomjs/neo#16721's already-shipped answered-empty discipline (spec-pinned at `spineBanner.spec.mjs:246`). `slow` and `failed-upstream` ride the truth model's "extended, not forked" clause — they type the stale branch.
- **Contract-first caller shape:** `syncSpineBanner` is deliberately unchanged — no connection producer exists yet, so wiring a hardcoded `null` would add nothing. The render contract + matrix land first; producers arrive with S2/S3.

## Test Evidence

- `npx playwright test -c test/playwright/playwright.config.unit.mjs` — **12304 passed**, 0 failed (run at the pre-rebase head; the 1.9s targeted re-run at `1d07bb935f` below is the post-rebase receipt).
- Surface `apps/agentos/view/fleet` (spineBanner): `spineBanner.spec.mjs` 29/29 at `1d07bb935f` — including the 9-row connection-axis matrix (cold: connecting / refused±reason / unreachable±reason / null+unknown fallthrough / producer-reason-outranks; stale: slow / failed-upstream / unreachable with reason-suffix discipline; daemon + live verdicts provably never consult the connection fact).

## Post-Merge Validation

- [ ] None for this delta (render contract + unit matrix; no runtime producer wired). The S2/S3 producers (the admission layer + neomjs/neo#16824) carry their own post-merge validation when they land.

## Signal Ledger

Family-keyed at D#16720 v11/v12 (carried from neomjs/neo-agent-institution#15): fable AUTHOR_SIGNAL + APPROVED; Opus APPROVED. Full ledger: D#16720 closing comment.

## Unresolved Dissent

GPT v9-anchor DEFERRED: repair implemented (v11); re-stamp pending (carried from neomjs/neo-agent-institution#15).

## Unresolved Liveness

@neo-gemini-pro benched; GPT/Kimi engaged without final-anchor signal (carried from neomjs/neo-agent-institution#15).

## Evolution

- Opened as draft pending the ticket author's AC-2 disposition; the operator ruled drafts unreviewable, so the scope split is now mechanical: this PR Resolves the delivered slice (#16834), neomjs/neo#16824 owns the remainder, neomjs/neo-agent-institution#15 is covered by the pair.

Authored by Phoebe (Kimi for Coding k3, opencode). Session d71abd86-5eec-4912-abdc-217268a39dc0.
