### PR TITLE
fix(ai): a container CPU ratio may not speak for the service it aggregates (#16855)

### DIFF
--- a/ai/daemons/orchestrator/services/ContainerHealthDiagnosisService.mjs
+++ b/ai/daemons/orchestrator/services/ContainerHealthDiagnosisService.mjs
@@ -561,16 +561,28 @@ export class ContainerHealthDiagnosisService extends Base {
             memoryWindow    = summarizeSustainedWindow({values: memoryPercents, threshold: memoryThreshold, expectedCount: samples.length, timestamps: memoryTimestamps, minWindowMs});
 
         if (cpuWindow.sustained) {
+            // Whether this container's ratio may speak for THIS service. See the shared subject rule
+            // beside `MEMORY_SATURATION_SCOPES`: a cgroup total aggregates PID 1 plus every fork, so
+            // a Node service running a scheduled child presents as the service saturating. The number
+            // stays reported; only its AUTHORITY is withdrawn, because `authoritative: false` cannot
+            // reach `minAuthoritativeFacts` and therefore licenses no action.
+            const cpuScope = resolveCpuSaturationScope({nodeCommand});
+
             facts.push(this.createFact({
                 type         : CONTAINER_HEALTH_FACT_TYPES.resourceSaturation,
                 serviceKey,
                 observedAt,
                 severity     : 'critical',
-                authoritative: true,
+                authoritative: cpuScope.authoritative,
                 details      : {
                     metric     : 'cpu',
-                    threshold  : this.configValues.cpuSaturationPercent,
-                    sampleCount: samples.length,
+                    // The subject the percent describes, published for the same reason the memory
+                    // fact publishes its scope: two different quantities both read as "cpu 98%", and
+                    // a consumer cannot re-derive which one it was handed.
+                    scope                   : cpuScope.scope,
+                    subjectUnavailableReason: cpuScope.reason,
+                    threshold               : this.configValues.cpuSaturationPercent,
+                    sampleCount             : samples.length,
                     // The window as MEASURED, beside the minimum enforced. Reporting only the
                     // configured value put an unobserved claim inside the evidence a heal decision
                     // reads -- the same defect as reporting the wrong threshold, one field over.
@@ -1383,6 +1395,37 @@ export function calculateDockerMemoryPercent(stats) {
 }
 
 /**
+ * @summary The saturation-SUBJECT rule, stated once for both metrics because they disagreed silently.
+ *
+ * A container ratio answers *"how busy is this container?"*. A fact keyed to a `serviceKey` asserts
+ * *"this service is saturated."* Those are different subjects whenever a container runs more than one
+ * process — and a Node service that forks a scheduled job is exactly that.
+ *
+ * **The rule, identical for both metrics:** the container ratio is a legitimate numerator for a claim
+ * about the service **only when the container has no other processes to aggregate**, which is what
+ * `nodeCommand === false` establishes. For anything else the number is real and its subject is wrong.
+ *
+ * **Where they deliberately differ, and why — this is the part that must stay written down together:**
+ *
+ * - **Memory** has somewhere else to go. The heap-observation channel publishes a subject-scoped
+ *   reading, so `resolveMemorySaturationScope` can *change numerator*, and when it cannot it emits
+ *   **nothing** — a fallback would re-create the cross-scope pair the slice removed, on precisely the
+ *   path where the channel is broken.
+ * - **CPU has no equivalent.** `processHeapObservation` publishes `rssBytes` and V8 heap fields and
+ *   nothing about CPU time; no producer in the tree emits a process-scoped CPU reading. So CPU cannot
+ *   change numerator, and its choice is a *disposition*: emit the container number **non-authoritatively**.
+ *   Container pressure is worth an operator seeing, there is no competing subject-scoped CPU fact for
+ *   it to be confused with, and removing the **authority** removes the defect while removing the
+ *   **signal** would cost real observability for nothing.
+ *
+ * These two paragraphs are co-located on purpose. The divergence above was previously implicit — the
+ * memory path grew a subject check and CPU kept the container ratio four lines away, with nothing
+ * between them saying so, and it took an unrelated observation on a live plane to surface it. A
+ * layout that needs an accident to reveal a contradiction is the defect; consistency achieved in two
+ * places that never reference each other is not consistency.
+ */
+
+/**
  * Which memory a `memory-saturation` percent describes. Published on the fact because the two are
  * different quantities that both read as "memory 91%".
  * @type {Object}
@@ -1392,6 +1435,47 @@ export const MEMORY_SATURATION_SCOPES = Object.freeze({
     heap       : 'heap',
     unavailable: 'unavailable'
 });
+
+/**
+ * Which CPU a `resource-saturation` percent describes — the sibling of {@link MEMORY_SATURATION_SCOPES}.
+ *
+ * - **`container`** — the container is the subject. Its ratio describes the service, and the fact is
+ *   authoritative.
+ * - **`unattributable`** — the container may aggregate processes beyond the service (a Node service
+ *   that forks, or a service whose identity could not be read). The number is still reported, and it
+ *   is **not** authoritative.
+ * @type {Object}
+ */
+export const CPU_SATURATION_SCOPES = Object.freeze({
+    container     : 'container',
+    unattributable: 'unattributable'
+});
+
+/**
+ * @summary Decides whether a container CPU ratio may speak for the service it is keyed to.
+ *
+ * Mirrors `resolveMemorySaturationScope`'s gate deliberately: **`nodeCommand === false` is the ONLY
+ * thing that licenses the container ratio.** An absent or unreadable identity resolves to
+ * `unattributable` rather than to `container` — an unknown service must not be able to manufacture an
+ * authoritative fact, which is the failure the memory path already paid for once.
+ *
+ * @param {Object} options
+ * @param {Boolean|null} [options.nodeCommand] Whether the container's `Config.Cmd` is Node.
+ * @returns {{scope: String, authoritative: Boolean, reason: String|null}}
+ */
+export function resolveCpuSaturationScope({nodeCommand} = {}) {
+    if (nodeCommand === false) {
+        return {scope: CPU_SATURATION_SCOPES.container, authoritative: true, reason: null};
+    }
+
+    return {
+        scope        : CPU_SATURATION_SCOPES.unattributable,
+        authoritative: false,
+        reason       : nodeCommand === true
+            ? 'node-service-may-fork'
+            : 'service-identity-unknown'
+    }
+}
 
 /**
  * @summary Decides which numerator this service's memory saturation may legitimately use.

--- a/test/playwright/unit/ai/daemons/orchestrator/services/ContainerHealthDiagnosisService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/ContainerHealthDiagnosisService.spec.mjs
@@ -1,4 +1,7 @@
 import {test, expect} from '@playwright/test';
+import fs             from 'node:fs';
+import path           from 'node:path';
+import process        from 'node:process';
 import Neo            from '../../../../../../../src/Neo.mjs';
 import * as core      from '../../../../../../../src/core/_export.mjs';
 // The COMMITTED declarative config, imported statically. Tests resolve committed config templates
@@ -16,7 +19,9 @@ import {
     classifyServiceKey,
     isStoreBackedService,
     evaluateRestartChurn,
+    CPU_SATURATION_SCOPES,
     calculateDockerCpuPercent,
+    resolveCpuSaturationScope,
     calculateDockerMemoryPercent,
     calculateHeapSaturationPercent,
     classifyHeapExhaustion
@@ -48,6 +53,7 @@ function heapObservation({
 }
 
 const OBSERVED_AT = 1710000000000;
+const repoRoot    = path.resolve(process.cwd());
 
 function createService(config = {}) {
     return Neo.create(ContainerHealthDiagnosisService, {
@@ -1734,5 +1740,140 @@ test.describe('describeClassification — the load-independent projection (#1659
         expect(Object.hasOwn(result, 'sustained')).toBe(false);
         expect(Object.hasOwn(result, 'severity')).toBe(false);
         expect(Object.hasOwn(result, 'authoritative')).toBe(false);
+    });
+});
+
+
+/**
+ * A container CPU ratio may only speak for the service when the container has nothing else to
+ * aggregate. These drive the REAL `diagnose()` seam rather than the resolver in isolation: a spec
+ * that re-implements the disposition would pass against a tree with the production wiring deleted.
+ */
+test.describe('cpu saturation names its subject', () => {
+    /** Two samples over threshold, far enough apart to satisfy the measured sustained window. */
+    function sustainedCpu() {
+        return [
+            statsSample({cpuPercent: 98, observedAtMs: OBSERVED_AT - 40_000}),
+            statsSample({cpuPercent: 99, observedAtMs: OBSERVED_AT})
+        ];
+    }
+
+    function cpuFact(decision) {
+        return decision.facts.find(fact =>
+            fact.type === CONTAINER_HEALTH_FACT_TYPES.resourceSaturation && fact.details?.metric === 'cpu');
+    }
+
+    test('a NODE service over threshold yields a NON-authoritative fact — the cgroup aggregates its forks', () => {
+        // The live instance: an orchestrator at ~98.7% where PID 1 held ~10% and a legitimate child
+        // job held ~91%. The number is real; the subject is not the service.
+        const decision = createService().diagnose({
+            serviceKey  : 'orchestrator',
+            nodeCommand : true,
+            inspect     : runningInspect(),
+            statsSamples: sustainedCpu()
+        });
+
+        const fact = cpuFact(decision);
+
+        expect(fact, 'the fact is still emitted — the signal is kept, only its authority is withdrawn').toBeTruthy();
+        expect(fact.authoritative).toBe(false);
+        expect(fact.details.scope).toBe(CPU_SATURATION_SCOPES.unattributable);
+        expect(fact.details.subjectUnavailableReason).toBe('node-service-may-fork');
+    });
+
+    test('POSITIVE CONTROL — a non-Node container over threshold is still authoritative', () => {
+        // Without this the guard could pass by disabling the metric outright. `nodeCommand === false`
+        // is the one thing that licenses the container ratio, exactly as the memory path has it.
+        const decision = createService().diagnose({
+            serviceKey  : 'chroma',
+            nodeCommand : false,
+            inspect     : runningInspect(),
+            statsSamples: sustainedCpu()
+        });
+
+        const fact = cpuFact(decision);
+
+        expect(fact.authoritative).toBe(true);
+        expect(fact.details.scope).toBe(CPU_SATURATION_SCOPES.container);
+        expect(fact.details.subjectUnavailableReason).toBeNull();
+    });
+
+    test('an UNREADABLE identity is unattributable, never container — an unknown service cannot manufacture authority', () => {
+        // The failure the memory path already paid for: consuming a refusal as a positive
+        // classification let an unknown service produce an authoritative container-scoped fact.
+        for (const nodeCommand of [null, undefined]) {
+            const fact = cpuFact(createService().diagnose({
+                serviceKey  : 'kb',
+                nodeCommand,
+                inspect     : runningInspect(),
+                statsSamples: sustainedCpu()
+            }));
+
+            expect(fact.authoritative, `nodeCommand=${nodeCommand} must not be authoritative`).toBe(false);
+            expect(fact.details.subjectUnavailableReason).toBe('service-identity-unknown');
+        }
+    });
+
+    test('a sustained CPU fact ALONE cannot license an action on a Node service', () => {
+        // Why the flag is the whole point: `authoritative: false` cannot reach `minAuthoritativeFacts`.
+        // Before this change the same input contributed one of the two facts an authoritative
+        // classification needs, with a shallow healthcheck available as the second.
+        const decision = createService().diagnose({
+            serviceKey  : 'orchestrator',
+            nodeCommand : true,
+            inspect     : runningInspect(),
+            statsSamples: sustainedCpu()
+        });
+
+        expect(decision.facts.filter(fact => fact.authoritative)).toHaveLength(0);
+        expect(decision.actionClass ?? null).toBeNull();
+    });
+
+    test('AC-4 — the PAIRING is covered: unhealthy container PLUS sustained CPU still cannot reach the gate', () => {
+        // This is the combination the ticket is actually about, and the previous test did not cover
+        // it. `minAuthoritativeFacts` is 2, and before this change a Node service could supply a
+        // sustained CPU fact as one of them while a shallow healthcheck supplied the other — the
+        // pairing that `resolveMemorySaturationScope`'s own comment records reaching
+        // `diagnosed -> throttle-shed` on the memory side.
+        const decision = createService().diagnose({
+            serviceKey  : 'orchestrator',
+            nodeCommand : true,
+            inspect     : runningInspect({Health: {Status: 'unhealthy'}}),
+            statsSamples: sustainedCpu()
+        });
+
+        const authoritative = decision.facts.filter(fact => fact.authoritative);
+
+        expect(authoritative.length, 'the CPU fact must not be the second authoritative signature')
+            .toBeLessThan(2);
+        expect(cpuFact(decision).authoritative).toBe(false);
+    });
+
+    test('AC-5 — the two subject rules are CO-LOCATED, not merely consistent', () => {
+        // The layout defect this ticket exists to close: the memory path grew a subject check and CPU
+        // kept the container ratio four lines away with nothing between them saying so. A guard on the
+        // shared block, because "both are correct in two files that never reference each other" is the
+        // state that produced the bug.
+        const source = fs.readFileSync(
+            path.join(repoRoot, 'ai/daemons/orchestrator/services/ContainerHealthDiagnosisService.mjs'), 'utf8');
+
+        const sharedRule = source.indexOf('The saturation-SUBJECT rule, stated once for both metrics');
+
+        expect(sharedRule, 'the shared subject rule must exist').toBeGreaterThan(-1);
+        // It must sit immediately before BOTH scope enums, so a reader landing on either finds it.
+        expect(sharedRule).toBeLessThan(source.indexOf('MEMORY_SATURATION_SCOPES = Object.freeze'));
+        expect(sharedRule).toBeLessThan(source.indexOf('CPU_SATURATION_SCOPES = Object.freeze'));
+        // ...and it must name the divergence rather than implying the two behave identically.
+        expect(source.slice(sharedRule, sharedRule + 2600)).toContain('CPU has no equivalent');
+    });
+
+    test('the resolver mirrors the memory gate exactly, and says no', () => {
+        // Non-vacuity for the predicate itself: a resolver that returned `container` for everything
+        // would make every assertion above pass through the authoritative branch only by accident.
+        expect(resolveCpuSaturationScope({nodeCommand: false}).authoritative).toBe(true);
+        expect(resolveCpuSaturationScope({nodeCommand: true}).authoritative).toBe(false);
+        expect(resolveCpuSaturationScope({}).authoritative).toBe(false);
+        expect(resolveCpuSaturationScope({nodeCommand: false}).scope).toBe(CPU_SATURATION_SCOPES.container);
+        expect(resolveCpuSaturationScope({nodeCommand: true}).scope).toBe(CPU_SATURATION_SCOPES.unattributable);
     });
 });


### PR DESCRIPTION
Resolves neomjs/neo#16855
Related: neomjs/neo-agent-brain#54, neomjs/neo#16630, neomjs/neo#16840

Authored by @neo-opus-grace (Claude Opus 5, Claude Code). Origin Session ID: `3c27118d-2de2-4579-bb42-1062c34cb895`.

## The defect

`calculateDockerCpuPercent` divides the Docker `stats` cgroup total — **PID 1 plus every process the service has forked**. The resulting `resource-saturation` fact is keyed to a `serviceKey` and shipped `severity: 'critical'`, `authoritative: true`.

So the metric answers *"how busy is this container?"* and the fact asserts *"this service is saturated."* **A daemon running a scheduled batch job is indistinguishable, at this instrument, from a daemon melting down.**

**Measured by @neo-opus-vega on our canonical plane**, re-measured by CPU-time delta across two `ps` readings 19 minutes apart:

| process | ΔCPU | Δelapsed | concurrent |
|---|---|---|---|
| PID 1 — daemon | 114 s | 1140 s | **10.0 %** |
| `summarize-sessions.mjs` | 1040 s | 1140 s | **91.2 %** |
| sum | | | 101 % ≈ observed 98.1–98.7 % ✓ |

**The child alone clears the 90 % threshold.** The crossing is a property of the job, not an unlucky overlap — and it held for **20:53 and counting**, so the critical fact stands for twenty-plus minutes rather than flickering past the 30 s window. A standing condition with a schedule.

## Why this is a gap in an existing repair, not a new class

**The same function already solved this one metric over.** `collectStatsFacts` routes **memory** through `resolveMemorySaturationScope`, whose contract is stated in its own source:

> **`nodeCommand === false` is the ONLY thing that licenses the container ratio**

CPU called `calculateDockerCpuPercent` unconditionally, four lines away, with nothing between them saying so.

**What `authoritative` costs:** `authoritative: false` facts *"cannot reach `minAuthoritativeFacts`, license no action"* — the file says so. With the gate at 2, a sustained CPU fact was **one of the two**, and `container-unhealthy` is a readily available second on a plane whose healthchecks are known to be shallow (#16830). **That pairing is not hypothetical: `resolveMemorySaturationScope`'s own comment records it reaching `diagnosed → throttle-shed`.** The memory half of that pair was fixed; **this PR removes the CPU half, which was untouched.**

## The disposition, and why it diverges from memory

Memory had somewhere to go — the heap channel publishes a subject-scoped reading, so it can *change numerator*, and it emits **nothing** when it cannot.

**CPU has no equivalent.** `processHeapObservation` publishes `rssBytes` and V8 heap fields and nothing about CPU time; no producer in the tree emits a process-scoped CPU reading. So CPU cannot change numerator, and the choice is a **disposition**: keep the number, drop the **authority**.

- Container pressure is worth an operator seeing.
- There is no competing subject-scoped CPU fact for it to be confused with — which is *why* memory's "emit nothing" reasoning does not carry over.
- Removing the authority removes the defect; removing the signal would cost real observability for nothing.

**An unreadable identity resolves to `unattributable`, never `container`.** The memory path already paid for the opposite: consuming a refusal as a positive classification let an *unknown* service manufacture an authoritative container-scoped fact.

## Deltas

| file | delta |
|---|---|
| `ContainerHealthDiagnosisService.mjs` | shared subject-rule block above **both** scope enums; new `CPU_SATURATION_SCOPES` + `resolveCpuSaturationScope`; the CPU fact's `authoritative` now derives from the scope, and `details` publish `scope` + `subjectUnavailableReason` |
| `ContainerHealthDiagnosisService.spec.mjs` | 7 tests driving the **real `diagnose()` seam** |

**Defaults and thresholds untouched.** No behaviour changes for a container that legitimately owns its ratio.

**Decision Record impact:** `aligned-with ADR 0025` — evidence before action. This makes one class of evidence honest about its provenance; it does not change what licenses an action.

## Test Evidence

Evidence: L1 structural + unit achieved (1,389 passed across `ai/daemons/orchestrator/`, mutation-convicted both directions, positive control present) → L3 required only for the post-merge plane read, annotated `[L3-deferred — needs a running plane]` on neomjs/neo#16855.


`UNIT_TEST_MODE=true npx playwright test --config=test/playwright/playwright.config.unit.mjs`

- `test/playwright/unit/ai/daemons/orchestrator/` → **1,389 passed**. Zero collateral.
- The focused spec → **94 passed**.

**Mutation-convicted against the real seam**, not the resolver in isolation — a spec that re-implemented the disposition would pass against a tree with the production wiring deleted. Restoring `authoritative: true` reddens **exactly three** tests and nothing else:

```
a NODE service over threshold yields a NON-authoritative fact
an UNREADABLE identity is unattributable, never container
a sustained CPU fact ALONE cannot license an action
→ 3 failed, 89 passed
```

**Positive control:** a non-Node container over threshold is still `authoritative: true`. Without it the guard could pass by disabling the metric outright.

## AC audit, done before pushing rather than at review

Walking neomjs/neo#16855's criteria against this diff found **two gaps I closed before opening this**:

- **AC-4** required the pairing with `container-unhealthy` covered *explicitly*. My first pass only asserted a CPU fact alone. Added the unhealthy-container + sustained-CPU case — the exact combination the ticket argues about.
- **AC-5** required the two subject rules **co-located, not merely consistent**. Added a guard asserting the shared block sits above both enums and names the divergence, because "both correct in two places that never reference each other" is the state that produced this bug.

## Post-Merge Validation

- [ ] On a plane running a scheduled batch job, confirm no authoritative saturation fact is emitted for it. `[L3-deferred — needs a running plane]`

## Out of scope

- **`probeOllamaServing` / `warmOllamaRoleModel`** — `#16853` and `#16860`.
- **Bounding actual CPU spend** — `#16780` owns magnitude; this is about the measurement's *subject*.
- **Container `healthcheck:` directives** — same class one layer down, different enforcement surface.
- **Changing `cpuSaturationPercent`.** Tuning a threshold cannot fix a numerator that describes the wrong thing.
