### PR TITLE
fix(deploy): give the heap-observation channel a shared mount (#16810)

### DIFF
--- a/ai/deploy/docker-compose.dev.yml
+++ b/ai/deploy/docker-compose.dev.yml
@@ -195,6 +195,10 @@ services:
       # which two parity projects resolve to the same directory. That is the exact
       # duplicate-stacks-on-one-plane failure the named-volume election was chosen to prevent.
       - parity-plane:/app/.neo-ai-data-parity
+      # Heap-observation channel, parity half: the env pin relocates the channel under the parity
+      # root (x-plane-env NEO_HEAP_OBSERVATION_DIR), so this dedicated volume shadows that subdir.
+      # Without it the writer still shares via the rw plane root — but the reader would too.
+      - parity-heap-observation:/app/.neo-ai-data-parity/heap-observation
       # Anonymous volume: the image's linux-built node_modules must not be shadowed by the
       # host bind (darwin/arm64 natives → exec format error; AC5 live-run defect 2, #15803).
       - /app/node_modules
@@ -259,6 +263,8 @@ services:
       # which two parity projects resolve to the same directory. That is the exact
       # duplicate-stacks-on-one-plane failure the named-volume election was chosen to prevent.
       - parity-plane:/app/.neo-ai-data-parity
+      # Heap-observation channel, parity half — see the kb-server mount. Writer side stays rw.
+      - parity-heap-observation:/app/.neo-ai-data-parity/heap-observation
       # Anonymous volume: same node_modules shadowing guard as kb-server (AC5 defect 2).
       - /app/node_modules
     # Served identity, same contract as kb-server above — both servers declare `plane {id, dataRoot}`
@@ -334,6 +340,10 @@ services:
       # which two parity projects resolve to the same directory. That is the exact
       # duplicate-stacks-on-one-plane failure the named-volume election was chosen to prevent.
       - parity-plane:/app/.neo-ai-data-parity
+      # Heap-observation channel, parity half — READ side, read-only on purpose: the record
+      # carries provenance self-reported, and the bridge must never author what it publishes.
+      # Without this shadow the rw plane root above would leave the parity reader writable.
+      - parity-heap-observation:/app/.neo-ai-data-parity/heap-observation:ro
       # Same node_modules shadowing guard as the servers (AC5 defect 2).
       - /app/node_modules
       - /var/run/docker.sock:/var/run/docker.sock
@@ -359,6 +369,10 @@ networks:
 volumes:
   parity-chroma: {}
   parity-plane: {}
+  # Heap-observation channel on the parity root: writers are the MCP servers declaring
+  # getHeapObservationServiceKey(), the orchestrator reads it :ro — mirrors the canonical
+  # shared-heap-observation-data one profile over, at the env-pinned parity path.
+  parity-heap-observation: {}
 
 # Environment-backed secret: the host exports the PAT once, Compose materializes it as a mounted
 # file only for the two MCP servers, and rendered config retains the env VAR NAME rather than its

--- a/ai/deploy/docker-compose.yml
+++ b/ai/deploy/docker-compose.yml
@@ -122,6 +122,14 @@ services:
       # A dedicated volume keeps this graph-independent receipt visible without
       # granting the KB container Docker/runtime authority.
       - shared-deployment-state-data:/app/.neo-ai-data/deployment-state:ro
+      # WRITE half of the heap-observation channel, which runs the OPPOSITE
+      # direction to the bridge above: this service reports its own V8 heap and the
+      # orchestrator reads it. Without this mount the reporter writes into the
+      # container's own layer and the orchestrator reads its own empty one, so every
+      # observation surfaces as `unavailable/absent` forever — a silent no-op, because
+      # the reporter is deliberately non-fatal and a successful local write looks
+      # identical to a delivered one.
+      - shared-heap-observation-data:/app/.neo-ai-data/heap-observation
     depends_on:
       chroma:
         condition: service_healthy
@@ -237,6 +245,9 @@ services:
       # Read-only half of the orchestrator -> public MCP deployment-state bridge, and the mount the
       # recovery actuator publishes its config overlay onto.
       - shared-deployment-state-data:/app/.neo-ai-data/deployment-state:ro
+      # WRITE half of the heap-observation channel — see the kb-server mount for why the
+      # absence of this line produced a channel that reported success and delivered nothing.
+      - shared-heap-observation-data:/app/.neo-ai-data/heap-observation
     depends_on:
       chroma:
         condition: service_healthy
@@ -334,15 +345,6 @@ services:
       # lifecycle operations aimed at the orchestrator structurally — restarting it through the bridge
       # it publishes would kill the process serving the request before any outcome could be reported.
       - NEO_ORCHESTRATOR_RUNTIME_ACCESS_ALLOWED_SERVICES=chroma,kb-server,mc-server,local-model,orchestrator
-      # The SECOND evidence channel. A container-unhealthy state is advisory on its own; it licenses a
-      # restart only alongside a failed DIRECT probe of the service, so without these URLs a wedged
-      # service is diagnosed and never acted on. Hostnames are the compose service keys.
-      #
-      # Only the two MCP-shaped services are listed. `chroma` answers a TCP check and `local-model`
-      # answers `ollama list`; neither speaks the MCP healthcheck tool, and a probe that failed against
-      # them would be a fault in this configuration reported as a fault in the service. They therefore
-      # get no direct probe and are never restarted on the runtime's verdict alone — the safe default.
-      - NEO_DEPLOYMENT_STATE_BRIDGE_DIRECT_PROBE_URLS=http://kb-server:3000,http://mc-server:3001
     volumes:
       # Scheduler cadence, tenant-repo revisions, recovery ledgers, logs, and
       # process-epoch files share AiConfig.orchestrator.dataDir. Persist the
@@ -354,6 +356,10 @@ services:
       # Sole writer for the graph-independent deployment-state bridge consumed
       # read-only by KB/MC.
       - shared-deployment-state-data:/app/.neo-ai-data/deployment-state
+      # READ half of the heap-observation channel. Read-only on purpose: the
+      # services vouch for their own heap, and the bridge must never be able to author
+      # an observation it then publishes as `provenance: self-reported`.
+      - shared-heap-observation-data:/app/.neo-ai-data/heap-observation:ro
       - tenant-repo-mirrors:/app/.neo-ai-data/tenant-repos
       # The `golden-path` scheduler lane writes the handoff and its derived
       # route artifacts here; mc-server mounts the same directory read-side.
@@ -616,6 +622,9 @@ volumes:
   shared-sqlite-data:
   shared-deployment-state-data:
   shared-handoff-data:
+  # Heap-observation channel: written by every MCP server declaring
+  # `getHeapObservationServiceKey()`, read by the orchestrator's deployment-state bridge.
+  shared-heap-observation-data:
   tenant-repo-mirrors:
   caddy-data:
   caddy-config:

--- a/ai/deploy/docker-compose.yml
+++ b/ai/deploy/docker-compose.yml
@@ -122,13 +122,11 @@ services:
       # A dedicated volume keeps this graph-independent receipt visible without
       # granting the KB container Docker/runtime authority.
       - shared-deployment-state-data:/app/.neo-ai-data/deployment-state:ro
-      # WRITE half of the heap-observation channel, which runs the OPPOSITE
-      # direction to the bridge above: this service reports its own V8 heap and the
-      # orchestrator reads it. Without this mount the reporter writes into the
-      # container's own layer and the orchestrator reads its own empty one, so every
-      # observation surfaces as `unavailable/absent` forever — a silent no-op, because
-      # the reporter is deliberately non-fatal and a successful local write looks
-      # identical to a delivered one.
+      # WRITE half of the heap-observation channel: this service reports its own V8 heap and the
+      # orchestrator reads it. Without a shared mount the reporter writes into the container's own
+      # layer and the orchestrator reads its own empty one, so every observation surfaces as
+      # `unavailable/absent` forever — a silent no-op, because a successful LOCAL write is
+      # indistinguishable from a delivered one at the writer.
       - shared-heap-observation-data:/app/.neo-ai-data/heap-observation
     depends_on:
       chroma:
@@ -245,8 +243,11 @@ services:
       # Read-only half of the orchestrator -> public MCP deployment-state bridge, and the mount the
       # recovery actuator publishes its config overlay onto.
       - shared-deployment-state-data:/app/.neo-ai-data/deployment-state:ro
-      # WRITE half of the heap-observation channel — see the kb-server mount for why the
-      # absence of this line produced a channel that reported success and delivered nothing.
+      # WRITE half of the heap-observation channel: this service reports its own V8 heap and the
+      # orchestrator reads it. Without a shared mount the reporter writes into the container's own
+      # layer and the orchestrator reads its own empty one, so every observation surfaces as
+      # `unavailable/absent` forever — a silent no-op, because a successful LOCAL write is
+      # indistinguishable from a delivered one at the writer.
       - shared-heap-observation-data:/app/.neo-ai-data/heap-observation
     depends_on:
       chroma:
@@ -345,6 +346,15 @@ services:
       # lifecycle operations aimed at the orchestrator structurally — restarting it through the bridge
       # it publishes would kill the process serving the request before any outcome could be reported.
       - NEO_ORCHESTRATOR_RUNTIME_ACCESS_ALLOWED_SERVICES=chroma,kb-server,mc-server,local-model,orchestrator
+      # The SECOND evidence channel. A container-unhealthy state is advisory on its own; it licenses a
+      # restart only alongside a failed DIRECT probe of the service, so without these URLs a wedged
+      # service is diagnosed and never acted on. Hostnames are the compose service keys.
+      #
+      # Only the two MCP-shaped services are listed. `chroma` answers a TCP check and `local-model`
+      # answers `ollama list`; neither speaks the MCP healthcheck tool, and a probe that failed against
+      # them would be a fault in this configuration reported as a fault in the service. They therefore
+      # get no direct probe and are never restarted on the runtime's verdict alone — the safe default.
+      - NEO_DEPLOYMENT_STATE_BRIDGE_DIRECT_PROBE_URLS=http://kb-server:3000,http://mc-server:3001
     volumes:
       # Scheduler cadence, tenant-repo revisions, recovery ledgers, logs, and
       # process-epoch files share AiConfig.orchestrator.dataDir. Persist the
@@ -356,9 +366,9 @@ services:
       # Sole writer for the graph-independent deployment-state bridge consumed
       # read-only by KB/MC.
       - shared-deployment-state-data:/app/.neo-ai-data/deployment-state
-      # READ half of the heap-observation channel. Read-only on purpose: the
-      # services vouch for their own heap, and the bridge must never be able to author
-      # an observation it then publishes as `provenance: self-reported`.
+      # READ half of the heap-observation channel. Read-only on purpose: the record carries
+      # `provenance: self-reported`, so the bridge must never be able to author an observation it
+      # then publishes as the service's own claim.
       - shared-heap-observation-data:/app/.neo-ai-data/heap-observation:ro
       - tenant-repo-mirrors:/app/.neo-ai-data/tenant-repos
       # The `golden-path` scheduler lane writes the handoff and its derived
@@ -622,8 +632,8 @@ volumes:
   shared-sqlite-data:
   shared-deployment-state-data:
   shared-handoff-data:
-  # Heap-observation channel: written by every MCP server declaring
-  # `getHeapObservationServiceKey()`, read by the orchestrator's deployment-state bridge.
+  # Heap-observation channel: written by every MCP server declaring a heap-observation service
+  # key, read by the orchestrator's deployment-state bridge.
   shared-heap-observation-data:
   tenant-repo-mirrors:
   caddy-data:


### PR DESCRIPTION
Resolves neomjs/neo#16810

Compose-only salvage from PR neomjs/neo#16811 per @neo-gpt-emmy's terminal Drop+Supersede (`PRR` on `7d041fe733`). Her salvage map: **preserve both Compose deltas unchanged, discard the 538-line scanner.** That is exactly this diff — the two compose files are byte-identical to the reviewed head, and nothing else ships.

The channel had no shared volume. Both ends resolve the identical expression, so the code reads symmetric, but the directory appeared in neither compose file: each service wrote into its own container layer while the orchestrator read its own empty one. Every reporting service has surfaced `unavailable/absent` on every containerized plane since the channel merged.

- **Canonical:** `shared-heap-observation-data` — `kb-server` and `mc-server` read-write, `orchestrator` read-only.
- **Parity:** `parity-heap-observation` at the relocated plane root, same RW/RW/RO shape. The parity stack overrides the channel path via `NEO_HEAP_OBSERVATION_DIR`, so one literal cannot serve both profiles.

Read-only on the reader is not tidiness: the record carries `provenance: self-reported`, so a bridge able to write the file could author an observation it then publishes as the service's own claim.

Evidence: L2 (both renderings independently confirmed with `docker compose config` during review; sibling compose specs green on this tree) → L2 required. Residual: the live `status: available` reading is `#16763` AC-9 and needs the plane recreated with the new volume.

## Deltas from ticket

- **No guard ships here, and `#16810`'s guard ACs are relocated to `#16838` rather than dropped.** Five review cycles established that a source-text scanner cannot bind the property it claims: a duplicate module-scope declaration (the scanner takes the first, Node executes the second) and an unrelated top-level decoy class (the scanner walks every `ClassBody`, the module exports another) each moved the executed runtime while the guard stayed 5/5 green. Both are **identity** failures — parsing cannot tell which declaration wins, only executing can — so each syntax repair deepened a non-authoritative parser instead of fixing it.
- **The parity profile needed its own volume**, discovered mid-review: it relocates the plane root and overrides the channel path, so a guard or mount bound to the canonical literal is vacuous there.

## Test Evidence

`npm run test-unit -- ai/deploy/ParityPlaneVolumeScoping.spec ai/deploy/DeclaredHeapCeilings.spec ai/daemons/orchestrator/daemon.spec ai/deploy/FleetServerComposition.spec --workers=1` → **68 passed**, including `daemon.spec`'s `#15759` sole-owner-volume invariant, which is the one most likely to conflict with a new volume under the same root.

Both profile renderings were confirmed with `docker compose config` on PR `#16811` at review — canonical and parity each resolving KB/MC read-write plus orchestrator read-only on their own profile-specific volume.

## Post-Merge Validation

- [ ] The plane is recreated with `compose up -d` — **never `restart`**, which re-runs the baked container config and never attaches a new volume. Deployment authority, not this PR's.
- [ ] `get_deployment_state_snapshot` reports `heapObservation.status: "available"` for `kb-server` and `mc-server`, stated with cgroup limit, declared ceiling and node version. That is `#16763` AC-9 and closes that ticket, not this one.

## Deltas

None beyond the two above.

Authored by Vega (@neo-opus-vega, Claude Opus 5, Claude Code). Origin Session ID: 4131135d-1b20-487f-9d23-d7213914246b.
