### PR TITLE
EMPTY_MATERIALIZATION means both "rows landed" and "nothing arrived"

### DIFF
--- a/ai/daemons/orchestrator/services/TenantRepoSyncErrors.mjs
+++ b/ai/daemons/orchestrator/services/TenantRepoSyncErrors.mjs
@@ -21,8 +21,16 @@ export const KB_TENANT_REPO_SYNC_CONCURRENCY_GATE_TIMEOUT = 'KB_TENANT_REPO_SYNC
 export const KB_TENANT_REPO_SYNC_EMPTY_MATERIALIZATION = 'KB_TENANT_REPO_SYNC_EMPTY_MATERIALIZATION';
 // The OTHER half of what `EMPTY_MATERIALIZATION` used to carry, and the opposite instruction.
 // A full materialization DID take effect — rows were ingested or deleted — but no receipt proves
-// this attempt, so the ingest is real and its proof is missing. Observed live with
-// `ingested=50, embeddings=50, errors=0` and no receipt.
+// this attempt, so the ingest is real and its proof is missing.
+//
+// **This arm is defence-in-depth, not a reproduction of a known incident, and the distinction is
+// load-bearing.** `persistManifestSnapshot` mints a fresh matching receipt for any valid
+// positive-effect attempt and reuses a prior one only when its digest already matches, so no current
+// producer path is known to deliver effect-plus-unmatched-proof. It is a genuine logical case of this
+// guard's own predicate and a state the guard must refuse if it ever arises — which is a different
+// and weaker warrant than "we have seen this". An earlier revision of this comment cited the live
+// `ingested=50, embeddings=50, errors=0` observation here; that incident had **no receipt at all**
+// rather than a mismatched one, so it belongs to the `EMPTY_MATERIALIZATION` side of the split.
 //
 // It is a separate CODE rather than a field on the existing one because the per-repo durable state
 // persists `lastErrorCode` and nothing else — there is no `lastErrorDetails` anywhere in `ai/`, so a

--- a/ai/daemons/orchestrator/services/TenantRepoSyncErrors.mjs
+++ b/ai/daemons/orchestrator/services/TenantRepoSyncErrors.mjs
@@ -19,6 +19,20 @@ export const KB_TENANT_REPO_SYNC_TENANT_NOT_FOUND       = 'KB_TENANT_REPO_SYNC_T
 export const KB_TENANT_REPO_SYNC_MANIFEST_UPDATE_FAILED = 'KB_TENANT_REPO_SYNC_MANIFEST_UPDATE_FAILED';
 export const KB_TENANT_REPO_SYNC_CONCURRENCY_GATE_TIMEOUT = 'KB_TENANT_REPO_SYNC_CONCURRENCY_GATE_TIMEOUT';
 export const KB_TENANT_REPO_SYNC_EMPTY_MATERIALIZATION = 'KB_TENANT_REPO_SYNC_EMPTY_MATERIALIZATION';
+// The OTHER half of what `EMPTY_MATERIALIZATION` used to carry, and the opposite instruction.
+// A full materialization DID take effect — rows were ingested or deleted — but no receipt proves
+// this attempt, so the ingest is real and its proof is missing. Observed live with
+// `ingested=50, embeddings=50, errors=0` and no receipt.
+//
+// It is a separate CODE rather than a field on the existing one because the per-repo durable state
+// persists `lastErrorCode` and nothing else — there is no `lastErrorDetails` anywhere in `ai/`, so a
+// discriminator carried in `details` would be dropped at the persistence boundary and never reach the
+// operator it exists for. A code is the only channel that survives.
+//
+// The distinction is not cosmetic: this arm means DO NOT re-ingest — the data landed and re-running
+// risks duplicating it — while `EMPTY_MATERIALIZATION` means nothing arrived and the embed stage is
+// where to look. One code for both told an operator the opposite of what happened half the time.
+export const KB_TENANT_REPO_SYNC_MATERIALIZATION_UNPROVEN = 'KB_TENANT_REPO_SYNC_MATERIALIZATION_UNPROVEN';
 // Non-failure defer reason: another process holds the cross-process tenant-repo-sync
 // lease. Surfaced as a `skipped` reasonCode (never thrown) so the periodic lane and
 // the manual CLI can branch on it without treating operator ownership as an error.
@@ -52,6 +66,7 @@ export const TENANT_REPO_SYNC_ERROR_CODES = Object.freeze([
     KB_TENANT_REPO_SYNC_MANIFEST_UPDATE_FAILED,
     KB_TENANT_REPO_SYNC_CONCURRENCY_GATE_TIMEOUT,
     KB_TENANT_REPO_SYNC_EMPTY_MATERIALIZATION,
+    KB_TENANT_REPO_SYNC_MATERIALIZATION_UNPROVEN,
     KB_TENANT_REPO_SYNC_LEASE_HELD,
     KB_TENANT_REPO_SYNC_LEASE_LOST,
     KB_TENANT_REPO_SYNC_STARVED

--- a/ai/daemons/orchestrator/services/TenantRepoSyncService.mjs
+++ b/ai/daemons/orchestrator/services/TenantRepoSyncService.mjs
@@ -43,6 +43,7 @@ import {
 } from '../scheduling/tenantRepoSync.mjs';
 import {
     KB_TENANT_REPO_SYNC_EMPTY_MATERIALIZATION,
+    KB_TENANT_REPO_SYNC_MATERIALIZATION_UNPROVEN,
     KB_TENANT_REPO_SYNC_SYNC_FAILED,
     KB_TENANT_REPO_SYNC_LEASE_HELD,
     KB_TENANT_REPO_SYNC_LEASE_LOST,
@@ -497,11 +498,41 @@ function assertFullMaterializationEffect(envelope, summary, priorState, material
             && receipt.attemptId !== materializationAttempt?.attemptId
             && receipt.attemptId !== priorState?.lastCommittedMaterializationAttemptId;
 
-    if ((hasEffect && !provesCurrentAttempt) || (!hasEffect && !provesUncommittedRetry)) {
+    // These two arms are OPPOSITE findings and they used to share one code and one message. The
+    // message described the second arm, so an operator hitting the first was told the reverse of
+    // what happened — observed live with `ingested=50, embeddings=50, errors=0` and no receipt.
+    //
+    // They are separate CODES rather than one code plus a discriminating field because the durable
+    // per-repo state persists `lastErrorCode` alone; there is no `lastErrorDetails` in `ai/`, so a
+    // field would be dropped at the persistence boundary and reach nobody. `details` is still
+    // populated for a log reader, but the code is what has to carry the distinction.
+    if (hasEffect && !provesCurrentAttempt) {
+        throw new TenantRepoSyncError(
+            KB_TENANT_REPO_SYNC_MATERIALIZATION_UNPROVEN,
+            'Tenant-repo full materialization took effect but no receipt proves this attempt.',
+            {
+                phase               : 'full-materialization',
+                // Counts and booleans only — no paths, filenames, or repo content, matching the
+                // credential discipline already applied to ingestion error messages.
+                ingested            : summary.ingested,
+                deleted             : summary.deleted,
+                receiptPresent      : Boolean(receipt),
+                receiptMatchesDigest: validReceipt
+            }
+        )
+    }
+
+    if (!hasEffect && !provesUncommittedRetry) {
         throw new TenantRepoSyncError(
             KB_TENANT_REPO_SYNC_EMPTY_MATERIALIZATION,
             'Tenant-repo full materialization produced no durable positive-effect proof.',
-            {phase: 'full-materialization'}
+            {
+                phase               : 'full-materialization',
+                ingested            : summary.ingested,
+                deleted             : summary.deleted,
+                receiptPresent      : Boolean(receipt),
+                receiptMatchesDigest: validReceipt
+            }
         )
     }
 
@@ -1059,7 +1090,8 @@ class TenantRepoSyncService extends Base {
      * | Code | Surface | Trigger |
      * |---|---|---|
      * | `KB_TENANT_REPO_SYNC_SYNC_FAILED` | per-repo `lastErrorCode` | underlying clone/fetch/envelope/ingest failure (wraps the original error) |
-     * | `KB_TENANT_REPO_SYNC_EMPTY_MATERIALIZATION` | per-repo `lastErrorCode` | full materialization lacks a fresh positive effect or matching unacknowledged retry receipt |
+     * | `KB_TENANT_REPO_SYNC_EMPTY_MATERIALIZATION` | per-repo `lastErrorCode` | full materialization produced NO positive effect and no matching unacknowledged retry receipt — nothing arrived; look at the embed stage |
+     * | `KB_TENANT_REPO_SYNC_MATERIALIZATION_UNPROVEN` | per-repo `lastErrorCode` | full materialization DID take effect, but no receipt proves this attempt — the rows landed and the proof is missing, so do NOT re-ingest |
      * | `KB_TENANT_REPO_SYNC_REPO_NOT_CONFIGURED` | outer `details.reasonCode` | `onlyRepoSlugs` filter requested a slug that is not in `tenantRepos[]` |
      * | `KB_TENANT_REPO_SYNC_MANIFEST_UPDATE_FAILED` | outer `details.reasonCode` | `tenant-repo-sync-revisions.json` write failure (next cycle settles the unacknowledged graph receipt idempotently) |
      * | `KB_TENANT_REPO_SYNC_TENANT_NOT_FOUND` | reserved | future `--tenant-id` CLI flag; no current emitter |

--- a/ai/daemons/orchestrator/services/TenantRepoSyncService.mjs
+++ b/ai/daemons/orchestrator/services/TenantRepoSyncService.mjs
@@ -499,8 +499,17 @@ function assertFullMaterializationEffect(envelope, summary, priorState, material
             && receipt.attemptId !== priorState?.lastCommittedMaterializationAttemptId;
 
     // These two arms are OPPOSITE findings and they used to share one code and one message. The
-    // message described the second arm, so an operator hitting the first was told the reverse of
-    // what happened — observed live with `ingested=50, embeddings=50, errors=0` and no receipt.
+    // message described the second arm, so an operator hitting the first would be told the reverse of
+    // what happened.
+    //
+    // **Asymmetric warrant, stated because it governs how much this is worth trusting.** The
+    // zero-effect arm below is the observed one — `ingested=0` with no committed proof is what the
+    // live `ingested=50, embeddings=50, errors=0`-with-no-receipt report reduces to once you notice
+    // the receipt was ABSENT rather than mismatched. The effect-bearing arm above is
+    // defence-in-depth: no known producer path delivers effect-plus-unmatched-proof, because
+    // `persistManifestSnapshot` mints a matching receipt on positive effect and reuses a prior one
+    // only on a digest match. It is refused here because a fail-closed guard must refuse it, not
+    // because it has been seen.
     //
     // They are separate CODES rather than one code plus a discriminating field because the durable
     // per-repo state persists `lastErrorCode` alone; there is no `lastErrorDetails` in `ai/`, so a

--- a/test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncErrors.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncErrors.spec.mjs
@@ -8,6 +8,7 @@ import {
     KB_TENANT_REPO_SYNC_MANIFEST_UPDATE_FAILED,
     KB_TENANT_REPO_SYNC_CONCURRENCY_GATE_TIMEOUT,
     KB_TENANT_REPO_SYNC_EMPTY_MATERIALIZATION,
+    KB_TENANT_REPO_SYNC_MATERIALIZATION_UNPROVEN,
     KB_TENANT_REPO_SYNC_STARVED,
     TENANT_REPO_SYNC_ERROR_CODES,
     TenantRepoSyncError,
@@ -34,7 +35,7 @@ test.describe('TenantRepoSyncErrors taxonomy (#11942 AC3+AC4)', () => {
 
     test('TENANT_REPO_SYNC_ERROR_CODES array contains exactly the exported codes', () => {
         expect(Array.isArray(TENANT_REPO_SYNC_ERROR_CODES)).toBe(true);
-        expect(TENANT_REPO_SYNC_ERROR_CODES.length).toBe(9);
+        expect(TENANT_REPO_SYNC_ERROR_CODES.length).toBe(10);
         expect(TENANT_REPO_SYNC_ERROR_CODES).toContain(KB_TENANT_REPO_SYNC_SYNC_FAILED);
         expect(TENANT_REPO_SYNC_ERROR_CODES).toContain(KB_TENANT_REPO_SYNC_LEASE_HELD);
         expect(TENANT_REPO_SYNC_ERROR_CODES).toContain(KB_TENANT_REPO_SYNC_LEASE_LOST);
@@ -43,6 +44,9 @@ test.describe('TenantRepoSyncErrors taxonomy (#11942 AC3+AC4)', () => {
         expect(TENANT_REPO_SYNC_ERROR_CODES).toContain(KB_TENANT_REPO_SYNC_MANIFEST_UPDATE_FAILED);
         expect(TENANT_REPO_SYNC_ERROR_CODES).toContain(KB_TENANT_REPO_SYNC_CONCURRENCY_GATE_TIMEOUT);
         expect(TENANT_REPO_SYNC_ERROR_CODES).toContain(KB_TENANT_REPO_SYNC_EMPTY_MATERIALIZATION);
+        // The effect-bearing sibling. Bumping the count alone would let a new code pass the guard
+        // without ever being named — the count is a tripwire, membership is the actual assertion.
+        expect(TENANT_REPO_SYNC_ERROR_CODES).toContain(KB_TENANT_REPO_SYNC_MATERIALIZATION_UNPROVEN);
         expect(TENANT_REPO_SYNC_ERROR_CODES).toContain(KB_TENANT_REPO_SYNC_STARVED);
     });
 
@@ -55,7 +59,7 @@ test.describe('TenantRepoSyncErrors taxonomy (#11942 AC3+AC4)', () => {
         expect(() => TENANT_REPO_SYNC_ERROR_CODES.push('KB_TENANT_REPO_SYNC_MUTATED')).toThrow(TypeError);
         expect(() => { TENANT_REPO_SYNC_ERROR_CODES[TENANT_REPO_SYNC_ERROR_CODES.length] = 'KB_TENANT_REPO_SYNC_MUTATED'; }).toThrow(TypeError);
         expect(() => { TENANT_REPO_SYNC_ERROR_CODES.length = 0; }).toThrow(TypeError);
-        expect(TENANT_REPO_SYNC_ERROR_CODES.length).toBe(9);
+        expect(TENANT_REPO_SYNC_ERROR_CODES.length).toBe(10);
         expect(TENANT_REPO_SYNC_ERROR_CODES).not.toContain('KB_TENANT_REPO_SYNC_MUTATED');
         expect(isTenantRepoSyncErrorCode('KB_TENANT_REPO_SYNC_MUTATED')).toBe(false);
     });

--- a/test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncService.spec.mjs
@@ -1251,6 +1251,88 @@ test.describe('TenantRepoSyncService (#11790)', () => {
         });
     });
 
+    // The arm above is zero-effect and keeps the original code. This is its OPPOSITE, and the two
+    // used to be indistinguishable: one code, one message, and the message described the zero-effect
+    // case — so an operator whose rows had actually landed was told the reverse of what happened.
+    //
+    // The two demand opposite responses, which is why a shared code is not a cosmetic problem:
+    // UNPROVEN means the data is in and the proof is missing, so DO NOT re-ingest; EMPTY means
+    // nothing arrived and the embed stage is where to look.
+    test('an effect WITHOUT proof is a distinct code from an empty materialization', async () => {
+        const
+            taskStateService = createInMemoryTaskStateService(),
+            repoSlug         = 'org/effect-without-receipt';
+
+        await provisionMirrorDir({tenantId: 't1', repoSlug});
+
+        const result = await TenantRepoSyncService.runTask({
+            reason           : 'manual',
+            taskStateService,
+            tenantReposConfig: {tenantRepos: [{
+                tenantId: 't1', repoSlug, mirrorRoot, cloneUrl: 'https://example.invalid/effect.git'
+            }]},
+            gitMirror      : makeFakeGitMirror(),
+            envelopeBuilder: async args => ({
+                tenantId        : args.tenantId,
+                repoSlug        : args.repoSlug,
+                files           : [{sourcePath: 'README.md', repoSlug: args.repoSlug, content: 'source'}],
+                headRevision    : 'sha-effect-no-receipt',
+                manifestSnapshot: {
+                    repoSlug      : args.repoSlug,
+                    pathsAfterPush: ['README.md']
+                }
+            }),
+            // Deliberately NOT `makeFakeIngestionService`: that fake mints a receipt whenever an
+            // attempt is present and the effect is non-zero, which is faithful to production —
+            // `persistManifestSnapshot` does the same. So effect-with-no-receipt-at-all is not a
+            // reachable steady state, and a fixture asserting it would be testing a shape production
+            // cannot produce.
+            //
+            // The reachable shape is a receipt that EXISTS and does not prove this envelope: a
+            // digest mismatch, which is one of the documented reasons production skips receipt
+            // creation. `validReceipt` is false, so `provesCurrentAttempt` is false while the ingest
+            // really happened.
+            knowledgeBaseIngestionService: {
+                async getTenantManifest({tenantId, repoSlug}) {
+                    return {tenantId, repoSlug, materializationReceipt: null}
+                },
+                async ingestSourceFiles(payload) {
+                    return {
+                        ingested              : 50,
+                        deleted               : 0,
+                        embeddingsGenerated   : 50,
+                        errors                : [],
+                        tenantId              : payload.tenantId,
+                        durationMs            : 1,
+                        materializationReceipt: {
+                            ...payload.materializationAttempt,
+                            envelopeDigest: 'sha256:deliberately-not-this-envelopes-digest',
+                            recordedAt    : Date.now()
+                        }
+                    }
+                }
+            },
+            onlyRepoSlugs    : [repoSlug],
+            revisionsFilePath: revisionsFile,
+            seedBootstrap    : false
+        });
+
+        expect(result).toMatchObject({
+            status : 'failed',
+            details: {
+                completedCount: 0,
+                failedCount   : 1,
+                repos         : [{
+                    lastErrorCode: 'KB_TENANT_REPO_SYNC_MATERIALIZATION_UNPROVEN'
+                }]
+            }
+        });
+
+        // The negative half, and it is the one that would rot silently: if a future edit collapsed the
+        // branch back to one code, THIS assertion fails while the arm above still passes.
+        expect(result.details.repos[0].lastErrorCode).not.toBe('KB_TENANT_REPO_SYNC_EMPTY_MATERIALIZATION');
+    });
+
     test('full delete-only reconciliation remains a successful checkpoint effect (#16045)', async () => {
         const
             taskStateService = createInMemoryTaskStateService(),

--- a/test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncService.spec.mjs
@@ -1258,7 +1258,7 @@ test.describe('TenantRepoSyncService (#11790)', () => {
     // The two demand opposite responses, which is why a shared code is not a cosmetic problem:
     // UNPROVEN means the data is in and the proof is missing, so DO NOT re-ingest; EMPTY means
     // nothing arrived and the embed stage is where to look.
-    test('an effect WITHOUT proof is a distinct code from an empty materialization', async () => {
+    test('INVARIANT BREACH — effect with unmatched proof is refused under its OWN code, not the empty one', async () => {
         const
             taskStateService = createInMemoryTaskStateService(),
             repoSlug         = 'org/effect-without-receipt';
@@ -1288,10 +1288,19 @@ test.describe('TenantRepoSyncService (#11790)', () => {
             // reachable steady state, and a fixture asserting it would be testing a shape production
             // cannot produce.
             //
-            // The reachable shape is a receipt that EXISTS and does not prove this envelope: a
-            // digest mismatch, which is one of the documented reasons production skips receipt
-            // creation. `validReceipt` is false, so `provesCurrentAttempt` is false while the ingest
-            // really happened.
+            // **So this double is an explicit INVARIANT-BREACH INJECTION, not a reachable
+            // production shape, and it must be read that way.** It hands the guard a receipt that
+            // exists and does not match this envelope's digest — a state no known producer path
+            // delivers, because `persistManifestSnapshot` mints a matching receipt on positive effect
+            // and reuses a prior one only when its digest already matches.
+            //
+            // An earlier revision of this comment called it "the reachable shape … one of the
+            // documented reasons production skips receipt creation." That was wrong: those reasons
+            // leave the receipt NULL, never mismatched, and @neo-gpt-emmy's exact-head read of the
+            // producer contract closed the route. The test therefore proves the GUARD refuses an
+            // invariant breach; it does not prove the breach occurs. Replace this double with the real
+            // producer and the mismatch disappears — which is the honest statement of its scope, and
+            // the reason a green here cannot be cited as evidence of a live failure mode.
             knowledgeBaseIngestionService: {
                 async getTenantManifest({tenantId, repoSlug}) {
                     return {tenantId, repoSlug, materializationReceipt: null}


### PR DESCRIPTION
Resolves neomjs/neo#16863
Related: neomjs/neo-agent-brain#64, neomjs/neo#16577

`assertFullMaterializationEffect` guarded on a **disjunction of two opposite findings** and raised one code with one message. The message described the zero-effect arm, so an operator hitting the other one would be told the reverse of what happened.

| arm | what happened | correct response | warrant |
|---|---|---|---|
| `!hasEffect && !provesUncommittedRetry` | nothing ingested or deleted | look at the **embed** stage | **observed** — this is what the live `ingested=50, embeddings=50, errors=0`-with-no-receipt report reduces to, once you notice the receipt was ABSENT |
| `hasEffect && !provesCurrentAttempt` | rows landed; no receipt proves this attempt | **do not re-ingest** | **defence-in-depth** — see below |

Evidence: L2 — reporting-only, no runtime privilege and no plane state. Asserted through the real `TenantRepoSyncService.runTask` seam, not against a stub of the function under test.

## ⚠️ The warrant on the second arm, corrected before merge

An earlier revision of this body claimed the effect-bearing arm reproduced the live incident. **It does not.** That incident had **no receipt at all**, not a mismatched one, so it belongs to the zero-effect arm.

And **no known producer path delivers effect-plus-unmatched-proof**: `persistManifestSnapshot` mints a fresh matching receipt for any valid positive-effect attempt, and reuses a prior receipt only when its digest already matches. `createTenantRepoMaterializationDigest` normalizes internally, so the two call sites agree despite digesting different objects.

So that arm lands as **defence-in-depth on a fail-closed guard's own predicate** — refused because such a guard must refuse it, not because it has been seen. That is a weaker and different warrant, and it is now what the code, the spec, the test name and the ticket all say.

**How it was found:** @neo-opus-grace published *"when a test replaces a boundary, ask what that boundary REFUSES — a permissive double removes an invariant, and every assertion downstream is a property of the double."* I pointed it at my own fixture and it closed both routes I had assumed open. @neo-gpt-emmy's exact-head read of the producer contract confirmed it independently. I disclosed it 26 seconds after her approval landed, which is why that approval was superseded by a bounded RC — the correct outcome.

**The transferable half:** an **empty admissible set can hide in the fixture**, not only in a bounds predicate. Same critique that terminated neomjs/neo#16858 this morning; I missed it twice because I was looking for it in code.

## Deltas

- **`TenantRepoSyncErrors.mjs`** — adds `KB_TENANT_REPO_SYNC_MATERIALIZATION_UNPROVEN` (declaration + `TENANT_REPO_SYNC_ERROR_CODES`, 9 → 10). Its comment now states the defence-in-depth warrant and records the retired incident claim **as retired**.
- **`TenantRepoSyncService.mjs`** — the guard becomes two `throw`s, each carrying `ingested`, `deleted`, `receiptPresent`, `receiptMatchesDigest` — counts and booleans only, matching the credential discipline already applied to ingestion errors. The guard comment states the **asymmetric** warrant explicitly.
- **`EMPTY_MATERIALIZATION` retained on the zero-effect arm**, the one its existing message was already accurate for, so no current consumer changes meaning underneath it.
- **Error table gains a row** rather than widening the existing description.
- **Spec** — the inline double is named an **invariant-breach injection**, with the retired "reachable shape" claim recorded as retired. The test name no longer overclaims.

**Why two codes and not a `reason` field:** `grep -rn "lastErrorDetails\|lastErrorReason\|lastErrorMessage" ai/` returns **nothing**. The durable per-repo state persists `lastErrorCode` alone, so a discriminator in `details` dies at the persistence boundary. Verified before choosing the shape.

## Test Evidence

**124 passed** — `TenantRepoSyncService.spec.mjs` + `TenantRepoSyncErrors.spec.mjs`. Earlier full sweep across all six specs importing the changed modules: **214 passed**.

The **116 pre-existing `TenantRepoSyncService` specs pass unchanged**, which is itself the proof that no already-covered case is silently reclassified — every existing `EMPTY_MATERIALIZATION` fixture exercises the zero-effect arm and keeps the old code.

**Mutation-convicted:** collapsing the split back to one code reddens the effect-bearing test while the zero-effect test still passes, so the two do not co-assert. The taxonomy guard gained the new code **by name**, not only a bumped `length`.

**What the green does NOT prove**, stated because it is the whole point of the correction above: the effect-bearing test proves the **guard refuses an invariant breach**. It does not prove the breach occurs. Replace the inline double with the real producer and the mismatch disappears.

## Post-Merge Validation

- On neomjs/neo-agent-brain#64: **AC-5 discharged.** AC-1 (scheduling fairness / REM starvation) and AC-6 remain open there and are **not** claimed here.
- On neomjs/neo#16577: **AC-4 only.** Its AC-1 — a genuinely zero-chunk materialization still fails and backs off forever — is **untouched**; the split makes the diagnosis correct, not the behaviour. Recorded on that ticket so nobody reads this as fixing the trap.
- No live reading of either code yet. The first belongs to a tenant ingest on the rebuilt plane (`70d45b161b`), and I claim no residual-live evidence.
- No plane state changes on merge; the orchestrator picks the new code up on its next restart.

Authored by @neo-opus-vega 🌿
