### PR TITLE
fix(buildScripts): a hex colour in value position is not a ticket ref (#16553)

### DIFF
--- a/buildScripts/util/check-ticket-archaeology.mjs
+++ b/buildScripts/util/check-ticket-archaeology.mjs
@@ -19,11 +19,31 @@ export const DEFAULT_IGNORES    = ['.claude', '.codex', 'dist', 'node_modules'];
 // Inline relief valve for a genuinely load-bearing comment ref (judgment-call escape, not a blanket bypass).
 export const ESCAPE_MARKER = 'ticket-ref-ok';
 
-// Decay-prone tracking anchors that must not live in durable source comments. `#\d{4,}\b` targets
-// issue/PR numbers (Neo tickets are 5 digits) while a trailing word boundary avoids matching hex colors
-// like `#1234ff`; the named forms catch the prose variants.
+// Decay-prone tracking anchors that must not live in durable source comments. The first pattern
+// targets issue/PR numbers (Neo tickets are 5 digits); the named forms catch the prose variants.
+//
+// **The trailing `\b` alone was a guarantee about one example, not a rule.** The superseded comment
+// claimed it "avoids matching hex colors like `#1234ff`" — true, and only because that example has
+// letters the `\d{4,}` run cannot consume. An ALL-NUMERIC colour has nothing to stop it: `#000000`
+// is six digits, `\d{4,}` takes all six, `\b` succeeds at the end, and the guard fires on a colour.
+// `#000000`, `#111111`, `#123456` and `#332211` were all reported as ticket refs.
+//
+// The lookbehind keys on VALUE POSITION rather than digit count: a colour literal is introduced by
+// a quote, backtick, or `=`, while a tracking ref is a bare word in prose. Digit-count numerology
+// (`exactly 3 or 6`) was the alternative and was rejected — it breaks the day a six-digit ticket
+// exists, and this guard's whole failure mode is a rule that was really a claim about one shape.
+//
+// Deliberately NOT "inside quotes": a real ref that merely sits inside a string literal — prose of
+// the form `'see #<number>'` — is still decay-prone and must still fire. Only a `#` IMMEDIATELY
+// after the delimiter is a value; one preceded by a space is prose that happens to sit in a string.
+// A bare unquoted all-numeric colour still fires too — outside value position this pattern cannot
+// tell it from a ref, and firing is the safe direction for a guard whose escape hatch is one
+// `ticket-ref-ok` marker away.
+//
+// (This paragraph originally carried a literal example ref and the guard rejected the commit. The
+// rule caught its own documentation, which is the correct outcome and worth leaving on the record.)
 export const TICKET_PATTERNS = [
-    /#\d{4,}\b/,
+    /(?<!['"`=])#\d{4,}\b/,
     /\bEpic\s+#?\d+\b/i,
     /\bDiscussion\s+#?\d+\b/i,
     /\bADR[-\s]?\d{3,4}\b/i

--- a/src/component/Gallery.mjs
+++ b/src/component/Gallery.mjs
@@ -30,7 +30,7 @@ class Gallery extends Component {
         amountRows_: 3,
         /**
          * The background color of the gallery container
-         * @member {String} backgroundColor_='#000000' ticket-ref-ok: hex colour, not an issue ref
+         * @member {String} backgroundColor_='#000000'
          * @reactive
          */
         backgroundColor_: '#000000',

--- a/src/component/Helix.mjs
+++ b/src/component/Helix.mjs
@@ -26,7 +26,7 @@ class Helix extends Component {
         ntype: 'helix',
         /**
          * The background color of the helix container
-         * @member {String} backgroundColor_='#000000' ticket-ref-ok: hex colour, not an issue ref
+         * @member {String} backgroundColor_='#000000'
          * @reactive
          */
         backgroundColor_: '#000000',

--- a/test/playwright/unit/ai/buildScripts/util/check-ticket-archaeology.spec.mjs
+++ b/test/playwright/unit/ai/buildScripts/util/check-ticket-archaeology.spec.mjs
@@ -71,6 +71,34 @@ test.describe('check-ticket-archaeology guard', () => {
         expect(hits.map(h => h.line)).toEqual([1, 2, 3])
     });
 
+    test('does NOT flag an ALL-NUMERIC hex colour in value position', () => {
+        // The reported defect. `#1234ff` passed only because its letters stop the `\d{4,}` run before
+        // the word boundary — an accident of that example, not a rule. An all-numeric colour has
+        // nothing to stop it, so `#000000` matched and every edit to a file holding one failed the
+        // pre-commit hook on a line the change never touched.
+        const hits = findTicketRefs([
+            "     * @member {String} backgroundColor_='#000000'",
+            '// the badge renders `#123456` on hover',
+            '// default is "#332211" until themed'
+        ].join('\n'));
+
+        expect(hits).toEqual([])
+    });
+
+    test('STILL flags a real ref that merely sits inside a string literal', () => {
+        // The control that keeps the repair honest. The fix keys on VALUE POSITION, not on quotes:
+        // a `#` immediately after a delimiter is a literal, one preceded by a space is prose that
+        // happens to live in a string — and prose refs decay exactly like unquoted ones. A repair
+        // that excluded everything inside quotes would pass the test above and silently stop
+        // guarding the case the guard exists for.
+        const hits = findTicketRefs([
+            "// see 'the note in #16538' before touching this",
+            '// TODO per #16553 — bare prose ref'
+        ].join('\n'));
+
+        expect(hits).toHaveLength(2)
+    });
+
     test('does NOT flag a 6-hex-with-letters color or a markdown-style "# 12345" heading in a comment', () => {
         const hits = findTicketRefs([
             '// fallback color #1234ff for the badge',


### PR DESCRIPTION
Resolves #16553

The guard's own docblock claimed the protection it did not provide. `#000000` is a hex colour; the guard read it as a ticket reference and failed the pre-commit hook on lines the change never touched.

Evidence: L2 (unit execution + a two-sided mutation receipt) → L2 required. Residual: none.

## The defect was a guarantee about one example

```js
// … a trailing word boundary avoids matching hex colors like `#1234ff`
/#\d{4,}\b/
```

True — **for that example only.** `#1234ff` has letters, so the `\d{4,}` run cannot reach a word boundary and the match fails. An **all-numeric** colour has nothing to stop it: `#000000` is six digits, `\d{4,}` consumes all six, `\b` succeeds at the string end, and the guard fires.

So the exclusion held for `#1234ff` and failed for `#000000`, `#111111`, `#123456`, `#332211`. **The prose read as a general rule; it was a claim about one shape** — which is the same defect class the guard exists to prevent in other people's comments.

## The fix keys on value position, not digit count

```js
/(?<!['"`=])#\d{4,}\b/
```

A colour literal is introduced by a quote, backtick, or `=`. A tracking ref is a bare word in prose.

**Digit-count numerology (`exactly 3 or 6`) was the stated alternative and is rejected.** It breaks the day a six-digit ticket number exists — the identical failure mode being repaired, re-committed one layer down.

**Deliberately NOT "exclude anything inside quotes."** A real ref that merely sits inside a string literal is still decay-prone and must still fire. Only a `#` **immediately** after the delimiter is a value; one preceded by a space is prose that happens to live in a string.

## Deltas

**The measured blast radius was two suppression markers, and they are removed here.** The reported false positive had been worked around by hand rather than fixed:

```
src/component/Helix.mjs:29     ticket-ref-ok: hex colour, not an issue ref
src/component/Gallery.mjs:33   ticket-ref-ok: hex colour, not an issue ref
```

**A suppression marker on a false positive is the defect persisting with its alarm silenced** — and it costs more than the noise, because the next reader sees a sanctioned escape and copies it. Both lines are now plain, and the guard scans them clean.

**The first commit attempt was rejected by this guard.** My explanatory comment used a live ticket number as its example, which the repaired rule correctly still flags. The rule caught its own documentation — the right outcome, and left on the record in the docblock rather than quietly edited away.

## Test Evidence

```
npm run test-unit -- unit/ai/buildScripts/util/check-ticket-archaeology.spec.mjs
  23 passed

node buildScripts/util/check-ticket-archaeology.mjs \
  buildScripts/util/check-ticket-archaeology.mjs <spec> src/component/Helix.mjs src/component/Gallery.mjs
  4 files scanned, 0 violations
```

**Two-sided mutation receipt — each control convicts one direction:**

| mutation | reddens |
|---|---|
| revert to the bare `/#\d{4,}\b/` | **only** the new all-numeric-hex test |
| over-broad "exclude anything in quotes" | **only** the in-string-ref control |

Neither too narrow nor too broad. The second row is the one that matters: the obvious fix — ignore anything between quotes — passes the hex test and silently stops guarding the case the guard exists for.

## What this does NOT establish

- **A bare unquoted all-numeric hex still fires.** Outside value position the pattern cannot distinguish `#000000` from a ref, and firing is the safe direction for a guard whose escape hatch is one marker away. Stated in the docblock rather than left for a reader to discover.
- **Only the numeric pattern changed.** The named `Epic` / `Discussion` / `ADR` forms are untouched.
- **No claim about non-`src` trees.** The two workarounds found were both in `src/component`.

## Post-Merge Validation

- [ ] Nothing outstanding. The guard runs in `lint-staged` and CI from this merge onward, and the two files that previously needed escape markers are now covered without them.

## Commits

- `2c2c9985e2` — value-position lookbehind, two controls, and removal of both suppression markers

Authored by Ada (Claude Opus 5, Claude Code). Session 77a6d06c-ef28-41d9-9a9d-6ebc78814611.
