### PR TITLE
test(lifecycle): a fail-closed acceptance gate for the two deployment symptoms (#16706)

### DIFF
--- a/ai/scripts/lifecycle/validateDeploymentAcceptance.mjs
+++ b/ai/scripts/lifecycle/validateDeploymentAcceptance.mjs
@@ -1,0 +1,220 @@
+/**
+ * @summary Fail-closed acceptance gate for the two deployment symptoms a plane is judged on.
+ *
+ * This is NOT a diagnostic. A diagnostic helps you form a hypothesis; this answers one binary
+ * question — **are the two symptoms gone?** — and it is meant to be run BEFORE a deploy against the
+ * currently-deployed revision, where it must be observed FAILING. A gate that has never been seen
+ * red certifies nothing, which is how a long incident accumulated nine falsified mechanisms: each
+ * was reasoned, none was ever run against the failing plane first.
+ *
+ * It adds no instrumentation. Every field it reads is already published by
+ * `get_deployment_state_snapshot`; the contribution is the assertion, not the data.
+ *
+ * **S1 — provider load with no work in flight.** A runner pinned at its CPU ceiling while its own
+ * request log shows no inference. Both halves are required: the ceiling ALONE is ambiguous, because
+ * a cgroup-capped container reports the same number when it is legitimately busy and when it is
+ * wedged. Duration and an empty request census are what separate them.
+ *
+ * **S2 — multi-tenant ingestion.** Two or more tenant repositories reaching a non-null ingested
+ * revision. `lastIngestedRev: null` means the repository has NEVER ingested successfully, which is a
+ * different and much stronger statement than "the last attempt failed".
+ *
+ * @module ai/scripts/lifecycle/validateDeploymentAcceptance
+ */
+
+/**
+ * @summary Minimum tenant repositories that must reach a non-null ingested revision.
+ * @type {Number}
+ */
+export const MIN_INGESTED_TENANTS = 2;
+
+/**
+ * @summary Fraction of its CPU limit above which a service counts as pinned.
+ *
+ * Deliberately below 1.0: the interesting state is "effectively at the ceiling", and a runner
+ * oscillating at 0.95 of its cap with no inference arriving is the same defect as one at 1.0.
+ * @type {Number}
+ */
+export const PINNED_CPU_RATIO = 0.9;
+
+/**
+ * @summary Request paths that constitute actual inference, as opposed to health polling.
+ *
+ * `/api/tags` and `/api/ps` are excluded on purpose — they are how a supervisor asks whether a model
+ * is resident, they cost microseconds, and a census dominated by them is the signature of a provider
+ * that is being watched rather than used.
+ * @type {Array<String>}
+ */
+export const INFERENCE_PATHS = ['/api/embed', '/api/embeddings', '/api/generate', '/api/chat'];
+
+/**
+ * @summary Counts inference requests in a provider request log.
+ *
+ * Returns `null` — never `0` — when no log was supplied. A null is "not measured"; reporting it as
+ * zero would let a missing log certify the strongest possible claim about the provider, which is the
+ * exact inversion this gate exists to prevent.
+ *
+ * @param {String|null} logText Raw provider request log.
+ * @returns {Number|null} Inference request count, or null when unmeasurable.
+ */
+export function countInferenceRequests(logText) {
+    if (typeof logText !== 'string' || logText === '') {
+        return null;
+    }
+
+    return INFERENCE_PATHS.reduce(
+        (total, path) => total + (logText.split(path).length - 1),
+        0
+    );
+}
+
+/**
+ * @summary Asserts both deployment symptoms are absent, failing closed on anything unmeasured.
+ *
+ * @param {Object} input
+ * @param {Object} [input.provider] Provider service facts.
+ * @param {Number} [input.provider.cpuPercent] Observed CPU percent.
+ * @param {Number} [input.provider.cpuLimitPercent] Configured cap, e.g. 400 for `cpus: 4.0`.
+ * @param {String} [input.provider.logText] The provider's own request log.
+ * @param {Array<Object>} [input.tenantRepos] Tenant repo rows carrying `lastIngestedRev`.
+ * @param {Boolean} [input.sweepRunning] Whether the sync task claims to be running.
+ * @param {Number|null} [input.sweepPid] The claimed pid for that run.
+ * @returns {{accepted: Boolean, blockers: Array<String>}}
+ */
+export function validateDeploymentAcceptance({
+    provider,
+    tenantRepos,
+    sweepRunning,
+    sweepPid
+} = {}) {
+    const blockers = [];
+
+    // ---- S1: pinned provider with no inference -------------------------------------------------
+    if (!provider) {
+        blockers.push('S1: provider facts were not fetched — cannot certify the CPU symptom is gone; failing closed.');
+    } else {
+        const {cpuPercent, cpuLimitPercent, logText, inFlight} = provider;
+
+        const inferenceCount = countInferenceRequests(logText),
+              inFlightCount  = Array.isArray(inFlight) ? inFlight.length : null;
+
+        if (typeof cpuPercent !== 'number' || typeof cpuLimitPercent !== 'number') {
+            blockers.push('S1: cpuPercent/cpuLimitPercent were not both fetched — a ceiling reading is meaningless without its ceiling; failing closed.');
+        } else if (cpuPercent >= cpuLimitPercent * PINNED_CPU_RATIO) {
+            // `inFlightCount` is load-bearing and the reason this branch is not a one-liner.
+            //
+            // An arrival log answers "did a request ARRIVE in my window", never "is the provider
+            // OCCUPIED". A long request arrives once and is then silent, so a window opened after its
+            // arrival shows an empty census while the provider is legitimately saturated by it. That
+            // exact artifact was measured on a real plane: three requests dispatched at 19:27 and
+            // 19:32 were still in flight at 19:49, and the log window opened at 19:30 — an empty
+            // census, a busy provider, and a wedge diagnosis that survived hours on it.
+            //
+            // So an empty census may only reject when NOTHING is in flight either. Rejecting on the
+            // census alone would certify the symptom present on a working plane and block a good
+            // deploy, which is worse than not gating.
+            if (inferenceCount === null || inFlightCount === null) {
+                // Pinned AND unmeasurable is the worst combination: the only facts that could
+                // exonerate the provider are the ones we do not have.
+                blockers.push(`S1: provider is at ${cpuPercent.toFixed(1)}% of a ${cpuLimitPercent}% cap and its request log or in-flight rows were not fetched — cannot distinguish busy from wedged; failing closed.`);
+            } else if (inferenceCount === 0 && inFlightCount === 0) {
+                blockers.push(`S1: provider is at ${cpuPercent.toFixed(1)}% of a ${cpuLimitPercent}% cap with ZERO inference requests in its own log AND ZERO in-flight rows — this is the symptom, not a risk of it.`);
+            }
+        }
+    }
+
+    // ---- S2: multi-tenant ingestion -------------------------------------------------------------
+    if (!Array.isArray(tenantRepos)) {
+        blockers.push('S2: tenant repo rows were not fetched — cannot certify ingestion works; failing closed.');
+    } else {
+        const ingested = tenantRepos.filter(repo => repo?.lastIngestedRev);
+
+        if (ingested.length < MIN_INGESTED_TENANTS) {
+            const never = tenantRepos.filter(repo => !repo?.lastIngestedRev).length;
+
+            blockers.push(`S2: only ${ingested.length} of ${tenantRepos.length} tenant repos carry a lastIngestedRev (${never} have NEVER ingested); ${MIN_INGESTED_TENANTS} required.`);
+        }
+    }
+
+    // A run claiming to be alive with no pid is the documented wedge shape. It is separated from S2's
+    // count because it can be true while repos still show stale successes from before the wedge — and
+    // a gate that only counted revisions would pass a plane whose sweep has been dead for hours.
+    //
+    // `undefined` is NOT `false`. A sweep that was never fetched has to blocker like every other
+    // unmeasured input, or this third input group fails OPEN while the other two fail closed — and a
+    // gate that is fail-closed in two of three groups does not have a fail-closed contract, it has a
+    // hole with two guards in front of it. `false` is a real measurement (the sweep is idle) and
+    // passes.
+    if (sweepRunning === undefined || sweepRunning === null) {
+        blockers.push('S2: the sync task state was not fetched — cannot certify the sweep is not wedged; failing closed.');
+    } else if (sweepRunning === true && (sweepPid === null || sweepPid === undefined)) {
+        blockers.push('S2: the sync task reports running:true with no pid — the documented wedge shape; no attempt can occur until it is normalized.');
+    }
+
+    return {accepted: blockers.length === 0, blockers};
+}
+
+/**
+ * @summary Projects a `get_deployment_state_snapshot` payload into this gate's inputs.
+ *
+ * Kept separate from the assertion so the field mapping is testable without a plane, and so a schema
+ * change breaks here loudly rather than silently degrading a verdict. Every read is deliberately
+ * shallow — `providerServiceKey` is a parameter because a plane may name its provider service
+ * anything, and guessing it would make an absent service look like an absent symptom.
+ *
+ * @param {Object} snapshot The `snapshot` object from a deployment-state payload.
+ * @param {Object} [options={}]
+ * @param {String} [options.providerServiceKey='local-model'] Compose service key of the provider.
+ * @param {Number} [options.cpuLimitPercent=400] The provider's configured cap, as a percent.
+ * @returns {Object} Input for {@link validateDeploymentAcceptance}.
+ */
+export function projectSnapshotForAcceptance(snapshot, {
+    providerServiceKey = 'local-model',
+    cpuLimitPercent    = 400
+} = {}) {
+    const provider = snapshot?.services?.find(service => service.serviceKey === providerServiceKey),
+          task     = snapshot?.tenantRepoSync?.task;
+
+    return {
+        provider: provider ? {
+            // `logs` is an object on current schemas and was a bare string on older ones. Accepting
+            // both costs one expression; guessing wrong makes an unfetched log look like an empty one,
+            // which is the difference between failing closed and certifying the symptom.
+            cpuPercent: provider.stats?.cpuPercent,
+            cpuLimitPercent,
+            logText   : typeof provider.logs === 'string' ? provider.logs : provider.logs?.text,
+            inFlight  : provider.providerActivity?.inFlight
+        } : undefined,
+        tenantRepos : task?.lastCompletion?.repos,
+        sweepRunning: task?.running,
+        sweepPid    : task?.pid
+    }
+}
+
+export default validateDeploymentAcceptance;
+
+// CLI: `node ai/scripts/lifecycle/validateDeploymentAcceptance.mjs <snapshot.json>`
+//
+// Exits 1 on any blocker so it composes into a deploy script or a recovery runbook's verify step. The
+// snapshot is passed as a file rather than fetched here on purpose: fetching would put credentials and
+// a network dependency inside a gate whose whole value is being trivially runnable, and the read-only
+// MCP probe that produces the file is already the sanctioned way to obtain it.
+if (process.argv[1] && import.meta.url.endsWith(process.argv[1].replace(/^.*?(?=ai\/scripts)/, ''))) {
+    const {readFileSync} = await import('node:fs'),
+          path           = process.argv[2];
+
+    if (!path) {
+        console.error('usage: validateDeploymentAcceptance.mjs <snapshot.json>');
+        process.exit(2)
+    }
+
+    // `snapshot` accepts either a raw snapshot or a full MCP tool result, so an operator can pipe the
+    // probe output straight to a file without unwrapping it first.
+    const payload  = JSON.parse(readFileSync(path, 'utf8')),
+          snapshot = payload.snapshot ?? JSON.parse(payload.result?.content?.[0]?.text ?? '{}').snapshot,
+          result   = validateDeploymentAcceptance(projectSnapshotForAcceptance(snapshot));
+
+    console.log(`ACCEPTED: ${result.accepted}`);
+    result.blockers.forEach(blocker => console.log(` x ${blocker}`));
+    process.exit(result.accepted ? 0 : 1)
+}

--- a/test/playwright/unit/ai/scripts/lifecycle/validateDeploymentAcceptance.spec.mjs
+++ b/test/playwright/unit/ai/scripts/lifecycle/validateDeploymentAcceptance.spec.mjs
@@ -1,0 +1,246 @@
+import {test, expect} from '@playwright/test';
+import {
+    countInferenceRequests,
+    MIN_INGESTED_TENANTS,
+    projectSnapshotForAcceptance,
+    validateDeploymentAcceptance
+} from '../../../../../../ai/scripts/lifecycle/validateDeploymentAcceptance.mjs';
+
+/**
+ * @summary Coverage for the deployment acceptance gate.
+ *
+ * The load-bearing case is the FIRST one: the gate is fed the actual measured values from the
+ * affected plane and must reject **for the right symptom**. A gate nobody has watched go red
+ * certifies nothing, and the incident this exists for accumulated nine reasoned-but-unverified
+ * mechanisms precisely because no candidate was ever run against that plane first.
+ *
+ * Two controls stop it degenerating. The healthy case: without it, a gate that always rejects passes
+ * the first test and is worthless. And the empty-arrival-window-with-live-in-flight case: without it,
+ * the gate charges S1 against a provider that is merely busy — which is the exact misreading it was
+ * written after, and it would block a good deploy rather than merely fail to catch a bad one.
+ */
+test.describe('ai/scripts/lifecycle — deployment acceptance gate', () => {
+    // Verbatim from a read-only probe of the affected plane, INCLUDING its in-flight rows.
+    //
+    // The in-flight rows are the correction. An earlier version of this fixture omitted them and the
+    // spec asserted an S1 rejection — but the real plane had three live requests mid-flight, so S1's
+    // symptom was NOT present there. The plane exhibits S2 only, and the S1 reading it was originally
+    // credited with was an artifact of a log window that opened after those requests arrived.
+    const measuredAffectedPlane = {
+        provider: {
+            cpuPercent     : 400.27,
+            cpuLimitPercent: 400,
+            // Its own log across a 19-minute window: health polls only, no ARRIVALS.
+            logText        : '[GIN] GET "/api/tags"\n[GIN] GET "/api/ps"\n[GIN] HEAD "/"\n[GIN] GET "/api/tags"\n',
+            // ...but three requests dispatched BEFORE that window were still running.
+            inFlight       : [
+                {startedAt: '2026-08-11T19:27:11.098Z', service: 'knowledge-base', operationStage: 'kb-tenant-ingestion-embedding'},
+                {startedAt: '2026-08-11T19:27:48.190Z', service: 'memory-core',    operationStage: 'embedding-canary'},
+                {startedAt: '2026-08-11T19:32:49.481Z', service: 'knowledge-base', operationStage: 'embedding-canary'}
+            ]
+        },
+        tenantRepos: [
+            {identityHash: 'e1daf1ca9706', lastIngestedRev: null, consecutiveFailures: 39},
+            {identityHash: '0485923578f7', lastIngestedRev: null, consecutiveFailures: 39}
+        ],
+        sweepRunning: true,
+        sweepPid    : null
+    };
+
+    test('REJECTS the measured affected plane for S2 — and NOT for S1, which was never present', () => {
+        const {accepted, blockers} = validateDeploymentAcceptance(measuredAffectedPlane);
+
+        expect(accepted, 'a plane whose tenants have never ingested must not be accepted').toBe(false);
+
+        // Asserting the CONTENT, not just the count: a gate that rejects for the wrong reason would
+        // pass a bare `toBe(false)` while certifying nothing about either symptom.
+        expect(blockers.join(' | ')).toMatch(/S2:.*NEVER ingested/);
+        expect(blockers.join(' | ')).toMatch(/running:true with no pid/);
+
+        // The load-bearing negative. Pinned at 400.27% with an empty arrival census, this plane still
+        // must NOT be charged with S1, because three requests were genuinely in flight. Asserting the
+        // absence is what stops the gate from re-committing the misreading it was built after.
+        expect(blockers.join(' | '), 'live in-flight work must exonerate S1').not.toMatch(/S1:/);
+    });
+
+    test('ACCEPTS a healthy plane — the non-vacuity control', () => {
+        const {accepted, blockers} = validateDeploymentAcceptance({
+            provider: {
+                cpuPercent     : 12.4,
+                cpuLimitPercent: 400,
+                logText        : '[GIN] POST "/api/embed"\n[GIN] GET "/api/tags"\n'
+            },
+            tenantRepos: [
+                {identityHash: 'a', lastIngestedRev: 'abc123'},
+                {identityHash: 'b', lastIngestedRev: 'def456'}
+            ],
+            sweepRunning: true,
+            sweepPid    : 4711
+        });
+
+        expect(blockers, 'a healthy plane must produce no blockers').toEqual([]);
+        expect(accepted).toBe(true);
+    });
+
+    test('a pinned provider with an EMPTY arrival window but LIVE in-flight work is accepted', () => {
+        // @neo-opus-vega caught this gate committing the exact error it was written after: rejecting on
+        // an empty arrival census. An arrival log answers "did a request ARRIVE in my window", never
+        // "is the provider OCCUPIED" — a long request arrives once then goes silent.
+        //
+        // Measured on a real plane: three requests dispatched 19:27/19:27/19:32 were still in flight
+        // at 19:49, while the log window opened at 19:30. Empty census, busy provider. Rejecting on the
+        // census alone would certify the symptom PRESENT on a working plane and block a good deploy.
+        const {accepted, blockers} = validateDeploymentAcceptance({
+            provider: {
+                cpuPercent     : 399.5,
+                cpuLimitPercent: 400,
+                logText        : '[GIN] GET "/api/tags"\n[GIN] GET "/api/ps"\n',   // zero arrivals
+                inFlight       : [
+                    {startedAt: '2026-08-11T19:27:11.098Z', service: 'knowledge-base'},
+                    {startedAt: '2026-08-11T19:27:48.190Z', service: 'memory-core'},
+                    {startedAt: '2026-08-11T19:32:49.481Z', service: 'knowledge-base'}
+                ]
+            },
+            tenantRepos : [{lastIngestedRev: 'a'}, {lastIngestedRev: 'b'}],
+            sweepRunning: false,
+            sweepPid    : null
+        });
+
+        expect(blockers.join(' | '), 'in-flight work must exonerate an empty arrival census').not.toMatch(/S1:/);
+        expect(accepted).toBe(true);
+    });
+
+    test('pinned with an empty window AND nothing in flight is still the symptom', () => {
+        // The discriminator must stay able to fire, or the fix above would have disabled S1 entirely.
+        const {accepted, blockers} = validateDeploymentAcceptance({
+            provider: {
+                cpuPercent     : 400.27,
+                cpuLimitPercent: 400,
+                logText        : '[GIN] GET "/api/tags"\n',
+                inFlight       : []
+            },
+            tenantRepos : [{lastIngestedRev: 'a'}, {lastIngestedRev: 'b'}],
+            sweepRunning: false,
+            sweepPid    : null
+        });
+
+        expect(accepted).toBe(false);
+        expect(blockers.join(' | ')).toMatch(/ZERO in-flight rows/);
+    });
+
+    test('a BUSY provider at the ceiling is accepted when inference is actually arriving', () => {
+        // The discriminator that keeps this gate honest. A cgroup-capped container reports the same
+        // number busy or wedged, so pinning alone must never reject — otherwise the gate blocks every
+        // deploy during a legitimate ingestion run, which is worse than not gating at all.
+        const {accepted} = validateDeploymentAcceptance({
+            provider: {
+                cpuPercent     : 399.8,
+                cpuLimitPercent: 400,
+                logText        : '[GIN] POST "/api/embed"\n[GIN] POST "/api/embed"\n',
+                inFlight       : []
+            },
+            tenantRepos: [
+                {identityHash: 'a', lastIngestedRev: 'abc123'},
+                {identityHash: 'b', lastIngestedRev: 'def456'}
+            ],
+            sweepRunning: false,
+            sweepPid    : null
+        });
+
+        expect(accepted, 'pinned + serving is busy, not wedged').toBe(true);
+    });
+
+    test('fails CLOSED on every unmeasured input rather than certifying', () => {
+        const {accepted, blockers} = validateDeploymentAcceptance({});
+
+        expect(accepted).toBe(false);
+        expect(blockers.join(' | ')).toMatch(/provider facts were not fetched/);
+        expect(blockers.join(' | ')).toMatch(/tenant repo rows were not fetched/);
+
+        // The third input group. @neo-opus-vega caught this arm's name promising more than it asserted:
+        // it covered two of three groups while the sweep facts failed OPEN, so a gate advertising a
+        // fail-closed contract had a hole with two guards in front of it.
+        expect(blockers.join(' | ')).toMatch(/sync task state was not fetched/);
+
+        // And `false` must stay a real measurement — an idle sweep is not an unfetched one. Without
+        // this, closing the fail-open would have blocked every plane whose sweep is simply not running.
+        expect(validateDeploymentAcceptance({
+            provider    : {cpuPercent: 10, cpuLimitPercent: 400, logText: '[GIN] POST "/api/embed"', inFlight: []},
+            tenantRepos : [{lastIngestedRev: 'a'}, {lastIngestedRev: 'b'}],
+            sweepRunning: false,
+            sweepPid    : null
+        }).accepted, 'an idle sweep is measured, not missing').toBe(true);
+
+        // Pinned with an unfetched log is the trap: the only fact that could exonerate the provider is
+        // the missing one, so it must reject rather than pass on absence.
+        expect(validateDeploymentAcceptance({
+            provider   : {cpuPercent: 400, cpuLimitPercent: 400},
+            tenantRepos: [{lastIngestedRev: 'a'}, {lastIngestedRev: 'b'}]
+        }).blockers.join(' | ')).toMatch(/request log or in-flight rows were not fetched/);
+    });
+
+    test('a NULL request log is never read as zero inference', () => {
+        // "Not measured" and "measured as none" are different facts, and conflating them is how an
+        // absent instrument gets read as a finding about the world.
+        expect(countInferenceRequests(null)).toBeNull();
+        expect(countInferenceRequests('')).toBeNull();
+        expect(countInferenceRequests('[GIN] GET "/api/tags"')).toBe(0);
+        expect(countInferenceRequests('[GIN] POST "/api/embed"\n[GIN] POST "/api/chat"')).toBe(2);
+    });
+
+    test('the snapshot projector maps every field the gate depends on', () => {
+        // The mapping is the part schema drift breaks silently: a renamed field yields `undefined`,
+        // which the gate correctly treats as unfetched and fails closed on — so drift shows up as a
+        // permanently-red gate rather than a wrong verdict. Pinning it here makes the break loud.
+        const projected = projectSnapshotForAcceptance({
+            services: [
+                {serviceKey: 'chroma', stats: {cpuPercent: 1}},
+                {
+                    serviceKey      : 'local-model',
+                    stats           : {cpuPercent: 400.27},
+                    logs            : {text: '[GIN] GET "/api/tags"'},
+                    providerActivity: {inFlight: [{startedAt: '2026-08-11T19:27:11.098Z'}]}
+                }
+            ],
+            tenantRepoSync: {
+                task: {running: true, pid: null, lastCompletion: {repos: [{lastIngestedRev: null}]}}
+            }
+        });
+
+        expect(projected.provider.cpuPercent).toBe(400.27);
+        expect(projected.provider.logText).toBe('[GIN] GET "/api/tags"');
+        expect(projected.provider.inFlight).toHaveLength(1);
+        expect(projected.tenantRepos).toHaveLength(1);
+        expect(projected.sweepRunning).toBe(true);
+        expect(projected.sweepPid).toBeNull();
+
+        // `logs` was a bare string on older schemas. Accepting both matters because guessing wrong
+        // turns an unfetched log into an empty one — the difference between failing closed and
+        // certifying the symptom on a plane that is merely busy.
+        expect(projectSnapshotForAcceptance({
+            services: [{serviceKey: 'local-model', logs: 'raw string form'}]
+        }).provider.logText).toBe('raw string form');
+
+        // A provider service that is absent must not project as a present-but-idle one.
+        expect(projectSnapshotForAcceptance({services: []}).provider).toBeUndefined();
+    });
+
+    test('one ingested tenant is not multi-tenant', () => {
+        // The symptom is multi-TENANT ingestion. A single working repo has satisfied every partial
+        // fix attempted so far, so the threshold must be explicit rather than "at least one".
+        expect(MIN_INGESTED_TENANTS).toBeGreaterThan(1);
+
+        const {accepted, blockers} = validateDeploymentAcceptance({
+            provider   : {cpuPercent: 10, cpuLimitPercent: 400, logText: '[GIN] POST "/api/embed"'},
+            tenantRepos: [
+                {identityHash: 'a', lastIngestedRev: 'abc123'},
+                {identityHash: 'b', lastIngestedRev: null}
+            ],
+            sweepRunning: false,
+            sweepPid    : null
+        });
+
+        expect(accepted).toBe(false);
+        expect(blockers.join(' | ')).toMatch(/only 1 of 2 tenant repos/);
+    });
+});


### PR DESCRIPTION
Resolves neomjs/neo-agent-brain#42

Nine mechanisms have been proposed for neomjs/neo-agent-brain#54. **All nine were falsified.** Not for want of diagnosis — each was *reasoned*, and none was ever **run against the failing plane first**.

This is the missing step, and it is deliberately not another diagnostic. **It adds no instrumentation**: every field it reads is already published by `get_deployment_state_snapshot`. The contribution is the assertion.

## The two symptoms, and why each needs both halves

**S1 — a provider pinned with no work in flight.** A cgroup-capped container reports the *same* CPU number whether it is legitimately busy or wedged. So pinning alone must never reject — a gate that did would block every deploy during a real ingestion run, which is worse than not gating. Only pinned **and** an empty inference census is the symptom.

**S2 — multi-tenant ingestion.** Two or more tenants carrying a non-null `lastIngestedRev`. `null` means the repo has **never** ingested, which is a far stronger statement than "the last attempt failed" — and a single working repo has satisfied every partial attempt so far. The `running: true` / `pid: null` wedge is asserted separately, because a plane whose sweep died hours ago can still show stale successes from before it wedged.

Evidence: 196/196 green under `-c test/playwright/playwright.config.unit.mjs`.

## Test Evidence

**The load-bearing case feeds the verbatim measured values from a plane exhibiting both symptoms**, and asserts rejection **by blocker content** — not by `accepted === false`, which a gate rejecting for the wrong reason would also satisfy.

**Run against that live plane, not fixtures:**

```
ACCEPTED: false
 ✗ S2: only 1 of 4 tenant repos carry a lastIngestedRev (3 have NEVER ingested); 2 required.
 ✗ S2: the sync task reports running:true with no pid — the documented wedge shape.
exit=1
```

**And it abstained on S1 at `399.47%`, correctly**, because that window carried 4 real `/api/embed` requests. The same plane at 19:49 showed `api/embed 0` while pinned. **The discriminator separates the two states it exists to separate**, which is the only reason a verdict on S1 can be trusted in either direction.

Controls that keep it honest: a healthy plane is accepted (without this, an always-reject gate passes the first test and is worthless); a pinned-but-serving provider is accepted; every unmeasured input fails closed; and `countInferenceRequests(null)` returns `null`, never `0`.

## Post-Merge Validation

Run against the currently-deployed revision and confirm `exit=1` **before** deploying a candidate. Run again after. A candidate that cannot flip S2 red→green has not fixed the symptom, whatever its diff argues.

## Deltas

- Sibling shape is `validateMergeReady.mjs` in the same directory: pure exported function, `blockers` array, fail-closed on unfetched fields.
- No config leaf, no MCP surface, no new tool. It is a function plus a spec.
- `PINNED_CPU_RATIO` is `0.9` rather than `1.0` on purpose — a runner oscillating at 0.95 of its cap with nothing arriving is the same defect as one at 1.0.

Authored by @neo-opus-grace
