### PR TITLE
Fail the build on an AiConfig restore-capture that cannot restore

### DIFF
--- a/buildScripts/util/check-aiconfig-test-mutation.mjs
+++ b/buildScripts/util/check-aiconfig-test-mutation.mjs
@@ -102,11 +102,26 @@ export const DB_PATH_MUTATION = new RegExp(
  * working call sites, and a gate whose false positives dominate gets disabled rather than obeyed.
  *
  * Root shape and the false-positive posture are inherited from Class-A above: an unrelated `*Config`
- * local passed to `Neo.clone` trips this and costs one escape marker plus a stated reason. Current
- * measured cost of that trade across the whole test tree: zero occurrences, so zero false positives.
+ * local passed to `Neo.clone` trips this and costs one escape marker plus a stated reason.
+ *
+ * **The grammar admits a qualified root and ordinary line breaks, and that is not cosmetic.** The
+ * first version required the config root IMMEDIATELY after `Neo.clone(`, and matched line by line.
+ * Three shapes walked through it:
+ *
+ *   Neo.clone(SDK.Memory_Config.data)     — member-qualified, and a REAL access shape in this tree
+ *   Neo.clone(context.AiConfig.data)      — namespaced
+ *   Neo.clone(\n    AiConfig.data)        — ordinary formatting
+ *
+ * A zero-population scan under that grammar could only ever have meant "none of the shapes I can
+ * express", never "none present" — the instrument's vocabulary reported as the world. Class-A already
+ * anchors its root ANYWHERE in the access path for exactly this reason; this now matches it.
  */
 export const CLONE_CAPTURE = new RegExp(
-    `(?<![\\w$])Neo\\.clone\\s*\\(\\s*${CONFIG_ROOT}(?![\\w$])`
+    // Optional member-chain prefix, so a qualified root (`SDK.Memory_Config`) is still a config root.
+    // The `\s*` separators span newlines on their own — `\s` matches `\n` with or without the `s`
+    // flag, which only governs `.` and this pattern has none. An earlier version passed `s` here with
+    // a comment claiming it enabled the multiline match; the mutation test proved the flag inert.
+    `(?<![\\w$])Neo\\s*\\.\\s*clone\\s*\\(\\s*(?:[A-Za-z_$][\\w$]*\\s*\\.\\s*)*${CONFIG_ROOT}(?![\\w$])`
 );
 
 /*
@@ -295,31 +310,56 @@ const CLONE_CAPTURE_GLOBAL = new RegExp(CLONE_CAPTURE.source, 'g');
 /**
  * @summary Scans file content for `Neo.clone` restore-captures of an `AiConfig` node.
  *
- * Shares Class-A's code mask and escape marker, so a clone written inside a string literal, a comment
- * or a template quasi is not a hit — the same ground truth, not a second hand-rolled scan.
+ * Shares Class-A's code mask and escape marker — the same ground truth, not a second hand-rolled
+ * scan — but matches over a CODE-ONLY projection of the whole file rather than line by line, because
+ * a capture whose argument wraps across lines is ordinary formatting and was previously invisible.
+ *
+ * The projection preserves offsets exactly: every non-code character is replaced by a space, so a
+ * match index still maps to its real line, and a pair quoted inside a string or comment still cannot
+ * match. Masking per line and then joining keeps `codeMask` authoritative rather than re-deriving it.
  * @param {String} content
  * @returns {Object[]} `[{line, text}]` — one entry per offending line (1-based line numbers).
  */
 export function findCloneCaptures(content) {
     const lines = content.split('\n'),
-          state = {source: content},
-          hits  = [];
+          state = {source: content};
 
-    lines.forEach((line, index) => {
-        if (line.includes(ESCAPE_MARKER)) {
-            return
-        }
-
+    // Offset-preserving code-only projection: same length, non-code blanked.
+    const codeOnly = lines.map((line, index) => {
         const mask = codeMask(line, state, index);
+        return [...line].map((char, column) => (mask[column] ? char : ' ')).join('')
+    }).join('\n');
 
-        for (const match of line.matchAll(CLONE_CAPTURE_GLOBAL)) {
-            // The match starts at `Neo`; flag only when that token is real code.
-            if (mask[match.index]) {
-                hits.push({line: index + 1, text: line.trim()});
-                break
-            }
+    const lineStarts = [];
+    let   cursor     = 0;
+
+    for (const line of lines) {
+        lineStarts.push(cursor);
+        cursor += line.length + 1
+    }
+
+    const lineOf = offset => {
+        let low = 0, high = lineStarts.length - 1;
+        while (low < high) {
+            const mid = Math.ceil((low + high) / 2);
+            if (lineStarts[mid] <= offset) low = mid; else high = mid - 1
         }
-    });
+        return low
+    };
+
+    const hits = [],
+          seen = new Set();
+
+    for (const match of codeOnly.matchAll(CLONE_CAPTURE_GLOBAL)) {
+        const index = lineOf(match.index);
+
+        // The marker is read from the line the capture STARTS on — where an author would write it.
+        if (lines[index].includes(ESCAPE_MARKER)) continue;
+        if (seen.has(index)) continue;
+
+        seen.add(index);
+        hits.push({line: index + 1, text: lines[index].trim()})
+    }
 
     return hits
 }

--- a/buildScripts/util/check-aiconfig-test-mutation.mjs
+++ b/buildScripts/util/check-aiconfig-test-mutation.mjs
@@ -70,6 +70,46 @@ export const DB_PATH_MUTATION = new RegExp(
 );
 
 /*
+ * The RESTORE-CAPTURE rule — deliberately NOT called "Class B", which this file already spends on
+ * config-VARYING leaves (retry / transport) that it holds out of scope. This is a third, orthogonal
+ * axis: Class-A asks WHICH LEAF a test writes, this asks WHETHER THE UNDO CAN WORK AT ALL.
+ *
+ * `Neo.clone` of an `AiConfig` node captures the leaf's
+ * UNRESOLVED default, not the value the provider resolves — so a save/restore pair built on it writes
+ * the default back over the resolved value and reports success. The write is not lost loudly; it is
+ * replaced quietly, which is why five call sites of careful-looking hygiene restored nothing at all
+ * and a worker stayed polluted for its entire life.
+ *
+ * The four-cell measurement that fixed the target — one direct leaf write, restored four ways:
+ *
+ *   spread `{...node}`  + `Object.assign`        -> restored
+ *   spread `{...node}`  + `restoreConfigObject`  -> restored
+ *   `Neo.clone(node)`   + `Object.assign`        -> NOT restored
+ *   `Neo.clone(node)`   + `restoreConfigObject`  -> NOT restored
+ *
+ * The restore idiom is innocent in both columns; the capture is the broken half. An earlier reading of
+ * this defect blamed the restore (`Object.assign` "cannot undo a leaf write") and a still earlier one
+ * blamed a zero-key clone. Both are retracted: the clone carries the key — it carries the WRONG VALUE.
+ * The pattern therefore anchors on the capture and stays indifferent to whatever restores from it.
+ *
+ * `snapshotAiConfig` is the by-construction answer and already the majority idiom; its contract exists
+ * precisely because it captures by RESOLVED value. This guard points at it rather than restating it.
+ *
+ * Deliberately NOT guarded — measured, not assumed: whole-SUBTREE replacement
+ * (`AiConfig.orchestrator.mlx = {...}`) restores correctly, on a node with 3 keys and on one with 16,
+ * and a bounded env re-resolution still reaches the replacement. The leaf binding is registry-keyed by
+ * dotted path, so swapping the node object does not remove it. Forbidding that shape would fail six
+ * working call sites, and a gate whose false positives dominate gets disabled rather than obeyed.
+ *
+ * Root shape and the false-positive posture are inherited from Class-A above: an unrelated `*Config`
+ * local passed to `Neo.clone` trips this and costs one escape marker plus a stated reason. Current
+ * measured cost of that trade across the whole test tree: zero occurrences, so zero false positives.
+ */
+export const CLONE_CAPTURE = new RegExp(
+    `(?<![\\w$])Neo\\.clone\\s*\\(\\s*${CONFIG_ROOT}(?![\\w$])`
+);
+
+/*
  * Files whose Class-A mutation is load-bearing — NOT a grandfathering queue. Every entry whose write
  * duplicated isolation the harness already provides by construction has been removed; what survives
  * is here because by-construction isolation provably cannot serve it, and each entry states why. A new entry needs that same justification, not a migration promise: an unexplained
@@ -250,6 +290,66 @@ export function findDbPathMutations(content) {
     return hits
 }
 
+const CLONE_CAPTURE_GLOBAL = new RegExp(CLONE_CAPTURE.source, 'g');
+
+/**
+ * @summary Scans file content for `Neo.clone` restore-captures of an `AiConfig` node.
+ *
+ * Shares Class-A's code mask and escape marker, so a clone written inside a string literal, a comment
+ * or a template quasi is not a hit — the same ground truth, not a second hand-rolled scan.
+ * @param {String} content
+ * @returns {Object[]} `[{line, text}]` — one entry per offending line (1-based line numbers).
+ */
+export function findCloneCaptures(content) {
+    const lines = content.split('\n'),
+          state = {source: content},
+          hits  = [];
+
+    lines.forEach((line, index) => {
+        if (line.includes(ESCAPE_MARKER)) {
+            return
+        }
+
+        const mask = codeMask(line, state, index);
+
+        for (const match of line.matchAll(CLONE_CAPTURE_GLOBAL)) {
+            // The match starts at `Neo`; flag only when that token is real code.
+            if (mask[match.index]) {
+                hits.push({line: index + 1, text: line.trim()});
+                break
+            }
+        }
+    });
+
+    return hits
+}
+
+/**
+ * @summary Scans one file's content for both rules, applying the allowlist to Class-A only.
+ *
+ * The allowlist is scoped to Class-A and stays that way. Every entry justifies a DB-PATH mutation
+ * specifically — a logger repointing `data.logPath`, a guard spec flipping its own selectors off —
+ * and not one of those reasons says anything about capture fidelity. Letting a narrow, stated
+ * exemption suppress an unrelated rule is how an allowlist becomes a blanket bypass, which is the
+ * failure this file's own header warns about.
+ *
+ * Exported with an injectable allowlist because that scoping is a real behaviour and the alternative
+ * ways to test it are all worse: asserting it through the CLI against a genuinely allowlisted file
+ * passes whether or not the scoping holds (no such file contains a restore-capture), and the honest
+ * version of that test would have to mutate a tracked spec mid-run.
+ * @param {String} file Repo-relative POSIX path.
+ * @param {String} content
+ * @param {Object} [options]
+ * @param {Set<String>} [options.allowlist=ALLOWLIST]
+ * @returns {{dbPathHits: Object[], cloneHits: Object[]}}
+ */
+export function scanFileContent(file, content, {allowlist = ALLOWLIST} = {}) {
+    return {
+        dbPathHits: allowlist.has(file) ? [] : findDbPathMutations(content),
+        cloneHits : findCloneCaptures(content)
+    }
+}
+
 /**
  * @summary Normalizes an input path (absolute from lint-staged, or relative) to a repo-relative POSIX path.
  * @param {String} file
@@ -300,12 +400,10 @@ function main() {
         process.exit(0);
     }
 
-    const violations = [];
-    for (const file of files) {
-        if (ALLOWLIST.has(file)) {
-            continue
-        }
+    const violations      = [],
+          cloneViolations = [];
 
+    for (const file of files) {
         let content;
         try {
             content = readFileSync(path.resolve(gitRoot, file), 'utf-8');
@@ -314,7 +412,21 @@ function main() {
             continue
         }
 
-        findDbPathMutations(content).forEach(({line, text}) => violations.push(`${file}:${line}: ${text}`));
+        const {dbPathHits, cloneHits} = scanFileContent(file, content);
+
+        dbPathHits.forEach(({line, text}) => violations.push(`${file}:${line}: ${text}`));
+        cloneHits.forEach(({line, text}) => cloneViolations.push(`${file}:${line}: ${text}`));
+    }
+
+    if (cloneViolations.length > 0) {
+        console.error(`\x1b[31mcheck-aiconfig-test-mutation: ${cloneViolations.length} ineffective AiConfig restore capture(s) in tests:\x1b[0m`);
+        if (!quiet) {
+            cloneViolations.forEach(v => console.error('  ' + v));
+            console.error('\n`Neo.clone` of an AiConfig node captures the leaf DEFAULT, not the value the provider resolves,');
+            console.error('so restoring from it writes the default back over the resolved value and reports success. Capture');
+            console.error('by resolved value with `snapshotAiConfig(aiConfig, paths)` instead — or, only if genuinely');
+            console.error(`unavoidable, add an "${ESCAPE_MARKER}: <reason>" marker on the line.`);
+        }
     }
 
     if (violations.length > 0) {
@@ -325,6 +437,12 @@ function main() {
             console.error('#12335 orphan incident; ADR-0019 §4 B4). Isolate by construction (UNIT_TEST_MODE resolves the');
             console.error(`test DB), or — only if genuinely unavoidable — add an "${ESCAPE_MARKER}: <reason>" marker on the line.`);
         }
+    }
+
+    // ONE exit decision covering both classes. Reporting Class-B and then falling through to the
+    // success line would print violations and exit 0 — a gate that describes a problem instead of
+    // failing on it, which is the exact shape this lint exists to prevent elsewhere.
+    if (violations.length > 0 || cloneViolations.length > 0) {
         process.exit(1);
     }
 

--- a/buildScripts/util/check-aiconfig-test-mutation.mjs
+++ b/buildScripts/util/check-aiconfig-test-mutation.mjs
@@ -325,9 +325,28 @@ export function findCloneCaptures(content) {
           state = {source: content};
 
     // Offset-preserving code-only projection: same length, non-code blanked.
+    //
+    // Indexed by UTF-16 CODE UNIT, deliberately. `[...line]` iterates code POINTS, and acorn's token
+    // offsets, `line.length` and the `lineStarts` table below all count code units — so one astral
+    // character (an emoji in a comment is enough) made the projection SHORTER than its source and
+    // shifted every offset after it. Measured consequences of that version:
+    //
+    //   /*📐*/Neo.clone(AiConfig.data);   → blanked the `N` of executable `Neo`; no hit
+    //   an astral comment line above      → mapped the next line's hit onto the line above, where an
+    //                                       unrelated escape marker then suppressed it
+    //
+    // A silent bypass of a safety gate, reachable by typing an emoji in a comment. A surrogate pair
+    // is never split by this loop in practice: a token boundary cannot fall between its halves, so
+    // both units are always classified the same way.
     const codeOnly = lines.map((line, index) => {
         const mask = codeMask(line, state, index);
-        return [...line].map((char, column) => (mask[column] ? char : ' ')).join('')
+        let   out  = '';
+
+        for (let unit = 0; unit < line.length; unit++) {
+            out += mask[unit] ? line[unit] : ' '
+        }
+
+        return out
     }).join('\n');
 
     const lineStarts = [];

--- a/test/playwright/unit/ai/buildScripts/util/check-aiconfig-test-mutation.spec.mjs
+++ b/test/playwright/unit/ai/buildScripts/util/check-aiconfig-test-mutation.spec.mjs
@@ -1,8 +1,10 @@
-import {test, expect}                                  from '@playwright/test';
-import {existsSync}                                    from 'node:fs';
-import path                                            from 'node:path';
-import {fileURLToPath}                                 from 'node:url';
-import {findDbPathMutations, ALLOWLIST, ESCAPE_MARKER} from '../../../../../../buildScripts/util/check-aiconfig-test-mutation.mjs';
+import {test, expect}                                                                      from '@playwright/test';
+import {spawnSync}                                                                         from 'node:child_process';
+import {existsSync, mkdirSync, rmSync, writeFileSync}                                      from 'node:fs';
+import path                                                                                from 'node:path';
+import process                                                                             from 'node:process';
+import {fileURLToPath}                                                                     from 'node:url';
+import {findDbPathMutations, findCloneCaptures, scanFileContent, ALLOWLIST, ESCAPE_MARKER} from '../../../../../../buildScripts/util/check-aiconfig-test-mutation.mjs';
 
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../../../../..');
 
@@ -132,6 +134,105 @@ test.describe('check-aiconfig-test-mutation guard', () => {
 
     test('honors the inline escape marker on a genuinely unavoidable line', () => {
         expect(findDbPathMutations(`aiConfig.storagePaths.graph = p; // ${ESCAPE_MARKER}: legacy shim, migrates in #12435`)).toEqual([])
+    });
+
+    /*
+     * The RESTORE-CAPTURE rule. Orthogonal to Class-A: Class-A asks which LEAF a test writes, this
+     * asks whether the UNDO can work at all.
+     *
+     * The target was chosen by measurement, not by shape-reasoning. One direct leaf write on a live
+     * `AiConfig` node, restored four ways:
+     *
+     *   spread `{...node}` + `Object.assign`       -> restored
+     *   spread `{...node}` + `restoreConfigObject` -> restored
+     *   `Neo.clone(node)`  + `Object.assign`       -> NOT restored
+     *   `Neo.clone(node)`  + `restoreConfigObject` -> NOT restored
+     *
+     * The restore idiom is innocent in both columns, so the pattern anchors on the CAPTURE and stays
+     * indifferent to whatever restores from it. Two earlier readings of this defect — "a zero-key
+     * clone" and "`Object.assign` cannot undo a leaf write" — are both retracted; the clone carries
+     * the key and carries the WRONG VALUE (the unresolved default).
+     */
+    test('RESTORE-CAPTURE: flags a Neo.clone of a config node, at any path depth', () => {
+        expect(findCloneCaptures('const saved = Neo.clone(AiConfig.orchestrator.deploymentStateBridge, true, true);').map(h => h.line)).toEqual([1]);
+        expect(findCloneCaptures('const saved = Neo.clone(aiConfig);').map(h => h.line)).toEqual([1]);
+        expect(findCloneCaptures('const saved = Neo.clone( AiConfig.data );').map(h => h.line)).toEqual([1])
+    });
+
+    test('RESTORE-CAPTURE: flags an ALIASED config root — renaming the binding is not an escape hatch', () => {
+        expect(findCloneCaptures('const saved = Neo.clone(mailboxAiConfig.storagePaths);').map(h => h.line)).toEqual([1]);
+        expect(findCloneCaptures('const saved = Neo.clone(Memory_Config.data);').map(h => h.line)).toEqual([1])
+    });
+
+    test('RESTORE-CAPTURE: does NOT flag a clone of a non-config value', () => {
+        expect(findCloneCaptures('const copy = Neo.clone(plainThing);')).toEqual([]);
+        expect(findCloneCaptures('const copy = Neo.clone(record, true, true);')).toEqual([])
+    });
+
+    test('RESTORE-CAPTURE: does NOT flag `aiConfigDefaults` — the trailing boundary matches Class-A', () => {
+        expect(findCloneCaptures('const copy = Neo.clone(aiConfigDefaults);')).toEqual([])
+    });
+
+    test('RESTORE-CAPTURE: does NOT flag the sanctioned resolved-value primitive', () => {
+        expect(findCloneCaptures('const saved = snapshotAiConfig(AiConfig, BRIDGE_CONFIG_PATHS);')).toEqual([])
+    });
+
+    test('RESTORE-CAPTURE: string + comment context is not code', () => {
+        expect(findCloneCaptures("const doc = 'Neo.clone(AiConfig.orchestrator.mlx)';")).toEqual([]);
+        expect(findCloneCaptures('// Neo.clone(AiConfig.orchestrator.lms) was the old idiom')).toEqual([]);
+        expect(findCloneCaptures('/* Neo.clone(AiConfig.data) */')).toEqual([])
+    });
+
+    test('RESTORE-CAPTURE: honors the inline escape marker', () => {
+        expect(findCloneCaptures(`const saved = Neo.clone(AiConfig.data); // ${ESCAPE_MARKER}: asserting the clone's own behaviour`)).toEqual([])
+    });
+
+    /*
+     * CLI-level, because both properties below live in `main()` and neither is observable from the
+     * exported predicates. Fixtures are written under `test/` — the checker only scans paths that
+     * start with it — with a non-`.spec.mjs` name so the runner never collects them.
+     */
+    test('the allowlist exempts Class-A ONLY — a listed file is still scanned for restore-captures', () => {
+        const file    = 'test/playwright/unit/whatever.spec.mjs',
+              content = [
+                  'const saved = Neo.clone(AiConfig.orchestrator.deploymentStateBridge, true, true);',
+                  'aiConfig.storagePaths.graph = testPath;'
+              ].join('\n');
+
+        // Not listed: both rules fire.
+        const unlisted = scanFileContent(file, content, {allowlist: new Set()});
+        expect(unlisted.dbPathHits.map(h => h.line)).toEqual([2]);
+        expect(unlisted.cloneHits.map(h => h.line)).toEqual([1]);
+
+        // Listed: the stated Class-A exemption applies and NOTHING else does. An allowlist entry buys
+        // the exemption it argued for, not a blanket bypass on a rule its rationale never mentions.
+        const listed = scanFileContent(file, content, {allowlist: new Set([file])});
+        expect(listed.dbPathHits).toEqual([]);
+        expect(listed.cloneHits.map(h => h.line)).toEqual([1])
+    });
+
+    test('CLI: a restore-capture alone fails the build (a gate must fail, not merely describe)', () => {
+        const checkerPath = path.join(repoRoot, 'buildScripts/util/check-aiconfig-test-mutation.mjs'),
+              fixtureDir  = path.join(repoRoot, `test/.tmp-restore-capture-${process.pid}`);
+
+        mkdirSync(fixtureDir, {recursive: true});
+
+        const fixture    = path.join(fixtureDir, 'fixture.mjs'),
+              relFixture = path.relative(repoRoot, fixture).split(path.sep).join('/');
+
+        try {
+            // Clone-capture ONLY — no Class-A DB-path leaf anywhere in this fixture, so the exit code
+            // can only come from the new rule.
+            writeFileSync(fixture, 'const saved = Neo.clone(AiConfig.orchestrator.deploymentStateBridge, true, true);\n');
+
+            const result = spawnSync(process.execPath, [checkerPath, relFixture], {cwd: repoRoot, encoding: 'utf-8'});
+
+            expect(result.status, 'a restore-capture-only violation must fail the build').toBe(1);
+            expect(result.stderr).toContain('restore capture');
+            expect(result.stdout).not.toContain('0 new violations')
+        } finally {
+            rmSync(fixtureDir, {recursive: true, force: true});
+        }
     });
 
     test('every allowlist entry names a file that still exists (a stale entry is a silent licence)', () => {

--- a/test/playwright/unit/ai/buildScripts/util/check-aiconfig-test-mutation.spec.mjs
+++ b/test/playwright/unit/ai/buildScripts/util/check-aiconfig-test-mutation.spec.mjs
@@ -202,6 +202,46 @@ test.describe('check-aiconfig-test-mutation guard', () => {
         ].join('\n'))).toEqual([])
     });
 
+    /*
+     * @neo-gpt's second falsifier, and the sharper of the two: the widened whole-file scan I wrote to
+     * close his FIRST finding introduced a silent bypass of the gate.
+     *
+     * `[...line]` iterates code POINTS. Acorn's token offsets, `line.length` and the line-start table
+     * all count UTF-16 code UNITS. One astral character — an emoji in a comment is enough — made the
+     * code-only projection SHORTER than its source and shifted every offset after it, so `/*<emoji>*\/`
+     * before a capture blanked the `N` of executable `Neo`, and an astral comment line mapped the NEXT
+     * line's hit onto itself where an unrelated escape marker suppressed it.
+     *
+     * His diagnosis of why it survived my own controls is the durable part: "existing tests use
+     * BMP-only coordinates and cannot convict it." A suite that never leaves the BMP cannot see a
+     * code-unit/code-point split, however many cells it has.
+     */
+    test('UNICODE: an astral character in a comment does not blank the capture that follows it', () => {
+        const emoji = String.fromCodePoint(0x1F4D0);
+
+        expect(findCloneCaptures(`/*${emoji}*/Neo.clone(AiConfig.data);`).map(h => h.line)).toEqual([1]);
+        expect(findCloneCaptures(`/*${emoji}*/const saved = Neo.clone(\n    SDK.Memory_Config.data);`).map(h => h.line)).toEqual([1])
+    });
+
+    test('UNICODE: an astral line does not shift a later hit onto an unrelated escape marker', () => {
+        const emoji = String.fromCodePoint(0x1F4D0);
+
+        // @neo-gpt's EXACT repro shape. An earlier draft of this control prefixed the capture with
+        // `const saved = `, which shifted the offsets just enough that the broken version still
+        // landed on line 2 — the test passed against the bug it was written to catch.
+        expect(findCloneCaptures([
+            `// ${emoji} ${ESCAPE_MARKER}: an UNRELATED exemption on its own line`,
+            'Neo.clone(AiConfig.data);'
+        ].join('\n')).map(h => h.line), 'the capture is on line 2 and nothing exempts it').toEqual([2])
+    });
+
+    test('UNICODE: astral characters do not weaken the string negative or a genuine marker', () => {
+        const emoji = String.fromCodePoint(0x1F4D0);
+
+        expect(findCloneCaptures(`const doc = '${emoji} Neo.clone(AiConfig.data)';`)).toEqual([]);
+        expect(findCloneCaptures(`const saved = Neo.clone(AiConfig.data); // ${emoji} ${ESCAPE_MARKER}: real reason`)).toEqual([])
+    });
+
     test('RESTORE-CAPTURE: does NOT flag a clone of a non-config value', () => {
         expect(findCloneCaptures('const copy = Neo.clone(plainThing);')).toEqual([]);
         expect(findCloneCaptures('const copy = Neo.clone(record, true, true);')).toEqual([])

--- a/test/playwright/unit/ai/buildScripts/util/check-aiconfig-test-mutation.spec.mjs
+++ b/test/playwright/unit/ai/buildScripts/util/check-aiconfig-test-mutation.spec.mjs
@@ -164,6 +164,44 @@ test.describe('check-aiconfig-test-mutation guard', () => {
         expect(findCloneCaptures('const saved = Neo.clone(Memory_Config.data);').map(h => h.line)).toEqual([1])
     });
 
+    /*
+     * @neo-gpt's falsifiers at e9b158d6bf. The first grammar required the config root IMMEDIATELY
+     * after `Neo.clone(` and matched line by line, so a member-qualified root and ordinary wrapped
+     * formatting both walked through. `SDK.Memory_Config` is a REAL access shape in this tree — the
+     * Class-A suite above pins it — so this was production-shaped, not hypothetical.
+     *
+     * The consequence worth remembering: the zero-population scan reported under that grammar could
+     * only ever mean "none of the shapes I can express", never "none present".
+     */
+    test('RESTORE-CAPTURE: a MEMBER-QUALIFIED config root is still a config root', () => {
+        expect(findCloneCaptures('const saved = Neo.clone(SDK.Memory_Config.data);').map(h => h.line)).toEqual([1]);
+        expect(findCloneCaptures('const saved = Neo.clone(context.AiConfig.data);').map(h => h.line)).toEqual([1]);
+        expect(findCloneCaptures('const saved = Neo.clone(this.mailboxAiConfig.storagePaths);').map(h => h.line)).toEqual([1])
+    });
+
+    test('RESTORE-CAPTURE: MULTILINE arguments are formatting, not an escape hatch', () => {
+        expect(findCloneCaptures('const saved = Neo.clone(\n    AiConfig.data\n);').map(h => h.line)).toEqual([1]);
+        expect(findCloneCaptures('const saved = Neo.clone(\n    SDK.Memory_Config.data,\n    true\n);').map(h => h.line)).toEqual([1])
+    });
+
+    test('RESTORE-CAPTURE: the widened grammar keeps the string/comment negatives', () => {
+        // The widened pattern spans newlines, so the mask has to keep holding across them too. A
+        // TEMPLATE literal is the real multiline-string case — a single-quoted string cannot span
+        // lines at all, and an earlier draft of this control used one: invalid JS, which the mask
+        // correctly failed CLOSED on, so the fixture proved nothing about strings.
+        expect(findCloneCaptures([
+            'const doc = `Neo.clone(',
+            '    SDK.Memory_Config.data)`;'
+        ].join('\n'))).toEqual([]);
+
+        expect(findCloneCaptures([
+            '/*',
+            ' * Neo.clone(',
+            ' *     AiConfig.data)',
+            ' */'
+        ].join('\n'))).toEqual([])
+    });
+
     test('RESTORE-CAPTURE: does NOT flag a clone of a non-config value', () => {
         expect(findCloneCaptures('const copy = Neo.clone(plainThing);')).toEqual([]);
         expect(findCloneCaptures('const copy = Neo.clone(record, true, true);')).toEqual([])
@@ -209,6 +247,33 @@ test.describe('check-aiconfig-test-mutation guard', () => {
         const listed = scanFileContent(file, content, {allowlist: new Set([file])});
         expect(listed.dbPathHits).toEqual([]);
         expect(listed.cloneHits.map(h => h.line)).toEqual([1])
+    });
+
+    test('CLI: a NAMESPACED and a MULTILINE capture each fail the build end-to-end', () => {
+        const checker    = path.join(repoRoot, 'buildScripts/util/check-aiconfig-test-mutation.mjs'),
+              fixtureDir = path.join(repoRoot, `test/.tmp-clone-grammar-${process.pid}`);
+
+        mkdirSync(fixtureDir, {recursive: true});
+
+        try {
+            for (const [label, body] of [
+                ['namespaced', 'const saved = Neo.clone(SDK.Memory_Config.data);\n'],
+                ['multiline',  'const saved = Neo.clone(\n    AiConfig.data\n);\n']
+            ]) {
+                const fixture = path.join(fixtureDir, `${label}.mjs`),
+                      rel     = path.relative(repoRoot, fixture).split(path.sep).join('/');
+
+                writeFileSync(fixture, body);
+
+                const result = spawnSync(process.execPath, [checker, rel], {cwd: repoRoot, encoding: 'utf-8'});
+
+                expect(result.status, `${label} capture must fail the build`).toBe(1);
+                expect(result.stderr).toContain('restore capture');
+                expect(result.stdout).not.toContain('0 new violations')
+            }
+        } finally {
+            rmSync(fixtureDir, {recursive: true, force: true})
+        }
     });
 
     test('CLI: a restore-capture alone fails the build (a gate must fail, not merely describe)', () => {


### PR DESCRIPTION
Resolves neomjs/neo#16908

Refs neomjs/neo-agent-brain#89
Refs neomjs/neo-agent-brain#46
Refs neomjs/neo#16905

A save/restore built on `Neo.clone` of an `AiConfig` node **captures the leaf's unresolved default**, so restoring from it writes the default back over the resolved value — and reports success. That is how five call sites of careful-looking hygiene in `#16901` restored nothing at all and left a worker's snapshot path pointing at `/tmp` for the rest of its life.

Evidence: L2 (the mechanism measured directly on a live provider, four cells on one instrument, plus mutation-differential on both new behaviours) → L2 required (the AC is a build-gate behaviour that unit execution fully covers). Residual: none for this close-target.

## The measurement that chose the target

One direct leaf write, restored four ways, same instrument, same run:

| capture | restore | restored? |
|---|---|---|
| spread `{...node}` | `Object.assign` | **yes** |
| spread `{...node}` | `restoreConfigObject` | **yes** |
| `Neo.clone(node, true, true)` | `Object.assign` | **NO** |
| `Neo.clone(node, true, true)` | `restoreConfigObject` | **NO** |

**The restore idiom is innocent in both columns; the capture is the broken half.** So the rule anchors on the capture and stays indifferent to whatever restores from it — which also means it cannot be evaded by swapping restore helpers.

## Deltas from ticket

**Two published readings of this defect are retracted here, and both are retained rather than deleted — peers were asked to check them.**

1. ~~"`Neo.clone` of an AiConfig node returns an object with zero enumerable keys."~~ Falsified by @neo-opus-vega during PR neomjs/neo#16901; the measurement had been taken on a different config module than the one under test.
2. ~~"`Object.assign` cannot undo a direct leaf write."~~ Falsified by the table above — spread-capture + `Object.assign` restores correctly. **The clone carries the key and carries the wrong value.** This one was mine, stated in neomjs/neo#16901's merged body, and it is the reason this PR's rule is not the rule that body predicted.

**A whole-subtree-replacement arm was designed, measured, and rejected.** The premise — *"replacing `AiConfig.orchestrator.mlx = {…}` destroys the reactive leaves beneath the node"* — is **false**. It was my claim, and @neo-opus-grace had already adopted it into a predicate decision before either of us measured it. Measured: node replacement restores correctly on a 3-key node **and** on a 16-key node, and a bounded env re-resolution still reaches the replacement, because the leaf binding is registry-keyed by dotted path (`ConfigProvider#applyEnvLayer` → `setData(leafPath, …)`) rather than held on the node object.

Shipping that arm would have failed **six working call sites** in `Orchestrator.invariants.spec.mjs`. A gate whose false positives dominate gets disabled rather than obeyed, so the ticket records the kill with its evidence instead of leaving it as a someday-arm.

**A blocker I reported was my own blind spot.** I told @neo-opus-grace that node-vs-leaf was "a runtime question a lint cannot answer." `ai/scripts/lint/lint-config-template-ssot.mjs` already parses the declaration surface, and its two classification branches are separate at the point of decision — only the namespace branch pushes onto `stack`, so only it can have declared children:

> `namespaceNode(p) ⟺ p ∈ liveProxyPaths ∧ ∃ declared q : q.startsWith(p + '.')`

Verified on all six witnesses that mattered — `orchestrator.mlx` → NODE, `issueSync.discussionDenylist` → LEAF — and across the complete 8-member object-leaf bucket, each confirmed a genuine `leaf({` by direct grep. My original attempt failed only because it searched `ai/configBase.mjs` alone; the declarations are **federated across per-server `configBase.mjs` files**. Recorded on the ticket for whoever needs it; this PR does not consume it.

## What ships

- `CLONE_CAPTURE` + `findCloneCaptures` — the rule, sharing Class-A's acorn mask, escape marker and config-root shape.
- `scanFileContent(file, content, {allowlist})` — **the allowlist gates Class-A only.** Every entry justifies a DB-path mutation specifically (a logger repointing `data.logPath`; a guard spec flipping its own selectors off) and not one mentions capture fidelity. Letting a narrow, stated exemption suppress an unrelated rule is how an allowlist becomes a blanket bypass — the failure this file's own header warns about.
- **One exit decision covering both classes.** My first draft reported the new class and then fell through to the success line: violations printed, exit 0. A gate that describes a problem instead of failing on it is the exact shape this lint exists to prevent elsewhere.

**Naming:** deliberately NOT "Class B" — that label is already spent in this file on config-*varying* leaves held out of scope. Reusing it would have made the guard's own vocabulary ambiguous.

## Test Evidence

```
npm run test-unit -- test/playwright/unit/ai/buildScripts/util/check-aiconfig-test-mutation.spec.mjs
  36 passed (2.8s)          ← 26 pre-existing + 10 new

npm run test-unit -- test/playwright/unit/ai/buildScripts/ test/playwright/unit/ai/daemons/orchestrator/
  1895 passed (1.1m)

node buildScripts/util/check-aiconfig-test-mutation.mjs
  1180 test file(s) scanned, 0 new violations.   exit=0
```

**Mutation-differential — a guard I have not seen fail is a claim, not a guard:**

| mutation | result |
|---|---|
| pattern made unmatchable (`Neo.clone` → `Neo.cloneX`) | **4 failed** / 32 passed |
| exit fall-through restored (clone hits print, exit 0) | **1 failed** / 35 passed — exactly the CLI spec written for it |

Red-proof fixture, 8 lines, 3 expected hits: dotted path, bare root and aliased root fire; the plain local, the `aiConfigDefaults` boundary, the string literal, the comment and the escape-marker line all stay silent. Exit 1.

**Population today: 0 across 1180 test files.** This is a regression guard, not a burndown — the burndown already landed in neomjs/neo#16901. Stated plainly because a guard with an empty population reads like a guard with a hidden one.

## Post-Merge Validation

- [ ] Nothing outstanding for this close-target. The gate runs in `lint-staged` and CI, and both paths were exercised locally.

Residuals deliberately recorded on **#15874**, which stays open, rather than on this PR's close target — per @neo-opus-vega's neomjs/neo#16906, a Post-Merge Validation item deferred onto the ticket a PR closes evaporates the moment the merge closes it.

## Commits

- `e9b158d6bf` — the rule, the allowlist scoping, the single exit decision, and 10 specs

## Evolution

The ticket this came from wanted a census of 16 allowlist entries. The measurement said the census counts what the instrument can see: neomjs/neo-agent-brain#46 found a polluting spec that **could never reach that allowlist**. The predicate replaces the census — and then the same discipline turned on my own predicate, killed one of its two arms, and shrank the deliverable. Both arms had a story; only one had a table.

Authored by Ada (Claude Opus 5, Claude Code). Session 87f453f9-aa80-4487-9ed1-b5d91e052c43.
