### PR TITLE
feat(memory-core): publish the WAL drain receipt beside provider activity (#16835)

### DIFF
--- a/ai/daemons/embed/drainCycle.mjs
+++ b/ai/daemons/embed/drainCycle.mjs
@@ -458,12 +458,13 @@ export async function drainWalOnce({
     backoffBaseMs,
     retentionLimit,
     expectedDimension,
-    retryState = new Map(),
-    log        = () => {},
-    sleep      = ms => new Promise(resolve => setTimeout(resolve, ms)),
-    now        = Date.now
+    retryState   = new Map(),
+    log          = () => {},
+    onCycleStart = () => {},
+    sleep        = ms => new Promise(resolve => setTimeout(resolve, ms)),
+    now          = Date.now
 } = {}) {
-    const summary = {pending: 0, embedded: 0, compensated: 0, failed: 0, metadataOnly: 0, unverifiable: 0, cooling: 0, prunedSegments: 0};
+    const summary = {pending: 0, embedded: 0, compensated: 0, failed: 0, selected: 0, metadataOnly: 0, unverifiable: 0, cooling: 0, prunedSegments: 0};
 
     // Full pending read (not limit-bounded): a newest-first limited read would let records
     // cooling down at the head permanently shadow older drainable ones. Scan cost is bounded —
@@ -485,6 +486,13 @@ export async function drainWalOnce({
 
         drainable.push(record);
     }
+
+    summary.selected = drainable.length;
+
+    // Publish the selection BEFORE the provider call. Everything below can block for the length of a
+    // provider round-trip, and until it returns the tracker has nothing to say — which makes a cycle
+    // that is legitimately working read as "no work" to any observer sampling mid-flight.
+    onCycleStart({pending: summary.pending, selected: drainable.length});
 
     if (drainable.length > 0) {
         const {succeeded, failed} = await embedBatch({collection, records: drainable, maxRetries, backoffBaseMs, sleep, log});
@@ -608,7 +616,7 @@ export function startDrainLoop({getCollection, getConfig, expectedDimension, log
 
         try {
             const collection = await getCollection();
-            const summary    = await drainWalOnce({dir, collection, batchSize, maxRetries, backoffBaseMs, retentionLimit, expectedDimension, retryState, log});
+            const summary    = await drainWalOnce({dir, collection, batchSize, maxRetries, backoffBaseMs, retentionLimit, expectedDimension, retryState, log, onCycleStart: disposition.recordCycleStart});
 
             // Idle cycles stay silent — at a multi-second poll interval, per-cycle no-op lines
             // would dominate the log without adding signal.
@@ -640,6 +648,19 @@ export function startDrainLoop({getCollection, getConfig, expectedDimension, log
          * @summary The drain receipt for this plane — see `createDrainDispositionTracker`.
          * @returns {Object}
          */
-        getDisposition: disposition.getDisposition
+        getDisposition: disposition.getDisposition,
+
+        /**
+         * @summary The work the currently-running cycle selected, before it completes.
+         * @returns {Object|null}
+         */
+        getInProgress: disposition.getInProgress,
+
+        /**
+         * @summary Completed cycles aggregated over a caller-supplied lookback.
+         * @param {Number} sinceTs Lower bound, epoch ms.
+         * @returns {Object}
+         */
+        getWindowSince: disposition.getWindowSince
     };
 }

--- a/ai/daemons/shared/drainDisposition.mjs
+++ b/ai/daemons/shared/drainDisposition.mjs
@@ -89,13 +89,76 @@
  * @param {Function} [options.now=Date.now] Injectable clock.
  * @returns {{recordCycle: Function, recordFailure: Function, getDisposition: Function}}
  */
-export function createDrainDispositionTracker({now = Date.now} = {}) {
-    let state  = 'unobserved',
-        reason = 'no-drain-cycle-completed-yet',
-        counts = null,
-        at     = null;
+export function createDrainDispositionTracker({historyLimit = 256, now = Date.now} = {}) {
+    let state      = 'unobserved',
+        reason     = 'no-drain-cycle-completed-yet',
+        counts     = null,
+        at         = null,
+        inProgress = null;
+
+    // Completed cycles, oldest first. The receipt above is a LAST-VALUE LATCH and cannot answer a
+    // windowed question: an idle poll overwrites a work-bearing cycle that is still inside a
+    // consumer's lookback, so "latest says pending 0" and "no work happened in the window" are
+    // different propositions. A consumer aggregating provider activity over `sinceTs` needs the
+    // cycles that fall in the SAME window, which is what this retains.
+    const history = [];
 
     return {
+        /**
+         * @summary Publishes the work a cycle SELECTED, before it completes.
+         *
+         * Without this, a cycle that has selected items and is waiting on the provider is invisible:
+         * the tracker cannot speak until the provider call returns, so the exact interval a load
+         * observer most needs to interpret reads as "no work". In-progress is cleared by the
+         * completion or failure that follows it.
+         * @param {Object} [data]
+         * @param {Number} [data.selected] Items admitted into this cycle.
+         * @param {Number} [data.pending] Items pending when the cycle began.
+         */
+        recordCycleStart({pending, selected} = {}) {
+            inProgress = {
+                pendingAtStart: Number.isFinite(pending)  ? pending  : null,
+                selectedCount : Number.isFinite(selected) ? selected : null,
+                startedAt     : now()
+            }
+        },
+
+        /**
+         * @summary Aggregates the completed cycles inside a consumer's lookback.
+         *
+         * `truncated` is not decoration: the ring is bounded, so a lookback older than the oldest
+         * retained cycle is a PARTIAL answer, and a partial answer reported as a total is the same
+         * false-zero this module exists to prevent.
+         * @param {Number} sinceTs Lower bound, epoch ms.
+         * @returns {Object}
+         */
+        getWindowSince(sinceTs) {
+            const inWindow = history.filter(entry => entry.at >= sinceTs),
+                  totals   = {embedded: 0, failed: 0, pending: 0, selected: 0};
+
+            for (const {counts: c} of inWindow) {
+                totals.embedded += Number(c?.embedded)  || 0;
+                totals.failed   += Number(c?.failed)    || 0;
+                totals.pending  += Number(c?.pending)   || 0;
+                totals.selected += Number(c?.selected)  || 0
+            }
+
+            return {
+                cycles          : inWindow.length,
+                oldestRetainedAt: history.length ? history[0].at : null,
+                totals,
+                truncated       : history.length === historyLimit && history[0].at > sinceTs
+            }
+        },
+
+        /**
+         * @summary The work the currently-running cycle selected, or null when none is running.
+         * @returns {Object|null}
+         */
+        getInProgress() {
+            return inProgress && {...inProgress}
+        },
+
         /**
          * @summary Records a completed cycle. Cleanliness is read from ONE producer-declared field,
          * `summary.outstanding`, never re-derived here from producer-specific counts.
@@ -111,8 +174,15 @@ export function createDrainDispositionTracker({now = Date.now} = {}) {
          * @param {Object} summary The loop's per-cycle summary; `outstanding` is the residue field.
          */
         recordCycle(summary = {}) {
-            counts = {...summary};
-            at     = now();
+            counts     = {...summary};
+            at         = now();
+            inProgress = null;
+
+            history.push({at, counts: {...summary}});
+
+            if (history.length > historyLimit) {
+                history.shift()
+            }
 
             if (summary.inactive) {
                 state  = 'inactive';
@@ -142,10 +212,11 @@ export function createDrainDispositionTracker({now = Date.now} = {}) {
          * @param {Error|String} error
          */
         recordFailure(error) {
-            state  = 'unobserved';
-            reason = `drain-cycle-failed: ${error?.message ?? error ?? 'unknown'}`;
-            counts = null;
-            at     = now()
+            state      = 'unobserved';
+            reason     = `drain-cycle-failed: ${error?.message ?? error ?? 'unknown'}`;
+            counts     = null;
+            at         = now();
+            inProgress = null
         },
 
         /**

--- a/ai/daemons/shared/drainDisposition.mjs
+++ b/ai/daemons/shared/drainDisposition.mjs
@@ -102,7 +102,8 @@ export function createDrainDispositionTracker({historyLimit = 256, now = Date.no
         counts         = null,
         at             = null,
         inProgress     = null,
-        evictedThrough = null;
+        evictedThrough = null,
+        lastFailureAt  = null;
 
     // Completed cycles, oldest first. The receipt above is a LAST-VALUE LATCH and cannot answer a
     // windowed question: an idle poll overwrites a work-bearing cycle that is still inside a
@@ -161,7 +162,8 @@ export function createDrainDispositionTracker({historyLimit = 256, now = Date.no
                 // just the first — so a fresh tracker answered "nothing happened, completely" for
                 // a window it could not see at all.
                 truncated       : sinceTs < coverageStartedAt ||
-                                  (evictedThrough !== null && sinceTs <= evictedThrough)
+                                  (evictedThrough !== null && sinceTs <= evictedThrough) ||
+                                  (lastFailureAt  !== null && lastFailureAt >= sinceTs)
             }
         },
 
@@ -232,7 +234,20 @@ export function createDrainDispositionTracker({historyLimit = 256, now = Date.no
             reason     = `drain-cycle-failed: ${error?.message ?? error ?? 'unknown'}`;
             counts     = null;
             at         = now();
-            inProgress = null
+            inProgress = null;
+
+            // The third way to lose coverage, and the one that survived two repairs. A cycle can
+            // START, reach the provider — durably, on the activity ledger — and then throw during
+            // post-add verification, pending re-read, marker append or prune; `startDrainLoop` routes
+            // every such throw here. It never becomes a completed history entry, so the window used
+            // to aggregate right past the hole and still report `truncated: false`: provider activity
+            // of 1 against window totals of 0, advertised as a complete denominator.
+            //
+            // Its counts are unknowable — that is what "failed" means — so it is deliberately NOT a
+            // history entry. Only the newest timestamp is kept: the question a lookback asks is
+            // "did any failure land at or after `sinceTs`", and the newest answers it for every
+            // `sinceTs` without an unbounded list.
+            lastFailureAt = at
         },
 
         /**

--- a/ai/daemons/shared/drainDisposition.mjs
+++ b/ai/daemons/shared/drainDisposition.mjs
@@ -90,11 +90,19 @@
  * @returns {{recordCycle: Function, recordFailure: Function, getDisposition: Function}}
  */
 export function createDrainDispositionTracker({historyLimit = 256, now = Date.now} = {}) {
-    let state      = 'unobserved',
-        reason     = 'no-drain-cycle-completed-yet',
-        counts     = null,
-        at         = null,
-        inProgress = null;
+    // The earliest instant this tracker could attest to anything. A lookback reaching further back
+    // than this is asking about a period the tracker did not exist for, and the only honest answer
+    // is "partial" — a process restart makes that the DAILY case, not an edge one.
+    const coverageStartedAt = now();
+
+    // `evictedThrough` is the newest cycle timestamp the ring has dropped, null while nothing has
+    // been evicted — the second boundary a lookback can fail to clear.
+    let state          = 'unobserved',
+        reason         = 'no-drain-cycle-completed-yet',
+        counts         = null,
+        at             = null,
+        inProgress     = null,
+        evictedThrough = null;
 
     // Completed cycles, oldest first. The receipt above is a LAST-VALUE LATCH and cannot answer a
     // windowed question: an idle poll overwrites a work-bearing cycle that is still inside a
@@ -144,10 +152,16 @@ export function createDrainDispositionTracker({historyLimit = 256, now = Date.no
             }
 
             return {
+                coverageStartedAt,
                 cycles          : inWindow.length,
                 oldestRetainedAt: history.length ? history[0].at : null,
                 totals,
-                truncated       : history.length === historyLimit && history[0].at > sinceTs
+                // Coverage, NOT capacity. A full ring is one way to lose the head of a lookback;
+                // never having observed it is the other, and keying only off `historyLimit` saw
+                // just the first — so a fresh tracker answered "nothing happened, completely" for
+                // a window it could not see at all.
+                truncated       : sinceTs < coverageStartedAt ||
+                                  (evictedThrough !== null && sinceTs <= evictedThrough)
             }
         },
 
@@ -181,7 +195,9 @@ export function createDrainDispositionTracker({historyLimit = 256, now = Date.no
             history.push({at, counts: {...summary}});
 
             if (history.length > historyLimit) {
-                history.shift()
+                // Remember WHAT was dropped, not just that the ring is full: the dropped cycle's
+                // timestamp is the boundary a later lookback must be told it cannot cross.
+                evictedThrough = history.shift().at
             }
 
             if (summary.inactive) {

--- a/ai/mcp/server/memory-core/Server.mjs
+++ b/ai/mcp/server/memory-core/Server.mjs
@@ -353,6 +353,8 @@ class Server extends BaseServer {
                 // than an empty backlog — zero pending against live provider load is the alarm condition,
                 // not a safe default.
                 MemoryCoreRecorderService.walDrainDispositionProvider = this.walDrainLoop.getDisposition;
+                MemoryCoreRecorderService.walDrainInProgressProvider   = this.walDrainLoop.getInProgress;
+                MemoryCoreRecorderService.walDrainWindowProvider       = this.walDrainLoop.getWindowSince;
                 // Release on process exit (the realistic single-process clean-shutdown path); a
                 // signal-kill leaves the lock for the next host to reclaim as stale.
                 process.on('exit', () => this.walDrainLock?.release());

--- a/ai/mcp/server/memory-core/Server.mjs
+++ b/ai/mcp/server/memory-core/Server.mjs
@@ -26,6 +26,7 @@ import {
 } from '../../../services.mjs';
 import {startDrainLoop}   from '../../../daemons/embed/drainCycle.mjs';
 import {acquireDrainLock} from '../../../daemons/embed/drainLock.mjs';
+import MemoryCoreRecorderService from '../../../services/memory-core/MemoryCoreRecorderService.mjs';
 import {
     createMessageGraphProjectionProcessor,
     startMessageDrainLoop
@@ -347,6 +348,11 @@ class Server extends BaseServer {
                     expectedDimension: aiConfig.vectorDimension,
                     log              : drainLog
                 });
+                // Publish the drain receipt to the metrics projection. Registered ONLY on the branch that
+                // actually hosts the loop, so a process that does not drain reports `unavailable` rather
+                // than an empty backlog — zero pending against live provider load is the alarm condition,
+                // not a safe default.
+                MemoryCoreRecorderService.walDrainDispositionProvider = this.walDrainLoop.getDisposition;
                 // Release on process exit (the realistic single-process clean-shutdown path); a
                 // signal-kill leaves the lock for the next host to reclaim as stale.
                 process.on('exit', () => this.walDrainLock?.release());

--- a/ai/mcp/server/memory-core/openapi.yaml
+++ b/ai/mcp/server/memory-core/openapi.yaml
@@ -2716,9 +2716,11 @@ components:
 
         Two properties are deliberate. `counts` is null — never zero — when this process does not host
         the drain, because zero pending against live provider load IS the anomaly, so a defaulted zero
-        would manufacture the alarm this projection exists to detect. And `withinWindow` reports
-        whether the receipt's cycle landed inside the same lookback as `providerActivity`; the two are
-        only a ratio when it is true.
+        would manufacture the alarm this projection exists to detect. And `window.truncated` reports
+        whether the aggregate may be read as the WHOLE lookback: the window is answered from an
+        in-memory ring, so a lookback reaching past `window.coverageStartedAt` — every process
+        restart does — or past a cycle the ring has evicted is a PARTIAL answer. Totals are a ratio
+        against `providerActivity` only when it is false.
       required:
         - status
         - state
@@ -2793,8 +2795,15 @@ components:
             Completed drain cycles aggregated over the SAME lookback as `providerActivity`. This is the
             comparable denominator; the `counts` field above describes one latest cycle and is not.
             Null when no observation is available.
-          required: [cycles, oldestRetainedAt, totals, truncated]
+          required: [coverageStartedAt, cycles, oldestRetainedAt, totals, truncated]
           properties:
+            coverageStartedAt:
+              type: string
+              format: date-time
+              description: >
+                Earliest instant this process could attest to. A lookback starting before it asks
+                about a period the tracker did not exist for; it is the denominator that makes
+                `truncated` actionable rather than merely alarming.
             cycles:
               type: integer
               description: Completed cycles inside the lookback.
@@ -2810,8 +2819,11 @@ components:
             truncated:
               type: boolean
               description: >
-                True when the lookback reaches further back than retained history, so the aggregate is
-                partial. A partial answer reported as a total is the same false zero as a defaulted one.
+                True when the lookback is not fully covered, so the aggregate is partial — either it
+                starts before `coverageStartedAt` (any process restart) or it reaches a cycle the ring
+                has evicted. Coverage, not capacity: keying only off ring fullness saw the second case
+                and reported a fresh tracker's empty window as a COMPLETE "nothing happened". A partial
+                answer reported as a total is the same false zero as a defaulted one.
 
     ProviderActivityResponse:
       type: object

--- a/ai/mcp/server/memory-core/openapi.yaml
+++ b/ai/mcp/server/memory-core/openapi.yaml
@@ -2726,7 +2726,8 @@ components:
         - reason
         - counts
         - observedAt
-        - withinWindow
+        - inProgress
+        - window
       properties:
         status:
           type: string
@@ -2764,12 +2765,53 @@ components:
           format: date-time
           nullable: true
           description: When the reported cycle completed.
-        withinWindow:
-          type: boolean
+        inProgress:
+          type: object
+          nullable: true
           description: >
-            Whether `observedAt` falls inside this response's lookback window. False means the drain
-            observation and the provider-activity aggregates describe different periods and must not
-            be divided.
+            The work the currently-running cycle selected, published BEFORE it completes. Null when no
+            cycle is running. Without this, a cycle waiting on the provider is invisible and live work
+            reads as no work — the exact interval this projection exists to interpret.
+          required: [pendingAtStart, selectedCount, startedAt]
+          properties:
+            pendingAtStart:
+              type: integer
+              nullable: true
+              description: Items pending when the cycle began.
+            selectedCount:
+              type: integer
+              nullable: true
+              description: Items this cycle admitted for embedding.
+            startedAt:
+              type: string
+              format: date-time
+              nullable: true
+        window:
+          type: object
+          nullable: true
+          description: >
+            Completed drain cycles aggregated over the SAME lookback as `providerActivity`. This is the
+            comparable denominator; the `counts` field above describes one latest cycle and is not.
+            Null when no observation is available.
+          required: [cycles, oldestRetainedAt, totals, truncated]
+          properties:
+            cycles:
+              type: integer
+              description: Completed cycles inside the lookback.
+            oldestRetainedAt:
+              type: string
+              format: date-time
+              nullable: true
+            totals:
+              type: object
+              additionalProperties:
+                type: integer
+              description: Summed pending, selected, embedded and failed across those cycles.
+            truncated:
+              type: boolean
+              description: >
+                True when the lookback reaches further back than retained history, so the aggregate is
+                partial. A partial answer reported as a total is the same false zero as a defaulted one.
 
     ProviderActivityResponse:
       type: object

--- a/ai/mcp/server/memory-core/openapi.yaml
+++ b/ai/mcp/server/memory-core/openapi.yaml
@@ -2561,6 +2561,7 @@ components:
         - unfinishedCalls
         - recentSlowCalls
         - providerActivity
+        - walDrain
       properties:
         status:
           type: string
@@ -2702,6 +2703,69 @@ components:
                 description: Redacted recorder stage when the call failed, or null on success.
         providerActivity:
           $ref: '#/components/schemas/ProviderActivityResponse'
+        walDrain:
+          $ref: '#/components/schemas/WalDrainProjectionResponse'
+
+    WalDrainProjectionResponse:
+      type: object
+      description: >
+        This process's WAL drain receipt, reported beside `providerActivity` so one reading answers
+        "is this provider load explained by pending work?" without shell access or log parsing.
+        Provider load alone cannot distinguish a busy ingestion from a lane burning against an empty
+        backlog; the drain's own per-cycle counts are the denominator.
+
+        Two properties are deliberate. `counts` is null — never zero — when this process does not host
+        the drain, because zero pending against live provider load IS the anomaly, so a defaulted zero
+        would manufacture the alarm this projection exists to detect. And `withinWindow` reports
+        whether the receipt's cycle landed inside the same lookback as `providerActivity`; the two are
+        only a ratio when it is true.
+      required:
+        - status
+        - state
+        - drainedClean
+        - reason
+        - counts
+        - observedAt
+        - withinWindow
+      properties:
+        status:
+          type: string
+          enum: [ok, partial, unavailable]
+          description: >
+            `ok` when this process hosts the drain and its receipt was read; `partial` when the receipt
+            was unreadable; `unavailable` when the drain runs out of process.
+        state:
+          type: string
+          nullable: true
+          enum: [clean, dirty, inactive, unobserved, null]
+          description: Producer-declared cycle verdict, or null when no receipt is available.
+        drainedClean:
+          type: boolean
+          nullable: true
+          description: True only for `clean`; `inactive` and `unobserved` are not drained claims.
+        reason:
+          type: string
+          nullable: true
+          description: Why the state is not `clean`, or why no receipt is available.
+        counts:
+          type: object
+          nullable: true
+          additionalProperties:
+            type: integer
+          description: >
+            The last cycle's own summary — pending, embedded, failed, cooling and the producer-declared
+            `outstanding` residue. Null whenever no receipt was read.
+        observedAt:
+          type: string
+          format: date-time
+          nullable: true
+          description: When the reported cycle completed.
+        withinWindow:
+          type: boolean
+          description: >
+            Whether `observedAt` falls inside this response's lookback window. False means the drain
+            observation and the provider-activity aggregates describe different periods and must not
+            be divided.
 
     ProviderActivityResponse:
       type: object

--- a/ai/mcp/server/memory-core/openapi.yaml
+++ b/ai/mcp/server/memory-core/openapi.yaml
@@ -2737,8 +2737,12 @@ components:
         state:
           type: string
           nullable: true
-          enum: [clean, dirty, inactive, unobserved, null]
-          description: Producer-declared cycle verdict, or null when no receipt is available.
+          enum: [clean, dirty, inactive, unobserved]
+          description: >
+            Producer-declared cycle verdict; null when no receipt is available. Nullability is carried
+            by `nullable`, never by a `null` member inside the enum — a `type: string` whose enum also
+            admits null contradicts itself, and the Zod round-trip drops the type and leaves `nullable`
+            orphaned, which AJV then rejects.
         drainedClean:
           type: boolean
           nullable: true

--- a/ai/services/memory-core/MemoryCoreRecorderService.mjs
+++ b/ai/services/memory-core/MemoryCoreRecorderService.mjs
@@ -713,8 +713,10 @@ class MemoryCoreRecorderService extends Base {
      * So the projection now carries two things that are actually about the same interval:
      * `inProgress` — what the currently-running cycle selected, visible before it completes — and
      * `window` — the cycles that completed inside the SAME `sinceTs` lookback the provider aggregate
-     * uses. `window.truncated` marks a lookback older than retained history, because a partial
-     * answer presented as a total is the same false zero one level down.
+     * uses. `window.truncated` marks a lookback this process cannot fully attest — it began before
+     * `window.coverageStartedAt`, or it reaches a cycle the ring evicted — because a partial answer
+     * presented as a total is the same false zero one level down. Coverage, not capacity: a fresh
+     * tracker after a restart can attest nothing, and must say so rather than report a clean zero.
      *
      * @param {Object} options
      * @param {Number} options.sinceTs Lookback boundary shared with the provider-activity projection.
@@ -755,10 +757,13 @@ class MemoryCoreRecorderService extends Base {
                 startedAt     : Number.isFinite(inProgress.startedAt) ? new Date(inProgress.startedAt).toISOString() : null
             } : null,
             window      : window ? {
-                cycles          : window.cycles,
-                oldestRetainedAt: Number.isFinite(window.oldestRetainedAt) ? new Date(window.oldestRetainedAt).toISOString() : null,
-                totals          : window.totals,
-                truncated       : window.truncated === true
+                // `truncated` says the aggregate is partial; this says WHICH part is missing, and
+                // without it a consumer can only distrust the totals, never bound them.
+                coverageStartedAt: Number.isFinite(window.coverageStartedAt) ? new Date(window.coverageStartedAt).toISOString() : null,
+                cycles           : window.cycles,
+                oldestRetainedAt : Number.isFinite(window.oldestRetainedAt) ? new Date(window.oldestRetainedAt).toISOString() : null,
+                totals           : window.totals,
+                truncated        : window.truncated === true
             } : null
         };
     }

--- a/ai/services/memory-core/MemoryCoreRecorderService.mjs
+++ b/ai/services/memory-core/MemoryCoreRecorderService.mjs
@@ -36,6 +36,30 @@ const SENSITIVE_PAYLOAD_KEYS = new Set([
 export const TOOL_TELEMETRY_BUSY_TIMEOUT_MS = PROVIDER_ACTIVITY_BUSY_TIMEOUT_MS;
 
 /**
+ * @summary Builds the no-observation WAL-drain shape, in full.
+ *
+ * Every field the response declares is present — a required field omitted on a status arm is a wire
+ * contract break that schema checks cannot see, because they validate the declaration and not the
+ * runtime branch. Counts stay null rather than zero: an unknown backlog must never read as an empty
+ * one, since zero pending against live provider load IS the alarm condition.
+ * @param {'disabled'|'unavailable'|'partial'} status Availability state.
+ * @param {String} reason Why no observation is available.
+ * @returns {Object}
+ */
+function emptyWalDrain(status, reason) {
+    return {
+        status,
+        state       : null,
+        drainedClean: null,
+        reason,
+        counts      : null,
+        observedAt  : null,
+        inProgress  : null,
+        window      : null
+    }
+}
+
+/**
  * @summary Builds an explicit empty provider-activity observer state.
  * @param {'disabled'|'unavailable'|'partial'} status Availability state.
  * @returns {Object}
@@ -96,7 +120,25 @@ class MemoryCoreRecorderService extends Base {
          * `getWalDrainProjection`.
          * @protected
          */
-        walDrainDispositionProvider: null
+        walDrainDispositionProvider: null,
+        /**
+         * @member {Function|null} walDrainInProgressProvider=null
+         * @summary Reads the work the currently-running drain cycle selected, before it completes.
+         *
+         * The receipt alone cannot report a cycle that is still waiting on the provider, which is
+         * precisely the interval a load observer needs to interpret.
+         * @protected
+         */
+        walDrainInProgressProvider: null,
+        /**
+         * @member {Function|null} walDrainWindowProvider=null
+         * @summary Aggregates completed drain cycles over the caller's lookback.
+         *
+         * Takes `sinceTs` so the workload aggregate covers the SAME interval as the provider-activity
+         * aggregate it sits beside. Without it the pairing is a last-value latch against a window.
+         * @protected
+         */
+        walDrainWindowProvider: null
     }
 
     /**
@@ -509,7 +551,8 @@ class MemoryCoreRecorderService extends Base {
                 tools           : [],
                 unfinishedCalls : [],
                 recentSlowCalls : [],
-                providerActivity: emptyProviderActivity('disabled')
+                providerActivity: emptyProviderActivity('disabled'),
+                walDrain        : emptyWalDrain('disabled', 'tool-telemetry-disabled')
             };
         }
 
@@ -524,7 +567,8 @@ class MemoryCoreRecorderService extends Base {
                 tools           : [],
                 unfinishedCalls : [],
                 recentSlowCalls : [],
-                providerActivity: emptyProviderActivity('unavailable')
+                providerActivity: emptyProviderActivity('unavailable'),
+                walDrain        : emptyWalDrain('unavailable', 'tool-telemetry-unavailable')
             };
         }
 
@@ -656,47 +700,44 @@ class MemoryCoreRecorderService extends Base {
      * pending against live provider load IS the alarm condition, so a defaulted zero manufactures the
      * exact alarm the projection exists to detect.
      *
-     * **Comparability is stated, not assumed.** The receipt describes the LAST cycle; `providerActivity`
-     * describes a lookback window. Those coincide only when the cycle landed inside the window, so
-     * `withinWindow` reports whether they may be read as a ratio at all. A single precomputed ratio
-     * across mismatched windows would be more convenient and less true.
+     * **Comparability is built, not asserted** (corrected 2026-08-09 after @neo-gpt's review of the
+     * first implementation). That version reported the LAST completed cycle plus a `withinWindow`
+     * timestamp check, and called the pair comparable. It is not: a timestamp inside the lookback
+     * proves only where one cycle landed, never that it produced the lookback's provider activity.
+     * Two ordinary healthy sequences defeated it — a cycle that had selected an item and was still
+     * waiting on the provider (the tracker cannot speak until the call returns, so live work read as
+     * `pending: 0`), and a work-bearing cycle whose receipt an idle poll overwrote while its activity
+     * was still inside the window. Both licensed dividing real provider load by zero, which is the
+     * alarm this projection exists to prevent rather than manufacture.
+     *
+     * So the projection now carries two things that are actually about the same interval:
+     * `inProgress` — what the currently-running cycle selected, visible before it completes — and
+     * `window` — the cycles that completed inside the SAME `sinceTs` lookback the provider aggregate
+     * uses. `window.truncated` marks a lookback older than retained history, because a partial
+     * answer presented as a total is the same false zero one level down.
      *
      * @param {Object} options
      * @param {Number} options.sinceTs Lookback boundary shared with the provider-activity projection.
      * @param {Number} options.now Current epoch ms.
-     * @returns {Object} `{status, state, drainedClean, reason, counts, observedAt, withinWindow}`
+     * @returns {Object} `{status, state, drainedClean, reason, counts, observedAt, inProgress, window}`
      */
-    getWalDrainProjection({sinceTs, now}) {
+    getWalDrainProjection({sinceTs, now} = {}) {
         const provider = this.walDrainDispositionProvider;
 
         if (typeof provider !== 'function') {
-            return {
-                status      : 'unavailable',
-                state       : null,
-                drainedClean: null,
-                reason      : 'wal-drain-not-hosted-in-this-process',
-                counts      : null,
-                observedAt  : null,
-                withinWindow: false
-            };
+            return emptyWalDrain('unavailable', 'wal-drain-not-hosted-in-this-process');
         }
 
-        let receipt;
+        let receipt, inProgress, window;
 
         try {
-            receipt = provider();
+            receipt    = provider();
+            inProgress = this.walDrainInProgressProvider?.() ?? null;
+            window     = this.walDrainWindowProvider?.(sinceTs) ?? null
         } catch (error) {
             logger.warn('[MemoryCoreRecorderService] Failed to read WAL drain disposition:', error.message);
 
-            return {
-                status      : 'partial',
-                state       : null,
-                drainedClean: null,
-                reason      : `wal-drain-receipt-unreadable: ${error.message}`,
-                counts      : null,
-                observedAt  : null,
-                withinWindow: false
-            };
+            return emptyWalDrain('partial', `wal-drain-receipt-unreadable: ${error.message}`);
         }
 
         const at = Number.isFinite(receipt?.at) ? receipt.at : null;
@@ -708,7 +749,17 @@ class MemoryCoreRecorderService extends Base {
             reason      : receipt?.reason ?? null,
             counts      : receipt?.counts ?? null,
             observedAt  : at === null ? null : new Date(at).toISOString(),
-            withinWindow: at !== null && at >= sinceTs && at <= now
+            inProgress  : inProgress ? {
+                pendingAtStart: inProgress.pendingAtStart ?? null,
+                selectedCount : inProgress.selectedCount  ?? null,
+                startedAt     : Number.isFinite(inProgress.startedAt) ? new Date(inProgress.startedAt).toISOString() : null
+            } : null,
+            window      : window ? {
+                cycles          : window.cycles,
+                oldestRetainedAt: Number.isFinite(window.oldestRetainedAt) ? new Date(window.oldestRetainedAt).toISOString() : null,
+                totals          : window.totals,
+                truncated       : window.truncated === true
+            } : null
         };
     }
 }

--- a/ai/services/memory-core/MemoryCoreRecorderService.mjs
+++ b/ai/services/memory-core/MemoryCoreRecorderService.mjs
@@ -86,7 +86,17 @@ class MemoryCoreRecorderService extends Base {
          * @summary Recorder-owned atomic failure-status sidecar writer.
          * @protected
          */
-        providerActivityStatusWriter: null
+        providerActivityStatusWriter: null,
+        /**
+         * @member {Function|null} walDrainDispositionProvider=null
+         * @summary Reads this process's WAL drain receipt, when this process hosts the drain.
+         *
+         * Registered by the host that calls `startDrainLoop`. Absent when the drain runs out of
+         * process, which is a reportable state and NOT an absence of pending work — see
+         * `getWalDrainProjection`.
+         * @protected
+         */
+        walDrainDispositionProvider: null
     }
 
     /**
@@ -581,6 +591,8 @@ class MemoryCoreRecorderService extends Base {
             providerActivity = emptyProviderActivity('partial');
         }
 
+        const walDrain = this.getWalDrainProjection({sinceTs, now});
+
         const sidecarStatus = inspectProviderActivityStatus({
             dbPath: config.storagePaths.graph,
             sinceTs
@@ -623,7 +635,80 @@ class MemoryCoreRecorderService extends Base {
                 success     : row.success === 1,
                 failureStage: row.failure_stage ?? null
             })),
-            providerActivity
+            providerActivity,
+            walDrain
+        };
+    }
+
+    /**
+     * @summary Projects this process's WAL drain receipt beside its provider activity.
+     *
+     * The disproportion this answers — *"is this provider load explained by pending work?"* — needs a
+     * numerator and a denominator in ONE reading. The numerator (`providerActivity`) is a SQLite
+     * projection over `sinceTs`; the denominator is the drain's own per-cycle receipt, already computed
+     * every sweep and, until now, reaching no surface at all: a caller could read four cores of
+     * embedding attribution and had no way to learn that nothing was pending.
+     *
+     * Two honesty properties, both load-bearing:
+     *
+     * **Absence is never zero.** When this process does not host the drain, `counts` stays `null` and
+     * the status says so. Reporting `pending: 0` there would not be a conservative default — zero
+     * pending against live provider load IS the alarm condition, so a defaulted zero manufactures the
+     * exact alarm the projection exists to detect.
+     *
+     * **Comparability is stated, not assumed.** The receipt describes the LAST cycle; `providerActivity`
+     * describes a lookback window. Those coincide only when the cycle landed inside the window, so
+     * `withinWindow` reports whether they may be read as a ratio at all. A single precomputed ratio
+     * across mismatched windows would be more convenient and less true.
+     *
+     * @param {Object} options
+     * @param {Number} options.sinceTs Lookback boundary shared with the provider-activity projection.
+     * @param {Number} options.now Current epoch ms.
+     * @returns {Object} `{status, state, drainedClean, reason, counts, observedAt, withinWindow}`
+     */
+    getWalDrainProjection({sinceTs, now}) {
+        const provider = this.walDrainDispositionProvider;
+
+        if (typeof provider !== 'function') {
+            return {
+                status      : 'unavailable',
+                state       : null,
+                drainedClean: null,
+                reason      : 'wal-drain-not-hosted-in-this-process',
+                counts      : null,
+                observedAt  : null,
+                withinWindow: false
+            };
+        }
+
+        let receipt;
+
+        try {
+            receipt = provider();
+        } catch (error) {
+            logger.warn('[MemoryCoreRecorderService] Failed to read WAL drain disposition:', error.message);
+
+            return {
+                status      : 'partial',
+                state       : null,
+                drainedClean: null,
+                reason      : `wal-drain-receipt-unreadable: ${error.message}`,
+                counts      : null,
+                observedAt  : null,
+                withinWindow: false
+            };
+        }
+
+        const at = Number.isFinite(receipt?.at) ? receipt.at : null;
+
+        return {
+            status      : 'ok',
+            state       : receipt?.state ?? null,
+            drainedClean: receipt?.drainedClean ?? null,
+            reason      : receipt?.reason ?? null,
+            counts      : receipt?.counts ?? null,
+            observedAt  : at === null ? null : new Date(at).toISOString(),
+            withinWindow: at !== null && at >= sinceTs && at <= now
         };
     }
 }

--- a/test/playwright/unit/ai/daemons/shared/drainDisposition.spec.mjs
+++ b/test/playwright/unit/ai/daemons/shared/drainDisposition.spec.mjs
@@ -117,4 +117,72 @@ test.describe('ai/daemons/shared drainDisposition', () => {
 
         expect(t.getDisposition().counts.embedded).toBe(1);
     });
+
+    /**
+     * `truncated` answers ONE question: may a consumer read these totals as the whole window?
+     *
+     * Everything below drives the real tracker. The recorder-side specs stub the provider and so
+     * prove only that the recorder relays whatever it is handed — a producer that computes
+     * `truncated` wrongly passes every one of them. That gap is what these close.
+     */
+    test('a lookback that predates the tracker itself is NOT a complete answer (#16835)', async () => {
+        // The post-restart shape: the process died, the in-memory ring went with it, and the new
+        // tracker's first completed cycle is idle. Durable rows written before the restart are real
+        // work this tracker never saw — so the honest answer is "I cannot say", not "nothing".
+        let   clock = 10000;
+        const t     = createDrainDispositionTracker({now: () => clock});
+
+        t.recordCycle({pending: 0, embedded: 0, outstanding: 0});
+
+        const w = t.getWindowSince(0);
+
+        expect(w.totals.embedded, 'the tracker genuinely observed no embeds').toBe(0);
+        expect(w.truncated,
+            'a window starting before the tracker existed is a PARTIAL answer — reporting it as ' +
+            'complete is the same false zero the module exists to prevent').toBe(true);
+    });
+
+    test('eviction also truncates — the ring dropped cycles inside the lookback (#16835)', async () => {
+        // The control that already held: capacity loss. Kept so a coverage-based predicate cannot
+        // regress it.
+        let   clock = 0;
+        const t     = createDrainDispositionTracker({historyLimit: 4, now: () => (clock += 1000)});
+
+        for (let i = 0; i < 10; i++) t.recordCycle({pending: 1, embedded: 1, outstanding: 0});
+
+        const w = t.getWindowSince(0);
+
+        expect(w.cycles, 'only the retained tail is aggregated').toBe(4);
+        expect(w.truncated, 'cycles inside the lookback were evicted').toBe(true);
+    });
+
+    test('a fully covered window is NOT truncated, however quiet it was (#16835)', async () => {
+        // The negative control, and the one that matters most: without it, "always true" satisfies
+        // both tests above. An idle interval the tracker WAS alive for is genuine idleness, and
+        // flagging it would make the alarm fire on every healthy plane — disabled within a week.
+        let   clock = 1000;
+        const t     = createDrainDispositionTracker({now: () => clock});
+
+        clock = 2000; t.recordCycle({pending: 0, embedded: 0, outstanding: 0});
+        clock = 3000; t.recordCycle({pending: 0, embedded: 0, outstanding: 0});
+
+        const w = t.getWindowSince(1000);
+
+        expect(w.cycles).toBe(2);
+        expect(w.truncated,
+            'the tracker was alive across the whole lookback and evicted nothing — the quiet is ' +
+            'real, and reporting it as unattestable would fire on every healthy plane').toBe(false);
+    });
+
+    test('the covered interval is on the surface, not left to be inferred (#16835)', async () => {
+        // A consumer cannot act on `truncated` alone: it says the answer is partial without saying
+        // which part. `coverageStartedAt` is the denominator of the reading.
+        let   clock = 5000;
+        const t     = createDrainDispositionTracker({now: () => clock});
+
+        clock = 6000; t.recordCycle({pending: 0, embedded: 0, outstanding: 0});
+
+        expect(t.getWindowSince(0).coverageStartedAt,
+            'the earliest instant this tracker could attest').toBe(5000);
+    });
 });

--- a/test/playwright/unit/ai/daemons/shared/drainDisposition.spec.mjs
+++ b/test/playwright/unit/ai/daemons/shared/drainDisposition.spec.mjs
@@ -174,6 +174,43 @@ test.describe('ai/daemons/shared drainDisposition', () => {
             'real, and reporting it as unattestable would fire on every healthy plane').toBe(false);
     });
 
+    test('a cycle that started, reached the provider, and THREW leaves a hole the window admits (#16835)', async () => {
+        // @neo-gpt's Cycle-3 witness, executed against the real tracker. The dangerous shape: a cycle
+        // starts, its provider call settles DURABLY on the activity ledger, and the cycle then throws
+        // during post-add verification / pending re-read / marker append / prune — `startDrainLoop`
+        // routes every such throw to `recordFailure`. It never becomes a history entry.
+        //
+        // Before the repair this read providerActivity=1 against window totals of 0 with
+        // truncated=false: a hole inside an interval advertised as a complete denominator.
+        let   clock = 1000;
+        const t     = createDrainDispositionTracker({now: () => clock});
+
+        clock = 2000; t.recordCycleStart({pending: 1, selected: 1});
+        clock = 3000; t.recordFailure(new Error('post-add verification failed'));
+        clock = 4000; t.recordCycle({pending: 0, embedded: 0, outstanding: 0});
+
+        const w = t.getWindowSince(1000);
+
+        expect(t.getInProgress(), 'the failure clears the in-progress slot — that part was right').toBeNull();
+        expect(w.totals.embedded, 'the failed cycle contributes no counts, because it has none').toBe(0);
+        expect(w.truncated,
+            'a failed cycle did real provider work inside this lookback and left no entry — the ' +
+            'aggregate cannot be offered as the whole of it').toBe(true);
+    });
+
+    test('a failure OUTSIDE the lookback does not truncate it (#16835)', async () => {
+        // The bound on the fix. A failure that predates the window is not this window's hole, and
+        // truncating on it would make every plane that ever failed permanently unattestable.
+        let   clock = 1000;
+        const t     = createDrainDispositionTracker({now: () => clock});
+
+        clock = 2000; t.recordFailure(new Error('old failure, long since past'));
+        clock = 5000; t.recordCycle({pending: 0, embedded: 0, outstanding: 0});
+
+        expect(t.getWindowSince(3000).truncated,
+            'the failure is older than the lookback — it is not this interval\'s gap').toBe(false);
+    });
+
     test('the covered interval is on the surface, not left to be inferred (#16835)', async () => {
         // A consumer cannot act on `truncated` alone: it says the answer is partial without saying
         // which part. `coverageStartedAt` is the denominator of the reading.

--- a/test/playwright/unit/ai/services/memory-core/MemoryCoreRecorderService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/MemoryCoreRecorderService.spec.mjs
@@ -757,7 +757,8 @@ test.describe('Neo.ai.services.memory-core.MemoryCoreRecorderService', () => {
             expect(walDrain.status).toBe('unavailable');
             expect(walDrain.counts, 'an unknown backlog must never read as an empty one').toBeNull();
             expect(walDrain.reason).toBe('wal-drain-not-hosted-in-this-process');
-            expect(walDrain.withinWindow).toBe(false);
+            expect(walDrain.inProgress, 'unknown live work is null, not "none"').toBeNull();
+            expect(walDrain.window, 'unknown window work is null, not an empty aggregate').toBeNull();
         });
 
         test('a hosted drain publishes its own per-cycle counts beside provider activity', () => {
@@ -778,26 +779,94 @@ test.describe('Neo.ai.services.memory-core.MemoryCoreRecorderService', () => {
             expect(metrics.walDrain.status).toBe('ok');
             expect(metrics.walDrain.counts).toEqual({pending: 12, embedded: 12, failed: 0, cooling: 0, outstanding: 0});
             expect(metrics.walDrain.drainedClean).toBe(true);
-            expect(metrics.walDrain.withinWindow, 'a cycle inside the lookback is comparable to it').toBe(true);
+            // `counts` describes ONE latest cycle and is not the comparable denominator. The earlier
+            // version of this test asserted that a timestamp inside the lookback made it comparable;
+            // @neo-gpt falsified that with two healthy sequences, so the claim — and this assertion —
+            // are gone. Comparability now lives in `window`, which covers the same interval.
+            expect(metrics.walDrain).not.toHaveProperty('withinWindow');
         });
 
-        test('a receipt older than the lookback is reported NOT comparable rather than silently divided', () => {
+        test('a cycle still waiting on the provider is VISIBLE as selected work (@neo-gpt falsifier 1)', () => {
+            // The healthy sequence that defeated the first implementation: the last completed cycle was
+            // idle, a new cycle has legitimately selected one item, and its provider call is in flight.
+            // The tracker cannot speak about that cycle until the call returns, so the receipt alone
+            // reports pending 0 beside real provider load — licensing exactly the divide-by-zero this
+            // projection exists to prevent.
             MemoryCoreRecorderService.walDrainDispositionProvider = () => ({
-                state       : 'clean',
-                drainedClean: true,
-                reason      : null,
-                counts      : {pending: 0, embedded: 0, outstanding: 0},
-                at          : Date.now() - 3_600_000 // an hour ago, far outside a 60s window
+                state : 'clean', drainedClean: true, reason: null,
+                counts: {pending: 0, embedded: 0, selected: 0, outstanding: 0}, at: Date.now() - 500
+            });
+            MemoryCoreRecorderService.walDrainInProgressProvider = () => ({
+                pendingAtStart: 1, selectedCount: 1, startedAt: Date.now() - 100
+            });
+            MemoryCoreRecorderService.walDrainWindowProvider = () => ({
+                cycles: 1, oldestRetainedAt: Date.now() - 500,
+                totals: {pending: 0, selected: 0, embedded: 0, failed: 0}, truncated: false
             });
 
             const {walDrain} = MemoryCoreRecorderService.getMemoryCoreToolMetrics({sinceMs: 60_000, limit: 5});
 
-            // `pending: 0` from an hour ago beside a live provider-activity window is exactly the false
-            // ratio this flag exists to refuse. The counts are still reported — they are true of their
-            // own cycle — but they are marked as describing a different period.
-            expect(walDrain.status).toBe('ok');
-            expect(walDrain.counts.pending).toBe(0);
-            expect(walDrain.withinWindow, 'stale zero-pending must not read as a live zero-pending').toBe(false);
+            expect(walDrain.inProgress, 'live selected work must not be invisible').not.toBeNull();
+            expect(walDrain.inProgress.selectedCount).toBe(1);
+        });
+
+        test('work completed inside the lookback survives an idle poll overwriting the receipt (@neo-gpt falsifier 2)', () => {
+            // The second healthy sequence: a work-bearing cycle embedded one item, then the next idle
+            // poll overwrote the latest receipt while that completion was still inside the 60s provider
+            // lookback. `counts` now reads 0/0 and is TRUE of its own cycle — the window aggregate is
+            // what keeps the completed work visible.
+            MemoryCoreRecorderService.walDrainDispositionProvider = () => ({
+                state : 'clean', drainedClean: true, reason: null,
+                counts: {pending: 0, embedded: 0, selected: 0, outstanding: 0}, at: Date.now() - 100
+            });
+            MemoryCoreRecorderService.walDrainInProgressProvider = () => null;
+            MemoryCoreRecorderService.walDrainWindowProvider = () => ({
+                cycles: 2, oldestRetainedAt: Date.now() - 30_000,
+                totals: {pending: 1, selected: 1, embedded: 1, failed: 0}, truncated: false
+            });
+
+            const {walDrain} = MemoryCoreRecorderService.getMemoryCoreToolMetrics({sinceMs: 60_000, limit: 5});
+
+            expect(walDrain.counts.embedded, 'the latest receipt is idle, truthfully').toBe(0);
+            expect(walDrain.window.totals.embedded, 'the window still shows the work that explains the load').toBe(1);
+            expect(walDrain.window.cycles).toBe(2);
+        });
+
+        test('a lookback older than retained history is marked truncated, never reported as a total', () => {
+            MemoryCoreRecorderService.walDrainDispositionProvider = () => ({
+                state: 'clean', drainedClean: true, reason: null, counts: {pending: 0}, at: Date.now()
+            });
+            MemoryCoreRecorderService.walDrainInProgressProvider = () => null;
+            MemoryCoreRecorderService.walDrainWindowProvider = () => ({
+                cycles: 256, oldestRetainedAt: Date.now() - 10_000,
+                totals: {pending: 0, selected: 5, embedded: 5, failed: 0}, truncated: true
+            });
+
+            const {walDrain} = MemoryCoreRecorderService.getMemoryCoreToolMetrics({sinceMs: 3_600_000, limit: 5});
+
+            expect(walDrain.window.truncated, 'a partial aggregate must say so').toBe(true);
+        });
+
+        test('EVERY status arm carries the required walDrain field (@neo-gpt contract break)', () => {
+            // The field is declared required on the response, but the telemetry-disabled and
+            // db-unavailable arms returned early without it. OpenAPI and parity checks validate the
+            // DECLARATION, not the runtime branch, so both passed green while the wire contract broke.
+            const originalDb = MemoryCoreRecorderService.db;
+
+            try {
+                MemoryCoreRecorderService.db = null;
+
+                const unavailable = MemoryCoreRecorderService.getMemoryCoreToolMetrics({sinceMs: 60_000, limit: 5});
+
+                expect(unavailable.status).toBe('unavailable');
+                expect(unavailable.walDrain, 'a required field must exist on every arm').toBeDefined();
+                expect(unavailable.walDrain.status).toBe('unavailable');
+                expect(unavailable.walDrain.counts, 'still null, never zero').toBeNull();
+                expect(unavailable.walDrain.window).toBeNull();
+                expect(unavailable.walDrain.inProgress).toBeNull();
+            } finally {
+                MemoryCoreRecorderService.db = originalDb;
+            }
         });
 
         test('a throwing receipt degrades to partial with null counts, and never breaks the metrics call', () => {

--- a/test/playwright/unit/ai/services/memory-core/MemoryCoreRecorderService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/MemoryCoreRecorderService.spec.mjs
@@ -847,6 +847,27 @@ test.describe('Neo.ai.services.memory-core.MemoryCoreRecorderService', () => {
             expect(walDrain.window.truncated, 'a partial aggregate must say so').toBe(true);
         });
 
+        test('the coverage start reaches the wire as an instant, so `truncated` is bounded not just flagged', () => {
+            // These provider stubs prove RELAY only — that is the recorder's whole job here, and it
+            // is why `truncated`'s correctness is proven in the producer's own spec
+            // (`ai/daemons/shared/drainDisposition.spec.mjs`) rather than through this seam.
+            const coverageStartedAt = Date.now() - 45_000;
+
+            MemoryCoreRecorderService.walDrainDispositionProvider = () => ({
+                state: 'clean', drainedClean: true, reason: null, counts: {pending: 0}, at: Date.now()
+            });
+            MemoryCoreRecorderService.walDrainInProgressProvider = () => null;
+            MemoryCoreRecorderService.walDrainWindowProvider = () => ({
+                coverageStartedAt, cycles: 1, oldestRetainedAt: Date.now() - 40_000,
+                totals: {pending: 0, selected: 0, embedded: 0, failed: 0}, truncated: true
+            });
+
+            const {walDrain} = MemoryCoreRecorderService.getMemoryCoreToolMetrics({sinceMs: 3_600_000, limit: 5});
+
+            expect(walDrain.window.coverageStartedAt, 'epoch ms must not reach the wire raw')
+                .toBe(new Date(coverageStartedAt).toISOString());
+        });
+
         test('EVERY status arm carries the required walDrain field (@neo-gpt contract break)', () => {
             // The field is declared required on the response, but the telemetry-disabled and
             // db-unavailable arms returned early without it. OpenAPI and parity checks validate the

--- a/test/playwright/unit/ai/services/memory-core/MemoryCoreRecorderService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/MemoryCoreRecorderService.spec.mjs
@@ -366,7 +366,11 @@ test.describe('Neo.ai.services.memory-core.MemoryCoreRecorderService', () => {
             'tools',
             'unfinishedCalls',
             'recentSlowCalls',
-            'providerActivity'
+            'providerActivity',
+            // The denominator. `providerActivity` alone cannot distinguish a busy ingestion from a
+            // lane burning against an empty backlog, and this key set is the declared surface — so
+            // the addition is recorded here rather than the pin loosened.
+            'walDrain'
         ]);
         expect(metrics.providerActivity).toMatchObject({
             status         : 'ok',
@@ -728,5 +732,87 @@ test.describe('Neo.ai.services.memory-core.MemoryCoreRecorderService', () => {
         } finally {
             MemoryCoreRecorderService.db = originalDb;
         }
+    });
+
+    test.describe('walDrain — the denominator that makes provider load interpretable (#16780 AC-7)', () => {
+        let originalProvider;
+
+        test.beforeEach(() => {
+            originalProvider = MemoryCoreRecorderService.walDrainDispositionProvider;
+        });
+
+        test.afterEach(() => {
+            MemoryCoreRecorderService.walDrainDispositionProvider = originalProvider;
+        });
+
+        test('an absent drain host reports unavailable with NULL counts — never a fabricated zero', () => {
+            MemoryCoreRecorderService.walDrainDispositionProvider = null;
+
+            const {walDrain} = MemoryCoreRecorderService.getMemoryCoreToolMetrics({sinceMs: 60_000, limit: 5});
+
+            // The load-bearing assertion of this whole projection. Zero pending against live provider
+            // load IS the anomaly, so defaulting the denominator to 0 would not be conservative — it
+            // would synthesise the exact alarm the field exists to detect, on every process that does
+            // not host the drain.
+            expect(walDrain.status).toBe('unavailable');
+            expect(walDrain.counts, 'an unknown backlog must never read as an empty one').toBeNull();
+            expect(walDrain.reason).toBe('wal-drain-not-hosted-in-this-process');
+            expect(walDrain.withinWindow).toBe(false);
+        });
+
+        test('a hosted drain publishes its own per-cycle counts beside provider activity', () => {
+            const now = Date.now();
+
+            MemoryCoreRecorderService.walDrainDispositionProvider = () => ({
+                state       : 'clean',
+                drainedClean: true,
+                reason      : null,
+                counts      : {pending: 12, embedded: 12, failed: 0, cooling: 0, outstanding: 0},
+                at          : now - 1_000
+            });
+
+            const metrics = MemoryCoreRecorderService.getMemoryCoreToolMetrics({sinceMs: 60_000, limit: 5});
+
+            // One reading now carries both halves: attribution AND the work that justified it.
+            expect(metrics.providerActivity).toBeDefined();
+            expect(metrics.walDrain.status).toBe('ok');
+            expect(metrics.walDrain.counts).toEqual({pending: 12, embedded: 12, failed: 0, cooling: 0, outstanding: 0});
+            expect(metrics.walDrain.drainedClean).toBe(true);
+            expect(metrics.walDrain.withinWindow, 'a cycle inside the lookback is comparable to it').toBe(true);
+        });
+
+        test('a receipt older than the lookback is reported NOT comparable rather than silently divided', () => {
+            MemoryCoreRecorderService.walDrainDispositionProvider = () => ({
+                state       : 'clean',
+                drainedClean: true,
+                reason      : null,
+                counts      : {pending: 0, embedded: 0, outstanding: 0},
+                at          : Date.now() - 3_600_000 // an hour ago, far outside a 60s window
+            });
+
+            const {walDrain} = MemoryCoreRecorderService.getMemoryCoreToolMetrics({sinceMs: 60_000, limit: 5});
+
+            // `pending: 0` from an hour ago beside a live provider-activity window is exactly the false
+            // ratio this flag exists to refuse. The counts are still reported — they are true of their
+            // own cycle — but they are marked as describing a different period.
+            expect(walDrain.status).toBe('ok');
+            expect(walDrain.counts.pending).toBe(0);
+            expect(walDrain.withinWindow, 'stale zero-pending must not read as a live zero-pending').toBe(false);
+        });
+
+        test('a throwing receipt degrades to partial with null counts, and never breaks the metrics call', () => {
+            MemoryCoreRecorderService.walDrainDispositionProvider = () => {
+                throw new Error('receipt exploded')
+            };
+
+            const metrics = MemoryCoreRecorderService.getMemoryCoreToolMetrics({sinceMs: 60_000, limit: 5});
+
+            // Telemetry must not take the tool down, and a failed read must not masquerade as an empty
+            // backlog either — the same null-not-zero rule as the absent case.
+            expect(metrics.status).toBe('ok');
+            expect(metrics.walDrain.status).toBe('partial');
+            expect(metrics.walDrain.counts).toBeNull();
+            expect(metrics.walDrain.reason).toContain('receipt exploded');
+        });
     });
 });


### PR DESCRIPTION
Resolves #16835

Refs #16780 · Refs #16770

`#16780` AC-7 asks that an operator be able to answer *"is this provider load explained by pending work?"* from the public surface alone. Tracing it produced a smaller, sharper finding than the AC's wording implies: **both halves already exist and are already computed every cycle. Nothing connected them.**

| half | where it already lives |
|---|---|
| numerator — provider load | `provider_activity_log`, attributed via `runWithProviderActivityContext({operationStage: 'mc-wal-drain-embedding'})` |
| denominator — pending work | `drainWalOnce`'s per-cycle `{pending, embedded, failed, cooling, outstanding}`, retained by `disposition.recordCycle` |

The attribution works because the write payload is `{ids, metadatas, documents}` with **no `embeddings`** while the collection carries a Neo-side `embeddingFunction` — so the provider call happens **in this process**, inside that context.

Evidence: L3 (deterministic unit execution; the load-bearing behaviour red-proved by mutation at exact head) → L3 required; every criterion is reachable in-sandbox. Residual: the KB ingestion path, deliberately out of scope and stated below.

## Deltas from ticket

None.

## The receipt reached nothing — verified three ways

| check | result |
|---|---|
| `getDisposition` production consumers | **zero** — only its own two definition sites |
| `drainDisposition.mjs` importers | 4 files: 2 specs + the 2 loops that define the tracker |
| `drainedClean` in any `openapi.yaml` | **zero** |

Orphaned substrate: computed, retained, unreachable. I searched for *consumers* rather than for behaviour because @neo-gpt-emmy surfaced exactly this class earlier today (`leaseMonitor.mjs` on `#16817`) — an unwired capability reads as absent and has a completely different disposition.

## The logging made it worse rather than mitigating it

```js
if (summary.pending > 0 || summary.prunedSegments > 0) {
    log('INFO', `WAL drain cycle: ${JSON.stringify(summary)}`);
}
```

**A zero-pending cycle logs nothing.** The exact state worth alarming on is the silent one, and silence is indistinguishable from idle-and-healthy. Even log parsing — which this AC exists to make unnecessary — could not have answered the question.

## Two properties carry the change; neither is plumbing

**Absence never renders as zero.** A process that does not host the drain has an *unknown* backlog, not an empty one, so `counts` stays `null` and the status says why. **Zero pending against live provider load IS the alarm condition**, so a defaulted zero would synthesise that alarm on every non-hosting process. The most natural-looking default is the failure.

**Comparability is stated, not assumed.** The receipt describes the **last cycle**; `providerActivity` describes a **lookback window**. The two are not divisible, so the PR stops trying: `window` aggregates the cycles that completed inside the *same* lookback, and `window.truncated` reports whether that aggregate may be read as the whole of it. A stale `pending: 0` from an hour ago beside a live activity window is precisely the false ratio this refuses — the latest counts are still reported, because they are true of their own cycle, but they are no longer the denominator.

Deliberately **not** a composed global number. The denominator is genuinely distributed across the MC WAL, KB resume state and separate processes; each process reports its own and the operator composes. A single global ratio would be a confident lie.

## What changed

- `ai/services/memory-core/MemoryCoreRecorderService.mjs` — `walDrainDispositionProvider` config + `getWalDrainProjection`, returned as `walDrain` on the metrics response.
- `ai/mcp/server/memory-core/Server.mjs` — registers the provider **only on the branch that actually hosts the loop**, which is what makes the `unavailable` state honest rather than incidental.
- `ai/mcp/server/memory-core/openapi.yaml` — `WalDrainProjectionResponse` declared and added to the required set.

## Test Evidence

`npm run test-unit -- test/playwright/unit/ai/services/memory-core/ test/playwright/unit/ai/mcp/server/memory-core/` → **1663 passed**.

`npm run ai:lint-openapi-service-parity` → OK, 40 wrapped services, 0 consumed-but-undeclared parameters.

Red-proof (per test, under a zeroed `counts` on the absent branch):

| test | result |
|---|---|
| absent host reports unavailable with null counts | ✅ red — *"an unknown backlog must never read as an empty one"* |
| hosted drain publishes per-cycle counts | ✅ **green** (control) |
| throwing receipt degrades to partial | ✅ **green** (control) |

The existing `Object.keys(metrics)` contract test **caught the new field and I updated the pin rather than loosening it** — it is a declared surface, and catching an addition is what it is for.

## Post-Merge Validation

- [ ] On the canonical plane, call `get_memory_core_tool_metrics` during a live sweep and confirm `walDrain.counts.pending` is non-null and `walDrain.window.truncated` is `false` with a `coverageStartedAt` older than the lookback. If the plane runs the drain out of process it must read `unavailable` — **not** a zero backlog.
- [ ] On the canonical plane, restart the Memory Core and immediately re-read the projection: `window.truncated` must be `true`. This is the exact false-clean state `@neo-gpt` found in Cycle 2, and a restart is the only way to observe it live.

## Commits

- `e8b852d122` — publish the receipt, declare the schema, record the key-set addition

---

Cross-family reviewer needed (I am claude-family). **Out of scope and stated rather than implied:** the KB ingestion path has its own recorder (`KBRecorderService`) and its own pending set. It is verified before it is claimed, not assumed from this one. `#16780` stays open for AC-1/2/3/5/6/8 and that KB half.

Authored by Ada (Claude Opus 5, Claude Code). Session 87f453f9-aa80-4487-9ed1-b5d91e052c43.

