### PR TITLE
fix(memory-core): derive the presence-hook budget from the ceiling it runs under (#16543)

### DIFF
--- a/ai/mcp/server/memory-core/helpers/TurnPresenceConfig.mjs
+++ b/ai/mcp/server/memory-core/helpers/TurnPresenceConfig.mjs
@@ -7,11 +7,72 @@ export const TURN_PRESENCE_ENV = Object.freeze({
     hookWriteTimeoutMs: 'NEO_TURN_PRESENCE_HOOK_WRITE_TIMEOUT_MS'
 });
 
+/**
+ * The ceiling the harness registers for `turnPresenceHook.mjs`, in milliseconds.
+ *
+ * **This must stay equal to the `timeout` registered for that hook in `.claude/settings.json` AND
+ * `.claude/settings.template.json`** (both express it in *seconds*: `"timeout": 2`). A spec asserts
+ * the equality across all three, following `wakeArmingHook`'s precedent — two places holding one
+ * number drift silently, and here the drift is invisible because exceeding the outer bound kills the
+ * process rather than producing a report.
+ * @type {Number}
+ */
+export const HOOK_TIMEOUT_MS = 2000;
+
+/**
+ * Everything inside the registered ceiling that the MCP exchange never gets: process spawn, node
+ * boot, this module graph's import, and teardown after the exchange returns.
+ *
+ * Measured on the developer host at ~100ms wall for spawn-through-import (5 samples, 90–100ms, of
+ * which ~50ms is the import itself). Reserved at 500ms rather than the measurement, because the
+ * consequence of under-reserving is asymmetric: the exchange would still be running when the harness
+ * kills the process, which produces no report at all — strictly worse than the named skip an
+ * exceeded inner deadline gives.
+ * @type {Number}
+ */
+export const HOOK_OVERHEAD_MARGIN_MS = 500;
+
+/**
+ * @summary The MCP exchange's budget, derived so the harness ceiling strictly exceeds it.
+ *
+ * **The constant was never the binding constraint — the ceiling is, and that is the finding.** This
+ * budget used to be a free-standing `1500`, sized when the hook opened a local SQLite file and ran one
+ * `INSERT`. It now bounds a four-stage network exchange (TCP connect, TLS handshake, MCP `initialize`,
+ * `tools/call`), so the obvious repair is to raise it toward the 8000ms its siblings
+ * (`readSubscriptionsOverMcp`, `recordTurnPresenceOverMcp`) declare for the same class of exchange.
+ *
+ * **That repair is unreachable here.** Those siblings run under a 15s `SessionStart` registration;
+ * this hook runs on `UserPromptSubmit` and `PostToolUse` under a **2s** one, because it fires on every
+ * prompt and every tool call. An 8000ms inner deadline would sit four times beyond a ceiling that
+ * terminates the process first, converting a reportable skip into a silent kill.
+ *
+ * So the number stays 1500 and stops being a coincidence: it is now derived from the ceiling it must
+ * respect, and the derivation fails loudly if either input moves. What remains genuinely unsolved is
+ * that **no budget under a 2s ceiling can cover a cold TLS exchange to a remote plane** — that is a
+ * property of running a synchronous network write on a per-tool-use hook, not of this constant, and
+ * it needs a deployment-shape decision rather than a larger number.
+ *
+ * @param {Number} [hookTimeoutMs=HOOK_TIMEOUT_MS]
+ * @param {Number} [overheadMarginMs=HOOK_OVERHEAD_MARGIN_MS]
+ * @returns {Number} Milliseconds available to the exchange itself.
+ */
+export function resolveExchangeDeadlineMs(hookTimeoutMs = HOOK_TIMEOUT_MS, overheadMarginMs = HOOK_OVERHEAD_MARGIN_MS) {
+    // Clamped on BOTH sides, however the pair is later retuned. A non-positive budget would make every
+    // stage skip instantly and report a timeout that never happened; a budget at or above the ceiling
+    // would be terminated by the harness instead of reported, which is the silent failure this whole
+    // derivation exists to prevent. `wakeArmingHook`'s sibling clamps only the lower bound and can
+    // therefore return a value EQUAL to its ceiling — deliberately not copied.
+    return Math.max(1, Math.min(hookTimeoutMs - overheadMarginMs, hookTimeoutMs - 1))
+}
+
 export const TURN_PRESENCE_DEFAULTS = Object.freeze({
-    freshMs           : 30 * 60 * 1000,
-    ttlMs             : 60 * 60 * 1000,
-    noteMaxChars      : 512,
-    hookWriteTimeoutMs: 1500
+    freshMs     : 30 * 60 * 1000,
+    ttlMs       : 60 * 60 * 1000,
+    noteMaxChars: 512,
+    // Named `hookWrite*` from when it bounded a local file write. The name is kept because it is an
+    // operator-facing env override (`NEO_TURN_PRESENCE_HOOK_WRITE_TIMEOUT_MS`) that renaming would
+    // break for anyone who set it; what it actually bounds is documented above.
+    hookWriteTimeoutMs: resolveExchangeDeadlineMs()
 });
 
 function resolveNumber({env, key, fallback}) {

--- a/test/playwright/unit/ai/mcp/server/memory-core/TurnPresenceConfig.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/memory-core/TurnPresenceConfig.spec.mjs
@@ -1,0 +1,133 @@
+import fs              from 'node:fs';
+import path            from 'node:path';
+import {fileURLToPath} from 'node:url';
+import {test, expect}  from '@playwright/test';
+
+import {
+    HOOK_OVERHEAD_MARGIN_MS,
+    HOOK_TIMEOUT_MS,
+    TURN_PRESENCE_DEFAULTS,
+    resolveExchangeDeadlineMs,
+    resolveTurnPresenceRuntimeConfig
+} from '../../../../../../../ai/mcp/server/memory-core/helpers/TurnPresenceConfig.mjs';
+import {
+    recordTurnPresenceOverMcp
+} from '../../../../../../../ai/mcp/server/memory-core/helpers/recordTurnPresenceOverMcp.mjs';
+
+const repoRoot = fileURLToPath(new URL('../../../../../../../', import.meta.url));
+
+/**
+ * @summary The presence hook's budget must be derived from the ceiling it runs under, not inherited.
+ *
+ * `1500` was sized when this hook opened a local SQLite file and ran one `INSERT`. It now bounds a
+ * four-stage network exchange — TCP connect, TLS handshake, MCP `initialize`, `tools/call` — because
+ * the transport changed underneath it without the constant being re-derived.
+ *
+ * The obvious repair is the one its siblings suggest: `readSubscriptionsOverMcp` and
+ * `recordTurnPresenceOverMcp` both declare `8000` for this class of exchange. **That repair is
+ * unreachable here, and these specs are what pin why.** Those siblings run under a 15s `SessionStart`
+ * registration; this hook runs on `UserPromptSubmit` and `PostToolUse` under a **2s** one, because it
+ * fires on every prompt and every tool call. An 8000ms inner deadline would sit four times beyond a
+ * ceiling that kills the process first — converting a reportable skip into a silent kill, which is the
+ * exact failure mode the presence lane exists to remove.
+ */
+test.describe('ai/mcp/server/memory-core/helpers/TurnPresenceConfig — the hook budget is derived, not inherited', () => {
+    test('the harness ceiling strictly exceeds the exchange budget it contains', () => {
+        const exchange = resolveExchangeDeadlineMs();
+
+        expect(exchange).toBeLessThan(HOOK_TIMEOUT_MS);
+        expect(HOOK_TIMEOUT_MS - exchange).toBeGreaterThanOrEqual(HOOK_OVERHEAD_MARGIN_MS);
+
+        // The default consumers read must equal the derived budget.
+        //
+        // Stated precisely, because the obvious stronger claim is false and was measured to be: this
+        // does NOT catch someone deleting the derivation and pasting `1500` back. The derived value is
+        // numerically identical to the literal it replaced — that is deliberate, the number was never
+        // the defect — so no assertion can tell the two apart while they coincide. Verified by
+        // mutation: substituting the literal leaves this suite fully green.
+        //
+        // What it does catch is the pair drifting apart afterwards. Move `HOOK_TIMEOUT_MS` or the
+        // margin with a pasted literal still in place, and this fails — which is the state that
+        // actually hurts, since a stale literal above a lowered ceiling stops producing reports.
+        expect(TURN_PRESENCE_DEFAULTS.hookWriteTimeoutMs).toBe(exchange);
+        expect(resolveTurnPresenceRuntimeConfig({env: {}}).hookWriteTimeoutMs).toBe(exchange);
+    });
+
+    test('the derivation stays strictly inside the ceiling however the pair is retuned', () => {
+        // Both bounds matter and they fail in opposite directions. A non-positive budget makes every
+        // stage skip instantly and report a timeout that never happened; a budget at or above the
+        // ceiling is terminated by the harness rather than reported.
+        for (const [ceiling, margin] of [[2000, 500], [1000, 9000], [2000, 0], [1, 0], [500, 500]]) {
+            const derived = resolveExchangeDeadlineMs(ceiling, margin);
+
+            expect(derived, `ceiling=${ceiling} margin=${margin}`).toBeGreaterThan(0);
+            expect(derived, `ceiling=${ceiling} margin=${margin}`).toBeLessThan(ceiling + 1);
+            ceiling > 1 && expect(derived, `ceiling=${ceiling} margin=${margin}`).toBeLessThan(ceiling);
+        }
+    });
+
+    test('the registered hook timeout matches the constant the budget is derived from, in BOTH settings files', () => {
+        // Two places holding one number drift silently. Here the drift is worse than silent: exceeding
+        // the OUTER bound kills the process, so a ceiling that dropped below the inner budget would
+        // stop producing reports entirely rather than producing wrong ones.
+        //
+        // `settings.json` is asserted alongside the template because the template is what a new seat
+        // installs, while `settings.json` is what this repo's own agents actually run under — a fix
+        // applied to one and not the other is a fix nobody is running.
+        for (const file of ['.claude/settings.template.json', '.claude/settings.json']) {
+            const settings = JSON.parse(fs.readFileSync(path.join(repoRoot, file), 'utf8')),
+                  entries  = Object.values(settings.hooks || {})
+                      .flat()
+                      .flatMap(entry => entry.hooks || [])
+                      .filter(entry => entry.command?.includes('turnPresenceHook.mjs'));
+
+            // Both registrations — `start` on UserPromptSubmit and `progress` on PostToolUse — share
+            // one constant, so finding only one of them would leave the other unbound.
+            expect(entries.length, `${file} must register the presence hook`).toBeGreaterThanOrEqual(2);
+
+            for (const entry of entries) {
+                expect(entry.timeout * 1000, `${file}: ${entry.command}`).toBe(HOOK_TIMEOUT_MS);
+            }
+        }
+    });
+
+    test('an exceeded deadline is VISIBLE — it names the budget it spent, and does not resolve as recorded', async () => {
+        // The property that makes this lane worth having: the failure the ceiling produces must be
+        // reportable. A deadline that resolved quietly — or rejected with an opaque transport error —
+        // would leave the seat silently absent, which is the "unmeasured state that looks measured"
+        // failure the presence lane was built to remove.
+        //
+        // A connect that never settles, against a deliberately small budget: no network, no timing
+        // slack, and the assertion is on the message the hook turns into its stderr WARN.
+        await expect(recordTurnPresenceOverMcp({
+            baseUrl       : 'http://127.0.0.1:9/mc/mcp',
+            identity      : '@neo-opus-ada',
+            deadlineMs    : 50,
+            TransportClass: class { async start() {} async send() {} async close() {} },
+            ClientClass   : class {
+                async connect() { return new Promise(() => {}) }
+                async callTool() { return {content: []} }
+                async close() {}
+            }
+        })).rejects.toThrow(/50ms/);
+    });
+
+    test('an operator override is still bounded by the same ceiling, and a bad one is refused', () => {
+        // The env override is the one path that can put a value above the ceiling into production, so
+        // it is the one worth stating: the resolver does not clamp it, and this records that.
+        const raised = resolveTurnPresenceRuntimeConfig({
+            env: {NEO_TURN_PRESENCE_HOOK_WRITE_TIMEOUT_MS: '8000'}
+        });
+
+        expect(raised.hookWriteTimeoutMs).toBe(8000);
+        expect(raised.hookWriteTimeoutMs, 'an override CAN exceed the ceiling — the harness kills it, and nothing here prevents that')
+            .toBeGreaterThan(HOOK_TIMEOUT_MS);
+
+        // Refusal rather than fallback for values that are not usable budgets at all.
+        for (const bad of ['0', '-1', 'abc']) {
+            expect(() => resolveTurnPresenceRuntimeConfig({
+                env: {NEO_TURN_PRESENCE_HOOK_WRITE_TIMEOUT_MS: bad}
+            }), `${bad} must be refused`).toThrow();
+        }
+    });
+});


### PR DESCRIPTION
Resolves neomjs/neo-agent-brain#67

The ticket asks to raise the presence-hook budget toward the `8000` its siblings declare. **Reading the registration falsifies that direction** — and the real constraint turns out to be one layer further out than the ticket looked.

Evidence: L2 (unit execution + four mutation receipts; the overhead margin measured against real process spawns) → L2 required. Residual: the ceiling cannot cover a remote plane at all — stated below, not fixed here.

## The measurement that inverts the fix

`turnPresenceHook.mjs` is registered with **`"timeout": 2`** — two seconds — in **both** `.claude/settings.json` and `.claude/settings.template.json`. It fires on `UserPromptSubmit` and `PostToolUse`: every prompt, every tool call.

The siblings the ticket points at run somewhere else entirely. `readSubscriptionsOverMcp`'s `8000` and `wakeArmingHook`'s derived budget both live under a **15s `SessionStart`** registration, which runs once per session.

| | registration | fires | inner budget |
|---|---|---|---|
| `wakeArmingHook` | `SessionStart`, 15s | once per session | 10000 (derived) |
| `turnPresenceHook` | `UserPromptSubmit` + `PostToolUse`, **2s** | every prompt, every tool call | 1500 |

So `1500` is **already inside** its ceiling, with 500ms to spare. Raising it to 8000 would place the inner deadline four times beyond a bound that terminates the process first — converting a reportable skip into a silent kill, which is precisely the *"unmeasured state that looks measured"* failure neomjs/neo#16513 existed to remove. **The constant was never the binding constraint. The ceiling is.**

## What actually changed

The number stays `1500` and stops being a coincidence. It is now derived from the ceiling it must respect, mirroring `wakeArmingHook`:

```js
export const HOOK_TIMEOUT_MS         = 2000;   // == the registered `timeout`, spec-asserted
export const HOOK_OVERHEAD_MARGIN_MS = 500;
resolveExchangeDeadlineMs()                    // → 1500
```

**The margin is measured, not guessed.** Spawn-through-import of the writer's full module graph: 5 samples, 90–100ms wall (~50ms of it the import). Reserved at 500ms rather than the measurement because under-reserving fails asymmetrically — if the exchange is still running when the harness kills the process, there is no report at all, which is strictly worse than the named skip an exceeded *inner* deadline produces.

**The clamp is two-sided, deliberately unlike the precedent.** `wakeArmingHook`'s `Math.max(1000, hookTimeoutMs - publishMarginMs)` bounds only the floor, so it can return a value *equal to* its own ceiling. Ceiling-equality is the silent-kill case, so this one clamps both ends.

## Deltas

**Delta 1 — the ticket's fix item 1 is not implementable as written**, for the reason above. Its fix item 3 ("respect the harness-registered hook timeout as the ceiling") is the one that governs, and honouring it forecloses item 1. Implemented accordingly.

**Delta 2 — the name is kept, not changed.** Fix item 2 offers rename *or* document. `NEO_TURN_PRESENCE_HOOK_WRITE_TIMEOUT_MS` is an operator-facing override; renaming it silently breaks anyone who set it, for a readability gain. Documented instead, with the history recorded where the constant lives.

**Delta 3 — fix item 4 is already done.** `resolveMemoryCoreGraphPath` exists **nowhere in the tree** — verified across every `.mjs` and `.json`. The ticket's second finding was resolved by other work before this lane opened. Nothing to remove.

## Test Evidence

```
npm run test-unit -- unit/ai/mcp/server/memory-core/
  104 passed
```

**Mutation-differential:**

| mutation | result |
|---|---|
| `HOOK_TIMEOUT_MS` → 8000 (adopt the sibling) | **2 failed** — both settings-parity assertions |
| drop the upper clamp (sibling's lower-only shape) | **1 failed** — the retune case |
| paste the literal `1500` back, and move the margin | **1 failed** — the drift case |
| paste the literal `1500` back, margin unchanged | **0 failed** — see below |

## The receipt that did NOT fire, and the comment I had to delete

I wrote, in the spec, that the derived-value assertion would catch someone pasting `1500` back. **It does not, and the mutation is what told me.** The derived value is numerically identical to the literal it replaces — that is the whole point, the number was never the defect — so no assertion can separate "derived" from "literal that happens to match" while the two coincide.

The claim is now stated at its true strength in the spec: what is pinned is the pair **drifting apart afterwards** (row three above — a stale literal under a moved margin fails), which is the state that actually stops reports. The false version was deleted rather than annotated.

Second time tonight a mutation caught an explanatory comment of mine that read well and was wrong. Worth naming as a pattern: a comment asserting *"this test would catch X"* is a claim about the test, and it is falsifiable in exactly the same way the code is.

## What this does NOT establish

- **It does not make presence reliable on a remote plane.** No budget under a 2s ceiling covers a cold TLS MCP exchange to a different machine. That is the operator's original scenario and it remains open.
- **The residual is a deployment-shape question, not a constant.** The options are raising a ceiling that runs on *every tool call* — a latency cost on every seat, an operator call and not mine to make — or not doing a synchronous network write from a per-tool-use hook at all. Flagged, deliberately unresolved, and out of this ticket's scope.
- **An operator override can still exceed the ceiling.** `resolveTurnPresenceRuntimeConfig` does not clamp `NEO_TURN_PRESENCE_HOOK_WRITE_TIMEOUT_MS` against `HOOK_TIMEOUT_MS`. A spec records this explicitly rather than leaving it implied; clamping an operator's stated intent silently would be its own defect.

## Post-Merge Validation

- [ ] Nothing outstanding. The parity spec binds the constant to both settings files from this merge onward, so a future change to either registration fails in CI rather than in silence.

## Commits

- `679c57fd4c` — the derivation, the measured margin, and the parity spec

Authored by Ada (Claude Opus 5, Claude Code). Session 87f453f9-aa80-4487-9ed1-b5d91e052c43.
