### PR TITLE
feat: supervision vocabulary only where supervision exists (#16924)

### DIFF
--- a/ai/services/fleet/fleetCockpitStatus.mjs
+++ b/ai/services/fleet/fleetCockpitStatus.mjs
@@ -214,36 +214,48 @@ export function createFleetCockpitStatus({agents = [], fleetStatus = [], runtime
                         lastSeenAt: null,
                         reason    : 'presence producer not wired'
                     },
+                // Every fact owns its bounded `reason` at THIS producer boundary — the consumer
+                // renders name+reason for answered-abnormal facts, and a reason invented anywhere
+                // downstream would be a fixture-truth (the review-caught defect this closes).
+                // Wired facts pass the underlying row's own cause through (null when it carries
+                // none); an ABSENT per-agent row states which truth is missing; not-wired axes
+                // carry the axis-level explanation. All bounded via `boundReason`.
                 sources: {
                     roster: {
                         source    : FLEET_COCKPIT_SOURCES.roster,
                         state     : 'wired',
-                        confidence: 'observed'
+                        confidence: 'observed',
+                        reason    : null
                     },
                     repoStatus: {
                         source    : FLEET_COCKPIT_SOURCES.repoStatus,
                         state     : repoStatus ? 'wired' : 'missing',
-                        confidence: repoStatus ? 'observed' : 'none'
+                        confidence: repoStatus ? 'observed' : 'none',
+                        reason    : repoStatus ? boundReason(repoStatus.reason) : 'no repository status answered for this agent'
                     },
                     runtime: {
                         source    : FLEET_COCKPIT_SOURCES.runtime,
                         state     : runtime ? 'wired' : 'not-wired',
-                        confidence: runtime ? (runtime.confidence ?? 'observed') : 'none'
+                        confidence: runtime ? (runtime.confidence ?? 'observed') : 'none',
+                        reason    : runtime ? boundReason(runtime.reason) : 'runtime process status is pending the Fleet runtime-status wire method'
                     },
                     wake: {
                         source    : FLEET_COCKPIT_SOURCES.wake,
                         state     : wake ? 'wired' : 'not-wired',
-                        confidence: wake ? (wake.confidence ?? 'none') : 'none'
+                        confidence: wake ? (wake.confidence ?? 'none') : 'none',
+                        reason    : wake ? boundReason(wake.reason) : 'wake-state producer not wired'
                     },
                     throttle: {
                         source    : FLEET_COCKPIT_SOURCES.throttle,
                         state     : throttle ? 'wired' : 'not-wired',
-                        confidence: throttle ? (throttle.confidence ?? 'none') : 'none'
+                        confidence: throttle ? (throttle.confidence ?? 'none') : 'none',
+                        reason    : throttle ? boundReason(throttle.reason) : 'throttle-state producer not wired'
                     },
                     presence: {
                         source    : FLEET_COCKPIT_SOURCES.presence,
                         state     : presence ? 'wired' : 'not-wired',
-                        confidence: presence ? (presence.confidence ?? 'none') : 'none'
+                        confidence: presence ? (presence.confidence ?? 'none') : 'none',
+                        reason    : presence ? boundReason(presence.reason) : 'presence producer not wired'
                     }
                 }
             }
@@ -291,6 +303,16 @@ export function createNotWiredCapability(source, reason) {
         confidence: 'none',
         reason
     }
+}
+
+/**
+ * @summary Bound a producer-supplied cause to a serializable trimmed string, or `null` — the DTO
+ * owns every reason it emits, and an unbounded upstream string must not ride the wire unchecked.
+ * @param {*} value
+ * @returns {String|null}
+ */
+export function boundReason(value) {
+    return typeof value === 'string' && value.trim() ? value.trim().slice(0, 200) : null
 }
 
 function sanitizePayload(value) {

--- a/apps/agentos/view/fleet/AgentCard.mjs
+++ b/apps/agentos/view/fleet/AgentCard.mjs
@@ -19,7 +19,7 @@ const PRESENCE_BAND_LABEL = Object.freeze({
     neverConnected: 'never connected'
 });
 
-import {normalizeFleetSources, resolveFleetDisplayState, summarizeFleetSources} from './sourceHealth.mjs';
+import {normalizeFleetSources, resolveFleetDisplayState, summarizeAnsweredAbnormal} from './sourceHealth.mjs';
 
 import {describeNameProvenance, resolveNameSlot} from './nameSlot.mjs';
 import {describeTelltale}                        from './telltale.mjs';
@@ -319,7 +319,10 @@ class AgentCard extends Container {
      *
      * Display fields land on the rail / avatar / identity / lane / strip surfaces. Source facts are
      * summarized once (the strip names the abnormal source and can never contradict the detail
-     * markers — both read {@link #summarizeFleetSources}). The state dot is gated so missing runtime
+     * markers — both read the shared abnormal composer). The strip's abnormal set is
+     * ANSWERED-abnormal only (`summarizeAnsweredAbnormal`): `not-wired` is expected absence and
+     * earns zero pixels here exactly as it carries zero attention weight — ONE interpretation
+     * across strip and aggregate. The state dot is gated so missing runtime
      * evidence cannot render as live; severity adds WEIGHT to the state word, never a hue. The B4/C2
      * control seam renders the honest round-trip: unauthorized disables the cluster, timeout reads as
      * an unfinished "…" with retry open, rejected shows "⚠ reason".
@@ -336,7 +339,7 @@ class AgentCard extends Container {
             controlReason = record.controlReason ?? null,
             pendingAction = record.pendingAction ?? null,
             sources       = normalizeFleetSources(record.sources),
-            summary       = summarizeFleetSources(record.sources),
+            summary       = summarizeAnsweredAbnormal(record.sources),
             // the runtime fact gates a resolved session state: a wired runtime renders the row's
             // state as session truth; without one, an explicit `off` stays the operator-benched
             // participation fact it is, while every other state renders `unobserved` — never a
@@ -441,7 +444,7 @@ class AgentCard extends Container {
 
         // the source strip: ONE honest word-line, a PURE role=status — no ▸/disclosure affordance on a
         // non-interactive node (the card-name drill → detail IS the disclosure route). The level cls
-        // colours the ::before dot; summary.text is a controlled literal from summarizeFleetSources.
+        // colours the ::before dot; summary.text is a controlled literal from summarizeAnsweredAbnormal.
         // EXCEPTION-ONLY: nominal earns zero pixels (the cockpit's own doctrine, operator-falsified
         // when this line rendered "all sources nominal" permanently) — the strip exists exactly when
         // a source is abnormal and NAMES it; full facts stay reachable via the drill.

--- a/apps/agentos/view/fleet/AgentCard.mjs
+++ b/apps/agentos/view/fleet/AgentCard.mjs
@@ -38,8 +38,9 @@ import {describeTelltale}                        from './telltale.mjs';
  *   lifecycle **actions** right-aligned;
  * - **work-row** — the current lane, two-line clamped with head+tail middle elision so two lanes
  *   sharing a prefix still distinguish by their preserved tail (the narrow-density falsifier);
- * - **strip** — ONE honest source word-line ("all sources nominal" / "REP not nominal"), retiring
- *   the three 9px markers; full facts stay reachable via the drill (detail), never hover-only.
+ * - **strip** — the exception-only source word-line: nominal renders NOTHING (zero-pixel doctrine);
+ *   an abnormal source renders its full-word NAME ("Runtime not nominal"), retiring the three 9px
+ *   markers; full facts stay reachable via the drill (detail), never hover-only.
  *
  * **Width modes are card-owned** (SCSS `@container`): narrow (<320px) scales the avatar to 32px,
  * hides the engine tag, and grows the inline lifecycle verbs to a 44px touch target — they stay
@@ -441,6 +442,9 @@ class AgentCard extends Container {
         // the source strip: ONE honest word-line, a PURE role=status — no ▸/disclosure affordance on a
         // non-interactive node (the card-name drill → detail IS the disclosure route). The level cls
         // colours the ::before dot; summary.text is a controlled literal from summarizeFleetSources.
+        // EXCEPTION-ONLY: nominal earns zero pixels (the cockpit's own doctrine, operator-falsified
+        // when this line rendered "all sources nominal" permanently) — the strip exists exactly when
+        // a source is abnormal and NAMES it; full facts stay reachable via the drill.
         // Rendered as an inert `text` node, NEVER `html`: that literal is safe only because the
         // summariser composes it from a frozen label map over a hardcoded key order, so `html` would
         // make safety a property the summariser must preserve forever rather than one the card cannot
@@ -450,8 +454,9 @@ class AgentCard extends Container {
         const strip = me.getReference('source-strip');
 
         strip.set({
-            cls : ['fm-card-strip', `fm-strip-${summary.level}`],
-            text: summary.text
+            cls   : ['fm-card-strip', `fm-strip-${summary.level}`],
+            hidden: summary.level === 'ok',
+            text  : summary.level === 'ok' ? '' : summary.text
         });
         strip.changeVdomRootKey('aria-label', summary.ariaLabel);
 

--- a/apps/agentos/view/fleet/FleetCockpit.mjs
+++ b/apps/agentos/view/fleet/FleetCockpit.mjs
@@ -1,30 +1,30 @@
-import ActivityStream              from './ActivityStream.mjs';
-import AddAgentForm                from './AddAgentForm.mjs';
-import AgentDetail                 from './AgentDetail.mjs';
-import Button                      from '../../../../src/button/Base.mjs';
-import CatchUpPane                 from './CatchUpPane.mjs';
-import Component                   from '../../../../src/component/Base.mjs';
-import Container                   from '../../../../src/container/Base.mjs';
-import DockLayoutAdapter           from '../../../../src/dashboard/DockLayoutAdapter.mjs';
-import DockMotionSignal            from '../../../../src/dashboard/DockMotionSignal.mjs';
-import DockPerspectiveStore        from '../../../../src/dashboard/DockPerspectiveStore.mjs';
-import DockPreviewProducer         from '../../../../src/dashboard/DockPreviewProducer.mjs';
-import DockProjectionReconciler    from '../../../../src/dashboard/DockProjectionReconciler.mjs';
-import DockService                 from '../../../../src/ai/client/DockService.mjs';
-import DockZoneModel               from '../../../../src/dashboard/DockZoneModel.mjs';
-import FleetCockpitController      from './FleetCockpitController.mjs';
-import FleetGrid                   from './FleetGrid.mjs';
-import FleetRoster                 from '../../store/FleetRoster.mjs';
-import MemoriesPane                from './MemoriesPane.mjs';
-import OperatorMailbox             from './OperatorMailbox.mjs';
-import WakeRoutePane               from './WakeRoutePane.mjs';
-import StateProvider               from '../../../../src/state/Provider.mjs';
-import cockpitDockDocument         from './cockpitDockDocument.mjs';
-import cockpitPresetCollection     from './cockpitPresets.mjs';
-import {createDockTearOutHandlers} from '../../../../src/dashboard/DockTearOut.mjs';
-import {deriveSpineBanner}         from './spineBanner.mjs';
-import {mapFleetSessionHealth}     from './sourceHealth.mjs';
-import {previewToOperation}        from '../../../../src/dashboard/dockPreviewContract.mjs';
+import ActivityStream                           from './ActivityStream.mjs';
+import AddAgentForm                             from './AddAgentForm.mjs';
+import AgentDetail                              from './AgentDetail.mjs';
+import Button                                   from '../../../../src/button/Base.mjs';
+import CatchUpPane                              from './CatchUpPane.mjs';
+import Component                                from '../../../../src/component/Base.mjs';
+import Container                                from '../../../../src/container/Base.mjs';
+import DockLayoutAdapter                        from '../../../../src/dashboard/DockLayoutAdapter.mjs';
+import DockMotionSignal                         from '../../../../src/dashboard/DockMotionSignal.mjs';
+import DockPerspectiveStore                     from '../../../../src/dashboard/DockPerspectiveStore.mjs';
+import DockPreviewProducer                      from '../../../../src/dashboard/DockPreviewProducer.mjs';
+import DockProjectionReconciler                 from '../../../../src/dashboard/DockProjectionReconciler.mjs';
+import DockService                              from '../../../../src/ai/client/DockService.mjs';
+import DockZoneModel                            from '../../../../src/dashboard/DockZoneModel.mjs';
+import FleetCockpitController                   from './FleetCockpitController.mjs';
+import FleetGrid                                from './FleetGrid.mjs';
+import FleetRoster                              from '../../store/FleetRoster.mjs';
+import MemoriesPane                             from './MemoriesPane.mjs';
+import OperatorMailbox                          from './OperatorMailbox.mjs';
+import WakeRoutePane                            from './WakeRoutePane.mjs';
+import StateProvider                            from '../../../../src/state/Provider.mjs';
+import cockpitDockDocument                      from './cockpitDockDocument.mjs';
+import cockpitPresetCollection                  from './cockpitPresets.mjs';
+import {createDockTearOutHandlers}              from '../../../../src/dashboard/DockTearOut.mjs';
+import {DAEMON_FAULT_STATES, deriveSpineBanner} from './spineBanner.mjs';
+import {mapFleetSessionHealth}                  from './sourceHealth.mjs';
+import {previewToOperation}                     from '../../../../src/dashboard/dockPreviewContract.mjs';
 import '../../../../src/tab/Container.mjs'; // registers the `tab-container` ntype the dock projection emits for tab zones
 
 /**
@@ -2842,6 +2842,11 @@ class FleetCockpit extends Container {
         me.daemonDegradedReason = state !== 'running' && response.cause
             ? (response.cause.detail || response.cause.source || null)
             : null;
+
+        // the header's aggregate fold reads the SAME fault set the banner renders from — one
+        // lifecycle authority, plumbed as a boolean; the grid derives nothing about daemons
+        const grid = me.getReference('fleet-grid');
+        grid && (grid.daemonFault = DAEMON_FAULT_STATES.includes(state));
 
         me.syncSpineBanner()
     }

--- a/apps/agentos/view/fleet/FleetGrid.mjs
+++ b/apps/agentos/view/fleet/FleetGrid.mjs
@@ -125,6 +125,14 @@ class FleetGrid extends Container {
          */
         presenceCapability_: null,
         /**
+         * Whether a Brain daemon sits in a fault state — the spine banner's own fault set
+         * (`DAEMON_FAULT_STATES`), plumbed by the cockpit from the one lifecycle authority. Feeds
+         * the health bar's aggregate attention fold; this grid derives nothing about daemons.
+         * @member {Boolean} daemonFault_=false
+         * @reactive
+         */
+        daemonFault_: false,
+        /**
          * An OPTIONAL Up/Down efficiency shortcut that jumps focus between the DRILL Buttons only (the
          * gate-1 scale disposition) — a fast inter-agent jump for large rosters WITHOUT an outer roving
          * tab stop or a hidden interaction mode. Every control (drill / toggle / restart) stays in ordinary
@@ -258,7 +266,34 @@ class FleetGrid extends Container {
             chip     = this.getReference('fleet-presence-cap');
 
         chip.set({hidden: !degraded, text});
-        chip.changeVdomRootKey('aria-label', degraded ? `Presence: unobservable.${reason ? ` ${reason}.` : ''}` : null)
+        chip.changeVdomRootKey('aria-label', degraded ? `Presence: unobservable.${reason ? ` ${reason}.` : ''}` : null);
+
+        // the chip and the aggregate dot read ONE fact: a rendered degradation always carries
+        // attention weight, so the chip can never sit over a green header
+        this.pushAttentionInputs()
+    }
+
+    /**
+     * Triggered after the daemonFault config changed — the cockpit-plumbed lifecycle fact feeds
+     * the bar's aggregate fold.
+     * @param {Boolean} value
+     * @param {Boolean} oldValue
+     * @protected
+     */
+    afterSetDaemonFault(value, oldValue) {
+        this.isConstructed && this.pushAttentionInputs()
+    }
+
+    /**
+     * @summary Hand the bar the non-roster attention facts this grid holds — one push site, so the
+     * chip render and the aggregate verdict cannot diverge.
+     * @protected
+     */
+    pushAttentionInputs() {
+        this.getReference('fleet-health').attentionInputs = {
+            daemonFault     : this.daemonFault === true,
+            presenceDegraded: this.presenceCapability?.state === 'degraded'
+        }
     }
 
     /**

--- a/apps/agentos/view/fleet/HealthBar.mjs
+++ b/apps/agentos/view/fleet/HealthBar.mjs
@@ -3,12 +3,22 @@ import HealthSwatch from './HealthSwatch.mjs';
 import {resolveFleetDisplayState} from './sourceHealth.mjs';
 
 /**
- * Canonical category order for the health summary — the six session-state buckets in the SSOT
- * legend order (working · idle · wedged · rate-limited · unobserved · benched/offline). One
- * vocabulary shared with {@link HealthSwatch} / {@link StateDot} on the agent-health axis.
+ * Canonical category order for the health summary — the seven session-state buckets in the SSOT
+ * legend order (working · idle · wedged · rate-limited · unobserved · external · benched/offline).
+ * One vocabulary shared with {@link HealthSwatch} / {@link StateDot} on the agent-health axis.
  * @type {String[]}
  */
-const HEALTH_ORDER = ['ok', 'idle', 'wedged', 'limited', 'unobserved', 'off'];
+const HEALTH_ORDER = ['ok', 'idle', 'wedged', 'limited', 'unobserved', 'external', 'off'];
+
+/**
+ * The display states that carry ATTENTION weight — the ones an operator should act on. Everything
+ * else is calm: `external` seats are the normal FM-as-client topology, `unobserved` claims nothing,
+ * and `ok`/`idle` are nominal. The bar derives its aggregate nominal/attention class from these, so
+ * a fleet of un-managed seats with nominal sources reads GREEN — the operator-ratified
+ * default-state contract (a header that is always yellow trains the operator to ignore it).
+ * @type {String[]}
+ */
+const ATTENTION_STATES = Object.freeze(['wedged', 'limited']);
 
 /**
  * @summary Pure fleet → per-category counts — the scale-to-a-glance tally.
@@ -23,17 +33,31 @@ const HEALTH_ORDER = ['ok', 'idle', 'wedged', 'limited', 'unobserved', 'off'];
  */
 export function healthCounts(agents) {
     const list   = Array.isArray(agents) ? agents : [],
-          counts = {ok: 0, idle: 0, wedged: 0, limited: 0, unobserved: 0, off: 0};
+          counts = {ok: 0, idle: 0, wedged: 0, limited: 0, unobserved: 0, external: 0, off: 0};
 
     list.forEach(agent => {
-        // canonical state → its own bucket; anything else (guest/unknown/absent) → off, never a 7th key
+        // canonical display state → its own bucket; a non-bucket value (transitional
+        // starting/stopping never reaches the tally, but fail closed anyway) → external, matching
+        // the resolver's own outside-supervision fold — never an invented benched verdict
         const resolved = resolveFleetDisplayState({state: agent?.state, sources: agent?.sources}),
-              key      = Object.hasOwn(counts, resolved) ? resolved : 'off';
+              key      = Object.hasOwn(counts, resolved) ? resolved : 'external';
 
         counts[key] += 1
     });
 
     return counts
+}
+
+/**
+ * @summary Pure counts → aggregate attention verdict: `true` when any attention-weighted bucket is
+ * non-zero. `external`/`unobserved`/`off` deliberately carry no weight — un-managed seats are the
+ * normal topology, and a managed-stopped seat is a fact, not an alarm. Exported for the header's
+ * nominal/attention class and unit-provable in isolation.
+ * @param {Object} counts The {@link #healthCounts} result.
+ * @returns {Boolean}
+ */
+export function hasAttention(counts) {
+    return ATTENTION_STATES.some(state => (counts?.[state] ?? 0) > 0)
 }
 
 /**
@@ -182,14 +206,21 @@ class HealthBar extends Container {
 
     /**
      * @summary Push the current per-category counts onto the stable swatch instances — in place, so
-     * the transition animates rather than the bar rebuilding.
+     * the transition animates rather than the bar rebuilding — and reflect the aggregate verdict as
+     * the nominal/attention class pair the skin colours (calm green when nothing needs an operator,
+     * attention only for states one should act on).
      */
     applyCounts() {
-        const counts = healthCounts(this.store?.items ?? []);
+        let me     = this,
+            counts = healthCounts(me.store?.items ?? []),
+            alert  = hasAttention(counts);
 
-        this.items.forEach(swatch => {
+        me.items.forEach(swatch => {
             swatch.count = counts[swatch.state] ?? 0
-        })
+        });
+
+        me.toggleCls('fm-health-attention', alert);
+        me.toggleCls('fm-health-nominal', !alert)
     }
 }
 

--- a/apps/agentos/view/fleet/HealthBar.mjs
+++ b/apps/agentos/view/fleet/HealthBar.mjs
@@ -86,7 +86,9 @@ export function deriveAttention({counts, rows = [], daemonFault = false, presenc
     return (Array.isArray(rows) ? rows : []).some(row => {
         const sources = normalizeFleetSources(row?.sources);
 
-        return FLEET_SOURCE_KEYS.some(key => sources[key].state === 'missing')
+        // missing (a producer answered something is gone) and invalid (a present answer the
+        // contract rejected) both carry weight; only genuine absence stays calm
+        return FLEET_SOURCE_KEYS.some(key => sources[key].state === 'missing' || sources[key].state === 'invalid')
     })
 }
 

--- a/apps/agentos/view/fleet/HealthBar.mjs
+++ b/apps/agentos/view/fleet/HealthBar.mjs
@@ -1,6 +1,6 @@
-import Container    from '../../../../src/container/Base.mjs';
-import HealthSwatch from './HealthSwatch.mjs';
-import {resolveFleetDisplayState} from './sourceHealth.mjs';
+import Container                                                            from '../../../../src/container/Base.mjs';
+import HealthSwatch                                                         from './HealthSwatch.mjs';
+import {FLEET_SOURCE_KEYS, normalizeFleetSources, resolveFleetDisplayState} from './sourceHealth.mjs';
 
 /**
  * Canonical category order for the health summary — the seven session-state buckets in the SSOT
@@ -49,15 +49,45 @@ export function healthCounts(agents) {
 }
 
 /**
- * @summary Pure counts → aggregate attention verdict: `true` when any attention-weighted bucket is
+ * @summary Pure counts → session-bucket attention: `true` when any attention-weighted bucket is
  * non-zero. `external`/`unobserved`/`off` deliberately carry no weight — un-managed seats are the
- * normal topology, and a managed-stopped seat is a fact, not an alarm. Exported for the header's
- * nominal/attention class and unit-provable in isolation.
+ * normal topology, and a managed-stopped seat is a fact, not an alarm. One input to
+ * {@link #deriveAttention}; exported separately so the bucket matrix stays unit-provable alone.
  * @param {Object} counts The {@link #healthCounts} result.
  * @returns {Boolean}
  */
 export function hasAttention(counts) {
     return ATTENTION_STATES.some(state => (counts?.[state] ?? 0) > 0)
+}
+
+/**
+ * @summary The single aggregate attention projection — every truth the header dot claims to
+ * summarize, folded in one pure derivation:
+ * - **session buckets** ({@link #hasAttention}: wedged / rate-limited);
+ * - **answered-abnormal sources**: any row source fact whose state is `missing` — a producer
+ *   ANSWERED that something is gone. `not-wired` deliberately contributes nothing: it is the
+ *   expected-absent state of every un-managed seat, and weighting it would make the header
+ *   permanently yellow again — the exact falsified default this ticket retires;
+ * - **degraded presence capability** (the roster-level chip's condition — the two surfaces read
+ *   one fact, so the chip can never render over a green dot);
+ * - **daemon fault** (the spine banner's own fault set, plumbed as a boolean — one authority).
+ * @param {Object} options
+ * @param {Object} [options.counts] The {@link #healthCounts} result.
+ * @param {Object[]} [options.rows=[]] Roster rows carrying `sources` field bags.
+ * @param {Boolean} [options.daemonFault=false] Brain daemon in a fault state.
+ * @param {Boolean} [options.presenceDegraded=false] Presence capability envelope degraded.
+ * @returns {Boolean}
+ */
+export function deriveAttention({counts, rows = [], daemonFault = false, presenceDegraded = false} = {}) {
+    if (hasAttention(counts) || daemonFault || presenceDegraded) {
+        return true
+    }
+
+    return (Array.isArray(rows) ? rows : []).some(row => {
+        const sources = normalizeFleetSources(row?.sources);
+
+        return FLEET_SOURCE_KEYS.some(key => sources[key].state === 'missing')
+    })
 }
 
 /**
@@ -112,6 +142,15 @@ class HealthBar extends Container {
          */
         animateCounts_: true,
         /**
+         * The non-roster attention facts the aggregate dot folds beside the row-derived truth:
+         * `{daemonFault: Boolean, presenceDegraded: Boolean}`, plumbed by the owning surface
+         * (FleetGrid / the cockpit) from the authorities that already hold them — the bar derives
+         * nothing about daemons or capabilities itself, it only summarizes what it is handed.
+         * @member {Object|null} attentionInputs_=null
+         * @reactive
+         */
+        attentionInputs_: null,
+        /**
          * One stable swatch per canonical category, in legend order — counts update in place.
          * @member {Object[]} items
          */
@@ -156,6 +195,17 @@ class HealthBar extends Container {
     }
 
     /**
+     * Triggered after the attentionInputs config changed — the non-roster halves of the aggregate
+     * verdict moved (daemon fault / presence capability), so the fold re-derives.
+     * @param {Object|null} value
+     * @param {Object|null} oldValue
+     * @protected
+     */
+    afterSetAttentionInputs(value, oldValue) {
+        this.isConstructed && this.applyCounts()
+    }
+
+    /**
      * @summary The one listener set this bar seats on its bound store — kept in one place so
      * `afterSetStore` re-seating and `destroy` teardown stay symmetric.
      * @returns {Object}
@@ -177,13 +227,14 @@ class HealthBar extends Container {
     }
 
     /**
-     * @summary One record's fields changed — only a session-`state` change can move a resident
-     * between buckets, so anything else is a no-op for the tally.
+     * @summary One record's fields changed — a session-`state` change can move a resident between
+     * buckets, and a `sources` change can flip both the resolved bucket (unmanaged↔managed) AND
+     * the answered-abnormal half of the aggregate verdict; anything else is a no-op for the tally.
      * @param {Object} data The store recordChange event `{fields, record, index, model}`.
      * @protected
      */
     onStoreRecordChange({fields}) {
-        this.isConstructed && fields.some(field => field.name === 'state') && this.applyCounts()
+        this.isConstructed && fields.some(field => field.name === 'state' || field.name === 'sources') && this.applyCounts()
     }
 
     /**
@@ -206,14 +257,20 @@ class HealthBar extends Container {
 
     /**
      * @summary Push the current per-category counts onto the stable swatch instances — in place, so
-     * the transition animates rather than the bar rebuilding — and reflect the aggregate verdict as
-     * the nominal/attention class pair the skin colours (calm green when nothing needs an operator,
-     * attention only for states one should act on).
+     * the transition animates rather than the bar rebuilding — and reflect the SINGLE aggregate
+     * projection ({@link #deriveAttention}: session buckets + answered-abnormal sources + the
+     * plumbed daemon/presence facts) as the nominal/attention class pair the skin colours.
      */
     applyCounts() {
         let me     = this,
-            counts = healthCounts(me.store?.items ?? []),
-            alert  = hasAttention(counts);
+            rows   = me.store?.items ?? [],
+            counts = healthCounts(rows),
+            alert  = deriveAttention({
+                counts,
+                rows,
+                daemonFault     : me.attentionInputs?.daemonFault      === true,
+                presenceDegraded: me.attentionInputs?.presenceDegraded === true
+            });
 
         me.items.forEach(swatch => {
             swatch.count = counts[swatch.state] ?? 0

--- a/apps/agentos/view/fleet/SourceHealthMarker.mjs
+++ b/apps/agentos/view/fleet/SourceHealthMarker.mjs
@@ -28,7 +28,9 @@ export function sourceMarkerView(sourceKey, health) {
             ? normalized.confidence.toUpperCase()
             : normalized.state === 'missing'
                 ? 'MISSING'
-                : 'NOT WIRED';
+                : normalized.state === 'invalid'
+                    ? 'INVALID'
+                    : 'NOT WIRED';
 
     return {
         ...normalized,

--- a/apps/agentos/view/fleet/StateDot.mjs
+++ b/apps/agentos/view/fleet/StateDot.mjs
@@ -22,6 +22,10 @@ const STATE_TOKEN = {
     // participation-active with NO session observation: the slate signal-pending token, visually
     // distinct from off's dead grey — no liveness claimed, no benched verdict claimed.
     unobserved: '--fm-state-unobserved',
+    // a seat Fleet does not manage: supervision vocabulary does not apply, so the dot carries the
+    // calm neutral token — un-managed is the NORMAL topology on FM-as-client deployments, never an
+    // attention state (the operator-ratified default-state contract).
+    external: '--fm-state-external',
     off     : '--fm-state-off'
 };
 
@@ -64,6 +68,10 @@ const STATE_LABEL = {
     starting: 'starting',
     stopping: 'stopping',
     unobserved: 'unobserved',
+    // neutral operator copy, not a supervision verdict: the seat runs in its own harness and Fleet
+    // simply does not manage it — "offline" would be a fact about FLEET presented as a fact about
+    // the agent (the falsified copy this label replaces).
+    external: 'external harness',
     off     : 'benched / offline'
 };
 

--- a/apps/agentos/view/fleet/sourceHealth.mjs
+++ b/apps/agentos/view/fleet/sourceHealth.mjs
@@ -62,17 +62,27 @@ export function normalizeSourceFact(value, expectedSource = null) {
         return {source, state: 'invalid', confidence: 'none', reason: reason ?? 'source fact failed producer validation'}
     }
 
+    // `missing` and `not-wired` cannot CARRY confidence: only the explicit `none` pairing is the
+    // declared shape. A present fact asserting `missing`/`not-wired` WITH an observation
+    // confidence is a contradictory pair — rejected evidence, never accepted onto the calm or
+    // answered-abnormal vocabulary (accepting impossible confidence on absence states would
+    // recreate the exact rejected-evidence→nominal conflation `invalid` exists to remove).
     if (state === 'missing') {
-        return {source, state: 'missing', confidence: 'none', reason}
+        return confidence === 'none'
+            ? {source, state: 'missing', confidence: 'none', reason}
+            : {source, state: 'invalid', confidence: 'none', reason: reason ?? 'source fact failed contract validation'}
     }
 
     if (state === 'wired' && (confidence === 'observed' || confidence === 'inferred')) {
         return {source, state: 'wired', confidence, reason}
     }
 
-    // The producer explicitly declares expected absence — the ONE present shape allowed to be calm.
+    // The producer explicitly declares expected absence — the ONE present shape allowed to be
+    // calm, and only with the explicit `none` confidence it is declared with.
     if (state === 'not-wired') {
-        return {source, state: 'not-wired', confidence: 'none', reason}
+        return confidence === 'none'
+            ? {source, state: 'not-wired', confidence: 'none', reason}
+            : {source, state: 'invalid', confidence: 'none', reason: reason ?? 'source fact failed contract validation'}
     }
 
     // Everything else is a present fact this contract cannot read (unknown state, cross-axis

--- a/apps/agentos/view/fleet/sourceHealth.mjs
+++ b/apps/agentos/view/fleet/sourceHealth.mjs
@@ -113,6 +113,46 @@ export function summarizeFleetSources(value) {
         return {level: 'ok', text: 'all sources nominal', ariaLabel: 'Source health: all sources nominal.'}
     }
 
+    return buildAbnormalSummary(sources, abnormal, labels)
+}
+
+/**
+ * @summary The strip's ANSWERED-abnormal summary — the one interpretation of `not-wired` shared
+ * with the aggregate attention fold: a `missing` fact is a producer ANSWERING that something is
+ * gone (renders, with its name and retained reason, and carries weight); `not-wired` is expected
+ * absence (earns zero pixels here exactly as it carries zero weight there — rendering it was the
+ * second permanent default-state line the operator verdict retired). Split from
+ * {@link #summarizeFleetSources} so the legacy any-abnormal summary stays available to the
+ * detail/drill surfaces that enumerate every fact.
+ * @param {*} value Source collection; malformed values fail closed.
+ * @returns {{level: String, text: String, ariaLabel: String}} `level` is `ok` (nothing answered
+ *     abnormal — the strip renders nothing) or `bad`.
+ */
+export function summarizeAnsweredAbnormal(value) {
+    const
+        sources  = normalizeFleetSources(value),
+        labels   = {runtime: 'Runtime', repoStatus: 'Repository', roster: 'Roster'},
+        order    = ['runtime', 'repoStatus', 'roster'],
+        abnormal = order.filter(key => sources[key].state === 'missing');
+
+    if (abnormal.length === 0) {
+        return {level: 'ok', text: '', ariaLabel: 'Source health: nothing answered abnormal.'}
+    }
+
+    return buildAbnormalSummary(sources, abnormal, labels)
+}
+
+/**
+ * @summary Shared abnormal-line composer: leading source name (+N overflow) with the leading
+ * source's retained reason when one exists — name-only otherwise, never a fabricated cause.
+ * @param {Object} sources Normalized source facts.
+ * @param {String[]} abnormal Abnormal keys, action-owning order.
+ * @param {Object} labels Full-word labels.
+ * @returns {{level: String, text: String, ariaLabel: String}}
+ * @private
+ */
+function buildAbnormalSummary(sources, abnormal, labels) {
+
     const
         first = abnormal[0],
         extra = abnormal.length > 1 ? ` +${abnormal.length - 1}` : '',

--- a/apps/agentos/view/fleet/sourceHealth.mjs
+++ b/apps/agentos/view/fleet/sourceHealth.mjs
@@ -2,8 +2,10 @@ import {FLEET_COCKPIT_SOURCES} from '../../config/cockpitSources.mjs';
 
 /**
  * @summary Closed source-health contract shared by the Fleet cockpit's store-backed cards and
- * serializable dock blueprints. It preserves the DTO's roster / repo / runtime provenance while
- * failing malformed or contradictory input to `not-wired` + `none` — never to healthy fact.
+ * serializable dock blueprints. It preserves the DTO's roster / repo / runtime provenance under a
+ * three-way honesty split: GENUINE absence (absent key or declared `not-wired`) is calm; a present
+ * fact the contract REJECTS (malformed, cross-axis, contradictory) is `invalid` — operator-visible
+ * and attention-bearing, never a healthy fact and never silently absent.
  */
 
 export const FLEET_SOURCE_KEYS = Object.freeze(['roster', 'repoStatus', 'runtime']);
@@ -18,16 +20,26 @@ const
 
 /**
  * @summary Normalize one `fleetCockpitStatus` row-source fact onto the closed render vocabulary.
- * `missing` and `not-wired` cannot carry confidence; `wired` is usable only with `observed` or
- * `inferred`. When supplied, `expectedSource` closes the fact over its DTO-owned producer. Unknown,
- * inherited, malformed, cross-axis, and contradictory values fail closed.
- * @param {*} value Source-health input; malformed values fail closed.
+ * `missing`, `not-wired`, and `invalid` cannot carry confidence; `wired` is usable only with
+ * `observed` or `inferred`. When supplied, `expectedSource` closes the fact over its DTO-owned
+ * producer. Absent input fails closed to the calm `not-wired`; unknown, inherited-shaped,
+ * malformed, cross-axis, and contradictory PRESENT values read `invalid` — rejected evidence is
+ * never conflated with absence.
+ * @param {*} value Source-health input.
  * @param {String|null} expectedSource Canonical producer literal for this source axis.
- * @returns {{source: String|null, state: String, confidence: String}}
+ * @returns {{source: String|null, state: String, confidence: String, reason: String|null}}
  */
 export function normalizeSourceFact(value, expectedSource = null) {
-    if (!isPlainObject(value)) {
+    // GENUINE absence: no fact was supplied at all (the absent-key path). Only this shape may be
+    // calm — an ABSENT producer is not the same fact as a REJECTED answer, and conflating them
+    // would let validation failure normalize into a green surface.
+    if (value === null || value === undefined) {
         return {source: null, state: 'not-wired', confidence: 'none', reason: null}
+    }
+
+    // PRESENT but not a plain own-key object: rejected evidence, not absence.
+    if (!isPlainObject(value)) {
+        return {source: null, state: 'invalid', confidence: 'none', reason: 'malformed source fact'}
     }
 
     const
@@ -44,8 +56,10 @@ export function normalizeSourceFact(value, expectedSource = null) {
             ? value.reason.trim()
             : null;
 
+    // A PRESENT fact naming no producer — or the wrong one — is rejected evidence: `invalid`,
+    // never `not-wired`. The retained reason survives; the rejection itself is the fallback cause.
     if (!source || expectedSource && source !== expectedSource) {
-        return {source, state: 'not-wired', confidence: 'none', reason}
+        return {source, state: 'invalid', confidence: 'none', reason: reason ?? 'source fact failed producer validation'}
     }
 
     if (state === 'missing') {
@@ -56,7 +70,14 @@ export function normalizeSourceFact(value, expectedSource = null) {
         return {source, state: 'wired', confidence, reason}
     }
 
-    return {source, state: 'not-wired', confidence: 'none', reason}
+    // The producer explicitly declares expected absence — the ONE present shape allowed to be calm.
+    if (state === 'not-wired') {
+        return {source, state: 'not-wired', confidence: 'none', reason}
+    }
+
+    // Everything else is a present fact this contract cannot read (unknown state, cross-axis
+    // value, contradictory confidence): rejected evidence, operator-visible.
+    return {source, state: 'invalid', confidence: 'none', reason: reason ?? 'source fact failed contract validation'}
 }
 
 /**
@@ -130,10 +151,13 @@ export function summarizeFleetSources(value) {
  */
 export function summarizeAnsweredAbnormal(value) {
     const
-        sources  = normalizeFleetSources(value),
-        labels   = {runtime: 'Runtime', repoStatus: 'Repository', roster: 'Roster'},
-        order    = ['runtime', 'repoStatus', 'roster'],
-        abnormal = order.filter(key => sources[key].state === 'missing');
+        sources = normalizeFleetSources(value),
+        labels  = {runtime: 'Runtime', repoStatus: 'Repository', roster: 'Roster'},
+        order   = ['runtime', 'repoStatus', 'roster'],
+        // missing = a producer ANSWERED that something is gone; invalid = a present answer this
+        // contract REJECTED. Both are operator-visible truth; only genuine absence (`not-wired`,
+        // whether declared or absent-key) stays silent.
+        abnormal = order.filter(key => sources[key].state === 'missing' || sources[key].state === 'invalid');
 
     if (abnormal.length === 0) {
         return {level: 'ok', text: '', ariaLabel: 'Source health: nothing answered abnormal.'}
@@ -184,9 +208,10 @@ export function mapFleetSessionHealth(lifecycle, sources) {
         downgradeRuntime  = () => ({
             sources: {
                 ...normalizedSources,
-                // the downgrade keeps the producer's retained cause — a fact failing closed keeps
-                // the reason that explains why (the same rule normalizeSourceFact follows)
-                runtime: {source: runtime.source, state: 'not-wired', confidence: 'none', reason: runtime.reason}
+                // a lifecycle/source CONTRADICTION is rejected evidence, not absence — `invalid`
+                // keeps it operator-visible and attention-bearing; the producer's retained cause
+                // survives, with the contradiction named as the fallback
+                runtime: {source: runtime.source, state: 'invalid', confidence: 'none', reason: runtime.reason ?? 'lifecycle and runtime facts contradict'}
             },
             state: 'off'
         });

--- a/apps/agentos/view/fleet/sourceHealth.mjs
+++ b/apps/agentos/view/fleet/sourceHealth.mjs
@@ -176,31 +176,39 @@ export function mapFleetSessionHealth(lifecycle, sources) {
  * @summary Resolve one roster row's display state as ONE atomic honesty contract shared by the
  * AgentCard and the HealthBar, so the card grain and the glance tally can never diverge.
  *
- * The vocabulary distinguishes participation truth from session truth:
- * - **Wired runtime** → the row's `state` IS session truth (observed/inferred) and renders as-is.
- * - **Not-wired + `state: 'off'`** → a first-party participation fact (operator-benched, e.g.
- *   identityRoots `operator_benched`) — renders `off` (`benched / offline`), never softened.
- * - **Not-wired + any other state** → participation-active with NO session observation (the
- *   derived sample path) — renders `unobserved`: no liveness is claimed and no benched verdict
- *   is claimed. Rendering it `off` would be a false participation claim; rendering it `ok`
- *   would fabricate session liveness. `unobserved` is the honest third answer.
+ * The vocabulary distinguishes participation truth from session truth, under one invariant:
+ * **supervision vocabulary renders only where supervision exists (a wired runtime)** — the
+ * operator-ratified default-state contract; un-managed is the NORMAL topology on FM-as-client
+ * deployments and must never read as a supervision verdict or carry attention weight.
+ * - **Wired runtime** → the row's `state` IS session truth (observed/inferred) and renders as-is —
+ *   including `off` (`benched / offline`): a process Fleet manages and knows to be stopped.
+ * - **Not-wired + `state: 'off'`** (and unknown / guest / missing rows, which are equally outside
+ *   any supervision contract) → `external`: the seat runs in its own harness; Fleet manages
+ *   nothing here, so no benched/offline verdict exists to claim. The previous mapping rendered
+ *   these `off` — the falsified copy ("offline" about agents visibly merging PRs) this partition
+ *   retires.
+ * - **Not-wired + any other canonical state** → participation-active with NO session observation
+ *   (the derived sample path) — renders `unobserved`: no liveness is claimed and no benched
+ *   verdict is claimed. Rendering it `off` would be a false participation claim; rendering it
+ *   `ok` would fabricate session liveness.
  * @param {Object} data
  * @param {String|null} [data.state] The row's raw state field.
  * @param {Object|null} [data.sources] The row's source facts (normalized here; malformed fails closed).
- * @returns {String} `ok` · `idle` · `wedged` · `limited` · `off` · `unobserved`
+ * @returns {String} `ok` · `idle` · `wedged` · `limited` · `off` · `unobserved` · `external`
  */
 export function resolveFleetDisplayState({state, sources} = {}) {
     if (normalizeFleetSources(sources).runtime.state === 'wired') {
         return state ?? 'off'
     }
 
-    // unknown / guest / missing rows are not participation-active: they fold to `off`, matching
-    // the grid's benched tier — `unobserved` belongs only to canonical states.
-    if (!CARD_STATES.includes(state)) {
-        return 'off'
+    // unknown / guest / missing rows sit outside any supervision contract exactly like an
+    // explicit un-managed `off` — both resolve `external` (the grid's raw-state tail tiering is
+    // unaffected: it reads `agent.state`, never this display value).
+    if (!CARD_STATES.includes(state) || state === 'off') {
+        return 'external'
     }
 
-    return state === 'off' ? 'off' : 'unobserved'
+    return 'unobserved'
 }
 
 /**

--- a/apps/agentos/view/fleet/sourceHealth.mjs
+++ b/apps/agentos/view/fleet/sourceHealth.mjs
@@ -27,7 +27,7 @@ const
  */
 export function normalizeSourceFact(value, expectedSource = null) {
     if (!isPlainObject(value)) {
-        return {source: null, state: 'not-wired', confidence: 'none'}
+        return {source: null, state: 'not-wired', confidence: 'none', reason: null}
     }
 
     const
@@ -35,21 +35,28 @@ export function normalizeSourceFact(value, expectedSource = null) {
             ? value.source.trim()
             : null,
         state      = Object.hasOwn(value, 'state') ? value.state : null,
-        confidence = Object.hasOwn(value, 'confidence') ? value.confidence : null;
+        confidence = Object.hasOwn(value, 'confidence') ? value.confidence : null,
+        // the producer's retained cause survives normalization VERBATIM (trimmed): the abnormal
+        // summary must name source AND reason, and a reason invented here would be a fabrication —
+        // absent stays null. Carried on every branch: a fact failing closed keeps the cause that
+        // explains WHY it failed closed.
+        reason     = Object.hasOwn(value, 'reason') && typeof value.reason === 'string' && value.reason.trim()
+            ? value.reason.trim()
+            : null;
 
     if (!source || expectedSource && source !== expectedSource) {
-        return {source, state: 'not-wired', confidence: 'none'}
+        return {source, state: 'not-wired', confidence: 'none', reason}
     }
 
     if (state === 'missing') {
-        return {source, state: 'missing', confidence: 'none'}
+        return {source, state: 'missing', confidence: 'none', reason}
     }
 
     if (state === 'wired' && (confidence === 'observed' || confidence === 'inferred')) {
-        return {source, state: 'wired', confidence}
+        return {source, state: 'wired', confidence, reason}
     }
 
-    return {source, state: 'not-wired', confidence: 'none'}
+    return {source, state: 'not-wired', confidence: 'none', reason}
 }
 
 /**
@@ -108,12 +115,16 @@ export function summarizeFleetSources(value) {
 
     const
         first = abnormal[0],
-        extra = abnormal.length > 1 ? ` +${abnormal.length - 1}` : '';
+        extra = abnormal.length > 1 ? ` +${abnormal.length - 1}` : '',
+        // the leading abnormal source's retained cause rides the line — name AND reason, the
+        // operator-ratified bar for a rendered exception. A reasonless fact renders name-only
+        // (never a fabricated cause); the text node downstream keeps the whole line inert.
+        reason = sources[first].reason ? ` · ${sources[first].reason}` : '';
 
     return {
         level    : 'bad',
-        text     : `${labels[first]} not nominal${extra}`,
-        ariaLabel: `Source health: ${abnormal.map(key => labels[key]).join(', ')} not nominal.`
+        text     : `${labels[first]} not nominal${extra}${reason}`,
+        ariaLabel: `Source health: ${abnormal.map(key => labels[key]).join(', ')} not nominal.${sources[first].reason ? ` ${labels[first]}: ${sources[first].reason}.` : ''}`
     }
 }
 
@@ -133,7 +144,9 @@ export function mapFleetSessionHealth(lifecycle, sources) {
         downgradeRuntime  = () => ({
             sources: {
                 ...normalizedSources,
-                runtime: {source: runtime.source, state: 'not-wired', confidence: 'none'}
+                // the downgrade keeps the producer's retained cause — a fact failing closed keeps
+                // the reason that explains why (the same rule normalizeSourceFact follows)
+                runtime: {source: runtime.source, state: 'not-wired', confidence: 'none', reason: runtime.reason}
             },
             state: 'off'
         });

--- a/apps/agentos/view/fleet/spineBanner.mjs
+++ b/apps/agentos/view/fleet/spineBanner.mjs
@@ -79,10 +79,11 @@ function reasonFor(surfaces, state) {
 /**
  * Brain daemon states that warrant the banner. `running` is nominal and earns zero pixels; an absent
  * or unrecognised state is UNKNOWN and also stays quiet — see the module note on daemon silence.
- * Mirrors `harness/appLifecycle.mjs`'s `BRAIN_STATES` minus the nominal one.
+ * Mirrors `harness/appLifecycle.mjs`'s `BRAIN_STATES` minus the nominal one. Exported so the
+ * header's aggregate attention fold reads the SAME fault set — one authority, two consumers.
  * @type {String[]}
  */
-const DAEMON_FAULT_STATES = Object.freeze(['degraded', 'stopped']);
+export const DAEMON_FAULT_STATES = Object.freeze(['degraded', 'stopped']);
 
 /**
  * @summary Picks the cold-case fallback line for SILENCE, from the topology that owns the truth.

--- a/resources/scss/src/apps/agentos/fleet/HealthBar.scss
+++ b/resources/scss/src/apps/agentos/fleet/HealthBar.scss
@@ -4,6 +4,26 @@
 .fm-health-bar {
     gap: 12px;
 
+    /* The aggregate verdict dot: ONE glanceable header signal ahead of the counts — green when no
+       state needs an operator (the default-state contract: a fleet of un-managed seats is CALM),
+       attention-toned only when an actionable bucket is non-zero. Colors ride the existing state
+       tokens — zero new hues; the counts beside it remain the accessible non-colour carrier. */
+    &::before {
+        border-radius: 50%;
+        content      : '';
+        flex         : none;
+        height       : 8px;
+        width        : 8px;
+    }
+
+    &.fm-health-nominal::before {
+        background: var(--fm-state-ok);
+    }
+
+    &.fm-health-attention::before {
+        background: var(--fm-state-wedged);
+    }
+
     @media (prefers-reduced-motion: no-preference) {
         &.fm-animate-counts .fm-sw-count {
             transition: color var(--motion-base) var(--ease-out-soft), opacity var(--motion-base) var(--ease-out-soft);

--- a/resources/scss/src/apps/agentos/fleet/SourceHealthMarker.scss
+++ b/resources/scss/src/apps/agentos/fleet/SourceHealthMarker.scss
@@ -45,4 +45,17 @@
     &.fm-source-not-wired::before {
         background: linear-gradient(135deg, transparent 42%, var(--fm-source-mark) 43%, var(--fm-source-mark) 57%, transparent 58%);
     }
+
+    /* rejected evidence (a present answer the contract refused): wedged-toned cross — visually
+       distinct from missing's dashed outline and not-wired's neutral slash, because an invalid
+       answer is operator-actionable where absence is not */
+    &.fm-source-invalid {
+        --fm-source-mark: var(--fm-state-wedged);
+    }
+
+    &.fm-source-invalid::before {
+        background:
+            linear-gradient(45deg,  transparent 42%, var(--fm-source-mark) 43%, var(--fm-source-mark) 57%, transparent 58%),
+            linear-gradient(135deg, transparent 42%, var(--fm-source-mark) 43%, var(--fm-source-mark) 57%, transparent 58%);
+    }
 }

--- a/resources/scss/theme-neo-dark/apps/agentos/Viewport.scss
+++ b/resources/scss/theme-neo-dark/apps/agentos/Viewport.scss
@@ -51,6 +51,9 @@
     // participation-active with no session observation: slate-blue "signal pending", distinct
     // from off's dead grey (#616d7c) — ≥3:1 against card surfaces (non-text floor).
     --fm-state-unobserved: #6b7f94;
+    // a seat Fleet does not manage (the FM-as-client normal): calm neutral, deliberately close to
+    // the dim ink — zero attention weight, distinct from off's supervision grey.
+    --fm-state-external: #7d8a9c;
     --fm-state-off     : #616d7c;
 
     --fm-family-claude : #d99a5b;

--- a/resources/scss/theme-neo-light/apps/agentos/Viewport.scss
+++ b/resources/scss/theme-neo-light/apps/agentos/Viewport.scss
@@ -58,6 +58,9 @@
     // participation-active with no session observation: slate-blue "signal pending", distinct
     // from off's dead grey (#7c889a) — ≥3:1 against card surfaces (non-text floor).
     --fm-state-unobserved: #5f6d7c;
+    // a seat Fleet does not manage (the FM-as-client normal): calm neutral, deliberately close to
+    // the dim ink — zero attention weight, distinct from off's supervision grey.
+    --fm-state-external: #6e7b8d;
     --fm-state-off     : #7c889a;
 
     --fm-family-claude : #a8621f;

--- a/test/playwright/unit/apps/agentos/view/fleet/agentCard.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/agentCard.spec.mjs
@@ -165,9 +165,11 @@ test.describe('Fleet cockpit AgentCard — resident card rendering its roster re
               stripId  = strip.id,
               stateDot = card.down({ntype: 'fm-state-dot'});
 
-        // all sources wired + observed → the honest nominal summary; the dot pulses live
-        expect(strip.text).toBe('all sources nominal');
-        expect(strip.cls).toContain('fm-strip-ok');
+        // all sources wired + observed → nominal earns ZERO pixels (the exception-only strip: the
+        // permanent "all sources nominal" line carried no operator meaning — the operator verdict
+        // this partition ships); the dot pulses live
+        expect(strip.hidden).toBe(true);
+        expect(strip.text).toBe('');
         expect(stateDot.state).toBe('ok');
         expect(stateDot.live).toBe(true);
 
@@ -182,6 +184,7 @@ test.describe('Fleet cockpit AgentCard — resident card rendering its roster re
 
         expect(card.id).toBe(beforeId);
         expect(card.down({reference: 'source-strip'}).id).toBe(stripId);   // same instance, updated in place
+        expect(strip.hidden).toBe(false);   // an abnormal source is the exception the strip exists for
         expect(strip.text).toBe('Runtime not nominal +1');   // pure status: full word, no ▸ affordance, never the RUN/REP/ROS acronym wall
         expect(strip.cls).toContain('fm-strip-bad');
         expect(stateDot.state).toBe('unobserved');
@@ -194,13 +197,14 @@ test.describe('Fleet cockpit AgentCard — resident card rendering its roster re
         // control-status line (which is reserved for the control round-trip: pending / timeout / rejected)
         expect(card.down({reference: 'control-status'}).hidden).toBe(true);
 
-        // all wired again (runtime merely INFERRED): the summary recovers to nominal and the controls
-        // re-enable, but the dot does NOT pulse — an inferred runtime is ok, not a live observation
+        // all wired again (runtime merely INFERRED): the strip recovers to zero pixels and the
+        // controls re-enable, but the dot does NOT pulse — an inferred runtime is ok, not a live
+        // observation
         applySet(card, {sources: {
             ...observedSources,
             runtime: {source: 'fleet:runtimeStatus', state: 'wired', confidence: 'inferred'}
         }});
-        expect(strip.text).toBe('all sources nominal');
+        expect(strip.hidden).toBe(true);
         expect(stateDot.state).toBe('ok');
         expect(stateDot.live).toBe(false);
         expect(card.down({reference: 'control-toggle'}).disabled).toBe(false);
@@ -490,10 +494,24 @@ test.describe('Fleet cockpit AgentCard — resident card rendering its roster re
         card.destroy()
     });
 
-    test('state-honesty: an explicit operator-benched `off` row keeps `benched / offline` even without a wired runtime (#15625)', () => {
-        // Gemini's seat is the fixture: `state: 'off'` is a first-party participation fact
-        // (identityRoots operator_benched), so the off verdict survives the missing runtime source
+    test('state-honesty: an un-wired `off` row renders `external harness` — supervision vocabulary only where supervision exists', () => {
+        // REVERSES the prior state-honesty mapping deliberately, under the newer operator
+        // ratification (the default-state contract): without a wired runtime there is no
+        // supervision contract, so "benched / offline" was a fact about FLEET presented as a
+        // verdict about the agent — falsified live against seats visibly working in their own
+        // harnesses. The participation fact still renders; its vocabulary is now neutral and
+        // carries no attention weight.
         const card = createCard({agentId: 'gemini', state: 'off', sources: {}});
+
+        expect(card.down({ntype: 'fm-state-dot'}).state).toBe('external');
+        expect(card.down({reference: 'card-state'}).text).toBe('external harness');
+
+        card.destroy()
+    });
+
+    test('state-honesty: a wired-and-stopped seat KEEPS `benched / offline` — the supervision verdict survives where supervision exists', () => {
+        // the partition's other half: Fleet manages this seat (wired runtime) and knows it stopped
+        const card = createCard({agentId: 'vega', state: 'off'});
 
         expect(card.down({ntype: 'fm-state-dot'}).state).toBe('off');
         expect(card.down({reference: 'card-state'}).text).toBe('benched / offline');
@@ -637,15 +655,11 @@ test.describe('Fleet cockpit AgentCard — resident card rendering its roster re
             strip = () => card.down({reference: 'source-strip'});
 
         // the role must reach the DOM through the vdom ROOT — a role that only lived in memory would
-        // announce nothing, and this strip is the card's source live-region
+        // announce nothing, and this strip is the card's source live-region. Nominal renders ZERO
+        // pixels (the exception-only contract), so the node exists hidden with no text to announce.
         expect(strip().vdom.role).toBe('status');
-        expect(strip().vdom['aria-label']).toBe('Source health: all sources nominal.');
-
-        // the word is an INERT text node, never innerHTML. `html` here would make safety a property
-        // summarizeFleetSources must preserve forever (it composes from a frozen label map today, so
-        // there is no live exploit) rather than one the card cannot get wrong. A text node holds even
-        // if a later edit folds a source REASON into the summary — the same contract the lane keeps.
-        expect(strip().text).toBe('all sources nominal');
+        expect(strip().hidden).toBe(true);
+        expect(strip().text).toBe('');
         expect(strip().html ?? null).toBeNull();
         expect(strip().vdom.html ?? null).toBeNull();
 
@@ -655,18 +669,20 @@ test.describe('Fleet cockpit AgentCard — resident card rendering its roster re
         expect(strip().ntype).toBe('component');
         expect(strip().handler ?? null).toBeNull();
 
-        // WCAG 1.4.1: `fm-strip-<level>` colours only the ::before dot, so the WORD itself must change
-        // with the level — otherwise colour would be the sole carrier of the health fact
-        const nominalText = strip().text;
-
+        // the exception path is where the word renders — an INERT text node, never innerHTML.
+        // `html` would make safety a property summarizeFleetSources must preserve forever (it
+        // composes from a frozen label map today, so there is no live exploit) rather than one the
+        // card cannot get wrong. A text node holds even if a later edit folds a source REASON into
+        // the summary — the same contract the lane keeps.
         applySet(card, {sources: {
             roster    : {source: 'fleet:listAgents',    state: 'wired',     confidence: 'observed'},
             repoStatus: {source: 'fleet:fleetStatus',   state: 'wired',     confidence: 'observed'},
             runtime   : {source: 'fleet:runtimeStatus', state: 'not-wired', confidence: 'none'}
         }});
 
+        expect(strip().hidden).toBe(false);
         expect(strip().cls).toContain('fm-strip-bad');
-        expect(strip().text).not.toBe(nominalText);
+        expect(strip().vdom['aria-label']).toBe('Source health: Runtime not nominal.');
         expect(strip().text).toBe('Runtime not nominal');
         // the sink stays closed ACROSS an update, not merely at construct time
         expect(strip().html ?? null).toBeNull();

--- a/test/playwright/unit/apps/agentos/view/fleet/agentCard.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/agentCard.spec.mjs
@@ -173,22 +173,23 @@ test.describe('Fleet cockpit AgentCard — resident card rendering its roster re
         expect(stateDot.state).toBe('ok');
         expect(stateDot.live).toBe(true);
 
-        // repo missing + runtime not-wired WITH a retained cause: the summary NAMES the abnormal
-        // source (action-owning runtime first) with a +1 overflow AND the leading source's reason
-        // (name + reason is the rendered-exception bar); the dot resolves unobserved
-        // (participation-active, session unobserved — never a benched verdict), the control
-        // cluster disables — in place
+        // repo ANSWERED-missing with a retained cause + runtime not-wired: only the answered
+        // abnormality renders (name + reason — the rendered-exception bar), while the not-wired
+        // runtime is expected absence — zero pixels on the strip exactly as it carries zero
+        // attention weight (ONE interpretation). The dot resolves unobserved (participation-
+        // active, session unobserved — never a benched verdict), the control cluster disables —
+        // in place.
         applySet(card, {sources: {
             roster    : {source: 'fleet:listAgents',    state: 'wired',     confidence: 'observed'},
-            repoStatus: {source: 'fleet:fleetStatus',   state: 'missing',   confidence: 'none'},
+            repoStatus: {source: 'fleet:fleetStatus',   state: 'missing',   confidence: 'none', reason: 'no repository status answered for this agent'},
             runtime   : {source: 'fleet:runtimeStatus', state: 'not-wired', confidence: 'none', reason: 'runtime probe refused'}
         }});
 
         expect(card.id).toBe(beforeId);
         expect(card.down({reference: 'source-strip'}).id).toBe(stripId);   // same instance, updated in place
-        expect(strip.hidden).toBe(false);   // an abnormal source is the exception the strip exists for
-        expect(strip.text).toBe('Runtime not nominal +1 · runtime probe refused');   // full word + retained cause; no ▸ affordance, never the acronym wall
-        expect(strip.vdom['aria-label']).toBe('Source health: Runtime, Repository not nominal. Runtime: runtime probe refused.');
+        expect(strip.hidden).toBe(false);   // an ANSWERED abnormality is the exception the strip exists for
+        expect(strip.text).toBe('Repository not nominal · no repository status answered for this agent');
+        expect(strip.vdom['aria-label']).toBe('Source health: Repository not nominal. Repository: no repository status answered for this agent.');
         expect(strip.cls).toContain('fm-strip-bad');
         expect(stateDot.state).toBe('unobserved');
         expect(stateDot.live).toBe(false);
@@ -673,14 +674,14 @@ test.describe('Fleet cockpit AgentCard — resident card rendering its roster re
         expect(strip().handler ?? null).toBeNull();
 
         // the exception path is where the word renders — an INERT text node, never innerHTML.
-        // `html` would make safety a property summarizeFleetSources must preserve forever (it
-        // composes from a frozen label map today, so there is no live exploit) rather than one the
-        // card cannot get wrong. A text node holds even if a later edit folds a source REASON into
-        // the summary — the same contract the lane keeps.
+        // `html` would make safety a property the summariser must preserve forever (it composes
+        // from a frozen label map + a producer-bounded reason today, so there is no live exploit)
+        // rather than one the card cannot get wrong. The fixture is an ANSWERED abnormality — the
+        // only class that renders under the one-interpretation rule.
         applySet(card, {sources: {
-            roster    : {source: 'fleet:listAgents',    state: 'wired',     confidence: 'observed'},
-            repoStatus: {source: 'fleet:fleetStatus',   state: 'wired',     confidence: 'observed'},
-            runtime   : {source: 'fleet:runtimeStatus', state: 'not-wired', confidence: 'none'}
+            roster    : {source: 'fleet:listAgents',    state: 'wired',   confidence: 'observed'},
+            repoStatus: {source: 'fleet:fleetStatus',   state: 'wired',   confidence: 'observed'},
+            runtime   : {source: 'fleet:runtimeStatus', state: 'missing', confidence: 'none'}
         }});
 
         expect(strip().hidden).toBe(false);
@@ -704,13 +705,26 @@ test.describe('Fleet cockpit AgentCard — resident card rendering its roster re
             runtime   : {source: hostile,             state: 'wired', confidence: 'observed'}
         }});
 
-        // the hostile producer fails the runtime row closed → BOTH rendered strings are pinned to the
-        // summariser's own frozen literals, and those exact matches ARE the containment proof. No
-        // `not.toContain(hostile)` alongside them: an assertion that cannot independently fail is not a
-        // witness. The aria-label is pinned separately because it is built by its own labels join.
-        expect(strip().text).toBe('Runtime not nominal');
-        expect(strip().vdom['aria-label']).toBe('Source health: Runtime not nominal.');
+        // the hostile producer fails the runtime row closed (not-wired) — which under the
+        // one-interpretation rule earns ZERO pixels: the strongest containment, nothing renders
+        // at all. The empty-and-hidden pin IS the witness.
+        expect(strip().hidden).toBe(true);
+        expect(strip().text).toBe('');
+
+        // the REASON is the one adapter-authored string that now rides a rendered line — pin its
+        // containment: a hostile reason on an ANSWERED abnormality renders as an inert text node
+        // (the vdom `html` sinks stay null), so escaping is never a property the summariser must
+        // remember to preserve.
+        applySet(card, {sources: {
+            roster    : {source: 'fleet:listAgents',    state: 'wired',   confidence: 'observed'},
+            repoStatus: {source: 'fleet:fleetStatus',   state: 'wired',   confidence: 'observed'},
+            runtime   : {source: 'fleet:runtimeStatus', state: 'missing', confidence: 'none', reason: hostile}
+        }});
+
+        expect(strip().hidden).toBe(false);
+        expect(strip().text).toBe(`Runtime not nominal · ${hostile}`);
         expect(strip().html ?? null).toBeNull();
+        expect(strip().vdom.html ?? null).toBeNull();
 
         card.destroy()
     });

--- a/test/playwright/unit/apps/agentos/view/fleet/agentCard.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/agentCard.spec.mjs
@@ -173,19 +173,22 @@ test.describe('Fleet cockpit AgentCard — resident card rendering its roster re
         expect(stateDot.state).toBe('ok');
         expect(stateDot.live).toBe(true);
 
-        // repo missing + runtime not-wired: the summary NAMES the abnormal source (action-owning runtime
-        // first) with a +1 overflow, the dot resolves unobserved (participation-active, session
-        // unobserved — never a benched verdict), the control cluster disables — in place
+        // repo missing + runtime not-wired WITH a retained cause: the summary NAMES the abnormal
+        // source (action-owning runtime first) with a +1 overflow AND the leading source's reason
+        // (name + reason is the rendered-exception bar); the dot resolves unobserved
+        // (participation-active, session unobserved — never a benched verdict), the control
+        // cluster disables — in place
         applySet(card, {sources: {
             roster    : {source: 'fleet:listAgents',    state: 'wired',     confidence: 'observed'},
             repoStatus: {source: 'fleet:fleetStatus',   state: 'missing',   confidence: 'none'},
-            runtime   : {source: 'fleet:runtimeStatus', state: 'not-wired', confidence: 'none'}
+            runtime   : {source: 'fleet:runtimeStatus', state: 'not-wired', confidence: 'none', reason: 'runtime probe refused'}
         }});
 
         expect(card.id).toBe(beforeId);
         expect(card.down({reference: 'source-strip'}).id).toBe(stripId);   // same instance, updated in place
         expect(strip.hidden).toBe(false);   // an abnormal source is the exception the strip exists for
-        expect(strip.text).toBe('Runtime not nominal +1');   // pure status: full word, no ▸ affordance, never the RUN/REP/ROS acronym wall
+        expect(strip.text).toBe('Runtime not nominal +1 · runtime probe refused');   // full word + retained cause; no ▸ affordance, never the acronym wall
+        expect(strip.vdom['aria-label']).toBe('Source health: Runtime, Repository not nominal. Runtime: runtime probe refused.');
         expect(strip.cls).toContain('fm-strip-bad');
         expect(stateDot.state).toBe('unobserved');
         expect(stateDot.live).toBe(false);

--- a/test/playwright/unit/apps/agentos/view/fleet/agentCard.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/agentCard.spec.mjs
@@ -705,11 +705,13 @@ test.describe('Fleet cockpit AgentCard — resident card rendering its roster re
             runtime   : {source: hostile,             state: 'wired', confidence: 'observed'}
         }});
 
-        // the hostile producer fails the runtime row closed (not-wired) — which under the
-        // one-interpretation rule earns ZERO pixels: the strongest containment, nothing renders
-        // at all. The empty-and-hidden pin IS the witness.
-        expect(strip().hidden).toBe(true);
-        expect(strip().text).toBe('');
+        // the hostile producer literal fails producer validation → the fact reads `invalid` and
+        // RENDERS as an answered abnormality — and the containment is that the rendered words are
+        // the summariser's frozen literals: the hostile SOURCE string appears nowhere (only the
+        // validation fallback rides the line). The exact match IS the witness.
+        expect(strip().hidden).toBe(false);
+        expect(strip().text).toBe('Runtime not nominal · source fact failed producer validation');
+        expect(strip().html ?? null).toBeNull();
 
         // the REASON is the one adapter-authored string that now rides a rendered line — pin its
         // containment: a hostile reason on an ANSWERED abnormality renders as an inert text node

--- a/test/playwright/unit/apps/agentos/view/fleet/fleetCardFactory.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/fleetCardFactory.spec.mjs
@@ -58,9 +58,11 @@ test.describe('fleetCardFactory — cockpit DTO → dock card descriptors (#1479
         expect(card.blueprint.record.avatarUrl).toBe('https://github.com/neo-opus-vega.png?size=80')
         expect(card.blueprint.record.sources.runtime).toEqual({
             confidence: 'none',
-            reason    : null,
-            source    : 'fleet:runtimeStatus',
-            state     : 'not-wired'
+            // the DTO owns the reason at the producer boundary — the axis-level explanation for a
+            // not-wired runtime rides every row fact (the review-caught fixture-truth gap closed)
+            reason: 'runtime process status is pending the Fleet runtime-status wire method',
+            source: 'fleet:runtimeStatus',
+            state : 'not-wired'
         })
 
         // serializable end-to-end — a captured perspective can restore a real card from the blueprint

--- a/test/playwright/unit/apps/agentos/view/fleet/fleetCardFactory.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/fleetCardFactory.spec.mjs
@@ -58,6 +58,7 @@ test.describe('fleetCardFactory — cockpit DTO → dock card descriptors (#1479
         expect(card.blueprint.record.avatarUrl).toBe('https://github.com/neo-opus-vega.png?size=80')
         expect(card.blueprint.record.sources.runtime).toEqual({
             confidence: 'none',
+            reason    : null,
             source    : 'fleet:runtimeStatus',
             state     : 'not-wired'
         })
@@ -125,7 +126,7 @@ test.describe('fleetCardFactory — cockpit DTO → dock card descriptors (#1479
         const card      = toAgentCardDescriptor({id: 'vega', lifecycle, sources})
 
         expect(card.blueprint.record.state).toBe('ok')
-        expect(card.blueprint.record.sources.runtime).toEqual({source: 'fleet:runtimeStatus', state: 'wired', confidence: 'observed'})
+        expect(card.blueprint.record.sources.runtime).toEqual({source: 'fleet:runtimeStatus', state: 'wired', confidence: 'observed', reason: null})
 
         const placeholder = toAgentCardDescriptor({id: 'vega', lifecycle: {state: 'running'}})
         expect(placeholder.blueprint.record.state).toBe('off')

--- a/test/playwright/unit/apps/agentos/view/fleet/fleetCardFactory.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/fleetCardFactory.spec.mjs
@@ -133,10 +133,12 @@ test.describe('fleetCardFactory — cockpit DTO → dock card descriptors (#1479
         const placeholder = toAgentCardDescriptor({id: 'vega', lifecycle: {state: 'running'}})
         expect(placeholder.blueprint.record.state).toBe('off')
 
+        // an ABSENT lifecycle beside a wired runtime fact is a contradiction — rejected evidence
+        // reads `invalid` (operator-visible), never a silently calm not-wired
         const contradictory = toAgentCardDescriptor({id: 'vega', sources})
         expect(contradictory.blueprint.record).toMatchObject({
             state  : 'off',
-            sources: {runtime: {source: 'fleet:runtimeStatus', state: 'not-wired', confidence: 'none'}}
+            sources: {runtime: {source: 'fleet:runtimeStatus', state: 'invalid', confidence: 'none', reason: 'lifecycle and runtime facts contradict'}}
         })
     })
 

--- a/test/playwright/unit/apps/agentos/view/fleet/fleetCockpit.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/fleetCockpit.spec.mjs
@@ -515,9 +515,11 @@ test.describe('Fleet cockpit — Store-backed roster (loadRoster)', () => {
                 sources  : liveSources()
             });
 
+        // a lifecycle/runtime confidence contradiction is rejected evidence — the downgrade reads
+        // `invalid` with the contradiction named, never a silently calm not-wired
         expect(contradictory).toMatchObject({
             state  : 'off',
-            sources: {runtime: {source: 'fleet:runtimeStatus', state: 'not-wired', confidence: 'none'}}
+            sources: {runtime: {source: 'fleet:runtimeStatus', state: 'invalid', confidence: 'none', reason: 'lifecycle and runtime facts contradict'}}
         });
         expect(stopped).toMatchObject({
             state  : 'off',

--- a/test/playwright/unit/apps/agentos/view/fleet/fleetCockpit.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/fleetCockpit.spec.mjs
@@ -180,10 +180,12 @@ test.describe('Fleet cockpit — activity feed binding (loadActivity, #14868)', 
 test.describe('Fleet cockpit — Store-backed roster (loadRoster)', () => {
     let FleetAgent, FleetCockpit, FleetRoster;
 
+    // reason: null on every fact — the fixture doubles as DTO input AND expected normalized
+    // output, and normalization now carries the producer's retained cause (null when absent)
     const liveSources = (runtimeConfidence = 'observed') => ({
-        roster    : {source: 'fleet:listAgents',    state: 'wired', confidence: 'observed'},
-        repoStatus: {source: 'fleet:fleetStatus',   state: 'wired', confidence: 'observed'},
-        runtime   : {source: 'fleet:runtimeStatus', state: 'wired', confidence: runtimeConfidence}
+        roster    : {source: 'fleet:listAgents',    state: 'wired', confidence: 'observed', reason: null},
+        repoStatus: {source: 'fleet:fleetStatus',   state: 'wired', confidence: 'observed', reason: null},
+        runtime   : {source: 'fleet:runtimeStatus', state: 'wired', confidence: runtimeConfidence, reason: null}
     });
 
     // scope the mock to the `fleet` subkey ONLY: `globalThis.AgentOS` is the app's Neo NAMESPACE

--- a/test/playwright/unit/apps/agentos/view/fleet/fleetGrid.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/fleetGrid.spec.mjs
@@ -18,7 +18,7 @@ import * as core      from '../../../../../../../src/core/_export.mjs';
 import Instance       from '../../../../../../../src/manager/Instance.mjs';
 
 test.describe('Fleet cockpit FleetGrid + HealthBar — Store-backed density-ranked grid (#14599)', () => {
-    let FleetAgent, FleetGrid, HealthBar, Store, rankFleet, healthCounts, hasAttention;
+    let FleetAgent, FleetGrid, HealthBar, Store, rankFleet, healthCounts, hasAttention, deriveAttention;
 
     const stores = [];
 
@@ -53,7 +53,8 @@ test.describe('Fleet cockpit FleetGrid + HealthBar — Store-backed density-rank
         rankFleet    = gridMod.rankFleet;
         HealthBar    = barMod.default;
         healthCounts = barMod.healthCounts;
-        hasAttention = barMod.hasAttention;
+        hasAttention    = barMod.hasAttention;
+        deriveAttention = barMod.deriveAttention;
         FleetAgent   = (await import('../../../../../../../apps/agentos/model/FleetAgent.mjs')).default;
         Store        = (await import('../../../../../../../src/data/Store.mjs')).default
     });
@@ -117,6 +118,34 @@ test.describe('Fleet cockpit FleetGrid + HealthBar — Store-backed density-rank
         expect(hasAttention(null)).toBe(false)
     });
 
+    test('deriveAttention is the SINGLE aggregate projection — every summarized truth folds, and expected-absence still weighs nothing', () => {
+        const zero = {ok: 0, idle: 0, wedged: 0, limited: 0, unobserved: 0, external: 0, off: 0};
+
+        // the un-managed normal: not-wired sources everywhere (the sample/FM-as-client topology)
+        // must NOT trip attention — weighting expected absence would make the header permanently
+        // yellow again, the exact falsified default this ticket retires
+        const unmanagedRows = [{sources: {}}, {sources: null}, {
+            sources: {runtime: {source: 'fleet:runtimeStatus', state: 'not-wired', confidence: 'none'}}
+        }];
+        expect(deriveAttention({counts: {...zero, external: 3}, rows: unmanagedRows})).toBe(false);
+
+        // an ANSWERED-abnormal source (a producer said `missing`) is real trouble on a real surface
+        expect(deriveAttention({counts: {...zero, unobserved: 1}, rows: [{
+            sources: {repoStatus: {source: 'fleet:fleetStatus', state: 'missing', confidence: 'none'}}
+        }]})).toBe(true);
+
+        // the plumbed non-roster facts each trip the fold on their own
+        expect(deriveAttention({counts: {...zero, external: 9}, rows: unmanagedRows, daemonFault: true})).toBe(true);
+        expect(deriveAttention({counts: {...zero, external: 9}, rows: unmanagedRows, presenceDegraded: true})).toBe(true);
+
+        // session buckets keep their weight through the fold
+        expect(deriveAttention({counts: {...zero, wedged: 1}, rows: []})).toBe(true);
+
+        // fail-closed shapes
+        expect(deriveAttention({})).toBe(false);
+        expect(deriveAttention()).toBe(false)
+    });
+
     test('rankFleet tiers deterministically (online → idle → benched, sorted by agentId) with the fold threshold', () => {
         // 4 online (ok/limited/wedged) · 3 idle · 2 benched(off) + 1 unknown-guest → benched tail
         const rank = rankFleet(roster(['ok', 'idle', 'off', 'limited', 'idle', 'wedged', 'off', 'idle', 'guest', 'ok']), {foldThreshold: 12});
@@ -171,6 +200,25 @@ test.describe('Fleet cockpit FleetGrid + HealthBar — Store-backed density-rank
         grid.presenceCapability = {source: 'fleet:presenceState', state: 'degraded', confidence: 'none', reason: 'x'};
         grid.presenceCapability = null;
         expect(chip().hidden).toBe(true);
+
+        // COMPOSITION with the aggregate dot: the chip and the header verdict read ONE fact —
+        // a rendered presence degradation always carries attention weight, and recovery clears
+        // both together (the chip can never sit over a green dot). The daemon plumb rides the
+        // same push seam.
+        const bar = grid.getReference('fleet-health');
+
+        grid.presenceCapability = {source: 'fleet:presenceState', state: 'degraded', confidence: 'none', reason: 'plane read failed'};
+        expect(chip().hidden).toBe(false);
+        expect(bar.cls).toContain('fm-health-attention');
+
+        grid.presenceCapability = null;
+        expect(chip().hidden).toBe(true);
+        expect(bar.cls).toContain('fm-health-nominal');
+
+        grid.daemonFault = true;
+        expect(bar.cls).toContain('fm-health-attention');
+        grid.daemonFault = false;
+        expect(bar.cls).toContain('fm-health-nominal');
 
         grid.destroy();
 
@@ -356,6 +404,25 @@ test.describe('Fleet cockpit FleetGrid + HealthBar — Store-backed density-rank
         expect(swatchOf(bar, 'external').count).toBe(2);    // un-wired off + mysterious
         expect(swatchOf(bar, 'off').count).toBe(0);
         expect(swatchOf(bar, 'unobserved').count).toBe(3);
+
+        // a SOURCES-only record change re-tallies too: wiring a runtime flips unmanaged→managed
+        // truth with no `state` field write — the mutation the old state-only filter dropped
+        const wired = {
+            roster    : {source: 'fleet:listAgents',    state: 'wired', confidence: 'observed'},
+            repoStatus: {source: 'fleet:fleetStatus',   state: 'wired', confidence: 'observed'},
+            runtime   : {source: 'fleet:runtimeStatus', state: 'wired', confidence: 'observed'}
+        };
+        store.items[1].set({sources: wired});               // an `ok` row: unobserved → ok, sources-only
+        expect(swatchOf(bar, 'ok').count).toBe(1);
+        expect(swatchOf(bar, 'unobserved').count).toBe(2);
+
+        // an answered-abnormal source arriving via the SAME sources-only seam trips the aggregate
+        store.items[1].set({sources: {...wired, repoStatus: {source: 'fleet:fleetStatus', state: 'missing', confidence: 'none'}}});
+        expect(bar.cls).toContain('fm-health-attention');
+
+        // recovery through the seam returns the calm verdict
+        store.items[1].set({sources: wired});
+        expect(bar.cls).toContain('fm-health-nominal');
 
         bar.destroy()
     });

--- a/test/playwright/unit/apps/agentos/view/fleet/fleetGrid.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/fleetGrid.spec.mjs
@@ -18,7 +18,7 @@ import * as core      from '../../../../../../../src/core/_export.mjs';
 import Instance       from '../../../../../../../src/manager/Instance.mjs';
 
 test.describe('Fleet cockpit FleetGrid + HealthBar — Store-backed density-ranked grid (#14599)', () => {
-    let FleetAgent, FleetGrid, HealthBar, Store, rankFleet, healthCounts;
+    let FleetAgent, FleetGrid, HealthBar, Store, rankFleet, healthCounts, hasAttention;
 
     const stores = [];
 
@@ -53,6 +53,7 @@ test.describe('Fleet cockpit FleetGrid + HealthBar — Store-backed density-rank
         rankFleet    = gridMod.rankFleet;
         HealthBar    = barMod.default;
         healthCounts = barMod.healthCounts;
+        hasAttention = barMod.hasAttention;
         FleetAgent   = (await import('../../../../../../../apps/agentos/model/FleetAgent.mjs')).default;
         Store        = (await import('../../../../../../../src/data/Store.mjs')).default
     });
@@ -62,34 +63,58 @@ test.describe('Fleet cockpit FleetGrid + HealthBar — Store-backed density-rank
         stores.length = 0
     });
 
-    test('healthCounts is the pure tally — six canonical categories through the SAME resolver the cards render; unknown/guest folds into off (no 7th key, no undercount)', () => {
-        // roster-only rows (no sources) resolve participation-active states to `unobserved`,
-        // exactly as the cards display them — the tally and the card grain can never diverge
-        const counts = healthCounts(roster(['ok', 'ok', 'idle', 'off', 'limited', 'wedged']));
-        expect(counts).toEqual({ok: 0, idle: 0, wedged: 0, limited: 0, unobserved: 5, off: 1});
+    test('healthCounts is the pure tally — seven canonical categories through the SAME resolver the cards render; outside-supervision rows count external', () => {
+        const zero = {ok: 0, idle: 0, wedged: 0, limited: 0, unobserved: 0, external: 0, off: 0};
 
-        // a wired runtime keeps the row state as session truth in the tally too
+        // roster-only rows (no sources) resolve participation-active states to `unobserved` and an
+        // un-wired `off` to `external` (supervision vocabulary only where supervision exists —
+        // the default-state contract), exactly as the cards display them — the tally and the card
+        // grain can never diverge
+        const counts = healthCounts(roster(['ok', 'ok', 'idle', 'off', 'limited', 'wedged']));
+        expect(counts).toEqual({...zero, unobserved: 5, external: 1});
+
+        // a wired runtime keeps the row state as session truth in the tally too — including `off`,
+        // the managed-and-stopped seat that KEEPS its benched bucket
         const wiredSources = {
             roster    : {source: 'fleet:listAgents',    state: 'wired', confidence: 'observed'},
             repoStatus: {source: 'fleet:fleetStatus',   state: 'wired', confidence: 'observed'},
             runtime   : {source: 'fleet:runtimeStatus', state: 'wired', confidence: 'observed'}
         };
-        expect(healthCounts([{agentId: 'a1', state: 'ok', sources: wiredSources}])).toEqual(
-            {ok: 1, idle: 0, wedged: 0, limited: 0, unobserved: 0, off: 0}
-        );
+        expect(healthCounts([{agentId: 'a1', state: 'ok', sources: wiredSources}])).toEqual({...zero, ok: 1});
+        expect(healthCounts([{agentId: 'a2', state: 'off', sources: wiredSources}])).toEqual({...zero, off: 1});
 
-        // zero-fill: exactly the six canonical keys, present even when absent
-        expect(healthCounts([])).toEqual({ok: 0, idle: 0, wedged: 0, limited: 0, unobserved: 0, off: 0});
+        // zero-fill: exactly the seven canonical keys, present even when absent
+        expect(healthCounts([])).toEqual(zero);
 
-        // unknown / guest / unsupported → off (benched), matching the grid's benched tier — NEVER a literal 7th key
+        // unknown / guest / unsupported rows sit outside any supervision contract → external,
+        // matching the resolver's own fold — never an invented benched verdict, never an 8th key
         const withGuest = healthCounts(roster(['ok', 'mysterious', 'guest']));
-        expect(withGuest).toEqual({ok: 0, idle: 0, wedged: 0, limited: 0, unobserved: 1, off: 2});
-        expect(Object.keys(withGuest).sort()).toEqual(['idle', 'limited', 'off', 'ok', 'unobserved', 'wedged']);
-        // the six visible counts sum to the roster size — the bar can never undercount
+        expect(withGuest).toEqual({...zero, unobserved: 1, external: 2});
+        expect(Object.keys(withGuest).sort()).toEqual(['external', 'idle', 'limited', 'off', 'ok', 'unobserved', 'wedged']);
+        // the seven visible counts sum to the roster size — the bar can never undercount
         expect(Object.values(withGuest).reduce((a, b) => a + b, 0)).toBe(3);
 
         // non-array guard
-        expect(healthCounts(null)).toEqual({ok: 0, idle: 0, wedged: 0, limited: 0, unobserved: 0, off: 0})
+        expect(healthCounts(null)).toEqual(zero)
+    });
+
+    test('hasAttention derives the aggregate header verdict — only actionable buckets carry weight', () => {
+        const zero = {ok: 0, idle: 0, wedged: 0, limited: 0, unobserved: 0, external: 0, off: 0};
+
+        // a fleet of un-managed seats with nominal sources is CALM — the operator-ratified
+        // default-state contract (a header that is always yellow trains the operator to ignore it)
+        expect(hasAttention({...zero, external: 9})).toBe(false);
+        expect(hasAttention({...zero, ok: 3, idle: 2, unobserved: 4})).toBe(false);
+        // a managed-stopped seat is a fact, not an alarm
+        expect(hasAttention({...zero, off: 2})).toBe(false);
+
+        // the actionable states carry the weight
+        expect(hasAttention({...zero, wedged: 1})).toBe(true);
+        expect(hasAttention({...zero, limited: 1})).toBe(true);
+
+        // fail-closed shapes
+        expect(hasAttention({})).toBe(false);
+        expect(hasAttention(null)).toBe(false)
     });
 
     test('rankFleet tiers deterministically (online → idle → benched, sorted by agentId) with the fold threshold', () => {
@@ -246,12 +271,14 @@ test.describe('Fleet cockpit FleetGrid + HealthBar — Store-backed density-rank
         first.set({state: 'off'});
 
         expect(agentCards(grid).length).toBe(3);           // still every card — a tier move, not a drop
-        expect(lastId()).toBe(first.agentId);              // now the benched tail
-        expect(agentCards(grid).at(-1).down({ntype: 'fm-state-dot'}).state).toBe('off');
+        expect(lastId()).toBe(first.agentId);              // now the benched tail (the grid tiers on RAW state)
+        // the display state partitions: an un-wired `off` renders external, never a benched verdict
+        expect(agentCards(grid).at(-1).down({ntype: 'fm-state-dot'}).state).toBe('external');
 
         // ...and the store-bound health bar re-tallied through ITS OWN record seam (no array push)
         expect(swatchOf(bar, 'unobserved').count).toBe(2);
-        expect(swatchOf(bar, 'off').count).toBe(1);
+        expect(swatchOf(bar, 'external').count).toBe(1);
+        expect(swatchOf(bar, 'off').count).toBe(0);
 
         grid.destroy()
     });
@@ -296,10 +323,15 @@ test.describe('Fleet cockpit FleetGrid + HealthBar — Store-backed density-rank
         const store = makeStore(roster(['ok', 'ok', 'idle', 'off'])),
               bar   = Neo.create(HealthBar, {appName, store});
 
-        expect(bar.items.length).toBe(6);
+        expect(bar.items.length).toBe(7);
         expect(swatchOf(bar, 'unobserved').count).toBe(3);
-        expect(swatchOf(bar, 'off').count).toBe(1);
+        expect(swatchOf(bar, 'external').count).toBe(1);   // an un-wired off is outside supervision
+        expect(swatchOf(bar, 'off').count).toBe(0);
         expect(swatchOf(bar, 'wedged').count).toBe(0);   // zero still renders (confirms "none")
+
+        // the aggregate verdict rides the bar as the nominal class — nothing here needs an operator
+        expect(bar.cls).toContain('fm-health-nominal');
+        expect(bar.cls).not.toContain('fm-health-attention');
 
         // stable instances: capture ids, mutate a RECORD, assert SAME swatch instances re-tallied
         const idsBefore = bar.items.map(sw => sw.id);
@@ -307,18 +339,22 @@ test.describe('Fleet cockpit FleetGrid + HealthBar — Store-backed density-rank
         expect(bar.items.map(sw => sw.id)).toEqual(idsBefore);   // not recreated → the count transition can animate
         expect(swatchOf(bar, 'idle').count).toBe(0);
         // an unwired canonical state stays unobserved in the tally — wedged only counts as session
-        // truth under a wired runtime (exactly the card's own honesty rule)
+        // truth under a wired runtime (exactly the card's own honesty rule); the aggregate verdict
+        // therefore stays nominal too
         expect(swatchOf(bar, 'wedged').count).toBe(0);
         expect(swatchOf(bar, 'unobserved').count).toBe(3);
+        expect(bar.cls).toContain('fm-health-nominal');
 
         // a store load (roster growth) re-tallies too
         store.add({agentId: 'agent-99', state: 'ok'});
         expect(swatchOf(bar, 'unobserved').count).toBe(4);
 
-        // guest/unknown folds into the VISIBLE off swatch — the six-swatch bar never undercounts a roster
+        // guest/unknown folds into the VISIBLE external swatch — the seven-swatch bar never
+        // undercounts a roster, and never invents a benched verdict for an unsupervised row
         store.items[0].set({state: 'mysterious'});
-        expect(bar.items.length).toBe(6);              // still no 7th swatch
-        expect(swatchOf(bar, 'off').count).toBe(2);    // off + mysterious rendered as benched
+        expect(bar.items.length).toBe(7);                   // still no 8th swatch
+        expect(swatchOf(bar, 'external').count).toBe(2);    // un-wired off + mysterious
+        expect(swatchOf(bar, 'off').count).toBe(0);
         expect(swatchOf(bar, 'unobserved').count).toBe(3);
 
         bar.destroy()

--- a/test/playwright/unit/apps/agentos/view/fleet/fleetGrid.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/fleetGrid.spec.mjs
@@ -134,6 +134,12 @@ test.describe('Fleet cockpit FleetGrid + HealthBar — Store-backed density-rank
             sources: {repoStatus: {source: 'fleet:fleetStatus', state: 'missing', confidence: 'none'}}
         }]})).toBe(true);
 
+        // REJECTED evidence (a present fact the contract refused — malformed, cross-axis,
+        // contradictory) carries weight too: validation failure must never read as a green surface
+        expect(deriveAttention({counts: {...zero, unobserved: 1}, rows: [{
+            sources: {runtime: {source: 'fleet:listAgents', state: 'wired', confidence: 'observed'}}
+        }]})).toBe(true);
+
         // the plumbed non-roster facts each trip the fold on their own
         expect(deriveAttention({counts: {...zero, external: 9}, rows: unmanagedRows, daemonFault: true})).toBe(true);
         expect(deriveAttention({counts: {...zero, external: 9}, rows: unmanagedRows, presenceDegraded: true})).toBe(true);

--- a/test/playwright/unit/apps/agentos/view/fleet/fleetStartPlan.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/fleetStartPlan.spec.mjs
@@ -104,10 +104,20 @@ test.describe('fleetStartPlan — the staged fleet bring-up (pure half)', () => 
         expect(eligible).toHaveLength(0);
         expect(excluded[0].reason).toContain("runtime source 'not-wired'");
 
-        // missing runtime axis → fail closed with the missing state visible
+        // a missing-state fact OMITTING its confidence field is an incomplete answer under the
+        // airtight vocabulary (missing/not-wired pair only with an explicit `none`) → it reads
+        // `invalid` — and the start STILL fails closed, which is this rule's actual authority
         ({eligible, excluded} = partitionOne({
             agentId: 'gone', state: 'off',
             sources: {...wiredRuntime(), runtime: {source: 'fleet:runtimeStatus', state: 'missing'}}
+        }));
+        expect(eligible).toHaveLength(0);
+        expect(excluded[0].reason).toContain("runtime source 'invalid'");
+
+        // the complete declared shape keeps its own name in the exclusion
+        ({eligible, excluded} = partitionOne({
+            agentId: 'gone-2', state: 'off',
+            sources: {...wiredRuntime(), runtime: {source: 'fleet:runtimeStatus', state: 'missing', confidence: 'none'}}
         }));
         expect(eligible).toHaveLength(0);
         expect(excluded[0].reason).toContain("runtime source 'missing'");

--- a/test/playwright/unit/apps/agentos/view/fleet/sourceHealthMarker.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/sourceHealthMarker.spec.mjs
@@ -30,14 +30,15 @@ test.describe('Fleet source-health honesty (#14643)', () => {
                 const
                     health        = {source: 'fleet:runtimeStatus', state, confidence},
                     normalized    = normalizeSourceFact(health),
-                    // wired-without-usable-confidence is a PRESENT contradictory fact → rejected
-                    // evidence (`invalid`), never silently calm; declared `not-wired` stays the
-                    // one calm present shape
+                    // impossible pairs are PRESENT contradictory facts → rejected evidence
+                    // (`invalid`), never silently accepted: wired needs a usable confidence;
+                    // missing/not-wired cannot CARRY one — only their explicit `none` pairing is
+                    // the declared shape
                     expectedState = state === 'wired'
                         ? (confidence !== 'none' ? 'wired' : 'invalid')
-                        : state === 'missing'
-                            ? 'missing'
-                            : 'not-wired',
+                        : confidence === 'none'
+                            ? state
+                            : 'invalid',
                     expectedConfidence   = expectedState === 'wired' ? confidence : 'none',
                     expectedReason       = expectedState === 'invalid' ? 'source fact failed contract validation' : null,
                     expectedTreatment    = expectedState === 'wired'

--- a/test/playwright/unit/apps/agentos/view/fleet/sourceHealthMarker.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/sourceHealthMarker.spec.mjs
@@ -30,21 +30,27 @@ test.describe('Fleet source-health honesty (#14643)', () => {
                 const
                     health        = {source: 'fleet:runtimeStatus', state, confidence},
                     normalized    = normalizeSourceFact(health),
-                    expectedState = state === 'wired' && confidence !== 'none'
-                        ? 'wired'
+                    // wired-without-usable-confidence is a PRESENT contradictory fact → rejected
+                    // evidence (`invalid`), never silently calm; declared `not-wired` stays the
+                    // one calm present shape
+                    expectedState = state === 'wired'
+                        ? (confidence !== 'none' ? 'wired' : 'invalid')
                         : state === 'missing'
                             ? 'missing'
                             : 'not-wired',
                     expectedConfidence   = expectedState === 'wired' ? confidence : 'none',
+                    expectedReason       = expectedState === 'invalid' ? 'source fact failed contract validation' : null,
                     expectedTreatment    = expectedState === 'wired'
                         ? expectedConfidence.toUpperCase()
                         : expectedState === 'missing'
                             ? 'MISSING'
-                            : 'NOT WIRED',
+                            : expectedState === 'invalid'
+                                ? 'INVALID'
+                                : 'NOT WIRED',
                     view                 = sourceMarkerView('runtime', health),
                     marker               = Neo.create(SourceHealthMarker, {appName, sourceKey: 'runtime', health});
 
-                expect(normalized).toEqual({source: 'fleet:runtimeStatus', state: expectedState, confidence: expectedConfidence, reason: null});
+                expect(normalized).toEqual({source: 'fleet:runtimeStatus', state: expectedState, confidence: expectedConfidence, reason: expectedReason});
                 expect(view).toMatchObject({
                     stateClass     : `fm-source-${expectedState}`,
                     confidenceClass: `fm-confidence-${expectedConfidence}`,
@@ -61,20 +67,32 @@ test.describe('Fleet source-health honesty (#14643)', () => {
         }
     });
 
-    test('malformed, unknown, inherited, and prototype-shaped inputs fail closed', () => {
-        for (const value of [null, undefined, [], 'wired', {}, {state: 'unknown', confidence: 'observed'}, Object.create({state: 'wired', confidence: 'observed'})]) {
+    test('rejected evidence reads `invalid` — only GENUINE absence fails closed to the calm `not-wired`', () => {
+        // absence: no fact was supplied at all — the one calm shape
+        for (const value of [null, undefined]) {
             expect(normalizeSourceFact(value)).toEqual({source: null, state: 'not-wired', confidence: 'none', reason: null})
         }
 
+        // present but malformed (non-plain / prototype-shaped): rejected evidence, operator-visible —
+        // an invalid answer must never normalize into the same green surface as no producer
+        for (const value of [[], 'wired', Object.create({state: 'wired', confidence: 'observed'})]) {
+            expect(normalizeSourceFact(value)).toEqual({source: null, state: 'invalid', confidence: 'none', reason: 'malformed source fact'})
+        }
+
+        // present plain objects failing producer validation (no/blank/non-string source)
+        expect(normalizeSourceFact({})).toEqual({source: null, state: 'invalid', confidence: 'none', reason: 'source fact failed producer validation'});
+        expect(normalizeSourceFact({state: 'unknown', confidence: 'observed'})).toEqual({source: null, state: 'invalid', confidence: 'none', reason: 'source fact failed producer validation'});
+
+        // inherited keys are refused as ABSENT (own-key discipline): the axis reads not-wired
         const polluted = Object.create({runtime: {state: 'wired', confidence: 'observed'}});
         expect(normalizeFleetSources(polluted).runtime).toEqual({source: null, state: 'not-wired', confidence: 'none', reason: null});
 
         for (const source of [undefined, '', '   ', 42]) {
             expect(normalizeSourceFact({source, state: 'wired', confidence: 'observed'}))
-                .toEqual({source: null, state: 'not-wired', confidence: 'none', reason: null})
+                .toEqual({source: null, state: 'invalid', confidence: 'none', reason: 'source fact failed producer validation'})
 
             expect(normalizeSourceFact({source, state: 'missing', confidence: 'none'}))
-                .toEqual({source: null, state: 'not-wired', confidence: 'none', reason: null})
+                .toEqual({source: null, state: 'invalid', confidence: 'none', reason: 'source fact failed producer validation'})
         }
     });
 
@@ -120,30 +138,35 @@ test.describe('Fleet source-health honesty (#14643)', () => {
             }),
             runtime = {runtime: {source: 'fleet:runtimeStatus', state: 'wired', confidence: 'observed'}};
 
-        expect(normalizeSourceFact(inheritedFact)).toEqual({source: 'fleet:runtimeStatus', state: 'not-wired', confidence: 'none', reason: null});
+        // a fact whose state/confidence live only on the prototype chain is a PRESENT answer this
+        // contract rejects — invalid, never silently calm
+        expect(normalizeSourceFact(inheritedFact)).toEqual({source: 'fleet:runtimeStatus', state: 'invalid', confidence: 'none', reason: 'source fact failed contract validation'});
+        // an inherited AXIS key is refused as absent (own-key discipline) — genuinely calm
         expect(normalizeFleetSources(inheritedSources).runtime).toEqual({source: null, state: 'not-wired', confidence: 'none', reason: null});
         expect(mapFleetSessionState(inheritedLifecycle, runtime)).toBe('off');
+        // a cross-axis producer literal is rejected evidence: invalid, operator-visible
         expect(mapFleetSessionHealth(
             {source: 'fleet:listAgents', state: 'running', confidence: 'observed'},
             {runtime: {source: 'fleet:listAgents', state: 'wired', confidence: 'observed'}}
-        )).toMatchObject({state: 'off', sources: {runtime: {state: 'not-wired', confidence: 'none'}}})
+        )).toMatchObject({state: 'off', sources: {runtime: {state: 'invalid', confidence: 'none'}}})
     });
 
     test('lifecycle/source contradictions downgrade runtime provenance atomically', () => {
         const sources = {runtime: {source: 'fleet:runtimeStatus', state: 'wired', confidence: 'observed'}};
 
+        // a contradiction is rejected evidence — the downgrade names it and stays operator-visible
         expect(mapFleetSessionHealth(null, sources)).toEqual({
             sources: {
                 roster    : {source: null, state: 'not-wired', confidence: 'none', reason: null},
                 repoStatus: {source: null, state: 'not-wired', confidence: 'none', reason: null},
-                runtime   : {source: 'fleet:runtimeStatus', state: 'not-wired', confidence: 'none', reason: null}
+                runtime   : {source: 'fleet:runtimeStatus', state: 'invalid', confidence: 'none', reason: 'lifecycle and runtime facts contradict'}
             },
             state: 'off'
         });
         expect(mapFleetSessionHealth(
             {source: 'fleet:runtimeStatus', state: 'running', confidence: 'inferred'},
             sources
-        )).toMatchObject({state: 'off', sources: {runtime: {state: 'not-wired', confidence: 'none'}}});
+        )).toMatchObject({state: 'off', sources: {runtime: {state: 'invalid', confidence: 'none'}}});
         expect(mapFleetSessionHealth(
             {source: 'fleet:runtimeStatus', state: 'stopped', confidence: 'observed'},
             sources

--- a/test/playwright/unit/apps/agentos/view/fleet/sourceHealthMarker.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/sourceHealthMarker.spec.mjs
@@ -44,7 +44,7 @@ test.describe('Fleet source-health honesty (#14643)', () => {
                     view                 = sourceMarkerView('runtime', health),
                     marker               = Neo.create(SourceHealthMarker, {appName, sourceKey: 'runtime', health});
 
-                expect(normalized).toEqual({source: 'fleet:runtimeStatus', state: expectedState, confidence: expectedConfidence});
+                expect(normalized).toEqual({source: 'fleet:runtimeStatus', state: expectedState, confidence: expectedConfidence, reason: null});
                 expect(view).toMatchObject({
                     stateClass     : `fm-source-${expectedState}`,
                     confidenceClass: `fm-confidence-${expectedConfidence}`,
@@ -63,18 +63,18 @@ test.describe('Fleet source-health honesty (#14643)', () => {
 
     test('malformed, unknown, inherited, and prototype-shaped inputs fail closed', () => {
         for (const value of [null, undefined, [], 'wired', {}, {state: 'unknown', confidence: 'observed'}, Object.create({state: 'wired', confidence: 'observed'})]) {
-            expect(normalizeSourceFact(value)).toEqual({source: null, state: 'not-wired', confidence: 'none'})
+            expect(normalizeSourceFact(value)).toEqual({source: null, state: 'not-wired', confidence: 'none', reason: null})
         }
 
         const polluted = Object.create({runtime: {state: 'wired', confidence: 'observed'}});
-        expect(normalizeFleetSources(polluted).runtime).toEqual({source: null, state: 'not-wired', confidence: 'none'});
+        expect(normalizeFleetSources(polluted).runtime).toEqual({source: null, state: 'not-wired', confidence: 'none', reason: null});
 
         for (const source of [undefined, '', '   ', 42]) {
             expect(normalizeSourceFact({source, state: 'wired', confidence: 'observed'}))
-                .toEqual({source: null, state: 'not-wired', confidence: 'none'})
+                .toEqual({source: null, state: 'not-wired', confidence: 'none', reason: null})
 
             expect(normalizeSourceFact({source, state: 'missing', confidence: 'none'}))
-                .toEqual({source: null, state: 'not-wired', confidence: 'none'})
+                .toEqual({source: null, state: 'not-wired', confidence: 'none', reason: null})
         }
     });
 
@@ -120,8 +120,8 @@ test.describe('Fleet source-health honesty (#14643)', () => {
             }),
             runtime = {runtime: {source: 'fleet:runtimeStatus', state: 'wired', confidence: 'observed'}};
 
-        expect(normalizeSourceFact(inheritedFact)).toEqual({source: 'fleet:runtimeStatus', state: 'not-wired', confidence: 'none'});
-        expect(normalizeFleetSources(inheritedSources).runtime).toEqual({source: null, state: 'not-wired', confidence: 'none'});
+        expect(normalizeSourceFact(inheritedFact)).toEqual({source: 'fleet:runtimeStatus', state: 'not-wired', confidence: 'none', reason: null});
+        expect(normalizeFleetSources(inheritedSources).runtime).toEqual({source: null, state: 'not-wired', confidence: 'none', reason: null});
         expect(mapFleetSessionState(inheritedLifecycle, runtime)).toBe('off');
         expect(mapFleetSessionHealth(
             {source: 'fleet:listAgents', state: 'running', confidence: 'observed'},
@@ -134,9 +134,9 @@ test.describe('Fleet source-health honesty (#14643)', () => {
 
         expect(mapFleetSessionHealth(null, sources)).toEqual({
             sources: {
-                roster    : {source: null, state: 'not-wired', confidence: 'none'},
-                repoStatus: {source: null, state: 'not-wired', confidence: 'none'},
-                runtime   : {source: 'fleet:runtimeStatus', state: 'not-wired', confidence: 'none'}
+                roster    : {source: null, state: 'not-wired', confidence: 'none', reason: null},
+                repoStatus: {source: null, state: 'not-wired', confidence: 'none', reason: null},
+                runtime   : {source: 'fleet:runtimeStatus', state: 'not-wired', confidence: 'none', reason: null}
             },
             state: 'off'
         });


### PR DESCRIPTION
Resolves neomjs/neo#16924

The cockpit's default state now renders calm, in operator vocabulary, under ONE invariant applied at every layer: **`not-wired` is expected absence — zero pixels, zero attention weight, everywhere — while an ANSWERED abnormality (`missing`) renders its source name + the producer's own reason and carries attention.** A new `external` display state ("external harness", neutral token) replaces the falsified `benched / offline` verdict for every seat Fleet does not manage (wired-and-stopped seats KEEP `benched / offline`, witnessed both ways). The source strip is exception-only under that same rule: nominal AND expected-absent render nothing (the permanent "all sources nominal" line and the permanent "Runtime not nominal" wall on un-managed seats were the same defect — a default state that renders); an answered abnormality renders `Repository not nominal · <producer's reason>`. The reasons are owned at the REAL producer boundary: `fleetCockpitStatus` emits a bounded `reason` on every per-row source fact (underlying row's cause passed through, axis-level explanation on absent/not-wired branches, `boundReason` capping the wire), `normalizeSourceFact` retains it verbatim on every branch including the `downgradeRuntime` contradiction path, and the hostile-string containment is witnessed on the reason path itself (inert text node, html sinks pinned null).

The health bar gains the `external` bucket plus **one aggregate projection** (`deriveAttention`): session buckets (`wedged`/`limited`) + answered-abnormal sources + the degraded presence capability (ONE fact with the neomjs/neo#16928 chip via a single push seam — the chip can never render over a green dot) + the daemon fault (`DAEMON_FAULT_STATES` exported from `spineBanner`, plumbed where `daemonState` lands — one authority, two consumers). The verdict renders as a green/attention dot ahead of the counts, and the bar re-tallies on `sources`-only record changes (the unmanaged→managed flip that carries no `state` write).

This deliberately reverses the `#15625` state-honesty mapping (un-wired `off` → `benched / offline`) under the newer operator ratification on the ticket; the reversal is named in the spec at the exact row that guarded the old contract.

Evidence: L3 (browser-rendered receipt on rebuilt themes: sample roster renders `9 unobserved · 1 external harness · 0 benched / offline`, green aggregate dot, zero permanent strips) → L3 required (render-contract ACs). Residual: the live-mode Electron receipt with wired sources + presence bands [#16924 Post-Merge].

## Deltas from ticket

- `deriveAttention` extracted as the pure single-projection helper; `hasAttention` remains the bucket half. The aggregate dot uses existing state tokens (zero new hues).
- The strip's abnormal set narrowed to ANSWERED-abnormal during review cycle 2 (the one-interpretation completion — cycle 1 had shipped name-only rendering for `not-wired` facts too, leaving the default state with a permanent line on un-managed seats and two incompatible readings of `not-wired`).
- Source reasons are producer-owned end-to-end (`fleetCockpitStatus` → normalize → summarize), added in cycle 2 — cycle 1's reason path existed only in consumer fixtures, which the re-review correctly rejected as fixture-truth.
- Unknown/guest rows fold to `external`; the grid's tail TIERING is untouched (ranks on raw state, verified).
- Branch rebased onto `dev` mid-review to compose against the MERGED neomjs/neo#16928 chip rather than a simulation.
- Sample-fixture polish (wired sources for the showcase rows) stays follow-up material.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/apps/agentos/view/fleet/ test/playwright/unit/apps/agentos/fleet/ test/playwright/unit/ai/services/fleet/` → **972 passed** (the three fleet surfaces end-to-end: producer, browser client, views). Key witnesses: the partition matrix both ways (`external harness` vs retained `benched / offline`); the `deriveAttention` matrix incl. the un-managed not-wired rows staying calm; sources-only reactivity (bucket move with zero `state` write, answered-abnormal arriving/recovering through the same seam); chip⇔attention and daemonFault⇔attention composition both directions; producer reason emission (axis strings on absent rows, passthrough + bounding on present rows — `fleetCardFactory` consumes the REAL producer); the hostile-source row failing closed to ZERO pixels and the hostile-REASON row rendering as an inert text node with html sinks pinned null.
- Visual receipt (rebuilt dev themes, sample roster): green verdict dot + `9 unobserved · 1 external harness · 0 benched / offline`; no permanent strip on any card.

## Post-Merge Validation

- [ ] Live-mode Electron receipt: wired sources + presence bands → cards with no strip, no supervision line on un-managed seats, green header (the exact scenario the operator verdict came from).

## Commits (if multi-commit)

- d8a266d022 — the partition + exception-only strip + aggregate verdict (cycle 1, rebased)
- 2266367688 — aggregate truth-fold completion: deriveAttention, plumbs, sources reactivity (cycle 2a)
- (head) — producer-owned reasons + the one-interpretation completion (cycle 2b)

## Evolution

Cycle 2 tightened the design rather than patching it: the review's "two incompatible interpretations of not-wired" observation collapsed the strip and the aggregate onto one rule, which retroactively simplified both — the strip's visibility condition and the attention condition are now the same predicate over the same producer-owned facts.

Authored by Clio (Fable 5, Claude Code). Session ff94e740-acb8-4f25-a94b-b614bdd91ea1.
