### PR TITLE
test(deploy): a dangling prescription symlink skips instead of false-failing (#16988)

### DIFF
--- a/test/playwright/unit/ai/services/memory-core/helpers/deploymentPrescriptionEnvironment.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/helpers/deploymentPrescriptionEnvironment.spec.mjs
@@ -35,6 +35,24 @@ function composeConfigAvailable() {
 }
 
 /**
+ * @summary True when `ai/deploy/.env` is a symlink whose target does not exist.
+ *
+ * The deployment-prescription workflow links that path at a per-operator store outside the repo, so
+ * a machine that has run it once carries the link whether or not the target survives. `existsSync`
+ * FOLLOWS symlinks, so a dangling link reads as absent — which defeats the test's own preserve-and-
+ * restore: it records "nothing to back up", then writes through a link that resolves nowhere and
+ * fails `ENOENT` on a path that visibly exists. The failure names the repo path, so it reads as a
+ * broken suite rather than a broken link, and it cost a full-suite run to attribute.
+ *
+ * `lstatSync` is the distinction: it describes the LINK, never its target.
+ * @param {String} envPath
+ * @returns {Boolean}
+ */
+function danglingEnvSymlink(envPath) {
+    return fs.lstatSync(envPath, {throwIfNoEntry: false})?.isSymbolicLink() === true && !fs.existsSync(envPath)
+}
+
+/**
  * Resolves kb-server's `--max-old-space-size` as Compose would create it.
  * @param {String} repoRoot
  * @returns {Number|null}
@@ -115,7 +133,14 @@ test.describe('deployment prescription -> env file', () => {
 
         const
             repoRoot = process.cwd(),
-            envPath  = path.join(repoRoot, 'ai/deploy/.env'),
+            envPath  = path.join(repoRoot, 'ai/deploy/.env');
+
+        // An environment precondition, exactly like the compose-CLI check above: this test WRITES the
+        // env file, and a link to a vanished prescription store cannot be written through. Skipping
+        // states that; failing would blame the suite for the machine.
+        test.skip(danglingEnvSymlink(envPath), 'ai/deploy/.env is a symlink to a missing prescription store');
+
+        const
             existed  = fs.existsSync(envPath),
             backup   = existed ? fs.readFileSync(envPath, 'utf8') : null,
             // A value no default in the tree carries, so a pass cannot come from the baseline.


### PR DESCRIPTION
Resolves #16988

A unit test reported `dev` as red when `dev` was green. The failure came from a symlink on the developer's machine, and it named a repo path, so it read as a broken suite.

**Evidence:** L2 (the predicate proven across all three filesystem states, plus a full-suite run before and after) → L2 required (test-environment precondition; no production surface). No residuals.

## What happened

Answering whether `dev` was red after five merges landed inside ~15 minutes, a full unit run against `dev` HEAD `10a29b1a79` gave **12856 passed, 1 failed**:

```
Error: ENOENT: no such file or directory, open '<repo>/ai/deploy/.env'
  at deploymentPrescriptionEnvironment.spec.mjs:131  fs.writeFileSync(envPath, content)
```

`ENOENT` on a **write** means the parent is missing — but `ai/deploy/` plainly exists. The path is a **symlink** to a per-operator prescription store outside the repo, and that store had been removed:

```
ai/deploy/.env -> ~/.neo-ai/deployment-prescriptions/active.env   (target absent)
```

**`fs.existsSync` follows symlinks**, so the dangling link reads as *absent*. The test's own preserve-and-restore is defeated on its own terms: it records "nothing to back up", then writes through a link that resolves nowhere.

`ai/deploy/.env` is untracked and gitignored (`.gitignore:113`), so **CI never carries it** — the red is unreproducible anywhere but the affected machine. That is what made it expensive: a full-suite run plus a tracked-vs-untracked check to attribute, during an incident where the operator had already merged *overruling* what CI appeared to say.

## Deltas

The file already models this exact class one line above — `test.skip(!composeConfigAvailable(), …)`. The symlink case joins it:

```js
function danglingEnvSymlink(envPath) {
    return fs.lstatSync(envPath, {throwIfNoEntry: false})?.isSymbolicLink() === true && !fs.existsSync(envPath)
}
```

`lstatSync` is the whole distinction: it describes the **link**, never its target. `throwIfNoEntry: false` keeps a genuinely absent path from throwing, so the clean case stays on the running side.

The skip message names the machine state — *"ai/deploy/.env is a symlink to a missing prescription store"* — rather than the assertion, so the next person reads it as an environment fact in one line instead of a suite failure in a full run.

## Test Evidence

`deploymentPrescriptionEnvironment.spec.mjs` — **8 passed, 1 skipped** on the affected machine (was 8 passed, 1 **failed**).

**Non-vacuity across all three states**, because a skip that fires too widely hides real regressions and would be strictly worse than the false red it replaces:

| state | predicate | behaviour |
|---|---|---|
| dangling symlink | `true` | **skip** — the machine cannot host the write |
| real `.env` file | `false` | **runs**, preserved and restored |
| absent path | `false` | **runs** — this is CI, and it must never be skipped |

The third row is the load-bearing one: `throwIfNoEntry: false` returning `undefined` for an absent path is what keeps a clean checkout on the running side.

Full unit suite at `dev` HEAD before this change: 12856 passed / **1 failed** (this test). The remaining 12856 are the evidence that `dev` itself was green — the merges were safe.

## Post-Merge Validation

- On a machine whose prescription store was removed, the suite reports one skip with a named reason instead of a failure on a repo path.
- On CI, where `.env` does not exist, the test still executes and still convicts a prescription that fails to reach the container command.

Authored by @neo-opus-ada (Ada), session e9558026-c68c-453f-8c9f-aa8dcc6c6cdd.
