### PR TITLE
docs(ai): heapSizeLimitBytes is what V8 reports, not the ceiling that kills (#16630)

### DIFF
--- a/ai/services/shared/processHeapObservation.mjs
+++ b/ai/services/shared/processHeapObservation.mjs
@@ -70,8 +70,18 @@ export const HEAP_OBSERVATION_STATE = Object.freeze({observed: 'observed', unava
  * Divergence between the two is reported as `ambiguous` rather than resolved. The last-wins rule is
  * consistent across all five measurements above (concatenate `NODE_OPTIONS` then the command line and
  * take the last), but it is V8's rule, not ours, and `heapSizeLimitBytes` is already observed
- * independently — so a consumer that needs the effective ceiling has it, and this field declines to
- * restate a resolution it would have to keep in sync with a runtime it does not control.
+ * independently — so a consumer needing to know **which declaration V8 actually applied** can read that
+ * back from the observed limit, and this field declines to restate a resolution it would have to keep in
+ * sync with a runtime it does not control.
+ *
+ * **What `heapSizeLimitBytes` is not: the number the process dies at.** An earlier revision of this
+ * paragraph called it *the effective ceiling*, which reads as exactly that. It is old space **plus** the
+ * semi-space allowance described above, so it sits strictly above the declared `--max-old-space-size`,
+ * and the process aborts on old-space exhaustion — at the declaration, not at this limit. A saturation
+ * ratio taken against it understates pressure by the whole gap (768 MiB declared reports 816 MiB under a
+ * 1 GiB cgroup) and reproduces this record's originating cross-scope defect one scope in, wearing a
+ * V8-scoped name. `oldGenerationUsedBytes ÷ declaredCeilingBytes` is the ratio; this field is what V8
+ * *reports*, kept because the gap between the two is the evidence that the declaration took effect.
  * @type {Object}
  */
 export const CEILING_STATE = Object.freeze({

--- a/test/playwright/unit/ai/services/shared/processHeapObservation.spec.mjs
+++ b/test/playwright/unit/ai/services/shared/processHeapObservation.spec.mjs
@@ -1,3 +1,6 @@
+import fs   from 'node:fs';
+import path from 'node:path';
+
 import {test, expect} from '@playwright/test';
 
 import {
@@ -229,6 +232,28 @@ test.describe('ai/services/shared/processHeapObservation — the declared ceilin
         expect(observation.ceilingState).toBe(CEILING_STATE.ambiguous);
         expect(observation.declaredCeilingBytes).toBeNull();
         expect(observation.heapSizeLimitBytes).toBe(816 * MEGABYTE);
+    });
+
+    test('the record says what `heapSizeLimitBytes` is NOT — and the retired wording cannot come back live', () => {
+        // A structural claim about the contract, never about behaviour. `heapSizeLimitBytes` is the one
+        // field on this record that reads like a ceiling and is not one: the process aborts at the
+        // declaration, and this limit sits above it by the semi-space allowance. An earlier revision
+        // pointed a consumer here as "the effective ceiling", which is the cross-scope defect this
+        // module exists to end, re-created one scope in under a V8-scoped name.
+        const source = fs.readFileSync(
+            path.join(path.resolve(process.cwd()), 'ai/services/shared/processHeapObservation.mjs'), 'utf8');
+
+        // The three facts a consumer needs in order not to reach for the wrong denominator.
+        expect(source).toContain('sits strictly above the declared');
+        expect(source).toContain('aborts on old-space exhaustion');
+        expect(source).toContain('oldGenerationUsedBytes ÷ declaredCeilingBytes');
+
+        // The retired phrasing survives EXACTLY ONCE, as its own retirement. A second occurrence is
+        // someone describing a field that way again, which is what must not return; asserting plain
+        // absence would forbid the record of the correction, and a correction nobody can read is how
+        // the wording came back the first time.
+        expect(source.match(/effective ceiling/g)).toHaveLength(1);
+        expect(source).toContain('An earlier revision of this');
     });
 });
 


### PR DESCRIPTION
Resolves #16630
Related: #16763, #16776, #16779, #16877

Authored by @neo-opus-vega (Claude Opus 5, Claude Code). Origin Session ID: `4131135d-1b20-487f-9d23-d7213914246b`.

Closes the last open criterion on #16630.

## The criterion, and where the wording actually was

> Any ADR-0025 amendment describes **what is actually measured**. The wording PR #16634 shipped — *"effective ceiling"* — encodes the conflation and must not return.

**It never reached ADR-0025.** PR #16634 was **closed, not merged** (`mergedAt: null`), and it is the only PR that carried that file alongside a spec literally named `EffectiveHeapCeilingDenominator.spec.mjs`. No ADR-0025 amendment exists for this ticket, and none is needed: §2.4 governs the *routes and thresholds* for `memory-saturation`, never the numerator, so Slice B's heap-scoped numerator contradicts no sentence in it.

Evidence: L1 structural + unit achieved (guard mutation-convicted; the absence discharged with a positive control; all four suites re-run) → no L3 receipt outstanding, because the criterion is a documentation contract.

```
$ git log --oneline -S"effective ceiling" -- learn/agentos/decisions/
(empty)

$ git log --oneline -S"store-ceiling-exhaustion" -- learn/agentos/decisions/0025-…md
82e26297b5 feat: A store's ceiling is raisable — bounded knob, live update, no restart (#16637) (#16638)
```

The second command is the **positive control**: it proves `-S` resolves on that path, so the empty result above is a finding rather than a broken instrument. Without it, *"the phrase is not in the ADR"* and *"my search cannot see the ADR"* produce identical output.

## The wording IS live, one file over

`CEILING_STATE`'s docblock resolves the two-channel declaration ambiguity by pointing a consumer at `heapSizeLimitBytes`:

> …`heapSizeLimitBytes` is already observed independently — so a consumer that needs the **effective ceiling** has it…

**The argument is sound and stays.** The observed limit does reveal which declaration V8 applied, so declining to restate V8's last-wins rule is right.

**The name is the trap this ticket already convicted.** #16630's own second criterion established — mutation-convicted by PR #16779 — that `heap_size_limit` is *not* the denominator: it is old space **plus** the semi-space allowance, so it sits strictly above the declared `--max-old-space-size`, and the process aborts on old-space exhaustion. **768 MiB declared reports 816 MiB under a 1 GiB cgroup.** A ratio taken against it understates pressure by the whole 48 MiB gap and re-creates the cross-scope defect this module exists to end — one scope in, wearing a V8-scoped name. A reader taking that sentence at face value reaches for precisely the field the earlier criterion forbids.

## Deltas

| file | delta |
|---|---|
| `processHeapObservation.mjs` | the ambiguity sentence now says *which declaration V8 applied* rather than *the effective ceiling*; a new paragraph states what the field is **not** (the number the process dies at), names `oldGenerationUsedBytes ÷ declaredCeilingBytes` as the ratio, and records the retired wording as retired |
| `processHeapObservation.spec.mjs` | one structural guard: the three facts a consumer needs, plus the retired phrasing permitted **exactly once** |

**No behaviour change.** No non-comment line in the module is touched.

## Test Evidence

`UNIT_TEST_MODE=true npx playwright test --config=test/playwright/playwright.config.unit.mjs --workers=1`

- the focused spec → **28 passed**
- `ai/services/shared/` → **141 passed**
- `ai/daemons/orchestrator/` → **1,393 passed**
- `ai/mcp/` → **704 passed** — both importers of this module live in those two trees (`ContainerHealthDiagnosisService`, `HeapObservationReporterService`)

**Mutation-convicted on the arm that matters.** Adding a second *live* use of the phrase — `a consumer that needs the effective ceiling should read the declaration` — reddens the guard:

```
Expected length: 1
Received length: 2
→ 1 failed, 2 passed
```

**Why the guard permits one occurrence rather than banning the phrase.** Plain absence would forbid recording the correction, and a correction nobody can read is how the wording arrived the first time. One occurrence is the retirement; a second is someone describing a field that way again, which is what *"must not return"* means.

**One pre-existing failure, with the control that proves it is not mine.** Running the three suites *together* reds `McpServerListToolsSmoke.spec.mjs:488` — *"knowledge-base and memory-core read worker-local deployment snapshots"* — while `ai/mcp/` alone passes 704/704. Stashing this PR's two files and re-running the identical combined command reproduces it on the clean tree:

| tree | result |
|---|---|
| this branch, three suites combined | `2216 passed`, `1 failed` at `:488` |
| **`origin/dev`, same command, my files stashed** | `2215 passed`, **`1 failed` at `:488`** |

A cross-suite isolation defect in that smoke spec, filed separately rather than fixed here. Recording it because the first run printed `2216 passed` with the failure line above the fold — `tail -3` alone would have reported this PR green.

## Post-Merge Validation

- [x] None outstanding. Both halves of the criterion — the ADR absence and the live wording — are discharged pre-merge with the receipts above.

## Out of scope

- **A phrase lint on the decision records.** Chosen against deliberately: a phrase ban is a syntax proxy for a semantic defect, it carries no sunset condition, and `ai/deploy/docker-compose.yml:265` already uses *"effective ceiling"* **correctly** — about a value being unknowable from outside the container — so the ban would need a carve-out on day one. The absence is discharged by receipt instead, and this is the line for a reviewer to disagree on.
- **Amending ADR-0025.** Not required, per above. An amendment recording that no amendment was needed is accretion.
- **The `McpServerListToolsSmoke` isolation failure.** Pre-existing, reproduced at `origin/dev`, its own ticket.
