### PR TITLE
fix(knowledge-base): ask billed a cloud model by default, and its local path was never wired (#16932)

### DIFF
--- a/ai/agent/profile/Librarian.mjs
+++ b/ai/agent/profile/Librarian.mjs
@@ -16,7 +16,7 @@ class Librarian extends Agent {
         className: 'Neo.ai.agent.profile.Librarian',
         /**
          * Configurable model provider. Defaults to 'gemini' for reasoning speed
-         * but can be instantiated with 'ollama' (e.g. gemma-4-31b-it) to support
+         * but can be instantiated with 'ollama' (e.g. gemma4:26b) to support
          * swarms and offline sub-agent spawning.
          * @member {String|Neo.ai.provider.Base} modelProvider='gemini'
          */

--- a/ai/configBase.mjs
+++ b/ai/configBase.mjs
@@ -1824,7 +1824,12 @@ class ConfigBase extends ConfigProvider {
                     // every runtime. A different id here does not merely disagree on paper: MLX and
                     // LM Studio JIT-load whatever they are handed, so a second dense 31b would sit
                     // resident (~20 GB) beside the 26b already serving traffic.
-                    model: leaf('mlx-community/gemma-4-26b-a4b-bf16', 'NEO_ORCHESTRATOR_MLX_MODEL', 'string'),
+                    // `-it` is load-bearing: the INSTRUCTION-TUNED weights, carried over from the
+                    // `gemma-4-31b-it-bf16` this replaces. Verified against the mlx-community
+                    // registry, where `gemma-4-26b-a4b-bf16` (no `-it`) ALSO exists — so dropping
+                    // the suffix swaps the BASE model into a chat/graph-parsing role with no 404 to
+                    // notice it, just quietly worse output.
+                    model: leaf('mlx-community/gemma-4-26b-a4b-it-bf16', 'NEO_ORCHESTRATOR_MLX_MODEL', 'string'),
                     port : leaf('11435', 'NEO_ORCHESTRATOR_MLX_PORT', 'string')
                 },
                 /**

--- a/ai/configBase.mjs
+++ b/ai/configBase.mjs
@@ -738,7 +738,10 @@ class ConfigBase extends ConfigProvider {
                 /**
                  * @summary Chat-model context limits in tokens — a WORKLOAD FLOOR, not a RAM-fit target.
                  *
-                 * Default is HALF of `gemma-4-31b-it`'s native 256K context (131072). This is a
+                 * Default is 131072 — half of the 256K native context the deployment's chat models
+                 * carry. The number was originally derived from `gemma-4-31b-it`; it is retained
+                 * under `google/gemma-4-26b-a4b` because it is a WORKLOAD floor, not a per-model
+                 * ceiling, so it does not move when the model does. This is a
                  * deliberate floor, NOT a value auto-shrunk to fit free host RAM: graph extraction
                  * (`SemanticGraphExtractor`, `TopologyInferenceEngine`) and session summaries
                  * (`SessionService`) read this via the AiConfig SSOT and degrade below ~half. The
@@ -1817,8 +1820,12 @@ class ConfigBase extends ConfigProvider {
                  */
                 mlx: {
                     enabled: leaf(false, 'NEO_ORCHESTRATOR_MLX_ENABLED', 'boolean'),
-                    model  : leaf('mlx-community/gemma-4-31b-it-bf16', 'NEO_ORCHESTRATOR_MLX_MODEL', 'string'),
-                    port   : leaf('11435', 'NEO_ORCHESTRATOR_MLX_PORT', 'string')
+                    // The 26b MoE, matching `openAiCompatible.model` — one agreed chat model across
+                    // every runtime. A different id here does not merely disagree on paper: MLX and
+                    // LM Studio JIT-load whatever they are handed, so a second dense 31b would sit
+                    // resident (~20 GB) beside the 26b already serving traffic.
+                    model: leaf('mlx-community/gemma-4-26b-a4b-bf16', 'NEO_ORCHESTRATOR_MLX_MODEL', 'string'),
+                    port : leaf('11435', 'NEO_ORCHESTRATOR_MLX_PORT', 'string')
                 },
                 /**
                  * Orchestrator-owned native Ollama server config. Operators tune via gitignored

--- a/ai/deploy/docker-compose.parity-capture.yml
+++ b/ai/deploy/docker-compose.parity-capture.yml
@@ -64,7 +64,7 @@ services:
       NEO_OPENAI_COMPATIBLE_EMBEDDING_MODEL: text-embedding-qwen3-embedding-8b
       NEO_OPENAI_COMPATIBLE_API_KEY: neo-parity-ci-key
       NEO_KB_ASK_PROVIDER: openAiCompatible
-      NEO_KB_ASK_MODEL: gemma-4-31b-it
+      NEO_KB_ASK_MODEL: google/gemma-4-26b-a4b
       NEO_KB_ASK_API_KEY: neo-parity-ci-key
       NEO_KB_ASK_BASE_URL: http://embedding-server:11434
     depends_on:

--- a/ai/deploy/docker-compose.parity-ci.yml
+++ b/ai/deploy/docker-compose.parity-ci.yml
@@ -67,7 +67,7 @@ services:
       # partial override could retain a workstation key or base URL even while the main
       # model path points at the mock.
       NEO_KB_ASK_PROVIDER: openAiCompatible
-      NEO_KB_ASK_MODEL: gemma-4-31b-it
+      NEO_KB_ASK_MODEL: google/gemma-4-26b-a4b
       NEO_KB_ASK_API_KEY: neo-parity-ci-key
       NEO_KB_ASK_BASE_URL: http://embedding-server:11434
     depends_on:

--- a/ai/deploy/mock-openai-embedding-server.mjs
+++ b/ai/deploy/mock-openai-embedding-server.mjs
@@ -5,7 +5,7 @@ const host       = process.env.NEO_TEST_EMBEDDING_HOST || '0.0.0.0';
 const port       = Number(process.env.NEO_TEST_EMBEDDING_PORT || 11434);
 const dimensions = Number(process.env.NEO_TEST_EMBEDDING_DIMENSIONS || 4096);
 const modelName  = process.env.NEO_TEST_EMBEDDING_MODEL || 'text-embedding-qwen3-embedding-8b';
-const chatModel  = process.env.NEO_TEST_CHAT_MODEL || process.env.NEO_OPENAI_COMPATIBLE_MODEL || 'gemma-4-31b-it';
+const chatModel  = process.env.NEO_TEST_CHAT_MODEL || process.env.NEO_OPENAI_COMPATIBLE_MODEL || 'google/gemma-4-26b-a4b';
 
 /**
  * @summary Reads a JSON request body.

--- a/ai/mcp/server/knowledge-base/configBase.mjs
+++ b/ai/mcp/server/knowledge-base/configBase.mjs
@@ -189,23 +189,36 @@ class ConfigBase extends ConfigProvider {
              * global-provider coupling forced `ask` onto the slow local gemma (~287s measured), at or past
              * the MCP request-timeout ceiling.
              *
-             * Cost-safety (the scripted-runaway class — a real incident hammered a shared key at
-             * ~1,200 calls/min): (1) `maxCallsPerMinute` runaway breaker — interactive use sits far below
-             * the cap, a script trips it; (2) `apiKey` is a DEDICATED env-only key so the operator can
-             * hard-cap the cloud budget on just the ask path; (3) `gemini-2.5-flash` default — ~15-22x
-             * cheaper than 3.5-flash for no synthesis-quality loss here.
+             * Cost-safety, and why the DEFAULT is now local. The controls below are all bounds on a
+             * metered call: (1) `maxCallsPerMinute` runaway breaker — a real incident hammered a
+             * shared key at ~1,200 calls/min; (2) `apiKey` is a DEDICATED env-only key so the cloud
+             * budget can be hard-capped on just this path. Both assume the call happens and try to
+             * limit the damage. They did not prevent ~EUR 70/month of steady-state spend, and they
+             * cannot do anything at all about a key a peer has already exposed.
              *
-             * Local-option preserved: `provider: 'ollama' | 'openAiCompatible'` + `baseUrl` -> a local
-             * endpoint runs `ask` fully local (slower, no code leaves the box) for privacy-mandated
-             * deployments. A `deploymentMode` preset picks this (follow-up per-task-models architecture).
+             * So the default is the local model instead. Cost-bounding machinery beats an unbounded
+             * remote default, but no remote default beats both — an `ask` that never leaves the box
+             * has no meter to run and no key to leak. Remote synthesis is preserved and unchanged:
+             * `provider: 'gemini'` + `NEO_KB_ASK_API_KEY`, one deliberate env var, for anyone who
+             * wants cloud latency and is choosing to pay for it.
              * @type {Object}
              */
             askSynthesis: {
-                // Provider for the ask path: 'gemini' (remote, fast) | 'openAiCompatible' | 'ollama' (local).
-                provider: leaf('gemini', 'NEO_KB_ASK_PROVIDER', 'string'),
-                // Model name. Default 'gemini-2.5-flash' (cheaper + sufficient vs 3.5-flash). For a local
-                // provider, set NEO_KB_ASK_MODEL to the local model name.
-                model: leaf('gemini-2.5-flash', 'NEO_KB_ASK_MODEL', 'string'),
+                // Provider for the ask path: 'openAiCompatible' (local, DEFAULT) | 'ollama' (local) |
+                // 'gemini' (remote — opt-in, metered, and it must stay opt-in).
+                //
+                // The default moved remote -> LOCAL. A cloud default is a standing charge on every
+                // `ask`, and it billed ~EUR 70/month while a peer additionally EXPOSED the dedicated
+                // ask key. The cost-safety machinery below (runaway breaker, dedicated env-only key,
+                // budget cap) all presupposes a metered remote call; making the default local removes
+                // the meter instead of bounding it. Remote synthesis stays one env var away for
+                // anyone who wants it, and now costs a deliberate act rather than silence.
+                provider: leaf('openAiCompatible', 'NEO_KB_ASK_PROVIDER', 'string'),
+                // The deployment's agreed chat model, matching `openAiCompatible.model` in
+                // `ai/configBase.mjs`. 26b was chosen over 31b on measured performance grounds; ask
+                // does not get to pick a different one, or LM Studio JIT-loads a SECOND resident
+                // chat model beside the one already serving traffic.
+                model: leaf('google/gemma-4-26b-a4b', 'NEO_KB_ASK_MODEL', 'string'),
                 /**
                  * @summary SECURITY - the ask-synthesis API key. Read ONLY from `NEO_KB_ASK_API_KEY`.
                  *

--- a/ai/provider/OpenAiCompatible.mjs
+++ b/ai/provider/OpenAiCompatible.mjs
@@ -21,9 +21,21 @@ class OpenAiCompatibleProvider extends Base {
          */
         host: 'http://127.0.0.1:8000',
         /**
-         * @member {String} modelName='gemma4:31b'
+         * @summary The model id, INJECTED by the caller. No default, deliberately.
+         *
+         * This carried `'gemma4:31b'` — an **Ollama**-namespaced id sitting in the OpenAI-compatible
+         * provider, so it could never name a model an OpenAI-compatible server actually serves. A
+         * caller that forgot `modelName` therefore did not get a working fallback; it got a request
+         * for a model that does not exist, at whatever host was configured.
+         *
+         * A default here is wrong in principle too. The model is a deployment decision owned by the
+         * `AiConfig` SSOT (`openAiCompatible.model`), and a class-level literal is a second, hidden
+         * source for the same value — so a config-resolution failure stops presenting as a failure
+         * and starts presenting as a slightly-wrong model, which is far harder to notice. `null`
+         * makes the omission loud at the call site instead.
+         * @member {String|null} modelName=null
          */
-        modelName: 'gemma4:31b',
+        modelName: null,
         /**
          * @summary Optional bearer token for OpenAI-compatible API servers that require one.
          *

--- a/ai/scripts/diagnostics/captureParityLatencyPair.mjs
+++ b/ai/scripts/diagnostics/captureParityLatencyPair.mjs
@@ -1017,7 +1017,7 @@ export class ParityLatencyCaptureActor {
             NEO_HOOK_PROJECTION_ROOT                    : under('hook-projections'),
             NEO_KB_ASK_API_KEY                          : 'neo-parity-ci-key',
             NEO_KB_ASK_BASE_URL                         : `http://127.0.0.1:${this.embeddingPort}`,
-            NEO_KB_ASK_MODEL                            : 'gemma-4-31b-it',
+            NEO_KB_ASK_MODEL                            : 'google/gemma-4-26b-a4b',
             NEO_KB_ASK_PROVIDER                         : 'openAiCompatible',
             NEO_KB_AUTO_START_DATABASE                  : 'false',
             NEO_KB_LOG_PATH                             : under('logs'),

--- a/ai/services/knowledge-base/SearchService.mjs
+++ b/ai/services/knowledge-base/SearchService.mjs
@@ -108,10 +108,36 @@ class SearchService extends Base {
         // through to the provider's configured host, and `model` selects the per-task model name.
         const ask = aiConfig.askSynthesis;
 
+        // Each provider config is assembled by READING the four leaves `buildChatModel` consumes
+        // (`apiKey` / `host` / `model` / `keep_alive`), never by spreading the AiConfig node.
+        //
+        // `{...aiConfig.openAiCompatible}` here was measurably `{}`. An AiConfig node is a
+        // `Neo.state.Provider` proxy whose `get` trap walks the parent chain but whose `ownKeys`
+        // trap (`Provider#getTopLevelDataKeys`) enumerates LOCAL `#dataConfigs` only — and these
+        // leaves live on the Tier-1 root, so from the Knowledge Base child every named read is
+        // correct and every enumeration is empty. The spread silently dropped `host`, leaving the
+        // provider to fall back to its class default of `http://127.0.0.1:8000` — Chroma's port,
+        // not a chat endpoint. It went unnoticed because the ask path defaulted to `gemini`, which
+        // ignores this object entirely; pointing the default at a local provider is exactly what
+        // would have surfaced it, as a chat request POSTed at a vector database.
         this.model = buildChatModel({
-            modelProvider           : ask.provider,
-            openAiCompatibleConfig  : {...aiConfig.openAiCompatible, ...(ask.baseUrl ? {host: ask.baseUrl} : {}), model: ask.model},
-            ollamaConfig            : {...aiConfig.ollama, ...(ask.baseUrl ? {host: ask.baseUrl} : {}), model: ask.model},
+            modelProvider         : ask.provider,
+            openAiCompatibleConfig: {
+                // The PROVIDER's own key, never `ask.apiKey`. `NEO_KB_ASK_API_KEY` is the dedicated
+                // GEMINI credential (passed below as `geminiApiKey`); forwarding it here would put a
+                // cloud key in an `Authorization` header aimed at a local LM Studio that never asked
+                // for one — a credential sent somewhere it has no business being, which is a leak
+                // whether or not the key is currently valid.
+                apiKey    : aiConfig.openAiCompatible.apiKey,
+                host      : ask.baseUrl || aiConfig.openAiCompatible.host,
+                model     : ask.model,
+                keep_alive: aiConfig.openAiCompatible.keep_alive
+            },
+            ollamaConfig            : {
+                host      : ask.baseUrl || aiConfig.ollama.host,
+                model     : ask.model,
+                keep_alive: aiConfig.ollama.keep_alive
+            },
             geminiApiKey            : ask.apiKey,
             geminiModelName         : ask.model,
             providerActivityRecorder: KBRecorderService,

--- a/ai/services/knowledge-base/SearchService.mjs
+++ b/ai/services/knowledge-base/SearchService.mjs
@@ -15,6 +15,57 @@ import {CONCEPT_EXPANSION_EDGE_TYPES, KB_TERMINAL_EDGE_TYPES, enrichWithConceptW
 import {buildKbFileResolveCandidate}                                                 from './conceptWalkKbFileGate.mjs';
 import KBRecorderService                                                             from './KBRecorderService.mjs';
 
+/**
+ * @summary Builds the ask path's provider configs, pairing each host with its OWN credential.
+ *
+ * **A host and its credential are one coordinate.** Overriding the host must never inherit secret
+ * authority from the endpoint it displaced. Two leaks of that shape exist here, and the second was
+ * created while fixing the first:
+ *
+ * 1. `ask.apiKey` (`NEO_KB_ASK_API_KEY`) is the dedicated **Gemini** credential — it belongs to the
+ *    remote synthesis path and is passed separately as `geminiApiKey`. Forwarding it into the
+ *    OpenAI-compatible config would aim a cloud key at a local LM Studio.
+ * 2. Subtler: with a Tier-1 coordinate of `https://managed.example` + `sk-remote`, the documented
+ *    local override `NEO_KB_ASK_BASE_URL=http://127.0.0.1:1234` moved the HOST while leaving
+ *    `sk-remote` attached, so the transport emitted `Authorization: Bearer sk-remote` to a local
+ *    server. @neo-gpt reproduced that against the real provider factory.
+ *
+ * So the key travels with its own host or not at all: an own-endpoint override is BY DEFINITION not
+ * the Tier-1 endpoint. Empty is the safe default — an endpoint that needs a credential fails
+ * loudly, whereas a wrong credential leaves silently.
+ *
+ * Every value is READ BY NAME off the AiConfig node. Never spread it: the proxy's `get` trap walks
+ * the parent chain while `ownKeys` enumerates local `#dataConfigs` only, so `{...node}` is
+ * measurably `{}` for leaves declared on the Tier-1 root — which silently dropped `host` here and
+ * left the provider on its class default of Chroma's port.
+ *
+ * Exported as a pure function so the credential pairing is drivable in a spec. Asserting it through
+ * `SearchService` alone would mean re-deriving the expected value in the test, which proves the
+ * arithmetic rather than the contract.
+ *
+ * @param {Object} config The Knowledge Base AiConfig node (`askSynthesis` + the Tier-1 providers).
+ * @returns {{openAiCompatibleConfig: Object, ollamaConfig: Object}}
+ */
+export function buildAskProviderConfigs(config) {
+    const ask = config.askSynthesis;
+
+    return {
+        openAiCompatibleConfig: {
+            apiKey    : ask.baseUrl ? '' : config.openAiCompatible.apiKey,
+            host      : ask.baseUrl || config.openAiCompatible.host,
+            model     : ask.model,
+            keep_alive: config.openAiCompatible.keep_alive
+        },
+        // Ollama carries no key in this config shape, so the pairing question does not arise here;
+        // the host override alone is complete.
+        ollamaConfig: {
+            host      : ask.baseUrl || config.ollama.host,
+            model     : ask.model,
+            keep_alive: config.ollama.keep_alive
+        }
+    }
+}
+
 const LOCAL_EMPTY_COLLECTION_ANSWER  = "The knowledge base collection is empty. Populate it with the release artifact via 'npm run ai:download-kb' (or build locally with 'npm run ai:sync-kb').";
 const REMOTE_EMPTY_COLLECTION_ANSWER = "The knowledge base collection is empty. In a cloud or remote tenant-ingestion deployment, inspect ingestion state first: call get_ingestion_progress(), then inspect_deployment or get_deployment_state_snapshot for tenantRepoSync / deployment-state details. For push-mode tenants, run the configured ingest_source_files or bulk tenant-ingest path before retrying the query.";
 
@@ -120,24 +171,12 @@ class SearchService extends Base {
         // not a chat endpoint. It went unnoticed because the ask path defaulted to `gemini`, which
         // ignores this object entirely; pointing the default at a local provider is exactly what
         // would have surfaced it, as a chat request POSTed at a vector database.
+        const {openAiCompatibleConfig, ollamaConfig} = buildAskProviderConfigs(aiConfig);
+
         this.model = buildChatModel({
             modelProvider         : ask.provider,
-            openAiCompatibleConfig: {
-                // The PROVIDER's own key, never `ask.apiKey`. `NEO_KB_ASK_API_KEY` is the dedicated
-                // GEMINI credential (passed below as `geminiApiKey`); forwarding it here would put a
-                // cloud key in an `Authorization` header aimed at a local LM Studio that never asked
-                // for one — a credential sent somewhere it has no business being, which is a leak
-                // whether or not the key is currently valid.
-                apiKey    : aiConfig.openAiCompatible.apiKey,
-                host      : ask.baseUrl || aiConfig.openAiCompatible.host,
-                model     : ask.model,
-                keep_alive: aiConfig.openAiCompatible.keep_alive
-            },
-            ollamaConfig            : {
-                host      : ask.baseUrl || aiConfig.ollama.host,
-                model     : ask.model,
-                keep_alive: aiConfig.ollama.keep_alive
-            },
+            openAiCompatibleConfig,
+            ollamaConfig,
             geminiApiKey            : ask.apiKey,
             geminiModelName         : ask.model,
             providerActivityRecorder: KBRecorderService,

--- a/ai/services/memory-core/helpers/consumerFrictionHelper.mjs
+++ b/ai/services/memory-core/helpers/consumerFrictionHelper.mjs
@@ -1,7 +1,7 @@
 /**
  * @summary Brain-Pillar Consumer-Friction Channel V1 — visibility-only.
  *
- * Local-model substrate consumers (e.g. Gemma 4-31b, Qwen3-8b) emit `ConsumerFriction` records
+ * Local-model substrate consumers (e.g. Gemma 4-26b, Qwen3-8b) emit `ConsumerFriction` records
  * when the substrate payload is the wrong shape for them: context overflow, parse failure,
  * pre-invocation size-precheck skip, etc. V1 is **visibility-only**: emitted frictions accumulate
  * in an in-memory aggregator and surface in the next `GoldenPathSynthesizer.synthesizeGoldenPath`
@@ -47,7 +47,7 @@ import {PROVIDER_TIMEOUT_CODE} from '../../../provider/createTimeoutError.mjs';
  * @typedef {Object} ConsumerFriction
  * @property {String} assetRef Graph node ID of the substrate causing friction (sessionId, documentId, etc.) — first member of aggregation tuple.
  * @property {String} consumer Service name (e.g. 'SemanticGraphExtractor', 'SessionService.summarizeSession') — second member of aggregation tuple.
- * @property {String} model Consumer model identifier (e.g. 'gemma4-31b', 'qwen3-8b').
+ * @property {String} model Consumer model identifier (e.g. 'google/gemma-4-26b-a4b', 'qwen3-8b').
  * @property {'context-overflow' | 'parse-failure' | 'token-budget-exceeded' | 'semantic-confusion' | 'timeout' | 'size-precheck-skip'} symptom Friction symptom enum — third member of aggregation tuple.
  * @property {'pre-invocation' | 'post-invocation-failure'} emissionPoint When the friction was detected.
  * @property {'split-document' | 'compress-payload' | 'extract-anchor' | 'reduce-review-cycle' | 'schema-repair' | 'unknown'} suggestionKind Enum-backed structured suggestion for substrate-evolution action.

--- a/test/playwright/unit/ai/LiveServiceGuards.spec.mjs
+++ b/test/playwright/unit/ai/LiveServiceGuards.spec.mjs
@@ -1,0 +1,140 @@
+import {setup} from '../../setup.mjs';
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name             : 'LiveServiceGuardsTest',
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect}  from '@playwright/test';
+import Neo             from '../../../../src/Neo.mjs';
+import * as core       from '../../../../src/core/_export.mjs';
+import fs              from 'fs-extra';
+import path            from 'path';
+import {fileURLToPath} from 'url';
+
+const
+    __dirname = path.dirname(fileURLToPath(import.meta.url)),
+    unitRoot  = path.resolve(__dirname, '..'),
+    // A model server answers chat/embedding requests and JIT-LOADS whatever model id it is handed.
+    // Chroma's port is deliberately absent: the unit harness starts a run-scoped Chroma on a free
+    // port under `UNIT_TEST_MODE`, so reaching Chroma is isolated by construction. Reaching a model
+    // server is not — there is one, it belongs to whoever is running the suite, and it has finite RAM.
+    MODEL_HOSTS = [':1234', ':11434', ':11435'],
+    OPT_IN      = 'NEO_TEST_LIVE_MODELS';
+
+/**
+ * @summary No unit spec may drive a real model server unless the runner explicitly opted in.
+ *
+ * **What this exists to prevent, observed rather than imagined.** A spec set the configured chat
+ * model to `gemma-4-31b-it` and pointed the host at `127.0.0.1:1234`, then ran real summarization.
+ * A model id in a request is not a fixture — it is a LOAD INSTRUCTION, and LM Studio honours it. So
+ * every routine local `npm run test-unit` pulled a ~20 GB dense model into the operator's RAM beside
+ * the one already serving production traffic, where a 60-minute idle TTL kept it resident long after
+ * the run ended. The suite was choosing the deployment's model policy, and choosing against it.
+ *
+ * **Why the old guard could not catch it.** These specs carried `test.skip(!!NEO_TEST_SKIP_CI, …)` —
+ * skip in CI, run everywhere else. That is inverted: it exempts the machine with nothing to lose and
+ * exposes the machine with the models loaded, the real Chroma, and the operator watching. The same
+ * shape as skipping on a missing API key, where the condition meaning "unsafe here" is wired as the
+ * condition to skip.
+ *
+ * **Why a source-level assertion.** A behavioural arm cannot express this: the failure mode is a spec
+ * doing something to a machine that CI does not have, so CI can never observe it directly. Reading
+ * the guard is the only check that runs in the environment which is structurally blind to the defect.
+ */
+function unitSpecFiles(dir = unitRoot, out = []) {
+    for (const entry of fs.readdirSync(dir, {withFileTypes: true})) {
+        const full = path.join(dir, entry.name);
+
+        if (entry.isDirectory()) {
+            unitSpecFiles(full, out)
+        } else if (entry.name.endsWith('.spec.mjs')) {
+            out.push(full)
+        }
+    }
+
+    return out
+}
+
+/**
+ * @summary Strips comments, so the prose in THIS file's own siblings cannot satisfy or trip a check.
+ * @param {String} source
+ * @returns {String}
+ */
+function stripComments(source) {
+    return source
+        .replace(/\/\*[\s\S]*?\*\//g, '')
+        .replace(/^\s*\/\/.*$/gm, '')
+}
+
+test.describe('no unit spec drives a live model server without an explicit opt-in', () => {
+    const files = unitSpecFiles();
+
+    test('the sweep actually found the unit specs — a zero-file sweep proves nothing', () => {
+        // Without this, a broken path resolution turns every assertion below into a vacuous pass.
+        expect(files.length, 'unit spec discovery returned nothing').toBeGreaterThan(100)
+    });
+
+    /**
+     * @summary The precise target: the INVERTED guard on a spec that reaches a model host.
+     *
+     * A first version of this arm flagged every spec merely NAMING a model port, and it reported 18
+     * — almost all of them config-assertion specs (`configBase.spec.mjs`, `generateKimiSeatConfig`)
+     * that carry the host string as expected data and never open a socket. Forcing an opt-in gate on
+     * those would disable real coverage to buy no safety at all, so breadth here is not caution, it
+     * is damage.
+     *
+     * What actually distinguishes a dangerous spec is not that it mentions a host — it is that its
+     * author already KNEW it needs a live service and reached for `NEO_TEST_SKIP_CI` to express it.
+     * That guard means "skip in CI, run everywhere else", and everywhere else is somebody's laptop
+     * with their models loaded. The pair — names a model host AND carries the inverted guard — is
+     * the signal, and it is the pair that must not exist.
+     */
+    test('no spec reaching a model host may use the INVERTED skip-in-CI guard', () => {
+        const offenders = [];
+
+        for (const file of files) {
+            const source = stripComments(fs.readFileSync(file, 'utf8'));
+
+            if (!MODEL_HOSTS.some(hostPort => source.includes(`127.0.0.1${hostPort}`) ||
+                    source.includes(`localhost${hostPort}`))) {
+                continue
+            }
+
+            if (source.includes('NEO_TEST_SKIP_CI')) {
+                offenders.push(path.relative(unitRoot, file))
+            }
+        }
+
+        expect(offenders,
+            'these specs reach a real model server and gate on NEO_TEST_SKIP_CI, which skips in CI ' +
+            'and RUNS on the operator machine — backwards. A model id in a request is a load ' +
+            `instruction. Gate on ${OPT_IN} instead, or point the spec at the mock server.`
+        ).toEqual([])
+    });
+
+    test('NON-VACUITY — both halves of the pair are detectable in this tree', () => {
+        // An empty offender list must mean "the pair does not occur", not "one half never matches".
+        // Asserted separately so a broken matcher names WHICH half went blind.
+        let namesHost       = 0,
+            usesLegacyGuard = 0;
+
+        for (const file of files) {
+            const source = stripComments(fs.readFileSync(file, 'utf8'));
+
+            if (MODEL_HOSTS.some(hostPort => source.includes(`127.0.0.1${hostPort}`))) namesHost++;
+            if (source.includes('NEO_TEST_SKIP_CI'))                                   usesLegacyGuard++
+        }
+
+        expect(namesHost, 'no spec matched the model-host pattern — that half of the matcher is broken')
+            .toBeGreaterThan(0);
+        expect(usesLegacyGuard, 'no spec matched the legacy guard — that half of the matcher is broken')
+            .toBeGreaterThan(0)
+    })
+});

--- a/test/playwright/unit/ai/daemons/orchestrator/Orchestrator.invariants.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/Orchestrator.invariants.spec.mjs
@@ -421,7 +421,7 @@ test.describe('Orchestrator config getters delegate to AiConfig (data env/parse 
             graphProvider    : 'openAiCompatible',
             embeddingProvider: 'openAiCompatible',
             openAiCompatible : {
-                model         : 'gemma-4-31b-it',
+                model         : 'google/gemma-4-26b-a4b',
                 embeddingModel: 'qwen3-embedding'
             },
             localModels: {
@@ -432,8 +432,8 @@ test.describe('Orchestrator config getters delegate to AiConfig (data env/parse 
         // Per-model slot counts are distinct from requireParallelModels, which governs how many
         // distinct configured models stay co-resident.
         expect(result.parallels).toEqual({
-            'gemma-4-31b-it' : 1,
-            'qwen3-embedding': 1
+            'google/gemma-4-26b-a4b': 1,
+            'qwen3-embedding'       : 1
         });
     });
 

--- a/test/playwright/unit/ai/daemons/orchestrator/Orchestrator.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/Orchestrator.spec.mjs
@@ -1714,7 +1714,7 @@ test.describe('Neo.ai.daemons.Orchestrator (#11009)', () => {
             });
 
             expect(orchestrator.taskDefinitions.mlx.args).toContain('operator-configured-mlx-model');
-            expect(orchestrator.taskDefinitions.mlx.args).not.toContain('gemma-4-31b-it');
+            expect(orchestrator.taskDefinitions.mlx.args).not.toContain('google/gemma-4-26b-a4b');
         } finally {
             AiConfig.orchestrator.mlx = savedMlx;
         }
@@ -1734,7 +1734,7 @@ test.describe('Neo.ai.daemons.Orchestrator (#11009)', () => {
             AiConfig.orchestrator.lms = {enabled: true, model: 'qwen3-embedding-8b', port: '4242'};
             AiConfig.openAiCompatible = {
                 host          : 'http://127.0.0.1:4242',
-                model         : 'gemma4-31b',
+                model         : 'gemma4-26b',
                 embeddingModel: 'qwen3-8b'
             };
             AiConfig.orchestrator.providerReadiness = {attempts: 2, delayMs: 0, timeoutMs: 50, routineCacheTtlMs: 1000};
@@ -1752,7 +1752,7 @@ test.describe('Neo.ai.daemons.Orchestrator (#11009)', () => {
             expect(orchestrator.taskDefinitions.lms.command).toBe('lms');
             expect(orchestrator.taskDefinitions.lms.args).toEqual(['server', 'start', '--port', '4242']);
             expect(orchestrator.taskDefinitions.lms.pidFileName).toBe('lms.pid');
-            expect(orchestrator.taskDefinitions.lms.requiredModels).toEqual(['gemma4-31b', 'qwen3-8b']);
+            expect(orchestrator.taskDefinitions.lms.requiredModels).toEqual(['gemma4-26b', 'qwen3-8b']);
         } finally {
             AiConfig.orchestrator.lms = saved.lms;
             AiConfig.openAiCompatible = saved.openAiCompatible;

--- a/test/playwright/unit/ai/daemons/orchestrator/daemon.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/daemon.spec.mjs
@@ -200,7 +200,7 @@ test.describe('ai/daemons/orchestrator/daemon.mjs (#11006/#11009)', () => {
         const templateSource = fs.readFileSync(path.resolve(process.cwd(), 'ai/configBase.mjs'), 'utf8');
 
         expect(templateSource).toMatch(
-            /mlx:\s*\{[\s\S]*?leaf\(false[\s\S]*?'mlx-community\/gemma-4-31b-it-bf16'[\s\S]*?'11435'/
+            /mlx:\s*\{[\s\S]*?leaf\(false[\s\S]*?'mlx-community\/gemma-4-26b-a4b-bf16'[\s\S]*?'11435'/
         );
     });
 
@@ -297,7 +297,7 @@ test.describe('ai/daemons/orchestrator/daemon.mjs (#11006/#11009)', () => {
             nodeBin      : '/test/node',
             ollamaEnabled: true,
             ollamaHost   : 'http://127.0.0.1:11434',
-            ollamaRoles  : [{model: 'gemma4:31b'}]
+            ollamaRoles  : [{model: 'gemma4:26b'}]
         }).ollama).toBeUndefined();
     });
 
@@ -318,7 +318,7 @@ test.describe('ai/daemons/orchestrator/daemon.mjs (#11006/#11009)', () => {
             const roles = [{
                 role         : 'chat',
                 providerRole : 'graphProvider',
-                model        : 'gemma4:31b',
+                model        : 'gemma4:26b',
                 contextLength: 131072
             }, {
                 role         : 'embedding',

--- a/test/playwright/unit/ai/daemons/orchestrator/daemon.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/daemon.spec.mjs
@@ -200,7 +200,7 @@ test.describe('ai/daemons/orchestrator/daemon.mjs (#11006/#11009)', () => {
         const templateSource = fs.readFileSync(path.resolve(process.cwd(), 'ai/configBase.mjs'), 'utf8');
 
         expect(templateSource).toMatch(
-            /mlx:\s*\{[\s\S]*?leaf\(false[\s\S]*?'mlx-community\/gemma-4-26b-a4b-bf16'[\s\S]*?'11435'/
+            /mlx:\s*\{[\s\S]*?leaf\(false[\s\S]*?'mlx-community\/gemma-4-26b-a4b-it-bf16'[\s\S]*?'11435'/
         );
     });
 

--- a/test/playwright/unit/ai/daemons/orchestrator/services/ContainerHealthDiagnosisService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/ContainerHealthDiagnosisService.spec.mjs
@@ -587,7 +587,7 @@ test.describe('Neo.ai.daemons.services.ContainerHealthDiagnosisService', () => {
 
         const evalAttribution = {
             primaryRole: {role: 'chat'},
-            primaryLoad: {model: 'gemma4:31b'},
+            primaryLoad: {model: 'gemma4:26b'},
             stuckModels: [{
                 model          : 'qwen3-embedding',
                 role           : 'embedding',

--- a/test/playwright/unit/ai/deploy/ParityPlaneVolumeScoping.spec.mjs
+++ b/test/playwright/unit/ai/deploy/ParityPlaneVolumeScoping.spec.mjs
@@ -248,7 +248,7 @@ test.describe('parity profile — volume scoping is the isolation mechanism', ()
         expect(overlaySource).not.toMatch(/\b(?:gh[pousr]_|github_pat_)[A-Za-z0-9_]+/);
         expect(parityOverlay.services?.['kb-server']?.environment).toMatchObject({
             NEO_KB_ASK_PROVIDER: 'openAiCompatible',
-            NEO_KB_ASK_MODEL   : 'gemma-4-31b-it',
+            NEO_KB_ASK_MODEL   : 'google/gemma-4-26b-a4b',
             NEO_KB_ASK_API_KEY : 'neo-parity-ci-key',
             NEO_KB_ASK_BASE_URL: 'http://embedding-server:11434'
         });

--- a/test/playwright/unit/ai/provider/KeepAlive.spec.mjs
+++ b/test/playwright/unit/ai/provider/KeepAlive.spec.mjs
@@ -623,7 +623,12 @@ test.describe('AI provider keep_alive payload shape (#12080, #12089)', () => {
     });
 
     test('Ollama.generate() can verify native format against a live env-configured daemon (#13855)', async () => {
-        test.skip(!!process.env.NEO_TEST_SKIP_CI, 'CI-skip: live Ollama daemon is an operator-local dependency');
+        // OPT-IN. The previous guard skipped in CI and RAN everywhere else — but its own message
+        // names the reason it must not: a live Ollama daemon is an OPERATOR-LOCAL dependency, so
+        // "everywhere else" is exactly the operator's machine. Default OFF; set
+        // `NEO_TEST_LIVE_MODELS=true` to run against a daemon you deliberately provisioned.
+        test.skip(!process.env.NEO_TEST_LIVE_MODELS,
+            'live-model spec — set NEO_TEST_LIVE_MODELS=true to run against a real Ollama daemon');
         test.skip(process.env.NEO_RUN_LIVE_OLLAMA_TESTS !== '1', 'Skipping live Ollama test; set NEO_RUN_LIVE_OLLAMA_TESTS=1 to run');
 
         const host      = process.env.NEO_OLLAMA_HOST || 'http://127.0.0.1:11434';

--- a/test/playwright/unit/ai/scripts/diagnostics/lmStudioEmbeddingInstances.spec.mjs
+++ b/test/playwright/unit/ai/scripts/diagnostics/lmStudioEmbeddingInstances.spec.mjs
@@ -77,7 +77,7 @@ test.describe('lmStudioEmbeddingInstances diagnostic (#13539)', () => {
     test('passes when exactly one matching embedding worker is loaded', () => {
         const analysis = analyzeEmbeddingInstances({
             data: [
-                {id: 'gemma-4-31b-it', type: 'vlm', state: 'loaded'},
+                {id: 'google/gemma-4-26b-a4b', type: 'vlm', state: 'loaded'},
                 {id: 'text-embedding-qwen3-embedding-8b', type: 'embeddings', state: 'loaded'},
                 {id: 'text-embedding-nomic-embed-text-v1.5', type: 'embeddings', state: 'not-loaded'}
             ]

--- a/test/playwright/unit/ai/scripts/diagnostics/seatCostReport.spec.mjs
+++ b/test/playwright/unit/ai/scripts/diagnostics/seatCostReport.spec.mjs
@@ -34,15 +34,43 @@ import {
 // synthetic pair.
 const
     repoRoot    = process.cwd(),
-    fixtureDir  = fs.mkdtempSync(path.join(os.tmpdir(), 'seatcost-fixtures-')),
     scriptPath  = path.join(repoRoot, 'ai/scripts/diagnostics/seatCostReport.mjs'),
     wireFixture = syntheticWireContent(),
     rowsFixture = syntheticOpencodeRows();
 
-writeSyntheticFixtures(fixtureDir);
-test.afterAll(() => fs.rmSync(fixtureDir, {recursive: true, force: true}));
+/**
+ * The temp dir the CLI arms read through. Assigned in `beforeAll`, NOT at module scope.
+ *
+ * **The bug this shape fixes.** `fixtureDir` was a module-scope `mkdtempSync` with
+ * `writeSyntheticFixtures()` called beside it at import time, while cleanup was a top-level
+ * `test.afterAll`. Those are two different lifecycles: the fixtures were an IMPORT side effect and
+ * their removal a TEST-lifecycle hook, so nothing tied the directory's existence to the window in
+ * which the tests actually needed it. The two CLI arms then failed with
+ * `ENOENT … /seatcost-fixtures-XXXXXX/kimi-wire.jsonl` — a spawned child looking for a directory
+ * that had already been swept — and the same run leaked one uncleaned temp dir (52 had accumulated
+ * on this machine).
+ *
+ * It reproduced in EVERY full-suite run and passed in isolation, which is exactly why it was read as
+ * flake for weeks. It is not flake: it is deterministic, and it only needs enough sibling files in
+ * the worker to surface. That distinction matters beyond this file — a suite cannot be safely
+ * parallelized or path-scoped while failures like this are dismissed as noise.
+ * @type {String|null}
+ */
+let fixtureDir = null;
 
 test.describe('seatCostReport — harness ledger aggregation', () => {
+    test.beforeAll(() => {
+        fixtureDir = fs.mkdtempSync(path.join(os.tmpdir(), 'seatcost-fixtures-'));
+        writeSyntheticFixtures(fixtureDir)
+    });
+
+    test.afterAll(() => {
+        if (fixtureDir) {
+            fs.rmSync(fixtureDir, {recursive: true, force: true});
+            fixtureDir = null
+        }
+    });
+
     test('kimi wire parsing dedupes consecutive double-written lines, keeps model identity', () => {
         const line = JSON.stringify({
             type : 'usage.record',

--- a/test/playwright/unit/ai/scripts/runners/runSandman.spec.mjs
+++ b/test/playwright/unit/ai/scripts/runners/runSandman.spec.mjs
@@ -179,23 +179,23 @@ test.describe('runSandman.mjs provider readiness diagnostics (#10587)', () => {
     test('extracts native Ollama resident model ids from /api/ps variants', () => {
         expect(providerReadinessHelper.getOllamaRunningModelIds({
             models: [
-                {name: 'gemma4:31b', context_length: 131072},
+                {name: 'gemma4:26b', context_length: 131072},
                 {model: 'qwen3-embedding', context_length: 32768},
                 {id: 'fallback-model'},
-                {name: 'gemma4:31b'},
+                {name: 'gemma4:26b'},
                 {}
             ]
-        })).toEqual(['gemma4:31b', 'qwen3-embedding', 'fallback-model']);
+        })).toEqual(['gemma4:26b', 'qwen3-embedding', 'fallback-model']);
 
         expect(providerReadinessHelper.getOllamaRunningModels({
             models: [
-                {name: 'gemma4:31b', context_length: 131072},
+                {name: 'gemma4:26b', context_length: 131072},
                 {model: 'qwen3-embedding', context_length: 32768},
                 {id: 'fallback-model'},
-                {name: 'gemma4:31b', context_length: 4096}
+                {name: 'gemma4:26b', context_length: 4096}
             ]
         })).toEqual([{
-            id           : 'gemma4:31b',
+            id           : 'gemma4:26b',
             contextLength: 131072
         }, {
             id           : 'qwen3-embedding',
@@ -220,7 +220,7 @@ test.describe('runSandman.mjs provider readiness diagnostics (#10587)', () => {
                     ok  : true,
                     json: async () => ({
                         models: [
-                            {name: 'gemma4:31b', context_length: 131072},
+                            {name: 'gemma4:26b', context_length: 131072},
                             {name: 'qwen3-embedding', context_length: 32768}
                         ]
                     })
@@ -228,7 +228,7 @@ test.describe('runSandman.mjs provider readiness diagnostics (#10587)', () => {
             }
         });
 
-        expect(result).toEqual(['gemma4:31b', 'qwen3-embedding']);
+        expect(result).toEqual(['gemma4:26b', 'qwen3-embedding']);
         expect(calls).toEqual([{url: 'http://ollama.test/api/ps', method: 'GET'}]);
     });
 
@@ -258,7 +258,7 @@ test.describe('runSandman.mjs provider readiness diagnostics (#10587)', () => {
 
         const chatWarm = await providerReadinessHelper.warmOllamaRoleModel({
             host     : 'http://ollama.test',
-            model    : 'gemma4:31b',
+            model    : 'gemma4:26b',
             role     : 'chat',
             keepAlive: '-1',
             timeoutMs: 25,
@@ -279,7 +279,7 @@ test.describe('runSandman.mjs provider readiness diagnostics (#10587)', () => {
             headers  : {'content-type': 'application/json'},
             hasSignal: false,
             body     : {
-                model     : 'gemma4:31b',
+                model     : 'gemma4:26b',
                 messages  : [{role: 'user', content: ''}],
                 stream    : false,
                 keep_alive: '-1'
@@ -296,7 +296,7 @@ test.describe('runSandman.mjs provider readiness diagnostics (#10587)', () => {
             }
         }]);
         expect(chatWarm.evalSample).toMatchObject({
-            model               : 'gemma4:31b',
+            model               : 'gemma4:26b',
             role                : 'chat',
             evalCount           : 20,
             evalTokensPerSecond : 20,
@@ -394,7 +394,7 @@ test.describe('runSandman.mjs provider readiness diagnostics (#10587)', () => {
 
         await providerReadinessHelper.warmOllamaRoleModel({
             host         : 'http://ollama.test',
-            model        : 'gemma4:31b',
+            model        : 'gemma4:26b',
             role         : 'chat',
             contextLength: 131072,
             timeoutMs    : 25,
@@ -412,7 +412,7 @@ test.describe('runSandman.mjs provider readiness diagnostics (#10587)', () => {
         expect(calls).toEqual([{
             url : 'http://ollama.test/api/chat',
             body: {
-                model   : 'gemma4:31b',
+                model   : 'gemma4:26b',
                 messages: [{role: 'user', content: ''}],
                 stream  : false,
                 options : {num_ctx: 131072}
@@ -435,13 +435,13 @@ test.describe('runSandman.mjs provider readiness diagnostics (#10587)', () => {
                 modelProvider: 'openAiCompatible',
                 ollama       : {
                     host                 : 'http://ollama.test',
-                    model                : 'gemma4:31b',
+                    model                : 'gemma4:26b',
                     embeddingModel       : 'qwen3-embedding',
                     requireParallelModels: 2
                 }
             },
             timeoutMs        : 25,
-            fetchOllamaModels: async () => ['gemma4:31b'],
+            fetchOllamaModels: async () => ['gemma4:26b'],
             log              : {warn: (...args) => warnings.push(args)}
         });
 
@@ -463,13 +463,13 @@ test.describe('runSandman.mjs provider readiness diagnostics (#10587)', () => {
                 modelProvider   : 'gemini',
                 openAiCompatible: {
                     host                 : 'http://oai.test',
-                    model                : 'gemma-4-31b-it',
+                    model                : 'google/gemma-4-26b-a4b',
                     embeddingModel       : 'text-embedding-qwen3-embedding-8b',
                     requireParallelModels: 2
                 }
             },
             timeoutMs                  : 25,
-            fetchOpenAiCompatibleModels: async () => ['gemma-4-31b-it', 'text-embedding-qwen3-embedding-8b'],
+            fetchOpenAiCompatibleModels: async () => ['google/gemma-4-26b-a4b', 'text-embedding-qwen3-embedding-8b'],
             log                        : {warn: (...args) => warnings.push(args)}
         });
 
@@ -489,7 +489,7 @@ test.describe('runSandman.mjs provider readiness diagnostics (#10587)', () => {
                 graphProvider   : 'openAiCompatible',
                 openAiCompatible: {
                     host          : 'http://oai.test',
-                    model         : 'gemma-4-31b-it',
+                    model         : 'google/gemma-4-26b-a4b',
                     embeddingModel: 'text-embedding-qwen3-embedding-8b'
                 }
             },
@@ -511,7 +511,7 @@ test.describe('runSandman.mjs provider readiness diagnostics (#10587)', () => {
                     graphProvider   : 'openAiCompatible',
                     openAiCompatible: {
                         host          : 'http://oai.test',
-                        model         : 'gemma-4-31b-it',
+                        model         : 'google/gemma-4-26b-a4b',
                         embeddingModel: 'text-embedding-qwen3-embedding-8b',
                         requireParallelModels
                     }
@@ -1631,7 +1631,7 @@ test.describe('runSandman.mjs provider readiness diagnostics (#10587)', () => {
         const modelSnapshots = [
             [],
             [
-                {id: 'gemma4:31b', contextLength: 131072},
+                {id: 'gemma4:26b', contextLength: 131072},
                 {id: 'qwen3-embedding', contextLength: 32768}
             ]
         ];
@@ -1641,7 +1641,7 @@ test.describe('runSandman.mjs provider readiness diagnostics (#10587)', () => {
             roles: [{
                 providerRole : 'modelProvider',
                 role         : 'chat',
-                model        : 'gemma4:31b',
+                model        : 'gemma4:26b',
                 contextLength: 131072
             }, {
                 providerRole : 'embeddingProvider',
@@ -1655,7 +1655,7 @@ test.describe('runSandman.mjs provider readiness diagnostics (#10587)', () => {
             timeoutMs            : 25,
             keepAlive            : '-1',
             fetchModelIds        : async () => modelSnapshots.shift() || [
-                {id: 'gemma4:31b', contextLength: 131072},
+                {id: 'gemma4:26b', contextLength: 131072},
                 {id: 'qwen3-embedding', contextLength: 32768}
             ],
             warmModel: async (role, options) => {
@@ -1678,7 +1678,7 @@ test.describe('runSandman.mjs provider readiness diagnostics (#10587)', () => {
             role: {
                 providerRole : 'modelProvider',
                 role         : 'chat',
-                model        : 'gemma4:31b',
+                model        : 'gemma4:26b',
                 contextLength: 131072
             },
             options: {
@@ -1705,7 +1705,7 @@ test.describe('runSandman.mjs provider readiness diagnostics (#10587)', () => {
             ready       : true,
             provider    : 'ollama',
             warmedModels: [{
-                model        : 'gemma4:31b',
+                model        : 'gemma4:26b',
                 role         : 'chat',
                 providerRole : 'modelProvider',
                 contextLength: 131072
@@ -1715,11 +1715,11 @@ test.describe('runSandman.mjs provider readiness diagnostics (#10587)', () => {
                 providerRole : 'embeddingProvider',
                 contextLength: 32768
             }],
-            requiredModels : ['gemma4:31b', 'qwen3-embedding'],
-            availableModels: ['gemma4:31b', 'qwen3-embedding'],
+            requiredModels : ['gemma4:26b', 'qwen3-embedding'],
+            availableModels: ['gemma4:26b', 'qwen3-embedding'],
             extraModels    : [],
             loadedContexts : {
-                'gemma4:31b'     : 131072,
+                'gemma4:26b'     : 131072,
                 'qwen3-embedding': 32768
             },
             observedRequiredCount: 2,
@@ -1727,7 +1727,7 @@ test.describe('runSandman.mjs provider readiness diagnostics (#10587)', () => {
         });
         expect(result.ollamaEvalAttribution).toMatchObject({
             primaryLoad: {
-                model          : 'gemma4:31b',
+                model          : 'gemma4:26b',
                 role           : 'chat',
                 tokensPerSecond: 20
             },
@@ -1813,8 +1813,8 @@ test.describe('runSandman.mjs provider readiness diagnostics (#10587)', () => {
     test('ensureOllamaModelsReady degrades resident models loaded below configured context (#13865)', async () => {
         const warmCalls      = [];
         const modelSnapshots = [
-            [{id: 'gemma4:31b', contextLength: 4096}],
-            [{id: 'gemma4:31b', contextLength: 4096}]
+            [{id: 'gemma4:26b', contextLength: 4096}],
+            [{id: 'gemma4:26b', contextLength: 4096}]
         ];
 
         const result = await providerReadinessHelper.ensureOllamaModelsReady({
@@ -1822,7 +1822,7 @@ test.describe('runSandman.mjs provider readiness diagnostics (#10587)', () => {
             roles: [{
                 providerRole : 'graphProvider',
                 role         : 'chat',
-                model        : 'gemma4:31b',
+                model        : 'gemma4:26b',
                 contextLength: 131072
             }],
             requireParallelModels: 1,
@@ -1831,7 +1831,7 @@ test.describe('runSandman.mjs provider readiness diagnostics (#10587)', () => {
             delayMs              : 0,
             timeoutMs            : 25,
             keepAlive            : '-1',
-            fetchModelIds        : async () => modelSnapshots.shift() || [{id: 'gemma4:31b', contextLength: 4096}],
+            fetchModelIds        : async () => modelSnapshots.shift() || [{id: 'gemma4:26b', contextLength: 4096}],
             warmModel            : async (role, options) => warmCalls.push({role, options}),
             log                  : {info: () => {}}
         });
@@ -1840,7 +1840,7 @@ test.describe('runSandman.mjs provider readiness diagnostics (#10587)', () => {
             role: {
                 providerRole : 'graphProvider',
                 role         : 'chat',
-                model        : 'gemma4:31b',
+                model        : 'gemma4:26b',
                 contextLength: 131072
             },
             options: {
@@ -1856,11 +1856,11 @@ test.describe('runSandman.mjs provider readiness diagnostics (#10587)', () => {
         expect(result.extraModels).toEqual([]);
         expect(result.observedRequiredCount).toBe(1);
         expect(result.insufficientContextModels).toEqual([{
-            model                : 'gemma4:31b',
+            model                : 'gemma4:26b',
             contextLength        : 4096,
             requiredContextLength: 131072
         }]);
-        expect(result.loadedContexts).toEqual({'gemma4:31b': 4096});
+        expect(result.loadedContexts).toEqual({'gemma4:26b': 4096});
         expect(result.warning).toContain('loaded context too small');
         expect(result.warning).toContain('observed=4096 required>=131072');
     });
@@ -1872,7 +1872,7 @@ test.describe('runSandman.mjs provider readiness diagnostics (#10587)', () => {
             roles: [{
                 providerRole: 'modelProvider',
                 role        : 'chat',
-                model       : 'gemma4:31b'
+                model       : 'gemma4:26b'
             }, {
                 providerRole: 'embeddingProvider',
                 role        : 'embedding',
@@ -1898,16 +1898,16 @@ test.describe('runSandman.mjs provider readiness diagnostics (#10587)', () => {
         expect(result.ready).toBe(false);
         expect(result.degraded).toBe(true);
         expect(result.failedModels).toEqual([{
-            model       : 'gemma4:31b',
+            model       : 'gemma4:26b',
             role        : 'chat',
             providerRole: 'modelProvider',
             error       : 'Ollama refused chat model'
         }]);
-        expect(result.missingModels).toEqual(['gemma4:31b']);
+        expect(result.missingModels).toEqual(['gemma4:26b']);
         expect(result.availableModels).toEqual(['qwen3-embedding']);
         expect(result.extraModels).toEqual([]);
         expect(result.observedRequiredCount).toBe(1);
-        expect(result.warning).toContain('ollama pull gemma4:31b');
+        expect(result.warning).toContain('ollama pull gemma4:26b');
         expect(result.warning).not.toContain('set OLLAMA_MAX_LOADED_MODELS=2');
         expect(warnings[0]).toContain('warm-up failed');
     });
@@ -1952,17 +1952,17 @@ test.describe('runSandman.mjs provider readiness diagnostics (#10587)', () => {
             roles: [{
                 providerRole: 'graphProvider',
                 role        : 'chat',
-                model       : 'gemma4:31b'
+                model       : 'gemma4:26b'
             }],
             requireParallelModels: 2,
             attempts             : 1,
             delayMs              : 0,
             timeoutMs            : 25,
-            fetchModelIds        : async () => ['gemma4:31b']
+            fetchModelIds        : async () => ['gemma4:26b']
         });
 
         expect(result.ready).toBe(true);
-        expect(result.requiredModels).toEqual(['gemma4:31b']);
+        expect(result.requiredModels).toEqual(['gemma4:26b']);
         expect(result.extraModels).toEqual([]);
         expect(result.observedRequiredCount).toBe(1);
         expect(result.requiredResidentModels).toBe(1);
@@ -2125,7 +2125,7 @@ test.describe('runSandman.mjs provider readiness diagnostics (#10587)', () => {
             graphProvider    : 'openAiCompatible',
             embeddingProvider: 'openAiCompatible',
             openAiCompatible : {
-                model         : 'gemma-4-31b-it',
+                model         : 'google/gemma-4-26b-a4b',
                 embeddingModel: 'text-embedding-qwen3-embedding-8b'
             },
             localModels: {
@@ -2138,11 +2138,11 @@ test.describe('runSandman.mjs provider readiness diagnostics (#10587)', () => {
             }
         })).toEqual({
             models: [
-                'gemma-4-31b-it',
+                'google/gemma-4-26b-a4b',
                 'text-embedding-qwen3-embedding-8b'
             ],
             contextLengths: {
-                'gemma-4-31b-it'                   : 262144,
+                'google/gemma-4-26b-a4b'           : 262144,
                 'text-embedding-qwen3-embedding-8b': 32768
             },
             parallels: {}
@@ -2156,7 +2156,7 @@ test.describe('runSandman.mjs provider readiness diagnostics (#10587)', () => {
             embeddingProvider: 'ollama',
             ollama           : {
                 host                 : 'http://ollama.test',
-                model                : 'gemma4:31b',
+                model                : 'gemma4:26b',
                 embeddingModel       : 'qwen3-embedding',
                 keep_alive           : '-1',
                 requireParallelModels: 2
@@ -2178,13 +2178,13 @@ test.describe('runSandman.mjs provider readiness diagnostics (#10587)', () => {
             host                 : 'http://ollama.test',
             keepAlive            : '-1',
             requireParallelModels: 2,
-            model                : 'gemma4:31b',
+            model                : 'gemma4:26b',
             embeddingModel       : 'qwen3-embedding',
             roles                : [{
                 provider     : 'ollama',
                 providerRole : 'graphProvider',
                 role         : 'chat',
-                model        : 'gemma4:31b',
+                model        : 'gemma4:26b',
                 contextLength: 131072
             }, {
                 provider     : 'ollama',
@@ -2193,9 +2193,9 @@ test.describe('runSandman.mjs provider readiness diagnostics (#10587)', () => {
                 model        : 'qwen3-embedding',
                 contextLength: 32768
             }],
-            models        : ['gemma4:31b', 'qwen3-embedding'],
+            models        : ['gemma4:26b', 'qwen3-embedding'],
             contextLengths: {
-                'gemma4:31b'     : 131072,
+                'gemma4:26b'     : 131072,
                 'qwen3-embedding': 32768
             }
         });
@@ -2206,7 +2206,7 @@ test.describe('runSandman.mjs provider readiness diagnostics (#10587)', () => {
             embeddingProvider: 'openAiCompatible',
             ollama           : {
                 host                 : 'http://ollama.test',
-                model                : 'gemma4:31b',
+                model                : 'gemma4:26b',
                 embeddingModel       : 'qwen3-embedding',
                 requireParallelModels: 2
             },
@@ -2257,14 +2257,14 @@ test.describe('runSandman.mjs provider readiness diagnostics (#10587)', () => {
             graphProvider: 'ollama',
             ollama       : {
                 host : 'http://127.0.0.1:11434/',
-                model: 'gemma4:31b'
+                model: 'gemma4:26b'
             }
         })).toMatchObject({
             provider : 'ollama',
             supported: true,
             endpoint : '/api/tags',
             host     : 'http://127.0.0.1:11434/',
-            model    : 'gemma4:31b',
+            model    : 'gemma4:26b',
             url      : 'http://127.0.0.1:11434/api/tags'
         });
 
@@ -2277,7 +2277,7 @@ test.describe('runSandman.mjs provider readiness diagnostics (#10587)', () => {
             },
             ollama        : {
                 host : 'http://127.0.0.1:11434',
-                model: 'gemma4:31b'
+                model: 'gemma4:26b'
             }
         })).toMatchObject({
             provider : 'openAiCompatible',
@@ -2390,9 +2390,9 @@ test.describe('runSandman.mjs provider readiness diagnostics (#10587)', () => {
             degraded             : true,
             provider             : 'ollama',
             host                 : 'http://ollama.test',
-            requiredModels       : ['gemma4:31b', 'qwen3-embedding'],
+            requiredModels       : ['gemma4:26b', 'qwen3-embedding'],
             availableModels      : ['qwen3-embedding'],
-            missingModels        : ['gemma4:31b'],
+            missingModels        : ['gemma4:26b'],
             observedCount        : 1,
             requireParallelModels: 2,
             warning              : '[provider/ollama] expected 2+ models loaded; set OLLAMA_MAX_LOADED_MODELS=2 in the Ollama server environment.'
@@ -2403,7 +2403,7 @@ test.describe('runSandman.mjs provider readiness diagnostics (#10587)', () => {
                 graphProvider: 'ollama',
                 ollama       : {
                     host          : 'http://ollama.test',
-                    model         : 'gemma4:31b',
+                    model         : 'gemma4:26b',
                     embeddingModel: 'qwen3-embedding'
                 }
             },

--- a/test/playwright/unit/ai/services/graph/providerDispatch.spec.mjs
+++ b/test/playwright/unit/ai/services/graph/providerDispatch.spec.mjs
@@ -102,7 +102,7 @@ test.describe('buildGraphProvider (#11965 Sub-2 cycle-3)', () => {
 
         const provider = buildGraphProvider({
             modelProvider                  : 'openAiCompatible',
-            openAiCompatibleConfig         : {host: 'http://oai.test', model: 'gemma-4-31b', apiKey: 'sk-test', keep_alive: -1},
+            openAiCompatibleConfig         : {host: 'http://oai.test', model: 'google/gemma-4-26b-a4b', apiKey: 'sk-test', keep_alive: -1},
             openAiCompatibleProviderFactory: (cfg) => {
                 factoryCalls.push(cfg);
                 return fakeProvider;
@@ -111,7 +111,7 @@ test.describe('buildGraphProvider (#11965 Sub-2 cycle-3)', () => {
 
         expect(provider).toBe(fakeProvider);
         expect(factoryCalls).toEqual([{
-            modelName: 'gemma-4-31b',
+            modelName: 'google/gemma-4-26b-a4b',
             host     : 'http://oai.test',
             apiKey   : 'sk-test',
             keepAlive: -1

--- a/test/playwright/unit/ai/services/knowledge-base/AskSynthesisConfig.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/AskSynthesisConfig.spec.mjs
@@ -102,9 +102,42 @@ test.describe('ai/knowledge-base — askSynthesis config contract (canonical bas
         expect(src).toMatch(/askSynthesis\s*:\s*\{/);
     });
 
-    test('defaults to the fast remote gemini provider + the cheaper 2.5-flash model', () => {
-        expect(src).toMatch(/provider\s*:\s*leaf\('gemini',\s*'NEO_KB_ASK_PROVIDER'/);
-        expect(src).toMatch(/model\s*:\s*leaf\('gemini-2\.5-flash',\s*'NEO_KB_ASK_MODEL'/);
+    /**
+     * @summary The ask default is LOCAL, and no remote model id may be the default.
+     *
+     * This arm previously asserted the opposite — a remote `gemini` provider on `gemini-2.5-flash`,
+     * justified as the cheaper of two cloud models. Cheaper is not free: a cloud DEFAULT bills every
+     * `ask` by nobody's decision, it ran ~EUR 70/month, and the dedicated key it required was
+     * exposed by a peer. The block's own cost-safety machinery (runaway breaker, dedicated key,
+     * budget cap) all bounds a metered call rather than removing the meter.
+     *
+     * The second assertion is the one that matters long-term. Pinning `'openAiCompatible'` alone
+     * would still pass if someone left a remote model id in the `model` leaf, which is precisely how
+     * this drifts back — a provider flip is visible in review, a model-id string is not.
+     */
+    test('defaults to the LOCAL provider on the deployment chat model — never a metered remote', () => {
+        expect(src).toMatch(/provider\s*:\s*leaf\('openAiCompatible',\s*'NEO_KB_ASK_PROVIDER'/);
+        expect(src).toMatch(/model\s*:\s*leaf\('google\/gemma-4-26b-a4b',\s*'NEO_KB_ASK_MODEL'/);
+
+        // The ask model must be the SAME id the deployment already serves. A different one is not a
+        // preference — LM Studio JIT-loads whatever it is handed, so it means a second resident
+        // chat model (~20 GB) beside the one serving traffic.
+        const tier1 = fs.readFileSync(path.join(repoRoot, 'ai/configBase.mjs'), 'utf8');
+
+        expect(tier1, 'the Tier-1 chat leaf is the single source for this id')
+            .toMatch(/model\s*:\s*leaf\('google\/gemma-4-26b-a4b',\s*'NEO_OPENAI_COMPATIBLE_MODEL'/);
+    });
+
+    test('NO remote model id may sit in a default anywhere in the askSynthesis block', () => {
+        // The regression this blocks is a quiet edit of one string, not a redesign. Named remote
+        // families rather than a generic pattern, so the failure says WHICH vendor crept back in.
+        const askBlock = src.slice(src.indexOf('askSynthesis'), src.indexOf('askSynthesis') + 4000);
+
+        for (const remote of ['gemini-', 'gpt-4', 'gpt-5', 'claude-3', 'claude-4', 'claude-5']) {
+            expect(askBlock.includes(`leaf('${remote}`),
+                `a metered ${remote}* id is the DEFAULT again — remote synthesis must stay opt-in via env`
+            ).toBe(false)
+        }
     });
 
     test('apiKey is env-only — null default bound to NEO_KB_ASK_API_KEY, no inline literal (security)', () => {

--- a/test/playwright/unit/ai/services/knowledge-base/SearchService.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/SearchService.spec.mjs
@@ -289,7 +289,7 @@ test.describe('Neo.ai.services.knowledge-base.SearchService', () => {
         SearchService.model = {
             generateContent: async (prompt, options) => {
                 capturedOptions = options;
-                throw new Error('[Ollama] ask_knowledge_base synthesis timed out after 30000ms (host=http://127.0.0.1:11434, model=gemma4:31b)');
+                throw new Error('[Ollama] ask_knowledge_base synthesis timed out after 30000ms (host=http://127.0.0.1:11434, model=gemma4:26b)');
             }
         };
 

--- a/test/playwright/unit/ai/services/knowledge-base/SearchService.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/SearchService.spec.mjs
@@ -477,4 +477,49 @@ test.describe('Neo.ai.services.knowledge-base.SearchService', () => {
             ChromaManager.getKnowledgeBaseCollection = originalGetCollection;
         }
     });
+
+    /**
+     * @summary A host override must not inherit the displaced endpoint's credential.
+     *
+     * @neo-gpt's falsifier, pinned. The first repair here removed the GEMINI key from the
+     * OpenAI-compatible branch and I described the credential boundary as closed. It was not: the
+     * documented local override `NEO_KB_ASK_BASE_URL` moved the HOST while the Tier-1
+     * `openAiCompatible.apiKey` stayed attached, so a managed `sk-remote` was emitted as
+     * `Authorization: Bearer sk-remote` at a local LM Studio. One cross-provider leak closed, one
+     * cross-endpoint leak opened, same shape.
+     *
+     * Driven through the exported producer with real config shapes, so it fails on the PRODUCER
+     * rather than on a value the test recomputed.
+     */
+    test('#16932: an ask.baseUrl override gets the LOCAL host and NO inherited Tier-1 key', async () => {
+        const {buildAskProviderConfigs} = await import('../../../../../../ai/services/knowledge-base/SearchService.mjs');
+
+        const {openAiCompatibleConfig} = buildAskProviderConfigs({
+            askSynthesis    : {baseUrl: 'http://127.0.0.1:1234', model: 'google/gemma-4-26b-a4b', apiKey: 'gemini-key'},
+            openAiCompatible: {host: 'https://managed.example', apiKey: 'sk-remote', keep_alive: -1},
+            ollama          : {host: 'http://127.0.0.1:11434', keep_alive: -1}
+        });
+
+        expect(openAiCompatibleConfig.host, 'the override must win the host').toBe('http://127.0.0.1:1234');
+        expect(openAiCompatibleConfig.apiKey,
+            'the displaced Tier-1 credential must NOT travel to the override host').toBe('');
+        expect(openAiCompatibleConfig.apiKey,
+            'and the Gemini ask key must never reach this branch either').not.toBe('gemini-key')
+    });
+
+    test('#16932: NON-VACUITY — with NO override, the Tier-1 host keeps its OWN key', async () => {
+        // Without this, the arm above passes against a producer that simply never sends a key —
+        // which would break every managed OpenAI-compatible deployment while looking secure.
+        const {buildAskProviderConfigs} = await import('../../../../../../ai/services/knowledge-base/SearchService.mjs');
+
+        const {openAiCompatibleConfig} = buildAskProviderConfigs({
+            askSynthesis    : {baseUrl: null, model: 'google/gemma-4-26b-a4b', apiKey: 'gemini-key'},
+            openAiCompatible: {host: 'https://managed.example', apiKey: 'sk-remote', keep_alive: -1},
+            ollama          : {host: 'http://127.0.0.1:11434', keep_alive: -1}
+        });
+
+        expect(openAiCompatibleConfig.host).toBe('https://managed.example');
+        expect(openAiCompatibleConfig.apiKey,
+            'an un-displaced endpoint keeps its own credential').toBe('sk-remote')
+    });
 });

--- a/test/playwright/unit/ai/services/memory-core/SessionSummarization.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/SessionSummarization.spec.mjs
@@ -44,7 +44,18 @@ test.describe('Memory Core Offline Summarization', () => {
     // The per-test `localModelActive` guard below stays as a defensive fallback for local-dev
     // without gemma4 running, but the CI-side skip is the early exit that prevents `beforeAll`
     // from probing a nonexistent endpoint.
-    test.skip(!!process.env.NEO_TEST_SKIP_CI, 'CI-skip: heavy SLM (gemma4) — bucket A (#10903)');
+    // OPT-IN, and the inversion is the point. This read `!!process.env.NEO_TEST_SKIP_CI` — skip in
+    // CI, RUN everywhere else — which protects the machine with nothing to lose and exposes the one
+    // with the real models loaded. These tests drive a REAL model server at `127.0.0.1:1234`, so on
+    // an operator's box every routine `npm run test-unit` was live inference against their LM Studio.
+    //
+    // The same shape as guarding on a missing API key: the condition that means "unsafe to run here"
+    // was wired as the condition to skip, so the guard fired precisely where running was harmless.
+    //
+    // Default OFF everywhere, including locally. Set `NEO_TEST_LIVE_MODELS=true` to run against a
+    // model server you have deliberately provisioned.
+    test.skip(!process.env.NEO_TEST_LIVE_MODELS,
+        'live-model spec — set NEO_TEST_LIVE_MODELS=true to run against a real model server');
 
     let SDK, TextEmbeddingService, dummySessionId, originalEmbedText, originalEmbedTexts, originalSessionModel, restoreAiConfig;
     let localModelActive = false;

--- a/test/playwright/unit/ai/services/memory-core/SessionSummarization.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/SessionSummarization.spec.mjs
@@ -73,7 +73,18 @@ test.describe('Memory Core Offline Summarization', () => {
         SDK.Memory_Config.data.modelProvider         = 'openAiCompatible';
         SDK.Memory_Config.data.embeddingProvider     = 'openAiCompatible';
         SDK.Memory_Config.data.openAiCompatible.host           = 'http://127.0.0.1:1234';
-        SDK.Memory_Config.data.openAiCompatible.model          = 'gemma-4-31b-it';
+        // The MODEL is deliberately NOT overridden: it resolves from the SSOT leaf
+        // (`ai/configBase.mjs` -> `google/gemma-4-26b-a4b`), the deployment's agreed chat model.
+        //
+        // This line previously hardcoded `gemma-4-31b-it`. That is not a fixture value — it is a
+        // LOAD INSTRUCTION. LM Studio JIT-loads whatever model id a request names, so every local
+        // run of this suite pulled a 19.7 GB second chat model into the operator's RAM beside the
+        // 15.6 GB one already serving real traffic, and the 60-minute idle TTL kept it resident
+        // long after the run finished. The suite was choosing the deployment's model policy, and
+        // choosing against it — 26b was selected over 31b on measured performance grounds.
+        //
+        // Only `host` is overridden, because the leaf default points at the Ollama port and this
+        // spec asserts the OpenAI-compatible route specifically.
         SDK.Memory_Config.data.openAiCompatible.embeddingModel = 'text-embedding-qwen3-embedding-8b';
         // Adjust batch limit to speed up test execution
         SDK.Memory_Config.data.summarizationBatchLimit = 5;

--- a/test/playwright/unit/ai/services/memory-core/helpers/consumerFrictionHelper.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/helpers/consumerFrictionHelper.spec.mjs
@@ -18,13 +18,13 @@ import Neo            from '../../../../../../../src/Neo.mjs';
 import * as core      from '../../../../../../../src/core/_export.mjs';
 
 /**
- * @summary Unit coverage for the Brain-Pillar Consumer-Friction Helper (#11447 V1).
+ * @summary Unit coverage for the Brain-Pillar Consumer-Friction Helper (#11447 V1). ticket-ref-ok: names the contract this file exists to verify
  *
  * The helper is module-singleton state — tests MUST `clearAggregatedFrictions()` in
  * `beforeEach` to prevent cross-test pollution. Per `feedback_symmetric_spec_cleanup`,
  * shared mutable state across tests requires symmetric reset discipline.
  *
- * Schema verified against Discussion #11444 graduation contract (Round-2 + Round-3
+ * Schema verified against Discussion #11444 graduation contract (Round-2 + Round-3 ticket-ref-ok: the schema authority
  * consensus): structured `ConsumerFriction` with `suggestionKind`, token-based durable
  * metrics, `(assetRef, consumer, symptom)` aggregation tuple, `serviceDomain` provenance,
  * `firstSeenAt`/`lastSeenAt`/`count` aggregation fields.
@@ -104,7 +104,7 @@ test.describe.serial('Neo.ai.services.memory-core.helpers.ConsumerFrictionHelper
         emitConsumerFriction({
             assetRef          : 'session:abc',
             consumer          : 'SemanticGraphExtractor',
-            model             : 'gemma4-31b',
+            model             : 'gemma4-26b',
             symptom           : 'size-precheck-skip',
             emissionPoint     : 'pre-invocation',
             inputBytes        : 100000,
@@ -118,7 +118,7 @@ test.describe.serial('Neo.ai.services.memory-core.helpers.ConsumerFrictionHelper
         expect(surfaced[0]).toMatchObject({
             assetRef           : 'session:abc',
             consumer           : 'SemanticGraphExtractor',
-            model              : 'gemma4-31b',
+            model              : 'gemma4-26b',
             symptom            : 'size-precheck-skip',
             emissionPoint      : 'pre-invocation',
             suggestionKind     : 'compress-payload',
@@ -139,7 +139,7 @@ test.describe.serial('Neo.ai.services.memory-core.helpers.ConsumerFrictionHelper
         emitConsumerFriction({
             assetRef          : 'session:def',
             consumer          : 'SessionService',
-            model             : 'gemma4-31b',
+            model             : 'gemma4-26b',
             symptom           : 'context-overflow',
             emissionPoint     : 'post-invocation-failure',
             inputBytes        : 50000,
@@ -160,7 +160,7 @@ test.describe.serial('Neo.ai.services.memory-core.helpers.ConsumerFrictionHelper
         const baseFriction = {
             assetRef          : 'session:ghi',
             consumer          : 'SemanticGraphExtractor',
-            model             : 'gemma4-31b',
+            model             : 'gemma4-26b',
             symptom           : 'parse-failure',
             emissionPoint     : 'post-invocation-failure',
             inputBytes        : 5000,
@@ -188,7 +188,7 @@ test.describe.serial('Neo.ai.services.memory-core.helpers.ConsumerFrictionHelper
 
         const base = {
             consumer          : 'SemanticGraphExtractor',
-            model             : 'gemma4-31b',
+            model             : 'gemma4-26b',
             symptom           : 'parse-failure',
             emissionPoint     : 'post-invocation-failure',
             inputBytes        : 5000,
@@ -213,7 +213,7 @@ test.describe.serial('Neo.ai.services.memory-core.helpers.ConsumerFrictionHelper
         emitConsumerFriction({
             assetRef          : 'session:ttl',
             consumer          : 'SemanticGraphExtractor',
-            model             : 'gemma4-31b',
+            model             : 'gemma4-26b',
             symptom           : 'size-precheck-skip',
             emissionPoint     : 'pre-invocation',
             inputBytes        : 100000,
@@ -236,7 +236,7 @@ test.describe.serial('Neo.ai.services.memory-core.helpers.ConsumerFrictionHelper
         const result  = await invokeWithGuardrail({
             invocationFn             : async () => { invoked = true; return 'should not run'; },
             inputPayload             : 'x'.repeat(50000), // 50000 bytes = 16667 tokens estimate
-            model                    : 'gemma4-31b',
+            model                    : 'gemma4-26b',
             assetRef                 : 'session:precheck',
             consumer                 : 'SemanticGraphExtractor',
             contextLimitTokens       : 10000,
@@ -299,7 +299,7 @@ test.describe.serial('Neo.ai.services.memory-core.helpers.ConsumerFrictionHelper
                 return {content: 'ok'};
             },
             inputPayload             : 'x'.repeat(21000), // 21000 bytes = 7000 tokens estimate
-            model                    : 'gemma4-31b',
+            model                    : 'gemma4-26b',
             assetRef                 : 'session:under-band',
             consumer                 : 'SemanticGraphExtractor',
             contextLimitTokens       : 10000,
@@ -320,7 +320,7 @@ test.describe.serial('Neo.ai.services.memory-core.helpers.ConsumerFrictionHelper
         const result = await invokeWithGuardrail({
             invocationFn      : async () => { invoked = true; return 'should not run'; },
             inputPayload      : 'x'.repeat(33000),
-            model             : 'gemma4-31b',
+            model             : 'gemma4-26b',
             assetRef          : 'session:precheck-default',
             consumer          : 'SemanticGraphExtractor',
             contextLimitTokens: 10000,
@@ -338,16 +338,16 @@ test.describe.serial('Neo.ai.services.memory-core.helpers.ConsumerFrictionHelper
         const {invokeWithGuardrail, getAggregatedFrictions} = helper;
 
         const result = await invokeWithGuardrail({
-            invocationFn      : async () => ({content: 'ok', model: 'gemma4-31b'}),
+            invocationFn      : async () => ({content: 'ok', model: 'gemma4-26b'}),
             inputPayload      : 'small input',
-            model             : 'gemma4-31b',
+            model             : 'gemma4-26b',
             assetRef          : 'session:success',
             consumer          : 'SemanticGraphExtractor',
             contextLimitTokens: 10000,
             serviceDomain     : 'dream-pipeline'
         });
 
-        expect(result.result).toEqual({content: 'ok', model: 'gemma4-31b'});
+        expect(result.result).toEqual({content: 'ok', model: 'gemma4-26b'});
         expect(result.friction).toBeNull();
         expect(getAggregatedFrictions()).toHaveLength(0);
     });
@@ -360,7 +360,7 @@ test.describe.serial('Neo.ai.services.memory-core.helpers.ConsumerFrictionHelper
             const result = await invokeWithGuardrail({
                 invocationFn      : async () => { throw new Error('Malformed JSON response'); },
                 inputPayload      : 'small input',
-                model             : 'gemma4-31b',
+                model             : 'gemma4-26b',
                 assetRef          : 'session:fail-parse',
                 consumer          : 'SemanticGraphExtractor',
                 contextLimitTokens: 10000,
@@ -384,7 +384,7 @@ test.describe.serial('Neo.ai.services.memory-core.helpers.ConsumerFrictionHelper
         const result = await invokeWithGuardrail({
             invocationFn      : async () => { throw new Error('Context window exceeded'); },
             inputPayload      : 'medium input',
-            model             : 'gemma4-31b',
+            model             : 'gemma4-26b',
             assetRef          : 'session:fail-overflow',
             consumer          : 'SessionService',
             contextLimitTokens: 10000,
@@ -402,7 +402,7 @@ test.describe.serial('Neo.ai.services.memory-core.helpers.ConsumerFrictionHelper
         const result = await invokeWithGuardrail({
             invocationFn      : async () => { throw new Error('JSON malformed'); },
             inputPayload      : 'tiny',
-            model             : 'gemma4-31b',
+            model             : 'gemma4-26b',
             assetRef          : 'session:hint',
             consumer          : 'SemanticGraphExtractor',
             contextLimitTokens: 10000,
@@ -418,15 +418,15 @@ test.describe.serial('Neo.ai.services.memory-core.helpers.ConsumerFrictionHelper
     test('emitConsumerFriction loud-fails on non-positive-finite contextLimitTokens (#12116 AC2)', () => {
         const {emitConsumerFriction, getAggregatedFrictions} = helper;
 
-        // Direct emitter contract: #12116 AC2 requires the same loud-fail discipline
+        // Direct emitter contract: #12116 AC2 requires the same loud-fail discipline ticket-ref-ok: names the AC under test
         // on emitConsumerFriction itself, not only on the invokeWithGuardrail wrapper.
         // Pre-fix the emitter happily recorded a friction entry with undefined
         // contextLimitTokens, silently corrupting the friction-feed downstream
-        // (cross-family reviewer's empirical falsifier on PR #12121 cycle-1).
+        // (cross-family reviewer's empirical falsifier on PR #12121 cycle-1). ticket-ref-ok: provenance of the falsifier
         const baseInput = {
             assetRef     : 'session:emit-loud-fail',
             consumer     : 'SemanticGraphExtractor',
-            model        : 'gemma4-31b',
+            model        : 'gemma4-26b',
             symptom      : 'size-precheck-skip',
             emissionPoint: 'pre-invocation',
             inputBytes   : 100,
@@ -447,7 +447,7 @@ test.describe.serial('Neo.ai.services.memory-core.helpers.ConsumerFrictionHelper
     test('invokeWithGuardrail loud-fails on non-positive-finite contextLimitTokens (#12116 AC1)', async () => {
         const {invokeWithGuardrail, getAggregatedFrictions} = helper;
 
-        // Pre-#12116 the NaN-silent-skip hole let undefined/null/NaN bypass the
+        // Pre-#12116 the NaN-silent-skip hole let undefined/null/NaN bypass the ticket-ref-ok: the before-state this arm pins
         // Angle-2 pre-check (Math.floor(undefined * 0.75) === NaN; `n > NaN`
         // === false), then the invocation proceeded unguarded and the friction
         // record stored undefined for contextLimitTokens — silently corrupting
@@ -457,7 +457,7 @@ test.describe.serial('Neo.ai.services.memory-core.helpers.ConsumerFrictionHelper
         const baseInput = {
             invocationFn : async () => 'should not reach here',
             inputPayload : 'small',
-            model        : 'gemma4-31b',
+            model        : 'gemma4-26b',
             assetRef     : 'session:loud-fail',
             consumer     : 'SemanticGraphExtractor',
             serviceDomain: 'dream-pipeline'
@@ -489,7 +489,7 @@ test.describe.serial('Neo.ai.services.memory-core.helpers.ConsumerFrictionHelper
         emitConsumerFriction({
             assetRef                 : 'session:render',
             consumer                 : 'SemanticGraphExtractor',
-            model                    : 'gemma4-31b',
+            model                    : 'gemma4-26b',
             symptom                  : 'size-precheck-skip',
             emissionPoint            : 'pre-invocation',
             inputBytes               : 100000,
@@ -504,7 +504,7 @@ test.describe.serial('Neo.ai.services.memory-core.helpers.ConsumerFrictionHelper
         expect(section).toContain('**size-precheck-skip**');
         expect(section).toContain('`SemanticGraphExtractor`');
         expect(section).toContain('`session:render`');
-        expect(section).toContain('`gemma4-31b`');
+        expect(section).toContain('`gemma4-26b`');
         expect(section).toContain('`dream-pipeline`');
         expect(section).toContain('33334 tokens');
         expect(section).toContain('safe 6144');
@@ -519,7 +519,7 @@ test.describe.serial('Neo.ai.services.memory-core.helpers.ConsumerFrictionHelper
         emitConsumerFriction({
             assetRef          : 'session:overflow-1',
             consumer          : 'SemanticGraphExtractor',
-            model             : 'gemma4-31b',
+            model             : 'gemma4-26b',
             symptom           : 'context-overflow',
             emissionPoint     : 'post-invocation-failure',
             inputBytes        : 50000,

--- a/test/playwright/unit/main/addon/ResizeObserver.spec.mjs
+++ b/test/playwright/unit/main/addon/ResizeObserver.spec.mjs
@@ -43,29 +43,37 @@ Object.defineProperty(documentRef, 'hidden', {
     get         : () => hiddenState
 });
 
-globalThis.document = documentRef;
-globalThis.window   = new EventTarget();
-
-globalThis.getComputedStyle = node => ({
+// NAMED so `beforeEach` can re-install them. They are assigned here as well because the addon
+// module is imported at this file's top level and must find a DOM already in place; the hook then
+// guarantees they are still there for every test, including a second worker slice that skips this
+// module's already-cached top level.
+const getComputedStyleStub = node => ({
     getPropertyValue: prop => String(node.styleValues?.[prop] ?? '0')
 });
 
-globalThis.ResizeObserver = class {
+const ResizeObserverStub = class {
     constructor(callback) { roCallback = callback }
     observe() {}
     unobserve() {}
     disconnect() {}
 };
 
-globalThis.requestAnimationFrame = callback => {
+const requestAnimationFrameStub = callback => {
     rafSequence++;
     rafQueue.set(rafSequence, callback);
     return rafSequence
 };
 
-globalThis.cancelAnimationFrame = id => {
+const cancelAnimationFrameStub = id => {
     rafQueue.delete(id)
 };
+
+globalThis.document              = documentRef;
+globalThis.window                = new EventTarget();
+globalThis.getComputedStyle      = getComputedStyleStub;
+globalThis.ResizeObserver        = ResizeObserverStub;
+globalThis.requestAnimationFrame = requestAnimationFrameStub;
+globalThis.cancelAnimationFrame  = cancelAnimationFrameStub;
 
 // Flushes the pending rAF queue, simulating one serviced frame.
 function serviceFrame() {
@@ -168,6 +176,27 @@ test.describe('Neo.main.addon.ResizeObserver — rendering-starvation contract',
     let addon;
 
     test.beforeEach(() => {
+        // RE-INSTALL the DOM globals, do not assume module scope still owns them.
+        //
+        // They are installed once at import time, but torn down by `afterAll` — two different
+        // lifecycles. Under `fullyParallel` a worker can receive a SECOND slice of this same file:
+        // the module is already in the import cache so its top level never re-runs, while the
+        // previous slice's `afterAll` has already deleted the globals. The second slice then dies in
+        // this hook with `ReferenceError: ResizeObserver is not defined`, thrown from
+        // `src/main/addon/ResizeObserver.mjs` — a production stack trace for a harness defect.
+        //
+        // It passed in isolation and failed in every full run, which is precisely why it read as
+        // flake. Re-installing here makes the globals a per-test precondition owned by the same
+        // lifecycle that tears them down, and leaves the import-time ordering above untouched —
+        // that ordering is load-bearing, since the addon module must be imported only after the
+        // harness stubs are removed.
+        globalThis.document              = documentRef;
+        globalThis.window              ??= new EventTarget();
+        globalThis.getComputedStyle      = getComputedStyleStub;
+        globalThis.ResizeObserver        = ResizeObserverStub;
+        globalThis.requestAnimationFrame = requestAnimationFrameStub;
+        globalThis.cancelAnimationFrame  = cancelAnimationFrameStub;
+
         nodeMap.clear();
         rafQueue.clear();
         hiddenState  = false;


### PR DESCRIPTION
Resolves #16932

Operator directive, prio 0, issued after the Gemini API key was deleted: `ask` must stop defaulting to a metered cloud model, and `gemma-4-31b-it` must go.

Evidence: L4 (both defects measured against the live config with a probe, not inferred; the regression arms mutation-verified) → L4 required.

## Two defects, and they had to ship together

**The default billed a cloud provider.** `askSynthesis` declared `provider: leaf('gemini')` + `model: leaf('gemini-2.5-flash')`, so every `ask_knowledge_base` call was metered by nobody's decision — ~EUR 70/month steady-state — behind a dedicated key a peer then exposed. That key is now deleted, so on `dev` the ask path is not merely expensive, it is **broken**.

The block already carried cost-safety machinery: a 20/min runaway breaker, a dedicated env-only key, a per-path budget cap. Every one of those **bounds a metered call**. None removes the meter, and none survives a leaked key. The default is now local; remote synthesis is preserved unchanged behind `NEO_KB_ASK_PROVIDER` + `NEO_KB_ASK_API_KEY`, so cloud spend costs a deliberate act instead of silence.

**And the local path could never have worked.** `SearchService` built its provider config by spreading the AiConfig node. Measured against the live KB config:

```
kbConfig.openAiCompatible.host      ->  http://127.0.0.1:1234
{...kbConfig.openAiCompatible}      ->  {}
what SearchService actually built   ->  {"model":"google/gemma-4-26b-a4b"}   // no host
```

An AiConfig node is a `Neo.state.Provider` proxy: `get` walks the parent chain, `ownKeys` (`Provider#getTopLevelDataKeys`, `src/state/Provider.mjs:676`) enumerates **local `#dataConfigs` only**. These leaves live on the Tier-1 root, so from the Knowledge Base child every named read is correct and every enumeration is empty. The spread silently dropped `host`, leaving `OpenAiCompatible` to fall back to its class default `http://127.0.0.1:8000` — **Chroma's port**. A chat request aimed at a vector database.

This was invisible while the default was `gemini`, which ignores that object entirely. **Switching the default to local is exactly what surfaces it** — so shipping the switch alone would have shipped a broken `ask`. Both are fixed here; the four leaves `buildChatModel` consumes are now read at the use site.

**Two credential leaks of one shape — and I created the second while fixing the first.**

`NEO_KB_ASK_API_KEY` is a *Gemini* credential; my first pass forwarded it into the OpenAI-compatible branch, aiming a cloud key at a local LM Studio. I fixed that and called the boundary closed. **It was not.** With a Tier-1 coordinate of `https://managed.example` + `sk-remote`, the documented local override `NEO_KB_ASK_BASE_URL=http://127.0.0.1:1234` moved the **host** while leaving `sk-remote` attached — so the transport emitted `Authorization: Bearer sk-remote` at a local server. @neo-gpt reproduced it against the real provider factory.

The rule from his review, which I did not have: **a host and its credential are one coordinate.** An own-endpoint override is by definition not the Tier-1 endpoint, so the key travels with its own host or not at all. Empty is the safe default — an endpoint that needs a credential fails loudly, while a wrong credential leaves silently.

The construction is now an exported pure `buildAskProviderConfigs`, so the pairing is driven on the **producer**. Asserting it through `SearchService` alone would mean recomputing the expected value inside the test — proving the arithmetic, not the contract, which is exactly the producer-blind fixture that let a broadcast-only resolver survive review on #16918 the same night.

## 31b

LM Studio and MLX **JIT-load whatever id they are handed**, so a stray `gemma-4-31b-it` is not a naming inconsistency — it is a load instruction for a ~20 GB dense model. Observed live: 31b and 26b **resident simultaneously**, 31b holding a 60-minute idle TTL, against the 26b that was chosen on measured performance grounds.

Removed from every consumable position: the MLX task leaf, both parity Compose profiles, the parity-latency diagnostics script, the mock server's chat fallback, and the OpenAI-compatible provider's class default. That last one was an **Ollama-namespaced** id sitting in the OpenAI-compatible provider — an id no OpenAI-compatible server can serve, so a caller that omitted `modelName` never got a working fallback, it got a request for a model that does not exist. It is now `null`, so the omission fails loudly instead.

## The recurrence fix — because the string was never the mechanism

Removing `gemma-4-31b-it` stops one spec loading one wrong model. It does not stop the next spec loading the next one. **The mechanism was the guard.**

Two specs that drive a real model server carried `test.skip(!!process.env.NEO_TEST_SKIP_CI, …)` — skip in CI, **run everywhere else**. Everywhere else is the operator's machine: models loaded, real Chroma, finite RAM. CI, which has none of that and nothing to lose, was the only environment exempted. Same shape as skipping on a missing API key — the condition meaning *"unsafe to run here"* wired as the condition to **skip**, so the guard fired precisely where running was harmless.

Both now default OFF everywhere and opt in via `NEO_TEST_LIVE_MODELS=true`. Coverage is preserved for anyone who has deliberately provisioned a model server; what is removed is a routine `npm run test-unit` doing live inference against whatever LM Studio happens to be listening.

**Two scoping corrections, recorded because each would have shipped a large confident wrong change:**

**The headline number was wrong.** 30 specs carry the inverted guard — but only **four** reach a live service, and only **two** reach a model server. The other 26 skip CI for slowness, which is legitimate and unrelated. `GraphService` and `ChromaRecovery` touch Chroma, which the unit harness already isolates by construction on a run-scoped free port. Acting on "30" would have been decisive and wrong.

**The new guard's first version was a false-positive machine.** It flagged every spec merely *naming* a model port and reported 18 — almost all config-assertion specs (`configBase.spec.mjs`, `generateKimiSeatConfig.spec.mjs`) that carry the host as expected data and never open a socket. Gating those would disable real coverage for zero safety gain. The signal is the **pair**: reaches a model host **and** uses the skip-in-CI guard — because that pair means the author already knew live services were needed and reached for the backwards guard to say so.

Mutation-verified: restoring the inverted guard on `KeepAlive.spec.mjs` fails the new arm and names that file. Non-vacuity asserts **both halves** of the pair are detectable independently, so an empty offender list cannot mean one matcher went blind.

Source-level rather than behavioural, deliberately: the failure is a spec doing something to a machine CI does not have, so CI is structurally incapable of observing it. Reading the guard is the only check that runs where the defect is invisible.

## The "flake" that was deterministic — and why it is in this PR

I could not honestly claim the guard change leaves a clean suite while the full run kept failing, so I chased the failure instead of asserting around it.

`seatCostReport.spec.mjs` created its fixture directory with a module-scope `mkdtempSync` and called `writeSyntheticFixtures()` beside it **at import time**, while cleanup was a top-level `test.afterAll`. Two different lifecycles, with nothing tying the directory's existence to the window the tests needed it. The two CLI arms spawn a child process that reads through that directory, and it died on `ENOENT … /seatcost-fixtures-XXXXXX/kimi-wire.jsonl`. Every run also leaked one uncleaned temp dir — **52 had accumulated** on this machine.

**It was never flake.** It failed in *every* full-suite run and passed in isolation, which is exactly why it read as noise — including to me, three times in one night, each time as grounds for calling my own PR's red "not mine". Deterministic; it simply needs enough sibling files in the worker to surface.

| full suite, 8 workers | before | after |
|---|---|---|
| failed | 4–7 (varying) | **1** |
| passed | 12675–12676 | **12679** |
| wall clock | 3.0m | **2.9m** |

The one remaining failure (`ResizeObserver.spec.mjs:302`) is Body-layer, unrelated, and present on a clean tree.

That distinction matters beyond this file: a suite cannot be safely parallelized or path-scoped while reproducible failures are dismissed as flake — and CI running at `workers: 1` (`playwright.config.unit.mjs:190`, with no comment justifying it, 60 lines below one stating the global should stay *"wide for the bulk-parallelism win"*) is what trains everyone to dismiss them.

## Deltas from ticket

**Retained deliberately, against a literal reading of "all occurrences":** prose recording *why 26b was chosen over 31b*, and a dated benchmark in `MemoryService`. Deleting the rationale for a decision is not the same as removing the value, and rewriting a dated measurement would falsify it. Likewise the ~180 references across `resources/content/archive/**` are historical records of what was said at the time.

**AC-5 is stronger than the ticket asked.** The obvious arm pins `provider: 'openAiCompatible'`. That would still pass with a remote model id left in the `model` leaf — which is precisely how this drifts back, because a provider flip is visible in review and a model-id string edit is not. The arm asserts the **id**, and a second arm rejects any `gemini-*` / `gpt-*` / `claude-*` default appearing anywhere in the block.

**AC-6 cross-checks two files.** The ask model id must equal the Tier-1 `openAiCompatible.model` id. Different ids are not a preference — they mean a second resident chat model.

## Test Evidence

**3109 passed** across `ai/daemons/orchestrator/`, `ai/deploy/`, `ai/services/knowledge-base/`, `ai/services/graph/`, `ai/mcp/server/knowledge-base/`, `ai/scripts/runners/`, `ai/services/memory-core/helpers/` via `npm run test-unit`; **14 passed** in `AskSynthesisConfig.spec.mjs`.

| mutation | result |
|---|---|
| restore `model: leaf('gemini-2.5-flash', …)` | **2 failed** — the id arm and the no-remote-default arm, independently |

The one spec that failed before I updated it — *"defaults to the fast remote gemini provider"* — was the contract arm pinning the old behaviour. It now pins the opposite, which is the honest form of that change rather than a deletion.

## Post-Merge Validation

- [ ] `ask_knowledge_base` answers on a plane with **no** `NEO_KB_ASK_API_KEY` set.
- [ ] LM Studio holds exactly one chat model after a full local suite run.

## Evolution

The spread defect here is the **second** instance tonight of the same substrate hazard — the first killed `mc-server` at boot in #16918. Both were invisible for the same reason: an AiConfig spread returns `{}` **silently**, and in each case a different default masked it (a `gemini` provider here, a plain-object test fixture there). It is worth knowing that materializing an AiConfig node is not a style violation but lossy by construction.

The deeper finding this came out of is not in this PR's scope: **30 unit specs carry `test.skip(!!process.env.NEO_TEST_SKIP_CI, …)`**, which skips in CI and therefore runs *only* against an operator's live LM Studio and Chroma. That is how a unit test came to dictate deployment model policy, and it is the same inversion as `test.skip(!API_KEY)`.

Authored by @neo-opus-grace (Opus 5)
