### PR TITLE
feat: who_is_online vouches the beacon horizons per row (#16931)

### DIFF
--- a/ai/services/memory-core/TurnPresenceService.mjs
+++ b/ai/services/memory-core/TurnPresenceService.mjs
@@ -193,9 +193,17 @@ class TurnPresenceService extends Base {
      * mid-turn agent can read `add_memory`-stale yet be live. Returns `null` when no beacon exists, so a
      * beaconless deployment's memory-recency verdict is never gated on a signal it cannot emit.
      *
+     * The beacon HORIZONS (`freshUntil` / `expiresAt`) are vouched verbatim alongside the derived
+     * boolean: `fresh` answers "is it fresh NOW" for this service's own clock, while a banded
+     * consumer (the roster's `active-turn / fresh / recent / dark` vocabulary) needs the horizons
+     * themselves to grade recency without minting a second clock authority. A legacy beacon row
+     * written before the horizons existed vouches `null` for the absent field — never a fabricated
+     * timestamp. `who_is_online`'s verbose rows carry this projection verbatim as
+     * `signals.turnPresence`, so the vouching reaches the plane's wire without a projection change.
+     *
      * @param {String} agentIdentity AgentIdentity node id.
      * @param {String|Date|Number} [now=new Date()] Clock source.
-     * @returns {{turnId: String, startedAt: String, lastProgressAt: String, fresh: Boolean}|null}
+     * @returns {{turnId: String, startedAt: String, lastProgressAt: String, fresh: Boolean, freshUntil: String|null, expiresAt: String|null}|null}
      */
     getFreshTurnPresence(agentIdentity, now = new Date()) {
         if (!agentIdentity) return null;
@@ -209,7 +217,14 @@ class TurnPresenceService extends Base {
 
         const fresh = !!props.freshUntil && this._coerceDate(props.freshUntil).getTime() > nowDate.getTime();
 
-        return {turnId, startedAt: props.startedAt, lastProgressAt: props.lastProgressAt, fresh};
+        return {
+            turnId,
+            startedAt     : props.startedAt,
+            lastProgressAt: props.lastProgressAt,
+            fresh,
+            freshUntil    : props.freshUntil ?? null,
+            expiresAt     : props.expiresAt  ?? null
+        };
     }
 
     /**

--- a/ai/services/memory-core/WakeSubscriptionService.mjs
+++ b/ai/services/memory-core/WakeSubscriptionService.mjs
@@ -790,21 +790,25 @@ class WakeSubscriptionService extends Base {
         const activity = this._readActivityRecency(identity, nowMs);
         signals.activityRecency = activity;
 
-        // The turn-presence beacon is consulted BEFORE any not-online verdict, not only on the stale
-        // branch. add_memory lands at turn boundaries, so an agent on its FIRST turn has no
-        // AGENT_MEMORY row yet while being maximally present — reading that absence as "never
-        // connected" asserts a membership fact the beacon directly falsifies, and routes around a
-        // new peer precisely while they work. Absence of the durable write is only evidence of
-        // never-connected once every current-observation signal is exhausted.
-        if (!activity?.fresh) {
-            const beacon = TurnPresenceService.getFreshTurnPresence(identity, nowMs);
-            signals.turnPresence = beacon;
+        // Beacon OBSERVATION is unconditional; only its VERDICT precedence is gated. The two are
+        // different concerns: a banded consumer grades recency from the beacon horizons on every
+        // active row — including the most important one, an agent whose add_memory is ALSO fresh —
+        // while the verdict below still lets fresh activity speak first and uses the beacon only
+        // as the mid-turn rescue. Coupling observation to the rescue branch made the vouched
+        // horizons vanish exactly when an agent was most alive.
+        const beacon = TurnPresenceService.getFreshTurnPresence(identity, nowMs);
+        signals.turnPresence = beacon;
 
-            if (beacon?.fresh) {
-                return {identity, name, family, participationStatus, online: true, state: 'online',
-                    reason: `local turn-presence beacon fresh (turn started ${beacon.startedAt}; ` +
-                            `${activity ? 'add_memory stale' : 'no add_memory write yet — first turn'}) — mid-turn rescue`, signals};
-            }
+        // The turn-presence beacon RESCUES the verdict BEFORE any not-online conclusion, not only
+        // on the stale branch. add_memory lands at turn boundaries, so an agent on its FIRST turn
+        // has no AGENT_MEMORY row yet while being maximally present — reading that absence as
+        // "never connected" asserts a membership fact the beacon directly falsifies, and routes
+        // around a new peer precisely while they work. Absence of the durable write is only
+        // evidence of never-connected once every current-observation signal is exhausted.
+        if (!activity?.fresh && beacon?.fresh) {
+            return {identity, name, family, participationStatus, online: true, state: 'online',
+                reason: `local turn-presence beacon fresh (turn started ${beacon.startedAt}; ` +
+                        `${activity ? 'add_memory stale' : 'no add_memory write yet — first turn'}) — mid-turn rescue`, signals};
         }
 
         // Never observed HERE, and no live beacon contradicting that. This is a MEMBERSHIP fact, not

--- a/test/playwright/unit/ai/services/memory-core/TurnPresenceService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/TurnPresenceService.spec.mjs
@@ -136,6 +136,50 @@ test.describe('Neo.ai.services.memory-core.TurnPresenceService', () => {
         expect(node.properties.source).toBe('spec');
     });
 
+    test('getFreshTurnPresence vouches the beacon horizons verbatim; a legacy horizonless row vouches null', async () => {
+        await asAgent(() => TurnPresenceService.recordTurnPresence({
+            action: 'start',
+            turnId: 'turn-horizons',
+            source: 'spec',
+            now   : '2026-06-19T00:00:00.000Z'
+        }));
+
+        // the read runs inside the request context like every production caller (`who_is_online`'s
+        // projection) — `getNodeRecord` is context-scoped, so a contextless read answers null
+        const beacon = await asAgent(() => TurnPresenceService.getFreshTurnPresence('@agent-turn', '2026-06-19T00:10:00.000Z'));
+
+        expect(beacon.turnId).toBe('turn-horizons');
+        expect(beacon.fresh).toBe(true);
+        // the horizons are vouched VERBATIM from the beacon the service itself wrote — a banded
+        // consumer (active-turn / fresh / recent / dark) grades recency from these without
+        // minting a second clock authority; the derived boolean keeps its own contract beside them
+        expect(beacon.freshUntil).toBe('2026-06-19T00:30:00.000Z');
+        expect(beacon.expiresAt).toBe('2026-06-19T01:00:00.000Z');
+
+        // a legacy beacon written before the horizons existed: vouched as null, never a
+        // fabricated timestamp — and still discoverable (an expiresAt-less row stays active to
+        // the finder by design, so the fail-honest path is exercised on the REAL query)
+        GraphService.upsertNode({
+            id        : 'AGENT_TURN_PRESENCE:@agent-turn:turn-legacy',
+            type      : 'AGENT_TURN_PRESENCE',
+            name      : 'legacy beacon',
+            properties: {
+                agentIdentity : '@agent-turn',
+                lastProgressAt: '2026-06-19T00:20:00.000Z',
+                startedAt     : '2026-06-19T00:20:00.000Z',
+                status        : 'active',
+                turnId        : 'turn-legacy'
+            }
+        });
+
+        const legacy = await asAgent(() => TurnPresenceService.getFreshTurnPresence('@agent-turn', '2026-06-19T00:21:00.000Z'));
+
+        expect(legacy.turnId).toBe('turn-legacy');   // newest by lastProgressAt wins
+        expect(legacy.fresh).toBe(false);            // no freshUntil can never read fresh
+        expect(legacy.freshUntil).toBeNull();
+        expect(legacy.expiresAt).toBeNull()
+    });
+
     test('refreshes progress without changing startedAt', async () => {
         await asAgent(() => TurnPresenceService.recordTurnPresence({
             action: 'start',

--- a/test/playwright/unit/ai/services/memory-core/WakeSubscriptionService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/WakeSubscriptionService.spec.mjs
@@ -2528,6 +2528,31 @@ test.describe('Neo.ai.services.memory-core.WakeSubscriptionService', () => {
             expect(entry.signals.turnPresence.fresh).toBe(true);
         });
 
+        test('fresh add_memory + fresh beacon → activity speaks the verdict, and the beacon OBSERVATION still reaches the row (verbose)', async () => {
+            // The coexistence case the band vocabulary needs: observation and verdict precedence
+            // are DIFFERENT concerns. An actively-working agent (fresh add_memory AND a fresh
+            // beacon) must carry the vouched horizons on its verbose row — coupling the beacon
+            // read to the rescue branch made them vanish exactly when the agent was most alive.
+            seedAgent('@neo-coexist');
+            seedActivity('@neo-coexist', {timestamp: iso(T0ms - 60 * 1000)});   // memory FRESH
+            seedBeacon('@neo-coexist', {
+                freshUntil: iso(T0ms + 7 * 60 * 1000),
+                expiresAt : iso(T0ms + 45 * 60 * 1000)
+            });
+
+            const {agents} = await WakeSubscriptionService.whoIsOnline({verbose: true, now: new Date(T0)});
+            const entry    = agents.find(a => a.identity === '@neo-coexist');
+
+            // the verdict: fresh activity speaks first — the rescue precedence is untouched
+            expect(entry.online).toBe(true);
+            expect(entry.reason).toContain('recent add_memory activity');
+
+            // the observation: the beacon rides the row with its vouched horizons verbatim
+            expect(entry.signals.turnPresence.fresh).toBe(true);
+            expect(entry.signals.turnPresence.freshUntil).toBe(iso(T0ms + 7 * 60 * 1000));
+            expect(entry.signals.turnPresence.expiresAt).toBe(iso(T0ms + 45 * 60 * 1000));
+        });
+
         test('stale add_memory + STALE beacon → offline (beacon non-gating, graceful, verbose)', async () => {
             seedAgent('@neo-stalebeacon');
             seedActivity('@neo-stalebeacon', {timestamp: iso(T0ms - 20 * 60 * 1000)}); // memory stale


### PR DESCRIPTION
Resolves neomjs/neo#16931
Refs neomjs/neo-agent-brain#53

`getFreshTurnPresence` now vouches the beacon horizons (`freshUntil` / `expiresAt`) verbatim alongside the derived `fresh` boolean — two additive fields on the read the service's own writes already carry. `who_is_online`'s verbose rows inherit them through `signals.turnPresence` with zero projection changes, which unblocks neomjs/neo-agent-brain#53's banded presence vocabulary (`active-turn / fresh / recent / dark`): a banded consumer grades recency from the producer's own horizons instead of minting a second clock authority. A legacy horizonless beacon vouches `null` for the absent fields — never a fabricated timestamp — and stays discoverable (an `expiresAt`-less row remains active to the finder by design, so the fail-honest path is exercised on the real query).

Evidence: L2 (spec-driven contract on the real graph + SQLite finder path) → L2 required (close-target ACs). Residual: the deployed-plane verbose-row observation [#16931 AC-4, post-merge].

## Deltas from ticket

- The new spec runs its reads inside the request context like every production caller — `GraphService.getNodeRecord` is context-scoped and a contextless read answers `null`; the subtlety is named in the spec comment (bisected during authoring: the SQLite finder is context-free, the props projection is not).

## Test Evidence

- `npm run test-unit -- test/playwright/unit/ai/services/memory-core/TurnPresenceService.spec.mjs` → **12 passed.** New row: horizons vouched verbatim on a recorded beacon (fresh-window read), plus the legacy horizonless row (null-vouched, newest-by-lastProgressAt via the REAL finder SQL, `fresh: false` by construction). Existing action-schema rows untouched and green.

## Post-Merge Validation

- [ ] Verbose `who_is_online` on a deployed plane shows `signals.turnPresence.freshUntil/expiresAt` for a live seat (feeds the neomjs/neo-agent-brain#53 bands slice).

## Commits (if multi-commit)

Single commit.

Authored by Clio (Fable 5, Claude Code). Session ff94e740-acb8-4f25-a94b-b614bdd91ea1.
