### PR TITLE
feat(memory-core): release add_message at the WAL boundary

### DIFF
--- a/ai/mcp/server/memory-core/openapi.yaml
+++ b/ai/mcp/server/memory-core/openapi.yaml
@@ -2022,7 +2022,12 @@ paths:
       x-neo-tool-tier: write
       x-pass-as-object: true
       x-neo-tool-summary: Send an A2A message to one peer or an agent broadcast.
-      description: Sends a message or optional Task; Task assignment is server-owned, and broadcasts remain unassigned until an eligible send-time recipient claims them.
+      description: |
+        Sends a message or optional Task. A successful response means the accepted message is
+        durable in the message WAL; Native Edge Graph projection may still be pending and is
+        completed by the WAL-backed projection drain. Wake delivery is best-effort after projection
+        and is not part of the durable receipt guarantee. Task assignment is server-owned, and
+        broadcasts remain unassigned until an eligible send-time recipient claims them.
       tags: [Mailbox]
       requestBody:
         required: true
@@ -2091,11 +2096,27 @@ paths:
                       description: Optional expiry time consumed by the Task TTL sweeper.
       responses:
         '200':
-          description: OK
+          description: Message accepted durably in the WAL; projectionStatus may remain pending while derived graph projection completes.
           content:
             application/json:
               schema:
                 type: object
+                required: [messageId, sentAt, priority, status, projectionStatus]
+                properties:
+                  messageId:
+                    type: string
+                  sentAt:
+                    type: string
+                    format: date-time
+                  priority:
+                    type: string
+                    nullable: true
+                  status:
+                    type: string
+                    enum: [sent]
+                  projectionStatus:
+                    type: string
+                    enum: [pending]
         '500':
           description: Error
           content:

--- a/ai/mcp/server/memory-core/toolService.mjs
+++ b/ai/mcp/server/memory-core/toolService.mjs
@@ -218,6 +218,14 @@ export function composeMemoryCoreHealthcheck({health, memoryWalDrain, plane}) {
     }
 }
 
+/**
+ * @summary Accepts an A2A message at the durable WAL boundary and defers its derived graph
+ * projection so graph saturation cannot withhold the write receipt.
+ * @param {Object} args add_message arguments.
+ * @returns {Promise<Object>}
+ */
+const addMessageTool = args => MailboxService.addMessage(args, {deferProjection: true});
+
 const serviceMapping = {
     add_memory           : MemoryService          .addMemory               .bind(MemoryService),
     get_mcp_tool_handbook: toolId => toolService.getToolHandbook(toolId),
@@ -260,7 +268,7 @@ const serviceMapping = {
     search_nodes                : GraphService           .searchNodes             .bind(GraphService),
     get_memory_core_tool_metrics:
                               MemoryCoreRecorderService.getMemoryCoreToolMetrics.bind(MemoryCoreRecorderService),
-    add_message           : MailboxService         .addMessage              .bind(MailboxService),
+    add_message           : addMessageTool,
     list_messages         : MailboxService         .listMessages            .bind(MailboxService),
     get_message           : MailboxService         .getMessage              .bind(MailboxService),
     get_rem_pipeline_state: HealthService          .getRemPipelineState     .bind(HealthService),

--- a/ai/services/memory-core/MailboxService.mjs
+++ b/ai/services/memory-core/MailboxService.mjs
@@ -2022,9 +2022,14 @@ class MailboxService extends Base {
      *   state-machine transitions, RBAC, and idempotent claim-and-lock semantics. Schema follows
      *   Neo's A2A hybrid contract: an A2A subset plus `expiresAt` / `Blocked`. See
      *   {@link https://a2a-protocol.org/latest/specification/} for the canonical Task envelope.
+     * @param {Object} [options]
+     * @param {Boolean} [options.deferProjection=false] Return after the accepted message is durable
+     *   in the WAL and schedule its graph projection. The MCP write boundary enables this mode so
+     *   an overloaded graph cannot withhold the durable receipt; internal callers retain the
+     *   immediate-projection default.
      * @returns {Promise<Object>}
      */
-    async addMessage({ to, subject, body, originSessionId, relatedSessions = [], relatedTickets = [], inReplyTo, priority = null, partOfThread, taggedConcepts = [], wakeSuppressed = null, task }) {
+    async addMessage({ to, subject, body, originSessionId, relatedSessions = [], relatedTickets = [], inReplyTo, priority = null, partOfThread, taggedConcepts = [], wakeSuppressed = null, task }, {deferProjection = false} = {}) {
         const db             = GraphService.requireDb('MailboxService.addMessage');
         const preNormalizeTo = to; // diagnostic payload captures caller-supplied target
         const boundSender    = RequestContextService.getAgentIdentityNodeId();
@@ -2257,6 +2262,18 @@ class MailboxService extends Base {
             planeId: aiConfig.plane.id
         });
 
+        if (deferProjection) {
+            this._scheduleMessageGraphProjection(walRecord);
+
+            return {
+                messageId,
+                sentAt          : timestamp,
+                priority,
+                status          : 'sent',
+                projectionStatus: 'pending'
+            }
+        }
+
         let projectionStatus = 'projected';
 
         try {
@@ -2276,6 +2293,31 @@ class MailboxService extends Base {
             status: 'sent',
             ...(projectionStatus === 'pending' ? {projectionStatus} : {})
         };
+    }
+
+    /**
+     * @summary Schedules graph projection after a durable message receipt has crossed the MCP
+     * response boundary.
+     *
+     * The accepted-message WAL remains the authority. This best-effort fast path normally projects
+     * on the next event-loop turn; the message-WAL drain is the durable retry owner when the process
+     * exits or projection fails.
+     *
+     * @param {Object} walRecord Accepted message WAL record.
+     * @returns {void}
+     * @private
+     */
+    _scheduleMessageGraphProjection(walRecord) {
+        const timer = setTimeout(() => {
+            this._projectMessageWalRecord(walRecord).catch(error => {
+                logger.error('[MailboxService.addMessage] deferred graph projection failed after durable receipt', {
+                    messageId: walRecord.id,
+                    error    : error?.message || String(error)
+                });
+            });
+        }, 0);
+
+        timer.unref?.();
     }
 
     /**

--- a/test/playwright/unit/ai/services/memory-core/MailboxService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/MailboxService.spec.mjs
@@ -25,7 +25,7 @@ import RequestContextService from '../../../../../../ai/mcp/server/shared/servic
 test.describe.configure({ mode: 'serial' });
 
 test.describe('Neo.ai.services.memory-core.MailboxService', () => {
-    let MailboxService, GraphService, PermissionService, LifecycleService, SwarmHeartbeatService, buildMailboxDelta, originalAutoSave, mailboxAiConfig, originalMailboxPolicy, readWalMessages, readPendingMessageWalRecords;
+    let MailboxService, GraphService, PermissionService, LifecycleService, SwarmHeartbeatService, buildMailboxDelta, callMemoryCoreTool, originalAutoSave, mailboxAiConfig, originalMailboxPolicy, readWalMessages, readPendingMessageWalRecords;
     let messageWalDir, getWakeDeliverySeries;
 
     test.beforeAll(async () => {
@@ -40,6 +40,7 @@ test.describe('Neo.ai.services.memory-core.MailboxService', () => {
         LifecycleService = (await import('../../../../../../ai/services/memory-core/lifecycle/SystemLifecycleService.mjs')).default;
         SwarmHeartbeatService = (await import('../../../../../../ai/daemons/orchestrator/services/SwarmHeartbeatService.mjs')).default;
         buildMailboxDelta = (await import('../../../../../../ai/services/memory-core/MemoryService.mjs')).buildMailboxDelta;
+        callMemoryCoreTool = (await import('../../../../../../ai/mcp/server/memory-core/toolService.mjs')).callTool;
         const messageWalStore = await import('../../../../../../ai/services/memory-core/helpers/messageWalStore.mjs');
         readWalMessages              = messageWalStore.readWalMessages;
         readPendingMessageWalRecords = messageWalStore.readPendingMessageWalRecords;
@@ -254,6 +255,61 @@ test.describe('Neo.ai.services.memory-core.MailboxService', () => {
 
         const pending = await readPendingMessageWalRecords({dir: messageWalDir});
         expect(pending).toHaveLength(0);
+    });
+
+    test('#16677: add_message returns its durable WAL receipt before graph projection', async () => {
+        await RequestContextService.run({agentIdentityNodeId: '@bob'}, async () => {
+            await PermissionService.grantPermission({to: '@alice', scope: 'CAN_REPLY_TO'});
+        });
+
+        const
+            originalProject = MailboxService._projectMessageWalRecord,
+            entered         = Promise.withResolvers(),
+            release         = Promise.withResolvers();
+
+        let projectionEntered = false;
+
+        MailboxService._projectMessageWalRecord = async function(...args) {
+            projectionEntered = true;
+            entered.resolve();
+            await release.promise;
+            return originalProject.apply(this, args)
+        };
+
+        try {
+            const outcome = await RequestContextService.run({agentIdentityNodeId: '@alice'}, async () => {
+                return Promise.race([
+                    callMemoryCoreTool('add_message', {
+                        to     : '@bob',
+                        subject: 'durable receipt boundary',
+                        body   : 'graph projection is deliberately paused'
+                    }).then(receipt => ({receipt})),
+                    new Promise(resolve => setTimeout(() => resolve({deadline: true}), 1000))
+                ])
+            });
+
+            expect(outcome.deadline).toBeUndefined();
+            expect(outcome.receipt).toMatchObject({
+                status          : 'sent',
+                projectionStatus: 'pending'
+            });
+            expect(projectionEntered).toBe(false);
+
+            const records = await readWalMessages({dir: messageWalDir});
+            expect(records.map(record => record.id)).toContain(outcome.receipt.messageId);
+            expect(GraphService.db.nodes.has(outcome.receipt.messageId)).toBe(false);
+
+            await entered.promise;
+            release.resolve();
+
+            await expect.poll(() => GraphService.db.nodes.has(outcome.receipt.messageId)).toBe(true);
+            await expect.poll(async () => (
+                await readPendingMessageWalRecords({dir: messageWalDir})
+            ).length).toBe(0);
+        } finally {
+            release.resolve();
+            MailboxService._projectMessageWalRecord = originalProject;
+        }
     });
 
     test('#16086: inspectReadState reads the owner SQLite without normal mailbox reads, repair, or mutation', async () => {


### PR DESCRIPTION
Resolves #16842

Related: #16677

`add_message` already crossed the durable message-WAL boundary before graph projection, but its MCP handler still withheld the successful receipt until that derived graph work finished. Under the post-admission saturation measured in #16677, this created the worst write outcome for an operator: the record could be durable while the caller timed out and could not distinguish “not accepted” from “accepted; acknowledgement lost.”

This change separates acceptance from visibility at the existing owner boundary:

- `MailboxService.addMessage()` gains an opt-in `deferProjection` mode; its default remains synchronous for internal callers.
- Only the MCP `add_message` binding elects that mode.
- After the awaited WAL append, the handler schedules the ordinary idempotent projector for the next event-loop turn and returns `status: sent` with `projectionStatus: pending`.
- Projection failure or process exit leaves the accepted WAL record for the existing in-process/daemon drain.
- OpenAPI now declares the exact receipt schema and states that graph visibility can lag.

Evidence: **L2** — the production MCP dispatch is exercised with the real projector paused, proving receipt resolution, exact WAL presence, graph absence, later projection, and pending-marker retirement. Two targeted mutations red the witness. This is sufficient for #16842's receipt-boundary ACs. The broader #16677 container-saturation diagnosis remains open.

## Deltas from ticket

- The ticket's durability-versus-visibility wording is preserved, but the public contract is narrower about wake: wake delivery is best-effort after projection and is **not** part of the durable receipt guarantee. The existing WAL marker records graph projection, not a durable wake disposition.
- `projectionStatus` is declared in the OpenAPI response schema rather than remaining prose-only.
- No `add_memory` behavior changes; that remains #16808 authority.

## Test Evidence

- `MailboxService.spec.mjs` → **153/153 passed**, including the new production-bound order witness and existing pending-WAL replay/failure retention controls.
- `McpServerToolLimits.spec.mjs` → **14/14 passed**.
- `OpenApiValidatorCompliance.spec.mjs` → **50/50 passed**.
- `npm run ai:lint-openapi-service-parity` → **green**: 40 wrappers, 121 operation-bound methods + 142 object handlers, zero consumed-but-undeclared parameters.
- `node --check` → green for every changed `.mjs` file.
- Mutation proof 1: restoring the direct `add_message -> MailboxService.addMessage.bind(...)` mapping makes the one-second receipt deadline win.
- Mutation proof 2: invoking the projector inline without the next-turn scheduler makes the pre-receipt-entry assertion red.
- Full unit run from the disposable source export reached **12,392 passed / 5 skipped / 3 did not run**, then exited non-zero in repository-root and external-service-sensitive suites. It is recorded as a ceiling, not used as acceptance evidence; exact-branch hosted CI remains the full gate.

## Post-Merge Validation

- [ ] Rebuild/recreate the Memory Core plane from the merged revision; a container restart cannot pick up the code.
- [ ] Under deliberately delayed graph projection, observe a prompt structured `add_message` receipt and later mailbox visibility from the same `MESSAGE:*` id.
- [ ] Confirm the message-WAL drain returns to caught-up after the delayed projection.
- [ ] Update the operator runbook only after deployment: a structured successful receipt proves durable acceptance; an absent receipt remains ambiguous and must not trigger a blind retry.
- [ ] Validate wake separately when immediate delivery matters; this receipt does not prove wake completion.

## Evolution

The broad #16677 incident was split at its measured boundary: cold admission and post-admission saturation remain distinct, while this child closes only the post-WAL acknowledgement ambiguity. Review falsification also removed an initially over-broad wake claim before publication.

Authored by Emmy (@neo-gpt-emmy, GPT-5.6 Sol Ultra, Codex). Origin Session ID: 878f05af-2c4e-4da2-a5c2-9e4af666fcb8.
