### PR TITLE
test(knowledge-base): pin persistence failure as an unbounded re-embed loop (#16875)

### DIFF
--- a/test/playwright/unit/ai/services/knowledge-base/VectorService.persistenceNonConvergence.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/VectorService.persistenceNonConvergence.spec.mjs
@@ -15,7 +15,7 @@ setup({
     }
 });
 
-import {mkdtempSync, rmSync} from 'node:fs';
+import {mkdtempSync, rmSync, writeFileSync} from 'node:fs';
 import os                    from 'node:os';
 import path                  from 'node:path';
 import {test, expect}        from '@playwright/test';
@@ -82,8 +82,22 @@ function createCollection({persists}) {
         upsertAttempts,
         name: 'spy-knowledge-base',
 
-        async get({limit = 1000, offset = 0} = {}) {
-            return {ids: [...landed].slice(offset, offset + limit)}
+        async get({limit = 1000, offset = 0, include = []} = {}) {
+            const slice = [...landed].slice(offset, offset + limit);
+
+            return {
+                ids      : slice,
+                metadatas: include.includes('metadatas') ? slice.map(() => ({})) : [],
+                documents: include.includes('documents') ? slice.map(() => '')   : []
+            }
+        },
+
+        async delete({ids}) {
+            ids.forEach(id => landed.delete(id));
+        },
+
+        async count() {
+            return landed.size
         },
 
         async upsert({ids, embeddings, metadatas}) {
@@ -118,8 +132,29 @@ function makeChunks(count) {
     }));
 }
 
+/**
+ * @summary Writes the JSONL corpus `VectorService.embed()` reads, so the deployed entry point can be
+ * driven with its own loader and its own selector rather than a hand-supplied chunk array.
+ * @param {String} filePath Destination of the synthetic corpus.
+ * @param {Number} chunkCount How many chunks to write.
+ * @returns {void}
+ */
+function writeFixtureJsonl(filePath, chunkCount) {
+    const lines = Array.from({length: chunkCount}, (_, i) => JSON.stringify({
+        hash       : `chunk-${i}`,
+        type       : 'method',
+        name       : `method${i}`,
+        className  : '',
+        description: `synthetic chunk ${i}`,
+        content    : `body ${i}`
+    }));
+
+    writeFileSync(filePath, lines.join('\n'), 'utf8');
+}
+
 test.describe('VectorService — persistence failure is an unbounded re-embed loop', () => {
-    let KB_VectorService, KB_Config, MC_Config, TextEmbeddingService, KBRecorderService;
+    let KB_VectorService, KB_Config, MC_Config, TextEmbeddingService, KBRecorderService, KB_ChromaManager;
+    let originalGetCollection, corpusPath;
     let selectResumableChunks, ensureEmbeddingIdentitySchema, getEmbeddingIdentityWindow;
     let restoreKBConfig, restoreMCConfig, originalOllamaProvider, originalRecorderDb;
     let db, tempDir;
@@ -163,13 +198,18 @@ test.describe('VectorService — persistence failure is an unbounded re-embed lo
         ({ensureEmbeddingIdentitySchema, getEmbeddingIdentityWindow} =
             await import('../../../../../../ai/services/shared/embeddingIdentityLedger.mjs'));
 
+        KB_ChromaManager = SDK.KB_ChromaManager;
+
         originalOllamaProvider = TextEmbeddingService.ollamaProvider;
         originalRecorderDb     = KBRecorderService.db;
+        originalGetCollection  = KB_ChromaManager.getKnowledgeBaseCollection.bind(KB_ChromaManager);
     });
 
     test.afterAll(() => {
-        TextEmbeddingService.ollamaProvider = originalOllamaProvider;
-        KBRecorderService.db                = originalRecorderDb;
+        TextEmbeddingService.ollamaProvider          = originalOllamaProvider;
+        KBRecorderService.db                         = originalRecorderDb;
+        KB_ChromaManager.getKnowledgeBaseCollection  = originalGetCollection;
+        KB_ChromaManager.invalidateKnowledgeBaseCollectionCache();
     });
 
     test.beforeEach(() => {
@@ -179,8 +219,9 @@ test.describe('VectorService — persistence failure is an unbounded re-embed lo
         Object.assign(KB_Config.data, {batchSize: 50, batchDelay: 0, maxRetries: 1});
         MC_Config.embeddingProvider = 'ollama';
 
-        tempDir = mkdtempSync(path.join(os.tmpdir(), 'neo-kb-nonconvergence-'));
-        db      = new Database(path.join(tempDir, 'telemetry.sqlite'));
+        tempDir    = mkdtempSync(path.join(os.tmpdir(), 'neo-kb-nonconvergence-'));
+        corpusPath = path.join(tempDir, 'corpus.jsonl');
+        db         = new Database(path.join(tempDir, 'telemetry.sqlite'));
         db.pragma('journal_mode = WAL');
         ensureEmbeddingIdentitySchema(db);
 
@@ -197,6 +238,9 @@ test.describe('VectorService — persistence failure is an unbounded re-embed lo
     });
 
     test.afterEach(() => {
+        KB_ChromaManager.getKnowledgeBaseCollection = originalGetCollection;
+        KB_ChromaManager.invalidateKnowledgeBaseCollectionCache();
+
         KBRecorderService.db = originalRecorderDb;
 
         if (db?.open) {
@@ -291,5 +335,59 @@ test.describe('VectorService — persistence failure is an unbounded re-embed lo
         expect(cleanWindow.submissions, 'the converging sweep submitted each text exactly once').toBe(3);
         expect(cleanWindow.ratio, 'and holds the ratio at exactly 1 — a legitimately busy run is NOT flagged')
             .toBe(1);
+    });
+
+    test('the DEPLOYED sweep entry point re-selects across successive embed() calls (#16780 AC-2)', async () => {
+        // The tests above drive the selection PRIMITIVES. This one drives `VectorService.embed()`, the
+        // entry point a deployment actually runs — and that distinction is load-bearing, because
+        // `embed()` carries its OWN inline selector rather than calling the shared helper. Binding only
+        // the helper would leave the deployed path unverified: the same selection rule exists twice in
+        // production, and a spec must say WHICH one it protects.
+        //
+        // Here `embed()` reads its own corpus off disk, reads existing ids off the collection, decides
+        // what to embed, and writes. Nothing in this test selects anything.
+        writeFixtureJsonl(corpusPath, 3);
+
+        const submissionsPerSweep = [];
+        let   sweepSubmissions    = 0;
+
+        TextEmbeddingService.ollamaProvider = {
+            async embed(input) {
+                const texts = Array.isArray(input) ? input : [input];
+                sweepSubmissions += texts.length;
+                return {embeddings: texts.map(() => new Array(384).fill(0.1))}
+            }
+        };
+
+        const runDeployedSweep = async collection => {
+            sweepSubmissions = 0;
+            KB_ChromaManager.getKnowledgeBaseCollection = async () => collection;
+            KB_ChromaManager.invalidateKnowledgeBaseCollectionCache();
+
+            await KB_VectorService.embed(corpusPath).then(() => null, () => null);
+            submissionsPerSweep.push(sweepSubmissions);
+        };
+
+        const failing = createCollection({persists: false});
+
+        await runDeployedSweep(failing);
+        await runDeployedSweep(failing);
+
+        expect(submissionsPerSweep, 'the deployed sweep paid the provider for the same corpus twice')
+            .toEqual([3, 3]);
+        expect(failing.landed.size, 'and stored nothing, so nothing bounds the next sweep either').toBe(0);
+
+        // Same entry point, same corpus, persistence restored. `embed()` now sees its own writes and
+        // selects nothing — the convergence its inline selector exists to produce.
+        submissionsPerSweep.length = 0;
+
+        const converging = createCollection({persists: true});
+
+        await runDeployedSweep(converging);
+        await runDeployedSweep(converging);
+
+        expect(submissionsPerSweep, 'the second deployed sweep had nothing left to select')
+            .toEqual([3, 0]);
+        expect(converging.landed.size, 'because the first one actually landed').toBe(3);
     });
 });

--- a/test/playwright/unit/ai/services/knowledge-base/VectorService.persistenceNonConvergence.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/VectorService.persistenceNonConvergence.spec.mjs
@@ -15,43 +15,98 @@ setup({
     }
 });
 
-import {test, expect} from '@playwright/test';
-import Neo            from '../../../../../../src/Neo.mjs';
-import * as core      from '../../../../../../src/core/_export.mjs';
+import {mkdtempSync, rmSync} from 'node:fs';
+import os                    from 'node:os';
+import path                  from 'node:path';
+import {test, expect}        from '@playwright/test';
+import Database              from 'better-sqlite3';
+import Neo                   from '../../../../../../src/Neo.mjs';
+import * as core             from '../../../../../../src/core/_export.mjs';
+import {snapshotAiConfig}    from '../memory-core/util.mjs';
 
 /**
- * @summary Persistence failure is an UNBOUNDED re-embed loop, and it must be visible as one.
+ * @summary Persistence failure is an UNBOUNDED re-embed loop, proven through PRODUCTION's own selector.
  *
- * `embedChunks` computes an embedding and then upserts inside the same `try`. A persistence failure
- * therefore discards work the provider has already been paid for, marks the batch failed, and the
- * next sweep re-selects exactly the same chunks — they are not in the collection — and pays for them
- * again. Every sweep costs full provider time and stores nothing.
+ * `embedChunks` computes an embedding and upserts inside the same `try`. A persistence failure
+ * discards work the provider has already been paid for, and the next sweep re-selects exactly the same
+ * chunks — they are not in the collection — and pays for them again. Every sweep costs full provider
+ * time and stores nothing.
  *
  * **The loop is not the finding; its invisibility is.** From provider load alone this is
  * indistinguishable from an ingestion making progress: continuous inference, a corpus that is not
- * growing, and every per-sweep receipt reporting a handled failure. That is the shape a deployment
- * can sit in for months.
+ * growing, and every per-sweep receipt reporting a handled failure.
  *
- * These specs prove the loop exists (so the repair target is real) and that it is now DETECTABLE —
- * repeated content drives the re-embed ratio above 1 while distinct content holds it at 1, which is
- * the discriminator between "does not converge" and "legitimately busy".
+ * ## Why selection must belong to production, and not to this file
+ *
+ * A spec that runs its own sweep loop and hands `embedChunks` the full corpus every pass measures
+ * nothing: the repetition it reports is authored by the test, and a control that discriminates with
+ * its own `filter(chunk => !landed.has(chunk.id))` is comparing two pieces of test code. The real
+ * sweep selector is `VectorService.embed()`, which reads `existingIds` off the collection and selects
+ * only what is missing — **that is the convergence mechanism itself**. A repair that stopped
+ * re-selecting would be invisible to arms shaped that way, so a correct implementation would keep
+ * them green.
+ *
+ * Both arms therefore run `runProductionSweep()` below, which is production all the way down, and the
+ * only variable between them is whether the upsert persisted — the same discriminator production uses.
+ *
+ * ## The reporting terminal
+ *
+ * A process-local observer cannot see this at all: the recorder and the reader are different OS
+ * processes, so a window owned by the embedding singleton in one process is unreadable in the other.
+ * The shared identity ledger removes that boundary — `VectorService` passes
+ * `providerActivityRecorder: KBRecorderService`, which stamps `source: 'knowledge-base'` into the
+ * ledger on every admitted batch.
+ *
+ * The ratio arm therefore drives the REAL `embedTexts` with the provider stubbed **below** the seam.
+ * Stubbing `embedTexts` skips the ledger write entirely and certifies the stub instead of the path.
  */
 test.describe.configure({mode: 'serial'});
 
-function createFailingCollection({failUpsert}) {
-    const upsertAttempts = [];
+/**
+ * @summary One collection double, one variable: whether the write persists.
+ *
+ * Modelling both arms with a single factory is deliberate. Two hand-written doubles can drift into
+ * differing on something other than persistence, and then the arms stop being each other's falsifier
+ * for a reason no reader can see.
+ *
+ * It refuses what ChromaDB refuses. A double that accepts any `{ids, embeddings}` pair deletes the
+ * store's mandatory refusals, and every assertion downstream of that removal becomes a property of
+ * the double rather than of the system — which is how a spec ends up proving the opposite of its
+ * claim. When a test replaces a boundary, model what the boundary REJECTS, not only what it records.
+ */
+function createCollection({persists}) {
+    const landed = new Set(), upsertAttempts = [];
 
     return {
+        landed,
         upsertAttempts,
         name: 'spy-knowledge-base',
-        async upsert({ids}) {
+
+        async get({limit = 1000, offset = 0} = {}) {
+            return {ids: [...landed].slice(offset, offset + limit)}
+        },
+
+        async upsert({ids, embeddings, metadatas}) {
             upsertAttempts.push([...ids]);
 
-            if (failUpsert()) {
+            const lengths = [['ids', ids?.length], ['embeddings', embeddings?.length], ['metadatas', metadatas?.length]]
+                .filter(([, length]) => Number.isFinite(length));
+
+            if (lengths.some(([, length]) => length === 0)) {
+                throw new Error('Non-empty lists are required for the record set');
+            }
+
+            if (new Set(lengths.map(([, length]) => length)).size > 1) {
+                throw new Error('Unequal lengths for fields in the record set');
+            }
+
+            if (!persists) {
                 throw new Error('collection unavailable: persistence rejected the write');
             }
+
+            ids.forEach(id => landed.add(id));
         }
-    };
+    }
 }
 
 function makeChunks(count) {
@@ -64,88 +119,177 @@ function makeChunks(count) {
 }
 
 test.describe('VectorService — persistence failure is an unbounded re-embed loop', () => {
-    let KB_VectorService, KB_Config, TextEmbeddingService;
-    let originalEmbedTexts, originalBatchConfig;
+    let KB_VectorService, KB_Config, MC_Config, TextEmbeddingService, KBRecorderService;
+    let selectResumableChunks, ensureEmbeddingIdentitySchema, getEmbeddingIdentityWindow;
+    let restoreKBConfig, restoreMCConfig, originalOllamaProvider, originalRecorderDb;
+    let db, tempDir;
+
+    /**
+     * @summary ONE sweep, decided by PRODUCTION.
+     *
+     * `readCollectionIds` asks the collection what actually landed, `selectResumableChunks` decides
+     * what remains, `embedChunks` embeds exactly that. No selection logic lives in this file, which is
+     * the whole repair: a change to how production selects moves these numbers.
+     *
+     * @param {Object} options
+     * @param {Object} options.collection The collection double under test.
+     * @param {Object[]} options.corpus The full current-corpus chunks.
+     * @returns {Promise<{selected: Number}>} How many chunks production chose to embed this sweep.
+     */
+    async function runProductionSweep({collection, corpus}) {
+        const existingIds = await KB_VectorService.readCollectionIds(collection),
+              {remaining} = selectResumableChunks({chunks: corpus, existingIds});
+
+        if (remaining.length === 0) {
+            return {selected: 0}
+        }
+
+        await KB_VectorService.embedChunks({collection, chunksToProcess: remaining})
+            .then(() => null, () => null);
+
+        return {selected: remaining.length}
+    }
 
     test.beforeAll(async () => {
         const SDK = await import('../../../../../../ai/services.mjs');
 
         KB_Config            = SDK.KB_Config;
         TextEmbeddingService = SDK.Memory_TextEmbeddingService;
+        MC_Config            = (await import('../../../../../../ai/mcp/server/memory-core/config.template.mjs')).default;
         KB_VectorService     = (await import('../../../../../../ai/services/knowledge-base/VectorService.mjs')).default;
+        KBRecorderService    = (await import('../../../../../../ai/services/knowledge-base/KBRecorderService.mjs')).default;
 
-        originalEmbedTexts  = TextEmbeddingService.embedTexts.bind(TextEmbeddingService);
-        originalBatchConfig = {
-            batchSize : KB_Config.data.batchSize,
-            batchDelay: KB_Config.data.batchDelay,
-            maxRetries: KB_Config.data.maxRetries
-        };
+        ({selectResumableChunks} = await import('../../../../../../ai/services/knowledge-base/helpers/resumableEmbedding.mjs'));
+        ({ensureEmbeddingIdentitySchema, getEmbeddingIdentityWindow} =
+            await import('../../../../../../ai/services/shared/embeddingIdentityLedger.mjs'));
+
+        originalOllamaProvider = TextEmbeddingService.ollamaProvider;
+        originalRecorderDb     = KBRecorderService.db;
     });
 
     test.afterAll(() => {
-        TextEmbeddingService.embedTexts = originalEmbedTexts;
-        Object.assign(KB_Config.data, originalBatchConfig);
+        TextEmbeddingService.ollamaProvider = originalOllamaProvider;
+        KBRecorderService.db                = originalRecorderDb;
     });
 
     test.beforeEach(() => {
+        restoreMCConfig = snapshotAiConfig(MC_Config, ['embeddingProvider']);
+        restoreKBConfig = snapshotAiConfig(KB_Config, ['data.batchSize', 'data.batchDelay', 'data.maxRetries']);
+
         Object.assign(KB_Config.data, {batchSize: 50, batchDelay: 0, maxRetries: 1});
+        MC_Config.embeddingProvider = 'ollama';
+
+        tempDir = mkdtempSync(path.join(os.tmpdir(), 'neo-kb-nonconvergence-'));
+        db      = new Database(path.join(tempDir, 'telemetry.sqlite'));
+        db.pragma('journal_mode = WAL');
+        ensureEmbeddingIdentitySchema(db);
+
+        KBRecorderService.db = db;
+
+        // Below the seam, deliberately. The real `embedTexts` must run so the KB recorder writes into
+        // the shared ledger; stubbing `embedTexts` would bypass the terminal this spec exists to assert.
+        TextEmbeddingService.ollamaProvider = {
+            async embed(input) {
+                const texts = Array.isArray(input) ? input : [input];
+                return {embeddings: texts.map(() => new Array(384).fill(0.1))}
+            }
+        };
     });
 
-    test('a persistence failure re-embeds the IDENTICAL set on every sweep (#16780 AC-2)', async () => {
-        // The loop, made explicit. Three sweeps, persistence failing throughout, and the corpus never
-        // grows — so each sweep re-selects the same ids and pays the provider again for vectors it
-        // will discard. Asserted on what was SUBMITTED, because the cost is the submission.
-        const corpus      = makeChunks(3),
-              collection  = createFailingCollection({failUpsert: () => true}),
-              submissions = [];
+    test.afterEach(() => {
+        KBRecorderService.db = originalRecorderDb;
 
-        TextEmbeddingService.embedTexts = async texts => {
-            submissions.push([...texts]);
-            return texts.map(() => new Array(384).fill(0))
-        };
-
-        for (let sweep = 0; sweep < 3; sweep++) {
-            await KB_VectorService.embedChunks({collection, chunksToProcess: corpus})
-                .then(() => null, () => null);
+        if (db?.open) {
+            db.close();
         }
 
-        expect(submissions.length, 'every sweep re-submitted rather than converging')
-            .toBeGreaterThanOrEqual(3);
+        rmSync(tempDir, {force: true, recursive: true});
 
-        const distinctSubmitted = new Set(submissions.flat());
-
-        expect(distinctSubmitted.size, 'three distinct texts, however many sweeps ran').toBe(3);
-        expect(submissions.flat().length, 'but far more submissions than distinct inputs — the loop')
-            .toBeGreaterThan(distinctSubmitted.size);
+        restoreKBConfig?.();
+        restoreMCConfig?.();
     });
 
-    test('a CONVERGING sweep does not re-submit — the control (#16780 AC-2)', async () => {
-        // Without this the test above proves only that embedChunks embeds things. The discriminator
-        // is that a sweep whose writes PERSIST submits each text exactly once and the next sweep has
-        // nothing to do. "Re-submitted" only means something against a case that does not.
+    test('PRODUCTION re-selects the identical set on every sweep when persistence fails (#16780 AC-2)', async () => {
+        // The numbers below are production's selection decisions, not this test's. That distinction is
+        // the entire repair: the previous version handed `embedChunks` the full corpus itself, so it
+        // would have produced [3, 3, 3] against a perfectly convergent implementation too.
         const corpus     = makeChunks(3),
-              landed     = new Set(),
-              collection = {
-                  name: 'spy-knowledge-base',
-                  async upsert({ids}) { ids.forEach(id => landed.add(id)) }
-              };
-
-        const submissions = [];
-
-        TextEmbeddingService.embedTexts = async texts => {
-            submissions.push([...texts]);
-            return texts.map(() => new Array(384).fill(0))
-        };
+              collection = createCollection({persists: false}),
+              selected   = [];
 
         for (let sweep = 0; sweep < 3; sweep++) {
-            const remaining = corpus.filter(chunk => !landed.has(chunk.id));
-
-            if (remaining.length === 0) break;
-
-            await KB_VectorService.embedChunks({collection, chunksToProcess: remaining});
+            selected.push((await runProductionSweep({collection, corpus})).selected);
         }
 
-        expect(landed.size, 'the corpus converged').toBe(3);
-        expect(submissions.flat().length, 'each text submitted exactly once — no repetition to report').toBe(3);
+        expect(selected, 'production re-selected the SAME three chunks on every sweep — the loop')
+            .toEqual([3, 3, 3]);
+        expect(collection.landed.size, 'and nothing ever landed, so the corpus cannot bound the work')
+            .toBe(0);
+        expect(collection.upsertAttempts.length, 'three sweeps, three paid-for upsert attempts')
+            .toBe(3);
+    });
+
+    test('the CONVERGING control: same boundary, writes land, production selects nothing (#16780 AC-2)', async () => {
+        // The falsifier for the test above. It differs in exactly ONE respect — `persists: true` — and
+        // every other line, including all selection, is identical and production-owned.
+        const corpus     = makeChunks(3),
+              collection = createCollection({persists: true}),
+              selected   = [];
+
+        for (let sweep = 0; sweep < 3; sweep++) {
+            selected.push((await runProductionSweep({collection, corpus})).selected);
+        }
+
+        expect(selected, 'production selected the corpus once, then had nothing left to do')
+            .toEqual([3, 0, 0]);
+        expect(collection.landed.size, 'the corpus converged').toBe(3);
+        expect(collection.upsertAttempts.length, 'exactly one upsert — no repetition to report').toBe(1);
+    });
+
+    test('the loop is VISIBLE at the shared ledger: ratio above 1, and exactly 1 when it converges (#16780 AC-2)', async () => {
+        // The detection/report terminal. Both arms run the real `embedTexts`, so `VectorService` stamps
+        // `source: 'knowledge-base'` into the shared identity ledger on every admitted batch.
+        //
+        // This is what makes the two arms above matter operationally. Selection behaviour alone is
+        // invisible in production: a deployment sees provider load and cannot tell which arm it is in.
+        // The ratio is the surface where "did the same work again" becomes expressible, and it has to
+        // be a CROSS-PROCESS surface — the recorder and the reader are different OS processes.
+        const corpus = makeChunks(3);
+
+        const sinceTs = Date.now() - 1;
+
+        const failing = createCollection({persists: false});
+        for (let sweep = 0; sweep < 3; sweep++) {
+            await runProductionSweep({collection: failing, corpus});
+        }
+
+        const loopWindow = getEmbeddingIdentityWindow(db, {sinceTs});
+
+        expect(loopWindow.distinct, 'three distinct texts, however many sweeps ran').toBe(3);
+        expect(loopWindow.submissions, 'but nine submissions — three sweeps of three').toBe(9);
+        expect(loopWindow.ratio, 'a non-converging sweep reports repetition, which is the alarm')
+            .toBeGreaterThan(1);
+
+        // Same corpus, same code, persistence restored — on a FRESH ledger so the two arms cannot
+        // contaminate each other's window.
+        db.close();
+        rmSync(path.join(tempDir, 'telemetry.sqlite'), {force: true});
+        db = new Database(path.join(tempDir, 'telemetry.sqlite'));
+        db.pragma('journal_mode = WAL');
+        ensureEmbeddingIdentitySchema(db);
+        KBRecorderService.db = db;
+
+        const cleanSince = Date.now() - 1;
+        const converging = createCollection({persists: true});
+
+        for (let sweep = 0; sweep < 3; sweep++) {
+            await runProductionSweep({collection: converging, corpus});
+        }
+
+        const cleanWindow = getEmbeddingIdentityWindow(db, {sinceTs: cleanSince});
+
+        expect(cleanWindow.submissions, 'the converging sweep submitted each text exactly once').toBe(3);
+        expect(cleanWindow.ratio, 'and holds the ratio at exactly 1 — a legitimately busy run is NOT flagged')
+            .toBe(1);
     });
 });

--- a/test/playwright/unit/ai/services/knowledge-base/VectorService.persistenceNonConvergence.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/VectorService.persistenceNonConvergence.spec.mjs
@@ -1,0 +1,151 @@
+import {setup} from '../../../../setup.mjs';
+
+const appName = 'KBPersistenceNonConvergenceTest';
+
+setup({
+    neoConfig: {
+        allowVdomUpdatesInTests: false,
+        unitTestMode           : true,
+        useDomApiRenderer      : false
+    },
+    appConfig: {
+        name             : appName,
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../../../src/Neo.mjs';
+import * as core      from '../../../../../../src/core/_export.mjs';
+
+/**
+ * @summary Persistence failure is an UNBOUNDED re-embed loop, and it must be visible as one.
+ *
+ * `embedChunks` computes an embedding and then upserts inside the same `try`. A persistence failure
+ * therefore discards work the provider has already been paid for, marks the batch failed, and the
+ * next sweep re-selects exactly the same chunks — they are not in the collection — and pays for them
+ * again. Every sweep costs full provider time and stores nothing.
+ *
+ * **The loop is not the finding; its invisibility is.** From provider load alone this is
+ * indistinguishable from an ingestion making progress: continuous inference, a corpus that is not
+ * growing, and every per-sweep receipt reporting a handled failure. That is the shape a deployment
+ * can sit in for months.
+ *
+ * These specs prove the loop exists (so the repair target is real) and that it is now DETECTABLE —
+ * repeated content drives the re-embed ratio above 1 while distinct content holds it at 1, which is
+ * the discriminator between "does not converge" and "legitimately busy".
+ */
+test.describe.configure({mode: 'serial'});
+
+function createFailingCollection({failUpsert}) {
+    const upsertAttempts = [];
+
+    return {
+        upsertAttempts,
+        name: 'spy-knowledge-base',
+        async upsert({ids}) {
+            upsertAttempts.push([...ids]);
+
+            if (failUpsert()) {
+                throw new Error('collection unavailable: persistence rejected the write');
+            }
+        }
+    };
+}
+
+function makeChunks(count) {
+    return Array.from({length: count}, (_, i) => ({
+        id     : `chunk-${i}`,
+        type   : 'guide',
+        name   : `symbol-${i}`,
+        content: `body for chunk ${i}`
+    }));
+}
+
+test.describe('VectorService — persistence failure is an unbounded re-embed loop', () => {
+    let KB_VectorService, KB_Config, TextEmbeddingService;
+    let originalEmbedTexts, originalBatchConfig;
+
+    test.beforeAll(async () => {
+        const SDK = await import('../../../../../../ai/services.mjs');
+
+        KB_Config            = SDK.KB_Config;
+        TextEmbeddingService = SDK.Memory_TextEmbeddingService;
+        KB_VectorService     = (await import('../../../../../../ai/services/knowledge-base/VectorService.mjs')).default;
+
+        originalEmbedTexts  = TextEmbeddingService.embedTexts.bind(TextEmbeddingService);
+        originalBatchConfig = {
+            batchSize : KB_Config.data.batchSize,
+            batchDelay: KB_Config.data.batchDelay,
+            maxRetries: KB_Config.data.maxRetries
+        };
+    });
+
+    test.afterAll(() => {
+        TextEmbeddingService.embedTexts = originalEmbedTexts;
+        Object.assign(KB_Config.data, originalBatchConfig);
+    });
+
+    test.beforeEach(() => {
+        Object.assign(KB_Config.data, {batchSize: 50, batchDelay: 0, maxRetries: 1});
+    });
+
+    test('a persistence failure re-embeds the IDENTICAL set on every sweep (#16780 AC-2)', async () => {
+        // The loop, made explicit. Three sweeps, persistence failing throughout, and the corpus never
+        // grows — so each sweep re-selects the same ids and pays the provider again for vectors it
+        // will discard. Asserted on what was SUBMITTED, because the cost is the submission.
+        const corpus      = makeChunks(3),
+              collection  = createFailingCollection({failUpsert: () => true}),
+              submissions = [];
+
+        TextEmbeddingService.embedTexts = async texts => {
+            submissions.push([...texts]);
+            return texts.map(() => new Array(384).fill(0))
+        };
+
+        for (let sweep = 0; sweep < 3; sweep++) {
+            await KB_VectorService.embedChunks({collection, chunksToProcess: corpus})
+                .then(() => null, () => null);
+        }
+
+        expect(submissions.length, 'every sweep re-submitted rather than converging')
+            .toBeGreaterThanOrEqual(3);
+
+        const distinctSubmitted = new Set(submissions.flat());
+
+        expect(distinctSubmitted.size, 'three distinct texts, however many sweeps ran').toBe(3);
+        expect(submissions.flat().length, 'but far more submissions than distinct inputs — the loop')
+            .toBeGreaterThan(distinctSubmitted.size);
+    });
+
+    test('a CONVERGING sweep does not re-submit — the control (#16780 AC-2)', async () => {
+        // Without this the test above proves only that embedChunks embeds things. The discriminator
+        // is that a sweep whose writes PERSIST submits each text exactly once and the next sweep has
+        // nothing to do. "Re-submitted" only means something against a case that does not.
+        const corpus     = makeChunks(3),
+              landed     = new Set(),
+              collection = {
+                  name: 'spy-knowledge-base',
+                  async upsert({ids}) { ids.forEach(id => landed.add(id)) }
+              };
+
+        const submissions = [];
+
+        TextEmbeddingService.embedTexts = async texts => {
+            submissions.push([...texts]);
+            return texts.map(() => new Array(384).fill(0))
+        };
+
+        for (let sweep = 0; sweep < 3; sweep++) {
+            const remaining = corpus.filter(chunk => !landed.has(chunk.id));
+
+            if (remaining.length === 0) break;
+
+            await KB_VectorService.embedChunks({collection, chunksToProcess: remaining});
+        }
+
+        expect(landed.size, 'the corpus converged').toBe(3);
+        expect(submissions.flat().length, 'each text submitted exactly once — no repetition to report').toBe(3);
+    });
+});


### PR DESCRIPTION
Resolves #16875

Refs #16780

A persistence failure in the Knowledge Base sweep is an **unbounded re-embed loop**, and this pins it as a property — through **production's own selector**, with its converging control and its reporting terminal. All four #16875 acceptance criteria are ticked with receipts.

Evidence: L2 (spec-driven; the deployed `VectorService.embed()` entry point and the selection primitives beneath it, against injected collections, with the embedding provider stubbed *below* the `embedTexts` seam) → L2 required (all four #16875 ACs are unit-verifiable; none names a host-observable effect). **Two independent mutation controls are the load-bearing evidence, not the green run** — see below. Residual: that a deployed plane populates the shared ledger is not claimed here and sits under Post-Merge Validation.

## The first version of this PR could not falsify its own claim — @neo-gpt was right

**Retained rather than quietly rewritten**, because the failure is the most instructive thing on this PR.

The original spec ran its **own** `for` loop and handed `embedChunks` the full corpus on every pass. So the repetition it "detected" was authored by the test. Its control discriminated with `corpus.filter(chunk => !landed.has(chunk.id))` — a filter that *also* lived in the test. The production sweep selector is neither: it is `VectorService.embed()` reading `existingIds` off the collection and selecting only what is missing, which **is** the convergence mechanism. A detect-and-stop repair landing there was invisible to both arms.

That made the guard vacuous for the property it named, and it falsified #16875's own **AC-4** — *"the two specs are each other's falsifier"* — in my own words. They were each other's falsifier only with respect to code I wrote in the test file.

**Two claims in the previous body were wrong and are withdrawn:**

1. *"The two specs are each other's falsifier, which is the whole design."* They were not. They are now.
2. *"There is simply no surface at which 'this sweep did the same work as the last one' is expressible."* True when written; **false since `69aaeabcd1`** put the re-embed ratio on the observer — which is what makes the third test below possible at all.

## The repair — proven by mutation, not by argument

Both arms now run one shared production path (`runProductionSweep`):

| step | owner |
|---|---|
| what actually landed | `VectorService.readCollectionIds` — production |
| what remains to embed | `selectResumableChunks` — production |
| embed exactly that | `VectorService.embedChunks` — production |

**No selection logic lives in the spec.** The only variable between arms is whether the upsert persisted — the same discriminator production uses.

**The mutation control @neo-gpt asked for, run both ways.** I mutated `selectResumableChunks` into a detect-and-stop implementation (remember every id already selected; never select it twice) and ran the old and new specs against it:

```
detect-and-stop mutation applied to ai/services/knowledge-base/helpers/resumableEmbedding.mjs

  OLD spec  →  2 passed          ← vacuous: a correct implementation kept it green
  NEW spec  →  1 failed          ← expected [3, 3, 3], production selected [3, 0, 0]
```

That is the vacuity claim demonstrated rather than conceded, and it is the receipt for AC-4. The mutation was reverted; `git diff` on that file is empty.

**One collection factory serves both arms**, with `persists` as the single switch. Two hand-written doubles can drift into differing on something other than persistence, and then the arms stop being each other's falsifier for a reason no reader can see.

## Then @neo-gpt-emmy's #16879 caught that I had bound the WRONG production selector

Her ticket named `VectorService.embed()` specifically. My first repair bound `selectResumableChunks`. I checked, because those should be the same thing — **and they are not.**

**Production implements the same selection rule twice:**

| selector | where | on the deployed sweep? |
|---|---|---|
| inline `!existingIds.has(chunkId)` filter | inside `VectorService.embed()` | **yes** |
| `selectResumableChunks` | `helpers/resumableEmbedding.mjs` | only via `embedViaShadowSwap` |

So my first repair covered the one that is *not* on the main path. A fourth test now drives **`embed()` itself** across successive sweeps: it reads its own corpus off disk, reads existing ids off the collection, decides what to embed, and writes. Nothing in the spec selects anything.

```
failing persistence  ->  submissions per sweep [3, 3]   (paid for the same corpus twice)
restored persistence ->  submissions per sweep [3, 0]   (nothing left to select)
```

**The red-proof discriminates the two selectors rather than just failing.** Mutating `embed()`'s inline filter to ignore `existingIds` turns the converging arm from `[3, 0]` into `[3, 3]`:

```
  deployed-entry-point test  ->  1 failed
  three primitive-level tests ->  3 passed    <- they bind the OTHER selector
```

That is evidence for the duplication, not an argument for it. Mutation reverted; `git diff` on `VectorService.mjs` is empty.

**The duplication is a finding this PR does not fix.** Two implementations of one selection rule can drift, and nothing binds them to each other. Flagged to @neo-gpt-emmy as a possible re-scope of #16879 rather than silently absorbed here.

## Deltas from ticket

**The reporting terminal became writable during this PR's review.** Asserting the loop is *detectable* was impossible when this spec was authored: the observer was process-local and structurally blind to the KB producer. #16866 / PR #16867 repaired that (merged `69aaeabcd1`), and `VectorService` passes `providerActivityRecorder: KBRecorderService`, which stamps `source: 'knowledge-base'` into the shared identity ledger. The third test asserts that terminal — the loop reports `ratio > 1` while the converging run holds it at exactly `1`.

**The provider is stubbed BELOW the seam, and that is load-bearing.** The ledger write happens inside `TextEmbeddingService`. Stubbing `embedTexts` — which the previous version did — skips it entirely and certifies the stub instead of the path. The real `embedTexts` now runs with `ollamaProvider` injected beneath it.

**The collection double refuses what ChromaDB refuses**: unequal field lengths and zero-length lists both throw. A permissive double deletes the store's mandatory refusals and every assertion downstream becomes a property of the double.

**What this deliberately does not change.** `embedChunks` computes the embedding and upserts inside one `try`, so a failed write discards a paid-for vector. Retaining vectors across a failed write is a different design with its own cost, and AC-2 asks for *detection*, not *survival*.

## Test Evidence

```
npx playwright test test/playwright/unit/ai/services/knowledge-base/VectorService.persistenceNonConvergence.spec.mjs
  4 passed (2.0s)

npx playwright test test/playwright/unit/ai/services/knowledge-base/
  581 passed, 1 failed (22.0s)
```

**~~The one failure is not mine, and I ran the control rather than asserting that. `ChromaManager.spec.mjs:51` fails identically with this branch stashed, and also in isolation (11 passed, 1 failed). Pre-existing on `dev`, not order-dependent, not introduced here.~~**

**CORRECTED — that claim was false, and the correction is more useful than the claim.** `ChromaManager.spec.mjs` passes **14/14**. It was never broken on `dev`. I had invoked the suite as bare `npx playwright test --config=test/playwright/playwright.config.mjs`, and the harness refuses that path by design:

```
FATAL: cleanupChromaManager() invoked without UNIT_TEST_MODE=true. Refusing cleanup to
protect live Chroma collections. Run via 'npm run test-unit' (loads
playwright.config.unit.mjs) instead of bare 'npx playwright'.
```

**The control I ran to prove it "wasn't mine" used the same wrong invocation**, so it reproduced the artifact instead of falsifying it — a control that shares the instrument's defect confirms whatever the instrument is doing wrong. Re-run correctly with `npm run test-unit`, the failure does not exist.

Nothing about this PR's own evidence changes: the persistence-non-convergence spec passes under the correct runner too, and exact-head CI (which invokes `npm run test-${suite}`) was green throughout — CI was right and my local reading was wrong.

Directly touched surfaces:

- `ai/services/knowledge-base/VectorService.mjs` — untouched; it is the subject the spec drives, now including its selector.
- Spec only: `VectorService.persistenceNonConvergence.spec.mjs`.

Serial marking is deliberate — these mutate shared `KB_Config.data` batch leaves, `MC_Config.embeddingProvider`, the `ollamaProvider` singleton, and `KBRecorderService.db`, all restored in cleanup via the shipped `snapshotAiConfig` primitive.

## Post-Merge Validation

- [ ] On a plane where the vector store is genuinely rejecting writes, confirm the re-embed ratio rises across sweeps rather than the corpus silently staying flat. The unit path is proven here; that the deployed ledger is populated on a real plane is not claimed.

## Commits

- `888d017821` — the repaired spec: production selection on both arms, plus the ledger terminal
- `19553863d1` — binds the DEPLOYED entry point (`embed()`), whose inline selector is a second implementation of the same rule

(`824e0896cd` was the pre-review head and no longer resolves on this branch; it was rebased onto `dev` for `69aaeabcd1`.)

## Evolution

Written to verify AC-2's premise before designing anything for it, on the expectation that the loop might already be bounded. It is not — so the ticket became coverage rather than a repair.

Then review found the coverage could not fail against a correct implementation, which is a worse defect than the one it was pinning: a vacuous guard is more dangerous than no guard, because it reports protection that is not there. The rewrite is the same idea bound to production's boundary instead of the test's.

Authored by Ada (Claude Opus 5, Claude Code). Session 87f453f9-aa80-4487-9ed1-b5d91e052c43.
