### PR TITLE
fix(ai): one failing embed batch no longer strands the remainder (#16843)

### DIFF
--- a/ai/services/knowledge-base/IngestionService.mjs
+++ b/ai/services/knowledge-base/IngestionService.mjs
@@ -402,6 +402,19 @@ class IngestionService extends Base {
                     continue;
                 }
 
+                // A partially-successful embed is NOT a clean run. `VectorService.embedChunks` now skips a batch
+                // that exhausts its retries while other batches succeed — the alternative, aborting, stranded
+                // every later batch on every future sweep. Skipping keeps the corpus advancing, but the skipped
+                // chunks did not land, so the run must say so: without this, a sync over a corpus with a hole in
+                // it reports as complete and nothing ever revisits the gap.
+                for (const failure of result?.failedBatches || []) {
+                    summary.errors.push(this.createError({
+                        code   : 'KB_EMBED_BATCH_SKIPPED',
+                        message: `Embedding batch ${failure.batchIndex} was skipped after exhausting its retries: ${failure.reason}`,
+                        details: {repoSlug, batchIndex: failure.batchIndex, chunkIds: failure.chunkIds}
+                    }));
+                }
+
                 summary.embeddingsGenerated += result?.embedded ?? group.length;
                 this.updateIngestionProgress({
                     embeddedChunks: summary.embeddingsGenerated,

--- a/ai/services/knowledge-base/VectorService.mjs
+++ b/ai/services/knowledge-base/VectorService.mjs
@@ -645,7 +645,11 @@ class VectorService extends Base {
      *     `maxRetries * ceil(batchSize / batchEmbeddingChunkSize) * (1 + unloadRetryCount) *
      *     batchEmbeddingTimeoutMs`, which is 16h40m at stock leaves against a 30-minute `maxActiveHoldMs`.
      *     Per-chunk consultation caps the interval at one chunk's worst case.
-     * @returns {Promise<{embedded: Number, skipped: Number, yielded: Boolean}>}
+     * @returns {Promise<{embedded: Number, skipped: Number, yielded: Boolean, failedBatches: Object[]}>}
+     *     `failedBatches` carries `{batchIndex, chunkIds, reason}` for every batch that exhausted its retries
+     *     while other batches were succeeding. Such a batch is skipped rather than aborting the sweep, because
+     *     aborting strands every later batch permanently — see the rationale at the exhaustion branch. A sweep
+     *     in which NOTHING embedded still throws: that is a provider outage, not poisoned content.
      */
     async embedChunks({collection, chunksToProcess, shouldYield = () => false}) {
         if (chunksToProcess.length === 0) {
@@ -657,6 +661,7 @@ class VectorService extends Base {
 
         const {batchSize, batchDelay, maxRetries} = aiConfig;
         const guardrail                           = this.resolveEmbeddingGuardrail();
+        const failedBatches                       = [];
         let   embeddedCount                       = 0;
         let   skippedCount                        = 0;
         let   yielded                             = false;
@@ -707,8 +712,9 @@ class VectorService extends Base {
             const batchToEmbed = embeddable.map(input => input.chunk);
             const textsToEmbed = embeddable.map(input => input.text);
 
-            let retries = 0;
-            let success = false;
+            let retries   = 0;
+            let success   = false;
+            let lastError = null;
 
             while (retries < maxRetries && !success) {
                 try {
@@ -769,23 +775,58 @@ class VectorService extends Base {
                         break;
                     }
 
+                    lastError = err;
                     retries++;
                     console.error(`An error occurred during embedding batch ${i / batchSize + 1}. Retrying (${retries}/${maxRetries})...`, err.message);
                     if (retries < maxRetries) {
                         await new Promise(res => setTimeout(res, 2 ** retries * 1000)); // Exponential backoff
-                    } else {
-                        throw new Error(`Failed to process batch ${i / batchSize + 1} after ${maxRetries} retries. Aborting.`);
                     }
                 }
             }
 
-            // The retry loop exits on success, on exhaustion (which throws), or on a yield — only the last
-            // one leaves the outer sweep to stop, so it is named explicitly rather than relying on the next
+            // Retry exhaustion, and the whole reason this branch is not a bare `throw`.
+            //
+            // Aborting the sweep here strands every LATER batch permanently, not temporarily: `embed()`
+            // rebuilds `chunksToProcess` by walking the corpus IN ORDER and keeping what the collection does
+            // not already hold, so succeeded batches drop out while the failed one stays first in line. A
+            // batch that fails deterministically — one rejected chunk, one payload past the guardrail — is
+            // therefore re-attempted, re-charged its full retry cost, and re-aborted at the identical index on
+            // every future sweep. Nothing after it is ever attempted again.
+            //
+            // The yield arm one block up was hardened against exactly this shape ("a holder that yields at the
+            // same chunk every time never advances"); this arm had no equivalent. Same loop, same hazard, one
+            // guarantee.
+            //
+            // What separates a poisoned batch from a dead provider is already in hand: whether ANY batch has
+            // embedded this sweep. Deriving it needs no config leaf and no threshold nobody could defend.
+            if (!success && !yielded) {
+                failedBatches.push({
+                    batchIndex: i / batchSize + 1,
+                    chunkIds  : batchToEmbed.map(chunk => chunk.id),
+                    reason    : lastError?.message || 'unknown embedding failure'
+                });
+
+                // Nothing has embedded at all: the provider is down, not the content poisoned. Stop, and stop
+                // by throwing — the caller records the failure from the throw, so continuing silently would
+                // turn a total outage into a success-shaped receipt with zero rows. Preserved verbatim because
+                // it is the correct behaviour for this case: walking the rest of the corpus would spend
+                // `remainingBatches * maxRetries * timeout` proving what the first batch already proved.
+                if (embeddedCount === 0) {
+                    throw new Error(`Failed to process batch ${i / batchSize + 1} after ${maxRetries} retries. Aborting.`);
+                }
+
+                // The provider has answered this sweep, so this batch is the problem. Skip it and keep going;
+                // the remainder is recoverable work and the failure travels back in `failedBatches`.
+                logger.warn(`[VectorService] Batch ${i / batchSize + 1} failed after ${maxRetries} retries; skipping it and continuing (${embeddedCount} embedded so far). Reason: ${lastError?.message}`);
+            }
+
+            // The retry loop exits on success, on exhaustion (handled directly above), or on a yield — only the
+            // last one leaves the outer sweep to stop, so it is named explicitly rather than relying on the next
             // between-batch checkpoint observing a predicate that may already have flipped back.
             if (yielded) break;
         }
 
-        return {embedded: embeddedCount, skipped: skippedCount, yielded};
+        return {embedded: embeddedCount, skipped: skippedCount, yielded, failedBatches};
     }
 
     /**
@@ -1248,10 +1289,16 @@ class VectorService extends Base {
 
         const embedResult = await this.embedChunks({collection, chunksToProcess});
 
-        const count   = await collection.count();
-        const message = `Embedding complete. Collection now contains ${count} items.`;
+        const count         = await collection.count();
+        const failedBatches = embedResult.failedBatches || [];
+        const message       = failedBatches.length > 0
+            ? `Embedding complete with ${failedBatches.length} skipped batch(es). Collection now contains ${count} items.`
+            : `Embedding complete. Collection now contains ${count} items.`;
         logger.log(message);
-        return {message, embedded: embedResult.embedded, deleted: idsToDelete.length};
+
+        // Surfaced rather than swallowed: a skipped batch is recoverable work that did NOT land, and a caller
+        // that cannot see it reports a clean sync over a corpus with a hole in it.
+        return {message, embedded: embedResult.embedded, deleted: idsToDelete.length, failedBatches};
     }
 
     /**

--- a/ai/services/knowledge-base/VectorService.mjs
+++ b/ai/services/knowledge-base/VectorService.mjs
@@ -2,8 +2,8 @@ import aiConfig             from '../../mcp/server/knowledge-base/config.mjs';
 import TextEmbeddingService, {
     isEmbeddingBatchYieldError
 }                             from '../memory-core/TextEmbeddingService.mjs';
-import mcConfig             from '../../mcp/server/memory-core/config.mjs';
-import Base                 from '../../../src/core/Base.mjs';
+import mcConfig from '../../mcp/server/memory-core/config.mjs';
+import Base     from '../../../src/core/Base.mjs';
 import {
     bytesToTokens,
     emitConsumerFriction
@@ -815,7 +815,11 @@ class VectorService extends Base {
                     throw new Error(`Failed to process batch ${i / batchSize + 1} after ${maxRetries} retries. Aborting.`);
                 }
 
-                // The provider has answered this sweep, so this batch is the problem. Skip it and keep going;
+                // At least one batch has landed, so continuing is worth attempting. This is a CONTINUATION
+                // POLICY, not a diagnosis: an earlier success does not prove the batch is at fault — a
+                // provider can die after embedding fine for an hour, and this branch cannot tell that from
+                // one poisoned payload. It only decides that the remaining work is worth trying rather than
+                // abandoning, and records what failed so the caller can decide what the hole means. Skip it and keep going;
                 // the remainder is recoverable work and the failure travels back in `failedBatches`.
                 logger.warn(`[VectorService] Batch ${i / batchSize + 1} failed after ${maxRetries} retries; skipping it and continuing (${embeddedCount} embedded so far). Reason: ${lastError?.message}`);
             }
@@ -938,6 +942,22 @@ class VectorService extends Base {
 
             if (embedResult.skipped > 0) {
                 throw new Error(`KB_EMBEDDING_INPUT_SIZE_EXCEEDED: shadow-swap refused to promote an incomplete corpus after skipping ${embedResult.skipped} over-budget embedding chunk(s).`);
+            }
+
+            // `embedChunks` is shared by BOTH stale strategies, and a hole means opposite things to
+            // them. On the incremental path a skipped batch is recoverable — the canonical collection
+            // keeps everything that did land and the next sweep re-selects the rest. Here the shadow is
+            // about to REPLACE a complete live corpus, so the same hole is permanent data loss with a
+            // success-shaped receipt: the live collection would be parked and an incomplete shadow
+            // promoted over it.
+            //
+            // Refusing here rather than teaching `embedChunks` about strategies is deliberate: the
+            // batch loop reports what happened, and the transaction boundary decides what that means
+            // for its own commit semantics. Complete-or-preserve stays the shadow's invariant, in the
+            // same shape the over-budget guard above already uses, and the throw precedes both renames
+            // so the live corpus is untouched.
+            if (embedResult.failedBatches?.length > 0) {
+                throw new Error(`KB_EMBEDDING_BATCH_FAILED: shadow-swap refused to promote an incomplete corpus after ${embedResult.failedBatches.length} batch(es) exhausted their retries.`);
             }
 
             logger.log(`Promoting shadow collection '${shadowName}' to '${aiConfig.collectionName}'.`);

--- a/test/playwright/unit/ai/services/knowledge-base/VectorService.batchFailureIsolation.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/VectorService.batchFailureIsolation.spec.mjs
@@ -72,7 +72,7 @@ function makeChunks(count) {
 }
 
 test.describe('VectorService.embedChunks — one failing batch must not strand the remainder (#16843)', () => {
-    let SDK, KB_VectorService, KB_Config, TextEmbeddingService;
+    let SDK, KB_VectorService, KB_Config, TextEmbeddingService, ChromaManager;
     let originalEmbedTexts, originalBatchConfig;
 
     test.beforeAll(async () => {
@@ -82,6 +82,7 @@ test.describe('VectorService.embedChunks — one failing batch must not strand t
 
         const VectorServiceModule = await import('../../../../../../ai/services/knowledge-base/VectorService.mjs');
         KB_VectorService          = VectorServiceModule.default;
+        ChromaManager             = (await import('../../../../../../ai/services/knowledge-base/ChromaManager.mjs')).default;
 
         originalEmbedTexts  = TextEmbeddingService.embedTexts.bind(TextEmbeddingService);
         originalBatchConfig = {
@@ -220,6 +221,65 @@ test.describe('VectorService.embedChunks — one failing batch must not strand t
         expect(result.embedded).toBe(150);
         expect(result.failedBatches).toHaveLength(0);
         expect(spy.calls.upsert).toBe(3);
+    });
+
+    test('CALLER BOUNDARY: shadow-swap REFUSES to promote when a batch failed', async () => {
+        // The defect this guards, found by @neo-gpt against the real seam: `embedChunks` is shared by
+        // BOTH stale strategies, and a hole means opposite things to them. Incrementally a skipped batch
+        // is recoverable — the canonical collection keeps what landed and the next sweep re-selects the
+        // rest. Under shadow-swap the shadow REPLACES a complete live corpus, so the same hole is
+        // permanent loss behind a success-shaped receipt: live parked, incomplete shadow promoted.
+        //
+        // Asserted on the RENAMES rather than the return value, because the return value is exactly what
+        // looked healthy. Neither collection may be renamed.
+        const renames        = [];
+        const collectionStub = name => ({
+            name,
+            async count()  { return 0 },
+            async get()    { return {ids: []} },
+            async upsert() {},
+            async modify({name: newName}) { renames.push(`${name}->${newName}`) }
+        });
+
+        // Drives the REAL `embedViaShadowSwap`. An earlier version of this spec re-implemented the
+        // promotion decision in the test and was mutation-tested: deleting the production guard left it
+        // green. A guard asserted against a copy of itself is worse than none, because it reads covered.
+        const originalEmbedChunks = KB_VectorService.embedChunks.bind(KB_VectorService);
+        const originalClient      = ChromaManager.client;
+        const originalInvalidate  = ChromaManager.invalidateKnowledgeBaseCollectionCache.bind(ChromaManager);
+
+        const shadow = collectionStub('shadow');
+
+        ChromaManager.client = {
+            async createCollection() { return shadow },
+            async getCollection()    { return shadow },
+            async deleteCollection()  {}
+        };
+        ChromaManager.invalidateKnowledgeBaseCollectionCache = () => {};
+
+        const runWith = async embedOutcome => {
+            KB_VectorService.embedChunks = async () => embedOutcome;
+            return KB_VectorService.embedViaShadowSwap({
+                liveCollection  : collectionStub('live'),
+                knowledgeBase   : makeChunks(3),
+                idsToDeleteCount: 0
+            })
+        };
+
+        try {
+            await expect(runWith({
+                embedded     : 1,
+                skipped      : 0,
+                yielded      : false,
+                failedBatches: [{batchIndex: 2, chunkIds: ['chunk-50'], reason: 'provider rejected this payload'}]
+            })).rejects.toThrow(/KB_EMBEDDING_BATCH_FAILED/);
+
+            expect(renames, 'neither collection may be renamed when the shadow is incomplete').toEqual([]);
+        } finally {
+            KB_VectorService.embedChunks                        = originalEmbedChunks;
+            ChromaManager.client                                = originalClient;
+            ChromaManager.invalidateKnowledgeBaseCollectionCache = originalInvalidate
+        }
     });
 
     test('a cooperative yield is NOT recorded as a batch failure', async () => {

--- a/test/playwright/unit/ai/services/knowledge-base/VectorService.batchFailureIsolation.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/VectorService.batchFailureIsolation.spec.mjs
@@ -1,0 +1,241 @@
+import {setup} from '../../../../setup.mjs';
+
+const appName = 'KBBatchFailureIsolationTest';
+
+setup({
+    neoConfig: {
+        allowVdomUpdatesInTests: false,
+        unitTestMode           : true,
+        useDomApiRenderer      : false
+    },
+    appConfig: {
+        name             : appName,
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../../../src/Neo.mjs';
+import * as core      from '../../../../../../src/core/_export.mjs';
+
+/**
+ * Batch-failure isolation for `VectorService.embedChunks`.
+ *
+ * The defect: a batch that exhausted its retries aborted the whole sweep. That is not a delay, it is a
+ * permanent strand — `embed()` rebuilds `chunksToProcess` by walking the corpus IN ORDER and keeping what the
+ * collection does not already hold, so succeeded batches drop out while the failed one stays first in line.
+ * Every later batch is re-abandoned at the identical index on every future sweep, forever.
+ *
+ * The cooperative-yield arm of this same loop was hardened against exactly this shape — *"a holder that yields
+ * at the same chunk every time never advances"* — and the failure arm had no equivalent.
+ *
+ * **The cross-sweep spec below is the one that convicts the defect.** A single-sweep test passes against the
+ * broken tree: within one sweep the abort and the skip are only distinguishable by what comes after, and the
+ * strand is a property of what the NEXT sweep re-selects. Any repair validated only in-sweep is unproven.
+ *
+ * The zero-success ceiling is the load-bearing other half: removing the abort entirely would turn a provider
+ * outage into a full-corpus walk at `maxRetries * timeout` per batch — strictly worse than the bug. That case
+ * must still stop at the first batch, and must still THROW, so a total outage cannot report as a clean run.
+ *
+ * Serial mode: specs mutate the shared `KB_Config.data` batch leaves and the `TextEmbeddingService.embedTexts`
+ * singleton.
+ */
+test.describe.configure({mode: 'serial'});
+
+/**
+ * In-memory stand-in for the Chroma collection. Records upserted ids so a test can assert exactly which
+ * chunks landed — a count alone cannot tell "the remainder embedded" from "the first batch embedded twice".
+ */
+function createSpyCollection() {
+    const calls       = {upsert: 0};
+    const upsertedIds = [];
+
+    return {
+        calls,
+        upsertedIds,
+        name: 'spy-knowledge-base',
+        async upsert({ids}) {
+            calls.upsert++;
+            upsertedIds.push(...ids);
+        }
+    };
+}
+
+function makeChunks(count) {
+    return Array.from({length: count}, (_, i) => ({
+        id     : `chunk-${i}`,
+        type   : 'guide',
+        name   : `symbol-${i}`,
+        content: `deterministic small body for chunk ${i}`
+    }));
+}
+
+test.describe('VectorService.embedChunks — one failing batch must not strand the remainder (#16843)', () => {
+    let SDK, KB_VectorService, KB_Config, TextEmbeddingService;
+    let originalEmbedTexts, originalBatchConfig;
+
+    test.beforeAll(async () => {
+        SDK                  = await import('../../../../../../ai/services.mjs');
+        KB_Config            = SDK.KB_Config;
+        TextEmbeddingService = SDK.Memory_TextEmbeddingService;
+
+        const VectorServiceModule = await import('../../../../../../ai/services/knowledge-base/VectorService.mjs');
+        KB_VectorService          = VectorServiceModule.default;
+
+        originalEmbedTexts  = TextEmbeddingService.embedTexts.bind(TextEmbeddingService);
+        originalBatchConfig = {
+            batchSize : KB_Config.data.batchSize,
+            batchDelay: KB_Config.data.batchDelay,
+            maxRetries: KB_Config.data.maxRetries
+        };
+    });
+
+    test.afterAll(() => {
+        TextEmbeddingService.embedTexts = originalEmbedTexts;
+        Object.assign(KB_Config.data, originalBatchConfig);
+    });
+
+    test.beforeEach(() => {
+        // `maxRetries: 1` deliberately: the retry arm backs off `2 ** retries` seconds, so a larger value buys
+        // no coverage and spends real wall-clock. One attempt per batch is enough to reach exhaustion.
+        Object.assign(KB_Config.data, {batchSize: 50, batchDelay: 0, maxRetries: 1});
+        TextEmbeddingService.embedTexts = async texts => texts.map(() => new Array(384).fill(0));
+    });
+
+    test('a poisoned batch is skipped and every LATER batch still embeds', async () => {
+        const spy    = createSpyCollection();
+        const chunks = makeChunks(150); // 3 batches at batchSize 50
+
+        let providerCalls = 0;
+
+        // Batch 2 fails deterministically; batches 1 and 3 succeed.
+        TextEmbeddingService.embedTexts = async texts => {
+            providerCalls++;
+            if (providerCalls === 2) {
+                throw new Error('provider rejected this payload');
+            }
+            return texts.map(() => new Array(384).fill(0));
+        };
+
+        const result = await KB_VectorService.embedChunks({collection: spy, chunksToProcess: chunks});
+
+        // The remainder is the whole point: batch 3 must not be collateral damage from batch 2.
+        expect(result.embedded).toBe(100);
+        expect(spy.upsertedIds).toContain('chunk-0');
+        expect(spy.upsertedIds).toContain('chunk-149');
+        expect(spy.upsertedIds).not.toContain('chunk-50');
+
+        expect(result.failedBatches).toHaveLength(1);
+        expect(result.failedBatches[0].batchIndex).toBe(2);
+        expect(result.failedBatches[0].chunkIds).toContain('chunk-50');
+        expect(result.failedBatches[0].reason).toContain('provider rejected this payload');
+    });
+
+    test('CROSS-SWEEP: a second sweep embeds the chunks that follow the poisoned batch', async () => {
+        // The spec that actually convicts the defect. Against the pre-fix tree sweep 1 aborts at batch 2, and
+        // sweep 2 re-selects from batch 2 and aborts there again — so chunks 100-149 are never embedded by any
+        // number of sweeps. Modelled faithfully: `embed()` derives the next work set by excluding ids the
+        // collection already holds, in corpus order, which is what this loop reproduces.
+        const spy    = createSpyCollection();
+        const corpus = makeChunks(150);
+
+        TextEmbeddingService.embedTexts = async texts => {
+            if (texts.some(text => text.includes('for chunk 50'))) {
+                throw new Error('provider rejected this payload');
+            }
+            return texts.map(() => new Array(384).fill(0));
+        };
+
+        const runSweep = async () => {
+            const landed          = new Set(spy.upsertedIds);
+            const chunksToProcess = corpus.filter(chunk => !landed.has(chunk.id));
+
+            if (chunksToProcess.length === 0) {
+                return {skipped: true};
+            }
+
+            try {
+                return await KB_VectorService.embedChunks({collection: spy, chunksToProcess});
+            } catch (error) {
+                return {threw: error.message};
+            }
+        };
+
+        const sweepOne     = await runSweep();
+        const landedAfter1 = new Set(spy.upsertedIds);
+
+        // THE CONVICTING ASSERTION. Pre-fix, sweep 1 aborts at the poisoned batch and chunks 100-149 are never
+        // written — not by this sweep and, because the next sweep re-selects the same failing prefix, not by any
+        // sweep that follows. Their presence here is the entire repair.
+        expect(landedAfter1.has('chunk-100')).toBe(true);
+        expect(landedAfter1.has('chunk-149')).toBe(true);
+        expect(landedAfter1.has('chunk-0')).toBe(true);
+        expect(sweepOne.failedBatches).toHaveLength(1);
+
+        // The poisoned chunks are isolated, not smuggled in.
+        expect(landedAfter1.has('chunk-50')).toBe(false);
+        expect(landedAfter1.size).toBe(100);
+
+        const sweepTwo = await runSweep();
+
+        // Sweep 2's work set is the poisoned batch and nothing else, so nothing embeds in it — which is
+        // indistinguishable from a provider outage from inside that sweep, and is correctly reported the same
+        // way: it throws, loudly, rather than returning a success-shaped result over an empty run. That is the
+        // intended steady state. The corpus holds every recoverable chunk and the unrecoverable ones keep
+        // announcing themselves instead of silently freezing everything behind them.
+        expect(sweepTwo.threw).toMatch(/Failed to process batch 1/);
+        expect(new Set(spy.upsertedIds).size).toBe(100);
+    });
+
+    test('CEILING: a sweep where NOTHING embeds still throws, and stops at the first batch', async () => {
+        // The load-bearing other half. Skipping unconditionally would walk a dead provider across the entire
+        // corpus at `maxRetries * timeout` per batch. A total outage must cost one batch, and must throw so the
+        // caller records a failure instead of a success-shaped receipt over an empty run.
+        const spy    = createSpyCollection();
+        const chunks = makeChunks(150); // 3 batches
+
+        let providerCalls = 0;
+
+        TextEmbeddingService.embedTexts = async () => {
+            providerCalls++;
+            throw new Error('provider is down');
+        };
+
+        await expect(
+            KB_VectorService.embedChunks({collection: spy, chunksToProcess: chunks})
+        ).rejects.toThrow(/Failed to process batch 1/);
+
+        // One batch, one attempt (maxRetries: 1) — NOT one per batch in the corpus.
+        expect(providerCalls).toBe(1);
+        expect(spy.calls.upsert).toBe(0);
+    });
+
+    test('a healthy sweep is unchanged — no failures recorded, every batch lands', async () => {
+        const spy    = createSpyCollection();
+        const chunks = makeChunks(150);
+
+        const result = await KB_VectorService.embedChunks({collection: spy, chunksToProcess: chunks});
+
+        expect(result.embedded).toBe(150);
+        expect(result.failedBatches).toHaveLength(0);
+        expect(spy.calls.upsert).toBe(3);
+    });
+
+    test('a cooperative yield is NOT recorded as a batch failure', async () => {
+        // The yield arm is a decision, not an error. Conflating them would re-break the fairness fix and would
+        // also pollute the ingest receipt with failures that never happened.
+        const spy    = createSpyCollection();
+        const chunks = makeChunks(150);
+
+        const result = await KB_VectorService.embedChunks({
+            collection     : spy,
+            chunksToProcess: chunks,
+            shouldYield    : () => true
+        });
+
+        expect(result.yielded).toBe(true);
+        expect(result.embedded).toBe(50);
+        expect(result.failedBatches).toHaveLength(0);
+    });
+});


### PR DESCRIPTION
Resolves neomjs/neo#16843
Related: neomjs/neo-agent-brain#54

Authored by @neo-opus-grace (Claude Opus 5, Claude Code). Origin Session ID: `d8332b13-5d97-4839-ac11-d2de4602a989`.

## What this fixes

`VectorService.embedChunks` aborted the whole sweep when a batch exhausted its retries. That is not a delay — it is a **permanent strand**.

`embed()` rebuilds `chunksToProcess` by walking the corpus **in order** and keeping every chunk the collection does not already hold. Succeeded batches drop out of the next work set; **the failed one stays first in line.** So for a batch that fails deterministically — one rejected chunk, one payload past the guardrail, one malformed record — the steady state is:

| sweep | behaviour |
|---|---|
| 1 | batches `1..N-1` upserted · batch `N` fails `maxRetries` · **throw** |
| 2 | `1..N-1` excluded (already present) · **starts at `N`** · fails · **throw** |
| … | identical, forever |

**Every chunk after batch `N` is never attempted again — not delayed, never.** The corpus freezes at a partial state, every subsequent sync re-pays the poison batch's full retry cost before aborting at the identical index, and no status field distinguishes it from "up to date".

The cooperative-yield arm of this same loop was hardened against exactly this hazard — its own comment reads *"a holder that yields at the same chunk every time never advances"*, and it persists a completed prefix plus a resume marker. **The failure arm got no equivalent.** One arm of one loop guarantees advancement; the other guaranteed repetition.

## The fix

On retry exhaustion, discriminate a **poisoned batch** from a **dead provider** using state the loop already holds — no config leaf, no threshold nobody could defend:

- **`embeddedCount > 0`** — the provider demonstrably works this sweep, so this batch is the problem. Record it and continue.
- **`embeddedCount === 0`** — nothing has succeeded at all. **Still throws**, byte-identical to today.

That second branch is the load-bearing half, not a leftover. Removing the abort *unconditionally* would turn a provider outage into a full-corpus walk at `remainingBatches * maxRetries * timeout` — **strictly worse than the bug**. It also has to keep throwing rather than returning quietly, or a total outage reports as a success-shaped receipt over an empty run.

Skipped batches travel back in `failedBatches` and reach the durable ingest receipt as `KB_EMBED_BATCH_SKIPPED`, so a corpus with a hole in it cannot report as a clean sync.

## Deltas

| file | delta |
|---|---|
| `ai/services/knowledge-base/VectorService.mjs` | `embedChunks` collects `failedBatches`; retry exhaustion moves out of the catch into an explicit post-retry disposition with the zero-success guard; `embed()` surfaces `failedBatches` and says so in its message; `@returns` documents the contract |
| `ai/services/knowledge-base/IngestionService.mjs` | `embedChunkGroups` folds `failedBatches` into `summary.errors` as `KB_EMBED_BATCH_SKIPPED` with `repoSlug`, `batchIndex`, `chunkIds` |
| `test/playwright/unit/…/VectorService.batchFailureIsolation.spec.mjs` | new — 5 controls incl. the cross-sweep convictor and the dead-provider ceiling |

Additive on every surface: existing `{embedded, skipped, yielded}` consumers are unaffected.

## Test Evidence

`UNIT_TEST_MODE=true npx playwright test --config=test/playwright/playwright.config.unit.mjs`

- **New spec: 7 passed.**
- **Blast radius: `test/playwright/unit/ai/services/knowledge-base/` — 572 passed.** This directory contains `VectorService.leaseYield.spec.mjs`, which drives the *same loop* through its yield arm; a regression there is the most likely way this change breaks something, so the whole directory is the relevant bound rather than the new file.

**Evidence:** mutation-convicted in both directions, each mutation checked to redden its *own expected* control and no other:

| mutation | expected to redden | result |
|---|---|---|
| `embeddedCount === 0` → `true` (restore the unconditional abort) | poisoned-batch + cross-sweep controls | ✅ reddened |
| `embeddedCount === 0` → `false` (delete the zero-success guard) | CEILING control | ✅ reddened |

**The cross-sweep control is the one that convicts the defect**, and it is the reason this PR is not testable in a single sweep: within one sweep an abort and a skip differ only in what comes *after*, and the strand is a property of what the **next** sweep re-selects. A repair validated in-sweep only would be unproven.

**A correction I made while writing that control**, because it changed the claim rather than the code: my first version asserted a clean second sweep. It failed — sweep 2's work set is the poisoned batch *alone*, so nothing embeds in it and it correctly throws, indistinguishable from an outage from inside that sweep. That is the intended steady state (recoverable chunks land; unrecoverable ones keep announcing themselves instead of silently freezing everything behind them), so the spec now asserts it explicitly rather than papering over it.

Lints run locally: `ai:lint-retry-bounds` (42 candidates, all classified), `ai:lint-mcp-test-locations` (OK), `check-ticket-archaeology` (zero offenders introduced by this diff).

## Post-Merge Validation

- [ ] On a plane with a working provider, confirm a `KB_EMBED_BATCH_SKIPPED` entry appears in the ingest summary when a batch fails, and that the collection count exceeds the pre-sweep count in the same run — i.e. the skip and the forward progress are observable together, not just in a fixture.
- [ ] Confirm the dead-provider path is unchanged in the field: a sweep against an unavailable provider still surfaces `Failed to process batch 1` and does **not** walk the corpus. Cheap to read off the ingest log line count.

## Out of scope

- Why a provider returns nothing in the first place — `#16830` / `#14154`. **This PR cannot fill an empty corpus**, and a `count: 0` plane is not the case it repairs.
- Fate-classification of failures into terminal-vs-retryable classes — `#16227` owns that contract for the rebuild runner.
- The shadow-swap resume path (`selectResumableChunks` / `decideResume`), which has its own working resume logic and is not on the tenant-ingest path.
- Any change to `batchSize`, `maxRetries` or timeout leaves.

## Review notes

The two places I would look hardest if I were reviewing this:

1. **Is the zero-success guard the right discriminator?** It answers *"has this provider embedded anything this sweep?"* — not *"is this provider healthy?"*. A provider that succeeds on batch 1 and then dies mid-corpus will now be skipped batch-by-batch to the end of the sweep rather than aborting at the first failure. That costs `remainingBatches * maxRetries * timeout` in the worst case. I judged that acceptable because the alternative is the permanent strand, and because the next sweep re-selects only what did not land — but it is a real trade and it is the decision most worth challenging.
2. **`lastError` capture.** It records the final attempt's error only; earlier attempts' messages are logged but not carried into the receipt. Adequate for the receipt's purpose (naming the batch and why it stopped), and deliberately not a fate classifier.
