### PR TITLE
fix(ai): isolate first-batch embedding poison (#17017)

### DIFF
--- a/ai/daemons/orchestrator/services/TenantRepoSyncService.mjs
+++ b/ai/daemons/orchestrator/services/TenantRepoSyncService.mjs
@@ -1514,21 +1514,22 @@ class TenantRepoSyncService extends Base {
             globalCadenceMs
         });
 
-        const resolvedRevisionsPath = revisionsFilePath || this.defaultRevisionsFilePath();
-        const ingestionService      = knowledgeBaseIngestionService || await this.resolveIngestionService();
+        const resolvedRevisionsPath          = revisionsFilePath || this.defaultRevisionsFilePath();
+        const ingestionService               = knowledgeBaseIngestionService || await this.resolveIngestionService();
         const ingestSourceFilesForTenantSync = typeof ingestionService.ingestSourceFilesForTenantSync === 'function'
             ? (payload, controls) => ingestionService.ingestSourceFilesForTenantSync(payload, controls)
             : (payload, controls) => ingestionService.ingestSourceFiles(payload, controls);
-        const providerTimeoutCircuit = new AbortController();
+        const providerTimeoutCircuit  = new AbortController();
         const providerCircuitControls = {
-            signal           : providerTimeoutCircuit.signal,
+            signal: providerTimeoutCircuit.signal,
+            ...(fullReplay ? {replayEmbeddingPoison: true} : {}),
             onProviderTimeout: () => {
                 if (!providerTimeoutCircuit.signal.aborted) {
                     providerTimeoutCircuit.abort(createProviderTimeoutCircuitError());
                 }
             }
         };
-        const persistedRevisions    = await this.readPersistedRevisions({
+        const persistedRevisions = await this.readPersistedRevisions({
             filePath: resolvedRevisionsPath,
             strict  : true
         });
@@ -2100,7 +2101,14 @@ class TenantRepoSyncService extends Base {
                             repoSlug: repo.repoSlug
                         })
                         : null,
-                    retryReceipt = isMatchingMaterializationReceipt(
+                    declaresNoContent = Array.isArray(envelope.manifestSnapshot?.pathsAfterPush)
+                        && envelope.manifestSnapshot.pathsAfterPush.length === 0,
+                    // A content-bearing full replay must reach VectorService so its explicit replay
+                    // control can clear and re-offer same-generation poison. An authoritative empty
+                    // manifest has no embedding work to suppress, so its uncommitted receipt remains
+                    // the exactly-once recovery proof for a post-ingest checkpoint-write failure.
+                    mustReplayEmbeddingCorpus = fullReplay && !declaresNoContent,
+                    retryReceipt = !mustReplayEmbeddingCorpus && isMatchingMaterializationReceipt(
                         existingManifest?.materializationReceipt,
                         envelopeDigest
                     ) && existingManifest.materializationReceipt.attemptId

--- a/ai/scripts/lint/retry-bound-registry.json
+++ b/ai/scripts/lint/retry-bound-registry.json
@@ -206,7 +206,7 @@
             "witness": "`retry.maxTotalDelayMs - totalDelayMs` remaining-budget clamp in #getCollectionResolveRetryDelay",
             "note": "The only max-window instance: bounded by TOTAL delay spent, not by a per-delay cap alone (it also carries maxDelayMs)."
         },
-        "ai/services/knowledge-base/VectorService.mjs#evaluateEmbeddingInput:2603053b": {
+        "ai/services/knowledge-base/VectorService.mjs#createFirstBatchAbort:2603053b": {
             "kind": "retry-growth",
             "lifetime": "in-cycle",
             "boundCarrier": "max-attempts",

--- a/ai/services/knowledge-base/IngestionService.mjs
+++ b/ai/services/knowledge-base/IngestionService.mjs
@@ -16,7 +16,13 @@ import {createTenantRepoMaterializationDigest}
                             from './helpers/tenantRepoIngestEnvelopeBuilder.mjs';
 import {isChromaConnectionError}
                             from '../shared/vector/chromaClientPrimitives.mjs';
-import {classifyEmbedFailureCode}
+import {
+    KB_VECTOR_EMBED_UNCLASSIFIED,
+    classifyEmbedFailureCode,
+    classifyEmbedFailureError,
+    classifyEmbedResidencyDisposition,
+    isEmbedFailureCode
+}
                             from './helpers/embedFailureClassification.mjs';
 import VectorService   from './VectorService.mjs';
 import aiConfig        from '../../mcp/server/knowledge-base/config.mjs';
@@ -250,12 +256,13 @@ class IngestionService extends Base {
             if (embeddableChunks.length > 0) {
                 this.updateIngestionProgress({phase: 'embedding'});
                 await this.embedChunkGroups({
-                    chunks: embeddableChunks,
-                    onProviderTimeout: controls.onProviderTimeout,
-                    signal           : controls.signal,
+                    chunks               : embeddableChunks,
+                    onProviderTimeout    : controls.onProviderTimeout,
+                    replayEmbeddingPoison: controls.replayEmbeddingPoison === true,
+                    signal               : controls.signal,
                     tenantContext,
                     summary,
-                    viaMcp: payload.viaMcp !== false
+                    viaMcp               : payload.viaMcp !== false
                 });
             }
 
@@ -380,13 +387,22 @@ class IngestionService extends Base {
      * @param {Object}  options
      * @param {AbortSignal} [options.signal] Shared tenant-sweep provider circuit signal.
      * @param {Function} [options.onProviderTimeout] Synchronous native-provider timeout hook.
+     * @param {Boolean} [options.replayEmbeddingPoison=false] Process-local operator replay control.
      * @param {Boolean} [options.viaMcp=true] Forwarded to `VectorService.embed`; `true` keeps
      *                                        the MCP work-volume gate, `false` (bulk CLI)
      *                                        bypasses it.
      * @returns {Promise<void>}
      * @protected
      */
-    async embedChunkGroups({chunks, tenantContext, summary, viaMcp = true, signal, onProviderTimeout}) {
+    async embedChunkGroups({
+        chunks,
+        tenantContext,
+        summary,
+        viaMcp = true,
+        signal,
+        onProviderTimeout,
+        replayEmbeddingPoison = false
+    }) {
         const groups = new Map();
 
         for (const chunk of chunks) {
@@ -404,6 +420,7 @@ class IngestionService extends Base {
                 const result = await this.vectorService.embed(tempFile, {
                     deleteStale  : false,
                     onProviderTimeout,
+                    replayEmbeddingPoison,
                     signal,
                     tenantContext: {...tenantContext, repoSlug},
                     viaMcp
@@ -439,17 +456,36 @@ class IngestionService extends Base {
                     }));
                 }
 
+                for (const poison of result?.poisonedChunks || []) {
+                    const reasonCode = isEmbedFailureCode(poison.reasonCode)
+                        ? poison.reasonCode
+                        : KB_VECTOR_EMBED_UNCLASSIFIED;
+
+                    summary.errors.push(this.createError({
+                        code   : reasonCode,
+                        message: 'A proven embedding poison remains fenced pending changed content, generation, or explicit replay.',
+                        details: {
+                            chunkId    : poison.chunkId,
+                            reasonCode,
+                            observedAt : poison.observedAt,
+                            disposition: 'proven-content-poison'
+                        }
+                    }));
+                }
+
                 summary.embeddingsGenerated += result?.embedded ?? group.length;
                 this.updateIngestionProgress({
                     embeddedChunks: summary.embeddingsGenerated,
                     errorCount    : summary.errors.length
                 });
             } catch (error) {
+                const residencyDisposition = classifyEmbedResidencyDisposition(error);
+
                 summary.errors.push(this.createError({
                     // The throw path carries the provider's code most often — a consumer-deadline
                     // timeout or an upstream abort — so this is the site where the inversion bit
                     // hardest: the better-classified the failure, the emptier the receipt.
-                    code   : classifyEmbedFailureCode(error.code),
+                    code   : classifyEmbedFailureError(error),
                     message: error.message,
                     // `residencyDisposition` is the difference between "re-check the model identifier"
                     // and "something took the model's slot" — opposite remediations behind one code.
@@ -459,7 +495,7 @@ class IngestionService extends Base {
                     // that reads like a measured one.
                     details: {
                         repoSlug,
-                        ...(error.residencyDisposition && {residencyDisposition: error.residencyDisposition})
+                        ...(residencyDisposition && {residencyDisposition})
                     }
                 }));
                 this.updateIngestionProgress({

--- a/ai/services/knowledge-base/VectorService.mjs
+++ b/ai/services/knowledge-base/VectorService.mjs
@@ -1,5 +1,6 @@
 import aiConfig             from '../../mcp/server/knowledge-base/config.mjs';
 import TextEmbeddingService, {
+    getEmbeddingModel,
     isEmbeddingBatchYieldError
 }                             from '../memory-core/TextEmbeddingService.mjs';
 import mcConfig from '../../mcp/server/memory-core/config.mjs';
@@ -22,7 +23,18 @@ import DestructiveOperationGuard                                       from '../
 import {computeCorpusFingerprint, decideResume, selectResumableChunks} from './helpers/resumableEmbedding.mjs';
 import {clearResumeState, readResumeState, writeResumeState}           from './helpers/kbEmbeddingResumeStore.mjs';
 import KBRecorderService                                               from './KBRecorderService.mjs';
-import {KB_VECTOR_EMBED_PROVIDER_CIRCUIT_OPEN}                         from './helpers/embedFailureClassification.mjs';
+import {
+    clearEmbeddingPoisonState,
+    createEmbeddingGenerationId,
+    createEmbeddingPoisonScopeId,
+    readEmbeddingPoisonState,
+    upsertEmbeddingPoisonEntries
+}                                                                     from './helpers/kbEmbeddingPoisonStore.mjs';
+import {
+    KB_VECTOR_EMBED_PROVIDER_CIRCUIT_OPEN,
+    classifyEmbedFailureError,
+    classifyEmbedResidencyDisposition
+}                                                                     from './helpers/embedFailureClassification.mjs';
 
 /**
  * @summary Flattens one chunk into Chroma-storable scalar metadata.
@@ -43,9 +55,10 @@ function buildChunkMetadata(chunk) {
     return metadata
 }
 
-const TENANT_GUARDED_FIELDS = ['tenantId', 'repoSlug', 'visibility', 'originAgentIdentity', 'tenantConfigVersion', 'ingestedAt'];
-const STALE_STRATEGIES      = Object.freeze(new Set(['delete-upfront', 'shadow-swap']));
-const STALE_STRATEGY_SKIP   = 'skip';
+const TENANT_GUARDED_FIELDS             = ['tenantId', 'repoSlug', 'visibility', 'originAgentIdentity', 'tenantConfigVersion', 'ingestedAt'];
+const STALE_STRATEGIES                  = Object.freeze(new Set(['delete-upfront', 'shadow-swap']));
+const STALE_STRATEGY_SKIP               = 'skip';
+const EMBEDDING_POISON_STRATEGY_VERSION = 'kb-embedding-input-v1';
 
 /**
  * @summary Manages vector database operations including embedding generation and storage.
@@ -359,6 +372,41 @@ class VectorService extends Base {
     }
 
     /**
+     * @summary Resolves the exact embedding-generation coordinate used by the poison retry fence.
+     *
+     * Provider selection remains owned by `TextEmbeddingService`; this method reads the same resolved
+     * AiConfig leaves at the disposition boundary so a provider, model, vector-schema, or input-strategy
+     * change invalidates prior poison evidence instead of silently suppressing work under a new route.
+     *
+     * @returns {{provider: String, model: String, vectorDimension: Number, strategyVersion: String}}
+     */
+    resolveEmbeddingPoisonGeneration() {
+        const provider = mcConfig.embeddingProvider;
+
+        return {
+            provider,
+            model          : getEmbeddingModel(provider),
+            vectorDimension: Number(aiConfig.vectorDimension),
+            strategyVersion: EMBEDDING_POISON_STRATEGY_VERSION
+        }
+    }
+
+    /**
+     * @summary Resolves one tenant/repository poison scope and active generation hash.
+     * @param {Object} tenantStamp Server-derived tenant/repository stamp.
+     * @returns {{scopeId: String, generationId: String}}
+     */
+    resolveEmbeddingPoisonCoordinates(tenantStamp) {
+        return {
+            scopeId: createEmbeddingPoisonScopeId({
+                tenantId: tenantStamp.tenantId,
+                repoSlug: tenantStamp.repoSlug
+            }),
+            generationId: createEmbeddingGenerationId(this.resolveEmbeddingPoisonGeneration())
+        }
+    }
+
+    /**
      * Builds the provider input string used by the embedding guardrail and provider call.
      *
      * @param {Object} chunk Parsed knowledge chunk.
@@ -654,6 +702,254 @@ class VectorService extends Base {
     }
 
     /**
+     * @summary Whether an embedding failure forbids poison isolation.
+     *
+     * These terminals say nothing about content. A timeout may leave provider work running, an
+     * abort/circuit refusal deliberately ended admission, and a cooperative yield transfers the
+     * lane. None may trigger exploratory provider calls.
+     *
+     * @param {*} error Provider failure.
+     * @param {AbortSignal} [signal] Active run signal.
+     * @returns {Boolean}
+     */
+    isPoisonIsolationForbidden(error, signal) {
+        if (signal?.aborted === true) return true;
+
+        const visited = new Set();
+        let   current = error;
+
+        for (let depth = 0; depth < 4 && current && typeof current === 'object' && !visited.has(current); depth++) {
+            visited.add(current);
+
+            if (isEmbeddingBatchYieldError(current) || current.name === 'AbortError' ||
+                current.code === 'ABORT_ERR' || current.code === KB_VECTOR_EMBED_PROVIDER_CIRCUIT_OPEN ||
+                current.code === PROVIDER_TIMEOUT_CODE ||
+                current.code === OPENAI_COMPATIBLE_REQUEST_TIMEOUT_CODE ||
+                current.code === 'ETIMEDOUT' || current.code === 'ESOCKETTIMEDOUT') {
+                return true
+            }
+
+            current = current.cause
+        }
+
+        return false
+    }
+
+    /**
+     * @summary Issues one isolation-scoped provider request without changing routing semantics.
+     * @param {Object[]} inputs Array of `{chunk, text}` inputs.
+     * @param {Function} shouldYield Cooperative yield predicate.
+     * @param {AbortSignal} [signal] Shared provider-circuit signal.
+     * @param {Function} [onProviderTimeout] Provider-timeout callback.
+     * @returns {Promise<Array<Array<Number>>>}
+     */
+    generateIsolationEmbeddings({inputs, shouldYield, signal, onProviderTimeout}) {
+        return TextEmbeddingService.embedTexts(
+            inputs.map(input => input.text),
+            mcConfig.embeddingProvider,
+            {
+                operationLabel          : 'knowledge base tenant ingestion poison isolation',
+                operationStage          : 'kb-tenant-ingestion-embedding',
+                providerActivityRecorder: KBRecorderService,
+                service                 : 'knowledge-base',
+                shouldYield,
+                signal,
+                onProviderTimeout
+            }
+        )
+    }
+
+    /**
+     * @summary Persists already-produced isolation embeddings against their exact input ids.
+     * @param {Object} collection Chroma collection.
+     * @param {Object[]} inputs Array of `{chunk, text}` inputs.
+     * @param {Array<Array<Number>>} embeddings Provider output.
+     * @returns {Promise<void>}
+     */
+    async persistIsolationEmbeddings({collection, inputs, embeddings}) {
+        if (!Array.isArray(embeddings) || embeddings.length !== inputs.length) {
+            throw new Error(`Poison isolation received ${embeddings?.length ?? 0} embedding(s) for ${inputs.length} input(s).`)
+        }
+
+        await collection.upsert({
+            ids      : inputs.map(input => input.chunk.id),
+            embeddings,
+            metadatas: inputs.map(input => buildChunkMetadata(input.chunk))
+        })
+    }
+
+    /**
+     * @summary Finds one bounded control outside the failed/poison set from the full current corpus.
+     * @param {Object} options
+     * @returns {Object|null} An embeddable `{chunk, text}` control, or null when no later evidence exists.
+     */
+    findPoisonIsolationControl({controlCandidates, startIndex, guardrail, excludedIds}) {
+        for (let index = startIndex; index < controlCandidates.length; index++) {
+            const candidate = controlCandidates[index];
+            const chunk     = candidate.chunk;
+
+            if (excludedIds.has(chunk.id)) continue;
+
+            const text       = this.buildEmbeddingInputText(chunk),
+                  evaluation = this.evaluateEmbeddingInput({chunk, text, guardrail});
+
+            if (!evaluation.skip) return {chunk, text, alreadyLanded: candidate.alreadyLanded === true}
+        }
+
+        return null
+    }
+
+    /**
+     * @summary Isolates content-dependent failures in the first batch under a dead-provider ceiling.
+     *
+     * The independent control is offered first. If it fails, the provider-wide control costs exactly one
+     * extra request and the corpus is not walked. Once it succeeds, the failed batch is bisected.
+     * Every failing singleton is paired with a fresh success from that same control before it is
+     * called poison; a provider that dies during isolation therefore aborts instead of quarantining
+     * the remainder. Successful subsets are persisted immediately and the later control id is marked
+     * so the ordinary loop does not buy it again.
+     *
+     * @param {Object} options
+     * @returns {Promise<{embedded: Number, poisonEntries: Object[], unproved: Boolean}>}
+     */
+    async isolateFirstFailedBatch({
+        collection,
+        failedInputs,
+        controlCandidates,
+        controlStartIndex,
+        guardrail,
+        excludedIds,
+        preEmbeddedIds,
+        shouldYield,
+        signal,
+        onProviderTimeout,
+        reasonCode,
+        now = Date.now
+    }) {
+        const control = this.findPoisonIsolationControl({
+            controlCandidates,
+            startIndex: controlStartIndex,
+            guardrail,
+            excludedIds
+        });
+
+        if (!control) return {embedded: 0, poisonEntries: [], unproved: true}
+
+        const controlEmbeddings = await this.generateIsolationEmbeddings({
+            inputs: [control], shouldYield, signal, onProviderTimeout
+        });
+        const controlAlreadyLanded = control.alreadyLanded === true;
+
+        let   embedded      = 0;
+        const poisonEntries = [];
+
+        const createPoisonEntry = (chunkId, error) => ({
+            chunkId,
+            reasonCode: error === undefined ? reasonCode : classifyEmbedFailureError(error),
+            observedAt: new Date(now()).toISOString()
+        });
+
+        const isolate = async inputs => {
+            let embeddings;
+
+            try {
+                embeddings = await this.generateIsolationEmbeddings({
+                    inputs, shouldYield, signal, onProviderTimeout
+                });
+            } catch (error) {
+                if (this.isPoisonIsolationForbidden(error, signal)) throw error;
+
+                if (inputs.length > 1) {
+                    const middle = Math.ceil(inputs.length / 2);
+                    await isolate(inputs.slice(0, middle));
+                    await isolate(inputs.slice(middle));
+                    return
+                }
+
+                // Paired evidence at the decision boundary. The earlier control success is not enough:
+                // a provider can die during the split walk, and quarantining everything after that point
+                // would turn a transient outage into durable content loss.
+                await this.generateIsolationEmbeddings({
+                    inputs: [control], shouldYield, signal, onProviderTimeout
+                });
+
+                let candidateRetry;
+
+                try {
+                    candidateRetry = await this.generateIsolationEmbeddings({
+                        inputs, shouldYield, signal, onProviderTimeout
+                    });
+                } catch (candidateRetryError) {
+                    if (this.isPoisonIsolationForbidden(candidateRetryError, signal)) throw candidateRetryError;
+                    poisonEntries.push(createPoisonEntry(inputs[0].chunk.id, candidateRetryError));
+                    return
+                }
+
+                await this.persistIsolationEmbeddings({collection, inputs, embeddings: candidateRetry});
+                preEmbeddedIds.add(inputs[0].chunk.id);
+                embedded++;
+                return
+            }
+
+            // Persistence is intentionally outside the provider-failure catch. A Chroma write error
+            // proves nothing about content and must never be bisected into a poison disposition.
+            await this.persistIsolationEmbeddings({collection, inputs, embeddings});
+            inputs.forEach(input => preEmbeddedIds.add(input.chunk.id));
+            embedded += inputs.length;
+        };
+
+        if (failedInputs.length === 1) {
+            let candidateRetry;
+
+            try {
+                candidateRetry = await this.generateIsolationEmbeddings({
+                    inputs: failedInputs, shouldYield, signal, onProviderTimeout
+                });
+            } catch (candidateRetryError) {
+                if (this.isPoisonIsolationForbidden(candidateRetryError, signal)) throw candidateRetryError;
+                poisonEntries.push(createPoisonEntry(failedInputs[0].chunk.id, candidateRetryError));
+            }
+
+            if (candidateRetry) {
+                await this.persistIsolationEmbeddings({collection, inputs: failedInputs, embeddings: candidateRetry});
+                preEmbeddedIds.add(failedInputs[0].chunk.id);
+                embedded++;
+            }
+        } else {
+            const middle = Math.ceil(failedInputs.length / 2);
+            await isolate(failedInputs.slice(0, middle));
+            await isolate(failedInputs.slice(middle));
+        }
+
+        if (!controlAlreadyLanded) {
+            await this.persistIsolationEmbeddings({collection, inputs: [control], embeddings: controlEmbeddings});
+            preEmbeddedIds.add(control.chunk.id);
+            embedded++;
+        }
+
+        return {embedded, poisonEntries, unproved: false}
+    }
+
+    /**
+     * @summary Wraps a zero-progress batch failure without losing its bounded cause/disposition.
+     * @param {Object} options
+     * @returns {Error}
+     */
+    createFirstBatchAbort({batchIndex, maxRetries, lastError}) {
+        const abort = new Error(`Failed to process batch ${batchIndex} after ${maxRetries} retries. Aborting.`);
+
+        abort.cause = lastError;
+
+        const residencyDisposition = classifyEmbedResidencyDisposition(lastError);
+
+        if (residencyDisposition) {
+            abort.residencyDisposition = residencyDisposition;
+        }
+
+        return abort
+    }
+
+    /**
      * @summary Embeds a set of chunks into the provided Chroma collection.
      *
      * @param {Object}   options
@@ -671,18 +967,43 @@ class VectorService extends Base {
      *     Per-chunk consultation caps the interval at one chunk's worst case.
      * @param {AbortSignal} [options.signal] Shared tenant-sweep provider circuit signal.
      * @param {Function} [options.onProviderTimeout] Synchronous native-provider timeout hook.
-     * @returns {Promise<{embedded: Number, skipped: Number, yielded: Boolean, failedBatches: Object[]}>}
+     * @param {Object[]} [options.knownPoisonEntries] Validated current-generation poison rows.
+     * @param {Object[]} [options.controlCandidates] Full current corpus with landed-state evidence.
+     * @param {Function} [options.onPoisonEntries] Durable writer for newly proven poison rows.
+     * @param {Function} [options.now] Clock seam for bounded poison receipts.
+     * @returns {Promise<{embedded: Number, skipped: Number, yielded: Boolean, failedBatches: Object[], poisonedChunks: Object[]}>}
      *     `failedBatches` carries `{batchIndex, chunkIds, reason}` for every batch that exhausted its retries
      *     while other batches were succeeding. Such a batch is skipped rather than aborting the sweep, because
      *     aborting strands every later batch permanently — see the rationale at the exhaustion branch. A sweep
-     *     in which NOTHING embedded still throws: that is a provider outage, not poisoned content.
+     *     with no earlier provider progress enters bounded paired isolation for non-terminal failures; an
+     *     unavailable control or provider-wide control failure still throws rather than laundering outage as poison.
      * @throws {Error} The original provider error when a provider-phase attempt returns a timeout-class code.
      *     The whole sweep ends after that one offer so the outer scheduler owns the later attempt; already-landed
      *     chunks remain the durable resume boundary.
      */
-    async embedChunks({collection, chunksToProcess, shouldYield = () => false, signal, onProviderTimeout}) {
+    async embedChunks({
+        collection,
+        chunksToProcess,
+        shouldYield = () => false,
+        signal,
+        onProviderTimeout,
+        knownPoisonEntries = [],
+        controlCandidates = chunksToProcess.map(chunk => ({chunk, alreadyLanded: false})),
+        onPoisonEntries,
+        now = Date.now
+    }) {
         if (chunksToProcess.length === 0) {
-            return {embedded: 0, skipped: 0, yielded: false};
+            if (knownPoisonEntries.length === 0) {
+                return {embedded: 0, skipped: 0, yielded: false}
+            }
+
+            return {
+                embedded      : 0,
+                skipped       : 0,
+                yielded       : false,
+                failedBatches : [],
+                poisonedChunks: knownPoisonEntries.map(entry => ({...entry}))
+            };
         }
 
         logger.log(`Using TextEmbeddingService with provider: ${mcConfig.embeddingProvider}.`);
@@ -691,6 +1012,9 @@ class VectorService extends Base {
         const {batchSize, batchDelay, maxRetries} = aiConfig;
         const guardrail                           = this.resolveEmbeddingGuardrail();
         const failedBatches                       = [];
+        const poisonedChunks                      = knownPoisonEntries.map(entry => ({...entry}));
+        const poisonIds                           = new Set(poisonedChunks.map(entry => entry.chunkId));
+        const preEmbeddedIds                      = new Set();
         let   embeddedCount                       = 0;
         let   skippedCount                        = 0;
         let   yielded                             = false;
@@ -712,7 +1036,11 @@ class VectorService extends Base {
                 await this.timeout(batchDelay);
             }
 
-            const batch       = chunksToProcess.slice(i, i + batchSize);
+            const batch = chunksToProcess.slice(i, i + batchSize)
+                .filter(chunk => !poisonIds.has(chunk.id) && !preEmbeddedIds.has(chunk.id));
+
+            if (batch.length === 0) continue;
+
             const batchInputs = batch.map(chunk => ({
                 chunk,
                 text: this.buildEmbeddingInputText(chunk)
@@ -868,37 +1196,88 @@ class VectorService extends Base {
             // same chunk every time never advances"); this arm had no equivalent. Same loop, same hazard, one
             // guarantee.
             //
-            // What separates a poisoned batch from a dead provider is already in hand: whether ANY batch has
-            // embedded this sweep. Deriving it needs no config leaf and no threshold nobody could defend.
+            // Prior success remains the continuation signal for later batches. Batch 1 is different: it has
+            // no earlier success by construction, so the only safe route is a bounded paired control. The
+            // control is offered before any split; if it fails, the provider-wide case stops at a fixed ceiling.
             if (!success && !yielded) {
+                if (embeddedCount === 0) {
+                    const abort = this.createFirstBatchAbort({
+                        batchIndex: i / batchSize + 1,
+                        maxRetries,
+                        lastError
+                    });
+
+                    // A non-null embedding payload means the provider succeeded and persistence
+                    // exhausted its retries. Storage failure is never content evidence.
+                    if (embeddings !== null) throw abort;
+
+                    if (this.isPoisonIsolationForbidden(lastError, signal)) throw abort;
+
+                    // A lease handoff is never evidence about content. It is checked before the first
+                    // isolation dispatch so the cooperative-yield path retains its dispatch ceiling.
+                    if (shouldYield()) {
+                        yielded = true;
+                        break
+                    }
+
+                    const excludedIds = new Set([
+                        ...poisonIds,
+                        ...preEmbeddedIds,
+                        ...batchToEmbed.map(chunk => chunk.id)
+                    ]);
+                    let isolation;
+
+                    try {
+                        isolation = await this.isolateFirstFailedBatch({
+                            collection,
+                            failedInputs     : embeddable,
+                            controlCandidates,
+                            controlStartIndex: 0,
+                            guardrail,
+                            excludedIds,
+                            preEmbeddedIds,
+                            shouldYield,
+                            signal,
+                            onProviderTimeout,
+                            reasonCode       : classifyEmbedFailureError(lastError),
+                            now
+                        });
+                    } catch (isolationError) {
+                        throw this.createFirstBatchAbort({
+                            batchIndex: i / batchSize + 1,
+                            maxRetries,
+                            lastError : isolationError
+                        })
+                    }
+
+                    if (isolation.unproved) throw abort;
+
+                    if (isolation.poisonEntries.length > 0) {
+                        if (typeof onPoisonEntries !== 'function') {
+                            throw new Error('VectorService.embedChunks: a durable poison-state writer is required before poison evidence can be returned.')
+                        }
+
+                        // The marker is the retry fence. If its durable write fails, fail the run even though
+                        // some isolation vectors may already have landed: reporting a partial success without
+                        // the fence would re-buy the same poison indefinitely on later sweeps.
+                        await onPoisonEntries(isolation.poisonEntries.map(entry => ({...entry})));
+
+                        for (const entry of isolation.poisonEntries) {
+                            poisonIds.add(entry.chunkId);
+                            poisonedChunks.push({...entry});
+                        }
+                    }
+
+                    embeddedCount += isolation.embedded;
+                    logger.warn(`[VectorService] First embedding batch was isolated with bounded paired evidence: ${isolation.embedded} recoverable chunk(s) landed and ${isolation.poisonEntries.length} proven poison chunk(s) were fenced.`);
+                    continue
+                }
+
                 failedBatches.push({
                     batchIndex: i / batchSize + 1,
                     chunkIds  : batchToEmbed.map(chunk => chunk.id),
                     reason    : lastError?.message || 'unknown embedding failure'
                 });
-
-                // Nothing has embedded at all: the provider is down, not the content poisoned. Stop, and stop
-                // by throwing — the caller records the failure from the throw, so continuing silently would
-                // turn a total outage into a success-shaped receipt with zero rows. Preserved verbatim because
-                // it is the correct behaviour for this case: walking the rest of the corpus would spend
-                // `remainingBatches * maxRetries * timeout` proving what the first batch already proved.
-                if (embeddedCount === 0) {
-                    const abort = new Error(`Failed to process batch ${i / batchSize + 1} after ${maxRetries} retries. Aborting.`);
-
-                    // A fresh Error here used to discard everything the provider had already worked out
-                    // about WHY, one hop before the receipt an operator reads. The message survived and
-                    // the classification did not, so a diagnosed outage arrived anonymous — the better
-                    // the diagnosis upstream, the more this hop threw away.
-                    abort.cause = lastError;
-
-                    // Carried only when observed. Absent stays absent: an unclassified failure must not
-                    // acquire a classification by passing through here.
-                    if (lastError?.residencyDisposition) {
-                        abort.residencyDisposition = lastError.residencyDisposition;
-                    }
-
-                    throw abort;
-                }
 
                 // At least one batch has landed, so continuing is worth attempting. This is a CONTINUATION
                 // POLICY, not a diagnosis: an earlier success does not prove the batch is at fault — a
@@ -915,7 +1294,7 @@ class VectorService extends Base {
             if (yielded) break;
         }
 
-        return {embedded: embeddedCount, skipped: skippedCount, yielded, failedBatches};
+        return {embedded: embeddedCount, skipped: skippedCount, yielded, failedBatches, poisonedChunks};
     }
 
     /**
@@ -949,17 +1328,27 @@ class VectorService extends Base {
      * @param {Function} [options.onProviderTimeout] Synchronous native-provider timeout hook.
      * @returns {Promise<Object>} Embedding result (carries `yielded: true` when the lease was cooperatively released).
      */
-    async embedViaShadowSwap({liveCollection, knowledgeBase, idsToDeleteCount, shouldYield = () => false, signal, onProviderTimeout}) {
+    async embedViaShadowSwap({
+        liveCollection,
+        knowledgeBase,
+        idsToDeleteCount,
+        shouldYield = () => false,
+        signal,
+        onProviderTimeout,
+        knownPoisonEntries = [],
+        onPoisonEntries
+    }) {
         const stateDir    = this.getResumeStateDir();
         const fingerprint = computeCorpusFingerprint(knowledgeBase);
         const resumeState = await readResumeState({dir: stateDir});
         const decision    = decideResume({resumeState, currentFingerprint: fingerprint});
 
-        let shadowCollection = null;
-        let shadowName       = null;
-        let chunksToEmbed    = knowledgeBase;
-        let attempts         = 1;
-        let alreadyEmbedded  = 0;
+        let shadowCollection  = null;
+        let shadowName        = null;
+        let chunksToEmbed     = knowledgeBase;
+        let attempts          = 1;
+        let alreadyEmbedded   = 0;
+        let shadowExistingIds = new Set();
 
         // Resume into the preserved shadow (it holds the completed batches), skipping already-embedded chunks.
         if (decision.resume) {
@@ -968,7 +1357,8 @@ class VectorService extends Base {
                 attempts         = decision.attempts;
                 shadowCollection = await ChromaManager.client.getCollection({name: shadowName, embeddingFunction: aiConfig.dummyEmbeddingFunction});
 
-                const selection = selectResumableChunks({chunks: knowledgeBase, existingIds: await this.readCollectionIds(shadowCollection)});
+                shadowExistingIds = await this.readCollectionIds(shadowCollection);
+                const selection = selectResumableChunks({chunks: knowledgeBase, existingIds: shadowExistingIds});
 
                 chunksToEmbed   = selection.remaining;
                 alreadyEmbedded = selection.alreadyEmbedded;
@@ -990,6 +1380,7 @@ class VectorService extends Base {
             attempts        = 1;
             chunksToEmbed   = knowledgeBase;
             alreadyEmbedded = 0;
+            shadowExistingIds = new Set();
             logger.log(`Building shadow knowledge-base collection '${shadowName}' (${decision.reason}).`);
 
             // Write-ahead resume marker: record the shadow BEFORE creating + embedding it, so a non-promoted
@@ -1007,12 +1398,23 @@ class VectorService extends Base {
         let shadowPromoted = false;
 
         try {
+            // The outer read filters markers against the live collection. A resumed shadow has its own
+            // durable target-local truth: if a formerly poisoned id is already present there, the hole is
+            // repaired for this transaction and must not keep blocking promotion.
+            const unresolvedPoisonEntries = knownPoisonEntries
+                .filter(entry => !shadowExistingIds.has(entry.chunkId));
             const embedResult = await this.embedChunks({
-                collection     : shadowCollection,
-                chunksToProcess: chunksToEmbed,
+                collection        : shadowCollection,
+                chunksToProcess   : chunksToEmbed,
                 shouldYield,
                 signal,
-                onProviderTimeout
+                onProviderTimeout,
+                knownPoisonEntries: unresolvedPoisonEntries,
+                controlCandidates : knowledgeBase.map(chunk => ({
+                    chunk,
+                    alreadyLanded: shadowExistingIds.has(chunk.id)
+                })),
+                onPoisonEntries
             });
 
             if (embedResult.yielded) {
@@ -1029,7 +1431,8 @@ class VectorService extends Base {
                     deleted         : idsToDeleteCount,
                     staleStrategy   : 'shadow-swap',
                     yielded         : true,
-                    shadowCollection: shadowName
+                    shadowCollection: shadowName,
+                    poisonedChunks  : embedResult.poisonedChunks || []
                 };
             }
 
@@ -1051,6 +1454,20 @@ class VectorService extends Base {
             // so the live corpus is untouched.
             if (embedResult.failedBatches?.length > 0) {
                 throw new Error(`KB_EMBEDDING_BATCH_FAILED: shadow-swap refused to promote an incomplete corpus after ${embedResult.failedBatches.length} batch(es) exhausted their retries.`);
+            }
+
+            if (embedResult.poisonedChunks?.length > 0) {
+                const message = `Shadow-swap preserved without promotion; ${embedResult.poisonedChunks.length} proven poison chunk(s) remain fenced for explicit replay or changed content.`;
+
+                logger.warn(`[VectorService] ${message}`);
+                return {
+                    message,
+                    embedded        : embedResult.embedded + alreadyEmbedded,
+                    deleted         : idsToDeleteCount,
+                    staleStrategy   : 'shadow-swap',
+                    shadowCollection: shadowName,
+                    poisonedChunks  : embedResult.poisonedChunks.map(entry => ({...entry}))
+                }
             }
 
             logger.log(`Promoting shadow collection '${shadowName}' to '${aiConfig.collectionName}'.`);
@@ -1223,6 +1640,8 @@ class VectorService extends Base {
      *                                             never yields, so non-lease-held callers are unaffected.
      * @param {AbortSignal} [opts.signal]          Shared tenant-sweep provider circuit signal.
      * @param {Function} [opts.onProviderTimeout]  Synchronous native-provider timeout hook.
+     * @param {Boolean} [opts.replayEmbeddingPoison=false] Explicit operator replay clears the
+     *                                             tenant/repository poison fence before diffing.
      * @returns {Promise<object>} A promise that resolves to a success message, OR a
      *     `{error, code: 'KB_SYNC_VOLUME_EXCEEDED', ...}` shape when the MCP gate fires.
      */
@@ -1233,7 +1652,8 @@ class VectorService extends Base {
         staleStrategy,
         shouldYield = () => false,
         signal,
-        onProviderTimeout
+        onProviderTimeout,
+        replayEmbeddingPoison = false
     } = {}) {
         logger.log('Starting knowledge base embedding...');
         const resolvedStaleStrategy = this.resolveStaleStrategy({staleStrategy, deleteStale});
@@ -1253,6 +1673,18 @@ class VectorService extends Base {
 
         const tenantStamp           = this.resolveTenantStamp(tenantContext);
         const expandedKnowledgeBase = this.expandOversizedEmbeddingChunks(knowledgeBase);
+        const poisonStateDir        = this.getResumeStateDir();
+        const poisonCoordinates     = this.resolveEmbeddingPoisonCoordinates(tenantStamp);
+
+        if (replayEmbeddingPoison) {
+            await clearEmbeddingPoisonState({dir: poisonStateDir, scopeId: poisonCoordinates.scopeId});
+        }
+
+        const poisonState = await readEmbeddingPoisonState({
+            dir         : poisonStateDir,
+            scopeId     : poisonCoordinates.scopeId,
+            generationId: poisonCoordinates.generationId
+        });
 
         for (let i = 0; i < expandedKnowledgeBase.length; i++) {
             expandedKnowledgeBase[i] = this.applyTenantStamp(expandedKnowledgeBase[i], tenantStamp);
@@ -1328,18 +1760,32 @@ class VectorService extends Base {
 
         logger.log(`Found ${existingIds.size} existing documents in this corpus.`);
 
+        const allIds             = new Set(expandedKnowledgeBase.map(chunk => chunk.id));
+        const knownPoisonEntries = poisonState.status === 'available'
+            ? poisonState.entries.filter(entry => allIds.has(entry.chunkId) && !existingIds.has(entry.chunkId))
+            : [];
+        const poisonIds       = new Set(knownPoisonEntries.map(entry => entry.chunkId));
         const chunksToProcess = [];
-        const allIds          = new Set();
         const processedIds    = new Set();
 
         expandedKnowledgeBase.forEach(chunk => {
             const chunkId = chunk.id;
-            allIds.add(chunkId);
 
-            if (!existingIds.has(chunkId) && !processedIds.has(chunkId)) {
+            if (!existingIds.has(chunkId) && !poisonIds.has(chunkId) && !processedIds.has(chunkId)) {
                 chunksToProcess.push(chunk);
                 processedIds.add(chunkId);
             }
+        });
+
+        const controlCandidates = expandedKnowledgeBase.map(chunk => ({
+            chunk,
+            alreadyLanded: existingIds.has(chunk.id)
+        }));
+        const persistPoisonEntries = entries => upsertEmbeddingPoisonEntries({
+            dir         : poisonStateDir,
+            scopeId     : poisonCoordinates.scopeId,
+            generationId: poisonCoordinates.generationId,
+            entries
         });
 
         // Convert existingIds Set to Array for filtering, as existingDocs object is no longer available
@@ -1391,9 +1837,16 @@ class VectorService extends Base {
         // success-shaped report for the opposite of no change. A delete-bearing pass now falls
         // through to the path below, which deletes and then states the resulting collection size.
         if (!shouldShadowSwap && chunksToProcess.length === 0 && idsToDelete.length === 0) {
-            const message = 'No changes detected. Knowledge base is up to date.';
+            const message = knownPoisonEntries.length > 0
+                ? `No recoverable changes detected; ${knownPoisonEntries.length} proven poison chunk(s) remain fenced for explicit replay or changed content.`
+                : 'No changes detected. Knowledge base is up to date.';
             logger.log(message);
-            return {message, embedded: 0, deleted: 0};
+            return {
+                message,
+                embedded      : 0,
+                deleted       : 0,
+                poisonedChunks: knownPoisonEntries.map(entry => ({...entry}))
+            };
         }
 
         if (shouldShadowSwap) {
@@ -1403,7 +1856,9 @@ class VectorService extends Base {
                 idsToDeleteCount: idsToDelete.length,
                 shouldYield,
                 signal,
-                onProviderTimeout
+                onProviderTimeout,
+                knownPoisonEntries,
+                onPoisonEntries : persistPoisonEntries
             });
         }
 
@@ -1412,18 +1867,35 @@ class VectorService extends Base {
             logger.log(`Deleted ${idsToDelete.length} stale chunks.`);
         }
 
-        const embedResult = await this.embedChunks({collection, chunksToProcess, signal, onProviderTimeout});
+        const embedResult = await this.embedChunks({
+            collection,
+            chunksToProcess,
+            signal,
+            onProviderTimeout,
+            knownPoisonEntries,
+            controlCandidates,
+            onPoisonEntries: persistPoisonEntries
+        });
 
-        const count         = await collection.count();
-        const failedBatches = embedResult.failedBatches || [];
-        const message       = failedBatches.length > 0
+        const count          = await collection.count();
+        const failedBatches  = embedResult.failedBatches || [];
+        const poisonedChunks = embedResult.poisonedChunks || [];
+        const message        = failedBatches.length > 0
             ? `Embedding complete with ${failedBatches.length} skipped batch(es). Collection now contains ${count} items.`
+            : poisonedChunks.length > 0
+                ? `Embedding complete with ${poisonedChunks.length} proven poison chunk(s) fenced. Collection now contains ${count} items.`
             : `Embedding complete. Collection now contains ${count} items.`;
         logger.log(message);
 
         // Surfaced rather than swallowed: a skipped batch is recoverable work that did NOT land, and a caller
         // that cannot see it reports a clean sync over a corpus with a hole in it.
-        return {message, embedded: embedResult.embedded, deleted: idsToDelete.length, failedBatches};
+        return {
+            message,
+            embedded: embedResult.embedded,
+            deleted : idsToDelete.length,
+            failedBatches,
+            poisonedChunks
+        };
     }
 
     /**

--- a/ai/services/knowledge-base/helpers/embedFailureClassification.mjs
+++ b/ai/services/knowledge-base/helpers/embedFailureClassification.mjs
@@ -142,6 +142,62 @@ export function classifyEmbedFailureCode(code) {
 }
 
 /**
+ * @summary Classifies an embed failure through its bounded `cause` chain.
+ *
+ * Wrapper errors are allowed to name the failed stage while keeping the provider failure in
+ * `error.cause`. Reading only the outer code therefore turns a precisely classified provider fault
+ * into the unclassified sentinel. This walker inspects at most four distinct Error-like objects,
+ * stops on cycles, and returns the first code that the closed vocabulary recognises. Raw messages
+ * and arbitrary fields never leave the chain.
+ *
+ * @param {*} error Error-like value whose `code` / `cause` chain should be classified.
+ * @returns {String} A bounded `KB_*` code.
+ */
+export function classifyEmbedFailureError(error) {
+    const visited = new Set();
+    let   current = error;
+
+    for (let depth = 0; depth < 4 && current && typeof current === 'object' && !visited.has(current); depth++) {
+        visited.add(current);
+
+        const classified = classifyEmbedFailureCode(current.code);
+        if (classified !== KB_VECTOR_EMBED_UNCLASSIFIED) {
+            return classified
+        }
+
+        current = current.cause
+    }
+
+    return KB_VECTOR_EMBED_UNCLASSIFIED
+}
+
+/**
+ * @summary Projects the closed provider-residency disposition through a bounded cause chain.
+ *
+ * The two literals are source-owned observations from `TextEmbeddingService`. Arbitrary provider
+ * strings never cross the durable receipt boundary; absent, unknown, cyclic, and over-depth values
+ * stay absent.
+ *
+ * @param {*} error Error-like value whose chain may carry a residency disposition.
+ * @returns {'never-resident'|'evicted-mid-batch'|undefined}
+ */
+export function classifyEmbedResidencyDisposition(error) {
+    const allowed = new Set(['never-resident', 'evicted-mid-batch']);
+    const visited = new Set();
+    let   current = error;
+
+    for (let depth = 0; depth < 4 && current && typeof current === 'object' && !visited.has(current); depth++) {
+        visited.add(current);
+
+        if (allowed.has(current.residencyDisposition)) {
+            return current.residencyDisposition
+        }
+
+        current = current.cause
+    }
+}
+
+/**
  * @summary Whether a failed embed may be retried later (`deferrable`) or must fail its ingest run
  * now (`rejected`).
  *

--- a/ai/services/knowledge-base/helpers/kbEmbeddingPoisonStore.mjs
+++ b/ai/services/knowledge-base/helpers/kbEmbeddingPoisonStore.mjs
@@ -1,0 +1,414 @@
+/**
+ * @module ai/services/knowledge-base/helpers/kbEmbeddingPoisonStore
+ * @summary Durable, content-scoped disposition for a proven embedding poison.
+ *
+ * The file is an intentionally narrow retry fence, not a provider-error log. Tenant/repository and
+ * embedding-generation coordinates are SHA-256 hashes, entry identities are tenant-aware chunk
+ * hashes, and reason codes come from the closed embed-failure vocabulary. Raw content, provider
+ * messages, endpoints, credentials, tenant ids, and repository slugs therefore have no writable
+ * field in the schema. A corrupt or unreadable marker returns `unavailable` with no entries: retrying
+ * provider work is safer than silently suppressing content on state we cannot prove.
+ */
+
+import crypto  from 'crypto';
+import fs      from 'fs/promises';
+import fsExtra from 'fs-extra';
+import path    from 'path';
+import {isEmbedFailureCode}
+                         from './embedFailureClassification.mjs';
+import {writeFileAtomic} from '../../shared/atomicFileWrite.mjs';
+import {
+    enterLifecycleGuard,
+    exitLifecycleGuard,
+    verifyLifecycleGuardOwnership
+} from '../../../daemons/shared/lifecycleGuard.mjs';
+
+export const EMBEDDING_POISON_SCHEMA_VERSION = 1;
+export const EMBEDDING_POISON_MAX_ENTRIES    = 256;
+
+const EMBEDDING_POISON_MAX_BYTES = 256 * 1024;
+const HASH_PATTERN               = /^[a-f0-9]{64}$/;
+const MAX_HASH_INPUT_LENGTH      = 1024;
+const SAFE_ENTRY_KEYS            = Object.freeze(['chunkId', 'observedAt', 'reasonCode']);
+const SAFE_ENVELOPE_KEYS         = Object.freeze([
+    'createdAt',
+    'entries',
+    'generationId',
+    'schemaVersion',
+    'scopeId',
+    'updatedAt'
+]);
+
+// Atomic rename prevents torn reads; this queue additionally preserves call order inside one process.
+// A lifecycle guard below protects the read-merge-write across KB server/orchestrator processes and
+// container PID namespaces that share the declared plane-state mount.
+const writeQueues = new Map();
+
+/**
+ * @summary Hashes the authoritative tenant/repository tuple used to name one poison-state file.
+ * @param {Object} options
+ * @param {String} options.tenantId Authoritative tenant identity (never persisted verbatim).
+ * @param {String} options.repoSlug Authoritative repository identity (never persisted verbatim).
+ * @returns {String} Lowercase SHA-256 scope id.
+ */
+export function createEmbeddingPoisonScopeId({tenantId, repoSlug} = {}) {
+    assertHashInput(tenantId, 'createEmbeddingPoisonScopeId: tenantId');
+    assertHashInput(repoSlug, 'createEmbeddingPoisonScopeId: repoSlug');
+
+    return sha256(JSON.stringify({tenantId, repoSlug}))
+}
+
+/**
+ * @summary Hashes every coordinate whose change must make poisoned content eligible again.
+ * @param {Object} options
+ * @param {String} options.provider Embedding provider identity (never persisted verbatim).
+ * @param {String} options.model Embedding model identity (never persisted verbatim).
+ * @param {Number} options.vectorDimension Expected vector dimension.
+ * @param {String} options.strategyVersion Input/chunking strategy version.
+ * @returns {String} Lowercase SHA-256 generation id.
+ */
+export function createEmbeddingGenerationId({provider, model, vectorDimension, strategyVersion} = {}) {
+    assertHashInput(provider, 'createEmbeddingGenerationId: provider');
+    assertHashInput(model, 'createEmbeddingGenerationId: model');
+    assertHashInput(strategyVersion, 'createEmbeddingGenerationId: strategyVersion');
+
+    if (!Number.isInteger(vectorDimension) || vectorDimension <= 0) {
+        throw new TypeError('createEmbeddingGenerationId: vectorDimension must be a positive integer')
+    }
+
+    return sha256(JSON.stringify({provider, model, vectorDimension, strategyVersion}))
+}
+
+/**
+ * @summary Resolves the per-scope poison marker path without exposing the raw scope tuple.
+ * @param {Object} options
+ * @param {String} options.dir Declared KB embedding state directory.
+ * @param {String} options.scopeId SHA-256 value from {@link createEmbeddingPoisonScopeId}.
+ * @returns {String} Absolute marker path.
+ */
+export function getEmbeddingPoisonStateFilePath({dir, scopeId} = {}) {
+    if (typeof dir !== 'string' || dir.length === 0) {
+        throw new TypeError('getEmbeddingPoisonStateFilePath: dir is required')
+    }
+
+    assertHash(scopeId, 'getEmbeddingPoisonStateFilePath: scopeId');
+
+    return path.resolve(dir, `kb-embedding-poison-${scopeId}.json`)
+}
+
+/**
+ * @summary Reads poison entries for one exact embedding generation.
+ *
+ * `unavailable` and `stale` deliberately return no entries. Callers may suppress provider work only
+ * from an `available` result whose full schema, scope, generation, and safe-entry vocabulary passed.
+ *
+ * @param {Object} options
+ * @param {String} options.dir Declared KB embedding state directory.
+ * @param {String} options.scopeId Hashed tenant/repository scope.
+ * @param {String} options.generationId Hashed embedding-generation coordinates.
+ * @returns {Promise<{status: 'missing'|'available'|'stale'|'unavailable', entries: Object[]}>}
+ */
+export async function readEmbeddingPoisonState({dir, scopeId, generationId} = {}) {
+    assertHash(generationId, 'readEmbeddingPoisonState: generationId');
+
+    const state = await readEnvelope({dir, scopeId});
+
+    if (state.status !== 'available') {
+        return {status: state.status, entries: []}
+    }
+
+    if (state.envelope.generationId !== generationId) {
+        return {status: 'stale', entries: []}
+    }
+
+    return {status: 'available', entries: state.envelope.entries.map(entry => ({...entry}))}
+}
+
+/**
+ * @summary Atomically merges proven poison rows for one scope and generation.
+ *
+ * The newest observation wins for a repeated chunk id. When the fixed retention cap is exceeded,
+ * the oldest rows fall out and become provider-eligible again; bounded rework is safer than an
+ * unbounded permanent deny-list. A generation mismatch starts a fresh envelope.
+ *
+ * @param {Object} options
+ * @param {String} options.dir Declared KB embedding state directory.
+ * @param {String} options.scopeId Hashed tenant/repository scope.
+ * @param {String} options.generationId Hashed embedding-generation coordinates.
+ * @param {Array<Object>} options.entries Safe `{chunkId, reasonCode, observedAt?}` rows.
+ * @param {Number|Date} [options.now=Date.now()] Deterministic clock seam.
+ * @returns {Promise<{status: 'available', entries: Object[]}>} The bounded stored projection.
+ */
+export async function upsertEmbeddingPoisonEntries({
+    dir,
+    scopeId,
+    generationId,
+    entries,
+    now = Date.now()
+} = {}) {
+    assertHash(generationId, 'upsertEmbeddingPoisonEntries: generationId');
+
+    if (!Array.isArray(entries) || entries.length === 0) {
+        throw new TypeError('upsertEmbeddingPoisonEntries: entries must be a non-empty array')
+    }
+
+    const observedAt = normalizeTimestamp(now, 'upsertEmbeddingPoisonEntries: now');
+    const incoming   = entries.map(entry => normalizeEntry(entry, observedAt));
+    const filePath   = getEmbeddingPoisonStateFilePath({dir, scopeId});
+
+    return await serializeMutation(filePath, async guard => {
+        const prior          = await readEnvelope({dir, scopeId});
+        const sameGeneration = prior.status === 'available' && prior.envelope.generationId === generationId;
+        const createdAt      = sameGeneration ? prior.envelope.createdAt : observedAt;
+        const merged         = new Map();
+
+        if (sameGeneration) {
+            for (const entry of prior.envelope.entries) {
+                merged.set(entry.chunkId, entry)
+            }
+        }
+
+        for (const entry of incoming) {
+            merged.set(entry.chunkId, entry)
+        }
+
+        const boundedEntries = Array.from(merged.values())
+            .sort(compareByAgeThenId)
+            .slice(-EMBEDDING_POISON_MAX_ENTRIES)
+            .sort((left, right) => left.chunkId.localeCompare(right.chunkId));
+
+        const envelope = {
+            schemaVersion: EMBEDDING_POISON_SCHEMA_VERSION,
+            scopeId,
+            generationId,
+            createdAt,
+            updatedAt    : observedAt,
+            entries      : boundedEntries
+        };
+
+        const json = `${JSON.stringify(envelope, null, 2)}\n`;
+
+        if (Buffer.byteLength(json, 'utf8') > EMBEDDING_POISON_MAX_BYTES) {
+            throw new Error(`upsertEmbeddingPoisonEntries: state exceeds ${EMBEDDING_POISON_MAX_BYTES} bytes`)
+        }
+
+        if (!await verifyLifecycleGuardOwnership({
+            ownerFilePath: guard.ownerFilePath,
+            fsModule     : fsExtra
+        })) {
+            throw new Error('upsertEmbeddingPoisonEntries: mutation guard ownership was lost')
+        }
+
+        await writeFileAtomic(filePath, json, {fsync: true});
+
+        return {status: 'available', entries: boundedEntries.map(entry => ({...entry}))}
+    })
+}
+
+/**
+ * @summary Clears one scope marker so an explicit operator replay offers every chunk again.
+ * @param {Object} options
+ * @param {String} options.dir Declared KB embedding state directory.
+ * @param {String} options.scopeId Hashed tenant/repository scope.
+ * @returns {Promise<Boolean>} True when a marker existed and was removed.
+ */
+export async function clearEmbeddingPoisonState({dir, scopeId} = {}) {
+    const filePath = getEmbeddingPoisonStateFilePath({dir, scopeId});
+
+    return await serializeMutation(filePath, async guard => {
+        try {
+            if (!await verifyLifecycleGuardOwnership({
+                ownerFilePath: guard.ownerFilePath,
+                fsModule     : fsExtra
+            })) {
+                throw new Error('clearEmbeddingPoisonState: mutation guard ownership was lost')
+            }
+
+            await fs.unlink(filePath);
+            return true
+        } catch (error) {
+            if (error?.code === 'ENOENT') return false;
+            throw error
+        }
+    })
+}
+
+/**
+ * @summary Reads and strictly validates a poison-state envelope.
+ * @param {Object} options
+ * @param {String} options.dir State directory.
+ * @param {String} options.scopeId Expected scope hash.
+ * @returns {Promise<Object>} `{status: 'missing'|'available'|'unavailable', envelope?}`.
+ * @private
+ */
+async function readEnvelope({dir, scopeId}) {
+    const filePath = getEmbeddingPoisonStateFilePath({dir, scopeId});
+
+    try {
+        const stat = await fs.stat(filePath);
+
+        if (!stat.isFile() || stat.size <= 0 || stat.size > EMBEDDING_POISON_MAX_BYTES) {
+            return {status: 'unavailable'}
+        }
+
+        const envelope = JSON.parse(await fs.readFile(filePath, 'utf8'));
+
+        if (!isValidEnvelope(envelope, scopeId)) {
+            return {status: 'unavailable'}
+        }
+
+        return {status: 'available', envelope}
+    } catch (error) {
+        return {status: error?.code === 'ENOENT' ? 'missing' : 'unavailable'}
+    }
+}
+
+/**
+ * @summary Validates the closed schema before any entry may suppress provider work.
+ * @param {*} envelope Parsed JSON value.
+ * @param {String} expectedScopeId Expected per-file scope hash.
+ * @returns {Boolean}
+ * @private
+ */
+function isValidEnvelope(envelope, expectedScopeId) {
+    if (!isExactObject(envelope, SAFE_ENVELOPE_KEYS)) return false;
+    if (envelope.schemaVersion !== EMBEDDING_POISON_SCHEMA_VERSION) return false;
+    if (envelope.scopeId !== expectedScopeId || !HASH_PATTERN.test(envelope.scopeId)) return false;
+    if (!HASH_PATTERN.test(envelope.generationId)) return false;
+    if (!isCanonicalTimestamp(envelope.createdAt) || !isCanonicalTimestamp(envelope.updatedAt)) return false;
+    if (envelope.updatedAt < envelope.createdAt) return false;
+    if (!Array.isArray(envelope.entries) || envelope.entries.length > EMBEDDING_POISON_MAX_ENTRIES) return false;
+
+    const seen = new Set();
+
+    for (const entry of envelope.entries) {
+        if (!isExactObject(entry, SAFE_ENTRY_KEYS)) return false;
+        if (!HASH_PATTERN.test(entry.chunkId) || !isEmbedFailureCode(entry.reasonCode) || !isCanonicalTimestamp(entry.observedAt)) {
+            return false
+        }
+        if (seen.has(entry.chunkId)) return false;
+        seen.add(entry.chunkId)
+    }
+
+    return true
+}
+
+/**
+ * @summary Normalizes one incoming row into the exact persistable projection.
+ * @param {*} entry Candidate row.
+ * @param {String} defaultObservedAt Call-level observation timestamp.
+ * @returns {{chunkId: String, reasonCode: String, observedAt: String}}
+ * @private
+ */
+function normalizeEntry(entry, defaultObservedAt) {
+    const allowedInputKeys = entry && typeof entry === 'object' && !Array.isArray(entry)
+        ? Object.keys(entry).sort()
+        : [];
+    const expectedWithoutTimestamp = ['chunkId', 'reasonCode'];
+    const expectedWithTimestamp    = SAFE_ENTRY_KEYS;
+
+    if (!sameKeys(allowedInputKeys, expectedWithoutTimestamp) && !sameKeys(allowedInputKeys, expectedWithTimestamp)) {
+        throw new TypeError('upsertEmbeddingPoisonEntries: each entry must contain only chunkId, reasonCode, and optional observedAt')
+    }
+
+    assertHash(entry.chunkId, 'upsertEmbeddingPoisonEntries: entry.chunkId');
+
+    if (!isEmbedFailureCode(entry.reasonCode)) {
+        throw new TypeError('upsertEmbeddingPoisonEntries: entry.reasonCode must be a declared bounded embed-failure code')
+    }
+
+    return {
+        chunkId   : entry.chunkId,
+        reasonCode: entry.reasonCode,
+        observedAt: entry.observedAt === undefined
+            ? defaultObservedAt
+            : normalizeTimestamp(entry.observedAt, 'upsertEmbeddingPoisonEntries: entry.observedAt')
+    }
+}
+
+function assertHash(value, label) {
+    if (typeof value !== 'string' || !HASH_PATTERN.test(value)) {
+        throw new TypeError(`${label} must be a lowercase SHA-256 hex string`)
+    }
+}
+
+function assertHashInput(value, label) {
+    if (typeof value !== 'string' || value.length === 0 || value.length > MAX_HASH_INPUT_LENGTH) {
+        throw new TypeError(`${label} must be a non-empty string of at most ${MAX_HASH_INPUT_LENGTH} characters`)
+    }
+}
+
+function compareByAgeThenId(left, right) {
+    return left.observedAt.localeCompare(right.observedAt) || left.chunkId.localeCompare(right.chunkId)
+}
+
+function isCanonicalTimestamp(value) {
+    if (typeof value !== 'string') return false;
+
+    const time = Date.parse(value);
+
+    return Number.isFinite(time) && new Date(time).toISOString() === value
+}
+
+function isExactObject(value, expectedKeys) {
+    return value !== null
+        && typeof value === 'object'
+        && !Array.isArray(value)
+        && sameKeys(Object.keys(value).sort(), expectedKeys)
+}
+
+function normalizeTimestamp(value, label) {
+    const time = value instanceof Date ? value.getTime() : typeof value === 'string' ? Date.parse(value) : value;
+
+    if (!Number.isFinite(time)) {
+        throw new TypeError(`${label} must be a finite timestamp`)
+    }
+
+    return new Date(time).toISOString()
+}
+
+function sameKeys(actual, expected) {
+    return actual.length === expected.length && actual.every((key, index) => key === expected[index])
+}
+
+function serializeWrite(filePath, operation) {
+    const previous = writeQueues.get(filePath) || Promise.resolve();
+    const current  = previous.catch(() => {}).then(operation);
+
+    writeQueues.set(filePath, current);
+
+    return current.finally(() => {
+        if (writeQueues.get(filePath) === current) {
+            writeQueues.delete(filePath)
+        }
+    })
+}
+
+/**
+ * @summary Serializes one state mutation across async calls, processes, and container PID namespaces.
+ * @param {String} filePath Canonical per-scope marker path.
+ * @param {Function} operation Guarded read-verify-mutate callback.
+ * @returns {Promise<*>}
+ * @private
+ */
+function serializeMutation(filePath, operation) {
+    return serializeWrite(filePath, async () => {
+        await fsExtra.ensureDir(path.dirname(filePath));
+
+        const guard = await enterLifecycleGuard({leasePath: filePath, fsModule: fsExtra});
+
+        if (!guard) {
+            throw new Error('kbEmbeddingPoisonStore: mutation guard unavailable')
+        }
+
+        try {
+            return await operation(guard)
+        } finally {
+            await exitLifecycleGuard({ownerFilePath: guard.ownerFilePath, fsModule: fsExtra})
+        }
+    })
+}
+
+function sha256(value) {
+    return crypto.createHash('sha256').update(value).digest('hex')
+}

--- a/ai/services/memory-core/TextEmbeddingService.mjs
+++ b/ai/services/memory-core/TextEmbeddingService.mjs
@@ -221,7 +221,7 @@ function normalizeEmbeddingOptions(options, defaultOperationLabel) {
  * @param {String} provider Explicit embedding provider.
  * @returns {String}
  */
-function getEmbeddingModel(provider) {
+export function getEmbeddingModel(provider) {
     if (provider === 'openAiCompatible') return aiConfig.openAiCompatible.embeddingModel;
     if (provider === 'ollama') return aiConfig.ollama.embeddingModel || aiConfig.ollama.model;
     if (provider === 'gemini') return aiConfig.embeddingModel;

--- a/test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncService.spec.mjs
@@ -52,15 +52,15 @@ import {
     parseArgs,
     resolveExitCode
 } from '../../../../../../../ai/scripts/maintenance/syncTenantRepos.mjs';
-import {readHealLedger} from '../../../../../../../ai/services/memory-core/helpers/healEventLedgerStore.mjs';
-import MemoryCoreConfig from '../../../../../../../ai/mcp/server/memory-core/config.template.mjs';
+import {readHealLedger}        from '../../../../../../../ai/services/memory-core/helpers/healEventLedgerStore.mjs';
+import MemoryCoreConfig        from '../../../../../../../ai/mcp/server/memory-core/config.template.mjs';
 import {PROVIDER_TIMEOUT_CODE} from '../../../../../../../ai/provider/createTimeoutError.mjs';
 import {
     KB_VECTOR_EMBED_PROVIDER_CIRCUIT_OPEN,
     classifyEmbedFailureCode
 } from '../../../../../../../ai/services/knowledge-base/helpers/embedFailureClassification.mjs';
 import TextEmbeddingService from '../../../../../../../ai/services/memory-core/TextEmbeddingService.mjs';
-import {snapshotAiConfig} from '../../../services/memory-core/util.mjs';
+import {snapshotAiConfig}   from '../../../services/memory-core/util.mjs';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname  = path.dirname(__filename);
@@ -1482,7 +1482,7 @@ test.describe('TenantRepoSyncService (#11790)', () => {
                 }
             },
             knowledgeBaseIngestionService: makeFakeIngestionService({
-                captureCalls : ingestCalls,
+                captureCalls  : ingestCalls,
                 summaryFactory: () => ({ingested: 0, deleted: 0, errors: []})
             }),
             onlyRepoSlugs    : [repoSlug],
@@ -1500,7 +1500,7 @@ test.describe('TenantRepoSyncService (#11790)', () => {
 
         // The trap is broken only if the checkpoint DURABLY commits — a `completed` status that leaves
         // no committed attempt id would re-enter the same state on the next sweep.
-        const persisted = await fs.readJson(revisionsFile);
+        const persisted     = await fs.readJson(revisionsFile);
         const persistedRepo = persisted.revisions[`t1/${repoSlug}`];
 
         expect(persistedRepo).toMatchObject({
@@ -1601,6 +1601,74 @@ test.describe('TenantRepoSyncService (#11790)', () => {
         // committed id, so without these two the test could go green having never reached the predicate.
         expect(ingestCalls).toHaveLength(2);
         expect(ingestCalls[1].payload.materializationAttempt.attemptId).not.toBe(committedAttemptId);
+    });
+
+    test('#17017 full replay bypasses a matching retry receipt and carries the poison-replay control', async () => {
+        const
+            taskStateService = createInMemoryTaskStateService(),
+            repoSlug         = 'org/poison-replay-receipt',
+            envelope         = {
+                tenantId        : 't1',
+                repoSlug,
+                files           : [{sourcePath: 'README.md', repoSlug, content: 'source'}],
+                deleted         : [],
+                headRevision    : 'sha-poison-replay',
+                manifestSnapshot: {repoSlug, pathsAfterPush: ['README.md']}
+            },
+            envelopeDigest   = createTenantRepoMaterializationDigest(envelope),
+            ingestionCalls   = [];
+
+        await fs.writeJson(revisionsFile, {revisions: {}});
+        await provisionMirrorDir({tenantId: 't1', repoSlug});
+
+        const result = await TenantRepoSyncService.runTask({
+            reason           : 'manual',
+            taskStateService,
+            tenantReposConfig: {tenantRepos: [{
+                tenantId: 't1', repoSlug, mirrorRoot, cloneUrl: 'https://example.invalid/poison-replay.git'
+            }]},
+            gitMirror                    : makeFakeGitMirror(),
+            envelopeBuilder              : async () => ({...envelope}),
+            knowledgeBaseIngestionService: {
+                async getTenantManifest() {
+                    return {
+                        materializationReceipt: {
+                            attemptId            : 'uncommitted-retry-receipt',
+                            ingestContractVersion: TENANT_REPO_INGEST_CONTRACT_VERSION,
+                            envelopeDigest,
+                            recordedAt           : Date.now()
+                        }
+                    }
+                },
+                async ingestSourceFilesForTenantSync(payload, controls) {
+                    ingestionCalls.push({payload, controls});
+
+                    return {
+                        ingested              : 1,
+                        deleted               : 0,
+                        embeddingsGenerated   : 1,
+                        errors                : [],
+                        tenantId              : payload.tenantId,
+                        durationMs            : 1,
+                        materializationReceipt: {
+                            ...payload.materializationAttempt,
+                            envelopeDigest,
+                            recordedAt: Date.now()
+                        }
+                    }
+                }
+            },
+            onlyRepoSlugs    : [repoSlug],
+            fullReplay       : true,
+            revisionsFilePath: revisionsFile,
+            seedBootstrap    : false
+        });
+
+        expect(result.status).toBe('completed');
+        expect(ingestionCalls).toHaveLength(1);
+        expect(ingestionCalls[0].controls.replayEmbeddingPoison).toBe(true);
+        expect(ingestionCalls[0].payload.materializationAttempt.attemptId)
+            .not.toBe('uncommitted-retry-receipt');
     });
 
     test('POSITIVE CONTROL — declared paths with NO effect and NO explanation still fails', async () => {

--- a/test/playwright/unit/ai/services/knowledge-base/IngestionService.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/IngestionService.spec.mjs
@@ -229,12 +229,56 @@ test.describe('IngestionService.ingestSourceFiles', () => {
             .toBe(controller.signal);
         expect(vectorCalls[0].options.onProviderTimeout, 'the synchronous hook is not stripped by makeSafe')
             .toBe(onProviderTimeout);
+        expect(vectorCalls[0].options.replayEmbeddingPoison).toBe(false);
 
         vectorCalls.length = 0;
         await Service.ingestSourceFiles(payload);
 
         expect(vectorCalls[0].options.signal, 'ordinary public ingestion remains circuit-neutral').toBeUndefined();
         expect(vectorCalls[0].options.onProviderTimeout, 'the control is internal, never implicit').toBeUndefined();
+    });
+
+    test('#17017 projects a poison as one bounded partial row and threads explicit replay internally', async () => {
+        const chunkId = 'a'.repeat(64);
+
+        Service.vectorService.embed = async (filePath, options) => {
+            const lines = (await fs.readFile(filePath, 'utf8')).trim().split('\n').filter(Boolean);
+            vectorCalls.push({filePath, options, records: lines.map(line => JSON.parse(line))});
+
+            return {
+                message       : 'Embedding completed with one poison fenced.',
+                embedded      : 0,
+                deleted       : 0,
+                poisonedChunks: [{
+                    chunkId,
+                    reasonCode: 'KB_VECTOR_EMBED_CONNECTION_REFUSED',
+                    observedAt: '2026-08-12T12:00:00.000Z'
+                }]
+            }
+        };
+
+        const summary = await SafeService.ingestSourceFilesForTenantSync({
+            tenantId: 'tenant-a',
+            files   : [{parsedChunks: [validParsedChunk()]}]
+        }, {
+            replayEmbeddingPoison: true
+        });
+
+        expect(vectorCalls[0].options.replayEmbeddingPoison).toBe(true);
+        expect(summary.embeddingsGenerated).toBe(0);
+        expect(summary.errors).toEqual([{
+            code   : 'KB_VECTOR_EMBED_CONNECTION_REFUSED',
+            message: 'A proven embedding poison remains fenced pending changed content, generation, or explicit replay.',
+            details: {
+                chunkId,
+                reasonCode : 'KB_VECTOR_EMBED_CONNECTION_REFUSED',
+                observedAt : '2026-08-12T12:00:00.000Z',
+                disposition: 'proven-content-poison'
+            }
+        }]);
+        expect(Object.keys(summary.errors[0].details).sort()).toEqual([
+            'chunkId', 'disposition', 'observedAt', 'reasonCode'
+        ]);
     });
 
     test('distinguishes NEVER-ATTEMPTED from idle, and discloses its process scope (#14028)', () => {

--- a/test/playwright/unit/ai/services/knowledge-base/VectorService.WorkVolumeBranching.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/VectorService.WorkVolumeBranching.spec.mjs
@@ -330,6 +330,68 @@ test.describe('VectorService.embed — work-volume branching (#10572)', () => {
         expect(spy.calls.upsert).toBeGreaterThan(0); // embedding actually happened
     });
 
+    test('#17017 unchanged poison is skipped across sweeps while changed content and replay re-enter', async () => {
+        const originalBatch = {
+            batchSize : KB_Config.data.batchSize,
+            batchDelay: KB_Config.data.batchDelay,
+            maxRetries: KB_Config.data.maxRetries
+        };
+        const spy           = createSpyCollection({existingIds: []});
+        let   providerCalls = 0;
+
+        Object.assign(KB_Config.data, {batchSize: 1, batchDelay: 0, maxRetries: 1});
+        KB_ChromaManager.getKnowledgeBaseCollection = async () => spy;
+
+        TextEmbeddingService.embedTexts = async texts => {
+            providerCalls++;
+
+            if (texts.some(text => text.includes('method0'))) {
+                throw new Error('private provider detail')
+            }
+
+            return texts.map(() => new Array(384).fill(0))
+        };
+
+        try {
+            writeFixtureJsonl(fixturePath, 3);
+
+            const first         = await KB_VectorService.embed(fixturePath);
+            const firstPoisonId = first.poisonedChunks[0].chunkId;
+
+            expect(first.embedded).toBe(2);
+            expect(first.poisonedChunks).toHaveLength(1);
+            expect(providerCalls).toBe(4);
+            expect(JSON.stringify(first.poisonedChunks)).not.toContain('private provider detail');
+
+            const beforeSecondSweep = providerCalls;
+            const second            = await KB_VectorService.embed(fixturePath);
+
+            expect(providerCalls, 'unchanged poison is never re-offered').toBe(beforeSecondSweep);
+            expect(second.embedded).toBe(0);
+            expect(second.poisonedChunks).toEqual(first.poisonedChunks);
+            expect(second.message).toContain('proven poison');
+
+            const rows = fs.readFileSync(fixturePath, 'utf8').split('\n').map(line => JSON.parse(line));
+            rows[0].hash = 'changed-poison-content-id';
+            fs.writeFileSync(fixturePath, rows.map(row => JSON.stringify(row)).join('\n'), 'utf8');
+
+            const beforeChangedContent = providerCalls;
+            const changed              = await KB_VectorService.embed(fixturePath);
+
+            expect(providerCalls - beforeChangedContent, 'changed content re-enters A-B-A proof').toBe(3);
+            expect(changed.poisonedChunks).toHaveLength(1);
+            expect(changed.poisonedChunks[0].chunkId).not.toBe(firstPoisonId);
+
+            const beforeReplay = providerCalls;
+            const replayed     = await KB_VectorService.embed(fixturePath, {replayEmbeddingPoison: true});
+
+            expect(providerCalls - beforeReplay, 'explicit replay clears and re-offers the current poison').toBe(3);
+            expect(replayed.poisonedChunks).toHaveLength(1);
+        } finally {
+            Object.assign(KB_Config.data, originalBatch)
+        }
+    });
+
     test('splits over-budget full-sync chunks before provider invocation while embedding the safe remainder', async () => {
         const originalResolveEmbeddingGuardrail = KB_VectorService.resolveEmbeddingGuardrail.bind(KB_VectorService);
 

--- a/test/playwright/unit/ai/services/knowledge-base/VectorService.batchFailureIsolation.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/VectorService.batchFailureIsolation.spec.mjs
@@ -168,6 +168,140 @@ test.describe('VectorService.embedChunks — one failing batch must not strand t
         expect(result.failedBatches[0].reason).toContain('provider rejected this payload');
     });
 
+    test('#17017: paired first-batch isolation fences one poison and lands every recoverable chunk', async () => {
+        Object.assign(KB_Config.data, {batchSize: 2, batchDelay: 0, maxRetries: 1});
+
+        const spy           = createSpyCollection();
+        const chunks        = makeChunks(4);
+        const persisted     = [];
+        let   providerCalls = 0;
+
+        TextEmbeddingService.embedTexts = async texts => {
+            providerCalls++;
+
+            if (texts.some(text => text.includes('for chunk 0'))) {
+                throw new Error('raw provider rejection must not enter the poison receipt')
+            }
+
+            return texts.map(() => new Array(384).fill(0))
+        };
+
+        const result = await KB_VectorService.embedChunks({
+            collection     : spy,
+            chunksToProcess: chunks,
+            onPoisonEntries: async entries => persisted.push(...entries),
+            now            : () => Date.UTC(2026, 7, 12, 12, 0, 0)
+        });
+
+        expect(providerCalls).toBe(7);
+        expect(result.embedded).toBe(3);
+        expect(spy.upsertedIds.sort()).toEqual(['chunk-1', 'chunk-2', 'chunk-3']);
+        expect(result.failedBatches).toEqual([]);
+        expect(result.poisonedChunks).toEqual([{
+            chunkId   : 'chunk-0',
+            reasonCode: 'KB_VECTOR_EMBED_FAILED',
+            observedAt: '2026-08-12T12:00:00.000Z'
+        }]);
+        expect(persisted).toEqual(result.poisonedChunks);
+        expect(JSON.stringify(result.poisonedChunks)).not.toContain('raw provider rejection');
+    });
+
+    test('#17017: a dead provider costs one bounded control after first-batch retries, never a corpus walk', async () => {
+        Object.assign(KB_Config.data, {batchSize: 2, batchDelay: 0, maxRetries: 1});
+
+        const spy           = createSpyCollection();
+        const chunks        = makeChunks(8);
+        let   providerCalls = 0,
+            poisonWrites = 0;
+
+        TextEmbeddingService.embedTexts = async () => {
+            providerCalls++;
+            throw new Error('provider is down')
+        };
+
+        await expect(KB_VectorService.embedChunks({
+            collection     : spy,
+            chunksToProcess: chunks,
+            onPoisonEntries: async () => poisonWrites++
+        })).rejects.toThrow(/Failed to process batch 1/);
+
+        expect(providerCalls, 'one failed batch offer plus one failed provider-wide control').toBe(2);
+        expect(poisonWrites).toBe(0);
+        expect(spy.upsertedIds).toEqual([]);
+    });
+
+    test('#17017: A-B-A recovers a one-off first-input failure instead of minting poison', async () => {
+        Object.assign(KB_Config.data, {batchSize: 1, batchDelay: 0, maxRetries: 1});
+
+        const spy           = createSpyCollection();
+        const chunks        = makeChunks(2);
+        let   providerCalls = 0,
+            poisonWrites = 0;
+
+        TextEmbeddingService.embedTexts = async texts => {
+            providerCalls++;
+
+            if (providerCalls === 1) throw new Error('one-off admission failure');
+
+            return texts.map(() => new Array(384).fill(0))
+        };
+
+        const result = await KB_VectorService.embedChunks({
+            collection     : spy,
+            chunksToProcess: chunks,
+            onPoisonEntries: async () => poisonWrites++
+        });
+
+        expect(providerCalls).toBe(3);
+        expect(result.embedded).toBe(2);
+        expect(result.poisonedChunks).toEqual([]);
+        expect(poisonWrites).toBe(0);
+        expect(spy.upsertedIds.sort()).toEqual(['chunk-0', 'chunk-1']);
+    });
+
+    test('#17017: persistence exhaustion never enters poison isolation or re-buys vectors', async () => {
+        const originalSetTimeout = globalThis.setTimeout;
+        const originalIsolate    = KB_VectorService.isolateFirstFailedBatch.bind(KB_VectorService);
+
+        globalThis.setTimeout = (fn, ms, ...args) => originalSetTimeout(fn, 0, ...args);
+        Object.assign(KB_Config.data, {batchSize: 1, batchDelay: 0, maxRetries: 2});
+
+        let providerCalls  = 0,
+            isolationCalls = 0,
+            poisonWrites   = 0,
+            upsertCalls    = 0;
+
+        TextEmbeddingService.embedTexts = async texts => {
+            providerCalls++;
+            return texts.map(() => new Array(384).fill(0))
+        };
+        KB_VectorService.isolateFirstFailedBatch = async (...args) => {
+            isolationCalls++;
+            return originalIsolate(...args)
+        };
+
+        try {
+            await expect(KB_VectorService.embedChunks({
+                collection: {
+                    async upsert() {
+                        upsertCalls++;
+                        throw new Error('Chroma write rejected')
+                    }
+                },
+                chunksToProcess: makeChunks(2),
+                onPoisonEntries: async () => poisonWrites++
+            })).rejects.toThrow(/Failed to process batch 1/);
+
+            expect(providerCalls).toBe(1);
+            expect(upsertCalls).toBe(2);
+            expect(isolationCalls).toBe(0);
+            expect(poisonWrites).toBe(0);
+        } finally {
+            KB_VectorService.isolateFirstFailedBatch = originalIsolate;
+            globalThis.setTimeout = originalSetTimeout
+        }
+    });
+
     test('CROSS-SWEEP: a second sweep embeds the chunks that follow the poisoned batch', async () => {
         // The spec that actually convicts the defect. Against the pre-fix tree sweep 1 aborts at batch 2, and
         // sweep 2 re-selects from batch 2 and aborts there again — so chunks 100-149 are never embedded by any
@@ -242,8 +376,8 @@ test.describe('VectorService.embedChunks — one failing batch must not strand t
             KB_VectorService.embedChunks({collection: spy, chunksToProcess: chunks})
         ).rejects.toThrow(/Failed to process batch 1/);
 
-        // One batch, one attempt (maxRetries: 1) — NOT one per batch in the corpus.
-        expect(providerCalls).toBe(1);
+        // One failed batch offer plus one provider-wide control — NOT one offer per corpus batch.
+        expect(providerCalls).toBe(2);
         expect(spy.calls.upsert).toBe(0);
     });
 
@@ -385,7 +519,7 @@ test.describe('VectorService.embedChunks — one failing batch must not strand t
         const thrown = await KB_VectorService.embedChunks({
             collection     : spy,
             chunksToProcess: makeChunks(2),
-            signal          : controller.signal,
+            signal         : controller.signal,
             onProviderTimeout
         }).then(() => null, error => error);
 
@@ -430,12 +564,17 @@ test.describe('VectorService.embedChunks — one failing batch must not strand t
         };
         ChromaManager.invalidateKnowledgeBaseCollectionCache = () => {};
 
-        const runWith = async embedOutcome => {
-            KB_VectorService.embedChunks = async () => embedOutcome;
+        let observedKnownPoisonEntries;
+        const runWith = async (embedOutcome, knownPoisonEntries = []) => {
+            KB_VectorService.embedChunks = async options => {
+                observedKnownPoisonEntries = options.knownPoisonEntries;
+                return embedOutcome
+            };
             return KB_VectorService.embedViaShadowSwap({
                 liveCollection  : collectionStub('live'),
                 knowledgeBase   : makeChunks(3),
-                idsToDeleteCount: 0
+                idsToDeleteCount: 0,
+                knownPoisonEntries
             })
         };
 
@@ -448,6 +587,41 @@ test.describe('VectorService.embedChunks — one failing batch must not strand t
             })).rejects.toThrow(/KB_EMBEDDING_BATCH_FAILED/);
 
             expect(renames, 'neither collection may be renamed when the shadow is incomplete').toEqual([]);
+
+            const poisonResult = await runWith({
+                embedded      : 2,
+                skipped       : 0,
+                yielded       : false,
+                failedBatches : [],
+                poisonedChunks: [{
+                    chunkId   : 'a'.repeat(64),
+                    reasonCode: 'KB_VECTOR_EMBED_FAILED',
+                    observedAt: '2026-08-12T12:00:00.000Z'
+                }]
+            });
+
+            expect(poisonResult.poisonedChunks).toHaveLength(1);
+            expect(poisonResult.message).toContain('preserved without promotion');
+            expect(renames, 'poison-bearing shadow remains preserved and never promotes').toEqual([]);
+
+            const restoredPoison = {
+                chunkId   : 'chunk-0',
+                reasonCode: 'KB_VECTOR_EMBED_FAILED',
+                observedAt: '2026-08-12T12:00:00.000Z'
+            };
+            shadow.get = async () => ({ids: [restoredPoison.chunkId]});
+
+            await runWith({
+                embedded      : 2,
+                skipped       : 0,
+                yielded       : false,
+                failedBatches : [],
+                poisonedChunks: []
+            }, [restoredPoison]);
+
+            expect(observedKnownPoisonEntries,
+                'a vector already restored in the resumable shadow is not an unresolved poison hole')
+                .toEqual([]);
         } finally {
             KB_VectorService.embedChunks                        = originalEmbedChunks;
             ChromaManager.client                                = originalClient;

--- a/test/playwright/unit/ai/services/knowledge-base/embedFailureClassification.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/embedFailureClassification.spec.mjs
@@ -14,6 +14,8 @@ import {
     KB_VECTOR_EMBED_UNCLASSIFIED,
     classifyEmbedDisposition,
     classifyEmbedFailureCode,
+    classifyEmbedFailureError,
+    classifyEmbedResidencyDisposition,
     isEmbedFailureCode
 } from '../../../../../../ai/services/knowledge-base/helpers/embedFailureClassification.mjs';
 import {normalizeTenantRepoCheckpointState}
@@ -42,6 +44,38 @@ import {normalizeTenantRepoCheckpointState}
  * here. A local copy would keep passing after a drift that breaks production.
  */
 test.describe('embed failure classification (#16647)', () => {
+    test('a bounded provider code survives an unclassified wrapper cause', () => {
+        const provider = Object.assign(new Error('provider detail must not be projected'), {
+                  code: 'EMBEDDING_MODEL_NOT_RESIDENT'
+              }),
+              wrapper  = new Error('Failed to process batch 1', {cause: provider});
+
+        expect(classifyEmbedFailureError(wrapper)).toBe('KB_VECTOR_EMBED_MODEL_NOT_RESIDENT');
+    });
+
+    test('a cyclic codeless cause chain remains honestly unclassified', () => {
+        const outer = new Error('outer'),
+              inner = new Error('inner');
+
+        outer.cause = inner;
+        inner.cause = outer;
+
+        expect(classifyEmbedFailureError(outer)).toBe(KB_VECTOR_EMBED_UNCLASSIFIED);
+    });
+
+    test('only a declared residency disposition survives a bounded wrapper chain', () => {
+        const provider = Object.assign(new Error('provider'), {
+            residencyDisposition: 'evicted-mid-batch'
+        });
+
+        expect(classifyEmbedResidencyDisposition(new Error('wrapper', {cause: provider})))
+            .toBe('evicted-mid-batch');
+
+        provider.residencyDisposition = 'provider-authored-secret';
+        expect(classifyEmbedResidencyDisposition(new Error('wrapper', {cause: provider})))
+            .toBeUndefined();
+    });
+
     test('two distinct provider faults surface as two distinct bounded codes', () => {
         const
             timeout = classifyEmbedFailureCode('EMBEDDING_PROBE_TIMEOUT'),
@@ -261,6 +295,24 @@ test.describe('embed failure classification — production path', () => {
             repoSlug            : 'org/witness',
             residencyDisposition: 'evicted-mid-batch'
         });
+    });
+
+    test('#17017 a wrapper preserves both the bounded cause code and declared disposition', async () => {
+        const provider = Object.assign(new Error('provider detail'), {
+                  code                : 'EMBEDDING_MODEL_NOT_RESIDENT',
+                  residencyDisposition: 'evicted-mid-batch'
+              }),
+              wrapper  = new Error('outer batch abort', {cause: provider}),
+              run      = await runEmbedWithFailure(async () => { throw wrapper });
+
+        expect(run.errors).toEqual([{
+            code   : 'KB_VECTOR_EMBED_MODEL_NOT_RESIDENT',
+            message: 'outer batch abort',
+            details: {
+                repoSlug            : 'org/witness',
+                residencyDisposition: 'evicted-mid-batch'
+            }
+        }]);
     });
 
     test('an unobserved residency state stays absent from the final ingestion receipt (#16859)', async () => {

--- a/test/playwright/unit/ai/services/knowledge-base/kbEmbeddingPoisonStore.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/kbEmbeddingPoisonStore.spec.mjs
@@ -1,0 +1,271 @@
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../../../src/Neo.mjs';
+import * as core      from '../../../../../../src/core/_export.mjs';
+import crypto         from 'crypto';
+import fs             from 'fs/promises';
+import os             from 'os';
+import path           from 'path';
+import {
+    EMBEDDING_POISON_MAX_ENTRIES,
+    clearEmbeddingPoisonState,
+    createEmbeddingGenerationId,
+    createEmbeddingPoisonScopeId,
+    getEmbeddingPoisonStateFilePath,
+    readEmbeddingPoisonState,
+    upsertEmbeddingPoisonEntries
+} from '../../../../../../ai/services/knowledge-base/helpers/kbEmbeddingPoisonStore.mjs';
+
+const GENERATION = createEmbeddingGenerationId({
+    provider       : 'openAiCompatible',
+    model          : 'text-embedding-model',
+    vectorDimension: 768,
+    strategyVersion: 'kb-input-v1'
+});
+
+const REASON_CODE = 'KB_VECTOR_EMBED_FAILED';
+
+function hash(value) {
+    return crypto.createHash('sha256').update(value).digest('hex')
+}
+
+async function createFixture() {
+    const dir     = await fs.mkdtemp(path.join(os.tmpdir(), 'kb-embedding-poison-'));
+    const scopeId = createEmbeddingPoisonScopeId({
+        tenantId: 'private-tenant-identity',
+        repoSlug: 'private/repository-identity'
+    });
+
+    return {
+        dir,
+        filePath: getEmbeddingPoisonStateFilePath({dir, scopeId}),
+        scopeId
+    }
+}
+
+test.describe('kbEmbeddingPoisonStore — bounded durable poison disposition', () => {
+    const fixtures = [];
+
+    test.afterEach(async () => {
+        await Promise.all(fixtures.splice(0).map(dir => fs.rm(dir, {recursive: true, force: true})))
+    });
+
+    async function fixture() {
+        const value = await createFixture();
+        fixtures.push(value.dir);
+        return value
+    }
+
+    test('persists only hashed coordinates and exact safe entry fields', async () => {
+        const {dir, filePath, scopeId} = await fixture();
+        const secretProvider           = 'https://embedding.example.invalid/v1?credential=bearer-secret';
+        const secretModel              = 'private-model-name';
+        const generationId             = createEmbeddingGenerationId({
+            provider       : secretProvider,
+            model          : secretModel,
+            vectorDimension: 1024,
+            strategyVersion: 'private-input-strategy'
+        });
+        const chunkId = hash('raw private chunk content');
+
+        await upsertEmbeddingPoisonEntries({
+            dir,
+            scopeId,
+            generationId,
+            entries: [{chunkId, reasonCode: REASON_CODE}],
+            now    : Date.UTC(2026, 7, 12, 10, 0, 0)
+        });
+
+        const raw   = await fs.readFile(filePath, 'utf8');
+        const state = JSON.parse(raw);
+
+        expect(path.basename(filePath)).toBe(`kb-embedding-poison-${scopeId}.json`);
+        expect(Object.keys(state).sort()).toEqual([
+            'createdAt', 'entries', 'generationId', 'schemaVersion', 'scopeId', 'updatedAt'
+        ]);
+        expect(Object.keys(state.entries[0]).sort()).toEqual(['chunkId', 'observedAt', 'reasonCode']);
+        expect(raw).not.toContain('private-tenant-identity');
+        expect(raw).not.toContain('private/repository-identity');
+        expect(raw).not.toContain(secretProvider);
+        expect(raw).not.toContain(secretModel);
+        expect(raw).not.toContain('raw private chunk content');
+        expect(raw).not.toContain('bearer-secret');
+    });
+
+    test('rejects raw ids, arbitrary bounded-looking codes, and extra secret-bearing fields', async () => {
+        const {dir, scopeId} = await fixture();
+
+        await expect(upsertEmbeddingPoisonEntries({
+            dir,
+            scopeId,
+            generationId: GENERATION,
+            entries     : [{chunkId: 'raw-chunk-id', reasonCode: REASON_CODE}]
+        })).rejects.toThrow(/SHA-256/);
+
+        await expect(upsertEmbeddingPoisonEntries({
+            dir,
+            scopeId,
+            generationId: GENERATION,
+            entries     : [{chunkId: hash('chunk'), reasonCode: 'KB_SECRET_TOKEN'}]
+        })).rejects.toThrow(/declared bounded embed-failure code/);
+
+        await expect(upsertEmbeddingPoisonEntries({
+            dir,
+            scopeId,
+            generationId: GENERATION,
+            entries     : [{chunkId: hash('chunk'), reasonCode: REASON_CODE, content: 'secret'}]
+        })).rejects.toThrow(/must contain only/);
+    });
+
+    test('corrupt and unreadable markers are explicitly unavailable and suppress nothing', async () => {
+        const {dir, filePath, scopeId} = await fixture();
+
+        await fs.mkdir(dir, {recursive: true});
+        await fs.writeFile(filePath, '{not-json', 'utf8');
+
+        await expect(readEmbeddingPoisonState({dir, scopeId, generationId: GENERATION}))
+            .resolves.toEqual({status: 'unavailable', entries: []});
+
+        await fs.rm(filePath, {force: true});
+        await fs.mkdir(filePath);
+
+        await expect(readEmbeddingPoisonState({dir, scopeId, generationId: GENERATION}))
+            .resolves.toEqual({status: 'unavailable', entries: []});
+    });
+
+    test('a generation change makes every prior poison eligible again', async () => {
+        const {dir, scopeId} = await fixture();
+        const chunkId        = hash('generation-drift-chunk');
+        const nextGeneration = createEmbeddingGenerationId({
+            provider       : 'openAiCompatible',
+            model          : 'text-embedding-model-v2',
+            vectorDimension: 1024,
+            strategyVersion: 'kb-input-v2'
+        });
+
+        await upsertEmbeddingPoisonEntries({
+            dir,
+            scopeId,
+            generationId: GENERATION,
+            entries     : [{chunkId, reasonCode: REASON_CODE}]
+        });
+
+        await expect(readEmbeddingPoisonState({dir, scopeId, generationId: GENERATION}))
+            .resolves.toMatchObject({status: 'available', entries: [{chunkId}]});
+        await expect(readEmbeddingPoisonState({dir, scopeId, generationId: nextGeneration}))
+            .resolves.toEqual({status: 'stale', entries: []});
+    });
+
+    test('a changed chunk id re-enters while same-generation upserts merge by id', async () => {
+        const {dir, scopeId} = await fixture();
+        const oldChunkId     = hash('chunk-content-v1');
+        const newChunkId     = hash('chunk-content-v2');
+
+        await upsertEmbeddingPoisonEntries({
+            dir,
+            scopeId,
+            generationId: GENERATION,
+            entries     : [{chunkId: oldChunkId, reasonCode: REASON_CODE}],
+            now         : Date.UTC(2026, 7, 12, 10, 0, 0)
+        });
+
+        const before = await readEmbeddingPoisonState({dir, scopeId, generationId: GENERATION});
+        expect(before.entries.map(entry => entry.chunkId)).not.toContain(newChunkId);
+
+        await upsertEmbeddingPoisonEntries({
+            dir,
+            scopeId,
+            generationId: GENERATION,
+            entries     : [{chunkId: newChunkId, reasonCode: 'KB_VECTOR_EMBED_CONNECTION_REFUSED'}],
+            now         : Date.UTC(2026, 7, 12, 10, 1, 0)
+        });
+
+        const after = await readEmbeddingPoisonState({dir, scopeId, generationId: GENERATION});
+        expect(after.entries.map(entry => entry.chunkId).sort()).toEqual([oldChunkId, newChunkId].sort());
+    });
+
+    test('concurrent same-process upserts atomically retain both merge inputs', async () => {
+        const {dir, scopeId} = await fixture();
+        const firstChunkId   = hash('concurrent-chunk-1');
+        const secondChunkId  = hash('concurrent-chunk-2');
+
+        await Promise.all([
+            upsertEmbeddingPoisonEntries({
+                dir,
+                scopeId,
+                generationId: GENERATION,
+                entries     : [{chunkId: firstChunkId, reasonCode: REASON_CODE}]
+            }),
+            upsertEmbeddingPoisonEntries({
+                dir,
+                scopeId,
+                generationId: GENERATION,
+                entries     : [{chunkId: secondChunkId, reasonCode: REASON_CODE}]
+            })
+        ]);
+
+        const state = await readEmbeddingPoisonState({dir, scopeId, generationId: GENERATION});
+
+        expect(state.entries.map(entry => entry.chunkId).sort()).toEqual([firstChunkId, secondChunkId].sort());
+    });
+
+    test('retention is capped and evicts the oldest observations', async () => {
+        const {dir, scopeId} = await fixture();
+        const base           = Date.UTC(2026, 7, 12, 10, 0, 0);
+        const offered        = Array.from({length: EMBEDDING_POISON_MAX_ENTRIES + 4}, (_, index) => ({
+            chunkId   : hash(`chunk-${index}`),
+            reasonCode: REASON_CODE,
+            observedAt: new Date(base + index).toISOString()
+        }));
+
+        await upsertEmbeddingPoisonEntries({
+            dir,
+            scopeId,
+            generationId: GENERATION,
+            entries     : offered,
+            now         : base + offered.length
+        });
+
+        const state       = await readEmbeddingPoisonState({dir, scopeId, generationId: GENERATION});
+        const retainedIds = new Set(state.entries.map(entry => entry.chunkId));
+
+        expect(state.entries).toHaveLength(EMBEDDING_POISON_MAX_ENTRIES);
+        expect(retainedIds.has(offered[0].chunkId)).toBe(false);
+        expect(retainedIds.has(offered.at(-1).chunkId)).toBe(true);
+    });
+
+    test('clear is the explicit replay path', async () => {
+        const {dir, scopeId} = await fixture();
+
+        expect(await readEmbeddingPoisonState({dir, scopeId, generationId: GENERATION}))
+            .toEqual({status: 'missing', entries: []});
+
+        await upsertEmbeddingPoisonEntries({
+            dir,
+            scopeId,
+            generationId: GENERATION,
+            entries     : [{chunkId: hash('replay-me'), reasonCode: REASON_CODE}]
+        });
+
+        expect(await clearEmbeddingPoisonState({dir, scopeId})).toBe(true);
+        expect(await readEmbeddingPoisonState({dir, scopeId, generationId: GENERATION}))
+            .toEqual({status: 'missing', entries: []});
+        expect(await clearEmbeddingPoisonState({dir, scopeId})).toBe(false);
+    });
+
+    test('clear is ordered after an in-flight upsert and cannot be recreated by that older write', async () => {
+        const {dir, scopeId} = await fixture();
+        const pending        = upsertEmbeddingPoisonEntries({
+            dir,
+            scopeId,
+            generationId: GENERATION,
+            entries     : [{chunkId: hash('ordered-replay'), reasonCode: REASON_CODE}]
+        });
+
+        const cleared = clearEmbeddingPoisonState({dir, scopeId});
+
+        await expect(pending).resolves.toMatchObject({status: 'available'});
+        await expect(cleared).resolves.toBe(true);
+        await expect(readEmbeddingPoisonState({dir, scopeId, generationId: GENERATION}))
+            .resolves.toEqual({status: 'missing', entries: []});
+    });
+});


### PR DESCRIPTION
Resolves neomjs/neo#17017

First-batch non-timeout failures now use bounded paired evidence instead of treating zero prior progress as proof of provider outage. Proven content poison is stored as a bounded, generation-scoped retry fence; recoverable chunks continue in the same sweep, unchanged poison remains visible without being re-offered, and changed content, changed generation, or explicit full replay re-enters it.

Evidence: L3 (production service composition with deterministic provider, storage, replay, and concurrency falsifiers) achieved; L3 required for the close-target ACs. Residual: none.

## Deltas from ticket

- Strengthened singleton proof from A→B to A→B→A so an alternating provider cannot quarantine healthy content.
- Reused the provider dispatch owner's model resolver and the declared KB resume-state directory; no new config leaf or routing authority.
- Added a cross-process owner-token guard around the bounded poison artifact because KB server and orchestrator can share its state directory.
- Preserved the existing delete-only full-replay receipt shortcut while forcing content-bearing full replay through ingestion, so operator poison replay does not regress exactly-once recovery.
- A resumable shadow treats an already-restored vector as resolved and still refuses promotion while any target-local poison hole remains.

## Test Evidence

- `NEO_TEST_SKIP_CI=true npm run test-unit -- <six neomjs/neo#17017 KB/orchestrator specs>` — 279/279 passed.
- `NEO_TEST_SKIP_CI=true npm run test-unit -- <TextEmbeddingService.spec.mjs TextEmbeddingService.retry.spec.mjs>` — 75/75 passed.
- `npm run agent-preflight -- --no-fix <12 touched files>` — all requested gates passed.
- `check-block-alignment`, `check-jsdoc-types`, `node --check`, `git diff --check`, and the full pre-commit hook — passed.
- Adversarial exact-current audit — clean; no concrete ticket blocker.

## Post-Merge Validation

No additional validation is required to satisfy the close target. The next naturally occurring deterministic non-timeout poison remains a useful non-blocking operational observation point for the persisted partial row and second-sweep suppression.

Authored by Euclid (GPT-5, Codex Desktop). Session 019fe0b1-114b-7c30-aaf4-8317c1f99d4b.
