### PR TITLE
feat: the cockpit page redeems the fleet bearer itself (#16911)

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -7,6 +7,12 @@
             "runtimeArgs": ["webpack", "serve", "-c", "./buildScripts/webpack/webpack.server.config.mjs"],
             "port": 8080,
             "autoPort": true
+        },
+        {
+            "name": "cockpit",
+            "runtimeExecutable": "npm",
+            "runtimeArgs": ["run", "cockpit"],
+            "port": 8080
         }
     ]
 }

--- a/ai/configBase.mjs
+++ b/ai/configBase.mjs
@@ -313,6 +313,19 @@ class ConfigBase extends ConfigProvider {
                  */
                 bearer         : leaf('', 'NEO_FLEET_BEARER', 'string'),
                 /**
+                 * Arms the transport's browser bearer-handshake redemption (`GET /fleet/handshake`):
+                 * while armed, an exact-allowlisted cockpit ORIGIN may fetch the process bearer once
+                 * per page boot, which is how the one-command flow (`npm run cockpit`) hands the
+                 * secret to a plain browser page with no agent in the loop. Default OFF — a
+                 * standalone `npm run ai:fleet-server` exposes zero new surface; the cockpit
+                 * launcher arms it in the fleet child's env because arming is a custody decision
+                 * and custody lives with the launcher (`buildScripts/devCockpit.mjs`). While armed,
+                 * browser-caller authentication deliberately collapses to the exact-Origin policy —
+                 * the documented Option-B dev-mode widening, never the packaged product path.
+                 * @type {boolean}
+                 */
+                bearerHandshake: leaf(false, 'NEO_FLEET_BEARER_HANDSHAKE', 'boolean'),
+                /**
                  * Exact origins the Fleet Manager cockpit may call browser-facing Agent OS HTTP
                  * transports from. The legacy local Fleet bridge and the composed KB/MC/Fleet CORS
                  * boundary consume the same resolved array. CSV-typed: the env form is a

--- a/ai/scripts/lint/config-leaf-parity.json
+++ b/ai/scripts/lint/config-leaf-parity.json
@@ -167,6 +167,7 @@
         "engines.chroma.useUnitTestDatabase",
         "fleet",
         "fleet.bearer",
+        "fleet.bearerHandshake",
         "fleet.cockpitOrigins",
         "fleet.dataDir",
         "fleet.harnessBinaries",

--- a/ai/services/fleet/devFleetServer.mjs
+++ b/ai/services/fleet/devFleetServer.mjs
@@ -212,7 +212,7 @@ async function boot() {
         // SOURCE, the Neo-free site the spec exercises. An explicit resolver stays the override seam.
         resolveSeatArming       : FleetManager.wakeStateOptions.resolveSeatArming ?? null,
         wakeReceiverManifestPath: FleetManager.wakeStateOptions.wakeReceiverManifestPath ?? null,
-        readPresence                   : planeClient ? createPlaneWhoIsOnlineReader(planeClient) : null
+        readPresence            : planeClient ? createPlaneWhoIsOnlineReader(planeClient) : null
     });
 
     // Wire the composed activitySource onto FleetControlBridge. The memory-core mailbox + graph
@@ -329,7 +329,10 @@ async function boot() {
             bearerToken,
             viewerContext : viewer,
             allowedOrigins: origins,
-            runInContext  : (context, fn) => RequestContextService.run(context, fn)
+            // The launcher's custody decision, resolved at the use site: `npm run cockpit` arms
+            // the browser bearer handshake in this child's env; a standalone boot defaults off.
+            bearerHandshake: AiConfig.fleet.bearerHandshake,
+            runInContext   : (context, fn) => RequestContextService.run(context, fn)
         });
 
         // AWAITED plane teardown before every exit: an un-awaited close races process death, which

--- a/ai/services/fleet/fleetBridgeServer.mjs
+++ b/ai/services/fleet/fleetBridgeServer.mjs
@@ -55,6 +55,10 @@ import {isLocalBearerToken}      from '../../mcp/server/shared/helpers/localBear
  *     cockpit origins for the CORS policy.
  * @param {String[]} [opts.extraAllowedHosts=[]] Additional exact `Host` header values (the defaults
  *     always cover the bound host:port spellings).
+ * @param {Boolean}  [opts.bearerHandshake=false] Arms `GET /fleet/handshake`: an exact-allowlisted
+ *     browser Origin may redeem the process bearer, which is how the one-command cockpit hands the
+ *     secret to a plain page with no agent seam (see the `fleet.bearerHandshake` leaf for the
+ *     custody decision). Unarmed, the path stays inside the bearer-gated 404 surface.
  * @returns {Promise<http.Server>} resolves once the server is listening.
  * @throws {TypeError} When the bearer, viewer binding, or context runner is missing/invalid — the
  *     fail-closed startup contract of the ingress trust boundary.
@@ -68,7 +72,8 @@ export function startFleetBridgeServer({
     viewerContext     = null,
     runInContext      = null,
     allowedOrigins    = ['http://localhost:8080', 'http://127.0.0.1:8080'],
-    extraAllowedHosts = []
+    extraAllowedHosts = [],
+    bearerHandshake   = false
 } = {}) {
     if (!isLocalBearerToken(bearerToken)) {
         throw new TypeError('[fleet] startup refused: a canonical 32-byte unpadded-base64url bearerToken is required (fail-closed ingress)')
@@ -90,6 +95,7 @@ export function startFleetBridgeServer({
     const admit = createFleetIngressGuard({
         bearerToken,
         allowedOrigins,
+        bearerHandshake,
         resolveAllowedHosts() {
             const hosts = ['127.0.0.1', 'localhost', '[::1]']
                 .map(name => boundPort === null ? null : `${name}:${boundPort}`)
@@ -142,6 +148,16 @@ export function startFleetBridgeServer({
 
             res.writeHead(204, headers);
             return res.end()
+        }
+
+        // The armed browser bearer handshake (guard step 3.5): the ONE response that carries the
+        // secret — never cached, never keep-alive, logged as identity facts only (the redeeming
+        // origin; the bearer itself stays out of every log line this process emits).
+        if (decision.handshake) {
+            console.log(`[fleet] bearer handshake redeemed by origin ${req.headers.origin} at ${new Date().toISOString()}`);
+            res.setHeader('Connection', 'close');
+            res.setHeader('Cache-Control', 'no-store');
+            return respond(res, 200, {ok: true, result: {bearerToken}}, decision.corsOrigin)
         }
 
         // Exact-path match — a sibling path like /fleetx must fail closed, never reach dispatch.

--- a/ai/services/fleet/fleetIngressAuth.mjs
+++ b/ai/services/fleet/fleetIngressAuth.mjs
@@ -18,7 +18,10 @@ import {isLocalBearerToken, matchesLocalBearerToken} from '../../mcp/server/shar
  * unpadded base64url; length-mismatched values fail closed before the equal-length compare).
  * CORS preflights (`OPTIONS`) cannot carry an `Authorization` header, so they are admitted on
  * Host + Origin alone — a preflight grants nothing: no body is read, no method dispatches, and the
- * echoed headers only permit the real request to present its bearer.
+ * echoed headers only permit the real request to present its bearer. When the launcher arms the
+ * browser bearer handshake (`bearerHandshake`), `GET /fleet/handshake` is additionally admitted on
+ * Host + a present-and-allowlisted Origin — the single deliberate pre-bearer admission, documented
+ * as the Option-B dev-mode custody widening on the `fleet.bearerHandshake` config leaf.
  *
  * The guard returns a decision object; applying it (status codes, headers, socket teardown) stays
  * the transport's job. Pure data-plane module by design — no Neo import, no config read, no state.
@@ -35,11 +38,19 @@ import {isLocalBearerToken, matchesLocalBearerToken} from '../../mcp/server/shar
  * @param {Function} options.resolveAllowedHosts Returns the iterable of exact `Host` header values
  *     admitted right now. A thunk because the bound port is only known after `listen` (ephemeral
  *     port 0 in tests); resolving late keeps the guard honest instead of freezing a guess.
- * @returns {Function} `admit(req)` → `{admitted: true, corsOrigin: String|null}` or
+ * @param {Boolean}  [options.bearerHandshake=false] Arms the browser bearer-handshake admission:
+ *     `GET /fleet/handshake` is then admitted on Host + a PRESENT-and-allowlisted Origin — stricter
+ *     than preflight, which tolerates an absent Origin. The handshake exists to hand the bearer to
+ *     a browser page, so a caller that states no browser origin has no business on the path; the
+ *     boot probe and every non-browser caller keep using the bearer-gated routes. Unarmed
+ *     (default), the path has no special admission and falls through to the bearer check —
+ *     byte-identical to the pre-handshake surface.
+ * @returns {Function} `admit(req)` → `{admitted: true, corsOrigin: String|null}` (plus
+ *     `handshake: true` on an armed handshake admission) or
  *     `{admitted: false, status: Number, error: String, corsOrigin: String|null}`.
  * @throws {TypeError} When the bearer is not canonical or the origin/host inputs are malformed.
  */
-export function createFleetIngressGuard({bearerToken, allowedOrigins, resolveAllowedHosts} = {}) {
+export function createFleetIngressGuard({bearerToken, allowedOrigins, resolveAllowedHosts, bearerHandshake = false} = {}) {
     if (!isLocalBearerToken(bearerToken)) {
         throw new TypeError('[fleetIngressAuth] a canonical 32-byte unpadded-base64url bearerToken is required')
     }
@@ -82,6 +93,18 @@ export function createFleetIngressGuard({bearerToken, allowedOrigins, resolveAll
         // header echo permitting the real request to present the bearer.
         if (req.method === 'OPTIONS') {
             return {admitted: true, preflight: true, corsOrigin}
+        }
+
+        // 3.5 Armed bearer handshake — the one admission that runs BEFORE the bearer check,
+        // because it exists to bootstrap it. Stricter than preflight: the Origin must be PRESENT
+        // and allowlisted (a browser cannot forge its Origin; a caller stating none is not the
+        // browser page this path serves). Unarmed, the path falls through to step 4 and refuses
+        // 401 like any other bearer-less request — the default surface is unchanged.
+        if (bearerHandshake && req.method === 'GET' &&
+            new URL(req.url, 'http://127.0.0.1').pathname === '/fleet/handshake') {
+            return corsOrigin === null
+                ? {admitted: false, status: 403, error: 'fleet: handshake requires an allowlisted browser origin', corsOrigin: null}
+                : {admitted: true, handshake: true, corsOrigin}
         }
 
         // 4. Bearer — constant-time via the shared localBearer primitives; malformed and

--- a/apps/agentos/app.mjs
+++ b/apps/agentos/app.mjs
@@ -1,5 +1,6 @@
 import Viewport             from './view/Viewport.mjs';
 import {FLEET_LOCAL_TRANSPORT_ERRORS, installFleetBridge} from './fleet/installFleetBridge.mjs';
+import {redeemFleetBearerHandshake}                       from './fleet/redeemFleetBearerHandshake.mjs';
 import WindowManager        from '../../src/manager/Window.mjs';
 
 /**
@@ -35,18 +36,48 @@ export function resolveFleetTransportMode({href}) {
     return new URL(href).protocol === 'app:' ? 'shell' : 'browser'
 }
 
+/**
+ * @summary Resolves the Fleet endpoint from the boot window's serialized URL — the one endpoint
+ * authority (`?fleetUrl=` override, else the pinned default) both the boot install and the
+ * handshake redemption derive from.
+ * @returns {String}
+ */
+export function resolveFleetUrl() {
+    const params = new URLSearchParams(Neo.config.url.search);
+
+    return params.has('fleetUrl') ? params.get('fleetUrl') : 'http://127.0.0.1:8083/fleet'
+}
+
+// The one-command hand-off, page half: in direct-browser mode with the designed slot still empty,
+// redeem the bearer from the transport's armed handshake BEFORE the app boots — this module-level
+// await completes inside `importApp`'s dynamic import, ahead of every `onStart` call, so the boot
+// install below sees the bearer exactly as if a launcher had placed it. Fail-closed: an unarmed or
+// absent transport resolves null and the existing bearer-less boot proceeds unchanged. The
+// URL-envelope guard keeps the module importable OUTSIDE the worker boot (unit specs import this
+// module for its pure exports; there is no serialized boot URL there, so there is nothing to dial).
+const bootUrl = globalThis.Neo?.config?.url;
+
+if (bootUrl?.href && resolveFleetTransportMode(bootUrl) === 'browser' && !globalThis.AgentOS?.fleet?.bearerToken) {
+    const token = await redeemFleetBearerHandshake({url: resolveFleetUrl()});
+
+    if (token) {
+        const agentOS = globalThis.AgentOS = globalThis.AgentOS || {};
+
+        agentOS.fleet             = agentOS.fleet || {};
+        agentOS.fleet.bearerToken = token
+    }
+}
+
 export const onStart = () => {
     const
         fallbackWindowId = Neo.bootingWindowId,
-        params           = new URLSearchParams(Neo.config.url.search),
-        fleetUrl         = params.has('fleetUrl')
-              ? params.get('fleetUrl')
-              : 'http://127.0.0.1:8083/fleet';
+        fleetUrl         = resolveFleetUrl();
 
     // The process bearer is an IN-MEMORY hand-off only: the Electron main process, the
-    // Neural Link, or a test init-script places it at globalThis.AgentOS.fleet.bearerToken BEFORE
-    // app start. Deliberately never read from URL params — a secret in a URL persists in history,
-    // logs, and referrers, so installFleetBridge refuses credential-shaped query params outright.
+    // Neural Link, a test init-script — or the armed-handshake redemption above — places it at
+    // globalThis.AgentOS.fleet.bearerToken BEFORE app start. Deliberately never read from URL
+    // params — a secret in a URL persists in history, logs, and referrers, so installFleetBridge
+    // refuses credential-shaped query params outright.
     // Without the bearer the bridge installs fail-closed: every call rejects locally, named.
     const bearerToken = globalThis.AgentOS?.fleet?.bearerToken ?? null;
 
@@ -66,7 +97,26 @@ export const onStart = () => {
     } else {
         // Direct-browser dev mode remains the distinct transitional topology: its in-memory bearer
         // and App-Worker credential field are supported here, never in the packaged app:// path.
-        installFleetBridge({url: fleetUrl, bearerToken})
+        installFleetBridge({url: fleetUrl, bearerToken});
+
+        // Late-transport healing: the module-level redemption races the fleet child's boot (plane
+        // admission alone can take seconds), and on a SharedWorker topology a reload re-enters
+        // here without re-running module scope. One lazy retry per joining window upgrades the
+        // fail-closed bridge in place — installFleetBridge is documented additive + idempotent,
+        // and the pane resolves the slot per call, so the next poll goes live. Still-no-bearer
+        // stays the honest fail-closed state.
+        if (!bearerToken) {
+            redeemFleetBearerHandshake({url: fleetUrl}).then(token => {
+                if (token) {
+                    const agentOS = globalThis.AgentOS = globalThis.AgentOS || {};
+
+                    agentOS.fleet             = agentOS.fleet || {};
+                    agentOS.fleet.bearerToken = token;
+
+                    installFleetBridge({url: fleetUrl, bearerToken: token})
+                }
+            })
+        }
     }
 
     Neo.app({

--- a/apps/agentos/fleet/redeemFleetBearerHandshake.mjs
+++ b/apps/agentos/fleet/redeemFleetBearerHandshake.mjs
@@ -1,0 +1,73 @@
+/**
+ * @module apps/agentos/fleet/redeemFleetBearerHandshake
+ * @summary The browser half of the one-command bearer hand-off: redeem the Fleet process bearer
+ * from the transport's armed handshake endpoint (`GET /fleet/handshake`) so the cockpit page can
+ * fill its designed pre-boot slot (`globalThis.AgentOS.fleet.bearerToken`) with no agent in the
+ * loop — no Neural Link injection, no Electron shell, no hand-carried env var.
+ *
+ * Trust posture, client half: the endpoint only answers armed launches (`fleet.bearerHandshake`,
+ * armed by `buildScripts/devCockpit.mjs`) and only for exact-allowlisted browser Origins — this
+ * module simply asks once and treats every non-success as "no bearer". The result is held in
+ * memory and handed to `installFleetBridge` as an argument; it is never persisted, logged, or
+ * placed in a URL. Fail-closed by shape: any refusal, timeout, malformed body, or malformed token
+ * resolves `null`, which boots the existing fail-closed bridge — the pre-handshake behavior,
+ * exactly.
+ *
+ * Worker-realm module: no Node imports, no Neo import — mirrors its sibling
+ * `installFleetBridge.mjs`, including the format-only bearer check (generation + constant-time
+ * verification stay Node-side in `ai/mcp/server/shared/helpers/localBearer.mjs`).
+ */
+
+/**
+ * Canonical shape of the Fleet process bearer — the same format-only gate its sibling
+ * `installFleetBridge.mjs` applies before dialing the transport.
+ * @type {RegExp}
+ */
+const FLEET_BEARER_PATTERN = /^[A-Za-z0-9_-]{43}$/;
+
+/**
+ * @summary Redeem the process bearer from an armed Fleet transport, or resolve `null` fail-closed.
+ *
+ * The handshake URL derives from the fleet endpoint's own origin (`<origin>/fleet/handshake`), so
+ * the one URL authority the cockpit already resolves (`fleetUrl`) stays the only endpoint input —
+ * no second host/port knob that can drift. The request is a plain GET (no custom headers → no
+ * preflight); the browser attaches the page Origin itself, which is the fact the server's
+ * exact-origin admission decides on.
+ *
+ * @param {Object}   opts
+ * @param {String}   opts.url                          The absolute Fleet endpoint the cockpit dials
+ *     (e.g. `http://127.0.0.1:8083/fleet`) — the handshake rides its origin.
+ * @param {Function} [opts.fetchImpl=globalThis.fetch] Injectable fetch for tests.
+ * @param {Number}   [opts.timeoutMs=1500]             Redemption patience: an absent transport
+ *     refuses the connection in milliseconds, so this bound only trims the hung-listener tail.
+ * @returns {Promise<String|null>} the canonical bearer, or `null` on every non-success path.
+ */
+export async function redeemFleetBearerHandshake({url, fetchImpl = globalThis.fetch, timeoutMs = 1500} = {}) {
+    let handshakeUrl;
+
+    try {
+        handshakeUrl = new URL('/fleet/handshake', new URL(url).origin)
+    } catch {
+        return null
+    }
+
+    try {
+        const response = await fetchImpl(handshakeUrl.href, {
+            cache : 'no-store',
+            signal: AbortSignal.timeout(timeoutMs)
+        });
+
+        if (!response.ok) {
+            return null
+        }
+
+        const envelope = await response.json(),
+              token    = envelope?.ok === true ? envelope.result?.bearerToken : null;
+
+        return typeof token === 'string' && FLEET_BEARER_PATTERN.test(token) ? token : null
+    } catch {
+        // Refused connection (no transport), abort (hung listener), or non-JSON body — all the
+        // same honest answer: no bearer, boot fail-closed.
+        return null
+    }
+}

--- a/buildScripts/devCockpit.mjs
+++ b/buildScripts/devCockpit.mjs
@@ -24,6 +24,15 @@
  * listener that answers anything else is an INCOMPATIBLE occupant and the launcher refuses with a
  * named reason — never a silent second server, never a false reuse.
  *
+ * Protocol identity is COMPATIBILITY, never ADOPTION AUTHORITY: the unauthenticated probe proves
+ * "a fleet server", not "our fleet server". Because the cockpit page this launcher opens can
+ * REDEEM the incumbent's bearer (the armed handshake), adopting an unverified incumbent would let
+ * an unauthenticated port-probe hand the page another launch's credential and server-bound viewer.
+ * So reuse requires the established authenticated proof — `probeExistingFleetServer`, "same token,
+ * same viewer", driven by this environment's pinned `NEO_FLEET_BEARER` + resolved identity claim —
+ * and an incumbent this launcher cannot verify is REFUSED with the remediation named, before any
+ * page exists to redeem anything.
+ *
  * The launch contract (bearer half): this launcher IS the cockpit launch path — it generates the
  * one process-lifetime bearer in its own memory and hands it to the fleet child via env
  * (`NEO_FLEET_BEARER`, the in-memory channel), never via URL, log, or file. The browser side then
@@ -132,9 +141,13 @@ export function probeFleetEndpoint(port, timeoutMs = 1500) {
  * @param {Number} options.fleetPort The resolved fleet port.
  * @param {('free'|'fleet'|'incompatible')} [options.endpointStatus] The probe result (omitted when refused pre-probe).
  * @param {String} [options.endpointDetail=''] The probe detail line.
+ * @param {Object|null} [options.reuseProof=null] The AUTHENTICATED reuse verdict for a `fleet`
+ *     occupant (`probeExistingFleetServer` shape: `{reusable, reason, viewer?, pid?}`), or `null`
+ *     when no proof could be attempted. Protocol identity alone never authorizes reuse: the page
+ *     this plan opens can redeem the incumbent's bearer, so an unproven incumbent is refused.
  * @returns {{refuse: Boolean, spawnFleet: Boolean, spawnWebpack: Boolean, notes: String[]}}
  */
-export function planCockpitBoot({fleetPort, endpointStatus, endpointDetail = ''}) {
+export function planCockpitBoot({fleetPort, endpointStatus, endpointDetail = '', reuseProof = null}) {
     if (fleetPort !== FLEET_PORT_DEFAULT) {
         return {
             refuse      : true,
@@ -160,11 +173,23 @@ export function planCockpitBoot({fleetPort, endpointStatus, endpointDetail = ''}
     }
 
     if (endpointStatus === 'fleet') {
+        if (reuseProof?.reusable === true) {
+            return {
+                refuse      : false,
+                spawnFleet  : false,
+                spawnWebpack: true,
+                notes       : [`fleet transport already serving :${fleetPort} — VERIFIED same token, same viewer (${reuseProof.viewer}, pid ${reuseProof.pid}); reusing it; not spawning a second server`]
+            };
+        }
+
         return {
-            refuse      : false,
+            refuse      : true,
             spawnFleet  : false,
-            spawnWebpack: true,
-            notes       : [`fleet transport already serving :${fleetPort} (${endpointDetail}) — reusing it; not spawning a second server`]
+            spawnWebpack: false,
+            notes       : [
+                `REFUSED: :${fleetPort} is occupied by a fleet server this launcher cannot verify (${reuseProof?.reason || 'no authenticated reuse proof was possible'}).`,
+                `The cockpit page can redeem the transport's bearer, so an UNVERIFIED incumbent must never become its credential authority — stop that process to let this launcher own a fresh transport, or export the incumbent's exact NEO_FLEET_BEARER (with the matching identity) so the authenticated reuse probe can prove "same token, same viewer".`
+            ]
         };
     }
 
@@ -186,13 +211,50 @@ export function planCockpitBoot({fleetPort, endpointStatus, endpointDetail = ''}
 async function main() {
     const
         fleetPort = Number(process.env.NEO_FLEET_PORT) || FLEET_PORT_DEFAULT,
-        probe     = fleetPort === FLEET_PORT_DEFAULT ? await probeFleetEndpoint(fleetPort) : null,
-        plan      = planCockpitBoot({
+        probe     = fleetPort === FLEET_PORT_DEFAULT ? await probeFleetEndpoint(fleetPort) : null;
+
+    // A protocol-identity occupant needs the AUTHENTICATED reuse proof before it may become the
+    // page's credential authority. The proof can only be attempted when this environment pins the
+    // incumbent's bearer (`NEO_FLEET_BEARER`) — the coordinated-launch mode; without a pin the
+    // launcher HOLDS no credential to authenticate with, and the plan refuses fail-closed.
+    let reuseProof = null;
+
+    if (probe?.status === 'fleet') {
+        const {isLocalBearerToken} = await import('../ai/mcp/server/shared/helpers/localBearer.mjs');
+
+        if (isLocalBearerToken(process.env.NEO_FLEET_BEARER)) {
+            try {
+                // The identity claim rides the shared stdio resolver, whose chain needs the Neo
+                // namespace — bootstrap it here, on this rare branch only, exactly like the fleet
+                // entrypoints do (the happy paths stay import-light).
+                await import('../src/Neo.mjs');
+                await import('../src/core/_export.mjs');
+                await import('../src/manager/Instance.mjs');
+
+                const {probeExistingFleetServer, resolveFleetViewerClaim} = await import('../ai/services/fleet/fleetLaunchContract.mjs'),
+                      viewer                                              = await resolveFleetViewerClaim();
+
+                reuseProof = await probeExistingFleetServer({
+                    probeUrl           : `http://127.0.0.1:${fleetPort}/fleet/probe`,
+                    bearerToken        : process.env.NEO_FLEET_BEARER,
+                    agentIdentityNodeId: viewer.agentIdentityNodeId
+                })
+            } catch (error) {
+                reuseProof = {reusable: false, reason: `reuse-proof attempt failed (${error.message})`}
+            }
+        } else {
+            reuseProof = {reusable: false, reason: 'no NEO_FLEET_BEARER pin in this environment — the launcher holds no credential to authenticate the incumbent with'}
+        }
+    }
+
+    const
+        plan     = planCockpitBoot({
             fleetPort,
             endpointStatus: probe?.status,
-            endpointDetail: probe?.detail ?? ''
+            endpointDetail: probe?.detail ?? '',
+            reuseProof
         }),
-        children  = [];
+        children = [];
 
     plan.notes.forEach(note => console.log(`[cockpit] ${note}`));
 

--- a/buildScripts/devCockpit.mjs
+++ b/buildScripts/devCockpit.mjs
@@ -27,8 +27,11 @@
  * The launch contract (bearer half): this launcher IS the cockpit launch path — it generates the
  * one process-lifetime bearer in its own memory and hands it to the fleet child via env
  * (`NEO_FLEET_BEARER`, the in-memory channel), never via URL, log, or file. The browser side then
- * receives it through the worker-realm injector (`ViewportController.wireFleetBridge`) — the
- * Neural Link / Electron seam — so no secret ever persists anywhere restartable.
+ * redeems it itself over the armed handshake (`NEO_FLEET_BEARER_HANDSHAKE` →
+ * `GET /fleet/handshake`, exact-Origin-gated): the page fills its designed in-memory slot before
+ * app boot with no agent in the loop, so no secret ever persists anywhere restartable. The
+ * worker-realm injector (`ViewportController.wireFleetBridge`) stays the explicit-selection seam
+ * for Neural Link / tooling flows.
  *
  * Signals: SIGINT/SIGTERM forward to every child this launcher spawned; a webpack exit tears the
  * session down; a fleet-server exit logs loudly while the cockpit degrades to its honest
@@ -216,8 +219,12 @@ async function main() {
             // a malformed override is ignored — the production default stands
         }
 
+        // NEO_FLEET_BEARER_HANDSHAKE: this launcher opens the page AND holds the bearer, so it is
+        // the one place arming the browser handshake is a coherent custody decision — the page the
+        // webpack child opens redeems the secret itself (apps/agentos/fleet/redeemFleetBearerHandshake.mjs),
+        // closing the launcher→page hand-off without an agent seam.
         const fleet = spawn(fleetCmd[0], fleetCmd.slice(1), {
-            env  : {...process.env, NEO_FLEET_BEARER: fleetBearer},
+            env  : {...process.env, NEO_FLEET_BEARER: fleetBearer, NEO_FLEET_BEARER_HANDSHAKE: '1'},
             stdio: 'inherit'
         });
 

--- a/test/playwright/unit/ai/buildScripts/devCockpit.spec.mjs
+++ b/test/playwright/unit/ai/buildScripts/devCockpit.spec.mjs
@@ -150,8 +150,10 @@ test.describe('buildScripts/devCockpit — the live-by-default boot plan', () =>
                 // probe means the bearer hand-down happened. No graph needed (stub viewer).
                 NEO_COCKPIT_FLEET_CMD: JSON.stringify([process.execPath, '--input-type=module', '-e',
                     // absolute specifiers (CWD-independent) + the Neo namespace bootstrap the fleet
-                    // module chain requires at load — the same entry-point invariant devFleetServer keeps
-                    `const root = ${JSON.stringify(repoRoot)}; await import(root + '/src/Neo.mjs'); await import(root + '/src/core/_export.mjs'); await import(root + '/src/manager/Instance.mjs'); const {startFleetBridgeServer} = await import(root + '/ai/services/fleet/fleetBridgeServer.mjs'); const server = await startFleetBridgeServer({port: 8083, bearerToken: process.env.NEO_FLEET_BEARER, viewerContext: {userId: 'cockpit-fixture', username: 'Cockpit Fixture', agentIdentityNodeId: '@cockpit-fixture'}, runInContext: (context, fn) => fn()}); ['SIGTERM', 'SIGINT'].forEach(signal => process.on(signal, () => server.close(() => process.exit(0))))`
+                    // module chain requires at load — the same entry-point invariant devFleetServer keeps.
+                    // The fixture consumes BOTH env halves of the launch contract exactly like
+                    // devFleetServer: the bearer and the handshake arm flag.
+                    `const root = ${JSON.stringify(repoRoot)}; await import(root + '/src/Neo.mjs'); await import(root + '/src/core/_export.mjs'); await import(root + '/src/manager/Instance.mjs'); const {startFleetBridgeServer} = await import(root + '/ai/services/fleet/fleetBridgeServer.mjs'); const server = await startFleetBridgeServer({port: 8083, bearerToken: process.env.NEO_FLEET_BEARER, bearerHandshake: process.env.NEO_FLEET_BEARER_HANDSHAKE === '1', viewerContext: {userId: 'cockpit-fixture', username: 'Cockpit Fixture', agentIdentityNodeId: '@cockpit-fixture'}, runInContext: (context, fn) => fn()}); ['SIGTERM', 'SIGINT'].forEach(signal => process.on(signal, () => server.close(() => process.exit(0))))`
                 ])
             },
             stdio: ['ignore', 'pipe', 'pipe']
@@ -166,7 +168,22 @@ test.describe('buildScripts/devCockpit — the live-by-default boot plan', () =>
             // default endpoint with zero manual server starts
             await expect.poll(async () => (await probeFleetEndpoint(8083)).status, {timeout: 30000}).toBe('fleet');
 
-            expect(output).toContain('starting fleet transport on :8083')
+            expect(output).toContain('starting fleet transport on :8083');
+
+            // The one-command hand-off, witnessed end-to-end through the REAL launcher: the
+            // launcher armed the child (NEO_FLEET_BEARER_HANDSHAKE), so a browser-Origin redemption
+            // returns a canonical bearer — and the redeemed value is proven by USE: the
+            // constant-time bearer gate on /fleet/probe admits it. Redeem → use, no agent seam.
+            const redemption = await fetch('http://127.0.0.1:8083/fleet/handshake', {headers: {Origin: 'http://localhost:8080'}}),
+                  {result}   = await redemption.json();
+
+            expect(redemption.status).toBe(200);
+            expect(result.bearerToken).toMatch(/^[A-Za-z0-9_-]{43}$/);
+
+            const probeWithRedeemed = await fetch('http://127.0.0.1:8083/fleet/probe', {headers: {Authorization: `Bearer ${result.bearerToken}`}});
+
+            expect(probeWithRedeemed.status).toBe(200);
+            expect((await probeWithRedeemed.json()).result.agentIdentityNodeId).toBe('@cockpit-fixture')
         } finally {
             // supervision teardown: one SIGTERM to the launcher ends the whole session
             const exited = new Promise(resolve => launcher.on('exit', resolve));

--- a/test/playwright/unit/ai/buildScripts/devCockpit.spec.mjs
+++ b/test/playwright/unit/ai/buildScripts/devCockpit.spec.mjs
@@ -33,6 +33,10 @@ const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../
  * listener, and a closed port — a listener is never presumed to be a fleet server.
  */
 test.describe('buildScripts/devCockpit — the live-by-default boot plan', () => {
+    // Two witnesses below OWN the real :8083 endpoint (the composed boot and the reuse
+    // falsifier). Parallel workers would race them onto the same port — and under the
+    // authenticated-reuse contract the loser correctly REFUSES, failing the wrong test.
+    test.describe.configure({mode: 'serial'});
 
     test('a non-default fleet port REFUSES with the named endpoint-authority reason', () => {
         const plan = planCockpitBoot({fleetPort: 9999});
@@ -56,14 +60,40 @@ test.describe('buildScripts/devCockpit — the live-by-default boot plan', () =>
         expect(plan.notes[0]).toContain('non-JSON')
     });
 
-    test('a confirmed fleet occupant → REUSE, never a second server', () => {
-        const plan = planCockpitBoot({fleetPort: 8083, endpointStatus: 'fleet', endpointDetail: 'wire-protocol identity confirmed'});
+    test('a fleet occupant WITH the authenticated proof → REUSE, never a second server', () => {
+        const plan = planCockpitBoot({
+            fleetPort     : 8083,
+            endpointStatus: 'fleet',
+            endpointDetail: 'wire-protocol identity confirmed',
+            reuseProof    : {reusable: true, reason: 'same token, same viewer', viewer: '@cockpit-witness', pid: 4242}
+        });
 
         expect(plan.refuse).toBe(false);
         expect(plan.spawnFleet).toBe(false);
         expect(plan.spawnWebpack).toBe(true);
-        expect(plan.notes[0]).toContain('reusing');
+        expect(plan.notes[0]).toContain('VERIFIED same token, same viewer');
+        expect(plan.notes[0]).toContain('@cockpit-witness');
         expect(plan.notes[0]).toContain('not spawning a second server')
+    });
+
+    test('a fleet occupant WITHOUT the authenticated proof → REFUSED; protocol identity is never adoption authority', () => {
+        // The composition this closes: the page a reuse-plan opens can REDEEM the incumbent's
+        // bearer, so an unauthenticated 401-signature match must not select the page's credential
+        // authority. No proof, failed proof, and wrong-viewer proof all refuse with the remediation.
+        for (const reuseProof of [
+            null,
+            {reusable: false, reason: 'no NEO_FLEET_BEARER pin in this environment — the launcher holds no credential to authenticate the incumbent with'},
+            {reusable: false, reason: "the existing Fleet is bound to viewer '@viewer-a' but this launch resolved '@viewer-b' — wrong-viewer process; refusing silent reuse"}
+        ]) {
+            const plan = planCockpitBoot({fleetPort: 8083, endpointStatus: 'fleet', reuseProof});
+
+            expect(plan.refuse, JSON.stringify(reuseProof)).toBe(true);
+            expect(plan.spawnFleet, JSON.stringify(reuseProof)).toBe(false);
+            expect(plan.spawnWebpack, 'no credential-redeeming page may open').toBe(false);
+            expect(plan.notes[0]).toContain('cannot verify');
+            expect(plan.notes[1]).toContain('credential authority');
+            reuseProof?.reason && expect(plan.notes[0]).toContain(reuseProof.reason)
+        }
     });
 
     test('a free endpoint → spawn the transport', () => {
@@ -192,6 +222,72 @@ test.describe('buildScripts/devCockpit — the live-by-default boot plan', () =>
         }
 
         await expect.poll(async () => (await probeFleetEndpoint(8083)).status, {timeout: 10000}).toBe('free')
+    });
+
+    test('⭐ real-ingress reuse falsifier: an armed incumbent bound to viewer/token A is NEVER adopted by launcher B — and the same-token+same-viewer control IS', async () => {
+        test.setTimeout(60000);
+
+        if ((await probeFleetEndpoint(8083)).status !== 'free') {
+            test.skip(true, 'the default fleet endpoint is occupied on this machine — the reuse falsifier needs to own it');
+            return
+        }
+
+        // The ARMED incumbent: viewer A, token A, handshake armed — the exact process whose bearer
+        // a wrongly-adopting launcher's page could redeem.
+        const tokenA    = generateLocalBearerToken(),
+              tokenB    = generateLocalBearerToken(),
+              incumbent = await startFleetBridgeServer(authenticatedOptions({
+                  port           : 8083,
+                  bearerToken    : tokenA,
+                  bearerHandshake: true
+              }));
+
+        const launchCockpit = env => new Promise(resolve => {
+            const child = spawn(process.execPath, [path.join(repoRoot, 'buildScripts/devCockpit.mjs')], {
+                cwd: repoRoot,
+                env: {
+                    ...process.env,
+                    // the webpack stub prints a marker so "no page opened" is directly observable
+                    NEO_COCKPIT_WEBPACK_CMD: JSON.stringify([process.execPath, '-e', 'console.log("WEBPACK_STUB_STARTED"); setInterval(() => {}, 1000)']),
+                    ...env
+                },
+                stdio: ['ignore', 'pipe', 'pipe']
+            });
+
+            let output = '';
+
+            child.stdout.on('data', chunk => output += chunk);
+            child.stderr.on('data', chunk => output += chunk);
+            child.on('exit', code => resolve({code, output, child}));
+
+            // the positive control never exits on its own — give it time to prove the reuse plan,
+            // then tear it down; the refusal path exits(1) well inside this window
+            setTimeout(() => {
+                if (child.exitCode === null) {
+                    child.kill('SIGTERM')
+                }
+            }, 8000)
+        });
+
+        try {
+            // Falsifier: launcher B (different token, different identity claim) must refuse before
+            // any page exists — no webpack stub, exit 1, remediation named.
+            const refused = await launchCockpit({NEO_FLEET_BEARER: tokenB, NEO_AGENT_IDENTITY: '@viewer-b'});
+
+            expect(refused.code).toBe(1);
+            expect(refused.output).toContain('REFUSED');
+            expect(refused.output).toContain('cannot verify');
+            expect(refused.output).not.toContain('WEBPACK_STUB_STARTED');
+
+            // Positive control: same token + same viewer proves reuse through the authenticated
+            // probe, and only THEN does the page open.
+            const reused = await launchCockpit({NEO_FLEET_BEARER: tokenA, NEO_AGENT_IDENTITY: '@cockpit-witness'});
+
+            expect(reused.output).toContain('VERIFIED same token, same viewer');
+            expect(reused.output).toContain('WEBPACK_STUB_STARTED')
+        } finally {
+            await new Promise(resolve => incumbent.close(resolve))
+        }
     });
 
     test('the composed command opens the COCKPIT surface, not the dev-server root', () => {

--- a/test/playwright/unit/ai/services/fleet/fleetBridgeServer.spec.mjs
+++ b/test/playwright/unit/ai/services/fleet/fleetBridgeServer.spec.mjs
@@ -266,6 +266,93 @@ test.describe('fleetBridgeServer — the authenticated Fleet ingress', () => {
         expect(seen).toEqual([])
     });
 
+    test('UNARMED (default): GET /fleet/handshake has no special admission — 401 bearer-less, 404 authenticated, bearer never in a body', async () => {
+        await startServer();
+
+        // Bearer-less with a perfect cockpit Origin: the unarmed guard has no handshake branch, so
+        // the request falls through to the bearer gate exactly like any other GET.
+        const bearerless = await rawRequest({method: 'GET', path: '/fleet/handshake', headers: {Origin: 'http://localhost:8080'}});
+
+        expect(bearerless.status).toBe(401);
+        expect(bearerless.body).not.toContain(bearer);
+
+        // Authenticated: the path is not a served route on an unarmed server — fail-closed 404.
+        const authenticated = await rawRequest({method: 'GET', path: '/fleet/handshake', headers: {Authorization: `Bearer ${bearer}`, Origin: 'http://localhost:8080'}});
+
+        expect(authenticated.status).toBe(404);
+        expect(authenticated.body).not.toContain(bearer);
+        expect(seen).toEqual([])
+    });
+
+    test('ARMED: an exact-allowlisted browser Origin redeems the process bearer — no-store, connection-close, exact-origin echo', async () => {
+        await startServer({bearerHandshake: true});
+
+        const res = await rawRequest({method: 'GET', path: '/fleet/handshake', headers: {Origin: 'http://localhost:8080'}});
+
+        expect(res.status).toBe(200);
+        expect(JSON.parse(res.body)).toEqual({ok: true, result: {bearerToken: bearer}});
+        expect(res.headers['access-control-allow-origin']).toBe('http://localhost:8080');
+        expect(res.headers['vary']).toBe('Origin');
+        expect(res.headers['cache-control']).toBe('no-store');
+        expect(res.headers['connection']).toBe('close');
+        expect(seen, 'a redemption never reaches dispatch').toEqual([]);
+        expect(contexts, 'a redemption never enters the context boundary').toEqual([])
+    });
+
+    test('ARMED: redemption stays available while armed — a page reload is a normal cockpit operation, not a lockout', async () => {
+        await startServer({bearerHandshake: true});
+
+        for (const attempt of [1, 2]) {
+            const res = await rawRequest({method: 'GET', path: '/fleet/handshake', headers: {Origin: 'http://127.0.0.1:8080'}});
+
+            expect(res.status, `redemption ${attempt}`).toBe(200);
+            expect(JSON.parse(res.body).result.bearerToken, `redemption ${attempt}`).toBe(bearer)
+        }
+    });
+
+    test('ARMED: an ABSENT Origin is refused — stricter than preflight, because only a browser page has business here', async () => {
+        await startServer({bearerHandshake: true});
+
+        const res = await rawRequest({method: 'GET', path: '/fleet/handshake', headers: {}});
+
+        expect(res.status).toBe(403);
+        expect(res.body).toContain('allowlisted browser origin');
+        expect(res.body).not.toContain(bearer)
+    });
+
+    test('ARMED: foreign and literal-null Origins are refused with no CORS grant and no bearer', async () => {
+        await startServer({bearerHandshake: true});
+
+        for (const origin of ['http://evil.example', 'null']) {
+            const res = await rawRequest({method: 'GET', path: '/fleet/handshake', headers: {Origin: origin}});
+
+            expect(res.status, `origin ${origin}`).toBe(403);
+            expect(res.headers['access-control-allow-origin'], `origin ${origin} gets no grant`).toBeUndefined();
+            expect(res.body, `origin ${origin} never sees the bearer`).not.toContain(bearer)
+        }
+    });
+
+    test('ARMED: a spoofed Host is refused before the handshake branch — the Host gate outranks arming', async () => {
+        await startServer({bearerHandshake: true});
+
+        const res = await rawRequest({method: 'GET', path: '/fleet/handshake', headers: {Host: 'evil.example:8083', Origin: 'http://localhost:8080'}});
+
+        expect(res.status).toBe(403);
+        expect(res.body).not.toContain(bearer)
+    });
+
+    test('ARMED: only the exact GET /fleet/handshake redeems — sibling paths and POST fall through to the bearer gate', async () => {
+        await startServer({bearerHandshake: true});
+
+        const sibling = await rawRequest({method: 'GET', path: '/fleet/handshakex', headers: {Origin: 'http://localhost:8080'}});
+        expect(sibling.status).toBe(401);
+        expect(sibling.body).not.toContain(bearer);
+
+        const post = await rawRequest({method: 'POST', path: '/fleet/handshake', headers: {Origin: 'http://localhost:8080'}, body: '{}'});
+        expect(post.status).toBe(401);
+        expect(post.body).not.toContain(bearer)
+    });
+
     test('delayed concurrent A/B: request contexts never leak or swap across in-flight requests', async () => {
         // Two servers with DISTINCT viewers share one real AsyncLocalStorage. The slow request
         // resolves after the fast one has entered and left the store; each dispatch reads the store

--- a/test/playwright/unit/apps/agentos/fleet/redeemFleetBearerHandshake.spec.mjs
+++ b/test/playwright/unit/apps/agentos/fleet/redeemFleetBearerHandshake.spec.mjs
@@ -1,0 +1,100 @@
+import {test, expect}               from '@playwright/test';
+import {redeemFleetBearerHandshake} from '../../../../../../apps/agentos/fleet/redeemFleetBearerHandshake.mjs';
+
+// The browser half of the one-command bearer hand-off, witnessed pure: a stub fetchImpl replaces
+// the network, so every claim below is about THIS module's contract — the derived handshake URL,
+// the no-store request shape, and the fail-closed null on every non-success path. The server half
+// (arming, exact-Origin admission, the redemption response itself) is witnessed in
+// `test/playwright/unit/ai/services/fleet/fleetBridgeServer.spec.mjs`; the composed launcher
+// hand-down in `test/playwright/unit/ai/buildScripts/devCockpit.spec.mjs`.
+test.describe('redeemFleetBearerHandshake — the page half of the one-command hand-off', () => {
+    const validToken = 'A'.repeat(43),
+          okEnvelope = token => ({
+              ok  : true,
+              json: async () => ({ok: true, result: {bearerToken: token}})
+          });
+
+    test('derives <fleet-origin>/fleet/handshake from the fleet URL and requests it no-store', async () => {
+        const calls = [];
+
+        const token = await redeemFleetBearerHandshake({
+            url      : 'http://127.0.0.1:8083/fleet',
+            fetchImpl: async (url, options) => {
+                calls.push({url, options});
+                return okEnvelope(validToken)
+            }
+        });
+
+        expect(token).toBe(validToken);
+        expect(calls).toHaveLength(1);
+        expect(calls[0].url).toBe('http://127.0.0.1:8083/fleet/handshake');
+        expect(calls[0].options.cache).toBe('no-store');
+        expect(calls[0].options.signal).toBeInstanceOf(AbortSignal)
+    });
+
+    test('the fleet URL is the ONE endpoint authority: path and query never leak into the handshake URL', async () => {
+        let requested;
+
+        await redeemFleetBearerHandshake({
+            url      : 'http://localhost:8083/fleet?whatever=1',
+            fetchImpl: async url => {
+                requested = url;
+                return okEnvelope(validToken)
+            }
+        });
+
+        expect(requested).toBe('http://localhost:8083/fleet/handshake')
+    });
+
+    test('non-success responses resolve null: refusal status, ok:false envelope, malformed token, non-JSON body', async () => {
+        const cases = [
+            ['refused status',   async () => ({ok: false, json: async () => ({ok: false, error: 'fleet: handshake requires an allowlisted browser origin'})})],
+            ['ok:false envelope', async () => ({ok: true, json: async () => ({ok: false, error: 'nope'})})],
+            ['missing result',   async () => ({ok: true, json: async () => ({ok: true})})],
+            ['short token',      async () => okEnvelope('too-short')],
+            ['padded token',     async () => okEnvelope(`${'A'.repeat(43)}=`)],
+            ['non-string token', async () => okEnvelope(42)],
+            ['non-JSON body',    async () => ({ok: true, json: async () => { throw new SyntaxError('not json') }})]
+        ];
+
+        for (const [label, fetchImpl] of cases) {
+            expect(await redeemFleetBearerHandshake({url: 'http://127.0.0.1:8083/fleet', fetchImpl}), label).toBeNull()
+        }
+    });
+
+    test('a refused connection (no transport listening) resolves null instead of throwing', async () => {
+        const token = await redeemFleetBearerHandshake({
+            url      : 'http://127.0.0.1:8083/fleet',
+            fetchImpl: async () => { throw new TypeError('fetch failed') }
+        });
+
+        expect(token).toBeNull()
+    });
+
+    test('a hung listener resolves null within the redemption patience via the abort signal', async () => {
+        const token = await redeemFleetBearerHandshake({
+            url      : 'http://127.0.0.1:8083/fleet',
+            timeoutMs: 25,
+            fetchImpl: (url, {signal}) => new Promise((resolve, reject) => {
+                signal.addEventListener('abort', () => reject(signal.reason))
+            })
+        });
+
+        expect(token).toBeNull()
+    });
+
+    test('a malformed fleet URL resolves null before any request is issued', async () => {
+        let called = false;
+
+        const token = await redeemFleetBearerHandshake({
+            url      : 'not a url',
+            fetchImpl: async () => {
+                called = true;
+                return okEnvelope(validToken)
+            }
+        });
+
+        expect(token).toBeNull();
+        expect(called).toBe(false)
+    })
+});


### PR DESCRIPTION
Resolves #16911

`npm run cockpit` now composes a session whose browser page obtains the fleet bearer ITSELF: the launcher arms a handshake redemption on the transport it spawns (`NEO_FLEET_BEARER_HANDSHAKE`), the ingress guard admits `GET /fleet/handshake` on Host + a present-and-allowlisted browser Origin (the single deliberate pre-bearer admission — refused absent/foreign Origins, refused entirely while unarmed), and the app module redeems the secret pre-boot via top-level await into the designed `globalThis.AgentOS.fleet.bearerToken` slot — so `installFleetBridge` sees the bearer exactly as if Electron main or the Neural Link had placed it, with no agent in the loop. A per-window lazy retry in `onStart` heals the boot race (plane admission can take seconds) and SharedWorker reloads via the documented idempotent re-install. Default posture is unchanged everywhere: the leaf ships `false`, a standalone `npm run ai:fleet-server` exposes zero new surface, and every non-success redemption path resolves `null` into the existing fail-closed boot.

The custody decision is named in the leaf JSDoc and the ticket: while armed, browser-caller authentication deliberately collapses to exact-Origin (browsers cannot forge Origin) — the opt-in Option-B dev-mode widening; the packaged Electron path keeps strict custody. Redemptions log origin + timestamp, never the bearer.

Evidence: L3 (live composed run on the operator machine — armed transport with plane-verified viewer, agentless browser redemption logged at `2026-08-10T19:56:25Z` for origin `http://localhost:8080`, live 9-agent roster rendering containerized-plane presence bands) → L3 required (close-target ACs). No residuals.

## Deltas from ticket

- The `onStart` lazy retry (per joining window) was added beyond the ticket's module-level redemption: the live run proved the race is real — the window the launcher auto-opens can beat the fleet child's plane admission, and a SharedWorker reload re-enters `onStart` without re-running module scope. `installFleetBridge`'s documented additive+idempotent contract makes the in-place upgrade safe.
- `resolveFleetUrl()` extracted in `apps/agentos/app.mjs` so the boot install and the redemption derive from the ONE endpoint authority instead of duplicating the query-param resolution.
- The spine-banner incoherence observed during the live receipt (live grid under a sample activity stream renders "showing the static roster") is a pre-existing surface-conflation defect in `deriveSpineBanner`, filed separately with tonight's evidence — deliberately not folded into this PR.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/ai/services/fleet/fleetBridgeServer.spec.mjs test/playwright/unit/apps/agentos/fleet/redeemFleetBearerHandshake.spec.mjs test/playwright/unit/apps/agentos/fleet/installFleetBridge.spec.mjs test/playwright/unit/apps/agentos/app.spec.mjs` → 47 passed. New handshake battery: unarmed 401/404 with no new surface; armed exact-origin redemption with `no-store` + `Vary: Origin` + connection-close; absent/foreign/`null`-Origin 403 with no CORS grant and no bearer in any refusal body; spoofed-Host 403; sibling-path and POST fall through to the bearer gate; multi-redemption while armed (reload semantics).
- `npm run test-unit -- test/playwright/unit/ai/buildScripts/devCockpit.spec.mjs` → 9 passed, including the composed-boot witness extended end-to-end: the REAL launcher spawn arms the fixture child via env, a browser-Origin fetch redeems a canonical bearer, and the redeemed value is proven by USE against the constant-time gate on `/fleet/probe` (redeem → use, no agent seam).
- `apps/agentos/fleet/redeemFleetBearerHandshake.mjs`: new spec covers URL derivation + `no-store` shape, the one-endpoint-authority rule, and `null` on refusal/ok:false/malformed-token/non-JSON/refused-connection/hung-listener/malformed-URL paths.
- Live composed receipt (operator machine): `NEO_FLEET_PLANE_BASE=http://127.0.0.1:3102 NEO_FLEET_PLANE_BEARER=$NEO_MCP_REMOTE_TOKEN npm run cockpit` → boot log `mailbox/compose/catch-up seams bound to the containerized plane (viewer @neo-fable-clio verified plane-side)` → `[fleet] bearer handshake redeemed by origin http://localhost:8080` with zero Neural-Link/Electron involvement → cockpit renders FLEET · 9 AGENTS with live presence bands (4 online / 1 idle / 4 dark, matching plane `who_is_online` truth; the rendered set differs from the static sample — 9 registry agents vs the sample's 10 including `neo-gemini-pro`, and the sample carries no presence fields — proving the rows are wire data, not seeds).

## Post-Merge Validation

- [ ] Operator-run reproduction of the one-command flow from `dev` (the umbrella `#16694` receipt lands there; this branch's live run is the same code pre-merge).
- [ ] `.claude/launch.json` `cockpit` entry fronts the composed flow from a fresh session.

## Commits (if multi-commit)

Single commit.

Authored by Clio (Fable 5, Claude Code). Session ff94e740-acb8-4f25-a94b-b614bdd91ea1.
