### PR TITLE
test(memory-core): bind residency diagnosis witnesses (#16859)

### DIFF
--- a/test/playwright/unit/ai/services/knowledge-base/embedFailureClassification.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/embedFailureClassification.spec.mjs
@@ -165,8 +165,9 @@ test.describe('embed failure classification (#16647)', () => {
  *
  * The specs above pin the classifier in isolation. That is necessary and not sufficient — a correct
  * helper wired to nothing would satisfy every one of them. This block drives the method the
- * orchestrator's sync lane actually calls, and asserts on `summary.errors[].code`: the exact field
- * `assertErrorFreeIngestionSummary` filters through `^KB_` on its way to `lastSourceErrorCode`.
+ * orchestrator's sync lane actually calls, and asserts on `summary.errors[].code` plus the bounded
+ * `summary.errors[].details.residencyDisposition` discriminator: the exact receipt fields a remote
+ * operator uses to distinguish a configuration fault from an eviction.
  *
  * The bounded-pattern assertion is the load-bearing half. Pre-fix these arrived as
  * `EMBEDDING_PROBE_TIMEOUT` and `ABORT_ERR`, which are rejected by that filter — so the receipt lost
@@ -187,23 +188,26 @@ test.describe('embed failure classification — production path', () => {
         );
         const
             summary = {errors: [], embeddingsGenerated: 0},
+            tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'neo-embed-witness-')),
             harness = {
                 createError            : IngestionService.createError.bind(IngestionService),
                 updateIngestionProgress: () => {},
                 vectorService          : {embed},
-                writeTempJsonl         : async () => path.join(
-                    await fs.mkdtemp(path.join(os.tmpdir(), 'neo-embed-witness-')), 'chunks.jsonl'
-                )
+                writeTempJsonl         : async () => path.join(tempDir, 'chunks.jsonl')
             };
 
-        await IngestionService.embedChunkGroups.call(harness, {
-            chunks       : [{repoSlug: 'org/witness', text: 'x'}],
-            summary,
-            tenantContext: {tenantId: 't1', repoSlug: 'org/witness'},
-            viaMcp       : false
-        });
+        try {
+            await IngestionService.embedChunkGroups.call(harness, {
+                chunks       : [{repoSlug: 'org/witness', text: 'x'}],
+                summary,
+                tenantContext: {tenantId: 't1', repoSlug: 'org/witness'},
+                viaMcp       : false
+            });
 
-        return summary
+            return summary
+        } finally {
+            await fs.remove(tempDir)
+        }
     }
 
     test('a thrown provider timeout and a thrown abort reach the receipt as distinct admissible codes', async () => {
@@ -239,6 +243,34 @@ test.describe('embed failure classification — production path', () => {
         expect(run.errors).toHaveLength(1);
         expect(run.errors[0].code).toMatch(BOUNDED_KB_ERROR_CODE_PATTERN);
         expect(run.errors[0].code).not.toBe(KB_VECTOR_EMBED_UNCLASSIFIED);
+    });
+
+    test('an observed mid-batch eviction reaches the final ingestion receipt (#16859)', async () => {
+        const error = Object.assign(new Error('embedding model was evicted'), {
+                  code                : 'EMBEDDING_MODEL_NOT_RESIDENT',
+                  residencyDisposition: 'evicted-mid-batch'
+              }),
+              run   = await runEmbedWithFailure(async () => { throw error });
+
+        expect(run.errors, 'the classified failure produced an operator-visible receipt').toHaveLength(1);
+        expect(run.errors[0].code).toBe('KB_VECTOR_EMBED_MODEL_NOT_RESIDENT');
+        expect(run.errors[0].details).toEqual({
+            repoSlug            : 'org/witness',
+            residencyDisposition: 'evicted-mid-batch'
+        });
+    });
+
+    test('an unobserved residency state stays absent from the final ingestion receipt (#16859)', async () => {
+        const error = Object.assign(new Error('embedding model was not resident'), {
+                  code: 'EMBEDDING_MODEL_NOT_RESIDENT'
+              }),
+              run   = await runEmbedWithFailure(async () => { throw error });
+
+        expect(run.errors, 'the unobserved-residency failure still produced an operator-visible receipt')
+            .toHaveLength(1);
+        expect(run.errors[0].details).toEqual({repoSlug: 'org/witness'});
+        expect(Object.hasOwn(run.errors[0].details, 'residencyDisposition'),
+            'absence means unobserved; a null-valued field would imply a measurement').toBe(false);
     });
 });
 

--- a/test/playwright/unit/ai/services/memory-core/TextEmbeddingService.retry.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/TextEmbeddingService.retry.spec.mjs
@@ -828,17 +828,23 @@ test.describe.serial('TextEmbeddingService #11393/#11402/#12487/#12509 — openA
         expect(requestCount, 'chunk 1 succeeded, chunk 2 + its retry both 404').toBe(3);
     });
 
-    test('a model that was NEVER resident keeps the configuration-fault code (#16852)', async () => {
+    test('a model that was NEVER resident keeps the configuration-fault code (#16852, #16859)', async () => {
         serverBehavior = 'fail-all-404';
+
+        let probeCount = 0;
 
         // Preflight finds nothing loaded, so the operation never observes residency. This is the
         // control that keeps the new code narrow: without it, reclassifying on 404 would relabel every
         // configuration fault as an eviction and destroy the distinction it exists to create.
-        TextEmbeddingService.openAiCompatibleLoadedModelsProbe = async () => [];
+        TextEmbeddingService.openAiCompatibleLoadedModelsProbe = async () => {
+            probeCount++;
+            return []
+        };
 
         const error = await TextEmbeddingService.embedTexts(['a'], 'openAiCompatible')
             .then(() => null, observed => observed);
 
+        expect(probeCount, 'the observed-negative arm performs exactly one residency preflight').toBe(1);
         expect(error.code).toBe('EMBEDDING_MODEL_NOT_RESIDENT');
         expect(error.residencyDisposition, 'never observed resident ⇒ configuration fault, not capacity').toBe('never-resident');
     });


### PR DESCRIPTION
Resolves #16859

Residency diagnosis now has mutation-sensitive evidence at both ends of its production chain. The never-resident control proves exactly one loaded-model preflight, while the real `IngestionService.embedChunkGroups()` composition proves an observed `evicted-mid-batch` discriminator reaches the operator-visible receipt and an unobserved state remains absent.

Evidence: L2 (production-shaped unit composition plus two named red mutations) → L2 required (all close-target ACs are unit-verifiable). No residuals.

## Deltas from ticket

No behavioral scope changed. The production implementation was already correct; this PR makes its two previously-green regressions fail CI. The existing ingestion test harness also removes its temporary directory in `finally`, preventing the two new receipt arms from amplifying a test-only filesystem leak.

## Test Evidence

- Focused canonical suites: `npm run test-unit -- test/playwright/unit/ai/services/memory-core/TextEmbeddingService.retry.spec.mjs test/playwright/unit/ai/services/knowledge-base/embedFailureClassification.spec.mjs` — 65 passed.
- Mutation 1: a second production loaded-model preflight makes the never-resident control fail with `Expected: 1`, `Received: 2`.
- Mutation 2: removing only the final `IngestionService` conditional carrier makes the observed-eviction receipt test fail because `residencyDisposition` is absent.
- Full unit suite: `npm run test-unit` — 12,842 passed, 11 skipped, zero failures. The first run exposed one unrelated `VdomDestroyCancellation` failure; its exact file passed 1/1 in isolation, and the complete rerun was green.
- `npm run agent-preflight -- --change-class zero-delta --commit-subject 'test(memory-core): bind residency diagnosis witnesses (#16859)' <two changed specs>` — passed.
- `git diff --check` — passed.

## Post-Merge Validation

None required. Every close-target acceptance criterion is owned by the deterministic unit and mutation evidence above.

Authored by Euclid (GPT-5.6, Codex Desktop). Session 8f7348e4-8be2-43bb-8bc0-b490bf79886a.
