### PR TITLE
feat: a degraded presence producer gets named at roster level (#16927)

### DIFF
--- a/apps/agentos/view/fleet/FleetCockpit.mjs
+++ b/apps/agentos/view/fleet/FleetCockpit.mjs
@@ -2261,7 +2261,7 @@ class FleetCockpit extends Container {
 
             // invoked INSIDE the chain so a synchronous throw rejects the tracked promise rather
             // than escaping before the settle hook attaches — see the activity twin
-            const {rows} = await boundedRead(
+            const {capabilities, rows} = await boundedRead(
                 Promise.resolve().then(() => bridge.fleetRoster()),
                 me.livenessReadTimeout,
                 () => { me.gridReadInFlight-- }
@@ -2314,6 +2314,11 @@ class FleetCockpit extends Container {
 
             me.gridAdapterState = 'live';
             grid.adapterState   = 'live';
+            // the presence-CAPABILITY envelope rides every admitted snapshot onto the grid's chip:
+            // a degraded producer gets NAMED at roster level (every band correctly vanished — the
+            // "no one is online" operator falsifier), and a recovered producer clears it on the
+            // next poll. Absent/malformed envelopes plumb null — the chip claims nothing.
+            grid.presenceCapability = capabilities?.presence ?? null;
             me.getReference('catch-up')?.set({partitionOptions: me.buildCatchUpPartitionOptions()});
             me.getReference('memories')?.set({agentOptions: me.buildMemoriesAgentOptions()});
             me.clearDegradedReason('grid')

--- a/apps/agentos/view/fleet/FleetGrid.mjs
+++ b/apps/agentos/view/fleet/FleetGrid.mjs
@@ -112,6 +112,19 @@ class FleetGrid extends Container {
          */
         adapterState_: 'live',
         /**
+         * The roster's presence-CAPABILITY envelope (the assembler DTO's `capabilities.presence`:
+         * `{source, state, confidence, capturedAt, reason}`), plumbed by the cockpit's roster load.
+         * Owns the header chip that NAMES an axis degradation: when the producer answered
+         * `degraded`, every card's band correctly vanishes (absence of signal, never a verdict) —
+         * but unnamed absence reads as "no one is online" to a human, the live operator falsifier.
+         * `wired` and `not-wired` render NOTHING (bands speak for themselves; an expected-absent
+         * axis must not become another permanent line), and recovery clears the chip on the next
+         * plumbed snapshot.
+         * @member {Object|null} presenceCapability_=null
+         * @reactive
+         */
+        presenceCapability_: null,
+        /**
          * An OPTIONAL Up/Down efficiency shortcut that jumps focus between the DRILL Buttons only (the
          * gate-1 scale disposition) — a fast inter-agent jump for large rosters WITHOUT an outer roving
          * tab stop or a hidden interaction mode. Every control (drill / toggle / restart) stays in ordinary
@@ -141,6 +154,19 @@ class FleetGrid extends Container {
             items: [
                 {module: Component, cls: ['fm-fleet-title'], reference: 'fleet-title', flex: 'none', text: 'Fleet · 0 agents'},
                 {module: Component, cls: ['fm-fleet-stale'], reference: 'fleet-stale', flex: 'none', text: ''},
+                {
+                    // the presence-capability chip: NAMES the axis degradation so absent bands stop
+                    // reading as a verdict ("no one is online" — the operator falsifier this
+                    // answers). Renders ONLY for a degraded producer; wired stays absent (bands
+                    // speak) and not-wired stays absent (an expected-absent axis must not become
+                    // another permanent line). role=status: it is the roster's presence live-region.
+                    module   : Component,
+                    cls      : ['fm-fleet-presence-cap'],
+                    flex     : 'none',
+                    hidden   : true,
+                    reference: 'fleet-presence-cap',
+                    role     : 'status'
+                },
                 {ntype: 'component', flex: 1},
                 {module: HealthBar, reference: 'fleet-health', flex: 'none'}
             ]
@@ -176,6 +202,10 @@ class FleetGrid extends Container {
 
         // the health bar tallies from the SAME bound store (its own reactive record seam, no array copy)
         me.getReference('fleet-health').store = me.store;
+        // a create-time capability envelope lands after the reference tree exists — explicitly,
+        // because isConstructed stays false until the whole onConstructed chain completes, so the
+        // reactive hook cannot fire here (the HealthBar applyCounts pattern)
+        me.presenceCapability && me.applyPresenceCapability(me.presenceCapability);
         me.refreshGrid()
     }
 
@@ -198,6 +228,37 @@ class FleetGrid extends Container {
             me.getReference('fleet-health').store = value;
             me.refreshGrid()
         }
+    }
+
+    /**
+     * Triggered after the presenceCapability config changed — routes to the applier once the
+     * reference tree exists (the create-time envelope is applied explicitly from onConstructed,
+     * where isConstructed is still false by design).
+     * @param {Object|null} value
+     * @param {Object|null} oldValue
+     * @protected
+     */
+    afterSetPresenceCapability(value, oldValue) {
+        this.isConstructed && this.applyPresenceCapability(value)
+    }
+
+    /**
+     * @summary Render the presence-capability envelope onto the header chip: a DEGRADED producer
+     * gets named (with its own retained reason when one exists), every other envelope clears the
+     * chip. The a11y label mirrors the visible words (no colour-only or hover-only channel).
+     * Idempotent — a polling cockpit re-plumbing the same envelope re-renders the same chip.
+     * @param {Object|null} value
+     * @protected
+     */
+    applyPresenceCapability(value) {
+        const
+            degraded = value?.state === 'degraded',
+            reason   = degraded && typeof value.reason === 'string' && value.reason.trim(),
+            text     = degraded ? `presence unobservable${reason ? ` · ${reason}` : ''}` : '',
+            chip     = this.getReference('fleet-presence-cap');
+
+        chip.set({hidden: !degraded, text});
+        chip.changeVdomRootKey('aria-label', degraded ? `Presence: unobservable.${reason ? ` ${reason}.` : ''}` : null)
     }
 
     /**

--- a/resources/scss/src/apps/agentos/fleet/FleetGrid.scss
+++ b/resources/scss/src/apps/agentos/fleet/FleetGrid.scss
@@ -25,6 +25,17 @@
         color: var(--fm-ink-dim);
     }
 
+    /* the presence-capability chip: names an axis degradation (every band vanished honestly) so
+       absence stops reading as a verdict. Amber-adjacent via the idle token — informational, below
+       the wedged alarm register; renders only while the producer is degraded. */
+    .fm-fleet-presence-cap {
+        border       : 1px solid var(--fm-state-idle);
+        border-radius: 9px;
+        color        : var(--fm-ink-dim);
+        padding      : 1px 8px;
+        white-space  : nowrap;
+    }
+
     .fm-fleet-cards {
         /* the scroll-OWNING region: the derived roster (10+ residents) overflows the zone height
            at cockpit splits; only the cards scroll, the summary header stays pinned above

--- a/test/playwright/unit/apps/agentos/view/fleet/fleetCockpit.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/fleetCockpit.spec.mjs
@@ -306,6 +306,35 @@ test.describe('Fleet cockpit — Store-backed roster (loadRoster)', () => {
         }
     });
 
+    test('the presence-capability envelope rides every admitted snapshot onto the grid chip config', async () => {
+        // the operator falsifier this plumbs for: the plane's who_is_online read failed, every
+        // card's band correctly vanished (absence of signal), and the unnamed absence read as
+        // "no one is online" — a verdict. The producer's degraded envelope was already on the
+        // wire; loadRoster previously dropped it at the destructure.
+        const degraded = {
+            source    : 'fleet:presenceState',
+            state     : 'degraded',
+            confidence: 'none',
+            capturedAt: '2026-08-10T21:45:00.000Z',
+            reason    : 'plane who_is_online read failed'
+        };
+
+        const {grid} = await routeLoadRoster({fleetRoster: async () => ({
+            capabilities: {presence: degraded},
+            rows        : [{id: 'a1', displayName: 'A1'}]
+        })});
+
+        expect(grid.presenceCapability).toEqual(degraded);
+
+        // a recovered producer (or an assembler omitting the envelope) plumbs null — the chip
+        // must claim nothing on the next poll
+        const {grid: recovered} = await routeLoadRoster({fleetRoster: async () => ({
+            rows: [{id: 'a1', displayName: 'A1'}]
+        })});
+
+        expect(recovered.presenceCapability).toBeNull()
+    });
+
     test('a resolved EMPTY first snapshot preserves the zero-call sample until a source is selected', async () => {
         const {cockpit, grid} = await routeLoadRoster({fleetRoster: async () => ({rows: []})});
 

--- a/test/playwright/unit/apps/agentos/view/fleet/fleetGrid.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/fleetGrid.spec.mjs
@@ -112,6 +112,56 @@ test.describe('Fleet cockpit FleetGrid + HealthBar — Store-backed density-rank
         expect(rankFleet(roster(Array(20).fill('idle')), {foldThreshold: 12}).folded).toBe(true)
     });
 
+    test('the presence-capability chip NAMES a degraded producer — and only a degraded one', () => {
+        const store = makeStore(roster(['ok', 'idle'])),
+              grid  = Neo.create(FleetGrid, {appName, foldThreshold: 12, store}),
+              chip  = () => grid.getReference('fleet-presence-cap');
+
+        // no envelope (the boot default): the chip claims nothing
+        expect(chip().hidden).toBe(true);
+
+        // a DEGRADED producer renders the named degradation with its retained reason — the
+        // roster-level answer to bands vanishing honestly ("no one is online" was a misread of
+        // unnamed absence, the live operator falsifier)
+        grid.presenceCapability = {source: 'fleet:presenceState', state: 'degraded', confidence: 'none', reason: 'plane who_is_online read failed'};
+        expect(chip().hidden).toBe(false);
+        expect(chip().text).toBe('presence unobservable · plane who_is_online read failed');
+        expect(chip().vdom['aria-label']).toBe('Presence: unobservable. plane who_is_online read failed.');
+        expect(chip().vdom.role).toBe('status');
+
+        // a reasonless degradation still names itself
+        grid.presenceCapability = {source: 'fleet:presenceState', state: 'degraded', confidence: 'none', reason: null};
+        expect(chip().hidden).toBe(false);
+        expect(chip().text).toBe('presence unobservable');
+
+        // wired (bands speak for themselves) and not-wired (expected-absent axis — never another
+        // permanent line) both render NOTHING; recovery clears the previous claim
+        for (const state of ['wired', 'not-wired']) {
+            grid.presenceCapability = {source: 'fleet:presenceState', state, confidence: 'observed'};
+            expect(chip().hidden, state).toBe(true);
+            expect(chip().text, state).toBe('')
+        }
+
+        // null (assembler omitted the envelope) clears too
+        grid.presenceCapability = {source: 'fleet:presenceState', state: 'degraded', confidence: 'none', reason: 'x'};
+        grid.presenceCapability = null;
+        expect(chip().hidden).toBe(true);
+
+        grid.destroy();
+
+        // the create-time path: an envelope supplied at construction renders once the reference
+        // tree exists (the reactive path skips pre-construction)
+        const eager = Neo.create(FleetGrid, {
+            appName, foldThreshold: 12, store: makeStore(roster(['ok'])),
+            presenceCapability: {source: 'fleet:presenceState', state: 'degraded', confidence: 'none', reason: 'boot-time read failed'}
+        });
+
+        expect(eager.getReference('fleet-presence-cap').hidden).toBe(false);
+        expect(eager.getReference('fleet-presence-cap').text).toBe('presence unobservable · boot-time read failed');
+
+        eager.destroy()
+    });
+
     test('a11y: named landmark region owning a role=list card container (#14619)', () => {
         const grid = Neo.create(FleetGrid, {appName, store: makeStore(roster(['ok', 'idle']))});
 


### PR DESCRIPTION
Resolves neomjs/neo#16927
Refs neomjs/neo-agent-brain#53

The roster now NAMES a degraded presence producer instead of letting absence read as a verdict. `loadRoster` retains the assembler DTO's `capabilities` (previously dropped at the destructure) and plumbs `capabilities.presence ?? null` onto the grid on every admitted, generation-fenced snapshot; `FleetGrid` gains a reactive `presenceCapability_` config rendering a `role=status` header chip — **degraded → `presence unobservable · <producer's retained reason>`** — while `wired` (bands speak for themselves), `not-wired` (an expected-absent axis must not become another permanent line), and `null` all render nothing, and recovery clears the claim on the next poll. This is the naming half of neomjs/neo-agent-brain#53's tier-degradation AC, falsified live by the operator ("no one is online") when a plane degradation wave correctly vanished every band with nothing on the surface saying why.

Evidence: L2 (fenced loadRoster harness + real-FleetGrid chip matrix, 114 specs green in the two touched files) → L2 required (close-target ACs are render/plumb contracts). Residual: the live-degradation-window pixel receipt [#16927 Post-Merge].

## Deltas from ticket

- The applier is split from the reactive hook (`applyPresenceCapability`) because `isConstructed` stays false through the whole `onConstructed` chain — the create-time envelope is applied explicitly there, the exact HealthBar `applyCounts` pattern; the lifecycle subtlety is named in both the code comment and the spec's create-time row.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/apps/agentos/view/fleet/fleetGrid.spec.mjs test/playwright/unit/apps/agentos/view/fleet/fleetCockpit.spec.mjs` → **114 passed.** New rows: the chip matrix on a real FleetGrid (degraded-with-reason, reasonless-degraded, wired/not-wired/null all silent, recovery clears, create-time envelope renders, a11y label mirrors visible words) and the cockpit plumb (degraded envelope reaches `grid.presenceCapability` deep-equal; omitted envelope plumbs null on the next admitted snapshot).
- The SCSS chip class rides existing tokens (idle-amber border); no theme-token additions.

## Post-Merge Validation

- [ ] Live receipt on the next real plane-degradation window: intact roster + vanished bands + the named chip (the exact scenario of the operator falsifier).

## Commits (if multi-commit)

Single commit.

Authored by Clio (Fable 5, Claude Code). Session ff94e740-acb8-4f25-a94b-b614bdd91ea1.
