### PR TITLE
feat(github-workflow): project exact-head readiness (#16902)

### DIFF
--- a/ai/mcp/server/github-workflow/openapi.yaml
+++ b/ai/mcp/server/github-workflow/openapi.yaml
@@ -382,13 +382,18 @@ paths:
         `projection: conversation` preserves the existing response shape.
 
         `projection: merge-readiness` is PR-only and accepts no caller-composed readiness
-        fields. GitHub Workflow binds the current AgentIdentity/GitHub/Memory Core principals,
-        reads the PR twice around two effective branch-rules reads, compares the snapshots,
-        derives required-vs-emitted context states, and feeds them to the existing
-        `validateMergeReady()` predicate. Only a positive coherent observation carries a
-        copyable `[merge-eligible][B-prime:...]` marker. Negative or unreadable observations
-        contain diagnostics and no marker. This resident-local observation reports what was
-        merge-ready at `observedAt`; it never grants merge authority or promises later validity.
+        fields. GitHub Workflow binds the current AgentIdentity/GitHub principals, reads the PR
+        twice around two effective branch-rules reads, compares the snapshots, selects every job
+        from the latest exact-head invocation of each GitHub Actions workflow, derives
+        required-vs-emitted context states, and feeds them to the existing `validateMergeReady()`
+        predicate. A missing Memory Core principal does not hide readable GitHub evidence: the
+        projection returns `verdict: unavailable` with a separate `checksVerdict`, names the missing
+        binding, and withholds the identity-bound marker. This preserves B-prime verdict semantics
+        while removing the need for a hand-rolled checks read. Only a positive observation with all
+        three principals carries a copyable `[merge-eligible][B-prime:...]` marker. Negative or
+        unreadable observations contain diagnostics and no marker. This resident-local observation
+        reports what was merge-ready at `observedAt`; it never grants merge authority or promises
+        later validity.
 
         **When to Use:**
         Use this tool to get the context of a pull request or issue — the initial proposal/body and the discussion history.

--- a/ai/services/github-workflow/PullRequestService.mjs
+++ b/ai/services/github-workflow/PullRequestService.mjs
@@ -704,8 +704,10 @@ async function buildMergeReadinessProjection({
         snapshot.checks.commitOid === snapshot.headRefOid;
     const checksGreen = checkSourceReady &&
         comparison.requiredStates.every(item => item.state === 'success');
+    const selectedChecksGreen = checkSourceReady &&
+        snapshot.checks.nodes.every(item => item.state === 'success');
     const checksVerdict = checkSourceReady
-        ? checksGreen ? 'green' : 'not-green'
+        ? selectedChecksGreen ? 'green' : 'not-green'
         : 'unknown';
     const reviewRequests = reviewSourceReady
         ? snapshot.reviewRequests.nodes.map(item => item.login)

--- a/ai/services/github-workflow/PullRequestService.mjs
+++ b/ai/services/github-workflow/PullRequestService.mjs
@@ -52,9 +52,11 @@ const DROP_SUPERSEDE_CONTRACT_FIELDS = [
     'Successor map citation'
 ];
 
-const MERGE_READINESS_PROJECTION     = 'merge-readiness';
-const MERGE_READINESS_SCHEMA_VERSION = 'neo.merge-readiness/v1';
-const MAX_BELIEVED_OPEN              = 100;
+const MERGE_READINESS_PROJECTION      = 'merge-readiness';
+const MERGE_READINESS_SCHEMA_VERSION  = 'neo.merge-readiness/v1';
+const MERGE_READINESS_RULES_PAGE_SIZE = 100;
+const MERGE_READINESS_RULES_MAX_PAGES = 10;
+const MAX_BELIEVED_OPEN               = 100;
 
 function stableStringify(value) {
     if (Array.isArray(value)) {
@@ -471,6 +473,46 @@ function parseRequiredContexts(rules) {
     ])).values()].sort((a, b) => stableStringify(a).localeCompare(stableStringify(b)));
 }
 
+/**
+ * @summary Reads the complete effective branch-rule population before reducing required contexts.
+ *
+ * GitHub paginates the branch-rules endpoint. A single readable JSON array is therefore not proof
+ * that an empty required-context set is authoritative: a required-status-check rule may live on a
+ * later page. Every page uses GitHub's maximum supported page size and only a terminal short page
+ * proves completeness. The hard page ceiling fails closed instead of turning an unexpectedly large
+ * or non-advancing source into a vacuous green result.
+ *
+ * @param {Function} rest      GitHub REST reader.
+ * @param {String}   rulesPath Branch-rules endpoint without pagination parameters.
+ * @returns {Promise<Object[]>} Complete branch-rule population.
+ * @throws {Error} When a page is malformed or the bounded read cannot prove completeness.
+ */
+async function readCompleteBranchRules(rest, rulesPath) {
+    const rules = [];
+
+    for (let page = 1; page <= MERGE_READINESS_RULES_MAX_PAGES; page++) {
+        const pageRules = await rest(
+            'GET',
+            `${rulesPath}?per_page=${MERGE_READINESS_RULES_PAGE_SIZE}&page=${page}`
+        );
+
+        if (!Array.isArray(pageRules)) {
+            throw createCodedError('REQUIRED_SET_UNREADABLE', 'Branch-rules response is not an array.');
+        }
+
+        rules.push(...pageRules);
+
+        if (pageRules.length < MERGE_READINESS_RULES_PAGE_SIZE) {
+            return rules;
+        }
+    }
+
+    throw createCodedError(
+        'REQUIRED_SET_UNREADABLE',
+        `Branch-rules response exceeded the bounded ${MERGE_READINESS_RULES_MAX_PAGES}-page read.`
+    );
+}
+
 function compareRequiredAndEmittedContexts(requiredContexts, emittedContexts) {
     const requiredStates = requiredContexts.map(required => {
         const matches = emittedContexts.filter(emitted =>
@@ -584,7 +626,7 @@ async function buildMergeReadinessProjection({
     let firstRequiredContexts;
 
     try {
-        firstRequiredContexts = parseRequiredContexts(await rest('GET', rulesPath));
+        firstRequiredContexts = parseRequiredContexts(await readCompleteBranchRules(rest, rulesPath));
         audit.push({source: `github-rest:${rulesPath}`, call: 1, outcome: 'read'});
     } catch (error) {
         return fail({
@@ -613,7 +655,7 @@ async function buildMergeReadinessProjection({
     let finalRequiredContexts;
 
     try {
-        finalRequiredContexts = parseRequiredContexts(await rest('GET', rulesPath));
+        finalRequiredContexts = parseRequiredContexts(await readCompleteBranchRules(rest, rulesPath));
         audit.push({source: `github-rest:${rulesPath}`, call: 2, outcome: 'read'});
     } catch (error) {
         return fail({

--- a/ai/services/github-workflow/PullRequestService.mjs
+++ b/ai/services/github-workflow/PullRequestService.mjs
@@ -242,6 +242,7 @@ function projectBelievedOpen(repository, lookups) {
 
 function classifyEmittedContext(node) {
     if (node?.__typename === 'CheckRun' && node.name) {
+        const workflowRun = node.checkSuite?.workflowRun;
         let state;
 
         if (node.status !== 'COMPLETED') {
@@ -264,7 +265,15 @@ function classifyEmittedContext(node) {
             status       : node.status,
             conclusion   : node.conclusion,
             state,
-            url          : node.detailsUrl ?? null
+            url          : node.detailsUrl ?? null,
+            workflow     : workflowRun ? {
+                id          : workflowRun.workflow?.databaseId ?? null,
+                name        : workflowRun.workflow?.name ?? null,
+                resourcePath: workflowRun.workflow?.resourcePath ?? null,
+                runId       : workflowRun.databaseId ?? null,
+                runNumber   : workflowRun.runNumber ?? null,
+                runAttempt  : workflowRun.runAttempt ?? null
+            } : null
         };
     }
 
@@ -285,7 +294,8 @@ function classifyEmittedContext(node) {
             status       : node.state,
             conclusion   : null,
             state,
-            url          : node.targetUrl ?? null
+            url          : node.targetUrl ?? null,
+            workflow     : null
         };
     }
 
@@ -297,8 +307,88 @@ function classifyEmittedContext(node) {
         status       : null,
         conclusion   : null,
         state        : 'not-applicable',
-        url          : null
+        url          : null,
+        workflow     : null
     };
+}
+
+/**
+ * @summary Keeps every job from the latest exact-head run of each GitHub Actions workflow.
+ *
+ * A commit rollup can retain check runs from multiple invocations of the same workflow. Comparing
+ * those rows by check name is unsafe: unrelated workflows commonly expose the same generic job name
+ * (for example `lint`). The workflow definition id is therefore the grouping authority; run number
+ * and attempt form the newest-run coordinate, while run id distinguishes contradictory equal tuples.
+ * Check runs without a workflow owner (external integrations and legacy status contexts) stay intact
+ * and continue through the conservative required-context comparison. A GitHub Actions check without
+ * complete workflow coordinates makes the whole selection unreadable: silently retaining or dropping
+ * it could either manufacture a green result or erase a live failure.
+ *
+ * @param {Object[]} contexts Normalized exact-head rollup contexts.
+ * @returns {{contexts: Object[], readable: Boolean}} Selected contexts and selection readability.
+ */
+function selectLatestWorkflowContexts(contexts) {
+    const latestByWorkflow = new Map();
+    let   readable         = true;
+
+    const compareCoordinates = (left, right) => {
+        for (const field of ['runNumber', 'runAttempt']) {
+            const delta = left[field] - right[field];
+
+            if (delta) {
+                return delta;
+            }
+        }
+
+        return 0;
+    };
+
+    for (const context of contexts) {
+        const workflow = context.workflow;
+
+        if (context.kind !== 'check-run' || context.integration !== 'github-actions') {
+            continue;
+        }
+
+        if (
+            !Number.isInteger(workflow?.id) ||
+            !Number.isInteger(workflow.runId) ||
+            !Number.isInteger(workflow.runNumber) ||
+            !Number.isInteger(workflow.runAttempt)
+        ) {
+            readable = false;
+            continue;
+        }
+
+        const current  = latestByWorkflow.get(workflow.id);
+        const ordering = current ? compareCoordinates(current, workflow) : 1;
+
+        if (current && ordering === 0 && current.runId !== workflow.runId) {
+            readable = false;
+        } else if (!current || ordering < 0) {
+            latestByWorkflow.set(workflow.id, workflow);
+        }
+    }
+
+    const selected = contexts.filter(context => {
+        const workflow = context.workflow;
+
+        if (context.kind !== 'check-run' || context.integration !== 'github-actions') {
+            return true;
+        }
+
+        if (!Number.isInteger(workflow?.id)) {
+            return true;
+        }
+
+        const latest = latestByWorkflow.get(workflow.id);
+
+        return workflow.runId === latest.runId &&
+            workflow.runNumber === latest.runNumber &&
+            workflow.runAttempt === latest.runAttempt;
+    });
+
+    return {contexts: selected, readable};
 }
 
 function normalizeMergeReadinessSnapshot(pullRequest) {
@@ -312,7 +402,9 @@ function normalizeMergeReadinessSnapshot(pullRequest) {
     const commit            = pullRequest.commits?.nodes?.[0]?.commit || null;
     const rollup            = commit?.statusCheckRollup;
     const contextConnection = rollup?.contexts;
-    const emittedContexts   = (contextConnection?.nodes || []).map(classifyEmittedContext)
+    const rawContexts       = Array.isArray(contextConnection?.nodes) ? contextConnection.nodes : [];
+    const selection         = selectLatestWorkflowContexts(rawContexts.map(classifyEmittedContext));
+    const emittedContexts   = selection.contexts
         .sort((a, b) => stableStringify(a).localeCompare(stableStringify(b)));
 
     return {
@@ -329,12 +421,14 @@ function normalizeMergeReadinessSnapshot(pullRequest) {
             nodes      : reviewers
         },
         checks: {
-            commitAvailable: Boolean(commit),
-            commitOid      : commit?.oid ?? null,
-            rollupAvailable: rollup === null || Boolean(contextConnection && Array.isArray(contextConnection.nodes)),
-            hasNextPage    : Boolean(contextConnection?.pageInfo?.hasNextPage),
-            totalCount     : contextConnection?.totalCount ?? emittedContexts.length,
-            nodes          : emittedContexts
+            commitAvailable  : Boolean(commit),
+            commitOid        : commit?.oid ?? null,
+            rollupAvailable  : Boolean(contextConnection && Array.isArray(contextConnection.nodes)),
+            hasNextPage      : Boolean(contextConnection?.pageInfo?.hasNextPage),
+            totalCount       : contextConnection?.totalCount ?? null,
+            rawCount         : rawContexts.length,
+            selectionReadable: selection.readable,
+            nodes            : emittedContexts
         }
     };
 }
@@ -461,13 +555,15 @@ async function buildMergeReadinessProjection({
         ...options
     });
 
-    if (!identityAssertion?.ok || Object.values(principals).some(value => !value)) {
+    if (!identityAssertion?.ok || !principals.agentIdentity || !principals.githubLogin) {
         return fail({
             code   : 'IDENTITY_BINDING_MISSING',
-            message: 'The merge-readiness projection requires bound AgentIdentity, GitHub, and Memory Core principals.',
+            message: 'The merge-readiness projection requires bound AgentIdentity and GitHub principals.',
             audit  : [{source: 'identity-assertion', outcome: 'failed'}]
         });
     }
+
+    const identityBindingComplete = Boolean(principals.memoryCoreIdentity);
 
     const variables = {owner, repo, prNumber};
     let firstSnapshot;
@@ -559,10 +655,16 @@ async function buildMergeReadinessProjection({
     const checkSourceReady = snapshot.checks.commitAvailable &&
         snapshot.checks.rollupAvailable &&
         !snapshot.checks.hasNextPage &&
+        Number.isInteger(snapshot.checks.totalCount) &&
+        snapshot.checks.totalCount === snapshot.checks.rawCount &&
+        snapshot.checks.selectionReadable &&
         snapshot.checks.nodes.every(item => item.kind !== 'unknown') &&
         snapshot.checks.commitOid === snapshot.headRefOid;
     const checksGreen = checkSourceReady &&
         comparison.requiredStates.every(item => item.state === 'success');
+    const checksVerdict = checkSourceReady
+        ? checksGreen ? 'green' : 'not-green'
+        : 'unknown';
     const reviewRequests = reviewSourceReady
         ? snapshot.reviewRequests.nodes.map(item => item.login)
         : undefined;
@@ -597,22 +699,27 @@ async function buildMergeReadinessProjection({
         mergeStateStatus: snapshot.mergeStateStatus,
         reviewRequests
     });
-    const strictMergeReady = predicate.strictMergeReady && sourceBlockers.length === 0;
-    const requiredSet      = {
+    const sourceMergeReady    = predicate.strictMergeReady && sourceBlockers.length === 0;
+    const certifiedMergeReady = sourceMergeReady && identityBindingComplete;
+    const requiredSet         = {
         source  : `GET ${rulesPath}`,
         digest  : digestValue(requiredContexts),
         contexts: requiredContexts
     };
     const observationCore = {
-        schemaVersion: MERGE_READINESS_SCHEMA_VERSION,
-        repo         : `${owner}/${repo}`,
-        pr           : prNumber,
-        base         : snapshot.baseRefName,
-        head         : snapshot.headRefOid,
-        state        : snapshot.state,
-        mergedAt     : snapshot.mergedAt,
+        schemaVersion  : MERGE_READINESS_SCHEMA_VERSION,
+        repo           : `${owner}/${repo}`,
+        pr             : prNumber,
+        base           : snapshot.baseRefName,
+        head           : snapshot.headRefOid,
+        state          : snapshot.state,
+        mergedAt       : snapshot.mergedAt,
         observedAt,
         principals,
+        identityBinding: {
+            complete: identityBindingComplete,
+            missing : identityBindingComplete ? [] : ['memoryCoreIdentity']
+        },
         requiredSet,
         contextStates: comparison.requiredStates,
         predicate
@@ -628,19 +735,34 @@ async function buildMergeReadinessProjection({
         emittedContexts : snapshot.checks.nodes,
         emittedOnly     : comparison.emittedOnly,
         checksGreen,
-        verdict         : strictMergeReady ? 'merge-ready-observed' : 'not-merge-ready',
-        statement       : strictMergeReady
-            ? `Observed strict merge-ready at ${observedAt} for ${owner}/${repo}#${prNumber} head ${snapshot.headRefOid}.`
-            : `Did not observe strict merge-readiness at ${observedAt} for ${owner}/${repo}#${prNumber} head ${snapshot.headRefOid}.`,
+        checksVerdict,
+        verdict         : identityBindingComplete
+            ? sourceMergeReady ? 'merge-ready-observed' : 'not-merge-ready'
+            : 'unavailable',
+        statement       : !identityBindingComplete
+            ? `Observed GitHub checks verdict '${checksVerdict}' at ${observedAt} for ${owner}/${repo}#${prNumber} head ${snapshot.headRefOid}; B-prime certification is unavailable because Memory Core identity is unbound.`
+            : certifiedMergeReady
+                ? `Observed strict merge-ready at ${observedAt} for ${owner}/${repo}#${prNumber} head ${snapshot.headRefOid}.`
+                : `Did not observe strict merge-readiness at ${observedAt} for ${owner}/${repo}#${prNumber} head ${snapshot.headRefOid}.`,
         blockers: [
+            ...(!identityBindingComplete ? [{
+                code             : 'IDENTITY_BINDING_MISSING',
+                message          : 'Memory Core identity is unbound; GitHub checks remain readable but B-prime certification is unavailable.',
+                missingPrincipals: ['memoryCoreIdentity'],
+                affects          : ['b-prime-certification']
+            }] : []),
             ...sourceBlockers,
             ...predicate.blockers.map(message => ({code: 'STRICT_MERGE_READINESS', message}))
         ],
         audit: [
             ...audit,
-            {source: 'validateMergeReady', call: 1, outcome: strictMergeReady ? 'positive' : 'negative'}
+            {source: 'validateMergeReady', call: 1, outcome: sourceMergeReady ? 'positive' : 'negative'},
+            {
+                source : 'memory-core-identity',
+                outcome: identityBindingComplete ? 'bound' : 'unbound-certification-withheld'
+            }
         ],
-        ...(strictMergeReady ? {marker: `[merge-eligible][B-prime:${observationId}]`} : {})
+        ...(certifiedMergeReady ? {marker: `[merge-eligible][B-prime:${observationId}]`} : {})
     };
 
     return deepFreeze(result);

--- a/ai/services/github-workflow/queries/pullRequestQueries.mjs
+++ b/ai/services/github-workflow/queries/pullRequestQueries.mjs
@@ -103,6 +103,16 @@ export const GET_MERGE_READINESS = `
                           databaseId
                           slug
                         }
+                        workflowRun {
+                          databaseId
+                          runNumber
+                          runAttempt
+                          workflow {
+                            databaseId
+                            name
+                            resourcePath
+                          }
+                        }
                       }
                     }
                     ... on StatusContext {

--- a/test/playwright/unit/ai/services/github-workflow/PullRequestService.spec.mjs
+++ b/test/playwright/unit/ai/services/github-workflow/PullRequestService.spec.mjs
@@ -421,8 +421,9 @@ test.describe('Neo.ai.services.github-workflow.PullRequestService — merge-read
         rules = [RULES, RULES],
         restError = null
     } = {}) => {
-        let queryCall = 0;
-        let restCall  = 0;
+        let   queryCall = 0;
+        let   restCall  = 0;
+        const restPaths = [];
 
         return {
             now  : () => new Date('2026-07-29T08:00:00.000Z'),
@@ -431,14 +432,17 @@ test.describe('Neo.ai.services.github-workflow.PullRequestService — merge-read
                     pullRequest: snapshots[Math.min(queryCall++, snapshots.length - 1)]
                 }
             }),
-            rest: async () => {
+            rest: async (method, path) => {
                 if (restError) {
                     throw restError;
                 }
 
+                restPaths.push({method, path});
+
                 return rules[Math.min(restCall++, rules.length - 1)];
             },
-            calls: () => ({queryCall, restCall})
+            calls    : () => ({queryCall, restCall}),
+            restPaths: () => restPaths
         };
     };
 
@@ -713,6 +717,44 @@ test.describe('Neo.ai.services.github-workflow.PullRequestService — merge-read
         expect(unreadable.marker).toBeUndefined();
         expect(empty.verdict).toBe('merge-ready-observed');
         expect(empty.requiredSet.contexts).toEqual([]);
+    });
+
+    test('#16902: reads every branch-rule page before an empty required set can become green', async () => {
+        const fullPage = Array.from({length: 100}, (value, index) => ({
+            type      : 'deletion',
+            ruleset_id: index + 1
+        }));
+        const deps   = dependencies({rules: [fullPage, RULES, fullPage, RULES]});
+        const result = await project(deps);
+
+        expect(result.verdict).toBe('merge-ready-observed');
+        expect(result.requiredSet.contexts).toEqual([
+            {context: 'integration-parity', integrationId: 15368}
+        ]);
+        expect(deps.calls()).toEqual({queryCall: 2, restCall: 4});
+        expect(deps.restPaths()).toEqual([
+            {method: 'GET', path: '/repos/neomjs/neo/rules/branches/dev?per_page=100&page=1'},
+            {method: 'GET', path: '/repos/neomjs/neo/rules/branches/dev?per_page=100&page=2'},
+            {method: 'GET', path: '/repos/neomjs/neo/rules/branches/dev?per_page=100&page=1'},
+            {method: 'GET', path: '/repos/neomjs/neo/rules/branches/dev?per_page=100&page=2'}
+        ]);
+    });
+
+    test('#16902: fails closed when the bounded branch-rule read never reaches a terminal page', async () => {
+        const fullPage = Array.from({length: 100}, (value, index) => ({
+            type      : 'deletion',
+            ruleset_id: index + 1
+        }));
+        const deps   = dependencies({rules: Array.from({length: 10}, () => fullPage)});
+        const result = await project(deps);
+
+        expect(result.verdict).toBe('unavailable');
+        expect(result.blockers[0]).toEqual(expect.objectContaining({
+            code   : 'REQUIRED_SET_UNREADABLE',
+            message: 'Branch-rules response exceeded the bounded 10-page read.'
+        }));
+        expect(result.marker).toBeUndefined();
+        expect(deps.calls()).toEqual({queryCall: 1, restCall: 10});
     });
 
     test('fails closed when the PR source moves during the observation', async () => {

--- a/test/playwright/unit/ai/services/github-workflow/PullRequestService.spec.mjs
+++ b/test/playwright/unit/ai/services/github-workflow/PullRequestService.spec.mjs
@@ -1,8 +1,8 @@
-import {setup} from '../../../../setup.mjs';
+import {setup}      from '../../../../setup.mjs';
 import {createHash} from 'node:crypto';
 
-const appName          = 'PullRequestServiceTest';
-const skipCiGitHubAuth = !!process.env.NEO_TEST_SKIP_CI;
+const appName                    = 'PullRequestServiceTest';
+const skipCiGitHubAuth           = !!process.env.NEO_TEST_SKIP_CI;
 const predecessorListQuerySha256 = '68b60ee57194252d68f3b50f2e174f25ff3859d3ba89bd2a66d7e2d873e1914f';
 
 setup({
@@ -299,7 +299,8 @@ test.describe('Neo.ai.services.github-workflow.PullRequestService — list fresh
     })
 });
 
-test.describe('Neo.ai.services.github-workflow.PullRequestService — merge-readiness projection (#16029)', () => {
+test.describe('Neo.ai.services.github-workflow.PullRequestService — merge-readiness projection (#16029, #16902)', () => {
+    let GET_MERGE_READINESS;
     let PullRequestService;
 
     const HEAD       = 'a'.repeat(40);
@@ -319,7 +320,9 @@ test.describe('Neo.ai.services.github-workflow.PullRequestService — merge-read
 
     const checkRun = (state = 'success', {
         integrationId = 15368,
-        name = 'integration-parity'
+        integration = 'github-actions',
+        name = 'integration-parity',
+        workflow = workflowFixture()
     } = {}) => {
         const variants = {
             success         : {status: 'COMPLETED', conclusion: 'SUCCESS'},
@@ -337,16 +340,44 @@ test.describe('Neo.ai.services.github-workflow.PullRequestService — merge-read
             checkSuite: {
                 app: {
                     databaseId: integrationId,
-                    slug      : 'github-actions'
-                }
+                    slug      : integration
+                },
+                workflowRun: workflow ? {
+                    databaseId: workflow.runId,
+                    runNumber : workflow.runNumber,
+                    runAttempt: workflow.runAttempt ?? 1,
+                    workflow  : {
+                        databaseId  : workflow.id,
+                        name        : workflow.name,
+                        resourcePath: workflow.resourcePath
+                    }
+                } : null
             }
         };
     };
+
+    const workflowFixture = ({
+        id = 278020769,
+        name = 'Tests',
+        resourcePath = '/neomjs/neo/actions/workflows/test.yml',
+        runId = 31404273390,
+        runNumber = 8462,
+        runAttempt = 1
+    } = {}) => ({
+        id,
+        name,
+        resourcePath,
+        runId,
+        runNumber,
+        runAttempt
+    });
 
     const pullRequest = ({
         baseRefName = 'dev',
         checkCommit = HEAD,
         checkHasNextPage = false,
+        checkRollupAvailable = true,
+        checkTotalCount,
         contexts = [checkRun()],
         headRefOid = HEAD,
         mergeStateStatus = 'CLEAN',
@@ -373,13 +404,13 @@ test.describe('Neo.ai.services.github-workflow.PullRequestService — merge-read
             nodes: [{
                 commit: {
                     oid              : checkCommit,
-                    statusCheckRollup: {
+                    statusCheckRollup: checkRollupAvailable ? {
                         contexts: {
-                            totalCount: contexts.length,
+                            totalCount: checkTotalCount ?? contexts.length,
                             pageInfo  : {hasNextPage: checkHasNextPage, endCursor: null},
                             nodes     : contexts
                         }
-                    }
+                    } : null
                 }
             }]
         }
@@ -422,6 +453,9 @@ test.describe('Neo.ai.services.github-workflow.PullRequestService — merge-read
         PullRequestService = (await import(
             '../../../../../../ai/services/github-workflow/PullRequestService.mjs'
         )).default;
+        ({GET_MERGE_READINESS} = await import(
+            '../../../../../../ai/services/github-workflow/queries/pullRequestQueries.mjs'
+        ));
     });
 
     test('returns one immutable positive exact-head observation and ignores caller readiness fields', async () => {
@@ -441,10 +475,205 @@ test.describe('Neo.ai.services.github-workflow.PullRequestService — merge-read
             {context: 'integration-parity', integrationId: 15368}
         ]);
         expect(result.principals).toEqual(PRINCIPALS);
+        expect(result.checksVerdict).toBe('green');
         expect(result.predicate.strictMergeReady).toBe(true);
         expect(Object.isFrozen(result)).toBe(true);
         expect(Object.isFrozen(result.requiredSet.contexts)).toBe(true);
         expect(deps.calls()).toEqual({queryCall: 2, restCall: 2});
+    });
+
+    test('#16902: query carries exact workflow-run coordinates instead of inferring attempts by job name', () => {
+        for (const field of ['workflowRun', 'runNumber', 'runAttempt', 'resourcePath', 'databaseId']) {
+            expect(GET_MERGE_READINESS).toContain(field);
+        }
+    });
+
+    test('#16902: returns a checks verdict but withholds B-prime when Memory Core identity is unbound', async () => {
+        const identityAssertion = {
+            ok        : true,
+            code      : 'OK',
+            reason    : null,
+            principals: {...PRINCIPALS, memoryCoreIdentity: null}
+        };
+        const deps   = dependencies();
+        const result = await PullRequestService.getConversation({
+            pr_number : 16029,
+            projection: 'merge-readiness',
+            identityAssertion
+        }, deps);
+
+        expect(result.verdict).toBe('unavailable');
+        expect(result.checksVerdict).toBe('green');
+        expect(result.checksGreen).toBe(true);
+        expect(result.predicate.strictMergeReady).toBe(true);
+        expect(result.identityBinding).toEqual({complete: false, missing: ['memoryCoreIdentity']});
+        expect(result.principals.memoryCoreIdentity).toBeNull();
+        expect(result.blockers).toContainEqual(expect.objectContaining({
+            code             : 'IDENTITY_BINDING_MISSING',
+            missingPrincipals: ['memoryCoreIdentity'],
+            affects          : ['b-prime-certification']
+        }));
+        expect(result.marker).toBeUndefined();
+        expect(result.audit).toContainEqual({
+            source : 'memory-core-identity',
+            outcome: 'unbound-certification-withheld'
+        });
+        expect(deps.calls()).toEqual({queryCall: 2, restCall: 2});
+    });
+
+    test('#16902: latest workflow invocation supersedes an earlier failure on the same exact head', async () => {
+        const oldRun = workflowFixture({
+            runId    : 31404455665,
+            runNumber: 7355
+        });
+        const newRun = workflowFixture({
+            runId    : 31406709306,
+            runNumber: 7357
+        });
+        const contexts = [
+            checkRun('failing', {workflow: oldRun}),
+            checkRun('success', {workflow: newRun})
+        ];
+        const result = await project(dependencies({
+            snapshots: [pullRequest({contexts}), pullRequest({contexts})]
+        }));
+
+        expect(result.verdict).toBe('merge-ready-observed');
+        expect(result.contextStates[0].state).toBe('success');
+        expect(result.emittedContexts).toHaveLength(1);
+        expect(result.emittedContexts[0].workflow.runNumber).toBe(7357);
+    });
+
+    test('#16902: a genuinely failing latest workflow invocation remains red', async () => {
+        const oldRun   = workflowFixture({runId: 10, runNumber: 9});
+        const newRun   = workflowFixture({runId: 11, runNumber: 10});
+        const contexts = [
+            checkRun('success', {workflow: oldRun}),
+            checkRun('failing', {workflow: newRun})
+        ];
+        const result = await project(dependencies({
+            snapshots: [pullRequest({contexts}), pullRequest({contexts})]
+        }));
+
+        expect(result.verdict).toBe('not-merge-ready');
+        expect(result.contextStates[0].state).toBe('failing');
+        expect(result.emittedContexts[0].workflow.runNumber).toBe(10);
+    });
+
+    test('#16902: a newer attempt of one workflow run supersedes its earlier attempt', async () => {
+        const oldAttempt = workflowFixture({runId: 20, runNumber: 12, runAttempt: 1});
+        const newAttempt = workflowFixture({runId: 20, runNumber: 12, runAttempt: 2});
+        const contexts   = [
+            checkRun('failing', {workflow: oldAttempt}),
+            checkRun('success', {workflow: newAttempt})
+        ];
+        const result = await project(dependencies({
+            snapshots: [pullRequest({contexts}), pullRequest({contexts})]
+        }));
+
+        expect(result.contextStates[0].state).toBe('success');
+        expect(result.emittedContexts[0].workflow.runAttempt).toBe(2);
+    });
+
+    test('#16902: generic job names from different workflows do not collapse into one population', async () => {
+        const lintA = workflowFixture({
+            id          : 278020769,
+            name        : 'Agent PR Body Lint',
+            resourcePath: '/neomjs/neo/actions/workflows/agent-pr-body-lint.yml',
+            runId       : 30,
+            runNumber   : 7357
+        });
+        const lintB = workflowFixture({
+            id          : 288951422,
+            name        : 'Config Template SSOT Lint',
+            resourcePath: '/neomjs/neo/actions/workflows/config-template-ssot-lint.yml',
+            runId       : 31,
+            runNumber   : 970
+        });
+        const contexts = [
+            checkRun('success', {name: 'lint', workflow: lintA}),
+            checkRun('success', {name: 'lint', workflow: lintB})
+        ];
+        const result = await project(dependencies({
+            rules    : [[], []],
+            snapshots: [pullRequest({contexts}), pullRequest({contexts})]
+        }));
+
+        expect(result.emittedContexts).toHaveLength(2);
+        expect(result.emittedContexts.map(item => item.workflow.resourcePath).sort()).toEqual([
+            '/neomjs/neo/actions/workflows/agent-pr-body-lint.yml',
+            '/neomjs/neo/actions/workflows/config-template-ssot-lint.yml'
+        ]);
+    });
+
+    test('#16902: retains every job from the selected latest workflow run', async () => {
+        const oldRun   = workflowFixture({runId: 40, runNumber: 20});
+        const newRun   = workflowFixture({runId: 41, runNumber: 21});
+        const contexts = [
+            checkRun('failing', {name: 'old-job', workflow: oldRun}),
+            checkRun('success', {name: 'lint', workflow: newRun}),
+            checkRun('success', {name: 'unit', workflow: newRun})
+        ];
+        const result = await project(dependencies({
+            rules    : [[], []],
+            snapshots: [pullRequest({contexts}), pullRequest({contexts})]
+        }));
+
+        expect(result.emittedContexts.map(item => item.name).sort()).toEqual(['lint', 'unit']);
+        expect(result.emittedContexts.every(item => item.workflow.runId === 41)).toBe(true);
+    });
+
+    test('#16902: preserves external checks without workflow-run coordinates', async () => {
+        const contexts = [checkRun('success', {
+            integration  : 'advanced-security',
+            integrationId: 57789,
+            name         : 'CodeQL',
+            workflow     : null
+        })];
+        const result = await project(dependencies({
+            rules    : [[], []],
+            snapshots: [pullRequest({contexts}), pullRequest({contexts})]
+        }));
+
+        expect(result.checksVerdict).toBe('green');
+        expect(result.emittedContexts).toHaveLength(1);
+        expect(result.emittedContexts[0].workflow).toBeNull();
+    });
+
+    test('#16902: fails closed on incomplete or ambiguous workflow-run evidence', async () => {
+        const sameTupleA = workflowFixture({id: 10, runId: 50, runNumber: 30, runAttempt: 2});
+        const sameTupleB = workflowFixture({id: 10, runId: 51, runNumber: 30, runAttempt: 2});
+        const cases      = [
+            pullRequest({contexts: [checkRun('success', {workflow: null})]}),
+            pullRequest({
+                contexts: [
+                    checkRun('success', {workflow: sameTupleA}),
+                    checkRun('success', {workflow: sameTupleB})
+                ]
+            }),
+            pullRequest({checkTotalCount: 2})
+        ];
+
+        for (const snapshot of cases) {
+            const result = await project(dependencies({snapshots: [snapshot, snapshot]}));
+
+            expect(result.checksVerdict).toBe('unknown');
+            expect(result.blockers.map(item => item.code)).toContain('EMITTED_CONTEXTS_UNREADABLE');
+            expect(result.marker).toBeUndefined();
+        }
+    });
+
+    test('#16902: a missing exact-head rollup or commit mismatch cannot inherit another head', async () => {
+        for (const snapshot of [
+            pullRequest({checkRollupAvailable: false}),
+            pullRequest({checkCommit: NEXT_HEAD})
+        ]) {
+            const result = await project(dependencies({snapshots: [snapshot, snapshot]}));
+
+            expect(result.checksVerdict).toBe('unknown');
+            expect(result.blockers.map(item => item.code)).toContain('EMITTED_CONTEXTS_UNREADABLE');
+            expect(result.marker).toBeUndefined();
+        }
     });
 
     test('preserves the default conversation projection shape and source count', async () => {
@@ -498,17 +727,26 @@ test.describe('Neo.ai.services.github-workflow.PullRequestService — merge-read
         expect(result.source.final.head).toBe(NEXT_HEAD);
     });
 
-    test('fails closed when identity binding is absent before any source read', async () => {
-        const deps   = dependencies();
-        const result = await PullRequestService.getConversation({
-            pr_number : 16029,
-            projection: 'merge-readiness'
-        }, deps);
+    test('fails closed before source reads when AgentIdentity or GitHub identity is unbound', async () => {
+        const assertions = [
+            undefined,
+            {...IDENTITY, principals: {...PRINCIPALS, agentIdentity: null}},
+            {...IDENTITY, principals: {...PRINCIPALS, githubLogin: null}}
+        ];
 
-        expect(result.verdict).toBe('unavailable');
-        expect(result.blockers[0].code).toBe('IDENTITY_BINDING_MISSING');
-        expect(result.marker).toBeUndefined();
-        expect(deps.calls()).toEqual({queryCall: 0, restCall: 0});
+        for (const identityAssertion of assertions) {
+            const deps   = dependencies();
+            const result = await PullRequestService.getConversation({
+                pr_number : 16029,
+                projection: 'merge-readiness',
+                identityAssertion
+            }, deps);
+
+            expect(result.verdict).toBe('unavailable');
+            expect(result.blockers[0].code).toBe('IDENTITY_BINDING_MISSING');
+            expect(result.marker).toBeUndefined();
+            expect(deps.calls()).toEqual({queryCall: 0, restCall: 0});
+        }
     });
 
     test('fails closed for a missing or wrong-integration required context', async () => {

--- a/test/playwright/unit/ai/services/github-workflow/PullRequestService.spec.mjs
+++ b/test/playwright/unit/ai/services/github-workflow/PullRequestService.spec.mjs
@@ -564,6 +564,31 @@ test.describe('Neo.ai.services.github-workflow.PullRequestService — merge-read
         expect(result.emittedContexts[0].workflow.runNumber).toBe(10);
     });
 
+    test('#16902: an optional latest failure makes the checks verdict non-green without changing B-prime', async () => {
+        const optionalWorkflow = workflowFixture({
+            id          : 288951422,
+            name        : 'Agent PR Body Lint',
+            resourcePath: '/neomjs/neo/actions/workflows/agent-pr-body-lint.yml',
+            runId       : 12,
+            runNumber   : 7355
+        });
+        const contexts = [
+            checkRun('success'),
+            checkRun('failing', {name: 'lint-pr-body', workflow: optionalWorkflow})
+        ];
+        const result = await project(dependencies({
+            snapshots: [pullRequest({contexts}), pullRequest({contexts})]
+        }));
+
+        expect(result.checksGreen).toBe(true);
+        expect(result.predicate.strictMergeReady).toBe(true);
+        expect(result.verdict).toBe('merge-ready-observed');
+        expect(result.emittedOnly).toEqual([
+            expect.objectContaining({name: 'lint-pr-body', state: 'failing'})
+        ]);
+        expect(result.checksVerdict).toBe('not-green');
+    });
+
     test('#16902: a newer attempt of one workflow run supersedes its earlier attempt', async () => {
         const oldAttempt = workflowFixture({runId: 20, runNumber: 12, runAttempt: 1});
         const newAttempt = workflowFixture({runId: 20, runNumber: 12, runAttempt: 2});


### PR DESCRIPTION
Resolves #16902

Related: #16029

The governed merge-readiness projection now carries exact-head GitHub checks evidence even when the caller has no bound Memory Core principal, while preserving the existing B-prime authority boundary: the top-level verdict remains `unavailable`, `checksVerdict` reports `green`, `not-green`, or `unknown` across the complete selected latest-run population, and no marker is emitted. B-prime's separate `checksGreen` predicate remains governed only by effective required contexts, so an optional latest failure makes the evidence verdict non-green without changing merge eligibility. GitHub Actions rows are reduced by workflow-definition id and latest `(runNumber, runAttempt)`, retaining every job from the selected run and failing closed on truncated, count-mismatched, malformed, or ambiguous evidence. Effective branch rules are read across bounded REST pagination; only a terminal short page can prove an honestly empty required-context set.

Evidence: L2 (production-bound unit composition, mutation-red controls, and live exact-head GraphQL/REST source census) → L2 required (the close target specifies deterministic source-contract behavior). No residuals.

## Deltas from ticket

- Established the null cause: GitHub Workflow's stdio server has no Memory Core `RequestContext`; this is not a seat-registration gap. The repair preserves `memoryCoreIdentity: null` instead of manufacturing a second principal from `NEO_AGENT_IDENTITY` or adding a Memory Core dependency.
- Kept B-prime's existing verdict vocabulary. A partially bound call returns full GitHub evidence through `checksVerdict`, but remains `verdict: unavailable` and names `memoryCoreIdentity` as affecting certification only.
- Separated the all-selected `checksVerdict` from B-prime's required-context-only `checksGreen`. A latest optional failure now reports `checksVerdict: not-green` while the required-context predicate and marker eligibility stay unchanged.
- Selected current workflow evidence by workflow id and run coordinates, not generic job name. External checks and legacy status contexts remain visible; GitHub Actions checks without workflow coordinates fail closed.
- Interpreted “no run for this head” through the existing exact-head authority: a missing head rollup or commit mismatch yields `checksVerdict: unknown`, while a missing required context remains `absent-required`. The exact-head query never imports a prior head.
- Closed a review-found completeness gap in the branch-rules authority. GitHub paginates the endpoint; the projection now reads 100 rules per page, requires a terminal short page, and fails closed after 10 full pages rather than allowing a stable first-page truncation to manufacture green.
- Did not add temporary manual mechanics to the `pr-review` skill. Once this projection answers, OpenAPI remains the sole tool-mechanics authority established by `#16029`.

## Test Evidence

- Current-head merge-readiness slice: `npm run test-unit -- test/playwright/unit/ai/services/github-workflow/PullRequestService.spec.mjs --workers=1 --grep 'merge-readiness projection' --reporter=list` → 26/26 passed on rebased head `46ebb8fbd9`.
- Full GitHub Workflow service: 120/120 passed on predecessor head `736f37042b`; current-head hosted unit CI is pending.
- Merge-readiness + MCP registration: focused combined run → 31/31 passed on the original implementation head.
- OpenAPI/service contract: `npm run ai:lint-openapi-service-parity` → 0 consumed-but-undeclared parameters.
- Syntax/diff gates: `node --check` on both service modules and the spec; `git diff --check` → passed.
- Mutation controls: restoring the all-three pre-read gate made the partial-identity test red; bypassing workflow selection made both stale-failure and all-latest-jobs controls red; restoring the old single-page branch-rule reads made both pagination controls red; reusing required-only `checksGreen` for the all-selected `checksVerdict` made the required-success plus optional-failure control red. The restored implementation passed all named controls.
- Live source census: exact-head `#16889` exposed multiple invocations per workflow and unrelated workflows sharing the job name `lint`, establishing workflow id rather than job name as the grouping authority. A live `dev?per_page=1` branch-rules read returned continuation metadata and placed the required-status rule beyond page 1, establishing pagination as a real source contract.

## Post-Merge Validation

- [ ] Re-run `get_conversation({pr_number: 16889, projection: 'merge-readiness'})` from a seat with `memoryCoreIdentity: null`; verify a usable `checksVerdict`, `verdict: unavailable`, the named certification gap, and no B-prime marker.
- [ ] Re-run the same projection with all three principals bound; verify the existing positive marker path is unchanged.

## Commits

- `dc0e00cf0f` — project exact-head readiness while preserving the B-prime identity boundary.
- `767b1fab58` — exhaust branch-rule pagination before accepting an empty required set.
- `46ebb8fbd9` — separate the all-selected checks verdict from required-context merge eligibility.

Authored by Emmy (GPT-5.6 Sol Ultra, Codex). Session 019fe5e8-b963-7e93-8762-c8e4af16bdec.
