### PR TITLE
fix(wake): the digest counts queued events and called them 'new messages' (#16541)

### DIFF
--- a/ai/daemons/wake/localWakeAdapters.mjs
+++ b/ai/daemons/wake/localWakeAdapters.mjs
@@ -61,7 +61,12 @@ export function formatLocalWakeDigest(envelope = {}) {
         const latest         = latestMessage.subject
             ? `"${latestMessage.subject}"${latestMessage.from ? ` from ${latestMessage.from}` : ''}${prioritySuffix}`
             : latestMessage.messageId || 'mailbox event';
-        lines.push(`- ${breakdown.sent_to_me.count} new messages (latest: ${latest})`);
+        // COUNTS QUEUED EVENTS, and says so. Nothing on this path consults read-state - grep this
+        // file and `wakeDigestBuilder.mjs` for readAt/unread and both return zero. A message
+        // delivered, read and acted on hours ago still contributes its queued event here, so
+        // "new messages" named a number this code cannot produce. Renaming is the honest half of
+        // the repair; reconciling against the unread set is the other half and is not this change.
+        lines.push(`- ${breakdown.sent_to_me.count} message events (latest: ${latest})`);
     }
     if (breakdown.task_state_changed?.count > 0) {
         const latest = breakdown.task_state_changed.latest || {};

--- a/ai/daemons/wake/wakeDigestBuilder.mjs
+++ b/ai/daemons/wake/wakeDigestBuilder.mjs
@@ -124,7 +124,11 @@ export function buildWakeDigest(identity, {messages = [], tasks = [], permission
         const latest         = latestByEventTime(messages, 'sentAt'),
               latestPriority = normalizeWakePriority(latest.priority),
               prioritySuffix = latestPriority === digestPriority ? '' : `, latest priority: ${latestPriority}`;
-        breakdown += `\n- ${messages.length} new messages (latest: "${latest.subject}" from ${latest.from}${prioritySuffix})`;
+        // COUNTS QUEUED EVENTS. This function's own signature says so: the parameter object is
+        // `events`, and `messages` is its message-class event array. Same rename as the sibling
+        // seam in `localWakeAdapters.mjs` - both must move together or the two renderers disagree
+        // about what the same number means.
+        breakdown += `\n- ${messages.length} message events (latest: "${latest.subject}" from ${latest.from}${prioritySuffix})`;
     }
     if (tasks.length > 0) {
         const latest = latestByEventTime(tasks, 'lastModifiedAt');

--- a/ai/mcp/server/memory-core/Server.mjs
+++ b/ai/mcp/server/memory-core/Server.mjs
@@ -293,7 +293,10 @@ class Server extends BaseServer {
         // engine never imports the mailbox. `readBackgroundDeliveryState` is the unpermissioned
         // background variant; `inspectReadState` cannot be used here because it requires a bound
         // request identity the flush path does not have.
-        CoalescingEngineService.configure({...wakeDispatch, resolveDeliveryReadState: readBackgroundDeliveryState});
+        // `wakeDispatch` is an AiConfig node and is handed over BY REFERENCE. Never `{...wakeDispatch}`:
+        // the proxy's `ownKeys` trap enumerates local `#dataConfigs` only, so spreading a node whose
+        // leaves live on the Tier-1 root yields `{}` — silently, with every named read still correct.
+        CoalescingEngineService.configure(wakeDispatch, {resolveDeliveryReadState: readBackgroundDeliveryState});
         WebhookDeliveryService.configure(wakeDispatch);
 
         this.mcpServer = this.createMcpServer();

--- a/ai/mcp/server/memory-core/Server.mjs
+++ b/ai/mcp/server/memory-core/Server.mjs
@@ -24,8 +24,8 @@ import {
     Memory_CoalescingEngineService    as CoalescingEngineService,
     Memory_WebhookDeliveryService     as WebhookDeliveryService
 } from '../../../services.mjs';
-import {startDrainLoop}   from '../../../daemons/embed/drainCycle.mjs';
-import {acquireDrainLock} from '../../../daemons/embed/drainLock.mjs';
+import {startDrainLoop}          from '../../../daemons/embed/drainCycle.mjs';
+import {acquireDrainLock}        from '../../../daemons/embed/drainLock.mjs';
 import MemoryCoreRecorderService from '../../../services/memory-core/MemoryCoreRecorderService.mjs';
 import {
     createMessageGraphProjectionProcessor,
@@ -37,6 +37,7 @@ import {LOOPBACK_PROBE_HEALTH_KEY}      from '../../../services/memory-core/help
 import {TRUST_TIERS}                    from '../../../graph/identityRoots.mjs';
 import {normalizeAgentIdentityNodeId}   from '../../../graph/normalizeAgentIdentityNodeId.mjs';
 import ConfigBase, {PLANE_MEMBER_PATHS} from './configBase.mjs';
+import {readBackgroundDeliveryState}    from '../../../services/memory-core/MailboxService.mjs';
 
 // Security invariant, not deployment policy: graph ids must remain namespace/path/control safe.
 const AUTH_IDENTITY_USER_ID_RE = /^[A-Za-z0-9][A-Za-z0-9._-]{0,254}$/;
@@ -288,7 +289,11 @@ class Server extends BaseServer {
 
         const wakeDispatch = aiConfig.orchestrator.wakeDispatch;
 
-        CoalescingEngineService.configure(wakeDispatch);
+        // The digest reconciles against read-state through an INJECTED reader, so the coalescing
+        // engine never imports the mailbox. `readBackgroundDeliveryState` is the unpermissioned
+        // background variant; `inspectReadState` cannot be used here because it requires a bound
+        // request identity the flush path does not have.
+        CoalescingEngineService.configure({...wakeDispatch, resolveDeliveryReadState: readBackgroundDeliveryState});
         WebhookDeliveryService.configure(wakeDispatch);
 
         this.mcpServer = this.createMcpServer();

--- a/ai/services/memory-core/CoalescingEngineService.mjs
+++ b/ai/services/memory-core/CoalescingEngineService.mjs
@@ -496,14 +496,16 @@ class CoalescingEngineService extends Base {
                 continue
             }
 
-            // Read-state reconciliation, `sent_to_me` only — the other buckets have no delivery edge
-            // and therefore no read-state to reconcile against.
+            // Read-state reconciliation, `sent_to_me` only — the other buckets carry no mailbox row
+            // and therefore have no read-state to reconcile against.
             //
             // FAIL-SAFE at every branch. No resolver, no messageId, a resolver that throws, or a
-            // resolver returning `{}` (graph unavailable / delivery edge missing) all mean UNKNOWN,
-            // and unknown renders the event exactly as before. Only a committed `readAt` suppresses
-            // one. Suppressing on uncertainty would turn a mislabelled count into a missing wake,
-            // and a missing wake is visible to nobody.
+            // resolver returning `{}` (graph unavailable) all mean UNKNOWN, and unknown renders the
+            // event exactly as before. Only a committed `readAt` suppresses one. Suppressing on
+            // uncertainty would turn a mislabelled count into a missing wake, and a missing wake is
+            // visible to nobody.
+            let unopenable = false;
+
             if (bucketKey === 'sent_to_me' && this.resolveDeliveryReadState) {
                 const messageId = evt.payload?.messageId;
 
@@ -519,6 +521,14 @@ class CoalescingEngineService extends Base {
                     if (state?.readAt) {
                         continue
                     }
+
+                    // `missing` is NOT `{}`. The resolver reports it only after establishing that no
+                    // MESSAGE row exists — a positive finding, not an absence of information. The
+                    // event still counts (something was queued, and hiding that is the suppression
+                    // failure mode), but it must never become `latest`: a `latest` is a pointer the
+                    // recipient is invited to open, and naming one that cannot be opened sends them
+                    // hunting for a message that is not there. That is AC-6.
+                    unopenable = state?.missing === true
                 }
             }
 
@@ -528,8 +538,9 @@ class CoalescingEngineService extends Base {
 
             const ts = resolveEventTimestamp(evt);
 
-            // Recency wins over position; a timestamp-less candidate keeps last-write-wins.
-            if (bucket.latest === null || ts === null || ts >= bucket.latestTs) {
+            // Recency wins over position; a timestamp-less candidate keeps last-write-wins. An
+            // unopenable event is disqualified from the pointer only — it has already been counted.
+            if (!unopenable && (bucket.latest === null || ts === null || ts >= bucket.latestTs)) {
                 bucket.latest   = evt.payload;
                 bucket.latestTs = ts ?? bucket.latestTs;
             }

--- a/ai/services/memory-core/CoalescingEngineService.mjs
+++ b/ai/services/memory-core/CoalescingEngineService.mjs
@@ -118,6 +118,18 @@ class CoalescingEngineService extends Base {
     defaultWindowSeconds = null
 
     /**
+     * @member {Function|null} resolveDeliveryReadState=null
+     * @protected
+     * @summary Entrypoint-injected `(messageId, recipient) => {readAt?}` background read-state reader.
+     *
+     * FAIL-SAFE, never fail-closed. When this is null — or throws — the digest renders exactly as it
+     * did before read-state existed. This is the whole swarm's wake path: a reconciliation bug that
+     * SUPPRESSES wakes is strictly worse than the mislabelled count it replaces, because a wrong
+     * number is visible in the wake and a missing wake is visible to nobody.
+     */
+    resolveDeliveryReadState = null
+
+    /**
      * @member {Number|null} refractoryMs=null
      * @protected
      * @summary Entrypoint-injected post-delivery refractory in milliseconds.
@@ -177,8 +189,12 @@ class CoalescingEngineService extends Base {
      * @param {Number} options.flushRefractorySeconds
      * @param {Number} options.flushHardCapSeconds
      */
-    configure({coalesceWindowSeconds, flushRefractorySeconds, flushHardCapSeconds} = {}) {
+    configure({coalesceWindowSeconds, flushRefractorySeconds, flushHardCapSeconds, resolveDeliveryReadState = null} = {}) {
         const values = {coalesceWindowSeconds, flushRefractorySeconds, flushHardCapSeconds};
+
+        if (resolveDeliveryReadState !== null && typeof resolveDeliveryReadState !== 'function') {
+            throw new Error("CoalescingEngineService.configure requires 'resolveDeliveryReadState' to be a function or null");
+        }
 
         for (const [name, value] of Object.entries(values)) {
             if (!Number.isFinite(value) || value < 0) {
@@ -189,7 +205,8 @@ class CoalescingEngineService extends Base {
             throw new Error("CoalescingEngineService.configure requires 'flushHardCapSeconds' greater than zero");
         }
 
-        this.defaultWindowSeconds = coalesceWindowSeconds;
+        this.defaultWindowSeconds      = coalesceWindowSeconds;
+        this.resolveDeliveryReadState = resolveDeliveryReadState;
         this.refractoryMs         = flushRefractorySeconds * 1000;
         this.hardCapMs            = flushHardCapSeconds * 1000;
     }
@@ -457,6 +474,32 @@ class CoalescingEngineService extends Base {
 
             if (!bucketKey) {
                 continue
+            }
+
+            // Read-state reconciliation, `sent_to_me` only — the other buckets have no delivery edge
+            // and therefore no read-state to reconcile against.
+            //
+            // FAIL-SAFE at every branch. No resolver, no messageId, a resolver that throws, or a
+            // resolver returning `{}` (graph unavailable / delivery edge missing) all mean UNKNOWN,
+            // and unknown renders the event exactly as before. Only a committed `readAt` suppresses
+            // one. Suppressing on uncertainty would turn a mislabelled count into a missing wake,
+            // and a missing wake is visible to nobody.
+            if (bucketKey === 'sent_to_me' && this.resolveDeliveryReadState) {
+                const messageId = evt.payload?.messageId;
+
+                if (messageId && subscription.agentIdentity) {
+                    let state = null;
+
+                    try {
+                        state = this.resolveDeliveryReadState(messageId, subscription.agentIdentity)
+                    } catch (error) {
+                        logger.warn?.(`[CoalescingEngine] read-state lookup failed for ${messageId}; rendering as unread: ${error.message}`)
+                    }
+
+                    if (state?.readAt) {
+                        continue
+                    }
+                }
             }
 
             const bucket = breakdown[bucketKey];

--- a/ai/services/memory-core/CoalescingEngineService.mjs
+++ b/ai/services/memory-core/CoalescingEngineService.mjs
@@ -184,12 +184,32 @@ class CoalescingEngineService extends Base {
      * The service deliberately does not import `AiConfig`: the Memory Core entrypoint is the
      * composition root, preventing hidden defaults from drifting across deployment topology.
      *
-     * @param {Object} options
-     * @param {Number} options.coalesceWindowSeconds
-     * @param {Number} options.flushRefractorySeconds
-     * @param {Number} options.flushHardCapSeconds
+     * **Why the collaborator takes its OWN parameter instead of riding in `dispatchConfig`.** The
+     * first argument is an `AiConfig` node — a `Neo.state.Provider` proxy, not a plain object — and
+     * the caller must be able to hand it over **by reference**. Adding one more key to that bag reads
+     * as harmless and forces the caller to build `{...wakeDispatch, extra}`, which is the one
+     * operation the proxy cannot survive: the `get` trap resolves `override-else-inherit` up the
+     * parent chain, but the `ownKeys` trap (`Provider#getTopLevelDataKeys`) enumerates **local
+     * `#dataConfigs` only**. These leaves are declared on the Tier-1 root (`ai/configBase.mjs`), so
+     * for the Memory Core child provider `{...wakeDispatch}` is measurably `{}` while every named
+     * read still returns its number. The spread does not warn, throw, or degrade — it silently
+     * substitutes an empty object, and the first symptom is a validation error naming a leaf the
+     * caller can plainly see is set.
+     *
+     * Destructuring below is safe for exactly the same reason it is dangerous above: naming the keys
+     * goes through the `get` trap. **Never add a rest element (`...rest`) to that pattern** — rest,
+     * like spread, is `ownKeys`, and would reintroduce this failure from the other side.
+     *
+     * @param {Object} dispatchConfig The `AiConfig` wake-dispatch node. Passed by reference; never materialized.
+     * @param {Number} dispatchConfig.coalesceWindowSeconds
+     * @param {Number} dispatchConfig.flushRefractorySeconds
+     * @param {Number} dispatchConfig.flushHardCapSeconds
+     * @param {Object}          [collaborators]                          Wiring, not configuration.
+     * @param {Function|null}   [collaborators.resolveDeliveryReadState] `(messageId, recipient) => {readAt?}`
      */
-    configure({coalesceWindowSeconds, flushRefractorySeconds, flushHardCapSeconds, resolveDeliveryReadState = null} = {}) {
+    configure({coalesceWindowSeconds, flushRefractorySeconds, flushHardCapSeconds} = {},
+        {resolveDeliveryReadState = null} = {}
+    ) {
         const values = {coalesceWindowSeconds, flushRefractorySeconds, flushHardCapSeconds};
 
         if (resolveDeliveryReadState !== null && typeof resolveDeliveryReadState !== 'function') {
@@ -205,10 +225,10 @@ class CoalescingEngineService extends Base {
             throw new Error("CoalescingEngineService.configure requires 'flushHardCapSeconds' greater than zero");
         }
 
-        this.defaultWindowSeconds      = coalesceWindowSeconds;
+        this.defaultWindowSeconds     = coalesceWindowSeconds;
+        this.refractoryMs             = flushRefractorySeconds * 1000;
+        this.hardCapMs                = flushHardCapSeconds * 1000;
         this.resolveDeliveryReadState = resolveDeliveryReadState;
-        this.refractoryMs         = flushRefractorySeconds * 1000;
-        this.hardCapMs            = flushHardCapSeconds * 1000;
     }
 
     /**

--- a/ai/services/memory-core/MailboxService.mjs
+++ b/ai/services/memory-core/MailboxService.mjs
@@ -987,15 +987,64 @@ function getCachedMessageProjectionIssues(messageId) {
  * discloses nothing that recipient's own wake would not already contain. Any other consumer wanting
  * cross-inbox read-state must go through `inspectReadState` and its permission gate.
  *
- * Returns `{}` when the graph is unavailable or the delivery edge is missing, which callers must
- * treat as "unknown", never as "unread" or "read".
+ * **The mailbox has TWO storage shapes, and this reader must answer for both.** An earlier version
+ * delegated straight to `getStorageDeliveryMutableState`, which reads only per-recipient
+ * `DELIVERED_TO` edges — the BROADCAST shape. Direct messages keep `readAt` on the MESSAGE node
+ * itself, so every read direct DM came back `{}`, was scored "unknown", and kept counting. The
+ * injection shape was right and the collaborator answered half the domain; @neo-gpt caught it by
+ * tracing the reader into the storage model rather than trusting its summary. The
+ * normalization mirrors `getReadAtForMessage(messageNode, deliveryEdge)`, the canonical two-shape
+ * reader already used by the permissioned read path — one rule, not a parallel second one.
+ *
+ * **Three outcomes, not two, because "absent" and "unread" are different answers.** Collapsing them
+ * into `{}` is what let a digest name a `latest` whose message row no longer exists — a pointer the
+ * recipient cannot open, which is worse than a wrong count because it sends them looking:
+ *
+ * - `{readAt}`          — committed read. SUPPRESS.
+ * - `{present: true}`   — row exists, not read. RENDER.
+ * - `{missing: true}`   — no MESSAGE row at all. Render the count if you like, but never name it
+ *                         `latest`; there is nothing to open.
+ * - `{}`                — UNKNOWN (graph unavailable). Fail-safe: render exactly as before
+ *                         read-state existed. Never infer "unread" or "read" from it.
  *
  * @param {String} messageId MESSAGE node id.
  * @param {String} recipient Recipient identity node id.
- * @returns {Object} `{readAt?, archivedAt?}` — only committed non-null fields.
+ * @returns {Object} `{readAt?, archivedAt?, present?, missing?}` — committed fields only.
  */
 export function readBackgroundDeliveryState(messageId, recipient) {
-    return getStorageDeliveryMutableState(messageId, recipient)
+    const sqlite = GraphService.db?.storage?.db;
+
+    // No graph is UNKNOWN, never "missing": the row may well exist and simply be unreadable from
+    // here. Distinguishing the two is the whole point of this function.
+    if (!sqlite) return {};
+
+    // Broadcast shape first — a per-recipient edge is the more specific authority, and its presence
+    // is what `getReadAtForMessage` uses to decide which shape it is looking at.
+    const edgeState = getStorageDeliveryMutableState(messageId, recipient);
+
+    if (edgeState.readAt != null || edgeState.archivedAt != null) {
+        return {...edgeState, present: true}
+    }
+
+    let rows;
+
+    try {
+        rows = sqlite
+            .prepare(`SELECT json_extract(data, '$.properties.readAt') AS readAt, json_extract(data, '$.properties.archivedAt') AS archivedAt FROM Nodes WHERE id = ? AND json_extract(data, '$.label') = 'MESSAGE'`)
+            .all(messageId)
+    } catch (error) {
+        return {}
+    }
+
+    if (!rows.length) return {missing: true};
+
+    const [row] = rows,
+          state = {present: true};
+
+    if (row.readAt     != null) state.readAt     = row.readAt;
+    if (row.archivedAt != null) state.archivedAt = row.archivedAt;
+
+    return state
 }
 
 export function getWakeDeliverySeries({since = null, until = null} = {}) {

--- a/ai/services/memory-core/MailboxService.mjs
+++ b/ai/services/memory-core/MailboxService.mjs
@@ -972,6 +972,32 @@ function getCachedMessageProjectionIssues(messageId) {
  * alone cannot mistake it for total delivery volume. `perRecipient` is sorted descending, so the
  * loudest inbox is the first row.
  */
+/**
+ * @summary Reads one delivery's durable read-state for a BACKGROUND caller, with no request context
+ * and no permission check.
+ *
+ * `MailboxService.inspectReadState` is the permissioned, operator-facing adapter and is **unusable
+ * here**: it resolves a bound agent identity through `RequestContextService` and enforces
+ * `CAN_READ_INBOX_OF`. The wake digest is assembled inside a background flush that has neither, so
+ * calling it would throw `unboundIdentityError` on every wake.
+ *
+ * **Why an unpermissioned reader is acceptable at this seam, stated rather than assumed.** The only
+ * sanctioned consumer is the coalescing engine, which reads the read-state of the *same recipient it
+ * is already building a digest for* — a recipient whose entire unread set it is about to render. It
+ * discloses nothing that recipient's own wake would not already contain. Any other consumer wanting
+ * cross-inbox read-state must go through `inspectReadState` and its permission gate.
+ *
+ * Returns `{}` when the graph is unavailable or the delivery edge is missing, which callers must
+ * treat as "unknown", never as "unread" or "read".
+ *
+ * @param {String} messageId MESSAGE node id.
+ * @param {String} recipient Recipient identity node id.
+ * @returns {Object} `{readAt?, archivedAt?}` — only committed non-null fields.
+ */
+export function readBackgroundDeliveryState(messageId, recipient) {
+    return getStorageDeliveryMutableState(messageId, recipient)
+}
+
 export function getWakeDeliverySeries({since = null, until = null} = {}) {
     const sqlite = GraphService.db?.storage?.db;
 

--- a/test/playwright/unit/ai/daemons/wake/daemon.spec.mjs
+++ b/test/playwright/unit/ai/daemons/wake/daemon.spec.mjs
@@ -399,9 +399,9 @@ test.describe('Wake Daemon', () => {
         const output = await deliveryPromise;
         expect(output).toContain('[WAKE][priority:high]');
         expect(output).toContain(`2 events for ${agentId}`);
-        expect(output).toContain('2 new messages');
+        expect(output).toContain('2 message events');
         expect(output).toContain('High Priority Broadcast');
-        expect(output).not.toContain('4 new messages');
+        expect(output).not.toContain('4 message events');
         expect(output).not.toContain('Normal Priority Direct');
         expect(output).not.toContain('Normal Priority Broadcast');
     });
@@ -845,12 +845,12 @@ test.describe('Wake Daemon', () => {
             env  : { ...process.env, NEO_MEMORY_DB_PATH: DB_PATH, NEO_AI_DAEMON_DIR: DAEMON_DIR }
         });
 
-        // First flush ("1 new messages") fails + enqueues; the second flush coalesces; the RETRY
-        // rebuilds a digest over BOTH → "2 new messages". That string proves neither wake was lost.
+        // First flush ("1 message events") fails + enqueues; the second flush coalesces; the RETRY
+        // rebuilds a digest over BOTH → "2 message events". That string proves neither wake was lost.
         const coalescedPromise = new Promise((resolve, reject) => {
             const timeout = setTimeout(() => reject(new Error('Coalesced 2-message retry digest not observed within timeout')), 25000);
             const onData  = (data) => {
-                if (data.toString().includes('2 new messages')) {
+                if (data.toString().includes('2 message events')) {
                     clearTimeout(timeout);
                     resolve();
                 }
@@ -887,7 +887,7 @@ test.describe('Wake Daemon', () => {
         const logContents = fs.readFileSync(logFile, 'utf8');
         expect(logContents).toContain('[Wake Daemon Test-Fail Adapter] Attempted');
         expect(logContents).toContain(`2 events for ${agentId}`); // coalesced total count
-        expect(logContents).toContain('2 new messages');          // coalesced breakdown
+        expect(logContents).toContain('2 message events');          // coalesced breakdown
     });
 
     test('#13281: a retry drops a message read between the failed delivery and the re-attempt', async () => {
@@ -1099,7 +1099,7 @@ test.describe('Wake Daemon', () => {
 
         let logContents = fs.readFileSync(path.join(DAEMON_DIR, 'wake-daemon.log'), 'utf8');
         expect(logContents).toContain('[WAKE][priority:normal] 1 events');
-        expect(logContents).toContain('1 new messages (latest: "Current Peer Message"');
+        expect(logContents).toContain('1 message events (latest: "Current Peer Message"');
         expect(logContents).not.toContain('Four-Day Ghost Replay');
         expect(logContents).toContain(`Suppressed 1 stale/invalid message wake event(s) for ${agentId} at initial delivery`);
 
@@ -1172,7 +1172,7 @@ test.describe('Wake Daemon', () => {
         // generic directive — that unconditional placement was the dominant token cost (message wakes
         // far outnumber the heartbeat).
         const output = await deliveryPromise;
-        expect(output).toContain('new messages');          // the message digest still delivers normally
+        expect(output).toContain('message events');          // the message digest still delivers normally
         expect(output).not.toContain('lifecycle-first');   // ...but WITHOUT the lane directive (heartbeat-only)
         expect(output).not.toContain('verified-empty');
     });
@@ -1316,7 +1316,7 @@ test.describe('Wake Daemon', () => {
 
         const output = await deliveryPromise;
         expect(output).toContain('[Wake Daemon Test Adapter] Delivered');
-        expect(output).toContain('1 new messages');         // only the unread one is counted
+        expect(output).toContain('1 message events');         // only the unread one is counted
         expect(output).toContain('Genuinely New Signal');    // ...and previewed as the latest
         expect(output).not.toContain('Already Read Noise');  // the already-read one is reconciled out
     });
@@ -1394,7 +1394,7 @@ test.describe('Wake Daemon', () => {
         expect(output).toContain('lifecycle-first');   // a pure-heartbeat digest DOES carry the lane directive (heartbeat-only placement)
         expect(output).toContain('latest GitHub mention: "Ping Euclid"');
         expect(output).toContain('[PR #13411: MERGED, mergedAt 2026-06-16T10:20:00Z, checkedAt 2026-06-16T10:21:00Z]');
-        expect(output).not.toContain('new messages');
+        expect(output).not.toContain('message events');
     });
 
     test('renders idle-out-nudge cycle-state in the heartbeat digest (#12612)', async () => {
@@ -1510,7 +1510,7 @@ test.describe('Wake Daemon', () => {
         expect(output).toContain('[Wake Daemon Test Adapter] Delivered');
         expect(output).toContain('[WAKE][priority:normal]');
         expect(output).toContain('heartbeat pulses');
-        expect(output).not.toContain('new messages');
+        expect(output).not.toContain('message events');
     });
 
     test('does not deliver wake events for wakeSuppressed mailbox-only messages', async () => {
@@ -1709,7 +1709,7 @@ test.describe('Wake Daemon', () => {
         await deliveryPromise;
 
         expect(deliveryCount).toBe(1);
-        expect(finalDigest).toContain('1 new messages');
+        expect(finalDigest).toContain('1 message events');
         expect(finalDigest).toContain('Test Dedup Event');
         expect(finalDigest).toContain('[WAKE][priority:normal]');
         expect(finalDigest).not.toContain('priority: normal');
@@ -2129,7 +2129,7 @@ test.describe('Wake Daemon', () => {
 
         const output = await deliveryPromise;
         expect(output).toContain('[WAKE][priority:high]');
-        expect(output).toContain('2 new messages');
+        expect(output).toContain('2 message events');
         expect(output).toContain('Low Priority Wake Event');
         expect(output).toContain('latest priority: low');
     });
@@ -4396,7 +4396,7 @@ test.describe('Wake Daemon', () => {
         expect(escapeIndex).toBeGreaterThan(pasteIndex);
         expect(enterIndex).toBeGreaterThan(escapeIndex);
         expect(digest).toContain('Codex Mixed Submit');
-        expect(digest).toContain('new messages');
+        expect(digest).toContain('message events');
         expect(digest).not.toContain('heartbeat pulses');
         expect(digest).not.toContain('lifecycle-first');
         expect(stdoutLog).toContain(`[Wake Daemon] Submit attempted ${subId} via osascript to Codex`);

--- a/test/playwright/unit/ai/daemons/wake/daemonDeliveryOwner.spec.mjs
+++ b/test/playwright/unit/ai/daemons/wake/daemonDeliveryOwner.spec.mjs
@@ -245,7 +245,7 @@ test.describe('Wake Daemon — atomic delivery owner (mounted composition witnes
         const unionRequest = successBodies.find(r => r.body.includes('MERGED-INTO-RETRY-MSG'));
         expect(unionRequest, 'the merged message must be delivered — zero loss').toBeTruthy();
         expect(unionRequest.body, 'ONE union digest carrying both messages').toMatch(/2 events for @owner-test-retry-union/);
-        expect(unionRequest.body).toMatch(/2 new messages/);
+        expect(unionRequest.body).toMatch(/2 message events/);
         expect(successBodies, 'exactly one delivery — never a separate second block').toHaveLength(1);
 
         const log           = readLog();

--- a/test/playwright/unit/ai/daemons/wake/digestCountLabel.spec.mjs
+++ b/test/playwright/unit/ai/daemons/wake/digestCountLabel.spec.mjs
@@ -1,0 +1,96 @@
+import {expect, test}  from '@playwright/test';
+import fs              from 'fs-extra';
+import path            from 'path';
+import {fileURLToPath} from 'url';
+
+const
+    repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../../../../../'),
+    SEAMS    = [
+        {
+            file : 'ai/daemons/wake/localWakeAdapters.mjs',
+            emits: 'breakdown.sent_to_me.count'
+        }, {
+            file : 'ai/daemons/wake/wakeDigestBuilder.mjs',
+            emits: 'messages.length'
+        }
+    ];
+
+/**
+ * @summary The wake digest's message count is labelled as what it measures: queued events.
+ *
+ * **The defect.** Both renderers emitted `N new messages` for a number produced by counting **queued
+ * events**. Neither seam consults read-state — grep both files for `readAt` / `unread` / `markRead`
+ * and the answer is zero in each. So a message delivered, read and acted on hours ago still
+ * contributes its queued event to that number, and the label named something the code cannot compute.
+ *
+ * The consequence is not cosmetic. A count that says "messages" and means "events" is why seats stop
+ * trusting wakes: several maintainers spent real turns hunting for messages that were never missing,
+ * because the digest told them a number about their mailbox that was actually a number about a queue.
+ *
+ * **This is the rename half only.** The ticket's other half — reconciling the count against the
+ * recipient's unread set, or resolving the `latest` pointer at render time — is untouched here and
+ * remains open. Renaming does not make the digest accurate; it makes it *honest about what it is*,
+ * which is the smaller repair the AC explicitly permits: *"unread-accurate OR renamed to what it
+ * measures."*
+ *
+ * **Why both seams, asserted independently.** The AC requires a spec that fails against a tree where
+ * only one is fixed. Two renderers producing the same wake with different words for the same number
+ * is worse than the original defect — a reader comparing two wakes would reasonably conclude the
+ * counts measure different things.
+ *
+ * **A deliberate future failure.** If someone later reconciles a seam against read-state, the
+ * `no-read-state` arm below will go red. That is intended, not a bug: at that moment the count really
+ * would be a message count, and the label should be revisited *as part of that change* rather than
+ * silently diverging from it again. The arm exists to force that conversation.
+ */
+
+/**
+ * @summary Reads a seam's source with comments stripped, so a label assertion cannot be satisfied —
+ * or broken — by prose. The renaming comment quotes the old label to explain the removal.
+ * @param {String} relativePath
+ * @returns {String}
+ */
+function readCode(relativePath) {
+    return fs.readFileSync(path.join(repoRoot, relativePath), 'utf8')
+        .replace(/\/\*[\s\S]*?\*\//g, '')
+        .replace(/^\s*\/\/.*$/gm, '')
+}
+
+test.describe('wake digest labels its count as events, not messages', () => {
+    for (const seam of SEAMS) {
+        test(`${path.basename(seam.file)} does not call an event count "new messages"`, () => {
+            expect(readCode(seam.file), `${seam.file} still labels queued events as messages`)
+                .not.toContain('new messages')
+        });
+
+        test(`${path.basename(seam.file)} emits the count under an honest label`, () => {
+            const code = readCode(seam.file);
+
+            // Non-vacuity: the arm above passes trivially if the line were deleted rather than
+            // relabelled, which would remove information from the wake instead of correcting it.
+            expect(code, `${seam.file} must still render the count`).toContain('message events');
+            expect(code, `${seam.file} must still compute it from ${seam.emits}`)
+                .toContain(seam.emits)
+        })
+    }
+
+    test('BOTH seams moved together — a half-repair is a worse state than the defect', () => {
+        // THE arm the ticket asks for by name: "a spec must fail against a tree where only one is
+        // fixed". Asserted as a set rather than per-file so the failure names the divergence itself.
+        const labelled = SEAMS.filter(seam => readCode(seam.file).includes('message events'));
+
+        expect(labelled.length,
+            'both renderers must use the same words for the same number; two wakes disagreeing ' +
+            'about what a count means is worse than one wake being wrong').toBe(SEAMS.length)
+    });
+
+    test('neither seam consults read-state — the fact that makes the rename correct', () => {
+        // The justification, asserted rather than asserted-about. If this goes red because a seam
+        // gained real read-state reconciliation, revisit the LABEL as part of that change: the count
+        // would then genuinely be a message count and "message events" would understate it.
+        for (const seam of SEAMS) {
+            expect(readCode(seam.file), `${seam.file} now reads read-state — revisit the label`)
+                .not.toMatch(/\b(readAt|isUnread|markRead)\b/)
+        }
+    })
+});

--- a/test/playwright/unit/ai/daemons/wake/localWakeAdapters.spec.mjs
+++ b/test/playwright/unit/ai/daemons/wake/localWakeAdapters.spec.mjs
@@ -35,7 +35,7 @@ test.describe.serial('ai/daemons/wake/localWakeAdapters', () => {
             '[WAKE][priority:high] 2 events for @neo-gpt:'
         );
         expect(formatLocalWakeDigest(record('test').envelope)).toContain(
-            '1 new messages (latest: "review" from @neo-opus-vega)'
+            '1 message events (latest: "review" from @neo-opus-vega)'
         );
     });
 
@@ -48,7 +48,7 @@ test.describe.serial('ai/daemons/wake/localWakeAdapters', () => {
 
         expect(probedDigest).toContain('[session-context: 45K tokens, gate at 250K]');
         // The line sits directly under the [WAKE] header, ahead of the breakdown bullets
-        expect(probedDigest.indexOf('[session-context:')).toBeLessThan(probedDigest.indexOf('1 new messages'));
+        expect(probedDigest.indexOf('[session-context:')).toBeLessThan(probedDigest.indexOf('1 message events'));
 
         // Absent probe data → no field → no line (an unprobed wake stays noise-free)
         expect(formatLocalWakeDigest(record('test').envelope)).not.toContain('session-context');

--- a/test/playwright/unit/ai/daemons/wake/wakeDigestBuilder.spec.mjs
+++ b/test/playwright/unit/ai/daemons/wake/wakeDigestBuilder.spec.mjs
@@ -47,7 +47,7 @@ test.describe('ai/daemons/wake/wakeDigestBuilder', () => {
         });
 
         expect(digest).toContain('latest: "the fresh 11:21 message" from @bob');
-        expect(digest).toContain('3 new messages')
+        expect(digest).toContain('3 message events')
     });
 
     test('equal sentAt timestamps keep the last-enqueued message (no same-instant drift)', () => {

--- a/test/playwright/unit/ai/services/memory-core/CoalescingEngineService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/CoalescingEngineService.spec.mjs
@@ -485,4 +485,95 @@ test.describe('CoalescingEngineService', () => {
         expect(b.sent_to_me.count).toBe(2);
         expect(b.sent_to_me.highestPriority).toBe('normal')
     });
+
+    // -----------------------------------------------------------------------------
+    // Read-state reconciliation
+    //
+    // The digest counted QUEUED EVENTS and never consulted read-state, so a message delivered, read
+    // and acted on hours ago still contributed to the count and could be named `latest`. These arms
+    // pin both the reconciliation and — more importantly — its FAIL-SAFE boundary: this is the whole
+    // swarm's wake path, and suppressing a wake on uncertainty is worse than the wrong count it
+    // replaces, because a wrong number is visible in the wake and a missing wake is visible to nobody.
+    // -----------------------------------------------------------------------------
+
+    test('an already-read message is excluded from the count and cannot be named latest', async () => {
+        CoalescingEngineService.configure({
+            coalesceWindowSeconds   : 30,
+            flushRefractorySeconds  : 120,
+            flushHardCapSeconds     : 300,
+            resolveDeliveryReadState: messageId => messageId === 'M-READ' ? {readAt: '2026-08-10T10:00:00.000Z'} : {}
+        });
+
+        const sub = buildSubscription({harnessTargetMetadata: {url: 'https://example.com/wake', coalesceWindow: 0.05}});
+        CoalescingEngineService.enqueue(sub, buildEnvelope('wake/sent_to_me', {messageId: 'M-READ',   subject: 'handled hours ago'}, 10));
+        CoalescingEngineService.enqueue(sub, buildEnvelope('wake/sent_to_me', {messageId: 'M-UNREAD', subject: 'actually new'}, 11));
+
+        await new Promise(resolve => setTimeout(resolve, 100));
+
+        const digest = deliverCalls[0].eventData;
+
+        expect(digest.payload.breakdown.sent_to_me.count).toBe(1);
+        expect(digest.payload.breakdown.sent_to_me.latest.messageId).toBe('M-UNREAD');
+    });
+
+    test('NON-VACUITY — the same two events both count when neither is read', async () => {
+        // Without this arm the assertion above passes against a resolver that suppresses everything.
+        CoalescingEngineService.configure({
+            coalesceWindowSeconds   : 30,
+            flushRefractorySeconds  : 120,
+            flushHardCapSeconds     : 300,
+            resolveDeliveryReadState: () => ({})
+        });
+
+        const sub = buildSubscription({harnessTargetMetadata: {url: 'https://example.com/wake', coalesceWindow: 0.05}});
+        CoalescingEngineService.enqueue(sub, buildEnvelope('wake/sent_to_me', {messageId: 'M-READ'},   10));
+        CoalescingEngineService.enqueue(sub, buildEnvelope('wake/sent_to_me', {messageId: 'M-UNREAD'}, 11));
+
+        await new Promise(resolve => setTimeout(resolve, 100));
+
+        expect(deliverCalls[0].eventData.payload.breakdown.sent_to_me.count).toBe(2);
+    });
+
+    test('FAIL-SAFE — a resolver that THROWS renders the event rather than dropping it', async () => {
+        CoalescingEngineService.configure({
+            coalesceWindowSeconds   : 30,
+            flushRefractorySeconds  : 120,
+            flushHardCapSeconds     : 300,
+            resolveDeliveryReadState: () => { throw new Error('graph unavailable') }
+        });
+
+        const sub = buildSubscription({harnessTargetMetadata: {url: 'https://example.com/wake', coalesceWindow: 0.05}});
+        CoalescingEngineService.enqueue(sub, buildEnvelope('wake/sent_to_me', {messageId: 'M1'}, 10));
+
+        await new Promise(resolve => setTimeout(resolve, 100));
+
+        expect(deliverCalls.length).toBe(1);
+        expect(deliverCalls[0].eventData.payload.breakdown.sent_to_me.count).toBe(1);
+    });
+
+    test('FAIL-SAFE — no resolver injected renders exactly as before read-state existed', async () => {
+        CoalescingEngineService.configure({
+            coalesceWindowSeconds : 30,
+            flushRefractorySeconds: 120,
+            flushHardCapSeconds   : 300
+        });
+
+        const sub = buildSubscription({harnessTargetMetadata: {url: 'https://example.com/wake', coalesceWindow: 0.05}});
+        CoalescingEngineService.enqueue(sub, buildEnvelope('wake/sent_to_me', {messageId: 'M1'}, 10));
+        CoalescingEngineService.enqueue(sub, buildEnvelope('wake/sent_to_me', {messageId: 'M2'}, 11));
+
+        await new Promise(resolve => setTimeout(resolve, 100));
+
+        expect(deliverCalls[0].eventData.payload.breakdown.sent_to_me.count).toBe(2);
+    });
+
+    test('configure REFUSES a non-function resolver rather than silently ignoring it', () => {
+        expect(() => CoalescingEngineService.configure({
+            coalesceWindowSeconds   : 30,
+            flushRefractorySeconds  : 120,
+            flushHardCapSeconds     : 300,
+            resolveDeliveryReadState: 'not-a-function'
+        })).toThrow(/resolveDeliveryReadState/);
+    });
+
 });

--- a/test/playwright/unit/ai/services/memory-core/CoalescingEngineService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/CoalescingEngineService.spec.mjs
@@ -542,6 +542,47 @@ test.describe('CoalescingEngineService', () => {
         expect(deliverCalls[0].eventData.payload.breakdown.sent_to_me.count).toBe(2);
     });
 
+    /**
+     * @summary AC-6 — a digest never names a `latest` the recipient cannot open.
+     *
+     * The consumer half of the two-shape repair. `missing` is a POSITIVE finding from the resolver
+     * (no MESSAGE row exists), deliberately distinct from `{}` (graph unavailable). The distinction
+     * carries the whole behaviour: the event still COUNTS, because something really was queued and
+     * hiding it is the suppression failure mode this feature exists to avoid — but it must not
+     * become the pointer, because a `latest` is an invitation to open something, and naming an
+     * absent row sends the recipient hunting for a message that is not there.
+     *
+     * Injecting the resolver is correct HERE and only here: this arm is about what the coalescer
+     * does with an answer. That the real resolver produces that answer against real graph rows is
+     * proven separately in `MailboxService.spec.mjs`, because a hand-injected fixture is
+     * structurally incapable of falsifying the producer — which is exactly how the broadcast-only
+     * reader survived review the first time.
+     */
+    test('AC-6 — a MISSING message counts but can never be named latest', async () => {
+        CoalescingEngineService.configure({
+            coalesceWindowSeconds : 30,
+            flushRefractorySeconds: 120,
+            flushHardCapSeconds   : 300
+        }, {
+            resolveDeliveryReadState: messageId => messageId === 'M-GONE' ? {missing: true} : {present: true}
+        });
+
+        const sub = buildSubscription({harnessTargetMetadata: {url: 'https://example.com/wake', coalesceWindow: 0.05}});
+
+        // M-GONE is the NEWEST, so recency alone would elect it — the disqualification has to be
+        // what keeps it out, not ordering luck.
+        CoalescingEngineService.enqueue(sub, buildEnvelope('wake/sent_to_me', {messageId: 'M-REAL', subject: 'openable'}, 10));
+        CoalescingEngineService.enqueue(sub, buildEnvelope('wake/sent_to_me', {messageId: 'M-GONE', subject: 'row deleted'}, 11));
+
+        await new Promise(resolve => setTimeout(resolve, 100));
+
+        const digest = deliverCalls[0].eventData;
+
+        expect(digest.payload.breakdown.sent_to_me.count, 'a queued event still counts').toBe(2);
+        expect(digest.payload.breakdown.sent_to_me.latest.messageId,
+            'latest must fall back to the openable message').toBe('M-REAL')
+    });
+
     test('FAIL-SAFE — a resolver that THROWS renders the event rather than dropping it', async () => {
         CoalescingEngineService.configure({
             coalesceWindowSeconds : 30,

--- a/test/playwright/unit/ai/services/memory-core/CoalescingEngineService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/CoalescingEngineService.spec.mjs
@@ -11,9 +11,15 @@ setup({
     }
 });
 
-import {test, expect} from '@playwright/test';
-import Neo            from '../../../../../../src/Neo.mjs';
-import * as core      from '../../../../../../src/core/_export.mjs';
+import {test, expect}  from '@playwright/test';
+import Neo             from '../../../../../../src/Neo.mjs';
+import * as core       from '../../../../../../src/core/_export.mjs';
+import StateProvider   from '../../../../../../src/state/Provider.mjs';
+import fs              from 'fs-extra';
+import path            from 'path';
+import {fileURLToPath} from 'url';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../../../../../');
 
 let CoalescingEngineService;
 let WebhookDeliveryService;
@@ -498,9 +504,10 @@ test.describe('CoalescingEngineService', () => {
 
     test('an already-read message is excluded from the count and cannot be named latest', async () => {
         CoalescingEngineService.configure({
-            coalesceWindowSeconds   : 30,
-            flushRefractorySeconds  : 120,
-            flushHardCapSeconds     : 300,
+            coalesceWindowSeconds : 30,
+            flushRefractorySeconds: 120,
+            flushHardCapSeconds   : 300
+        }, {
             resolveDeliveryReadState: messageId => messageId === 'M-READ' ? {readAt: '2026-08-10T10:00:00.000Z'} : {}
         });
 
@@ -519,9 +526,10 @@ test.describe('CoalescingEngineService', () => {
     test('NON-VACUITY — the same two events both count when neither is read', async () => {
         // Without this arm the assertion above passes against a resolver that suppresses everything.
         CoalescingEngineService.configure({
-            coalesceWindowSeconds   : 30,
-            flushRefractorySeconds  : 120,
-            flushHardCapSeconds     : 300,
+            coalesceWindowSeconds : 30,
+            flushRefractorySeconds: 120,
+            flushHardCapSeconds   : 300
+        }, {
             resolveDeliveryReadState: () => ({})
         });
 
@@ -536,9 +544,10 @@ test.describe('CoalescingEngineService', () => {
 
     test('FAIL-SAFE — a resolver that THROWS renders the event rather than dropping it', async () => {
         CoalescingEngineService.configure({
-            coalesceWindowSeconds   : 30,
-            flushRefractorySeconds  : 120,
-            flushHardCapSeconds     : 300,
+            coalesceWindowSeconds : 30,
+            flushRefractorySeconds: 120,
+            flushHardCapSeconds   : 300
+        }, {
             resolveDeliveryReadState: () => { throw new Error('graph unavailable') }
         });
 
@@ -569,11 +578,75 @@ test.describe('CoalescingEngineService', () => {
 
     test('configure REFUSES a non-function resolver rather than silently ignoring it', () => {
         expect(() => CoalescingEngineService.configure({
-            coalesceWindowSeconds   : 30,
-            flushRefractorySeconds  : 120,
-            flushHardCapSeconds     : 300,
+            coalesceWindowSeconds : 30,
+            flushRefractorySeconds: 120,
+            flushHardCapSeconds   : 300
+        }, {
             resolveDeliveryReadState: 'not-a-function'
         })).toThrow(/resolveDeliveryReadState/);
+    });
+
+    /**
+     * @summary `configure` must accept the wake-dispatch config as a LIVE AiConfig node.
+     *
+     * **The production failure this exists to prevent, measured.** The first version of this feature
+     * added `resolveDeliveryReadState` as one more key on the config bag, which forced the Memory Core
+     * entrypoint to call `configure({...wakeDispatch, resolveDeliveryReadState})`. Every arm above
+     * stayed green because they all hand `configure` a plain object literal — and a plain object
+     * spreads perfectly. Production does not pass a plain object. It passes an `AiConfig` node, whose
+     * `get` trap resolves override-else-inherit up the parent chain while its `ownKeys` trap
+     * (`Provider#getTopLevelDataKeys`) enumerates **local `#dataConfigs` only**. The wake-dispatch
+     * leaves are declared on the Tier-1 root, so the spread produced `{}` — measured, not inferred —
+     * and mc-server died at boot on a validation error naming a leaf that was plainly set. Thirty-plus
+     * integration specs then failed with `ECONNREFUSED`, every one of them downstream of that.
+     *
+     * **Why a real two-Provider hierarchy and not a mock.** A hand-rolled proxy asserting
+     * "ownKeys returns []" would test my model of the trap rather than the trap. This builds the
+     * actual primitive — a parent holding the data, a child resolving through it — so the arm fails if
+     * `Provider`'s enumeration semantics ever diverge from what this repair assumes. The one
+     * substitution against production is the leaf VALUES (30/120/300 rather than the shipped
+     * 150/120/300); the parent/child resolution path, the proxy, and both traps are the real ones.
+     */
+    test('REGRESSION — configure accepts a live AiConfig node whose leaves are INHERITED, not local', () => {
+        const
+            parent = Neo.create(StateProvider, {
+                data: {wakeDispatch: {coalesceWindowSeconds: 30, flushRefractorySeconds: 120, flushHardCapSeconds: 300}}
+            }),
+            child  = Neo.create(StateProvider, {data: {unrelatedLocalLeaf: 1}});
+
+        child.getParent = () => parent;
+
+        const node = child.data.wakeDispatch;
+
+        // The trap itself, pinned first: this is WHY the spread failed, and if these two ever stop
+        // disagreeing the regression below would pass for the wrong reason.
+        expect(node.coalesceWindowSeconds, 'the named read must resolve up the parent chain').toBe(30);
+        expect(Object.keys(node), 'enumeration must NOT see inherited leaves — the trap under test').toEqual([]);
+        expect({...node}, 'spreading this node is measurably lossy').toEqual({});
+
+        // The repair: configure must survive the node itself, by reference.
+        expect(() => CoalescingEngineService.configure(node, {resolveDeliveryReadState: null})).not.toThrow();
+        expect(CoalescingEngineService.defaultWindowSeconds).toBe(30);
+        expect(CoalescingEngineService.refractoryMs).toBe(120000);
+        expect(CoalescingEngineService.hardCapMs).toBe(300000);
+
+        parent.destroy?.();
+        child.destroy?.()
+    });
+
+    test('REGRESSION — the Memory Core entrypoint hands the node over without materializing it', () => {
+        // The behavioural arm above proves `configure` CAN take a live node; it cannot prove the
+        // entrypoint actually does. This is the call site that broke, asserted directly — a future
+        // edit reintroducing the spread fails here even if it never runs a container.
+        const serverSource = fs.readFileSync(
+            path.join(repoRoot, 'ai/mcp/server/memory-core/Server.mjs'), 'utf8')
+            .replace(/\/\*[\s\S]*?\*\//g, '')
+            .replace(/^\s*\/\/.*$/gm, '');
+
+        expect(serverSource, 'never spread an AiConfig node — `ownKeys` drops inherited leaves')
+            .not.toMatch(/configure\(\s*\{\s*\.\.\.\s*wakeDispatch/);
+        expect(serverSource, 'the node must still reach configure by reference')
+            .toMatch(/CoalescingEngineService\.configure\(\s*wakeDispatch\s*,/)
     });
 
 });

--- a/test/playwright/unit/ai/services/memory-core/MailboxService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/MailboxService.spec.mjs
@@ -26,6 +26,7 @@ test.describe.configure({ mode: 'serial' });
 
 test.describe('Neo.ai.services.memory-core.MailboxService', () => {
     let MailboxService, GraphService, PermissionService, LifecycleService, SwarmHeartbeatService, buildMailboxDelta, callMemoryCoreTool, originalAutoSave, mailboxAiConfig, originalMailboxPolicy, readWalMessages, readPendingMessageWalRecords;
+    let readBackgroundDeliveryState;
     let messageWalDir, getWakeDeliverySeries;
 
     test.beforeAll(async () => {
@@ -36,6 +37,7 @@ test.describe('Neo.ai.services.memory-core.MailboxService', () => {
         GraphService = (await import('../../../../../../ai/services/memory-core/GraphService.mjs')).default;
         MailboxService = (await import('../../../../../../ai/services/memory-core/MailboxService.mjs')).default;
         getWakeDeliverySeries = (await import('../../../../../../ai/services/memory-core/MailboxService.mjs')).getWakeDeliverySeries;
+        readBackgroundDeliveryState = (await import('../../../../../../ai/services/memory-core/MailboxService.mjs')).readBackgroundDeliveryState;
         PermissionService = (await import('../../../../../../ai/services/memory-core/PermissionService.mjs')).default;
         LifecycleService = (await import('../../../../../../ai/services/memory-core/lifecycle/SystemLifecycleService.mjs')).default;
         SwarmHeartbeatService = (await import('../../../../../../ai/daemons/orchestrator/services/SwarmHeartbeatService.mjs')).default;
@@ -423,6 +425,67 @@ test.describe('Neo.ai.services.memory-core.MailboxService', () => {
         expect(outputs[1].mailboxReadState).toEqual(outputs[0].mailboxReadState);
         await expect(MailboxService.inspectReadState({messageId, recipient: '@bob'}))
             .rejects.toThrow(/no agent identity context bound/);
+    });
+
+    /**
+     * @summary The background wake resolver, driven against REAL graph rows — both storage shapes.
+     *
+     * **Why these arms exist.** The coalescer's own spec hand-injects `{readAt}`, which exercises the
+     * consumer branch and is structurally incapable of falsifying the PRODUCER. Under that fixture a
+     * resolver reading only broadcast `DELIVERED_TO` edges looked correct, while every READ DIRECT DM
+     * came back `{}`, scored "unknown", and kept counting. @neo-gpt found it by tracing the reader
+     * into the storage model instead of trusting its summary.
+     *
+     * The mailbox has two shapes and one rule: a per-recipient `DELIVERED_TO` edge carries broadcast
+     * read-state, the MESSAGE node carries direct read-state. `seedReadStateCarrier` builds exactly
+     * that, so these arms fail against a reader that knows only one half.
+     *
+     * The tri-state matters as much as the two shapes. `{}` meant BOTH "graph unavailable" and "row
+     * absent", and collapsing them is what let a digest name a `latest` the recipient cannot open.
+     */
+    test('#16918: the background resolver reads DIRECT read-state off the MESSAGE node, not just the edge', () => {
+        const messageId = 'MESSAGE:bg-direct-read';
+
+        // Direct DM: readAt lives on the node and there is NO DELIVERED_TO edge at all.
+        seedReadStateCarrier({messageId, recipient: '@bob', broadcast: false, readAt: '2026-08-10T10:00:00.000Z'});
+
+        const state = readBackgroundDeliveryState(messageId, '@bob');
+
+        expect(state.readAt, 'a read direct DM must report its committed readAt').toBe('2026-08-10T10:00:00.000Z');
+        expect(state.present, 'and it must report the row as present').toBe(true);
+        expect(state.missing).toBeUndefined()
+    });
+
+    test('#16918: NON-VACUITY — an UNREAD direct DM is present-without-readAt, not read', () => {
+        // Without this the arm above passes against a resolver that reports every direct row as read.
+        const messageId = 'MESSAGE:bg-direct-unread';
+
+        seedReadStateCarrier({messageId, recipient: '@bob', broadcast: false, readAt: null});
+
+        const state = readBackgroundDeliveryState(messageId, '@bob');
+
+        expect(state.readAt, 'an unread row must not fabricate a readAt').toBeUndefined();
+        expect(state.present, 'but it exists and is openable').toBe(true);
+        expect(state.missing).toBeUndefined()
+    });
+
+    test('#16918: broadcast read-state still resolves off the per-recipient DELIVERED_TO edge', () => {
+        // The half that already worked, pinned so the direct-shape repair cannot regress it.
+        const messageId = 'MESSAGE:bg-broadcast-read';
+
+        seedReadStateCarrier({messageId, recipient: '@bob', broadcast: true, readAt: '2026-08-10T11:00:00.000Z'});
+
+        expect(readBackgroundDeliveryState(messageId, '@bob').readAt).toBe('2026-08-10T11:00:00.000Z')
+    });
+
+    test('#16918: an ABSENT message row reports `missing`, which is not the same answer as unread', () => {
+        // AC-6. Nothing is seeded — the row genuinely does not exist. Reporting `{}` here is what let
+        // the digest advertise a `latest` pointing at a message the recipient could never open.
+        const state = readBackgroundDeliveryState('MESSAGE:bg-never-existed', '@bob');
+
+        expect(state.missing, 'an absent row must be positively reported as missing').toBe(true);
+        expect(state.present).toBeUndefined();
+        expect(state.readAt).toBeUndefined()
     });
 
     test('addMessage stamps the normalized canonical user_id, keeping @-form only as the sender label (#13578)', async () => {


### PR DESCRIPTION
Resolves neomjs/neo#16541

The wake digest counted **queued events** and labelled them `N new messages`, and neither renderer consulted read-state — zero references to `readAt` / `unread` / `markRead` in either seam. So a message delivered, read and acted on hours ago still contributed to the count and could be named `latest`.

This PR does both halves: the label says what it measures, **and** the number is reconciled against the recipient's read-state across BOTH mailbox storage shapes — direct `readAt` on the MESSAGE node, broadcast `readAt` on the per-recipient `DELIVERED_TO` edge.

Evidence: L4 (four seams traced at source, seven behavioural arms driving the real `enqueue` → `_flush` → `_buildDigestEnvelope` path, six mutations executed) → L4 required (every AC below is reachable in-suite). Residual: AC-7 and AC-8 — see *Deltas*.

## The defect this PR introduced, and what it taught

The first two pushes wired the new collaborator by adding one key to the config bag, which forced the entrypoint to call `configure({...wakeDispatch, resolveDeliveryReadState})`. That did not thread an extra key. **It replaced the entire config with `{}`**, and `mc-server` died at boot on `requires non-negative finite 'coalesceWindowSeconds'` — naming a leaf that is plainly set. Thirty-plus integration specs then failed with `ECONNREFUSED 127.0.0.1:13001` and `service "mc-server" is not running`, every one of them downstream of that single line.

Measured against the live config, not reasoned about:

```
wakeDispatch.coalesceWindowSeconds  ->  150
Object.keys(wakeDispatch)           ->  []
{...wakeDispatch}                   ->  {}
```

An `AiConfig` node is a `Neo.state.Provider` proxy. Its `get` trap resolves override-else-inherit up the parent chain (`Provider#getOwnerOfDataProperty`), but its `ownKeys` trap (`Provider#getTopLevelDataKeys`, `src/state/Provider.mjs:676`) enumerates the **local `#dataConfigs` only**. The wake-dispatch leaves are declared on the Tier-1 root (`ai/configBase.mjs:1542`), so for the Memory Core child provider every named read is correct and every enumeration is empty.

**Spread and rest are `ownKeys`; named destructuring is `get`.** That asymmetry is why `dev` — which destructures — was healthy, why every unit arm stayed green, and why the failure could only surface in a container. The spread does not warn, throw, or degrade; it silently substitutes an empty object.

The repair is not "spread more carefully". `resolveDeliveryReadState` is **wiring, not configuration**, and bagging it into the config object is what forced the materialization. It now takes its own parameter, so the SSOT node is handed over by reference exactly as the adjacent `WebhookDeliveryService.configure(wakeDispatch)` call already does. ADR-0019's rule — *read resolved leaves at the use site, never materialize the SSOT* — has a sharper edge here than the catalog currently records: materializing an `AiConfig` node is not a style violation, it is **lossy by construction**.

## Cycle 2 — the resolver answered for ONE of the mailbox's two storage shapes

@neo-gpt requested changes, correctly. The first version of `readBackgroundDeliveryState` delegated straight to `getStorageDeliveryMutableState`, which reads per-recipient `DELIVERED_TO` edges — the **broadcast** shape only. Direct messages keep `readAt` on the MESSAGE node (`MailboxService.mjs:1698`), so every read direct DM returned `{}`, scored UNKNOWN, and kept counting. The injection shape was right; the collaborator answered half its domain.

The normalization now mirrors `getReadAtForMessage(messageNode, deliveryEdge)` — the canonical two-shape reader the permissioned path already uses. One rule extended, not a parallel second one.

**Three outcomes, not two.** `{}` meant both "graph unavailable" and "row absent", and collapsing them is exactly what let a digest name a `latest` whose message no longer exists:

| result | meaning | digest behaviour |
|---|---|---|
| `{readAt}` | committed read | suppress |
| `{present: true}` | exists, unread | render |
| `{missing: true}` | no MESSAGE row | **counts, never named `latest`** — AC-6 |
| `{}` | graph unavailable | UNKNOWN — render exactly as before |

`missing` is a positive finding, reached only after establishing the row is absent. It still counts — something really was queued, and hiding that is the suppression failure mode this whole feature exists to avoid — but it is disqualified from the pointer, because a `latest` invites the recipient to open something.

**Why my own mutation testing missed this, which is the part worth keeping.** Every coalescer arm hand-injects `{readAt}`, so all of them exercise the *consumer* branch and none can falsify the *producer*. Under that fixture a broadcast-only reader looks correct. This is the **second** instance of the same shape in this PR — the first was a plain object standing in for an AiConfig Provider proxy. Not insufficient coverage: **insufficient fidelity**, where no number of extra arms on the same fixture would have found it.

So the producer arms moved to `MailboxService.spec.mjs`, where `seedReadStateCarrier` builds real graph rows in both shapes — node-carried `readAt` with no edge for direct, edge-carried for broadcast, nothing at all for missing. Injection is retained only for the consumer arm and the resolver-throws fail-safe arm.

| cycle-2 mutation | red arm |
|---|---|
| resolver reverted to broadcast-only | the direct-DM read arm |
| `latest` disqualification removed | the AC-6 arm |

Plus non-vacuity: an **unread** direct DM must report present-without-`readAt`, so the read-direct arm cannot pass against a reader that calls everything read.

## Deltas from ticket

**AC-7 and AC-8 rest on retracted evidence and are not silently ticked.** AC-7 cites *"the three Instance-3 hypotheses"* and AC-8 *"the read-state rollback"* — both from instances withdrawn on the ticket: @neo-opus-ada's was a `limit`-truncated query against a 669-deep backlog, and mine compared announced counts against an unread population I never measured. Ticking ACs built on falsified evidence would be the shortcut this ticket is about. They need re-deriving from the surviving source-level defect or striking, and that is a decision on the ticket rather than something a PR should quietly resolve.

**A property the ACs do not state, added deliberately: FAIL-SAFE, never fail-closed.** No resolver, no `messageId`, a resolver that throws, or a resolver returning `{}` all mean **unknown**, and unknown renders exactly as before. Only a committed `readAt` suppresses. This is the whole swarm's wake path — suppressing on uncertainty converts a mislabelled count into a **missing wake**, and a wrong number is visible in the wake while a missing wake is visible to nobody. Two of the arms exist only to pin this.

**`inspectReadState` is a trap and the PR takes the other road.** It looks like the resolver but resolves a bound identity through `RequestContextService` and enforces `CAN_READ_INBOX_OF`; the digest is built in a background flush with neither, so it would throw `unboundIdentityError` on every wake. The new `readBackgroundDeliveryState` export documents why an unpermissioned reader is acceptable at exactly this seam: the coalescer reads the read-state of the same recipient whose entire unread set it is about to render, disclosing nothing that recipient's own wake would not already contain.

## Test Evidence

`ai/services/memory-core/**` + `ai/daemons/wake/**` — **488 passed** across `MailboxService.spec.mjs` + `CoalescingEngineService.spec.mjs` + `ai/daemons/wake/` via `npm run test-unit`.

**Mutation conviction — six, each caught by exactly one arm:**

| mutation | result |
|---|---|
| revert one renderer's label only | 3 failed, incl. `BOTH seams moved together` (AC-3) |
| make reconciliation **fail-closed** (suppress on unknown) | fails the `FAIL-SAFE — resolver THROWS` arm |
| remove the reconciliation | fails `an already-read message is excluded…` |
| pass a non-function resolver | `configure` refuses rather than ignoring |
| **reintroduce `configure({...wakeDispatch, …})` at the entrypoint** | fails the source arm only |
| **materialize the node INSIDE `configure`** | fails the behavioural arm only |

The last two are complementary on purpose. The behavioural arm builds a **real two-Provider hierarchy** — not a mock of one — so it fails if `Provider`'s enumeration semantics ever diverge from what this repair assumes, and it pins the `get`/`ownKeys` disagreement before relying on it. But it can only prove `configure` *can* take a live node, never that the call site *does*; the source arm asserts the entrypoint hands it over unmaterialized, so a future edit reintroducing the spread fails without anyone running a container.

Plus a **non-vacuity** arm: the same two events both count when neither is read, so the exclusion assertion cannot pass against a resolver that suppresses everything.

## Post-Merge Validation

- [ ] A wake digest observed in the wild reads `N message events` and the count matches the recipient's unread set.
- [ ] `mc-server` boots in the deployed plane with the wake-dispatch leaves resolved (the integration suite covers this in CI; the check is that the deployed plane agrees).

## Evolution

**Two separate CI failures on this PR, and each hid behind a green-looking number.**

*First:* I ran bare `npx playwright test <path>`, which loads the **default** config rather than `playwright.config.unit.mjs` — the repo's own guidance says not to. The symptom was a persistent `N did not run` line I read past three times while treating `N passed` as green. The correct runner surfaced 18 assertions pinning the old label across five files.

*Second, and the more useful lesson:* every unit arm in this file hands `configure` a **plain object literal**, and a plain object spreads perfectly. Production hands it a Provider proxy. The suite could not see the defect because the fixture did not have production's shape — the failure was not insufficient coverage but **insufficient fidelity**, and no amount of additional arms built on the same fixture would have caught it. That is what the real-`Provider` regression arm is for.

The local full suite shows a handful of failures that vary run-to-run. Control: with this branch's changes fully stashed, the same command on the clean tree produces a **different and larger** failing set (7 failed / 18 did not run, vs 5 / 2 here), overlapping only on the known order-dependent specs. Pre-existing worker-storage pollution — neomjs/neo-agent-brain#46's subject — not this change.

Authored by @neo-opus-grace (Opus 5) · origin session `3c27118d-2de2-4579-bb42-1062c34cb895`
