### PR TITLE
feat(ai): publish vector-generation election primitives (#17035)

### DIFF
--- a/ai/daemons/orchestrator/Orchestrator.mjs
+++ b/ai/daemons/orchestrator/Orchestrator.mjs
@@ -25,6 +25,7 @@ import {getDueTask as goldenPathGetDueTaskImport}                               
 import {getDueTask as dreamGetDueTaskImport}                                      from './scheduling/dream.mjs';
 import {getDueTask as embedDrainLivenessWatchdogGetDueTaskImport}                 from './scheduling/embedDrainLivenessWatchdog.mjs';
 import memoryCoreConfig                                                           from '../../mcp/server/memory-core/config.mjs';
+import {resolveVectorGenerationElectionDir}                                       from '../../services/shared/vector/generationElectionStore.mjs';
 import MailboxService                                                             from '../../services/memory-core/MailboxService.mjs';
 import WakeSubscriptionService                                                    from '../../services/memory-core/WakeSubscriptionService.mjs';
 import RequestContextService                                                      from '../../mcp/server/shared/services/RequestContextService.mjs';
@@ -679,6 +680,7 @@ export class Orchestrator extends Base {
                             graph    : memoryCoreConfig.storagePaths.graph
                         },
                         stagingRoot              : restoreStagingRoot,
+                        electionDir              : resolveVectorGenerationElectionDir({planeDataRoot: memoryCoreConfig.plane.dataRoot}),
                         invalidateCollectionCache: type => ChromaManager.invalidateCollectionCache(type),
                         syncGraphCache           : () => GraphService.db?.syncCache?.()
                     })

--- a/ai/deploy/docker-compose.yml
+++ b/ai/deploy/docker-compose.yml
@@ -35,10 +35,10 @@ services:
     volumes:
       - chroma-data:/data
     healthcheck:
-      test: ["CMD-SHELL", "bash -c '</dev/tcp/127.0.0.1/8000'"]
-      interval: 10s
-      timeout: 5s
-      retries: 12
+      test        : ["CMD-SHELL", "bash -c '</dev/tcp/127.0.0.1/8000'"]
+      interval    : 10s
+      timeout     : 5s
+      retries     : 12
       start_period: 60s
     networks:
       - neo-mcp-network
@@ -64,11 +64,11 @@ services:
         # every stored vector.
         limits:
           memory: "${NEO_CHROMA_MEMORY_LIMIT:-8g}"
-          cpus: "2.0"
+          cpus  : "2.0"
 
   kb-server:
     build:
-      context: .
+      context   : .
       dockerfile: Dockerfile
       args:
         TARGET_SERVER: knowledge-base
@@ -76,7 +76,7 @@ services:
         # Compose maps it to both internal Docker arguments so source acquisition and
         # the OCI revision assertion cannot disagree. The `:-dev` default preserves
         # the unpinned path without passing an empty ref to `git fetch`.
-        NEO_REF: ${NEO_REVISION:-dev}
+        NEO_REF     : ${NEO_REVISION:-dev}
         NEO_REVISION: ${NEO_REVISION:-}
     environment:
       - NEO_TRANSPORT=streamable-http
@@ -167,6 +167,10 @@ services:
       # A dedicated volume keeps this graph-independent receipt visible without
       # granting the KB container Docker/runtime authority.
       - shared-deployment-state-data:/app/.neo-ai-data/deployment-state:ro
+      # The vector-generation election record is a plane SINGLETON: identical absolute paths inside
+      # separate writable layers are separate authorities, and a split record inverts the election
+      # fence's legacy fail-safe into a bypass. Every producer/consumer shares this one mount.
+      - shared-vector-generation-data:/app/.neo-ai-data/vector-generation
       # WRITE half of the heap-observation channel: this service reports its own V8 heap and the
       # orchestrator reads it. Without a shared mount the reporter writes into the container's own
       # layer and the orchestrator reads its own empty one, so every observation surfaces as
@@ -184,10 +188,10 @@ services:
     # self-probe must authenticate too. Ensure NEO_MCP_HEALTHCHECK_TOKEN is present
     # in the container environment; mcpHealthcheck.mjs sends it as a bearer token.
     healthcheck:
-      test: ["CMD", "node", "./ai/scripts/diagnostics/mcpHealthcheck.mjs", "--url", "http://127.0.0.1:3000", "--client-name", "neo-kb-container-healthcheck"]
-      interval: 10s
-      timeout: 10s
-      retries: 12
+      test        : ["CMD", "node", "./ai/scripts/diagnostics/mcpHealthcheck.mjs", "--url", "http://127.0.0.1:3000", "--client-name", "neo-kb-container-healthcheck"]
+      interval    : 10s
+      timeout     : 10s
+      retries     : 12
       start_period: 45s
     deploy:
       resources:
@@ -198,16 +202,16 @@ services:
           # constant — a constant goes stale the moment this moves. A YAML literal is reachable by
           # neither config nor the overlay, so it cannot serve as the bound at all.
           memory: "${NEO_KB_SERVER_MEMORY_LIMIT:-1g}"
-          cpus: "1.0"
+          cpus  : "1.0"
 
   mc-server:
     build:
-      context: .
+      context   : .
       dockerfile: Dockerfile
       args:
         TARGET_SERVER: memory-core
         # Cohort invariant (#15774/#16087): every Neo service uses the SAME resolved pin.
-        NEO_REF: ${NEO_REVISION:-dev}
+        NEO_REF     : ${NEO_REVISION:-dev}
         NEO_REVISION: ${NEO_REVISION:-}
     environment:
       - NEO_TRANSPORT=streamable-http
@@ -304,6 +308,9 @@ services:
       # Read-only half of the orchestrator -> public MCP deployment-state bridge, and the mount the
       # recovery actuator publishes its config overlay onto.
       - shared-deployment-state-data:/app/.neo-ai-data/deployment-state:ro
+      # Plane-singleton vector-generation election record — one shared mount for every
+      # producer/consumer; see the kb-server mount comment for the split-authority rationale.
+      - shared-vector-generation-data:/app/.neo-ai-data/vector-generation
       # WRITE half of the heap-observation channel: this service reports its own V8 heap and the
       # orchestrator reads it. Without a shared mount the reporter writes into the container's own
       # layer and the orchestrator reads its own empty one, so every observation surfaces as
@@ -334,10 +341,10 @@ services:
     # `unhealthy` is still failing, and is still the only failing verdict. The point is to
     # distinguish the two, not to erase both.
     healthcheck:
-      test: ["CMD", "node", "./ai/scripts/diagnostics/mcpHealthcheck.mjs", "--url", "http://127.0.0.1:3001", "--client-name", "neo-mc-container-healthcheck", "--expected-status", "healthy,degraded"]
-      interval: 10s
-      timeout: 10s
-      retries: 12
+      test        : ["CMD", "node", "./ai/scripts/diagnostics/mcpHealthcheck.mjs", "--url", "http://127.0.0.1:3001", "--client-name", "neo-mc-container-healthcheck", "--expected-status", "healthy,degraded"]
+      interval    : 10s
+      timeout     : 10s
+      retries     : 12
       start_period: 45s
     deploy:
       resources:
@@ -346,7 +353,7 @@ services:
           # strictly-below bound on the heap ceiling is a relationship against this leaf, so this
           # value must be reachable by something other than a YAML literal.
           memory: "${NEO_MC_SERVER_MEMORY_LIMIT:-1g}"
-          cpus: "1.0"
+          cpus  : "1.0"
 
   # The Agent OS maintenance orchestrator (ADR 0014 §2.3). Built from the shared
   # image via the generalized `SERVICE_ENTRYPOINT` arg. AiConfig defaults to the
@@ -356,12 +363,12 @@ services:
   # `cloud` profile — started by `docker compose --profile cloud up`.
   orchestrator:
     build:
-      context: .
+      context   : .
       dockerfile: Dockerfile
       args:
         SERVICE_ENTRYPOINT: ai/daemons/orchestrator/daemon.mjs
         # Cohort invariant (#15774/#16087): every Neo service uses the SAME resolved pin.
-        NEO_REF: ${NEO_REVISION:-dev}
+        NEO_REF     : ${NEO_REVISION:-dev}
         NEO_REVISION: ${NEO_REVISION:-}
     environment:
       - *handoff-file-env
@@ -459,6 +466,9 @@ services:
       # `provenance: self-reported`, so the bridge must never be able to author an observation it
       # then publishes as the service's own claim.
       - shared-heap-observation-data:/app/.neo-ai-data/heap-observation:ro
+      # Plane-singleton vector-generation election record — the restore seam and the rebuild runner
+      # mutate it from this container; one shared mount with the KB/MC readers of the same record.
+      - shared-vector-generation-data:/app/.neo-ai-data/vector-generation
       - tenant-repo-mirrors:/app/.neo-ai-data/tenant-repos
       # The `golden-path` scheduler lane writes the handoff and its derived
       # route artifacts here; mc-server mounts the same directory read-side.
@@ -513,10 +523,10 @@ services:
     # minutes; task progress stays observable there without making Docker report daemon
     # death. 90s start_period covers the first-poll latency on cold container boot.
     healthcheck:
-      test: ["CMD", "node", "--input-type=module", "-e", "await import('./src/Neo.mjs');await import('./src/core/_export.mjs');const{default:AiConfig}=await import('./ai/config.mjs');const{inspectAuthorityLease}=await import('./ai/daemons/orchestrator/authorityLease.mjs');try{const{fresh}=inspectAuthorityLease({dir:AiConfig.orchestrator.dataDir,profile:AiConfig.orchestrator.authorityProfile});process.exit(fresh?0:1)}catch{process.exit(1)}"]
-      interval: 60s
-      timeout: 5s
-      retries: 3
+      test        : ["CMD", "node", "--input-type=module", "-e", "await import('./src/Neo.mjs');await import('./src/core/_export.mjs');const{default:AiConfig}=await import('./ai/config.mjs');const{inspectAuthorityLease}=await import('./ai/daemons/orchestrator/authorityLease.mjs');try{const{fresh}=inspectAuthorityLease({dir:AiConfig.orchestrator.dataDir,profile:AiConfig.orchestrator.authorityProfile});process.exit(fresh?0:1)}catch{process.exit(1)}"]
+      interval    : 60s
+      timeout     : 5s
+      retries     : 3
       start_period: 90s
     # Heap ceilings are PER PROCESS, so they are set on the command rather than in `environment`.
     # `ProcessSupervisorService` spawns supervised tasks with `{...process.env}`, so a service-level
@@ -567,7 +577,7 @@ services:
         # measurement and now, for the first time, has a plane that can produce it.
         limits:
           memory: 12g
-          cpus: "1.0"
+          cpus  : "1.0"
 
   # Optional Fleet control service (#16735). It is a regular authenticated HTTP service, not a
   # sixth MCP server: AuthService owns bearer/provider verification while the Fleet entrypoint owns
@@ -575,12 +585,12 @@ services:
   # is profile-gated so a headless KB/MC deployment remains valid.
   fleet-server:
     build:
-      context: .
+      context   : .
       dockerfile: Dockerfile
       args:
         SERVICE_ENTRYPOINT: ai/services/fleet/fleetServer.mjs
-        NEO_REF: ${NEO_REVISION:-dev}
-        NEO_REVISION: ${NEO_REVISION:-}
+        NEO_REF           : ${NEO_REVISION:-dev}
+        NEO_REVISION      : ${NEO_REVISION:-}
     environment:
       # Caddy reaches Fleet over the compose network. Standalone `ai:fleet-server` remains the
       # loopback-only transitional dev transport; only this composed entrypoint binds all interfaces.
@@ -622,16 +632,16 @@ services:
     profiles:
       - fleet
     healthcheck:
-      test: ["CMD", "node", "./ai/scripts/diagnostics/fleetHealthcheck.mjs", "--url", "http://127.0.0.1:8083/fleet/probe", "--expected-data-dir", "/app/.neo-ai-data/fleet"]
-      interval: 10s
-      timeout: 10s
-      retries: 12
+      test        : ["CMD", "node", "./ai/scripts/diagnostics/fleetHealthcheck.mjs", "--url", "http://127.0.0.1:8083/fleet/probe", "--expected-data-dir", "/app/.neo-ai-data/fleet"]
+      interval    : 10s
+      timeout     : 10s
+      retries     : 12
       start_period: 30s
     deploy:
       resources:
         limits:
           memory: "${NEO_FLEET_SERVER_MEMORY_LIMIT:-512m}"
-          cpus: "0.5"
+          cpus  : "0.5"
 
   # Reverse proxy + TLS termination — the public ingress for the cloud Agent OS
   # deployment (Sub C #11724). `ingress` profile — `docker compose --profile
@@ -660,16 +670,16 @@ services:
     # TCP connection, non-zero = caddy crashed. Avoids the wget --quiet + grep
     # silent-success-empty-output failure mode (#11939 cycle-1 review per @neo-gpt).
     healthcheck:
-      test: ["CMD-SHELL", "nc -z 127.0.0.1 443"]
-      interval: 30s
-      timeout: 5s
-      retries: 3
+      test        : ["CMD-SHELL", "nc -z 127.0.0.1 443"]
+      interval    : 30s
+      timeout     : 5s
+      retries     : 3
       start_period: 30s
     deploy:
       resources:
         limits:
           memory: 256m
-          cpus: "0.5"
+          cpus  : "0.5"
 
   # Optional self-hosted model-provider runtime (Post-MVP residual #11734).
   # The service is disabled unless the operator starts `--profile local-model`.
@@ -693,10 +703,10 @@ services:
     expose:
       - "11434"
     healthcheck:
-      test: ["CMD", "ollama", "list"]
-      interval: 30s
-      timeout: 10s
-      retries: 10
+      test        : ["CMD", "ollama", "list"]
+      interval    : 30s
+      timeout     : 10s
+      retries     : 10
       start_period: 60s
     profiles:
       - local-model
@@ -704,7 +714,7 @@ services:
       resources:
         limits:
           memory: "${NEO_LOCAL_MODEL_MEMORY_LIMIT:-32g}"
-          cpus: "${NEO_LOCAL_MODEL_CPU_LIMIT:-4.0}"
+          cpus  : "${NEO_LOCAL_MODEL_CPU_LIMIT:-4.0}"
 
 # kb-server / mc-server stay internal-only (`expose`) on `neo-mcp-network`; the
 # `ingress` profile is the sole public surface. `caddy-data` persists Caddy's
@@ -724,6 +734,9 @@ volumes:
   # Heap-observation channel: written by every MCP server declaring a heap-observation service
   # key, read by the orchestrator's deployment-state bridge.
   shared-heap-observation-data:
+  # Plane-singleton vector-generation election record; mounted by kb-server, mc-server, and the
+  # orchestrator so the authority cannot split across container writable layers.
+  shared-vector-generation-data:
   tenant-repo-mirrors:
   caddy-data:
   caddy-config:

--- a/ai/mcp/server/knowledge-base/toolService.mjs
+++ b/ai/mcp/server/knowledge-base/toolService.mjs
@@ -10,6 +10,10 @@ import AiConfig                      from '../../../config.mjs';
 import kbConfig                      from './config.mjs';
 import {readDeploymentStateSnapshot} from '../../../services/memory-core/helpers/deploymentStateBridgeStore.mjs';
 import {
+    projectVectorGenerationHealth,
+    resolveVectorGenerationElectionDir
+}                                    from '../../../services/shared/vector/generationElectionStore.mjs';
+import {
     assertToolTransportAllowed,
     ingestSourceFilesViaMcp,
     ingestToolName,
@@ -64,7 +68,12 @@ const serviceMapping = {
     // child overlay can never verify one identity and report another.
     healthcheck                  : async () => ({
         ...await HealthService.healthcheck(),
-        plane: {id: kbConfig.plane.id, dataRoot: kbConfig.plane.dataRoot}
+        plane           : {id: kbConfig.plane.id, dataRoot: kbConfig.plane.dataRoot},
+        // Elected + parked vector-generation identities (never throws; `missing` on a plane that
+        // has not declared an election) — acceptance for a generation cutover reads this block.
+        vectorGeneration: await projectVectorGenerationHealth({
+            dir: resolveVectorGenerationElectionDir({planeDataRoot: kbConfig.plane.dataRoot})
+        })
     }),
     get_deployment_state_snapshot: readDeploymentInspection,
     inspect_deployment           : readDeploymentInspection,

--- a/ai/mcp/server/memory-core/toolService.mjs
+++ b/ai/mcp/server/memory-core/toolService.mjs
@@ -23,8 +23,12 @@ import {makeChatModelGenerate}       from '../../../services/memory-core/helpers
 import {makeLandscapeCensusSource}   from '../../../services/graph/laneLandscapeCensusSource.mjs';
 import {makeOpenWorkCensusReader}    from '../../../services/github-workflow/openWorkCensusReader.mjs';
 import {synthesizeTemporalBirdView}  from '../../../services/memory-core/helpers/temporalBirdViewSynthesizer.mjs';
-import GitHubWorkflowConfig          from '../github-workflow/config.mjs';
-import MemoryCoreConfig              from './config.mjs';
+import {
+    projectVectorGenerationHealth,
+    resolveVectorGenerationElectionDir
+}                                    from '../../../services/shared/vector/generationElectionStore.mjs';
+import GitHubWorkflowConfig from '../github-workflow/config.mjs';
+import MemoryCoreConfig     from './config.mjs';
 import {
     admitCommunityBatch,
     areHostedCommunityToolsVisible,
@@ -194,8 +198,8 @@ const ALL_FEATURES_OPERATIONAL_DETAIL = 'All features are operational';
  * @param {Object} options.plane Observed Memory Core plane identity.
  * @returns {Object}
  */
-export function composeMemoryCoreHealthcheck({health, memoryWalDrain, plane}) {
-    const response = {...health, memoryWalDrain, plane};
+export function composeMemoryCoreHealthcheck({health, memoryWalDrain, plane, vectorGeneration = null}) {
+    const response = {...health, memoryWalDrain, plane, vectorGeneration};
 
     if (memoryWalDrain.state !== 'stalled') {
         return response
@@ -254,7 +258,12 @@ const serviceMapping = {
     healthcheck                 : async args => composeMemoryCoreHealthcheck({
         health        : await HealthService.healthcheck(args),
         memoryWalDrain: await MemoryService.describeDrainState(),
-        plane         : {id: mcConfig.plane.id, dataRoot: mcConfig.plane.dataRoot}
+        plane         : {id: mcConfig.plane.id, dataRoot: mcConfig.plane.dataRoot},
+        // Elected + parked vector-generation identities (never throws; `missing` on a plane that
+        // has not declared an election) — acceptance for a generation cutover reads this block.
+        vectorGeneration: await projectVectorGenerationHealth({
+            dir: resolveVectorGenerationElectionDir({planeDataRoot: mcConfig.plane.dataRoot})
+        })
     }),
     mutate_frontier             : MemoryService          .mutateFrontier          .bind(MemoryService),
     pre_brief_session           : MemoryService          .preBriefSession         .bind(MemoryService),

--- a/ai/services/knowledge-base/VectorService.mjs
+++ b/ai/services/knowledge-base/VectorService.mjs
@@ -22,6 +22,12 @@ import readline                                                        from 'rea
 import DestructiveOperationGuard                                       from '../../mcp/server/shared/services/DestructiveOperationGuard.mjs';
 import {computeCorpusFingerprint, decideResume, selectResumableChunks} from './helpers/resumableEmbedding.mjs';
 import {clearResumeState, readResumeState, writeResumeState}           from './helpers/kbEmbeddingResumeStore.mjs';
+import {
+    assertCapturedPromoteView,
+    captureVectorPromoteView,
+    recordPromoteCompletion,
+    resolveVectorGenerationElectionDir
+}                                                                      from '../shared/vector/generationElectionStore.mjs';
 import KBRecorderService                                               from './KBRecorderService.mjs';
 import {
     clearEmbeddingPoisonState,
@@ -1342,6 +1348,11 @@ class VectorService extends Base {
         const fingerprint = computeCorpusFingerprint(knowledgeBase);
         const resumeState = await readResumeState({dir: stateDir});
         const decision    = decideResume({resumeState, currentFingerprint: fingerprint});
+        // Captured BEFORE any shadow work: the election fence compares this view at the promote
+        // moment, so a generation commit or rollback landing mid-build fences this writer out
+        // instead of letting a corpus built under the old view advertise into the new generation.
+        const electionDir = resolveVectorGenerationElectionDir({planeDataRoot: aiConfig.plane.dataRoot});
+        const promoteView = await captureVectorPromoteView({dir: electionDir});
 
         let shadowCollection  = null;
         let shadowName        = null;
@@ -1470,6 +1481,14 @@ class VectorService extends Base {
                 }
             }
 
+            // The stale-writer fence, immediately before the renames: refuses unless the view this
+            // corpus was built under is still the elected generation at the current epoch.
+            const promoteAdmission = await assertCapturedPromoteView({
+                dir          : electionDir,
+                collectionKey: 'kb.unified',
+                view         : promoteView
+            });
+
             logger.log(`Promoting shadow collection '${shadowName}' to '${aiConfig.collectionName}'.`);
             await liveCollection.modify({name: parkingName});
             liveParked = true;
@@ -1478,6 +1497,16 @@ class VectorService extends Base {
 
             ChromaManager.invalidateKnowledgeBaseCollectionCache();
             await clearResumeState({dir: stateDir}); // promoted → nothing to resume
+
+            if (promoteAdmission.mode === 'elected' && promoteAdmission.electionStatus === 'committed') {
+                try {
+                    await recordPromoteCompletion({dir: electionDir, collectionKey: 'kb.unified', expectedEpoch: promoteAdmission.epoch})
+                } catch (completionError) {
+                    // The renames landed; a lost completion mark only keeps acceptance blocked
+                    // (rollback authority retained) — never unwind a successful promote for bookkeeping.
+                    logger.error('[VectorService] Promote landed but the election completion mark failed; acceptance stays blocked until repaired:', completionError.message);
+                }
+            }
 
             const collection = await ChromaManager.getKnowledgeBaseCollection();
             const count      = await collection.count();

--- a/ai/services/knowledge-base/helpers/kbEmbeddingPoisonStore.mjs
+++ b/ai/services/knowledge-base/helpers/kbEmbeddingPoisonStore.mjs
@@ -58,26 +58,9 @@ export function createEmbeddingPoisonScopeId({tenantId, repoSlug} = {}) {
     return sha256(JSON.stringify({tenantId, repoSlug}))
 }
 
-/**
- * @summary Hashes every coordinate whose change must make poisoned content eligible again.
- * @param {Object} options
- * @param {String} options.provider Embedding provider identity (never persisted verbatim).
- * @param {String} options.model Embedding model identity (never persisted verbatim).
- * @param {Number} options.vectorDimension Expected vector dimension.
- * @param {String} options.strategyVersion Input/chunking strategy version.
- * @returns {String} Lowercase SHA-256 generation id.
- */
-export function createEmbeddingGenerationId({provider, model, vectorDimension, strategyVersion} = {}) {
-    assertHashInput(provider, 'createEmbeddingGenerationId: provider');
-    assertHashInput(model, 'createEmbeddingGenerationId: model');
-    assertHashInput(strategyVersion, 'createEmbeddingGenerationId: strategyVersion');
-
-    if (!Number.isInteger(vectorDimension) || vectorDimension <= 0) {
-        throw new TypeError('createEmbeddingGenerationId: vectorDimension must be a positive integer')
-    }
-
-    return sha256(JSON.stringify({provider, model, vectorDimension, strategyVersion}))
-}
+// One id-space with the plane's generation election: the implementation lives with the election
+// authority so the same coordinate tuple can never hash differently in the two stores.
+export {createEmbeddingGenerationId} from '../../shared/vector/generationElectionStore.mjs';
 
 /**
  * @summary Resolves the per-scope poison marker path without exposing the raw scope tuple.

--- a/ai/services/memory-core/helpers/restoreTargetSetStorage.mjs
+++ b/ai/services/memory-core/helpers/restoreTargetSetStorage.mjs
@@ -83,13 +83,23 @@ export function createRestoreTargetSetStorage({
         onPhase
     });
 
-    // One captured view per restore run: every role's promote validates against the SAME view, so
-    // a generation commit landing between two role promotes cannot split one run across generations.
-    let promoteViewPromise = null;
+    // One captured view per restore ATTEMPT: every role's promote inside one attempt validates
+    // against the SAME view (a commit landing between two role promotes cannot split the attempt
+    // across generations), while a NEW attempt captures fresh — the storage object outlives
+    // attempts at its call site, so a per-factory memo would leak a stale view across an
+    // intervening election.
+    const promoteViewByAttempt = new Map();
 
-    function capturePromoteViewOnce() {
-        promoteViewPromise ??= captureVectorPromoteView({dir: electionDir});
-        return promoteViewPromise
+    function capturePromoteViewForAttempt(attemptFingerprint) {
+        if (typeof attemptFingerprint !== 'string' || attemptFingerprint.length === 0) {
+            throw new Error('restoreTargetSetStorage: promoteComponent requires context.attemptFingerprint for election-view capture')
+        }
+
+        if (!promoteViewByAttempt.has(attemptFingerprint)) {
+            promoteViewByAttempt.set(attemptFingerprint, captureVectorPromoteView({dir: electionDir}))
+        }
+
+        return promoteViewByAttempt.get(attemptFingerprint)
     }
 
     return {
@@ -247,7 +257,7 @@ export function createRestoreTargetSetStorage({
             promoteAdmission = await assertCapturedPromoteView({
                 dir          : electionDir,
                 collectionKey: electionKey,
-                view         : await capturePromoteViewOnce()
+                view         : await capturePromoteViewForAttempt(context.attemptFingerprint)
             })
         }
 

--- a/ai/services/memory-core/helpers/restoreTargetSetStorage.mjs
+++ b/ai/services/memory-core/helpers/restoreTargetSetStorage.mjs
@@ -17,6 +17,11 @@ import {
     importVectorJsonlToEmptyCollection,
     validateVectorCollectionFromJsonl
 } from './vectorJsonlImport.mjs';
+import {
+    assertCapturedPromoteView,
+    captureVectorPromoteView,
+    recordPromoteCompletion
+} from '../../shared/vector/generationElectionStore.mjs';
 
 /**
  * @module ai/services/memory-core/helpers/restoreTargetSetStorage
@@ -31,6 +36,12 @@ import {
 
 const VECTOR_ROLES = Object.freeze(['memories', 'summaries']);
 
+// Election census keys for the vector roles this seam promotes. The graph component is SQLite,
+// not an embedding collection, so it is deliberately outside the vector-generation election; the
+// temporal-summary collection has no restore seam here — its promote path belongs to the
+// resumable rebuild runner, which calls the election fence directly.
+const ELECTION_KEY_BY_ROLE = Object.freeze({memories: 'mc.memory', summaries: 'mc.session'});
+
 /**
  * @summary Creates store collaborators consumed by
  * `createRestoreEmptyTargetOperation`.
@@ -41,6 +52,10 @@ const VECTOR_ROLES = Object.freeze(['memories', 'summaries']);
  * @param {Object} options.graphDb Open production better-sqlite3 graph DB.
  * @param {Object} options.expectedDestinations `{memories,summaries,graph}`.
  * @param {String} options.stagingRoot Gitignored run-owned staging directory.
+ * @param {String} [options.electionDir=null] Shared vector-generation election directory (resolved
+ * by the entrypoint from its per-server config). When set, every vector-role promote passes the
+ * stale-writer fence and reports completion; `null` means a plane without election gating
+ * (tests / pre-adoption planes).
  * @param {Function} [options.invalidateCollectionCache=()=>{}] Cache invalidator.
  * @param {Function} [options.syncGraphCache=()=>{}] Native graph cache sync.
  * @param {Function} [options.onPhase=()=>{}] Measurement/diagnostic observer.
@@ -52,6 +67,7 @@ export function createRestoreTargetSetStorage({
     graphDb,
     expectedDestinations,
     stagingRoot,
+    electionDir = null,
     invalidateCollectionCache = () => {},
     syncGraphCache = () => {},
     onPhase = () => {}
@@ -66,6 +82,15 @@ export function createRestoreTargetSetStorage({
         syncGraphCache,
         onPhase
     });
+
+    // One captured view per restore run: every role's promote validates against the SAME view, so
+    // a generation commit landing between two role promotes cannot split one run across generations.
+    let promoteViewPromise = null;
+
+    function capturePromoteViewOnce() {
+        promoteViewPromise ??= captureVectorPromoteView({dir: electionDir});
+        return promoteViewPromise
+    }
 
     return {
         inspectFreshTargetSet,
@@ -215,6 +240,17 @@ export function createRestoreTargetSetStorage({
 
         onPhase({phase: `promote-${role}`, event: 'start'});
 
+        const electionKey      = ELECTION_KEY_BY_ROLE[role];
+        let   promoteAdmission = null;
+
+        if (electionDir && electionKey) {
+            promoteAdmission = await assertCapturedPromoteView({
+                dir          : electionDir,
+                collectionKey: electionKey,
+                view         : await capturePromoteViewOnce()
+            })
+        }
+
         const result = role === 'graph'
             ? await promoteGraph({
                 graphPath: staging.graphPath,
@@ -226,6 +262,16 @@ export function createRestoreTargetSetStorage({
                 expectedDimension: admission.expectedDimension,
                 names            : staging.collections[role]
             });
+
+        if (promoteAdmission?.mode === 'elected' && promoteAdmission.electionStatus === 'committed') {
+            try {
+                await recordPromoteCompletion({dir: electionDir, collectionKey: electionKey, expectedEpoch: promoteAdmission.epoch})
+            } catch (completionError) {
+                // The promote landed; a lost completion mark only keeps acceptance blocked
+                // (rollback authority retained) — never unwind a successful promote for bookkeeping.
+                onPhase({phase: `promote-${role}`, event: 'election-completion-failed', error: completionError.message})
+            }
+        }
 
         onPhase({phase: `promote-${role}`, event: 'complete', result});
         return result
@@ -290,8 +336,8 @@ export function createRestoreTargetSetStorage({
             observed[role] = {
                 canonical: Boolean(canonical),
                 liveCount,
-                shadow : Boolean(shadow),
-                parking: Boolean(parking)
+                shadow   : Boolean(shadow),
+                parking  : Boolean(parking)
             };
 
             if (!canonical) {

--- a/ai/services/memory-core/helpers/restoreTargetSetStorage.mjs
+++ b/ai/services/memory-core/helpers/restoreTargetSetStorage.mjs
@@ -83,20 +83,29 @@ export function createRestoreTargetSetStorage({
         onPhase
     });
 
-    // One captured view per restore ATTEMPT: every role's promote inside one attempt validates
-    // against the SAME view (a commit landing between two role promotes cannot split the attempt
-    // across generations), while a NEW attempt captures fresh — the storage object outlives
-    // attempts at its call site, so a per-factory memo would leak a stale view across an
-    // intervening election.
+    // One captured view per restore ATTEMPT, taken at STAGING start: every role's promote inside
+    // one attempt validates against the SAME view captured when the attempt's content generation
+    // was decided (a commit landing during staging, validation, or between two role promotes fences
+    // the whole attempt), while a NEW attempt captures fresh — the storage object outlives attempts
+    // at its call site, so a per-factory memo would leak a stale view across an intervening election.
     const promoteViewByAttempt = new Map();
 
     function capturePromoteViewForAttempt(attemptFingerprint) {
         if (typeof attemptFingerprint !== 'string' || attemptFingerprint.length === 0) {
-            throw new Error('restoreTargetSetStorage: promoteComponent requires context.attemptFingerprint for election-view capture')
+            throw new Error('restoreTargetSetStorage: election-view capture requires context.attemptFingerprint')
         }
 
         if (!promoteViewByAttempt.has(attemptFingerprint)) {
             promoteViewByAttempt.set(attemptFingerprint, captureVectorPromoteView({dir: electionDir}))
+        }
+
+        return promoteViewByAttempt.get(attemptFingerprint)
+    }
+
+    function requirePromoteViewForAttempt(attemptFingerprint) {
+        if (typeof attemptFingerprint !== 'string' || attemptFingerprint.length === 0 ||
+            !promoteViewByAttempt.has(attemptFingerprint)) {
+            throw new Error('restoreTargetSetStorage: no election view was captured for this attempt at staging; stage before promoting')
         }
 
         return promoteViewByAttempt.get(attemptFingerprint)
@@ -168,6 +177,14 @@ export function createRestoreTargetSetStorage({
                 expectedDestinations,
                 stagingRoot
             });
+
+        // The election view is captured at STAGING start — the moment this attempt's content
+        // generation is decided — not at first promote. An election that lands while staging or
+        // validation runs must fence the stale build at promote time; a promote-time capture would
+        // read the NEW election as current and admit content built under the old view.
+        if (electionDir) {
+            capturePromoteViewForAttempt(context.attemptFingerprint)
+        }
 
         await fs.mkdir(stagingRoot, {recursive: true});
 
@@ -257,7 +274,7 @@ export function createRestoreTargetSetStorage({
             promoteAdmission = await assertCapturedPromoteView({
                 dir          : electionDir,
                 collectionKey: electionKey,
-                view         : await capturePromoteViewForAttempt(context.attemptFingerprint)
+                view         : await requirePromoteViewForAttempt(context.attemptFingerprint)
             })
         }
 

--- a/ai/services/shared/vector/electionGatedPromote.mjs
+++ b/ai/services/shared/vector/electionGatedPromote.mjs
@@ -15,6 +15,15 @@
  *
  * A collection whose promote never ran has nothing to un-park after a rollback; the runner records
  * that collection's un-park completion directly instead of calling {@link unparkCollectionUnderElection}.
+ *
+ * Two hard-interruption truths shape the surface: the fence is re-asserted immediately before the
+ * SECOND rename as well (a window expiring between the renames refuses, and the crash-rollback
+ * restores the canonical name), and a process death between the renames — which no `finally` can
+ * catch — leaves parking present with the canonical name absent; {@link reconcileInterruptedPromote}
+ * is the restart path that resumes or restores instead of dead-ending on the parking precondition.
+ *
+ * `now` accepts a value or a CLOCK FUNCTION: interruption semantics are about time passing between
+ * the two renames, so fixtures inject a stepping clock while production defaults to `Date.now`.
  */
 
 import {
@@ -22,6 +31,10 @@ import {
     recordPromoteCompletion,
     recordUnparkCompletion
 } from './generationElectionStore.mjs';
+
+function toClock(now) {
+    return typeof now === 'function' ? now : () => now
+}
 
 /**
  * @summary Promotes one shadow collection to its canonical name under the election fence.
@@ -38,9 +51,10 @@ import {
  * @param {String} options.dir Declared plane-state directory.
  * @param {String} options.collectionKey Census key this promote serves.
  * @param {Object} options.view Result of `captureVectorPromoteView` taken before the build.
- * @param {Number|Date} [options.now=Date.now()] Deterministic clock seam for the window check.
+ * @param {Number|Date|Function} [options.now=Date.now] Clock seam — value or function; the window
+ * is checked before EACH of the two renames, so a function lets fixtures step time between them.
  * @returns {Promise<Object>} `{admission, parkingName, completionRecorded, completionError}`.
- * @throws {Error} When the fence refuses, or a collection precondition fails — before any rename.
+ * @throws {Error} When the fence refuses (before either rename), or a collection precondition fails.
  */
 export async function promoteCollectionUnderElection({
     getCollection,
@@ -50,11 +64,12 @@ export async function promoteCollectionUnderElection({
     dir,
     collectionKey,
     view,
-    now = Date.now()
+    now = Date.now
 } = {}) {
     assertNames({canonicalName, shadowName, parkingName}, 'promoteCollectionUnderElection');
 
-    const admission = await assertCapturedPromoteView({dir, collectionKey, view, now});
+    const clock     = toClock(now);
+    const admission = await assertCapturedPromoteView({dir, collectionKey, view, now: clock()});
     const live      = await getCollection(canonicalName);
     const shadow    = await getCollection(shadowName);
 
@@ -63,11 +78,11 @@ export async function promoteCollectionUnderElection({
     }
 
     if (!live) {
-        throw new Error(`promoteCollectionUnderElection: canonical collection '${canonicalName}' is missing; a promote replaces a live corpus, it does not create one`)
+        throw new Error(`promoteCollectionUnderElection: canonical collection '${canonicalName}' is missing; a promote replaces a live corpus, it does not create one — if a prior promote was interrupted between its renames, run reconcileInterruptedPromote`)
     }
 
     if (await getCollection(parkingName)) {
-        throw new Error(`promoteCollectionUnderElection: parking collection '${parkingName}' already exists`)
+        throw new Error(`promoteCollectionUnderElection: parking collection '${parkingName}' already exists; if a prior promote was interrupted between its renames, run reconcileInterruptedPromote instead of retrying blind`)
     }
 
     await live.modify({name: parkingName});
@@ -75,6 +90,9 @@ export async function promoteCollectionUnderElection({
     let promoted = false;
 
     try {
+        // The window is re-asserted with a fresh clock reading: an expiry between the two renames
+        // refuses HERE, and the finally-rollback below restores the canonical name.
+        await assertCapturedPromoteView({dir, collectionKey, view, now: clock()});
         await shadow.modify({name: canonicalName});
         promoted = true
     } finally {
@@ -90,7 +108,7 @@ export async function promoteCollectionUnderElection({
     const completion = await maybeRecordCompletion({
         admission,
         expectStatus: 'committed',
-        record      : () => recordPromoteCompletion({dir, collectionKey, expectedEpoch: admission.epoch, now})
+        record      : () => recordPromoteCompletion({dir, collectionKey, expectedEpoch: admission.epoch, now: clock()})
     });
 
     return {admission, parkingName, ...completion}
@@ -111,9 +129,10 @@ export async function promoteCollectionUnderElection({
  * @param {String} options.dir Declared plane-state directory.
  * @param {String} options.collectionKey Census key this un-park serves.
  * @param {Object} options.view Result of `captureVectorPromoteView` taken after the rollback.
- * @param {Number|Date} [options.now=Date.now()] Deterministic clock seam for the window check.
+ * @param {Number|Date|Function} [options.now=Date.now] Clock seam — value or function; the window
+ * is checked before EACH rename.
  * @returns {Promise<Object>} `{admission, movedAbandonedTo, completionRecorded, completionError}`.
- * @throws {Error} When the fence refuses, or a collection precondition fails — before any rename.
+ * @throws {Error} When the fence refuses (before either rename), or a collection precondition fails.
  */
 export async function unparkCollectionUnderElection({
     getCollection,
@@ -123,11 +142,12 @@ export async function unparkCollectionUnderElection({
     dir,
     collectionKey,
     view,
-    now = Date.now()
+    now = Date.now
 } = {}) {
     assertNames({canonicalName, parkingName}, 'unparkCollectionUnderElection');
 
-    const admission = await assertCapturedPromoteView({dir, collectionKey, view, now});
+    const clock     = toClock(now);
+    const admission = await assertCapturedPromoteView({dir, collectionKey, view, now: clock()});
     const parked    = await getCollection(parkingName);
     const current   = await getCollection(canonicalName);
 
@@ -150,6 +170,9 @@ export async function unparkCollectionUnderElection({
     let restored = false;
 
     try {
+        // Same double-check discipline as the promote: expiry between the two renames refuses
+        // here, and the finally-rollback restores the abandoned generation to the canonical name.
+        await assertCapturedPromoteView({dir, collectionKey, view, now: clock()});
         await parked.modify({name: canonicalName});
         restored = true
     } finally {
@@ -163,10 +186,86 @@ export async function unparkCollectionUnderElection({
     const completion = await maybeRecordCompletion({
         admission,
         expectStatus: 'rolled-back',
-        record      : () => recordUnparkCompletion({dir, collectionKey, expectedEpoch: admission.epoch, now})
+        record      : () => recordUnparkCompletion({dir, collectionKey, expectedEpoch: admission.epoch, now: clock()})
     });
 
     return {admission, movedAbandonedTo: current ? abandonedName : null, ...completion}
+}
+
+/**
+ * @summary Restart path for a promote interrupted between its two renames — resume or restore.
+ *
+ * A process death after `live → parking` but before `shadow → canonical` escapes every in-process
+ * `finally`: the plane restarts with the parking collection present and the canonical name absent,
+ * and a blind promote retry refuses on the parking precondition. This reconcile inspects the
+ * physical state and takes exactly one action:
+ *
+ * - canonical present → `clean` (nothing was interrupted; parking is a completed promote's artifact);
+ * - canonical absent + shadow present → fence, complete `shadow → canonical`, report completion (`resumed-promote`);
+ * - canonical absent + shadow absent + parking present → `parking → canonical` (`restored-prior`;
+ *   the candidate is gone, so the prior corpus resumes serving — no completion is reported, the
+ *   transition remains incomplete and rollback authority intact);
+ * - all three absent → throw; the collection is unrecoverable from names alone and needs operator
+ *   forensics.
+ *
+ * @param {Object} options
+ * @param {Function} options.getCollection Async `name => collection|null` client seam.
+ * @param {String} options.canonicalName Reader-visible collection name.
+ * @param {String} options.shadowName The interrupted promote's candidate collection.
+ * @param {String} options.parkingName The interrupted promote's parking name.
+ * @param {String} options.dir Declared plane-state directory.
+ * @param {String} options.collectionKey Census key this promote serves.
+ * @param {Object} options.view Result of `captureVectorPromoteView` on the RESTARTED process.
+ * @param {Number|Date|Function} [options.now=Date.now] Clock seam.
+ * @returns {Promise<Object>} `{status: 'clean'|'resumed-promote'|'restored-prior', completionRecorded, completionError}`.
+ * @throws {Error} When the fence refuses a resume, or no source collection exists to serve the name.
+ */
+export async function reconcileInterruptedPromote({
+    getCollection,
+    canonicalName,
+    shadowName,
+    parkingName,
+    dir,
+    collectionKey,
+    view,
+    now = Date.now
+} = {}) {
+    assertNames({canonicalName, shadowName, parkingName}, 'reconcileInterruptedPromote');
+
+    const clock = toClock(now);
+
+    if (await getCollection(canonicalName)) {
+        return {status: 'clean', completionRecorded: false, completionError: null}
+    }
+
+    const shadow = await getCollection(shadowName);
+    const parked = await getCollection(parkingName);
+
+    if (shadow) {
+        // Resuming the SECOND rename is still a transition rename: it passes the fence (window
+        // included) exactly as the original promote would have.
+        const admission = await assertCapturedPromoteView({dir, collectionKey, view, now: clock()});
+
+        await shadow.modify({name: canonicalName});
+
+        const completion = await maybeRecordCompletion({
+            admission,
+            expectStatus: 'committed',
+            record      : () => recordPromoteCompletion({dir, collectionKey, expectedEpoch: admission.epoch, now: clock()})
+        });
+
+        return {status: 'resumed-promote', ...completion}
+    }
+
+    if (parked) {
+        // The candidate is gone; restoring the prior corpus keeps the canonical name served and the
+        // transition honestly incomplete — acceptance stays blocked, rollback authority intact.
+        await parked.modify({name: canonicalName});
+
+        return {status: 'restored-prior', completionRecorded: false, completionError: null}
+    }
+
+    throw new Error(`reconcileInterruptedPromote: '${canonicalName}' has no canonical, shadow, or parking collection; unrecoverable from names alone — operator forensics required`)
 }
 
 /**

--- a/ai/services/shared/vector/electionGatedPromote.mjs
+++ b/ai/services/shared/vector/electionGatedPromote.mjs
@@ -1,0 +1,202 @@
+/**
+ * @module ai/services/shared/vector/electionGatedPromote
+ * @summary Election-gated two-rename promote and un-park for collections without a service seam.
+ *
+ * The KB shadow-swap and the MC restore adapter carry their own election hooks; the temporal-summary
+ * and graph-node collections have no such seam, so the rebuild runner performs their transition
+ * renames through this helper. Every rename passes the captured-view fence immediately before it
+ * runs — including the quiesce-window check for transition renames — and completion is reported to
+ * the election record afterwards, with the same posture as the seams: a lost completion mark only
+ * keeps acceptance blocked, it never unwinds a successful rename.
+ *
+ * The Chroma client enters through one injected `getCollection(name)` seam (resolves a collection
+ * object exposing `modify({name})`, or `null` when absent), so the helper stays engine-agnostic and
+ * unit-testable against the same fake-client shape the restore adapter's suite uses.
+ *
+ * A collection whose promote never ran has nothing to un-park after a rollback; the runner records
+ * that collection's un-park completion directly instead of calling {@link unparkCollectionUnderElection}.
+ */
+
+import {
+    assertCapturedPromoteView,
+    recordPromoteCompletion,
+    recordUnparkCompletion
+} from './generationElectionStore.mjs';
+
+/**
+ * @summary Promotes one shadow collection to its canonical name under the election fence.
+ *
+ * Rename order matches the KB seam: live → parking, shadow → canonical. A failure between the two
+ * renames un-parks the live collection before rethrowing, so a crash cannot leave the canonical
+ * name unserved.
+ *
+ * @param {Object} options
+ * @param {Function} options.getCollection Async `name => collection|null` client seam.
+ * @param {String} options.canonicalName Reader-visible collection name.
+ * @param {String} options.shadowName Fully built candidate collection.
+ * @param {String} options.parkingName Rollback-authority name for the displaced live collection.
+ * @param {String} options.dir Declared plane-state directory.
+ * @param {String} options.collectionKey Census key this promote serves.
+ * @param {Object} options.view Result of `captureVectorPromoteView` taken before the build.
+ * @param {Number|Date} [options.now=Date.now()] Deterministic clock seam for the window check.
+ * @returns {Promise<Object>} `{admission, parkingName, completionRecorded, completionError}`.
+ * @throws {Error} When the fence refuses, or a collection precondition fails — before any rename.
+ */
+export async function promoteCollectionUnderElection({
+    getCollection,
+    canonicalName,
+    shadowName,
+    parkingName,
+    dir,
+    collectionKey,
+    view,
+    now = Date.now()
+} = {}) {
+    assertNames({canonicalName, shadowName, parkingName}, 'promoteCollectionUnderElection');
+
+    const admission = await assertCapturedPromoteView({dir, collectionKey, view, now});
+    const live      = await getCollection(canonicalName);
+    const shadow    = await getCollection(shadowName);
+
+    if (!shadow) {
+        throw new Error(`promoteCollectionUnderElection: shadow collection '${shadowName}' is missing`)
+    }
+
+    if (!live) {
+        throw new Error(`promoteCollectionUnderElection: canonical collection '${canonicalName}' is missing; a promote replaces a live corpus, it does not create one`)
+    }
+
+    if (await getCollection(parkingName)) {
+        throw new Error(`promoteCollectionUnderElection: parking collection '${parkingName}' already exists`)
+    }
+
+    await live.modify({name: parkingName});
+
+    let promoted = false;
+
+    try {
+        await shadow.modify({name: canonicalName});
+        promoted = true
+    } finally {
+        if (!promoted) {
+            // Crash-rollback: the canonical name must never be left unserved. Best-effort by
+            // design — the throw in flight is the primary signal and must not be masked.
+            try {
+                await live.modify({name: canonicalName})
+            } catch {}
+        }
+    }
+
+    const completion = await maybeRecordCompletion({
+        admission,
+        expectStatus: 'committed',
+        record      : () => recordPromoteCompletion({dir, collectionKey, expectedEpoch: admission.epoch, now})
+    });
+
+    return {admission, parkingName, ...completion}
+}
+
+/**
+ * @summary Restores one parked collection to its canonical name after a rollback, under the fence.
+ *
+ * When the abandoned generation's collection currently holds the canonical name (its promote ran
+ * before the rollback), it is moved aside to `abandonedName` first; a failure between the renames
+ * moves it back so the canonical name stays served.
+ *
+ * @param {Object} options
+ * @param {Function} options.getCollection Async `name => collection|null` client seam.
+ * @param {String} options.canonicalName Reader-visible collection name.
+ * @param {String} options.parkingName Where the restored generation is parked.
+ * @param {String} [options.abandonedName] Required when the abandoned generation holds the canonical name.
+ * @param {String} options.dir Declared plane-state directory.
+ * @param {String} options.collectionKey Census key this un-park serves.
+ * @param {Object} options.view Result of `captureVectorPromoteView` taken after the rollback.
+ * @param {Number|Date} [options.now=Date.now()] Deterministic clock seam for the window check.
+ * @returns {Promise<Object>} `{admission, movedAbandonedTo, completionRecorded, completionError}`.
+ * @throws {Error} When the fence refuses, or a collection precondition fails — before any rename.
+ */
+export async function unparkCollectionUnderElection({
+    getCollection,
+    canonicalName,
+    parkingName,
+    abandonedName = null,
+    dir,
+    collectionKey,
+    view,
+    now = Date.now()
+} = {}) {
+    assertNames({canonicalName, parkingName}, 'unparkCollectionUnderElection');
+
+    const admission = await assertCapturedPromoteView({dir, collectionKey, view, now});
+    const parked    = await getCollection(parkingName);
+    const current   = await getCollection(canonicalName);
+
+    if (!parked) {
+        throw new Error(`unparkCollectionUnderElection: parking collection '${parkingName}' is missing; nothing to restore`)
+    }
+
+    if (current) {
+        if (typeof abandonedName !== 'string' || abandonedName.length === 0) {
+            throw new Error(`unparkCollectionUnderElection: '${canonicalName}' is currently served by the abandoned generation; abandonedName is required to move it aside`)
+        }
+
+        if (await getCollection(abandonedName)) {
+            throw new Error(`unparkCollectionUnderElection: abandoned-name collection '${abandonedName}' already exists`)
+        }
+
+        await current.modify({name: abandonedName})
+    }
+
+    let restored = false;
+
+    try {
+        await parked.modify({name: canonicalName});
+        restored = true
+    } finally {
+        if (!restored && current) {
+            try {
+                await current.modify({name: canonicalName})
+            } catch {}
+        }
+    }
+
+    const completion = await maybeRecordCompletion({
+        admission,
+        expectStatus: 'rolled-back',
+        record      : () => recordUnparkCompletion({dir, collectionKey, expectedEpoch: admission.epoch, now})
+    });
+
+    return {admission, movedAbandonedTo: current ? abandonedName : null, ...completion}
+}
+
+/**
+ * @summary Reports transition completion to the record, never unwinding a successful rename.
+ * @param {Object} options
+ * @param {Object} options.admission Fence result the rename ran under.
+ * @param {String} options.expectStatus Election status under which completion applies.
+ * @param {Function} options.record Completion call.
+ * @returns {Promise<{completionRecorded: Boolean, completionError: (String|null)}>}
+ * @private
+ */
+async function maybeRecordCompletion({admission, expectStatus, record}) {
+    if (admission.mode !== 'elected' || admission.electionStatus !== expectStatus) {
+        return {completionRecorded: false, completionError: null}
+    }
+
+    try {
+        await record();
+        return {completionRecorded: true, completionError: null}
+    } catch (error) {
+        // The rename landed; a lost mark only keeps acceptance (or the next candidate) blocked
+        // until repaired — fail-safe in the direction of retained rollback authority.
+        return {completionRecorded: false, completionError: error.message}
+    }
+}
+
+function assertNames(names, label) {
+    for (const [key, value] of Object.entries(names)) {
+        if (typeof value !== 'string' || value.length === 0) {
+            throw new TypeError(`${label}: ${key} is required`)
+        }
+    }
+}

--- a/ai/services/shared/vector/generationElectionStore.mjs
+++ b/ai/services/shared/vector/generationElectionStore.mjs
@@ -594,10 +594,11 @@ export async function captureVectorPromoteView({dir} = {}) {
  * @param {String} options.dir Declared plane-state directory.
  * @param {String} options.collectionKey One of {@link VECTOR_PLANE_COLLECTION_KEYS}.
  * @param {Object} options.view Result of {@link captureVectorPromoteView}.
+ * @param {Number|Date} [options.now=Date.now()] Deterministic clock seam for the window check.
  * @returns {Promise<Object>} The admissible view, with `electionStatus` refreshed for elected mode.
  * @throws {Error} When the writer is stale or the record is unprovable — the promote must not run.
  */
-export async function assertCapturedPromoteView({dir, collectionKey, view} = {}) {
+export async function assertCapturedPromoteView({dir, collectionKey, view, now = Date.now()} = {}) {
     assertCollectionKey(collectionKey, 'assertCapturedPromoteView');
 
     if (view === null || typeof view !== 'object' || (view.mode !== 'legacy' && view.mode !== 'elected')) {
@@ -618,7 +619,7 @@ export async function assertCapturedPromoteView({dir, collectionKey, view} = {})
         throw new Error('assertCapturedPromoteView: an election was declared after this writer began; re-run the build against the elected view')
     }
 
-    return await assertVectorPromoteAdmissible({dir, collectionKey, generationId: view.generationId, epoch: view.epoch})
+    return await assertVectorPromoteAdmissible({dir, collectionKey, generationId: view.generationId, epoch: view.epoch, now})
 }
 
 /**

--- a/ai/services/shared/vector/generationElectionStore.mjs
+++ b/ai/services/shared/vector/generationElectionStore.mjs
@@ -8,13 +8,16 @@
  * independently, but GENERATION VISIBILITY commits through this one plane-singleton record — never
  * through per-collection flags that can disagree.
  *
- * **The barrier gates PROMOTES, not reads.** Readers only ever resolve canonical collection names;
- * a generation becomes visible at exactly one moment per collection — the promote rename performed
- * by one of the two seams (KB `VectorService.embedViaShadowSwap`, MC `restoreTargetSetStorage`).
- * Each seam calls {@link assertVectorPromoteAdmissible} immediately before its renames and refuses
- * unless the generation it built is the ELECTED one at the CURRENT epoch. An uncommitted election
- * therefore never advertises: no admissible promote exists, so no rename has happened, so every
- * reader still resolves the prior generation. No read-path generation filter exists anywhere.
+ * **The barrier gates PROMOTES, not reads — and transition renames are QUIESCE-BOUNDED.** Readers
+ * only ever resolve canonical collection names, so per-collection renames are individually visible
+ * the moment they happen. Two mechanisms therefore compose: (1) BEFORE commit, no promote of the
+ * candidate is admissible anywhere, so an uncommitted election never advertises; (2) the commit
+ * (and any rollback) REQUIRES a declared quiesce window `{scope, startedAt, boundMs}`, and every
+ * transition rename — promote after commit, un-park after rollback — refuses to run outside that
+ * active window. The mixed-generation interval between the first and last rename exists ONLY inside
+ * a declared, bounded window in which the operator has quiesced readers; the record enforces the
+ * declaration and the bound, the deployment enforces the quiet. Steady-state same-generation
+ * refresh promotes need no window — both sides of their rename are the elected generation.
  *
  * **Fail-safe polarity** (deliberately opposite to `kbEmbeddingPoisonStore`): a MISSING record means
  * the plane pre-dates the election contract — promotes stay admissible in declared legacy mode, and
@@ -57,12 +60,14 @@ export const VECTOR_GENERATION_ELECTION_SCHEMA_VERSION = 1;
 /**
  * @summary The vector-plane collection census — every live embedding collection the election governs.
  *
- * KB serves one unified collection; MC serves memories, session summaries, and temporal summaries
- * (the graph's Chroma usage rides the MC collections — no separate graph collection creator exists).
- * A promote for a key outside this census is a caller bug, not a new collection.
+ * KB serves one unified collection; MC serves memories, session summaries, temporal summaries, and
+ * the graph-node embedding collection (`StorageRouter.getGraphCollection()` — resolved through the
+ * accessor layer, which an earlier creator-layer sweep missed). A promote for a key outside this
+ * census is a caller bug, not a new collection.
  */
 export const VECTOR_PLANE_COLLECTION_KEYS = Object.freeze([
     'kb.unified',
+    'mc.graph',
     'mc.memory',
     'mc.session',
     'mc.temporalSummary'
@@ -86,6 +91,7 @@ const SAFE_COORDINATE_KEYS  = Object.freeze([
 const SAFE_GENERATION_KEYS = Object.freeze(['coordinates', 'declaredAt', 'embeddingGenerationId', 'generationId']);
 const SAFE_COLLECTION_KEYS = Object.freeze(['promotedAt', 'receipt', 'unparkedAt']);
 const SAFE_RECEIPT_KEYS    = Object.freeze(['candidateCollection', 'rowCount', 'validatedAt']);
+const SAFE_QUIESCE_KEYS    = Object.freeze(['boundMs', 'declaredAt', 'scope', 'startedAt']);
 const SAFE_RECORD_KEYS     = Object.freeze([
     'acceptedAt',
     'candidate',
@@ -95,6 +101,7 @@ const SAFE_RECORD_KEYS     = Object.freeze([
     'elected',
     'epoch',
     'parked',
+    'quiesce',
     'retired',
     'retiredAt',
     'rolledBack',
@@ -103,6 +110,14 @@ const SAFE_RECORD_KEYS     = Object.freeze([
     'status',
     'updatedAt'
 ]);
+
+// A transition window longer than a day is a configuration error, not a long migration — the
+// canonical-scale REBUILD happens before commit; only the bounded rename window sits inside quiesce.
+const QUIESCE_MAX_BOUND_MS = 24 * 60 * 60 * 1000;
+
+// Identity coordinates that carry no identifying power. Accepting them silently would forfeit the
+// exact invalidation guarantee the tuple exists for, so they throw at declaration time.
+const PLACEHOLDER_COORDINATE_VALUES = Object.freeze(new Set(['n/a', 'na', 'placeholder', 'tbd', 'todo', 'unknown']));
 
 // Atomic rename prevents torn reads; this queue additionally preserves call order inside one process.
 // The lifecycle guard below protects each read-verify-mutate across KB/MC processes and container PID
@@ -144,12 +159,14 @@ export function createEmbeddingGenerationId({provider, model, vectorDimension, s
  * what makes a lane/engine switch a new corpus generation by construction. `quantization`,
  * `pooling`, and `distance` are explicit because the live `model` value is a config tag, not an
  * immutable digest — a quantization or pooling change with an unchanged tag must still invalidate.
- * Placeholder values ('unknown', 'n/a') are accepted mechanically but forfeit exactly that
- * invalidation guarantee; callers own declaring real coordinates.
+ * Placeholder values ('unknown', 'n/a', 'tbd', …) THROW: a placeholder coordinate forfeits exactly
+ * the invalidation guarantee the tuple exists for. The `model` value must be digest-bearing
+ * (contain `@` or a `sha256:` digest), so the identity binds to the immutable selected artifact —
+ * the elected coordinate from the envelope election, not a mutable tag.
  *
  * @param {Object} coordinates
  * @param {String} coordinates.provider Embedding provider/engine identity (e.g. 'openAiCompatible').
- * @param {String} coordinates.model Model reference; prefer a digest-qualified immutable form.
+ * @param {String} coordinates.model Digest-bearing immutable model reference (coordinate or `sha256:` form).
  * @param {String} coordinates.quantization Model quantization (e.g. 'q4_K_M', or 'none').
  * @param {Number} coordinates.vectorDimension Output vector dimension.
  * @param {String} coordinates.pooling Pooling/normalization semantics (e.g. 'last-token-normalized').
@@ -166,12 +183,16 @@ export function createVectorGenerationIdentity({
     distance,
     strategyVersion
 } = {}) {
-    assertHashInput(provider, 'createVectorGenerationIdentity: provider');
-    assertHashInput(model, 'createVectorGenerationIdentity: model');
-    assertHashInput(quantization, 'createVectorGenerationIdentity: quantization');
-    assertHashInput(pooling, 'createVectorGenerationIdentity: pooling');
-    assertHashInput(distance, 'createVectorGenerationIdentity: distance');
-    assertHashInput(strategyVersion, 'createVectorGenerationIdentity: strategyVersion');
+    assertCoordinateValue(provider, 'createVectorGenerationIdentity: provider');
+    assertCoordinateValue(model, 'createVectorGenerationIdentity: model');
+    assertCoordinateValue(quantization, 'createVectorGenerationIdentity: quantization');
+    assertCoordinateValue(pooling, 'createVectorGenerationIdentity: pooling');
+    assertCoordinateValue(distance, 'createVectorGenerationIdentity: distance');
+    assertCoordinateValue(strategyVersion, 'createVectorGenerationIdentity: strategyVersion');
+
+    if (!/@|sha256:/.test(model)) {
+        throw new TypeError('createVectorGenerationIdentity: model must be digest-bearing (a coordinate containing "@" or a "sha256:" digest); a mutable tag cannot anchor a generation identity')
+    }
 
     if (!Number.isInteger(vectorDimension) || vectorDimension <= 0) {
         throw new TypeError('createVectorGenerationIdentity: vectorDimension must be a positive integer')
@@ -302,6 +323,7 @@ export async function declareBaselineVectorGeneration({dir, identity, now = Date
             elected,
             candidate    : null,
             parked       : null,
+            quiesce      : null,
             rolledBack   : null,
             retired      : null,
             collections  : emptyCollectionsState()
@@ -352,6 +374,7 @@ export async function declareCandidateVectorGeneration({dir, identity, expectedE
             acceptedAt  : null,
             rolledBackAt: null,
             candidate,
+            quiesce     : null,
             rolledBack  : null,
             collections : emptyCollectionsState()
         });
@@ -392,22 +415,25 @@ export async function recordCandidateValidationReceipt({dir, collectionKey, rece
 }
 
 /**
- * @summary Commits the election — the single durable visibility transition.
+ * @summary Commits the election — the single durable authority transition, inside a declared quiesce.
  *
- * Refuses unless every census collection carries a validation receipt. The elected generation
- * parks (full-set rollback authority), the candidate becomes elected, and the epoch increments —
- * from this moment the seams' promotes for the new generation are admissible and stale writers are
- * fenced out. No rename has happened yet; the promotes themselves remain per-collection actions
- * whose completion {@link recordPromoteCompletion} tracks.
+ * Refuses unless every census collection carries a validation receipt AND the caller declares the
+ * quiesce window the transition renames will run inside. The elected generation parks (full-set
+ * rollback authority), the candidate becomes elected, and the epoch increments. No rename has
+ * happened yet — the per-collection promotes follow, each refusing to run outside the declared
+ * window, and readers must be quiesced by the deployment for exactly that window: the record
+ * enforces the declaration and the bound, not the quiet itself.
  *
  * @param {Object} options
  * @param {String} options.dir Declared plane-state directory.
  * @param {Number} options.expectedEpoch The epoch the caller read.
+ * @param {Object} options.quiesce `{scope, startedAt?, boundMs}` — the declared reader-quiesce window.
  * @param {Number|Date} [options.now=Date.now()] Deterministic clock seam.
  * @returns {Promise<Object>} The persisted record.
  */
-export async function commitVectorGenerationElection({dir, expectedEpoch, now = Date.now()} = {}) {
+export async function commitVectorGenerationElection({dir, expectedEpoch, quiesce, now = Date.now()} = {}) {
     const committedAt = normalizeTimestamp(now, 'commitVectorGenerationElection: now');
+    const window      = normalizeQuiesce(quiesce, committedAt, 'commitVectorGenerationElection');
     const filePath    = getVectorGenerationElectionFilePath({dir});
 
     return await serializeMutation(filePath, async guard => {
@@ -430,7 +456,8 @@ export async function commitVectorGenerationElection({dir, expectedEpoch, now = 
             committedAt,
             parked   : record.elected,
             elected  : record.candidate,
-            candidate: null
+            candidate: null,
+            quiesce  : window
         });
 
         return await persistRecord({filePath, record, guard, label: 'commitVectorGenerationElection'})
@@ -438,21 +465,62 @@ export async function commitVectorGenerationElection({dir, expectedEpoch, now = 
 }
 
 /**
+ * @summary Renews the declared quiesce window of a running transition — the stall remediation.
+ *
+ * A committed or rolled-back transition whose window expired with renames incomplete is stuck by
+ * design (renames refuse outside the window). The operator renews with a fresh declared window —
+ * an explicit, receipted act — rather than the record silently tolerating late renames.
+ *
+ * @param {Object} options
+ * @param {String} options.dir Declared plane-state directory.
+ * @param {Number} options.expectedEpoch The epoch the caller read.
+ * @param {Object} options.quiesce `{scope, startedAt?, boundMs}` — the fresh reader-quiesce window.
+ * @param {Number|Date} [options.now=Date.now()] Deterministic clock seam.
+ * @returns {Promise<Object>} The persisted record.
+ */
+export async function renewTransitionQuiesce({dir, expectedEpoch, quiesce, now = Date.now()} = {}) {
+    const declaredAt = normalizeTimestamp(now, 'renewTransitionQuiesce: now');
+    const window     = normalizeQuiesce(quiesce, declaredAt, 'renewTransitionQuiesce');
+    const filePath   = getVectorGenerationElectionFilePath({dir});
+
+    return await serializeMutation(filePath, async guard => {
+        const record = await requireRecord({dir, expectedEpoch, label: 'renewTransitionQuiesce'});
+
+        if (record.status !== 'committed' && record.status !== 'rolled-back') {
+            throw new Error(`renewTransitionQuiesce: refused from status "${record.status}"; only a running transition carries a quiesce window`)
+        }
+
+        Object.assign(record, {
+            updatedAt: declaredAt,
+            quiesce  : window
+        });
+
+        return await persistRecord({filePath, record, guard, label: 'renewTransitionQuiesce'})
+    })
+}
+
+/**
  * @summary The stale-writer fence — every seam calls this immediately before its promote renames.
  *
- * One rule for every status: the generation being promoted must be the ELECTED one and the caller's
- * epoch must be the CURRENT one. A writer holding a pre-election view fails both. Un-park renames
- * during a rollback pass the same fence, because rollback re-elects the prior generation first.
+ * Two rules compose. IDENTITY, for every status: the generation being promoted must be the ELECTED
+ * one and the caller's epoch must be the CURRENT one — a writer holding a pre-election view fails
+ * both. WINDOW, for transitions only: while the record is `committed` or `rolled-back`, the rename
+ * this call admits is a TRANSITION rename (it changes which generation a canonical name serves), so
+ * it must additionally fall inside the declared quiesce window; outside the window it refuses, and
+ * the remediation is {@link renewTransitionQuiesce}. Steady-state refresh promotes on an `accepted`
+ * record need no window — both sides of that rename are the same generation.
  *
  * @param {Object} options
  * @param {String} options.dir Declared plane-state directory.
  * @param {String} options.collectionKey One of {@link VECTOR_PLANE_COLLECTION_KEYS}.
  * @param {String} options.generationId The full election generation id the writer built against.
  * @param {Number} options.epoch The epoch the writer read before building.
+ * @param {Number|Date} [options.now=Date.now()] Deterministic clock seam for the window check.
  * @returns {Promise<{mode: 'legacy'}|{mode: 'elected', epoch: Number, generationId: String}>}
- * @throws {Error} When the record is unprovable or the writer is stale — the promote must not run.
+ * @throws {Error} When the record is unprovable, the writer is stale, or a transition rename falls
+ * outside the declared quiesce window — the promote must not run.
  */
-export async function assertVectorPromoteAdmissible({dir, collectionKey, generationId, epoch} = {}) {
+export async function assertVectorPromoteAdmissible({dir, collectionKey, generationId, epoch, now = Date.now()} = {}) {
     assertCollectionKey(collectionKey, 'assertVectorPromoteAdmissible');
 
     const state = await readVectorGenerationElection({dir});
@@ -475,6 +543,14 @@ export async function assertVectorPromoteAdmissible({dir, collectionKey, generat
 
     if (generationId !== record.elected.generationId) {
         throw new Error(`assertVectorPromoteAdmissible: generation ${generationId.slice(0, 12)}… is not the elected generation at epoch ${record.epoch}`)
+    }
+
+    if (record.status === 'committed' || record.status === 'rolled-back') {
+        const at = normalizeTimestamp(now, 'assertVectorPromoteAdmissible: now');
+
+        if (!isWithinQuiesceWindow(record.quiesce, at)) {
+            throw new Error(`assertVectorPromoteAdmissible: transition rename refused outside the declared quiesce window (scope "${record.quiesce.scope}", ${record.quiesce.startedAt} + ${record.quiesce.boundMs}ms); renew the window explicitly to continue`)
+        }
     }
 
     return {mode: 'elected', epoch: record.epoch, generationId: record.elected.generationId, electionStatus: record.status}
@@ -579,17 +655,20 @@ export async function recordPromoteCompletion({dir, collectionKey, expectedEpoch
  *
  * A code-only rollback without the generation restore is impossible by construction: this is the
  * only rollback, it flips the whole plane, and the epoch increments so every writer that built
- * against the abandoned generation is fenced out. Seams then un-park the restored generation's
- * collections and report via {@link recordUnparkCompletion}.
+ * against the abandoned generation is fenced out. The un-park renames that restore the prior
+ * generation are transition renames, so rollback carries the SAME quiesce obligation as commit —
+ * the caller declares the window the un-parks will run inside, and each un-park refuses outside it.
  *
  * @param {Object} options
  * @param {String} options.dir Declared plane-state directory.
  * @param {Number} options.expectedEpoch The epoch the caller read.
+ * @param {Object} options.quiesce `{scope, startedAt?, boundMs}` — the declared reader-quiesce window.
  * @param {Number|Date} [options.now=Date.now()] Deterministic clock seam.
  * @returns {Promise<Object>} The persisted record.
  */
-export async function rollbackVectorGenerationElection({dir, expectedEpoch, now = Date.now()} = {}) {
+export async function rollbackVectorGenerationElection({dir, expectedEpoch, quiesce, now = Date.now()} = {}) {
     const rolledBackAt = normalizeTimestamp(now, 'rollbackVectorGenerationElection: now');
+    const window       = normalizeQuiesce(quiesce, rolledBackAt, 'rollbackVectorGenerationElection');
     const filePath     = getVectorGenerationElectionFilePath({dir});
 
     return await serializeMutation(filePath, async guard => {
@@ -608,6 +687,7 @@ export async function rollbackVectorGenerationElection({dir, expectedEpoch, now 
             rolledBack : record.elected,
             elected    : record.parked,
             parked     : null,
+            quiesce    : window,
             collections: resetPromotesKeepReceipts(record.collections)
         });
 
@@ -680,7 +760,8 @@ export async function acceptVectorGenerationElection({dir, expectedEpoch, now = 
             acceptedAt,
             retiredAt: acceptedAt,
             retired  : record.parked,
-            parked   : null
+            parked   : null,
+            quiesce  : null
         });
 
         return await persistRecord({filePath, record, guard, label: 'acceptVectorGenerationElection'})
@@ -712,6 +793,7 @@ export async function projectVectorGenerationHealth({dir} = {}) {
         elected    : projectGeneration(record.elected),
         parked     : projectGeneration(record.parked),
         candidate  : projectGeneration(record.candidate),
+        quiesce    : record.quiesce === null ? null : {...record.quiesce},
         collections: Object.fromEntries(VECTOR_PLANE_COLLECTION_KEYS.map(key => [key, {
             validated : record.collections[key].receipt !== null,
             promotedAt: record.collections[key].promotedAt,
@@ -806,6 +888,7 @@ function isValidRecord(record) {
     if (!nullOr(record.acceptedAt, isCanonicalTimestamp) || (record.acceptedAt !== null) !== (status === 'accepted')) return false;
     if (!nullOr(record.rolledBackAt, isCanonicalTimestamp) || (record.rolledBackAt !== null) !== (status === 'rolled-back')) return false;
     if (!nullOr(record.retiredAt, isCanonicalTimestamp) || (record.retiredAt !== null) !== (record.retired !== null)) return false;
+    if (!nullOr(record.quiesce, isValidQuiesce) || (record.quiesce !== null) !== (status === 'committed' || status === 'rolled-back')) return false;
 
     if (!isExactObject(record.collections, VECTOR_PLANE_COLLECTION_KEYS)) return false;
 
@@ -971,6 +1054,70 @@ function assertHash(value, label) {
     if (typeof value !== 'string' || !HASH_PATTERN.test(value)) {
         throw new TypeError(`${label} must be a lowercase SHA-256 hex string`)
     }
+}
+
+function assertCoordinateValue(value, label) {
+    assertHashInput(value, label);
+
+    if (PLACEHOLDER_COORDINATE_VALUES.has(value.trim().toLowerCase())) {
+        throw new TypeError(`${label} is a placeholder ("${value}") — a placeholder coordinate forfeits the invalidation guarantee; declare the real value`)
+    }
+}
+
+/**
+ * @summary Validates one stored quiesce window declaration.
+ * @param {*} quiesce Candidate window.
+ * @returns {Boolean}
+ * @private
+ */
+function isValidQuiesce(quiesce) {
+    return isExactObject(quiesce, SAFE_QUIESCE_KEYS)
+        && typeof quiesce.scope === 'string'
+        && quiesce.scope.length > 0
+        && quiesce.scope.length <= MAX_HASH_INPUT_LENGTH
+        && isCanonicalTimestamp(quiesce.startedAt)
+        && isCanonicalTimestamp(quiesce.declaredAt)
+        && Number.isInteger(quiesce.boundMs)
+        && quiesce.boundMs > 0
+        && quiesce.boundMs <= QUIESCE_MAX_BOUND_MS
+}
+
+/**
+ * @summary Normalizes a caller quiesce declaration into the persistable window.
+ * @param {*} quiesce `{scope, startedAt?, boundMs}`.
+ * @param {String} declaredAt Canonical declaration timestamp; also the default window start.
+ * @param {String} label Error-message prefix.
+ * @returns {Object}
+ * @private
+ */
+function normalizeQuiesce(quiesce, declaredAt, label) {
+    const keys = quiesce && typeof quiesce === 'object' && !Array.isArray(quiesce)
+        ? Object.keys(quiesce).sort()
+        : [];
+
+    if (!sameKeys(keys, ['boundMs', 'scope']) && !sameKeys(keys, ['boundMs', 'scope', 'startedAt'])) {
+        throw new TypeError(`${label}: quiesce must declare exactly {scope, boundMs, startedAt?} — a transition without a declared reader-quiesce window is refused`)
+    }
+
+    const normalized = {
+        boundMs  : quiesce.boundMs,
+        declaredAt,
+        scope    : quiesce.scope,
+        startedAt: quiesce.startedAt === undefined
+            ? declaredAt
+            : normalizeTimestamp(quiesce.startedAt, `${label}: quiesce.startedAt`)
+    };
+
+    if (!isValidQuiesce(normalized)) {
+        throw new TypeError(`${label}: quiesce failed validation (bounded scope string, positive integer boundMs ≤ ${QUIESCE_MAX_BOUND_MS})`)
+    }
+
+    return normalized
+}
+
+function isWithinQuiesceWindow(quiesce, at) {
+    return at >= quiesce.startedAt
+        && Date.parse(at) <= Date.parse(quiesce.startedAt) + quiesce.boundMs
 }
 
 function assertHashInput(value, label) {

--- a/ai/services/shared/vector/generationElectionStore.mjs
+++ b/ai/services/shared/vector/generationElectionStore.mjs
@@ -1,0 +1,969 @@
+/**
+ * @module ai/services/shared/vector/generationElectionStore
+ * @summary One durable election authority for the vector plane's embedding-generation visibility.
+ *
+ * Any change to a load-bearing embedding-generation coordinate (provider/engine, model reference,
+ * quantization, output dimension, pooling/normalization, distance semantics, preprocessing/chunk
+ * strategy) invalidates every existing vector. Per-collection shadow builds may proceed
+ * independently, but GENERATION VISIBILITY commits through this one plane-singleton record — never
+ * through per-collection flags that can disagree.
+ *
+ * **The barrier gates PROMOTES, not reads.** Readers only ever resolve canonical collection names;
+ * a generation becomes visible at exactly one moment per collection — the promote rename performed
+ * by one of the two seams (KB `VectorService.embedViaShadowSwap`, MC `restoreTargetSetStorage`).
+ * Each seam calls {@link assertVectorPromoteAdmissible} immediately before its renames and refuses
+ * unless the generation it built is the ELECTED one at the CURRENT epoch. An uncommitted election
+ * therefore never advertises: no admissible promote exists, so no rename has happened, so every
+ * reader still resolves the prior generation. No read-path generation filter exists anywhere.
+ *
+ * **Fail-safe polarity** (deliberately opposite to `kbEmbeddingPoisonStore`): a MISSING record means
+ * the plane pre-dates the election contract — promotes stay admissible in declared legacy mode, and
+ * the cutover's first act is {@link declareBaselineVectorGeneration}. A CORRUPT or unreadable record
+ * REFUSES promotes: promoting on unprovable state could advertise a wrong generation, which is the
+ * exact forbidden outcome, while refusing merely leaves readers on the intact prior generation.
+ *
+ * **Coordinates are stored verbatim**, unlike the poison store's hashed generation coordinates.
+ * That contrast is deliberate: the poison marker is per-tenant-scope state where identity hashes
+ * suffice, while this record IS the plane's deployment identity — health surfaces and operators must
+ * read WHICH generation is elected and parked to act on it. The coordinates describe deployment
+ * software configuration only; tenant identities, content, credentials, endpoints, and client names
+ * have no writable field in the schema.
+ *
+ * **Deployment invariant — the shared mount:** KB and MC processes mutate this one file, so the
+ * declared state directory must resolve to the SAME filesystem path on the SAME mount in every
+ * process/container of the plane. A per-service copy of the path with per-service storage silently
+ * splits the authority in two; the compose mount line is part of this design.
+ *
+ * Lifecycle (epoch increments on every visibility flip — commit and rollback, nothing else):
+ *
+ *     accepted ──declareCandidate──▶ candidate ──commit──▶ committed ──accept──▶ accepted
+ *                                                             │
+ *                                                          rollback ──▶ rolled-back ──declareCandidate──▶ …
+ */
+
+import crypto            from 'crypto';
+import fs                from 'fs/promises';
+import fsExtra           from 'fs-extra';
+import path              from 'path';
+import {writeFileAtomic} from '../atomicFileWrite.mjs';
+import {
+    enterLifecycleGuard,
+    exitLifecycleGuard,
+    verifyLifecycleGuardOwnership
+} from '../../../daemons/shared/lifecycleGuard.mjs';
+
+export const VECTOR_GENERATION_ELECTION_SCHEMA_VERSION = 1;
+
+/**
+ * @summary The vector-plane collection census — every live embedding collection the election governs.
+ *
+ * KB serves one unified collection; MC serves memories, session summaries, and temporal summaries
+ * (the graph's Chroma usage rides the MC collections — no separate graph collection creator exists).
+ * A promote for a key outside this census is a caller bug, not a new collection.
+ */
+export const VECTOR_PLANE_COLLECTION_KEYS = Object.freeze([
+    'kb.unified',
+    'mc.memory',
+    'mc.session',
+    'mc.temporalSummary'
+]);
+
+export const VECTOR_ELECTION_STATUSES = Object.freeze(['accepted', 'candidate', 'committed', 'rolled-back']);
+
+const ELECTION_FILE_NAME    = 'vector-generation-election.json';
+const ELECTION_MAX_BYTES    = 64 * 1024;
+const HASH_PATTERN          = /^[a-f0-9]{64}$/;
+const MAX_HASH_INPUT_LENGTH = 1024;
+const SAFE_COORDINATE_KEYS  = Object.freeze([
+    'distance',
+    'model',
+    'pooling',
+    'provider',
+    'quantization',
+    'strategyVersion',
+    'vectorDimension'
+]);
+const SAFE_GENERATION_KEYS = Object.freeze(['coordinates', 'declaredAt', 'embeddingGenerationId', 'generationId']);
+const SAFE_COLLECTION_KEYS = Object.freeze(['promotedAt', 'receipt', 'unparkedAt']);
+const SAFE_RECEIPT_KEYS    = Object.freeze(['candidateCollection', 'rowCount', 'validatedAt']);
+const SAFE_RECORD_KEYS     = Object.freeze([
+    'acceptedAt',
+    'candidate',
+    'collections',
+    'committedAt',
+    'createdAt',
+    'elected',
+    'epoch',
+    'parked',
+    'retired',
+    'retiredAt',
+    'rolledBack',
+    'rolledBackAt',
+    'schemaVersion',
+    'status',
+    'updatedAt'
+]);
+
+// Atomic rename prevents torn reads; this queue additionally preserves call order inside one process.
+// The lifecycle guard below protects each read-verify-mutate across KB/MC processes and container PID
+// namespaces that share the declared plane-state mount.
+const writeQueues = new Map();
+
+/**
+ * @summary Hashes the poison-store-compatible embedding-generation coordinates.
+ *
+ * This is the ONE implementation of the four-coordinate id-space shared with
+ * `kbEmbeddingPoisonStore` (which re-exports it): the same tuple must always produce the same id in
+ * both stores, so poison dispositions and election records join on generation without translation.
+ * The full election identity ({@link createVectorGenerationIdentity}) hashes MORE coordinates; this
+ * narrower id exists solely as that join key.
+ *
+ * @param {Object} options
+ * @param {String} options.provider Embedding provider identity (never persisted verbatim by the poison store).
+ * @param {String} options.model Embedding model identity.
+ * @param {Number} options.vectorDimension Expected vector dimension.
+ * @param {String} options.strategyVersion Input/chunking strategy version.
+ * @returns {String} Lowercase SHA-256 generation id.
+ */
+export function createEmbeddingGenerationId({provider, model, vectorDimension, strategyVersion} = {}) {
+    assertHashInput(provider, 'createEmbeddingGenerationId: provider');
+    assertHashInput(model, 'createEmbeddingGenerationId: model');
+    assertHashInput(strategyVersion, 'createEmbeddingGenerationId: strategyVersion');
+
+    if (!Number.isInteger(vectorDimension) || vectorDimension <= 0) {
+        throw new TypeError('createEmbeddingGenerationId: vectorDimension must be a positive integer')
+    }
+
+    return sha256(JSON.stringify({provider, model, vectorDimension, strategyVersion}))
+}
+
+/**
+ * @summary Builds the complete, validated generation identity the election records.
+ *
+ * Carries the full coordinate tuple: any change to ANY field yields a new `generationId`, which is
+ * what makes a lane/engine switch a new corpus generation by construction. `quantization`,
+ * `pooling`, and `distance` are explicit because the live `model` value is a config tag, not an
+ * immutable digest — a quantization or pooling change with an unchanged tag must still invalidate.
+ * Placeholder values ('unknown', 'n/a') are accepted mechanically but forfeit exactly that
+ * invalidation guarantee; callers own declaring real coordinates.
+ *
+ * @param {Object} coordinates
+ * @param {String} coordinates.provider Embedding provider/engine identity (e.g. 'openAiCompatible').
+ * @param {String} coordinates.model Model reference; prefer a digest-qualified immutable form.
+ * @param {String} coordinates.quantization Model quantization (e.g. 'q4_K_M', or 'none').
+ * @param {Number} coordinates.vectorDimension Output vector dimension.
+ * @param {String} coordinates.pooling Pooling/normalization semantics (e.g. 'last-token-normalized').
+ * @param {String} coordinates.distance Distance semantics of the collections (e.g. 'cosine').
+ * @param {String} coordinates.strategyVersion Preprocessing/chunk-strategy version.
+ * @returns {{coordinates: Object, generationId: String, embeddingGenerationId: String}} Frozen identity.
+ */
+export function createVectorGenerationIdentity({
+    provider,
+    model,
+    quantization,
+    vectorDimension,
+    pooling,
+    distance,
+    strategyVersion
+} = {}) {
+    assertHashInput(provider, 'createVectorGenerationIdentity: provider');
+    assertHashInput(model, 'createVectorGenerationIdentity: model');
+    assertHashInput(quantization, 'createVectorGenerationIdentity: quantization');
+    assertHashInput(pooling, 'createVectorGenerationIdentity: pooling');
+    assertHashInput(distance, 'createVectorGenerationIdentity: distance');
+    assertHashInput(strategyVersion, 'createVectorGenerationIdentity: strategyVersion');
+
+    if (!Number.isInteger(vectorDimension) || vectorDimension <= 0) {
+        throw new TypeError('createVectorGenerationIdentity: vectorDimension must be a positive integer')
+    }
+
+    // Canonical order is alphabetical; the hash is stable because the literal fixes key order.
+    const coordinates = Object.freeze({
+        distance,
+        model,
+        pooling,
+        provider,
+        quantization,
+        strategyVersion,
+        vectorDimension
+    });
+
+    return Object.freeze({
+        coordinates,
+        generationId         : sha256(JSON.stringify(coordinates)),
+        embeddingGenerationId: createEmbeddingGenerationId({provider, model, vectorDimension, strategyVersion})
+    })
+}
+
+/**
+ * @summary Resolves the plane-singleton election record path.
+ * @param {Object} options
+ * @param {String} options.dir Declared plane-state directory shared by every KB/MC process.
+ * @returns {String} Absolute record path.
+ */
+export function getVectorGenerationElectionFilePath({dir} = {}) {
+    if (typeof dir !== 'string' || dir.length === 0) {
+        throw new TypeError('getVectorGenerationElectionFilePath: dir is required')
+    }
+
+    return path.resolve(dir, ELECTION_FILE_NAME)
+}
+
+/**
+ * @summary Reads and strictly validates the election record.
+ *
+ * `missing` means the plane never declared an election (legacy mode for the promote fence).
+ * `unavailable` means a record exists but cannot be proven (corrupt, oversized, schema drift,
+ * derived-hash mismatch) — promotes must refuse on it while readers stay unaffected.
+ *
+ * @param {Object} options
+ * @param {String} options.dir Declared plane-state directory.
+ * @returns {Promise<Object>} `{status: 'missing'|'available'|'unavailable', record?}`.
+ */
+export async function readVectorGenerationElection({dir} = {}) {
+    const filePath = getVectorGenerationElectionFilePath({dir});
+
+    try {
+        const stat = await fs.stat(filePath);
+
+        if (!stat.isFile() || stat.size <= 0 || stat.size > ELECTION_MAX_BYTES) {
+            return {status: 'unavailable'}
+        }
+
+        const record = JSON.parse(await fs.readFile(filePath, 'utf8'));
+
+        if (!isValidRecord(record)) {
+            return {status: 'unavailable'}
+        }
+
+        return {status: 'available', record}
+    } catch (error) {
+        return {status: error?.code === 'ENOENT' ? 'missing' : 'unavailable'}
+    }
+}
+
+/**
+ * @summary Declares the baseline election on a plane that never had one — records reality, changes nothing.
+ *
+ * This is the bootstrap act of the cutover runbook: it names the generation the live collections
+ * already hold, at epoch 1, already accepted. It refuses when ANY record exists — including a
+ * corrupt one, because silently overwriting unprovable state destroys the forensics an operator
+ * needs; inspect and remove the file explicitly, then re-declare.
+ *
+ * @param {Object} options
+ * @param {String} options.dir Declared plane-state directory.
+ * @param {Object} options.identity Result of {@link createVectorGenerationIdentity}.
+ * @param {Number|Date} [options.now=Date.now()] Deterministic clock seam.
+ * @returns {Promise<Object>} The persisted record.
+ */
+export async function declareBaselineVectorGeneration({dir, identity, now = Date.now()} = {}) {
+    const declaredAt = normalizeTimestamp(now, 'declareBaselineVectorGeneration: now');
+    const elected    = toGenerationEnvelope(identity, declaredAt, 'declareBaselineVectorGeneration');
+    const filePath   = getVectorGenerationElectionFilePath({dir});
+
+    return await serializeMutation(filePath, async guard => {
+        const prior = await readVectorGenerationElection({dir});
+
+        if (prior.status !== 'missing') {
+            throw new Error(`declareBaselineVectorGeneration: a record already exists (status: ${prior.status}); baseline only initializes a plane without one`)
+        }
+
+        const record = {
+            schemaVersion: VECTOR_GENERATION_ELECTION_SCHEMA_VERSION,
+            epoch        : 1,
+            status       : 'accepted',
+            createdAt    : declaredAt,
+            updatedAt    : declaredAt,
+            committedAt  : declaredAt,
+            acceptedAt   : declaredAt,
+            rolledBackAt : null,
+            retiredAt    : null,
+            elected,
+            candidate    : null,
+            parked       : null,
+            rolledBack   : null,
+            retired      : null,
+            collections  : emptyCollectionsState()
+        };
+
+        return await persistRecord({filePath, record, guard, label: 'declareBaselineVectorGeneration'})
+    })
+}
+
+/**
+ * @summary Declares the candidate generation a transition intends to elect.
+ *
+ * Allowed from `accepted` or — once every collection reports its un-park — from `rolled-back`.
+ * Resets the per-collection tracking; validation receipts then accumulate via
+ * {@link recordCandidateValidationReceipt} until {@link commitVectorGenerationElection}.
+ *
+ * @param {Object} options
+ * @param {String} options.dir Declared plane-state directory.
+ * @param {Object} options.identity Result of {@link createVectorGenerationIdentity}.
+ * @param {Number} options.expectedEpoch The epoch the caller read; refuses when it moved.
+ * @param {Number|Date} [options.now=Date.now()] Deterministic clock seam.
+ * @returns {Promise<Object>} The persisted record.
+ */
+export async function declareCandidateVectorGeneration({dir, identity, expectedEpoch, now = Date.now()} = {}) {
+    const declaredAt = normalizeTimestamp(now, 'declareCandidateVectorGeneration: now');
+    const candidate  = toGenerationEnvelope(identity, declaredAt, 'declareCandidateVectorGeneration');
+    const filePath   = getVectorGenerationElectionFilePath({dir});
+
+    return await serializeMutation(filePath, async guard => {
+        const record = await requireRecord({dir, expectedEpoch, label: 'declareCandidateVectorGeneration'});
+
+        if (record.status !== 'accepted' && record.status !== 'rolled-back') {
+            throw new Error(`declareCandidateVectorGeneration: refused from status "${record.status}"; accept or roll back the running transition first`)
+        }
+
+        if (record.status === 'rolled-back' && !everyCollection(record, entry => entry.unparkedAt !== null)) {
+            throw new Error('declareCandidateVectorGeneration: refused; the rolled-back transition has collections that never reported their un-park')
+        }
+
+        if (candidate.generationId === record.elected.generationId) {
+            throw new Error('declareCandidateVectorGeneration: candidate equals the elected generation; a no-op election is a caller bug')
+        }
+
+        Object.assign(record, {
+            status      : 'candidate',
+            updatedAt   : declaredAt,
+            committedAt : null,
+            acceptedAt  : null,
+            rolledBackAt: null,
+            candidate,
+            rolledBack  : null,
+            collections : emptyCollectionsState()
+        });
+
+        return await persistRecord({filePath, record, guard, label: 'declareCandidateVectorGeneration'})
+    })
+}
+
+/**
+ * @summary Records one collection's candidate-validation receipt — the proof commit requires.
+ * @param {Object} options
+ * @param {String} options.dir Declared plane-state directory.
+ * @param {String} options.collectionKey One of {@link VECTOR_PLANE_COLLECTION_KEYS}.
+ * @param {Object} options.receipt `{candidateCollection, rowCount, validatedAt?}` — re-validation replaces.
+ * @param {Number} options.expectedEpoch The epoch the caller read.
+ * @param {Number|Date} [options.now=Date.now()] Deterministic clock seam.
+ * @returns {Promise<Object>} The persisted record.
+ */
+export async function recordCandidateValidationReceipt({dir, collectionKey, receipt, expectedEpoch, now = Date.now()} = {}) {
+    assertCollectionKey(collectionKey, 'recordCandidateValidationReceipt');
+
+    const observedAt = normalizeTimestamp(now, 'recordCandidateValidationReceipt: now');
+    const normalized = normalizeReceipt(receipt, observedAt);
+    const filePath   = getVectorGenerationElectionFilePath({dir});
+
+    return await serializeMutation(filePath, async guard => {
+        const record = await requireRecord({dir, expectedEpoch, label: 'recordCandidateValidationReceipt'});
+
+        if (record.status !== 'candidate') {
+            throw new Error(`recordCandidateValidationReceipt: refused from status "${record.status}"; receipts only accumulate for a declared candidate`)
+        }
+
+        record.collections[collectionKey].receipt = normalized;
+        record.updatedAt                          = observedAt;
+
+        return await persistRecord({filePath, record, guard, label: 'recordCandidateValidationReceipt'})
+    })
+}
+
+/**
+ * @summary Commits the election — the single durable visibility transition.
+ *
+ * Refuses unless every census collection carries a validation receipt. The elected generation
+ * parks (full-set rollback authority), the candidate becomes elected, and the epoch increments —
+ * from this moment the seams' promotes for the new generation are admissible and stale writers are
+ * fenced out. No rename has happened yet; the promotes themselves remain per-collection actions
+ * whose completion {@link recordPromoteCompletion} tracks.
+ *
+ * @param {Object} options
+ * @param {String} options.dir Declared plane-state directory.
+ * @param {Number} options.expectedEpoch The epoch the caller read.
+ * @param {Number|Date} [options.now=Date.now()] Deterministic clock seam.
+ * @returns {Promise<Object>} The persisted record.
+ */
+export async function commitVectorGenerationElection({dir, expectedEpoch, now = Date.now()} = {}) {
+    const committedAt = normalizeTimestamp(now, 'commitVectorGenerationElection: now');
+    const filePath    = getVectorGenerationElectionFilePath({dir});
+
+    return await serializeMutation(filePath, async guard => {
+        const record = await requireRecord({dir, expectedEpoch, label: 'commitVectorGenerationElection'});
+
+        if (record.status !== 'candidate') {
+            throw new Error(`commitVectorGenerationElection: refused from status "${record.status}"; only a declared candidate commits`)
+        }
+
+        const missing = VECTOR_PLANE_COLLECTION_KEYS.filter(key => record.collections[key].receipt === null);
+
+        if (missing.length > 0) {
+            throw new Error(`commitVectorGenerationElection: refused; collections without a validation receipt: ${missing.join(', ')}`)
+        }
+
+        Object.assign(record, {
+            epoch    : record.epoch + 1,
+            status   : 'committed',
+            updatedAt: committedAt,
+            committedAt,
+            parked   : record.elected,
+            elected  : record.candidate,
+            candidate: null
+        });
+
+        return await persistRecord({filePath, record, guard, label: 'commitVectorGenerationElection'})
+    })
+}
+
+/**
+ * @summary The stale-writer fence — every seam calls this immediately before its promote renames.
+ *
+ * One rule for every status: the generation being promoted must be the ELECTED one and the caller's
+ * epoch must be the CURRENT one. A writer holding a pre-election view fails both. Un-park renames
+ * during a rollback pass the same fence, because rollback re-elects the prior generation first.
+ *
+ * @param {Object} options
+ * @param {String} options.dir Declared plane-state directory.
+ * @param {String} options.collectionKey One of {@link VECTOR_PLANE_COLLECTION_KEYS}.
+ * @param {String} options.generationId The full election generation id the writer built against.
+ * @param {Number} options.epoch The epoch the writer read before building.
+ * @returns {Promise<{mode: 'legacy'}|{mode: 'elected', epoch: Number, generationId: String}>}
+ * @throws {Error} When the record is unprovable or the writer is stale — the promote must not run.
+ */
+export async function assertVectorPromoteAdmissible({dir, collectionKey, generationId, epoch} = {}) {
+    assertCollectionKey(collectionKey, 'assertVectorPromoteAdmissible');
+
+    const state = await readVectorGenerationElection({dir});
+
+    if (state.status === 'missing') {
+        return {mode: 'legacy'}
+    }
+
+    if (state.status === 'unavailable') {
+        throw new Error('assertVectorPromoteAdmissible: the election record exists but cannot be proven; refusing to promote on unprovable state')
+    }
+
+    assertHash(generationId, 'assertVectorPromoteAdmissible: generationId');
+
+    const {record} = state;
+
+    if (!Number.isInteger(epoch) || epoch !== record.epoch) {
+        throw new Error(`assertVectorPromoteAdmissible: stale writer fenced; writer epoch ${epoch} vs elected epoch ${record.epoch}`)
+    }
+
+    if (generationId !== record.elected.generationId) {
+        throw new Error(`assertVectorPromoteAdmissible: generation ${generationId.slice(0, 12)}… is not the elected generation at epoch ${record.epoch}`)
+    }
+
+    return {mode: 'elected', epoch: record.epoch, generationId: record.elected.generationId}
+}
+
+/**
+ * @summary Marks one collection's promote renames as completed for the committed election.
+ * @param {Object} options
+ * @param {String} options.dir Declared plane-state directory.
+ * @param {String} options.collectionKey One of {@link VECTOR_PLANE_COLLECTION_KEYS}.
+ * @param {Number} options.expectedEpoch The epoch the caller read.
+ * @param {Number|Date} [options.now=Date.now()] Deterministic clock seam.
+ * @returns {Promise<Object>} The persisted record.
+ */
+export async function recordPromoteCompletion({dir, collectionKey, expectedEpoch, now = Date.now()} = {}) {
+    assertCollectionKey(collectionKey, 'recordPromoteCompletion');
+
+    const promotedAt = normalizeTimestamp(now, 'recordPromoteCompletion: now');
+    const filePath   = getVectorGenerationElectionFilePath({dir});
+
+    return await serializeMutation(filePath, async guard => {
+        const record = await requireRecord({dir, expectedEpoch, label: 'recordPromoteCompletion'});
+
+        if (record.status !== 'committed') {
+            throw new Error(`recordPromoteCompletion: refused from status "${record.status}"; promotes only complete under a committed election`)
+        }
+
+        record.collections[collectionKey].promotedAt = promotedAt;
+        record.updatedAt                             = promotedAt;
+
+        return await persistRecord({filePath, record, guard, label: 'recordPromoteCompletion'})
+    })
+}
+
+/**
+ * @summary Rolls the committed election back — the parked prior generation is re-elected in full.
+ *
+ * A code-only rollback without the generation restore is impossible by construction: this is the
+ * only rollback, it flips the whole plane, and the epoch increments so every writer that built
+ * against the abandoned generation is fenced out. Seams then un-park the restored generation's
+ * collections and report via {@link recordUnparkCompletion}.
+ *
+ * @param {Object} options
+ * @param {String} options.dir Declared plane-state directory.
+ * @param {Number} options.expectedEpoch The epoch the caller read.
+ * @param {Number|Date} [options.now=Date.now()] Deterministic clock seam.
+ * @returns {Promise<Object>} The persisted record.
+ */
+export async function rollbackVectorGenerationElection({dir, expectedEpoch, now = Date.now()} = {}) {
+    const rolledBackAt = normalizeTimestamp(now, 'rollbackVectorGenerationElection: now');
+    const filePath     = getVectorGenerationElectionFilePath({dir});
+
+    return await serializeMutation(filePath, async guard => {
+        const record = await requireRecord({dir, expectedEpoch, label: 'rollbackVectorGenerationElection'});
+
+        if (record.status !== 'committed') {
+            throw new Error(`rollbackVectorGenerationElection: refused from status "${record.status}"; only a committed, unaccepted election rolls back`)
+        }
+
+        Object.assign(record, {
+            epoch      : record.epoch + 1,
+            status     : 'rolled-back',
+            updatedAt  : rolledBackAt,
+            committedAt: null,
+            rolledBackAt,
+            rolledBack : record.elected,
+            elected    : record.parked,
+            parked     : null,
+            collections: resetPromotesKeepReceipts(record.collections)
+        });
+
+        return await persistRecord({filePath, record, guard, label: 'rollbackVectorGenerationElection'})
+    })
+}
+
+/**
+ * @summary Marks one collection's un-park renames as completed after a rollback.
+ * @param {Object} options
+ * @param {String} options.dir Declared plane-state directory.
+ * @param {String} options.collectionKey One of {@link VECTOR_PLANE_COLLECTION_KEYS}.
+ * @param {Number} options.expectedEpoch The epoch the caller read.
+ * @param {Number|Date} [options.now=Date.now()] Deterministic clock seam.
+ * @returns {Promise<Object>} The persisted record.
+ */
+export async function recordUnparkCompletion({dir, collectionKey, expectedEpoch, now = Date.now()} = {}) {
+    assertCollectionKey(collectionKey, 'recordUnparkCompletion');
+
+    const unparkedAt = normalizeTimestamp(now, 'recordUnparkCompletion: now');
+    const filePath   = getVectorGenerationElectionFilePath({dir});
+
+    return await serializeMutation(filePath, async guard => {
+        const record = await requireRecord({dir, expectedEpoch, label: 'recordUnparkCompletion'});
+
+        if (record.status !== 'rolled-back') {
+            throw new Error(`recordUnparkCompletion: refused from status "${record.status}"; un-parks only complete after a rollback`)
+        }
+
+        record.collections[collectionKey].unparkedAt = unparkedAt;
+        record.updatedAt                             = unparkedAt;
+
+        return await persistRecord({filePath, record, guard, label: 'recordUnparkCompletion'})
+    })
+}
+
+/**
+ * @summary Accepts the committed election — rollback authority ends, the parked generation retires.
+ *
+ * Refuses until every census collection reports its promote. After acceptance the parked
+ * generation's collections become GC-eligible for the seams; the record keeps the retired identity
+ * as rolling forensics.
+ *
+ * @param {Object} options
+ * @param {String} options.dir Declared plane-state directory.
+ * @param {Number} options.expectedEpoch The epoch the caller read.
+ * @param {Number|Date} [options.now=Date.now()] Deterministic clock seam.
+ * @returns {Promise<Object>} The persisted record.
+ */
+export async function acceptVectorGenerationElection({dir, expectedEpoch, now = Date.now()} = {}) {
+    const acceptedAt = normalizeTimestamp(now, 'acceptVectorGenerationElection: now');
+    const filePath   = getVectorGenerationElectionFilePath({dir});
+
+    return await serializeMutation(filePath, async guard => {
+        const record = await requireRecord({dir, expectedEpoch, label: 'acceptVectorGenerationElection'});
+
+        if (record.status !== 'committed') {
+            throw new Error(`acceptVectorGenerationElection: refused from status "${record.status}"; only a committed election is accepted`)
+        }
+
+        const pending = VECTOR_PLANE_COLLECTION_KEYS.filter(key => record.collections[key].promotedAt === null);
+
+        if (pending.length > 0) {
+            throw new Error(`acceptVectorGenerationElection: refused; collections without a completed promote: ${pending.join(', ')}`)
+        }
+
+        Object.assign(record, {
+            status   : 'accepted',
+            updatedAt: acceptedAt,
+            acceptedAt,
+            retiredAt: acceptedAt,
+            retired  : record.parked,
+            parked   : null
+        });
+
+        return await persistRecord({filePath, record, guard, label: 'acceptVectorGenerationElection'})
+    })
+}
+
+/**
+ * @summary Projects the election for health surfaces — elected + parked identities, per-collection state.
+ *
+ * Health must never throw on plane-state problems; `missing` and `unavailable` are reportable
+ * conditions, not errors. Acceptance reads this projection.
+ *
+ * @param {Object} options
+ * @param {String} options.dir Declared plane-state directory.
+ * @returns {Promise<Object>} `{status, epoch?, elected?, parked?, candidate?, collections?}`.
+ */
+export async function projectVectorGenerationHealth({dir} = {}) {
+    const state = await readVectorGenerationElection({dir});
+
+    if (state.status !== 'available') {
+        return {status: state.status}
+    }
+
+    const {record} = state;
+
+    return {
+        status     : record.status,
+        epoch      : record.epoch,
+        elected    : projectGeneration(record.elected),
+        parked     : projectGeneration(record.parked),
+        candidate  : projectGeneration(record.candidate),
+        collections: Object.fromEntries(VECTOR_PLANE_COLLECTION_KEYS.map(key => [key, {
+            validated : record.collections[key].receipt !== null,
+            promotedAt: record.collections[key].promotedAt,
+            unparkedAt: record.collections[key].unparkedAt
+        }]))
+    }
+}
+
+/**
+ * @summary Reads the record for a mutation and enforces the caller's epoch view.
+ * @param {Object} options
+ * @param {String} options.dir Declared plane-state directory.
+ * @param {Number} options.expectedEpoch The epoch the caller read.
+ * @param {String} options.label Error-message prefix.
+ * @returns {Promise<Object>} The live record (mutation-owned copy).
+ * @private
+ */
+async function requireRecord({dir, expectedEpoch, label}) {
+    const state = await readVectorGenerationElection({dir});
+
+    if (state.status === 'missing') {
+        throw new Error(`${label}: no election record exists; declare the baseline first`)
+    }
+
+    if (state.status === 'unavailable') {
+        throw new Error(`${label}: the election record exists but cannot be proven; refusing to mutate unprovable state`)
+    }
+
+    if (!Number.isInteger(expectedEpoch) || expectedEpoch !== state.record.epoch) {
+        throw new Error(`${label}: epoch moved (expected ${expectedEpoch}, live ${state.record.epoch}); re-read before mutating`)
+    }
+
+    return state.record
+}
+
+/**
+ * @summary Validates the persisted projection and writes it through the atomic primitive.
+ * @param {Object} options
+ * @param {String} options.filePath Canonical record path.
+ * @param {Object} options.record The mutated record.
+ * @param {Object} options.guard Held lifecycle guard.
+ * @param {String} options.label Error-message prefix.
+ * @returns {Promise<Object>} The persisted record.
+ * @private
+ */
+async function persistRecord({filePath, record, guard, label}) {
+    // Self-check before persisting: a state-machine bug must fail THIS call loudly, not surface
+    // later as an unprovable record that freezes every promote on the plane.
+    if (!isValidRecord(record)) {
+        throw new Error(`${label}: refusing to persist a record that fails its own schema validation`)
+    }
+
+    const json = `${JSON.stringify(record, null, 2)}\n`;
+
+    if (Buffer.byteLength(json, 'utf8') > ELECTION_MAX_BYTES) {
+        throw new Error(`${label}: record exceeds ${ELECTION_MAX_BYTES} bytes`)
+    }
+
+    if (!await verifyLifecycleGuardOwnership({ownerFilePath: guard.ownerFilePath, fsModule: fsExtra})) {
+        throw new Error(`${label}: mutation guard ownership was lost`)
+    }
+
+    await writeFileAtomic(filePath, json, {fsync: true});
+
+    return record
+}
+
+/**
+ * @summary Validates the closed record schema, per-status cross-field invariants, and derived-hash
+ * consistency (a hand-edited identity fails validation).
+ * @param {*} record Parsed JSON value.
+ * @returns {Boolean}
+ * @private
+ */
+function isValidRecord(record) {
+    if (!isExactObject(record, SAFE_RECORD_KEYS)) return false;
+    if (record.schemaVersion !== VECTOR_GENERATION_ELECTION_SCHEMA_VERSION) return false;
+    if (!Number.isInteger(record.epoch) || record.epoch <= 0) return false;
+    if (!VECTOR_ELECTION_STATUSES.includes(record.status)) return false;
+    if (!isCanonicalTimestamp(record.createdAt) || !isCanonicalTimestamp(record.updatedAt)) return false;
+    if (record.updatedAt < record.createdAt) return false;
+
+    const {status} = record;
+
+    if (!isValidGenerationEnvelope(record.elected)) return false;
+    if (!nullOr(record.candidate, isValidGenerationEnvelope) || (record.candidate !== null) !== (status === 'candidate')) return false;
+    if (!nullOr(record.parked, isValidGenerationEnvelope) || (record.parked !== null) !== (status === 'committed')) return false;
+    if (!nullOr(record.rolledBack, isValidGenerationEnvelope) || (record.rolledBack !== null) !== (status === 'rolled-back')) return false;
+    if (!nullOr(record.retired, isValidGenerationEnvelope)) return false;
+
+    if (!nullOr(record.committedAt, isCanonicalTimestamp) || (record.committedAt !== null) !== (status === 'committed' || status === 'accepted')) return false;
+    if (!nullOr(record.acceptedAt, isCanonicalTimestamp) || (record.acceptedAt !== null) !== (status === 'accepted')) return false;
+    if (!nullOr(record.rolledBackAt, isCanonicalTimestamp) || (record.rolledBackAt !== null) !== (status === 'rolled-back')) return false;
+    if (!nullOr(record.retiredAt, isCanonicalTimestamp) || (record.retiredAt !== null) !== (record.retired !== null)) return false;
+
+    if (!isExactObject(record.collections, VECTOR_PLANE_COLLECTION_KEYS)) return false;
+
+    for (const key of VECTOR_PLANE_COLLECTION_KEYS) {
+        const entry = record.collections[key];
+
+        if (!isExactObject(entry, SAFE_COLLECTION_KEYS)) return false;
+        if (!nullOr(entry.receipt, isValidReceipt)) return false;
+        if (!nullOr(entry.promotedAt, isCanonicalTimestamp)) return false;
+        if (!nullOr(entry.unparkedAt, isCanonicalTimestamp)) return false
+    }
+
+    return true
+}
+
+/**
+ * @summary Validates one generation envelope including recomputing both derived hashes.
+ * @param {*} envelope Candidate envelope.
+ * @returns {Boolean}
+ * @private
+ */
+function isValidGenerationEnvelope(envelope) {
+    if (!isExactObject(envelope, SAFE_GENERATION_KEYS)) return false;
+    if (!isCanonicalTimestamp(envelope.declaredAt)) return false;
+    if (!HASH_PATTERN.test(envelope.generationId) || !HASH_PATTERN.test(envelope.embeddingGenerationId)) return false;
+
+    const {coordinates} = envelope;
+
+    if (!isExactObject(coordinates, SAFE_COORDINATE_KEYS)) return false;
+
+    for (const key of SAFE_COORDINATE_KEYS) {
+        if (key === 'vectorDimension') continue;
+        const value = coordinates[key];
+        if (typeof value !== 'string' || value.length === 0 || value.length > MAX_HASH_INPUT_LENGTH) return false
+    }
+
+    if (!Number.isInteger(coordinates.vectorDimension) || coordinates.vectorDimension <= 0) return false;
+
+    let identity;
+
+    try {
+        identity = createVectorGenerationIdentity(coordinates)
+    } catch {
+        return false
+    }
+
+    return identity.generationId === envelope.generationId
+        && identity.embeddingGenerationId === envelope.embeddingGenerationId
+}
+
+/**
+ * @summary Validates one closed validation receipt.
+ * @param {*} receipt Candidate receipt.
+ * @returns {Boolean}
+ * @private
+ */
+function isValidReceipt(receipt) {
+    return isExactObject(receipt, SAFE_RECEIPT_KEYS)
+        && typeof receipt.candidateCollection === 'string'
+        && receipt.candidateCollection.length > 0
+        && receipt.candidateCollection.length <= MAX_HASH_INPUT_LENGTH
+        && Number.isInteger(receipt.rowCount)
+        && receipt.rowCount >= 0
+        && isCanonicalTimestamp(receipt.validatedAt)
+}
+
+/**
+ * @summary Normalizes and re-derives a caller identity into the persistable envelope.
+ * @param {*} identity Result of {@link createVectorGenerationIdentity} (or its exact shape).
+ * @param {String} declaredAt Canonical declaration timestamp.
+ * @param {String} label Error-message prefix.
+ * @returns {Object} Envelope with re-derived hashes — a tampered identity cannot enter the record.
+ * @private
+ */
+function toGenerationEnvelope(identity, declaredAt, label) {
+    if (identity === null || typeof identity !== 'object' || identity.coordinates === undefined) {
+        throw new TypeError(`${label}: identity must come from createVectorGenerationIdentity`)
+    }
+
+    const derived = createVectorGenerationIdentity(identity.coordinates);
+
+    return {
+        coordinates          : {...derived.coordinates},
+        declaredAt,
+        embeddingGenerationId: derived.embeddingGenerationId,
+        generationId         : derived.generationId
+    }
+}
+
+/**
+ * @summary Normalizes one incoming receipt into the exact persistable projection.
+ * @param {*} receipt Candidate receipt.
+ * @param {String} defaultValidatedAt Call-level timestamp.
+ * @returns {Object}
+ * @private
+ */
+function normalizeReceipt(receipt, defaultValidatedAt) {
+    const keys = receipt && typeof receipt === 'object' && !Array.isArray(receipt)
+        ? Object.keys(receipt).sort()
+        : [];
+
+    if (!sameKeys(keys, ['candidateCollection', 'rowCount']) && !sameKeys(keys, SAFE_RECEIPT_KEYS)) {
+        throw new TypeError('recordCandidateValidationReceipt: receipt must contain only candidateCollection, rowCount, and optional validatedAt')
+    }
+
+    const normalized = {
+        candidateCollection: receipt.candidateCollection,
+        rowCount           : receipt.rowCount,
+        validatedAt        : receipt.validatedAt === undefined
+            ? defaultValidatedAt
+            : normalizeTimestamp(receipt.validatedAt, 'recordCandidateValidationReceipt: receipt.validatedAt')
+    };
+
+    if (!isValidReceipt(normalized)) {
+        throw new TypeError('recordCandidateValidationReceipt: receipt failed validation (bounded string candidateCollection, non-negative integer rowCount)')
+    }
+
+    return normalized
+}
+
+/**
+ * @summary Projects one generation envelope for health surfaces.
+ * @param {Object|null} envelope Stored envelope.
+ * @returns {Object|null}
+ * @private
+ */
+function projectGeneration(envelope) {
+    return envelope === null ? null : {
+        generationId         : envelope.generationId,
+        embeddingGenerationId: envelope.embeddingGenerationId,
+        declaredAt           : envelope.declaredAt,
+        coordinates          : {...envelope.coordinates}
+    }
+}
+
+function emptyCollectionsState() {
+    return Object.fromEntries(VECTOR_PLANE_COLLECTION_KEYS.map(key => [key, {
+        receipt   : null,
+        promotedAt: null,
+        unparkedAt: null
+    }]))
+}
+
+function resetPromotesKeepReceipts(collections) {
+    return Object.fromEntries(VECTOR_PLANE_COLLECTION_KEYS.map(key => [key, {
+        receipt   : collections[key].receipt,
+        promotedAt: null,
+        unparkedAt: null
+    }]))
+}
+
+function everyCollection(record, predicate) {
+    return VECTOR_PLANE_COLLECTION_KEYS.every(key => predicate(record.collections[key]))
+}
+
+function assertCollectionKey(value, label) {
+    if (!VECTOR_PLANE_COLLECTION_KEYS.includes(value)) {
+        throw new TypeError(`${label}: collectionKey must be one of ${VECTOR_PLANE_COLLECTION_KEYS.join(', ')}`)
+    }
+}
+
+function assertHash(value, label) {
+    if (typeof value !== 'string' || !HASH_PATTERN.test(value)) {
+        throw new TypeError(`${label} must be a lowercase SHA-256 hex string`)
+    }
+}
+
+function assertHashInput(value, label) {
+    if (typeof value !== 'string' || value.length === 0 || value.length > MAX_HASH_INPUT_LENGTH) {
+        throw new TypeError(`${label} must be a non-empty string of at most ${MAX_HASH_INPUT_LENGTH} characters`)
+    }
+}
+
+function isCanonicalTimestamp(value) {
+    if (typeof value !== 'string') return false;
+
+    const time = Date.parse(value);
+
+    return Number.isFinite(time) && new Date(time).toISOString() === value
+}
+
+function isExactObject(value, expectedKeys) {
+    return value !== null
+        && typeof value === 'object'
+        && !Array.isArray(value)
+        && sameKeys(Object.keys(value).sort(), expectedKeys)
+}
+
+function normalizeTimestamp(value, label) {
+    const time = value instanceof Date ? value.getTime() : typeof value === 'string' ? Date.parse(value) : value;
+
+    if (!Number.isFinite(time)) {
+        throw new TypeError(`${label} must be a finite timestamp`)
+    }
+
+    return new Date(time).toISOString()
+}
+
+function nullOr(value, predicate) {
+    return value === null || predicate(value)
+}
+
+function sameKeys(actual, expected) {
+    return actual.length === expected.length && actual.every((key, index) => key === expected[index])
+}
+
+function serializeWrite(filePath, operation) {
+    const previous = writeQueues.get(filePath) || Promise.resolve();
+    const current  = previous.catch(() => {}).then(operation);
+
+    writeQueues.set(filePath, current);
+
+    return current.finally(() => {
+        if (writeQueues.get(filePath) === current) {
+            writeQueues.delete(filePath)
+        }
+    })
+}
+
+/**
+ * @summary Serializes one record mutation across async calls, processes, and container PID namespaces.
+ * @param {String} filePath Canonical record path.
+ * @param {Function} operation Guarded read-verify-mutate callback.
+ * @returns {Promise<*>}
+ * @private
+ */
+function serializeMutation(filePath, operation) {
+    return serializeWrite(filePath, async () => {
+        await fsExtra.ensureDir(path.dirname(filePath));
+
+        const guard = await enterLifecycleGuard({leasePath: filePath, fsModule: fsExtra});
+
+        if (!guard) {
+            throw new Error('generationElectionStore: mutation guard unavailable')
+        }
+
+        try {
+            return await operation(guard)
+        } finally {
+            await exitLifecycleGuard({ownerFilePath: guard.ownerFilePath, fsModule: fsExtra})
+        }
+    })
+}
+
+function sha256(value) {
+    return crypto.createHash('sha256').update(value).digest('hex')
+}

--- a/ai/services/shared/vector/generationElectionStore.mjs
+++ b/ai/services/shared/vector/generationElectionStore.mjs
@@ -209,6 +209,27 @@ export function getVectorGenerationElectionFilePath({dir} = {}) {
     return path.resolve(dir, ELECTION_FILE_NAME)
 }
 
+export const VECTOR_GENERATION_ELECTION_SUBDIR = 'vector-generation';
+
+/**
+ * @summary Resolves the shared election directory beneath the resolved plane data root.
+ *
+ * `plane.dataRoot` is the one anchor every KB/MC process of a plane already resolves — which is
+ * exactly the shared-mount invariant this record requires. Callers read their per-server config at
+ * the use site and pass the RESOLVED root; the subpath constant lives here so two entrypoints
+ * cannot drift it.
+ * @param {Object} options
+ * @param {String} options.planeDataRoot Resolved `plane.dataRoot` of the calling process.
+ * @returns {String} Absolute election directory.
+ */
+export function resolveVectorGenerationElectionDir({planeDataRoot} = {}) {
+    if (typeof planeDataRoot !== 'string' || planeDataRoot.length === 0) {
+        throw new TypeError('resolveVectorGenerationElectionDir: planeDataRoot is required')
+    }
+
+    return path.resolve(planeDataRoot, VECTOR_GENERATION_ELECTION_SUBDIR)
+}
+
 /**
  * @summary Reads and strictly validates the election record.
  *
@@ -456,7 +477,72 @@ export async function assertVectorPromoteAdmissible({dir, collectionKey, generat
         throw new Error(`assertVectorPromoteAdmissible: generation ${generationId.slice(0, 12)}… is not the elected generation at epoch ${record.epoch}`)
     }
 
-    return {mode: 'elected', epoch: record.epoch, generationId: record.elected.generationId}
+    return {mode: 'elected', epoch: record.epoch, generationId: record.elected.generationId, electionStatus: record.status}
+}
+
+/**
+ * @summary Captures the election view a writer builds against — taken BEFORE the build starts.
+ *
+ * The stale-writer fence compares this captured view to the live record at the promote moment, so
+ * a commit or rollback landing mid-build fences the writer out instead of letting content whose
+ * generation was decided under the old view advertise itself into the new one.
+ * @param {Object} options
+ * @param {String} options.dir Declared plane-state directory.
+ * @returns {Promise<Object>} `{mode: 'legacy'}` or `{mode: 'elected', generationId, epoch, electionStatus}`.
+ * @throws {Error} When a record exists but cannot be proven — a build must not start on unprovable state.
+ */
+export async function captureVectorPromoteView({dir} = {}) {
+    const state = await readVectorGenerationElection({dir});
+
+    if (state.status === 'missing') {
+        return {mode: 'legacy'}
+    }
+
+    if (state.status === 'unavailable') {
+        throw new Error('captureVectorPromoteView: the election record exists but cannot be proven; refusing to start a build on unprovable state')
+    }
+
+    const {record} = state;
+
+    return {mode: 'elected', generationId: record.elected.generationId, epoch: record.epoch, electionStatus: record.status}
+}
+
+/**
+ * @summary Validates a captured writer view at the promote moment — the seam-facing fence form.
+ *
+ * A legacy view stays admissible only while the plane still has no record; an election declared
+ * after the writer began refuses the promote, because the writer cannot prove which generation it
+ * built — the remediation is re-running the build against the elected view. An elected view
+ * delegates to {@link assertVectorPromoteAdmissible}.
+ * @param {Object} options
+ * @param {String} options.dir Declared plane-state directory.
+ * @param {String} options.collectionKey One of {@link VECTOR_PLANE_COLLECTION_KEYS}.
+ * @param {Object} options.view Result of {@link captureVectorPromoteView}.
+ * @returns {Promise<Object>} The admissible view, with `electionStatus` refreshed for elected mode.
+ * @throws {Error} When the writer is stale or the record is unprovable — the promote must not run.
+ */
+export async function assertCapturedPromoteView({dir, collectionKey, view} = {}) {
+    assertCollectionKey(collectionKey, 'assertCapturedPromoteView');
+
+    if (view === null || typeof view !== 'object' || (view.mode !== 'legacy' && view.mode !== 'elected')) {
+        throw new TypeError('assertCapturedPromoteView: view must come from captureVectorPromoteView')
+    }
+
+    if (view.mode === 'legacy') {
+        const state = await readVectorGenerationElection({dir});
+
+        if (state.status === 'missing') {
+            return {mode: 'legacy'}
+        }
+
+        if (state.status === 'unavailable') {
+            throw new Error('assertCapturedPromoteView: the election record exists but cannot be proven; refusing to promote on unprovable state')
+        }
+
+        throw new Error('assertCapturedPromoteView: an election was declared after this writer began; re-run the build against the elected view')
+    }
+
+    return await assertVectorPromoteAdmissible({dir, collectionKey, generationId: view.generationId, epoch: view.epoch})
 }
 
 /**

--- a/test/playwright/unit/ai/daemons/orchestrator/services/DeploymentStateBridgeService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/DeploymentStateBridgeService.spec.mjs
@@ -3043,7 +3043,10 @@ test.describe('classifyDirectProbeOutcome — a probe fault is not a service fau
         // Asserted ACROSS the two artifacts rather than as a magic number, so moving either one without
         // the other fails here instead of on a live plane.
         const compose = readFileSync(new URL('../../../../../../../ai/deploy/docker-compose.yml', import.meta.url), 'utf8'),
-              seconds = [...compose.matchAll(/mcpHealthcheck\.mjs[\s\S]{0,400}?timeout:\s*(\d+)s/g)].map(match => Number(match[1]));
+              // `timeout\s*:` — the block-alignment gate pads compose keys to the house style
+              // (`timeout     : 5s`), so any compose-touching commit re-aligns these blocks; the
+              // extraction must accept both the padded and unpadded forms.
+              seconds = [...compose.matchAll(/mcpHealthcheck\.mjs[\s\S]{0,400}?timeout\s*:\s*(\d+)s/g)].map(match => Number(match[1]));
 
         expect(seconds.length).toBeGreaterThan(0);   // the probe blocks were actually found
 

--- a/test/playwright/unit/ai/deploy/VectorGenerationElectionMount.spec.mjs
+++ b/test/playwright/unit/ai/deploy/VectorGenerationElectionMount.spec.mjs
@@ -1,0 +1,60 @@
+import {test, expect}     from '@playwright/test';
+import fs                 from 'node:fs';
+import path               from 'node:path';
+import {load as loadYaml} from 'js-yaml';
+import {
+    VECTOR_GENERATION_ELECTION_SUBDIR,
+    resolveVectorGenerationElectionDir
+} from '../../../../../ai/services/shared/vector/generationElectionStore.mjs';
+
+const repoRoot             = path.resolve(process.cwd());
+const composePath          = path.join(repoRoot, 'ai/deploy/docker-compose.yml');
+const VOLUME_NAME          = 'shared-vector-generation-data';
+const CONTAINER_PLANE_ROOT = '/app/.neo-ai-data';
+
+// Every service that produces or consumes the election record. A service on this list without the
+// shared mount gets its own container-local copy of the "singleton", and a split record inverts the
+// fence's legacy fail-safe into a bypass (one service sees `missing` while another declared an
+// election elsewhere).
+const ELECTION_SERVICES = ['kb-server', 'mc-server', 'orchestrator'];
+
+test.describe('the vector-generation election record is one physical mount (#17023)', () => {
+    const doc      = loadYaml(fs.readFileSync(composePath, 'utf8').replace(/!override\b/g, ''));
+    const services = doc.services || {};
+
+    test('the canonical profile declares the shared election volume', () => {
+        expect(Object.keys(doc.volumes || {}), 'top-level volumes must declare the election volume')
+            .toContain(VOLUME_NAME)
+    });
+
+    test('every election producer/consumer mounts the SAME volume at the SAME resolved path, writable', () => {
+        // The container-side target is tied to the store's own resolver, so a drift in EITHER the
+        // compose literal or the shared subpath constant fails here rather than splitting authority.
+        const expectedTarget = resolveVectorGenerationElectionDir({planeDataRoot: CONTAINER_PLANE_ROOT});
+
+        expect(expectedTarget).toBe(`${CONTAINER_PLANE_ROOT}/${VECTOR_GENERATION_ELECTION_SUBDIR}`);
+
+        for (const serviceKey of ELECTION_SERVICES) {
+            const mounts = (services[serviceKey]?.volumes || []).filter(entry =>
+                typeof entry === 'string' && entry.startsWith(`${VOLUME_NAME}:`));
+
+            expect(mounts, `${serviceKey} must mount ${VOLUME_NAME}`).toHaveLength(1);
+            expect(mounts[0], `${serviceKey} must mount the election volume at the resolved dir, writable`)
+                .toBe(`${VOLUME_NAME}:${expectedTarget}`)
+        }
+    });
+
+    test('no service mounts the election path from any OTHER source', () => {
+        for (const [serviceKey, service] of Object.entries(services)) {
+            for (const entry of service?.volumes || []) {
+                if (typeof entry !== 'string') continue;
+                const [source, target] = entry.split(':');
+
+                if (target === `${CONTAINER_PLANE_ROOT}/${VECTOR_GENERATION_ELECTION_SUBDIR}`) {
+                    expect(source, `${serviceKey} mounts the election dir from '${source}' — only ${VOLUME_NAME} may serve it`)
+                        .toBe(VOLUME_NAME)
+                }
+            }
+        }
+    })
+});

--- a/test/playwright/unit/ai/services/memory-core/helpers/restoreTargetSetStorage.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/helpers/restoreTargetSetStorage.spec.mjs
@@ -148,6 +148,82 @@ test.describe('restoreTargetSetStorage — fake Chroma + disposable SQLite targe
         expect(proof.reason).toContain('persisted graph differs from boot seed')
     });
 
+    test('an election landing during staging fences every vector promote of that attempt (#17035)', async () => {
+        const {
+            VECTOR_PLANE_COLLECTION_KEYS,
+            commitVectorGenerationElection,
+            createVectorGenerationIdentity,
+            declareBaselineVectorGeneration,
+            declareCandidateVectorGeneration,
+            recordCandidateValidationReceipt
+        } = await import('../../../../../../../ai/services/shared/vector/generationElectionStore.mjs');
+
+        const electionDir = path.join(fixture.root, 'election');
+        const identityFor = model => createVectorGenerationIdentity({
+            provider       : 'openAiCompatible',
+            model,
+            quantization   : 'q4_K_M',
+            vectorDimension: 8,
+            pooling        : 'last-token',
+            distance       : 'cosine',
+            strategyVersion: 'v1'
+        });
+
+        await declareBaselineVectorGeneration({
+            dir     : electionDir,
+            identity: identityFor('hf://fixture/G1@sha256:1111111111111111111111111111111111111111111111111111111111111111')
+        });
+
+        const
+            storage = createRestoreTargetSetStorage({
+                chromaClient          : fixture.client,
+                dummyEmbeddingFunction: fixture.dummyEmbeddingFunction,
+                graphDb               : fixture.graphDb,
+                expectedDestinations  : fixture.destinations,
+                stagingRoot           : fixture.stagingRoot,
+                electionDir
+            }),
+            identity = deriveRestoreTargetSetIdentity(fixture.targetSet),
+            context  = {
+                targetSet : fixture.targetSet,
+                descriptor: identity.descriptor,
+                ...identity
+            };
+
+        // A promote before any staging refuses loudly — the view must exist for the attempt.
+        await expect(storage.promoteComponent({...context, role: 'memories'}))
+            .rejects.toThrow(/stage before promoting/);
+
+        // Staging captures the attempt's election view (elected G1 at epoch 1).
+        const staging = await storage.stageTargetSet(context);
+        await storage.validateStagedTargetSet({...context, staging});
+
+        // An election commits WHILE the attempt is between staging and promotion.
+        await declareCandidateVectorGeneration({
+            dir          : electionDir,
+            identity     : identityFor('hf://fixture/G2@sha256:2222222222222222222222222222222222222222222222222222222222222222'),
+            expectedEpoch: 1
+        });
+        for (const key of VECTOR_PLANE_COLLECTION_KEYS) {
+            await recordCandidateValidationReceipt({
+                dir          : electionDir, collectionKey: key,
+                receipt      : {candidateCollection: `shadow-${key}`, rowCount: 1},
+                expectedEpoch: 1
+            })
+        }
+        await commitVectorGenerationElection({
+            dir    : electionDir, expectedEpoch: 1,
+            quiesce: {scope: 'staging-race-window', boundMs: 60 * 60 * 1000}
+        });
+
+        // The attempt's staged content was built under the pre-election view: every vector-role
+        // promote is fenced as stale, and the graph promote (outside the vector election) is not.
+        await expect(storage.promoteComponent({...context, staging, role: 'memories'}))
+            .rejects.toThrow(/stale writer fenced/);
+        await expect(storage.promoteComponent({...context, staging, role: 'summaries'}))
+            .rejects.toThrow(/stale writer fenced/)
+    });
+
     test('detects a live component that advanced without its strict transition', async () => {
         const
             storage  = createStorage(fixture),

--- a/test/playwright/unit/ai/services/shared/vector/electionGatedPromote.spec.mjs
+++ b/test/playwright/unit/ai/services/shared/vector/electionGatedPromote.spec.mjs
@@ -4,6 +4,7 @@ import os             from 'node:os';
 import path           from 'node:path';
 import {
     promoteCollectionUnderElection,
+    reconcileInterruptedPromote,
     unparkCollectionUnderElection
 } from '../../../../../../../ai/services/shared/vector/electionGatedPromote.mjs';
 import {
@@ -251,6 +252,94 @@ test.describe('electionGatedPromote — the physical halt/crash matrix (#17023)'
         expect(result.completionRecorded).toBe(false);
         expect(client.readMarker(canonicalName('kb.unified'))).toBe('G2');
         expect((await readVectorGenerationElection({dir})).status).toBe('missing')
+    });
+
+    test('an expiry between the two renames refuses at the second fence and restores the canonical name', async () => {
+        await commitTransition(dir);
+
+        const view = await captureVectorPromoteView({dir});
+        // Stepping clock: the first fence reads inside the window, the second reads beyond it —
+        // the exact interruption class no single-timestamp check can observe.
+        let   calls = 0;
+        const clock = () => (calls++ === 0 ? T2 : AFTER_CLOSE);
+
+        await expect(promoteCollectionUnderElection(promoteArgs(client, dir, 'kb.unified', view, clock)))
+            .rejects.toThrow(/outside the declared quiesce window/);
+
+        // The first rename happened and was rolled back: canonical serves G1, no parking residue.
+        expect(client.readMarker(canonicalName('kb.unified'))).toBe('G1');
+        expect(await client.getCollection('parking-kb.unified')).toBeNull()
+    });
+
+    test('reconcile resumes a promote killed between its renames — or restores the prior when the candidate is gone', async () => {
+        await commitTransition(dir);
+
+        const view = await captureVectorPromoteView({dir});
+
+        // Manufacture the SIGKILL state: the first rename ran (canonical → parking), the process
+        // died before the second — no in-process finally ever saw it.
+        const live = await client.getCollection(canonicalName('kb.unified'));
+        await live.modify({name: 'parking-kb.unified'});
+        expect(client.readMarker(canonicalName('kb.unified'))).toBeNull();
+
+        // A blind promote retry refuses and names the remediation.
+        await expect(promoteCollectionUnderElection(promoteArgs(client, dir, 'kb.unified', view, T2)))
+            .rejects.toThrow(/run reconcileInterruptedPromote/);
+
+        // The reconcile completes the interrupted second rename under the fence.
+        const resumed = await reconcileInterruptedPromote({
+            getCollection: client.getCollection,
+            canonicalName: canonicalName('kb.unified'),
+            shadowName   : 'shadow-kb.unified',
+            parkingName  : 'parking-kb.unified',
+            dir,
+            collectionKey: 'kb.unified',
+            view,
+            now          : T2
+        });
+
+        expect(resumed.status).toBe('resumed-promote');
+        expect(resumed.completionRecorded).toBe(true);
+        expect(client.readMarker(canonicalName('kb.unified'))).toBe('G2');
+
+        // Second flavor on another collection: the interrupted state with the CANDIDATE gone —
+        // reconcile restores the prior corpus and reports nothing (transition stays incomplete).
+        const live2 = await client.getCollection(canonicalName('mc.memory'));
+        await live2.modify({name: 'parking-mc.memory'});
+        const deadShadow = await client.getCollection('shadow-mc.memory');
+        await deadShadow.modify({name: 'discarded-mc.memory'});
+
+        const restored = await reconcileInterruptedPromote({
+            getCollection: client.getCollection,
+            canonicalName: canonicalName('mc.memory'),
+            shadowName   : 'shadow-mc.memory',
+            parkingName  : 'parking-mc.memory',
+            dir,
+            collectionKey: 'mc.memory',
+            view,
+            now          : T2
+        });
+
+        expect(restored.status).toBe('restored-prior');
+        expect(restored.completionRecorded).toBe(false);
+        expect(client.readMarker(canonicalName('mc.memory'))).toBe('G1');
+
+        // Clean state is a no-op; a name with no source anywhere is loud.
+        expect((await reconcileInterruptedPromote({
+            getCollection: client.getCollection,
+            canonicalName: canonicalName('mc.session'),
+            shadowName   : 'shadow-mc.session',
+            parkingName  : 'parking-mc.session',
+            dir, collectionKey: 'mc.session', view, now: T2
+        })).status).toBe('clean');
+
+        await expect(reconcileInterruptedPromote({
+            getCollection: client.getCollection,
+            canonicalName: 'canonical-ghost',
+            shadowName   : 'shadow-ghost',
+            parkingName  : 'parking-ghost',
+            dir, collectionKey: 'mc.graph', view, now: T2
+        })).rejects.toThrow(/unrecoverable from names alone/)
     });
 
     test('preconditions refuse before any rename', async () => {

--- a/test/playwright/unit/ai/services/shared/vector/electionGatedPromote.spec.mjs
+++ b/test/playwright/unit/ai/services/shared/vector/electionGatedPromote.spec.mjs
@@ -1,0 +1,275 @@
+import {test, expect} from '@playwright/test';
+import fs             from 'node:fs/promises';
+import os             from 'node:os';
+import path           from 'node:path';
+import {
+    promoteCollectionUnderElection,
+    unparkCollectionUnderElection
+} from '../../../../../../../ai/services/shared/vector/electionGatedPromote.mjs';
+import {
+    VECTOR_PLANE_COLLECTION_KEYS,
+    acceptVectorGenerationElection,
+    captureVectorPromoteView,
+    commitVectorGenerationElection,
+    createVectorGenerationIdentity,
+    declareBaselineVectorGeneration,
+    declareCandidateVectorGeneration,
+    readVectorGenerationElection,
+    recordCandidateValidationReceipt,
+    recordUnparkCompletion,
+    rollbackVectorGenerationElection
+} from '../../../../../../../ai/services/shared/vector/generationElectionStore.mjs';
+
+const T0 = new Date('2026-08-12T12:00:00.000Z');
+const T1 = new Date('2026-08-12T12:05:00.000Z');
+const T2 = new Date('2026-08-12T12:10:00.000Z');
+
+const QUIESCE     = Object.freeze({scope: 'physical-matrix-quiesce', boundMs: 60 * 60 * 1000});
+const AFTER_CLOSE = new Date(T2.getTime() + 2 * 60 * 60 * 1000);
+
+const DIGEST_MODEL_G1 = 'hf://fixture/G1@sha256:1111111111111111111111111111111111111111111111111111111111111111';
+const DIGEST_MODEL_G2 = 'hf://fixture/G2@sha256:2222222222222222222222222222222222222222222222222222222222222222';
+
+function identityFor(model) {
+    return createVectorGenerationIdentity({
+        provider       : 'openAiCompatible',
+        model,
+        quantization   : 'q4_K_M',
+        vectorDimension: 8,
+        pooling        : 'last-token',
+        distance       : 'cosine',
+        strategyVersion: 'v1'
+    })
+}
+
+/**
+ * Minimal name-resolving Chroma-shaped client: collections live in one name→object map and
+ * `modify({name})` performs a REAL rename, so reading a canonical NAME after each transition step
+ * observes exactly what a production reader resolving that name would observe.
+ */
+function createFakeChromaClient() {
+    const collections = new Map();
+
+    async function createCollection({name, marker}) {
+        if (collections.has(name)) {
+            throw new Error(`collection '${name}' already exists`)
+        }
+
+        const collection = {
+            marker,
+            async modify({name: nextName}) {
+                if (collections.has(nextName)) {
+                    throw new Error(`collection '${nextName}' already exists`)
+                }
+
+                for (const [key, value] of collections.entries()) {
+                    if (value === collection) {
+                        collections.delete(key)
+                    }
+                }
+
+                collections.set(nextName, collection)
+            }
+        };
+
+        collections.set(name, collection);
+        return collection
+    }
+
+    return {
+        createCollection,
+        getCollection: async name => collections.get(name) ?? null,
+        readMarker   : name => collections.get(name)?.marker ?? null,
+        names        : () => [...collections.keys()].sort()
+    }
+}
+
+function canonicalName(key) {
+    return `canonical-${key}`
+}
+
+/** Reads the generation marker every reader would observe at each canonical name. */
+function readPlane(client) {
+    return Object.fromEntries(VECTOR_PLANE_COLLECTION_KEYS.map(key => [key, client.readMarker(canonicalName(key))]))
+}
+
+async function seedPlane(client) {
+    for (const key of VECTOR_PLANE_COLLECTION_KEYS) {
+        await client.createCollection({name: canonicalName(key), marker: 'G1'});
+        await client.createCollection({name: `shadow-${key}`, marker: 'G2'})
+    }
+}
+
+async function commitTransition(dir) {
+    const g1 = identityFor(DIGEST_MODEL_G1);
+    const g2 = identityFor(DIGEST_MODEL_G2);
+
+    await declareBaselineVectorGeneration({dir, identity: g1, now: T0});
+    await declareCandidateVectorGeneration({dir, identity: g2, expectedEpoch: 1, now: T1});
+
+    for (const key of VECTOR_PLANE_COLLECTION_KEYS) {
+        await recordCandidateValidationReceipt({
+            dir, collectionKey: key,
+            receipt      : {candidateCollection: `shadow-${key}`, rowCount: 1},
+            expectedEpoch: 1, now: T1
+        })
+    }
+
+    await commitVectorGenerationElection({dir, expectedEpoch: 1, quiesce: QUIESCE, now: T2});
+    return {g1, g2}
+}
+
+function promoteArgs(client, dir, key, view, now) {
+    return {
+        getCollection: client.getCollection,
+        canonicalName: canonicalName(key),
+        shadowName   : `shadow-${key}`,
+        parkingName  : `parking-${key}`,
+        dir,
+        collectionKey: key,
+        view,
+        now
+    }
+}
+
+test.describe('electionGatedPromote — the physical halt/crash matrix (#17023)', () => {
+    let dir, client;
+
+    test.beforeEach(async () => {
+        dir    = await fs.mkdtemp(path.join(os.tmpdir(), 'election-gated-promote-'));
+        client = createFakeChromaClient();
+        await seedPlane(client)
+    });
+
+    test.afterEach(async () => {
+        await fs.rm(dir, {recursive: true, force: true})
+    });
+
+    test('halted mid-transition, every canonical name reads exactly the declared mixed set — bounded, refused outside the window, rollback-covered, and fully restored', async () => {
+        await commitTransition(dir);
+
+        const view = await captureVectorPromoteView({dir});
+
+        // Step 0 — committed, zero renames: every reader still resolves G1.
+        expect(readPlane(client)).toEqual(Object.fromEntries(VECTOR_PLANE_COLLECTION_KEYS.map(key => [key, 'G1'])));
+
+        // Steps 1+2 — promote two collections inside the window, then HALT (simulated crash: no
+        // further calls). Read every physical canonical name.
+        await promoteCollectionUnderElection(promoteArgs(client, dir, 'kb.unified', view, T2));
+        await promoteCollectionUnderElection(promoteArgs(client, dir, 'mc.memory', view, T2));
+
+        expect(readPlane(client)).toEqual({
+            'kb.unified'        : 'G2',
+            'mc.memory'         : 'G2',
+            'mc.graph'          : 'G1',
+            'mc.session'        : 'G1',
+            'mc.temporalSummary': 'G1'
+        });
+
+        // The halted state cannot be accepted (partial promotion) and stays rollback-covered.
+        await expect(acceptVectorGenerationElection({dir, expectedEpoch: 2, now: T2}))
+            .rejects.toThrow(/without a completed promote/);
+        expect((await readVectorGenerationElection({dir})).record.parked).not.toBeNull();
+
+        // The mixed interval cannot GROW outside the declared window: the next promote refuses.
+        await expect(promoteCollectionUnderElection(promoteArgs(client, dir, 'mc.session', view, AFTER_CLOSE)))
+            .rejects.toThrow(/outside the declared quiesce window/);
+        expect(client.readMarker(canonicalName('mc.session'))).toBe('G1');
+
+        // Rollback under its own declared window re-elects G1 and fences the abandoned generation.
+        await rollbackVectorGenerationElection({
+            dir, expectedEpoch: 2,
+            quiesce: {scope: 'rollback-window', boundMs: QUIESCE.boundMs, startedAt: AFTER_CLOSE},
+            now    : AFTER_CLOSE
+        });
+
+        const rollbackView = await captureVectorPromoteView({dir});
+
+        // A promote of the abandoned generation's shadow refuses at the fence.
+        await expect(promoteCollectionUnderElection(promoteArgs(client, dir, 'mc.session', view, AFTER_CLOSE)))
+            .rejects.toThrow(/stale writer fenced/);
+
+        // Un-park the two promoted collections; the abandoned G2 canonicals move aside first.
+        for (const key of ['kb.unified', 'mc.memory']) {
+            const result = await unparkCollectionUnderElection({
+                getCollection: client.getCollection,
+                canonicalName: canonicalName(key),
+                parkingName  : `parking-${key}`,
+                abandonedName: `abandoned-${key}`,
+                dir,
+                collectionKey: key,
+                view         : rollbackView,
+                now          : AFTER_CLOSE
+            });
+
+            expect(result.movedAbandonedTo).toBe(`abandoned-${key}`);
+            expect(result.completionRecorded).toBe(true)
+        }
+
+        // Never-promoted collections have nothing to un-park; the runner records them directly.
+        for (const key of ['mc.graph', 'mc.session', 'mc.temporalSummary']) {
+            await recordUnparkCompletion({dir, collectionKey: key, expectedEpoch: 3, now: AFTER_CLOSE})
+        }
+
+        // Every physical canonical name reads G1 again — the FULL prior set, by observation.
+        expect(readPlane(client)).toEqual(Object.fromEntries(VECTOR_PLANE_COLLECTION_KEYS.map(key => [key, 'G1'])));
+
+        // And the plane can move on: the next candidate is declarable only now.
+        const g3 = identityFor('hf://fixture/G3@sha256:3333333333333333333333333333333333333333333333333333333333333333');
+        await expect(declareCandidateVectorGeneration({dir, identity: g3, expectedEpoch: 3, now: AFTER_CLOSE}))
+            .resolves.toMatchObject({status: 'candidate'})
+    });
+
+    test('a crash between the two renames restores the canonical name before rethrowing', async () => {
+        await commitTransition(dir);
+
+        const view   = await captureVectorPromoteView({dir});
+        const shadow = await client.getCollection('shadow-kb.unified');
+        const modify = shadow.modify.bind(shadow);
+
+        shadow.modify = async () => {
+            throw new Error('simulated crash between renames')
+        };
+
+        await expect(promoteCollectionUnderElection(promoteArgs(client, dir, 'kb.unified', view, T2)))
+            .rejects.toThrow(/simulated crash/);
+
+        // The canonical name is served again (G1), no parking residue blocks a retry.
+        expect(client.readMarker(canonicalName('kb.unified'))).toBe('G1');
+        expect(await client.getCollection('parking-kb.unified')).toBeNull();
+
+        shadow.modify = modify;
+        await promoteCollectionUnderElection(promoteArgs(client, dir, 'kb.unified', view, T2));
+        expect(client.readMarker(canonicalName('kb.unified'))).toBe('G2')
+    });
+
+    test('a legacy plane promotes ungated and records nothing', async () => {
+        const view   = await captureVectorPromoteView({dir});
+        const result = await promoteCollectionUnderElection(promoteArgs(client, dir, 'kb.unified', view, T0));
+
+        expect(result.admission).toEqual({mode: 'legacy'});
+        expect(result.completionRecorded).toBe(false);
+        expect(client.readMarker(canonicalName('kb.unified'))).toBe('G2');
+        expect((await readVectorGenerationElection({dir})).status).toBe('missing')
+    });
+
+    test('preconditions refuse before any rename', async () => {
+        await commitTransition(dir);
+        const view = await captureVectorPromoteView({dir});
+
+        await client.createCollection({name: 'parking-mc.graph', marker: 'stale'});
+        await expect(promoteCollectionUnderElection(promoteArgs(client, dir, 'mc.graph', view, T2)))
+            .rejects.toThrow(/parking collection 'parking-mc.graph' already exists/);
+        expect(client.readMarker(canonicalName('mc.graph'))).toBe('G1');
+
+        await expect(unparkCollectionUnderElection({
+            getCollection: client.getCollection,
+            canonicalName: canonicalName('mc.session'),
+            parkingName  : 'parking-mc.session',
+            dir,
+            collectionKey: 'mc.session',
+            view,
+            now          : T2
+        })).rejects.toThrow(/nothing to restore/)
+    })
+});

--- a/test/playwright/unit/ai/services/shared/vector/generationElectionStore.spec.mjs
+++ b/test/playwright/unit/ai/services/shared/vector/generationElectionStore.spec.mjs
@@ -4,9 +4,12 @@ import os             from 'node:os';
 import path           from 'node:path';
 import {
     VECTOR_GENERATION_ELECTION_SCHEMA_VERSION,
+    VECTOR_GENERATION_ELECTION_SUBDIR,
     VECTOR_PLANE_COLLECTION_KEYS,
     acceptVectorGenerationElection,
+    assertCapturedPromoteView,
     assertVectorPromoteAdmissible,
+    captureVectorPromoteView,
     commitVectorGenerationElection,
     createEmbeddingGenerationId,
     createVectorGenerationIdentity,
@@ -15,6 +18,7 @@ import {
     getVectorGenerationElectionFilePath,
     projectVectorGenerationHealth,
     readVectorGenerationElection,
+    resolveVectorGenerationElectionDir,
     recordCandidateValidationReceipt,
     recordPromoteCompletion,
     recordUnparkCompletion,
@@ -389,6 +393,54 @@ test.describe('generationElectionStore — one durable authority for vector-plan
             const raw = JSON.parse(await fs.readFile(getVectorGenerationElectionFilePath({dir}), 'utf8'));
             expect(raw.schemaVersion).toBe(VECTOR_GENERATION_ELECTION_SCHEMA_VERSION);
             expect(Object.keys(raw.collections).sort()).toEqual([...VECTOR_PLANE_COLLECTION_KEYS].sort())
+        })
+    });
+
+    test.describe('the seam-facing captured view', () => {
+        test('the election dir resolves beneath the plane data root with the shared subpath', () => {
+            expect(resolveVectorGenerationElectionDir({planeDataRoot: '/plane'}))
+                .toBe(path.resolve('/plane', VECTOR_GENERATION_ELECTION_SUBDIR));
+            expect(() => resolveVectorGenerationElectionDir({})).toThrow(/planeDataRoot/)
+        });
+
+        test('a legacy view stays admissible only while the plane still has no record', async () => {
+            const view = await captureVectorPromoteView({dir});
+
+            expect(view).toEqual({mode: 'legacy'});
+            await expect(assertCapturedPromoteView({dir, collectionKey: 'kb.unified', view}))
+                .resolves.toEqual({mode: 'legacy'});
+
+            await declareBaselineVectorGeneration({dir, identity: base, now: T0});
+            await expect(assertCapturedPromoteView({dir, collectionKey: 'kb.unified', view}))
+                .rejects.toThrow(/declared after this writer began/)
+        });
+
+        test('an elected view delegates to the fence and goes stale the moment a transition commits', async () => {
+            await declareBaselineVectorGeneration({dir, identity: base, now: T0});
+
+            const view = await captureVectorPromoteView({dir});
+
+            expect(view).toMatchObject({mode: 'elected', generationId: base.generationId, epoch: 1, electionStatus: 'accepted'});
+            await expect(assertCapturedPromoteView({dir, collectionKey: 'mc.memory', view}))
+                .resolves.toMatchObject({mode: 'elected', epoch: 1, electionStatus: 'accepted'});
+
+            await declareCandidateVectorGeneration({dir, identity: next, expectedEpoch: 1, now: T1});
+            for (const key of VECTOR_PLANE_COLLECTION_KEYS) {
+                await recordCandidateValidationReceipt({dir, collectionKey: key, receipt: receiptFor(key), expectedEpoch: 1, now: T1})
+            }
+            await commitVectorGenerationElection({dir, expectedEpoch: 1, now: T2});
+
+            await expect(assertCapturedPromoteView({dir, collectionKey: 'mc.memory', view}))
+                .rejects.toThrow(/stale writer fenced/)
+        });
+
+        test('capture refuses to start a build on an unprovable record', async () => {
+            await declareBaselineVectorGeneration({dir, identity: base, now: T0});
+            await fs.writeFile(getVectorGenerationElectionFilePath({dir}), '{broken');
+
+            await expect(captureVectorPromoteView({dir})).rejects.toThrow(/unprovable/);
+            await expect(assertCapturedPromoteView({dir, collectionKey: 'kb.unified', view: {mode: 'legacy'}}))
+                .rejects.toThrow(/unprovable/)
         })
     })
 });

--- a/test/playwright/unit/ai/services/shared/vector/generationElectionStore.spec.mjs
+++ b/test/playwright/unit/ai/services/shared/vector/generationElectionStore.spec.mjs
@@ -1,0 +1,394 @@
+import {test, expect} from '@playwright/test';
+import fs             from 'node:fs/promises';
+import os             from 'node:os';
+import path           from 'node:path';
+import {
+    VECTOR_GENERATION_ELECTION_SCHEMA_VERSION,
+    VECTOR_PLANE_COLLECTION_KEYS,
+    acceptVectorGenerationElection,
+    assertVectorPromoteAdmissible,
+    commitVectorGenerationElection,
+    createEmbeddingGenerationId,
+    createVectorGenerationIdentity,
+    declareBaselineVectorGeneration,
+    declareCandidateVectorGeneration,
+    getVectorGenerationElectionFilePath,
+    projectVectorGenerationHealth,
+    readVectorGenerationElection,
+    recordCandidateValidationReceipt,
+    recordPromoteCompletion,
+    recordUnparkCompletion,
+    rollbackVectorGenerationElection
+} from '../../../../../../../ai/services/shared/vector/generationElectionStore.mjs';
+import {createEmbeddingGenerationId as poisonStoreGenerationId}
+    from '../../../../../../../ai/services/knowledge-base/helpers/kbEmbeddingPoisonStore.mjs';
+
+const T0 = new Date('2026-08-12T12:00:00.000Z');
+const T1 = new Date('2026-08-12T12:05:00.000Z');
+const T2 = new Date('2026-08-12T12:10:00.000Z');
+
+function coordinates(overrides = {}) {
+    return {
+        provider       : 'ollama',
+        model          : 'qwen3-embedding:8b',
+        quantization   : 'q4_K_M',
+        vectorDimension: 4096,
+        pooling        : 'last-token',
+        distance       : 'cosine',
+        strategyVersion: 'v1',
+        ...overrides
+    }
+}
+
+function receiptFor(key) {
+    return {candidateCollection: `shadow-${key}`, rowCount: 104000}
+}
+
+async function makeDir() {
+    return await fs.mkdtemp(path.join(os.tmpdir(), 'generation-election-'))
+}
+
+/**
+ * Drives a fresh plane to a committed election of `next` over a baseline of `base`.
+ * Returns the committed record (epoch 2, status 'committed').
+ */
+async function commitTransition(dir, base, next) {
+    await declareBaselineVectorGeneration({dir, identity: base, now: T0});
+    await declareCandidateVectorGeneration({dir, identity: next, expectedEpoch: 1, now: T1});
+
+    for (const key of VECTOR_PLANE_COLLECTION_KEYS) {
+        await recordCandidateValidationReceipt({dir, collectionKey: key, receipt: receiptFor(key), expectedEpoch: 1, now: T1})
+    }
+
+    return await commitVectorGenerationElection({dir, expectedEpoch: 1, now: T2})
+}
+
+test.describe('generationElectionStore — one durable authority for vector-plane generation visibility', () => {
+    let dir, base, next;
+
+    test.beforeEach(async () => {
+        dir  = await makeDir();
+        base = createVectorGenerationIdentity(coordinates());
+        next = createVectorGenerationIdentity(coordinates({provider: 'openAiCompatible', quantization: 'none'}))
+    });
+
+    test.afterEach(async () => {
+        await fs.rm(dir, {recursive: true, force: true})
+    });
+
+    test.describe('generation identity', () => {
+        test('the same coordinate tuple always yields the same ids; any coordinate change yields a new generation', () => {
+            const again = createVectorGenerationIdentity(coordinates());
+
+            expect(again.generationId).toBe(base.generationId);
+            expect(again.embeddingGenerationId).toBe(base.embeddingGenerationId);
+
+            for (const [key, value] of Object.entries({
+                provider       : 'openAiCompatible',
+                model          : 'other-model:1b',
+                quantization   : 'q8_0',
+                vectorDimension: 1024,
+                pooling        : 'mean',
+                distance       : 'l2',
+                strategyVersion: 'v2'
+            })) {
+                const changed = createVectorGenerationIdentity(coordinates({[key]: value}));
+                expect(changed.generationId, `changing ${key} must produce a new generation`).not.toBe(base.generationId)
+            }
+        });
+
+        test('the embedding join key is one id-space with the poison store re-export', () => {
+            const tuple = {provider: 'ollama', model: 'qwen3-embedding:8b', vectorDimension: 4096, strategyVersion: 'v1'};
+
+            expect(createEmbeddingGenerationId(tuple)).toBe(poisonStoreGenerationId(tuple));
+            expect(base.embeddingGenerationId).toBe(poisonStoreGenerationId(tuple))
+        });
+
+        test('incomplete or invalid coordinates are refused', () => {
+            expect(() => createVectorGenerationIdentity(coordinates({pooling: ''}))).toThrow(/pooling/);
+            expect(() => createVectorGenerationIdentity(coordinates({vectorDimension: 0}))).toThrow(/vectorDimension/);
+            expect(() => createVectorGenerationIdentity({provider: 'ollama'})).toThrow()
+        })
+    });
+
+    test.describe('fail-safe polarity', () => {
+        test('a plane with no record grandfathers promotes in declared legacy mode', async () => {
+            await expect(assertVectorPromoteAdmissible({
+                dir, collectionKey: 'kb.unified', generationId: base.generationId, epoch: 1
+            })).resolves.toEqual({mode: 'legacy'})
+        });
+
+        test('a corrupt record refuses every promote while reads report unavailable', async () => {
+            await declareBaselineVectorGeneration({dir, identity: base, now: T0});
+            await fs.writeFile(getVectorGenerationElectionFilePath({dir}), '{not json');
+
+            expect((await readVectorGenerationElection({dir})).status).toBe('unavailable');
+            expect((await projectVectorGenerationHealth({dir})).status).toBe('unavailable');
+
+            for (const key of VECTOR_PLANE_COLLECTION_KEYS) {
+                await expect(assertVectorPromoteAdmissible({
+                    dir, collectionKey: key, generationId: base.generationId, epoch: 1
+                })).rejects.toThrow(/unprovable/)
+            }
+        });
+
+        test('a hand-edited identity fails the derived-hash consistency check and reads as unavailable', async () => {
+            await declareBaselineVectorGeneration({dir, identity: base, now: T0});
+
+            const filePath = getVectorGenerationElectionFilePath({dir});
+            const record   = JSON.parse(await fs.readFile(filePath, 'utf8'));
+
+            record.elected.coordinates.model = 'tampered-model';
+            await fs.writeFile(filePath, JSON.stringify(record, null, 2));
+
+            expect((await readVectorGenerationElection({dir})).status).toBe('unavailable')
+        });
+
+        test('baseline declaration refuses to overwrite ANY existing record, including a corrupt one', async () => {
+            await declareBaselineVectorGeneration({dir, identity: base, now: T0});
+            await expect(declareBaselineVectorGeneration({dir, identity: next, now: T1}))
+                .rejects.toThrow(/already exists/);
+
+            await fs.writeFile(getVectorGenerationElectionFilePath({dir}), '{broken');
+            await expect(declareBaselineVectorGeneration({dir, identity: next, now: T1}))
+                .rejects.toThrow(/already exists/)
+        })
+    });
+
+    test.describe('the election lifecycle', () => {
+        test('baseline records reality at epoch 1, already accepted', async () => {
+            const record = await declareBaselineVectorGeneration({dir, identity: base, now: T0});
+
+            expect(record).toMatchObject({
+                schemaVersion: VECTOR_GENERATION_ELECTION_SCHEMA_VERSION,
+                epoch        : 1,
+                status       : 'accepted',
+                parked       : null,
+                candidate    : null,
+                retired      : null
+            });
+            expect(record.elected.generationId).toBe(base.generationId)
+        });
+
+        test('a no-op candidate equal to the elected generation is refused as a caller bug', async () => {
+            await declareBaselineVectorGeneration({dir, identity: base, now: T0});
+            await expect(declareCandidateVectorGeneration({dir, identity: base, expectedEpoch: 1, now: T1}))
+                .rejects.toThrow(/no-op election/)
+        });
+
+        test('commit refuses until EVERY census collection carries a validation receipt', async () => {
+            await declareBaselineVectorGeneration({dir, identity: base, now: T0});
+            await declareCandidateVectorGeneration({dir, identity: next, expectedEpoch: 1, now: T1});
+
+            for (const key of VECTOR_PLANE_COLLECTION_KEYS.slice(0, -1)) {
+                await recordCandidateValidationReceipt({dir, collectionKey: key, receipt: receiptFor(key), expectedEpoch: 1, now: T1})
+            }
+
+            const missing = VECTOR_PLANE_COLLECTION_KEYS.at(-1);
+            await expect(commitVectorGenerationElection({dir, expectedEpoch: 1, now: T2}))
+                .rejects.toThrow(new RegExp(missing.replace('.', '\\.')))
+        });
+
+        test('a receipt with unknown keys or an unknown collection is refused', async () => {
+            await declareBaselineVectorGeneration({dir, identity: base, now: T0});
+            await declareCandidateVectorGeneration({dir, identity: next, expectedEpoch: 1, now: T1});
+
+            await expect(recordCandidateValidationReceipt({
+                dir, collectionKey: 'kb.unified',
+                receipt      : {candidateCollection: 'x', rowCount: 1, extra: true},
+                expectedEpoch: 1, now: T1
+            })).rejects.toThrow(/only candidateCollection, rowCount/);
+
+            await expect(recordCandidateValidationReceipt({
+                dir, collectionKey: 'kb.wrong', receipt: receiptFor('kb.wrong'), expectedEpoch: 1, now: T1
+            })).rejects.toThrow(/collectionKey/)
+        });
+
+        test('commit parks the prior generation, elects the candidate, and bumps the epoch', async () => {
+            const record = await commitTransition(dir, base, next);
+
+            expect(record).toMatchObject({epoch: 2, status: 'committed', candidate: null});
+            expect(record.elected.generationId).toBe(next.generationId);
+            expect(record.parked.generationId).toBe(base.generationId);
+
+            for (const key of VECTOR_PLANE_COLLECTION_KEYS) {
+                expect(record.collections[key].receipt).not.toBeNull();
+                expect(record.collections[key].promotedAt).toBeNull()
+            }
+        });
+
+        test('acceptance refuses until every collection reports its promote, then retires the parked set', async () => {
+            await commitTransition(dir, base, next);
+
+            await recordPromoteCompletion({dir, collectionKey: 'kb.unified', expectedEpoch: 2, now: T2});
+            await expect(acceptVectorGenerationElection({dir, expectedEpoch: 2, now: T2}))
+                .rejects.toThrow(/without a completed promote/);
+
+            for (const key of VECTOR_PLANE_COLLECTION_KEYS.slice(1)) {
+                await recordPromoteCompletion({dir, collectionKey: key, expectedEpoch: 2, now: T2})
+            }
+
+            const record = await acceptVectorGenerationElection({dir, expectedEpoch: 2, now: T2});
+
+            expect(record).toMatchObject({status: 'accepted', epoch: 2, parked: null});
+            expect(record.retired.generationId).toBe(base.generationId);
+            expect(record.retiredAt).toBe(T2.toISOString())
+        });
+
+        test('every mutation enforces the caller epoch view', async () => {
+            await declareBaselineVectorGeneration({dir, identity: base, now: T0});
+
+            await expect(declareCandidateVectorGeneration({dir, identity: next, expectedEpoch: 7, now: T1}))
+                .rejects.toThrow(/epoch moved/);
+
+            await declareCandidateVectorGeneration({dir, identity: next, expectedEpoch: 1, now: T1});
+            await expect(recordCandidateValidationReceipt({
+                dir, collectionKey: 'kb.unified', receipt: receiptFor('kb.unified'), expectedEpoch: 2, now: T1
+            })).rejects.toThrow(/epoch moved/)
+        })
+    });
+
+    test.describe('the stale-writer fence (mixed-generation mutation coverage)', () => {
+        test('an uncommitted election never advertises: candidate promotes are refused on every collection', async () => {
+            // The mid-promotion-halt semantics at store level: candidate declared, receipts present,
+            // commit NOT reached — a writer that built the new generation cannot rename anywhere,
+            // so every reader still resolves the prior generation by construction.
+            await declareBaselineVectorGeneration({dir, identity: base, now: T0});
+            await declareCandidateVectorGeneration({dir, identity: next, expectedEpoch: 1, now: T1});
+
+            for (const key of VECTOR_PLANE_COLLECTION_KEYS) {
+                await recordCandidateValidationReceipt({dir, collectionKey: key, receipt: receiptFor(key), expectedEpoch: 1, now: T1});
+                await expect(assertVectorPromoteAdmissible({
+                    dir, collectionKey: key, generationId: next.generationId, epoch: 1
+                })).rejects.toThrow(/not the elected generation/)
+            }
+
+            // Same-generation refresh promotes stay admissible during the build window.
+            await expect(assertVectorPromoteAdmissible({
+                dir, collectionKey: 'kb.unified', generationId: base.generationId, epoch: 1
+            })).resolves.toMatchObject({mode: 'elected', epoch: 1})
+        });
+
+        test('after commit, a writer holding the pre-election view is fenced on both coordinates', async () => {
+            await commitTransition(dir, base, next);
+
+            // Stale epoch (the pre-commit view).
+            await expect(assertVectorPromoteAdmissible({
+                dir, collectionKey: 'mc.memory', generationId: base.generationId, epoch: 1
+            })).rejects.toThrow(/stale writer fenced/);
+
+            // Current epoch but the abandoned generation.
+            await expect(assertVectorPromoteAdmissible({
+                dir, collectionKey: 'mc.memory', generationId: base.generationId, epoch: 2
+            })).rejects.toThrow(/not the elected generation/);
+
+            // The elected generation at the current epoch promotes.
+            await expect(assertVectorPromoteAdmissible({
+                dir, collectionKey: 'mc.memory', generationId: next.generationId, epoch: 2
+            })).resolves.toMatchObject({mode: 'elected', epoch: 2, generationId: next.generationId})
+        });
+
+        test('a partially-promoted committed election cannot be accepted and stays rollback-covered', async () => {
+            await commitTransition(dir, base, next);
+
+            await recordPromoteCompletion({dir, collectionKey: 'kb.unified', expectedEpoch: 2, now: T2});
+            await recordPromoteCompletion({dir, collectionKey: 'mc.memory', expectedEpoch: 2, now: T2});
+
+            await expect(acceptVectorGenerationElection({dir, expectedEpoch: 2, now: T2}))
+                .rejects.toThrow(/without a completed promote/);
+
+            const record = (await readVectorGenerationElection({dir})).record;
+            expect(record.parked.generationId).toBe(base.generationId)
+        })
+    });
+
+    test.describe('rollback restores the full prior set', () => {
+        test('rollback re-elects the parked generation, bumps the epoch, and fences the abandoned writers', async () => {
+            await commitTransition(dir, base, next);
+            await recordPromoteCompletion({dir, collectionKey: 'kb.unified', expectedEpoch: 2, now: T2});
+
+            const record = await rollbackVectorGenerationElection({dir, expectedEpoch: 2, now: T2});
+
+            expect(record).toMatchObject({epoch: 3, status: 'rolled-back', parked: null, committedAt: null});
+            expect(record.elected.generationId).toBe(base.generationId);
+            expect(record.rolledBack.generationId).toBe(next.generationId);
+
+            for (const key of VECTOR_PLANE_COLLECTION_KEYS) {
+                expect(record.collections[key].promotedAt, `${key} promote is void after rollback`).toBeNull()
+            }
+
+            // The abandoned generation cannot promote at any epoch; the restored one can (un-park renames).
+            await expect(assertVectorPromoteAdmissible({
+                dir, collectionKey: 'kb.unified', generationId: next.generationId, epoch: 3
+            })).rejects.toThrow(/not the elected generation/);
+            await expect(assertVectorPromoteAdmissible({
+                dir, collectionKey: 'kb.unified', generationId: base.generationId, epoch: 3
+            })).resolves.toMatchObject({mode: 'elected', epoch: 3})
+        });
+
+        test('rollback is only reachable before acceptance — a code-only rollback without the generation restore cannot exist', async () => {
+            await commitTransition(dir, base, next);
+
+            for (const key of VECTOR_PLANE_COLLECTION_KEYS) {
+                await recordPromoteCompletion({dir, collectionKey: key, expectedEpoch: 2, now: T2})
+            }
+            await acceptVectorGenerationElection({dir, expectedEpoch: 2, now: T2});
+
+            await expect(rollbackVectorGenerationElection({dir, expectedEpoch: 2, now: T2}))
+                .rejects.toThrow(/only a committed, unaccepted election rolls back/)
+        });
+
+        test('a new candidate is refused until every collection reports its un-park', async () => {
+            await commitTransition(dir, base, next);
+            await rollbackVectorGenerationElection({dir, expectedEpoch: 2, now: T2});
+
+            const third = createVectorGenerationIdentity(coordinates({strategyVersion: 'v3'}));
+
+            await expect(declareCandidateVectorGeneration({dir, identity: third, expectedEpoch: 3, now: T2}))
+                .rejects.toThrow(/never reported their un-park/);
+
+            for (const key of VECTOR_PLANE_COLLECTION_KEYS) {
+                await recordUnparkCompletion({dir, collectionKey: key, expectedEpoch: 3, now: T2})
+            }
+
+            const record = await declareCandidateVectorGeneration({dir, identity: third, expectedEpoch: 3, now: T2});
+            expect(record.status).toBe('candidate');
+            expect(record.rolledBack).toBeNull()
+        })
+    });
+
+    test.describe('health projection', () => {
+        test('health reports elected + parked identities and per-collection state without throwing', async () => {
+            expect((await projectVectorGenerationHealth({dir})).status).toBe('missing');
+
+            await commitTransition(dir, base, next);
+            await recordPromoteCompletion({dir, collectionKey: 'kb.unified', expectedEpoch: 2, now: T2});
+
+            const health = await projectVectorGenerationHealth({dir});
+
+            expect(health.status).toBe('committed');
+            expect(health.epoch).toBe(2);
+            expect(health.elected.generationId).toBe(next.generationId);
+            expect(health.parked.generationId).toBe(base.generationId);
+            expect(health.elected.coordinates.provider).toBe('openAiCompatible');
+            expect(health.collections['kb.unified']).toMatchObject({validated: true});
+            expect(health.collections['kb.unified'].promotedAt).not.toBeNull();
+            expect(health.collections['mc.session'].promotedAt).toBeNull()
+        })
+    });
+
+    test.describe('durability shape', () => {
+        test('the record round-trips through disk and revalidates on every read', async () => {
+            await commitTransition(dir, base, next);
+
+            const reread = await readVectorGenerationElection({dir});
+
+            expect(reread.status).toBe('available');
+            expect(reread.record.elected.generationId).toBe(next.generationId);
+
+            const raw = JSON.parse(await fs.readFile(getVectorGenerationElectionFilePath({dir}), 'utf8'));
+            expect(raw.schemaVersion).toBe(VECTOR_GENERATION_ELECTION_SCHEMA_VERSION);
+            expect(Object.keys(raw.collections).sort()).toEqual([...VECTOR_PLANE_COLLECTION_KEYS].sort())
+        })
+    })
+});

--- a/test/playwright/unit/ai/services/shared/vector/generationElectionStore.spec.mjs
+++ b/test/playwright/unit/ai/services/shared/vector/generationElectionStore.spec.mjs
@@ -18,10 +18,11 @@ import {
     getVectorGenerationElectionFilePath,
     projectVectorGenerationHealth,
     readVectorGenerationElection,
-    resolveVectorGenerationElectionDir,
     recordCandidateValidationReceipt,
     recordPromoteCompletion,
     recordUnparkCompletion,
+    renewTransitionQuiesce,
+    resolveVectorGenerationElectionDir,
     rollbackVectorGenerationElection
 } from '../../../../../../../ai/services/shared/vector/generationElectionStore.mjs';
 import {createEmbeddingGenerationId as poisonStoreGenerationId}
@@ -30,11 +31,17 @@ import {createEmbeddingGenerationId as poisonStoreGenerationId}
 const T0 = new Date('2026-08-12T12:00:00.000Z');
 const T1 = new Date('2026-08-12T12:05:00.000Z');
 const T2 = new Date('2026-08-12T12:10:00.000Z');
+const T3 = new Date('2026-08-12T12:20:00.000Z');
+
+// One hour from T2 — transition fixtures pass explicit `now` values inside/outside this window.
+const QUIESCE = Object.freeze({scope: 'fixture-plane-quiesce', boundMs: 60 * 60 * 1000});
+
+const DIGEST_MODEL = 'hf://Qwen/Qwen3-Embedding-8B-GGUF@69d0e58a13e463cd99a9b83e3f5fee7c10265fab/Qwen3-Embedding-8B-Q4_K_M.gguf';
 
 function coordinates(overrides = {}) {
     return {
         provider       : 'ollama',
-        model          : 'qwen3-embedding:8b',
+        model          : DIGEST_MODEL,
         quantization   : 'q4_K_M',
         vectorDimension: 4096,
         pooling        : 'last-token',
@@ -54,7 +61,7 @@ async function makeDir() {
 
 /**
  * Drives a fresh plane to a committed election of `next` over a baseline of `base`.
- * Returns the committed record (epoch 2, status 'committed').
+ * Returns the committed record (epoch 2, status 'committed', quiesce window open from T2).
  */
 async function commitTransition(dir, base, next) {
     await declareBaselineVectorGeneration({dir, identity: base, now: T0});
@@ -64,7 +71,7 @@ async function commitTransition(dir, base, next) {
         await recordCandidateValidationReceipt({dir, collectionKey: key, receipt: receiptFor(key), expectedEpoch: 1, now: T1})
     }
 
-    return await commitVectorGenerationElection({dir, expectedEpoch: 1, now: T2})
+    return await commitVectorGenerationElection({dir, expectedEpoch: 1, quiesce: QUIESCE, now: T2})
 }
 
 test.describe('generationElectionStore — one durable authority for vector-plane generation visibility', () => {
@@ -89,7 +96,7 @@ test.describe('generationElectionStore — one durable authority for vector-plan
 
             for (const [key, value] of Object.entries({
                 provider       : 'openAiCompatible',
-                model          : 'other-model:1b',
+                model          : 'ollama://registry.ollama.ai/library/other:1b@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
                 quantization   : 'q8_0',
                 vectorDimension: 1024,
                 pooling        : 'mean',
@@ -102,10 +109,17 @@ test.describe('generationElectionStore — one durable authority for vector-plan
         });
 
         test('the embedding join key is one id-space with the poison store re-export', () => {
-            const tuple = {provider: 'ollama', model: 'qwen3-embedding:8b', vectorDimension: 4096, strategyVersion: 'v1'};
+            const tuple = {provider: 'ollama', model: DIGEST_MODEL, vectorDimension: 4096, strategyVersion: 'v1'};
 
             expect(createEmbeddingGenerationId(tuple)).toBe(poisonStoreGenerationId(tuple));
             expect(base.embeddingGenerationId).toBe(poisonStoreGenerationId(tuple))
+        });
+
+        test('placeholder coordinates and mutable model tags are refused at declaration time', () => {
+            expect(() => createVectorGenerationIdentity(coordinates({pooling: 'unknown'}))).toThrow(/placeholder/);
+            expect(() => createVectorGenerationIdentity(coordinates({quantization: 'TBD'}))).toThrow(/placeholder/);
+            expect(() => createVectorGenerationIdentity(coordinates({distance: 'n/a'}))).toThrow(/placeholder/);
+            expect(() => createVectorGenerationIdentity(coordinates({model: 'qwen3-embedding:8b'}))).toThrow(/digest-bearing/)
         });
 
         test('incomplete or invalid coordinates are refused', () => {
@@ -118,7 +132,7 @@ test.describe('generationElectionStore — one durable authority for vector-plan
     test.describe('fail-safe polarity', () => {
         test('a plane with no record grandfathers promotes in declared legacy mode', async () => {
             await expect(assertVectorPromoteAdmissible({
-                dir, collectionKey: 'kb.unified', generationId: base.generationId, epoch: 1
+                dir, collectionKey: 'kb.unified', generationId: base.generationId, epoch: 1, now: T0
             })).resolves.toEqual({mode: 'legacy'})
         });
 
@@ -131,7 +145,7 @@ test.describe('generationElectionStore — one durable authority for vector-plan
 
             for (const key of VECTOR_PLANE_COLLECTION_KEYS) {
                 await expect(assertVectorPromoteAdmissible({
-                    dir, collectionKey: key, generationId: base.generationId, epoch: 1
+                    dir, collectionKey: key, generationId: base.generationId, epoch: 1, now: T0
                 })).rejects.toThrow(/unprovable/)
             }
         });
@@ -142,7 +156,7 @@ test.describe('generationElectionStore — one durable authority for vector-plan
             const filePath = getVectorGenerationElectionFilePath({dir});
             const record   = JSON.parse(await fs.readFile(filePath, 'utf8'));
 
-            record.elected.coordinates.model = 'tampered-model';
+            record.elected.coordinates.model = 'tampered@sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
             await fs.writeFile(filePath, JSON.stringify(record, null, 2));
 
             expect((await readVectorGenerationElection({dir})).status).toBe('unavailable')
@@ -160,7 +174,7 @@ test.describe('generationElectionStore — one durable authority for vector-plan
     });
 
     test.describe('the election lifecycle', () => {
-        test('baseline records reality at epoch 1, already accepted', async () => {
+        test('baseline records reality at epoch 1, already accepted, with no quiesce window', async () => {
             const record = await declareBaselineVectorGeneration({dir, identity: base, now: T0});
 
             expect(record).toMatchObject({
@@ -169,9 +183,11 @@ test.describe('generationElectionStore — one durable authority for vector-plan
                 status       : 'accepted',
                 parked       : null,
                 candidate    : null,
-                retired      : null
+                retired      : null,
+                quiesce      : null
             });
-            expect(record.elected.generationId).toBe(base.generationId)
+            expect(record.elected.generationId).toBe(base.generationId);
+            expect(Object.keys(record.collections).sort()).toEqual([...VECTOR_PLANE_COLLECTION_KEYS].sort())
         });
 
         test('a no-op candidate equal to the elected generation is refused as a caller bug', async () => {
@@ -189,8 +205,22 @@ test.describe('generationElectionStore — one durable authority for vector-plan
             }
 
             const missing = VECTOR_PLANE_COLLECTION_KEYS.at(-1);
-            await expect(commitVectorGenerationElection({dir, expectedEpoch: 1, now: T2}))
+            await expect(commitVectorGenerationElection({dir, expectedEpoch: 1, quiesce: QUIESCE, now: T2}))
                 .rejects.toThrow(new RegExp(missing.replace('.', '\\.')))
+        });
+
+        test('commit refuses without a declared quiesce window', async () => {
+            await declareBaselineVectorGeneration({dir, identity: base, now: T0});
+            await declareCandidateVectorGeneration({dir, identity: next, expectedEpoch: 1, now: T1});
+
+            for (const key of VECTOR_PLANE_COLLECTION_KEYS) {
+                await recordCandidateValidationReceipt({dir, collectionKey: key, receipt: receiptFor(key), expectedEpoch: 1, now: T1})
+            }
+
+            await expect(commitVectorGenerationElection({dir, expectedEpoch: 1, now: T2}))
+                .rejects.toThrow(/quiesce must declare/);
+            await expect(commitVectorGenerationElection({dir, expectedEpoch: 1, quiesce: {scope: 'x', boundMs: 0}, now: T2}))
+                .rejects.toThrow(/quiesce failed validation/)
         });
 
         test('a receipt with unknown keys or an unknown collection is refused', async () => {
@@ -208,12 +238,13 @@ test.describe('generationElectionStore — one durable authority for vector-plan
             })).rejects.toThrow(/collectionKey/)
         });
 
-        test('commit parks the prior generation, elects the candidate, and bumps the epoch', async () => {
+        test('commit parks the prior generation, elects the candidate, bumps the epoch, and stores the window', async () => {
             const record = await commitTransition(dir, base, next);
 
             expect(record).toMatchObject({epoch: 2, status: 'committed', candidate: null});
             expect(record.elected.generationId).toBe(next.generationId);
             expect(record.parked.generationId).toBe(base.generationId);
+            expect(record.quiesce).toMatchObject({scope: QUIESCE.scope, boundMs: QUIESCE.boundMs, startedAt: T2.toISOString()});
 
             for (const key of VECTOR_PLANE_COLLECTION_KEYS) {
                 expect(record.collections[key].receipt).not.toBeNull();
@@ -221,7 +252,7 @@ test.describe('generationElectionStore — one durable authority for vector-plan
             }
         });
 
-        test('acceptance refuses until every collection reports its promote, then retires the parked set', async () => {
+        test('acceptance refuses until every collection reports its promote, then retires the parked set and clears the window', async () => {
             await commitTransition(dir, base, next);
 
             await recordPromoteCompletion({dir, collectionKey: 'kb.unified', expectedEpoch: 2, now: T2});
@@ -234,7 +265,7 @@ test.describe('generationElectionStore — one durable authority for vector-plan
 
             const record = await acceptVectorGenerationElection({dir, expectedEpoch: 2, now: T2});
 
-            expect(record).toMatchObject({status: 'accepted', epoch: 2, parked: null});
+            expect(record).toMatchObject({status: 'accepted', epoch: 2, parked: null, quiesce: null});
             expect(record.retired.generationId).toBe(base.generationId);
             expect(record.retiredAt).toBe(T2.toISOString())
         });
@@ -254,41 +285,34 @@ test.describe('generationElectionStore — one durable authority for vector-plan
 
     test.describe('the stale-writer fence (mixed-generation mutation coverage)', () => {
         test('an uncommitted election never advertises: candidate promotes are refused on every collection', async () => {
-            // The mid-promotion-halt semantics at store level: candidate declared, receipts present,
-            // commit NOT reached — a writer that built the new generation cannot rename anywhere,
-            // so every reader still resolves the prior generation by construction.
             await declareBaselineVectorGeneration({dir, identity: base, now: T0});
             await declareCandidateVectorGeneration({dir, identity: next, expectedEpoch: 1, now: T1});
 
             for (const key of VECTOR_PLANE_COLLECTION_KEYS) {
                 await recordCandidateValidationReceipt({dir, collectionKey: key, receipt: receiptFor(key), expectedEpoch: 1, now: T1});
                 await expect(assertVectorPromoteAdmissible({
-                    dir, collectionKey: key, generationId: next.generationId, epoch: 1
+                    dir, collectionKey: key, generationId: next.generationId, epoch: 1, now: T1
                 })).rejects.toThrow(/not the elected generation/)
             }
 
-            // Same-generation refresh promotes stay admissible during the build window.
             await expect(assertVectorPromoteAdmissible({
-                dir, collectionKey: 'kb.unified', generationId: base.generationId, epoch: 1
+                dir, collectionKey: 'kb.unified', generationId: base.generationId, epoch: 1, now: T1
             })).resolves.toMatchObject({mode: 'elected', epoch: 1})
         });
 
         test('after commit, a writer holding the pre-election view is fenced on both coordinates', async () => {
             await commitTransition(dir, base, next);
 
-            // Stale epoch (the pre-commit view).
             await expect(assertVectorPromoteAdmissible({
-                dir, collectionKey: 'mc.memory', generationId: base.generationId, epoch: 1
+                dir, collectionKey: 'mc.memory', generationId: base.generationId, epoch: 1, now: T2
             })).rejects.toThrow(/stale writer fenced/);
 
-            // Current epoch but the abandoned generation.
             await expect(assertVectorPromoteAdmissible({
-                dir, collectionKey: 'mc.memory', generationId: base.generationId, epoch: 2
+                dir, collectionKey: 'mc.memory', generationId: base.generationId, epoch: 2, now: T2
             })).rejects.toThrow(/not the elected generation/);
 
-            // The elected generation at the current epoch promotes.
             await expect(assertVectorPromoteAdmissible({
-                dir, collectionKey: 'mc.memory', generationId: next.generationId, epoch: 2
+                dir, collectionKey: 'mc.memory', generationId: next.generationId, epoch: 2, now: T2
             })).resolves.toMatchObject({mode: 'elected', epoch: 2, generationId: next.generationId})
         });
 
@@ -306,28 +330,77 @@ test.describe('generationElectionStore — one durable authority for vector-plan
         })
     });
 
+    test.describe('the quiesce window bounds every transition rename', () => {
+        test('a transition promote refuses outside the declared window and resumes after an explicit renewal', async () => {
+            await commitTransition(dir, base, next);
+
+            // Inside the T2 + 1h window: admissible.
+            await expect(assertVectorPromoteAdmissible({
+                dir, collectionKey: 'kb.unified', generationId: next.generationId, epoch: 2, now: T2
+            })).resolves.toMatchObject({mode: 'elected'});
+
+            // Beyond the window (T2 + 2h): the rename refuses with the renewal remediation named.
+            const late = new Date(T2.getTime() + 2 * 60 * 60 * 1000);
+            await expect(assertVectorPromoteAdmissible({
+                dir, collectionKey: 'kb.unified', generationId: next.generationId, epoch: 2, now: late
+            })).rejects.toThrow(/outside the declared quiesce window/);
+
+            // Renewal is explicit and receipted; the same rename is admissible again.
+            await renewTransitionQuiesce({dir, expectedEpoch: 2, quiesce: {scope: 'renewed-window', boundMs: QUIESCE.boundMs, startedAt: late}, now: late});
+            await expect(assertVectorPromoteAdmissible({
+                dir, collectionKey: 'kb.unified', generationId: next.generationId, epoch: 2, now: late
+            })).resolves.toMatchObject({mode: 'elected'})
+        });
+
+        test('renewal is only reachable for a running transition', async () => {
+            await declareBaselineVectorGeneration({dir, identity: base, now: T0});
+            await expect(renewTransitionQuiesce({dir, expectedEpoch: 1, quiesce: QUIESCE, now: T1}))
+                .rejects.toThrow(/only a running transition/)
+        });
+
+        test('steady-state refresh promotes need no window', async () => {
+            await declareBaselineVectorGeneration({dir, identity: base, now: T0});
+
+            // Years later, no transition running — a same-generation refresh promote is admissible.
+            const muchLater = new Date('2027-01-01T00:00:00.000Z');
+            await expect(assertVectorPromoteAdmissible({
+                dir, collectionKey: 'kb.unified', generationId: base.generationId, epoch: 1, now: muchLater
+            })).resolves.toMatchObject({mode: 'elected', electionStatus: 'accepted'})
+        })
+    });
+
     test.describe('rollback restores the full prior set', () => {
-        test('rollback re-elects the parked generation, bumps the epoch, and fences the abandoned writers', async () => {
+        test('rollback re-elects the parked generation under its own declared window and fences the abandoned writers', async () => {
             await commitTransition(dir, base, next);
             await recordPromoteCompletion({dir, collectionKey: 'kb.unified', expectedEpoch: 2, now: T2});
 
-            const record = await rollbackVectorGenerationElection({dir, expectedEpoch: 2, now: T2});
+            await expect(rollbackVectorGenerationElection({dir, expectedEpoch: 2, now: T3}))
+                .rejects.toThrow(/quiesce must declare/);
+
+            const record = await rollbackVectorGenerationElection({dir, expectedEpoch: 2, quiesce: {scope: 'rollback-window', boundMs: QUIESCE.boundMs}, now: T3});
 
             expect(record).toMatchObject({epoch: 3, status: 'rolled-back', parked: null, committedAt: null});
             expect(record.elected.generationId).toBe(base.generationId);
             expect(record.rolledBack.generationId).toBe(next.generationId);
+            expect(record.quiesce).toMatchObject({scope: 'rollback-window', startedAt: T3.toISOString()});
 
             for (const key of VECTOR_PLANE_COLLECTION_KEYS) {
                 expect(record.collections[key].promotedAt, `${key} promote is void after rollback`).toBeNull()
             }
 
-            // The abandoned generation cannot promote at any epoch; the restored one can (un-park renames).
+            // The abandoned generation cannot rename at any epoch; the restored one can, inside the window.
             await expect(assertVectorPromoteAdmissible({
-                dir, collectionKey: 'kb.unified', generationId: next.generationId, epoch: 3
+                dir, collectionKey: 'kb.unified', generationId: next.generationId, epoch: 3, now: T3
             })).rejects.toThrow(/not the elected generation/);
             await expect(assertVectorPromoteAdmissible({
-                dir, collectionKey: 'kb.unified', generationId: base.generationId, epoch: 3
-            })).resolves.toMatchObject({mode: 'elected', epoch: 3})
+                dir, collectionKey: 'kb.unified', generationId: base.generationId, epoch: 3, now: T3
+            })).resolves.toMatchObject({mode: 'elected', epoch: 3});
+
+            // Un-park renames refuse outside the rollback window too — the defect cannot recur in reverse.
+            const late = new Date(T3.getTime() + 2 * 60 * 60 * 1000);
+            await expect(assertVectorPromoteAdmissible({
+                dir, collectionKey: 'kb.unified', generationId: base.generationId, epoch: 3, now: late
+            })).rejects.toThrow(/outside the declared quiesce window/)
         });
 
         test('rollback is only reachable before acceptance — a code-only rollback without the generation restore cannot exist', async () => {
@@ -338,13 +411,13 @@ test.describe('generationElectionStore — one durable authority for vector-plan
             }
             await acceptVectorGenerationElection({dir, expectedEpoch: 2, now: T2});
 
-            await expect(rollbackVectorGenerationElection({dir, expectedEpoch: 2, now: T2}))
+            await expect(rollbackVectorGenerationElection({dir, expectedEpoch: 2, quiesce: QUIESCE, now: T2}))
                 .rejects.toThrow(/only a committed, unaccepted election rolls back/)
         });
 
         test('a new candidate is refused until every collection reports its un-park', async () => {
             await commitTransition(dir, base, next);
-            await rollbackVectorGenerationElection({dir, expectedEpoch: 2, now: T2});
+            await rollbackVectorGenerationElection({dir, expectedEpoch: 2, quiesce: QUIESCE, now: T2});
 
             const third = createVectorGenerationIdentity(coordinates({strategyVersion: 'v3'}));
 
@@ -357,12 +430,13 @@ test.describe('generationElectionStore — one durable authority for vector-plan
 
             const record = await declareCandidateVectorGeneration({dir, identity: third, expectedEpoch: 3, now: T2});
             expect(record.status).toBe('candidate');
-            expect(record.rolledBack).toBeNull()
+            expect(record.rolledBack).toBeNull();
+            expect(record.quiesce).toBeNull()
         })
     });
 
     test.describe('health projection', () => {
-        test('health reports elected + parked identities and per-collection state without throwing', async () => {
+        test('health reports elected + parked identities, the window, and per-collection state without throwing', async () => {
             expect((await projectVectorGenerationHealth({dir})).status).toBe('missing');
 
             await commitTransition(dir, base, next);
@@ -374,25 +448,12 @@ test.describe('generationElectionStore — one durable authority for vector-plan
             expect(health.epoch).toBe(2);
             expect(health.elected.generationId).toBe(next.generationId);
             expect(health.parked.generationId).toBe(base.generationId);
+            expect(health.quiesce).toMatchObject({scope: QUIESCE.scope});
             expect(health.elected.coordinates.provider).toBe('openAiCompatible');
             expect(health.collections['kb.unified']).toMatchObject({validated: true});
             expect(health.collections['kb.unified'].promotedAt).not.toBeNull();
+            expect(health.collections['mc.graph'].promotedAt).toBeNull();
             expect(health.collections['mc.session'].promotedAt).toBeNull()
-        })
-    });
-
-    test.describe('durability shape', () => {
-        test('the record round-trips through disk and revalidates on every read', async () => {
-            await commitTransition(dir, base, next);
-
-            const reread = await readVectorGenerationElection({dir});
-
-            expect(reread.status).toBe('available');
-            expect(reread.record.elected.generationId).toBe(next.generationId);
-
-            const raw = JSON.parse(await fs.readFile(getVectorGenerationElectionFilePath({dir}), 'utf8'));
-            expect(raw.schemaVersion).toBe(VECTOR_GENERATION_ELECTION_SCHEMA_VERSION);
-            expect(Object.keys(raw.collections).sort()).toEqual([...VECTOR_PLANE_COLLECTION_KEYS].sort())
         })
     });
 
@@ -428,7 +489,7 @@ test.describe('generationElectionStore — one durable authority for vector-plan
             for (const key of VECTOR_PLANE_COLLECTION_KEYS) {
                 await recordCandidateValidationReceipt({dir, collectionKey: key, receipt: receiptFor(key), expectedEpoch: 1, now: T1})
             }
-            await commitVectorGenerationElection({dir, expectedEpoch: 1, now: T2});
+            await commitVectorGenerationElection({dir, expectedEpoch: 1, quiesce: QUIESCE, now: T2});
 
             await expect(assertCapturedPromoteView({dir, collectionKey: 'mc.memory', view}))
                 .rejects.toThrow(/stale writer fenced/)
@@ -441,6 +502,22 @@ test.describe('generationElectionStore — one durable authority for vector-plan
             await expect(captureVectorPromoteView({dir})).rejects.toThrow(/unprovable/);
             await expect(assertCapturedPromoteView({dir, collectionKey: 'kb.unified', view: {mode: 'legacy'}}))
                 .rejects.toThrow(/unprovable/)
+        })
+    });
+
+    test.describe('durability shape', () => {
+        test('the record round-trips through disk and revalidates on every read', async () => {
+            await commitTransition(dir, base, next);
+
+            const reread = await readVectorGenerationElection({dir});
+
+            expect(reread.status).toBe('available');
+            expect(reread.record.elected.generationId).toBe(next.generationId);
+
+            const raw = JSON.parse(await fs.readFile(getVectorGenerationElectionFilePath({dir}), 'utf8'));
+            expect(raw.schemaVersion).toBe(VECTOR_GENERATION_ELECTION_SCHEMA_VERSION);
+            expect(Object.keys(raw.collections).sort()).toEqual([...VECTOR_PLANE_COLLECTION_KEYS].sort());
+            expect(raw.quiesce.scope).toBe(QUIESCE.scope)
         })
     })
 });


### PR DESCRIPTION
Resolves #17035

Refs #17023

Related: #17018, #17023 (retained outcome leaf — reader-quiescence actuator + witnesses, blocked_by #17035)

Delivers AC-C: one durable election authority commits coordinated vector-plane generations, with two composed mechanisms at the reader boundary. Before commit, no promote of the candidate is admissible anywhere, so an uncommitted election never advertises. The commit itself — and any rollback — REQUIRES a declared quiesce window `{scope, startedAt, boundMs}`, and every transition rename refuses to run outside that active window: the mixed-generation interval between the first and last rename exists only inside a declared, bounded window in which the deployment has quiesced readers. The record enforces the declaration and the bound; the deployment enforces the quiet. Steady-state same-generation refresh promotes need no window.

Evidence: L3 (physical halt/crash matrix on name-resolving collections — real renames, every canonical name read after each transition step; 63 greens across the vector tree, poison, restore, and mount suites at this head) → L4 required (one canonical-scale ~104k-row rebuild through this record). Residual: AC-E canonical run + live-plane quiesce execution receipts, Residual-Owner: #17025.

## What ships

- **`generationElectionStore.mjs`** — the plane-singleton durable record. Lifecycle `accepted → candidate → committed → accepted` with `rolled-back` as the abort arm; epoch increments only on visibility flips. Commit refuses without every census receipt AND a declared quiesce window; rollback carries its own window; `renewTransitionQuiesce` is the explicit, receipted stall remediation. The fence checks two coordinates for every writer (elected generation, current epoch) plus the window for transition renames. Fail-safe polarity: missing record = legacy-grandfathered; corrupt/tampered record (derived-hash validation) refuses promotes while readers stay untouched. Identity hardening: the seven-coordinate tuple refuses placeholder values and requires a digest-bearing model reference, so the identity binds to the immutable elected artifact.
- **Five-collection census** — `kb.unified`, `mc.graph` (via the `StorageRouter` accessor layer), `mc.memory`, `mc.session`, `mc.temporalSummary`. Commit requires receipts for all five; acceptance requires all five promotes; the next candidate requires all five un-parks after a rollback.
- **One physical mount** — `shared-vector-generation-data` mounted read-write into kb-server, mc-server, and the orchestrator at the store-resolved dir. A static spec ties the compose literal to `resolveVectorGenerationElectionDir` so drift on either side fails, asserts all three services mount the same volume, and refuses any other source serving the election path — identical absolute paths in separate writable layers are separate authorities, and a split record inverts the legacy fail-safe into a bypass.
- **`electionGatedPromote.mjs`** — the runner-owned two-rename promote and un-park for collections without a service seam (`mc.temporalSummary`, `mc.graph`): fence immediately before the renames (window included), crash-rollback between the renames so the canonical name is never left unserved, completion reporting that never unwinds a successful rename.
- **Both service seams gated** — `embedViaShadowSwap` captures its election view before any shadow work and fences before its two renames; `restoreTargetSetStorage` fences each vector-role promote under one view per restore ATTEMPT (keyed by `attemptFingerprint` — the storage object outlives attempts at its call site, so a per-factory view would leak across an intervening election).
- **Health surfaces** — KB and MC healthchecks report `vectorGeneration`: elected + parked identities, the active quiesce window, and per-collection validated/promoted/unparked state.

## Deltas from ticket

- The ticket's AC-2 offered two mechanisms; this PR implements the quiesced-bounded arm with the declaration and bound enforced by the record. The alternative arm — generation-qualified collection names with one reader-consulted pointer — is feasible (resolution is centralized in two ChromaManagers plus StorageRouter) but changes stable canonical names that restore destinations, backup bundles, healthchecks, and diagnostics depend on; it is recorded as the successor shape rather than attempted under this leaf.
- The fence gained a seam-facing captured-view form: the view is captured before the build and validated (identity + epoch + window) at the promote moment, which also fences an election declared mid-build on a previously-legacy plane.
- The four-coordinate `embeddingGenerationId` implementation moved here from `kbEmbeddingPoisonStore` (which re-exports it) — one id-space, layering-correct direction.
- The restore adapter's graph component (SQLite) is deliberately outside the vector election; the graph-node CHROMA collection (`mc.graph`) is inside it, promoted via `electionGatedPromote`.
- A completion-mark failure after successful renames reports and continues: it only keeps acceptance (or the next candidate) blocked — rollback authority retained — and never unwinds a rename.

## Contract Ledger

Mirrors the ledger now carried on #17023 (backfilled this cycle): identity (placeholder-refusing, digest-bound, derived-hash-validated) → record; record (one shared mount) → seams/runner/health with identity+epoch+window fencing; five-key receipts → commit; completion marks → acceptance/next-candidate; health projection → cutover acceptance, `missing`/`unavailable` as status, never a throw.

## Test Evidence

- `npx playwright test test/playwright/unit/ai/services/shared/vector/ …poison …restore …mount --workers=1` → **63 passed** at this head.
- **The physical halt/crash matrix** (`electionGatedPromote.spec.mjs`): real renames on name-resolving collections; after each transition step every canonical name is read. Halted after two of five promotes, the plane reads exactly `{kb.unified: G2, mc.memory: G2, rest: G1}`; acceptance refuses; the mixed interval cannot grow outside the declared window (third promote refused at the fence); rollback under its own window plus un-parks restores ALL five canonical names to G1 by observation; the abandoned generation is fenced at every step; a crash between the two renames restores the canonical name before rethrowing and the promote is retryable.
- Election-store fixtures (31): lifecycle, both fence coordinates, commit-refuses-without-window, window-expiry refusal + explicit renewal, steady-state-needs-no-window, rollback-carries-its-own-window, placeholder/digest identity refusals, tamper/corrupt polarity, health projection.
- Mount spec (3): the shared volume is declared, all three services mount it at the store-resolved path writable, and no other source may serve the election dir.
- Restore-storage suite (9, including its live-Chroma SDK arm) green through the per-attempt view change; poison suite (9) green through the moved join key.

## Post-Merge Validation

- [ ] The AC-E resumable rebuild runs one canonical-scale (~104k row) generation through this record — including the live quiesce-window execution receipts — and lands them as the commit's validation inputs.
- [ ] The cutover runbook's first act declares the baseline election on the target plane.

Residual-Owner: #17025

Authored by Vega (@neo-opus-vega, Claude Fable 5). Origin Session ID: 8637b4b9-b852-45d9-b057-de34184aae8b


