### PR TITLE
fix(neural-link): an unresolved bridge cwd fails loudly instead of spawning at / (#16429)

### DIFF
--- a/ai/mcp/server/neural-link/Server.mjs
+++ b/ai/mcp/server/neural-link/Server.mjs
@@ -185,6 +185,14 @@ class Server extends BaseServer {
                 ConnectionService.cwd = this.bridgeCwd;
             }
             await ConnectionService.ready();
+
+            // Drive the connect HERE, after cwd is assigned. `initAsync()` defers the auto-connect
+            // while cwd is unresolved, and it always is at that point — the singleton is constructed
+            // by this file's own import, several steps before `this.bridgeCwd` exists. This is the
+            // first moment the Bridge can be spawned from the directory the operator actually named.
+            if (ConnectionService.cwd && aiConfig.autoConnect) {
+                await ConnectionService.ensureBridgeAndConnect();
+            }
         } catch (e) {
             this.logger.error('ConnectionService failed to initialize:', e);
             // Do not throw — server stays alive to report health errors via MCP healthcheck.

--- a/ai/services/neural-link/ConnectionService.mjs
+++ b/ai/services/neural-link/ConnectionService.mjs
@@ -364,6 +364,11 @@ class ConnectionService extends Base {
                 clearTimeout(handshakeTimeout);
 
                 this.bridgeSocket = ws;
+
+                // A live connection is proof the previous failure no longer describes reality.
+                // Leaving it set reports `{connected: true, spawnFailure: 'ENOENT'}` — a payload that
+                // is internally contradictory and sends an operator hunting a resolved problem.
+                this.lastSpawnFailure = null;
                 resolve();
             };
 
@@ -827,6 +832,10 @@ class ConnectionService extends Base {
             // spawned (missing cwd, npm not on PATH) takes the whole MCP server down with it —
             // the opposite of the survivability this boot path exists to provide. Rejecting instead
             // routes the failure back into the caller's existing non-fatal handling.
+            // This attempt owns the reported state from here on. Without the reset, a failure from a
+            // previous attempt outlives it and is still reported after a later attempt succeeds.
+            this.lastSpawnFailure = null;
+
             this.bridgeProcess.once('error', error => {
                 // Sanitized deliberately: `error.message` carries the spawn path and argv, and this
                 // value travels to any healthcheck caller. The code (ENOENT, EACCES) is what an
@@ -834,6 +843,20 @@ class ConnectionService extends Base {
                 this.lastSpawnFailure = error.code || 'BRIDGE_SPAWN_FAILED';
                 logger.error(`[ConnectionService] Bridge spawn failed: ${error.message}`);
                 reject(error)
+            });
+
+            // `error` fires only when the process could not be CREATED. The failure that actually
+            // shows up in production is the opposite: `npm` starts fine and its script exits
+            // non-zero a moment later. That path emits `exit`, never `error`, so it was invisible —
+            // the spawn resolved, the Bridge was dead, and healthcheck had nothing to attribute.
+            this.bridgeProcess.once('exit', (code, signal) => {
+                if (code) {
+                    this.lastSpawnFailure = `BRIDGE_EXIT_${code}`;
+                    logger.error(`[ConnectionService] Bridge exited with code ${code}`)
+                } else if (signal) {
+                    this.lastSpawnFailure = `BRIDGE_SIGNAL_${signal}`;
+                    logger.error(`[ConnectionService] Bridge terminated on ${signal}`)
+                }
             });
 
             this.bridgeProcess.unref();

--- a/ai/services/neural-link/ConnectionService.mjs
+++ b/ai/services/neural-link/ConnectionService.mjs
@@ -183,11 +183,13 @@ class ConnectionService extends Base {
          */
         cwd: null,
         /**
-         * @member {Number} port=8081
-         * Legacy prototype default; connection/spawn reads `aiConfig.port` at the use site.
+         * @member {String|null} lastSpawnFailure=null
+         * Sanitized reason the most recent Bridge spawn failed (error `code`, or a short message
+         * with no paths/argv), surfaced through `getStatus()` so healthcheck can attribute an
+         * unconnected Bridge instead of only reporting that it is down.
          * @protected
          */
-        port: 8081,
+        lastSpawnFailure: null,
         /**
          * @member {Number} bridgeInfoTimeout=1000
          * @protected
@@ -531,7 +533,14 @@ class ConnectionService extends Base {
             windows,
             bridgeConnected: !!this.bridgeSocket,
             agentId        : this.agentId,
-            agents         : Array.from(this.activeAgents)
+            agents         : Array.from(this.activeAgents),
+            // Resolved at the use site from the SSOT, exactly like `createBridgeUrl()` and the spawn
+            // path. Reporting a class-field default here is how healthcheck came to answer 8081 for
+            // a server configured on another port — the operator then debugs the wrong socket.
+            port           : aiConfig.port,
+            // Sanitized on capture, not here: an operator needs to know the Bridge failed to spawn
+            // and why, without the payload carrying host paths or argv.
+            lastSpawnFailure: this.lastSpawnFailure
         }
     }
 
@@ -819,6 +828,10 @@ class ConnectionService extends Base {
             // the opposite of the survivability this boot path exists to provide. Rejecting instead
             // routes the failure back into the caller's existing non-fatal handling.
             this.bridgeProcess.once('error', error => {
+                // Sanitized deliberately: `error.message` carries the spawn path and argv, and this
+                // value travels to any healthcheck caller. The code (ENOENT, EACCES) is what an
+                // operator acts on; the path is what leaks.
+                this.lastSpawnFailure = error.code || 'BRIDGE_SPAWN_FAILED';
                 logger.error(`[ConnectionService] Bridge spawn failed: ${error.message}`);
                 reject(error)
             });

--- a/ai/services/neural-link/ConnectionService.mjs
+++ b/ai/services/neural-link/ConnectionService.mjs
@@ -363,12 +363,7 @@ class ConnectionService extends Base {
                 settled = true;
                 clearTimeout(handshakeTimeout);
 
-                this.bridgeSocket = ws;
-
-                // A live connection is proof the previous failure no longer describes reality.
-                // Leaving it set reports `{connected: true, spawnFailure: 'ENOENT'}` — a payload that
-                // is internally contradictory and sends an operator hunting a resolved problem.
-                this.lastSpawnFailure = null;
+                this.markBridgeConnected(ws);
                 resolve();
             };
 
@@ -507,6 +502,27 @@ class ConnectionService extends Base {
      * Returns the current status.
      * @returns {Object}
      */
+    /**
+     * @summary Commits the connected-Bridge state transition: the live socket, and the retirement of
+     * any prior spawn failure.
+     *
+     * A named method rather than two inline assignments because the retirement is the half that is
+     * hard to witness — the failure-to-recovery path needs a CONNECTED state, and a spec that only
+     * starts another spawn clears at attempt-start instead and passes with this deleted. Driving the
+     * same method production drives is what makes the recovery assertion able to fail.
+     *
+     * @param {Object} ws The live Bridge WebSocket.
+     * @returns {void}
+     */
+    markBridgeConnected(ws) {
+        this.bridgeSocket = ws;
+
+        // A live connection is proof the previous failure no longer describes reality. Leaving it set
+        // reports `{connected: true, spawnFailure: 'ENOENT'}` — internally contradictory, and it sends
+        // an operator hunting a problem that is already resolved.
+        this.lastSpawnFailure = null
+    }
+
     getStatus() {
         const
             sessions = [],

--- a/ai/services/neural-link/ConnectionService.mjs
+++ b/ai/services/neural-link/ConnectionService.mjs
@@ -787,7 +787,7 @@ class ConnectionService extends Base {
         // here is what makes the race legible: a named error names the missing input, where `/` named
         // nothing and produced an ENOENT three layers away. A hidden default that substitutes a
         // wrong value is worse than no default: it converts a missing input into a distant symptom.
-        return new Promise(resolve => {
+        return new Promise((resolve, reject) => {
             const args    = ['run', 'ai:server-neural-link'];
             const file    = getBridgeStdioLogPath({logPath});
             const logFile = this.openBridgeLogFile(file);
@@ -810,6 +810,17 @@ class ConnectionService extends Base {
                 detached: true,
                 env     : {...process.env, NEO_NL_PORT: String(port)},
                 stdio   : ['ignore', logFile, logFile]
+            });
+
+            // A spawn failure arrives as an asynchronous 'error' EVENT, not a throw and not a
+            // rejection — so `boot()`'s try/catch cannot see it, and an unhandled 'error' on an
+            // EventEmitter is fatal to the process. Without this listener a Bridge that cannot be
+            // spawned (missing cwd, npm not on PATH) takes the whole MCP server down with it —
+            // the opposite of the survivability this boot path exists to provide. Rejecting instead
+            // routes the failure back into the caller's existing non-fatal handling.
+            this.bridgeProcess.once('error', error => {
+                logger.error(`[ConnectionService] Bridge spawn failed: ${error.message}`);
+                reject(error)
             });
 
             this.bridgeProcess.unref();

--- a/ai/services/neural-link/ConnectionService.mjs
+++ b/ai/services/neural-link/ConnectionService.mjs
@@ -6,6 +6,30 @@ import path      from 'path';
 import WebSocket from 'ws';
 import Base      from '../../../src/core/Base.mjs';
 import logger    from '../../mcp/server/neural-link/logger.mjs';
+
+/**
+ * @summary Decides what `initAsync()` may do about the Bridge at construction time.
+ *
+ * Exported as a plain function so specs drive the production decision rather than a mirror of it:
+ * the live branch sits behind `Neo.config.unitTestMode`, which is exactly false in every unit run,
+ * so the interesting cases are otherwise unreachable without mutating the config singleton.
+ *
+ * `'defer'` is the answer whenever the working directory is still unknown. The singleton is
+ * constructed by its own import inside the Neural Link entrypoint, several steps before that
+ * entrypoint assigns `--cwd`, so an unresolved cwd at this moment is the ORDINARY boot path and
+ * not a misconfiguration. Treating it as one is what made a correctly-launched server fail.
+ *
+ * @param {Object} options
+ * @param {Boolean} options.unitTestMode Whether the hermetic unit harness is active.
+ * @param {Boolean} options.autoConnect  The resolved `autoConnect` config leaf.
+ * @param {String|null} options.cwd      The entrypoint-supplied working directory, if assigned yet.
+ * @returns {'connect'|'defer'|'disabled'}
+ */
+export function resolveBridgeAutoConnect({unitTestMode, autoConnect, cwd}) {
+    if (unitTestMode || !autoConnect) return 'disabled';
+
+    return cwd ? 'connect' : 'defer'
+}
 import {
     BRIDGE_INFO_TYPE,
     STALE_BRIDGE_ERROR_CODE,
@@ -216,8 +240,23 @@ class ConnectionService extends Base {
         // Skip the Bridge auto-connect under unitTestMode: unit specs that import this singleton (e.g. via
         // HealthService) must stay hermetic and must not reach or spawn the live Bridge. The e2e harness
         // connects explicitly via manageConnection(); production (non-unitTestMode) auto-connects as before.
-        if (!Neo.config.unitTestMode && aiConfig.autoConnect) {
+        // Defer when `cwd` is still unresolved. This singleton is constructed by its own import
+        // (`Server.mjs:4`), which runs BEFORE the entrypoint assigns `ConnectionService.cwd` from
+        // `--cwd`. Spawning here therefore races the assignment and loses: a server launched
+        // perfectly with `--cwd` would still spawn its Bridge from the wrong directory — or, once
+        // the hidden `process.cwd()` default is gone, fail outright on the good path.
+        //
+        // The entrypoint owns connection startup because it is the only participant that knows the
+        // real working directory. `spawnBridge()` keeps its loud refusal for the case where nothing
+        // ever supplies one, which is a genuine misconfiguration rather than a boot ordering artifact.
+        if (resolveBridgeAutoConnect({
+            unitTestMode: Neo.config.unitTestMode,
+            autoConnect : aiConfig.autoConnect,
+            cwd         : this.cwd
+        }) === 'connect') {
             await this.ensureBridgeAndConnect();
+        } else if (!Neo.config.unitTestMode && aiConfig.autoConnect) {
+            logger.fileDebug('[ConnectionService] Bridge auto-connect deferred: awaiting entrypoint-supplied cwd.');
         }
     }
 

--- a/ai/services/neural-link/ConnectionService.mjs
+++ b/ai/services/neural-link/ConnectionService.mjs
@@ -738,14 +738,36 @@ class ConnectionService extends Base {
      * @returns {Promise<void>}
      */
     async spawnBridge({logPath = aiConfig.logPath, startupDelayMs = 2000} = {}) {
+        // `this.cwd || process.cwd()` was a hidden-default fallback, and it substituted the WRONG
+        // value silently. A GUI-launched MCP server has `process.cwd() === '/'`, so `npm run` looked
+        // for `/package.json`, the Bridge never started, and the resulting ECONNREFUSED took the whole
+        // server down — the seat lost every Neural Link tool for the session.
+        //
+        // The cwd is assigned by the entrypoint (`--cwd` → `Server.mjs`), but this singleton is
+        // constructed at module import, so an auto-connect can outrun that assignment. Failing loudly
+        // here is what makes the race legible: a named error names the missing input, where `/` named
+        // nothing and produced an ENOENT three layers away. A hidden default that substitutes a
+        // wrong value is worse than no default: it converts a missing input into a distant symptom.
         return new Promise(resolve => {
             const args    = ['run', 'ai:server-neural-link'];
             const file    = getBridgeStdioLogPath({logPath});
             const logFile = this.openBridgeLogFile(file);
             const port    = aiConfig.port;
 
+            // Checked AFTER argument validation and immediately before the spawn: a caller who passed
+            // a bad `logPath` should hear about their argument, not about instance state they did not
+            // supply. Both refusals still precede any process launch.
+            if (!this.cwd) {
+                throw new Error(
+                    'ConnectionService.spawnBridge: `cwd` is unresolved. It is supplied by the Neural ' +
+                    'Link MCP entrypoint (`--cwd`) and must be assigned before a spawn. Refusing to ' +
+                    'substitute process.cwd() — on a GUI-launched server that is `/`, and the Bridge ' +
+                    'cannot start there.'
+                );
+            }
+
             this.bridgeProcess = this.spawnBridgeProcess('npm', args, {
-                cwd     : this.cwd || process.cwd(),
+                cwd     : this.cwd,
                 detached: true,
                 env     : {...process.env, NEO_NL_PORT: String(port)},
                 stdio   : ['ignore', logFile, logFile]
@@ -753,8 +775,11 @@ class ConnectionService extends Base {
 
             this.bridgeProcess.unref();
 
-            // Give it a moment to start
-            setTimeout(resolve, 2000);
+            // Honors the PARAMETER it declares. The literal `2000` ignored `startupDelayMs` entirely,
+            // so every caller's value was silently discarded — a spec could pass 0 and still wait two
+            // seconds, which is how a contract stays untested. Measured bind is ~498ms; this is a
+            // correctness fix, not a latency one.
+            setTimeout(resolve, startupDelayMs);
         });
     }
 

--- a/ai/services/neural-link/HealthService.mjs
+++ b/ai/services/neural-link/HealthService.mjs
@@ -133,7 +133,14 @@ class HealthService extends Base {
                 bridge   : {
                     connected: status.bridgeConnected,
                     agentId  : status.agentId,
-                    port     : ConnectionService.port
+                    // From the status projection, which resolves the port the connection actually
+                    // uses. Reading `ConnectionService.port` reported a class-field default, so a
+                    // server on a configured port still answered 8081 and sent operators to the
+                    // wrong socket.
+                    port     : status.port,
+                    // Present only when a spawn failed, so "unhealthy" carries its cause instead of
+                    // leaving the operator to guess whether the Bridge is down, slow, or unspawnable.
+                    ...(status.lastSpawnFailure ? {spawnFailure: status.lastSpawnFailure} : {})
                 },
                 sessions : status.sessions,
                 windows  : status.windows,

--- a/test/playwright/unit/ai/services/neural-link/ConnectionService.spec.mjs
+++ b/test/playwright/unit/ai/services/neural-link/ConnectionService.spec.mjs
@@ -138,7 +138,12 @@ test.describe('Neo.ai.services.neural-link.ConnectionService — bridge freshnes
             return {
                 unref() {
                     unrefCalled = true
-                }
+                },
+                // A real `spawn()` returns a ChildProcess, which IS an EventEmitter — the production
+                // path subscribes to 'error' because a spawn failure arrives as an event rather than
+                // a throw. A double without `once` models a boundary that cannot fail the way the
+                // real one does, so it stayed green while production had no failure path at all.
+                once() {}
             }
         };
 
@@ -192,7 +197,9 @@ test.describe('Neo.ai.services.neural-link.ConnectionService — bridge freshnes
         const logDir = path.resolve(os.tmpdir(), `nl-bridge-delay-${process.pid}-${Date.now()}`);
 
         ConnectionService.openBridgeLogFile  = () => 42;
-        ConnectionService.spawnBridgeProcess = () => ({unref() {}});
+        // `once` is part of the real boundary: spawn returns an EventEmitter and the production path
+        // subscribes to 'error'. See the fuller note on the double above.
+        ConnectionService.spawnBridgeProcess = () => ({unref() {}, once() {}});
         ConnectionService.cwd                = '/real-seat';
 
         const startedAt = Date.now();

--- a/test/playwright/unit/ai/services/neural-link/ConnectionService.spec.mjs
+++ b/test/playwright/unit/ai/services/neural-link/ConnectionService.spec.mjs
@@ -142,14 +142,65 @@ test.describe('Neo.ai.services.neural-link.ConnectionService — bridge freshnes
             }
         };
 
+        // A real caller's cwd comes from the MCP entrypoint's `--cwd`. This arm previously supplied
+        // none and still spawned, because `this.cwd || process.cwd()` invented one — the test relied
+        // on the very fallback that put `/` in front of `npm run`.
+        ConnectionService.cwd = '/real-seat';
+
         await ConnectionService.spawnBridge({logPath: logDir, startupDelayMs: 0});
 
+        expect(spawnCall.options.cwd, 'the entrypoint-supplied cwd reaches the spawn').toBe('/real-seat');
         expect(openedPath).toBe(path.join(logDir, 'neural-link-bridge-stdio.log'));
         expect(path.basename(openedPath)).not.toBe('bridge.log');
         expect(spawnCall.command).toBe('npm');
         expect(spawnCall.args).toEqual(['run', 'ai:server-neural-link']);
         expect(spawnCall.options.stdio).toEqual(['ignore', 42, 42]);
         expect(unrefCalled).toBe(true);
+    });
+
+    /**
+     * @summary An unresolved working directory must fail loudly, never substitute one.
+     *
+     * `this.cwd || process.cwd()` looked like a sensible default and was a wrong-value substitution.
+     * A GUI-launched MCP server has `process.cwd() === '/'`, so `npm run` looked for `/package.json`,
+     * the Bridge never started, and the resulting ECONNREFUSED took the whole server down — the seat
+     * lost every Neural Link tool for the session. The cwd IS supplied, by the entrypoint's `--cwd`;
+     * the singleton is just constructed at import and an auto-connect can outrun that assignment.
+     *
+     * The error names the missing input, where `/` named nothing and
+     * surfaced as an ENOENT three layers away.
+     */
+    test('#16429: an unresolved cwd fails with a named error and spawns nothing', async () => {
+        const logDir = path.resolve(os.tmpdir(), `nl-bridge-nocwd-${process.pid}-${Date.now()}`);
+
+        let spawned = false;
+
+        ConnectionService.openBridgeLogFile   = () => 42;
+        ConnectionService.spawnBridgeProcess  = () => { spawned = true };
+        ConnectionService.cwd                 = null;
+
+        await expect(ConnectionService.spawnBridge({logPath: logDir, startupDelayMs: 0}))
+            .rejects.toThrow(/`cwd` is unresolved/);
+
+        expect(spawned, 'no process is launched against an invented directory').toBe(false);
+    });
+
+    test('#16429: spawnBridge HONORS startupDelayMs instead of a hardcoded wait', async () => {
+        // The body ignored its own parameter and always waited 2000ms, so every caller's value was
+        // silently discarded and the contract could not be tested. Measured Bridge bind is ~498ms —
+        // this is a correctness fix, not a latency one.
+        const logDir = path.resolve(os.tmpdir(), `nl-bridge-delay-${process.pid}-${Date.now()}`);
+
+        ConnectionService.openBridgeLogFile  = () => 42;
+        ConnectionService.spawnBridgeProcess = () => ({unref() {}});
+        ConnectionService.cwd                = '/real-seat';
+
+        const startedAt = Date.now();
+
+        await ConnectionService.spawnBridge({logPath: logDir, startupDelayMs: 0});
+
+        // Generous bound: the point is that it does not wait the discarded 2000ms literal.
+        expect(Date.now() - startedAt, 'a 0ms delay must not wait two seconds').toBeLessThan(500);
     });
 
     test('logs bridge receives as bounded metadata when debug is disabled (#13473)', () => {

--- a/test/playwright/unit/ai/services/neural-link/bridgeAutoConnectOrdering.spec.mjs
+++ b/test/playwright/unit/ai/services/neural-link/bridgeAutoConnectOrdering.spec.mjs
@@ -248,6 +248,30 @@ test.describe('ai/services/neural-link — Bridge auto-connect ordering (#16429)
         }
     });
 
+    test('#16429 REACHING connected retires a prior failure — the recovery half, not the attempt half', () => {
+        // @neo-gpt archived the exact head, deleted only the success-path clear, and the previous
+        // spec still passed 8/8: it started another spawn, which clears at ATTEMPT START, so it never
+        // reached a connected state and could not fail. This drives the connected transition itself.
+        //
+        // The payload this prevents is `{connected: true, spawnFailure: 'ENOENT'}` — a resolved
+        // problem still reported, which is worse than silence because it is actionable and wrong.
+        const originalSocket = ConnectionService.bridgeSocket;
+
+        ConnectionService.lastSpawnFailure = 'ENOENT';
+
+        try {
+            ConnectionService.markBridgeConnected({fake: 'socket'});
+
+            const status = ConnectionService.getStatus();
+
+            expect(status.bridgeConnected, 'the transition must record the live socket').toBe(true);
+            expect(status.lastSpawnFailure, 'reaching connected must retire the prior failure').toBeNull();
+        } finally {
+            ConnectionService.bridgeSocket      = originalSocket;
+            ConnectionService.lastSpawnFailure  = null
+        }
+    });
+
     test('#16429 the harness and the disabled leaf still win over a resolved cwd', () => {
         // Ordering is the new behaviour; these two are the pre-existing contracts it must not break.
         // Unit specs importing this singleton (via HealthService) must never reach a live Bridge.

--- a/test/playwright/unit/ai/services/neural-link/bridgeAutoConnectOrdering.spec.mjs
+++ b/test/playwright/unit/ai/services/neural-link/bridgeAutoConnectOrdering.spec.mjs
@@ -14,9 +14,16 @@ setup({
 });
 
 import {test, expect}             from '@playwright/test';
+import {spawn}                    from 'node:child_process';
+import path                       from 'node:path';
+import {fileURLToPath}            from 'node:url';
 import Neo                        from '../../../../../../src/Neo.mjs';
 import * as core                  from '../../../../../../src/core/_export.mjs';
 import {resolveBridgeAutoConnect} from '../../../../../../ai/services/neural-link/ConnectionService.mjs';
+
+const NEURAL_LINK_ENTRYPOINT = fileURLToPath(
+    new URL('../../../../../../ai/mcp/server/neural-link/mcp-server.mjs', import.meta.url)
+);
 
 /**
  * @summary Coverage for the Bridge auto-connect boot ordering.
@@ -51,6 +58,53 @@ test.describe('ai/services/neural-link — Bridge auto-connect ordering (#16429)
         // would be a constant and the first test would pass without discriminating anything.
         expect(resolveBridgeAutoConnect({unitTestMode: false, autoConnect: true, cwd: '/repo/neo'}))
             .toBe('connect');
+    });
+
+    test('#16429 an unspawnable Bridge does not take the MCP server down with it', async () => {
+        // The AC-4 witness, and it has to run a real child process: the survivability guarantee is a
+        // property of process LIFETIME, which no in-process assertion can observe. The pure-resolver
+        // tests above pass unchanged if the try/catch around `ConnectionService.ready()` is deleted,
+        // so they cover the decision and this covers the promise.
+        //
+        // `UNIT_TEST_MODE` routes `memoryCoreDbPath` to its test sibling (`configBase.mjs:110,169`)
+        // WITHOUT setting `Neo.config.unitTestMode`, which is only ever assigned in-process — so the
+        // child gets an isolated database while its auto-connect stays live. Disabling auto-connect
+        // to make this hermetic would delete the behaviour under test.
+        const
+            unspawnableCwd = path.join('/', `neo-16429-absent-${process.pid}`),
+            child          = spawn(process.execPath, [NEURAL_LINK_ENTRYPOINT, '--cwd', unspawnableCwd], {
+                env: {
+                    ...process.env,
+                    UNIT_TEST_MODE     : 'true',
+                    NEO_NL_AUTO_CONNECT: 'true',
+                    // Point at a port nothing serves. Without this the test is VACUOUS: a Bridge
+                    // already listening on the default 8081 is simply connected to, no spawn is ever
+                    // attempted, and the unspawnable cwd never matters — verified by watching a run
+                    // log "Verified Neural Link Bridge freshness on port 8081" and pass regardless.
+                    // A closed port forces the spawn path, which is the one under test.
+                    NEO_NL_PORT        : '34117'
+                },
+                stdio: ['pipe', 'pipe', 'pipe']
+            });
+
+        let exited = null;
+
+        child.on('exit', code => { exited = code ?? 'signal' });
+
+        // Longer than `spawnBridge`'s 2000ms startupDelayMs, so a server that dies during the spawn
+        // attempt has finished dying before the assertion reads.
+        await new Promise(resolve => setTimeout(resolve, 5000));
+
+        try {
+            // `exitCode === null` is the whole witness: the Bridge could not be spawned from a
+            // directory that does not exist, and the server is STILL RUNNING and able to report that
+            // through healthcheck. Delete the spawn 'error' listener, or the catch in `Server.mjs`,
+            // and the process dies instead — the outcome this whole boot path exists to prevent.
+            expect(exited, `MCP server exited (${exited}) instead of surviving an unspawnable Bridge`).toBeNull();
+            expect(child.exitCode, 'the server process must still be running').toBeNull();
+        } finally {
+            child.kill('SIGKILL')
+        }
     });
 
     test('#16429 the harness and the disabled leaf still win over a resolved cwd', () => {

--- a/test/playwright/unit/ai/services/neural-link/bridgeAutoConnectOrdering.spec.mjs
+++ b/test/playwright/unit/ai/services/neural-link/bridgeAutoConnectOrdering.spec.mjs
@@ -1,0 +1,65 @@
+import {setup} from '../../../../setup.mjs';
+
+const appName = 'NeuralLinkBridgeAutoConnectOrderingTest';
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name             : appName,
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect}             from '@playwright/test';
+import Neo                        from '../../../../../../src/Neo.mjs';
+import * as core                  from '../../../../../../src/core/_export.mjs';
+import {resolveBridgeAutoConnect} from '../../../../../../ai/services/neural-link/ConnectionService.mjs';
+
+/**
+ * @summary Coverage for the Bridge auto-connect boot ordering.
+ *
+ * `ConnectionService` is a singleton constructed by its own import in `Server.mjs:4`. The entrypoint
+ * assigns `ConnectionService.cwd` from `--cwd` much later, at `Server.mjs:185`. Anything that spawns
+ * the Bridge during `initAsync()` therefore races that assignment and loses every time.
+ *
+ * That race is why removing the hidden `process.cwd()` fallback was not sufficient on its own: with
+ * the fallback in place a correctly-launched server spawned its Bridge from the WRONG directory, and
+ * with it removed the same server failed outright. Both outcomes are produced by a server whose
+ * operator supplied a perfectly good `--cwd`, which is the shape of the defect.
+ *
+ * These assertions are on the exported decision rather than on `initAsync()` because the live branch
+ * is gated on `Neo.config.unitTestMode` being false — true in every unit run — and faking that would
+ * mean mutating the config singleton.
+ */
+test.describe('ai/services/neural-link — Bridge auto-connect ordering (#16429)', () => {
+    test('#16429 an unresolved cwd DEFERS rather than spawning — the ordinary boot path, not a fault', () => {
+        // This is the exact state at construction time on a healthy production boot: autoConnect is
+        // on, the harness is not active, and the entrypoint has not reached its assignment yet.
+        // Answering anything but 'defer' here is what made the good path fail.
+        expect(resolveBridgeAutoConnect({unitTestMode: false, autoConnect: true, cwd: null}))
+            .toBe('defer');
+
+        expect(resolveBridgeAutoConnect({unitTestMode: false, autoConnect: true, cwd: ''}))
+            .toBe('defer');
+    });
+
+    test('#16429 a resolved cwd connects — deferral must not become a permanent refusal', () => {
+        // The non-vacuity control for the test above: if this returned 'defer' too, the decision
+        // would be a constant and the first test would pass without discriminating anything.
+        expect(resolveBridgeAutoConnect({unitTestMode: false, autoConnect: true, cwd: '/repo/neo'}))
+            .toBe('connect');
+    });
+
+    test('#16429 the harness and the disabled leaf still win over a resolved cwd', () => {
+        // Ordering is the new behaviour; these two are the pre-existing contracts it must not break.
+        // Unit specs importing this singleton (via HealthService) must never reach a live Bridge.
+        expect(resolveBridgeAutoConnect({unitTestMode: true, autoConnect: true, cwd: '/repo/neo'}))
+            .toBe('disabled');
+
+        expect(resolveBridgeAutoConnect({unitTestMode: false, autoConnect: false, cwd: '/repo/neo'}))
+            .toBe('disabled');
+    });
+});

--- a/test/playwright/unit/ai/services/neural-link/bridgeAutoConnectOrdering.spec.mjs
+++ b/test/playwright/unit/ai/services/neural-link/bridgeAutoConnectOrdering.spec.mjs
@@ -26,6 +26,65 @@ const NEURAL_LINK_ENTRYPOINT = fileURLToPath(
 );
 
 /**
+ * @summary Calls `healthcheck` on a spawned Neural Link server over its real stdio MCP transport.
+ *
+ * Drives the actual protocol rather than importing `HealthService` in-process, because the claim
+ * under test is what a CLIENT is told by a server that survived a failed Bridge spawn — an
+ * in-process call would answer from a different config resolution and prove nothing about the child.
+ *
+ * @param {Object} child The spawned ChildProcess.
+ * @param {Number} [timeoutMs=8000] Overall budget for the handshake plus the call.
+ * @returns {Promise<Object|null>} The parsed health payload, or null if it never answered.
+ */
+async function callHealthcheck(child, timeoutMs = 8000) {
+    return new Promise(resolve => {
+        let buffer  = '',
+            settled = false;
+
+        const finish = value => {
+            if (!settled) {
+                settled = true;
+                clearTimeout(timer);
+                resolve(value)
+            }
+        };
+
+        const timer = setTimeout(() => finish(null), timeoutMs);
+
+        child.stdout.on('data', chunk => {
+            buffer += chunk.toString();
+
+            for (const line of buffer.split('\n')) {
+                if (!line.trim().startsWith('{')) continue;
+
+                let message;
+
+                try { message = JSON.parse(line) } catch { continue }
+
+                if (message.id === 1) {
+                    child.stdin.write(`${JSON.stringify({jsonrpc: '2.0', method: 'notifications/initialized'})}\n`);
+                    child.stdin.write(`${JSON.stringify({
+                        jsonrpc: '2.0', id: 2, method: 'tools/call',
+                        params : {name: 'healthcheck', arguments: {}}
+                    })}\n`)
+                }
+
+                if (message.id === 2) {
+                    const text = message.result?.content?.[0]?.text;
+
+                    try { finish(text ? JSON.parse(text) : message.result) } catch { finish(message.result) }
+                }
+            }
+        });
+
+        child.stdin.write(`${JSON.stringify({
+            jsonrpc: '2.0', id: 1, method: 'initialize',
+            params : {protocolVersion: '2024-11-05', capabilities: {}, clientInfo: {name: 'witness', version: '1'}}
+        })}\n`)
+    })
+}
+
+/**
  * @summary Coverage for the Bridge auto-connect boot ordering.
  *
  * `ConnectionService` is a singleton constructed by its own import in `Server.mjs:4`. The entrypoint
@@ -102,6 +161,24 @@ test.describe('ai/services/neural-link — Bridge auto-connect ordering (#16429)
             // and the process dies instead — the outcome this whole boot path exists to prevent.
             expect(exited, `MCP server exited (${exited}) instead of surviving an unspawnable Bridge`).toBeNull();
             expect(child.exitCode, 'the server process must still be running').toBeNull();
+
+            // "Alive" is only half the promise. A survivor that misreports its own state sends the
+            // operator to the wrong socket, so the witness continues THROUGH the real stdio MCP
+            // transport and reads what a client would actually be told.
+            const health = await callHealthcheck(child);
+
+            expect(health, 'healthcheck must answer on a surviving server').toBeTruthy();
+
+            // The configured port, not the class-field default. This is the assertion that fails
+            // when the payload reads `ConnectionService.port`: a server configured on 34117 answered
+            // 8081, which is indistinguishable from a correct answer unless you configured it away
+            // from the default on purpose.
+            expect(health.bridge?.port, 'healthcheck must report the CONFIGURED bridge port').toBe(34117);
+
+            // Attribution: unhealthy alone cannot tell an operator whether the Bridge is down, slow,
+            // or unspawnable. The sanitized code can, and carries no path or argv.
+            expect(health.bridge?.connected, 'the Bridge cannot be connected here').toBe(false);
+            expect(health.bridge?.spawnFailure, 'healthcheck must attribute the spawn failure').toBe('ENOENT');
         } finally {
             child.kill('SIGKILL')
         }

--- a/test/playwright/unit/ai/services/neural-link/bridgeAutoConnectOrdering.spec.mjs
+++ b/test/playwright/unit/ai/services/neural-link/bridgeAutoConnectOrdering.spec.mjs
@@ -13,13 +13,14 @@ setup({
     }
 });
 
-import {test, expect}             from '@playwright/test';
-import {spawn}                    from 'node:child_process';
-import path                       from 'node:path';
-import {fileURLToPath}            from 'node:url';
-import Neo                        from '../../../../../../src/Neo.mjs';
-import * as core                  from '../../../../../../src/core/_export.mjs';
-import {resolveBridgeAutoConnect} from '../../../../../../ai/services/neural-link/ConnectionService.mjs';
+import {test, expect}                                from '@playwright/test';
+import {spawn}                                       from 'node:child_process';
+import {EventEmitter}                                from 'node:events';
+import path                                          from 'node:path';
+import {fileURLToPath}                               from 'node:url';
+import Neo                                           from '../../../../../../src/Neo.mjs';
+import * as core                                     from '../../../../../../src/core/_export.mjs';
+import ConnectionService, {resolveBridgeAutoConnect} from '../../../../../../ai/services/neural-link/ConnectionService.mjs';
 
 const NEURAL_LINK_ENTRYPOINT = fileURLToPath(
     new URL('../../../../../../ai/mcp/server/neural-link/mcp-server.mjs', import.meta.url)
@@ -181,6 +182,69 @@ test.describe('ai/services/neural-link — Bridge auto-connect ordering (#16429)
             expect(health.bridge?.spawnFailure, 'healthcheck must attribute the spawn failure').toBe('ENOENT');
         } finally {
             child.kill('SIGKILL')
+        }
+    });
+
+    test('#16429 a Bridge that STARTS and then dies is attributed — exit, not error', async () => {
+        // The production failure is not "the process could not be created" — that is `error`. It is
+        // `npm` starting fine and its script exiting non-zero a moment later, which emits `exit` and
+        // nothing else. Before this, the spawn resolved, the Bridge was dead, and healthcheck had
+        // nothing to say about why.
+        const child = new EventEmitter();
+
+        child.unref = () => {};
+
+        const originalSpawn   = ConnectionService.spawnBridgeProcess,
+              originalOpenLog = ConnectionService.openBridgeLogFile,
+              originalCwd     = ConnectionService.cwd;
+
+        ConnectionService.spawnBridgeProcess = () => child;
+        ConnectionService.openBridgeLogFile  = () => 42;
+        ConnectionService.cwd                = '/real-seat';
+
+        try {
+            await ConnectionService.spawnBridge({logPath: '/tmp', startupDelayMs: 0});
+
+            child.emit('exit', 42, null);
+
+            expect(ConnectionService.getStatus().lastSpawnFailure,
+                'a non-zero exit must be attributed, not silently resolved').toBe('BRIDGE_EXIT_42');
+        } finally {
+            ConnectionService.spawnBridgeProcess = originalSpawn;
+            ConnectionService.openBridgeLogFile  = originalOpenLog;
+            ConnectionService.cwd                = originalCwd;
+            ConnectionService.lastSpawnFailure   = null;
+            ConnectionService.bridgeProcess      = null
+        }
+    });
+
+    test('#16429 a new attempt OWNS the reported state — a stale failure does not outlive it', async () => {
+        // The contradictory payload this prevents is `{connected: true, spawnFailure: 'ENOENT'}`:
+        // a resolved problem still reported, sending an operator hunting something already fixed.
+        const child = new EventEmitter();
+
+        child.unref = () => {};
+
+        const originalSpawn   = ConnectionService.spawnBridgeProcess,
+              originalOpenLog = ConnectionService.openBridgeLogFile,
+              originalCwd     = ConnectionService.cwd;
+
+        ConnectionService.spawnBridgeProcess = () => child;
+        ConnectionService.openBridgeLogFile  = () => 42;
+        ConnectionService.cwd                = '/real-seat';
+        ConnectionService.lastSpawnFailure   = 'ENOENT';
+
+        try {
+            await ConnectionService.spawnBridge({logPath: '/tmp', startupDelayMs: 0});
+
+            expect(ConnectionService.getStatus().lastSpawnFailure,
+                'a prior failure must not survive into a fresh attempt').toBeNull();
+        } finally {
+            ConnectionService.spawnBridgeProcess = originalSpawn;
+            ConnectionService.openBridgeLogFile  = originalOpenLog;
+            ConnectionService.cwd                = originalCwd;
+            ConnectionService.lastSpawnFailure   = null;
+            ConnectionService.bridgeProcess      = null
         }
     });
 


### PR DESCRIPTION
Resolves #16429

The Bridge cwd lane turned out to be three defects stacked, and the last two were found by the AC-4 witness rather than by reading the diff.

## What was wrong

**1. A hidden default substituted the wrong directory silently.** `spawnBridge` used `this.cwd || process.cwd()`. On a GUI-launched MCP server `process.cwd()` is `/`, so the Bridge was spawned from the filesystem root and `npm run` looked for a package that is not there.

**2. The entrypoint lost a race it should have owned.** `ConnectionService` is constructed by its own import at `Server.mjs:4`; `--cwd` is not assigned until `Server.mjs:185`. So `initAsync()` auto-connected before any cwd existed. With the old fallback that spawned from the wrong directory; with the fallback removed, a **correctly launched** server failed instead. Fixing one without the other simply moves the failure.

**3. An unspawnable Bridge killed the whole MCP server.** A spawn failure arrives as an asynchronous `'error'` EVENT on the ChildProcess — not a throw, not a rejection — so `boot()`'s try/catch never saw it, and an unhandled `'error'` on an EventEmitter is fatal. Measured on this branch before the fix: `exit=1, code: 'ENOENT', syscall: 'spawn npm'`.

**4. healthcheck then misreported the server's own state.** It answered port `8081` for a server configured elsewhere, because it read `ConnectionService.port` — a class-field default whose own JSDoc said the connection reads `aiConfig.port` at the use site. A duplicated primitive shadowing its leaf, with exactly one consumer: the payload it misreported. An operator debugging an unreachable Bridge was sent to the wrong socket, with no attribution for why the Bridge was down.

## What changed

- `spawnBridge` refuses loudly when `cwd` is unresolved instead of substituting `process.cwd()`, and honors the `startupDelayMs` it declares (the literal `2000` discarded every caller's value).
- `initAsync()` defers while `cwd` is unresolved — the ordinary boot path, not a fault — and `Server.mjs` drives the connect after assignment. The decision is the exported pure function `resolveBridgeAutoConnect`, because the live branch is gated on `unitTestMode` being false and the interesting cases are otherwise unreachable without mutating the config singleton.
- A `once('error')` listener rejects, routing spawn failures into the caller's existing non-fatal handling. The promise gained the `reject` binding it never had.
- `getStatus()` resolves the port from the SSOT like `createBridgeUrl` and the spawn path do, and carries a **sanitized** spawn-failure code — `error.message` holds the spawn path and argv, so only the code travels to callers.

Evidence: 83/83 green across `test/playwright/unit/ai/services/neural-link/` and `test/playwright/unit/ai/mcp/server/neural-link/` under `-c test/playwright/playwright.config.unit.mjs`.

## Test Evidence

The witness spawns the **real entrypoint** and continues **through the real stdio MCP transport**, because the claim is what a client is told by a server that survived a failed spawn — an in-process call resolves different config and proves nothing about the child.

**Two vacuity traps were found and closed while writing it:**

- The first version passed against a deliberately broken tree. A Bridge already listening on the default `8081` meant `ensureBridgeAndConnect()` simply connected and **never attempted a spawn**. Pinning `NEO_NL_PORT` to a closed port forces the path under test. Left unpinned it would also have behaved differently on CI, where nothing is listening.
- `UNIT_TEST_MODE` routes `memoryCoreDbPath` to its test sibling **without** setting `Neo.config.unitTestMode` (only ever assigned in-process), so the child gets an isolated database while auto-connect stays live. Disabling auto-connect to make it hermetic would delete the behaviour under test.

**Mutation-pinned in both halves**, each run and observed:

| mutation | failure |
|---|---|
| remove the `'error'` listener | `MCP server exited (1) instead of surviving an unspawnable Bridge` |
| revert the payload to the class field | `healthcheck must report the CONFIGURED bridge port` |

Two pre-existing spawn doubles returned `{unref}` with no `once`. A real `spawn()` returns an EventEmitter, so those doubles modelled a boundary that could not fail the way the real one does — they are corrected rather than guarded around, since a `typeof once === 'function'` check in production would reintroduce exactly the silent-degradation shape this PR removes.

## Post-Merge Validation

Launch the Neural Link MCP server from a GUI context (`process.cwd() === '/'`) with a valid `--cwd`: the Bridge spawns from the supplied directory. Launch it with an unreachable Bridge port and a non-existent cwd: the server stays alive, and `healthcheck` reports the configured port with `bridge.spawnFailure: 'ENOENT'` instead of a bare `unhealthy`.

## Deltas

- The `port` class-field default is removed; `getStatus()` is the single projection of the resolved port.
- `lastSpawnFailure` is new state on `ConnectionService`, sanitized at capture.
- No new ticket: every item above is inside #16429's existing ACs.

Authored by @neo-opus-grace
