### PR TITLE
fix(knowledge-base): a failed vector write no longer re-buys identical embeddings (#16963)

### DIFF
--- a/ai/services/knowledge-base/VectorService.mjs
+++ b/ai/services/knowledge-base/VectorService.mjs
@@ -716,9 +716,21 @@ class VectorService extends Base {
             let success   = false;
             let lastError = null;
 
+            // Held ACROSS retries, and that is the point: the provider call and the upsert share one
+            // `try`, so a PERSISTENCE failure used to send the retry back through the provider and buy
+            // the identical vectors again. Same texts, same model, same result — the second purchase
+            // cannot differ, it can only be charged.
+            //
+            // The yield arm below already refuses to discard paid work ("Persist what the yield already
+            // paid for"). This is the same principle on the ordinary failure path, which never had it:
+            // a batch that embeds fine but cannot write kept re-embedding on every attempt, and on
+            // every later sweep, producing continuous provider load against a collection that never
+            // grows — indistinguishable from progress from the outside.
+            let embeddings = null;
+
             while (retries < maxRetries && !success) {
                 try {
-                    const embeddings = await TextEmbeddingService.embedTexts(textsToEmbed, mcConfig.embeddingProvider, {
+                    embeddings ??= await TextEmbeddingService.embedTexts(textsToEmbed, mcConfig.embeddingProvider, {
                         operationLabel          : 'knowledge base tenant ingestion embedding',
                         operationStage          : 'kb-tenant-ingestion-embedding',
                         providerActivityRecorder: KBRecorderService,

--- a/test/playwright/unit/ai/services/knowledge-base/VectorService.persistenceNonConvergence.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/VectorService.persistenceNonConvergence.spec.mjs
@@ -16,13 +16,13 @@ setup({
 });
 
 import {mkdtempSync, rmSync, writeFileSync} from 'node:fs';
-import os                    from 'node:os';
-import path                  from 'node:path';
-import {test, expect}        from '@playwright/test';
-import Database              from 'better-sqlite3';
-import Neo                   from '../../../../../../src/Neo.mjs';
-import * as core             from '../../../../../../src/core/_export.mjs';
-import {snapshotAiConfig}    from '../memory-core/util.mjs';
+import os                                   from 'node:os';
+import path                                 from 'node:path';
+import {test, expect}                       from '@playwright/test';
+import Database                             from 'better-sqlite3';
+import Neo                                  from '../../../../../../src/Neo.mjs';
+import * as core                            from '../../../../../../src/core/_export.mjs';
+import {snapshotAiConfig}                   from '../memory-core/util.mjs';
 
 /**
  * @summary Persistence failure is an UNBOUNDED re-embed loop, proven through PRODUCTION's own selector.
@@ -251,6 +251,137 @@ test.describe('VectorService — persistence failure is an unbounded re-embed lo
 
         restoreKBConfig?.();
         restoreMCConfig?.();
+    });
+
+    test('a PROVIDER rejection is STILL retried — the repair caches a result, never a failure', async () => {
+        // The negative control for `??=`. Caching the embeddings across retries is only safe if a
+        // FAILED provider call leaves nothing cached: `embeddings ??= await embedTexts(...)` never
+        // assigns when the await throws, so the next lap must re-attempt the provider. If that were
+        // wrong the repair would convert one transient provider blip into a permanently unembeddable
+        // batch — strictly worse than the redundant work it removes.
+        KB_Config.data.maxRetries = 3;
+
+        const corpus = makeChunks(2);
+
+        let providerAttempts = 0,
+            upsertCalls      = 0;
+
+        TextEmbeddingService.ollamaProvider = {
+            async embed(input) {
+                const texts = Array.isArray(input) ? input : [input];
+
+                providerAttempts++;
+
+                // Fails the first attempt, succeeds after — a transient provider, which must still be
+                // re-asked rather than written off.
+                if (providerAttempts < 2) throw new Error('provider unavailable: transient embed rejection');
+
+                return {embeddings: texts.map(() => new Array(384).fill(0.1))}
+            }
+        };
+
+        const landed     = new Set(),
+              collection = {
+                  name: 'flaky-provider-knowledge-base',
+                  async count() { return landed.size },
+                  async get() { return {ids: [...landed], metadatas: [], documents: []} },
+                  async delete({ids}) { ids.forEach(id => landed.delete(id)) },
+                  async upsert({ids}) { upsertCalls++; ids.forEach(id => landed.add(id)) }
+              };
+
+        const result = await KB_VectorService.embedChunks({collection, chunksToProcess: corpus});
+
+        expect(providerAttempts, 'the failed provider call is re-attempted, not cached').toBe(2);
+        expect(result.embedded, 'and the batch converges once the provider recovers').toBe(corpus.length);
+        expect(upsertCalls, 'the write runs only after the provider actually produced vectors').toBe(1)
+    });
+
+    test('EXHAUSTED persistence retries report failure, never false embedded progress', async () => {
+        // The other direction: caching vectors across retries must not make a batch that NEVER landed
+        // look landed. `embedded` counts what reached the store, so a store that rejects every attempt
+        // has to end at zero — otherwise the repair would manufacture exactly the phantom progress this
+        // ticket family exists to remove.
+        KB_Config.data.maxRetries = 2;
+
+        const corpus = makeChunks(2);
+
+        let providerCalls = 0,
+            upsertCalls   = 0;
+
+        TextEmbeddingService.ollamaProvider = {
+            async embed(input) {
+                const texts = Array.isArray(input) ? input : [input];
+                providerCalls += texts.length;
+                return {embeddings: texts.map(() => new Array(384).fill(0.1))}
+            }
+        };
+
+        const collection = {
+            name: 'permanently-unwritable-knowledge-base',
+            async count() { return 0 },
+            async get() { return {ids: [], metadatas: [], documents: []} },
+            async delete() {},
+            async upsert() { upsertCalls++; throw new Error('collection unavailable: permanent write rejection') }
+        };
+
+        // The pre-existing contract, deliberately asserted rather than assumed: exhausting the write
+        // retries REJECTS. I first wrote this expecting `{embedded: 0}` and the suite corrected me —
+        // "preserve current failure accounting" means preserving the throw, not softening it into a
+        // zero-count success that a caller could mistake for an empty batch.
+        await expect(
+            KB_VectorService.embedChunks({collection, chunksToProcess: corpus}),
+            'a batch that never lands still rejects'
+        ).rejects.toThrow(/after 2 retries/);
+
+        expect(upsertCalls, 'every configured attempt was spent on the write').toBe(2);
+        // The repair still holds on the failing path: the provider is paid once even though the write
+        // was attempted twice. Redundant purchase is removed WITHOUT softening the failure accounting.
+        expect(providerCalls, 'and the provider was still paid exactly once per text').toBe(corpus.length)
+    });
+
+    test('a PERSISTENCE failure retries the WRITE, never re-buying the vectors (#16780)', async () => {
+        // The loop the other tests in this file prove costs provider time on every lap, and this is the
+        // seam where that cost was paid: `embedTexts` and `collection.upsert` shared one `try`, so a
+        // failed WRITE sent the retry back through the PROVIDER for identical texts. Same model, same
+        // inputs — the second purchase could not differ, only be charged.
+        KB_Config.data.maxRetries = 3;
+
+        const corpus = makeChunks(2);
+
+        let providerCalls = 0,
+            upsertCalls   = 0;
+
+        TextEmbeddingService.ollamaProvider = {
+            async embed(input) {
+                const texts = Array.isArray(input) ? input : [input];
+                providerCalls += texts.length;
+                return {embeddings: texts.map(() => new Array(384).fill(0.1))}
+            }
+        };
+
+        // Rejects the first two writes, then accepts — a transient store, which is precisely the case
+        // that must not be charged three times.
+        const landed     = new Set(),
+              collection = {
+                  name: 'flaky-knowledge-base',
+                  async count() { return landed.size },
+                  async get() { return {ids: [...landed], metadatas: [], documents: []} },
+                  async delete({ids}) { ids.forEach(id => landed.delete(id)) },
+                  async upsert({ids}) {
+                      upsertCalls++;
+                      if (upsertCalls < 3) throw new Error('collection unavailable: transient write rejection');
+                      ids.forEach(id => landed.add(id))
+                  }
+              };
+
+        const result = await KB_VectorService.embedChunks({collection, chunksToProcess: corpus});
+
+        expect(upsertCalls, 'the write is retried until it lands').toBe(3);
+        expect(result.embedded, 'and the batch ultimately succeeds').toBe(corpus.length);
+
+        // The load-bearing assertion. Before the repair this was 6: two texts re-embedded on every one
+        // of the three attempts.
+        expect(providerCalls, 'the provider is paid exactly once for each text').toBe(corpus.length)
     });
 
     test('PRODUCTION re-selects the identical set on every sweep when persistence fails (#16780 AC-2)', async () => {


### PR DESCRIPTION
Resolves neomjs/neo#16963

The provider call and the upsert shared one `try`, so a **persistence** failure sent the retry back through the **provider** and bought the identical vectors again. Same texts, same model, same result — the second purchase cannot differ, it can only be charged.

Evidence: L2 (unit execution + the AC2 mutation receipt) → L2 required. Residual: none.

## The change

```js
let embeddings = null;

while (retries < maxRetries && !success) {
    embeddings ??= await TextEmbeddingService.embedTexts(textsToEmbed, …);
```

One line of behaviour. `??=` caches a **result**, never a failure: when the await throws, the assignment never happens and the next lap re-attempts the provider.

The yield arm below it already refused to discard paid work (*"Persist what the yield already paid for"*). This is the same principle on the ordinary failure path, which never had it.

## Why it is not cosmetic

A batch that embeds fine but cannot write kept re-embedding on **every attempt, and on every later sweep** — continuous provider load against a collection that never grows, which is indistinguishable from progress from the outside.

**Stated without joining A and B, per the neomjs/neo-agent-brain#54 ledger's Rule 0:** this is one separately-evidenced redundant-work source. It does **not** claim to explain the pegged cores; that is B and it remains open. Same standing as the other Tier-1 items, and the post-deploy measurement is still what decides.

## Deltas

**Verified against `dev` rather than trusted from the ledger ticks.** neomjs/neo#16780's progress table shows AC-1/AC-3/AC-6 merged via `#16867`; I checked the shipped source anyway, and the provider call is still inside the retry loop. Not covered.

**The two AC controls are the interesting half, because the repair is only safe if both hold:**

- **A failed provider call must leave nothing cached.** Without it, this "fix" would convert one transient provider blip into a permanently unembeddable batch — strictly worse than the redundant work it removes.
- **Exhausted write retries must not report false progress.** I wrote this expecting `{embedded: 0}` and the suite corrected me: the contract **rejects**. *"Preserve current failure accounting"* means preserving the throw, not softening it into a zero-count success a caller could read as an empty batch. Asserted as a rejection, with the provider still paid exactly once.

**The AC2 receipt was blinded on the first attempt, and that is worth recording.** Running the whole spec under the mutation showed *one* failure and looked like a negative result — the earlier test aborted the run before the AC1 test executed. Re-run with the AC1 test isolated, the receipt is exact. A mutation that reddens *something* is not the same as a mutation that reddens *the assertion you meant*.

## Test Evidence

```
npm run test-unit -- unit/ai/services/knowledge-base/VectorService.persistenceNonConvergence.spec.mjs
  9 passed

npm run test-unit -- unit/ai/services/knowledge-base/
  603 passed
```

**AC2 mutation — provider computation moved back inside the write retry loop:**

```
AC1 test, isolated:
  Error: the provider is paid exactly once for each text
  Expected: 2
  Received: 6
```

| AC | evidence |
|---|---|
| 3 upsert attempts, 2 provider submissions, `embedded: 2` | the AC1 test, green |
| mutation yields 6 submissions | receipt above, exact |
| an ordinary provider rejection is still retried | new control — 2 provider attempts, converges, 1 upsert |
| exhausted retries preserve failure accounting | new control — rejects with `/after 2 retries/`, provider paid once |
| focused suites + KB unit directory pass on the rebased head | 9 / 603 above |

## What this does NOT establish

- **It does not bound embedding work by pending items** — that is neomjs/neo#16780's wider list, delivered through other leaves. This closes one redundant-work path on the retry loop only.
- **It does not change failure semantics.** Exhaustion still rejects; the control exists to prove the repair did not soften it.
- **No claim about the pegged cores.** See Rule 0 above.

## Post-Merge Validation

- [ ] During a controlled transient vector-write rejection, provider activity records one logical submission per selected text while the write attempts retry independently — the leaf's own post-merge check, unchanged.

## Commits

- `9ea462ac02` — the paid-once repair
- `278d710fc4` — the two controls proving the cache holds a result, not a failure

Authored by Ada (Claude Opus 5, Claude Code). Session 87f453f9-aa80-4487-9ed1-b5d91e052c43.
