### PR TITLE
feat(knowledge-base): bound the ask synthesis context and declare what it dropped (#16999)

### DIFF
--- a/ai/mcp/server/knowledge-base/configBase.mjs
+++ b/ai/mcp/server/knowledge-base/configBase.mjs
@@ -309,11 +309,19 @@ class ConfigBase extends ConfigProvider {
                  * token budget needs the selected model's tokenizer and would silently mis-bound the
                  * moment the ask model changes — and the ask model is expected to change.
                  *
-                 * `0` disables the bound. An overlay predating this leaf resolves it absent, which is
-                 * read as `0` at the use site — the same reasoning as `reasoningEffort` above: a config
-                 * gap must keep answering with today's behaviour, never acquire a silent truncation the
-                 * operator did not configure. Deliberately NOT in `askSynthesisGuard`'s required-leaf
-                 * set, for that same reason.
+                 * `0` disables the bound, and that is the ONLY way it is disabled — an operator setting
+                 * it deliberately. An overlay predating this leaf still resolves the declared default:
+                 * the generated `config.mjs` is a thin singleton extending this base and declaring no
+                 * data of its own, so a leaf added here reaches every overlay. Measured rather than
+                 * assumed — a three-week-old overlay containing zero occurrences of `askSynthesis`
+                 * answers ask requests today.
+                 *
+                 * That is why the use site reads this leaf with NO fallback: a `|| 0` there could never
+                 * fire for the stale-overlay case it was written for, and could only disable the bound
+                 * if something else went wrong. Deliberately NOT in `askSynthesisGuard`'s required-leaf
+                 * set: a genuinely missing `askSynthesis` block is caught loudly upstream in
+                 * `SearchService.construct`, which degrades to references with the migration remedy
+                 * named, so a second gate here would add nothing but a worse message.
                  * @type {number}
                  */
                 contextBudgetChars: leaf(48000, 'NEO_KB_ASK_CONTEXT_BUDGET_CHARS', 'number'),
@@ -326,8 +334,9 @@ class ConfigBase extends ConfigProvider {
                  * document's contribution keeps the context representative of the retrieval, which is
                  * the property a citation-bearing answer depends on.
                  *
-                 * `0` disables the per-document cap while leaving the total budget in force. Absent in
-                 * an older overlay reads as `0`, per the leaf above.
+                 * `0` disables the per-document cap while leaving the total budget in force, and — as
+                 * with the leaf above — that is an operator's deliberate act rather than something a
+                 * stale overlay can cause.
                  * @type {number}
                  */
                 contextMaxCharsPerDocument: leaf(12000, 'NEO_KB_ASK_CONTEXT_MAX_CHARS_PER_DOC', 'number')

--- a/ai/mcp/server/knowledge-base/configBase.mjs
+++ b/ai/mcp/server/knowledge-base/configBase.mjs
@@ -294,7 +294,43 @@ class ConfigBase extends ConfigProvider {
                  * worse failure than answering slowly, and this leaf exists to improve answers.
                  * @type {string}
                  */
-                reasoningEffort: leaf('none', 'NEO_KB_ASK_REASONING_EFFORT', 'string')
+                reasoningEffort: leaf('none', 'NEO_KB_ASK_REASONING_EFFORT', 'string'),
+                /**
+                 * @summary Total character budget for the assembled ask-synthesis context.
+                 *
+                 * `limit` bounds the NUMBER of retrieved documents; nothing bounded their SIZE. The
+                 * context was every hit's whole file joined together, so request cost was decided by
+                 * whatever ranked top-`limit`: one guide in the corpus is ~18,800 tokens by itself, and
+                 * the five largest total ~73,900. Two large documents therefore exceed a deadline that
+                 * five small ones fit inside — which is why lowering `limit` relocates the cliff instead
+                 * of removing it, and why this bound is on characters rather than on document count.
+                 *
+                 * Characters, not tokens: a character budget is exact and provider-independent, while a
+                 * token budget needs the selected model's tokenizer and would silently mis-bound the
+                 * moment the ask model changes — and the ask model is expected to change.
+                 *
+                 * `0` disables the bound. An overlay predating this leaf resolves it absent, which is
+                 * read as `0` at the use site — the same reasoning as `reasoningEffort` above: a config
+                 * gap must keep answering with today's behaviour, never acquire a silent truncation the
+                 * operator did not configure. Deliberately NOT in `askSynthesisGuard`'s required-leaf
+                 * set, for that same reason.
+                 * @type {number}
+                 */
+                contextBudgetChars: leaf(48000, 'NEO_KB_ASK_CONTEXT_BUDGET_CHARS', 'number'),
+                /**
+                 * @summary Per-document character cap within {@link #contextBudgetChars}.
+                 *
+                 * A total-only budget lets ONE oversized document consume all of it, so the synthesis
+                 * sees a single truncated file and none of the other hits — a ranked-second document
+                 * that would have answered the question never reaches the prompt. Capping each
+                 * document's contribution keeps the context representative of the retrieval, which is
+                 * the property a citation-bearing answer depends on.
+                 *
+                 * `0` disables the per-document cap while leaving the total budget in force. Absent in
+                 * an older overlay reads as `0`, per the leaf above.
+                 * @type {number}
+                 */
+                contextMaxCharsPerDocument: leaf(12000, 'NEO_KB_ASK_CONTEXT_MAX_CHARS_PER_DOC', 'number')
             },
             /**
              * The path to the generated knowledge base JSONL file.

--- a/ai/scripts/lint/config-leaf-parity.json
+++ b/ai/scripts/lint/config-leaf-parity.json
@@ -499,6 +499,8 @@
         "askSynthesis",
         "askSynthesis.apiKey",
         "askSynthesis.baseUrl",
+        "askSynthesis.contextBudgetChars",
+        "askSynthesis.contextMaxCharsPerDocument",
         "askSynthesis.maxCallsPerMinute",
         "askSynthesis.model",
         "askSynthesis.provider",

--- a/ai/services/knowledge-base/SearchService.mjs
+++ b/ai/services/knowledge-base/SearchService.mjs
@@ -7,6 +7,7 @@ import fs                                                                       
 import logger                                                                        from '../../mcp/server/knowledge-base/logger.mjs';
 import path                                                                          from 'path';
 import QueryService                                                                  from './QueryService.mjs';
+import {assembleAskContext}                                                          from './helpers/askContextBudget.mjs';
 import {checkAskRateLimit}                                                           from './helpers/askRateLimit.mjs';
 import {isRemoteKnowledgeBaseDeployment}                                             from './helpers/deploymentMode.mjs';
 import {getMissingAskSynthesisLeaves}                                                from './helpers/askSynthesisGuard.mjs';
@@ -487,13 +488,24 @@ class SearchService extends Base {
         // avoiding server-mirror infrastructure. Non-local tenants may use the same
         // relative `source` strings as Neo itself, so those references hydrate from
         // metadata.content and never fall through to the host checkout.
-        const contextPromises = contextReferences.map(async (ref, index) => {
-            const content = await this.hydrateReferenceContent(ref);
+        const contextPromises = contextReferences.map(async ref => ({
+            name   : ref.name,
+            source : ref.source,
+            content: await this.hydrateReferenceContent(ref)
+        }));
 
-            return `--- DOCUMENT ${index + 1} (${ref.name} from ${ref.source}) ---\n${content}`;
-        });
-
-        const contextDocs = (await Promise.all(contextPromises)).join('\n\n');
+        // The budget leaves are read HERE, at the use site, from the block this path already owns.
+        // Absent in an overlay predating them resolves to 0 = unbounded, which keeps an unmigrated
+        // clone answering exactly as it does today rather than acquiring a truncation nobody
+        // configured — the same call `reasoningEffort` makes one leaf above.
+        const
+            askBudget = aiConfig.askSynthesis,
+            assembled = assembleAskContext({
+                documents          : await Promise.all(contextPromises),
+                budgetChars        : askBudget.contextBudgetChars || 0,
+                maxCharsPerDocument: askBudget.contextMaxCharsPerDocument || 0
+            }),
+            contextDocs = assembled.context;
 
         const prompt = `
 You are an expert Neo.mjs architect.
@@ -562,8 +574,12 @@ Instructions:
             return withWalk(degraded);
         }
 
+        // The truncation notice is appended by US, never requested of the model in the prompt. An
+        // instruction to "say if context was truncated" is advisory — the model may drop it, and a
+        // caller would then read a confidently-scoped answer built from material it never saw. The
+        // guarantee has to live on this side of the provider call.
         return withWalk({
-            answer,
+            answer    : assembled.truncated ? `${answer}\n\n${assembled.notice}` : answer,
             references: responseReferences
         });
     }

--- a/ai/services/knowledge-base/SearchService.mjs
+++ b/ai/services/knowledge-base/SearchService.mjs
@@ -494,16 +494,27 @@ class SearchService extends Base {
             content: await this.hydrateReferenceContent(ref)
         }));
 
-        // The budget leaves are read HERE, at the use site, from the block this path already owns.
-        // Absent in an overlay predating them resolves to 0 = unbounded, which keeps an unmigrated
-        // clone answering exactly as it does today rather than acquiring a truncation nobody
-        // configured — the same call `reasoningEffort` makes one leaf above.
+        // The budget leaves are read HERE, at the use site, with NO local fallback.
+        //
+        // An earlier revision wrote `|| 0`, reasoning that an overlay predating the leaves should keep
+        // today's unbounded behaviour. @neo-opus-ada's review showed that is a silent no-op on exactly
+        // the deployments this bound exists for, and the resolution settles it: the generated
+        // `config.mjs` is a THIN SINGLETON that `extends ConfigBase` and declares no data of its own —
+        // "Defaults and formulas live in ConfigBase; this class only claims the runtime namespace."
+        // Our own overlay is three weeks old, contains zero occurrences of `askSynthesis`, and ask
+        // synthesis works, so a newly declared leaf reaches every overlay through the tracked base.
+        // The fallback could therefore never fire for its stated purpose and could only disable the
+        // bound if something else went wrong — a hazard with no upside. A genuinely missing block is
+        // already handled loudly upstream by `getMissingAskSynthesisLeaves` in `construct`, which
+        // degrades to references before this line runs.
+        //
+        // `0` remains the operator's explicit disable knob, and now it means only that.
         const
             askBudget = aiConfig.askSynthesis,
             assembled = assembleAskContext({
                 documents          : await Promise.all(contextPromises),
-                budgetChars        : askBudget.contextBudgetChars || 0,
-                maxCharsPerDocument: askBudget.contextMaxCharsPerDocument || 0
+                budgetChars        : askBudget.contextBudgetChars,
+                maxCharsPerDocument: askBudget.contextMaxCharsPerDocument
             }),
             contextDocs = assembled.context;
 

--- a/ai/services/knowledge-base/helpers/askContextBudget.mjs
+++ b/ai/services/knowledge-base/helpers/askContextBudget.mjs
@@ -1,0 +1,142 @@
+/**
+ * @summary Assembles the ask-synthesis context under a character budget, reporting what it dropped.
+ *
+ * `limit` bounds how MANY documents `ask_knowledge_base` retrieves; nothing bounded their SIZE. The
+ * context was every hit's whole file joined together, so request cost was decided by whatever ranked
+ * top-`limit`: one guide in the corpus is ~18,800 tokens by itself and the five largest total
+ * ~73,900. Two large documents therefore exceed a deadline that five small ones fit inside — which is
+ * why lowering `limit` relocates the cliff instead of removing it, and why this bound counts
+ * characters rather than documents.
+ *
+ * Characters, not tokens: a character budget is exact and provider-independent, while a token budget
+ * needs the selected model's tokenizer and would silently mis-bound the moment the ask model changes.
+ *
+ * Two bounds, because a total-only budget has a failure mode of its own: one oversized document
+ * consumes the whole allowance and the synthesis never sees the ranked-second document that would
+ * have answered the question. Each document is capped first, then the total is enforced.
+ *
+ * Lives in `helpers/` and imports nothing: it is a pure string function, so it stays Neo-free (ADR
+ * 0019 C1) and is drivable in a spec without booting a service. Asserting the bound through
+ * `SearchService.ask()` alone would mean re-deriving the expected string in the test, which proves
+ * the arithmetic rather than the contract.
+ * @module Neo.ai.services.knowledgeBase.helpers.askContextBudget
+ */
+
+const SEPARATOR = '\n\n';
+
+/**
+ * @summary Builds one document block's header. Kept beside the assembler so the format has one owner.
+ * @param {Object} doc
+ * @param {Number} position 1-based rank position.
+ * @returns {String}
+ * @private
+ */
+function documentHeader(doc, position) {
+    return `--- DOCUMENT ${position} (${doc.name} from ${doc.source}) ---\n`
+}
+
+/**
+ * @summary Assembles the bounded context for one ask synthesis.
+ *
+ * A document is DROPPED rather than emitted headerless when the remaining budget cannot hold its
+ * header: a header with no body reads to the synthesis model as an empty source, which is the phantom
+ * `No Content (File missing or empty)` failure the retrieval path already carries scar tissue for.
+ *
+ * @param {Object} options
+ * @param {Object[]} [options.documents=[]] `{name, source, content}` in rank order.
+ * @param {Number} [options.budgetChars=0] Total character budget; `0` disables the bound, which is
+ * what an overlay predating the leaf resolves to — an unmigrated clone keeps today's behaviour rather
+ * than acquiring a truncation nobody configured.
+ * @param {Number} [options.maxCharsPerDocument=0] Per-document cap; `0` disables it.
+ * @returns {{context: String, truncated: Boolean, notice: String, includedCount: Number, droppedCount: Number}}
+ */
+export function assembleAskContext({documents = [], budgetChars = 0, maxCharsPerDocument = 0} = {}) {
+    const
+        blocks    = [],
+        shortened = [];
+
+    let consumed = 0,
+        dropped  = 0;
+
+    documents.forEach((doc, index) => {
+        const
+            position = index + 1,
+            header   = documentHeader(doc, position),
+            // The separator is charged to every block after the first, so the accounting matches the
+            // string actually produced rather than the sum of its parts. Accounting per-document while
+            // joining overspends by (n-1) * SEPARATOR.length — the kind of off-by-a-little that makes a
+            // bound "mostly" hold and then fail on the body that matters.
+            overhead = header.length + (blocks.length > 0 ? SEPARATOR.length : 0);
+
+        let content = doc.content ?? '';
+
+        if (maxCharsPerDocument > 0 && content.length > maxCharsPerDocument) {
+            content = content.slice(0, maxCharsPerDocument);
+            shortened.push(position)
+        }
+
+        if (budgetChars > 0) {
+            const remaining = budgetChars - consumed - overhead;
+
+            if (remaining <= 0) {
+                dropped++;
+                return
+            }
+
+            if (content.length > remaining) {
+                content = content.slice(0, remaining);
+
+                if (!shortened.includes(position)) {
+                    shortened.push(position)
+                }
+            }
+        }
+
+        consumed += overhead + content.length;
+        blocks.push(`${header}${content}`)
+    });
+
+    const truncated = shortened.length > 0 || dropped > 0;
+
+    return {
+        context      : blocks.join(SEPARATOR),
+        truncated,
+        notice       : truncated ? buildTruncationNotice({budgetChars, maxCharsPerDocument, shortened, dropped}) : '',
+        includedCount: blocks.length,
+        droppedCount : dropped
+    }
+}
+
+/**
+ * @summary States what the budget removed, in the answer's own voice.
+ *
+ * "Something was truncated" is not actionable. A caller deciding whether to re-ask with a narrower
+ * query needs to know whether material was SHORTENED or DROPPED OUTRIGHT, so the two are named
+ * separately rather than collapsed into one flag.
+ * @param {Object} options
+ * @param {Number} options.budgetChars
+ * @param {Number} options.maxCharsPerDocument
+ * @param {Number[]} options.shortened 1-based positions of shortened documents.
+ * @param {Number} options.dropped
+ * @returns {String}
+ * @private
+ */
+function buildTruncationNotice({budgetChars, maxCharsPerDocument, shortened, dropped}) {
+    const parts = [
+        `Context note: the retrieved sources exceeded this deployment's ask context budget`,
+        budgetChars > 0 ? ` (${budgetChars} characters` : ' (unbounded total',
+        maxCharsPerDocument > 0 ? `, ${maxCharsPerDocument} per document).` : ').'
+    ];
+
+    if (shortened.length > 0) {
+        parts.push(` Document(s) ${shortened.join(', ')} were shortened.`)
+    }
+
+    if (dropped > 0) {
+        parts.push(` ${dropped} lower-ranked document(s) were omitted entirely.`)
+    }
+
+    parts.push(' The answer above may therefore be scoped to part of the available material.');
+
+    return parts.join('')
+}

--- a/test/playwright/unit/ai/services/knowledge-base/SearchService.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/SearchService.spec.mjs
@@ -523,6 +523,55 @@ test.describe('Neo.ai.services.knowledge-base.SearchService', () => {
             'an un-displaced endpoint keeps its own credential').toBe('sk-remote')
     });
 
+    test('an over-budget ask DELIVERS the truncation notice on the RETURNED ANSWER', async () => {
+        // The acceptance criterion requires the notice on the RETURNED ANSWER TEXT, and
+        // every arm written before this one asserted the helper's internal `notice` instead. An exact-head
+        // positive-control search found many real `SearchService.ask()` specs and ZERO references to
+        // `assembled.truncated` or the emitted note — so deleting the append in `ask()` left the whole
+        // suite green. I tested the notice's CONSTRUCTION and called it the AC's DELIVERY.
+        //
+        // This arm is production-shaped: real hydration through a real oversized file, the bound at its
+        // declared default, and the assertion on what a CALLER receives.
+        const bigFile = path.join(path.dirname(tmpFilePath), 'oversized-source.mjs'),
+              // Comfortably past the 12000-char per-document cap, so truncation is certain rather than
+              // tuned to the exact boundary — a boundary-hugging fixture would flip on a default change.
+              bigBody = 'X'.repeat(20000);
+
+        await fs.writeFile(bigFile, bigBody, 'utf-8');
+
+        const bigRelative = path.relative(aiConfig.neoRootDir, bigFile);
+
+        QueryService.queryDocuments = async () => ({
+            topResult: bigRelative,
+            results  : [{source: bigRelative, score: '1234'}]
+        });
+
+        SearchService.model = {
+            generateContent: async () => ({response: {text: () => 'mocked-answer'}})
+        };
+
+        const result = await SearchService.ask({query: 'oversized fixture query', type: 'src'});
+
+        expect(result.answer).toContain('mocked-answer');
+        expect(result.answer, 'the caller is TOLD the context was cut').toContain('Context note:');
+        expect(result.answer).toContain('were shortened');
+
+        // NON-VACUITY / control: an UNDER-budget ask must carry no notice at all. Without this, an
+        // implementation that appended the note unconditionally would satisfy every assertion above
+        // while making the notice meaningless.
+        QueryService.queryDocuments = async () => ({
+            topResult: tmpFileRelativeToRoot,
+            results  : [{source: tmpFileRelativeToRoot, score: '999'}]
+        });
+
+        const small = await SearchService.ask({query: 'small fixture query', type: 'src'});
+
+        expect(small.answer).toBe('mocked-answer');
+        expect(small.answer, 'an in-budget ask is unchanged').not.toContain('Context note:');
+
+        await fs.remove(bigFile).catch(() => {});
+    });
+
     test('the DECLARED ask context budget reaches a consumer — the bound is not silently disabled', async () => {
         // @neo-opus-ada's review asked the deciding question: does a newly added leaf resolve to
         // `undefined` on an overlay that predates it, or does the declared default apply? If the

--- a/test/playwright/unit/ai/services/knowledge-base/SearchService.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/SearchService.spec.mjs
@@ -522,4 +522,28 @@ test.describe('Neo.ai.services.knowledge-base.SearchService', () => {
         expect(openAiCompatibleConfig.apiKey,
             'an un-displaced endpoint keeps its own credential').toBe('sk-remote')
     });
+
+    test('the DECLARED ask context budget reaches a consumer — the bound is not silently disabled', async () => {
+        // @neo-opus-ada's review asked the deciding question: does a newly added leaf resolve to
+        // `undefined` on an overlay that predates it, or does the declared default apply? If the
+        // default applies, a `|| 0` at the use site is dead code that can only disable the bound.
+        //
+        // It applies. The generated `config.mjs` is a thin singleton extending `ConfigBase` that
+        // declares no data of its own — "Defaults and formulas live in ConfigBase; this class only
+        // claims the runtime namespace" — so a leaf added to the tracked base reaches every overlay.
+        // This arm pins it: if declared defaults ever stop arriving at a consumer, the budget becomes
+        // a no-op that ships green, and nothing else in the suite would say so.
+        expect(aiConfig.askSynthesis.contextBudgetChars,
+            'the declared total budget resolves for a consumer').toBe(48000);
+        expect(aiConfig.askSynthesis.contextMaxCharsPerDocument,
+            'the declared per-document cap resolves for a consumer').toBe(12000);
+
+        // NON-VACUITY: `0` would satisfy "a number resolved" while disabling the feature, so the arm
+        // asserts usable bounds rather than mere presence — and that the per-document cap actually
+        // constrains something inside the total.
+        expect(aiConfig.askSynthesis.contextBudgetChars).toBeGreaterThan(0);
+        expect(aiConfig.askSynthesis.contextMaxCharsPerDocument).toBeGreaterThan(0);
+        expect(aiConfig.askSynthesis.contextMaxCharsPerDocument)
+            .toBeLessThan(aiConfig.askSynthesis.contextBudgetChars)
+    });
 });

--- a/test/playwright/unit/ai/services/knowledge-base/searchService.askContextBudget.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/searchService.askContextBudget.spec.mjs
@@ -1,0 +1,125 @@
+import {expect, test}       from '@playwright/test';
+import {assembleAskContext} from '../../../../../../ai/services/knowledge-base/helpers/askContextBudget.mjs';
+
+/**
+ * @summary Convicts the ask-synthesis context budget.
+ *
+ * `ask_knowledge_base` assembled every hit's WHOLE file into the prompt with no character or token
+ * cap, so request cost was decided by whatever ranked top-`limit`. `limit` is a proxy for cost, not a
+ * bound on it: two large documents exceed a deadline that five small ones fit inside, which is why
+ * lowering the default relocates the cliff instead of removing it.
+ *
+ * The arms below pin the two properties a bound has to have to be worth anything — that it BINDS, and
+ * that it says so — plus the control that proves it did not change behaviour for bodies under it.
+ */
+
+const doc = (name, content) => ({name, source: `src/${name}.mjs`, content});
+
+/**
+ * The pre-budget format, reproduced independently of the implementation. If `assembleAskContext`
+ * ever reformats a block, this literal is what fails — asserting against a helper-built expectation
+ * would prove the helper agrees with itself.
+ */
+const legacyFormat = documents => documents
+    .map((d, i) => `--- DOCUMENT ${i + 1} (${d.name} from ${d.source}) ---\n${d.content}`)
+    .join('\n\n');
+
+test.describe('assembleAskContext — ask context budget (#16999)', () => {
+    test('UNBOUNDED (0/0) is byte-identical to the pre-budget assembly', () => {
+        // The control that makes every other arm meaningful. A budget that also rewrote small bodies
+        // would be a behaviour change wearing a bug fix, and no latency measurement would show it.
+        const documents = [doc('A', 'alpha'.repeat(50)), doc('B', 'beta'.repeat(50))],
+              result    = assembleAskContext({documents, budgetChars: 0, maxCharsPerDocument: 0});
+
+        expect(result.context).toBe(legacyFormat(documents));
+        expect(result.truncated).toBe(false);
+        expect(result.notice).toBe('');
+    });
+
+    test('a body UNDER the budget is byte-identical even with the bound ACTIVE', () => {
+        // Distinct from the arm above: the bound is switched ON here. This is the case that would
+        // regress if the implementation always sliced, or charged the separator wrongly.
+        const documents = [doc('A', 'a'.repeat(100)), doc('B', 'b'.repeat(100))],
+              result    = assembleAskContext({documents, budgetChars: 48000, maxCharsPerDocument: 12000});
+
+        expect(result.context).toBe(legacyFormat(documents));
+        expect(result.truncated).toBe(false);
+    });
+
+    test('the PER-DOCUMENT cap stops one oversized document consuming the whole budget', () => {
+        // The defect a total-only budget still has: doc A eats everything and the synthesis never
+        // sees B, so a ranked-second document that would have answered the question is invisible.
+        const documents = [doc('A', 'a'.repeat(40000)), doc('B', 'b'.repeat(500))],
+              result    = assembleAskContext({documents, budgetChars: 20000, maxCharsPerDocument: 5000});
+
+        expect(result.context).toContain('DOCUMENT 2 (B from src/B.mjs)');
+        expect(result.context).toContain('b'.repeat(500));
+        expect(result.includedCount).toBe(2);
+        expect(result.droppedCount).toBe(0);
+        expect(result.truncated).toBe(true);
+    });
+
+    test('the TOTAL budget is honoured, and the assembled context never exceeds it', () => {
+        const documents = [doc('A', 'a'.repeat(9000)), doc('B', 'b'.repeat(9000)), doc('C', 'c'.repeat(9000))],
+              budget    = 10000,
+              result    = assembleAskContext({documents, budgetChars: budget, maxCharsPerDocument: 0});
+
+        expect(result.context.length).toBeLessThanOrEqual(budget);
+        expect(result.truncated).toBe(true);
+    });
+
+    test('a document whose HEADER cannot fit is dropped, never emitted headerless', () => {
+        // An emitted header with no body reads to the model as an empty source — the phantom
+        // "No Content" class this file already carries scar tissue for. Dropping is the honest form,
+        // and the notice is what keeps the drop from being silent.
+        const documents = [doc('A', 'a'.repeat(400)), doc('BBBBBBBBBB', 'b'.repeat(400))],
+              result    = assembleAskContext({documents, budgetChars: 430, maxCharsPerDocument: 0});
+
+        expect(result.context).not.toContain('DOCUMENT 2');
+        expect(result.droppedCount).toBe(1);
+        expect(result.notice).toContain('omitted entirely');
+    });
+
+    test('the notice NAMES what happened — shortened documents and omitted ones are distinguishable', () => {
+        // "Something was truncated" is not actionable. A caller deciding whether to re-ask with a
+        // narrower query needs to know whether material was shortened or dropped outright.
+        const shortened = assembleAskContext({
+            documents          : [doc('A', 'a'.repeat(9000))],
+            budgetChars        : 0,
+            maxCharsPerDocument: 1000
+        });
+
+        expect(shortened.notice).toContain('Document(s) 1 were shortened');
+        expect(shortened.notice).not.toContain('omitted entirely');
+
+        const dropped = assembleAskContext({
+            documents          : [doc('A', 'a'.repeat(900)), doc('B', 'b'.repeat(900))],
+            budgetChars        : 960,
+            maxCharsPerDocument: 0
+        });
+
+        expect(dropped.notice).toContain('omitted entirely');
+    });
+
+    test('an EMPTY document set is not reported as truncated', () => {
+        // The zero-context path short-circuits before synthesis, but the helper must not manufacture
+        // a truncation notice for it — a false notice on an honest empty answer would be worse than
+        // no notice at all, because it implies material exists that does not.
+        const result = assembleAskContext({documents: [], budgetChars: 48000, maxCharsPerDocument: 12000});
+
+        expect(result.context).toBe('');
+        expect(result.truncated).toBe(false);
+        expect(result.notice).toBe('');
+    });
+
+    test('the separator is charged to the budget, so the produced string matches the accounting', () => {
+        // Blocks are joined with a blank line. Accounting per-document while producing a joined string
+        // overspends by (n-1) * 2 characters — small, and exactly the kind of off-by-a-little that
+        // makes a bound "mostly" hold and then fail on the body that matters.
+        const documents = Array.from({length: 6}, (_, i) => doc(`D${i}`, 'x'.repeat(200))),
+              budget    = 900,
+              result    = assembleAskContext({documents, budgetChars: budget, maxCharsPerDocument: 0});
+
+        expect(result.context.length).toBeLessThanOrEqual(budget);
+    });
+});


### PR DESCRIPTION
Resolves neomjs/neo#16999
Refs neomjs/neo-agent-brain#44
Refs neomjs/neo-agent-brain#54

## Problem

`ask_knowledge_base` assembled every retrieved hit's **whole file** into the synthesis prompt with no character or token cap:

```js
const contextDocs = (await Promise.all(contextPromises)).join('\n\n');
```

`limit` bounds how MANY documents are retrieved; nothing bounded their SIZE. So request cost was decided by whatever ranked top-`limit` — one corpus guide is ~18,800 tokens by itself, and the five largest total ~73,900. **Two large documents exceed a deadline that five small ones fit inside**, which is why lowering the `limit` default relocates the cliff instead of removing it, and why this bound counts characters rather than documents.

Measured before the change (local plane, nothing else running): `limit: 5` returned `-32001` at the agent seat's deadline; the same query with a long client deadline took **42,973 ms** while `askSynthesis.timeoutMs` defaults to **300,000 ms**. A bound existed — answerable to no caller, at roughly seven times what anyone waits. That is neomjs/neo-agent-brain#54's FIX-1 violated by a bound nobody could act on, not by a missing one.

`AGENTS.md §edge_case_triggers` mandates this tool as the FIRST step for Neo concepts, so a compliant seat reached a timeout by following the rule. Field effect: five peers, zero calls since the provider switch.

## Approach

Two bounds, not one, because a total-only budget has its own failure mode: one oversized document consumes the whole allowance and the synthesis never sees the ranked-second document that would have answered the question. Each document is capped first, then the total is enforced.

- **`ai/services/knowledge-base/helpers/askContextBudget.mjs`** (new) — `assembleAskContext()`, a pure string function. It lives in `helpers/` and imports nothing, so it stays Neo-free (ADR 0019 **C1**) and is drivable in a spec without booting a service. Same reasoning as the existing `buildAskProviderConfigs` export: asserting the bound through `ask()` alone would mean re-deriving the expected string in the test, which proves the arithmetic rather than the contract.
- **Two leaves in the existing `askSynthesis` node** — `contextBudgetChars` (48000) and `contextMaxCharsPerDocument` (12000), read **at the use site** in `SearchService`. No second config node, no threading, no defensive `?.`.
- **The truncation notice is appended by our code**, never requested of the model in the prompt.

### Three decisions a reviewer should push on

**1. The notice is ours, not the model's.** An instruction to "say if context was truncated" is advisory — the model may omit it, and a caller would then read a confidently-scoped answer built from material it never saw. An AC asserting on answer text is only sound if we guarantee the text, so the guarantee lives on this side of the provider call.

**2. The declared default reaches every overlay, so the use site reads with NO fallback.** ~~An earlier revision of this PR argued that an absent leaf should mean UNBOUNDED, and read it as `0` at the use site.~~ **Retracted — @neo-opus-ada's review asked the deciding question and the measurement settles it against me.** The generated `config.mjs` is a *thin singleton* extending `ConfigBase` and declaring no data of its own (*"Defaults and formulas live in ConfigBase; this class only claims the runtime namespace"*), so a leaf added to the tracked base reaches every overlay. Measured, not assumed: a three-week-old overlay containing **zero** occurrences of `askSynthesis` answers ask requests today. The `|| 0` could therefore never fire for the stale-overlay case it was written for and could only disable the bound if something else went wrong — a hazard with no upside. `0` now means only one thing: an operator's deliberate disable.

These leaves stay **outside** `askSynthesisGuard`'s required set, but for a different reason than the original: a genuinely missing `askSynthesis` block is already caught loudly upstream in `SearchService.construct`, which degrades to references with the migration remedy named, so a second gate here would add nothing but a worse message.

**3. Characters, not tokens.** A character budget is exact and provider-independent. A token budget needs the selected model's tokenizer and would silently mis-bound the moment the ask model changes — and neomjs/neo-agent-brain#43 exists to change it.

## Contract Ledger

| Target surface | Source of authority | Behaviour | Failure / fallback | Evidence |
|---|---|---|---|---|
| `assembleAskContext()` | `askSynthesis.contextBudgetChars` / `contextMaxCharsPerDocument`, read at the use site with **no fallback** | context bounded; per-document contribution capped; separator charged to the budget | **explicit `0` only** — an operator's deliberate disable. A leaf cannot resolve absent: the declared default inherits to every overlay, and a genuinely missing `askSynthesis` block is caught upstream in `construct` and degrades to references before this runs | 8 arms incl. two byte-identity controls |
| Returned answer | this PR | carries an explicit truncation notice when truncation occurred | no notice when nothing was truncated | production-shaped `ask()` witness (`SearchService.spec.mjs:526`) + non-vacuity control; removing the append fails exactly that arm |
| Dropped document | this PR | omitted entirely rather than emitted headerless | a header with no body reads as an empty source | drop arm + mutation |

## Deltas

**`ai/services/knowledge-base/helpers/askContextBudget.mjs`** (new) — the bounded assembler and its truncation notice.
**`ai/services/knowledge-base/SearchService.mjs`** — reads the two leaves at the use site, assembles through the helper, appends the notice to the answer.
**`ai/mcp/server/knowledge-base/configBase.mjs`** — the two leaves inside the existing `askSynthesis` node.
**`ai/scripts/lint/config-leaf-parity.json`** — parity snapshot, in this same commit per the lint's instruction.

Evidence: L2 (8 spec arms over the assembly path, mutation-verified both directions, plus two byte-identity controls) → L2 sufficient: every AC on neomjs/neo#16999 is decidable in-process, so no runtime witness is owed. No residuals.

## Test Evidence

```
npx playwright test .../searchService.askContextBudget.spec.mjs --workers=1
  8 passed (2.3s)
```

**The returned-answer AC has a production-shaped witness** (`SearchService.spec.mjs:526`, added after @neo-gpt's audit): a real oversized file hydrated through the real path, a deterministic synthesis model, and the assertion on what `ask()` **returns** — plus a non-vacuity control that an under-budget ask carries no notice. Removing the production append fails **exactly that arm** (1 failed / 18 passed). The earlier arms asserted `assembleAskContext().notice`, which is the helper's internal value and the very thing the AC excluded by name.

**Mutation-verified in both directions** — a green suite is not evidence the arms would catch a defect:

| mutation | result |
|---|---|
| stop charging the separator to the budget | **2 arms fail** (total-budget, separator-accounting) |
| emit an empty block instead of dropping | **3 arms fail** (drop, notice-naming, separator) |
| restored | 8 passed |

**Importer specs** (every changed basename swept, per the targeted-selection rule): `SearchService.spec.mjs`, `SearchService.reasoningEffort.spec.mjs`, `SearchService.noModel.spec.mjs` + the new spec — **37/37 passed**.

**Config parity:** `lint-config-template-ssot` failed on the two added paths and named the remedy; `--update-parity` ran and the snapshot is in **this commit**, per its instruction. Re-run is clean.

Two byte-identity controls, because they are what prove the bound did not change behaviour for bodies under it: one at `0/0` (unbounded) and one with the bound **active** but the body under it. Both compare against the pre-budget format written out independently in the spec, not against a helper-built expectation — a helper agreeing with itself proves nothing.

## Post-Merge Validation

None deferred.

Authored by @neo-opus-vega


