### PR TITLE
The prescription renderer has no caller and no admission boundary

### DIFF
--- a/ai/services/memory-core/helpers/deploymentPrescriptionLedger.mjs
+++ b/ai/services/memory-core/helpers/deploymentPrescriptionLedger.mjs
@@ -1,0 +1,188 @@
+import {isKnownKnob, knobEnvBindings, RECOVERY_KNOBS, validateKnobTransaction} from './recoveryKnobRegistry.mjs';
+
+/**
+ * Admits ledger records into the active prescription set the env renderer materializes.
+ *
+ * **This module exists because the ledger is an untrusted transport and the registry is the authority.**
+ * A record arrives having been validated once, by a producer, against a context that has since moved.
+ * Rendering it on that strength would make the ledger the security boundary — and the ledger is a file.
+ * So every record is revalidated here against the *current* registry: the knob must still exist, still
+ * address the target it names, still bound the values it carries, and still bind the env keys the
+ * renderer will write. Admission is computed, never accepted.
+ *
+ * **The env key is taken from the registry and never from the record.** The renderer downstream accepts
+ * any uppercase identifier with a positive finite value, so a record permitted to name its own `env`
+ * could turn a bounded heap prescription into an arbitrary numeric config mutation — the whole knob
+ * abstraction bypassed by one extra field. `knobEnvBindings()` is the only source consulted, which is
+ * also why a rebinding in the registry propagates here with no edit.
+ *
+ * **Ordering is `sequence`, never `prescribedAt`.** `prescribedAt` is audit metadata written by whoever
+ * produced the record, so letting it order deployment state lets a wrong clock choose which ceiling is
+ * live. `sequence` is sink-assigned and monotonic, so it is the only field with the authority to say
+ * which of two prescriptions for the same target supersedes the other.
+ *
+ * Scope: this is the READ side. It admits and folds; it does not append, and it does not write files.
+ * The trusted append ingress — compare-and-append per target, sink-stamped producer provenance,
+ * forged-producer rejection — is a separate boundary and deliberately not reachable from here.
+ */
+
+/**
+ * The record shape this module admits. Fields the registry already owns — the leaf→env binding, bounds,
+ * required context, the target service — are deliberately absent: a record that restated them could
+ * disagree with the authority, and then the disagreement would have to be adjudicated rather than
+ * simply not existing.
+ * @typedef {Object} LedgerPrescriptionRecord
+ * @property {String} recordType            Must be `deployment-prescription`.
+ * @property {String} prescriptionId        Identity, used for idempotent replay.
+ * @property {Number} sequence              Sink-assigned monotonic ordering authority.
+ * @property {String} knob                  A key of `RECOVERY_KNOBS`.
+ * @property {Object} targetIdentity        `{kind, id}`; `id` must match the knob's declared service.
+ * @property {Object} values                Keyed by the knob's registry leaf paths.
+ * @property {Object} [validatedAgainst]    `{context, observationFingerprint, observedAt}`.
+ */
+
+/**
+ * Refusal reasons, named rather than free-text so a caller can act on them and a ledger audit can count
+ * them. A refused record is a fact worth recording — the alternative is a materialization that is
+ * quietly narrower than the ledger it claims to represent.
+ * @type {Object}
+ */
+export const LEDGER_REFUSALS = Object.freeze({
+    conflictingSequence: 'conflicting-sequence',
+    invalidTransaction : 'invalid-transaction',
+    notAPrescription   : 'not-a-prescription',
+    targetMismatch     : 'target-mismatch',
+    unknownKnob        : 'unknown-knob',
+    unorderable        : 'unorderable'
+});
+
+/**
+ * @summary Groups records by the target they compete for.
+ *
+ * Supersession is per `{target, knob}` and not global: two knobs on the same service are independent
+ * prescriptions, and the same knob on two services must not have one silently outrank the other.
+ * @param {LedgerPrescriptionRecord} record
+ * @returns {String}
+ */
+function competitionKey(record) {
+    return `${record.knob}::${record.targetIdentity?.kind ?? '?'}:${record.targetIdentity?.id ?? '?'}`
+}
+
+/**
+ * @summary Revalidates one record against the current registry, returning a refusal reason or null.
+ *
+ * Ordered cheapest-first and deliberately total: a record that fails anything is admitted for nothing.
+ * Partial admission is the same failure `validateKnobTransaction` refuses partial application for — a
+ * half-applied knob leaves state that depends on what the target happened to hold.
+ * @param {LedgerPrescriptionRecord} record
+ * @returns {{reason: String, detail: String[]}|null}
+ */
+export function refuseLedgerRecord(record) {
+    if (record?.recordType !== 'deployment-prescription') {
+        return {reason: LEDGER_REFUSALS.notAPrescription, detail: [`recordType '${record?.recordType}'`]}
+    }
+
+    // A record the sink never ordered cannot be folded, and defaulting it to 0 or to arrival order would
+    // hand ordering authority back to the transport this module exists to distrust.
+    if (!Number.isInteger(record.sequence) || record.sequence < 0) {
+        return {reason: LEDGER_REFUSALS.unorderable, detail: [`sequence ${JSON.stringify(record.sequence)} is not a non-negative integer`]}
+    }
+
+    if (!isKnownKnob(record.knob)) {
+        return {reason: LEDGER_REFUSALS.unknownKnob, detail: [`'${record.knob}'`]}
+    }
+
+    // The registry declares the one service a knob addresses. A record aiming a chroma ceiling at
+    // another container is refused here rather than rendered, because the env binding would resolve
+    // from the registry and silently move the service the knob DOES own.
+    const declaredService = RECOVERY_KNOBS[record.knob].serviceKey;
+
+    if (record.targetIdentity?.id !== declaredService) {
+        return {
+            reason: LEDGER_REFUSALS.targetMismatch,
+            detail: [`knob '${record.knob}' addresses '${declaredService}', record names '${record.targetIdentity?.id}'`]
+        }
+    }
+
+    const {valid, violations} = validateKnobTransaction({
+        knob  : record.knob,
+        values: record.values,
+        // The producer's resolved bounds travel with the record; they are re-evaluated, not trusted. A
+        // context that has gone stale surfaces as a violation, which is a disposition — not a new line.
+        context: record.validatedAgainst?.context
+    });
+
+    return valid ? null : {reason: LEDGER_REFUSALS.invalidTransaction, detail: violations}
+}
+
+/**
+ * @summary Folds a ledger into the active prescription set, ready for the env renderer.
+ *
+ * **Last-write-wins is decided by `sequence` here rather than left to the renderer.** The renderer's
+ * own duplicate collapse is a rendering detail — it cannot tell a legitimate successor from a replay,
+ * a conflict, or a late arrival with a stale watermark, because it never sees the ordering field. So the
+ * ledger resolves supersession and hands the renderer a set with one entry per key.
+ * @param {LedgerPrescriptionRecord[]} records Ledger order as read; arrival order is NOT trusted.
+ * @returns {{prescriptions: Array<{key: String, value: Number}>, admitted: Object[], refused: Array<{record: Object, reason: String, detail: String[]}>}}
+ */
+export function admitLedgerPrescriptions(records) {
+    const
+        refused = [],
+        winners = new Map();
+
+    for (const record of records ?? []) {
+        const refusal = refuseLedgerRecord(record);
+
+        if (refusal) {
+            refused.push({record, ...refusal});
+            continue
+        }
+
+        const
+            key       = competitionKey(record),
+            incumbent = winners.get(key);
+
+        if (!incumbent) {
+            winners.set(key, record);
+            continue
+        }
+
+        if (record.sequence > incumbent.sequence) {
+            winners.set(key, record);
+            continue
+        }
+
+        // Equal watermark, different payload: the sink assigned one ordering position to two different
+        // intents, so neither can be shown to supersede the other. Refusing the newcomer keeps the
+        // materialization deterministic; picking either would make deployment state depend on read order.
+        if (record.sequence === incumbent.sequence
+            && JSON.stringify(record.values) !== JSON.stringify(incumbent.values)) {
+            refused.push({
+                record,
+                reason: LEDGER_REFUSALS.conflictingSequence,
+                detail: [`sequence ${record.sequence} already held by '${incumbent.prescriptionId}' with different values`]
+            });
+            continue
+        }
+
+        // Lower sequence, or an idempotent replay of the same payload. Both are non-events: a stale
+        // watermark completing late must not unwind a newer admitted prescription.
+        refused.push({
+            record,
+            reason: LEDGER_REFUSALS.conflictingSequence,
+            detail: [`superseded by sequence ${incumbent.sequence}`]
+        })
+    }
+
+    const
+        admitted      = [...winners.values()],
+        prescriptions = [];
+
+    for (const record of admitted) {
+        for (const {path, env} of knobEnvBindings(record.knob)) {
+            prescriptions.push({key: env, value: record.values[path]})
+        }
+    }
+
+    return {prescriptions, admitted, refused}
+}

--- a/ai/services/memory-core/helpers/recoveryKnobRegistry.mjs
+++ b/ai/services/memory-core/helpers/recoveryKnobRegistry.mjs
@@ -196,6 +196,23 @@ export function knobLeafPaths(knob) {
 }
 
 /**
+ * @summary The leaf→environment bindings a knob delivers through, resolved from the registry.
+ *
+ * **This exists so a consumer never has to take an env key from a record it was handed.** The renderer
+ * downstream accepts any uppercase identifier, so a record carrying its own `env` field would let a
+ * forged prescription for one knob write an arbitrary numeric config key. The binding is registry
+ * property, and this accessor is the only sanctioned way to learn it — same reason
+ * {@link knobRequiredContext} exists: adding or rebinding a leaf must not require editing the caller.
+ * @param {String} knob
+ * @returns {Array<{path: String, env: String}>} Empty for an unknown knob — gate on {@link isKnownKnob}.
+ */
+export function knobEnvBindings(knob) {
+    return isKnownKnob(knob)
+        ? RECOVERY_KNOBS[knob].leaves.map(leaf => ({path: leaf.path, env: leaf.env}))
+        : []
+}
+
+/**
  * @summary The leaf paths a caller must resolve and pass as `context` before a knob can be validated.
  *
  * These are leaves the knob does not change but is bounded by. Exposed so the actuator can resolve

--- a/test/playwright/unit/ai/services/memory-core/helpers/deploymentPrescriptionLedger.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/helpers/deploymentPrescriptionLedger.spec.mjs
@@ -1,0 +1,227 @@
+import {test, expect} from '@playwright/test';
+import fs             from 'node:fs';
+import os             from 'node:os';
+import path           from 'node:path';
+import {execFileSync} from 'node:child_process';
+
+import {
+    admitLedgerPrescriptions,
+    LEDGER_REFUSALS,
+    refuseLedgerRecord
+} from '../../../../../../../ai/services/memory-core/helpers/deploymentPrescriptionLedger.mjs';
+import {renderPrescribedEnvironment} from '../../../../../../../ai/services/memory-core/helpers/deploymentPrescriptionEnvironment.mjs';
+
+/**
+ * The three obligations were declared on the ticket BEFORE this file was written, so a green here means
+ * the thing that was asked for rather than whatever these tests happen to cover:
+ *
+ * 1. **Effect witness** — a ledger record changes what Compose CREATES the container with. Asserting
+ *    that a record was admitted would have passed against the original `reconfigure` no-op throughout.
+ * 2. **Counterfactual** — a record carrying a FORGED `env` field renders only the registry-derived key.
+ *    Without this arm the security boundary is a claim in a docblock.
+ * 3. **Ordering** — `sequence` decides supersession and `prescribedAt` does not, asserted with a record
+ *    whose clock is newer and whose watermark is older.
+ *
+ * `docker compose config` resolves interpolation with no reachable daemon, so the effect boundary is
+ * testable here. It runs against the REAL `ai/deploy/docker-compose.yml` via `--env-file` pointing at a
+ * temp file: a hand-written compose fixture could be looser than production and pass on an expression
+ * production does not use, and writing the real `ai/deploy/.env` would leave a window in which a peer's
+ * recreate picks up a test value.
+ */
+
+const
+    COMPOSE_RELATIVE = 'ai/deploy/docker-compose.yml',
+    KNOB             = 'container-memory-ceiling',
+    LEAF             = 'deploy.chroma.memoryCeilingBytes',
+    ENV_KEY          = 'NEO_CHROMA_MEMORY_LIMIT',
+    // Shaped from the LIVE target, not invented: the registry bounds this leaf to 8..16 GiB and the
+    // `raise-not-lower` invariant requires a value strictly above the container's live limit. 12 GiB
+    // clears both, and is not a default anywhere in the tree — so a pass cannot come from the baseline.
+    LIVE_LIMIT_BYTES = 8 * 1024 ** 3,
+    PROBE_BYTES      = 12 * 1024 ** 3;
+
+/**
+ * A record that is admissible on purpose, so each negative test can name the ONE field it breaks.
+ * @param {Object} [overrides]
+ * @returns {Object}
+ */
+function prescriptionRecord(overrides = {}) {
+    return {
+        recordType      : 'deployment-prescription',
+        prescriptionId  : 'PRESCRIPTION:base',
+        sequence        : 1,
+        knob            : KNOB,
+        targetIdentity  : {kind: 'compose-service', id: 'chroma'},
+        values          : {[LEAF]: PROBE_BYTES},
+        prescribedAt    : 1_000,
+        validatedAgainst: {
+            context: {'runtime.chroma.liveMemoryLimitBytes': LIVE_LIMIT_BYTES}
+        },
+        ...overrides
+    }
+}
+
+/**
+ * @returns {Boolean} whether `docker compose config` can run here
+ */
+function composeConfigAvailable() {
+    try {
+        execFileSync('docker', ['compose', 'version'], {stdio: 'ignore'});
+        return true
+    } catch {
+        return false
+    }
+}
+
+/**
+ * Resolves chroma's memory limit exactly as Compose would create it.
+ * @param {String} repoRoot
+ * @param {String|null} envFilePath
+ * @returns {String|null}
+ */
+function resolvedChromaMemory(repoRoot, envFilePath) {
+    const args = ['compose', '-f', path.join(repoRoot, COMPOSE_RELATIVE)];
+
+    envFilePath && args.push('--env-file', envFilePath);
+    args.push('config', '--format', 'json');
+
+    try {
+        const parsed = JSON.parse(execFileSync('docker', args, {encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore']}));
+
+        return parsed?.services?.chroma?.deploy?.resources?.limits?.memory ?? null
+    } catch {
+        return null
+    }
+}
+
+test.describe('the ledger admits against the registry, not against the record', () => {
+    test('a well-formed record is admitted and its env key comes from the REGISTRY', () => {
+        const {prescriptions, admitted, refused} = admitLedgerPrescriptions([prescriptionRecord()]);
+
+        expect(refused).toEqual([]);
+        expect(admitted).toHaveLength(1);
+        expect(prescriptions).toEqual([{key: ENV_KEY, value: PROBE_BYTES}])
+    });
+
+    test('OBLIGATION 2 — a forged `env` field renders NOTHING of its own', () => {
+        const {prescriptions} = admitLedgerPrescriptions([
+            prescriptionRecord({env: 'NEO_ORCHESTRATOR_HEAP_MB', leafPath: 'deploy.orchestrator.heapMb'})
+        ]);
+
+        // The forged key is absent and the registry key is present — both halves matter. Asserting only
+        // that the registry key appears would pass while the forged one was ALSO written.
+        expect(prescriptions.map(entry => entry.key)).toEqual([ENV_KEY]);
+        expect(renderPrescribedEnvironment(prescriptions).content).not.toContain('NEO_ORCHESTRATOR_HEAP_MB')
+    });
+
+    test('a record aiming a knob at a service the registry does not give it is refused', () => {
+        const refusal = refuseLedgerRecord(prescriptionRecord({targetIdentity: {kind: 'compose-service', id: 'kb-server'}}));
+
+        expect(refusal?.reason).toBe(LEDGER_REFUSALS.targetMismatch)
+    });
+
+    test('an unknown knob is refused rather than rendered', () => {
+        expect(refuseLedgerRecord(prescriptionRecord({knob: 'not-a-knob'}))?.reason).toBe(LEDGER_REFUSALS.unknownKnob)
+    });
+
+    test('the producer\'s validation is re-run, not trusted — an out-of-bounds value is refused', () => {
+        const refusal = refuseLedgerRecord(prescriptionRecord({values: {[LEAF]: 64 * 1024 ** 3}}));
+
+        expect(refusal?.reason).toBe(LEDGER_REFUSALS.invalidTransaction);
+        expect(refusal.detail.join(' ')).toContain(LEAF)
+    });
+
+    test('a record whose context no longer bounds it is refused, not skipped', () => {
+        const refusal = refuseLedgerRecord(prescriptionRecord({validatedAgainst: {context: {}}}));
+
+        expect(refusal?.reason).toBe(LEDGER_REFUSALS.invalidTransaction);
+        expect(refusal.detail.join(' ')).toContain('runtime.chroma.liveMemoryLimitBytes')
+    });
+
+    test('raise-not-lower is enforced HERE — a value at the live limit is refused', () => {
+        const refusal = refuseLedgerRecord(prescriptionRecord({values: {[LEAF]: LIVE_LIMIT_BYTES}}));
+
+        expect(refusal?.reason).toBe(LEDGER_REFUSALS.invalidTransaction)
+    });
+});
+
+test.describe('OBLIGATION 3 — sequence orders supersession; prescribedAt does not', () => {
+    test('a higher sequence supersedes, whatever order the records are read in', () => {
+        const records = [
+            prescriptionRecord({prescriptionId: 'P:old', sequence: 1, values: {[LEAF]: 10 * 1024 ** 3}}),
+            prescriptionRecord({prescriptionId: 'P:new', sequence: 2, values: {[LEAF]: PROBE_BYTES}})
+        ];
+
+        expect(admitLedgerPrescriptions(records).prescriptions).toEqual([{key: ENV_KEY, value: PROBE_BYTES}]);
+        // Reversed read order must not change the outcome, or arrival order is the real authority.
+        expect(admitLedgerPrescriptions([...records].reverse()).prescriptions).toEqual([{key: ENV_KEY, value: PROBE_BYTES}])
+    });
+
+    test('a NEWER prescribedAt with an OLDER sequence loses — the clock is not the authority', () => {
+        const {prescriptions, refused} = admitLedgerPrescriptions([
+            prescriptionRecord({prescriptionId: 'P:winner', sequence: 9, prescribedAt: 1, values: {[LEAF]: PROBE_BYTES}}),
+            prescriptionRecord({prescriptionId: 'P:latecomer', sequence: 2, prescribedAt: 9_999_999, values: {[LEAF]: 16 * 1024 ** 3}})
+        ]);
+
+        expect(prescriptions).toEqual([{key: ENV_KEY, value: PROBE_BYTES}]);
+        expect(refused[0]?.reason).toBe(LEDGER_REFUSALS.conflictingSequence)
+    });
+
+    test('one watermark holding two different payloads is a conflict, not a coin flip', () => {
+        const {refused} = admitLedgerPrescriptions([
+            prescriptionRecord({prescriptionId: 'P:a', sequence: 5, values: {[LEAF]: 10 * 1024 ** 3}}),
+            prescriptionRecord({prescriptionId: 'P:b', sequence: 5, values: {[LEAF]: PROBE_BYTES}})
+        ]);
+
+        expect(refused).toHaveLength(1);
+        expect(refused[0].detail.join(' ')).toContain('different values')
+    });
+
+    test('an unordered record cannot be folded at all', () => {
+        expect(refuseLedgerRecord(prescriptionRecord({sequence: undefined}))?.reason).toBe(LEDGER_REFUSALS.unorderable);
+        expect(refuseLedgerRecord(prescriptionRecord({sequence: 1.5}))?.reason).toBe(LEDGER_REFUSALS.unorderable)
+    });
+});
+
+test.describe('OBLIGATION 1 — the effect witness', () => {
+    test('a ledger record changes what Compose CREATES the container with', () => {
+        test.skip(!composeConfigAvailable(), 'docker compose CLI unavailable');
+
+        const
+            repoRoot = process.cwd(),
+            envPath  = path.join(fs.mkdtempSync(path.join(os.tmpdir(), 'neo-prescription-')), 'prescribed.env'),
+            baseline = resolvedChromaMemory(repoRoot, null);
+
+        // The control: without the prescription the field resolves to the compose default. A witness
+        // whose baseline already equals the probe proves nothing about delivery.
+        expect(baseline, 'the compose default resolves before any prescription').not.toBe(String(PROBE_BYTES));
+
+        const {prescriptions} = admitLedgerPrescriptions([prescriptionRecord()]),
+              {content}       = renderPrescribedEnvironment(prescriptions);
+
+        fs.writeFileSync(envPath, content);
+
+        expect(resolvedChromaMemory(repoRoot, envPath), 'the ledger record reaches the created container')
+            .toBe(String(PROBE_BYTES))
+    });
+
+    test('a REFUSED record reaches nothing — the same file renders the default', () => {
+        test.skip(!composeConfigAvailable(), 'docker compose CLI unavailable');
+
+        const
+            repoRoot = process.cwd(),
+            envPath  = path.join(fs.mkdtempSync(path.join(os.tmpdir(), 'neo-prescription-')), 'prescribed.env'),
+            // Same value, same knob, aimed at a service the registry does not give this knob.
+            {prescriptions} = admitLedgerPrescriptions([
+                prescriptionRecord({targetIdentity: {kind: 'compose-service', id: 'kb-server'}})
+            ]);
+
+        expect(prescriptions).toEqual([]);
+
+        fs.writeFileSync(envPath, renderPrescribedEnvironment(prescriptions).content);
+
+        // The negative arm of the SAME instrument that showed delivery, so a pass above cannot be an
+        // artifact of the harness resolving the probe value by some other route.
+        expect(resolvedChromaMemory(repoRoot, envPath)).toBe(resolvedChromaMemory(repoRoot, null))
+    });
+});


### PR DESCRIPTION
Resolves neomjs/neo#16857
Related: neomjs/neo-agent-brain#55

The merged prescription renderer had no production caller. This is the ledger **read side**: it admits records against the registry and hands the renderer an active set.

**Admission is computed, never accepted.** A record arrives having been validated once, by a producer, against a context that has since moved. Rendering it on that strength would make the ledger the security boundary — and the ledger is a file. So every record is revalidated against the *current* registry: the knob must still exist, still address the target it names, still bound the values it carries.

Evidence: residual-live not required — this slice returns content and grants no privilege. The effect boundary is exercised at L2-plus: `docker compose config` resolves interpolation against the **real** `ai/deploy/docker-compose.yml`, so the witness runs on the production expression rather than a fixture's imitation of it.

## Deltas

- **`recoveryKnobRegistry.mjs`** — adds `knobEnvBindings(knob)`, the sanctioned way to learn a leaf→env binding. It exists so a consumer never takes an env key from a record it was handed: `refusePrescription` accepts any uppercase identifier with a positive finite value, so a record allowed to name its own `env` would turn a bounded ceiling into an arbitrary numeric config mutation — the knob abstraction bypassed by one extra field. Mirrors `knobRequiredContext()`, so a rebinding propagates with no caller edit.
- **`deploymentPrescriptionLedger.mjs`** (new) — `refuseLedgerRecord()` returns a named reason or `null`; `admitLedgerPrescriptions()` folds admitted records into `{prescriptions, admitted, refused}`. Refusals are reported, never dropped: a caller that ignored them would ship a materialization quietly narrower than the ledger it claims to represent.
- **Ordering is `sequence`, never `prescribedAt`.** `prescribedAt` is written by whoever produced the record; letting it order deployment state lets a wrong clock choose which ceiling is live. Equal watermark with differing payloads is a **conflict** rather than a coin flip, so materialization cannot depend on read order.
- **No I/O, no actuator reach.** Pure functions in the same directory as the renderer and the registry they consume. The atomic file materialization and the actuator boundary stay on the parent.

## Test Evidence

**76 passed** — the new spec plus every importer spec found by grepping the changed basenames, not just the file I wrote:

```
deploymentPrescriptionLedger.spec.mjs      (new, 13 tests)
deploymentPrescriptionEnvironment.spec.mjs (importer, unchanged)
recoveryKnobRegistry.spec.mjs              (importer, unchanged)
DeploymentRuntimeAccessService.spec.mjs    (importer, unchanged)
```

`check-jsdoc-types`: 1988 files scanned, 0 unparseable type expressions.

**MUTATION-CONVICTED at both boundaries**, because a green here would otherwise be indistinguishable from a fold that never ran — the exact defect this PR exists to repair one layer up:

| mutation | result |
|---|---|
| `key: record.env ?? env` — read the record instead of the registry | forged-env test goes **RED** |
| `record.prescribedAt > incumbent.prescribedAt` — order on the clock | **two** ordering tests go RED, including read-order invariance |

**The effect witness and its controls.** It runs against the real compose via `--env-file` pointing at a temp file — a hand-written compose fixture could be looser than production and pass on an expression production does not use, and writing `ai/deploy/.env` would leave a window in which a peer's recreate picks up a test value. Two controls: a baseline arm asserting the compose default differs from the probe (a witness whose baseline already equals the probe proves nothing), and a negative arm rendering a **refused** record through the same instrument and asserting the compose default — so delivery cannot be a harness artifact.

**The fixture is shaped from the live target, not invented.** The registry bounds this leaf to 8–16 GiB and `raise-not-lower` requires a value strictly above the container's live limit, which `docker inspect` reports as exactly 8 GiB. 12 GiB clears both and is no default in the tree. Had the live limit been 16 GiB the admissible set would have been **empty** — the same trap that killed the two heap descriptors on the parent, which is why the bound was read rather than assumed.

## Post-Merge Validation

- On the parent neomjs/neo-agent-brain#55: AC-4 (*prescription proven to reach an effect*) and AC-5 (*negative control*) are discharged by this slice. AC-1, AC-2 and AC-6 remain open there and are **not** claimed here.
- Next slice, on the parent: the trusted append ingress — compare-and-append per `{targetIdentity, knob}`, sink-stamped `producerPrincipal`, forged-producer rejection — following the `hookProjectionSubmission` producer fence.
- Not verifiable pre-merge and deliberately unclaimed: no live plane exercises this path yet, because nothing produces ledger records. The first end-to-end reading belongs to the append ingress, not here — and a receipt claimed now would be the "recorded a prescription equals delivery" trap the parent's Avoided Traps section names.

## Reviewer notes

Cross-family reviewer needed (§6.1): I am claude-family, so this needs gpt / kimi / gemini eyes.

The two places I would push on hardest if I were reviewing: whether `competitionKey()` is the right supersession scope (per `{knob, target}` rather than global — two knobs on one service are independent, but I would want that challenged), and whether refusing on equal-watermark-differing-payload is the right disposition versus admitting the lower `prescriptionId` deterministically. I chose refusal because a sink that assigned one position to two intents has a defect that should surface, not be smoothed over.

Authored by @neo-opus-vega 🌿
