### PR TITLE
fix(ai): keep tenant repo waiters behind active work (#16961)

### DIFF
--- a/ai/daemons/orchestrator/services/TenantRepoSyncService.mjs
+++ b/ai/daemons/orchestrator/services/TenantRepoSyncService.mjs
@@ -707,14 +707,15 @@ class TenantRepoSyncService extends Base {
         concurrencyLimit_: 2,
         /**
          * Maximum time a per-repo task waits to acquire a concurrency slot before
-         * surfacing `KB_TENANT_REPO_SYNC_CONCURRENCY_GATE_TIMEOUT`. Default `30000`
-         * (30s) accommodates a slow-clone tenant ahead in the queue without
-         * waiting indefinitely. Set to `0` to disable the timeout (slots wait
-         * indefinitely until a release).
-         * @member {Number} concurrencyGateTimeoutMs_=30000
+         * surfacing `KB_TENANT_REPO_SYNC_CONCURRENCY_GATE_TIMEOUT`. Default `0`
+         * keeps ordinary work in the FIFO until a slot is released: timing out a
+         * waiter cannot bound `runTask` while the active holder is still pending,
+         * and recording that waiter as failed creates backoff without an attempt.
+         * A positive value remains an explicit fail-fast override.
+         * @member {Number} concurrencyGateTimeoutMs_=0
          * @reactive
          */
-        concurrencyGateTimeoutMs_: 30000
+        concurrencyGateTimeoutMs_: 0
     }
 
     /**
@@ -780,7 +781,7 @@ class TenantRepoSyncService extends Base {
      * @returns {Number}
      */
     beforeSetConcurrencyGateTimeoutMs(value, oldValue) {
-        if (!Number.isFinite(value) || value < 0) return oldValue ?? 30000;
+        if (!Number.isFinite(value) || value < 0) return oldValue ?? 0;
         return value;
     }
 
@@ -1847,8 +1848,8 @@ class TenantRepoSyncService extends Base {
                 repoLabel            = `${repo.tenantId}/${repo.repoSlug}`,
                 priorState           = persistedRevisions[repoLabel] || null,
                 checkpointStatus     = classifyTenantRepoCheckpoint(priorState),
-                revalidationRequired = requiresTenantRepoCheckpointRevalidation(priorState),
-                startedMs            = Date.now();
+                revalidationRequired = requiresTenantRepoCheckpointRevalidation(priorState);
+            let startedMs = Date.now();
 
             // Per-repo due check applies deterministic jitter + exponential backoff on
             // top of configured cadence. Manual CLI runs (onlyRepoSlugs filter)
@@ -1951,6 +1952,10 @@ class TenantRepoSyncService extends Base {
             try {
                 await semaphore.acquire();
                 slotAcquired = true;
+                // The actual attempt begins when capacity is admitted, not when the repo joined
+                // the FIFO. Otherwise a long legitimate wait is persisted as work time and can
+                // make a just-completed repo immediately due again.
+                startedMs = Date.now();
 
                 // Work fence: do not START this repo's git phase without provable
                 // lease ownership. A run that lost its lease (renewal failure or

--- a/test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncService.spec.mjs
@@ -217,9 +217,9 @@ test.describe('TenantRepoSyncService (#11790)', () => {
     test.afterEach(async () => {
         await fs.remove(tmpDir);
         // Restore the singleton's reactive config to default values so
-        // concurrency tests cannot leak short timeouts / serial-limit to siblings.
+        // concurrency tests cannot leak opt-in timeouts / serial-limit to siblings.
         TenantRepoSyncService.concurrencyLimit         = 2;
-        TenantRepoSyncService.concurrencyGateTimeoutMs = 30000;
+        TenantRepoSyncService.concurrencyGateTimeoutMs = 0;
         TenantRepoSyncService.clearTenantRepoAccessReadiness();
         TenantRepoSyncService.clearEmbeddingRecoveryProbeState();
     });
@@ -3614,19 +3614,14 @@ test.describe('TenantRepoSyncService (#11790)', () => {
         expect(TenantRepoSyncService.concurrencyLimit).toBe(10);
     });
 
-    test('concurrency-gate: beforeSetConcurrencyGateTimeoutMs rejects NaN/Infinity/negative; accepts 0 as no-timeout sentinel (#11942 AC2)', () => {
-        TenantRepoSyncService.concurrencyGateTimeoutMs = 30000;
-        expect(TenantRepoSyncService.concurrencyGateTimeoutMs).toBe(30000);
+    test('concurrency-gate: beforeSetConcurrencyGateTimeoutMs defaults to FIFO waiting and accepts an opt-in timeout (#11942 AC2)', () => {
+        expect(TenantRepoSyncService.concurrencyGateTimeoutMs).toBe(0);
 
         // Invalid values fall back to the previous valid value.
         for (const invalid of [-1, -100, NaN, Infinity, -Infinity, '5000', null, undefined]) {
             TenantRepoSyncService.concurrencyGateTimeoutMs = invalid;
-            expect(TenantRepoSyncService.concurrencyGateTimeoutMs).toBe(30000);
+            expect(TenantRepoSyncService.concurrencyGateTimeoutMs).toBe(0);
         }
-
-        // 0 is a valid sentinel (no timeout — slots wait indefinitely).
-        TenantRepoSyncService.concurrencyGateTimeoutMs = 0;
-        expect(TenantRepoSyncService.concurrencyGateTimeoutMs).toBe(0);
 
         // Positive finite values are accepted.
         TenantRepoSyncService.concurrencyGateTimeoutMs = 60000;
@@ -4061,7 +4056,101 @@ test.describe('TenantRepoSyncService (#11790)', () => {
         expect(ingestCalls).toHaveLength(1);
     });
 
-    test('concurrency-gate: queued slot acquisition surfaces KB_TENANT_REPO_SYNC_CONCURRENCY_GATE_TIMEOUT (#11942 AC2)', async () => {
+    test('concurrency-gate: queued repos wait for the default FIFO slot instead of acquiring failure backoff (#16780 O3)', async () => {
+        TenantRepoSyncService.concurrencyLimit = 1;
+
+        const
+            nativeSetTimeout = globalThis.setTimeout,
+            ingestOrder      = [];
+        let releaseSlowRepo,
+            signalSlowStarted,
+            resultPromise;
+
+        const
+            slowRepoGate = new Promise(resolve => { releaseSlowRepo = resolve; }),
+            slowStarted  = new Promise(resolve => { signalSlowStarted = resolve; });
+
+        for (const slug of ['org/slow', 'org/queued']) {
+            await provisionMirrorDir({tenantId: 't1', repoSlug: slug});
+        }
+
+        // Compress only the retired shipped 30s default. On the pre-repair source this makes the
+        // queued repo fail in 10ms; with the FIFO default no slot timer is scheduled at all.
+        globalThis.setTimeout = (callback, delay, ...args) => nativeSetTimeout(
+            callback,
+            delay === 30000 ? 10 : delay,
+            ...args
+        );
+
+        try {
+            resultPromise = TenantRepoSyncService.runTask({
+                reason           : 'periodic',
+                taskStateService : createInMemoryTaskStateService(),
+                tenantReposConfig: {tenantRepos: [
+                    {tenantId: 't1', repoSlug: 'org/slow',   mirrorRoot, cloneUrl: 'https://github.com/neomjs/slow.git'},
+                    {tenantId: 't1', repoSlug: 'org/queued', mirrorRoot, cloneUrl: 'https://github.com/neomjs/queued.git'}
+                ]},
+                gitMirror                    : makeFakeGitMirror(),
+                envelopeBuilder              : makeFakeEnvelopeBuilder(),
+                knowledgeBaseIngestionService: makeFakeIngestionService({
+                    summaryFactory: async payload => {
+                        ingestOrder.push(payload.repoSlug);
+
+                        if (payload.repoSlug === 'org/slow') {
+                            signalSlowStarted();
+                            await slowRepoGate;
+                        }
+
+                        return {
+                            ingested           : 1,
+                            deleted            : 0,
+                            embeddingsGenerated: 1,
+                            errors             : [],
+                            tenantId           : payload.tenantId,
+                            durationMs         : 1
+                        }
+                    }
+                }),
+                revisionsFilePath: revisionsFile,
+                seedBootstrap    : false
+            });
+
+            await slowStarted;
+            await new Promise(resolve => nativeSetTimeout(resolve, 40));
+
+            expect(ingestOrder).toEqual(['org/slow']);
+
+            const queuedAdmittedAfter = Date.now();
+            releaseSlowRepo();
+
+            const result = await resultPromise;
+
+            expect(result).toMatchObject({
+                status : 'completed',
+                details: {
+                    completedCount: 2,
+                    failedCount   : 0
+                }
+            });
+            expect(result.details.repos.map(repo => [repo.repoSlug, repo.status])).toEqual([
+                ['org/slow', 'active'],
+                ['org/queued', 'active']
+            ]);
+            expect(ingestOrder).toEqual(['org/slow', 'org/queued']);
+            expect(result.details.repos.some(repo =>
+                repo.lastErrorCode === 'KB_TENANT_REPO_SYNC_CONCURRENCY_GATE_TIMEOUT'
+            )).toBe(false);
+
+            const persisted = await fs.readJson(revisionsFile);
+            expect(persisted.revisions['t1/org/queued'].lastRunAttemptAt).toBeGreaterThanOrEqual(queuedAdmittedAfter);
+        } finally {
+            releaseSlowRepo?.();
+            await resultPromise?.catch(() => {});
+            globalThis.setTimeout = nativeSetTimeout;
+        }
+    });
+
+    test('concurrency-gate: explicit queued slot timeout surfaces KB_TENANT_REPO_SYNC_CONCURRENCY_GATE_TIMEOUT (#11942 AC2)', async () => {
         TenantRepoSyncService.concurrencyLimit         = 1;
         TenantRepoSyncService.concurrencyGateTimeoutMs = 50;
 


### PR DESCRIPTION
Resolves neomjs/neo#16961
Related: neomjs/neo#16780
Related: neomjs/neo-agent-brain#54

Tenant-repository sweeps now keep ordinary capacity waiters in the existing FIFO until an admitted repository releases its slot. The former shipped 30-second default could not bound the outer run—the active repository still kept `Promise.all()` pending—but it did classify untouched sibling repositories as failed and persist exponential backoff. The explicit positive timeout remains available as an opt-in fail-fast override.

Evidence: L3 (production `TenantRepoSyncService.runTask()` with the historical timer compressed at the real semaphore boundary) achieved; L4 (next external-plane multi-repository sweep) required. Residual: deployment receipt [#16706].

## Deltas from ticket

No behavioral delta from neomjs/neo#16961. The leaf was created after implementation to correct this PR's invalid draft-without-close-target state. It scopes exactly one delivery under neomjs/neo#16780: ordinary tenant-repository waiters remain in the existing FIFO instead of acquiring failure/backoff at the former 30-second default.

The change also resets `lastRunAttemptAt` when the FIFO slot is actually admitted, so minutes spent waiting are not persisted as repository work time.

The change does **not** terminate already-orphaned Ollama requests or claim to cure the sustained provider CPU incident. Those prevention lanes remain separate; this PR prevents valid sibling repositories from acquiring failure/backoff solely because an earlier admitted request takes longer than 30 seconds.

## Test Evidence

- Mutation receipt: restoring the shipped `30000` default made the new production-shaped test fail with `completedCount: 1` / `failedCount: 1`; the repaired default produced `2` / `0`.
- `npm run test-unit -- test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncService.spec.mjs --grep 'queued repos wait'` — 3 passed.
- `npm run test-unit -- test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncService.spec.mjs` — 124 passed.
- `npm run agent-preflight -- --change-class restoration --commit-subject 'fix(ai): keep tenant repo waiters behind active work (#16780)' ...` — all requested gates passed.
- `git diff --check` — passed.

## Post-Merge Validation

- [ ] On the next multi-repository deployment sweep, verify a repository queued behind slow admitted work becomes `active` after handoff and never records `KB_TENANT_REPO_SYNC_CONCURRENCY_GATE_TIMEOUT` under the default configuration.
- [ ] Verify the queued repository's durable `lastRunAttemptAt` begins at slot admission rather than FIFO entry.

Residual-Owner: neomjs/neo-agent-brain#54

## Evolution

The first design question was whether to replace the semaphore. Source replay showed the semaphore already provides correct FIFO handoff. The defect was narrower: a hard-wired default timer attached failure semantics to capacity contention while leaving the active holder—and therefore the outer run—untouched. The repair changes the default and timestamp boundary without adding a second admission mechanism.

The workflow correction is equally explicit: a draft PR without a ticket it can close is not a reviewable delivery unit. neomjs/neo#16961 now owns this exact one-PR behavior and is natively linked under neomjs/neo#16780.

Authored by Euclid (GPT-5.6, Codex Desktop). Session 7f0e4829-173a-4780-9a46-8e4811a979b5.
