### PR TITLE
fix(heap-observation): a quoted NODE_OPTIONS ceiling is in force, not undeclared (#16819)

### DIFF
--- a/ai/mcp/server/shared/services/HeapObservationReporterService.mjs
+++ b/ai/mcp/server/shared/services/HeapObservationReporterService.mjs
@@ -134,18 +134,30 @@ class HeapObservationReporterService extends Base {
      *
      * `true` means the cadence started, NOT that the first write succeeded — a write failure is
      * reported through `writeOnce()`'s own return and must not stop the channel from trying again.
-     * `config` is the same use-site-default seam the bridge's reader takes, so a spec can exercise the
-     * disabled and unreadable arms without mutating the shared `AiConfig` singleton.
+     *
+     * **The seam is a reader rather than a value, and that is what makes the guard falsifiable.** It
+     * was `config = AiConfig.heapObservation`, a default parameter — and JavaScript evaluates those
+     * *before* entering the function body, so the one config read production actually performs sat
+     * outside the very `try` this method's contract is built on. The old spec injected an object whose
+     * `enabled` getter throws, which proves the in-body read is caught and can never reach the
+     * production path, so the totality claim above held only by code-reading. A thunk closes it: the
+     * default is now an arrow-function literal, whose *creation* cannot throw, and the read happens at
+     * `readConfig()` inside the guard. Production and every spec arm then run the identical mechanism
+     * and differ only in which function is invoked — an injected throwing reader is a true falsifier
+     * for the shipped path, and the shared `AiConfig` singleton still never gets mutated to isolate a
+     * test.
      *
      * @param {Object}   options
-     * @param {String}   options.serviceKey Stable service identity.
-     * @param {String}   [options.dir]      Directory to publish into.
-     * @param {Function} [options.writeLog] Optional logger, called `(level, message)`.
-     * @param {Object}   [options.config]   Resolved `heapObservation` leaves.
+     * @param {String}   options.serviceKey   Stable service identity.
+     * @param {String}   [options.dir]        Directory to publish into.
+     * @param {Function} [options.writeLog]   Optional logger, called `(level, message)`.
+     * @param {Function} [options.readConfig] Returns the resolved `heapObservation` leaves.
      * @returns {Boolean} Whether reporting started.
      */
-    start({serviceKey, dir, writeLog, config = AiConfig.heapObservation}) {
+    start({serviceKey, dir, writeLog, readConfig = () => AiConfig.heapObservation}) {
         try {
+            const config = readConfig();
+
             if (!config.enabled) {
                 return false
             }

--- a/ai/services/shared/processHeapObservation.mjs
+++ b/ai/services/shared/processHeapObservation.mjs
@@ -67,7 +67,16 @@ export const HEAP_OBSERVATION_STATE = Object.freeze({observed: 'observed', unava
  * as "nobody bounded this", which is precisely the claim this record exists to make falsifiable. Both
  * channels are now read.
  *
- * Divergence between the two is reported as `ambiguous` rather than resolved. The last-wins rule is
+ * **`ambiguous` means "a declaration is in play and no single ceiling can be read from it", which has
+ * two causes rather than one.** The first is divergence between the channels, below. The second is a
+ * declaration that names the flag while carrying no ceiling this reader will state — a value V8
+ * ignores, a value Node refuses to start on, or a `NODE_OPTIONS` string Node cannot tokenize at all;
+ * {@link readCeilingToken} and {@link tokenizeNodeOptions} carry the measurements. Both causes leave
+ * `bytes` at `null` and both are emphatically **not** `undeclared`, which is affirmative evidence that
+ * no declaration exists. Consumers already gate on `ceilingState === 'declared'`
+ * (`ContainerHealthDiagnosisService`), so the widened meaning reaches them as the same refusal.
+ *
+ * Divergence between the two channels is reported as `ambiguous` rather than resolved. The last-wins rule is
  * consistent across all five measurements above (concatenate `NODE_OPTIONS` then the command line and
  * take the last), but it is V8's rule, not ours, and `heapSizeLimitBytes` is already observed
  * independently — so a consumer needing to know **which declaration V8 actually applied** can read that
@@ -115,6 +124,22 @@ export const UNAVAILABLE_REASON = Object.freeze({
 const MEGABYTE = 1024 * 1024;
 
 /**
+ * Matches an argument token that names the old-generation ceiling flag, capturing its raw value.
+ * `[\s\S]*` rather than `.*` so a value carrying a newline is captured instead of silently truncated:
+ * only the space character separates tokens in `NODE_OPTIONS`, so a newline reaches the value intact.
+ * @type {RegExp}
+ */
+const CEILING_FLAG = /^--max[-_]old[-_]space[-_]size(?:=([\s\S]*))?$/;
+
+/**
+ * Detects the flag name anywhere in a raw, untokenizable `NODE_OPTIONS` value. Deliberately unanchored
+ * and used only when tokenization failed: at that point no token boundaries exist to anchor to, and the
+ * question has narrowed to whether the unreadable value is one worth failing closed over.
+ * @type {RegExp}
+ */
+const NAMES_CEILING_FLAG = /--max[-_]old[-_]space[-_]size/;
+
+/**
  * @summary Reads the declared old-generation ceiling out of a process argument vector.
  *
  * Fail-closed on ambiguity, matching how `DeploymentStateBridgeService` treats the same flag when it
@@ -127,6 +152,11 @@ const MEGABYTE = 1024 * 1024;
  * for the measurements. `sources` names which channels carried a declaration, so a ceiling arriving
  * through `NODE_OPTIONS` on a deployment that forbids it is visible rather than merely counted.
  *
+ * The two channels are also **parsed** differently, which is not an inconsistency but the measured
+ * behaviour: `NODE_OPTIONS` is quote-aware syntax Node consumes itself, while an `execArgv` entry
+ * reaches V8 verbatim. {@link tokenizeNodeOptions} covers the split and why applying it to both would
+ * credit declarations that cannot exist.
+ *
  * @param {String[]} [execArgv]    Node execution arguments.
  * @param {String}   [nodeOptions] Raw `NODE_OPTIONS` value.
  * @returns {Object} `{state, bytes, sources}` where `bytes` is `null` for every non-`declared` state.
@@ -137,28 +167,152 @@ export function readDeclaredCeiling(execArgv = [], nodeOptions = '') {
             const found = [];
 
             for (const arg of Array.isArray(args) ? args : []) {
-                const match = /^--max[-_]old[-_]space[-_]size=(\d+)$/.exec(String(arg));
+                const read = readCeilingToken(String(arg));
 
-                match && found.push({bytes: Number(match[1]) * MEGABYTE, source})
+                read && found.push({bytes: read.bytes, source})
             }
 
             return found
         },
-        // Whitespace-split rather than shell-parsed: Node accepts no quoting inside NODE_OPTIONS for
-        // this flag, and a parser richer than the input it reads invents cases it cannot verify.
-        envArgs = typeof nodeOptions === 'string' ? nodeOptions.split(/\s+/).filter(Boolean) : [],
-        values  = [...readFrom(envArgs, CEILING_SOURCE.nodeOptions), ...readFrom(execArgv, CEILING_SOURCE.execArgv)],
+        // `null` means the value is one Node itself rejects, so no token list exists to read. The two
+        // channels get different treatment on purpose: quotes are NODE_OPTIONS syntax and are illegal
+        // in `execArgv` — see {@link tokenizeNodeOptions}.
+        envTokens = typeof nodeOptions === 'string' ? tokenizeNodeOptions(nodeOptions) : [],
+        envValues = envTokens === null
+            // Unreadable, yet it names the flag: a declaration is present and its ceiling cannot be
+            // stated. That is the `ambiguous` case, never the `undeclared` one.
+            ? (NAMES_CEILING_FLAG.test(nodeOptions) ? [{bytes: null, source: CEILING_SOURCE.nodeOptions}] : [])
+            : readFrom(envTokens, CEILING_SOURCE.nodeOptions),
+        values  = [...envValues, ...readFrom(execArgv, CEILING_SOURCE.execArgv)],
         sources = Object.freeze([...new Set(values.map(value => value.source))]);
 
     if (values.length === 0) {
         return {state: CEILING_STATE.undeclared, bytes: null, sources}
     }
 
-    if (values.some(value => value.bytes !== values[0].bytes)) {
+    // A declaration exists, so `undeclared` is off the table from here — it is affirmative evidence
+    // that none was found, and returning it for a flag that is present is the false negative this
+    // whole record exists to prevent. A `null` bytes entry is a declaration whose ceiling could not
+    // be read; it degrades the answer to `ambiguous` exactly as a disagreement between two readable
+    // ones does, because both mean "a declaration is in play and I decline to name a number".
+    if (values.some(value => value.bytes === null || value.bytes !== values[0].bytes)) {
         return {state: CEILING_STATE.ambiguous, bytes: null, sources}
     }
 
     return {state: CEILING_STATE.declared, bytes: values[0].bytes, sources}
+}
+
+/**
+ * @summary Splits a raw `NODE_OPTIONS` value into argument tokens the way Node itself does.
+ *
+ * This is a transcription of Node's `ParseNodeOptionsEnvVar` (`src/node_options.cc`), not a shell
+ * parser and not a richer one: **double quotes are removed wherever they appear**, a backslash escapes
+ * the next character only *inside* a quoted run, and **only the space character separates** — a tab
+ * does not. Measured on node `v25.9.0`, all five of these apply an identical 256 MiB ceiling
+ * (`heap_size_limit = 469762048` against a 4288 MiB baseline):
+ *
+ * | `NODE_OPTIONS`                  | ceiling in force |
+ * |---------------------------------|------------------|
+ * | `--max-old-space-size=256`      | yes              |
+ * | `"--max-old-space-size=256"`    | yes              |
+ * | `--max-old-space-size="256"`    | yes              |
+ * | `"--max-old-space-size"=256`    | yes              |
+ * | `--max-old-space-size=25"6"`    | yes              |
+ *
+ * The superseded revision whitespace-split and applied an unquoted-token regex, and its comment
+ * asserted Node accepts no quoting here. Four of those five rows therefore reported `undeclared` for a
+ * process that was genuinely bounded — the exact false-negative direction {@link CEILING_STATE} was
+ * written to eliminate on the `execArgv`-only bug, reintroduced one channel over. Note that matching
+ * only the two *shapes* named above would still miss row five, so the transcription is the fix rather
+ * than a pair of extra patterns: the mechanism strips quotes, it does not recognise forms.
+ *
+ * **The asymmetry with `execArgv` is real and measured.** Quoting is `NODE_OPTIONS` syntax that Node
+ * consumes before V8 sees the flag; the same text arriving through the command line reaches V8 intact
+ * and Node **refuses to start** (`--max-old-space-size="256"` → *Value for flag ... of type size_t is
+ * out of bounds*). So a live process can never carry a quoted `execArgv` entry, and stripping quotes
+ * there would credit a declaration that cannot exist. Only this channel is tokenized.
+ *
+ * @param {String} nodeOptions Raw `NODE_OPTIONS` value.
+ * @returns {String[]|null} The tokens, or `null` for a value Node rejects outright — an unterminated
+ * quoted run or a trailing escape, both of which abort startup rather than yielding a process to
+ * observe.
+ */
+function tokenizeNodeOptions(nodeOptions) {
+    const tokens = [];
+
+    let inString    = false,
+        startNewArg = true;
+
+    for (let index = 0; index < nodeOptions.length; index++) {
+        let char = nodeOptions[index];
+
+        if (char === '\\' && inString) {
+            if (index + 1 === nodeOptions.length) {
+                return null
+            }
+
+            char = nodeOptions[++index]
+        } else if (char === ' ' && !inString) {
+            startNewArg = true;
+            continue
+        } else if (char === '"') {
+            inString = !inString;
+            continue
+        }
+
+        if (startNewArg) {
+            tokens.push(char);
+            startNewArg = false
+        } else {
+            tokens[tokens.length - 1] += char
+        }
+    }
+
+    return inString ? null : tokens
+}
+
+/**
+ * @summary Reads one already-tokenized argument as a ceiling declaration.
+ *
+ * Separating "does this name the flag" from "can I read its value" is what keeps a broken declaration
+ * out of the `undeclared` bucket. The value rule is measured against what V8 does with it rather than
+ * assumed, on node `v25.9.0` and against a 4288 MiB baseline:
+ *
+ * | value                    | node starts | ceiling in force | read as    |
+ * |--------------------------|-------------|------------------|------------|
+ * | `256`, `0256`            | yes         | 256 MiB          | `declared` |
+ * | `+256`                   | yes         | 256 MiB          | `declared` |
+ * | `0`                      | yes         | **no**           | ambiguous  |
+ * | `-256`                   | yes         | **no**           | ambiguous  |
+ * | `99999999999999999999`   | yes         | **no**           | ambiguous  |
+ * | `256abc`, `256.0`        | **no**      | —                | ambiguous  |
+ * | *(no `=value` at all)*   | **no**      | —                | ambiguous  |
+ *
+ * The superseded `=(\d+)` predicate got two of these wrong in both directions at once: it reported
+ * `undeclared` for `+256`, which bounds the process at 256 MiB, and `declared` at **zero bytes** for
+ * `=0`, which bounds nothing at all — a ceiling of zero makes every saturation ratio taken against it
+ * infinite. V8 silently ignores the three "no" rows, so each is a declaration whose ceiling is not
+ * what it says; naming a number for any of them would be worse than declining to.
+ *
+ * The upper bound is `Number.isSafeInteger` on the byte product rather than a transcribed V8 `size_t`
+ * limit: the point is to never state a byte count this runtime cannot represent exactly, which is a
+ * property of the arithmetic here and needs no constant from a runtime we do not control.
+ *
+ * @param {String} token One argument token.
+ * @returns {Object|null} `{bytes}` when the token names the flag — `bytes` is `null` when it names it
+ * without a readable ceiling — or `null` when the token is some other flag entirely.
+ */
+function readCeilingToken(token) {
+    const match = CEILING_FLAG.exec(token);
+
+    if (!match) {
+        return null
+    }
+
+    const digits = /^\+?(\d+)$/.exec(match[1] ?? ''),
+          mib    = digits ? Number(digits[1]) : NaN;
+
+    return {bytes: mib > 0 && Number.isSafeInteger(mib * MEGABYTE) ? mib * MEGABYTE : null}
 }
 
 /**

--- a/test/playwright/unit/ai/mcp/server/shared/services/HeapObservationReporterService.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/shared/services/HeapObservationReporterService.spec.mjs
@@ -153,10 +153,39 @@ test.describe('Neo.ai.mcp.server.shared.services.HeapObservationReporterService 
         // `start()` runs inside `BaseServer.initAsync()`, so a throw here fails a whole MCP server's
         // startup over an observation lane. The config read is the one operation that runs before any
         // guard could report through a return value, which is why it is inside this one.
-        const unreadable = {get enabled() { throw new Error('overlay unresolved') }};
+        //
+        // This throws where PRODUCTION reads. The superseded seam was a default parameter,
+        // `config = AiConfig.heapObservation`, and defaults evaluate before the body — so the shipped
+        // read sat outside the `try` while this spec injected an object whose getter throws INSIDE it.
+        // That arm passed against a boundary production never crossed. Failing the reader itself is
+        // the same call the shipped path makes.
+        const unreadable = () => { throw new Error('overlay unresolved') };
 
-        expect(HeapObservationReporterService.start({serviceKey: 'mc-server', dir: makeDir(), config: unreadable}))
+        expect(HeapObservationReporterService.start({serviceKey: 'mc-server', dir: makeDir(), readConfig: unreadable}))
             .toBe(false);
+    });
+
+    test('an unreadable config is caught at the READER, not merely at the leaf access', () => {
+        // The distinction the default-parameter bug hid: a reader that throws on invocation models an
+        // `AiConfig.heapObservation` read that fails outright — an unresolved overlay, a provider that
+        // rejects — whereas a throwing `enabled` getter only models a failure one property deeper, and
+        // is reachable from inside any guard. Both must be total; only the first was ever in doubt.
+        const dir = makeDir();
+
+        expect(() => HeapObservationReporterService.start({
+            serviceKey: 'mc-server',
+            dir,
+            readConfig: () => { throw new Error('provider rejected the read') }
+        })).not.toThrow();
+
+        expect(HeapObservationReporterService.start({
+            serviceKey: 'mc-server',
+            dir,
+            readConfig: () => ({get enabled() { throw new Error('leaf unresolved') }})
+        })).toBe(false);
+
+        // Neither arm started a cadence, so neither published.
+        expect(fs.readdirSync(dir)).toEqual([]);
     });
 
     test('start() survives a channel that can never be written', () => {
@@ -177,7 +206,7 @@ test.describe('Neo.ai.mcp.server.shared.services.HeapObservationReporterService 
     test('a disabled channel starts nothing', () => {
         const dir = makeDir();
 
-        expect(HeapObservationReporterService.start({serviceKey: 'mc-server', dir, config: {enabled: false}}))
+        expect(HeapObservationReporterService.start({serviceKey: 'mc-server', dir, readConfig: () => ({enabled: false})}))
             .toBe(false);
         expect(fs.readdirSync(dir)).toEqual([]);
     });

--- a/test/playwright/unit/ai/services/shared/processHeapObservation.spec.mjs
+++ b/test/playwright/unit/ai/services/shared/processHeapObservation.spec.mjs
@@ -223,6 +223,114 @@ test.describe('ai/services/shared/processHeapObservation — the declared ceilin
         expect(bytes).toBeNull();
     });
 
+    // ---- The quoting regression. -----------------------------------------------------------------
+    // The repair above read both channels but whitespace-split NODE_OPTIONS and applied an
+    // unquoted-token regex, asserting in a comment that Node accepts no quoting here. Measured on node
+    // v25.9.0 by spawning real children with an explicit env object, every row below applies an
+    // identical 256 MiB ceiling — `heap_size_limit = 469762048` against a 4288 MiB baseline — while the
+    // superseded reader called four of the five `undeclared`. Node strips double quotes wherever they
+    // appear (`ParseNodeOptionsEnvVar`), so recognising SHAPES would still miss the last row; the
+    // tokenizer transcribes the mechanism instead.
+
+    for (const nodeOptions of [
+        '--max-old-space-size=256',
+        '"--max-old-space-size=256"',
+        '--max-old-space-size="256"',
+        '"--max-old-space-size"=256',
+        '--max-old-space-size=25"6"'
+    ]) {
+        test(`a quoted NODE_OPTIONS ceiling is in force and must read as declared: ${nodeOptions}`, () => {
+            expect(readDeclaredCeiling([], nodeOptions)).toEqual({
+                state  : CEILING_STATE.declared,
+                bytes  : 256 * MEGABYTE,
+                sources: ['node-options']
+            });
+        });
+    }
+
+    test('quoting is stripped WITHOUT swallowing the options around it', () => {
+        // The control for the row above: a tokenizer that over-matched would credit a ceiling here, or
+        // lose one. Measured — this exact value boots with the 256 MiB ceiling in force.
+        expect(readDeclaredCeiling([], '"--enable-source-maps" --max-old-space-size=256 --no-warnings').bytes)
+            .toBe(256 * MEGABYTE);
+        // ...and a quoted option that is NOT the ceiling flag is still no declaration at all.
+        expect(readDeclaredCeiling([], '"--enable-source-maps" --no-warnings')).toEqual({
+            state: CEILING_STATE.undeclared, bytes: null, sources: []
+        });
+    });
+
+    test('only a SPACE separates in NODE_OPTIONS — a tab does not, and Node refuses to start', () => {
+        // Measured: `--max-old-space-size=256\t--no-warnings` aborts startup with *illegal value for
+        // flag* — Node's parser tests `c == ' '` literally. The superseded `/\s+/` split reported this
+        // as a clean 256 MiB declaration for a process that cannot exist.
+        expect(readDeclaredCeiling([], '--max-old-space-size=256\t--no-warnings').state)
+            .toBe(CEILING_STATE.ambiguous);
+    });
+
+    test('a NODE_OPTIONS value Node cannot tokenize is ambiguous, never undeclared', () => {
+        // Measured: an unterminated quoted run aborts startup — *invalid value for NODE_OPTIONS
+        // (unterminated string)*. No process to observe, but the declaration is unmistakably present,
+        // and reading "nobody bounded this" off a string that names the flag is the false negative
+        // this record exists to prevent.
+        expect(readDeclaredCeiling([], '"--max-old-space-size=256')).toEqual({
+            state: CEILING_STATE.ambiguous, bytes: null, sources: ['node-options']
+        });
+
+        // An unreadable value that does NOT name the flag is genuinely no declaration of ours.
+        expect(readDeclaredCeiling([], '"--enable-source-maps').state).toBe(CEILING_STATE.undeclared);
+    });
+
+    // ---- Values V8 accepts, ignores, or rejects. --------------------------------------------------
+
+    test('a leading + is a real ceiling, not an absent one', () => {
+        // Measured: `+256` boots with the 256 MiB ceiling in force. `=(\d+)` missed it — the same
+        // false-negative direction as the quoting rows, from the same predicate.
+        expect(readDeclaredCeiling([], '--max-old-space-size=+256').bytes).toBe(256 * MEGABYTE);
+        expect(readDeclaredCeiling(['--max-old-space-size=0256']).bytes).toBe(256 * MEGABYTE);
+    });
+
+    test('a value V8 IGNORES is ambiguous, never a ceiling of that number', () => {
+        // Measured: each of these boots at the 4288 MiB baseline — the declaration binds nothing. The
+        // superseded predicate reported `=0` as `declared` at ZERO bytes, which is worse than missing
+        // it: every saturation ratio taken against a zero ceiling is infinite, so an unbounded process
+        // reads as catastrophically saturated.
+        for (const value of ['0', '-256', '99999999999999999999']) {
+            const {state, bytes} = readDeclaredCeiling([`--max-old-space-size=${value}`]);
+
+            expect(state, `--max-old-space-size=${value}`).toBe(CEILING_STATE.ambiguous);
+            expect(bytes,  `--max-old-space-size=${value}`).toBeNull();
+        }
+    });
+
+    test('a value Node REFUSES to start on is ambiguous, and so is a bare flag', () => {
+        // Measured: `256abc` and `256.0` both abort startup (*illegal value for flag*), and the
+        // space-separated form `--max-old-space-size 256` aborts too — the flag takes no detached
+        // value. All three name the ceiling; none yields one.
+        for (const arg of ['--max-old-space-size=256abc', '--max-old-space-size=256.0', '--max-old-space-size']) {
+            expect(readDeclaredCeiling([arg]).state, arg).toBe(CEILING_STATE.ambiguous);
+        }
+    });
+
+    test('quoting is NODE_OPTIONS syntax only — the same text in execArgv cannot be a ceiling', () => {
+        // The asymmetry is measured, not stylistic: Node consumes the quotes before V8 sees the flag,
+        // so `--max-old-space-size="256"` on the COMMAND LINE reaches V8 intact and aborts startup
+        // (*Value for flag ... of type size_t is out of bounds*). Stripping quotes in this channel too
+        // would credit a 256 MiB ceiling to a process that could never have booted.
+        expect(readDeclaredCeiling(['--max-old-space-size="256"']).state).toBe(CEILING_STATE.ambiguous);
+        expect(readDeclaredCeiling([], '--max-old-space-size="256"').bytes).toBe(256 * MEGABYTE);
+    });
+
+    test('a quoted NODE_OPTIONS ceiling agreeing with a plain execArgv one is declared once', () => {
+        // The deployment-drift signal has to survive quoting: `ai/deploy/docker-compose.yml` forbids
+        // the NODE_OPTIONS channel, and a quoted declaration that read as `undeclared` would hide
+        // exactly the drift `sources` exists to expose.
+        expect(readDeclaredCeiling(['--max-old-space-size=256'], '"--max-old-space-size=256"')).toEqual({
+            state  : CEILING_STATE.declared,
+            bytes  : 256 * MEGABYTE,
+            sources: ['node-options', 'exec-argv']
+        });
+    });
+
     test('an ambiguous ceiling does not stop the heap from being observed', () => {
         // The declaration and the measurement are independent facts; losing one must not blind the
         // record to the other.


### PR DESCRIPTION
Resolves #16819

A process running under `NODE_OPTIONS='"--max-old-space-size=256"'` is bounded at 256 MiB and reported `{state: 'undeclared'}` — affirmative evidence that nobody bounded it. And `start()` promised "returns, never throws" while its one production config read sat outside the `try`, on an MCP server's boot path.

Evidence: L2 (both fixes exercised by unit execution, every behavioural claim measured against real spawned `node v25.9.0` children before it was written) → L2 required. Residual: the value rules are measured on one Node line; see **Post-Merge Validation**.

## The measurement came first, and it corrected the ticket twice

Every row below is from spawning real children with an explicit env object — no shell, so no shell quoting could contaminate the input. Baseline `heap_size_limit` with no declaration: **4496293888** (4288 MiB).

| `NODE_OPTIONS` | `heap_size_limit` | ceiling in force | old reader said |
|---|---|---|---|
| `--max-old-space-size=256` | 469762048 | yes | `declared` ✔ |
| `"--max-old-space-size=256"` | 469762048 | **yes** | `undeclared` ✘ |
| `--max-old-space-size="256"` | 469762048 | **yes** | `undeclared` ✘ |
| `"--max-old-space-size"=256` | 469762048 | **yes** | `undeclared` ✘ |
| `--max-old-space-size=25"6"` | 469762048 | **yes** | `undeclared` ✘ |

**Delta 1 — the ticket prescribed a shape list, and a shape list is still wrong.** It asked to "recognize at minimum a double-quoted whole option and a double-quoted numeric value" — rows two and three. That leaves row five reporting `undeclared` for a live 256 MiB ceiling. Node's `ParseNodeOptionsEnvVar` does not recognise forms; it **removes double quotes wherever they appear**, escapes with backslash only inside a quoted run, and separates on the space character alone. `tokenizeNodeOptions` transcribes that algorithm, so the fix covers the shapes nobody enumerated. This is the ticket's own lesson — an instrument's vocabulary reported as the population — applied to the ticket's own prescription.

**Delta 2 — the ticket did not mention the other channel, and the two are opposite.** Quoting is `NODE_OPTIONS` syntax that Node consumes *before* V8 sees the flag. The same text on the command line reaches V8 intact and **Node refuses to start**:

```
node --max-old-space-size="256" -e 0
  → Error: Value for flag --max-old-space-size="256" of type size_t is out of bounds
```

So a live process can never carry a quoted `execArgv` entry, and applying the tokenizer to both channels would credit a ceiling to a process that could not have booted. `execArgv` keeps the strict parse. The asymmetry is pinned by its own test.

## The same predicate was wrong in both directions on values

Not in the ticket; found by measuring the predicate rather than the reported symptom. All against the same 4288 MiB baseline:

| value | node starts | ceiling in force | old reader | now |
|---|---|---|---|---|
| `+256` | yes | **256 MiB** | `undeclared` ✘ | `declared` |
| `0` | yes | **no** | `declared`, **0 bytes** ✘ | `ambiguous` |
| `-256` | yes | no | `undeclared` | `ambiguous` |
| `99999999999999999999` | yes | **no** | `declared`, ~1e26 bytes ✘ | `ambiguous` |
| `256abc`, `256.0` | **no** | — | `undeclared` | `ambiguous` |
| `--max-old-space-size` (bare) | **no** | — | `undeclared` | `ambiguous` |
| `256\t--no-warnings` | **no** | — | `declared` ✘ | `ambiguous` |

`=0` is the one worth naming: it binds nothing, and the old reader called it a **ceiling of zero bytes**. Every saturation ratio taken against zero is infinite, so an unbounded process read as catastrophically saturated. The last row is the `/\s+/` split — only `' '` separates in `NODE_OPTIONS`, so that input aborts startup while the old reader reported a clean 256 MiB declaration.

The upper bound is `Number.isSafeInteger` on the byte product, not a transcribed V8 `size_t` constant: the rule is "never state a byte count this runtime cannot represent exactly", which is a property of the arithmetic here and needs nothing from a runtime we do not control.

**`ambiguous` is widened, and consumers already handle it.** It now means "a declaration is in play and no single ceiling can be read from it" — divergence between channels, or a declaration naming the flag without yielding a ceiling. Both leave `bytes: null`. `ContainerHealthDiagnosisService.mjs:1975` gates on `ceilingState !== 'declared'`, so the widening reaches the only consumer as the same refusal. What is emphatically **not** returned is `undeclared`, which is affirmative evidence that no declaration exists.

## Deltas

**Delta 3 — gap 2 is fixed with a reader thunk, not by moving the default into the body.** The obvious repair is `config ??= AiConfig.heapObservation` inside the `try`. That does put the production read under the guard — and leaves the totality claim **unfalsifiable by unit test**, because proving it would require making `AiConfig.heapObservation` itself throw, i.e. mutating the shared singleton (ADR 0019 §4 B4, the mechanism behind the #12335 orphan incident). The seam is now `readConfig = () => AiConfig.heapObservation`: creating an arrow-function literal cannot throw, the read happens at `readConfig()` inside the guard, and **production and every spec arm run the identical mechanism, differing only in which function is invoked.** An injected throwing reader is therefore a true falsifier for the shipped path.

That distinction is the whole defect. The superseded spec injected `{get enabled() { throw }}` — a failure one property *deeper*, reachable from inside any guard — so it passed against a boundary production never crossed, which is exactly what the ticket caught. Both depths now have a test.

`AiConfig` reads stay at the use site, no alias (B2), no defensive `?.` (B3), no threading (B5). `observationPath`'s own default-parameter read is untouched and already guarded: it is evaluated when the method is *called*, which is inside `writeOnce()`'s `try`.

## Test Evidence

```
npm run test-unit -- unit/ai/services/shared/processHeapObservation.spec.mjs \
                     unit/ai/mcp/server/shared/services/HeapObservationReporterService.spec.mjs
  55 passed

npm run test-unit -- unit/ai/deploy/DeclaredHeapCeilings.spec.mjs \
                     unit/ai/daemons/orchestrator/DeclaredHeapCeilingObservation.spec.mjs \
                     unit/ai/daemons/orchestrator/services/ContainerHealthDiagnosisService.spec.mjs \
                     unit/ai/mcp/server/
  707 passed
```

**Mutation-differential — both source files reverted to the merge base, specs kept:**

| reverted file | result |
|---|---|
| `processHeapObservation.mjs` | **11 failed**, 30 passed |
| `HeapObservationReporterService.mjs` | **3 failed**, 13 passed |
| both at once | **14 failed**, 41 passed |

All 14 are tests this PR adds or whose seam it renames; **no untouched pre-existing test reddens**, so no contracted behaviour changed. The two new parser tests that stay green on the merge base are deliberate controls — the unquoted baseline row, and the check that quote-stripping does not swallow the options around it.

## What this does NOT establish

- **One Node line.** Every row was measured on `node v25.9.0`. The tokenizer transcribes an algorithm that has been stable in `node_options.cc` for years, but the *value* rules (`=0` and overflow being silently ignored) are V8 behaviour I observed rather than a documented contract.
- **It does not prove the ceiling is correct** — only that a declaration present in either channel is never reported as absent, and that a number is never stated for a declaration that does not produce one.
- **`heapSizeLimitBytes` remains the independent instrument.** Nothing here derives a ceiling from it or vice versa.

## Post-Merge Validation

- [ ] On the next deployment touching Node's major version, re-run the two measurement harnesses (attached to the ticket) and confirm the `=0` / overflow rows still land in `ambiguous`. They encode V8 behaviour, not a documented contract, and a change there would move a row from `ambiguous` to `declared` — the safe direction, but worth seeing.

## Commits

- `1c0bf86db9` — the tokenizer, the value rules, and the widened `ambiguous`
- `2cde0d7797` — the reporter's boot guard covers the config read it claims to

Authored by Ada (Claude Opus 5, Claude Code). Session 87f453f9-aa80-4487-9ed1-b5d91e052c43.
