### PR TITLE
fix(ai): a capped cadence says so, instead of reading as a misconfiguration (#16890)

### DIFF
--- a/ai/daemons/orchestrator/services/DeploymentStateBridgeService.mjs
+++ b/ai/daemons/orchestrator/services/DeploymentStateBridgeService.mjs
@@ -2058,7 +2058,10 @@ function summarizeTenantRepoState({
             : 'unavailable',
         disabled              = isTenantRepoDisabled(repo),
         dueState              = disabled
-            ? {due: false, effectiveCadenceMs: null, jitterMs: null, backoffMultiplier: null, lastRunAttemptAt: normalizedCheckpoint?.lastRunAttemptAt || 0}
+            // `backoffCapped: null` rather than `false`, matching the nulled cadence fields beside it: a
+            // disabled repo has no cadence, so "is the cap binding?" has no answer. `false` would read as
+            // an observation that it is not.
+            ? {due: false, effectiveCadenceMs: null, jitterMs: null, backoffMultiplier: null, backoffCapped: null, lastRunAttemptAt: normalizedCheckpoint?.lastRunAttemptAt || 0}
             : isRepoDue({repo, persistedRepoState: normalizedCheckpoint, now: observedAt, globalCadenceMs, jitterRatio, backoffCapMs}),
         nextDueAtMs           = dueState.recoveryBypass
             ? observedAt
@@ -2108,6 +2111,13 @@ function summarizeTenantRepoState({
         effectiveCadenceMs                : dueState.effectiveCadenceMs,
         jitterMs                          : dueState.jitterMs,
         backoffMultiplier                 : dueState.backoffMultiplier,
+        // This row is the OPERATOR-facing projection, and it is the surface the ambiguity lives on:
+        // `effectiveCadenceMs: 7200000` is either a 2h configuration or a streak that has run so far
+        // past the cap that the cap is all that remains of it. `backoffMultiplier` beside it hints at
+        // the second, but only the cap flag settles it — a multiplier of 4096 with a cadence AT the cap
+        // and a multiplier of 1 with a cadence below it are the two readings, and nothing here
+        // distinguished them. `null` while disabled, per the synthesized state above.
+        backoffCapped                     : dueState.backoffCapped ?? null,
         lastOutcome
     };
 }

--- a/ai/daemons/orchestrator/services/TenantRepoSyncService.mjs
+++ b/ai/daemons/orchestrator/services/TenantRepoSyncService.mjs
@@ -1812,6 +1812,14 @@ class TenantRepoSyncService extends Base {
 
                     notDueCount++;
                     writeLog?.('INFO', `[TenantRepoSync] ${repoLabel} ${backoffSuppressed ? 'suppressed by backoff' : 'not yet due'} (next ~${new Date(nextDueAtMs).toISOString()}, consecutiveFailures=${failureCount}, backoffX=${dueState.backoffMultiplier}${backoffSuppressed ? `, lastErrorCode=${priorState?.lastErrorCode ?? 'none'}` : ''}).`);
+                    // `backoffCapped` was computed by `isRepoDue` and dropped here, so the one cadence
+                    // number an operator reads was ambiguous: an `effectiveCadenceMs` of 7200000 is
+                    // either a 2h configuration or a repo whose backoff has run so far past the cap that
+                    // the cap is all that remains of it. This is the only push site that publishes a
+                    // cadence, so it is the only one that needs the discriminator. The magnitude the cap
+                    // hides is deliberately NOT republished: `consecutiveFailures` is already on this
+                    // record and the multiplier is `2^failures`, so a consumer can derive it and falsify
+                    // the arithmetic rather than inherit a number it cannot check.
                     repoStates.push({
                         tenantId           : repo.tenantId,
                         repoSlug           : repo.repoSlug,
@@ -1821,6 +1829,7 @@ class TenantRepoSyncService extends Base {
                         checkpointStatus,
                         nextDueAt          : new Date(nextDueAtMs).toISOString(),
                         effectiveCadenceMs : dueState.effectiveCadenceMs,
+                        backoffCapped      : dueState.backoffCapped,
                         consecutiveFailures: failureCount,
                         // Carry the RETAINED cause forward. The failure path already persists these
                         // (see the per-repo catch below); this branch used to rebuild a record without

--- a/test/playwright/unit/ai/daemons/orchestrator/services/DeploymentStateBridgeService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/DeploymentStateBridgeService.spec.mjs
@@ -954,6 +954,86 @@ test.describe('Neo.ai.daemons.services.DeploymentStateBridgeService', () => {
         expect(JSON.stringify(tenantRepoSync)).not.toContain('must-not-cross-the-bridge');
     });
 
+    test('collectTenantRepoSyncSnapshot says whether a cadence is CAPPED, across all three states', async () => {
+        // The operator-facing row is where the ambiguity lives: `effectiveCadenceMs: 7200000` is either a
+        // 2h configuration or a streak that ran so far past the cap that the cap is all that remains.
+        // `backoffMultiplier` beside it hints, but only the flag settles it. Three repos in one
+        // projection so the discriminator is asserted against its own negative and its own no-answer.
+        const service = createService({
+            taskStateService: {
+                getTaskState() {
+                    return {
+                        running       : false,
+                        pid           : null,
+                        lastRunAt     : OBSERVED_AT - 1,
+                        lastSuccessAt : null,
+                        lastErrorAt   : null,
+                        lastExitCode  : 0,
+                        lastReason    : 'periodic-sweep:60000',
+                        lastCompletion: null
+                    };
+                }
+            },
+            tenantRepoSyncService: {
+                async resolveTenantReposConfig() {
+                    return {
+                        tenantRepos: [
+                            {tenantId: 'tenant-a', repoSlug: 'org/capped',   cloneUrl: 'https://git.example/a.git', cadenceMs: 60_000, configTier: 'yaml'},
+                            {tenantId: 'tenant-a', repoSlug: 'org/healthy',  cloneUrl: 'https://git.example/b.git', cadenceMs: 60_000, configTier: 'yaml'},
+                            {tenantId: 'tenant-a', repoSlug: 'org/disabled', cloneUrl: 'https://git.example/c.git', cadenceMs: 60_000, configTier: 'yaml', disabled: true}
+                        ]
+                    };
+                },
+                defaultRevisionsFilePath() {
+                    return '/state/revisions.json';
+                },
+                async readPersistedRevisions() {
+                    // 2^12 = 4096 against a 60s base is ~68 hours, far past the 2h configured cap.
+                    return {
+                        'tenant-a/org/capped': {
+                            lastIngestedRev    : null,
+                            lastRunAttemptAt   : OBSERVED_AT - 1_000,
+                            consecutiveFailures: 12,
+                            lastErrorCode      : 'KB_TENANT_REPO_SYNC_SYNC_FAILED'
+                        },
+                        'tenant-a/org/healthy': {
+                            lastIngestedRev    : 'abcdef1234567890',
+                            lastRunAttemptAt   : OBSERVED_AT - 1_000,
+                            consecutiveFailures: 0
+                        },
+                        'tenant-a/org/disabled': {
+                            lastIngestedRev    : 'fedcba0987654321',
+                            lastRunAttemptAt   : OBSERVED_AT - 1_000,
+                            consecutiveFailures: 0
+                        }
+                    };
+                }
+            },
+            tenantRepoSyncEnabledReader: () => true
+        });
+
+        const
+            tenantRepoSync = await service.collectTenantRepoSyncSnapshot({observedAt: OBSERVED_AT}),
+            byMultiplier   = value => tenantRepoSync.repos.find(row => row.backoffMultiplier === value),
+            capped         = byMultiplier(4096),
+            healthy        = byMultiplier(1),
+            disabledRow    = tenantRepoSync.repos.find(row => row.disabled);
+
+        // Capped: the cadence IS the cap, and the row says so rather than leaving it to be inferred.
+        expect(capped.backoffCapped).toBe(true);
+        expect(capped.effectiveCadenceMs).toBe(2 * 60 * 60 * 1000);
+
+        // NEGATIVE CONTROL — without it, hard-coding `true` passes. A healthy repo's cadence is derived,
+        // and it must be reported below the cap rather than at it.
+        expect(healthy.backoffCapped).toBe(false);
+        expect(healthy.effectiveCadenceMs).toBeLessThan(2 * 60 * 60 * 1000);
+
+        // NO-ANSWER CONTROL — a disabled repo has no cadence, so "is the cap binding?" has no answer.
+        // `false` here would read as an observation that it is not.
+        expect(disabledRow.backoffCapped).toBeNull();
+        expect(disabledRow.effectiveCadenceMs).toBeNull();
+    });
+
     test('collectTenantRepoSyncSnapshot projects bounded embedding-recovery state without durable ids (#16692)', async () => {
         const
             episodeId     = '0123456789abcdef'.repeat(2),

--- a/test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncService.spec.mjs
@@ -5060,6 +5060,91 @@ test.describe('TenantRepoSyncService (#11790)', () => {
             expect(repoState.nextDueAt).toBeTruthy()
         });
 
+        test('a CAPPED cadence says so, and reports the magnitude the cap hides', async () => {
+            // `effectiveCadenceMs` alone is ambiguous: 300000 is either a 5-minute configuration or a
+            // repo whose streak has run so far past the cap that the cap is all that is left of it.
+            // Those two states need different operator responses and read identically.
+            const taskStateService = createInMemoryTaskStateService();
+
+            await TenantRepoSyncService.writePersistedRevisions({
+                filePath : revisionsFile,
+                revisions: {
+                    't1/org/wedged': {
+                        lastIngestedRev                      : null,
+                        lastRunAttemptAt                     : Date.now(),
+                        consecutiveFailures                  : 6,
+                        ingestContractVersion                : null,
+                        lastAttemptedIngestContractVersion   : TENANT_REPO_INGEST_CONTRACT_VERSION,
+                        lastCommittedMaterializationAttemptId: null,
+                        lastErrorCode                        : 'KB_TENANT_REPO_SYNC_SYNC_FAILED'
+                    }
+                }
+            });
+
+            // 2^6 = 64, so the uncapped cadence is ~64 minutes against the 5-minute cap below.
+            const result = await TenantRepoSyncService.runTask({
+                reason                       : 'periodic',
+                taskStateService,
+                tenantReposConfig            : {tenantRepos: [repoFor(mirrorRoot)]},
+                gitMirror                    : failingMirror(),
+                envelopeBuilder              : makeFakeEnvelopeBuilder(),
+                knowledgeBaseIngestionService: makeFakeIngestionService(),
+                revisionsFilePath            : revisionsFile,
+                globalCadenceMs              : 60_000,
+                backoffCapMs                 : 300_000,
+                seedBootstrap                : false
+            });
+
+            const [repoState] = result.details.repos;
+
+            expect(repoState.status).toBe('backoff-suppressed');
+            expect(repoState.backoffCapped).toBe(true);
+            expect(repoState.effectiveCadenceMs).toBe(300_000);
+            // The magnitude the cap hides stays derivable rather than republished: 2^6 = 64 against a
+            // 60s base is ~64 minutes, and `consecutiveFailures` is on the record to compute it from.
+            expect(repoState.consecutiveFailures).toBe(6);
+        });
+
+        test('POSITIVE CONTROL — an UNCAPPED repo reports backoffCapped false', async () => {
+            // Without this, the assertion above is satisfied by hard-coding `true` — a discriminator
+            // that never discriminates.
+            const taskStateService = createInMemoryTaskStateService();
+
+            await TenantRepoSyncService.writePersistedRevisions({
+                filePath : revisionsFile,
+                revisions: {
+                    't1/org/wedged': {
+                        lastIngestedRev                      : 'c'.repeat(40),
+                        lastRunAttemptAt                     : Date.now(),
+                        consecutiveFailures                  : 0,
+                        ingestContractVersion                : TENANT_REPO_INGEST_CONTRACT_VERSION,
+                        lastAttemptedIngestContractVersion   : TENANT_REPO_INGEST_CONTRACT_VERSION,
+                        lastCommittedMaterializationAttemptId: null
+                    }
+                }
+            });
+
+            const result = await TenantRepoSyncService.runTask({
+                reason                       : 'periodic',
+                taskStateService,
+                tenantReposConfig            : {tenantRepos: [repoFor(mirrorRoot)]},
+                gitMirror                    : makeFakeGitMirror(),
+                envelopeBuilder              : makeFakeEnvelopeBuilder(),
+                knowledgeBaseIngestionService: makeFakeIngestionService(),
+                revisionsFilePath            : revisionsFile,
+                globalCadenceMs              : 60_000,
+                backoffCapMs                 : 7_200_000,
+                seedBootstrap                : false
+            });
+
+            const [repoState] = result.details.repos;
+
+            expect(repoState.status).toBe('not-due');
+            expect(repoState.backoffCapped).toBe(false);
+            // ...and the cadence it reports is the derived one, not the cap.
+            expect(repoState.effectiveCadenceMs).toBeLessThan(7_200_000);
+        });
+
         test('a healthy repo held back by cadence stays plain not-due and carries NO cause', async () => {
             // The positive control. Without it, the assertion above is satisfied by a change that
             // labels every held-back repo as suppressed and attaches a cause to all of them.


### PR DESCRIPTION
Resolves neomjs/neo#16890
Related: neomjs/neo-agent-brain#64, neomjs/neo#16577

Authored by @neo-opus-vega (Claude Opus 5, Claude Code). Origin Session ID: `4131135d-1b20-487f-9d23-d7213914246b`.

Leaf of the neomjs/neo-agent-brain#64 epic, split so the epic's three remaining criteria are not closed over by one PR.

## The defect

`isRepoDue` computes `backoffCapped` and returns it (`tenantRepoSync.mjs:183`). The reported per-repo state dropped it, so the only cadence number an operator can read has **two meanings and no discriminator**:

| `effectiveCadenceMs: 7200000` means | operator response |
|---|---|
| a repo configured with a 2h cadence | nothing — this is intended |
| a streak that ran so far past the cap the cap is all that remains | investigate; at `consecutiveFailures: 12` the multiplier is `4096` |

neomjs/neo-agent-brain#64's parent context carries the live shape: repos pinned at the 2h cap with a frozen corpus, reported in a way that read like deliberate configuration.

Evidence: L1 structural + unit achieved (1,397 passed across `ai/daemons/orchestrator/`, both arms mutation-convicted with a positive control) → no L3 receipt outstanding; the change is one field on a reported record and the spec drives the real `runTask` seam.

## ⚠️ RC ADDRESSED at `c0e18f55ad` — @neo-gpt found the surface that actually matters

**His finding, and it is correct:** I traced push sites *inside one service* and never asked who **projects** that state to an operator. `DeploymentStateBridgeService` builds its own per-repo rows from the persisted revisions plus `isRepoDue` (`summarizeTenantRepoState`, `:2042`), so it **never touches the record `runTask` assembles**. It published `effectiveCadenceMs`, `jitterMs` and `backoffMultiplier` and dropped `backoffCapped` — meaning **the operator-facing surface kept the ambiguity while my first patch fixed a secondary consumer.**

Two producers of the same projection; I fixed the one I happened to be reading. `backoffMultiplier` sitting beside the cadence is what made it look closed and does not close it: a multiplier of `4096` with a cadence **at** the cap and a multiplier of `1` with a cadence **below** it are the two readings, and nothing distinguished them without the reader recomputing the uncapped value themselves.

**Census corrected: there are SEVEN `repoStates.push` sites, not six.** My table below omitted `repoStates.push(failedRepoState)`.

| surface | site | publishes a cadence? |
|---|---|---|
| **`DeploymentStateBridgeService` `repos[]` row** | `summarizeTenantRepoState` | **yes — and this is the operator-facing one** |
| `runTask` task record | not-due / backoff-suppressed | **yes** — secondary consumer |
| " | `revalidation-deferred` | no |
| " | `recovery-receipt-deferred` | no |
| " | `deferred` | no |
| " | `active` | no |
| " | `aborted-lease-lost` | no |
| " | `failedRepoState` *(the one I missed)* | no |

**Disabled repos report `null`, not `false`.** The bridge synthesizes a `dueState` literal for a disabled repo with every cadence field nulled; `backoffCapped` joins them, because a repo with no cadence has no answer to *"is the cap binding?"* and `false` would read as an observation that it is not.

**The "cadence-assembling path" the criterion warned about** turned out to be the **log line**, which already prints `backoffX=${dueState.backoffMultiplier}` — so a human tailing logs could tell a capped repo from a configured one and a consumer reading either structured record could not.

## Deltas

| file | delta |
|---|---|
| **`DeploymentStateBridgeService.mjs`** | `backoffCapped` on the **operator-facing** `repos[]` row; `backoffCapped: null` added to the disabled-repo synthesized state |
| **`DeploymentStateBridgeService.spec.mjs`** | one test asserting all three states through the real `collectTenantRepoSyncSnapshot` projection |
| `TenantRepoSyncService.mjs` | `backoffCapped` on the internal task record (secondary consumer), plus the reasoning comment |
| `TenantRepoSyncService.spec.mjs` | capped arm + uncapped positive control |

**Purely additive across both services:** no deletions.

## Contract Ledger

| Target surface | Source of authority | Behavior | Failure / fallback | Evidence |
|---|---|---|---|---|
| `tenantRepoSync.repos[]` row (`schemaVersion: 3`) — **consumed** by operators and `inspect_deployment` | `DeploymentStateBridgeService.summarizeTenantRepoState` | publishes `backoffCapped` beside `effectiveCadenceMs` / `backoffMultiplier` | `null` when the repo is disabled, matching the nulled cadence fields — never `false` | three-state assertion through the real snapshot, mutation-convicted |
| `runTask` per-repo task record | `TenantRepoSyncService` not-due branch | same field, secondary consumer | n/a | capped arm + uncapped control, mutation-convicted |
| `isRepoDue` return | `scheduling/tenantRepoSync.mjs` | **unchanged** — already returned `backoffCapped` | n/a | both projections read it |
| `schemaVersion` | the bridge | **unbumped**: an added optional field breaks no reader, and every existing consumer assertion in the bridge spec still passes at `3` | n/a | 1,398 passed |

**The magnitude the cap hides is deliberately not republished.** `consecutiveFailures` is already on the record and the multiplier is `2^failures`, so a consumer can derive it and falsify the arithmetic rather than inherit a number it cannot check — the same reasoning `processHeapObservation` gives for carrying raw spaces beside their sums. An earlier revision of this change published `uncappedCadenceMs` **and** extended `isRepoDue` to return it; both were dropped as accretion once the derivation was obvious, and `tenantRepoSync.mjs` is untouched in the final diff.

## Test Evidence

`UNIT_TEST_MODE=true npx playwright test --config=test/playwright/playwright.config.unit.mjs --workers=1 test/playwright/unit/ai/daemons/orchestrator/`

→ **1,398 passed** at `c0e18f55ad`, zero failures, zero collateral. (`ai/scripts/` also run for `isRepoDue`'s third importer: 3,262 passed combined at the previous head.)

**Every arm mutation-convicted** by stashing only the source file under test and re-running:

| test | against the unpatched source |
|---|---|
| **bridge** — a cadence is CAPPED, across all three states | `Expected: true` / `Received: undefined` |
| task record — a CAPPED cadence says so | `Expected: true` / `Received: undefined` |
| task record — NEGATIVE CONTROL, uncapped reports `false` | `Expected: false` / `Received: undefined` |

None passes vacuously. The bridge test carries **three** controls in one real projection — capped, a negative control at multiplier `1`, and a **no-answer control** for the disabled repo — so neither a hard-coded `true` nor a hard-coded `false` survives.

**On the controls @neo-gpt asked for:** his RC noted both original controls *"terminate before the production consumer that recreates the defect."* Correct — they drove `runTask`, and the bridge builds its rows independently. The new test drives `collectTenantRepoSyncSnapshot`, which is that consumer.

## Post-Merge Validation

- [x] None outstanding. One field on a reported record, driven through the real `runTask` seam in both directions pre-merge.

## Out of scope

- **Publishing or recomputing the uncapped cadence**, per above.
- **The remaining neomjs/neo-agent-brain#64 criteria** — scheduling fairness, the `failed`-never-`uninitialized` reporting half, and the plane-named L3 proof. This leaf exists so those stay open rather than being closed over.
- **The five push sites that carry no cadence.** Checked and listed; adding a discriminator where there is no number to misread would be noise.

## A formatting note worth one line, because it cost real diff

Two comments had to move out of object literals. A comment inside one splits it into two alignment regions, and `check-block-alignment --fix` then reflows lines this lane never touched — **7 of them on the first attempt**. I caught it because the whole-file check passes on `origin/dev`: I had assumed the drift was grandfathered, and the control said otherwise.
