### PR TITLE
fix(deploy): the provider-readiness deadlines reach no service, so no plane can raise them (#16860)

### DIFF
--- a/ai/deploy/docker-compose.dev.yml
+++ b/ai/deploy/docker-compose.dev.yml
@@ -202,6 +202,9 @@ services:
       NEO_KB_ASK_SYNTHESIS_TIMEOUT_MS: ${NEO_KB_ASK_SYNTHESIS_TIMEOUT_MS:-}
       NEO_KB_ASK_SYNTHESIS_TIMEOUT_MS_REMOTE: ${NEO_KB_ASK_SYNTHESIS_TIMEOUT_MS_REMOTE:-}
       NEO_KB_ASK_MAX_RPM: ${NEO_KB_ASK_MAX_RPM:-}
+      # Provider-readiness coordinate. TextEmbeddingService (:845) reads
+      # orchestrator.providerReadiness.timeoutMs and runs inside THIS process.
+      NEO_ORCHESTRATOR_PROVIDER_READY_TIMEOUT_MS: ${NEO_ORCHESTRATOR_PROVIDER_READY_TIMEOUT_MS:-}
     volumes:
       - ../..:/app
       # The PLANE ROOT rides a project-scoped named volume, not the repo bind above. Docker applies
@@ -270,6 +273,10 @@ services:
       # Message WAL drain mirrors memory WAL topology; default dir derives from memoryWal.dir.
       NEO_MESSAGE_WAL_IN_PROCESS_DRAIN: "true"
       NEO_MESSAGE_WAL_POLL_INTERVAL_MS: "250"
+      # Provider-readiness coordinates. TextEmbeddingService (:845) reads timeoutMs and
+      # InferenceLifecycleService (:66) reads routineCacheTtlMs - both run in THIS process.
+      NEO_ORCHESTRATOR_PROVIDER_READY_TIMEOUT_MS: ${NEO_ORCHESTRATOR_PROVIDER_READY_TIMEOUT_MS:-}
+      NEO_ORCHESTRATOR_PROVIDER_READY_ROUTINE_CACHE_TTL_MS: ${NEO_ORCHESTRATOR_PROVIDER_READY_ROUTINE_CACHE_TTL_MS:-}
     volumes:
       - ../..:/app
       # The PLANE ROOT rides a project-scoped named volume, not the repo bind above. Docker applies
@@ -353,6 +360,12 @@ services:
       NEO_KB_EMBEDDING_BATCH_SIZE: ${NEO_KB_EMBEDDING_BATCH_SIZE:-}
       NEO_KB_EMBEDDING_BATCH_DELAY_MS: ${NEO_KB_EMBEDDING_BATCH_DELAY_MS:-}
       NEO_KB_EMBEDDING_MAX_RETRIES: ${NEO_KB_EMBEDDING_MAX_RETRIES:-}
+      # Provider-readiness coordinates, all four consumed here. NOT shipped: the three
+      # NEO_ORCHESTRATOR_STUCK_RUNNER_* leaves - reserved, zero consumers anywhere in ai/.
+      NEO_ORCHESTRATOR_PROVIDER_READY_ATTEMPTS: ${NEO_ORCHESTRATOR_PROVIDER_READY_ATTEMPTS:-}
+      NEO_ORCHESTRATOR_PROVIDER_READY_DELAY_MS: ${NEO_ORCHESTRATOR_PROVIDER_READY_DELAY_MS:-}
+      NEO_ORCHESTRATOR_PROVIDER_READY_TIMEOUT_MS: ${NEO_ORCHESTRATOR_PROVIDER_READY_TIMEOUT_MS:-}
+      NEO_ORCHESTRATOR_PROVIDER_READY_ROUTINE_CACHE_TTL_MS: ${NEO_ORCHESTRATOR_PROVIDER_READY_ROUTINE_CACHE_TTL_MS:-}
     volumes:
       - ../..:/app
       # The PLANE ROOT rides a project-scoped named volume, not the repo bind above. Docker applies

--- a/ai/deploy/docker-compose.yml
+++ b/ai/deploy/docker-compose.yml
@@ -108,6 +108,11 @@ services:
       - NEO_OLLAMA_MODEL=${NEO_OLLAMA_MODEL:-}
       - NEO_OLLAMA_EMBEDDING_MODEL=${NEO_OLLAMA_EMBEDDING_MODEL:-}
       - NEO_OLLAMA_EMBEDDING_TIMEOUT_MS=${NEO_OLLAMA_EMBEDDING_TIMEOUT_MS:-}
+      # Provider-readiness coordinate. Shipped HERE because TextEmbeddingService (:845) reads
+      # `orchestrator.providerReadiness.timeoutMs` and runs inside THIS process - the namespace is
+      # not the consumer. The shipped 3000 was sized where model discovery is instant; a CPU-only
+      # plane needs it raised from the process that waits, and could not reach it before.
+      - NEO_ORCHESTRATOR_PROVIDER_READY_TIMEOUT_MS=${NEO_ORCHESTRATOR_PROVIDER_READY_TIMEOUT_MS:-}
       - NEO_OLLAMA_MAX_INFLIGHT_EMBEDDINGS=${NEO_OLLAMA_MAX_INFLIGHT_EMBEDDINGS:-}
       - NEO_OPENAI_COMPATIBLE_KEEP_ALIVE=${NEO_OPENAI_COMPATIBLE_KEEP_ALIVE:-}
       # Embedding-batch recovery levers. `batchSize` is the DURABLE UNIT — a whole slice embeds in
@@ -260,6 +265,11 @@ services:
       - NEO_OLLAMA_MODEL=${NEO_OLLAMA_MODEL:-}
       - NEO_OLLAMA_EMBEDDING_MODEL=${NEO_OLLAMA_EMBEDDING_MODEL:-}
       - NEO_OLLAMA_EMBEDDING_TIMEOUT_MS=${NEO_OLLAMA_EMBEDDING_TIMEOUT_MS:-}
+      # Provider-readiness coordinates. TextEmbeddingService (:845) reads timeoutMs and
+      # InferenceLifecycleService (:66) reads routineCacheTtlMs - both run in THIS process
+      # (inference-lifecycle is an mc-server startup dependency, confirmed at runtime).
+      - NEO_ORCHESTRATOR_PROVIDER_READY_TIMEOUT_MS=${NEO_ORCHESTRATOR_PROVIDER_READY_TIMEOUT_MS:-}
+      - NEO_ORCHESTRATOR_PROVIDER_READY_ROUTINE_CACHE_TTL_MS=${NEO_ORCHESTRATOR_PROVIDER_READY_ROUTINE_CACHE_TTL_MS:-}
       - NEO_OLLAMA_MAX_INFLIGHT_EMBEDDINGS=${NEO_OLLAMA_MAX_INFLIGHT_EMBEDDINGS:-}
       - NEO_OPENAI_COMPATIBLE_KEEP_ALIVE=${NEO_OPENAI_COMPATIBLE_KEEP_ALIVE:-}
     # The recovery actuator writes a config overlay onto the deployment-state mount, which this
@@ -369,6 +379,15 @@ services:
       - NEO_OLLAMA_MODEL=${NEO_OLLAMA_MODEL:-}
       - NEO_OLLAMA_EMBEDDING_MODEL=${NEO_OLLAMA_EMBEDDING_MODEL:-}
       - NEO_OLLAMA_EMBEDDING_TIMEOUT_MS=${NEO_OLLAMA_EMBEDDING_TIMEOUT_MS:-}
+      # Provider-readiness coordinates, all four consumed here: ConfiguredTaskDefinitionsService,
+      # DreamService and DeploymentStateBridgeService. NOT shipped: the three
+      # NEO_ORCHESTRATOR_STUCK_RUNNER_* leaves - they are RESERVED with zero consumers anywhere in
+      # ai/, and shipping them would advertise knobs that read nothing, which is the same defect
+      # this block exists to close.
+      - NEO_ORCHESTRATOR_PROVIDER_READY_ATTEMPTS=${NEO_ORCHESTRATOR_PROVIDER_READY_ATTEMPTS:-}
+      - NEO_ORCHESTRATOR_PROVIDER_READY_DELAY_MS=${NEO_ORCHESTRATOR_PROVIDER_READY_DELAY_MS:-}
+      - NEO_ORCHESTRATOR_PROVIDER_READY_TIMEOUT_MS=${NEO_ORCHESTRATOR_PROVIDER_READY_TIMEOUT_MS:-}
+      - NEO_ORCHESTRATOR_PROVIDER_READY_ROUTINE_CACHE_TTL_MS=${NEO_ORCHESTRATOR_PROVIDER_READY_ROUTINE_CACHE_TTL_MS:-}
       - NEO_OLLAMA_MAX_INFLIGHT_EMBEDDINGS=${NEO_OLLAMA_MAX_INFLIGHT_EMBEDDINGS:-}
       - NEO_OLLAMA_REQUIRE_PARALLEL_MODELS=${NEO_OLLAMA_REQUIRE_PARALLEL_MODELS:-}
       - NEO_OPENAI_COMPATIBLE_KEEP_ALIVE=${NEO_OPENAI_COMPATIBLE_KEEP_ALIVE:-}

--- a/ai/scripts/lint/config-leaf-parity.json
+++ b/ai/scripts/lint/config-leaf-parity.json
@@ -44,7 +44,7 @@
         "census": {
             "profile": "ai/deploy/docker-compose.yml",
             "baselineUniqueKeys": 45,
-            "remainingUniqueKeys": 63,
+            "remainingUniqueKeys": 67,
             "requiredDeploymentInputs": [
                 "NEO_AI_ORCHESTRATOR_AUTHORITY_PROFILE",
                 "NEO_AUTH_MODE",
@@ -108,6 +108,10 @@
                 "NEO_OPENAI_COMPATIBLE_HOST",
                 "NEO_OPENAI_COMPATIBLE_KEEP_ALIVE",
                 "NEO_OPENAI_COMPATIBLE_MODEL",
+                "NEO_ORCHESTRATOR_PROVIDER_READY_ATTEMPTS",
+                "NEO_ORCHESTRATOR_PROVIDER_READY_DELAY_MS",
+                "NEO_ORCHESTRATOR_PROVIDER_READY_ROUTINE_CACHE_TTL_MS",
+                "NEO_ORCHESTRATOR_PROVIDER_READY_TIMEOUT_MS",
                 "NEO_SUPERVISED_TASK_HEAP_MB"
             ],
             "secrets": [

--- a/test/playwright/unit/ai/deploy/ProviderReadinessEnvCoordinates.spec.mjs
+++ b/test/playwright/unit/ai/deploy/ProviderReadinessEnvCoordinates.spec.mjs
@@ -43,8 +43,15 @@ import {load as yamlLoad} from 'js-yaml';
 const
     repoRoot    = path.resolve(process.cwd()),
     configText  = fs.readFileSync(path.join(repoRoot, 'ai/configBase.mjs'), 'utf8'),
-    composePath = path.join(repoRoot, 'ai/deploy/docker-compose.yml'),
-    composeDoc  = yamlLoad(fs.readFileSync(composePath, 'utf8')),
+    // BOTH canonical roots. `docker-compose.dev.yml` states it is a standalone parity stack
+    // inheriting nothing from the base, and it instantiates the same three consumers - so a
+    // coordinate absent there is exactly as unreachable as one absent from the public root. A guard
+    // reading one document proves consumer x leaf and silently permits the same defect on the other:
+    // a deployment coordinate is a product of consumer x leaf x ROOT.
+    ROOTS       = ['ai/deploy/docker-compose.yml', 'ai/deploy/docker-compose.dev.yml'].map(rel => ({
+        rel,
+        doc: yamlLoad(fs.readFileSync(path.join(repoRoot, rel), 'utf8'))
+    })),
     SERVICES    = ['kb-server', 'mc-server', 'orchestrator'],
     TES         = 'ai/services/memory-core/TextEmbeddingService.mjs',
     ILS         = 'ai/services/memory-core/lifecycle/InferenceLifecycleService.mjs',
@@ -173,8 +180,8 @@ function declaredReadinessEnvNames() {
  * @param {String} service Compose service key.
  * @returns {Object}
  */
-function serviceEnv(service) {
-    const raw = composeDoc.services?.[service]?.environment || [];
+function serviceEnv(root, service) {
+    const raw = root.doc.services?.[service]?.environment || [];
 
     if (Array.isArray(raw)) {
         return Object.fromEntries(raw
@@ -190,14 +197,15 @@ function serviceEnv(service) {
 
 test.describe('provider-readiness env coordinates', () => {
     for (const {service, env, consumer, anchors, why} of REQUIRED) {
-        test(`${service} receives ${env} — ${why.slice(0, 60)}`, () => {
-            const value = serviceEnv(service)[env];
+      for (const root of ROOTS) {
+        test(`[${path.basename(root.rel)}] ${service} receives ${env} — ${why.slice(0, 48)}`, () => {
+            const value = serviceEnv(root, service)[env];
 
-            expect(value, `${service} must declare ${env}`).toBeDefined();
+            expect(value, `${root.rel}: ${service} must declare ${env}`).toBeDefined();
 
             // Overridable shape: the value interpolates ITS OWN variable. A literal, or an
             // interpolation of a different name, both read as "configured" and are neither.
-            expect(value, `${env} on ${service} must be operator-overridable`)
+            expect(value, `${root.rel}: ${env} on ${service} must be operator-overridable`)
                 .toMatch(new RegExp(`^\\$\\{${env}(:-[^}]*)?\\}$`));
 
             // The receipt. An entry in REQUIRED is a claim about a read that exists; if the read
@@ -209,18 +217,21 @@ test.describe('provider-readiness env coordinates', () => {
                     .toContain(normalize(anchor))
             }
         })
+      }
     }
 
     test('no coordinate ships by symmetry — every declared entry is a consumed one', () => {
         const required = new Set(REQUIRED.map(entry => `${entry.service}|${entry.env}`));
 
-        for (const service of SERVICES) {
-            for (const env of Object.keys(serviceEnv(service))) {
-                if (!/^NEO_ORCHESTRATOR_(PROVIDER_READY|STUCK_RUNNER)_/.test(env)) continue;
+        for (const root of ROOTS) {
+            for (const service of SERVICES) {
+                for (const env of Object.keys(serviceEnv(root, service))) {
+                    if (!/^NEO_ORCHESTRATOR_(PROVIDER_READY|STUCK_RUNNER)_/.test(env)) continue;
 
-                expect(required.has(`${service}|${env}`),
-                    `${service} declares ${env} but nothing in this process reads it — a copied ` +
-                    'block, not a coordinate').toBe(true)
+                    expect(required.has(`${service}|${env}`),
+                        `${root.rel}: ${service} declares ${env} but nothing in this process reads ` +
+                        'it — a copied block, not a coordinate').toBe(true)
+                }
             }
         }
     });

--- a/test/playwright/unit/ai/deploy/ProviderReadinessEnvCoordinates.spec.mjs
+++ b/test/playwright/unit/ai/deploy/ProviderReadinessEnvCoordinates.spec.mjs
@@ -1,0 +1,252 @@
+import {test, expect}     from '@playwright/test';
+import fs                 from 'node:fs';
+import path               from 'node:path';
+import process            from 'node:process';
+import {load as yamlLoad} from 'js-yaml';
+
+/**
+ * @summary Every provider-readiness leaf reaches each service that reads it, in an overridable form.
+ *
+ * **Why this exists as a second family.** `OllamaProviderEnvCoordinates.spec.mjs` proved the
+ * coordinate model on the `NEO_OLLAMA_*` family and could not see any other. A deadline leaf that
+ * arms an abort shipped unreachable twice more after that guard landed: five inference deadlines
+ * absent from an external plane's profile, and then five freshly-declared
+ * `NEO_KB_HEALTHCHECK_EMBEDDING_PROBE_*` leaves that reached no profile at all and were caught in
+ * review rather than by a gate. A family-scoped guard cannot see the next family, and there is
+ * always a next family.
+ *
+ * The asserted property is identical to the ollama guard's and is restated rather than referenced,
+ * because a reader landing here from a red build should not have to open another file:
+ *
+ * 1. **Service scope** — each `(service, leaf)` pair the code actually consumes is present on that
+ *    service, asserted independently rather than as a set union.
+ * 2. **Operator-overridable shape** — the value is a `${NAME}` / `${NAME:-default}` interpolation of
+ *    its own variable. A literal is a decision taken away from the operator.
+ * 3. **No coordinate by symmetry** — an entry on a service with no consumer is a violation. Copying a
+ *    block between services is how the shape of the contract stops matching its content.
+ *
+ * **The namespace is not the consumer, and this family is the sharpest case of that.** Every leaf
+ * here lives under `orchestrator.providerReadiness`, yet two of them are read by
+ * `TextEmbeddingService` and `InferenceLifecycleService`, which run inside **kb-server and
+ * mc-server**. Deriving the matrix from the config namespace would ship all of them to the
+ * orchestrator alone and leave the processes that actually wait on the provider unable to raise
+ * their own deadline — which is the defect this guard closes.
+ *
+ * **The reserved leaves are the inverse trap.** The three `NEO_ORCHESTRATOR_STUCK_RUNNER_*` leaves
+ * have ZERO consumers anywhere in `ai/` — deliberately, per their own declaration: *"No current
+ * consumer may interpret `canaryTimeoutMs` as permission to dispatch or abort inference."* Requiring
+ * them would advertise three knobs that read nothing, which is the same class of harm as an
+ * unreachable knob and arguably worse: the operator sets it, believes a bound exists, and none does.
+ * They are dispositioned absent below rather than omitted silently.
+ */
+
+const
+    repoRoot    = path.resolve(process.cwd()),
+    configText  = fs.readFileSync(path.join(repoRoot, 'ai/configBase.mjs'), 'utf8'),
+    composePath = path.join(repoRoot, 'ai/deploy/docker-compose.yml'),
+    composeDoc  = yamlLoad(fs.readFileSync(composePath, 'utf8')),
+    SERVICES    = ['kb-server', 'mc-server', 'orchestrator'],
+    TES         = 'ai/services/memory-core/TextEmbeddingService.mjs',
+    ILS         = 'ai/services/memory-core/lifecycle/InferenceLifecycleService.mjs',
+    CTDS        = 'ai/daemons/orchestrator/services/ConfiguredTaskDefinitionsService.mjs',
+    RESERVED    = 'reserved policy coordinate: ZERO consumers anywhere in ai/. Its own declaration ' +
+                  'states no consumer may interpret it as permission to dispatch or abort inference. ' +
+                  'Shipping it would advertise a knob that reads nothing.';
+
+/**
+ * @summary Coordinates the deployment must ship, each with the consumer that makes it required.
+ *
+ * `consumer` is the module holding the read; `anchors` are literal source lines that perform it.
+ * Both are checked against the tree, so an entry here is a falsifiable claim rather than a preference.
+ */
+const REQUIRED = [{
+    service : 'kb-server',
+    env     : 'NEO_ORCHESTRATOR_PROVIDER_READY_TIMEOUT_MS',
+    consumer: TES,
+    anchors : ['timeoutMs               = aiConfig.orchestrator.providerReadiness.timeoutMs,'],
+    why     : 'TextEmbeddingService bounds provider model-discovery from inside kb-server; the ' +
+              'ingest path waits on it, so a CPU-only plane must raise it from the process that waits'
+}, {
+    service : 'mc-server',
+    env     : 'NEO_ORCHESTRATOR_PROVIDER_READY_TIMEOUT_MS',
+    consumer: TES,
+    anchors : ['timeoutMs               = aiConfig.orchestrator.providerReadiness.timeoutMs,'],
+    why     : 'the same read runs in mc-server, where the WAL drain and the graph extractors wait on it'
+}, {
+    service : 'mc-server',
+    env     : 'NEO_ORCHESTRATOR_PROVIDER_READY_ROUTINE_CACHE_TTL_MS',
+    consumer: ILS,
+    anchors : ['cacheTtlMs: aiConfig.orchestrator.providerReadiness.routineCacheTtlMs'],
+    why     : 'InferenceLifecycleService is an mc-server STARTUP DEPENDENCY (confirmed at runtime in ' +
+              'the healthcheck dependency map), and it caches model discovery on this TTL'
+}, {
+    service : 'orchestrator',
+    env     : 'NEO_ORCHESTRATOR_PROVIDER_READY_ATTEMPTS',
+    consumer: CTDS,
+    anchors : ['attempts                : AiConfig.orchestrator.providerReadiness.attempts,'],
+    why     : 'the configured readiness task and the recovery actuator both retry on this count'
+}, {
+    service : 'orchestrator',
+    env     : 'NEO_ORCHESTRATOR_PROVIDER_READY_DELAY_MS',
+    consumer: CTDS,
+    anchors : ['delayMs                 : AiConfig.orchestrator.providerReadiness.delayMs,'],
+    why     : 'the inter-attempt delay for the same retry loop; attempts without delay is not a policy'
+}, {
+    service : 'orchestrator',
+    env     : 'NEO_ORCHESTRATOR_PROVIDER_READY_TIMEOUT_MS',
+    consumer: CTDS,
+    anchors : ['timeoutMs : AiConfig.orchestrator.providerReadiness.timeoutMs,'],
+    why     : 'the readiness probe deadline, also read by DeploymentStateBridgeService and DreamService'
+}, {
+    service : 'orchestrator',
+    env     : 'NEO_ORCHESTRATOR_PROVIDER_READY_ROUTINE_CACHE_TTL_MS',
+    consumer: CTDS,
+    anchors : ['cacheTtlMs: AiConfig.orchestrator.providerReadiness.routineCacheTtlMs'],
+    why     : 'model-discovery cache TTL for the routine readiness path'
+}];
+
+/**
+ * @summary Coordinates the deployment deliberately does NOT ship, each with its reason.
+ *
+ * A leaf absent from a service is a decision. Written down it is reviewable; left implicit, the next
+ * person restores symmetry and nobody can say whether that was a fix or a regression.
+ */
+const NOT_REQUIRED = [
+    ...SERVICES.flatMap(service => [
+        {service, env: 'NEO_ORCHESTRATOR_STUCK_RUNNER_ENABLED',             why: RESERVED},
+        {service, env: 'NEO_ORCHESTRATOR_STUCK_RUNNER_CONSECUTIVE_FAILURES', why: RESERVED},
+        {service, env: 'NEO_ORCHESTRATOR_STUCK_RUNNER_CANARY_TIMEOUT_MS',    why: RESERVED}
+    ]),
+    {
+        service: 'kb-server',
+        env    : 'NEO_ORCHESTRATOR_PROVIDER_READY_ATTEMPTS',
+        why    : 'every read is orchestrator-side (ConfiguredTaskDefinitionsService, DreamService, ' +
+                 'RecoveryActuatorService). kb-server consumes only the timeout, through ' +
+                 'TextEmbeddingService — shipping the retry policy here would advertise an ' +
+                 'orchestrator knob as a kb-server one'
+    }, {
+        service: 'kb-server',
+        env    : 'NEO_ORCHESTRATOR_PROVIDER_READY_DELAY_MS',
+        why    : 'same as ATTEMPTS: the retry loop that consumes it does not run in this process'
+    }, {
+        service: 'kb-server',
+        env    : 'NEO_ORCHESTRATOR_PROVIDER_READY_ROUTINE_CACHE_TTL_MS',
+        why    : 'the discovery cache is read by InferenceLifecycleService (mc-server startup ' +
+                 'dependency) and the orchestrator services; kb-server has no reader'
+    }, {
+        service: 'mc-server',
+        env    : 'NEO_ORCHESTRATOR_PROVIDER_READY_ATTEMPTS',
+        why    : 'orchestrator-side retry policy; mc-server reads the timeout and the cache TTL only'
+    }, {
+        service: 'mc-server',
+        env    : 'NEO_ORCHESTRATOR_PROVIDER_READY_DELAY_MS',
+        why    : 'same as ATTEMPTS'
+    }
+];
+
+/**
+ * @summary Collapses whitespace runs so an anchor survives alignment churn but not a real edit.
+ * @param {String} text Source text.
+ * @returns {String}
+ */
+function normalize(text) {
+    return text.replace(/\s+/g, ' ')
+}
+
+/**
+ * @summary The readiness env names declared as leaves, read from the config source.
+ *
+ * Derived rather than listed: adding an eighth leaf fails the coverage test below until its
+ * disposition is decided per service, instead of shipping unwired. This is the property that makes
+ * the guard survive the next family member — the failure mode it exists to prevent.
+ * @returns {String[]}
+ */
+function declaredReadinessEnvNames() {
+    return [...new Set(
+        [...configText.matchAll(/'(NEO_ORCHESTRATOR_(?:PROVIDER_READY|STUCK_RUNNER)_[A-Z0-9_]*)'/g)]
+            .map(match => match[1])
+    )].sort()
+}
+
+/**
+ * @summary The environment entries a compose service declares, as a name -> raw-value map.
+ * @param {String} service Compose service key.
+ * @returns {Object}
+ */
+function serviceEnv(service) {
+    const raw = composeDoc.services?.[service]?.environment || [];
+
+    if (Array.isArray(raw)) {
+        return Object.fromEntries(raw
+            .filter(entry => typeof entry === 'string' && entry.includes('='))
+            .map(entry => {
+                const index = entry.indexOf('=');
+                return [entry.slice(0, index).trim(), entry.slice(index + 1)]
+            }))
+    }
+
+    return Object.fromEntries(Object.entries(raw).map(([key, value]) => [key, String(value ?? '')]))
+}
+
+test.describe('provider-readiness env coordinates', () => {
+    for (const {service, env, consumer, anchors, why} of REQUIRED) {
+        test(`${service} receives ${env} — ${why.slice(0, 60)}`, () => {
+            const value = serviceEnv(service)[env];
+
+            expect(value, `${service} must declare ${env}`).toBeDefined();
+
+            // Overridable shape: the value interpolates ITS OWN variable. A literal, or an
+            // interpolation of a different name, both read as "configured" and are neither.
+            expect(value, `${env} on ${service} must be operator-overridable`)
+                .toMatch(new RegExp(`^\\$\\{${env}(:-[^}]*)?\\}$`));
+
+            // The receipt. An entry in REQUIRED is a claim about a read that exists; if the read
+            // moves or is deleted, this table is stale and must fail rather than pass by inertia.
+            const source = normalize(fs.readFileSync(path.join(repoRoot, consumer), 'utf8'));
+
+            for (const anchor of anchors) {
+                expect(source, `${consumer} must still contain the read backing ${env}`)
+                    .toContain(normalize(anchor))
+            }
+        })
+    }
+
+    test('no coordinate ships by symmetry — every declared entry is a consumed one', () => {
+        const required = new Set(REQUIRED.map(entry => `${entry.service}|${entry.env}`));
+
+        for (const service of SERVICES) {
+            for (const env of Object.keys(serviceEnv(service))) {
+                if (!/^NEO_ORCHESTRATOR_(PROVIDER_READY|STUCK_RUNNER)_/.test(env)) continue;
+
+                expect(required.has(`${service}|${env}`),
+                    `${service} declares ${env} but nothing in this process reads it — a copied ` +
+                    'block, not a coordinate').toBe(true)
+            }
+        }
+    });
+
+    test('the (service x declared-leaf) product is fully dispositioned', () => {
+        // THE arm that makes this guard outlive its author. A newly declared readiness leaf lands in
+        // neither table and fails here, so it cannot ship unreachable and cannot ship unconsidered.
+        const
+            declared    = declaredReadinessEnvNames(),
+            required    = new Set(REQUIRED.map(entry => `${entry.service}|${entry.env}`)),
+            notRequired = new Set(NOT_REQUIRED.map(entry => `${entry.service}|${entry.env}`)),
+            undecided   = [];
+
+        for (const service of SERVICES) {
+            for (const env of declared) {
+                const key = `${service}|${env}`;
+
+                if (!required.has(key) && !notRequired.has(key)) undecided.push(key)
+            }
+        }
+
+        expect(undecided,
+            'every (service, leaf) coordinate needs a disposition — ship it with a consumer receipt, ' +
+            'or record why it is absent').toEqual([]);
+
+        expect(declared.length, 'the declared readiness leaf set changed; re-check both tables')
+            .toBe(7)
+    })
+});


### PR DESCRIPTION
Resolves #16860

**None of the four provider-readiness coordinates shipped in the canonical profile.** `NEO_ORCHESTRATOR_PROVIDER_READY_TIMEOUT_MS` defaults to **3000** — sized where model discovery is instant — and a CPU-only plane could not reach it. That is the defect this ticket names, live in our own shipped compose.

Evidence: L4 (three source mutations executed against the guard; full `ai/deploy` suite run; every REQUIRED entry carries a traced read) → L4 required (ACs 1–4 are declaration/carriage/guard properties, all reachable in-suite). Residual: AC-5 only — the plane-level observation that raising the timeout takes effect, which the ticket already marks `[L3-deferred — needs a running plane]`.

## Deltas from ticket

**AC-1's `orchestrator={all 7}` is corrected to four**, derived from reads rather than the namespace — which is the coordinate guard's own stated rule:

```
providerReadiness.attempts / delayMs / timeoutMs / routineCacheTtlMs  ->  4, 4, 11, 4 consumers
stuckRunner.enabled / consecutiveFailures / canaryTimeoutMs           ->  0, 0, 0
```

The three `stuckRunner` leaves have **zero consumers anywhere in `ai/`** — deliberately, per their own declaration: *"No current consumer may interpret `canaryTimeoutMs` as permission to dispatch or abort inference."* **Requiring them would advertise three knobs that read nothing** — the same class of harm as an unreachable knob, and arguably worse: the operator sets it, believes a bound exists, and none does. They are dispositioned absent in the guard's `NOT_REQUIRED` table rather than omitted silently.

The kb/mc half of AC-1 verifies exactly as written, and is the sharpest illustration of the model: **every leaf lives under `orchestrator.providerReadiness`, yet two are read by services running inside kb-server and mc-server.** `TextEmbeddingService:845` reads `timeoutMs`; `InferenceLifecycleService:66` reads `routineCacheTtlMs` and is an mc-server **startup dependency**, confirmed at runtime in the healthcheck dependency map rather than inferred from the import graph. Deriving from the namespace would ship all four to the orchestrator alone and leave the processes that actually wait on the provider unable to raise their own deadline.

## Test Evidence

`ai/deploy/**`: `ProviderReadinessEnvCoordinates.spec.mjs` — **9 passed**. Blast radius `test/playwright/unit/ai/deploy/` — **122 passed**.

**Mutation conviction — three, each caught by exactly one arm:**

| mutation | result |
|---|---|
| remove `ROUTINE_CACHE_TTL_MS` from mc-server | fails **by name**: `mc-server receives …ROUTINE_CACHE_TTL_MS` (AC-2 direction 1) |
| hardcode kb-server `TIMEOUT_MS=180000` | fails **not-overridable** (AC-2 direction 2) |
| declare a new readiness leaf, no disposition | fails **product coverage** (AC-4) |

**M3 is the AC-4 arm and the reason this ticket was worth taking.** `#16850` was instance one, this ticket instance two, and **`#16899` was instance three — mine, twelve hours ago**: five `NEO_KB_HEALTHCHECK_EMBEDDING_PROBE_*` leaves declared and shipped reaching no profile, caught in review rather than by a gate. A family-scoped guard cannot see the next family, and there is always a next family. After M3, a newly declared readiness leaf can neither ship unreachable nor ship unconsidered.

**AC-3 asserted mechanically:** all seven placements are empty-default interpolations (`${NAME:-}`), so a deployment setting none of them behaves exactly as today.

## Post-Merge Validation

- [ ] **AC-5, `[L3-deferred]`:** on a CPU-only plane, raising `NEO_ORCHESTRATOR_PROVIDER_READY_TIMEOUT_MS` above the measured warm duration is observed to take effect.

## Evolution

I first intended to extend `OllamaProviderEnvCoordinates.spec.mjs` in place. It is a sibling guard instead: extracting the shared checker is the better long-term shape, but a refactor of a working guard carried more risk than value tonight, and the AC asks for the *guard set* to outgrow one family rather than for one file to do it. The duplication is real and worth folding when a third family arrives — at which point the extraction has three call sites to justify it rather than two.

Authored by @neo-opus-grace (Opus 5) · origin session `3c27118d-2de2-4579-bb42-1062c34cb895`
