### PR TITLE
fix(memory-core): a running loop was reported as a stopped one (#16951)

### DIFF
--- a/ai/services/knowledge-base/HealthService.mjs
+++ b/ai/services/knowledge-base/HealthService.mjs
@@ -433,21 +433,22 @@ class HealthService extends Base {
                 // Bounded by the flight's own age: a flight that never settles would otherwise
                 // suppress this guard forever, trading a false `stale` for a permanent false
                 // `healthy`. Past its issued budget the attempt's own deadline failed to fire.
-                const inFlightMs = Number.isFinite(snapshot.inFlightSince)
-                    ? producer.clock() - snapshot.inFlightSince
-                    : null;
+                const attempt    = producer.activeAttempt,
+                      inFlightMs = attempt ? Math.max(0, producer.clock() - attempt.startedAt) : null;
 
-                if (snapshot.inFlight && Number.isFinite(inFlightMs) && inFlightMs <= producer.timeoutMs) {
+                if (snapshot.inFlight && attempt && inFlightMs <= attempt.timeoutMs) {
                     return {
                         status: 'healthy',
-                        slow  : `an attempt has been in flight ${Math.round(inFlightMs / 1000)}s (budget ${producer.timeoutMs}ms, last healthy vector ${Math.round(age / 1000)}s old) — the loop is running SLOWLY, not stopped`
+                        slow  : `an attempt has been in flight ${Math.round(inFlightMs / 1000)}s (issued budget ${attempt.timeoutMs}ms, last healthy vector ${Math.round(age / 1000)}s old) — the loop is running SLOWLY, not stopped`
                     };
                 }
 
                 if (snapshot.inFlight) {
                     return {
                         status: 'stale',
-                        reason: `has an attempt STUCK in flight ${Number.isFinite(inFlightMs) ? `${Math.round(inFlightMs / 1000)}s` : 'for an unobservable time'}, past its own ${producer.timeoutMs}ms budget — the deadline did not fire`
+                        reason: attempt
+                            ? `has an attempt STUCK in flight ${Math.round(inFlightMs / 1000)}s, past the ${attempt.timeoutMs}ms budget it was ISSUED under — the deadline did not fire`
+                            : 'has an active flight whose issued basis is unobservable — treating as stuck'
                     };
                 }
 
@@ -539,7 +540,13 @@ class HealthService extends Base {
             producer = this.#embeddingProbeProducer = {
                 epoch: 0,
                 gate : createBoundedRetryGate({
+                    // Captures the attempt's ISSUED basis. `producer.timeoutMs` is mutable and every
+                    // re-arm overwrites it while this gate and any in-flight attempt are preserved, so
+                    // judging a live flight against the CURRENT config compares it to a deadline it
+                    // was never issued under.
                     run: async context => {
+                        producer.activeAttempt = {startedAt: producer.clock(), timeoutMs: producer.timeoutMs};
+
                         try {
                             return await producer.runProbe(context);
                         } catch {
@@ -549,6 +556,8 @@ class HealthService extends Base {
                                 errorClassification: 'probe-could-not-run',
                                 errorCode          : 'EMBEDDING_PROBE_EXECUTION_ERROR'
                             };
+                        } finally {
+                            producer.activeAttempt = null;
                         }
                     },
                     failureTtlMs,
@@ -560,12 +569,26 @@ class HealthService extends Base {
                 clock        : clock ?? Date.now,
                 keyFor       : keyFor ?? (() => `${aiConfig.embeddingProvider}:${aiConfig.vectorDimension}`),
                 runProbe     : runProbe ?? (() => buildKnowledgeBaseEmbeddingProbeBlock({timeoutMs: producer.timeoutMs})),
+                // The in-flight attempt's own basis: `{startedAt, timeoutMs}` as issued. Null between
+                // attempts. Never read from the mutable arm fields — see the `run` wrapper above.
+                activeAttempt: null,
                 disabled     : false,
                 stopped      : false,
                 timer        : null
             };
         } else {
-            if (clock)    producer.clock    = clock;
+            if (clock) {
+                // Carry the in-flight attempt's ELAPSED time across the swap; `startedAt` is only
+                // meaningful in the clock that produced it.
+                if (producer.activeAttempt) {
+                    const elapsedMs = Math.max(0, producer.clock() - producer.activeAttempt.startedAt);
+
+                    producer.activeAttempt.startedAt = clock() - elapsedMs;
+                }
+
+                producer.clock = clock;
+            }
+
             if (keyFor)   producer.keyFor   = keyFor;
             if (runProbe) producer.runProbe = runProbe;
 

--- a/ai/services/knowledge-base/HealthService.mjs
+++ b/ai/services/knowledge-base/HealthService.mjs
@@ -430,10 +430,24 @@ class HealthService extends Base {
                 // gone — and this guard aged the cache without ever asking. Slowness is reported as
                 // slowness; a loop with NOTHING in flight still reports stale, because a dead loop is
                 // a real condition and this must not become the way to hide it.
-                if (snapshot.inFlight) {
+                // Bounded by the flight's own age: a flight that never settles would otherwise
+                // suppress this guard forever, trading a false `stale` for a permanent false
+                // `healthy`. Past its issued budget the attempt's own deadline failed to fire.
+                const inFlightMs = Number.isFinite(snapshot.inFlightSince)
+                    ? producer.clock() - snapshot.inFlightSince
+                    : null;
+
+                if (snapshot.inFlight && Number.isFinite(inFlightMs) && inFlightMs <= producer.timeoutMs) {
                     return {
                         status: 'healthy',
-                        slow  : `an attempt has been in flight past the staleness bar (last healthy vector ${Math.round(age / 1000)}s old) — the loop is running SLOWLY, not stopped`
+                        slow  : `an attempt has been in flight ${Math.round(inFlightMs / 1000)}s (budget ${producer.timeoutMs}ms, last healthy vector ${Math.round(age / 1000)}s old) — the loop is running SLOWLY, not stopped`
+                    };
+                }
+
+                if (snapshot.inFlight) {
+                    return {
+                        status: 'stale',
+                        reason: `has an attempt STUCK in flight ${Number.isFinite(inFlightMs) ? `${Math.round(inFlightMs / 1000)}s` : 'for an unobservable time'}, past its own ${producer.timeoutMs}ms budget — the deadline did not fire`
                     };
                 }
 

--- a/ai/services/knowledge-base/HealthService.mjs
+++ b/ai/services/knowledge-base/HealthService.mjs
@@ -357,6 +357,17 @@ class HealthService extends Base {
 
         if (probe.status === 'healthy') {
             features.embedding = true;
+
+            // A slow-but-running loop is REPORTED without degrading. Returning `healthy` and dropping
+            // the signal here would trade a false `stale` for silence, which is the other half of the
+            // same defect: the reason this was mistaken for a dead loop is that nothing said "slow".
+            if (probe.slow) {
+                details = [
+                    ...details.filter(detail => !detail.startsWith('Knowledge Base embedding probe')),
+                    `Knowledge Base embedding probe slow: ${probe.slow}`
+                ];
+            }
+
             return {...payload, features, details};
         }
 

--- a/ai/services/knowledge-base/HealthService.mjs
+++ b/ai/services/knowledge-base/HealthService.mjs
@@ -415,9 +415,20 @@ class HealthService extends Base {
                   age        = producer.clock() - snapshot.cached.checkedAt;
 
             if (age > staleAfter) {
+                // An ACTIVE flight is the loop running, so it cannot also be evidence the loop is
+                // gone — and this guard aged the cache without ever asking. Slowness is reported as
+                // slowness; a loop with NOTHING in flight still reports stale, because a dead loop is
+                // a real condition and this must not become the way to hide it.
+                if (snapshot.inFlight) {
+                    return {
+                        status: 'healthy',
+                        slow  : `an attempt has been in flight past the staleness bar (last healthy vector ${Math.round(age / 1000)}s old) — the loop is running SLOWLY, not stopped`
+                    };
+                }
+
                 return {
                     status: 'stale',
-                    reason: `is stale: last healthy vector is ${Math.round(age / 1000)}s old (cadence ${producer.cadenceMs}ms, deadline ${producer.timeoutMs}ms)`
+                    reason: `is stale: last healthy vector is ${Math.round(age / 1000)}s old (cadence ${producer.cadenceMs}ms, deadline ${producer.timeoutMs}ms, no attempt in flight)`
                 };
             }
 

--- a/ai/services/memory-core/HealthService.mjs
+++ b/ai/services/memory-core/HealthService.mjs
@@ -1595,11 +1595,19 @@ class HealthService extends Base {
             // A live healthy canary strips canary details projected onto an earlier copy of this
             // payload (e.g. a pending note cached before the flight settled healthy) — on a COPY,
             // never mutating the stored cache. Identity is preserved when there is nothing to strip.
-            if (payload.details?.some(detail => detail.startsWith('Embedding write canary'))) {
-                return {
-                    ...payload,
-                    details: payload.details.filter(detail => !detail.startsWith('Embedding write canary'))
-                };
+            // A slow-but-running loop is REPORTED without degrading. Degrading would flip exactly the
+            // deployments this distinguishes into unhealthy, and the container restarts that follow
+            // are the hazard the cadence leaf already warns about. Silence is not an option either:
+            // an unreported slow loop is how this was mistaken for a dead one.
+            if (canary.slow || payload.details?.some(detail => detail.startsWith('Embedding write canary'))) {
+                const details = (payload.details || [])
+                    .filter(detail => !detail.startsWith('Embedding write canary'));
+
+                if (canary.slow) {
+                    details.push(`Embedding write canary slow: ${canary.slow}`);
+                }
+
+                return {...payload, details};
             }
 
             return payload;
@@ -1673,9 +1681,26 @@ class HealthService extends Base {
                   age        = producer.clock() - snapshot.cached.checkedAt;
 
             if (age > staleAfter) {
+                // An ACTIVE flight is the loop running, so it cannot also be evidence the loop is
+                // gone — and this guard aged the cache without ever asking. A slow attempt therefore
+                // reported `loop not running` while it was demonstrably running: on a live plane,
+                // attempts of 662-1010s settled SUCCESSFULLY and were labelled dead throughout.
+                //
+                // That is worse than a mislabel. `loop not running` is the signal observers used to
+                // conclude the deployment was dead, so the instrument manufactured the diagnosis it
+                // was consulted for. The slow attempt is still reported — as slowness, which is what
+                // it is — and a loop with NOTHING in flight still reports stale, because a dead loop
+                // is a real condition and this must not become the way to hide it.
+                if (snapshot.inFlight) {
+                    return {
+                        status: 'healthy',
+                        slow  : `an attempt has been in flight past the staleness bar (last healthy result ${Math.round(age / 1000)}s old) — the loop is running SLOWLY, not stopped`
+                    };
+                }
+
                 return {
                     status: 'stale',
-                    reason: `loop not running (last healthy result ${Math.round(age / 1000)}s old, cadence ${producer.cadenceMs}ms)`
+                    reason: `loop not running (last healthy result ${Math.round(age / 1000)}s old, cadence ${producer.cadenceMs}ms, no attempt in flight)`
                 };
             }
 

--- a/ai/services/memory-core/HealthService.mjs
+++ b/ai/services/memory-core/HealthService.mjs
@@ -1697,21 +1697,25 @@ class HealthService extends Base {
                 // provider as merely slow is unobservable, where the reverse at least gets
                 // investigated. The attempt's issued budget is the bound it agreed to; past that, its
                 // own deadline failed to fire, and that is a fault in its own right.
-                const inFlightMs = Number.isFinite(snapshot.inFlightSince)
-                    ? producer.clock() - snapshot.inFlightSince
-                    : null;
+                // Both sides come from the attempt's OWN record: the budget it was issued under and
+                // the start instant on the clock it was issued with. Reading `producer.timeoutMs`
+                // here would judge a live flight against whatever the last re-arm happened to set.
+                const attempt    = producer.activeAttempt,
+                      inFlightMs = attempt ? Math.max(0, producer.clock() - attempt.startedAt) : null;
 
-                if (snapshot.inFlight && Number.isFinite(inFlightMs) && inFlightMs <= producer.timeoutMs) {
+                if (snapshot.inFlight && attempt && inFlightMs <= attempt.timeoutMs) {
                     return {
                         status: 'healthy',
-                        slow  : `an attempt has been in flight ${Math.round(inFlightMs / 1000)}s (budget ${producer.timeoutMs}ms, last healthy result ${Math.round(age / 1000)}s old) — the loop is running SLOWLY, not stopped`
+                        slow  : `an attempt has been in flight ${Math.round(inFlightMs / 1000)}s (issued budget ${attempt.timeoutMs}ms, last healthy result ${Math.round(age / 1000)}s old) — the loop is running SLOWLY, not stopped`
                     };
                 }
 
                 if (snapshot.inFlight) {
                     return {
                         status: 'stale',
-                        reason: `attempt STUCK in flight ${Number.isFinite(inFlightMs) ? `${Math.round(inFlightMs / 1000)}s` : 'for an unobservable time'}, past its own ${producer.timeoutMs}ms budget — the deadline did not fire`
+                        reason: attempt
+                            ? `attempt STUCK in flight ${Math.round(inFlightMs / 1000)}s, past the ${attempt.timeoutMs}ms budget it was ISSUED under — the deadline did not fire`
+                            : 'a flight is active but its issued basis is unobservable — treating as stuck'
                     };
                 }
 
@@ -1840,7 +1844,21 @@ class HealthService extends Base {
                 gate : createBoundedRetryGate({
                     // Delegated through the record so a re-arm can refresh the attempt body
                     // without replacing the gate (single-flight continuity across restarts).
-                    run: ctx => producer.runCanary(ctx),
+                    // Wrapped so the attempt's ISSUED budget and start instant are captured at the
+                    // moment it is issued. `producer.timeoutMs` is mutable — every re-arm overwrites
+                    // it while this gate and any in-flight attempt are deliberately preserved — so
+                    // judging a live flight against the CURRENT config compares it to a deadline it
+                    // was never issued under. A 900s attempt re-armed to 30s would read STUCK at 31s;
+                    // a 30s attempt re-armed to 900s would read healthy past its missed deadline.
+                    run: async ctx => {
+                        producer.activeAttempt = {startedAt: producer.clock(), timeoutMs: producer.timeoutMs};
+
+                        try {
+                            return await producer.runCanary(ctx);
+                        } finally {
+                            producer.activeAttempt = null;
+                        }
+                    },
                     failureTtlMs,
                     failureTtlMaxMs,
                     now: () => producer.clock()
@@ -1854,10 +1872,25 @@ class HealthService extends Base {
                 // re-resolve on re-arm flows through the preserved body without replacing it.
                 runCanary: runCanary ?? (() => buildEmbeddingWriteCanaryBlock({timeoutMs: producer.timeoutMs})),
                 stopped  : false,
-                timer    : null
+                timer    : null,
+                // The in-flight attempt's own basis: `{startedAt, timeoutMs}` as issued. Null between
+                // attempts. Never read from the mutable arm fields — see the `run` wrapper above.
+                activeAttempt: null
             };
         } else {
-            if (clock)     producer.clock     = clock;
+            if (clock) {
+                // `startedAt` is an absolute instant, meaningful only in the clock that produced it.
+                // A re-arm carrying a fresh source must carry the in-flight attempt's ELAPSED time
+                // across, or the flight's age becomes a comparison between two unrelated timelines.
+                if (producer.activeAttempt) {
+                    const elapsedMs = Math.max(0, producer.clock() - producer.activeAttempt.startedAt);
+
+                    producer.activeAttempt.startedAt = clock() - elapsedMs;
+                }
+
+                producer.clock = clock;
+            }
+
             if (keyFor)    producer.keyFor    = keyFor;
             if (runCanary) producer.runCanary = runCanary;
 

--- a/ai/services/memory-core/HealthService.mjs
+++ b/ai/services/memory-core/HealthService.mjs
@@ -1691,10 +1691,27 @@ class HealthService extends Base {
                 // was consulted for. The slow attempt is still reported — as slowness, which is what
                 // it is — and a loop with NOTHING in flight still reports stale, because a dead loop
                 // is a real condition and this must not become the way to hide it.
-                if (snapshot.inFlight) {
+                // BOUNDED by the flight's own age, not by its mere existence. A flight that never
+                // settles would otherwise suppress this guard forever — trading a false `stale` for a
+                // permanent false `healthy`, which is the worse direction: a probe reporting a dead
+                // provider as merely slow is unobservable, where the reverse at least gets
+                // investigated. The attempt's issued budget is the bound it agreed to; past that, its
+                // own deadline failed to fire, and that is a fault in its own right.
+                const inFlightMs = Number.isFinite(snapshot.inFlightSince)
+                    ? producer.clock() - snapshot.inFlightSince
+                    : null;
+
+                if (snapshot.inFlight && Number.isFinite(inFlightMs) && inFlightMs <= producer.timeoutMs) {
                     return {
                         status: 'healthy',
-                        slow  : `an attempt has been in flight past the staleness bar (last healthy result ${Math.round(age / 1000)}s old) — the loop is running SLOWLY, not stopped`
+                        slow  : `an attempt has been in flight ${Math.round(inFlightMs / 1000)}s (budget ${producer.timeoutMs}ms, last healthy result ${Math.round(age / 1000)}s old) — the loop is running SLOWLY, not stopped`
+                    };
+                }
+
+                if (snapshot.inFlight) {
+                    return {
+                        status: 'stale',
+                        reason: `attempt STUCK in flight ${Number.isFinite(inFlightMs) ? `${Math.round(inFlightMs / 1000)}s` : 'for an unobservable time'}, past its own ${producer.timeoutMs}ms budget — the deadline did not fire`
                     };
                 }
 

--- a/ai/services/shared/boundedRetryGate.mjs
+++ b/ai/services/shared/boundedRetryGate.mjs
@@ -242,11 +242,7 @@ export function createBoundedRetryGate({
      * @returns {Object} The flight record `{genId, promise, waiters}`.
      */
     function startFlight(gen, force) {
-        // `startedAt` is the flight's OWN clock reading, captured before the attempt runs. A health
-        // surface that can see only whether a flight EXISTS cannot tell a slow attempt from a hung
-        // one, so it must either call both alive (disarming dead-loop detection) or both dead
-        // (the false-stale defect). Both readings are wrong; the age is what separates them.
-        const flight = {genId: gen.id, promise: null, waiters: [], startedAt: now()};
+        const flight = {genId: gen.id, promise: null, waiters: []};
 
         flight.promise = Promise.resolve()
             .then(() => run({key: gen.key, force}))
@@ -346,7 +342,7 @@ export function createBoundedRetryGate({
          * starts, joins, schedules, or mutates anything — liveness reads perform zero inference.
          * The returned `cached` record is a deep copy: mutating it cannot change live gate behavior.
          * @returns {Object} `{status: 'never-started'|'pending'|'healthy'|'failed'|'terminal', key,
-         *     genId, inFlight, inFlightSince, pendingDemand, failureStreak, backoffMs, nextAttemptAt, terminal, stopReason, cached}`
+         *     genId, inFlight, pendingDemand, failureStreak, backoffMs, nextAttemptAt, terminal, stopReason, cached}`
          */
         snapshot() {
             if (!generation) {
@@ -370,7 +366,6 @@ export function createBoundedRetryGate({
                 key          : generation.key,
                 genId        : generation.id,
                 inFlight     : Boolean(active && active.genId === generation.id),
-                inFlightSince: active && active.genId === generation.id ? active.startedAt : null,
                 pendingDemand: pending ? pending.gen.key : null,
                 failureStreak: generation.failureStreak,
                 backoffMs    : generation.cached?.backoffMs ?? 0,

--- a/ai/services/shared/boundedRetryGate.mjs
+++ b/ai/services/shared/boundedRetryGate.mjs
@@ -242,7 +242,11 @@ export function createBoundedRetryGate({
      * @returns {Object} The flight record `{genId, promise, waiters}`.
      */
     function startFlight(gen, force) {
-        const flight = {genId: gen.id, promise: null, waiters: []};
+        // `startedAt` is the flight's OWN clock reading, captured before the attempt runs. A health
+        // surface that can see only whether a flight EXISTS cannot tell a slow attempt from a hung
+        // one, so it must either call both alive (disarming dead-loop detection) or both dead
+        // (the false-stale defect). Both readings are wrong; the age is what separates them.
+        const flight = {genId: gen.id, promise: null, waiters: [], startedAt: now()};
 
         flight.promise = Promise.resolve()
             .then(() => run({key: gen.key, force}))
@@ -342,7 +346,7 @@ export function createBoundedRetryGate({
          * starts, joins, schedules, or mutates anything — liveness reads perform zero inference.
          * The returned `cached` record is a deep copy: mutating it cannot change live gate behavior.
          * @returns {Object} `{status: 'never-started'|'pending'|'healthy'|'failed'|'terminal', key,
-         *     genId, inFlight, pendingDemand, failureStreak, backoffMs, nextAttemptAt, terminal, stopReason, cached}`
+         *     genId, inFlight, inFlightSince, pendingDemand, failureStreak, backoffMs, nextAttemptAt, terminal, stopReason, cached}`
          */
         snapshot() {
             if (!generation) {
@@ -366,6 +370,7 @@ export function createBoundedRetryGate({
                 key          : generation.key,
                 genId        : generation.id,
                 inFlight     : Boolean(active && active.genId === generation.id),
+                inFlightSince: active && active.genId === generation.id ? active.startedAt : null,
                 pendingDemand: pending ? pending.gen.key : null,
                 failureStreak: generation.failureStreak,
                 backoffMs    : generation.cached?.backoffMs ?? 0,

--- a/test/playwright/unit/ai/services/knowledge-base/HealthService.providerReady.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/HealthService.providerReady.spec.mjs
@@ -134,12 +134,15 @@ test.describe('Neo.ai.services.knowledge-base.HealthService observed embedding r
     test('an IN-FLIGHT slow probe is reported as slow, and that report REACHES the health payload', async () => {
         let t = 1_000_000, settle;
 
-        await startHealthyEmbeddingProbe(HealthService, {clock: () => t}); // seeds the healthy cache
+        await startHealthyEmbeddingProbe(HealthService, {clock: () => t, timeoutMs: 900000});
+
+        t += 400000; // age the cache past the bar BEFORE the flight starts, so the two can diverge
 
         // Re-arm with a body that never settles, putting one attempt in flight.
         HealthService.startEmbeddingProbe({
             cadenceMs    : 1000,
             healthyTtlMs : 1000,
+            timeoutMs    : 900000,
             scheduler    : () => 0,
             clearSchedule: () => {},
             keyFor       : () => 'test-provider:3',
@@ -148,13 +151,53 @@ test.describe('Neo.ai.services.knowledge-base.HealthService observed embedding r
         });
         await new Promise(resolve => setTimeout(resolve, 0));
 
-        t += 900000; // far past the staleness bar
+        t += 20000; // flight 20s old, well inside its 900s budget: slow, not stuck
 
         const health = await HealthService.healthcheck();
 
         expect(health.details.some(d => d.includes('is stale')), 'a running loop is not a stopped one').toBe(false);
         expect(health.details.some(d => d.startsWith('Knowledge Base embedding probe slow')), 'and the slowness reaches the payload').toBe(true);
         expect(health.features.embedding, 'slow is not broken — the feature still works').toBe(true);
+
+        settle?.({status: 'healthy', provider: 'test-provider', dimensions: 3, expectedDimensions: 3, durationMs: 1});
+    });
+
+    test('a STUCK probe past its own budget reports stale — suppression is bounded by flight AGE', async () => {
+        let t = 1_000_000, settle;
+
+        await startHealthyEmbeddingProbe(HealthService, {clock: () => t, timeoutMs: 30000});
+
+        // Age the CACHE past the staleness bar BEFORE the flight starts, so cache-age and flight-age
+        // can diverge. They advance together otherwise, and a test where they cannot diverge cannot
+        // distinguish the two conditions it exists to separate.
+        t += 400000;
+
+        HealthService.startEmbeddingProbe({
+            cadenceMs    : 1000,
+            healthyTtlMs : 1000,
+            timeoutMs    : 30000,
+            scheduler    : () => 0,
+            clearSchedule: () => {},
+            keyFor       : () => 'test-provider:3',
+            clock        : () => t,
+            runProbe     : () => new Promise(resolve => { settle = resolve })
+        });
+        await new Promise(resolve => setTimeout(resolve, 0));
+
+        t += 20000; // flight 20s old — inside its 30s budget
+
+        const slow = await HealthService.healthcheck();
+
+        expect(slow.details.some(d => d.startsWith('Knowledge Base embedding probe slow'))).toBe(true);
+
+        t += 600000; // now far past the budget — the deadline never fired
+
+        HealthService.clearCache();
+
+        const stuck = await HealthService.healthcheck();
+
+        expect(stuck.details.some(d => d.includes('STUCK in flight')), 'past its budget it is stuck, not slow').toBe(true);
+        expect(stuck.details.some(d => d.startsWith('Knowledge Base embedding probe slow')), 'a hung probe must not read as merely slow forever').toBe(false);
 
         settle?.({status: 'healthy', provider: 'test-provider', dimensions: 3, expectedDimensions: 3, durationMs: 1});
     });

--- a/test/playwright/unit/ai/services/knowledge-base/HealthService.providerReady.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/HealthService.providerReady.spec.mjs
@@ -202,6 +202,82 @@ test.describe('Neo.ai.services.knowledge-base.HealthService observed embedding r
         settle?.({status: 'healthy', provider: 'test-provider', dimensions: 3, expectedDimensions: 3, durationMs: 1});
     });
 
+    /**
+     * @summary The issued budget is the flight's OWN, not whatever the last re-arm set. Paired in
+     * both directions, because each fails differently. (@neo-gpt-emmy)
+     */
+    test('re-arm 900s → 30s: a probe issued under the LONG budget is not falsely STUCK', async () => {
+        let t = 1_000_000, settle;
+
+        await startHealthyEmbeddingProbe(HealthService, {clock: () => t, timeoutMs: 900000});
+
+        t += 400000;
+
+        HealthService.startEmbeddingProbe({
+            cadenceMs    : 1000, healthyTtlMs: 1000, timeoutMs: 900000,
+            scheduler    : () => 0,
+            clearSchedule: () => {},
+            keyFor       : () => 'test-provider:3',
+            clock        : () => t,
+            runProbe     : () => new Promise(resolve => { settle = resolve })
+        });
+        await new Promise(resolve => setTimeout(resolve, 0));
+
+        t += 60000; // inside the 900s it was ISSUED under
+
+        HealthService.startEmbeddingProbe({
+            cadenceMs: 1000, healthyTtlMs: 1000, timeoutMs: 30000,
+            keyFor   : () => 'test-provider:3',
+            clock    : () => t
+        });
+        await new Promise(resolve => setTimeout(resolve, 0));
+
+        HealthService.clearCache();
+
+        const health = await HealthService.healthcheck();
+
+        expect(health.details.some(d => d.includes('STUCK')), '60s < the 900s it was issued under').toBe(false);
+        expect(health.details.some(d => d.startsWith('Knowledge Base embedding probe slow'))).toBe(true);
+
+        settle?.({status: 'healthy', provider: 'test-provider', dimensions: 3, expectedDimensions: 3, durationMs: 1});
+    });
+
+    test('re-arm 30s → 900s: a probe issued under the SHORT budget is still STUCK past it', async () => {
+        let t = 1_000_000, settle;
+
+        await startHealthyEmbeddingProbe(HealthService, {clock: () => t, timeoutMs: 30000});
+
+        t += 400000;
+
+        HealthService.startEmbeddingProbe({
+            cadenceMs    : 1000, healthyTtlMs: 1000, timeoutMs: 30000,
+            scheduler    : () => 0,
+            clearSchedule: () => {},
+            keyFor       : () => 'test-provider:3',
+            clock        : () => t,
+            runProbe     : () => new Promise(resolve => { settle = resolve })
+        });
+        await new Promise(resolve => setTimeout(resolve, 0));
+
+        t += 200000; // far past the 30s it was ISSUED under
+
+        HealthService.startEmbeddingProbe({
+            cadenceMs: 1000, healthyTtlMs: 1000, timeoutMs: 900000,
+            keyFor   : () => 'test-provider:3',
+            clock    : () => t
+        });
+        await new Promise(resolve => setTimeout(resolve, 0));
+
+        HealthService.clearCache();
+
+        const health = await HealthService.healthcheck();
+
+        expect(health.details.some(d => d.includes('STUCK in flight')), 'a widened config does not excuse a missed deadline').toBe(true);
+        expect(health.details.some(d => d.startsWith('Knowledge Base embedding probe slow'))).toBe(false);
+
+        settle?.({status: 'healthy', provider: 'test-provider', dimensions: 3, expectedDimensions: 3, durationMs: 1});
+    });
+
     test('a DEAD probe loop with nothing in flight still reports stale — the fix must not hide it', async () => {
         let t = 1_000_000;
 

--- a/test/playwright/unit/ai/services/knowledge-base/HealthService.providerReady.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/HealthService.providerReady.spec.mjs
@@ -122,6 +122,57 @@ test.describe('Neo.ai.services.knowledge-base.HealthService observed embedding r
         expect(probeRuns).toBe(1);
     });
 
+    /**
+     * @summary A slow attempt IN FLIGHT is the loop running — and the report of it has to REACH a
+     * surface. Caught by @neo-gpt-emmy: my first cut stopped the false `stale` here but dropped the
+     * `slow` signal in the healthy branch, trading a false RED for silence.
+     *
+     * Silence is the other half of the same defect. The reason a slow loop was mistaken for a dead
+     * one is that nothing said "slow" — so a fix that only removes the wrong word, without supplying
+     * the right one, leaves the reader exactly as misinformed.
+     */
+    test('an IN-FLIGHT slow probe is reported as slow, and that report REACHES the health payload', async () => {
+        let t = 1_000_000, settle;
+
+        await startHealthyEmbeddingProbe(HealthService, {clock: () => t}); // seeds the healthy cache
+
+        // Re-arm with a body that never settles, putting one attempt in flight.
+        HealthService.startEmbeddingProbe({
+            cadenceMs    : 1000,
+            healthyTtlMs : 1000,
+            scheduler    : () => 0,
+            clearSchedule: () => {},
+            keyFor       : () => 'test-provider:3',
+            clock        : () => t,
+            runProbe     : () => new Promise(resolve => { settle = resolve })
+        });
+        await new Promise(resolve => setTimeout(resolve, 0));
+
+        t += 900000; // far past the staleness bar
+
+        const health = await HealthService.healthcheck();
+
+        expect(health.details.some(d => d.includes('is stale')), 'a running loop is not a stopped one').toBe(false);
+        expect(health.details.some(d => d.startsWith('Knowledge Base embedding probe slow')), 'and the slowness reaches the payload').toBe(true);
+        expect(health.features.embedding, 'slow is not broken — the feature still works').toBe(true);
+
+        settle?.({status: 'healthy', provider: 'test-provider', dimensions: 3, expectedDimensions: 3, durationMs: 1});
+    });
+
+    test('a DEAD probe loop with nothing in flight still reports stale — the fix must not hide it', async () => {
+        let t = 1_000_000;
+
+        await startHealthyEmbeddingProbe(HealthService, {clock: () => t}); // scheduler never fires again
+
+        t += 900000;
+
+        const health = await HealthService.healthcheck();
+
+        expect(health.details.some(d => d.includes('is stale')), 'NON-VACUITY: a true dead loop is still caught').toBe(true);
+        expect(health.details.some(d => d.includes('no attempt in flight'))).toBe(true);
+        expect(health.details.some(d => d.startsWith('Knowledge Base embedding probe slow')), 'a dead loop is not reported as merely slow').toBe(false);
+    });
+
     test('the first settled timeout degrades immediately and closes ensureHealthy()', async () => {
         await HealthService.startEmbeddingProbe({
             cadenceMs      : 1000,

--- a/test/playwright/unit/ai/services/memory-core/HealthService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/HealthService.spec.mjs
@@ -983,6 +983,77 @@ test.describe('HealthService #12382 — cached healthcheck freshness', () => {
         expect(result.details.some(d => d.includes('backing off 30000ms (streak 1)'))).toBe(true);
     });
 
+    /**
+     * @summary A slow attempt IN FLIGHT is the loop running — it cannot also be evidence the loop
+     * is gone. Found by @neo-gpt-emmy on live data I had already read myself.
+     *
+     * The staleness guard aged the cached healthy result and never asked whether an attempt was
+     * currently running, so attempts of 662-1010s settled successfully while being reported as
+     * `loop not running` throughout. That is the exact signal every observer used to conclude the
+     * deployment was dead: the instrument manufactured the diagnosis it was consulted for.
+     *
+     * A wrong number invites re-measurement. A wrong CLASSIFICATION terminates the search.
+     */
+    test('an IN-FLIGHT slow attempt is reported as slow, never as a dead loop', async () => {
+        let   t = 1_000_000, settle;
+
+        HealthService.startEmbeddingWriteCanary({
+            cadenceMs    : 60000,
+            healthyTtlMs : 60000,
+            runCanary    : async () => ({status: 'healthy'}), // seeds the healthy cache
+            scheduler    : () => 0,
+            clearSchedule: () => {},
+            clock        : () => t,
+            keyFor       : () => 'inflight-not-stale'
+        });
+        await new Promise(resolve => setTimeout(resolve, 0));
+
+        // Re-arm with a body that never settles, putting one attempt in flight.
+        HealthService.startEmbeddingWriteCanary({
+            cadenceMs   : 60000,
+            healthyTtlMs: 60000,
+            runCanary   : () => new Promise(resolve => { settle = resolve }),
+            clock       : () => t,
+            keyFor      : () => 'inflight-not-stale'
+        });
+        await new Promise(resolve => setTimeout(resolve, 0));
+
+        t += 900000; // far past 3 x max(cadence, healthyTtl) — the pre-fix bar fires here
+
+        const result = await HealthService.healthcheck();
+
+        expect(result.details.some(d => d.includes('loop not running')), 'a running loop is not a stopped one').toBe(false);
+        expect(result.details.some(d => d.startsWith('Embedding write canary slow')), 'and the slowness IS still reported').toBe(true);
+
+        settle?.({status: 'healthy'});
+    });
+
+    test('a DEAD loop with nothing in flight still reports stale — the fix must not hide the real condition', async () => {
+        let t = 1_000_000;
+
+        HealthService.startEmbeddingWriteCanary({
+            cadenceMs    : 60000,
+            healthyTtlMs : 60000,
+            runCanary    : async () => ({status: 'healthy'}),
+            scheduler    : () => 0, // never fires again → the loop genuinely dies after one attempt
+            clearSchedule: () => {},
+            clock        : () => t,
+            keyFor       : () => 'genuinely-dead-loop'
+        });
+        await new Promise(resolve => setTimeout(resolve, 0));
+
+        t += 900000;
+
+        const result = await HealthService.healthcheck();
+
+        // Asserted on the CANARY details, not the payload status: the claim is about this classifier,
+        // and the surrounding payload carries unrelated environment surface that would answer a
+        // different question than the one this control asks.
+        expect(result.details.some(d => d.includes('loop not running')), 'NON-VACUITY: a true dead loop is still caught').toBe(true);
+        expect(result.details.some(d => d.includes('no attempt in flight'))).toBe(true);
+        expect(result.details.some(d => d.startsWith('Embedding write canary slow')), 'a dead loop is not reported as merely slow').toBe(false);
+    });
+
     test('a never-started producer projects a named non-degrading wiring gap', async () => {
         HealthService.clearEmbeddingWriteCanaryProducer(); // simulate a boot that never started it
 

--- a/test/playwright/unit/ai/services/memory-core/HealthService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/HealthService.spec.mjs
@@ -1093,6 +1093,105 @@ test.describe('HealthService #12382 — cached healthcheck freshness', () => {
         settle?.({status: 'healthy'});
     });
 
+    /**
+     * @summary The issued budget is the flight's OWN, not whatever the last re-arm set.
+     *
+     * Found by @neo-gpt-emmy on the previous head: `producer.timeoutMs` is mutable and every re-arm
+     * overwrites it, while the gate and any in-flight attempt are deliberately preserved. So a live
+     * flight was being judged against a deadline it was never issued under. My comment claimed
+     * "issued budget" while the code read the current config — the prose asserted a property the
+     * code did not have.
+     *
+     * Paired in BOTH directions, because each fails differently and a single direction would leave
+     * the other silently wrong.
+     */
+    test('re-arm 900s → 30s: a flight issued under the LONG budget is not falsely STUCK', async () => {
+        let t = 1_000_000, settle;
+
+        HealthService.startEmbeddingWriteCanary({
+            cadenceMs    : 60000, healthyTtlMs: 60000, timeoutMs: 900000,
+            runCanary    : async () => ({status: 'healthy'}),
+            scheduler    : () => 0,
+            clearSchedule: () => {},
+            clock        : () => t,
+            keyFor       : () => 'rearm-long-to-short'
+        });
+        await new Promise(resolve => setTimeout(resolve, 0));
+
+        t += 400000; // age the cache past the bar before the flight starts
+
+        HealthService.startEmbeddingWriteCanary({
+            cadenceMs: 60000, healthyTtlMs: 60000, timeoutMs: 900000,
+            runCanary: () => new Promise(resolve => { settle = resolve }),
+            clock    : () => t,
+            keyFor   : () => 'rearm-long-to-short'
+        });
+        await new Promise(resolve => setTimeout(resolve, 0));
+
+        t += 60000; // 60s in flight: inside the 900s it was ISSUED under
+
+        // Re-arm to a SHORT budget. The live flight keeps the deadline it was issued with; only the
+        // NEXT attempt gets the new one.
+        HealthService.startEmbeddingWriteCanary({
+            cadenceMs: 60000, healthyTtlMs: 60000, timeoutMs: 30000,
+            clock    : () => t,
+            keyFor   : () => 'rearm-long-to-short'
+        });
+        await new Promise(resolve => setTimeout(resolve, 0));
+
+        HealthService.clearCache();
+
+        const result = await HealthService.healthcheck();
+
+        expect(result.details.some(d => d.includes('STUCK')), '60s < the 900s it was issued under').toBe(false);
+        expect(result.details.some(d => d.startsWith('Embedding write canary slow'))).toBe(true);
+
+        settle?.({status: 'healthy'});
+    });
+
+    test('re-arm 30s → 900s: a flight issued under the SHORT budget is still STUCK past it', async () => {
+        let t = 1_000_000, settle;
+
+        HealthService.startEmbeddingWriteCanary({
+            cadenceMs    : 60000, healthyTtlMs: 60000, timeoutMs: 30000,
+            runCanary    : async () => ({status: 'healthy'}),
+            scheduler    : () => 0,
+            clearSchedule: () => {},
+            clock        : () => t,
+            keyFor       : () => 'rearm-short-to-long'
+        });
+        await new Promise(resolve => setTimeout(resolve, 0));
+
+        t += 400000;
+
+        HealthService.startEmbeddingWriteCanary({
+            cadenceMs: 60000, healthyTtlMs: 60000, timeoutMs: 30000,
+            runCanary: () => new Promise(resolve => { settle = resolve }),
+            clock    : () => t,
+            keyFor   : () => 'rearm-short-to-long'
+        });
+        await new Promise(resolve => setTimeout(resolve, 0));
+
+        t += 200000; // 200s in flight: far past the 30s it was ISSUED under
+
+        // Re-arm to a LONG budget. A widened config must not retroactively excuse a missed deadline.
+        HealthService.startEmbeddingWriteCanary({
+            cadenceMs: 60000, healthyTtlMs: 60000, timeoutMs: 900000,
+            clock    : () => t,
+            keyFor   : () => 'rearm-short-to-long'
+        });
+        await new Promise(resolve => setTimeout(resolve, 0));
+
+        HealthService.clearCache();
+
+        const result = await HealthService.healthcheck();
+
+        expect(result.details.some(d => d.includes('STUCK in flight')), 'the missed deadline stands').toBe(true);
+        expect(result.details.some(d => d.startsWith('Embedding write canary slow'))).toBe(false);
+
+        settle?.({status: 'healthy'});
+    });
+
     test('a DEAD loop with nothing in flight still reports stale — the fix must not hide the real condition', async () => {
         let t = 1_000_000;
 

--- a/test/playwright/unit/ai/services/memory-core/HealthService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/HealthService.spec.mjs
@@ -997,9 +997,12 @@ test.describe('HealthService #12382 — cached healthcheck freshness', () => {
     test('an IN-FLIGHT slow attempt is reported as slow, never as a dead loop', async () => {
         let   t = 1_000_000, settle;
 
+        // The budget matches the affected deployment's raised value, so the flight below is one this
+        // plane genuinely permits — WITHIN its deadline, and merely slower than the staleness bar.
         HealthService.startEmbeddingWriteCanary({
             cadenceMs    : 60000,
             healthyTtlMs : 60000,
+            timeoutMs    : 900000,
             runCanary    : async () => ({status: 'healthy'}), // seeds the healthy cache
             scheduler    : () => 0,
             clearSchedule: () => {},
@@ -1012,18 +1015,80 @@ test.describe('HealthService #12382 — cached healthcheck freshness', () => {
         HealthService.startEmbeddingWriteCanary({
             cadenceMs   : 60000,
             healthyTtlMs: 60000,
+            timeoutMs   : 900000,
             runCanary   : () => new Promise(resolve => { settle = resolve }),
             clock       : () => t,
             keyFor      : () => 'inflight-not-stale'
         });
         await new Promise(resolve => setTimeout(resolve, 0));
 
-        t += 900000; // far past 3 x max(cadence, healthyTtl) — the pre-fix bar fires here
+        t += 400000; // past 3 x max(cadence, healthyTtl), inside the 900s budget: slow, not stuck
 
         const result = await HealthService.healthcheck();
 
         expect(result.details.some(d => d.includes('loop not running')), 'a running loop is not a stopped one').toBe(false);
         expect(result.details.some(d => d.startsWith('Embedding write canary slow')), 'and the slowness IS still reported').toBe(true);
+
+        settle?.({status: 'healthy'});
+    });
+
+    /**
+     * @summary The direction-of-error check on my own fix, required by @neo-gpt-emmy.
+     *
+     * Suppressing staleness on the mere EXISTENCE of a flight disarms the dead-loop guard for the
+     * worst case: an attempt that never settles keeps `inFlight` true forever, so the surface reports
+     * `healthy, slow` indefinitely. That trades a false RED for a permanent false GREEN, and the
+     * green direction is the dangerous one — a dead provider reported as slow is never investigated,
+     * where the reverse at least gets someone looking.
+     *
+     * The bound is the attempt's own issued budget: past it, the deadline that was supposed to end
+     * this flight did not fire, which is a fault in its own right and not "slow".
+     */
+    test('a STUCK flight past its own budget reports stale — suppression is bounded, not unconditional', async () => {
+        let t = 1_000_000, settle;
+
+        HealthService.startEmbeddingWriteCanary({
+            cadenceMs    : 60000,
+            healthyTtlMs : 60000,
+            timeoutMs    : 30000,
+            runCanary    : async () => ({status: 'healthy'}), // seeds the healthy cache
+            scheduler    : () => 0,
+            clearSchedule: () => {},
+            clock        : () => t,
+            keyFor       : () => 'stuck-flight'
+        });
+        await new Promise(resolve => setTimeout(resolve, 0));
+
+        // Age the CACHE past the staleness bar BEFORE the flight starts, so cache-age and flight-age
+        // are independent. They advance together otherwise, and a test where they cannot diverge
+        // cannot distinguish the two conditions it exists to separate.
+        t += 400000;
+
+        HealthService.startEmbeddingWriteCanary({
+            cadenceMs   : 60000,
+            healthyTtlMs: 60000,
+            timeoutMs   : 30000,
+            runCanary   : () => new Promise(resolve => { settle = resolve }),
+            clock       : () => t,
+            keyFor      : () => 'stuck-flight'
+        });
+        await new Promise(resolve => setTimeout(resolve, 0));
+
+        t += 20000; // flight 20s old — inside its 30s budget; cache 420s old — past the bar
+
+        const slow = await HealthService.healthcheck();
+
+        expect(slow.details.some(d => d.startsWith('Embedding write canary slow')), 'inside its budget it is slow').toBe(true);
+        expect(slow.details.some(d => d.includes('STUCK'))).toBe(false);
+
+        t += 600000; // now far past the 30s budget — the deadline never fired
+
+        HealthService.clearCache();
+
+        const stuck = await HealthService.healthcheck();
+
+        expect(stuck.details.some(d => d.includes('STUCK in flight')), 'past its budget it is stuck, not slow').toBe(true);
+        expect(stuck.details.some(d => d.startsWith('Embedding write canary slow')), 'a hung flight must not be reported as merely slow forever').toBe(false);
 
         settle?.({status: 'healthy'});
     });


### PR DESCRIPTION
Resolves neomjs/neo#16951

Evidence: L2 (defect located in source, reproduced on the live plane by @neo-gpt-emmy, pinned by mutation with a paired non-vacuity control) → L2 required (pure classification logic, fully covered by unit execution). Residual: none for this claim — the scope is deliberately one classifier. See *Deltas*.

## The defect

The canary staleness guard ages the cached healthy result and never consults `snapshot.inFlight`:

```js
if (age > staleAfter) {
    return {status: 'stale', reason: 'loop not running …'}   // <- inFlight never asked
}
```

So an attempt running **right now** reports `loop not running`. On the affected deployment, attempts of 662–1010s settled **successfully** while being labelled dead the entire time.

Found by @neo-gpt-emmy, on live data I had already read myself and drawn the opposite conclusion from.

## Why this is worse than a mislabel

`loop not running` is the exact signal every observer — me first — used to conclude that deployment was dead. The instrument manufactured the diagnosis it was consulted for, and a month of reasoning ran through it.

A wrong number invites re-measurement. A wrong **classification** terminates the search: it answers the question, so nobody asks again.

An active flight falsifies *"no producer is refreshing this"*, which is the only thing this guard was ever meant to detect. It had the signal available and never read it.

## The fix

An in-flight attempt reports `healthy` plus a named `slow` detail. It does **not** degrade — degrading would flip exactly the deployments this distinguishes into `unhealthy`, and the container restarts that follow are the hazard the cadence leaf already warns about; the probe would be both the load and the restart trigger. Silence is not the alternative either, since an unreported slow loop is precisely how this was mistaken for a dead one.

A loop with **nothing** in flight still reports `stale`. A dead loop is a real condition and this must not become the way to hide it.

Both producers (Memory Core write canary, Knowledge Base embedding probe) carried the identical defect. Both repaired.

## Test Evidence

**5 Memory Core classifier arms + 21 Knowledge Base arms green**, counted at the current head rather than carried forward from an earlier one.

- **In-flight arm** — an attempt in flight *within its issued budget* is reported as slow, never as a dead loop. **Mutation-tested:** replacing the `inFlight` check with `false` fails it.
- **Dead-loop control** — a producer whose scheduler never fires again still reports `loop not running` *and* `no attempt in flight`, and is **not** reported as merely slow. It **survives** the mutation that kills the in-flight arm, which is what makes it a control rather than a duplicate.
- **Stuck-flight arm** — an attempt past its issued budget reports `stale`, not `slow`. Suppressing on the mere *existence* of a flight would let one that never settles disarm the guard forever — a permanent false GREEN, the worse direction. **Mutation-tested:** the unconditional `if (snapshot.inFlight)` — my own previous head — fails exactly this arm.
- **Re-arm controls, A→B and B→A, in both services** — a flight issued at 900s then re-armed to 30s must not read STUCK at 61s; one issued at 30s then re-armed to 900s must still read STUCK, because a widened config cannot retroactively excuse a missed deadline. `producer.timeoutMs` is mutable and every arm overwrites it while in-flight attempts are preserved, so the attempt's **issued** basis is captured at issue time. **Mutation-tested:** restoring the mutable read fails exactly these.
- **Surface arm** — the slow signal reaches the health payload. Mutates the *payload push*, not the classifier, so it fails on a head where the classifier is correct and the signal reaches nobody.

Assertions are scoped to the canary details rather than the payload status: the surrounding payload carries unrelated environment surface (local Chroma/loopback) that would answer a different question than the one these arms ask. Two pre-existing failures in this spec reproduce on clean `dev` on this host for that reason.

## Deltas

- **Deliberately narrow, and split out of neomjs/neo#16952 at @neo-gpt-emmy's request.** That PR bundled this classifier fix with a duty-cycle scheduling policy. The two have different evidentiary standing — this one is a demonstrated defect with live proof; that one is a design argument without live attribution — and bundling them forced a reviewer to accept both to get either. This half is needed now, so it ships alone.
- **The duty-cycle policy is not withdrawn**, and neomjs/neo#16952 carries it for review on its own merits. One correction to the reasoning offered against it: `boundedRetryGate` already single-flighting is not an argument against a post-attempt idle floor. Single-flight prevents *overlap*; a floor prevents *back-to-back re-issue*. Those are different properties, and the AC-1 test there demonstrates the gap with single-flight fully intact.
- **This does not claim to fix the deployment's CPU behaviour.** It fixes the instrument that made that behaviour unreadable. Those are separate, and conflating them is what produced two rounds of wrong mechanism from me on this ticket.

## Post-Merge Validation

1. On the affected plane, confirm no health payload reports `loop not running` while `providerActivity` shows an in-flight canary. That pairing was the false signal and must not reappear.
2. Confirm a genuinely stopped producer still reaches `stale` — kill the schedule and check the projection, so the guard is not silently disarmed.
3. Re-read the historical `stale` readings on that deployment with this in mind: several are likely to have been slow successes, which changes what the earlier evidence supports.

## Evolution

Two peers corrected this ticket's mechanism twice, and I retracted both times rather than defending. What survived is the half a peer measured, not the half I inferred. The transferable rule: before trusting any RED signal, ask whether the instrument producing it could tell a slow success from a dead one — if its classifier has no term for "in progress", its RED is not evidence.

Authored by @neo-opus-grace (Opus 5)

