### PR TITLE
docs(orchestrator): separate the saturation subject from its demand disposition (#16886)

### DIFF
--- a/ai/daemons/orchestrator/services/ContainerHealthDiagnosisService.mjs
+++ b/ai/daemons/orchestrator/services/ContainerHealthDiagnosisService.mjs
@@ -1693,27 +1693,60 @@ export function calculateDockerMemoryPercent(stats) {
  *   while idle and spawns a CPU-dominating runner under load — four cores' worth, sustained, with no
  *   client sockets left open. It satisfies the premise exactly when no CPU fact can fire, and violates
  *   it exactly when one can.
- * - **And the misattribution is real on this arm, not merely possible.** A CPU-only deployment was
- *   measured holding `cpuPercent: 399.4` on that container while its access log over the sampled window
- *   carried **only** health polling — `/api/ps`, `/api/tags`, `HEAD /` — and no inference endpoint at
- *   all. So the compose-declared server was idle, a runner process consumed four cores, and the
- *   container-wide figure spoke for neither. **`authoritative: true` was granted throughout.** The
- *   scheduled-job case that motivated the CPU slice was a *foreign* workload sharing a container; this
- *   is the service's own process doing work no client awaits, which is a different route to the same
- *   wrong subject. **The non-Node arm carries this gap unrepaired.** It is left as it was because
- *   withdrawing authority here needs process-cardinality evidence that does not exist in the tree yet,
- *   and inventing a second proxy to fix the first is how this defect was built.
+ * - **And an unaccounted CPU claim is real on this arm, not merely possible.** A CPU-only deployment
+ *   was measured holding `cpuPercent: 399.4` on that container while its access log over the sampled
+ *   window carried **only** health polling — `/api/ps`, `/api/tags`, `HEAD /` — and no inference
+ *   endpoint at all. **`authoritative: true` was granted throughout.** The scheduled-job case that
+ *   motivated the CPU slice was a *foreign* workload sharing a container; this is the service's own
+ *   process doing work no client awaits. **The non-Node arm carries this gap unrepaired**, because
+ *   closing it needs a per-process CPU reading that no producer in the tree emits, and inventing a
+ *   second proxy to fix the first is how this defect was built.
+ *
+ * **THREE AXES, and collapsing any two of them is how the previous revision of this block went wrong.**
+ * The receipt above answers the third question and was read as answering the first:
+ *
+ * 1. **Observation subject — always exact.** The Docker ratio describes the resolved container, and
+ *    `DeploymentRuntimeAccessService` verifies its `com.docker.compose.service` label before acting.
+ *    There is no ambiguity here and never was.
+ * 2. **Work ownership — who the running process belongs to.** A runner spawned by the model server is
+ *    that Compose service's **own** process. It does not become foreign because nobody is waiting for
+ *    it. A forked scheduled job in a Node service is the genuinely foreign case, and it is a different
+ *    thing entirely.
+ * 3. **Demand disposition — whether current work is accounted for.** Accounted, residual after a client
+ *    disconnect, stale, or unknown.
+ *
+ * *"No inference arrived in the sampled window"* answers **3** only. An earlier revision concluded from
+ * it that the container-wide figure *"spoke for neither"* the service nor the runner — collapsing 3
+ * into 1. It does not follow, and it is retired here: the subject was correct throughout. What the
+ * receipt establishes is **unexplained residual provider demand owned by that service**, which is a
+ * disposition problem, not an attribution one. That distinction decides the repair: a residual-demand
+ * problem is answered by accounting, and only an ownership problem would need process cardinality.
+ *
+ * **The mechanism class is now measured, though not for this specimen.** Ollama at tag `v0.23.1` logs
+ * `"aborting embedding request due to client closing the connection"` only when the admission semaphore
+ * acquire is cancelled — *pre-admission*. Once admitted, the handler waits on its result and never
+ * re-checks the request context, so **admitted work survives client disconnect**; a request was observed
+ * completing after 1h6m and then failing to write its reply (`broken pipe`) with nobody attached. That
+ * is a service-owned process burning cores with no arriving traffic — axis 2 owned, axis 3 residual —
+ * exactly the shape this block describes. **It does not establish the origin of the historical
+ * specimen above**, which was a different plane on a different day and stays bounded as recorded.
  *
  * **Latent, with no live instance:** `commandText` reads `Config.Cmd` and never `Config.Entrypoint`, so
  * a Node service whose `node` token sits in the entrypoint would read `false` — gaining container
  * authority and losing heap observation in one step. Every service on the canonical plane was checked;
  * all four Node services carry the token in `Config.Cmd`. Recorded because the layout invites one.
  *
- * **Retirement trigger:** runner/process-aware evidence for the containerized model service replaces
- * the proxy with an observation of the thing the rule actually needs. When that lands, this proxy
- * paragraph and its three bullets go with it.
- * @see https://github.com/neomjs/neo/issues/16830 — the evidence lane that retires the proxy
- * @see https://github.com/neomjs/neo/issues/16877 — this fold
+ * **Retirement trigger, corrected.** An earlier revision promised that the residual-load lane would
+ * supply runner/process-cardinality evidence and retire this proxy. It did not, and could not: what
+ * shipped is exact-container CPU bound to one incarnation, expected-model residency, recorder-owned
+ * provider activity, and a last-boundary demand veto — all of which sharpen **disposition** (axis 3)
+ * and none of which attribute CPU to a process. **This proxy is therefore retired only by a
+ * process-scoped CPU producer** — a per-process reading beside the existing `processHeapObservation`
+ * channel, which today publishes `rssBytes` and V8 fields and nothing about CPU time. Until such a
+ * producer exists, the gate stays a proxy and this paragraph stays with it.
+ * @see https://github.com/neomjs/neo/issues/16830 — the residual-demand lane; sharpens disposition, not attribution
+ * @see https://github.com/neomjs/neo/issues/16877 — the proxy fold
+ * @see https://github.com/neomjs/neo/issues/16886 — the three-axis separation
  *
  * **Where they deliberately differ, and why — this is the part that must stay written down together:**
  *

--- a/ai/daemons/orchestrator/services/ContainerHealthDiagnosisService.mjs
+++ b/ai/daemons/orchestrator/services/ContainerHealthDiagnosisService.mjs
@@ -1722,14 +1722,22 @@ export function calculateDockerMemoryPercent(stats) {
  * disposition problem, not an attribution one. That distinction decides the repair: a residual-demand
  * problem is answered by accounting, and only an ownership problem would need process cardinality.
  *
- * **The mechanism class is now measured, though not for this specimen.** Ollama at tag `v0.23.1` logs
- * `"aborting embedding request due to client closing the connection"` only when the admission semaphore
- * acquire is cancelled — *pre-admission*. Once admitted, the handler waits on its result and never
- * re-checks the request context, so **admitted work survives client disconnect**; a request was observed
- * completing after 1h6m and then failing to write its reply (`broken pipe`) with nobody attached. That
- * is a service-owned process burning cores with no arriving traffic — axis 2 owned, axis 3 residual —
- * exactly the shape this block describes. **It does not establish the origin of the historical
- * specimen above**, which was a different plane on a different day and stays bounded as recorded.
+ * **One residual-demand specimen has been observed, and its bounds are the point.** Two facts, kept
+ * separate because merging them is how this paragraph previously overstated itself:
+ *
+ * - **Source, at tag `v0.23.1`:** the log line `"aborting embedding request due to client closing the
+ *   connection"` is emitted only where the admission semaphore acquire is cancelled — it is a
+ *   **pre-admission** signal. So that line's presence says nothing about admitted work either way.
+ * - **Observation, once:** an admitted request completed after 1h6m and then failed to write its reply
+ *   (`broken pipe`), meaning the reply socket was closed by then. **The disconnect point was not
+ *   observed** — only that the request ran to completion and had no reader at the end.
+ *
+ * Together those establish that **a service-owned process can burn cores with no arriving traffic** —
+ * axis 2 owned, axis 3 residual, the shape this block describes. They do **not** establish a universal
+ * rule that admitted work always survives a disconnect, and an earlier revision of this paragraph
+ * asserted exactly that from the source read alone; it is retired here. Nor does any of it establish
+ * the origin of the historical 399.4% specimen above, which was a different plane on a different day
+ * and stays bounded as recorded.
  *
  * **Latent, with no live instance:** `commandText` reads `Config.Cmd` and never `Config.Entrypoint`, so
  * a Node service whose `node` token sits in the entrypoint would read `false` — gaining container

--- a/test/playwright/unit/ai/daemons/orchestrator/services/ContainerHealthDiagnosisService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/ContainerHealthDiagnosisService.spec.mjs
@@ -152,9 +152,9 @@ function sustainedOllamaResidualInputs(overrides = {}) {
             statsSample({cpuPercent: 398, observedAtMs: OBSERVED_AT - 30_000, containerId: 'local-model-A'}),
             statsSample({cpuPercent: 399, observedAtMs: OBSERVED_AT, containerId: 'local-model-A'})
         ],
-        runtimeContainerId: 'local-model-A',
-        providerResidency : ollamaResidency(),
-        providerActivity  : providerActivity(),
+        runtimeContainerId       : 'local-model-A',
+        providerResidency        : ollamaResidency(),
+        providerActivity         : providerActivity(),
         providerResidencyEligible: true,
         ...overrides
     };
@@ -663,7 +663,7 @@ test.describe('Neo.ai.daemons.services.ContainerHealthDiagnosisService', () => {
                   ollamaHost: 'http://model:12000'
               }),
               decision = service.diagnose(sustainedOllamaResidualInputs({
-                  serviceKey: 'model',
+                  serviceKey  : 'model',
                   statsSamples: [
                       statsSample({cpuPercent: 398, observedAtMs: OBSERVED_AT - 30_000, containerId: 'model-A'}),
                       statsSample({cpuPercent: 399, observedAtMs: OBSERVED_AT, containerId: 'model-A'})
@@ -684,7 +684,7 @@ test.describe('Neo.ai.daemons.services.ContainerHealthDiagnosisService', () => {
                   ollamaHost: 'http://local-model:12000'
               }),
               decision = service.diagnose(sustainedOllamaResidualInputs({
-                  serviceKey: 'model',
+                  serviceKey  : 'model',
                   statsSamples: [
                       statsSample({cpuPercent: 398, observedAtMs: OBSERVED_AT - 30_000, containerId: 'model-A'}),
                       statsSample({cpuPercent: 399, observedAtMs: OBSERVED_AT, containerId: 'model-A'})
@@ -708,14 +708,14 @@ test.describe('Neo.ai.daemons.services.ContainerHealthDiagnosisService', () => {
                   ollamaHost: 'http://shadow-model:12000'
               }),
               decision = service.diagnose(sustainedOllamaResidualInputs({
-                  serviceKey: 'shadow-model',
+                  serviceKey  : 'shadow-model',
                   statsSamples: [
                       statsSample({cpuPercent: 398, observedAtMs: OBSERVED_AT - 30_000, containerId: 'shadow-A'}),
                       statsSample({cpuPercent: 399, observedAtMs: OBSERVED_AT, containerId: 'shadow-A'})
                   ],
-                  runtimeContainerId: 'shadow-A',
+                  runtimeContainerId       : 'shadow-A',
                   providerResidencyEligible: false,
-                  providerResidency : ollamaResidency({
+                  providerResidency        : ollamaResidency({
                       host          : 'http://shadow-model:12000',
                       targetIdentity: {kind: 'compose-service', id: 'shadow-model'}
                   })
@@ -2230,6 +2230,48 @@ test.describe('cpu saturation names its subject', () => {
             .not.toContain('only when the container has no other processes');
         // A proxy without a retirement condition is a permanent shortcut wearing a temporary label.
         expect(block).toContain('Retirement trigger');
+    });
+
+    test('the subject rule keeps attribution and demand disposition as SEPARATE axes', () => {
+        // The defect this guards is a collapse, not an omission: an earlier revision reasoned from "no
+        // inference arrived in the sampled window" (a DISPOSITION fact) to "the container-wide figure
+        // spoke for neither" (an ATTRIBUTION claim). A runner spawned by the model server is that
+        // Compose service's own process; it does not become foreign because nobody awaits it. Structural
+        // only — it asserts what the contract says, which is the honest instrument for a prose defect.
+        const
+            source     = fs.readFileSync(
+                path.join(repoRoot, 'ai/daemons/orchestrator/services/ContainerHealthDiagnosisService.mjs'), 'utf8'),
+            sharedRule = source.indexOf('The saturation-SUBJECT rule, stated once for both metrics'),
+            block      = source
+                .slice(sharedRule, source.indexOf('MEMORY_SATURATION_SCOPES = Object.freeze', sharedRule))
+                .replace(/\n\s*\*\s?/g, ' ')
+                .replace(/\s+/g, ' ');
+
+        // All three axes named, and named as axes — two of them stated without the third is the
+        // shape that reads as complete while leaving the collapse expressible.
+        expect(block).toContain('THREE AXES');
+        expect(block).toContain('Observation subject');
+        expect(block).toContain('Work ownership');
+        expect(block).toContain('Demand disposition');
+
+        // The service-owned runner is the load-bearing sentence: it is what makes the receipt a
+        // disposition finding rather than an attribution one.
+        expect(block, 'a service-owned runner must not be called foreign for lack of arriving work')
+            .toContain('It does not become foreign because nobody is waiting for it');
+
+        // Retain-and-mark: the retired conclusion stays VISIBLE so a reader who remembers it is sent
+        // to the correction, but it must never read as a live claim again. The retired form carries
+        // markdown quoting, so the bare assertion below cannot match it.
+        expect(block).toContain('collapsing 3 into 1');
+        expect(block, 'the collapse must not return as a live conclusion')
+            .not.toContain('container-wide figure spoke for neither');
+
+        // The retirement trigger names what actually retires the proxy. The residual-demand lane
+        // sharpened disposition and shipped no per-process attribution, so citing it as the retiring
+        // evidence is the same collapse wearing a schedule.
+        expect(block).toContain('retired only by a process-scoped CPU producer');
+        expect(block, 'the residual-demand lane must not be cited as retiring the proxy')
+            .not.toContain('the evidence lane that retires the proxy');
     });
 
     test('the resolver mirrors the memory gate exactly, and says no', () => {


### PR DESCRIPTION
Resolves neomjs/neo#16886

The saturation-subject contract reasoned from a **disposition** fact to an **attribution** conclusion. Its receipt — 399.4% CPU on the model container while only health polling arrived — was read as proving the container-wide figure *"spoke for neither"* the service nor the runner. It does not follow: a runner spawned by the model server is that Compose service's **own** process. The subject was correct throughout; what was unknown was whether the demand was accounted for.

**Evidence:** L2 (structural assertions over the shipped contract prose, each pinned by a mutation that reddens exactly it) → L2 required (the ACs are documentation and structural-guard authority; zero production behaviour changes). No residuals.

## Deltas

**Three axes, named as axes.** Collapsing any two is how the previous revision went wrong:

1. **Observation subject — always exact.** The Docker ratio describes the resolved container, and `DeploymentRuntimeAccessService` verifies its `com.docker.compose.service` label before acting. Never ambiguous.
2. **Work ownership.** A runner spawned by the model server is service-owned. *It does not become foreign because nobody is waiting for it.* A forked scheduled job in a Node service is the genuinely foreign case, and it is a different thing.
3. **Demand disposition.** Accounted, residual after a client disconnect, stale, or unknown.

*"No inference arrived in the sampled window"* answers **3** only. The retired conclusion collapsed 3 into 1, which mattered practically: a residual-demand problem is answered by accounting, and only an ownership problem would need process cardinality.

**The retirement trigger was stale before it shipped.** It promised the residual-load lane would supply runner/process-cardinality evidence and retire the proxy. That lane shipped exact-container CPU bound to one incarnation, expected-model residency, recorder-owned provider activity, and a last-boundary demand veto — all of which sharpen **disposition**, none of which attribute CPU to a process. The trigger now names what actually retires the proxy: **a process-scoped CPU producer**, a per-process reading beside the existing `processHeapObservation` channel, which today publishes `rssBytes` and V8 fields and nothing about CPU time.

**Retain-and-mark, not delete.** The retired conclusion stays visible in the block so a reader who remembers it is routed to the correction rather than left wondering whether it was ever considered. It carries markdown quoting, which is what lets the guard below assert the bare claim can never return as live text.

**One measured addition, and its bounds are the point.** Two facts, kept separate in the source because merging them is how the previous revision overstated itself:

- **Source, at tag `v0.23.1`:** the disconnect-abort line is emitted only where the admission semaphore acquire is cancelled — a **pre-admission** signal. Its presence says nothing about admitted work either way.
- **Observation, once:** an admitted request completed after 1h6m and then failed to write its reply (`broken pipe`), so the reply socket was closed by then. **The disconnect point was not observed** — only that the request ran to completion and had no reader at the end.

Together those establish that **a service-owned process can burn cores with no arriving traffic** — axis-2 owned, axis-3 residual, the shape the block describes. They do **not** establish a universal rule that admitted work always survives a disconnect; an earlier revision asserted exactly that from the source read alone, and it is retired in the source as retired. Nor do they establish the origin of the historical 399.4% specimen, which was a different plane on a different day and keeps its recorded bounds.

## Test Evidence

`ContainerHealthDiagnosisService.spec.mjs` — **116 passed**, including the new structural guard.

The guard asserts the axes stay separated, and both of its load-bearing negatives are proven to fail:

| Mutation | Result |
|---|---|
| un-retire the collapsed conclusion (strip the markdown quoting so it reads as live text) | **red** — `the collapse must not return as a live conclusion` |
| restore the stale `@see` citing the residual-demand lane as retiring the proxy | **red** — `the residual-demand lane must not be cited as retiring the proxy` |

Both failed with their own named assertion, not incidentally. The existing `#16878` guard (gate-is-a-proxy, retired-premise-as-retired) still passes unchanged, so the new axis separation composes with it rather than replacing it.

Structural only — it asserts what the contract *says*, never what the code does, which is the honest instrument for a prose defect. Zero production behaviour changes: no threshold, authority, actuator or lifecycle path is touched.

Boy-scout: fixed 8 lines of pre-existing block-alignment drift in the spec (line ~718, unrelated to this change).

## Post-Merge Validation

- An operator reading the block can answer "is this CPU figure about the right subject?" and "is this demand accounted for?" as separate questions, and the answer to the second no longer implies the first.
- The next agent proposing to retire the `nodeCommand` proxy is pointed at a process-scoped CPU producer rather than at a lane that cannot supply one.

Authored by @neo-opus-ada (Ada), session e9558026-c68c-453f-8c9f-aa8dcc6c6cdd.
