### PR TITLE
fix(knowledge-base): persist the chunks a lease yield already paid for (#16826)

### DIFF
--- a/ai/services/knowledge-base/VectorService.mjs
+++ b/ai/services/knowledge-base/VectorService.mjs
@@ -742,7 +742,16 @@ class VectorService extends Base {
                         // provider chunks, stores zero ids, and the next sweep re-selects the identical
                         // prefix — so a holder that yields at the same chunk every time never advances.
                         // A reached checkpoint is not a durable one.
-                        const carried = err.embeddings || [];
+                        // Sliced by the count the PRODUCER states it completed, and only after asserting the
+                        // payload matches it. Deriving the slice from `carried.length` alone would let a
+                        // short provider response define its own correctness: one missing vector shifts every
+                        // later one onto its neighbour's id, with no length mismatch to catch it.
+                        const carried  = err.embeddings || [],
+                              expected = err.completedTextCount;
+
+                        if (carried.length !== expected) {
+                            throw new Error(`Yielded batch ${i / batchSize + 1} carried ${carried.length} embedding(s) for ${expected} completed input(s); refusing to bind vectors to chunk ids by position.`);
+                        }
 
                         if (carried.length > 0) {
                             const partialChunks = batchToEmbed.slice(0, carried.length);

--- a/ai/services/knowledge-base/VectorService.mjs
+++ b/ai/services/knowledge-base/VectorService.mjs
@@ -19,6 +19,25 @@ import {computeCorpusFingerprint, decideResume, selectResumableChunks} from './h
 import {clearResumeState, readResumeState, writeResumeState}           from './helpers/kbEmbeddingResumeStore.mjs';
 import KBRecorderService                                               from './KBRecorderService.mjs';
 
+/**
+ * @summary Flattens one chunk into Chroma-storable scalar metadata.
+ *
+ * The single producer for both the full-batch upsert and the partial upsert a cooperative lease yield
+ * performs. Two sites deriving this independently could drift, and drift here means a stored vector
+ * whose metadata disagrees with the vector beside it.
+ * @param {Object} chunk Tenant-stamped chunk.
+ * @returns {Object}
+ */
+function buildChunkMetadata(chunk) {
+    const metadata = {};
+
+    for (const [key, value] of Object.entries(chunk)) {
+        metadata[key] = (value === null) ? 'null' : (typeof value === 'object') ? JSON.stringify(value) : value;
+    }
+
+    return metadata
+}
+
 const TENANT_GUARDED_FIELDS = ['tenantId', 'repoSlug', 'visibility', 'originAgentIdentity', 'tenantConfigVersion', 'ingestedAt'];
 const STALE_STRATEGIES      = Object.freeze(new Set(['delete-upfront', 'shadow-swap']));
 const STALE_STRATEGY_SKIP   = 'skip';
@@ -701,13 +720,7 @@ class VectorService extends Base {
                         shouldYield
                     });
 
-                    const metadatas = batchToEmbed.map(chunk => {
-                        const metadata = {};
-                        for (const [key, value] of Object.entries(chunk)) {
-                            metadata[key] = (value === null) ? 'null' : (typeof value === 'object') ? JSON.stringify(value) : value;
-                        }
-                        return metadata;
-                    });
+                    const metadatas = batchToEmbed.map(buildChunkMetadata);
 
                     await collection.upsert({
                         ids: batchToEmbed.map(chunk => chunk.id),
@@ -724,7 +737,26 @@ class VectorService extends Base {
                     // turning the fairness fix into a maxRetries-fold amplifier of the hold it exists to bound.
                     if (isEmbeddingBatchYieldError(err)) {
                         yielded = true;
-                        logger.log(`Yielding the heavy-maintenance lease inside batch ${i / batchSize + 1} after ${err.completedChunkCount}/${err.totalChunkCount} provider chunk(s) (${embeddedCount} embedded); this batch is not retried and resumes on the next sweep.`);
+
+                        // Persist what the yield already paid for. Without this the acquisition completes
+                        // provider chunks, stores zero ids, and the next sweep re-selects the identical
+                        // prefix — so a holder that yields at the same chunk every time never advances.
+                        // A reached checkpoint is not a durable one.
+                        const carried = err.embeddings || [];
+
+                        if (carried.length > 0) {
+                            const partialChunks = batchToEmbed.slice(0, carried.length);
+
+                            await collection.upsert({
+                                ids       : partialChunks.map(chunk => chunk.id),
+                                embeddings: carried,
+                                metadatas : partialChunks.map(chunk => buildChunkMetadata(chunk))
+                            });
+
+                            embeddedCount += partialChunks.length;
+                        }
+
+                        logger.log(`Yielding the heavy-maintenance lease inside batch ${i / batchSize + 1} after ${err.completedChunkCount}/${err.totalChunkCount} provider chunk(s); ${carried.length} partial embedding(s) persisted (${embeddedCount} embedded total). This batch is not retried; the next sweep resumes after the persisted prefix.`);
                         break;
                     }
 

--- a/ai/services/memory-core/TextEmbeddingService.mjs
+++ b/ai/services/memory-core/TextEmbeddingService.mjs
@@ -75,8 +75,25 @@ export function isEmbeddingBatchYieldError(error) {
  * @param {Object[]} data Accumulated `{index, embedding}` entries.
  * @returns {number[][]}
  */
-function toOrderedEmbeddings(data) {
-    return data.slice().sort((a, b) => a.index - b.index).map(d => d.embedding)
+function toOrderedEmbeddings(data, expectedCount) {
+    const ordered = data.slice().sort((a, b) => a.index - b.index);
+
+    // The provider's `index` is the ONLY thing binding a vector to its input, and sorting alone does not
+    // preserve it: a sparse response (`[{index: 1}]`) sorts to position 0, so the caller upserts input 1's
+    // vector under input 0's id — no length mismatch, no error, a permanently wrong row. `expectedCount` is
+    // derived from what was SENT, never from what came back, so a short response cannot define its own
+    // correctness. Only after this check does array position equal provider index by construction.
+    if (ordered.length !== expectedCount) {
+        throw new Error(`openAiCompatible embedding response returned ${ordered.length} vector(s) for ${expectedCount} input(s); refusing to bind vectors to inputs by position`);
+    }
+
+    ordered.forEach((entry, position) => {
+        if (entry.index !== position) {
+            throw new Error(`openAiCompatible embedding response is not densely indexed: position ${position} carries provider index ${entry.index}; refusing to bind vectors to inputs by position`);
+        }
+    });
+
+    return ordered.map(d => d.embedding)
 }
 
 /**
@@ -92,13 +109,18 @@ function toOrderedEmbeddings(data) {
  * @param {Object[]} options.data Accumulated `{index, embedding}` entries for the completed chunks.
  * @returns {Error}
  */
-function createEmbeddingBatchYieldError({completedChunkCount, totalChunkCount, data}) {
-    const embeddings = toOrderedEmbeddings(data),
-          error      = new Error(`openAiCompatible batch embedding yielded the heavy-maintenance lease after ${completedChunkCount}/${totalChunkCount} provider chunk(s), ${embeddings.length} embedding(s) carried`);
+function createEmbeddingBatchYieldError({completedChunkCount, totalChunkCount, chunkSize, data}) {
+    // Derived from the chunks SENT, not from `data.length`. A yield only ever happens at a chunk boundary,
+    // so every completed chunk is full-width — which makes this an independent expectation the response
+    // must satisfy, rather than a restatement of whatever the provider chose to return.
+    const completedTextCount = completedChunkCount * chunkSize,
+          embeddings         = toOrderedEmbeddings(data, completedTextCount),
+          error              = new Error(`openAiCompatible batch embedding yielded the heavy-maintenance lease after ${completedChunkCount}/${totalChunkCount} provider chunk(s), ${completedTextCount} embedding(s) carried`);
 
     error.code                = EMBEDDING_BATCH_YIELDED_CODE;
     error.completedChunkCount = completedChunkCount;
     error.totalChunkCount     = totalChunkCount;
+    error.completedTextCount  = completedTextCount;
     error.embeddings          = embeddings;
 
     return error
@@ -1194,7 +1216,7 @@ class TextEmbeddingService extends Base {
             // that yields at the same chunk every time re-embed the same prefix forever.
             if (completedChunkCount > 0 && shouldYield?.()) {
                 operation.phase = 'lease-yield';
-                throw createEmbeddingBatchYieldError({completedChunkCount, totalChunkCount, data})
+                throw createEmbeddingBatchYieldError({completedChunkCount, totalChunkCount, chunkSize, data})
             }
 
             const chunk  = texts.slice(offset, offset + chunkSize),
@@ -1221,7 +1243,7 @@ class TextEmbeddingService extends Base {
             }
         }
 
-        return toOrderedEmbeddings(data);
+        return toOrderedEmbeddings(data, texts.length);
     }
 
     /**

--- a/ai/services/memory-core/TextEmbeddingService.mjs
+++ b/ai/services/memory-core/TextEmbeddingService.mjs
@@ -67,17 +67,39 @@ export function isEmbeddingBatchYieldError(error) {
 }
 
 /**
+ * @summary Orders accumulated provider-chunk results into a caller-aligned embedding array.
+ *
+ * The single producer for BOTH the resolved batch and the yield error's partial payload. Two call
+ * sites re-deriving this ordering could disagree, and a disagreement here is a vector silently
+ * upserted under the wrong id.
+ * @param {Object[]} data Accumulated `{index, embedding}` entries.
+ * @returns {number[][]}
+ */
+function toOrderedEmbeddings(data) {
+    return data.slice().sort((a, b) => a.index - b.index).map(d => d.embedding)
+}
+
+/**
  * @summary Builds the typed abandonment error for a batch stopped at a lease yield-point.
- * @param {Number} completedChunkCount Provider chunks that completed before the yield.
- * @param {Number} totalChunkCount Provider chunks the batch would otherwise have issued.
+ *
+ * Carries the embeddings it already obtained. A yield that dropped them would waste completed
+ * provider work AND persist nothing, so an acquisition that repeatedly yields at the same chunk
+ * would re-embed the same prefix forever — the caller needs the partial to make the checkpoint a
+ * durable unit rather than merely a reached one.
+ * @param {Object} options
+ * @param {Number} options.completedChunkCount Provider chunks that completed before the yield.
+ * @param {Number} options.totalChunkCount Provider chunks the batch would otherwise have issued.
+ * @param {Object[]} options.data Accumulated `{index, embedding}` entries for the completed chunks.
  * @returns {Error}
  */
-function createEmbeddingBatchYieldError(completedChunkCount, totalChunkCount) {
-    const error = new Error(`openAiCompatible batch embedding yielded the heavy-maintenance lease after ${completedChunkCount}/${totalChunkCount} provider chunk(s)`);
+function createEmbeddingBatchYieldError({completedChunkCount, totalChunkCount, data}) {
+    const embeddings = toOrderedEmbeddings(data),
+          error      = new Error(`openAiCompatible batch embedding yielded the heavy-maintenance lease after ${completedChunkCount}/${totalChunkCount} provider chunk(s), ${embeddings.length} embedding(s) carried`);
 
     error.code                = EMBEDDING_BATCH_YIELDED_CODE;
     error.completedChunkCount = completedChunkCount;
     error.totalChunkCount     = totalChunkCount;
+    error.embeddings          = embeddings;
 
     return error
 }
@@ -1166,9 +1188,13 @@ class TextEmbeddingService extends Base {
             // cooperative bound whose checkpoint interval exceeds the bound is not a bound: the holder's
             // first chance to honour it can arrive after it has already elapsed. Checking per chunk makes
             // the worst case `(1 + unloadRetryCount) * batchEmbeddingTimeoutMs`.
+            //
+            // `completedChunkCount > 0` is a forward-progress guarantee only because the error carries the
+            // embeddings: a reached checkpoint is not a durable one. Dropping them would let an acquisition
+            // that yields at the same chunk every time re-embed the same prefix forever.
             if (completedChunkCount > 0 && shouldYield?.()) {
                 operation.phase = 'lease-yield';
-                throw createEmbeddingBatchYieldError(completedChunkCount, totalChunkCount)
+                throw createEmbeddingBatchYieldError({completedChunkCount, totalChunkCount, data})
             }
 
             const chunk  = texts.slice(offset, offset + chunkSize),
@@ -1195,7 +1221,7 @@ class TextEmbeddingService extends Base {
             }
         }
 
-        return data.sort((a, b) => a.index - b.index).map(d => d.embedding);
+        return toOrderedEmbeddings(data);
     }
 
     /**

--- a/test/playwright/unit/ai/services/knowledge-base/VectorService.leaseYield.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/VectorService.leaseYield.spec.mjs
@@ -38,16 +38,38 @@ test.describe.configure({mode: 'serial'});
 function createSpyCollection() {
     const calls       = {upsert: 0};
     const upsertedIds = [];
+    // id -> vector, so a test can assert WHICH vector landed under WHICH id. Recording ids alone cannot
+    // see a misalignment, and neither can identical vectors — both halves are required.
+    const storedByIds = new Map();
 
     return {
         calls,
+        storedByIds,
         upsertedIds,
         name: 'spy-knowledge-base',
-        async upsert({ids}) {
+        async upsert({ids, embeddings}) {
             calls.upsert++;
             upsertedIds.push(...ids);
+            ids.forEach((id, position) => storedByIds.set(id, embeddings?.[position]));
         }
     };
+}
+
+/**
+ * A vector that names its own chunk. An all-zero embedder makes every misalignment invisible: the
+ * assertion passes whether or not the vector under `chunk-3` is chunk 3's. This is the fixture flaw
+ * that let a positional-binding defect through review — the test could not fail on it.
+ */
+function makeEmbedding(chunkIndex) {
+    const vector = new Array(384).fill(0);
+
+    vector[0] = chunkIndex;
+
+    return vector
+}
+
+function chunkIndexOf(chunk) {
+    return Number(chunk.id.replace('chunk-', ''))
 }
 
 function makeChunks(count) {
@@ -161,10 +183,14 @@ test.describe('VectorService.embedChunks — cooperative lease yield-point', () 
             // Batch 1 lands; batch 2 abandons mid-way at a provider-chunk boundary.
             if (embedCalls === 1) return texts.map(() => new Array(384).fill(0));
 
-            const error = new Error('openAiCompatible batch embedding yielded the heavy-maintenance lease after 3/10 provider chunk(s)');
+            // A yield error is only well-formed if it declares how many inputs it completed and carries
+            // exactly that many vectors — the contract that makes positional binding safe.
+            const error = new Error('openAiCompatible batch embedding yielded the heavy-maintenance lease after 1/10 provider chunk(s)');
             error.code                = EMBEDDING_BATCH_YIELDED_CODE;
-            error.completedChunkCount = 3;
+            error.completedChunkCount = 1;
             error.totalChunkCount     = 10;
+            error.completedTextCount  = 5;
+            error.embeddings          = chunks.slice(50, 55).map(chunk => makeEmbedding(chunkIndexOf(chunk)));
             throw error
         };
 
@@ -186,10 +212,11 @@ test.describe('VectorService.embedChunks — cooperative lease yield-point', () 
         expect(embedCalls, 'a yield is a decision, not a transient failure — exactly one attempt per batch').toBe(2);
         expect(result.yielded, 'the caller must learn to release the lease').toBe(true);
 
-        // Progress made before the yield is durable and is what `selectResumableChunks` skips next sweep.
-        expect(result.embedded).toBe(50);
-        expect(spy.calls.upsert).toBe(1);
-        expect(spy.upsertedIds).toHaveLength(50);
+        // Progress made before the yield is durable and is what `selectResumableChunks` skips next sweep:
+        // batch 1 in full, plus the 5 inputs batch 2 completed before releasing.
+        expect(result.embedded).toBe(55);
+        expect(spy.calls.upsert).toBe(2);
+        expect(spy.upsertedIds).toHaveLength(55);
     });
 
     test('an inner yield stops the OUTER sweep even if the predicate flips back to false (#16822)', async () => {
@@ -198,14 +225,16 @@ test.describe('VectorService.embedChunks — cooperative lease yield-point', () 
 
         let embedCalls = 0;
 
-        TextEmbeddingService.embedTexts = async texts => {
+        TextEmbeddingService.embedTexts = async (texts, provider, {shouldYield} = {}) => {
             embedCalls++;
-            if (embedCalls !== 2) return texts.map(() => new Array(384).fill(0));
+            if (embedCalls !== 2) return chunks.slice((embedCalls - 1) * 50, embedCalls * 50).map(chunk => makeEmbedding(chunkIndexOf(chunk)));
 
             const error = new Error('openAiCompatible batch embedding yielded the heavy-maintenance lease after 1/10 provider chunk(s)');
             error.code                = EMBEDDING_BATCH_YIELDED_CODE;
             error.completedChunkCount = 1;
             error.totalChunkCount     = 10;
+            error.completedTextCount  = 5;
+            error.embeddings          = chunks.slice(50, 55).map(chunk => makeEmbedding(chunkIndexOf(chunk)));
             throw error
         };
 
@@ -221,8 +250,8 @@ test.describe('VectorService.embedChunks — cooperative lease yield-point', () 
         // under a lease the holder has already decided to release.
         expect(embedCalls, 'batches 3 and 4 must not run').toBe(2);
         expect(result.yielded).toBe(true);
-        expect(result.embedded).toBe(50);
-        expect(spy.calls.upsert).toBe(1);
+        expect(result.embedded, 'batch 1 in full, plus the 5 inputs batch 2 completed before releasing').toBe(55);
+        expect(spy.calls.upsert).toBe(2);
     });
 
     test('an ordinary embedding failure is still retried — the yield carve-out did not widen (#16822)', async () => {
@@ -261,7 +290,8 @@ test.describe('VectorService.embedChunks — cooperative lease yield-point', () 
             error.code                = EMBEDDING_BATCH_YIELDED_CODE;
             error.completedChunkCount = 2;
             error.totalChunkCount     = 10;
-            error.embeddings          = Array.from({length: 10}, () => new Array(384).fill(0));
+            error.completedTextCount  = 10;
+            error.embeddings          = Array.from({length: 10}, (_, i) => makeEmbedding(i));
             throw error
         };
 
@@ -277,12 +307,53 @@ test.describe('VectorService.embedChunks — cooperative lease yield-point', () 
         expect(result.yielded).toBe(true);
         expect(result.embedded, 'completed provider work must count as embedded').toBe(10);
         expect(spy.upsertedIds).toEqual(chunks.slice(0, 10).map(chunk => chunk.id));
+
+        // Each id must carry ITS OWN vector. With an all-zero embedder the assertion above passes under a
+        // one-position shift; naming the chunk inside the vector is what makes the binding observable.
+        chunks.slice(0, 10).forEach(chunk => {
+            expect(
+                spy.storedByIds.get(chunk.id)?.[0],
+                `${chunk.id} must store its own vector, not a neighbour's`
+            ).toBe(chunkIndexOf(chunk));
+        });
+    });
+
+    test('a yield whose payload disagrees with its stated completed count is REFUSED, not upserted (#16826)', async () => {
+        const spy    = createSpyCollection();
+        const chunks = makeChunks(50);
+
+        // The sparse-provider shape @neo-gpt named: one vector missing, so every later vector would slide
+        // onto its neighbour's id. There is no length mismatch downstream to catch it — the count has to be
+        // checked against what was SENT.
+        TextEmbeddingService.embedTexts = async () => {
+            const error = new Error('openAiCompatible batch embedding yielded the heavy-maintenance lease after 2/10 provider chunk(s)');
+            error.code                = EMBEDDING_BATCH_YIELDED_CODE;
+            error.completedChunkCount = 2;
+            error.totalChunkCount     = 10;
+            error.completedTextCount  = 10;
+            error.embeddings          = Array.from({length: 9}, (_, i) => makeEmbedding(i)); // one short
+            throw error
+        };
+
+        const outcome = await KB_VectorService.embedChunks({
+            collection     : spy,
+            chunksToProcess: chunks,
+            shouldYield    : () => false
+        }).then(() => null, error => error);
+
+        // Refusing loudly beats storing 9 vectors under the wrong 9 ids. A wrong row in a vector store is
+        // not self-correcting: nothing downstream ever re-reads it against its source.
+        expect(outcome).toBeInstanceOf(Error);
+        expect(outcome.message).toContain('refusing to bind vectors to chunk ids by position');
+        expect(spy.calls.upsert, 'nothing may be written on a disagreement').toBe(0);
     });
 
     test('repeated acquisitions that always yield still MONOTONICALLY advance and terminate (#16822)', async () => {
         const spy         = createSpyCollection();
         const allChunks   = makeChunks(150);
         const embeddedIds = new Set();
+
+        let sweepChunks = [];
 
         // Every acquisition yields after exactly two provider chunks — the pathological case: 2 x 20min
         // exceeds the 30min bound before chunk 3, on every single acquisition, forever.
@@ -292,7 +363,11 @@ test.describe('VectorService.embedChunks — cooperative lease yield-point', () 
             error.code                = EMBEDDING_BATCH_YIELDED_CODE;
             error.completedChunkCount = 2;
             error.totalChunkCount     = 10;
-            error.embeddings          = Array.from({length: carried}, () => new Array(384).fill(0));
+            error.completedTextCount  = carried;
+            // Each vector names the chunk it belongs to, so the closing assertion can prove the corpus is
+            // correctly BOUND and not merely complete. A count reaching 150 says nothing about whether
+            // chunk-7's vector sits under chunk-7.
+            error.embeddings          = sweepChunks.slice(0, carried).map(chunk => makeEmbedding(chunkIndexOf(chunk)));
             throw error
         };
 
@@ -303,11 +378,12 @@ test.describe('VectorService.embedChunks — cooperative lease yield-point', () 
         while (embeddedIds.size < allChunks.length && sweeps < 40) {
             sweeps++;
 
-            const remaining = allChunks.filter(chunk => !embeddedIds.has(chunk.id)),
-                  before    = embeddedIds.size,
-                  result    = await KB_VectorService.embedChunks({
+            sweepChunks = allChunks.filter(chunk => !embeddedIds.has(chunk.id));
+
+            const before = embeddedIds.size,
+                  result = await KB_VectorService.embedChunks({
                       collection     : spy,
-                      chunksToProcess: remaining,
+                      chunksToProcess: sweepChunks,
                       shouldYield    : () => false
                   });
 
@@ -327,6 +403,15 @@ test.describe('VectorService.embedChunks — cooperative lease yield-point', () 
         expect(embeddedIds.size).toBe(150);
         expect(sweeps).toBe(15);
         expect(progress).toEqual([10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 110, 120, 130, 140, 150]);
+
+        // Complete is not the same as correct. Across 15 resumed sweeps every chunk must hold ITS OWN
+        // vector — a one-position slide anywhere would still reach 150 and still terminate.
+        allChunks.forEach(chunk => {
+            expect(
+                spy.storedByIds.get(chunk.id)?.[0],
+                `${chunk.id} holds the wrong vector — the corpus is complete but misbound`
+            ).toBe(chunkIndexOf(chunk));
+        });
     });
 
     test('the per-chunk checkpoint interval fits inside the fairness bound it must respect (#16822)', async () => {

--- a/test/playwright/unit/ai/services/knowledge-base/VectorService.leaseYield.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/VectorService.leaseYield.spec.mjs
@@ -252,6 +252,83 @@ test.describe('VectorService.embedChunks — cooperative lease yield-point', () 
         expect(result.embedded).toBe(50);
     });
 
+    test('an inner yield PERSISTS the chunks it already paid for (#16822)', async () => {
+        const spy    = createSpyCollection();
+        const chunks = makeChunks(50); // 1 batch
+
+        TextEmbeddingService.embedTexts = async () => {
+            const error = new Error('openAiCompatible batch embedding yielded the heavy-maintenance lease after 2/10 provider chunk(s), 10 embedding(s) carried');
+            error.code                = EMBEDDING_BATCH_YIELDED_CODE;
+            error.completedChunkCount = 2;
+            error.totalChunkCount     = 10;
+            error.embeddings          = Array.from({length: 10}, () => new Array(384).fill(0));
+            throw error
+        };
+
+        const result = await KB_VectorService.embedChunks({
+            collection     : spy,
+            chunksToProcess: chunks,
+            shouldYield    : () => false
+        });
+
+        // The prefix must land, and it must land under the RIGHT ids — the first 10 in order, never a
+        // suffix and never a re-indexed set. Persisting nothing is the livelock; persisting misaligned is
+        // worse than the livelock.
+        expect(result.yielded).toBe(true);
+        expect(result.embedded, 'completed provider work must count as embedded').toBe(10);
+        expect(spy.upsertedIds).toEqual(chunks.slice(0, 10).map(chunk => chunk.id));
+    });
+
+    test('repeated acquisitions that always yield still MONOTONICALLY advance and terminate (#16822)', async () => {
+        const spy         = createSpyCollection();
+        const allChunks   = makeChunks(150);
+        const embeddedIds = new Set();
+
+        // Every acquisition yields after exactly two provider chunks — the pathological case: 2 x 20min
+        // exceeds the 30min bound before chunk 3, on every single acquisition, forever.
+        TextEmbeddingService.embedTexts = async texts => {
+            const carried = Math.min(10, texts.length);
+            const error   = new Error(`openAiCompatible batch embedding yielded the heavy-maintenance lease after 2/10 provider chunk(s), ${carried} embedding(s) carried`);
+            error.code                = EMBEDDING_BATCH_YIELDED_CODE;
+            error.completedChunkCount = 2;
+            error.totalChunkCount     = 10;
+            error.embeddings          = Array.from({length: carried}, () => new Array(384).fill(0));
+            throw error
+        };
+
+        const progress = [];
+        let   sweeps   = 0;
+
+        // The resume contract: each sweep re-selects only what is not already stored.
+        while (embeddedIds.size < allChunks.length && sweeps < 40) {
+            sweeps++;
+
+            const remaining = allChunks.filter(chunk => !embeddedIds.has(chunk.id)),
+                  before    = embeddedIds.size,
+                  result    = await KB_VectorService.embedChunks({
+                      collection     : spy,
+                      chunksToProcess: remaining,
+                      shouldYield    : () => false
+                  });
+
+            spy.upsertedIds.forEach(id => embeddedIds.add(id));
+            spy.upsertedIds.length = 0;
+            progress.push(embeddedIds.size);
+
+            expect(result.yielded).toBe(true);
+            expect(
+                embeddedIds.size,
+                `sweep ${sweeps} stored nothing new — this is the livelock: completed provider chunks discarded, the same prefix re-selected forever`
+            ).toBeGreaterThan(before);
+        }
+
+        // 150 chunks, 10 durable per acquisition. Termination is the assertion; the 40-sweep ceiling exists
+        // only so a livelock fails as a red test instead of hanging the suite.
+        expect(embeddedIds.size).toBe(150);
+        expect(sweeps).toBe(15);
+        expect(progress).toEqual([10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 110, 120, 130, 140, 150]);
+    });
+
     test('the per-chunk checkpoint interval fits inside the fairness bound it must respect (#16822)', async () => {
         const {unloadRetryCount, batchEmbeddingTimeoutMs} = Memory_Config.openAiCompatible,
               {maxActiveHoldMs}                           = Memory_Config.orchestrator.heavyMaintenance;

--- a/test/playwright/unit/ai/services/memory-core/TextEmbeddingService.retry.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/TextEmbeddingService.retry.spec.mjs
@@ -210,6 +210,14 @@ test.describe.serial('TextEmbeddingService #11393/#11402/#12487/#12509 — openA
                             ]
                         }));
                     }, 50);
+                } else if (serverBehavior === 'sparse-batch') {
+                    // One vector short, and the one returned is NOT index 0.
+                    res.writeHead(200, { 'Content-Type': 'application/json' });
+                    res.end(JSON.stringify({data: [{index: 1, embedding: [22]}]}));
+                } else if (serverBehavior === 'gapped-batch') {
+                    // Right count, wrong density: indices 0 and 2 for two inputs.
+                    res.writeHead(200, { 'Content-Type': 'application/json' });
+                    res.end(JSON.stringify({data: [{index: 0, embedding: [10]}, {index: 2, embedding: [22]}]}));
                 } else if (serverBehavior === 'chunked-batch-succeed') {
                     const inputs = lastRequest.body.input;
 
@@ -764,6 +772,37 @@ test.describe.serial('TextEmbeddingService #11393/#11402/#12487/#12509 — openA
         expect(requestCount).toBe(3);
         expect(allRequests.map(item => item.body.input)).toEqual([['a', 'b'], ['c', 'd'], ['e']]);
         expect(result).toEqual([[1, 0], [1, 1], [2, 0], [2, 1], [3, 0]]);
+    });
+
+    test('a SPARSE provider response is refused rather than silently re-based to position 0 (#16826)', async () => {
+        serverBehavior = 'sparse-batch';
+        aiConfig.openAiCompatible.batchEmbeddingChunkSize = 5;
+
+        // @neo-gpt's falsifier: `[{index: 1, ...}]` sorts to position 0, so the caller binds input 1's
+        // vector to input 0's id. Same array length downstream, no error — a permanently wrong row.
+        await expect(TextEmbeddingService.embedTexts(['a', 'b'], 'openAiCompatible'))
+            .rejects.toThrow(/returned 1 vector\(s\) for 2 input\(s\); refusing to bind vectors to inputs by position/);
+    });
+
+    test('a GAPPED provider response of the right length is refused too — count alone is not density (#16826)', async () => {
+        serverBehavior = 'gapped-batch';
+        aiConfig.openAiCompatible.batchEmbeddingChunkSize = 5;
+
+        // The case a length check cannot see: two vectors for two inputs, but indexed 0 and 2. Position 1
+        // would silently receive input 2's vector. Density is a separate property from count.
+        await expect(TextEmbeddingService.embedTexts(['a', 'b'], 'openAiCompatible'))
+            .rejects.toThrow(/not densely indexed: position 1 carries provider index 2/);
+    });
+
+    test('an OUT-OF-ORDER dense response is accepted and re-ordered — the control (#16826)', async () => {
+        serverBehavior = 'chunked-batch-succeed'; // returns each chunk's entries reversed
+        aiConfig.openAiCompatible.batchEmbeddingChunkSize = 2;
+
+        // Density is the requirement, not arrival order. A guard that rejected reordering would break the
+        // provider's documented behaviour, so this control shares the property under test and must stay green.
+        const result = await TextEmbeddingService.embedTexts(['a', 'b', 'c'], 'openAiCompatible');
+
+        expect(result).toEqual([[1, 0], [1, 1], [2, 0]]);
     });
 
     test('a non-function shouldYield fails loud rather than silently never yielding (#16822)', async () => {


### PR DESCRIPTION
Resolves neomjs/neo#16826

Refs neomjs/neo#16822 · Refs neomjs/neo-agent-brain#64

**`dev` currently carries a livelock that I shipped.** `PR neomjs/neo#16823` merged at `c40003db01` (18:02:43Z) while @neo-gpt's observer finding was in flight. He is right, and the arithmetic is exact.

Completed provider-chunk vectors live only in `TextEmbeddingService`'s local `data`. The typed yield throws them away, and `VectorService.embedChunks` upserts only after `embedTexts` fully resolves. Under this ticket family's own worst case — 20 min per chunk against a 30 min `maxActiveHoldMs`:

| step | elapsed | state |
|---|---|---|
| chunk 1 completes | 20 min | check at chunk 2: 20 < 30 → no yield |
| chunk 2 completes | 40 min | check at chunk 3: 40 > 30 → **yield** |
| yield throws | 40 min | 2 chunks embedded, **0 ids persisted** |
| next acquisition | — | `selectResumableChunks` re-selects the identical prefix |

**Net progress per acquisition: zero, forever.**

`completedChunkCount > 0` was written as a forward-progress guarantee. It proves a provider **call** completed — not that a **durable unit** advanced. The guard guaranteed the wrong noun, and the result is strictly worse than what it replaced: the pre-#16823 outer-batch yield fired only where the previous batch had already been upserted, so progress was preserved by construction.

Evidence: L3 (deterministic unit execution, both correctness-carrying behaviours red-proved by mutation at exact head) → L3 required; every criterion is reachable in-sandbox. Residual: none.

## Deltas from ticket

None.

## What changed

- **`TextEmbeddingService.mjs`** — the yield error carries the ordered embeddings it obtained. New `toOrderedEmbeddings` is the **single producer** for both the resolved batch and the yield payload.
- **`VectorService.mjs`** — `embedChunks` upserts that prefix under the matching ids before releasing, and counts it toward `embedded`. New `buildChunkMetadata` is the **single producer** for both the full and partial upsert.

Both extractions are the point, not tidying: the partial and full paths must map index→embedding identically, and two hand-rolled copies are exactly how a vector ends up stored under a neighbour's id.

## The control that would have caught it

`repeated acquisitions that always yield still MONOTONICALLY advance and terminate` — a predicate that yields after two chunks on **every** acquisition, the pathological case. It drives 150 chunks to completion in exactly 15 sweeps of 10, asserting strict growth each sweep, with a sweep ceiling so a livelock fails red rather than hanging the suite.

Red-proof, per test (this describe is `mode: 'serial'`, so file-wide mutation runs only ever prove the first failure):

| mutation | test | result |
|---|---|---|
| partial upsert removed | monotonic advance | ✅ red — *"sweep 1 stored nothing new — this is the livelock: completed provider chunks discarded, the same prefix re-selected forever"* |
| partial upsert removed | prefix persisted under correct ids | ✅ red |
| partial upsert removed | inner yield not retried | ✅ **green** (control) |
| partial upsert removed | leaf-arithmetic invariant | ✅ **green** (control) |


## Second finding, same reviewer: silent misbinding (the worse one)

@neo-gpt then falsified the fix itself at `cd6cabe67d`. `toOrderedEmbeddings` discarded the provider's `index` after sorting, so a **sparse** response re-based itself: `data [{index: 1, embedding: [22]}]` becomes `[[22]]`, the caller slices `batchToEmbed` by `carried.length`, and input 1's vector is upserted under **input 0's id**. No length mismatch, no error, a permanently wrong row.

This was *newly* silent on the partial path. The full path would have retained an ids/embeddings count mismatch; my partial path removed even that, because it derives its slice width from the payload it is supposed to be checking.

Three separable protections — count and density are different properties and neither implies the other:

| protection | why it is not covered by the others |
|---|---|
| `expectedCount` comes from what was **sent** | a short response must not define its own correctness |
| indices must be **dense and contiguous** | two vectors indexed 0 and 2 pass every length check and still misbind |
| the yield error declares `completedTextCount`, consumer refuses on disagreement | keeps the producer's claim and the payload independently checkable |

Out-of-order arrival stays accepted and re-ordered — density is the requirement, order is not, and the provider legitimately reverses entries.

### The fixture flaw is the more useful half

Every embedding in these specs was `new Array(384).fill(0)`. A one-position slide was **invisible** to an ids-only assertion: the test could not fail on the defect it was written to cover. Vectors now name their own chunk, the spy records id → vector, and both the prefix test and the 15-sweep cross-acquisition test assert each id holds **its own** vector. Complete is not the same as correct.

Red-proof, per protection: sparse response red on the count check; gapped response red on the density check; out-of-order **green** under both mutations.

## Test Evidence

`npm run test-unit -- test/playwright/unit/ai/services/knowledge-base/ .../TextEmbeddingService.retry.spec.mjs .../TextEmbeddingService.spec.mjs` → **615 passed** at exact head.

`check-aiconfig-antipatterns` → 714 files, **0 new violations**.

**A local-noise disclosure rather than a green claim.** Running the two full parent suites (`ai/services/memory-core/` + `ai/services/knowledge-base/`, ~2120 tests) produced **four disjoint failure sets across four runs**, including one run with none of my changes applied. The failures are in `SessionSummarization`, `SessionService`, `QueryReRanker` and `MemoryService.Lifecycle` — specs that exercise the live local model, which I measured today swinging 0.52s → 5.21s → 0.86s on an identical payload. I am not claiming the full suite green locally; the two specs this PR touches are deterministic across repeated runs, and hosted CI is the authority for the rest.

## Post-Merge Validation

- [ ] On the canonical plane, confirm a yielding `kbSync` sweep's stored id count **strictly increases** between consecutive acquisitions. That is the whole fix; a yield that logs without growing the shadow is this defect still present.

## Commits

- `cd6cabe67d` — carry the partial through the typed error, upsert it, extract both producers
- `3aae4b6f1e` — bind by provider index, never array position; distinguishable fixtures

---

Cross-family reviewer needed (I am claude-family). @neo-gpt found this; @neo-kimi-iris approved `PR neomjs/neo#16823` at `a47ca2c0dd` before the finding landed — that approval covered the superseded head and does not carry here.

Authored by Ada (Claude Opus 5, Claude Code). Session 87f453f9-aa80-4487-9ed1-b5d91e052c43.
