### PR TITLE
feat(agent-os): a deferral streak survives the process that measured it (#16903)

### DIFF
--- a/ai/daemons/orchestrator/services/MaintenanceBackpressureService.mjs
+++ b/ai/daemons/orchestrator/services/MaintenanceBackpressureService.mjs
@@ -232,6 +232,7 @@ export function clearDeferralLogState({deferralLogKeys, deferralStreakStarts, ta
  * @param {Object} [options.taskDefinitions={}] Task-definition map for label resolution.
  * @param {Function} [options.writeLog=()=>{}] Logger function `(level, message) => void`.
  * @param {Object|null} [options.healthService=null] Optional `recordTaskOutcome(name, status, payload)` sink.
+ * @param {Object|null} [options.taskStateService=null] Optional `markDeferred(name, deferredAt)` sink owning the DURABLE streak. Absent means in-memory only, which resets on restart.
  * @returns {void}
  */
 export function recordDeferral({
@@ -244,7 +245,8 @@ export function recordDeferral({
     holdingLease     = null,
     taskDefinitions  = {},
     writeLog         = () => {},
-    healthService    = null
+    healthService    = null,
+    taskStateService = null
 }) {
     const isLeaseHeld = reasonCode === 'heavy-maintenance-lease-held';
     const holderOwner = holdingLease?.owner || 'unknown';
@@ -293,9 +295,16 @@ export function recordDeferral({
         deferredAt: new Date().toISOString()
     };
 
-    // Absent map (direct pure-function callers that pass no streak state) reports no streak rather
-    // than a falsely-fresh one — an unmeasured streak must not read as a just-started one.
-    const deferredSince = deferralStreakStarts?.get(taskName);
+    // **The durable streak wins over the in-memory one, and that ordering is the point.** The map lives on
+    // this instance, so it resets on every daemon restart — a starvation that spans a restart reported a
+    // FRESH streak, and a threshold measured from a value that resets can never be crossed. The persisted
+    // envelope answers "how long has this task been unable to run" across the process that observed it.
+    //
+    // Absent both (direct pure-function callers that pass neither) reports no streak rather than a
+    // falsely-fresh one — an unmeasured streak must not read as a just-started one.
+    const durableSince  = taskStateService?.markDeferred?.(taskName, outcomePayload.deferredAt),
+          deferredSince = durableSince || deferralStreakStarts?.get(taskName);
+
     if (deferredSince) {
         outcomePayload.deferredSince = deferredSince;
     }
@@ -575,7 +584,8 @@ export class MaintenanceBackpressureService extends Base {
             holdingLease,
             taskDefinitions     : this.taskDefinitions,
             writeLog            : this.writeLog,
-            healthService       : this.healthService
+            healthService       : this.healthService,
+            taskStateService    : this.taskStateService
         });
     }
 

--- a/ai/daemons/orchestrator/services/TaskStateService.mjs
+++ b/ai/daemons/orchestrator/services/TaskStateService.mjs
@@ -18,7 +18,14 @@ export function createInitialTaskState(taskDefinitions) {
             lastReason            : null,
             lastCompletion        : null,
             failureStreakStartedAt: null,
-            interruptedAt         : null
+            // The sibling of `failureStreakStartedAt`, for the opposite condition: a task that keeps
+            // being DEFERRED rather than keeps failing. Durable because the question it answers — how
+            // long has this task been unable to run — outlives the process that measured it, and the
+            // in-memory streak map it shadows resets on every restart. A starvation that spans a daemon
+            // restart reported a fresh streak, which is how an 8.5-hour priority-0 starvation stayed
+            // invisible while every sweep read healthy.
+            deferralStreakStartedAt: null,
+            interruptedAt          : null
         };
         return state;
     }, {});
@@ -49,6 +56,32 @@ export function createInitialTaskState(taskDefinitions) {
 export function openFailureStreak(state, timestamp) {
     state.lastErrorAt             = timestamp;
     state.failureStreakStartedAt ??= timestamp;
+}
+
+/**
+ * @summary Opens a task's deferral streak once, at the first deferral after it last ran.
+ *
+ * The deliberate mirror of {@link openFailureStreak}, for the condition that lane never covers: a task
+ * that is repeatedly **deferred** rather than repeatedly failing. A deferred task records no failure, so
+ * `failureStreakStartedAt` stays null and every sweep reads healthy while the task never runs — which is
+ * the shape of an 8.5-hour priority-0 starvation nobody saw.
+ *
+ * **`??=` is the whole contract, for the same reason it is in the failure sibling.** The streak marks
+ * when the task last became unable to run and must not move while it stays that way. A field that
+ * advanced with each deferral would make the elapsed window reset on every poll, so a starvation
+ * threshold measured from it could never be crossed — an alarm that is structurally unreachable is
+ * worse than none, because the absence of it reads as evidence of health.
+ *
+ * Closed by {@link TaskStateService#markStarted}: a task that starts is, by definition, no longer
+ * deferred. That is the single close point, and it already exists as the universal "this task is running
+ * now" writer — so no second opinion about what ends a streak can drift in.
+ *
+ * @param {Object} state A single task's state envelope, mutated in place.
+ * @param {String} timestamp ISO timestamp of the deferral.
+ * @returns {void}
+ */
+export function openDeferralStreak(state, timestamp) {
+    state.deferralStreakStartedAt ??= timestamp;
 }
 
 /**
@@ -229,6 +262,12 @@ export class TaskStateService extends Base {
         state.running    = true;
         state.lastRunAt  = Date.now();
         state.lastReason = reason;
+        // A task that starts is no longer deferred, so this is where the streak closes — and it closes
+        // here rather than anywhere else because this is already the universal "this task is running now"
+        // writer. Clearing it at the deferral site instead would need every future deferral path to
+        // remember to, which is the second-opinion drift `openFailureStreak`'s docblock records paying
+        // for once already.
+        state.deferralStreakStartedAt = null;
         this.writeState();
     }
 
@@ -304,6 +343,32 @@ export class TaskStateService extends Base {
         state.lastExitCode = null;
         state.lastCompletion = lastCompletion;
         this.writeState();
+    }
+
+    /**
+     * @summary Records that a task was DEFERRED, opening its durable deferral streak.
+     *
+     * Separate from {@link TaskStateService#markSkipped} because a skip and a deferral are different
+     * facts: a skip can mean *nothing to do* — a repo already current, an empty queue — and a task that
+     * is idle for lack of work is not starved. Hanging the streak off every skip would make an idle lane
+     * indistinguishable from a blocked one, which is the conflation this measurement exists to end.
+     *
+     * Writes only the streak. The deferral's own reporting stays with the recorder that owns it; this is
+     * the durable half, so the answer survives the process that observed it.
+     *
+     * @param {String} taskName
+     * @param {String} [deferredAt=new Date().toISOString()] ISO timestamp of THIS deferral.
+     * @returns {String|null} The streak start after the write — the first deferral's timestamp, not this one.
+     */
+    markDeferred(taskName, deferredAt = new Date().toISOString()) {
+        const state = this.taskState[taskName];
+
+        if (!state) return null;
+
+        openDeferralStreak(state, deferredAt);
+        this.writeState();
+
+        return state.deferralStreakStartedAt;
     }
 
     /**

--- a/test/playwright/unit/ai/daemons/orchestrator/services/MaintenanceBackpressureService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/MaintenanceBackpressureService.spec.mjs
@@ -243,6 +243,81 @@ test.describe('Neo.ai.daemons.orchestrator.services.MaintenanceBackpressureServi
         expect([...deferralLogKeys]).toEqual(['kbSync:summary:r3']);
     });
 
+    test('PRODUCTION SEAM — a real deferral reaches taskStateService.markDeferred and prefers its durable value', () => {
+        // **The binding, not the helper.** `TaskStateService`'s own specs convict the durable field; they
+        // cannot prove that anything in production ever writes it. This drives the CLASS method — the one
+        // `acquireLeaseAndExecute` actually calls — so a wiring regression that leaves `taskStateService`
+        // unpassed fails here rather than shipping a field nobody populates.
+        //
+        // The durable value must also WIN over the in-memory streak map, which is the whole point: the map
+        // resets on restart, and a threshold measured from a resetting value can never be crossed. The two
+        // are given deliberately different timestamps so a fallback-order regression is visible rather
+        // than masked by them agreeing.
+        const
+            deferredCalls        = [],
+            outcomeCalls         = [],
+            durableSince         = '2026-08-10T09:00:00.000Z',
+            staleInMemorySince   = '2026-08-10T15:00:00.000Z',
+            deferralStreakStarts = new Map([['kbSync', staleInMemorySince]]),
+            service              = buildService({
+                deferralStreakStarts,
+                healthService: {
+                    recordTaskOutcome(taskName, status, payload) {
+                        outcomeCalls.push({taskName, status, payload});
+                    }
+                },
+                taskStateService: {
+                    markDeferred(taskName, deferredAt) {
+                        deferredCalls.push({taskName, deferredAt});
+                        return durableSince;
+                    }
+                }
+            });
+
+        service.recordDeferral({
+            taskName        : 'kbSync',
+            reasonCode      : 'heavy-maintenance-backpressure',
+            reasonText      : 'periodic-sync:1800000',
+            blockingTaskName: 'summary'
+        });
+
+        // The production writer reached the durable sink at all — the binding this test exists for.
+        expect(deferredCalls).toHaveLength(1);
+        expect(deferredCalls[0].taskName).toBe('kbSync');
+        expect(deferredCalls[0].deferredAt).toEqual(expect.any(String));
+
+        // ...and the published streak is the DURABLE one, not the stale in-memory entry.
+        expect(outcomeCalls[0].payload.deferredSince).toBe(durableSince);
+        expect(outcomeCalls[0].payload.deferredSince).not.toBe(staleInMemorySince);
+    });
+
+    test('PRODUCTION SEAM control — with NO task-state sink the in-memory streak is still reported', () => {
+        // Non-vacuity for the arm above. Without this, a regression that ignored the durable value
+        // entirely — or one that dropped `deferredSince` altogether — could pass by never being exercised
+        // against the fallback path direct pure-function callers still rely on.
+        const
+            outcomeCalls         = [],
+            inMemorySince        = '2026-08-10T15:00:00.000Z',
+            deferralStreakStarts = new Map([['kbSync', inMemorySince]]),
+            service              = buildService({
+                deferralStreakStarts,
+                healthService: {
+                    recordTaskOutcome(taskName, status, payload) {
+                        outcomeCalls.push({taskName, status, payload});
+                    }
+                }
+            });
+
+        service.recordDeferral({
+            taskName        : 'kbSync',
+            reasonCode      : 'heavy-maintenance-backpressure',
+            reasonText      : 'periodic-sync:1800000',
+            blockingTaskName: 'summary'
+        });
+
+        expect(outcomeCalls[0].payload.deferredSince).toBe(inMemorySince);
+    });
+
     test('recordDeferral (intra-process heavy backpressure) dedupes + emits skipped outcome', () => {
         const deferralLogKeys = new Set();
         const logCalls        = [];

--- a/test/playwright/unit/ai/daemons/orchestrator/services/TaskStateService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/TaskStateService.spec.mjs
@@ -221,6 +221,66 @@ test.describe('Neo.ai.daemons.services.TaskStateService', () => {
         expect(JSON.parse(fs.readFileSync(stateFile, 'utf8')).mockTask.failureStreakStartedAt).toBe(opened);
     });
 
+    test('deferralStreakStartedAt opens at the first deferral and never slides (#16561)', async () => {
+        // The mirror of the failure-streak contract, for the condition that lane never covers: a task
+        // repeatedly DEFERRED records no failure, so `failureStreakStartedAt` stays null and every sweep
+        // reads healthy while the task never runs.
+        const {service, stateFile} = createTestService();
+
+        const opened = service.markDeferred('mockTask');
+        expect(opened).toBeTruthy();
+
+        await new Promise(resolve => setTimeout(resolve, 5));
+
+        const later = new Date().toISOString();
+        expect(later).not.toBe(opened);   // the control: time DID advance between the two deferrals
+
+        expect(service.markDeferred('mockTask', later)).toBe(opened);
+        expect(service.getTaskState('mockTask').deferralStreakStartedAt).toBe(opened);
+
+        // Durable, because the question outlives the process that measured it.
+        expect(JSON.parse(fs.readFileSync(stateFile, 'utf8')).mockTask.deferralStreakStartedAt).toBe(opened);
+    });
+
+    test('the deferral streak SURVIVES a restart — which is the whole reason it is durable (#16561)', () => {
+        // An in-memory streak map resets when the daemon restarts, so a starvation spanning a restart
+        // reported a FRESH streak — and a threshold measured from a value that resets can never be
+        // crossed. This is the property that makes the measurement worth having.
+        const {service, stateFile} = createTestService();
+        const opened               = service.markDeferred('mockTask');
+
+        const reborn = Neo.create(TaskStateService, {
+            stateFile,
+            taskDefinitions: {mockTask: {name: 'mockTask', scriptPath: '/mock/script.mjs'}},
+            writeLogFn     : () => {}
+        });
+
+        reborn.configure({
+            stateFile,
+            taskDefinitions: {mockTask: {name: 'mockTask', scriptPath: '/mock/script.mjs'}},
+            writeLogFn     : () => {}
+        });
+
+        expect(reborn.readState().mockTask.deferralStreakStartedAt).toBe(opened);
+    });
+
+    test('NEGATIVE DIRECTION — a task that RUNS reports no deferral streak (#16561)', () => {
+        // The other half of the both-directions requirement. Without it, an implementation that never
+        // clears the streak passes the assertions above and reports every task as starved forever — an
+        // always-alarm is as useless as no alarm, and harder to notice because it looks like coverage.
+        const {service} = createTestService();
+
+        service.markDeferred('mockTask');
+        expect(service.getTaskState('mockTask').deferralStreakStartedAt).toBeTruthy();
+
+        service.markStarted('mockTask', 'periodic');
+        expect(service.getTaskState('mockTask').deferralStreakStartedAt).toBeNull();
+
+        // ...and a deferral AFTER a run opens a fresh streak rather than resurrecting the old one.
+        const reopened = service.markDeferred('mockTask');
+        expect(reopened).toBeTruthy();
+    });
+
     test('a success closes the streak and clears the interruption marker (#16348)', () => {
         const {service} = createTestService();
 

--- a/test/playwright/unit/ai/daemons/orchestrator/services/TaskStateService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/TaskStateService.spec.mjs
@@ -264,6 +264,36 @@ test.describe('Neo.ai.daemons.services.TaskStateService', () => {
         expect(reborn.readState().mockTask.deferralStreakStartedAt).toBe(opened);
     });
 
+    test('a LEGACY state file with no deferral field reads null, not undefined (#16561)', () => {
+        // The migration path, asserted rather than assumed: every persisted state file written before
+        // this field existed lacks the key. `readState` spreads the fallback FIRST and the persisted data
+        // over it, so the initial-envelope `null` survives for a key the file does not carry. Reversing
+        // that spread order would yield `undefined`, and `undefined` is the value a threshold comparison
+        // silently mishandles — `undefined > x` is false, so a legacy repo would read as never-deferred
+        // rather than as unmeasured.
+        const {service, stateFile} = createTestService();
+
+        fs.writeJsonSync(stateFile, {
+            mockTask: {
+                running       : false,
+                pid           : null,
+                lastRunAt     : 0,
+                lastSuccessAt : null,
+                lastErrorAt   : null,
+                lastExitCode  : null,
+                lastReason    : null,
+                lastCompletion: null
+            }
+        });
+
+        const migrated = service.readState().mockTask;
+
+        expect(migrated.deferralStreakStartedAt).toBeNull();
+        expect('deferralStreakStartedAt' in migrated).toBe(true);
+        // ...and the field is writable from that state, so a legacy task is not stuck unmeasurable.
+        expect(service.markDeferred('mockTask')).toBeTruthy();
+    });
+
     test('NEGATIVE DIRECTION — a task that RUNS reports no deferral streak (#16561)', () => {
         // The other half of the both-directions requirement. Without it, an implementation that never
         // clears the streak passes the assertions above and reports every task as starved forever — an


### PR DESCRIPTION
Resolves neomjs/neo#16903
Related: neomjs/neo#16561, neomjs/neo#16904, neomjs/neo-agent-brain#64, neomjs/neo-agent-brain#73, neomjs/neo#16348

Authored by @neo-opus-vega (Claude Opus 5, Claude Code). Origin Session ID: `4131135d-1b20-487f-9d23-d7213914246b`.

Option **(c)** from this ticket's own OQ1 — signal only. The heavy-maintenance lease is untouched, and so is `PRIORITY_ZERO_TASKS`: selection was already correct and the hypothesis that it was wrong is falsified in the ticket body. Sizing a fairness policy from three observed holds would repeat what neomjs/neo-agent-brain#73 documented — a threshold derived from observations taken while the system was misbehaving.

## The defect

An 8.5-hour priority-0 backup starvation reported `healthy` on every sweep. **A deferred task records no failure**, so `failureStreakStartedAt` stays `null` and nothing in the health model has anything to look at.

Half the measurement already shipped and I did not rebuild it: `recordDeferral` seeds a streak on a task's first deferral, keeps it across a **change of blocker** (the consumer asks how long *this task* has been unable to run, not who most recently prevented it), and publishes `deferredSince` onto the `skipped` outcome.

**Two gaps were real, and both were confirmed by absence with a positive control on the search.**

Evidence: L1 structural + L2 unit achieved (1,430 passed across `ai/daemons/orchestrator/`, three tests mutation-convicted including the negative direction). The L3 live-restart receipt remains explicitly deferred below; the health-surface threshold is a separate slice and is not claimed here.

**Gap 1 — the streak was process-local.** `deferralStreakStarts = new Map()` is an instance field, and grepping every `load` / `read` / `hydrate` / `persist` reference to it under `ai/` returns nothing. **A daemon restart reset it**, so a starvation spanning a restart reported a *fresh* streak — and a threshold measured from a value that resets can never be crossed. An alarm that is structurally unreachable is worse than none, because its silence reads as evidence of health.

**Gap 2 — `deferredSince` is written and never read.** Four references, all inside `MaintenanceBackpressureService.mjs`, all on the producing side.

**The positive control that makes those absences results rather than broken instruments:** grepping the same shape for `deferredAt` finds cross-file consumers at `pipeline.mjs:894`, where the REM watchdog already keys on it. So the instrument does find consumers when they exist.

## The fix

The durable half lands as the **deliberate mirror of `failureStreakStartedAt`** — same envelope, same `??=`, same stated reason, one function below it:

```js
export function openDeferralStreak(state, timestamp) {
    state.deferralStreakStartedAt ??= timestamp;
}
```

**`??=` is the whole contract**, exactly as its sibling's docblock records: the anchor marks when the task became unable to run and must not move while it stays that way. A field that advanced with each deferral would reset the elapsed window on every poll, so a starvation threshold measured from it could never be crossed.

- **`markDeferred` is separate from `markSkipped`.** A skip can mean *nothing to do* — an empty queue, a repo already current — and a task idle for lack of work is not starved. Hanging the streak off every skip would make an idle lane indistinguishable from a blocked one, which is the conflation the measurement exists to end.
- **`markStarted` is the single close point.** A task that starts is by definition no longer deferred, and that writer already exists as the universal *this task is running now* mutation. Clearing at each deferral site instead would need every future deferral path to remember to — the second-opinion drift `openFailureStreak`'s own docblock records paying for once.
- **The durable value wins over the in-memory map** wherever both exist; the map stays as the fallback for direct pure-function callers, which report *no* streak rather than a falsely-fresh one.

## Deltas

| file | delta |
|---|---|
| `TaskStateService.mjs` | `deferralStreakStartedAt` on the persisted envelope; `openDeferralStreak`; `markDeferred`; `markStarted` closes the streak |
| `MaintenanceBackpressureService.mjs` | `recordDeferral` accepts `taskStateService` and prefers the durable streak over the in-memory map; the class passes `this.taskStateService`, which was already injected at construction |
| `TaskStateService.spec.mjs` | three tests, both directions |

**No scheduling behaviour changes.** No lease call, no due-computation change, no new task class.

## Test Evidence

`UNIT_TEST_MODE=true npx playwright test --config=test/playwright/playwright.config.unit.mjs --workers=1 test/playwright/unit/ai/daemons/orchestrator/`

→ **1,430 passed**, zero failures, zero collateral. The focused spec: **18 passed**.

**All three mutation-convicted** — stashing only `TaskStateService.mjs` yields `3 failed, 15 passed`, so none passes vacuously:

| test | property |
|---|---|
| opens at the first deferral and never slides | the `??=` contract, with a control proving time *did* advance between the two deferrals |
| **survives a restart** | a fresh service reading the same file sees the original streak — the property that makes the measurement worth having |
| **NEGATIVE DIRECTION — a task that RUNS reports no streak** | the ticket's own warning: a one-sided test passes for an always-alarm implementation |

The negative arm also asserts that a deferral *after* a run opens a **fresh** streak rather than resurrecting the old one.

## Post-Merge Validation

- [ ] On the canonical plane, confirm a deferred heavy-maintenance task's `deferralStreakStartedAt` survives an orchestrator restart. `[L3-deferred — needs a restart across a live deferral]`

## Out of scope

- **The health-surface threshold and its unprotected-data-window derivation** (this ticket's AC-2 and AC-4). Next slice in this lane; a durable measurement is a strict prerequisite for a threshold, and shipping them together would have made the threshold untestable against a value that resets.
- **`staleAfterMs`** — deliberately not the lever. AC-6 wants that reason recorded where a tuner will read it; that belongs with the threshold slice, since the comparison only makes sense once a threshold exists.
- **Lease fairness — OQ1 (a) and (b).** The ticket recommends deciding those against measured deferral distributions, which is what this slice makes possible.
- **`PRIORITY_ZERO_TASKS`.** Selection is already correct.
