### PR TITLE
feat(agent-os): recover residual Ollama load (#16830)

### DIFF
--- a/ai/daemons/orchestrator/Orchestrator.mjs
+++ b/ai/daemons/orchestrator/Orchestrator.mjs
@@ -459,7 +459,11 @@ export class Orchestrator extends Base {
                 restartChurnSeverity : restartChurn.severity,
                 restartChurnThreshold: restartChurn.threshold,
                 restartChurnWindowMs : restartChurn.windowMs
-            }
+            },
+            // Preserve AiConfig as the source of truth while keeping this service free of a
+            // non-entrypoint config import. A reader rather than a snapshot keeps a reactive
+            // endpoint override visible at the diagnosis use site.
+            ollamaHostReader: () => AiConfig.ollama.host
         });
     }
 

--- a/ai/daemons/orchestrator/Orchestrator.mjs
+++ b/ai/daemons/orchestrator/Orchestrator.mjs
@@ -86,6 +86,8 @@ import {
 import {acquireAuthorityLease, authorityLeaseFilename} from './authorityLease.mjs';
 import {FileLeaseLostError}                            from '../shared/fileLease.mjs';
 import {writeBootIdentityFact}                         from './services/bootIdentityFactStore.mjs';
+import {getProviderActivityMetrics}                    from '../../services/shared/providerActivityLedger.mjs';
+import {inspectProviderActivityStatus}                 from '../../services/shared/providerActivityStatusStore.mjs';
 import {
     inspectHeavyMaintenanceLeaseSync,
     withHeavyMaintenanceLease
@@ -242,6 +244,10 @@ export class Orchestrator extends Base {
     swarmHeartbeatService    = SwarmHeartbeatService
     goldenPathSynthesizer    = GoldenPathSynthesizer
     initializeDatabaseFn     = initializeDatabaseSelfBootstrap
+    /** @summary Reads the resolved provider-telemetry enablement leaf at use time. */
+    providerActivityTelemetryEnabledReader = () => memoryCoreConfig.toolTelemetry.enabled
+    /** @summary Reads recorder-owned health sidecars for the provider-activity projection. */
+    providerActivityStatusReader = inspectProviderActivityStatus
     summaryGetDueTask        = summaryGetDueTaskImport
     backupGetDueTask         = backupGetDueTaskImport
     graphLogCompactionGetDueTask = graphLogCompactionGetDueTaskImport
@@ -476,6 +482,11 @@ export class Orchestrator extends Base {
             // this sweep act"; this answers "may THIS service be acted on now", which is a different
             // question once a snapshot carries several unhealthy services and each actuation takes time.
             isAuthorityHeld    : () => !this.authorityLeaseLost && this.pulseAuthorityLease() === 'held',
+            // Only the residual-Ollama route consumes this. It is carried through the actuator to
+            // the runtime's last-owned boundary, where a newly admitted provider request vetoes the
+            // restart after every intervening cooldown/target-resolution await.
+            isEffectStillAdmitted: decision => decision?.diagnosis?.details?.classificationReason !==
+                'ollama-residual-load-restart' || this.isOllamaResidualRestartStillAdmitted(),
             healLedgerDir      : path.join(this.dataDir, HEAL_LEDGER_DIR_NAME),
             healLedgerRetention: validateHealLedgerRetention(healLedger.maxEvents, healLedger.pruneTriggerBytes),
             writeLog           : this.containerHealthControllerWriteLog
@@ -493,9 +504,63 @@ export class Orchestrator extends Base {
             taskStateService           : this.taskStateService,
             tenantRepoSyncService      : this.tenantRepoSyncService,
             tenantRepoSyncEnabledReader: () => this.tenantRepoSyncEnabled,
+            providerActivityProbe      : options => this.readProviderActivityProjection(options),
+            providerActivityWindowMs   : memoryCoreConfig.toolTelemetry.aggregateWindowMs,
+            providerActivityLimit      : memoryCoreConfig.toolTelemetry.aggregateLimit,
             healLedgerDir              : path.join(this.dataDir, HEAL_LEDGER_DIR_NAME),
             writeLog                   : this.deploymentStateBridgeWriteLog
         });
+    }
+
+    /**
+     * @summary Reads the recorder-owned provider ledger from the canonical container-plane database.
+     * Disabled, unavailable, or unhealthy recorder state is explicit and can never mean idle.
+     * @param {Object} options
+     * @param {Number} options.sinceTs Inclusive recent-completion cutoff.
+     * @param {Number} options.limit Projection row bound.
+     * @param {Number} options.observedAt Observation epoch.
+     * @returns {Object}
+     */
+    readProviderActivityProjection({sinceTs, limit, observedAt}) {
+        if (this.providerActivityTelemetryEnabledReader() !== true) {
+            return {status: 'unavailable', unavailableReason: 'provider-activity-disabled'};
+        }
+
+        // Container-plane boot opens this exact shared graph database before polling. Do not depend
+        // on GraphService readiness: swarm heartbeat is one initializer, but intentionally defaults
+        // off on canonical Agent OS deployments.
+        const db = this.db;
+
+        if (!db) return {status: 'unavailable', unavailableReason: 'graph-database-unavailable'};
+
+        const projection = getProviderActivityMetrics(db, {sinceTs, limit, now: observedAt}),
+              observer   = this.providerActivityStatusReader({
+                  dbPath: memoryCoreConfig.storagePaths.graph,
+                  sinceTs
+              });
+
+        return {
+            ...projection,
+            status: observer.status,
+            ...(observer.status === 'ok' ? {} : {unavailableReason: 'recorder-status-not-ok'})
+        };
+    }
+
+    /**
+     * @summary Revalidates zero live provider demand at the lifecycle effect boundary.
+     * @returns {Boolean}
+     */
+    isOllamaResidualRestartStillAdmitted() {
+        const observedAt = Date.now(),
+              projection = this.readProviderActivityProjection({
+                  sinceTs: observedAt - memoryCoreConfig.toolTelemetry.aggregateWindowMs,
+                  limit  : memoryCoreConfig.toolTelemetry.aggregateLimit,
+                  observedAt
+              });
+
+        return projection.status === 'ok' && projection.totalInFlight === 0 &&
+            projection.inFlightTruncated === false && Array.isArray(projection.inFlight) &&
+            projection.inFlight.length === 0;
     }
 
     beforeSetMaintenanceBackpressureService(value) {

--- a/ai/daemons/orchestrator/services/ContainerHealthControllerService.mjs
+++ b/ai/daemons/orchestrator/services/ContainerHealthControllerService.mjs
@@ -165,6 +165,12 @@ export class ContainerHealthControllerService extends Base {
      * @member {Function|null} isAuthorityHeld=null
      */
     isAuthorityHeld = null
+    /**
+     * Last-boundary effect-admission predicate, `(decision) => Boolean`. Only recovery classes whose
+     * evidence can become unsafe while the actuator awaits preparation opt in.
+     * @member {Function|null} isEffectStillAdmitted=null
+     */
+    isEffectStillAdmitted = null
 
     /**
      * @summary Routes every diagnosed decision in one deployment-state snapshot.
@@ -274,7 +280,13 @@ export class ContainerHealthControllerService extends Base {
      */
     async actuate({decision, now, route}) {
         const {actionClass, diagnosis, serviceKey} = decision,
-              reason                               = `container-health-controller:${diagnosis.details?.classificationReason || route.reasonCode}`;
+              classificationReason                 = diagnosis.details?.classificationReason,
+              reason                               = `container-health-controller:${classificationReason || route.reasonCode}`,
+              needsLiveAdmission                   = classificationReason === 'ollama-residual-load-restart',
+              residualEvidence                     = needsLiveAdmission
+                  ? diagnosis.evidenceFacts?.find(fact => fact?.type === 'ollama-residual-load')
+                  : null,
+              expectedContainerId                   = residualEvidence?.details?.runtimeContainerId;
 
         let outcome;
 
@@ -292,7 +304,13 @@ export class ContainerHealthControllerService extends Base {
                 // immediately before the privileged effect. A check made out here is separated from
                 // the effect by `readHealAttempts`, which is I/O — and an authority check with an
                 // await between it and the effect does not bind the effect.
-                isAuthorityHeld: this.isAuthorityHeld
+                isAuthorityHeld: this.isAuthorityHeld,
+                ...(needsLiveAdmission && typeof this.isEffectStillAdmitted === 'function'
+                    ? {isEffectStillAdmitted: () => this.isEffectStillAdmitted(decision)}
+                    : {}),
+                ...(needsLiveAdmission && typeof expectedContainerId === 'string'
+                    ? {expectedContainerId}
+                    : {})
             });
         } catch (error) {
             outcome = {

--- a/ai/daemons/orchestrator/services/ContainerHealthDiagnosisService.mjs
+++ b/ai/daemons/orchestrator/services/ContainerHealthDiagnosisService.mjs
@@ -29,18 +29,25 @@ export const CONTAINER_HEALTH_ACTION_CLASSES = Object.freeze({
 });
 
 /**
- * @summary Proves that native-Ollama residency came from the Compose service this diagnosis may
- * restart. External/loopback providers are valid configurations, but they cannot authorize a
- * lifecycle effect against `local-model` merely because the bridge is observing that service key.
- * @param {String|null} host Provider endpoint.
+ * @summary Proves that the configured native-Ollama endpoint is the Compose service this diagnosis
+ * may restart. The endpoint and eligible service roster remain AiConfig-owned; this helper only
+ * compares their injected/read-observed values. Ports are deliberately not pinned because
+ * `NEO_OLLAMA_HOST` owns that deployment choice.
+ * @param {String|null} configuredHost AiConfig-owned provider endpoint.
+ * @param {String|null} observedHost Provider endpoint carried by the residency observation.
+ * @param {String} serviceKey Candidate Compose service key.
  * @returns {Boolean}
  */
-function isLocalModelComposeOllamaHost(host) {
+function isConfiguredComposeOllamaHost({configuredHost, observedHost, serviceKey}) {
     try {
-        const endpoint = new URL(host);
+        const configuredEndpoint = new URL(configuredHost),
+              observedEndpoint   = new URL(observedHost);
 
-        return endpoint.protocol === 'http:' && endpoint.hostname === 'local-model' &&
-            endpoint.port === '11434' && endpoint.username === '' && endpoint.password === '';
+        return ['http:', 'https:'].includes(observedEndpoint.protocol) &&
+            configuredEndpoint.origin === observedEndpoint.origin &&
+            configuredEndpoint.username === '' && configuredEndpoint.password === '' &&
+            observedEndpoint.hostname === serviceKey &&
+            observedEndpoint.username === '' && observedEndpoint.password === '';
     } catch {
         return false;
     }
@@ -184,6 +191,15 @@ export class ContainerHealthDiagnosisService extends Base {
          */
         diagnosisConfig_: null,
         /**
+         * Reads the resolved native-Ollama endpoint at the diagnosis use site. The reader keeps
+         * AiConfig ownership in the Orchestrator entrypoint while allowing reactive overrides to
+         * remain visible after this service is constructed.
+         * @member {Function|null} ollamaHostReader_=null
+         * @protected
+         * @reactive
+         */
+        ollamaHostReader_: null,
+        /**
          * @member {Function|null} nowFn_=null
          * @protected
          * @reactive
@@ -267,6 +283,8 @@ export class ContainerHealthDiagnosisService extends Base {
      * @param {Object|null} [options.ollamaEvalAttribution=null] Native Ollama eval attribution.
      * @param {Object|null} [options.providerResidency=null] Active-provider residency observation.
      * @param {Object|null} [options.providerActivity=null] Bounded provider-work projection.
+     * @param {Boolean} [options.providerResidencyEligible=false] Whether the bridge's configured
+     *     provider-service roster selected this Compose service for observation.
      * @param {String|null} [options.runtimeContainerId=null] Inspect/stats proof identity.
      * @param {Number} [options.observedAt] Epoch milliseconds for the observation.
      * @returns {Object} Diagnosis decision with advisory facts and optional diagnosis event.
@@ -281,6 +299,7 @@ export class ContainerHealthDiagnosisService extends Base {
         ollamaEvalAttribution = null,
         providerResidency = null,
         providerActivity = null,
+        providerResidencyEligible = false,
         runtimeContainerId = null,
         churnBaseline = null,
         inspectReadFailed = false,
@@ -331,6 +350,7 @@ export class ContainerHealthDiagnosisService extends Base {
             statsSamples,
             providerActivity,
             providerResidency,
+            providerResidencyEligible,
             runtimeContainerId,
             observedAt,
             facts
@@ -840,20 +860,33 @@ export class ContainerHealthDiagnosisService extends Base {
      * @param {Object[]|null} options.statsSamples Docker samples spanning the candidate window.
      * @param {Object|null} options.providerActivity Provider-work projection.
      * @param {Object|null} options.providerResidency Passive residency observation.
+     * @param {Boolean} options.providerResidencyEligible Whether the configured provider-service
+     *     roster selected this Compose service.
      * @param {String|null} options.runtimeContainerId Inspect/stats proof identity.
      * @param {Number} options.observedAt Observation epoch ms.
      * @param {Object[]} options.facts Facts collected before this composition.
      * @returns {Object[]}
      */
-    collectOllamaResidualLoadFacts({serviceKey, inspect, statsSamples, providerActivity, providerResidency, runtimeContainerId, observedAt, facts}) {
+    collectOllamaResidualLoadFacts({
+        serviceKey,
+        inspect,
+        statsSamples,
+        providerActivity,
+        providerResidency,
+        providerResidencyEligible,
+        runtimeContainerId,
+        observedAt,
+        facts
+    }) {
         const cpuFact = facts.find(fact =>
             fact.type === CONTAINER_HEALTH_FACT_TYPES.resourceSaturation &&
             fact.details?.metric === 'cpu'
         );
 
-        if (serviceKey !== 'local-model' || !cpuFact) return [];
+        if (!cpuFact) return [];
 
         const
+            configuredHost  = this.ollamaHostReader?.(),
             targetIdentity  = this.readProviderTargetIdentity(providerResidency?.targetIdentity),
             availableModels = toSafeArray(providerResidency?.availableModels),
             roles           = [
@@ -892,8 +925,17 @@ export class ContainerHealthDiagnosisService extends Base {
                 details      : {...baseDetails, ...details, reasonCode}
             })];
 
+        if (providerResidencyEligible !== true) {
+            // Generic CPU saturation must not manufacture an Ollama advisory. A declined residual
+            // path becomes visible when upstream actually supplied provider evidence for a service
+            // the configured roster excludes.
+            if (!providerResidency && !providerActivity) return [];
+
+            return advisory('provider-residency-service-not-configured');
+        }
+        if (!providerResidency) return advisory('provider-residency-unavailable');
         if (providerResidency?.provider !== 'ollama') return advisory('provider-not-ollama');
-        if (!isLocalModelComposeOllamaHost(providerResidency.host)) {
+        if (!isConfiguredComposeOllamaHost({configuredHost, observedHost: providerResidency.host, serviceKey})) {
             return advisory('provider-endpoint-target-mismatch');
         }
         if (targetIdentity?.kind !== 'compose-service' || targetIdentity.id !== serviceKey) {

--- a/ai/daemons/orchestrator/services/ContainerHealthDiagnosisService.mjs
+++ b/ai/daemons/orchestrator/services/ContainerHealthDiagnosisService.mjs
@@ -13,6 +13,7 @@ export const CONTAINER_HEALTH_FACT_TYPES = Object.freeze({
     evalContention            : 'ollama-eval-contention',
     heapObservationUnavailable: 'heap-observation-unavailable',
     memorySaturation          : 'memory-saturation',
+    ollamaResidualLoad        : 'ollama-residual-load',
     providerResidency         : 'provider-residency-degraded',
     resourceSaturation        : 'resource-saturation',
     restartChurn              : 'restart-churn',
@@ -26,6 +27,24 @@ export const CONTAINER_HEALTH_ACTION_CLASSES = Object.freeze({
     throttleShed: 'throttle-shed',
     warmProvider: 'warm-provider'
 });
+
+/**
+ * @summary Proves that native-Ollama residency came from the Compose service this diagnosis may
+ * restart. External/loopback providers are valid configurations, but they cannot authorize a
+ * lifecycle effect against `local-model` merely because the bridge is observing that service key.
+ * @param {String|null} host Provider endpoint.
+ * @returns {Boolean}
+ */
+function isLocalModelComposeOllamaHost(host) {
+    try {
+        const endpoint = new URL(host);
+
+        return endpoint.protocol === 'http:' && endpoint.hostname === 'local-model' &&
+            endpoint.port === '11434' && endpoint.username === '' && endpoint.password === '';
+    } catch {
+        return false;
+    }
+}
 
 /**
  * @summary The two service classes a heal decision can be reasoned about.
@@ -247,6 +266,8 @@ export class ContainerHealthDiagnosisService extends Base {
      * @param {Object|null} [options.configCheck=null] Config correctness result.
      * @param {Object|null} [options.ollamaEvalAttribution=null] Native Ollama eval attribution.
      * @param {Object|null} [options.providerResidency=null] Active-provider residency observation.
+     * @param {Object|null} [options.providerActivity=null] Bounded provider-work projection.
+     * @param {String|null} [options.runtimeContainerId=null] Inspect/stats proof identity.
      * @param {Number} [options.observedAt] Epoch milliseconds for the observation.
      * @returns {Object} Diagnosis decision with advisory facts and optional diagnosis event.
      */
@@ -259,6 +280,8 @@ export class ContainerHealthDiagnosisService extends Base {
         configCheck = null,
         ollamaEvalAttribution = null,
         providerResidency = null,
+        providerActivity = null,
+        runtimeContainerId = null,
         churnBaseline = null,
         inspectReadFailed = false,
         plannedRestarts = 0,
@@ -301,6 +324,17 @@ export class ContainerHealthDiagnosisService extends Base {
             ...this.collectEvalAttributionFacts({serviceKey, ollamaEvalAttribution, observedAt}),
             ...this.collectProviderResidencyFacts({serviceKey, providerResidency, observedAt})
         ];
+
+        facts.push(...this.collectOllamaResidualLoadFacts({
+            serviceKey,
+            inspect,
+            statsSamples,
+            providerActivity,
+            providerResidency,
+            runtimeContainerId,
+            observedAt,
+            facts
+        }));
 
         // A SUCCESSFUL probe produces no fact — `collectEndpointProbeFacts` only emits on `ok === false`
         // — so the one observation that directly contradicts a restart would otherwise never reach the
@@ -770,6 +804,8 @@ export class ContainerHealthDiagnosisService extends Base {
             details      : {
                 provider                 : typeof providerResidency.provider === 'string' ? providerResidency.provider : null,
                 host                     : typeof providerResidency.host === 'string' ? providerResidency.host : null,
+                model                    : typeof providerResidency.model === 'string' ? providerResidency.model : null,
+                embeddingModel           : typeof providerResidency.embeddingModel === 'string' ? providerResidency.embeddingModel : null,
                 message                  : typeof providerResidency.message === 'string' ? providerResidency.message : null,
                 reasonCode,
                 ready                    : typeof providerResidency.ready === 'boolean' ? providerResidency.ready : null,
@@ -790,11 +826,206 @@ export class ContainerHealthDiagnosisService extends Base {
     }
 
     /**
+     * @summary Folds passive container CPU, Ollama residency, and bounded provider demand into one
+     * residual-load fact without dispatching provider work.
+     *
+     * The CPU observation is container-scoped; `/api/ps` contributes only resident model identity.
+     * Consequently any accounted native-Ollama activity vetoes recovery — this layer cannot prove
+     * which resident runner owns the container CPU. Missing, stale, truncated, contradictory, or
+     * cold-start evidence emits an advisory fact and can never license a restart.
+     *
+     * @param {Object} options
+     * @param {String} options.serviceKey Compose service key.
+     * @param {Object|null} options.inspect Docker inspect payload.
+     * @param {Object[]|null} options.statsSamples Docker samples spanning the candidate window.
+     * @param {Object|null} options.providerActivity Provider-work projection.
+     * @param {Object|null} options.providerResidency Passive residency observation.
+     * @param {String|null} options.runtimeContainerId Inspect/stats proof identity.
+     * @param {Number} options.observedAt Observation epoch ms.
+     * @param {Object[]} options.facts Facts collected before this composition.
+     * @returns {Object[]}
+     */
+    collectOllamaResidualLoadFacts({serviceKey, inspect, statsSamples, providerActivity, providerResidency, runtimeContainerId, observedAt, facts}) {
+        const cpuFact = facts.find(fact =>
+            fact.type === CONTAINER_HEALTH_FACT_TYPES.resourceSaturation &&
+            fact.details?.metric === 'cpu'
+        );
+
+        if (serviceKey !== 'local-model' || !cpuFact) return [];
+
+        const
+            targetIdentity  = this.readProviderTargetIdentity(providerResidency?.targetIdentity),
+            availableModels = toSafeArray(providerResidency?.availableModels),
+            roles           = [
+                {role: 'chat', model: typeof providerResidency?.model === 'string' ? providerResidency.model : null},
+                {role: 'embedding', model: typeof providerResidency?.embeddingModel === 'string' ? providerResidency.embeddingModel : null}
+            ].filter(role => role.model),
+            residentRoles = roles.map(role => ({
+                ...role,
+                resident: availableModels.includes(role.model)
+            })),
+            startedAt = Date.parse(inspect?.State?.StartedAt ?? ''),
+            containerAgeMs = Number.isFinite(startedAt) ? observedAt - startedAt : null,
+            baseDetails = {
+                observationSource         : 'deployment-runtime+provider-activity-ledger+ollama-api-ps',
+                subjectIdentity           : {kind: 'compose-service', id: serviceKey},
+                targetIdentity,
+                runtimeContainerId        : typeof runtimeContainerId === 'string' ? runtimeContainerId : null,
+                provider                  : typeof providerResidency?.provider === 'string' ? providerResidency.provider : null,
+                roles                     : residentRoles,
+                availableModels,
+                providerActivityObservedAt: Number.isFinite(providerActivity?.observedAt)
+                    ? providerActivity.observedAt
+                    : null,
+                providerActivitySinceMs: Number.isFinite(providerActivity?.sinceMs)
+                    ? providerActivity.sinceMs
+                    : null,
+                containerAgeMs,
+                cpuFactId: cpuFact.id
+            },
+            advisory = (reasonCode, details = {}) => [this.createFact({
+                type         : CONTAINER_HEALTH_FACT_TYPES.ollamaResidualLoad,
+                serviceKey,
+                observedAt,
+                severity     : 'warning',
+                authoritative: false,
+                details      : {...baseDetails, ...details, reasonCode}
+            })];
+
+        if (providerResidency?.provider !== 'ollama') return advisory('provider-not-ollama');
+        if (!isLocalModelComposeOllamaHost(providerResidency.host)) {
+            return advisory('provider-endpoint-target-mismatch');
+        }
+        if (targetIdentity?.kind !== 'compose-service' || targetIdentity.id !== serviceKey) {
+            return advisory('subject-identity-mismatch');
+        }
+        const samples = normalizeStatsSamples({stats: null, statsSamples});
+        if (typeof runtimeContainerId !== 'string' || samples.length === 0 ||
+            samples.some(sample => sample.containerId !== runtimeContainerId)
+        ) {
+            return advisory('stats-incarnation-unbounded');
+        }
+        if (containerAgeMs === null || containerAgeMs < this.configValues.sampleWindowMs) {
+            return advisory(containerAgeMs === null ? 'container-age-unknown' : 'container-cold-start');
+        }
+        if (providerResidency?.ready !== true || residentRoles.length === 0 || !residentRoles.some(role => role.resident)) {
+            return advisory('resident-model-evidence-unavailable');
+        }
+        if (providerActivity?.status !== 'ok') return advisory('provider-activity-unavailable');
+
+        const projectionAgeMs = Number.isFinite(providerActivity.observedAt)
+            ? observedAt - providerActivity.observedAt
+            : null;
+
+        if (projectionAgeMs === null || projectionAgeMs < 0 || projectionAgeMs > this.configValues.sampleWindowMs) {
+            return advisory('provider-activity-stale', {projectionAgeMs});
+        }
+        if (!Number.isFinite(providerActivity.sinceMs) || providerActivity.sinceMs < this.configValues.sampleWindowMs) {
+            return advisory('provider-activity-lookback-too-short');
+        }
+        if (!Number.isInteger(providerActivity.totalInFlight) || providerActivity.totalInFlight < 0 ||
+            !Array.isArray(providerActivity.inFlight) ||
+            typeof providerActivity.inFlightTruncated !== 'boolean' ||
+            providerActivity.inFlightTruncated ||
+            providerActivity.totalInFlight !== providerActivity.inFlight.length
+        ) {
+            return advisory('provider-activity-in-flight-unbounded');
+        }
+
+        const liveOllama = providerActivity.inFlight.filter(activity => activity?.provider === 'ollama');
+        if (liveOllama.length > 0) {
+            return advisory('provider-demand-in-flight', {
+                inFlight: liveOllama.map(activity => ({
+                    activityId    : typeof activity.activityId === 'string' ? activity.activityId : null,
+                    service       : typeof activity.service === 'string' ? activity.service : null,
+                    operationStage: typeof activity.operationStage === 'string' ? activity.operationStage : null,
+                    role          : typeof activity.role === 'string' ? activity.role : null,
+                    model         : typeof activity.model === 'string' ? activity.model : null,
+                    elapsedMs     : Number.isFinite(activity.elapsedMs) ? activity.elapsedMs : null
+                }))
+            });
+        }
+
+        const
+            recentCompletions = providerActivity.recentCompletions,
+            recentCount       = providerActivity.totalRecentCompletions,
+            recentTruncated   = providerActivity.recentCompletionsTruncated,
+            oldestReturnedAt  = Array.isArray(recentCompletions) && recentCompletions.length > 0
+                ? Date.parse(recentCompletions.at(-1)?.completedAt ?? '')
+                : NaN,
+            hiddenRowsPredateCpuWindow = recentTruncated === true &&
+                Number.isInteger(recentCount) && recentCount > recentCompletions?.length &&
+                Number.isFinite(oldestReturnedAt) &&
+                observedAt - oldestReturnedAt > this.configValues.sampleWindowMs,
+            recentProjectionBounded = recentTruncated === false
+                ? recentCount === recentCompletions?.length
+                : hiddenRowsPredateCpuWindow;
+
+        if (!Number.isInteger(recentCount) || recentCount < 0 ||
+            !Array.isArray(recentCompletions) ||
+            typeof recentTruncated !== 'boolean' ||
+            !recentProjectionBounded
+        ) {
+            return advisory('provider-activity-recent-unbounded');
+        }
+
+        const recentOllama = recentCompletions.filter(activity => {
+            if (activity?.provider !== 'ollama') return false;
+            const completedAt = Date.parse(activity.completedAt ?? '');
+
+            return Number.isFinite(completedAt) && observedAt - completedAt >= 0 &&
+                observedAt - completedAt <= this.configValues.sampleWindowMs;
+        });
+
+        if (recentOllama.length > 0) {
+            return advisory('provider-demand-recently-settled', {
+                recentCompletions: recentOllama.map(activity => ({
+                    activityId : typeof activity.activityId === 'string' ? activity.activityId : null,
+                    role       : typeof activity.role === 'string' ? activity.role : null,
+                    model      : typeof activity.model === 'string' ? activity.model : null,
+                    completedAt: activity.completedAt
+                }))
+            });
+        }
+
+        return [this.createFact({
+            type         : CONTAINER_HEALTH_FACT_TYPES.ollamaResidualLoad,
+            serviceKey,
+            observedAt,
+            severity     : 'critical',
+            authoritative: true,
+            details      : {
+                ...baseDetails,
+                reasonCode   : 'sustained-unexplained-ollama-load',
+                projectionAgeMs,
+                totalInFlight: providerActivity.totalInFlight
+            }
+        })];
+    }
+
+    /**
      * Classifies facts into the recovery diagnosis contract.
      * @param {Object} options
      * @returns {Object|null}
      */
     classifyFacts({facts, serviceAnswering = false}) {
+        const ollamaResidualFacts = facts.filter(fact =>
+            fact.type === CONTAINER_HEALTH_FACT_TYPES.ollamaResidualLoad &&
+            fact.authoritative === true &&
+            fact.details?.reasonCode === 'sustained-unexplained-ollama-load'
+        );
+
+        if (ollamaResidualFacts.length > 0) {
+            return {
+                recoveryClass : 'exhaustion',
+                actionClass   : CONTAINER_HEALTH_ACTION_CLASSES.restart,
+                confidence    : 0.95,
+                evidenceFacts : this.selectEvidenceFacts(facts, ollamaResidualFacts),
+                reason        : 'ollama-residual-load-restart',
+                targetIdentity: ollamaResidualFacts[0].details.targetIdentity
+            };
+        }
+
         const providerRoleResidencyFacts = facts.filter(fact => this.isProviderRoleResidencyRecoverable(fact));
         if (providerRoleResidencyFacts.length > 0) {
             return {

--- a/ai/daemons/orchestrator/services/DeploymentRuntimeAccessService.mjs
+++ b/ai/daemons/orchestrator/services/DeploymentRuntimeAccessService.mjs
@@ -261,9 +261,11 @@ export class DeploymentRuntimeAccessService extends Base {
      * @param {Function|null} [options.isAuthorityHeld=null] Current-authority oracle, re-asked AFTER
      * target resolution and immediately before the mutating call. Optional: a caller that omits it
      * keeps today's behaviour exactly.
+     * @param {Function|null} [options.isEffectStillAdmitted=null] Live effect-admission oracle.
+     * @param {String|null} [options.expectedContainerId=null] Diagnosed container incarnation.
      * @returns {Promise<Object>} Lifecycle result plus structured proof metadata.
      */
-    async applyLifecycle({serviceKey, operation = 'restart', reason = 'manual', restartTimeoutSeconds, memoryLimitBytes, isAuthorityHeld = null} = {}) {
+    async applyLifecycle({serviceKey, operation = 'restart', reason = 'manual', restartTimeoutSeconds, memoryLimitBytes, isAuthorityHeld = null, isEffectStillAdmitted = null, expectedContainerId = null} = {}) {
         this.assertEnabled();
         this.assertMechanismSupported();
         this.assertOperationAllowed('lifecycle-write', operation);
@@ -287,6 +289,25 @@ export class DeploymentRuntimeAccessService extends Base {
                 reason : 'runtime-authority-lost',
                 message: `Authority moved while resolving '${serviceKey}'; refusing the lifecycle write. `
                     + 'A displaced holder must not mutate a plane another holder now owns.',
+                details: {serviceKey, operation}
+            });
+        }
+
+        if (typeof expectedContainerId === 'string' && target.containerId !== expectedContainerId) {
+            throw createRuntimeAccessError({
+                reason : 'runtime-target-incarnation-changed',
+                message: `Container '${serviceKey}' changed from '${expectedContainerId}' to '${target.containerId}' before lifecycle write; refusing stale recovery.`,
+                details: {serviceKey, operation, expectedContainerId, actualContainerId: target.containerId}
+            });
+        }
+
+        // Last-owned dynamic safety predicate. It intentionally follows target resolution and the
+        // incarnation check, leaving no await before the Docker mutation. For residual provider load,
+        // a request admitted during controller/actuator preparation therefore vetoes the restart.
+        if (typeof isEffectStillAdmitted === 'function' && isEffectStillAdmitted() !== true) {
+            throw createRuntimeAccessError({
+                reason : 'runtime-effect-not-admitted',
+                message: `Lifecycle write for '${serviceKey}' is no longer admitted by live evidence.`,
                 details: {serviceKey, operation}
             });
         }

--- a/ai/daemons/orchestrator/services/DeploymentStateBridgeService.mjs
+++ b/ai/daemons/orchestrator/services/DeploymentStateBridgeService.mjs
@@ -621,7 +621,7 @@ export class DeploymentStateBridgeService extends Base {
         // Query after every preceding async read and immediately before the synchronous diagnosis.
         // This is the safety boundary: a snapshot-start projection can claim idle even though a
         // request began while earlier services were still being observed.
-        if (serviceKey === 'local-model') {
+        if (this.isProviderResidencyServiceKey(serviceKey)) {
             providerActivity = await this.collectProviderActivity({observedAt: observationNow()});
         }
 
@@ -638,6 +638,7 @@ export class DeploymentStateBridgeService extends Base {
                 endpointProbe,
                 providerResidency,
                 providerActivity,
+                providerResidencyEligible: this.isProviderResidencyServiceKey(serviceKey),
                 churnBaseline     : churnBaseline?.unreadable ? undefined : churnBaseline,
                 plannedRestarts,
                 // `null` when `includeLogs` is off — which must surface as an UNAVAILABLE
@@ -773,7 +774,7 @@ export class DeploymentStateBridgeService extends Base {
      * @returns {Promise<Object|null>}
      */
     async collectProviderResidency({serviceKey, observedAt}) {
-        if (!AiConfig.orchestrator.deploymentStateBridge.providerResidencyServiceKeys.includes(serviceKey)) {
+        if (!this.isProviderResidencyServiceKey(serviceKey)) {
             return null;
         }
 
@@ -805,6 +806,17 @@ export class DeploymentStateBridgeService extends Base {
                 targetIdentity
             };
         }
+    }
+
+    /**
+     * @summary Resolves whether a Compose service participates in provider-residency observation.
+     * The same predicate gates residency and adjacent provider-activity collection so a configured
+     * service can never receive one half of the residual-load evidence pair without the other.
+     * @param {String} serviceKey Compose service key.
+     * @returns {Boolean}
+     */
+    isProviderResidencyServiceKey(serviceKey) {
+        return AiConfig.orchestrator.deploymentStateBridge.providerResidencyServiceKeys.includes(serviceKey);
     }
 
     /**

--- a/ai/daemons/orchestrator/services/DeploymentStateBridgeService.mjs
+++ b/ai/daemons/orchestrator/services/DeploymentStateBridgeService.mjs
@@ -185,6 +185,23 @@ export class DeploymentStateBridgeService extends Base {
          */
         providerResidencyProbe: null,
         /**
+         * Read-only provider-activity seam. The orchestrator injects the recorder-owned ledger
+         * projection; this service never opens or mutates the telemetry database itself.
+         * @member {Function|null} providerActivityProbe=null
+         * @protected
+         */
+        providerActivityProbe: null,
+        /**
+         * @member {Number|null} providerActivityWindowMs=null
+         * @protected
+         */
+        providerActivityWindowMs: null,
+        /**
+         * @member {Number|null} providerActivityLimit=null
+         * @protected
+         */
+        providerActivityLimit: null,
+        /**
          * Direct-probe seam: `async ({url, expectedStatus, timeoutMs, ...}) => void`, resolving when the
          * service is serving and throwing otherwise. Falls back to `runHealthcheck`. Injected so specs
          * can drive every failure shape — answered-but-wrong-status, starved, unresponsive, unreachable
@@ -296,10 +313,15 @@ export class DeploymentStateBridgeService extends Base {
      * @returns {Promise<Object>}
      */
     async collectSnapshot({generatedAt = this.now()} = {}) {
-        const services = [];
+        const
+            services    = [],
+            serviceKeys = this.getServiceKeys();
 
-        for (const serviceKey of this.getServiceKeys()) {
-            services.push(await this.collectServiceSnapshot({serviceKey, observedAt: generatedAt}));
+        for (const serviceKey of serviceKeys) {
+            // Each service owns its observation clock. In particular, local-model provider activity
+            // is read adjacent to its diagnosis, after preceding service reads, so an Ollama request
+            // that starts during snapshot collection cannot disappear behind a snapshot-start query.
+            services.push(await this.collectServiceSnapshot({serviceKey}));
         }
 
         const recoveryRuns      = await this.collectRecoveryRunSnapshot();
@@ -481,18 +503,20 @@ export class DeploymentStateBridgeService extends Base {
      * Collects one bounded per-service state envelope.
      * @param {Object} options
      * @param {String} options.serviceKey Allowlisted service key.
-     * @param {Number} options.observedAt Epoch ms.
+     * @param {Number|null} [options.observedAt=null] Fixed epoch for deterministic callers.
      * @returns {Promise<Object>}
      */
-    async collectServiceSnapshot({serviceKey, observedAt}) {
+    async collectServiceSnapshot({serviceKey, observedAt = null}) {
         const
-            errors = [],
-            proofs = [];
+            errors         = [],
+            proofs         = [],
+            observationNow = () => Number.isFinite(observedAt) ? observedAt : this.now();
 
         let inspect           = null,
             stats             = null,
             logs              = null,
-            providerResidency = null;
+            providerResidency = null,
+            providerActivity  = null;
 
         // Retained per operation because target IDENTITY, not just the payload, decides whether two
         // reads describe the same container. `readObserve` resolves a target per call, so a compose
@@ -514,6 +538,7 @@ export class DeploymentStateBridgeService extends Base {
 
         inspect = await read('inspect');
         stats   = await read('stats');
+        const statsObservedAt = observationNow();
 
         const bridgeConfig = AiConfig.orchestrator.deploymentStateBridge;
 
@@ -529,7 +554,7 @@ export class DeploymentStateBridgeService extends Base {
             });
         }
 
-        providerResidency = await this.collectProviderResidency({serviceKey, observedAt});
+        providerResidency = await this.collectProviderResidency({serviceKey, observedAt: observationNow()});
 
         // The SECOND evidence channel. Until this existed, `endpointProbe` had no producer anywhere in
         // the orchestrator, so ADR-0025 §2.4's authoritative pair could never form and a wedged // ticket-ref-ok: the ADR clause is the reason this call exists at all
@@ -561,6 +586,10 @@ export class DeploymentStateBridgeService extends Base {
                 proofByOperation.inspect?.target?.containerId &&
                 proofByOperation.logs.target.containerId === proofByOperation.inspect.target.containerId
             ),
+            sampleContainerId = typeof proofByOperation.inspect?.target?.containerId === 'string' &&
+                proofByOperation.inspect.target.containerId === proofByOperation.stats?.target?.containerId
+                ? proofByOperation.inspect.target.containerId
+                : null,
             logSummary     = summarizeLogs(logs, bridgeConfig.logMaxBytes, {sameTarget}),
             // Consumes the SAME `nodeCommand` observation the heap attribution uses, rather than
             // re-deriving what "a Node service" means. Placed after the summary for that reason
@@ -569,7 +598,7 @@ export class DeploymentStateBridgeService extends Base {
             heapObservation = this.readHeapObservation({
                 serviceKey,
                 nodeCommand: inspectSummary?.nodeCommand ?? null,
-                observedAt
+                observedAt : statsObservedAt
             });
 
         // Remembered HERE rather than at the read above, because the heap observation rides ON the
@@ -583,8 +612,20 @@ export class DeploymentStateBridgeService extends Base {
         // describe one instant. A parallel sample store would have to re-establish that alignment,
         // and could silently lose it.
         if (stats) {
-            this.rememberStatsSample(serviceKey, stats, observedAt, heapObservation);
+            this.rememberStatsSample(serviceKey, stats, statsObservedAt, heapObservation, sampleContainerId);
         }
+
+        const statsSamples    = this.getStatsSamples(serviceKey);
+        const plannedRestarts = await this.countPlannedRestarts({serviceKey, observedAt: observationNow()});
+
+        // Query after every preceding async read and immediately before the synchronous diagnosis.
+        // This is the safety boundary: a snapshot-start projection can claim idle even though a
+        // request began while earlier services were still being observed.
+        if (serviceKey === 'local-model') {
+            providerActivity = await this.collectProviderActivity({observedAt: observationNow()});
+        }
+
+        const diagnosisObservedAt = observationNow();
 
         const diagnosis = this.diagnosisService?.diagnose
             ? this.diagnosisService.diagnose({
@@ -592,17 +633,19 @@ export class DeploymentStateBridgeService extends Base {
                 serviceKey,
                 inspect,
                 stats,
-                statsSamples   : this.getStatsSamples(serviceKey),
+                statsSamples,
+                runtimeContainerId: sampleContainerId,
                 endpointProbe,
                 providerResidency,
-                churnBaseline  : churnBaseline?.unreadable ? undefined : churnBaseline,
-                plannedRestarts: await this.countPlannedRestarts({serviceKey, observedAt}),
+                providerActivity,
+                churnBaseline     : churnBaseline?.unreadable ? undefined : churnBaseline,
+                plannedRestarts,
                 // `null` when `includeLogs` is off — which must surface as an UNAVAILABLE
                 // attribution, never as "not a heap death". A disabled channel is not evidence.
                 logs                 : logSummary,
                 nodeCommand          : inspectSummary?.nodeCommand ?? null,
                 declaredHeapCeilingMb: inspectSummary?.declaredHeapCeilingMb ?? null,
-                observedAt
+                observedAt           : diagnosisObservedAt
             })
             : null;
 
@@ -626,19 +669,20 @@ export class DeploymentStateBridgeService extends Base {
             recordType    : 'deployment-service-state',
             serviceKey,
             targetIdentity: {kind: 'compose-service', id: serviceKey},
-            observedAt,
+            observedAt    : diagnosisObservedAt,
             status        : errors.length > 0 ? 'degraded' : 'available',
             inspect       : inspectSummary,
             stats         : summarizeStats(stats),
             logs          : logSummary,
             providerResidency,
+            providerActivity,
             heapObservation,
             // EVERY snapshot, independent of load. The classification, the threshold that applies to
             // it, and the measured window state used to live only inside a sustained-saturation fact,
             // so a healthy store exposed none of them and no load-independent claim about the
             // classification machinery was verifiable from outside the process.
             classification: this.diagnosisService?.describeClassification
-                ? this.diagnosisService.describeClassification({serviceKey, statsSamples: this.getStatsSamples(serviceKey)})
+                ? this.diagnosisService.describeClassification({serviceKey, statsSamples})
                 : null,
             diagnosis     : diagnosis ? publishedDiagnosis : null,
             proofs,
@@ -760,6 +804,65 @@ export class DeploymentStateBridgeService extends Base {
                 message    : error.message,
                 targetIdentity
             };
+        }
+    }
+
+    /**
+     * @summary Reads one bounded, recorder-owned provider-work projection without dispatching provider
+     * work or treating an unavailable observer as an idle provider.
+     * @param {Object} options
+     * @param {Number} options.observedAt Snapshot observation epoch ms.
+     * @returns {Promise<Object>}
+     */
+    async collectProviderActivity({observedAt}) {
+        const unavailable = reason => ({
+            schemaVersion             : 1,
+            recordType                : 'deployment-provider-activity',
+            source                    : 'provider-activity-ledger',
+            status                    : 'unavailable',
+            unavailableReason         : reason,
+            observedAt,
+            sinceMs                   : Number.isFinite(this.providerActivityWindowMs) ? this.providerActivityWindowMs : null,
+            totalActivities           : null,
+            totalInFlight             : null,
+            totalRecentCompletions    : null,
+            inFlightTruncated         : null,
+            recentCompletionsTruncated: null,
+            inFlight                  : null,
+            recentCompletions         : null
+        });
+
+        if (typeof this.providerActivityProbe !== 'function') return unavailable('probe-unconfigured');
+        if (!Number.isFinite(this.providerActivityWindowMs) || this.providerActivityWindowMs <= 0 ||
+            !Number.isInteger(this.providerActivityLimit) || this.providerActivityLimit <= 0
+        ) {
+            return unavailable('projection-bounds-invalid');
+        }
+
+        try {
+            const projection = await this.providerActivityProbe({
+                sinceTs: observedAt - this.providerActivityWindowMs,
+                limit  : this.providerActivityLimit,
+                observedAt
+            });
+
+            if (!projection || !['ok', 'partial', 'unavailable'].includes(projection.status)) {
+                return unavailable('projection-malformed');
+            }
+
+            return {
+                ...projection,
+                schemaVersion    : 1,
+                recordType       : 'deployment-provider-activity',
+                source           : 'provider-activity-ledger',
+                observedAt,
+                sinceMs          : this.providerActivityWindowMs,
+                unavailableReason: projection.status === 'ok'
+                    ? null
+                    : (projection.unavailableReason || 'recorder-projection-unavailable')
+            };
+        } catch {
+            return unavailable('projection-read-failed');
         }
     }
 
@@ -1041,16 +1144,24 @@ export class DeploymentStateBridgeService extends Base {
      *     instant, carried ON the sample so the V8-scoped ratio inherits this window rather than
      *     maintaining a second one. `null` is the honest value for a non-Node or unreported service
      *     and must never be read as zero usage.
+     * @param {String|null} [containerId=null] Runtime-access proof identity shared by inspect/stats.
      * @returns {void}
      */
-    rememberStatsSample(serviceKey, stats, observedAt, heapObservation = null) {
-        const samples = this.statsSamplesByService.get(serviceKey) || [];
+    rememberStatsSample(serviceKey, stats, observedAt, heapObservation = null, containerId = null) {
+        let samples = this.statsSamplesByService.get(serviceKey) || [];
+
+        // A sustained window belongs to one container incarnation. A newly proven identity clears
+        // every earlier sample whose identity is absent or different; otherwise a recreate can join
+        // two short high-CPU bursts into one authoritative recovery trigger.
+        if (containerId && samples.some(sample => sample.containerId !== containerId)) {
+            samples = [];
+        }
 
         // Shallow copy with additive keys: the percent calculators read specific Docker fields and
         // ignore anything else, so this cannot alter their arithmetic.
         samples.push(Number.isFinite(observedAt)
-            ? {...stats, observedAtMs: observedAt, heapObservation}
-            : {...stats, heapObservation});
+            ? {...stats, observedAtMs: observedAt, heapObservation, containerId}
+            : {...stats, heapObservation, containerId});
 
         this.statsSamplesByService.set(serviceKey, samples.slice(-AiConfig.orchestrator.deploymentStateBridge.statsSampleWindow));
     }

--- a/ai/daemons/orchestrator/services/RecoveryActuatorService.mjs
+++ b/ai/daemons/orchestrator/services/RecoveryActuatorService.mjs
@@ -258,6 +258,8 @@ export class RecoveryActuatorService extends Base {
      * @param {String|null} [options.recoveryRunId=null] Optional stable recovery run id.
      * @param {Number} [options.now=Date.now()] Epoch milliseconds.
      * @param {String|null} [options.reason=null] Operator/controller reason.
+     * @param {Function|null} [options.isEffectStillAdmitted=null] Last-boundary effect predicate.
+     * @param {String|null} [options.expectedContainerId=null] Diagnosed container incarnation.
      * @returns {Promise<Object>} Action outcome descriptor.
      */
     async apply(serviceKey, action, {
@@ -270,6 +272,8 @@ export class RecoveryActuatorService extends Base {
         // the privileged effect. Optional so existing callers are unchanged; a caller that omits it
         // keeps today's behaviour exactly.
         isAuthorityHeld = null,
+        isEffectStillAdmitted = null,
+        expectedContainerId = null,
         // Only `reconfigure` consumes these. A controller names a KNOB, never a config leaf — the
         // transaction boundary belongs to the closed set, so a caller cannot compose an arbitrary
         // group of leaves and have it applied as one.
@@ -377,7 +381,16 @@ export class RecoveryActuatorService extends Base {
         const startedAt = now;
 
         try {
-            const result = await this.executeTargetAction({target, action, knob, knobValues, reason, isAuthorityHeld});
+            const result = await this.executeTargetAction({
+                target,
+                action,
+                knob,
+                knobValues,
+                reason,
+                isAuthorityHeld,
+                isEffectStillAdmitted,
+                expectedContainerId
+            });
 
             const updatedAt     = Date.now(),
                   diagnosis     = this.resolveDiagnosisEvent({diagnosisEvent, action, target, now: startedAt}),
@@ -460,10 +473,16 @@ export class RecoveryActuatorService extends Base {
             // here with an ordinary transport error and was reported `declined` with no audit at
             // all. A possibly-landed restart was erased — and erased silently, which is worse than
             // a loud failure because nothing observes it.
-            if (error?.reason === 'runtime-authority-lost') {
+            if (error?.reason === 'runtime-authority-lost' || error?.reason === 'runtime-effect-not-admitted' ||
+                error?.reason === 'runtime-target-incarnation-changed'
+            ) {
                 return {
-                    status        : 'declined',
-                    reasonCode    : 'authority-lost',
+                    status    : 'declined',
+                    reasonCode: error.reason === 'runtime-authority-lost'
+                        ? 'authority-lost'
+                        : (error.reason === 'runtime-effect-not-admitted'
+                            ? 'effect-no-longer-admitted'
+                            : 'target-incarnation-changed'),
                     serviceKey,
                     action,
                     targetIdentity: createRecoveryTargetIdentity({kind: target.kind, id: target.id})
@@ -901,7 +920,7 @@ export class RecoveryActuatorService extends Base {
      * @param {Object} options
      * @returns {Promise<Object>}
      */
-    async executeTargetAction({target, action, reason, knob, knobValues, isAuthorityHeld = null}) {
+    async executeTargetAction({target, action, reason, knob, knobValues, isAuthorityHeld = null, isEffectStillAdmitted = null, expectedContainerId = null}) {
         // The last COMMON point before every effect kind dispatches — common in syntax, which is not
         // the same as last-owned in time. It fences an action whose effect begins immediately
         // (`warm-provider` awaits its repair as its first statement), and it is NOT sufficient for an
@@ -922,7 +941,13 @@ export class RecoveryActuatorService extends Base {
         }
 
         if (target.kind === 'compose-service') {
-            return this.restartComposeService({target, reason, isAuthorityHeld});
+            return this.restartComposeService({
+                target,
+                reason,
+                isAuthorityHeld,
+                isEffectStillAdmitted,
+                expectedContainerId
+            });
         }
 
         if (target.kind === 'supervised-task') {
@@ -962,7 +987,7 @@ export class RecoveryActuatorService extends Base {
      * @param {Object} options
      * @returns {Promise<Object>}
      */
-    async restartComposeService({target, reason, isAuthorityHeld = null}) {
+    async restartComposeService({target, reason, isAuthorityHeld = null, isEffectStillAdmitted = null, expectedContainerId = null}) {
         if (!this.deploymentRuntimeAccessService?.applyLifecycle) {
             throw new Error('Deployment runtime access service is unavailable');
         }
@@ -975,7 +1000,9 @@ export class RecoveryActuatorService extends Base {
             // conditionally so a caller without an oracle sends a byte-identical request to before,
             // which keeps the specs' strict argument assertions meaningful rather than forcing them
             // to loosen to `toMatchObject` and stop noticing unexpected arguments.
-            ...(typeof isAuthorityHeld === 'function' ? {isAuthorityHeld} : {})
+            ...(typeof isAuthorityHeld === 'function' ? {isAuthorityHeld} : {}),
+            ...(typeof isEffectStillAdmitted === 'function' ? {isEffectStillAdmitted} : {}),
+            ...(typeof expectedContainerId === 'string' ? {expectedContainerId} : {})
         });
 
         return {

--- a/ai/services/memory-core/MemoryCoreRecorderService.mjs
+++ b/ai/services/memory-core/MemoryCoreRecorderService.mjs
@@ -96,11 +96,14 @@ function emptyWalDrain(status, reason) {
 function emptyProviderActivity(status) {
     return {
         status,
-        totalActivities  : 0,
-        totalInFlight    : 0,
-        aggregates       : [],
-        inFlight         : [],
-        recentCompletions: []
+        totalActivities           : 0,
+        totalInFlight             : 0,
+        totalRecentCompletions    : 0,
+        inFlightTruncated         : false,
+        recentCompletionsTruncated: false,
+        aggregates                : [],
+        inFlight                  : [],
+        recentCompletions         : []
     };
 }
 

--- a/ai/services/shared/providerActivityLedger.mjs
+++ b/ai/services/shared/providerActivityLedger.mjs
@@ -370,21 +370,28 @@ export function getProviderActivityMetrics(db, {sinceTs, limit, now = Date.now()
               FROM provider_activity_log
              WHERE enqueued_at >= @sinceTs
         `).get({sinceTs})?.total || 0,
+        // In-flight work is bounded by `limit`, never by the historical lookback. A caller may narrow
+        // `sinceTs` to recent completions, but an unresolved provider call older than that window is
+        // still live demand. Filtering it out manufactures an "idle" provider from an active one — the
+        // unsafe direction for every recovery consumer of this projection.
         totalInFlight = db.prepare(`
             SELECT COUNT(*) AS total
               FROM provider_activity_log
-             WHERE enqueued_at >= @sinceTs
-               AND completed_at IS NULL
+             WHERE completed_at IS NULL
+        `).get()?.total || 0,
+        totalRecentCompletions = db.prepare(`
+            SELECT COUNT(*) AS total
+              FROM provider_activity_log
+             WHERE completed_at >= @sinceTs
         `).get({sinceTs})?.total || 0,
         inFlightRows = db.prepare(`
             SELECT activity_id, service, operation_stage, role, provider, model, priority,
                    enqueued_at, started_at, queue_disposition, queue_wait_ms
               FROM provider_activity_log
-             WHERE enqueued_at >= @sinceTs
-               AND completed_at IS NULL
+             WHERE completed_at IS NULL
              ORDER BY enqueued_at ASC, activity_id ASC
              LIMIT @limit
-        `).all({sinceTs, limit}),
+        `).all({limit}),
         recentRows = db.prepare(`
             SELECT activity_id, service, operation_stage, role, provider, model, priority,
                    enqueued_at, started_at, completed_at, queue_disposition, queue_wait_ms,
@@ -410,10 +417,13 @@ export function getProviderActivityMetrics(db, {sinceTs, limit, now = Date.now()
     });
 
     return {
-        status    : 'ok',
+        status                    : 'ok',
         totalActivities,
         totalInFlight,
-        aggregates: aggregates.map(row => ({
+        totalRecentCompletions,
+        inFlightTruncated         : totalInFlight > inFlightRows.length,
+        recentCompletionsTruncated: totalRecentCompletions > recentRows.length,
+        aggregates                : aggregates.map(row => ({
             service         : row.service,
             operationStage  : row.operation_stage,
             role            : row.role,

--- a/test/playwright/unit/ai/daemons/orchestrator/Orchestrator.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/Orchestrator.spec.mjs
@@ -1,4 +1,5 @@
 import {test, expect} from '@playwright/test';
+import Database       from 'better-sqlite3';
 import fs             from 'fs-extra';
 import path           from 'path';
 import Neo            from '../../../../../../src/Neo.mjs';
@@ -24,6 +25,10 @@ import TaskStateService, { createInitialTaskState } from '../../../../../../ai/d
 import os                                           from 'os';
 import {createBootIdentityReadSource}               from '../../../../../../ai/services/fleet/createBootIdentityReadSource.mjs';
 import {BOOT_FRESHNESS_CLASS}                       from '../../../../../../ai/daemons/orchestrator/services/bootIdentityFreshness.mjs';
+import {
+    beginProviderActivity,
+    ensureProviderActivitySchema
+} from '../../../../../../ai/services/shared/providerActivityLedger.mjs';
 
 let   testOrchestratorSeq            = 0;
 const TEST_DEV_SERVER_PORT           = 18080;
@@ -780,6 +785,7 @@ test.describe('Neo.ai.daemons.Orchestrator (#11009)', () => {
         orchestrator.deploymentRuntimeAccessService = {};
         orchestrator.deploymentStateBridgeService = {};
         orchestrator.containerHealthDiagnosisService = {};
+        orchestrator.containerHealthControllerService = {};
 
         expect(orchestrator.deploymentStateBridgeService.runtimeAccessService)
             .toBe(orchestrator.deploymentRuntimeAccessService);
@@ -791,6 +797,109 @@ test.describe('Neo.ai.daemons.Orchestrator (#11009)', () => {
             .toBe(orchestrator.tenantRepoSyncService);
         expect(orchestrator.deploymentStateBridgeService.tenantRepoSyncEnabledReader())
             .toBe(false);
+        expect(typeof orchestrator.deploymentStateBridgeService.providerActivityProbe)
+            .toBe('function');
+        expect(orchestrator.deploymentStateBridgeService.providerActivityWindowMs)
+            .toBeGreaterThan(0);
+        expect(orchestrator.deploymentStateBridgeService.providerActivityLimit)
+            .toBeGreaterThan(0);
+        expect(typeof orchestrator.containerHealthControllerService.isEffectStillAdmitted)
+            .toBe('function');
+    });
+
+    test('provider activity projection fails closed when recorder telemetry is disabled', async () => {
+        const orchestrator = createTestOrchestrator({kbSyncEnabled: false});
+
+        orchestrator.deploymentStateBridgeService = {};
+        orchestrator.providerActivityTelemetryEnabledReader = () => false;
+
+        const db = new Database(':memory:');
+        ensureProviderActivitySchema(db);
+        orchestrator.db = db;
+
+        try {
+            expect(orchestrator.deploymentStateBridgeService.providerActivityProbe({
+                sinceTs   : Date.now() - 60_000,
+                limit     : 10,
+                observedAt: Date.now()
+            })).toEqual({
+                status           : 'unavailable',
+                unavailableReason: 'provider-activity-disabled'
+            });
+        } finally {
+            db.close();
+        }
+    });
+
+    test('effect-boundary provider admission veto applies only to residual Ollama restarts', () => {
+        const orchestrator = createTestOrchestrator({kbSyncEnabled: false});
+
+        orchestrator.containerHealthControllerService = {};
+        orchestrator.isOllamaResidualRestartStillAdmitted = () => false;
+
+        const isEffectStillAdmitted = orchestrator.containerHealthControllerService.isEffectStillAdmitted;
+
+        expect(isEffectStillAdmitted({
+            diagnosis: {details: {classificationReason: 'ollama-residual-load-restart'}}
+        })).toBe(false);
+        expect(isEffectStillAdmitted({
+            diagnosis: {details: {classificationReason: 'container-unhealthy-restart'}}
+        })).toBe(true);
+    });
+
+    test('effect-boundary provider admission follows the real shared-ledger transition', () => {
+        const orchestrator = createTestOrchestrator({kbSyncEnabled: false});
+        const db           = new Database(':memory:');
+
+        ensureProviderActivitySchema(db);
+        orchestrator.db = db;
+        orchestrator.providerActivityTelemetryEnabledReader = () => true;
+        orchestrator.providerActivityStatusReader = () => ({status: 'ok'});
+
+        try {
+            expect(orchestrator.isOllamaResidualRestartStillAdmitted()).toBe(true);
+
+            beginProviderActivity(db, {
+                service         : 'knowledge-base',
+                operationStage  : 'kb-tenant-ingestion-embedding',
+                role            : 'embedding',
+                provider        : 'ollama',
+                model           : 'qwen3-embedding:latest',
+                priority        : 'batch',
+                enqueuedAt      : Date.now(),
+                startedAt       : Date.now(),
+                queueDisposition: 'not-applicable'
+            });
+
+            expect(orchestrator.isOllamaResidualRestartStillAdmitted()).toBe(false);
+        } finally {
+            db.close();
+        }
+    });
+
+    test('provider activity projection reads the container-plane boot database without heartbeat readiness', async () => {
+        const orchestrator = createTestOrchestrator({kbSyncEnabled: false});
+
+        orchestrator.deploymentStateBridgeService = {};
+
+        const db = new Database(':memory:');
+        ensureProviderActivitySchema(db);
+        orchestrator.db = db;
+
+        try {
+            const projection = await orchestrator.deploymentStateBridgeService.providerActivityProbe({
+                sinceTs   : Date.now() - 60_000,
+                limit     : 10,
+                observedAt: Date.now()
+            });
+
+            expect(projection).toMatchObject({
+                totalInFlight         : 0,
+                totalRecentCompletions: 0
+            });
+        } finally {
+            db.close();
+        }
     });
 
     test('refreshes golden path while dream graph mutation is active — decoupled for hourly freshness', async () => {

--- a/test/playwright/unit/ai/daemons/orchestrator/Orchestrator.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/Orchestrator.spec.mjs
@@ -803,6 +803,8 @@ test.describe('Neo.ai.daemons.Orchestrator (#11009)', () => {
             .toBeGreaterThan(0);
         expect(orchestrator.deploymentStateBridgeService.providerActivityLimit)
             .toBeGreaterThan(0);
+        expect(orchestrator.containerHealthDiagnosisService.ollamaHostReader())
+            .toBe(AiConfig.ollama.host);
         expect(typeof orchestrator.containerHealthControllerService.isEffectStillAdmitted)
             .toBe('function');
     });

--- a/test/playwright/unit/ai/daemons/orchestrator/services/ContainerHealthControllerService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/ContainerHealthControllerService.spec.mjs
@@ -224,6 +224,33 @@ test.describe('Neo.ai.daemons.services.ContainerHealthControllerService', () => 
         }]);
     });
 
+    test('residual Ollama recovery carries live admission and container incarnation to runtime access', async () => {
+        let admitted = true;
+
+        const {controller, runtimeCalls} = createStack({
+                  controllerConfig: {isEffectStillAdmitted: () => admitted}
+              }),
+              decision = decisionWithActionClass(CONTAINER_HEALTH_ACTION_CLASSES.restart, {
+                  serviceKey   : 'local-model',
+                  recoveryClass: 'exhaustion'
+              });
+
+        decision.diagnosis.details.classificationReason = 'ollama-residual-load-restart';
+        decision.diagnosis.evidenceFacts = [{
+            type   : 'ollama-residual-load',
+            details: {runtimeContainerId: 'local-model-A'}
+        }];
+
+        await controller.consume({decision});
+
+        expect(runtimeCalls).toHaveLength(1);
+        expect(runtimeCalls[0].expectedContainerId).toBe('local-model-A');
+        expect(typeof runtimeCalls[0].isEffectStillAdmitted).toBe('function');
+
+        admitted = false;
+        expect(runtimeCalls[0].isEffectStillAdmitted()).toBe(false);
+    });
+
     test('SAFETY — an ANSWERING service is not restarted even with a SECOND authoritative fact', async () => {
         // Euclid's exact-head falsifier. `hasAuthoritativeEvidence`'s first arm admits ANY two
         // authoritative facts, so `container-unhealthy` + a sustained `memory-saturation` reached

--- a/test/playwright/unit/ai/daemons/orchestrator/services/ContainerHealthDiagnosisService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/ContainerHealthDiagnosisService.spec.mjs
@@ -56,9 +56,15 @@ const OBSERVED_AT = 1710000000000;
 const repoRoot    = path.resolve(process.cwd());
 
 function createService(config = {}) {
+    const {
+        ollamaHost = 'http://local-model:11434',
+        ...diagnosisConfig
+    } = config;
+
     return Neo.create(ContainerHealthDiagnosisService, {
-        diagnosisConfig: config,
-        nowFn          : () => OBSERVED_AT
+        diagnosisConfig,
+        nowFn           : () => OBSERVED_AT,
+        ollamaHostReader: () => ollamaHost
     });
 }
 
@@ -149,6 +155,7 @@ function sustainedOllamaResidualInputs(overrides = {}) {
         runtimeContainerId: 'local-model-A',
         providerResidency : ollamaResidency(),
         providerActivity  : providerActivity(),
+        providerResidencyEligible: true,
         ...overrides
     };
 }
@@ -649,6 +656,77 @@ test.describe('Neo.ai.daemons.services.ContainerHealthDiagnosisService', () => {
                 ]
             }
         });
+    });
+
+    test('derives the residual-load target and port from configured provider identity', () => {
+        const service = createService({
+                  ollamaHost: 'http://model:12000'
+              }),
+              decision = service.diagnose(sustainedOllamaResidualInputs({
+                  serviceKey: 'model',
+                  statsSamples: [
+                      statsSample({cpuPercent: 398, observedAtMs: OBSERVED_AT - 30_000, containerId: 'model-A'}),
+                      statsSample({cpuPercent: 399, observedAtMs: OBSERVED_AT, containerId: 'model-A'})
+                  ],
+                  runtimeContainerId: 'model-A',
+                  providerResidency : ollamaResidency({
+                      host          : 'http://model:12000',
+                      targetIdentity: {kind: 'compose-service', id: 'model'}
+                  })
+              }));
+
+        expect(decision.actionClass).toBe(CONTAINER_HEALTH_ACTION_CLASSES.restart);
+        expect(decision.targetIdentity).toEqual({kind: 'compose-service', id: 'model'});
+    });
+
+    test('refuses a configured provider endpoint owned by a different Compose service', () => {
+        const service = createService({
+                  ollamaHost: 'http://local-model:12000'
+              }),
+              decision = service.diagnose(sustainedOllamaResidualInputs({
+                  serviceKey: 'model',
+                  statsSamples: [
+                      statsSample({cpuPercent: 398, observedAtMs: OBSERVED_AT - 30_000, containerId: 'model-A'}),
+                      statsSample({cpuPercent: 399, observedAtMs: OBSERVED_AT, containerId: 'model-A'})
+                  ],
+                  runtimeContainerId: 'model-A',
+                  providerResidency : ollamaResidency({
+                      host          : 'http://local-model:12000',
+                      targetIdentity: {kind: 'compose-service', id: 'model'}
+                  })
+              }));
+
+        expect(decision.actionClass).toBeNull();
+        expect(decision.facts).toContainEqual(expect.objectContaining({
+            type   : CONTAINER_HEALTH_FACT_TYPES.ollamaResidualLoad,
+            details: expect.objectContaining({reasonCode: 'provider-endpoint-target-mismatch'})
+        }));
+    });
+
+    test('publishes why a saturated service is outside the configured provider roster', () => {
+        const service = createService({
+                  ollamaHost: 'http://shadow-model:12000'
+              }),
+              decision = service.diagnose(sustainedOllamaResidualInputs({
+                  serviceKey: 'shadow-model',
+                  statsSamples: [
+                      statsSample({cpuPercent: 398, observedAtMs: OBSERVED_AT - 30_000, containerId: 'shadow-A'}),
+                      statsSample({cpuPercent: 399, observedAtMs: OBSERVED_AT, containerId: 'shadow-A'})
+                  ],
+                  runtimeContainerId: 'shadow-A',
+                  providerResidencyEligible: false,
+                  providerResidency : ollamaResidency({
+                      host          : 'http://shadow-model:12000',
+                      targetIdentity: {kind: 'compose-service', id: 'shadow-model'}
+                  })
+              }));
+
+        expect(decision.actionClass).toBeNull();
+        expect(decision.status).toBe('advisory');
+        expect(decision.facts).toContainEqual(expect.objectContaining({
+            type   : CONTAINER_HEALTH_FACT_TYPES.ollamaResidualLoad,
+            details: expect.objectContaining({reasonCode: 'provider-residency-service-not-configured'})
+        }));
     });
 
     for (const [name, overrides, reasonCode] of [

--- a/test/playwright/unit/ai/daemons/orchestrator/services/ContainerHealthDiagnosisService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/ContainerHealthDiagnosisService.spec.mjs
@@ -78,13 +78,14 @@ function runningInspect(overrides = {}) {
  * window nothing observed — which is precisely the defect these fixtures used to encode, so it is a
  * required argument in spirit even though it defaults for the single-sample cases.
  */
-function statsSample({cpuPercent = 0, memoryPercent = 0, observedAtMs} = {}) {
+function statsSample({cpuPercent = 0, memoryPercent = 0, observedAtMs, containerId = null} = {}) {
     const systemDelta = 1_000_000_000,
           cpuDelta    = (cpuPercent / 100) * systemDelta / 4,
           memoryLimit = 1000;
 
     return {
         ...(Number.isFinite(observedAtMs) ? {observedAtMs} : {}),
+        containerId,
         cpu_stats: {
             online_cpus     : 4,
             system_cpu_usage: systemDelta,
@@ -101,6 +102,54 @@ function statsSample({cpuPercent = 0, memoryPercent = 0, observedAtMs} = {}) {
             usage: memoryLimit * memoryPercent / 100,
             limit: memoryLimit
         }
+    };
+}
+
+function ollamaResidency(overrides = {}) {
+    return {
+        provider       : 'ollama',
+        host           : 'http://local-model:11434',
+        model          : 'gemma4:26b',
+        embeddingModel : 'qwen3-embedding:latest',
+        ready          : true,
+        requiredModels : ['gemma4:26b', 'qwen3-embedding:latest'],
+        availableModels: ['gemma4:26b', 'qwen3-embedding:latest'],
+        missingModels  : [],
+        targetIdentity : {kind: 'compose-service', id: 'local-model'},
+        ...overrides
+    };
+}
+
+function providerActivity(overrides = {}) {
+    return {
+        status                    : 'ok',
+        observedAt                : OBSERVED_AT,
+        sinceMs                   : 24 * 60 * 60 * 1000,
+        totalInFlight             : 0,
+        totalRecentCompletions    : 0,
+        inFlightTruncated         : false,
+        recentCompletionsTruncated: false,
+        inFlight                  : [],
+        recentCompletions         : [],
+        ...overrides
+    };
+}
+
+function sustainedOllamaResidualInputs(overrides = {}) {
+    return {
+        serviceKey : 'local-model',
+        nodeCommand: false,
+        inspect    : runningInspect({
+            StartedAt: new Date(OBSERVED_AT - 120_000).toISOString()
+        }),
+        statsSamples: [
+            statsSample({cpuPercent: 398, observedAtMs: OBSERVED_AT - 30_000, containerId: 'local-model-A'}),
+            statsSample({cpuPercent: 399, observedAtMs: OBSERVED_AT, containerId: 'local-model-A'})
+        ],
+        runtimeContainerId: 'local-model-A',
+        providerResidency : ollamaResidency(),
+        providerActivity  : providerActivity(),
+        ...overrides
     };
 }
 
@@ -570,6 +619,170 @@ test.describe('Neo.ai.daemons.services.ContainerHealthDiagnosisService', () => {
             CONTAINER_HEALTH_FACT_TYPES.evalContention,
             CONTAINER_HEALTH_FACT_TYPES.resourceSaturation
         ]);
+    });
+
+    test('restarts only sustained unexplained local-model CPU with passive resident role evidence', () => {
+        const service  = createService(),
+              decision = service.diagnose(sustainedOllamaResidualInputs());
+
+        expect(decision.status).toBe('diagnosed');
+        expect(decision.actionClass).toBe(CONTAINER_HEALTH_ACTION_CLASSES.restart);
+        expect(decision.targetIdentity).toEqual({kind: 'compose-service', id: 'local-model'});
+        expect(decision.diagnosis).toMatchObject({
+            recoveryClass: 'exhaustion',
+            details      : {
+                classificationReason: 'ollama-residual-load-restart'
+            }
+        });
+        expect(decision.diagnosis.evidenceFacts.map(fact => fact.type)).toEqual([
+            CONTAINER_HEALTH_FACT_TYPES.ollamaResidualLoad,
+            CONTAINER_HEALTH_FACT_TYPES.resourceSaturation
+        ]);
+        expect(decision.diagnosis.evidenceFacts[0]).toMatchObject({
+            authoritative: true,
+            details      : {
+                reasonCode     : 'sustained-unexplained-ollama-load',
+                subjectIdentity: {kind: 'compose-service', id: 'local-model'},
+                roles          : [
+                    {role: 'chat', model: 'gemma4:26b', resident: true},
+                    {role: 'embedding', model: 'qwen3-embedding:latest', resident: true}
+                ]
+            }
+        });
+    });
+
+    for (const [name, overrides, reasonCode] of [
+        ['live native-Ollama demand', {
+            providerActivity: providerActivity({
+                totalInFlight: 1,
+                inFlight     : [{
+                    activityId    : 'active-embedding',
+                    service       : 'knowledge-base',
+                    operationStage: 'kb-tenant-ingestion-embedding',
+                    role          : 'embedding',
+                    provider      : 'ollama',
+                    model         : 'qwen3-embedding:latest',
+                    elapsedMs     : 180_000
+                }]
+            })
+        }, 'provider-demand-in-flight'],
+        ['partial recorder telemetry', {
+            providerActivity: providerActivity({status: 'partial'})
+        }, 'provider-activity-unavailable'],
+        ['stale recorder telemetry', {
+            providerActivity: providerActivity({observedAt: OBSERVED_AT - 30_001})
+        }, 'provider-activity-stale'],
+        ['identity-mismatched residency', {
+            providerResidency: ollamaResidency({targetIdentity: {kind: 'compose-service', id: 'other-model'}})
+        }, 'subject-identity-mismatch'],
+        ['external Ollama provider endpoint', {
+            providerResidency: ollamaResidency({host: 'http://external-provider:11434'})
+        }, 'provider-endpoint-target-mismatch'],
+        ['cross-incarnation CPU samples', {
+            statsSamples: [
+                statsSample({cpuPercent: 398, observedAtMs: OBSERVED_AT - 30_000, containerId: 'local-model-A'}),
+                statsSample({cpuPercent: 399, observedAtMs: OBSERVED_AT, containerId: 'local-model-B'})
+            ],
+            runtimeContainerId: 'local-model-B'
+        }, 'stats-incarnation-unbounded'],
+        ['cold-start model service', {
+            inspect: runningInspect({StartedAt: new Date(OBSERVED_AT - 10_000).toISOString()})
+        }, 'container-cold-start'],
+        ['recently settled native-Ollama demand', {
+            providerActivity: providerActivity({
+                totalRecentCompletions: 1,
+                recentCompletions     : [{
+                    activityId : 'just-finished',
+                    provider   : 'ollama',
+                    role       : 'embedding',
+                    model      : 'qwen3-embedding:latest',
+                    completedAt: new Date(OBSERVED_AT - 1_000).toISOString()
+                }]
+            })
+        }, 'provider-demand-recently-settled'],
+        ['truncated live-demand projection', {
+            providerActivity: providerActivity({
+                totalInFlight    : 51,
+                inFlightTruncated: true
+            })
+        }, 'provider-activity-in-flight-unbounded'],
+        ['mismatched live-demand count', {
+            providerActivity: providerActivity({totalInFlight: 1})
+        }, 'provider-activity-in-flight-unbounded'],
+        ['mismatched recent-demand count', {
+            providerActivity: providerActivity({totalRecentCompletions: 1})
+        }, 'provider-activity-recent-unbounded']
+    ]) {
+        test(`does not restart sustained CPU with ${name}`, () => {
+            const service  = createService(),
+                  decision = service.diagnose(sustainedOllamaResidualInputs(overrides));
+
+            expect(decision.actionClass).toBeNull();
+            expect(decision.diagnosis).toBeNull();
+            expect(decision.status).toBe('advisory');
+            expect(decision.facts.find(fact => fact.type === CONTAINER_HEALTH_FACT_TYPES.ollamaResidualLoad)).toMatchObject({
+                authoritative: false,
+                details      : {reasonCode}
+            });
+        });
+    }
+
+    test('accepts truncated completion history only when every hidden row predates the CPU window', () => {
+        const oldCompletions = Array.from({length: 50}, (_, index) => ({
+            activityId : `old-${index}`,
+            provider   : 'gemini',
+            completedAt: new Date(OBSERVED_AT - 30_001 - index).toISOString()
+        }));
+
+        const service  = createService(),
+              decision = service.diagnose(sustainedOllamaResidualInputs({
+                  providerActivity: providerActivity({
+                      totalRecentCompletions    : 51,
+                      recentCompletionsTruncated: true,
+                      recentCompletions         : oldCompletions
+                  })
+              }));
+
+        expect(decision.actionClass).toBe(CONTAINER_HEALTH_ACTION_CLASSES.restart);
+    });
+
+    test('refuses truncated completion history tied at the inclusive CPU cutoff', () => {
+        const tiedCompletions = Array.from({length: 50}, (_, index) => ({
+            activityId : `tied-${index}`,
+            provider   : 'gemini',
+            completedAt: new Date(OBSERVED_AT - 30_000).toISOString()
+        }));
+
+        const service  = createService(),
+              decision = service.diagnose(sustainedOllamaResidualInputs({
+                  providerActivity: providerActivity({
+                      totalRecentCompletions    : 51,
+                      recentCompletionsTruncated: true,
+                      recentCompletions         : tiedCompletions
+                  })
+              }));
+
+        expect(decision.actionClass).toBeNull();
+        expect(decision.facts.find(fact => fact.type === CONTAINER_HEALTH_FACT_TYPES.ollamaResidualLoad))
+            .toMatchObject({details: {reasonCode: 'provider-activity-recent-unbounded'}});
+    });
+
+    test('keeps one high-CPU sample and an idle resident model non-actionable', () => {
+        const service   = createService(),
+              oneSample = service.diagnose(sustainedOllamaResidualInputs({
+                  statsSamples: [statsSample({cpuPercent: 399, observedAtMs: OBSERVED_AT})]
+              })),
+              idle = service.diagnose(sustainedOllamaResidualInputs({
+                  statsSamples: [
+                      statsSample({cpuPercent: 0, observedAtMs: OBSERVED_AT - 30_000}),
+                      statsSample({cpuPercent: 0, observedAtMs: OBSERVED_AT})
+                  ]
+              }));
+
+        expect(oneSample.actionClass).toBeNull();
+        expect(oneSample.diagnosis).toBeNull();
+        expect(idle.actionClass).toBeNull();
+        expect(idle.diagnosis).toBeNull();
     });
 
     test('routes missing provider role models to warm-provider before config-drift escalation', () => {

--- a/test/playwright/unit/ai/daemons/orchestrator/services/DeploymentRuntimeAccessService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/DeploymentRuntimeAccessService.spec.mjs
@@ -895,6 +895,42 @@ test.describe('applyLifecycle — authority is rechecked AFTER target resolution
         expect(calls.some(call => /\/restart/.test(call.path))).toBe(true);
     });
 
+    test('live demand admitted during target resolution vetoes the restart at the last boundary', async () => {
+        let admitted = true;
+
+        const {service, calls} = createService(),
+              inner            = service.dockerRequestFn;
+
+        service.dockerRequestFn = async request => {
+            const result = await inner(request);
+
+            if (request.path.startsWith('/containers/json')) admitted = false;
+
+            return result;
+        };
+
+        await expect(service.applyLifecycle({
+            serviceKey           : 'mc-server',
+            operation            : 'restart',
+            isEffectStillAdmitted: () => admitted,
+            expectedContainerId  : 'container-abc'
+        })).rejects.toMatchObject({reason: 'runtime-effect-not-admitted'});
+
+        expect(calls.some(call => /\/restart/.test(call.path))).toBe(false);
+    });
+
+    test('a recreated container is never restarted from the predecessor incarnation diagnosis', async () => {
+        const {service, calls} = createService({containers: [makeContainer({Id: 'container-B'})]});
+
+        await expect(service.applyLifecycle({
+            serviceKey         : 'mc-server',
+            operation          : 'restart',
+            expectedContainerId: 'container-A'
+        })).rejects.toMatchObject({reason: 'runtime-target-incarnation-changed'});
+
+        expect(calls.some(call => /\/restart/.test(call.path))).toBe(false);
+    });
+
     test('a caller with no oracle is unaffected — byte-identical to before', async () => {
         const {service, calls} = createService();
 

--- a/test/playwright/unit/ai/daemons/orchestrator/services/DeploymentStateBridgeService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/DeploymentStateBridgeService.spec.mjs
@@ -608,9 +608,9 @@ test.describe('Neo.ai.daemons.services.DeploymentStateBridgeService', () => {
         });
     });
 
-    test('composes one passive provider-work projection into the local-model diagnosis', async () => {
+    test('composes one passive provider-work projection into each configured model-service diagnosis', async () => {
         Object.assign(AiConfig.orchestrator.deploymentStateBridge, {
-            allowedServices: ['local-model'],
+            allowedServices: ['model'],
             includeLogs    : false
         });
 
@@ -679,10 +679,10 @@ test.describe('Neo.ai.daemons.services.DeploymentStateBridgeService', () => {
             limit     : 50,
             observedAt: OBSERVED_AT
         }]);
-        expect(residencyCalls).toEqual([expect.objectContaining({serviceKey: 'local-model', observedAt: OBSERVED_AT})]);
+        expect(residencyCalls).toEqual([expect.objectContaining({serviceKey: 'model', observedAt: OBSERVED_AT})]);
         expect(diagnoses).toHaveLength(1);
         expect(diagnoses[0]).toMatchObject({
-            serviceKey      : 'local-model',
+            serviceKey      : 'model',
             providerActivity: {
                 recordType   : 'deployment-provider-activity',
                 source       : 'provider-activity-ledger',
@@ -693,7 +693,7 @@ test.describe('Neo.ai.daemons.services.DeploymentStateBridgeService', () => {
             },
             providerResidency: {
                 provider      : 'ollama',
-                targetIdentity: {kind: 'compose-service', id: 'local-model'}
+                targetIdentity: {kind: 'compose-service', id: 'model'}
             }
         });
         expect(snapshot.services[0].providerActivity).toEqual(diagnoses[0].providerActivity);
@@ -753,7 +753,10 @@ test.describe('Neo.ai.daemons.services.DeploymentStateBridgeService', () => {
                     recentCompletions         : []
                 };
             },
-            diagnosisService = Neo.create(ContainerHealthDiagnosisService, {nowFn: () => OBSERVED_AT}),
+            diagnosisService = Neo.create(ContainerHealthDiagnosisService, {
+                nowFn          : () => OBSERVED_AT,
+                ollamaHostReader: () => 'http://local-model:11434'
+            }),
             clock = {now: OBSERVED_AT - 30_000},
             service = createService({
                 runtimeAccessService,
@@ -856,7 +859,10 @@ test.describe('Neo.ai.daemons.services.DeploymentStateBridgeService', () => {
                     recentCompletions         : []
                 };
             },
-            diagnosisService = Neo.create(ContainerHealthDiagnosisService, {nowFn: () => OBSERVED_AT}),
+            diagnosisService = Neo.create(ContainerHealthDiagnosisService, {
+                nowFn          : () => OBSERVED_AT,
+                ollamaHostReader: () => 'http://local-model:11434'
+            }),
             service = createService({
                 runtimeAccessService,
                 diagnosisService,

--- a/test/playwright/unit/ai/daemons/orchestrator/services/DeploymentStateBridgeService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/DeploymentStateBridgeService.spec.mjs
@@ -52,12 +52,16 @@ function createService({
     diagnosisService,
     directProbeFn = null,
     providerResidencyProbe = async () => null,
+    providerActivityProbe = null,
+    providerActivityWindowMs = 24 * 60 * 60 * 1000,
+    providerActivityLimit = 50,
     recoveryRunStateReader = null,
     healLedgerDir = null,
     healLedgerReader = null,
     taskStateService = null,
     tenantRepoSyncService = null,
-    tenantRepoSyncEnabledReader = null
+    tenantRepoSyncEnabledReader = null,
+    nowFn = () => OBSERVED_AT
 } = {}) {
     return Neo.create(DeploymentStateBridgeService, {
         runtimeAccessService,
@@ -67,10 +71,13 @@ function createService({
         tenantRepoSyncEnabledReader,
         directProbeFn,
         providerResidencyProbe,
+        providerActivityProbe,
+        providerActivityWindowMs,
+        providerActivityLimit,
         recoveryRunStateReader,
         healLedgerDir,
         healLedgerReader,
-        nowFn: () => OBSERVED_AT
+        nowFn
     });
 }
 
@@ -598,6 +605,322 @@ test.describe('Neo.ai.daemons.services.DeploymentStateBridgeService', () => {
                 missingModels: ['gemma4:26b'],
                 target       : {kind: 'compose-service', id: 'model'}
             }
+        });
+    });
+
+    test('composes one passive provider-work projection into the local-model diagnosis', async () => {
+        Object.assign(AiConfig.orchestrator.deploymentStateBridge, {
+            allowedServices: ['local-model'],
+            includeLogs    : false
+        });
+
+        const
+            activityCalls        = [],
+            residencyCalls       = [],
+            diagnoses            = [],
+            runtimeAccessService = {
+                async readObserve({operation}) {
+                    if (operation === 'inspect') {
+                        return {
+                            data : {State: {Status: 'running', StartedAt: new Date(OBSERVED_AT - 120_000).toISOString()}},
+                            proof: {operation}
+                        };
+                    }
+
+                    return {
+                        data : statsSample({cpuPercent: 399}),
+                        proof: {operation}
+                    };
+                }
+            },
+            providerResidencyProbe = async options => {
+                residencyCalls.push(options);
+
+                return {
+                    provider       : 'ollama',
+                    ready          : true,
+                    model          : 'gemma4:26b',
+                    embeddingModel : 'qwen3-embedding:latest',
+                    requiredModels : ['gemma4:26b', 'qwen3-embedding:latest'],
+                    availableModels: ['gemma4:26b', 'qwen3-embedding:latest']
+                };
+            },
+            providerActivityProbe = async options => {
+                activityCalls.push(options);
+
+                return {
+                    status                    : 'ok',
+                    totalActivities           : 0,
+                    totalInFlight             : 0,
+                    totalRecentCompletions    : 0,
+                    inFlightTruncated         : false,
+                    recentCompletionsTruncated: false,
+                    aggregates                : [],
+                    inFlight                  : [],
+                    recentCompletions         : []
+                };
+            },
+            diagnosisService = {
+                diagnose(options) {
+                    diagnoses.push(options);
+                    return {status: 'healthy'};
+                }
+            },
+            service = createService({
+                runtimeAccessService,
+                diagnosisService,
+                providerResidencyProbe,
+                providerActivityProbe
+            }),
+            snapshot = await service.collectSnapshot();
+
+        expect(activityCalls).toEqual([{
+            sinceTs   : OBSERVED_AT - 24 * 60 * 60 * 1000,
+            limit     : 50,
+            observedAt: OBSERVED_AT
+        }]);
+        expect(residencyCalls).toEqual([expect.objectContaining({serviceKey: 'local-model', observedAt: OBSERVED_AT})]);
+        expect(diagnoses).toHaveLength(1);
+        expect(diagnoses[0]).toMatchObject({
+            serviceKey      : 'local-model',
+            providerActivity: {
+                recordType   : 'deployment-provider-activity',
+                source       : 'provider-activity-ledger',
+                status       : 'ok',
+                observedAt   : OBSERVED_AT,
+                sinceMs      : 24 * 60 * 60 * 1000,
+                totalInFlight: 0
+            },
+            providerResidency: {
+                provider      : 'ollama',
+                targetIdentity: {kind: 'compose-service', id: 'local-model'}
+            }
+        });
+        expect(snapshot.services[0].providerActivity).toEqual(diagnoses[0].providerActivity);
+    });
+
+    test('routes a sustained passive local-model residual through the real bridge and diagnosis', async () => {
+        Object.assign(AiConfig.orchestrator.deploymentStateBridge, {
+            allowedServices: ['local-model'],
+            includeLogs    : false
+        });
+
+        const
+            runtimeCalls         = [],
+            providerCalls        = [],
+            runtimeAccessService = {
+                async readObserve({operation}) {
+                    runtimeCalls.push(operation);
+
+                    if (operation === 'inspect') {
+                        return {
+                            data: {
+                                State: {
+                                    Status   : 'running',
+                                    StartedAt: new Date(OBSERVED_AT - 120_000).toISOString()
+                                }
+                            },
+                            proof: {operation, target: {containerId: 'local-model-A'}}
+                        };
+                    }
+
+                    return {
+                        data : statsSample({cpuPercent: 399}),
+                        proof: {operation, target: {containerId: 'local-model-A'}}
+                    };
+                }
+            },
+            providerResidencyProbe = async () => ({
+                provider       : 'ollama',
+                host           : 'http://local-model:11434',
+                ready          : true,
+                model          : 'gemma4:26b',
+                embeddingModel : 'qwen3-embedding:latest',
+                availableModels: ['gemma4:26b', 'qwen3-embedding:latest']
+            }),
+            providerActivityProbe = async options => {
+                providerCalls.push(options);
+
+                return {
+                    status                    : 'ok',
+                    totalActivities           : 0,
+                    totalInFlight             : 0,
+                    totalRecentCompletions    : 0,
+                    inFlightTruncated         : false,
+                    recentCompletionsTruncated: false,
+                    aggregates                : [],
+                    inFlight                  : [],
+                    recentCompletions         : []
+                };
+            },
+            diagnosisService = Neo.create(ContainerHealthDiagnosisService, {nowFn: () => OBSERVED_AT}),
+            clock = {now: OBSERVED_AT - 30_000},
+            service = createService({
+                runtimeAccessService,
+                diagnosisService,
+                providerResidencyProbe,
+                providerActivityProbe,
+                nowFn: () => clock.now
+            }),
+            first = await service.collectSnapshot({generatedAt: OBSERVED_AT - 30_000});
+
+        clock.now = OBSERVED_AT;
+
+        const second = await service.collectSnapshot({generatedAt: OBSERVED_AT});
+
+        expect(first.services[0].diagnosis.actionClass).toBeNull();
+        expect(second.services[0]).toMatchObject({
+            serviceKey: 'local-model',
+            diagnosis : {
+                status        : 'diagnosed',
+                actionClass   : 'restart',
+                targetIdentity: {kind: 'compose-service', id: 'local-model'},
+                diagnosis     : {
+                    recoveryClass: 'exhaustion',
+                    details      : {classificationReason: 'ollama-residual-load-restart'}
+                }
+            }
+        });
+        expect(second.services[0].diagnosis.diagnosis.evidenceFacts.map(fact => fact.type)).toEqual([
+            'ollama-residual-load',
+            'resource-saturation'
+        ]);
+        expect(providerCalls).toHaveLength(2);
+        expect(runtimeCalls).toEqual(['inspect', 'stats', 'inspect', 'stats']);
+    });
+
+    test('reads provider demand after earlier service awaits and immediately before local-model diagnosis', async () => {
+        Object.assign(AiConfig.orchestrator.deploymentStateBridge, {
+            allowedServices: ['orchestrator', 'local-model'],
+            includeLogs    : false
+        });
+
+        let activityStarted = false;
+
+        const
+            probeSawStarted      = [],
+            runtimeAccessService = {
+                async readObserve({serviceKey, operation}) {
+                    if (serviceKey === 'orchestrator') activityStarted = true;
+
+                    const containerId = `${serviceKey}-A`;
+
+                    if (operation === 'inspect') {
+                        return {
+                            data: {
+                                State: {
+                                    Status   : 'running',
+                                    StartedAt: new Date(OBSERVED_AT - 120_000).toISOString()
+                                }
+                            },
+                            proof: {operation, target: {containerId}}
+                        };
+                    }
+
+                    return {
+                        data : statsSample({cpuPercent: serviceKey === 'local-model' ? 399 : 0}),
+                        proof: {operation, target: {containerId}}
+                    };
+                }
+            },
+            providerResidencyProbe = async () => ({
+                provider       : 'ollama',
+                host           : 'http://local-model:11434',
+                ready          : true,
+                model          : 'gemma4:26b',
+                embeddingModel : 'qwen3-embedding:latest',
+                availableModels: ['gemma4:26b', 'qwen3-embedding:latest']
+            }),
+            providerActivityProbe = async () => {
+                probeSawStarted.push(activityStarted);
+
+                const inFlight = activityStarted ? [{
+                    activityId    : 'activity-after-snapshot-start',
+                    provider      : 'ollama',
+                    service       : 'knowledge-base',
+                    operationStage: 'embedding',
+                    role          : 'embedding',
+                    model         : 'qwen3-embedding:latest',
+                    elapsedMs     : 1
+                }] : [];
+
+                return {
+                    status                    : 'ok',
+                    totalActivities           : inFlight.length,
+                    totalInFlight             : inFlight.length,
+                    totalRecentCompletions    : 0,
+                    inFlightTruncated         : false,
+                    recentCompletionsTruncated: false,
+                    aggregates                : [],
+                    inFlight,
+                    recentCompletions         : []
+                };
+            },
+            diagnosisService = Neo.create(ContainerHealthDiagnosisService, {nowFn: () => OBSERVED_AT}),
+            service = createService({
+                runtimeAccessService,
+                diagnosisService,
+                providerResidencyProbe,
+                providerActivityProbe,
+                nowFn: () => OBSERVED_AT
+            });
+
+        service.rememberStatsSample(
+            'local-model',
+            statsSample({cpuPercent: 399}),
+            OBSERVED_AT - 30_000,
+            null,
+            'local-model-A'
+        );
+
+        const snapshot   = await service.collectSnapshot({generatedAt: OBSERVED_AT});
+        const localModel = snapshot.services.find(entry => entry.serviceKey === 'local-model');
+
+        expect(probeSawStarted).toEqual([true]);
+        expect(localModel.providerActivity.totalInFlight).toBe(1);
+        expect(localModel.diagnosis.actionClass).toBeNull();
+        expect(localModel.diagnosis.facts).toContainEqual(expect.objectContaining({
+            type   : 'ollama-residual-load',
+            details: expect.objectContaining({reasonCode: 'provider-demand-in-flight'})
+        }));
+    });
+
+    test('clears the sustained stats window when the runtime container incarnation changes', () => {
+        Object.assign(AiConfig.orchestrator.deploymentStateBridge, {statsSampleWindow: 2});
+
+        const service = createService();
+
+        service.rememberStatsSample('local-model', statsSample({cpuPercent: 399}), OBSERVED_AT - 30_000, null, 'container-A');
+        service.rememberStatsSample('local-model', statsSample({cpuPercent: 399}), OBSERVED_AT, null, 'container-B');
+
+        expect(service.getStatsSamples('local-model')).toEqual([
+            expect.objectContaining({containerId: 'container-B', observedAtMs: OBSERVED_AT})
+        ]);
+    });
+
+    test('publishes an unavailable provider-work envelope instead of manufacturing idle', async () => {
+        Object.assign(AiConfig.orchestrator.deploymentStateBridge, {
+            allowedServices: ['local-model'],
+            includeLogs    : false
+        });
+
+        const runtimeAccessService = {
+                  async readObserve({operation}) {
+                      return {
+                          data : operation === 'inspect' ? {State: {Status: 'running'}} : statsSample(),
+                          proof: {operation}
+                      };
+                  }
+              },
+              service  = createService({runtimeAccessService}),
+              snapshot = await service.collectSnapshot();
+
+        expect(snapshot.services[0].providerActivity).toMatchObject({
+            recordType       : 'deployment-provider-activity',
+            status           : 'unavailable',
+            unavailableReason: 'probe-unconfigured',
+            totalInFlight    : null,
+            inFlight         : null
         });
     });
 
@@ -1845,10 +2168,12 @@ test.describe('DeploymentStateBridgeService — the classification projection is
         // The falsifier this projection was created for: before it, these fields lived only inside
         // `if (memoryWindow.sustained)`, so a healthy store at a raised ceiling exposed none of them
         // and three successive post-merge verification formulations were each unobservable.
-        const service = Neo.create(DeploymentStateBridgeService, {
+        const clock   = {now: OBSERVED_AT},
+              service = Neo.create(DeploymentStateBridgeService, {
             runtimeAccessService: healthyRuntime(),
             diagnosisService    : Neo.create(ContainerHealthDiagnosisService, {}),
-            writeLog            : () => {}
+            writeLog            : () => {},
+            nowFn               : () => clock.now
         });
 
         const snapshot     = await service.collectSnapshot({generatedAt: OBSERVED_AT}),
@@ -1880,6 +2205,8 @@ test.describe('DeploymentStateBridgeService — the classification projection is
         // And the window ACCUMULATES load-independently: a second healthy observation later yields a
         // measured span, so a reader can verify the sustained-window machinery is alive without ever
         // saturating the service.
+        clock.now = OBSERVED_AT + 45000;
+
         const later = await service.collectSnapshot({generatedAt: OBSERVED_AT + 45000});
 
         expect(later.services[0].classification).toMatchObject({

--- a/test/playwright/unit/ai/daemons/orchestrator/services/RecoveryActuatorService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/RecoveryActuatorService.spec.mjs
@@ -286,6 +286,43 @@ test.describe('Neo.ai.daemons.services.RecoveryActuatorService', () => {
         expect((await readdir(actuatorConfig.recoveryRunStateDir)).length).toBe(runsBefore);
     });
 
+    for (const [runtimeReason, reasonCode] of [
+        ['runtime-effect-not-admitted', 'effect-no-longer-admitted'],
+        ['runtime-target-incarnation-changed', 'target-incarnation-changed']
+    ]) {
+        test(`a last-boundary ${runtimeReason} refusal charges no recovery attempt`, async () => {
+            let dispatches = 0;
+
+            const {service, actuatorConfig} = createService({
+                deploymentRuntimeAccessService: {
+                    async applyLifecycle() {
+                        dispatches++;
+                        const error = new Error(runtimeReason);
+                        error.reason = runtimeReason;
+                        throw error;
+                    }
+                }
+            });
+
+            const result = await service.apply('local-model', 'restart', {
+                now                  : 10_000,
+                expectedContainerId  : 'local-model-A',
+                isAuthorityHeld      : () => true,
+                isEffectStillAdmitted: () => false
+            });
+
+            expect(dispatches).toBe(1);
+            expect(result).toMatchObject({
+                status    : 'declined',
+                reasonCode,
+                serviceKey: 'local-model',
+                action    : 'restart'
+            });
+            expect(existsSync(actuatorConfig.healAttemptsPath)).toBe(false);
+            expect(existsSync(actuatorConfig.recoveryRunStateDir)).toBe(false);
+        });
+    }
+
     test('a dispatched effect whose outcome is lost after takeover is recorded UNCERTAIN, never erased', async () => {
         // @neo-gpt's third interval. The restart POST goes out under held authority; the takeover
         // happens; the socket resets before the outcome is known. This previously returned

--- a/test/playwright/unit/ai/services/memory-core/MemoryCoreRecorderService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/MemoryCoreRecorderService.spec.mjs
@@ -683,12 +683,15 @@ test.describe('Neo.ai.services.memory-core.MemoryCoreRecorderService', () => {
 
             expect(metrics.status).toBe('ok');
             expect(metrics.providerActivity).toEqual({
-                status           : 'partial',
-                totalActivities  : 0,
-                totalInFlight    : 0,
-                aggregates       : [],
-                inFlight         : [],
-                recentCompletions: []
+                status                    : 'partial',
+                totalActivities           : 0,
+                totalInFlight             : 0,
+                totalRecentCompletions    : 0,
+                inFlightTruncated         : false,
+                recentCompletionsTruncated: false,
+                aggregates                : [],
+                inFlight                  : [],
+                recentCompletions         : []
             });
         } finally {
             MemoryCoreRecorderService.db = originalDb;
@@ -755,12 +758,15 @@ test.describe('Neo.ai.services.memory-core.MemoryCoreRecorderService', () => {
 
         try {
             expect(MemoryCoreRecorderService.getMemoryCoreToolMetrics({sinceMs: 60_000, limit: 5}).providerActivity).toEqual({
-                status           : 'unavailable',
-                totalActivities  : 0,
-                totalInFlight    : 0,
-                aggregates       : [],
-                inFlight         : [],
-                recentCompletions: []
+                status                    : 'unavailable',
+                totalActivities           : 0,
+                totalInFlight             : 0,
+                totalRecentCompletions    : 0,
+                inFlightTruncated         : false,
+                recentCompletionsTruncated: false,
+                aggregates                : [],
+                inFlight                  : [],
+                recentCompletions         : []
             });
         } finally {
             fs.renameSync(withheldFile, kbFile);

--- a/test/playwright/unit/ai/services/shared/providerActivityLedger.spec.mjs
+++ b/test/playwright/unit/ai/services/shared/providerActivityLedger.spec.mjs
@@ -197,6 +197,38 @@ test.describe('providerActivityLedger', () => {
         expect(() => lifecycle.onSettled({completedAt: 30, success: true})).not.toThrow();
     });
 
+    test('retains unresolved provider work outside the recent-completion lookback', () => {
+        const oldInFlightId = beginProviderActivity(db, {
+            service         : 'knowledge-base',
+            operationStage  : 'kb-tenant-ingestion-embedding',
+            role            : 'embedding',
+            provider        : 'ollama',
+            model           : 'qwen3-embedding:latest',
+            priority        : 'batch',
+            enqueuedAt      : 100,
+            startedAt       : 100,
+            queueDisposition: 'not-applicable'
+        });
+
+        const metrics = getProviderActivityMetrics(db, {
+            sinceTs: 10_000,
+            limit  : 10,
+            now    : 20_000
+        });
+
+        expect(metrics.totalActivities).toBe(0);
+        expect(metrics.totalInFlight).toBe(1);
+        expect(metrics.inFlightTruncated).toBe(false);
+        expect(metrics.totalRecentCompletions).toBe(0);
+        expect(metrics.recentCompletionsTruncated).toBe(false);
+        expect(metrics.inFlight).toEqual([expect.objectContaining({
+            activityId: oldInFlightId,
+            provider  : 'ollama',
+            role      : 'embedding',
+            elapsedMs : 19_900
+        })]);
+    });
+
     test('deduplicates retry attribution and degrades a multi-model activity to unknown', () => {
         const refinements = [];
         const lifecycle   = createProviderActivityLifecycle({


### PR DESCRIPTION
Resolves neomjs/neo#16830

Related: neomjs/neo-agent-brain#54
Related: neomjs/neo-agent-brain#48
Related: neomjs/neo#16780

Containerized native Ollama now has a passive, fail-closed residual-load diagnosis composed through the existing ADR-0026 recovery path. The deployment bridge samples exact-container CPU history, expected-model residency, and recorder-owned provider activity without dispatching inference; the diagnosis becomes restart-eligible only after sustained CPU with no accounted native-Ollama demand. Exact container identity and an adjacent provider-demand oracle are carried to the last lifecycle boundary, so a recreated container or newly started request refuses the restart. Missing, disabled, stale, truncated, contradictory, external-host, or mixed-incarnation evidence remains advisory.

Evidence: L2 (401 exact post-rebase production-bound unit controls, an independent 24-control safety audit plus 6 actuator/cooldown controls, source integrity, and exact remote-tree equality) → L4 required (AC4 retained CPU-only Compose replay of the candidate detector/recovery path). Residual: AC4 [#16830].

## Deltas from ticket

- Merged PR neomjs/neo#16869 already retired the aborting inference canary and delivered neomjs/neo-agent-brain#48 before this branch. This diff neither recreates nor rebinds an inference health probe; an invariant control keeps the running-child `healthProbe` absent.
- The canonical runtime surface measures whole `local-model` **container CPU**, not per-runner or per-model CPU. Residency identifies the expected configured model(s), while any accounted native-Ollama activity vetoes restart. The implementation and evidence make no stronger attribution claim.
- Provider activity is read through the Memory Core recorder-owned projection rather than direct SQLite access from the orchestrator. Disabled, unavailable, stale, partial, or unsafe truncation states cannot become false idle.
- Bounded truncation is accepted only when the oldest returned completion is strictly older than the CPU evidence window; equal-cutoff and newer hidden work remain fail-closed.
- The existing ADR-0026 `restart` action, authority checks, cooldown, append-only provenance, and runtime-access privilege boundary are reused. No new action class or direct Docker privilege is introduced.
- This PR does not claim a second live four-core reproduction. The retained local reproduction branch remains the operator-gated L4 lane.

## Test Evidence

- Exact current-`dev` composition after rebase: `npm run test-unit -- <8 production-bound orchestrator/recorder/ledger specs> --workers=1` → 401 passed.
- Independent severe-only safety slice: 24/24 passed across disabled telemetry, idle→live ledger transition, exact-host and exact-container binding, adjacent provider sampling, sustained diagnosis, every demand/status/truncation fail-closed arm, and runtime last-boundary veto.
- Existing actuator/cooldown composition: 6/6 passed, including special refusal without attempt charge plus ordinary restart/backoff controls.
- Source integrity: `git diff --check` and `git show --check` → passed; branch is one commit over current `origin/dev`.
- Agent preflight: capability classification, ticket-tagged commit subject, and changed-file scope → passed; only pre-existing stale-overlay warnings remained.
- Remote integrity: tested local tree `f03341b8aa2f748c9a78516e038973765fd52eb6` equals pushed remote tree `f03341b8aa2f748c9a78516e038973765fd52eb6`; remote parent is current `dev` `7ef07a7ee311b6ab1c198dd7aae684eeefb783af`.
- No UI or application-body surface changed.

## Post-Merge Validation

- [ ] Build/deploy the candidate image on the canonical CPU-only Compose plane.
- [ ] Use retained branch `codex/16830-cpu-ollama-repro` to run the natural provider-timeout control and confirm provider settlement plus return to idle.
- [ ] Reproduce the measured residual arm, then verify the passive detector reaches sustained diagnosis with resident expected model, no live accounted provider demand, and exact-container evidence.
- [ ] Verify the existing actuator restarts that exact `local-model` container at most once inside the cooldown and records diagnosis, refusal/action, and recovery provenance.
- [ ] Run the active-request negative control and confirm high CPU with matching in-flight Ollama activity produces zero restart.
- [ ] File the L4 receipt on neomjs/neo#16830 before treating AC4 as closed; retain the reproduction branch until the natural, residual-detection, and recovery receipts are public.

## Evolution

The first topology repair shape risked rebuilding an inference canary around `/api/ps` or a new active probe. The measured early-disconnect residual made that unsafe: observation cannot dispatch the work whose persistence it diagnoses. The final composition instead reuses already-owned passive facts and the existing recovery authority, then closes the two safety intervals that a snapshot alone cannot close—provider demand starting after diagnosis and container replacement before lifecycle dispatch.

Decision Record impact: None. ADR 0026 remains the recovery-action authority; this adds no privilege or action class. ADR 0019 remains unchanged; this PR adds no configuration leaf or alternative config authority.

Authored by Emmy (GPT-5.6 Sol Ultra, Codex). Session 878f05af-2c4e-4da2-a5c2-9e4af666fcb8.
