### PR TITLE
docs(ai): truth-fold resolveMemorySaturationScope's docblock to shipped behavior (#16840)

### DIFF
--- a/ai/daemons/orchestrator/services/ContainerHealthDiagnosisService.mjs
+++ b/ai/daemons/orchestrator/services/ContainerHealthDiagnosisService.mjs
@@ -1404,9 +1404,23 @@ export const MEMORY_SATURATION_SCOPES = Object.freeze({
  *
  * Three outcomes, and the third is the point of the slice:
  *
- * - **`container`** — no envelope, or an envelope explicitly reporting `not-node`. Container usage
- *   over the container limit is the honest measure of container pressure for these, and nothing about
- *   this slice changes them. `chroma` is the live example.
+ * - **`container`** — licensed by **`nodeCommand === false` and nothing else**. Container usage over
+ *   the container limit is the honest measure of container pressure for a genuinely non-Node service,
+ *   and nothing about this slice changes them. `chroma` is the live example.
+ *
+ *   **The envelope deliberately does not count here, even when every envelope in the window says
+ *   `not-node`.** Two independent reasons, both found by falsifier rather than by reading:
+ *
+ *   1. The producer's `not-node` was never the positive classification it looked like — its gate was
+ *      `nodeCommand !== true`, so an UNREADABLE inspect refused with the same word as a genuine
+ *      non-Node service. Consuming that as authority let an unknown identity manufacture an
+ *      authoritative container-scoped fact, and with a CPU fact alongside it reached
+ *      `diagnosed → throttle-shed` while inspect itself was unreadable. The producer now distinguishes
+ *      `identity-unknown`, and this consumer deliberately does **not** depend on that distinction being
+ *      right — which is the more durable half of the repair.
+ *   2. Envelopes ride on **retained** samples; `nodeCommand` is read live per collection. A window held
+ *      from earlier collections can therefore carry an all-`not-node` set while the current
+ *      `nodeCommand` reads `true`, letting a stale classification silently outvote a live one.
  * - **`heap`** — a Node service with at least one usable V8 reading in the window. Old-generation
  *   usage over the declared ceiling.
  * - **`unavailable`** — a Node service with no usable reading: channel disabled, stale, skewed,
@@ -1415,7 +1429,12 @@ export const MEMORY_SATURATION_SCOPES = Object.freeze({
  *   removes, and would do it silently on the path where the heap channel is broken — which is the
  *   moment the number is least trustworthy and most likely to be believed.
  *
- * @param {Object[]} samples Stats samples, each optionally carrying `heapObservation`.
+ * @param {Object}         options
+ * @param {Object[]}       options.samples Stats samples, each optionally carrying `heapObservation`.
+ * @param {Boolean|null}   options.nodeCommand Live per-collection identity read. **The sole authority
+ *     for the `container` scope**: only an explicit `false` licenses the container ratio. `true` and
+ *     `null` both route to `heap`/`unavailable`, because "not Node" and "could not tell" must not
+ *     collapse into one answer — that collapse is the defect this parameter exists to prevent.
  * @returns {Object} `{scope, percents}` — `percents` is populated only for the `heap` scope.
  */
 function resolveMemorySaturationScope({samples, nodeCommand}) {

--- a/ai/daemons/orchestrator/services/ContainerHealthDiagnosisService.mjs
+++ b/ai/daemons/orchestrator/services/ContainerHealthDiagnosisService.mjs
@@ -1449,7 +1449,18 @@ export const MEMORY_SATURATION_SCOPES = Object.freeze({
  *     for the `container` scope**: only an explicit `false` licenses the container ratio. `true` and
  *     `null` both route to `heap`/`unavailable`, because "not Node" and "could not tell" must not
  *     collapse into one answer — that collapse is the defect this parameter exists to prevent.
- * @returns {Object} `{scope, percents}` — `percents` is populated only for the `heap` scope.
+ * @returns {Object} `{scope, percents, timestamps, unavailableReason}` — all four keys on every
+ *     branch, never a scope-dependent shape, so a consumer reads `scope` to know which fields carry
+ *     meaning instead of testing for a key's presence. `percents` and `timestamps` are populated only
+ *     for `heap`; `unavailableReason` only for `unavailable`.
+ *
+ *     **`timestamps` is not a convenience copy of the sample times**, and that is why it has to be
+ *     returned rather than re-derived. These are the SUBJECT's own `observedAt` stamps; the caller
+ *     measures the heap window from them precisely because the poll clock and the reporter's clock
+ *     tick independently. Substituting `samples[].observedAtMs` here looks equivalent and is the
+ *     observer's-clock defect described above. `unavailableReason` is consumer-visible output, not an
+ *     internal diagnostic: it is published verbatim in the `heap-observation-unavailable` fact, where
+ *     it is the field that names which repair is owed.
  */
 function resolveMemorySaturationScope({samples, nodeCommand}) {
     const

--- a/ai/daemons/orchestrator/services/ContainerHealthDiagnosisService.mjs
+++ b/ai/daemons/orchestrator/services/ContainerHealthDiagnosisService.mjs
@@ -1396,11 +1396,19 @@ export const MEMORY_SATURATION_SCOPES = Object.freeze({
 /**
  * @summary Decides which numerator this service's memory saturation may legitimately use.
  *
- * **A service's scope is read from the observation envelope, not from a roster.** Each stats sample
- * carries the heap envelope captured at the same instant, and that envelope already answers "is this
- * a Node process" — the bridge refuses to publish an observation for anything whose `Config.Cmd` is
- * not Node and says so with `not-node`. Re-deriving that here would put a second definition of "a
- * Node service" in the codebase, and the two would drift.
+ * **Identity and measurement are separate axes, and only one of them is the envelope's.**
+ *
+ * - **Identity** — whether this service may use the container ratio at all — comes from the live
+ *   `nodeCommand` read, never from the envelope. An envelope's `not-node` was a *refusal* gate, not a
+ *   positive classification, so consuming it as identity let an unreadable inspect manufacture an
+ *   authoritative container-scoped fact. Detail and both falsifiers in the `container` bullet below.
+ * - **Measurement** — the V8 numbers themselves — comes from the envelope on each stats sample,
+ *   captured at the same instant as the container reading it is paired with.
+ *
+ * An earlier revision of this docblock said scope was *"read from the observation envelope, not from
+ * a roster"*, on the reasoning that re-deriving Node-ness here would create a second definition that
+ * could drift. That premise was retired when identity moved to the live read: there is no second definition, because
+ * identity has exactly one source — `nodeCommand` — and the envelope never carried it.
  *
  * Three outcomes, and the third is the point of the slice:
  *
@@ -1421,10 +1429,16 @@ export const MEMORY_SATURATION_SCOPES = Object.freeze({
  *   2. Envelopes ride on **retained** samples; `nodeCommand` is read live per collection. A window held
  *      from earlier collections can therefore carry an all-`not-node` set while the current
  *      `nodeCommand` reads `true`, letting a stale classification silently outvote a live one.
- * - **`heap`** — a Node service with at least one usable V8 reading in the window. Old-generation
- *   usage over the declared ceiling.
- * - **`unavailable`** — a Node service with no usable reading: channel disabled, stale, skewed,
- *   identity-mismatched, an undeclared ceiling, or simply not deployed yet. **No fact is emitted.**
+ * - **`heap`** — a Node service with a usable V8 reading on **every** sample in the window
+ *   (`usable.length === samples.length`). Old-generation usage over the declared ceiling.
+ *
+ *   **Full coverage or nothing**, and the partial case is the reason: a window with one usable
+ *   reading and one hole is not a weaker heap signal, it is a *different* window than the one the
+ *   count floor was calibrated against. Admitting it would let a single sample clear a floor meant
+ *   for the full set.
+ * - **`unavailable`** — a Node service **without** full coverage: no usable reading at all, or some
+ *   but not all — channel disabled, stale, skewed, identity-mismatched, an undeclared ceiling, or
+ *   simply not deployed yet. **No fact is emitted.**
  *   Falling back to the container ratio here would reinstate exactly the cross-scope pair this slice
  *   removes, and would do it silently on the path where the heap channel is broken — which is the
  *   moment the number is least trustworthy and most likely to be believed.


### PR DESCRIPTION
Resolves #16840

`resolveMemorySaturationScope`'s implementation was repaired in `#16630` Slice B after @neo-gpt falsified the envelope's scope authority. **Its docblock was not, and still taught the defect.**

Eleven lines apart, in the same function:

```
docblock:  container — no envelope, or an envelope explicitly reporting `not-node`
inline:    nodeCommand === false is the ONLY thing that licenses the container ratio,
           and the envelope deliberately does not count
```

And `nodeCommand` — the destructured parameter deciding the entire outcome — appeared nowhere in the `@param` list.

Evidence: L2 (docs truth-fold; the behavioural spec is the control and is unchanged) → L2 required. Residual: none.

## Deltas from ticket

None. One addition beyond the prescription: the docblock now records **both** reasons the envelope was demoted rather than stating the rule bare — a constraint without its rationale gets re-litigated as arbitrary, and this one was already re-derived once by falsifier.

## Test Evidence

`npm run test-unit -- ai/daemons/orchestrator/services/ContainerHealthDiagnosisService.spec --workers=1` → **87 passed**, unchanged. That is the control, not a demonstration: a docs-only change that moved a behavioural test would mean the change was not docs-only.

## Post-Merge Validation

- [ ] None. The rendered doclet is the artifact and it is produced from the committed source.

## Deltas

None beyond the one noted above.

Authored by Vega (@neo-opus-vega, Claude Opus 5, Claude Code). Origin Session ID: 4131135d-1b20-487f-9d23-d7213914246b.
