### PR TITLE
feat: the presence band grades from the vouched horizons (#16937)

### DIFF
--- a/ai/services/fleet/fleetPresenceStateAdapter.mjs
+++ b/ai/services/fleet/fleetPresenceStateAdapter.mjs
@@ -36,6 +36,41 @@ import {redactCredentials} from './redactCredentials.mjs'
  */
 export const PRESENCE_STATES = Object.freeze(['online', 'idle', 'dark', 'benched', 'neverConnected'])
 
+/**
+ * The GRADED render vocabulary this adapter emits — the banded recency contract derived from the
+ * plane's verdicts plus the vouched beacon horizons: `active-turn` (a fresh turn-presence beacon —
+ * mid-turn RIGHT NOW, regardless of add_memory staleness: the 70-minute-turn flap falsifier) ·
+ * `fresh` (the plane says online: recent durable activity, no fresh beacon) · `recent` (the
+ * plane's idle window) · `dark` (rostered, not recently seen), with the membership facts
+ * (`benched` / `neverConnected`) passing through untouched — they are participation truth, not
+ * recency grades. The grade DERIVES; it never re-computes liveness (no second clock authority).
+ * @type {String[]}
+ */
+export const PRESENCE_BANDS = Object.freeze(['active-turn', 'fresh', 'recent', 'dark', 'benched', 'neverConnected'])
+
+/**
+ * @summary Grade one plane presence verdict + its vouched beacon signal onto the banded render
+ * vocabulary. Pure and total: an out-of-vocabulary input state passes through unchanged (the
+ * caller's own closed-set admission already refused it — this function never fabricates a grade).
+ * @param {Object} options
+ * @param {String} options.state The plane's own verdict (`online` · `idle` · `dark` · `benched` · `neverConnected`).
+ * @param {Boolean} [options.beaconFresh=false] Whether the row's vouched turn-presence beacon is fresh.
+ * @returns {String}
+ */
+export function gradePresenceBand({state, beaconFresh = false} = {}) {
+    // membership facts are never recency-graded — a fresh beacon cannot rescue a benched seat
+    // here any more than it may in the plane's own hard gate
+    if (state === 'benched' || state === 'neverConnected') {
+        return state
+    }
+
+    if (beaconFresh) {
+        return 'active-turn'
+    }
+
+    return state === 'online' ? 'fresh' : state === 'idle' ? 'recent' : state
+}
+
 export const PRESENCE_SOURCE_LABEL = 'fleet:presenceState'
 
 /**
@@ -100,9 +135,12 @@ export async function readFleetPresenceSnapshot({
                     if (typeof row?.identity !== 'string' || !PRESENCE_STATES.includes(row.state)) continue
 
                     byIdentity.set(row.identity, {
-                        state     : row.state,
-                        lastSeenAt: row.signals?.activityRecency?.lastActivityAt ?? null,
-                        reason    : typeof row.reason === 'string' ? redactReason(row.reason) : null
+                        state      : row.state,
+                        // the vouched beacon signal (the per-row turn-presence observation): the ONLY
+                        // input the recency grade adds over the plane's own verdict
+                        beaconFresh: row.signals?.turnPresence?.fresh === true,
+                        lastSeenAt : row.signals?.activityRecency?.lastActivityAt ?? null,
+                        reason     : typeof row.reason === 'string' ? redactReason(row.reason) : null
                     })
                 }
             }
@@ -124,7 +162,10 @@ export async function readFleetPresenceSnapshot({
             const row = byIdentity.get(presenceIdentityFor(agent))
 
             if (row) {
-                presence   = row.state
+                // the emitted band is the GRADED vocabulary: the plane's verdict refined by the
+                // vouched beacon (a fresh beacon grades active-turn even over stale add_memory —
+                // the long-turn flap falsifier), membership facts passing through untouched
+                presence   = gradePresenceBand({state: row.state, beaconFresh: row.beaconFresh})
                 lastSeenAt = row.lastSeenAt
                 rowReason  = row.reason
             } else {

--- a/apps/agentos/view/fleet/AgentCard.mjs
+++ b/apps/agentos/view/fleet/AgentCard.mjs
@@ -12,11 +12,18 @@ import StateDot, {stateLabel} from './StateDot.mjs';
  * @type {Object}
  */
 const PRESENCE_BAND_LABEL = Object.freeze({
-    online        : 'online',
-    idle          : 'idle',
+    // the graded recency vocabulary (the banded-presence contract: derived from the plane's
+    // verdicts + the vouched beacon horizons, never boolean online/offline)
+    'active-turn' : 'active turn',
+    fresh         : 'fresh',
+    recent        : 'recent',
     dark          : 'dark',
     benched       : 'benched',
-    neverConnected: 'never connected'
+    neverConnected: 'never connected',
+    // the plane's raw verdicts stay ACCEPTED for deployment skew (an older adapter emitting the
+    // ungraded vocabulary must not blank the band) — retire once every deployment grades
+    online: 'online',
+    idle  : 'idle'
 });
 
 import {normalizeFleetSources, resolveFleetDisplayState, summarizeFleetSources} from './sourceHealth.mjs';

--- a/test/playwright/unit/ai/services/fleet/fleetPresenceStateAdapter.spec.mjs
+++ b/test/playwright/unit/ai/services/fleet/fleetPresenceStateAdapter.spec.mjs
@@ -230,8 +230,9 @@ test.describe('fleetPresenceStateAdapter — healthy report (band join)', () => 
         })
 
         expect(capability.state).toBe('wired')
-        expect(states.find(row => row.agentId === 'prefixed').presence).toBe('online')
-        expect(states.find(row => row.agentId === 'bare').presence).toBe('idle')
+        // graded emission: beaconless online → fresh, idle → recent
+        expect(states.find(row => row.agentId === 'prefixed').presence).toBe('fresh')
+        expect(states.find(row => row.agentId === 'bare').presence).toBe('recent')
 
         // the canonicalizer itself: one prefix, degenerate stacking stripped, id fallback covered
         expect(presenceIdentityForAgent({githubUsername: '@neo-gpt'})).toBe('@neo-gpt')
@@ -248,7 +249,7 @@ test.describe('fleetPresenceStateAdapter — healthy report (band join)', () => 
             readPresence: () => ({agents: [{identity: '@neo-gpt', state: 'online'}]})
         })
 
-        expect(states.map(row => row.presence)).toEqual(['online', 'online'])
+        expect(states.map(row => row.presence)).toEqual(['fresh', 'fresh'])
     })
 
     test('a custom presenceIdentityFor overrides the identity join', async () => {
@@ -258,7 +259,7 @@ test.describe('fleetPresenceStateAdapter — healthy report (band join)', () => 
             presenceIdentityFor: () => 'IDENTITY:custom'
         })
 
-        expect(states[0].presence).toBe('online')
+        expect(states[0].presence).toBe('fresh')
     })
 
     test('agents without an id are skipped — the sibling adapters\' one-agent-set rule', async () => {

--- a/test/playwright/unit/ai/services/fleet/fleetPresenceStateAdapter.spec.mjs
+++ b/test/playwright/unit/ai/services/fleet/fleetPresenceStateAdapter.spec.mjs
@@ -18,6 +18,8 @@ import Neo            from '../../../../../../src/Neo.mjs'
 import * as core      from '../../../../../../src/core/_export.mjs'
 
 import {
+    gradePresenceBand,
+    PRESENCE_BANDS,
     PRESENCE_SOURCE_LABEL,
     PRESENCE_STATES,
     presenceIdentityForAgent,
@@ -102,7 +104,7 @@ test.describe('fleetPresenceStateAdapter — capability envelope (producer healt
 })
 
 test.describe('fleetPresenceStateAdapter — healthy report (band join)', () => {
-    test('bands + recency join per agent through the default @githubUsername identity', async () => {
+    test('bands + recency join per agent through the default @githubUsername identity — emitted GRADED', async () => {
         const {capability, states} = await readFleetPresenceSnapshot({
             agents,
             readPresence: () => healthyPayload
@@ -112,15 +114,63 @@ test.describe('fleetPresenceStateAdapter — healthy report (band join)', () => 
         expect(capability.confidence).toBe('observed')
         expect(capability.reason).toBeNull()
 
+        // the emitted vocabulary is the GRADE: online-without-a-fresh-beacon reads `fresh`
+        // (recent durable activity), the plane's idle window reads `recent`
         expect(states[0]).toEqual({
             agentId   : 'neo-fable-clio',
-            presence  : 'online',
+            presence  : 'fresh',
             lastSeenAt: '2026-08-09T11:00:00.000Z',
             confidence: 'observed',
             source    : PRESENCE_SOURCE_LABEL
         })
-        expect(states[1].presence).toBe('idle')
+        expect(states[1].presence).toBe('recent')
         expect(states[1].lastSeenAt).toBeNull()
+    })
+
+    test('the flap falsifier: a FRESH beacon grades active-turn regardless of add_memory staleness; membership facts never grade', async () => {
+        const {states} = await readFleetPresenceSnapshot({
+            agents: [
+                {id: 'mid-turn',  githubUsername: 'mid-turn'},
+                {id: 'long-turn', githubUsername: 'long-turn'},
+                {id: 'benched',   githubUsername: 'benched'}
+            ],
+            readPresence: () => ({agents: [
+                // fresh beacon + fresh activity: mid-turn RIGHT NOW
+                {identity: '@mid-turn', state: 'online', signals: {turnPresence: {fresh: true, freshUntil: '2026-08-11T00:30:00.000Z'}}},
+                // the 70-minute-turn specimen: add_memory stale (plane says idle) but the beacon
+                // is fresh — the grade is active-turn, never a flap to recent/dark
+                {identity: '@long-turn', state: 'idle', signals: {turnPresence: {fresh: true, freshUntil: '2026-08-11T00:30:00.000Z'}}},
+                // a fresh beacon must not rescue a membership fact
+                {identity: '@benched', state: 'benched', signals: {turnPresence: {fresh: true}}}
+            ]})
+        })
+
+        expect(states.map(row => row.presence)).toEqual(['active-turn', 'active-turn', 'benched'])
+    })
+
+    test('gradePresenceBand is pure and total: the full grade matrix, malformed signals never fabricate', () => {
+        // the grade matrix over the plane vocabulary × beacon freshness
+        expect(gradePresenceBand({state: 'online', beaconFresh: true})).toBe('active-turn')
+        expect(gradePresenceBand({state: 'idle',   beaconFresh: true})).toBe('active-turn')
+        expect(gradePresenceBand({state: 'dark',   beaconFresh: true})).toBe('active-turn')
+        expect(gradePresenceBand({state: 'online'})).toBe('fresh')
+        expect(gradePresenceBand({state: 'idle'})).toBe('recent')
+        expect(gradePresenceBand({state: 'dark'})).toBe('dark')
+
+        // membership facts pass through untouched, beacon or not
+        expect(gradePresenceBand({state: 'benched',        beaconFresh: true})).toBe('benched')
+        expect(gradePresenceBand({state: 'neverConnected', beaconFresh: true})).toBe('neverConnected')
+
+        // total on odd input: pass-through, never a fabricated grade; absent signal = not fresh
+        expect(gradePresenceBand({state: 'unknown'})).toBe('unknown')
+        expect(gradePresenceBand({})).toBe(undefined)
+        expect(gradePresenceBand()).toBe(undefined)
+
+        // every graded output the adapter can emit is in the declared band vocabulary
+        for (const state of PRESENCE_STATES) {
+            expect(PRESENCE_BANDS).toContain(gradePresenceBand({state, beaconFresh: true}))
+            expect(PRESENCE_BANDS).toContain(gradePresenceBand({state, beaconFresh: false}))
+        }
     })
 
     test('a seat absent from a HEALTHY report is row-local unknown — capability stays wired/observed', async () => {
@@ -138,7 +188,7 @@ test.describe('fleetPresenceStateAdapter — healthy report (band join)', () => 
         expect(absent.reason).toBe('seat absent from the presence report')
 
         // Siblings keep their own truth — row-local honesty never spreads.
-        expect(states.find(row => row.agentId === 'neo-fable-clio').presence).toBe('online')
+        expect(states.find(row => row.agentId === 'neo-fable-clio').presence).toBe('fresh')
     })
 
     test('an out-of-vocabulary band is skipped, not admitted — the seat answers unknown, the enum stays closed', async () => {
@@ -153,13 +203,16 @@ test.describe('fleetPresenceStateAdapter — healthy report (band join)', () => 
         expect(PRESENCE_STATES).not.toContain('levitating')
     })
 
-    test('every emitted band in the closed vocabulary passes through verbatim', async () => {
+    test('every admitted plane verdict emits its GRADE — the closed input set maps onto the closed band set', async () => {
         const
             roster   = PRESENCE_STATES.map((state, index) => ({id: `agent-${index}`, githubUsername: `agent-${index}`})),
             payload  = {agents: PRESENCE_STATES.map((state, index) => ({identity: `@agent-${index}`, state}))},
             {states} = await readFleetPresenceSnapshot({agents: roster, readPresence: () => payload})
 
-        expect(states.map(row => row.presence)).toEqual([...PRESENCE_STATES])
+        // beaconless grading: online→fresh, idle→recent, the rest verbatim — and every emission
+        // is in the declared band vocabulary
+        expect(states.map(row => row.presence)).toEqual(['fresh', 'recent', 'dark', 'benched', 'neverConnected'])
+        states.forEach(row => expect(PRESENCE_BANDS).toContain(row.presence))
     })
 
     test('the default join accepts the registry\'s FULL production spelling domain — a persisted leading @ never fabricates absence', async () => {


### PR DESCRIPTION
Resolves neomjs/neo#16937
Refs neomjs/neo-agent-brain#53

The presence band now grades from the vouched beacon horizons — the consumer half of neomjs/neo-agent-brain#53's banded-presence AC, unblocked by PR neomjs/neo#16934's merge earlier tonight. A pure exported `gradePresenceBand({state, beaconFresh})` in the presence adapter derives the render vocabulary from the plane's own verdicts plus the per-row vouched beacon signal: **`active-turn`** (a fresh turn-presence beacon — mid-turn RIGHT NOW, regardless of `add_memory` staleness: the 70-minute-turn flap specimen the AC names as its falsifier grades `active-turn`, never a flap to recent/dark) → **`fresh`** (plane `online` without a fresh beacon) → **`recent`** (the plane's idle window) → **`dark`**, with the membership facts (`benched` / `neverConnected`) passing through untouched — a fresh beacon may not rescue a benched seat here any more than in the plane's own hard gate. The grade DERIVES; it never re-computes liveness (no second clock authority — the neomjs/neo#16931 design). The adapter's per-row retention gains the one new input (`signals.turnPresence.fresh`), the emitted closed set is declared as `PRESENCE_BANDS`, and `AgentCard`'s label map carries the graded vocabulary while keeping the plane's raw verdicts accepted for deployment skew (an older adapter must not blank the band; the acceptance is marked for retirement).

Evidence: L2 (grade matrix + adapter emission + flap-falsifier specs on the real snapshot path) → L2 required (close-target ACs; the AC-3 live receipt is explicitly post-deploy — the running plane predates neomjs/neo#16934's vouching until its next rebuild). Residual: AC-3 [#16937 Post-Merge].

## Deltas from ticket

- `PRESENCE_BANDS` exported as the declared emitted set (the spec asserts every possible grade lands inside it) — the ticket implied it; the export makes it checkable.
- Card back-compat for the ungraded vocabulary is explicit and marked for retirement (deployment-skew honesty rather than a silent dual vocabulary).

## Test Evidence

- `npm run test-unit -- test/playwright/unit/ai/services/fleet/ test/playwright/unit/apps/agentos/view/fleet/ test/playwright/unit/apps/agentos/fleet/` → **968 passed.** New rows: the full grade matrix (beacon × every plane verdict; membership pass-through; total-on-odd-input never fabricates), the flap falsifier through the REAL snapshot path (stale-activity + fresh-beacon row grades `active-turn`), the graded join (online→`fresh`, idle→`recent` with recency verbatim), and the closed-set emission proof; existing tier-degradation/identity-join/capability rows all green unchanged.

## Post-Merge Validation

- [ ] Live receipt once the deployed plane serves vouched horizons (next rebuild): a mid-turn seat renders `◉ active turn` while its `add_memory` is stale.

## Commits (if multi-commit)

Single commit.

Authored by Clio (Fable 5, Claude Code). Session ff94e740-acb8-4f25-a94b-b614bdd91ea1.
