### PR TITLE
fix(fleet): make vocabulary parity coverage exhaustive (#16805)

### DIFF
--- a/ai/scripts/lint/lint-fleet-vocabulary-parity.mjs
+++ b/ai/scripts/lint/lint-fleet-vocabulary-parity.mjs
@@ -5,9 +5,10 @@
  *
  * The realms deliberately share NO imports: `apps/agentos/config/*` twins render/form with the
  * same vocabulary the `ai/services/fleet/*` authorities validate, and THIS lint is what makes the
- * duplication safe — every constant is deep-equaled and every shared pure helper is executed over
- * drift-sensitive fixtures on both sides. A divergence names its surface and reddens CI; silent
- * drift (the convention-without-a-lint failure class) cannot exist.
+ * duplication safe — every live namespace export is dispositioned as paired data, paired helper,
+ * or a reasoned realm-only member. Constants are deep-equaled and shared pure helpers execute over
+ * drift-sensitive fixtures on both sides. A divergence or unclassified export names its surface
+ * and reddens CI; silent export growth (the convention-without-a-lint failure class) cannot exist.
  *
  * Consumed three ways: lint-staged (pre-commit, vocabulary globs), the CI lint job, and the unit
  * spec `test/playwright/unit/apps/agentos/config/fleetVocabularyParity.spec.mjs` — which also
@@ -56,6 +57,74 @@ function outcome(fn, args) {
 }
 
 /**
+ * @summary Verifies that every live namespace export has exactly one declared disposition and
+ * every declared disposition still names a live export.
+ * @param {Object} options
+ * @param {Object} options.namespaces Namespace pairs keyed by stable surface name.
+ * @param {Array} options.dataPairs Registered deep-equality pairs.
+ * @param {Array} options.helperCases Registered behavior-parity pairs.
+ * @param {Array} options.realmOnlyExports Reasoned one-sided exports.
+ * @returns {String[]}
+ * @private
+ */
+function censusExportDispositions({namespaces, dataPairs, helperCases, realmOnlyExports}) {
+    const
+        dispositions   = new Map(),
+        violations     = [],
+        addDisposition = (surface, side, name, kind, reason = null) => {
+            const key     = `${surface}:${side}:${name}`;
+            const entries = dispositions.get(key) || [];
+
+            entries.push({kind, reason});
+            dispositions.set(key, entries)
+        };
+
+    dataPairs.forEach(([surface, name]) => {
+        addDisposition(surface, 'authority', name, 'data-pair');
+        addDisposition(surface, 'twin', name, 'data-pair')
+    });
+
+    helperCases.forEach(([surface, name]) => {
+        addDisposition(surface, 'authority', name, 'helper-pair');
+        addDisposition(surface, 'twin', name, 'helper-pair')
+    });
+
+    realmOnlyExports.forEach(([surface, side, name, reason]) => {
+        addDisposition(surface, side, name, 'realm-only', reason);
+
+        if (typeof reason !== 'string' || !reason.trim()) {
+            violations.push(`${surface}.${side}.${name}: realm-only disposition requires a reason`)
+        }
+    });
+
+    Object.entries(namespaces).forEach(([surface, sides]) => {
+        ['authority', 'twin'].forEach(side => {
+            const namespace = sides[side] || {};
+
+            Object.keys(namespace).forEach(name => {
+                const entries = dispositions.get(`${surface}:${side}:${name}`) || [];
+
+                if (entries.length === 0) {
+                    violations.push(`${surface}.${side}.${name}: export is unclassified`)
+                } else if (entries.length > 1) {
+                    violations.push(`${surface}.${side}.${name}: export has ${entries.length} dispositions`)
+                }
+            });
+
+            for (const [key, entries] of dispositions) {
+                const [entrySurface, entrySide, name] = key.split(':');
+
+                if (entrySurface === surface && entrySide === side && !Object.hasOwn(namespace, name)) {
+                    violations.push(`${surface}.${side}.${name}: ${entries[0].kind} disposition names a missing export`)
+                }
+            }
+        })
+    });
+
+    return violations
+}
+
+/**
  * @summary Compare the full FM vocabulary between authority and twin namespaces.
  * @param {Object} sides
  * @param {Object} sides.authority `{mcp, harness, wire, cockpit}` — the Brain-side namespaces.
@@ -63,25 +132,32 @@ function outcome(fn, args) {
  * @returns {String[]} Violations, one named surface each; empty = parity holds.
  */
 export function compareFleetVocabulary({authority, twin}) {
-    const violations = [];
+    const
+        violations = [],
+        namespaces = {
+            mcp    : {authority: authority.mcp,     twin: twin.mcp},
+            harness: {authority: authority.harness, twin: twin.harness},
+            wire   : {authority: authority.wire,    twin: twin.wire},
+            cockpit: {authority: authority.cockpit, twin: twin.sources}
+        };
 
     // REMOTE_MCP_CREDENTIAL_ENV_VAR is deliberately absent: credential env-var vocabulary is
     // Brain-only (no app consumer exists; the App Worker reads no process environment).
     const dataPairs = [
-        ['MCP_SERVERS',              authority.mcp.MCP_SERVERS,               twin.mcp.MCP_SERVERS],
-        ['TENANT_MCP_HARNESS_TYPES', authority.mcp.TENANT_MCP_HARNESS_TYPES,  twin.mcp.TENANT_MCP_HARNESS_TYPES],
-        ['HARNESS_TYPES',            authority.harness.HARNESS_TYPES,         twin.harness.HARNESS_TYPES],
-        ['FLEET_WIRE_METHODS',       authority.wire.FLEET_WIRE_METHODS,       twin.wire.FLEET_WIRE_METHODS],
-        ['FLEET_CREDENTIAL_METHODS', authority.wire.FLEET_CREDENTIAL_METHODS, twin.wire.FLEET_CREDENTIAL_METHODS],
-        ['FLEET_WIRE_PROTOCOL_VERSIONS', authority.wire.FLEET_WIRE_PROTOCOL_VERSIONS, twin.wire.FLEET_WIRE_PROTOCOL_VERSIONS],
-        ['FLEET_WIRE_CAPABILITIES', authority.wire.FLEET_WIRE_CAPABILITIES, twin.wire.FLEET_WIRE_CAPABILITIES],
-        ['FLEET_WIRE_REQUIRED_CAPABILITIES', authority.wire.FLEET_WIRE_REQUIRED_CAPABILITIES, twin.wire.FLEET_WIRE_REQUIRED_CAPABILITIES],
-        ['FLEET_WIRE_RESPONSE_STATES', authority.wire.FLEET_WIRE_RESPONSE_STATES, twin.wire.FLEET_WIRE_RESPONSE_STATES],
-        ['FLEET_WIRE_ENVELOPE_SCHEMA', authority.wire.FLEET_WIRE_ENVELOPE_SCHEMA, twin.wire.FLEET_WIRE_ENVELOPE_SCHEMA],
-        ['FLEET_COCKPIT_SOURCES',    authority.cockpit.FLEET_COCKPIT_SOURCES, twin.sources.FLEET_COCKPIT_SOURCES]
+        ['mcp',     'MCP_SERVERS',              authority.mcp.MCP_SERVERS,               twin.mcp.MCP_SERVERS],
+        ['mcp',     'TENANT_MCP_HARNESS_TYPES', authority.mcp.TENANT_MCP_HARNESS_TYPES,  twin.mcp.TENANT_MCP_HARNESS_TYPES],
+        ['harness', 'HARNESS_TYPES',            authority.harness.HARNESS_TYPES,         twin.harness.HARNESS_TYPES],
+        ['wire',    'FLEET_WIRE_METHODS',       authority.wire.FLEET_WIRE_METHODS,       twin.wire.FLEET_WIRE_METHODS],
+        ['wire',    'FLEET_CREDENTIAL_METHODS', authority.wire.FLEET_CREDENTIAL_METHODS, twin.wire.FLEET_CREDENTIAL_METHODS],
+        ['wire',    'FLEET_WIRE_PROTOCOL_VERSIONS', authority.wire.FLEET_WIRE_PROTOCOL_VERSIONS, twin.wire.FLEET_WIRE_PROTOCOL_VERSIONS],
+        ['wire',    'FLEET_WIRE_CAPABILITIES', authority.wire.FLEET_WIRE_CAPABILITIES, twin.wire.FLEET_WIRE_CAPABILITIES],
+        ['wire',    'FLEET_WIRE_REQUIRED_CAPABILITIES', authority.wire.FLEET_WIRE_REQUIRED_CAPABILITIES, twin.wire.FLEET_WIRE_REQUIRED_CAPABILITIES],
+        ['wire',    'FLEET_WIRE_RESPONSE_STATES', authority.wire.FLEET_WIRE_RESPONSE_STATES, twin.wire.FLEET_WIRE_RESPONSE_STATES],
+        ['wire',    'FLEET_WIRE_ENVELOPE_SCHEMA', authority.wire.FLEET_WIRE_ENVELOPE_SCHEMA, twin.wire.FLEET_WIRE_ENVELOPE_SCHEMA],
+        ['cockpit', 'FLEET_COCKPIT_SOURCES',    authority.cockpit.FLEET_COCKPIT_SOURCES, twin.sources.FLEET_COCKPIT_SOURCES]
     ];
 
-    dataPairs.forEach(([name, authorityValue, twinValue]) => {
+    dataPairs.forEach(([, name, authorityValue, twinValue]) => {
         if (!sameShape(authorityValue, twinValue)) {
             violations.push(`${name}: authority and twin diverge`)
         }
@@ -90,15 +166,15 @@ export function compareFleetVocabulary({authority, twin}) {
     // Helper-behavior parity over drift-sensitive fixtures: same inputs, same outcome class, same
     // content — a fork in validation or projection logic reddens here even when the data agrees.
     const helperCases = [
-        ['listMcpServers()',                       authority.mcp.listMcpServers,          twin.mcp.listMcpServers,          [[]]],
-        ['defaultMcpMatrix()',                     authority.mcp.defaultMcpMatrix,        twin.mcp.defaultMcpMatrix,        [[]]],
-        ['resolveMcpMatrix(...)',                  authority.mcp.resolveMcpMatrix,        twin.mcp.resolveMcpMatrix,        [
+        ['mcp', 'listMcpServers',                  authority.mcp.listMcpServers,          twin.mcp.listMcpServers,          [[]]],
+        ['mcp', 'defaultMcpMatrix',                authority.mcp.defaultMcpMatrix,        twin.mcp.defaultMcpMatrix,        [[]]],
+        ['mcp', 'resolveMcpMatrix',                authority.mcp.resolveMcpMatrix,        twin.mcp.resolveMcpMatrix,        [
             [null],
             [{'github-workflow': true}],
             [{'retired-server': true}],
             [{'memory-core': 'truthy-legacy'}]
         ]],
-        ['normalizeMcpOverrides(...)',             authority.mcp.normalizeMcpOverrides,   twin.mcp.normalizeMcpOverrides,   [
+        ['mcp', 'normalizeMcpOverrides',           authority.mcp.normalizeMcpOverrides,   twin.mcp.normalizeMcpOverrides,   [
             [null],
             [{}],
             [{'memory-core': true}],
@@ -107,40 +183,40 @@ export function compareFleetVocabulary({authority, twin}) {
             [{'memory-core': 1}],
             [['not-an-object']]
         ]],
-        ['supportsTenantMcpTarget(...)',           authority.mcp.supportsTenantMcpTarget, twin.mcp.supportsTenantMcpTarget, [
+        ['mcp', 'supportsTenantMcpTarget',         authority.mcp.supportsTenantMcpTarget, twin.mcp.supportsTenantMcpTarget, [
             ...authority.harness.HARNESS_TYPES.map(entry => [entry.type]),
             ['unregistered-harness']
         ]],
-        ['listHarnessTypes()',                     authority.harness.listHarnessTypes,    twin.harness.listHarnessTypes,    [[]]],
-        ['resolveHarnessType(...)',                authority.harness.resolveHarnessType,  twin.harness.resolveHarnessType,  [
+        ['harness', 'listHarnessTypes',            authority.harness.listHarnessTypes,    twin.harness.listHarnessTypes,    [[]]],
+        ['harness', 'resolveHarnessType',          authority.harness.resolveHarnessType,  twin.harness.resolveHarnessType,  [
             ...authority.harness.HARNESS_TYPES.map(entry => [entry.type]),
             ['unregistered-harness']
         ]],
-        ['createFleetWireOffer()',                 authority.wire.createFleetWireOffer, twin.wire.createFleetWireOffer, [
+        ['wire', 'createFleetWireOffer',           authority.wire.createFleetWireOffer, twin.wire.createFleetWireOffer, [
             []
         ]],
-        ['createFleetWireProtocolStamp(...)',      authority.wire.createFleetWireProtocolStamp, twin.wire.createFleetWireProtocolStamp, [
+        ['wire', 'createFleetWireProtocolStamp',  authority.wire.createFleetWireProtocolStamp, twin.wire.createFleetWireProtocolStamp, [
             [],
             [1, ['method-schema-v1']]
         ]],
-        ['selectFleetWireContract(...)',           authority.wire.selectFleetWireContract, twin.wire.selectFleetWireContract, [
+        ['wire', 'selectFleetWireContract',       authority.wire.selectFleetWireContract, twin.wire.selectFleetWireContract, [
             [authority.wire.createFleetWireOffer()],
             [{versions: [0], capabilities: [...authority.wire.FLEET_WIRE_CAPABILITIES]}],
             [{versions: [1], capabilities: []}],
             [{versions: '1', capabilities: []}]
         ]],
-        ['createFleetWireRequest(...)',            authority.wire.createFleetWireRequest, twin.wire.createFleetWireRequest, [
+        ['wire', 'createFleetWireRequest',        authority.wire.createFleetWireRequest, twin.wire.createFleetWireRequest, [
             ['listAgents', undefined],
             ['listAgents', {page: 1}, {versions: [1], capabilities: [...authority.wire.FLEET_WIRE_CAPABILITIES]}],
             ['getManager', null]
         ]],
-        ['createFleetWireResponse(...)',           authority.wire.createFleetWireResponse, twin.wire.createFleetWireResponse, [
+        ['wire', 'createFleetWireResponse',       authority.wire.createFleetWireResponse, twin.wire.createFleetWireResponse, [
             [authority.wire.FLEET_WIRE_RESPONSE_STATES.ok, {result: []}],
             [authority.wire.FLEET_WIRE_RESPONSE_STATES.ok, {}],
             [authority.wire.FLEET_WIRE_RESPONSE_STATES.unsupportedProtocol, {error: 'fleet: unsupported wire protocol'}],
             ['invented-state', {}]
         ]],
-        ['inspectFleetWireResponse(...)',          authority.wire.inspectFleetWireResponse, twin.wire.inspectFleetWireResponse, [
+        ['wire', 'inspectFleetWireResponse',      authority.wire.inspectFleetWireResponse, twin.wire.inspectFleetWireResponse, [
             [authority.wire.createFleetWireResponse(
                 authority.wire.FLEET_WIRE_RESPONSE_STATES.ok,
                 {result: []}
@@ -175,7 +251,21 @@ export function compareFleetVocabulary({authority, twin}) {
         ]]
     ];
 
-    helperCases.forEach(([name, authorityFn, twinFn, argSets]) => {
+    const realmOnlyExports = [
+        ['mcp', 'authority', 'REMOTE_MCP_CREDENTIAL_ENV_VAR', 'deployment credential vocabulary; the App Worker reads no process environment'],
+        ['mcp', 'authority', 'normalizeMcpTarget', 'registry-owned target validation; the app emits intent and the Brain is the gate'],
+        ['mcp', 'authority', 'default', 'Brain-side aggregate for server consumers; the operable-cold app twin uses named exports'],
+        ['harness', 'authority', 'default', 'Brain-side aggregate for server consumers; the operable-cold app twin uses named exports'],
+        ['cockpit', 'authority', 'FLEET_COCKPIT_EVENT_TYPES', 'Brain-owned event validation vocabulary; the app twin only names sources'],
+        ['cockpit', 'authority', 'boundReason', 'Brain-owned status sanitization; the app twin only names sources'],
+        ['cockpit', 'authority', 'createFleetCockpitEvent', 'Brain-owned event assembler; the app twin only names sources'],
+        ['cockpit', 'authority', 'createFleetCockpitStatus', 'Brain-owned status assembler; the app twin only names sources'],
+        ['cockpit', 'authority', 'createNotWiredCapability', 'Brain-owned capability assembler; the app twin only names sources']
+    ];
+
+    violations.push(...censusExportDispositions({namespaces, dataPairs, helperCases, realmOnlyExports}));
+
+    helperCases.forEach(([, name, authorityFn, twinFn, argSets]) => {
         if (typeof authorityFn !== 'function' || typeof twinFn !== 'function') {
             violations.push(`${name}: helper missing on ${typeof authorityFn === 'function' ? 'twin' : 'authority'}`);
             return
@@ -213,7 +303,7 @@ function main() {
         process.exit(1)
     }
 
-    console.log('[lint-fleet-vocabulary-parity] OK — vocabulary constants + shared helper behavior identical across the realm boundary.')
+    console.log('[lint-fleet-vocabulary-parity] OK — every export dispositioned; paired data + helper behavior identical across the realm boundary.')
 }
 
 if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {

--- a/test/playwright/unit/apps/agentos/config/fleetVocabularyParity.spec.mjs
+++ b/test/playwright/unit/apps/agentos/config/fleetVocabularyParity.spec.mjs
@@ -19,8 +19,46 @@ const
     twin      = {mcp: twinMcp, harness: twinHarness, wire: twinWire, sources: twinSources};
 
 test.describe('FM vocabulary parity — the realm boundary carries no imports, so the lint is the binding', () => {
-    test('the live twin mirrors the live authority: every constant, every shared helper outcome', () => {
+    test('the live twin mirrors the live authority: every export is dispositioned and every pair agrees', () => {
         expect(compareFleetVocabulary({authority, twin})).toEqual([])
+    });
+
+    test('an unclassified authority-only export fails closed with its namespace and name (#16805)', () => {
+        const expandedAuthority = {
+            ...authority,
+            mcp: {...authority.mcp, UNCLASSIFIED_AUTHORITY_PROBE: true}
+        };
+
+        expect(compareFleetVocabulary({authority: expandedAuthority, twin})).toContain(
+            'mcp.authority.UNCLASSIFIED_AUTHORITY_PROBE: export is unclassified'
+        )
+    });
+
+    test('an unclassified twin-only export fails closed with its namespace and name (#16805)', () => {
+        const expandedTwin = {
+            ...twin,
+            harness: {...twin.harness, UNCLASSIFIED_TWIN_PROBE: true}
+        };
+
+        expect(compareFleetVocabulary({authority, twin: expandedTwin})).toContain(
+            'harness.twin.UNCLASSIFIED_TWIN_PROBE: export is unclassified'
+        )
+    });
+
+    test('same-named exports on both realms are not silently treated as a registered pair (#16805)', () => {
+        const
+            expandedAuthority = {
+                ...authority,
+                wire: {...authority.wire, UNREGISTERED_PAIR_PROBE: {owner: 'authority'}}
+            },
+            expandedTwin = {
+                ...twin,
+                wire: {...twin.wire, UNREGISTERED_PAIR_PROBE: {owner: 'twin'}}
+            },
+            violations = compareFleetVocabulary({authority: expandedAuthority, twin: expandedTwin});
+
+        expect(violations).toContain('wire.authority.UNREGISTERED_PAIR_PROBE: export is unclassified');
+        expect(violations).toContain('wire.twin.UNREGISTERED_PAIR_PROBE: export is unclassified')
     });
 
     test('the comparator is not a rubber stamp: an induced data drift reddens with the surface named', () => {
@@ -190,11 +228,14 @@ test.describe('FM vocabulary parity — the realm boundary carries no imports, s
 
     test('the operable-cold app contract imports no ai or server trust authority', () => {
         const sources = [
-            ['fleetWireMethods', new URL('../../../../../../apps/agentos/config/fleetWireMethods.mjs', import.meta.url)],
-            ['installFleetBridge', new URL('../../../../../../apps/agentos/fleet/installFleetBridge.mjs', import.meta.url)]
+            ['mcpServers',         new URL('../../../../../../apps/agentos/config/mcpServers.mjs', import.meta.url),        []],
+            ['harnessTypes',       new URL('../../../../../../apps/agentos/config/harnessTypes.mjs', import.meta.url),      []],
+            ['fleetWireMethods',   new URL('../../../../../../apps/agentos/config/fleetWireMethods.mjs', import.meta.url),  []],
+            ['cockpitSources',     new URL('../../../../../../apps/agentos/config/cockpitSources.mjs', import.meta.url),    []],
+            ['installFleetBridge', new URL('../../../../../../apps/agentos/fleet/installFleetBridge.mjs', import.meta.url), ['../config/fleetWireMethods.mjs']]
         ];
 
-        for (const [label, url] of sources) {
+        for (const [label, url, expectedImports] of sources) {
             const
                 ast     = parse(readFileSync(url, 'utf8'), {ecmaVersion: 'latest', sourceType: 'module'}),
                 imports = ast.body
@@ -204,12 +245,7 @@ test.describe('FM vocabulary parity — the realm boundary carries no imports, s
             expect(imports.every(source => !source.includes('/ai/') &&
                 !/fleetIngressAuth|FleetControlBridge|localBearer|Identity|ownership|authorization/i.test(source)), label)
                 .toBe(true);
-
-            if (label === 'fleetWireMethods') {
-                expect(imports, 'the app vocabulary twin must remain operable-cold').toEqual([])
-            } else {
-                expect(imports).toEqual(['../config/fleetWireMethods.mjs'])
-            }
+            expect(imports, `${label} must retain its operable-cold import contract`).toEqual(expectedImports)
         }
     })
 });

--- a/test/playwright/unit/apps/agentos/config/fleetVocabularyParity.spec.mjs
+++ b/test/playwright/unit/apps/agentos/config/fleetVocabularyParity.spec.mjs
@@ -61,6 +61,24 @@ test.describe('FM vocabulary parity — the realm boundary carries no imports, s
         expect(violations).toContain('wire.twin.UNREGISTERED_PAIR_PROBE: export is unclassified')
     });
 
+    test('a registered pair missing from both realms fails closed on each side (#16805)', () => {
+        const
+            {FLEET_WIRE_ENVELOPE_SCHEMA: omittedAuthority, ...authorityWireWithoutSchema} = authority.wire,
+            {FLEET_WIRE_ENVELOPE_SCHEMA: omittedTwin,      ...twinWireWithoutSchema}      = twin.wire,
+            shrunkAuthority                                                               = {...authority, wire: authorityWireWithoutSchema},
+            shrunkTwin                                                                    = {...twin,      wire: twinWireWithoutSchema},
+            violations                                                                    = compareFleetVocabulary({authority: shrunkAuthority, twin: shrunkTwin});
+
+        expect(omittedAuthority).toBeDefined();
+        expect(omittedTwin).toBeDefined();
+        expect(violations).toContain(
+            'wire.authority.FLEET_WIRE_ENVELOPE_SCHEMA: data-pair disposition names a missing export'
+        );
+        expect(violations).toContain(
+            'wire.twin.FLEET_WIRE_ENVELOPE_SCHEMA: data-pair disposition names a missing export'
+        )
+    });
+
     test('the comparator is not a rubber stamp: an induced data drift reddens with the surface named', () => {
         // The permanent red-proof: a twin whose catalog gained an unmirrored server MUST fail, and
         // the violation names the drifted surface — the exact defect class the dissolution's


### PR DESCRIPTION
Resolves #16805

## Summary

Fleet vocabulary parity is now mechanically exhaustive over the live ESM namespace surfaces. The lint dispositions every export as paired data, paired helper behavior, or a reasoned realm-only member, then refuses unclassified, multiply classified, or stale/missing roster entries.

The measured baseline contains 33 Brain-authority exports and 24 app-twin exports across MCP, harness, wire, and cockpit/source pairs. Nine legitimate authority-only exports are explicit and reasoned; no twin-only export is silently assumed. Existing deep-equality and behavior-parity checks remain intact.

Evidence: 12 canonical unit tests pass; the live CLI census passes; deleting only the census invocation makes all three export-growth witnesses fail.

## Evidence

- Authority-only growth fails with the exact namespace and export name.
- Twin-only growth fails with the exact namespace and export name.
- Adding the same unregistered name to both realms still fails on both sides rather than being inferred as a pair.
- Registered data drift and helper-behavior forks retain their existing red controls.
- All four app config twins are parsed and required to remain import-free; the Fleet installer retains only its one cold-twin import.
- The lint-staged vocabulary glob executes this CLI, while the canonical unit spec supplies hosted Tests reach.

## Deltas from ticket

The implementation follows the prescribed two-file shape. The cold-realm control was strengthened beyond its previous wire-only check to enumerate all four app vocabulary twins, matching the ticket acceptance criterion without changing app runtime code.

The repository-wide structure-map failure described by the ticket was not retried; the existing lint owner and canonical spec remained the exact bounded placement.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/apps/agentos/config/fleetVocabularyParity.spec.mjs` — 12 passed.
- `npm run --silent ai:lint-fleet-vocabulary-parity` — every export dispositioned; paired data and helper behavior identical.
- `node ./ai/scripts/lint/lint-guard-ci-parity.mjs` — 13 lint-staged guards, 6 accepted client-only; passed.
- `npm run agent-preflight -- --change-class restoration --commit-subject 'fix(fleet): make vocabulary parity coverage exhaustive (#16805)' --no-fix` — passed.
- `git diff --cached --check` and `node --check ai/scripts/lint/lint-fleet-vocabulary-parity.mjs` — passed.
- Mutation: deleting only `censusExportDispositions(...)` made the authority-only, twin-only, and same-named-unregistered witnesses fail 3/3.

## Post-Merge Validation

No external validation is required. The merge gate and canonical unit spec operate directly on the live ESM namespace objects; runtime Fleet vocabulary is unchanged.

## Commits

- `91105eea31` — `fix(fleet): make vocabulary parity coverage exhaustive (#16805)`
- `06d07c2937` — `test(fleet): pin missing registered export census (#16805)`

Authored by Euclid (GPT-5.6, Codex Desktop).
