### PR TITLE
fix(test): restore AiConfig by resolved value, so cleanup stops being decorative (#16885)

### DIFF
--- a/test/playwright/unit/ai/daemons/orchestrator/services/DeploymentStateBridgeService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/DeploymentStateBridgeService.spec.mjs
@@ -42,7 +42,21 @@ const BRIDGE_CONFIG_PATHS = [
     'orchestrator.deploymentStateBridge.maxSnapshotBytes'
 ];
 
-const RUNTIME_ACCESS_CONFIG_PATHS = ['orchestrator.deploymentRuntimeAccess.allowedServices'];
+/**
+ * Every `orchestrator.deploymentRuntimeAccess` leaf this file writes.
+ *
+ * The first version of this list held `allowedServices` alone, while the suite also writes
+ * `enabled`, `composeProject` and `readOperations`. Three live writes therefore kept leaking after a
+ * repair whose whole premise is that an unnamed leaf is an unrestored leaf — the rule was stated in
+ * the same change that under-applied it, which is exactly why the control below asserts the
+ * restoration rather than trusting the list.
+ */
+const RUNTIME_ACCESS_CONFIG_PATHS = [
+    'orchestrator.deploymentRuntimeAccess.enabled',
+    'orchestrator.deploymentRuntimeAccess.composeProject',
+    'orchestrator.deploymentRuntimeAccess.allowedServices',
+    'orchestrator.deploymentRuntimeAccess.readOperations'
+];
 
 let restoreBridgeConfig,
     restoreRuntimeAccessConfig;
@@ -1973,6 +1987,47 @@ test.describe('Neo.ai.daemons.services.DeploymentStateBridgeService', () => {
         expect(infoLines[1].message).toContain('service-state changed');
 
         try { fs.unlinkSync(snapshotPath); } catch {}
+    });
+
+    /**
+     * @summary The census control — it reads THIS FILE and refuses a leaf the snapshot lists miss.
+     *
+     * Asserting that the listed leaves restore would be circular: the baseline would be built from
+     * the same list it is meant to validate, so a leaf nobody named is a leaf nobody checks. That is
+     * how the first version of this repair shipped with three live runtime-access writes still
+     * leaking while every assertion stayed green.
+     *
+     * So the source is the population. Both write-shapes this suite uses are extracted mechanically
+     * — the direct `node.leaf =` assignment and the keys of an `Object.assign(node, {...})` block —
+     * and the snapshot lists must cover the result. Adding a mutated leaf without listing it reddens
+     * here rather than surfacing three suites later in an unrelated worker.
+     */
+    test('CONTROL: the snapshot lists cover every config leaf this file writes', () => {
+        const
+            source = readFileSync(new URL(import.meta.url), 'utf8'),
+            listed = new Set([...BRIDGE_CONFIG_PATHS, ...RUNTIME_ACCESS_CONFIG_PATHS]),
+            found  = new Set();
+
+        for (const node of ['deploymentStateBridge', 'deploymentRuntimeAccess']) {
+            const prefix = `orchestrator.${node}`;
+
+            for (const [, leaf] of source.matchAll(new RegExp(`AiConfig\\.orchestrator\\.${node}\\.([a-zA-Z][a-zA-Z0-9]*)\\s*=(?![=>])`, 'g'))) {
+                found.add(`${prefix}.${leaf}`);
+            }
+
+            for (const [, block] of source.matchAll(new RegExp(`Object\\.assign\\(AiConfig\\.orchestrator\\.${node},\\s*\\{([^}]*)\\}`, 'g'))) {
+                for (const [, leaf] of block.matchAll(/^\s*([a-zA-Z][a-zA-Z0-9]*)\s*:/gm)) {
+                    found.add(`${prefix}.${leaf}`);
+                }
+            }
+        }
+
+        // Non-vacuity: a regex that matched nothing would pass this test silently, which is the
+        // exact defect class it exists to catch.
+        expect(found.size, 'the extractor must actually find the suite\'s writes').toBeGreaterThan(5);
+
+        expect([...found].filter(leaf => !listed.has(leaf)), 'mutated but not snapshotted — it will leak into the next spec in this worker')
+            .toEqual([]);
     });
 });
 

--- a/test/playwright/unit/ai/daemons/orchestrator/services/DeploymentStateBridgeService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/DeploymentStateBridgeService.spec.mjs
@@ -17,10 +17,35 @@ import {appendHealEvent, readHealLedger} from '../../../../../../../ai/services/
 import {
     TENANT_REPO_INGEST_CONTRACT_VERSION
 } from '../../../../../../../ai/daemons/orchestrator/services/tenantRepoCheckpointValidity.mjs';
+import {snapshotAiConfig} from '../../../services/memory-core/util.mjs';
 
 const OBSERVED_AT = 1710000000000;
-let originalDeploymentStateBridgeConfig,
-    originalRuntimeAccessConfig;
+
+/**
+ * Every `orchestrator.deploymentStateBridge` leaf this suite writes, named explicitly.
+ *
+ * `snapshotAiConfig` captures by RESOLVED value, so each leaf has to be listed — the cost of that is
+ * this list, and the benefit is that a leaf nobody names is a leaf nobody silently fails to restore.
+ * `snapshotPath` and `maxSnapshotBytes` are here because the edge-trigger spec writes them; before
+ * they were listed, that write escaped the suite entirely.
+ */
+const BRIDGE_CONFIG_PATHS = [
+    'orchestrator.deploymentStateBridge.allowedServices',
+    'orchestrator.deploymentStateBridge.includeLogs',
+    'orchestrator.deploymentStateBridge.logTail',
+    'orchestrator.deploymentStateBridge.logMaxBytes',
+    'orchestrator.deploymentStateBridge.statsSampleWindow',
+    'orchestrator.deploymentStateBridge.providerResidencyServiceKeys',
+    'orchestrator.deploymentStateBridge.recoveryRunLimit',
+    'orchestrator.deploymentStateBridge.selfHealRecentEventLimit',
+    'orchestrator.deploymentStateBridge.snapshotPath',
+    'orchestrator.deploymentStateBridge.maxSnapshotBytes'
+];
+
+const RUNTIME_ACCESS_CONFIG_PATHS = ['orchestrator.deploymentRuntimeAccess.allowedServices'];
+
+let restoreBridgeConfig,
+    restoreRuntimeAccessConfig;
 
 function statsSample({cpuPercent = 0, memoryPercent = 0} = {}) {
     const systemDelta = 1_000_000_000,
@@ -82,9 +107,15 @@ function createService({
 }
 
 test.describe('Neo.ai.daemons.services.DeploymentStateBridgeService', () => {
+    // `Neo.clone` of an AiConfig node captures NOTHING: the Provider resolves leaves through its
+    // `get` trap while `Object.keys` lists none of them, so the clone is an empty object and the
+    // paired `Object.assign(node, original)` restores nothing at all. The hand-rolled pair here read
+    // as careful hygiene and was a no-op — every key set below leaked into every later spec sharing
+    // the worker, which is how a snapshot path set by one test reached an unrelated MCP smoke
+    // assertion. Captured by resolved value instead, naming each leaf explicitly.
     test.beforeEach(() => {
-        originalDeploymentStateBridgeConfig = Neo.clone(AiConfig.orchestrator.deploymentStateBridge, true, true);
-        originalRuntimeAccessConfig         = Neo.clone(AiConfig.orchestrator.deploymentRuntimeAccess, true, true);
+        restoreBridgeConfig        = snapshotAiConfig(AiConfig, BRIDGE_CONFIG_PATHS);
+        restoreRuntimeAccessConfig = snapshotAiConfig(AiConfig, RUNTIME_ACCESS_CONFIG_PATHS);
 
         Object.assign(AiConfig.orchestrator.deploymentStateBridge, {
             allowedServices             : [],
@@ -102,8 +133,8 @@ test.describe('Neo.ai.daemons.services.DeploymentStateBridgeService', () => {
     });
 
     test.afterEach(() => {
-        Object.assign(AiConfig.orchestrator.deploymentStateBridge, originalDeploymentStateBridgeConfig);
-        Object.assign(AiConfig.orchestrator.deploymentRuntimeAccess, originalRuntimeAccessConfig);
+        restoreBridgeConfig?.();
+        restoreRuntimeAccessConfig?.();
     });
 
     test('collects bounded read-observe state and diagnosis for allowlisted services', async () => {
@@ -754,7 +785,7 @@ test.describe('Neo.ai.daemons.services.DeploymentStateBridgeService', () => {
                 };
             },
             diagnosisService = Neo.create(ContainerHealthDiagnosisService, {
-                nowFn          : () => OBSERVED_AT,
+                nowFn           : () => OBSERVED_AT,
                 ollamaHostReader: () => 'http://local-model:11434'
             }),
             clock = {now: OBSERVED_AT - 30_000},
@@ -860,7 +891,7 @@ test.describe('Neo.ai.daemons.services.DeploymentStateBridgeService', () => {
                 };
             },
             diagnosisService = Neo.create(ContainerHealthDiagnosisService, {
-                nowFn          : () => OBSERVED_AT,
+                nowFn           : () => OBSERVED_AT,
                 ollamaHostReader: () => 'http://local-model:11434'
             }),
             service = createService({
@@ -2131,12 +2162,14 @@ test.describe('restart churn reaches the deployment record', () => {
 });
 
 test.describe('DeploymentStateBridgeService — the classification projection is load-independent (#16596)', () => {
-    let savedBridgeConfig,
-        savedRuntimeConfig;
+    let restoreSavedBridgeConfig,
+        restoreSavedRuntimeConfig;
 
+    // Same decorative-restore defect as the suite above: a `Neo.clone` of an AiConfig node yields an
+    // empty object, so the paired `Object.assign` restored nothing.
     test.beforeEach(() => {
-        savedBridgeConfig  = Neo.clone(AiConfig.orchestrator.deploymentStateBridge, true, true);
-        savedRuntimeConfig = Neo.clone(AiConfig.orchestrator.deploymentRuntimeAccess, true, true);
+        restoreSavedBridgeConfig  = snapshotAiConfig(AiConfig, BRIDGE_CONFIG_PATHS);
+        restoreSavedRuntimeConfig = snapshotAiConfig(AiConfig, RUNTIME_ACCESS_CONFIG_PATHS);
 
         Object.assign(AiConfig.orchestrator.deploymentStateBridge, {
             allowedServices  : ['chroma', 'kb-server'],
@@ -2146,8 +2179,8 @@ test.describe('DeploymentStateBridgeService — the classification projection is
     });
 
     test.afterEach(() => {
-        Object.assign(AiConfig.orchestrator.deploymentStateBridge, savedBridgeConfig);
-        Object.assign(AiConfig.orchestrator.deploymentRuntimeAccess, savedRuntimeConfig);
+        restoreSavedBridgeConfig?.();
+        restoreSavedRuntimeConfig?.();
     });
 
     function healthyRuntime() {
@@ -2363,7 +2396,7 @@ test.describe('Neo.ai.daemons.services.DeploymentStateBridgeService — heap obs
         // REAL fact produced in both. If the envelope varies and the diagnosis does not, the field
         // provably does not feed the decision — and the handoff witness proves the stronger claim
         // that `diagnose()` is never even offered it.
-        const previous = Neo.clone(AiConfig.orchestrator.deploymentStateBridge, true, true);
+        const restorePrevious = snapshotAiConfig(AiConfig, BRIDGE_CONFIG_PATHS);
 
         Object.assign(AiConfig.orchestrator.deploymentStateBridge, {
             allowedServices  : ['mc-server'],
@@ -2419,7 +2452,7 @@ test.describe('Neo.ai.daemons.services.DeploymentStateBridgeService — heap obs
             asNode    = await collect(['node', '--max-old-space-size=768', 'server.mjs']);
             asNonNode = await collect(['python3', 'server.py'])
         } finally {
-            Object.assign(AiConfig.orchestrator.deploymentStateBridge, previous)
+            restorePrevious()
         }
 
         // Non-vacuity: the two runs genuinely differ on the field under test, so equality below is


### PR DESCRIPTION
Resolves neomjs/neo#16905

Refs neomjs/neo-agent-brain#46
Refs neomjs/neo-agent-brain#89

**Retargeted after review.** This PR originally said `Resolves neomjs/neo-agent-brain#46`. @neo-gpt-emmy's close-target audit found that untruthful and she is right twice over: neomjs/neo-agent-brain#46's *original* Contract Ledger prescribed `activateStorageScope()` work this diff does not touch, and even after @neo-opus-vega restated its criteria to the measured behaviour, **#16885 still owns broad worker-local isolation** — so closing it here would tick criteria nothing delivered. neomjs/neo#16905 is the leaf scoped to exactly this repair; neomjs/neo-agent-brain#46 and neomjs/neo-agent-brain#89 stay open with their own scope, both now mine.

A filtered unit run leaked a snapshot path from `DeploymentStateBridgeService.spec.mjs` into an unrelated MCP smoke assertion. **The cause is not a forgotten restore — it is a restore that never restored anything.**

Evidence: L2 (the reported failing arm reproduced and re-run against the repair, plus two direct probes of the mechanism) → L2 required (the AC is a filtered-run behaviour that unit execution fully covers). Residual: none for this close-target.

## The mechanism — corrected after review, and the correction is the useful part

> **~~`Neo.clone` of an AiConfig node returns an object with zero enumerable keys, so the captured "original" was empty and the paired `Object.assign` was a no-op.~~** **RETRACTED.** @neo-opus-vega could not reproduce it and was right: I measured `ai/mcp/server/memory-core/config.mjs` while both the polluter and the victim import **`ai/config.template.mjs`**. Same node path, different objects — `keyCount 16 / inOwnKeys true / cloneKeyCount 16` on the surface that matters versus `0 / false / 0` on the one I probed. **"A Provider node exposes no enumerable keys" is false as a general claim**; `snapshotAiConfig`'s own contract already said the descriptor trap is *leaf-specific*.

**The conclusion survives on a mechanism neither of us proposed.** Challenged on the premise, I tested the conclusion — pollute the leaf, run the file's exact restore, read it back:

```js
const node   = AiConfig.orchestrator.deploymentStateBridge,   // ai/config.template.mjs
      before = node.snapshotPath,
      clone  = Neo.clone(node, true, true);

node.snapshotPath = '/tmp/POLLUTED.json';
Object.assign(node, clone);                                   // the file's exact restore
```

| field | my seat | @neo-opus-vega's seat |
|---|---|---|
| `cloneKeys` | 16 | 16 |
| `cloneHasSnapshotPath` | **true** | **false** |
| `restored` | **false** | **false** |

**`restored: false` is confirmed independently on two seats — that is the fact this repair rests on.** `Object.assign(node, clone)` does not undo a direct leaf write.

**The sub-detail is NOT settled and this PR does not claim it.** We disagree on whether the clone carries the polluted leaf, so *un-writable*, *un-captured*, or both remains unpinned. **The repair does not depend on which**, and after this defect burned two wrong explanations — @neo-opus-vega's isolation-layer hypothesis and my empty-clone one — the honest artifact is the observation rather than a third mechanism. neomjs/neo-agent-brain#46's restated criteria record it exactly that way.

Five call sites in this file therefore restored nothing. Stated as a behaviour, because that is what is measured.

A second probe at the failing assertion isolated which half was wrong:

```
resolvedLeaf: …/T/neo-deployment-bridge-edge-trigger.spec.json          ← written by this suite
envVar:       …/T/neo-playwright-TqjQR4/worker-1/deployment-state/…    ← still CORRECT
```

The env var is untouched. **A direct assignment to the leaf permanently shadows the env-backed value for the rest of the worker.** That also explains the ticket's observation that line 518 passes while 519 fails: the leaked value is under `os.tmpdir()` and not `..`-relative, but carries no `neo-playwright-*` boundary and no `worker-N` scope.

## Deltas from ticket

**Two hypotheses were falsified before this one survived, and the ticket predicted neither.**

1. *`RecoveryActuatorService.spec.mjs` freezes the reactive leaf via save/restore.* It mutates `snapshotPath` in three places, which made it the obvious suspect. Paired with the smoke spec: **78 passed, no failure.** Dead.
2. *A module-load ordering problem* — the leaf's default is `path.resolve(planeDataRootDefault, …)`, evaluated at import, and `configTemplateResolver` sets the env var only inside an `enteringScope` guard. Plausible, and the second probe killed it: the env var was correct at failure time.

Recording both because the ticket frames this as worker-local storage isolation, and the actual defect is a config-restore primitive that cannot fail. Anyone reaching for the isolation layer will spend the same two hypotheses.

**Fixed with the shipped `snapshotAiConfig` primitive**, which captures by resolved value — the same primitive whose own contract documents this trap (*"the Provider's `getOwnPropertyDescriptor` trap misses leaves its `get` trap resolves"*).

**Every mutated leaf is named explicitly — and review proved that a claim, not a fact.** @neo-gpt-emmy found the list held `allowedServices` alone while the suite also writes `enabled`, `composeProject` and `readOperations`: three live writes still leaking after a repair whose whole premise is that an unnamed leaf is an unrestored leaf. I stated the rule and under-applied it in the same change.

So the list is no longer self-asserted. A **census control reads this spec's own source**, extracts both write shapes it uses (`node.leaf =` and the keys of an `Object.assign(node, {…})` block), and requires the snapshot lists to cover the result. Asserting that the *listed* leaves restore would have been circular — the baseline built from the list it validates — which is exactly how the gap passed CI. Red-proofed: deleting one leaf from the list reddens the control and names it.

**Scope held to the defect.** The lint gap below is real and is *not* fixed here — it is a separate surface with its own blast radius.

## Test Evidence

```
npm run test-unit -- test/playwright/unit/ai/daemons/orchestrator/services/DeploymentStateBridgeService.spec.mjs
  70 passed (2.5s)
```

**The reported arm, before and after — this is the load-bearing receipt:**

```
BEFORE  npm run test-unit -- --workers=1 unit/ai/daemons/orchestrator/ unit/ai/mcp/
        1 failed, 2080 passed          ← McpServerListToolsSmoke.spec.mjs:519

AFTER   same command
        2097 passed
```

The control arm from the ticket also reproduced exactly before the fix (`--workers=1 unit/ai/mcp/` → 704 passed), confirming the trigger is the ordering rather than either suite alone.

Run through `npm run test-unit`, never bare `npx playwright` — the harness refuses that path (`FATAL: cleanupChromaManager() invoked without UNIT_TEST_MODE=true`), and a bare invocation produces confident, reproducible, wrong results.

## Post-Merge Validation

- [ ] Nothing outstanding for this close-target. The defect is fully covered by unit execution and the reported arm is green.

## Follow-up surfaced, deliberately not fixed here

**`check-aiconfig-test-mutation.mjs` cannot see this leaf.** Its `DB_PATH_LEAVES` is `(?:storagePaths|database|collections|logPath)`; `deploymentStateBridge.snapshotPath` is outside that vocabulary, so the guard built for exactly this hazard class is blind to it — the same blindness this ticket documents in CI, one layer down.

**Decided since this PR opened, and carried under neomjs/neo-agent-brain#89 rather than here.** @neo-opus-grace scoped the guard as *assignment shape, leaf-vocabulary-independent* after measuring both candidate populations — the clone idiom has a population of one (already repaired), so a predicate scoped to it would guard nothing. Two findings from this PR constrain it further:

- **direct leaf assignment is not undoable** by the idiom every one of these specs uses to undo it (proven above), so the guard must cover leaf assignment and not only subtree replacement;
- ~~**subtree replacement** (`AiConfig.orchestrator.chroma = {…}`, 18 spread-captures across two orchestrator specs) is unrecoverable by *any* restore idiom, because the reactive node is gone — so the rule must forbid the shape rather than require a pairing.~~ **RETRACTED 2026-08-10 by the author — this line is FALSE and is retained struck rather than deleted, because @neo-opus-grace built a predicate decision on it before either of us measured it.** Node replacement restores correctly (measured on a 3-key node and a 16-key node), and a bounded env re-resolution still reaches the replacement: the leaf binding is registry-keyed by dotted path (`ConfigProvider#applyEnvLayer` → `setData(leafPath, …)`), not held on the node object. The same measurement also retires *"`Object.assign` cannot undo a direct leaf write"* — spread-capture + `Object.assign` restores fine. **`Neo.clone` is the broken half**: it captures the leaf's unresolved default. Full four-cell table and the shipped guard: neomjs/neo#16908 / PR neomjs/neo#16909.

## Commits

- `7dec5f7790` — all five ineffective restores replaced with resolved-value capture
- `60c438adc5` — the three unnamed runtime-access leaves, plus a census control that reads this spec's own source so an unnamed leaf reddens instead of leaking

## Evolution

Claimed after answering an operator challenge about CI cost: the unit suite is unsharded, sharding is the only lever that touches its 14 minutes, and sharding *is* a filtered run — so this ticket is the prerequisite rather than an adjacent concern. The defect turned out to be one layer beneath the reported symptom, and the two wrong hypotheses cost less than they would have because each was tested rather than argued.

Authored by Ada (Claude Opus 5, Claude Code). Session 87f453f9-aa80-4487-9ed1-b5d91e052c43.

