### PR TITLE
docs(ai): the empty-manifest replay exception reaches both doc surfaces (#16914)

### DIFF
--- a/ai/daemons/orchestrator/services/TenantRepoSyncService.mjs
+++ b/ai/daemons/orchestrator/services/TenantRepoSyncService.mjs
@@ -471,9 +471,12 @@ function isMatchingMaterializationReceipt(receipt, expectedDigest) {
  * replay, or legacy revalidation. It must reach ingestion before this check so an
  * empty manifest can reconcile and delete stale rows. A fresh attempt must prove a
  * safely-counted ingest/delete effect or a source-observed empty manifest, and persist
- * its matching graph receipt. A zero-effect retry may settle only an unacknowledged
- * receipt left by a prior positive attempt whose checkpoint commit failed. Incremental
- * envelopes have no manifest and may remain healthy zero-delta checkpoints.
+ * its matching graph receipt. A zero-effect retry may settle an unacknowledged
+ * receipt left by a prior positive attempt whose checkpoint commit failed, and — only on a
+ * manifest that authoritatively declares NO content — a receipt whose attempt is already
+ * committed, because that is proof of a prior success rather than an absence of proof. On a
+ * manifest that declares content, a zero-effect attempt still cannot manufacture a receipt.
+ * Incremental envelopes have no manifest and may remain healthy zero-delta checkpoints.
  *
  * @param {Object} envelope Tenant-repo ingestion envelope.
  * @param {Object} summary Validated error-free ingestion summary.

--- a/learn/agentos/cloud-deployment/Troubleshooting.md
+++ b/learn/agentos/cloud-deployment/Troubleshooting.md
@@ -279,8 +279,12 @@ node ./ai/scripts/maintenance/syncTenantRepos.mjs --full --repo-slug <slug>
 `--full` is rejected without an explicit repo selector. It does not delete the stored checkpoint:
 a failed or fresh zero-effect replay preserves it, while an error-free replay with a positive
 ingest/delete effect advances it to the current head and writes the current success-contract
-marker. A zero-effect retry can advance only when it settles the matching unacknowledged receipt
-from an interrupted post-ingest checkpoint commit before repeating Knowledge Base mutation.
+marker. A zero-effect retry can advance when it settles the matching unacknowledged receipt
+from an interrupted post-ingest checkpoint commit before repeating Knowledge Base mutation, and
+also when the manifest authoritatively declares no content and the matching receipt's attempt is
+already committed — repeating `--full` on an unchanged, legitimately-empty repo therefore succeeds
+every time instead of failing from the second run onward. On a manifest that declares content, a
+zero-effect replay still cannot advance the checkpoint.
 
 The CLI and the daemon's periodic sweep serialize through a cross-process lease next to the
 revisions manifest. Exit code `4` (reason `KB_TENANT_REPO_SYNC_LEASE_HELD`) means another sync is


### PR DESCRIPTION
Resolves #16914

@neo-gpt found this reviewing PR #16907. I folded it into that PR under the operator's new no-Approve+Follow-Up directive — **the PR merged before my push landed**, so it arrives as its own narrow leaf instead of a fold. That sequencing is the only reason this is a ticket.

Evidence: L1 (static prose/comment audit; the executable diff is mechanically verified empty) → L1 required (no runtime-verify AC). No residuals.

## Why this is a defect and not a tidy-up

`learn/agentos/cloud-deployment/Troubleshooting.md:282` on `dev` says a zero-effect retry can advance **only** by settling an unacknowledged receipt from an interrupted checkpoint commit.

Since #16897 shipped, that is false: a replay whose manifest authoritatively declares no content, carrying a receipt whose attempt is already committed, also advances. So the **troubleshooting** guide — the surface an operator opens precisely when something looks wrong — tells them a repeated `--full` on an empty repo should fail. It now succeeds. The failure mode is a *false bug report* against correct behaviour.

The helper's leading JSDoc carried the same superseded `only`, so the contract a future author reads before editing `assertFullMaterializationEffect` described behaviour the function no longer has.

This is incomplete delivery on my own merged PR.

## Deltas

**`ai/daemons/orchestrator/services/TenantRepoSyncService.mjs`** — the `@summary` above `assertFullMaterializationEffect`.

**`learn/agentos/cloud-deployment/Troubleshooting.md`** — the `--full` CLI replay paragraph, which additionally now states plainly that repeating `--full` on an unchanged, legitimately-empty repo succeeds on every run.

Both name the exception **and** the boundary in the same sentence: on a manifest that declares content, a zero-effect attempt still cannot manufacture a receipt. Naming the exception alone would read as a general relaxation of the zero-effect guard, which is the misreading worth preventing — the shipped predicate is a conjunction (`declaresNoContent && (provesCurrentAttempt || provesCommittedSuccess)`), and the prose has to carry the conjunction or it misrepresents the code.

## Test Evidence

No tests: the executable diff is empty. That claim is mechanically verified rather than asserted —

```
git diff --cached -- ai/daemons/orchestrator/services/TenantRepoSyncService.mjs \
  | grep -E '^[+-]' | grep -vE '^(\+\+\+|---)' | grep -vE '^[+-]\s*(\*|//|/\*)'
→ NO non-comment lines changed — code is byte-identical
```

Pre-commit chain green on both files: `check-ticket-archaeology` (0 violations), `check-whitespace`, `check-jsdoc-types` (0 unparseable), `check-block-alignment --staged`, `check-shorthand`, `check-parse`.

#16897's own suite is untouched and remains green on `dev` at `2033 passed`; this branch changes no code it could affect.

## Post-Merge Validation

None deferred. Both acceptance criteria are static and verified above: neither surface retains the false `only`, both carry the exception with its boundary, and the executable diff is empty.

This section names no ticket deliberately — a residual parked on the close target evaporates when the merge closes it, which is the class recorded in #16906.

## Review

Cross-family seat needed (author is opus). Prose-only, so the useful question is not correctness of the change but **whether the new sentences could still be misread as relaxing the zero-effect guard** — that was the risk I wrote them against, and a second reader is the only real test of it.

Authored by @neo-opus-vega 🌿
