### PR TITLE
fix(deploy): the ollama provider's env reaches the containers (#16850)

### DIFF
--- a/ai/deploy/docker-compose.yml
+++ b/ai/deploy/docker-compose.yml
@@ -90,18 +90,24 @@ services:
       - NEO_OPENAI_COMPATIBLE_MODEL=${NEO_OPENAI_COMPATIBLE_MODEL:-}
       - NEO_OPENAI_COMPATIBLE_EMBEDDING_MODEL=${NEO_OPENAI_COMPATIBLE_EMBEDDING_MODEL:-}
       - NEO_OPENAI_COMPATIBLE_API_KEY=${NEO_OPENAI_COMPATIBLE_API_KEY:-}
-      # The ollama provider is a first-class `NEO_EMBEDDING_PROVIDER` choice and the code backs it
-      # fully (ai/provider/Ollama.mjs, the native embed path, the readiness branch keyed on
-      # /api/embed). Only KEEP_ALIVE used to reach the containers, so `ollama.host` fell back to its
-      # leaf default `http://127.0.0.1:11434` — which inside these containers is the container
-      # itself. Every native embed hit nothing, on every deployment, permanently. The model service
-      # sits on this network as `local-model:11434` and no config path could name it.
+      # Native ollama is a first-class `NEO_EMBEDDING_PROVIDER` choice and the code backs it fully
+      # (ai/provider/Ollama.mjs, the native embed path, the readiness branch keyed on /api/embed),
+      # but THIS profile passed only KEEP_ALIVE. `ollama.host` then fell back to its leaf default
+      # `http://127.0.0.1:11434`, which inside this container IS this container, so ingestion
+      # embedded into nothing. A hand-written or out-of-band Compose could always supply the
+      # variable — what was missing is that the canonical profile made every operator re-derive it,
+      # while `local-model:11434` sits one name away on this network.
+      #
+      # kb-server reads host / model / embeddingModel / keep_alive through TextEmbeddingService and
+      # the dispatch seam, and EMBEDDING_TIMEOUT_MS because ingestion is the process that waits on a
+      # CPU-only provider. REQUIRE_PARALLEL_MODELS is deliberately NOT here: its only reader is
+      # called from the orchestrator. Coordinates are enforced per service by
+      # test/playwright/unit/ai/deploy/OllamaProviderEnvCoordinates.spec.mjs.
       - NEO_OLLAMA_HOST=${NEO_OLLAMA_HOST:-}
       - NEO_OLLAMA_KEEP_ALIVE=${NEO_OLLAMA_KEEP_ALIVE:-}
       - NEO_OLLAMA_MODEL=${NEO_OLLAMA_MODEL:-}
       - NEO_OLLAMA_EMBEDDING_MODEL=${NEO_OLLAMA_EMBEDDING_MODEL:-}
       - NEO_OLLAMA_EMBEDDING_TIMEOUT_MS=${NEO_OLLAMA_EMBEDDING_TIMEOUT_MS:-}
-      - NEO_OLLAMA_REQUIRE_PARALLEL_MODELS=${NEO_OLLAMA_REQUIRE_PARALLEL_MODELS:-}
       - NEO_OPENAI_COMPATIBLE_KEEP_ALIVE=${NEO_OPENAI_COMPATIBLE_KEEP_ALIVE:-}
       # Ask-synthesis pass-throughs (ask_knowledge_base -> SearchService.ask): the synthesis
       # provider + its DEDICATED budget-cappable key (NEO_KB_ASK_API_KEY, never the shared
@@ -223,18 +229,16 @@ services:
       - NEO_OPENAI_COMPATIBLE_MODEL=${NEO_OPENAI_COMPATIBLE_MODEL:-}
       - NEO_OPENAI_COMPATIBLE_EMBEDDING_MODEL=${NEO_OPENAI_COMPATIBLE_EMBEDDING_MODEL:-}
       - NEO_OPENAI_COMPATIBLE_API_KEY=${NEO_OPENAI_COMPATIBLE_API_KEY:-}
-      # The ollama provider is a first-class `NEO_EMBEDDING_PROVIDER` choice and the code backs it
-      # fully (ai/provider/Ollama.mjs, the native embed path, the readiness branch keyed on
-      # /api/embed). Only KEEP_ALIVE used to reach the containers, so `ollama.host` fell back to its
-      # leaf default `http://127.0.0.1:11434` — which inside these containers is the container
-      # itself. Every native embed hit nothing, on every deployment, permanently. The model service
-      # sits on this network as `local-model:11434` and no config path could name it.
+      # Native ollama pass-through for mc-server. Memory embedding and the graph extractors run in
+      # this process: TextEmbeddingService dials host and embeddingModel, the dispatch seam carries
+      # model and keep_alive for Dream-pipeline calls, and EMBEDDING_TIMEOUT_MS bounds the request
+      # the WAL drain waits on. REQUIRE_PARALLEL_MODELS is deliberately absent — see the kb-server
+      # block above for the rationale and the guard that enforces these coordinates.
       - NEO_OLLAMA_HOST=${NEO_OLLAMA_HOST:-}
       - NEO_OLLAMA_KEEP_ALIVE=${NEO_OLLAMA_KEEP_ALIVE:-}
       - NEO_OLLAMA_MODEL=${NEO_OLLAMA_MODEL:-}
       - NEO_OLLAMA_EMBEDDING_MODEL=${NEO_OLLAMA_EMBEDDING_MODEL:-}
       - NEO_OLLAMA_EMBEDDING_TIMEOUT_MS=${NEO_OLLAMA_EMBEDDING_TIMEOUT_MS:-}
-      - NEO_OLLAMA_REQUIRE_PARALLEL_MODELS=${NEO_OLLAMA_REQUIRE_PARALLEL_MODELS:-}
       - NEO_OPENAI_COMPATIBLE_KEEP_ALIVE=${NEO_OPENAI_COMPATIBLE_KEEP_ALIVE:-}
     # The recovery actuator writes a config overlay onto the deployment-state mount, which this
     # service reads read-only — the actuator's container writes, the target only reads, so a target
@@ -332,12 +336,12 @@ services:
       - NEO_OPENAI_COMPATIBLE_MODEL=${NEO_OPENAI_COMPATIBLE_MODEL:-}
       - NEO_OPENAI_COMPATIBLE_EMBEDDING_MODEL=${NEO_OPENAI_COMPATIBLE_EMBEDDING_MODEL:-}
       - NEO_OPENAI_COMPATIBLE_API_KEY=${NEO_OPENAI_COMPATIBLE_API_KEY:-}
-      # The ollama provider is a first-class `NEO_EMBEDDING_PROVIDER` choice and the code backs it
-      # fully (ai/provider/Ollama.mjs, the native embed path, the readiness branch keyed on
-      # /api/embed). Only KEEP_ALIVE used to reach the containers, so `ollama.host` fell back to its
-      # leaf default `http://127.0.0.1:11434` — which inside these containers is the container
-      # itself. Every native embed hit nothing, on every deployment, permanently. The model service
-      # sits on this network as `local-model:11434` and no config path could name it.
+      # Native ollama pass-through for the orchestrator. This is the supervising process: it renders
+      # the ollama serve environment, probes readiness against host/model/embeddingModel, and repairs
+      # role-set residency. REQUIRE_PARALLEL_MODELS lives HERE and only here — buildOllamaReadiness-
+      # Config is its sole reader and every caller of that is orchestrator-side (the configured serve
+      # task, DreamService, the recovery actuator). EMBEDDING_TIMEOUT_MS is present because Dream and
+      # the tenant repo sync embed through the same TextEmbeddingService the other services use.
       - NEO_OLLAMA_HOST=${NEO_OLLAMA_HOST:-}
       - NEO_OLLAMA_KEEP_ALIVE=${NEO_OLLAMA_KEEP_ALIVE:-}
       - NEO_OLLAMA_MODEL=${NEO_OLLAMA_MODEL:-}

--- a/ai/deploy/docker-compose.yml
+++ b/ai/deploy/docker-compose.yml
@@ -90,7 +90,18 @@ services:
       - NEO_OPENAI_COMPATIBLE_MODEL=${NEO_OPENAI_COMPATIBLE_MODEL:-}
       - NEO_OPENAI_COMPATIBLE_EMBEDDING_MODEL=${NEO_OPENAI_COMPATIBLE_EMBEDDING_MODEL:-}
       - NEO_OPENAI_COMPATIBLE_API_KEY=${NEO_OPENAI_COMPATIBLE_API_KEY:-}
+      # The ollama provider is a first-class `NEO_EMBEDDING_PROVIDER` choice and the code backs it
+      # fully (ai/provider/Ollama.mjs, the native embed path, the readiness branch keyed on
+      # /api/embed). Only KEEP_ALIVE used to reach the containers, so `ollama.host` fell back to its
+      # leaf default `http://127.0.0.1:11434` — which inside these containers is the container
+      # itself. Every native embed hit nothing, on every deployment, permanently. The model service
+      # sits on this network as `local-model:11434` and no config path could name it.
+      - NEO_OLLAMA_HOST=${NEO_OLLAMA_HOST:-}
       - NEO_OLLAMA_KEEP_ALIVE=${NEO_OLLAMA_KEEP_ALIVE:-}
+      - NEO_OLLAMA_MODEL=${NEO_OLLAMA_MODEL:-}
+      - NEO_OLLAMA_EMBEDDING_MODEL=${NEO_OLLAMA_EMBEDDING_MODEL:-}
+      - NEO_OLLAMA_EMBEDDING_TIMEOUT_MS=${NEO_OLLAMA_EMBEDDING_TIMEOUT_MS:-}
+      - NEO_OLLAMA_REQUIRE_PARALLEL_MODELS=${NEO_OLLAMA_REQUIRE_PARALLEL_MODELS:-}
       - NEO_OPENAI_COMPATIBLE_KEEP_ALIVE=${NEO_OPENAI_COMPATIBLE_KEEP_ALIVE:-}
       # Ask-synthesis pass-throughs (ask_knowledge_base -> SearchService.ask): the synthesis
       # provider + its DEDICATED budget-cappable key (NEO_KB_ASK_API_KEY, never the shared
@@ -212,7 +223,18 @@ services:
       - NEO_OPENAI_COMPATIBLE_MODEL=${NEO_OPENAI_COMPATIBLE_MODEL:-}
       - NEO_OPENAI_COMPATIBLE_EMBEDDING_MODEL=${NEO_OPENAI_COMPATIBLE_EMBEDDING_MODEL:-}
       - NEO_OPENAI_COMPATIBLE_API_KEY=${NEO_OPENAI_COMPATIBLE_API_KEY:-}
+      # The ollama provider is a first-class `NEO_EMBEDDING_PROVIDER` choice and the code backs it
+      # fully (ai/provider/Ollama.mjs, the native embed path, the readiness branch keyed on
+      # /api/embed). Only KEEP_ALIVE used to reach the containers, so `ollama.host` fell back to its
+      # leaf default `http://127.0.0.1:11434` — which inside these containers is the container
+      # itself. Every native embed hit nothing, on every deployment, permanently. The model service
+      # sits on this network as `local-model:11434` and no config path could name it.
+      - NEO_OLLAMA_HOST=${NEO_OLLAMA_HOST:-}
       - NEO_OLLAMA_KEEP_ALIVE=${NEO_OLLAMA_KEEP_ALIVE:-}
+      - NEO_OLLAMA_MODEL=${NEO_OLLAMA_MODEL:-}
+      - NEO_OLLAMA_EMBEDDING_MODEL=${NEO_OLLAMA_EMBEDDING_MODEL:-}
+      - NEO_OLLAMA_EMBEDDING_TIMEOUT_MS=${NEO_OLLAMA_EMBEDDING_TIMEOUT_MS:-}
+      - NEO_OLLAMA_REQUIRE_PARALLEL_MODELS=${NEO_OLLAMA_REQUIRE_PARALLEL_MODELS:-}
       - NEO_OPENAI_COMPATIBLE_KEEP_ALIVE=${NEO_OPENAI_COMPATIBLE_KEEP_ALIVE:-}
     # The recovery actuator writes a config overlay onto the deployment-state mount, which this
     # service reads read-only — the actuator's container writes, the target only reads, so a target
@@ -310,7 +332,18 @@ services:
       - NEO_OPENAI_COMPATIBLE_MODEL=${NEO_OPENAI_COMPATIBLE_MODEL:-}
       - NEO_OPENAI_COMPATIBLE_EMBEDDING_MODEL=${NEO_OPENAI_COMPATIBLE_EMBEDDING_MODEL:-}
       - NEO_OPENAI_COMPATIBLE_API_KEY=${NEO_OPENAI_COMPATIBLE_API_KEY:-}
+      # The ollama provider is a first-class `NEO_EMBEDDING_PROVIDER` choice and the code backs it
+      # fully (ai/provider/Ollama.mjs, the native embed path, the readiness branch keyed on
+      # /api/embed). Only KEEP_ALIVE used to reach the containers, so `ollama.host` fell back to its
+      # leaf default `http://127.0.0.1:11434` — which inside these containers is the container
+      # itself. Every native embed hit nothing, on every deployment, permanently. The model service
+      # sits on this network as `local-model:11434` and no config path could name it.
+      - NEO_OLLAMA_HOST=${NEO_OLLAMA_HOST:-}
       - NEO_OLLAMA_KEEP_ALIVE=${NEO_OLLAMA_KEEP_ALIVE:-}
+      - NEO_OLLAMA_MODEL=${NEO_OLLAMA_MODEL:-}
+      - NEO_OLLAMA_EMBEDDING_MODEL=${NEO_OLLAMA_EMBEDDING_MODEL:-}
+      - NEO_OLLAMA_EMBEDDING_TIMEOUT_MS=${NEO_OLLAMA_EMBEDDING_TIMEOUT_MS:-}
+      - NEO_OLLAMA_REQUIRE_PARALLEL_MODELS=${NEO_OLLAMA_REQUIRE_PARALLEL_MODELS:-}
       - NEO_OPENAI_COMPATIBLE_KEEP_ALIVE=${NEO_OPENAI_COMPATIBLE_KEEP_ALIVE:-}
       - NEO_CHROMA_HOST=chroma
       # The child heap ceiling needs a WRITER here, not just a reader in the service: without this

--- a/ai/scripts/lint/config-leaf-parity.json
+++ b/ai/scripts/lint/config-leaf-parity.json
@@ -44,7 +44,7 @@
         "census": {
             "profile": "ai/deploy/docker-compose.yml",
             "baselineUniqueKeys": 45,
-            "remainingUniqueKeys": 49,
+            "remainingUniqueKeys": 54,
             "requiredDeploymentInputs": [
                 "NEO_AI_ORCHESTRATOR_AUTHORITY_PROFILE",
                 "NEO_AUTH_MODE",
@@ -68,7 +68,6 @@
             ],
             "optionalOverrides": [
                 "NEO_AUTH_ALLOWED_CLIENT_IDS",
-                "NEO_DEPLOYMENT_STATE_BRIDGE_DIRECT_PROBE_URLS",
                 "NEO_AUTH_ALLOWED_USERS",
                 "NEO_AUTH_GITHUB_API_BASE_URL",
                 "NEO_AUTH_GITLAB_API_BASE_URL",
@@ -78,6 +77,7 @@
                 "NEO_AUTH_PAT_VALIDATION_TIMEOUT_MS",
                 "NEO_AUTH_PORT",
                 "NEO_AUTH_REALM",
+                "NEO_DEPLOYMENT_STATE_BRIDGE_DIRECT_PROBE_URLS",
                 "NEO_EMBEDDING_PROVIDER",
                 "NEO_KB_ASK_BASE_URL",
                 "NEO_KB_ASK_MAX_RPM",
@@ -88,13 +88,18 @@
                 "NEO_MEMORY_WAL_POLL_INTERVAL_MS",
                 "NEO_MESSAGE_WAL_POLL_INTERVAL_MS",
                 "NEO_MODEL_PROVIDER",
+                "NEO_OAUTH_CLIENT_ID",
+                "NEO_OLLAMA_EMBEDDING_MODEL",
+                "NEO_OLLAMA_EMBEDDING_TIMEOUT_MS",
+                "NEO_OLLAMA_HOST",
                 "NEO_OLLAMA_KEEP_ALIVE",
+                "NEO_OLLAMA_MODEL",
+                "NEO_OLLAMA_REQUIRE_PARALLEL_MODELS",
                 "NEO_OPENAI_COMPATIBLE_EMBEDDING_MODEL",
                 "NEO_OPENAI_COMPATIBLE_HOST",
                 "NEO_OPENAI_COMPATIBLE_KEEP_ALIVE",
                 "NEO_OPENAI_COMPATIBLE_MODEL",
-                "NEO_SUPERVISED_TASK_HEAP_MB",
-                "NEO_OAUTH_CLIENT_ID"
+                "NEO_SUPERVISED_TASK_HEAP_MB"
             ],
             "secrets": [
                 "NEO_KB_ASK_API_KEY",

--- a/test/playwright/unit/ai/deploy/LoopbackDefaultReachability.spec.mjs
+++ b/test/playwright/unit/ai/deploy/LoopbackDefaultReachability.spec.mjs
@@ -1,0 +1,110 @@
+import {test, expect}     from '@playwright/test';
+import fs                 from 'node:fs';
+import path               from 'node:path';
+import process            from 'node:process';
+import {load as yamlLoad} from 'js-yaml';
+
+/**
+ * @summary A leaf whose default is a loopback address must be reachable through the deployment.
+ *
+ * Inside a container, `127.0.0.1` and `localhost` name **the container itself**. So a leaf that
+ * defaults to a loopback address and cannot be overridden through the Compose profile is not
+ * "using a sensible default" — it is unconditionally pointed at the wrong process, on every
+ * deployment, with no configuration path able to correct it. The failure surfaces as a connection
+ * refused, which reads as "the dependency is down" rather than "the host was never configurable".
+ *
+ * That is not hypothetical: `NEO_OLLAMA_HOST` was declared as a leaf, consumed by a complete
+ * provider and a readiness branch, and passed to no service. Any plane selecting the ollama
+ * provider sent every embed to its own container and never wrote a row.
+ *
+ * **This guard is deliberately narrow.** The broader rule — *every declared leaf must reach
+ * Compose* — is **false by design** and was measured to be false before this spec was written:
+ * 8 of 14 `NEO_OPENAI_COMPATIBLE_*` leaves are legitimately absent from the profile, because most
+ * leaves are tunables whose defaults are authoritative and which no deployment needs to override.
+ * Loopback defaults are the subset where the default cannot be authoritative in a container.
+ */
+
+const
+    repoRoot    = path.resolve(process.cwd()),
+    configText  = fs.readFileSync(path.join(repoRoot, 'ai/configBase.mjs'), 'utf8'),
+    composePath = path.join(repoRoot, 'ai/deploy/docker-compose.yml'),
+    composeDoc  = yamlLoad(fs.readFileSync(composePath, 'utf8')),
+    // A leaf default that is a bare loopback host or a loopback URL, with its env binding.
+    LOOPBACK_LEAF = /leaf\(\s*'(?:https?:\/\/)?(?:127\.0\.0\.1|localhost|\[::1\])[^']*'\s*,\s*'([A-Z][A-Z0-9_]*)'/g;
+
+/**
+ * @summary Env names exempt from the reachability rule, each with the reason it is exempt.
+ *
+ * An exemption is a claim and it is written down rather than filtered silently — a regex that
+ * quietly drops a name is how this class of defect survives its own guard.
+ */
+const EXEMPT = {
+    NEO_CHROMA_HOST_TEST: 'test-harness twin; never rendered into a deployment profile',
+    HOST                : 'transport bind host, not a dial target — binding to loopback inside the ' +
+                          'container is the intended posture; the listener override is NEO_MCP_LISTEN_HOST'
+};
+
+function declaredLoopbackEnvNames() {
+    return [...configText.matchAll(LOOPBACK_LEAF)].map(match => match[1]);
+}
+
+function composeEnvNames() {
+    const names = new Set();
+
+    for (const service of Object.values(composeDoc.services || {})) {
+        for (const entry of service.environment || []) {
+            // Compose list form is `NAME=value`; the mapping form would be a plain object key.
+            const name = typeof entry === 'string' ? entry.split('=')[0] : entry;
+            names.add(name)
+        }
+    }
+
+    return names
+}
+
+test.describe('Loopback-default leaves are reachable through the deployment', () => {
+    test('every loopback-default leaf is overridable in the canonical Compose profile', () => {
+        const
+            declared    = declaredLoopbackEnvNames(),
+            inCompose   = composeEnvNames(),
+            unreachable = declared
+                .filter(name => !Object.hasOwn(EXEMPT, name))
+                .filter(name => !inCompose.has(name))
+                .sort();
+
+        expect(unreachable, `loopback-default leaves with no Compose override: ${unreachable.join(', ')}`)
+            .toEqual([]);
+    });
+
+    test('NON-VACUITY — the scan actually finds loopback leaves, and finds the known ones', () => {
+        // Without this, a regex that matches nothing makes the guard above pass forever. The named
+        // members are the positive controls: they carry loopback defaults AND already reach Compose,
+        // so they prove the rule is satisfiable rather than merely unviolated.
+        const declared = declaredLoopbackEnvNames();
+
+        expect(declared.length).toBeGreaterThanOrEqual(4);
+        expect(declared).toContain('NEO_CHROMA_HOST');
+        expect(declared).toContain('NEO_OPENAI_COMPATIBLE_HOST');
+        expect(declared).toContain('NEO_OLLAMA_HOST');
+    });
+
+    test('NON-VACUITY — the Compose reader actually reads env, and sees a known-present name', () => {
+        // Guards the other half: an env parser returning an empty set would make every name look
+        // unreachable, which fails loud — but a parser returning a name-shaped garbage set would
+        // make every name look reachable, which fails silent. Assert a known member is present.
+        const inCompose = composeEnvNames();
+
+        expect(inCompose.size).toBeGreaterThan(20);
+        expect(inCompose.has('NEO_CHROMA_HOST')).toBe(true);
+        expect(inCompose.has('NEO_TRANSPORT')).toBe(true);
+    });
+
+    test('every exemption names a reason', () => {
+        // An exemption list is where a guard goes to die quietly. A bare name is not an exemption,
+        // it is an unexplained hole; requiring prose makes adding one a decision someone reviews.
+        for (const [name, reason] of Object.entries(EXEMPT)) {
+            expect(typeof reason, `${name} exemption must state a reason`).toBe('string');
+            expect(reason.length, `${name} exemption reason is too thin to review`).toBeGreaterThan(30)
+        }
+    });
+});

--- a/test/playwright/unit/ai/deploy/LoopbackDefaultReachability.spec.mjs
+++ b/test/playwright/unit/ai/deploy/LoopbackDefaultReachability.spec.mjs
@@ -14,8 +14,15 @@ import {load as yamlLoad} from 'js-yaml';
  * refused, which reads as "the dependency is down" rather than "the host was never configurable".
  *
  * That is not hypothetical: `NEO_OLLAMA_HOST` was declared as a leaf, consumed by a complete
- * provider and a readiness branch, and passed to no service. Any plane selecting the ollama
- * provider sent every embed to its own container and never wrote a row.
+ * provider and a readiness branch, and passed to no service in this profile. Any plane selecting
+ * the ollama provider through the canonical profile sent every embed to its own container.
+ *
+ * **This is a floor, and a weak one on purpose.** It asks only whether a name is overridable
+ * *somewhere* in the profile, which cannot distinguish "every consuming service receives it" from
+ * "one service does". It also says nothing about the bound *value*. The per-service contract — the
+ * `(service, leaf)` coordinates and their operator-overridable shape — is a different and stronger
+ * assertion and lives in `OllamaProviderEnvCoordinates.spec.mjs`. Read a green here as "the leaf is
+ * not entirely unreachable", never as "the deployment is wired correctly".
  *
  * **This guard is deliberately narrow.** The broader rule — *every declared leaf must reach
  * Compose* — is **false by design** and was measured to be false before this spec was written:

--- a/test/playwright/unit/ai/deploy/OllamaProviderEnvCoordinates.spec.mjs
+++ b/test/playwright/unit/ai/deploy/OllamaProviderEnvCoordinates.spec.mjs
@@ -1,0 +1,499 @@
+import {test, expect}     from '@playwright/test';
+import fs                 from 'node:fs';
+import path               from 'node:path';
+import process            from 'node:process';
+import {load as yamlLoad} from 'js-yaml';
+
+/**
+ * @summary Every `NEO_OLLAMA_*` leaf reaches each service that reads it, in an overridable form.
+ *
+ * The deployment contract is a set of **coordinates**, not a set of names. `NEO_OLLAMA_HOST`
+ * appearing somewhere in the profile does nothing for `kb-server` if `kb-server` is the process
+ * that dials the provider and never receives it. A union of env names across services cannot see
+ * that difference, and neither can it see a name bound to a hardcoded target that no operator can
+ * change — both read as "the variable is configured".
+ *
+ * This guard therefore asserts three things per coordinate:
+ *
+ * 1. **Service scope** — each `(service, leaf)` pair the code actually consumes is present on that
+ *    service, asserted independently rather than as a set union.
+ * 2. **Operator-overridable shape** — the value must be a `${NAME}` / `${NAME:-default}`
+ *    interpolation of its own variable. A literal is a decision taken away from the operator.
+ * 3. **No coordinate by symmetry** — a `NEO_OLLAMA_*` entry on a service with no consumer is a
+ *    violation, not a harmless extra. Copying the block between services is how the *shape* of the
+ *    contract stops matching the *content* of it, and the next reader cannot tell which service
+ *    owns which leaf.
+ *
+ * **Every REQUIRED entry carries a receipt**: the consuming module plus the literal source lines
+ * that perform the read, matched against the tree with whitespace normalised. An excerpt rather
+ * than a pattern, because the first version of this check used a pattern and could not see
+ * `const config = aiConfig.ollama` followed by `config.host` — and the repair for a pattern that
+ * misses a real read is to quote the read, not to widen the pattern until it matches anything.
+ *
+ * **Every absent coordinate carries a written disposition**, and the two tables must cover the full
+ * (service x declared-leaf) product: a newly declared leaf fails this spec until someone decides,
+ * per service, whether it ships.
+ *
+ * Scope: this is the ollama-family contract. The family-agnostic floor — *a loopback-default leaf
+ * must be overridable somewhere in the profile* — lives in `LoopbackDefaultReachability.spec.mjs`
+ * and is deliberately weaker; it cannot see service scope and does not claim to.
+ */
+
+const
+    repoRoot    = path.resolve(process.cwd()),
+    configText  = fs.readFileSync(path.join(repoRoot, 'ai/configBase.mjs'), 'utf8'),
+    composePath = path.join(repoRoot, 'ai/deploy/docker-compose.yml'),
+    composeDoc  = yamlLoad(fs.readFileSync(composePath, 'utf8')),
+    // The Neo services built from the shared image. `local-model` is the ollama server itself and
+    // is configured through `OLLAMA_*`, not through the client-side `NEO_OLLAMA_*` leaves.
+    ENTRYPOINTS = {
+        'kb-server'   : 'ai/mcp/server/knowledge-base/mcp-server.mjs',
+        'mc-server'   : 'ai/mcp/server/memory-core/mcp-server.mjs',
+        'orchestrator': 'ai/daemons/orchestrator/daemon.mjs'
+    },
+    TES        = 'ai/services/memory-core/TextEmbeddingService.mjs',
+    DISPATCH   = 'ai/services/graph/providerDispatch.mjs',
+    READINESS  = 'ai/services/graph/providerReadinessHelper.mjs';
+
+/**
+ * @summary Coordinates the deployment must ship, each with the consumer that makes it required.
+ *
+ * `consumer` is the module holding the read and `anchors` are the source lines that perform it.
+ * Both are checked against the tree and against the service's import graph, so an entry here is a
+ * falsifiable claim rather than a preference.
+ */
+const REQUIRED = [{
+    service : 'kb-server',
+    env     : 'NEO_OLLAMA_HOST',
+    consumer: TES,
+    anchors : ['const config = aiConfig.ollama;', 'host : config.host,'],
+    why     : 'VectorService, QueryService and HealthService all embed through TextEmbeddingService, ' +
+              'whose #getOllamaProvider dials ollama.host from inside the kb-server process'
+}, {
+    service : 'kb-server',
+    env     : 'NEO_OLLAMA_MODEL',
+    consumer: DISPATCH,
+    anchors : ['modelName : ollamaConfig?.model,'],
+    why     : 'the ask path builds a chat model from ollamaConfig.model; TextEmbeddingService also ' +
+              'falls back to it when embeddingModel is unset'
+}, {
+    service : 'kb-server',
+    env     : 'NEO_OLLAMA_EMBEDDING_MODEL',
+    consumer: 'ai/services/knowledge-base/VectorService.mjs',
+    anchors : ['? aiConfig.ollama.embeddingModel'],
+    why     : 'the ingest path names the embedding model when the provider is ollama, and the model ' +
+              'decides the vector dimension the corpus is written with'
+}, {
+    service : 'kb-server',
+    env     : 'NEO_OLLAMA_KEEP_ALIVE',
+    consumer: DISPATCH,
+    anchors : ['ollamaProviderConfig.keepAlive = ollamaConfig.keep_alive;'],
+    why     : 'keep_alive rides on every dispatched ollama request; a cold reload per call is the ' +
+              'difference between a usable ask tool and a timeout'
+}, {
+    service : 'kb-server',
+    env     : 'NEO_OLLAMA_EMBEDDING_TIMEOUT_MS',
+    consumer: TES,
+    anchors : ['const timeoutMs = aiConfig.ollama.embeddingTimeoutMs;'],
+    why     : 'the sole reader bounds one native embed request, and kb-server is where ingestion ' +
+              'issues them — a CPU-only provider needs this raised from the process that waits'
+}, {
+    service : 'mc-server',
+    env     : 'NEO_OLLAMA_HOST',
+    consumer: TES,
+    anchors : ['const config = aiConfig.ollama;', 'host : config.host,'],
+    why     : 'memory embedding and the graph extractors dial ollama.host from inside mc-server'
+}, {
+    service : 'mc-server',
+    env     : 'NEO_OLLAMA_MODEL',
+    consumer: 'ai/services/graph/SemanticGraphExtractor.mjs',
+    anchors : ['model : AiConfig.ollama.model,'],
+    why     : 'graph extraction and topology inference run the chat model in this process'
+}, {
+    service : 'mc-server',
+    env     : 'NEO_OLLAMA_EMBEDDING_MODEL',
+    consumer: TES,
+    anchors : ["return aiConfig.ollama.embeddingModel || aiConfig.ollama.model;"],
+    why     : 'memory embeddings are written here; the model decides their dimension'
+}, {
+    service : 'mc-server',
+    env     : 'NEO_OLLAMA_KEEP_ALIVE',
+    consumer: DISPATCH,
+    anchors : ['ollamaProviderConfig.keepAlive = ollamaConfig.keep_alive;'],
+    why     : 'the same dispatch seam carries keep_alive for the Dream pipeline calls made here'
+}, {
+    service : 'mc-server',
+    env     : 'NEO_OLLAMA_EMBEDDING_TIMEOUT_MS',
+    consumer: TES,
+    anchors : ['const timeoutMs = aiConfig.ollama.embeddingTimeoutMs;'],
+    why     : 'the WAL drain embeds in this process and stalls behind an unbounded request'
+}, {
+    service : 'orchestrator',
+    env     : 'NEO_OLLAMA_HOST',
+    consumer: READINESS,
+    anchors : ['host : ollamaConfig.host,'],
+    why     : 'readiness probes, the ollama serve task and the recovery actuator all address the ' +
+              'provider by host from the orchestrator'
+}, {
+    service : 'orchestrator',
+    env     : 'NEO_OLLAMA_MODEL',
+    consumer: READINESS,
+    anchors : ['chatModel = ollamaConfig.model,'],
+    why     : 'the chat role in the readiness role-set is this model; residency repair reloads it'
+}, {
+    service : 'orchestrator',
+    env     : 'NEO_OLLAMA_EMBEDDING_MODEL',
+    consumer: READINESS,
+    anchors : ['embeddingModel = ollamaConfig.embeddingModel,'],
+    why     : 'the embedding role in the readiness role-set, and what Dream re-embeds with'
+}, {
+    service : 'orchestrator',
+    env     : 'NEO_OLLAMA_KEEP_ALIVE',
+    consumer: READINESS,
+    anchors : ['keepAlive : ollamaConfig.keep_alive,'],
+    why     : 'buildOllamaServeEnv renders the resolved keep-alive into OLLAMA_KEEP_ALIVE for the ' +
+              'supervised server process'
+}, {
+    service : 'orchestrator',
+    env     : 'NEO_OLLAMA_EMBEDDING_TIMEOUT_MS',
+    consumer: TES,
+    anchors : ['const timeoutMs = aiConfig.ollama.embeddingTimeoutMs;'],
+    why     : 'Orchestrator, DreamService and TenantRepoSyncService embed through the same service'
+}, {
+    service : 'orchestrator',
+    env     : 'NEO_OLLAMA_REQUIRE_PARALLEL_MODELS',
+    consumer: READINESS,
+    anchors : ['requireParallelModels: ollamaConfig.requireParallelModels,'],
+    why     : 'buildOllamaReadinessConfig reads it and every caller is orchestrator-side: the ' +
+              'configured serve task, DreamService, and the residency repair'
+}];
+
+/**
+ * @summary Coordinates the deployment deliberately does NOT ship, each with its reason.
+ *
+ * A leaf absent from a service is a decision. Written down, it is reviewable; left implicit, the
+ * next person restores symmetry and nobody can say whether that was a fix or a regression.
+ */
+const NOT_REQUIRED = [{
+    service: 'kb-server',
+    env    : 'NEO_OLLAMA_REQUIRE_PARALLEL_MODELS',
+    why    : 'the only read is buildOllamaReadinessConfig (providerReadinessHelper.mjs) and all ' +
+             'three of its callers live under ai/daemons/orchestrator/. The module IS in this ' +
+             "service's import graph, but only because TextEmbeddingService dynamic-imports " +
+             'fetchLmsLoadedModels from it — a different function that never reads this leaf. ' +
+             'Module reachability is not consumption, and shipping it here would advertise an ' +
+             'orchestrator knob as a kb-server one.'
+}, {
+    service: 'mc-server',
+    env    : 'NEO_OLLAMA_REQUIRE_PARALLEL_MODELS',
+    why    : 'same as kb-server: the reader is orchestrator-called only, and the module is present ' +
+             'in this graph through an unrelated named import'
+}];
+
+/**
+ * @summary Collapses whitespace runs so an anchor survives alignment churn but not a real edit.
+ * @param {String} text Source text.
+ * @returns {String}
+ */
+function normalize(text) {
+    return text.replace(/\s+/g, ' ')
+}
+
+/**
+ * @summary The `NEO_OLLAMA_*` env names declared as leaves, read from the config source.
+ *
+ * Derived rather than listed so that adding a seventh leaf fails the coverage test below until its
+ * disposition is decided per service, instead of shipping unwired.
+ * @returns {String[]}
+ */
+function declaredOllamaEnvNames() {
+    return [...new Set([...configText.matchAll(/'(NEO_OLLAMA_[A-Z0-9_]*)'/g)].map(match => match[1]))].sort()
+}
+
+/**
+ * @summary Reads one service's `environment:` block as a name -> value map.
+ * @param {Object} doc Parsed compose document.
+ * @param {String} service Service key.
+ * @returns {Map<String, String>}
+ */
+function serviceEnv(doc, service) {
+    const
+        entries = doc.services?.[service]?.environment || [],
+        map     = new Map();
+
+    if (Array.isArray(entries)) {
+        for (const entry of entries) {
+            const
+                text  = String(entry),
+                index = text.indexOf('=');
+
+            index === -1 ? map.set(text, null) : map.set(text.slice(0, index), text.slice(index + 1))
+        }
+    } else {
+        for (const [name, value] of Object.entries(entries)) {
+            map.set(name, value === null ? null : String(value))
+        }
+    }
+
+    return map
+}
+
+/**
+ * @summary True when a compose value hands the decision to the operator via its own variable.
+ * @param {String} env Env name the entry binds.
+ * @param {String|null} value The compose-side value.
+ * @returns {Boolean}
+ */
+function isOperatorOverridable(env, value) {
+    // `${NAME}`, `${NAME:-fallback}` and `${NAME-fallback}` all resolve from the operator's
+    // environment. Anything else — a literal, or an interpolation of a DIFFERENT variable — pins
+    // the target inside the artifact.
+    return typeof value === 'string' && new RegExp(`^\\$\\{${env}(?:[:-][^}]*)?\\}$`).test(value.trim())
+}
+
+/**
+ * @summary The whole contract as a pure function of a compose document.
+ *
+ * Pure so the mutation controls below can run it against deliberately broken documents — a guard
+ * whose failure mode is never exercised is a guard nobody has tested.
+ *
+ * @param {Object} doc Parsed compose document.
+ * @returns {Object[]} Violations, each `{service, env, kind, detail}`.
+ */
+function coordinateViolations(doc) {
+    const
+        violations = [],
+        required   = new Set(REQUIRED.map(entry => `${entry.service}::${entry.env}`));
+
+    for (const entry of REQUIRED) {
+        const env = serviceEnv(doc, entry.service);
+
+        if (!env.has(entry.env)) {
+            violations.push({
+                service: entry.service,
+                env    : entry.env,
+                kind   : 'missing',
+                detail : `${entry.service} consumes ${entry.env} via ${entry.consumer} but never receives it`
+            });
+            continue
+        }
+
+        const value = env.get(entry.env);
+
+        if (!isOperatorOverridable(entry.env, value)) {
+            violations.push({
+                service: entry.service,
+                env    : entry.env,
+                kind   : 'not-overridable',
+                detail : `${entry.service} pins ${entry.env} to ${JSON.stringify(value)}; the operator cannot change it`
+            })
+        }
+    }
+
+    for (const service of Object.keys(ENTRYPOINTS)) {
+        for (const name of serviceEnv(doc, service).keys()) {
+            if (name.startsWith('NEO_OLLAMA_') && !required.has(`${service}::${name}`)) {
+                violations.push({
+                    service,
+                    env   : name,
+                    kind  : 'undeclared',
+                    detail: `${service} ships ${name} with no consumer behind it — added by symmetry, not by need`
+                })
+            }
+        }
+    }
+
+    return violations
+}
+
+/**
+ * @summary Every repo-relative module reachable from a service entrypoint, static or dynamic.
+ * @param {String} entryRelPath Repo-relative entrypoint.
+ * @returns {Set<String>} Absolute file paths.
+ */
+function importGraph(entryRelPath) {
+    const
+        // Static `from '...'` and dynamic `import('...')`. Bare specifiers are dependencies and are
+        // not traversed; only first-party relative paths can hold a config read.
+        SPECIFIER = /(?:\bfrom\s*|(?:^|[^.\w])import\s*\(\s*)['"]([^'"]+)['"]/g,
+        seen      = new Set(),
+        stack     = [path.join(repoRoot, entryRelPath)];
+
+    while (stack.length > 0) {
+        const file = stack.pop();
+
+        if (seen.has(file)) continue;
+
+        seen.add(file);
+
+        let text;
+
+        try {
+            text = fs.readFileSync(file, 'utf8')
+        } catch {
+            continue
+        }
+
+        for (const match of text.matchAll(SPECIFIER)) {
+            const specifier = match[1];
+
+            if (!specifier.startsWith('.')) continue;
+
+            const base = path.resolve(path.dirname(file), specifier);
+
+            for (const candidate of [base, `${base}.mjs`, `${base}.js`, path.join(base, 'index.mjs')]) {
+                if (fs.existsSync(candidate) && fs.statSync(candidate).isFile()) {
+                    if (!seen.has(candidate)) stack.push(candidate);
+                    break
+                }
+            }
+        }
+    }
+
+    return seen
+}
+
+test.describe('NEO_OLLAMA_* coordinates reach every consuming service', () => {
+    test('the canonical profile satisfies every required coordinate', () => {
+        const violations = coordinateViolations(composeDoc);
+
+        expect(violations.map(violation => violation.detail)).toEqual([])
+    });
+
+    test('MUTATION — dropping a required leaf from one service is caught', () => {
+        // The predecessor guard's first falsifier: removing NEO_OLLAMA_HOST from kb-server and
+        // mc-server left it on orchestrator, and a union-of-names check stayed green.
+        const mutant = structuredClone(composeDoc);
+
+        for (const service of ['kb-server', 'mc-server']) {
+            mutant.services[service].environment = mutant.services[service].environment
+                .filter(entry => !String(entry).startsWith('NEO_OLLAMA_HOST='))
+        }
+
+        const violations = coordinateViolations(mutant);
+
+        expect(violations.filter(violation => violation.kind === 'missing').map(violation => violation.service).sort())
+            .toEqual(['kb-server', 'mc-server']);
+        expect(coordinateViolations(composeDoc)).toEqual([])
+    });
+
+    test('MUTATION — pinning a value to a hardcoded target is caught', () => {
+        // The second falsifier: every value replaced with a literal wrong host still passed, because
+        // the name was still there. Reachability is a property of the VALUE, not of the key.
+        const mutant = structuredClone(composeDoc);
+
+        for (const service of Object.keys(ENTRYPOINTS)) {
+            mutant.services[service].environment = mutant.services[service].environment.map(entry =>
+                String(entry).startsWith('NEO_OLLAMA_HOST=')
+                    ? 'NEO_OLLAMA_HOST=http://wrong-process.invalid:11434'
+                    : entry)
+        }
+
+        const violations = coordinateViolations(mutant).filter(violation => violation.kind === 'not-overridable');
+
+        expect(violations.map(violation => violation.service).sort()).toEqual(['kb-server', 'mc-server', 'orchestrator'])
+    });
+
+    test('MUTATION — interpolating a DIFFERENT variable is caught', () => {
+        // The subtler half of the same defect: `${SOMETHING_ELSE:-}` is interpolation-shaped, so a
+        // "does it contain ${" check would pass while the documented variable does nothing.
+        const mutant = structuredClone(composeDoc);
+
+        mutant.services['kb-server'].environment = mutant.services['kb-server'].environment.map(entry =>
+            String(entry).startsWith('NEO_OLLAMA_HOST=') ? 'NEO_OLLAMA_HOST=${NEO_CHROMA_HOST:-}' : entry);
+
+        expect(coordinateViolations(mutant).some(violation =>
+            violation.kind === 'not-overridable' && violation.service === 'kb-server')).toBe(true)
+    });
+
+    test('MUTATION — a coordinate copied by symmetry is caught', () => {
+        // The regression this repair exists to prevent: the block was pasted onto all three
+        // services, so an orchestrator-only knob advertised itself as a kb-server one.
+        const mutant = structuredClone(composeDoc);
+
+        mutant.services['kb-server'].environment.push(
+            'NEO_OLLAMA_REQUIRE_PARALLEL_MODELS=${NEO_OLLAMA_REQUIRE_PARALLEL_MODELS:-}');
+
+        expect(coordinateViolations(mutant).some(violation =>
+            violation.kind === 'undeclared' && violation.env === 'NEO_OLLAMA_REQUIRE_PARALLEL_MODELS')).toBe(true)
+    });
+
+    test('RECEIPTS — every required coordinate quotes a real read in a reachable module', () => {
+        // Without this, the REQUIRED table is a list of opinions. With it, an entry can only be
+        // added when the quoted source is present in a module that service actually loads.
+        const graphs = Object.fromEntries(
+            Object.entries(ENTRYPOINTS).map(([service, entry]) => [service, importGraph(entry)]));
+
+        for (const entry of REQUIRED) {
+            const consumerPath = path.join(repoRoot, entry.consumer);
+
+            expect(fs.existsSync(consumerPath), `${entry.consumer} does not exist`).toBe(true);
+
+            const source = normalize(fs.readFileSync(consumerPath, 'utf8'));
+
+            for (const anchor of entry.anchors) {
+                expect(
+                    source.includes(normalize(anchor)),
+                    `${entry.consumer} no longer contains the quoted read for ${entry.env}: ${anchor}`
+                ).toBe(true)
+            }
+
+            expect(
+                graphs[entry.service].has(consumerPath),
+                `${entry.consumer} is not reachable from the ${entry.service} entrypoint`
+            ).toBe(true);
+
+            expect(entry.why.length, `${entry.service}/${entry.env} needs a reviewable reason`).toBeGreaterThan(40)
+        }
+    });
+
+    test('COVERAGE — every declared leaf has a disposition on every service', () => {
+        // The "next added leaf cannot silently fail to ship" gate. A new NEO_OLLAMA_* leaf lands in
+        // declaredOllamaEnvNames() immediately and has no row in either table, so this reddens until
+        // someone decides, per service, whether it ships.
+        const
+            declared  = declaredOllamaEnvNames(),
+            decided   = new Set([...REQUIRED, ...NOT_REQUIRED].map(entry => `${entry.service}::${entry.env}`)),
+            undecided = [];
+
+        for (const service of Object.keys(ENTRYPOINTS)) {
+            for (const env of declared) {
+                if (!decided.has(`${service}::${env}`)) undecided.push(`${service}::${env}`)
+            }
+        }
+
+        expect(declared.length, 'the leaf scan found nothing — the config regex has drifted').toBeGreaterThanOrEqual(6);
+        expect(declared, 'the leaf scan misses a known member').toContain('NEO_OLLAMA_HOST');
+        expect(undecided, `coordinates with no disposition: ${undecided.join(', ')}`).toEqual([])
+    });
+
+    test('every deliberate absence names a reason', () => {
+        for (const entry of NOT_REQUIRED) {
+            expect(entry.why.length, `${entry.service}/${entry.env} absence is too thin to review`).toBeGreaterThan(60)
+        }
+    });
+
+    test('NON-VACUITY — the import graph, the compose reader and the value check all discriminate', () => {
+        // Each of the three fails silent rather than loud: an import graph that resolved nothing, an
+        // env reader returning an empty map, or a value predicate that never says no would each make
+        // some assertion above vacuous while leaving the suite green.
+        const kbGraph = importGraph(ENTRYPOINTS['kb-server']);
+
+        expect(kbGraph.size).toBeGreaterThan(50);
+        expect(kbGraph.has(path.join(repoRoot, 'ai/services/knowledge-base/VectorService.mjs'))).toBe(true);
+        // ...and it must NOT reach an entrypoint no kb-server code imports, or membership is free.
+        expect(kbGraph.has(path.join(repoRoot, 'ai/daemons/orchestrator/daemon.mjs'))).toBe(false);
+
+        const orchestratorEnv = serviceEnv(composeDoc, 'orchestrator');
+
+        expect(orchestratorEnv.size).toBeGreaterThan(10);
+        expect(orchestratorEnv.get('NEO_OLLAMA_HOST')).toBe('${NEO_OLLAMA_HOST:-}');
+
+        expect(isOperatorOverridable('NEO_OLLAMA_HOST', '${NEO_OLLAMA_HOST:-}')).toBe(true);
+        expect(isOperatorOverridable('NEO_OLLAMA_HOST', 'http://local-model:11434')).toBe(false);
+
+        // The anchor matcher must also be able to say no, or every receipt passes.
+        expect(normalize('  a   b ').includes(normalize('a b'))).toBe(true);
+        expect(normalize('a b').includes(normalize('a c'))).toBe(false)
+    })
+});


### PR DESCRIPTION
Resolves neomjs/neo#16850
Related: neomjs/neo-agent-brain#54

Authored by @neo-opus-grace (Claude Opus 5, Claude Code). Origin Session ID: `d8332b13-5d97-4839-ac11-d2de4602a989`.

## The defect

`ai/configBase.mjs` declares **six** `NEO_OLLAMA_*` leaves. `ai/deploy/docker-compose.yml` passed **one**.

`NEO_OLLAMA_HOST` appeared **zero times** across *every* compose variant in `ai/deploy/`. So `ollama.host` fell back to its leaf default `http://127.0.0.1:11434` — and inside `kb-server`, that address **is `kb-server`**.

**Any plane configured through this profile with `NEO_EMBEDDING_PROVIDER=ollama` sent every native embed to its own container's localhost and got connection-refused, permanently.** The model service sits on the same compose network as `local-model:11434`, and no path *in the canonical profile* could name it. The operator's chosen chat model, embedding model and timeout were silently ignored too.

**This is an omission, not a policy**, and the file says so itself: the sibling provider is fully wired, and **`NEO_OLLAMA_KEEP_ALIVE` was already passed** — nobody wires a keep-alive for a provider they intend to exclude. Meanwhile `ai/provider/Ollama.mjs` is a complete provider, `TextEmbeddingService` carries the native embed path, and `providerReadinessHelper` has a whole ollama branch keyed on `role === 'embedding' ? '/api/embed' : '/api/chat'`. **Everything an operator can read says ollama is supported; the canonical deployment layer could not deliver it.**

**Bounded, because the first version of this claim overclaimed twice.** It said the composition was *unbuildable* and that *no configuration path* existed. Neither is true: @neo-gpt-emmy brought the composition up by supplying `NEO_OLLAMA_HOST` out-of-band, and a Compose profile our side maintains hand-writes it on all three services.

> **Attribution corrected 2026-08-10 11:1xZ, after merge.** This originally said an *external plane's own* Compose hand-writes it, offered as field evidence of cost borne downstream. Git blame says **@tobiu wrote those lines himself** on 2026-05-26, in a file our side maintains — so the re-derivation cost was ours, and calling it external inflated the defect's reach.
>
> It is still evidence, and sharper for being ours: the person mirroring the canonical profile could not express the composition through it either, and hand-wired around the gap without the omission ever being filed. A profile its own author must work around is incomplete on the best available witness. The accurate claim is narrower and still the defect:

> **The composition is not expressible through the canonical profile.** Anyone who wants it must independently discover a missing variable and inject it by a route no committed artifact records.

## How it was found

Configuring **our own** containers to mirror an external plane's ollama topology, for an operator-directed reproduction.

## Deltas

| file | delta |
|---|---|
| `ai/deploy/docker-compose.yml` | each `NEO_OLLAMA_*` leaf passes through to the services that **consume** it — five on `kb-server` and `mc-server`, six on `orchestrator` — with per-service rationale inline |
| `ai/scripts/lint/config-leaf-parity.json` | five new keys classified as `optionalOverrides`; compose census `49 → 54` |
| `test/…/ai/deploy/OllamaProviderEnvCoordinates.spec.mjs` | **new** — the per-`(service, leaf)` contract, with four in-suite mutation controls, per-coordinate receipts, and a coverage gate |
| `test/…/ai/deploy/LoopbackDefaultReachability.spec.mjs` | the weaker family-agnostic floor, with its header now stating what it cannot see |

Defaults unchanged: a deployment setting none of them behaves exactly as today. **This adds reachability, not behaviour.**

**Decision Record impact:** `aligned-with ADR 0019` — the leaves already own env-override-with-default; this is the deployment layer failing to deliver the env. No leaf definitions touched, no resolution logic added.

## Review notes — what the second cycle changed

**@neo-gpt's review falsified the first guard with two exact-head mutations over the Git blobs at `be29257967`, and both are correct.** Removing `NEO_OLLAMA_HOST` from `kb-server` *and* `mc-server` while leaving it on `orchestrator` passed. Replacing every value with `http://wrong-process.invalid:11434` passed. Those are exactly the two boundaries the PR claimed to protect.

The reason is the shape, not an oversight in the details: **a union of env names across services cannot see service scope, and a name-only check cannot see the value.** The contract is a set of `(service, leaf)` **coordinates**.

`OllamaProviderEnvCoordinates.spec.mjs` asserts three things per coordinate:

1. **Service scope** — each required pair is asserted independently.
2. **Operator-overridable shape** — the value must be a `${NAME}` / `${NAME:-default}` interpolation of **its own** variable. A literal is a decision taken away from the operator.
3. **No coordinate by symmetry** — a `NEO_OLLAMA_*` entry on a service with no consumer is a violation, not a harmless extra.

**The mutations are permanent tests, not a claim.** `coordinateViolations()` is a pure function of a compose document, so the suite runs it against deliberately broken clones — both of the reviewer's falsifiers, plus the subtler `${DIFFERENT_VAR:-}` case (interpolation-shaped, so a "does it contain `${`" check would pass) and the symmetry-copy case. A guard whose failure mode is never exercised is a guard nobody has tested.

**Receipts, so the required table cannot be a list of opinions.** Every coordinate names the consuming module **and quotes the literal source lines that perform the read**, matched with whitespace normalised and checked against that service's import graph. The first version of the receipt check used a property *pattern* and could not see `const config = aiConfig.ollama` followed by `config.host`. **The repair for a pattern that misses a real read is to quote the read, not to widen the pattern until it matches anything.**

**`REQUIRE_PARALLEL_MODELS` drops off `kb-server` and `mc-server`.** Its sole read is `buildOllamaReadinessConfig` and all three callers live under `ai/daemons/orchestrator/`. **The convenient instrument disagreed:** an import-graph scan reports readers for all six leaves in all three graphs, because `TextEmbeddingService` dynamic-imports `fetchLmsLoadedModels` from that same module. Module reachability is not consumption — and had I trusted the scan, it would have restored the symmetry copy with machinery behind it, which is worse than the hand-written version because it looks derived.

**Rhetorical drift, truth-folded in the same cycle** rather than deferred to a documentation round: the three identical Compose comments claimed every native embed failed *"on every deployment"* with *"no config path"* able to name the target. Each service now states what **it** consumes and why, the universal claim is narrowed to the canonical profile, and `LoopbackDefaultReachability.spec.mjs` says in its own header that it is a floor which cannot see service scope — *read a green there as "not entirely unreachable", never as "wired correctly"*. The ticket's Contract Ledger is re-cut as a coordinate matrix, and the AC that said "all six … to every service" is corrected, because that wording is what licensed the symmetry copy.

## Test Evidence

Evidence: L1 exact-head coordinate mutations and source-consumer receipts → L3 post-merge canonical-plane confirmation required.

`UNIT_TEST_MODE=true npx playwright test --config=test/playwright/playwright.config.unit.mjs`

- **`test/playwright/unit/ai/scripts/lint/` + `test/playwright/unit/ai/deploy/` → 417 passed.**
- `ai:lint-config-template-ssot` → **green**. The compose census binds this: every `NEO_`/`MCP_` key must be classified into a bucket **and** the total must match, so an unclassified addition fails rather than passing silently.

*(`docker compose config` was **not** used as a witness: this compose version rejects `--no-interpolate`, and without that flag the command prints secret **values**. Structural parse of the profile instead.)*

## Post-Merge Validation

- [ ] On a `--profile local-model` plane with `NEO_EMBEDDING_PROVIDER=ollama` and `NEO_OLLAMA_HOST=http://local-model:11434`, confirm a native embed reaches the model service rather than container-localhost. Not reachable from unit CI — it needs a running compose plane. The closing ticket carries the required `[L3-deferred — operator handoff needed]` annotation.
- [ ] Confirm a deployment setting none of the leaves behaves identically to the prior revision.

## Out of scope

- **Changing the default provider.** `openAiCompatible` stays the default.
- Whether ollama-native or openAiCompatible-against-ollama is the *recommended* path.
- `#16849` (`Ollama.stream()` timeout), `#16846` (embedding batch env overrides) — same neighbourhood, separate defects.

