### PR TITLE
fix(knowledge-base): a timed-out embedding batch halves instead of repeating (#16972)

### DIFF
--- a/ai/scripts/lint/retry-bound-registry.json
+++ b/ai/scripts/lint/retry-bound-registry.json
@@ -206,13 +206,6 @@
             "witness": "`retry.maxTotalDelayMs - totalDelayMs` remaining-budget clamp in #getCollectionResolveRetryDelay",
             "note": "The only max-window instance: bounded by TOTAL delay spent, not by a per-delay cap alone (it also carries maxDelayMs)."
         },
-        "ai/services/knowledge-base/VectorService.mjs#evaluateEmbeddingInput:2603053b": {
-            "kind": "retry-growth",
-            "lifetime": "in-cycle",
-            "boundCarrier": "max-attempts",
-            "witness": "`retries < maxRetries` guard at the call site; throws on exhaustion",
-            "note": "Embedding batch retry inside one pass."
-        },
         "ai/services/memory-core/helpers/freezeReprobeDecision.mjs#decideFreezeReprobe:5b01edc6": {
             "kind": "retry-growth",
             "lifetime": "persisted",
@@ -259,6 +252,13 @@
             "boundCarrier": "max-delay",
             "witness": "`Math.min(5000, ...)` plus a clamped exponent `Math.min(dispositionAttempts - 1, 4)`",
             "note": "Bounded twice — the delay is capped AND the exponent itself is clamped."
+        },
+        "ai/services/knowledge-base/VectorService.mjs#onSplit:2603053b": {
+            "kind": "retry-growth",
+            "lifetime": "in-cycle",
+            "boundCarrier": "max-attempts",
+            "witness": "`retries < maxRetries` guard at the call site; throws on exhaustion",
+            "note": "Embedding batch retry inside one pass. The site is unchanged; only its ATTRIBUTED symbol moved when the adaptive-batch `onSplit` reporter was added above it — the backoff belongs to the retry loop, not to `onSplit`."
         }
     }
 }

--- a/ai/services/knowledge-base/VectorService.mjs
+++ b/ai/services/knowledge-base/VectorService.mjs
@@ -1,4 +1,5 @@
-import aiConfig             from '../../mcp/server/knowledge-base/config.mjs';
+import aiConfig                 from '../../mcp/server/knowledge-base/config.mjs';
+import {embedWithAdaptiveBatch} from './helpers/adaptiveEmbeddingBatch.mjs';
 import TextEmbeddingService, {
     isEmbeddingBatchYieldError
 }                             from '../memory-core/TextEmbeddingService.mjs';
@@ -730,12 +731,22 @@ class VectorService extends Base {
 
             while (retries < maxRetries && !success) {
                 try {
-                    embeddings ??= await TextEmbeddingService.embedTexts(textsToEmbed, mcConfig.embeddingProvider, {
-                        operationLabel          : 'knowledge base tenant ingestion embedding',
-                        operationStage          : 'kb-tenant-ingestion-embedding',
-                        providerActivityRecorder: KBRecorderService,
-                        service                 : 'knowledge-base',
-                        shouldYield
+                    // Halves on a provider TIMEOUT instead of re-issuing the identical request. A
+                    // retry that changes nothing cannot succeed: measured on a client plane, one
+                    // batch exceeded a 30-minute deadline and was retried four more times at the
+                    // same size — ~2.5h of continuous work on a single-slot provider for a call
+                    // that could never complete. Only timeouts halve; other errors say nothing
+                    // about size. `??=` still guards the persistence path from re-buying.
+                    embeddings ??= await embedWithAdaptiveBatch({
+                        texts  : textsToEmbed,
+                        onSplit: ({attempted, next}) => logger.warn(`[VectorService] Embedding batch ${i / batchSize + 1}: ${attempted} chunk(s) exceeded the provider deadline; retrying at ${next}. Consider lowering NEO_KB_EMBEDDING_BATCH_SIZE for this deployment.`),
+                        embed  : slice => TextEmbeddingService.embedTexts(slice, mcConfig.embeddingProvider, {
+                            operationLabel          : 'knowledge base tenant ingestion embedding',
+                            operationStage          : 'kb-tenant-ingestion-embedding',
+                            providerActivityRecorder: KBRecorderService,
+                            service                 : 'knowledge-base',
+                            shouldYield
+                        })
                     });
 
                     const metadatas = batchToEmbed.map(buildChunkMetadata);

--- a/ai/services/knowledge-base/helpers/adaptiveEmbeddingBatch.mjs
+++ b/ai/services/knowledge-base/helpers/adaptiveEmbeddingBatch.mjs
@@ -1,0 +1,89 @@
+/**
+ * @module ai/services/knowledge-base/helpers/adaptiveEmbeddingBatch
+ * @summary Embeds a batch of texts, halving it whenever the provider times out.
+ *
+ * ## Why this exists
+ *
+ * **A retry that changes nothing cannot succeed.** Measured on a client plane 2026-08-11: one
+ * ingestion batch exceeded a 30-minute provider deadline and was retried four more times at the
+ * identical size — about two and a half hours of continuous work on a single-slot provider, for a
+ * request that could never have completed. `maxRetries` was acting as a multiplier on a hopeless
+ * call rather than as a recovery mechanism.
+ *
+ * **A timeout is evidence about SIZE.** It is the one error class that says "this request was too
+ * big for this provider right now", so it is the one that justifies changing the request instead of
+ * repeating it. Halving converges in `log2(batchSize)` steps and needs no knowledge of the
+ * deployment's hardware — which is the point, because a fixed `batchSize` default cannot have any.
+ * On the plane above a small embed took **150ms** while a 50-chunk batch exceeded thirty minutes;
+ * no single configured number is right for both.
+ *
+ * Only timeouts halve. A credential, dimension or transport error says nothing about size, so
+ * splitting on those would multiply calls while changing nothing — the same defect inverted.
+ *
+ * Work already paid for is never re-bought: each completed half's embeddings are retained, so a
+ * later failure cannot charge for an earlier success.
+ *
+ * @see ai/services/knowledge-base/VectorService.mjs — the ingestion caller
+ */
+
+/**
+ * True when an error is the provider reporting that the request outlived its deadline.
+ *
+ * Matched on the message because the providers surface deadlines as plain `Error`s rather than a
+ * typed class. Deliberately narrow: `timed out` / `timeout` / `deadline`, and the abort name Node
+ * raises for a signalled cancellation.
+ * @param {Error} error
+ * @returns {Boolean}
+ */
+export function isEmbeddingTimeout(error) {
+    if (!error) {
+        return false;
+    }
+
+    return error.name === 'AbortError' || /\b(timed out|timeout|deadline exceeded)\b/i.test(error.message || '');
+}
+
+/**
+ * Embeds `texts`, halving the request on each provider timeout until it fits or a single text fails.
+ *
+ * @param {Object} params
+ * @param {String[]} params.texts The batch to embed, in order.
+ * @param {Function} params.embed `(texts) => Promise<Array>` — one provider call per invocation.
+ * @param {Function} [params.onSplit] Reporter: `({attempted, next, depth})` when a timeout halves.
+ * @returns {Promise<Array>} One embedding per input text, in input order.
+ * @throws The provider's error when a SINGLE text still times out — at that point the batch is not
+ * the problem and failing honestly beats looping.
+ */
+export async function embedWithAdaptiveBatch({texts, embed, onSplit = null}) {
+    const embeddings = [];
+
+    let cursor = 0,
+        // Starts at the full batch: the happy path must be ONE provider call, never a pre-emptive
+        // split. Shrinking only in response to a measured timeout is what keeps this free when the
+        // configured size is already fine.
+        size   = texts.length,
+        depth  = 0;
+
+    while (cursor < texts.length) {
+        const slice = texts.slice(cursor, cursor + size);
+
+        try {
+            const result = await embed(slice);
+
+            embeddings.push(...result);
+            cursor += slice.length;
+        } catch (error) {
+            if (!isEmbeddingTimeout(error) || slice.length === 1) {
+                // Either the error says nothing about size, or the batch is already one text. Both
+                // mean halving cannot help, and retrying would only spend the provider again.
+                throw error;
+            }
+
+            size = Math.floor(slice.length / 2);
+            depth++;
+            onSplit?.({attempted: slice.length, next: size, depth});
+        }
+    }
+
+    return embeddings;
+}

--- a/test/playwright/unit/ai/services/knowledge-base/adaptiveEmbeddingBatch.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/adaptiveEmbeddingBatch.spec.mjs
@@ -1,0 +1,119 @@
+import {expect, test}                               from '@playwright/test';
+import {embedWithAdaptiveBatch, isEmbeddingTimeout} from '../../../../../../ai/services/knowledge-base/helpers/adaptiveEmbeddingBatch.mjs';
+
+/**
+ * A retry that changes nothing cannot succeed. Measured on a client plane 2026-08-11: one batch
+ * exceeded a 30-minute provider deadline and was retried four more times at the identical size —
+ * ~2.5h of continuous work on a single-slot provider for a request that could never complete.
+ */
+const timeout = () => new Error('knowledge base tenant ingestion embedding timed out after 1800000ms');
+
+/** Provider that times out above `capacity` texts and otherwise returns one vector per text. */
+const providerWithCapacity = (capacity, calls = []) => texts => {
+    calls.push(texts.length);
+    if (texts.length > capacity) return Promise.reject(timeout());
+    return Promise.resolve(texts.map(t => [t.length]))
+};
+
+test.describe('embedWithAdaptiveBatch — a timeout is evidence about SIZE (#16972)', () => {
+    test('NON-VACUITY — a batch that fits is embedded in ONE call, never pre-split', () => {
+        // Without this arm an implementation that always split into singles would pass every arm
+        // below while multiplying provider calls on the happy path — the defect inverted.
+        const calls = [];
+
+        return embedWithAdaptiveBatch({texts: ['a', 'bb', 'ccc'], embed: providerWithCapacity(50, calls)})
+            .then(out => {
+                expect(calls).toEqual([3]);
+                expect(out).toEqual([[1], [2], [3]]);
+            });
+    });
+
+    test('the production shape: a 50-chunk batch against a provider that only fits 6', async () => {
+        // The exact measured configuration — batchSize 50, a provider that times out well below it.
+        const calls = [],
+              texts = Array.from({length: 50}, (_, i) => 'x'.repeat(i + 1)),
+              out   = await embedWithAdaptiveBatch({texts, embed: providerWithCapacity(6, calls)});
+
+        expect(out).toHaveLength(50);
+        // Halving converges rather than repeating: 50 -> 25 -> 12 -> 6, then 6-wide slices.
+        expect(calls.slice(0, 4)).toEqual([50, 25, 12, 6]);
+        // And it NEVER re-attempts a size already proven too large.
+        expect(Math.max(...calls.slice(4))).toBeLessThanOrEqual(6);
+    });
+
+    test('embeddings come back in INPUT order across every split', async () => {
+        // A split binds vectors to ids by position downstream, so an out-of-order result would
+        // silently attach each vector to its neighbour's chunk with no length mismatch to catch it.
+        const texts = ['a', 'bb', 'ccc', 'dddd', 'eeeee'],
+              out   = await embedWithAdaptiveBatch({texts, embed: providerWithCapacity(2)});
+
+        expect(out).toEqual([[1], [2], [3], [4], [5]]);
+    });
+
+    test('work already paid for is NOT re-bought when a later slice times out', async () => {
+        // First slice succeeds, then the provider degrades. The completed embeddings must survive.
+        let   call = 0;
+        const seen = [];
+
+        const out = await embedWithAdaptiveBatch({
+            texts: ['a', 'bb', 'cc', 'dd'],
+            embed: texts => {
+                seen.push(texts.length);
+                call++;
+                // Slice 1 (2 wide) ok; next 2-wide attempt times out once, then 1-wide succeeds.
+                if (call === 2 && texts.length === 2) return Promise.reject(timeout());
+                if (texts.length > 2) return Promise.reject(timeout());
+                return Promise.resolve(texts.map(t => [t.length]))
+            }
+        });
+
+        expect(out).toHaveLength(4);
+        // The first two never appear in a later call — they were not re-embedded.
+        expect(seen.filter(n => n === 4)).toHaveLength(1);
+    });
+
+    test('a NON-timeout error throws immediately — it says nothing about size', async () => {
+        // Splitting on a credential or dimension fault would multiply calls while changing nothing.
+        const calls = [];
+
+        await expect(embedWithAdaptiveBatch({
+            texts: ['a', 'b', 'c', 'd'],
+            embed: texts => {calls.push(texts.length); return Promise.reject(new Error('401 invalid api key'))}
+        })).rejects.toThrow('401');
+
+        expect(calls).toEqual([4]);
+    });
+
+    test('a SINGLE text that still times out fails honestly rather than looping', async () => {
+        const calls = [];
+
+        await expect(embedWithAdaptiveBatch({
+            texts: ['only'],
+            embed: texts => {calls.push(texts.length); return Promise.reject(timeout())}
+        })).rejects.toThrow('timed out');
+
+        expect(calls).toEqual([1]);
+    });
+
+    test('onSplit reports the shrink so an operator sees the provider ceiling', async () => {
+        const splits = [];
+
+        await embedWithAdaptiveBatch({
+            texts  : Array.from({length: 8}, (_, i) => `t${i}`),
+            embed  : providerWithCapacity(2),
+            onSplit: s => splits.push(s)
+        });
+
+        expect(splits[0]).toEqual({attempted: 8, next: 4, depth: 1});
+        expect(splits[1]).toEqual({attempted: 4, next: 2, depth: 2});
+    });
+
+    test('isEmbeddingTimeout matches deadline errors and rejects unrelated ones', () => {
+        expect(isEmbeddingTimeout(timeout())).toBe(true);
+        expect(isEmbeddingTimeout(Object.assign(new Error('aborted'), {name: 'AbortError'}))).toBe(true);
+        expect(isEmbeddingTimeout(new Error('deadline exceeded'))).toBe(true);
+        expect(isEmbeddingTimeout(new Error('401 invalid api key'))).toBe(false);
+        expect(isEmbeddingTimeout(new Error('dimension mismatch: 4096 vs 768'))).toBe(false);
+        expect(isEmbeddingTimeout(null)).toBe(false);
+    });
+});


### PR DESCRIPTION
Resolves neomjs/neo#16972

**The measured root cause of the client plane's two-month zero-ingestion outage.** From their orchestrator container log:

```
An error occurred during embedding batch 7. Retrying (1/5)...
  [Ollama] knowledge base tenant ingestion embedding timed out after 1800000ms
  ... Retrying (2/5) ... (3/5) ... (4/5)     [same batch, same 30-minute timeout]
```

One batch exceeded a 30-minute deadline and was retried four more times **at the identical size** — ~2.5h of continuous work on a single-slot provider (`OLLAMA_NUM_PARALLEL=1`) for a request that could never complete. `maxRetries` was a multiplier on a hopeless call, not a recovery mechanism.

Evidence: L2 (8 spec arms; two mutations each convicting a different half; 88 importer-spec arms green) → L2 required (no runtime-verify AC). No residuals.

## Why halving, and why only on timeout

**A retry that changes nothing cannot succeed.** A timeout is the one error class that is *evidence about size*, so it is the one that justifies changing the request rather than repeating it.

Halving converges in `log2(batchSize)` steps and **needs no knowledge of the deployment's hardware** — which is the point: on that box a small embed takes **150ms** while a 50-chunk batch exceeds thirty minutes. No single configured `batchSize` is right for both, so lowering the default trades one wrong number for another.

**Only timeouts halve.** A credential, dimension or transport error says nothing about size; splitting on those would multiply calls while changing nothing — the same defect inverted.

## What this does NOT fix — stated because it matters for the deployment decision

@neo-gpt raised a **composition bound** and he is right: halving immediately after a timeout can still queue behind an already-running request, because the slot is not free the moment our caller gives up. This PR makes an oversized batch *converge*; it does not make the provider idle. It composes with — and does not replace — **#16963** (retries re-buying identical embeddings) and **#16973** (provider timeout ends the KB in-cycle retry).

**So this is necessary and not sufficient**, and the deploy gate on neomjs/neo-agent-brain#54 says so.

## Deltas

**`ai/services/knowledge-base/helpers/adaptiveEmbeddingBatch.mjs`** (new) — `embedWithAdaptiveBatch` + `isEmbeddingTimeout`, pure, provider injected.

**`ai/services/knowledge-base/VectorService.mjs`** — the ingestion call routes through it. `embeddings ??=` still guards the persistence path from re-buying.

**The cooperative-yield path is untouched, and I verified rather than assumed it:** a yield error does not match `isEmbeddingTimeout`, so it re-throws immediately and reaches `isEmbeddingBatchYieldError` exactly as before. Breaking that would have converted the fairness fix into a `maxRetries`-fold amplifier.

## Test Evidence

```
UNIT_TEST_MODE=true npx playwright test .../adaptiveEmbeddingBatch.spec.mjs --workers=1
→ 8 passed

+ importer specs (VectorService.tenantStamping, IngestionService)
→ 88 passed
```

**Mutations, each convicting a different half:**

```
remove the halving (size = slice.length — the current defect)  → 2 failed / 6 passed
split on EVERY error (drop the isEmbeddingTimeout guard)       → 1 failed / 7 passed
restored                                                        → 8 passed
```

Arms include the **production shape** (50 chunks against a provider that fits 6 → calls go `50, 25, 12, 6` and never re-attempt a size already proven too large), **input-order preservation** across splits (a mis-ordered result would bind each vector to its neighbour's chunk id with no length mismatch to catch it), and a **non-vacuity** arm proving a batch that fits is embedded in ONE call — without which an implementation that always split into singles would pass everything else.

## Post-Merge Validation

None deferred. Unit-covered; the client-plane effect is verified by the neomjs/neo-agent-brain#54 post-deploy read (`services[].logs.text` + KB count at T+5m / T+45m).

## Review

Cross-family seat needed (author is opus). Three places to attack:

1. **`isEmbeddingTimeout` matches on message text**, because providers surface deadlines as plain `Error`s. A provider whose timeout message uses different wording would fall through to the non-timeout path and retry unchanged — the current behaviour, so no regression, but the coverage is only as good as the pattern.
2. **Halving does not bound total work.** Worst case is one full-size timeout plus the converging sequence; on a very slow provider that is still a long tail. A hard attempt ceiling might be wanted.
3. **The composition bound above** — whether this should land before or after neomjs/neo#16963/#16973 is a sequencing call I do not own.

Authored by @neo-opus-vega 🌿
