### PR TITLE
test(orchestrator): witness the heap ceiling through the env layer, not a singleton mutation (#16485)

### DIFF
--- a/test/playwright/unit/ai/configBase.spec.mjs
+++ b/test/playwright/unit/ai/configBase.spec.mjs
@@ -50,7 +50,7 @@ test.describe('ai/configBase — delta-only subclass overlays (overlay-drift roo
      * unset, which would have failed boot for every deployment that never set the override. Only
      * probing all of them caught it.
      */
-    test('#16463 — the supervised-child heap ceiling refuses a non-positive override rather than falling back', () => {
+    test('#16480 — the supervised-child heap ceiling refuses a non-positive override rather than falling back', () => {
         const envName  = 'NEO_SUPERVISED_TASK_HEAP_MB',
               original = process.env[envName];
 

--- a/test/playwright/unit/ai/daemons/orchestrator/Orchestrator.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/Orchestrator.spec.mjs
@@ -1,4 +1,5 @@
 import {test, expect} from '@playwright/test';
+import {spawnSync}    from 'node:child_process';
 import Database       from 'better-sqlite3';
 import fs             from 'fs-extra';
 import path           from 'path';
@@ -2678,76 +2679,104 @@ test.describe('taskDefinitions — chroma persist dir rides the resolved leaf (#
  * therefore set to a value no fallback can produce.
  */
 test.describe('Neo.ai.daemons.Orchestrator — supervised-child heap ceiling injection (#16463)', () => {
-    const LEAF_PATH = 'orchestrator.supervisedTaskHeapMb',
-          // Deliberately not 384, and not any other constant in the module under test.
-          INJECTED   = 777;
+    // Must be a value NEITHER fallback can produce, or the assertions pass with the injection
+    // deleted. Both forbidden values are derived live rather than written as literals, because the
+    // pair drifted once already: this ticket was filed stating both were 384, and the leaf default
+    // has since moved to 1024 while the service fallback stayed at 384. A hard-coded premise would
+    // have gone on asserting the old arithmetic without failing.
+    const INJECTED = 777,
+          WITNESS  = 'test/playwright/unit/ai/daemons/orchestrator/fixtures/heapCeilingEnvWitness.mjs',
+          // The service's own fallback, read through the real function rather than copied from it:
+          // `buildSupervisedTaskEnv` applies `FALLBACK_SUPERVISED_TASK_HEAP_MB` when given no ceiling.
+          serviceFallback = () => Number(/--max-old-space-size=(\d+)/.exec(buildSupervisedTaskEnv({}).NODE_OPTIONS)[1]),
+          // The leaf default: this process carries no `NEO_SUPERVISED_TASK_HEAP_MB`, so what the leaf
+          // resolves to HERE is exactly what the child would get without the override.
+          //
+          // Both are THUNKS so the reads happen at test time. A describe body runs at COLLECTION
+          // time — before any test and before the suite's fixtures — and capturing a config leaf
+          // there is the module-load capture this repo has been burned by: the value is read at a
+          // moment the suite does not control, and a later env or overlay resolution cannot reach it.
+          leafDefault = () => AiConfig.orchestrator.supervisedTaskHeapMb;
 
-    let saved;
+    let witness;
 
-    test.beforeEach(() => {
-        saved = AiConfig.orchestrator.supervisedTaskHeapMb;
-        AiConfig.setData(LEAF_PATH, INJECTED);
+    /**
+     * @summary Runs the witness in a fresh process whose env carries the override.
+     *
+     * The superseded fixture mutated the shared `AiConfig` singleton
+     * (`AiConfig.setData('orchestrator.supervisedTaskHeapMb', 777)`) in `beforeEach`. That is unsound
+     * for the claim, not merely a style violation: the leaf resolves through its env layer at config
+     * construction, so writing the member afterwards proves the member can be SET, never that the
+     * override RESOLVES — a deployment sets `NEO_SUPERVISED_TASK_HEAP_MB` and the leaf's
+     * `metadata.parse` hook reads it by name. It was also only invisible by luck; any later spec in
+     * this file resolving config inside the mutated window would inherit a value it never asked for
+     * and fail as an unrelated flake.
+     *
+     * A process that cannot be spawned or that throws FAILS here. There is deliberately no in-process
+     * fallback: degrading to `setData` on a bad day would restore the defect silently.
+     */
+    test.beforeAll(() => {
+        const result = spawnSync(process.execPath, [WITNESS], {
+            cwd     : process.cwd(),
+            encoding: 'utf8',
+            timeout : 120000,
+            env     : {
+                ...process.env,
+                NEO_SUPERVISED_TASK_HEAP_MB: String(INJECTED),
+                // The Orchestrator reads this during `Neo.create`'s config processing, before any
+                // instance field a caller could assign, and its leaf default is the empty string the
+                // profile assertion rejects. Supplied through env for the same reason the ceiling is.
+                NEO_AI_ORCHESTRATOR_AUTHORITY_PROFILE: 'legacy-mixed'
+            }
+        });
+
+        // stdout carries service boot logging ahead of the payload, so take the last JSON line rather
+        // than assuming the process wrote nothing else.
+        const payload = (result.stdout || '').trim().split('\n').filter(line => line.startsWith('{')).pop();
+
+        expect(result.status, `witness process failed: ${result.stderr || result.error?.message || 'no output'}`).toBe(0);
+        expect(payload, `witness produced no JSON payload. stderr: ${result.stderr}`).toBeTruthy();
+
+        witness = JSON.parse(payload);
     });
 
-    test.afterEach(() => {
-        AiConfig.setData(LEAF_PATH, saved);
+    test('the premise holds: the injected ceiling is one NO fallback can produce', () => {
+        // Without this, every assertion below would pass with the injection deleted — the exact
+        // vacuity the original coverage was shaped to avoid.
+        expect(INJECTED).not.toBe(serviceFallback());
+        expect(INJECTED).not.toBe(leafDefault());
+        // And the override genuinely reached the child's environment, rather than the child having
+        // agreed with us by coincidence.
+        expect(witness.envVarSeen).toBe(String(INJECTED));
+    });
+
+    test('the override resolves through the ENV LAYER, the path a deployment uses', () => {
+        // The claim the superseded `setData` fixture could not make: the value arrived by the leaf's
+        // `metadata.parse` hook reading the env var by name at construction, in a process where the
+        // var existed before any canonical import.
+        expect(witness.resolvedLeaf).toBe(INJECTED);
     });
 
     test('the resolved leaf reaches the constructed ProcessSupervisorService', () => {
-        // The premise: the injected value is distinguishable from the service's own fallback.
-        expect(INJECTED).not.toBe(384);
-        expect(AiConfig.orchestrator.supervisedTaskHeapMb).toBe(INJECTED);
-
-        const orchestrator = createTestOrchestrator();
-
-        expect(orchestrator.processSupervisorService.supervisedTaskHeapMb).toBe(INJECTED);
+        expect(witness.injectedIntoService).toBe(INJECTED);
     });
 
     /**
      * SECOND HOP, driven rather than replayed.
      *
-     * The previous revision of this test called `buildSupervisedTaskEnv({defaultHeapMb: <member>})`
-     * itself — it hand-fed the value across the very boundary it claimed to cover, so it asserted
-     * that a pure function formats a number it was given. @neo-gpt-emmy mutated `runTask`'s read to
-     * the module fallback and BOTH tests stayed green; the service-to-child hop had no coverage at
-     * all while its test name claimed otherwise.
+     * An earlier revision called `buildSupervisedTaskEnv({defaultHeapMb: <member>})` itself — it
+     * hand-fed the value across the very boundary it claimed to cover, so it asserted that a pure
+     * function formats a number it was given. @neo-gpt-emmy mutated `runTask`'s read to the module
+     * fallback and BOTH tests stayed green; the service-to-child hop had no coverage at all while its
+     * test name claimed otherwise.
      *
-     * This drives the real `runTask` on the orchestrator-constructed service and reads the ceiling
-     * off the spawn arguments, so the assertion depends on the production expression rather than on
-     * a copy of it.
+     * The witness drives the real `runTask` on the orchestrator-constructed service and reads the
+     * ceiling off the spawn arguments, so the assertion depends on the production expression rather
+     * than on a copy of it.
      */
     test('the injected ceiling reaches the SPAWNED child env — driven through runTask, not replayed', () => {
-        const orchestrator = createTestOrchestrator(),
-              supervisor   = orchestrator.processSupervisorService;
-
-        let spawnedEnv = null;
-
-        const probeDefinition = {
-            heapCeilingProbe: {
-                label          : 'Heap Ceiling Probe',
-                command        : 'node',
-                args           : ['--version'],
-                pidFileName    : 'heap-ceiling-probe.pid',
-                expectedCommand: 'node'
-            }
-        };
-
-        supervisor.taskDefinitions = {...supervisor.taskDefinitions, ...probeDefinition};
-
-        // `taskState` is seeded from the definitions the harness constructed with, so a definition
-        // added afterwards has none and `runTask` reads `state.running` off undefined. Seeded with
-        // the same factory rather than a hand-shaped literal, so the probe cannot drift from the
-        // real initial shape.
-        Object.assign(TaskStateService.taskState, createInitialTaskState(probeDefinition));
-
-        supervisor.spawnFn = (command, args, options) => {
-            spawnedEnv = options.env;
-            return {pid: 4711, on: () => {}, stderr: {on: () => {}}};
-        };
-
-        expect(supervisor.runTask('heapCeilingProbe', 'heap-ceiling-witness')).toBe(true);
-
-        // Read off the spawn call, which is the only surface a real child ever sees.
-        expect(spawnedEnv.NODE_OPTIONS).toBe(`--max-old-space-size=${INJECTED}`);
+        expect(witness.ran).toBe(true);
+        // Read off the spawn call, which is the only surface a real supervised child ever sees.
+        expect(witness.spawnedNodeOptions).toBe(`--max-old-space-size=${INJECTED}`);
     });
 });

--- a/test/playwright/unit/ai/daemons/orchestrator/Orchestrator.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/Orchestrator.spec.mjs
@@ -2678,7 +2678,7 @@ test.describe('taskDefinitions — chroma persist dir rides the resolved leaf (#
  * by falling back, and a test that cannot fail on the deletion is not covering it. The override is
  * therefore set to a value no fallback can produce.
  */
-test.describe('Neo.ai.daemons.Orchestrator — supervised-child heap ceiling injection (#16463)', () => {
+test.describe('Neo.ai.daemons.Orchestrator — supervised-child heap ceiling injection (#16480)', () => {
     // Must be a value NEITHER fallback can produce, or the assertions pass with the injection
     // deleted. Both forbidden values are derived live rather than written as literals, because the
     // pair drifted once already: this ticket was filed stating both were 384, and the leaf default

--- a/test/playwright/unit/ai/daemons/orchestrator/fixtures/heapCeilingEnvWitness.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/fixtures/heapCeilingEnvWitness.mjs
@@ -1,0 +1,97 @@
+import Neo                                        from '../../../../../../../src/Neo.mjs';
+import * as core                                  from '../../../../../../../src/core/_export.mjs';
+import AiConfig                                   from '../../../../../../../ai/config.template.mjs';
+import {Orchestrator}                             from '../../../../../../../ai/daemons/orchestrator/Orchestrator.mjs';
+import {buildTaskDefinitions}                     from '../../../../../../../ai/daemons/orchestrator/taskDefinitions.mjs';
+import TaskStateService, {createInitialTaskState} from '../../../../../../../ai/daemons/orchestrator/services/TaskStateService.mjs';
+
+/**
+ * @summary A fresh-process witness for the supervised-child heap ceiling, run as a child of the spec.
+ *
+ * **Why a whole process instead of a fixture inside the spec.** The value under test resolves through
+ * the leaf's env layer, and that layer runs once — at config construction, during the first canonical
+ * import. A spec that sets the member afterwards with `AiConfig.setData` proves the member can be
+ * *written*, which is not the claim: a deployment sets `NEO_SUPERVISED_TASK_HEAP_MB` and the leaf's
+ * `metadata.parse` hook reads it by name. Only an env that exists *before* these imports exercises
+ * that path. The mutation was also unsound beyond its own assertion — it wrote the shared `AiConfig`
+ * singleton, so any later spec in that file resolving config inside the mutated window would inherit
+ * a value it never asked for and fail as an unrelated flake.
+ *
+ * Nothing here is stubbed except `spawnFn`. The two hops are read off the real objects: the
+ * Orchestrator's construction seam injects the resolved leaf into `ProcessSupervisorService`, and
+ * `runTask` composes the child env, which is the only surface a real supervised child ever sees.
+ *
+ * Emits one JSON line on stdout. Any throw exits non-zero with the reason on stderr, so the spec
+ * fails on a spawn or boot failure rather than silently degrading to an in-process shortcut.
+ */
+
+const DATA_DIR = `/tmp/orchestrator-heap-ceiling-witness-${process.pid}`;
+
+const taskDefinitions = buildTaskDefinitions({scriptDir: '/repo/ai/scripts', nodeBin: '/node'});
+
+TaskStateService.configure({
+    stateFile : `${DATA_DIR}/state.json`,
+    taskDefinitions,
+    writeLogFn: () => {}
+});
+
+TaskStateService.taskState = createInitialTaskState(taskDefinitions);
+
+// `authorityProfile` is read during `Neo.create`'s config processing — before any instance field a
+// caller could assign afterwards — and falls back to `AiConfig.orchestrator.authorityProfile`, whose
+// leaf default is the empty string that the profile assertion rejects. The spec supplies it through
+// this process's env for the same reason it supplies the ceiling that way: in a fresh process the env
+// layer is the configuration channel, and reaching for `setData` here would reintroduce exactly the
+// singleton mutation this fixture exists to remove.
+const orchestrator = Neo.create(Orchestrator, {
+    dataDir         : DATA_DIR,
+    stateFile       : `${DATA_DIR}/state.json`,
+    logFile         : null,
+    taskDefinitions,
+    taskStateService: TaskStateService,
+    healthService   : {recordTaskOutcome() {}},
+    spawnFn         : () => { throw new Error('spawnFn not expected during construction') }
+});
+
+orchestrator.writeLog = () => {};
+
+const supervisor = orchestrator.processSupervisorService;
+
+// SECOND HOP, driven rather than replayed. Calling `buildSupervisedTaskEnv` directly would hand-feed
+// the value across the very boundary under test; driving `runTask` makes the assertion depend on the
+// production expression instead of on a copy of it.
+const probeDefinition = {
+    heapCeilingProbe: {
+        label          : 'Heap Ceiling Probe',
+        command        : 'node',
+        args           : ['--version'],
+        pidFileName    : 'heap-ceiling-probe.pid',
+        expectedCommand: 'node'
+    }
+};
+
+supervisor.taskDefinitions = {...supervisor.taskDefinitions, ...probeDefinition};
+
+// A definition added after construction has no `taskState`, and `runTask` would read `state.running`
+// off undefined. Seeded with the same factory rather than a hand-shaped literal, so the probe cannot
+// drift from the real initial shape.
+Object.assign(TaskStateService.taskState, createInitialTaskState(probeDefinition));
+
+let spawnedEnv = null;
+
+supervisor.spawnFn = (command, args, options) => {
+    spawnedEnv = options.env;
+    return {pid: 4711, on: () => {}, stderr: {on: () => {}}}
+};
+
+const ran = supervisor.runTask('heapCeilingProbe', 'heap-ceiling-witness');
+
+process.stdout.write(JSON.stringify({
+    // Echoed so the spec can prove the child actually received the override rather than inferring it
+    // from a value that might have come from a default.
+    envVarSeen         : process.env.NEO_SUPERVISED_TASK_HEAP_MB ?? null,
+    resolvedLeaf       : AiConfig.orchestrator.supervisedTaskHeapMb,
+    injectedIntoService: supervisor.supervisedTaskHeapMb,
+    ran,
+    spawnedNodeOptions : spawnedEnv?.NODE_OPTIONS ?? null
+}));


### PR DESCRIPTION
Resolves neomjs/neo#16485

The heap-ceiling fixture proved the member could be **written**, not that the override **resolves** — and it proved it by mutating the shared `AiConfig` singleton, the mechanism behind the neomjs/neo#12335 orphan incident.

Evidence: L2 (both hops driven through real objects in a fresh process; three mutation receipts) → L2 required. Residual: one pre-existing suite flake, unrelated and characterised below.

## Why the old fixture could not make its own claim

```js
saved = AiConfig.orchestrator.supervisedTaskHeapMb;
AiConfig.setData('orchestrator.supervisedTaskHeapMb', INJECTED);   // beforeEach
```

The leaf resolves through its **env layer at config construction** — `metadata.parse` receives the env var's *name* and reads it itself. Writing the member afterwards exercises a different path than any deployment does. The `afterEach` restore bounded the blast radius; it did not make the setup correct, and the mutation was invisible only because nothing else in the file happened to resolve config inside that window.

## The witness

A fresh process (`fixtures/heapCeilingEnvWitness.mjs`) whose env carries `NEO_SUPERVISED_TASK_HEAP_MB=777` **before any canonical import**, so the value arrives the way a container does. Nothing is stubbed but `spawnFn`; both hops are read off the real objects — the Orchestrator's construction seam and `runTask`'s composed child env. It emits one JSON line; a spawn or boot failure **fails the test**, with no in-process fallback, because degrading to `setData` on a bad day would restore the defect silently.

`NEO_AI_ORCHESTRATOR_AUTHORITY_PROFILE` is supplied the same way. It is read during `Neo.create`'s config processing — before any instance field a caller could assign — and its leaf default is the empty string the profile assertion rejects. Reaching for `setData` there would have reintroduced exactly what this removes.

## Deltas

**Delta 1 — the ticket's stated trap is stale, and I derived the values instead of re-pinning them.** It says `FALLBACK_SUPERVISED_TASK_HEAP_MB` and the leaf default "are both `384`, so `384` cannot be the fixture value." Measured: the fallback is still 384 (`ProcessSupervisorService.mjs:36`), the **leaf default is now 1024** (`configBase.mjs:1115`). A hard-coded premise had already gone stale without ever failing — so both forbidden values are now read live: the fallback through `buildSupervisedTaskEnv({})` (the real function, not a copy of its constant), and the leaf default from this process, which carries no override. `777` remains valid against both, and the premise now fails if either moves.

**Delta 2 — the reads are thunks, not `const`s.** A `describe` body runs at **collection time**, before any test and before the suite's fixtures. Capturing a config leaf there is the module-load capture this repo has been burned by. Nothing forced this — it is the correct shape regardless.

**Delta 3 — the AC anchors moved, in both files.** AC-F1 (`configBase.spec.mjs:53`) and AC-F2 (`Orchestrator.spec.mjs`) both named parent neomjs/neo-agent-brain#73, which stays open for its L4 half; the coverage they label was delivered and closed by neomjs/neo#16480. Retargeted, so following an anchor no longer lands on scope unrelated to the test in front of you.

## Test Evidence

```
npm run test-unit -- unit/ai/daemons/orchestrator/
  1443 passed

npm run test-unit -- unit/ai/configBase.spec.mjs unit/ai/daemons/orchestrator/Orchestrator.spec.mjs
  93 passed
```

**Mutation-differential.** The suite carries a pre-existing flaky pair (below); it appears in every arm including the unmutated baseline, and is subtracted here.

| mutation | tests reddened |
|---|---|
| `Orchestrator.mjs` injection seam → `0` | leaf→service **and** service→child |
| `runTask` reads `FALLBACK_SUPERVISED_TASK_HEAP_MB` | **service→child only** |
| delete `NEO_SUPERVISED_TASK_HEAP_MB` from the spawn env | **all four** |

Row two is the receipt the ticket names explicitly — *"and only that one"* — and it holds. Row one reddening both is correct rather than sloppy: a zeroed first hop necessarily starves the second. Row three is the control that the witness is doing real work: with the override gone, every assertion in the block fails, so none of them can be passing on a default.

## A pre-existing flake I did NOT introduce, and did not fix here

Two tests in this file — `chroma max-runtime recycle (#12138) › defers an over-age chroma recycle…` and `› does not start pending chroma defrag…` — fail on **`origin/dev` itself**.

I nearly mis-attributed this to my own change. A single clean-`dev` run came back green, which is exactly the trap; running both arms five times each is what settled it:

| arm | runs | result |
|---|---|---|
| clean `origin/dev` | 5 | 4 × `2 failed`, 1 × `1 failed` |
| this branch | 5 | 5 × `2 failed` (same two) |

Sharpened further: with `/tmp/orchestrator-test` emptied first, the **first** run is green and every run after it fails, on `dev` and on this branch alike. The spec leaks per-run heavy-maintenance lease files (2,767 had accumulated locally since Aug 4) and the next run reads them. CI starts from a clean container each time, which is why it is green there and why this has gone unnoticed.

Out of scope here and **not** fixed in this PR — a different defect from the one neomjs/neo#16485 names, and folding it in would make this PR's close target untrue. Reported separately for whoever owns the lane.

## What this does NOT establish

- **One override, one leaf.** The witness proves this leaf resolves through its env layer; it says nothing about other leaves' parse hooks.
- **Not the L4 half of neomjs/neo-agent-brain#73** — live survival, retained-set, steady-state concurrency — which stays open and untouched.
- **No production change.** `ai/` is untouched by this PR; the mutations above were applied and reverted, never committed.

## Post-Merge Validation

- [ ] Nothing outstanding. The witness runs in the ordinary unit suite from this merge onward.

## Commits

- `155a09951a` — the fresh-process witness replaces the singleton mutation
- `6f1e830487` — AC-F1/AC-F2 anchors retargeted to neomjs/neo#16480

Authored by Ada (Claude Opus 5, Claude Code). Session 87f453f9-aa80-4487-9ed1-b5d91e052c43.
