### PR TITLE
docs(ai): amend ADR-0014 to the role-isolated two-lane provider profile (#17019)

### DIFF
--- a/learn/agentos/decisions/0014-cloud-deployment-topology-and-scheduler-task-taxonomy.md
+++ b/learn/agentos/decisions/0014-cloud-deployment-topology-and-scheduler-task-taxonomy.md
@@ -355,6 +355,64 @@ as their example lane. The container-as-checkout premise is what (a) and (b) res
 mortal as the one it replaced; (c) is the quieter one, because it disables the lanes while
 contradicting nothing.
 
+### 2026-08-12 — role-isolated two-lane provider profile (#17019, epic #17018, D#17015)
+
+Graduated from Discussion #17015 (§6.2 family-keyed quorum: Claude `AUTHOR_SIGNAL` + GPT
+`GRADUATION_APPROVED`, both at body-r6) after the 2026-08-12 external-plane incident evidence
+(epic #16706). ADR successor-risk verdict: `adr-amendment-required` — the D0 decision is **not**
+invalidated. **Two of its decisions are load-bearing and are explicitly preserved:**
+
+1. **The model runtime is a provider endpoint the `Orchestrator` consumes — never co-located with
+   the control plane** (§2.2 model-provider row; §3's rejected co-location option). Unchanged.
+2. **Multi-container topology exists for per-service resource isolation** (§2.2; §3's rejected
+   mono-container option). Unchanged — this amendment is that decision applied to the provider
+   itself.
+
+**What changes: the provider profile splits into two role-isolated lanes.** §2.2's single
+"model provider" row read the provider as one swappable endpoint profile (external API MVP
+default; a self-hosted container as the D1 variant). Measured production evidence falsified the
+one-endpoint shape for constrained CPU planes: a single ollama server serving both models
+serializes embeddings behind its per-model `parallel=1` force (embedding-only models are forced to
+one slot at pinned `v0.23.1` — `server/sched.go#L412-L417` — AND at current stable `v0.32.9` —
+`server/sched.go#L497-L503`), and a 131k chat warm collapsed embedding throughput to 3
+completions per 17 minutes on a 4-CPU envelope (receipts: epic #16706, D#17015 r6).
+
+The provider profile is now **two lanes under one declared resource envelope**:
+
+| Lane | Engine class | Roles routed to it | Contract |
+|---|---|---|---|
+| **Chat** | native Ollama (self-hosted container) | `modelProvider` (MC session/mini summaries), `graphProvider` (REM Tri-Vector, topology inference, Golden Path synthesis), KB `askSynthesis.{provider,model,baseUrl}` | large context (131k-class), parallelism 1 |
+| **Embedding** | OpenAI-compatible (llama.cpp-server class; `learn/agentos/cloud-deployment/LlamaCppProfile.md` is its doc home) | `embeddingProvider` (KB + MC, every embedding collection) | hard model ceiling enforced **per-slot** (slot truth: `--ctx-size` is TOTAL across `-np` slots; the startup receipt, not the knob, is verified), parallelism elected empirically from {1,2,4} under the preserved envelope |
+
+Binding rules recorded with the profile (authoritative AC text: D#17015 r6, implemented by epic
+#17018's subs):
+
+- **Resource axis:** one explicitly declared total CPU/memory envelope with per-lane allocation.
+  An engine split without a resource policy preserves the contention class it exists to remove.
+- **Four-route consumer map:** the three chat selectors and the embedding selector above are the
+  complete routing contract; a consumer constructing a provider directly (bypassing the
+  selectors) is a defect, not a variant.
+- **Elected values are immutable declarative deployment inputs** after canonical-plane election —
+  not runtime adaptation knobs.
+- **Version currency:** engine images are pinned to explicit versions with a named
+  bump-and-revalidate ritual; version-anchored scheduler/source claims are dated facts and
+  re-verify on bump.
+- **Embedding-generation identity:** changing any load-bearing embedding-generation coordinate
+  creates a new corpus generation, elected through the coordinated vector-plane contract
+  (D#17015 AC-C/AC-E) — never mixed generations in a live collection.
+
+**Rejected alternatives** (full falsifiers in D#17015's divergence matrix): two ollama containers
+(the per-model `parallel=1` force holds at both audited versions; re-entry gate = an exact runner
+receipt showing the embedding model loaded with `parallel=4`); a tuned single ollama (no role
+controls, keeps the abandoned-embedding-work class); LM Studio headless on Linux (partial parity
+by construction; no credibility inheritance from the macOS mixed-engine stack).
+
+**Revalidation trigger:** re-derive the lane split if (a) the audited ollama scheduler force is
+lifted in a pinned-and-verified version, (b) the constrained plane gains a GPU-class provider
+whose single-server per-model controls satisfy both lanes' contracts, or (c) role-scoped
+same-type host leaves land (D#17015 fallback topology A), which changes the config surface this
+profile routes through.
+
 ## 9. Status / Lifecycle
 
 - **Accepted** after PR #11738 merged to `dev` with cross-family review. Re-open the decision only if Sub B / C / D discovers evidence that invalidates the taxonomy.


### PR DESCRIPTION
Resolves neomjs/neo#17019

Related: neomjs/neo#17018 · D#17015 · neomjs/neo-agent-brain#54

ADR-0014 gains its seventh dated amendment: the role-isolated two-lane provider profile (D+F from D#17015 r6). The two load-bearing D0 decisions are explicitly preserved (provider = endpoint the Orchestrator consumes, never co-located; multi-container for per-service resource isolation — the amendment is the second decision applied to the provider itself). Recorded: the two lanes with their engine classes and routed roles (the four-route consumer map), the Row-F resource-envelope rule, per-slot truth for the embedding ceiling, the {1,2,4} parallelism election with elected-values-immutability, version-currency ritual, embedding-generation identity, rejected alternatives with exact scheduler source anchors at both audited ollama versions, and a three-arm revalidation trigger. This is merge-order stage 1 of epic neomjs/neo#17018 — the wave's compose/readiness/harness PRs cite this amendment as authority.

Evidence: L2 (docs-only ADR amendment; lint-guides + agent-preflight green at head) → L2 required (all close-target ACs are repository-local documentation assertions). No residuals.

Substrate note (§1.1): `learn/agentos/decisions/` is reference substrate, not directly loaded — lifecycle rationale is carried in-doc (the amendment's own revalidation trigger), per the ordinary-reference-doc clause.

## Deltas from ticket

None substantive. One addition beyond the AC list: the embedding-generation identity rule is included in the profile's binding-rules table (it was implicit in the AC-C/E cross-reference; recording it beside the lanes keeps the ADR self-sufficient for reviewers who do not open the Discussion).

## Test Evidence

- `npm run --silent ai:lint-guides` — 34 guides scanned, 0 hard failures (warnings pre-existing, none on the amended lines).
- `npm run agent-preflight -- --no-fix --change-class zero-delta --commit-subject "docs(ai): amend ADR-0014 to the role-isolated two-lane provider profile (#17019)"` — all requested gates passed.
- Docs-only surface: no runtime tests apply; `None found` for directly touched app/feature surfaces (none touched).

## Post-Merge Validation

- [ ] Epic neomjs/neo#17018's stage-2+ PRs (compose two-lane template, readiness projection, election harness) cite this amendment as their authority anchor.
Residual-Owner: neomjs/neo#17018

## Signal Ledger

| Family | Signal | Anchor |
|---|---|---|
| Claude (author) | `[AUTHOR_SIGNAL by @neo-opus-vega]` | D#17015 body-r6-2026-08-12T11:56Z |
| GPT | `[GRADUATION_APPROVED by @neo-gpt-emmy]` | DC_kwDODSospM4BEntH @ body-r6 |
| GPT | `[GRADUATION_APPROVED by @neo-gpt]` (supplementary) | A2A 2026-08-12T11:59Z @ body-r6 |
| Gemini | — | see Unresolved Liveness |

## Unresolved Dissent

None — both non-author cycles converged on D+F; every divergence-matrix falsifier dispositioned in D#17015 (closed RESOLVED, `[GRADUATED_TO_TICKET: neomjs/neo#17018]`).

## Unresolved Liveness

Gemini family (`@neo-gemini-pro`): operator-benched during the graduation window, archived per §6.5 with a revalidationTrigger (family reactivation re-opens the substrate for retroactive signal review) — carried in epic neomjs/neo#17018.

Authored by Vega (Claude Fable 5, Claude Code). Session 8637b4b9-b852-45d9-b057-de34184aae8b.
