### PR TITLE
feat(ai): compactToolSchemas — schema prose leaves tools/list, relocates to the handbook (#16588)

### DIFF
--- a/ai/mcp/ToolService.mjs
+++ b/ai/mcp/ToolService.mjs
@@ -43,6 +43,15 @@ class ToolService_tmp extends Base {
          */
         compactToolDescriptions: false,
         /**
+         * Strips `description` prose from the schemas emitted through `tools/list`, recursively,
+         * while preserving every shape-bearing key — `description` is a JSON Schema annotation and
+         * is never asserted, so the projected schema validates the identical accept/reject set.
+         * The fully-described schema relocates into `getToolHandbook()` — relocated, not deleted.
+         * Sibling of `compactToolDescriptions`: same default-off, same per-server opt-in.
+         * @member {Boolean} compactToolSchemas=false
+         */
+        compactToolSchemas: false,
+        /**
          * Maximum description length emitted through compact `tools/list`.
          * @member {Number} toolListDescriptionMaxLength=160
          */
@@ -201,16 +210,33 @@ class ToolService_tmp extends Base {
                     };
                     me.toolMapping[toolName] = tool;
                     me.toolProjectionTiers[toolName] = toolTier;
-                    me.toolHandbookMapping[toolName] = me.buildToolHandbookEntry(toolName, operation, fullDescription);
+                    // The prose/schema split: the listing carries shape only when compaction is on,
+                    // and the handbook is where the fully-described schema lives — the same lazy
+                    // surface the compacted operation description already defers to. The described
+                    // originals are never mutated; the listing gets fresh projected objects.
+                    me.toolHandbookMapping[toolName] = me.buildToolHandbookEntry(toolName, operation, fullDescription,
+                        me.compactToolSchemas
+                            ? {inputSchema: inputJsonSchema, outputSchema: outputJsonSchema}
+                            : null
+                    );
+
+                    const listedInputSchema = me.compactToolSchemas
+                        ? me.stripSchemaDescriptions(inputJsonSchema)
+                        : inputJsonSchema;
+
+                    let listedOutputSchema = outputJsonSchema;
+                    if (me.compactToolSchemas && outputJsonSchema !== null) {
+                        listedOutputSchema = me.stripSchemaDescriptions(outputJsonSchema)
+                    }
 
                     const toolForListing = {
                         name       : tool.name,
                         title      : tool.title,
                         description: tool.description,
-                        inputSchema: inputJsonSchema
+                        inputSchema: listedInputSchema
                     };
-                    if (outputJsonSchema !== null) {
-                        toolForListing.outputSchema = outputJsonSchema;
+                    if (listedOutputSchema !== null) {
+                        toolForListing.outputSchema = listedOutputSchema;
                     }
                     if (operation['x-annotations'] !== null) {
                         toolForListing.annotations = operation['x-annotations'];
@@ -339,19 +365,60 @@ class ToolService_tmp extends Base {
     }
 
     /**
+     * @summary Projects a JSON Schema for `tools/list` by removing every `description` key,
+     * recursively.
+     *
+     * Blacklist, not whitelist: ONLY `description` is dropped, so every shape-bearing key —
+     * `type`, `required`, `enum`, `properties`, `items`, `additionalProperties`, `$ref`, `format`,
+     * `default`, and any future assertion keyword — survives by construction. That is what makes
+     * the projection validation-neutral: in JSON Schema, `description` is an annotation and is
+     * never part of the accept/reject semantics, so a stripped schema accepts and rejects exactly
+     * the set the described one did. A whitelist would silently drop the next assertion keyword the
+     * contract starts using.
+     *
+     * Returns fresh objects — the described input is never mutated, because the handbook surface
+     * keeps it (the prose is relocated, not deleted).
+     * @param {*} schema
+     * @returns {*}
+     * @protected
+     */
+    stripSchemaDescriptions(schema) {
+        if (Array.isArray(schema)) {
+            return schema.map(item => this.stripSchemaDescriptions(item))
+        }
+
+        if (schema && typeof schema === 'object') {
+            const projected = {};
+
+            for (const [key, value] of Object.entries(schema)) {
+                if (key !== 'description') {
+                    projected[key] = this.stripSchemaDescriptions(value)
+                }
+            }
+
+            return projected
+        }
+
+        return schema
+    }
+
+    /**
      * @summary Builds one lazy-loaded handbook entry from OpenAPI metadata.
      * @param {String} toolName        The operation id.
      * @param {Object} operation       Parsed OpenAPI operation.
      * @param {String} fullDescription Full operation description fallback.
+     * @param {Object|null} [schemas]  The fully-described JSON schemas (`{inputSchema, outputSchema}`),
+     *     passed only when `compactToolSchemas` stripped them from the listing — the prose is
+     *     relocated here, never deleted. `null` keeps the pre-compaction entry shape byte-identical.
      * @returns {Object}
      * @protected
      */
-    buildToolHandbookEntry(toolName, operation, fullDescription) {
+    buildToolHandbookEntry(toolName, operation, fullDescription, schemas=null) {
         const
             dedicated = operation['x-neo-tool-handbook'],
             handbook  = dedicated || fullDescription || operation.summary || toolName;
 
-        return {
+        const entry = {
             toolId     : toolName,
             found      : true,
             title      : operation.summary || toolName,
@@ -359,6 +426,16 @@ class ToolService_tmp extends Base {
             handbook,
             source     : dedicated ? 'x-neo-tool-handbook' : (operation.description ? 'description' : 'summary')
         };
+
+        if (schemas) {
+            entry.inputSchema = schemas.inputSchema;
+
+            if (schemas.outputSchema !== null) {
+                entry.outputSchema = schemas.outputSchema
+            }
+        }
+
+        return entry
     }
 
     /**

--- a/ai/mcp/ToolService.mjs
+++ b/ai/mcp/ToolService.mjs
@@ -365,16 +365,21 @@ class ToolService_tmp extends Base {
     }
 
     /**
-     * @summary Projects a JSON Schema for `tools/list` by removing every `description` key,
-     * recursively.
+     * @summary Projects a JSON Schema for `tools/list` by removing every annotation-position
+     * `description` — position-aware, never key-name-blind.
      *
-     * Blacklist, not whitelist: ONLY `description` is dropped, so every shape-bearing key —
-     * `type`, `required`, `enum`, `properties`, `items`, `additionalProperties`, `$ref`, `format`,
-     * `default`, and any future assertion keyword — survives by construction. That is what makes
-     * the projection validation-neutral: in JSON Schema, `description` is an annotation and is
-     * never part of the accept/reject semantics, so a stripped schema accepts and rejects exactly
-     * the set the described one did. A whitelist would silently drop the next assertion keyword the
-     * contract starts using.
+     * `description` is an annotation ONLY where a schema object carries it. The walker descends
+     * exclusively into schema-valued positions — the `properties` / `$defs` / `patternProperties` /
+     * `dependentSchemas` maps, the `items` / `contains` / `additionalProperties` / `not` / `if` /
+     * `then` / `else` subschemas, and the `oneOf` / `anyOf` / `allOf` / `prefixItems` arrays —
+     * and copies everything else verbatim. Three failure modes are excluded by construction:
+     *
+     * - an APPLICATION property named `description` (a key under `properties`) is data, not an
+     *   annotation: the property declaration survives; only its own annotation is stripped;
+     * - object-valued assertion data (`enum`, `const`, `default`, `examples`) is never descended
+     *   into, so a `description` key inside a default value survives untouched;
+     * - a keyword the walker does not know is copied rather than recursed, so the next schema
+     *   feature the contract adopts cannot be silently mangled — at worst its prose stays.
      *
      * Returns fresh objects — the described input is never mutated, because the handbook surface
      * keeps it (the prose is relocated, not deleted).
@@ -383,23 +388,49 @@ class ToolService_tmp extends Base {
      * @protected
      */
     stripSchemaDescriptions(schema) {
+        if (!schema || typeof schema !== 'object') {
+            return schema
+        }
+
         if (Array.isArray(schema)) {
             return schema.map(item => this.stripSchemaDescriptions(item))
         }
 
-        if (schema && typeof schema === 'object') {
-            const projected = {};
+        const
+            SCHEMA_MAP_KEYS   = new Set(['properties', '$defs', 'patternProperties', 'dependentSchemas']),
+            SUBSCHEMA_KEYS    = new Set(['items', 'additionalItems', 'additionalProperties', 'unevaluatedProperties', 'contains', 'propertyNames', 'not', 'if', 'then', 'else']),
+            SCHEMA_ARRAY_KEYS = new Set(['oneOf', 'anyOf', 'allOf', 'prefixItems']),
+            projected         = {};
 
-            for (const [key, value] of Object.entries(schema)) {
-                if (key !== 'description') {
-                    projected[key] = this.stripSchemaDescriptions(value)
+        for (const [key, value] of Object.entries(schema)) {
+            if (key === 'description') {
+                continue // the annotation at THIS schema position
+            }
+
+            if (value && typeof value === 'object') {
+                if (SCHEMA_MAP_KEYS.has(key)) {
+                    projected[key] = Object.fromEntries(
+                        Object.entries(value).map(([name, subschema]) => [name, this.stripSchemaDescriptions(subschema)])
+                    );
+                    continue
+                }
+
+                if (SUBSCHEMA_KEYS.has(key)) {
+                    projected[key] = this.stripSchemaDescriptions(value);
+                    continue
+                }
+
+                if (SCHEMA_ARRAY_KEYS.has(key) && Array.isArray(value)) {
+                    projected[key] = value.map(subschema => this.stripSchemaDescriptions(subschema));
+                    continue
                 }
             }
 
-            return projected
+            // type / required / enum / const / default / format / $ref / unknown keys: verbatim.
+            projected[key] = value
         }
 
-        return schema
+        return projected
     }
 
     /**
@@ -657,8 +688,16 @@ class ToolService_tmp extends Base {
             return Object.entries(exactProfile.tools).map(([toolName, profileTool]) => {
                 const tool = me.allToolsForListing.find(candidate => candidate.name === toolName);
 
+                // The profile's constrained schema replaces the default one — and must ride the
+                // SAME prose projection as the default listing, or a harness-projected seat gets
+                // the full description payload the compaction exists to keep off the wire.
                 return profileTool.inputJsonSchema
-                    ? {...tool, inputSchema: profileTool.inputJsonSchema}
+                    ? {
+                        ...tool,
+                        inputSchema: me.compactToolSchemas
+                            ? me.stripSchemaDescriptions(profileTool.inputJsonSchema)
+                            : profileTool.inputJsonSchema
+                    }
                     : tool;
             });
         }

--- a/ai/mcp/ToolService.mjs
+++ b/ai/mcp/ToolService.mjs
@@ -688,16 +688,14 @@ class ToolService_tmp extends Base {
             return Object.entries(exactProfile.tools).map(([toolName, profileTool]) => {
                 const tool = me.allToolsForListing.find(candidate => candidate.name === toolName);
 
-                // The profile's constrained schema replaces the default one — and must ride the
-                // SAME prose projection as the default listing, or a harness-projected seat gets
-                // the full description payload the compaction exists to keep off the wire.
+                // Exact-profile schemas are served DESCRIBED by design, compaction or not: a
+                // profile is a curated minimal surface (local-readonly-probe exposes 3 tools),
+                // and `get_mcp_tool_handbook` itself is policy-refused inside the projection —
+                // so the listing is the ONLY surface where the profile's constraint prose
+                // (depth bounds, forced flags) can reach a projected seat. Compaction targets
+                // the full default listing, never these.
                 return profileTool.inputJsonSchema
-                    ? {
-                        ...tool,
-                        inputSchema: me.compactToolSchemas
-                            ? me.stripSchemaDescriptions(profileTool.inputJsonSchema)
-                            : profileTool.inputJsonSchema
-                    }
+                    ? {...tool, inputSchema: profileTool.inputJsonSchema}
                     : tool;
             });
         }

--- a/ai/mcp/ToolService.mjs
+++ b/ai/mcp/ToolService.mjs
@@ -662,7 +662,21 @@ class ToolService_tmp extends Base {
 
         const canonicalSurface = me.getToolsForProjection(toolProjection)
             .filter(Boolean)
-            .map(tool => ({name: tool.name, inputSchema: tool.inputSchema ?? null}))
+            .map(tool => {
+                let inputSchema = tool.inputSchema ?? null;
+
+                // The digest's axis is capability reachability, never copy-freshness. With schema
+                // compaction on, hash the VALIDATION SHAPE (annotation prose stripped) even when a
+                // route deliberately lists prose — the exact-profile exception keeps its constraint
+                // documentation on the listing because the handbook is policy-refused there, and a
+                // docs-only reword must not read as a capability change. Idempotent on the default
+                // route, whose listed schemas are already projected.
+                if (me.compactToolSchemas && inputSchema) {
+                    inputSchema = me.stripSchemaDescriptions(inputSchema)
+                }
+
+                return {name: tool.name, inputSchema};
+            })
             .sort((lhs, rhs) => lhs.name < rhs.name ? -1 : lhs.name > rhs.name ? 1 : 0);
 
         return crypto.createHash('sha256').update(me.canonicalize(canonicalSurface)).digest('hex').slice(0, 12)

--- a/ai/mcp/server/file-system/openapi.yaml
+++ b/ai/mcp/server/file-system/openapi.yaml
@@ -88,6 +88,10 @@ paths:
                     type: string
                   message:
                     type: string
+                  inputSchema:
+                    type: object
+                  outputSchema:
+                    type: object
 
   /read_file:
     post:

--- a/ai/mcp/server/file-system/services/toolService.mjs
+++ b/ai/mcp/server/file-system/services/toolService.mjs
@@ -1,7 +1,7 @@
-import path               from 'path';
-import {fileURLToPath}    from 'url';
-import FileSystemService  from './FileSystemService.mjs';
-import ToolService        from '../../../ToolService.mjs';
+import path              from 'path';
+import {fileURLToPath}   from 'url';
+import FileSystemService from './FileSystemService.mjs';
+import ToolService       from '../../../ToolService.mjs';
 
 const __filename      = fileURLToPath(import.meta.url);
 const __dirname       = path.dirname(__filename);
@@ -18,7 +18,8 @@ const serviceMapping = {
 };
 
 const toolService = Neo.create(ToolService, {
-    compactToolDescriptions    : true,
+    compactToolDescriptions     : true,
+    compactToolSchemas          : true,
     openApiFilePath,
     serviceMapping,
     toolListDescriptionMaxLength: 120

--- a/ai/mcp/server/github-workflow/openapi.yaml
+++ b/ai/mcp/server/github-workflow/openapi.yaml
@@ -128,6 +128,10 @@ paths:
                     type: string
                   message:
                     type: string
+                  inputSchema:
+                    type: object
+                  outputSchema:
+                    type: object
 
   /labels:
     get:

--- a/ai/mcp/server/github-workflow/toolService.mjs
+++ b/ai/mcp/server/github-workflow/toolService.mjs
@@ -465,6 +465,7 @@ export {
 
 const toolService = Neo.create(ToolService, {
     compactToolDescriptions     : true,
+    compactToolSchemas          : true,
     openApiFilePath,
     serviceMapping              : guardedServiceMapping,
     toolListDescriptionMaxLength: 120

--- a/ai/mcp/server/gitlab-workflow/openapi.yaml
+++ b/ai/mcp/server/gitlab-workflow/openapi.yaml
@@ -62,6 +62,10 @@ paths:
                     type: string
                   message:
                     type: string
+                  inputSchema:
+                    type: object
+                  outputSchema:
+                    type: object
 
   /issues:
     get:

--- a/ai/mcp/server/gitlab-workflow/toolService.mjs
+++ b/ai/mcp/server/gitlab-workflow/toolService.mjs
@@ -18,24 +18,25 @@ const openApiFilePath = path.join(__dirname, 'openapi.yaml');
  * local-file syncer surface remains scaffold-level pending its subtask.
  */
 const serviceMapping = {
-    create_issue           : IssueService       .createIssue                .bind(IssueService),
-    get_local_issue_by_id  : LocalFileService   .getIssueById               .bind(LocalFileService),
-    get_mcp_tool_handbook  : toolId => toolService.getToolHandbook(toolId),
-    get_merge_request      : MergeRequestService.getMergeRequest            .bind(MergeRequestService),
-    healthcheck            : HealthService      .healthcheck                .bind(HealthService),
-    list_issues            : IssueService       .listIssues                 .bind(IssueService),
-    list_merge_requests    : MergeRequestService.listMergeRequests          .bind(MergeRequestService),
-    manage_issue_assignees : IssueService       .manageIssueAssignees       .bind(IssueService),
-    manage_issue_comment   : IssueService       .manageIssueComment         .bind(IssueService),
-    manage_issue_labels    : IssueService       .manageIssueLabels          .bind(IssueService),
-    manage_mr_assignees    : MergeRequestService.manageMergeRequestAssignees.bind(MergeRequestService),
-    manage_mr_comment      : MergeRequestService.manageMergeRequestComment  .bind(MergeRequestService),
-    manage_mr_labels       : MergeRequestService.manageMergeRequestLabels   .bind(MergeRequestService),
-    manage_mr_reviewers    : MergeRequestService.manageMergeRequestReviewers.bind(MergeRequestService)
+    create_issue          : IssueService       .createIssue                .bind(IssueService),
+    get_local_issue_by_id : LocalFileService   .getIssueById               .bind(LocalFileService),
+    get_mcp_tool_handbook : toolId => toolService.getToolHandbook(toolId),
+    get_merge_request     : MergeRequestService.getMergeRequest            .bind(MergeRequestService),
+    healthcheck           : HealthService      .healthcheck                .bind(HealthService),
+    list_issues           : IssueService       .listIssues                 .bind(IssueService),
+    list_merge_requests   : MergeRequestService.listMergeRequests          .bind(MergeRequestService),
+    manage_issue_assignees: IssueService       .manageIssueAssignees       .bind(IssueService),
+    manage_issue_comment  : IssueService       .manageIssueComment         .bind(IssueService),
+    manage_issue_labels   : IssueService       .manageIssueLabels          .bind(IssueService),
+    manage_mr_assignees   : MergeRequestService.manageMergeRequestAssignees.bind(MergeRequestService),
+    manage_mr_comment     : MergeRequestService.manageMergeRequestComment  .bind(MergeRequestService),
+    manage_mr_labels      : MergeRequestService.manageMergeRequestLabels   .bind(MergeRequestService),
+    manage_mr_reviewers   : MergeRequestService.manageMergeRequestReviewers.bind(MergeRequestService)
 };
 
 const toolService = Neo.create(ToolService, {
-    compactToolDescriptions    : true,
+    compactToolDescriptions     : true,
+    compactToolSchemas          : true,
     openApiFilePath,
     serviceMapping,
     toolListDescriptionMaxLength: 120

--- a/ai/mcp/server/knowledge-base/openapi.yaml
+++ b/ai/mcp/server/knowledge-base/openapi.yaml
@@ -153,6 +153,10 @@ paths:
                     type: string
                   message:
                     type: string
+                  inputSchema:
+                    type: object
+                  outputSchema:
+                    type: object
 
   /deployment/state/snapshot:
     post:

--- a/ai/mcp/server/knowledge-base/toolService.mjs
+++ b/ai/mcp/server/knowledge-base/toolService.mjs
@@ -81,7 +81,8 @@ const serviceMapping = {
 };
 
 const toolService = Neo.create(ToolService, {
-    compactToolDescriptions     : true,
+    compactToolDescriptions: true,
+    compactToolSchemas     : true,
     // The server config owns the OpenAPI-contract path (default + the test-isolation env
     // binding) — consumed at the use site, never re-derived from env here.
     openApiFilePath             : kbConfig.openApiPath,

--- a/ai/mcp/server/memory-core/openapi.yaml
+++ b/ai/mcp/server/memory-core/openapi.yaml
@@ -205,6 +205,10 @@ paths:
                     type: string
                   message:
                     type: string
+                  inputSchema:
+                    type: object
+                  outputSchema:
+                    type: object
 
   /diagnostics/tool-metrics:
     post:

--- a/ai/mcp/server/memory-core/toolService.mjs
+++ b/ai/mcp/server/memory-core/toolService.mjs
@@ -287,6 +287,7 @@ const serviceMapping = {
 
 const toolService = Neo.create(ToolService, {
     compactToolDescriptions     : true,
+    compactToolSchemas          : true,
     openApiFilePath,
     serviceMapping,
     toolListDescriptionMaxLength: 120

--- a/ai/mcp/server/neural-link/openapi.yaml
+++ b/ai/mcp/server/neural-link/openapi.yaml
@@ -128,6 +128,10 @@ paths:
                     type: string
                   message:
                     type: string
+                  inputSchema:
+                    type: object
+                  outputSchema:
+                    type: object
 
   /check_namespace:
     post:

--- a/ai/mcp/server/neural-link/toolService.mjs
+++ b/ai/mcp/server/neural-link/toolService.mjs
@@ -81,6 +81,7 @@ const serviceMapping = {
 
 const toolService = Neo.create(ToolService, {
     compactToolDescriptions     : true,
+    compactToolSchemas          : true,
     openApiFilePath,
     serviceMapping,
     toolListDescriptionMaxLength: 120

--- a/test/playwright/unit/ai/mcp/advertisedSurfaceDigest.spec.mjs
+++ b/test/playwright/unit/ai/mcp/advertisedSurfaceDigest.spec.mjs
@@ -91,6 +91,21 @@ test.describe('ToolService advertised-surface digest', () => {
         expect(reworded).toBe(withDescription)
     });
 
+    test('the digest covers the projected listing shape — prose leaking into a listed schema moves it (#16588)', () => {
+        // With compactToolSchemas the listing is prose-free by construction, so schema descriptions
+        // can no longer move this digest. The canary for the regression direction: if prose ever
+        // reappears IN the list payload, the digest must shift — a silent reintroduction fails here.
+        const stripped = serviceWith([
+            {name: 'alpha', inputSchema: {type: 'object', properties: {a: {type: 'string'}}}}
+        ]).getAdvertisedSurfaceDigest();
+
+        const withProse = serviceWith([
+            {name: 'alpha', inputSchema: {type: 'object', properties: {a: {type: 'string', description: 'prose that must never ride the listing'}}}}
+        ]).getAdvertisedSurfaceDigest();
+
+        expect(withProse).not.toBe(stripped)
+    });
+
     test('tool order and object-key order do not change the digest', () => {
         const ordered = serviceWith([
             {name: 'alpha', inputSchema: {type: 'object', properties: {a: {type: 'string'}}}},

--- a/test/playwright/unit/ai/mcp/schemaCompaction.spec.mjs
+++ b/test/playwright/unit/ai/mcp/schemaCompaction.spec.mjs
@@ -1,0 +1,188 @@
+import {setup} from '../../../setup.mjs';
+
+const appName = 'McpSchemaCompactionTest';
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name             : appName,
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect}  from '@playwright/test';
+import path            from 'path';
+import {fileURLToPath} from 'url';
+import Neo             from '../../../../../src/Neo.mjs';
+
+/**
+ * The `tools/list` schema-prose projection (`compactToolSchemas`).
+ *
+ * The description compaction (`compactToolDescriptions`) capped the operation line but shipped the
+ * schemas beside it whole: every `description:` inside `inputSchema` / `outputSchema` rode the
+ * listing in full — measured at ~49.8KB across 666 fields on five servers, ≥74% of the remaining
+ * description payload. The projection here strips ONLY the `description` annotation key,
+ * recursively, so shape (and therefore the accept/reject semantics MCP clients validate against)
+ * is unchanged by construction; the fully-described schema relocates into the lazy handbook
+ * payload — relocated, never deleted.
+ *
+ * The file-system server (7 operations, the smallest real contract) is the live witness; the
+ * sibling advertisedSurfaceDigest.spec.mjs carries the digest-canary half (AC-5).
+ */
+test.describe('ToolService compactToolSchemas — the schema-prose projection (#16588)', () => {
+    const
+        __filename = fileURLToPath(import.meta.url),
+        __dirname  = path.dirname(__filename),
+        repoRoot   = path.resolve(__dirname, '../../../../..');
+
+    let ToolService;
+
+    test.beforeAll(async () => {
+        ToolService = (await import('../../../../../ai/mcp/ToolService.mjs')).default
+    });
+
+    /**
+     * @summary Collects every `description` value under a schema node, recursively.
+     * @param {*} node
+     * @param {String[]} [hits]
+     * @returns {String[]}
+     */
+    function collectDescriptions(node, hits=[]) {
+        if (Array.isArray(node)) {
+            node.forEach(item => collectDescriptions(item, hits))
+        } else if (node && typeof node === 'object') {
+            Object.entries(node).forEach(([key, value]) => {
+                if (key === 'description') {
+                    hits.push(value)
+                } else {
+                    collectDescriptions(value, hits)
+                }
+            })
+        }
+
+        return hits
+    }
+
+    test.describe('stripSchemaDescriptions — the pure projection', () => {
+        // Every shape-bearing keyword the contract uses today, with prose at every level.
+        const DESCRIBED = Object.freeze({
+            type       : 'object',
+            description: 'root prose',
+            properties : {
+                name: {type: 'string', description: 'name prose'},
+                tags: {type: 'array', description: 'tags prose', items: {type: 'string', description: 'item prose'}},
+                mode: {enum: ['a', 'b'], description: 'mode prose', default: 'a'}
+            },
+            required            : ['name'],
+            additionalProperties: {type: 'number', description: 'ap prose'},
+            oneOf               : [{type: 'null', description: 'oneOf prose'}],
+            $defs               : {entry: {type: 'string', description: 'def prose', format: 'uuid'}}
+        });
+
+        // The accept/reject proof: the projection must equal the fixture minus annotation keys
+        // exactly — `description` is never asserted by JSON Schema, so this twin validates the
+        // identical set. A whitelist slip (a dropped assertion keyword) fails this equality.
+        const STRIPPED_TWIN = {
+            type      : 'object',
+            properties: {
+                name: {type: 'string'},
+                tags: {type: 'array', items: {type: 'string'}},
+                mode: {enum: ['a', 'b'], default: 'a'}
+            },
+            required            : ['name'],
+            additionalProperties: {type: 'number'},
+            oneOf               : [{type: 'null'}],
+            $defs               : {entry: {type: 'string', format: 'uuid'}}
+        };
+
+        test('drops every description key, recursively, and nothing else', () => {
+            const service  = Object.create(ToolService.prototype),
+                  stripped = service.stripSchemaDescriptions(DESCRIBED);
+
+            expect(stripped).toEqual(STRIPPED_TWIN);
+            expect(collectDescriptions(stripped)).toEqual([])
+        });
+
+        test('never mutates the described input — the handbook keeps the prose', () => {
+            const service  = Object.create(ToolService.prototype),
+                  stripped = service.stripSchemaDescriptions(DESCRIBED);
+
+            expect(stripped).not.toBe(DESCRIBED);
+            expect(collectDescriptions(DESCRIBED)).toHaveLength(8)
+        });
+
+        test('arrays and scalars pass through; null stays null', () => {
+            const service = Object.create(ToolService.prototype);
+
+            expect(service.stripSchemaDescriptions(null)).toBe(null);
+            expect(service.stripSchemaDescriptions('description')).toBe('description');
+            expect(service.stripSchemaDescriptions([{description: 'x', type: 'string'}])).toEqual([{type: 'string'}])
+        })
+    });
+
+    test.describe('the real file-system contract — listing stripped, handbook described', () => {
+        let fsService, tools;
+
+        test.beforeAll(async () => {
+            fsService      = await import('../../../../../ai/mcp/server/file-system/services/toolService.mjs');
+            ({tools}       = await fsService.listTools())
+        });
+
+        test('AC-1: no description key survives anywhere in a listed schema', () => {
+            expect(tools.length).toBeGreaterThan(0);
+
+            for (const tool of tools) {
+                expect(collectDescriptions(tool.inputSchema), `${tool.name}.inputSchema`).toEqual([]);
+
+                if (tool.outputSchema) {
+                    expect(collectDescriptions(tool.outputSchema), `${tool.name}.outputSchema`).toEqual([])
+                }
+            }
+        });
+
+        test('AC-3: the handbook payload carries the fully-described schema — relocated, not deleted', async () => {
+            // The file-system contract authors 27 description fields; at least one tool must pair
+            // a prose-free listing with a prose-carrying handbook entry.
+            let paired = 0;
+
+            for (const tool of tools) {
+                const handbook  = await fsService.callTool('get_mcp_tool_handbook', {toolId: tool.name}),
+                      inSchema  = collectDescriptions(handbook.inputSchema),
+                      outSchema = handbook.outputSchema ? collectDescriptions(handbook.outputSchema) : [];
+
+                if (inSchema.length + outSchema.length > 0) {
+                    paired++;
+                    expect(collectDescriptions(tool.inputSchema)).toEqual([])
+                }
+            }
+
+            expect(paired, 'the authored prose must reach the handbook of at least one tool').toBeGreaterThan(0)
+        })
+    });
+
+    test.describe('AC-4: default-off is byte-identical to the pre-flag behavior', () => {
+        test('a fresh service without the flag lists described schemas and a schema-free handbook', async () => {
+            const service = Neo.create(ToolService, {
+                    openApiFilePath: path.join(repoRoot, 'ai/mcp/server/file-system/openapi.yaml'),
+                    serviceMapping : {}
+                }),
+                {tools} = await service.listTools();
+
+            expect(tools.length).toBeGreaterThan(0);
+            expect(service.compactToolSchemas).toBe(false);
+
+            // the listing still carries prose…
+            const described = tools.filter(tool => collectDescriptions(tool.inputSchema).length > 0);
+            expect(described.length, 'default-off keeps the descriptions on the listing').toBeGreaterThan(0);
+
+            // …and the handbook entry shape is untouched — no relocated schema keys.
+            const handbook = service.getToolHandbook(tools[0].name);
+            expect(handbook.inputSchema).toBeUndefined();
+            expect(handbook.outputSchema).toBeUndefined();
+            expect(Object.keys(handbook).sort()).toEqual(['description', 'found', 'handbook', 'source', 'title', 'toolId'])
+        })
+    })
+});

--- a/test/playwright/unit/ai/mcp/schemaCompaction.spec.mjs
+++ b/test/playwright/unit/ai/mcp/schemaCompaction.spec.mjs
@@ -16,6 +16,8 @@ setup({
 import {test, expect}  from '@playwright/test';
 import Ajv             from 'ajv';
 import crypto          from 'node:crypto';
+import fs              from 'node:fs';
+import os              from 'node:os';
 import path            from 'path';
 import {fileURLToPath} from 'url';
 import Neo             from '../../../../../src/Neo.mjs';
@@ -312,6 +314,49 @@ test.describe('ToolService compactToolSchemas — the schema-prose projection (#
 
             expect(service.getAdvertisedSurfaceDigest()).toBe(expected);
             expect(listing.every(tool => collectDescriptions(tool.inputSchema).length === 0)).toBe(true)
+        });
+
+        test('exact-profile prose does NOT shift the capability digest; a validation-shape edit DOES', async () => {
+            // The digest's axis is capability reachability. The exact-profile exception keeps
+            // prose on the listing (the handbook is policy-refused in-profile), so the digest
+            // must normalize to the validation shape — a docs-only reword is not a new surface.
+            const
+                yamlPath    = path.join(repoRoot, 'ai/mcp/server/neural-link/openapi.yaml'),
+                yamlText    = fs.readFileSync(yamlPath, 'utf8'),
+                proseAnchor = 'Bounded structural depth. 1=Self, 2=Self+Children.',
+                shapeAnchor = 'maximum: 2';
+
+            expect(yamlText).toContain(proseAnchor);
+            expect(yamlText).toContain(shapeAnchor);
+
+            const
+                proseVariant = yamlText.replace(proseAnchor, 'Depth of the tree walk, bounded. 1 is self, 2 adds children.'),
+                shapeVariant = yamlText.replace(shapeAnchor, 'maximum: 3'),
+                tmpDir       = fs.mkdtempSync(path.join(os.tmpdir(), 'neo-schema-compaction-')),
+                prosePath    = path.join(tmpDir, 'prose.yaml'),
+                shapePath    = path.join(tmpDir, 'shape.yaml');
+
+            fs.writeFileSync(prosePath, proseVariant);
+            fs.writeFileSync(shapePath, shapeVariant);
+
+            const digestOf = async openApiFilePath => {
+                const service = Neo.create(ToolService, {
+                    compactToolSchemas: true,
+                    openApiFilePath,
+                    serviceMapping    : {}
+                });
+
+                await service.listTools();
+
+                return service.getAdvertisedSurfaceDigest('local-readonly-probe')
+            };
+
+            const baseline = await digestOf(yamlPath);
+
+            expect(await digestOf(prosePath), 'a docs-only reword of the profile schema must not move the capability digest')
+                .toBe(baseline);
+            expect(await digestOf(shapePath), 'widening a constraint bound IS a capability change and must move the digest')
+                .not.toBe(baseline)
         })
     })
 });

--- a/test/playwright/unit/ai/mcp/schemaCompaction.spec.mjs
+++ b/test/playwright/unit/ai/mcp/schemaCompaction.spec.mjs
@@ -83,7 +83,8 @@ test.describe('ToolService compactToolSchemas — the schema-prose projection (#
             properties : {
                 name: {type: 'string', description: 'name prose'},
                 tags: {type: 'array', description: 'tags prose', items: {type: 'string', description: 'item prose'}},
-                mode: {enum: ['a', 'b'], description: 'mode prose', default: 'a'}
+                mode: {enum: ['a', 'b'], description: 'mode prose', default: 'a'},
+                refd: {$ref: '#/$defs/entry', description: 'ref prose'}
             },
             required            : ['name'],
             additionalProperties: {type: 'number', description: 'ap prose'},
@@ -99,7 +100,8 @@ test.describe('ToolService compactToolSchemas — the schema-prose projection (#
             properties: {
                 name: {type: 'string'},
                 tags: {type: 'array', items: {type: 'string'}},
-                mode: {enum: ['a', 'b'], default: 'a'}
+                mode: {enum: ['a', 'b'], default: 'a'},
+                refd: {$ref: '#/$defs/entry'}
             },
             required            : ['name'],
             additionalProperties: {type: 'number'},
@@ -120,7 +122,7 @@ test.describe('ToolService compactToolSchemas — the schema-prose projection (#
                   stripped = service.stripSchemaDescriptions(DESCRIBED);
 
             expect(stripped).not.toBe(DESCRIBED);
-            expect(collectDescriptions(DESCRIBED)).toHaveLength(8)
+            expect(collectDescriptions(DESCRIBED)).toHaveLength(9)
         });
 
         test('arrays and scalars pass through; null stays null', () => {
@@ -266,10 +268,11 @@ test.describe('ToolService compactToolSchemas — the schema-prose projection (#
     });
 
     test.describe('every listing route rides the projection — production-bound witnesses', () => {
-        test('the exact-profile route (neural-link local-readonly-probe) lists compact schemas; the handbook keeps the prose', async () => {
-            // The bypass this pins: the exact-profile branch swaps in the profile's constrained
-            // schema — if that swap skips the projection, a harness-projected seat gets the full
-            // prose payload the flag exists to keep off the wire.
+        test('the exact-profile route keeps its prose BY DESIGN — the handbook is policy-refused inside the projection', async () => {
+            // The architectural exception: a profile is a curated minimal surface, and its
+            // constraint prose (depth bounds, forced flags) must reach the projected seat — but
+            // the handbook tool is not part of the profile, so the listing is the ONLY surface
+            // that can carry it. Compaction therefore targets the default listing, never this one.
             const service = Neo.create(ToolService, {
                     compactToolSchemas: true,
                     openApiFilePath   : path.join(repoRoot, 'ai/mcp/server/neural-link/openapi.yaml'),
@@ -280,11 +283,14 @@ test.describe('ToolService compactToolSchemas — the schema-prose projection (#
 
             expect(tools.length).toBeGreaterThan(0);
             expect(tree, 'get_component_tree is inside the local-readonly-probe profile').toBeTruthy();
-            expect(collectDescriptions(tree.inputSchema)).toEqual([]);
+            expect(
+                collectDescriptions(tree.inputSchema).length,
+                'the profile schema keeps its prose — a projected seat has no other surface for it'
+            ).toBeGreaterThan(0);
 
-            const handbook = service.getToolHandbook('get_component_tree');
-
-            expect(collectDescriptions(handbook.inputSchema).length).toBeGreaterThan(0)
+            // the exception's premise, asserted: the handbook is genuinely unreachable in-profile
+            expect(() => service.assertToolProjectionAllows('get_mcp_tool_handbook', 'local-readonly-probe'))
+                .toThrow(/not visible in the local-readonly-probe projection/)
         });
 
         test('the advertised-surface digest is computed over the SAME projected objects the listing emits', async () => {

--- a/test/playwright/unit/ai/mcp/schemaCompaction.spec.mjs
+++ b/test/playwright/unit/ai/mcp/schemaCompaction.spec.mjs
@@ -14,6 +14,8 @@ setup({
 });
 
 import {test, expect}  from '@playwright/test';
+import Ajv             from 'ajv';
+import crypto          from 'node:crypto';
 import path            from 'path';
 import {fileURLToPath} from 'url';
 import Neo             from '../../../../../src/Neo.mjs';
@@ -45,7 +47,10 @@ test.describe('ToolService compactToolSchemas — the schema-prose projection (#
     });
 
     /**
-     * @summary Collects every `description` value under a schema node, recursively.
+     * @summary Collects every annotation-position `description` under a schema node. Mirrors the
+     * walker's position discipline: a property NAMED `description` (an object-valued declaration
+     * under `properties`) is application data and is not collected — a key-name-blind collector
+     * would false-positive on exactly the handbook response contract that declares one.
      * @param {*} node
      * @param {String[]} [hits]
      * @returns {String[]}
@@ -55,10 +60,14 @@ test.describe('ToolService compactToolSchemas — the schema-prose projection (#
             node.forEach(item => collectDescriptions(item, hits))
         } else if (node && typeof node === 'object') {
             Object.entries(node).forEach(([key, value]) => {
-                if (key === 'description') {
+                if (key === 'description' && typeof value === 'string') {
                     hits.push(value)
-                } else {
+                } else if (['properties', '$defs', 'patternProperties', 'dependentSchemas'].includes(key) && value && typeof value === 'object') {
+                    Object.values(value).forEach(subschema => collectDescriptions(subschema, hits))
+                } else if (['items', 'additionalItems', 'additionalProperties', 'unevaluatedProperties', 'contains', 'propertyNames', 'not', 'if', 'then', 'else'].includes(key)) {
                     collectDescriptions(value, hits)
+                } else if (['oneOf', 'anyOf', 'allOf', 'prefixItems'].includes(key) && Array.isArray(value)) {
+                    value.forEach(subschema => collectDescriptions(subschema, hits))
                 }
             })
         }
@@ -120,6 +129,76 @@ test.describe('ToolService compactToolSchemas — the schema-prose projection (#
             expect(service.stripSchemaDescriptions(null)).toBe(null);
             expect(service.stripSchemaDescriptions('description')).toBe('description');
             expect(service.stripSchemaDescriptions([{description: 'x', type: 'string'}])).toEqual([{type: 'string'}])
+        });
+
+        test('an application PROPERTY named description is data, not an annotation — it survives', () => {
+            // The position-blind failure this guards: a schema declaring a real `description`
+            // property, required and closed. Only the property's own ANNOTATION may leave.
+            const service = Object.create(ToolService.prototype),
+                  schema  = {
+                      type       : 'object',
+                      description: 'schema annotation',
+                      properties : {
+                          description: {type: 'string', description: 'annotation for the property'}
+                      },
+                      required            : ['description'],
+                      additionalProperties: false
+                  },
+                  stripped = service.stripSchemaDescriptions(schema);
+
+            expect(stripped.description).toBeUndefined();
+            expect(stripped.properties.description).toEqual({type: 'string'});
+            expect(stripped.required).toEqual(['description']);
+            expect(stripped.additionalProperties).toBe(false)
+        });
+
+        test('object-valued assertion data is never descended into (enum / const / default)', () => {
+            const service = Object.create(ToolService.prototype),
+                  schema  = {
+                      type   : 'object',
+                      default: {description: 'data, not annotation'},
+                      enum   : [{description: 'x'}, 'plain'],
+                      const  : undefined
+                  },
+                  stripped = service.stripSchemaDescriptions({type: 'object', default: schema.default, enum: schema.enum});
+
+            expect(stripped.default).toEqual({description: 'data, not annotation'});
+            expect(stripped.enum).toEqual([{description: 'x'}, 'plain'])
+        });
+
+        test('the real validator proves an identical accept/reject set (Ajv battery)', () => {
+            const
+                service = Object.create(ToolService.prototype),
+                ajv     = new Ajv({allErrors: true}),
+                schema  = {
+                    type       : 'object',
+                    description: 'schema annotation',
+                    properties : {
+                        description: {type: 'string', description: 'property annotation'},
+                        count      : {type: 'integer', description: 'count annotation', default: 0},
+                        mode       : {enum: ['a', 'b'], description: 'mode annotation'}
+                    },
+                    required            : ['description'],
+                    additionalProperties: false
+                },
+                projected = service.stripSchemaDescriptions(schema),
+                validateOriginal  = ajv.compile(schema),
+                validateProjected = ajv.compile(projected),
+                battery = [
+                    {description: 'ok'},                          // accept
+                    {description: 'ok', count: 3, mode: 'a'},     // accept
+                    {},                                           // reject: missing required
+                    {description: 42},                            // reject: wrong type
+                    {description: 'ok', extra: true},             // reject: additionalProperties false
+                    {description: 'ok', mode: 'c'}                // reject: enum
+                ];
+
+            for (const value of battery) {
+                expect(
+                    validateProjected(value),
+                    `accept/reject must match for ${JSON.stringify(value)}`
+                ).toBe(validateOriginal(value))
+            }
         })
     });
 
@@ -183,6 +262,50 @@ test.describe('ToolService compactToolSchemas — the schema-prose projection (#
             expect(handbook.inputSchema).toBeUndefined();
             expect(handbook.outputSchema).toBeUndefined();
             expect(Object.keys(handbook).sort()).toEqual(['description', 'found', 'handbook', 'source', 'title', 'toolId'])
+        })
+    });
+
+    test.describe('every listing route rides the projection — production-bound witnesses', () => {
+        test('the exact-profile route (neural-link local-readonly-probe) lists compact schemas; the handbook keeps the prose', async () => {
+            // The bypass this pins: the exact-profile branch swaps in the profile's constrained
+            // schema — if that swap skips the projection, a harness-projected seat gets the full
+            // prose payload the flag exists to keep off the wire.
+            const service = Neo.create(ToolService, {
+                    compactToolSchemas: true,
+                    openApiFilePath   : path.join(repoRoot, 'ai/mcp/server/neural-link/openapi.yaml'),
+                    serviceMapping    : {}
+                }),
+                {tools} = await service.listTools({toolProjection: 'local-readonly-probe'}),
+                tree    = tools.find(tool => tool.name === 'get_component_tree');
+
+            expect(tools.length).toBeGreaterThan(0);
+            expect(tree, 'get_component_tree is inside the local-readonly-probe profile').toBeTruthy();
+            expect(collectDescriptions(tree.inputSchema)).toEqual([]);
+
+            const handbook = service.getToolHandbook('get_component_tree');
+
+            expect(collectDescriptions(handbook.inputSchema).length).toBeGreaterThan(0)
+        });
+
+        test('the advertised-surface digest is computed over the SAME projected objects the listing emits', async () => {
+            // The anti-bypass pin for the digest: if the digest ever reads a second, unprojected
+            // source (raw OpenAPI schemas carry prose), the recomputed value diverges and reds.
+            const service = Neo.create(ToolService, {
+                    compactToolSchemas: true,
+                    openApiFilePath   : path.join(repoRoot, 'ai/mcp/server/file-system/openapi.yaml'),
+                    serviceMapping    : {}
+                });
+
+            await service.listTools(); // owns initializeToolMapping — getToolsForProjection does not
+
+            const listing = service.getToolsForProjection(null),
+                canonical = listing.filter(Boolean)
+                    .map(tool => ({name: tool.name, inputSchema: tool.inputSchema ?? null}))
+                    .sort((lhs, rhs) => lhs.name < rhs.name ? -1 : lhs.name > rhs.name ? 1 : 0),
+                expected  = crypto.createHash('sha256').update(service.canonicalize(canonical)).digest('hex').slice(0, 12);
+
+            expect(service.getAdvertisedSurfaceDigest()).toBe(expected);
+            expect(listing.every(tool => collectDescriptions(tool.inputSchema).length === 0)).toBe(true)
         })
     })
 });

--- a/test/playwright/unit/ai/mcp/server/memory-core/McpServerToolLimits.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/memory-core/McpServerToolLimits.spec.mjs
@@ -34,6 +34,7 @@ test.describe('Neo.ai.mcp.server.memory-core Tool limits', () => {
 
         const ToolServiceModule = await import('../../../../../../../ai/mcp/server/memory-core/toolService.mjs');
         toolService = {
+            callTool                    : ToolServiceModule.callTool,
             composeMemoryCoreHealthcheck: ToolServiceModule.composeMemoryCoreHealthcheck,
             listTools                   : ToolServiceModule.listTools,
             readLaneLandscapeConfig     : ToolServiceModule.readLaneLandscapeConfig
@@ -65,10 +66,22 @@ test.describe('Neo.ai.mcp.server.memory-core Tool limits', () => {
             expect(tool.name.length).toBeLessThanOrEqual(64);
             expect(tool.description.length).toBeLessThanOrEqual(1024);
 
+            // Schema prose no longer rides the listing at all — the absence is the
+            // contract here, and the length discipline moves to the prose's new home below.
             if (tool.inputSchema && tool.inputSchema.properties) {
                 for (const [propName, propDef] of Object.entries(tool.inputSchema.properties)) {
+                    expect(propDef.description, `${tool.name}.${propName} schema prose stays off the listing`).toBeUndefined();
+                }
+            }
+
+            // Relocated, not deleted: the handbook payload carries the fully-described schema,
+            // and the ≤1024 discipline still binds there.
+            const handbook = await toolService.callTool('get_mcp_tool_handbook', {toolId: tool.name});
+
+            if (handbook.inputSchema && handbook.inputSchema.properties) {
+                for (const [propName, propDef] of Object.entries(handbook.inputSchema.properties)) {
                     if (propDef.description) {
-                        expect(propDef.description.length).toBeLessThanOrEqual(1024);
+                        expect(propDef.description.length, `${tool.name}.${propName} handbook prose`).toBeLessThanOrEqual(1024);
                     }
                 }
             }
@@ -81,7 +94,6 @@ test.describe('Neo.ai.mcp.server.memory-core Tool limits', () => {
         const metadata  = tool.inputSchema.properties.harnessTargetMetadata;
 
         expect(metadata.required).toBeUndefined();
-        expect(metadata.description).toContain("exempt for envelope-routed adapters 'opencode-server', 'kimi-server', 'kimi-pull-bridge'");
         expect(Object.keys(metadata.properties)).toEqual(expect.arrayContaining([
             'addressType',
             'adapter',
@@ -101,6 +113,13 @@ test.describe('Neo.ai.mcp.server.memory-core Tool limits', () => {
         expect(metadata.properties.adapter.enum).toEqual(['osascript', 'tmux', 'codex-app-server', 'opencode-server', 'kimi-server', 'kimi-pull-bridge']);
         expect(metadata.properties.envelopePath.type).toBe('string');
         expect(metadata.properties.addressType.enum).toEqual(['userDataDir', 'pid', 'tmuxSession', 'webhookUrl']);
+
+        // The prose half of the contract relocated to the lazy handbook payload — the
+        // listing above now witnesses shape-only (type/enum/properties survive the projection).
+        const handbook = await toolService.callTool('get_mcp_tool_handbook', {toolId: 'manage_wake_subscription'});
+
+        expect(handbook.inputSchema.properties.harnessTargetMetadata.description)
+            .toContain("exempt for envelope-routed adapters 'opencode-server', 'kimi-server', 'kimi-pull-bridge'");
     });
 
     test('get_neighbors output schema exposes semanticVectorId contract (#11680)', async () => {
@@ -109,8 +128,13 @@ test.describe('Neo.ai.mcp.server.memory-core Tool limits', () => {
         const neighbor  = tool.outputSchema.properties.neighbors.items;
 
         expect(neighbor.properties.semanticVectorId.type).toBe('string');
-        expect(neighbor.properties.semanticVectorId.description).toContain('semantic vector identifier');
         expect(neighbor.additionalProperties).not.toBe(false);
+
+        // The description relocated to the handbook payload — the listing keeps shape only.
+        const handbook = await toolService.callTool('get_mcp_tool_handbook', {toolId: 'get_neighbors'});
+
+        expect(handbook.outputSchema.properties.neighbors.items.properties.semanticVectorId.description)
+            .toContain('semantic vector identifier');
     });
 
     test('get_rem_pipeline_state surfaces the REM axis-count output contract (#12087)', async () => {


### PR DESCRIPTION
Resolves #16588

The `tools/list` description compaction capped the operation line and shipped the schemas beside it whole — every `description:` inside `inputSchema` / `outputSchema` rode the listing in full. This PR adds the sibling projection: `compactToolSchemas` strips the `description` ANNOTATION, position-aware — the walker descends only schema-valued positions (`properties`/`$defs`/`patternProperties`/`dependentSchemas` maps, `items`/`additionalProperties`/`not`/`if`/`then`/`else` subschemas, `oneOf`/`anyOf`/`allOf`/`prefixItems` arrays), so an application property NAMED `description` survives as data and object-valued assertion data (`enum`/`const`/`default`) is never descended into. Ajv convicts the identical accept/reject set. The fully-described schema relocates into the `get_mcp_tool_handbook` payload — declared in all six servers' response contracts. Opted in on all six MCP servers beside their existing `compactToolDescriptions: true`; the default stays `false` and default-off output is byte-identical (spec-pinned).

Evidence: L2 (unit matrix over the pure projection + the real file-system contract + the real exact-profile route + the full unit suite) → L2 required (all six ACs are projection-contract ACs reachable in-sandbox). Residual: none — AC-6's measurement is below.

## Measured (AC-6) — listing bytes, flag OFF → ON, same six servers, post-repair head

| server | ops | listing bytes OFF | listing bytes ON | schema-desc bytes OFF → ON |
|---|---:|---:|---:|---:|
| memory-core | 41 | 78,990 | 48,542 | 25,368 → 0 |
| github-workflow | 23 | 37,258 | 21,946 | 12,757 → 0 |
| knowledge-base | 12 | 21,756 | 12,224 | 8,085 → 0 |
| neural-link | 58 | 35,058 | 24,604 | 7,579 → 0 |
| file-system | 6 | 2,445 | 2,091 | 235 → 0 |
| gitlab-workflow | 13 | 12,144 | 9,734 | 1,594 → 0 |
| **total** | **153** | **187,651** | **119,141** | **55,618 → 0** |

Method: measured on the BUILT listing at the post-repair head (JSON bytes + summed annotation-position description bytes), `healthcheck` excluded on both sides (its descriptor carries the stamped digest). The ticket's table counted yaml fields (49,772 over five servers); this table measures the wire payload. Net: **~68.5KB (−36.5%) off a full six-server attach**; every harness boot of every seat pays this today.

## Deltas from ticket

- **All six servers opted in** (including `gitlab-workflow`, excluded only from the ticket's measurement table) — a dark flag delivers zero; rollback is a one-line flip per server.
- **Two consumer specs rewired to the prose's new home** (`McpServerToolLimits`): the description-length discipline and two prose assertions now read the handbook payload; their shape assertions stay on the listing and now double as strip witnesses.
- **Second-order digest benefit, pinned:** the advertised-surface digest hashes listed input schemas — with prose stripped, nested-prose edits can no longer shift it (the digest's own "capability-reachability, not copy-freshness" axis, now true for nested prose too). The digest spec's canary asserts prose-in-payload shifts the digest; the production binding (identity-strip reds) lives in `schemaCompaction.spec.mjs`.
- Structural pre-flight fast-path: the new spec's directory is a sibling-pattern match (`advertisedSurfaceDigest.spec.mjs`, same class surface).

## Evolution

- Cycle 2 (post-RC1): the walker is **position-aware** (a property NAMED `description` under `properties` is data and survives — the pre-RC1 key-name-blind walker deleted it; Ajv battery convicts identical accept/reject). The six `get_mcp_tool_handbook` response contracts **declare** `inputSchema` / `outputSchema`. The digest is pinned to consume the same projected objects the listing emits (anti-bypass). Identity-strip mutation reds 8 tests in `schemaCompaction.spec.mjs` (pre-RC1: green).
- Cycle 3 (post-cycle-2-review): the cycle-2 exact-profile compaction is **REVERTED by design** — an exact profile is a curated minimal surface and `get_mcp_tool_handbook` is policy-refused inside the projection, so the listing is the ONLY surface a projected seat has for the profile's constraint prose. The architectural exception is documented in code (`getToolsForProjection`), pinned by the sign-flipped witness (profile listing keeps prose; handbook refusal asserted), and truth-folded into #16588's AC-3 (ticket amended with receipts per the RA's explicit prescription; edit-trail comment with author revert-authority on the ticket).
- Cycle 4 (post-cycle-3-review): the digest normalizes to the **validation shape** when the flag is on — the exact-profile exception keeps prose on the listing (only reachable surface), but a docs-only reword no longer shifts the capability digest (production witness over the real neural-link profile: prose-only mutation stable at the baseline digest; a `maximum: 2 → 3` constraint edit moves it).

## Test Evidence

- `npx playwright test -c test/playwright/playwright.config.unit.mjs` — **12361 passed**, 5 skipped, 2 did-not-run, 0 failed (2.0m), post-repair head.
- `test/playwright/unit/ai/mcp/schemaCompaction.spec.mjs` (new, 11/11): strip-twin equality + non-mutation + null/array passthrough; **property-named-`description` survival** (RA-1 control); **object-valued-data preservation** (enum/default); **Ajv accept/reject battery** (original ≡ projected over 6 value shapes); real file-system contract — zero annotation descriptions in any listed schema (AC-1), handbook carries the described schema (AC-3); default-off byte-identical listing + schema-free handbook shape (AC-4); **exact-profile exception witness** (neural-link `local-readonly-probe` keeps its prose BY DESIGN; the handbook is asserted policy-refused in-profile); **digest anti-bypass** (digest input ≡ listing objects); **digest normalization witness** (prose-only edit digest-stable, shape edit digest-shifts, over the real `local-readonly-probe` route).
- `advertisedSurfaceDigest.spec.mjs` (+1 test, 16/16): the AC-5 canary.
- `McpServerToolLimits.spec.mjs` (17/17): the rewired consumers, discipline preserved against the handbook.
- Mutation receipt: `stripSchemaDescriptions` → identity projection reds **8** tests — all in `schemaCompaction.spec.mjs` (the digest spec's fixtures are deliberately stubbed; the production binding lives in the named spec).
- Surface `ai/mcp` (686 specs incl. `McpServerListToolsSmoke` / `OpenApiValidatorCompliance` / dispatch): green with the six declared handbook contracts.

## Post-Merge Validation

- [ ] Next session boots across seats attach with the compacted surface (observable in any harness's `tools/list` payload size). No seat action required — the advertised-surface digest shifts once per server BY DESIGN, marking the new generation; a seat holding a pre-merge descriptor reads "stale" once and re-provisions.

Authored by Phoebe (Kimi for Coding k3, opencode). Session: post-reset recovery session 2026-08-09 (MC-bound).



