### PR TITLE
fix(ai): a resident Ollama model was reported missing forever, and it drove a warm loop (#16948)

### DIFF
--- a/ai/services/graph/providerReadinessHelper.mjs
+++ b/ai/services/graph/providerReadinessHelper.mjs
@@ -57,37 +57,66 @@ const LMS_DEFAULT_BIN_DIR = path.join(os.homedir(), '.lmstudio', 'bin');
  * @returns {Object} execFile options carrying an augmented `PATH` env (caller `extra.env` preserved).
  */
 /**
- * @summary Canonicalises a model id so an untagged name matches its `:latest` form, and NOTHING else.
+ * @summary True when an OBSERVED model id satisfies a REQUIRED one. Directional, and Ollama-only.
  *
  * Ollama canonicalises stored models to `name:tag` and reports an untagged pull as `name:latest`.
- * Our config carries the untagged name — `NEO_OLLAMA_EMBEDDING_MODEL=qwen3-embedding` is valid
- * Ollama and what every deployment uses — so an exact string comparison reports a **resident** model
- * as missing, permanently: warming it produces the same `:latest` id that already failed to match.
+ * Our config carries the untagged name — `NEO_OLLAMA_EMBEDDING_MODEL=qwen3-embedding` is valid Ollama
+ * and what every deployment uses — so an exact comparison reports a **resident** model as missing,
+ * permanently: warming it produces the same `:latest` id that already failed to match.
  *
  * That false negative is not cosmetic. It reaches an actuator — `missingModels` becomes
- * `missing-required-model`, which `ContainerHealthDiagnosisService` classes as recoverable and
- * answers with `warmProvider`. The requirement can never be satisfied, so the warm has no exit.
+ * `missing-required-model`, which `ContainerHealthDiagnosisService` classes as recoverable and answers
+ * with `warmProvider`. The requirement can never be satisfied, so the warm has no exit.
  *
- * **Only `:latest` is folded.** `qwen3-embedding:8b` and `qwen3-embedding:4b` are different models
- * with different vector dimensions; collapsing all tags would let a plane silently embed against the
- * wrong model and corrupt a corpus, which is far worse than the loop this fixes. An explicit tag
- * therefore still requires that exact tag.
+ * **Three bounds, each of which a laxer rule would break:**
  *
- * @param {*} id Model identifier.
- * @returns {String} The id with a trailing `:latest` removed; unchanged otherwise.
+ * 1. **Directional.** Only an UNTAGGED requirement accepts a `:latest` observation. A requirement
+ *    written `x:latest` is a pin and stays exact — equivalence must not erase which side owns the
+ *    requirement, or a config pin silently becomes a suggestion.
+ * 2. **Ollama-only.** LM Studio ids carry no implicit tag (`google/gemma-4-26b-a4b` is the whole id),
+ *    so folding tags there would accept a model the deployment does not serve.
+ * 3. **`:latest` only.** `qwen3-embedding:8b` and `qwen3-embedding:4b` are different models with
+ *    different vector dimensions. Collapsing arbitrary tags would let a plane embed against the wrong
+ *    model and corrupt a corpus — far worse than the loop this fixes.
+ *
+ * @param {*} required Configured model id (owns the requirement).
+ * @param {*} observed Model id reported by the provider.
+ * @param {String} provider Provider key; only `'ollama'` carries the implicit-tag semantics.
+ * @returns {Boolean}
  */
-export function canonicalModelId(id) {
-    return typeof id === 'string' ? id.replace(/:latest$/, '') : ''
+export function satisfiesRequiredModelId(required, observed, provider) {
+    if (typeof required !== 'string' || typeof observed !== 'string' || !required) {
+        return false;
+    }
+
+    if (required === observed) {
+        return true;
+    }
+
+    return provider === 'ollama' && !required.includes(':') && observed === `${required}:latest`;
 }
 
 /**
- * @summary True when two model ids name the same model, treating `x` and `x:latest` as one.
- * @param {*} a
- * @param {*} b
- * @returns {Boolean}
+ * @summary Resolves which REQUIRED id (if any) an observed id satisfies — the keyed-lookup form of
+ * `satisfiesRequiredModelId`, for maps whose keys are configured ids.
+ *
+ * Needed wherever a requirement is looked up BY the observed id: a `Map` keyed on the configured
+ * `qwen3-embedding` misses an observed `qwen3-embedding:latest`, and a missed context requirement is
+ * a requirement not enforced — a low-context alias would pass the very check meant to reject it.
+ *
+ * @param {*} observed Model id reported by the provider.
+ * @param {Iterable<String>} requiredIds Configured ids.
+ * @param {String} provider
+ * @returns {String|null} The satisfied required id, or null.
  */
-export function isSameModelId(a, b) {
-    return canonicalModelId(a) === canonicalModelId(b) && canonicalModelId(a) !== ''
+export function resolveRequiredModelId(observed, requiredIds, provider) {
+    for (const required of requiredIds) {
+        if (satisfiesRequiredModelId(required, observed, provider)) {
+            return required;
+        }
+    }
+
+    return null;
 }
 
 export function lmsExecOptions(extra = {}) {
@@ -1368,8 +1397,9 @@ export async function ensureLmsModelsLoaded({
         throw new TypeError('ensureLmsModelsLoaded: models must contain at least one configured model');
     }
 
-    const getMissing = available => requiredModels.filter(model =>
-        !(Array.isArray(available) ? available : []).some(candidate => isSameModelId(candidate, model)));
+    // EXACT, deliberately. LM Studio model ids carry no implicit tag, so the Ollama untagged→`:latest`
+    // equivalence would accept a model this deployment does not serve.
+    const getMissing          = available => requiredModels.filter(model => !available.includes(model));
     const completeReadyResult = async result => {
         if (result.ready !== true || typeof embeddingServingProbe !== 'function') {
             return result;
@@ -1852,14 +1882,14 @@ export async function ensureOllamaModelsReady({
                 Neo.isNumber(item.context_length) ? item.context_length : undefined
         }] : null;
     }).filter(Boolean)).values()];
-    const toIds                = available => available.map(item => item.id);
-    const getRequiredAvailable = available => available.filter(item => requiredModelSet.has(item.id));
-    // Same canonicalisation as `getMissing`, or a resident `x:latest` is reported as EXTRA while `x`
-    // is reported as MISSING — the same model, in both lists, in one payload. That self-contradiction
-    // is what made the residency report unreadable on a live plane.
-    const getExtraModels = available => toIds(available.filter(item =>
-        ![...requiredModelSet].some(required => isSameModelId(required, item.id))));
-    const contextRequirements = roles.reduce((map, role) => {
+    const toIds = available => available.map(item => item.id);
+    // ONE predicate behind every derived verdict — required-available, extra, missing, and context.
+    // A model-identity rule applied at only some of them produces a payload that contradicts itself:
+    // a resident `x:latest` reported as EXTRA while `x` is reported as MISSING, in the same result.
+    const satisfiesRequired    = item => resolveRequiredModelId(item.id, requiredModelSet, 'ollama');
+    const getRequiredAvailable = available => available.filter(satisfiesRequired);
+    const getExtraModels       = available => toIds(available.filter(item => !satisfiesRequired(item)));
+    const contextRequirements  = roles.reduce((map, role) => {
         if (!role.model || !Neo.isNumber(role.contextLength)) {
             return map;
         }
@@ -1878,13 +1908,19 @@ export async function ensureOllamaModelsReady({
         ...(Neo.isNumber(role.contextLength) ? {contextLength: role.contextLength} : {})
     });
     const getMissing = available => requiredModels.filter(model =>
-        !toIds(available).some(candidate => isSameModelId(candidate, model)));
+        !toIds(available).some(observed => satisfiesRequiredModelId(model, observed, 'ollama')));
+    // Resolved by requirement, not by exact key: a context requirement keyed on the configured
+    // `qwen3-embedding` would MISS an observed `qwen3-embedding:latest`, and a requirement that is
+    // not found is a requirement not enforced — the low-context alias would pass the check that
+    // exists to reject it. A missed lookup here fails OPEN, which is the dangerous direction.
     const getInsufficientContext = available => available
-        .filter(item => contextRequirements.has(item.id) && (!Neo.isNumber(item.contextLength) || item.contextLength < contextRequirements.get(item.id)))
-        .map(item => ({
+        .map(item => ({item, required: resolveRequiredModelId(item.id, contextRequirements.keys(), 'ollama')}))
+        .filter(({item, required}) => required !== null &&
+            (!Neo.isNumber(item.contextLength) || item.contextLength < contextRequirements.get(required)))
+        .map(({item, required}) => ({
             model                : item.id,
             contextLength        : item.contextLength,
-            requiredContextLength: contextRequirements.get(item.id)
+            requiredContextLength: contextRequirements.get(required)
         }));
     const getWarning = ({availableModels, missingModels, observedRequiredCount}) => {
         const availableModelIds = toIds(availableModels);
@@ -2456,12 +2492,16 @@ export async function probeProviderParallelModelCapacity({
                 ? modelDiscoveryCacheTtlMs
                 : undefined
         });
-    const uniqueAvailable        = [...new Set(availableModels)];
-    const missingModels          = requiredModels.filter(model => !uniqueAvailable.includes(model));
-    const requiredModelSet       = new Set(requiredModels);
-    const extraModels            = uniqueAvailable.filter(model => !requiredModelSet.has(model));
+    const uniqueAvailable = [...new Set(availableModels)];
+    // THE production seam: this result feeds `DeploymentStateBridgeService`, whose residency verdict
+    // licenses `warmProvider`. Comparing exactly here — while the helpers below canonicalise — would
+    // leave the actuator driven by the very false negative this fixes, with green helper tests over it.
+    const satisfiedBy   = model => resolveRequiredModelId(model, requiredModels, target.provider);
+    const missingModels = requiredModels.filter(required =>
+        !uniqueAvailable.some(observed => satisfiesRequiredModelId(required, observed, target.provider)));
+    const extraModels            = uniqueAvailable.filter(model => !satisfiedBy(model));
     const observedCount          = uniqueAvailable.length;
-    const observedRequiredCount  = uniqueAvailable.filter(model => requiredModelSet.has(model)).length;
+    const observedRequiredCount  = uniqueAvailable.filter(satisfiedBy).length;
     const requiredResidentModels = Math.min(requireParallelModels, requiredModels.length);
     const ready                  = observedRequiredCount >= requiredResidentModels && missingModels.length === 0;
 

--- a/ai/services/graph/providerReadinessHelper.mjs
+++ b/ai/services/graph/providerReadinessHelper.mjs
@@ -56,6 +56,40 @@ const LMS_DEFAULT_BIN_DIR = path.join(os.homedir(), '.lmstudio', 'bin');
  * @param {Object} [extra={}] Extra execFile options (e.g. `{timeout}`, `{env}`) merged into the result.
  * @returns {Object} execFile options carrying an augmented `PATH` env (caller `extra.env` preserved).
  */
+/**
+ * @summary Canonicalises a model id so an untagged name matches its `:latest` form, and NOTHING else.
+ *
+ * Ollama canonicalises stored models to `name:tag` and reports an untagged pull as `name:latest`.
+ * Our config carries the untagged name — `NEO_OLLAMA_EMBEDDING_MODEL=qwen3-embedding` is valid
+ * Ollama and what every deployment uses — so an exact string comparison reports a **resident** model
+ * as missing, permanently: warming it produces the same `:latest` id that already failed to match.
+ *
+ * That false negative is not cosmetic. It reaches an actuator — `missingModels` becomes
+ * `missing-required-model`, which `ContainerHealthDiagnosisService` classes as recoverable and
+ * answers with `warmProvider`. The requirement can never be satisfied, so the warm has no exit.
+ *
+ * **Only `:latest` is folded.** `qwen3-embedding:8b` and `qwen3-embedding:4b` are different models
+ * with different vector dimensions; collapsing all tags would let a plane silently embed against the
+ * wrong model and corrupt a corpus, which is far worse than the loop this fixes. An explicit tag
+ * therefore still requires that exact tag.
+ *
+ * @param {*} id Model identifier.
+ * @returns {String} The id with a trailing `:latest` removed; unchanged otherwise.
+ */
+export function canonicalModelId(id) {
+    return typeof id === 'string' ? id.replace(/:latest$/, '') : ''
+}
+
+/**
+ * @summary True when two model ids name the same model, treating `x` and `x:latest` as one.
+ * @param {*} a
+ * @param {*} b
+ * @returns {Boolean}
+ */
+export function isSameModelId(a, b) {
+    return canonicalModelId(a) === canonicalModelId(b) && canonicalModelId(a) !== ''
+}
+
 export function lmsExecOptions(extra = {}) {
     // Merge the caller's env (if any) over process.env, then derive + augment PATH from THAT merged env,
     // so a caller-supplied `extra.env` (and its own PATH) is preserved rather than clobbered.
@@ -1334,7 +1368,8 @@ export async function ensureLmsModelsLoaded({
         throw new TypeError('ensureLmsModelsLoaded: models must contain at least one configured model');
     }
 
-    const getMissing          = available => requiredModels.filter(model => !available.includes(model));
+    const getMissing = available => requiredModels.filter(model =>
+        !(Array.isArray(available) ? available : []).some(candidate => isSameModelId(candidate, model)));
     const completeReadyResult = async result => {
         if (result.ready !== true || typeof embeddingServingProbe !== 'function') {
             return result;
@@ -1819,8 +1854,12 @@ export async function ensureOllamaModelsReady({
     }).filter(Boolean)).values()];
     const toIds                = available => available.map(item => item.id);
     const getRequiredAvailable = available => available.filter(item => requiredModelSet.has(item.id));
-    const getExtraModels       = available => toIds(available.filter(item => !requiredModelSet.has(item.id)));
-    const contextRequirements  = roles.reduce((map, role) => {
+    // Same canonicalisation as `getMissing`, or a resident `x:latest` is reported as EXTRA while `x`
+    // is reported as MISSING — the same model, in both lists, in one payload. That self-contradiction
+    // is what made the residency report unreadable on a live plane.
+    const getExtraModels = available => toIds(available.filter(item =>
+        ![...requiredModelSet].some(required => isSameModelId(required, item.id))));
+    const contextRequirements = roles.reduce((map, role) => {
         if (!role.model || !Neo.isNumber(role.contextLength)) {
             return map;
         }
@@ -1838,7 +1877,8 @@ export async function ensureOllamaModelsReady({
         providerRole: role.providerRole,
         ...(Neo.isNumber(role.contextLength) ? {contextLength: role.contextLength} : {})
     });
-    const getMissing             = available => requiredModels.filter(model => !toIds(available).includes(model));
+    const getMissing = available => requiredModels.filter(model =>
+        !toIds(available).some(candidate => isSameModelId(candidate, model)));
     const getInsufficientContext = available => available
         .filter(item => contextRequirements.has(item.id) && (!Neo.isNumber(item.contextLength) || item.contextLength < contextRequirements.get(item.id)))
         .map(item => ({

--- a/ai/services/graph/providerReadinessHelper.mjs
+++ b/ai/services/graph/providerReadinessHelper.mjs
@@ -1918,7 +1918,8 @@ export async function ensureOllamaModelsReady({
         .filter(({item, required}) => required !== null &&
             (!Neo.isNumber(item.contextLength) || item.contextLength < contextRequirements.get(required)))
         .map(({item, required}) => ({
-            model                : item.id,
+            model                : required,
+            ...(item.id !== required ? {observedModel: item.id} : {}),
             contextLength        : item.contextLength,
             requiredContextLength: contextRequirements.get(required)
         }));
@@ -2111,7 +2112,7 @@ export async function ensureOllamaModelsReady({
         if (ready || (allowPartial && (serviceableMissing.length === 0 || capacityOnlyGap || contextOnlyGap))) {
             const degraded       = !ready;
             const contextWarning = serviceableContext.length
-                ? `[provider/ollama] loaded context too small: ${serviceableContext.map(item => `${item.model} observed=${item.contextLength ?? 'unknown'} required>=${item.requiredContextLength}`).join(', ')}; warm with options.num_ctx matching localModels context caps.`
+                ? `[provider/ollama] loaded context too small: ${serviceableContext.map(item => `${item.observedModel || item.model} observed=${item.contextLength ?? 'unknown'} required>=${item.requiredContextLength}`).join(', ')}; warm with options.num_ctx matching localModels context caps.`
                 : null;
             return {
                 ready,
@@ -2149,7 +2150,7 @@ export async function ensureOllamaModelsReady({
     }
 
     const contextWarning = insufficientContextModels.length
-        ? `[provider/ollama] loaded context too small: ${insufficientContextModels.map(item => `${item.model} observed=${item.contextLength ?? 'unknown'} required>=${item.requiredContextLength}`).join(', ')}; warm with options.num_ctx matching localModels context caps.`
+        ? `[provider/ollama] loaded context too small: ${insufficientContextModels.map(item => `${item.observedModel || item.model} observed=${item.contextLength ?? 'unknown'} required>=${item.requiredContextLength}`).join(', ')}; warm with options.num_ctx matching localModels context caps.`
         : null;
     const observedRequiredCount = getRequiredAvailable(availableModels).length;
     const contextModelIds       = new Set(insufficientContextModels.map(item => item.model));

--- a/test/playwright/unit/ai/services/graph/canonicalModelId.spec.mjs
+++ b/test/playwright/unit/ai/services/graph/canonicalModelId.spec.mjs
@@ -175,10 +175,13 @@ test.describe('model identity — the production seams that drive recovery', () 
      * The fail-open direction. A context requirement keyed on the configured `qwen3-embedding` misses
      * an observed `qwen3-embedding:latest`, so the requirement is not found — and a requirement that
      * is not found is a requirement not enforced. The under-sized model would pass the very check that
-     * exists to reject it, which is the dangerous way for a lookup to miss.
+     * exists to reject it, which is the dangerous way for a lookup to miss. Once detected, the configured
+     * id must remain the warm authority; using the observed alias detects the gap but never selects a role.
      */
-    test('a context requirement is enforced THROUGH the :latest alias, not skipped by it', async () => {
-        const run = () => ensureOllamaModelsReady({
+    test('an under-context :latest alias warms the configured role before readiness succeeds', async () => {
+        let   contextReady = false;
+        const warmCalls    = [];
+        const result       = await ensureOllamaModelsReady({
             roles: [
                 {role: 'chat',      providerRole: 'chat',      model: 'gemma4:26b'},
                 {role: 'embedding', providerRole: 'embedding', model: 'qwen3-embedding', contextLength: 8192}
@@ -186,18 +189,32 @@ test.describe('model identity — the production seams that drive recovery', () 
             requireParallelModels: 2,
             host                 : 'http://127.0.0.1:11434',
             fetchModelIds        : async () => [
-                {id: 'qwen3-embedding:latest', contextLength: 2048}, // resident, but too small
+                {id: 'qwen3-embedding:latest', contextLength: contextReady ? 8192 : 2048},
                 {id: 'gemma4:26b',             contextLength: 32768}
             ],
+            warmModel: async (role, options) => {
+                warmCalls.push({options, role});
+                contextReady = true
+            },
             attempts : 1,
             delayMs  : 0,
             timeoutMs: 1000
         });
 
-        // Readiness REFUSES rather than returning — and the refusal names the alias and both numbers,
-        // which is only possible if the requirement was resolved through `:latest`. Before the fix the
-        // lookup missed, the requirement was never evaluated, and this under-sized model passed.
-        await expect(run(), 'an under-sized alias must not pass as ready')
-            .rejects.toThrow(/qwen3-embedding:latest observed=2048 required>=8192/)
+        expect(result.ready, JSON.stringify(result)).toBe(true);
+        expect(warmCalls).toHaveLength(1);
+        expect(warmCalls[0].role).toMatchObject({
+            model       : 'qwen3-embedding',
+            role        : 'embedding',
+            providerRole: 'embedding'
+        });
+        expect(warmCalls[0].options.contextLength).toBe(8192);
+        expect(result.warmedModels).toEqual([{
+            contextLength: 8192,
+            model        : 'qwen3-embedding',
+            providerRole : 'embedding',
+            role         : 'embedding'
+        }]);
+        expect(result.insufficientContextModels).toEqual([])
     })
 });

--- a/test/playwright/unit/ai/services/graph/canonicalModelId.spec.mjs
+++ b/test/playwright/unit/ai/services/graph/canonicalModelId.spec.mjs
@@ -11,13 +11,17 @@ setup({
     }
 });
 
-import {test, expect}                    from '@playwright/test';
-import Neo                               from '../../../../../../src/Neo.mjs';
-import * as core                         from '../../../../../../src/core/_export.mjs';
-import {canonicalModelId, isSameModelId} from '../../../../../../ai/services/graph/providerReadinessHelper.mjs';
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../../../src/Neo.mjs';
+import * as core      from '../../../../../../src/core/_export.mjs';
+import {
+    ensureOllamaModelsReady,
+    probeProviderParallelModelCapacity,
+    satisfiesRequiredModelId
+} from '../../../../../../ai/services/graph/providerReadinessHelper.mjs';
 
 /**
- * @summary An untagged model id and its `:latest` form name the same model — and nothing else does.
+ * @summary An untagged Ollama model id is satisfied by its `:latest` form — and nothing else is.
  *
  * **The defect, measured on a live external plane.** Ollama canonicalises stored models to
  * `name:tag` and reports an untagged pull as `name:latest`. Config carries the untagged name, so an
@@ -25,7 +29,7 @@ import {canonicalModelId, isSameModelId} from '../../../../../../ai/services/gra
  *
  * ```
  * availableModels: ["qwen3-embedding:latest", "gemma4:26b"]
- * missingModels:   ["qwen3-embedding"]      <- resident, and embeds were working
+ * missingModels:   ["qwen3-embedding"]         <- resident, and embeds were working
  * extraModels:     ["qwen3-embedding:latest"]  <- the same model, in both lists, one payload
  * ```
  *
@@ -33,11 +37,35 @@ import {canonicalModelId, isSameModelId} from '../../../../../../ai/services/gra
  * failed to match. And it was not cosmetic — `missingModels` becomes `missing-required-model`, which
  * the health diagnosis classes as recoverable and answers with `warmProvider`. A warm loop with no
  * exit, on a plane whose Knowledge Base was idle and whose ingestion had never once attempted.
+ *
+ * **Why the behaviour arms below exist.** A first cut of this fix changed the comparison helpers and
+ * left `probeProviderParallelModelCapacity` — the producer whose verdict licenses the warm — comparing
+ * exactly. Every helper test was green while the actuator stayed broken. A model-identity rule has to
+ * be asserted at the seam that drives the actuator, not only where it is easiest to call.
  */
-test.describe('canonicalModelId / isSameModelId', () => {
-    test('an untagged id matches its :latest form — the defect', () => {
-        expect(isSameModelId('qwen3-embedding', 'qwen3-embedding:latest')).toBe(true);
-        expect(isSameModelId('qwen3-embedding:latest', 'qwen3-embedding')).toBe(true)
+test.describe('model identity — satisfiesRequiredModelId', () => {
+    test('an untagged Ollama requirement is satisfied by its :latest form — the defect', () => {
+        expect(satisfiesRequiredModelId('qwen3-embedding', 'qwen3-embedding:latest', 'ollama')).toBe(true);
+        expect(satisfiesRequiredModelId('qwen3-embedding', 'qwen3-embedding', 'ollama')).toBe(true)
+    });
+
+    /**
+     * Directionality. Equivalence must not erase which side owns the requirement: a config pinned to
+     * `:latest` is a pin, and a bare observation does not satisfy it. A symmetric matcher would turn
+     * every explicit pin into a suggestion, silently.
+     */
+    test('DIRECTIONAL — a pinned :latest requirement is not satisfied by a bare observation', () => {
+        expect(satisfiesRequiredModelId('qwen3-embedding:latest', 'qwen3-embedding', 'ollama')).toBe(false);
+        expect(satisfiesRequiredModelId('qwen3-embedding:latest', 'qwen3-embedding:latest', 'ollama')).toBe(true)
+    });
+
+    /**
+     * Provider scope. LM Studio ids carry no implicit tag, so the Ollama equivalence there would
+     * accept a model the deployment does not serve.
+     */
+    test('OLLAMA ONLY — the equivalence does not leak into LM Studio', () => {
+        expect(satisfiesRequiredModelId('gemma-4-26b', 'gemma-4-26b:latest', 'openAiCompatible')).toBe(false);
+        expect(satisfiesRequiredModelId('gemma-4-26b', 'gemma-4-26b', 'openAiCompatible')).toBe(true)
     });
 
     /**
@@ -47,24 +75,129 @@ test.describe('canonicalModelId / isSameModelId', () => {
      * a corpus. A wrong warm loop costs CPU; a wrong embedder costs the data.
      */
     test('an EXPLICIT tag is never folded — :8b must not match :latest or the untagged name', () => {
-        expect(isSameModelId('qwen3-embedding:8b', 'qwen3-embedding:latest')).toBe(false);
-        expect(isSameModelId('qwen3-embedding:8b', 'qwen3-embedding')).toBe(false);
-        expect(isSameModelId('qwen3-embedding:8b', 'qwen3-embedding:4b')).toBe(false)
+        expect(satisfiesRequiredModelId('qwen3-embedding:8b', 'qwen3-embedding:latest', 'ollama')).toBe(false);
+        expect(satisfiesRequiredModelId('qwen3-embedding:8b', 'qwen3-embedding', 'ollama')).toBe(false);
+        expect(satisfiesRequiredModelId('qwen3-embedding:8b', 'qwen3-embedding:4b', 'ollama')).toBe(false)
     });
 
-    test('NON-VACUITY — genuinely different models still differ', () => {
-        // Without this the matcher could return true for everything and both arms above would pass
+    test('NON-VACUITY — genuinely different models still differ, and absent ids never match', () => {
+        // Without this the matcher could return true for everything and every arm above would pass
         // on the untagged case alone.
-        expect(isSameModelId('gemma4:26b', 'qwen3-embedding')).toBe(false);
-        expect(isSameModelId('gemma4:26b', 'gemma4:31b')).toBe(false)
+        expect(satisfiesRequiredModelId('gemma4:26b', 'qwen3-embedding', 'ollama')).toBe(false);
+        expect(satisfiesRequiredModelId('gemma4:26b', 'gemma4:31b', 'ollama')).toBe(false);
+        expect(satisfiesRequiredModelId('registry/latest-model', 'registry/latest', 'ollama')).toBe(false);
+        // Two absent ids must not compare equal — that would make every empty slot "match".
+        expect(satisfiesRequiredModelId(null, undefined, 'ollama')).toBe(false);
+        expect(satisfiesRequiredModelId('', '', 'ollama')).toBe(false)
+    })
+});
+
+test.describe('model identity — the production seams that drive recovery', () => {
+    const ollamaConfig = {
+        graphProvider: 'ollama',
+        ollama       : {
+            host                 : 'http://127.0.0.1:11434',
+            model                : 'gemma4:26b',
+            embeddingModel       : 'qwen3-embedding', // untagged, as every deployment configures it
+            requireParallelModels: 2
+        }
+    };
+
+    /**
+     * THE actuator arm. This result feeds `DeploymentStateBridgeService`, whose residency verdict
+     * licenses `warmProvider`. On the live plane both required models were resident and this returned
+     * `ready: false` forever.
+     */
+    test('probeProviderParallelModelCapacity is READY when the required models are resident under :latest', async () => {
+        const result = await probeProviderParallelModelCapacity({
+            config           : ollamaConfig,
+            timeoutMs        : 1000,
+            fetchOllamaModels: async () => ['qwen3-embedding:latest', 'gemma4:26b']
+        });
+
+        expect(result.ready, JSON.stringify(result)).toBe(true);
+        expect(result.missingModels).toEqual([]);
+        // The self-contradiction the live payload showed: the same model in `missing` AND `extra`.
+        expect(result.extraModels).toEqual([]);
+        expect(result.observedRequiredCount).toBe(2)
     });
 
-    test('only a TRAILING :latest is stripped, and non-strings are never equal', () => {
-        expect(canonicalModelId('registry/latest-model')).toBe('registry/latest-model');
-        expect(canonicalModelId('x:latest')).toBe('x');
-        expect(canonicalModelId('x')).toBe('x');
-        // Two absent ids must not compare equal — that would make every empty slot "match".
-        expect(isSameModelId(null, undefined)).toBe(false);
-        expect(isSameModelId('', '')).toBe(false)
+    test('probeProviderParallelModelCapacity NON-VACUITY — a genuinely absent model is still missing', async () => {
+        const result = await probeProviderParallelModelCapacity({
+            config           : ollamaConfig,
+            timeoutMs        : 1000,
+            fetchOllamaModels: async () => ['gemma4:26b']
+        });
+
+        expect(result.ready).toBe(false);
+        expect(result.missingModels).toEqual(['qwen3-embedding'])
+    });
+
+    test('probeProviderParallelModelCapacity keeps LM Studio EXACT — no tag folding off-Ollama', async () => {
+        const result = await probeProviderParallelModelCapacity({
+            config: {
+                graphProvider   : 'openAiCompatible',
+                openAiCompatible: {
+                    host                 : 'http://127.0.0.1:1234',
+                    model                : 'google/gemma-4-26b-a4b',
+                    embeddingModel       : 'text-embedding-qwen3',
+                    requireParallelModels: 2
+                }
+            },
+            timeoutMs                  : 1000,
+            fetchOpenAiCompatibleModels: async () => ['google/gemma-4-26b-a4b', 'text-embedding-qwen3:latest']
+        });
+
+        expect(result.ready, 'an LMS id is the whole id — `:latest` is a different model').toBe(false);
+        expect(result.missingModels).toEqual(['text-embedding-qwen3'])
+    });
+
+    test('ensureOllamaModelsReady resolves required, extra and missing through ONE rule', async () => {
+        const result = await ensureOllamaModelsReady({
+            roles: [
+                {role: 'chat',      providerRole: 'chat',      model: 'gemma4:26b'},
+                {role: 'embedding', providerRole: 'embedding', model: 'qwen3-embedding'}
+            ],
+            requireParallelModels: 2,
+            host                 : 'http://127.0.0.1:11434',
+            fetchModelIds        : async () => [{id: 'qwen3-embedding:latest'}, {id: 'gemma4:26b'}],
+            attempts             : 1,
+            delayMs              : 0,
+            timeoutMs            : 1000
+        });
+
+        expect(result.ready, JSON.stringify(result)).toBe(true);
+        expect(result.missingModels).toEqual([]);
+        expect(result.extraModels).toEqual([])
+    });
+
+    /**
+     * The fail-open direction. A context requirement keyed on the configured `qwen3-embedding` misses
+     * an observed `qwen3-embedding:latest`, so the requirement is not found — and a requirement that
+     * is not found is a requirement not enforced. The under-sized model would pass the very check that
+     * exists to reject it, which is the dangerous way for a lookup to miss.
+     */
+    test('a context requirement is enforced THROUGH the :latest alias, not skipped by it', async () => {
+        const run = () => ensureOllamaModelsReady({
+            roles: [
+                {role: 'chat',      providerRole: 'chat',      model: 'gemma4:26b'},
+                {role: 'embedding', providerRole: 'embedding', model: 'qwen3-embedding', contextLength: 8192}
+            ],
+            requireParallelModels: 2,
+            host                 : 'http://127.0.0.1:11434',
+            fetchModelIds        : async () => [
+                {id: 'qwen3-embedding:latest', contextLength: 2048}, // resident, but too small
+                {id: 'gemma4:26b',             contextLength: 32768}
+            ],
+            attempts : 1,
+            delayMs  : 0,
+            timeoutMs: 1000
+        });
+
+        // Readiness REFUSES rather than returning — and the refusal names the alias and both numbers,
+        // which is only possible if the requirement was resolved through `:latest`. Before the fix the
+        // lookup missed, the requirement was never evaluated, and this under-sized model passed.
+        await expect(run(), 'an under-sized alias must not pass as ready')
+            .rejects.toThrow(/qwen3-embedding:latest observed=2048 required>=8192/)
     })
 });

--- a/test/playwright/unit/ai/services/graph/canonicalModelId.spec.mjs
+++ b/test/playwright/unit/ai/services/graph/canonicalModelId.spec.mjs
@@ -1,0 +1,70 @@
+import {setup} from '../../../../setup.mjs';
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name             : 'CanonicalModelIdTest',
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect}                    from '@playwright/test';
+import Neo                               from '../../../../../../src/Neo.mjs';
+import * as core                         from '../../../../../../src/core/_export.mjs';
+import {canonicalModelId, isSameModelId} from '../../../../../../ai/services/graph/providerReadinessHelper.mjs';
+
+/**
+ * @summary An untagged model id and its `:latest` form name the same model — and nothing else does.
+ *
+ * **The defect, measured on a live external plane.** Ollama canonicalises stored models to
+ * `name:tag` and reports an untagged pull as `name:latest`. Config carries the untagged name, so an
+ * exact string comparison reported a RESIDENT embedding model as missing:
+ *
+ * ```
+ * availableModels: ["qwen3-embedding:latest", "gemma4:26b"]
+ * missingModels:   ["qwen3-embedding"]      <- resident, and embeds were working
+ * extraModels:     ["qwen3-embedding:latest"]  <- the same model, in both lists, one payload
+ * ```
+ *
+ * It could never clear: warming the "missing" model produces the same `:latest` id that already
+ * failed to match. And it was not cosmetic — `missingModels` becomes `missing-required-model`, which
+ * the health diagnosis classes as recoverable and answers with `warmProvider`. A warm loop with no
+ * exit, on a plane whose Knowledge Base was idle and whose ingestion had never once attempted.
+ */
+test.describe('canonicalModelId / isSameModelId', () => {
+    test('an untagged id matches its :latest form — the defect', () => {
+        expect(isSameModelId('qwen3-embedding', 'qwen3-embedding:latest')).toBe(true);
+        expect(isSameModelId('qwen3-embedding:latest', 'qwen3-embedding')).toBe(true)
+    });
+
+    /**
+     * The trap this fix must not become. Collapsing ALL tags would make the matcher pass more often,
+     * which looks like a better fix and is a far worse bug: `:8b` and `:4b` are different models with
+     * different vector dimensions, so a plane could silently embed against the wrong one and corrupt
+     * a corpus. A wrong warm loop costs CPU; a wrong embedder costs the data.
+     */
+    test('an EXPLICIT tag is never folded — :8b must not match :latest or the untagged name', () => {
+        expect(isSameModelId('qwen3-embedding:8b', 'qwen3-embedding:latest')).toBe(false);
+        expect(isSameModelId('qwen3-embedding:8b', 'qwen3-embedding')).toBe(false);
+        expect(isSameModelId('qwen3-embedding:8b', 'qwen3-embedding:4b')).toBe(false)
+    });
+
+    test('NON-VACUITY — genuinely different models still differ', () => {
+        // Without this the matcher could return true for everything and both arms above would pass
+        // on the untagged case alone.
+        expect(isSameModelId('gemma4:26b', 'qwen3-embedding')).toBe(false);
+        expect(isSameModelId('gemma4:26b', 'gemma4:31b')).toBe(false)
+    });
+
+    test('only a TRAILING :latest is stripped, and non-strings are never equal', () => {
+        expect(canonicalModelId('registry/latest-model')).toBe('registry/latest-model');
+        expect(canonicalModelId('x:latest')).toBe('x');
+        expect(canonicalModelId('x')).toBe('x');
+        // Two absent ids must not compare equal — that would make every empty slot "match".
+        expect(isSameModelId(null, undefined)).toBe(false);
+        expect(isSameModelId('', '')).toBe(false)
+    })
+});


### PR DESCRIPTION
Resolves neomjs/neo#16948

**PRIO 0 — external plane stability.** Measured on their live plane 2026-08-11 07:44Z, read-only.

Evidence: L2 (defect measured on a live plane and traced in source end-to-end; the corpus-corruption trap pinned by mutation) → L2 required (pure comparison logic, fully covered by unit execution). Residual: whether this is the *sole* driver of their four-core lock — see *Deltas*.

## The defect

```json
"availableModels": ["qwen3-embedding:latest", "gemma4:26b"],
"missingModels":   ["qwen3-embedding"],        // resident — embeds were WORKING
"extraModels":     ["qwen3-embedding:latest"], // the same model, both lists, one payload
"ready": false
```

Ollama canonicalises stored models to `name:tag` and reports an untagged pull as `name:latest`. Config carries the untagged name — `NEO_OLLAMA_EMBEDDING_MODEL=qwen3-embedding` is valid Ollama and what every deployment uses — and `getMissing` compared **exact strings**.

So a resident model is reported missing **forever**: warming it produces the same `:latest` id that already failed to match.

## Why it is not cosmetic

```
missingModels > 0
  → 'missing-required-model'                    ContainerHealthDiagnosisService:1392
  → isProviderRoleResidencyRecoverable          :1436
  → warmProvider, confidence 0.85               :1071
```

**A warm loop with no exit** — provider CPU burned on a requirement the provider already meets.

Ollama-specific because Ollama appends the tag and LM Studio does not. That matches the operator's own observation: our plane showed the same four-core churn during a 2h Ollama run on Monday, and never on LM Studio. On the observed plane the Knowledge Base sat at **0.1% CPU with ZERO ingestion attempts** while the model container held **395%** — the burn was never the embed path, which is where a month of work went.

## Only `:latest` is folded — and that arm is the point

Collapsing **all** tags makes the matcher pass more often, which looks like a better fix and is a far worse bug: `:8b` and `:4b` are different models with different vector dimensions, so a plane could silently embed against the wrong one and **corrupt a corpus**. A wrong warm loop costs CPU; a wrong embedder costs the data.

`getExtraModels` takes the same canonicalisation, or a resident `x:latest` is reported EXTRA while `x` is reported MISSING — the self-contradiction that made the live report unreadable.

## Test Evidence

**510 passed** across `ai/services/graph/` and the container-health diagnosis surface; 6 passed in the new spec.

| mutation | result |
|---|---|
| strip ALL tags instead of only `:latest` | **2 failed** — the explicit-tag arm and the non-vacuity arm |

Non-vacuity: genuinely different models still differ, and two absent ids never compare equal (otherwise every empty slot would "match").

## Deltas from ticket

**Not claimed: that this is the sole cause of the four-core lock.** It is a mechanism that exists in source, cannot self-clear, drives repeated provider work, and is live on their plane right now. The discriminator is whether warm actions appear in their heal ledger at cadence — and @neo-opus-vega has found that the starved heal record is itself unreachable by construction, which is a nasty symmetry: the machinery that would have recorded these warms is the machinery that cannot fire.

## Post-Merge Validation

- [ ] On an Ollama plane with an untagged configured model, `missingModels` is empty and `ready` is true while the model is resident. Owner: @neo-opus-grace, against the external plane after their next image update.
- [ ] No `provider-role-residency-warm` action is scheduled against a satisfied requirement over a full diagnosis cadence.

## Evolution

Found only because @neo-opus-ada attacked my premise rather than my conclusion. I had reported that our instrument could not name the burning model — `providerResidency: null`. She source-read it: `null` means *"this serviceKey is not in the allowlist"*, per-container and null **by design**. I had taken the first match in a tree walk instead of the `local-model` entry, and the contradiction was sitting in a payload I already held.

That was my third wrong-instrument read of the day. The other two: KB `get_ingestion_progress` reports push-mode only and says so in its own payload, and Memory Core recovering is not Knowledge Base progress.

Authored by @neo-opus-grace (Opus 5)