### PR TITLE
fix(deploy): the local Agent OS secret is checkout-independent (#16993)

### DIFF
--- a/ai/deploy/docker-compose.local-agent-os.yml
+++ b/ai/deploy/docker-compose.local-agent-os.yml
@@ -104,5 +104,17 @@ services:
       test: ["CMD-SHELL", "nc -z 127.0.0.1 8080"]
 
 secrets:
+  # Checkout-INDEPENDENT by default, the same shape `NEO_HOST_BACKUP_ROOT` already carries in the
+  # base compose. A relative `file:` resolves inside whichever checkout renders this document, so
+  # provisioning the token once made exactly ONE clone able to run the sanctioned rebuild — and
+  # pinned the whole local plane to whatever branch that clone happened to sit on. Measured cost:
+  # every container running a revision 103 commits behind `dev` while the fixes sat merged.
+  #
+  # The value must be the token the plane ALREADY bootstrapped (it is both the auth-provider
+  # bootstrap PAT and the healthcheck token), so a per-checkout copy is not a workaround — every
+  # root needs the same secret, which is precisely what a checkout-relative path prevents.
+  #
+  # A missing file makes Compose refuse to start. That is the intended failure: loud, at the one
+  # moment someone can act, rather than a silent fallback that restores the single-seat dependency.
   mcp-auth-token: !override
-    file: ../../.neo-ai-secrets/mcp-auth-token
+    file: ${NEO_MCP_AUTH_TOKEN_FILE:-${HOME}/.neo-ai/secrets/mcp-auth-token}

--- a/ai/scripts/lifecycle/local-agent-os/README.md
+++ b/ai/scripts/lifecycle/local-agent-os/README.md
@@ -60,8 +60,30 @@ silent. Declare a role explicitly if you need that entrypoint directly.
 
 ## Start the container plane
 
-Run from the repository root after provisioning `.env` and the mode-0600
-`.neo-ai-secrets/mcp-auth-token`.
+Run from **any** current repository root after provisioning `.env`, plus the
+mode-0600 auth token at the machine-level path
+`~/.neo-ai/secrets/mcp-auth-token` (override with `NEO_MCP_AUTH_TOKEN_FILE`).
+
+**The token lives outside every checkout on purpose.** It used to be read from
+`<checkout>/.neo-ai-secrets/mcp-auth-token`, so provisioning it once made exactly
+one clone able to run the rebuild — and pinned the whole local plane to whatever
+branch that clone sat on. Measured cost: a plane running 103 commits behind `dev`
+while the fixes sat merged.
+
+**Its value must be the token the plane already bootstrapped**, not a fresh one:
+it is both `NEO_AUTH_PROVIDER_BOOTSTRAP_PAT_FILE` and
+`NEO_MCP_HEALTHCHECK_TOKEN_FILE`, so a newly generated secret breaks auth rather
+than provisioning it. Migrating an existing machine is one move:
+
+```sh
+mkdir -p ~/.neo-ai/secrets
+mv <the-provisioned-checkout>/.neo-ai-secrets/mcp-auth-token ~/.neo-ai/secrets/
+chmod 600 ~/.neo-ai/secrets/mcp-auth-token
+```
+
+A missing file makes Compose refuse to start, which is deliberate — loud at the
+one moment someone can act, rather than a silent fallback that restores the
+single-clone dependency.
 
 **Resolve the channel to a commit first.** Compose maps one operator pin to both
 internal Docker arguments, and the source stage refuses a mutable ref (#16635) —

--- a/test/playwright/unit/ai/deploy/ParityPlaneVolumeScoping.spec.mjs
+++ b/test/playwright/unit/ai/deploy/ParityPlaneVolumeScoping.spec.mjs
@@ -439,7 +439,12 @@ test.describe('data-plane profile election — base and integration-fixture disp
         expect(overlaySource).toContain('NEO_AUTH_PIN_FIRST_PROVIDER_SUBJECT: "false"');
         expect(overlaySource).not.toContain('NEO_AUTH_PROVIDER_BOOTSTRAP_PAT');
         expect(overlaySource).toContain('NEO_MCP_HEALTHCHECK_TOKEN_FILE: /run/secrets/mcp-auth-token');
-        expect(overlaySource).toContain('file: ../../.neo-ai-secrets/mcp-auth-token');
+        // Checkout-INDEPENDENT: a relative `file:` resolves inside whichever checkout renders the
+        // overlay, which made the sanctioned rebuild runnable from exactly one clone. Asserting the
+        // interpolated form is what makes a revert to the relative path redden here.
+        expect(overlaySource).toContain('file: ${NEO_MCP_AUTH_TOKEN_FILE:-${HOME}/.neo-ai/secrets/mcp-auth-token}');
+        expect(overlaySource, 'the checkout-relative secret path must not return')
+            .not.toContain('file: ../../.neo-ai-secrets/mcp-auth-token');
         expect(overlaySource).not.toContain('environment: GH_TOKEN');
         expect(overlaySource).toContain(
             'NEO_OPENAI_COMPATIBLE_HOST: ${NEO_LOCAL_AGENT_OS_PROVIDER_HOST:-http://host.docker.internal:1234}'

--- a/test/playwright/unit/ai/scripts/diagnostics/mcpHealthcheck.spec.mjs
+++ b/test/playwright/unit/ai/scripts/diagnostics/mcpHealthcheck.spec.mjs
@@ -479,7 +479,11 @@ test.describe('ai/scripts/diagnostics/mcpHealthcheck (#11725)', () => {
         expect(source).not.toContain('NEO_AUTH_AUTO_PROVISION_IDENTITY_SOURCES');
         expect(source).toContain('NEO_AUTH_PIN_FIRST_PROVIDER_SUBJECT: "false"');
         expect(source).not.toContain('NEO_AUTH_PROVIDER_BOOTSTRAP_PAT');
-        expect(source).toContain('file: ../../.neo-ai-secrets/mcp-auth-token');
+        // Checkout-INDEPENDENT — see the overlay's own comment. The negative is the load-bearing
+        // half: a revert to the relative path restores the single-seat rebuild dependency.
+        expect(source).toContain('file: ${NEO_MCP_AUTH_TOKEN_FILE:-${HOME}/.neo-ai/secrets/mcp-auth-token}');
+        expect(source, 'the checkout-relative secret path must not return')
+            .not.toContain('file: ../../.neo-ai-secrets/mcp-auth-token');
         expect(source).not.toContain('environment: GH_TOKEN');
         expect(source).toContain('"127.0.0.1:3102:8080"');
         expect(source).not.toContain('docker-compose.dev.yml');


### PR DESCRIPTION
Resolves #16993

Our own Agent OS ran 103 commits behind `dev` all day — not through neglect, but because the sanctioned rebuild is executable from exactly one person's clone. The cause is one line: the compose secret resolves against whichever checkout renders the document.

**Evidence:** L2 (the same secret path rendered from two different roots, plus a mutation reddening both existing assertions) → L2 required (the property is what Compose resolves; `docker compose config` is the mechanism, not a proxy for it). One residual: the operator moves the token once, named below.

## What this fixes, measured today

Every container ran `3f9f8343a88e…` while `origin/dev` was `accfdb0c1a…`, so **none of the day's merges were live for us** and every instrument we read ran pre-fix code. Three roots, three blockers:

| root | blocker |
|---|---|
| the **running** project dir | no `.env`, no `.neo-ai-secrets/`, not a git repo — an extracted snapshot |
| the main checkout | has `.env`, **no `.neo-ai-secrets/` at all** |
| one peer's clone | has both — 103 commits behind, its `docker-compose.yml` **123 lines** from `dev` |

Rebuilding under the canonical project name from that third root renders a materially different stack. `D#16304` R3 already named this — *"the sanctioned rebuild is currently executable from exactly one peer's personal clone… an undeclared single-seat dependency"* — and it stayed recorded and unfixed until it cost a day.

## Deltas

**The pattern already exists in this repo and this path never got it.** `docker-compose.yml:357-372` gives the backup root an env override *and* a checkout-independent default:

```yaml
#   host source — `NEO_HOST_BACKUP_ROOT`, whose DEFAULT is checkout-independent.
- ${NEO_HOST_BACKUP_ROOT:-${HOME}/.neo-ai/backups}:/app/.neo-ai-data/backups
```

The secret is now the same shape:

```yaml
mcp-auth-token: !override
  file: ${NEO_MCP_AUTH_TOKEN_FILE:-${HOME}/.neo-ai/secrets/mcp-auth-token}
```

**Deliberately a breaking default rather than an opt-in.** An override nobody sets leaves the defect in place; a missing file makes Compose refuse to start — loud, at the one moment someone can act, instead of silently restoring the single-clone dependency.

**Why a per-checkout copy was never the workaround:** the token is both `NEO_AUTH_PROVIDER_BOOTSTRAP_PAT_FILE` and `NEO_MCP_HEALTHCHECK_TOKEN_FILE`, so its value must be the one the plane already bootstrapped. A freshly generated secret breaks auth rather than provisioning it. Every root needs *the same* secret — exactly what a checkout-relative path prevents.

Nothing about what the token **is** or how it is generated changes. This moves where it is looked up.

## Test Evidence

`ParityPlaneVolumeScoping.spec.mjs` + `mcpHealthcheck.spec.mjs` — **67 passed**.

**The acceptance criterion, run from two physically separate checkout roots** (a second working tree at this exact head, so both roots carry their own base compose):

| root | binding | resolves to |
|---|---|---|
| A — this worktree | **new** | `/Users/…/.neo-ai/secrets/mcp-auth-token` |
| B — `/private/tmp/ada-probe-root` | **new** | `/Users/…/.neo-ai/secrets/mcp-auth-token` |
| B — same root, **old** overlay replayed from `origin/dev` | old | `/private/tmp/ada-probe-root/.neo-ai-secrets/mcp-auth-token` |

Identical under the new binding; **root-local under the old one**. That third row is the control: it shows the two roots provably disagreed before and provably agree now, rather than agreeing for some unrelated reason.

*An earlier revision of this section claimed the control was "copy the overlay to `/tmp` and render from another root". That is not a control — Compose anchors relative paths to the **first/base** compose file, not to the overridden one, so both renders stayed anchored to the same base and the comparison proved nothing. Corrected after @neo-gpt caught it; the experiment above is the one that actually varies the root.*

**Mutation:** reverting the binding to `file: ../../.neo-ai-secrets/mcp-auth-token` reddens **both** specs (2 failed / 65 passed). Both assertions carry an explicit negative on the retired path, so a revert cannot pass by adding the new form alongside the old.

## Post-Merge Validation

- One-time, operator-side, per machine — the only step that touches the credential:

```sh
mkdir -p ~/.neo-ai/secrets
mv <the-provisioned-checkout>/.neo-ai-secrets/mcp-auth-token ~/.neo-ai/secrets/
chmod 600 ~/.neo-ai/secrets/mcp-auth-token
```

- After the move, the rebuild runs from **any** current checkout, and `docker compose … exec mc-server cat /app/.neo-revision` equals the exported `NEO_REVISION` — the artifact read, never `--wait`, which proves health and never revision.
- The build-context half of `D#16304` R3 (which root supplies the compose files) resolves on its own once any current checkout can run it.

Authored by @neo-opus-ada (Ada), session e9558026-c68c-453f-8c9f-aa8dcc6c6cdd.
