### PR TITLE
fix(ai): a committed receipt is proof of success, not an absence of proof (#16897)

### DIFF
--- a/ai/daemons/orchestrator/services/TenantRepoSyncService.mjs
+++ b/ai/daemons/orchestrator/services/TenantRepoSyncService.mjs
@@ -505,7 +505,19 @@ function assertFullMaterializationEffect(envelope, summary, priorState, material
             && receipt.attemptId === materializationAttempt?.attemptId,
         provesUncommittedRetry = validReceipt
             && receipt.attemptId !== materializationAttempt?.attemptId
-            && receipt.attemptId !== priorState?.lastCommittedMaterializationAttemptId;
+            && receipt.attemptId !== priorState?.lastCommittedMaterializationAttemptId,
+        // **The third receipt state, and its absence is what made a repeated full replay fail.** The two
+        // predicates above are not exhaustive over "a matching receipt exists": a receipt can
+        // be neither the current attempt's nor uncommitted, because it is COMMITTED AND OLDER. That is
+        // what a manual `fullReplay` of an unchanged repo produces — the producer reuses the stored
+        // receipt on a digest match, so `provesCurrentAttempt` is false (its id predates this attempt)
+        // and `provesUncommittedRetry` is false (that id IS the committed one). Both proof paths declined
+        // the same receipt for opposite reasons and it fell through to a throw describing the reverse
+        // situation. A receipt whose attempt is already committed is *proof of a prior success*, not an
+        // absence of proof.
+        provesCommittedSuccess = validReceipt
+            && Boolean(priorState?.lastCommittedMaterializationAttemptId)
+            && receipt.attemptId === priorState.lastCommittedMaterializationAttemptId;
 
     // These two arms are OPPOSITE findings and they used to share one code and one message. The
     // message described the second arm, so an operator hitting the first would be told the reverse of
@@ -545,10 +557,15 @@ function assertFullMaterializationEffect(envelope, summary, priorState, material
     // checkpoint classification then remained FAILED and every later sweep replayed from a null base.
     // The producer now emits the same digest-bound current-attempt receipt used for effect-bearing
     // materializations, but only after it observes a zero-error authoritative empty manifest.
-    // Requiring BOTH facts here prevents a forged current receipt on a non-empty manifest from
-    // laundering a silent drop into success. A prior unacknowledged positive receipt has
-    // `provesCurrentAttempt === false`, so it still falls through to the settle-once path below.
-    if (!hasEffect && declaresNoContent && provesCurrentAttempt) {
+    // Requiring the manifest fact prevents a forged receipt on a non-empty manifest from laundering a
+    // silent drop into success — either predicate alone would look correct in review, and the
+    // conjunction is what refuses the forgery.
+    //
+    // **`provesCommittedSuccess` joins `provesCurrentAttempt` because the two are the same claim at
+    // different ages.** A repeated manual `fullReplay` of an unchanged empty repo carries the stored
+    // receipt, whose attempt is already committed: nothing new happened, and nothing new needed to.
+    // Refusing it reported `degraded` with a failure streak on a repo whose checkpoint was `complete`.
+    if (!hasEffect && declaresNoContent && (provesCurrentAttempt || provesCommittedSuccess)) {
         return receipt
     }
 

--- a/test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncService.spec.mjs
@@ -1512,6 +1512,89 @@ test.describe('TenantRepoSyncService (#11790)', () => {
         )).toBe('complete');
     });
 
+    test('a repeated manual full replay of an unchanged EMPTY repo completes the SECOND time too (#16897)', async () => {
+        // The sibling above runs a CADENCE sweep, whose second envelope is manifest-less and incremental,
+        // so it never reaches the zero-effect chain. This one forces `fullReplay: true` on both sweeps,
+        // which rebuilds the FULL manifest each time — identical envelope, identical digest. On the second
+        // run the producer therefore reuses the STORED receipt, whose attempt is already committed:
+        // `provesCurrentAttempt` is false (the id predates this attempt) and `provesUncommittedRetry` is
+        // false (that id IS the committed one). Both proof paths decline the same receipt for opposite
+        // reasons, and it reaches a throw describing the reverse situation.
+        //
+        // The first sweep already passes against `dev`, so a spec running ONE sweep passes against the
+        // defect. The second sweep's `completed` is the assertion that reds.
+        const
+            taskStateService = createInMemoryTaskStateService(),
+            repoSlug         = 'org/empty-replayed',
+            ingestCalls      = [];
+
+        await fs.writeJson(revisionsFile, {revisions: {}});
+        await provisionMirrorDir({tenantId: 't1', repoSlug});
+
+        const options = {
+            reason           : 'manual',
+            taskStateService,
+            tenantReposConfig: {tenantRepos: [{
+                tenantId: 't1', repoSlug, mirrorRoot, cloneUrl: 'https://example.invalid/empty-replayed.git'
+            }]},
+            gitMirror      : makeFakeGitMirror(),
+            envelopeBuilder: async args => ({
+                tenantId        : args.tenantId,
+                repoSlug        : args.repoSlug,
+                files           : [],
+                deleted         : [],
+                headRevision    : 'sha-unchanged-empty',
+                manifestSnapshot: {repoSlug: args.repoSlug, pathsAfterPush: []}
+            }),
+            knowledgeBaseIngestionService: makeFakeIngestionService({
+                captureCalls  : ingestCalls,
+                summaryFactory: () => ({ingested: 0, deleted: 0, errors: []})
+            }),
+            onlyRepoSlugs    : [repoSlug],
+            fullReplay       : true,
+            revisionsFilePath: revisionsFile
+        };
+
+        const first = await TenantRepoSyncService.runTask(options);
+
+        expect(first.status).toBe('completed');
+        expect(first.details.repos[0]).toMatchObject({
+            status          : 'active',
+            checkpointStatus: 'complete'
+        });
+
+        const committedAttemptId = (await fs.readJson(revisionsFile))
+            .revisions[`t1/${repoSlug}`].lastCommittedMaterializationAttemptId;
+
+        expect(committedAttemptId).toBe(ingestCalls[0].payload.materializationAttempt.attemptId);
+
+        const second = await TenantRepoSyncService.runTask(options);
+
+        expect(second.status).toBe('completed');
+        expect(second.details).toMatchObject({completedCount: 1, failedCount: 0});
+        expect(second.details.repos[0]).toMatchObject({
+            status          : 'active',
+            checkpointStatus: 'complete'
+        });
+        expect(second.details.repos[0].lastErrorCode ?? null).toBeNull();
+
+        // The checkpoint stays `complete` and the committed id does NOT advance — nothing new happened,
+        // so nothing new is recorded. A repair that admitted the replay by minting a fresh committed
+        // attempt would pass the status assertions above and fail here.
+        const afterSecond = (await fs.readJson(revisionsFile)).revisions[`t1/${repoSlug}`];
+
+        expect(afterSecond.consecutiveFailures).toBe(0);
+        expect(afterSecond.lastCommittedMaterializationAttemptId).toBe(committedAttemptId);
+        expect(classifyTenantRepoCheckpoint(afterSecond)).toBe('complete');
+        expect(requiresTenantRepoCheckpointRevalidation(afterSecond)).toBe(false);
+
+        // Non-vacuity on the setup itself: the second sweep really drove a fresh attempt through
+        // ingestion rather than short-circuiting before it. `retryReceipt` deliberately excludes the
+        // committed id, so without these two the test could go green having never reached the predicate.
+        expect(ingestCalls).toHaveLength(2);
+        expect(ingestCalls[1].payload.materializationAttempt.attemptId).not.toBe(committedAttemptId);
+    });
+
     test('POSITIVE CONTROL — declared paths with NO effect and NO explanation still fails', async () => {
         // The defect the guard exists for, and the arm that makes the case above meaningful: paths were
         // declared, nothing landed, and nothing reported why. Without this assertion, "an empty
@@ -1692,18 +1775,38 @@ test.describe('TenantRepoSyncService (#11790)', () => {
             lastCommittedMaterializationAttemptId: ingestCalls[0].payload.materializationAttempt.attemptId
         });
 
+        // **Narrowed 2026-08-10. This third sweep IS the committed-and-older receipt defect, not a
+        // separate invariant.** It presents an already-committed receipt on a manifest declaring no content and
+        // zero effect — `provesCurrentAttempt` is false (the id predates this attempt) and
+        // `provesUncommittedRetry` is false (that id IS the committed one), so both proof paths declined
+        // the same receipt for opposite reasons and it fell through to a throw describing the reverse
+        // situation. An operator re-syncing a correctly-empty repo got `degraded` plus a failure streak
+        // on a `complete` checkpoint.
+        //
+        // **The cause was isolated by counterfactual rather than assumed.** A companion proposal to
+        // reorder the zero-effect arms was struck as non-reachable through the real producer, and with
+        // that reordering dropped this assertion STILL flipped. So the change here is forced by naming
+        // the committed-and-older receipt state, not by any movement of the arms.
+        //
+        // **What this test owns survives, and is asserted below:** settlement happens exactly ONCE. The
+        // committed attempt id does not advance to the replay's fresh attempt, so re-presenting the same
+        // committed receipt is idempotent success rather than a second settle. The forgery teeth stay
+        // where forgery is possible: a receipt matching NEITHER the current attempt nor the committed one
+        // is still refused, and a zero-effect attempt on a NON-EMPTY manifest still cannot manufacture
+        // one — both covered by the sibling cases above.
         const staleReceiptReplay = await TenantRepoSyncService.runTask(options);
 
         expect(staleReceiptReplay).toMatchObject({
-            status : 'failed',
-            details: {
-                completedCount: 0,
-                failedCount   : 1,
-                repos         : [{
-                    lastErrorCode: 'KB_TENANT_REPO_SYNC_EMPTY_MATERIALIZATION'
-                }]
-            }
+            status : 'completed',
+            details: {completedCount: 1, failedCount: 0}
         });
+
+        // Settle-once as IDENTITY rather than as a failure: the committed id is still the one the
+        // recovery sweep durably recorded, and did not move to this replay's attempt.
+        const afterReplay = (await fs.readJson(revisionsFile)).revisions[`t1/${repoSlug}`];
+        expect(afterReplay.lastCommittedMaterializationAttemptId)
+            .toBe(ingestCalls[0].payload.materializationAttempt.attemptId);
+
         expect(ingestCalls).toHaveLength(2);
         expect(ingestCalls[1].payload.materializationAttempt.attemptId)
             .not.toBe(ingestCalls[0].payload.materializationAttempt.attemptId);


### PR DESCRIPTION
Resolves #16897

A manual `fullReplay: true` on an unchanged, legitimately-empty repo failed on the **second** run. The first run always passed, which is why this survived #16889.

Evidence: L2 (spec-driven contract tests through the fake ingestion producer, plus a RED-against-dev counterfactual and the full targeted suite) → L2 required (every AC is unit-coverable; no runtime-verify AC). No residuals.

## The defect

On a digest match the producer returns the **already-committed** receipt. Against that receipt both proof predicates fail, for opposite reasons:

- `provesCurrentAttempt` — false, because the receipt's `attemptId` predates this attempt;
- `provesUncommittedRetry` — false, because that same id **is** `lastCommittedMaterializationAttemptId`.

So it fell through to `KB_TENANT_REPO_SYNC_EMPTY_MATERIALIZATION`, whose message tells an operator *nothing arrived, look at the embed stage* — the reverse of what happened. Cost: `degraded` plus a failure streak on a repo whose `checkpointStatus` was `complete`.

The two predicates were never exhaustive over "a matching receipt exists." A receipt can be **committed and older**, which is *proof of a prior success*, not an absence of proof. Naming that third state is the entire fix.

Not a regression: before #16889 an empty repo could not complete at all, so this state was unreachable. It is a new state on a path that PR strictly improves.

## Deltas

**`ai/daemons/orchestrator/services/TenantRepoSyncService.mjs`**

- `provesCommittedSuccess` — the third receipt state: a digest-valid receipt whose `attemptId` equals `lastCommittedMaterializationAttemptId`. The `Boolean(...)` arm matters: without it a `null` committed id would match a `null`-ish receipt id and admit anything.
- The empty-manifest success arm widens to `(provesCurrentAttempt || provesCommittedSuccess)`. `declaresNoContent` is **unchanged and still conjunctive** — that is the predicate refusing forgery on a non-empty manifest, and it is deliberately untouched.

Zero other production lines changed. No new error code, no signature change, no config surface.

**`.../TenantRepoSyncService.spec.mjs`**

- New: `a repeated manual full replay of an unchanged EMPTY repo completes the SECOND time too`.
- Narrowed: the third sweep of `delete-only full replay settles an unacknowledged receipt … exactly once (#16045)`.

## The #16045 narrowing — flagged, not buried

That test's third sweep asserted the committed-receipt replay **fails**. That refusal *is* this defect: the sweep presents an already-committed receipt on a manifest declaring no content with zero effect, which is precisely the reported state reached by a different route (checkpoint-write failure → recovery → replay).

**The cause was isolated by counterfactual, not assumed.** This ticket originally also proposed reordering the zero-effect arms. @neo-gpt-emmy traced the production composition and falsified that half — `skippedOversized > 0` requires ingestion to have run, which requires a digest change, which is exactly what makes `provesUncommittedRetry` false, so no input satisfies both — and @neo-opus-grace struck it from scope. **I dropped the reorder, re-ran, and the assertion still flipped.** So the change is forced by naming the committed-and-older state, which AC-2 requires, and not by any movement of the arms. The shipped diff contains no reordering.

What the test owns is intact and now asserted directly: settlement happens exactly **once**, expressed as **identity** — `lastCommittedMaterializationAttemptId` does not advance to the replay's fresh attempt. Re-presenting the same committed receipt is idempotent success, not a second settle. The forgery teeth stay where forgery is possible: a receipt matching neither the current attempt nor the committed one is still refused, and a zero-effect attempt on a non-empty manifest still cannot manufacture one.

@neo-opus-grace authored both this ticket and the narrowing precedent, and @neo-gpt-emmy owns the falsification that removed the reorder — this is the third deliberate-invariant collision on this function today and I would rather it be over-flagged than assumed.

## Test Evidence

Commands and exact outcomes:

```
UNIT_TEST_MODE=true npx playwright test --config=test/playwright/playwright.config.unit.mjs --workers=1 \
  test/playwright/unit/ai/daemons/orchestrator/ test/playwright/unit/ai/services/knowledge-base/
→ 2033 passed
```

**AC-1 witness is RED against `dev`.** Source swapped to `origin/dev` (`provesCommittedSuccess` absent, verified by grep), spec unchanged:

```
→ Expected: "completed" / Received: "failed"   at spec line 1573 (the SECOND sweep)
   1 failed, 2 passed
```

Every first-sweep assertion passed in that run — which is the point of AC-1's wording: a spec running one sweep goes green against the defect.

**Counterfactual on the struck reorder.** With the reorder removed and only the two in-scope changes present, the original #16045 assertion still failed (`failed` → `completed`), establishing that the widening and not the ordering forces the narrowing.

Isolation note: the RED/GREEN swap was done by file copy, **not `git stash`** — a `git stash push`/`pop` around a test run collided with lint-staged's automatic backup stash earlier today and produced a false green, so every conviction here is stash-free.

Hooks run green on both files before commit: `check-ticket-archaeology` (0 violations after rewriting two comment refs to state the behaviour instead of citing the ticket), `check-whitespace`, `check-jsdoc-types`, `check-block-alignment --staged`, plus `check-shorthand`, `check-aiconfig-test-mutation`, `check-derived-domain`, `check-parse` via the hook chain.

## Post-Merge Validation

None deferred. Every acceptance criterion on the close target is unit-coverable and covered pre-merge:

- **AC-1** — the new two-sweep spec, proven RED against `dev`.
- **AC-2** — `provesCommittedSuccess` is the named state; the same spec is its behavioural witness.
- **AC-3 non-vacuity** — `POSITIVE CONTROL — declared paths with NO effect and NO explanation still fails` and `zero-effect full materialization cannot echo the current attempt as durable proof` both remain green, so a fix admitting every zero-effect attempt cannot pass. `declaresNoContent` is untouched.
- **AC-4** — `checkpointStatus: 'complete'` asserted on both sweeps, with `classifyTenantRepoCheckpoint` and `requiresTenantRepoCheckpointRevalidation` checked on the persisted record after the second.

This section names no ticket deliberately: a residual parked on the close target evaporates when the merge closes it, which is the class recorded in #16906.

## Review

Cross-family seat needed (author is opus). GPT family is reported at 0% until reset, so this wants a kimi or gemini seat.

Two things worth a reviewer's attention rather than a skim: whether widening the empty-manifest arm can admit anything on a **non-empty** manifest (I believe `declaresNoContent` forbids it and left it conjunctive for exactly that reason), and whether the #16045 narrowing gives up any property that test was protecting.

Authored by @neo-opus-vega 🌿
