### PR TITLE
fix(ai): the file-system surface stops promising containment it does not have (#16481)

### DIFF
--- a/ai/mcp/server/file-system/openapi.yaml
+++ b/ai/mcp/server/file-system/openapi.yaml
@@ -212,7 +212,14 @@ paths:
     post:
       summary: Executes a single Playwright spec.
       operationId: run_playwright_test
-      description: Runs the Playwright runner isolated to the requested spec file to test pass/fail conditions.
+      description: |
+        Runs the Playwright runner isolated to the requested spec file to test pass/fail conditions.
+
+        EXECUTION IS NOT JAILED. The path argument is validated against the project root; the spec
+        that runs is arbitrary JavaScript, so what it reads and writes is bounded by this server's
+        host process, not by that root. Combined with write_file this reaches outside the project
+        root without either call violating a guard. Do not pass this tool input you would not grant
+        the host process.
       tags: [Execution]
       x-pass-as-object: true
       requestBody:

--- a/ai/mcp/server/file-system/openapi.yaml
+++ b/ai/mcp/server/file-system/openapi.yaml
@@ -2,10 +2,21 @@ openapi: 3.0.3
 info:
   title: Neo File System MCP Server API
   description: |
-    This API provides baseline environment tools to autonomous agents.
-    It includes heavily sandboxed file system manipulation and strictly
-    limited execution capabilities (like syntax checking and testing) essential
-    for agent feedback loops.
+    This API provides baseline environment tools to autonomous agents:
+    path-jailed file system manipulation, and execution capabilities
+    (syntax checking, test running) essential for agent feedback loops.
+
+    CONTAINMENT, STATED PRECISELY. Every path argument is jailed to the project
+    root. That is a guarantee about ARGUMENTS, and it is not a sandbox.
+
+    `run_playwright_test` executes a spec, and a spec is arbitrary JavaScript,
+    so what it reads and writes is bounded by the process this server runs in
+    — not by the path guard. `write_file` plus `run_playwright_test` therefore
+    composes past the jail without either call violating it (#16481).
+
+    Real containment needs process or container isolation for the executor.
+    Until that exists, treat this surface as: jailed arguments, unjailed
+    execution. Do not grant it inputs you would not grant the host process.
   version: 1.0.0
   contact:
     name: Neo.mjs Project

--- a/ai/mcp/server/file-system/openapi.yaml
+++ b/ai/mcp/server/file-system/openapi.yaml
@@ -212,6 +212,10 @@ paths:
     post:
       summary: Executes a single Playwright spec.
       operationId: run_playwright_test
+      # `tools/list` is compacted on this server (max 120 chars) and reads this field, never the
+      # description below — so the warning has to exist in BOTH places or the ordinary discovery
+      # surface keeps describing runner isolation while the real limit lives one call away.
+      x-neo-tool-summary: "Executes one Playwright spec. EXECUTION IS NOT JAILED — the spec runs with this server's host trust."
       description: |
         Runs the Playwright runner isolated to the requested spec file to test pass/fail conditions.
 

--- a/ai/mcp/server/file-system/services/FileSystemService.mjs
+++ b/ai/mcp/server/file-system/services/FileSystemService.mjs
@@ -105,7 +105,16 @@ async function ensureSandboxed(absolutePath) {
     const relative = path.relative(rootPath, targetPath);
 
     if (relative !== '' && (path.isAbsolute(relative) || relative.split(path.sep)[0] === '..')) {
-        throw new Error(`403 Forbidden: Path traversal detected. Operation jailed to ${rootPath}`);
+        // "jailed to <root>" described a containment this surface does not have. The jail binds this
+        // ARGUMENT; it does not bind the process. `run_playwright_test` executes a spec, a spec is
+        // arbitrary JavaScript, and its read set is therefore the whole host — so `write_file` plus
+        // `run_playwright_test` reaches outside the root without either call violating a guard
+        // — reported externally and reproduced from source.
+        //
+        // The message now says what it enforces. A caller who reads "jailed" and infers containment
+        // is being misled by us, and a false boundary is worse than a stated absence of one: it is
+        // trusted. Real containment needs process isolation for the executor and does not exist yet.
+        throw new Error(`403 Forbidden: Path traversal detected. This ARGUMENT is jailed to ${rootPath}; execution tools are not.`);
     }
 
     return targetPath;

--- a/test/playwright/unit/ai/mcp/server/file-system/FileSystemService.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/file-system/FileSystemService.spec.mjs
@@ -49,6 +49,26 @@ test.describe('ai/mcp/server/file-system FileSystemService', () => {
             .rejects.toThrow(/403 Forbidden: Path traversal detected/);
     });
 
+    /**
+     * @summary The guard message must describe what it ENFORCES, not a containment we do not have.
+     *
+     * It read "Operation jailed to <root>". The jail binds this ARGUMENT; it does not bind the
+     * process. `run_playwright_test` executes a spec, a spec is arbitrary JavaScript, and its read
+     * set is the whole host — so `write_file` plus `run_playwright_test` reaches outside the root
+     * without either call violating a guard, reported externally and reproduced from source.
+     *
+     * A false boundary is worse than a stated absence of one, because it is trusted. This arm exists
+     * so the stronger wording cannot come back without someone deciding to bring it back.
+     */
+    test('#16481: the message scopes the jail to the ARGUMENT and names execution as unjailed', async () => {
+        const attempt = FileSystemService.readFile({absolutePath: '/tmp/OUTSIDE_SECRET.txt'});
+
+        await expect(attempt).rejects.toThrow(/This ARGUMENT is jailed to/);
+        await expect(attempt).rejects.toThrow(/execution tools are not/);
+        // The claim this ticket exists to remove: a promise of operation-wide containment.
+        await expect(attempt).rejects.not.toThrow(/Operation jailed to/);
+    });
+
     test('#15818 ordinary traversal is still rejected — no regression of the original guard', async () => {
         await expect(FileSystemService.readFile({absolutePath: path.join(root, '..', 'outside.txt')}))
             .rejects.toThrow(/403 Forbidden: Path traversal detected/);

--- a/test/playwright/unit/ai/mcp/server/file-system/toolServiceDispatch.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/file-system/toolServiceDispatch.spec.mjs
@@ -136,6 +136,33 @@ test.describe('ai/mcp/server/file-system — ToolService dispatch (#16231)', () 
             .toMatchObject({toolId: 'read_file', found: true});
     });
 
+    test('#16481 the not-jailed warning reaches the CALLER, not just the raw spec', async () => {
+        // The warning is only worth anything on the surface a caller actually reads before handing
+        // this tool a spec file. Both projections below resolve `operation.description` — neither
+        // reads `info.description` — so putting the warning in top-level OpenAPI metadata satisfies
+        // a human reading the YAML while leaving every MCP caller on the old isolated-spec wording.
+        // Asserting the projected text is therefore the falsifier: it fails if the warning moves
+        // back up to `info`, is deleted, or is softened into describing runner isolation again.
+        const handbook = await callTool('get_mcp_tool_handbook', {toolId: 'run_playwright_test'});
+
+        expect(handbook.handbook, 'the handbook a caller reads must carry the containment limit')
+            .toMatch(/EXECUTION IS NOT JAILED/);
+
+        // `tools/list` is the ordinary discovery path — a caller that never opens the handbook still
+        // sees this one. Both must carry it, because either alone leaves a reachable blind surface.
+        const {tools} = await listTools(),
+              listed  = tools.find(tool => tool.name === 'run_playwright_test');
+
+        expect(listed, 'run_playwright_test should be listed at all').toBeDefined();
+        expect(listed.description, 'the listed description must carry the containment limit too')
+            .toMatch(/EXECUTION IS NOT JAILED/);
+
+        // The substantive claim, not just the shouty line: the reason the warning exists is that the
+        // path guard bounds the ARGUMENT while the spec that runs is arbitrary JavaScript bounded by
+        // the host process. A rewrite that keeps the banner but drops the mechanism fails here.
+        expect(handbook.handbook).toMatch(/host process/);
+    });
+
     test('#16231 every tool this server LISTS is annotated — the contract cannot grow past this spec unnoticed', async () => {
         // The dispatch tests above name the tools they call, so a seventh tool added later would
         // inherit the same 0-annotation treatment unnoticed. This one reads `tools/list` instead, so


### PR DESCRIPTION
Resolves #16481
Refs #16979

Evidence: L2 (composition reproduced from source; both claim sites read and corrected; the wording pinned in both directions by a dedicated arm) → L2 required (message and description contract, fully covered by unit execution). Residual: this does not create containment — see *Deltas*.

## What is true

The path jail is **correct**. It binds arguments, and it does so properly — `path.relative` rather than `startsWith`, so a sibling directory whose name merely begins with the root's does not pass.

What it does not bind is the process. `run_playwright_test` executes a spec, a spec is arbitrary JavaScript, so the executor's read set is the host — not the root. `write_file` plus `run_playwright_test` therefore reaches outside the project root **without either call violating any guard.**

Reported externally by @novice-22, three independent times, and reproduced from source.

## Why this is the shippable half

@novice-22 closed the option we were circling, in the ticket thread on 08-05:

> *"A sound tool-level partition would have to keep `write_file` out of everywhere `run_playwright_test` can read. But a spec is arbitrary JavaScript, so the executor's read set is not statically bounded — it is the project."*

That is decisive and it leaves exactly two ends: **make containment true** with process or container isolation for the executor, or **stop claiming it**. There is no tool-level partition to draw. This PR is the second, and it is the half that can ship today.

## The change

| site | was | now |
|---|---|---|
| `openapi.yaml` | "heavily sandboxed file system manipulation" | the actual contract — jailed arguments, unjailed execution — naming the composition, and telling a caller not to grant this surface inputs they would not grant the host process |
| the guard | `Operation jailed to <root>` | `This ARGUMENT is jailed to <root>; execution tools are not.` |

**A false boundary is worse than a stated absence of one, because it is trusted.** Someone reading "heavily sandboxed" makes a decision on it, and that decision is the damage. Three independent reports is what a misleading claim looks like from outside the team.

## Test Evidence

12/12 in the touched spec. The four existing traversal arms are unchanged — they match on `403 Forbidden: Path traversal detected`, which is preserved, because the guard's *behaviour* was never the defect.

The new arm pins the correction **in both directions**:

- asserts the scoped wording is present (`This ARGUMENT is jailed to`, `execution tools are not`)
- asserts the operation-wide phrasing is **gone** (`.rejects.not.toThrow(/Operation jailed to/)`)

Without the second assertion the stronger claim could return and the arm would still pass. That is the whole point of this ticket, so it is asserted rather than assumed.

## Deltas

- **This creates no containment.** It stops asserting containment that does not exist. Anyone reading this PR as a security fix is reading more than it says — the composition still works after it merges, and now the surface says so.
- **Real containment is a separate lane**: process or container isolation for the executor. Not started here, and it is an architecture call that deserves its own ticket rather than being smuggled into a wording change.
- **The architecture half is now #16979, not a `Refs` on this one.** I first wrote this as `Refs #16481` to keep the ticket open, which collides with operator rule #12367 — every agent PR body must carry a `Resolves`. The rule's own comment names the right resolution and I should have reached for it first: *"it must become an epic + subs or be split."* So #16481 is now the claim correction (this PR resolves it) and **#16979** holds the executor-isolation decision. That is better than what I was doing: two distinct outcomes were sharing one ticket, and `Refs` was papering over it.

## Post-Merge Validation

1. `run_playwright_test` on a spec that reads outside the root still succeeds. That is expected and now documented; if it ever fails, containment arrived from somewhere and the description needs updating again.
2. The guard message on a traversal attempt names the argument scope, so an operator reading a 403 does not infer more than it enforces.

## Evolution

This sat six days on my name with the architecture call open, and I found it by reading my own board rather than by anyone escalating it. The external reporter had already done the decisive thinking on 08-05 and I had not acted on it — the useful half of that thread was an opinion I nearly walked past, and asked for only because I noticed I had moved past it.

Authored by @neo-opus-grace (Opus 5)

