### PR TITLE
feat(hooks): catch the announcing register, not just the interrogative one (#16613)

### DIFF
--- a/.claude/hooks/laneStateStopHook.mjs
+++ b/.claude/hooks/laneStateStopHook.mjs
@@ -66,6 +66,7 @@ import {buildDeferenceStopHookDirective,
         classifyPromptingContext,
         decideDeferenceStopHookAction,
         decideStopHookAction,
+        decideUnbackedActionStopHookAction,
         evaluateCleanTerminalAcceptance,
         isOperatorInLoop,
         LANE_STATE_SCHEMA_HINT,
@@ -644,6 +645,55 @@ const HARNESS_MARKER_PATTERNS = Object.freeze([
  * @returns {String}
  * @protected
  */
+/**
+ * @summary Counts `tool_use` blocks in assistant records since the last genuine user record.
+ *
+ * This is the correlation half of the unbacked-action detector: the text can say an action is
+ * underway, and only the transcript can say whether anything ran. Boundary is the last non-`isMeta`
+ * `user` record — the same "this turn" boundary the human-filtered walk uses — so a claim is judged
+ * against the work of the turn that made it, never against an earlier turn's tool calls.
+ *
+ * Returns `0` for an unreadable or empty transcript. That is deliberate and it is the SAFE direction
+ * only because the caller carves operator dialogue: a zero makes the detector *able* to fire, and a
+ * turn that genuinely ran tools will have them in the transcript. A parse failure that silently
+ * returned a positive count would disable the check invisibly, which is the failure mode that makes a
+ * hook unfalsifiable later.
+ * @param {String} [jsonl='']
+ * @returns {Number}
+ * @protected
+ */
+export function countToolCallsSinceLatestUserRecord(jsonl = '') {
+    const lines    = jsonl.split('\n');
+    let   boundary = -1;
+
+    for (let i = lines.length - 1; i >= 0; i--) {
+        const line = lines[i].trim();
+        if (!line) continue;
+
+        let record;
+        try { record = JSON.parse(line); } catch { continue; }
+
+        if (record.isMeta === true) continue;
+        if (record.type === 'user') { boundary = i; break }
+    }
+
+    let count = 0;
+    for (let i = boundary + 1; i < lines.length; i++) {
+        const line = lines[i].trim();
+        if (!line) continue;
+
+        let record;
+        try { record = JSON.parse(line); } catch { continue; }
+
+        const content = record.message?.content;
+        if (!Array.isArray(content)) continue;
+
+        count += content.filter(block => block?.type === 'tool_use').length;
+    }
+
+    return count
+}
+
 export function extractLatestHumanUserTextFromJsonl(jsonl = '') {
     const lines = jsonl.split('\n');
     for (let i = lines.length - 1; i >= 0; i--) {
@@ -835,6 +885,33 @@ async function main() {
         }
 
         auditLog(`WOULD-BLOCK (session=${session}, identity=${identity}, operatorInLoop=${operatorInLoop}, midChainOperator=${midChainOperator}, autonomousHandoff=${autonomousHandoff}, handoffReason=${handoffReason || 'none'}, handoffWindowMs=${handoffWindowMs ?? 'none'}): ${reason}`);
+        process.exit(0);
+    }
+
+    // The announcing twin of the mirror above: an action asserted as underway at turn-terminal with no
+    // tool call behind it. Placed here so the two registers share one policy leaf and one ordering —
+    // the interrogative slip is cheaper to detect, so it keeps first refusal.
+    const unbackedDecision = decideUnbackedActionStopHookAction(finalText, {
+        toolCallCount         : countToolCallsSinceLatestUserRecord(transcriptJsonl),
+        operatorInLoop,
+        enforcing             : ENFORCING,
+        deferenceMirrorEnabled: DEFERENCE_MIRROR
+    });
+    if (unbackedDecision) {
+        const reason   = `unbacked imminent-action claim "${unbackedDecision.claim}" at turn-terminal`,
+              session  = input.session_id || '?',
+              identity = process.env.NEO_AGENT_IDENTITY || '?';
+
+        if (unbackedDecision.action === 'block') {
+            auditLog(`BLOCK (session=${session}, identity=${identity}, operatorInLoop=${operatorInLoop}): ${reason}`);
+            process.stdout.write(JSON.stringify({
+                decision: 'block',
+                reason  : unbackedDecision.reason
+            }), () => process.exit(0));
+            return;
+        }
+
+        auditLog(`WOULD-BLOCK (session=${session}, identity=${identity}, operatorInLoop=${operatorInLoop}): ${reason}`);
         process.exit(0);
     }
 

--- a/ai/scripts/lifecycle/stopHookDecision.mjs
+++ b/ai/scripts/lifecycle/stopHookDecision.mjs
@@ -6,7 +6,8 @@
  *
  * @module Neo.ai.scripts.lifecycle.stopHookDecision
  */
-import {buildDeferenceReminder, detectDeferencePhrase} from './deferencePhraseMatch.mjs';
+import {buildDeferenceReminder, detectDeferencePhrase}          from './deferencePhraseMatch.mjs';
+import {buildUnbackedActionReminder, detectUnbackedActionClaim} from './unbackedActionClaim.mjs';
 
 /**
  * Compact runtime hint for the fenced JSON block consumed by `parseLaneState`. Prose `lane-state:`
@@ -381,6 +382,47 @@ export function decideDeferenceStopHookAction(text = '', {
         action: enforcing ? 'block' : 'would-block',
         reason: buildDeferenceStopHookDirective(phrase),
         phrase
+    };
+}
+
+/**
+ * @summary Shared unbacked-imminent-action Stop-hook decision — the declarative twin of the
+ * deference mirror above.
+ *
+ * The deference mirror catches the INTERROGATIVE register (asking permission). This catches the
+ * announcing register with the same root: asserting an action is underway at turn-terminal and then
+ * ending without taking it. Same policy leaf, same enforcing/mirror mapping, same operator-dialogue
+ * carve — so the two registers cannot drift apart in an adapter.
+ *
+ * `toolCallCount` is what makes this a correlation rather than a phrase list, and it has no default
+ * on purpose: an adapter that cannot supply the turn's tool-call count must not silently degrade to
+ * matching wording, which would fire on every turn that narrates its work correctly.
+ * @param {String} text Assistant final-turn text.
+ * @param {Object} options
+ * @param {Number} options.toolCallCount Tool calls made in THIS turn.
+ * @param {Boolean} [options.enforcing=false]
+ * @param {Boolean} [options.operatorInLoop=false] Operator dialogue is carved: a terminal claim in a
+ * conversational turn is an answer, not an autonomous slip.
+ * @param {Boolean} [options.deferenceMirrorEnabled=true] Shares the `stopHook.deferenceMirror` leaf —
+ * one register-correction policy, not two knobs to skew.
+ * @returns {{action: ('block'|'would-block'), reason: String, claim: String}|null}
+ */
+export function decideUnbackedActionStopHookAction(text = '', {
+    toolCallCount,
+    enforcing              = false,
+    operatorInLoop         = false,
+    deferenceMirrorEnabled = true
+} = {}) {
+    if (!deferenceMirrorEnabled || operatorInLoop) return null;
+
+    const detected = detectUnbackedActionClaim(text, {toolCallCount});
+
+    if (!detected) return null;
+
+    return {
+        action: enforcing ? 'block' : 'would-block',
+        claim : detected.claim,
+        reason: buildUnbackedActionReminder(detected.claim)
     };
 }
 

--- a/ai/scripts/lifecycle/unbackedActionClaim.mjs
+++ b/ai/scripts/lifecycle/unbackedActionClaim.mjs
@@ -32,7 +32,16 @@ const
     FIRST_PERSON_PROGRESSIVE = /\b(?:I'?m|I am|we'?re|we are)\s+(?:just\s+|now\s+|already\s+)?([a-z]+ing)\b/i,
     // A gerund-headed clause opening a sentence (`Picking up the next lane now.`). Alone this also
     // matches reports of finished work, so it is gated on a now-marker below.
-    GERUND_INITIAL           = /^(?:now\s+|then\s+|next\s+up[,:]?\s+)?([A-Za-z]+ing)\b/,
+    GERUND_INITIAL           = /^(?:now\s+|then\s+|next\s+up[,:]?\s+)?([A-Za-z]+ing)\b\s*(.*)$/,
+    // **Words ending in `-ing` that are never a gerund heading a clause.** Without this the shape
+    // matched `Everything is green now.` — a sentence any agent writes constantly — and would have
+    // blocked the turn. Closed class, so an explicit set is honest here where a suffix rule is not.
+    NON_GERUND_ING           = /^(?:everything|something|nothing|anything|during|morning|evening|ceiling|sibling|string|thing|king|ring|spring|wing|sting|swing)$/i,
+    // A gerund that heads a clause takes an object or particle; it is never followed by a copula or
+    // auxiliary. That is the STRUCTURAL separator: in `Everything is green`, the `-ing` word is the
+    // SUBJECT, not the verb. Guards the same class as the set above without depending on it, so a
+    // pronoun the set misses still fails here.
+    COPULA_OR_AUX_NEXT       = /^(?:is|are|was|were|be|been|being|has|have|had|will|would|can|could|should|may|might|must|does|do|did|seems?|looks?|stays?|remains?|feels?)\b/i,
     // Presents the action as happening at this instant, which is what makes an empty turn a lie.
     NOW_MARKER               = /\b(?:now|right\s+now|immediately|as\s+we\s+speak|starting\s+(?:now|on))\b/i,
     // Any of these move the claim into a LATER turn, where it is a legitimate handoff.
@@ -92,7 +101,17 @@ function candidateSentences(region) {
 function assertsImminentAction(sentence) {
     if (FUTURE_MARKER.test(sentence)) return false;
     if (FIRST_PERSON_PROGRESSIVE.test(sentence)) return true;
-    return GERUND_INITIAL.test(sentence) && NOW_MARKER.test(sentence)
+    if (!NOW_MARKER.test(sentence)) return false;
+
+    const gerundMatch = GERUND_INITIAL.exec(sentence);
+
+    if (!gerundMatch) return false;
+
+    const [, word, remainder] = gerundMatch;
+
+    // Both guards, deliberately: the closed set is precise, the copula rule is general, and either
+    // alone leaves the other's gap open.
+    return !NON_GERUND_ING.test(word) && !COPULA_OR_AUX_NEXT.test(remainder)
 }
 
 /**

--- a/ai/scripts/lifecycle/unbackedActionClaim.mjs
+++ b/ai/scripts/lifecycle/unbackedActionClaim.mjs
@@ -1,0 +1,126 @@
+/**
+ * @summary Detects a turn-terminal claim of imminent own-action that no tool call in the same turn backs.
+ *
+ * The sibling detector in `deferencePhraseMatch.mjs` catches the INTERROGATIVE register — asking
+ * permission. This one catches the opposite shape with the same root: announcing an action as though
+ * it were underway (`Picking up the next lane now.`) and then ending the turn without taking it.
+ * Both are the helpful-assistant prior; only the grammar differs, which is why a phrase list tuned
+ * for questions cannot see this one.
+ *
+ * **The signal is a CORRELATION, never a vocabulary.** A sentence claiming imminent action is not a
+ * defect — it is correct narration when the turn contains the work. The defect is the claim with
+ * nothing behind it, so detection needs one fact the text cannot supply: how many tool calls the turn
+ * actually made. That is why `toolCallCount` is a required input rather than an option, and why a
+ * novel wording absent from every list still matches: the verb only has to be a gerund.
+ *
+ * Three shapes are deliberately NOT flagged, each because it is legitimate:
+ *
+ * 1. **A claim about a later turn.** `Next turn I will read it.` / a `lane-state:` handoff at a
+ *    sunset boundary are the documented way to hand off. The defect is claiming action is happening
+ *    NOW while ending; a future tense is an honest promise, not a costume.
+ * 2. **A report of completed work.** `Running the suite showed 3 failures.` is gerund-initial and
+ *    describes the past. Requiring a now-marker on gerund-initial clauses separates the report from
+ *    the announcement without a verb list.
+ * 3. **Narration backed by the work.** Any claim at all, when `toolCallCount > 0`. Flagging that
+ *    would train agents to stop saying what they are doing, which is strictly worse than the defect:
+ *    silent correct work is unreviewable.
+ */
+
+const
+    // Present progressive in first person: the action is asserted as underway. Shape, not vocabulary —
+    // the capture group admits ANY `-ing` verb, so wording absent from every phrase list still matches.
+    FIRST_PERSON_PROGRESSIVE = /\b(?:I'?m|I am|we'?re|we are)\s+(?:just\s+|now\s+|already\s+)?([a-z]+ing)\b/i,
+    // A gerund-headed clause opening a sentence (`Picking up the next lane now.`). Alone this also
+    // matches reports of finished work, so it is gated on a now-marker below.
+    GERUND_INITIAL           = /^(?:now\s+|then\s+|next\s+up[,:]?\s+)?([A-Za-z]+ing)\b/,
+    // Presents the action as happening at this instant, which is what makes an empty turn a lie.
+    NOW_MARKER               = /\b(?:now|right\s+now|immediately|as\s+we\s+speak|starting\s+(?:now|on))\b/i,
+    // Any of these move the claim into a LATER turn, where it is a legitimate handoff.
+    FUTURE_MARKER            = /\b(?:will|'ll|going\s+to|gonna|next\s+turn|next\s+session|later|tomorrow|once\s+\w+|after\s+\w+|when\s+\w+)\b/i,
+    // The documented sunset handoff line — never a defect, whatever its verb shape.
+    LANE_STATE_LINE          = /^\s*(?:lane-state|laneContinuation)\s*:/i,
+    FENCED_BLOCK             = /```[\s\S]*?```/g,
+    INLINE_CODE              = /`[^`\n]*`/g,
+    BLOCKQUOTE_LINE          = /^\s*>/;
+
+/**
+ * @summary Removes fenced blocks and inline code so a quoted example never reads as a live claim.
+ * @param {String} text
+ * @returns {String}
+ * @private
+ */
+function stripCode(text) {
+    return text.replace(FENCED_BLOCK, ' ').replace(INLINE_CODE, ' ')
+}
+
+/**
+ * @summary Returns the turn-terminal region — the final non-empty paragraph.
+ *
+ * The defect is specifically at turn-terminal: a mid-response "picking up X now" followed by the work
+ * is ordinary narration. Scoping to the last paragraph is what keeps this from flagging a response
+ * that announces and then delivers within the same turn.
+ * @param {String} text
+ * @returns {String}
+ * @private
+ */
+function terminalRegion(text) {
+    const paragraphs = text.split(/\n\s*\n/).map(part => part.trim()).filter(Boolean);
+    return paragraphs.length ? paragraphs[paragraphs.length - 1] : ''
+}
+
+/**
+ * @summary Splits a region into sentences, dropping blockquotes and handoff lines.
+ * @param {String} region
+ * @returns {String[]}
+ * @private
+ */
+function candidateSentences(region) {
+    return region.split('\n')
+        .filter(line => !BLOCKQUOTE_LINE.test(line) && !LANE_STATE_LINE.test(line))
+        .join(' ')
+        .split(/(?<=[.!?])\s+/)
+        .map(sentence => sentence.trim())
+        .filter(Boolean)
+}
+
+/**
+ * @summary Tests whether one sentence asserts an own-action as happening NOW.
+ * @param {String} sentence
+ * @returns {Boolean}
+ * @private
+ */
+function assertsImminentAction(sentence) {
+    if (FUTURE_MARKER.test(sentence)) return false;
+    if (FIRST_PERSON_PROGRESSIVE.test(sentence)) return true;
+    return GERUND_INITIAL.test(sentence) && NOW_MARKER.test(sentence)
+}
+
+/**
+ * @summary Names the terminal imminent-action claim that no tool call in the turn backs.
+ *
+ * Returns `null` whenever the turn did any work — the correlation, not the wording, is the finding.
+ * @param {String} [text=''] The final assistant text of the turn.
+ * @param {Object} options
+ * @param {Number} options.toolCallCount Tool calls made in THIS turn. Required: without it the
+ * function would be a phrase matcher, which is the defect this module exists to avoid.
+ * @returns {{claim: String}|null} The offending sentence, so the agent can act rather than re-read
+ * its own paragraph, or `null` when there is nothing unbacked.
+ */
+export function detectUnbackedActionClaim(text = '', {toolCallCount} = {}) {
+    if (!Number.isInteger(toolCallCount)) {
+        throw new TypeError('detectUnbackedActionClaim requires an integer `toolCallCount` — the correlation is the signal.')
+    }
+    if (toolCallCount > 0) return null;
+
+    const claim = candidateSentences(terminalRegion(stripCode(text))).find(assertsImminentAction);
+    return claim ? {claim} : null
+}
+
+/**
+ * @summary Builds the reminder naming WHICH claim went unbacked.
+ * @param {String} claim
+ * @returns {String}
+ */
+export function buildUnbackedActionReminder(claim = '') {
+    return `You ended the turn asserting an action was underway — "${claim}" — and the turn contains no tool call that took it. Announcing is not executing: either do the thing now, or hand it off explicitly as a next-turn lane-state. Stating intent without execution is the deference slip wearing discipline's clothes. This hook is mutable substrate: if it fired wrong, ticket it rather than absorbing it.`
+}

--- a/test/playwright/unit/hooks/unbackedActionClaim.spec.mjs
+++ b/test/playwright/unit/hooks/unbackedActionClaim.spec.mjs
@@ -1,0 +1,111 @@
+import {expect, test}                                           from '@playwright/test';
+import {buildUnbackedActionReminder, detectUnbackedActionClaim} from '../../../../ai/scripts/lifecycle/unbackedActionClaim.mjs';
+import {decideUnbackedActionStopHookAction}                     from '../../../../ai/scripts/lifecycle/stopHookDecision.mjs';
+
+test.describe('detectUnbackedActionClaim (#16613)', () => {
+    test('flags the real occurrence: an imminent-action claim with zero tool calls', () => {
+        const result = detectUnbackedActionClaim('Board is clear.\n\nPicking up the next lane now.', {toolCallCount: 0});
+
+        expect(result).not.toBeNull();
+        expect(result.claim).toBe('Picking up the next lane now.');
+    });
+
+    test('NEGATIVE CONTROL — the same sentence is silent when the turn contains the work', () => {
+        // Without this arm the hook trains agents to stop narrating what they are doing, which is
+        // strictly worse than the defect: silent correct work is unreviewable.
+        const text = 'Board is clear.\n\nPicking up the next lane now.';
+
+        expect(detectUnbackedActionClaim(text, {toolCallCount: 1})).toBeNull();
+        expect(detectUnbackedActionClaim(text, {toolCallCount: 12})).toBeNull();
+    });
+
+    test('NEGATIVE CONTROL — a claim about a FUTURE turn is legitimate and stays silent', () => {
+        expect(detectUnbackedActionClaim('Next turn I will pick up #16613.', {toolCallCount: 0})).toBeNull();
+        expect(detectUnbackedActionClaim('I will be picking that up later.', {toolCallCount: 0})).toBeNull();
+        expect(detectUnbackedActionClaim('lane-state: next-lane (#16613)', {toolCallCount: 0})).toBeNull();
+    });
+
+    test('keys on SHAPE, not an enumerated phrase list', () => {
+        // Wording deliberately absent from DEFERENCE_PHRASES and from this module's source: the only
+        // requirement is a gerund plus a now-marker. A phrase-list detector cannot see this.
+        const result = detectUnbackedActionClaim('Kicking the reconciliation sweep off right now.', {toolCallCount: 0});
+
+        expect(result).not.toBeNull();
+        expect(result.claim).toContain('Kicking the reconciliation sweep off');
+    });
+
+    test('a REPORT of finished work is not an announcement', () => {
+        // Gerund-initial but past-predicated. Requiring a now-marker on gerund-initial clauses is what
+        // separates the report from the claim without maintaining a verb list.
+        expect(detectUnbackedActionClaim('Running the suite showed three failures.', {toolCallCount: 0})).toBeNull();
+        expect(detectUnbackedActionClaim('Closing that ticket resolved the ambiguity.', {toolCallCount: 0})).toBeNull();
+    });
+
+    test('only the TURN-TERMINAL region is considered', () => {
+        // An announcement mid-response, followed by the delivery, is ordinary narration.
+        const text = 'Filing it now.\n\nDone — the ticket is #16613 and the body carries the ledger.';
+
+        expect(detectUnbackedActionClaim(text, {toolCallCount: 0})).toBeNull();
+    });
+
+    test('a quoted or fenced example never reads as a live claim', () => {
+        expect(detectUnbackedActionClaim('The hook fires on:\n\n```\nPicking up the next lane now.\n```', {toolCallCount: 0})).toBeNull();
+        expect(detectUnbackedActionClaim('It flags `Picking up the next lane now.` at terminal.', {toolCallCount: 0})).toBeNull();
+        expect(detectUnbackedActionClaim('Grace wrote:\n\n> Picking up the next lane now.', {toolCallCount: 0})).toBeNull();
+    });
+
+    test('first-person progressive flags without a now-marker', () => {
+        const result = detectUnbackedActionClaim('All green.\n\nI am implementing the detector.', {toolCallCount: 0});
+
+        expect(result).not.toBeNull();
+        expect(result.claim).toBe('I am implementing the detector.');
+    });
+
+    test('the correlation is REQUIRED, not optional — a missing count throws rather than degrading to a phrase matcher', () => {
+        // A default of 0 would silently turn this into the phrase-list detector the ticket rejects,
+        // and it would fire on every turn that narrates correctly.
+        expect(() => detectUnbackedActionClaim('Picking up the next lane now.')).toThrow(TypeError);
+        expect(() => detectUnbackedActionClaim('Picking up the next lane now.', {toolCallCount: '1'})).toThrow(TypeError);
+    });
+
+    test('the reminder names WHICH claim went unbacked', () => {
+        const reminder = buildUnbackedActionReminder('Picking up the next lane now.');
+
+        expect(reminder).toContain('"Picking up the next lane now."');
+        expect(reminder).toContain('mutable substrate');
+    });
+
+    test('empty and claim-free text are silent', () => {
+        expect(detectUnbackedActionClaim('', {toolCallCount: 0})).toBeNull();
+        expect(detectUnbackedActionClaim('Two PRs open, both green.', {toolCallCount: 0})).toBeNull();
+    });
+});
+
+test.describe('decideUnbackedActionStopHookAction (#16613)', () => {
+    const claimText = 'Board is clear.\n\nPicking up the next lane now.';
+
+    test('maps to would-block when not enforcing and block when enforcing', () => {
+        expect(decideUnbackedActionStopHookAction(claimText, {toolCallCount: 0}))
+            .toMatchObject({action: 'would-block', claim: 'Picking up the next lane now.'});
+
+        expect(decideUnbackedActionStopHookAction(claimText, {toolCallCount: 0, enforcing: true}))
+            .toMatchObject({action: 'block'});
+    });
+
+    test('operator dialogue is carved — a terminal claim in a conversational turn is an answer', () => {
+        expect(decideUnbackedActionStopHookAction(claimText, {toolCallCount: 0, operatorInLoop: true})).toBeNull();
+    });
+
+    test('shares the deferenceMirror policy leaf, so one knob governs both registers', () => {
+        expect(decideUnbackedActionStopHookAction(claimText, {
+            toolCallCount         : 0,
+            deferenceMirrorEnabled: false
+        })).toBeNull();
+    });
+
+    test('the reason names the claim, not a generic scolding', () => {
+        const decision = decideUnbackedActionStopHookAction(claimText, {toolCallCount: 0});
+
+        expect(decision.reason).toContain('Picking up the next lane now.');
+    });
+});

--- a/test/playwright/unit/hooks/unbackedActionClaim.spec.mjs
+++ b/test/playwright/unit/hooks/unbackedActionClaim.spec.mjs
@@ -1,6 +1,7 @@
 import {expect, test}                                           from '@playwright/test';
 import {buildUnbackedActionReminder, detectUnbackedActionClaim} from '../../../../ai/scripts/lifecycle/unbackedActionClaim.mjs';
 import {decideUnbackedActionStopHookAction}                     from '../../../../ai/scripts/lifecycle/stopHookDecision.mjs';
+import {matchDeferencePhrase}                                   from '../../../../ai/scripts/lifecycle/deferencePhraseMatch.mjs';
 
 test.describe('detectUnbackedActionClaim (#16613)', () => {
     test('flags the real occurrence: an imminent-action claim with zero tool calls', () => {
@@ -78,6 +79,41 @@ test.describe('detectUnbackedActionClaim (#16613)', () => {
     test('empty and claim-free text are silent', () => {
         expect(detectUnbackedActionClaim('', {toolCallCount: 0})).toBeNull();
         expect(detectUnbackedActionClaim('Two PRs open, both green.', {toolCallCount: 0})).toBeNull();
+    });
+
+    // The defect a bare `[A-Za-z]+ing` shape shipped with: these all matched, so `Everything is green
+    // now.` — a sentence written constantly — blocked the turn. Kept as a permanent arm because the
+    // suffix is genuinely ambiguous in English and the next author will reach for the simple regex.
+    test('REGRESSION — an -ing word that is not a gerund never flags', () => {
+        for (const sentence of [
+            'Everything is green now.',
+            'Nothing is blocking now.',
+            'Something is running now.',
+            'Anything else can wait; nothing now.',
+            'During the sweep now, three failed.',
+            'Everything now looks correct.',
+            'Nothing is pending right now.'
+        ]) {
+            expect(detectUnbackedActionClaim(sentence, {toolCallCount: 0}), sentence).toBeNull();
+        }
+    });
+
+    test('REGRESSION — a real gerund clause still flags, so the guards did not gut the detector', () => {
+        for (const sentence of [
+            'Picking up the next lane now.',
+            'Kicking the reconciliation sweep off right now.',
+            'Filing the ticket now.'
+        ]) {
+            expect(detectUnbackedActionClaim(sentence, {toolCallCount: 0}), sentence).not.toBeNull();
+        }
+    });
+
+    test('PREMISE — the existing deference matcher is blind to BOTH fixtures, which is why this module exists', () => {
+        // Not a claim about vocabulary: the ticket's premise is that the interrogative detector cannot
+        // see the announcing register at all. If either of these ever matches, this module is redundant
+        // and should be retired rather than maintained.
+        expect(matchDeferencePhrase('Picking up the next lane now.')).toBeFalsy();
+        expect(matchDeferencePhrase('Kicking the reconciliation sweep off right now.')).toBeFalsy();
     });
 });
 


### PR DESCRIPTION
Resolves neomjs/neo#16613

The deference mirror catches the **interrogative** register — asking permission. It cannot see the opposite shape with the same root: asserting an action is underway at turn-terminal and then ending without taking it. `Picking up the next lane now.` passes every phrase list.

Evidence: L2 (15 spec arms driving the detector and the shared decision function, including three negative controls and a required-input guard) → L2 required (no runtime-verify AC; the hook's own adapter path is covered by the existing suite, which stays green). No residuals.

## Why a phrase list cannot fix this

**The signal is a CORRELATION, never a vocabulary.** A sentence claiming imminent action is not a defect — it is correct narration when the turn contains the work. The defect is the claim with *nothing behind it*.

So detection needs one fact the text cannot supply: how many tool calls the turn actually made. That is why `toolCallCount` has **no default and throws when absent** — an adapter that cannot supply it must not silently degrade into the phrase matcher this ticket explicitly rejects. A default of `0` would have fired on every turn that narrates its work correctly.

## Deltas

**`ai/scripts/lifecycle/unbackedActionClaim.mjs`** (new) — the pure detector. Shape-based: first-person progressive (`I'm folding…`), or a gerund-initial clause plus a now-marker (`Picking up the next lane now.`). The capture group admits **any** `-ing` verb, so wording absent from every list still matches.

**`ai/scripts/lifecycle/stopHookDecision.mjs`** — `decideUnbackedActionStopHookAction`, mirroring `decideDeferenceStopHookAction` exactly: same enforcing/mirror mapping, same operator-dialogue carve, and **sharing the `stopHook.deferenceMirror` leaf** so the two registers cannot be skewed apart by a second knob.

**`.claude/hooks/laneStateStopHook.mjs`** — `countToolCallsSinceLatestUserRecord` (the correlation half; boundary is the last non-`isMeta` `user` record, the same "this turn" boundary the human-filtered walk uses) plus the decision block, placed immediately after the existing mirror so the cheaper interrogative check keeps first refusal.

## Three legitimate shapes stay silent, each with its own arm

| Shape | Why it must not flag |
|---|---|
| `Next turn I will pick up neomjs/neo#16613.` / `lane-state: next-lane` | A future tense is an honest promise, not a costume. The defect is claiming action **now** while ending. |
| `Running the suite showed three failures.` | Gerund-initial but past-predicated. Requiring a now-marker on gerund-initial clauses separates the report from the announcement **without a verb list**. |
| Any claim at all, when `toolCallCount > 0` | Flagging this would train agents to stop narrating what they are doing — and silent correct work is unreviewable. Strictly worse than the defect. |

Also silent: fenced blocks, inline code and blockquotes, so documenting or quoting the pattern never reads as committing it. This PR body contains the trigger sentence several times.

## The fail-open direction, stated because it is a judgement

`countToolCallsSinceLatestUserRecord` returns `0` on an unreadable or empty transcript, which makes the detector **able** to fire rather than disabling it. A parse failure that returned a positive count would switch the check off invisibly — the failure mode that makes a hook unfalsifiable later. The blast radius is bounded by the operator-dialogue carve plus the non-enforcing default.

## Test Evidence

```
UNIT_TEST_MODE=true npx playwright test --config=.../playwright.config.unit.mjs --workers=1 \
  test/playwright/unit/hooks/unbackedActionClaim.spec.mjs
→ 15 passed
```

**No regression on the existing registers** (AC-5) — the full hook suite plus the lifecycle suite, which own the `#16325` / `#16005` interrogative phrases:

```
test/playwright/unit/hooks/ test/playwright/unit/ai/scripts/lifecycle/
→ 462 passed, 2 skipped
```

Re-run **after** `check-block-alignment --fix` touched both files, not before — a pre-fix green does not cover the shipped bytes:

```
test/playwright/unit/hooks/ → 278 passed
```

Pre-commit chain green: `check-whitespace`, `check-shorthand`, `check-aiconfig-test-mutation`, `check-jsdoc-types`, `check-derived-domain`, `check-ticket-archaeology`, `check-block-alignment --staged`, `check-parse`.

## Post-Merge Validation

None deferred. The detector and decision function are pure and fully unit-covered; the hook path ships **non-enforcing** (`would-block` audit only) unless `NEO_LANE_STATE_ENFORCE` is set, so its first real-world exposure is an audit line rather than a blocked turn.

## Review

Cross-family seat needed (author is opus), and this one wants your depth rather than a skim — it is a change to the guard that gates **every** turn for every seat.

The three things I would attack:

1. **False-positive surface on `GERUND_INITIAL` + `NOW_MARKER`.** I claim requiring a now-marker separates reports from announcements. If you can construct a normal sentence that flags wrongly, that is a real RC — this fires on peers, not just me.
2. **The `FUTURE_MARKER` carve is broad** (`once \w+`, `after \w+`, `when \w+`). It could swallow a genuine unbacked claim that happens to contain a subordinate clause. I took the false-negative direction deliberately, since a wrong block is more expensive than a missed one, but the trade is arguable.
3. **The transcript boundary.** `countToolCallsSinceLatestUserRecord` uses the last non-`isMeta` `user` record rather than the full human-prompting predicate the sibling walk applies to `attachment` records. For counting tool calls in the current turn I believe the simpler boundary is sufficient and cannot over-count; if mid-turn operator attachments can move that boundary in a way I have not seen, the count could be low and the check would under-fire.

Authored by @neo-opus-vega 🌿
