### PR TITLE
fix(ai): Linearize oversized ingestion splitting (#17013)

### DIFF
--- a/ai/services/knowledge-base/VectorService.mjs
+++ b/ai/services/knowledge-base/VectorService.mjs
@@ -501,6 +501,9 @@ class VectorService extends Base {
 
     /**
      * Splits text on stable line boundaries, falling back to character slices for huge lines.
+     * Tracks each line's byte size once: re-measuring the growing output prefix makes a large
+     * minified/generated source file quadratic and can starve every writer on the shared
+     * orchestrator event loop.
      *
      * @param {String} text Source text.
      * @param {Number} maxBytes Maximum byte size per returned part.
@@ -511,57 +514,73 @@ class VectorService extends Base {
             return [text];
         }
 
-        const parts   = [];
-        let   current = '';
+        const parts        = [];
+        let   currentLines = [],
+              currentBytes = 0;
+
+        const flushCurrent = () => {
+            if (currentLines.length === 0) return;
+
+            parts.push(currentLines.join(''));
+            currentLines = [];
+            currentBytes = 0
+        };
 
         for (const line of text.match(/[^\n]*\n?|[^\n]+$/g).filter(Boolean)) {
-            if (Buffer.byteLength(line, 'utf8') > maxBytes) {
-                if (current) {
-                    parts.push(current);
-                    current = '';
-                }
+            const lineBytes = Buffer.byteLength(line, 'utf8');
+
+            if (lineBytes > maxBytes) {
+                flushCurrent();
                 parts.push(...this.splitLongStringByByteBudget(line, maxBytes));
                 continue;
             }
 
-            if (current && Buffer.byteLength(current + line, 'utf8') > maxBytes) {
-                parts.push(current);
-                current = line;
-            } else {
-                current += line;
+            if (currentLines.length > 0 && currentBytes + lineBytes > maxBytes) {
+                flushCurrent()
             }
+
+            currentLines.push(line);
+            currentBytes += lineBytes
         }
 
-        if (current) {
-            parts.push(current);
-        }
+        flushCurrent();
 
         return parts.filter(part => part.length > 0);
     }
 
     /**
      * Splits one oversized line without breaking JavaScript surrogate pairs.
+     * The byte accumulator is linear in code points; each character is measured exactly once.
      *
      * @param {String} value Source string.
      * @param {Number} maxBytes Maximum byte size per part.
      * @returns {String[]} Split text parts.
      */
     splitLongStringByByteBudget(value, maxBytes) {
-        const parts   = [];
-        let   current = '';
+        const parts        = [];
+        let   currentChars = [],
+              currentBytes = 0;
+
+        const flushCurrent = () => {
+            if (currentChars.length === 0) return;
+
+            parts.push(currentChars.join(''));
+            currentChars = [];
+            currentBytes = 0
+        };
 
         for (const char of value) {
-            if (current && Buffer.byteLength(current + char, 'utf8') > maxBytes) {
-                parts.push(current);
-                current = char;
-            } else {
-                current += char;
+            const charBytes = Buffer.byteLength(char, 'utf8');
+
+            if (currentChars.length > 0 && currentBytes + charBytes > maxBytes) {
+                flushCurrent()
             }
+
+            currentChars.push(char);
+            currentBytes += charBytes
         }
 
-        if (current) {
-            parts.push(current);
-        }
+        flushCurrent();
 
         return parts;
     }
@@ -989,7 +1008,7 @@ class VectorService extends Base {
 
         try {
             const embedResult = await this.embedChunks({
-                collection: shadowCollection,
+                collection     : shadowCollection,
                 chunksToProcess: chunksToEmbed,
                 shouldYield,
                 signal,

--- a/test/playwright/unit/ai/services/knowledge-base/IngestionService.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/IngestionService.spec.mjs
@@ -996,6 +996,35 @@ test.describe('IngestionService.ingestSourceFiles', () => {
         });
     });
 
+    test('#17013 keeps production-sized single-line ingestion bounded and lossless', async () => {
+        const content = 'z'.repeat(105_000);
+
+        Service.resolveEmbeddingInputGuardrail = () => createEmbeddingGuardrail({
+            contextLimitTokens       : 40_000,
+            safeProcessingLimitTokens: 33_400
+        });
+
+        const startedAt = performance.now();
+        const summary   = await Service.ingestSourceFiles({
+            tenantId: 'tenant-a',
+            repoSlug: 'repo-a',
+            files   : [{
+                content,
+                sourcePath: 'dist/generated.min.js'
+            }]
+        });
+        const durationMs = performance.now() - startedAt;
+        const records    = vectorCalls[0].records;
+
+        expect(durationMs).toBeLessThan(1_000);
+        expect(summary.ingested).toBeGreaterThan(1);
+        expect(summary.embeddingsGenerated).toBe(summary.ingested);
+        expect(summary.errors).toEqual([]);
+        expect(records.every(record => record.sourcePath === 'dist/generated.min.js')).toBe(true);
+        expect(records.every(record => record.oversizedSplit === true)).toBe(true);
+        expect(records.map(record => record.content).join('')).toBe(content);
+    });
+
     test('keeps skip diagnostics for over-budget chunks that cannot be split', async () => {
         Service.resolveEmbeddingInputGuardrail = () => createEmbeddingGuardrail({
             contextLimitTokens       : 50,

--- a/test/playwright/unit/ai/services/knowledge-base/VectorService.WorkVolumeBranching.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/VectorService.WorkVolumeBranching.spec.mjs
@@ -400,6 +400,73 @@ test.describe('VectorService.embed — work-volume branching (#10572)', () => {
         }
     });
 
+    test('#17013 splits a production-sized single line in linear time without breaking Unicode', () => {
+        const
+            ascii              = 'x'.repeat(100_000),
+            astral             = '🧠'.repeat(2_500),
+            source             = ascii + astral,
+            maxBytes           = 100_000,
+            originalByteLength = Buffer.byteLength;
+
+        let durationMs,
+            parts,
+            scannedChars = 0;
+
+        Buffer.byteLength = (value, encoding) => {
+            scannedChars += String(value).length;
+            return originalByteLength(value, encoding)
+        };
+
+        try {
+            const startedAt = performance.now();
+
+            parts      = KB_VectorService.splitLongStringByByteBudget(source, maxBytes);
+            durationMs = performance.now() - startedAt
+        } finally {
+            Buffer.byteLength = originalByteLength
+        }
+
+        expect(durationMs).toBeLessThan(1_000);
+        expect(scannedChars).toBe(source.length);
+        expect(parts.length).toBeGreaterThan(1);
+        expect(parts.join('')).toBe(source);
+        expect(parts.every(part => part.length > 0)).toBe(true);
+        expect(parts.every(part => Buffer.byteLength(part, 'utf8') <= maxBytes)).toBe(true);
+        expect(parts.every(part => !/[\uD800-\uDBFF]$/u.test(part) && !/^[\uDC00-\uDFFF]/u.test(part))).toBe(true);
+    });
+
+    test('#17013 packs many short lines without rescanning the growing output prefix', () => {
+        const
+            source             = Array.from({length: 12_000}, (_, index) => `${index.toString().padStart(5, '0')}:${'y'.repeat(24)}\n`).join(''),
+            maxBytes           = 100_000,
+            originalByteLength = Buffer.byteLength;
+
+        let durationMs,
+            parts,
+            scannedChars = 0;
+
+        Buffer.byteLength = (value, encoding) => {
+            scannedChars += String(value).length;
+            return originalByteLength(value, encoding)
+        };
+
+        try {
+            const startedAt = performance.now();
+
+            parts      = KB_VectorService.splitTextByByteBudget(source, maxBytes);
+            durationMs = performance.now() - startedAt
+        } finally {
+            Buffer.byteLength = originalByteLength
+        }
+
+        expect(durationMs).toBeLessThan(1_000);
+        expect(scannedChars).toBe(source.length * 2);
+        expect(parts.length).toBeGreaterThan(1);
+        expect(parts.join('')).toBe(source);
+        expect(parts.every(part => part.length > 0)).toBe(true);
+        expect(parts.every(part => Buffer.byteLength(part, 'utf8') <= maxBytes)).toBe(true);
+    });
+
     test('does not apply local-model input caps to non-local embedding providers', async () => {
         Memory_Config.data.embeddingProvider                            = 'gemini';
         KB_Config.data.localModels.embedding.contextLimitTokens        = 50;


### PR DESCRIPTION
Resolves neomjs/neo#17013

Related: neomjs/neo-agent-brain#54

Oversized raw-source splitting now measures each line or Unicode code point once instead of repeatedly measuring a growing prefix. Tenant refresh retains exact content, byte boundaries, surrogate-pair safety, and chunk identity while eliminating the synchronous quadratic event-loop block.

Evidence: L2 (real production methods under the repository-local unit harness plus a deterministic byte-work witness) → L2 required (all close-target ACs are repository-local). No residuals.

## Deltas from ticket

None substantive. The repair stays inside the existing `VectorService` primitive. Coverage adds both direct linear-work witnesses and the production `IngestionService.ingestSourceFiles()` raw-source path.

After the PR opened, a second external observation reproduced the same discriminator: the same repository lane blocked all independent event-loop writers while a larger-file-count control lane kept yielding. A read-only corpus census then found six individual lines above 100,000 bytes (maximum 569,174), binding that lane to the repaired long-line path without using the external deployment as a test environment.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/ai/services/knowledge-base/VectorService.WorkVolumeBranching.spec.mjs test/playwright/unit/ai/services/knowledge-base/IngestionService.spec.mjs` — 94/94 passed.
- Exact 100,000-byte Unicode probe — 3.748 ms, two bounded parts, exact round-trip; the pre-repair implementation exceeded five seconds on the same workload and was interrupted.
- The actual `splitOversizedEmbeddingChunk()` at `98643299a7` processed the largest production-shaped 5,749,518-byte source fixture in 88.678 ms: 81 non-empty chunks, exact round-trip, maximum final provider input 85,901 bytes.
- `npm run agent-preflight -- --change-class restoration --commit-subject 'fix(ai): linearize oversized ingestion splitting (#17013)' ...` — passed; only unrelated stale-overlay warnings reported.
- `git diff --cached --check` — clean before commit.
- Vector splitting surface: `VectorService.WorkVolumeBranching.spec.mjs` covers production-sized long lines, Unicode boundaries, many-line packing, byte-work linearity, and existing oversized-chunk identity behavior.
- Tenant ingestion surface: `IngestionService.spec.mjs` covers a 105,000-character raw generated source through the real `ingestSourceFiles()` split path, bounded completion, lossless materialization, and unchanged ingestion accounting.

## Post-Merge Validation

- [x] Repository-local proof completes the close target; external deployments are explicitly excluded as test environments.

Authored by Emmy (GPT-5.6 Sol Ultra, Codex). Session 3b6a56b3-6197-42d7-9bca-c5e9b1bb1496.
