### PR TITLE
fix(ai): stop native Ollama timeout handoff across tenant repos

### DIFF
--- a/ai/daemons/orchestrator/services/TenantRepoSyncService.mjs
+++ b/ai/daemons/orchestrator/services/TenantRepoSyncService.mjs
@@ -21,6 +21,7 @@ import {buildEmbeddingProbeBlock} from '../../../services/shared/embeddingProbe.
 import {
     BOUNDED_KB_ERROR_CODE_PATTERN,
     EMBED_DISPOSITION,
+    KB_VECTOR_EMBED_PROVIDER_CIRCUIT_OPEN,
     classifyEmbedDisposition,
     isEmbedFailureCode
 }                                from '../../../services/knowledge-base/helpers/embedFailureClassification.mjs';
@@ -407,6 +408,17 @@ function classifyIngestionOutcome(summary) {
     }
 
     return {outcome: 'complete', summary, deferredCodes: []}
+}
+
+/**
+ * @summary Creates the bounded reason used to stop never-dispatched repository embeds in one sweep.
+ * @returns {Error} Internal circuit-open error safe for the KB failure classifier.
+ */
+function createProviderTimeoutCircuitError() {
+    const error = new Error('Tenant-repo embedding deferred because an earlier native provider request timed out in this sweep.');
+
+    error.code = KB_VECTOR_EMBED_PROVIDER_CIRCUIT_OPEN;
+    return error
 }
 
 /**
@@ -1504,6 +1516,18 @@ class TenantRepoSyncService extends Base {
 
         const resolvedRevisionsPath = revisionsFilePath || this.defaultRevisionsFilePath();
         const ingestionService      = knowledgeBaseIngestionService || await this.resolveIngestionService();
+        const ingestSourceFilesForTenantSync = typeof ingestionService.ingestSourceFilesForTenantSync === 'function'
+            ? (payload, controls) => ingestionService.ingestSourceFilesForTenantSync(payload, controls)
+            : (payload, controls) => ingestionService.ingestSourceFiles(payload, controls);
+        const providerTimeoutCircuit = new AbortController();
+        const providerCircuitControls = {
+            signal           : providerTimeoutCircuit.signal,
+            onProviderTimeout: () => {
+                if (!providerTimeoutCircuit.signal.aborted) {
+                    providerTimeoutCircuit.abort(createProviderTimeoutCircuitError());
+                }
+            }
+        };
         const persistedRevisions    = await this.readPersistedRevisions({
             filePath: resolvedRevisionsPath,
             strict  : true
@@ -2090,11 +2114,11 @@ class TenantRepoSyncService extends Base {
                             errors                : [],
                             materializationReceipt: retryReceipt
                         }
-                        : await ingestionService.ingestSourceFiles({
+                        : await ingestSourceFilesForTenantSync({
                             ...envelope,
                             ...(materializationAttempt ? {materializationAttempt} : {}),
                             viaMcp: false // operator-bulk path
-                        });
+                        }, providerCircuitControls);
 
                 // Emitted before BOTH guards on this path, which is what makes it useful:
                 // `classifyIngestionOutcome` throws on a rejected error-bearing summary, and

--- a/ai/services/knowledge-base/IngestionService.mjs
+++ b/ai/services/knowledge-base/IngestionService.mjs
@@ -186,9 +186,12 @@ class IngestionService extends Base {
      *                                        MCP-safe. Explicit `false` (the `ai:ingest-tenant`
      *                                        bulk CLI path) bypasses the gate as an opt-in to
      *                                        long-running bulk work.
+     * @param {Object} [controls={}] Internal non-MCP execution controls.
+     * @param {AbortSignal} [controls.signal] Shared tenant-sweep provider circuit signal.
+     * @param {Function} [controls.onProviderTimeout] Synchronous native-provider timeout hook.
      * @returns {Promise<{ingested: Number, deleted: Number, embeddingsGenerated: Number, errors: Array, tenantId: String, durationMs: Number}>}
      */
-    async ingestSourceFiles(payload = {}) {
+    async ingestSourceFiles(payload = {}, controls = {}) {
         const startedAt = Date.now();
         const summary   = this.createSummary({startedAt});
 
@@ -248,6 +251,8 @@ class IngestionService extends Base {
                 this.updateIngestionProgress({phase: 'embedding'});
                 await this.embedChunkGroups({
                     chunks: embeddableChunks,
+                    onProviderTimeout: controls.onProviderTimeout,
+                    signal           : controls.signal,
                     tenantContext,
                     summary,
                     viaMcp: payload.viaMcp !== false
@@ -286,6 +291,21 @@ class IngestionService extends Base {
             this.finishIngestionProgress({summary, status: 'failed'});
             return summary;
         }
+    }
+
+    /**
+     * @summary Internal tenant-sync entry that preserves execution controls outside the OpenAPI wrapper.
+     *
+     * The canonical SDK proxy intentionally forwards one validated OpenAPI argument to
+     * `ingestSourceFiles`. Tenant sync needs a second, process-local control envelope, so it calls
+     * this unwrapped method rather than smuggling non-contract fields into the public payload.
+     *
+     * @param {Object} payload Canonical ingestion payload.
+     * @param {Object} controls Internal provider-circuit controls.
+     * @returns {Promise<Object>} The canonical ingestion summary.
+     */
+    async ingestSourceFilesForTenantSync(payload = {}, controls = {}) {
+        return this.ingestSourceFiles(payload, controls)
     }
 
     /**
@@ -358,13 +378,15 @@ class IngestionService extends Base {
     /**
      * @summary Groups parsed chunks by repoSlug and routes each group to VectorService.embed().
      * @param {Object}  options
+     * @param {AbortSignal} [options.signal] Shared tenant-sweep provider circuit signal.
+     * @param {Function} [options.onProviderTimeout] Synchronous native-provider timeout hook.
      * @param {Boolean} [options.viaMcp=true] Forwarded to `VectorService.embed`; `true` keeps
      *                                        the MCP work-volume gate, `false` (bulk CLI)
      *                                        bypasses it.
      * @returns {Promise<void>}
      * @protected
      */
-    async embedChunkGroups({chunks, tenantContext, summary, viaMcp = true}) {
+    async embedChunkGroups({chunks, tenantContext, summary, viaMcp = true, signal, onProviderTimeout}) {
         const groups = new Map();
 
         for (const chunk of chunks) {
@@ -381,6 +403,8 @@ class IngestionService extends Base {
             try {
                 const result = await this.vectorService.embed(tempFile, {
                     deleteStale  : false,
+                    onProviderTimeout,
+                    signal,
                     tenantContext: {...tenantContext, repoSlug},
                     viaMcp
                 });

--- a/ai/services/knowledge-base/VectorService.mjs
+++ b/ai/services/knowledge-base/VectorService.mjs
@@ -22,6 +22,7 @@ import DestructiveOperationGuard                                       from '../
 import {computeCorpusFingerprint, decideResume, selectResumableChunks} from './helpers/resumableEmbedding.mjs';
 import {clearResumeState, readResumeState, writeResumeState}           from './helpers/kbEmbeddingResumeStore.mjs';
 import KBRecorderService                                               from './KBRecorderService.mjs';
+import {KB_VECTOR_EMBED_PROVIDER_CIRCUIT_OPEN}                         from './helpers/embedFailureClassification.mjs';
 
 /**
  * @summary Flattens one chunk into Chroma-storable scalar metadata.
@@ -634,7 +635,7 @@ class VectorService extends Base {
     }
 
     /**
-     * Embeds a set of chunks into the provided Chroma collection.
+     * @summary Embeds a set of chunks into the provided Chroma collection.
      *
      * @param {Object}   options
      * @param {Object}   options.collection      Chroma collection target.
@@ -649,6 +650,8 @@ class VectorService extends Base {
      *     `maxRetries * ceil(batchSize / batchEmbeddingChunkSize) * (1 + unloadRetryCount) *
      *     batchEmbeddingTimeoutMs`, which is 16h40m at stock leaves against a 30-minute `maxActiveHoldMs`.
      *     Per-chunk consultation caps the interval at one chunk's worst case.
+     * @param {AbortSignal} [options.signal] Shared tenant-sweep provider circuit signal.
+     * @param {Function} [options.onProviderTimeout] Synchronous native-provider timeout hook.
      * @returns {Promise<{embedded: Number, skipped: Number, yielded: Boolean, failedBatches: Object[]}>}
      *     `failedBatches` carries `{batchIndex, chunkIds, reason}` for every batch that exhausted its retries
      *     while other batches were succeeding. Such a batch is skipped rather than aborting the sweep, because
@@ -658,7 +661,7 @@ class VectorService extends Base {
      *     The whole sweep ends after that one offer so the outer scheduler owns the later attempt; already-landed
      *     chunks remain the durable resume boundary.
      */
-    async embedChunks({collection, chunksToProcess, shouldYield = () => false}) {
+    async embedChunks({collection, chunksToProcess, shouldYield = () => false, signal, onProviderTimeout}) {
         if (chunksToProcess.length === 0) {
             return {embedded: 0, skipped: 0, yielded: false};
         }
@@ -742,7 +745,9 @@ class VectorService extends Base {
                         operationStage          : 'kb-tenant-ingestion-embedding',
                         providerActivityRecorder: KBRecorderService,
                         service                 : 'knowledge-base',
-                        shouldYield
+                        shouldYield,
+                        signal,
+                        onProviderTimeout
                     });
 
                     const metadatas = batchToEmbed.map(buildChunkMetadata);
@@ -804,15 +809,21 @@ class VectorService extends Base {
                     // The phase guard is load-bearing. This catch also covers `collection.upsert()`: a write
                     // error carrying a foreign timeout-shaped code must retry the write with the cached vectors,
                     // never be misclassified as provider work that might still be running.
-                    const providerTimedOut = embeddings === null && (
-                        err?.code === PROVIDER_TIMEOUT_CODE ||
-                        err?.code === OPENAI_COMPATIBLE_REQUEST_TIMEOUT_CODE ||
-                        err?.code === 'ETIMEDOUT' ||
-                        err?.code === 'ESOCKETTIMEDOUT'
-                    );
+                    const
+                        providerCircuitOpen = embeddings === null && err?.code === KB_VECTOR_EMBED_PROVIDER_CIRCUIT_OPEN,
+                        providerTimedOut    = embeddings === null && (
+                            err?.code === PROVIDER_TIMEOUT_CODE ||
+                            err?.code === OPENAI_COMPATIBLE_REQUEST_TIMEOUT_CODE ||
+                            err?.code === 'ETIMEDOUT' ||
+                            err?.code === 'ESOCKETTIMEDOUT'
+                        );
 
-                    if (providerTimedOut) {
-                        console.error(`An error occurred during embedding batch ${i / batchSize + 1}. Ending this embedding sweep after one timeout-class provider attempt; pending chunks remain for a later scheduler cycle.`, err.message);
+                    if (providerCircuitOpen || providerTimedOut) {
+                        const disposition = providerCircuitOpen
+                            ? 'the run-scoped provider circuit opened before this repository dispatched'
+                            : 'one timeout-class provider attempt ended';
+
+                        console.error(`An error occurred during embedding batch ${i / batchSize + 1}. Ending this embedding sweep because ${disposition}; pending chunks remain for a later scheduler cycle.`, err.message);
                         throw err
                     }
 
@@ -899,7 +910,7 @@ class VectorService extends Base {
     }
 
     /**
-     * Rebuilds the full corpus into a shadow collection, then promotes it to the
+     * @summary Rebuilds the full corpus into a shadow collection, then promotes it to the
      * canonical name without ever gutting the live collection in-place.
      *
      * ChromaDB has no single atomic exchange primitive, so the promote step is a
@@ -915,9 +926,11 @@ class VectorService extends Base {
      *     threaded to `embedChunks`. On a between-batch yield the shadow is preserved-not-promoted (the
      *     write-ahead resume marker already indexes it) and a `{yielded: true}` envelope is returned so the
      *     lease holder releases; the next sweep resumes from the preserved shadow.
+     * @param {AbortSignal} [options.signal] Shared tenant-sweep provider circuit signal.
+     * @param {Function} [options.onProviderTimeout] Synchronous native-provider timeout hook.
      * @returns {Promise<Object>} Embedding result (carries `yielded: true` when the lease was cooperatively released).
      */
-    async embedViaShadowSwap({liveCollection, knowledgeBase, idsToDeleteCount, shouldYield = () => false}) {
+    async embedViaShadowSwap({liveCollection, knowledgeBase, idsToDeleteCount, shouldYield = () => false, signal, onProviderTimeout}) {
         const stateDir    = this.getResumeStateDir();
         const fingerprint = computeCorpusFingerprint(knowledgeBase);
         const resumeState = await readResumeState({dir: stateDir});
@@ -975,7 +988,13 @@ class VectorService extends Base {
         let shadowPromoted = false;
 
         try {
-            const embedResult = await this.embedChunks({collection: shadowCollection, chunksToProcess: chunksToEmbed, shouldYield});
+            const embedResult = await this.embedChunks({
+                collection: shadowCollection,
+                chunksToProcess: chunksToEmbed,
+                shouldYield,
+                signal,
+                onProviderTimeout
+            });
 
             if (embedResult.yielded) {
                 // Cooperative lease-yield: the shadow holds the completed batches and the write-ahead
@@ -1157,7 +1176,7 @@ class VectorService extends Base {
     }
 
     /**
-     * Reads a JSONL file, enriches data, generates embeddings, and updates ChromaDB.
+     * @summary Reads a JSONL file, enriches data, generates embeddings, and updates ChromaDB.
      *
      * **Work-volume gate:** when invoked via MCP (`viaMcp: true`), refuses
      * synchronous execution if `chunksToProcess.length` exceeds `aiConfig.mcpSyncMaxChunks`
@@ -1183,10 +1202,20 @@ class VectorService extends Base {
      *                                             re-embed releases the lease at a batch boundary for a starved
      *                                             heavy task, then resumes from the preserved shadow. Default
      *                                             never yields, so non-lease-held callers are unaffected.
+     * @param {AbortSignal} [opts.signal]          Shared tenant-sweep provider circuit signal.
+     * @param {Function} [opts.onProviderTimeout]  Synchronous native-provider timeout hook.
      * @returns {Promise<object>} A promise that resolves to a success message, OR a
      *     `{error, code: 'KB_SYNC_VOLUME_EXCEEDED', ...}` shape when the MCP gate fires.
      */
-    async embed(knowledgeBasePath, {viaMcp = false, tenantContext = {}, deleteStale = true, staleStrategy, shouldYield = () => false} = {}) {
+    async embed(knowledgeBasePath, {
+        viaMcp = false,
+        tenantContext = {},
+        deleteStale = true,
+        staleStrategy,
+        shouldYield = () => false,
+        signal,
+        onProviderTimeout
+    } = {}) {
         logger.log('Starting knowledge base embedding...');
         const resolvedStaleStrategy = this.resolveStaleStrategy({staleStrategy, deleteStale});
 
@@ -1353,7 +1382,9 @@ class VectorService extends Base {
                 liveCollection  : collection,
                 knowledgeBase   : expandedKnowledgeBase,
                 idsToDeleteCount: idsToDelete.length,
-                shouldYield
+                shouldYield,
+                signal,
+                onProviderTimeout
             });
         }
 
@@ -1362,7 +1393,7 @@ class VectorService extends Base {
             logger.log(`Deleted ${idsToDelete.length} stale chunks.`);
         }
 
-        const embedResult = await this.embedChunks({collection, chunksToProcess});
+        const embedResult = await this.embedChunks({collection, chunksToProcess, signal, onProviderTimeout});
 
         const count         = await collection.count();
         const failedBatches = embedResult.failedBatches || [];

--- a/ai/services/knowledge-base/helpers/embedFailureClassification.mjs
+++ b/ai/services/knowledge-base/helpers/embedFailureClassification.mjs
@@ -67,6 +67,12 @@ export const BOUNDED_KB_ERROR_CODE_PATTERN = /^KB_[A-Z0-9_]{1,120}$/;
 export const KB_VECTOR_EMBED_UNCLASSIFIED = 'KB_VECTOR_EMBED_FAILED';
 
 /**
+ * @summary Bounded cause for a repository that never dispatched because this tenant sweep opened its provider circuit.
+ * @type {String}
+ */
+export const KB_VECTOR_EMBED_PROVIDER_CIRCUIT_OPEN = 'KB_VECTOR_EMBED_PROVIDER_CIRCUIT_OPEN';
+
+/**
  * @summary The codes our OWN layers raise on the embed path, and the only ones allowed through
  * unchanged.
  *
@@ -83,7 +89,8 @@ export const KB_VECTOR_EMBED_UNCLASSIFIED = 'KB_VECTOR_EMBED_FAILED';
 const INTERNAL_EMBED_ERROR_CODES = Object.freeze(new Set([
     'KB_EMBEDDING_INPUT_SIZE_EXCEEDED',
     'KB_SYNC_VOLUME_EXCEEDED',
-    'KB_TENANT_SPOOF_REJECTED'
+    'KB_TENANT_SPOOF_REJECTED',
+    KB_VECTOR_EMBED_PROVIDER_CIRCUIT_OPEN
 ]));
 
 /**

--- a/ai/services/memory-core/TextEmbeddingService.mjs
+++ b/ai/services/memory-core/TextEmbeddingService.mjs
@@ -164,6 +164,7 @@ function normalizeEmbeddingOptions(options, defaultOperationLabel) {
     const allowedKeys = [
         'operationLabel',
         'operationStage',
+        'onProviderTimeout',
         'providerActivityRecorder',
         'service',
         'shouldYield',
@@ -187,6 +188,9 @@ function normalizeEmbeddingOptions(options, defaultOperationLabel) {
     if (options.operationStage !== undefined && typeof options.operationStage !== 'string') {
         throw new TypeError('TextEmbeddingService: options.operationStage must be a string');
     }
+    if (options.onProviderTimeout !== undefined && typeof options.onProviderTimeout !== 'function') {
+        throw new TypeError('TextEmbeddingService: options.onProviderTimeout must be a function');
+    }
     if (options.service !== undefined && typeof options.service !== 'string') {
         throw new TypeError('TextEmbeddingService: options.service must be a string');
     }
@@ -202,6 +206,7 @@ function normalizeEmbeddingOptions(options, defaultOperationLabel) {
     return {
         operationLabel          : requestedLabel.substring(0, EMBEDDING_OPERATION_LABEL_MAX_LENGTH),
         operationStage          : options.operationStage || 'unknown',
+        onProviderTimeout       : options.onProviderTimeout,
         providerActivityRecorder: options.providerActivityRecorder === undefined
             ? MemoryCoreRecorderService
             : options.providerActivityRecorder,
@@ -1419,6 +1424,7 @@ class TextEmbeddingService extends Base {
      * @param {String|String[]} inputData Text input to embed.
      * @param {String} operationLabel Safe diagnostic label for timeout errors.
      * @param {AbortSignal|undefined} signal Upstream cancellation signal.
+     * @param {Function|undefined} onProviderTimeout Synchronous provider-timeout circuit hook.
      * @param {Object} operation Mutable local-phase observability record.
      * @param {Object|null} providerActivityRecorder Best-effort telemetry sink.
      * @param {Object} providerActivity Bounded provider activity descriptor.
@@ -1426,7 +1432,7 @@ class TextEmbeddingService extends Base {
      * @returns {Promise<Object>}
      * @private
      */
-    async #embedOllama(inputData, operationLabel, signal, operation, providerActivityRecorder, providerActivity, identityTexts = null) {
+    async #embedOllama(inputData, operationLabel, signal, onProviderTimeout, operation, providerActivityRecorder, providerActivity, identityTexts = null) {
         const
             provider         = this.#getOllamaProvider(),
             dispatchModel    = provider.embeddingModel || provider.modelName || 'unknown',
@@ -1541,7 +1547,26 @@ class TextEmbeddingService extends Base {
         // cannot reject unhandled.
         providerPromise.then(
             () => this.#releaseOllamaEmbeddingSlot(),
-            () => this.#releaseOllamaEmbeddingSlot()
+            error => {
+                try {
+                    // Open a caller-owned sweep circuit BEFORE releasing the provider slot. Abort
+                    // listeners synchronously remove never-dispatched waiters from the admission
+                    // queue; releasing first would let the next repository acquire the slot behind
+                    // work whose provider-side settlement is not known to imply compute idleness.
+                    if (error?.code === PROVIDER_TIMEOUT_CODE) {
+                        onProviderTimeout?.(error);
+                    }
+                } catch (hookError) {
+                    // The hook is an advisory circuit signal, never a replacement for the source
+                    // provider error. Preserve A's timeout identity even if a caller supplied a
+                    // broken hook, and keep the log bounded to structural error identity.
+                    logger.warn('[TextEmbeddingService] Native Ollama provider-timeout hook failed.', {
+                        errorName: hookError?.name || 'Error'
+                    });
+                } finally {
+                    this.#releaseOllamaEmbeddingSlot();
+                }
+            }
         );
 
         return settleCallerWhileProviderContinues({
@@ -1657,6 +1682,7 @@ class TextEmbeddingService extends Base {
      * @param {AbortSignal} [options.signal] Caller-owned cancellation signal.
      * @param {String} [options.operationLabel] Bounded diagnostic label.
      * @param {String} [options.operationStage='unknown'] Stable low-cardinality stage.
+     * @param {Function} [options.onProviderTimeout] Synchronous native-provider timeout hook.
      * @param {String} [options.service='unknown'] Stable service owner.
      * @param {Object|null} [options.providerActivityRecorder] Best-effort telemetry sink.
      * @returns {Promise<number[]>}
@@ -1670,6 +1696,7 @@ class TextEmbeddingService extends Base {
               {
                   operationLabel,
                   operationStage,
+                  onProviderTimeout,
                   providerActivityRecorder,
                   service,
                   signal
@@ -1712,6 +1739,7 @@ class TextEmbeddingService extends Base {
                     text,
                     operationLabel,
                     signal,
+                    onProviderTimeout,
                     operation,
                     providerActivityRecorder,
                     providerActivity
@@ -1772,6 +1800,7 @@ class TextEmbeddingService extends Base {
      * @param {AbortSignal} [options.signal] Caller-owned cancellation signal.
      * @param {String} [options.operationLabel] Bounded diagnostic label.
      * @param {String} [options.operationStage='unknown'] Stable low-cardinality stage.
+     * @param {Function} [options.onProviderTimeout] Synchronous native-provider timeout hook.
      * @param {String} [options.service='unknown'] Stable service owner.
      * @param {Object|null} [options.providerActivityRecorder] Best-effort telemetry sink.
      * @param {Function} [options.shouldYield] Cooperative heavy-maintenance-lease yield predicate,
@@ -1789,6 +1818,7 @@ class TextEmbeddingService extends Base {
               {
                   operationLabel,
                   operationStage,
+                  onProviderTimeout,
                   providerActivityRecorder,
                   service,
                   shouldYield,
@@ -1824,6 +1854,7 @@ class TextEmbeddingService extends Base {
                     texts,
                     operationLabel,
                     signal,
+                    onProviderTimeout,
                     operation,
                     providerActivityRecorder,
                     providerActivity,

--- a/test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncService.spec.mjs
@@ -53,6 +53,14 @@ import {
     resolveExitCode
 } from '../../../../../../../ai/scripts/maintenance/syncTenantRepos.mjs';
 import {readHealLedger} from '../../../../../../../ai/services/memory-core/helpers/healEventLedgerStore.mjs';
+import MemoryCoreConfig from '../../../../../../../ai/mcp/server/memory-core/config.mjs';
+import {PROVIDER_TIMEOUT_CODE} from '../../../../../../../ai/provider/createTimeoutError.mjs';
+import {
+    KB_VECTOR_EMBED_PROVIDER_CIRCUIT_OPEN,
+    classifyEmbedFailureCode
+} from '../../../../../../../ai/services/knowledge-base/helpers/embedFailureClassification.mjs';
+import TextEmbeddingService from '../../../../../../../ai/services/memory-core/TextEmbeddingService.mjs';
+import {snapshotAiConfig} from '../../../services/memory-core/util.mjs';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname  = path.dirname(__filename);
@@ -2363,6 +2371,172 @@ test.describe('TenantRepoSyncService (#11790)', () => {
         // The load-bearing assertion. `completed` here would report a cycle that ingested nothing
         // as a clean run — the same shape as a healthy lane feeding a KB that receives no content.
         expect(result.status).toBe('deferred');
+    });
+
+    test('a provider timeout stops the next queued repo in this sweep and a fresh sweep can dispatch (#16995)', async () => {
+        const
+            restoreMCConfig        = snapshotAiConfig(MemoryCoreConfig, ['ollama.maxInFlightEmbeddings']),
+            originalOllamaProvider = TextEmbeddingService.ollamaProvider,
+            taskStateService       = createInMemoryTaskStateService(),
+            slugs                  = ['org/provider-timeout-a', 'org/provider-timeout-b'],
+            providerInputs         = [],
+            ingestionEntries       = [],
+            controlsSeen           = [],
+            timeoutError           = Object.assign(new Error('simulated native provider timeout'), {
+                code: PROVIDER_TIMEOUT_CODE
+            }),
+            ingestionService       = makeFakeIngestionService();
+
+        let firstProviderSettlement,
+            firstRunPromise,
+            secondRunPromise,
+            signalBothEntered;
+
+        const bothEntered = new Promise(resolve => signalBothEntered = resolve);
+
+        MemoryCoreConfig.ollama.maxInFlightEmbeddings = 1;
+        TenantRepoSyncService.concurrencyLimit        = 2;
+
+        TextEmbeddingService.ollamaProvider = {
+            embed(inputs) {
+                providerInputs.push([...inputs]);
+
+                if (providerInputs.length === 1) {
+                    return new Promise((resolve, reject) => {
+                        firstProviderSettlement = {resolve, reject};
+                    })
+                }
+
+                return Promise.resolve({embeddings: inputs.map(() => [0.1])})
+            }
+        };
+
+        ingestionService.ingestSourceFilesForTenantSync = async (payload, controls) => {
+            // Start the real native admission path before announcing entry. When the second entry
+            // resolves `bothEntered`, repo B is already parked behind A's cap-owned provider call.
+            const embeddingPromise = TextEmbeddingService.embedTexts([payload.repoSlug], 'ollama', {
+                ...controls,
+                operationLabel          : 'tenant timeout circuit spec',
+                operationStage          : 'kb-tenant-ingestion-embedding',
+                providerActivityRecorder: null,
+                service                 : 'knowledge-base'
+            });
+
+            ingestionEntries.push(payload.repoSlug);
+            controlsSeen.push(controls);
+
+            if (ingestionEntries.length === 2) {
+                signalBothEntered();
+            }
+
+            try {
+                await embeddingPromise;
+
+                return {
+                    ingested           : 1,
+                    deleted            : 0,
+                    embeddingsGenerated: 1,
+                    errors             : [],
+                    tenantId           : payload.tenantId,
+                    durationMs         : 1
+                }
+            } catch (error) {
+                return {
+                    ingested           : 0,
+                    deleted            : 0,
+                    embeddingsGenerated: 0,
+                    errors             : [{code: classifyEmbedFailureCode(error.code)}],
+                    tenantId           : payload.tenantId,
+                    durationMs         : 1
+                }
+            }
+        };
+
+        const options = {
+            reason           : 'manual',
+            taskStateService,
+            tenantReposConfig: {tenantRepos: slugs.map((repoSlug, index) => ({
+                tenantId: 't1',
+                repoSlug,
+                mirrorRoot,
+                cloneUrl: `https://github.com/neomjs/circuit-${index}.git`
+            }))},
+            gitMirror                    : makeFakeGitMirror(),
+            envelopeBuilder              : makeFakeEnvelopeBuilder(),
+            knowledgeBaseIngestionService: ingestionService,
+            revisionsFilePath            : revisionsFile,
+            seedBootstrap                : false
+        };
+
+        try {
+            for (const repoSlug of slugs) {
+                await provisionMirrorDir({tenantId: 't1', repoSlug});
+            }
+
+            firstRunPromise = TenantRepoSyncService.runTask({...options, onlyRepoSlugs: slugs});
+            await bothEntered;
+
+            expect(ingestionEntries).toHaveLength(2);
+            expect(providerInputs, 'cap=1 admitted A while B is genuinely queued').toHaveLength(1);
+            expect(controlsSeen[0].signal, 'both repos share one run-scoped circuit').toBe(controlsSeen[1].signal);
+
+            const
+                dispatchedSlug = providerInputs[0][0],
+                queuedSlug     = slugs.find(repoSlug => repoSlug !== dispatchedSlug);
+
+            firstProviderSettlement.reject(timeoutError);
+
+            const first  = await firstRunPromise,
+                  bySlug = Object.fromEntries(first.details.repos.map(repo => [repo.repoSlug, repo]));
+
+            expect(providerInputs, 'the provider timeout must not hand its slot to repo B').toHaveLength(1);
+            expect(first).toMatchObject({
+                status : 'deferred',
+                details: {completedCount: 0, deferredCount: 2, failedCount: 0}
+            });
+            expect(bySlug[dispatchedSlug]).toMatchObject({
+                status             : 'deferred',
+                lastSourceErrorCode: 'KB_VECTOR_EMBED_PROVIDER_TIMEOUT'
+            });
+            expect(bySlug[queuedSlug]).toMatchObject({
+                status             : 'deferred',
+                lastSourceErrorCode: KB_VECTOR_EMBED_PROVIDER_CIRCUIT_OPEN
+            });
+            expect(taskStateService.taskState['tenant-repo-sync']).toMatchObject({
+                running       : false,
+                lastCompletion: {status: 'deferred'}
+            });
+
+            secondRunPromise = TenantRepoSyncService.runTask({
+                ...options,
+                reason       : 'manual-resume',
+                onlyRepoSlugs: [queuedSlug]
+            });
+
+            const second = await secondRunPromise;
+
+            expect(providerInputs, 'the later sweep, not the timed-out sweep, dispatches B').toEqual([
+                [dispatchedSlug],
+                [queuedSlug]
+            ]);
+            expect(controlsSeen[2].signal).not.toBe(controlsSeen[0].signal);
+            expect(controlsSeen[2].signal.aborted).toBe(false);
+            expect(second).toMatchObject({
+                status : 'completed',
+                details: {
+                    completedCount: 1,
+                    deferredCount : 0,
+                    failedCount   : 0,
+                    repos         : [{repoSlug: queuedSlug, status: 'active'}]
+                }
+            });
+            expect(taskStateService.taskState['tenant-repo-sync'].running).toBe(false);
+        } finally {
+            firstProviderSettlement?.reject(timeoutError);
+            await Promise.allSettled([firstRunPromise, secondRunPromise].filter(Boolean));
+            TextEmbeddingService.ollamaProvider = originalOllamaProvider;
+            restoreMCConfig();
+        }
     });
 
     test('a deferral at a capped failure streak retains its cause for the recovery lane', async () => {

--- a/test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncService.spec.mjs
@@ -53,7 +53,7 @@ import {
     resolveExitCode
 } from '../../../../../../../ai/scripts/maintenance/syncTenantRepos.mjs';
 import {readHealLedger} from '../../../../../../../ai/services/memory-core/helpers/healEventLedgerStore.mjs';
-import MemoryCoreConfig from '../../../../../../../ai/mcp/server/memory-core/config.mjs';
+import MemoryCoreConfig from '../../../../../../../ai/mcp/server/memory-core/config.template.mjs';
 import {PROVIDER_TIMEOUT_CODE} from '../../../../../../../ai/provider/createTimeoutError.mjs';
 import {
     KB_VECTOR_EMBED_PROVIDER_CIRCUIT_OPEN,

--- a/test/playwright/unit/ai/services/knowledge-base/IngestionService.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/IngestionService.spec.mjs
@@ -112,6 +112,7 @@ function createEmbeddingGuardrail(overrides = {}) {
 
 test.describe('IngestionService.ingestSourceFiles', () => {
     let Service;
+    let SafeService;
     let originals;
     let vectorCalls;
     let metrics;
@@ -119,6 +120,7 @@ test.describe('IngestionService.ingestSourceFiles', () => {
 
     test.beforeAll(async () => {
         Service = (await import('../../../../../../ai/services/knowledge-base/IngestionService.mjs')).default;
+        SafeService = (await import('../../../../../../ai/services.mjs')).KB_IngestionService;
     });
 
     test.beforeEach(() => {
@@ -207,6 +209,32 @@ test.describe('IngestionService.ingestSourceFiles', () => {
             chunksTotal   : 1,
             chunksEmbedded: 1
         });
+    });
+
+    test('#16995: the unwrapped tenant-sync entry preserves circuit controls outside OpenAPI', async () => {
+        const controller        = new AbortController(),
+              onProviderTimeout = () => {};
+        const payload = {
+            tenantId: 'tenant-a',
+            files   : [{parsedChunks: [validParsedChunk()]}]
+        };
+
+        await SafeService.ingestSourceFilesForTenantSync(payload, {
+            signal: controller.signal,
+            onProviderTimeout
+        });
+
+        expect(vectorCalls).toHaveLength(1);
+        expect(vectorCalls[0].options.signal, 'the exact run-scoped signal reaches VectorService')
+            .toBe(controller.signal);
+        expect(vectorCalls[0].options.onProviderTimeout, 'the synchronous hook is not stripped by makeSafe')
+            .toBe(onProviderTimeout);
+
+        vectorCalls.length = 0;
+        await Service.ingestSourceFiles(payload);
+
+        expect(vectorCalls[0].options.signal, 'ordinary public ingestion remains circuit-neutral').toBeUndefined();
+        expect(vectorCalls[0].options.onProviderTimeout, 'the control is internal, never implicit').toBeUndefined();
     });
 
     test('distinguishes NEVER-ATTEMPTED from idle, and discloses its process scope (#14028)', () => {

--- a/test/playwright/unit/ai/services/knowledge-base/VectorService.batchFailureIsolation.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/VectorService.batchFailureIsolation.spec.mjs
@@ -22,6 +22,8 @@ import {
     OPENAI_COMPATIBLE_REQUEST_TIMEOUT_CODE,
     PROVIDER_TIMEOUT_CODE
 } from '../../../../../../ai/provider/createTimeoutError.mjs';
+import {KB_VECTOR_EMBED_PROVIDER_CIRCUIT_OPEN}
+    from '../../../../../../ai/services/knowledge-base/helpers/embedFailureClassification.mjs';
 
 /**
  * Batch-failure isolation for `VectorService.embedChunks`.
@@ -359,6 +361,39 @@ test.describe('VectorService.embedChunks — one failing batch must not strand t
         } finally {
             globalThis.setTimeout = originalSetTimeout;
         }
+    });
+
+    test('#16995: circuit-open is provider-phase terminal and preserves the exact controls', async () => {
+        Object.assign(KB_Config.data, {batchSize: 1, batchDelay: 0, maxRetries: 5});
+
+        const
+            spy               = createSpyCollection(),
+            controller        = new AbortController(),
+            onProviderTimeout = () => {},
+            circuitError      = Object.assign(new Error('tenant provider circuit open'), {
+                code: KB_VECTOR_EMBED_PROVIDER_CIRCUIT_OPEN
+            });
+        let providerCalls = 0,
+            observedOptions;
+
+        TextEmbeddingService.embedTexts = async (texts, provider, options) => {
+            providerCalls++;
+            observedOptions = options;
+            throw circuitError
+        };
+
+        const thrown = await KB_VectorService.embedChunks({
+            collection     : spy,
+            chunksToProcess: makeChunks(2),
+            signal          : controller.signal,
+            onProviderTimeout
+        }).then(() => null, error => error);
+
+        expect(thrown, 'the never-dispatched repository keeps its bounded circuit reason').toBe(circuitError);
+        expect(providerCalls, 'an open circuit is not retried five times as provider work').toBe(1);
+        expect(observedOptions.signal).toBe(controller.signal);
+        expect(observedOptions.onProviderTimeout).toBe(onProviderTimeout);
+        expect(spy.upsertedIds).toEqual([]);
     });
 
     test('CALLER BOUNDARY: shadow-swap REFUSES to promote when a batch failed', async () => {

--- a/test/playwright/unit/ai/services/knowledge-base/embedFailureClassification.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/embedFailureClassification.spec.mjs
@@ -10,6 +10,7 @@ import '../../../../../../src/core/Base.mjs';
 import {
     BOUNDED_KB_ERROR_CODE_PATTERN,
     EMBED_DISPOSITION,
+    KB_VECTOR_EMBED_PROVIDER_CIRCUIT_OPEN,
     KB_VECTOR_EMBED_UNCLASSIFIED,
     classifyEmbedDisposition,
     classifyEmbedFailureCode,
@@ -88,6 +89,8 @@ test.describe('embed failure classification (#16647)', () => {
         // member, not because of how it is spelled — see the provenance test below.
         expect(classifyEmbedFailureCode('KB_SYNC_VOLUME_EXCEEDED')).toBe('KB_SYNC_VOLUME_EXCEEDED');
         expect(classifyEmbedFailureCode('KB_EMBEDDING_INPUT_SIZE_EXCEEDED')).toBe('KB_EMBEDDING_INPUT_SIZE_EXCEEDED');
+        expect(classifyEmbedFailureCode(KB_VECTOR_EMBED_PROVIDER_CIRCUIT_OPEN))
+            .toBe(KB_VECTOR_EMBED_PROVIDER_CIRCUIT_OPEN);
     });
 
     test('a provider-authored KB_-shaped code does NOT pass through — shape is not provenance', () => {
@@ -382,6 +385,7 @@ test.describe('classifyEmbedDisposition (retry-or-discard)', () => {
         'KB_VECTOR_EMBED_ABORTED',
         'KB_VECTOR_EMBED_CONNECTION_REFUSED',
         'KB_VECTOR_EMBED_MODEL_NOT_RESIDENT',
+        KB_VECTOR_EMBED_PROVIDER_CIRCUIT_OPEN,
         'KB_VECTOR_EMBED_TIMEOUT',
         'KB_VECTOR_EMBED_PROVIDER_TIMEOUT'
     ]) {
@@ -410,6 +414,7 @@ test.describe('classifyEmbedDisposition (retry-or-discard)', () => {
         // advancing, never surfacing a cause. This is the guard that keeps deferral opt-in by domain.
         expect(isEmbedFailureCode(KB_VECTOR_EMBED_UNCLASSIFIED)).toBe(true);
         expect(isEmbedFailureCode('KB_VECTOR_EMBED_TIMEOUT')).toBe(true);
+        expect(isEmbedFailureCode(KB_VECTOR_EMBED_PROVIDER_CIRCUIT_OPEN)).toBe(true);
         expect(isEmbedFailureCode('KB_TENANT_SPOOF_REJECTED')).toBe(true);
 
         // A real non-embed code from a sibling stage. It is bounded and legitimate, and it must NOT
@@ -432,6 +437,7 @@ test.describe('classifyEmbedDisposition (retry-or-discard)', () => {
             classifyEmbedFailureCode('EMBEDDING_MODEL_NOT_RESIDENT'),
             classifyEmbedFailureCode('ABORT_ERR'),
             classifyEmbedFailureCode('KB_EMBEDDING_INPUT_SIZE_EXCEEDED'),
+            classifyEmbedFailureCode(KB_VECTOR_EMBED_PROVIDER_CIRCUIT_OPEN),
             classifyEmbedFailureCode('an unmapped provider code')
         ];
 

--- a/test/playwright/unit/ai/services/memory-core/TextEmbeddingService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/TextEmbeddingService.spec.mjs
@@ -578,6 +578,103 @@ test.describe('TextEmbeddingService #11965 Sub-2 — native Ollama dispatch', ()
         }
     });
 
+    test('#16995: a provider timeout opens the sweep circuit before the queued caller can dispatch', async () => {
+        aiConfig.ollama.maxInFlightEmbeddings = 1;
+
+        const
+            activities = [],
+            recorder   = {
+                nextId: 0,
+                beginProviderActivity(entry) {
+                    const id = `circuit-${++this.nextId}`;
+
+                    activities.push({type: 'begin', id, ...entry});
+                    return id
+                },
+                startProviderActivity(id, startedAt) { activities.push({type: 'start', id, startedAt}) },
+                completeProviderActivity(id, outcome) { activities.push({type: 'complete', id, outcome}) }
+            },
+            controller   = new AbortController(),
+            timeoutError = Object.assign(new Error('native provider timed out'), {
+                code     : PROVIDER_TIMEOUT_CODE,
+                timeoutMs: 1800000
+            }),
+            circuitError = Object.assign(new Error('tenant sweep provider circuit is open'), {
+                code: 'KB_VECTOR_EMBED_PROVIDER_CIRCUIT_OPEN'
+            }),
+            hookErrors = [];
+
+        let providerCalls = 0,
+            rejectProvider;
+
+        TextEmbeddingService.ollamaProvider = {
+            embed() {
+                providerCalls++;
+                return new Promise((resolve, reject) => rejectProvider = reject)
+            }
+        };
+
+        const onProviderTimeout = error => {
+            hookErrors.push(error);
+            controller.abort(circuitError);
+        };
+        const first = TextEmbeddingService.embedTexts(['repo-a'], 'ollama', {
+            onProviderTimeout,
+            providerActivityRecorder: recorder,
+            signal                  : controller.signal
+        }).then(() => null, error => error);
+        const second = TextEmbeddingService.embedTexts(['repo-b'], 'ollama', {
+            onProviderTimeout,
+            providerActivityRecorder: recorder,
+            signal                  : controller.signal
+        }).then(() => null, error => error);
+
+        try {
+            await waitForCondition(
+                () => providerCalls === 1 &&
+                    activities.filter(item => item.type === 'begin').length === 2 &&
+                    activities.filter(item => item.type === 'start').length === 1,
+                'repo B to be queued behind repo A without provider dispatch'
+            );
+
+            rejectProvider(timeoutError);
+
+            const [firstError, secondError] = await Promise.all([first, second]);
+
+            expect(firstError, 'the dispatched caller retains the source provider timeout').toBe(timeoutError);
+            expect(secondError, 'the queued caller reports the circuit reason, not a fabricated timeout').toBe(circuitError);
+            expect(hookErrors, 'the source timeout opens the circuit exactly once').toEqual([timeoutError]);
+            expect(providerCalls, 'repo B must never reach native Ollama in this sweep').toBe(1);
+
+            const
+                queuedRow       = activities.filter(item => item.type === 'begin').at(-1),
+                queuedCompletion = activities.find(item => item.type === 'complete' && item.id === queuedRow.id);
+
+            expect(queuedCompletion?.outcome).toMatchObject({failureStage: 'queue', success: false});
+
+            const ordinaryError = new Error('ordinary provider rejection');
+
+            TextEmbeddingService.ollamaProvider = {async embed() { throw ordinaryError }};
+
+            const ordinaryObserved = await TextEmbeddingService.embedTexts(['ordinary'], 'ollama', {
+                onProviderTimeout
+            }).then(() => null, error => error);
+
+            expect(ordinaryObserved).toBe(ordinaryError);
+            expect(hookErrors, 'non-timeout provider errors must not open the tenant circuit').toEqual([timeoutError]);
+        } finally {
+            rejectProvider?.(timeoutError);
+            await Promise.allSettled([first, second]);
+
+            // A real post-condition rather than an internal counter: a leaked slot or waiter would
+            // leave this uncontended call parked and poison whichever spec runs next.
+            TextEmbeddingService.ollamaProvider = {
+                async embed() { return {embeddings: [[0.1, 0.2]]} }
+            };
+            await TextEmbeddingService.embedTexts(['drain'], 'ollama');
+        }
+    });
+
     test('#16880 NON-VACUITY: an UNCONTENDED caller also records neo-queued, with a ~zero wait', async () => {
         // Without this, the arm above passes against an implementation that only opens a row under
         // contention — which would make the queue look like it materializes at load rather than


### PR DESCRIPTION
Resolves neomjs/neo#16995

Related: neomjs/neo-agent-brain#54

One tenant repository native-Ollama provider timeout now opens a run-scoped circuit before native Ollama admission hands its slot to another queued repository. The dispatched repository retains its real provider-timeout outcome; never-dispatched peers defer under a distinct bounded circuit-open code; a later tenant sweep starts with a fresh circuit and resumes from durable Knowledge Base state. The repair does not abort native transport work or claim provider settlement.

Evidence: L2 (production-composed cap-1/two-repo unit witness plus an ordering mutation that dispatches the queued repository and turns the named test red) → L2 required (AC-1 through AC-7 are deterministic source-boundary contracts). Residual: None within neomjs/neo#16995's native-Ollama admission scope. OpenAI-compatible has a distinct serialized queue and Gemini has unqueued concurrency; provider-neutral policy remains outside this leaf and must preserve those different settlement boundaries.

## Deltas from ticket

- Added the distinct `KB_VECTOR_EMBED_PROVIDER_CIRCUIT_OPEN` cause so a repository that never reached the provider is not misreported as a provider timeout.
- Added `ingestSourceFilesForTenantSync(payload, controls)` as an unwrapped internal entry. The canonical OpenAPI-safe proxy forwards one validated argument, so a second control envelope on the public method would be silently discarded in production.
- Kept provider settlement ownership unchanged: the native-Ollama timeout hook opens the caller-owned sweep circuit synchronously before slot release, while the provider promise continues to own activity and admission until it settles.

## Test Evidence

- Native Ollama admission and settlement ordering: `TextEmbeddingService.spec.mjs` in the consolidated focused run.
- Knowledge Base classifier, ingestion control carriage, and provider-phase terminal behavior: `embedFailureClassification.spec.mjs`, `IngestionService.spec.mjs`, and `VectorService.batchFailureIsolation.spec.mjs` in the consolidated focused run.
- Tenant-task production composition and later-sweep resume: `TenantRepoSyncService.spec.mjs` in the consolidated focused run.
- `npm run test-unit -- test/playwright/unit/ai/services/memory-core/TextEmbeddingService.spec.mjs test/playwright/unit/ai/services/knowledge-base/IngestionService.spec.mjs test/playwright/unit/ai/services/knowledge-base/VectorService.batchFailureIsolation.spec.mjs test/playwright/unit/ai/services/knowledge-base/embedFailureClassification.spec.mjs test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncService.spec.mjs --workers=1` — 276/276 passed.
- Mutation witness: delaying `onProviderTimeout` by one timer turn made the two-repository spec fail with `providerInputs` length 2 instead of 1; restoring the synchronous boundary returned the exact witness to 3/3 passed.
- `git diff --check`, `node --check` over all ten modified modules/specs, and the repository pre-commit guards passed.

## Post-Merge Validation

- [ ] Deploy a revision containing this repair and the predecessor timeout-terminal sweep repair, then confirm a native-Ollama provider timeout emits no later same-run tenant-repository provider start.
- [ ] Confirm the next scheduled or manual tenant sweep starts with a fresh circuit and advances the deferred repository checkpoint/corpus state.
- [ ] After pre-deployment provider work drains or the model is recycled once, confirm zero current/recent provider demand and either idle model CPU or the existing exact-target residual-load recovery action.

## Evolution

The first source trace placed the circuit only at the tenant task. Falsification showed that opening it after ingestion returns is too late because native admission has already woken the next waiter. The final shape therefore carries one internal control envelope to the provider-settlement boundary and opens the circuit synchronously before release, without changing MCP schemas or native transport cancellation.

Authored by Emmy (GPT-5.6 Sol Ultra, Codex). Session 019fe5e8-b963-7e93-8762-c8e4af16bdec.
