### PR TITLE
feat(ai): every script declares the plane it needs, and the declaration is checked (#16929)

### DIFF
--- a/.github/workflows/script-plane-lint.yml
+++ b/.github/workflows/script-plane-lint.yml
@@ -1,0 +1,32 @@
+name: Script Plane Lint
+
+on:
+  pull_request:
+    branches: [dev]
+    paths:
+      - 'ai/scripts/**'
+      - '.github/workflows/script-plane-lint.yml'
+  push:
+    branches: [dev]
+    paths:
+      - 'ai/scripts/**'
+      - '.github/workflows/script-plane-lint.yml'
+
+concurrency:
+  group: script-plane-lint-${{ github.run_attempt == '1' && github.ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+
+      - name: Lint script execution planes (every script declares where it runs, and the declaration is checked)
+        run: node ai/scripts/lint/lint-script-plane.mjs

--- a/ai/scripts/benchmark/gemma4-rem-benchmark.mjs
+++ b/ai/scripts/benchmark/gemma4-rem-benchmark.mjs
@@ -1,3 +1,6 @@
+/**
+ * @plane in-plane
+ */
 import {Command} from 'commander';
 import {mkdir, writeFile} from 'fs/promises';
 import path from 'path';

--- a/ai/scripts/benchmark/helpers/servingCostCore.mjs
+++ b/ai/scripts/benchmark/helpers/servingCostCore.mjs
@@ -18,6 +18,7 @@
  *   schema's own validation, and this module never fabricates one;
  * - aggregation reports COVERAGE (`sampleCount`, `gapCount`, window bounds) so a sparse or
  *   interrupted run reads as exactly that, never as a clean day.
+ * @plane in-plane
  */
 
 /**

--- a/ai/scripts/benchmark/helpers/stats.mjs
+++ b/ai/scripts/benchmark/helpers/stats.mjs
@@ -9,6 +9,7 @@
  *
  * @see ai/scripts/benchmark/gemma4-rem-benchmark.mjs — primary consumer
  * @see test/playwright/unit/ai/scripts/benchmark/stats.spec.mjs — unit tests
+ * @plane in-plane
  */
 
 /**

--- a/ai/scripts/benchmark/helpers/targetSetMeasurementCore.mjs
+++ b/ai/scripts/benchmark/helpers/targetSetMeasurementCore.mjs
@@ -19,6 +19,7 @@
  * @see learn/agentos/decisions/0027-autonomous-data-recovery-actuator.md
  * @see https://github.com/neomjs/neo/issues/15695
  * @see https://github.com/neomjs/neo/issues/15740
+ * @plane in-plane
  */
 
 /**

--- a/ai/scripts/benchmark/keep-alive-probe.mjs
+++ b/ai/scripts/benchmark/keep-alive-probe.mjs
@@ -1,3 +1,6 @@
+/**
+ * @plane in-plane
+ */
 import {Command} from 'commander';
 import Neo from '../../../src/Neo.mjs';
 import '../../../src/core/_export.mjs';

--- a/ai/scripts/benchmark/restore-empty-target-meter.mjs
+++ b/ai/scripts/benchmark/restore-empty-target-meter.mjs
@@ -1,3 +1,6 @@
+/**
+ * @plane host
+ */
 import {Command}                             from 'commander';
 import {execFile}                            from 'node:child_process';
 import {once}                                from 'node:events';

--- a/ai/scripts/benchmark/serving-cost-meter.mjs
+++ b/ai/scripts/benchmark/serving-cost-meter.mjs
@@ -1,3 +1,6 @@
+/**
+ * @plane host
+ */
 import {Command}          from 'commander';
 import {execFile}         from 'node:child_process';
 import {mkdir, writeFile} from 'node:fs/promises';

--- a/ai/scripts/benchmark/setupClass-cold-start.mjs
+++ b/ai/scripts/benchmark/setupClass-cold-start.mjs
@@ -1,3 +1,6 @@
+/**
+ * @plane in-plane
+ */
 import {Command} from 'commander';
 import {mkdir, writeFile} from 'fs/promises';
 import path from 'path';

--- a/ai/scripts/diagnostics/analyzeNlTelemetry.mjs
+++ b/ai/scripts/diagnostics/analyzeNlTelemetry.mjs
@@ -5,6 +5,7 @@
  * of intelligence (trajectories) for RLAIF dataset curation.
  *
  * Usage: node ai/scripts/diagnostics/analyzeNlTelemetry.mjs <sessionId> [--save]
+ * @plane in-plane
  */
 import Neo from '../../../src/Neo.mjs';
 import * as core from '../../../src/core/_export.mjs';

--- a/ai/scripts/diagnostics/audit-discussion-lifecycle.mjs
+++ b/ai/scripts/diagnostics/audit-discussion-lifecycle.mjs
@@ -1,3 +1,6 @@
+/**
+ * @plane host
+ */
 import fs                                     from 'node:fs/promises';
 import path                                   from 'node:path';
 import process                                from 'node:process';

--- a/ai/scripts/diagnostics/bootstrapCodexSandbox.mjs
+++ b/ai/scripts/diagnostics/bootstrapCodexSandbox.mjs
@@ -17,6 +17,7 @@
  * to rerun with escalated permissions or replace a symlink with a local path.
  *
  * @see https://github.com/neomjs/neo/issues/10714
+ * @plane in-plane
  */
 import crypto          from 'node:crypto';
 import fs              from 'node:fs';

--- a/ai/scripts/diagnostics/captureParityLatencyPair.mjs
+++ b/ai/scripts/diagnostics/captureParityLatencyPair.mjs
@@ -14,6 +14,7 @@
  * and host load is recorded. The timed loop only starts/stops already-created runtimes. No build,
  * create, volume reset, or page-cache operation occurs inside a sample. Cleanup removes only the
  * uniquely named Compose project and temp plane this actor created, after every sample is captured.
+ * @plane host
  */
 
 import {execFile}                        from 'node:child_process';

--- a/ai/scripts/diagnostics/check-identity-facts.mjs
+++ b/ai/scripts/diagnostics/check-identity-facts.mjs
@@ -1,4 +1,8 @@
 #!/usr/bin/env node
+
+/**
+ * @plane in-plane
+ */
 import fs              from 'node:fs';
 import path            from 'node:path';
 import process         from 'node:process';

--- a/ai/scripts/diagnostics/check-retired-primitives.mjs
+++ b/ai/scripts/diagnostics/check-retired-primitives.mjs
@@ -1,3 +1,6 @@
+/**
+ * @plane host
+ */
 import {execFileSync} from 'node:child_process';
 import fs             from 'node:fs';
 import path           from 'node:path';

--- a/ai/scripts/diagnostics/check-substrate-size.mjs
+++ b/ai/scripts/diagnostics/check-substrate-size.mjs
@@ -1,3 +1,6 @@
+/**
+ * @plane in-plane
+ */
 import fs   from 'fs';
 import path from 'path';
 

--- a/ai/scripts/diagnostics/conceptNeighborhoodProbe.mjs
+++ b/ai/scripts/diagnostics/conceptNeighborhoodProbe.mjs
@@ -11,6 +11,7 @@
  * writes by contract; the readonly connection makes that mechanical. Sample = the locked plan
  * from the ticket: the Discussion's specimen concept + the two known alias clusters + N curated
  * (verifiedAt set) + N auto (verifiedAt null) drawn live.
+ * @plane in-plane
  */
 
 import Neo             from '../../../src/Neo.mjs';

--- a/ai/scripts/diagnostics/consumerRelevanceCensus.mjs
+++ b/ai/scripts/diagnostics/consumerRelevanceCensus.mjs
@@ -42,6 +42,7 @@
  * UTC instants when two seats must measure the identical corpus). The report header always names
  * the window measured. Generated reports land under `resources/data/reports/`, which is
  * gitignored — derived data is regenerable, never committed.
+ * @plane host
  */
 import {execFileSync}  from 'node:child_process';
 import fs              from 'node:fs';

--- a/ai/scripts/diagnostics/consumerRelevanceMap.mjs
+++ b/ai/scripts/diagnostics/consumerRelevanceMap.mjs
@@ -20,6 +20,7 @@
  * The six seed judgments recorded at ticket creation — the premise falsifier the spec reproduces:
  * fleet tooling = direct/future · agent-cloud + docking + MCP runtime + grid/store = direct/now ·
  * team-facing workflow server + dream/nightshift + skill machinery = enabling.
+ * @plane in-plane
  */
 
 export const SUBSYSTEMS = {

--- a/ai/scripts/diagnostics/detectTruncatedTimelines.mjs
+++ b/ai/scripts/diagnostics/detectTruncatedTimelines.mjs
@@ -27,6 +27,7 @@
  *
  * @see ai/services/github-workflow/sync/IssueSyncer.mjs
  * @see ai/services/github-workflow/queries/issueQueries.mjs
+ * @plane in-plane
  */
 import fs              from 'fs/promises';
 import path            from 'path';

--- a/ai/scripts/diagnostics/devDependencyCensus.mjs
+++ b/ai/scripts/diagnostics/devDependencyCensus.mjs
@@ -43,6 +43,7 @@
  *   node ai/scripts/diagnostics/devDependencyCensus.mjs [--out <path>] [--json <path>]
  *
  * No flags: print the markdown report to stdout. Derived data is regenerable, never committed.
+ * @plane host
  */
 import {execFileSync}                 from 'node:child_process';
 import fs                             from 'node:fs';

--- a/ai/scripts/diagnostics/diagnoseMcpConcurrency.mjs
+++ b/ai/scripts/diagnostics/diagnoseMcpConcurrency.mjs
@@ -35,6 +35,7 @@
  * @see ai/graph/Database.mjs                                 vicinityLoadedNodes mark-without-load
  * @see ai/graph/storage/SQLite.mjs                           WAL pragma (storage layer is concurrency-safe)
  * @see learn/agentos/decisions/0001-cross-process-cache-coherence.md
+ * @plane host
  */
 import {execSync}                     from 'child_process';
 import fs                             from 'fs';

--- a/ai/scripts/diagnostics/fleetHealthcheck.mjs
+++ b/ai/scripts/diagnostics/fleetHealthcheck.mjs
@@ -1,3 +1,6 @@
+/**
+ * @plane in-plane
+ */
 import 'dotenv/config';
 
 import {Command}       from 'commander';

--- a/ai/scripts/diagnostics/gemini-incident-cost-ledger.mjs
+++ b/ai/scripts/diagnostics/gemini-incident-cost-ledger.mjs
@@ -1,3 +1,6 @@
+/**
+ * @plane in-plane
+ */
 import fs              from 'node:fs';
 import path            from 'node:path';
 import process         from 'node:process';

--- a/ai/scripts/diagnostics/genesisProbe.mjs
+++ b/ai/scripts/diagnostics/genesisProbe.mjs
@@ -1,3 +1,6 @@
+/**
+ * @plane host
+ */
 import {Client}                          from '@modelcontextprotocol/sdk/client/index.js';
 import {StreamableHTTPClientTransport}   from '@modelcontextprotocol/sdk/client/streamableHttp.js';
 import {Command, InvalidArgumentError}   from 'commander';

--- a/ai/scripts/diagnostics/lmStudioEmbeddingInstances.mjs
+++ b/ai/scripts/diagnostics/lmStudioEmbeddingInstances.mjs
@@ -1,3 +1,6 @@
+/**
+ * @plane in-plane
+ */
 import 'dotenv/config';
 
 import {Command, InvalidArgumentError} from 'commander';

--- a/ai/scripts/diagnostics/mailboxReadStateProbe.mjs
+++ b/ai/scripts/diagnostics/mailboxReadStateProbe.mjs
@@ -1,3 +1,6 @@
+/**
+ * @plane in-plane
+ */
 import Database        from 'better-sqlite3';
 import path            from 'node:path';
 import {fileURLToPath} from 'node:url';

--- a/ai/scripts/diagnostics/mcpHandlerSignatureCensus.mjs
+++ b/ai/scripts/diagnostics/mcpHandlerSignatureCensus.mjs
@@ -63,6 +63,7 @@
  * No flags: census the current checkout, print the markdown report to stdout. `--fail-on-defects`
  * exits 1 when the defect set (classes 2, 2M, 3) is non-empty — the mechanical-checkability proof
  * for the lint follow-up. Generated reports are derived data: regenerable, never committed.
+ * @plane host
  */
 import {execFileSync}                 from 'node:child_process';
 import fs                             from 'node:fs';

--- a/ai/scripts/diagnostics/mcpHealthcheck.mjs
+++ b/ai/scripts/diagnostics/mcpHealthcheck.mjs
@@ -1,3 +1,6 @@
+/**
+ * @plane in-plane
+ */
 import 'dotenv/config';
 
 import {Command}                       from 'commander';

--- a/ai/scripts/diagnostics/parityLatencyPair.mjs
+++ b/ai/scripts/diagnostics/parityLatencyPair.mjs
@@ -31,6 +31,7 @@
  *
  * Pure and dependency-free: samples arrive as arguments, so the whole contract is testable without a
  * container, a socket, or a clock.
+ * @plane in-plane
  */
 
 /**

--- a/ai/scripts/diagnostics/pilotPlaneTerminal.mjs
+++ b/ai/scripts/diagnostics/pilotPlaneTerminal.mjs
@@ -59,6 +59,7 @@
  * `learn/agentos/tooling/PilotPlaneRunbook.md` carries the provenance — which rule is adopted, which
  * converging proposal is not yet adopted, and permalinks to both. It lives there rather than here so a
  * reader gets one citation that is maintained, instead of decaying references scattered through code.
+ * @plane in-plane
  */
 
 import {UNKNOWN_PLANE_ID, isOpaquePlaneId}     from '../../planeConfig.mjs';

--- a/ai/scripts/diagnostics/planePlacementCensus.mjs
+++ b/ai/scripts/diagnostics/planePlacementCensus.mjs
@@ -1,3 +1,6 @@
+/**
+ * @plane host
+ */
 import {execFileSync}  from 'node:child_process';
 import fs              from 'node:fs';
 import readline        from 'node:readline';

--- a/ai/scripts/diagnostics/printAiConfig.mjs
+++ b/ai/scripts/diagnostics/printAiConfig.mjs
@@ -27,6 +27,7 @@
  * Read-only by construction: resolves and prints; never assigns to any config path. Env faithfulness:
  * the leaf machinery owns env overrides, so a caller-exported `UNIT_TEST_MODE` resolves exactly as
  * it would in the harness; `--unit` merely sets it for you.
+ * @plane in-plane
  */
 import path                           from 'node:path';
 import {fileURLToPath, pathToFileURL} from 'node:url';

--- a/ai/scripts/diagnostics/probePortClaims.mjs
+++ b/ai/scripts/diagnostics/probePortClaims.mjs
@@ -34,6 +34,7 @@
  *
  * @see ai/scripts/diagnostics/diagnoseMcpConcurrency.mjs  sibling probe; `lsof -F` idiom
  * @see ai/scripts/migrations/bootstrapWorktree.mjs        symlinkDataDir dryRun — axes 1-3
+ * @plane host
  */
 
 import {execFileSync} from 'child_process';

--- a/ai/scripts/diagnostics/review-cost-meter.mjs
+++ b/ai/scripts/diagnostics/review-cost-meter.mjs
@@ -1,3 +1,6 @@
+/**
+ * @plane host
+ */
 import {execFileSync}  from 'child_process';
 import {fileURLToPath} from 'url';
 

--- a/ai/scripts/diagnostics/seatCostReport.mjs
+++ b/ai/scripts/diagnostics/seatCostReport.mjs
@@ -1,3 +1,6 @@
+/**
+ * @plane host
+ */
 import fs              from 'node:fs';
 import os              from 'node:os';
 import path            from 'node:path';

--- a/ai/scripts/diagnostics/structureMap.mjs
+++ b/ai/scripts/diagnostics/structureMap.mjs
@@ -11,12 +11,15 @@
  * The generator is intentionally read-only and timestamp-free so its JSON output can be
  * committed or diffed by follow-on architecture linting. It defaults to `ai/`, but accepts a
  * configurable root for tests, migrations, or future architecture programs.
+ * @plane in-plane
  */
 import {Command}       from 'commander';
 import fs              from 'node:fs';
 import path            from 'node:path';
 import process         from 'node:process';
 import {fileURLToPath} from 'node:url';
+
+import {readDeclaredPlane, stripComments} from '../lint/scriptSource.mjs';
 
 const DEFAULT_ROOT = 'ai';
 
@@ -55,7 +58,8 @@ export function createProgram() {
         .description('Emit deterministic JSON describing an Agent OS folder structure.')
         .option('-r, --root <path>', 'Root directory to inspect.', DEFAULT_ROOT)
         .option('--files', 'Include sorted file names per folder.')
-        .option('--loc', 'Include code LOC per file, excluding blank lines and common comment forms.');
+        .option('--loc', 'Include code LOC per file, excluding blank lines and common comment forms.')
+        .option('--plane', 'Include each script\'s declared execution plane, plus a per-folder tally.');
 }
 
 /**
@@ -74,93 +78,19 @@ export function parseArgs(argv=process.argv.slice(2)) {
 }
 
 /**
- * Strips simple block and line comments from one source line for deterministic LOC accounting.
- * This is intentionally lexical, not language-semantic; it is good enough for cohesion budgets
- * without pretending to be a parser for every file type under `ai/`.
- * @param {string} line
- * @param {{jsBlock: boolean, htmlBlock: boolean}} state
- * @param {string} ext
- * @returns {string}
- */
-function stripCommentText(line, state, ext) {
-    let index  = 0,
-        output = '';
-
-    while (index < line.length) {
-        if (state.jsBlock) {
-            const end = line.indexOf('*/', index);
-
-            if (end === -1) {
-                return output;
-            }
-
-            state.jsBlock = false;
-            index         = end + 2;
-            continue;
-        }
-
-        if (state.htmlBlock) {
-            const end = line.indexOf('-->', index);
-
-            if (end === -1) {
-                return output;
-            }
-
-            state.htmlBlock = false;
-            index           = end + 3;
-            continue;
-        }
-
-        const jsStart        = line.indexOf('/*', index),
-              htmlStart      = line.indexOf('<!--', index),
-              slash          = line.indexOf('//', index),
-              hashIndex      = ['.yaml', '.yml', '.sh'].includes(ext) ? line.indexOf('#', index) : -1,
-              hash           = hashIndex !== -1 && line.slice(hashIndex, hashIndex + 2) !== '#!' ? hashIndex : -1,
-              commentIndexes = [jsStart, htmlStart, slash, hash]
-                  .filter(value => value !== -1)
-                  .sort((a, b) => a - b),
-              nextComment    = commentIndexes[0];
-
-        if (nextComment == null) {
-            output += line.slice(index);
-            break;
-        }
-
-        output += line.slice(index, nextComment);
-
-        if (nextComment === jsStart) {
-            state.jsBlock = true;
-            index         = nextComment + 2;
-            continue;
-        }
-
-        if (nextComment === htmlStart) {
-            state.htmlBlock = true;
-            index           = nextComment + 4;
-            continue;
-        }
-
-        break;
-    }
-
-    return output;
-}
-
-/**
  * Counts non-empty, non-comment source lines.
+ *
+ * The comment model itself lives in `ai/scripts/lint/scriptSource.mjs`, shared with the plane
+ * classifier so this map and `lint-script-plane` cannot drift on what counts as a comment.
  * @param {string} content
  * @param {string} [filePath]
  * @returns {number}
  */
 export function countCodeLoc(content, filePath='') {
-    const state = {jsBlock: false, htmlBlock: false},
-          ext   = path.extname(filePath).toLowerCase();
-
-    return content.split(/\r?\n/).reduce((count, line) => {
-        const code = stripCommentText(line, state, ext).trim();
-
-        return code ? count + 1 : count;
-    }, 0);
+    return stripComments(content, filePath)
+        .split('\n')
+        .filter(line => line.trim())
+        .length;
 }
 
 /**
@@ -170,24 +100,60 @@ export function countCodeLoc(content, filePath='') {
  * @param {{includeFiles: boolean, includeLoc: boolean}} options
  * @returns {(Array<string>|Array<Object>|undefined)}
  */
-function buildFileList(folderPath, files, {includeFiles, includeLoc}) {
-    if (!includeFiles && !includeLoc) {
+function buildFileList(folderPath, files, {includeFiles, includeLoc, includePlane, cwd}) {
+    if (!includeFiles && !includeLoc && !includePlane) {
         return undefined;
     }
 
     return files.map(file => {
-        if (!includeLoc) {
+        if (!includeLoc && !includePlane) {
             return file.name;
         }
 
-        const filePath = path.join(folderPath, file.name),
-              content  = fs.readFileSync(filePath, 'utf8');
+        const filePath   = path.join(folderPath, file.name),
+              content    = fs.readFileSync(filePath, 'utf8'),
+              descriptor = {name: file.name};
 
-        return {
-            name   : file.name,
-            codeLoc: countCodeLoc(content, filePath)
-        };
+        if (includeLoc) {
+            descriptor.codeLoc = countCodeLoc(content, filePath);
+        }
+
+        if (includePlane && file.name.endsWith('.mjs')) {
+            // The DECLARED plane is what the map publishes — the reader wants the author's answer to
+            // "can I run this?", not the detector's partial view. `lint-script-plane` is what keeps
+            // the two honest, so the map never has to hedge.
+            descriptor.plane = readDeclaredPlane(content, filePath).plane;
+        }
+
+        return descriptor;
     });
+}
+
+/**
+ * Tallies declared planes across one folder's scripts.
+ *
+ * This is the line that answers the ticket's actual complaint. A folder reporting both a `host` and
+ * an `in-plane` count is a MIXED folder — the verb-named taxonomy said nothing about that, and
+ * finding it previously meant opening every file in the directory.
+ * @param {(Array<string>|Array<Object>|undefined)} fileList
+ * @returns {(Object|undefined)}
+ */
+function tallyPlanes(fileList) {
+    if (!Array.isArray(fileList)) {
+        return undefined;
+    }
+
+    const tally = {};
+
+    fileList.forEach(entry => {
+        const plane = entry?.plane;
+
+        if (plane) {
+            tally[plane] = (tally[plane] || 0) + 1;
+        }
+    });
+
+    return Object.keys(tally).length > 0 ? tally : undefined;
 }
 
 /**
@@ -203,7 +169,8 @@ export function buildStructureMap({
     root         = DEFAULT_ROOT,
     cwd          = process.cwd(),
     includeFiles = false,
-    includeLoc   = false
+    includeLoc   = false,
+    includePlane = false
 } = {}) {
     const rootPath = path.resolve(cwd, root),
           stat     = fs.statSync(rootPath);
@@ -225,10 +192,16 @@ export function buildStructureMap({
             fileCount: files.length
         };
 
-        const fileList = buildFileList(folderPath, files, {includeFiles, includeLoc});
+        const fileList = buildFileList(folderPath, files, {includeFiles, includeLoc, includePlane, cwd});
 
         if (fileList) {
             folder.files = fileList;
+        }
+
+        const planes = includePlane ? tallyPlanes(fileList) : undefined;
+
+        if (planes) {
+            folder.planes = planes;
         }
 
         folders.push(folder);
@@ -262,7 +235,8 @@ function writeStructureMap(options, {
         root        : options.root,
         cwd,
         includeFiles: options.files,
-        includeLoc  : options.loc
+        includeLoc  : options.loc,
+        includePlane: options.plane
     });
 
     stdout.write(`${JSON.stringify(map, null, 2)}\n`);

--- a/ai/scripts/diagnostics/validateConceptEdges.mjs
+++ b/ai/scripts/diagnostics/validateConceptEdges.mjs
@@ -1,3 +1,6 @@
+/**
+ * @plane in-plane
+ */
 import 'dotenv/config';
 import fs from 'fs/promises';
 import path from 'path';

--- a/ai/scripts/diagnostics/walReplayPlan.mjs
+++ b/ai/scripts/diagnostics/walReplayPlan.mjs
@@ -1,3 +1,6 @@
+/**
+ * @plane in-plane
+ */
 import crypto from 'node:crypto';
 
 /**

--- a/ai/scripts/diagnostics/walSnapshotClone.mjs
+++ b/ai/scripts/diagnostics/walSnapshotClone.mjs
@@ -1,3 +1,6 @@
+/**
+ * @plane in-plane
+ */
 import crypto from 'node:crypto';
 import path   from 'node:path';
 

--- a/ai/scripts/diagnostics/walVolumeBaseline.mjs
+++ b/ai/scripts/diagnostics/walVolumeBaseline.mjs
@@ -43,6 +43,7 @@
  * fabricated zero argues for the *cheaper* posture, which is precisely the wrong way for a guard to
  * fail. This module also scans with `node:fs` rather than shelling out, so there is no `find` dialect to
  * be wrong about.
+ * @plane in-plane
  */
 
 import fs   from 'node:fs/promises';

--- a/ai/scripts/fleet/onboardPeer.mjs
+++ b/ai/scripts/fleet/onboardPeer.mjs
@@ -1,4 +1,8 @@
 #!/usr/bin/env node
+
+/**
+ * @plane host
+ */
 import * as acorn                  from 'acorn';
 import {execFileSync}              from 'node:child_process';
 import path                        from 'node:path';

--- a/ai/scripts/lifecycle/backfill-memory-summaries.mjs
+++ b/ai/scripts/lifecycle/backfill-memory-summaries.mjs
@@ -12,6 +12,7 @@
  *
  * @see ai/services/memory-core/MemoryService.backfillMiniSummaries
  * @see ai/scripts/lifecycle/summarize-sessions.mjs
+ * @plane in-plane
  */
 import Neo       from '../../../src/Neo.mjs';
 import AiConfig  from '../../config.mjs';

--- a/ai/scripts/lifecycle/checkAllAgentIdle.mjs
+++ b/ai/scripts/lifecycle/checkAllAgentIdle.mjs
@@ -16,6 +16,7 @@
  *     "coordinator_recommendation": string,
  *     "details": { [identity]: { "lastMemTime": string, "ageMs": number } }
  *   }
+ * @plane in-plane
  */
 import Neo from '../../../src/Neo.mjs';
 import * as core from '../../../src/core/_export.mjs';

--- a/ai/scripts/lifecycle/checkSunsetted.mjs
+++ b/ai/scripts/lifecycle/checkSunsetted.mjs
@@ -56,6 +56,7 @@
  * @see ai/scripts/lifecycle/resumeHarness.mjs       — sunset-mode action dispatcher
  * @see ai/scripts/lifecycle/swarmWakeCooldown.mjs   — idle-out-mode action dispatcher
  * @see learn/agentos/incidents/2026-05-04-runaway-spawn-pattern.md — wake-recovery failure-mode background
+ * @plane in-plane
  */
 import Neo from '../../../src/Neo.mjs';
 import * as core from '../../../src/core/_export.mjs';

--- a/ai/scripts/lifecycle/deferencePhraseMatch.mjs
+++ b/ai/scripts/lifecycle/deferencePhraseMatch.mjs
@@ -8,6 +8,7 @@
  *
  * Consumed by Stop hooks on autonomous turn-ends only. A deference phrase in live operator dialogue
  * can be a legitimate Tier-4 operator ask; the same phrase on an autonomous turn is the slip.
+ * @plane in-plane
  */
 
 /**

--- a/ai/scripts/lifecycle/harnessLifecycle.mjs
+++ b/ai/scripts/lifecycle/harnessLifecycle.mjs
@@ -13,6 +13,7 @@
  *
  * @see ai/scripts/lifecycle/inflightLock.mjs (sibling per-identity primitive)
  * @see ai/scripts/lifecycle/resumeHarness.mjs (consumer)
+ * @plane host
  */
 import fs   from 'fs/promises';
 import path from 'path';

--- a/ai/scripts/lifecycle/harnessRouting.mjs
+++ b/ai/scripts/lifecycle/harnessRouting.mjs
@@ -9,6 +9,7 @@
  * @see ai/graph/identityRoots.mjs
  * @see ai/scripts/lifecycle/resumeHarness.mjs
  * @see ai/daemons/wake/daemon.mjs
+ * @plane in-plane
  */
 import {IDENTITIES}                   from '../../graph/identityRoots.mjs';
 import {normalizeAgentIdentityNodeId} from '../../graph/normalizeAgentIdentityNodeId.mjs';

--- a/ai/scripts/lifecycle/heartbeatLock.mjs
+++ b/ai/scripts/lifecycle/heartbeatLock.mjs
@@ -15,6 +15,7 @@
  *   node ai/scripts/lifecycle/heartbeatLock.mjs -- npx playwright test test/playwright/unit/foo.spec.mjs
  *
  * @see ai/daemons/SwarmHeartbeatService.mjs
+ * @plane host
  */
 import {spawn} from 'child_process';
 import fs      from 'fs-extra';

--- a/ai/scripts/lifecycle/hookProjectionReader.mjs
+++ b/ai/scripts/lifecycle/hookProjectionReader.mjs
@@ -12,6 +12,7 @@
  * invalid projection returns an empty render and the existing bare Stop policy stays untouched.
  * Fail-open therefore applies to the independent hook policy; it never licenses malformed, foreign,
  * stale, or degraded facts to render as current rows.
+ * @plane in-plane
  */
 
 import fs from 'node:fs';

--- a/ai/scripts/lifecycle/idleOutNudge.mjs
+++ b/ai/scripts/lifecycle/idleOutNudge.mjs
@@ -52,6 +52,7 @@
  * @see ai/scripts/lifecycle/swarmWakeCooldown.mjs  — sibling for swarm-wide all-idle case
  * @see ai/scripts/lifecycle/resumeHarness.mjs     — sibling for sunset-restart case
  * @see test/playwright/unit/ai/scripts/idleOutNudge.spec.mjs
+ * @plane in-plane
  */
 import Neo                                                       from '../../../src/Neo.mjs';
 import * as core                                                 from '../../../src/core/_export.mjs';

--- a/ai/scripts/lifecycle/inflightLock.mjs
+++ b/ai/scripts/lifecycle/inflightLock.mjs
@@ -1,3 +1,6 @@
+/**
+ * @plane in-plane
+ */
 import fs from 'fs/promises';
 import path from 'path';
 import { fileURLToPath } from 'url';

--- a/ai/scripts/lifecycle/materialArtifactKey.mjs
+++ b/ai/scripts/lifecycle/materialArtifactKey.mjs
@@ -24,6 +24,7 @@
  *
  * Pure + total throughout: injected strings in, plain objects out, never throws (turn-end hook
  * path), no imports beyond the standard library.
+ * @plane in-plane
  */
 
 /**

--- a/ai/scripts/lifecycle/nightlyE2eDigest.mjs
+++ b/ai/scripts/lifecycle/nightlyE2eDigest.mjs
@@ -6,6 +6,7 @@
  * report, send the A2A digest — while this module is the pure projection it delegates to: walk a Playwright json
  * report into actionable failure pointers, and format the red digest. Keeping it free of the memory-core service
  * imports is what lets the digest logic unit-test in isolation (no GraphService / LifecycleService boot).
+ * @plane in-plane
  */
 
 /**

--- a/ai/scripts/lifecycle/nightlyE2eRunner.mjs
+++ b/ai/scripts/lifecycle/nightlyE2eRunner.mjs
@@ -15,6 +15,7 @@
  *
  * Out of scope (per the ticket): CI integration (the outside-CI discipline stands), fixing the reds (the digest
  * points; owners fix), and unit/integration suites (CI owns those).
+ * @plane host
  */
 import {spawnSync}                                         from 'node:child_process';
 import path                                                from 'node:path';

--- a/ai/scripts/lifecycle/parseLaneState.mjs
+++ b/ai/scripts/lifecycle/parseLaneState.mjs
@@ -14,6 +14,7 @@
  *  - a block with broken JSON → it THROWS (a present-but-malformed emission is a distinct failure from absent).
  *
  * @module Neo.ai.scripts.lifecycle.parseLaneState
+ * @plane in-plane
  */
 
 /**

--- a/ai/scripts/lifecycle/resumeHarness.mjs
+++ b/ai/scripts/lifecycle/resumeHarness.mjs
@@ -10,6 +10,7 @@
  * @see ai/scripts/lifecycle/checkSunsetted.mjs (caller; supplies originSessionId)
  * @see ai/daemons/SwarmHeartbeatService.mjs
  * @see .agents/skills/session-sunset/references/session-sunset-workflow.md §1
+ * @plane host
  */
 import Neo                                                from '../../../src/Neo.mjs';
 import * as core                                          from '../../../src/core/_export.mjs';

--- a/ai/scripts/lifecycle/revalidationSweep.mjs
+++ b/ai/scripts/lifecycle/revalidationSweep.mjs
@@ -22,6 +22,7 @@
  * @see ai/graph/identityRoots.mjs                        — participationStatus source-of-truth
  * @see .agents/skills/ideation-sandbox/references/ideation-sandbox-workflow.md §6.5 — invocation discipline
  * @see .agents/skills/ideation-sandbox/audits/consensus-mandate.md §quorum-rule — Tier-2 rule background
+ * @plane host
  */
 
 import { execFileSync }              from 'child_process';

--- a/ai/scripts/lifecycle/stopHookDecision.mjs
+++ b/ai/scripts/lifecycle/stopHookDecision.mjs
@@ -5,6 +5,7 @@
  * decision semantics so Claude and Codex cannot drift on the valid-terminal / loop-guard gate.
  *
  * @module Neo.ai.scripts.lifecycle.stopHookDecision
+ * @plane in-plane
  */
 import {buildDeferenceReminder, detectDeferencePhrase} from './deferencePhraseMatch.mjs';
 

--- a/ai/scripts/lifecycle/summarize-sessions.mjs
+++ b/ai/scripts/lifecycle/summarize-sessions.mjs
@@ -10,6 +10,7 @@
  * removed as an obsolete boot/healthcheck-timeout safeguard.
  *
  * @see ai/services/memory-core/SessionService.summarizeSessions
+ * @plane in-plane
  */
 // Neo namespace bootstrap (entry-point invariant) — this script is an orchestrator
 // spawn-child entry point (`spawn(node, [summarize-sessions.mjs])`). Each spawned

--- a/ai/scripts/lifecycle/swarmWakeCooldown.mjs
+++ b/ai/scripts/lifecycle/swarmWakeCooldown.mjs
@@ -4,6 +4,7 @@
  *
  * Prevents swarm heartbeat from spamming wake events by enforcing a 10-minute cooldown
  * TTL between WAKE messages.
+ * @plane in-plane
  */
 import fs from 'fs-extra';
 import path from 'path';

--- a/ai/scripts/lifecycle/sweepExpiredTasks.mjs
+++ b/ai/scripts/lifecycle/sweepExpiredTasks.mjs
@@ -18,6 +18,7 @@
  * @example
  *   node ai/scripts/lifecycle/sweepExpiredTasks.mjs
  *   # → {"success":true,"sweptCount":3}
+ * @plane in-plane
  */
 // IMPORTANT: `Neo` MUST be imported BEFORE any module that uses `Neo.gatekeep()` /
 // `Neo.setupClass()` at module-load time (e.g. `src/core/Compare.mjs`, transitively

--- a/ai/scripts/lifecycle/validateLaneStateTerminal.mjs
+++ b/ai/scripts/lifecycle/validateLaneStateTerminal.mjs
@@ -10,6 +10,7 @@
  * (that is the separate, deferred external-enforcement layer).
  *
  * @module Neo.ai.scripts.lifecycle.validateLaneStateTerminal
+ * @plane in-plane
  */
 
 const PR_REF_RE = /\b(?:PR|pull request)\s*#?(\d+)\b/i;

--- a/ai/scripts/lifecycle/validateMergeReady.mjs
+++ b/ai/scripts/lifecycle/validateMergeReady.mjs
@@ -11,6 +11,7 @@
  * that a PR is strict-merge-ready, so a stale reviewer contract is not reported as a green surface.
  *
  * @module Neo.ai.scripts.lifecycle.validateMergeReady
+ * @plane in-plane
  */
 
 /**

--- a/ai/scripts/lifecycle/wakeSafetyGate.mjs
+++ b/ai/scripts/lifecycle/wakeSafetyGate.mjs
@@ -39,6 +39,7 @@
  * @see ai/scripts/lifecycle/resumeHarness.mjs     — gate consumer (direct fresh-session-spawn)
  * @see ai/scripts/lifecycle/checkSunsetted.mjs    — companion predicate
  * @see test/playwright/unit/ai/scripts/wakeSafetyGate.spec.mjs
+ * @plane in-plane
  */
 import fs                from 'fs/promises';
 import path              from 'path';

--- a/ai/scripts/lifecycle/windowsBatchSpawn.mjs
+++ b/ai/scripts/lifecycle/windowsBatchSpawn.mjs
@@ -6,6 +6,7 @@
  * quoting logic local to Neo instead of adding a broad subprocess dependency.
  *
  * @see ai/scripts/lifecycle/resumeHarness.mjs
+ * @plane in-plane
  */
 
 /**

--- a/ai/scripts/lint/check-front-door-fingerprint.mjs
+++ b/ai/scripts/lint/check-front-door-fingerprint.mjs
@@ -9,6 +9,7 @@
  * so this guard keeps it true BY CONSTRUCTION: check mode fails CI on any drift; `--fix` rewrites the
  * declared numbers to the current fixed point (replacing digits changes the byte count, so the fix
  * iterates until declared === actual — bounded, converges because the digit-width stabilizes).
+ * @plane in-plane
  */
 
 import fs              from 'fs';

--- a/ai/scripts/lint/lint-adr-seam-table.mjs
+++ b/ai/scripts/lint/lint-adr-seam-table.mjs
@@ -11,6 +11,7 @@
  *
  * The composition ADR is located by CONTENT (the seam-table marker), not by filename/number, so
  * renumbering or renaming never silently disables the guard.
+ * @plane in-plane
  */
 
 import fs              from 'fs';

--- a/ai/scripts/lint/lint-agents.mjs
+++ b/ai/scripts/lint/lint-agents.mjs
@@ -22,6 +22,7 @@
  *
  * @see learn/agentos/decisions/0011-substrate-numbering-convention.md (amendment in progress)
  * @see feedback_agents_md_24kib_hard_cap (review discipline anchor)
+ * @plane host
  */
 import {execFileSync}    from 'node:child_process';
 import path              from 'node:path';

--- a/ai/scripts/lint/lint-config-template-ssot.mjs
+++ b/ai/scripts/lint/lint-config-template-ssot.mjs
@@ -38,6 +38,7 @@
  * longer matches a live violation fails the lint, keeping the burndown honest.
  *
  * @see learn/agentos/decisions  The AiConfig reactive Provider SSOT decision record.
+ * @plane in-plane
  */
 import fs                             from 'node:fs';
 import path                           from 'node:path';

--- a/ai/scripts/lint/lint-fleet-vocabulary-parity.mjs
+++ b/ai/scripts/lint/lint-fleet-vocabulary-parity.mjs
@@ -12,6 +12,7 @@
  * Consumed three ways: lint-staged (pre-commit, vocabulary globs), the CI lint job, and the unit
  * spec `test/playwright/unit/apps/agentos/config/fleetVocabularyParity.spec.mjs` — which also
  * red-proves the comparator against an induced drift, so the mechanism itself is witnessed.
+ * @plane in-plane
  */
 
 import * as authorityCockpit from '../../services/fleet/fleetCockpitStatus.mjs';

--- a/ai/scripts/lint/lint-guard-ci-parity.mjs
+++ b/ai/scripts/lint/lint-guard-ci-parity.mjs
@@ -37,6 +37,7 @@
  * The population is `lint-staged` only. The `ai/scripts/lint/lint-*.mjs` family has its own
  * coverage question and is a separate lane; it is named in the registry's `$schema.outOfScope` so
  * the boundary is recorded rather than implied.
+ * @plane in-plane
  */
 
 import fs        from 'fs';

--- a/ai/scripts/lint/lint-guides.mjs
+++ b/ai/scripts/lint/lint-guides.mjs
@@ -34,6 +34,7 @@
  *
  * @see .agents/skills/guide-authoring/references/guide-authoring-bar.md (the discipline half)
  * @see learn/agentos/decisions/0008-skill-anatomy-and-authoring-contract.md
+ * @plane in-plane
  */
 import {readFileSync, readdirSync, existsSync} from 'node:fs';
 import path                                    from 'node:path';

--- a/ai/scripts/lint/lint-identity-engine-coherence.mjs
+++ b/ai/scripts/lint/lint-identity-engine-coherence.mjs
@@ -74,6 +74,7 @@
  * This guard exists because the engine is a session-scoped fact stored in identity-scoped records.
  * When the era layer makes engine facts span-carrying and single-sourced, these three places
  * collapse into one and this lint should be RETIRED with them rather than kept for its own sake.
+ * @plane in-plane
  */
 
 import fs                 from 'node:fs';

--- a/ai/scripts/lint/lint-identity-vocabulary.mjs
+++ b/ai/scripts/lint/lint-identity-vocabulary.mjs
@@ -33,6 +33,7 @@
  * There is no `--fix`. The correct substitution depends on which hemisphere a line is about —
  * "engine" for runtime-facing text, "Neo.mjs" for text about knowledge of the project — and a flag
  * that guessed would launder one category error into another.
+ * @plane in-plane
  */
 
 import fs              from 'node:fs';

--- a/ai/scripts/lint/lint-mcp-test-locations.mjs
+++ b/ai/scripts/lint/lint-mcp-test-locations.mjs
@@ -6,6 +6,7 @@
  * The legacy `test/playwright/mcp/` tree is deprecated and may contain only
  * explicitly grandfathered files until they are migrated. This lint makes that
  * convention mechanical so new tests cannot silently land in the old tree.
+ * @plane in-plane
  */
 import fs              from 'node:fs';
 import path            from 'node:path';

--- a/ai/scripts/lint/lint-openapi-service-parity.mjs
+++ b/ai/scripts/lint/lint-openapi-service-parity.mjs
@@ -72,6 +72,7 @@
  * artifacts, different join and different failure mode; the coverage is complementary rather than
  * overlapping, which is why both exist. Shared AST helpers are imported from that module so the two
  * cannot drift into disagreeing about what a parameter is.
+ * @plane in-plane
  */
 
 import fs              from 'node:fs';

--- a/ai/scripts/lint/lint-retry-bounds.mjs
+++ b/ai/scripts/lint/lint-retry-bounds.mjs
@@ -57,6 +57,7 @@
  * Production `.mjs` under `ai/`, `src/`, `apps/`, `buildScripts/`. Specs and tests are excluded: a
  * test asserting backoff arithmetic is not a production retry site, and including them would make
  * the registry churn with every fixture.
+ * @plane in-plane
  */
 import fs              from 'fs';
 import path            from 'path';

--- a/ai/scripts/lint/lint-script-plane.mjs
+++ b/ai/scripts/lint/lint-script-plane.mjs
@@ -1,0 +1,185 @@
+#!/usr/bin/env node
+
+/**
+ * @summary Requires every `ai/scripts` script to declare the execution plane it needs, and fails
+ * when that declaration contradicts what the script's own dependencies prove.
+ *
+ * A script's plane decides whether it is usable at all: per Local Runtime Parity a client topology
+ * has no host shell and no Docker socket. The `ai/scripts` taxonomy is verb-named (`maintenance`,
+ * `diagnostics`) and answers a different question, so before this guard the only way to learn where
+ * a script runs was to open it — across 144 files in 9 directories, 5 of them mixed.
+ *
+ * **This is a comparator, not a convention.** The declaration is read from the script's COMMENTS and
+ * the evidence from its CODE, and those two texts are disjoint by construction — so no amount of
+ * confident documentation can move the evidence. A README would rot on the first commit with nothing
+ * detecting the rot, and a naming convention is graded by whoever follows it — both are rules whose
+ * only evidence of compliance is the performer's own account of it.
+ *
+ * Only the checkable direction is enforced. `declares in-plane` + host evidence is a contradiction —
+ * the script claims to run where it demonstrably cannot. The reverse is NOT: an operator-run script
+ * may legitimately import plane modules and talk to services over the network. The full asymmetry
+ * argument, and the 15 measured scripts that shell out AND import a plane module, are documented in
+ * `scriptSource.mjs`.
+ *
+ * @plane in-plane
+ */
+
+import fs              from 'node:fs';
+import path            from 'node:path';
+import {fileURLToPath} from 'node:url';
+
+import {PLANE_VALUES, classifyPlane, readDeclaredPlane, stripComments} from './scriptSource.mjs';
+
+const __filename = fileURLToPath(import.meta.url),
+      SCAN_ROOT  = 'ai/scripts';
+
+/**
+ * Recursively collects every `.mjs` file under a root.
+ *
+ * The population is read from the FILESYSTEM rather than from a registry, which is what makes the
+ * coverage assertion self-maintaining: a newly added script is in scope the moment it exists, so it
+ * cannot pass by being absent from a list somebody forgot to update.
+ * @param {string} absoluteRoot
+ * @param {string} cwd
+ * @returns {string[]} Repo-relative POSIX paths, sorted.
+ */
+export function collectScripts(absoluteRoot, cwd) {
+    const found = [];
+
+    function visit(directory) {
+        fs.readdirSync(directory, {withFileTypes: true})
+            .sort((a, b) => a.name.localeCompare(b.name))
+            .forEach(entry => {
+                const entryPath = path.join(directory, entry.name);
+
+                if (entry.isDirectory()) {
+                    visit(entryPath);
+                } else if (entry.name.endsWith('.mjs')) {
+                    found.push(path.relative(cwd, entryPath).split(path.sep).join('/'));
+                }
+            });
+    }
+
+    visit(absoluteRoot);
+
+    return found.sort();
+}
+
+/**
+ * Checks one script's declaration against its evidence.
+ * @param {Object} params
+ * @param {string} params.file Repo-relative path.
+ * @param {string} params.content Raw source.
+ * @param {string} [params.cwd]
+ * @returns {(Object|null)} A finding, or `null` when the script is consistent.
+ */
+export function auditScript({file, content, cwd=process.cwd()}) {
+    const {plane: declared, invalid, conflicting} = readDeclaredPlane(content, file);
+
+    if (conflicting) {
+        return {
+            file,
+            rule   : 'CONFLICTING_TAG',
+            message: `declares more than one @plane value. Exactly one of ${PLANE_VALUES.join(' | ')} is legal.`
+        };
+    }
+
+    if (invalid.length > 0 && !declared) {
+        return {
+            file,
+            rule   : 'INVALID_TAG',
+            message: `@plane ${invalid[0]} is not a legal value. Use ${PLANE_VALUES.join(' or ')}.`
+        };
+    }
+
+    if (!declared) {
+        return {
+            file,
+            rule   : 'MISSING_TAG',
+            message: `no @plane declaration. Add \`@plane host\` if it needs the operator's shell, Docker socket or home directory, otherwise \`@plane in-plane\`.`
+        };
+    }
+
+    const {plane: evidenced, evidence} = classifyPlane({file, code: stripComments(content, file), cwd});
+
+    if (declared === 'in-plane' && evidenced === 'host') {
+        return {
+            file,
+            rule   : 'CONTRADICTION',
+            message: `declares @plane in-plane but ${evidence.join('; ')} — that is a host requirement, so a client topology cannot run it.`
+        };
+    }
+
+    return null;
+}
+
+/**
+ * Audits every script under the scan root.
+ * @param {Object} [params]
+ * @param {string} [params.cwd]
+ * @returns {{findings: Object[], scanned: number, declared: number}}
+ */
+export function lintScriptPlanes({cwd=process.cwd()} = {}) {
+    const files    = collectScripts(path.resolve(cwd, SCAN_ROOT), cwd),
+          findings = [];
+
+    files.forEach(file => {
+        const content = fs.readFileSync(path.resolve(cwd, file), 'utf8'),
+              finding = auditScript({file, content, cwd});
+
+        if (finding) {
+            findings.push(finding);
+        }
+    });
+
+    // A script is DECLARED iff it carries exactly one legal tag — precisely the complement of the
+    // three declaration rules. CONTRADICTION is not among them: that script declared, and lied.
+    const undeclared = findings.filter(
+        finding => ['MISSING_TAG', 'INVALID_TAG', 'CONFLICTING_TAG'].includes(finding.rule)
+    ).length;
+
+    return {findings, scanned: files.length, declared: files.length - undeclared};
+}
+
+/**
+ * Runs the lint and reports.
+ * @param {Object} [params]
+ * @param {string} [params.cwd]
+ * @param {Object} [params.console]
+ * @returns {{exitCode: number}}
+ */
+export function runLint({cwd=process.cwd(), console: out=console} = {}) {
+    const {findings, scanned, declared} = lintScriptPlanes({cwd});
+
+    if (findings.length === 0) {
+        out.log(`[lint-script-plane] OK — ${declared}/${scanned} scripts declare an execution plane, none contradicted by its own dependencies.`);
+
+        return {exitCode: 0};
+    }
+
+    out.error(`[lint-script-plane] FAILED — ${findings.length} of ${scanned} scripts (${declared} declared):`);
+
+    findings.forEach(finding => {
+        out.error(`  ${finding.rule}  ${finding.file}`);
+        out.error(`      ${finding.message}`);
+    });
+
+    return {exitCode: 1};
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === __filename) {
+    if (process.argv.includes('--help')) {
+        console.log('Usage: node ai/scripts/lint/lint-script-plane.mjs');
+        console.log('');
+        console.log(`Every .mjs under ${SCAN_ROOT} declares where it can run, and the declaration is checked:`);
+        console.log('  1. MISSING_TAG      every script carries @plane host or @plane in-plane');
+        console.log('  2. INVALID_TAG      no other value is legal — two values, never a catch-all third');
+        console.log('  3. CONFLICTING_TAG  a script declares exactly one plane');
+        console.log('  4. CONTRADICTION    @plane in-plane is refuted by a host dependency in the same file');
+        process.exit(0);
+    }
+
+    const {exitCode} = runLint();
+
+    process.exit(exitCode);
+}

--- a/ai/scripts/lint/lint-skill-manifest.mjs
+++ b/ai/scripts/lint/lint-skill-manifest.mjs
@@ -5,6 +5,7 @@
  * `SKILL.md` frontmatter stays runtime-canonical. The manifest mirrors that
  * data for CI and governance checks; this script enforces one-way consistency
  * plus local substrate-budget and harness-symlink invariants.
+ * @plane host
  */
 import fs                                                            from 'fs/promises';
 import {existsSync, lstatSync, readFileSync, readlinkSync, statSync} from 'fs';

--- a/ai/scripts/lint/lint-tree-json.mjs
+++ b/ai/scripts/lint/lint-tree-json.mjs
@@ -42,6 +42,7 @@
  * filesystem. The CLI wrapper supplies a real `fs`-backed probe.
  *
  * Usage: `node ai/scripts/lint/lint-tree-json.mjs` (no arguments; validates the whole file).
+ * @plane in-plane
  */
 import fs               from 'node:fs';
 import path             from 'node:path';

--- a/ai/scripts/lint/scriptSource.mjs
+++ b/ai/scripts/lint/scriptSource.mjs
@@ -1,0 +1,331 @@
+/**
+ * @module ai/scripts/lint/scriptSource
+ * @summary Static facts read out of a script's source text: which comments it carries, which modules
+ * it imports, and which execution plane its dependencies prove it needs.
+ *
+ * ## Why this module exists
+ *
+ * A script's execution plane decides whether it is usable at all. Per Local Runtime Parity a client
+ * topology has **no host shell and no Docker socket**, so a script that shells out is dead weight
+ * there — and `ai/scripts` encodes the VERB (`maintenance`, `diagnostics`) and never the plane.
+ *
+ * The fix is a comparator rather than a convention: every script DECLARES its plane in a `@plane`
+ * tag, and this module derives, independently, what the script's real dependencies prove. A
+ * contradiction between the two fails `lint-script-plane`.
+ *
+ * **The two artifacts cannot collapse into one, by construction:** the declaration is read from the
+ * COMMENTS and the evidence is read from the CODE, and {@link stripComments} guarantees those two
+ * texts are disjoint. Writing a more confident comment can never change the evidence.
+ *
+ * ## Conviction is deliberately asymmetric
+ *
+ * Only one direction is checkable, and building the symmetric version would convict correct files:
+ *
+ * | declared | evidence | verdict | why |
+ * |---|---|---|---|
+ * | `in-plane` | host | **contradiction** | it claims to run where it demonstrably cannot |
+ * | `host` | plane imports | pass | an operator-run script may talk to services over the network |
+ * | either | none | pass | detection is silent; the declaration is the only source |
+ *
+ * **Host evidence proves a requirement. Plane evidence never proves sufficiency.** Measured on the
+ * 144-file corpus: 15 scripts both shell out to `docker` AND import a plane module — `backup.mjs`
+ * and `uploadKnowledgeBase.mjs` import a config module only to learn WHICH container to act on.
+ * Importing config is not running in the plane, so host evidence dominates and there is no third
+ * `either` value to argue about.
+ *
+ * ## Silence is a legitimate answer
+ *
+ * 68 of 144 scripts carry no detectable evidence of either plane. That is not a gap to be closed by
+ * a cleverer detector — a pure helper genuinely needs nothing. Those files are exactly why the tag
+ * exists: `diagnostics/seatCostReport.mjs` reads `~/.kimi-code/sessions` through `os.homedir()` and
+ * is unambiguously host-edge, and no import-based detector can see it. The declaration states what
+ * detection cannot, and the lint re-checks it on every future commit — so the moment such a file
+ * grows an `execSync`, the stale declaration reds.
+ *
+ * @see ai/scripts/lint/lint-script-plane.mjs — the enforcing lint
+ * @see ai/scripts/diagnostics/structureMap.mjs — consumes this to emit a generated plane map
+ * @plane in-plane
+ */
+
+import path from 'node:path';
+
+/**
+ * The only two legal `@plane` values.
+ *
+ * Deliberately two, never three. An `either` value becomes the default nobody argues with and the
+ * comparator loses its teeth — a genuinely ambiguous script is a finding to resolve, not a category
+ * to file it under.
+ * @type {string[]}
+ */
+export const PLANE_VALUES = ['host', 'in-plane'];
+
+/**
+ * Removes comment text from one line, tracking multi-line block state across calls.
+ *
+ * Lifted verbatim from `structureMap.mjs`, which needed exactly this to count code LOC. Relocated
+ * here rather than duplicated so the repo carries ONE comment model: the plane classifier and the
+ * LOC counter now disagree about what a comment is only if both change together.
+ *
+ * Intentionally lexical, not language-semantic; good enough for cohesion budgets and dependency
+ * evidence without pretending to be a parser for every file type under `ai/`.
+ * @param {string} line
+ * @param {{jsBlock: boolean, htmlBlock: boolean}} state
+ * @param {string} ext
+ * @returns {string}
+ */
+function stripCommentText(line, state, ext) {
+    let index  = 0,
+        output = '';
+
+    while (index < line.length) {
+        if (state.jsBlock) {
+            const end = line.indexOf('*/', index);
+
+            if (end === -1) {
+                return output;
+            }
+
+            state.jsBlock = false;
+            index         = end + 2;
+            continue;
+        }
+
+        if (state.htmlBlock) {
+            const end = line.indexOf('-->', index);
+
+            if (end === -1) {
+                return output;
+            }
+
+            state.htmlBlock = false;
+            index           = end + 3;
+            continue;
+        }
+
+        const jsStart        = line.indexOf('/*', index),
+              htmlStart      = line.indexOf('<!--', index),
+              slash          = line.indexOf('//', index),
+              hashIndex      = ['.yaml', '.yml', '.sh'].includes(ext) ? line.indexOf('#', index) : -1,
+              hash           = hashIndex !== -1 && line.slice(hashIndex, hashIndex + 2) !== '#!' ? hashIndex : -1,
+              commentIndexes = [jsStart, htmlStart, slash, hash]
+                  .filter(value => value !== -1)
+                  .sort((a, b) => a - b),
+              nextComment    = commentIndexes[0];
+
+        if (nextComment == null) {
+            output += line.slice(index);
+            break;
+        }
+
+        output += line.slice(index, nextComment);
+
+        if (nextComment === jsStart) {
+            state.jsBlock = true;
+            index         = nextComment + 2;
+            continue;
+        }
+
+        if (nextComment === htmlStart) {
+            state.htmlBlock = true;
+            index           = nextComment + 4;
+            continue;
+        }
+
+        break;
+    }
+
+    return output;
+}
+
+/**
+ * Returns the source with every comment removed, so prose can never be read as evidence.
+ *
+ * This is load-bearing rather than tidy. `maintenance/restore.mjs` mentions `compose` twice — both
+ * times in a JSDoc paragraph explaining bind-mount paths — and a detector that skipped this step
+ * would convict a file for what its documentation says.
+ *
+ * The stripper is line-oriented and not string-literal aware, so it also truncates a line at a `//`
+ * that falls inside a string. That over-removal is conservative in the right direction: it can only
+ * hide evidence, never manufacture it, and a false negative leaves the declaration standing while a
+ * false positive would fail a correct file. Measured against a string-literal-aware stripper across
+ * all 144 scripts: **zero classification disagreements**, so the simpler shared model is kept.
+ * @param {string} content
+ * @param {string} [filePath]
+ * @returns {string}
+ */
+export function stripComments(content, filePath='') {
+    const state = {jsBlock: false, htmlBlock: false},
+          ext   = path.extname(filePath).toLowerCase();
+
+    return content.split(/\r?\n/).map(line => stripCommentText(line, state, ext)).join('\n');
+}
+
+const IMPORT_SPECIFIER = /(?:^|\n)\s*import\s[^;]*?from\s*['"]([^'"]+)['"]|(?:^|\n)\s*import\s*['"]([^'"]+)['"]|\bimport\s*\(\s*['"]([^'"]+)['"]/g;
+
+/**
+ * Collects every module specifier the code imports, static and dynamic.
+ * @param {string} code Comment-stripped source.
+ * @returns {string[]}
+ */
+export function importSpecifiers(code) {
+    const specifiers = [];
+    let   match;
+
+    IMPORT_SPECIFIER.lastIndex = 0;
+
+    while ((match = IMPORT_SPECIFIER.exec(code))) {
+        specifiers.push(match[1] ?? match[2] ?? match[3]);
+    }
+
+    return specifiers;
+}
+
+const CHILD_PROCESS = /^(node:)?child_process$/,
+      DOCKER_TOKEN  = /['"`](docker|docker-compose|compose)['"`]|docker-compose[\w.-]*\.ya?ml/,
+      HOME_DIR      = /\bos\.homedir\(\)|process\.env\.HOME\b/,
+      PROCESS_KILL  = /\bprocess\.kill\s*\(/,
+      PLANE_ROOTS   = ['ai/services/', 'ai/mcp/server/'],
+      PLANE_LEAF    = /[/\\](AiConfig|StorageRouter)\.mjs$/;
+
+/**
+ * Derives what a script's real dependencies prove about the plane it needs.
+ *
+ * Returns `'host'`, `'in-plane'`, or `null` when the source proves nothing either way — `null` is a
+ * normal outcome for 68 of the 144 scripts and never an error.
+ * @param {Object} params
+ * @param {string} params.file Repo-relative path, used to resolve relative import specifiers.
+ * @param {string} params.code Comment-stripped source.
+ * @param {string} [params.cwd]
+ * @returns {{plane: (string|null), evidence: string[]}}
+ */
+export function classifyPlane({file, code, cwd=process.cwd()}) {
+    const specifiers = importSpecifiers(code),
+          hostHits   = [];
+
+    specifiers.forEach(specifier => {
+        if (CHILD_PROCESS.test(specifier)) {
+            hostHits.push(`imports '${specifier}'`);
+        }
+    });
+
+    const dockerMatch = code.match(DOCKER_TOKEN);
+
+    if (dockerMatch) {
+        hostHits.push(`references ${dockerMatch[0]}`);
+    }
+
+    if (HOME_DIR.test(code)) {
+        hostHits.push('reads the operator home directory');
+    }
+
+    if (PROCESS_KILL.test(code)) {
+        hostHits.push('signals host processes via process.kill');
+    }
+
+    // Host evidence dominates: needing a shell is a proof of requirement, and a plane import
+    // alongside it is usually just a config read. See the module header's asymmetry table.
+    if (hostHits.length > 0) {
+        return {plane: 'host', evidence: hostHits};
+    }
+
+    const planeHits = [];
+
+    specifiers.forEach(specifier => {
+        if (!specifier.startsWith('.')) {
+            return;
+        }
+
+        const resolved = path.relative(cwd, path.resolve(path.dirname(file), specifier)).split(path.sep).join('/');
+
+        // Resolved, never substring-matched: `./mcpHealthcheck.mjs` is a sibling SCRIPT, and a
+        // naive `mcp` test read it as a plane service.
+        if (PLANE_ROOTS.some(root => resolved.startsWith(root)) || PLANE_LEAF.test(resolved)) {
+            planeHits.push(`imports '${specifier}' → ${resolved}`);
+        }
+    });
+
+    return planeHits.length > 0 ? {plane: 'in-plane', evidence: planeHits} : {plane: null, evidence: []};
+}
+
+/**
+ * Returns the file's own header comment — the FIRST block comment, before any line of code.
+ *
+ * The `@plane` declaration describes the whole file, so it belongs in the file's own header block.
+ * Bounding the search this tightly is what makes two different mistakes detectable:
+ *
+ * - **Scanning the whole file** makes any script that DOCUMENTS planes declare them.
+ *   `lint-script-plane.mjs` prints both legal values in its help text and flagged itself as
+ *   self-contradictory until the search was bounded.
+ * - **Scanning every leading comment** accepts a tag parked on the first FUNCTION's JSDoc, because
+ *   the run of comments before the first code line includes it. A declaration sitting on `median()`
+ *   is wrong even though a looser reader would happily find it — and the looser reader cannot
+ *   report what it is willing to accept.
+ * @param {string} content
+ * @param {string} [filePath]
+ * @returns {string}
+ */
+export function headerRegion(content, filePath='') {
+    const state  = {jsBlock: false, htmlBlock: false},
+          ext    = path.extname(filePath).toLowerCase(),
+          lines  = content.split(/\r?\n/),
+          header = [];
+
+    let entered = false;
+
+    for (let index = 0; index < lines.length; index++) {
+        const line = lines[index];
+
+        // A shebang is not code for this purpose; it precedes the JSDoc block in most CLI scripts.
+        if (index === 0 && line.startsWith('#!')) {
+            header.push(line);
+            continue;
+        }
+
+        if (stripCommentText(line, state, ext).trim()) {
+            break;
+        }
+
+        header.push(line);
+
+        if (state.jsBlock) {
+            entered = true;
+        } else if (entered) {
+            // The first block comment just closed on this line — the header ends with it.
+            break;
+        }
+    }
+
+    return header.join('\n');
+}
+
+const PLANE_TAG = /@plane\s+(\S+)/g;
+
+/**
+ * Reads the `@plane` declaration out of a script's header comment.
+ *
+ * Reads RAW text on purpose — the tag lives in a comment, which is exactly what
+ * {@link stripComments} discards before evidence is derived. That disjointness is what makes the
+ * declaration and the evidence two independent artifacts rather than one claim restated twice.
+ * @param {string} content Raw source, comments included.
+ * @param {string} [filePath]
+ * @returns {{plane: (string|null), invalid: string[], conflicting: boolean}}
+ */
+export function readDeclaredPlane(content, filePath='') {
+    const values = [];
+    let   match;
+
+    PLANE_TAG.lastIndex = 0;
+
+    while ((match = PLANE_TAG.exec(headerRegion(content, filePath)))) {
+        values.push(match[1]);
+    }
+
+    const invalid  = values.filter(value => !PLANE_VALUES.includes(value)),
+          declared = [...new Set(values.filter(value => PLANE_VALUES.includes(value)))];
+
+    return {
+        plane      : declared.length === 1 ? declared[0] : null,
+        invalid,
+        conflicting: declared.length > 1
+    };
+}

--- a/ai/scripts/maintenance/aggregate-temporal-summary.mjs
+++ b/ai/scripts/maintenance/aggregate-temporal-summary.mjs
@@ -10,6 +10,7 @@
  *
  * @see ai/daemons/temporal-summary/TemporalSummaryAggregationService.mjs — the aggregation cycle this drives.
  * @see ai/daemons/orchestrator/taskDefinitions.mjs — the supervised-child task definition that spawns this.
+ * @plane in-plane
  */
 
 // Neo namespace bootstrap (entry-point invariant): `Neo` + `core/_export` populate `globalThis.Neo` so the

--- a/ai/scripts/maintenance/auditConceptSpineAliases.mjs
+++ b/ai/scripts/maintenance/auditConceptSpineAliases.mjs
@@ -1,3 +1,6 @@
+/**
+ * @plane in-plane
+ */
 import {Command}       from 'commander';
 import fs              from 'fs-extra';
 import path            from 'path';

--- a/ai/scripts/maintenance/auditGraphIntegrity.mjs
+++ b/ai/scripts/maintenance/auditGraphIntegrity.mjs
@@ -1,3 +1,6 @@
+/**
+ * @plane in-plane
+ */
 import 'dotenv/config';
 import {Command}       from 'commander';
 import fsExtra         from 'fs-extra';

--- a/ai/scripts/maintenance/backup.mjs
+++ b/ai/scripts/maintenance/backup.mjs
@@ -1,3 +1,6 @@
+/**
+ * @plane host
+ */
 import {execFile}      from 'child_process';
 import fs              from 'fs-extra';
 import path            from 'path';

--- a/ai/scripts/maintenance/backupCorruptionTimeline.mjs
+++ b/ai/scripts/maintenance/backupCorruptionTimeline.mjs
@@ -1,3 +1,6 @@
+/**
+ * @plane in-plane
+ */
 import {program}                      from 'commander';
 import fs                             from 'fs-extra';
 import path                           from 'path';

--- a/ai/scripts/maintenance/backupStagingResidueCore.mjs
+++ b/ai/scripts/maintenance/backupStagingResidueCore.mjs
@@ -1,3 +1,6 @@
+/**
+ * @plane in-plane
+ */
 import fs   from 'fs-extra';
 import path from 'path';
 

--- a/ai/scripts/maintenance/buildKbAgentFaqs.mjs
+++ b/ai/scripts/maintenance/buildKbAgentFaqs.mjs
@@ -1,3 +1,6 @@
+/**
+ * @plane in-plane
+ */
 import '../../../src/Neo.mjs';
 import * as core        from '../../../src/core/_export.mjs';
 import KBRecorderService from '../../mcp/server/knowledge-base/services/KBRecorderService.mjs';

--- a/ai/scripts/maintenance/businessMetricsProbeCore.mjs
+++ b/ai/scripts/maintenance/businessMetricsProbeCore.mjs
@@ -1,3 +1,6 @@
+/**
+ * @plane in-plane
+ */
 import {Command} from 'commander';
 import {
     createMetricId,

--- a/ai/scripts/maintenance/checkChromaIntegrity.mjs
+++ b/ai/scripts/maintenance/checkChromaIntegrity.mjs
@@ -1,3 +1,6 @@
+/**
+ * @plane host
+ */
 import {program}       from 'commander';
 import {ChromaClient}  from 'chromadb';
 import {execFile}      from 'child_process';

--- a/ai/scripts/maintenance/checkDetectionRetentionSla.mjs
+++ b/ai/scripts/maintenance/checkDetectionRetentionSla.mjs
@@ -41,6 +41,7 @@
  * `0` — the invariant holds. Anything else is a breach, including an input the guard could not
  * resolve: an unresolvable window is reported as a failure, never assumed benign. The output names
  * the required ceiling so the message carries the remedy rather than only the symptom.
+ * @plane in-plane
  */
 
 import {pathToFileURL} from 'url';

--- a/ai/scripts/maintenance/communityActivityShadowProbeCore.mjs
+++ b/ai/scripts/maintenance/communityActivityShadowProbeCore.mjs
@@ -1,3 +1,6 @@
+/**
+ * @plane in-plane
+ */
 import {createHash} from 'crypto';
 import {Command}    from 'commander';
 

--- a/ai/scripts/maintenance/communityBatchPushClient.mjs
+++ b/ai/scripts/maintenance/communityBatchPushClient.mjs
@@ -1,3 +1,6 @@
+/**
+ * @plane in-plane
+ */
 // Neo namespace bootstrap (entry-point invariant) — hosted community batch push client.
 import 'dotenv/config';
 import {Command}                from 'commander';

--- a/ai/scripts/maintenance/communitySourceOperator.mjs
+++ b/ai/scripts/maintenance/communitySourceOperator.mjs
@@ -1,3 +1,6 @@
+/**
+ * @plane in-plane
+ */
 // Neo namespace bootstrap (entry-point invariant) — co-located community source control plane.
 import 'dotenv/config';
 import {Command}             from 'commander';

--- a/ai/scripts/maintenance/compactGraphLog.mjs
+++ b/ai/scripts/maintenance/compactGraphLog.mjs
@@ -1,3 +1,6 @@
+/**
+ * @plane in-plane
+ */
 // Bootstrap Neo namespace BEFORE importing runtime config; `ConfigProvider` consumes core utilities
 // through `Neo.gatekeep()` / `Neo.isObject()` once the config module is loaded.
 import Neo             from '../../../src/Neo.mjs';

--- a/ai/scripts/maintenance/defragChromaDB.mjs
+++ b/ai/scripts/maintenance/defragChromaDB.mjs
@@ -1,3 +1,6 @@
+/**
+ * @plane host
+ */
 import {program}                      from 'commander';
 import {ChromaClient}                 from 'chromadb';
 import {execSync}                     from 'child_process';

--- a/ai/scripts/maintenance/defragSQLiteDB.mjs
+++ b/ai/scripts/maintenance/defragSQLiteDB.mjs
@@ -1,3 +1,6 @@
+/**
+ * @plane host
+ */
 import path from 'path';
 import fs from 'fs-extra';
 import { fileURLToPath } from 'url';

--- a/ai/scripts/maintenance/deploymentMigrationCore.mjs
+++ b/ai/scripts/maintenance/deploymentMigrationCore.mjs
@@ -39,6 +39,7 @@
  *
  * No Neo import, no Docker call, no filesystem read: every refusal branch is reachable from a plain
  * object, so the gate is unit-testable without a container or a plane.
+ * @plane in-plane
  */
 
 /**

--- a/ai/scripts/maintenance/detectionRetentionSla.mjs
+++ b/ai/scripts/maintenance/detectionRetentionSla.mjs
@@ -21,6 +21,7 @@
  * live config shapes into these two durations, and `checkDetectionRetentionSla.mjs` reads the config
  * SSOT and fails CI on a breach. Keep this module free of config shape and of process exits — that
  * separation is why its verdict stays unit-testable against explicit inputs.
+ * @plane in-plane
  */
 
 /**

--- a/ai/scripts/maintenance/detectionRetentionSlaInputs.mjs
+++ b/ai/scripts/maintenance/detectionRetentionSlaInputs.mjs
@@ -30,6 +30,7 @@
  * type-error reads as a bug in the guard rather than as the policy breach it is. Resolving it to an
  * explicit breach reason turns a stack trace into an actionable sentence, and keeps the throw path
  * meaning what it should — a shape the guard never expected.
+ * @plane in-plane
  */
 
 /**

--- a/ai/scripts/maintenance/downloadKnowledgeBase.mjs
+++ b/ai/scripts/maintenance/downloadKnowledgeBase.mjs
@@ -1,3 +1,6 @@
+/**
+ * @plane host
+ */
 import {execFile}      from 'child_process';
 import fs              from 'fs-extra';
 import os              from 'os';

--- a/ai/scripts/maintenance/exportMemoryQuarantine.mjs
+++ b/ai/scripts/maintenance/exportMemoryQuarantine.mjs
@@ -1,3 +1,6 @@
+/**
+ * @plane in-plane
+ */
 import {Command}       from 'commander';
 import fs              from 'fs-extra';
 import path            from 'path';

--- a/ai/scripts/maintenance/graphLifecycleReport.mjs
+++ b/ai/scripts/maintenance/graphLifecycleReport.mjs
@@ -1,3 +1,6 @@
+/**
+ * @plane in-plane
+ */
 import 'dotenv/config';
 import {Command}       from 'commander';
 import path            from 'path';

--- a/ai/scripts/maintenance/ingestTenant.mjs
+++ b/ai/scripts/maintenance/ingestTenant.mjs
@@ -1,3 +1,6 @@
+/**
+ * @plane in-plane
+ */
 // Neo namespace bootstrap (entry-point invariant) — KB data-plane CLI.
 // `InstanceManager` binds Neo.find/findFirst/get aliases + consumes pre-singleton
 // `Neo.idMap`; required for any consumer of the Neo singleton API.

--- a/ai/scripts/maintenance/kbPushClient.mjs
+++ b/ai/scripts/maintenance/kbPushClient.mjs
@@ -1,3 +1,6 @@
+/**
+ * @plane in-plane
+ */
 // Neo namespace bootstrap (entry-point invariant) - tenant-side KB push client.
 // Mirrors ai/scripts/maintenance/ingestTenant.mjs so this CLI can use Neo's MCP client
 // wrapper from a tenant checkout or CI job.

--- a/ai/scripts/maintenance/knowledgeBaseArtifact.mjs
+++ b/ai/scripts/maintenance/knowledgeBaseArtifact.mjs
@@ -1,3 +1,6 @@
+/**
+ * @plane in-plane
+ */
 import fs       from 'fs-extra';
 import path     from 'path';
 import readline from 'readline';

--- a/ai/scripts/maintenance/materializeDeploymentPrescriptions.mjs
+++ b/ai/scripts/maintenance/materializeDeploymentPrescriptions.mjs
@@ -1,4 +1,8 @@
 #!/usr/bin/env node
+
+/**
+ * @plane host
+ */
 import {execFile}               from 'node:child_process';
 import {createHash, randomUUID} from 'node:crypto';
 import * as fs                  from 'node:fs/promises';

--- a/ai/scripts/maintenance/migrateDeployment.mjs
+++ b/ai/scripts/maintenance/migrateDeployment.mjs
@@ -1,4 +1,8 @@
 #!/usr/bin/env node
+
+/**
+ * @plane host
+ */
 import fs              from 'fs-extra';
 import os              from 'node:os';
 import path            from 'path';

--- a/ai/scripts/maintenance/migrationCensusReport.mjs
+++ b/ai/scripts/maintenance/migrationCensusReport.mjs
@@ -1,3 +1,6 @@
+/**
+ * @plane in-plane
+ */
 import 'dotenv/config';
 import {Command}       from 'commander';
 import path            from 'path';

--- a/ai/scripts/maintenance/offHostSync.mjs
+++ b/ai/scripts/maintenance/offHostSync.mjs
@@ -1,3 +1,6 @@
+/**
+ * @plane host
+ */
 import {execFile} from 'node:child_process';
 
 import {

--- a/ai/scripts/maintenance/probeBusinessMetrics.mjs
+++ b/ai/scripts/maintenance/probeBusinessMetrics.mjs
@@ -1,3 +1,6 @@
+/**
+ * @plane host
+ */
 // Neo namespace bootstrap (entry-point invariant) — business-metric ingestion probe CLI.
 // `InstanceManager` binds Neo.find/findFirst/get aliases + consumes pre-singleton
 // `Neo.idMap`; required for any consumer of the Neo singleton API.

--- a/ai/scripts/maintenance/probeCollectionQueryHealth.mjs
+++ b/ai/scripts/maintenance/probeCollectionQueryHealth.mjs
@@ -1,3 +1,6 @@
+/**
+ * @plane in-plane
+ */
 import 'dotenv/config';
 
 import {

--- a/ai/scripts/maintenance/probeCommunityActivityShadow.mjs
+++ b/ai/scripts/maintenance/probeCommunityActivityShadow.mjs
@@ -1,3 +1,6 @@
+/**
+ * @plane in-plane
+ */
 // Neo namespace bootstrap (entry-point invariant) — community-activity shadow probe CLI.
 // `InstanceManager` binds Neo.find/findFirst/get aliases + consumes pre-singleton
 // `Neo.idMap`; required before loading a Neo singleton service.

--- a/ai/scripts/maintenance/purgeNoContentGraphMemories.mjs
+++ b/ai/scripts/maintenance/purgeNoContentGraphMemories.mjs
@@ -1,3 +1,6 @@
+/**
+ * @plane in-plane
+ */
 // Bootstrap Neo namespace BEFORE importing Memory Core services; runtime config evaluates
 // through the Neo singleton namespace during service setup.
 import Neo             from '../../../src/Neo.mjs';

--- a/ai/scripts/maintenance/purgeTestCollections.mjs
+++ b/ai/scripts/maintenance/purgeTestCollections.mjs
@@ -1,3 +1,6 @@
+/**
+ * @plane in-plane
+ */
 import {program}                       from 'commander';
 import {ChromaClient}                  from 'chromadb';
 import fs                              from 'fs-extra';

--- a/ai/scripts/maintenance/recreateGraphDb.mjs
+++ b/ai/scripts/maintenance/recreateGraphDb.mjs
@@ -1,3 +1,6 @@
+/**
+ * @plane in-plane
+ */
 import fs              from 'fs';
 import path            from 'path';
 import Neo             from '../../../src/Neo.mjs';

--- a/ai/scripts/maintenance/redeployPreflight.mjs
+++ b/ai/scripts/maintenance/redeployPreflight.mjs
@@ -1,3 +1,6 @@
+/**
+ * @plane host
+ */
 import fs              from 'fs-extra';
 import path            from 'path';
 import {execFile}      from 'node:child_process';

--- a/ai/scripts/maintenance/repairMemoryCoreStoredEmbeddings.mjs
+++ b/ai/scripts/maintenance/repairMemoryCoreStoredEmbeddings.mjs
@@ -19,6 +19,7 @@
  * explicit authorization); this module is the pure extraction logic, unit-tested against mocked Chroma.
  *
  * @module Neo.ai.scripts.maintenance.repairMemoryCoreStoredEmbeddings
+ * @plane in-plane
  */
 
 import {bytesToTokens}              from '../../services/memory-core/helpers/consumerFrictionHelper.mjs';

--- a/ai/scripts/maintenance/repairUnprojectedSessions.mjs
+++ b/ai/scripts/maintenance/repairUnprojectedSessions.mjs
@@ -1,3 +1,6 @@
+/**
+ * @plane in-plane
+ */
 import {pathToFileURL} from 'url';
 
 export const DEFAULT_BATCH_SIZE = 500;

--- a/ai/scripts/maintenance/restore.mjs
+++ b/ai/scripts/maintenance/restore.mjs
@@ -1,3 +1,6 @@
+/**
+ * @plane in-plane
+ */
 import fs              from 'fs-extra';
 import path            from 'path';
 import {fileURLToPath} from 'url';

--- a/ai/scripts/maintenance/syncGithubWorkflow.mjs
+++ b/ai/scripts/maintenance/syncGithubWorkflow.mjs
@@ -1,3 +1,6 @@
+/**
+ * @plane in-plane
+ */
 // ---------------------------------------------------------------------------------------------
 // DELIBERATE, TEMPORARY SDK-BOUNDARY EXCEPTION — retirement is enforced mechanically, see below.
 //

--- a/ai/scripts/maintenance/syncGithubWorkflowBranchGuard.mjs
+++ b/ai/scripts/maintenance/syncGithubWorkflowBranchGuard.mjs
@@ -1,3 +1,6 @@
+/**
+ * @plane host
+ */
 import {execFile}  from 'child_process';
 import path        from 'path';
 import {promisify} from 'util';

--- a/ai/scripts/maintenance/syncKnowledgeBase.mjs
+++ b/ai/scripts/maintenance/syncKnowledgeBase.mjs
@@ -1,3 +1,6 @@
+/**
+ * @plane in-plane
+ */
 // Neo namespace bootstrap (entry-point invariant) — orchestrator spawn-child.
 // `InstanceManager` binds Neo.find/findFirst/get aliases + consumes pre-singleton
 // `Neo.idMap`; required for any consumer of the Neo singleton API.

--- a/ai/scripts/maintenance/syncTenantRepos.mjs
+++ b/ai/scripts/maintenance/syncTenantRepos.mjs
@@ -25,6 +25,7 @@
  *
  * @see ai/daemons/orchestrator/services/TenantRepoSyncService.mjs
  * @see learn/agentos/cloud-deployment/TenantIngestionModel.md
+ * @plane in-plane
  */
 
 import Neo             from '../../../src/Neo.mjs';

--- a/ai/scripts/maintenance/uploadKnowledgeBase.mjs
+++ b/ai/scripts/maintenance/uploadKnowledgeBase.mjs
@@ -1,3 +1,6 @@
+/**
+ * @plane host
+ */
 import {execFile}      from 'child_process';
 import fs              from 'fs-extra';
 import os              from 'os';

--- a/ai/scripts/migrations/backfillChromaSharedUserId.mjs
+++ b/ai/scripts/migrations/backfillChromaSharedUserId.mjs
@@ -38,6 +38,7 @@
  *
  * @see ai/mcp/server/shared/services/RequestContextService.mjs
  * @see ai/services/memory-core/SummaryService.mjs
+ * @plane in-plane
  */
 
 import path            from 'node:path';

--- a/ai/scripts/migrations/bootstrapWorktree.mjs
+++ b/ai/scripts/migrations/bootstrapWorktree.mjs
@@ -119,6 +119,7 @@
  * @see AGENTS_STARTUP.md
  * @see .gitignore
  * @see {@link materializeServerConfigTemplate}
+ * @plane host
  */
 import {execFile}      from 'child_process';
 import fs              from 'fs/promises';

--- a/ai/scripts/migrations/canonicalizeStoredAgentIdentities.mjs
+++ b/ai/scripts/migrations/canonicalizeStoredAgentIdentities.mjs
@@ -18,6 +18,7 @@
  * one SQLite transaction. Quiesce graph writers and back up the database before
  * applying; restart all graph caches afterward. Read-side storage variants may
  * retire only after the applied migration reports a clean census.
+ * @plane in-plane
  */
 
 import path from 'node:path';

--- a/ai/scripts/migrations/migrate-discussions-b1.mjs
+++ b/ai/scripts/migrations/migrate-discussions-b1.mjs
@@ -1,3 +1,6 @@
+/**
+ * @plane in-plane
+ */
 import fs from 'fs/promises';
 import path from 'path';
 import { fileURLToPath } from 'url';

--- a/ai/scripts/migrations/migrateMemoryCore.mjs
+++ b/ai/scripts/migrations/migrateMemoryCore.mjs
@@ -1,3 +1,6 @@
+/**
+ * @plane in-plane
+ */
 import Neo                 from '../../../src/Neo.mjs';
 import * as core           from '../../../src/core/_export.mjs';
 import MC_Config           from '../../mcp/server/memory-core/config.mjs';

--- a/ai/scripts/migrations/migrateWakeSubscriptions.mjs
+++ b/ai/scripts/migrations/migrateWakeSubscriptions.mjs
@@ -15,6 +15,7 @@
  *   node ai/scripts/migrations/migrateWakeSubscriptions.mjs --skip-generic-cleanup
  *   node ai/scripts/migrations/migrateWakeSubscriptions.mjs --db <path> # override SQLite path
  *   node ai/scripts/migrations/migrateWakeSubscriptions.mjs --help      # print usage
+ * @plane in-plane
  */
 
 import {program}       from 'commander';

--- a/ai/scripts/migrations/normalizeGraphIdentities.mjs
+++ b/ai/scripts/migrations/normalizeGraphIdentities.mjs
@@ -43,6 +43,7 @@
  *     *alias* `AgentIdentity` nodes + re-points their edges; it does not touch memory-row RLS scope.
  *
  * @see learn/agentos/tooling/MemoryCoreMcpAuth.md §Identity Normalization Migration
+ * @plane in-plane
  */
 
 import path from 'node:path';

--- a/ai/scripts/migrations/priorityBackfill.mjs
+++ b/ai/scripts/migrations/priorityBackfill.mjs
@@ -25,6 +25,7 @@
  * 2. **Drain phase** (skippable): runs `LazyEdgeDrainer.drainQueue` to retry any queued
  *    provenance edges (`MENTIONED_IN`/`DISCUSSED_IN`/`REFERENCED_BY`) whose
  *    endpoints may now exist in the graph after the ingest phase.
+ * @plane in-plane
  */
 import 'dotenv/config';
 import {

--- a/ai/scripts/migrations/rebucketArchive.mjs
+++ b/ai/scripts/migrations/rebucketArchive.mjs
@@ -18,6 +18,7 @@
  *
  * @see ai/services/github-workflow/sync/IssueSyncer.mjs (migrateArchiveBuckets)
  * @see ai/services/github-workflow/SyncService.mjs (facade)
+ * @plane in-plane
  */
 import {GH_SyncService} from '../../services.host.mjs';
 

--- a/ai/scripts/migrations/refetchStaleDiscussions.mjs
+++ b/ai/scripts/migrations/refetchStaleDiscussions.mjs
@@ -13,6 +13,7 @@
  *
  * @see ai/scripts/migrations/refetchStalePulls.mjs
  * @see ai/services/github-workflow/SyncService.mjs
+ * @plane in-plane
  */
 import {GH_SyncService} from '../../services.host.mjs';
 

--- a/ai/scripts/migrations/refetchStalePulls.mjs
+++ b/ai/scripts/migrations/refetchStalePulls.mjs
@@ -13,6 +13,7 @@
  *
  * @see ai/scripts/migrations/refetchTruncatedIssues.mjs
  * @see ai/services/github-workflow/SyncService.mjs
+ * @plane in-plane
  */
 import {GH_SyncService} from '../../services.host.mjs';
 

--- a/ai/scripts/migrations/refetchTruncatedIssues.mjs
+++ b/ai/scripts/migrations/refetchTruncatedIssues.mjs
@@ -17,6 +17,7 @@
  * @see ai/scripts/diagnostics/detectTruncatedTimelines.mjs
  * @see ai/services/github-workflow/SyncService.mjs
  * @see https://github.com/neomjs/neo/issues/10090
+ * @plane in-plane
  */
 import {GH_SyncService} from '../../services.host.mjs';
 

--- a/ai/scripts/migrations/renameAgentIdentities.mjs
+++ b/ai/scripts/migrations/renameAgentIdentities.mjs
@@ -29,6 +29,7 @@
  * Idempotent: re-running after `--apply` is safe. If both old and new graph nodes
  * exist, the old node is merged into the new node and the old `createdAt` is
  * preserved on the canonical node.
+ * @plane in-plane
  */
 
 import path            from 'node:path';

--- a/ai/scripts/runners/roadmapPlanner.mjs
+++ b/ai/scripts/runners/roadmapPlanner.mjs
@@ -1,3 +1,6 @@
+/**
+ * @plane host
+ */
 import fs from 'fs';
 import path from 'path';
 import { execSync } from 'child_process';

--- a/ai/scripts/runners/runAgent.mjs
+++ b/ai/scripts/runners/runAgent.mjs
@@ -1,3 +1,6 @@
+/**
+ * @plane in-plane
+ */
 import Neo               from '../../../src/Neo.mjs';
 import * as core         from '../../../src/core/_export.mjs';
 import InstanceManager   from '../../../src/manager/Instance.mjs';

--- a/ai/scripts/runners/runSandman.mjs
+++ b/ai/scripts/runners/runSandman.mjs
@@ -1,3 +1,6 @@
+/**
+ * @plane in-plane
+ */
 import Neo           from '../../../src/Neo.mjs';
 import AiConfig      from '../../config.mjs';
 import * as core     from '../../../src/core/_export.mjs';

--- a/ai/scripts/setup/cohortAdmissibility.mjs
+++ b/ai/scripts/setup/cohortAdmissibility.mjs
@@ -76,6 +76,7 @@
  * parent process does not change the rendered service either. A `docker compose config` render shows
  * it staying `container-plane` while an interpolated control such as `NEO_DEPLOY_HOSTNAME` picks up
  * its override normally — so the render, not the export, is the boundary that settles both questions.
+ * @plane in-plane
  */
 
 /**

--- a/ai/scripts/setup/generateRosterOnboarding.mjs
+++ b/ai/scripts/setup/generateRosterOnboarding.mjs
@@ -1,4 +1,8 @@
 #!/usr/bin/env node
+
+/**
+ * @plane host
+ */
 import fs                             from 'node:fs';
 import path                           from 'node:path';
 import {execFileSync}                 from 'node:child_process';

--- a/ai/scripts/setup/initServerConfigs.mjs
+++ b/ai/scripts/setup/initServerConfigs.mjs
@@ -1,3 +1,6 @@
+/**
+ * @plane host
+ */
 import {execFileSync}  from 'child_process';
 import fs              from 'fs-extra';
 import path            from 'path';

--- a/ai/scripts/setup/migrateConfigOverlay.mjs
+++ b/ai/scripts/setup/migrateConfigOverlay.mjs
@@ -23,6 +23,7 @@
  *
  * Scope: the ROOT overlay pair (`ai/configBase.mjs` ← `ai/config.mjs`) by default, or one
  * explicit per-server pair via `--config-root <server-dir>`.
+ * @plane in-plane
  */
 import fs                             from 'fs';
 import path                           from 'path';

--- a/ai/scripts/setup/seedAgentIdentities.mjs
+++ b/ai/scripts/setup/seedAgentIdentities.mjs
@@ -42,6 +42,7 @@
  * stamp only for entries the registry does not describe.
  *
  * Usage: node ai/scripts/setup/seedAgentIdentities.mjs
+ * @plane in-plane
  */
 
 import path            from 'node:path';

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
         "ai:lint-mcp-test-locations"           : "node ./ai/scripts/lint/lint-mcp-test-locations.mjs",
         "ai:lint-openapi-service-parity"       : "node ./ai/scripts/lint/lint-openapi-service-parity.mjs",
         "ai:lint-retry-bounds"                 : "node ./ai/scripts/lint/lint-retry-bounds.mjs",
+        "ai:lint-script-plane"                 : "node ./ai/scripts/lint/lint-script-plane.mjs",
         "ai:lint-skill-manifest"               : "node ./ai/scripts/lint/lint-skill-manifest.mjs",
         "ai:lint-tree-json"                    : "node ./ai/scripts/lint/lint-tree-json.mjs",
         "ai:skill-size-report"                 : "node ./ai/scripts/lint/lint-skill-manifest.mjs --report-sizes",

--- a/test/playwright/unit/ai/scripts/lint/lintScriptPlane.spec.mjs
+++ b/test/playwright/unit/ai/scripts/lint/lintScriptPlane.spec.mjs
@@ -1,0 +1,144 @@
+import {expect, test} from '@playwright/test';
+
+import {auditScript, lintScriptPlanes}                                 from '../../../../../../ai/scripts/lint/lint-script-plane.mjs';
+import {classifyPlane, headerRegion, readDeclaredPlane, stripComments} from '../../../../../../ai/scripts/lint/scriptSource.mjs';
+
+/**
+ * A script's execution plane decides whether it is usable at all — a client topology has no host
+ * shell and no Docker socket — and `ai/scripts` names its directories after the VERB, so the plane
+ * was previously discoverable only by opening the file.
+ *
+ * The guard is a comparator, not a convention: the declaration is read from the COMMENTS and the
+ * evidence from the CODE, and those two texts are disjoint by construction. These arms exist to
+ * prove the comparison actually fires, that it fires for the right reason, and that it does NOT
+ * fire on the two shapes that made the naive detector convict correct files.
+ */
+
+const file = 'ai/scripts/maintenance/probe.mjs';
+
+const script = (header, body='export const x = 1;\n') => `/**\n * @summary probe.\n${header}\n */\n${body}`;
+
+test.describe('lint-script-plane — declaration vs dependency comparator (#16929)', () => {
+    test('a script with NO declaration fails, and the message prescribes the two legal values', () => {
+        const finding = auditScript({file, content: '/**\n * @summary probe.\n */\nexport const x = 1;\n'});
+
+        expect(finding.rule).toBe('MISSING_TAG');
+        expect(finding.message).toContain('@plane host');
+        expect(finding.message).toContain('@plane in-plane');
+    });
+
+    test('a declaration of in-plane contradicted by a host dependency FAILS, quoting the evidence', () => {
+        const finding = auditScript({
+            file,
+            content: script(' * @plane in-plane', "import {execSync} from 'child_process';\n")
+        });
+
+        expect(finding.rule).toBe('CONTRADICTION');
+        expect(finding.message).toContain("imports 'child_process'");
+    });
+
+    test('NON-VACUITY — a correct host script and a correct in-plane script both pass', () => {
+        // Without this arm a lint that rejected every script would go green on both arms above.
+        expect(auditScript({
+            file,
+            content: script(' * @plane host', "import {execSync} from 'child_process';\n")
+        })).toBeNull();
+
+        expect(auditScript({
+            file,
+            content: script(' * @plane in-plane', 'export const pure = 1;\n')
+        })).toBeNull();
+    });
+
+    test('ASYMMETRY — a host declaration is NOT refuted by plane imports', () => {
+        // Only one direction is checkable. An operator-run script may legitimately import plane
+        // modules and reach services over the network, so `host` + plane evidence must pass.
+        // Measured on the corpus: 15 scripts shell out to docker AND import a plane module —
+        // `backup.mjs` imports a config module only to learn WHICH container to act on. Enforcing
+        // the symmetric rule would fail every one of them.
+        expect(auditScript({
+            file,
+            content: script(' * @plane host', "import cfg from '../../mcp/server/knowledge-base/config.mjs';\nimport {execSync} from 'child_process';\n")
+        })).toBeNull();
+    });
+
+    test('PROSE IS NOT EVIDENCE — a comment mentioning compose cannot convict a file', () => {
+        // `maintenance/restore.mjs` mentions `compose` twice, both times in a JSDoc paragraph about
+        // bind-mount paths. The pre-comment-strip detector classified it host on that basis alone.
+        const content = `/**\n * @summary probe.\n * Paths are relative to the compose project directory, so a docker run elsewhere differs.\n * @plane in-plane\n */\nexport const x = 1;\n`;
+
+        expect(auditScript({file, content})).toBeNull();
+    });
+
+    test('A SIBLING SCRIPT IS NOT A PLANE MODULE — imports are resolved, never substring-matched', () => {
+        // `./mcpHealthcheck.mjs` is a sibling SCRIPT; a naive `mcp` substring test read it as an
+        // in-plane service import and manufactured a dual-plane category that does not exist.
+        const {plane} = classifyPlane({
+            file: 'ai/scripts/diagnostics/probe.mjs',
+            code: "import {readToolJson} from './mcpHealthcheck.mjs';",
+            cwd : process.cwd()
+        });
+
+        expect(plane).toBeNull();
+    });
+
+    test('the declaration must live in the file header, not on the first function', () => {
+        // The run of comments before the first code line includes the first FUNCTION's JSDoc. A
+        // reader bounded only by "before any code" accepts a file-level declaration parked on
+        // median() — and cannot report what it is willing to accept.
+        const content = '/**\n * @summary probe.\n */\n\n/**\n * Median.\n * @plane in-plane\n */\nexport function median() {}\n';
+
+        expect(auditScript({file, content}).rule).toBe('MISSING_TAG');
+    });
+
+    test('two conflicting declarations fail as CONFLICTING_TAG, never silently pick one', () => {
+        const content = '/**\n * @plane host\n * @plane in-plane\n */\nexport const x = 1;\n';
+
+        expect(auditScript({file, content}).rule).toBe('CONFLICTING_TAG');
+    });
+
+    test('an unrecognised value is INVALID_TAG — there is no third plane to fall back on', () => {
+        // `either` is deliberately illegal: it would become the default nobody argues with and the
+        // comparator would lose its teeth.
+        const finding = auditScript({file, content: script(' * @plane either')});
+
+        expect(finding.rule).toBe('INVALID_TAG');
+        expect(finding.message).toContain('either');
+    });
+
+    test('a script that DOCUMENTS the tag does not thereby declare it', () => {
+        // lint-script-plane.mjs prints both legal values in its own help text and flagged itself as
+        // self-contradictory until the search was bounded to the header block.
+        const content = `/**\n * @summary probe.\n * @plane in-plane\n */\nconsole.log('use @plane host or @plane in-plane');\n`;
+
+        expect(auditScript({file, content})).toBeNull();
+        expect(readDeclaredPlane(content, file).plane).toBe('in-plane');
+    });
+
+    test('the shebang does not end the header region', () => {
+        const content = '#!/usr/bin/env node\n/**\n * @plane host\n */\nexport const x = 1;\n';
+
+        expect(headerRegion(content, file)).toContain('@plane host');
+        expect(auditScript({file, content})).toBeNull();
+    });
+
+    test('COVERAGE — every script in the live tree declares a plane and none is contradicted', () => {
+        // The population is read from the filesystem, not a registry, so a newly added script is in
+        // scope the moment it exists and cannot pass by being missing from a list.
+        const {findings, scanned, declared} = lintScriptPlanes({cwd: process.cwd()});
+
+        expect(findings).toEqual([]);
+        expect(declared).toBe(scanned);
+        expect(scanned).toBeGreaterThan(100);
+    });
+
+    test('stripComments removes comment text while preserving line structure', () => {
+        // countCodeLoc in structureMap.mjs now counts non-blank lines of this output, so a stripper
+        // that collapsed lines would silently change every LOC number in the map.
+        const stripped = stripComments('const a = 1; // trailing\n/* block */\nconst b = 2;\n', 'x.mjs');
+
+        expect(stripped.split('\n').length).toBe(4);
+        expect(stripped).toContain('const a = 1;');
+        expect(stripped).not.toContain('trailing');
+    });
+});


### PR DESCRIPTION
Resolves #16929

`ai/scripts` names its directories after the **verb** and never the **execution plane** — and the plane is what decides whether a script is usable at all. Per Local Runtime Parity a client topology has no host shell and no Docker socket, so finding out where a script runs meant opening it, across 144 files in 9 directories.

Every script now declares `@plane host` or `@plane in-plane`, and `lint-script-plane` compares that declaration against what the file's real dependencies prove.

Evidence: L2 (13 spec arms; two mutations each convicting a different half; the classifier measured against the live 146-file corpus) → L2 required (no runtime-verify AC). No residuals.

## The gate is a comparison, not a judgement

The declaration is read from the **comments**; the evidence is read from the **code**. `stripComments` guarantees those two texts are disjoint, so **no amount of confident documentation can move the evidence**. A README rots on the first commit with nothing detecting the rot, and a naming convention is graded by whoever follows it — both are rules whose only proof of compliance is the performer's own account of it.

## Two corrections to my own ticket, made before implementation

Both were measured at `origin/dev` before a line of the lint was written, and both are folded into the ticket body.

**1. The ticket's measurement table was wrong.** It showed `maintenance` as 6 host-edge / 37 in-plane — 43 of 44 classified. That "in-plane" column was the **complement** of host-edge, not a positive detection. Real positive detection covers 77 of 146, not 105. This makes the tag *more* justified, not less: 69 scripts are invisible to any detector, so the declaration is the only artifact that can speak for them.

**2. The detector the ticket specified produced false positives on both sides**, and shipping it as written would have convicted correct files:

| specimen | naive verdict | why it was wrong |
|---|---|---|
| `maintenance/restore.mjs` | host | its only `compose` mentions are **JSDoc prose** about bind-mount paths |
| `diagnostics/captureParityLatencyPair.mjs` | in-plane | matched `./mcpHealthcheck.mjs` — a **sibling script**, on the substring `mcp` |

The shipped classifier strips comments before reading evidence and **resolves** import specifiers to real paths.

## Conviction is asymmetric, and a symmetric rule would have been wrong

| declared | evidence | verdict |
|---|---|---|
| `in-plane` | host | **contradiction** — claims to run where it demonstrably cannot |
| `host` | plane imports | pass — an operator-run script may reach services over the network |
| either | none | pass — the declaration is the only source |

**Host evidence proves a requirement; plane evidence never proves sufficiency.** 15 scripts both shell out *and* import a plane module — `backup.mjs` imports a config module only to learn **which container** to act on. Enforcing the symmetric rule would fail all 15. This also dissolves the "dual plane" category without needing a third `either` value: host evidence dominates, so a dual-signal script has a determinate answer.

## Deltas

**`ai/scripts/lint/scriptSource.mjs`** (new) — the static facts read out of a script: comment stripping, import specifiers, plane classification, declaration reading.

**`ai/scripts/lint/lint-script-plane.mjs`** (new) — `MISSING_TAG`, `INVALID_TAG`, `CONFLICTING_TAG`, `CONTRADICTION`. The population is read from the **filesystem**, never a registry, so a newly added script is in scope the moment it exists.

**`ai/scripts/diagnostics/structureMap.mjs`** — gains `--plane`, emitting the declared plane per script plus a per-folder tally. **Its comment stripper moved into `scriptSource.mjs` rather than being duplicated**, so the map and the lint cannot drift on what a comment is. Measured against a string-literal-aware stripper across all 144 scripts: **zero classification disagreements**, so the simpler shared model was kept rather than a second one added.

**144 scripts** — one `@plane` line each; 67 had no header block at all and gained a minimal one.

## Test Evidence

```
test/playwright/unit/ai/scripts/lint/lintScriptPlane.spec.mjs        13 passed
test/playwright/unit/ai/scripts/diagnostics/structureMap.spec.mjs     6 passed  (unchanged, guards the stripper relocation)
```

**Mutations, each convicting a different half:**

```
M1  flip a real host script's tag to in-plane
    CONTRADICTION  ai/scripts/maintenance/backup.mjs
        declares @plane in-plane but imports 'child_process' — that is a host
        requirement, so a client topology cannot run it.

M2  move a tag out of the header into a function's JSDoc
    MISSING_TAG    ai/scripts/benchmark/helpers/stats.mjs

restored → [lint-script-plane] OK — 146/146 scripts declare an execution plane,
           none contradicted by its own dependencies.
```

**M2 exists because the first migration had that exact bug.** My original anchor took the *last* `*/` before the first line of code, which put `stats.mjs`'s declaration inside `median()`'s JSDoc — and the lint went **green anyway**, because it scanned the whole leading comment run. Bounding `headerRegion` to the file's first block fixed the placement *and* made the misplacement detectable. A guard that cannot report what it is willing to accept is the failure mode this whole ticket is about.

**AC-7 — mixed directories, from generated output with no file opened:**

```
ai/scripts/benchmark      {"in-plane":3,"host":2}    <-- MIXED
ai/scripts/diagnostics    {"in-plane":20,"host":12}  <-- MIXED
ai/scripts/lifecycle      {"in-plane":19,"host":5}   <-- MIXED
ai/scripts/lint           {"in-plane":14,"host":2}   <-- MIXED
ai/scripts/maintenance    {"in-plane":32,"host":12}  <-- MIXED
ai/scripts/migrations     {"in-plane":12,"host":1}   <-- MIXED
ai/scripts/runners        {"host":1,"in-plane":2}    <-- MIXED
ai/scripts/setup          {"in-plane":3,"host":2}    <-- MIXED
```

**8 of 10**, not the 5 the ticket claimed — the original count came from the flawed complement measurement. Two useful findings fall straight out: `lint-agents` and `lint-skill-manifest` are **host** scripts, because their `--base origin/dev` git calls need a shell.

Guards run on all 149 changed files: `check-parse` clean, `check-whitespace` clean, `check-block-alignment` clean on every file this PR authors. `roadmapPlanner.mjs` carries 14 pre-existing alignment findings — **14 at `origin/dev` and 14 here**, so this PR adds none and does not repair unrelated lines.

## Post-Merge Validation

None deferred. Every acceptance criterion is unit-covered and verified above.

## Review

Cross-family seat needed (author is opus). Three places worth attacking:

1. **The 69 silent scripts.** Their declarations are my assertion, and the lint cannot falsify them — it only catches a declaration that a *future* dependency contradicts. If you think a specific one is mis-declared, that is a real finding and I have no instrument that would have caught it.
2. **`classifyPlane`'s host signal set** (`child_process`, docker tokens, `os.homedir`, `process.kill`). A missing signal is the quiet failure: it leaves a wrong `in-plane` standing.
3. **The strict privilege test.** I classified by *"does it require a shell/Docker/home?"* rather than *"where is it usually run?"* — so `fleetHealthcheck.mjs`, defaulting to `127.0.0.1`, is `in-plane` because it only needs a reachable URL. That is a definitional call worth challenging.

Authored by @neo-opus-vega 🌿
