### PR TITLE
fix(orchestrator): bind durable deferral persistence (#16904)

### DIFF
--- a/ai/daemons/orchestrator/services/TaskStateService.mjs
+++ b/ai/daemons/orchestrator/services/TaskStateService.mjs
@@ -224,13 +224,15 @@ export class TaskStateService extends Base {
 
     /**
      * Persists the current task-state envelope.
-     * @returns {void}
+     * @returns {Boolean} True when the envelope was written; false after the existing fail-soft log.
      */
     writeState() {
         try {
             fs.writeFileSync(this.stateFile, JSON.stringify(this.taskState, null, 2), 'utf8');
+            return true
         } catch (e) {
             this.writeLog('ERROR', `[TaskStateService] Failed to write state file: ${e.message}`);
+            return false
         }
     }
 
@@ -353,8 +355,9 @@ export class TaskStateService extends Base {
      * is idle for lack of work is not starved. Hanging the streak off every skip would make an idle lane
      * indistinguishable from a blocked one, which is the conflation this measurement exists to end.
      *
-     * Writes only the streak. The deferral's own reporting stays with the recorder that owns it; this is
-     * the durable half, so the answer survives the process that observed it.
+     * Writes only when this call opens the streak. The deferral's own reporting stays with the recorder
+     * that owns it; this is the durable half, so the answer survives the process that observed it. Once
+     * the streak is durable, later deferrals return the same anchor without rewriting the whole envelope.
      *
      * @param {String} taskName
      * @param {String} [deferredAt=new Date().toISOString()] ISO timestamp of THIS deferral.
@@ -365,8 +368,21 @@ export class TaskStateService extends Base {
 
         if (!state) return null;
 
+        const opensStreak = state.deferralStreakStartedAt === null || state.deferralStreakStartedAt === undefined;
+
+        if (!opensStreak) {
+            return state.deferralStreakStartedAt
+        }
+
         openDeferralStreak(state, deferredAt);
-        this.writeState();
+
+        if (!this.writeState()) {
+            // `writeState()` is deliberately fail-soft for existing callers. This writer still needs
+            // a durable receipt before it can cache/publish the anchor: otherwise one failed first
+            // write makes every later poll look unchanged and suppresses persistence forever.
+            state.deferralStreakStartedAt = null;
+            return null
+        }
 
         return state.deferralStreakStartedAt;
     }

--- a/test/playwright/unit/ai/daemons/orchestrator/services/MaintenanceBackpressureService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/MaintenanceBackpressureService.spec.mjs
@@ -1,4 +1,6 @@
 import {test, expect} from '@playwright/test';
+import fs             from 'fs-extra';
+import path           from 'path';
 import Neo            from '../../../../../../../src/Neo.mjs';
 import * as core      from '../../../../../../../src/core/_export.mjs';
 import {
@@ -15,6 +17,7 @@ import {
     recordDeferral,
     resolveHeavyMaintenanceLeasePath
 } from '../../../../../../../ai/daemons/orchestrator/services/MaintenanceBackpressureService.mjs';
+import {TaskStateService} from '../../../../../../../ai/daemons/orchestrator/services/TaskStateService.mjs';
 
 // A non-heavy task name (must NOT be in DEFAULT_HEAVY_MAINTENANCE_TASK_NAMES) for
 // passthrough tests of `acquireLeaseAndExecute`.
@@ -316,6 +319,69 @@ test.describe('Neo.ai.daemons.orchestrator.services.MaintenanceBackpressureServi
         });
 
         expect(outcomeCalls[0].payload.deferredSince).toBe(inMemorySince);
+    });
+
+    test('PRODUCTION SEAM — durable deferral continuity survives service recreation and blocker change (#16904)', async () => {
+        const
+            dataDir         = `/tmp/maintenance-backpressure-deferral-${Date.now()}-${Math.random()}`,
+            stateFile       = path.join(dataDir, 'task-state.json'),
+            taskDefinitions = {
+                kbSync : {name: 'kbSync',  label: 'KB sync', scriptPath: '/mock/kb-sync.mjs'},
+                summary: {name: 'summary', label: 'Summary', scriptPath: '/mock/summary.mjs'},
+                backup : {name: 'backup',  label: 'Backup', scriptPath: '/mock/backup.mjs'}
+            },
+            bootTaskState = () => {
+                const service = Neo.create(TaskStateService, {stateFile, taskDefinitions, writeLogFn: () => {}});
+
+                service.configure({stateFile, taskDefinitions, writeLogFn: () => {}});
+                return service
+            },
+            recordThroughProduction = ({taskStateService, blockingTaskName}) => {
+                const outcomes = [];
+                const service  = buildService({
+                    taskDefinitions,
+                    taskStateService,
+                    healthService: {
+                        recordTaskOutcome(taskName, status, payload) {
+                            outcomes.push({taskName, status, payload});
+                        }
+                    }
+                });
+
+                service.recordDeferral({
+                    taskName  : 'kbSync',
+                    reasonCode: 'heavy-maintenance-backpressure',
+                    reasonText: 'periodic-sync',
+                    blockingTaskName
+                });
+
+                return outcomes[0].payload.deferredSince
+            };
+
+        fs.ensureDirSync(dataDir);
+
+        try {
+            const first  = bootTaskState();
+            const opened = recordThroughProduction({taskStateService: first, blockingTaskName: 'summary'});
+
+            const reborn    = bootTaskState();
+            const preserved = recordThroughProduction({taskStateService: reborn, blockingTaskName: 'backup'});
+
+            expect(preserved, 'changing the blocker after restart must not slide the starved task anchor')
+                .toBe(opened);
+
+            reborn.markStarted('kbSync', 'scheduled');
+            expect(reborn.getTaskState('kbSync').deferralStreakStartedAt).toBeNull();
+
+            await new Promise(resolve => setTimeout(resolve, 5));
+
+            const reopened = recordThroughProduction({taskStateService: reborn, blockingTaskName: 'summary'});
+
+            expect(reopened, 'a real start closes the episode; a later deferral opens a fresh one')
+                .not.toBe(opened);
+        } finally {
+            fs.removeSync(dataDir);
+        }
     });
 
     test('recordDeferral (intra-process heavy backpressure) dedupes + emits skipped outcome', () => {

--- a/test/playwright/unit/ai/daemons/orchestrator/services/TaskStateService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/TaskStateService.spec.mjs
@@ -242,6 +242,41 @@ test.describe('Neo.ai.daemons.services.TaskStateService', () => {
         expect(JSON.parse(fs.readFileSync(stateFile, 'utf8')).mockTask.deferralStreakStartedAt).toBe(opened);
     });
 
+    test('markDeferred persists the first anchor once and skips unchanged whole-state rewrites (#16904)', () => {
+        const {service}          = createTestService();
+        const originalWriteState = service.writeState.bind(service);
+        let   writeCount         = 0;
+
+        service.writeState = () => {
+            writeCount += 1;
+            return originalWriteState()
+        };
+
+        const opened = service.markDeferred('mockTask', '2026-08-11T13:40:00.000Z');
+
+        expect(opened).toBe('2026-08-11T13:40:00.000Z');
+        expect(writeCount).toBe(1);
+
+        expect(service.markDeferred('mockTask', '2026-08-11T13:41:00.000Z')).toBe(opened);
+        expect(writeCount).toBe(1);
+    });
+
+    test('markDeferred retries first-anchor persistence after a fail-soft write rejection (#16904)', () => {
+        const {service}  = createTestService();
+        let   writeCount = 0;
+
+        service.writeState = () => {
+            writeCount += 1;
+            return false
+        };
+
+        expect(service.markDeferred('mockTask', '2026-08-11T13:40:00.000Z')).toBeNull();
+        expect(service.getTaskState('mockTask').deferralStreakStartedAt).toBeNull();
+
+        expect(service.markDeferred('mockTask', '2026-08-11T13:41:00.000Z')).toBeNull();
+        expect(writeCount, 'a failed first write must not turn later deferrals into no-op rewrites').toBe(2);
+    });
+
     test('the deferral streak SURVIVES a restart — which is the whole reason it is durable (#16561)', () => {
         // An in-memory streak map resets when the daemon restarts, so a starvation spanning a restart
         // reported a FRESH streak — and a threshold measured from a value that resets can never be


### PR DESCRIPTION
Resolves #16904

## Summary

The production backpressure path now has an executable durability witness, and unchanged deferrals stop rewriting the complete task-state envelope after their anchor is durable.

`TaskStateService.markDeferred()` writes synchronously only when opening a streak. Its existing fail-soft writer now returns a bounded Boolean receipt: when the first write fails, `markDeferred()` rolls the in-memory anchor back and returns `null`, allowing the next poll to retry persistence instead of caching an anchor that never reached disk.

Evidence: 63 focused tests pass, and three disposable mutations independently convict the production carriage, unchanged-anchor rewrite guard, and failed-write rollback.

## Evidence

- A production-composition spec drives `MaintenanceBackpressureService.recordDeferral()` through a real `TaskStateService`, recreates the service over the same file, changes the blocking task, and proves the original anchor survives.
- The same witness calls the real `markStarted()` transition and proves the next deferral opens a fresh episode.
- A first-write counter proves the anchor is persisted before return and an unchanged second deferral performs no additional whole-state write.
- A fail-soft writer witness proves a rejected first persistence leaves no cached anchor and is retried on the next deferral.
- The existing no-task-state control continues to prove the process-local fallback.

## Deltas from ticket

The production carriage already existed at implementation time; this PR binds it with the missing mutation-sensitive composition test rather than changing the delegation itself.

The ticket described persistence failure as loud, but exact source showed `writeState()` deliberately catches and logs write failures. The implementation preserves that contract while adding a Boolean write receipt and rolling back an unpersisted first anchor. This closes the more dangerous failure mode where one failed write would otherwise make every later poll look unchanged.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/ai/daemons/orchestrator/services/TaskStateService.spec.mjs test/playwright/unit/ai/daemons/orchestrator/services/MaintenanceBackpressureService.spec.mjs` — 63 passed.
- `npm run agent-preflight -- --change-class restoration --commit-subject 'fix(orchestrator): bind durable deferral persistence (#16904)' --no-fix` — passed.
- `git diff --cached --check` and `node --check ai/daemons/orchestrator/services/TaskStateService.mjs` — passed.
- Mutation: removing `taskStateService: this.taskStateService` made both the direct production-seam witness and restart-continuity witness fail.
- Mutation: removing the unchanged-anchor early return changed the expected write count from 1 to 2.
- Mutation: removing failed-write rollback left the unpersisted anchor cached and made the retry-safety witness fail.

## Post-Merge Validation

No external validation is required. The close target is the deterministic production composition, persisted restart boundary, real start transition, and exact write-count behavior exercised by the focused suites.

## Commits

- `7caf2dbf90` — `fix(orchestrator): bind durable deferral persistence (#16904)`

Authored by Euclid (GPT-5.6, Codex Desktop).
