### PR TITLE
fix(ai): a daemon crash exits non-zero so a supervisor can see it (#16882)

### DIFF
--- a/ai/daemons/embed/daemon.mjs
+++ b/ai/daemons/embed/daemon.mjs
@@ -33,10 +33,11 @@ import fs         from 'fs-extra';
 import path       from 'path';
 import {execSync} from 'child_process';
 
-import StorageRouter               from '../../services/memory-core/managers/StorageRouter.mjs';
-import {startDrainLoop}            from './drainCycle.mjs';
-import {acquireDrainLock}          from './drainLock.mjs';
-import {getMissingMemoryWalLeaves} from '../../services/memory-core/helpers/memoryWalStore.mjs';
+import StorageRouter                       from '../../services/memory-core/managers/StorageRouter.mjs';
+import {DAEMON_EXIT_CRASH, DAEMON_EXIT_OK} from '../shared/daemonExit.mjs';
+import {startDrainLoop}                    from './drainCycle.mjs';
+import {acquireDrainLock}                  from './drainLock.mjs';
+import {getMissingMemoryWalLeaves}         from '../../services/memory-core/helpers/memoryWalStore.mjs';
 
 // Stale-config boot guard: the gitignored config.mjs is a MATERIALIZED template copy — on a
 // deployment whose overlay predates the memoryWal daemon leaves they resolve undefined, and
@@ -257,9 +258,13 @@ async function enforceSingleton() {
         }
     }
 
-    // Cleanup on exit
-    let   cleanedUp = false;
-    const cleanup   = () => {
+    // Cleanup on exit. `releasePidFile` is separated from `cleanup` deliberately: the `exit` listener
+    // must RELEASE without exiting. It previously ran the whole of `cleanup`, whose bare
+    // `process.exit()` could re-enter during a non-zero exit and reset the code to 0 — the same class
+    // of bug as the crash path below. This mirrors the orchestrator, which already registers
+    // release-only on `exit`.
+    let   cleanedUp      = false;
+    const releasePidFile = () => {
         if (cleanedUp) return;
         cleanedUp = true;
         try {
@@ -270,15 +275,20 @@ async function enforceSingleton() {
                 }
             }
         } catch (e) {}
-        process.exit();
+    };
+    const cleanup = (exitCode = DAEMON_EXIT_OK) => {
+        releasePidFile();
+        process.exit(exitCode);
     };
 
-    process.on('SIGINT', cleanup);
-    process.on('SIGTERM', cleanup);
-    process.on('exit', cleanup);
+    // Each registration passes its code EXPLICITLY. `process.on('SIGINT', cleanup)` would invoke the
+    // listener with the SIGNAL NAME, handing `'SIGINT'` to `process.exit`.
+    process.on('SIGINT',  () => cleanup(DAEMON_EXIT_OK));
+    process.on('SIGTERM', () => cleanup(DAEMON_EXIT_OK));
+    process.on('exit', releasePidFile);
     process.on('uncaughtException', err => {
         writeLog('ERROR', `[Embed Daemon] Uncaught exception: ${err && err.stack ? err.stack : err}`);
-        cleanup(); // Calls process.exit() automatically
+        cleanup(DAEMON_EXIT_CRASH);
     });
 }
 

--- a/ai/daemons/message/daemon.mjs
+++ b/ai/daemons/message/daemon.mjs
@@ -19,9 +19,10 @@ import {
     createMessageGraphProjectionProcessor,
     startMessageDrainLoop
 } from './drainCycle.mjs';
-import {acquireMessageDrainLock}    from './drainLock.mjs';
-import {getMissingMessageWalLeaves} from '../../services/memory-core/helpers/messageWalStore.mjs';
-import MailboxService               from '../../services/memory-core/MailboxService.mjs';
+import {acquireMessageDrainLock}           from './drainLock.mjs';
+import {DAEMON_EXIT_CRASH, DAEMON_EXIT_OK} from '../shared/daemonExit.mjs';
+import {getMissingMessageWalLeaves}        from '../../services/memory-core/helpers/messageWalStore.mjs';
+import MailboxService                      from '../../services/memory-core/MailboxService.mjs';
 
 const missingLeaves = getMissingMessageWalLeaves(memoryCoreConfig.messageWal,
     ['dir', 'daemonDataDir', 'pollIntervalMs', 'batchSize', 'maxRetries', 'backoffBaseMs']);
@@ -191,8 +192,12 @@ async function enforceSingleton() {
         throw e;
     }
 
-    let   cleanedUp = false;
-    const cleanup   = () => {
+    // `releasePidFile` is separated from `cleanup` deliberately: the `exit` listener must RELEASE
+    // without exiting. It previously ran the whole of `cleanup`, whose bare `process.exit()` could
+    // re-enter during a non-zero exit and reset the code to 0 — the same class of bug as the crash
+    // path below. This mirrors the orchestrator, which already registers release-only on `exit`.
+    let   cleanedUp      = false;
+    const releasePidFile = () => {
         if (cleanedUp) return;
         cleanedUp = true;
         try {
@@ -203,15 +208,20 @@ async function enforceSingleton() {
                 }
             }
         } catch (e) {}
-        process.exit();
+    };
+    const cleanup = (exitCode = DAEMON_EXIT_OK) => {
+        releasePidFile();
+        process.exit(exitCode);
     };
 
-    process.on('SIGINT', cleanup);
-    process.on('SIGTERM', cleanup);
-    process.on('exit', cleanup);
+    // Each registration passes its code EXPLICITLY. `process.on('SIGINT', cleanup)` would invoke the
+    // listener with the SIGNAL NAME, handing `'SIGINT'` to `process.exit`.
+    process.on('SIGINT',  () => cleanup(DAEMON_EXIT_OK));
+    process.on('SIGTERM', () => cleanup(DAEMON_EXIT_OK));
+    process.on('exit', releasePidFile);
     process.on('uncaughtException', err => {
         writeLog('ERROR', `[Message Daemon] Uncaught exception: ${err && err.stack ? err.stack : err}`);
-        cleanup();
+        cleanup(DAEMON_EXIT_CRASH);
     });
 }
 

--- a/ai/daemons/orchestrator/daemon.mjs
+++ b/ai/daemons/orchestrator/daemon.mjs
@@ -35,6 +35,7 @@ import Orchestrator, {rotateLogFileIfNewDay}                             from '.
 import {acquireAuthorityLease, AUTHORITY_LEASE_TTL_MS}                   from './authorityLease.mjs';
 import {assertAuthorityProfile, isTaskOwnedByProfile}                    from './taskAuthority.mjs';
 import {assertConfigFresh}                                               from '../../scripts/setup/initServerConfigs.mjs';
+import {DAEMON_EXIT_CRASH, DAEMON_EXIT_OK}                               from '../shared/daemonExit.mjs';
 import Tier1ConfigBase, {PLANE_MEMBER_PATHS as TIER1_PLANE_MEMBER_PATHS} from '../../configBase.mjs';
 import {
     assertPlaneCoherence,
@@ -190,19 +191,36 @@ export async function enforceSingleton({pidFile = pidFilePath()} = {}) {
     fs.writeFileSync(pidFile, process.pid.toString(), 'utf8');
 }
 
+/**
+ * @summary Installs the shutdown handlers, and makes a crash exit non-zero.
+ *
+ * `cleanup` used to call a bare `process.exit()` — exit code **0** — from every caller including the
+ * `uncaughtException` arm, so a crash was reported to the container runtime as SUCCESS. A restart
+ * policy brings the daemon back either way, which is why this survived: the loss is not availability
+ * but attribution. An external plane showed `restartCount: 12` with `exitCode: 0` and `error: null`,
+ * next to a self-heal ledger with zero events, because nothing keyed on a non-zero exit ever fired.
+ *
+ * Every registration below passes its code EXPLICITLY, and that is load-bearing rather than stylistic:
+ * `process.on('SIGINT', cleanup)` invokes the listener with the **signal name**, so a positional
+ * `cleanup(code = 0)` would receive `'SIGTERM'` and hand a string to `process.exit`. Wrapping each
+ * registration is what keeps the signal path at 0 while the crash path reports failure.
+ *
+ * A signal-initiated stop exits **0** deliberately — an operator stopping the daemon is success, and
+ * flattening both paths to non-zero would make every graceful shutdown look like a crash.
+ */
 function setupCleanupHandlers() {
-    const cleanup = () => {
+    const cleanup = (exitCode = DAEMON_EXIT_OK) => {
         Orchestrator.stop();
         removePidFile();
-        process.exit();
+        process.exit(exitCode);
     };
 
-    process.on('SIGINT', cleanup);
-    process.on('SIGTERM', cleanup);
+    process.on('SIGINT',  () => cleanup(DAEMON_EXIT_OK));
+    process.on('SIGTERM', () => cleanup(DAEMON_EXIT_OK));
     process.on('exit', removePidFile);
     process.on('uncaughtException', err => {
         writeLog('ERROR', `[Orchestrator] Uncaught exception: ${err && err.stack ? err.stack : err}`);
-        cleanup();
+        cleanup(DAEMON_EXIT_CRASH);
     });
 }
 

--- a/ai/daemons/shared/daemonExit.mjs
+++ b/ai/daemons/shared/daemonExit.mjs
@@ -1,0 +1,57 @@
+/**
+ * @module ai/daemons/shared/daemonExit
+ * @summary The exit-code contract every long-lived daemon owes its supervisor.
+ *
+ * **The defect this closes.** All four long-lived daemons — orchestrator, embed, message, wake —
+ * routed their `uncaughtException` handler into the same `cleanup()` their signal handlers use, and
+ * that `cleanup()` called a bare `process.exit()`. Node's `process.exit()` with no argument exits
+ * **0**. So a crash was reported to the container runtime as SUCCESS, indistinguishable from an
+ * operator stopping the service.
+ *
+ * A restart policy brings the daemon back either way, which is precisely why this survived for so
+ * long: **the loss is not availability, it is attribution.** An external CPU-only plane showed
+ * `restartCount: 12` with `exitCode: 0`, `oomKilled: false` and `error: null` — readings that say
+ * "somebody stopped it twelve times" — beside a self-heal ledger reading `total: 0`, no events ever.
+ * Twelve probable crashes invisible to everything keyed on a non-zero exit, while the stack traces
+ * sat in the log seconds before each exit and nobody went looking, because the exit code said there
+ * was nothing to find.
+ *
+ * **Both codes are the contract, not just the failure one.** A signal-initiated stop is SUCCESS and
+ * must stay `0`. A repair that set every exit non-zero would satisfy the obvious test and make every
+ * graceful shutdown look like a crash — strictly worse than the defect, because it would train
+ * operators to ignore the signal we just built.
+ *
+ * **Why this is a module and not four literals.** Three of the four `cleanup()` bodies were already
+ * textually identical, and this defect is what four independent copies of an implicit convention
+ * produce. Single-sourcing makes the contract assertable by a spec rather than by reading four files
+ * and trusting your eyes.
+ *
+ * **Why a constant and not a config leaf.** An exit code is a contract with the process supervisor,
+ * not a deployment preference. A plane that could configure "what a crash reports" could configure
+ * the signal away — and the reactive-config leaf model exists for values a deployment legitimately
+ * varies. No leaf is introduced here deliberately.
+ *
+ * **The positional-argument trap this exists to keep visible.** `process.on('SIGINT', cleanup)`
+ * invokes the listener with the **signal name**, and `process.on('exit', cleanup)` invokes it with
+ * the **exit code**. A `cleanup(exitCode = 0)` wired directly to either would therefore receive
+ * `'SIGTERM'` or a runtime-chosen number rather than the intended code. Every registration must pass
+ * its code explicitly — `() => cleanup(DAEMON_EXIT_OK)` — and that wrapping is load-bearing, not a
+ * style choice.
+ *
+ * @see https://github.com/neomjs/neo/issues/16882 — the ticket
+ */
+
+/**
+ * Exit code for a deliberate, signal-initiated shutdown. An operator stopping a daemon is success.
+ * @type {Number}
+ */
+export const DAEMON_EXIT_OK = 0;
+
+/**
+ * Exit code for a daemon terminating because of an unhandled error.
+ *
+ * Deliberately distinct from {@link DAEMON_EXIT_OK} so a supervisor, a restart-policy audit, or a
+ * human reading `docker inspect` can tell a crash from a stop without correlating logs by timestamp.
+ * @type {Number}
+ */
+export const DAEMON_EXIT_CRASH = 1;

--- a/ai/daemons/wake/daemon.mjs
+++ b/ai/daemons/wake/daemon.mjs
@@ -35,6 +35,7 @@ import memoryCoreConfig                          from '../../mcp/server/memory-c
 import {assertConfigFresh}                       from '../../scripts/setup/initServerConfigs.mjs';
 import {buildWakeDigest, getHighestWakePriority} from './wakeDigestBuilder.mjs';
 import {withOutboxLock}                          from './outboxLock.mjs';
+import {DAEMON_EXIT_CRASH, DAEMON_EXIT_OK}       from '../shared/daemonExit.mjs';
 import nodeCrypto                                from 'node:crypto';
 
 import fs                               from 'fs-extra';
@@ -496,9 +497,13 @@ async function enforceSingleton() {
         }
     }
 
-    // Cleanup on exit
-    let   cleanedUp = false;
-    const cleanup   = () => {
+    // Cleanup on exit. `releasePidFile` is separated from `cleanup` deliberately: the `exit` listener
+    // must RELEASE without exiting. It previously ran the whole of `cleanup`, whose bare
+    // `process.exit()` could re-enter during a non-zero exit and reset the code to 0 — the same class
+    // of bug as the crash path below. This mirrors the orchestrator, which already registers
+    // release-only on `exit`.
+    let   cleanedUp      = false;
+    const releasePidFile = () => {
         if (cleanedUp) return;
         cleanedUp = true;
         try {
@@ -509,15 +514,20 @@ async function enforceSingleton() {
                 }
             }
         } catch (e) {}
-        process.exit();
+    };
+    const cleanup = (exitCode = DAEMON_EXIT_OK) => {
+        releasePidFile();
+        process.exit(exitCode);
     };
 
-    process.on('SIGINT', cleanup);
-    process.on('SIGTERM', cleanup);
-    process.on('exit', cleanup);
+    // Each registration passes its code EXPLICITLY. `process.on('SIGINT', cleanup)` would invoke the
+    // listener with the SIGNAL NAME, handing `'SIGINT'` to `process.exit`.
+    process.on('SIGINT',  () => cleanup(DAEMON_EXIT_OK));
+    process.on('SIGTERM', () => cleanup(DAEMON_EXIT_OK));
+    process.on('exit', releasePidFile);
     process.on('uncaughtException', (err) => {
         writeLog('ERROR', `[Wake Daemon] Uncaught exception: ${err && err.stack ? err.stack : err}`);
-        cleanup(); // Calls process.exit() automatically
+        cleanup(DAEMON_EXIT_CRASH);
     });
 }
 

--- a/test/playwright/unit/ai/daemons/shared/daemonExit.spec.mjs
+++ b/test/playwright/unit/ai/daemons/shared/daemonExit.spec.mjs
@@ -1,0 +1,119 @@
+import {expect, test}                      from '@playwright/test';
+import fs                                  from 'fs-extra';
+import path                                from 'path';
+import {fileURLToPath}                     from 'url';
+import {DAEMON_EXIT_CRASH, DAEMON_EXIT_OK} from '../../../../../../ai/daemons/shared/daemonExit.mjs';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../../../../../');
+
+/**
+ * @summary Coverage for the daemon exit-code contract.
+ *
+ * **The defect.** All four long-lived daemons routed `uncaughtException` into the same `cleanup()`
+ * their signal handlers use, and it called a bare `process.exit()` — exit code **0**. A crash was
+ * therefore reported to the container runtime as SUCCESS. A restart policy masks it, which is why it
+ * survived: the loss is attribution, not availability.
+ *
+ * **Two instruments here, and they prove different things — do not read one as the other:**
+ *
+ * 1. The `DAEMON_EXIT_*` tests are **behavioural** over the contract module. They prove the codes are
+ *    distinct and that success is `0`.
+ * 2. The per-daemon tests are **STRUCTURAL** — they read source text and assert how the handlers are
+ *    WIRED. They cannot prove what the process does at runtime. That limit is deliberate and stated
+ *    rather than papered over: proving the runtime behaviour would mean spawning each daemon and
+ *    inducing a real uncaught exception, which needs their config, PID locks and stores. The wiring
+ *    IS the defect here — a bare `process.exit()` and a directly-registered listener — so a
+ *    structural assertion has the right subject, but it is not a behavioural claim.
+ *
+ * **Retirement condition for the structural half:** if handler installation is ever extracted into an
+ * injectable function taking an `exit` port, these become behavioural and the source-reading versions
+ * should go.
+ *
+ * **The `SIGINT` trap these guard.** `process.on('SIGINT', cleanup)` invokes the listener with the
+ * **signal name**, so a positional `cleanup(exitCode = 0)` wired directly would hand `'SIGTERM'` to
+ * `process.exit`. Each registration must pass its code explicitly. A repair that only changed the
+ * crash path and left `process.on('SIGTERM', cleanup)` in place would still be broken, and the
+ * signal-path assertions below are what catch that.
+ */
+
+const DAEMONS = [
+    {key: 'orchestrator', file: 'ai/daemons/orchestrator/daemon.mjs'},
+    {key: 'embed',        file: 'ai/daemons/embed/daemon.mjs'},
+    {key: 'message',      file: 'ai/daemons/message/daemon.mjs'},
+    {key: 'wake',         file: 'ai/daemons/wake/daemon.mjs'}
+];
+
+/**
+ * Reads a daemon's source with comments removed, so an assertion about CODE cannot be satisfied — or
+ * broken — by prose. The docblocks in these files quote `process.exit()` while explaining the defect;
+ * without stripping, a "no bare exit" assertion would fail on its own explanation.
+ * @param {String} relativePath
+ * @returns {String}
+ */
+function readCode(relativePath) {
+    return fs.readFileSync(path.join(repoRoot, relativePath), 'utf8')
+        .replace(/\/\*[\s\S]*?\*\//g, '')
+        .replace(/^\s*\/\/.*$/gm, '');
+}
+
+test.describe('daemon exit-code contract', () => {
+    test('success and crash are DISTINCT codes, and success is 0', () => {
+        // Behavioural. `0` is not arbitrary — it is what a supervisor reads as a clean stop, so an
+        // operator-initiated shutdown must land here and a crash must not.
+        expect(DAEMON_EXIT_OK).toBe(0);
+        expect(DAEMON_EXIT_CRASH).not.toBe(DAEMON_EXIT_OK);
+        expect(Number.isInteger(DAEMON_EXIT_CRASH)).toBe(true);
+        expect(DAEMON_EXIT_CRASH).toBeGreaterThan(0);
+    });
+
+    for (const daemon of DAEMONS) {
+        test(`${daemon.key} — the crash path exits NON-ZERO`, () => {
+            const code = readCode(daemon.file);
+
+            // Single-sourced, not a local literal. Four copies of an implicit convention is what
+            // produced this defect; a daemon that reintroduces its own constant fails here.
+            expect(code).toContain("from '../shared/daemonExit.mjs'");
+            expect(code).toMatch(/import\s*\{[^}]*DAEMON_EXIT_CRASH[^}]*\}/);
+
+            // The crash arm hands the failure code through.
+            expect(code).toMatch(/cleanup\(\s*DAEMON_EXIT_CRASH\s*\)/);
+        });
+
+        test(`${daemon.key} — the SIGNAL path still exits 0 (non-vacuity arm)`, () => {
+            const code = readCode(daemon.file);
+
+            // THE arm that makes this suite non-vacuous. Without it, a change setting every exit
+            // non-zero would satisfy the crash assertions above and make every graceful stop look
+            // like a crash — strictly worse than the defect, because it trains operators to ignore
+            // the signal we just built.
+            expect(code).toMatch(/process\.on\(\s*'SIGINT',\s*\(\)\s*=>\s*cleanup\(\s*DAEMON_EXIT_OK\s*\)/);
+            expect(code).toMatch(/process\.on\(\s*'SIGTERM',\s*\(\)\s*=>\s*cleanup\(\s*DAEMON_EXIT_OK\s*\)/);
+
+            // And the trap itself: a directly-registered listener receives the SIGNAL NAME as its
+            // first argument. This is the shape the fix removes, and it must not come back.
+            expect(code).not.toMatch(/process\.on\(\s*'SIGINT',\s*cleanup\s*\)/);
+            expect(code).not.toMatch(/process\.on\(\s*'SIGTERM',\s*cleanup\s*\)/);
+        });
+
+        test(`${daemon.key} — no bare process.exit() remains`, () => {
+            const code = readCode(daemon.file);
+
+            // A bare `process.exit()` is the original defect verbatim: it yields 0 regardless of why
+            // it was reached. Every exit in these files must now name its code.
+            expect(code).not.toMatch(/process\.exit\(\s*\)/);
+        });
+    }
+
+    test('the `exit` listener RELEASES without exiting, in every daemon', () => {
+        // A listener registered on `exit` that itself calls `process.exit(0)` can reset a non-zero
+        // code chosen by whatever triggered the exit — the same failure this ticket closes, arriving
+        // by a different door. Three daemons previously registered the whole of `cleanup` here; the
+        // orchestrator already registered release-only, and this asserts all four now agree.
+        for (const daemon of DAEMONS) {
+            const code = readCode(daemon.file);
+
+            expect(code, `${daemon.key} registers a release-only exit listener`)
+                .toMatch(/process\.on\(\s*'exit',\s*(removePidFile|releasePidFile)\s*\)/);
+        }
+    });
+});


### PR DESCRIPTION
Resolves #16882

All four long-lived daemons routed `uncaughtException` into the same `cleanup()` their signal handlers use, and it called a bare `process.exit()` — exit code **0**. A crash was reported to the container runtime as success, indistinguishable from an operator stop. A restart policy masks it, which is why it survived: the loss is attribution, not availability. The signal path deliberately still exits 0, each registration passes its code explicitly (`process.on('SIGINT', cleanup)` invokes the listener with the *signal name*), and `releasePidFile` is split out of `cleanup` in the three daemons that registered the whole of it on `exit`, where its exit call could reset a non-zero code.

Evidence: L4 (specs executed locally against the real daemon sources, plus two source mutations) → L4 required (#16882's ACs are per-daemon wiring assertions and a signal-path non-vacuity arm, both reachable in-suite). Residual: none for the delivered ACs; the runtime-behaviour limit is stated in the spec docblock and carries a retirement condition rather than an open AC [#16882].

## Deltas from ticket

Two additions beyond the ticket text, both found while implementing:

- **`releasePidFile` split** — the ticket named only the `uncaughtException` arm. Three daemons also registered the whole of `cleanup` on `process.on('exit', ...)`, so a `process.exit(1)` elsewhere in those files could re-enter and reset the code to 0 — the same defect by another door. The orchestrator already registered release-only; all four now agree.
- **`ai/daemons/shared/daemonExit.mjs`** — the ticket said "prove the shared shape". A shared constant module makes that assertable by spec instead of by reading four files. No config leaf: an exit code is a contract with the supervisor, not a deployment preference, and the module states why.

## Test Evidence

`ai/daemons/**` (the four entry points + shared): `test/playwright/unit/ai/daemons/shared/daemonExit.spec.mjs` — **14 passed**.

Blast radius, full suite over every daemon: `UNIT_TEST_MODE=true npx playwright test test/playwright/unit/ai/daemons/` — **1772 passed, 0 failed**.

Mutation conviction, run rather than asserted:

| mutation applied to source | result |
|---|---|
| crash arm reverted to bare `cleanup()` | **1 failed** — `orchestrator — the crash path exits NON-ZERO`; 13 passed |
| `process.on('SIGTERM', cleanup)` restored | **1 failed** — `orchestrator — the SIGNAL path still exits 0`; crash arms unaffected |

Each mutation fails exactly the arm that owns it and nothing else. Sources restored; `git diff --stat` clean against the committed tree before push.

## Post-Merge Validation

- [ ] On a plane that has restarted a daemon: `docker inspect` reports a non-zero `ExitCode` for a crash, where it previously reported `0`.
- [ ] A deliberate `docker compose stop` still reports `ExitCode: 0` — the arm no spec can prove outside a real container runtime.

## Evolution

Initially wired a positional `cleanup(exitCode = 0)` directly to the existing registrations. That is wrong: `process.on('SIGINT', cleanup)` passes the **signal name** as the first argument, so `process.exit('SIGTERM')` would have shipped. Every registration is now wrapped explicitly, and the spec asserts the absence of the direct-registration shape so it cannot return.

Authored by @neo-opus-grace (Opus 5) · origin session `3c27118d-2de2-4579-bb42-1062c34cb895`
