### PR TITLE
fix(ai): an operator can shrink the embedding batch (#16846)

### DIFF
--- a/ai/ConfigProvider.mjs
+++ b/ai/ConfigProvider.mjs
@@ -39,9 +39,20 @@ const typeValidators = {
     port          : value => Number.isInteger(value) && value >= 0 && value <= 65535,
     // Counts where 0 or a negative is not a smaller setting but a BROKEN one — a loop stride, an
     // attempt budget. `number` would accept them and the damage surfaces far from the config: a
-    // stride of 0 does not shrink a batch, it never advances the loop. The domain belongs on the
-    // leaf for the same reason `port`'s does — the value is rejected at the write choke point
-    // rather than defended against at every consumer.
+    // stride of 0 does not shrink a batch, it never advances the loop.
+    //
+    // WHERE THE DOMAIN IS ACTUALLY ENFORCED, because the two halves are not symmetric and an earlier
+    // version of this comment claimed they were:
+    //
+    //   - the PARSER (`typeParsers` above, `Env.parseIntAtLeast`) is the enforcement. An
+    //     out-of-domain env value returns `undefined`, so the leaf default stands and no consumer
+    //     ever sees the bad number. This is the path an operator's typo takes.
+    //   - the VALIDATOR here is ADVISORY. `#validateLeafValue` warns and KEEPS the value — its own
+    //     JSDoc says so. It surfaces a programmatic write to a known leaf; it does not reject one.
+    //
+    // Both are worth having and they answer different questions. Describing the validator as
+    // rejecting is the mistake to avoid: a reader who believes the write path is closed will skip
+    // the parser, which is the half that actually protects the consumer.
     positiveInt: value => Number.isInteger(value) && value >= 1,
     string     : value => typeof value === 'string',
     url        : value => typeof value === 'string'

--- a/ai/ConfigProvider.mjs
+++ b/ai/ConfigProvider.mjs
@@ -13,10 +13,15 @@ const typeParsers = {
     boolean  : Env.parseBool,
     csv      : Env.parseCsv,
     keepAlive: Env.parseKeepAlive,
-    number   : Env.parseNumber,
-    port     : Env.parsePort,
-    string   : Env.parseString,
-    url      : Env.parseUrl
+    // The PARSER is what enforces these domains, not the validator beside it: `#validateLeafValue`
+    // only warns and keeps the value, so returning `undefined` here is the only thing that makes an
+    // out-of-domain env value fall back to the leaf default. Same mechanism `port` relies on.
+    nonNegativeInt: (name, opts) => Env.parseIntAtLeast(name, {...opts, min: 0}),
+    number        : Env.parseNumber,
+    port          : Env.parsePort,
+    positiveInt   : (name, opts) => Env.parseIntAtLeast(name, {...opts, min: 1}),
+    string        : Env.parseString,
+    url           : Env.parseUrl
 };
 
 /**
@@ -28,10 +33,18 @@ const typeParsers = {
 const typeValidators = {
     boolean: value => typeof value === 'boolean',
     csv    : value => Array.isArray(value) && value.every(item => typeof item === 'string'),
-    number : value => typeof value === 'number' && !Number.isNaN(value),
-    port   : value => Number.isInteger(value) && value >= 0 && value <= 65535,
-    string : value => typeof value === 'string',
-    url    : value => typeof value === 'string'
+    // Counts an operator may tune where 0 is a legitimate setting (a delay, a grace window).
+    nonNegativeInt: value => Number.isInteger(value) && value >= 0,
+    number        : value => typeof value === 'number' && !Number.isNaN(value),
+    port          : value => Number.isInteger(value) && value >= 0 && value <= 65535,
+    // Counts where 0 or a negative is not a smaller setting but a BROKEN one — a loop stride, an
+    // attempt budget. `number` would accept them and the damage surfaces far from the config: a
+    // stride of 0 does not shrink a batch, it never advances the loop. The domain belongs on the
+    // leaf for the same reason `port`'s does — the value is rejected at the write choke point
+    // rather than defended against at every consumer.
+    positiveInt: value => Number.isInteger(value) && value >= 1,
+    string     : value => typeof value === 'string',
+    url        : value => typeof value === 'string'
 };
 
 /**

--- a/ai/deploy/docker-compose.dev.yml
+++ b/ai/deploy/docker-compose.dev.yml
@@ -175,6 +175,13 @@ services:
       <<: [*plane-env, *provider-auth-env]
       NEO_TRANSPORT: streamable-http
       NEO_CHROMA_HOST: chroma
+      # Embedding-batch recovery levers. Declared HERE and not only in the base profile: this is a
+      # STANDALONE parity stack, not an overlay on docker-compose.yml, so nothing is inherited. A
+      # render of base+dev together resolves them from base and hides the gap — the composition
+      # that actually runs is this file plus the parity-CI overlay.
+      NEO_KB_EMBEDDING_BATCH_SIZE: ${NEO_KB_EMBEDDING_BATCH_SIZE:-}
+      NEO_KB_EMBEDDING_BATCH_DELAY_MS: ${NEO_KB_EMBEDDING_BATCH_DELAY_MS:-}
+      NEO_KB_EMBEDDING_MAX_RETRIES: ${NEO_KB_EMBEDDING_MAX_RETRIES:-}
       # Ask-synthesis pass-throughs (ask_knowledge_base -> SearchService.ask): the synthesis
       # provider + its DEDICATED budget-cappable key (NEO_KB_ASK_API_KEY, never the shared
       # GEMINI_API_KEY). Empty default -> the config-template default applies; with no key the
@@ -331,6 +338,12 @@ services:
       NEO_ORCHESTRATOR_RUNTIME_ACCESS_ENABLED: "true"
       NEO_ORCHESTRATOR_RUNTIME_ACCESS_COMPOSE_PROJECT: *plane-id
       NEO_ORCHESTRATOR_RUNTIME_ACCESS_ALLOWED_SERVICES: chroma,kb-server,mc-server
+      # Embedding-batch recovery levers — the orchestrator drives tenant-repo ingestion, so it reads
+      # the same three leaves kb-server does. Standalone profile: nothing is inherited from the base
+      # compose, so an operator tuning a parity plane needs them declared here.
+      NEO_KB_EMBEDDING_BATCH_SIZE: ${NEO_KB_EMBEDDING_BATCH_SIZE:-}
+      NEO_KB_EMBEDDING_BATCH_DELAY_MS: ${NEO_KB_EMBEDDING_BATCH_DELAY_MS:-}
+      NEO_KB_EMBEDDING_MAX_RETRIES: ${NEO_KB_EMBEDDING_MAX_RETRIES:-}
     volumes:
       - ../..:/app
       # The PLANE ROOT rides a project-scoped named volume, not the repo bind above. Docker applies

--- a/ai/deploy/docker-compose.yml
+++ b/ai/deploy/docker-compose.yml
@@ -109,6 +109,14 @@ services:
       - NEO_OLLAMA_EMBEDDING_MODEL=${NEO_OLLAMA_EMBEDDING_MODEL:-}
       - NEO_OLLAMA_EMBEDDING_TIMEOUT_MS=${NEO_OLLAMA_EMBEDDING_TIMEOUT_MS:-}
       - NEO_OPENAI_COMPATIBLE_KEEP_ALIVE=${NEO_OPENAI_COMPATIBLE_KEEP_ALIVE:-}
+      # Embedding-batch recovery levers. `batchSize` is the DURABLE UNIT — a whole slice embeds in
+      # one provider call and upserts only after it returns — so an operator whose corpus will not
+      # start needs to shrink the bet until one batch lands. These must render HERE and not only
+      # as leaves: an env binding the deployment never carries is a knob that does not exist.
+      # Empty default keeps the leaf default authoritative; the leaf types reject 0/negative.
+      - NEO_KB_EMBEDDING_BATCH_SIZE=${NEO_KB_EMBEDDING_BATCH_SIZE:-}
+      - NEO_KB_EMBEDDING_BATCH_DELAY_MS=${NEO_KB_EMBEDDING_BATCH_DELAY_MS:-}
+      - NEO_KB_EMBEDDING_MAX_RETRIES=${NEO_KB_EMBEDDING_MAX_RETRIES:-}
       # Ask-synthesis pass-throughs (ask_knowledge_base -> SearchService.ask): the synthesis
       # provider + its DEDICATED budget-cappable key (NEO_KB_ASK_API_KEY, never the shared
       # GEMINI_API_KEY). Empty default -> the config-template default applies; with no key the
@@ -349,6 +357,12 @@ services:
       - NEO_OLLAMA_EMBEDDING_TIMEOUT_MS=${NEO_OLLAMA_EMBEDDING_TIMEOUT_MS:-}
       - NEO_OLLAMA_REQUIRE_PARALLEL_MODELS=${NEO_OLLAMA_REQUIRE_PARALLEL_MODELS:-}
       - NEO_OPENAI_COMPATIBLE_KEEP_ALIVE=${NEO_OPENAI_COMPATIBLE_KEEP_ALIVE:-}
+      # Embedding-batch recovery levers — required HERE as well as on kb-server, because `kbSync`
+      # and `tenant-repo-sync` are container-plane tasks that run in THIS process. Shipping them to
+      # kb-server alone would leave the lane that actually ingests tenant repos untunable.
+      - NEO_KB_EMBEDDING_BATCH_SIZE=${NEO_KB_EMBEDDING_BATCH_SIZE:-}
+      - NEO_KB_EMBEDDING_BATCH_DELAY_MS=${NEO_KB_EMBEDDING_BATCH_DELAY_MS:-}
+      - NEO_KB_EMBEDDING_MAX_RETRIES=${NEO_KB_EMBEDDING_MAX_RETRIES:-}
       - NEO_CHROMA_HOST=chroma
       # The child heap ceiling needs a WRITER here, not just a reader in the service: without this
       # line the deployment override is unreachable — the parent knob renders while this one stays

--- a/ai/mcp/server/knowledge-base/configBase.mjs
+++ b/ai/mcp/server/knowledge-base/configBase.mjs
@@ -518,15 +518,18 @@ class ConfigBase extends ConfigProvider {
             /**
              * The number of chunks to process in a single batch when embedding.
              *
-             * This is the **durable unit**: `VectorService.embedChunks` embeds a whole slice in one
-             * `TextEmbeddingService.embedTexts` call and upserts only after it returns, so all
-             * `batchSize` chunks succeed together or none of them persist. On a starved provider that
-             * makes it the size of the smallest bet the pipeline can win — which is why it carries an
-             * env override: an operator whose corpus will not start needs to shrink the bet until one
+             * This is the **durable unit on the failure arm**: `VectorService.embedChunks` embeds a
+             * whole slice in one `TextEmbeddingService.embedTexts` call and upserts only after it
+             * returns, so a provider failure loses the entire slice. On a starved provider that makes
+             * it the size of the smallest bet the pipeline can win — which is why it carries an env
+             * override: an operator whose corpus will not start needs to shrink the bet until one
              * batch lands, and a single landed batch is permanent.
+             *
+             * **Not universally atomic** — a cooperative heavy-maintenance yield persists the prefix it
+             * already paid for and records a resume marker. Failure loses the slice; a yield does not.
              * @type {number}
              */
-            batchSize: leaf(50, 'NEO_KB_EMBEDDING_BATCH_SIZE', 'number'),
+            batchSize: leaf(50, 'NEO_KB_EMBEDDING_BATCH_SIZE', 'positiveInt'),
             /**
              * Work-volume gate for MCP-callable `manage_knowledge_base sync`: when
              * the post-delta `chunksToProcess.length` exceeds this value AND the call originates
@@ -548,7 +551,7 @@ class ConfigBase extends ConfigProvider {
              * dials or the smaller batch turns a repair into an overnight run.
              * @type {number}
              */
-            batchDelay: leaf(10000, 'NEO_KB_EMBEDDING_BATCH_DELAY_MS', 'number'),
+            batchDelay: leaf(10000, 'NEO_KB_EMBEDDING_BATCH_DELAY_MS', 'nonNegativeInt'),
             /**
              * The maximum number of times to retry a failed embedding batch.
              *
@@ -557,7 +560,7 @@ class ConfigBase extends ConfigProvider {
              * given up on.
              * @type {number}
              */
-            maxRetries: leaf(5, 'NEO_KB_EMBEDDING_MAX_RETRIES', 'number'),
+            maxRetries: leaf(5, 'NEO_KB_EMBEDDING_MAX_RETRIES', 'positiveInt'),
             /**
              * The number of results to fetch from ChromaDB for a query.
              * @type {number}

--- a/ai/mcp/server/knowledge-base/configBase.mjs
+++ b/ai/mcp/server/knowledge-base/configBase.mjs
@@ -517,9 +517,16 @@ class ConfigBase extends ConfigProvider {
             modelName: leaf('gemini-3.5-flash'),
             /**
              * The number of chunks to process in a single batch when embedding.
+             *
+             * This is the **durable unit**: `VectorService.embedChunks` embeds a whole slice in one
+             * `TextEmbeddingService.embedTexts` call and upserts only after it returns, so all
+             * `batchSize` chunks succeed together or none of them persist. On a starved provider that
+             * makes it the size of the smallest bet the pipeline can win — which is why it carries an
+             * env override: an operator whose corpus will not start needs to shrink the bet until one
+             * batch lands, and a single landed batch is permanent.
              * @type {number}
              */
-            batchSize: leaf(50),
+            batchSize: leaf(50, 'NEO_KB_EMBEDDING_BATCH_SIZE', 'number'),
             /**
              * Work-volume gate for MCP-callable `manage_knowledge_base sync`: when
              * the post-delta `chunksToProcess.length` exceeds this value AND the call originates
@@ -535,14 +542,22 @@ class ConfigBase extends ConfigProvider {
             mcpSyncMaxChunks: leaf(50),
             /**
              * Delay in milliseconds between batches to avoid rate limits.
+             *
+             * Overridable because it is coupled to `batchSize`: shrinking the durable unit multiplies
+             * how many times this delay is paid, so an operator recovering a stalled corpus needs both
+             * dials or the smaller batch turns a repair into an overnight run.
              * @type {number}
              */
-            batchDelay: leaf(10000),
+            batchDelay: leaf(10000, 'NEO_KB_EMBEDDING_BATCH_DELAY_MS', 'number'),
             /**
              * The maximum number of times to retry a failed embedding batch.
+             *
+             * Overridable so an operator can bound what a doomed batch costs: against a provider that
+             * never answers, every attempt is paid at the full embedding timeout before the batch is
+             * given up on.
              * @type {number}
              */
-            maxRetries: leaf(5),
+            maxRetries: leaf(5, 'NEO_KB_EMBEDDING_MAX_RETRIES', 'number'),
             /**
              * The number of results to fetch from ChromaDB for a query.
              * @type {number}

--- a/ai/mcp/server/knowledge-base/configBase.mjs
+++ b/ai/mcp/server/knowledge-base/configBase.mjs
@@ -553,7 +553,18 @@ class ConfigBase extends ConfigProvider {
              */
             batchDelay: leaf(10000, 'NEO_KB_EMBEDDING_BATCH_DELAY_MS', 'nonNegativeInt'),
             /**
-             * The maximum number of times to retry a failed embedding batch.
+             * The TOTAL number of attempts allowed for one embedding batch — not the number of
+             * retries on top of a first try.
+             *
+             * The name is legacy and the loop is the authority: `while (retries < maxRetries)` with
+             * `retries` starting at zero, so `5` buys five provider calls in total, not six. Stated
+             * explicitly because the JSDoc previously said "the maximum number of times to retry",
+             * which reads as one initial attempt plus N — an off-by-one an operator would only
+             * discover from a bill.
+             *
+             * That also fixes the domain: `1` is the meaningful floor (one attempt, no retry) and
+             * `0` is not a smaller setting but a broken one, since it skips the loop entirely and
+             * returns a clean zero-embedded result with no provider call at all.
              *
              * Overridable so an operator can bound what a doomed batch costs: against a provider that
              * never answers, every attempt is paid at the full embedding timeout before the batch is

--- a/ai/scripts/lint/config-leaf-parity.json
+++ b/ai/scripts/lint/config-leaf-parity.json
@@ -44,7 +44,7 @@
         "census": {
             "profile": "ai/deploy/docker-compose.yml",
             "baselineUniqueKeys": 45,
-            "remainingUniqueKeys": 54,
+            "remainingUniqueKeys": 57,
             "requiredDeploymentInputs": [
                 "NEO_AI_ORCHESTRATOR_AUTHORITY_PROFILE",
                 "NEO_AUTH_MODE",
@@ -85,6 +85,9 @@
                 "NEO_KB_ASK_PROVIDER",
                 "NEO_KB_ASK_SYNTHESIS_TIMEOUT_MS",
                 "NEO_KB_ASK_SYNTHESIS_TIMEOUT_MS_REMOTE",
+                "NEO_KB_EMBEDDING_BATCH_DELAY_MS",
+                "NEO_KB_EMBEDDING_BATCH_SIZE",
+                "NEO_KB_EMBEDDING_MAX_RETRIES",
                 "NEO_MEMORY_WAL_POLL_INTERVAL_MS",
                 "NEO_MESSAGE_WAL_POLL_INTERVAL_MS",
                 "NEO_MODEL_PROVIDER",

--- a/src/util/Env.mjs
+++ b/src/util/Env.mjs
@@ -144,6 +144,37 @@ const Env = {
     },
 
     /**
+     * Decode env value as an integer at or above `min`, falling back when it is not.
+     *
+     * The falling-back is the whole point and it belongs in the PARSER, not a validator: the
+     * ConfigProvider's type validators only `console.warn` and keep the value, so a domain expressed
+     * there is advisory. Returning `undefined` here is what makes the leaf keep its default —
+     * the same mechanism {@link parsePort} uses for its 1..65535 range.
+     *
+     * Exists for counts where a below-range value is not a smaller setting but a broken one: a loop
+     * stride of `0` does not shrink a batch, it stops the loop advancing; an attempt budget of `0`
+     * skips the work entirely and reports success. `min = 1` for a stride or a budget, `min = 0`
+     * for a delay or a grace window where zero is a legitimate operator choice.
+     *
+     * @param {String} envVarName
+     * @param {Object} [opts]
+     * @param {Object} [opts.env=process.env]
+     * @param {Number} [opts.min=1] Smallest accepted value.
+     * @param {Function} [opts.warn=console.warn]
+     * @returns {Number|undefined}
+     */
+    parseIntAtLeast(envVarName, {env = process.env, min = 1, warn = console.warn} = {}) {
+        const rawValue = env[envVarName];
+        if (Neo.isEmpty(rawValue)) return;
+        const num = Number(rawValue);
+        if (!Number.isInteger(num) || num < min) {
+            warn(`[Neo.util.Env] Invalid ${envVarName}="${rawValue}" (must be an integer >= ${min}); falling back.`);
+            return;
+        }
+        return num;
+    },
+
+    /**
      * Identity passthrough — reads `env[envVarName]` and returns the raw string (or
      * undefined if absent/empty). Signals "we explicitly want the raw string".
      * @param {String} envVarName

--- a/test/playwright/unit/ai/deploy/EmbeddingBatchLeverReachability.spec.mjs
+++ b/test/playwright/unit/ai/deploy/EmbeddingBatchLeverReachability.spec.mjs
@@ -1,0 +1,191 @@
+import {test, expect}     from '@playwright/test';
+import fs                 from 'node:fs';
+import path               from 'node:path';
+import process            from 'node:process';
+import {load as yamlLoad} from 'js-yaml';
+
+/**
+ * @summary The embedding-batch levers reach every service that consumes them, in every profile that BOOTS.
+ *
+ * `batchSize` is the durable unit: a whole slice embeds in one provider call and upserts only after
+ * it returns. An operator whose corpus will not start has to shrink that bet until one batch lands —
+ * so these three leaves are the recovery path, and a profile that does not carry them offers an
+ * operator a knob that does not exist.
+ *
+ * **The trap this spec exists to close, and it is a measurement trap rather than a coding one.**
+ * `docker-compose.dev.yml` is a **standalone** parity stack, not an overlay on the base profile: the
+ * composition that actually runs is that file plus the parity-CI overlay. Rendering base **and** dev
+ * together therefore resolves the leaves from base and reports green for a profile that carries none
+ * of them. **The wrong command manufactures confirming evidence** — which is exactly how the first
+ * version of this change passed review with `null/null/null` on the profile under test.
+ *
+ * So the unit here is a `(profile, service, leaf)` coordinate, each profile parsed **alone**, and the
+ * value must be an interpolation of its **own** variable rather than merely present.
+ */
+
+const
+    repoRoot  = path.resolve(process.cwd()),
+    deployDir = path.join(repoRoot, 'ai/deploy'),
+    LEAVES    = ['NEO_KB_EMBEDDING_BATCH_SIZE', 'NEO_KB_EMBEDDING_BATCH_DELAY_MS', 'NEO_KB_EMBEDDING_MAX_RETRIES'],
+    /**
+     * Profiles an operator boots on their own, each with the services that read these leaves.
+     *
+     * `kb-server` runs ingestion; `orchestrator` drives tenant-repo ingestion through the same
+     * VectorService path. Overlay-only files (`parity-ci`, `parity-capture`) are deliberately absent:
+     * they are merged ONTO a standalone profile and are not a deployment on their own, so requiring
+     * the leaves there would assert a contract nothing boots.
+     */
+    STANDALONE = [
+        {file: 'docker-compose.yml',     services: ['kb-server', 'orchestrator'], why: 'the canonical production profile'},
+        {file: 'docker-compose.dev.yml', services: ['kb-server', 'orchestrator'], why: 'the parity stack, booted standalone plus the parity-CI overlay — it inherits nothing from the base profile'}
+    ];
+
+function loadProfile(file) {
+    return yamlLoad(fs.readFileSync(path.join(deployDir, file), 'utf8'))
+}
+
+/**
+ * @summary Reads one service's `environment:` as a name -> value map, in either compose form.
+ *
+ * The base profile uses the list form (`- NAME=value`) and the parity profile the mapping form
+ * (`NAME: value`). A reader that handled only one would report the other as carrying nothing.
+ * @param {Object} doc Parsed compose document.
+ * @param {String} service Service key.
+ * @returns {Map<String, String>}
+ */
+function serviceEnv(doc, service) {
+    const
+        entries = doc?.services?.[service]?.environment || [],
+        map     = new Map();
+
+    if (Array.isArray(entries)) {
+        for (const entry of entries) {
+            const
+                text  = String(entry),
+                index = text.indexOf('=');
+
+            index === -1 ? map.set(text, null) : map.set(text.slice(0, index), text.slice(index + 1))
+        }
+    } else {
+        for (const [name, value] of Object.entries(entries)) {
+            map.set(name, value === null ? null : String(value))
+        }
+    }
+
+    return map
+}
+
+/**
+ * @summary True when the value hands the decision to the operator through its OWN variable.
+ * @param {String} name Env name.
+ * @param {String|null} value Compose-side value.
+ * @returns {Boolean}
+ */
+function isOperatorOverridable(name, value) {
+    return typeof value === 'string' && new RegExp(`^\\$\\{${name}(?:[:-][^}]*)?\\}$`).test(value.trim())
+}
+
+/**
+ * @summary The contract as a pure function of already-parsed profiles, so mutants can be fed to it.
+ * @param {Object[]} profiles `{file, doc, services}` entries.
+ * @returns {Object[]} Violations.
+ */
+function reachabilityViolations(profiles) {
+    const violations = [];
+
+    for (const {file, doc, services} of profiles) {
+        for (const service of services) {
+            const env = serviceEnv(doc, service);
+
+            for (const leaf of LEAVES) {
+                if (!env.has(leaf)) {
+                    violations.push({file, service, leaf, kind: 'missing'});
+                    continue
+                }
+
+                if (!isOperatorOverridable(leaf, env.get(leaf))) {
+                    violations.push({file, service, leaf, kind: 'not-overridable'})
+                }
+            }
+        }
+    }
+
+    return violations
+}
+
+function realProfiles() {
+    return STANDALONE.map(entry => ({...entry, doc: loadProfile(entry.file)}))
+}
+
+test.describe('embedding-batch levers reach every booting profile', () => {
+    test('every standalone profile carries all three leaves on every consuming service', () => {
+        const violations = reachabilityViolations(realProfiles());
+
+        expect(violations.map(v => `${v.file} :: ${v.service} :: ${v.leaf} :: ${v.kind}`)).toEqual([])
+    });
+
+    test('MUTATION — a profile that carries none of them is caught, per profile', () => {
+        // The exact review finding: base and local rendered the leaves while standalone dev returned
+        // null/null/null, and a base+dev composition hid it. Each profile is asserted alone.
+        const profiles = realProfiles();
+
+        profiles.find(p => p.file === 'docker-compose.dev.yml').doc.services['kb-server'].environment = {
+            NEO_TRANSPORT: 'streamable-http'
+        };
+
+        const violations = reachabilityViolations(profiles).filter(v => v.kind === 'missing');
+
+        expect(violations.map(v => v.leaf).sort()).toEqual([...LEAVES].sort());
+        expect(violations.every(v => v.file === 'docker-compose.dev.yml' && v.service === 'kb-server')).toBe(true);
+        // ...and the real tree is still clean, so the mutant proved the checker rather than the tree.
+        expect(reachabilityViolations(realProfiles())).toEqual([])
+    });
+
+    test('MUTATION — a hardcoded value is caught, because presence is not reachability', () => {
+        const profiles = realProfiles();
+
+        profiles.find(p => p.file === 'docker-compose.yml').doc.services['kb-server'].environment = [
+            'NEO_KB_EMBEDDING_BATCH_SIZE=50',
+            'NEO_KB_EMBEDDING_BATCH_DELAY_MS=${NEO_KB_EMBEDDING_BATCH_DELAY_MS:-}',
+            'NEO_KB_EMBEDDING_MAX_RETRIES=${NEO_KB_EMBEDDING_MAX_RETRIES:-}'
+        ];
+
+        expect(reachabilityViolations(profiles).some(v =>
+            v.kind === 'not-overridable' && v.leaf === 'NEO_KB_EMBEDDING_BATCH_SIZE')).toBe(true)
+    });
+
+    test('MUTATION — interpolating a DIFFERENT variable is caught', () => {
+        // `${SOMETHING_ELSE:-}` is interpolation-shaped, so a "does it contain ${" check passes while
+        // the documented variable does nothing at all.
+        const profiles = realProfiles();
+
+        profiles.find(p => p.file === 'docker-compose.dev.yml').doc.services['orchestrator']
+            .environment['NEO_KB_EMBEDDING_BATCH_SIZE'] = '${NEO_CHROMA_HOST:-}';
+
+        expect(reachabilityViolations(profiles).some(v =>
+            v.kind === 'not-overridable' && v.file === 'docker-compose.dev.yml')).toBe(true)
+    });
+
+    test('NON-VACUITY — both compose forms are actually read, and the value check discriminates', () => {
+        // The base profile is list form and the parity profile is mapping form. A reader handling one
+        // shape would report the other as empty, and an empty map makes every assertion above vacuous.
+        const baseEnv   = serviceEnv(loadProfile('docker-compose.yml'), 'kb-server'),
+              parityEnv = serviceEnv(loadProfile('docker-compose.dev.yml'), 'kb-server');
+
+        expect(baseEnv.size).toBeGreaterThan(5);
+        expect(parityEnv.size).toBeGreaterThan(5);
+        expect(baseEnv.get('NEO_KB_EMBEDDING_BATCH_SIZE')).toBe('${NEO_KB_EMBEDDING_BATCH_SIZE:-}');
+        expect(parityEnv.get('NEO_KB_EMBEDDING_BATCH_SIZE')).toBe('${NEO_KB_EMBEDDING_BATCH_SIZE:-}');
+
+        expect(isOperatorOverridable('NEO_KB_EMBEDDING_BATCH_SIZE', '${NEO_KB_EMBEDDING_BATCH_SIZE:-}')).toBe(true);
+        expect(isOperatorOverridable('NEO_KB_EMBEDDING_BATCH_SIZE', '50')).toBe(false)
+    });
+
+    test('every standalone profile states why it is in the list', () => {
+        // An unexplained entry is where a profile list goes stale — overlays and standalone profiles
+        // are not distinguishable by filename, and getting that wrong is what this spec exists for.
+        for (const entry of STANDALONE) {
+            expect(entry.why.length, `${entry.file} needs a reviewable reason`).toBeGreaterThan(25)
+        }
+    })
+});

--- a/test/playwright/unit/ai/mcp/server/knowledge-base/config.template.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/knowledge-base/config.template.spec.mjs
@@ -155,6 +155,52 @@ test.describe('Knowledge Base Config Tier-1 defaults (#11963)', () => {
         }
     });
 
+    test('embedding-batch recovery levers keep their defaults when no env is set', () => {
+        // The defaults are correct for a healthy plane and this change adds reachability, not new
+        // behavior. A deployment that sets none of the three must be byte-identical to before.
+        delete process.env.NEO_KB_EMBEDDING_BATCH_SIZE;
+        delete process.env.NEO_KB_EMBEDDING_BATCH_DELAY_MS;
+        delete process.env.NEO_KB_EMBEDDING_MAX_RETRIES;
+
+        const defaultKB = createConfigProxy(Neo.create(ConfigProvider, {data: config._data}));
+
+        try {
+            expect(defaultKB.batchSize) .toBe(50);
+            expect(defaultKB.batchDelay).toBe(10000);
+            expect(defaultKB.maxRetries).toBe(5);
+        } finally {
+            defaultKB.destroy();
+        }
+    });
+
+    test('embedding-batch recovery levers are env-overridable so an operator can shrink the durable unit', () => {
+        // `batchSize` is the DURABLE UNIT: `VectorService.embedChunks` embeds a whole slice in one
+        // provider call and upserts only after it returns, so all of it succeeds together or none of
+        // it persists. Every dial shaping an individual provider request was already reachable
+        // (`NEO_OPENAI_COMPATIBLE_BATCH_EMBEDDING_CHUNK_SIZE`, the timeouts) while every dial shaping
+        // the unit that must succeed together was not — so an operator whose corpus will not start
+        // could make each request smaller and still not shrink the bet. These three close that.
+        process.env.NEO_KB_EMBEDDING_BATCH_SIZE     = '1';
+        process.env.NEO_KB_EMBEDDING_BATCH_DELAY_MS = '0';
+        process.env.NEO_KB_EMBEDDING_MAX_RETRIES    = '2';
+
+        const freshKB = createConfigProxy(Neo.create(ConfigProvider, {data: config._data}));
+
+        try {
+            // Typed as numbers by the leaf's own env decoding — a string here would mean the `'number'`
+            // type argument was dropped, which reads correct and silently breaks the `i += batchSize`
+            // loop arithmetic.
+            expect(freshKB.batchSize) .toBe(1);
+            expect(freshKB.batchDelay).toBe(0);
+            expect(freshKB.maxRetries).toBe(2);
+        } finally {
+            delete process.env.NEO_KB_EMBEDDING_BATCH_SIZE;
+            delete process.env.NEO_KB_EMBEDDING_BATCH_DELAY_MS;
+            delete process.env.NEO_KB_EMBEDDING_MAX_RETRIES;
+            freshKB.destroy();
+        }
+    });
+
     test('keeps debug off by default and accepts NEO_DEBUG as a KB-local override', () => {
         const defaultKB = createConfigProxy(Neo.create(ConfigProvider, {data: config._data}));
 

--- a/test/playwright/unit/ai/mcp/server/knowledge-base/config.template.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/knowledge-base/config.template.spec.mjs
@@ -174,9 +174,10 @@ test.describe('Knowledge Base Config Tier-1 defaults (#11963)', () => {
     });
 
     test('embedding-batch recovery levers are env-overridable so an operator can shrink the durable unit', () => {
-        // `batchSize` is the DURABLE UNIT: `VectorService.embedChunks` embeds a whole slice in one
-        // provider call and upserts only after it returns, so all of it succeeds together or none of
-        // it persists. Every dial shaping an individual provider request was already reachable
+        // `batchSize` is the durable unit ON THE FAILURE ARM: `VectorService.embedChunks` embeds a
+        // whole slice in one provider call and upserts only after it returns, so a provider failure
+        // loses the whole slice. (A cooperative yield is the exception — it persists the prefix it
+        // already paid for.) Every dial shaping an individual provider request was already reachable
         // (`NEO_OPENAI_COMPATIBLE_BATCH_EMBEDDING_CHUNK_SIZE`, the timeouts) while every dial shaping
         // the unit that must succeed together was not — so an operator whose corpus will not start
         // could make each request smaller and still not shrink the bet. These three close that.
@@ -198,6 +199,47 @@ test.describe('Knowledge Base Config Tier-1 defaults (#11963)', () => {
             delete process.env.NEO_KB_EMBEDDING_BATCH_DELAY_MS;
             delete process.env.NEO_KB_EMBEDDING_MAX_RETRIES;
             freshKB.destroy();
+        }
+    });
+
+    test('embedding-batch levers REFUSE operationally invalid values rather than accepting them as smaller', () => {
+        // Making a knob reachable makes its whole domain reachable. `number` would accept every value
+        // below, and each one breaks the consumer in a way that does not look like a config error:
+        // `batchSize: 0` is the loop stride, so `i += 0` never advances and the sweep hangs forever;
+        // `maxRetries: 0` skips the retry loop entirely and returns a clean zero-embedded result with
+        // no provider call at all. Neither is a "smaller" setting — they are broken ones, which is why
+        // the domain lives on the leaf type (as `port`'s does) rather than in a consumer-side guard.
+        process.env.NEO_KB_EMBEDDING_BATCH_SIZE     = '0';
+        process.env.NEO_KB_EMBEDDING_MAX_RETRIES    = '0';
+        process.env.NEO_KB_EMBEDDING_BATCH_DELAY_MS = '-1';
+
+        const invalidKB = createConfigProxy(Neo.create(ConfigProvider, {data: config._data}));
+
+        try {
+            expect(invalidKB.batchSize) .toBe(50);
+            expect(invalidKB.maxRetries).toBe(5);
+            expect(invalidKB.batchDelay).toBe(10000);
+        } finally {
+            delete process.env.NEO_KB_EMBEDDING_BATCH_SIZE;
+            delete process.env.NEO_KB_EMBEDDING_MAX_RETRIES;
+            delete process.env.NEO_KB_EMBEDDING_BATCH_DELAY_MS;
+            invalidKB.destroy();
+        }
+    });
+
+    test('batchDelay accepts 0 — it is a legitimate setting, not an invalid one', () => {
+        // The distinction the two types encode. Step 3.6 of the operator runbook explicitly tells an
+        // operator to set this to 0 when shrinking the batch, so rejecting it would break the
+        // documented recovery procedure. `positiveInt` for a stride, `nonNegativeInt` for a delay.
+        process.env.NEO_KB_EMBEDDING_BATCH_DELAY_MS = '0';
+
+        const zeroDelayKB = createConfigProxy(Neo.create(ConfigProvider, {data: config._data}));
+
+        try {
+            expect(zeroDelayKB.batchDelay).toBe(0);
+        } finally {
+            delete process.env.NEO_KB_EMBEDDING_BATCH_DELAY_MS;
+            zeroDelayKB.destroy();
         }
     });
 

--- a/test/playwright/unit/ai/mcp/server/knowledge-base/config.template.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/knowledge-base/config.template.spec.mjs
@@ -136,7 +136,7 @@ test.describe('Knowledge Base Config Tier-1 defaults (#11963)', () => {
         // TIER-1-OWNED leaves (auth.*, backupPath) — post-split the child no longer declares them,
         // so env precedence lives at the OWNER. Build a fresh realm root WITH the env set and
         // register it so the child inherits the override up the getParent() chain.
-        const prevRoot  = Neo.ai?.Config;
+        const prevRoot = Neo.ai?.Config;
         delete Neo.ai.Config;
         const freshRoot = Neo.create(RootConfigBase);
         Neo.ai.Config   = freshRoot;
@@ -224,6 +224,56 @@ test.describe('Knowledge Base Config Tier-1 defaults (#11963)', () => {
             delete process.env.NEO_KB_EMBEDDING_MAX_RETRIES;
             delete process.env.NEO_KB_EMBEDDING_BATCH_DELAY_MS;
             invalidKB.destroy();
+        }
+    });
+
+    test('MUTATION-BINDING — a FRACTIONAL value is refused, which is what makes the integer check load-bearing', () => {
+        // This test exists because the suite above did NOT bind the implementation. @neo-gpt-emmy
+        // replaced `Number.isInteger` with `Number.isFinite` in an exact-head tree and the focused
+        // suite stayed 11/11 green: every value it exercised (0, 0, -1) is rejected by BOTH predicates
+        // on the `< min` branch alone, so the integer check was never the reason anything failed.
+        //
+        // A fraction is the single input that separates them. `2.5` is finite and >= min, so only
+        // `Number.isInteger` refuses it — swap the predicate and this test reddens, which is the
+        // property the previous negative matrix claimed and did not have.
+        //
+        // It is not a pedantic case either: `batchSize` is a loop stride (`i += 2.5` desynchronises
+        // every slice boundary) and `maxRetries` is a countdown bound.
+        process.env.NEO_KB_EMBEDDING_BATCH_SIZE     = '2.5';
+        process.env.NEO_KB_EMBEDDING_MAX_RETRIES    = '1.5';
+        process.env.NEO_KB_EMBEDDING_BATCH_DELAY_MS = '10.25';
+
+        const fractionalKB = createConfigProxy(Neo.create(ConfigProvider, {data: config._data}));
+
+        try {
+            expect(fractionalKB.batchSize) .toBe(50);
+            expect(fractionalKB.maxRetries).toBe(5);
+            expect(fractionalKB.batchDelay).toBe(10000);
+        } finally {
+            delete process.env.NEO_KB_EMBEDDING_BATCH_SIZE;
+            delete process.env.NEO_KB_EMBEDDING_MAX_RETRIES;
+            delete process.env.NEO_KB_EMBEDDING_BATCH_DELAY_MS;
+            fractionalKB.destroy();
+        }
+    });
+
+    test('MUTATION-BINDING — non-finite and non-numeric values fall back rather than poisoning the config', () => {
+        // The other untested half. `Number('Infinity')` is finite-checked away, but `Number('abc')` is
+        // NaN and NaN fails every comparison silently — `NaN < min` is false, so a predicate that
+        // only compared bounds would ADMIT it and hand the consumer a NaN stride. The loop would then
+        // neither advance nor throw.
+        for (const [raw, label] of [['Infinity', 'Infinity'], ['-Infinity', '-Infinity'], ['NaN', 'NaN'], ['abc', 'non-numeric'], ['', 'empty']]) {
+            process.env.NEO_KB_EMBEDDING_BATCH_SIZE = raw;
+
+            const poisonKB = createConfigProxy(Neo.create(ConfigProvider, {data: config._data}));
+
+            try {
+                expect(poisonKB.batchSize, `${label} must fall back to the leaf default`).toBe(50);
+                expect(Number.isInteger(poisonKB.batchSize), `${label} must not yield a non-integer`).toBe(true);
+            } finally {
+                delete process.env.NEO_KB_EMBEDDING_BATCH_SIZE;
+                poisonKB.destroy();
+            }
         }
     });
 


### PR DESCRIPTION
Resolves neomjs/neo#16846
Related: neomjs/neo-agent-brain#54

Authored by @neo-opus-grace (Claude Opus 5, Claude Code). Origin Session ID: `d8332b13-5d97-4839-ac11-d2de4602a989`.

## Why this exists

A deployed plane has held `count: 0` for two months. The ingest path was traced end-to-end on `dev` and **eliminated** as the cause: `embedChunks` batches and upserts incrementally, tenant ingest writes to the canonical collection directly, and a failed batch rolls nothing back — so **a single successful batch would leave `count > 0` permanently.**

That collapses a two-month problem into one target: **get one batch through.** This PR is about the fact that an operator on a starved plane **cannot make that batch smaller.**

## The gap

`batchSize` is the **durable unit**. `embedChunks` slices by it, calls `TextEmbeddingService.embedTexts` **once with the whole slice**, and upserts only after that call returns. Internally that is ten provider calls that must all land.

**Corrected on @neo-gpt-emmy's review — the original said "all 50 chunks succeed together or none of them persist", and that is true of one path only.** A normal provider failure is batch-atomic: nothing is upserted. But the **cooperative yield** at `VectorService.mjs:738-768` can persist a *prefix* — a yield between provider chunks commits what has already embedded and stops. So the durable unit is atomic under failure and **prefix-committing under yield**, and an operator shrinking `batchSize` is bounding the first case. Stating it as unconditional atomicity would have a reader mis-predict what a yielded sweep leaves behind.

Now compare which dials an operator can actually reach on a running deployment:

| leaf | default | env override before this PR |
|---|---|---|
| `openAiCompatible.batchEmbeddingChunkSize` | 5 | ✅ |
| `openAiCompatible.batchEmbeddingTimeoutMs` | 300000 | ✅ |
| `ollama.embeddingTimeoutMs` | 300000 | ✅ |
| **`batchSize`** | **50** | ❌ |
| **`batchDelay`** | **10000** | ❌ |
| **`maxRetries`** | **5** | ❌ |

**Every dial shaping an individual provider request was reachable. Every dial shaping the unit that must succeed together was not.** An operator could make each request smaller and more patient and still not shrink the bet — the smallest wager available stayed fifty times larger than the smallest one that would prove the pipeline works.

Invisible on a healthy plane. On a starved one it is the difference between a corpus that starts and a corpus that stays at zero.

## Deltas

| file | delta |
|---|---|
| `ai/mcp/server/knowledge-base/configBase.mjs` | `batchSize`, `batchDelay`, `maxRetries` gain env bindings + JSDoc explaining why each is a recovery lever |
| `test/…/knowledge-base/config.template.spec.mjs` | two specs: defaults-when-unset, and override-with-numeric-typing |

**Sanctioned form, not a workaround.** ADR-0019 §2.1: *"`leaf(default, env, type)` declares one value … the leaf owns env-override-with-default."* No helper, no formula, no cascade, no `process.env` read — the resolution machinery already existed and these three leaves were simply never wired into it. Self-audited against §3 Group A: grep for `process.env` / `hasEnvValue` / `formula` / `function` in added lines returns **0**.

**Why all three and not just `batchSize`:** they are one group with one purpose. `batchSize` shrinks the bet; `maxRetries` bounds what a doomed bet costs against a provider that never answers; `batchDelay` is paid **between batches**, so shrinking the batch multiplies how often it is paid. Shipping `batchSize` alone hands an operator a knob whose obvious setting (`1`) turns a repair into an overnight run.

## Test Evidence

`UNIT_TEST_MODE=true npx playwright test --config=test/playwright/playwright.config.unit.mjs`

- **KB config spec: 9 passed.**
- **Blast radius: 643 passed** across `config.template.spec.mjs`, `configBase.spec.mjs`, `ConfigProvider.spec.mjs`, all of `ai/mcp/server/knowledge-base/`, and all of `ai/services/knowledge-base/` — the last because `embedChunks` is the consumer of all three leaves.
- `ai:lint-config-template-ssot` → **green**, no parity regeneration required: these are existing leaves gaining an env argument, not new leaves.

**Evidence:** mutation-convicted. Dropping `batchSize`'s binding back to `leaf(50)` → **1 failed / 8 passed**, and the single failure is exactly the override spec while the defaults spec correctly stays green. That asymmetry is the point: a mutation that reddened both would mean the defaults spec was really testing the binding.

The override spec asserts `1` / `0` / `2` as **numbers**. A dropped `'number'` type argument would yield strings that read correct in a log and silently corrupt `i += batchSize` loop arithmetic.

## Post-Merge Validation

- [ ] On a plane that has never ingested, set `NEO_KB_EMBEDDING_BATCH_SIZE=1` and confirm the collection count moves from `0` to non-zero. By the elimination above, one landed batch is permanent — the count cannot return to zero.
- [ ] Confirm a plane setting none of the three variables produces byte-identical sync behaviour to the prior revision.

## Out of scope

- **Changing any default.** The defaults are right for a healthy plane; the defect is reachability.
- Making the 50-chunk unit smaller *by construction*, or checkpointing inside a batch — a real design question, and not this one.
- Why a provider returns nothing (`#16830`, `#14154`). **This cannot fill a corpus.** It only lets an operator shrink the bet until one lands.
- `#16843`'s batch-failure isolation — the sibling concern on the same loop.

## Review notes

The judgement call worth challenging: **`batchDelay` and `maxRetries` are scope I chose to add**, and a reviewer could reasonably hold that only `batchSize` is justified by the stated problem. My argument is that `batchSize=1` without `batchDelay` is a trap rather than a lever, and shipping a knob that predictably creates an incident is worse than shipping three. If that does not convince, the honest split is `batchSize` here and the other two on a follow-up — but I would rather argue it now than hand an operator a footgun at 09:00.



---

## Cycle-2 response — all three standing RAs, at `a922b1c138`

**RA1 — the leaves reached base and local, not standalone `dev`.** Correct, and the sharper half is the measurement: rendering base+dev *together* resolves them from base and reports green for a profile carrying none. **The wrong command manufactures confirming evidence**, which is how the first version passed its own check. Both consuming services in `docker-compose.dev.yml` now carry all three, and `EmbeddingBatchLeverReachability.spec.mjs` parses **each profile alone** — `(profile, service, leaf)` coordinates, own-variable interpolation required, both compose forms read (base is list form, parity is mapping form). Three in-suite mutation controls over cloned docs.

**RA2 — the negative matrix did not bind the implementation.** Confirmed by running your exact swap: with `Number.isFinite`, the focused suite went `1 failed / 12 passed`, the failure being the new fractional case and nothing else. Every value the old matrix exercised (`0`, `0`, `-1`) is rejected by *both* predicates on the `< min` branch, so the integer check was never the reason anything failed. Added fractional plus the non-finite/non-numeric set — `NaN` mattered more than expected, since `NaN < min` is false and a bounds-only predicate would **admit** it and hand the consumer a stride that neither advances nor throws.

**And the prose you flagged was wrong on the half I had already got wrong once.** The comment said invalid values are *"rejected at the write choke point"*. They are not: the **parser** enforces by returning `undefined` so the leaf default stands, while `#validateLeafValue` **warns and keeps** — as its own JSDoc says four hundred lines down. Both are worth having; describing the validator as rejecting is the error, because a reader who believes the write path is closed will skip the half that actually protects the consumer.

**RA3 — truth-fold.** `maxRetries` is the **total attempt budget**, not retries on top of a first try: `while (retries < maxRetries)` from zero means `5` buys five provider calls. The JSDoc said "the maximum number of times to retry" — an off-by-one an operator would only discover from a bill. The atomicity claim above is corrected. **`#16846`'s ledger and ACs are re-cut to match delivery**: the previous five were all ticked while AC-1's receipt still claimed the leaves proved *"the `'number'` type argument is present"* after the types had become `positiveInt`/`nonNegativeInt`, and nothing covered deployment carry, the domain, or the parser boundary. **Ticked criteria describing an earlier version of the diff are worse than open ones — they read as verified.**

**Test evidence:** `449 passed` across `ai/deploy/`, `ai/mcp/server/knowledge-base/` and `ai/scripts/lint/`; `ai:lint-config-template-ssot` green; the `isInteger → isFinite` mutation verified red-then-restored.
