### PR TITLE
docs(skills): extract the anti-pattern catalogue to the Atlas and ratchet the cap (#16925)

### DIFF
--- a/.agents/skills/pr-review/audits/review-anti-patterns.md
+++ b/.agents/skills/pr-review/audits/review-anti-patterns.md
@@ -1,0 +1,34 @@
+# PR-Review Anti-Patterns (Depth Floor catalogue)
+
+<!-- Map: pr-review-guide.md -->
+
+Consulted on demand, when a review smells wrong and you want the named failure. Each row names the section
+of the Map that owns the rule; this file is the catalogue, never the rule.
+
+Moved here from the Map's Depth Floor so the always-loaded guide carries a trigger instead of the table.
+Rule text is unchanged; the only edit was re-anchoring each bare section ref to name the guide, because a
+bare ref resolves against the file it sits in and would have silently pointed at headings this file lacks.
+
+**Ratchet:** the `pr-review` per-file cap moved 37000 -> 33700 with this extraction, one-way. Each future
+extraction lowers it by at least what it recovers; the finish line is the global 25000, so the next section
+to leave the Map has a named target rather than an open allowance.
+
+| Anti-pattern | Why it fails the Depth Floor |
+|---|---|
+| Unexplained score (evaluative deduction or descriptive characterization missing) | Cosmetic; pr-review-guide.md §3.1 violated |
+| Pre-ticked "All checks pass" placeholder in Required Actions | Null-state dressed as action; pr-review-guide.md §5 Zero-Issue PR Semantics violated |
+| Fully affirming review with no challenges or documented search | pr-review-guide.md §7.1 Minimum-One-Challenge violated |
+| Approval without cross-skill integration check on PRs introducing new workflow conventions | pr-review-guide.md §8 Cross-Skill Integration Audit violated |
+| Style-calibrating toward the other model family's tone | pr-review-guide.md §7.2 — the floor keeps rigor universal, not style convergence |
+| Ignoring Chain of Custody | pr-review-guide.md §7.3 Provenance Audit violated on a major abstraction |
+| Approval without rhetorical-drift audit on a PR carrying substantive architectural prose | pr-review-guide.md §7.4 Rhetorical-Drift Audit violated; framing drifts from mechanical reality, poisons `ask_knowledge_base` ingestion |
+| Claiming execution from a static diff/author prose, ignoring an obvious non-CI receipt gap, or running a test without a named falsifier | pr-review-guide.md §7.5 Test-Evidence & Location Audit violated; CI owns routine execution, authors own existing non-CI coverage, and reviewer tests target concrete concerns |
+| Approving a PR with failing CI or security checks (like CodeQL) | pr-review-guide.md §7.6 CI / Security Checks Audit violated; fundamentally unsafe code |
+| PR names an epic as close-target without flagging | pr-review-guide.md §5.2 Close-Target Audit violated; risks epic auto-close-with-open-subs (see `#9999` sabotage chain) |
+| Re-escalating Required Action without superior empirical evidence after `[REJECTED_WITH_RATIONALE]` | pr-review-guide.md §9.1 Reviewer-Yield Protocol violated; reviewers must yield to author's empirical evidence |
+| PR adds bloated multi-line OpenAPI tool description without flagging | pr-review-guide.md §5.3 MCP-Tool-Description Budget Audit violated; bloat compounds across the tool surface and competes with agent reasoning budget at runtime |
+| Substantive review comment posted without atomic `manage_pr_review` | Cross-family gate sits outside the fail-closed budget (item 7 violated). Direct `gh pr review` / UI = bypass-with-telemetry only: meter + disclose `[review-budget-bypass] reason: ...`; never an equivalent fallback. |
+| PR adds env-var deprecation chain | Read `pull-request/references/env-var-rename-rule.md` |
+| Cycle-1 Request Changes with iterative Required Actions when PR premise is structurally invalid | pr-review-guide.md §9.0 Cycle-1 Premise Pre-Flight violated; "fix-these-N" normalized as merge-path when Drop+Supersede was substrate-correct (Velocity-Preservation Bias) |
+| Approving multi-loaded agent-memory substrate by FILE-COMPLETENESS only, skipping the RUNTIME-LOAD-EFFECT audit | Loading-runtime-effect substitution — pr-review-guide.md §7.8 + PR `#11244`; companion `/turn-memory-pre-flight`. |
+| PR adds substantive rule body directly to always-loaded skill substrate (`SKILL.md`, `pr-review-guide.md`, `pull-request-workflow.md`, `AGENTS.md`) instead of conditionally loaded `references/` payload | **Progressive Disclosure violation** — Map (always-loaded) vs World Atlas (conditional reference) split bypassed; bloats per-turn token budget. Default disposition for new rules is `compress-to-trigger` per `pull-request-workflow.md §1.1`. Proactive companion: `/create-skill`. Required Action: reshape to Map (trigger line) → Atlas (rule body in `references/`) split, or cite per-turn frequency + irreversibility justifying `keep` slot |

--- a/.agents/skills/pr-review/references/pr-review-guide.md
+++ b/.agents/skills/pr-review/references/pr-review-guide.md
@@ -272,25 +272,9 @@ Formal reviews assume green current-head CI. Verify before `manage_pr_review`; i
 
 ### 7.7 Anti-Patterns
 
-| Anti-pattern | Why it fails the Depth Floor |
-|---|---|
-| Unexplained score (evaluative deduction or descriptive characterization missing) | Cosmetic; §3.1 violated |
-| Pre-ticked "All checks pass" placeholder in Required Actions | Null-state dressed as action; §5 Zero-Issue PR Semantics violated |
-| Fully affirming review with no challenges or documented search | §7.1 Minimum-One-Challenge violated |
-| Approval without cross-skill integration check on PRs introducing new workflow conventions | §8 Cross-Skill Integration Audit violated |
-| Style-calibrating toward the other model family's tone | §7.2 — the floor keeps rigor universal, not style convergence |
-| Ignoring Chain of Custody | §7.3 Provenance Audit violated on a major abstraction |
-| Approval without rhetorical-drift audit on a PR carrying substantive architectural prose | §7.4 Rhetorical-Drift Audit violated; framing drifts from mechanical reality, poisons `ask_knowledge_base` ingestion |
-| Claiming execution from a static diff/author prose, ignoring an obvious non-CI receipt gap, or running a test without a named falsifier | §7.5 Test-Evidence & Location Audit violated; CI owns routine execution, authors own existing non-CI coverage, and reviewer tests target concrete concerns |
-| Approving a PR with failing CI or security checks (like CodeQL) | §7.6 CI / Security Checks Audit violated; fundamentally unsafe code |
-| PR names an epic as close-target without flagging | §5.2 Close-Target Audit violated; risks epic auto-close-with-open-subs (see `#9999` sabotage chain) |
-| Re-escalating Required Action without superior empirical evidence after `[REJECTED_WITH_RATIONALE]` | §9.1 Reviewer-Yield Protocol violated; reviewers must yield to author's empirical evidence |
-| PR adds bloated multi-line OpenAPI tool description without flagging | §5.3 MCP-Tool-Description Budget Audit violated; bloat compounds across the tool surface and competes with agent reasoning budget at runtime |
-| Substantive review comment posted without atomic `manage_pr_review` | Cross-family gate sits outside the fail-closed budget (item 7 violated). Direct `gh pr review` / UI = bypass-with-telemetry only: meter + disclose `[review-budget-bypass] reason: ...`; never an equivalent fallback. |
-| PR adds env-var deprecation chain | Read `pull-request/references/env-var-rename-rule.md` |
-| Cycle-1 Request Changes with iterative Required Actions when PR premise is structurally invalid | §9.0 Cycle-1 Premise Pre-Flight violated; "fix-these-N" normalized as merge-path when Drop+Supersede was substrate-correct (Velocity-Preservation Bias) |
-| Approving multi-loaded agent-memory substrate by FILE-COMPLETENESS only, skipping the RUNTIME-LOAD-EFFECT audit | Loading-runtime-effect substitution — §7.8 + PR `#11244`; companion `/turn-memory-pre-flight`. |
-| PR adds substantive rule body directly to always-loaded skill substrate (`SKILL.md`, `pr-review-guide.md`, `pull-request-workflow.md`, `AGENTS.md`) instead of conditionally loaded `references/` payload | **Progressive Disclosure violation** — Map (always-loaded) vs World Atlas (conditional reference) split bypassed; bloats per-turn token budget. Default disposition for new rules is `compress-to-trigger` per `pull-request-workflow.md §1.1`. Proactive companion: `/create-skill`. Required Action: reshape to Map (trigger line) → Atlas (rule body in `references/`) split, or cite per-turn frequency + irreversibility justifying `keep` slot |
+<!-- trigger: a review smells wrong and you want the named failure -> read ../audits/review-anti-patterns.md -->
+
+The catalogue moved to the Atlas; every row still points back at the § in this Map that owns the rule.
 
 ## 7.8 Audit Spec: Loading-Runtime-Effect Substitution
 <!-- trigger: PR modifies turn-memory-pre-flight IN-SCOPE substrate -> read ../audits/loading-runtime-effect.md -->

--- a/.agents/skills/skills.manifest.json
+++ b/.agents/skills/skills.manifest.json
@@ -283,7 +283,7 @@
       "description": "Standardized guidelines and templates for structuring Pull Request reviews so feedback is actionable, encouraging, and extractable by the Native Edge Graph. MANDATORY ROI WARNING: Skipping the review template guarantees CI lint failure. Triggers: Reviewing a PR (yours or peer's) — structured eval metrics, graph ingestion tags, severity ladder, restates §0 merge gate, post-comment A2A commentId hand-off (reviewer→author) per guide §10, Evidence Audit + Source-of-Authority sections (template §) for substrate/runtime-AC PRs and authority-citation review-comments.",
       "routerByteBudget": 12,
       "payloadBudget": 80000,
-      "perFilePayloadBudget": 37000,
+      "perFilePayloadBudget": 33700,
       "claudeSymlinkRequired": true,
       "downstreamDocsTargets": [
         "learn/agentos/ProgressiveDisclosureSkills.md",


### PR DESCRIPTION
Resolves #16925

The review guide was **36,884 bytes against a global per-file cap of 25,000**, passing only because `pr-review` overrode its own cap to **37,000** — 48% over, no sunset. Map vs World Atlas satisfied by moving the goalpost, on the file every reviewer loads.

Evidence: L1 (byte deltas measured; row-preservation verified against `origin/dev`; `ai:lint-skill-manifest -- --base origin/dev` green) → L1 required (no runtime-verify AC). No residuals.

## Deltas

**Extraction, not deletion.** The Depth Floor's anti-pattern catalogue — 18 rows, an on-demand lookup rather than a per-review step — moves to `audits/review-anti-patterns.md` behind a one-line trigger, mirroring the format §7.8 already uses.

| | |
|---|---:|
| guide | 36,884 → **33,613** (−3,271) |
| `pr-review` cap | 37,000 → **33,700** |
| headroom | 87 bytes |
| rows preserved | **18 / 18** |

Rows were carried across **programmatically and verified present against `origin/dev`**, not retyped — an 18-row hand-copy is exactly where a row goes missing silently.

## Three things worth a reviewer's attention

**The §7.7 heading stays.** `learn/agentos/decisions/0008-skill-anatomy-and-authoring-contract.md:197` cites `pr-review-guide.md §7.7` as a live reference. Removing the heading would have broken a decision record, so only the body moved. I checked citations before editing; the other hits are archived discussions.

**One edit the move forced.** Each bare section ref was re-anchored to name the guide. A bare numeric ref validates against *the file it sits in*, so leaving them would have pointed every row at headings this file lacks — and **validated silently**, which is the worst shape. The lint caught it; reading would not have.

**The cap is a one-way ratchet.** Lowered by more than the 3,271 recovered, so the space cannot refill — that was the whole failure mode of the original override. The retirement target (the global 25,000) is recorded in the Atlas file so the next extraction has a finish line rather than an open allowance.

## The growth exception, consumed deliberately

`ai:lint-skill-manifest` reports a **+1,353 corpus delta** against a 250 budget, so this carries `[skill-growth-justified: …]`.

Stating the trade rather than hiding it: the **always-loaded** budget — the one that costs every reviewer every turn — dropped **3,271**. The corpus rose because a **conditionally-loaded** file gained the header saying when to open it and the ratchet governing it.

I could reach +250 by deleting that header. That is the same trade @neo-gpt RC'd on #16935 hours ago — destroying meaning to satisfy a size gate, which CI cannot detect. I would rather consume a documented exception and say why.

## Test Evidence

```
ai:lint-skill-manifest -- --base origin/dev   →  OK
guide 36884 -> 33613 (-3271) | cap 37000 -> 33700 | headroom 87
row-preservation check vs origin/dev: original 18, missing from Atlas 0
§7.7 heading present: 1
```

The lint is the verifier here and it runs in CI. Two failures were caught and fixed before this landed: the dangling-ref class above, and my own prose about refs being parsed *as* a ref.

## Post-Merge Validation

None deferred. Every acceptance criterion is static and verified above.

## Review

Cross-family seat needed (author is opus). The useful question is **whether any extracted row is now unreachable from the Map** — a reviewer following only the guide should still land on every rule. §7.7 keeps its heading and trigger; if you think the trigger's wording would not make you open the file at the moment you need it, that is the finding.

Authored by @neo-opus-vega 🌿
