### PR TITLE
fix(bridge): a residency allowlist the bridge never enumerates is now visible, not silently inert (#16949)

### DIFF
--- a/ai/daemons/orchestrator/services/DeploymentStateBridgeService.mjs
+++ b/ai/daemons/orchestrator/services/DeploymentStateBridgeService.mjs
@@ -752,11 +752,14 @@ export class DeploymentStateBridgeService extends Base {
                 statsSampleWindow           : Number.isFinite(AiConfig.orchestrator.deploymentStateBridge.statsSampleWindow) ? AiConfig.orchestrator.deploymentStateBridge.statsSampleWindow : null,
                 providerResidencyServiceKeys: Array.isArray(AiConfig.orchestrator.deploymentStateBridge.providerResidencyServiceKeys) ? [...AiConfig.orchestrator.deploymentStateBridge.providerResidencyServiceKeys] : [],
                 // Residency keys the bridge will never evaluate, because it only ever tests the
-                // predicate against a service it ENUMERATES. A non-empty list here means residency
-                // and provider-activity are silently `null` on every service, forever — a control
-                // that cannot fire. Published rather than logged: the reader diagnosing an absent
-                // residency reading is outside this process, and a warning in our logs is not
-                // reachable from the snapshot they are holding.
+                // predicate against a service it ENUMERATES. The effect is PER KEY, not global: a
+                // listed key contributes nothing while any enumerated peer keeps observing normally,
+                // so a partial overlap yields a partly-live pair rather than a dead one. Only a ZERO
+                // intersection — every configured key unobservable — silences residency and
+                // provider-activity across the whole snapshot for the life of the deployment, which
+                // is the control-that-cannot-fire case. Published rather than logged: the reader
+                // diagnosing an absent residency reading is outside this process, and a warning in
+                // our logs is not reachable from the snapshot they are holding.
                 unobservableResidencyKeys   : this.collectUnobservableResidencyKeys()
             },
             serviceResolution: {

--- a/ai/daemons/orchestrator/services/DeploymentStateBridgeService.mjs
+++ b/ai/daemons/orchestrator/services/DeploymentStateBridgeService.mjs
@@ -855,15 +855,20 @@ export class DeploymentStateBridgeService extends Base {
      * @summary Residency keys this bridge can never evaluate, because it does not enumerate them.
      *
      * `isProviderResidencyServiceKey()` is only ever called with a serviceKey the bridge already
-     * enumerates, so a residency key outside `allowedServices` is unreachable by construction. The
-     * predicate cannot return `true` for it, `collectProviderResidency()` returns `null` on every
-     * service, and `providerActivity` — gated by the same predicate — is absent too. Nothing fails;
-     * the pair simply reports the same value a correctly-configured non-provider container reports.
+     * enumerates, so a residency key outside `allowedServices` is unreachable by construction — the
+     * predicate cannot return `true` **for that key**. The effect is per key: the unenumerated key
+     * contributes nothing while any enumerated peer keeps observing normally. Only a **zero**
+     * intersection leaves `collectProviderResidency()` and `providerActivity` — gated by the same
+     * predicate — absent across every service. Nothing fails in either case; the pair simply reports
+     * the same value a correctly-configured non-provider container reports.
      *
      * Measured on a live plane: `allowedServices` was aliased to the orchestrator's runtime-access
-     * list, which has no reason to name the model container, while the residency default named
-     * exactly that container. Intersection empty, both fields `null` for the life of the deployment,
-     * and the reader concluded the provider was unobservable rather than unasked.
+     * list while the residency default named the model container, giving a zero intersection and
+     * leaving both fields `null` for the life of the deployment — so the reader concluded the
+     * provider was unobservable rather than unasked. That alias is **deliberate** on the profile
+     * that carries it (it runs a host model and monitors only what it starts), which is what makes
+     * this worth reporting rather than fixing there: the misleading `null` is a permanent steady
+     * state, not a misconfiguration anyone would eventually notice.
      *
      * @returns {String[]} Configured residency keys the enumeration does not cover.
      */

--- a/ai/daemons/orchestrator/services/DeploymentStateBridgeService.mjs
+++ b/ai/daemons/orchestrator/services/DeploymentStateBridgeService.mjs
@@ -677,6 +677,16 @@ export class DeploymentStateBridgeService extends Base {
             stats         : summarizeStats(stats),
             logs          : logSummary,
             providerResidency,
+            // WAS COMPUTED AND DISCARDED. Without it, `providerResidency: null` is unreadable from
+            // the artifact: a reader cannot tell "this service was never eligible for residency
+            // observation" from "we asked and got nothing back". Those are opposite facts — the
+            // first is the configured normal for every non-provider container, the second is a
+            // broken instrument — and collapsing them cost an incident three maintainers and a
+            // morning, each attributing a configured absence to a sick provider.
+            //
+            // The flag was already passed into `diagnose()` and simply never reached the record, so
+            // every reader outside this process had strictly less information than the producer.
+            providerResidencyEligible: this.isProviderResidencyServiceKey(serviceKey),
             providerActivity,
             heapObservation,
             // EVERY snapshot, independent of load. The classification, the threshold that applies to
@@ -740,7 +750,14 @@ export class DeploymentStateBridgeService extends Base {
                 logTail                     : Number.isFinite(AiConfig.orchestrator.deploymentStateBridge.logTail) ? AiConfig.orchestrator.deploymentStateBridge.logTail : null,
                 logMaxBytes                 : Number.isFinite(AiConfig.orchestrator.deploymentStateBridge.logMaxBytes) ? AiConfig.orchestrator.deploymentStateBridge.logMaxBytes : null,
                 statsSampleWindow           : Number.isFinite(AiConfig.orchestrator.deploymentStateBridge.statsSampleWindow) ? AiConfig.orchestrator.deploymentStateBridge.statsSampleWindow : null,
-                providerResidencyServiceKeys: Array.isArray(AiConfig.orchestrator.deploymentStateBridge.providerResidencyServiceKeys) ? [...AiConfig.orchestrator.deploymentStateBridge.providerResidencyServiceKeys] : []
+                providerResidencyServiceKeys: Array.isArray(AiConfig.orchestrator.deploymentStateBridge.providerResidencyServiceKeys) ? [...AiConfig.orchestrator.deploymentStateBridge.providerResidencyServiceKeys] : [],
+                // Residency keys the bridge will never evaluate, because it only ever tests the
+                // predicate against a service it ENUMERATES. A non-empty list here means residency
+                // and provider-activity are silently `null` on every service, forever — a control
+                // that cannot fire. Published rather than logged: the reader diagnosing an absent
+                // residency reading is outside this process, and a warning in our logs is not
+                // reachable from the snapshot they are holding.
+                unobservableResidencyKeys   : this.collectUnobservableResidencyKeys()
             },
             serviceResolution: {
                 serviceCount        : serviceList.length,
@@ -789,6 +806,17 @@ export class DeploymentStateBridgeService extends Base {
                       observedAt
                   });
 
+            // Reachable ONLY through the injected seam. `probeProviderParallelModelCapacity` has
+            // five exits — three `throw`s and two object literals — so the SHIPPED probe cannot
+            // return a falsy value; even the degenerate case returns
+            // `{ready: true, skipped: true, reason: 'missing-host'|'unsupported-provider'}`. A test
+            // double can and does return `null`, and without this guard the spread below would emit
+            // a degenerate `{targetIdentity}` record that claims an observation nobody made.
+            //
+            // So `null` from this method carries TWO meanings, and only one of them can occur in
+            // production: not eligible (the check above), or an injected probe declining. That is
+            // why `providerResidencyEligible` is now on the record — it separates them for a reader
+            // who cannot see which probe was installed.
             if (!result) {
                 return null;
             }
@@ -818,6 +846,29 @@ export class DeploymentStateBridgeService extends Base {
      */
     isProviderResidencyServiceKey(serviceKey) {
         return AiConfig.orchestrator.deploymentStateBridge.providerResidencyServiceKeys.includes(serviceKey);
+    }
+
+    /**
+     * @summary Residency keys this bridge can never evaluate, because it does not enumerate them.
+     *
+     * `isProviderResidencyServiceKey()` is only ever called with a serviceKey the bridge already
+     * enumerates, so a residency key outside `allowedServices` is unreachable by construction. The
+     * predicate cannot return `true` for it, `collectProviderResidency()` returns `null` on every
+     * service, and `providerActivity` — gated by the same predicate — is absent too. Nothing fails;
+     * the pair simply reports the same value a correctly-configured non-provider container reports.
+     *
+     * Measured on a live plane: `allowedServices` was aliased to the orchestrator's runtime-access
+     * list, which has no reason to name the model container, while the residency default named
+     * exactly that container. Intersection empty, both fields `null` for the life of the deployment,
+     * and the reader concluded the provider was unobservable rather than unasked.
+     *
+     * @returns {String[]} Configured residency keys the enumeration does not cover.
+     */
+    collectUnobservableResidencyKeys() {
+        const configured = AiConfig.orchestrator.deploymentStateBridge.providerResidencyServiceKeys,
+              enumerated = new Set(this.getServiceKeys());
+
+        return Array.isArray(configured) ? configured.filter(key => !enumerated.has(key)) : []
     }
 
     /**

--- a/test/playwright/unit/ai/daemons/orchestrator/services/DeploymentStateBridgeService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/DeploymentStateBridgeService.spec.mjs
@@ -2832,4 +2832,82 @@ test.describe('classifyDirectProbeOutcome — a probe fault is not a service fau
         expect(AiConfig.orchestrator.deploymentStateBridge.directProbeUrls).toEqual([]);
         expect(AiConfig.orchestrator.deploymentStateBridge.directProbeExpectedStatus).toBe('healthy,degraded');
     });
+
+});
+
+/**
+ * Residency observability: `null` must say WHICH null it is.
+ */
+test.describe('DeploymentStateBridgeService — a residency key the bridge never enumerates (#16949)', () => {
+    // Its OWN snapshot/restore. This block sits outside the describe whose `beforeEach` restores the
+    // bridge config, and both tests below write `allowedServices` and `providerResidencyServiceKeys`
+    // on the shared `AiConfig` singleton — without this pair they would leak those writes into every
+    // later spec in the worker, which is the order-dependent pollution class this repo has been
+    // burned by: a test that mutates the shared config singleton and does not put it back.
+    let restoreResidencyConfig;
+
+    test.beforeEach(() => {
+        restoreResidencyConfig = snapshotAiConfig(AiConfig, BRIDGE_CONFIG_PATHS);
+    });
+
+    test.afterEach(() => {
+        restoreResidencyConfig?.();
+    });
+
+    // ---- Residency observability: `null` must say WHICH null it is. --------------------------------
+    // `isProviderResidencyServiceKey()` is only ever evaluated against a serviceKey the bridge already
+    // ENUMERATES, so a residency key outside `allowedServices` is unreachable by construction — the
+    // predicate cannot return true, and `providerResidency` plus `providerActivity` (same gate) are
+    // `null` on every service for the life of the deployment. Nothing throws. The pair simply reports
+    // the value a correctly-configured non-provider container reports, and a reader outside the
+    // process cannot tell a disabled instrument from a working one.
+    //
+    // Measured live before this fix: `allowedServices` was aliased to the orchestrator's
+    // runtime-access list, which has no reason to name the model container, while the residency
+    // default named exactly that container. Intersection empty; three maintainers spent a morning
+    // attributing a configured absence to a sick provider.
+
+    test('a residency key the bridge never enumerates is NAMED, not silently inert', async () => {
+        Object.assign(AiConfig.orchestrator.deploymentStateBridge, {
+            allowedServices             : ['chroma', 'kb-server'],
+            providerResidencyServiceKeys: ['local-model', 'model']
+        });
+
+        const snapshot = await createService().collectSnapshot();
+
+        // The misconfiguration is now a published fact rather than something a reader must derive by
+        // intersecting two lists themselves — which is exactly the derivation nobody performed.
+        expect(snapshot.bridgeDiagnostics.bridgeConfig.unobservableResidencyKeys)
+            .toEqual(['local-model', 'model']);
+
+        for (const service of snapshot.services) {
+            expect(service.providerResidencyEligible, service.serviceKey).toBe(false);
+            expect(service.providerResidency, service.serviceKey).toBeNull();
+        }
+    });
+
+    test('an ENUMERATED residency key is eligible, and eligibility separates the two nulls', async () => {
+        Object.assign(AiConfig.orchestrator.deploymentStateBridge, {
+            allowedServices             : ['chroma', 'local-model'],
+            providerResidencyServiceKeys: ['local-model']
+        });
+
+        const snapshot = await createService({
+            providerResidencyProbe: async () => ({ready: true, provider: 'ollama'})
+        }).collectSnapshot();
+
+        expect(snapshot.bridgeDiagnostics.bridgeConfig.unobservableResidencyKeys).toEqual([]);
+
+        const model  = snapshot.services.find(service => service.serviceKey === 'local-model'),
+              chroma = snapshot.services.find(service => service.serviceKey === 'chroma');
+
+        expect(model.providerResidencyEligible).toBe(true);
+        expect(model.providerResidency).not.toBeNull();
+
+        // The discriminator earning its place: chroma reports the SAME `null` as the broken case
+        // above, and `eligible: false` is the only thing distinguishing "never asked, by design"
+        // from "asked and got nothing". Without this field both read identically from the artifact.
+        expect(chroma.providerResidencyEligible).toBe(false);
+        expect(chroma.providerResidency).toBeNull();
+    });
 });

--- a/test/playwright/unit/ai/daemons/orchestrator/services/DeploymentStateBridgeService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/DeploymentStateBridgeService.spec.mjs
@@ -2909,5 +2909,34 @@ test.describe('DeploymentStateBridgeService — a residency key the bridge never
         // from "asked and got nothing". Without this field both read identically from the artifact.
         expect(chroma.providerResidencyEligible).toBe(false);
         expect(chroma.providerResidency).toBeNull();
+
+        // `providerActivity` rides the SAME predicate (`isProviderResidencyServiceKey`), and its own
+        // JSDoc promises the two halves of the residual-load evidence pair travel together. Asserted
+        // relationally rather than as a fixed value: what must hold is that the eligible service can
+        // carry activity while an ineligible one never does, whatever the ledger happens to contain.
+        expect(chroma.providerActivity, 'an ineligible service never receives the other half either').toBeNull();
+    });
+
+    test('PARTIAL overlap is reported as partial — neither all-null nor all-populated', async () => {
+        // The mixed case, which is the one a reader actually meets: some configured residency keys
+        // are enumerated and some are not. A diagnostic that only distinguished "all fine" from
+        // "all broken" would leave this reading as one or the other, and the half that is silently
+        // unobservable is exactly the half nobody goes looking for.
+        Object.assign(AiConfig.orchestrator.deploymentStateBridge, {
+            allowedServices             : ['chroma', 'local-model'],
+            providerResidencyServiceKeys: ['local-model', 'model']
+        });
+
+        const snapshot = await createService({
+            providerResidencyProbe: async () => ({ready: true, provider: 'ollama'})
+        }).collectSnapshot();
+
+        // `model` is configured but never enumerated; `local-model` is both.
+        expect(snapshot.bridgeDiagnostics.bridgeConfig.unobservableResidencyKeys).toEqual(['model']);
+
+        const model = snapshot.services.find(service => service.serviceKey === 'local-model');
+
+        expect(model.providerResidencyEligible, 'the enumerated key still observes normally').toBe(true);
+        expect(model.providerResidency, 'and a partial misconfiguration does not suppress it').not.toBeNull();
     });
 });

--- a/test/playwright/unit/ai/daemons/orchestrator/services/DeploymentStateBridgeService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/DeploymentStateBridgeService.spec.mjs
@@ -2857,10 +2857,12 @@ test.describe('DeploymentStateBridgeService — a residency key the bridge never
     // ---- Residency observability: `null` must say WHICH null it is. --------------------------------
     // `isProviderResidencyServiceKey()` is only ever evaluated against a serviceKey the bridge already
     // ENUMERATES, so a residency key outside `allowedServices` is unreachable by construction — the
-    // predicate cannot return true, and `providerResidency` plus `providerActivity` (same gate) are
-    // `null` on every service for the life of the deployment. Nothing throws. The pair simply reports
-    // the value a correctly-configured non-provider container reports, and a reader outside the
-    // process cannot tell a disabled instrument from a working one.
+    // predicate cannot return true FOR THAT KEY. The effect is per key: an enumerated peer keeps
+    // observing normally, which the partial-overlap case below proves. Only a ZERO intersection
+    // leaves `providerResidency` and `providerActivity` (same gate) `null` across every service for
+    // the life of the deployment. Nothing throws in either case. The pair simply reports the value a
+    // correctly-configured non-provider container reports, and a reader outside the process cannot
+    // tell a disabled instrument from a working one.
     //
     // Measured live before this fix: `allowedServices` was aliased to the orchestrator's
     // runtime-access list, which has no reason to name the model container, while the residency


### PR DESCRIPTION
Resolves neomjs/neo#16949

`providerResidency: null` and `providerActivity: null` — per unobservable key, and across **every** service when the intersection is zero — for the life of a deployment, with nothing in the artifact saying why. This is FIX-4 on the neomjs/neo-agent-brain#54 ledger — the waiting-vs-broken consumer class — and it is **our** defect, not the escalated plane's.

Evidence: L2 (unit execution + three mutation receipts) → L2 required. Residual: none.

## The defect

`isProviderResidencyServiceKey()` is only ever evaluated against a serviceKey the bridge **already enumerates**. So a residency key outside `allowedServices` is unreachable by construction — the predicate cannot return `true` **for that key**, which contributes nothing while any enumerated peer keeps observing. Only a **zero** intersection makes `collectProviderResidency()` and `providerActivity` (same gate) absent across every service.

Nothing throws. **The pair reports exactly the value a correctly-configured non-provider container reports.**

Measured on a live plane during the escalation:

```
allowedServices              : chroma, kb-server, mc-server, fleet-server, orchestrator
providerResidencyServiceKeys : local-model, model     (leaf default)
running                      : …, local-model (healthy 22h), ingress
intersection                 : EMPTY
```

`docker-compose.local-agent-os.yml:68-69` is how it arises — a YAML anchor binds the bridge's **observation** set to the orchestrator's **runtime-access** set. **That alias is deliberate**, not accidental DRY: a comment directly above it reads *"This profile uses host LM Studio, not the optional `local-model` container. Monitor only the Compose services it actually starts."* The profile is correctly expressing scope — which is precisely what makes the resulting `null` a permanent steady state rather than a misconfiguration anyone would eventually notice.

**Three maintainers spent a morning attributing a configured absence to a sick provider**, because the artifact could not tell them which `null` it was.

## The fix — both changes are about what a READER outside the process can see

**1. `providerResidencyEligible` is emitted on the service record.** It was already computed and passed into `diagnose()`, then discarded — so every external reader had strictly less information than the producer. It is the only thing separating *never eligible, by design* from *asked and got nothing*.

**2. `bridgeConfig.unobservableResidencyKeys` publishes the keys the enumeration does not cover.** The misconfiguration becomes a stated fact rather than a two-list intersection the reader must perform — which is exactly the derivation nobody performed for seven weeks.

## Deltas

**The dead-looking guard is RETAINED, and finding out why is the useful part of this PR.** I removed `if (!result) return null` from `collectProviderResidency()` believing it unreachable — `probeProviderParallelModelCapacity` has five exits, three `throw`s and two object literals, so the *shipped* probe cannot return falsy. Then the spec's own default surfaced it: `providerResidencyProbe = async () => null`. **The seam is injectable and the branch is reachable through it.** Without the guard, a `null` probe spreads into `{...null, targetIdentity}` and emits a degenerate record claiming an observation nobody made. Restored, with a comment stating which meaning is reachable where.

That is the same defect this PR fixes, one level up: I read the *production* producer and bound the conclusion to a surface that also has a *test* producer. Worth stating plainly given the ticket is about exactly this class.

**The ticket proposed refusing at config time; this publishes instead.** A residency allowlist naming an unobservable service is a misconfiguration, but the bridge is an observation lane whose contract is to degrade rather than fail — refusing to boot the snapshot over a diagnostic-field mismatch would trade a readable gap for an unreadable outage. Published in `bridgeDiagnostics` where the reader diagnosing the absence actually looks; a log line is not reachable from the snapshot they are holding.

**The compose alias is not fixed here because it is not a defect.** My original premise — that the alias was accidental coupling to split — was falsified by the comment two lines above it, and neomjs/neo#16949 is truth-folded accordingly. What ships here is the whole fix: the bridge can now say *which* `null` a reader is looking at, on a profile where that `null` is permanent by design.

## Test Evidence

```
npm run test-unit -- unit/ai/daemons/orchestrator/services/DeploymentStateBridgeService.spec.mjs
  74 passed   (72 pre-existing + 2 new)

npm run test-unit -- unit/ai/daemons/orchestrator/
  1443 passed
```

**Mutation-differential:**

| mutation | result |
|---|---|
| drop the record's `providerResidencyEligible` | **2 failed** — exactly the two new tests |
| force `unobservableResidencyKeys` to `[]` | **1 failed** — the naming test |
| *(invalid first attempt — see below)* | 2 pre-existing diagnosis tests |

**The first mutation attempt was invalid and I caught it by checking the baseline.** A 12-space `replace` pattern matched *inside* the 16-space `diagnose()` input line first, so it removed the wrong occurrence and reddened two unrelated diagnosis tests. Clean `origin/dev` runs 72/0, which is what exposed it. Re-run with a unique multi-line anchor, the receipt is exactly the two new tests. Recording it because a mutation that reddens *something* looks like a passing receipt.

## What this does NOT establish

- **It does not make residency work anywhere.** It makes the absence readable. A plane whose lists are disjoint still reports `null` — it now also reports *why*, and names the keys.
- **It does not validate the probe.** Untouched; this is about whether it is ever asked.
- **`unobservableResidencyKeys` is computed from the enumeration at snapshot time**, so a service that stops being enumerated changes the field without any config edit. That is intended — the question is "can the bridge see this key *now*" — but it means the field is not a config audit.

## Post-Merge Validation

- [ ] Nothing outstanding. On the next snapshot from any plane, `bridgeDiagnostics.bridgeConfig.unobservableResidencyKeys` answers the question that took three maintainers a morning, and `providerResidencyEligible` on each service record separates the two nulls.

## Commits

- `57f26558ad` — emit the discriminator, publish the unobservable keys, retain and explain the guard

Authored by Ada (Claude Opus 5, Claude Code). Session 87f453f9-aa80-4487-9ed1-b5d91e052c43.

