### PR TITLE
feat(provider): bound ask admission so a dedicated endpoint can actually be used (#17000)

### DIFF
--- a/ai/deploy/docker-compose.dev.yml
+++ b/ai/deploy/docker-compose.dev.yml
@@ -202,6 +202,7 @@ services:
       NEO_KB_ASK_SYNTHESIS_TIMEOUT_MS: ${NEO_KB_ASK_SYNTHESIS_TIMEOUT_MS:-}
       NEO_KB_ASK_SYNTHESIS_TIMEOUT_MS_REMOTE: ${NEO_KB_ASK_SYNTHESIS_TIMEOUT_MS_REMOTE:-}
       NEO_KB_ASK_MAX_RPM: ${NEO_KB_ASK_MAX_RPM:-}
+      NEO_KB_ASK_MAX_PARALLEL: ${NEO_KB_ASK_MAX_PARALLEL:-}
       # Provider-readiness coordinate. TextEmbeddingService (:845) reads
       # orchestrator.providerReadiness.timeoutMs and runs inside THIS process.
       NEO_ORCHESTRATOR_PROVIDER_READY_TIMEOUT_MS: ${NEO_ORCHESTRATOR_PROVIDER_READY_TIMEOUT_MS:-}

--- a/ai/deploy/docker-compose.yml
+++ b/ai/deploy/docker-compose.yml
@@ -146,6 +146,7 @@ services:
       - NEO_KB_ASK_SYNTHESIS_TIMEOUT_MS=${NEO_KB_ASK_SYNTHESIS_TIMEOUT_MS:-}
       - NEO_KB_ASK_SYNTHESIS_TIMEOUT_MS_REMOTE=${NEO_KB_ASK_SYNTHESIS_TIMEOUT_MS_REMOTE:-}
       - NEO_KB_ASK_MAX_RPM=${NEO_KB_ASK_MAX_RPM:-}
+      - NEO_KB_ASK_MAX_PARALLEL=${NEO_KB_ASK_MAX_PARALLEL:-}
     # Declared V8 heap ceiling, sized BELOW the 1g container limit below. Without it V8 picks a
     # heuristic (~560 MiB in a 1 GiB container) and self-aborts with `Ineffective mark-compacts near
     # heap limit` while ~460 MiB of the container's own allowance is still unused — and because NODE

--- a/ai/mcp/server/knowledge-base/configBase.mjs
+++ b/ai/mcp/server/knowledge-base/configBase.mjs
@@ -339,7 +339,30 @@ class ConfigBase extends ConfigProvider {
                  * stale overlay can cause.
                  * @type {number}
                  */
-                contextMaxCharsPerDocument: leaf(12000, 'NEO_KB_ASK_CONTEXT_MAX_CHARS_PER_DOC', 'number')
+                contextMaxCharsPerDocument: leaf(12000, 'NEO_KB_ASK_CONTEXT_MAX_CHARS_PER_DOC', 'number'),
+                /**
+                 * @summary How many ask syntheses may be in flight at once.
+                 *
+                 * Ask dispatches through a serializing admission queue, so two asks arriving seconds
+                 * apart are served one after the other REGARDLESS of how much idle capacity the
+                 * serving endpoint has — the bound is admission, not the endpoint. Provisioning more
+                 * serving capacity without raising this leaves idle replicas behind a queued second
+                 * ask, and the symptom reads as "the model is slow" rather than "the queue admitted
+                 * one".
+                 *
+                 * `1` is the default and reproduces today's behaviour exactly. Raise it ONLY when ask
+                 * has its own serving endpoint (`baseUrl` above): against a SHARED endpoint, extra
+                 * parallelism moves contention downstream into the model server instead of removing
+                 * it, and it competes with the full-power summarisation lane this separation exists to
+                 * protect.
+                 *
+                 * Size it to the host's real headroom and the number of dev agents, not to an
+                 * aspiration — each in-flight synthesis holds its own context. Absent in an overlay
+                 * predating this leaf resolves to `1`, so an unmigrated clone keeps serializing rather
+                 * than silently acquiring concurrency the host may not survive.
+                 * @type {number}
+                 */
+                maxParallel: leaf(1, 'NEO_KB_ASK_MAX_PARALLEL', 'number')
             },
             /**
              * The path to the generated knowledge base JSONL file.

--- a/ai/provider/InteractiveBatchQueue.mjs
+++ b/ai/provider/InteractiveBatchQueue.mjs
@@ -1,14 +1,22 @@
 /**
- * @summary A single-lane request scheduler that runs async tasks one at a time, preferring
- * interactive work over batch work.
+ * @summary A bounded-lane request scheduler that admits up to `capacity` tasks at a time (default
+ * one), preferring interactive work over batch work.
  *
  * Local chat/embedding endpoints (LM Studio, `lms server`, Ollama, llama.cpp, MLX) serialize
  * model requests, so a long-running batch task — a 30-60m session-summary or a KB backfill — can
  * monopolize the endpoint and stall a latency-sensitive interactive request (an `ask` synthesis,
- * or the mini-summary fired right after `add_memory`). This queue admits one task at a time and,
+ * or the mini-summary fired right after `add_memory`). This queue bounds admission and,
  * whenever it picks the next task, prefers any waiting `interactive` task over `batch` work — so
  * interactive requests jump ahead of queued batch work without starving it (a batch task still
  * runs once no interactive work is waiting). Within a single priority lane, selection is FIFO.
+ *
+ * **`capacity` defaults to 1, which is the original single-lane behaviour exactly.** A capacity
+ * above one exists for a consumer with its OWN serving endpoint: when `ask` synthesis is bound to a
+ * dedicated endpoint, two asks arriving seconds apart must both be served, and a single-lane queue
+ * serializes them no matter how much idle capacity that endpoint has — the bound is admission, not
+ * the endpoint. Raising capacity against a SHARED endpoint would merely move contention downstream
+ * into the model server, which is why the default stays 1 and the capacity travels with the
+ * dedicated instance rather than the shared one.
  *
  * It controls admission ORDER, not in-flight cancellation: a local endpoint request is
  * non-preemptible, so an already-running task always finishes; the queue only decides which
@@ -31,11 +39,19 @@ export default class InteractiveBatchQueue {
      */
     #queue = [];
     /**
-     * Whether the drain loop is currently running (guards against concurrent drains).
-     * @member {Boolean} #active=false
+     * How many tasks are executing right now. A COUNTER rather than a boolean: the boolean it
+     * replaced could only express "a lane is busy", which cannot represent a freed slot among
+     * several.
+     * @member {Number} #running=0
      * @private
      */
-    #active = false;
+    #running = 0;
+    /**
+     * Maximum tasks admitted concurrently. `1` reproduces the original single-lane scheduler.
+     * @member {Number} #capacity=1
+     * @private
+     */
+    #capacity = 1;
     /**
      * Injectable monotonic-enough wall clock for deterministic lifecycle receipts.
      * @member {Function} #now=Date.now
@@ -44,16 +60,34 @@ export default class InteractiveBatchQueue {
     #now = Date.now;
 
     /**
-     * @summary Creates an isolated queue with an optional deterministic clock seam.
+     * @summary Creates an isolated queue with an optional deterministic clock seam and admission bound.
      * @param {Object} [options]
      * @param {Function} [options.now=Date.now] Timestamp provider.
+     * @param {Number} [options.capacity=1] Maximum concurrently admitted tasks. Validated eagerly:
+     * a `0`, negative, fractional or non-numeric capacity would silently stall the lane forever or
+     * admit unbounded work, and a scheduler that never runs a task is indistinguishable from a hung
+     * provider from the caller's side.
      */
-    constructor({now = Date.now} = {}) {
+    constructor({now = Date.now, capacity = 1} = {}) {
         if (typeof now !== 'function') {
             throw new TypeError('InteractiveBatchQueue: options.now must be a function');
         }
 
-        this.#now = now;
+        if (!Number.isInteger(capacity) || capacity < 1) {
+            throw new TypeError(`InteractiveBatchQueue: options.capacity must be an integer >= 1, got ${capacity}`);
+        }
+
+        this.#now      = now;
+        this.#capacity = capacity;
+    }
+
+    /**
+     * @summary The configured admission bound, for observability and assertions.
+     * @member {Number} capacity
+     * @readonly
+     */
+    get capacity() {
+        return this.#capacity
     }
 
     /**
@@ -75,62 +109,76 @@ export default class InteractiveBatchQueue {
     }
 
     /**
-     * @summary Drains the queue one task at a time, selecting interactive work first. A throwing
-     * task rejects its own promise without aborting the loop.
+     * @summary Fills every free slot, selecting interactive work first.
+     *
+     * SYNCHRONOUS on purpose. Two `enqueue` calls arriving in the same tick must both be admitted
+     * when capacity allows, so slot-filling cannot sit behind an `await` — an async gap here would
+     * let the first task's dispatch delay the second, reintroducing the serialization this bound
+     * exists to remove while still reporting a capacity above one.
+     * @returns {void}
+     * @private
+     */
+    #drain() {
+        while (this.#running < this.#capacity && this.#queue.length > 0) {
+            this.#runNext()
+        }
+    }
+
+    /**
+     * @summary Admits and executes one task, then re-drains so a freed slot pulls the next waiting
+     * task. A throwing task rejects its own promise and always releases its slot.
+     *
+     * The next task is selected when a slot FREES, not when the queue was built, which is what keeps
+     * the documented contract — "whenever it picks the next task, prefers any waiting interactive
+     * task" — true under capacity above one.
      * @returns {Promise<void>}
      * @private
      */
-    async #drain() {
-        if (this.#active) {
-            return
-        }
+    async #runNext() {
+        const index = this.#nextIndex(),
+              item  = this.#queue.splice(index, 1)[0];
 
-        this.#active = true;
+        this.#running++;
+
+        const startedAt = this.#now();
+
+        this.#notify(item.lifecycle, 'onStarted', {
+            enqueuedAt : item.enqueuedAt,
+            priority   : item.priority,
+            queueWaitMs: Math.max(0, startedAt - item.enqueuedAt),
+            startedAt
+        });
 
         try {
-            while (this.#queue.length > 0) {
-                const index = this.#nextIndex(),
-                      item  = this.#queue.splice(index, 1)[0];
+            const result      = await item.task(),
+                  completedAt = this.#now();
 
-                const startedAt = this.#now();
+            this.#notify(item.lifecycle, 'onSettled', {
+                completedAt,
+                enqueuedAt : item.enqueuedAt,
+                executionMs: Math.max(0, completedAt - startedAt),
+                priority   : item.priority,
+                startedAt,
+                success    : true
+            });
+            item.resolve(result)
+        } catch (error) {
+            const completedAt = this.#now();
 
-                this.#notify(item.lifecycle, 'onStarted', {
-                    enqueuedAt : item.enqueuedAt,
-                    priority   : item.priority,
-                    queueWaitMs: Math.max(0, startedAt - item.enqueuedAt),
-                    startedAt
-                });
-
-                try {
-                    const result      = await item.task(),
-                          completedAt = this.#now();
-
-                    this.#notify(item.lifecycle, 'onSettled', {
-                        completedAt,
-                        enqueuedAt : item.enqueuedAt,
-                        executionMs: Math.max(0, completedAt - startedAt),
-                        priority   : item.priority,
-                        startedAt,
-                        success    : true
-                    });
-                    item.resolve(result)
-                } catch (error) {
-                    const completedAt = this.#now();
-
-                    this.#notify(item.lifecycle, 'onSettled', {
-                        completedAt,
-                        enqueuedAt : item.enqueuedAt,
-                        error,
-                        executionMs: Math.max(0, completedAt - startedAt),
-                        priority   : item.priority,
-                        startedAt,
-                        success    : false
-                    });
-                    item.reject(error)
-                }
-            }
+            this.#notify(item.lifecycle, 'onSettled', {
+                completedAt,
+                enqueuedAt : item.enqueuedAt,
+                error,
+                executionMs: Math.max(0, completedAt - startedAt),
+                priority   : item.priority,
+                startedAt,
+                success    : false
+            });
+            item.reject(error)
         } finally {
-            this.#active = false
+            // Release BEFORE re-draining, or the freed slot is invisible to the drain it triggers.
+            this.#running--;
+            this.#drain()
         }
     }
 

--- a/ai/provider/buildChatModel.mjs
+++ b/ai/provider/buildChatModel.mjs
@@ -92,7 +92,15 @@ function toGeminiEnvelope(result) {
  * @param {Function} [options.ollamaProviderFactory] Test seam — if omitted, lazily imports `./Ollama.mjs` and calls `Neo.create(...)`.
  * @param {Function} [options.openAiCompatibleProviderFactory] Test seam — if omitted, lazily imports `./OpenAiCompatible.mjs` and calls `Neo.create(...)`.
  * @param {Function} [options.geminiClientFactory] Test seam — if omitted, lazily imports `@google/generative-ai` on first `generateContent()`.
- * @param {InteractiveBatchQueue} [options.chatRequestQueue] Test seam — the serializing queue the local providers route through; defaults to the process-wide {@link sharedLocalChatRequestQueue}.
+ * @param {InteractiveBatchQueue} [options.chatRequestQueue] The admission queue the local providers
+ * route through; defaults to the process-wide {@link sharedLocalChatRequestQueue}. A PRODUCTION
+ * injection point, not only a test seam: a consumer with its OWN serving endpoint passes its own
+ * queue so its parallelism is configurable without handing concurrency to every other local chat
+ * consumer in the process. The queue arrives already constructed because its capacity comes from that
+ * consumer's config, and this module must neither receive config values second-hand nor read
+ * `AiConfig` itself. Per ADR 0019 B5 + C1 (ticket-ref-ok: the ADR clauses are the authority for why
+ * the queue arrives constructed instead of as a capacity number — a maintainer "simplifying" this
+ * into a threaded parameter would violate the zero-tolerance C1 rule, so the rule has to be named).
  * @param {Object} [options.providerActivityRecorder] Best-effort bounded provider telemetry sink.
  * @param {String} [options.providerActivityService='unknown'] Stable service owner for emitted activity.
  * @returns {Object|null} Gemini-shaped `{generateContent}` model, OR `null` for gemini without an API key.

--- a/ai/scripts/lint/config-leaf-parity.json
+++ b/ai/scripts/lint/config-leaf-parity.json
@@ -44,7 +44,7 @@
         "census": {
             "profile": "ai/deploy/docker-compose.yml",
             "baselineUniqueKeys": 45,
-            "remainingUniqueKeys": 67,
+            "remainingUniqueKeys": 68,
             "requiredDeploymentInputs": [
                 "NEO_AI_ORCHESTRATOR_AUTHORITY_PROFILE",
                 "NEO_AUTH_MODE",
@@ -80,6 +80,7 @@
                 "NEO_DEPLOYMENT_STATE_BRIDGE_DIRECT_PROBE_URLS",
                 "NEO_EMBEDDING_PROVIDER",
                 "NEO_KB_ASK_BASE_URL",
+                "NEO_KB_ASK_MAX_PARALLEL",
                 "NEO_KB_ASK_MAX_RPM",
                 "NEO_KB_ASK_MODEL",
                 "NEO_KB_ASK_PROVIDER",

--- a/ai/scripts/lint/config-leaf-parity.json
+++ b/ai/scripts/lint/config-leaf-parity.json
@@ -502,6 +502,7 @@
         "askSynthesis.contextBudgetChars",
         "askSynthesis.contextMaxCharsPerDocument",
         "askSynthesis.maxCallsPerMinute",
+        "askSynthesis.maxParallel",
         "askSynthesis.model",
         "askSynthesis.provider",
         "askSynthesis.reasoningEffort",

--- a/ai/services/knowledge-base/SearchService.mjs
+++ b/ai/services/knowledge-base/SearchService.mjs
@@ -98,6 +98,44 @@ export function buildAskRequestQueue(config) {
     return new InteractiveBatchQueue({capacity: config.askSynthesis.maxParallel})
 }
 
+/**
+ * @summary Assembles the EXACT options object `SearchService` hands to `buildChatModel`.
+ *
+ * Extracted as a pure function because a review showed the gap it closes: the
+ * spec asserted `buildAskRequestQueue(...).capacity` directly, so **deleting the injection from the
+ * call site left the whole suite green.** A helper-capacity assertion proves the helper builds a
+ * queue; it proves nothing about asks USING that queue. With the composition itself returned, a spec
+ * asserts what the provider layer actually receives, and removing the injection fails an arm.
+ *
+ * Same precedent and same reason as {@link buildAskProviderConfigs}: the alternative is asserting
+ * through a constructed singleton, which cannot observe what was passed.
+ *
+ * @param {Object} config The Knowledge Base AiConfig node.
+ * @param {Object} providerConfigs Output of {@link buildAskProviderConfigs}.
+ * @param {Object} providerConfigs.openAiCompatibleConfig
+ * @param {Object} providerConfigs.ollamaConfig
+ * @returns {Object} The `buildChatModel` options, including the ask-owned admission queue.
+ */
+export function buildAskChatModelOptions(config, {openAiCompatibleConfig, ollamaConfig}) {
+    const ask = config.askSynthesis;
+
+    return {
+        modelProvider         : ask.provider,
+        openAiCompatibleConfig,
+        ollamaConfig,
+        // Ask owns its admission queue so its parallelism is configurable without handing concurrency
+        // to any other consumer. No contention changes hands: the two `buildChatModel` callers are
+        // SearchService and memory-core's `SessionService`, which runs in a DIFFERENT process — so the
+        // "process-wide" shared queue never serialized them against each other, and ask is the only
+        // chat consumer in this process.
+        chatRequestQueue        : buildAskRequestQueue(config),
+        geminiApiKey            : ask.apiKey,
+        geminiModelName         : ask.model,
+        providerActivityRecorder: KBRecorderService,
+        providerActivityService : 'knowledge-base'
+    }
+}
+
 const LOCAL_EMPTY_COLLECTION_ANSWER  = "The knowledge base collection is empty. Populate it with the release artifact via 'npm run ai:download-kb' (or build locally with 'npm run ai:sync-kb').";
 const REMOTE_EMPTY_COLLECTION_ANSWER = "The knowledge base collection is empty. In a cloud or remote tenant-ingestion deployment, inspect ingestion state first: call get_ingestion_progress(), then inspect_deployment or get_deployment_state_snapshot for tenantRepoSync / deployment-state details. For push-mode tenants, run the configured ingest_source_files or bulk tenant-ingest path before retrying the query.";
 
@@ -205,21 +243,7 @@ class SearchService extends Base {
         // would have surfaced it, as a chat request POSTed at a vector database.
         const {openAiCompatibleConfig, ollamaConfig} = buildAskProviderConfigs(aiConfig);
 
-        this.model = buildChatModel({
-            modelProvider         : ask.provider,
-            openAiCompatibleConfig,
-            ollamaConfig,
-            // Ask owns its admission queue so its parallelism is configurable without handing
-            // concurrency to any other consumer. No contention changes hands: the two
-            // `buildChatModel` callers are this one and memory-core's `SessionService`, which runs in
-            // a DIFFERENT process — so the "process-wide" shared queue never serialized them against
-            // each other, and ask is the only chat consumer in this process.
-            chatRequestQueue        : buildAskRequestQueue(aiConfig),
-            geminiApiKey            : ask.apiKey,
-            geminiModelName         : ask.model,
-            providerActivityRecorder: KBRecorderService,
-            providerActivityService : 'knowledge-base'
-        });
+        this.model = buildChatModel(buildAskChatModelOptions(aiConfig, {openAiCompatibleConfig, ollamaConfig}));
     }
 
     /**

--- a/ai/services/knowledge-base/SearchService.mjs
+++ b/ai/services/knowledge-base/SearchService.mjs
@@ -8,6 +8,7 @@ import logger                                                                   
 import path                                                                          from 'path';
 import QueryService                                                                  from './QueryService.mjs';
 import {assembleAskContext}                                                          from './helpers/askContextBudget.mjs';
+import InteractiveBatchQueue                                                         from '../../provider/InteractiveBatchQueue.mjs';
 import {checkAskRateLimit}                                                           from './helpers/askRateLimit.mjs';
 import {isRemoteKnowledgeBaseDeployment}                                             from './helpers/deploymentMode.mjs';
 import {getMissingAskSynthesisLeaves}                                                from './helpers/askSynthesisGuard.mjs';
@@ -65,6 +66,36 @@ export function buildAskProviderConfigs(config) {
             keep_alive: config.ollama.keep_alive
         }
     }
+}
+
+/**
+ * @summary Builds the ask path's OWN admission queue, sized by the `askSynthesis.maxParallel` leaf.
+ *
+ * Ask needs its own queue instance rather than a raised capacity on the shared one: capacity belongs
+ * to the consumer that has its own serving endpoint, and raising it on the process-wide queue would
+ * hand concurrency to every other local chat consumer in the process as a side effect.
+ *
+ * The capacity is READ HERE, at the use site. It is never threaded into `buildChatModel` as a value,
+ * and `buildChatModel` must not read `AiConfig` itself — Neo/AiConfig imports belong only in
+ * thread-entrypoints and the provider layer is not one. Per ADR 0019 B5 + C1 (ticket-ref-ok: the ADR
+ * clauses are the authority for this shape; without naming them, "pass maxParallel through" reads
+ * like the simpler option instead of a zero-tolerance violation). So the config-derived object is
+ * constructed on this side and injected; an injected collaborator is not a threaded config value,
+ * which is what keeps this inside B5.
+ *
+ * Exported as a pure function for the same reason as {@link buildAskProviderConfigs}: the capacity
+ * wiring is then assertable without booting a service or reaching into a private member.
+ *
+ * @param {Object} config The Knowledge Base AiConfig node.
+ * @returns {InteractiveBatchQueue} A queue owned by the ask path.
+ */
+export function buildAskRequestQueue(config) {
+    // Read with NO fallback, for the reason measured on the budget leaves: the generated `config.mjs`
+    // is a thin singleton extending the tracked base and declaring no data, so a leaf added there
+    // reaches every overlay and cannot resolve absent. A `|| 1` here would be dead code that could
+    // only mask a real config break — and masking it as "serialized" is the quiet failure, since a
+    // deployment that meant to run parallel asks would silently keep serializing them.
+    return new InteractiveBatchQueue({capacity: config.askSynthesis.maxParallel})
 }
 
 const LOCAL_EMPTY_COLLECTION_ANSWER  = "The knowledge base collection is empty. Populate it with the release artifact via 'npm run ai:download-kb' (or build locally with 'npm run ai:sync-kb').";
@@ -178,6 +209,12 @@ class SearchService extends Base {
             modelProvider         : ask.provider,
             openAiCompatibleConfig,
             ollamaConfig,
+            // Ask owns its admission queue so its parallelism is configurable without handing
+            // concurrency to any other consumer. No contention changes hands: the two
+            // `buildChatModel` callers are this one and memory-core's `SessionService`, which runs in
+            // a DIFFERENT process — so the "process-wide" shared queue never serialized them against
+            // each other, and ask is the only chat consumer in this process.
+            chatRequestQueue        : buildAskRequestQueue(aiConfig),
             geminiApiKey            : ask.apiKey,
             geminiModelName         : ask.model,
             providerActivityRecorder: KBRecorderService,

--- a/ai/services/knowledge-base/SearchService.mjs
+++ b/ai/services/knowledge-base/SearchService.mjs
@@ -192,6 +192,14 @@ class SearchService extends Base {
      * @protected
      */
     askCallTimestamps = []
+    /**
+     * The admission queue this service handed to `buildChatModel`, published as a receipt of the
+     * composition. Read off the same options object the provider layer received — a spec that rebuilds
+     * a queue proves the builder, never that THIS service composed one.
+     * @member {InteractiveBatchQueue|null} askRequestQueue=null
+     * @protected
+     */
+    askRequestQueue = null
 
     /**
      * Builds the synthesis model via the configured provider (`gemini` / `openAiCompatible` / `ollama`)
@@ -241,9 +249,17 @@ class SearchService extends Base {
         // not a chat endpoint. It went unnoticed because the ask path defaulted to `gemini`, which
         // ignores this object entirely; pointing the default at a local provider is exactly what
         // would have surfaced it, as a chat request POSTed at a vector database.
-        const {openAiCompatibleConfig, ollamaConfig} = buildAskProviderConfigs(aiConfig);
+        const
+            {openAiCompatibleConfig, ollamaConfig} = buildAskProviderConfigs(aiConfig),
+            chatModelOptions                       = buildAskChatModelOptions(aiConfig, {openAiCompatibleConfig, ollamaConfig});
 
-        this.model = buildChatModel(buildAskChatModelOptions(aiConfig, {openAiCompatibleConfig, ollamaConfig}));
+        this.model = buildChatModel(chatModelOptions);
+        // Published from the SAME options object the provider layer received, so it is a receipt of
+        // what was composed rather than a second construction. A spec asserting a rebuilt queue proves
+        // the builder; this proves THIS SERVICE handed one over. Two review rounds were lost to that
+        // distinction — each fix asserted the newly-extracted pure function while the unwitnessed edge
+        // moved up to its caller, so the receipt has to come off the value that actually travelled.
+        this.askRequestQueue = chatModelOptions.chatRequestQueue
     }
 
     /**

--- a/test/playwright/unit/ai/provider/InteractiveBatchQueue.spec.mjs
+++ b/test/playwright/unit/ai/provider/InteractiveBatchQueue.spec.mjs
@@ -154,4 +154,160 @@ test.describe('Neo.ai.provider.InteractiveBatchQueue', () => {
         await expect(second).rejects.toThrow('task failed');
         await expect(third).resolves.toBe('after');
     });
+
+    test.describe('admission capacity', () => {
+        test('DEFAULT capacity is 1 and still serializes — the pre-capacity behaviour', () => {
+            // The control for every arm below. If this drifts, the shared chat queue silently gained
+            // concurrency against a SHARED endpoint, which moves contention into the model server
+            // instead of removing it.
+            const queue = new InteractiveBatchQueue(),
+                  ran   = [],
+                  gate  = deferred();
+
+            expect(queue.capacity).toBe(1);
+
+            queue.enqueue(async () => { ran.push('A'); await gate.promise });
+            queue.enqueue(async () => { ran.push('B') });
+
+            expect(ran).toEqual(['A']);
+            gate.resolve();
+        });
+
+        test('capacity 2 admits BOTH tasks in the same tick — the whole point of the bound', async () => {
+            // Two asks arriving seconds apart must both be served. A single-lane queue serializes
+            // them no matter how much idle capacity the endpoint has, so this arm is the one that
+            // distinguishes "the endpoint is busy" from "the queue admitted one".
+            const queue = new InteractiveBatchQueue({capacity: 2}),
+                  ran   = [],
+                  gateA = deferred(),
+                  gateB = deferred();
+
+            const pA = queue.enqueue(async () => { ran.push('A'); await gateA.promise; return 'A' });
+            const pB = queue.enqueue(async () => { ran.push('B'); await gateB.promise; return 'B' });
+
+            // Synchronously after both enqueues: BOTH are in flight. Not "eventually" — an async gap
+            // in slot-filling would reintroduce serialization while still reporting capacity 2.
+            expect(ran).toEqual(['A', 'B']);
+
+            gateA.resolve();
+            gateB.resolve();
+
+            await expect(pA).resolves.toBe('A');
+            await expect(pB).resolves.toBe('B');
+        });
+
+        test('capacity is an upper BOUND — a third task waits for a freed slot', async () => {
+            const queue = new InteractiveBatchQueue({capacity: 2}),
+                  ran   = [],
+                  gates = [deferred(), deferred(), deferred()];
+
+            const promises = gates.map((gate, i) => queue.enqueue(async () => {
+                ran.push(i);
+                await gate.promise;
+                return i
+            }));
+
+            // Bounded at 2 even though 3 are queued.
+            expect(ran).toEqual([0, 1]);
+
+            // Freeing ONE slot admits exactly one more, not the remainder.
+            gates[0].resolve();
+            await promises[0];
+
+            expect(ran).toEqual([0, 1, 2]);
+
+            gates[1].resolve();
+            gates[2].resolve();
+            await Promise.all(promises);
+        });
+
+        test('a THROWING task releases its slot — capacity does not leak', async () => {
+            // A leaked slot is the worst failure mode here: it degrades silently, one task per
+            // failure, until the queue is permanently narrower than configured. Nothing in a latency
+            // measurement would name it, so it gets an arm rather than trust.
+            const queue = new InteractiveBatchQueue({capacity: 2}),
+                  ran   = [];
+
+            const failing = Promise.all([
+                queue.enqueue(async () => { ran.push('x'); throw new Error('boom') }),
+                queue.enqueue(async () => { ran.push('y'); throw new Error('boom') })
+            ].map(p => p.catch(() => 'handled')));
+
+            await failing;
+
+            const gateC = deferred(),
+                  gateD = deferred(),
+                  pC    = queue.enqueue(async () => { ran.push('C'); await gateC.promise; return 'C' }),
+                  pD    = queue.enqueue(async () => { ran.push('D'); await gateD.promise; return 'D' });
+
+            // Full capacity is still available after two failures.
+            expect(ran).toEqual(['x', 'y', 'C', 'D']);
+
+            gateC.resolve();
+            gateD.resolve();
+            await Promise.all([pC, pD]);
+        });
+
+        test('interactive is still preferred when a slot frees under capacity > 1', async () => {
+            // Selection happens when a slot FREES, not when the queue was built. Without that, the
+            // documented lane preference would quietly stop holding above capacity 1 — the contract
+            // regressing in exactly the configuration that is new.
+            const queue = new InteractiveBatchQueue({capacity: 2}),
+                  ran   = [],
+                  gates = [deferred(), deferred()];
+
+            queue.enqueue(async () => { ran.push('B1'); await gates[0].promise }, 'batch');
+            queue.enqueue(async () => { ran.push('B2'); await gates[1].promise }, 'batch');
+
+            const pBatch       = queue.enqueue(async () => { ran.push('B3') }, 'batch'),
+                  pInteractive = queue.enqueue(async () => { ran.push('I1') }, 'interactive');
+
+            expect(ran).toEqual(['B1', 'B2']);
+
+            gates[0].resolve();
+            gates[1].resolve();
+            await Promise.all([pBatch, pInteractive]);
+
+            // I1 was enqueued AFTER B3 and still ran first.
+            expect(ran.indexOf('I1')).toBeLessThan(ran.indexOf('B3'));
+        });
+
+        test('an unusable capacity is REFUSED at construction, not at admission', () => {
+            // A 0 or negative capacity makes `#running < #capacity` false forever: every task sits
+            // queued and the caller sees a hung provider, with nothing in the logs naming the cause.
+            // Fractional is refused too — 1.5 would round somewhere and the operator's number would
+            // not be the behaviour.
+            expect(() => new InteractiveBatchQueue({capacity: 0})).toThrow(/capacity must be an integer >= 1/);
+            expect(() => new InteractiveBatchQueue({capacity: -1})).toThrow(/capacity must be an integer >= 1/);
+            expect(() => new InteractiveBatchQueue({capacity: 1.5})).toThrow(/capacity must be an integer >= 1/);
+            expect(() => new InteractiveBatchQueue({capacity: '2'})).toThrow(/capacity must be an integer >= 1/);
+
+            // Control: a valid capacity constructs, so the guard is not simply rejecting everything.
+            expect(new InteractiveBatchQueue({capacity: 4}).capacity).toBe(4);
+        });
+
+        test('queueWaitMs distinguishes an ADMITTED task from a QUEUED one', async () => {
+            // The witness for the dedicated-endpoint work is judged on persisted queue wait, so the
+            // number this queue reports has to mean what that judgement assumes: ~0 for a task that
+            // was admitted immediately, and the wait actually served for one that queued.
+            let clock = 1000;
+
+            const queue   = new InteractiveBatchQueue({capacity: 1, now: () => clock}),
+                  waits   = [],
+                  gate    = deferred(),
+                  observe = {onStarted: ({queueWaitMs}) => waits.push(queueWaitMs)};
+
+            const pA = queue.enqueue(async () => { await gate.promise }, 'interactive', observe);
+
+            queue.enqueue(async () => {}, 'interactive', observe);
+
+            expect(waits).toEqual([0]);
+
+            clock = 1750;
+            gate.resolve();
+            await pA;
+
+            expect(waits).toEqual([0, 750]);
+        });
+    });
 });

--- a/test/playwright/unit/ai/services/knowledge-base/SearchService.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/SearchService.spec.mjs
@@ -595,4 +595,28 @@ test.describe('Neo.ai.services.knowledge-base.SearchService', () => {
         expect(aiConfig.askSynthesis.contextMaxCharsPerDocument)
             .toBeLessThan(aiConfig.askSynthesis.contextBudgetChars)
     });
+
+    test('ask owns an admission queue sized by maxParallel, defaulting to serialized', async () => {
+        const {buildAskRequestQueue} = await import('../../../../../../ai/services/knowledge-base/SearchService.mjs');
+
+        expect(buildAskRequestQueue({askSynthesis: {maxParallel: 3}}).capacity,
+            'the operator-set parallelism reaches the queue').toBe(3);
+
+        // NON-VACUITY: a second, different value — otherwise the arm would pass against a hardcoded
+        // constant and prove nothing about the leaf being read at all.
+        expect(buildAskRequestQueue({askSynthesis: {maxParallel: 1}}).capacity,
+            'the serialized default is read, not assumed').toBe(1);
+
+        // A missing leaf lands on the QUEUE PRIMITIVE's own documented default of 1, not on a second
+        // fallback inside this builder — which is the distinction worth pinning. It cannot happen in
+        // production anyway, since the declared default inherits to every overlay; the arm exists so
+        // that a future `|| N` added here would fail rather than pass silently.
+        expect(buildAskRequestQueue({askSynthesis: {}}).capacity,
+            'no builder-local fallback — the primitive default applies').toBe(1);
+
+        // An UNUSABLE capacity is refused at construction rather than clamped, so an operator typo
+        // fails loudly instead of quietly serializing a deployment that asked for parallelism.
+        expect(() => buildAskRequestQueue({askSynthesis: {maxParallel: 0}}))
+            .toThrow(/capacity must be an integer >= 1/)
+    });
 });

--- a/test/playwright/unit/ai/services/knowledge-base/SearchService.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/SearchService.spec.mjs
@@ -596,6 +596,22 @@ test.describe('Neo.ai.services.knowledge-base.SearchService', () => {
             .toBeLessThan(aiConfig.askSynthesis.contextBudgetChars)
     });
 
+    test('the CONSTRUCTED service published the queue it handed over — the production edge', async () => {
+        // Third round on one defect, and the shape is the lesson: each previous fix asserted the
+        // newly-extracted pure function while the unwitnessed edge moved UP to its caller.
+        //   round 1: asserted buildAskRequestQueue().capacity  -> removing the injection stayed green
+        //   round 2: asserted buildAskChatModelOptions()       -> removing the CALL from construct stayed green
+        // Both proved a builder. Neither proved THIS SERVICE composed anything.
+        //
+        // `askRequestQueue` is published off the SAME options object handed to `buildChatModel`, so it
+        // is a receipt of what actually travelled rather than a second construction. Bypass the call in
+        // `construct` and this is `null` — which no rebuilt-in-the-spec assertion can detect.
+        expect(SearchService.askRequestQueue, 'construct composed and handed over a queue').toBeTruthy();
+        expect(SearchService.askRequestQueue.capacity,
+            'and its capacity came from the config leaf, not a literal')
+            .toBe(aiConfig.askSynthesis.maxParallel);
+    });
+
     test('the queue is actually HANDED to buildChatModel — not merely constructible', async () => {
         // The arm below asserts `buildAskRequestQueue(...).capacity`, which proves the
         // helper builds a queue and says NOTHING about asks using it. Deleting the injection from the

--- a/test/playwright/unit/ai/services/knowledge-base/SearchService.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/SearchService.spec.mjs
@@ -596,6 +596,28 @@ test.describe('Neo.ai.services.knowledge-base.SearchService', () => {
             .toBeLessThan(aiConfig.askSynthesis.contextBudgetChars)
     });
 
+    test('the queue is actually HANDED to buildChatModel — not merely constructible', async () => {
+        // The arm below asserts `buildAskRequestQueue(...).capacity`, which proves the
+        // helper builds a queue and says NOTHING about asks using it. Deleting the injection from the
+        // call site left the entire suite green — testing the proxy and calling it the delivery, the same
+        // class as testing a helper's output instead of the production path that consumes it.
+        //
+        // This asserts the COMPOSITION: the exact options object the provider layer receives.
+        const {buildAskChatModelOptions} = await import('../../../../../../ai/services/knowledge-base/SearchService.mjs'),
+              providerConfigs            = {openAiCompatibleConfig: {}, ollamaConfig: {}},
+              options                    = buildAskChatModelOptions(
+                  {askSynthesis: {provider: 'openAiCompatible', model: 'm', maxParallel: 4}},
+                  providerConfigs
+              );
+
+        expect(options.chatRequestQueue, 'an admission queue reaches buildChatModel').toBeTruthy();
+        expect(options.chatRequestQueue.capacity, 'and it carries the operator-set parallelism').toBe(4);
+
+        // NON-VACUITY: the queue handed over must be the ASK-OWNED one, not whatever the provider layer
+        // would have defaulted to. A different capacity than the shared queue's 1 is what proves it.
+        expect(options.chatRequestQueue.capacity).not.toBe(1);
+    });
+
     test('ask owns an admission queue sized by maxParallel, defaulting to serialized', async () => {
         const {buildAskRequestQueue} = await import('../../../../../../ai/services/knowledge-base/SearchService.mjs');
 


### PR DESCRIPTION
Resolves neomjs/neo#17008
Refs neomjs/neo#17000
Refs neomjs/neo-agent-brain#44

> **Un-stacked: neomjs/neo#17002 merged at 07:14Z, so this now targets `dev` directly.** The three neomjs/neo#16999 commits are in `dev` and were dropped from this branch by `git rebase --onto origin/dev`; the four commits here are its own. Carried action RA-4 (retarget + full exact-head CI) is therefore discharged.

## Problem

`ask_knowledge_base` dispatches through a **serializing** admission queue, so two asks arriving seconds apart are served one after the other **regardless of how much idle capacity the serving endpoint has.** Traced at `271bb132d8`:

```
SearchService.mjs:176        this.model = buildChatModel({…})
buildChatModel.mjs:160       return chatRequestQueue.enqueue(…)      // openAiCompatible = ask's default provider
buildChatModel.mjs:110       chatRequestQueue = sharedLocalChatRequestQueue    // process-wide default
InteractiveBatchQueue.mjs:2  "A single-lane request scheduler that runs async tasks one at a time"
```

At the measured ~43 s per ask, the second returns near ~86 s. **So provisioning a dedicated endpoint or a replica pool without addressing admission yields idle replicas behind a queued second ask** — and the symptom reads as *"the model is slow"* rather than *"the queue admitted one"*. The constraint is **admission, not capacity**, and neomjs/neo#17000's operator requirement (two asks 2 s apart, both served) cannot be met by deployment alone.

## Approach

- **`InteractiveBatchQueue` gains an optional `capacity`, default 1** — the original single-lane behaviour exactly, so every existing consumer is byte-identical. The `#active` boolean became a `#running` **counter**, because a boolean can only say "a lane is busy" and cannot represent a freed slot among several.
- **`askSynthesis.maxParallel`** (default 1) in the existing node — no second config node.
- **`buildAskRequestQueue()`** reads that leaf at the use site, constructs the queue, and `SearchService` injects it.

### Three decisions worth pushing on

**1. Slot-filling is SYNCHRONOUS on purpose.** Two `enqueue` calls in the same tick must both be admitted when capacity allows. An `await` in the drain would let the first task's dispatch delay the second — reintroducing serialization *while still reporting a capacity above one*, which is the worst outcome because the number would look right.

**2. Ask gets its OWN queue instance, not a raised capacity on the shared one.** Capacity belongs to the consumer that has its own endpoint; raising it on the process-wide queue would hand concurrency to every other local chat consumer as a side effect. **Blast radius measured rather than assumed:** the only two `buildChatModel` callers repo-wide are `SearchService` (KB process) and memory-core's `SessionService` (**a different process**), so the "process-wide" queue never serialized them against each other and ask is the only chat consumer in its process. No contention changes hands.

**3. The capacity is read at the use site and the CONSTRUCTED QUEUE is injected — never the number.** ADR 0019 **B5** forbids passing `AiConfig` values into another consumer's config, and **C1** (zero-tolerance) forbids `buildChatModel` importing `AiConfig`, since the provider layer is not a thread-entrypoint. So the capacity cannot reach `buildChatModel` by either route; an injected collaborator is not a threaded config value, which is what keeps this inside B5. The injection parameter is now documented as a **production injection point** rather than left labelled a test seam — the explicit argument neomjs/neo#17000 asked for instead of quiet reuse.

**No builder-local fallback.** `maxParallel` is read plainly. A `|| 1` would be dead code — the declared default inherits to every overlay (the generated `config.mjs` is a thin singleton declaring no data of its own) — and masking a real config break as "serialized" is the quiet failure, since a deployment that meant to run parallel asks would silently keep serializing them.

## Contract Ledger

| Target surface | Source of authority | Behaviour | Failure / fallback | Evidence |
|---|---|---|---|---|
| `InteractiveBatchQueue` | this PR | admits up to `capacity` concurrently; selection still prefers `interactive` when a slot frees | capacity `1` is byte-identical to the previous single-lane scheduler | 7 new arms + the original 7 unchanged |
| construction guard | this PR | an integer `>= 1` is required | `0` / negative / fractional / non-numeric throws at construction | explicit arm with a valid-capacity control |
| `askSynthesis.maxParallel` | KB `AiConfig`, read at the use site by `SearchService` | sizes the ask-owned queue | no builder fallback; a missing leaf lands on the primitive's own documented default | `buildAskRequestQueue` arms |
| `chatRequestQueue` injection | shipped `buildChatModel` parameter | ask supplies its own queue | omitted → the process-wide shared queue, unchanged | `SessionService` specs unchanged |

## Deltas

**`ai/provider/InteractiveBatchQueue.mjs`** — optional parallel capacity, default 1; `#running` counter; synchronous slot-filling; slot released before re-draining.
**`ai/provider/buildChatModel.mjs`** — the queue parameter re-documented as a production injection point (JSDoc only).
**`ai/mcp/server/knowledge-base/configBase.mjs`** — the `maxParallel` leaf inside the existing `askSynthesis` node.
**`ai/services/knowledge-base/SearchService.mjs`** — `buildAskRequestQueue()` + injection at the `buildChatModel` call.
**`ai/scripts/lint/config-leaf-parity.json`** — parity snapshot, in the same commit per the lint's instruction.

Evidence: L2 (queue arms mutation-verified in both directions, the original 7 as the default-capacity control, plus a composition arm proving the queue reaches `buildChatModel`) → L2 sufficient for **#17008**, whose ACs are all decidable in-process. No residuals: the endpoint, exclusivity, attribution, model decision and L3 witness are **#17000's scope**, not deferred work from this close-target.

## Test Evidence

```
npx playwright test .../InteractiveBatchQueue.spec.mjs .../SearchService.spec.mjs \
                   .../searchService.askContextBudget.spec.mjs .../SessionService.buildChatModel.spec.mjs
  57 passed
```

**Mutation-verified in both directions** — a green suite is not evidence the arms would catch a defect:

| mutation | result |
|---|---|
| make slot-filling `async` (reintroduces serialization) | **9 arms fail** |
| re-drain *before* releasing the slot (freed slot invisible) | **9 arms fail**, and the run hangs 3.6 min — the documented stall |
| restored | 14 passed |

The original 7 queue arms pass unchanged, including *"never runs two tasks concurrently"*, which now serves as the **default-capacity control**: if capacity 1 ever stopped being the old behaviour, that arm is what says so.

## Review round 2 — all four required actions

- [x] **Capacity reachable from a deployment.** `NEO_KB_ASK_MAX_PARALLEL` was absent from every file under `ai/deploy/` — verified with a positive control, since the sibling `NEO_KB_ASK_MODEL` appears in three. Now carried through `docker-compose.yml` and `docker-compose.dev.yml`. This was the same defect I had diagnosed on the miniSummary window leaves hours earlier and then committed here.
- [x] **Mutation-sensitive composition witness.** `buildAskChatModelOptions()` returns the exact options object handed to `buildChatModel`, and an arm asserts the queue that arrives there. **Removing `chatRequestQueue` now fails exactly that arm** (1 failed / 20 passed in that spec); before, it left the whole suite green.
- [x] **Truthful close edge.** Carved **#17008** for what this PR fully resolves; **#17000 keeps** the endpoint, exclusivity, attribution, model decision and L3 witness, which need host provisioning this PR does not perform. No requirement is assigned back to a ticket this PR declares resolved.
- [x] **Retargeted to `dev` + full exact-head CI.** neomjs/neo#17002 merged; this branch was rebased onto `dev`, and all 20 hosted checks are green at `bba7d992f0`.

## Post-Merge Validation

- [ ] **L3 witness, once a dedicated endpoint exists:** one long-running Dream/graph call on the full-power lane, then two asks 2 s apart. Judged on each ask's **persisted `queue_wait_ms`** (`providerActivityLedger.mjs:357-360` already returns queue wait and execution time as separate columns) — the second ask's wait must collapse to near zero. A wait ≈ the first ask's duration is the serialized-admission signature.
- [ ] Confirm no summarisation or graph call reaches the ask endpoint during that witness.

⚠️ Not valid against the external plane until it carries `accfdb0c1a` (#16943) — pre-fix rows there report a real queue as absent, so a `queue_wait_ms` read would encode the fixed defect rather than measure admission.

Residual-Owner: neomjs/neo#17000

Authored by @neo-opus-vega



