### PR TITLE
fix(knowledge-base): stop in-cycle retries after provider timeout

### DIFF
--- a/ai/scripts/lint/retry-bound-registry.json
+++ b/ai/scripts/lint/retry-bound-registry.json
@@ -210,8 +210,8 @@
             "kind": "retry-growth",
             "lifetime": "in-cycle",
             "boundCarrier": "max-attempts",
-            "witness": "`retries < maxRetries` guard at the call site; throws on exhaustion",
-            "note": "Embedding batch retry inside one pass."
+            "witness": "`retries < maxRetries` bounds non-timeout failures; timeout-class provider failures throw after their first provider offer",
+            "note": "Embedding batch retry inside one pass. A provider timeout terminates the whole sweep so the outer scheduler, not this exponential ladder, owns the later attempt."
         },
         "ai/services/memory-core/helpers/freezeReprobeDecision.mjs#decideFreezeReprobe:5b01edc6": {
             "kind": "retry-growth",

--- a/ai/services/knowledge-base/VectorService.mjs
+++ b/ai/services/knowledge-base/VectorService.mjs
@@ -3,6 +3,10 @@ import TextEmbeddingService, {
     isEmbeddingBatchYieldError
 }                             from '../memory-core/TextEmbeddingService.mjs';
 import mcConfig from '../../mcp/server/memory-core/config.mjs';
+import {
+    OPENAI_COMPATIBLE_REQUEST_TIMEOUT_CODE,
+    PROVIDER_TIMEOUT_CODE
+}               from '../../provider/createTimeoutError.mjs';
 import Base     from '../../../src/core/Base.mjs';
 import {
     bytesToTokens,
@@ -650,6 +654,9 @@ class VectorService extends Base {
      *     while other batches were succeeding. Such a batch is skipped rather than aborting the sweep, because
      *     aborting strands every later batch permanently — see the rationale at the exhaustion branch. A sweep
      *     in which NOTHING embedded still throws: that is a provider outage, not poisoned content.
+     * @throws {Error} The original provider error when a provider-phase attempt returns a timeout-class code.
+     *     The whole sweep ends after that one offer so the outer scheduler owns the later attempt; already-landed
+     *     chunks remain the durable resume boundary.
      */
     async embedChunks({collection, chunksToProcess, shouldYield = () => false}) {
         if (chunksToProcess.length === 0) {
@@ -785,6 +792,28 @@ class VectorService extends Base {
 
                         logger.log(`Yielding the heavy-maintenance lease inside batch ${i / batchSize + 1} after ${err.completedChunkCount}/${err.totalChunkCount} provider chunk(s); ${carried.length} partial embedding(s) persisted (${embeddedCount} embedded total). This batch is not retried; the next sweep resumes after the persisted prefix.`);
                         break;
+                    }
+
+                    // A provider timeout is evidence that OUR wait ended, not that the provider work did.
+                    // The affected plane returned one abandoned request after 66 minutes against a 30-minute
+                    // client budget. Re-offering batch 7 — or merely continuing with batch 8 — can therefore
+                    // queue new work behind a still-running predecessor. End the whole sweep after the first
+                    // provider-phase timeout; the outer tenant-sync scheduler owns the later retry and the
+                    // already-persisted prefix remains the next sweep's resume boundary.
+                    //
+                    // The phase guard is load-bearing. This catch also covers `collection.upsert()`: a write
+                    // error carrying a foreign timeout-shaped code must retry the write with the cached vectors,
+                    // never be misclassified as provider work that might still be running.
+                    const providerTimedOut = embeddings === null && (
+                        err?.code === PROVIDER_TIMEOUT_CODE ||
+                        err?.code === OPENAI_COMPATIBLE_REQUEST_TIMEOUT_CODE ||
+                        err?.code === 'ETIMEDOUT' ||
+                        err?.code === 'ESOCKETTIMEDOUT'
+                    );
+
+                    if (providerTimedOut) {
+                        console.error(`An error occurred during embedding batch ${i / batchSize + 1}. Ending this embedding sweep after one timeout-class provider attempt; pending chunks remain for a later scheduler cycle.`, err.message);
+                        throw err
                     }
 
                     lastError = err;

--- a/test/playwright/unit/ai/services/knowledge-base/VectorService.batchFailureIsolation.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/VectorService.batchFailureIsolation.spec.mjs
@@ -18,6 +18,10 @@ setup({
 import {test, expect} from '@playwright/test';
 import Neo            from '../../../../../../src/Neo.mjs';
 import * as core      from '../../../../../../src/core/_export.mjs';
+import {
+    OPENAI_COMPATIBLE_REQUEST_TIMEOUT_CODE,
+    PROVIDER_TIMEOUT_CODE
+} from '../../../../../../ai/provider/createTimeoutError.mjs';
 
 /**
  * Batch-failure isolation for `VectorService.embedChunks`.
@@ -250,6 +254,111 @@ test.describe('VectorService.embedChunks — one failing batch must not strand t
         expect(result.embedded).toBe(150);
         expect(result.failedBatches).toHaveLength(0);
         expect(spy.calls.upsert).toBe(3);
+    });
+
+    test('#16973: a provider timeout ends the whole sweep after one offer and the next sweep resumes', async () => {
+        const originalSetTimeout = globalThis.setTimeout;
+
+        // Mutation control: on the pre-repair loop this compresses the 2s/4s/8s/16s ladder so the
+        // provider-call assertion fails immediately instead of making the suite spend 30 seconds proving it.
+        globalThis.setTimeout = (fn, ms, ...args) => originalSetTimeout(fn, 0, ...args);
+
+        try {
+            Object.assign(KB_Config.data, {batchSize: 1, batchDelay: 0, maxRetries: 5});
+
+            for (const code of [
+                PROVIDER_TIMEOUT_CODE,
+                OPENAI_COMPATIBLE_REQUEST_TIMEOUT_CODE,
+                'ETIMEDOUT',
+                'ESOCKETTIMEDOUT'
+            ]) {
+                const
+                    spy          = createSpyCollection(),
+                    chunks       = makeChunks(3),
+                    timeoutError = Object.assign(new Error(`provider timeout: ${code}`), {
+                        code,
+                        timeoutMs: 1800000
+                    });
+                let providerCalls = 0;
+
+                TextEmbeddingService.embedTexts = async texts => {
+                    providerCalls++;
+
+                    if (providerCalls === 1) {
+                        return texts.map(() => new Array(384).fill(0))
+                    }
+
+                    throw timeoutError
+                };
+
+                const thrown = await KB_VectorService.embedChunks({collection: spy, chunksToProcess: chunks})
+                    .then(() => null, error => error);
+
+                expect(thrown, `${code} must survive as the original typed failure`).toBe(timeoutError);
+                expect(providerCalls,
+                    `${code}: batch 1 lands, batch 2 times out once, and batch 3 must never dispatch`).toBe(2);
+                expect(spy.upsertedIds, `${code}: the durable prefix remains landed`).toEqual(['chunk-0']);
+
+                const remaining = chunks.filter(chunk => !spy.upsertedIds.includes(chunk.id));
+
+                TextEmbeddingService.embedTexts = async texts => {
+                    providerCalls++;
+                    return texts.map(() => new Array(384).fill(0))
+                };
+
+                const resumed = await KB_VectorService.embedChunks({collection: spy, chunksToProcess: remaining});
+
+                expect(resumed.embedded, `${code}: the later scheduler-shaped pass lands only the remainder`)
+                    .toBe(2);
+                expect(spy.upsertedIds, `${code}: the successful prefix is not re-bought`).toEqual([
+                    'chunk-0', 'chunk-1', 'chunk-2'
+                ]);
+                expect(providerCalls, `${code}: one landed + one timed out + two resumed provider calls`).toBe(4);
+            }
+        } finally {
+            globalThis.setTimeout = originalSetTimeout;
+        }
+    });
+
+    test('#16973 phase guard: a timeout-shaped upsert error retries only the write', async () => {
+        const originalSetTimeout = globalThis.setTimeout;
+
+        globalThis.setTimeout = (fn, ms, ...args) => originalSetTimeout(fn, 0, ...args);
+
+        try {
+            Object.assign(KB_Config.data, {batchSize: 1, batchDelay: 0, maxRetries: 2});
+
+            const chunks        = makeChunks(1);
+            let   providerCalls = 0,
+                upsertCalls   = 0;
+
+            TextEmbeddingService.embedTexts = async texts => {
+                providerCalls++;
+                return texts.map(() => new Array(384).fill(0))
+            };
+
+            const collection = {
+                name: 'timeout-shaped-write-spy',
+                async upsert() {
+                    upsertCalls++;
+
+                    if (upsertCalls === 1) {
+                        throw Object.assign(new Error('vector-store write timed out'), {
+                            code     : PROVIDER_TIMEOUT_CODE,
+                            timeoutMs: 1800000
+                        })
+                    }
+                }
+            };
+
+            const result = await KB_VectorService.embedChunks({collection, chunksToProcess: chunks});
+
+            expect(result.embedded).toBe(1);
+            expect(upsertCalls, 'the persistence attempt remains retryable').toBe(2);
+            expect(providerCalls, 'cached vectors prevent a write retry from re-entering the provider').toBe(1);
+        } finally {
+            globalThis.setTimeout = originalSetTimeout;
+        }
     });
 
     test('CALLER BOUNDARY: shadow-swap REFUSES to promote when a batch failed', async () => {


### PR DESCRIPTION
Resolves neomjs/neo#16973

Related: neomjs/neo-agent-brain#54, neomjs/neo#16012

Knowledge Base embedding now treats a timeout-class provider failure as the end of the current sweep. It preserves the original typed error for the existing deferral pipeline, leaves already-persisted chunks as the resume boundary, and prevents the next batch or retry from being dispatched behind provider work that may still be alive.

Evidence: L2 (production-shaped unit composition plus two named red mutations) → L4 required (external provider-settlement and durable-ingestion receipt). Residual: external deployment validation [#16706].

## Deltas from ticket

The ticket's original prescription said to wait one timeout budget and retry. The measured 66-minute provider response against a 30-minute client budget falsified that rule. This PR adopts the stronger, already-established neomjs/neo#16012 contract: a timeout ends the entire in-cycle sweep and the outer scheduler owns the later attempt.

The timeout classifier is provider-phase-only. A timeout-shaped Chroma write error still retries the write with cached vectors, and ordinary non-timeout provider failures retain the existing bounded exponential retry. This prevents future same-cycle timeout amplification; it does not terminate provider work already running, alter batch sizing, or claim that ingestion progress proves CPU recovery.

## Test Evidence

- Knowledge Base production-adjacent controls: `npm run test-unit -- test/playwright/unit/ai/services/knowledge-base/VectorService.batchFailureIsolation.spec.mjs test/playwright/unit/ai/services/knowledge-base/VectorService.leaseYield.spec.mjs test/playwright/unit/ai/services/knowledge-base/VectorService.persistenceNonConvergence.spec.mjs test/playwright/unit/ai/services/knowledge-base/embedFailureClassification.spec.mjs` — 59 passed on current `dev`.
- Retry classification guard: `npm run test-unit -- test/playwright/unit/ai/scripts/lint/lintRetryBounds.spec.mjs` — 19 passed; `npm run ai:lint-retry-bounds` — 42 candidates, all classified.
- Mutation 1: disabling the timeout terminal made the test dispatch all five attempts for batch 2 and then all five for batch 3; the original-error and provider-call assertions failed.
- Mutation 2: removing the provider-phase guard made a timeout-shaped Chroma upsert error abort the sweep; the write-retry control failed.
- `npm run agent-preflight -- --change-class restoration --commit-subject 'fix(knowledge-base): stop retrying provider timeouts in-cycle (#16973)' --no-fix` — passed.
- Pre-commit staged gates — whitespace, shorthand, JSDoc types, ticket archaeology, block alignment, parse, AiConfig test mutation, derived-domain, atomic-write shape, and OpenAPI service parity all passed.
- `git diff --cached --check` and direct Node parse checks passed before commit.

## Post-Merge Validation

- [ ] Deploy the merged Neo revision and clear any provider work already running before the observation window.
- [ ] On the next timeout-class KB embedding failure, verify one provider offer for that batch, no later batch in the same sweep, and a later scheduler-owned resume from the persisted prefix.
- [ ] Record durable ingestion progress (`lastIngestedRev` / collection count) independently from model CPU settling; neither receipt may substitute for the other.

Authored by Euclid (GPT-5.6, Codex Desktop).
