### PR TITLE
fix(ai): a repo with nothing to ingest completes instead of backing off forever (#16577)

### DIFF
--- a/ai/daemons/orchestrator/services/TenantRepoSyncErrors.mjs
+++ b/ai/daemons/orchestrator/services/TenantRepoSyncErrors.mjs
@@ -41,6 +41,20 @@ export const KB_TENANT_REPO_SYNC_EMPTY_MATERIALIZATION = 'KB_TENANT_REPO_SYNC_EM
 // risks duplicating it — while `EMPTY_MATERIALIZATION` means nothing arrived and the embed stage is
 // where to look. One code for both told an operator the opposite of what happened half the time.
 export const KB_TENANT_REPO_SYNC_MATERIALIZATION_UNPROVEN = 'KB_TENANT_REPO_SYNC_MATERIALIZATION_UNPROVEN';
+// The THIRD zero-effect case, and the one that used to be told the opposite of what happened.
+// Content reached the pipeline and every chunk was refused BEFORE the provider — `summary.ingested`
+// counts embeddable chunks only, and an oversized chunk increments `skippedOversized` instead of
+// joining that array, so a repo whose every chunk exceeds the safe band reports `ingested: 0` with
+// `skippedOversized > 0`.
+//
+// It shared `EMPTY_MATERIALIZATION` and therefore told an operator *nothing arrived, look at the embed
+// stage*. Everything arrived; the embed stage never saw it, and re-ingesting cannot help because the
+// chunks are the same size on the next attempt. The actionable surface is chunking or the safe band.
+//
+// A separate CODE for the same reason as its neighbour above: the durable per-repo state persists
+// `lastErrorCode` and nothing else, so a discriminator carried in `details` is dropped at the
+// persistence boundary and never reaches the operator it exists for.
+export const KB_TENANT_REPO_SYNC_CONTENT_NOT_EMBEDDABLE = 'KB_TENANT_REPO_SYNC_CONTENT_NOT_EMBEDDABLE';
 // Non-failure defer reason: another process holds the cross-process tenant-repo-sync
 // lease. Surfaced as a `skipped` reasonCode (never thrown) so the periodic lane and
 // the manual CLI can branch on it without treating operator ownership as an error.
@@ -75,6 +89,7 @@ export const TENANT_REPO_SYNC_ERROR_CODES = Object.freeze([
     KB_TENANT_REPO_SYNC_CONCURRENCY_GATE_TIMEOUT,
     KB_TENANT_REPO_SYNC_EMPTY_MATERIALIZATION,
     KB_TENANT_REPO_SYNC_MATERIALIZATION_UNPROVEN,
+    KB_TENANT_REPO_SYNC_CONTENT_NOT_EMBEDDABLE,
     KB_TENANT_REPO_SYNC_LEASE_HELD,
     KB_TENANT_REPO_SYNC_LEASE_LOST,
     KB_TENANT_REPO_SYNC_STARVED

--- a/ai/daemons/orchestrator/services/TenantRepoSyncService.mjs
+++ b/ai/daemons/orchestrator/services/TenantRepoSyncService.mjs
@@ -42,6 +42,7 @@ import {
     isStarvedOrderInverted
 } from '../scheduling/tenantRepoSync.mjs';
 import {
+    KB_TENANT_REPO_SYNC_CONTENT_NOT_EMBEDDABLE,
     KB_TENANT_REPO_SYNC_EMPTY_MATERIALIZATION,
     KB_TENANT_REPO_SYNC_MATERIALIZATION_UNPROVEN,
     KB_TENANT_REPO_SYNC_SYNC_FAILED,
@@ -492,6 +493,14 @@ function assertFullMaterializationEffect(envelope, summary, priorState, material
         validReceipt   = isMatchingMaterializationReceipt(receipt, expectedDigest),
         hasEffect      = [summary.ingested, summary.deleted]
             .some(value => Number.isSafeInteger(value) && value > 0),
+        // The envelope's own manifest, not a proxy for it: `pathsAfterPush` is what the repo carries
+        // after the push, so an EMPTY array is a positive statement that there is nothing to ingest —
+        // and a non-empty one is what makes zero effect a finding.
+        declaredPaths     = envelope.manifestSnapshot.pathsAfterPush,
+        declaresNoContent = Array.isArray(declaredPaths) && declaredPaths.length === 0,
+        // Chunks that reached the pipeline and were refused before the provider. Disjoint from
+        // `ingested`, which counts embeddable chunks only.
+        skippedOversized  = Number.isSafeInteger(summary.skippedOversized) ? summary.skippedOversized : 0,
         provesCurrentAttempt = validReceipt
             && receipt.attemptId === materializationAttempt?.attemptId,
         provesUncommittedRetry = validReceipt
@@ -525,6 +534,53 @@ function assertFullMaterializationEffect(envelope, summary, priorState, material
                 // credential discipline already applied to ingestion error messages.
                 ingested            : summary.ingested,
                 deleted             : summary.deleted,
+                receiptPresent      : Boolean(receipt),
+                receiptMatchesDigest: validReceipt
+            }
+        )
+    }
+
+    // **A repo with nothing to ingest is a SUCCESS, and it has to be, or it can never leave.** The
+    // producer mints a receipt only on positive effect, so `provesUncommittedRetry` needs a receipt
+    // that will never exist for this repo — the checkpoint never commits,
+    // `lastCommittedMaterializationAttemptId` is never recorded, and the escape below can therefore
+    // never engage on any later attempt either. Fixing only the first failure would leave every
+    // empty repo permanently backing off. Returning `null` here is what the `manifestSnapshot == null`
+    // arm at the top already does: no receipt to carry, and the caller commits.
+    // `!provesUncommittedRetry` is load-bearing, not defensive. A delete-only repo also declares no
+    // content, and on a retry after a checkpoint-write failure its effect is already applied — so
+    // `hasEffect` is false while a valid unacknowledged receipt is waiting to be settled exactly once.
+    // Returning early there would drop the receipt the caller records as
+    // `lastCommittedMaterializationAttemptId`, and the settle-once invariant would silently break.
+    // With the guard, that case falls through to `return receipt` and only a repo with nothing to
+    // settle takes this arm.
+    // ...and `!priorState?.lastCommittedMaterializationAttemptId` narrows this to the case the ticket
+    // names — a repo that has never committed an attempt. A repo that HAS committed one and later
+    // reports no content is a different question — a replay carrying a receipt whose attempt is already
+    // committed is refused today, and the settle-once invariant asserts that refusal — so this arm
+    // deliberately does not answer it. That residual is an open fork rather than a decision made here.
+    if (!hasEffect
+        && declaresNoContent
+        && !provesUncommittedRetry
+        && !priorState?.lastCommittedMaterializationAttemptId) {
+        return null
+    }
+
+    // Content arrived and every chunk was refused before the provider. Sharing the code below told the
+    // operator *nothing arrived, look at the embed stage* — the reverse of what happened, and the same
+    // mislabelling the arm above was split out to end. Still fail-closed: a repo whose content cannot
+    // be embedded is not synced, and calling it `completed` would make a broken tenant read as healthy.
+    // Whether this case should instead commit is a product judgement recorded as open on the ticket.
+    if (!hasEffect && skippedOversized > 0) {
+        throw new TenantRepoSyncError(
+            KB_TENANT_REPO_SYNC_CONTENT_NOT_EMBEDDABLE,
+            'Tenant-repo materialization produced no ingestible chunk: every candidate was refused before the provider.',
+            {
+                phase               : 'full-materialization',
+                ingested            : summary.ingested,
+                deleted             : summary.deleted,
+                skippedOversized,
+                declaredPathCount   : Array.isArray(declaredPaths) ? declaredPaths.length : null,
                 receiptPresent      : Boolean(receipt),
                 receiptMatchesDigest: validReceipt
             }
@@ -1101,6 +1157,7 @@ class TenantRepoSyncService extends Base {
      * | `KB_TENANT_REPO_SYNC_SYNC_FAILED` | per-repo `lastErrorCode` | underlying clone/fetch/envelope/ingest failure (wraps the original error) |
      * | `KB_TENANT_REPO_SYNC_EMPTY_MATERIALIZATION` | per-repo `lastErrorCode` | full materialization produced NO positive effect and no matching unacknowledged retry receipt — nothing arrived; look at the embed stage |
      * | `KB_TENANT_REPO_SYNC_MATERIALIZATION_UNPROVEN` | per-repo `lastErrorCode` | full materialization DID take effect, but no receipt proves this attempt — the rows landed and the proof is missing, so do NOT re-ingest |
+     * | `KB_TENANT_REPO_SYNC_CONTENT_NOT_EMBEDDABLE` | per-repo `lastErrorCode` | the repo declares content and every candidate chunk was refused BEFORE the provider — re-ingesting cannot help; the actionable surface is chunking or the safe band |
      * | `KB_TENANT_REPO_SYNC_REPO_NOT_CONFIGURED` | outer `details.reasonCode` | `onlyRepoSlugs` filter requested a slug that is not in `tenantRepos[]` |
      * | `KB_TENANT_REPO_SYNC_MANIFEST_UPDATE_FAILED` | outer `details.reasonCode` | `tenant-repo-sync-revisions.json` write failure (next cycle settles the unacknowledged graph receipt idempotently) |
      * | `KB_TENANT_REPO_SYNC_TENANT_NOT_FOUND` | reserved | future `--tenant-id` CLI flag; no current emitter |

--- a/ai/daemons/orchestrator/services/TenantRepoSyncService.mjs
+++ b/ai/daemons/orchestrator/services/TenantRepoSyncService.mjs
@@ -470,10 +470,10 @@ function isMatchingMaterializationReceipt(receipt, expectedDigest) {
  * A manifest-bearing envelope represents bootstrap, non-linear fallback, manual full
  * replay, or legacy revalidation. It must reach ingestion before this check so an
  * empty manifest can reconcile and delete stale rows. A fresh attempt must prove a
- * safely-counted ingest/delete effect and persist its matching graph receipt. A
- * zero-effect retry may settle only an unacknowledged receipt left by a prior positive
- * attempt whose checkpoint commit failed. Incremental envelopes have no manifest and
- * may remain healthy zero-delta checkpoints.
+ * safely-counted ingest/delete effect or a source-observed empty manifest, and persist
+ * its matching graph receipt. A zero-effect retry may settle only an unacknowledged
+ * receipt left by a prior positive attempt whose checkpoint commit failed. Incremental
+ * envelopes have no manifest and may remain healthy zero-delta checkpoints.
  *
  * @param {Object} envelope Tenant-repo ingestion envelope.
  * @param {Object} summary Validated error-free ingestion summary.
@@ -540,30 +540,16 @@ function assertFullMaterializationEffect(envelope, summary, priorState, material
         )
     }
 
-    // **A repo with nothing to ingest is a SUCCESS, and it has to be, or it can never leave.** The
-    // producer mints a receipt only on positive effect, so `provesUncommittedRetry` needs a receipt
-    // that will never exist for this repo — the checkpoint never commits,
-    // `lastCommittedMaterializationAttemptId` is never recorded, and the escape below can therefore
-    // never engage on any later attempt either. Fixing only the first failure would leave every
-    // empty repo permanently backing off. Returning `null` here is what the `manifestSnapshot == null`
-    // arm at the top already does: no receipt to carry, and the caller commits.
-    // `!provesUncommittedRetry` is load-bearing, not defensive. A delete-only repo also declares no
-    // content, and on a retry after a checkpoint-write failure its effect is already applied — so
-    // `hasEffect` is false while a valid unacknowledged receipt is waiting to be settled exactly once.
-    // Returning early there would drop the receipt the caller records as
-    // `lastCommittedMaterializationAttemptId`, and the settle-once invariant would silently break.
-    // With the guard, that case falls through to `return receipt` and only a repo with nothing to
-    // settle takes this arm.
-    // ...and `!priorState?.lastCommittedMaterializationAttemptId` narrows this to the case the ticket
-    // names — a repo that has never committed an attempt. A repo that HAS committed one and later
-    // reports no content is a different question — a replay carrying a receipt whose attempt is already
-    // committed is refused today, and the settle-once invariant asserts that refusal — so this arm
-    // deliberately does not answer it. That residual is an open fork rather than a decision made here.
-    if (!hasEffect
-        && declaresNoContent
-        && !provesUncommittedRetry
-        && !priorState?.lastCommittedMaterializationAttemptId) {
-        return null
+    // **A repo with nothing to ingest is a SUCCESS, but success still needs durable proof.** Returning
+    // `null` here used to let the caller report `completed` while persisting no committed attempt id;
+    // checkpoint classification then remained FAILED and every later sweep replayed from a null base.
+    // The producer now emits the same digest-bound current-attempt receipt used for effect-bearing
+    // materializations, but only after it observes a zero-error authoritative empty manifest.
+    // Requiring BOTH facts here prevents a forged current receipt on a non-empty manifest from
+    // laundering a silent drop into success. A prior unacknowledged positive receipt has
+    // `provesCurrentAttempt === false`, so it still falls through to the settle-once path below.
+    if (!hasEffect && declaresNoContent && provesCurrentAttempt) {
+        return receipt
     }
 
     // Content arrived and every chunk was refused before the provider. Sharing the code below told the

--- a/ai/services/knowledge-base/IngestionService.mjs
+++ b/ai/services/knowledge-base/IngestionService.mjs
@@ -1079,6 +1079,22 @@ class IngestionService extends Base {
                 // Preserve a prior positive receipt so a crash or checkpoint-write
                 // failure after KB mutation can settle idempotently on the retry.
                 receipt = existing.materializationReceipt;
+            } else if (
+                summary.errors.length === 0
+                && normalized.pathsAfterPush.length === 0
+            ) {
+                // A source-observed empty manifest is a completed materialization, not an
+                // effect-shaped one. It still needs the ordinary digest-bound proof so the
+                // orchestrator can commit a complete checkpoint instead of reporting success
+                // while leaving revalidation armed. Prior positive receipts deliberately win
+                // above: replacing one here would break settle-once recovery after a checkpoint
+                // write failure.
+                receipt = {
+                    attemptId            : attempt.attemptId,
+                    ingestContractVersion: attempt.ingestContractVersion,
+                    envelopeDigest,
+                    recordedAt           : Date.now()
+                };
             }
         }
 

--- a/test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncErrors.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncErrors.spec.mjs
@@ -8,6 +8,7 @@ import {
     KB_TENANT_REPO_SYNC_MANIFEST_UPDATE_FAILED,
     KB_TENANT_REPO_SYNC_CONCURRENCY_GATE_TIMEOUT,
     KB_TENANT_REPO_SYNC_EMPTY_MATERIALIZATION,
+    KB_TENANT_REPO_SYNC_CONTENT_NOT_EMBEDDABLE,
     KB_TENANT_REPO_SYNC_MATERIALIZATION_UNPROVEN,
     KB_TENANT_REPO_SYNC_STARVED,
     TENANT_REPO_SYNC_ERROR_CODES,
@@ -35,7 +36,7 @@ test.describe('TenantRepoSyncErrors taxonomy (#11942 AC3+AC4)', () => {
 
     test('TENANT_REPO_SYNC_ERROR_CODES array contains exactly the exported codes', () => {
         expect(Array.isArray(TENANT_REPO_SYNC_ERROR_CODES)).toBe(true);
-        expect(TENANT_REPO_SYNC_ERROR_CODES.length).toBe(10);
+        expect(TENANT_REPO_SYNC_ERROR_CODES.length).toBe(11);
         expect(TENANT_REPO_SYNC_ERROR_CODES).toContain(KB_TENANT_REPO_SYNC_SYNC_FAILED);
         expect(TENANT_REPO_SYNC_ERROR_CODES).toContain(KB_TENANT_REPO_SYNC_LEASE_HELD);
         expect(TENANT_REPO_SYNC_ERROR_CODES).toContain(KB_TENANT_REPO_SYNC_LEASE_LOST);
@@ -47,6 +48,8 @@ test.describe('TenantRepoSyncErrors taxonomy (#11942 AC3+AC4)', () => {
         // The effect-bearing sibling. Bumping the count alone would let a new code pass the guard
         // without ever being named — the count is a tripwire, membership is the actual assertion.
         expect(TENANT_REPO_SYNC_ERROR_CODES).toContain(KB_TENANT_REPO_SYNC_MATERIALIZATION_UNPROVEN);
+        // The third zero-effect case: content declared, every chunk refused before the provider.
+        expect(TENANT_REPO_SYNC_ERROR_CODES).toContain(KB_TENANT_REPO_SYNC_CONTENT_NOT_EMBEDDABLE);
         expect(TENANT_REPO_SYNC_ERROR_CODES).toContain(KB_TENANT_REPO_SYNC_STARVED);
     });
 
@@ -59,7 +62,7 @@ test.describe('TenantRepoSyncErrors taxonomy (#11942 AC3+AC4)', () => {
         expect(() => TENANT_REPO_SYNC_ERROR_CODES.push('KB_TENANT_REPO_SYNC_MUTATED')).toThrow(TypeError);
         expect(() => { TENANT_REPO_SYNC_ERROR_CODES[TENANT_REPO_SYNC_ERROR_CODES.length] = 'KB_TENANT_REPO_SYNC_MUTATED'; }).toThrow(TypeError);
         expect(() => { TENANT_REPO_SYNC_ERROR_CODES.length = 0; }).toThrow(TypeError);
-        expect(TENANT_REPO_SYNC_ERROR_CODES.length).toBe(10);
+        expect(TENANT_REPO_SYNC_ERROR_CODES.length).toBe(11);
         expect(TENANT_REPO_SYNC_ERROR_CODES).not.toContain('KB_TENANT_REPO_SYNC_MUTATED');
         expect(isTenantRepoSyncErrorCode('KB_TENANT_REPO_SYNC_MUTATED')).toBe(false);
     });

--- a/test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncService.spec.mjs
@@ -28,7 +28,9 @@ import TenantRepoSyncService from '../../../../../../../ai/daemons/orchestrator/
 import {classifyEmbeddingRecoveryState, isRepoDue}
                             from '../../../../../../../ai/daemons/orchestrator/scheduling/tenantRepoSync.mjs';
 import {
+    classifyTenantRepoCheckpoint,
     normalizeTenantRepoCheckpointState,
+    requiresTenantRepoCheckpointRevalidation,
     TENANT_REPO_INGEST_CONTRACT_VERSION
 } from '../../../../../../../ai/daemons/orchestrator/services/tenantRepoCheckpointValidity.mjs';
 import {TENANT_REPO_SYNC_ERROR_CODES}
@@ -167,6 +169,21 @@ test.describe('TenantRepoSyncService (#11790)', () => {
                         && existing.envelopeDigest === envelopeDigest
                     ) {
                         summary.materializationReceipt = existing;
+                    } else if (
+                        payload.materializationAttempt
+                        && Array.isArray(summary.errors)
+                        && summary.errors.length === 0
+                        && Array.isArray(payload.manifestSnapshot.pathsAfterPush)
+                        && payload.manifestSnapshot.pathsAfterPush.length === 0
+                    ) {
+                        const receipt = {
+                            ...payload.materializationAttempt,
+                            envelopeDigest,
+                            recordedAt: Date.now()
+                        };
+
+                        materializationReceipts.set(key, receipt);
+                        summary.materializationReceipt = receipt;
                     } else if (!payload.materializationAttempt) {
                         materializationReceipts.delete(key);
                     }
@@ -1428,32 +1445,44 @@ test.describe('TenantRepoSyncService (#11790)', () => {
         // repo can never reach a checkpoint, on this attempt or any future one.
         const
             taskStateService = createInMemoryTaskStateService(),
-            repoSlug         = 'org/genuinely-empty';
+            repoSlug         = 'org/genuinely-empty',
+            envelopeCalls    = [],
+            ingestCalls      = [];
 
         await fs.writeJson(revisionsFile, {revisions: {}});
         await provisionMirrorDir({tenantId: 't1', repoSlug});
 
-        const result = await TenantRepoSyncService.runTask({
+        const options = {
             reason           : 'manual',
             taskStateService,
             tenantReposConfig: {tenantRepos: [{
                 tenantId: 't1', repoSlug, mirrorRoot, cloneUrl: 'https://example.invalid/empty.git'
             }]},
             gitMirror      : makeFakeGitMirror(),
-            envelopeBuilder: async args => ({
-                tenantId        : args.tenantId,
-                repoSlug        : args.repoSlug,
-                files           : [],
-                headRevision    : 'sha-empty-head',
-                manifestSnapshot: {repoSlug: args.repoSlug, pathsAfterPush: []}
-            }),
+            envelopeBuilder: async args => {
+                envelopeCalls.push(args);
+
+                return {
+                    tenantId    : args.tenantId,
+                    repoSlug    : args.repoSlug,
+                    files       : [],
+                    deleted     : [],
+                    headRevision: 'sha-empty-head',
+                    ...(args.lastIngestedRev ? {} : {
+                        manifestSnapshot: {repoSlug: args.repoSlug, pathsAfterPush: []}
+                    })
+                }
+            },
             knowledgeBaseIngestionService: makeFakeIngestionService({
+                captureCalls : ingestCalls,
                 summaryFactory: () => ({ingested: 0, deleted: 0, errors: []})
             }),
             onlyRepoSlugs    : [repoSlug],
-            fullReplay       : true,
+            fullReplay       : false,
             revisionsFilePath: revisionsFile
-        });
+        };
+
+        const result = await TenantRepoSyncService.runTask(options);
 
         expect(result.status).toBe('completed');
         expect(result.details.repos[0]).toMatchObject({
@@ -1464,8 +1493,23 @@ test.describe('TenantRepoSyncService (#11790)', () => {
         // The trap is broken only if the checkpoint DURABLY commits — a `completed` status that leaves
         // no committed attempt id would re-enter the same state on the next sweep.
         const persisted = await fs.readJson(revisionsFile);
+        const persistedRepo = persisted.revisions[`t1/${repoSlug}`];
 
-        expect(persisted.revisions[`t1/${repoSlug}`].lastIngestedRev).toBe('sha-empty-head');
+        expect(persistedRepo).toMatchObject({
+            lastIngestedRev                      : 'sha-empty-head',
+            lastCommittedMaterializationAttemptId: ingestCalls[0].payload.materializationAttempt.attemptId
+        });
+        expect(classifyTenantRepoCheckpoint(persistedRepo)).toBe('complete');
+        expect(requiresTenantRepoCheckpointRevalidation(persistedRepo)).toBe(false);
+
+        const second = await TenantRepoSyncService.runTask(options);
+
+        expect(second.status).toBe('completed');
+        expect(envelopeCalls).toHaveLength(2);
+        expect(envelopeCalls[1].lastIngestedRev).toBe('sha-empty-head');
+        expect(classifyTenantRepoCheckpoint(
+            (await fs.readJson(revisionsFile)).revisions[`t1/${repoSlug}`]
+        )).toBe('complete');
     });
 
     test('POSITIVE CONTROL — declared paths with NO effect and NO explanation still fails', async () => {

--- a/test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncService.spec.mjs
@@ -31,6 +31,8 @@ import {
     normalizeTenantRepoCheckpointState,
     TENANT_REPO_INGEST_CONTRACT_VERSION
 } from '../../../../../../../ai/daemons/orchestrator/services/tenantRepoCheckpointValidity.mjs';
+import {TENANT_REPO_SYNC_ERROR_CODES}
+    from '../../../../../../../ai/daemons/orchestrator/services/TenantRepoSyncErrors.mjs';
 import {deriveTenantRepoMirrorPath} from '../../../../../../../ai/services/knowledge-base/helpers/tenantRepoAccessContract.mjs';
 import {createTenantRepoMaterializationDigest}
     from '../../../../../../../ai/services/knowledge-base/helpers/tenantRepoIngestEnvelopeBuilder.mjs';
@@ -1042,11 +1044,21 @@ test.describe('TenantRepoSyncService (#11790)', () => {
 
     for (const scenario of [
         {
-            label        : 'bootstrap',
-            fullReplay   : false,
-            priorState   : null,
-            expectedBase : null,
-            manifestPaths: []
+            label       : 'bootstrap',
+            fullReplay  : false,
+            priorState  : null,
+            expectedBase: null,
+            // Was `[]`, which made this the one scenario in the table that did NOT match the table's
+            // own premise — the envelope below states `'source exists but parser materialized nothing'`,
+            // and an empty manifest means no source existed. That combination is now a SUCCESS (see the
+            // empty-repo test above), so asserting `EMPTY_MATERIALIZATION` here contradicted it.
+            //
+            // The change is safe because an empty `pathsAfterPush` is a positive observation rather than
+            // a silent failure: `listRevisionPaths` THROWS `KB_INGEST_ENVELOPE_LIST_FAILED` on any
+            // enumeration error and never returns `[]`, so the array is trustworthy at this guard.
+            // Bootstrap keeps its arm here, testing what the table means to test — a first sync where
+            // content is present and nothing materialized.
+            manifestPaths: ['README.md']
         },
         {
             label     : 'non-linear fallback',
@@ -1396,6 +1408,151 @@ test.describe('TenantRepoSyncService (#11790)', () => {
 
         const persisted = await fs.readJson(revisionsFile);
         expect(persisted.revisions[`t1/${repoSlug}`].lastIngestedRev).toBe('sha-after-delete');
+    });
+
+    /**
+     * @summary The three zero-effect cases the guard currently collapses into one code.
+     *
+     * The delete-only test above passes because `deleted: 1` makes `hasEffect` true. Everything below
+     * has `ingested: 0` AND `deleted: 0`, which is the state that cannot commit: the producer mints a
+     * receipt only on positive effect, so `provesUncommittedRetry` needs a receipt that never exists,
+     * so the checkpoint never commits, so `lastCommittedMaterializationAttemptId` is never recorded —
+     * and the escape can never engage on any later attempt either. The loop has no exit.
+     *
+     * `manifestSnapshot.pathsAfterPush` is what separates the cases, and it is already on the envelope
+     * at the guard rather than being a proxy for anything.
+     */
+    test('an EMPTY repo completes and commits — nothing to ingest is not a failure', async () => {
+        // The onboarding case: a fresh tenant repo with no ingestible paths. No prior revision state,
+        // so `deleted` is 0 as well — there is nothing to have removed. Under the current guard this
+        // repo can never reach a checkpoint, on this attempt or any future one.
+        const
+            taskStateService = createInMemoryTaskStateService(),
+            repoSlug         = 'org/genuinely-empty';
+
+        await fs.writeJson(revisionsFile, {revisions: {}});
+        await provisionMirrorDir({tenantId: 't1', repoSlug});
+
+        const result = await TenantRepoSyncService.runTask({
+            reason           : 'manual',
+            taskStateService,
+            tenantReposConfig: {tenantRepos: [{
+                tenantId: 't1', repoSlug, mirrorRoot, cloneUrl: 'https://example.invalid/empty.git'
+            }]},
+            gitMirror      : makeFakeGitMirror(),
+            envelopeBuilder: async args => ({
+                tenantId        : args.tenantId,
+                repoSlug        : args.repoSlug,
+                files           : [],
+                headRevision    : 'sha-empty-head',
+                manifestSnapshot: {repoSlug: args.repoSlug, pathsAfterPush: []}
+            }),
+            knowledgeBaseIngestionService: makeFakeIngestionService({
+                summaryFactory: () => ({ingested: 0, deleted: 0, errors: []})
+            }),
+            onlyRepoSlugs    : [repoSlug],
+            fullReplay       : true,
+            revisionsFilePath: revisionsFile
+        });
+
+        expect(result.status).toBe('completed');
+        expect(result.details.repos[0]).toMatchObject({
+            status          : 'active',
+            checkpointStatus: 'complete'
+        });
+
+        // The trap is broken only if the checkpoint DURABLY commits — a `completed` status that leaves
+        // no committed attempt id would re-enter the same state on the next sweep.
+        const persisted = await fs.readJson(revisionsFile);
+
+        expect(persisted.revisions[`t1/${repoSlug}`].lastIngestedRev).toBe('sha-empty-head');
+    });
+
+    test('POSITIVE CONTROL — declared paths with NO effect and NO explanation still fails', async () => {
+        // The defect the guard exists for, and the arm that makes the case above meaningful: paths were
+        // declared, nothing landed, and nothing reported why. Without this assertion, "an empty
+        // materialization completes" is indistinguishable from having disabled the guard.
+        const
+            taskStateService = createInMemoryTaskStateService(),
+            repoSlug         = 'org/silent-drop';
+
+        await fs.writeJson(revisionsFile, {revisions: {}});
+        await provisionMirrorDir({tenantId: 't1', repoSlug});
+
+        const result = await TenantRepoSyncService.runTask({
+            reason           : 'manual',
+            taskStateService,
+            tenantReposConfig: {tenantRepos: [{
+                tenantId: 't1', repoSlug, mirrorRoot, cloneUrl: 'https://example.invalid/silent.git'
+            }]},
+            gitMirror      : makeFakeGitMirror(),
+            envelopeBuilder: async args => ({
+                tenantId        : args.tenantId,
+                repoSlug        : args.repoSlug,
+                files           : [{path: 'a.txt'}],
+                headRevision    : 'sha-silent-head',
+                manifestSnapshot: {repoSlug: args.repoSlug, pathsAfterPush: ['a.txt']}
+            }),
+            knowledgeBaseIngestionService: makeFakeIngestionService({
+                summaryFactory: () => ({ingested: 0, deleted: 0, errors: []})
+            }),
+            onlyRepoSlugs    : [repoSlug],
+            fullReplay       : true,
+            revisionsFilePath: revisionsFile
+        });
+
+        expect(result.status).toBe('failed');
+        expect(result.details.repos[0].lastErrorCode).toBe('KB_TENANT_REPO_SYNC_EMPTY_MATERIALIZATION');
+    });
+
+    test('every chunk OVERSIZED is not an empty materialization — the code must not say nothing arrived', async () => {
+        // `summary.ingested = embeddableChunks.length` and an oversized chunk increments
+        // `skippedOversized` instead of joining that array, so a repo whose every chunk exceeds the
+        // embedding safe band reports `ingested: 0, skippedOversized: N`. `hasEffect` is false, so the
+        // guard raises EMPTY_MATERIALIZATION — telling the operator that nothing arrived and the embed
+        // stage is where to look, when everything arrived and was refused before the provider for a
+        // reason already logged per chunk. Re-ingesting cannot help: the chunks are the same size.
+        //
+        // This asserts only what the code must NOT say. Which code it SHOULD carry, and whether this
+        // case commits or fails, is the open decision on the ticket.
+        const
+            taskStateService = createInMemoryTaskStateService(),
+            repoSlug         = 'org/all-oversized';
+
+        await fs.writeJson(revisionsFile, {revisions: {}});
+        await provisionMirrorDir({tenantId: 't1', repoSlug});
+
+        const result = await TenantRepoSyncService.runTask({
+            reason           : 'manual',
+            taskStateService,
+            tenantReposConfig: {tenantRepos: [{
+                tenantId: 't1', repoSlug, mirrorRoot, cloneUrl: 'https://example.invalid/oversized.git'
+            }]},
+            gitMirror      : makeFakeGitMirror(),
+            envelopeBuilder: async args => ({
+                tenantId        : args.tenantId,
+                repoSlug        : args.repoSlug,
+                files           : [{path: 'huge.txt'}],
+                headRevision    : 'sha-oversized-head',
+                manifestSnapshot: {repoSlug: args.repoSlug, pathsAfterPush: ['huge.txt']}
+            }),
+            knowledgeBaseIngestionService: makeFakeIngestionService({
+                summaryFactory: () => ({ingested: 0, deleted: 0, skippedOversized: 1, errors: []})
+            }),
+            onlyRepoSlugs    : [repoSlug],
+            fullReplay       : true,
+            revisionsFilePath: revisionsFile
+        });
+
+        // Both halves. The negative alone would pass against any code at all, including one produced by
+        // an unrelated crash upstream of the guard.
+        expect(result.details.repos[0].lastErrorCode)
+            .not.toBe('KB_TENANT_REPO_SYNC_EMPTY_MATERIALIZATION');
+        expect(result.details.repos[0].lastErrorCode)
+            .toBe('KB_TENANT_REPO_SYNC_CONTENT_NOT_EMBEDDABLE');
+        // The code has to survive the persistence boundary, which is the entire reason it is a code
+        // rather than a field on the existing one.
+        expect(TENANT_REPO_SYNC_ERROR_CODES).toContain('KB_TENANT_REPO_SYNC_CONTENT_NOT_EMBEDDABLE');
     });
 
     test('delete-only full replay settles an unacknowledged receipt after checkpoint-write failure exactly once (#16045)', async () => {

--- a/test/playwright/unit/ai/services/knowledge-base/IngestionService.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/IngestionService.spec.mjs
@@ -20,6 +20,8 @@ import Neo            from '../../../../../../src/Neo.mjs';
 import * as core      from '../../../../../../src/core/_export.mjs';
 import fs             from 'fs-extra';
 import aiConfig       from '../../../../../../ai/mcp/server/knowledge-base/config.template.mjs';
+import {createTenantRepoMaterializationDigest}
+    from '../../../../../../ai/services/knowledge-base/helpers/tenantRepoIngestEnvelopeBuilder.mjs';
 
 /**
  * Contract coverage for IngestionService.
@@ -770,13 +772,49 @@ test.describe('IngestionService.ingestSourceFiles', () => {
         })).materializationReceipt).toBeNull();
     });
 
-    test('fresh zero-effect full attempts never manufacture a replay receipt (#16045)', async () => {
+    test('an authoritative empty manifest earns a current digest-bound receipt (#16577)', async () => {
+        const
+            attempt = {
+                attemptId            : 'c'.repeat(32),
+                ingestContractVersion: 2
+            },
+            envelope = {
+                tenantId        : 'tenant-a',
+                repoSlug        : 'repo-empty',
+                files           : [],
+                headRevision    : 'head-empty',
+                manifestSnapshot: {repoSlug: 'repo-empty', pathsAfterPush: []}
+            },
+            summary = await Service.ingestSourceFiles({
+                ...envelope,
+                materializationAttempt: attempt
+            }),
+            expectedDigest = createTenantRepoMaterializationDigest(envelope),
+            stored = await Service.getTenantManifest({
+                tenantId: 'tenant-a',
+                repoSlug: 'repo-empty'
+            });
+
+        expect(summary).toMatchObject({
+            ingested              : 0,
+            deleted               : 0,
+            errors                : [],
+            materializationReceipt: {
+                ...attempt,
+                envelopeDigest: expectedDigest,
+                recordedAt    : expect.any(Number)
+            }
+        });
+        expect(stored.materializationReceipt).toEqual(summary.materializationReceipt);
+    });
+
+    test('fresh zero-effect NON-EMPTY full attempts never manufacture a replay receipt (#16045)', async () => {
         const envelope = {
             tenantId        : 'tenant-a',
-            repoSlug        : 'repo-empty',
-            files           : [],
-            headRevision    : 'head-empty',
-            manifestSnapshot: {repoSlug: 'repo-empty', pathsAfterPush: []}
+            repoSlug        : 'repo-silent-drop',
+            files           : [{sourcePath: 'README.md', parsedChunks: []}],
+            headRevision    : 'head-silent-drop',
+            manifestSnapshot: {repoSlug: 'repo-silent-drop', pathsAfterPush: ['README.md']}
         };
 
         for (const attemptId of ['c'.repeat(32), 'd'.repeat(32)]) {
@@ -791,7 +829,7 @@ test.describe('IngestionService.ingestSourceFiles', () => {
 
         expect((await Service.getTenantManifest({
             tenantId: 'tenant-a',
-            repoSlug: 'repo-empty'
+            repoSlug: 'repo-silent-drop'
         })).materializationReceipt).toBeNull();
     });
 


### PR DESCRIPTION
Resolves neomjs/neo#16577
Related: neomjs/neo-agent-brain#64, neomjs/neo#16863, neomjs/neo#16045

Authored by @neo-opus-vega (Claude Opus 5, Claude Code) with the durable-proof repair authored by @neo-gpt-emmy under an operator-directed post-RC takeover. Origin Session ID: `4131135d-1b20-487f-9d23-d7213914246b`.

> **Body truth-folded at `4a6ac93bdf`.** The first revision described my orchestrator-only implementation, which @neo-gpt-emmy's `CHANGES_REQUESTED` correctly showed fixed the immediate call and left the loop armed. That approach is **retired, not merely amended**, and what follows describes the shipped one.

## The defect

**An empty tenant repo could never sync, and could never recover.** `IngestionService` mints a materialization receipt only on positive effect, so for `ingested: 0, deleted: 0` the `provesUncommittedRetry` escape needs a receipt that will never exist. The guard throws, the checkpoint never commits, `lastCommittedMaterializationAttemptId` is never recorded — and the escape can therefore never engage on any later attempt either. The population is **new tenant onboarding**.

**And a first fix is not enough, which is the part the review caught.** Returning `null` for an empty manifest made the immediate call report `completed` while persisting no committed attempt id. `classifyTenantRepoCheckpoint` then stays `FAILED` (because `lastAttemptedIngestContractVersion` is current), `requiresTenantRepoCheckpointRevalidation` is `true`, and **every later sweep replays from a null base.** The call status changed and the trap stayed armed — exactly what this ticket's AC-2 warns against.

Evidence: L1 structural + unit achieved (1,975 passed across `ai/daemons/orchestrator/` + `ai/services/knowledge-base/`, both sides mutation-convicted, invariant narrowed rather than deleted) → the plane receipt is annotated `[L3-deferred]` on neomjs/neo#16577.

## The shipped design: proof at the producer, admission at the consumer

**Producer** (`IngestionService.persistManifestSnapshot`) mints the ordinary digest-bound receipt for a zero-error attempt whose `pathsAfterPush` is empty. A source-observed empty manifest is a *completed* materialization rather than an effect-shaped one, and the envelope digest already binds that claim — it covers `pathsAfterPush` (empty) and `parserBindings` (empty) at this exact head. Ordered **after** prior-receipt preservation: a delete-only repo also has an empty manifest, and minting a fresh id on its retry would replace the receipt the consumer settles exactly once.

**Consumer** (`assertFullMaterializationEffect`) admits zero effect only under `!hasEffect && declaresNoContent && provesCurrentAttempt`, and returns the receipt so the caller persists it.

**Requiring BOTH facts is the safety property.** Either alone looks correct in review:

- `provesCurrentAttempt` alone lets **any** zero-effect run self-certify by echoing the current attempt id — the forgery `zero-effect full materialization cannot echo the current attempt as durable proof` exists to refuse.
- `declaresNoContent` alone is a consumer-side null-proof exception, trusting an absence it cannot verify.

Together, neither side admits a zero-effect claim on its own word.

## The neomjs/neo#16045 invariant was NARROWED, not deleted

`fresh zero-effect full attempts never manufacture a replay receipt` collided head-on with the repair: it asserted, on `pathsAfterPush: []` across two attempt ids, that no receipt is ever minted. It is now **`fresh zero-effect NON-EMPTY full attempts never manufacture a replay receipt (#16045)`**, with its envelope carrying a declared path and a file present.

So the invariant keeps its teeth **exactly where forgery is possible** — a declared-but-empty materialization still cannot self-certify — and loses them only on the shape that cannot forge anything. A new `#16577` test covers the empty-manifest subset positively, binding the receipt to `createTenantRepoMaterializationDigest(envelope)` rather than to a digest *shape*.

## A third case, found while verifying the second

`summary.ingested` counts **embeddable** chunks only; an oversized chunk increments `skippedOversized` instead. So a repo whose every chunk exceeds the safe band reported *"produced no durable positive-effect proof"* — telling an operator **nothing arrived, look at the embed stage**. Everything arrived, the embed stage never saw it, and re-ingesting cannot help. Now `KB_TENANT_REPO_SYNC_CONTENT_NOT_EMBEDDABLE`, still failing closed.

| # | `pathsAfterPush` | `ingested` | `skippedOversized` | before | after |
|---|---|---|---|---|---|
| 1 | **empty** | 0 | 0 | `EMPTY_MATERIALIZATION`, permanent backoff | **`completed` + durable `complete` checkpoint** |
| 2 | non-empty | 0 | 0 | `EMPTY_MATERIALIZATION` | **unchanged** — the guard's real job |
| 3 | non-empty | 0 | > 0 | `EMPTY_MATERIALIZATION` (wrong instruction) | `CONTENT_NOT_EMBEDDABLE`, still fails |

## Deltas

| file | delta |
|---|---|
| `IngestionService.mjs` | empty-manifest receipt arm, after prior-receipt preservation |
| `TenantRepoSyncService.mjs` | the both-facts admission; `CONTENT_NOT_EMBEDDABLE` throw; error-code table row; guard docblock |
| `TenantRepoSyncErrors.mjs` | `KB_TENANT_REPO_SYNC_CONTENT_NOT_EMBEDDABLE` + frozen-array entry (10 → 11) |
| `IngestionService.spec.mjs` | neomjs/neo#16045 narrowed to NON-EMPTY; new empty-manifest positive test |
| `TenantRepoSyncService.spec.mjs` | empty-repo durability + second sweep, positive control, oversized case; double mirrors the producer arm in the producer's order |

## Test Evidence

`UNIT_TEST_MODE=true npx playwright test --config=test/playwright/playwright.config.unit.mjs --workers=1`

→ **1,975 passed** across `ai/daemons/orchestrator/` + `ai/services/knowledge-base/` at `4a6ac93bdf`, run independently by the reviewer as well as the author.

**The durability property is asserted, not inferred:**

- `lastCommittedMaterializationAttemptId` equals the attempt id the ingest call actually received — not merely truthy;
- `classifyTenantRepoCheckpoint(record) === 'complete'` and `requiresTenantRepoCheckpointRevalidation === false`;
- a **second sweep** is handed `lastIngestedRev: 'sha-empty-head'` rather than `null`, which is the observable form of "the loop is disarmed".

**Mutation-convicted on both sides**, and the two sides need separate witnesses: the orchestrator spec uses a double that mirrors the producer, so it **passes with the real producer stashed** — the producer's own witness lives in `IngestionService.spec.mjs`. A control that stops at the double cannot convict the production arm.

## Post-Merge Validation

- [ ] On a plane with a tenant repo that has no ingestible paths, confirm the repo reaches `active` / `checkpointStatus: complete` and that a *subsequent* sweep does not replay from a null base. `[L3-deferred — needs a configured empty tenant repo]`

## Out of scope

- **A manual `fullReplay: true` on an *unchanged* empty repo**, which fails on the second run (`degraded`, `consecutiveFailures: 1`, checkpoint still `complete`) because a digest match returns the already-committed receipt so neither proof arm holds. Probed and evidenced in review; **not a regression** — the state was unreachable before this PR — and the permanent trap stays disarmed. Accepted as Approve+Follow-Up rather than a third review cycle on this lane.
- **Whether `CONTENT_NOT_EMBEDDABLE` should commit rather than fail.** The mislabelling is fixed either way; the disposition is a product judgement.
- **`pathsAfterPush` non-empty with `errors.length > 0` and zero effect.** Not traced; not guessed at in a guard.
- **The oversized threshold** and the chunking that produces it.
