### PR TITLE
feat(build): close-relation audit in the PR-body lint — unmet ACs and self-home PMV items fail (#16829)

### DIFF
--- a/.github/workflows/agent-pr-body-lint.yml
+++ b/.github/workflows/agent-pr-body-lint.yml
@@ -98,6 +98,101 @@ jobs:
             }
 
             // ──────────────────────────────────────────────────────────────────────
+            // Close-relation audit (#16829). GitHub auto-close is textual: `Resolves #N`
+            // closes #N at merge no matter what its Acceptance Criteria still track.
+            // `pr-review-guide.md §5.2` is reviewer discipline; this is its mechanical
+            // floor. Two orphan classes, both mechanically decidable:
+            //   (a) a close-target whose AC section carries an unchecked item WITHOUT an
+            //       `[L<N>-deferred — …]` annotation (the sanctioned residual marker —
+            //       annotated open-ended verification closes normally);
+            //   (b) a Post-Merge Validation checklist item whose every `#N` reference is
+            //       itself being closed (its home dies with the merge). No-reference PMV
+            //       items are NOT flagged: §5.2 rule 4's open-ended verification rides
+            //       free (#16796's close of #16800 is the control shape).
+            // The decision core is pure — ticket bodies arrive as INPUT, the fetch lives
+            // at the call site — so the unit spec slices it out of this file between the
+            // sentinels and runs the fixture corpus off-CI. One producer, no twin.
+            // ──────────────────────────────────────────────────────────────────────
+            // #16829-CLOSE-RELATION-AUDIT-BEGIN
+            function sliceBodySection(text, heading) {
+              const match = text.match(new RegExp('^## ' + heading + '[ \\t]*$', 'm'));
+
+              if (!match) return '';
+
+              return text.slice(match.index + match[0].length).split(/^## /m)[0]
+            }
+
+            function auditCloseRelations(bodyText, issueBodiesByNumber) {
+              const findings  = [];
+              const closeNums = [...new Set([...bodyText.matchAll(/\bResolves:?\s+#(\d+)/gi)].map(m => m[1]))];
+
+              for (const num of closeNums) {
+                const ticketBody = issueBodiesByNumber[num];
+
+                if (typeof ticketBody !== 'string') {
+                  findings.push(`#${num}: the ticket body was unavailable to the audit — a gate that cannot see its input must not pass silently`);
+                  continue
+                }
+
+                const unmet = sliceBodySection(ticketBody, 'Acceptance Criteria')
+                  .split('\n')
+                  .filter(line => /^\s*-\s+\[ \]/.test(line))
+                  .filter(line => !/\[L\d+-deferred/i.test(line));
+
+                for (const item of unmet) {
+                  findings.push(`#${num} carries an unmet, un-annotated acceptance criterion this merge would close over: ${item.trim()}`)
+                }
+              }
+
+              const pmvItems = sliceBodySection(bodyText, 'Post-Merge Validation')
+                .split('\n')
+                .filter(line => /^\s*-\s+\[[ xX]\]/.test(line));
+
+              for (const item of pmvItems) {
+                const refs = [...item.matchAll(/#(\d+)/g)].map(m => m[1]);
+
+                if (refs.length > 0 && refs.every(ref => closeNums.includes(ref))) {
+                  findings.push(`Post-Merge Validation item references only ticket(s) this PR closes — its home dies with the merge: ${item.trim()}`)
+                }
+              }
+
+              return findings
+            }
+            // #16829-CLOSE-RELATION-AUDIT-END
+
+            const closeRelationFindings = [];
+
+            if (hasResolves) {
+              const resolveNums = [...new Set([...body.matchAll(/\bResolves:?\s+#(\d+)/gi)].map(m => m[1]))];
+              const issueBodies = {};
+
+              for (const num of resolveNums) {
+                try {
+                  const issue = await github.rest.issues.get({
+                    owner: context.repo.owner, repo: context.repo.repo, issue_number: Number(num)
+                  });
+                  issueBodies[num] = issue.data.body || "";
+                } catch (err) {
+                  // a gate that cannot see its input must not pass silently — the core
+                  // converts the missing body into a finding below
+                  issueBodies[num] = null;
+                }
+              }
+
+              closeRelationFindings.push(...auditCloseRelations(body, issueBodies));
+            }
+
+            if (closeRelationFindings.length > 0) {
+              missingVisible.push(
+                "close-relation audit (#16829): " + closeRelationFindings.length + " orphaned item(s). " +
+                "Sanctioned repairs: (a) tick the delivered ACs on the ticket with their receipts; " +
+                "(b) annotate genuinely post-merge criteria on the ticket as `[L<N>-deferred — …]`; " +
+                "(c) split an L2-delivered leaf (#16776 pattern) and `Resolves` the leaf. " +
+                "Findings: " + closeRelationFindings.join(" | ")
+              );
+            }
+
+            // ──────────────────────────────────────────────────────────────────────
             // Stacked-PR guard (#15352). A PR branched off another feature branch —
             // rather than `dev` — carries that branch's commits. It is INVISIBLE to
             // every other gate: GitHub computes the file diff from the merge-base, so

--- a/test/playwright/unit/ai/scripts/lint/prBodyCloseRelationAudit.spec.mjs
+++ b/test/playwright/unit/ai/scripts/lint/prBodyCloseRelationAudit.spec.mjs
@@ -1,0 +1,182 @@
+import {test, expect} from '@playwright/test';
+import fs             from 'fs-extra';
+import path           from 'node:path';
+
+/**
+ * @summary Close-relation audit fixtures — the mechanical floor under the reviewer-side close-target audit.
+ *
+ * The decision core lives inline in the PR-body lint workflow (that file is sync-by-convention: no shared
+ * module). This spec slices the function out of the committed workflow between its sentinels — the shipped
+ * script is the only producer, never a copied twin — and drives the red/green corpus through it with the
+ * close-target bodies as injected input, so the gate is falsifiable off-CI.
+ *
+ * The corpus encodes the defect classes the gate exists for: a `Resolves` whose target carries unmet,
+ * un-annotated acceptance criteria (the named red case); the deferred-evidence annotation convention (the
+ * sanctioned escape); a Post-Merge Validation item whose only ticket home closes with the merge; and the
+ * no-reference verification box that must NOT fire (open-ended verification closes normally).
+ */
+
+const WORKFLOW_PATH = path.resolve(process.cwd(), '.github/workflows/agent-pr-body-lint.yml');
+
+/**
+ * Extracts `auditCloseRelations` from the committed workflow file. Fails loud when the sentinels are
+ * absent — a gate whose extraction contract breaks must go red, never silently test a stale twin.
+ * @returns {Function} The workflow's own decision core
+ */
+function loadAudit() {
+    const source = fs.readFileSync(WORKFLOW_PATH, 'utf8');
+    const begin  = source.indexOf('// #16829-CLOSE-RELATION-AUDIT-BEGIN');
+    const end    = source.indexOf('// #16829-CLOSE-RELATION-AUDIT-END');
+
+    if (begin === -1 || end === -1 || end <= begin) {
+        throw new Error('close-relation audit sentinels missing from agent-pr-body-lint.yml — the spec must extract the shipped function, never a copy')
+    }
+
+    return new Function(`${source.slice(begin, end)}; return auditCloseRelations;`)()
+}
+
+/**
+ * A PR body in the canonical defect shape: it resolves a ticket whose Post-Merge Validation box carries
+ * that ticket's unmet acceptance criterion verbatim, with no ticket reference of its own.
+ * @param {Object}   [overrides]
+ * @param {String}   [overrides.closes]  The `Resolves` target number
+ * @param {String[]} [overrides.pmv]     Post-Merge Validation checklist lines
+ * @param {String}   [overrides.refs]    Optional non-closing reference line
+ * @returns {String}
+ */
+function prBody({closes = '16806', pmv, refs = ''} = {}) {
+    const items = (pmv || [
+        "- [ ] `list_issues({assignee: '@me'})` against the merged server returns the caller's open lanes — identical set to `list_issues({assignee: '<caller login>'})`."
+    ]).join('\n');
+
+    return [
+        `Resolves #${closes}`,
+        refs,
+        '',
+        '## Test Evidence',
+        '',
+        'receipts',
+        '',
+        '## Post-Merge Validation',
+        '',
+        items,
+        '',
+        'Authored by a test.'
+    ].join('\n')
+}
+
+/**
+ * A close-target ticket body with the given Acceptance Criteria lines.
+ * @param {String[]} acLines
+ * @returns {String}
+ */
+function ticketBody(acLines) {
+    return [
+        '## The Problem',
+        '',
+        'context',
+        '',
+        '## Acceptance Criteria',
+        '',
+        ...acLines,
+        '',
+        '## Out of Scope',
+        ''
+    ].join('\n')
+}
+
+test.describe('agent-pr-body-lint close-relation audit (#16829)', () => {
+    let audit;
+
+    test.beforeAll(() => {
+        audit = loadAudit()
+    });
+
+    test('named red case: PR #16809 cycle-0 — an unmet, un-annotated AC on the close-target fails, naming ticket and criterion', () => {
+        const findings = audit(prBody(), {
+            '16806': ticketBody([
+                "- [ ] `list_issues({assignee: '@me'})` returns the same set as `list_issues({assignee: '<resolved login>'})` for the authenticated token.",
+                '- [x] Non-alias logins pass through with no added REST round-trip.'
+            ])
+        });
+
+        expect(findings.length, 'exactly one orphan: the unmet AC-1').toBe(1);
+        expect(findings[0]).toContain('#16806');
+        expect(findings[0]).toContain('returns the same set')
+    });
+
+    test('green: the same AC annotated `[L3-deferred]` is the sanctioned residual and passes', () => {
+        const findings = audit(prBody(), {
+            '16806': ticketBody([
+                "- [ ] [L3-deferred — post-merge live equivalence] `@me` returns the same set as the concrete login against the merged server.",
+                '- [x] Non-alias logins pass through with no added REST round-trip.'
+            ])
+        });
+
+        expect(findings).toEqual([])
+    });
+
+    test('green: a fully ticked close-target passes', () => {
+        const findings = audit(prBody(), {
+            '16806': ticketBody([
+                '- [x] alias resolves pre-query',
+                '- [x] failure path returns a named error'
+            ])
+        });
+
+        expect(findings).toEqual([])
+    });
+
+    test('red: a Post-Merge Validation item referencing only the close-target is a self-home orphan', () => {
+        const findings = audit(prBody({
+            pmv: ['- [ ] Verify the alias against the merged server (#16806 AC-1).']
+        }), {
+            '16806': ticketBody(['- [x] alias resolves pre-query'])
+        });
+
+        expect(findings.length, 'the item\'s only home closes with the merge').toBe(1);
+        expect(findings[0]).toContain('Post-Merge Validation')
+    });
+
+    test('green control: a no-reference PMV item against a fully-ticked target rides free (the #16796 open-ended-verification shape)', () => {
+        const findings = audit(prBody({closes: '16800'}), {
+            '16800': ticketBody(['- [x] digest derived above the watermark'])
+        });
+
+        expect(findings, '§5.2 rule 4: open-ended verification closes normally').toEqual([])
+    });
+
+    test('green control: a PMV item citing a `Refs`-referenced open parent survives (the leaf-split shape)', () => {
+        const findings = audit(prBody({
+            closes: '16828',
+            pmv   : ['- [ ] live equivalence against the merged server (= #16806 AC-1, verbatim; the parent stays open for it).'],
+            refs  : 'Refs #16806'
+        }), {
+            '16828': ticketBody(['- [x] alias resolves pre-query'])
+        });
+
+        expect(findings).toEqual([])
+    });
+
+    test('red: a close-target body the audit could not obtain is a loud failure, never a silent pass', () => {
+        const findings = audit(prBody(), {});
+
+        expect(findings.length).toBe(1);
+        expect(findings[0]).toContain('#16806');
+        expect(findings[0]).toContain('must not pass silently')
+    });
+
+    test('green: a body without close keywords produces no findings', () => {
+        const findings = audit(prBody({pmv: []}).replace('Resolves #16806', 'Refs #16806'), {});
+
+        expect(findings).toEqual([])
+    });
+
+    test('the failure annotation teaches: all three sanctioned repairs are named verbatim in the workflow', () => {
+        const source = fs.readFileSync(WORKFLOW_PATH, 'utf8');
+
+        expect(source).toContain('(a) tick the delivered ACs on the ticket with their receipts');
+        expect(source).toContain('[L<N>-deferred');
+        expect(source).toContain('(c) split an L2-delivered leaf (#16776 pattern) and `Resolves` the leaf')
+    });
+});


### PR DESCRIPTION
Resolves #16829

Adds the mechanical floor under `pr-review-guide.md §5.2` to `.github/workflows/agent-pr-body-lint.yml`. GitHub auto-close is textual; until this PR the fleet's only defense against a `Resolves #N` closing a ticket with unmet acceptance criteria was reviewer discipline — which caught the shape twice in one day at full review-cycle cost and missed it once until after merge. The workflow now audits every close-target's `## Acceptance Criteria` section: an unchecked, un-annotated item fails the lint. `[L<N>-deferred]` annotated residuals pass by construction (the sanctioned escape). A Post-Merge Validation item whose every ticket reference is itself being closed fails as a self-home orphan; no-reference items ride free (open-ended verification closes normally — the control shape).

Intake note (self-authored carve): filed, amended pre-implementation (the first draft's "no API in the lint" trap was the wrong axis — the decision core is pure, the fetch is CI-native), and self-assigned this session; the six-stage chain ran at creation.

## Deltas from ticket

One, recorded in the ticket's own amendment: the purely-textual first prescription both over-fired (the no-reference PMV control) and under-fired (the verbatim-AC case), so the decidable signal moved to the close-target's AC list, with the fetch injected at the call site and the decision core kept pure for off-CI falsifiability. Everything else is as prescribed: sentinel-sliced single producer, three-repair teaching annotation, no weakening of the mandatory-`Resolves` rule.

## Test Evidence

`UNIT_TEST_MODE=true npx playwright test -c test/playwright/playwright.config.unit.mjs test/playwright/unit/ai/scripts/lint/prBodyCloseRelationAudit.spec.mjs` → **11 passed** (8 red/green corpus fixtures + the annotation teaching-text pin + 2 infra). The spec extracts `auditCloseRelations` from the committed workflow YAML between sentinels — never a copied twin.

Red direction, stash-verified: against the pre-fix workflow the spec fails on every test with "sentinels missing … never a copy" — the extraction contract refuses a silent twin.

YAML + compile: the workflow parses (`js-yaml`) and the full inline script compiles (`new Function` async wrap) — a syntax break in this file fails every PR's lint, so both are proven locally before push.

Pre-commit battery: run manually this session (the seat's husky `pre-commit` shim is mode 100644 in-repo, so the hook did not auto-fire — its own commands ran green instead: chore-sync, shorthand, jsdoc-types, aiconfig-test-mutation, derived-domain, ticket-archaeology, block-alignment, parse).

Self-audit: this PR's body says `Resolves #16829`; the ticket's ACs are ticked with these receipts, so the new gate passes its own first live run on this PR.

`.github/workflows/agent-pr-body-lint.yml` + `test/playwright/unit/ai/scripts/lint/prBodyCloseRelationAudit.spec.mjs`: covered by the new spec (11/11) and the job's own CI run on this PR.

Evidence: L3 (the decision core executes locally against fixture corpora extracted from the committed workflow; the CI job runs the same code path live on this PR) → L3 required (CI-gate change, locally falsifiable). Residual: none.

## Post-Merge Validation

- [ ] Watch the next `Resolves #N` PR with an unmet-AC target trip the gate with the teaching annotation (first live red), and confirm no false fires on routine fully-ticked closes.

Authored by Iris (Kimi K3, Kimi Code CLI). Session d05afdba-d7f9-4733-b9da-e1a8a7946777.
