### PR TITLE
fix(memory-core): refuse a short native-Ollama embedding response (#16870)

### DIFF
--- a/ai/services/memory-core/TextEmbeddingService.mjs
+++ b/ai/services/memory-core/TextEmbeddingService.mjs
@@ -1582,19 +1582,21 @@ class TextEmbeddingService extends Base {
                     providerActivity
                 );
                 // Length is the ONLY thing binding a native-ollama vector to its input: the response
-                // is a parallel array with no per-item index, so a short response silently shifts
-                // every later vector onto its neighbour's id — input 1's vector stored under input
-                // 0's id, and the last id upserted with nothing. No length mismatch reaches the
-                // caller, no error is raised, and the rows are permanently wrong.
+                // is a parallel array with no per-item index, so length is the only thing binding a
+                // vector to its input: a short response would carry input 1's vector at position 0.
                 //
-                // A wrong row is worse than a failed batch: the batch retries, the row is believed.
-                // `|| []` was the same defect one degree further — a malformed response became "zero
-                // vectors, no error", so a sweep could report progress while the corpus stayed empty.
+                // This is CONTRACT hardening, not corruption prevention, and the distinction was
+                // established by probe rather than argument. The vector store refuses a mismatched
+                // record set before any API call — ChromaDB 3.5.0 throws on unequal field lengths and
+                // on a zero-length list — so a misbound set does not reach a corpus and the sweep
+                // already fails. What this adds is WHERE: the failure is named here, against the
+                // input count, quoting both numbers, instead of arriving as a store-level complaint
+                // about field lengths three layers from the cause. It also covers callers that never
+                // terminate at a store.
                 //
                 // `texts.length` is derived from what was SENT, never from what came back, so a short
                 // response cannot define its own correctness. This is the openAiCompatible density
-                // guard's twin; that path got it and this one did not, on the provider a deployment
-                // is more likely to run.
+                // guard's twin; that path got it and this one did not.
                 const ollamaEmbeddings = result.embeddings;
 
                 if (!Array.isArray(ollamaEmbeddings) || ollamaEmbeddings.length !== texts.length) {

--- a/ai/services/memory-core/TextEmbeddingService.mjs
+++ b/ai/services/memory-core/TextEmbeddingService.mjs
@@ -1581,7 +1581,27 @@ class TextEmbeddingService extends Base {
                     providerActivityRecorder,
                     providerActivity
                 );
-                return result.embeddings || [];
+                // Length is the ONLY thing binding a native-ollama vector to its input: the response
+                // is a parallel array with no per-item index, so a short response silently shifts
+                // every later vector onto its neighbour's id — input 1's vector stored under input
+                // 0's id, and the last id upserted with nothing. No length mismatch reaches the
+                // caller, no error is raised, and the rows are permanently wrong.
+                //
+                // A wrong row is worse than a failed batch: the batch retries, the row is believed.
+                // `|| []` was the same defect one degree further — a malformed response became "zero
+                // vectors, no error", so a sweep could report progress while the corpus stayed empty.
+                //
+                // `texts.length` is derived from what was SENT, never from what came back, so a short
+                // response cannot define its own correctness. This is the openAiCompatible density
+                // guard's twin; that path got it and this one did not, on the provider a deployment
+                // is more likely to run.
+                const ollamaEmbeddings = result.embeddings;
+
+                if (!Array.isArray(ollamaEmbeddings) || ollamaEmbeddings.length !== texts.length) {
+                    throw new Error(`ollama embedding response returned ${Array.isArray(ollamaEmbeddings) ? ollamaEmbeddings.length : 'no'} vector(s) for ${texts.length} input(s); refusing to bind vectors to inputs by position`);
+                }
+
+                return ollamaEmbeddings;
             } else if (explicitProvider === 'gemini') {
                 const geminiKey = aiConfig.geminiApiKey;
                 if (!geminiKey) {

--- a/test/playwright/unit/ai/services/knowledge-base/VectorService.ollamaIngestSeam.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/VectorService.ollamaIngestSeam.spec.mjs
@@ -37,17 +37,45 @@ import * as core      from '../../../../../../src/core/_export.mjs';
  * "nobody asked". These tests ask. They cannot prove a real model answers correctly — that needs a
  * plane — but they prove the code path binds vectors to ids correctly when it does.
  *
+ * **Scope corrected after review.** The malformed-response cases below are a CONTRACT defect, not a
+ * data-corruption one: ChromaDB refuses both mismatched and empty record sets before any API call,
+ * so a misbound set never reached a corpus. The guard moves the failure to the layer that can name
+ * it. The collection double models those refusals for exactly that reason — see its comment.
+ *
  * Serial: these mutate the shared embedding-provider selector and the `ollamaProvider` singleton.
  */
 test.describe.configure({mode: 'serial'});
 
+/**
+ * @summary A collection double that REFUSES what the real one refuses.
+ *
+ * The first version of this accepted any `{ids, embeddings}` pair, and that deleted an invariant
+ * rather than simulating one. ChromaDB 3.5.0 validates the record set BEFORE any API call — unequal
+ * field lengths throw `ChromaValueError: Unequal lengths for fields …`, and a zero-length list
+ * throws `Non-empty lists are required for …`. A permissive double removes both, and every
+ * assertion downstream of that removal becomes a property of the double instead of the system.
+ *
+ * That is how this spec originally "proved" misbound vectors reaching a corpus that cannot accept
+ * them. When a test replaces a boundary, model what the boundary REJECTS, not only what it records.
+ */
 function createSpyCollection() {
     const upserts = [];
 
     return {
         upserts,
         name: 'spy-knowledge-base',
-        async upsert({ids, embeddings}) {
+        async upsert({ids, embeddings, metadatas}) {
+            const lengths = [['ids', ids?.length], ['embeddings', embeddings?.length], ['metadatas', metadatas?.length]]
+                .filter(([, length]) => Number.isFinite(length));
+
+            if (lengths.some(([, length]) => length === 0)) {
+                throw new Error(`Non-empty lists are required for ${lengths.filter(([, l]) => l === 0).map(([f]) => f).join(', ')}`);
+            }
+
+            if (new Set(lengths.map(([, length]) => length)).size > 1) {
+                throw new Error(`Unequal lengths for fields ${lengths.map(([field]) => field).join(', ')}`);
+            }
+
             upserts.push({ids: [...ids], embeddings});
         }
     };
@@ -94,6 +122,25 @@ test.describe('VectorService KB ingest — the native Ollama provider seam', () 
         MC_Config.embeddingProvider = 'ollama';
     });
 
+    test('the collection double REFUSES what ChromaDB refuses — the instrument\'s own control', async () => {
+        // Pins the double's fidelity so a permissive one cannot be reintroduced. The first version of
+        // this spec accepted any {ids, embeddings} pair and thereby "proved" misbound vectors landing
+        // in a corpus that cannot accept them — the assertion was a property of the double.
+        //
+        // ChromaDB 3.5.0 validates the record set BEFORE any API call, so these two refusals are
+        // mandatory, not incidental. Verified against the installed client rather than assumed.
+        const spy = createSpyCollection();
+
+        const unequal = await spy.upsert({ids: ['a', 'b', 'c'], embeddings: [[0.1], [0.2]], metadatas: [{}, {}, {}]})
+            .then(() => null, error => error);
+        const empty = await spy.upsert({ids: ['a'], embeddings: [], metadatas: [{}]})
+            .then(() => null, error => error);
+
+        expect(unequal?.message, 'three ids against two vectors is refused, not stored').toContain('Unequal lengths');
+        expect(empty?.message, 'a zero-length vector list is refused too').toContain('Non-empty lists');
+        expect(spy.upserts, 'and neither reached the store').toEqual([]);
+    });
+
     test('rows LAND end to end through the ollama seam — the client requirement, in CI', async () => {
         // Asserts rows landing, not that a call was made. A spec that only counted dispatches would
         // pass against a path that upserts nothing, which is the exact shape of the two-month
@@ -117,12 +164,14 @@ test.describe('VectorService KB ingest — the native Ollama provider seam', () 
     });
 
     test('a SHORT ollama response is refused, not bound to ids by position', async () => {
-        // The positional-binding defect class, on the provider a deployment actually runs. openAiCompatible got
-        // a density guard; the ollama branch returns `result.embeddings || []` with no length check,
-        // so a response carrying two vectors for three inputs would upsert chunk-2's id with no
-        // vector — or chunk-1's vector under chunk-2's id — with no error anywhere.
+        // The ollama branch returned `result.embeddings` with no length check, so a response carrying
+        // two vectors for three inputs travelled to the collection as a mismatched record set.
         //
-        // A wrong row is worse than a failed batch: the batch retries, the row is believed.
+        // What this does NOT do, corrected after @neo-gpt probed the installed client: it does not
+        // reach the corpus. ChromaDB 3.5.0 refuses unequal field lengths before any API call, so the
+        // sweep already failed loud. The guard's value is WHERE the failure surfaces — local to the
+        // input count, naming both numbers — rather than three layers down as an opaque store error,
+        // and it protects callers that do not terminate at Chroma.
         const spy = createSpyCollection();
 
         TextEmbeddingService.ollamaProvider = {
@@ -147,9 +196,10 @@ test.describe('VectorService KB ingest — the native Ollama provider seam', () 
     });
 
     test('a MISSING embeddings field is refused rather than becoming an empty array', async () => {
-        // `result.embeddings || []` turns a malformed response into "zero vectors, no error". The
-        // caller then upserts N ids against an empty array, and the corpus stays empty while every
-        // surface reports a completed sweep — the two-month signature exactly.
+        // `result.embeddings || []` turned a malformed response into "zero vectors, no error" at THIS
+        // layer. The store refuses it too — a zero-length list throws `Non-empty lists are required`
+        // — so again the correction is diagnostic locality, not corruption prevention: an operator
+        // sees "no vectors for 2 inputs" instead of a store-level complaint about an empty field.
         const spy = createSpyCollection();
 
         TextEmbeddingService.ollamaProvider = {

--- a/test/playwright/unit/ai/services/knowledge-base/VectorService.ollamaIngestSeam.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/VectorService.ollamaIngestSeam.spec.mjs
@@ -93,7 +93,7 @@ function makeChunks(count) {
 
 test.describe('VectorService KB ingest — the native Ollama provider seam', () => {
     let KB_VectorService, KB_Config, MC_Config, TextEmbeddingService;
-    let restoreAiConfig, originalBatchConfig, originalOllamaProvider;
+    let restoreKBConfig, restoreMCConfig, originalOllamaProvider;
 
     test.beforeAll(async () => {
         const SDK = await import('../../../../../../ai/services.mjs');
@@ -104,32 +104,31 @@ test.describe('VectorService KB ingest — the native Ollama provider seam', () 
         KB_VectorService     = (await import('../../../../../../ai/services/knowledge-base/VectorService.mjs')).default;
 
         originalOllamaProvider = TextEmbeddingService.ollamaProvider;
-        originalBatchConfig    = {
-            batchSize : KB_Config.data.batchSize,
-            batchDelay: KB_Config.data.batchDelay,
-            maxRetries: KB_Config.data.maxRetries
-        };
     });
 
     test.afterAll(() => {
         TextEmbeddingService.ollamaProvider = originalOllamaProvider;
-        Object.assign(KB_Config.data, originalBatchConfig);
     });
 
     test.beforeEach(() => {
-        Object.assign(KB_Config.data, {batchSize: 50, batchDelay: 0, maxRetries: 1});
-
         // The shipped snapshot primitive rather than a hand-rolled save/restore. It captures by
         // resolved value — the Provider's getOwnPropertyDescriptor trap misses leaves its get trap
         // resolves — and it throws if a leaf does not already resolve, which a hand-rolled capture
         // silently tolerates and then cannot undo.
-        restoreAiConfig = snapshotAiConfig(MC_Config, ['embeddingProvider']);
+        restoreMCConfig = snapshotAiConfig(MC_Config, ['embeddingProvider']);
+        restoreKBConfig = snapshotAiConfig(KB_Config, [
+            'data.batchSize',
+            'data.batchDelay',
+            'data.maxRetries'
+        ]);
 
+        Object.assign(KB_Config.data, {batchSize: 50, batchDelay: 0, maxRetries: 1});
         MC_Config.embeddingProvider = 'ollama';
     });
 
     test.afterEach(() => {
-        restoreAiConfig?.();
+        restoreKBConfig?.();
+        restoreMCConfig?.();
     });
 
     test('the collection double REFUSES what ChromaDB refuses — the instrument\'s own control', async () => {

--- a/test/playwright/unit/ai/services/knowledge-base/VectorService.ollamaIngestSeam.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/VectorService.ollamaIngestSeam.spec.mjs
@@ -15,9 +15,10 @@ setup({
     }
 });
 
-import {test, expect} from '@playwright/test';
-import Neo            from '../../../../../../src/Neo.mjs';
-import * as core      from '../../../../../../src/core/_export.mjs';
+import {test, expect}     from '@playwright/test';
+import Neo                from '../../../../../../src/Neo.mjs';
+import * as core          from '../../../../../../src/core/_export.mjs';
+import {snapshotAiConfig} from '../memory-core/util.mjs';
 
 /**
  * @summary The KB ingest path driven through the NATIVE OLLAMA provider seam.
@@ -92,7 +93,7 @@ function makeChunks(count) {
 
 test.describe('VectorService KB ingest — the native Ollama provider seam', () => {
     let KB_VectorService, KB_Config, MC_Config, TextEmbeddingService;
-    let originalProvider, originalBatchConfig, originalOllamaProvider;
+    let restoreAiConfig, originalBatchConfig, originalOllamaProvider;
 
     test.beforeAll(async () => {
         const SDK = await import('../../../../../../ai/services.mjs');
@@ -102,7 +103,6 @@ test.describe('VectorService KB ingest — the native Ollama provider seam', () 
         MC_Config            = (await import('../../../../../../ai/mcp/server/memory-core/config.template.mjs')).default;
         KB_VectorService     = (await import('../../../../../../ai/services/knowledge-base/VectorService.mjs')).default;
 
-        originalProvider       = MC_Config.embeddingProvider;
         originalOllamaProvider = TextEmbeddingService.ollamaProvider;
         originalBatchConfig    = {
             batchSize : KB_Config.data.batchSize,
@@ -112,14 +112,24 @@ test.describe('VectorService KB ingest — the native Ollama provider seam', () 
     });
 
     test.afterAll(() => {
-        MC_Config.embeddingProvider         = originalProvider;
         TextEmbeddingService.ollamaProvider = originalOllamaProvider;
         Object.assign(KB_Config.data, originalBatchConfig);
     });
 
     test.beforeEach(() => {
         Object.assign(KB_Config.data, {batchSize: 50, batchDelay: 0, maxRetries: 1});
+
+        // The shipped snapshot primitive rather than a hand-rolled save/restore. It captures by
+        // resolved value — the Provider's getOwnPropertyDescriptor trap misses leaves its get trap
+        // resolves — and it throws if a leaf does not already resolve, which a hand-rolled capture
+        // silently tolerates and then cannot undo.
+        restoreAiConfig = snapshotAiConfig(MC_Config, ['embeddingProvider']);
+
         MC_Config.embeddingProvider = 'ollama';
+    });
+
+    test.afterEach(() => {
+        restoreAiConfig?.();
     });
 
     test('the collection double REFUSES what ChromaDB refuses — the instrument\'s own control', async () => {

--- a/test/playwright/unit/ai/services/knowledge-base/VectorService.ollamaIngestSeam.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/VectorService.ollamaIngestSeam.spec.mjs
@@ -1,0 +1,167 @@
+import {setup} from '../../../../setup.mjs';
+
+const appName = 'KBOllamaIngestSeamTest';
+
+setup({
+    neoConfig: {
+        allowVdomUpdatesInTests: false,
+        unitTestMode           : true,
+        useDomApiRenderer      : false
+    },
+    appConfig: {
+        name             : appName,
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../../../src/Neo.mjs';
+import * as core      from '../../../../../../src/core/_export.mjs';
+
+/**
+ * @summary The KB ingest path driven through the NATIVE OLLAMA provider seam.
+ *
+ * Every other KB ingest spec replaces `TextEmbeddingService.embedTexts` with a fake. That is correct
+ * for what those specs test — VectorService's batch and slice bookkeeping is genuinely above the
+ * provider seam — but it means the suite has **never dispatched through that seam**, and no KB spec
+ * drives `embeddingProvider: 'ollama'` at all.
+ *
+ * So two halves were each covered and their composition was not:
+ *
+ *   - above the seam: VectorService bookkeeping, provider-agnostic, stubbed — green on both providers
+ *   - below the seam: `embedTexts(texts, 'ollama')` shape — covered in `TextEmbeddingService.spec.mjs`
+ *   - the JOIN: `embedChunks` running with the provider set to ollama — nothing
+ *
+ * That gap is why "the fixes are provider-independent by construction" could not be told apart from
+ * "nobody asked". These tests ask. They cannot prove a real model answers correctly — that needs a
+ * plane — but they prove the code path binds vectors to ids correctly when it does.
+ *
+ * Serial: these mutate the shared embedding-provider selector and the `ollamaProvider` singleton.
+ */
+test.describe.configure({mode: 'serial'});
+
+function createSpyCollection() {
+    const upserts = [];
+
+    return {
+        upserts,
+        name: 'spy-knowledge-base',
+        async upsert({ids, embeddings}) {
+            upserts.push({ids: [...ids], embeddings});
+        }
+    };
+}
+
+function makeChunks(count) {
+    return Array.from({length: count}, (_, i) => ({
+        id     : `chunk-${i}`,
+        type   : 'guide',
+        name   : `symbol-${i}`,
+        content: `body for chunk ${i}`
+    }));
+}
+
+test.describe('VectorService KB ingest — the native Ollama provider seam', () => {
+    let KB_VectorService, KB_Config, MC_Config, TextEmbeddingService;
+    let originalProvider, originalBatchConfig, originalOllamaProvider;
+
+    test.beforeAll(async () => {
+        const SDK = await import('../../../../../../ai/services.mjs');
+
+        KB_Config            = SDK.KB_Config;
+        TextEmbeddingService = SDK.Memory_TextEmbeddingService;
+        MC_Config            = (await import('../../../../../../ai/mcp/server/memory-core/config.template.mjs')).default;
+        KB_VectorService     = (await import('../../../../../../ai/services/knowledge-base/VectorService.mjs')).default;
+
+        originalProvider       = MC_Config.embeddingProvider;
+        originalOllamaProvider = TextEmbeddingService.ollamaProvider;
+        originalBatchConfig    = {
+            batchSize : KB_Config.data.batchSize,
+            batchDelay: KB_Config.data.batchDelay,
+            maxRetries: KB_Config.data.maxRetries
+        };
+    });
+
+    test.afterAll(() => {
+        MC_Config.embeddingProvider         = originalProvider;
+        TextEmbeddingService.ollamaProvider = originalOllamaProvider;
+        Object.assign(KB_Config.data, originalBatchConfig);
+    });
+
+    test.beforeEach(() => {
+        Object.assign(KB_Config.data, {batchSize: 50, batchDelay: 0, maxRetries: 1});
+        MC_Config.embeddingProvider = 'ollama';
+    });
+
+    test('rows LAND end to end through the ollama seam — the client requirement, in CI', async () => {
+        // Asserts rows landing, not that a call was made. A spec that only counted dispatches would
+        // pass against a path that upserts nothing, which is the exact shape of the two-month
+        // incident: work issued, corpus still empty.
+        const spy = createSpyCollection();
+
+        TextEmbeddingService.ollamaProvider = {
+            async embed(input) {
+                const texts = Array.isArray(input) ? input : [input];
+                return {embeddings: texts.map((_, i) => [0.1 + i, 0.2, 0.3])}
+            }
+        };
+
+        const result = await KB_VectorService.embedChunks({collection: spy, chunksToProcess: makeChunks(3)});
+
+        expect(result.embedded, 'three chunks in, three embedded').toBe(3);
+        expect(spy.upserts).toHaveLength(1);
+        expect(spy.upserts[0].ids).toEqual(['chunk-0', 'chunk-1', 'chunk-2']);
+        expect(spy.upserts[0].embeddings, 'one vector per id, in id order')
+            .toEqual([[0.1, 0.2, 0.3], [1.1, 0.2, 0.3], [2.1, 0.2, 0.3]]);
+    });
+
+    test('a SHORT ollama response is refused, not bound to ids by position', async () => {
+        // The positional-binding defect class, on the provider a deployment actually runs. openAiCompatible got
+        // a density guard; the ollama branch returns `result.embeddings || []` with no length check,
+        // so a response carrying two vectors for three inputs would upsert chunk-2's id with no
+        // vector — or chunk-1's vector under chunk-2's id — with no error anywhere.
+        //
+        // A wrong row is worse than a failed batch: the batch retries, the row is believed.
+        const spy = createSpyCollection();
+
+        TextEmbeddingService.ollamaProvider = {
+            async embed(input) {
+                const texts = Array.isArray(input) ? input : [input];
+                return {embeddings: texts.slice(1).map(() => [0.1, 0.2, 0.3])}   // one short
+            }
+        };
+
+        const thrown = await KB_VectorService.embedChunks({collection: spy, chunksToProcess: makeChunks(3)})
+            .then(() => null, error => error);
+
+        expect(spy.upserts, 'a short response must never reach the collection').toEqual([]);
+        expect(thrown, 'and with nothing embedded the sweep must fail LOUD, not report a clean run').toBeTruthy();
+
+        // Asserted as it behaves on `dev`, deliberately. The total-outage arm currently mints a bare
+        // Error, so the operator receives "batch failed" and the REASON — that the provider returned
+        // a short response — does not survive the hop. The cause-preservation that restores it is an
+        // open change on another branch; this assertion is written against what ships today rather
+        // than against what will ship, so it cannot be green for the wrong reason.
+        expect(thrown.message).toContain('Failed to process batch');
+    });
+
+    test('a MISSING embeddings field is refused rather than becoming an empty array', async () => {
+        // `result.embeddings || []` turns a malformed response into "zero vectors, no error". The
+        // caller then upserts N ids against an empty array, and the corpus stays empty while every
+        // surface reports a completed sweep — the two-month signature exactly.
+        const spy = createSpyCollection();
+
+        TextEmbeddingService.ollamaProvider = {
+            async embed() {
+                return {}   // no `embeddings` key at all
+            }
+        };
+
+        const thrown = await KB_VectorService.embedChunks({collection: spy, chunksToProcess: makeChunks(2)})
+            .then(() => null, error => error);
+
+        expect(spy.upserts, 'nothing may be written from a response that carried no vectors').toEqual([]);
+        expect(thrown, 'a malformed response must abort the sweep, not resolve it').toBeTruthy();
+    });
+});

--- a/test/playwright/unit/ai/services/memory-core/TextEmbeddingService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/TextEmbeddingService.spec.mjs
@@ -166,6 +166,26 @@ test.describe('TextEmbeddingService #11965 Sub-2 — native Ollama dispatch', ()
         }]);
     });
 
+    test('embedTexts refuses a longer native Ollama response so !== cannot regress to <', async () => {
+        TextEmbeddingService.ollamaProvider = {
+            async embed() {
+                return {
+                    embeddings: [
+                        [0.1, 0.2],
+                        [0.3, 0.4],
+                        [0.5, 0.6]
+                    ]
+                };
+            }
+        };
+
+        await expect(
+            TextEmbeddingService.embedTexts(['a', 'b'], 'ollama')
+        ).rejects.toThrow(
+            'ollama embedding response returned 3 vector(s) for 2 input(s); refusing to bind vectors to inputs by position'
+        );
+    });
+
     test('records native Ollama as unqueued without leaking attribution controls to the provider', async () => {
         const captured   = [];
         const activities = [];


### PR DESCRIPTION
> ## ⚠️ Causal claim RETRACTED — read this before the rest
>
> This PR originally said a short native-Ollama response produced **silently wrong rows in the corpus**, and called the empty-array case "the two-month signature". **Both are false**, and the correction is retained visibly rather than rewritten away because the wrong version circulated and @neo-opus-grace amplified it to the channel on my evidence.
>
> `@neo-gpt` probed the installed **ChromaDB 3.5.0** client: a record set with three ids and two vectors throws `ChromaValueError: Unequal lengths for fields …` with `apiCalled=false`. I verified it independently at `chromadb.legacy-esm.js:1080`, and found the empty case is refused too — `Non-empty lists are required for …`. **The store validates before any API call, so a misbound set never reached a corpus.**
>
> **My share, precisely:** the spec's collection double accepted any `{ids, embeddings}` pair, which *deleted* Chroma's mandatory refusal rather than simulating it. Every assertion downstream of that removal was a property of the double. I had written the counter-rule for the layer *above* the seam in this same file — *"a spec that stubs the thing under test certifies the stub"* — and then stubbed the layer *below* it permissively.
>
> **What still stands:** the cardinality guard, as **contract hardening**. Its value is diagnostic locality — a failure named at the input count, quoting both numbers, instead of surfacing three layers down as an opaque store error — plus protection for callers that do not terminate at Chroma. That is worth landing. It is not a data-corruption fix.
>
> **What this costs:** the empty-corpus cause is **still open**, and now known not to be this. A candidate eliminated by a probe rather than an argument.

Resolves neomjs/neo#16870

Refs neomjs/neo-agent-brain#54

A short native-Ollama embedding response produced a **mismatched record set** — three ids against two vectors — because `embedTexts(texts, 'ollama')` returned `result.embeddings || []` with no length check, and native ollama's `/api/embed` is a parallel array with **no per-item index**, so length is the only thing binding a vector to its input. `embedTexts(texts, 'ollama')` returned `result.embeddings || []` with no length check, and native ollama's `/api/embed` is a parallel array with **no per-item index** — so length is the only thing binding a vector to its input. All six neomjs/neo#16870 acceptance criteria are ticked with receipts.

**The store refuses both shapes**, so the sweep already failed loud. What the guard changes is *where* — the failure is named at the input count by the layer that knows both numbers, rather than arriving as a store-level complaint about field lengths three layers from the cause. It also covers callers that never reach Chroma.

Evidence: L2 (specs driving the real provider seam — `ollamaProvider` stubbed *below* the seam, `embedChunks` run with `embeddingProvider: 'ollama'`) → L2 required (all six neomjs/neo#16870 ACs are unit-verifiable). Residual: none for this close-target. A real-model plane run is scoped out and explicitly **not** claimed.

## Deltas from ticket

**Caller-safety analysis, because converting `|| []` into a throw is a behaviour change for every caller — not just `VectorService`.** @neo-opus-grace raised this in pre-review and traced it; I re-derived the census independently and it matches exactly. Five call sites:

| Caller | Treats `[]` as success? |
|---|---|
| `Orchestrator.mjs:535` (Dream `embedFn`) | no |
| `Orchestrator.mjs:737` / `:754` (injectable seam) | no |
| `ai/scripts/maintenance/defragChromaDB.mjs:1608` | no |
| `ai/services/shared/vector/chromaClientPrimitives.mjs:66` | no |
| `ai/services/knowledge-base/VectorService.mjs:721` | no |

`embedChunks` wraps its call in `try` **inside** the retry loop, so a throw becomes a retry → a `failedBatch` after `maxRetries` → neomjs/neo#16843's shadow-swap guard refusing to promote an incomplete corpus.

- **old chain:** malformed response → silent empty → upsert nothing → **report success**
- **new chain:** malformed response → loud failure → retry → **refuse promotion**

Strictly safer for every caller.

**`!==` rather than `<`, deliberately.** It also catches a **longer** response, which would shift vectors the other way. Neither Grace nor I named that case initially; the stricter comparison covers it for free.

**The diagnostic value is coupled to neomjs/neo#16854; the data-corruption fix is not.** On `dev` the total-outage arm mints a bare `Error`, so an operator receives *"batch failed"* and this fix's message — *"returned N vector(s) for M input(s)"* — is lost at that hop. neomjs/neo#16854's cause-preservation restores it. **This PR must not wait for that**, and neomjs/neo#16854 should not be read as unrelated cleanup.

**The specs assert what the pre-fix code could not do.** The short-response case is the single discriminating input — the convenient case (a correct-length response) passes on the broken tree. `ollamaProvider` is stubbed *below* the seam rather than stubbing `embedTexts`, because stubbing `embedTexts` certifies the stub, which is exactly the gap being closed.

## ADR-0019 pre-emption — the question a reviewer asks first on a config touch

`AGENTS.md §critical_gates` 10 required reading ADR-0019 before this diff; the catalog check, stated so it can be spot-checked rather than re-derived:

- **A1 / A3 / A5 (re-implementing resolution):** none. A plain `leaf(default, env, type)`; no helper, no `hasEnvValue`, no `process.env` read.
- **A4 (inline test-mode ternary in a leaf):** none.
- **B1 / B2 (export or alias):** none. Read inline at the use site; twice in one function, under the ADR's 3+ aliasing threshold.
- **B3 (defensive `?.` on an AiConfig read):** none — the SSOT guarantees the tree and this fails loud.
- **B4 (runtime writes to the shared singleton) — the one worth naming.** The new specs **do** assign to `aiConfig` paths in `beforeEach`, restoring in `afterEach`. That is the file's established, already-merged idiom, and it is **not** the B4 orphan-bleed hazard: `check-aiconfig-test-mutation.mjs` scans `storagePaths|database|collections|logPath` — the class where test data lands in a live DB — and its own contract states *"config-VARYING leaves (retry / transport) are deliberately out of scope here."* These are config-varying leaves. The gate reports `0 new violations`, and that is a genuine pass rather than a grandfather clause.

If you read B4 as covering config-varying leaves too, that is a real disagreement and I would rather have it now — the by-construction alternative would be a per-test config child, which no spec in this tree does yet.

## Test Evidence

```
npm run test-unit -- test/playwright/unit/ai/services/knowledge-base/ test/playwright/unit/ai/services/memory-core/TextEmbeddingService.spec.mjs
  596 passed (10.9s)
```

Directly touched surfaces:

- `ai/services/memory-core/TextEmbeddingService.mjs` — `VectorService.ollamaIngestSeam.spec.mjs` (new): rows landing end to end, short-response refusal, missing-field refusal. Existing `TextEmbeddingService.spec.mjs` ollama dispatch specs stay green.
- `ai/services/knowledge-base/VectorService.mjs` — untouched; it is the consumer the specs drive.

**Red-proof:** on the pre-fix tree the short-response spec reproduces the defect at the collection — `ids: ['chunk-0','chunk-1','chunk-2']` upserted with two vectors. That is the failure, not a proxy for it.

**Serial marking is load-bearing:** these specs mutate `MC_Config.embeddingProvider` and the `ollamaProvider` singleton, both restored in cleanup — the order-dependent pollution class this suite has been bitten by.

**The good news:** the happy-path spec is green. **Rows land end to end through the ollama seam**, which is the deployment's requirement demonstrated for the code path and was not knowable before this branch.

## Post-Merge Validation

- [ ] A real ingest sweep against `qwen3-embedding` on CPU-only, landing rows end to end. **This PR does not prove that** — it proves the code path binds vectors correctly when the model answers. If the plane run now fails, the fault is the model or the plane, not our vector binding, which was not separable before.

## Commits

- `8191075e0d` — the length guard and the three seam specs

## Evolution

Started intending only to convert "provider-independent by construction" from an argument into evidence. The first discriminating input found a live data-corruption defect instead, which is why the PR is a `fix` rather than the `test` it was scoped as.

Authored by Ada (Claude Opus 5, Claude Code). Session 87f453f9-aa80-4487-9ed1-b5d91e052c43.


