### PR TITLE
fix(recovery): preserve write-time audit provenance (#16837)

### DIFF
--- a/ai/daemons/orchestrator/services/ContainerHealthControllerService.mjs
+++ b/ai/daemons/orchestrator/services/ContainerHealthControllerService.mjs
@@ -411,6 +411,8 @@ export class ContainerHealthControllerService extends Base {
      * `rejected` / `recorded` / `failed`) rather than a controller vocabulary, so `summarizeHealLedger`
      * folds one status space and an anti-thrash deferral stays distinguishable from a refusal. A ledger
      * failure is logged and swallowed: observability must never veto the heal it is observing.
+     * When this controller has a live authority oracle, the same oracle travels into the store so the
+     * append is revalidated after its awaited directory setup, not only at the preflight below.
      *
      * @param {Object} options
      * @returns {Promise<void>}
@@ -452,7 +454,14 @@ export class ContainerHealthControllerService extends Base {
                     targetIdentity: decision.diagnosis.targetIdentity || decision.targetIdentity || null,
                     evidenceFacts : decision.diagnosis.evidenceFacts || []
                 }
-            }, {dir: this.healLedgerDir, now, ...(this.healLedgerRetention || {})});
+            }, {
+                dir: this.healLedgerDir,
+                now,
+                ...(this.healLedgerRetention || {}),
+                // Preserve legacy callers exactly: only an authority-bearing controller asks the
+                // shared store to stamp/refuse this owner-authoritative receipt.
+                ...(typeof this.isAuthorityHeld === 'function' ? {isAuthorityHeld: this.isAuthorityHeld} : {})
+            });
         } catch (error) {
             this.writeLog?.('ERROR', `[ContainerHealthController] heal-event append failed for ${decision.serviceKey}: ${error.message}`);
         }

--- a/ai/daemons/orchestrator/services/RecoveryActuatorService.mjs
+++ b/ai/daemons/orchestrator/services/RecoveryActuatorService.mjs
@@ -542,6 +542,8 @@ export class RecoveryActuatorService extends Base {
      * @param {String|null} [options.recoveryRunId=null] Optional stable recovery run id.
      * @param {Number} [options.now=Date.now()] Epoch milliseconds.
      * @param {String|null} [options.reason=null] Controller reason.
+     * @param {Function|null} [options.isAuthorityHeld=null] Live authority oracle carried into both
+     * durable stores so each can sample adjacent to its own append.
      * @returns {Promise<Object>} Record outcome descriptor.
      */
     async recordDiagnosis(diagnosisEvent, {
@@ -609,7 +611,15 @@ export class RecoveryActuatorService extends Base {
                 targetIdentity: createRecoveryTargetIdentity(diagnosis.targetIdentity),
                 evidenceFacts : diagnosis.evidenceFacts || []
             }
-        }, {dir: this.healEventLedgerDir, now, ...this.healLedgerRetention});
+        }, {
+            dir: this.healEventLedgerDir,
+            now,
+            ...this.healLedgerRetention,
+            // The entry check above precedes an awaited directory setup inside the store. Carry the
+            // oracle to that source boundary so a takeover during setup refuses this owner-success
+            // audit instead of leaving an unqualified `recorded` row.
+            isAuthorityHeld
+        });
 
         const updatedAt = Date.now();
 
@@ -919,7 +929,7 @@ export class RecoveryActuatorService extends Base {
             return this.restartSupervisedTask({target, reason});
         }
 
-        return this.recordDeployTarget({target, action, reason});
+        return this.recordDeployTarget({target, action, reason, isAuthorityHeld});
     }
 
     /**
@@ -1021,9 +1031,11 @@ export class RecoveryActuatorService extends Base {
      * cloud has no human to page, so an un-resolvable deploy-target is RECORDED (durable async-audit), never
      * paged — this completes the escalate/page → record cutover for the last lifecycle page path.
      * @param {Object} options
+     * @param {Function|null} [options.isAuthorityHeld=null] Live authority oracle carried into the
+     * heal-event store so it can sample adjacent to the record-only append.
      * @returns {Promise<Object>}
      */
-    async recordDeployTarget({target, action, reason}) {
+    async recordDeployTarget({target, action, reason, isAuthorityHeld = null}) {
         const recorded = {
             serviceKey  : target.serviceKey,
             deployTarget: target.id,
@@ -1036,7 +1048,12 @@ export class RecoveryActuatorService extends Base {
             collection: target.id,
             status    : 'recorded',
             detail    : recorded
-        }, {dir: this.healEventLedgerDir, now: Date.now(), ...this.healLedgerRetention});
+        }, {
+            dir: this.healEventLedgerDir,
+            now: Date.now(),
+            ...this.healLedgerRetention,
+            ...(typeof isAuthorityHeld === 'function' ? {isAuthorityHeld} : {})
+        });
 
         this.writeLog?.('INFO', `[RecoveryActuator] Redeploy required for ${target.id}; recorded to the heal-event ledger (no operator to page).`);
 

--- a/ai/services/memory-core/helpers/healEventLedgerStore.mjs
+++ b/ai/services/memory-core/helpers/healEventLedgerStore.mjs
@@ -95,10 +95,20 @@ export function validateHealLedgerRetention(maxEvents, triggerBytes) {
  * @param {Number} [options.now] Epoch ms used to stamp `at` when the entry omits it.
  * @param {Number} [options.triggerBytes] Byte threshold that arms the auto-prune (from the AiConfig retention leaf). The auto-prune is skipped unless both this and `maxEvents` are finite.
  * @param {Number} [options.maxEvents] Retention cap the triggered auto-prune enforces (from the AiConfig retention leaf).
+ * @param {Function|null} [options.isAuthorityHeld=null] Optional live authority oracle. When supplied, it is
+ * sampled after awaited directory setup and immediately before the append; admitted rows are stamped
+ * `heldAtWrite: true`, while a displaced writer is refused. Callers without an oracle retain the legacy row shape.
  * @returns {Promise<String>} The ledger file path written to.
  * @throws {TypeError} when `entry` is not an object or `dir` is missing/empty.
+ * @throws {Error} with `reason: 'runtime-authority-lost'` when a supplied oracle reports takeover.
  */
-export async function appendHealEvent(entry, {dir, now, triggerBytes, maxEvents} = {}) {
+export async function appendHealEvent(entry, {
+    dir,
+    now,
+    triggerBytes,
+    maxEvents,
+    isAuthorityHeld = null
+} = {}) {
     if (!entry || typeof entry !== 'object') {
         throw new TypeError('appendHealEvent: entry object is required');
     }
@@ -106,10 +116,26 @@ export async function appendHealEvent(entry, {dir, now, triggerBytes, maxEvents}
         throw new TypeError('appendHealEvent: dir is required');
     }
 
-    const stamped = {...entry, at: Number.isFinite(entry.at) ? entry.at : (Number.isFinite(now) ? now : null)};
+    const timed = {...entry, at: Number.isFinite(entry.at) ? entry.at : (Number.isFinite(now) ? now : null)};
 
     await mkdir(dir, {recursive: true});
     const filePath = getHealLedgerFilePath(dir);
+
+    // The caller's entry check cannot bind this write: directory setup above yielded. Sample at the
+    // store boundary, with no await before `appendFile`, so a record-only predecessor cannot write
+    // an unqualified `status: recorded` row after its successor has taken authority.
+    const heldAtWrite = typeof isAuthorityHeld === 'function' ? isAuthorityHeld() === true : null;
+
+    if (heldAtWrite === false) {
+        const error = new Error('Authority moved before the heal-event append; refusing.');
+
+        error.reason = 'runtime-authority-lost';
+
+        throw error;
+    }
+
+    const stamped = heldAtWrite === null ? timed : {...timed, heldAtWrite};
+
     await appendFile(filePath, `${JSON.stringify(stamped)}\n`, 'utf8');
 
     // Self-bound (mirrors acceptedLossAuditStore) ONLY when the AiConfig-aware caller supplied the retention

--- a/ai/services/memory-core/helpers/recoveryRunStateStore.mjs
+++ b/ai/services/memory-core/helpers/recoveryRunStateStore.mjs
@@ -493,6 +493,10 @@ export async function pruneRecoveryRunStates({dir, retentionLimit} = {}) {
  * @param {Object|null} [options.graphPublicationSummary=null] Mutable summary counters for publication attempts.
  * @param {Function|null} [options.onGraphPublicationError=null] Optional callback invoked after graph publication fails.
  * @param {Function|null} [options.writeLog=null] Optional logger for graph publication failures.
+ * @param {Function|null} [options.isAuthorityHeld=null] Live authority oracle sampled after directory setup and
+ * immediately before the source append. When omitted, the legacy unstamped append contract is preserved.
+ * @param {Boolean} [options.preserveOnAuthorityLoss=false] Preserve a dispatched-effect audit after authority loss,
+ * stamped `heldAtWrite: false`; non-dispatched records refuse instead.
  * @returns {Promise<String>} Written file path.
  */
 export async function appendRecoveryRunState(entry, {
@@ -543,7 +547,11 @@ export async function appendRecoveryRunState(entry, {
     await fs.appendFile(filePath, `${JSON.stringify(stamped)}\n`, 'utf8');
 
     if (graphService) {
-        await publishRecoveryRunStateToGraphWithSurface(entry, {
+        // Source and projection are ONE accepted operation. Publish the exact record that reached
+        // JSONL — including its store-adjacent authority sample — rather than the caller's earlier
+        // unstamped object. Re-sampling after the append would create a second authority decision;
+        // publishing `entry` loses the decision the source already made.
+        await publishRecoveryRunStateToGraphWithSurface(stamped, {
             graphPublicationSummary,
             graphService,
             onGraphPublicationError,
@@ -616,6 +624,16 @@ function getEntrySortTime(entry) {
     return 0;
 }
 
+/**
+ * @summary Projects one accepted recovery-run source record into the properties shared by its graph proof nodes.
+ *
+ * `heldAtWrite` is copied from the accepted source record. It is never inferred from the earlier
+ * `details.heldAtAppend` sample, and absence stays explicit as `null` on the raw graph surface.
+ * @param {Object} entry Accepted recovery-run source record.
+ * @param {Object} ids Stable graph node ids.
+ * @returns {Object} Graph properties shared by the run and state proof nodes.
+ * @private
+ */
 function createRecoveryRunGraphProperties(entry, {runNodeId, stateNodeId, diagnosisNodeId}) {
     return {
         schemaVersion         : 1,
@@ -641,6 +659,7 @@ function createRecoveryRunGraphProperties(entry, {runNodeId, stateNodeId, diagno
         wallClockMs           : entry.wallClockMs,
         backoffUntil          : entry.backoffUntil,
         hasReobserveRequest   : entry.reobserveRequest !== null,
+        heldAtWrite           : normalizeHeldAtWrite(entry.heldAtWrite, null),
         details               : entry.details
     };
 }
@@ -676,8 +695,22 @@ function normalizeRecoveryRunGraphRecord(record) {
 
     return {
         id: record.id || properties.recoveryRunStateNodeId,
-        ...properties
+        ...properties,
+        // Legacy graph nodes predate the store-adjacent sample. Surface that ignorance instead of
+        // allowing an earlier `details.heldAtAppend` Boolean to masquerade as write-time authority.
+        heldAtWrite: normalizeHeldAtWrite(properties.heldAtWrite, 'unknown')
     };
+}
+
+/**
+ * @summary Normalizes write-time authority without coercing legacy or malformed provenance.
+ * @param {*} value Candidate `heldAtWrite` value.
+ * @param {Boolean|String|null} unknownValue Explicit fallback for the target surface.
+ * @returns {Boolean|String|null} `true`, `false`, or the caller's unknown sentinel.
+ * @private
+ */
+function normalizeHeldAtWrite(value, unknownValue) {
+    return value === true || value === false ? value : unknownValue;
 }
 
 async function publishRecoveryRunStateToGraphWithSurface(entry, {

--- a/test/playwright/unit/ai/daemons/orchestrator/services/ContainerHealthControllerService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/ContainerHealthControllerService.spec.mjs
@@ -16,7 +16,11 @@ import {
     ContainerHealthDiagnosisService
 } from '../../../../../../../ai/daemons/orchestrator/services/ContainerHealthDiagnosisService.mjs';
 import {RecoveryActuatorService}              from '../../../../../../../ai/daemons/orchestrator/services/RecoveryActuatorService.mjs';
-import {HEAL_LEDGER_DIR_NAME, readHealLedger} from '../../../../../../../ai/services/memory-core/helpers/healEventLedgerStore.mjs';
+import {
+    appendHealEvent,
+    HEAL_LEDGER_DIR_NAME,
+    readHealLedger
+} from '../../../../../../../ai/services/memory-core/helpers/healEventLedgerStore.mjs';
 import {createRecoveryDiagnosisEvent}         from '../../../../../../../ai/services/memory-core/helpers/recoveryRunStateStore.mjs';
 
 const OBSERVED_AT = 1710000000000;
@@ -618,6 +622,28 @@ test.describe('Neo.ai.daemons.services.ContainerHealthControllerService', () => 
         expect(outcome.actuatorOutcome.status).toBe('actioned');
         // ...and the controller does NOT then name itself the actor in the successor's ledger.
         expect((await readLedger()).filter(event => event.status === 'actioned')).toEqual([]);
+    });
+
+    test('takeover inside the receipt store cannot land an unqualified controller audit', async () => {
+        let held = true;
+
+        const {controller, runtimeCalls} = createStack({
+            controllerConfig: {
+                isAuthorityHeld: () => held,
+                async appendHealEventFn(entry, options) {
+                    // The action and controller preflight were admitted. Flip only inside the append
+                    // seam, immediately before the real store's awaited setup + adjacent fence.
+                    held = false;
+                    return appendHealEvent(entry, options);
+                }
+            }
+        });
+
+        const outcome = await controller.consume({decision: wedged('mc-server')});
+
+        expect(runtimeCalls).toHaveLength(1);
+        expect(outcome.actuatorOutcome.status).toBe('actioned');
+        expect(await readLedger()).toEqual([]);
     });
 
     test('(d) a runtime AUTHORITY-LOST refusal is not collapsed into executor failure, and writes nothing', async () => {

--- a/test/playwright/unit/ai/daemons/orchestrator/services/RecoveryActuatorService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/RecoveryActuatorService.spec.mjs
@@ -1,4 +1,5 @@
 import {test, expect}                   from '@playwright/test';
+import {existsSync, readdirSync}        from 'fs';
 import {mkdtemp, readdir, rm, readFile} from 'fs/promises';
 import os                               from 'os';
 import path                             from 'path';
@@ -14,8 +15,9 @@ import {
     createRecoveryDiagnosisEvent,
     createRecoveryTargetIdentity
 } from '../../../../../../../ai/services/memory-core/helpers/recoveryRunStateStore.mjs';
-import {readHealLedger} from '../../../../../../../ai/services/memory-core/helpers/healEventLedgerStore.mjs';
-import AiConfig         from '../../../../../../../ai/config.template.mjs';
+import {RECOVERY_OVERRIDE_FILENAME} from '../../../../../../../ai/services/memory-core/helpers/recoveryOverrideStore.mjs';
+import {readHealLedger}             from '../../../../../../../ai/services/memory-core/helpers/healEventLedgerStore.mjs';
+import AiConfig                     from '../../../../../../../ai/config.template.mjs';
 
 const DEFAULT_RUNTIME_ACCESS_CONFIG = {
     allowedServices: ['chroma', 'kb-server', 'mc-server', 'local-model']
@@ -106,6 +108,19 @@ test.describe('Neo.ai.daemons.services.RecoveryActuatorService', () => {
 
     async function readAttempts() {
         return JSON.parse(await readFile(path.join(tmpDir, 'heal-attempts.json'), 'utf8'));
+    }
+
+    function createScratchSensitiveAuthorityOracle(overrideDir) {
+        return () => {
+            try {
+                return !readdirSync(overrideDir).some(fileName =>
+                    fileName.startsWith(`${RECOVERY_OVERRIDE_FILENAME}.`) && fileName.endsWith('.tmp')
+                );
+            } catch (error) {
+                if (error?.code === 'ENOENT') return true;
+                throw error;
+            }
+        };
     }
 
     function backupEscalationDiagnosis(overrides = {}) {
@@ -343,24 +358,17 @@ test.describe('Neo.ai.daemons.services.RecoveryActuatorService', () => {
         expect(rows.at(-1).heldAtWrite).toBe(false);
     });
 
-    test('the provider repair receives the oracle and refuses before the warm leaves the process', async () => {
-        // @neo-gpt-emmy's last interval. I argued against threading a lease into a
-        // provider-readiness module — a COUPLING objection against her SAFETY one — and weighted
-        // them the wrong way round. The repair reaches a privileged effect, so it gets the oracle.
-        //
-        // The refusal must come from INSIDE the repair, after its read-only role resolution: a
-        // caller-side check cannot bind an effect dispatched past its own await.
+    test('warm-provider carries the oracle into the selected repair adapter', async () => {
+        // Composition control only: the default LMS/Ollama helpers have their own production-bound
+        // per-mutation controls in providerReadinessHelper.spec. This row proves the actuator does
+        // not drop the oracle before whichever provider adapter is selected.
         let receivedOracle = null;
 
         const {service, runtimeCalls} = createService({
             serviceConfig: {
                 async providerResidencyRepair({isAuthorityHeld}) {
                     receivedOracle = isAuthorityHeld;
-                    // The takeover lands during the repair's own read-only preparation — the
-                    // interval a caller-side check cannot cover.
                     held = false;
-
-                    // Stands in for the real helper's assertion at its last-owned point.
                     if (typeof isAuthorityHeld === 'function' && isAuthorityHeld() !== true) {
                         const error = new Error('Authority moved before the provider residency repair; refusing.');
                         error.reason = 'runtime-authority-lost';
@@ -384,18 +392,6 @@ test.describe('Neo.ai.daemons.services.RecoveryActuatorService', () => {
         expect(result).toMatchObject({status: 'declined', reasonCode: 'authority-lost'});
         // No lifecycle write may accompany a refused warm.
         expect(runtimeCalls).toEqual([]);
-    });
-
-    test('reconfigure carries the authority oracle into the restart it triggers after its durable write', async () => {
-        // `writeKnobOverride` is awaited, so the dispatch check in `executeTargetAction` is no longer
-        // the last point owned before the container is restarted. The oracle must reach
-        // `restartComposeService`, which re-asserts after resolving the container.
-        const {service, runtimeCalls} = createService();
-
-        await service.apply('mc-server', 'restart', {now: 10_000, isAuthorityHeld: () => true});
-
-        expect(runtimeCalls[0]).toHaveProperty('isAuthorityHeld');
-        expect(typeof runtimeCalls[0].isAuthorityHeld).toBe('function');
     });
 
     test('warm-provider restores provider role-set residency through the bounded actuator envelope', async () => {
@@ -650,6 +646,22 @@ test.describe('Neo.ai.daemons.services.RecoveryActuatorService', () => {
         }));
     });
 
+    test('deploy-target record-only takeover during store setup leaves no owner-success audit', async () => {
+        const {service, runtimeCalls} = createService();
+
+        const result = await service.apply('cloud-deploy', 'redeploy', {
+            now   : 301_000,
+            reason: 'config-drift',
+            // Held through apply preparation and dispatch; flips only after the real heal-store
+            // directory appears, proving this deploy branch carries the oracle into that store.
+            isAuthorityHeld : () => !existsSync(service.healEventLedgerDir)
+        });
+
+        expect(result).toMatchObject({status: 'declined', reasonCode: 'authority-lost'});
+        expect(runtimeCalls).toEqual([]);
+        expect(await readHealLedger({dir: service.healEventLedgerDir})).toEqual([]);
+    });
+
     test('recordDiagnosis records a supervised-task diagnosis to the heal-event ledger without executing target actions', async () => {
         const {service, runtimeCalls, supervisorCalls, taskOutcomes} = createService();
         let   executedTargetAction                                   = false;
@@ -690,6 +702,40 @@ test.describe('Neo.ai.daemons.services.RecoveryActuatorService', () => {
                 ledgerStatus: 'recorded'
             })
         }));
+    });
+
+    test('recordDiagnosis carries authority to the first store and refuses a takeover before its append', async () => {
+        const {service, actuatorConfig} = createService();
+        let   authorityReads            = 0;
+
+        const write = service.recordDiagnosis(backupEscalationDiagnosis(), {
+            now            : 505_000,
+            isAuthorityHeld: () => ++authorityReads === 1
+        });
+
+        await expect(write).rejects.toMatchObject({reason: 'runtime-authority-lost'});
+        expect(authorityReads).toBe(2); // entry admitted; store-adjacent sample refused
+        expect(await readHealLedger({dir: service.healEventLedgerDir})).toEqual([]);
+        await expect(readdir(actuatorConfig.recoveryRunStateDir)).rejects.toMatchObject({code: 'ENOENT'});
+    });
+
+    test('takeover between the two record-only sinks preserves only the admitted first-source proof', async () => {
+        const {service, actuatorConfig} = createService();
+        let   authorityReads            = 0;
+
+        const write = service.recordDiagnosis(backupEscalationDiagnosis(), {
+            now            : 506_000,
+            // Entry + heal-event source append are held; finishAction and its recovery-run source
+            // append observe the successor. Removing either downstream fence makes this row red.
+            isAuthorityHeld: () => ++authorityReads <= 2
+        });
+
+        await expect(write).rejects.toMatchObject({reason: 'runtime-authority-lost'});
+
+        const healEvents = await readHealLedger({dir: service.healEventLedgerDir});
+        expect(healEvents).toHaveLength(1);
+        expect(healEvents[0]).toMatchObject({status: 'recorded', heldAtWrite: true});
+        expect(await readdir(actuatorConfig.recoveryRunStateDir)).toEqual([]);
     });
 
     test('recordDiagnosis rejects non-record diagnoses without privileged actions', async () => {
@@ -745,6 +791,53 @@ test.describe('Neo.ai.daemons.services.RecoveryActuatorService', () => {
                 action: 'reconfigure',
                 target: {kind: 'deploy-target', id: 'cloud-deploy'}
             })).toBe(false);
+        });
+
+        test('the full reconfigure action carries authority through its durable overlay into the restart', async () => {
+            const originalSnapshotPath = AiConfig.orchestrator.deploymentStateBridge.snapshotPath;
+            AiConfig.orchestrator.deploymentStateBridge.snapshotPath = path.join(tmpDir, 'reconfigure-state', 'snapshot.json');
+
+            try {
+                const {service, runtimeCalls} = createService();
+                const result                  = await service.apply('mc-server', 'reconfigure', {
+                    knob           : KNOB,
+                    knobValues     : VALUES,
+                    now            : 100_000,
+                    isAuthorityHeld: () => true
+                });
+
+                expect(result.status).toBe('actioned');
+                expect(runtimeCalls).toHaveLength(1);
+                expect(runtimeCalls[0]).toMatchObject({serviceKey: 'mc-server', operation: 'restart'});
+                expect(typeof runtimeCalls[0].isAuthorityHeld).toBe('function');
+            } finally {
+                AiConfig.orchestrator.deploymentStateBridge.snapshotPath = originalSnapshotPath;
+            }
+        });
+
+        test('the full reconfigure action refuses takeover after its scratch write and before overlay publication', async () => {
+            const originalSnapshotPath = AiConfig.orchestrator.deploymentStateBridge.snapshotPath,
+                  overrideDir          = path.join(tmpDir, 'reconfigure-takeover');
+            AiConfig.orchestrator.deploymentStateBridge.snapshotPath = path.join(overrideDir, 'snapshot.json');
+
+            try {
+                const {service, runtimeCalls} = createService();
+                const result                  = await service.apply('mc-server', 'reconfigure', {
+                    knob      : KNOB,
+                    knobValues: VALUES,
+                    now       : 100_000,
+                    // This stays held through every caller-side sample and flips only when the real
+                    // override writer has created its UUID scratch file. Omitting the oracle from
+                    // `writeKnobOverride()` therefore makes this control action the target.
+                    isAuthorityHeld : createScratchSensitiveAuthorityOracle(overrideDir)
+                });
+
+                expect(result).toMatchObject({status: 'declined', reasonCode: 'authority-lost'});
+                expect(runtimeCalls).toEqual([]);
+                expect(await readdir(overrideDir)).toEqual([]);
+            } finally {
+                AiConfig.orchestrator.deploymentStateBridge.snapshotPath = originalSnapshotPath;
+            }
         });
 
         test('a refused transaction costs the target NO restart', async () => {
@@ -889,6 +982,66 @@ test.describe('Neo.ai.daemons.services.RecoveryActuatorService', () => {
             expect(JSON.parse(await readFile(overlayPath, 'utf8'))).toEqual({
                 deploy: {chroma: {memoryCeilingBytes: 8 * GIB}}
             });
+        });
+
+        test('the full raise-ceiling action carries authority into the live update after its durable overlay', async () => {
+            let held           = true,
+                receivedOracle = null,
+                liveEffects    = 0;
+
+            const {service} = createRaiseService({
+                liveLimitBytes                : 2 * GIB,
+                deploymentRuntimeAccessService: {
+                    async applyLifecycle(options) {
+                        receivedOracle = options.isAuthorityHeld;
+                        held = false; // takeover during the runtime adapter's awaited target resolution
+
+                        if (typeof options.isAuthorityHeld === 'function' && options.isAuthorityHeld() !== true) {
+                            const error = new Error('Authority moved before the live ceiling update; refusing.');
+                            error.reason = 'runtime-authority-lost';
+                            throw error;
+                        }
+
+                        liveEffects++;
+                        return {ok: true, proof: {operation: options.operation}};
+                    }
+                }
+            });
+
+            const result = await service.apply('chroma', 'raise-ceiling', {
+                knob           : CEILING_KNOB,
+                knobValues     : {[CEIL_LEAF]: 8 * GIB},
+                now            : 100_000,
+                targetIdentity : CHROMA_TARGET,
+                isAuthorityHeld: () => held
+            });
+
+            expect(result).toMatchObject({status: 'declined', reasonCode: 'authority-lost'});
+            expect(typeof receivedOracle).toBe('function');
+            expect(liveEffects).toBe(0);
+
+            // The durable intent was admitted while held; only the later live mutation was refused.
+            const overlayPath = path.join(tmpDir, 'deployment-state', 'recovery-actuator-overrides.json');
+            expect(JSON.parse(await readFile(overlayPath, 'utf8'))).toEqual({
+                deploy: {chroma: {memoryCeilingBytes: 8 * GIB}}
+            });
+        });
+
+        test('the full raise-ceiling action refuses takeover before its scratch overlay becomes durable intent', async () => {
+            const overrideDir             = path.join(tmpDir, 'deployment-state');
+            const {service, runtimeCalls} = createRaiseService({liveLimitBytes: 2 * GIB});
+
+            const result = await service.apply('chroma', 'raise-ceiling', {
+                knob           : CEILING_KNOB,
+                knobValues     : {[CEIL_LEAF]: 8 * GIB},
+                now            : 100_000,
+                targetIdentity : CHROMA_TARGET,
+                isAuthorityHeld: createScratchSensitiveAuthorityOracle(overrideDir)
+            });
+
+            expect(result).toMatchObject({status: 'declined', reasonCode: 'authority-lost'});
+            expect(runtimeCalls).toEqual([]);
+            expect(await readdir(overrideDir)).toEqual([]);
         });
 
         test('is admitted for the store-classed compose service ONLY — the matrix row is mechanical', async () => {

--- a/test/playwright/unit/ai/services/graph/providerReadinessHelper.spec.mjs
+++ b/test/playwright/unit/ai/services/graph/providerReadinessHelper.spec.mjs
@@ -132,3 +132,104 @@ test.describe('lmsExecOptions — embedding-readiness PATH fix', () => {
         await expect(secondPromise).resolves.toEqual([{id: 'embedding-model'}]);
     });
 });
+
+test.describe('provider residency helpers — production mutation authority fences (#16837)', () => {
+    let ensureLmsModelsLoaded, ensureOllamaModelsReady;
+
+    test.beforeAll(async () => {
+        const mod = await import('../../../../../../ai/services/graph/providerReadinessHelper.mjs');
+
+        ensureLmsModelsLoaded   = mod.ensureLmsModelsLoaded;
+        ensureOllamaModelsReady = mod.ensureOllamaModelsReady;
+    });
+
+    test('LMS refuses the first unload after authority moves during awaited model metadata', async () => {
+        let   held    = true;
+        const unloads = [],
+              loads   = [];
+
+        const repair = ensureLmsModelsLoaded({
+            host          : 'http://127.0.0.1:1234',
+            models        : ['chat-model'],
+            contextLengths: {'chat-model': 4096},
+            attempts      : 1,
+            delayMs       : 0,
+            timeoutMs     : 10,
+            fetchModelIds : async () => ['chat-model'],
+            async fetchLoadedModels() {
+                held = false;
+                return [{id: 'chat-model', contextLength: 1024}];
+            },
+            async unloadModel(model) {
+                unloads.push(model);
+            },
+            async loadModel(model) {
+                loads.push(model);
+            },
+            isAuthorityHeld: () => held,
+            log            : {info() {}, warn() {}}
+        });
+
+        await expect(repair).rejects.toMatchObject({reason: 'runtime-authority-lost'});
+        expect(unloads).toEqual([]);
+        expect(loads).toEqual([]);
+    });
+
+    test('LMS rechecks authority between a stale-model unload and its replacement load', async () => {
+        let   held    = true;
+        const unloads = [],
+              loads   = [];
+
+        const repair = ensureLmsModelsLoaded({
+            host             : 'http://127.0.0.1:1234',
+            models           : ['chat-model'],
+            contextLengths   : {'chat-model': 4096},
+            attempts         : 1,
+            delayMs          : 0,
+            timeoutMs        : 10,
+            fetchModelIds    : async () => ['chat-model'],
+            fetchLoadedModels: async () => [{id: 'chat-model', contextLength: 1024}],
+            async unloadModel(model) {
+                unloads.push(model);
+                held = false;
+            },
+            async loadModel(model) {
+                loads.push(model);
+            },
+            isAuthorityHeld: () => held,
+            log            : {info() {}, warn() {}}
+        });
+
+        await expect(repair).rejects.toMatchObject({reason: 'runtime-authority-lost'});
+        expect(unloads).toEqual(['chat-model']);
+        expect(loads).toEqual([]);
+    });
+
+    test('Ollama rechecks authority between role warms instead of authorizing the loop once', async () => {
+        let   held  = true;
+        const warms = [];
+
+        const repair = ensureOllamaModelsReady({
+            host : 'http://127.0.0.1:11434',
+            roles: [
+                {role: 'chat',      providerRole: 'chat',      model: 'chat-model'},
+                {role: 'embedding', providerRole: 'embedding', model: 'embed-model'}
+            ],
+            requireParallelModels: 2,
+            attempts             : 1,
+            delayMs              : 0,
+            timeoutMs            : 10,
+            fetchModelIds        : async () => [],
+            async warmModel(role) {
+                warms.push(role.role);
+                held = false;
+                return {};
+            },
+            isAuthorityHeld: () => held,
+            log            : {info() {}, warn() {}}
+        });
+
+        await expect(repair).rejects.toMatchObject({reason: 'runtime-authority-lost'});
+        expect(warms).toEqual(['chat']);
+    });
+});

--- a/test/playwright/unit/ai/services/memory-core/helpers/healEventLedgerStore.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/helpers/healEventLedgerStore.spec.mjs
@@ -1,6 +1,7 @@
 import {test, expect} from '@playwright/test';
 import Neo            from '../../../../../../../src/Neo.mjs';
 import * as core      from '../../../../../../../src/core/_export.mjs';
+import {existsSync}   from 'fs';
 import fs             from 'fs/promises';
 import os             from 'os';
 import path           from 'path';
@@ -53,6 +54,53 @@ test.describe('healEventLedgerStore — durable append-only heal ledger', () => 
         const dir = await tmpDir();
         await appendHealEvent({type: 'unfreeze', collection: 'c1', status: 'unfrozen'}, {dir, now: 777});
         expect((await readHealLedger({dir}))[0].at).toBe(777);
+        await fs.rm(dir, {recursive: true, force: true});
+    });
+
+    test('an admitted authority-bound append carries truthful write-time provenance', async () => {
+        const dir = await tmpDir();
+
+        await appendHealEvent({type: 'ambiguous', collection: 'backup', status: 'recorded'}, {
+            dir,
+            now            : 778,
+            isAuthorityHeld: () => true
+        });
+
+        expect((await readHealLedger({dir}))[0]).toMatchObject({
+            at         : 778,
+            heldAtWrite: true,
+            status     : 'recorded'
+        });
+        await fs.rm(dir, {recursive: true, force: true});
+    });
+
+    test('takeover during awaited directory setup refuses before the first audit append', async () => {
+        const root = await tmpDir(),
+              dir  = path.join(root, 'durable-ledger');
+
+        const write = appendHealEvent(
+            {type: 'ambiguous', collection: 'backup', status: 'recorded'},
+            {
+                dir,
+                // The oracle stays held until the production `mkdir()` has completed. Moving the
+                // store fence above that await, or removing it, lets the forbidden row land.
+                isAuthorityHeld: () => !existsSync(dir)
+            }
+        );
+
+        await expect(write).rejects.toMatchObject({reason: 'runtime-authority-lost'});
+        expect(await readHealLedger({dir})).toEqual([]);
+        await fs.rm(root, {recursive: true, force: true});
+    });
+
+    test('callers without an authority oracle retain the legacy row shape', async () => {
+        const dir = await tmpDir();
+
+        await appendHealEvent({type: 'heal', collection: 'c1', status: 'healed'}, {dir, now: 779});
+
+        const [event] = await readHealLedger({dir});
+        expect(event).toEqual({type: 'heal', collection: 'c1', status: 'healed', at: 779});
+        expect(Object.hasOwn(event, 'heldAtWrite')).toBe(false);
         await fs.rm(dir, {recursive: true, force: true});
     });
 

--- a/test/playwright/unit/ai/services/memory-core/helpers/recoveryRunStateStore.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/helpers/recoveryRunStateStore.spec.mjs
@@ -1,9 +1,16 @@
-import {test, expect}                            from '@playwright/test';
-import Neo                                       from '../../../../../../../src/Neo.mjs';
-import * as core                                 from '../../../../../../../src/core/_export.mjs';
-import {mkdtemp, rm, readdir, utimes, writeFile} from 'fs/promises';
-import os                                        from 'os';
-import path                                      from 'path';
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../../../../src/Neo.mjs';
+import * as core      from '../../../../../../../src/core/_export.mjs';
+import {
+    mkdtemp,
+    rm,
+    readdir,
+    readFile,
+    utimes,
+    writeFile
+} from 'fs/promises';
+import os   from 'os';
+import path from 'path';
 
 import {
     appendRecoveryRunState,
@@ -296,6 +303,75 @@ test.describe('RecoveryRunStateStore', () => {
 
         const recent = await readRecentRecoveryRunStates({dir: tmpDir, limit: 1});
         expect(recent[0].recoveryRunId).toBe('recovery-graph');
+    });
+
+    test('a displaced dispatched audit publishes the exact `heldAtWrite: false` source record to every state proof', async () => {
+        const nodes    = [];
+        const filePath = await appendRecoveryRunState(runEntry('recovery-displaced', 2100, {
+            details: {heldAtAppend: true}
+        }), {
+            dir                    : tmpDir,
+            isAuthorityHeld        : () => false,
+            preserveOnAuthorityLoss: true,
+            graphService           : {
+                async upsertNode(node) {
+                    nodes.push(node);
+                }
+            }
+        });
+
+        const sourceRecord = JSON.parse((await readFile(filePath, 'utf8')).trim().split('\n').at(-1));
+        const stateProofs  = nodes.filter(node => [
+            RECOVERY_RUN_GRAPH_NODE_TYPES.recoveryRun,
+            RECOVERY_RUN_GRAPH_NODE_TYPES.recoveryRunState
+        ].includes(node.type));
+
+        expect(sourceRecord.heldAtWrite).toBe(false);
+        expect(stateProofs).toHaveLength(2);
+        expect(stateProofs.every(node => node.properties.heldAtWrite === false)).toBe(true);
+
+        const [remoteProof] = selectRecoveryRunGraphRecords(nodes);
+        expect(remoteProof).toMatchObject({
+            heldAtWrite: false,
+            details    : {heldAtAppend: true}
+        });
+    });
+
+    test('an admitted audit publishes `heldAtWrite: true` from source to graph', async () => {
+        const nodes    = [];
+        const filePath = await appendRecoveryRunState(runEntry('recovery-held', 2200), {
+            dir            : tmpDir,
+            isAuthorityHeld: () => true,
+            graphService   : {
+                async upsertNode(node) {
+                    nodes.push(node);
+                }
+            }
+        });
+
+        const sourceRecord  = JSON.parse((await readFile(filePath, 'utf8')).trim().split('\n').at(-1));
+        const [remoteProof] = selectRecoveryRunGraphRecords(nodes);
+
+        expect(sourceRecord.heldAtWrite).toBe(true);
+        expect(remoteProof.heldAtWrite).toBe(true);
+    });
+
+    test('legacy or unstamped graph provenance is `unknown`, never inferred from `details.heldAtAppend`', () => {
+        const currentNodes = createRecoveryRunGraphNodes(runEntry('recovery-unstamped', 2300, {
+            details: {heldAtAppend: true}
+        }));
+        const legacyState = structuredClone(currentNodes.find(
+            node => node.type === RECOVERY_RUN_GRAPH_NODE_TYPES.recoveryRunState
+        ));
+
+        delete legacyState.properties.heldAtWrite;
+
+        const [current] = selectRecoveryRunGraphRecords(currentNodes),
+              [legacy]  = selectRecoveryRunGraphRecords([legacyState]);
+
+        expect(current.heldAtWrite).toBe('unknown');
+        expect(legacy.heldAtWrite).toBe('unknown');
+        expect(legacy.details.heldAtAppend).toBe(true);
     });
 
     test('appendRecoveryRunState surfaces graph publication failure without losing the local ledger', async () => {


### PR DESCRIPTION
Resolves #16837

Recovery audit provenance now stays truthful across every source/projection and store boundary this lease-bearing recovery path owns. Recovery-run graph publication consumes the exact JSONL record accepted by the source append, heal-event writes can revalidate authority after their awaited directory setup, and each existing authority-bearing caller carries that oracle to the store. Callers without a lease oracle retain their legacy row and option shape.

Evidence: **L2** — production-bound unit controls exercise the real stores, graph projector, provider helpers, actuator actions, and controller composition; twelve independent production mutations turn the corresponding controls red. This satisfies all close-target ACs; no operator-only residual remains.

## Deltas from ticket

- The exhaustive caller census found two additional existing lease owners that crossed the same heal-event store boundary: the container-health controller receipt and deploy-target `recorded` terminal. Both now carry their already-owned oracle; unrelated heal-event producers remain unchanged.
- The deterministic takeover controls use observable production boundaries—directory creation and UUID scratch-file appearance—instead of brittle authority-read counters.
- No recovery action, privilege, anti-thrash policy, or graph authority is widened.

## Test Evidence

- Focused recovery source/projection + actuator/controller/provider slice: **132/132 passed**.
- `npm run agent-preflight -- --change-class restoration ... --no-fix`: **green**, including ticket archaeology and block alignment.
- `git diff --cached --check` / final clean-tree verification: **green**.
- Mutation matrix: **12/12 red** when independently removing or moving the accepted-record projection, legacy-unknown normalization, heal-store adjacent fence, both `recordDiagnosis` sink handoffs, LMS/Ollama inner fences, reconfigure/raise overlay and runtime handoffs, controller receipt handoff, or either deploy-target forwarding hop.
- Recovery-run source/projection: displaced `false`, admitted `true`, and legacy `unknown` are independently covered; stale `details.heldAtAppend` cannot substitute for the store sample.
- Heal-event compatibility: no-oracle callers retain the exact legacy row shape.
- Surface coverage: recovery JSONL + graph, heal-event ledger, default provider helpers, actual `reconfigure`, actual `raise-ceiling`, controller receipt, and deploy-target record-only terminal all have production-bound controls.

## Post-Merge Validation

- [ ] After deployment, compare one new recovery-run JSONL row with its graph state proof and confirm the same `heldAtWrite` Boolean.
- [ ] Query a legacy recovery-run graph state and confirm the normalized remote surface reports `heldAtWrite: unknown`.

## Evolution

The first falsifier pass exposed two green composition mutants at the durable override boundary; scratch-sensitive full-action controls closed them. The subsequent authority-bearing caller census found the controller receipt and deploy-target record-only branch crossing the newly explicit heal-store seam without their existing oracle. Both were repaired before commit, while no-lease callers stayed byte-compatible.

Authored by Emmy (GPT-5.6 Sol Ultra, Codex). Session 878f05af-2c4e-4da2-a5c2-9e4af666fcb8.
