### PR TITLE
fix(bridge): planned-restart subtraction reads the ledger the actuator writes (#16482)

### DIFF
--- a/ai/daemons/orchestrator/services/DeploymentStateBridgeService.mjs
+++ b/ai/daemons/orchestrator/services/DeploymentStateBridgeService.mjs
@@ -617,7 +617,11 @@ export class DeploymentStateBridgeService extends Base {
         }
 
         const statsSamples    = this.getStatsSamples(serviceKey);
-        const plannedRestarts = await this.countPlannedRestarts({serviceKey, observedAt: observationNow()});
+        const plannedRestarts = await this.collectPlannedRestarts({
+            serviceKey,
+            baseline  : churnBaseline,
+            observedAt: observationNow()
+        });
 
         // Query after every preceding async read and immediately before the synchronous diagnosis.
         // This is the safety boundary: a snapshot-start projection can claim idle even though a
@@ -641,7 +645,7 @@ export class DeploymentStateBridgeService extends Base {
                 providerActivity,
                 providerResidencyEligible: this.isProviderResidencyServiceKey(serviceKey),
                 churnBaseline            : churnBaseline?.unreadable ? undefined : churnBaseline,
-                plannedRestarts,
+                plannedRestarts          : plannedRestarts.count,
                 // `null` when `includeLogs` is off — which must surface as an UNAVAILABLE
                 // attribution, never as "not a heap death". A disabled channel is not evidence.
                 logs                 : logSummary,
@@ -657,14 +661,36 @@ export class DeploymentStateBridgeService extends Base {
         // reasoning ADR-0025 rejects in-memory anti-thrash state on. // ticket-ref-ok: names the decision this durability requirement inherits
         // An unjudgeable baseline must not be overwritten by a fresh anchor derived from it —
         // that is the silent-reset path. Leave it and let the ERROR log carry the degradation.
+        let baselineWrite = null;
+
         if (diagnosis?.churnBaseline && !churnBaseline?.unreadable) {
-            this.writeChurnBaseline(serviceKey, diagnosis.churnBaseline);
+            baselineWrite = this.writeChurnBaseline(serviceKey, diagnosis.churnBaseline) ? 'written' : 'failed';
         }
 
         // `churnBaseline` is INTERNAL scheduling state, not part of the published contract. The
         // decision carries it back so this service can persist it; publishing it would add an
         // undocumented field to `inspect_deployment` that no Contract Ledger row admits.
         const {churnBaseline: _internalBaseline, ...publishedDiagnosis} = diagnosis || {};
+
+        // Restart-churn is the one diagnosis whose FAILURE is shaped exactly like its healthy verdict:
+        // `collectRestartChurnFacts` emits nothing when there is no churn AND nothing when it cannot
+        // tell, so a plane whose detector was dead published a record indistinguishable from a quiet
+        // one. An unreadable baseline is never overwritten — deliberately, because re-anchoring on a
+        // damaged baseline is the silent-reset path — which means detection stays dead until a human
+        // removes the file, with only an ERROR log to say so. This section is what makes that sayable.
+        //
+        // It reports the detector's own health, never a churn verdict; the verdict remains the
+        // diagnosis service's non-authoritative `restart-churn` fact and no authority moves here.
+        const restartChurn = {
+            baseline       : churnBaseline?.unreadable ? 'unreadable' : churnBaseline ? 'available' : 'absent',
+            baselineWrite,
+            plannedRestarts: {reason: plannedRestarts.reason, status: plannedRestarts.status},
+            // The operator's actual question, answered directly rather than left to be inferred from
+            // the three fields above: can this service produce a churn verdict at all right now?
+            detecting      : !churnBaseline?.unreadable &&
+                plannedRestarts.status === 'available' &&
+                baselineWrite !== 'failed'
+        };
 
         return {
             schemaVersion : 1,
@@ -679,6 +705,7 @@ export class DeploymentStateBridgeService extends Base {
             providerResidency,
             providerActivity,
             heapObservation,
+            restartChurn,
             // EVERY snapshot, independent of load. The classification, the threshold that applies to
             // it, and the measured window state used to live only inside a sustained-saturation fact,
             // so a healthy store exposed none of them and no load-independent claim about the
@@ -1055,9 +1082,14 @@ export class DeploymentStateBridgeService extends Base {
 
     /**
      * @summary Persists the restart-churn baseline for one service.
+     *
+     * Returns the outcome rather than only logging it. The ERROR log below is written to a stream
+     * nothing on the published record reads, so a plane whose baseline could not be persisted looked
+     * exactly like one that never needed to persist it.
+     *
      * @param {String} serviceKey
      * @param {Object} baseline
-     * @returns {void}
+     * @returns {Boolean} `true` when the baseline reached disk.
      */
     writeChurnBaseline(serviceKey, baseline) {
         try {
@@ -1067,12 +1099,16 @@ export class DeploymentStateBridgeService extends Base {
             // baseline or the new one, never a fragment. The former `${target}.${pid}.tmp` scratch was
             // unique per process, but baselines are written per service key inside one.
             writeFileAtomicSync(this.churnBaselinePath(serviceKey), JSON.stringify(baseline, null, 2) + '\n')
+
+            return true
         } catch (error) {
             // ERROR, not WARN: a baseline that stops advancing means churn stops accumulating, and
             // the signal dies without the record ever going unhealthy.
             this.writeLog?.('ERROR', `[DeploymentStateBridge] churn baseline write FAILED for ${serviceKey}: ${error.message}. Churn detection is degraded until this succeeds.`);
             // The scratch cleanup that used to live here is the primitive's `finally`, which runs on
             // the failure path — there is no leaked sibling left for this block to remove.
+
+            return false
         }
     }
 
@@ -1086,55 +1122,97 @@ export class DeploymentStateBridgeService extends Base {
     }
 
     /**
-     * @summary Counts restarts this system itself initiated for one service inside the churn window.
+     * @summary Counts restarts this system itself initiated for one service inside the churn window,
+     * and reports whether that count is provably complete.
      *
-     * Subtracted from the observed delta so a deploy or an actuator restart cannot raise churn. The
-     * heal-event ledger is the record of what we did, which makes it the only honest source: this
-     * frame cannot otherwise distinguish an actuator restart from a crash, and guessing would fire
-     * the alarm on every deploy — after which it gets disabled and the blind spot returns with a
-     * dead alarm on top.
+     * Subtracted from the observed delta so a deploy or an actuator restart cannot raise churn. This
+     * frame cannot otherwise distinguish an actuator restart from a crash, and guessing would fire the
+     * alarm on every deploy — after which it gets disabled and the blind spot returns with a dead
+     * alarm on top.
+     *
+     * The source is the recovery-run ledger, which is the store the lifecycle actuator actually writes
+     * (`finishAction` → `appendRecoveryRunState`). The heal-event ledger this previously read serves
+     * the DATA-recovery actuator, whose action vocabulary contains no restart member at all — so the
+     * filter matched nothing any production plane had ever written, and every planned restart counted
+     * as unplanned churn on a live plane. It passed its unit test only because the fixture appended by
+     * hand the exact row the production path does not produce.
+     *
+     * The predicate is the lifecycle PROOF (`capabilityEnvelope: 'lifecycle-write'` +
+     * `operation: 'restart'`), never the recovery action's name, because the two disagree in both
+     * directions:
+     *
+     * - `reconfigure` restarts the container as part of the action — the knob overlay is read at boot,
+     *   so writing it without a restart is a no-op. Keying on the restart action alone would miss
+     *   these and raise the false churn this subtraction exists to prevent.
+     * - `raise-ceiling` deliberately does NOT restart; its proof carries `update-memory-limit`.
+     * - a supervised-task recycle restarts a PROCESS, so Docker's `RestartCount` never moves for it
+     *   and it must not be subtracted. It carries no lifecycle proof, so this predicate excludes it
+     *   without needing a second rule.
+     *
+     * The proof also stamps `observedAt` at the moment the restart was dispatched and carries its own
+     * `serviceKey` — the honest window bound and owner for this count, rather than the diagnosis time.
      *
      * @param {Object} options
      * @param {String} options.serviceKey
+     * @param {Object|null} options.baseline The already-read churn baseline. Passed in rather than
+     *     re-read, so the count and the diagnosis cannot compare against two different anchors.
      * @param {Number} options.observedAt
-     * @returns {Number}
+     * @returns {Promise<Object>} `{count, reason, status}`. `status: 'degraded'` means the count could
+     *     not be proven complete, and `count` then suppresses churn instead of asserting a number.
      */
-    async countPlannedRestarts({serviceKey, observedAt}) {
-        const baseline = this.readChurnBaseline(serviceKey);
+    async collectPlannedRestarts({serviceKey, baseline, observedAt}) {
+        // No usable anchor means no window to count inside — and `evaluateRestartChurn` reports
+        // nothing on a first look or an unjudgeable baseline either. Zero here is a measured zero.
+        if (!baseline || baseline.unreadable) {
+            return {count: 0, reason: null, status: 'available'};
+        }
 
-        if (!baseline) return 0;
+        // The store's OWN retention bound, not the snapshot's publication cap (`recoveryRunLimit`).
+        // Reading fewer entries than the store retains would silently under-subtract.
+        const limit = AiConfig.orchestrator.recoveryActuator.recoveryRunRetentionLimit;
+
+        // Checked before the read, because `readRecentRecoveryRunStates` answers a non-finite limit
+        // with an empty array — which is indistinguishable from "no planned restarts" and would raise
+        // false churn on a misconfigured plane rather than reporting that it cannot count.
+        if (!Number.isFinite(limit) || limit <= 0) {
+            return {count: Number.MAX_SAFE_INTEGER, reason: 'recovery-run-limit-invalid', status: 'degraded'};
+        }
 
         try {
-            // Same injection seam the snapshot fold uses (`healLedgerReader || readHealLedger`),
-            // rather than a second direct reader — one source of ledger truth, and testable.
-            // AWAITED: `readHealLedger` is async, and the snapshot fold awaits it too. An earlier
-            // revision did not, so `queryHealLedger` received a Promise, matched nothing, and planned
-            // restarts counted 0 — every deploy would have raised false churn.
-            const reader = this.healLedgerReader || readHealLedger,
-                  events = await reader({dir: this.healLedgerDir});
+            // Same injection seam `collectRecoveryRunSnapshot` uses, rather than a second direct
+            // reader — one source of recovery-run truth, and testable.
+            const reader  = this.recoveryRunStateReader || readRecentRecoveryRunStates,
+                  entries = await reader({dir: AiConfig.orchestrator.recoveryActuator.recoveryRunStateDir, limit});
 
-            return queryHealLedger(events, {collections: [serviceKey]})
-                // Filter on status too, or one recovery action counts TWICE: `recordRun` writes
-                // `status: 'attempt'` and `recordHealOutcome` writes a second row with the SAME
-                // type and collection. Double-counting over-subtracts, which suppresses genuine
-                // churn — a false negative on the whole signal, and one that only became reachable
-                // once the async/epoch defects above were fixed and real events started matching.
-                .filter(event => event?.type === 'restart' && event?.status === 'attempt')
-                .filter(event => {
-                    // `appendHealEvent` stamps `at` as EPOCH MS (healEventLedgerStore: `at:
-                    // Number.isFinite(entry.at) ? entry.at : now`). An earlier revision ran
-                    // `Date.parse(event.at)` — `Date.parse` of a number is NaN, so every REAL event
-                    // was filtered out, planned restarts counted 0, and a deploy would have raised
-                    // false churn. It passed its test only because the test fabricated ISO strings.
-                    const at = typeof event.at === 'number' ? event.at : Date.parse(event.at ?? '');
+            // Entries arrive newest-first, so the last one is the furthest back this read reached.
+            const oldest   = entries[entries.length - 1],
+                  oldestAt = [oldest?.updatedAt, oldest?.completedAt, oldest?.startedAt].find(Number.isFinite) ?? null;
 
-                    return Number.isFinite(at) && at >= baseline.observedAt && at <= observedAt;
-                })
-                .length
+            // A full read cannot prove it reached back to the baseline: retention prunes the far end.
+            // Publishing the truncated count would UNDER-subtract and raise churn for restarts we
+            // performed ourselves — the exact false positive that gets an alarm switched off.
+            if (entries.length >= limit && (oldestAt === null || oldestAt >= baseline.observedAt)) {
+                return {count: Number.MAX_SAFE_INTEGER, reason: 'recovery-run-window-truncated', status: 'degraded'};
+            }
+
+            const count = entries.filter(entry => {
+                const proof = entry?.details?.runtimeAccess;
+
+                return proof?.capabilityEnvelope === 'lifecycle-write' &&
+                    proof.operation  === 'restart'   &&
+                    proof.serviceKey === serviceKey  &&
+                    Number.isFinite(proof.observedAt) &&
+                    proof.observedAt >= baseline.observedAt &&
+                    proof.observedAt <= observedAt
+            }).length;
+
+            return {count, reason: null, status: 'available'};
         } catch {
             // Unknown provenance must not raise churn: an unreadable ledger means we cannot prove a
-            // restart was ours, and a false churn alarm costs more than a missed one.
-            return Number.MAX_SAFE_INTEGER
+            // restart was ours, and a false churn alarm costs more than a missed one. Suppressing the
+            // signal AND saying so is what makes the silence readable — the suppression alone is what
+            // left an operator unable to tell a quiet plane from a broken detector.
+            return {count: Number.MAX_SAFE_INTEGER, reason: 'recovery-run-read-failed', status: 'degraded'};
         }
     }
 

--- a/ai/daemons/orchestrator/services/DeploymentStateBridgeService.mjs
+++ b/ai/daemons/orchestrator/services/DeploymentStateBridgeService.mjs
@@ -660,7 +660,12 @@ export class DeploymentStateBridgeService extends Base {
         // anchor resets on every restart and the count can never reach a threshold — the same
         // reasoning ADR-0025 rejects in-memory anti-thrash state on. // ticket-ref-ok: names the decision this durability requirement inherits
         // An unjudgeable baseline must not be overwritten by a fresh anchor derived from it —
-        // that is the silent-reset path. Leave it and let the ERROR log carry the degradation.
+        // that is the silent-reset path. Leave it; the `restartChurn` section below reports the
+        // degradation on the record, so skipping the write no longer costs an operator the signal.
+        //
+        // `null` is the honest value for "no write was attempted", which is distinct from both
+        // outcomes of one that was — a tri-state, because collapsing it to a boolean would make a
+        // first observation and a failed write agree.
         let baselineWrite = null;
 
         if (diagnosis?.churnBaseline && !churnBaseline?.unreadable) {

--- a/test/playwright/unit/ai/daemons/orchestrator/services/DeploymentStateBridgeService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/DeploymentStateBridgeService.spec.mjs
@@ -13,7 +13,11 @@ import {
     summarizeProbeReliability
 } from '../../../../../../../ai/daemons/orchestrator/services/DeploymentStateBridgeService.mjs';
 import {ContainerHealthDiagnosisService} from '../../../../../../../ai/daemons/orchestrator/services/ContainerHealthDiagnosisService.mjs';
-import {appendHealEvent, readHealLedger} from '../../../../../../../ai/services/memory-core/helpers/healEventLedgerStore.mjs';
+import {DeploymentRuntimeAccessService}  from '../../../../../../../ai/daemons/orchestrator/services/DeploymentRuntimeAccessService.mjs';
+import {
+    createRecoveryDiagnosisEvent,
+    createRecoveryRunStateEntry
+} from '../../../../../../../ai/services/memory-core/helpers/recoveryRunStateStore.mjs';
 import {
     TENANT_REPO_INGEST_CONTRACT_VERSION
 } from '../../../../../../../ai/daemons/orchestrator/services/tenantRepoCheckpointValidity.mjs';
@@ -2131,11 +2135,83 @@ test.describe('restart churn reaches the deployment record', () => {
         }
     });
 
-    const bridgeFor = (Id, RestartCount, healLedgerReader = null) => createService({
+    const bridgeFor = (Id, RestartCount, recoveryRunStateReader = null) => createService({
         diagnosisService    : Neo.create(ContainerHealthDiagnosisService, {}),
         healLedgerDir       : dir,
-        healLedgerReader,
+        recoveryRunStateReader,
         runtimeAccessService: churningRuntime(Id, RestartCount)
+    });
+
+    /**
+     * The real runtime-access service, stamped at a chosen instant. Only `nowFn` and the Docker seam
+     * are substituted, so the proof it emits is the production one.
+     */
+    const runtimeAccessAt = at => Neo.create(DeploymentRuntimeAccessService, {
+        runtimeAccessConfig: {
+            enabled                     : true,
+            mechanism                   : 'docker-socket',
+            socketPath                  : '/var/run/docker.sock',
+            composeProject              : 'neo',
+            allowedServices             : ['orchestrator', 'chroma'],
+            readOperations              : ['inspect'],
+            lifecycleOperations         : ['restart'],
+            timeoutMs                   : 5000,
+            responseMaxBytes            : 1024,
+            logTail                     : 10,
+            defaultRestartTimeoutSeconds: 10,
+            auditMode                   : 'metadata'
+        },
+        dockerRequestFn: async () => ({statusCode: 204, headers: {}, body: ''}),
+        nowFn          : () => at
+    });
+
+    const targetFor = serviceKey => ({
+        serviceKey,
+        containerId   : 'c1',
+        names         : [`/neo-${serviceKey}-1`],
+        image         : 'neo:test',
+        state         : 'running',
+        status        : 'Up',
+        composeProject: 'neo',
+        labels        : {}
+    });
+
+    /**
+     * Drives the REAL restart path end-to-end, so the specimen proves the lifecycle write actually
+     * stamps `operation: 'restart'`. Building the proof directly would still be production-shaped but
+     * could not notice the restart path changing the operation it declares.
+     */
+    const restartProof = async (serviceKey, at) =>
+        (await runtimeAccessAt(at).restartTarget(targetFor(serviceKey), {reason: 'test'})).proof;
+
+    /** The same production proof builder, for the operations that have no cheap end-to-end driver. */
+    const lifecycleProof = (operation, serviceKey, at) => runtimeAccessAt(at).createProofMetadata({
+        envelope: 'lifecycle-write',
+        operation,
+        target  : targetFor(serviceKey)
+    });
+
+    /**
+     * Wraps a proof in a recovery-run entry through the production constructor, which validates every
+     * field. The previous fixture hand-appended `{type: 'restart'}` heal-event rows — a shape NO
+     * production writer emits — so the suite agreed with itself while disagreeing with the plane.
+     */
+    const runEntry = (proof, at) => createRecoveryRunStateEntry({
+        recoveryRunId : `recovery-actuator:${proof.serviceKey}:${proof.operation}:${new Date(at).toISOString()}`,
+        diagnosisEvent: createRecoveryDiagnosisEvent({
+            diagnosisId   : `d-${proof.serviceKey}-${at}`,
+            recoveryClass : 'crash',
+            confidence    : 1,
+            targetIdentity: {kind: 'compose-service', id: proof.serviceKey},
+            observedAt    : at
+        }),
+        rung       : 'rung-2',
+        attempt    : 1,
+        status     : 'reobserve-requested',
+        startedAt  : at,
+        updatedAt  : at,
+        completedAt: at,
+        details    : {runtimeAccess: proof}
     });
 
     test.beforeEach(() => {dir = fs.mkdtempSync(path.join(os.tmpdir(), 'churn-bridge-'))});
@@ -2176,71 +2252,51 @@ test.describe('restart churn reaches the deployment record', () => {
     });
 
     /**
-     * The AC that is harder than the recreate case: restarts WE caused must not raise the alarm. The
-     * heal-event ledger is the record of what we did, and an alarm that fires on every deploy is
-     * disabled within a week — leaving the blind spot plus a dead alarm.
+     * The AC that is harder than the recreate case: restarts WE caused must not raise the alarm. An
+     * alarm that fires on every deploy is disabled within a week — leaving the blind spot plus a dead
+     * alarm.
+     *
+     * This is also the regression guard for the source itself. The count now reads the recovery-run
+     * ledger, which is what the lifecycle actuator writes; the heal-event ledger it read before serves
+     * the DATA-recovery actuator and has no restart member in its action vocabulary at all. Reverting
+     * the source turns this test red, because nothing here writes a heal event.
      */
-    test('restarts recorded as ours in the heal ledger are subtracted, so a deploy raises nothing', async () => {
+    test('restarts the lifecycle actuator recorded are subtracted, so a deploy raises nothing', async () => {
         await bridgeFor('c1', 0).collectServiceSnapshot({serviceKey: 'orchestrator', observedAt: OBSERVED_AT});
 
-        // Written through the REAL `appendHealEvent`, not hand-shaped. An earlier revision fabricated
-        // ISO-string `at` values; production stamps epoch ms, so the filter dropped every real event
-        // and the test passed against a specimen that could not occur. The specimen has to be
-        // production-shaped by construction, which means using the production writer.
-        // `status: 'attempt'` is what `recordRun` writes. The outcome row that follows carries the
-        // same type + collection, so both are appended here — counting them as two restarts would
-        // over-subtract and suppress genuine churn.
+        const ourRestarts = [];
+
         for (let i = 0; i < 5; i++) {
-            await appendHealEvent(
-                {type: 'restart', collection: 'orchestrator', status: 'attempt', detail: {}},
-                {dir, now: OBSERVED_AT + 30000}
-            );
-            await appendHealEvent(
-                {type: 'restart', collection: 'orchestrator', status: 'healed', detail: {}},
-                {dir, now: OBSERVED_AT + 30001}
-            );
+            ourRestarts.push(runEntry(await restartProof('orchestrator', OBSERVED_AT + 30000 + i), OBSERVED_AT + 30000 + i));
         }
 
-        const ourRestarts = await readHealLedger({dir});
+        // The specimen must carry the production marker, or this proves nothing about the predicate.
+        expect(ourRestarts[0].details.runtimeAccess.capabilityEnvelope).toBe('lifecycle-write');
+        expect(ourRestarts[0].details.runtimeAccess.operation).toBe('restart');
 
-        expect(ourRestarts.length).toBe(10);
-        expect(typeof ourRestarts[0].at).toBe('number');
-
-        const withLedger = await bridgeFor('c1', 5, () => ourRestarts)
+        const withLedger = await bridgeFor('c1', 5, async () => ourRestarts)
             .collectServiceSnapshot({serviceKey: 'orchestrator', observedAt: OBSERVED_AT + 60000});
 
         expect(withLedger.diagnosis?.diagnosis?.details?.classificationReason).not.toBe('restart-churn-recorded');
+        expect(withLedger.restartChurn.plannedRestarts.status).toBe('available');
     });
 
     /**
-     * The test above proves the alarm stays quiet; it does NOT prove the arithmetic, and cannot.
-     * With 5 observed and 5 planned it passes on a correct subtraction AND on the paired-row
-     * double-count that `9795dee622` repaired, because `Math.max(0, ...)` clamps 5 - 10 to the same
-     * 0. A suppression test is satisfied by over-suppression.
+     * The test above proves the alarm stays quiet; it does NOT prove the arithmetic, and cannot — a
+     * suppression test is satisfied by over-suppression, so it passes on a correct subtraction AND on
+     * one that subtracts too much.
      *
-     * This one is positioned so the two answers disagree. 4 observed restarts against ONE
-     * attempt/outcome pair leaves exactly the threshold and must FIRE. Count that pair as two
-     * restarts and the delta drops to 2, the alarm goes quiet, and this test goes red — which is the
-     * property the suppression test cannot have, since quiet is its passing state.
+     * This one is positioned where the two answers disagree: 4 observed restarts against exactly ONE
+     * planned restart leaves the threshold and must FIRE. Subtract one too many and the alarm goes
+     * quiet and this goes red — the property the suppression test cannot have, since quiet is its
+     * passing state.
      */
-    test('a single attempt/outcome pair subtracts ONE restart, not two — churn still fires at the boundary', async () => {
+    test('the subtraction is exact, not merely suppressive — churn still fires at the boundary', async () => {
         await bridgeFor('c1', 0).collectServiceSnapshot({serviceKey: 'orchestrator', observedAt: OBSERVED_AT});
 
-        await appendHealEvent(
-            {type: 'restart', collection: 'orchestrator', status: 'attempt', detail: {}},
-            {dir, now: OBSERVED_AT + 30000}
-        );
-        await appendHealEvent(
-            {type: 'restart', collection: 'orchestrator', status: 'healed', detail: {}},
-            {dir, now: OBSERVED_AT + 30001}
-        );
+        const one = [runEntry(await restartProof('orchestrator', OBSERVED_AT + 30000), OBSERVED_AT + 30000)];
 
-        const onePair = await readHealLedger({dir});
-
-        // The specimen must contain the over-counting hazard, or the test proves nothing about it.
-        expect(onePair.length).toBe(2);
-
-        const atBoundary = await bridgeFor('c1', 4, () => onePair)
+        const atBoundary = await bridgeFor('c1', 4, async () => one)
             .collectServiceSnapshot({serviceKey: 'orchestrator', observedAt: OBSERVED_AT + 60000});
 
         expect(atBoundary.diagnosis.diagnosis.details.classificationReason).toBe('restart-churn-recorded');
@@ -2256,14 +2312,107 @@ test.describe('restart churn reaches the deployment record', () => {
         expect(churnFact.details.threshold).toBe(3);
     });
 
-    /** Unknown provenance must not raise churn: we cannot prove those restarts were not ours. */
-    test('an unreadable ledger suppresses the alarm rather than guessing', async () => {
+    /**
+     * The cell where the action name and the lifecycle proof DISAGREE, which is the whole reason the
+     * predicate reads the proof.
+     *
+     * `reconfigure` restarts the container as part of the action — the knob overlay is read at boot,
+     * so writing it without a restart is a no-op. Its run is therefore a planned restart even though
+     * its action is not named `restart`. An implementation keyed on the action name misses it, fails
+     * to subtract, and raises churn for a restart we performed: this test goes red.
+     */
+    test('a reconfigure run counts as a planned restart — the proof decides, not the action name', async () => {
         await bridgeFor('c1', 0).collectServiceSnapshot({serviceKey: 'orchestrator', observedAt: OBSERVED_AT});
 
-        const unreadable = await bridgeFor('c1', 9, () => {throw new Error('ledger unreadable')})
+        const at    = OBSERVED_AT + 30000,
+              proof = await restartProof('orchestrator', at),
+              // Exactly what `reconfigureComposeService` persists: it spreads the restart result, so
+              // the lifecycle proof rides along under a run whose id names the reconfigure action.
+              reconfigure = {
+                  ...runEntry(proof, at),
+                  recoveryRunId: `recovery-actuator:orchestrator:reconfigure:${new Date(at).toISOString()}`
+              };
+
+        const afterReconfigure = await bridgeFor('c1', 3, async () => [reconfigure])
+            .collectServiceSnapshot({serviceKey: 'orchestrator', observedAt: OBSERVED_AT + 60000});
+
+        expect(afterReconfigure.diagnosis?.diagnosis?.details?.classificationReason).not.toBe('restart-churn-recorded');
+    });
+
+    /**
+     * The same predicate from the other side, so it cannot be satisfied by "any lifecycle write".
+     * `raise-ceiling` moves the cgroup limit on the RUNNING container and deliberately does not
+     * restart it — its proof carries `update-memory-limit`. Subtracting it would hide real churn.
+     */
+    test('a raise-ceiling run is NOT a planned restart — churn still fires', async () => {
+        await bridgeFor('c1', 0).collectServiceSnapshot({serviceKey: 'orchestrator', observedAt: OBSERVED_AT});
+
+        const at      = OBSERVED_AT + 30000,
+              ceiling = runEntry(lifecycleProof('update-memory-limit', 'orchestrator', at), at);
+
+        const afterRaise = await bridgeFor('c1', 3, async () => [ceiling])
+            .collectServiceSnapshot({serviceKey: 'orchestrator', observedAt: OBSERVED_AT + 60000});
+
+        expect(afterRaise.diagnosis.diagnosis.details.classificationReason).toBe('restart-churn-recorded');
+    });
+
+    /** One shared store serves every service, so the count has to be owned by its own service key. */
+    test("another service's restart is not subtracted from this one", async () => {
+        await bridgeFor('c1', 0).collectServiceSnapshot({serviceKey: 'orchestrator', observedAt: OBSERVED_AT});
+
+        const at       = OBSERVED_AT + 30000,
+              otherKey = runEntry(await restartProof('chroma', at), at);
+
+        const record = await bridgeFor('c1', 3, async () => [otherKey])
+            .collectServiceSnapshot({serviceKey: 'orchestrator', observedAt: OBSERVED_AT + 60000});
+
+        expect(record.diagnosis.diagnosis.details.classificationReason).toBe('restart-churn-recorded');
+    });
+
+    /** Unknown provenance must not raise churn: we cannot prove those restarts were not ours. */
+    test('an unreadable ledger suppresses the alarm AND publishes that it could not count', async () => {
+        await bridgeFor('c1', 0).collectServiceSnapshot({serviceKey: 'orchestrator', observedAt: OBSERVED_AT});
+
+        const unreadable = await bridgeFor('c1', 9, async () => {throw new Error('ledger unreadable')})
             .collectServiceSnapshot({serviceKey: 'orchestrator', observedAt: OBSERVED_AT + 60000});
 
         expect(unreadable.diagnosis?.diagnosis?.details?.classificationReason).not.toBe('restart-churn-recorded');
+
+        // Suppression alone is what made a broken detector look like a quiet plane. The suppression
+        // has to come with a statement that it happened.
+        expect(unreadable.restartChurn.plannedRestarts.status).toBe('degraded');
+        expect(unreadable.restartChurn.plannedRestarts.reason).toBe('recovery-run-read-failed');
+        expect(unreadable.restartChurn.detecting).toBe(false);
+    });
+
+    /**
+     * Retention prunes the far end of the store, so a read that comes back full cannot prove it
+     * reached the baseline. Reporting the truncated count would UNDER-subtract and raise churn for
+     * restarts we performed — the precise false positive that gets an alarm switched off.
+     */
+    test('a read that fills the retention window degrades instead of reporting a truncated count', async () => {
+        await bridgeFor('c1', 0).collectServiceSnapshot({serviceKey: 'orchestrator', observedAt: OBSERVED_AT});
+
+        const limit = AiConfig.orchestrator.recoveryActuator.recoveryRunRetentionLimit,
+              at    = OBSERVED_AT + 30000,
+              proof = await restartProof('orchestrator', at),
+              // Every entry sits INSIDE the window, so nothing here reaches back past the baseline.
+              filled = Array.from({length: limit}, () => runEntry(proof, at));
+
+        const truncated = await bridgeFor('c1', 9, async () => filled)
+            .collectServiceSnapshot({serviceKey: 'orchestrator', observedAt: OBSERVED_AT + 60000});
+
+        expect(truncated.restartChurn.plannedRestarts.status).toBe('degraded');
+        expect(truncated.restartChurn.plannedRestarts.reason).toBe('recovery-run-window-truncated');
+        expect(truncated.diagnosis?.diagnosis?.details?.classificationReason).not.toBe('restart-churn-recorded');
+
+        // A read of the same size that DOES reach past the baseline is complete, not truncated —
+        // otherwise "degraded" would just mean "busy", and the marker would carry no information.
+        const reaching = [...filled.slice(0, limit - 1), runEntry(proof, OBSERVED_AT - 60000)];
+        const complete = await bridgeFor('c1', 9, async () => reaching)
+            .collectServiceSnapshot({serviceKey: 'orchestrator', observedAt: OBSERVED_AT + 60000});
+
+        expect(complete.restartChurn.plannedRestarts.status).toBe('available');
     });
 
     test('an unjudgeable baseline suppresses churn instead of silently re-anchoring', async () => {
@@ -2285,6 +2434,86 @@ test.describe('restart churn reaches the deployment record', () => {
         const record = await bridgeFor('c1', 0).collectServiceSnapshot({serviceKey: 'orchestrator', observedAt: OBSERVED_AT});
 
         expect(record.diagnosis === null || !Object.hasOwn(record.diagnosis, 'churnBaseline')).toBe(true);
+    });
+
+    /**
+     * The residual this section exists for, asserted as a DISAGREEMENT rather than as two separate
+     * readings. `collectRestartChurnFacts` emits nothing when there is no churn and nothing when it
+     * cannot tell, so both planes previously published byte-identical churn evidence: absence. A
+     * reader could not distinguish "quiet" from "the detector is dead", which is the state a corrupt
+     * baseline leaves a service in permanently — an unjudgeable baseline is deliberately never
+     * overwritten, so nothing recovers it until a human removes the file.
+     *
+     * Asserting the two records DIFFER is what makes this fail if the marker is ever reduced to a
+     * constant; two independent assertions could both pass against a field hardcoded either way.
+     */
+    test('a dead churn detector is distinguishable from a quiet plane', async () => {
+        await bridgeFor('c1', 0).collectServiceSnapshot({serviceKey: 'orchestrator', observedAt: OBSERVED_AT});
+
+        const quiet = await bridgeFor('c1', 1).collectServiceSnapshot({serviceKey: 'orchestrator', observedAt: OBSERVED_AT + 60000});
+
+        fs.writeFileSync(path.join(dir, 'churn-baselines', 'orchestrator.json'), '{ truncated');
+
+        const dead = await bridgeFor('c1', 1).collectServiceSnapshot({serviceKey: 'orchestrator', observedAt: OBSERVED_AT + 120000});
+
+        // Neither plane reports churn — that is precisely why the verdict cannot carry this fact.
+        expect(quiet.diagnosis?.diagnosis?.details?.classificationReason).not.toBe('restart-churn-recorded');
+        expect(dead.diagnosis?.diagnosis?.details?.classificationReason).not.toBe('restart-churn-recorded');
+
+        expect(dead.restartChurn.detecting).not.toBe(quiet.restartChurn.detecting);
+        expect(quiet.restartChurn).toMatchObject({baseline: 'available',  detecting: true});
+        expect(dead.restartChurn).toMatchObject({baseline: 'unreadable', detecting: false});
+    });
+
+    /**
+     * A baseline that cannot be PERSISTED is the same failure one step later: the anchor never
+     * advances, so the counter cannot accumulate toward a threshold and the signal is dead. It was
+     * reported only to an ERROR log, which the published record does not read.
+     */
+    /**
+     * Split deliberately from the publication test below. The reader and the writer share one path, so
+     * any filesystem obstruction that breaks the write breaks the read FIRST and the service reports
+     * `unreadable` — a different residual. Driving the writer directly is what isolates this one.
+     */
+    test('writeChurnBaseline reports a real write failure instead of only logging it', () => {
+        const logs   = [],
+              bridge = bridgeFor('c1', 0);
+
+        bridge.writeLog = (level, message) => logs.push({level, message});
+
+        // A DIRECTORY where the baseline file belongs: the atomic rename onto it fails with a genuine
+        // filesystem error, so this cannot pass against a writer that never touches disk.
+        fs.mkdirSync(path.join(dir, 'churn-baselines'), {recursive: true});
+        fs.mkdirSync(bridge.churnBaselinePath('orchestrator'));
+
+        expect(bridge.writeChurnBaseline('orchestrator', {containerId: 'c1', observedAt: OBSERVED_AT, restartCount: 0})).toBe(false);
+        expect(logs.some(entry => entry.level === 'ERROR' && entry.message.includes('churn baseline write FAILED'))).toBe(true);
+
+        // The positive control: the SAME call against an unobstructed path must return true, or
+        // `false` would just be this method's constant and the assertion above would prove nothing.
+        fs.rmdirSync(bridge.churnBaselinePath('orchestrator'));
+
+        expect(bridge.writeChurnBaseline('orchestrator', {containerId: 'c1', observedAt: OBSERVED_AT, restartCount: 0})).toBe(true);
+    });
+
+    test('a baseline that cannot be written degrades the published record, not just the log', async () => {
+        const bridge = bridgeFor('c1', 0);
+
+        // The write outcome is what this asserts on — the failure MODE is the test above. Stubbing the
+        // one seam keeps this from depending on a filesystem obstruction that would trip the reader.
+        bridge.writeChurnBaseline = () => false;
+
+        const record = await bridge.collectServiceSnapshot({serviceKey: 'orchestrator', observedAt: OBSERVED_AT});
+
+        expect(record.restartChurn.baselineWrite).toBe('failed');
+        expect(record.restartChurn.detecting).toBe(false);
+
+        // A plane whose baseline DOES persist publishes the other value, so `detecting` is reporting
+        // this outcome rather than being pinned false by something else on a first observation.
+        const healthy = await bridgeFor('c1', 0).collectServiceSnapshot({serviceKey: 'orchestrator', observedAt: OBSERVED_AT});
+
+        expect(healthy.restartChurn.baselineWrite).toBe('written');
+        expect(healthy.restartChurn.detecting).toBe(true);
     });
 
     test('a quiet container produces no churn diagnosis across two observations', async () => {


### PR DESCRIPTION
Resolves neomjs/neo#16482

`countPlannedRestarts` filtered the heal-event ledger for `type: 'restart' && status: 'attempt'`. **No production writer emits that row.** On a live plane the subtraction always found zero, so every planned restart — every deploy, every actuator repair, every operator-triggered recycle — was counted as *unplanned* churn. Its unit test passed only because the fixture hand-appended the exact row the production path does not produce.

The second residual is the same defect one layer up: `collectRestartChurnFacts` emits nothing when there is no churn **and** nothing when it cannot tell, so a plane whose detector was dead published a record indistinguishable from a quiet one.

**Evidence:** the producer census, not the ticket's word.

- `HEAL_ACTIONS` (`ai/services/memory-core/helpers/healActionDispatch.mjs:30`) = `['re-embed-missing','re-embed-rows',RESTORE_EMPTY_TARGET_ACTION,'quarantine','freeze','throttle-shed','defrag']` — no `restart` member. The data-recovery actuator owns that ledger; lifecycle restarts are not its vocabulary.
- `grep -rn "type: *'restart'" ai/ test/` → **4 hits, all four in `DeploymentStateBridgeService.spec.mjs`** (2195/2199/2230/2234). Zero production writers, before this change.
- The lifecycle actuator writes `finishAction` → `appendRecoveryRunState` (`RecoveryActuatorService.mjs:1261`), whose proof is built by `DeploymentRuntimeAccessService.createProofMetadata` (`:1008`) carrying `{capabilityEnvelope, operation, serviceKey, observedAt}`.

## Deltas

**The predicate is the lifecycle proof, not the action name.** The ticket prescribed keying on the restart action; the source falsifies that in both directions, so this deviates deliberately:

- `reconfigure` **restarts the container** as part of the action (`RecoveryActuatorService.mjs:780`) — the knob overlay is read at boot, so writing it without a restart is a no-op. Keying on the action name misses these and raises the false churn the subtraction exists to prevent.
- `raise-ceiling` **deliberately does not restart** (`:875`, guarded by a negative spec); its proof carries `update-memory-limit`.
- a supervised-task recycle restarts a *process*, so Docker's `RestartCount` never moves — it carries no lifecycle proof, so the same predicate excludes it without a second rule.

I also had a tidier hypothesis (`details.operation === 'restart'`) that the producer falsified: `restartComposeService` returns only `{runtimeAccess: result.proof}` — the `operation: 'restart'` at `:997` is the *argument* to `applyLifecycle`, not the recorded outcome.

**Completeness is proven, not assumed.** The store prunes by retention, so a read that comes back full cannot prove it reached the baseline. Reporting a truncated count would under-subtract and raise churn for restarts we performed. A full read that does not reach past the baseline reports `degraded` instead.

**A second deliberate deviation from the ticket.** Its Contract Ledger says an unreadable store must "subtract nothing". That is the false-alarm direction, and the existing code suppresses instead, reasoning *"a false churn alarm costs more than a missed one"*. Suppression is kept **and** the degradation is now published — which satisfies the ticket's own better principle: *degraded is a positive statement, never an omission*.

`writeChurnBaseline` now returns its outcome rather than only logging ERROR to a stream the record does not read.

### Contract Ledger

| Target Surface | Source of Authority | Behavior | Fallback / Error Semantics | Docs | Evidence |
|---|---|---|---|---|---|
| planned-restart count | `recoveryRunStateStore` via `readRecentRecoveryRunStates` | Counts runs whose lifecycle proof records an executed container restart for this service key, inside the churn window | Unreadable / truncated / invalid limit ⇒ suppress churn AND publish `degraded`; never a silent zero | method JSDoc | mutation: heal-ledger revert reddens 3 tests |
| `services[].restartChurn` (new, `inspect_deployment`) | `readChurnBaseline` / `writeChurnBaseline` / planned-restart outcomes | Publishes detector health — `baseline`, `baselineWrite`, `plannedRestarts.{status,reason}`, `detecting` | Reports the detector's own state; never a churn verdict, no authority moves | method JSDoc | mutation: constant `detecting` reddens 3 tests |

Additive field only; the `restart-churn` verdict remains the diagnosis service's non-authoritative fact with `actionClass: record`, and the classification branch stays last.

## Test Evidence

`DeploymentStateBridgeService.spec.mjs` — **77/77 green**, 15 in the churn block (was 12).

Every design decision is defended by a test **proven capable of failing** — three mutations run against the shipped implementation:

| Mutation | Result |
|---|---|
| revert the source to the heal-ledger predicate (the AC-2 regression) | **3 red** — both subtraction tests + reconfigure. The boundary test fails on *magnitude* (`unplannedRestarts` 4, not 3), which is why that assertion pins the number rather than "fires". |
| key on the action name (`recoveryRunId.includes(':restart:')`) | **exactly 1 red** — the reconfigure cell, nothing else. |
| hardcode `detecting: true` | **3 red** — including the quiet-vs-dead distinguishability assertion. |

Specimens are built by the production writers, never hand-shaped — the real `restartTarget()` for the proof, `createRecoveryRunStateEntry` + `createRecoveryDiagnosisEvent` for the entry. That is the discipline the old fixture's own comment asked for and did not get.

The distinguishability AC is asserted as a **disagreement** (`dead.detecting !== quiet.detecting`) rather than two independent readings, so it cannot pass against a field hardcoded either way. The write-failure test carries a positive control: the same call against an unobstructed path must return `true`.

Suite: `test/playwright/unit/ai/daemons/orchestrator/` — **1349 passed**. `Orchestrator.spec.mjs` shows **61 failed / 22 passed on this branch and 61 failed / 22 passed on clean `origin/dev`** — a pre-existing local failure (`Unknown authority profile ""` from `taskAuthority.mjs:220`), byte-identical on both arms and not touched by this diff.

## Post-Merge Validation

- On a plane that has performed a lifecycle restart, `inspect_deployment` shows that service's `restartChurn.plannedRestarts.status: 'available'` and no `restart-churn` fact for the restart we caused.
- Delete a service's churn baseline file mid-flight: the next snapshot reports `baseline: 'absent'` then `'available'`, with `detecting: true` throughout.
- Corrupt a baseline file: that service reports `baseline: 'unreadable'`, `detecting: false`, and the file is **not** overwritten — the operator can now see the detector is dead instead of reading it as a quiet plane.

Authored by @neo-opus-ada (Ada), session 87f453f9-aa80-4487-9ed1-b5d91e052c43.
