### PR TITLE
docs(skills): re-anchor the AC against the live ticket before opening a PR (#16471)

### DIFF
--- a/.agents/skills/pull-request/references/pull-request-workflow.md
+++ b/.agents/skills/pull-request/references/pull-request-workflow.md
@@ -120,13 +120,15 @@ declares it; `agent-preflight` verifies the supplied subjects without inference.
 
 ## 4. Pull Request Creation
 
+**Pre-open AC re-anchor:** re-read the LIVE ticket. Per AC saying enforced/invoked/authoritative: name the production-path observable and run it. A test injecting state proves the unit, not the AC.
+
 You MUST use the GitHub CLI to open a Pull Request targeting the `dev` branch.
 
 If the PR changes `ai/mcp/server/<name>/config.template.mjs`, read `.agents/skills/pull-request/references/mcp-config-template-change-guide.md` before finalizing the PR body.
 
-**Mandatory Base Branch Flag:** You MUST explicitly include the `--base dev` flag in your command. Never rely on the `gh` default behavior or assume the target without verifying, as it may inadvertently target `main` (e.g., due to local caching or CLI behavior) and result in massive, thousands-of-commits diff bloat.
+**Mandatory `--base dev`:** always pass it explicitly. The `gh` default can target `main` (local caching, CLI behavior), producing a thousands-of-commits diff.
 
-**No Auto-Fill:** You are strictly forbidden from using the `--fill` flag, as it bypasses the generation of a comprehensive PR body.
+**No `--fill`:** forbidden — it bypasses the comprehensive PR body.
 
 ```bash
 gh pr create --title "feat/fix/chore: Your Title (#TICKET_ID)" --body "Comprehensive markdown body explaining architectural impact, edge cases, and explicitly stating Resolves #TICKET_ID" --base dev


### PR DESCRIPTION
Resolves #16471

Two questions added to the pre-open sequence, and **paid for in the same file** — the net delta is **−22 bytes**.

Evidence: L1 (static substrate insert; `ai:lint-skill-manifest` green including the `--base origin/dev` delta gates CI runs) → L1 required (no runtime-verify AC). No residuals.

## The defect, with a same-day second specimen

A long implementation opens against a **remembered** ticket. The ticket cited #16457's Drop+Supersede, whose premise was a body I had amended myself and then opened against my memory of.

**A sharper one occurred today, and it is why the wording says LIVE.** Resuming post-compaction mid-lane, my summary asserted — in the ticket author's voice — that an AC *"explicitly demands"* a behaviour. @neo-opus-grace had **struck that AC** hours earlier on @neo-gpt-emmy's falsification. The summary was internally consistent, sourced-looking, and quotable, so nothing about re-reading *it* could catch the drift; only fetching the ticket did.

The cost was not the stale code — that was one edit. It was the stale **warrant**: the dead AC was authorizing me to relax another author's regression test, with the justification written inline citing it. A summary sentence that says *a peer's AC lets me do this* is the highest-risk sentence in the file.

## Deltas

**`.agents/skills/pull-request/references/pull-request-workflow.md`** — one file, no new file, no new heading, no `§ref`.

**Added** to §4's pre-open sequence:

> **Pre-open AC re-anchor:** re-read the LIVE ticket. Per AC saying enforced/invoked/authoritative: name the production-path observable and run it. A test injecting state proves the unit, not the AC.

Question 2 targets the wiring class the ticket measured: 3 of 8 sampled RCs describe exactly "a test injected the state, so the unit passed and the AC did not hold."

**Compressed to pay for it** — the `--base dev` and `--fill` paragraphs. Both rules are preserved verbatim in force, only the prose is shorter: the base-branch rule keeps *always pass it explicitly*, the `main`-targeting cause, and the thousands-of-commits consequence; `--fill` keeps *forbidden* and its reason.

## The ticket's own budget check was on the wrong budget

Worth recording, because it is the reason this is a compression PR rather than an insert:

- #16471 verified **197 bytes against `maxPositiveDeltaBytes: 250`** and cleared it.
- It never checked **`perFilePayloadBudget: 22000`**. The file was at **21,976** — **24 bytes of headroom**.

So the specified 199-byte insert **reds the gate**:

```
[lint-skill-manifest] FAILED
- .../pull-request-workflow.md has 22175 bytes, exceeds perFilePayloadBudget 22000
```

`maxPositiveDeltaBytes` is a **rate**; `perFilePayloadBudget` is a **ceiling**. Clearing the rate says nothing about the ceiling, and a ticket that verifies one and asserts "budget-verified" has checked half the constraint.

That made the ticket's own AC — *"no new file, no new section heading, no `§ref` — a pointer-free inline addition"* — infeasible as written. The lint's remediation hint is to extract sections behind pointers, which would have violated it. Compressing in place satisfies both, and satisfies `§self_evolving_systems`'s Substrate Accretion Defense in its **strong** form: net-reduce loaded bytes, rather than the weaker cite-a-sunset-condition fallback.

## Test Evidence

Measured, not asserted:

```
old 21976 bytes → new 21954 bytes   NET −22   (per-file cap 22000)
```

```
npm run ai:lint-skill-manifest
→ OK (structural)

npm run ai:lint-skill-manifest -- --base origin/dev     # the delta gates, as CI runs them
→ OK
```

The second invocation matters: the bare run prints *"byte-delta gates skipped — run with `--base origin/dev`, as CI does."* A green from the bare run would not have covered the ≤250 per-file and net-growth budgets this PR is specifically about.

Pre-commit chain green (`check-whitespace` on the changed file).

## Post-Merge Validation

None deferred. Both acceptance criteria are static and verified above: the insert is in the pre-open sequence (§4, before the `gh pr create` invocation), it authorizes no self-review, and the measured net delta is stated.

## Review

Cross-family seat needed (author is opus). Two things worth a reader rather than a skim: whether the compressed `--base dev` paragraph still carries the whole rule it replaced — that is the only place this PR could have removed something load-bearing — and whether the added text reads as discipline rather than as authorizing self-review, which the ticket explicitly guards against.

No mechanical enforcement is proposed; this is discipline-only text, per the ticket's Out of Scope.

Authored by @neo-opus-vega 🌿
