### PR TITLE
Require a readiness discipline for initAsync-assigned members

### DIFF
--- a/.github/workflows/initasync-readiness-lint.yml
+++ b/.github/workflows/initasync-readiness-lint.yml
@@ -1,0 +1,44 @@
+name: InitAsync Readiness Lint
+
+# CI mirror of the `.husky/pre-commit` guard, so `git commit --no-verify` cannot bypass it.
+
+on:
+  pull_request:
+    branches: [dev]
+    paths:
+      - 'ai/**/*.mjs'
+      - 'buildScripts/util/check-init-async-readiness.mjs'
+      - '.github/workflows/initasync-readiness-lint.yml'
+  push:
+    branches: [dev]
+    paths:
+      - 'ai/**/*.mjs'
+      - 'buildScripts/util/check-init-async-readiness.mjs'
+      - '.github/workflows/initasync-readiness-lint.yml'
+
+concurrency:
+  group: initasync-readiness-lint-${{ github.run_attempt == '1' && github.ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+          cache: 'npm'
+
+      # Parses with acorn rather than scanning lines. The regex predecessor was dropped after two
+      # review cycles because each closed its named fixtures while the next found a shape it could
+      # not reach — multiline declarations, aliases, compound guards. Hence the install.
+      # --ignore-scripts skips the heavy prepare lifecycle (Husky + generated local configs).
+      - name: Install dependencies (acorn)
+        run: npm ci --ignore-scripts
+
+      - name: Require a readiness discipline for initAsync-assigned members
+        run: node ./buildScripts/util/check-init-async-readiness.mjs

--- a/buildScripts/util/check-init-async-readiness.mjs
+++ b/buildScripts/util/check-init-async-readiness.mjs
@@ -59,8 +59,47 @@ const READY_CALL = 'ready';
  */
 export const REGISTRY = new Map([
     ['ai/services/memory-core/SessionService.mjs::findSessionsToSummarize::memoryCollection',
-     'The read this guard was written to catch. Left unfixed ON PURPOSE for one commit so the lint is ' +
-     'observed failing on the real tree; the repair follows and this entry goes with it.']
+     'The read this guard was written to catch, kept here so the lint has a named in-tree witness. ' +
+     'The paired spec asserts the predicate FIRES on it against the tree as it stands, so the guard is ' +
+     'observed failing without CI going permanently red.'],
+    ["ai/daemons/orchestrator/services/DreamService.mjs::findUndigestedSessions::sessionsCollection",
+     "Daemon-side collection read. The daemon awaits its own boot before scheduling, so the risk is a direct call from a test or a future caller rather than the scheduled path — which is exactly the class an unwritten guarantee cannot survive."],
+    ["ai/daemons/orchestrator/services/DreamService.mjs::processUndigestedSessions::sessionsCollection",
+     "Daemon-side collection read. The daemon awaits its own boot before scheduling, so the risk is a direct call from a test or a future caller rather than the scheduled path — which is exactly the class an unwritten guarantee cannot survive."],
+    ["ai/agent/Loop.mjs::processEvent::tools",
+     "Agent loop reads its tool surface with no readiness discipline. Lowest blast radius of the set and the natural first burndown candidate."],
+    ["ai/agent/Loop.mjs::executeTools::toolRegistry",
+     "Agent loop reads its tool surface with no readiness discipline. Lowest blast radius of the set and the natural first burndown candidate."],
+    ["ai/services/memory-core/MemoryCoreRecorderService.mjs::getReembedRatioProjection::db",
+     "The one read in this class still uncovered: the projection passes this.db straight to a helper, where its siblings all guard with an early return. The narrowest fix is the same early return."],
+    ["ai/services/memory-core/SourceRegistryService.mjs::registerForTenant::db",
+     "Tenant-scoped registry read with no readiness discipline present. Candidate fix is one require-style accessor mirroring GraphService.requireDb(), which would cover every read in this class at once rather than six separate awaits."],
+    ["ai/services/memory-core/SourceRegistryService.mjs::getRegistrationForTenant::db",
+     "Tenant-scoped registry read with no readiness discipline present. Candidate fix is one require-style accessor mirroring GraphService.requireDb(), which would cover every read in this class at once rather than six separate awaits."],
+    ["ai/services/memory-core/SourceRegistryService.mjs::resolveRegistration::db",
+     "Tenant-scoped registry read with no readiness discipline present. Candidate fix is one require-style accessor mirroring GraphService.requireDb(), which would cover every read in this class at once rather than six separate awaits."],
+    ["ai/services/memory-core/SourceRegistryService.mjs::transitionLifecycleForTenant::db",
+     "Tenant-scoped registry read with no readiness discipline present. Candidate fix is one require-style accessor mirroring GraphService.requireDb(), which would cover every read in this class at once rather than six separate awaits."],
+    ["ai/services/memory-core/SourceRegistryService.mjs::listAuditForTenant::db",
+     "Tenant-scoped registry read with no readiness discipline present. Candidate fix is one require-style accessor mirroring GraphService.requireDb(), which would cover every read in this class at once rather than six separate awaits."],
+    ["ai/services/memory-core/SourceRegistryService.mjs::recordAudit::db",
+     "Tenant-scoped registry read with no readiness discipline present. Candidate fix is one require-style accessor mirroring GraphService.requireDb(), which would cover every read in this class at once rather than six separate awaits."],
+    ["ai/services/memory-core/CommunityBatchAdmissionService.mjs::getHostedSourceHealth::db",
+     "Guards its tenantId but not its db. Same candidate fix as its SourceRegistry sibling, and the two should adopt it together since they share the store."],
+    ["ai/services/memory-core/CommunityBatchAdmissionService.mjs::listObservations::db",
+     "Guards its tenantId but not its db. Same candidate fix as its SourceRegistry sibling, and the two should adopt it together since they share the store."],
+    ["ai/services/memory-core/CommunityBatchAdmissionService.mjs::readCheckpoint::db",
+     "Guards its tenantId but not its db. Same candidate fix as its SourceRegistry sibling, and the two should adopt it together since they share the store."],
+    ["ai/services/memory-core/SessionService.mjs::findSessionsToSummarize::sessionsCollection",
+     "The class this guard was written for. Its collections are assigned in initAsync and read across the summarization surface with neither discipline; the repair is its own lane because the call graph reaches these from both daemon and MCP entry points."],
+    ["ai/services/memory-core/SessionService.mjs::summarizeSession::memoryCollection",
+     "The class this guard was written for. Its collections are assigned in initAsync and read across the summarization surface with neither discipline; the repair is its own lane because the call graph reaches these from both daemon and MCP entry points."],
+    ["ai/services/memory-core/SessionService.mjs::summarizeSession::sessionsCollection",
+     "The class this guard was written for. Its collections are assigned in initAsync and read across the summarization surface with neither discipline; the repair is its own lane because the call graph reaches these from both daemon and MCP entry points."],
+    ["ai/services/memory-core/SessionService.mjs::ingestAntigravityArtifacts::memoryCollection",
+     "The class this guard was written for. Its collections are assigned in initAsync and read across the summarization surface with neither discipline; the repair is its own lane because the call graph reaches these from both daemon and MCP entry points."],
+    ["ai/services/memory-core/SessionService.mjs::recoverSessionSummaryReceipts::sessionsCollection",
+     "The class this guard was written for. Its collections are assigned in initAsync and read across the summarization surface with neither discipline; the repair is its own lane because the call graph reaches these from both daemon and MCP entry points."]
 ]);
 
 /**
@@ -153,16 +192,36 @@ function inMethodTruthinessGuards(methodNode) {
     const guardedFrom = new Map(),
           testSpans   = [];
 
+    /**
+     * `this.x` members whose ABSENCE makes the test true, so passing the test proves them present.
+     *
+     * `!this.db` alone, and every `!this.x` operand of an `||` chain — `if (!enabled || !this.db)
+     * return` is a real and common guard, and reading only a bare test misses it. COMPOUND GUARDS
+     * are named in this ticket's own history as one of the classes that defeated the regex
+     * predecessor, and the first version of this parse had exactly the same hole.
+     *
+     * `&&` deliberately does NOT credit: passing `if (!this.db && other)` proves nothing about
+     * `this.db` on its own.
+     */
+    const absenceOperands = node => {
+        if (node?.type === 'UnaryExpression' && node.operator === '!') {
+            const arg = node.argument;
+            return arg?.type === 'MemberExpression' &&
+                   arg.object?.type === 'ThisExpression' &&
+                   arg.property?.type === 'Identifier' ? [arg.property.name] : []
+        }
+
+        if (node?.type === 'LogicalExpression' && node.operator === '||') {
+            return [...absenceOperands(node.left), ...absenceOperands(node.right)]
+        }
+
+        return []
+    };
+
     walk(methodNode, node => {
         if (node.type !== 'IfStatement') return;
 
-        const test    = node.test,
-              negated = test?.type === 'UnaryExpression' && test.operator === '!' ? test.argument : null,
-              subject = negated ?? test;
-
-        if (subject?.type !== 'MemberExpression' ||
-            subject.object?.type !== 'ThisExpression' ||
-            subject.property?.type !== 'Identifier') return;
+        const test = node.test;
 
         // `if (!this.x) { return/throw }` guards what follows; `if (this.x) { … }` guards its own body.
         let exits = false;
@@ -170,15 +229,24 @@ function inMethodTruthinessGuards(methodNode) {
             if (inner.type === 'ReturnStatement' || inner.type === 'ThrowStatement') exits = true
         });
 
-        const name = subject.property.name,
-              from = negated && exits ? node.end : node.start;
-
         // The guard's OWN test reads the member it protects. Without this the lint reports every
         // correctly-guarded method for the act of checking — `ensureSchema()`'s `if (!this.db) return`
         // was flagged at the `if` line itself.
         testSpans.push([test.start, test.end]);
 
-        guardedFrom.set(name, Math.min(guardedFrom.get(name) ?? Infinity, from))
+        const absent = exits ? absenceOperands(test) : [];
+
+        for (const name of absent) {
+            guardedFrom.set(name, Math.min(guardedFrom.get(name) ?? Infinity, node.end))
+        }
+
+        // The positive form `if (this.x) { … }` guards only its own body, which the offset covers.
+        if (test?.type === 'MemberExpression' &&
+            test.object?.type === 'ThisExpression' &&
+            test.property?.type === 'Identifier') {
+            const name = test.property.name;
+            guardedFrom.set(name, Math.min(guardedFrom.get(name) ?? Infinity, node.start))
+        }
     });
 
     return {guardedFrom, testSpans}

--- a/buildScripts/util/check-init-async-readiness.mjs
+++ b/buildScripts/util/check-init-async-readiness.mjs
@@ -1,0 +1,417 @@
+#!/usr/bin/env node
+import * as acorn            from 'acorn';
+import {execSync, spawnSync} from 'child_process';
+import {readFileSync}        from 'fs';
+import path                  from 'path';
+import {fileURLToPath}       from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname  = path.dirname(__filename);
+const scriptRoot = path.resolve(__dirname, '../..');
+
+/**
+ * @summary Guards the readiness contract for members a class assigns in `initAsync()`.
+ *
+ * `core.Base` schedules `initAsync()` on a microtask, so anything it assigns is `undefined` for an
+ * unbounded window after `construct()` returns. A method that reads such a member without
+ * establishing readiness does not fail loudly — it reads `undefined` and fails somewhere else,
+ * later, as a different symptom.
+ *
+ * ## Two disciplines are valid, and this recognises BOTH
+ *
+ * 1. **`await this.ready()`** before the read.
+ * 2. **A require-style accessor** — a method that tests the member and THROWS when it is unset
+ *    (`GraphService.requireDb()`), so every consumer gets a loud, attributable failure instead of
+ *    `undefined`. This is not a weaker discipline; it is the one that works for synchronous callers.
+ *
+ * Crediting only the first would fail `GraphService`, which is correct code. That is the difference
+ * between a guard that is recognised and one that is merely tolerated.
+ *
+ * ## Why this is an AST analyser and not a regex
+ *
+ * Its predecessor was a regex predicate, and it was dropped after two review cycles on
+ * evidence rather than taste: each cycle closed its named fixtures and the next found a new class the
+ * scanner could not reach — multiline declarations, `const me = this` aliases, regex literals read as
+ * structure, single-statement branch extent, compound guards, `&&`/`!!` conditions. The population
+ * kept admitting shapes a line-oriented predicate has no way to see, so the parse is the fix.
+ *
+ * ## WHAT THIS DOES NOT ESTABLISH — read this before trusting a green run
+ *
+ * - **Per-file only.** A member guarded by a caller in another module is invisible here, and reads
+ *   as unguarded. That is why the registry exists and why every entry states a reason.
+ * - **Textual order, not branch dominance.** A `ready()` earlier in the method body credits every
+ *   later read in that method, including reads on paths the `await` cannot actually dominate.
+ *   Ordering is the approximation; a control-flow analysis is not attempted.
+ * - **No cross-method following.** A private helper that guards internally does not credit its
+ *   callers, and a helper called BEFORE the read does not transfer its guard.
+ * - It proves a discipline is **present**, never that it is **correct**.
+ */
+
+/** Members whose readiness is established by a require-style accessor rather than by `ready()`. */
+const READY_CALL = 'ready';
+
+/**
+ * Known-unguarded reads, each with the reason it is not yet fixed. NOT a grandfathering queue: this
+ * is the baseline to shrink, and its size at introduction is recorded in the PR that adds it.
+ *
+ * Keyed `repo/relative/path.mjs::method::member`, so moving a read to another method re-reports it
+ * rather than inheriting an exemption granted somewhere else.
+ */
+export const REGISTRY = new Map([
+    ['ai/services/memory-core/SessionService.mjs::findSessionsToSummarize::memoryCollection',
+     'The read this guard was written to catch. Left unfixed ON PURPOSE for one commit so the lint is ' +
+     'observed failing on the real tree; the repair follows and this entry goes with it.']
+]);
+
+/**
+ * @summary Parses one module, tolerating nothing — an unparseable file is a hard error rather than a
+ * silent skip, because a skipped file reads as a clean one.
+ * @param {String} source
+ * @param {String} file For the thrown message.
+ * @returns {Object} acorn Program node.
+ */
+function parseModule(source, file) {
+    try {
+        return acorn.parse(source, {ecmaVersion: 'latest', sourceType: 'module', locations: true})
+    } catch (error) {
+        throw new Error(`check-init-async-readiness: ${file} did not parse: ${error.message}`)
+    }
+}
+
+/**
+ * @summary Walks every node, depth-first, invoking `visit` on each.
+ *
+ * Hand-rolled because `acorn-walk` is not a dependency here and this needs no node-type knowledge —
+ * only "reach every object that looks like a node".
+ * @param {Object} node
+ * @param {Function} visit
+ * @returns {void}
+ */
+function walk(node, visit, parent = null) {
+    if (!node || typeof node !== 'object') return;
+
+    if (Array.isArray(node)) {
+        node.forEach(child => walk(child, visit, parent));
+        return
+    }
+
+    if (typeof node.type === 'string') visit(node, parent);
+
+    for (const key of Object.keys(node)) {
+        if (key === 'loc' || key === 'start' || key === 'end') continue;
+        walk(node[key], visit, typeof node.type === 'string' ? node : parent)
+    }
+}
+
+/**
+ * @summary `this.<name>` member expressions inside a subtree, with their source offsets.
+ * @param {Object} node
+ * @returns {Object[]} `[{name, start, line}]`
+ */
+function thisMemberReads(node) {
+    const found = [];
+
+    walk(node, (current, parent) => {
+        if (current.type === 'MemberExpression' &&
+            current.object?.type === 'ThisExpression' &&
+            current.property?.type === 'Identifier' &&
+            !current.computed) {
+            // `this.writer?.publish()` is undefined-safe BY CONSTRUCTION — the whole defect class is
+            // "reads undefined and fails later as a different symptom", and an optional chain cannot
+            // propagate the undefined onward. Telemetry lanes use this deliberately: the record is
+            // best-effort, and a missing writer must degrade rather than throw.
+            //
+            // The `optional` flag sits on the CONSUMING node, not on `this.writer` itself — an
+            // earlier draft tested `current.optional` and credited nothing, because that flag is
+            // always false here.
+            const optionallyConsumed = parent &&
+                (parent.type === 'MemberExpression' || parent.type === 'CallExpression') &&
+                parent.optional === true &&
+                (parent.object === current || parent.callee === current);
+
+            if (optionallyConsumed) return;
+
+            found.push({name: current.property.name, start: current.start, line: current.loc?.start.line})
+        }
+    });
+
+    return found
+}
+
+/**
+ * @summary The source offset after which each member is established by an in-method truthiness
+ * guard — `if (!this.db) return …`.
+ *
+ * A degraded return is a real discipline, not a weaker one: `getMemoryCoreToolMetrics()` answers
+ * `{status: 'unavailable'}` rather than throwing, which is the correct contract for an observation
+ * surface whose absence must not take down its caller. Crediting only `throw` would report every
+ * such method and turn this lint's own narrowness into repo debt.
+ * @param {Object} methodNode
+ * @returns {Map<String,Number>} member -> offset after which reads are guarded
+ */
+function inMethodTruthinessGuards(methodNode) {
+    const guardedFrom = new Map(),
+          testSpans   = [];
+
+    walk(methodNode, node => {
+        if (node.type !== 'IfStatement') return;
+
+        const test    = node.test,
+              negated = test?.type === 'UnaryExpression' && test.operator === '!' ? test.argument : null,
+              subject = negated ?? test;
+
+        if (subject?.type !== 'MemberExpression' ||
+            subject.object?.type !== 'ThisExpression' ||
+            subject.property?.type !== 'Identifier') return;
+
+        // `if (!this.x) { return/throw }` guards what follows; `if (this.x) { … }` guards its own body.
+        let exits = false;
+        walk(node.consequent, inner => {
+            if (inner.type === 'ReturnStatement' || inner.type === 'ThrowStatement') exits = true
+        });
+
+        const name = subject.property.name,
+              from = negated && exits ? node.end : node.start;
+
+        // The guard's OWN test reads the member it protects. Without this the lint reports every
+        // correctly-guarded method for the act of checking — `ensureSchema()`'s `if (!this.db) return`
+        // was flagged at the `if` line itself.
+        testSpans.push([test.start, test.end]);
+
+        guardedFrom.set(name, Math.min(guardedFrom.get(name) ?? Infinity, from))
+    });
+
+    return {guardedFrom, testSpans}
+}
+
+/**
+ * @summary The members a class assigns in `initAsync()` — the population, DERIVED.
+ *
+ * Derived from the assignment rather than from a hardcoded member list, because the predecessor's
+ * defect was a hand-written query shaping its own population. Assignments nested in the arrow
+ * functions and try blocks `initAsync` bodies actually use are included; the walk does not care
+ * about depth.
+ * @param {Object} classBody
+ * @returns {Set<String>}
+ */
+export function membersAssignedInInitAsync(classBody) {
+    const assigned = new Set();
+
+    for (const member of classBody.body ?? []) {
+        if (member.type !== 'MethodDefinition' || member.key?.name !== 'initAsync') continue;
+
+        walk(member.value, node => {
+            if (node.type === 'AssignmentExpression' &&
+                node.left?.type === 'MemberExpression' &&
+                node.left.object?.type === 'ThisExpression' &&
+                node.left.property?.type === 'Identifier' &&
+                !node.left.computed) {
+                assigned.add(node.left.property.name)
+            }
+        })
+    }
+
+    return assigned
+}
+
+/**
+ * @summary Methods that are require-style guards: they test a member and throw when it is unset.
+ *
+ * Recognising this is what lets `GraphService` pass without `await this.ready()`. The shape is
+ * deliberately narrow — a member test whose consequent throws — so an ordinary `if (x) { ... }` that
+ * merely returns early does not silently count as a readiness guarantee.
+ * @param {Object} classBody
+ * @returns {Map<String,String>} guarded member -> guarding method name
+ */
+export function requireStyleGuards(classBody) {
+    const guards = new Map();
+
+    for (const member of classBody.body ?? []) {
+        if (member.type !== 'MethodDefinition' || !member.key?.name) continue;
+
+        walk(member.value, node => {
+            if (node.type !== 'IfStatement') return;
+
+            const test    = node.test,
+                  negated = test?.type === 'UnaryExpression' && test.operator === '!' ? test.argument : null,
+                  subject = negated ?? test;
+
+            if (subject?.type !== 'MemberExpression' ||
+                subject.object?.type !== 'ThisExpression' ||
+                subject.property?.type !== 'Identifier') return;
+
+            let throws = false;
+            walk(node.consequent, inner => { if (inner.type === 'ThrowStatement') throws = true });
+
+            if (throws) guards.set(subject.property.name, member.key.name)
+        })
+    }
+
+    return guards
+}
+
+/**
+ * @summary Finds unguarded reads of `initAsync`-assigned members.
+ * @param {String} source
+ * @param {String} [file='<inline>']
+ * @returns {Object[]} `[{method, member, line}]`
+ */
+export function findUnguardedInitAsyncReads(source, file = '<inline>') {
+    const program = parseModule(source, file),
+          hits    = [];
+
+    walk(program, node => {
+        if (node.type !== 'ClassBody') return;
+
+        const population = membersAssignedInInitAsync(node);
+        if (population.size === 0) return;
+
+        const guards         = requireStyleGuards(node),
+              guardMachinery = new Set(guards.values());
+
+        // One level: whatever a guard calls on `this` is part of the guard's own path.
+        for (const member of node.body ?? []) {
+            if (member.type !== 'MethodDefinition' || !guardMachinery.has(member.key?.name)) continue;
+
+            walk(member.value, inner => {
+                if (inner.type === 'CallExpression' &&
+                    inner.callee?.type === 'MemberExpression' &&
+                    inner.callee.object?.type === 'ThisExpression' &&
+                    inner.callee.property?.type === 'Identifier') {
+                    guardMachinery.add(inner.callee.property.name)
+                }
+            })
+        }
+
+        for (const member of node.body ?? []) {
+            if (member.type !== 'MethodDefinition' || !member.key?.name) continue;
+
+            const methodName = member.key.name;
+
+            // `initAsync` assigns the population; a constructor-adjacent lifecycle hook establishing
+            // it is not a consumer of it.
+            if (methodName === 'initAsync' || methodName === 'construct') continue;
+
+            // A require-style guard reads the member it protects, by construction — and so does the
+            // guard's own failure path. `GraphService.requireDb()` throws `createUnavailableError()`,
+            // which reads `graphInitError` to build the diagnostic. Treating that helper as a consumer
+            // would report the guard for being a guard.
+            //
+            // This is ONE level and it is exclusion, not credit: being called by a guard removes a
+            // method from the consumer set; it never establishes readiness for anything else.
+            if (guardMachinery.has(methodName)) continue;
+
+            // Textual order, not dominance — stated in the header as a bound, not hidden as a detail.
+            let readyAt = Infinity;
+            walk(member.value, node2 => {
+                if (node2.type === 'CallExpression' &&
+                    node2.callee?.type === 'MemberExpression' &&
+                    node2.callee.object?.type === 'ThisExpression' &&
+                    node2.callee.property?.name === READY_CALL) {
+                    readyAt = Math.min(readyAt, node2.start)
+                }
+            });
+
+            const {guardedFrom, testSpans} = inMethodTruthinessGuards(member.value),
+                  insideAGuardTest         = offset => testSpans.some(([from, to]) => offset >= from && offset < to);
+
+            for (const read of thisMemberReads(member.value)) {
+                if (!population.has(read.name)) continue;
+                if (guards.has(read.name))      continue;   // a require-style accessor owns this member
+                if (read.start > readyAt)       continue;   // `ready()` established earlier in this method
+                if (read.start > (guardedFrom.get(read.name) ?? Infinity)) continue; // `if (!this.x) return`
+                if (insideAGuardTest(read.start)) continue; // the guard checking the member is not a consumer
+
+                hits.push({method: methodName, member: read.name, line: read.line})
+            }
+        }
+    });
+
+    // One report per (method, member): a member read five times in one method is one obligation.
+    const seen = new Set();
+
+    return hits.filter(hit => {
+        const key = `${hit.method}::${hit.member}`;
+        if (seen.has(key)) return false;
+        seen.add(key);
+        return true
+    })
+}
+
+/**
+ * @summary Normalizes an input path to a repo-relative POSIX path.
+ * @param {String} file
+ * @param {String} gitRoot
+ * @returns {String}
+ */
+export function toRepoRelative(file, gitRoot) {
+    return path.relative(gitRoot, path.resolve(gitRoot, file)).split(path.sep).join('/')
+}
+
+function main() {
+    let gitRoot;
+    try {
+        gitRoot = execSync('git rev-parse --show-toplevel', {cwd: scriptRoot, encoding: 'utf-8'}).trim();
+    } catch {
+        console.error('\x1b[31mError: Could not determine git repository root.\x1b[0m');
+        process.exit(1)
+    }
+
+    const rawArgv   = process.argv.slice(2),
+          quiet     = rawArgv.includes('-q') || rawArgv.includes('--quiet'),
+          argvFiles = rawArgv.filter(arg => !arg.startsWith('-'));
+
+    function collectDefaultFiles() {
+        const result = spawnSync('find', ['ai', '-type', 'f', '-name', '*.mjs'], {cwd: gitRoot, encoding: 'utf-8'});
+        if (result.status !== 0) {
+            console.error('\x1b[31mError: find command failed.\x1b[0m');
+            process.exit(1)
+        }
+        return result.stdout.trim().split('\n').filter(Boolean)
+    }
+
+    const files = (argvFiles.length > 0 ? argvFiles : collectDefaultFiles())
+        .filter(file => file.endsWith('.mjs'))
+        .map(file => toRepoRelative(file, gitRoot))
+        .filter(file => file.startsWith('ai/'));
+
+    const violations = [],
+          startedAt  = Date.now();
+
+    for (const file of files) {
+        let content;
+        try {
+            content = readFileSync(path.resolve(gitRoot, file), 'utf-8')
+        } catch (e) {
+            console.error(`check-init-async-readiness: could not read ${file}: ${e.message}`);
+            continue
+        }
+
+        for (const {method, member, line} of findUnguardedInitAsyncReads(content, file)) {
+            if (REGISTRY.has(`${file}::${method}::${member}`)) continue;
+            violations.push(`${file}:${line}: ${method}() reads this.${member}, assigned in initAsync(), with neither discipline`)
+        }
+    }
+
+    const elapsedMs = Date.now() - startedAt;
+
+    if (violations.length > 0) {
+        console.error(`\x1b[31mcheck-init-async-readiness: ${violations.length} unguarded initAsync-member read(s):\x1b[0m`);
+        if (!quiet) {
+            violations.forEach(violation => console.error('  ' + violation));
+            console.error('\nEstablish readiness before the read, either way:');
+            console.error('  • `await this.ready()` earlier in the method, or');
+            console.error('  • a require-style accessor that tests the member and THROWS when unset');
+            console.error('    (see `GraphService.requireDb()`), so callers fail loudly instead of on undefined.');
+            console.error('\nIf neither applies, add a REGISTRY entry stating why — a bare list is not acceptable.');
+        }
+        process.exit(1)
+    }
+
+    console.log(`check-init-async-readiness: ${files.length} ai .mjs file(s) scanned in ${elapsedMs}ms, ${REGISTRY.size} registered, 0 new violations.`)
+}
+
+const invokedDirectly = process.argv[1] && path.resolve(process.argv[1]) === __filename;
+if (invokedDirectly) {
+    main()
+}

--- a/package.json
+++ b/package.json
@@ -263,7 +263,8 @@
             "node ./buildScripts/util/check-derived-domain.mjs"
         ],
         "ai/**/*.mjs": [
-            "node ./buildScripts/util/check-atomic-write-shape.mjs"
+            "node ./buildScripts/util/check-atomic-write-shape.mjs",
+            "node ./buildScripts/util/check-init-async-readiness.mjs"
         ],
         "{package.json,.husky/pre-commit,.github/workflows/*.yml,.github/workflows/*.yaml,ai/scripts/lint/lint-guard-ci-parity.mjs,ai/scripts/lint/guard-ci-parity-registry.json}": [
             "node ./ai/scripts/lint/lint-guard-ci-parity.mjs"

--- a/test/playwright/unit/ai/buildScripts/util/check-init-async-readiness.spec.mjs
+++ b/test/playwright/unit/ai/buildScripts/util/check-init-async-readiness.spec.mjs
@@ -1,0 +1,146 @@
+import * as acorn      from 'acorn';
+import {test, expect}  from '@playwright/test';
+import {readFileSync}  from 'node:fs';
+import path            from 'node:path';
+import {fileURLToPath} from 'node:url';
+import {
+    findUnguardedInitAsyncReads,
+    membersAssignedInInitAsync,
+    REGISTRY,
+    requireStyleGuards
+} from '../../../../../../buildScripts/util/check-init-async-readiness.mjs';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../../../../..'),
+      readRepo = rel => readFileSync(path.join(repoRoot, rel), 'utf8');
+
+/**
+ * @summary Self-test for the initAsync readiness analyser.
+ *
+ * The two witnesses below run against the tree AS IT STANDS — no local revert, no fixture standing in
+ * for production. That is deliberate: a lint whose red-proof needs the repo mutated cannot run in CI,
+ * and this ticket's predecessor was dropped partly for proving itself against fixtures it had shaped.
+ */
+test.describe('check-init-async-readiness analyser', () => {
+    test('WITNESS: fires on a real in-tree unguarded read, with no revert', () => {
+        const hits = findUnguardedInitAsyncReads(
+            readRepo('ai/services/memory-core/SessionService.mjs'),
+            'SessionService.mjs'
+        );
+
+        // `memoryCollection` is assigned in initAsync and read here with neither discipline.
+        expect(hits.some(hit => hit.method === 'findSessionsToSummarize' && hit.member === 'memoryCollection'),
+            'the named witness must be detected against the current tree').toBe(true)
+    });
+
+    test('WITNESS: GraphService PASSES without `await this.ready()` — requireDb is recognised, not tolerated', () => {
+        const source = readRepo('ai/services/memory-core/GraphService.mjs');
+
+        expect(source.includes('await this.ready()'),
+            'the point of this witness is that it passes WITHOUT the ready() discipline').toBe(false);
+
+        expect(findUnguardedInitAsyncReads(source, 'GraphService.mjs'), 'requireDb() must be credited').toEqual([])
+    });
+
+    test('the population is DERIVED from the initAsync assignment, not a member-name list', () => {
+        const source = 'class X { async initAsync() { this.alpha = 1; if (true) { this.beta = 2 } } }';
+
+        expect([...membersAssignedInInitAsync(parseClassBody(source))].sort()).toEqual(['alpha', 'beta'])
+    });
+
+    test('a require-style guard is a method that TESTS the member and THROWS', () => {
+        const guarded   = 'class X { async initAsync() { this.db = 1 } requireDb() { if (!this.db) { throw new Error("x") } return this.db } }',
+              tolerated = 'class X { async initAsync() { this.db = 1 } maybeDb() { if (!this.db) { return null } return this.db } }';
+
+        expect([...requireStyleGuards(parseClassBody(guarded)).keys()]).toEqual(['db']);
+        // An early RETURN is a degraded-return discipline, not a require-style accessor — it guards
+        // its own method rather than every consumer, so it must not be credited class-wide.
+        expect([...requireStyleGuards(parseClassBody(tolerated)).keys()]).toEqual([])
+    });
+
+    /*
+     * Each of the four below is a false-positive class this analyser reported before it was corrected.
+     * They are kept as controls because every one of them, left uncorrected, would have been recorded
+     * as repo debt in the registry — the lint's own narrowness booked as the world's problem. The
+     * population moved 59 -> 41 -> 22 -> 19 as they were closed, none by weakening the rule.
+     */
+    test('CREDITS an optional-chained read — it cannot propagate undefined onward', () => {
+        const source = 'class X { async initAsync() { this.writer = 1 } flush() { this.writer?.publish() } }';
+
+        expect(findUnguardedInitAsyncReads(source)).toEqual([])
+    });
+
+    test('CREDITS a degraded early return — `if (!this.db) return`', () => {
+        const source = 'class X { async initAsync() { this.db = 1 } read() { if (!this.db) return null; return this.db.query() } }';
+
+        expect(findUnguardedInitAsyncReads(source)).toEqual([])
+    });
+
+    test('CREDITS a COMPOUND guard — `if (!enabled || !this.db) return`', () => {
+        // Named in this ticket's history as a class that defeated the regex predecessor. The first
+        // version of this parse had the same hole: it only read a BARE `!this.db` test.
+        const source = 'class X { async initAsync() { this.db = 1 } log(on) { if (!on || !this.db) return null; return this.db.write() } }';
+
+        expect(findUnguardedInitAsyncReads(source)).toEqual([])
+    });
+
+    test('does NOT report the guard for the act of guarding', () => {
+        // `ensureSchema()`'s own `if (!this.db) return` was reported AT the `if` line. A guard that
+        // reports guarding reads as noise and gets switched off.
+        const source = 'class X { async initAsync() { this.db = 1 } ensureSchema() { if (!this.db) return; this.db.exec("x") } }';
+
+        expect(findUnguardedInitAsyncReads(source)).toEqual([])
+    });
+
+    test('CREDITS `await this.ready()` earlier in the method', () => {
+        const source = 'class X { async initAsync() { this.db = 1 } async read() { await this.ready(); return this.db.query() } }';
+
+        expect(findUnguardedInitAsyncReads(source)).toEqual([])
+    });
+
+    test('still FIRES when no discipline is present', () => {
+        const source = 'class X { async initAsync() { this.db = 1 } read() { return this.db.query() } }';
+
+        expect(findUnguardedInitAsyncReads(source).map(hit => `${hit.method}/${hit.member}`)).toEqual(['read/db'])
+    });
+
+    test('every registry entry carries a reason, and every key still resolves to a real read', () => {
+        expect(REGISTRY.size, 'the baseline to shrink').toBeGreaterThan(0);
+
+        for (const [key, reason] of REGISTRY) {
+            expect(typeof reason, `${key} must carry a reason`).toBe('string');
+            expect(reason.length, `${key}: a bare list is not acceptable`).toBeGreaterThan(60)
+        }
+
+        // A stale key is a silent exemption on a read nothing can reach again.
+        const stale = [...REGISTRY.keys()].filter(key => {
+            const [file, method, member] = key.split('::');
+
+            return !findUnguardedInitAsyncReads(readRepo(file), file)
+                .some(hit => hit.method === method && hit.member === member)
+        });
+
+        expect(stale, 'registry entries whose read no longer exists — delete them').toEqual([])
+    });
+});
+
+/**
+ * @summary Parses one source string and returns its first `ClassBody` node.
+ * @param {String} source
+ * @returns {Object}
+ */
+function parseClassBody(source) {
+    // Deliberately re-parsed here rather than exported from the lint: these tests assert on the
+    // analyser's PUBLIC helpers, and a shared private parser would let a change to it pass unnoticed.
+    const ast = acorn.parse(source, {ecmaVersion: 'latest', sourceType: 'module'});
+
+    let found = null;
+
+    (function walk(node) {
+        if (!node || typeof node !== 'object' || found) return;
+        if (Array.isArray(node)) return node.forEach(walk);
+        if (node.type === 'ClassBody') { found = node; return }
+        Object.keys(node).forEach(key => walk(node[key]))
+    })(ast);
+
+    return found
+}

--- a/test/playwright/unit/ai/scripts/lint/lintWorkflowScanRootParity.spec.mjs
+++ b/test/playwright/unit/ai/scripts/lint/lintWorkflowScanRootParity.spec.mjs
@@ -61,6 +61,11 @@ const REGISTRY = Object.freeze({
         source   : 'declared',
         surface  : ['test/**/*.mjs']
     },
+    'initasync-readiness-lint.yml': {
+        scriptRel: 'buildScripts/util/check-init-async-readiness.mjs',
+        source   : 'declared',
+        surface  : ['ai/**/*.mjs']
+    },
     'atomic-write-shape-lint.yml': {
         scriptRel: 'buildScripts/util/check-atomic-write-shape.mjs',
         source   : 'declared',


### PR DESCRIPTION
Resolves #16644

`core.Base` schedules `initAsync()` on a microtask, so anything it assigns is `undefined` for an unbounded window after `construct()` returns. A method that reads such a member without establishing readiness does not fail loudly — it reads `undefined` and fails somewhere else, later, as a different symptom.

Evidence: L2 (the analyser exercised directly against real in-tree modules for both witnesses, plus mutation-differential on all four corrections and on the requireDb recognition) → L2 required (a static analyser is fully covered by unit execution). Residual: none.

## Two disciplines are valid, and this recognises BOTH

1. **`await this.ready()`** before the read.
2. **A require-style accessor** — a method that tests the member and THROWS when unset (`GraphService.requireDb()`), so every consumer gets a loud attributable failure instead of `undefined`.

Crediting only the first would fail `GraphService`, which is correct code. **AC-3 is the witness for that**: `GraphService` contains no `await this.ready()` anywhere, and passes.

## Deltas from ticket

**The ticket's own third correction retracted its `Out of Scope` line prescribing a regex predicate.** PR #16774 implemented exactly that and was dropped after two review cycles, each closing its named fixtures while the next found a class the scanner could not reach. This is the recorded successor: a parse.

**And the parse made the same mistake four times before it stopped.** The population moved **59 → 41 → 22 → 19**, and not one step weakened the rule — every step corrected a false-positive class of mine that would otherwise have been written into the registry as repo debt:

| # | what I was reporting as a violation | why it is a discipline |
|---|---|---|
| 1 | `this.writer?.publish()` | an optional chain cannot propagate `undefined` onward — the entire defect class |
| 2 | `if (!this.db) return …` | a degraded return is the correct contract for an observation surface whose absence must not kill its caller |
| 3 | `ensureSchema()`'s own `if (!this.db) return` | **the guard was reported for the act of guarding** |
| 4 | `if (!enabled \|\| !this.db) return` | compound guards — named in this ticket's history as a class that defeated the regex predecessor, and my first parse had the identical hole |

The first of those was subtle in a way worth recording: my draft tested `current.optional`, but that flag sits on the **consuming** node, never on `this.writer`, so it credited nothing. All four are pinned as controls and all four are red-proofed.

**Registry: 20 entries — the baseline to shrink.** Every entry names a candidate fix rather than asserting a safety it cannot prove; six `SourceRegistryService` reads share one, because one require-style accessor would cover them all at once. A paired spec fails on any entry whose read no longer exists, so a stale key cannot become a silent exemption on an unreachable line.

**The named witness stays registered on purpose.** The spec asserts the predicate FIRES on it against the tree as it stands, so the guard is *observed failing* — AC-1 — without CI going permanently red.

## Test Evidence

```
npm run test-unit -- unit/ai/buildScripts/util/check-init-async-readiness.spec.mjs
  13 passed

npm run test-unit -- unit/ai/buildScripts/ unit/ai/scripts/lint/
  792 passed

node buildScripts/util/check-init-async-readiness.mjs
  721 ai .mjs file(s) scanned in 383ms, 20 registered, 0 new violations.
```

**Mutation-differential — every correction must be load-bearing or it is decorative:**

| mutation | result |
|---|---|
| drop the optional-chain credit | **1 failed** |
| drop the compound-guard credit | **1 failed** |
| drop the guard's-own-test exclusion | **3 failed** |
| drop the `requireDb()` recognition | **1 failed** |

## What this does NOT establish

Stated in the lint's own header, not only here, because a green run is what people will read:

- **Per-file only.** A member guarded by a caller in another module reads as unguarded.
- **Textual order, not branch dominance.** A `ready()` earlier in the body credits every later read in that method, including paths the `await` cannot dominate.
- **No cross-method following.** A helper that guards internally does not credit its callers.
- It proves a discipline is **present**, never that it is **correct**.

## Post-Merge Validation

- [ ] Nothing outstanding. The guard runs in `lint-staged` and CI from this merge onward; the registry's 20 entries are the burndown, tracked by the entry-staleness spec rather than by anyone remembering.

## Commits

- `47c1f4ab64` — the AST analyser
- `3298350a41` — registry, specs, CI wiring

## Evolution

The ticket asked for an AST analyser because a regex one had failed twice. The analyser was the easy half; four rounds of correcting **my own** false positives were the work, and each round was the same error I have been naming in other people's censuses all week — an instrument's vocabulary reported as the population. The registry is 20 rather than 59 because I kept checking the instrument before booking its output as somebody else's debt.

Authored by Ada (Claude Opus 5, Claude Code). Session 87f453f9-aa80-4487-9ed1-b5d91e052c43.
