### PR TITLE
feat(build): deferred work must name an owner that survives the merge (#16906)

### DIFF
--- a/.agents/skills/pr-review/assets/pr-review-template.md
+++ b/.agents/skills/pr-review/assets/pr-review-template.md
@@ -129,7 +129,7 @@ Reference: [`learn/agentos/process/evidence-ladder.md`](../../../../learn/agento
 The PR body must declare achieved evidence in 1-line greppable form:
 
 ```md
-Evidence: L<X> (<sandbox-ceiling description>) → L<Y> required (<close-target ACs requiring it>). Residual: AC<N> [#<close-target>].
+Evidence: L<X> (<sandbox-ceiling description>) → L<Y> required (<close-target ACs requiring it>). Residual: AC<N>, Residual-Owner: #<an EXISTING open ticket that is NOT the close target>.
 ```
 
 - [ ] PR body contains an `Evidence:` declaration line (or N/A justified inline)

--- a/.agents/skills/pull-request/references/pull-request-workflow.md
+++ b/.agents/skills/pull-request/references/pull-request-workflow.md
@@ -313,7 +313,7 @@ Resolves #N
 
 <one-paragraph outcome summary — what actually shipped, not restating ticket>
 
-Evidence: L<X> (<sandbox-ceiling description>) → L<Y> required (<close-target ACs requiring it>). Residual: AC<N> [#<close-target>].
+Evidence: L<X> (<sandbox-ceiling description>) → L<Y> required (<close-target ACs requiring it>). Residual: AC<N>, Residual-Owner: #<an EXISTING open ticket that is NOT the close target>.
 
 ## Deltas from ticket
 <scope additions, better solutions, edge cases — "None substantive" when empty; heading is a lint anchor>

--- a/.agents/skills/pull-request/references/pull-request-workflow.md
+++ b/.agents/skills/pull-request/references/pull-request-workflow.md
@@ -311,9 +311,9 @@ authorization before amend/rebase/force-push cleanup.
 ```markdown
 Resolves #N
 
-<one-paragraph outcome summary — what actually shipped, not restating ticket>
+<one-paragraph outcome — what shipped, not a restatement of the ticket>
 
-Evidence: L<X> (<sandbox-ceiling description>) → L<Y> required (<close-target ACs requiring it>). Residual: AC<N>, Residual-Owner: #<an EXISTING open ticket that is NOT the close target>.
+Evidence: L<X> (<sandbox-ceiling description>) → L<Y> required (<close-target ACs requiring it>). Residual: AC<N>, Residual-Owner: #<EXISTING open ticket, NOT the close target>.
 
 ## Deltas from ticket
 <scope additions, better solutions, edge cases — "None substantive" when empty; heading is a lint anchor>

--- a/.github/workflows/agent-pr-body-lint.yml
+++ b/.github/workflows/agent-pr-body-lint.yml
@@ -8,6 +8,34 @@ jobs:
   lint-pr-body:
     runs-on: ubuntu-latest
     steps:
+      # ONE OWNING IMPLEMENTATION for the body gates. The inline script below cannot import
+      # `validatePrBody`, so any rule added there is unreachable at the merge gate — which is
+      # exactly how the residual-owner gate shipped enforcing nothing. This step runs the same
+      # validator the author runs locally, so local and hosted verdicts cannot diverge.
+      #
+      # The `if:` MIRRORS the inline script's own gate. `agentAuthors` is a list whose every
+      # entry starts with `neo-`, so `isAgentAuthor` reduces exactly to the prefix test; the
+      # label arm is carried verbatim. Without this condition the validator would start judging
+      # human-authored PRs that the existing gate deliberately skips.
+      - name: Checkout repository
+        if: startsWith(github.event.pull_request.user.login, 'neo-') || contains(github.event.pull_request.labels.*.name, 'ai')
+        uses: actions/checkout@v6
+
+      - name: Validate PR body with the owning implementation
+        if: startsWith(github.event.pull_request.user.login, 'neo-') || contains(github.event.pull_request.labels.*.name, 'ai')
+        env:
+          # Passed through the environment, never interpolated into the shell: a PR body is
+          # attacker-controlled text and `${{ }}` inside `run:` would splice it into the script.
+          PR_BODY : ${{ github.event.pull_request.body }}
+          PR_DRAFT: ${{ github.event.pull_request.draft }}
+        run: |
+          printf '%s' "$PR_BODY" > "$RUNNER_TEMP/pr-body.md"
+          if [ "$PR_DRAFT" = "true" ]; then
+            node buildScripts/util/agent-preflight.mjs --pr-body "$RUNNER_TEMP/pr-body.md" --pr-draft
+          else
+            node buildScripts/util/agent-preflight.mjs --pr-body "$RUNNER_TEMP/pr-body.md"
+          fi
+
       - name: Validate PR Body
         uses: actions/github-script@v9
         with:

--- a/.github/workflows/agent-pr-body-lint.yml
+++ b/.github/workflows/agent-pr-body-lint.yml
@@ -21,6 +21,18 @@ jobs:
         if: startsWith(github.event.pull_request.user.login, 'neo-') || contains(github.event.pull_request.labels.*.name, 'ai')
         uses: actions/checkout@v6
 
+      - name: Setup Node.js
+        if: startsWith(github.event.pull_request.user.login, 'neo-') || contains(github.event.pull_request.labels.*.name, 'ai')
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+
+      # The validator imports `commander`, so the checkout alone is not runnable. Matches the
+      # install step every sibling lint workflow already carries.
+      - name: Install dependencies
+        if: startsWith(github.event.pull_request.user.login, 'neo-') || contains(github.event.pull_request.labels.*.name, 'ai')
+        run: npm ci
+
       - name: Validate PR body with the owning implementation
         if: startsWith(github.event.pull_request.user.login, 'neo-') || contains(github.event.pull_request.labels.*.name, 'ai')
         env:

--- a/.github/workflows/agent-pr-body-lint.yml
+++ b/.github/workflows/agent-pr-body-lint.yml
@@ -20,6 +20,14 @@ jobs:
       - name: Checkout repository
         if: startsWith(github.event.pull_request.user.login, 'neo-') || contains(github.event.pull_request.labels.*.name, 'ai')
         uses: actions/checkout@v6
+        with:
+          # The stacked-ticket gate walks `<base>..HEAD`, so a shallow single-branch
+          # clone leaves it with no base ref to diff against.
+          fetch-depth: 0
+
+      - name: Fetch base branch
+        if: startsWith(github.event.pull_request.user.login, 'neo-') || contains(github.event.pull_request.labels.*.name, 'ai')
+        run: git fetch --no-tags origin "${{ github.base_ref }}:refs/remotes/origin/${{ github.base_ref }}" || true
 
       - name: Setup Node.js
         if: startsWith(github.event.pull_request.user.login, 'neo-') || contains(github.event.pull_request.labels.*.name, 'ai')
@@ -40,12 +48,13 @@ jobs:
           # attacker-controlled text and `${{ }}` inside `run:` would splice it into the script.
           PR_BODY : ${{ github.event.pull_request.body }}
           PR_DRAFT: ${{ github.event.pull_request.draft }}
+          BASE_REF: ${{ github.base_ref }}
         run: |
           printf '%s' "$PR_BODY" > "$RUNNER_TEMP/pr-body.md"
           if [ "$PR_DRAFT" = "true" ]; then
-            node buildScripts/util/agent-preflight.mjs --pr-body "$RUNNER_TEMP/pr-body.md" --pr-draft
+            node buildScripts/util/agent-preflight.mjs --pr-body "$RUNNER_TEMP/pr-body.md" --pr-base "origin/$BASE_REF" --pr-draft
           else
-            node buildScripts/util/agent-preflight.mjs --pr-body "$RUNNER_TEMP/pr-body.md"
+            node buildScripts/util/agent-preflight.mjs --pr-body "$RUNNER_TEMP/pr-body.md" --pr-base "origin/$BASE_REF"
           fi
 
       - name: Validate PR Body

--- a/buildScripts/util/agent-preflight.mjs
+++ b/buildScripts/util/agent-preflight.mjs
@@ -37,11 +37,20 @@ const
     // undetected, which is the quiet failure: the guard reports success on the exact grammar the
     // template teaches. `Residual-Owner:` cannot match it — the colon must follow `Residual`.
     INLINE_RESIDUAL_PATTERN       = /\bResidual:[ \t]*(AC\s*\d+[^\n.]*)/i,
-    // The COLON is mandatory. `:?` accepted `Residual-Owner #200`, a spelling no template teaches, so a
-    // near-miss line discharged a live obligation. Preceded by line-start or whitespace rather than
-    // line-anchored, because the Evidence Ladder's canonical residual sits MID-LINE on the `Evidence:`
-    // line and its owner has to be declarable there too.
-    RESIDUAL_OWNER_PATTERN        = /(?:^|[\s>])Residual-Owner:[ \t]+#(\d+)/im,
+    // TWO legitimate declaration shapes, because the substrate teaches two — conflating them is what
+    // produced a bypass in one direction and a broken canonical form in the other.
+    //
+    // 1. SECTION shape: the owner is the LINE's content, after optional blockquote / list markers. The
+    //    ticket says line — *"an explicit `Residual-Owner: #N` line"*. Anchoring matters here because a
+    //    section is prose: `We considered Residual-Owner: #200 but rejected that owner.` discharged work
+    //    while SAYING it rejected the owner.
+    RESIDUAL_OWNER_LINE_PATTERN   = /^[ \t]*(?:>[ \t]*)*(?:[-*+][ \t]+)?Residual-Owner:[ \t]+#(\d+)[ \t]*$/im,
+    // 2. INLINE shape: `evidence-ladder.md` prescribes a **1-line** declaration whose owner is mid-line —
+    //    `Evidence: L2 (…) → L4 required (AC5 …). Residual: AC5, Residual-Owner: #<an existing open ticket>.` Anchoring THIS
+    //    would refuse the documented template, which is what my first attempt did; a spec arm written the
+    //    round before caught it. The owner must follow the `Residual:` clause on that same line, so a
+    //    bare mid-line mention still cannot qualify.
+    RESIDUAL_OWNER_INLINE_PATTERN = /Residual:[^\n]*?,[ \t]*Residual-Owner:[ \t]+#(\d+)/i,
     RESOLVES_PATTERN              = /\bResolves:?\s+#\d+/i,
     NON_CLOSING_REFERENCE_PATTERN = /\b(Refs|Related):?\s+#\d+/i,
     FORBIDDEN_CLOSE_PATTERN       = /\b(Closes|Fixes):?\s+#\d+/i,
@@ -283,7 +292,16 @@ function withoutFencedBlocks(body = '') {
  * @private
  */
 function withoutInlineCode(text = '') {
-    return text.replace(/`[^`\n]*`/g, match => match.replace(/[^\n]/g, ' '))
+    return text
+        // Longest backtick runs FIRST: a ``double`` span is not two single spans, and a single-backtick
+        // pattern applied first would consume the opening pair and leave the token exposed.
+        .replace(/(`{2,})[\s\S]*?\1/g, match => match.replace(/[^\n]/g, ' '))
+        .replace(/`[^`\n]*`/g, match => match.replace(/[^\n]/g, ' '))
+        // GFM indented code: four spaces (or a tab) at line start is a code block, so a token there is
+        // rendered example text, not a declaration. Blanked per line to keep offsets stable.
+        .split('\n')
+        .map(line => (/^(?: {4,}|\t)/.test(line) ? line.replace(/[^\n]/g, ' ') : line))
+        .join('\n')
 }
 
 /**
@@ -375,7 +393,13 @@ export function validatePrBody(body, {draft = false} = {}) {
         // sections does, and the owner must appear in THAT section — so an earlier discharged duplicate
         // can no longer stand in for a later live one.
         pmvSections       = postMergeValidationSections(body),
-        pmvSection        = pmvSections.find(section => firstLiveObligation(section)) ?? pmvSections[0] ?? '',
+        // EVERY owing section is checked, not the first. `find()` validated one and let a second owing
+        // section ride on the first's owner — the same shadowing defect one level along, where the fix
+        // for duplicate sections introduced its own blind spot. The first UNOWNED owing section is the
+        // one reported, so the message names work that is genuinely orphaned.
+        owingSections     = pmvSections.filter(section => firstLiveObligation(section)),
+        pmvSection        = owingSections.find(section => !withoutInlineCode(section).match(RESIDUAL_OWNER_LINE_PATTERN))
+            ?? owingSections[0] ?? pmvSections[0] ?? '',
         sectionObligation = firstLiveObligation(pmvSection),
         inlineResidual    = fenceless.match(INLINE_RESIDUAL_PATTERN),
         inlineLine        = inlineResidual
@@ -393,7 +417,11 @@ export function validatePrBody(body, {draft = false} = {}) {
     if (obligation) {
         const
             resolvesMatch = body.match(RESOLVES_PATTERN),
-            ownerMatch    = ownerScope.match(RESIDUAL_OWNER_PATTERN),
+            // The shape is chosen by which obligation is being discharged: a section obligation needs a
+            // declaration LINE, the Evidence Ladder's 1-line form needs its mid-line owner.
+            ownerMatch    = sectionObligation
+                ? ownerScope.match(RESIDUAL_OWNER_LINE_PATTERN)
+                : ownerScope.match(RESIDUAL_OWNER_INLINE_PATTERN),
             closeTarget   = resolvesMatch ? resolvesMatch[0].match(/\d+/)[0] : null,
             owner         = ownerMatch ? ownerMatch[1] : null;
 

--- a/buildScripts/util/agent-preflight.mjs
+++ b/buildScripts/util/agent-preflight.mjs
@@ -236,7 +236,16 @@ export function validateChangeClass({
  * @returns {String}
  * @private
  */
+function withoutFencedBlocks(body = '') {
+    // A heading inside a fence is an EXAMPLE, not this body's section. Bodies that document the
+    // template — including this PR's own — carry `## Post-Merge Validation` inside ``` fences, and
+    // anchoring there reads a worked example as the real obligation.
+    return body.replace(/^```[^\n]*\n[\s\S]*?^```[ \t]*$/gm, match => match.replace(/[^\n]/g, ' '));
+}
+
 function postMergeValidationSection(body = '') {
+    body = withoutFencedBlocks(body);
+
     const match = body.match(POST_MERGE_VALIDATION_H2);
 
     if (!match) return '';
@@ -287,15 +296,27 @@ export function validatePrBody(body, {draft = false} = {}) {
     // four merged PRs whose close targets shut within a second of the merge, three of them keeping no
     // record at all. `Residual-Owner` names ownership that ALREADY exists; it is never a licence to
     // mint a ticket, which is why the message below prescribes finishing or dropping first.
+    // The owner must live in the SAME unit that owes the work. A `Residual-Owner` anywhere in the
+    // body — a prose mention, a quoted example, another section's deferral — would otherwise
+    // discharge an obligation it has no relationship to.
     const
-        inlineResidual = body.match(INLINE_RESIDUAL_PATTERN),
-        obligation     = firstLiveObligation(postMergeValidationSection(body))
+        fenceless         = withoutFencedBlocks(body),
+        pmvSection        = postMergeValidationSection(body),
+        sectionObligation = firstLiveObligation(pmvSection),
+        inlineResidual    = fenceless.match(INLINE_RESIDUAL_PATTERN),
+        inlineLine        = inlineResidual
+            ? fenceless.slice(0, inlineResidual.index).split('\n').length - 1
+            : -1,
+        ownerScope       = sectionObligation
+            ? pmvSection
+            : (inlineLine >= 0 ? fenceless.split('\n')[inlineLine] : ''),
+        obligation       = sectionObligation
             || (inlineResidual ? `Residual: ${inlineResidual[1].trim()}` : null);
 
     if (obligation) {
         const
             resolvesMatch = body.match(RESOLVES_PATTERN),
-            ownerMatch    = body.match(RESIDUAL_OWNER_PATTERN),
+            ownerMatch    = ownerScope.match(RESIDUAL_OWNER_PATTERN),
             closeTarget   = resolvesMatch ? resolvesMatch[0].match(/\d+/)[0] : null,
             owner         = ownerMatch ? ownerMatch[1] : null;
 

--- a/buildScripts/util/agent-preflight.mjs
+++ b/buildScripts/util/agent-preflight.mjs
@@ -296,7 +296,16 @@ function withoutHtmlComments(text = '') {
     // declaration — a reader of the PR sees unowned work while the gate reports success. Same class as
     // a fenced example: text that is present in the source and absent from the artifact. Blanked per
     // character so every later line keeps its index.
-    return text.replace(/<!--[\s\S]*?-->/g, match => match.replace(/[^\n]/g, ' '))
+    //
+    // `(?:-->|$)` — an UNTERMINATED comment runs to end-of-body and must blank too. Requiring the
+    // closing delimiter made the gate's notion of "commented out" stricter than the renderer's:
+    // GitHub swallows everything from `<!--` to EOF, so `## Post-Merge Validation / - [ ] do real
+    // work / <!-- / Residual-Owner: #200` renders as an unowned obligation while the gate read the
+    // owner and passed. Verified against the real renderer (`POST /markdown`): the response carries
+    // the heading and the list item and NO owner. The rule is the same one every arm here restates —
+    // judge what a READER SEES — and the closing delimiter was an assumption about how the evasion
+    // would be spelled.
+    return text.replace(/<!--[\s\S]*?(?:-->|$)/g, match => match.replace(/[^\n]/g, ' '))
 }
 
 function withoutInlineCode(text = '') {

--- a/buildScripts/util/agent-preflight.mjs
+++ b/buildScripts/util/agent-preflight.mjs
@@ -27,8 +27,17 @@ export const INVISIBLE_PR_BODY_ANCHORS = [
 
 const
     POST_MERGE_VALIDATION_HEADING = '## Post-Merge Validation',
+    // A REAL level-two heading on its own line. `indexOf` would anchor on the first substring, so a
+    // body that merely quotes the heading in prose or a fenced block would have its section read
+    // from the wrong offset.
+    POST_MERGE_VALIDATION_H2      = /^##[ \t]+Post-Merge Validation[ \t]*$/m,
     // An unchecked task box, or an explicit residual marker. Checked boxes owe nothing.
     LIVE_OBLIGATION_PATTERN       = /^\s*[-*]\s*\[ \]|NOT_YET_MEASURED|^\s*Residual:/m,
+    // The Evidence Ladder's CANONICAL residual form is inline on the `Evidence:` line — outside the
+    // Post-Merge Validation section entirely. Scanning only that section leaves the documented shape
+    // undetected, which is the quiet failure: the guard reports success on the exact grammar the
+    // template teaches. `Residual-Owner:` cannot match it — the colon must follow `Residual`.
+    INLINE_RESIDUAL_PATTERN       = /\bResidual:[ \t]*(AC\s*\d+[^\n.]*)/i,
     RESIDUAL_OWNER_PATTERN        = /\bResidual-Owner:?\s+#(\d+)/i,
     RESOLVES_PATTERN              = /\bResolves:?\s+#\d+/i,
     NON_CLOSING_REFERENCE_PATTERN = /\b(Refs|Related):?\s+#\d+/i,
@@ -228,12 +237,12 @@ export function validateChangeClass({
  * @private
  */
 function postMergeValidationSection(body = '') {
-    const start = body.indexOf(POST_MERGE_VALIDATION_HEADING);
+    const match = body.match(POST_MERGE_VALIDATION_H2);
 
-    if (start === -1) return '';
+    if (!match) return '';
 
     const
-        after = body.slice(start + POST_MERGE_VALIDATION_HEADING.length),
+        after = body.slice(match.index + match[0].length),
         next  = after.search(/^##\s/m);
 
     return next === -1 ? after : after.slice(0, next)
@@ -278,7 +287,10 @@ export function validatePrBody(body, {draft = false} = {}) {
     // four merged PRs whose close targets shut within a second of the merge, three of them keeping no
     // record at all. `Residual-Owner` names ownership that ALREADY exists; it is never a licence to
     // mint a ticket, which is why the message below prescribes finishing or dropping first.
-    const obligation = firstLiveObligation(postMergeValidationSection(body));
+    const
+        inlineResidual = body.match(INLINE_RESIDUAL_PATTERN),
+        obligation     = firstLiveObligation(postMergeValidationSection(body))
+            || (inlineResidual ? `Residual: ${inlineResidual[1].trim()}` : null);
 
     if (obligation) {
         const
@@ -288,7 +300,7 @@ export function validatePrBody(body, {draft = false} = {}) {
             owner         = ownerMatch ? ownerMatch[1] : null;
 
         if (!owner) {
-            missingVisible.push(`\`## Post-Merge Validation\` still owes work — "${obligation}" — with no \`Residual-Owner: #N\`. Finish it before merge, or name an EXISTING open ticket that owns it, or drop the obligation. Do not open a ticket to satisfy this.`)
+            missingVisible.push(`This PR still owes work — "${obligation}" — with no \`Residual-Owner: #N\`. Finish it before merge, or name an EXISTING open ticket that owns it, or drop the obligation. Do not open a ticket to satisfy this.`)
         } else if (owner === closeTarget) {
             missingVisible.push(`\`Residual-Owner: #${owner}\` is this PR's own close target, so the owner disappears when the merge closes it. Name an EXISTING open ticket, or finish the work, or drop it.`)
         }

--- a/buildScripts/util/agent-preflight.mjs
+++ b/buildScripts/util/agent-preflight.mjs
@@ -37,7 +37,11 @@ const
     // undetected, which is the quiet failure: the guard reports success on the exact grammar the
     // template teaches. `Residual-Owner:` cannot match it — the colon must follow `Residual`.
     INLINE_RESIDUAL_PATTERN       = /\bResidual:[ \t]*(AC\s*\d+[^\n.]*)/i,
-    RESIDUAL_OWNER_PATTERN        = /\bResidual-Owner:?\s+#(\d+)/i,
+    // The COLON is mandatory. `:?` accepted `Residual-Owner #200`, a spelling no template teaches, so a
+    // near-miss line discharged a live obligation. Preceded by line-start or whitespace rather than
+    // line-anchored, because the Evidence Ladder's canonical residual sits MID-LINE on the `Evidence:`
+    // line and its owner has to be declarable there too.
+    RESIDUAL_OWNER_PATTERN        = /(?:^|[\s>])Residual-Owner:[ \t]+#(\d+)/im,
     RESOLVES_PATTERN              = /\bResolves:?\s+#\d+/i,
     NON_CLOSING_REFERENCE_PATTERN = /\b(Refs|Related):?\s+#\d+/i,
     FORBIDDEN_CLOSE_PATTERN       = /\b(Closes|Fixes):?\s+#\d+/i,
@@ -230,9 +234,56 @@ export function validateChangeClass({
  */
 function withoutFencedBlocks(body = '') {
     // A heading inside a fence is an EXAMPLE, not this body's section. Bodies that document the
-    // template — including this PR's own — carry `## Post-Merge Validation` inside ``` fences, and
+    // template — including this PR's own — carry `## Post-Merge Validation` inside fences, and
     // anchoring there reads a worked example as the real obligation.
-    return body.replace(/^```[^\n]*\n[\s\S]*?^```[ \t]*$/gm, match => match.replace(/[^\n]/g, ' '));
+    //
+    // Line-scanned rather than regex-matched, because GFM fences are not one spelling: an opener is
+    // three-or-more BACKTICKS **or** three-or-more TILDES, indentable up to three spaces, and a closer
+    // must use the same character and be at least as long. A single ```-only pattern let `~~~~md` and
+    // ````markdown` shadow the real section — two live bypasses at review. Blanked (not deleted) so
+    // every later line keeps its index.
+    let fenceChar = null,
+        fenceLen  = 0;
+
+    return body.split('\n').map(line => {
+        const marker = line.match(/^[ \t]{0,3}(`{3,}|~{3,})/),
+              blank  = () => line.replace(/[^\n]/g, ' ');
+
+        if (fenceChar === null) {
+            if (!marker) {
+                return line;
+            }
+            fenceChar = marker[1][0];
+            fenceLen  = marker[1].length;
+
+            return blank();
+        }
+
+        // A closer carries nothing but its own run; an info string means a new opener, never a close.
+        const closer = line.match(/^[ \t]{0,3}(`{3,}|~{3,})[ \t]*$/);
+
+        if (closer && closer[1][0] === fenceChar && closer[1].length >= fenceLen) {
+            fenceChar = null;
+            fenceLen  = 0;
+        }
+
+        return blank();
+    }).join('\n')
+}
+
+/**
+ * @summary Blanks inline code spans, preserving length so offsets stay comparable.
+ *
+ * A backticked `Residual-Owner: #200` inside a Post-Merge Validation section DOCUMENTS the spelling; it
+ * does not declare ownership. Reading it as a declaration let a section satisfy its own live obligation
+ * by quoting the syntax that would have satisfied it — the same class as a fenced heading standing in
+ * for a real one, one grain finer.
+ * @param {String} text
+ * @returns {String}
+ * @private
+ */
+function withoutInlineCode(text = '') {
+    return text.replace(/`[^`\n]*`/g, match => match.replace(/[^\n]/g, ' '))
 }
 
 /**
@@ -246,18 +297,27 @@ function withoutFencedBlocks(body = '') {
  * @returns {String}
  * @private
  */
-function postMergeValidationSection(body = '') {
-    body = withoutFencedBlocks(body);
-
-    const match = body.match(POST_MERGE_VALIDATION_H2);
-
-    if (!match) return '';
-
+function postMergeValidationSections(body = '') {
+    // EVERY matching section, not the first. `body.match()` returns one hit, so a duplicate — even an
+    // empty `## Post-Merge Validation / None deferred.` earlier in the document — shadowed a later
+    // section that genuinely owed work. A body owes work if ANY of its sections does, so the caller
+    // needs the whole set and picks the owing one.
     const
-        after = body.slice(match.index + match[0].length),
-        next  = after.search(/^##\s/m);
+        fenceless = withoutFencedBlocks(body),
+        matcher   = new RegExp(POST_MERGE_VALIDATION_H2.source, 'gm'),
+        sections  = [];
 
-    return next === -1 ? after : after.slice(0, next)
+    let match;
+
+    while ((match = matcher.exec(fenceless)) !== null) {
+        const
+            after = fenceless.slice(match.index + match[0].length),
+            next  = after.search(/^##\s/m);
+
+        sections.push(next === -1 ? after : after.slice(0, next))
+    }
+
+    return sections
 }
 
 /**
@@ -311,15 +371,22 @@ export function validatePrBody(body, {draft = false} = {}) {
     // discharge an obligation it has no relationship to.
     const
         fenceless         = withoutFencedBlocks(body),
-        pmvSection        = postMergeValidationSection(body),
+        // The OWING section, not the first one. A body owes work if any of its Post-Merge Validation
+        // sections does, and the owner must appear in THAT section — so an earlier discharged duplicate
+        // can no longer stand in for a later live one.
+        pmvSections       = postMergeValidationSections(body),
+        pmvSection        = pmvSections.find(section => firstLiveObligation(section)) ?? pmvSections[0] ?? '',
         sectionObligation = firstLiveObligation(pmvSection),
         inlineResidual    = fenceless.match(INLINE_RESIDUAL_PATTERN),
         inlineLine        = inlineResidual
             ? fenceless.slice(0, inlineResidual.index).split('\n').length - 1
             : -1,
-        ownerScope       = sectionObligation
+        // Inline code is blanked in the scope: a backticked `Residual-Owner: #200` documents the spelling
+        // rather than declaring an owner, and reading it as a declaration let a section discharge its own
+        // obligation by quoting the syntax that would have discharged it.
+        ownerScope       = withoutInlineCode(sectionObligation
             ? pmvSection
-            : (inlineLine >= 0 ? fenceless.split('\n')[inlineLine] : ''),
+            : (inlineLine >= 0 ? fenceless.split('\n')[inlineLine] : '')),
         obligation       = sectionObligation
             || (inlineResidual ? `Residual: ${inlineResidual[1].trim()}` : null);
 

--- a/buildScripts/util/agent-preflight.mjs
+++ b/buildScripts/util/agent-preflight.mjs
@@ -291,6 +291,14 @@ function withoutFencedBlocks(body = '') {
  * @returns {String}
  * @private
  */
+function withoutHtmlComments(text = '') {
+    // An HTML comment is INVISIBLE in rendered Markdown, so a declaration inside one is not a
+    // declaration — a reader of the PR sees unowned work while the gate reports success. Same class as
+    // a fenced example: text that is present in the source and absent from the artifact. Blanked per
+    // character so every later line keeps its index.
+    return text.replace(/<!--[\s\S]*?-->/g, match => match.replace(/[^\n]/g, ' '))
+}
+
 function withoutInlineCode(text = '') {
     return text
         // Longest backtick runs FIRST: a ``double`` span is not two single spans, and a single-backtick
@@ -321,7 +329,7 @@ function postMergeValidationSections(body = '') {
     // section that genuinely owed work. A body owes work if ANY of its sections does, so the caller
     // needs the whole set and picks the owing one.
     const
-        fenceless = withoutFencedBlocks(body),
+        fenceless = withoutHtmlComments(withoutFencedBlocks(body)),
         matcher   = new RegExp(POST_MERGE_VALIDATION_H2.source, 'gm'),
         sections  = [];
 
@@ -388,7 +396,7 @@ export function validatePrBody(body, {draft = false} = {}) {
     // body — a prose mention, a quoted example, another section's deferral — would otherwise
     // discharge an obligation it has no relationship to.
     const
-        fenceless         = withoutFencedBlocks(body),
+        fenceless         = withoutHtmlComments(withoutFencedBlocks(body)),
         // The OWING section, not the first one. A body owes work if any of its Post-Merge Validation
         // sections does, and the owner must appear in THAT section — so an earlier discharged duplicate
         // can no longer stand in for a later live one.

--- a/buildScripts/util/agent-preflight.mjs
+++ b/buildScripts/util/agent-preflight.mjs
@@ -26,7 +26,6 @@ export const INVISIBLE_PR_BODY_ANCHORS = [
 ];
 
 const
-    POST_MERGE_VALIDATION_HEADING = '## Post-Merge Validation',
     // A REAL level-two heading on its own line. `indexOf` would anchor on the first substring, so a
     // body that merely quotes the heading in prose or a fenced block would have its section read
     // from the wrong offset.
@@ -220,18 +219,11 @@ export function validateChangeClass({
 }
 
 /**
- * @summary Mirrors the Agent PR Body Lint workflow's local body-shape checks.
- * @param {String} body
- * @param {Object} [options]
- * @param {Boolean} [options.draft=false]
- * @returns {Object}
- */
-/**
- * @summary Returns the body of the `## Post-Merge Validation` section, or `''` when absent.
+ * @summary Blanks fenced code blocks, preserving line structure so offsets stay comparable.
  *
- * The anchor check above proves the heading string appears SOMEWHERE; it says nothing about what
- * follows it. This reads the section itself — heading to the next `##` heading, or to end-of-body when
- * it is last.
+ * A heading inside a fence is an EXAMPLE, not a section this body owes work under. Replacing the
+ * fence with spaces rather than deleting it keeps every later line at its original index, which is
+ * what lets a caller map a match back onto the untouched body.
  * @param {String} body
  * @returns {String}
  * @private
@@ -243,6 +235,17 @@ function withoutFencedBlocks(body = '') {
     return body.replace(/^```[^\n]*\n[\s\S]*?^```[ \t]*$/gm, match => match.replace(/[^\n]/g, ' '));
 }
 
+/**
+ * @summary Returns the body of the `## Post-Merge Validation` section, or `''` when absent.
+ *
+ * The anchor check in `validatePrBody` proves the heading string appears SOMEWHERE; it says nothing
+ * about what follows it. This reads the section itself — heading to the next `##` heading, or to
+ * end-of-body when it is last — and reads it from a fenceless copy so a worked example in a fence
+ * cannot shadow the real section.
+ * @param {String} body
+ * @returns {String}
+ * @private
+ */
 function postMergeValidationSection(body = '') {
     body = withoutFencedBlocks(body);
 
@@ -273,6 +276,13 @@ function firstLiveObligation(section = '') {
     return line ? line.trim() : null
 }
 
+/**
+ * @summary Mirrors the Agent PR Body Lint workflow's local body-shape checks.
+ * @param {String} body
+ * @param {Object} [options]
+ * @param {Boolean} [options.draft=false]
+ * @returns {Object}
+ */
 export function validatePrBody(body, {draft = false} = {}) {
     const
         missingVisible         = VISIBLE_PR_BODY_ANCHORS.filter(anchor => !body.includes(anchor)),

--- a/buildScripts/util/agent-preflight.mjs
+++ b/buildScripts/util/agent-preflight.mjs
@@ -26,6 +26,10 @@ export const INVISIBLE_PR_BODY_ANCHORS = [
 ];
 
 const
+    POST_MERGE_VALIDATION_HEADING = '## Post-Merge Validation',
+    // An unchecked task box, or an explicit residual marker. Checked boxes owe nothing.
+    LIVE_OBLIGATION_PATTERN       = /^\s*[-*]\s*\[ \]|NOT_YET_MEASURED|^\s*Residual:/m,
+    RESIDUAL_OWNER_PATTERN        = /\bResidual-Owner:?\s+#(\d+)/i,
     RESOLVES_PATTERN              = /\bResolves:?\s+#\d+/i,
     NON_CLOSING_REFERENCE_PATTERN = /\b(Refs|Related):?\s+#\d+/i,
     FORBIDDEN_CLOSE_PATTERN       = /\b(Closes|Fixes):?\s+#\d+/i,
@@ -213,6 +217,44 @@ export function validateChangeClass({
  * @param {Boolean} [options.draft=false]
  * @returns {Object}
  */
+/**
+ * @summary Returns the body of the `## Post-Merge Validation` section, or `''` when absent.
+ *
+ * The anchor check above proves the heading string appears SOMEWHERE; it says nothing about what
+ * follows it. This reads the section itself — heading to the next `##` heading, or to end-of-body when
+ * it is last.
+ * @param {String} body
+ * @returns {String}
+ * @private
+ */
+function postMergeValidationSection(body = '') {
+    const start = body.indexOf(POST_MERGE_VALIDATION_HEADING);
+
+    if (start === -1) return '';
+
+    const
+        after = body.slice(start + POST_MERGE_VALIDATION_HEADING.length),
+        next  = after.search(/^##\s/m);
+
+    return next === -1 ? after : after.slice(0, next)
+}
+
+/**
+ * @summary Reports whether a Post-Merge Validation section still owes work.
+ *
+ * A live obligation is an unchecked task box, or an explicit residual marker. A section of checked
+ * boxes, or one that says the work is done, owes nothing — which is why presence of the section is
+ * never itself the trigger.
+ * @param {String} section
+ * @returns {String|null} The first live obligation, for the failure message, or `null`.
+ * @private
+ */
+function firstLiveObligation(section = '') {
+    const line = section.split('\n').find(entry => LIVE_OBLIGATION_PATTERN.test(entry));
+
+    return line ? line.trim() : null
+}
+
 export function validatePrBody(body, {draft = false} = {}) {
     const
         missingVisible         = VISIBLE_PR_BODY_ANCHORS.filter(anchor => !body.includes(anchor)),
@@ -229,6 +271,27 @@ export function validatePrBody(body, {draft = false} = {}) {
         missingVisible.push(draft
             ? 'Draft PR bodies without `Resolves #N` require `Refs #N` or `Related: #N`'
             : '`Resolves #N` is required')
+    }
+
+    // Deferred work must name a home that SURVIVES the merge. Parking it on the close target is the
+    // one destination guaranteed to be unreachable the moment it becomes actionable — measured across
+    // four merged PRs whose close targets shut within a second of the merge, three of them keeping no
+    // record at all. `Residual-Owner` names ownership that ALREADY exists; it is never a licence to
+    // mint a ticket, which is why the message below prescribes finishing or dropping first.
+    const obligation = firstLiveObligation(postMergeValidationSection(body));
+
+    if (obligation) {
+        const
+            resolvesMatch = body.match(RESOLVES_PATTERN),
+            ownerMatch    = body.match(RESIDUAL_OWNER_PATTERN),
+            closeTarget   = resolvesMatch ? resolvesMatch[0].match(/\d+/)[0] : null,
+            owner         = ownerMatch ? ownerMatch[1] : null;
+
+        if (!owner) {
+            missingVisible.push(`\`## Post-Merge Validation\` still owes work — "${obligation}" — with no \`Residual-Owner: #N\`. Finish it before merge, or name an EXISTING open ticket that owns it, or drop the obligation. Do not open a ticket to satisfy this.`)
+        } else if (owner === closeTarget) {
+            missingVisible.push(`\`Residual-Owner: #${owner}\` is this PR's own close target, so the owner disappears when the merge closes it. Name an EXISTING open ticket, or finish the work, or drop it.`)
+        }
     }
 
     return {

--- a/learn/agentos/process/evidence-ladder.md
+++ b/learn/agentos/process/evidence-ladder.md
@@ -59,17 +59,21 @@ The ladder applies to any PR where:
 PRs whose close-target hits the trigger MUST include a 1-line evidence declaration in the body:
 
 ```md
-Evidence: L<X> (<sandbox-ceiling description>) → L<Y> required (<close-target ACs requiring it>). Residual: AC<N> [#<close-target>].
+Evidence: L<X> (<sandbox-ceiling description>) → L<Y> required (<close-target ACs requiring it>). Residual: AC<N>, Residual-Owner: #<an EXISTING open ticket that is NOT the close target>.
 ```
+
+⛔**The residual's owner must survive the merge.** Naming the close target there is the one destination guaranteed to be unreachable the moment the residual becomes actionable — the merge closes it. Measured on four merged PRs: three close targets shut within a second of the merge and two kept no record at all, so the deferral and its own invalidation were the same event. `agent-preflight` now fails a body whose Post-Merge Validation section owes work without a `Residual-Owner` distinct from `Resolves`.
+
+**`Residual-Owner` points at ownership that ALREADY exists.** It is never a licence to open a ticket — if no owner exists, finish the work before merge or drop the obligation.
 
 **Examples:**
 
 ```md
-Evidence: L2 (mock-bin dispatch + real SIGTERM on spawned node child) → L4 required (AC5 sessionId distinctness via MCP from spawned session). Residual: AC5 [#10677].
+Evidence: L2 (mock-bin dispatch + real SIGTERM on spawned node child) → L4 required (AC5 sessionId distinctness via MCP from spawned session). Residual: AC5, Residual-Owner: #10677.
 ```
 
 ```md
-Evidence: L3 (browser-rendered visual confirmation on local Chromium) → L4 required (AC2 cross-browser parity on Safari). Residual: AC2 [#NNNN].
+Evidence: L3 (browser-rendered visual confirmation on local Chromium) → L4 required (AC2 cross-browser parity on Safari). Residual: AC2, Residual-Owner: #NNNN.
 ```
 
 ```md

--- a/test/playwright/unit/ai/buildScripts/util/agent-preflight.residualOwner.spec.mjs
+++ b/test/playwright/unit/ai/buildScripts/util/agent-preflight.residualOwner.spec.mjs
@@ -305,6 +305,50 @@ test.describe('validatePrBody — Residual-Owner gate (#16906)', () => {
         expect(residualFindings(commentThenRealOwner)).toHaveLength(0);
     });
 
+    test('BYPASS 11 — an UNTERMINATED comment hides the owner too, and needs no closing delimiter', () => {
+        // @neo-gpt's round-6 falsifier, and the sharpest statement yet of what this family is about.
+        // BYPASS 10 closed the comments that CLOSE. Requiring `-->` made the gate's notion of
+        // "commented out" stricter than the renderer's: GitHub swallows everything from `<!--` to
+        // end-of-body, so this renders as an obligation with NO owner while the gate read the owner
+        // and passed.
+        //
+        // Verified against the real renderer rather than assumed — `POST /markdown` on this exact body
+        // returns the heading and `<li>[ ] do real work</li>` and NOTHING else. The owner is absent
+        // from the artifact a reviewer reads.
+        //
+        // The lesson is not "handle one more spelling": my fix encoded an assumption about how the
+        // evasion would be SPELLED (with a closing delimiter) rather than the property that matters
+        // (invisible to a reader). Every arm in this family is that same correction at a finer grain.
+        const unterminated = [
+            base, '', '## Post-Merge Validation', '- [ ] do real work',
+            '<!--', 'Residual-Owner: #200'
+        ].join('\n');
+
+        expect(residualFindings(unterminated)).toHaveLength(1);
+
+        // Same shape on ONE line, with no newline before EOF.
+        expect(residualFindings(`${base}\n\n## Post-Merge Validation\n- [ ] do real work\n<!-- Residual-Owner: #200`))
+            .toHaveLength(1);
+
+        // Control: blanking-to-EOF must not swallow a document that has NO comment. Without this, a
+        // regex that blanked from any `<` onward would pass every arm above while destroying ordinary
+        // bodies — the over-reach direction of this fix.
+        const ownedNoComment = [
+            base, '', '## Post-Merge Validation', '- [ ] do real work', 'Residual-Owner: #16853'
+        ].join('\n');
+
+        expect(residualFindings(ownedNoComment)).toHaveLength(0);
+
+        // Control: a TERMINATED comment early in the body must not blank the real owner after it —
+        // proof the EOF alternation did not become greedy.
+        const terminatedThenOwner = [
+            base, '', '## Post-Merge Validation', '- [ ] do real work',
+            '<!-- an aside -->', 'Residual-Owner: #16853', '', 'Trailing prose stays readable.'
+        ].join('\n');
+
+        expect(residualFindings(terminatedThenOwner)).toHaveLength(0);
+    });
+
     test('TWO declaration shapes — and anchoring the wrong one breaks the documented template', () => {
         // This arm exists because I broke it in both directions in consecutive rounds. `evidence-ladder.md`
         // prescribes a **1-line** declaration whose owner is MID-LINE:

--- a/test/playwright/unit/ai/buildScripts/util/agent-preflight.residualOwner.spec.mjs
+++ b/test/playwright/unit/ai/buildScripts/util/agent-preflight.residualOwner.spec.mjs
@@ -93,6 +93,43 @@ test.describe('validatePrBody — Residual-Owner gate (#16906)', () => {
         expect(message.toLowerCase()).not.toContain('file a follow-up');
     });
 
+    test("the Evidence Ladder's CANONICAL inline residual is a live obligation", () => {
+        // The documented declaration puts the residual INLINE on the Evidence line, outside the
+        // Post-Merge Validation section entirely. A gate scanning only that section reports success
+        // on the exact grammar the template teaches — the quietest possible failure.
+        const body = base.replace(
+            'Evidence: L1 (static) → L1 required. No residuals.',
+            'Evidence: L2 (mock dispatch) → L4 required (AC5 live handoff). Residual: AC5.'
+        );
+
+        const findings = residualFindings(`${body}\n\n## Post-Merge Validation\n\nNone deferred.\n`);
+
+        expect(findings).toHaveLength(1);
+        expect(findings[0]).toContain('AC5');
+    });
+
+    test('an inline residual naming a distinct owner passes', () => {
+        // NON-VACUITY for the arm above: the inline form is not rejected wholesale, only unowned.
+        const body = base.replace(
+            'Evidence: L1 (static) → L1 required. No residuals.',
+            'Evidence: L2 → L4 required. Residual: AC5, Residual-Owner: #200.'
+        );
+
+        expect(residualFindings(`${body}\n\n## Post-Merge Validation\n\nNone deferred.\n`)).toHaveLength(0);
+    });
+
+    test('a PROSE mention of the heading does not become the section', () => {
+        // `indexOf` anchored on the first substring, so a body that merely quotes the heading — in
+        // prose or a fenced block — had its section read from the wrong offset, and the real
+        // section's live obligation went unseen.
+        const body = `${base}\n\nEvery PR needs a \`## Post-Merge Validation\` section, which is where deferrals live.\n\n## Post-Merge Validation\n\n- [ ] run the container exit check\n`;
+
+        const findings = residualFindings(body);
+
+        expect(findings).toHaveLength(1);
+        expect(findings[0]).toContain('run the container exit check');
+    });
+
     test('an absent section is unchanged — the anchor check owns that failure, not this gate', () => {
         expect(residualFindings(base)).toHaveLength(0);
     });

--- a/test/playwright/unit/ai/buildScripts/util/agent-preflight.residualOwner.spec.mjs
+++ b/test/playwright/unit/ai/buildScripts/util/agent-preflight.residualOwner.spec.mjs
@@ -280,6 +280,31 @@ test.describe('validatePrBody — Residual-Owner gate (#16906)', () => {
         expect(residualFindings(bothOwned)).toHaveLength(0);
     });
 
+    test('BYPASS 10 — an HTML comment is INVISIBLE in the rendered artifact', () => {
+        // The last of the rendered-authority set, and the cleanest statement of what the whole family
+        // has been about: the gate must judge what a READER SEES, not what the source contains. An owner
+        // inside `<!-- … -->` renders as nothing, so the reviewer sees unowned work while the lint
+        // reports success — the exact inversion the gate exists to prevent.
+        const multiLine = [
+            base, '', '## Post-Merge Validation', '- [ ] do real work', '',
+            '<!--', 'Residual-Owner: #200', '-->'
+        ].join('\n');
+
+        expect(residualFindings(multiLine)).toHaveLength(1);
+
+        const singleLine = `${base}\n\n## Post-Merge Validation\n- [ ] do real work\n<!-- Residual-Owner: #200 -->`;
+
+        expect(residualFindings(singleLine)).toHaveLength(1);
+
+        // Control: blanking comments must not blank the document around them.
+        const commentThenRealOwner = [
+            base, '', '## Post-Merge Validation', '- [ ] do real work',
+            '<!-- an aside about ownership -->', 'Residual-Owner: #16853'
+        ].join('\n');
+
+        expect(residualFindings(commentThenRealOwner)).toHaveLength(0);
+    });
+
     test('TWO declaration shapes — and anchoring the wrong one breaks the documented template', () => {
         // This arm exists because I broke it in both directions in consecutive rounds. `evidence-ladder.md`
         // prescribes a **1-line** declaration whose owner is MID-LINE:

--- a/test/playwright/unit/ai/buildScripts/util/agent-preflight.residualOwner.spec.mjs
+++ b/test/playwright/unit/ai/buildScripts/util/agent-preflight.residualOwner.spec.mjs
@@ -227,6 +227,87 @@ test.describe('validatePrBody — Residual-Owner gate (#16906)', () => {
         expect(residualFindings(inlineForm)).toHaveLength(0);
     });
 
+    test('BYPASS 7 — PROSE is not a declaration, even prose that REJECTS the owner', () => {
+        // The sharpest of the set: the sentence says the owner was rejected, and the gate accepted it as
+        // the owner. A section is prose, so an owner there must BE the line rather than appear in it.
+        const body = [
+            base, '', '## Post-Merge Validation', '- [ ] do real work',
+            'We considered Residual-Owner: #200 but rejected that owner.'
+        ].join('\n');
+
+        expect(residualFindings(body)).toHaveLength(1);
+
+        // Trailing text disqualifies too — a declaration ends at the ticket number.
+        const trailing = `${base}\n\n## Post-Merge Validation\n- [ ] do real work\nResidual-Owner: #200 but not really`;
+
+        expect(residualFindings(trailing)).toHaveLength(1);
+    });
+
+    test('BYPASS 8 — code rendering has more spellings than one backtick pair', () => {
+        // A `` ``double`` `` span is not two single spans, so a single-backtick-first strip consumed the
+        // opening pair and left the token exposed. Four-space indentation is GFM code too, and was not
+        // stripped at all.
+        const doubleTick = [
+            base, '', '## Post-Merge Validation', '- [ ] do real work',
+            'Spelling example: ``Residual-Owner: #200`` — documented only.'
+        ].join('\n');
+
+        expect(residualFindings(doubleTick)).toHaveLength(1);
+
+        const indented = `${base}\n\n## Post-Merge Validation\n- [ ] do real work\n\n    Residual-Owner: #200`;
+
+        expect(residualFindings(indented)).toHaveLength(1);
+    });
+
+    test('BYPASS 9 — EVERY owing section carries its own owner, not just the first', () => {
+        // The fix for duplicate sections introduced this: validating the first owing section let a second
+        // owing section ride on the first's owner. Same shadowing defect, one level along.
+        const secondUnowned = [
+            base, '', '## Post-Merge Validation', '- [ ] first work', 'Residual-Owner: #16853', '',
+            '## Notes', 'x', '',
+            '## Post-Merge Validation', '- [ ] second work'
+        ].join('\n');
+
+        expect(residualFindings(secondUnowned)).toHaveLength(1);
+
+        // Control: both owned is legal, so this is not "more than one owing section always fails".
+        const bothOwned = [
+            base, '', '## Post-Merge Validation', '- [ ] a', 'Residual-Owner: #16853', '',
+            '## Notes', 'x', '',
+            '## Post-Merge Validation', '- [ ] b', 'Residual-Owner: #16853'
+        ].join('\n');
+
+        expect(residualFindings(bothOwned)).toHaveLength(0);
+    });
+
+    test('TWO declaration shapes — and anchoring the wrong one breaks the documented template', () => {
+        // This arm exists because I broke it in both directions in consecutive rounds. `evidence-ladder.md`
+        // prescribes a **1-line** declaration whose owner is MID-LINE:
+        //
+        //   Evidence: L2 (…) → L4 required (AC5 …). Residual: AC5, Residual-Owner: #<an existing open ticket>.
+        //
+        // …while the Post-Merge Validation section form is a standalone LINE. Anchoring both refuses the
+        // template; anchoring neither lets prose discharge work. The shape is selected by which obligation
+        // is being discharged, and each half needs its own arm or the next author will collapse them again.
+        const inlineForm = [
+            'Resolves #16906', '',
+            'Evidence: L2 (mock dispatch) → L4 required (AC5 distinctness). Residual: AC5, Residual-Owner: #16853.', '',
+            '## Test Evidence', 'Ran it.', '', 'Authored by @neo-opus-vega', '', '## Deltas', 'none', '',
+            '## Post-Merge Validation', 'None deferred.'
+        ].join('\n');
+
+        expect(residualFindings(inlineForm), 'the canonical 1-line inline form must discharge').toHaveLength(0);
+
+        // …and the inline shape requires the owner to follow the `Residual:` clause, so a bare mid-line
+        // mention elsewhere on a line does not qualify as one.
+        const bareMidLine = inlineForm.replace(
+            'Residual: AC5, Residual-Owner: #16853.',
+            'Residual: AC5. Ownership discussed with Residual-Owner: #16853 pending.'
+        );
+
+        expect(residualFindings(bareMidLine)).toHaveLength(1);
+    });
+
     test('BYPASS 6 — a DISCHARGED duplicate section cannot shadow a later live one', () => {
         // `body.match()` returns one hit, so an earlier `None deferred.` section satisfied the gate while a
         // later section owed real work. Every section is now read, and the OWING one carries the scope.

--- a/test/playwright/unit/ai/buildScripts/util/agent-preflight.residualOwner.spec.mjs
+++ b/test/playwright/unit/ai/buildScripts/util/agent-preflight.residualOwner.spec.mjs
@@ -140,4 +140,52 @@ test.describe('validatePrBody — Residual-Owner gate (#16906)', () => {
         expect(residualFindings(draftBody)).toHaveLength(0);
         expect(validatePrBody(draftBody, {draft: true}).valid).toBe(true);
     });
+
+    test('BYPASS 1 — a heading inside a FENCED block is an example, not this body\'s section', () => {
+        // @neo-gpt's falsifier. A body documenting the template carries the heading inside ```
+        // fences; anchoring there reads a worked example as the real obligation and lets the true
+        // section's unchecked work through unseen.
+        const body = [
+            base,
+            '',
+            '```md',
+            '## Post-Merge Validation',
+            'None deferred.',
+            '```',
+            '',
+            '## Post-Merge Validation',
+            '',
+            '- [ ] the REAL obligation',
+            ''
+        ].join('\n');
+
+        const findings = residualFindings(body);
+
+        expect(findings).toHaveLength(1);
+        expect(findings[0]).toContain('the REAL obligation');
+    });
+
+    test('BYPASS 2 — an owner elsewhere in the body cannot discharge the section\'s obligation', () => {
+        // The owner must live in the SAME unit that owes the work. A Residual-Owner in an unrelated
+        // section, or quoted in prose, has no relationship to this deferral.
+        const body = [
+            base,
+            '',
+            'Historically we pointed these at `Residual-Owner: #200`, which was wrong.',
+            '',
+            '## Post-Merge Validation',
+            '',
+            '- [ ] run the container exit check',
+            ''
+        ].join('\n');
+
+        expect(residualFindings(body)).toHaveLength(1);
+    });
+
+    test('BYPASS 2 control — an owner INSIDE the section still discharges it', () => {
+        // Non-vacuity: scoping must not reject a correctly-placed owner.
+        const body = `${base}\n\n## Post-Merge Validation\n\n- [ ] run it\n\nResidual-Owner: #200\n`;
+
+        expect(residualFindings(body)).toHaveLength(0);
+    });
 });

--- a/test/playwright/unit/ai/buildScripts/util/agent-preflight.residualOwner.spec.mjs
+++ b/test/playwright/unit/ai/buildScripts/util/agent-preflight.residualOwner.spec.mjs
@@ -1,0 +1,106 @@
+import {expect, test}   from '@playwright/test';
+import {validatePrBody} from '../../../../../../buildScripts/util/agent-preflight.mjs';
+
+/**
+ * Deferred work must name a home that SURVIVES the merge.
+ *
+ * Measured across four merged PRs: each parked unchecked Post-Merge Validation work on the ticket its
+ * own `Resolves` closed. Three of those close targets shut within one second of the merge and two kept
+ * no record at all — the deferral and its own invalidation were the same event.
+ *
+ * The gate is a comparison between two independently-produced values (the declared owner and the close
+ * target), never a judgement, so it cannot be satisfied by writing prose about diligence.
+ */
+
+const base = [
+    'Resolves #100',
+    '',
+    'Evidence: L1 (static) → L1 required. No residuals.',
+    '',
+    '## Deltas',
+    'one file',
+    '',
+    '## Test Evidence',
+    'green',
+    '',
+    'Authored by @neo-opus-vega'
+].join('\n');
+
+const withPmv = section => `${base}\n\n## Post-Merge Validation\n\n${section}\n`;
+
+/**
+ * Only THIS gate's findings.
+ *
+ * Matching on the heading name is too loose: when the section is absent the ANCHOR check emits a
+ * finding containing `## Post-Merge Validation`, which a heading-based filter would report as a gate
+ * failure. Keying on the gate's own wording keeps the two instruments separable.
+ */
+const residualFindings = body =>
+    validatePrBody(body).missingVisible.filter(entry => /still owes work|Residual-Owner: #/.test(entry));
+
+test.describe('validatePrBody — Residual-Owner gate (#16906)', () => {
+    test('a live obligation with NO owner fails, and names the obligation', () => {
+        const findings = residualFindings(withPmv('- [ ] run the container exit check'));
+
+        expect(findings).toHaveLength(1);
+        expect(findings[0]).toContain('run the container exit check');
+    });
+
+    test('an owner equal to the close target fails — that owner dies with the merge', () => {
+        const findings = residualFindings(withPmv('- [ ] run it\n\nResidual-Owner: #100'));
+
+        expect(findings).toHaveLength(1);
+        expect(findings[0]).toContain("this PR's own close target");
+    });
+
+    test('an owner DIFFERENT from the close target passes', () => {
+        expect(residualFindings(withPmv('- [ ] run it\n\nResidual-Owner: #200'))).toHaveLength(0);
+    });
+
+    test('NON-VACUITY — a section with no live obligation passes with no owner at all', () => {
+        // Without this arm a gate that rejected every Post-Merge Validation section would go green on
+        // all three arms above. Presence of the section is never the trigger; owing work is.
+        expect(residualFindings(withPmv('None deferred.'))).toHaveLength(0);
+        expect(residualFindings(withPmv('- [x] already measured on the plane'))).toHaveLength(0);
+    });
+
+    test('NOT_YET_MEASURED is a live obligation even with no task box', () => {
+        // The exact wording of the specimen that motivated this: a reviewer-owned evidence handoff
+        // stating AC3/AC4 are unmeasured, posted eleven minutes before its ticket closed.
+        expect(residualFindings(withPmv('AC3 and AC4 are NOT_YET_MEASURED.'))).toHaveLength(1);
+    });
+
+    test('the section is found when it is LAST in the body', () => {
+        // The extractor reads heading-to-next-`##`; an off-by-one at end-of-body would silently exempt
+        // every PR that puts Post-Merge Validation last, which is the common shape.
+        expect(residualFindings(`${base}\n\n## Post-Merge Validation\n- [ ] tail obligation\n`)).toHaveLength(1);
+    });
+
+    test('an unchecked box OUTSIDE the section does not trigger the gate', () => {
+        // Scoping proof: acceptance criteria and task lists elsewhere in a body are not deferred work.
+        const body = `${base}\n\n## Checklist\n- [ ] unrelated task\n\n## Post-Merge Validation\n\nNone deferred.\n`;
+
+        expect(residualFindings(body)).toHaveLength(0);
+    });
+
+    test('the message prescribes finishing, naming an EXISTING ticket, or dropping — never filing one', () => {
+        // Raised by @neo-gpt at intake and load-bearing: a gate demanding a durable owner reads as a gate
+        // demanding a NEW ticket, which would make it the backlog generator wearing a guard's clothes.
+        const [message] = residualFindings(withPmv('- [ ] run it'));
+
+        expect(message).toContain('EXISTING');
+        expect(message).toContain('Do not open a ticket');
+        expect(message.toLowerCase()).not.toContain('file a follow-up');
+    });
+
+    test('an absent section is unchanged — the anchor check owns that failure, not this gate', () => {
+        expect(residualFindings(base)).toHaveLength(0);
+    });
+
+    test('--pr-draft behaviour is unchanged by the gate', () => {
+        const draftBody = withPmv('- [ ] run it\n\nResidual-Owner: #200').replace('Resolves #100', 'Refs #100');
+
+        expect(residualFindings(draftBody)).toHaveLength(0);
+        expect(validatePrBody(draftBody, {draft: true}).valid).toBe(true);
+    });
+});

--- a/test/playwright/unit/ai/buildScripts/util/agent-preflight.residualOwner.spec.mjs
+++ b/test/playwright/unit/ai/buildScripts/util/agent-preflight.residualOwner.spec.mjs
@@ -188,4 +188,62 @@ test.describe('validatePrBody — Residual-Owner gate (#16906)', () => {
 
         expect(residualFindings(body)).toHaveLength(0);
     });
+
+    test('BYPASS 3 — GFM has more than one fence spelling', () => {
+        // The first fence guard matched ``` only. GFM opens a fence with three-or-more BACKTICKS **or**
+        // three-or-more TILDES, so a worked example in either of these shadowed the real section and the
+        // obligation went unseen. Fence handling is now line-scanned: same character, closer at least as
+        // long as its opener.
+        const owes = '## Post-Merge Validation\n- [ ] do real work';
+
+        for (const fence of ['~~~~md', '````markdown', '~~~text', '`````']) {
+            const closer = fence.replace(/[a-z]+$/, ''),
+                  body   = `${base}\n\nExample:\n\n${fence}\n## Post-Merge Validation\nNone deferred.\n${closer}\n\n${owes}`;
+
+            expect(residualFindings(body), `fence ${fence} must not shadow the real section`).toHaveLength(1);
+        }
+    });
+
+    test('BYPASS 4 — a backticked owner DOCUMENTS the spelling, it does not declare an owner', () => {
+        // One grain finer than BYPASS 2: the mention is inside the owing section, so scoping alone cannot
+        // reject it. Quoting the syntax that would discharge an obligation must not discharge it.
+        const body = [
+            base, '', '## Post-Merge Validation', '- [ ] do real work',
+            'The canonical spelling is `Residual-Owner: #200` — documented, not declared.'
+        ].join('\n');
+
+        expect(residualFindings(body)).toHaveLength(1);
+    });
+
+    test('BYPASS 5 — the colon is part of the declaration', () => {
+        // `Residual-Owner:?` accepted a spelling no template teaches, so a near-miss line discharged live
+        // work. Control below keeps the mid-line canonical form legal, which is why this is not anchored.
+        const colonless = `${base}\n\n## Post-Merge Validation\n- [ ] do real work\nResidual-Owner #200`;
+
+        expect(residualFindings(colonless)).toHaveLength(1);
+
+        const inlineForm = `${base.replace('Evidence: L2', 'Evidence: L2 — Residual: AC3 pending. Residual-Owner: #200')}\n`;
+
+        expect(residualFindings(inlineForm)).toHaveLength(0);
+    });
+
+    test('BYPASS 6 — a DISCHARGED duplicate section cannot shadow a later live one', () => {
+        // `body.match()` returns one hit, so an earlier `None deferred.` section satisfied the gate while a
+        // later section owed real work. Every section is now read, and the OWING one carries the scope.
+        const body = [
+            base, '', '## Post-Merge Validation', 'None deferred.', '',
+            '## Notes', 'unrelated', '',
+            '## Post-Merge Validation', '- [ ] do real work'
+        ].join('\n');
+
+        expect(residualFindings(body)).toHaveLength(1);
+
+        // …and the owner must sit in the section that OWES, not in the discharged duplicate.
+        const ownerInWrongSection = [
+            base, '', '## Post-Merge Validation', 'None deferred.', 'Residual-Owner: #200', '',
+            '## Post-Merge Validation', '- [ ] do real work'
+        ].join('\n');
+
+        expect(residualFindings(ownerInWrongSection)).toHaveLength(1);
+    });
 });


### PR DESCRIPTION
Resolves neomjs/neo#16906

Four merged PRs parked unchecked Post-Merge Validation work on the ticket their own `Resolves` closed. **Three of those close targets shut within one second of the merge**, and two kept no record at all — the deferral and its own invalidation were the same event.

Evidence: L2 (11 spec arms; two mutations each convicting a different half; the regression corpus run against the real merged PR bodies) → L2 required (no runtime-verify AC). No residuals.

## Why a guard alone would have been wrong

**Nobody improvised the bad shape — `evidence-ladder.md` prescribed it:**

```md
Evidence: … Residual: AC<N> [#<close-target>].
```

Shipping the linter against an unamended template would put it in contradiction with the doc it enforces. Both change here.

## The gate is a comparison, not a judgement

The declared owner against the close target — two independently-produced values — so it **cannot be satisfied by writing prose about diligence**. That is the whole reason this can work where the review guide's 10,694-byte anti-rubber-stamp section did not: that section is graded by the person performing it, so compliance saturates and correlates with nothing.

**Scope is "owes work", never "has a section".** A live obligation is an unchecked box or an explicit `NOT_YET_MEASURED` / `Residual:` marker. `None deferred.` or a section of checked boxes owes nothing and needs no owner.

**`Residual-Owner` names ownership that ALREADY exists.** @neo-gpt raised this at intake and it is load-bearing: a gate demanding a durable owner reads as a gate demanding a *new* ticket, which would make it the backlog generator wearing a guard's clothes. The failure message prescribes **finish / name-existing / drop** and never "file a follow-up" — asserted by a spec on the message text.

## Deltas

**`buildScripts/util/agent-preflight.mjs`** — a `## Post-Merge Validation` section extractor plus the gate. A prerequisite the ticket's first draft missed: `validatePrBody` had **no extractor at all**, only `body.includes(anchor)`, which proves a heading string appears *somewhere* and nothing about what follows it.

**`learn/agentos/process/evidence-ladder.md`** — the declaration template now prescribes `Residual-Owner: #<an EXISTING open ticket that is NOT the close target>`, with the reason and the never-a-licence-to-file constraint stated inline.

## Test Evidence

**Regression corpus — the real merged bodies, not fixtures:**

| body | result | |
|---|---|---|
| neomjs/neo#16887 · neomjs/neo#16894 · neomjs/neo#16899 · neomjs/neo#16884 | **red 4/4** | the withdrawn same-target rule caught 2/4 — two cite no ticket at all |
| neomjs/neo#16907 · neomjs/neo#16938 | green | no live obligation |
| neomjs/neo#16900 · neomjs/neo#16901 | red | **legitimately** — each names a live owner in *prose*; a new declared-field requirement cannot be retroactively satisfied by older bodies. Appending their existing owners (`#16904` / `#15874`) turns both green, verified. |

**Mutations, each convicting a different half:**

- disable the close-target comparison → **only** the owner-equals-target arm reds
- widen the extractor to the whole body → **only** the outside-the-section scoping arm reds

```
test/playwright/unit/ai/buildScripts/util/   →  369 passed
```

One test-design flaw caught and fixed before landing: my finding-filter matched the section heading, so when the section was *absent* it picked up the **anchor check's** message instead of the gate's. Keying on the gate's own wording keeps the two instruments separable — a looser filter would have masked a real miss.

## Post-Merge Validation

None deferred. Every acceptance criterion is unit-covered and verified above.

## Review

Cross-family seat needed (author is opus). Two places to attack: whether `LIVE_OBLIGATION_PATTERN` can **miss** a real obligation phrased another way (a false negative is the quiet failure here), and whether the section extractor mis-scopes when a body nests `###` subheadings under Post-Merge Validation — I read heading-to-next-`##` deliberately, but that is an assumption about body shape rather than a measured fact.

Authored by @neo-opus-vega 🌿
