### PR TITLE
feat(memory-core): tell an evicted embedding model apart from one never loaded (#16852)

### DIFF
--- a/ai/services/knowledge-base/IngestionService.mjs
+++ b/ai/services/knowledge-base/IngestionService.mjs
@@ -427,7 +427,16 @@ class IngestionService extends Base {
                     // hardest: the better-classified the failure, the emptier the receipt.
                     code   : classifyEmbedFailureCode(error.code),
                     message: error.message,
-                    details: {repoSlug}
+                    // `residencyDisposition` is the difference between "re-check the model identifier"
+                    // and "something took the model's slot" — opposite remediations behind one code.
+                    // This receipt is where an operator actually reads the failure, so a discriminator
+                    // that stops short of it is not an instrument, only an intention. Spread
+                    // conditionally: unobserved must stay absent rather than arrive as a null field
+                    // that reads like a measured one.
+                    details: {
+                        repoSlug,
+                        ...(error.residencyDisposition && {residencyDisposition: error.residencyDisposition})
+                    }
                 }));
                 this.updateIngestionProgress({
                     embeddedChunks: summary.embeddingsGenerated,

--- a/ai/services/knowledge-base/VectorService.mjs
+++ b/ai/services/knowledge-base/VectorService.mjs
@@ -812,7 +812,21 @@ class VectorService extends Base {
                 // it is the correct behaviour for this case: walking the rest of the corpus would spend
                 // `remainingBatches * maxRetries * timeout` proving what the first batch already proved.
                 if (embeddedCount === 0) {
-                    throw new Error(`Failed to process batch ${i / batchSize + 1} after ${maxRetries} retries. Aborting.`);
+                    const abort = new Error(`Failed to process batch ${i / batchSize + 1} after ${maxRetries} retries. Aborting.`);
+
+                    // A fresh Error here used to discard everything the provider had already worked out
+                    // about WHY, one hop before the receipt an operator reads. The message survived and
+                    // the classification did not, so a diagnosed outage arrived anonymous — the better
+                    // the diagnosis upstream, the more this hop threw away.
+                    abort.cause = lastError;
+
+                    // Carried only when observed. Absent stays absent: an unclassified failure must not
+                    // acquire a classification by passing through here.
+                    if (lastError?.residencyDisposition) {
+                        abort.residencyDisposition = lastError.residencyDisposition;
+                    }
+
+                    throw abort;
                 }
 
                 // At least one batch has landed, so continuing is worth attempting. This is a CONTINUATION

--- a/ai/services/memory-core/TextEmbeddingService.mjs
+++ b/ai/services/memory-core/TextEmbeddingService.mjs
@@ -1016,10 +1016,17 @@ class TextEmbeddingService extends Base {
                 // retries exhausted means the model existed and something took its slot, which is a
                 // capacity question. Never observed resident stays a configuration fault. Only the
                 // exhausted case is marked — a Shape-C with retries left may still succeed.
-                if (!(unloadRetriesLeft > 0)) {
-                    err.residencyDisposition = operation.residentAtPreflight
-                        ? EMBEDDING_RESIDENCY_EVICTED_MID_BATCH
-                        : EMBEDDING_RESIDENCY_NEVER_RESIDENT
+                // Strictly `true`, never merely truthy. The preflight is SKIPPED entirely for an
+                // openAiCompatible endpoint that is not LM Studio (`#getOpenAiCompatibleEmbeddingRuntime`
+                // returns before recording anything), so the flag is then `undefined` — an absence of
+                // observation, not an observation of absence. A ternary read it as `never-resident`
+                // and minted a positive configuration-fault claim from a check that never ran, which
+                // is the hidden default this ticket's own Avoided Traps forbids.
+                //
+                // `never-resident` is therefore minted ONLY where it is observed: the preflight
+                // rejection above. Unobserved leaves the field absent, and absent is readable.
+                if (!(unloadRetriesLeft > 0) && operation.residentAtPreflight === true) {
+                    err.residencyDisposition = EMBEDDING_RESIDENCY_EVICTED_MID_BATCH
                 }
             }
 

--- a/ai/services/memory-core/TextEmbeddingService.mjs
+++ b/ai/services/memory-core/TextEmbeddingService.mjs
@@ -34,6 +34,30 @@ const EMBEDDING_OPERATION_LABEL_MAX_LENGTH         = 120;
 export const EMBEDDING_MODEL_NOT_RESIDENT_CODE = 'EMBEDDING_MODEL_NOT_RESIDENT';
 
 /**
+ * @summary Disposition for a model that WAS resident at preflight and is gone by the time the batch
+ * reaches a later chunk. Carried BESIDE the code, never instead of it.
+ *
+ * Distinct from {@link EMBEDDING_MODEL_NOT_RESIDENT_CODE} because the two demand OPPOSITE responses and
+ * were previously indistinguishable. *Never resident* is a deployment or configuration fault — the wrong
+ * identifier, an unloaded model, a mis-pointed host — and no amount of retrying fixes it. *Evicted
+ * mid-batch* means the configuration was correct and a co-resident model took the slot, which is a
+ * capacity and co-residency question. Reporting both as "not resident" sends an operator to re-check a
+ * configuration that was already right.
+ *
+ * The distinction is free: residency is already observed at preflight, so this only requires remembering
+ * that it was, rather than probing again per chunk — which at stock leaves would add ~13,000 `lms` CLI
+ * spawns to a full corpus sync.
+ * @type {String}
+ */
+export const EMBEDDING_RESIDENCY_EVICTED_MID_BATCH = 'evicted-mid-batch';
+
+/**
+ * @summary Disposition for a model that was never observed resident for this operation.
+ * @type {String}
+ */
+export const EMBEDDING_RESIDENCY_NEVER_RESIDENT = 'never-resident';
+
+/**
  * @summary Carries a known model-residency cause separately from its diagnostic message.
  *
  * Model-load messages include configured model identifiers, observed resident ids and provider
@@ -748,14 +772,28 @@ class TextEmbeddingService extends Base {
         const loadedModel = loadedModels.find(item => item.id === model);
 
         if (!loadedModel) {
-            const observedIds = loadedModels.map(item => item.id).filter(Boolean).slice(0, 5).join(', ') || 'none';
-            throw markEmbeddingModelNotResidentError(
-                new Error(`TextEmbeddingService: LM Studio embedding model '${model}' is not resident under its configured identifier; observed=${observedIds}`)
-            );
+            const observedIds = loadedModels.map(item => item.id).filter(Boolean).slice(0, 5).join(', ') || 'none',
+                  error       = markEmbeddingModelNotResidentError(
+                      new Error(`TextEmbeddingService: LM Studio embedding model '${model}' is not resident under its configured identifier; observed=${observedIds}`)
+                  );
+
+            // The preflight rejection is the OTHER origin of "not resident", and it carries the same
+            // disposition field so a consumer never has to infer the cause from which throw site it
+            // came out of. Absent here, only the post-request path would be classified and this one
+            // would read as unclassified rather than as the configuration fault it plainly is.
+            error.residencyDisposition = EMBEDDING_RESIDENCY_NEVER_RESIDENT;
+
+            throw error
         }
         if (!Neo.isNumber(loadedModel.contextLength)) {
             throw new Error(`TextEmbeddingService: LM Studio embedding model '${model}' has unknown loaded context; configured>=${configuredContextLength}`);
         }
+
+        // Record that residency was OBSERVED here, so a later 404 can be told apart from one raised by
+        // a model that was never loaded. This preflight runs once per embedTexts call while the batch
+        // below issues one request per chunk — the check is a point observation, not an invariant over
+        // the requests it licenses, and a co-resident chat model can evict this one inside that window.
+        operation.residentAtPreflight = true;
 
         return {configuredContextLength, loadedModel, model};
     }
@@ -967,7 +1005,22 @@ class TextEmbeddingService extends Base {
             )) || err.message.includes('HTTP 404');                         // Shape C — model not resident
 
             if (isModelLoadError) {
-                markEmbeddingModelNotResidentError(err)
+                markEmbeddingModelNotResidentError(err);
+
+                // ADDITIVE, deliberately. `code` keeps its spelling because two downstream readers own
+                // it — `embeddingProbe`'s `model-not-resident` and the KB's durable
+                // `KB_VECTOR_EMBED_MODEL_NOT_RESIDENT` — and re-coding here would drop an evicted
+                // failure out of both classifications rather than refining it.
+                //
+                // The disposition rides alongside: residency observed at preflight and gone by the time
+                // retries exhausted means the model existed and something took its slot, which is a
+                // capacity question. Never observed resident stays a configuration fault. Only the
+                // exhausted case is marked — a Shape-C with retries left may still succeed.
+                if (!(unloadRetriesLeft > 0)) {
+                    err.residencyDisposition = operation.residentAtPreflight
+                        ? EMBEDDING_RESIDENCY_EVICTED_MID_BATCH
+                        : EMBEDDING_RESIDENCY_NEVER_RESIDENT
+                }
             }
 
             if (unloadRetriesLeft > 0 && isModelLoadError) {

--- a/test/playwright/unit/ai/services/knowledge-base/VectorService.batchFailureIsolation.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/VectorService.batchFailureIsolation.spec.mjs
@@ -298,4 +298,50 @@ test.describe('VectorService.embedChunks — one failing batch must not strand t
         expect(result.embedded).toBe(50);
         expect(result.failedBatches).toHaveLength(0);
     });
+
+    test('a total outage carries the provider classification past this hop (#16852)', async () => {
+        // The total-outage arm mints a FRESH Error, one hop before the receipt an operator reads.
+        // Minting it bare discarded everything the provider had worked out about why — the better the
+        // diagnosis upstream, the more this hop threw away. A discriminator that dies here is an
+        // intention, not an instrument.
+        const spy    = createSpyCollection(),
+              chunks = makeChunks(50);
+
+        TextEmbeddingService.embedTexts = async () => {
+            const err = new Error('embedding model not resident');
+
+            err.code                   = 'EMBEDDING_MODEL_NOT_RESIDENT';
+            err.residencyDisposition   = 'evicted-mid-batch';
+
+            throw err
+        };
+
+        const thrown = await KB_VectorService.embedChunks({collection: spy, chunksToProcess: chunks})
+            .then(() => null, error => error);
+
+        expect(thrown, 'nothing embedded ⇒ the sweep aborts by throwing').toBeTruthy();
+        expect(thrown.residencyDisposition,
+            'the classification must survive the re-throw, or no operator ever sees it').toBe('evicted-mid-batch');
+        expect(thrown.cause?.code, 'the original failure stays reachable, not just its message')
+            .toBe('EMBEDDING_MODEL_NOT_RESIDENT');
+    });
+
+    test('an UNCLASSIFIED outage does not acquire a classification in transit (#16852)', async () => {
+        // The negative control. Carrying the field forward must never mean inventing one: a failure
+        // with no residency observation has to arrive unclassified, or the discriminator becomes
+        // noise that always says something.
+        const spy    = createSpyCollection(),
+              chunks = makeChunks(50);
+
+        TextEmbeddingService.embedTexts = async () => {
+            throw new Error('provider socket closed')
+        };
+
+        const thrown = await KB_VectorService.embedChunks({collection: spy, chunksToProcess: chunks})
+            .then(() => null, error => error);
+
+        expect(thrown).toBeTruthy();
+        expect(thrown.residencyDisposition,
+            'absent upstream must stay absent downstream').toBeUndefined();
+    });
 });

--- a/test/playwright/unit/ai/services/memory-core/TextEmbeddingService.retry.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/TextEmbeddingService.retry.spec.mjs
@@ -843,6 +843,27 @@ test.describe.serial('TextEmbeddingService #11393/#11402/#12487/#12509 — openA
         expect(error.residencyDisposition, 'never observed resident ⇒ configuration fault, not capacity').toBe('never-resident');
     });
 
+    test('a preflight that never RAN leaves the disposition absent — unknown is not never (#16852)', async () => {
+        // The third state, and the one a boolean erased. An openAiCompatible endpoint that is not
+        // LM Studio skips the residency preflight entirely, so nothing is ever observed. Reporting
+        // that as `never-resident` would mint a positive configuration-fault claim out of a check
+        // that did not run — sending an operator to re-check an identifier nobody ever tested.
+        //
+        // The probe must be nulled EXPLICITLY: `beforeEach` installs a default that reports the model
+        // loaded, so omitting this would silently test the resident path instead. Written the lazy way
+        // first, and it returned `evicted-mid-batch` — the absent condition has to be established, not
+        // assumed, or the test quietly measures the opposite of its name.
+        TextEmbeddingService.openAiCompatibleLoadedModelsProbe = null;
+        serverBehavior                                         = 'fail-all-404';
+
+        const error = await TextEmbeddingService.embedTexts(['a'], 'openAiCompatible')
+            .then(() => null, observed => observed);
+
+        expect(error, 'the batch still fails loudly — only the CLASSIFICATION is withheld').toBeTruthy();
+        expect(error.residencyDisposition,
+            'an absence of observation is not an observation of absence').toBeUndefined();
+    });
+
     test('a SPARSE provider response is refused rather than silently re-based to position 0 (#16826)', async () => {
         serverBehavior = 'sparse-batch';
         aiConfig.openAiCompatible.batchEmbeddingChunkSize = 5;

--- a/test/playwright/unit/ai/services/memory-core/TextEmbeddingService.retry.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/TextEmbeddingService.retry.spec.mjs
@@ -785,7 +785,7 @@ test.describe.serial('TextEmbeddingService #11393/#11402/#12487/#12509 — openA
         expect(result).toEqual([[1, 0], [1, 1], [2, 0], [2, 1], [3, 0]]);
     });
 
-    test('the residency preflight is a POINT CHECK licensing N requests — eviction after it is invisible (#14154)', async () => {
+    test('the residency preflight is a POINT CHECK licensing N requests — eviction after it is invisible (#16852)', async () => {
         serverBehavior = 'resident-then-evicted';
         aiConfig.openAiCompatible.batchEmbeddingChunkSize = 1;
         aiConfig.openAiCompatible.unloadRetryCount        = 1;
@@ -828,7 +828,7 @@ test.describe.serial('TextEmbeddingService #11393/#11402/#12487/#12509 — openA
         expect(requestCount, 'chunk 1 succeeded, chunk 2 + its retry both 404').toBe(3);
     });
 
-    test('a model that was NEVER resident keeps the configuration-fault code (#14154)', async () => {
+    test('a model that was NEVER resident keeps the configuration-fault code (#16852)', async () => {
         serverBehavior = 'fail-all-404';
 
         // Preflight finds nothing loaded, so the operation never observes residency. This is the

--- a/test/playwright/unit/ai/services/memory-core/TextEmbeddingService.retry.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/TextEmbeddingService.retry.spec.mjs
@@ -210,6 +210,17 @@ test.describe.serial('TextEmbeddingService #11393/#11402/#12487/#12509 — openA
                             ]
                         }));
                     }, 50);
+                } else if (serverBehavior === 'resident-then-evicted') {
+                    // The mid-sync eviction shape: chunk 1 embeds normally, then the model is gone.
+                    // A preflight that ran before chunk 1 cannot see this.
+                    if (requestCount === 1) {
+                        const inputs = lastRequest.body.input;
+                        res.writeHead(200, { 'Content-Type': 'application/json' });
+                        res.end(JSON.stringify({data: inputs.map((_, index) => ({index, embedding: [index]}))}));
+                        return;
+                    }
+                    res.writeHead(404, { 'Content-Type': 'application/json' });
+                    res.end(JSON.stringify({ error: 'The requested resource could not be found.' }));
                 } else if (serverBehavior === 'sparse-batch') {
                     // One vector short, and the one returned is NOT index 0.
                     res.writeHead(200, { 'Content-Type': 'application/json' });
@@ -772,6 +783,64 @@ test.describe.serial('TextEmbeddingService #11393/#11402/#12487/#12509 — openA
         expect(requestCount).toBe(3);
         expect(allRequests.map(item => item.body.input)).toEqual([['a', 'b'], ['c', 'd'], ['e']]);
         expect(result).toEqual([[1, 0], [1, 1], [2, 0], [2, 1], [3, 0]]);
+    });
+
+    test('the residency preflight is a POINT CHECK licensing N requests — eviction after it is invisible (#14154)', async () => {
+        serverBehavior = 'resident-then-evicted';
+        aiConfig.openAiCompatible.batchEmbeddingChunkSize = 1;
+        aiConfig.openAiCompatible.unloadRetryCount        = 1;
+
+        let probeCount = 0;
+
+        // The provider reports the model resident. It is true when asked, and the preflight is
+        // therefore correct — which is the whole point: correctness at t0 is not an invariant over
+        // the batch that follows.
+        TextEmbeddingService.openAiCompatibleLoadedModelsProbe = async () => {
+            probeCount++;
+            return [{
+                id           : aiConfig.openAiCompatible.embeddingModel,
+                contextLength: aiConfig.localModels.embedding.contextLimitTokens
+            }];
+        };
+
+        const error = await TextEmbeddingService.embedTexts(['a', 'b', 'c'], 'openAiCompatible')
+            .then(() => null, observed => observed);
+
+        // ONE preflight for a batch that issues one request per chunk. The window between the check
+        // and the last chunk is the entire batch duration — on the observed plane, long enough for a
+        // chat-model load to evict the embedder mid-sweep. This is the mid-sync 404 the ticket
+        // title: not a cold start, a residency change under a green check.
+        expect(probeCount, 'residency is checked once per embedTexts call, not per provider request').toBe(1);
+
+        expect(error).toBeInstanceOf(Error);
+
+        // The load-bearing distinction. "Never resident" is a configuration fault — wrong identifier,
+        // wrong host, model never loaded — and retrying cannot fix it. "Evicted mid-batch" means the
+        // configuration was RIGHT and something took the slot, which is a capacity question. Both used
+        // to mint EMBEDDING_MODEL_NOT_RESIDENT, so an operator was sent to re-check a config that was
+        // already correct.
+        expect(error.code, 'the code keeps its spelling — two downstream readers own it').toBe('EMBEDDING_MODEL_NOT_RESIDENT');
+        expect(error.residencyDisposition, 'residency was observed at preflight, so this is an eviction').toBe('evicted-mid-batch');
+
+        // Chunk 1 embedded against a resident model; chunk 2 found it gone and burned its bounded
+        // unload retries against a provider that will not reload it. The batch then throws, and from
+        // there the sweep-level stranding takes over — a different defect, one layer up.
+        expect(requestCount, 'chunk 1 succeeded, chunk 2 + its retry both 404').toBe(3);
+    });
+
+    test('a model that was NEVER resident keeps the configuration-fault code (#14154)', async () => {
+        serverBehavior = 'fail-all-404';
+
+        // Preflight finds nothing loaded, so the operation never observes residency. This is the
+        // control that keeps the new code narrow: without it, reclassifying on 404 would relabel every
+        // configuration fault as an eviction and destroy the distinction it exists to create.
+        TextEmbeddingService.openAiCompatibleLoadedModelsProbe = async () => [];
+
+        const error = await TextEmbeddingService.embedTexts(['a'], 'openAiCompatible')
+            .then(() => null, observed => observed);
+
+        expect(error.code).toBe('EMBEDDING_MODEL_NOT_RESIDENT');
+        expect(error.residencyDisposition, 'never observed resident ⇒ configuration fault, not capacity').toBe('never-resident');
     });
 
     test('a SPARSE provider response is refused rather than silently re-based to position 0 (#16826)', async () => {


### PR DESCRIPTION
Resolves neomjs/neo#16852

Refs neomjs/neo-agent-brain#131

When an embedding batch fails with model-not-resident **and residency was actually observed at preflight**, the failure now says which of two opposite conditions it was — `evicted-mid-batch` or `never-resident` — and that classification travels to the ingestion receipt an operator reads. The two have opposite remediations: one sends an operator to `keep_alive` and VRAM budget, the other to provisioning, env wiring, or a dead runner.

**Where the preflight never ran, the field is absent.** An openAiCompatible endpoint that is not LM Studio skips residency checking entirely, and an unobserved state must not be reported as `never-resident` — that would mint a positive configuration-fault claim from a check that did not happen. Absence of observation is not observation of absence.

The disposition rides *beside* `err.code` rather than replacing it, because `embeddingProbe` and the KB's durable `KB_VECTOR_EMBED_MODEL_NOT_RESIDENT` already classify on that spelling; re-coding would have dropped an evicted failure out of both classifications instead of refining it.

All **seven** neomjs/neo#16852 acceptance criteria are ticked on the ticket with per-AC receipts. The list grew from five during this review cycle and the revision is marked in place on the ticket: the original five described a **binary** fact, and the delivered behaviour is **tri-state** (absent when residency was never observed), plus a criterion for reaching a production consumer at all. Leaving five ACs describing behaviour the diff no longer has would be a Request Changes on its own.

Evidence: L2 (spec-driven contract tests — a real `http.createServer` on 127.0.0.1 exercises the full fetch path, but the LM Studio binary is faked) → L2 required (all seven neomjs/neo#16852 ACs are unit-verifiable; none names a host-observable effect). Residual: the final `IngestionService` receipt hop is delivered but NOT mutation-guarded [#16859].

## Deltas from ticket

**Class corrected before handoff.** The first commit was authored `fix` and retargeted to `feat`: a new separately-testable path is `capability` under `pull-request-workflow.md §3.1`, and that rule wins explicitly "even when a bug motivated the work." The `bug` label on the parent ticket does not decide the class.

**Close-target split.** This work was done under neomjs/neo-agent-brain#131, whose remaining scope is *why the embedder gets evicted*. This PR does not answer that — it delivers the discriminator that decides whether an eviction happened at all. neomjs/neo-agent-brain#131 therefore stays open and gets `Refs`, and neomjs/neo#16852 was filed as the honest leaf. The two test titles that cited neomjs/neo-agent-brain#131 were retargeted in the second commit, so a reader following the reference lands on the ACs the test actually verifies.

**One trap folded in from a peer's measurement.** The obvious alternative — probe the provider for residency at failure time — is now explicitly rejected in the ticket's Avoided Traps, on the strength of @neo-opus-grace's 2026-08-10 reproduction: a forced abort at ~1s left an ollama runner pegged at ~399% CPU for 60s+ with every client stopped. An abort-capable probe is a write disguised as a read, so a residency probe could wedge the runner it was sent to inspect. The disposition is derived only from state the service already holds and issues **no additional provider request**.

## Test Evidence

```
npm run test-unit -- test/playwright/unit/ai/services/memory-core/TextEmbeddingService.retry.spec.mjs
  35 passed (3.0s)
```

```
npm run test-unit -- test/playwright/unit/ai/services/memory-core/
  1584 passed (50.7s)
```

Both runs are at the rebased HEAD `d61741d842` (branch rebased onto `origin/dev` @ `14d1e3fb55`).

Directly touched surfaces:

- `ai/services/memory-core/TextEmbeddingService.mjs` — `TextEmbeddingService.retry.spec.mjs`: 35 passed. New coverage: `resident-then-evicted` (the TOCTOU witness — the preflight is a point check licensing N requests), `never-resident` (preflight rejection carries the disposition too; it initially carried none, and this control is what exposed that).
- No app/feature surface touched — `None found` is not applicable; this is a Brain-side service.

**Red-proof:** the `never-resident` control was written first and failed against the initial implementation, which attached the disposition only on the retry-exhaustion arm. The preflight-rejection arm threw before any request and carried nothing, so a consumer would have had to infer cause from which throw site an error emerged. Both arms carry it now.

## Post-Merge Validation

- [ ] On the next model-not-resident failure on a live LM Studio plane, confirm the disposition is present and names the correct branch (this needs a real recurrence; it cannot be forced in CI).

## Review cycle 2 — @neo-gpt-emmy's three Required Actions, repaired at `d28c7d5ca1`

**Tri-state.** The ternary read an unobserved preflight as `never-resident`. neomjs/neo#16852's own Avoided Traps forbids exactly that default — I wrote the rule and shipped its violation in the same PR. `never-resident` is now minted only where it is observed.

**Delivery.** The field existed only in `TextEmbeddingService` and its spec. `VectorService`'s total-outage arm minted a bare `Error`, discarding classification and cause one hop before the receipt; it now carries both, and `IngestionService` puts the disposition on the operator-visible receipt. Emmy's generalisation, adopted: *a diagnostic field without a production reader is not an instrument.*

**Mutation-sensitivity — partial, and the earlier claim here was false.**

The `VectorService` re-throw hop is red-proofed: disabling its carry line reddens the delivery test. **The `IngestionService` receipt hop is not.** @neo-gpt-emmy showed that deleting only the final `details` spread leaves **37/37 green** — so the hop that actually reaches an operator is delivered but unguarded, and a refactor could remove it silently.

This section previously read *"Delivery is red-proofed"* and the `Evidence:` line said *"No residuals."* Both were false. The correction is retained rather than quietly rewritten because it is the **same defect the review found in the first place, one hop further along**: I verified a hop and claimed the chain. Getting told that once should have made me check the last link before asserting it.

Residual now named and owned by **#16859** (@neo-gpt-emmy), which takes the exact-one never-resident probe and the final receipt mutation control.

**Two bounds on what IS proven:** the `VectorService` spec is `mode: 'serial'`, so its mutated run *skipped* the negative control rather than passing it (1 failed + 8 passed of 10) — the positive test is mutation-sensitive, the control is green only unmutated.

## Commits

- `d86b59b8b2` — the residency disposition: preflight state recorded, both terminal arms carry it additively
- `cc06e23b11` — retarget two test titles from the parent question to the delivered close-target

## Evolution

Started as a `fix` under neomjs/neo-agent-brain#131 on the premise that the discriminator *was* the root-cause work. It is not: it is the instrument that decides which root-cause question to ask. Recognising that changed both the close-target and the commit class, and left neomjs/neo-agent-brain#131 open where it belongs.

Authored by Ada (Claude Opus 5, Claude Code). Session 87f453f9-aa80-4487-9ed1-b5d91e052c43.



