### PR TITLE
One owned write-temp-then-rename primitive

### DIFF
--- a/.github/workflows/atomic-write-shape-lint.yml
+++ b/.github/workflows/atomic-write-shape-lint.yml
@@ -1,0 +1,48 @@
+name: Atomic Write Shape Lint
+
+# CI mirror of the `.husky/pre-commit` guard, so `git commit --no-verify` cannot bypass it.
+
+on:
+  pull_request:
+    branches: [dev]
+    paths:
+      - 'ai/**/*.mjs'
+      - 'buildScripts/util/check-atomic-write-shape.mjs'
+      - 'buildScripts/util/check-aiconfig-test-mutation.mjs'
+      - '.github/workflows/atomic-write-shape-lint.yml'
+  push:
+    branches: [dev]
+    paths:
+      - 'ai/**/*.mjs'
+      - 'buildScripts/util/check-atomic-write-shape.mjs'
+      - 'buildScripts/util/check-aiconfig-test-mutation.mjs'
+      - '.github/workflows/atomic-write-shape-lint.yml'
+
+concurrency:
+  group: atomic-write-shape-lint-${{ github.run_attempt == '1' && github.ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+          cache: 'npm'
+
+      # This guard imports the shared acorn-backed `codeMask` from the AiConfig test-mutation guard —
+      # hence that file in the path filters above, and hence the install. The mask is why a
+      # write-then-rename pair quoted inside GENERATED plugin source is not a hit: one module in this
+      # repo emits exactly this pair as a string, and a maskless scan would flag the generator for the
+      # code it writes rather than the code it runs.
+      # --ignore-scripts skips the heavy prepare lifecycle (Husky + generated local configs).
+      - name: Install dependencies (acorn — the shared codeMask tokenizer)
+        run: npm ci --ignore-scripts
+
+      - name: Ban hand-rolled write-temp-then-rename pairs
+        run: node ./buildScripts/util/check-atomic-write-shape.mjs

--- a/.github/workflows/atomic-write-shape-lint.yml
+++ b/.github/workflows/atomic-write-shape-lint.yml
@@ -8,14 +8,12 @@ on:
     paths:
       - 'ai/**/*.mjs'
       - 'buildScripts/util/check-atomic-write-shape.mjs'
-      - 'buildScripts/util/check-aiconfig-test-mutation.mjs'
       - '.github/workflows/atomic-write-shape-lint.yml'
   push:
     branches: [dev]
     paths:
       - 'ai/**/*.mjs'
       - 'buildScripts/util/check-atomic-write-shape.mjs'
-      - 'buildScripts/util/check-aiconfig-test-mutation.mjs'
       - '.github/workflows/atomic-write-shape-lint.yml'
 
 concurrency:
@@ -35,11 +33,9 @@ jobs:
           node-version: '24'
           cache: 'npm'
 
-      # This guard imports the shared acorn-backed `codeMask` from the AiConfig test-mutation guard —
-      # hence that file in the path filters above, and hence the install. The mask is why a
-      # write-then-rename pair quoted inside GENERATED plugin source is not a hit: one module in this
-      # repo emits exactly this pair as a string, and a maskless scan would flag the generator for the
-      # code it writes rather than the code it runs.
+      # The guard parses with acorn rather than scanning lines: a call whose arguments wrap across
+      # lines is ordinary formatting, not a bypass, and a pair that exists only inside emitted plugin
+      # source is a string literal in the AST rather than a call. Hence the install.
       # --ignore-scripts skips the heavy prepare lifecycle (Husky + generated local configs).
       - name: Install dependencies (acorn — the shared codeMask tokenizer)
         run: npm ci --ignore-scripts

--- a/ai/daemons/orchestrator/services/DeploymentStateBridgeService.mjs
+++ b/ai/daemons/orchestrator/services/DeploymentStateBridgeService.mjs
@@ -5,6 +5,7 @@ import Base                                 from '../../../../src/core/Base.mjs'
 import AiConfig                             from '../../../config.mjs';
 import {probeProviderParallelModelCapacity} from '../../../services/graph/providerReadinessHelper.mjs';
 import {runHealthcheck}                     from '../../../scripts/diagnostics/mcpHealthcheck.mjs';
+import {writeFileAtomicSync}                from '../../../services/shared/atomicFileWrite.mjs';
 
 /**
  * The message `runHealthcheck` produces when the server ANSWERED and reported a status outside the
@@ -634,12 +635,12 @@ export class DeploymentStateBridgeService extends Base {
                 inspect,
                 stats,
                 statsSamples,
-                runtimeContainerId: sampleContainerId,
+                runtimeContainerId       : sampleContainerId,
                 endpointProbe,
                 providerResidency,
                 providerActivity,
                 providerResidencyEligible: this.isProviderResidencyServiceKey(serviceKey),
-                churnBaseline     : churnBaseline?.unreadable ? undefined : churnBaseline,
+                churnBaseline            : churnBaseline?.unreadable ? undefined : churnBaseline,
                 plannedRestarts,
                 // `null` when `includeLogs` is off — which must surface as an UNAVAILABLE
                 // attribution, never as "not a heap death". A disabled channel is not evidence.
@@ -1059,21 +1060,19 @@ export class DeploymentStateBridgeService extends Base {
      * @returns {void}
      */
     writeChurnBaseline(serviceKey, baseline) {
-        const target  = this.churnBaselinePath(serviceKey),
-              staging = `${target}.${process.pid}.tmp`;
-
         try {
             // Write-then-rename: a direct write torn by a crash leaves a half-written baseline, which
             // the reader above must then treat as unjudgeable — turning a crash into a silently
             // reset counter. `rename` within a directory is atomic, so a reader sees the old
-            // baseline or the new one, never a fragment.
-            fs.outputJsonSync(staging, baseline);
-            fs.renameSync(staging, target)
+            // baseline or the new one, never a fragment. The former `${target}.${pid}.tmp` scratch was
+            // unique per process, but baselines are written per service key inside one.
+            writeFileAtomicSync(this.churnBaselinePath(serviceKey), JSON.stringify(baseline, null, 2) + '\n')
         } catch (error) {
             // ERROR, not WARN: a baseline that stops advancing means churn stops accumulating, and
             // the signal dies without the record ever going unhealthy.
             this.writeLog?.('ERROR', `[DeploymentStateBridge] churn baseline write FAILED for ${serviceKey}: ${error.message}. Churn detection is degraded until this succeeds.`);
-            fs.removeSync(staging)
+            // The scratch cleanup that used to live here is the primitive's `finally`, which runs on
+            // the failure path — there is no leaked sibling left for this block to remove.
         }
     }
 

--- a/ai/daemons/orchestrator/services/TenantRepoSyncService.mjs
+++ b/ai/daemons/orchestrator/services/TenantRepoSyncService.mjs
@@ -13,6 +13,7 @@ import {
     describeCorpusOutstanding
 }                                from '../../../services/knowledge-base/helpers/corpusOutstanding.mjs';
 import {createBoundedRetryGate}   from '../../../services/shared/boundedRetryGate.mjs';
+import {writeFileAtomic}          from '../../../services/shared/atomicFileWrite.mjs';
 import {buildEmbeddingProbeBlock} from '../../../services/shared/embeddingProbe.mjs';
 // The filter below and the codes it admits are one contract. Importing the pattern from the module
 // that PRODUCES bounded codes keeps a re-declared copy from drifting into a pair that separately
@@ -2716,19 +2717,17 @@ class TenantRepoSyncService extends Base {
             return true
         }
 
-        const tmpPath = `${filePath}.tmp-${process.pid}`;
-
         try {
-            await fsModule.ensureDir(path.dirname(filePath));
-            await fsModule.writeFile(tmpPath, JSON.stringify(attempts, null, 2) + '\n');
-            await fsModule.rename(tmpPath, filePath);
+            // Was `${filePath}.tmp-${pid}` — unique per process, but this sidecar is written per repo
+            // inside one sweep, so two repos raced the same scratch.
+            await writeFileAtomic(filePath, JSON.stringify(attempts, null, 2) + '\n', {fsModule});
             return true
         } catch (e) {
             // Best-effort by contract: a sidecar write failure must not fail a repo whose actual
             // sync is fine. The cost is exactly one unrecorded attempt — the same price the
             // write-behind behaviour paid on every crash — so failing the run here would be
-            // strictly worse than the defect this record exists to fix.
-            await fsModule.remove(tmpPath).catch(() => {});
+            // strictly worse than the defect this record exists to fix. Scratch cleanup is the
+            // primitive's `finally` now, so nothing is left here to remove.
             return false
         }
     }
@@ -2871,6 +2870,9 @@ class TenantRepoSyncService extends Base {
                 return {committed: false, reason: 'ownership-lost'}
             }
 
+            // DELIBERATELY NOT the shared write-temp-then-rename primitive: the ownership fence above
+            // must sit between the scratch write and this rename, exactly as the comment block says.
+            // The primitive collapses both into one call, leaving the fence nowhere to stand.
             await fsModule.rename(tmpPath, filePath);
 
             return {committed: true}

--- a/ai/daemons/orchestrator/services/TenantRepoSyncService.mjs
+++ b/ai/daemons/orchestrator/services/TenantRepoSyncService.mjs
@@ -2873,7 +2873,7 @@ class TenantRepoSyncService extends Base {
             // DELIBERATELY NOT the shared write-temp-then-rename primitive: the ownership fence above
             // must sit between the scratch write and this rename, exactly as the comment block says.
             // The primitive collapses both into one call, leaving the fence nowhere to stand.
-            await fsModule.rename(tmpPath, filePath);
+            await fsModule.rename(tmpPath, filePath); // atomic-write-ok: assertOwnership() must fence between write and rename
 
             return {committed: true}
         } catch (e) {

--- a/ai/daemons/orchestrator/services/bootIdentityFactStore.mjs
+++ b/ai/daemons/orchestrator/services/bootIdentityFactStore.mjs
@@ -1,6 +1,7 @@
-import {mkdir, readFile, rename, stat, unlink, writeFile} from 'fs/promises';
-import path                                               from 'path';
-import {BOOT_FRESHNESS_CLASS}                             from './bootIdentityFreshness.mjs';
+import {mkdir, readFile, stat} from 'fs/promises';
+import {writeFileAtomic}       from '../../../services/shared/atomicFileWrite.mjs';
+import path                    from 'path';
+import {BOOT_FRESHNESS_CLASS}  from './bootIdentityFreshness.mjs';
 
 /**
  * @module ai/daemons/orchestrator/services/bootIdentityFactStore
@@ -61,7 +62,6 @@ const
 
 // Per-process monotonic write counter — disambiguates two writes within the same millisecond so the
 // unique-temp name never collides even under a tight write loop in one process.
-let writeSeq = 0;
 
 export {BOOT_IDENTITY_FACT_VERSION, DEFAULT_MAX_FACT_AGE_MS, MAX_FACT_BYTES};
 
@@ -135,21 +135,12 @@ export async function writeBootIdentityFact(fact, {dir, nowFn = Date.now} = {}) 
 
     await mkdir(dir, {recursive: true});
 
-    const
-        filePath = getBootIdentityFactFilePath(dir),
-        // Unique per-write temp: pid + timestamp + monotonic seq → no two concurrent writers (overlapping
-        // polls / a restart racing a poll) ever share a temp path, so a rename never unlinks a temp another
-        // writer is mid-write to. Matches deploymentStateBridgeStore's atomic-snapshot precedent.
-        tmpPath  = `${filePath}.${process.pid}.${nowFn()}.${++writeSeq}.tmp`;
+    const filePath = getBootIdentityFactFilePath(dir);
 
-    try {
-        await writeFile(tmpPath, serialized, 'utf8');
-        await rename(tmpPath, filePath);
-    } catch (error) {
-        // Best-effort cleanup so a failed write never orphans its own temp; the original error still throws.
-        await unlink(tmpPath).catch(() => {});
-        throw error;
-    }
+    // The pid+timestamp+seq temp naming this used to build by hand — so no two concurrent writers
+    // (overlapping polls, a restart racing a poll) share a scratch — is the primitive's contract now,
+    // along with the cleanup that used to sit in the catch.
+    await writeFileAtomic(filePath, serialized);
 
     return filePath;
 }

--- a/ai/daemons/orchestrator/services/heavyMaintenanceLeasePrimitives.mjs
+++ b/ai/daemons/orchestrator/services/heavyMaintenanceLeasePrimitives.mjs
@@ -1,7 +1,8 @@
-import crypto from 'crypto';
-import fs     from 'fs-extra';
-import os     from 'node:os';
-import path   from 'path';
+import crypto                                 from 'crypto';
+import fs                                     from 'fs-extra';
+import os                                     from 'node:os';
+import path                                   from 'path';
+import {writeFileAtomic, writeFileAtomicSync} from '../../../services/shared/atomicFileWrite.mjs';
 import {
     enterLifecycleGuard,
     enterLifecycleGuardSync,
@@ -574,22 +575,10 @@ export function renewHeavyMaintenanceLeaseSync({
             expiresAt: new Date(nowMs + staleAfterMs).toISOString()
         };
 
-        const tmpPath = `${leasePath}.renew-tmp-${process.pid}`;
-        try {
-            fsModule.writeFileSync(tmpPath, JSON.stringify(renewed, null, 2), 'utf8');
-            const fd = fsModule.openSync(tmpPath, 'r+');
-            try {
-                fsModule.fsyncSync(fd);
-            } finally {
-                fsModule.closeSync(fd);
-            }
-            fsModule.renameSync(tmpPath, leasePath);
-        } catch (e) {
-            try {
-                fsModule.removeSync(tmpPath);
-            } catch (cleanupError) {}
-            throw e;
-        }
+        // `fsync: true` is load-bearing, not decoration: a lease that survives a crash as a stale
+        // renewal is how two holders end up believing they own the same lease. The scratch was
+        // `${leasePath}.renew-tmp-${pid}` — unique per process but not per renewal attempt.
+        writeFileAtomicSync(leasePath, JSON.stringify(renewed, null, 2), {fsModule, fsync: true});
 
         return {status: 'renewed', renewed: true, lease: renewed};
     } finally {
@@ -843,20 +832,9 @@ export async function renewHeavyMaintenanceLease({
             expiresAt: new Date(nowMs + staleAfterMs).toISOString()
         };
 
-        const tmpPath = `${leasePath}.renew-tmp-${process.pid}`;
-        try {
-            await fsModule.writeFile(tmpPath, JSON.stringify(renewed, null, 2), 'utf8');
-            const fd = await fsModule.open(tmpPath, 'r+');
-            try {
-                await fsModule.fsync(fd);
-            } finally {
-                await fsModule.close(fd);
-            }
-            await fsModule.rename(tmpPath, leasePath);
-        } catch (e) {
-            await fsModule.remove(tmpPath).catch(() => {});
-            throw e;
-        }
+        // Async twin of the sync renewal: same durability requirement, same reason. The injected
+        // fsModule here is fd-style (`open` -> fd, `fsync(fd)`), which the primitive's flush handles.
+        await writeFileAtomic(leasePath, JSON.stringify(renewed, null, 2), {fsModule, fsync: true});
 
         return {status: 'renewed', renewed: true, lease: renewed};
     } finally {

--- a/ai/daemons/shared/lifecycleGuard.mjs
+++ b/ai/daemons/shared/lifecycleGuard.mjs
@@ -81,6 +81,10 @@ export async function enterLifecycleGuard({leasePath, fsModule, guardStaleAfterM
               ownerFileName = `${GUARD_OWNER_FILE_PREFIX}${token}`;
 
         try {
+            // NOT an atomic file write, despite sharing the `rename` verb with one. This renames a
+            // staging DIRECTORY onto the guard path, and the rename FAILING is the mutual exclusion:
+            // a loser gets ENOTEMPTY/EEXIST and retries. The shared write-temp-then-rename primitive
+            // writes a file and treats a failed rename as an error, so it cannot express this at all.
             await fsModule.mkdir(stagingPath);
             await fsModule.writeFile(path.join(stagingPath, ownerFileName), '', 'utf8');
             await fsModule.rename(stagingPath, guardPath);
@@ -196,6 +200,8 @@ export function enterLifecycleGuardSync({leasePath, fsModule, guardStaleAfterMs 
               ownerFileName = `${GUARD_OWNER_FILE_PREFIX}${token}`;
 
         try {
+            // Sync twin of the directory-rename mutex above — same reason it is not the shared
+            // atomic-write primitive: the rename target is a directory and its failure is the lock.
             fsModule.mkdirSync(stagingPath);
             fsModule.writeFileSync(path.join(stagingPath, ownerFileName), '', 'utf8');
             fsModule.renameSync(stagingPath, guardPath);

--- a/ai/daemons/wake/buildReceiverManifest.mjs
+++ b/ai/daemons/wake/buildReceiverManifest.mjs
@@ -457,6 +457,10 @@ export async function writeValidatedManifest({manifest, targetPath}) {
         // re-implementing its rules here and letting the two drift.
         await loadWakeReceiverManifest(stagingPath);
 
+        // DELIBERATELY NOT the shared write-temp-then-rename primitive. The validation directly above
+        // reads the STAGED file and must run between the write and the rename — that ordering is what
+        // stops an unusable manifest from ever becoming the live one. The primitive collapses the two
+        // into a single call, leaving nowhere for the check to stand.
         await fs.rename(stagingPath, targetPath)
     } catch (error) {
         await handle?.close().catch(() => {});

--- a/ai/daemons/wake/buildReceiverManifest.mjs
+++ b/ai/daemons/wake/buildReceiverManifest.mjs
@@ -461,7 +461,7 @@ export async function writeValidatedManifest({manifest, targetPath}) {
         // reads the STAGED file and must run between the write and the rename — that ordering is what
         // stops an unusable manifest from ever becoming the live one. The primitive collapses the two
         // into a single call, leaving nowhere for the check to stand.
-        await fs.rename(stagingPath, targetPath)
+        await fs.rename(stagingPath, targetPath) // atomic-write-ok: the receiver validates the STAGED file between write and rename
     } catch (error) {
         await handle?.close().catch(() => {});
         await fs.rm(stagingPath, {force: true});

--- a/ai/daemons/wake/daemon.mjs
+++ b/ai/daemons/wake/daemon.mjs
@@ -31,6 +31,7 @@ import Neo                                       from '../../../src/Neo.mjs';
 import * as core                                 from '../../../src/core/_export.mjs';
 import InstanceManager                           from '../../../src/manager/Instance.mjs';
 import AiConfig                                  from '../../config.mjs';
+import {writeFileAtomicSync}                     from '../../services/shared/atomicFileWrite.mjs';
 import memoryCoreConfig                          from '../../mcp/server/memory-core/config.mjs';
 import {assertConfigFresh}                       from '../../scripts/setup/initServerConfigs.mjs';
 import {buildWakeDigest, getHighestWakePriority} from './wakeDigestBuilder.mjs';
@@ -353,15 +354,13 @@ function loadTerminalDeliveryFailures() {
  * @private
  */
 function persistTerminalDeliveryFailures() {
-    const tmpPath = `${DELIVERY_FAILURE_STATE_FILE}.${process.pid}.tmp`;
-
     try {
-        fs.writeFileSync(tmpPath, JSON.stringify(terminalDeliveryFailures, null, 2) + '\n', {mode: 0o600});
-        fs.chmodSync(tmpPath, 0o600);
-        fs.renameSync(tmpPath, DELIVERY_FAILURE_STATE_FILE);
+        // The former scratch was `${file}.${pid}.tmp` — unique per process but not per call, and the
+        // explicit chmod after write existed because the mode was applied to a file the umask had
+        // already touched. The primitive creates at 0o600 with `wx` and cleans up its own scratch.
+        writeFileAtomicSync(DELIVERY_FAILURE_STATE_FILE, JSON.stringify(terminalDeliveryFailures, null, 2) + '\n');
         terminalDeliveryFailuresNeedRepair = false;
     } catch (error) {
-        try { fs.removeSync(tmpPath); } catch {}
         writeLog('ERROR', `[Wake Daemon] Could not persist terminal delivery-failure receipts (${error.message}).`);
     }
 }

--- a/ai/daemons/wake/queries.mjs
+++ b/ai/daemons/wake/queries.mjs
@@ -1,5 +1,6 @@
 import fs                              from 'fs-extra';
 import Database                        from 'better-sqlite3';
+import {writeFileAtomicSync}           from '../../services/shared/atomicFileWrite.mjs';
 import { SQLITE_IN_CLAUSE_BATCH_SIZE } from '../../graph/storage/constants.mjs';
 // Only the WAKE_SUBSCRIPTION reads below use this. The HARNESS_PRESENCE query later in this file
 // carries the same COALESCE idiom for a DIFFERENT entity and must not be folded into it.
@@ -82,9 +83,9 @@ function getMaxLogId(db) {
  * @returns {void}
  */
 export function writeLastSyncId(stateFile, lastSyncId) {
-    const tmpFile = `${stateFile}.tmp`;
-    fs.writeFileSync(tmpFile, lastSyncId.toString(), 'utf8');
-    fs.renameSync(tmpFile, stateFile);
+    // Was a fixed `${stateFile}.tmp` with no cleanup: two daemons sharing a state file raced the same
+    // scratch, and a throw between write and rename stranded it next to the cursor permanently.
+    writeFileAtomicSync(stateFile, lastSyncId.toString())
 }
 
 export function getActiveShapeCSubscriptions(db) {

--- a/ai/daemons/wake/receiverState.mjs
+++ b/ai/daemons/wake/receiverState.mjs
@@ -226,7 +226,10 @@ export class WakeReceiverState {
         const tempPath   = `${recordPath}.${process.pid}.${crypto.randomUUID()}.tmp`;
 
         await this._writeSynced(tempPath, record);
-        await fs.rename(tempPath, recordPath);
+        // _syncDirectory() below deliberately tolerates EINVAL/ENOTSUP/EPERM. The shared primitive's
+        // fsync is STRICT by contract, so migrating would turn a tolerated platform degradation into a
+        // hard failure on exactly the platforms that cannot fsync a directory.
+        await fs.rename(tempPath, recordPath); // atomic-write-ok: strict primitive fsync vs this site's tolerated directory sync
         await fs.chmod(recordPath, 0o600);
         await this._syncDirectory();
     }

--- a/ai/mcp/server/shared/helpers/seatToken.mjs
+++ b/ai/mcp/server/shared/helpers/seatToken.mjs
@@ -1,6 +1,7 @@
-import fs           from 'fs';
-import path         from 'path';
-import {createHash} from 'crypto';
+import fs                    from 'fs';
+import path                  from 'path';
+import {createHash}          from 'crypto';
+import {writeFileAtomicSync} from '../../../../services/shared/atomicFileWrite.mjs';
 import {
     generateLocalBearerToken,
     isLocalBearerToken
@@ -152,9 +153,8 @@ export function readSeatTokenRegistry(filePath) {
  * @returns {void}
  */
 export function writeSeatTokenRegistry(filePath, registry) {
-    const tmpPath = `${filePath}.tmp-${process.pid}`;
-
-    fs.mkdirSync(path.dirname(filePath), {recursive: true});
-    fs.writeFileSync(tmpPath, JSON.stringify(registry, null, 4) + '\n', 'utf8');
-    fs.renameSync(tmpPath, filePath)
+    // The former scratch name was `${filePath}.tmp-${process.pid}` — unique across processes but NOT
+    // across concurrent writers inside one, which is exactly the shape this registry sees. The
+    // primitive's pid+UUID scratch closes that, and adds the cleanup this never had.
+    writeFileAtomicSync(filePath, JSON.stringify(registry, null, 4) + '\n')
 }

--- a/ai/mcp/server/shared/services/HeapObservationReporterService.mjs
+++ b/ai/mcp/server/shared/services/HeapObservationReporterService.mjs
@@ -4,6 +4,7 @@ import Base     from '../../../../../src/core/Base.mjs';
 import AiConfig from '../../../../config.mjs';
 
 import {collectProcessHeapObservation} from '../../../../services/shared/processHeapObservation.mjs';
+import {writeFileAtomicSync}           from '../../../../services/shared/atomicFileWrite.mjs';
 
 /**
  * @summary Publishes this process's own heap/non-heap observation on a cadence, so a sibling process
@@ -89,14 +90,8 @@ class HeapObservationReporterService extends Base {
      * @returns {Boolean} Whether the record reached disk.
      */
     writeOnce({serviceKey, dir, writeLog}) {
-        let staging = null;
-
         try {
-            const target = this.observationPath(serviceKey, dir);
-
-            staging = `${target}.${process.pid}.tmp`;
-
-            fs.outputJsonSync(staging, {
+            const record = {
                 schemaVersion: 1,
                 recordType   : 'process-heap-observation',
                 serviceKey,
@@ -105,18 +100,19 @@ class HeapObservationReporterService extends Base {
                 provenance : 'self-reported',
                 pid        : process.pid,
                 observation: collectProcessHeapObservation()
-            });
+            };
 
-            fs.renameSync(staging, target);
+            // Was a `${target}.${pid}.tmp` scratch: unique per process, but this reporter is called
+            // per service key within one process, so two keys racing shared the scratch.
+            writeFileAtomicSync(this.observationPath(serviceKey, dir), JSON.stringify(record, null, 2) + '\n');
 
             return true
         } catch (error) {
             // WARN, not ERROR: the channel degrading is a loss of visibility, and the reader's
             // staleness bound already reports that loss honestly as absence rather than as health.
             safely(() => writeLog?.('WARN', `[HeapObservationReporter] observation write FAILED for ${serviceKey}: ${error.message}. The heap/non-heap split is unobservable until this succeeds.`));
-            // Best effort, and its failure is silent by design: the only thing left to report a failed
-            // cleanup with is the logger that may itself be the reason we are here.
-            staging && safely(() => fs.removeSync(staging));
+            // The scratch cleanup that used to live here is now the primitive's `finally`, which runs
+            // on the failure path too — so there is no leaked sibling left for this block to remove.
 
             return false
         }

--- a/ai/scripts/lifecycle/wakeSafetyGate.mjs
+++ b/ai/scripts/lifecycle/wakeSafetyGate.mjs
@@ -40,9 +40,10 @@
  * @see ai/scripts/lifecycle/checkSunsetted.mjs    — companion predicate
  * @see test/playwright/unit/ai/scripts/wakeSafetyGate.spec.mjs
  */
-import fs from 'fs/promises';
-import path from 'path';
+import fs                from 'fs/promises';
+import path              from 'path';
 import { fileURLToPath } from 'url';
+import {writeFileAtomic} from '../../services/shared/atomicFileWrite.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -82,12 +83,12 @@ const DEFAULT_TRIPPED = {
  */
 export async function readGateState() {
     try {
-        const raw = await fs.readFile(gateFilePath(), 'utf8');
+        const raw    = await fs.readFile(gateFilePath(), 'utf8');
         const parsed = JSON.parse(raw);
         if (!parsed || typeof parsed !== 'object' || typeof parsed.state !== 'string') {
             return {
                 ...DEFAULT_TRIPPED,
-                reason: 'Gate file present but malformed; treating as tripped.',
+                reason   : 'Gate file present but malformed; treating as tripped.',
                 trippedBy: 'malformed-state-file'
             };
         }
@@ -101,7 +102,7 @@ export async function readGateState() {
         if (err.code === 'ENOENT') return {...DEFAULT_TRIPPED};
         return {
             ...DEFAULT_TRIPPED,
-            reason: `Gate file read error: ${err.message}; treating as tripped.`,
+            reason   : `Gate file read error: ${err.message}; treating as tripped.`,
             trippedBy: 'read-error'
         };
     }
@@ -122,9 +123,7 @@ export async function writeGateState(payload) {
         trippedAt: payload.state === 'enabled' ? null : new Date().toISOString(),
         trippedBy: payload.trippedBy ?? null
     };
-    const tmpPath = `${filePath}.tmp-${process.pid}`;
-    await fs.writeFile(tmpPath, JSON.stringify(body, null, 2) + '\n', 'utf8');
-    await fs.rename(tmpPath, filePath);
+    await writeFileAtomic(filePath, JSON.stringify(body, null, 2) + '\n');
 }
 
 /**
@@ -163,11 +162,11 @@ export async function isGateOpen() {
 //   enable   — write enabled state. No reason required (cleared on enable).
 async function main() {
     const argv = process.argv.slice(2);
-    const cmd = argv[0];
+    const cmd  = argv[0];
 
     const flag = name => {
         const prefix = `--${name}=`;
-        const arg = argv.find(a => a.startsWith(prefix));
+        const arg    = argv.find(a => a.startsWith(prefix));
         return arg ? arg.slice(prefix.length) : null;
     };
 
@@ -186,7 +185,7 @@ async function main() {
         process.exit(0);
     }
     if (cmd === 'trip' || cmd === 'disable') {
-        const reason = flag('reason') ?? '';
+        const reason    = flag('reason') ?? '';
         const trippedBy = flag('by') ?? 'cli';
         await writeGateState({state: cmd === 'trip' ? 'tripped' : 'disabled', reason, trippedBy});
         process.exit(0);

--- a/ai/scripts/maintenance/materializeDeploymentPrescriptions.mjs
+++ b/ai/scripts/maintenance/materializeDeploymentPrescriptions.mjs
@@ -12,6 +12,7 @@ import {
     LEDGER_REFUSALS
 } from '../../services/memory-core/helpers/deploymentPrescriptionLedger.mjs';
 import {renderPrescribedEnvironment} from '../../services/memory-core/helpers/deploymentPrescriptionEnvironment.mjs';
+import {writeFileAtomic}             from '../../services/shared/atomicFileWrite.mjs';
 import {
     appendDeploymentPrescription,
     readDeploymentPrescriptions,
@@ -138,23 +139,21 @@ export function mergePrescribedEnvironment(
 
 /**
  * @summary Writes a UTF-8 file through a unique sibling and atomic rename.
+ *
+ * This was the repo's best hand-rolled copy of the shape and is now a thin delegation to the owned
+ * primitive — the implementation moved to `ai/services/shared/atomicFileWrite.mjs` rather than being
+ * duplicated a fourteenth time. The positional `fsModule` signature is kept because this module's
+ * callers and specs inject through it.
+ *
+ * (The previous `@returns {Promise<{createdLink, capturedPath}>}` on this function was wrong — it
+ * described a different helper and the body never returned a value.)
  * @param {String} filePath
  * @param {String} content
  * @param {Object} [fsModule]
- * @returns {Promise<{createdLink: Boolean, capturedPath: String|null}>} Reversible link preparation.
+ * @returns {Promise<void>}
  */
 export async function writeAtomicFile(filePath, content, fsModule = fs) {
-    const absolute = path.resolve(filePath),
-          scratch  = `${absolute}.${process.pid}.${randomUUID()}.tmp`;
-
-    await fsModule.mkdir(path.dirname(absolute), {recursive: true});
-
-    try {
-        await fsModule.writeFile(scratch, content, {encoding: 'utf8', flag: 'wx', mode: 0o600});
-        await fsModule.rename(scratch, absolute)
-    } finally {
-        await fsModule.rm(scratch, {force: true}).catch(() => {})
-    }
+    await writeFileAtomic(filePath, content, {fsModule})
 }
 
 /**

--- a/ai/scripts/setup/migrateConfigOverlay.mjs
+++ b/ai/scripts/setup/migrateConfigOverlay.mjs
@@ -27,6 +27,7 @@
 import fs                             from 'fs';
 import path                           from 'path';
 import {fileURLToPath, pathToFileURL} from 'url';
+import {writeFileAtomicSync}          from '../../services/shared/atomicFileWrite.mjs';
 
 const __dirname  = path.dirname(fileURLToPath(import.meta.url));
 const neoRootDir = path.resolve(__dirname, '../../../');
@@ -360,22 +361,17 @@ export function extractParentConfigImport(source) {
  * @returns {{backupPath: String}}
  */
 export function writeMigratedOverlay({overlayPath, generated, fileSystem = fs}) {
-    const
-        backupPath = `${overlayPath}.pre-migration.bak`,
-        tempPath   = `${overlayPath}.migration-${process.pid}-${Date.now()}.tmp`;
+    const backupPath = `${overlayPath}.pre-migration.bak`;
 
-    try {
-        fileSystem.writeFileSync(tempPath, generated, {encoding: 'utf8', flag: 'wx'});
-        fileSystem.copyFileSync(overlayPath, backupPath);
-        fileSystem.renameSync(tempPath, overlayPath);
-    } catch (error) {
-        try {
-            fileSystem.rmSync(tempPath, {force: true});
-        } catch {
-            // Preserve the original failure. A cleanup error must never disguise why migration stopped.
-        }
-        throw error
-    }
+    // The backup is taken FIRST rather than between the scratch write and the rename. It copies the
+    // ORIGINAL overlay, which is untouched until the atomic write publishes — so both orders capture
+    // the same bytes, and taking it first means a failed backup aborts before anything was staged.
+    //
+    // The former `${overlayPath}.migration-${pid}-${Date.now()}.tmp` and its catch-block cleanup are
+    // both gone: the primitive owns its scratch and removes it in a `finally`, so there is no longer
+    // a leaked sibling for this function to chase.
+    fileSystem.copyFileSync(overlayPath, backupPath);
+    writeFileAtomicSync(overlayPath, generated, {fsModule: fileSystem, mode: 0o644});
 
     return {backupPath}
 }

--- a/ai/services/fleet/FleetRegistryService.mjs
+++ b/ai/services/fleet/FleetRegistryService.mjs
@@ -1,9 +1,10 @@
-import crypto          from 'crypto';
-import fs              from 'fs';
-import path            from 'path';
-import aiConfig        from '../../config.mjs';
-import Base            from '../../../src/core/Base.mjs';
-import {HARNESS_TYPES} from './harnessTypes.mjs';
+import crypto                from 'crypto';
+import fs                    from 'fs';
+import path                  from 'path';
+import aiConfig              from '../../config.mjs';
+import Base                  from '../../../src/core/Base.mjs';
+import {HARNESS_TYPES}       from './harnessTypes.mjs';
+import {writeFileAtomicSync} from '../shared/atomicFileWrite.mjs';
 import {
     normalizeMcpOverrides,
     normalizeMcpTarget,
@@ -62,18 +63,10 @@ export function resolveFleetCredentialKey({
             const legacyHex = raw.toString('ascii');
 
             if (raw.length === 64 && /^[0-9a-fA-F]{64}$/.test(legacyHex)) {
-                const
-                    key      = Buffer.from(legacyHex, 'hex'),
-                    tempFile = `${keyFile}.${process.pid}.${crypto.randomUUID()}.tmp`;
+                const key = Buffer.from(legacyHex, 'hex');
 
-                try {
-                    fs.writeFileSync(tempFile, key, {flag: 'wx', mode: 0o600});
-                    fs.renameSync(tempFile, keyFile)
-                } finally {
-                    try {
-                        fs.unlinkSync(tempFile)
-                    } catch {}
-                }
+                // Binary payload: `encoding: null` so the key is written as bytes, not re-encoded.
+                writeFileAtomicSync(keyFile, key, {encoding: null});
 
                 return key
             }
@@ -743,20 +736,10 @@ class FleetRegistryService extends Base {
      */
     writeRegistry(agents=this.agents) {
         this.ensureDataDir();
-        const
-            file    = this.registryPath(),
-            tmpFile = `${file}.${process.pid}.${crypto.randomUUID()}.tmp`,
-            payload = {agents: Object.fromEntries(agents)};
 
-        try {
-            fs.writeFileSync(tmpFile, JSON.stringify(payload, null, 2), 'utf8');
-            fs.renameSync(tmpFile, file)
-        } catch (error) {
-            if (fs.existsSync(tmpFile)) {
-                fs.unlinkSync(tmpFile)
-            }
-            throw error
-        }
+        const payload = {agents: Object.fromEntries(agents)};
+
+        writeFileAtomicSync(this.registryPath(), JSON.stringify(payload, null, 2))
     }
 
     /**
@@ -809,19 +792,8 @@ class FleetRegistryService extends Base {
      */
     writeCredentials(map) {
         this.ensureDataDir();
-        const
-            file    = this.credentialsPath(),
-            tmpFile = `${file}.${process.pid}.${crypto.randomUUID()}.tmp`;
 
-        try {
-            fs.writeFileSync(tmpFile, this.encrypt(JSON.stringify(map)), {mode: 0o600});
-            fs.renameSync(tmpFile, file)
-        } catch (error) {
-            if (fs.existsSync(tmpFile)) {
-                fs.unlinkSync(tmpFile)
-            }
-            throw error
-        }
+        writeFileAtomicSync(this.credentialsPath(), this.encrypt(JSON.stringify(map)))
     }
 
     // ---- crypto (AES-256-GCM) ----------------------------------------------

--- a/ai/services/fleet/FleetTenantService.mjs
+++ b/ai/services/fleet/FleetTenantService.mjs
@@ -1,6 +1,7 @@
-import crypto from 'node:crypto';
-import fs     from 'node:fs';
-import path   from 'node:path';
+import crypto                from 'node:crypto';
+import fs                    from 'node:fs';
+import path                  from 'node:path';
+import {writeFileAtomicSync} from '../shared/atomicFileWrite.mjs';
 import {
     InitializeResultSchema,
     SUPPORTED_PROTOCOL_VERSIONS
@@ -432,21 +433,9 @@ class FleetTenantService extends Base {
      * @protected
      */
     publishAtomically(file, contents) {
-        const dir     = path.dirname(file),
-              tmpFile = `${file}.${process.pid}.${crypto.randomUUID()}.tmp`;
-
-        fs.mkdirSync(dir, {recursive: true});
-
-        try {
-            fs.writeFileSync(tmpFile, contents, {mode: 0o600});
-            fs.renameSync(tmpFile, file)
-        } catch (error) {
-            if (fs.existsSync(tmpFile)) {
-                fs.unlinkSync(tmpFile)
-            }
-
-            throw error
-        }
+        // This site was already correct — pid+UUID scratch, 0o600, cleanup on throw. It is one of the
+        // two exemplars the owned primitive was modelled on; the call replaces the copy, not the care.
+        writeFileAtomicSync(file, contents)
     }
 
     /**

--- a/ai/services/fleet/opencodeWakeEnvelopePlugin.mjs
+++ b/ai/services/fleet/opencodeWakeEnvelopePlugin.mjs
@@ -132,7 +132,7 @@ export const NeoWakeEnvelope = async (ctx) => {
         const tmpPath = `${envelopePath}.${process.pid}.tmp`;
         await fs.writeFile(tmpPath, JSON.stringify(envelope, null, 2) + '\n', {mode: 0o600});
         await fs.chmod(tmpPath, 0o600);
-        await fs.rename(tmpPath, envelopePath);
+        await fs.rename(tmpPath, envelopePath); // atomic-write-ok: PLANT executed outside this repo; a relative import cannot resolve
         await fs.chmod(envelopePath, 0o600);
 
         await log('info', `wake envelope written for session ${sessionId} (port ${port})`);

--- a/ai/services/fleet/opencodeWakeEnvelopePlugin.mjs
+++ b/ai/services/fleet/opencodeWakeEnvelopePlugin.mjs
@@ -124,6 +124,11 @@ export const NeoWakeEnvelope = async (ctx) => {
         // Atomic private write: the secret-bearing tmp is born 0600, explicitly tightened in
         // case a stale tmp already exists, then renamed without ever exposing a permissive window.
         // The final chmod remains defense-in-depth for a pre-existing permissive destination.
+        // DELIBERATELY NOT the shared write-temp-then-rename primitive, and this one is not a
+        // semantic objection — it is a LOCATION one. This file is a PLANT: it is copied to
+        // `~/.config/opencode/plugins/` on the seat machine and executes OUTSIDE this repo, so a
+        // relative import of anything in `ai/` would fail to resolve at load time and take the whole
+        // wake-envelope route down. The hand-rolled pair is the price of being self-contained.
         const tmpPath = `${envelopePath}.${process.pid}.tmp`;
         await fs.writeFile(tmpPath, JSON.stringify(envelope, null, 2) + '\n', {mode: 0o600});
         await fs.chmod(tmpPath, 0o600);

--- a/ai/services/fleet/prepareManagedAgentWorkspace.mjs
+++ b/ai/services/fleet/prepareManagedAgentWorkspace.mjs
@@ -1,5 +1,6 @@
 import {constants as fsConstants}                  from 'node:fs';
 import fs                                          from 'node:fs/promises';
+import {writeFileAtomic}                           from '../shared/atomicFileWrite.mjs';
 import path                                        from 'node:path';
 import crypto                                      from 'node:crypto';
 import {fileURLToPath}                             from 'node:url';
@@ -1633,16 +1634,10 @@ async function removeTransportReceipt({receiptPath, fileSystem, instanceHome}) {
 
 /** @private */
 async function publishTextAtomically({filePath, content, fileSystem}) {
-    const tmpPath = `${filePath}.${process.pid}.${crypto.randomUUID()}.tmp`;
-
-    try {
-        await fileSystem.writeFile(tmpPath, content, {encoding: 'utf8', mode: 0o600});
-        await fileSystem.rename(tmpPath, filePath);
-        await fileSystem.chmod(filePath, 0o600)
-    } catch (error) {
-        await fileSystem.unlink(tmpPath).catch(() => {});
-        throw error
-    }
+    // Scratch naming and cleanup-on-failure are the primitive's now; the `unlink(tmpPath)` that used
+    // to live in the catch referenced a binding this no longer declares.
+    await writeFileAtomic(filePath, content, {fsModule: fileSystem, mode: 0o600});
+    await fileSystem.chmod(filePath, 0o600)
 }
 
 /** @private */

--- a/ai/services/github-workflow/sync/PullRequestSyncer.mjs
+++ b/ai/services/github-workflow/sync/PullRequestSyncer.mjs
@@ -1,6 +1,7 @@
 import aiConfig                                                                   from '../../../mcp/server/github-workflow/config.mjs';
 import Base                                                                       from '../../../../src/core/Base.mjs';
 import crypto                                                                     from 'crypto';
+import {writeFileAtomic}                                                          from '../../shared/atomicFileWrite.mjs';
 import {existsSync}                                                               from 'fs';
 import fs                                                                         from 'fs/promises';
 import logger                                                                     from '../../../mcp/server/github-workflow/logger.mjs';
@@ -819,12 +820,7 @@ class PullRequestSyncer extends Base {
                 // is not "durable"; only a file on disk is.
                 //
                 // Temp + atomic rename so a torn write cannot masquerade as the canonical artifact.
-                await fs.mkdir(path.dirname(targetPath), {recursive: true});
-
-                const tempPath = `${targetPath}.${process.pid}.tmp`;
-
-                await fs.writeFile(tempPath, content, 'utf-8');
-                await fs.rename(tempPath, targetPath);
+                await writeFileAtomic(targetPath, content);
 
                 // Only now remove the stale copies — and never the one just written, which may BE
                 // one of them when the canonical location is a copy's own address.

--- a/ai/services/graph/TopologyInferenceEngine.mjs
+++ b/ai/services/graph/TopologyInferenceEngine.mjs
@@ -1,6 +1,7 @@
 import fs                            from 'fs';
 import path                          from 'path';
 import { Memory_Config as AiConfig } from '../../services.mjs';
+import {writeFileAtomic}             from '../shared/atomicFileWrite.mjs';
 import Base                          from '../../../src/core/Base.mjs';
 import Json                          from '../../../src/util/Json.mjs';
 import logger                        from '../../mcp/server/memory-core/logger.mjs';
@@ -488,7 +489,6 @@ ${contextText}
 
             // Write to sandman_handoff.md
             const handoffFile = AiConfig.handoffFilePath;
-            const tmpFile     = `${handoffFile}.tmp`;
 
             let handoffContent = '';
             try {
@@ -500,9 +500,7 @@ ${contextText}
             const {content, changed} = this.mergeConflictAlerts(handoffContent, conflicts, sessionId);
 
             if (changed) {
-                await fs.promises.mkdir(path.dirname(handoffFile), {recursive: true});
-                await fs.promises.writeFile(tmpFile, content, 'utf8');
-                await fs.promises.rename(tmpFile, handoffFile);
+                await writeFileAtomic(handoffFile, content);
                 logger.info(`[TopologyInferenceEngine] Registered new topological conflicts to sandman_handoff.md for session ${sessionId}.`);
             }
 

--- a/ai/services/memory-core/helpers/acceptedLossAuditStore.mjs
+++ b/ai/services/memory-core/helpers/acceptedLossAuditStore.mjs
@@ -1,4 +1,5 @@
 import {appendFile, mkdir, readFile, rename, stat, writeFile} from 'fs/promises';
+import {writeFileAtomic}                                      from '../../shared/atomicFileWrite.mjs';
 import path                                                   from 'path';
 
 /**
@@ -149,11 +150,10 @@ export async function writeAutoAcceptedLossState(state, {dir} = {}) {
 
     await mkdir(dir, {recursive: true});
 
-    const filePath = getAcceptedLossStateFilePath(dir),
-          tmpPath  = `${filePath}.tmp`;
+    const filePath = getAcceptedLossStateFilePath(dir);
 
-    await writeFile(tmpPath, JSON.stringify(state, null, 2) + '\n', 'utf8');
-    await rename(tmpPath, filePath);
+    // Was a fixed `${filePath}.tmp`: two audit writers in one process raced the same scratch.
+    await writeFileAtomic(filePath, JSON.stringify(state, null, 2) + '\n');
 
     return filePath;
 }
@@ -203,11 +203,9 @@ export async function pruneAutoAcceptedLossAudit({dir, maxEvents = MAX_AUTO_ACCE
     }
 
     const retained = events.slice(events.length - maxEvents),
-          filePath = getAcceptedLossAuditFilePath(dir),
-          tmpPath  = `${filePath}.tmp`;
+          filePath = getAcceptedLossAuditFilePath(dir);
 
-    await writeFile(tmpPath, retained.map(entry => JSON.stringify(entry)).join('\n') + '\n', 'utf8');
-    await rename(tmpPath, filePath);
+    await writeFileAtomic(filePath, retained.map(entry => JSON.stringify(entry)).join('\n') + '\n');
 
     return {pruned: events.length - retained.length, retained: retained.length};
 }

--- a/ai/services/memory-core/helpers/deploymentStateBridgeStore.mjs
+++ b/ai/services/memory-core/helpers/deploymentStateBridgeStore.mjs
@@ -1,5 +1,5 @@
-import fs   from 'fs-extra';
-import path from 'path';
+import fs                from 'fs-extra';
+import {writeFileAtomic} from '../../shared/atomicFileWrite.mjs';
 
 export const DEPLOYMENT_STATE_BRIDGE_SCHEMA_VERSION = 1;
 
@@ -106,11 +106,9 @@ export async function writeDeploymentStateSnapshot({
         throw new Error(`Deployment state snapshot exceeds ${maxBytes} bytes`);
     }
 
-    await fs.ensureDir(path.dirname(filePath));
-
-    const tempPath = `${filePath}.${process.pid}.${Date.now()}.tmp`;
-    await fs.writeFile(tempPath, json, 'utf8');
-    await fs.rename(tempPath, filePath);
+    // Was `${filePath}.${pid}.${Date.now()}.tmp` — `Date.now()` has millisecond resolution, so two
+    // snapshots written inside one tick by the same process collided. The primitive's UUID does not.
+    await writeFileAtomic(filePath, json);
 
     return {ok: true, filePath, bytes};
 }

--- a/ai/services/memory-core/helpers/offHostSyncStore.mjs
+++ b/ai/services/memory-core/helpers/offHostSyncStore.mjs
@@ -241,7 +241,7 @@ export async function writeBackupReceipt({filePath, receipt, now = Date.now()}) 
     // naming and does not publish a matcher, so adopting it would leave every crash-leaked temp
     // permanently unreapable. Writer and reaper stay one unit until the primitive exports that
     // predicate — which would be new public API in service of a single caller.
-    await fs.promises.rename(tempPath, filePath);
+    await fs.promises.rename(tempPath, filePath); // atomic-write-ok: the scratch NAME is a contract with the stale-temp reaper below
 
     // Stale-temp sweep: age makes a temp eligible, but only a provably dead encoded owner makes it
     // removable. PID reuse / EPERM / malformed metadata intentionally leak in the safe direction.

--- a/ai/services/memory-core/helpers/offHostSyncStore.mjs
+++ b/ai/services/memory-core/helpers/offHostSyncStore.mjs
@@ -235,6 +235,12 @@ export async function writeBackupReceipt({filePath, receipt, now = Date.now()}) 
     } finally {
         await handle.close()
     }
+    // DELIBERATELY NOT the shared `writeFileAtomic` primitive. The scratch NAME is a contract between this writer
+    // and the stale-temp reaper below: the reaper matches `${basename}.tmp-` and decodes the owner pid
+    // out of the name to prove the owner is dead before removing it. The primitive owns its own scratch
+    // naming and does not publish a matcher, so adopting it would leave every crash-leaked temp
+    // permanently unreapable. Writer and reaper stay one unit until the primitive exports that
+    // predicate — which would be new public API in service of a single caller.
     await fs.promises.rename(tempPath, filePath);
 
     // Stale-temp sweep: age makes a temp eligible, but only a provably dead encoded owner makes it

--- a/ai/services/memory-core/helpers/quarantineStore.mjs
+++ b/ai/services/memory-core/helpers/quarantineStore.mjs
@@ -1,4 +1,5 @@
 import {mkdir, readFile, rename, stat, writeFile} from 'fs/promises';
+import {writeFileAtomic}                          from '../../shared/atomicFileWrite.mjs';
 import path                                       from 'path';
 
 /**
@@ -76,11 +77,9 @@ async function readFenceMap(dir) {
 async function writeFenceMap(dir, fences) {
     await mkdir(dir, {recursive: true});
 
-    const filePath = getQuarantineFilePath(dir),
-          tmpPath  = `${filePath}.${process.pid}.tmp`;
+    const filePath = getQuarantineFilePath(dir);
 
-    await writeFile(tmpPath, JSON.stringify(fences), 'utf8');
-    await rename(tmpPath, filePath); // atomic publish
+    await writeFileAtomic(filePath, JSON.stringify(fences));
     fenceCache.delete(filePath);     // force a re-stat on the next read
 }
 

--- a/ai/services/memory-core/helpers/recoveryOverrideStore.mjs
+++ b/ai/services/memory-core/helpers/recoveryOverrideStore.mjs
@@ -188,6 +188,11 @@ export async function writeKnobOverride({
         throw error;
     }
 
+    // DELIBERATELY NOT the shared `writeFileAtomic` primitive. It collapses write-then-rename into one
+    // call, and this site's correctness depends on what happens BETWEEN them: `assertHeld()` above is
+    // the only check that binds the effect, and it must run after the scratch exists and immediately
+    // before the commit. Adopting the primitive would silently delete that fencing point and turn a
+    // displaced holder's refusal into a published instruction. The hand-rolled pair stays.
     await fsModule.rename(tempPath, overridePath);
 
     return {applied: true, path: overridePath, violations: []}

--- a/ai/services/memory-core/helpers/recoveryOverrideStore.mjs
+++ b/ai/services/memory-core/helpers/recoveryOverrideStore.mjs
@@ -193,7 +193,7 @@ export async function writeKnobOverride({
     // the only check that binds the effect, and it must run after the scratch exists and immediately
     // before the commit. Adopting the primitive would silently delete that fencing point and turn a
     // displaced holder's refusal into a published instruction. The hand-rolled pair stays.
-    await fsModule.rename(tempPath, overridePath);
+    await fsModule.rename(tempPath, overridePath); // atomic-write-ok: assertHeld() must fence between write and rename
 
     return {applied: true, path: overridePath, violations: []}
 }

--- a/ai/services/memory-core/helpers/remRunStateStore.mjs
+++ b/ai/services/memory-core/helpers/remRunStateStore.mjs
@@ -1,5 +1,6 @@
-import fs   from 'fs/promises';
-import path from 'path';
+import fs                from 'fs/promises';
+import path              from 'path';
+import {writeFileAtomic} from '../../shared/atomicFileWrite.mjs';
 
 const ACTIVE_REM_CALL_FILE = 'active-rem-call.json';
 
@@ -235,13 +236,11 @@ export async function writeActiveRemCallState(state, {dir} = {}) {
         throw new TypeError('writeActiveRemCallState: dir is required');
     }
 
-    await fs.mkdir(dir, {recursive: true});
+    const filePath = getActiveRemCallStateFilePath(dir);
 
-    const filePath = getActiveRemCallStateFilePath(dir),
-          tmpPath  = `${filePath}.tmp`;
-
-    await fs.writeFile(tmpPath, `${JSON.stringify(state, null, 2)}\n`, 'utf8');
-    await fs.rename(tmpPath, filePath);
+    // Was a fixed `${filePath}.tmp`: two REM runs in one process raced the same scratch, and a throw
+    // between write and rename stranded it beside the state file. The primitive owns both.
+    await writeFileAtomic(filePath, `${JSON.stringify(state, null, 2)}\n`);
 
     return filePath;
 }

--- a/ai/services/memory-core/hookProjectionTransport.mjs
+++ b/ai/services/memory-core/hookProjectionTransport.mjs
@@ -118,7 +118,7 @@ export function makeAtomicProjectionTransport({fs, runtimeRoot, uniqueSuffix} = 
             // above states: the deadline assertion has to land between the flush and the rename,
             // because the rename IS the mutation. A primitive that owns both ends removes the one
             // instant this bound exists to hold.
-            fs.renameSync(temp, file);
+            fs.renameSync(temp, file); // atomic-write-ok: assertDeadline() must fence between flush and rename
 
             return {file}
         } catch (error) {

--- a/ai/services/memory-core/hookProjectionTransport.mjs
+++ b/ai/services/memory-core/hookProjectionTransport.mjs
@@ -114,6 +114,10 @@ export function makeAtomicProjectionTransport({fs, runtimeRoot, uniqueSuffix} = 
             // instant it exists to hold.
             assertDeadline?.();
 
+            // DELIBERATELY NOT the shared write-temp-then-rename primitive, for the reason the block
+            // above states: the deadline assertion has to land between the flush and the rename,
+            // because the rename IS the mutation. A primitive that owns both ends removes the one
+            // instant this bound exists to hold.
             fs.renameSync(temp, file);
 
             return {file}

--- a/ai/services/shared/atomicFileWrite.mjs
+++ b/ai/services/shared/atomicFileWrite.mjs
@@ -1,0 +1,184 @@
+import fs           from 'fs';
+import fsPromises   from 'fs/promises';
+import path         from 'path';
+import {randomUUID} from 'crypto';
+
+/**
+ * @summary The owned write-temp-then-rename primitive — one implementation for the whole Brain.
+ *
+ * Every hand-rolled copy of this shape gets the same three details wrong in the same order, which is
+ * why this exists as a primitive rather than a convention:
+ *
+ * 1. **A fixed `${filePath}.tmp` scratch name collides.** Two processes (or two async writers in one
+ *    process) racing the same target both write the same scratch path, and the loser's partial
+ *    content is what `rename` promotes. The scratch name here carries pid + a UUID, so concurrent
+ *    writers cannot select the same sibling.
+ * 2. **A leaked scratch file survives the failure that created it.** Without a `finally`, a throw
+ *    between write and rename leaves a `.tmp` next to the real file forever — and the next reader
+ *    that globs the directory sees it.
+ * 3. **Atomic is not durable.** `rename` is atomic *within* the filesystem: a reader sees the old
+ *    file or the new one, never a torn one. It says nothing about surviving power loss. Callers that
+ *    need the bytes on the platter after a crash pass `fsync: true`, which costs a real disk round
+ *    trip and is therefore opt-in rather than the default.
+ *
+ * **The scratch sits beside the target, deliberately, not in `os.tmpdir()`.** `rename` is only
+ * atomic within one filesystem; a scratch on a different mount degrades to copy-then-delete and
+ * loses the property the primitive is named for.
+ *
+ * The async surface is primary because most callers are already inside `await` paths — several
+ * inside daemon transaction commits, where switching to sync would be a behaviour change rather than
+ * a refactor. {@link writeFileAtomicSync} exists for the callers that genuinely are synchronous.
+ */
+
+/**
+ * @summary Builds the unique scratch sibling path for a target.
+ * @param {String} absolute Absolute target path.
+ * @returns {String}
+ * @private
+ */
+function scratchPathFor(absolute) {
+    return `${absolute}.${process.pid}.${randomUUID()}.tmp`
+}
+
+/**
+ * @summary Writes a file through a unique sibling and an atomic rename.
+ * @param {String} filePath Target path; relative paths resolve against `process.cwd()`.
+ * @param {String|Buffer} content
+ * @param {Object} [options]
+ * @param {String} [options.encoding='utf8']
+ * @param {Number} [options.mode=0o600] Mode for the scratch file, inherited by the target on rename.
+ * @param {Boolean} [options.fsync=false] Also flush the file and its directory to disk before
+ * returning. Atomic without it; durable across power loss with it.
+ * @param {Object} [options.fsModule=fsPromises] Injection seam for tests and for callers that hold a
+ * pre-bound fs module.
+ * @returns {Promise<String>} The absolute path written.
+ */
+export async function writeFileAtomic(filePath, content, options = {}) {
+    const {
+        encoding = 'utf8',
+        fsModule = fsPromises,
+        fsync    = false,
+        mode     = 0o600
+    } = options;
+
+    const absolute = path.resolve(filePath),
+          scratch  = scratchPathFor(absolute);
+
+    await fsModule.mkdir(path.dirname(absolute), {recursive: true});
+
+    try {
+        // `flag: 'wx'` fails loud if the scratch somehow exists rather than silently adopting it —
+        // with a UUID in the name that should be impossible, so a throw here is a real signal.
+        await fsModule.writeFile(scratch, content, {encoding, flag: 'wx', mode});
+
+        if (fsync) {
+            await fsyncPath(scratch, fsModule)
+        }
+
+        await fsModule.rename(scratch, absolute);
+
+        if (fsync) {
+            // The rename itself is a directory mutation; flushing the file alone leaves the
+            // directory entry unflushed, so a crash can lose the name while keeping the bytes.
+            await fsyncPath(path.dirname(absolute), fsModule)
+        }
+    } finally {
+        // Runs on the success path too, where the scratch no longer exists — `force` makes that a
+        // no-op rather than a second failure mode.
+        await fsModule.rm(scratch, {force: true}).catch(() => {})
+    }
+
+    return absolute
+}
+
+/**
+ * @summary Flushes one path to disk, tolerating fs modules without an `open` seam.
+ * @param {String} target
+ * @param {Object} fsModule
+ * @returns {Promise<void>}
+ * @private
+ */
+async function fsyncPath(target, fsModule) {
+    if (typeof fsModule.open !== 'function') return;
+
+    let handle = null;
+
+    try {
+        handle = await fsModule.open(target, 'r');
+        await handle.sync()
+    } catch (error) {
+        // A directory fsync is not permitted on every platform (Windows notably). The rename has
+        // already happened and is atomic; only the durability upgrade is unavailable, so this must
+        // not fail the write.
+        if (error?.code !== 'EPERM' && error?.code !== 'EISDIR' && error?.code !== 'EBADF') throw error
+    } finally {
+        await handle?.close().catch(() => {})
+    }
+}
+
+/**
+ * @summary Synchronous {@link writeFileAtomic}, for callers that genuinely are synchronous.
+ * @param {String} filePath Target path; relative paths resolve against `process.cwd()`.
+ * @param {String|Buffer} content
+ * @param {Object} [options]
+ * @param {String} [options.encoding='utf8']
+ * @param {Number} [options.mode=0o600]
+ * @param {Boolean} [options.fsync=false]
+ * @param {Object} [options.fsModule=fs] Injection seam; the SYNC fs surface, not `fs/promises`.
+ * @returns {String} The absolute path written.
+ */
+export function writeFileAtomicSync(filePath, content, options = {}) {
+    const {
+        encoding = 'utf8',
+        fsModule = fs,
+        fsync    = false,
+        mode     = 0o600
+    } = options;
+
+    const absolute = path.resolve(filePath),
+          scratch  = scratchPathFor(absolute);
+
+    fsModule.mkdirSync(path.dirname(absolute), {recursive: true});
+
+    try {
+        fsModule.writeFileSync(scratch, content, {encoding, flag: 'wx', mode});
+
+        if (fsync) {
+            fsyncPathSync(scratch, fsModule)
+        }
+
+        fsModule.renameSync(scratch, absolute);
+
+        if (fsync) {
+            fsyncPathSync(path.dirname(absolute), fsModule)
+        }
+    } finally {
+        try { fsModule.rmSync(scratch, {force: true}) } catch {}
+    }
+
+    return absolute
+}
+
+/**
+ * @summary Synchronous {@link fsyncPath}.
+ * @param {String} target
+ * @param {Object} fsModule
+ * @returns {void}
+ * @private
+ */
+function fsyncPathSync(target, fsModule) {
+    if (typeof fsModule.openSync !== 'function') return;
+
+    let fd = null;
+
+    try {
+        fd = fsModule.openSync(target, 'r');
+        fsModule.fsyncSync(fd)
+    } catch (error) {
+        if (error?.code !== 'EPERM' && error?.code !== 'EISDIR' && error?.code !== 'EBADF') throw error
+    } finally {
+        if (fd !== null) {
+            try { fsModule.closeSync(fd) } catch {}
+        }
+    }
+}

--- a/ai/services/shared/atomicFileWrite.mjs
+++ b/ai/services/shared/atomicFileWrite.mjs
@@ -47,11 +47,13 @@ function scratchPathFor(absolute) {
  * @param {Object} [options]
  * @param {String} [options.encoding='utf8']
  * @param {Number} [options.mode=0o600] Mode for the scratch file, inherited by the target on rename.
- * @param {Boolean} [options.fsync=false] Also flush the file and its directory to disk before
- * returning. Atomic without it; durable across power loss with it.
+ * @param {Boolean} [options.fsync=false] Flush the file AND every directory entry this call created,
+ * in the order `write → file sync → rename → directory sync`. **Strict**: if any required flush
+ * cannot be performed, this THROWS rather than resolving. See the durability note below.
  * @param {Object} [options.fsModule=fsPromises] Injection seam for tests and for callers that hold a
  * pre-bound fs module.
  * @returns {Promise<String>} The absolute path written.
+ * @throws {Error} When `fsync:true` and any required flush is unavailable or fails.
  */
 export async function writeFileAtomic(filePath, content, options = {}) {
     const {
@@ -61,10 +63,14 @@ export async function writeFileAtomic(filePath, content, options = {}) {
         mode     = 0o600
     } = options;
 
-    const absolute = path.resolve(filePath),
-          scratch  = scratchPathFor(absolute);
+    const absolute  = path.resolve(filePath),
+          directory = path.dirname(absolute),
+          scratch   = scratchPathFor(absolute);
 
-    await fsModule.mkdir(path.dirname(absolute), {recursive: true});
+    // `recursive: true` returns the FIRST directory it created, or undefined when none were. That is
+    // the anchor for durability: flushing only the leaf leaves every newly created ancestor entry
+    // unflushed, so a crash could lose the whole chain while the leaf's own bytes survived.
+    const firstCreatedDir = await fsModule.mkdir(directory, {recursive: true});
 
     try {
         // `flag: 'wx'` fails loud if the scratch somehow exists rather than silently adopting it —
@@ -78,9 +84,11 @@ export async function writeFileAtomic(filePath, content, options = {}) {
         await fsModule.rename(scratch, absolute);
 
         if (fsync) {
-            // The rename itself is a directory mutation; flushing the file alone leaves the
-            // directory entry unflushed, so a crash can lose the name while keeping the bytes.
-            await fsyncPath(path.dirname(absolute), fsModule)
+            // The rename is a DIRECTORY mutation; flushing the file alone leaves the directory entry
+            // unflushed, so a crash can lose the name while keeping the bytes.
+            for (const dir of directoryChainToFlush(directory, firstCreatedDir)) {
+                await fsyncPath(dir, fsModule)
+            }
         }
     } finally {
         // Runs on the success path too, where the scratch no longer exists — `force` makes that a
@@ -92,25 +100,61 @@ export async function writeFileAtomic(filePath, content, options = {}) {
 }
 
 /**
- * @summary Flushes one path to disk, tolerating fs modules without an `open` seam.
+ * @summary The directories whose entries must be flushed: the target's own directory, plus every
+ * ancestor this call created, deepest first.
+ * @param {String} directory Absolute directory holding the target.
+ * @param {String|undefined} firstCreatedDir `mkdir(recursive)`'s return — the shallowest new dir.
+ * @returns {String[]}
+ * @private
+ */
+function directoryChainToFlush(directory, firstCreatedDir) {
+    const chain = [directory];
+
+    if (typeof firstCreatedDir !== 'string' || firstCreatedDir.length === 0) return chain;
+
+    // Walk up from the target's directory to the shallowest directory this call created, and include
+    // that one's PARENT too — the parent is where the new chain's top entry actually appears.
+    let current = directory;
+
+    while (current !== firstCreatedDir && path.dirname(current) !== current) {
+        current = path.dirname(current);
+        chain.push(current)
+    }
+
+    const parentOfNewChain = path.dirname(firstCreatedDir);
+
+    if (!chain.includes(parentOfNewChain)) chain.push(parentOfNewChain);
+
+    return chain
+}
+
+/**
+ * @summary Flushes one path to disk. STRICT — a missing seam or a failed sync throws.
+ *
+ * The earlier version returned early when `fsModule.open` was absent and swallowed `EPERM`/`EISDIR`/
+ * `EBADF`, so `fsync:true` could resolve having performed **zero** flushes while the contract
+ * promised power-loss durability. A durability option that reports success without doing the work is
+ * worse than no option, because callers stop carrying their own flush.
+ *
+ * The platform concern that motivated the tolerance is real — directory `fsync` is not permitted
+ * everywhere — but the honest response is to FAIL a requested guarantee we cannot provide, not to
+ * report it as delivered. `fsync` is opt-in, so no caller pays for this unless it asked.
  * @param {String} target
  * @param {Object} fsModule
  * @returns {Promise<void>}
+ * @throws {Error} When the seam is missing or the flush fails.
  * @private
  */
 async function fsyncPath(target, fsModule) {
-    if (typeof fsModule.open !== 'function') return;
+    if (typeof fsModule.open !== 'function') {
+        throw new Error(`atomicFileWrite: fsync was requested but this fs module exposes no "open"; refusing to report "${target}" as durable.`)
+    }
 
     let handle = null;
 
     try {
         handle = await fsModule.open(target, 'r');
         await handle.sync()
-    } catch (error) {
-        // A directory fsync is not permitted on every platform (Windows notably). The rename has
-        // already happened and is atomic; only the durability upgrade is unavailable, so this must
-        // not fail the write.
-        if (error?.code !== 'EPERM' && error?.code !== 'EISDIR' && error?.code !== 'EBADF') throw error
     } finally {
         await handle?.close().catch(() => {})
     }
@@ -123,9 +167,11 @@ async function fsyncPath(target, fsModule) {
  * @param {Object} [options]
  * @param {String} [options.encoding='utf8']
  * @param {Number} [options.mode=0o600]
- * @param {Boolean} [options.fsync=false]
+ * @param {Boolean} [options.fsync=false] Same STRICT contract as {@link writeFileAtomic}: throws
+ * rather than resolving when a required flush is unavailable or fails.
  * @param {Object} [options.fsModule=fs] Injection seam; the SYNC fs surface, not `fs/promises`.
  * @returns {String} The absolute path written.
+ * @throws {Error} When `fsync:true` and any required flush is unavailable or fails.
  */
 export function writeFileAtomicSync(filePath, content, options = {}) {
     const {
@@ -135,10 +181,11 @@ export function writeFileAtomicSync(filePath, content, options = {}) {
         mode     = 0o600
     } = options;
 
-    const absolute = path.resolve(filePath),
-          scratch  = scratchPathFor(absolute);
+    const absolute  = path.resolve(filePath),
+          directory = path.dirname(absolute),
+          scratch   = scratchPathFor(absolute);
 
-    fsModule.mkdirSync(path.dirname(absolute), {recursive: true});
+    const firstCreatedDir = fsModule.mkdirSync(directory, {recursive: true});
 
     try {
         fsModule.writeFileSync(scratch, content, {encoding, flag: 'wx', mode});
@@ -150,7 +197,9 @@ export function writeFileAtomicSync(filePath, content, options = {}) {
         fsModule.renameSync(scratch, absolute);
 
         if (fsync) {
-            fsyncPathSync(path.dirname(absolute), fsModule)
+            for (const dir of directoryChainToFlush(directory, firstCreatedDir)) {
+                fsyncPathSync(dir, fsModule)
+            }
         }
     } finally {
         try { fsModule.rmSync(scratch, {force: true}) } catch {}
@@ -160,22 +209,24 @@ export function writeFileAtomicSync(filePath, content, options = {}) {
 }
 
 /**
- * @summary Synchronous {@link fsyncPath}.
+ * @summary Synchronous {@link fsyncPath}. STRICT for the same reason — a missing `openSync`/
+ * `fsyncSync` seam or a failed flush throws rather than letting the caller believe it got durability.
  * @param {String} target
  * @param {Object} fsModule
  * @returns {void}
+ * @throws {Error} When the seam is missing or the flush fails.
  * @private
  */
 function fsyncPathSync(target, fsModule) {
-    if (typeof fsModule.openSync !== 'function') return;
+    if (typeof fsModule.openSync !== 'function' || typeof fsModule.fsyncSync !== 'function') {
+        throw new Error(`atomicFileWrite: fsync was requested but this fs module exposes no "openSync"/"fsyncSync"; refusing to report "${target}" as durable.`)
+    }
 
     let fd = null;
 
     try {
         fd = fsModule.openSync(target, 'r');
         fsModule.fsyncSync(fd)
-    } catch (error) {
-        if (error?.code !== 'EPERM' && error?.code !== 'EISDIR' && error?.code !== 'EBADF') throw error
     } finally {
         if (fd !== null) {
             try { fsModule.closeSync(fd) } catch {}

--- a/ai/services/shared/atomicFileWrite.mjs
+++ b/ai/services/shared/atomicFileWrite.mjs
@@ -150,13 +150,29 @@ async function fsyncPath(target, fsModule) {
         throw new Error(`atomicFileWrite: fsync was requested but this fs module exposes no "open"; refusing to report "${target}" as durable.`)
     }
 
-    let handle = null;
+    let opened = null;
 
     try {
-        handle = await fsModule.open(target, 'r');
-        await handle.sync()
+        opened = await fsModule.open(target, 'r');
+
+        // Two shapes reach here and both are legitimate. `fs/promises.open` resolves a FileHandle
+        // carrying `.sync()`/`.close()`. Promisified/fd-style modules — which the lease-renewal
+        // callers inject for testability — resolve a NUMBER, and flush via `fsModule.fsync(fd)`.
+        // Supporting only the FileHandle shape would crash those callers on the flush path, which is
+        // the opposite of what a durability option is for.
+        if (typeof opened?.sync === 'function') {
+            await opened.sync()
+        } else if (typeof fsModule.fsync === 'function') {
+            await fsModule.fsync(opened)
+        } else {
+            throw new Error(`atomicFileWrite: fsync was requested but this fs module's "open" returned no FileHandle and it exposes no "fsync"; refusing to report "${target}" as durable.`)
+        }
     } finally {
-        await handle?.close().catch(() => {})
+        if (typeof opened?.close === 'function') {
+            await opened.close().catch(() => {})
+        } else if (opened !== null && typeof fsModule.close === 'function') {
+            await Promise.resolve(fsModule.close(opened)).catch(() => {})
+        }
     }
 }
 

--- a/ai/services/shared/providerActivityStatusStore.mjs
+++ b/ai/services/shared/providerActivityStatusStore.mjs
@@ -136,6 +136,11 @@ export function createProviderActivityStatusWriter({dbPath, recorder, now = Date
                                 throw new Error('providerActivityStatusStore: status merge guard ownership lost');
                             }
 
+                            // DELIBERATELY NOT the shared write-temp-then-rename primitive. The
+                            // ownership check directly above is the only thing that binds this
+                            // effect, and it must sit BETWEEN the scratch write and the rename. The
+                            // primitive collapses those into one call, which would delete the fence
+                            // and let a holder that has already lost the guard publish its merge.
                             await fs.promises.rename(temp, file);
                         } finally {
                             await fs.promises.unlink(temp).catch(() => {});

--- a/ai/services/shared/providerActivityStatusStore.mjs
+++ b/ai/services/shared/providerActivityStatusStore.mjs
@@ -141,7 +141,7 @@ export function createProviderActivityStatusWriter({dbPath, recorder, now = Date
                             // effect, and it must sit BETWEEN the scratch write and the rename. The
                             // primitive collapses those into one call, which would delete the fence
                             // and let a holder that has already lost the guard publish its merge.
-                            await fs.promises.rename(temp, file);
+                            await fs.promises.rename(temp, file); // atomic-write-ok: guard-ownership re-verify must fence between write and rename
                         } finally {
                             await fs.promises.unlink(temp).catch(() => {});
                         }

--- a/buildScripts/util/check-atomic-write-shape.mjs
+++ b/buildScripts/util/check-atomic-write-shape.mjs
@@ -1,0 +1,168 @@
+#!/usr/bin/env node
+import {execSync, spawnSync} from 'child_process';
+import {readFileSync}        from 'fs';
+import path                  from 'path';
+import {fileURLToPath}       from 'url';
+import {codeMask}            from './check-aiconfig-test-mutation.mjs';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname  = path.dirname(__filename);
+const scriptRoot = path.resolve(__dirname, '../..');
+
+/**
+ * Inline relief valve for a write-then-rename pair that legitimately stays hand-rolled. A line
+ * carrying this marker is skipped, and the marker is required to carry a reason after the colon —
+ * an unexplained escape is a silent licence.
+ */
+export const ESCAPE_MARKER = 'atomic-write-ok';
+
+/*
+ * The SHAPE, not the verb.
+ *
+ * `rg -l "renameSync\(" ai` over-counts in three distinct ways, every one of which is a legitimate
+ * caller this guard must stay silent about:
+ *
+ *   1. LOG ROTATION      — `renameSync(logFile, `${logFile}.${day}`)`. Moves an existing file; there
+ *                          is no scratch and nothing was written to `logFile` first.
+ *   2. PLAIN RELOCATION  — the issue/PR syncers moving a file to its corrected path.
+ *   3. A DIRECTORY MUTEX — `lifecycleGuard` renames a staging DIRECTORY onto the guard path, and the
+ *                          rename FAILING is the mutual exclusion. The write inside it targets a file
+ *                          within the staging dir, never the renamed path itself.
+ *
+ * A guard keyed on `rename` would flag all three. So the predicate is a PAIR: some earlier call in
+ * the same file writes to a name, and a later `rename` promotes that SAME name. That is the
+ * write-temp-then-rename shape and nothing else matches it.
+ *
+ * What this deliberately does NOT do is prove the pair is wrong. Five of the six known hand-rolled
+ * survivors are correct — each runs a fence (lease re-assert, guard-ownership re-verify, deadline
+ * assertion, staged-manifest validation) BETWEEN the write and the rename, which the primitive
+ * cannot express because it owns both ends. Those carry the escape marker with their reason, which
+ * is what turns "an explicit documented reason" from a promise into a checkable one.
+ */
+const WRITE_CALLS  = '(?:writeFile|writeFileSync|outputFile|outputFileSync|outputJson|outputJsonSync|appendFile|appendFileSync)',
+      RENAME_CALLS = '(?:rename|renameSync)',
+      IDENTIFIER   = '[A-Za-z_$][\\w$]*';
+
+export const WRITE_TO_SCRATCH = new RegExp(`(?<![\\w$])${WRITE_CALLS}\\s*\\(\\s*(${IDENTIFIER})\\b`);
+export const RENAME_OF_NAME   = new RegExp(`(?<![\\w$])${RENAME_CALLS}\\s*\\(\\s*(${IDENTIFIER})\\s*,`);
+
+/**
+ * @summary Finds write-temp-then-rename pairs: a name written to, then renamed away.
+ *
+ * Both halves must sit in executable code — the mask is shared with the sibling AiConfig guard so a
+ * pair quoted inside a string, a comment, or a template quasi is not a hit. That matters more than
+ * it looks: `generateOpenCodeSeatConfig.mjs` EMITS this exact pair as generated plugin source, and a
+ * scanner without the mask would flag the generator for the code it writes rather than the code it
+ * runs.
+ * @param {String} content
+ * @returns {Object[]} `[{line, name, text}]`, one per offending rename (1-based lines).
+ */
+export function findWriteThenRenamePairs(content) {
+    const lines   = content.split('\n'),
+          state   = {source: content},
+          written = new Map(),
+          hits    = [];
+
+    lines.forEach((line, index) => {
+        const mask = codeMask(line, state, index);
+
+        const writeMatch = line.match(WRITE_TO_SCRATCH);
+        if (writeMatch && mask[writeMatch.index]) {
+            written.set(writeMatch[1], index + 1)
+        }
+
+        if (line.includes(ESCAPE_MARKER)) return;
+
+        const renameMatch = line.match(RENAME_OF_NAME);
+        if (renameMatch && mask[renameMatch.index] && written.has(renameMatch[1])) {
+            hits.push({line: index + 1, name: renameMatch[1], text: line.trim()})
+        }
+    });
+
+    return hits
+}
+
+/**
+ * @summary Normalizes an input path to a repo-relative POSIX path.
+ * @param {String} file
+ * @param {String} gitRoot
+ * @returns {String}
+ */
+export function toRepoRelative(file, gitRoot) {
+    return path.relative(gitRoot, path.resolve(gitRoot, file)).split(path.sep).join('/')
+}
+
+function main() {
+    let gitRoot;
+    try {
+        gitRoot = execSync('git rev-parse --show-toplevel', {cwd: scriptRoot, encoding: 'utf-8'}).trim();
+    } catch {
+        console.error('\x1b[31mError: Could not determine git repository root.\x1b[0m');
+        process.exit(1);
+    }
+
+    const rawArgv   = process.argv.slice(2),
+          quiet     = rawArgv.includes('-q') || rawArgv.includes('--quiet'),
+          argvFiles = rawArgv.filter(arg => !arg.startsWith('-'));
+
+    function collectDefaultFiles() {
+        const result = spawnSync('find', ['ai', '-type', 'f', '-name', '*.mjs'], {cwd: gitRoot, encoding: 'utf-8'});
+        if (result.status !== 0) {
+            console.error('\x1b[31mError: find command failed.\x1b[0m');
+            process.exit(1);
+        }
+        return result.stdout.trim().split('\n').filter(Boolean);
+    }
+
+    const files = (argvFiles.length > 0 ? argvFiles : collectDefaultFiles())
+        .filter(file => file.endsWith('.mjs'))
+        .map(file => toRepoRelative(file, gitRoot))
+        .filter(file => file.startsWith('ai/'));
+
+    if (files.length === 0) {
+        console.log('check-atomic-write-shape: 0 ai .mjs files in scope, nothing to check.');
+        process.exit(0);
+    }
+
+    const violations = [];
+
+    for (const file of files) {
+        // The primitive itself IS the shape — exempting it by path rather than by marker keeps the
+        // implementation free of a marker that would read as a carve-out to anyone reading it.
+        if (file === 'ai/services/shared/atomicFileWrite.mjs') continue;
+
+        let content;
+        try {
+            content = readFileSync(path.resolve(gitRoot, file), 'utf-8');
+        } catch (e) {
+            console.error(`check-atomic-write-shape: could not read ${file}: ${e.message}`);
+            continue
+        }
+
+        findWriteThenRenamePairs(content).forEach(({line, name, text}) => {
+            violations.push(`${file}:${line}: [${name}] ${text}`)
+        });
+    }
+
+    if (violations.length > 0) {
+        console.error(`\x1b[31mcheck-atomic-write-shape: ${violations.length} hand-rolled write-temp-then-rename pair(s):\x1b[0m`);
+        if (!quiet) {
+            violations.forEach(violation => console.error('  ' + violation));
+            console.error('\nUse the owned primitive — `writeFileAtomic` / `writeFileAtomicSync` from');
+            console.error('`ai/services/shared/atomicFileWrite.mjs`. It owns the unique scratch, the cleanup on');
+            console.error('failure, and the opt-in fsync, which hand-rolled copies get wrong in that order.');
+            console.error(`\nIf a check must run BETWEEN the write and the rename (a lease re-assert, a guard`);
+            console.error(`ownership re-verify, a deadline assertion, a staged-artifact validation), the primitive`);
+            console.error(`cannot express it — keep the pair and add an "${ESCAPE_MARKER}: <reason>" marker on the`);
+            console.error('rename line stating which check needs that instant.');
+        }
+        process.exit(1);
+    }
+
+    console.log(`check-atomic-write-shape: ${files.length} ai .mjs file(s) scanned, 0 hand-rolled pairs.`);
+}
+
+const invokedDirectly = process.argv[1] && path.resolve(process.argv[1]) === __filename;
+if (invokedDirectly) {
+    main()
+}

--- a/buildScripts/util/check-atomic-write-shape.mjs
+++ b/buildScripts/util/check-atomic-write-shape.mjs
@@ -1,9 +1,9 @@
 #!/usr/bin/env node
+import * as acorn            from 'acorn';
 import {execSync, spawnSync} from 'child_process';
 import {readFileSync}        from 'fs';
 import path                  from 'path';
 import {fileURLToPath}       from 'url';
-import {codeMask}            from './check-aiconfig-test-mutation.mjs';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname  = path.dirname(__filename);
@@ -39,47 +39,107 @@ export const ESCAPE_MARKER = 'atomic-write-ok';
  * cannot express because it owns both ends. Those carry the escape marker with their reason, which
  * is what turns "an explicit documented reason" from a promise into a checkable one.
  */
-const WRITE_CALLS  = '(?:writeFile|writeFileSync|outputFile|outputFileSync|outputJson|outputJsonSync|appendFile|appendFileSync)',
-      RENAME_CALLS = '(?:rename|renameSync)',
-      IDENTIFIER   = '[A-Za-z_$][\\w$]*';
-
-export const WRITE_TO_SCRATCH = new RegExp(`(?<![\\w$])${WRITE_CALLS}\\s*\\(\\s*(${IDENTIFIER})\\b`);
-export const RENAME_OF_NAME   = new RegExp(`(?<![\\w$])${RENAME_CALLS}\\s*\\(\\s*(${IDENTIFIER})\\s*,`);
+/**
+ * A call that CREATES or writes the scratch. Deliberately name-shaped rather than an allowlist of fs
+ * functions, because the first version of this guard used a fixed list and missed three real sites:
+ *
+ *   - `this._writeSynced(tempPath, record)` — a custom writer the list never had
+ *   - `fs.promises.open(tempPath, 'w')`     — the scratch is created by `open`, then written
+ *                                             through the returned HANDLE, so the name never
+ *                                             appears in a write call at all
+ *
+ * Matching the *shape of the name* covers all three and anything the next author invents.
+ */
+const CREATES_SCRATCH = /(?:^|[._])(?:write|output|append|open|create)/i,
+      RENAME_CALLEE   = /^(?:rename|renameSync)$/;
 
 /**
- * @summary Finds write-temp-then-rename pairs: a name written to, then renamed away.
+ * @summary Depth-first walk over an acorn AST.
+ * @param {Object} node
+ * @param {Function} visit
+ * @returns {void}
+ */
+function walk(node, visit) {
+    if (!node || typeof node !== 'object') return;
+
+    if (Array.isArray(node)) {
+        node.forEach(child => walk(child, visit));
+        return
+    }
+
+    if (typeof node.type === 'string') visit(node);
+
+    for (const key of Object.keys(node)) {
+        if (key === 'loc' || key === 'start' || key === 'end') continue;
+        walk(node[key], visit)
+    }
+}
+
+/**
+ * @summary The trailing identifier of a callee — `fs.promises.rename` -> `rename`.
+ * @param {Object} callee
+ * @returns {String}
+ */
+function calleeName(callee) {
+    if (!callee) return '';
+    if (callee.type === 'Identifier')       return callee.name;
+    if (callee.type === 'MemberExpression') return callee.property?.name ?? '';
+    return ''
+}
+
+/**
+ * @summary Finds write-temp-then-rename pairs: a name created or written, then renamed away.
  *
- * Both halves must sit in executable code — the mask is shared with the sibling AiConfig guard so a
- * pair quoted inside a string, a comment, or a template quasi is not a hit. That matters more than
- * it looks: `generateOpenCodeSeatConfig.mjs` EMITS this exact pair as generated plugin source, and a
- * scanner without the mask would flag the generator for the code it writes rather than the code it
- * runs.
+ * **Parsed, not scanned.** The first version matched line by line and therefore could not see a call
+ * whose arguments wrap across lines — ordinary formatting was a bypass. It also keyed the write half
+ * on a fixed list of fs functions, which missed a custom writer and two handle-based writes. Both
+ * misses shared one root: the detector's vocabulary was mistaken for the population, and a clean run
+ * meant "nothing I can see" rather than "nothing there".
+ *
+ * A parse also makes the string/comment exclusion structural rather than masked: a pair that only
+ * exists inside emitted plugin source (`generateOpenCodeSeatConfig` writes exactly this shape as
+ * generated text) is a string literal in the AST and is never a call.
  * @param {String} content
+ * @param {String} [file='<inline>'] For the parse-failure message.
  * @returns {Object[]} `[{line, name, text}]`, one per offending rename (1-based lines).
  */
-export function findWriteThenRenamePairs(content) {
+export function findWriteThenRenamePairs(content, file = '<inline>') {
+    let program;
+
+    try {
+        program = acorn.parse(content, {ecmaVersion: 'latest', sourceType: 'module', locations: true})
+    } catch (error) {
+        // Fail CLOSED. A file this guard cannot parse is a file it cannot clear.
+        throw new Error(`check-atomic-write-shape: ${file} did not parse: ${error.message}`)
+    }
+
     const lines   = content.split('\n'),
-          state   = {source: content},
-          written = new Map(),
-          hits    = [];
+          scratch = new Map(),
+          renames = [];
 
-    lines.forEach((line, index) => {
-        const mask = codeMask(line, state, index);
+    walk(program, node => {
+        if (node.type !== 'CallExpression') return;
 
-        const writeMatch = line.match(WRITE_TO_SCRATCH);
-        if (writeMatch && mask[writeMatch.index]) {
-            written.set(writeMatch[1], index + 1)
-        }
+        const name  = calleeName(node.callee),
+              first = node.arguments?.[0];
 
-        if (line.includes(ESCAPE_MARKER)) return;
+        if (first?.type !== 'Identifier') return;
 
-        const renameMatch = line.match(RENAME_OF_NAME);
-        if (renameMatch && mask[renameMatch.index] && written.has(renameMatch[1])) {
-            hits.push({line: index + 1, name: renameMatch[1], text: line.trim()})
+        if (RENAME_CALLEE.test(name)) {
+            renames.push({name: first.name, start: node.start, line: node.loc.start.line})
+        } else if (CREATES_SCRATCH.test(name)) {
+            const previous = scratch.get(first.name);
+            if (previous === undefined || node.start < previous) scratch.set(first.name, node.start)
         }
     });
 
-    return hits
+    return renames
+        .filter(({name, start}) => {
+            const createdAt = scratch.get(name);
+            return createdAt !== undefined && createdAt < start
+        })
+        .filter(({line}) => !lines[line - 1]?.includes(ESCAPE_MARKER))
+        .map(({name, line}) => ({line, name, text: lines[line - 1]?.trim() ?? ''}))
 }
 
 /**
@@ -139,7 +199,7 @@ function main() {
             continue
         }
 
-        findWriteThenRenamePairs(content).forEach(({line, name, text}) => {
+        findWriteThenRenamePairs(content, file).forEach(({line, name, text}) => {
             violations.push(`${file}:${line}: [${name}] ${text}`)
         });
     }

--- a/buildScripts/util/check-atomic-write-shape.mjs
+++ b/buildScripts/util/check-atomic-write-shape.mjs
@@ -174,10 +174,13 @@ function main() {
         return result.stdout.trim().split('\n').filter(Boolean);
     }
 
-    const files = (argvFiles.length > 0 ? argvFiles : collectDefaultFiles())
-        .filter(file => file.endsWith('.mjs'))
-        .map(file => toRepoRelative(file, gitRoot))
-        .filter(file => file.startsWith('ai/'));
+    // The `ai/` bound applies to the DEFAULT sweep, not to explicitly named files. A caller that
+    // passes a path has already chosen the scope — lint-staged passes its matched set, and a spec
+    // needs to check a fixture without planting it inside the tree a sibling spec is scanning. An
+    // earlier version filtered both, which forced the fixture under `ai/` and made the two specs race.
+    const files = argvFiles.length > 0
+        ? argvFiles.filter(file => file.endsWith('.mjs')).map(file => toRepoRelative(file, gitRoot))
+        : collectDefaultFiles().filter(file => file.endsWith('.mjs')).map(file => toRepoRelative(file, gitRoot));
 
     if (files.length === 0) {
         console.log('check-atomic-write-shape: 0 ai .mjs files in scope, nothing to check.');

--- a/package.json
+++ b/package.json
@@ -262,6 +262,9 @@
             "node ./buildScripts/util/check-aiconfig-test-mutation.mjs",
             "node ./buildScripts/util/check-derived-domain.mjs"
         ],
+        "ai/**/*.mjs": [
+            "node ./buildScripts/util/check-atomic-write-shape.mjs"
+        ],
         "{package.json,.husky/pre-commit,.github/workflows/*.yml,.github/workflows/*.yaml,ai/scripts/lint/lint-guard-ci-parity.mjs,ai/scripts/lint/guard-ci-parity-registry.json}": [
             "node ./ai/scripts/lint/lint-guard-ci-parity.mjs"
         ],

--- a/test/playwright/unit/ai/buildScripts/util/check-atomic-write-shape.spec.mjs
+++ b/test/playwright/unit/ai/buildScripts/util/check-atomic-write-shape.spec.mjs
@@ -75,6 +75,48 @@ test.describe('check-atomic-write-shape guard', () => {
         ].join('\n'))).toEqual([])
     });
 
+    /*
+     * @neo-gpt's re-review found the first version blind in three ways at once, and all three shared
+     * one root: it matched line by line against a fixed list of fs write functions, so its vocabulary
+     * was mistaken for the population. A clean run meant "nothing I can see".
+     */
+    test('MULTILINE: ordinary formatting is not a bypass', () => {
+        expect(findWriteThenRenamePairs([
+            'await writeFile(tmpPath, body);',
+            'await fs.rename(',
+            '    tmpPath,',
+            '    filePath',
+            ');'
+        ].join('\n')).length, 'wrapped rename arguments must still be seen').toBe(1);
+
+        expect(findWriteThenRenamePairs([
+            'await fs.writeFile(',
+            '    tmpPath,',
+            '    body',
+            ');',
+            'await fs.rename(tmpPath, filePath);'
+        ].join('\n')).length, 'a wrapped WRITE must still register the scratch').toBe(1)
+    });
+
+    test('a CUSTOM writer counts — the scratch does not have to be written by an fs function', () => {
+        // `receiverState._replace` writes through `this._writeSynced(tempPath, record)`. A fixed
+        // fs-function list never had it, so a live pair sat outside the census.
+        expect(findWriteThenRenamePairs([
+            'await this._writeSynced(tempPath, record);',
+            'await fs.rename(tempPath, recordPath);'
+        ].join('\n')).length).toBe(1)
+    });
+
+    test('a HANDLE-based write counts — the scratch is created by open(), then written through the handle', () => {
+        // `buildReceiverManifest` and `offHostSyncStore` never pass the scratch NAME to a write call
+        // at all; it reaches `open()` and everything after goes through the returned handle.
+        expect(findWriteThenRenamePairs([
+            "const handle = await fs.open(stagingPath, 'wx', 0o600);",
+            'await handle.writeFile(body);',
+            'await fs.rename(stagingPath, targetPath);'
+        ].join('\n')).length).toBe(1)
+    });
+
     test('honors the escape marker on the rename line', () => {
         const source = [
             'await writeFile(tmpPath, body);',

--- a/test/playwright/unit/ai/buildScripts/util/check-atomic-write-shape.spec.mjs
+++ b/test/playwright/unit/ai/buildScripts/util/check-atomic-write-shape.spec.mjs
@@ -1,6 +1,7 @@
 import {test, expect}                            from '@playwright/test';
 import {spawnSync}                               from 'node:child_process';
-import {mkdirSync, rmSync, writeFileSync}        from 'node:fs';
+import {mkdtempSync, rmSync, writeFileSync}      from 'node:fs';
+import {tmpdir}                                  from 'node:os';
 import path                                      from 'node:path';
 import process                                   from 'node:process';
 import {fileURLToPath}                           from 'node:url';
@@ -127,18 +128,17 @@ test.describe('check-atomic-write-shape guard', () => {
     });
 
     test('CLI: a hand-rolled pair fails the build', () => {
-        const checker    = path.join(repoRoot, 'buildScripts/util/check-atomic-write-shape.mjs'),
-              fixtureDir = path.join(repoRoot, `ai/.tmp-atomic-shape-${process.pid}`);
+        const checker = path.join(repoRoot, 'buildScripts/util/check-atomic-write-shape.mjs'),
+              // OUTSIDE the scanned tree on purpose: a sibling spec scans all of `ai/`, and Playwright
+              // runs them in parallel, so a fixture planted there made the two race.
+              fixtureDir = mkdtempSync(path.join(tmpdir(), 'atomic-shape-'));
 
-        mkdirSync(fixtureDir, {recursive: true});
-
-        const fixture = path.join(fixtureDir, 'fixture.mjs'),
-              rel     = path.relative(repoRoot, fixture).split(path.sep).join('/');
+        const fixture = path.join(fixtureDir, 'fixture.mjs');
 
         try {
             writeFileSync(fixture, "await writeFile(tmpPath, body);\nawait rename(tmpPath, filePath);\n");
 
-            const result = spawnSync(process.execPath, [checker, rel], {cwd: repoRoot, encoding: 'utf-8'});
+            const result = spawnSync(process.execPath, [checker, fixture], {cwd: repoRoot, encoding: 'utf-8'});
 
             expect(result.status, 'a hand-rolled pair must fail the build').toBe(1);
             expect(result.stderr).toContain('write-temp-then-rename');

--- a/test/playwright/unit/ai/buildScripts/util/check-atomic-write-shape.spec.mjs
+++ b/test/playwright/unit/ai/buildScripts/util/check-atomic-write-shape.spec.mjs
@@ -1,0 +1,116 @@
+import {test, expect}                            from '@playwright/test';
+import {spawnSync}                               from 'node:child_process';
+import {mkdirSync, rmSync, writeFileSync}        from 'node:fs';
+import path                                      from 'node:path';
+import process                                   from 'node:process';
+import {fileURLToPath}                           from 'node:url';
+import {ESCAPE_MARKER, findWriteThenRenamePairs} from '../../../../../../buildScripts/util/check-atomic-write-shape.mjs';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../../../../..');
+
+/**
+ * @summary Self-test for the write-temp-then-rename shape guard.
+ *
+ * The guard exists because the obvious predicate — grep for `rename` — is wrong in FOUR directions
+ * at once, and each direction is a real caller in this repo. The negative tests below are therefore
+ * the load-bearing ones: a guard that flags a log rotation, a file relocation, or a directory-rename
+ * mutex gets switched off, and a switched-off guard protects nothing.
+ */
+test.describe('check-atomic-write-shape guard', () => {
+    test('flags the PAIR: a name written to, then renamed away', () => {
+        const source = [
+            "const tmpPath = `${filePath}.tmp`;",
+            "await writeFile(tmpPath, body, 'utf8');",
+            'await rename(tmpPath, filePath);'
+        ].join('\n');
+
+        expect(findWriteThenRenamePairs(source).map(hit => hit.line)).toEqual([3])
+    });
+
+    test('flags every call spelling, including a DESTRUCTURED rename import', () => {
+        // The destructured form is why this guard exists rather than a verb grep: `\.rename\(` never
+        // matched `await rename(tmp, file)`, and four real sites hid behind exactly that.
+        const shapes = [
+            "writeFileSync(t, b); renameSync(t, f);",
+            "fs.outputJsonSync(t, b);\nfs.renameSync(t, f);",
+            "await fsModule.writeFile(t, b);\nawait fsModule.rename(t, f);",
+            "await writeFile(t, b);\nawait rename(t, f);"
+        ];
+
+        shapes.forEach(source => expect(findWriteThenRenamePairs(source).length, source).toBeGreaterThan(0))
+    });
+
+    test('does NOT flag LOG ROTATION — a move of an existing file, no scratch', () => {
+        expect(findWriteThenRenamePairs('fs.renameSync(logFile, `${logFile}.${fileDay}`);')).toEqual([])
+    });
+
+    test('does NOT flag a plain RELOCATION', () => {
+        expect(findWriteThenRenamePairs('await fs.rename(oldAbsolutePath, targetPath);')).toEqual([])
+    });
+
+    /*
+     * The subtlest negative. lifecycleGuard writes a file INSIDE a staging directory and renames the
+     * DIRECTORY — the rename failing is the mutual exclusion. The written name and the renamed name
+     * are different, so the pair predicate stays silent where a verb predicate would fire.
+     */
+    test('does NOT flag the directory-rename MUTEX', () => {
+        const source = [
+            'await fsModule.mkdir(stagingPath);',
+            "await fsModule.writeFile(path.join(stagingPath, ownerFileName), '', 'utf8');",
+            'await fsModule.rename(stagingPath, guardPath);'
+        ].join('\n');
+
+        expect(findWriteThenRenamePairs(source)).toEqual([])
+    });
+
+    test('does NOT flag a pair that lives in a string or a comment', () => {
+        expect(findWriteThenRenamePairs([
+            "const generated = 'await fs.writeFile(tmpPath, x);';",
+            "const more = 'await fs.rename(tmpPath, envelopePath);';"
+        ].join('\n'))).toEqual([]);
+
+        expect(findWriteThenRenamePairs([
+            '// await writeFile(tmpPath, x);',
+            '// await rename(tmpPath, filePath);'
+        ].join('\n'))).toEqual([])
+    });
+
+    test('honors the escape marker on the rename line', () => {
+        const source = [
+            'await writeFile(tmpPath, body);',
+            `await rename(tmpPath, filePath); // ${ESCAPE_MARKER}: assertHeld() must fence between write and rename`
+        ].join('\n');
+
+        expect(findWriteThenRenamePairs(source)).toEqual([])
+    });
+
+    test('CLI: a hand-rolled pair fails the build', () => {
+        const checker    = path.join(repoRoot, 'buildScripts/util/check-atomic-write-shape.mjs'),
+              fixtureDir = path.join(repoRoot, `ai/.tmp-atomic-shape-${process.pid}`);
+
+        mkdirSync(fixtureDir, {recursive: true});
+
+        const fixture = path.join(fixtureDir, 'fixture.mjs'),
+              rel     = path.relative(repoRoot, fixture).split(path.sep).join('/');
+
+        try {
+            writeFileSync(fixture, "await writeFile(tmpPath, body);\nawait rename(tmpPath, filePath);\n");
+
+            const result = spawnSync(process.execPath, [checker, rel], {cwd: repoRoot, encoding: 'utf-8'});
+
+            expect(result.status, 'a hand-rolled pair must fail the build').toBe(1);
+            expect(result.stderr).toContain('write-temp-then-rename');
+            expect(result.stdout).not.toContain('0 hand-rolled pairs')
+        } finally {
+            rmSync(fixtureDir, {recursive: true, force: true})
+        }
+    });
+
+    test('CLI: the live ai/ tree is clean — the migration is complete, not merely started', () => {
+        const checker = path.join(repoRoot, 'buildScripts/util/check-atomic-write-shape.mjs'),
+              result  = spawnSync(process.execPath, [checker], {cwd: repoRoot, encoding: 'utf-8'});
+
+        expect(result.status, result.stderr).toBe(0);
+        expect(result.stdout).toContain('0 hand-rolled pairs')
+    });
+});

--- a/test/playwright/unit/ai/scripts/lint/lintWorkflowScanRootParity.spec.mjs
+++ b/test/playwright/unit/ai/scripts/lint/lintWorkflowScanRootParity.spec.mjs
@@ -62,11 +62,9 @@ const REGISTRY = Object.freeze({
         surface  : ['test/**/*.mjs']
     },
     'atomic-write-shape-lint.yml': {
-        // The shared acorn `codeMask` lives in the AiConfig test-mutation guard, so a change THERE
-        // can change this lint's verdict — it is a scan surface, not just a neighbour.
         scriptRel: 'buildScripts/util/check-atomic-write-shape.mjs',
         source   : 'declared',
-        surface  : ['ai/**/*.mjs', 'buildScripts/util/check-aiconfig-test-mutation.mjs']
+        surface  : ['ai/**/*.mjs']
     },
     'config-template-ssot-lint.yml': {
         scriptRel: 'ai/scripts/lint/lint-config-template-ssot.mjs',

--- a/test/playwright/unit/ai/scripts/lint/lintWorkflowScanRootParity.spec.mjs
+++ b/test/playwright/unit/ai/scripts/lint/lintWorkflowScanRootParity.spec.mjs
@@ -61,6 +61,13 @@ const REGISTRY = Object.freeze({
         source   : 'declared',
         surface  : ['test/**/*.mjs']
     },
+    'atomic-write-shape-lint.yml': {
+        // The shared acorn `codeMask` lives in the AiConfig test-mutation guard, so a change THERE
+        // can change this lint's verdict — it is a scan surface, not just a neighbour.
+        scriptRel: 'buildScripts/util/check-atomic-write-shape.mjs',
+        source   : 'declared',
+        surface  : ['ai/**/*.mjs', 'buildScripts/util/check-aiconfig-test-mutation.mjs']
+    },
     'config-template-ssot-lint.yml': {
         scriptRel: 'ai/scripts/lint/lint-config-template-ssot.mjs',
         source   : 'imported',

--- a/test/playwright/unit/ai/services/shared/atomicFileWrite.spec.mjs
+++ b/test/playwright/unit/ai/services/shared/atomicFileWrite.spec.mjs
@@ -140,3 +140,141 @@ test.describe('writeFileAtomicSync (sync surface)', () => {
         expect(fs.readFileSync(path.join(workDir, 'sync-durable.txt'), 'utf8')).toBe('flushed')
     });
 });
+
+/**
+ * @summary The durability contract, proven by ORDER and by REFUSAL rather than by "the file exists".
+ *
+ * The first version of this suite asserted only that `fsync:true` produced the file — an outcome
+ * identical whether both flushes ran or neither did. @neo-gpt falsified it at exact head: an async
+ * seam whose `open` always threw `EBADF` resolved as success, and the sync surface resolved with a
+ * seam carrying no `openSync` at all. A durability option that reports success without doing the work
+ * is worse than no option, because callers stop carrying their own flush.
+ *
+ * So these assert the sequence `write → file sync → rename → directory sync` and every way it can
+ * fail. Deleting either flush call from the primitive fails the order tests below.
+ */
+test.describe('fsync contract — strict, ordered, and mutation-sensitive', () => {
+    /**
+     * @summary Wraps a real fs surface, recording ordered `[op, basename]` pairs and optionally
+     * failing one specific flush.
+     */
+    function recordingAsyncSeam({failFileSync = false, failDirSync = false, dropOpen = false} = {}) {
+        const calls = [];
+
+        const seam = {
+            ...fsPromises,
+            mkdir    : async (...args) => { calls.push(['mkdir', path.basename(args[0])]);     return fsPromises.mkdir(...args) },
+            writeFile: async (...args) => { calls.push(['writeFile', path.basename(args[0])]); return fsPromises.writeFile(...args) },
+            rename   : async (...args) => { calls.push(['rename', path.basename(args[1])]);    return fsPromises.rename(...args) },
+            rm       : async (...args) => fsPromises.rm(...args)
+        };
+
+        if (dropOpen) {
+            // `...fsPromises` above already spread a working `open` in, so the seam must have it
+            // DELETED to model a module without the capability. Omitting the wrapper is not enough —
+            // an earlier draft of this test did exactly that and passed against a real flush.
+            delete seam.open
+        } else {
+            seam.open = async (target, flags) => {
+                const isFile = target.endsWith('.tmp'),
+                      handle = await fsPromises.open(target, flags);
+
+                return {
+                    sync: async () => {
+                        calls.push([isFile ? 'fileSync' : 'dirSync', path.basename(target)]);
+
+                        if (isFile && failFileSync) throw new Error('probe: file sync refused');
+                        if (!isFile && failDirSync) throw new Error('probe: directory sync refused');
+
+                        return handle.sync()
+                    },
+                    close: () => handle.close()
+                }
+            }
+        }
+
+        return {seam, calls};
+    }
+
+    test('ORDER: write → file sync → rename → directory sync', async () => {
+        const target        = path.join(workDir, 'ordered.txt'),
+              {seam, calls} = recordingAsyncSeam();
+
+        await writeFileAtomic(target, 'ordered', {fsModule: seam, fsync: true});
+
+        const ops = calls.map(([op]) => op).filter(op => op !== 'mkdir');
+
+        expect(ops, 'the flush order is the whole durability guarantee').toEqual([
+            'writeFile', 'fileSync', 'rename', 'dirSync'
+        ]);
+
+        // The file flush targets the SCRATCH (pre-rename); the directory flush targets the directory.
+        expect(calls.find(([op]) => op === 'fileSync')[1].endsWith('.tmp')).toBe(true);
+        expect(calls.find(([op]) => op === 'dirSync')[1]).toBe(path.basename(workDir))
+    });
+
+    test('a missing open seam REFUSES rather than reporting durability it did not perform', async () => {
+        const {seam} = recordingAsyncSeam({dropOpen: true});
+
+        await expect(writeFileAtomic(path.join(workDir, 'no-seam.txt'), 'x', {fsModule: seam, fsync: true}))
+            .rejects.toThrow(/exposes no "open"/);
+    });
+
+    test('a failed PRE-RENAME file sync refuses, and the target is never created', async () => {
+        const target        = path.join(workDir, 'file-sync-fails.txt'),
+              {seam, calls} = recordingAsyncSeam({failFileSync: true});
+
+        await expect(writeFileAtomic(target, 'x', {fsModule: seam, fsync: true}))
+            .rejects.toThrow('probe: file sync refused');
+
+        expect(fs.existsSync(target), 'refusing before the rename means nothing was published').toBe(false);
+        expect(calls.map(([op]) => op)).not.toContain('rename');
+        expect(scratchLeftIn(workDir)).toEqual([])
+    });
+
+    test('a failed POST-RENAME directory sync refuses — the write is committed but NOT durable', async () => {
+        const target        = path.join(workDir, 'dir-sync-fails.txt'),
+              {seam, calls} = recordingAsyncSeam({failDirSync: true});
+
+        await expect(writeFileAtomic(target, 'committed', {fsModule: seam, fsync: true}))
+            .rejects.toThrow('probe: directory sync refused');
+
+        // This is the honest, documented asymmetry: the rename ALREADY happened, so the content is
+        // visible. The throw says "you asked for durable and did not get it", not "nothing happened".
+        expect(calls.map(([op]) => op)).toContain('rename');
+        expect(fs.readFileSync(target, 'utf8')).toBe('committed');
+        expect(scratchLeftIn(workDir)).toEqual([])
+    });
+
+    test('NESTED: every directory this call created is flushed, not just the leaf', async () => {
+        const target        = path.join(workDir, 'p', 'q', 'r', 'deep.txt'),
+              {seam, calls} = recordingAsyncSeam();
+
+        await writeFileAtomic(target, 'deep', {fsModule: seam, fsync: true});
+
+        const flushed = calls.filter(([op]) => op === 'dirSync').map(([, name]) => name);
+
+        expect(flushed, 'flushing only the leaf leaves new ancestor entries unflushed').toEqual(
+            expect.arrayContaining(['r', 'q', 'p'])
+        );
+    });
+
+    test('SYNC surface: a seam without openSync/fsyncSync refuses instead of silently skipping', () => {
+        const {openSync, fsyncSync, ...withoutFlushSeam} = fs;
+
+        expect(() => writeFileAtomicSync(path.join(workDir, 'sync-no-seam.txt'), 'x', {
+            fsModule: withoutFlushSeam, fsync: true
+        })).toThrow(/exposes no "openSync"\/"fsyncSync"/);
+    });
+
+    test('SYNC surface: a failed file sync refuses and publishes nothing', () => {
+        const target  = path.join(workDir, 'sync-flush-fails.txt'),
+              failing = {...fs, fsyncSync: () => { throw new Error('probe: sync flush refused') }};
+
+        expect(() => writeFileAtomicSync(target, 'x', {fsModule: failing, fsync: true}))
+            .toThrow('probe: sync flush refused');
+
+        expect(fs.existsSync(target)).toBe(false);
+        expect(scratchLeftIn(workDir)).toEqual([])
+    });
+});

--- a/test/playwright/unit/ai/services/shared/atomicFileWrite.spec.mjs
+++ b/test/playwright/unit/ai/services/shared/atomicFileWrite.spec.mjs
@@ -313,6 +313,75 @@ test.describe('fsync contract — strict, ordered, and mutation-sensitive', () =
         })).toThrow(/exposes no "openSync"\/"fsyncSync"/);
     });
 
+    /**
+     * @summary Sync twin of the recording seam.
+     *
+     * These exist because @neo-gpt's re-review found the async proof did not cover the sync surface:
+     * deleting the sync post-rename directory flush left all 21 tests green. Mutation-sensitivity
+     * proven on one surface says nothing about the other, and the untested half is the half that
+     * silently stops flushing.
+     */
+    function recordingSyncSeam({failDirSync = false} = {}) {
+        const calls  = [],
+              isFile = new Map();
+
+        const seam = {
+            ...fs,
+            mkdirSync    : (...args) => { calls.push(['mkdir', path.basename(args[0])]);     return fs.mkdirSync(...args) },
+            writeFileSync: (...args) => { calls.push(['writeFile', path.basename(args[0])]); return fs.writeFileSync(...args) },
+            renameSync   : (...args) => { calls.push(['rename', path.basename(args[1])]);    return fs.renameSync(...args) },
+            openSync     : (target, flags) => {
+                const fd = fs.openSync(target, flags);
+                isFile.set(fd, target.endsWith('.tmp'));
+                return fd
+            },
+            fsyncSync: fd => {
+                const fileFlush = isFile.get(fd);
+                calls.push([fileFlush ? 'fileSync' : 'dirSync', String(fd)]);
+
+                if (!fileFlush && failDirSync) throw new Error('probe: sync directory flush refused');
+
+                return fs.fsyncSync(fd)
+            }
+        };
+
+        return {seam, calls}
+    }
+
+    test('SYNC ORDER: write → file sync → rename → directory sync', () => {
+        const target        = path.join(workDir, 'sync-ordered.txt'),
+              {seam, calls} = recordingSyncSeam();
+
+        writeFileAtomicSync(target, 'ordered', {fsModule: seam, fsync: true});
+
+        expect(calls.map(([op]) => op).filter(op => op !== 'mkdir'))
+            .toEqual(['writeFile', 'fileSync', 'rename', 'dirSync']);
+        expect(fs.readFileSync(target, 'utf8')).toBe('ordered')
+    });
+
+    test('SYNC: a failed POST-RENAME directory sync refuses — committed but NOT durable', () => {
+        const target        = path.join(workDir, 'sync-dir-fails.txt'),
+              {seam, calls} = recordingSyncSeam({failDirSync: true});
+
+        expect(() => writeFileAtomicSync(target, 'committed', {fsModule: seam, fsync: true}))
+            .toThrow('probe: sync directory flush refused');
+
+        // Same asymmetry the async surface pins: the rename already landed, so the content IS
+        // visible. The throw reports a missing durability upgrade, never a rollback.
+        expect(calls.map(([op]) => op)).toContain('rename');
+        expect(fs.readFileSync(target, 'utf8')).toBe('committed');
+        expect(scratchLeftIn(workDir)).toEqual([])
+    });
+
+    test('SYNC NESTED: every directory this call created is flushed, not just the leaf', () => {
+        const target        = path.join(workDir, 'sy', 'nc', 'deep.txt'),
+              {seam, calls} = recordingSyncSeam();
+
+        writeFileAtomicSync(target, 'deep', {fsModule: seam, fsync: true});
+
+        expect(calls.filter(([op]) => op === 'dirSync').length).toBeGreaterThan(1)
+    });
+
     test('SYNC surface: a failed file sync refuses and publishes nothing', () => {
         const target  = path.join(workDir, 'sync-flush-fails.txt'),
               failing = {...fs, fsyncSync: () => { throw new Error('probe: sync flush refused') }};

--- a/test/playwright/unit/ai/services/shared/atomicFileWrite.spec.mjs
+++ b/test/playwright/unit/ai/services/shared/atomicFileWrite.spec.mjs
@@ -259,6 +259,52 @@ test.describe('fsync contract — strict, ordered, and mutation-sensitive', () =
         );
     });
 
+    test('FD-STYLE seam: an fs module whose open resolves a NUMBER flushes via fsModule.fsync', async () => {
+        const target = path.join(workDir, 'fd-style.txt'),
+              synced = [];
+
+        // The shape the lease-renewal callers inject: open -> fd number, fsync(fd), close(fd).
+        // The real handle is retained so `close` can release it — returning only `.fd` and dropping
+        // the handle leaks it to GC, which Node now treats as an error.
+        const handles = new Map();
+
+        const fdSeam = {
+            ...fsPromises,
+            open : async (file, flags) => {
+                const handle = await fsPromises.open(file, flags);
+                handles.set(handle.fd, handle);
+                return handle.fd
+            },
+            fsync: async fd => { synced.push(fd) },
+            close: async fd => { await handles.get(fd)?.close(); handles.delete(fd) }
+        };
+
+        await writeFileAtomic(target, 'fd-flushed', {fsModule: fdSeam, fsync: true});
+
+        expect(fs.readFileSync(target, 'utf8')).toBe('fd-flushed');
+        expect(synced.length, 'file flush + directory flush both routed through fsModule.fsync').toBe(2)
+    });
+
+    test('FD-STYLE seam WITHOUT fsync refuses rather than reporting durability', async () => {
+        const handles = new Map();
+
+        const noFsyncSeam = {
+            ...fsPromises,
+            open : async (file, flags) => {
+                const handle = await fsPromises.open(file, flags);
+                handles.set(handle.fd, handle);
+                return handle.fd
+            },
+            close: async fd => { await handles.get(fd)?.close(); handles.delete(fd) }
+        };
+
+        delete noFsyncSeam.fsync;
+
+        await expect(writeFileAtomic(path.join(workDir, 'fd-no-fsync.txt'), 'x', {
+            fsModule: noFsyncSeam, fsync: true
+        })).rejects.toThrow(/exposes no "fsync"/);
+    });
+
     test('SYNC surface: a seam without openSync/fsyncSync refuses instead of silently skipping', () => {
         const {openSync, fsyncSync, ...withoutFlushSeam} = fs;
 

--- a/test/playwright/unit/ai/services/shared/atomicFileWrite.spec.mjs
+++ b/test/playwright/unit/ai/services/shared/atomicFileWrite.spec.mjs
@@ -1,0 +1,142 @@
+import {test, expect}                         from '@playwright/test'
+import fs                                     from 'fs'
+import fsPromises                             from 'fs/promises'
+import os                                     from 'os'
+import path                                   from 'path'
+import {writeFileAtomic, writeFileAtomicSync} from '../../../../../../ai/services/shared/atomicFileWrite.mjs'
+
+/**
+ * @summary Contract suite for the owned write-temp-then-rename primitive.
+ *
+ * The load-bearing tests are the ones a hand-rolled copy FAILS: concurrent writers against one
+ * target (a fixed `${filePath}.tmp` scratch makes them collide), and scratch cleanup after a failed
+ * rename (without a `finally`, the partial file outlives the error). Everything else here is the
+ * behaviour those two depend on.
+ */
+
+let workDir;
+
+test.beforeEach(() => {
+    workDir = fs.mkdtempSync(path.join(os.tmpdir(), 'neo-atomic-write-'))
+});
+
+test.afterEach(() => {
+    fs.rmSync(workDir, {force: true, recursive: true})
+});
+
+const scratchLeftIn = dir => fs.readdirSync(dir).filter(name => name.endsWith('.tmp'));
+
+test.describe('writeFileAtomic (async surface)', () => {
+    test('writes the content and returns the absolute path', async () => {
+        const target   = path.join(workDir, 'plain.json'),
+              returned = await writeFileAtomic(target, '{"ok":true}\n');
+
+        expect(returned).toBe(path.resolve(target));
+        expect(fs.readFileSync(target, 'utf8')).toBe('{"ok":true}\n')
+    });
+
+    test('creates missing parent directories', async () => {
+        const target = path.join(workDir, 'a', 'b', 'c', 'deep.txt');
+
+        await writeFileAtomic(target, 'deep');
+
+        expect(fs.readFileSync(target, 'utf8')).toBe('deep')
+    });
+
+    test('overwrites an existing file without leaving scratch behind', async () => {
+        const target = path.join(workDir, 'twice.txt');
+
+        await writeFileAtomic(target, 'first');
+        await writeFileAtomic(target, 'second');
+
+        expect(fs.readFileSync(target, 'utf8')).toBe('second');
+        expect(scratchLeftIn(workDir)).toEqual([])
+    });
+
+    /*
+     * THE discriminating cell. A hand-rolled `${filePath}.tmp` gives both writers the same scratch
+     * path: with `flag:'wx'` the loser throws EEXIST, and without it the two interleave and `rename`
+     * promotes a torn file. A unique scratch makes concurrent writers independent, so both resolve
+     * and the target holds exactly one of the two payloads — never a blend.
+     */
+    test('concurrent writers to one target do not collide, and the result is never torn', async () => {
+        const target   = path.join(workDir, 'contended.txt'),
+              payloads = Array.from({length: 8}, (_, index) => `payload-${index}`.padEnd(4096, '.'));
+
+        await Promise.all(payloads.map(content => writeFileAtomic(target, content)));
+
+        expect(payloads).toContain(fs.readFileSync(target, 'utf8'));
+        expect(scratchLeftIn(workDir)).toEqual([])
+    });
+
+    test('a failed rename leaves no scratch file behind', async () => {
+        const target  = path.join(workDir, 'doomed.txt'),
+              failing = {
+                  ...fsPromises,
+                  rename: async () => { throw new Error('rename refused by the probe') }
+              };
+
+        await expect(writeFileAtomic(target, 'never lands', {fsModule: failing}))
+            .rejects.toThrow('rename refused by the probe');
+
+        expect(fs.existsSync(target), 'the target must not exist after a failed rename').toBe(false);
+        expect(scratchLeftIn(workDir), 'the scratch must be cleaned up by the finally').toEqual([])
+    });
+
+    test('the scratch never occupies the target path, so a reader cannot observe a partial write', async () => {
+        const target  = path.join(workDir, 'observed.txt'),
+              seen    = [],
+              probing = {
+                  ...fsPromises,
+                  writeFile: async (file, ...rest) => {
+                      seen.push(file);
+                      return fsPromises.writeFile(file, ...rest)
+                  }
+              };
+
+        await writeFileAtomic(target, 'final', {fsModule: probing});
+
+        expect(seen.length).toBe(1);
+        expect(seen[0], 'content is written to a sibling, never to the target').not.toBe(path.resolve(target));
+        expect(seen[0].startsWith(path.resolve(target))).toBe(true)
+    });
+
+    test('fsync:true still produces the file (durability upgrade, not a behaviour change)', async () => {
+        const target = path.join(workDir, 'durable.txt');
+
+        await writeFileAtomic(target, 'flushed', {fsync: true});
+
+        expect(fs.readFileSync(target, 'utf8')).toBe('flushed');
+        expect(scratchLeftIn(workDir)).toEqual([])
+    });
+});
+
+test.describe('writeFileAtomicSync (sync surface)', () => {
+    test('matches the async surface: content, parent creation, no scratch', () => {
+        const target = path.join(workDir, 'x', 'sync.txt');
+
+        expect(writeFileAtomicSync(target, 'sync-body')).toBe(path.resolve(target));
+        expect(fs.readFileSync(target, 'utf8')).toBe('sync-body');
+        expect(scratchLeftIn(path.dirname(target))).toEqual([])
+    });
+
+    test('a failed rename leaves no scratch file behind', () => {
+        const target  = path.join(workDir, 'sync-doomed.txt'),
+              failing = {
+                  ...fs,
+                  renameSync: () => { throw new Error('sync rename refused by the probe') }
+              };
+
+        expect(() => writeFileAtomicSync(target, 'never lands', {fsModule: failing}))
+            .toThrow('sync rename refused by the probe');
+
+        expect(fs.existsSync(target)).toBe(false);
+        expect(scratchLeftIn(workDir)).toEqual([])
+    });
+
+    test('fsync:true still produces the file', () => {
+        writeFileAtomicSync(path.join(workDir, 'sync-durable.txt'), 'flushed', {fsync: true});
+
+        expect(fs.readFileSync(path.join(workDir, 'sync-durable.txt'), 'utf8')).toBe('flushed')
+    });
+});


### PR DESCRIPTION
Resolves #16629

One owned write-temp-then-rename primitive, every genuine caller migrated to it, and a shape-keyed guard that makes the next hand-rolled copy fail the build.

Evidence: L2 (the primitive exercised directly — concurrency, failure injection, ordered flush sequence, fd-style and FileHandle seams — plus the guard demonstrated red on the pre-migration tree and green on this one) → L2 required (a file-I/O primitive and a static guard are fully covered by unit execution). Residual: none.

## What every hand-rolled copy gets wrong

1. **A fixed `${filePath}.tmp` scratch collides.** Two writers racing one target select the same sibling; the loser's partial content is what `rename` promotes.
2. **No `finally`, so the scratch outlives the failure that created it.**
3. **Atomic is not durable.** `rename` guarantees a reader sees the old file or the new one. It says nothing about power loss — so `fsync` is opt-in, **strict**, and flushes the directory entry as well as the file.

The scratch sits **beside the target**: `rename` is only atomic within one filesystem, and a cross-mount scratch silently degrades to copy-then-delete.

## Deltas from ticket

**The ticket's census command is wrong in four directions, and the fourth was found by the guard itself.** `rg -l "renameSync\(" ai` under-counts (the async population, per the ticket's own correction) and over-counts three ways:

| what it matches | why it must not be migrated |
|---|---|
| **log rotation** — `renameSync(logFile, \`${logFile}.${day}\`)` | a move of an existing file; there is no scratch |
| **plain relocation** — the issue/PR syncers | same |
| **a directory-rename MUTEX** — `lifecycleGuard` | it renames a staging **directory**, and the rename **failing** is the mutual exclusion |

And the fourth: **four sites were invisible to every `\.rename\(` census on this ticket because they import `rename` destructured** — `bootIdentityFactStore`, `acceptedLossAuditStore` ×2, `quarantineStore`. Two of them used a fixed `${filePath}.tmp`, the exact collision the primitive exists to remove. The shape found what the verb could not.

**Six survivors stay hand-rolled, each with a machine-checked reason.** Five are the same shape: a check must run **between** the write and the rename, and the primitive owns both ends so it cannot express one.

| site | the fence that needs that instant |
|---|---|
| `recoveryOverrideStore` | `assertHeld()` — "the only check that binds the effect" |
| `TenantRepoSyncService` | `assertOwnership()` — its own comment says proving after the rename "is worse than useless" |
| `providerActivityStatusStore` | guard-ownership re-verify |
| `hookProjectionTransport` | `assertDeadline()` — "the rename IS the mutation" |
| `buildReceiverManifest` | the receiver validates the **staged** manifest before it can become live |
| `offHostSyncStore` | its scratch **name** is a contract with a reaper that decodes the owner pid from it |

Plus one that is not a semantic objection at all: **`opencodeWakeEnvelopePlugin` is a PLANT**, copied to `~/.config/opencode/plugins/` and executed **outside this repo**, so a relative import into `ai/` cannot resolve at load time. That migration was already written before I read the file header; it would have broken the wake-envelope route on every seat.

**Semantic deviations, recorded per AC-3:** `fsync: true` preserved on both lease renewals (a lease surviving a crash as a stale renewal is how two holders come to believe they own the same lease); `encoding: null` on FleetRegistry's binary key path; the overlay writer's backup moved *before* the write (it copies the original, which the atomic write leaves untouched until it publishes); and four dead scratch-cleanup branches removed, one of which referenced a binding its change deleted — a `ReferenceError` on the failure path only, invisible to `node --check`.

## The guard, and its red proof

The predicate is the **pair** — a name written to, then renamed away — which is the only thing that separates an atomic write from the three legitimate callers above.

```
pre-migration tree (merge-base 44e1e988a5)  →  29 pairs, exit 1
this head                                   →   0 pairs, exit 0
```

Wired into `lint-staged` for `ai/**/*.mjs` **with its CI mirror**, so `--no-verify` cannot bypass it, and registered in the scan-root parity registry — including the sibling guard that owns the shared acorn `codeMask`, because a change there can change this lint's verdict.

## Test Evidence

```
npm run test-unit -- unit/ai/services/shared/atomicFileWrite.spec.mjs
  24 passed

npm run test-unit -- unit/ai/buildScripts/util/check-atomic-write-shape.spec.mjs
  11 passed

npm run test-unit          (full suite, this head)
  12694 passed
```

**Mutation-differential — a guard nobody has watched fail is a claim.** @neo-gpt's RC found the first `fsync` proof mutation-insensitive, and his re-review found the async proof did not cover the sync surface. Both closed:

| mutation | result |
|---|---|
| delete the async pre-rename file flush | **2 failed** |
| delete the async post-rename directory flush | **3 failed** |
| restore the `EBADF` swallow | **2 failed** |
| delete the **sync** post-rename directory flush | **3 failed** (was: 21 passed, undetected) |
| delete the **sync** pre-rename file flush | **2 failed** |
| replace the unique scratch with a fixed `.tmp` | **1 failed** — the concurrency cell |

**The four full-suite failures at this head are pre-existing, baseline-proved rather than asserted.** Running the identical suite on clean `origin/dev`: `seatCostReport` ×2 and `deploymentPrescriptionEnvironment` fail there too (the last is a sandbox artifact — the agent harness blocks `.env` writes, and CI skips that test for lack of docker). `McpServersHealth` fails **3/3 on clean dev and 1/3 on this branch** — the Memory Core is degraded on this host, and this branch is the healthier of the two.

## Post-Merge Validation

- [ ] Nothing outstanding. The primitive, the migration and the guard are all covered by unit execution, and the guard runs in `lint-staged` and CI from this merge onward.

## Commits

- `b6546a2245` — the primitive, 12 specs, first four callers
- `99d3a8d07f` — five more callers
- `f31d35498d` — the strict `fsync` contract + four stores
- `a082eac0a4` — the lifecycle-guard mutex carve-out
- `1dc70319d7` — fd-style flush seams, the lease renewals
- `4713ae28fd` — the overlay writer, three carve-outs
- `256f83f0ae` — the sync-surface durability proof
- `c5adadb36d` — the last safe callers, two fencing carve-outs
- `d6666de6d5` — the shape-keyed guard, red-proofed, wired to CI

## Evolution

The ticket asked for a primitive and named thirteen sites. The primitive was the easy half; the population was the work. Every instrument used to measure it — the original `renameSync` grep, the corrected async sweep, my own reading of each site — missed something the next one caught, and the guard caught what all of them missed. **A census keyed on a verb is wrong in both directions at once**, which is the argument for a shape-keyed guard made with the population rather than about it.

Authored by Ada (Claude Opus 5, Claude Code). Session 87f453f9-aa80-4487-9ed1-b5d91e052c43.
