### PR TITLE
fix(memory-core): never dispatch provider work that outlives its caller (#16853)

### DIFF
--- a/ai/mcp/server/memory-core/configBase.mjs
+++ b/ai/mcp/server/memory-core/configBase.mjs
@@ -385,6 +385,14 @@ class ConfigBase extends ConfigProvider {
                  * @type {number}
                  */
                 embeddingWriteCanaryTimeoutMs: leaf(30000, 'NEO_MEMORY_HEALTHCHECK_EMBEDDING_WRITE_CANARY_TIMEOUT_MS', 'number'),
+                /*
+                 * How long the caller of this healthcheck will actually wait — the container
+                 * healthcheck `timeout`. The provider does not cancel on client disconnect
+                 * (ollama/ollama#11889), so any budget beyond this dispatches work nobody is (ticket-ref-ok: upstream provider behaviour, not a Neo tracking ref — the mechanism this guard exists for)
+                 * waiting for and, on a single-slot provider, pins the slot. `0` = unknown, which
+                 * passes budgets through unclamped rather than inventing a bound.
+                 */
+                callerDeadlineMs: leaf(0, 'NEO_MEMORY_HEALTHCHECK_CALLER_DEADLINE_MS', 'number'),
                 /**
                  * The canary producer's attempt period. A liveness probe NEVER triggers a canary
                  * run — healthcheck is a cheap pure read of the gate's current truth, so a

--- a/ai/services/memory-core/HealthService.mjs
+++ b/ai/services/memory-core/HealthService.mjs
@@ -1,4 +1,5 @@
 import fs                       from 'fs/promises';
+import {orphanSafeBudget}       from '../shared/orphanSafeBudget.mjs';
 import fsExtra                  from 'fs-extra';
 import path                     from 'path';
 import {fileURLToPath}          from 'url';
@@ -211,12 +212,24 @@ export {createEmbeddingProbeTimeoutError};
  *     errorClassification: String|undefined, errorCode: String|undefined}>}
  */
 export async function buildEmbeddingWriteCanaryBlock({
-    cfg       = aiConfig,
-    embedText = null,
-    input     = 'neo-healthcheck-embedding-write-canary',
-    now       = Date.now,
-    timeoutMs = aiConfig.healthcheck.embeddingWriteCanaryTimeoutMs
+    callerDeadlineMs = aiConfig.healthcheck.callerDeadlineMs,
+    cfg              = aiConfig,
+    embedText        = null,
+    input            = 'neo-healthcheck-embedding-write-canary',
+    now              = Date.now,
+    timeoutMs        = aiConfig.healthcheck.embeddingWriteCanaryTimeoutMs
 } = {}) {
+    // The provider does not cancel on client disconnect (ollama/ollama#11889), so a budget larger (ticket-ref-ok: upstream provider behaviour, not a Neo tracking ref — the mechanism this guard exists for)
+    // than the caller's deadline dispatches work we can never recall — and on a single-slot provider
+    // each orphan pins the slot. Bounded HERE because dispatch is the last moment a lever exists.
+    const {budgetMs, clamped, reason} = orphanSafeBudget({configuredMs: timeoutMs, callerDeadlineMs});
+
+    if (clamped) {
+        console.warn(`[HealthService] embedding write canary: ${reason}`);
+    }
+
+    timeoutMs = budgetMs;
+
     const probe = embedText || (async (text, explicitProvider, options) => {
         const {default: TextEmbeddingService} = await import('./TextEmbeddingService.mjs');
         return TextEmbeddingService.embedText(text, explicitProvider, options);

--- a/ai/services/shared/orphanSafeBudget.mjs
+++ b/ai/services/shared/orphanSafeBudget.mjs
@@ -1,0 +1,77 @@
+/**
+ * @module ai/services/shared/orphanSafeBudget
+ * @summary Refuses to dispatch provider work that outlives the caller waiting for it.
+ *
+ * ## Why this exists
+ *
+ * **Ollama does not stop processing when its client disconnects** — `ollama/ollama#11889`, open (ticket-ref-ok: upstream provider behaviour, not a Neo tracking ref — the mechanism this guard exists for)
+ * upstream. An `AbortController` gives up locally; the inference runs to completion regardless. So a
+ * request whose budget exceeds the caller's willingness to wait is not "a request that might time
+ * out". It is work we can never take back.
+ *
+ * On a single-slot provider (`OLLAMA_NUM_PARALLEL=1`) each orphan holds the only slot until it
+ * finishes on its own, and `OLLAMA_MAX_QUEUE` (512 by default) means upstream sheds no load either.
+ * Orphans therefore accumulate and the provider stays pinned at its CPU cap serving work nobody is
+ * waiting for.
+ *
+ * **Measured in production 2026-08-11T09:18Z:** three provider operations SUCCEEDED after 961,609ms,
+ * 662,615ms and 1,010,684ms — their callers had abandoned them 5-15 minutes earlier. Fresh probes
+ * immediately afterwards completed in ~1.4s, because the slot had finally cleared. The provider was
+ * never slow; it was busy with abandoned work.
+ *
+ * The configuration that produced it: healthchecks abandoned at 45s (the container `timeout`) while
+ * the probe they dispatched carried a 5-minute (KB) / 15-minute (MC) server-side budget. Nothing
+ * refused that pairing, because the budget leaf accepts any number and never sees the caller.
+ *
+ * ## The rule
+ *
+ * **Never dispatch a request whose budget exceeds the caller's deadline.** Clamping is not a
+ * courtesy — for an uncancellable provider it is the only moment at which the work can still be
+ * bounded. After dispatch there is no lever left.
+ *
+ * Clamping is deliberately silent-safe rather than throwing: a throw would turn a working-but-
+ * over-configured deployment into a hard outage, while a clamp denies only the excess. The
+ * `clamped` flag is returned so the caller can report it instead of hiding a shortened deadline.
+ *
+ * @see ai/services/memory-core/HealthService.mjs — embedding write canary
+ * @see ai/services/knowledge-base/HealthService.mjs — embedding probe
+ * @plane in-plane
+ */
+
+/**
+ * Bounds a provider request budget by the deadline of whoever is waiting for it.
+ *
+ * `callerDeadlineMs` is the honest upper bound on how long the caller will still be listening — a
+ * container healthcheck `timeout`, a request deadline, a poll interval. When it is unknown the
+ * budget passes through unchanged: this guard narrows, and never invents a bound it cannot justify.
+ * @param {Object} params
+ * @param {Number} params.configuredMs The configured provider budget.
+ * @param {Number} [params.callerDeadlineMs] How long the caller will actually wait, when known.
+ * @returns {{budgetMs: Number, clamped: Boolean, reason: (String|null)}} `budgetMs` is what the
+ * dispatch must use. `clamped` is true only when the configured budget was reduced, so a caller can
+ * surface the shortened deadline rather than silently applying it.
+ */
+export function orphanSafeBudget({configuredMs, callerDeadlineMs}) {
+    const configuredValid = Number.isFinite(configuredMs) && configuredMs > 0;
+
+    if (!configuredValid) {
+        return {budgetMs: configuredMs, clamped: false, reason: null};
+    }
+
+    const deadlineValid = Number.isFinite(callerDeadlineMs) && callerDeadlineMs > 0;
+
+    // An unknown caller deadline is not a licence to invent one. Pass through: this guard exists to
+    // NARROW a budget against a known bound, and a fabricated ceiling would shorten deadlines on
+    // deployments whose callers genuinely wait longer.
+    if (!deadlineValid || configuredMs <= callerDeadlineMs) {
+        return {budgetMs: configuredMs, clamped: false, reason: null};
+    }
+
+    return {
+        budgetMs: callerDeadlineMs,
+        clamped : true,
+        reason  : `provider budget ${configuredMs}ms exceeds the caller deadline ${callerDeadlineMs}ms; ` +
+            'clamped because the provider does not cancel on client disconnect (ollama/ollama#11889), ' +
+            'so the excess would run on unwatched and hold the provider slot'
+    };
+}

--- a/test/playwright/unit/ai/services/shared/orphanSafeBudget.spec.mjs
+++ b/test/playwright/unit/ai/services/shared/orphanSafeBudget.spec.mjs
@@ -1,0 +1,61 @@
+import {expect, test}     from '@playwright/test';
+import {orphanSafeBudget} from '../../../../../../ai/services/shared/orphanSafeBudget.mjs';
+
+/**
+ * Ollama does not cancel on client disconnect (`ollama/ollama#11889`, open upstream), so a budget (ticket-ref-ok: upstream provider behaviour, not a Neo tracking ref — the mechanism this guard exists for)
+ * larger than the caller's deadline dispatches work that can never be recalled. On a single-slot
+ * provider those orphans hold the slot and pin the CPU cap.
+ *
+ * Measured live 2026-08-11T09:18Z: three operations SUCCEEDED after 961,609ms / 662,615ms /
+ * 1,010,684ms with their callers gone 5-15 minutes earlier; fresh probes then took ~1.4s.
+ */
+test.describe('orphanSafeBudget — never dispatch work that outlives its caller (#16853)', () => {
+    test('clamps the production pairing: a 15-minute canary against a 45-second caller', () => {
+        // The exact external-plane configuration. 900000ms budget, 45000ms container timeout.
+        const {budgetMs, clamped, reason} = orphanSafeBudget({configuredMs: 900000, callerDeadlineMs: 45000});
+
+        expect(budgetMs).toBe(45000);
+        expect(clamped).toBe(true);
+        expect(reason).toContain('11889');
+    });
+
+    test('NON-VACUITY — a budget INSIDE the caller deadline passes through untouched', () => {
+        // Without this arm a guard that clamped everything to the deadline would pass the arm above.
+        const {budgetMs, clamped} = orphanSafeBudget({configuredMs: 30000, callerDeadlineMs: 45000});
+
+        expect(budgetMs).toBe(30000);
+        expect(clamped).toBe(false);
+    });
+
+    test('an EQUAL budget is not clamped — the boundary is inclusive', () => {
+        const {budgetMs, clamped} = orphanSafeBudget({configuredMs: 45000, callerDeadlineMs: 45000});
+
+        expect(budgetMs).toBe(45000);
+        expect(clamped).toBe(false);
+    });
+
+    test('an UNKNOWN caller deadline passes through — the guard narrows, it never invents a bound', () => {
+        // Fabricating a ceiling would shorten deadlines on deployments whose callers genuinely wait
+        // longer, which is a different outage. Absence of a bound is not permission to impose one.
+        for (const callerDeadlineMs of [undefined, null, 0, -1, NaN]) {
+            expect(orphanSafeBudget({configuredMs: 900000, callerDeadlineMs}))
+                .toEqual({budgetMs: 900000, clamped: false, reason: null});
+        }
+    });
+
+    test('a non-positive or non-finite CONFIGURED budget is returned unchanged, never clamped', () => {
+        // These are configuration errors owned by config validation. Silently rewriting them here
+        // would hide the defect behind a plausible number.
+        for (const configuredMs of [0, -1, NaN, undefined]) {
+            expect(orphanSafeBudget({configuredMs, callerDeadlineMs: 45000}).clamped).toBe(false);
+        }
+    });
+
+    test('the reason names the mechanism, so an operator can act without reading this module', () => {
+        const {reason} = orphanSafeBudget({configuredMs: 300000, callerDeadlineMs: 45000});
+
+        expect(reason).toContain('300000');
+        expect(reason).toContain('45000');
+        expect(reason).toContain('does not cancel');
+    });
+});


### PR DESCRIPTION
Resolves neomjs/neo-agent-brain#48

**The four pegged cores on the external plane are orphaned work we dispatched and cannot recall.** This stops us creating them.

Evidence: L2 (6 spec arms incl. the exact production pairing; live external-plane measurement) → L2 required (no runtime-verify AC). No residuals.

## The mechanism, every link confirmed

1. Our healthchecks abandon at **45s** (container `timeout`); the embed they dispatched carries a **5-min (KB) / 15-min (MC)** server-side budget.
2. **Ollama does not stop processing when its client disconnects** — open upstream (`ollama/ollama#11889`). An `AbortController` gives up *locally*; the inference runs to completion.
3. `OLLAMA_NUM_PARALLEL=1` — each orphan holds the **only** slot until it finishes on its own.
4. `OLLAMA_MAX_QUEUE=512` — upstream sheds no load either.
5. → the provider stays pinned at its CPU cap serving work **nobody is waiting for**.

**Production confirmation (external plane, 2026-08-11T09:18Z):** three operations **SUCCEEDED** after `961,609ms` / `662,615ms` / `1,010,684ms` — their callers had abandoned them 5–15 minutes earlier. Fresh probes immediately after completed in **~1.4s** once the slot cleared.

**The provider was never slow. It was busy with abandoned work.** That is why seven weeks of timeout tuning moved nothing: a timeout is the moment we stop listening, not the moment the work stops.

## Why the bound belongs at dispatch

For an uncancellable provider, dispatch is **the last moment a lever exists**. After it, there is nothing to pull. So the rule is not "time out sooner" — it is **never issue a request whose budget exceeds the caller's willingness to wait**.

`orphanSafeBudget` **narrows only**. An unknown caller deadline passes through unchanged rather than inventing a ceiling, because a fabricated bound would shorten deadlines on deployments whose callers genuinely wait longer — a different outage. Clamping is silent-safe rather than throwing: a throw turns a working-but-over-configured deployment into a hard outage, while a clamp denies only the excess, and `clamped` is returned so the caller reports the shortened deadline instead of hiding it.

## Deltas

**`ai/services/shared/orphanSafeBudget.mjs`** (new) — the pure guard.
**`ai/services/memory-core/HealthService.mjs`** — the write canary bounds its budget at dispatch and warns when clamped.
**`ai/mcp/server/memory-core/configBase.mjs`** — `callerDeadlineMs` leaf, default `0` = unknown = pass through.

## Test Evidence

```
UNIT_TEST_MODE=true npx playwright test .../orphanSafeBudget.spec.mjs --workers=1
→ 6 passed
```

Arms include the **exact production pairing** (900000ms budget vs 45000ms caller → clamped to 45000), a **non-vacuity** arm (30000 inside 45000 passes through untouched, so a guard that clamped everything would fail), the inclusive boundary, and the unknown-deadline pass-through across `undefined / null / 0 / -1 / NaN`.

## Post-Merge Validation

None deferred. The guard is unit-covered and its effect is local to dispatch.

## Review

Cross-family seat needed (author is opus). Three places to attack:

1. **`callerDeadlineMs` defaults to `0` (unknown), so this changes nothing until a deployment sets it.** That is deliberate — inventing a bound is the worse failure — but it means the fix is inert without a config change, and you may argue that is too weak.
2. **Only the MC canary is wired.** The KB probe (`knowledge-base/HealthService.mjs`) has the identical shape and is *not* bounded here. I scoped to one site to keep the guard reviewable; if you want both in this PR, say so.
3. Whether `clamp` beats `throw`. I argue a throw converts over-configuration into an outage; you may weigh the silent shortening higher.

Authored by @neo-opus-vega 🌿
