### PR TITLE
feat(ai): deliver deployment prescriptions through host pipeline (#16868)

### DIFF
--- a/ai/examples/cloud-deployment/deploy-pipeline.sh
+++ b/ai/examples/cloud-deployment/deploy-pipeline.sh
@@ -47,10 +47,15 @@ COMPOSE_FILE="${NEO_DEPLOY_COMPOSE_FILE:-}"
 # by the rehearsal witness printing "(4 file(s))" for two files.
 compose_file_args=()
 compose_file_count=0
+first_compose_file=""
 while IFS= read -r compose_file_entry; do
     if [ -n "$compose_file_entry" ]; then
         compose_file_args+=(-f "$compose_file_entry")
         compose_file_count=$((compose_file_count + 1))
+
+        if [ -z "$first_compose_file" ]; then
+            first_compose_file="$compose_file_entry"
+        fi
     fi
 done <<< "$(printf '%s' "$COMPOSE_FILE" | tr ':' '\n')"
 
@@ -58,6 +63,18 @@ if [ "$compose_file_count" -eq 0 ]; then
     echo "[deploy] FATAL: NEO_DEPLOY_COMPOSE_FILE must name an ordered, auth-complete Compose file set. Docker was NOT invoked." >&2
     exit 1
 fi
+
+# Compose resolves its default `.env` from the first declared file's project directory. Keep that
+# project-facing location stable while the durable carrier lives outside the checkout, so source
+# updates cannot discard an admitted prescription. The materializer owns the adoption/symlink
+# safety contract; this pipeline only supplies the explicit paths.
+compose_project_dir="$(dirname "$first_compose_file")"
+prescription_root="${NEO_HOST_DEPLOYMENT_PRESCRIPTION_ROOT:-${HOME}/.neo-ai/deployment-prescriptions}"
+prescription_ledger="$prescription_root/prescriptions.jsonl"
+prescription_environment="$prescription_root/active.env"
+prescription_deploy_lock="$prescription_root/deploy.lock"
+project_environment="$compose_project_dir/.env"
+prescription_cli="$SCRIPT_DIR/../../scripts/maintenance/materializeDeploymentPrescriptions.mjs"
 
 # A stable project name pins named-volume identity across redeploys. Export the
 # same value consumed by docker-compose.yml for its top-level project name and
@@ -86,7 +103,14 @@ fi
 # `compose_file_args` is guaranteed non-empty by the abort above, so expanding it is safe on bash 3.2
 # where an EMPTY array expansion is an unbound-variable error under `set -u` (see the note at the
 # preflight below — macOS ships 3.2 and hosted CI does not, so that class fails only on maintainer machines).
-compose() { docker compose "${compose_file_args[@]}" -p "$PROJECT_NAME" "${profile_args[@]}" "$@"; }
+#
+# Compose's default lookup follows project-directory rules that vary with file/flag composition. Pin
+# the same persistent carrier on EVERY pipeline-owned Compose call so the delivery contract does not
+# depend on implicit lookup and the final `ps` observes the same interpolation input as `up`.
+compose() {
+    docker compose --env-file "$prescription_environment" \
+        "${compose_file_args[@]}" -p "$PROJECT_NAME" "${profile_args[@]}" "$@"
+}
 
 # Resolve the deployed revision BEFORE Docker runs (#15792). Every run pins:
 # there is deliberately no unpinned path, because this is the reference pipeline
@@ -225,11 +249,62 @@ else
     node "$PREFLIGHT" --compose-project "$PROJECT_NAME"
 fi
 
-# Build + recreate containers, KEEPING named volumes and the backup bind-mount.
-# `--wait` blocks until every service with a healthcheck reports healthy and
-# exits non-zero if one does not — this is the deploy health gate. `set -e`
-# then fails the job, so a broken redeploy is never reported as success.
-compose up -d --build --wait
+# One host may receive overlapping deploy jobs. The materialized environment and state manifest are a
+# pair, so a second job must not replace either between this job's materialize and receipt phases.
+# `mkdir` is the cross-process atomic claim; the subshell's EXIT trap releases it on every ordinary
+# success/failure path without replacing the revision probe's parent-shell cleanup trap.
+(
+    mkdir -p "$prescription_root"
 
-echo "[deploy] all services healthy — redeploy complete"
-compose ps
+    if ! mkdir "$prescription_deploy_lock" 2>/dev/null; then
+        echo "[deploy] FATAL: deployment lock exists at ${prescription_deploy_lock}; another deploy is active or the stale lock needs operator inspection." >&2
+        echo "[deploy] No prescription was materialized and Docker was NOT invoked." >&2
+        exit 1
+    fi
+
+    release_prescription_deploy_lock() {
+        rmdir "$prescription_deploy_lock" 2>/dev/null || true
+    }
+    trap release_prescription_deploy_lock EXIT
+
+    # Bind state and receipt to this exact deployment transaction. The lock serializes the shared
+    # active environment; the UUID prevents a later run from ever satisfying this run's receipt
+    # contract with a different manifest, even if artifacts are inspected after the lock is released.
+    deployment_run_id="$(node --input-type=module -e \
+        "import {randomUUID} from 'node:crypto'; process.stdout.write(randomUUID())")"
+    prescription_run_root="$prescription_root/runs/$deployment_run_id"
+    prescription_state="$prescription_run_root/materialized-state.json"
+    prescription_receipt="$prescription_run_root/delivery-receipt.json"
+
+    # Materialize admitted host prescriptions before the first Docker mutation. A refusal exits through
+    # `set -e`, leaving the currently running plane untouched. `--adopt-existing-env` is explicit here:
+    # the materializer preserves unrelated operator entries before replacing the project `.env` with its
+    # durable carrier link.
+    node "$prescription_cli" materialize \
+        --ledger "$prescription_ledger" \
+        --env "$prescription_environment" \
+        --state "$prescription_state" \
+        --project-env "$project_environment" \
+        --compose-project "$PROJECT_NAME" \
+        --run-id "$deployment_run_id" \
+        --adopt-existing-env
+
+    # Build + recreate containers, KEEPING named volumes and the backup bind-mount.
+    # `--wait` blocks until every service with a healthcheck reports healthy and
+    # exits non-zero if one does not — this is the deploy health gate. `set -e`
+    # then fails the job, so a broken redeploy is never reported as success.
+    compose up -d --build --wait
+
+    # The receipt is a delivery claim, not an observation claim: reaching it proves the exact revision
+    # passed Compose's health gate with the admitted environment. A failed `up --wait` exits before this
+    # command, so no success artifact can survive a failed deployment.
+    node "$prescription_cli" receipt \
+        --env "$prescription_environment" \
+        --state "$prescription_state" \
+        --receipt "$prescription_receipt" \
+        --run-id "$deployment_run_id" \
+        --deployed-revision "$NEO_REVISION"
+
+    echo "[deploy] all services healthy — redeploy complete"
+    compose ps
+)

--- a/ai/scripts/maintenance/materializeDeploymentPrescriptions.mjs
+++ b/ai/scripts/maintenance/materializeDeploymentPrescriptions.mjs
@@ -1,0 +1,914 @@
+#!/usr/bin/env node
+import {execFile}               from 'node:child_process';
+import {createHash, randomUUID} from 'node:crypto';
+import * as fs                  from 'node:fs/promises';
+import os                       from 'node:os';
+import path                     from 'node:path';
+import {promisify}              from 'node:util';
+import {fileURLToPath}          from 'node:url';
+
+import {
+    admitLedgerPrescriptions,
+    LEDGER_REFUSALS
+} from '../../services/memory-core/helpers/deploymentPrescriptionLedger.mjs';
+import {renderPrescribedEnvironment} from '../../services/memory-core/helpers/deploymentPrescriptionEnvironment.mjs';
+import {
+    appendDeploymentPrescription,
+    readDeploymentPrescriptions,
+    validateDeploymentPrescriptionLedger
+} from '../../services/memory-core/helpers/deploymentPrescriptionStore.mjs';
+import {knobEnvBindings, RECOVERY_KNOBS} from '../../services/memory-core/helpers/recoveryKnobRegistry.mjs';
+
+/**
+ * @module ai/scripts/maintenance/materializeDeploymentPrescriptions
+ * @summary Trusted host-side delivery entrypoint for deployment prescriptions: `append` stamps an
+ * operator-authored intent into the guarded JSONL store; `materialize` re-admits the ledger against
+ * the current recovery-knob registry and atomically merges only registry-owned environment keys into
+ * the persistent Compose carrier; `receipt` records what the health-gated deploy actually consumed.
+ *
+ * This module deliberately has no Neo or AiConfig bootstrap. It runs on the deployment host before
+ * the containers are recreated, while the configuration inside those containers may be the thing
+ * under repair. The registry remains the authority for knob shape, bounds, target, and environment
+ * bindings; the ledger is transport, never executable authority.
+ *
+ * The materialization manifest is load-bearing. A ledger may receive a newer record while Compose is
+ * building. Re-folding the ledger after `up --wait` would then stamp the newer prescription as
+ * delivered even though the running container consumed the earlier env file. `materialize` therefore
+ * snapshots exact prescription identities plus the env digest before Docker, and `receipt` consumes
+ * that snapshot only after verifying that the carrier still has the same digest.
+ */
+
+const
+    execFileAsync  = promisify(execFile),
+    SCHEMA_VERSION = 1,
+    RUN_ID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i,
+    DEFAULT_ROOT   = process.env.NEO_HOST_DEPLOYMENT_PRESCRIPTION_ROOT
+        || path.join(os.homedir(), '.neo-ai', 'deployment-prescriptions');
+
+/**
+ * @summary Returns the closed environment-key set the recovery-knob registry owns.
+ * @returns {Set<String>} Registry-derived keys; never record-derived.
+ */
+export function prescribedEnvironmentKeys() {
+    // Some recovery knobs are actuator-local overlays and intentionally declare no deployment
+    // service. Owning their env keys here would erase operator config even though no ledger record
+    // can target them. The same service declaration admission requires defines this narrower set.
+    return new Set(Object.entries(RECOVERY_KNOBS)
+        .filter(([, descriptor]) => typeof descriptor.serviceKey === 'string' && descriptor.serviceKey)
+        .flatMap(([knob]) => knobEnvBindings(knob).map(binding => binding.env)))
+}
+
+/**
+ * @summary Refuses ambient process values that would outrank the persistent Compose carrier.
+ *
+ * Docker Compose gives an exported process variable precedence over `.env` and `--env-file`. A
+ * materializer that ignored that layer could write and receipt one admitted value while Compose
+ * deployed another. Refusal keeps the operator-owned environment intact and aborts before Docker;
+ * callers must move deployment-owned values into the governed carrier instead of silently losing
+ * either authority.
+ * @param {Object} [ambientEnvironment]
+ * @param {Set<String>} [ownedKeys]
+ * @returns {void}
+ */
+export function assertNoAmbientPrescribedEnvironment(
+    ambientEnvironment = process.env,
+    ownedKeys = prescribedEnvironmentKeys()
+) {
+    const conflicts = [...ownedKeys]
+        .filter(key => Object.prototype.hasOwnProperty.call(ambientEnvironment, key)
+            && ambientEnvironment[key] !== undefined)
+        .sort();
+
+    if (conflicts.length) {
+        throw new Error(
+            `deployment-owned environment must be unset before materialization: ${conflicts.join(', ')}`
+        )
+    }
+}
+
+/**
+ * @summary Splits env-file content without changing any retained byte, including CRLF and blank lines.
+ * @param {String} content
+ * @returns {String[]} Segments including their original line terminators.
+ * @private
+ */
+function splitLinesPreservingTerminators(content) {
+    return String(content ?? '').match(/[^\r\n]*(?:\r\n|\n|\r|$)/g)?.filter(Boolean) ?? []
+}
+
+/**
+ * @summary Extracts an env assignment key without interpreting or reserializing its value.
+ * @param {String} line
+ * @returns {String|null}
+ * @private
+ */
+function envAssignmentKey(line) {
+    const match = line.replace(/(?:\r\n|\n|\r)$/, '').match(/^\s*(?:export\s+)?([A-Za-z_][A-Za-z0-9_]*)\s*=/);
+
+    return match?.[1] ?? null
+}
+
+/**
+ * @summary Replaces only registry-owned env assignments while preserving every unrelated byte.
+ *
+ * All previous occurrences of an owned key are removed before the sorted renderer output is appended;
+ * this prevents a stale duplicate later in the operator file from overriding the admitted value. An
+ * empty active set removes stale owned lines, while comments, blank lines, quoting, secrets, and all
+ * unowned assignments retain their exact bytes and order.
+ * @param {String} existingContent Existing operator/persistent env content.
+ * @param {String} renderedContent Registry-admitted renderer output.
+ * @param {Set<String>} [ownedKeys]
+ * @returns {String} Merged env content.
+ */
+export function mergePrescribedEnvironment(
+    existingContent,
+    renderedContent,
+    ownedKeys = prescribedEnvironmentKeys()
+) {
+    const retained = splitLinesPreservingTerminators(existingContent)
+        .filter(line => !ownedKeys.has(envAssignmentKey(line)))
+        .join('');
+
+    if (!renderedContent) return retained;
+
+    return retained && !/[\r\n]$/.test(retained)
+        ? `${retained}\n${renderedContent}`
+        : `${retained}${renderedContent}`
+}
+
+/**
+ * @summary Writes a UTF-8 file through a unique sibling and atomic rename.
+ * @param {String} filePath
+ * @param {String} content
+ * @param {Object} [fsModule]
+ * @returns {Promise<{createdLink: Boolean, capturedPath: String|null}>} Reversible link preparation.
+ */
+export async function writeAtomicFile(filePath, content, fsModule = fs) {
+    const absolute = path.resolve(filePath),
+          scratch  = `${absolute}.${process.pid}.${randomUUID()}.tmp`;
+
+    await fsModule.mkdir(path.dirname(absolute), {recursive: true});
+
+    try {
+        await fsModule.writeFile(scratch, content, {encoding: 'utf8', flag: 'wx', mode: 0o600});
+        await fsModule.rename(scratch, absolute)
+    } finally {
+        await fsModule.rm(scratch, {force: true}).catch(() => {})
+    }
+}
+
+/**
+ * @summary Reads an optional UTF-8 file, distinguishing absence from every other I/O failure.
+ * @param {String} filePath
+ * @param {Object} fsModule
+ * @returns {Promise<String|null>}
+ * @private
+ */
+async function readOptionalFile(filePath, fsModule) {
+    try {
+        return await fsModule.readFile(filePath, 'utf8')
+    } catch (error) {
+        if (error?.code === 'ENOENT') return null;
+        throw error
+    }
+}
+
+/**
+ * @summary Reads optional path metadata without treating permission/type errors as absence.
+ * @param {String} filePath
+ * @param {Object} fsModule
+ * @returns {Promise<Object|null>}
+ * @private
+ */
+async function lstatOptional(filePath, fsModule) {
+    try {
+        return await fsModule.lstat(filePath)
+    } catch (error) {
+        if (error?.code === 'ENOENT') return null;
+        throw error
+    }
+}
+
+/**
+ * @summary Captures enough metadata to reject a project-env replacement race.
+ * @param {Object} stat
+ * @returns {Object}
+ * @private
+ */
+function statIdentity(stat) {
+    return {
+        dev    : stat.dev,
+        ino    : stat.ino,
+        mode   : stat.mode,
+        size   : stat.size,
+        mtimeMs: stat.mtimeMs
+    }
+}
+
+/**
+ * @summary Classifies the Compose project env carrier and validates any existing symlink target.
+ * @param {String} projectEnvPath
+ * @param {String} envPath
+ * @param {Object} fsModule
+ * @returns {Promise<Object>} `{kind, statIdentity?, content?}`.
+ * @private
+ */
+async function inspectProjectEnvironment(projectEnvPath, envPath, fsModule) {
+    const stat = await lstatOptional(projectEnvPath, fsModule);
+
+    if (!stat) return {kind: 'missing'};
+
+    if (stat.isSymbolicLink()) {
+        const linkTarget = await fsModule.readlink(projectEnvPath),
+              resolved   = path.resolve(path.dirname(projectEnvPath), linkTarget);
+
+        if (resolved !== path.resolve(envPath)) {
+            throw new Error('project env is an unexpected symlink; refusing to retarget operator state')
+        }
+
+        return {kind: 'linked'}
+    }
+
+    if (!stat.isFile()) {
+        throw new Error('project env is neither a regular file nor the managed symlink')
+    }
+
+    return {
+        kind        : 'regular',
+        statIdentity: statIdentity(stat),
+        content     : await fsModule.readFile(projectEnvPath, 'utf8')
+    }
+}
+
+/**
+ * @summary Restores a captured regular project env without overwriting a concurrent replacement.
+ * @param {String} capturedPath
+ * @param {String} projectEnvPath
+ * @param {Object} fsModule
+ * @returns {Promise<Boolean>} `true` when restored; `false` when another path occupant won.
+ * @private
+ */
+async function restoreCapturedProjectEnvironment(capturedPath, projectEnvPath, fsModule) {
+    try {
+        // `link` is the no-overwrite primitive `rename` is not. The capture is a sibling, so it is on
+        // the same filesystem; retaining it until the link succeeds also preserves the operator bytes
+        // when another writer has already recreated `.env`.
+        await fsModule.link(capturedPath, projectEnvPath);
+        await fsModule.unlink(capturedPath);
+        return true
+    } catch (error) {
+        if (error?.code === 'EEXIST') return false;
+        throw error
+    }
+}
+
+/**
+ * @summary Makes the Compose project's default `.env` resolve to the persistent carrier.
+ *
+ * Missing paths are created without replacement semantics. A regular file is adopted only under the
+ * explicit flag and only if its metadata still matches the version inspected before materialization;
+ * an unexpected symlink or a concurrent replacement is never overwritten.
+ * @param {Object} options
+ * @param {String} options.projectEnvPath
+ * @param {String} options.envPath
+ * @param {Boolean} options.adoptExistingEnv
+ * @param {Object} options.observation
+ * @param {Object} options.fsModule
+ * @returns {Promise<void>}
+ * @private
+ */
+async function ensureProjectEnvironmentLink({
+    projectEnvPath,
+    envPath,
+    adoptExistingEnv,
+    observation,
+    fsModule
+}) {
+    if (observation.kind === 'linked') return {createdLink: false, capturedPath: null};
+
+    await fsModule.mkdir(path.dirname(projectEnvPath), {recursive: true});
+
+    if (observation.kind === 'missing') {
+        try {
+            await fsModule.symlink(path.resolve(envPath), projectEnvPath)
+        } catch (error) {
+            if (error?.code === 'EEXIST') {
+                throw new Error('project env appeared during materialization; refusing to replace it')
+            }
+            throw error
+        }
+        return {createdLink: true, capturedPath: null}
+    }
+
+    if (!adoptExistingEnv) {
+        throw new Error('project env is a regular file; pass --adopt-existing-env to preserve and adopt it')
+    }
+
+    const capturedPath = `${projectEnvPath}.${process.pid}.${randomUUID()}.captured`;
+
+    // Capture the ACTUAL final path occupant first. A check followed by rename(target) is not CAS:
+    // rename would silently overwrite an operator update that lands between those calls. Moving the
+    // occupant to a unique sibling never overwrites it, and leaves the destination absent so symlink
+    // creation can use its native no-overwrite behavior.
+    await fsModule.rename(projectEnvPath, capturedPath);
+
+    let capturedStat, capturedContent;
+
+    try {
+        capturedStat    = await fsModule.lstat(capturedPath);
+        capturedContent = await fsModule.readFile(capturedPath, 'utf8')
+    } catch (error) {
+        const restored = await restoreCapturedProjectEnvironment(capturedPath, projectEnvPath, fsModule);
+
+        throw new Error(restored
+            ? `project env capture could not be verified and was restored: ${error.message}`
+            : `project env capture could not be verified; operator file retained at ${capturedPath}`)
+    }
+
+    const unchanged = capturedStat.isFile()
+        && JSON.stringify(statIdentity(capturedStat)) === JSON.stringify(observation.statIdentity)
+        && capturedContent === observation.content;
+
+    if (!unchanged) {
+        const restored = await restoreCapturedProjectEnvironment(capturedPath, projectEnvPath, fsModule);
+
+        throw new Error(restored
+            ? 'project env changed during materialization; restored without replacement'
+            : `project env changed during materialization; captured operator file retained at ${capturedPath}`)
+    }
+
+    try {
+        await fsModule.symlink(path.resolve(envPath), projectEnvPath)
+    } catch (error) {
+        const restored = await restoreCapturedProjectEnvironment(capturedPath, projectEnvPath, fsModule);
+
+        if (!restored) {
+            throw new Error(
+                `project env appeared during adoption; captured operator file retained at ${capturedPath}`
+            )
+        }
+
+        throw error
+    }
+
+    // Keep the captured regular file until the caller commits the persistent carrier. If that write
+    // fails, rollback can restore the exact original instead of leaving a dangling symlink.
+    return {createdLink: true, capturedPath}
+}
+
+/**
+ * @summary Commits a prepared project-env link after the persistent carrier write succeeds.
+ * @param {Object} transaction
+ * @param {Object} fsModule
+ * @returns {Promise<void>}
+ * @private
+ */
+async function commitProjectEnvironmentLink(transaction, fsModule) {
+    if (transaction.capturedPath) {
+        await fsModule.unlink(transaction.capturedPath)
+    }
+}
+
+/**
+ * @summary Rolls back a prepared link without overwriting a concurrent path occupant.
+ * @param {Object} transaction
+ * @param {String} projectEnvPath
+ * @param {String} envPath
+ * @param {Object} fsModule
+ * @returns {Promise<void>}
+ * @private
+ */
+async function rollbackProjectEnvironmentLink(transaction, projectEnvPath, envPath, fsModule) {
+    if (!transaction.createdLink) return;
+
+    const current = await lstatOptional(projectEnvPath, fsModule);
+
+    if (!current?.isSymbolicLink()) {
+        throw new Error(transaction.capturedPath
+            ? `project env changed during rollback; operator file retained at ${transaction.capturedPath}`
+            : 'project env changed during rollback; refusing to remove it')
+    }
+
+    const currentTarget = path.resolve(path.dirname(projectEnvPath), await fsModule.readlink(projectEnvPath));
+
+    if (currentTarget !== path.resolve(envPath)) {
+        throw new Error(transaction.capturedPath
+            ? `project env retargeted during rollback; operator file retained at ${transaction.capturedPath}`
+            : 'project env retargeted during rollback; refusing to remove it')
+    }
+
+    await fsModule.unlink(projectEnvPath);
+
+    if (transaction.capturedPath) {
+        const restored = await restoreCapturedProjectEnvironment(
+            transaction.capturedPath,
+            projectEnvPath,
+            fsModule
+        );
+
+        if (!restored) {
+            throw new Error(
+                `project env appeared during rollback; operator file retained at ${transaction.capturedPath}`
+            )
+        }
+    }
+}
+
+/**
+ * @summary Identifies benign history rows that lost to a newer sink sequence.
+ * @param {Object} refusal
+ * @returns {Boolean}
+ * @private
+ */
+function isBenignSupersession(refusal) {
+    return refusal?.reason === LEDGER_REFUSALS.conflictingSequence
+        && refusal.detail?.length === 1
+        && refusal.detail[0].startsWith('superseded by sequence ')
+}
+
+/**
+ * @summary Identifies a strict-raise refusal whose desired deployment state is already live.
+ *
+ * This is deliberately registry-declared and materializer-only. Append/actuation keeps the strict
+ * transaction invariant; only reconciliation may accept equality, and an absent predicate fails
+ * closed for future knobs.
+ * @param {Object} refusal
+ * @returns {Boolean}
+ * @private
+ */
+function isAlreadyApplied(refusal) {
+    const record  = refusal?.record,
+          matcher = RECOVERY_KNOBS[record?.knob]?.matchesCurrentDeployment;
+
+    return refusal?.reason === LEDGER_REFUSALS.invalidTransaction
+        && typeof matcher === 'function'
+        && matcher(record.values, record.validatedAgainst?.context)
+}
+
+/**
+ * @summary Creates a stable SHA-256 digest for exact carrier-byte provenance.
+ * @param {String} content
+ * @returns {String}
+ * @private
+ */
+function digest(content) {
+    return createHash('sha256').update(content).digest('hex')
+}
+
+/**
+ * @summary Resolves the current runtime context required to revalidate one active deployment knob.
+ *
+ * The stored `validatedAgainst.context` proves why the operator's append was valid THEN. It cannot
+ * authorize deployment NOW: a 12 GiB raise captured against an 8 GiB container becomes a lowering
+ * instruction if the live container has since moved to 14 GiB. The materializer therefore asks Docker
+ * for the one identity-proven Compose target immediately before rendering and substitutes that fresh
+ * fact into current-registry validation.
+ *
+ * The resolver is intentionally closed over today's deployment-capable requirement. A future knob with
+ * another context leaf must add its own measured resolver rather than inheriting a guessed/default value.
+ * @param {Object} record Active, trusted ledger record.
+ * @param {Object} options
+ * @param {String} options.composeProject Exact Compose project identity.
+ * @param {Function} [options.execFileImpl]
+ * @returns {Promise<Object>} Current context keyed by registry requirement path.
+ */
+export async function resolveDeploymentRuntimeContext(record, {
+    composeProject,
+    execFileImpl = execFileAsync
+} = {}) {
+    if (!composeProject) {
+        throw new Error('runtime-context resolution requires the Compose project identity')
+    }
+
+    const requirements = RECOVERY_KNOBS[record?.knob]?.requires ?? [];
+
+    if (requirements.length === 0) return {};
+
+    if (requirements.length !== 1 || requirements[0] !== 'runtime.chroma.liveMemoryLimitBytes'
+        || record.targetIdentity?.id !== 'chroma') {
+        throw new Error(`no runtime-context resolver is declared for knob '${record?.knob}'`)
+    }
+
+    const listed = await execFileImpl('docker', [
+        'ps', '-a',
+        '--filter', `label=com.docker.compose.project=${composeProject}`,
+        '--filter', `label=com.docker.compose.service=${record.targetIdentity.id}`,
+        '--format', '{{.ID}}'
+    ], {encoding: 'utf8'}),
+          ids = listed.stdout.split('\n').map(value => value.trim()).filter(Boolean);
+
+    if (ids.length !== 1) {
+        throw new Error(
+            `runtime-context resolution expected one '${record.targetIdentity.id}' container in ` +
+            `Compose project '${composeProject}', found ${ids.length}`
+        )
+    }
+
+    const inspected = await execFileImpl(
+        'docker',
+        ['inspect', ids[0], '--format', '{{.HostConfig.Memory}}'],
+        {encoding: 'utf8'}
+    ),
+          liveMemoryLimitBytes = Number(inspected.stdout.trim());
+
+    if (!Number.isFinite(liveMemoryLimitBytes) || liveMemoryLimitBytes <= 0) {
+        throw new Error(`runtime-context resolution returned no finite positive memory limit for '${ids[0]}'`)
+    }
+
+    return {'runtime.chroma.liveMemoryLimitBytes': liveMemoryLimitBytes}
+}
+
+/**
+ * @summary Re-admits the ledger, atomically writes the persistent env carrier, links the Compose
+ * project to it, and snapshots the exact pre-deploy materialization for the later receipt.
+ * @param {Object} options
+ * @param {String} options.ledgerPath
+ * @param {String} options.envPath
+ * @param {String} options.projectEnvPath
+ * @param {String} [options.statePath]
+ * @param {String} [options.deploymentRunId]
+ * @param {Boolean} [options.adoptExistingEnv]
+ * @param {Function} [options.resolveContext] Fresh runtime-context resolver for each active record.
+ * @param {Object} [options.ambientEnvironment]
+ * @param {Object} [options.fsModule]
+ * @param {Function} [options.now]
+ * @returns {Promise<Object>} Bounded materialization summary; never env values or unrelated content.
+ */
+export async function materializeDeploymentPrescriptions({
+    ledgerPath,
+    envPath,
+    projectEnvPath,
+    statePath = null,
+    deploymentRunId = randomUUID(),
+    adoptExistingEnv = false,
+    resolveContext = null,
+    ambientEnvironment = process.env,
+    fsModule = fs,
+    now = Date.now
+} = {}) {
+    if (!ledgerPath || !envPath || !projectEnvPath) {
+        throw new Error('materialize requires ledgerPath, envPath, and projectEnvPath')
+    }
+
+    if (path.resolve(envPath) === path.resolve(projectEnvPath)) {
+        throw new Error('persistent env and project env must be distinct paths')
+    }
+
+    if (!RUN_ID_PATTERN.test(deploymentRunId ?? '')) {
+        throw new Error('materialize requires a UUID deploymentRunId')
+    }
+
+    assertNoAmbientPrescribedEnvironment(ambientEnvironment);
+
+    const
+        resolvedStatePath = statePath || path.join(path.dirname(path.resolve(envPath)), 'materialized-state.json'),
+        observation       = await inspectProjectEnvironment(projectEnvPath, envPath, fsModule),
+        persistentContent = await readOptionalFile(envPath, fsModule);
+
+    if (observation.kind === 'regular' && !adoptExistingEnv) {
+        throw new Error('project env is a regular file; pass --adopt-existing-env to preserve and adopt it')
+    }
+
+    if (observation.kind === 'regular' && persistentContent !== null
+        && persistentContent !== observation.content) {
+        throw new Error('persistent env and project env both exist with different content; refusing to choose one')
+    }
+
+    const
+        baseContent = observation.kind === 'regular' ? observation.content : (persistentContent ?? ''),
+        records     = await readDeploymentPrescriptions(ledgerPath, fsModule);
+
+    // Parsing JSONL is not an authority check. This audit verifies the sink-owned schema, producer
+    // stamp, global monotonic sequence, per-competition predecessor CAS, and observation watermark
+    // before the read-side fold is allowed to derive executable environment values.
+    validateDeploymentPrescriptionLedger(records);
+
+    const
+        historicalFold = admitLedgerPrescriptions(records),
+        fatal          = historicalFold.refused.filter(refusal => !isBenignSupersession(refusal));
+
+    if (fatal.length) {
+        const reasons = [...new Set(fatal.map(entry => entry.reason))].sort().join(', ');
+
+        throw new Error(`prescription ledger refused ${fatal.length} active/invalid record(s): ${reasons}`)
+    }
+
+    if (historicalFold.admitted.length && typeof resolveContext !== 'function') {
+        throw new Error('active deployment prescriptions require a fresh runtime-context resolver')
+    }
+
+    const currentRecords = await Promise.all(historicalFold.admitted.map(async record => ({
+        ...record,
+        validatedAgainst: {
+            ...record.validatedAgainst,
+            context: await resolveContext(record)
+        }
+    }))),
+          currentFold = admitLedgerPrescriptions(currentRecords),
+          alreadyApplied = currentFold.refused.filter(isAlreadyApplied),
+          currentFatal = currentFold.refused.filter(refusal => !isAlreadyApplied(refusal));
+
+    if (currentFatal.length) {
+        const reasons = [...new Set(currentFatal.map(entry => entry.reason))].sort().join(', ');
+
+        throw new Error(`active prescription failed current runtime revalidation: ${reasons}`)
+    }
+
+    const
+        activeRecords = [...currentFold.admitted, ...alreadyApplied.map(entry => entry.record)],
+        prescriptions = activeRecords.flatMap(record => knobEnvBindings(record.knob).map(binding => ({
+            key  : binding.env,
+            value: record.values[binding.path]
+        }))),
+        rendered = renderPrescribedEnvironment(prescriptions);
+
+    if (rendered.refused.length) {
+        throw new Error(`env renderer refused ${rendered.refused.length} admitted prescription(s)`)
+    }
+
+    const
+        merged             = mergePrescribedEnvironment(baseContent, rendered.content),
+        materializedDigest = digest(merged),
+        materializedAt     = new Date(now()).toISOString(),
+        state              = {
+            schemaVersion      : SCHEMA_VERSION,
+            recordType         : 'deployment-prescription-materialization',
+            deploymentRunId,
+            materializedAt,
+            materializedDigest,
+            activePrescriptions: activeRecords.map(record => ({
+                prescriptionId: record.prescriptionId,
+                sequence      : record.sequence,
+                knob          : record.knob,
+                targetIdentity: record.targetIdentity
+            }))
+        };
+
+    const linkTransaction = await ensureProjectEnvironmentLink({
+        projectEnvPath,
+        envPath,
+        adoptExistingEnv,
+        observation,
+        fsModule
+    });
+
+    try {
+        await writeAtomicFile(envPath, merged, fsModule)
+    } catch (error) {
+        await rollbackProjectEnvironmentLink(linkTransaction, projectEnvPath, envPath, fsModule);
+        throw error
+    }
+
+    await commitProjectEnvironmentLink(linkTransaction, fsModule);
+    await writeAtomicFile(resolvedStatePath, `${JSON.stringify(state, null, 2)}\n`, fsModule);
+
+    return {
+        status            : 'materialized',
+        activeCount       : state.activePrescriptions.length,
+        benignHistoryCount: historicalFold.refused.length,
+        deploymentRunId,
+        materializedDigest,
+        statePath         : resolvedStatePath
+    }
+}
+
+/**
+ * @summary Writes a post-health delivery receipt for the exact pre-up materialization snapshot.
+ * @param {Object} options
+ * @param {String} options.envPath
+ * @param {String} options.statePath
+ * @param {String} options.receiptPath
+ * @param {String} options.deploymentRunId
+ * @param {String} options.deployedRevision Full commit SHA the pipeline built.
+ * @param {Object} [options.fsModule]
+ * @param {Function} [options.now]
+ * @returns {Promise<Object>} The receipt written.
+ */
+export async function writeDeploymentPrescriptionReceipt({
+    envPath,
+    statePath,
+    receiptPath,
+    deploymentRunId,
+    deployedRevision,
+    fsModule = fs,
+    now = Date.now
+} = {}) {
+    if (!envPath || !statePath || !receiptPath || !RUN_ID_PATTERN.test(deploymentRunId ?? '')
+        || !/^[0-9a-f]{40}$/.test(deployedRevision ?? '')) {
+        throw new Error(
+            'receipt requires envPath, statePath, receiptPath, a UUID deploymentRunId, and a full lowercase commit SHA'
+        )
+    }
+
+    const state   = JSON.parse(await fsModule.readFile(statePath, 'utf8')),
+          content = await fsModule.readFile(envPath, 'utf8');
+
+    if (state?.schemaVersion !== SCHEMA_VERSION
+        || state?.recordType !== 'deployment-prescription-materialization'
+        || state?.deploymentRunId !== deploymentRunId
+        || !Array.isArray(state.activePrescriptions)
+        || !/^[0-9a-f]{64}$/.test(state.materializedDigest ?? '')) {
+        throw new Error('materialization state is malformed; refusing a delivery receipt')
+    }
+
+    if (digest(content) !== state.materializedDigest) {
+        throw new Error('persistent env changed after materialization; refusing a false delivery receipt')
+    }
+
+    const receipt = {
+        schemaVersion      : SCHEMA_VERSION,
+        recordType         : 'deployment-prescription-delivery-receipt',
+        status             : 'delivered',
+        deploymentRunId,
+        deliveredAt        : new Date(now()).toISOString(),
+        deployedRevision,
+        materializedAt     : state.materializedAt,
+        materializedDigest : state.materializedDigest,
+        activePrescriptions: state.activePrescriptions
+    };
+
+    await writeAtomicFile(receiptPath, `${JSON.stringify(receipt, null, 2)}\n`, fsModule);
+
+    return receipt
+}
+
+/**
+ * @summary Parses the three CLI modes with strict known-flag handling.
+ * @param {String[]} argv
+ * @returns {Object}
+ */
+export function parseArgs(argv) {
+    const [mode, ...rest] = argv,
+          knownModes      = new Set(['append', 'materialize', 'receipt']),
+          flags           = {};
+
+    if (!knownModes.has(mode)) {
+        throw new Error(`first argument must be append, materialize, or receipt (received ${mode || '<none>'})`)
+    }
+
+    for (let index = 0; index < rest.length; index++) {
+        const flag = rest[index];
+
+        if (flag === '--adopt-existing-env') {
+            flags.adoptExistingEnv = true;
+            continue
+        }
+
+        if (!flag.startsWith('--') || rest[index + 1] === undefined || rest[index + 1].startsWith('--')) {
+            throw new Error(`flag ${flag} requires a value`)
+        }
+
+        const key = flag.slice(2).replace(/-([a-z])/g, (match, letter) => letter.toUpperCase());
+
+        if (![
+            'ledger', 'env', 'state', 'projectEnv', 'receipt', 'deployedRevision', 'runId',
+            'composeProject',
+            'id', 'knob', 'target', 'values', 'context', 'observedAt', 'supersedes',
+            'diagnosisId', 'recoveryRunId'
+        ].includes(key)) {
+            throw new Error(`unknown flag: ${flag}`)
+        }
+
+        flags[key] = rest[++index]
+    }
+
+    return {mode, ...flags}
+}
+
+/**
+ * @summary Parses a CLI JSON object with a bounded field-specific failure.
+ * @param {String} raw
+ * @param {String} field
+ * @returns {Object}
+ * @private
+ */
+function parseObject(raw, field) {
+    let value;
+
+    try {
+        value = JSON.parse(raw)
+    } catch {
+        throw new Error(`${field} must be valid JSON`)
+    }
+
+    if (!value || typeof value !== 'object' || Array.isArray(value)) {
+        throw new Error(`${field} must be a JSON object`)
+    }
+
+    return value
+}
+
+/**
+ * @summary Runs one operator CLI mode, returning a process exit code.
+ * @param {String[]} [argv]
+ * @returns {Promise<Number>}
+ */
+export async function main(argv = process.argv.slice(2)) {
+    try {
+        const options         = parseArgs(argv),
+              ledgerPath      = options.ledger || path.join(DEFAULT_ROOT, 'prescriptions.jsonl'),
+              envPath         = options.env    || path.join(DEFAULT_ROOT, 'active.env'),
+              deploymentRunId = options.runId,
+              statePath       = options.state || (deploymentRunId
+                  ? path.join(DEFAULT_ROOT, `materialized-state.${deploymentRunId}.json`)
+                  : null);
+
+        if (options.mode === 'append') {
+            if (!options.id || !options.knob || !options.target || !options.values
+                || !options.context || !options.observedAt) {
+                throw new Error('append requires --id, --knob, --target, --values, --context, and --observed-at')
+            }
+
+            const observedAt = Number(options.observedAt);
+
+            if (!Number.isFinite(observedAt)) {
+                throw new Error('--observed-at must be a finite numeric watermark')
+            }
+
+            const result = await appendDeploymentPrescription({
+                ledgerPath,
+                producerPrincipal: 'operator-local',
+                prescription     : {
+                    prescriptionId          : options.id,
+                    supersedesPrescriptionId: options.supersedes || null,
+                    diagnosisId             : options.diagnosisId || null,
+                    recoveryRunId           : options.recoveryRunId || null,
+                    targetIdentity          : {kind: 'compose-service', id: options.target},
+                    knob                    : options.knob,
+                    values                  : parseObject(options.values, '--values'),
+                    validatedAgainst        : {
+                        context   : parseObject(options.context, '--context'),
+                        observedAt
+                    }
+                }
+            });
+
+            if (!result.appended && !result.replayed) {
+                throw new Error(`append refused: ${result.reason}`)
+            }
+
+            console.log(JSON.stringify({
+                status        : result.replayed ? 'replayed' : 'appended',
+                prescriptionId: result.record.prescriptionId,
+                sequence      : result.record.sequence
+            }));
+
+            return 0
+        }
+
+        if (options.mode === 'materialize') {
+            if (!options.composeProject || !deploymentRunId) {
+                throw new Error(
+                    'materialize requires --compose-project and --run-id for fresh, run-bound revalidation'
+                )
+            }
+
+            const result = await materializeDeploymentPrescriptions({
+                ledgerPath,
+                envPath,
+                statePath,
+                deploymentRunId,
+                projectEnvPath  : options.projectEnv || path.resolve('ai/deploy/.env'),
+                adoptExistingEnv: Boolean(options.adoptExistingEnv),
+                resolveContext  : record => resolveDeploymentRuntimeContext(record, {
+                    composeProject: options.composeProject
+                })
+            });
+
+            console.log(JSON.stringify(result));
+            return 0
+        }
+
+        if (!deploymentRunId) {
+            throw new Error('receipt requires --run-id')
+        }
+
+        const receipt = await writeDeploymentPrescriptionReceipt({
+            envPath,
+            statePath,
+            receiptPath     : options.receipt
+                || path.join(DEFAULT_ROOT, `delivery-receipt.${deploymentRunId}.json`),
+            deploymentRunId,
+            deployedRevision: options.deployedRevision || process.env.NEO_REVISION
+        });
+
+        console.log(JSON.stringify({
+            status            : receipt.status,
+            deploymentRunId   : receipt.deploymentRunId,
+            deployedRevision  : receipt.deployedRevision,
+            activeCount       : receipt.activePrescriptions.length,
+            materializedDigest: receipt.materializedDigest
+        }));
+
+        return 0
+    } catch (error) {
+        console.error(`[deployment-prescriptions] FATAL: ${error.message}`);
+        return 1
+    }
+}
+
+const isDirectRun = process.argv[1] && fileURLToPath(import.meta.url) === path.resolve(process.argv[1]);
+
+if (isDirectRun) {
+    process.exitCode = await main()
+}

--- a/ai/services/memory-core/helpers/deploymentPrescriptionLedger.mjs
+++ b/ai/services/memory-core/helpers/deploymentPrescriptionLedger.mjs
@@ -1,0 +1,250 @@
+import {isKnownKnob, knobEnvBindings, RECOVERY_KNOBS, validateKnobTransaction} from './recoveryKnobRegistry.mjs';
+
+/**
+ * Admits ledger records into the active prescription set the env renderer materializes.
+ *
+ * **This module exists because the ledger is an untrusted transport and the registry is the authority.**
+ * A record arrives having been validated once, by a producer, against a context that has since moved.
+ * Rendering it on that strength would make the ledger the security boundary — and the ledger is a file.
+ * So every record is revalidated here against the *current* registry: the knob must still exist, still
+ * address the target it names, still bound the values it carries, and still bind the env keys the
+ * renderer will write. Admission is computed, never accepted.
+ *
+ * **The env key is taken from the registry and never from the record.** The renderer downstream accepts
+ * any uppercase identifier with a positive finite value, so a record permitted to name its own `env`
+ * could turn a bounded heap prescription into an arbitrary numeric config mutation — the whole knob
+ * abstraction bypassed by one extra field. `knobEnvBindings()` is the only source consulted, which is
+ * also why a rebinding in the registry propagates here with no edit.
+ *
+ * **Ordering is `sequence`, never `prescribedAt`.** `prescribedAt` is audit metadata written by whoever
+ * produced the record, so letting it order deployment state lets a wrong clock choose which ceiling is
+ * live. `sequence` is sink-assigned and monotonic, so it is the only field with the authority to say
+ * which of two prescriptions for the same target supersedes the other.
+ *
+ * Scope: this is the READ side. It admits and folds; it does not append, and it does not write files.
+ * The trusted append ingress — compare-and-append per target, sink-stamped producer provenance,
+ * forged-producer rejection — is a separate boundary and deliberately not reachable from here.
+ */
+
+/**
+ * The record shape this module admits. Fields the registry already owns — the leaf→env binding, bounds,
+ * required context, the target service — are deliberately absent: a record that restated them could
+ * disagree with the authority, and then the disagreement would have to be adjudicated rather than
+ * simply not existing.
+ * @typedef {Object} LedgerPrescriptionRecord
+ * @property {String} recordType            Must be `deployment-prescription`.
+ * @property {String} prescriptionId        Identity, used for idempotent replay.
+ * @property {Number} sequence              Sink-assigned monotonic ordering authority.
+ * @property {String} knob                  A key of `RECOVERY_KNOBS`.
+ * @property {Object} targetIdentity        `{kind, id}`; `id` must match the knob's declared service.
+ * @property {Object} values                Keyed by the knob's registry leaf paths.
+ * @property {Object} [validatedAgainst]    `{context, observationFingerprint, observedAt}`.
+ */
+
+/**
+ * The target kinds a prescription may address. Closed rather than open because `competitionKey()`
+ * includes `kind`: an unbounded kind is a way to mint extra competitions for one env variable, so the
+ * set is the guard and not documentation. Widening it is a deliberate edit with its own delivery story.
+ * @type {Set<String>}
+ */
+const DEPLOYMENT_CAPABLE_TARGET_KINDS = new Set(['compose-service']);
+
+/**
+ * Refusal reasons, named rather than free-text so a caller can act on them and a ledger audit can count
+ * them. A refused record is a fact worth recording — the alternative is a materialization that is
+ * quietly narrower than the ledger it claims to represent.
+ * @type {Object}
+ */
+export const LEDGER_REFUSALS = Object.freeze({
+    conflictingSequence: 'conflicting-sequence',
+    invalidTransaction : 'invalid-transaction',
+    notAPrescription   : 'not-a-prescription',
+    targetMismatch     : 'target-mismatch',
+    unknownKnob        : 'unknown-knob',
+    unorderable        : 'unorderable'
+});
+
+/**
+ * @summary Groups records by the target they compete for.
+ *
+ * Supersession is per `{target, knob}` and not global: two knobs on the same service are independent
+ * prescriptions, and the same knob on two services must not have one silently outrank the other.
+ * @param {LedgerPrescriptionRecord} record
+ * @returns {String}
+ */
+function competitionKey(record) {
+    return `${record.knob}::${record.targetIdentity?.kind ?? '?'}:${record.targetIdentity?.id ?? '?'}`
+}
+
+/**
+ * @summary Canonicalizes the registry leaf map for semantic payload comparison.
+ *
+ * Object insertion order is transport trivia. Comparing raw `JSON.stringify(values)` would poison an
+ * equal-sequence replay whose two registry leaves were serialized in a different order, even though
+ * the transaction was identical. Registry leaf values are JSON primitives, so sorting their paths is
+ * the complete semantic projection.
+ * @param {Object} values
+ * @returns {String}
+ * @private
+ */
+function canonicalValues(values) {
+    return JSON.stringify(Object.keys(values ?? {}).sort().map(key => [key, values[key]]))
+}
+
+/**
+ * @summary Revalidates one record against the current registry, returning a refusal reason or null.
+ *
+ * Ordered cheapest-first and deliberately total: a record that fails anything is admitted for nothing.
+ * Partial admission is the same failure `validateKnobTransaction` refuses partial application for — a
+ * half-applied knob leaves state that depends on what the target happened to hold.
+ * @param {LedgerPrescriptionRecord} record
+ * @returns {{reason: String, detail: String[]}|null}
+ */
+export function refuseLedgerRecord(record) {
+    if (record?.recordType !== 'deployment-prescription') {
+        return {reason: LEDGER_REFUSALS.notAPrescription, detail: [`recordType '${record?.recordType}'`]}
+    }
+
+    // A record the sink never ordered cannot be folded, and defaulting it to 0 or to arrival order would
+    // hand ordering authority back to the transport this module exists to distrust.
+    if (!Number.isInteger(record.sequence) || record.sequence < 0) {
+        return {reason: LEDGER_REFUSALS.unorderable, detail: [`sequence ${JSON.stringify(record.sequence)} is not a non-negative integer`]}
+    }
+
+    if (!isKnownKnob(record.knob)) {
+        return {reason: LEDGER_REFUSALS.unknownKnob, detail: [`'${record.knob}'`]}
+    }
+
+    // `kind` is validated against a closed set BEFORE `id`, because the competition key includes it:
+    // an unvalidated kind lets one `id` open a SECOND competition for the same env key, and then two
+    // winners render for one variable and the last one written wins by array position. Measured on the
+    // superseded revision — `{kind: 'anything', id: 'chroma'}` beside the declared kind produced two
+    // entries whose order flipped with read order. A field the competition key reads is a field
+    // admission must bound.
+    if (!DEPLOYMENT_CAPABLE_TARGET_KINDS.has(record.targetIdentity?.kind)) {
+        return {
+            reason: LEDGER_REFUSALS.targetMismatch,
+            detail: [`target kind '${record.targetIdentity?.kind}' is not deployment-capable`]
+        }
+    }
+
+    // The registry declares the one service a knob addresses. A record aiming a chroma ceiling at
+    // another container is refused here rather than rendered, because the env binding would resolve
+    // from the registry and silently move the service the knob DOES own.
+    const declaredService = RECOVERY_KNOBS[record.knob].serviceKey;
+
+    if (record.targetIdentity?.id !== declaredService) {
+        return {
+            reason: LEDGER_REFUSALS.targetMismatch,
+            detail: [`knob '${record.knob}' addresses '${declaredService}', record names '${record.targetIdentity?.id}'`]
+        }
+    }
+
+    const {valid, violations} = validateKnobTransaction({
+        knob  : record.knob,
+        values: record.values,
+        // The producer's resolved bounds travel with the record; they are re-evaluated, not trusted. A
+        // context that has gone stale surfaces as a violation, which is a disposition — not a new line.
+        context: record.validatedAgainst?.context
+    });
+
+    return valid ? null : {reason: LEDGER_REFUSALS.invalidTransaction, detail: violations}
+}
+
+/**
+ * @summary Folds a ledger into the active prescription set, ready for the env renderer.
+ *
+ * **Last-write-wins is decided by `sequence` here rather than left to the renderer.** The renderer's
+ * own duplicate collapse is a rendering detail — it cannot tell a legitimate successor from a replay,
+ * a conflict, or a late arrival with a stale watermark, because it never sees the ordering field. So the
+ * ledger resolves supersession and hands the renderer a set with one entry per key.
+ * @param {LedgerPrescriptionRecord[]} records Ledger order as read; arrival order is NOT trusted.
+ * @returns {{prescriptions: Array<{key: String, value: Number}>, admitted: Object[], refused: Array<{record: Object, reason: String, detail: String[]}>}}
+ */
+export function admitLedgerPrescriptions(records) {
+    const
+        conflicted = new Set(),
+        refused    = [],
+        winners    = new Map();
+
+    for (const record of records ?? []) {
+        const refusal = refuseLedgerRecord(record);
+
+        if (refusal) {
+            refused.push({record, ...refusal});
+            continue
+        }
+
+        const
+            key       = competitionKey(record),
+            incumbent = winners.get(key);
+
+        if (!incumbent) {
+            winners.set(key, record);
+            continue
+        }
+
+        if (record.sequence > incumbent.sequence) {
+            winners.set(key, record);
+            continue
+        }
+
+        // Equal watermark, different payload: the sink assigned one ordering position to two different
+        // intents, so NEITHER can be shown to supersede the other.
+        //
+        // **The whole competition fails closed — refusing only the newcomer was the bug.** That kept the
+        // incumbent, and the incumbent is whichever record was READ FIRST, so deployment state depended
+        // on read order: the same two records rendered 10 GiB in one order and 12 GiB in the other. A
+        // fold whose output depends on input order has not resolved the conflict, it has hidden it
+        // behind an arbitrary winner. Poisoning the key means the env variable is simply not
+        // materialized until the ledger is repaired, which is the honest state.
+        if (record.sequence === incumbent.sequence
+            && canonicalValues(record.values) !== canonicalValues(incumbent.values)) {
+            conflicted.add(key);
+
+            refused.push({
+                record,
+                reason: LEDGER_REFUSALS.conflictingSequence,
+                detail: [`sequence ${record.sequence} contested with '${incumbent.prescriptionId}'; the whole competition is refused`]
+            });
+            continue
+        }
+
+        // Lower sequence, or an idempotent replay of the same payload. Both are non-events: a stale
+        // watermark completing late must not unwind a newer admitted prescription.
+        refused.push({
+            record,
+            reason: LEDGER_REFUSALS.conflictingSequence,
+            detail: [`superseded by sequence ${incumbent.sequence}`]
+        })
+    }
+
+    // The poisoned keys are dropped AFTER the fold, not during it: a conflict can be discovered by a
+    // record that arrives after the incumbent was already admitted, so the incumbent must be withdrawn
+    // retroactively. Deciding at admission time would make the outcome depend on when the conflict was
+    // seen — the same read-order dependence one step removed.
+    for (const key of conflicted) {
+        const loser = winners.get(key);
+
+        if (loser) {
+            winners.delete(key);
+            refused.push({
+                record: loser,
+                reason: LEDGER_REFUSALS.conflictingSequence,
+                detail: [`withdrawn: competition '${key}' is contested at sequence ${loser.sequence}`]
+            })
+        }
+    }
+
+    const
+        admitted      = [...winners.values()],
+        prescriptions = [];
+
+    for (const record of admitted) {
+        for (const {path, env} of knobEnvBindings(record.knob)) {
+            prescriptions.push({key: env, value: record.values[path]})
+        }
+    }
+
+    return {prescriptions, admitted, refused}
+}

--- a/ai/services/memory-core/helpers/deploymentPrescriptionStore.mjs
+++ b/ai/services/memory-core/helpers/deploymentPrescriptionStore.mjs
@@ -1,0 +1,566 @@
+import {randomUUID} from 'node:crypto';
+import fs           from 'node:fs/promises';
+import path         from 'node:path';
+
+import {refuseLedgerRecord} from './deploymentPrescriptionLedger.mjs';
+
+/**
+ * @module ai/services/memory-core/helpers/deploymentPrescriptionStore
+ * @summary Trusted, durable append ingress for semantic deployment prescriptions.
+ *
+ * The caller supplies intent; this sink owns transport authority. It therefore rejects caller-provided
+ * sequence, provenance, schema, record-type, and audit-time fields, stamps them only after holding the
+ * ledger lock, and revalidates the resulting record against the current recovery-knob registry through
+ * {@link module:ai/services/memory-core/helpers/deploymentPrescriptionLedger.refuseLedgerRecord}.
+ *
+ * Compare-and-append and sequence assignment happen under one bounded, atomic `wx` lock. A live holder is
+ * waited out; a lock that cannot be acquired within the bound refuses without falling through unlocked.
+ * This is intentionally stricter than the best-effort Memory WAL lock: an interleaved WAL line can be
+ * skipped, while an interleaved prescription can select the wrong deployment state.
+ */
+
+const
+    DEFAULT_LOCK_RETRY_MS   = 10,
+    DEFAULT_LOCK_TIMEOUT_MS = 2_000,
+    RECORD_TYPE             = 'deployment-prescription',
+    SCHEMA_VERSION          = 1;
+
+const SINK_OWNED_FIELDS = new Set([
+    'prescribedAt',
+    'producerPrincipal',
+    'recordType',
+    'schemaVersion',
+    'sequence'
+]);
+
+const SEMANTIC_FIELDS = new Set([
+    'diagnosisId',
+    'knob',
+    'prescriptionId',
+    'recoveryRunId',
+    'supersedesPrescriptionId',
+    'targetIdentity',
+    'validatedAgainst',
+    'values'
+]);
+
+const STORED_FIELDS = new Set([...SINK_OWNED_FIELDS, ...SEMANTIC_FIELDS]);
+
+/**
+ * @summary Returns the four-field result contract used for both appends and refusals.
+ * @param {Object} [options]
+ * @param {Boolean} [options.appended=false]
+ * @param {Boolean} [options.replayed=false]
+ * @param {Object|null} [options.record=null]
+ * @param {String|null} [options.reason=null]
+ * @returns {{appended: Boolean, replayed: Boolean, record: Object|null, reason: String|null}}
+ */
+function appendResult({appended = false, replayed = false, record = null, reason = null} = {}) {
+    return {appended, replayed, record, reason}
+}
+
+/**
+ * @summary Converts JSON-safe data into a recursively key-sorted value.
+ *
+ * This is the idempotence boundary. Object insertion order is not semantic, so two callers expressing
+ * the same context or values in a different key order must compare equal. Non-JSON values are refused
+ * instead of relying on `JSON.stringify()`'s lossy coercions (`NaN` to `null`, functions to absence).
+ * @param {*} value
+ * @param {Set<Object>} [ancestors]
+ * @returns {*}
+ */
+function canonicalizeJson(value, ancestors = new Set()) {
+    if (value === null || typeof value === 'string' || typeof value === 'boolean') {
+        return value
+    }
+
+    if (typeof value === 'number') {
+        if (!Number.isFinite(value)) {
+            throw new TypeError('semantic prescription contains a non-finite number')
+        }
+
+        return value
+    }
+
+    if (typeof value !== 'object') {
+        throw new TypeError(`semantic prescription contains unsupported ${typeof value}`)
+    }
+
+    if (ancestors.has(value)) {
+        throw new TypeError('semantic prescription contains a circular reference')
+    }
+
+    ancestors.add(value);
+
+    let canonical;
+
+    if (Array.isArray(value)) {
+        canonical = value.map(item => {
+            if (item === undefined) {
+                throw new TypeError('semantic prescription contains undefined in an array')
+            }
+
+            return canonicalizeJson(item, ancestors)
+        })
+    } else {
+        const prototype = Object.getPrototypeOf(value);
+
+        if (prototype !== Object.prototype && prototype !== null) {
+            throw new TypeError('semantic prescription contains a non-plain object')
+        }
+
+        canonical = {};
+
+        for (const key of Object.keys(value).sort()) {
+            if (value[key] !== undefined) {
+                canonical[key] = canonicalizeJson(value[key], ancestors)
+            }
+        }
+    }
+
+    ancestors.delete(value);
+
+    return canonical
+}
+
+/**
+ * @summary Produces the stable byte representation used for semantic replay comparison.
+ * @param {Object} value
+ * @returns {String}
+ */
+function canonicalJson(value) {
+    return JSON.stringify(canonicalizeJson(value))
+}
+
+/**
+ * @summary Validates and canonicalizes the caller-owned portion of a prescription.
+ * @param {Object} prescription
+ * @returns {{prescription: Object|null, reason: String|null}}
+ */
+function normalizeSemanticPrescription(prescription) {
+    if (!prescription || typeof prescription !== 'object' || Array.isArray(prescription)) {
+        return {prescription: null, reason: 'invalid-prescription'}
+    }
+
+    for (const field of SINK_OWNED_FIELDS) {
+        if (Object.hasOwn(prescription, field)) {
+            return {prescription: null, reason: `caller-field-forbidden:${field}`}
+        }
+    }
+
+    for (const field of Object.keys(prescription)) {
+        if (!SEMANTIC_FIELDS.has(field)) {
+            return {prescription: null, reason: `unsupported-field:${field}`}
+        }
+    }
+
+    if (typeof prescription.prescriptionId !== 'string' || prescription.prescriptionId.trim().length === 0) {
+        return {prescription: null, reason: 'invalid-prescription-id'}
+    }
+
+    const supersedesPrescriptionId = prescription.supersedesPrescriptionId ?? null;
+
+    if (supersedesPrescriptionId !== null
+        && (typeof supersedesPrescriptionId !== 'string' || supersedesPrescriptionId.trim().length === 0)) {
+        return {prescription: null, reason: 'invalid-supersedes-prescription-id'}
+    }
+
+    const observedAt = prescription.validatedAgainst?.observedAt;
+
+    if (observedAt !== undefined && !Number.isFinite(observedAt)) {
+        return {prescription: null, reason: 'invalid-observation-watermark'}
+    }
+
+    try {
+        const semantic = {supersedesPrescriptionId};
+
+        for (const field of SEMANTIC_FIELDS) {
+            if (field !== 'supersedesPrescriptionId' && Object.hasOwn(prescription, field)) {
+                semantic[field] = prescription[field]
+            }
+        }
+
+        return {
+            prescription: JSON.parse(canonicalJson(semantic)),
+            reason      : null
+        }
+    } catch {
+        return {prescription: null, reason: 'invalid-semantic-payload'}
+    }
+}
+
+/**
+ * @summary Projects a stored record back to its caller-owned semantic payload.
+ * @param {Object} record
+ * @returns {Object}
+ */
+function semanticPayload(record) {
+    const payload = {};
+
+    for (const field of SEMANTIC_FIELDS) {
+        if (Object.hasOwn(record, field)) {
+            payload[field] = record[field]
+        }
+    }
+
+    const normalized = normalizeSemanticPrescription(payload);
+
+    if (normalized.reason) {
+        throw new Error(`Deployment prescription ledger contains invalid semantic payload: ${normalized.reason}`)
+    }
+
+    return normalized.prescription
+}
+
+/**
+ * @summary Returns the target-and-knob competition key guarded by compare-and-append.
+ * @param {Object} record
+ * @returns {String}
+ */
+function competitionKey(record) {
+    return `${record.knob}::${record.targetIdentity.kind}:${record.targetIdentity.id}`
+}
+
+/**
+ * @summary Reads a JSONL prescription ledger in append order.
+ *
+ * Absence means no prescriptions and returns `[]`. A malformed or non-object line throws with its line
+ * number: silently skipping a torn line could skip the active predecessor and make a later CAS appear valid.
+ * @param {String} ledgerPath Durable JSONL path.
+ * @param {Object} [fsModule=fs] Injectable `node:fs/promises`-compatible module.
+ * @returns {Promise<Object[]>}
+ */
+export async function readDeploymentPrescriptions(ledgerPath, fsModule = fs) {
+    if (typeof ledgerPath !== 'string' || ledgerPath.length === 0) {
+        throw new TypeError('readDeploymentPrescriptions: ledgerPath is required')
+    }
+
+    let text;
+
+    try {
+        text = await fsModule.readFile(ledgerPath, 'utf8')
+    } catch (error) {
+        if (error?.code === 'ENOENT') {
+            return []
+        }
+
+        throw error
+    }
+
+    const records = [];
+
+    for (const [index, line] of text.split('\n').entries()) {
+        if (line.trim().length === 0) continue;
+
+        let record;
+
+        try {
+            record = JSON.parse(line)
+        } catch (cause) {
+            throw new SyntaxError(`Invalid deployment prescription JSONL at line ${index + 1}`, {cause})
+        }
+
+        if (!record || typeof record !== 'object' || Array.isArray(record)) {
+            throw new SyntaxError(`Invalid deployment prescription record at line ${index + 1}: object required`)
+        }
+
+        records.push(record)
+    }
+
+    return records
+}
+
+/**
+ * @summary Audits sink-owned invariants in an existing ledger and rebuilds its active CAS index.
+ * @param {Object[]} records
+ * @returns {{activeByKey: Map<String, Object>, byId: Map<String, Object>, maxSequence: Number}}
+ */
+function inspectTrustedLedger(records) {
+    const
+        activeByKey = new Map(),
+        byId        = new Map();
+
+    let maxSequence = 0;
+
+    for (const [index, record] of records.entries()) {
+        const line = index + 1;
+
+        for (const field of Object.keys(record)) {
+            if (!STORED_FIELDS.has(field)) {
+                throw new Error(`Deployment prescription ledger line ${line} contains unsupported field '${field}'`)
+            }
+        }
+
+        if (record.schemaVersion !== SCHEMA_VERSION || record.recordType !== RECORD_TYPE) {
+            throw new Error(`Deployment prescription ledger line ${line} has an unsupported schema or record type`)
+        }
+
+        if (!Number.isSafeInteger(record.sequence) || record.sequence < 1 || record.sequence <= maxSequence) {
+            throw new Error(`Deployment prescription ledger line ${line} breaks monotonic sequence ordering`)
+        }
+
+        if (typeof record.producerPrincipal !== 'string' || record.producerPrincipal.trim().length === 0) {
+            throw new Error(`Deployment prescription ledger line ${line} has no sink-stamped producer principal`)
+        }
+
+        if (!Number.isFinite(record.prescribedAt)) {
+            throw new Error(`Deployment prescription ledger line ${line} has no finite sink-stamped audit time`)
+        }
+
+        const refusal = refuseLedgerRecord(record);
+
+        if (refusal) {
+            throw new Error(`Deployment prescription ledger line ${line} is refused by current authority: ${refusal.reason}`)
+        }
+
+        if (byId.has(record.prescriptionId)) {
+            throw new Error(`Deployment prescription ledger repeats prescriptionId '${record.prescriptionId}'`)
+        }
+
+        const
+            semantic = semanticPayload(record),
+            key      = competitionKey(record),
+            active   = activeByKey.get(key),
+            expected = active?.prescriptionId ?? null;
+
+        if (semantic.supersedesPrescriptionId !== expected) {
+            throw new Error(`Deployment prescription ledger line ${line} breaks predecessor CAS for '${key}'`)
+        }
+
+        const
+            activeObservedAt = active?.validatedAgainst?.observedAt,
+            observedAt       = record.validatedAgainst?.observedAt;
+
+        if (Number.isFinite(activeObservedAt)
+            && (!Number.isFinite(observedAt) || observedAt < activeObservedAt)) {
+            throw new Error(`Deployment prescription ledger line ${line} regresses validation watermark for '${key}'`)
+        }
+
+        activeByKey.set(key, record);
+        byId.set(record.prescriptionId, record);
+        maxSequence = record.sequence
+    }
+
+    return {activeByKey, byId, maxSequence}
+}
+
+/**
+ * @summary Validates the complete sink-owned ledger contract before any record may be admitted or rendered.
+ *
+ * Reading JSONL proves only that bytes parse. This audit additionally proves the schema and producer fields
+ * were sink-stamped, sequence is globally monotonic, every record still clears current registry authority,
+ * ids are unique, predecessor CAS is continuous per target-and-knob, and observation watermarks never regress.
+ * It returns only bounded counts; callers that need records retain the array they supplied.
+ * @param {Object[]} records Parsed records from {@link readDeploymentPrescriptions}.
+ * @returns {{valid: true, recordCount: Number, activeCount: Number, maxSequence: Number}}
+ * @throws {TypeError} when `records` is not an array.
+ * @throws {Error} when any record breaks the trusted-ledger contract.
+ */
+export function validateDeploymentPrescriptionLedger(records) {
+    if (!Array.isArray(records)) {
+        throw new TypeError('validateDeploymentPrescriptionLedger: records must be an array')
+    }
+
+    const {activeByKey, maxSequence} = inspectTrustedLedger(records);
+
+    return {
+        valid      : true,
+        recordCount: records.length,
+        activeCount: activeByKey.size,
+        maxSequence
+    }
+}
+
+/**
+ * @summary Claims a bounded exclusive lock via atomic `wx`, returning an idempotent release callback.
+ *
+ * There is deliberately no unlocked fall-through and no content-blind stale reclaim. On a live collision
+ * the caller waits only to `timeoutMs`; on an abandoned lock it returns `null`, leaving an explicit operator
+ * repair rather than risking removal of a successor's lock through a path-level TOCTOU race.
+ * @param {String} ledgerPath
+ * @param {Object} fsModule
+ * @param {Number} timeoutMs
+ * @param {Number} retryMs
+ * @returns {Promise<Function|null>}
+ */
+async function acquireAppendLock(ledgerPath, fsModule, timeoutMs, retryMs) {
+    const
+        lockPath = `${ledgerPath}.lock`,
+        started  = Date.now(),
+        token    = `${process.pid}:${randomUUID()}`;
+
+    while (true) {
+        try {
+            await fsModule.writeFile(lockPath, token, {encoding: 'utf8', flag: 'wx', mode: 0o600});
+
+            return async () => {
+                try {
+                    if (await fsModule.readFile(lockPath, 'utf8') === token) {
+                        await fsModule.unlink(lockPath)
+                    }
+                } catch (error) {
+                    if (error?.code !== 'ENOENT') throw error
+                }
+            }
+        } catch (error) {
+            if (error?.code !== 'EEXIST') {
+                throw error
+            }
+
+            const elapsed = Date.now() - started;
+
+            if (elapsed >= timeoutMs) {
+                return null
+            }
+
+            await new Promise(resolve => setTimeout(resolve, Math.min(retryMs, timeoutMs - elapsed)))
+        }
+    }
+}
+
+/**
+ * @summary Appends one complete JSONL record and fsyncs it before reporting success.
+ * @param {String} ledgerPath
+ * @param {Object} record
+ * @param {Object} fsModule
+ * @returns {Promise<void>}
+ */
+async function appendDurably(ledgerPath, record, fsModule) {
+    const handle = await fsModule.open(ledgerPath, 'a', 0o600);
+
+    try {
+        await handle.appendFile(`${JSON.stringify(record)}\n`, 'utf8');
+        await handle.sync()
+    } finally {
+        await handle.close()
+    }
+}
+
+/**
+ * @summary Validates, compare-and-appends, and durably records one semantic deployment prescription.
+ *
+ * A domain refusal always returns `{appended:false, replayed:false, record:null, reason}` and writes zero
+ * ledger bytes. Exact idempotent replay returns the original sink-stamped record without appending. I/O
+ * errors and a corrupt existing ledger throw because reporting those as an ordinary refusal would hide a
+ * broken authority surface.
+ * @param {Object} options
+ * @param {String} options.ledgerPath Durable JSONL path.
+ * @param {Object} options.prescription Caller-owned semantic prescription.
+ * @param {String} [options.producerPrincipal='operator-local'] Principal injected by the trusted sink.
+ * @param {Function|Number} [options.now=Date.now] Sink audit clock.
+ * @param {Object} [options.fsModule=fs] Injectable `node:fs/promises`-compatible module.
+ * @param {Number} [options.lockTimeoutMs=2000] Maximum live-lock wait before a no-write refusal.
+ * @param {Number} [options.lockRetryMs=10] Retry interval while a live holder completes.
+ * @returns {Promise<{appended: Boolean, replayed: Boolean, record: Object|null, reason: String|null}>}
+ */
+export async function appendDeploymentPrescription({
+    ledgerPath,
+    prescription,
+    producerPrincipal = 'operator-local',
+    now               = Date.now,
+    fsModule          = fs,
+    lockTimeoutMs     = DEFAULT_LOCK_TIMEOUT_MS,
+    lockRetryMs       = DEFAULT_LOCK_RETRY_MS
+} = {}) {
+    if (typeof ledgerPath !== 'string' || ledgerPath.length === 0) {
+        throw new TypeError('appendDeploymentPrescription: ledgerPath is required')
+    }
+
+    const normalized = normalizeSemanticPrescription(prescription);
+
+    if (normalized.reason) {
+        return appendResult({reason: normalized.reason})
+    }
+
+    if (typeof producerPrincipal !== 'string' || producerPrincipal.trim().length === 0) {
+        return appendResult({reason: 'invalid-producer-principal'})
+    }
+
+    if (!Number.isFinite(lockTimeoutMs) || lockTimeoutMs < 0
+        || !Number.isFinite(lockRetryMs) || lockRetryMs <= 0) {
+        throw new TypeError('appendDeploymentPrescription: lock bounds must be finite and non-negative')
+    }
+
+    const prescribedAt = typeof now === 'function' ? now() : now;
+
+    if (!Number.isFinite(prescribedAt)) {
+        return appendResult({reason: 'invalid-prescribed-at'})
+    }
+
+    await fsModule.mkdir(path.dirname(ledgerPath), {recursive: true});
+
+    const releaseLock = await acquireAppendLock(
+        ledgerPath,
+        fsModule,
+        lockTimeoutMs,
+        lockRetryMs
+    );
+
+    if (!releaseLock) {
+        return appendResult({reason: 'append-lock-timeout'})
+    }
+
+    try {
+        const
+            records                          = await readDeploymentPrescriptions(ledgerPath, fsModule),
+            {activeByKey, byId, maxSequence} = inspectTrustedLedger(records),
+            semantic                         = normalized.prescription,
+            existing                         = byId.get(semantic.prescriptionId);
+
+        if (existing) {
+            if (canonicalJson(semanticPayload(existing)) === canonicalJson(semantic)) {
+                return appendResult({replayed: true, record: existing})
+            }
+
+            return appendResult({reason: 'prescription-id-conflict'})
+        }
+
+        const nextSequence = maxSequence + 1;
+
+        if (!Number.isSafeInteger(nextSequence)) {
+            return appendResult({reason: 'sequence-exhausted'})
+        }
+
+        const record = {
+            schemaVersion: SCHEMA_VERSION,
+            recordType   : RECORD_TYPE,
+            ...semantic,
+            sequence     : nextSequence,
+            producerPrincipal,
+            prescribedAt
+        };
+
+        const refusal = refuseLedgerRecord(record);
+
+        if (refusal) {
+            return appendResult({reason: `ledger-refused:${refusal.reason}`})
+        }
+
+        const
+            key                 = competitionKey(record),
+            active              = activeByKey.get(key),
+            expectedPredecessor = active?.prescriptionId ?? null;
+
+        if (semantic.supersedesPrescriptionId !== expectedPredecessor) {
+            return appendResult({reason: 'predecessor-mismatch'})
+        }
+
+        const
+            activeObservedAt = active?.validatedAgainst?.observedAt,
+            observedAt       = record.validatedAgainst?.observedAt;
+
+        if (Number.isFinite(activeObservedAt) && !Number.isFinite(observedAt)) {
+            return appendResult({reason: 'observation-watermark-required'})
+        }
+
+        if (Number.isFinite(activeObservedAt) && observedAt < activeObservedAt) {
+            return appendResult({reason: 'stale-observation-watermark'})
+        }
+
+        await appendDurably(ledgerPath, record, fsModule);
+
+        return appendResult({appended: true, record})
+    } finally {
+        await releaseLock()
+    }
+}

--- a/ai/services/memory-core/helpers/recoveryKnobRegistry.mjs
+++ b/ai/services/memory-core/helpers/recoveryKnobRegistry.mjs
@@ -97,6 +97,19 @@ export const RECOVERY_KNOBS = Object.freeze({
                 max     : CONTAINER_MEMORY_CEILING_MAX_BYTES
             })
         ]),
+        /**
+         * Delivery reconciliation is not actuation admission. The actuator must only propose a
+         * strict raise, but after that raise has landed an ordinary redeploy sees equality and must
+         * keep delivering the same desired state. This predicate lets the host materializer
+         * distinguish that idempotent equality from a now-lower, dangerous stale prescription
+         * without weakening `raise-not-lower` for any producer or actuator caller.
+         * @param {Object} values
+         * @param {Object} context
+         * @returns {Boolean}
+         */
+        matchesCurrentDeployment: (values, context = {}) =>
+            values['deploy.chroma.memoryCeilingBytes'] ===
+            context['runtime.chroma.liveMemoryLimitBytes'],
         invariants: Object.freeze([
             Object.freeze({
                 id    : 'raise-not-lower',
@@ -193,6 +206,23 @@ export function isKnownKnob(knob) {
  */
 export function knobLeafPaths(knob) {
     return isKnownKnob(knob) ? RECOVERY_KNOBS[knob].leaves.map(leaf => leaf.path) : []
+}
+
+/**
+ * @summary The leaf→environment bindings a knob delivers through, resolved from the registry.
+ *
+ * **This exists so a consumer never has to take an env key from a record it was handed.** The renderer
+ * downstream accepts any uppercase identifier, so a record carrying its own `env` field would let a
+ * forged prescription for one knob write an arbitrary numeric config key. The binding is registry
+ * property, and this accessor is the only sanctioned way to learn it — same reason
+ * {@link knobRequiredContext} exists: adding or rebinding a leaf must not require editing the caller.
+ * @param {String} knob
+ * @returns {Array<{path: String, env: String}>} Empty for an unknown knob — gate on {@link isKnownKnob}.
+ */
+export function knobEnvBindings(knob) {
+    return isKnownKnob(knob)
+        ? RECOVERY_KNOBS[knob].leaves.map(leaf => ({path: leaf.path, env: leaf.env}))
+        : []
 }
 
 /**

--- a/learn/agentos/cloud-deployment/PipelineWiring.md
+++ b/learn/agentos/cloud-deployment/PipelineWiring.md
@@ -18,12 +18,13 @@ Hook Wiring is about ingesting what a tenant *writes*. This guide is about shipp
 A downstream deploy job runs on the deployment host (or a runner with Docker access to it) and performs a fixed sequence:
 
 1. **Check out** the pinned Agent OS revision — a release tag, not an arbitrary commit (see *Release-gating*).
-2. **Build** the images — `docker compose -f ai/deploy/docker-compose.yml [--profile …] build`.
-3. **Redeploy** — recreate the containers against the *existing* persistence volumes (see *Redeploy-safe persistence*).
-4. **Gate on health** — block until the deployed MCP healthchecks pass; fail the job if they do not.
-5. **Report** — surface the healthcheck result so a failed deploy is visible.
+2. **Preflight** the deployment for redeploy-survivability before Docker can mutate the plane.
+3. **Materialize** any host-held deployment prescriptions into the Compose environment (see *Delivering deployment prescriptions*).
+4. **Build and redeploy** — recreate the containers against the *existing* persistence volumes (see *Redeploy-safe persistence*).
+5. **Gate on health** — block until the deployed MCP healthchecks pass; fail the job if they do not.
+6. **Report** — surface the healthcheck result and, after success, bind delivered prescriptions to the deployed revision.
 
-[`ai/examples/cloud-deployment/deploy-pipeline.sh`](../../../ai/examples/cloud-deployment/deploy-pipeline.sh) is a runnable reference for steps 2–5. A CI job (GitHub Actions, GitLab CI, Jenkins, …) calls it; the script is CI-system-neutral so the wiring is not locked to one vendor.
+[`ai/examples/cloud-deployment/deploy-pipeline.sh`](../../../ai/examples/cloud-deployment/deploy-pipeline.sh) is a runnable reference for steps 2–6. A CI job (GitHub Actions, GitLab CI, Jenkins, …) calls it; the script is CI-system-neutral so the wiring is not locked to one vendor.
 
 ## Release-gating
 
@@ -139,6 +140,18 @@ treating the narrower guarantee as the broader one is how an operator discovers
 the gap during a recovery rather than before one.
 
 **Verification:** the redeploy-survival check is [Day-0 Tutorial Milestone 7](./Day0Tutorial.md) — a `docker compose down && docker compose up --build` cycle, then confirm the Memory Core store, Sandman handoff, orchestrator task/revision state, and backup bundles are intact. Run that check once when the pipeline is first wired; subsequent redeploys rely on the named-volume + project-name + bind-mount contract above.
+
+## Delivering deployment prescriptions
+
+Some recovery knobs only take effect when Compose creates a container. A diagnosis can identify that such a knob is relevant, but it does **not** choose a value or authorize a deployment change. The first producer is an explicit trusted host/operator action; the pipeline's narrower job is to validate and deliver that prescription without letting an append-only file become configuration authority.
+
+The reference script keeps this state outside the checkout under `NEO_HOST_DEPLOYMENT_PRESCRIPTION_ROOT`, which defaults to `${HOME}/.neo-ai/deployment-prescriptions`. `prescriptions.jsonl` is the append sink, while `active.env` is the persistent carrier Compose consumes. The deployment project's `.env` points to that carrier. Adopting an existing regular `.env` is explicit: unrelated variables, comments, and other operator-owned content are preserved before the project path is replaced by the carrier symlink. This keeps a later checkout or redeploy from silently reverting the delivered values.
+
+Materialization runs after the redeploy-survivability preflight and before `docker compose up`. Every candidate is revalidated against the current recovery-knob registry **and fresh runtime context from the exact Compose target**; a formerly valid raise cannot become a lowering instruction after the live ceiling moves. Equality is treated separately as an already-applied desired state, so the first successful raise does not brick later redeploys; the actuator's strict raise-only admission remains unchanged. An invalid or conflicted active prescription, a missing/ambiguous target, or an unreadable live bound aborts before Docker mutates the plane instead of falling back to a stale carrier. With no active prescription, deployment-owned entries are removed and Compose retains its declared defaults.
+
+The reference pipeline pins `active.env` explicitly on every Compose call and refuses when a deployment-owned key is already exported in the runner environment: exported values outrank env files, so accepting one would let the receipt describe a value Compose did not consume. One atomic host deploy lock covers materialization through the health gate. Each run also gets a UUID-bound state manifest and receipt path, so even an out-of-band materialization cannot make deployment A receipt deployment B's snapshot.
+
+Only after `docker compose up --wait` has passed its health gate does the pipeline atomically write that run's delivery receipt. The receipt binds the deployment-run UUID, `deployedRevision`, the materialized carrier digest, and the active prescription IDs. It proves which prescription set the successful deployment path delivered; it does **not** claim that a runtime observer independently read back each resulting process value.
 
 ## The health gate
 

--- a/test/playwright/unit/ai/DeployPipelineComposeFileList.spec.mjs
+++ b/test/playwright/unit/ai/DeployPipelineComposeFileList.spec.mjs
@@ -2,6 +2,7 @@ import {test, expect}  from '@playwright/test';
 import fs              from 'fs-extra';
 import path            from 'path';
 import {execFile}      from 'node:child_process';
+import {randomUUID}    from 'node:crypto';
 import {promisify}     from 'node:util';
 import {fileURLToPath} from 'url';
 
@@ -37,24 +38,58 @@ const execFileAsync = promisify(execFile),
  * @param {Boolean} [config.omitComposeFile]  Leave the variable UNSET rather than setting it.
  * @param {Boolean} [config.failIfGitCalled]  Install a recording `git` stub that fails if the pipeline
  * reaches revision resolution. Used only for missing-composition cases, which must stop first.
+ * @param {Boolean} [config.failMaterialize]  Fail the prescription materializer before Docker.
+ * @param {Boolean} [config.failDockerUp]     Fail the health-gated `docker compose up` call.
+ * @param {Boolean} [config.holdDeployLock]   Present an existing atomic deploy claim.
+ * @param {String}  [config.deploymentRunId]  UUID returned by the recording Node runtime.
  * @param {String}  [config.revision]         Selector for `NEO_REF`; defaults to this checkout's `HEAD`.
- * @returns {Promise<Object>} `{code, stdout, calls, dockerCalls, gitCalls, composeArgs, preflightCallIndex, firstDockerIndex}`
+ * @returns {Promise<Object>} Ordered call evidence and derived prescription paths.
  */
-async function runPipeline({composeFileValue, omitComposeFile, failIfGitCalled, revision}) {
-    const workDir = await fs.mkdtemp(path.join(repoRoot, 'test/playwright/test-results/compose-list-')),
-          binDir  = path.join(workDir, 'bin'),
-          logPath = path.join(workDir, 'calls.log');
+async function runPipeline({
+    composeFileValue,
+    omitComposeFile,
+    failIfGitCalled,
+    failMaterialize,
+    failDockerUp,
+    holdDeployLock,
+    deploymentRunId,
+    revision
+}) {
+    const workDir          = await fs.mkdtemp(path.join(repoRoot, 'test/playwright/test-results/compose-list-')),
+          binDir           = path.join(workDir, 'bin'),
+          logPath          = path.join(workDir, 'calls.log'),
+          prescriptionRoot = path.join(workDir, 'deployment-prescriptions'),
+          runId            = deploymentRunId || randomUUID();
 
     await fs.ensureDir(binDir);
     await fs.writeFile(logPath, '');
 
-    // Recording stubs. `exit 0` so the script proceeds past them and we observe every call it makes.
-    for (const name of ['docker', 'node']) {
-        const stubPath = path.join(binDir, name);
-
-        await fs.writeFile(stubPath, `#!/usr/bin/env bash\nprintf '${name} %s\\n' "$*" >> "$CALL_LOG"\nexit 0\n`);
-        await fs.chmod(stubPath, 0o755)
+    if (holdDeployLock) {
+        await fs.ensureDir(path.join(prescriptionRoot, 'deploy.lock'))
     }
+
+    // Recording stubs. Their opt-in failures prove that a failed phase cannot leak into a later one.
+    const dockerStubPath = path.join(binDir, 'docker'),
+          nodeStubPath   = path.join(binDir, 'node');
+
+    await fs.writeFile(
+        dockerStubPath,
+        '#!/usr/bin/env bash\n' +
+        'printf \'docker %s\\n\' "$*" >> "$CALL_LOG"\n' +
+        'if [ "${FAIL_DOCKER_UP:-0}" = "1" ] && [[ " $* " == *" up "* ]]; then exit 92; fi\n' +
+        'exit 0\n'
+    );
+    await fs.chmod(dockerStubPath, 0o755);
+
+    await fs.writeFile(
+        nodeStubPath,
+        '#!/usr/bin/env bash\n' +
+        'printf \'node %s\\n\' "$*" >> "$CALL_LOG"\n' +
+        'if [[ "$*" == *"randomUUID"* ]]; then printf \'%s\' "$STUB_DEPLOYMENT_RUN_ID"; exit 0; fi\n' +
+        'if [ "${FAIL_MATERIALIZE:-0}" = "1" ] && [[ " $* " == *"materializeDeploymentPrescriptions.mjs materialize "* ]]; then exit 91; fi\n' +
+        'exit 0\n'
+    );
+    await fs.chmod(nodeStubPath, 0o755);
 
     if (failIfGitCalled) {
         const gitStubPath = path.join(binDir, 'git');
@@ -73,12 +108,16 @@ async function runPipeline({composeFileValue, omitComposeFile, failIfGitCalled, 
     // reaches bash as genuinely unset, which is the distinction under test.
     const childEnv = {
         ...process.env,
-        PATH                   : `${binDir}:${process.env.PATH}`,
-        CALL_LOG               : logPath,
-        NEO_REPO_URL           : repoRoot,
-        NEO_REF                : selector,
-        NEO_DEPLOY_PROJECT_NAME: 'compose-list-spec',
-        NEO_DEPLOY_COMPOSE_FILE: composeFileValue ?? ''
+        PATH                                 : `${binDir}:${process.env.PATH}`,
+        CALL_LOG                             : logPath,
+        FAIL_DOCKER_UP                       : failDockerUp ? '1' : '0',
+        FAIL_MATERIALIZE                     : failMaterialize ? '1' : '0',
+        STUB_DEPLOYMENT_RUN_ID               : runId,
+        NEO_REPO_URL                         : repoRoot,
+        NEO_REF                              : selector,
+        NEO_DEPLOY_PROJECT_NAME              : 'compose-list-spec',
+        NEO_DEPLOY_COMPOSE_FILE              : composeFileValue ?? '',
+        NEO_HOST_DEPLOYMENT_PRESCRIPTION_ROOT: prescriptionRoot
     };
 
     if (omitComposeFile) {
@@ -94,10 +133,15 @@ async function runPipeline({composeFileValue, omitComposeFile, failIfGitCalled, 
         stdout = (error.stdout || '') + (error.stderr || '')
     }
 
-    const calls       = (await fs.readFile(logPath, 'utf8')).split('\n').filter(Boolean),
-          dockerCalls = calls.filter(line => line.startsWith('docker ')),
-          gitCalls    = calls.filter(line => line.startsWith('git ')),
-          firstUp     = dockerCalls.find(line => line.includes(' up ')) || '';
+    const calls                = (await fs.readFile(logPath, 'utf8')).split('\n').filter(Boolean),
+          dockerCalls          = calls.filter(line => line.startsWith('docker ')),
+          gitCalls             = calls.filter(line => line.startsWith('git ')),
+          firstUp              = dockerCalls.find(line => line.includes(' up ')) || '',
+          preflightCallIndex   = calls.findIndex(line => line.startsWith('node ') && line.includes('redeployPreflight')),
+          materializeCallIndex = calls.findIndex(line => line.startsWith('node ') && line.includes('materializeDeploymentPrescriptions.mjs materialize ')),
+          firstDockerIndex     = calls.findIndex(line => line.startsWith('docker ')),
+          receiptCallIndex     = calls.findIndex(line => line.startsWith('node ') && line.includes('materializeDeploymentPrescriptions.mjs receipt ')),
+          deployLockExists     = await fs.pathExists(path.join(prescriptionRoot, 'deploy.lock'));
 
     await fs.remove(workDir);
 
@@ -109,9 +153,14 @@ async function runPipeline({composeFileValue, omitComposeFile, failIfGitCalled, 
         calls,
         dockerCalls,
         gitCalls,
-        composeArgs       : firstUp,
-        preflightCallIndex: calls.findIndex(line => line.startsWith('node ') && line.includes('redeployPreflight')),
-        firstDockerIndex  : calls.findIndex(line => line.startsWith('docker '))
+        composeArgs    : firstUp,
+        prescriptionRoot,
+        deploymentRunId: runId,
+        preflightCallIndex,
+        materializeCallIndex,
+        firstDockerIndex,
+        receiptCallIndex,
+        deployLockExists
     }
 }
 
@@ -203,7 +252,7 @@ test.describe('deploy-pipeline.sh — ordered Compose-file set', () => {
         expect(oneFile.stdout).toContain('(1 file(s)')
     });
 
-    test('the preflight runs BEFORE any Docker call — asserted on recorded POSITION', async () => {
+    test('preflight, prescription materialization, Docker health gate, and receipt run in delivery order', async () => {
         // The earlier version of this test only checked that both the preflight message and some Docker
         // call appeared, which is true for ANY ordering and so proved nothing about the guarantee it
         // claimed. The property is positional: the survivability gate must precede every container
@@ -211,8 +260,89 @@ test.describe('deploy-pipeline.sh — ordered Compose-file set', () => {
         const result = await runPipeline({composeFileValue: '/tmp/a.yml:/tmp/b.yml'});
 
         expect(result.preflightCallIndex).toBeGreaterThan(-1);
+        expect(result.materializeCallIndex).toBeGreaterThan(-1);
         expect(result.firstDockerIndex).toBeGreaterThan(-1);
-        expect(result.preflightCallIndex).toBeLessThan(result.firstDockerIndex)
+        expect(result.receiptCallIndex).toBeGreaterThan(-1);
+        expect(result.preflightCallIndex).toBeLessThan(result.materializeCallIndex);
+        expect(result.materializeCallIndex).toBeLessThan(result.firstDockerIndex);
+        expect(result.firstDockerIndex).toBeLessThan(result.receiptCallIndex);
+        expect(result.deployLockExists).toBe(false);
+
+        const materializeCall = result.calls[result.materializeCallIndex],
+              receiptCall     = result.calls[result.receiptCallIndex],
+              runRoot         = path.join(
+                  result.prescriptionRoot,
+                  'runs',
+                  result.deploymentRunId
+              ),
+              uuidCalls       = result.calls.filter(line => line.startsWith('node ') && line.includes('randomUUID'));
+
+        expect(materializeCall).toContain(`--ledger ${result.prescriptionRoot}/prescriptions.jsonl`);
+        expect(materializeCall).toContain(`--env ${result.prescriptionRoot}/active.env`);
+        expect(materializeCall).toContain(`--state ${runRoot}/materialized-state.json`);
+        expect(materializeCall).toContain('--project-env /tmp/.env');
+        expect(materializeCall).toContain('--compose-project compose-list-spec');
+        expect(materializeCall).toContain(`--run-id ${result.deploymentRunId}`);
+        expect(materializeCall).toContain('--adopt-existing-env');
+        expect(receiptCall).toContain(`--state ${runRoot}/materialized-state.json`);
+        expect(receiptCall).toContain(`--receipt ${runRoot}/delivery-receipt.json`);
+        expect(receiptCall).toContain(`--run-id ${result.deploymentRunId}`);
+        expect(materializeCall).not.toContain('--receipt');
+        expect(uuidCalls).toHaveLength(1);
+        expect(result.calls.indexOf(uuidCalls[0])).toBeGreaterThan(result.preflightCallIndex);
+        expect(result.calls.indexOf(uuidCalls[0])).toBeLessThan(result.materializeCallIndex);
+
+        // The script runs from `repoRoot`, while the first composition lives in `/tmp`. An explicit
+        // env-file operand is therefore the production contract that makes the materialized carrier
+        // authoritative rather than depending on Compose's cwd/project-directory discovery.
+        for (const dockerCall of result.dockerCalls) {
+            expect(dockerCall).toContain(`compose --env-file ${result.prescriptionRoot}/active.env`)
+        }
+    });
+
+    test('an existing deploy claim refuses a concurrent materialization transaction', async () => {
+        const result = await runPipeline({
+            composeFileValue: '/tmp/a.yml:/tmp/b.yml',
+            holdDeployLock  : true
+        });
+
+        expect(result.code).not.toBe(0);
+        expect(result.preflightCallIndex).toBeGreaterThan(-1);
+        expect(result.materializeCallIndex).toBe(-1);
+        expect(result.dockerCalls).toEqual([]);
+        expect(result.receiptCallIndex).toBe(-1);
+        expect(result.deployLockExists).toBe(true);
+        expect(result.stdout).toContain('deployment lock exists');
+        expect(result.stdout).toContain('No prescription was materialized')
+    });
+
+    test('a materialization refusal stops before every Docker lifecycle call', async () => {
+        const result = await runPipeline({
+            composeFileValue: '/tmp/a.yml:/tmp/b.yml',
+            failMaterialize : true
+        });
+
+        expect(result.code).not.toBe(0);
+        expect(result.preflightCallIndex).toBeGreaterThan(-1);
+        expect(result.materializeCallIndex).toBeGreaterThan(result.preflightCallIndex);
+        expect(result.dockerCalls).toEqual([]);
+        expect(result.receiptCallIndex).toBe(-1);
+        expect(result.deployLockExists).toBe(false)
+    });
+
+    test('a failed Docker health gate cannot emit a delivery receipt', async () => {
+        const result = await runPipeline({
+            composeFileValue: '/tmp/a.yml:/tmp/b.yml',
+            failDockerUp    : true
+        });
+
+        expect(result.code).not.toBe(0);
+        expect(result.materializeCallIndex).toBeGreaterThan(result.preflightCallIndex);
+        expect(result.firstDockerIndex).toBeGreaterThan(result.materializeCallIndex);
+        expect(result.receiptCallIndex).toBe(-1);
+        expect(result.deployLockExists).toBe(false);
+        expect(result.dockerCalls).toHaveLength(1);
+        expect(result.dockerCalls[0]).toContain(' up ')
     });
 
     test('the health gate and project pinning are unchanged, and `down` is never issued', async () => {
@@ -220,6 +350,7 @@ test.describe('deploy-pipeline.sh — ordered Compose-file set', () => {
 
         expect(result.composeArgs).toContain('up -d --build --wait');
         expect(result.composeArgs).toContain('-p compose-list-spec');
+        expect(result.composeArgs).toContain(`--env-file ${result.prescriptionRoot}/active.env`);
         expect(result.dockerCalls.some(line => line.includes(' down '))).toBe(false)
     });
 

--- a/test/playwright/unit/ai/DeployPipelineRevisionPin.spec.mjs
+++ b/test/playwright/unit/ai/DeployPipelineRevisionPin.spec.mjs
@@ -51,8 +51,14 @@ const
  */
 async function createFakeBin(plainLines, peelLine = '') {
     const
-        bin       = await fs.mkdtemp(path.join(os.tmpdir(), 'neo-deploy-pin-')),
-        dockerLog = path.join(bin, 'docker-invocations.log');
+        bin         = await fs.mkdtemp(path.join(os.tmpdir(), 'neo-deploy-pin-')),
+        composeFile = path.join(bin, 'docker-compose.yml'),
+        dockerLog   = path.join(bin, 'docker-invocations.log');
+
+    // The deployment pipeline now owns a durable project `.env` carrier. Keeping composition in
+    // the fixture root makes that carrier per-test instead of adopting the operator's real
+    // `ai/deploy/.env` or contending on one host-global deploy lock across parallel workers.
+    await fs.writeFile(composeFile, 'services: {}\n');
 
     await fs.writeFile(path.join(bin, 'git'), [
         '#!/usr/bin/env bash',
@@ -94,7 +100,7 @@ async function createFakeBin(plainLines, peelLine = '') {
 
     await fs.writeFile(dockerLog, '');
 
-    return {bin, dockerLog, plainLines, peelLine}
+    return {bin, composeFile, dockerLog, plainLines, peelLine}
 }
 
 /**
@@ -135,9 +141,10 @@ function preflightEnv(fake, declareInitialization, projectName) {
         NEO_BACKUP_PATH        : path.join(fake.bin, 'preflight-backups'),
         // Revision tests need a valid explicit composition so the mandatory caller-owned boundary does
         // not stop them before their actual subject. The fake Docker never starts this base file.
-        NEO_DEPLOY_COMPOSE_FILE: composePath,
-        NEO_DEPLOY_INITIALIZE  : declareInitialization ? '1' : '0',
-        NEO_DEPLOY_PROJECT_NAME: projectName
+        NEO_DEPLOY_COMPOSE_FILE              : fake.composeFile,
+        NEO_DEPLOY_INITIALIZE                : declareInitialization ? '1' : '0',
+        NEO_DEPLOY_PROJECT_NAME              : projectName,
+        NEO_HOST_DEPLOYMENT_PRESCRIPTION_ROOT: path.join(fake.bin, 'deployment-prescriptions')
     }
 }
 
@@ -335,8 +342,8 @@ test.describe('deploy-pipeline.sh revision pinning (#15792)', () => {
     test('every SCRIPT_DIR-relative path in the script actually RESOLVES', async () => {
         // Both instances of one bug shipped here: `$SCRIPT_DIR` is `ai/examples/cloud-deployment`, so
         // `../..` is ALREADY `ai/`, and two lines re-added `ai/` on top of it. The old `COMPOSE_FILE`
-        // default was removed because composition is caller-owned; the maintenance preflight remains
-        // the script's sole sibling-path reference.
+        // default was removed because composition is caller-owned; the prescription materializer and
+        // maintenance preflight are the script's two sibling-path references.
         //
         // So this asserts resolution directly rather than trusting the next author to count `../`.
         const source    = await fs.readFile(scriptPath, 'utf8'),
@@ -344,9 +351,12 @@ test.describe('deploy-pipeline.sh revision pinning (#15792)', () => {
               refs      = [...source.matchAll(/\$SCRIPT_DIR\/([A-Za-z0-9/._-]+)/g)].map(match => match[1]),
               unique    = [...new Set(refs)];
 
-        // Positive control: pin the one intended script-relative dependency so removal or accidental
+        // Positive control: pin the intended script-relative dependencies so removal or accidental
         // reintroduction of an implicit Compose path changes this contract loudly.
-        expect(unique).toEqual(['../../scripts/maintenance/redeployPreflight.mjs']);
+        expect(unique).toEqual([
+            '../../scripts/maintenance/materializeDeploymentPrescriptions.mjs',
+            '../../scripts/maintenance/redeployPreflight.mjs'
+        ]);
 
         for (const ref of unique) {
             const resolved = path.resolve(scriptRel, ref);
@@ -405,7 +415,7 @@ test.describe('deploy-pipeline.sh revision pinning (#15792)', () => {
         const fake   = await createFakeBin(''),
               result = runPipelineWithProbe(fake, FULL_SHA, {peelTo: FULL_SHA});
 
-        expect(result.code).toBe(0);
+        expect(result.code, result.output).toBe(0);
         expect(result.output).toContain(FULL_SHA);
         // The host checkout must be reported as explicitly NOT the deployed revision.
         expect(result.output).toContain('host-checkout:');
@@ -473,7 +483,7 @@ test.describe('deploy-pipeline.sh revision pinning (#15792)', () => {
             fake   = await createFakeBin(`${FULL_SHA}\trefs/heads/dev`),
             result = runPipeline(fake, 'dev');
 
-        expect(result.code).toBe(0);
+        expect(result.code, result.output).toBe(0);
 
         // Compose maps this one value to both Docker args. Keeping NEO_REF in the outgoing
         // environment would preserve the conflicting second input at the boundary.

--- a/test/playwright/unit/ai/scripts/maintenance/materializeDeploymentPrescriptions.spec.mjs
+++ b/test/playwright/unit/ai/scripts/maintenance/materializeDeploymentPrescriptions.spec.mjs
@@ -1,0 +1,483 @@
+import {test, expect}  from '@playwright/test';
+import {execFileSync}  from 'node:child_process';
+import fs              from 'fs-extra';
+import os              from 'node:os';
+import path            from 'node:path';
+import {fileURLToPath} from 'node:url';
+
+import {
+    materializeDeploymentPrescriptions,
+    mergePrescribedEnvironment,
+    prescribedEnvironmentKeys,
+    resolveDeploymentRuntimeContext,
+    writeDeploymentPrescriptionReceipt
+} from '../../../../../../ai/scripts/maintenance/materializeDeploymentPrescriptions.mjs';
+import {
+    appendDeploymentPrescription,
+    readDeploymentPrescriptions
+} from '../../../../../../ai/services/memory-core/helpers/deploymentPrescriptionStore.mjs';
+
+/**
+ * End-to-end host-delivery witnesses for deployment prescriptions.
+ *
+ * The store, admission fold, env merge, persistent carrier, project symlink, pre-up manifest, and
+ * post-health receipt are tested together here. Testing those modules only in isolation would permit
+ * the exact helper-only defect this delivery path closes: specs composing an edge no production caller owns.
+ *
+ * No live container is started. The optional effect witness uses `docker compose config`, which
+ * evaluates the real production Compose interpolation without contacting the Docker daemon.
+ */
+
+const
+    repoRoot     = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../../../../..'),
+    CLI          = path.join(repoRoot, 'ai/scripts/maintenance/materializeDeploymentPrescriptions.mjs'),
+    COMPOSE_FILE = path.join(repoRoot, 'ai/deploy/docker-compose.yml'),
+    KNOB         = 'container-memory-ceiling',
+    LEAF         = 'deploy.chroma.memoryCeilingBytes',
+    ENV_KEY      = 'NEO_CHROMA_MEMORY_LIMIT',
+    LIVE_BYTES   = 8 * 1024 ** 3,
+    PRESCRIBED   = 12 * 1024 ** 3,
+    SECOND_VALUE = 14 * 1024 ** 3,
+    DEPLOYED_SHA = 'a'.repeat(40),
+    RUN_ID       = '11111111-1111-4111-8111-111111111111';
+
+let workRoot;
+
+test.beforeEach(async () => {
+    workRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'neo-prescription-materialize-'))
+});
+
+test.afterEach(async () => {
+    await fs.remove(workRoot)
+});
+
+/**
+ * @summary Builds the temp paths one materialization cycle owns.
+ * @param {String} [name]
+ * @returns {Object}
+ */
+function pathsFor(name = 'default') {
+    const root = path.join(workRoot, name);
+
+    return {
+        root,
+        ledgerPath    : path.join(root, 'prescriptions.jsonl'),
+        envPath       : path.join(root, 'active.env'),
+        statePath     : path.join(root, 'materialized-state.json'),
+        receiptPath   : path.join(root, 'last-delivery-receipt.json'),
+        projectEnvPath: path.join(root, 'project', '.env')
+    }
+}
+
+/**
+ * @summary Creates one valid semantic prescription for the registry's deployed container knob.
+ * @param {Object} [overrides]
+ * @returns {Object}
+ */
+function semanticPrescription(overrides = {}) {
+    return {
+        prescriptionId          : 'P:first',
+        supersedesPrescriptionId: null,
+        knob                    : KNOB,
+        targetIdentity          : {kind: 'compose-service', id: 'chroma'},
+        values                  : {[LEAF]: PRESCRIBED},
+        validatedAgainst        : {
+            context   : {'runtime.chroma.liveMemoryLimitBytes': LIVE_BYTES},
+            observedAt: 1_000
+        },
+        ...overrides
+    }
+}
+
+/**
+ * @summary Supplies the measured live limit used by valid materialization controls.
+ * @returns {Promise<Object>}
+ */
+async function liveContext() {
+    return {'runtime.chroma.liveMemoryLimitBytes': LIVE_BYTES}
+}
+
+/**
+ * @summary Reports whether the daemon-free Compose config evaluator is installed.
+ * @returns {Boolean}
+ */
+function composeConfigAvailable() {
+    try {
+        execFileSync('docker', ['compose', 'version'], {stdio: 'ignore'});
+        return true
+    } catch {
+        return false
+    }
+}
+
+/**
+ * @summary Resolves the real Chroma memory field through production Compose interpolation.
+ * @param {String|null} envFilePath
+ * @returns {String|null}
+ */
+function resolvedChromaMemory(envFilePath) {
+    const args = ['compose', '-f', COMPOSE_FILE];
+
+    envFilePath && args.push('--env-file', envFilePath);
+    args.push('config', '--format', 'json');
+
+    const config = JSON.parse(execFileSync('docker', args, {
+        cwd     : repoRoot,
+        encoding: 'utf8',
+        stdio   : ['ignore', 'pipe', 'ignore']
+    }));
+
+    return config?.services?.chroma?.deploy?.resources?.limits?.memory ?? null
+}
+
+test.describe('registry-owned env merge', () => {
+    test('preserves unrelated bytes and removes every stale deployment-owned occurrence', () => {
+        const existing = [
+            '# operator comment\r\n',
+            'TOKEN="s==x"\r\n',
+            `${ENV_KEY}=8g\r\n`,
+            'UNOWNED=1\n',
+            // This is an actuator-local knob with no deployment service; the materializer must not
+            // claim or erase it merely because the shared registry has an env binding.
+            'NEO_MC_GENERATE_MINI_SUMMARY_TIMEOUT_MS=12345\n',
+            `${ENV_KEY}=10g\n`
+        ].join('');
+
+        const merged = mergePrescribedEnvironment(existing, `${ENV_KEY}=${PRESCRIBED}\n`);
+
+        expect(prescribedEnvironmentKeys()).toEqual(new Set([ENV_KEY]));
+        expect(merged).toBe(
+            '# operator comment\r\n' +
+            'TOKEN="s==x"\r\n' +
+            'UNOWNED=1\n' +
+            'NEO_MC_GENERATE_MINI_SUMMARY_TIMEOUT_MS=12345\n' +
+            `${ENV_KEY}=${PRESCRIBED}\n`
+        )
+    });
+
+    test('an empty active set removes a stale owned line without touching the rest', () => {
+        expect(mergePrescribedEnvironment(`KEEP=1\n${ENV_KEY}=12g\n# tail`, ''))
+            .toBe('KEEP=1\n# tail')
+    })
+});
+
+test.describe('persistent carrier and authority gates', () => {
+    test('explicitly adopts a regular project .env, preserves it, and installs the durable symlink', async () => {
+        const paths = pathsFor('adopt');
+
+        await fs.ensureDir(path.dirname(paths.projectEnvPath));
+        await fs.writeFile(paths.projectEnvPath, `TOKEN=keep-me\n${ENV_KEY}=operator-old\n`);
+
+        const result = await materializeDeploymentPrescriptions({...paths, adoptExistingEnv: true});
+
+        expect(result.status).toBe('materialized');
+        expect(result.activeCount).toBe(0);
+        expect(await fs.readFile(paths.envPath, 'utf8')).toBe('TOKEN=keep-me\n');
+        expect((await fs.lstat(paths.projectEnvPath)).isSymbolicLink()).toBe(true);
+        expect(await fs.realpath(paths.projectEnvPath)).toBe(await fs.realpath(paths.envPath));
+
+        const state = await fs.readJson(paths.statePath);
+
+        expect(state.activePrescriptions).toEqual([]);
+        expect(state.materializedDigest).toMatch(/^[0-9a-f]{64}$/)
+    });
+
+    test('a regular project .env refuses without explicit adoption and remains untouched', async () => {
+        const paths = pathsFor('refuse-adopt');
+
+        await fs.ensureDir(path.dirname(paths.projectEnvPath));
+        await fs.writeFile(paths.projectEnvPath, 'TOKEN=untouched\n');
+
+        await expect(materializeDeploymentPrescriptions(paths)).rejects.toThrow('--adopt-existing-env');
+        expect(await fs.readFile(paths.projectEnvPath, 'utf8')).toBe('TOKEN=untouched\n');
+        expect(await fs.pathExists(paths.envPath)).toBe(false);
+        expect(await fs.pathExists(paths.statePath)).toBe(false)
+    });
+
+    test('adoption restores a last-moment operator update instead of overwriting it', async () => {
+        const paths = pathsFor('adopt-race');
+
+        await fs.ensureDir(path.dirname(paths.projectEnvPath));
+        await fs.writeFile(paths.projectEnvPath, 'TOKEN=observed\n');
+        await fs.writeFile(paths.envPath, 'TOKEN=observed\n');
+
+        let raced = false;
+
+        const racingFs = new Proxy(fs, {
+            get(target, property) {
+                if (property === 'rename') {
+                    return async (source, destination) => {
+                        if (!raced && source === paths.projectEnvPath && destination.endsWith('.captured')) {
+                            raced = true;
+                            await fs.writeFile(paths.projectEnvPath, 'TOKEN=operator-new\n')
+                        }
+
+                        return fs.rename(source, destination)
+                    }
+                }
+
+                const value = target[property];
+
+                return typeof value === 'function' ? value.bind(target) : value
+            }
+        });
+
+        await expect(materializeDeploymentPrescriptions({
+            ...paths,
+            adoptExistingEnv: true,
+            fsModule        : racingFs
+        })).rejects.toThrow('changed during materialization; restored without replacement');
+
+        expect(raced).toBe(true);
+        expect((await fs.lstat(paths.projectEnvPath)).isFile()).toBe(true);
+        expect(await fs.readFile(paths.projectEnvPath, 'utf8')).toBe('TOKEN=operator-new\n');
+        expect(await fs.readFile(paths.envPath, 'utf8')).toBe('TOKEN=observed\n');
+        expect(await fs.pathExists(paths.statePath)).toBe(false)
+    });
+
+    test('an exported deployment-owned key refuses before changing the carrier', async () => {
+        const paths = pathsFor('ambient-precedence');
+
+        await fs.ensureDir(paths.root);
+        await fs.writeFile(paths.envPath, 'KEEP=previous\n');
+        await fs.ensureDir(path.dirname(paths.projectEnvPath));
+        await fs.symlink(paths.envPath, paths.projectEnvPath);
+
+        await expect(materializeDeploymentPrescriptions({
+            ...paths,
+            ambientEnvironment: {[ENV_KEY]: '13g'}
+        })).rejects.toThrow(`must be unset before materialization: ${ENV_KEY}`);
+
+        expect(await fs.readFile(paths.envPath, 'utf8')).toBe('KEEP=previous\n');
+        expect(await fs.pathExists(paths.statePath)).toBe(false)
+    });
+
+    test('a tampered sink record aborts before changing the existing carrier or manifest', async () => {
+        const paths = pathsFor('tampered');
+
+        await fs.ensureDir(paths.root);
+        await fs.writeFile(paths.envPath, 'KEEP=previous\n');
+        await fs.ensureDir(path.dirname(paths.projectEnvPath));
+        await fs.symlink(paths.envPath, paths.projectEnvPath);
+
+        await appendDeploymentPrescription({
+            ledgerPath  : paths.ledgerPath,
+            prescription: semanticPrescription(),
+            now         : 2_000
+        });
+
+        const [record] = await readDeploymentPrescriptions(paths.ledgerPath);
+
+        delete record.producerPrincipal;
+        await fs.writeFile(paths.ledgerPath, `${JSON.stringify(record)}\n`);
+
+        await expect(materializeDeploymentPrescriptions(paths)).rejects.toThrow('producer principal');
+        expect(await fs.readFile(paths.envPath, 'utf8')).toBe('KEEP=previous\n');
+        expect(await fs.pathExists(paths.statePath)).toBe(false)
+    });
+
+    test('fresh runtime context prevents an old raise from becoming a lowering instruction', async () => {
+        const paths = pathsFor('runtime-moved');
+
+        await fs.ensureDir(paths.root);
+        await fs.writeFile(paths.envPath, 'KEEP=previous\n');
+        await fs.ensureDir(path.dirname(paths.projectEnvPath));
+        await fs.symlink(paths.envPath, paths.projectEnvPath);
+        await appendDeploymentPrescription({
+            ledgerPath  : paths.ledgerPath,
+            prescription: semanticPrescription(),
+            now         : 2_000
+        });
+
+        await expect(materializeDeploymentPrescriptions({
+            ...paths,
+            resolveContext: async () => ({
+                'runtime.chroma.liveMemoryLimitBytes': SECOND_VALUE
+            })
+        })).rejects.toThrow('current runtime revalidation');
+
+        expect(await fs.readFile(paths.envPath, 'utf8')).toBe('KEEP=previous\n');
+        expect(await fs.pathExists(paths.statePath)).toBe(false)
+    });
+
+    test('an already-applied ceiling remains idempotently deployable', async () => {
+        const paths = pathsFor('already-applied');
+
+        await appendDeploymentPrescription({
+            ledgerPath  : paths.ledgerPath,
+            prescription: semanticPrescription(),
+            now         : 2_000
+        });
+
+        const result = await materializeDeploymentPrescriptions({
+            ...paths,
+            resolveContext: async () => ({
+                'runtime.chroma.liveMemoryLimitBytes': PRESCRIBED
+            })
+        });
+
+        expect(result.status).toBe('materialized');
+        expect(result.activeCount).toBe(1);
+        expect(await fs.readFile(paths.envPath, 'utf8')).toBe(`${ENV_KEY}=${PRESCRIBED}\n`)
+    });
+
+    test('the production resolver binds Docker reads to exact project and service labels', async () => {
+        const calls   = [],
+              context = await resolveDeploymentRuntimeContext(semanticPrescription(), {
+                  composeProject: 'plane-a',
+                  execFileImpl  : async (command, args) => {
+                      calls.push({command, args});
+
+                      return args[0] === 'ps'
+                          ? {stdout: 'container-123\n'}
+                          : {stdout: `${LIVE_BYTES}\n`}
+                  }
+              });
+
+        expect(context).toEqual({'runtime.chroma.liveMemoryLimitBytes': LIVE_BYTES});
+        expect(calls).toEqual([
+            {
+                command: 'docker',
+                args   : [
+                    'ps', '-a',
+                    '--filter', 'label=com.docker.compose.project=plane-a',
+                    '--filter', 'label=com.docker.compose.service=chroma',
+                    '--format', '{{.ID}}'
+                ]
+            },
+            {
+                command: 'docker',
+                args   : ['inspect', 'container-123', '--format', '{{.HostConfig.Memory}}']
+            }
+        ])
+    })
+});
+
+test.describe('operator append through exact delivery receipt', () => {
+    test('the real CLI appends, materialization snapshots it, and later ledger movement cannot inflate the receipt', async () => {
+        const paths = pathsFor('delivery');
+
+        await fs.ensureDir(path.dirname(paths.projectEnvPath));
+        await fs.writeFile(paths.projectEnvPath, `TOKEN=preserved\n${ENV_KEY}=8g\n`);
+
+        const stdout = execFileSync(process.execPath, [
+            CLI,
+            'append',
+            '--ledger', paths.ledgerPath,
+            '--id', 'P:first',
+            '--knob', KNOB,
+            '--target', 'chroma',
+            '--values', JSON.stringify({[LEAF]: PRESCRIBED}),
+            '--context', JSON.stringify({'runtime.chroma.liveMemoryLimitBytes': LIVE_BYTES}),
+            '--observed-at', '1000'
+        ], {encoding: 'utf8'});
+
+        expect(JSON.parse(stdout)).toMatchObject({status: 'appended', prescriptionId: 'P:first', sequence: 1});
+
+        await materializeDeploymentPrescriptions({
+            ...paths,
+            deploymentRunId : RUN_ID,
+            adoptExistingEnv: true,
+            resolveContext  : liveContext,
+            now             : () => 2_000
+        });
+
+        expect(await fs.readFile(paths.envPath, 'utf8'))
+            .toBe(`TOKEN=preserved\n${ENV_KEY}=${PRESCRIBED}\n`);
+
+        // A newer record arrives while Compose is building. The receipt must describe the env snapshot
+        // that actually preceded `up`, not re-fold this now-newer ledger after health succeeds.
+        const successor = await appendDeploymentPrescription({
+            ledgerPath  : paths.ledgerPath,
+            prescription: semanticPrescription({
+                prescriptionId          : 'P:second',
+                supersedesPrescriptionId: 'P:first',
+                values                  : {[LEAF]: SECOND_VALUE},
+                validatedAgainst        : {
+                    context   : {'runtime.chroma.liveMemoryLimitBytes': LIVE_BYTES},
+                    observedAt: 2_000
+                }
+            }),
+            now: 2_500
+        });
+
+        expect(successor.appended).toBe(true);
+
+        const receipt = await writeDeploymentPrescriptionReceipt({
+            envPath         : paths.envPath,
+            statePath       : paths.statePath,
+            receiptPath     : paths.receiptPath,
+            deploymentRunId : RUN_ID,
+            deployedRevision: DEPLOYED_SHA,
+            now             : () => 3_000
+        });
+
+        expect(receipt.status).toBe('delivered');
+        expect(receipt.deploymentRunId).toBe(RUN_ID);
+        expect(receipt.deployedRevision).toBe(DEPLOYED_SHA);
+        expect(receipt.activePrescriptions).toEqual([{
+            prescriptionId: 'P:first',
+            sequence      : 1,
+            knob          : KNOB,
+            targetIdentity: {kind: 'compose-service', id: 'chroma'}
+        }]);
+
+        const durableReceipt = await fs.readJson(paths.receiptPath);
+
+        expect(durableReceipt.activePrescriptions).toEqual(receipt.activePrescriptions);
+
+        await fs.appendFile(paths.envPath, 'CHANGED_AFTER_MATERIALIZE=1\n');
+
+        await expect(writeDeploymentPrescriptionReceipt({
+            envPath         : paths.envPath,
+            statePath       : paths.statePath,
+            receiptPath     : path.join(paths.root, 'false-receipt.json'),
+            deploymentRunId : RUN_ID,
+            deployedRevision: DEPLOYED_SHA
+        })).rejects.toThrow('changed after materialization');
+        expect(await fs.pathExists(path.join(paths.root, 'false-receipt.json'))).toBe(false)
+    });
+
+    test('a different deployment run cannot receipt another run snapshot', async () => {
+        const paths = pathsFor('run-binding');
+
+        await materializeDeploymentPrescriptions({
+            ...paths,
+            deploymentRunId : RUN_ID,
+            adoptExistingEnv: true
+        });
+
+        await expect(writeDeploymentPrescriptionReceipt({
+            envPath         : paths.envPath,
+            statePath       : paths.statePath,
+            receiptPath     : paths.receiptPath,
+            deploymentRunId : '22222222-2222-4222-8222-222222222222',
+            deployedRevision: DEPLOYED_SHA
+        })).rejects.toThrow('materialization state is malformed');
+
+        expect(await fs.pathExists(paths.receiptPath)).toBe(false)
+    });
+
+    test('the host-produced carrier changes the real Compose container limit; empty ledger resolves the default', async () => {
+        test.skip(!composeConfigAvailable(), 'docker compose CLI unavailable');
+
+        const active = pathsFor('compose-active'),
+              empty  = pathsFor('compose-empty');
+
+        await appendDeploymentPrescription({
+            ledgerPath  : active.ledgerPath,
+            prescription: semanticPrescription(),
+            now         : 2_000
+        });
+        await materializeDeploymentPrescriptions({...active, adoptExistingEnv: true, resolveContext: liveContext});
+        await materializeDeploymentPrescriptions({...empty, adoptExistingEnv: true});
+
+        const baseline = resolvedChromaMemory(null);
+
+        expect(baseline, 'the control must differ from the probe').not.toBe(String(PRESCRIBED));
+        expect(resolvedChromaMemory(active.envPath), 'store -> admission -> carrier -> production Compose')
+            .toBe(String(PRESCRIBED));
+        expect(resolvedChromaMemory(empty.envPath), 'no ledger retains the production default')
+            .toBe(baseline)
+    })
+});

--- a/test/playwright/unit/ai/services/memory-core/helpers/deploymentPrescriptionLedger.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/helpers/deploymentPrescriptionLedger.spec.mjs
@@ -1,0 +1,265 @@
+import {test, expect} from '@playwright/test';
+import fs             from 'node:fs';
+import os             from 'node:os';
+import path           from 'node:path';
+import {execFileSync} from 'node:child_process';
+
+import {
+    admitLedgerPrescriptions,
+    LEDGER_REFUSALS,
+    refuseLedgerRecord
+} from '../../../../../../../ai/services/memory-core/helpers/deploymentPrescriptionLedger.mjs';
+import {renderPrescribedEnvironment} from '../../../../../../../ai/services/memory-core/helpers/deploymentPrescriptionEnvironment.mjs';
+
+/**
+ * The three obligations were declared on the ticket BEFORE this file was written, so a green here means
+ * the thing that was asked for rather than whatever these tests happen to cover:
+ *
+ * 1. **Effect witness** — a ledger record changes what Compose CREATES the container with. Asserting
+ *    that a record was admitted would have passed against the original `reconfigure` no-op throughout.
+ * 2. **Counterfactual** — a record carrying a FORGED `env` field renders only the registry-derived key.
+ *    Without this arm the security boundary is a claim in a docblock.
+ * 3. **Ordering** — `sequence` decides supersession and `prescribedAt` does not, asserted with a record
+ *    whose clock is newer and whose watermark is older.
+ *
+ * `docker compose config` resolves interpolation with no reachable daemon, so the effect boundary is
+ * testable here. It runs against the REAL `ai/deploy/docker-compose.yml` via `--env-file` pointing at a
+ * temp file: a hand-written compose fixture could be looser than production and pass on an expression
+ * production does not use, and writing the real `ai/deploy/.env` would leave a window in which a peer's
+ * recreate picks up a test value.
+ */
+
+const
+    COMPOSE_RELATIVE = 'ai/deploy/docker-compose.yml',
+    KNOB             = 'container-memory-ceiling',
+    LEAF             = 'deploy.chroma.memoryCeilingBytes',
+    ENV_KEY          = 'NEO_CHROMA_MEMORY_LIMIT',
+    // Shaped from the LIVE target, not invented: the registry bounds this leaf to 8..16 GiB and the
+    // `raise-not-lower` invariant requires a value strictly above the container's live limit. 12 GiB
+    // clears both, and is not a default anywhere in the tree — so a pass cannot come from the baseline.
+    LIVE_LIMIT_BYTES = 8 * 1024 ** 3,
+    PROBE_BYTES      = 12 * 1024 ** 3;
+
+/**
+ * A record that is admissible on purpose, so each negative test can name the ONE field it breaks.
+ * @param {Object} [overrides]
+ * @returns {Object}
+ */
+function prescriptionRecord(overrides = {}) {
+    return {
+        recordType      : 'deployment-prescription',
+        prescriptionId  : 'PRESCRIPTION:base',
+        sequence        : 1,
+        knob            : KNOB,
+        targetIdentity  : {kind: 'compose-service', id: 'chroma'},
+        values          : {[LEAF]: PROBE_BYTES},
+        prescribedAt    : 1_000,
+        validatedAgainst: {
+            context: {'runtime.chroma.liveMemoryLimitBytes': LIVE_LIMIT_BYTES}
+        },
+        ...overrides
+    }
+}
+
+/**
+ * @returns {Boolean} whether `docker compose config` can run here
+ */
+function composeConfigAvailable() {
+    try {
+        execFileSync('docker', ['compose', 'version'], {stdio: 'ignore'});
+        return true
+    } catch {
+        return false
+    }
+}
+
+/**
+ * Resolves chroma's memory limit exactly as Compose would create it.
+ * @param {String} repoRoot
+ * @param {String|null} envFilePath
+ * @returns {String|null}
+ */
+function resolvedChromaMemory(repoRoot, envFilePath) {
+    const args = ['compose', '-f', path.join(repoRoot, COMPOSE_RELATIVE)];
+
+    envFilePath && args.push('--env-file', envFilePath);
+    args.push('config', '--format', 'json');
+
+    try {
+        const parsed = JSON.parse(execFileSync('docker', args, {encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore']}));
+
+        return parsed?.services?.chroma?.deploy?.resources?.limits?.memory ?? null
+    } catch {
+        return null
+    }
+}
+
+test.describe('the ledger admits against the registry, not against the record', () => {
+    test('a well-formed record is admitted and its env key comes from the REGISTRY', () => {
+        const {prescriptions, admitted, refused} = admitLedgerPrescriptions([prescriptionRecord()]);
+
+        expect(refused).toEqual([]);
+        expect(admitted).toHaveLength(1);
+        expect(prescriptions).toEqual([{key: ENV_KEY, value: PROBE_BYTES}])
+    });
+
+    test('OBLIGATION 2 — a forged `env` field renders NOTHING of its own', () => {
+        const {prescriptions} = admitLedgerPrescriptions([
+            prescriptionRecord({env: 'NEO_ORCHESTRATOR_HEAP_MB', leafPath: 'deploy.orchestrator.heapMb'})
+        ]);
+
+        // The forged key is absent and the registry key is present — both halves matter. Asserting only
+        // that the registry key appears would pass while the forged one was ALSO written.
+        expect(prescriptions.map(entry => entry.key)).toEqual([ENV_KEY]);
+        expect(renderPrescribedEnvironment(prescriptions).content).not.toContain('NEO_ORCHESTRATOR_HEAP_MB')
+    });
+
+    test('a record aiming a knob at a service the registry does not give it is refused', () => {
+        const refusal = refuseLedgerRecord(prescriptionRecord({targetIdentity: {kind: 'compose-service', id: 'kb-server'}}));
+
+        expect(refusal?.reason).toBe(LEDGER_REFUSALS.targetMismatch)
+    });
+
+    test('an unknown knob is refused rather than rendered', () => {
+        expect(refuseLedgerRecord(prescriptionRecord({knob: 'not-a-knob'}))?.reason).toBe(LEDGER_REFUSALS.unknownKnob)
+    });
+
+    test('the producer\'s validation is re-run, not trusted — an out-of-bounds value is refused', () => {
+        const refusal = refuseLedgerRecord(prescriptionRecord({values: {[LEAF]: 64 * 1024 ** 3}}));
+
+        expect(refusal?.reason).toBe(LEDGER_REFUSALS.invalidTransaction);
+        expect(refusal.detail.join(' ')).toContain(LEAF)
+    });
+
+    test('a record whose context no longer bounds it is refused, not skipped', () => {
+        const refusal = refuseLedgerRecord(prescriptionRecord({validatedAgainst: {context: {}}}));
+
+        expect(refusal?.reason).toBe(LEDGER_REFUSALS.invalidTransaction);
+        expect(refusal.detail.join(' ')).toContain('runtime.chroma.liveMemoryLimitBytes')
+    });
+
+    test('raise-not-lower is enforced HERE — a value at the live limit is refused', () => {
+        const refusal = refuseLedgerRecord(prescriptionRecord({values: {[LEAF]: LIVE_LIMIT_BYTES}}));
+
+        expect(refusal?.reason).toBe(LEDGER_REFUSALS.invalidTransaction)
+    });
+});
+
+test.describe('OBLIGATION 3 — sequence orders supersession; prescribedAt does not', () => {
+    test('a higher sequence supersedes, whatever order the records are read in', () => {
+        const records = [
+            prescriptionRecord({prescriptionId: 'P:old', sequence: 1, values: {[LEAF]: 10 * 1024 ** 3}}),
+            prescriptionRecord({prescriptionId: 'P:new', sequence: 2, values: {[LEAF]: PROBE_BYTES}})
+        ];
+
+        expect(admitLedgerPrescriptions(records).prescriptions).toEqual([{key: ENV_KEY, value: PROBE_BYTES}]);
+        // Reversed read order must not change the outcome, or arrival order is the real authority.
+        expect(admitLedgerPrescriptions([...records].reverse()).prescriptions).toEqual([{key: ENV_KEY, value: PROBE_BYTES}])
+    });
+
+    test('a NEWER prescribedAt with an OLDER sequence loses — the clock is not the authority', () => {
+        const {prescriptions, refused} = admitLedgerPrescriptions([
+            prescriptionRecord({prescriptionId: 'P:winner', sequence: 9, prescribedAt: 1, values: {[LEAF]: PROBE_BYTES}}),
+            prescriptionRecord({prescriptionId: 'P:latecomer', sequence: 2, prescribedAt: 9_999_999, values: {[LEAF]: 16 * 1024 ** 3}})
+        ]);
+
+        expect(prescriptions).toEqual([{key: ENV_KEY, value: PROBE_BYTES}]);
+        expect(refused[0]?.reason).toBe(LEDGER_REFUSALS.conflictingSequence)
+    });
+
+    // This test previously asserted `refused.length === 1` and a substring of the refusal message, and
+    // it PASSED against an implementation that rendered 10 GiB in one input order and 12 GiB in the
+    // other. A refusal assertion is not an outcome assertion: "something was rejected" says nothing
+    // about which value is live. @neo-gpt's counterexample terminated that revision.
+    //
+    // So the assertion is now the SURVIVING value, under BOTH orders. A single-order test of an
+    // order-sensitivity property is structurally blind.
+    test('one watermark holding two different payloads renders NOTHING, in either order', () => {
+        const
+            a        = prescriptionRecord({prescriptionId: 'P:a', sequence: 5, values: {[LEAF]: 10 * 1024 ** 3}}),
+            b        = prescriptionRecord({prescriptionId: 'P:b', sequence: 5, values: {[LEAF]: PROBE_BYTES}}),
+            forward  = admitLedgerPrescriptions([a, b]),
+            backward = admitLedgerPrescriptions([b, a]);
+
+        // Fail closed on the WHOLE competition: refusing only the newcomer kept the incumbent, and the
+        // incumbent is whichever record was read first — so the env variable took its value from input
+        // order. Not materializing it at all is the honest state until the ledger is repaired.
+        expect(forward.prescriptions,  'forward order renders no value').toEqual([]);
+        expect(backward.prescriptions, 'reverse order renders no value').toEqual([]);
+        expect(forward.admitted).toEqual([]);
+        expect(backward.admitted).toEqual([]);
+        // Both records are reported, so a caller can see WHY the key is missing rather than inferring it.
+        expect(forward.refused.length).toBe(2);
+        expect(backward.refused.length).toBe(2)
+    });
+
+    test('an undeclared target KIND cannot mint a second competition for the same env key', () => {
+        const
+            declared   = prescriptionRecord({prescriptionId: 'P:declared', values: {[LEAF]: 10 * 1024 ** 3}}),
+            undeclared = prescriptionRecord({
+                prescriptionId: 'P:undeclared',
+                targetIdentity: {kind: 'not-a-declared-kind', id: 'chroma'},
+                values        : {[LEAF]: 16 * 1024 ** 3}
+            });
+
+        // `competitionKey()` includes `kind`, so an unvalidated kind opened a SECOND competition for one
+        // env variable and the renderer picked by array position — order-dependent again, one field over.
+        expect(refuseLedgerRecord(undeclared)?.reason).toBe(LEDGER_REFUSALS.targetMismatch);
+
+        for (const order of [[declared, undeclared], [undeclared, declared]]) {
+            const {prescriptions} = admitLedgerPrescriptions(order);
+
+            expect(prescriptions, 'exactly one entry per env key, whatever the order').toEqual([
+                {key: ENV_KEY, value: 10 * 1024 ** 3}
+            ])
+        }
+    });
+
+    test('an unordered record cannot be folded at all', () => {
+        expect(refuseLedgerRecord(prescriptionRecord({sequence: undefined}))?.reason).toBe(LEDGER_REFUSALS.unorderable);
+        expect(refuseLedgerRecord(prescriptionRecord({sequence: 1.5}))?.reason).toBe(LEDGER_REFUSALS.unorderable)
+    });
+});
+
+test.describe('OBLIGATION 1 — the effect witness', () => {
+    test('a ledger record changes what Compose CREATES the container with', () => {
+        test.skip(!composeConfigAvailable(), 'docker compose CLI unavailable');
+
+        const
+            repoRoot = process.cwd(),
+            envPath  = path.join(fs.mkdtempSync(path.join(os.tmpdir(), 'neo-prescription-')), 'prescribed.env'),
+            baseline = resolvedChromaMemory(repoRoot, null);
+
+        // The control: without the prescription the field resolves to the compose default. A witness
+        // whose baseline already equals the probe proves nothing about delivery.
+        expect(baseline, 'the compose default resolves before any prescription').not.toBe(String(PROBE_BYTES));
+
+        const {prescriptions} = admitLedgerPrescriptions([prescriptionRecord()]),
+              {content}       = renderPrescribedEnvironment(prescriptions);
+
+        fs.writeFileSync(envPath, content);
+
+        expect(resolvedChromaMemory(repoRoot, envPath), 'the ledger record reaches the created container')
+            .toBe(String(PROBE_BYTES))
+    });
+
+    test('a REFUSED record reaches nothing — the same file renders the default', () => {
+        test.skip(!composeConfigAvailable(), 'docker compose CLI unavailable');
+
+        const
+            repoRoot = process.cwd(),
+            envPath  = path.join(fs.mkdtempSync(path.join(os.tmpdir(), 'neo-prescription-')), 'prescribed.env'),
+            // Same value, same knob, aimed at a service the registry does not give this knob.
+            {prescriptions} = admitLedgerPrescriptions([
+                prescriptionRecord({targetIdentity: {kind: 'compose-service', id: 'kb-server'}})
+            ]);
+
+        expect(prescriptions).toEqual([]);
+
+        fs.writeFileSync(envPath, renderPrescribedEnvironment(prescriptions).content);
+
+        // The negative arm of the SAME instrument that showed delivery, so a pass above cannot be an
+        // artifact of the harness resolving the probe value by some other route.
+        expect(resolvedChromaMemory(repoRoot, envPath)).toBe(resolvedChromaMemory(repoRoot, null))
+    });
+});

--- a/test/playwright/unit/ai/services/memory-core/helpers/deploymentPrescriptionStore.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/helpers/deploymentPrescriptionStore.spec.mjs
@@ -1,0 +1,313 @@
+import {test, expect}                from '@playwright/test';
+import {mkdtemp, readFile, rm, stat} from 'node:fs/promises';
+import os                            from 'node:os';
+import path                          from 'node:path';
+
+import {
+    appendDeploymentPrescription,
+    readDeploymentPrescriptions,
+    validateDeploymentPrescriptionLedger
+} from '../../../../../../../ai/services/memory-core/helpers/deploymentPrescriptionStore.mjs';
+
+const
+    KNOB             = 'container-memory-ceiling',
+    LEAF             = 'deploy.chroma.memoryCeilingBytes',
+    LIVE_LIMIT_BYTES = 8 * 1024 ** 3,
+    VALUE_BYTES      = 12 * 1024 ** 3;
+
+/**
+ * @summary Creates one complete semantic prescription; transport fields are deliberately absent.
+ * @param {Object} [overrides]
+ * @returns {Object}
+ */
+function semanticPrescription(overrides = {}) {
+    return {
+        prescriptionId          : 'P:base',
+        supersedesPrescriptionId: null,
+        diagnosisId             : 'D:base',
+        recoveryRunId           : 'R:base',
+        targetIdentity          : {kind: 'compose-service', id: 'chroma'},
+        knob                    : KNOB,
+        values                  : {[LEAF]: VALUE_BYTES},
+        validatedAgainst        : {
+            context               : {'runtime.chroma.liveMemoryLimitBytes': LIVE_LIMIT_BYTES},
+            observationFingerprint: 'obs:100',
+            observedAt            : 100
+        },
+        ...overrides
+    }
+}
+
+test.describe('deploymentPrescriptionStore — trusted compare-and-append ingress', () => {
+    let ledgerPath, tmpDir;
+
+    test.beforeEach(async () => {
+        tmpDir     = await mkdtemp(path.join(os.tmpdir(), 'neo-deployment-prescription-store-'));
+        ledgerPath = path.join(tmpDir, 'deployment-prescriptions.jsonl')
+    });
+
+    test.afterEach(async () => {
+        await rm(tmpDir, {recursive: true, force: true})
+    });
+
+    /**
+     * @summary Reads exact ledger bytes without turning absence into a test failure.
+     * @returns {Promise<String>}
+     */
+    async function ledgerBytes() {
+        try {
+            return await readFile(ledgerPath, 'utf8')
+        } catch (error) {
+            if (error?.code === 'ENOENT') return '';
+            throw error
+        }
+    }
+
+    test('first append is registry-valid, sink-stamped, sequenced, and durable', async () => {
+        const result = await appendDeploymentPrescription({
+            ledgerPath,
+            prescription: semanticPrescription(),
+            now         : () => 1_234
+        });
+
+        expect(result).toEqual({
+            appended: true,
+            replayed: false,
+            record  : expect.objectContaining({
+                schemaVersion    : 1,
+                recordType       : 'deployment-prescription',
+                prescriptionId   : 'P:base',
+                sequence         : 1,
+                producerPrincipal: 'operator-local',
+                prescribedAt     : 1_234
+            }),
+            reason: null
+        });
+
+        const records = await readDeploymentPrescriptions(ledgerPath);
+
+        expect(records).toEqual([result.record]);
+        expect(validateDeploymentPrescriptionLedger(records)).toEqual({
+            valid      : true,
+            recordCount: 1,
+            activeCount: 1,
+            maxSequence: 1
+        });
+        expect((await stat(ledgerPath)).size).toBe(Buffer.byteLength(`${JSON.stringify(result.record)}\n`))
+    });
+
+    test('the public ledger audit rejects forged sink provenance and schema', async () => {
+        const {record} = await appendDeploymentPrescription({
+            ledgerPath,
+            prescription: semanticPrescription()
+        });
+
+        expect(() => validateDeploymentPrescriptionLedger([{...record, producerPrincipal: ''}]))
+            .toThrow(/producer principal/);
+        expect(() => validateDeploymentPrescriptionLedger([{...record, schemaVersion: 99}]))
+            .toThrow(/schema or record type/)
+    });
+
+    test('the public ledger audit rejects broken sequence and predecessor continuity', async () => {
+        const first = await appendDeploymentPrescription({ledgerPath, prescription: semanticPrescription()});
+        const next  = await appendDeploymentPrescription({
+            ledgerPath,
+            prescription: semanticPrescription({
+                prescriptionId          : 'P:next',
+                supersedesPrescriptionId: 'P:base',
+                values                  : {[LEAF]: 16 * 1024 ** 3},
+                validatedAgainst        : {
+                    context               : {'runtime.chroma.liveMemoryLimitBytes': LIVE_LIMIT_BYTES},
+                    observationFingerprint: 'obs:200',
+                    observedAt            : 200
+                }
+            })
+        });
+
+        expect(() => validateDeploymentPrescriptionLedger([first.record, {...next.record, sequence: 1}]))
+            .toThrow(/monotonic sequence/);
+        expect(() => validateDeploymentPrescriptionLedger([
+            first.record,
+            {...next.record, supersedesPrescriptionId: 'P:foreign'}
+        ])).toThrow(/predecessor CAS/)
+    });
+
+    test('caller-forged sink fields and registry-owned transport fields write zero ledger bytes', async () => {
+        const forgeries = [
+            ['sequence', 99],
+            ['producerPrincipal', 'forged'],
+            ['prescribedAt', 99],
+            ['recordType', 'deployment-prescription'],
+            ['schemaVersion', 1],
+            ['env', 'NEO_UNRELATED_SECRET']
+        ];
+
+        for (const [field, value] of forgeries) {
+            const result = await appendDeploymentPrescription({
+                ledgerPath,
+                prescription: semanticPrescription({[field]: value})
+            });
+
+            expect(result.appended, field).toBe(false);
+            expect(result.replayed, field).toBe(false);
+            expect(result.record, field).toBeNull();
+            expect(result.reason, field).toContain(field)
+        }
+
+        const wrongTarget = await appendDeploymentPrescription({
+            ledgerPath,
+            prescription: semanticPrescription({targetIdentity: {kind: 'shell-target', id: 'chroma'}})
+        });
+
+        expect(wrongTarget).toMatchObject({appended: false, replayed: false, record: null});
+        expect(wrongTarget.reason).toBe('ledger-refused:target-mismatch');
+        expect(await ledgerBytes()).toBe('')
+    });
+
+    test('an exact semantic replay is idempotent even when object key order changes', async () => {
+        const original = semanticPrescription();
+        const first    = await appendDeploymentPrescription({ledgerPath, prescription: original, now: () => 1_000});
+        const before   = await ledgerBytes();
+        const replay   = await appendDeploymentPrescription({
+            ledgerPath,
+            producerPrincipal: 'operator-second-seat',
+            now              : () => 9_999,
+            prescription     : {
+                values          : {[LEAF]: VALUE_BYTES},
+                validatedAgainst: {
+                    observedAt            : 100,
+                    observationFingerprint: 'obs:100',
+                    context               : {'runtime.chroma.liveMemoryLimitBytes': LIVE_LIMIT_BYTES}
+                },
+                targetIdentity          : {id: 'chroma', kind: 'compose-service'},
+                supersedesPrescriptionId: null,
+                recoveryRunId           : 'R:base',
+                prescriptionId          : 'P:base',
+                knob                    : KNOB,
+                diagnosisId             : 'D:base'
+            }
+        });
+
+        expect(replay).toEqual({appended: false, replayed: true, record: first.record, reason: null});
+        expect(await ledgerBytes()).toBe(before)
+    });
+
+    test('the same prescriptionId with a different semantic payload refuses without writing', async () => {
+        await appendDeploymentPrescription({ledgerPath, prescription: semanticPrescription()});
+
+        const before = await ledgerBytes();
+        const result = await appendDeploymentPrescription({
+            ledgerPath,
+            prescription: semanticPrescription({values: {[LEAF]: 16 * 1024 ** 3}})
+        });
+
+        expect(result).toEqual({
+            appended: false,
+            replayed: false,
+            record  : null,
+            reason  : 'prescription-id-conflict'
+        });
+        expect(await ledgerBytes()).toBe(before)
+    });
+
+    test('compare-and-append requires the active predecessor, including on a first append', async () => {
+        const premature = await appendDeploymentPrescription({
+            ledgerPath,
+            prescription: semanticPrescription({supersedesPrescriptionId: 'P:not-there'})
+        });
+
+        expect(premature.reason).toBe('predecessor-mismatch');
+        expect(await ledgerBytes()).toBe('');
+
+        const first  = await appendDeploymentPrescription({ledgerPath, prescription: semanticPrescription()});
+        const before = await ledgerBytes();
+        const stale  = await appendDeploymentPrescription({
+            ledgerPath,
+            prescription: semanticPrescription({
+                prescriptionId          : 'P:next',
+                supersedesPrescriptionId: 'P:wrong',
+                validatedAgainst        : {
+                    context               : {'runtime.chroma.liveMemoryLimitBytes': LIVE_LIMIT_BYTES},
+                    observationFingerprint: 'obs:200',
+                    observedAt            : 200
+                }
+            })
+        });
+
+        expect(first.appended).toBe(true);
+        expect(stale.reason).toBe('predecessor-mismatch');
+        expect(await ledgerBytes()).toBe(before)
+    });
+
+    test('a lower validation watermark cannot complete after a newer active prescription', async () => {
+        await appendDeploymentPrescription({
+            ledgerPath,
+            prescription: semanticPrescription({
+                validatedAgainst: {
+                    context               : {'runtime.chroma.liveMemoryLimitBytes': LIVE_LIMIT_BYTES},
+                    observationFingerprint: 'obs:200',
+                    observedAt            : 200
+                }
+            })
+        });
+
+        const before = await ledgerBytes();
+        const result = await appendDeploymentPrescription({
+            ledgerPath,
+            prescription: semanticPrescription({
+                prescriptionId          : 'P:stale',
+                supersedesPrescriptionId: 'P:base',
+                validatedAgainst        : {
+                    context               : {'runtime.chroma.liveMemoryLimitBytes': LIVE_LIMIT_BYTES},
+                    observationFingerprint: 'obs:100',
+                    observedAt            : 100
+                }
+            })
+        });
+
+        expect(result.reason).toBe('stale-observation-watermark');
+        expect(await ledgerBytes()).toBe(before)
+    });
+
+    test('the sink assigns one global monotonic sequence across valid successors', async () => {
+        const first = await appendDeploymentPrescription({ledgerPath, prescription: semanticPrescription()});
+        const next  = await appendDeploymentPrescription({
+            ledgerPath,
+            prescription: semanticPrescription({
+                prescriptionId          : 'P:next',
+                supersedesPrescriptionId: 'P:base',
+                values                  : {[LEAF]: 16 * 1024 ** 3},
+                validatedAgainst        : {
+                    context               : {'runtime.chroma.liveMemoryLimitBytes': LIVE_LIMIT_BYTES},
+                    observationFingerprint: 'obs:200',
+                    observedAt            : 200
+                }
+            })
+        });
+
+        expect(first.record.sequence).toBe(1);
+        expect(next.record.sequence).toBe(2);
+        expect((await readDeploymentPrescriptions(ledgerPath)).map(record => record.sequence)).toEqual([1, 2])
+    });
+
+    test('a concurrent first-append pair cannot both pass the same CAS read', async () => {
+        const [a, b] = await Promise.all([
+            appendDeploymentPrescription({
+                ledgerPath,
+                prescription: semanticPrescription({prescriptionId: 'P:a'})
+            }),
+            appendDeploymentPrescription({
+                ledgerPath,
+                prescription: semanticPrescription({prescriptionId: 'P:b'})
+            })
+        ]);
+
+        expect([a, b].filter(result => result.appended)).toHaveLength(1);
+        expect([a, b].filter(result => result.reason === 'predecessor-mismatch')).toHaveLength(1);
+
+        const records = await readDeploymentPrescriptions(ledgerPath);
+
+        expect(records).toHaveLength(1);
+        expect(records[0].sequence).toBe(1)
+    });
+});


### PR DESCRIPTION
Resolves neomjs/neo#16868
Related: neomjs/neo-agent-brain#55
Related: neomjs/neo#16857

Deployment prescriptions now have a real host delivery path: an operator append enters one sink-stamped store, active intent is re-admitted against the current registry and live Docker context, a persistent Compose carrier is materialized before deployment, and a run-bound delivery receipt is written only after `compose up --wait` succeeds. This deliberately does not invent diagnosis-side values or widen actuator authority.

Evidence: L3 (real `docker compose config` against the production composition, plus exact CLI and mock-host pipeline dispatch) → L3 required (the close target requires a daemon-free real Compose effect, not a live container mutation). No residuals.

The close target's eight acceptance items are checked against this exact-head evidence; no post-merge item is being used to defer delivery.

## Deltas from ticket

- The repaired admission layer from the superseded helper-only slice is included only behind its first production caller.
- Fresh Docker context is resolved at materialization time. A stale raise that is now lower refuses; exact equality is admitted only as already-applied deployment state, without weakening the actuator's strict raise invariant.
- Exported deployment-owned variables refuse before writes because process environment outranks env files.
- One host deploy lock serializes the shared carrier, while UUID-scoped state and receipt paths prevent one run from receipting another run's manifest.
- Regular `.env` adoption is capture-first and no-overwrite. A last-moment operator update restores both the operator file and prior persistent carrier instead of creating a permanent refusal.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/ai/services/memory-core/helpers/deploymentPrescriptionStore.spec.mjs test/playwright/unit/ai/services/memory-core/helpers/deploymentPrescriptionLedger.spec.mjs test/playwright/unit/ai/services/memory-core/helpers/deploymentPrescriptionEnvironment.spec.mjs test/playwright/unit/ai/scripts/maintenance/materializeDeploymentPrescriptions.spec.mjs test/playwright/unit/ai/DeployPipelineComposeFileList.spec.mjs` — 56/56 passed on rebased head.
- `bash -n ai/examples/cloud-deployment/deploy-pipeline.sh` — passed.
- `npm run agent-preflight -- --change-class capability --commit-subject "feat(ai): deliver deployment prescriptions through host pipeline (#16868)" <10 scoped files>` — passed, including parse, JSDoc, whitespace, shorthand, block-alignment, AiConfig-test-mutation, and ticket-archaeology gates.
- `npm run ai:lint-guides` — 0 hard failures.
- Store/admission: compare-and-append interleavings, replay, forged fields, sequence/CAS, current-registry refusal, and read-order conflict controls passed.
- Host materializer: real CLI append, fresh-runtime lowering refusal, already-applied equality, ambient precedence, byte-preserving adoption, adoption-race rollback, run binding, and tamper controls passed.
- Deployment pipeline: preflight/materialize/health/receipt order, persistent `--env-file`, lock contention, UUID state binding, and failure-boundary controls passed.
- Production Compose effect: admitted `container-memory-ceiling` changes the resolved Chroma limit; empty/refused controls retain the default.

## Post-Merge Validation

- [ ] On an isolated host plane, append one operator-selected ceiling, run the reference deployment pipeline, and retain the UUID-scoped post-health receipt.
- [ ] Repeat the deployment with the already-applied ceiling and confirm idempotent reconciliation plus a second run-bound receipt.

## Evolution

The first slice proved admission only in a spec and was correctly retired. This branch keeps its registry-derived salvage, then closes the missing producer-to-host edge. Adversarial pre-PR falsifiers also changed four details before handoff: runtime context became fresh rather than historical, redeploy equality became a separate reconciliation state, process-env precedence became an explicit refusal, and `.env` adoption became a reversible capture transaction.

Authored by Euclid (GPT-5.6, Codex Desktop). Session 7f0e4829-173a-4780-9a46-8e4811a979b5.
