### PR TITLE
fix(memory-core): index mailbox list projection (#16960)

### DIFF
--- a/ai/services/memory-core/MailboxService.mjs
+++ b/ai/services/memory-core/MailboxService.mjs
@@ -3018,7 +3018,7 @@ class MailboxService extends Base {
                     }
                     if (sourceEdgeType === 'DELIVERED_TO') {
                         hasDeliveryEdges = true;
-                        if (sameMailboxIdentity(sourceEdgeTarget, target)) deliveryEdge = sourceEdge;
+                        if (!deliveryEdge && sameMailboxIdentity(sourceEdgeTarget, target)) deliveryEdge = sourceEdge;
                     }
                     if (sourceEdgeType === 'PART_OF_THREAD') foundThreadId = sourceEdgeTarget;
                     if (sourceEdgeType === 'TAGGED_CONCEPT') messageTaggedConcepts.push(sourceEdgeTarget);

--- a/ai/services/memory-core/MailboxService.mjs
+++ b/ai/services/memory-core/MailboxService.mjs
@@ -99,18 +99,16 @@ function parseRelatedPullRequestNumber(ticket = '') {
  * @param {Object} db Graph database facade.
  * @param {String} messageId Message node id.
  * @param {Object} [messageNode] Message graph node.
+ * @param {Object[]} [sourceEdges] Pre-resolved outbound edges for the message.
  * @returns {String[]}
  */
-function getRelatedTicketsForMessage(db, messageId, messageNode) {
+function getRelatedTicketsForMessage(db, messageId, messageNode, sourceEdges = db.edges.getByIndex('source', messageId)) {
     const relatedTickets = Array.isArray(messageNode?.properties?.relatedTickets)
         ? [...messageNode.properties.relatedTickets]
         : [];
 
-    for (const edge of db.edges.items) {
-        if (
-            getRecordField(edge, 'source') === messageId &&
-            getRecordField(edge, 'type') === 'REFERENCES_TICKET'
-        ) {
+    for (const edge of sourceEdges) {
+        if (getRecordField(edge, 'type') === 'REFERENCES_TICKET') {
             relatedTickets.push(getRecordField(edge, 'target'));
         }
     }
@@ -2956,63 +2954,93 @@ class MailboxService extends Base {
             }
         }
 
-        let messages = [];
+        const candidateMessageIds = new Set();
 
-        for (const edge of db.edges.items) {
-            const edgeType = getRecordField(edge, 'type'),
-                edgeSource = getRecordField(edge, 'source'),
-                edgeTarget = getRecordField(edge, 'target');
-
-            let isMatch      = false,
-                targetNode   = null,
-                senderNode   = null,
-                deliveryEdge = null;
-
-            if (edgeType === 'DELIVERED_TO') {
-                targetNode = edgeTarget;
-                if ((box === 'inbox' || box === 'all') && sameMailboxIdentity(targetNode, target)) {
-                    isMatch = true;
-                    deliveryEdge = edge;
-                }
-            } else if (edgeType === 'SENT_TO') {
-                targetNode = edgeTarget;
-                if (box === 'inbox' || box === 'all') {
-                    if (sameMailboxIdentity(targetNode, target)) {
-                        isMatch = true;
-                    } else if (targetNode === 'AGENT:*') {
-                        // Load the full message vicinity before deciding whether this is a
-                        // per-recipient broadcast or a legacy shared-read broadcast.
-                        db.getAdjacentNodes(edgeSource, 'outbound');
-                        deliveryEdge = getBroadcastDeliveryEdge(edgeSource, target);
-                        if (deliveryEdge || !hasBroadcastDeliveryEdges(edgeSource)) {
-                            isMatch = true;
-                        }
-                    }
-                }
-            } else if (edgeType === 'SENT_BY') {
-                senderNode = edgeTarget;
-                if ((box === 'outbox' || box === 'all') && sameMailboxIdentity(senderNode, target)) {
-                    isMatch = true;
+        // The graph Store already maintains exact `target` and `source` secondary indexes. Route
+        // discovery must consume those indexes rather than enumerate the whole cached edge graph:
+        // `limit` bounds the response page, not the amount of unrelated graph work we may perform.
+        // Legacy identity spellings remain complete because the same bounded variant set used for
+        // vicinity hydration drives the target-index union.
+        const collectCandidates = (targetValue, acceptedTypes) => {
+            for (const edge of db.edges.getByIndex('target', targetValue)) {
+                if (acceptedTypes.has(getRecordField(edge, 'type'))) {
+                    candidateMessageIds.add(getRecordField(edge, 'source'));
                 }
             }
+        };
 
-            if (isMatch) {
-                // Determine message node id depending on which edge we matched
-                const messageNodeId = edgeSource;
-                // Avoid duplicates if 'all' is chosen
-                if (messages.find(m => m.messageId === messageNodeId)) continue;
+        if (box === 'inbox' || box === 'all') {
+            const inboxEdgeTypes = new Set(['SENT_TO', 'DELIVERED_TO']);
+            for (const targetVariant of targetStorageVariants) {
+                collectCandidates(targetVariant, inboxEdgeTypes);
+            }
+            collectCandidates('AGENT:*', new Set(['SENT_TO']));
+        }
+        if (box === 'outbox' || box === 'all') {
+            const outboxEdgeTypes = new Set(['SENT_BY']);
+            for (const targetVariant of targetStorageVariants) {
+                collectCandidates(targetVariant, outboxEdgeTypes);
+            }
+        }
 
-                // Lazy-reload this message's outbound vicinity — loads SENT_BY,
-                // PART_OF_THREAD, TAGGED_CONCEPT, etc. edges authored by the message.
-                // Without this, the inner `sourceEdge` iteration (below) sees only
-                // edges present in the process's cache at query entry, which is empty
-                // for peer-process writes.
-                db.getAdjacentNodes(messageNodeId, 'outbound');
+        let messages = [];
 
-                const messageNode = db.nodes.get(messageNodeId);
-                if (messageNode && messageNode.label === 'MESSAGE') {
-                    deliveryEdge = deliveryEdge || getBroadcastDeliveryEdge(messageNodeId, target);
+        for (const messageNodeId of candidateMessageIds) {
+            // Lazy-reload this message's outbound vicinity — loads SENT_BY, SENT_TO,
+            // DELIVERED_TO, PART_OF_THREAD, TAGGED_CONCEPT, and REFERENCES_TICKET once. The
+            // source index then projects only this message's degree instead of re-walking E edges
+            // for every matched message.
+            db.getAdjacentNodes(messageNodeId, 'outbound');
 
+            const messageNode = db.nodes.get(messageNodeId);
+            if (messageNode && messageNode.label === 'MESSAGE') {
+                const sourceEdges = db.edges.getByIndex('source', messageNodeId);
+
+                let sentByNodeId          = null;
+                let sentToNodeId          = null;
+                let foundThreadId         = null;
+                let deliveryEdge          = null;
+                let hasDeliveryEdges      = false;
+                let isDirectRecipient     = false;
+                let isBroadcastRecipient  = false;
+                let messageTaggedConcepts = [];
+
+                for (const sourceEdge of sourceEdges) {
+                    const
+                        sourceEdgeType   = getRecordField(sourceEdge, 'type'),
+                        sourceEdgeTarget = getRecordField(sourceEdge, 'target');
+
+                    if (sourceEdgeType === 'SENT_BY') sentByNodeId = sourceEdgeTarget;
+                    if (sourceEdgeType === 'SENT_TO') {
+                        sentToNodeId = sourceEdgeTarget;
+                        if (sameMailboxIdentity(sourceEdgeTarget, target)) isDirectRecipient = true;
+                        if (sourceEdgeTarget === 'AGENT:*') isBroadcastRecipient = true;
+                    }
+                    if (sourceEdgeType === 'DELIVERED_TO') {
+                        hasDeliveryEdges = true;
+                        if (sameMailboxIdentity(sourceEdgeTarget, target)) deliveryEdge = sourceEdge;
+                    }
+                    if (sourceEdgeType === 'PART_OF_THREAD') foundThreadId = sourceEdgeTarget;
+                    if (sourceEdgeType === 'TAGGED_CONCEPT') messageTaggedConcepts.push(sourceEdgeTarget);
+                }
+
+                // Preserve the historical damaged-projection fallback: if a DELIVERED_TO edge
+                // survives while SENT_TO is absent beyond the bounded repair window, the old
+                // outer-edge match surfaced that recipient rather than manufacturing `to: null`.
+                if (!sentToNodeId && deliveryEdge) {
+                    sentToNodeId = getRecordField(deliveryEdge, 'target');
+                }
+
+                const
+                    isInboxMatch  = isDirectRecipient || Boolean(deliveryEdge) || (isBroadcastRecipient && !hasDeliveryEdges),
+                    isOutboxMatch = sameMailboxIdentity(sentByNodeId, target),
+                    isMatch       = box === 'all'
+                        ? isInboxMatch || isOutboxMatch
+                        : box === 'inbox'
+                            ? isInboxMatch
+                            : isOutboxMatch;
+
+                if (isMatch) {
                     const readAt   = getReadAtForMessage(messageNode, deliveryEdge);
                     const isUnread = !readAt;
                     if (status === 'unread' && !isUnread) continue;
@@ -3025,22 +3053,6 @@ class MailboxService extends Base {
                     // remains coherent.
                     const archivedAt = getArchivedAtForMessage(messageNode, deliveryEdge);
                     if (!includeArchived && archivedAt) continue;
-
-                    let sentByNodeId          = senderNode;
-                    let sentToNodeId          = targetNode;
-                    let foundThreadId         = null;
-                    let messageTaggedConcepts = [];
-
-                    for (const sourceEdge of db.edges.items) {
-                        if (getRecordField(sourceEdge, 'source') === messageNode.id) {
-                            const sourceEdgeType = getRecordField(sourceEdge, 'type');
-
-                            if (sourceEdgeType === 'SENT_BY') sentByNodeId = getRecordField(sourceEdge, 'target');
-                            if (sourceEdgeType === 'SENT_TO') sentToNodeId = getRecordField(sourceEdge, 'target');
-                            if (sourceEdgeType === 'PART_OF_THREAD') foundThreadId = getRecordField(sourceEdge, 'target');
-                            if (sourceEdgeType === 'TAGGED_CONCEPT') messageTaggedConcepts.push(getRecordField(sourceEdge, 'target'));
-                        }
-                    }
 
                     if (normalizedFromIdentity && !sameMailboxIdentity(sentByNodeId, normalizedFromIdentity)) continue;
                     if (threadId && foundThreadId !== threadId) continue;
@@ -3073,7 +3085,7 @@ class MailboxService extends Base {
                     // above for the `threadId` filter. Project it so callers can group a thread
                     // without re-walking edges — consumers that only filtered by it never saw it.
                     if (foundThreadId) summary.partOfThread = foundThreadId;
-                    const relatedTickets = getRelatedTicketsForMessage(db, messageNode.id, messageNode);
+                    const relatedTickets = getRelatedTicketsForMessage(db, messageNode.id, messageNode, sourceEdges);
                     if (relatedTickets.length > 0) {
                         summary.relatedTickets = relatedTickets;
                     }

--- a/test/playwright/unit/ai/services/memory-core/MailboxService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/MailboxService.spec.mjs
@@ -2696,6 +2696,87 @@ test.describe('Neo.ai.services.memory-core.MailboxService', () => {
         });
     });
 
+    test('#16960 listMessages projects only indexed routing candidates, never the full edge store', async () => {
+        GraphService.upsertNode({id: '@charlie', type: 'AgentIdentity', name: 'Charlie', properties: {accountType: 'agent'}});
+        GraphService.upsertNode({id: 'THREAD:indexed', type: 'THREAD', name: 'Indexed Thread', properties: {}});
+        GraphService.upsertNode({id: 'ISSUE:indexed', type: 'ISSUE', name: 'Indexed Issue', properties: {}});
+        GraphService.upsertNode({id: 'CONCEPT:indexed', type: 'CONCEPT', name: 'Indexed Concept', properties: {}});
+        GraphService.upsertNode({id: 'UNRELATED:source', type: 'UNRELATED', name: 'Unrelated Source', properties: {}});
+
+        await RequestContextService.run({agentIdentityNodeId: '@bob'}, async () => {
+            await PermissionService.grantPermission({to: '@alice', scope: 'CAN_REPLY_TO'});
+        });
+
+        let directId, broadcastId;
+        await RequestContextService.run({agentIdentityNodeId: '@alice'}, async () => {
+            directId = (await MailboxService.addMessage({
+                to            : '@bob',
+                subject       : 'indexed direct',
+                body          : 'direct body',
+                partOfThread  : 'THREAD:indexed',
+                relatedTickets: ['ISSUE:indexed'],
+                taggedConcepts: ['CONCEPT:indexed']
+            })).messageId;
+            broadcastId = (await MailboxService.addMessage({
+                to     : 'AGENT:*',
+                subject: 'indexed broadcast',
+                body   : 'broadcast body'
+            })).messageId;
+        });
+
+        // An unrelated target-@bob edge proves the target index is still type-filtered. It must
+        // neither become a mailbox candidate nor force a cache-wide scan.
+        GraphService.linkNodes('UNRELATED:source', '@bob', 'UNRELATED', 1, {});
+
+        const db = GraphService.db;
+        db.getAdjacentNodes('@bob', 'inbound');
+        db.getAdjacentNodes('AGENT:*', 'inbound');
+        db.getAdjacentNodes(directId, 'outbound');
+        db.getAdjacentNodes(broadcastId, 'outbound');
+        db.acknowledgeLocalMutations();
+
+        const
+            originalItems  = db.edges._items,
+            originalRepair = MailboxService.repairMessageGraphIntegrity;
+
+        // The secondary index maps own independent Sets. Poisoning only full-array iteration is a
+        // mutation witness: the former outer and per-message `db.edges.items` walks throw, while
+        // `getByIndex('target'|'source', ...)` remains fully functional.
+        db.edges._items = new Proxy(originalItems, {
+            get(target, property, receiver) {
+                if (property === Symbol.iterator) {
+                    throw new Error('full edge-store iteration is forbidden in listMessages');
+                }
+                return Reflect.get(target, property, receiver)
+            }
+        });
+        MailboxService.repairMessageGraphIntegrity = async () => ({scanned: 0, repaired: 0, failed: 0});
+
+        try {
+            await RequestContextService.run({agentIdentityNodeId: '@bob'}, async () => {
+                const all = await MailboxService.listMessages({box: 'all'});
+                expect(all.messages.map(message => message.subject).sort()).toEqual([
+                    'indexed broadcast',
+                    'indexed direct'
+                ]);
+
+                const direct = all.messages.find(message => message.messageId === directId);
+                expect(direct).toMatchObject({
+                    from          : '@alice',
+                    to            : '@bob',
+                    partOfThread  : 'THREAD:indexed',
+                    relatedTickets: ['ISSUE:indexed']
+                });
+
+                const tagged = await MailboxService.listMessages({taggedConcepts: ['CONCEPT:indexed']});
+                expect(tagged.messages.map(message => message.messageId)).toEqual([directId]);
+            });
+        } finally {
+            MailboxService.repairMessageGraphIntegrity = originalRepair;
+            db.edges._items = originalItems;
+        }
+    });
+
     test('listMessages pagination (limit/offset) boundary', async () => {
         await RequestContextService.run({ agentIdentityNodeId: '@bob' }, async () => {
             await PermissionService.grantPermission({ to: '@alice', scope: 'CAN_REPLY_TO' });

--- a/test/playwright/unit/ai/services/memory-core/MailboxService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/MailboxService.spec.mjs
@@ -2777,6 +2777,39 @@ test.describe('Neo.ai.services.memory-core.MailboxService', () => {
         }
     });
 
+    test('#16960 indexed broadcast projection preserves first-match legacy receipt precedence', async () => {
+        GraphService.upsertNode({id: 'bob', type: 'AgentIdentity', name: 'Legacy Bob', properties: {accountType: 'agent'}});
+
+        let messageId;
+        await RequestContextService.run({agentIdentityNodeId: '@alice'}, async () => {
+            messageId = (await MailboxService.addMessage({
+                to     : 'AGENT:*',
+                subject: 'duplicate legacy delivery',
+                body   : 'receipt precedence'
+            })).messageId;
+        });
+
+        await RequestContextService.run({agentIdentityNodeId: '@bob'}, async () => {
+            await MailboxService.markRead({messageId});
+        });
+
+        const canonicalReceipt = GraphService.db.edges.getByIndex('source', messageId)
+            .find(edge => edge.type === 'DELIVERED_TO' && edge.target === '@bob');
+        expect(canonicalReceipt.properties.readAt).toBeTruthy();
+
+        // Historical stores can contain an equivalent bare-id receipt beside the canonical one.
+        // The former `getBroadcastDeliveryEdge(...).find(...)` contract selected the first match;
+        // indexed projection must not silently let the later null receipt erase that read state.
+        GraphService.linkNodes(messageId, 'bob', 'DELIVERED_TO', 1, {readAt: null});
+
+        await RequestContextService.run({agentIdentityNodeId: '@bob'}, async () => {
+            const result  = await MailboxService.listMessages({status: 'read'});
+            const message = result.messages.find(candidate => candidate.messageId === messageId);
+
+            expect(message?.readAt).toBe(canonicalReceipt.properties.readAt);
+        });
+    });
+
     test('listMessages pagination (limit/offset) boundary', async () => {
         await RequestContextService.run({ agentIdentityNodeId: '@bob' }, async () => {
             await PermissionService.grantPermission({ to: '@alice', scope: 'CAN_REPLY_TO' });


### PR DESCRIPTION
Resolves #16960

Related: #16677

`MailboxService.listMessages()` now discovers routing candidates through the graph Store's maintained target index and projects each candidate through its source index. The public mailbox/Fleet envelope, hydration, authorization, filtering, completeness, and pagination contracts stay unchanged; the former cache-wide candidate walk, per-message cache-wide metadata/ticket walks, and linear duplicate scan are gone.

Evidence: L2 (production-owner graph composition with a poisoned full-edge iterator plus the unchanged Fleet consumer) → L2 required (all close-target ACs are CI-reachable). No residuals.

## Deltas from ticket

None substantive. The implementation follows the corrected ticket ledger: it consumes the existing `source` and `target` graph Store indexes rather than building a second per-call index.

## Test Evidence

- Memory Core mailbox: `npm run test-unit -- test/playwright/unit/ai/services/memory-core/MailboxService.spec.mjs --workers=1` — 159/159 passed.
- Fleet activity consumer: `npm run test-unit -- test/playwright/unit/ai/services/fleet/fleetA2AActivityAdapter.spec.mjs --workers=1` — 11/11 passed.
- Exact current-`dev` composition: `npm run test-unit -- test/playwright/unit/ai/services/memory-core/MailboxService.spec.mjs test/playwright/unit/ai/services/fleet/fleetA2AActivityAdapter.spec.mjs --workers=1` — 168/168 passed.
- Repository preflight: `npm run agent-preflight -- --change-class restoration --commit-subject "fix(memory-core): index mailbox list projection (#16960)" ai/services/memory-core/MailboxService.mjs test/playwright/unit/ai/services/memory-core/MailboxService.spec.mjs` — passed.

The named `#16960` fixtures hydrate direct and broadcast candidates, preserve thread/tag/ticket projection, poison full edge-array iteration while leaving Store indexes intact, and preserve first-match read-state precedence when canonical and legacy-equivalent delivery receipts coexist. Restoring either former `db.edges.items` loop makes the work-bound fixture throw at the forbidden iterator.

## Post-Merge Validation

- [ ] Re-measure Fleet-bound `list_messages` latency on the canonical one-CPU plane and append the fixed-window receipt to parent #16677; do not promote reset overlap from correlation to request-identity causation.

## Evolution

The source audit found that `ai/graph/Store.mjs` already maintains the exact source/target indexes this path needs. The repair therefore reduced to consuming existing authority inside `MailboxService`, avoiding a duplicate index and keeping Fleet unchanged.

Authored by Emmy (GPT-5.6 Sol Ultra, Codex).

Origin Session ID: 019fe5e8-b963-7e93-8762-c8e4af16bdec
