### PR TITLE
feat(ai): add provider-lane election runner (#17034)

### DIFF
--- a/ai/deploy/docker-compose.provider-lanes.yml
+++ b/ai/deploy/docker-compose.provider-lanes.yml
@@ -256,10 +256,11 @@ services:
       embedding-model:
         condition: service_healthy
 
-  # Disposable benchmark worker (#17024). This service deliberately does not extend any resident
+  # Disposable benchmark worker (#17034; outcome #17024). It deliberately does not extend a resident
   # Agent OS service: Compose inheritance would otherwise carry the orchestrator's Docker socket and
-  # host-backup bind into an evidence process. The controller starts it only via `compose run` under
-  # the dedicated profile, on the internal network, with one read-only candidate receipt mount.
+  # host-backup bind into an evidence process. The service therefore declares no static volumes.
+  # The controller starts it only via `compose run` under the dedicated profile and injects exactly
+  # one validated candidate receipt as a per-run read-only mount on the internal network.
   provider-lane-worker:
     build:
       context: .

--- a/ai/deploy/docker-compose.provider-lanes.yml
+++ b/ai/deploy/docker-compose.provider-lanes.yml
@@ -250,6 +250,33 @@ services:
       embedding-model:
         condition: service_healthy
 
+  # Disposable benchmark worker (#17024). This service deliberately does not extend any resident
+  # Agent OS service: Compose inheritance would otherwise carry the orchestrator's Docker socket and
+  # host-backup bind into an evidence process. The controller starts it only via `compose run` under
+  # the dedicated profile, on the internal network, with one read-only candidate receipt mount.
+  provider-lane-worker:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      args:
+        SERVICE_ENTRYPOINT: ai/scripts/benchmark/provider-lane-election.mjs
+        NEO_REF: ${NEO_REVISION:-dev}
+        NEO_REVISION: ${NEO_REVISION:-}
+    environment:
+      <<: *provider-lane-env
+      GEMINI_API_KEY: ""
+      NEO_KB_ASK_PROVIDER: ollama
+      NEO_KB_ASK_MODEL: gemma4:26b
+      NEO_KB_ASK_API_KEY: ""
+      NEO_KB_ASK_BASE_URL: http://chat-model:11434
+      NEO_OPENAI_COMPATIBLE_API_KEY: ""
+      NEO_OPENAI_COMPATIBLE_BATCH_EMBEDDING_CHUNK_SIZE: "5"
+    volumes: []
+    networks:
+      - neo-mcp-network
+    profiles:
+      - provider-lane-election
+
 volumes:
   chat-model-data:
   embedding-model-data:

--- a/ai/deploy/docker-compose.provider-lanes.yml
+++ b/ai/deploy/docker-compose.provider-lanes.yml
@@ -56,6 +56,8 @@ x-provider-lane-contract:
       slots: ${NEO_PROVIDER_LANE_EMBEDDING_SLOTS:?embedding lane slot allocation required}
       totalContextTokens: ${NEO_PROVIDER_LANE_EMBEDDING_TOTAL_CONTEXT_TOKENS:?embedding total context allocation required}
       contextTokensPerSlotRequired: ${NEO_PROVIDER_LANE_EMBEDDING_CONTEXT_TOKENS_PER_SLOT_REQUIRED:?embedding per-slot context requirement required}
+      batchTokens: ${NEO_PROVIDER_LANE_EMBEDDING_BATCH_TOKENS:?embedding logical batch required}
+      ubatchTokens: ${NEO_PROVIDER_LANE_EMBEDDING_UBATCH_TOKENS:?embedding physical ubatch required}
       model:
         id: qwen3-embedding-8b
         coordinate: hf://Qwen/Qwen3-Embedding-8B-GGUF@69d0e58a13e463cd99a9b83e3f5fee7c10265fab/Qwen3-Embedding-8B-Q4_K_M.gguf
@@ -88,9 +90,11 @@ x-provider-lane-contract:
           contextTokensField: n_ctx
           processingField: is_processing
       controls:
+        batchEnv: LLAMA_ARG_BATCH
         contextEnv: LLAMA_ARG_CTX_SIZE
         slotsEnv: LLAMA_ARG_N_PARALLEL
         slotsEndpointEnv: LLAMA_ARG_ENDPOINT_SLOTS
+        ubatchEnv: LLAMA_ARG_UBATCH
   roles:
     model:
       configPath: modelProvider
@@ -196,6 +200,8 @@ services:
       LLAMA_ARG_PORT: "8080"
       LLAMA_ARG_CTX_SIZE: ${NEO_PROVIDER_LANE_EMBEDDING_TOTAL_CONTEXT_TOKENS:?embedding total context required}
       LLAMA_ARG_N_PARALLEL: ${NEO_PROVIDER_LANE_EMBEDDING_SLOTS:?embedding slots required}
+      LLAMA_ARG_BATCH: ${NEO_PROVIDER_LANE_EMBEDDING_BATCH_TOKENS:?embedding logical batch required}
+      LLAMA_ARG_UBATCH: ${NEO_PROVIDER_LANE_EMBEDDING_UBATCH_TOKENS:?embedding physical ubatch required}
       LLAMA_ARG_ENDPOINT_SLOTS: "true"
       NEO_PROVIDER_LANE_MODEL_URL: https://huggingface.co/Qwen/Qwen3-Embedding-8B-GGUF/resolve/69d0e58a13e463cd99a9b83e3f5fee7c10265fab/Qwen3-Embedding-8B-Q4_K_M.gguf
       NEO_PROVIDER_LANE_MODEL_SHA256: 3fcd3febec8b3fd64435204db75bf0dd73b91e8d0661e0331acfe7e7c3120b85

--- a/ai/scripts/benchmark/helpers/providerLaneElectionCore.mjs
+++ b/ai/scripts/benchmark/helpers/providerLaneElectionCore.mjs
@@ -23,6 +23,7 @@ const
     EMBED_SOURCES          = Object.freeze(['knowledge-base', 'memory-core', 'orchestrator']),
     LANE_NAMES             = Object.freeze(['chat', 'embedding']),
     OUTCOMES               = Object.freeze(['completed', 'error', 'unexpected-refusal']),
+    PROVIDER_OUTCOMES      = Object.freeze(['completed', 'error']),
     PROBE_RESPONSE_CLASSES = Object.freeze(['completed', 'context-limit-refusal', 'provider-error']),
     QUEUE_DISPOSITIONS     = Object.freeze(['not-applicable', 'queued']),
     SAFE_PUBLIC_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$/,
@@ -123,18 +124,22 @@ export function createProviderLanePlanDigest(plan) {
  *
  * @param {Object} options
  * @param {Object} options.plan Immutable candidate profiles, workload, SLO, and sampling.
+ * @param {Object[]} options.contextEvidence One runtime context/refusal receipt per candidate.
  * @param {Object[]} options.trials Chronological raw operation/resource receipts.
  * @returns {Object} Bounded election receipt.
  */
-export function evaluateProviderLaneElection({plan, trials} = {}) {
+export function evaluateProviderLaneElection({contextEvidence, plan, trials} = {}) {
     const schedule   = validatePlan(plan),
           planDigest = deriveProviderLanePlanDigest(plan),
-          derived    = validateAndDeriveTrials({plan, schedule, trials});
+          ids        = new Set(),
+          contexts   = validateContextEvidence({evidence: contextEvidence, ids, plan}),
+          derived    = validateAndDeriveTrials({ids, plan, schedule, trials});
 
     const candidates = CANDIDATES.map(candidate => evaluateCandidate({
               candidate,
+              contextEvidence: contexts.find(receipt => receipt.candidate === candidate),
               plan,
-              trials: derived.filter(trial => trial.candidate === candidate)
+              trials         : derived.filter(trial => trial.candidate === candidate)
           })),
           winner = candidates.find(candidate => candidate.status === 'PASS') ?? null;
 
@@ -514,13 +519,12 @@ function validateResourceSampling(sampling) {
  * @param {Object} options
  * @returns {Object[]}
  */
-function validateAndDeriveTrials({plan, schedule, trials}) {
+function validateAndDeriveTrials({ids, plan, schedule, trials}) {
     if (!Array.isArray(trials) || trials.length !== schedule.length) {
         throw new Error(`provider-lane matrix requires ${schedule.length} chronological trials`)
     }
 
-    const ids     = new Set(),
-          derived = [];
+    const derived = [];
 
     trials.forEach((trial, index) => {
         const slot    = schedule[index],
@@ -580,21 +584,21 @@ function validateAndDeriveTrials({plan, schedule, trials}) {
  * @returns {Object}
  */
 function deriveLaneReceipt({ids, lane, laneName, plan, profile, trial}) {
-    if (!lane || !Array.isArray(lane.operations) || !Array.isArray(lane.resourceSamples) || lane.resourceSamples.length < 2) {
-        throw new Error(`trial ${trial.executionIndex} lane ${laneName} requires operations and at least two resource samples`)
+    if (!lane || !Array.isArray(lane.operations) || !Array.isArray(lane.sourceCalls) ||
+        !Array.isArray(lane.resourceSamples) || lane.resourceSamples.length < 2) {
+        throw new Error(`trial ${trial.executionIndex} lane ${laneName} requires provider operations, source calls, and resource samples`)
     }
-
-    const overLimitProbe = validateContextReceipt({
-        ids,
-        lane,
-        laneName,
-        profile,
-        trial
-    });
 
     validateRuntimeProfile(lane.runtimeProfile, profile.lanes[laneName], laneName, trial.executionIndex);
 
-    const operations = lane.operations.map(operation => validateOperation({
+    const sourceCalls = lane.sourceCalls.map(call => validateSourceCall({
+              call,
+              ids,
+              laneName,
+              trial
+          })),
+          sourceCallById = new Map(sourceCalls.map(call => [call.id, call])),
+          operations = lane.operations.map(operation => validateOperation({
               ids,
               laneName,
               operation,
@@ -608,9 +612,23 @@ function deriveLaneReceipt({ids, lane, laneName, plan, profile, trial}) {
           }),
           queueWaits = operations.filter(operation => operation.queueWaitMs !== null).map(operation => operation.queueWaitMs),
           providerDurations = operations.map(operation => operation.providerDurationMs),
-          completions = operations.filter(operation => operation.outcome === 'completed').map(operation => operation.completedAtMs),
+          completions = sourceCalls.filter(call => call.outcome === 'completed').map(call => call.completedAtMs),
           windowMs = trial.completedAtMs - trial.startedAtMs,
           maxResourceSamples = Math.ceil(windowMs / plan.resourceSampling.expectedIntervalMs) + 2;
+
+    for (const call of sourceCalls) {
+        const linked = operations.filter(operation => operation.callId === call.id);
+
+        if (linked.length === 0 || linked.some(operation => operation.completedAtMs > call.completedAtMs ||
+            operation.demandAtMs < call.demandAtMs) ||
+            (call.outcome === 'completed' && linked.some(operation => operation.outcome !== 'completed')) ||
+            (call.outcome === 'unexpected-refusal' && linked.every(operation => operation.outcome !== 'error'))) {
+            throw new Error(`trial ${trial.executionIndex} lane ${laneName} has an incoherent source-call lifecycle`)
+        }
+    }
+    if (operations.some(operation => !sourceCallById.has(operation.callId))) {
+        throw new Error(`trial ${trial.executionIndex} lane ${laneName} has an unbound provider operation`)
+    }
 
     if (lane.resourceSamples.length > maxResourceSamples) {
         throw new Error(`trial ${trial.executionIndex} lane ${laneName} exceeds the bounded raw resource sample count`)
@@ -637,29 +655,38 @@ function deriveLaneReceipt({ids, lane, laneName, plan, profile, trial}) {
     }
 
     return {
-        completedOperations         : completions.length,
-        cpuHighWaterPercent         : Math.max(...lane.resourceSamples.map(sample => sample.cpuPercent)),
-        errorCount                  : operations.filter(operation => operation.outcome === 'error').length,
-        maxNeoQueueWaitMs           : queueWaits.length > 0 ? Math.max(...queueWaits) : null,
-        maxProgressGapMs            : deriveMaxProgressGap(trial.startedAtMs, trial.completedAtMs, completions),
-        maxProviderDurationMs       : Math.max(...providerDurations),
-        observedContextTokensPerSlot: lane.observedContextTokensPerSlot,
+        completedOperations  : completions.length,
+        cpuHighWaterPercent  : Math.max(...lane.resourceSamples.map(sample => sample.cpuPercent)),
+        errorCount           : sourceCalls.filter(call => call.outcome === 'error').length,
+        maxNeoQueueWaitMs    : queueWaits.length > 0 ? Math.max(...queueWaits) : null,
+        maxProgressGapMs     : deriveMaxProgressGap(trial.startedAtMs, trial.completedAtMs, completions),
+        maxProviderDurationMs: Math.max(...providerDurations),
         observedMaxProviderConcurrency,
-        offeredOperations           : operations.length,
-        operations,
-        overLimitProbe,
-        queueDispositionCounts      : {
+        offeredOperations    : sourceCalls.length,
+        operations           : operations.map(operation => ({
+            ...operation,
+            callId: projectOpaqueId(operation.callId)
+        })),
+        providerOperationCount: operations.length,
+        queueDispositionCounts: {
             'not-applicable': operations.filter(operation => operation.queueDisposition === 'not-applicable').length,
             queued          : operations.filter(operation => operation.queueDisposition === 'queued').length
         },
-        resourceCoverageRatio : resource.coverageRatio,
-        resourceGapCount      : resource.gapCount,
-        resourceSampleCount   : resource.sampleCount,
-        resourceSamples       : lane.resourceSamples.map(({atMs, cpuPercent, rssBytes}) => ({atMs, cpuPercent, rssBytes})),
-        rssHighWaterBytes     : resource.rssHighWaterBytes,
-        runtimeProfile        : projectRuntimeProfile(lane.runtimeProfile),
+        resourceCoverageRatio: resource.coverageRatio,
+        resourceGapCount     : resource.gapCount,
+        resourceSampleCount  : resource.sampleCount,
+        resourceSamples      : lane.resourceSamples.map(({atMs, cpuPercent, rssBytes}) => ({atMs, cpuPercent, rssBytes})),
+        rssHighWaterBytes    : resource.rssHighWaterBytes,
+        runtimeProfile       : projectRuntimeProfile(lane.runtimeProfile),
+        sourceCalls          : sourceCalls.map(call => ({
+            completedAtMs: call.completedAtMs,
+            demandAtMs   : call.demandAtMs,
+            id           : projectOpaqueId(call.id),
+            outcome      : call.outcome,
+            source       : call.source
+        })),
         throughputPerSecond   : completions.length / (windowMs / 1000),
-        unexpectedRefusalCount: operations.filter(operation => operation.outcome === 'unexpected-refusal').length
+        unexpectedRefusalCount: sourceCalls.filter(call => call.outcome === 'unexpected-refusal').length
     }
 }
 
@@ -680,15 +707,56 @@ function projectRuntimeProfile(runtime) {
 }
 
 /**
- * @summary Validates runtime-observed context and an independent over-limit probe.
+ * @summary Validates exactly one runtime context/refusal receipt per candidate and lane.
  * @param {Object} options Validation inputs.
- * @returns {Object} Bounded, identity-bound probe receipt.
+ * @returns {Object[]} Bounded candidate receipts.
  */
-function validateContextReceipt({ids, lane, laneName, profile, trial}) {
-    const label = `trial ${trial.executionIndex} ${laneName}`,
-          probe = lane.overLimitProbe;
+function validateContextEvidence({evidence, ids, plan}) {
+    if (!Array.isArray(evidence) || evidence.length !== CANDIDATES.length) {
+        throw new Error('provider-lane election requires one context receipt for each candidate 1, 2, and 4')
+    }
 
-    assertPositiveInteger(lane.observedContextTokensPerSlot, `${label}.observedContextTokensPerSlot`);
+    const sorted = [...evidence].sort((left, right) => left?.candidate - right?.candidate);
+
+    if (sorted.some((receipt, index) => receipt?.candidate !== CANDIDATES[index])) {
+        throw new Error('provider-lane context receipts require each candidate 1, 2, and 4 exactly once')
+    }
+
+    return sorted.map(receipt => {
+        const profile = getProfile(plan, receipt.candidate);
+
+        if (!Number.isFinite(receipt.startedAtMs) || !Number.isFinite(receipt.completedAtMs) ||
+            receipt.completedAtMs <= receipt.startedAtMs ||
+            receipt.compositionReceiptDigest !== profile.compositionReceiptDigest) {
+            throw new Error(`candidate ${receipt.candidate} requires a receipt-bound context evidence window`)
+        }
+
+        return {
+            candidate               : receipt.candidate,
+            completedAtMs           : receipt.completedAtMs,
+            compositionReceiptDigest: receipt.compositionReceiptDigest,
+            lanes                   : Object.fromEntries(LANE_NAMES.map(laneName => [laneName, validateContextLane({
+                ids,
+                lane    : receipt.lanes?.[laneName],
+                laneName,
+                profile,
+                receipt
+            })])),
+            startedAtMs: receipt.startedAtMs
+        }
+    })
+}
+
+/**
+ * @summary Validates one runtime-observed context value and its independent over-limit probe.
+ * @param {Object} options Validation inputs.
+ * @returns {Object} Bounded, identity-bound lane evidence.
+ */
+function validateContextLane({ids, lane, laneName, profile, receipt}) {
+    const label = `candidate ${receipt.candidate} ${laneName}`,
+          probe = lane?.overLimitProbe;
+
+    assertPositiveInteger(lane?.observedContextTokensPerSlot, `${label}.observedContextTokensPerSlot`);
     assertPositiveInteger(probe?.requestedContextTokens, `${label}.overLimitProbe.requestedContextTokens`);
 
     if (!probe || typeof probe.id !== 'string' || probe.id.length === 0 || probe.id.length > 1024 || ids.has(probe.id)) {
@@ -697,7 +765,7 @@ function validateContextReceipt({ids, lane, laneName, profile, trial}) {
     ids.add(probe.id);
 
     if (!Number.isFinite(probe.startedAtMs) || !Number.isFinite(probe.completedAtMs) ||
-        probe.startedAtMs < trial.startedAtMs || probe.completedAtMs > trial.completedAtMs ||
+        probe.startedAtMs < receipt.startedAtMs || probe.completedAtMs > receipt.completedAtMs ||
         probe.completedAtMs <= probe.startedAtMs ||
         probe.requestedContextTokens <= lane.observedContextTokensPerSlot ||
         probe.serviceKey !== profile.lanes[laneName].serviceKey ||
@@ -707,27 +775,30 @@ function validateContextReceipt({ids, lane, laneName, profile, trial}) {
         !DIGEST_PATTERN.test(probe.responseBodyDigest ?? '') ||
         !Number.isInteger(probe.observedOutputTokens) || probe.observedOutputTokens < 0 ||
         !Number.isInteger(probe.transportStatus) || probe.transportStatus < 100 || probe.transportStatus > 599) {
-        throw new Error(`trial ${trial.executionIndex} lane ${laneName} requires a truthful identity-bound over-limit probe`)
+        throw new Error(`candidate ${receipt.candidate} lane ${laneName} requires truthful identity-bound context evidence`)
     }
 
     if (probe.responseClass === 'completed' && probe.transportStatus >= 400 ||
         probe.responseClass !== 'completed' && probe.transportStatus < 400 ||
         probe.responseClass === 'context-limit-refusal' && probe.observedOutputTokens !== 0) {
-        throw new Error(`trial ${trial.executionIndex} lane ${laneName} has an inconsistent over-limit provider response`)
+        throw new Error(`candidate ${receipt.candidate} lane ${laneName} has an inconsistent over-limit provider response`)
     }
 
     return {
-        completedAtMs         : probe.completedAtMs,
-        id                    : projectOpaqueId(probe.id),
-        modelDigest           : probe.modelDigest,
-        observedOutputTokens  : probe.observedOutputTokens,
-        protocolAdapter       : probe.protocolAdapter,
-        requestedContextTokens: probe.requestedContextTokens,
-        responseBodyDigest    : probe.responseBodyDigest,
-        responseClass         : probe.responseClass,
-        serviceKey            : probe.serviceKey,
-        startedAtMs           : probe.startedAtMs,
-        transportStatus       : probe.transportStatus
+        observedContextTokensPerSlot: lane.observedContextTokensPerSlot,
+        overLimitProbe              : {
+            completedAtMs         : probe.completedAtMs,
+            id                    : projectOpaqueId(probe.id),
+            modelDigest           : probe.modelDigest,
+            observedOutputTokens  : probe.observedOutputTokens,
+            protocolAdapter       : probe.protocolAdapter,
+            requestedContextTokens: probe.requestedContextTokens,
+            responseBodyDigest    : probe.responseBodyDigest,
+            responseClass         : probe.responseClass,
+            serviceKey            : probe.serviceKey,
+            startedAtMs           : probe.startedAtMs,
+            transportStatus       : probe.transportStatus
+        }
     }
 }
 
@@ -763,7 +834,36 @@ function validateRuntimeProfile(runtime, allocation, laneName, trialIndex) {
 }
 
 /**
- * @summary Validates one operation timeline and derives queue/provider durations.
+ * @summary Validates one caller-visible source-call timeline used for durable progress.
+ * @param {Object} options
+ * @returns {Object}
+ */
+function validateSourceCall({call, ids, laneName, trial}) {
+    const allowedSources = laneName === 'chat' ? ['chat'] : EMBED_SOURCES;
+
+    if (typeof call?.id !== 'string' || call.id.length === 0 || call.id.length > 1024 || ids.has(call.id)) {
+        throw new Error(`trial ${trial.executionIndex} contains a missing or duplicate source-call id`)
+    }
+    ids.add(call.id);
+
+    if (!allowedSources.includes(call.source) || !OUTCOMES.includes(call.outcome) ||
+        !Number.isFinite(call.demandAtMs) || !Number.isFinite(call.completedAtMs) ||
+        call.demandAtMs < trial.startedAtMs || call.completedAtMs <= call.demandAtMs ||
+        call.completedAtMs > trial.completedAtMs) {
+        throw new Error(`trial ${trial.executionIndex} lane ${laneName} contains an invalid source-call contract`)
+    }
+
+    return {
+        completedAtMs: call.completedAtMs,
+        demandAtMs   : call.demandAtMs,
+        id           : call.id,
+        outcome      : call.outcome,
+        source       : call.source
+    }
+}
+
+/**
+ * @summary Validates one provider-operation timeline and derives queue/provider durations.
  * @param {Object} options
  * @returns {Object}
  */
@@ -775,8 +875,9 @@ function validateOperation({ids, laneName, operation, trial}) {
     }
     ids.add(operation.id);
 
-    if (!allowedSources.includes(operation.source) || !QUEUE_DISPOSITIONS.includes(operation.queueDisposition) ||
-        !OUTCOMES.includes(operation.outcome)) {
+    if (typeof operation.callId !== 'string' || operation.callId.length === 0 || operation.callId.length > 1024 ||
+        !allowedSources.includes(operation.source) || !QUEUE_DISPOSITIONS.includes(operation.queueDisposition) ||
+        !PROVIDER_OUTCOMES.includes(operation.outcome)) {
         throw new Error(`trial ${trial.executionIndex} lane ${laneName} contains an invalid operation contract`)
     }
     if (!Number.isFinite(operation.providerStartedAtMs) || !Number.isFinite(operation.completedAtMs) ||
@@ -804,6 +905,7 @@ function validateOperation({ids, laneName, operation, trial}) {
     }
 
     return {
+        callId             : operation.callId,
         completedAtMs      : operation.completedAtMs,
         demandAtMs,
         id                 : projectOpaqueId(operation.id),
@@ -823,10 +925,10 @@ function validateOperation({ids, laneName, operation, trial}) {
  * @param {Number} trialIndex Trial index.
  */
 function validateSourceCardinality(lanes, expected, trialIndex) {
-    const operations = [...lanes.chat.operations, ...lanes.embedding.operations];
+    const sourceCalls = [...lanes.chat.sourceCalls, ...lanes.embedding.sourceCalls];
 
     for (const source of SOURCE_NAMES) {
-        const count = operations.filter(operation => operation.source === source).length;
+        const count = sourceCalls.filter(call => call.source === source).length;
 
         if (count !== expected[source]) {
             throw new Error(`trial ${trialIndex} source ${source} offered ${count}; fixed workload requires ${expected[source]}`)
@@ -840,15 +942,15 @@ function validateSourceCardinality(lanes, expected, trialIndex) {
  * @returns {Boolean}
  */
 function hasCommonDemandOverlap(lanes) {
-    const operations = [...lanes.chat.operations, ...lanes.embedding.operations],
-          boundaries = [...new Set(operations.flatMap(operation => [operation.demandAtMs, operation.completedAtMs]))]
+    const sourceCalls = [...lanes.chat.sourceCalls, ...lanes.embedding.sourceCalls],
+          boundaries  = [...new Set(sourceCalls.flatMap(call => [call.demandAtMs, call.completedAtMs]))]
               .sort((a, b) => a - b);
 
     return boundaries.slice(0, -1).some((startMs, index) => {
         const probeAtMs = (startMs + boundaries[index + 1]) / 2;
 
-        return SOURCE_NAMES.every(source => operations.some(operation =>
-            operation.source === source && operation.demandAtMs <= probeAtMs && operation.completedAtMs > probeAtMs
+        return SOURCE_NAMES.every(source => sourceCalls.some(call =>
+            call.source === source && call.demandAtMs <= probeAtMs && call.completedAtMs > probeAtMs
         ))
     })
 }
@@ -887,9 +989,19 @@ function validateResidencyReceipt(receipt, trial, trialIndex, priorCompletedAtMs
  * @param {Object} options
  * @returns {Object}
  */
-function evaluateCandidate({candidate, plan, trials}) {
+function evaluateCandidate({candidate, contextEvidence, plan, trials}) {
     const failures = [],
           profile  = getProfile(plan, candidate);
+
+    for (const laneName of LANE_NAMES) {
+        const evidence = contextEvidence.lanes[laneName],
+              fail     = code => failures.push({code, lane: laneName, runId: 'context-evidence'});
+
+        evidence.observedContextTokensPerSlot < plan.slo.lanes[laneName].minContextTokensPerSlot &&
+            fail('CONTEXT_BELOW_SLO');
+        evidence.overLimitProbe.responseClass !== 'context-limit-refusal' &&
+            fail('OVER_LIMIT_NOT_REFUSED')
+    }
 
     for (const trial of trials) {
         if (!trial.workload.concurrent) {
@@ -910,6 +1022,7 @@ function evaluateCandidate({candidate, plan, trials}) {
 
     return {
         candidate,
+        contextEvidence,
         failures,
         sampleCount: trials.length,
         status     : failures.length === 0 ? 'PASS' : 'FAIL',
@@ -929,9 +1042,7 @@ function evaluateLane({allocation, failures, lane, laneName, runId, slo}) {
     const fail          = code => failures.push({code, lane: laneName, runId}),
           requiredCount = lane.queueDispositionCounts[slo.requiredQueueDisposition];
 
-    lane.observedContextTokensPerSlot < slo.minContextTokensPerSlot && fail('CONTEXT_BELOW_SLO');
-    lane.overLimitProbe.responseClass !== 'context-limit-refusal' && fail('OVER_LIMIT_NOT_REFUSED');
-    requiredCount !== lane.offeredOperations && fail('QUEUE_DISPOSITION_MISMATCH');
+    requiredCount !== lane.providerOperationCount && fail('QUEUE_DISPOSITION_MISMATCH');
     lane.maxNeoQueueWaitMs !== null && lane.maxNeoQueueWaitMs > slo.maxNeoQueueWaitMs && fail('QUEUE_WAIT_EXCEEDED');
     lane.maxProviderDurationMs > slo.maxProviderDurationMs && fail('PROVIDER_DURATION_EXCEEDED');
     lane.throughputPerSecond < slo.minThroughputPerSecond && fail('THROUGHPUT_BELOW_SLO');

--- a/ai/scripts/benchmark/helpers/providerLaneElectionCore.mjs
+++ b/ai/scripts/benchmark/helpers/providerLaneElectionCore.mjs
@@ -24,7 +24,12 @@ const
     LANE_NAMES             = Object.freeze(['chat', 'embedding']),
     OUTCOMES               = Object.freeze(['completed', 'error', 'unexpected-refusal']),
     PROVIDER_OUTCOMES      = Object.freeze(['completed', 'error']),
-    PROBE_RESPONSE_CLASSES = Object.freeze(['completed', 'context-limit-refusal', 'provider-error']),
+    PROBE_RESPONSE_CLASSES = Object.freeze([
+        'completed',
+        'context-limit-refusal',
+        'physical-batch-refusal',
+        'provider-error'
+    ]),
     QUEUE_DISPOSITIONS     = Object.freeze(['not-applicable', 'queued']),
     SAFE_PUBLIC_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$/,
     SOURCE_NAMES           = Object.freeze(['chat', ...EMBED_SOURCES]),
@@ -753,21 +758,62 @@ function validateContextEvidence({evidence, ids, plan}) {
  * @returns {Object} Bounded, identity-bound lane evidence.
  */
 function validateContextLane({ids, lane, laneName, profile, receipt}) {
-    const label = `candidate ${receipt.candidate} ${laneName}`,
-          probe = lane?.overLimitProbe;
+    const label = `candidate ${receipt.candidate} ${laneName}`;
 
     assertPositiveInteger(lane?.observedContextTokensPerSlot, `${label}.observedContextTokensPerSlot`);
-    assertPositiveInteger(probe?.requestedContextTokens, `${label}.overLimitProbe.requestedContextTokens`);
+    const overLimitProbe = validateContextProbe({
+        ids,
+        label,
+        lane,
+        laneName,
+        mode : 'over-limit',
+        probe: lane?.overLimitProbe,
+        profile,
+        receipt
+    });
+    const supportedLimitProbe = laneName === 'embedding'
+        ? validateContextProbe({
+            ids,
+            label,
+            lane,
+            laneName,
+            mode : 'supported-limit',
+            probe: lane?.supportedLimitProbe,
+            profile,
+            receipt
+        })
+        : null;
+
+    return {
+        observedContextTokensPerSlot: lane.observedContextTokensPerSlot,
+        overLimitProbe,
+        ...(supportedLimitProbe ? {supportedLimitProbe} : {})
+    }
+}
+
+/**
+ * @summary Validates and projects one supported-limit or over-limit provider probe.
+ * @param {Object} options Validation inputs.
+ * @returns {Object} Bounded structural response receipt.
+ */
+function validateContextProbe({ids, label, lane, laneName, mode, probe, profile, receipt}) {
+    const path = `${label}.${mode === 'over-limit' ? 'overLimitProbe' : 'supportedLimitProbe'}`;
+
+    assertPositiveInteger(probe?.requestedContextTokens, `${path}.requestedContextTokens`);
 
     if (!probe || typeof probe.id !== 'string' || probe.id.length === 0 || probe.id.length > 1024 || ids.has(probe.id)) {
-        throw new Error(`${label}.overLimitProbe requires a unique request id`)
+        throw new Error(`${path} requires a unique request id`)
     }
     ids.add(probe.id);
 
-    if (!Number.isFinite(probe.startedAtMs) || !Number.isFinite(probe.completedAtMs) ||
+    const requestBound = mode === 'over-limit'
+        ? probe.requestedContextTokens > lane.observedContextTokensPerSlot
+        : probe.requestedContextTokens === lane.observedContextTokensPerSlot;
+
+    if (lane.observedContextTokensPerSlot > profile.lanes[laneName].totalContextTokens ||
+        !requestBound || !Number.isFinite(probe.startedAtMs) || !Number.isFinite(probe.completedAtMs) ||
         probe.startedAtMs < receipt.startedAtMs || probe.completedAtMs > receipt.completedAtMs ||
         probe.completedAtMs <= probe.startedAtMs ||
-        probe.requestedContextTokens <= lane.observedContextTokensPerSlot ||
         probe.serviceKey !== profile.lanes[laneName].serviceKey ||
         probe.modelDigest !== profile.lanes[laneName].modelDigest ||
         probe.protocolAdapter !== profile.lanes[laneName].protocolAdapter ||
@@ -778,27 +824,28 @@ function validateContextLane({ids, lane, laneName, profile, receipt}) {
         throw new Error(`candidate ${receipt.candidate} lane ${laneName} requires truthful identity-bound context evidence`)
     }
 
-    if (probe.responseClass === 'completed' && probe.transportStatus >= 400 ||
+    if (probe.responseClass === 'completed' && (probe.transportStatus < 200 || probe.transportStatus >= 300) ||
         probe.responseClass !== 'completed' && probe.transportStatus < 400 ||
-        probe.responseClass === 'context-limit-refusal' && probe.observedOutputTokens !== 0) {
-        throw new Error(`candidate ${receipt.candidate} lane ${laneName} has an inconsistent over-limit provider response`)
+        probe.responseClass !== 'completed' && probe.observedOutputTokens !== 0) {
+        throw new Error(`candidate ${receipt.candidate} lane ${laneName} has an inconsistent ${mode} provider response`)
+    }
+    if (probe.responseClass === 'physical-batch-refusal' &&
+        (laneName !== 'embedding' || probe.requestedContextTokens <= profile.lanes.embedding.totalContextTokens)) {
+        throw new Error(`candidate ${receipt.candidate} lane ${laneName} has an impossible physical-batch refusal`)
     }
 
     return {
-        observedContextTokensPerSlot: lane.observedContextTokensPerSlot,
-        overLimitProbe              : {
-            completedAtMs         : probe.completedAtMs,
-            id                    : projectOpaqueId(probe.id),
-            modelDigest           : probe.modelDigest,
-            observedOutputTokens  : probe.observedOutputTokens,
-            protocolAdapter       : probe.protocolAdapter,
-            requestedContextTokens: probe.requestedContextTokens,
-            responseBodyDigest    : probe.responseBodyDigest,
-            responseClass         : probe.responseClass,
-            serviceKey            : probe.serviceKey,
-            startedAtMs           : probe.startedAtMs,
-            transportStatus       : probe.transportStatus
-        }
+        completedAtMs         : probe.completedAtMs,
+        id                    : projectOpaqueId(probe.id),
+        modelDigest           : probe.modelDigest,
+        observedOutputTokens  : probe.observedOutputTokens,
+        protocolAdapter       : probe.protocolAdapter,
+        requestedContextTokens: probe.requestedContextTokens,
+        responseBodyDigest    : probe.responseBodyDigest,
+        responseClass         : probe.responseClass,
+        serviceKey            : probe.serviceKey,
+        startedAtMs           : probe.startedAtMs,
+        transportStatus       : probe.transportStatus
     }
 }
 
@@ -999,7 +1046,12 @@ function evaluateCandidate({candidate, contextEvidence, plan, trials}) {
 
         evidence.observedContextTokensPerSlot < plan.slo.lanes[laneName].minContextTokensPerSlot &&
             fail('CONTEXT_BELOW_SLO');
-        evidence.overLimitProbe.responseClass !== 'context-limit-refusal' &&
+        laneName === 'embedding' &&
+            (evidence.supportedLimitProbe.responseClass !== 'completed' ||
+                evidence.supportedLimitProbe.observedOutputTokens < 1) &&
+            fail('SUPPORTED_LIMIT_NOT_COMPLETED');
+        !(evidence.overLimitProbe.responseClass === 'context-limit-refusal' ||
+            laneName === 'embedding' && evidence.overLimitProbe.responseClass === 'physical-batch-refusal') &&
             fail('OVER_LIMIT_NOT_REFUSED')
     }
 

--- a/ai/scripts/benchmark/helpers/providerLaneElectionCore.mjs
+++ b/ai/scripts/benchmark/helpers/providerLaneElectionCore.mjs
@@ -1,0 +1,1064 @@
+/**
+ * @module ai/scripts/benchmark/helpers/providerLaneElectionCore
+ * @summary Pure evidence validation and election core for the fixed-envelope provider-lane benchmark.
+ *
+ * The live runner owns composition, workload dispatch, resource sampling, and artifact
+ * authority. This module owns only a deterministic counterbalanced schedule plus pure
+ * validation/aggregation over injected receipts. Synthetic controls can exercise every branch,
+ * but they can never emit authoritative deployment inputs.
+ *
+ * @see https://github.com/neomjs/neo/issues/17024
+ * @see learn/agentos/decisions/0014-cloud-deployment-topology-and-scheduler-task-taxonomy.md
+ */
+
+import {createHash}         from 'node:crypto';
+
+import {aggregateWindow}    from './servingCostCore.mjs';
+import {median, percentile} from './stats.mjs';
+
+const
+    CANDIDATES             = Object.freeze([1, 2, 4]),
+    DIGEST_PATTERN         = /^(?:sha256:)?[0-9a-f]{64}$/i,
+    EVIDENCE_CLASSES       = Object.freeze(['exact-head-candidate', 'synthetic-control']),
+    EMBED_SOURCES          = Object.freeze(['knowledge-base', 'memory-core', 'orchestrator']),
+    LANE_NAMES             = Object.freeze(['chat', 'embedding']),
+    OUTCOMES               = Object.freeze(['completed', 'error', 'unexpected-refusal']),
+    PROBE_RESPONSE_CLASSES = Object.freeze(['completed', 'provider-error']),
+    QUEUE_DISPOSITIONS     = Object.freeze(['not-applicable', 'queued']),
+    SAFE_PUBLIC_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$/,
+    SOURCE_NAMES           = Object.freeze(['chat', ...EMBED_SOURCES]),
+
+    // Six permutations ordered as one continuous stream. Across all 17 real boundaries no
+    // candidate follows itself and the six directed pair counts differ by at most one.
+    COUNTERBALANCE_BLOCK = Object.freeze([
+        1, 2, 4,
+        1, 4, 2,
+        4, 2, 1,
+        2, 1, 4,
+        2, 4, 1,
+        4, 1, 2
+    ]),
+
+    SLO_FIELDS = Object.freeze([
+        'maxCpuHighWaterPercent',
+        'maxErrors',
+        'maxNeoQueueWaitMs',
+        'maxProgressGapMs',
+        'maxProviderDurationMs',
+        'maxResourceGapCount',
+        'maxRssHighWaterBytes',
+        'maxUnexpectedRefusals',
+        'minCompletedOperations',
+        'minContextTokensPerSlot',
+        'minResourceCoverageRatio',
+        'minThroughputPerSecond'
+    ]),
+
+    SUMMARY_FIELDS = Object.freeze([
+        'cpuHighWaterPercent',
+        'maxNeoQueueWaitMs',
+        'maxProgressGapMs',
+        'maxProviderDurationMs',
+        'resourceCoverageRatio',
+        'resourceGapCount',
+        'resourceSampleCount',
+        'rssHighWaterBytes',
+        'throughputPerSecond'
+    ]);
+
+/**
+ * @summary Builds complete counterbalance blocks for the candidate matrix.
+ *
+ * The output is the actual continuous execution order, not grouped candidate buckets. One
+ * block runs every candidate six times, covers all six permutations, has no equal-candidate
+ * transition, and balances directed adjacency across sequence boundaries.
+ *
+ * @param {Object} options
+ * @param {Number} [options.blocks=1] Positive number of complete counterbalance blocks.
+ * @returns {ReadonlyArray<{blockIndex: Number, candidate: Number, executionIndex: Number, id: String}>}
+ */
+export function buildProviderLaneCandidateSchedule({blocks = 1} = {}) {
+    if (!Number.isInteger(blocks) || blocks <= 0) {
+        throw new Error('provider-lane schedule requires a positive integer block count')
+    }
+
+    const schedule = [];
+
+    for (let blockIndex = 0; blockIndex < blocks; blockIndex++) {
+        COUNTERBALANCE_BLOCK.forEach(candidate => {
+            const executionIndex = schedule.length;
+
+            schedule.push(Object.freeze({
+                blockIndex,
+                candidate,
+                executionIndex,
+                id: `block-${blockIndex}:trial-${executionIndex % COUNTERBALANCE_BLOCK.length}`
+            }))
+        })
+    }
+
+    return Object.freeze(schedule)
+}
+
+/**
+ * @summary Creates the canonical digest binding candidate profiles, workload, SLO, and
+ * resource-sampling coordinates into one exact election plan identity.
+ * @param {Object} plan Candidate election plan.
+ * @returns {String} `sha256:`-prefixed canonical plan digest.
+ */
+export function createProviderLanePlanDigest(plan) {
+    validatePlan(plan);
+
+    return deriveProviderLanePlanDigest(plan)
+}
+
+/**
+ * @summary Validates one complete fixed-envelope matrix and evaluates the smallest passing
+ * candidate.
+ *
+ * Evidence-integrity failures throw because an incomplete or incomparable matrix cannot
+ * support any verdict. Measured SLO failures remain in candidate receipts. Synthetic controls
+ * return `NON_AUTHORITATIVE` with a provisional outcome and no deployment inputs; only an
+ * exact-head candidate carrying the live runner's complete provenance may return `ELECTED` or
+ * `NO_ELECTION`.
+ *
+ * @param {Object} options
+ * @param {Object} options.plan Immutable candidate profiles, workload, SLO, sampling, and provenance.
+ * @param {Object[]} options.trials Chronological raw operation/resource receipts.
+ * @returns {Object} Bounded election receipt.
+ */
+export function evaluateProviderLaneElection({plan, trials} = {}) {
+    const schedule   = validatePlan(plan),
+          planDigest = deriveProviderLanePlanDigest(plan),
+          authority  = validateEvidence(plan.evidence, planDigest),
+          derived    = validateAndDeriveTrials({plan, schedule, trials});
+
+    const candidates = CANDIDATES.map(candidate => evaluateCandidate({
+              candidate,
+              plan,
+              trials: derived.filter(trial => trial.candidate === candidate)
+          })),
+          winner = candidates.find(candidate => candidate.status === 'PASS') ?? null,
+          computedOutcome = winner ? 'ELECTED' : 'NO_ELECTION';
+
+    const base = {
+        authority,
+        candidates,
+        computedOutcome,
+        jointSlo: {
+            lanes: Object.fromEntries(LANE_NAMES.map(laneName => [laneName, projectLaneSlo(plan.slo.lanes[laneName])]))
+        },
+        planCoordinates: {
+            blocks                   : plan.blocks,
+            candidateRunCount        : COUNTERBALANCE_BLOCK.filter(candidate => candidate === 1).length * plan.blocks,
+            planDigest,
+            resourceSampling         : projectResourceSampling(plan.resourceSampling),
+            totalRunCount            : schedule.length,
+            uncertaintyMethod        : 'observed-range-and-nearest-rank-p95',
+            workloadDigest           : plan.workload.digest,
+            workloadOfferedOperations: {...plan.workload.offeredOperations}
+        }
+    };
+
+    if (!authority.authoritative) {
+        return {
+            ...base,
+            electedCandidate    : null,
+            immutableInputs     : null,
+            provisionalCandidate: winner?.candidate ?? null,
+            status              : 'NON_AUTHORITATIVE'
+        }
+    }
+
+    return {
+        ...base,
+        electedCandidate    : winner?.candidate ?? null,
+        immutableInputs     : winner ? buildImmutableInputs(plan, winner.candidate) : null,
+        provisionalCandidate: null,
+        status              : computedOutcome
+    }
+}
+
+/**
+ * @summary Projects the exact joint-SLO allowlist carried by the public receipt.
+ * @param {Object} lane SLO lane.
+ * @returns {Object}
+ */
+function projectLaneSlo(lane) {
+    return Object.fromEntries([
+        ...SLO_FIELDS.map(field => [field, lane[field]]),
+        ['requiredQueueDisposition', lane.requiredQueueDisposition]
+    ])
+}
+
+/**
+ * @summary Projects the exact resource-sampling allowlist carried by the public receipt.
+ * @param {Object} sampling Sampling plan.
+ * @returns {Object}
+ */
+function projectResourceSampling(sampling) {
+    return {
+        activeCpuThreshold: sampling.activeCpuThreshold,
+        expectedIntervalMs: sampling.expectedIntervalMs,
+        gapFactor         : sampling.gapFactor
+    }
+}
+
+/**
+ * @summary Hashes only semantic plan coordinates in a stable candidate/key order.
+ * @param {Object} plan Validated candidate election plan.
+ * @returns {String}
+ */
+function deriveProviderLanePlanDigest(plan) {
+    const coordinates = {
+        blocks           : plan.blocks,
+        candidateProfiles: [...plan.candidateProfiles]
+            .sort((a, b) => a.embeddingSlots - b.embeddingSlots)
+            .map(projectCandidateProfile),
+        resourceSampling: projectResourceSampling(plan.resourceSampling),
+        slo             : {lanes: Object.fromEntries(LANE_NAMES.map(laneName => [
+            laneName,
+            projectLaneSlo(plan.slo.lanes[laneName])
+        ]))},
+        workload: {
+            digest           : plan.workload.digest,
+            offeredOperations: Object.fromEntries(SOURCE_NAMES.map(source => [
+                source,
+                plan.workload.offeredOperations[source]
+            ]))
+        }
+    };
+
+    return `sha256:${createHash('sha256').update(stableSerialize(coordinates)).digest('hex')}`
+}
+
+/**
+ * @summary Projects the exact candidate-profile fields which define one election plan.
+ * @param {Object} profile Candidate profile.
+ * @returns {Object}
+ */
+function projectCandidateProfile(profile) {
+    return {
+        embeddingSlots: profile.embeddingSlots,
+        lanes         : Object.fromEntries(LANE_NAMES.map(laneName => [laneName, {
+            contextLimitCode  : profile.lanes[laneName].contextLimitCode,
+            contextLimitStatus: profile.lanes[laneName].contextLimitStatus,
+            cpuCores          : profile.lanes[laneName].cpuCores,
+            imageDigest       : profile.lanes[laneName].imageDigest,
+            memoryBytes       : profile.lanes[laneName].memoryBytes,
+            modelDigest       : profile.lanes[laneName].modelDigest,
+            parallelism       : profile.lanes[laneName].parallelism,
+            serviceKey        : profile.lanes[laneName].serviceKey
+        }])),
+        totalResources: {
+            cpuCores   : profile.totalResources.cpuCores,
+            memoryBytes: profile.totalResources.memoryBytes
+        }
+    }
+}
+
+/**
+ * @summary Serializes JSON-compatible evidence with recursively sorted object keys.
+ * @param {*} value JSON-compatible value.
+ * @returns {String}
+ */
+function stableSerialize(value) {
+    const normalize = item => {
+        if (Array.isArray(item)) {
+            return item.map(normalize)
+        }
+
+        if (item && typeof item === 'object') {
+            return Object.fromEntries(Object.keys(item).sort().map(key => [key, normalize(item[key])]))
+        }
+
+        return item
+    };
+
+    return JSON.stringify(normalize(value))
+}
+
+/**
+ * @summary Validates immutable plan coordinates and returns the matching schedule.
+ * @param {Object} plan Candidate plan.
+ * @returns {ReadonlyArray<Object>}
+ */
+function validatePlan(plan) {
+    if (!plan || typeof plan !== 'object' || Array.isArray(plan)) {
+        throw new Error('provider-lane election requires an explicit plan')
+    }
+
+    const schedule = buildProviderLaneCandidateSchedule({blocks: plan.blocks});
+
+    validateCandidateProfiles(plan.candidateProfiles);
+    validateSlo(plan.slo);
+    validateWorkload(plan.workload);
+    validateResourceSampling(plan.resourceSampling);
+
+    return schedule
+}
+
+/**
+ * @summary Validates exact `{1,2,4}` profiles under one fixed total envelope and identity set.
+ * @param {Object[]} profiles Candidate profiles.
+ */
+function validateCandidateProfiles(profiles) {
+    if (!Array.isArray(profiles) || profiles.length !== CANDIDATES.length) {
+        throw new Error('provider-lane plan requires exactly three candidate profiles: 1, 2, and 4')
+    }
+
+    const sorted = [...profiles].sort((a, b) => a?.embeddingSlots - b?.embeddingSlots);
+
+    if (sorted.some((profile, index) => profile?.embeddingSlots !== CANDIDATES[index])) {
+        throw new Error('provider-lane plan requires each candidate 1, 2, and 4 exactly once')
+    }
+
+    for (const profile of sorted) {
+        validateCandidateProfile(profile)
+    }
+
+    const baseline = sorted[0];
+
+    for (const profile of sorted.slice(1)) {
+        if (profile.totalResources.cpuCores !== baseline.totalResources.cpuCores ||
+            profile.totalResources.memoryBytes !== baseline.totalResources.memoryBytes) {
+            throw new Error(`candidate ${profile.embeddingSlots} changed the fixed total CPU/memory envelope`)
+        }
+
+        for (const laneName of LANE_NAMES) {
+            for (const field of ['serviceKey', 'imageDigest', 'modelDigest', 'contextLimitCode', 'contextLimitStatus']) {
+                if (profile.lanes[laneName][field] !== baseline.lanes[laneName][field]) {
+                    throw new Error(`candidate ${profile.embeddingSlots} changed ${laneName}.${field}; profile mismatch aborts the election`)
+                }
+            }
+        }
+    }
+}
+
+/**
+ * @summary Validates one candidate profile and its per-lane allocation.
+ * @param {Object} profile Candidate profile.
+ */
+function validateCandidateProfile(profile) {
+    assertPositiveFinite(profile?.totalResources?.cpuCores, `candidate ${profile?.embeddingSlots} totalResources.cpuCores`);
+    assertPositiveInteger(profile?.totalResources?.memoryBytes, `candidate ${profile?.embeddingSlots} totalResources.memoryBytes`);
+
+    let allocatedCpu    = 0,
+        allocatedMemory = 0;
+
+    for (const laneName of LANE_NAMES) {
+        const lane = profile?.lanes?.[laneName];
+
+        if (!lane || !SAFE_PUBLIC_ID_PATTERN.test(lane.serviceKey ?? '')) {
+            throw new Error(`candidate ${profile?.embeddingSlots} lanes.${laneName}.serviceKey is required`)
+        }
+        if (!DIGEST_PATTERN.test(lane.imageDigest ?? '') || !DIGEST_PATTERN.test(lane.modelDigest ?? '')) {
+            throw new Error(`candidate ${profile?.embeddingSlots} lanes.${laneName} requires immutable image and model digests`)
+        }
+        if (!Number.isInteger(lane.contextLimitStatus) || lane.contextLimitStatus < 400 || lane.contextLimitStatus > 599 ||
+            typeof lane.contextLimitCode !== 'string' || !/^[A-Z][A-Z0-9_.-]{0,63}$/.test(lane.contextLimitCode)) {
+            throw new Error(`candidate ${profile?.embeddingSlots} lanes.${laneName} requires a closed context-limit code/status pair`)
+        }
+
+        assertPositiveFinite(lane.cpuCores, `candidate ${profile.embeddingSlots} lanes.${laneName}.cpuCores`);
+        assertPositiveInteger(lane.memoryBytes, `candidate ${profile.embeddingSlots} lanes.${laneName}.memoryBytes`);
+
+        allocatedCpu    += lane.cpuCores;
+        allocatedMemory += lane.memoryBytes
+    }
+
+    if (profile.lanes.chat.serviceKey === profile.lanes.embedding.serviceKey) {
+        throw new Error(`candidate ${profile.embeddingSlots} must name distinct chat and embedding service identities`)
+    }
+    if (Math.abs(allocatedCpu - profile.totalResources.cpuCores) > Number.EPSILON * 16 ||
+        allocatedMemory !== profile.totalResources.memoryBytes) {
+        throw new Error(`candidate ${profile.embeddingSlots} lane allocations must exactly consume the declared total envelope`)
+    }
+    if (profile.lanes.chat.parallelism !== 1 || profile.lanes.embedding.parallelism !== profile.embeddingSlots) {
+        throw new Error(`candidate ${profile.embeddingSlots} must keep chat parallelism 1 and embedding parallelism equal to the candidate`)
+    }
+}
+
+/**
+ * @summary Validates the explicit joint SLO without inventing defaults.
+ * @param {Object} slo Joint SLO.
+ */
+function validateSlo(slo) {
+    for (const laneName of LANE_NAMES) {
+        const lane = slo?.lanes?.[laneName];
+
+        if (!lane || !QUEUE_DISPOSITIONS.includes(lane.requiredQueueDisposition)) {
+            throw new Error(`provider-lane SLO requires lanes.${laneName} with an explicit queue disposition`)
+        }
+
+        for (const field of SLO_FIELDS) {
+            if (!Number.isFinite(lane[field]) || lane[field] < 0) {
+                throw new Error(`provider-lane SLO lanes.${laneName}.${field} must be finite and non-negative`)
+            }
+        }
+
+        for (const field of [
+            'maxErrors',
+            'maxResourceGapCount',
+            'maxUnexpectedRefusals',
+            'minCompletedOperations',
+            'minContextTokensPerSlot'
+        ]) {
+            if (!Number.isInteger(lane[field])) {
+                throw new Error(`provider-lane SLO lanes.${laneName}.${field} must be an integer`)
+            }
+        }
+
+        if (lane.minCompletedOperations <= 0 || lane.minContextTokensPerSlot <= 0 || lane.minThroughputPerSecond <= 0 ||
+            lane.minResourceCoverageRatio <= 0 || lane.minResourceCoverageRatio > 1) {
+            throw new Error(`provider-lane SLO lanes.${laneName} requires positive progress, context, throughput, and coverage targets`)
+        }
+    }
+}
+
+/**
+ * @summary Validates one immutable workload identity and exact offered-operation counts.
+ * @param {Object} workload Workload coordinate.
+ */
+function validateWorkload(workload) {
+    if (!DIGEST_PATTERN.test(workload?.digest ?? '')) {
+        throw new Error('provider-lane workload requires an immutable digest')
+    }
+
+    for (const source of SOURCE_NAMES) {
+        assertPositiveInteger(workload?.offeredOperations?.[source], `workload.offeredOperations.${source}`)
+    }
+
+    const embeddingOffers = EMBED_SOURCES.reduce((sum, source) => sum + workload.offeredOperations[source], 0);
+
+    if (embeddingOffers < Math.max(...CANDIDATES)) {
+        throw new Error('provider-lane workload must offer enough embedding operations to exercise candidate 4')
+    }
+
+    if (Object.keys(workload.offeredOperations).some(source => !SOURCE_NAMES.includes(source))) {
+        throw new Error('provider-lane workload contains an unknown demand source')
+    }
+}
+
+/**
+ * @summary Validates the raw resource sampler contract used by `aggregateWindow`.
+ * @param {Object} sampling Sampling coordinate.
+ */
+function validateResourceSampling(sampling) {
+    assertPositiveFinite(sampling?.activeCpuThreshold, 'resourceSampling.activeCpuThreshold');
+    assertPositiveFinite(sampling?.expectedIntervalMs, 'resourceSampling.expectedIntervalMs');
+    assertPositiveFinite(sampling?.gapFactor, 'resourceSampling.gapFactor')
+}
+
+/**
+ * @summary Validates provenance and distinguishes evidence integrity from evidence authority.
+ * @param {Object} evidence Evidence provenance.
+ * @param {String} planDigest Canonical digest derived from the evaluated plan.
+ * @returns {Object}
+ */
+function validateEvidence(evidence, planDigest) {
+    if (!EVIDENCE_CLASSES.includes(evidence?.evidenceClass)) {
+        throw new Error(`provider-lane evidenceClass must be one of: ${EVIDENCE_CLASSES.join(', ')}`)
+    }
+
+    if (evidence.evidenceClass === 'synthetic-control') {
+        return {authoritative: false, evidenceClass: evidence.evidenceClass}
+    }
+
+    for (const field of ['hardwareId', 'profileDigest', 'repositoryHead', 'runnerDigest']) {
+        if (typeof evidence[field] !== 'string' || evidence[field].length === 0) {
+            throw new Error(`exact-head provider-lane evidence requires ${field}`)
+        }
+    }
+    if (!/^[0-9a-f]{40}$/i.test(evidence.repositoryHead) || !DIGEST_PATTERN.test(evidence.profileDigest) ||
+        !DIGEST_PATTERN.test(evidence.runnerDigest) || !SAFE_PUBLIC_ID_PATTERN.test(evidence.hardwareId) ||
+        evidence.canonicalPlane !== true) {
+        throw new Error('exact-head provider-lane evidence requires canonical-plane and immutable head/profile/runner provenance')
+    }
+    if (evidence.profileDigest !== planDigest) {
+        throw new Error('exact-head provider-lane profileDigest does not match the canonical election plan digest')
+    }
+
+    return {
+        authoritative : true,
+        canonicalPlane: true,
+        evidenceClass : evidence.evidenceClass,
+        hardwareId    : evidence.hardwareId,
+        profileDigest : evidence.profileDigest,
+        repositoryHead: evidence.repositoryHead,
+        runnerDigest  : evidence.runnerDigest
+    }
+}
+
+/**
+ * @summary Validates chronological trial receipts and derives all election metrics.
+ * @param {Object} options
+ * @returns {Object[]}
+ */
+function validateAndDeriveTrials({plan, schedule, trials}) {
+    if (!Array.isArray(trials) || trials.length !== schedule.length) {
+        throw new Error(`provider-lane matrix requires ${schedule.length} chronological trials`)
+    }
+
+    const ids     = new Set(),
+          derived = [];
+
+    trials.forEach((trial, index) => {
+        const slot = schedule[index];
+
+        if (trial?.scheduleId !== slot.id || trial?.candidate !== slot.candidate || trial?.executionIndex !== index) {
+            throw new Error(`trial ${index} does not match counterbalanced slot ${slot.id} candidate ${slot.candidate}`)
+        }
+        if (!Number.isFinite(trial.startedAtMs) || !Number.isFinite(trial.completedAtMs) || trial.completedAtMs <= trial.startedAtMs) {
+            throw new Error(`trial ${index} requires finite startedAtMs < completedAtMs`)
+        }
+        if (index > 0 && trial.startedAtMs < trials[index - 1].completedAtMs) {
+            throw new Error(`trial ${index} overlaps the previous candidate trial`)
+        }
+        if (trial.workloadDigest !== plan.workload.digest) {
+            throw new Error(`trial ${index} changed the immutable workload digest`)
+        }
+
+        const profile = getProfile(plan, trial.candidate),
+              lanes   = Object.fromEntries(LANE_NAMES.map(laneName => [
+                  laneName,
+                  deriveLaneReceipt({ids, lane: trial.lanes?.[laneName], laneName, plan, profile, trial})
+              ]));
+
+        validateSourceCardinality(lanes, plan.workload.offeredOperations, index);
+
+        derived.push({
+            candidate      : trial.candidate,
+            completedAtMs  : trial.completedAtMs,
+            executionIndex : index,
+            lanes,
+            residencyBefore: validateResidencyReceipt(
+                trial.residencyBefore,
+                trial,
+                index,
+                index > 0 ? trials[index - 1].completedAtMs : Number.NEGATIVE_INFINITY
+            ),
+            scheduleId : trial.scheduleId,
+            startedAtMs: trial.startedAtMs,
+            workload   : {
+                concurrent       : hasCommonDemandOverlap(lanes),
+                digest           : trial.workloadDigest,
+                offeredOperations: {...plan.workload.offeredOperations}
+            }
+        })
+    });
+
+    return derived
+}
+
+/**
+ * @summary Derives one lane's queue/provider/progress/resource metrics from raw receipts.
+ * @param {Object} options
+ * @returns {Object}
+ */
+function deriveLaneReceipt({ids, lane, laneName, plan, profile, trial}) {
+    if (!lane || !Array.isArray(lane.operations) || !Array.isArray(lane.resourceSamples) || lane.resourceSamples.length < 2) {
+        throw new Error(`trial ${trial.executionIndex} lane ${laneName} requires operations and at least two resource samples`)
+    }
+
+    const overLimitProbe = validateContextReceipt({
+        ids,
+        lane,
+        laneName,
+        profile,
+        trial
+    });
+
+    validateRuntimeProfile(lane.runtimeProfile, profile.lanes[laneName], laneName, trial.executionIndex);
+
+    const operations = lane.operations.map(operation => validateOperation({
+              ids,
+              laneName,
+              operation,
+              trial
+          })),
+          resource = aggregateWindow(lane.resourceSamples, {
+              activeCpuThreshold: plan.resourceSampling.activeCpuThreshold,
+              expectedIntervalMs: plan.resourceSampling.expectedIntervalMs,
+              gapFactor         : plan.resourceSampling.gapFactor,
+              windowBounds      : {startMs: trial.startedAtMs, endMs: trial.completedAtMs}
+          }),
+          queueWaits = operations.filter(operation => operation.queueWaitMs !== null).map(operation => operation.queueWaitMs),
+          providerDurations = operations.map(operation => operation.providerDurationMs),
+          completions = operations.filter(operation => operation.outcome === 'completed').map(operation => operation.completedAtMs),
+          windowMs = trial.completedAtMs - trial.startedAtMs,
+          maxResourceSamples = Math.ceil(windowMs / plan.resourceSampling.expectedIntervalMs) + 2;
+
+    if (lane.resourceSamples.length > maxResourceSamples) {
+        throw new Error(`trial ${trial.executionIndex} lane ${laneName} exceeds the bounded raw resource sample count`)
+    }
+
+    for (const [index, sample] of lane.resourceSamples.entries()) {
+        if (!Number.isFinite(sample?.atMs) || !Number.isFinite(sample.cpuPercent) || sample.cpuPercent < 0 ||
+            !Number.isFinite(sample.rssBytes) || sample.rssBytes < 0) {
+            throw new Error(`trial ${trial.executionIndex} lane ${laneName} has an invalid raw resource sample`)
+        }
+        if (index > 0 && sample.atMs <= lane.resourceSamples[index - 1].atMs) {
+            throw new Error(`trial ${trial.executionIndex} lane ${laneName} resource samples must be chronological`)
+        }
+    }
+
+    const observedMaxProviderConcurrency = deriveMaxProviderConcurrency(operations);
+
+    if (observedMaxProviderConcurrency > profile.lanes[laneName].parallelism) {
+        throw new Error(`trial ${trial.executionIndex} lane ${laneName} exceeds its runtime parallelism`)
+    }
+
+    if (lane.resourceSamples.some(sample => sample.atMs < trial.startedAtMs || sample.atMs > trial.completedAtMs)) {
+        throw new Error(`trial ${trial.executionIndex} lane ${laneName} has a resource sample outside the measurement window`)
+    }
+
+    return {
+        completedOperations         : completions.length,
+        cpuHighWaterPercent         : Math.max(...lane.resourceSamples.map(sample => sample.cpuPercent)),
+        errorCount                  : operations.filter(operation => operation.outcome === 'error').length,
+        maxNeoQueueWaitMs           : queueWaits.length > 0 ? Math.max(...queueWaits) : null,
+        maxProgressGapMs            : deriveMaxProgressGap(trial.startedAtMs, trial.completedAtMs, completions),
+        maxProviderDurationMs       : Math.max(...providerDurations),
+        observedContextTokensPerSlot: lane.observedContextTokensPerSlot,
+        observedMaxProviderConcurrency,
+        offeredOperations           : operations.length,
+        operations,
+        overLimitProbe,
+        queueDispositionCounts      : {
+            'not-applicable': operations.filter(operation => operation.queueDisposition === 'not-applicable').length,
+            queued          : operations.filter(operation => operation.queueDisposition === 'queued').length
+        },
+        resourceCoverageRatio : resource.coverageRatio,
+        resourceGapCount      : resource.gapCount,
+        resourceSampleCount   : resource.sampleCount,
+        resourceSamples       : lane.resourceSamples.map(({atMs, cpuPercent, rssBytes}) => ({atMs, cpuPercent, rssBytes})),
+        rssHighWaterBytes     : resource.rssHighWaterBytes,
+        runtimeProfile        : projectRuntimeProfile(lane.runtimeProfile),
+        throughputPerSecond   : completions.length / (windowMs / 1000),
+        unexpectedRefusalCount: operations.filter(operation => operation.outcome === 'unexpected-refusal').length
+    }
+}
+
+/**
+ * @summary Projects only the six validated runtime-profile coordinates.
+ * @param {Object} runtime Runtime profile receipt.
+ * @returns {Object}
+ */
+function projectRuntimeProfile(runtime) {
+    return {
+        cpuCores   : runtime.cpuCores,
+        imageDigest: runtime.imageDigest,
+        memoryBytes: runtime.memoryBytes,
+        modelDigest: runtime.modelDigest,
+        parallelism: runtime.parallelism,
+        serviceKey : runtime.serviceKey
+    }
+}
+
+/**
+ * @summary Validates runtime-observed context and an independent over-limit probe.
+ * @param {Object} options Validation inputs.
+ * @returns {Object} Bounded, identity-bound probe receipt.
+ */
+function validateContextReceipt({ids, lane, laneName, profile, trial}) {
+    const label = `trial ${trial.executionIndex} ${laneName}`,
+          probe = lane.overLimitProbe;
+
+    assertPositiveInteger(lane.observedContextTokensPerSlot, `${label}.observedContextTokensPerSlot`);
+    assertPositiveInteger(probe?.requestedContextTokens, `${label}.overLimitProbe.requestedContextTokens`);
+
+    if (!probe || typeof probe.id !== 'string' || probe.id.length === 0 || probe.id.length > 1024 || ids.has(probe.id)) {
+        throw new Error(`${label}.overLimitProbe requires a unique request id`)
+    }
+    ids.add(probe.id);
+
+    if (!Number.isFinite(probe.startedAtMs) || !Number.isFinite(probe.completedAtMs) ||
+        probe.startedAtMs < trial.startedAtMs || probe.completedAtMs > trial.completedAtMs ||
+        probe.completedAtMs <= probe.startedAtMs ||
+        probe.requestedContextTokens <= lane.observedContextTokensPerSlot ||
+        probe.serviceKey !== profile.lanes[laneName].serviceKey ||
+        probe.modelDigest !== profile.lanes[laneName].modelDigest ||
+        !PROBE_RESPONSE_CLASSES.includes(probe.responseClass) ||
+        !Number.isInteger(probe.observedOutputTokens) || probe.observedOutputTokens < 0 ||
+        !Number.isInteger(probe.transportStatus) || probe.transportStatus < 100 || probe.transportStatus > 599) {
+        throw new Error(`trial ${trial.executionIndex} lane ${laneName} requires a truthful identity-bound over-limit probe`)
+    }
+
+    const hasErrorCode = typeof probe.providerErrorCode === 'string' &&
+        /^[A-Z][A-Z0-9_.-]{0,63}$/.test(probe.providerErrorCode);
+
+    if (probe.responseClass === 'completed' && (probe.providerErrorCode !== null || probe.transportStatus >= 400) ||
+        probe.responseClass === 'provider-error' && (!hasErrorCode || probe.transportStatus < 400)) {
+        throw new Error(`trial ${trial.executionIndex} lane ${laneName} has an inconsistent over-limit provider response`)
+    }
+
+    const responseClass = probe.responseClass === 'provider-error' &&
+        probe.providerErrorCode === profile.lanes[laneName].contextLimitCode &&
+        probe.transportStatus === profile.lanes[laneName].contextLimitStatus &&
+        probe.observedOutputTokens === 0 ? 'context-limit-refusal' : probe.responseClass;
+
+    return {
+        completedAtMs         : probe.completedAtMs,
+        id                    : projectOpaqueId(probe.id),
+        modelDigest           : probe.modelDigest,
+        observedOutputTokens  : probe.observedOutputTokens,
+        providerErrorCode     : probe.providerErrorCode,
+        requestedContextTokens: probe.requestedContextTokens,
+        responseClass,
+        serviceKey            : probe.serviceKey,
+        startedAtMs           : probe.startedAtMs,
+        transportStatus       : probe.transportStatus
+    }
+}
+
+/**
+ * @summary Replaces caller-owned request identifiers with bounded opaque digests.
+ * @param {String} id Raw request identifier used only for matrix-local uniqueness.
+ * @returns {String}
+ */
+function projectOpaqueId(id) {
+    return `sha256:${createHash('sha256').update(id).digest('hex')}`
+}
+
+/**
+ * @summary Validates runtime containment against the declared lane allocation.
+ * @param {Object} limits Runtime limits.
+ * @param {Object} allocation Declared allocation.
+ * @param {String} laneName Lane name.
+ * @param {Number} trialIndex Trial index.
+ */
+function validateRuntimeProfile(runtime, allocation, laneName, trialIndex) {
+    for (const field of [
+        'cpuCores',
+        'imageDigest',
+        'memoryBytes',
+        'modelDigest',
+        'parallelism',
+        'serviceKey'
+    ]) {
+        if (runtime?.[field] !== allocation[field]) {
+            throw new Error(`trial ${trialIndex} lane ${laneName} runtime profile does not match declared ${field}`)
+        }
+    }
+}
+
+/**
+ * @summary Validates one operation timeline and derives queue/provider durations.
+ * @param {Object} options
+ * @returns {Object}
+ */
+function validateOperation({ids, laneName, operation, trial}) {
+    const allowedSources = laneName === 'chat' ? ['chat'] : EMBED_SOURCES;
+
+    if (typeof operation?.id !== 'string' || operation.id.length === 0 || operation.id.length > 1024 || ids.has(operation.id)) {
+        throw new Error(`trial ${trial.executionIndex} contains a missing or duplicate operation id`)
+    }
+    ids.add(operation.id);
+
+    if (!allowedSources.includes(operation.source) || !QUEUE_DISPOSITIONS.includes(operation.queueDisposition) ||
+        !OUTCOMES.includes(operation.outcome)) {
+        throw new Error(`trial ${trial.executionIndex} lane ${laneName} contains an invalid operation contract`)
+    }
+    if (!Number.isFinite(operation.providerStartedAtMs) || !Number.isFinite(operation.completedAtMs) ||
+        operation.providerStartedAtMs < trial.startedAtMs || operation.completedAtMs <= operation.providerStartedAtMs ||
+        operation.completedAtMs > trial.completedAtMs) {
+        throw new Error(`trial ${trial.executionIndex} operation ${projectOpaqueId(operation.id)} has an invalid provider timeline`)
+    }
+
+    let demandAtMs,
+        queueWaitMs;
+
+    if (operation.queueDisposition === 'queued') {
+        if (!Number.isFinite(operation.enqueuedAtMs) || operation.enqueuedAtMs < trial.startedAtMs ||
+            operation.enqueuedAtMs > operation.providerStartedAtMs) {
+            throw new Error(`trial ${trial.executionIndex} queued operation ${projectOpaqueId(operation.id)} requires a valid enqueue timestamp`)
+        }
+        demandAtMs  = operation.enqueuedAtMs;
+        queueWaitMs = operation.providerStartedAtMs - operation.enqueuedAtMs
+    } else {
+        if (operation.enqueuedAtMs !== null) {
+            throw new Error(`trial ${trial.executionIndex} not-applicable operation ${projectOpaqueId(operation.id)} requires enqueuedAtMs=null`)
+        }
+        demandAtMs  = operation.providerStartedAtMs;
+        queueWaitMs = null
+    }
+
+    return {
+        completedAtMs      : operation.completedAtMs,
+        demandAtMs,
+        id                 : projectOpaqueId(operation.id),
+        outcome            : operation.outcome,
+        providerDurationMs : operation.completedAtMs - operation.providerStartedAtMs,
+        providerStartedAtMs: operation.providerStartedAtMs,
+        queueDisposition   : operation.queueDisposition,
+        queueWaitMs,
+        source             : operation.source
+    }
+}
+
+/**
+ * @summary Requires the exact fixed workload cardinality in every trial.
+ * @param {Object} lanes Derived lane receipts.
+ * @param {Object} expected Expected source counts.
+ * @param {Number} trialIndex Trial index.
+ */
+function validateSourceCardinality(lanes, expected, trialIndex) {
+    const operations = [...lanes.chat.operations, ...lanes.embedding.operations];
+
+    for (const source of SOURCE_NAMES) {
+        const count = operations.filter(operation => operation.source === source).length;
+
+        if (count !== expected[source]) {
+            throw new Error(`trial ${trialIndex} source ${source} offered ${count}; fixed workload requires ${expected[source]}`)
+        }
+    }
+}
+
+/**
+ * @summary Verifies that all four demand sources had an overlapping outstanding interval.
+ * @param {Object} lanes Derived lane receipts.
+ * @returns {Boolean}
+ */
+function hasCommonDemandOverlap(lanes) {
+    const operations = [...lanes.chat.operations, ...lanes.embedding.operations],
+          boundaries = [...new Set(operations.flatMap(operation => [operation.demandAtMs, operation.completedAtMs]))]
+              .sort((a, b) => a - b);
+
+    return boundaries.slice(0, -1).some((startMs, index) => {
+        const probeAtMs = (startMs + boundaries[index + 1]) / 2;
+
+        return SOURCE_NAMES.every(source => operations.some(operation =>
+            operation.source === source && operation.demandAtMs <= probeAtMs && operation.completedAtMs > probeAtMs
+        ))
+    })
+}
+
+/**
+ * @summary Validates and bounds the pre-trial residency observation.
+ * @param {Object} receipt Residency observation.
+ * @param {Object} trial Trial receipt.
+ * @param {Number} trialIndex Trial index.
+ * @returns {Object}
+ */
+function validateResidencyReceipt(receipt, trial, trialIndex, priorCompletedAtMs) {
+    if (!Number.isFinite(receipt?.observedAtMs) || receipt.observedAtMs > trial.startedAtMs ||
+        receipt.observedAtMs < priorCompletedAtMs) {
+        throw new Error(`trial ${trialIndex} requires a pre-trial residency observation`)
+    }
+
+    const lanes = {};
+
+    for (const laneName of LANE_NAMES) {
+        const lane = receipt.lanes?.[laneName];
+
+        if (typeof lane?.resident !== 'boolean' ||
+            (lane.resident ? !DIGEST_PATTERN.test(lane.modelDigest ?? '') : lane.modelDigest !== null)) {
+            throw new Error(`trial ${trialIndex} residency.${laneName} requires resident boolean and bounded model digest`)
+        }
+
+        lanes[laneName] = {modelDigest: lane.modelDigest, resident: lane.resident}
+    }
+
+    return {lanes, observedAtMs: receipt.observedAtMs}
+}
+
+/**
+ * @summary Evaluates all trial receipts for one candidate against the joint SLO.
+ * @param {Object} options
+ * @returns {Object}
+ */
+function evaluateCandidate({candidate, plan, trials}) {
+    const failures = [],
+          profile  = getProfile(plan, candidate);
+
+    for (const trial of trials) {
+        if (!trial.workload.concurrent) {
+            failures.push({code: 'WORKLOAD_NOT_CONCURRENT', runId: trial.scheduleId})
+        }
+
+        for (const laneName of LANE_NAMES) {
+            evaluateLane({
+                allocation: profile.lanes[laneName],
+                failures,
+                lane      : trial.lanes[laneName],
+                laneName,
+                runId     : trial.scheduleId,
+                slo       : plan.slo.lanes[laneName]
+            })
+        }
+    }
+
+    return {
+        candidate,
+        declaredInputs: buildImmutableInputs(plan, candidate),
+        failures,
+        sampleCount   : trials.length,
+        status        : failures.length === 0 ? 'PASS' : 'FAIL',
+        trials,
+        uncertainty   : Object.fromEntries(LANE_NAMES.map(laneName => [
+            laneName,
+            summarizeLaneTrials(trials.map(trial => trial.lanes[laneName]))
+        ]))
+    }
+}
+
+/**
+ * @summary Evaluates one lane/run receipt against the explicit SLO and declared containment.
+ * @param {Object} options
+ */
+function evaluateLane({allocation, failures, lane, laneName, runId, slo}) {
+    const fail          = code => failures.push({code, lane: laneName, runId}),
+          requiredCount = lane.queueDispositionCounts[slo.requiredQueueDisposition];
+
+    lane.observedContextTokensPerSlot < slo.minContextTokensPerSlot && fail('CONTEXT_BELOW_SLO');
+    lane.observedMaxProviderConcurrency !== allocation.parallelism && fail('CANDIDATE_CONCURRENCY_NOT_OBSERVED');
+    lane.overLimitProbe.responseClass !== 'context-limit-refusal' && fail('OVER_LIMIT_NOT_REFUSED');
+    requiredCount !== lane.offeredOperations && fail('QUEUE_DISPOSITION_MISMATCH');
+    lane.maxNeoQueueWaitMs !== null && lane.maxNeoQueueWaitMs > slo.maxNeoQueueWaitMs && fail('QUEUE_WAIT_EXCEEDED');
+    lane.maxProviderDurationMs > slo.maxProviderDurationMs && fail('PROVIDER_DURATION_EXCEEDED');
+    lane.throughputPerSecond < slo.minThroughputPerSecond && fail('THROUGHPUT_BELOW_SLO');
+    lane.cpuHighWaterPercent > slo.maxCpuHighWaterPercent && fail('CPU_HIGH_WATER_EXCEEDED');
+    lane.rssHighWaterBytes > slo.maxRssHighWaterBytes && fail('RSS_HIGH_WATER_EXCEEDED');
+    lane.cpuHighWaterPercent > allocation.cpuCores * 100 && fail('CPU_ALLOCATION_EXCEEDED');
+    lane.rssHighWaterBytes > allocation.memoryBytes && fail('RSS_ALLOCATION_EXCEEDED');
+    lane.resourceCoverageRatio < slo.minResourceCoverageRatio && fail('RESOURCE_COVERAGE_BELOW_SLO');
+    lane.resourceGapCount > slo.maxResourceGapCount && fail('RESOURCE_GAPS_EXCEEDED');
+    lane.errorCount > slo.maxErrors && fail('ERROR_BUDGET_EXCEEDED');
+    lane.unexpectedRefusalCount > slo.maxUnexpectedRefusals && fail('REFUSAL_BUDGET_EXCEEDED');
+    lane.completedOperations < slo.minCompletedOperations && fail('PROGRESS_BELOW_SLO');
+    lane.maxProgressGapMs > slo.maxProgressGapMs && fail('PROGRESS_GAP_EXCEEDED')
+}
+
+/**
+ * @summary Summarizes candidate variability without guessing missing queue waits into zero.
+ * @param {Object[]} lanes Derived lane receipts.
+ * @returns {Object}
+ */
+function summarizeLaneTrials(lanes) {
+    return Object.fromEntries(SUMMARY_FIELDS.map(field => [
+        field,
+        summarizeValues(lanes.map(lane => lane[field]))
+    ]))
+}
+
+/**
+ * @summary Projects honest descriptive statistics; p95 appears only with at least five values.
+ * @param {Array<Number|null>} values Values.
+ * @returns {Object}
+ */
+function summarizeValues(values) {
+    const finite = values.filter(Number.isFinite);
+
+    if (finite.length === 0) {
+        return {max: null, median: null, min: null, n: 0, observedRange: null, p95: null}
+    }
+
+    const min = Math.min(...finite),
+          max = Math.max(...finite);
+
+    return {
+        max,
+        median       : median(finite),
+        min,
+        n            : finite.length,
+        observedRange: max - min,
+        p95          : finite.length >= 5 ? percentile(finite, 0.95) : null
+    }
+}
+
+/**
+ * @summary Projects exact immutable inputs for the winning candidate.
+ * @param {Object} plan Election plan.
+ * @param {Number} candidate Candidate value.
+ * @returns {Object}
+ */
+function buildImmutableInputs(plan, candidate) {
+    const profile = getProfile(plan, candidate);
+
+    return {
+        chatParallelism: 1,
+        embeddingSlots : candidate,
+        laneIdentities : Object.fromEntries(LANE_NAMES.map(laneName => [laneName, {
+            imageDigest: profile.lanes[laneName].imageDigest,
+            modelDigest: profile.lanes[laneName].modelDigest,
+            serviceKey : profile.lanes[laneName].serviceKey
+        }])),
+        laneResources: Object.fromEntries(LANE_NAMES.map(laneName => [laneName, {
+            cpuCores   : profile.lanes[laneName].cpuCores,
+            memoryBytes: profile.lanes[laneName].memoryBytes
+        }])),
+        perSlotContextTarget: Object.fromEntries(LANE_NAMES.map(laneName => [
+            laneName,
+            plan.slo.lanes[laneName].minContextTokensPerSlot
+        ])),
+        totalResources: {...profile.totalResources}
+    }
+}
+
+/**
+ * @summary Resolves one candidate profile.
+ * @param {Object} plan Election plan.
+ * @param {Number} candidate Candidate value.
+ * @returns {Object}
+ */
+function getProfile(plan, candidate) {
+    return plan.candidateProfiles.find(profile => profile.embeddingSlots === candidate)
+}
+
+/**
+ * @summary Derives the largest no-completion interval across one measured trial.
+ * @param {Number} startedAtMs Trial start.
+ * @param {Number} completedAtMs Trial completion.
+ * @param {Number[]} completions Durable completion timestamps.
+ * @returns {Number}
+ */
+function deriveMaxProgressGap(startedAtMs, completedAtMs, completions) {
+    const points = [startedAtMs, ...completions.sort((a, b) => a - b), completedAtMs];
+
+    return Math.max(...points.slice(1).map((point, index) => point - points[index]))
+}
+
+/**
+ * @summary Derives actual provider concurrency from operation intervals.
+ * @param {Object[]} operations Derived operations.
+ * @returns {Number}
+ */
+function deriveMaxProviderConcurrency(operations) {
+    const events = operations.flatMap(operation => [
+        {atMs: operation.providerStartedAtMs, delta: 1},
+        {atMs: operation.completedAtMs, delta: -1}
+    ]).sort((a, b) => a.atMs - b.atMs || a.delta - b.delta);
+
+    let active  = 0,
+        maximum = 0;
+
+    for (const event of events) {
+        active  += event.delta;
+        maximum = Math.max(maximum, active)
+    }
+
+    return maximum
+}
+
+/**
+ * @summary Requires a positive finite number.
+ * @param {*} value Candidate value.
+ * @param {String} label Error label.
+ */
+function assertPositiveFinite(value, label) {
+    if (!Number.isFinite(value) || value <= 0) {
+        throw new Error(`${label} must be a positive finite number`)
+    }
+}
+
+/**
+ * @summary Requires a positive integer.
+ * @param {*} value Candidate value.
+ * @param {String} label Error label.
+ */
+function assertPositiveInteger(value, label) {
+    if (!Number.isInteger(value) || value <= 0) {
+        throw new Error(`${label} must be a positive integer`)
+    }
+}

--- a/ai/scripts/benchmark/helpers/providerLaneElectionCore.mjs
+++ b/ai/scripts/benchmark/helpers/providerLaneElectionCore.mjs
@@ -4,8 +4,8 @@
  *
  * The live runner owns composition, workload dispatch, resource sampling, and artifact
  * authority. This module owns only a deterministic counterbalanced schedule plus pure
- * validation/aggregation over injected receipts. Synthetic controls can exercise every branch,
- * but they can never emit authoritative deployment inputs.
+ * validation/aggregation over injected, already-normalized receipts. It selects the smallest
+ * passing measured candidate, but never emits deployment inputs or an authoritative verdict.
  *
  * @see https://github.com/neomjs/neo/issues/17024
  * @see learn/agentos/decisions/0014-cloud-deployment-topology-and-scheduler-task-taxonomy.md
@@ -18,12 +18,12 @@ import {median, percentile} from './stats.mjs';
 
 const
     CANDIDATES             = Object.freeze([1, 2, 4]),
-    DIGEST_PATTERN         = /^(?:sha256:)?[0-9a-f]{64}$/i,
-    EVIDENCE_CLASSES       = Object.freeze(['exact-head-candidate', 'synthetic-control']),
+    COMPOSITION_SCHEMA     = 'provider-lane-composition.v1',
+    DIGEST_PATTERN         = /^sha256:[0-9a-f]{64}$/,
     EMBED_SOURCES          = Object.freeze(['knowledge-base', 'memory-core', 'orchestrator']),
     LANE_NAMES             = Object.freeze(['chat', 'embedding']),
     OUTCOMES               = Object.freeze(['completed', 'error', 'unexpected-refusal']),
-    PROBE_RESPONSE_CLASSES = Object.freeze(['completed', 'provider-error']),
+    PROBE_RESPONSE_CLASSES = Object.freeze(['completed', 'context-limit-refusal', 'provider-error']),
     QUEUE_DISPOSITIONS     = Object.freeze(['not-applicable', 'queued']),
     SAFE_PUBLIC_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$/,
     SOURCE_NAMES           = Object.freeze(['chat', ...EMBED_SOURCES]),
@@ -117,20 +117,18 @@ export function createProviderLanePlanDigest(plan) {
  * candidate.
  *
  * Evidence-integrity failures throw because an incomplete or incomparable matrix cannot
- * support any verdict. Measured SLO failures remain in candidate receipts. Synthetic controls
- * return `NON_AUTHORITATIVE` with a provisional outcome and no deployment inputs; only an
- * exact-head candidate carrying the live runner's complete provenance may return `ELECTED` or
- * `NO_ELECTION`.
+ * support even a measured comparison. Measured SLO failures remain in candidate receipts. The
+ * returned winner is deliberately non-authoritative: the live runner owns exact composition
+ * validation, protocol adaptation, artifact provenance, and deployment-input publication.
  *
  * @param {Object} options
- * @param {Object} options.plan Immutable candidate profiles, workload, SLO, sampling, and provenance.
+ * @param {Object} options.plan Immutable candidate profiles, workload, SLO, and sampling.
  * @param {Object[]} options.trials Chronological raw operation/resource receipts.
  * @returns {Object} Bounded election receipt.
  */
 export function evaluateProviderLaneElection({plan, trials} = {}) {
     const schedule   = validatePlan(plan),
           planDigest = deriveProviderLanePlanDigest(plan),
-          authority  = validateEvidence(plan.evidence, planDigest),
           derived    = validateAndDeriveTrials({plan, schedule, trials});
 
     const candidates = CANDIDATES.map(candidate => evaluateCandidate({
@@ -138,13 +136,10 @@ export function evaluateProviderLaneElection({plan, trials} = {}) {
               plan,
               trials: derived.filter(trial => trial.candidate === candidate)
           })),
-          winner = candidates.find(candidate => candidate.status === 'PASS') ?? null,
-          computedOutcome = winner ? 'ELECTED' : 'NO_ELECTION';
+          winner = candidates.find(candidate => candidate.status === 'PASS') ?? null;
 
-    const base = {
-        authority,
+    return {
         candidates,
-        computedOutcome,
         jointSlo: {
             lanes: Object.fromEntries(LANE_NAMES.map(laneName => [laneName, projectLaneSlo(plan.slo.lanes[laneName])]))
         },
@@ -157,25 +152,8 @@ export function evaluateProviderLaneElection({plan, trials} = {}) {
             uncertaintyMethod        : 'observed-range-and-nearest-rank-p95',
             workloadDigest           : plan.workload.digest,
             workloadOfferedOperations: {...plan.workload.offeredOperations}
-        }
-    };
-
-    if (!authority.authoritative) {
-        return {
-            ...base,
-            electedCandidate    : null,
-            immutableInputs     : null,
-            provisionalCandidate: winner?.candidate ?? null,
-            status              : 'NON_AUTHORITATIVE'
-        }
-    }
-
-    return {
-        ...base,
-        electedCandidate    : winner?.candidate ?? null,
-        immutableInputs     : winner ? buildImmutableInputs(plan, winner.candidate) : null,
-        provisionalCandidate: null,
-        status              : computedOutcome
+        },
+        winnerCandidate: winner?.candidate ?? null
     }
 }
 
@@ -239,17 +217,28 @@ function deriveProviderLanePlanDigest(plan) {
  */
 function projectCandidateProfile(profile) {
     return {
-        embeddingSlots: profile.embeddingSlots,
-        lanes         : Object.fromEntries(LANE_NAMES.map(laneName => [laneName, {
-            contextLimitCode  : profile.lanes[laneName].contextLimitCode,
-            contextLimitStatus: profile.lanes[laneName].contextLimitStatus,
-            cpuCores          : profile.lanes[laneName].cpuCores,
-            imageDigest       : profile.lanes[laneName].imageDigest,
-            memoryBytes       : profile.lanes[laneName].memoryBytes,
-            modelDigest       : profile.lanes[laneName].modelDigest,
-            parallelism       : profile.lanes[laneName].parallelism,
-            serviceKey        : profile.lanes[laneName].serviceKey
+        compositionReceiptDigest: profile.compositionReceiptDigest,
+        compositionSchemaVersion: profile.compositionSchemaVersion,
+        embeddingSlots          : profile.embeddingSlots,
+        lanes                   : Object.fromEntries(LANE_NAMES.map(laneName => [laneName, {
+            baseUrl                     : profile.lanes[laneName].baseUrl,
+            contextTokensPerSlotRequired: profile.lanes[laneName].contextTokensPerSlotRequired,
+            cpuCores                    : profile.lanes[laneName].cpuCores,
+            endpointDigest              : profile.lanes[laneName].endpointDigest,
+            imageDigest                 : profile.lanes[laneName].imageDigest,
+            imageReference              : profile.lanes[laneName].imageReference,
+            memoryBytes                 : profile.lanes[laneName].memoryBytes,
+            modelCoordinate             : profile.lanes[laneName].modelCoordinate,
+            modelDigest                 : profile.lanes[laneName].modelDigest,
+            modelDigestKind             : profile.lanes[laneName].modelDigestKind,
+            modelId                     : profile.lanes[laneName].modelId,
+            parallelism                 : profile.lanes[laneName].parallelism,
+            protocolAdapter             : profile.lanes[laneName].protocolAdapter,
+            provider                    : profile.lanes[laneName].provider,
+            serviceKey                  : profile.lanes[laneName].serviceKey,
+            totalContextTokens          : profile.lanes[laneName].totalContextTokens
         }])),
+        roleMapDigest : profile.roleMapDigest,
         totalResources: {
             cpuCores   : profile.totalResources.cpuCores,
             memoryBytes: profile.totalResources.memoryBytes
@@ -292,10 +281,26 @@ function validatePlan(plan) {
 
     validateCandidateProfiles(plan.candidateProfiles);
     validateSlo(plan.slo);
+    validateContextContract(plan);
     validateWorkload(plan.workload);
     validateResourceSampling(plan.resourceSampling);
 
     return schedule
+}
+
+/**
+ * @summary Binds the joint-SLO context floor to the canonical composition requirement.
+ * @param {Object} plan Validated election plan.
+ */
+function validateContextContract(plan) {
+    const baseline = getProfile(plan, CANDIDATES[0]);
+
+    for (const laneName of LANE_NAMES) {
+        if (plan.slo.lanes[laneName].minContextTokensPerSlot !==
+            baseline.lanes[laneName].contextTokensPerSlotRequired) {
+            throw new Error(`provider-lane SLO ${laneName} context floor must equal the composition-required per-slot context`)
+        }
+    }
 }
 
 /**
@@ -325,12 +330,38 @@ function validateCandidateProfiles(profiles) {
             throw new Error(`candidate ${profile.embeddingSlots} changed the fixed total CPU/memory envelope`)
         }
 
+        if (profile.compositionSchemaVersion !== baseline.compositionSchemaVersion ||
+            profile.roleMapDigest !== baseline.roleMapDigest) {
+            throw new Error(`candidate ${profile.embeddingSlots} changed the composition schema or role map`)
+        }
+
         for (const laneName of LANE_NAMES) {
-            for (const field of ['serviceKey', 'imageDigest', 'modelDigest', 'contextLimitCode', 'contextLimitStatus']) {
+            for (const field of [
+                'baseUrl',
+                'endpointDigest',
+                'imageDigest',
+                'imageReference',
+                'modelCoordinate',
+                'modelDigest',
+                'modelDigestKind',
+                'modelId',
+                'protocolAdapter',
+                'provider',
+                'serviceKey'
+            ]) {
                 if (profile.lanes[laneName][field] !== baseline.lanes[laneName][field]) {
                     throw new Error(`candidate ${profile.embeddingSlots} changed ${laneName}.${field}; profile mismatch aborts the election`)
                 }
             }
+
+            if (profile.lanes[laneName].contextTokensPerSlotRequired !==
+                baseline.lanes[laneName].contextTokensPerSlotRequired) {
+                throw new Error(`candidate ${profile.embeddingSlots} changed ${laneName}.contextTokensPerSlotRequired`)
+            }
+        }
+
+        if (profile.lanes.chat.totalContextTokens !== baseline.lanes.chat.totalContextTokens) {
+            throw new Error(`candidate ${profile.embeddingSlots} changed chat.totalContextTokens`)
         }
     }
 }
@@ -340,6 +371,12 @@ function validateCandidateProfiles(profiles) {
  * @param {Object} profile Candidate profile.
  */
 function validateCandidateProfile(profile) {
+    if (profile?.compositionSchemaVersion !== COMPOSITION_SCHEMA ||
+        !DIGEST_PATTERN.test(profile?.compositionReceiptDigest ?? '') ||
+        !DIGEST_PATTERN.test(profile?.roleMapDigest ?? '')) {
+        throw new Error(`candidate ${profile?.embeddingSlots} requires immutable validated composition provenance`)
+    }
+
     assertPositiveFinite(profile?.totalResources?.cpuCores, `candidate ${profile?.embeddingSlots} totalResources.cpuCores`);
     assertPositiveInteger(profile?.totalResources?.memoryBytes, `candidate ${profile?.embeddingSlots} totalResources.memoryBytes`);
 
@@ -349,19 +386,36 @@ function validateCandidateProfile(profile) {
     for (const laneName of LANE_NAMES) {
         const lane = profile?.lanes?.[laneName];
 
-        if (!lane || !SAFE_PUBLIC_ID_PATTERN.test(lane.serviceKey ?? '')) {
+        if (!lane || !SAFE_PUBLIC_ID_PATTERN.test(lane.serviceKey ?? '') ||
+            !SAFE_PUBLIC_ID_PATTERN.test(lane.provider ?? '') ||
+            !SAFE_PUBLIC_ID_PATTERN.test(lane.modelId ?? '') ||
+            !SAFE_PUBLIC_ID_PATTERN.test(lane.modelDigestKind ?? '')) {
             throw new Error(`candidate ${profile?.embeddingSlots} lanes.${laneName}.serviceKey is required`)
         }
-        if (!DIGEST_PATTERN.test(lane.imageDigest ?? '') || !DIGEST_PATTERN.test(lane.modelDigest ?? '')) {
+        if (!DIGEST_PATTERN.test(lane.imageDigest ?? '') || !DIGEST_PATTERN.test(lane.modelDigest ?? '') ||
+            !DIGEST_PATTERN.test(lane.endpointDigest ?? '') || typeof lane.imageReference !== 'string' ||
+            lane.imageReference.length === 0 || lane.imageReference.length > 512 ||
+            typeof lane.modelCoordinate !== 'string' || lane.modelCoordinate.length === 0 ||
+            lane.modelCoordinate.length > 512) {
             throw new Error(`candidate ${profile?.embeddingSlots} lanes.${laneName} requires immutable image and model digests`)
         }
-        if (!Number.isInteger(lane.contextLimitStatus) || lane.contextLimitStatus < 400 || lane.contextLimitStatus > 599 ||
-            typeof lane.contextLimitCode !== 'string' || !/^[A-Z][A-Z0-9_.-]{0,63}$/.test(lane.contextLimitCode)) {
-            throw new Error(`candidate ${profile?.embeddingSlots} lanes.${laneName} requires a closed context-limit code/status pair`)
+        try {
+            const url = new URL(lane.baseUrl);
+
+            if (url.protocol !== 'http:' || url.hostname !== lane.serviceKey || url.pathname !== '/' || url.search || url.hash) {
+                throw new Error()
+            }
+        } catch {
+            throw new Error(`candidate ${profile?.embeddingSlots} lanes.${laneName} requires an internal receipt-bound base URL`)
+        }
+        if (!SAFE_PUBLIC_ID_PATTERN.test(lane.protocolAdapter ?? '')) {
+            throw new Error(`candidate ${profile?.embeddingSlots} lanes.${laneName} requires a bounded provider protocol adapter identity`)
         }
 
         assertPositiveFinite(lane.cpuCores, `candidate ${profile.embeddingSlots} lanes.${laneName}.cpuCores`);
         assertPositiveInteger(lane.memoryBytes, `candidate ${profile.embeddingSlots} lanes.${laneName}.memoryBytes`);
+        assertPositiveInteger(lane.totalContextTokens, `candidate ${profile.embeddingSlots} lanes.${laneName}.totalContextTokens`);
+        assertPositiveInteger(lane.contextTokensPerSlotRequired, `candidate ${profile.embeddingSlots} lanes.${laneName}.contextTokensPerSlotRequired`);
 
         allocatedCpu    += lane.cpuCores;
         allocatedMemory += lane.memoryBytes
@@ -376,6 +430,11 @@ function validateCandidateProfile(profile) {
     }
     if (profile.lanes.chat.parallelism !== 1 || profile.lanes.embedding.parallelism !== profile.embeddingSlots) {
         throw new Error(`candidate ${profile.embeddingSlots} must keep chat parallelism 1 and embedding parallelism equal to the candidate`)
+    }
+    if (profile.lanes.chat.totalContextTokens !== profile.lanes.chat.contextTokensPerSlotRequired ||
+        profile.lanes.embedding.totalContextTokens <
+            profile.lanes.embedding.parallelism * profile.lanes.embedding.contextTokensPerSlotRequired) {
+        throw new Error(`candidate ${profile.embeddingSlots} has incoherent total and per-slot context coordinates`)
     }
 }
 
@@ -451,46 +510,6 @@ function validateResourceSampling(sampling) {
 }
 
 /**
- * @summary Validates provenance and distinguishes evidence integrity from evidence authority.
- * @param {Object} evidence Evidence provenance.
- * @param {String} planDigest Canonical digest derived from the evaluated plan.
- * @returns {Object}
- */
-function validateEvidence(evidence, planDigest) {
-    if (!EVIDENCE_CLASSES.includes(evidence?.evidenceClass)) {
-        throw new Error(`provider-lane evidenceClass must be one of: ${EVIDENCE_CLASSES.join(', ')}`)
-    }
-
-    if (evidence.evidenceClass === 'synthetic-control') {
-        return {authoritative: false, evidenceClass: evidence.evidenceClass}
-    }
-
-    for (const field of ['hardwareId', 'profileDigest', 'repositoryHead', 'runnerDigest']) {
-        if (typeof evidence[field] !== 'string' || evidence[field].length === 0) {
-            throw new Error(`exact-head provider-lane evidence requires ${field}`)
-        }
-    }
-    if (!/^[0-9a-f]{40}$/i.test(evidence.repositoryHead) || !DIGEST_PATTERN.test(evidence.profileDigest) ||
-        !DIGEST_PATTERN.test(evidence.runnerDigest) || !SAFE_PUBLIC_ID_PATTERN.test(evidence.hardwareId) ||
-        evidence.canonicalPlane !== true) {
-        throw new Error('exact-head provider-lane evidence requires canonical-plane and immutable head/profile/runner provenance')
-    }
-    if (evidence.profileDigest !== planDigest) {
-        throw new Error('exact-head provider-lane profileDigest does not match the canonical election plan digest')
-    }
-
-    return {
-        authoritative : true,
-        canonicalPlane: true,
-        evidenceClass : evidence.evidenceClass,
-        hardwareId    : evidence.hardwareId,
-        profileDigest : evidence.profileDigest,
-        repositoryHead: evidence.repositoryHead,
-        runnerDigest  : evidence.runnerDigest
-    }
-}
-
-/**
  * @summary Validates chronological trial receipts and derives all election metrics.
  * @param {Object} options
  * @returns {Object[]}
@@ -504,7 +523,8 @@ function validateAndDeriveTrials({plan, schedule, trials}) {
           derived = [];
 
     trials.forEach((trial, index) => {
-        const slot = schedule[index];
+        const slot    = schedule[index],
+              profile = getProfile(plan, slot.candidate);
 
         if (trial?.scheduleId !== slot.id || trial?.candidate !== slot.candidate || trial?.executionIndex !== index) {
             throw new Error(`trial ${index} does not match counterbalanced slot ${slot.id} candidate ${slot.candidate}`)
@@ -518,21 +538,24 @@ function validateAndDeriveTrials({plan, schedule, trials}) {
         if (trial.workloadDigest !== plan.workload.digest) {
             throw new Error(`trial ${index} changed the immutable workload digest`)
         }
+        if (trial.compositionReceiptDigest !== profile.compositionReceiptDigest) {
+            throw new Error(`trial ${index} does not match candidate ${slot.candidate}'s composition receipt`)
+        }
 
-        const profile = getProfile(plan, trial.candidate),
-              lanes   = Object.fromEntries(LANE_NAMES.map(laneName => [
-                  laneName,
-                  deriveLaneReceipt({ids, lane: trial.lanes?.[laneName], laneName, plan, profile, trial})
-              ]));
+        const lanes = Object.fromEntries(LANE_NAMES.map(laneName => [
+            laneName,
+            deriveLaneReceipt({ids, lane: trial.lanes?.[laneName], laneName, plan, profile, trial})
+        ]));
 
         validateSourceCardinality(lanes, plan.workload.offeredOperations, index);
 
         derived.push({
-            candidate      : trial.candidate,
-            completedAtMs  : trial.completedAtMs,
-            executionIndex : index,
+            candidate               : trial.candidate,
+            completedAtMs           : trial.completedAtMs,
+            compositionReceiptDigest: trial.compositionReceiptDigest,
+            executionIndex          : index,
             lanes,
-            residencyBefore: validateResidencyReceipt(
+            residencyBefore         : validateResidencyReceipt(
                 trial.residencyBefore,
                 trial,
                 index,
@@ -679,33 +702,29 @@ function validateContextReceipt({ids, lane, laneName, profile, trial}) {
         probe.requestedContextTokens <= lane.observedContextTokensPerSlot ||
         probe.serviceKey !== profile.lanes[laneName].serviceKey ||
         probe.modelDigest !== profile.lanes[laneName].modelDigest ||
+        probe.protocolAdapter !== profile.lanes[laneName].protocolAdapter ||
         !PROBE_RESPONSE_CLASSES.includes(probe.responseClass) ||
+        !DIGEST_PATTERN.test(probe.responseBodyDigest ?? '') ||
         !Number.isInteger(probe.observedOutputTokens) || probe.observedOutputTokens < 0 ||
         !Number.isInteger(probe.transportStatus) || probe.transportStatus < 100 || probe.transportStatus > 599) {
         throw new Error(`trial ${trial.executionIndex} lane ${laneName} requires a truthful identity-bound over-limit probe`)
     }
 
-    const hasErrorCode = typeof probe.providerErrorCode === 'string' &&
-        /^[A-Z][A-Z0-9_.-]{0,63}$/.test(probe.providerErrorCode);
-
-    if (probe.responseClass === 'completed' && (probe.providerErrorCode !== null || probe.transportStatus >= 400) ||
-        probe.responseClass === 'provider-error' && (!hasErrorCode || probe.transportStatus < 400)) {
+    if (probe.responseClass === 'completed' && probe.transportStatus >= 400 ||
+        probe.responseClass !== 'completed' && probe.transportStatus < 400 ||
+        probe.responseClass === 'context-limit-refusal' && probe.observedOutputTokens !== 0) {
         throw new Error(`trial ${trial.executionIndex} lane ${laneName} has an inconsistent over-limit provider response`)
     }
-
-    const responseClass = probe.responseClass === 'provider-error' &&
-        probe.providerErrorCode === profile.lanes[laneName].contextLimitCode &&
-        probe.transportStatus === profile.lanes[laneName].contextLimitStatus &&
-        probe.observedOutputTokens === 0 ? 'context-limit-refusal' : probe.responseClass;
 
     return {
         completedAtMs         : probe.completedAtMs,
         id                    : projectOpaqueId(probe.id),
         modelDigest           : probe.modelDigest,
         observedOutputTokens  : probe.observedOutputTokens,
-        providerErrorCode     : probe.providerErrorCode,
+        protocolAdapter       : probe.protocolAdapter,
         requestedContextTokens: probe.requestedContextTokens,
-        responseClass,
+        responseBodyDigest    : probe.responseBodyDigest,
+        responseClass         : probe.responseClass,
         serviceKey            : probe.serviceKey,
         startedAtMs           : probe.startedAtMs,
         transportStatus       : probe.transportStatus
@@ -891,12 +910,11 @@ function evaluateCandidate({candidate, plan, trials}) {
 
     return {
         candidate,
-        declaredInputs: buildImmutableInputs(plan, candidate),
         failures,
-        sampleCount   : trials.length,
-        status        : failures.length === 0 ? 'PASS' : 'FAIL',
+        sampleCount: trials.length,
+        status     : failures.length === 0 ? 'PASS' : 'FAIL',
         trials,
-        uncertainty   : Object.fromEntries(LANE_NAMES.map(laneName => [
+        uncertainty: Object.fromEntries(LANE_NAMES.map(laneName => [
             laneName,
             summarizeLaneTrials(trials.map(trial => trial.lanes[laneName]))
         ]))
@@ -912,7 +930,6 @@ function evaluateLane({allocation, failures, lane, laneName, runId, slo}) {
           requiredCount = lane.queueDispositionCounts[slo.requiredQueueDisposition];
 
     lane.observedContextTokensPerSlot < slo.minContextTokensPerSlot && fail('CONTEXT_BELOW_SLO');
-    lane.observedMaxProviderConcurrency !== allocation.parallelism && fail('CANDIDATE_CONCURRENCY_NOT_OBSERVED');
     lane.overLimitProbe.responseClass !== 'context-limit-refusal' && fail('OVER_LIMIT_NOT_REFUSED');
     requiredCount !== lane.offeredOperations && fail('QUEUE_DISPOSITION_MISMATCH');
     lane.maxNeoQueueWaitMs !== null && lane.maxNeoQueueWaitMs > slo.maxNeoQueueWaitMs && fail('QUEUE_WAIT_EXCEEDED');
@@ -964,35 +981,6 @@ function summarizeValues(values) {
         n            : finite.length,
         observedRange: max - min,
         p95          : finite.length >= 5 ? percentile(finite, 0.95) : null
-    }
-}
-
-/**
- * @summary Projects exact immutable inputs for the winning candidate.
- * @param {Object} plan Election plan.
- * @param {Number} candidate Candidate value.
- * @returns {Object}
- */
-function buildImmutableInputs(plan, candidate) {
-    const profile = getProfile(plan, candidate);
-
-    return {
-        chatParallelism: 1,
-        embeddingSlots : candidate,
-        laneIdentities : Object.fromEntries(LANE_NAMES.map(laneName => [laneName, {
-            imageDigest: profile.lanes[laneName].imageDigest,
-            modelDigest: profile.lanes[laneName].modelDigest,
-            serviceKey : profile.lanes[laneName].serviceKey
-        }])),
-        laneResources: Object.fromEntries(LANE_NAMES.map(laneName => [laneName, {
-            cpuCores   : profile.lanes[laneName].cpuCores,
-            memoryBytes: profile.lanes[laneName].memoryBytes
-        }])),
-        perSlotContextTarget: Object.fromEntries(LANE_NAMES.map(laneName => [
-            laneName,
-            plan.slo.lanes[laneName].minContextTokensPerSlot
-        ])),
-        totalResources: {...profile.totalResources}
     }
 }
 

--- a/ai/scripts/benchmark/provider-lane-election.mjs
+++ b/ai/scripts/benchmark/provider-lane-election.mjs
@@ -1,0 +1,2379 @@
+import {Command}                         from 'commander';
+import {AsyncLocalStorage}               from 'node:async_hooks';
+import {execFile, spawn}                 from 'node:child_process';
+import {createHash, randomBytes}         from 'node:crypto';
+import {mkdir, readFile, realpath, stat} from 'node:fs/promises';
+import path                              from 'node:path';
+import {promisify}                       from 'node:util';
+import {fileURLToPath, pathToFileURL}    from 'node:url';
+
+import {
+    PROVIDER_LANE_DEPLOYMENT_INPUT_ENVS,
+    validateProviderLaneCompositionReceipt
+} from '../diagnostics/providerLaneComposition.mjs';
+import {
+    buildProviderLaneCandidateSchedule,
+    createProviderLanePlanDigest,
+    evaluateProviderLaneElection
+} from './helpers/providerLaneElectionCore.mjs';
+import {writeFileAtomic} from '../../services/shared/atomicFileWrite.mjs';
+
+const
+    execFileAsync = promisify(execFile),
+
+    CANDIDATES        = Object.freeze([1, 2, 4]),
+    CHAT_SOURCE       = 'chat',
+    EMBEDDING_SOURCES = Object.freeze(['knowledge-base', 'memory-core', 'orchestrator']),
+    LANE_NAMES        = Object.freeze(['chat', 'embedding']),
+    PLAN_SCHEMA       = 'provider-lane-election-plan.v1',
+    REPORT_SCHEMA     = 'provider-lane-election-report.v1',
+    WORKER_SCHEMA     = 'provider-lane-election-worker.v1',
+    WORKER_SENTINEL   = 'NEO_PROVIDER_LANE_WORKER:',
+    DIGEST_PATTERN    = /^sha256:[a-f0-9]{64}$/,
+    REVISION_PATTERN  = /^[0-9a-f]{40}$/,
+    RESPONSE_BYTE_CAP    = 1024 * 1024,
+    DOCKER_TOP_BYTE_CAP  = 1024 * 1024,
+    EMBEDDING_CHUNK_SIZE = 5,
+
+    BASE_COMPOSE_FILE     = 'ai/deploy/docker-compose.yml',
+    LANE_COMPOSE_FILE     = 'ai/deploy/docker-compose.provider-lanes.yml',
+    COMPOSITION_ANALYZER  = 'ai/scripts/diagnostics/providerLaneComposition.mjs',
+    RUNNER_ENTRYPOINT     = 'ai/scripts/benchmark/provider-lane-election.mjs',
+
+    CHAT_ADAPTER = Object.freeze({
+        id                  : 'ollama-chat-v0.32.9',
+        imageDigest         : 'sha256:1685741456770df6e3cceb2a945a5f75e020f658d1701509668d6f4688f1dd3f',
+        imageReference      : 'ollama/ollama:0.32.9',
+        lane                : 'chat',
+        modelDigest         : 'sha256:7121486771cbfe218851513210c40b35dbdee93ab1ef43fe36283c883980f0df',
+        provider            : 'ollama',
+        refusalErrorMessages: Object.freeze([
+            'the prompt is longer than the context length currently available to the model; shorten the prompt, adjust the context length in settings, or use a model with a longer context length',
+            'the input length exceeds the context length'
+        ]),
+        refusalStatus: 400,
+        workloadKind : 'ollamaChat'
+    }),
+    EMBEDDING_ADAPTER = Object.freeze({
+        id              : 'llama-cpp-openai-embeddings-b10380',
+        imageDigest     : 'sha256:9b518883e8faab479650ec802e02c9e37c6bb21d36168509efd8fb3c87fc1648',
+        imageReference  : 'ghcr.io/ggml-org/llama.cpp:server-b10380',
+        lane            : 'embedding',
+        modelDigest     : 'sha256:3fcd3febec8b3fd64435204db75bf0dd73b91e8d0661e0331acfe7e7c3120b85',
+        provider        : 'openAiCompatible',
+        refusalErrorType: 'exceed_context_size_error',
+        refusalStatus   : 400,
+        workloadKind    : 'openAiEmbeddings'
+    }),
+    CLOSED_ADAPTERS = Object.freeze({
+        chat     : CHAT_ADAPTER,
+        embedding: EMBEDDING_ADAPTER
+    }),
+
+    WORKLOAD_PAYLOADS = Object.freeze({
+        chat: Object.freeze([
+            'Provider lane simultaneous large-context chat warm fixture. '.repeat(4096),
+            'Explain why durable progress and provider latency must be measured separately in two sentences.'
+        ]),
+        'knowledge-base': Object.freeze([
+            'Knowledge Base election fixture: deterministic retrieval-shaped embedding demand. '.repeat(32)
+        ]),
+        'memory-core': Object.freeze([
+            Object.freeze(Array.from({length: 20}, (_, index) =>
+                `Memory Core WAL batch fixture ${index}: deterministic durable-memory embedding demand. `.repeat(16)
+            ))
+        ]),
+        orchestrator: Object.freeze([
+            Object.freeze(Array.from({length: 8}, (_, index) =>
+                `Orchestrator recovery batch A fixture ${index}: deterministic recovery-shaped embedding demand. `.repeat(16)
+            )),
+            Object.freeze(Array.from({length: 8}, (_, index) =>
+                `Orchestrator recovery batch B fixture ${index}: deterministic maintenance-shaped embedding demand. `.repeat(16)
+            ))
+        ])
+    }),
+    SOURCE_CONTRACT = Object.freeze({
+        chat: Object.freeze({
+            callKind: 'chat-queue',
+            priority: 'interactive',
+            role    : 'chat',
+            service : 'knowledge-base',
+            stage   : 'kb-ask-synthesis'
+        }),
+        'knowledge-base': Object.freeze({
+            callKind: 'interactive-single',
+            priority: 'interactive',
+            role    : 'embedding',
+            service : 'knowledge-base',
+            stage   : 'kb-query-embedding'
+        }),
+        'memory-core': Object.freeze({
+            callKind: 'batch-array',
+            priority: 'batch',
+            role    : 'embedding',
+            service : 'memory-core',
+            stage   : 'mc-wal-drain-embedding'
+        }),
+        orchestrator: Object.freeze({
+            callKind: 'batch-array',
+            priority: 'batch',
+            role    : 'embedding',
+            service : 'orchestrator',
+            stage   : 'unknown'
+        })
+    });
+
+/**
+ * @module ai/scripts/benchmark/provider-lane-election
+ * @summary Canonical disposable-plane actor for the `{1,2,4}` provider-lane election.
+ *
+ * The controller owns a fresh Compose project, renders every candidate through the canonical
+ * provider-lane composition analyzer, launches queue-real producer-shaped workers from one dedicated exact-revision image,
+ * samples the two provider containers through DeploymentRuntimeAccessService, and publishes only
+ * the winning receipt's already-validated deployment inputs. It never parses Compose, discovers
+ * endpoints, adapts an external plane, reads caller content, or silently supplies SLO defaults.
+ *
+ * Numeric joint-SLO thresholds are required in a versioned plan. They are policy inputs, not facts
+ * this runner is allowed to invent. Context-limit probes run once per candidate and lane outside the
+ * timed workload windows so the proof does not contaminate the latency/throughput measurement.
+ *
+ * @see https://github.com/neomjs/neo/issues/17024
+ * @see ai/scripts/diagnostics/providerLaneComposition.mjs
+ * @see ai/scripts/benchmark/helpers/providerLaneElectionCore.mjs
+ */
+
+/**
+ * @summary Returns one stable SHA-256 digest for JSON-compatible evidence.
+ * @param {*} value JSON-compatible value.
+ * @returns {String}
+ */
+export function digestProviderLaneValue(value) {
+    return `sha256:${createHash('sha256').update(stableSerialize(value)).digest('hex')}`
+}
+
+/**
+ * @summary Validates the exact caller-owned plan surface without creating SLO or workload defaults.
+ * @param {Object} plan Candidate run plan.
+ * @returns {Object} Bounded normalized plan.
+ */
+export function validateProviderLaneRunPlan(plan) {
+    requireExactKeys(plan, [
+        'blocks',
+        'candidateDeploymentInputs',
+        'contextProbeTimeoutMs',
+        'resourceSampling',
+        'revision',
+        'schemaVersion',
+        'slo',
+        'trialTimeoutMs'
+    ], 'provider-lane run plan');
+
+    if (plan.schemaVersion !== PLAN_SCHEMA || !REVISION_PATTERN.test(plan.revision ?? '')) {
+        throw new Error(`provider-lane run plan requires ${PLAN_SCHEMA} and one lowercase full revision SHA`)
+    }
+    if (!Number.isInteger(plan.blocks) || plan.blocks <= 0 ||
+        !Number.isInteger(plan.contextProbeTimeoutMs) || plan.contextProbeTimeoutMs <= 0 ||
+        !Number.isInteger(plan.trialTimeoutMs) || plan.trialTimeoutMs <= 0) {
+        throw new Error('provider-lane run plan requires positive integer blocks and explicit context/trial timeouts')
+    }
+
+    const candidateDeploymentInputs = validateCandidateDeploymentInputs(plan.candidateDeploymentInputs);
+
+    return {
+        blocks               : plan.blocks,
+        candidateDeploymentInputs,
+        contextProbeTimeoutMs: plan.contextProbeTimeoutMs,
+        resourceSampling     : structuredClone(plan.resourceSampling),
+        revision             : plan.revision,
+        schemaVersion        : PLAN_SCHEMA,
+        slo                  : structuredClone(plan.slo),
+        trialTimeoutMs       : plan.trialTimeoutMs
+    }
+}
+
+/**
+ * @summary Validates exact `{1,2,4}` envelopes against the composition analyzer's exported env map.
+ * @param {Object[]} rows Candidate envelopes.
+ * @returns {Object[]} Normalized rows.
+ */
+function validateCandidateDeploymentInputs(rows) {
+    if (!Array.isArray(rows) || rows.length !== CANDIDATES.length) {
+        throw new Error('provider-lane run plan requires exactly three candidate deployment envelopes')
+    }
+
+    const expectedKeys = Object.keys(PROVIDER_LANE_DEPLOYMENT_INPUT_ENVS).sort(),
+          sorted       = [...rows].sort((left, right) => left?.candidate - right?.candidate);
+
+    if (sorted.some((row, index) => row?.candidate !== CANDIDATES[index])) {
+        throw new Error('provider-lane deployment envelopes require candidates 1, 2, and 4 exactly once')
+    }
+
+    return sorted.map(row => {
+        requireExactKeys(row, ['candidate', 'deploymentInputs'], `candidate ${row.candidate}`);
+        requireExactKeys(row.deploymentInputs, expectedKeys, `candidate ${row.candidate}.deploymentInputs`);
+
+        const deploymentInputs = {};
+
+        for (const key of expectedKeys) {
+            const input = row.deploymentInputs[key];
+
+            requireExactKeys(input, ['env', 'value'], `candidate ${row.candidate}.deploymentInputs.${key}`);
+            if (input.env !== PROVIDER_LANE_DEPLOYMENT_INPUT_ENVS[key] ||
+                !Number.isFinite(input.value) || input.value <= 0) {
+                throw new Error(`candidate ${row.candidate} has an invalid canonical deployment input '${key}'`)
+            }
+            deploymentInputs[key] = {env: input.env, value: input.value}
+        }
+
+        if (deploymentInputs.embeddingParallelSlots.value !== row.candidate) {
+            throw new Error(`candidate ${row.candidate} deployment envelope changed its embedding slot value`)
+        }
+
+        return {candidate: row.candidate, deploymentInputs}
+    })
+}
+
+/**
+ * @summary Validates a canonical composition receipt and selects only the closed exact-image adapters.
+ * @param {Object} receipt Canonical provider-lane composition receipt.
+ * @returns {Object} Lane adapter map.
+ */
+export function resolveProviderLaneAdapters(receipt) {
+    const validation = validateProviderLaneCompositionReceipt(receipt);
+
+    if (!validation.valid) {
+        const error = new Error('provider-lane composition receipt failed canonical validation');
+        error.code  = 'COMPOSITION_RECEIPT_INVALID';
+        throw error
+    }
+
+    return Object.fromEntries(LANE_NAMES.map(laneName => {
+        const lane    = receipt.lanes[laneName],
+              adapter = CLOSED_ADAPTERS[laneName],
+              kind    = lane.endpoints?.workload?.kind;
+
+        if (lane.provider !== adapter.provider || lane.image?.reference !== adapter.imageReference ||
+            lane.image?.digest !== adapter.imageDigest || lane.model?.digest !== adapter.modelDigest ||
+            kind !== adapter.workloadKind) {
+            const error = new Error(`provider-lane ${laneName} receipt does not match a closed exact-image adapter`);
+            error.code  = 'UNSUPPORTED_PROVIDER_ADAPTER';
+            throw error
+        }
+
+        return [laneName, adapter]
+    }))
+}
+
+/**
+ * @summary Projects one validated composition receipt into the pure core's immutable profile.
+ * @param {Object} options
+ * @param {String} options.compositionReceiptDigest Digest of the exact archived receipt bytes.
+ * @param {Object} options.receipt Validated composition receipt.
+ * @returns {Object}
+ */
+export function createProviderLaneCandidateProfile({compositionReceiptDigest, receipt}) {
+    const adapters  = resolveProviderLaneAdapters(receipt),
+          candidate = receipt.lanes.embedding.parallelSlots;
+
+    if (!CANDIDATES.includes(candidate)) {
+        throw new Error(`provider-lane composition receipt selected unsupported candidate ${candidate}`)
+    }
+
+    return {
+        compositionReceiptDigest,
+        compositionSchemaVersion: receipt.schemaVersion,
+        embeddingSlots          : candidate,
+        lanes                   : Object.fromEntries(LANE_NAMES.map(laneName => {
+            const lane = receipt.lanes[laneName];
+
+            return [laneName, {
+                baseUrl                     : lane.baseUrl,
+                contextTokensPerSlotRequired: lane.contextTokensPerSlotRequired,
+                cpuCores                    : lane.cpuCores,
+                endpointDigest              : digestProviderLaneValue(lane.endpoints),
+                imageDigest                 : lane.image.digest,
+                imageReference              : lane.image.reference,
+                memoryBytes                 : lane.memoryBytes,
+                modelCoordinate             : lane.model.coordinate,
+                modelDigest                 : lane.model.digest,
+                modelDigestKind             : lane.model.digestKind,
+                modelId                     : lane.model.id,
+                parallelism                 : lane.parallelSlots,
+                protocolAdapter             : adapters[laneName].id,
+                provider                    : lane.provider,
+                serviceKey                  : lane.serviceKey,
+                totalContextTokens          : lane.totalContextTokens
+            }]
+        })),
+        roleMapDigest : digestProviderLaneValue(receipt.roles),
+        totalResources: {
+            cpuCores   : receipt.envelope.total.cpuCores,
+            memoryBytes: receipt.envelope.total.memoryBytes
+        }
+    }
+}
+
+/**
+ * @summary Parses a bounded provider response into the runner-owned context-refusal vocabulary.
+ * @param {Object} options
+ * @param {Object} options.adapter Closed exact-image adapter.
+ * @param {String} options.body Raw bounded response body.
+ * @param {Number} options.status HTTP status.
+ * @returns {{observedOutputTokens: Number, responseBodyDigest: String, responseClass: String, transportStatus: Number}}
+ */
+export function classifyProviderLaneProbeResponse({adapter, body, status}) {
+    if (!Object.values(CLOSED_ADAPTERS).includes(adapter) || !Number.isInteger(status) ||
+        typeof body !== 'string' || Buffer.byteLength(body) > 1024 * 1024) {
+        throw new Error('provider-lane probe requires a closed adapter and bounded raw response')
+    }
+
+    const parsed       = safeJson(body),
+          errorType    = findProviderErrorType(parsed),
+          errorMessage = findProviderErrorMessage(parsed),
+          refused      = status === adapter.refusalStatus && (
+              adapter.refusalErrorType
+                  ? errorType === adapter.refusalErrorType
+                  : adapter.refusalErrorMessages?.includes(errorMessage)
+          ),
+          completed = status >= 200 && status < 300;
+
+    return {
+        observedOutputTokens: completed ? inferObservedOutput(parsed) : 0,
+        responseBodyDigest  : digestRaw(body),
+        responseClass       : refused ? 'context-limit-refusal' : completed ? 'completed' : 'provider-error',
+        transportStatus     : status
+    }
+}
+
+/**
+ * @summary Parses the Engine API's bounded `docker top -eo pid,rss` payload into aggregate process RSS.
+ *
+ * RSS is summed per process exactly as the Linux `ps` contract reports it. Shared pages may therefore
+ * appear once per process, but the definition stays identical across every candidate. Docker cgroup-v2
+ * `memory.stat.anon` is deliberately rejected: it excludes resident file-backed model mappings and is
+ * not process RSS.
+ *
+ * @param {Object|String} payload Docker top JSON payload or its bounded serialized form.
+ * @returns {Number} Aggregate process RSS bytes.
+ */
+export function parseProviderLaneDockerTopRss(payload) {
+    const parsed    = typeof payload === 'string' ? safeJson(payload) : payload,
+          titles    = parsed?.Titles,
+          processes = parsed?.Processes,
+          pidIndex  = Array.isArray(titles) ? titles.indexOf('PID') : -1,
+          rssIndex  = Array.isArray(titles) ? titles.indexOf('RSS') : -1;
+
+    if (pidIndex < 0 || rssIndex < 0 || !Array.isArray(processes) || processes.length === 0) {
+        throw Object.assign(new Error('provider-lane Docker top receipt requires PID and RSS rows'), {
+            code: 'DOCKER_TOP_RSS_INVALID'
+        })
+    }
+
+    let totalKiB = 0;
+
+    for (const row of processes) {
+        const pid = Number(row?.[pidIndex]),
+              rss = Number(row?.[rssIndex]);
+
+        if (!Number.isSafeInteger(pid) || pid <= 0 || !Number.isSafeInteger(rss) || rss < 0 ||
+            !Number.isSafeInteger(totalKiB + rss)) {
+            throw Object.assign(new Error('provider-lane Docker top receipt contains an invalid PID/RSS row'), {
+                code: 'DOCKER_TOP_RSS_INVALID'
+            })
+        }
+        totalKiB += rss
+    }
+
+    const totalBytes = totalKiB * 1024;
+
+    if (!Number.isSafeInteger(totalBytes)) {
+        throw Object.assign(new Error('provider-lane aggregate process RSS exceeds the safe receipt range'), {
+            code: 'DOCKER_TOP_RSS_INVALID'
+        })
+    }
+
+    return totalBytes
+}
+
+/**
+ * @summary Preserves truthful zero CPU while retaining the shared Docker delta calculator for active samples.
+ * @param {Object} stats Raw non-streaming Docker stats.
+ * @param {Function} calculateDockerCpuPercent Canonical Docker CPU calculator.
+ * @returns {Number|null}
+ */
+export function calculateProviderLaneDockerCpuPercent(stats, calculateDockerCpuPercent) {
+    const calculated = calculateDockerCpuPercent(stats);
+
+    if (Number.isFinite(calculated)) return calculated;
+
+    const cpuStats    = stats?.cpu_stats || {},
+          preCpuStats = stats?.precpu_stats || {},
+          cpuDelta    = Number(cpuStats.cpu_usage?.total_usage) - Number(preCpuStats.cpu_usage?.total_usage),
+          systemDelta = Number(cpuStats.system_cpu_usage) - Number(preCpuStats.system_cpu_usage);
+
+    return cpuDelta === 0 && Number.isFinite(systemDelta) && systemDelta > 0 ? 0 : null
+}
+
+/**
+ * @summary Parses one Docker CLI endpoint and admits only a local absolute Unix socket.
+ * @param {String} endpoint Docker Engine endpoint.
+ * @returns {String} Absolute socket path before canonicalization.
+ */
+export function parseProviderLaneDockerEndpoint(endpoint) {
+    let parsed;
+
+    try {
+        parsed = new URL(endpoint)
+    } catch {
+        parsed = null
+    }
+
+    if (!parsed || parsed.protocol !== 'unix:' || parsed.hostname || parsed.username || parsed.password ||
+        parsed.search || parsed.hash || !parsed.pathname.startsWith('/')) {
+        throw Object.assign(new Error('provider-lane election requires one local Unix Docker endpoint'), {
+            code: 'DOCKER_ENDPOINT_NOT_LOCAL_UNIX'
+        })
+    }
+
+    const socketPath = fileURLToPath(new URL(`file://${parsed.pathname}`));
+
+    if (!path.isAbsolute(socketPath)) {
+        throw Object.assign(new Error('provider-lane Docker socket path must be absolute'), {
+            code: 'DOCKER_ENDPOINT_NOT_LOCAL_UNIX'
+        })
+    }
+
+    return socketPath
+}
+
+/**
+ * @summary Resolves and verifies the one Docker daemon authority used by mutation and observation.
+ * @param {Object} [options]
+ * @param {Function} [options.inspectEndpoint] Read-only effective Docker-context inspector.
+ * @param {Function} [options.realpathFn] Filesystem canonicalizer.
+ * @param {Function} [options.statFn] Filesystem stat reader.
+ * @returns {Promise<Readonly<{endpoint: String, socketPath: String}>>}
+ */
+export async function resolveProviderLaneDockerAuthority({
+    inspectEndpoint = async () => {
+        const env = {
+            HOME: process.env.HOME,
+            PATH: process.env.PATH
+        };
+
+        for (const key of ['DOCKER_CONFIG', 'DOCKER_CONTEXT', 'DOCKER_HOST']) {
+            if (process.env[key]) env[key] = process.env[key]
+        }
+
+        const {stdout} = await execFileAsync('docker', [
+            'context', 'inspect', '--format', '{{json .Endpoints.docker.Host}}'
+        ], {env, maxBuffer: 1024 * 1024});
+        return JSON.parse(stdout.trim())
+    },
+    realpathFn = realpath,
+    statFn = stat
+} = {}) {
+    const socketPath = parseProviderLaneDockerEndpoint(await inspectEndpoint()),
+          canonical  = await realpathFn(socketPath),
+          metadata   = await statFn(canonical);
+
+    if (!path.isAbsolute(canonical) || !metadata.isSocket()) {
+        throw Object.assign(new Error('provider-lane Docker endpoint does not resolve to a Unix socket'), {
+            code: 'DOCKER_ENDPOINT_NOT_LOCAL_UNIX'
+        })
+    }
+
+    return Object.freeze({endpoint: `unix://${canonical}`, socketPath: canonical})
+}
+
+/**
+ * @summary Creates one idempotent cleanup owner for normal completion and process interruption.
+ * @param {Object} options
+ * @param {Function} options.teardown Bounded disposable-project teardown.
+ * @returns {Function} Idempotent asynchronous cleanup function.
+ */
+export function createProviderLaneCleanup({teardown}) {
+    if (typeof teardown !== 'function') throw new TypeError('provider-lane cleanup requires teardown');
+
+    let cleanupPromise;
+
+    return () => {
+        cleanupPromise ??= Promise.resolve().then(teardown);
+        return cleanupPromise
+    }
+}
+
+/**
+ * @summary Routes SIGINT/SIGTERM through the run AbortController and its idempotent cleanup owner.
+ * @param {Object} options
+ * @param {Function} options.cleanup Idempotent cleanup function.
+ * @param {AbortController} options.controller Active run controller.
+ * @param {Object} [options.processTarget=process] EventEmitter-compatible process boundary.
+ * @returns {Function} Listener disposer.
+ */
+export function installProviderLaneSignalHandlers({cleanup, controller, processTarget = process}) {
+    if (typeof cleanup !== 'function' || !controller?.signal) {
+        throw new TypeError('provider-lane signal routing requires cleanup and an AbortController')
+    }
+
+    const onSignal = signal => {
+        if (!controller.signal.aborted) {
+            const error = new Error(`provider-lane election interrupted by ${signal}`);
+            error.code  = 'PROVIDER_LANE_INTERRUPTED';
+            controller.abort(error);
+            void cleanup().catch(() => {})
+        }
+    },
+          onSigint  = () => onSignal('SIGINT'),
+          onSigterm = () => onSignal('SIGTERM');
+
+    processTarget.on('SIGINT', onSigint);
+    processTarget.on('SIGTERM', onSigterm);
+
+    return () => {
+        processTarget.off('SIGINT', onSigint);
+        processTarget.off('SIGTERM', onSigterm)
+    }
+}
+
+/**
+ * @summary Keeps signal ownership through teardown and refuses an authoritative return after interruption.
+ * @param {Object} options
+ * @param {Function} options.cleanup Idempotent cleanup owner.
+ * @param {AbortController} options.controller Active run controller.
+ * @param {Function} options.dispose Signal-listener disposer.
+ * @returns {Promise<void>}
+ */
+export async function completeProviderLaneCleanup({cleanup, controller, dispose}) {
+    try {
+        await cleanup()
+    } finally {
+        dispose()
+    }
+
+    if (controller.signal.aborted) throw controller.signal.reason
+}
+
+/**
+ * @summary Projects a pure measured winner onto its already-validated deployment envelope.
+ * @param {Object} options
+ * @returns {{deploymentInputs: Object|null, status: String}} Non-authoritative bounded outcome.
+ */
+export function projectProviderLaneOutcome({election, receipts}) {
+    if (!election || !Array.isArray(election.candidates) || !Array.isArray(receipts) ||
+        receipts.length !== CANDIDATES.length) {
+        throw new Error('provider-lane outcome projection requires a complete measured election')
+    }
+
+    const sortedReceipts = [...receipts].sort((left, right) => left?.candidate - right?.candidate);
+
+    if (sortedReceipts.some((entry, index) => entry?.candidate !== CANDIDATES[index] ||
+        !DIGEST_PATTERN.test(entry?.compositionReceiptDigest ?? '') ||
+        entry?.receipt?.lanes?.embedding?.parallelSlots !== entry.candidate)) {
+        throw new Error('provider-lane outcome projection requires exact validated candidate receipts')
+    }
+    sortedReceipts.forEach(entry => resolveProviderLaneAdapters(entry.receipt));
+
+    const passing = election.candidates
+              .filter(candidate => candidate?.status === 'PASS')
+              .map(candidate => candidate.candidate)
+              .sort((left, right) => left - right),
+          winner = election.winnerCandidate,
+          expectedWinner = passing[0] ?? null,
+          receipt = winner === null ? null : sortedReceipts.find(item => item.candidate === winner);
+
+    if (winner !== expectedWinner || (winner !== null && (!CANDIDATES.includes(winner) || !receipt))) {
+        throw new Error('provider-lane outcome projection received an incoherent measured winner')
+    }
+
+    return {
+        deploymentInputs   : receipt ? structuredClone(receipt.receipt.deploymentInputs) : null,
+        selectedComposition: receipt ? projectSelectedProviderLaneComposition(receipt) : null,
+        status             : winner === null ? 'NO_ELECTION' : 'ELECTED'
+    }
+}
+
+/**
+ * @summary Projects the self-describing immutable composition selected by the measured winner.
+ *
+ * The profile digest proves which archived receipt was measured, but downstream generation identity
+ * cannot recover model coordinates, endpoints, role routing, or the fixed resource envelope from a
+ * digest alone. This projection is therefore copied from the same already-validated receipt as the
+ * deployment inputs. It contains no operator secrets and never re-derives configuration.
+ *
+ * @param {Object} receiptEntry Validated archived candidate receipt wrapper.
+ * @returns {Object} Allowlisted immutable composition artifact.
+ */
+function projectSelectedProviderLaneComposition(receiptEntry) {
+    const receipt = receiptEntry.receipt;
+
+    resolveProviderLaneAdapters(receipt);
+
+    return {
+        candidate               : receiptEntry.candidate,
+        compositionReceiptDigest: receiptEntry.compositionReceiptDigest,
+        envelope                : structuredClone(receipt.envelope),
+        lanes                   : Object.fromEntries(LANE_NAMES.map(laneName => {
+            const lane = receipt.lanes[laneName];
+
+            return [laneName, {
+                baseUrl                     : lane.baseUrl,
+                contextTokensPerSlotRequired: lane.contextTokensPerSlotRequired,
+                cpuCores                    : lane.cpuCores,
+                endpoints                   : structuredClone(lane.endpoints),
+                image                       : structuredClone(lane.image),
+                memoryBytes                 : lane.memoryBytes,
+                model                       : structuredClone(lane.model),
+                parallelSlots               : lane.parallelSlots,
+                provider                    : lane.provider,
+                serviceKey                  : lane.serviceKey,
+                totalContextTokens          : lane.totalContextTokens
+            }]
+        })),
+        roles        : structuredClone(receipt.roles),
+        schemaVersion: receipt.schemaVersion
+    }
+}
+
+/**
+ * @summary Finalizes live-controller evidence without exposing an authority-minting public seam.
+ * @private
+ */
+function finalizeProviderLaneElection({artifacts, election, head, projectName, receipts}) {
+    if (!REVISION_PATTERN.test(head ?? '') || typeof projectName !== 'string' || !projectName) {
+        throw new Error('provider-lane finalizer requires an exact live controller identity')
+    }
+
+    const outcome = projectProviderLaneOutcome({election, receipts});
+
+    return {
+        artifacts: structuredClone(artifacts),
+        authority: {
+            authoritative: true,
+            evidenceClass: 'canonical-disposable-plane',
+            reason       : 'complete validated matrix on a run-owned disposable Compose project'
+        },
+        deploymentInputs   : outcome.deploymentInputs,
+        election,
+        projectName,
+        repositoryHead     : head,
+        schemaVersion      : REPORT_SCHEMA,
+        selectedComposition: outcome.selectedComposition,
+        status             : outcome.status
+    }
+}
+
+/**
+ * @summary Creates a bounded incomplete report which can never expose deployment inputs.
+ * @param {Object} options
+ * @returns {Object}
+ */
+export function createIncompleteProviderLaneReport({code = 'RUN_ABORTED', measuredHead = null, projectName = null} = {}) {
+    return {
+        artifacts: {candidateReceipts: []},
+        authority: {
+            authoritative: false,
+            evidenceClass: 'incomplete',
+            reason       : String(code).slice(0, 120)
+        },
+        deploymentInputs   : null,
+        election           : null,
+        projectName,
+        repositoryHead     : REVISION_PATTERN.test(measuredHead ?? '') ? measuredHead : null,
+        schemaVersion      : REPORT_SCHEMA,
+        selectedComposition: null,
+        status             : 'INCOMPLETE'
+    }
+}
+
+/**
+ * @summary Runs one queue-real producer-shaped worker inside the dedicated exact-revision image.
+ * @param {Object} options
+ * @param {Object} options.receipt Validated candidate receipt.
+ * @param {String} options.source Closed workload source.
+ * @returns {Promise<Object>} Bounded worker lifecycle receipt.
+ */
+export async function runProviderLaneWorkloadWorker({receipt, source}) {
+    const contract = SOURCE_CONTRACT[source],
+          payloads = WORKLOAD_PAYLOADS[source];
+
+    if (!contract || !payloads) {
+        throw new Error(`provider-lane worker received unknown source '${source}'`)
+    }
+
+    resolveProviderLaneAdapters(receipt);
+
+    const recorder = createInMemoryProviderRecorder(),
+          results  = source === CHAT_SOURCE
+              ? await runChatWorker({contract, payloads, receipt, recorder})
+              : await runEmbeddingWorker({contract, payloads, receipt, recorder, source}),
+          operations         = recorder.project(),
+          expectedOperations = countExpectedProviderOperations(source, payloads);
+
+    if (results.length !== payloads.length || operations.length < payloads.length ||
+        operations.length > expectedOperations) {
+        throw new Error(`provider-lane ${source} worker observed ${operations.length}/${expectedOperations} provider lifecycles`)
+    }
+
+    return {
+        callKind: contract.callKind,
+        operations,
+        results : results.map((result, index) => {
+            const kind        = source === CHAT_SOURCE ? 'chat' : 'embedding',
+                  outputCount = result.status === 'fulfilled'
+                      ? countProviderLaneOperationOutput(result.value, kind)
+                      : 0;
+
+            return {
+                callId       : `${source}-${index}`,
+                completedAtMs: result.completedAtMs,
+                demandAtMs   : result.demandAtMs,
+                outcome      : classifyProviderLaneOperationResult(result, {
+                    kind               : source === CHAT_SOURCE ? 'chat' : 'embedding',
+                    expectedOutputCount: source === CHAT_SOURCE
+                        ? 1
+                        : Array.isArray(payloads[index]) ? payloads[index].length : 1
+                }),
+                outputCount
+            }
+        }),
+        schemaVersion: WORKER_SCHEMA,
+        source
+    }
+}
+
+/**
+ * @summary Runs one receipt-bound context observation and optional over-limit probe inside the network.
+ * @param {Object} options
+ * @param {Boolean} options.includeOverLimit Whether to run the capacity refusal request.
+ * @param {Object} options.receipt Validated candidate receipt.
+ * @param {Number} options.timeoutMs Explicit request timeout.
+ * @returns {Promise<Object>}
+ */
+export async function runProviderLaneContextWorker({includeOverLimit, receipt, timeoutMs}) {
+    const adapters = resolveProviderLaneAdapters(receipt);
+
+    if (!Number.isInteger(timeoutMs) || timeoutMs <= 0) {
+        throw new Error('provider-lane context worker requires an explicit positive timeout')
+    }
+
+    if (includeOverLimit) {
+        await warmChatLane({adapter: adapters.chat, lane: receipt.lanes.chat, timeoutMs})
+    }
+
+    const startedAtMs  = Date.now(),
+          observations = Object.fromEntries(await Promise.all(LANE_NAMES.map(async laneName => [
+              laneName,
+              await observeLaneContext({adapter: adapters[laneName], lane: receipt.lanes[laneName], timeoutMs})
+          ]))),
+          lanes = {};
+
+    for (const laneName of LANE_NAMES) {
+        const observation = observations[laneName],
+              lane        = receipt.lanes[laneName];
+
+        lanes[laneName] = {
+            observedContextTokensPerSlot: observation.contextTokensPerSlot,
+            parallelism                 : observation.parallelism,
+            resident                    : observation.resident
+        };
+
+        if (includeOverLimit) {
+            lanes[laneName].overLimitProbe = await runOverLimitProbe({
+                adapter                     : adapters[laneName],
+                lane,
+                observedContextTokensPerSlot: observation.contextTokensPerSlot,
+                timeoutMs
+            })
+        }
+    }
+
+    return {
+        completedAtMs: Date.now(),
+        lanes,
+        schemaVersion: WORKER_SCHEMA,
+        startedAtMs
+    }
+}
+
+/**
+ * @summary Establishes one explicit pre-trial chat residency state on the disposable lane.
+ * @param {Object} options
+ * @param {Object} options.receipt Validated candidate receipt.
+ * @param {Boolean} options.resident Requested pre-trial state.
+ * @param {Number} options.timeoutMs Explicit request timeout.
+ * @returns {Promise<Object>} Bounded preparation receipt.
+ */
+export async function runProviderLanePreparationWorker({receipt, resident, timeoutMs}) {
+    const adapters    = resolveProviderLaneAdapters(receipt),
+          lane        = receipt.lanes.chat,
+          startedAtMs = Date.now();
+
+    if (typeof resident !== 'boolean' || !Number.isInteger(timeoutMs) || timeoutMs <= 0) {
+        throw new Error('provider-lane preparation worker requires explicit residency and timeout')
+    }
+
+    if (resident) {
+        await warmChatLane({adapter: adapters.chat, lane, timeoutMs})
+    } else {
+        const response = await fetchBounded(lane.endpoints.workload.url, {
+            body  : JSON.stringify({keep_alive: 0, messages: [], model: lane.model.id, stream: false}),
+            method: lane.endpoints.workload.method,
+            timeoutMs
+        });
+
+        if (response.status < 200 || response.status >= 300) {
+            throw Object.assign(new Error('provider-lane chat unload failed'), {code: 'CHAT_UNLOAD_FAILED'})
+        }
+    }
+
+    return {
+        completedAtMs: Date.now(),
+        resident,
+        schemaVersion: WORKER_SCHEMA,
+        startedAtMs
+    }
+}
+
+/**
+ * @summary Runs the real OpenAI-compatible embedding queue in one source process.
+ * @private
+ */
+async function runEmbeddingWorker({contract, payloads, receipt, recorder, source}) {
+    await import('../../../src/Neo.mjs');
+    await import('../../../src/core/_export.mjs');
+
+    const [{default: aiConfig}, {default: TextEmbeddingService}] = await Promise.all([
+        source === 'knowledge-base'
+            ? import('../../mcp/server/knowledge-base/config.mjs')
+            : source === 'memory-core'
+                ? import('../../mcp/server/memory-core/config.mjs')
+                : import('../../config.mjs'),
+        import('../../services/memory-core/TextEmbeddingService.mjs')
+    ]);
+
+    assertProviderLaneWorkerConfig({aiConfig, receipt, source});
+
+    return Promise.all(payloads.map((payload, index) => observeProviderLaneSourceCall({
+        callId  : `${source}-${index}`,
+        callback: () => invokeProviderLaneEmbeddingSource({
+            embeddingService: TextEmbeddingService,
+            options         : {
+                operationLabel          : `provider-lane-election-${contract.service}-${index}`,
+                operationStage          : contract.stage,
+                providerActivityRecorder: recorder,
+                service                 : contract.service
+            },
+            provider: aiConfig.embeddingProvider,
+            payload,
+            source
+        }),
+        recorder
+    })))
+}
+
+/**
+ * @summary Invokes the source-owned interactive or batch scheduler seam without changing its payload.
+ * @param {Object} options
+ * @returns {Promise<*>} Provider result.
+ */
+export function invokeProviderLaneEmbeddingSource({embeddingService, options, payload, provider, source}) {
+    const contract = SOURCE_CONTRACT[source];
+
+    if (!contract || contract.role !== 'embedding' || !embeddingService) {
+        throw new Error(`provider-lane embedding source '${source}' has no closed scheduler contract`)
+    }
+    if (contract.callKind === 'interactive-single') {
+        if (typeof payload !== 'string') throw new Error('provider-lane interactive embedding payload must be one string');
+        return embeddingService.embedText(payload, provider, options)
+    }
+    if (contract.callKind === 'batch-array') {
+        if (!Array.isArray(payload) || payload.length < 2 || payload.some(text => typeof text !== 'string')) {
+            throw new Error('provider-lane batch embedding payload must contain multiple strings')
+        }
+        return embeddingService.embedTexts(payload, provider, options)
+    }
+    throw new Error(`provider-lane embedding source '${source}' has an unsupported scheduler contract`)
+}
+
+/**
+ * @summary Runs the real capacity-1 chat queue in one source process.
+ * @private
+ */
+async function runChatWorker({contract, payloads, receipt, recorder}) {
+    await import('../../../src/Neo.mjs');
+    await import('../../../src/core/_export.mjs');
+
+    const [
+        {default: aiConfig},
+        {buildChatModel},
+        {buildAskChatModelOptions, buildAskProviderConfigs}
+    ] = await Promise.all([
+        import('../../mcp/server/knowledge-base/config.mjs'),
+        import('../../provider/buildChatModel.mjs'),
+        import('../../services/knowledge-base/SearchService.mjs')
+    ]);
+
+    const providerConfigs = buildAskProviderConfigs(aiConfig),
+          options         = buildAskChatModelOptions(aiConfig, providerConfigs);
+
+    assertProviderLaneWorkerConfig({
+        aiConfig,
+        providerConfig: providerConfigs.ollamaConfig,
+        receipt,
+        source        : CHAT_SOURCE
+    });
+
+    const model = buildChatModel({
+        ...options,
+        providerActivityRecorder: recorder,
+        providerActivityService : contract.service
+    });
+
+    if (!model) throw new Error('provider-lane chat worker could not construct the configured model');
+
+    const ask = aiConfig.askSynthesis;
+
+    return Promise.all(payloads.map((text, index) => observeProviderLaneSourceCall({
+        callId  : `${CHAT_SOURCE}-${index}`,
+        callback: () => model.generateContent(text, {
+            operationLabel  : `provider-lane-election-kb-ask-${index}`,
+            operationStage  : contract.stage,
+            priority        : contract.priority,
+            reasoning_effort: ask.reasoningEffort || undefined,
+            timeoutMs       : ask.timeoutMs
+        }),
+        recorder
+    })))
+}
+
+/**
+ * @summary Captures one caller-visible source operation around every provider lifecycle it creates.
+ * @param {Object} options
+ * @param {String} options.callId Bounded source-call identity.
+ * @param {Function} options.callback Source-owned provider call.
+ * @param {Object} options.recorder In-memory lifecycle recorder.
+ * @returns {Promise<Object>} Settled result with caller demand/completion timestamps.
+ * @private
+ */
+async function observeProviderLaneSourceCall({callId, callback, recorder}) {
+    const demandAtMs = Date.now();
+
+    try {
+        const value = await recorder.withCall(callId, callback);
+
+        return {completedAtMs: Math.max(Date.now(), demandAtMs + 1), demandAtMs, status: 'fulfilled', value}
+    } catch (reason) {
+        return {completedAtMs: Math.max(Date.now(), demandAtMs + 1), demandAtMs, reason, status: 'rejected'}
+    }
+}
+
+/**
+ * @summary Binds an internal worker's resolved provider leaves to the exact validated receipt.
+ * @param {Object} options
+ * @param {Object} options.aiConfig Resolved service config.
+ * @param {Object} [options.providerConfig] Canonical resolved ask provider config.
+ * @param {Object} options.receipt Validated composition receipt.
+ * @param {String} options.source Closed producer source.
+ * @returns {void}
+ */
+export function assertProviderLaneWorkerConfig({aiConfig, providerConfig, receipt, source}) {
+    resolveProviderLaneAdapters(receipt);
+
+    if (source === CHAT_SOURCE) {
+        const ask  = aiConfig.askSynthesis,
+              lane = receipt.lanes.chat;
+
+        if (!providerConfig || ask.provider !== lane.provider || ask.model !== lane.model.id ||
+            providerConfig.host !== lane.baseUrl || providerConfig.model !== lane.model.id || ask.apiKey) {
+            throw Object.assign(new Error('provider-lane chat worker config differs from its exact receipt'), {
+                code: 'WORKER_CONFIG_MISMATCH'
+            })
+        }
+        return
+    }
+
+    const lane = receipt.lanes.embedding;
+
+    if (!EMBEDDING_SOURCES.includes(source) || aiConfig.embeddingProvider !== lane.provider ||
+        aiConfig.openAiCompatible.host !== lane.baseUrl ||
+        aiConfig.openAiCompatible.embeddingModel !== lane.model.id ||
+        aiConfig.openAiCompatible.batchEmbeddingChunkSize !== EMBEDDING_CHUNK_SIZE ||
+        aiConfig.openAiCompatible.apiKey) {
+        throw Object.assign(new Error('provider-lane embedding worker config differs from its exact receipt'), {
+            code: 'WORKER_CONFIG_MISMATCH'
+        })
+    }
+}
+
+/**
+ * @summary Reduces one caller-visible provider result to completed/error/refusal without retaining content.
+ * @param {PromiseSettledResult<*>} result Settled source operation.
+ * @param {Object} expected Closed output contract.
+ * @returns {'completed'|'error'|'unexpected-refusal'}
+ */
+export function classifyProviderLaneOperationResult(result, {expectedOutputCount, kind}) {
+    if (result?.status === 'fulfilled') {
+        return countProviderLaneOperationOutput(result.value, kind) === expectedOutputCount ? 'completed' : 'error'
+    }
+    if (result?.status !== 'rejected') return 'error';
+
+    return isProviderLaneUnexpectedRefusal(result.reason) ? 'unexpected-refusal' : 'error'
+}
+
+/**
+ * @summary Counts only non-empty finite embedding vectors or one non-empty chat response.
+ * @param {*} value Provider result.
+ * @param {'chat'|'embedding'} kind Result kind.
+ * @returns {Number}
+ * @private
+ */
+function countProviderLaneOperationOutput(value, kind) {
+    if (kind === 'chat') {
+        try {
+            const text = value?.response?.text?.();
+            return typeof text === 'string' && text.length > 0 ? 1 : 0
+        } catch {
+            return 0
+        }
+    }
+
+    const vectors = Array.isArray(value?.[0]) ? value : [value];
+
+    return vectors.length > 0 && vectors.every(vector =>
+        Array.isArray(vector) && vector.length > 0 && vector.every(Number.isFinite)
+    ) ? vectors.length : 0
+}
+
+/**
+ * @summary Classifies only closed provider HTTP 4xx error prefixes as unexpected refusals.
+ * @param {*} error Rejected provider error.
+ * @returns {Boolean}
+ * @private
+ */
+function isProviderLaneUnexpectedRefusal(error) {
+    for (let current = error, depth = 0; current && depth <= 4; current = current.cause, depth++) {
+        const message = typeof current?.message === 'string' ? current.message : '';
+
+        if (/^(?:Ollama API error:|OpenAI-Compatible API error:) 4\d\d\b/.test(message) ||
+            /^openAiCompatible embedding error HTTP 4\d\d:/.test(message)) {
+            return true
+        }
+    }
+
+    return false
+}
+
+/**
+ * @summary Creates a synchronous recorder implementing the shipped provider lifecycle contract.
+ * @returns {Object}
+ * @private
+ */
+function createInMemoryProviderRecorder() {
+    const callContext = new AsyncLocalStorage(),
+          rows        = new Map();
+    let   nextId = 0;
+
+    return {
+        beginProviderActivity(entry) {
+            const callId = callContext.getStore(),
+                  id     = `worker-activity-${nextId++}`;
+
+            if (typeof callId !== 'string') {
+                throw new Error('provider-lane activity began outside a source-call boundary')
+            }
+
+            rows.set(id, {...entry, callId, id, startedAt: null, completedAt: null, success: null});
+            return id
+        },
+        startProviderActivity(id, startedAt) {
+            const row = rows.get(id);
+            if (row) row.startedAt = startedAt
+        },
+        refineProviderActivity(id, activity) {
+            const row = rows.get(id);
+            if (row && Object.hasOwn(activity, 'model')) row.model = activity.model
+        },
+        completeProviderActivity(id, outcome) {
+            const row = rows.get(id);
+            if (row) Object.assign(row, {completedAt: outcome.completedAt, success: outcome.success === true})
+        },
+        project() {
+            return [...rows.values()].map(row => ({
+                callId             : row.callId,
+                completedAtMs      : row.completedAt,
+                enqueuedAtMs       : row.enqueuedAt,
+                failureStage       : row.success ? null : 'provider',
+                id                 : row.id,
+                model              : row.model,
+                operationStage     : row.operationStage,
+                outcome            : row.success ? 'completed' : 'error',
+                priority           : row.priority,
+                provider           : row.provider,
+                providerStartedAtMs: row.startedAt,
+                queueDisposition   : row.queueDisposition,
+                role               : row.role,
+                service            : row.service
+            }))
+        },
+        withCall(callId, callback) {
+            if (!/^(?:chat|knowledge-base|memory-core|orchestrator)-\d+$/.test(callId) ||
+                typeof callback !== 'function') {
+                throw new Error('provider-lane recorder requires one bounded source-call identity')
+            }
+
+            return callContext.run(callId, callback)
+        }
+    }
+}
+
+/**
+ * @summary Ensures the native chat model is resident before reading `/api/ps`.
+ * @private
+ */
+async function warmChatLane({adapter, lane, timeoutMs}) {
+    const body = JSON.stringify({
+        messages: [{content: 'Reply with OK.', role: 'user'}],
+        model   : lane.model.id,
+        options : {num_predict: 1, temperature: 0},
+        stream  : false
+    });
+    const response = await fetchBounded(lane.endpoints.workload.url, {
+        body,
+        method   : lane.endpoints.workload.method,
+        timeoutMs
+    });
+
+    if (response.status < 200 || response.status >= 300) {
+        const classified = classifyProviderLaneProbeResponse({adapter, body: response.body, status: response.status});
+        throw Object.assign(new Error(`provider-lane chat warm failed as ${classified.responseClass}`), {
+            code: 'CHAT_WARM_FAILED'
+        })
+    }
+}
+
+/**
+ * @summary Reads runtime slot/context truth from one closed lane adapter.
+ * @private
+ */
+async function observeLaneContext({adapter, lane, timeoutMs}) {
+    if (adapter === CHAT_ADAPTER) {
+        const response = await fetchBounded(lane.endpoints.modelContext.url, {
+            method: lane.endpoints.modelContext.method,
+            timeoutMs
+        });
+        const payload = safeJson(response.body),
+              models  = Array.isArray(payload?.models) ? payload.models : [],
+              model   = models.find(item => item?.name === lane.model.id || item?.model === lane.model.id);
+
+        if (response.status !== 200) {
+            throw Object.assign(new Error('provider-lane chat context receipt is unavailable'), {
+                code: 'CHAT_CONTEXT_UNAVAILABLE'
+            })
+        }
+
+        if (!model) return {contextTokensPerSlot: null, parallelism: 1, resident: false};
+        if (!Number.isInteger(model.context_length) || model.context_length <= 0) {
+            throw Object.assign(new Error('provider-lane chat context receipt is invalid'), {
+                code: 'CHAT_CONTEXT_UNAVAILABLE'
+            })
+        }
+
+        return {contextTokensPerSlot: model.context_length, parallelism: 1, resident: true}
+    }
+
+    const response = await fetchBounded(lane.endpoints.slotContext.url, {
+        method: lane.endpoints.slotContext.method,
+        timeoutMs
+    });
+    const slots = safeJson(response.body);
+
+    if (response.status !== 200 || !Array.isArray(slots) || slots.length !== lane.parallelSlots ||
+        slots.some(slot => !Number.isInteger(slot?.n_ctx) || slot.n_ctx <= 0) ||
+        new Set(slots.map(slot => slot.n_ctx)).size !== 1) {
+        throw Object.assign(new Error('provider-lane embedding slot context receipt is unavailable'), {
+            code: 'EMBEDDING_CONTEXT_UNAVAILABLE'
+        })
+    }
+
+    return {contextTokensPerSlot: slots[0].n_ctx, parallelism: slots.length, resident: true}
+}
+
+/**
+ * @summary Executes one raw over-limit request and emits only bounded structural evidence.
+ * @private
+ */
+async function runOverLimitProbe({adapter, lane, observedContextTokensPerSlot, timeoutMs}) {
+    const {body, requestedContextTokens} = createProviderLaneOverLimitRequest({
+              adapter,
+              lane,
+              observedContextTokensPerSlot
+          }),
+          startedAtMs = Date.now(),
+          response = await fetchBounded(lane.endpoints.workload.url, {
+              body,
+              method: lane.endpoints.workload.method,
+              timeoutMs
+          });
+
+    return {
+        completedAtMs  : Date.now(),
+        id             : `${lane.serviceKey}:${startedAtMs}:${randomBytes(8).toString('hex')}`,
+        modelDigest    : lane.model.digest,
+        protocolAdapter: adapter.id,
+        requestedContextTokens,
+        serviceKey     : lane.serviceKey,
+        startedAtMs,
+        ...classifyProviderLaneProbeResponse({adapter, body: response.body, status: response.status})
+    }
+}
+
+/**
+ * @summary Builds one bounded closed-adapter over-limit request from verified runtime context truth.
+ * @param {Object} options
+ * @returns {{body: String, requestedContextTokens: Number}}
+ */
+export function createProviderLaneOverLimitRequest({adapter, lane, observedContextTokensPerSlot}) {
+    const modelCeiling = Number(lane.model?.contextTokensMax),
+          required     = Number(lane.contextTokensPerSlotRequired);
+
+    if (!Object.values(CLOSED_ADAPTERS).includes(adapter) ||
+        !Number.isInteger(observedContextTokensPerSlot) || !Number.isInteger(modelCeiling) ||
+        !Number.isInteger(required) || observedContextTokensPerSlot < required ||
+        observedContextTokensPerSlot > modelCeiling) {
+        throw Object.assign(new Error('provider-lane over-limit probe refused an unbounded runtime context'), {
+            code: 'CONTEXT_PROBE_BOUND_INVALID'
+        })
+    }
+
+    const requestedContextTokens = observedContextTokensPerSlot + 1,
+          body                   = adapter === CHAT_ADAPTER
+              ? JSON.stringify({
+                  messages: [{content: 'x '.repeat(requestedContextTokens), role: 'user'}],
+                  model   : lane.model.id,
+                  options : {num_predict: 1, temperature: 0},
+                  shift   : false,
+                  stream  : false,
+                  truncate: false
+              })
+              : JSON.stringify({
+                  input: 'x '.repeat(requestedContextTokens),
+                  model: lane.model.id
+              });
+
+    return {body, requestedContextTokens}
+}
+
+/**
+ * @summary Performs one bounded internal HTTP request without following redirects.
+ * @private
+ */
+async function fetchBounded(url, {body, method, timeoutMs}) {
+    const response = await fetch(url, {
+        body,
+        headers : body === undefined ? undefined : {'content-type': 'application/json'},
+        method,
+        redirect: 'error',
+        signal  : AbortSignal.timeout(timeoutMs)
+    });
+    const text = await readBoundedProviderLaneResponseBody(response);
+
+    return {body: text, status: response.status}
+}
+
+/**
+ * @summary Stream-reads one provider response and cancels before evidence exceeds 1 MiB.
+ * @param {Response} response Fetch response.
+ * @returns {Promise<String>} Bounded UTF-8 body.
+ */
+export async function readBoundedProviderLaneResponseBody(response) {
+    const declaredLength = Number(response?.headers?.get?.('content-length'));
+
+    if (Number.isFinite(declaredLength) && declaredLength > RESPONSE_BYTE_CAP) {
+        await response.body?.cancel?.().catch(() => {});
+        throw createProviderResponseTooLargeError()
+    }
+    if (!response?.body) return '';
+
+    const reader = response.body.getReader(),
+          chunks = [];
+    let   byteLength = 0;
+
+    try {
+        while (true) {
+            const {done, value} = await reader.read();
+            if (done) break;
+            byteLength += value.byteLength;
+            if (byteLength > RESPONSE_BYTE_CAP) {
+                await reader.cancel().catch(() => {});
+                throw createProviderResponseTooLargeError()
+            }
+            chunks.push(Buffer.from(value))
+        }
+    } finally {
+        reader.releaseLock()
+    }
+
+    return Buffer.concat(chunks, byteLength).toString('utf8')
+}
+
+/**
+ * @summary Creates the stable bounded-response refusal without retaining provider content.
+ * @private
+ */
+function createProviderResponseTooLargeError() {
+    return Object.assign(new Error('provider-lane response exceeded the 1 MiB evidence cap'), {
+        code: 'PROVIDER_RESPONSE_TOO_LARGE'
+    })
+}
+
+/**
+ * @summary Executes one complete exact-head election in a run-owned disposable Compose project.
+ * @param {Object} options
+ * @param {String} options.artifactDir Persistent candidate-receipt directory.
+ * @param {Readonly<{endpoint: String, socketPath: String}>} options.dockerAuthority One local Docker daemon.
+ * @param {String} options.head Measured exact checkout head.
+ * @param {Object} options.plan Validated run plan.
+ * @param {String} options.projectName Internally minted project identity.
+ * @param {String} options.projectRoot Exact checkout root.
+ * @returns {Promise<Object>} Authoritative complete report.
+ */
+async function runProviderLaneElectionController({artifactDir, dockerAuthority, head, plan, projectName, projectRoot}) {
+    if (head !== plan.revision) {
+        throw Object.assign(new Error('provider-lane plan revision does not match the exact checkout head'), {
+            code: 'REVISION_MISMATCH'
+        })
+    }
+
+    await assertTrackedWorktreeClean(projectRoot);
+    await mkdir(artifactDir, {recursive: true});
+
+    const controller = new AbortController(),
+          actor      = createComposeActor({dockerAuthority, plan, projectName, projectRoot, signal: controller.signal}),
+          cleanup    = createProviderLaneCleanup({teardown: actor.teardown}),
+          dispose    = installProviderLaneSignalHandlers({cleanup, controller});
+    let receipts;
+
+    try {
+        receipts = await renderAndArchiveCandidateReceipts({actor, artifactDir, plan});
+
+        const candidateProfiles = receipts.map(item => createProviderLaneCandidateProfile(item)),
+              workload          = createWorkloadContract(plan),
+              purePlan          = {
+                  blocks          : plan.blocks,
+                  candidateProfiles,
+                  resourceSampling: plan.resourceSampling,
+                  slo             : plan.slo,
+                  workload
+              },
+              schedule          = buildProviderLaneCandidateSchedule({blocks: plan.blocks}),
+              planDigest        = createProviderLanePlanDigest(purePlan),
+              runtime           = await createRuntimeObserver({dockerAuthority, projectName}),
+              contextEvidence   = [],
+              contextByCandidate = new Map(),
+              candidateRuns     = new Map(),
+              trials            = [];
+
+        await actor.buildWorkers(receipts[0]);
+
+        for (const slot of schedule) {
+            const receiptEntry       = receipts.find(item => item.candidate === slot.candidate),
+                  candidateRun       = candidateRuns.get(slot.candidate) ?? 0,
+                  chatResidentBefore = candidateRun % 2 === 1;
+
+            candidateRuns.set(slot.candidate, candidateRun + 1);
+
+            await actor.activateCandidate(receiptEntry);
+
+            if (!contextByCandidate.has(slot.candidate)) {
+                const worker = await actor.runContextWorker(receiptEntry, {
+                    includeOverLimit: true,
+                    timeoutMs       : plan.contextProbeTimeoutMs
+                });
+                const evidence = normalizeCandidateContextEvidence({receiptEntry, worker});
+
+                contextByCandidate.set(slot.candidate, evidence);
+                contextEvidence.push(evidence)
+            }
+
+            trials.push(await runMeasuredTrial({
+                actor,
+                plan,
+                receiptEntry,
+                runtime,
+                slot,
+                chatResidentBefore,
+                workloadDigest: workload.digest
+            }))
+        }
+
+        const election  = evaluateProviderLaneElection({contextEvidence, plan: purePlan, trials}),
+              artifacts = {
+                  candidateReceipts: receipts.map(item => ({
+                      candidate: item.candidate,
+                      digest   : item.compositionReceiptDigest,
+                      file     : path.basename(item.file)
+                  })),
+                  planDigest,
+                  workloadDigest: workload.digest
+              };
+
+        return finalizeProviderLaneElection({
+            artifacts,
+            election,
+            head,
+            projectName,
+            receipts
+        })
+    } finally {
+        await completeProviderLaneCleanup({cleanup, controller, dispose})
+    }
+}
+
+/**
+ * @summary Builds the immutable internal workload identity from code-owned public fixtures.
+ * @private
+ */
+function createWorkloadContract(plan) {
+    const offeredOperations = Object.fromEntries(Object.entries(WORKLOAD_PAYLOADS).map(([source, payloads]) => [
+        source,
+        payloads.length
+    ]));
+
+    return {
+        digest: digestProviderLaneValue({
+            contextProbeTimeoutMs: plan.contextProbeTimeoutMs,
+            embeddingChunkSize   : EMBEDDING_CHUNK_SIZE,
+            fixtures             : WORKLOAD_PAYLOADS,
+            schemaVersion        : 'provider-lane-workload.v1',
+            trialTimeoutMs       : plan.trialTimeoutMs
+        }),
+        offeredOperations
+    }
+}
+
+/**
+ * @summary Counts source calls as the exact provider lifecycle rows the shipped queue will create.
+ * @param {String} source Closed workload source.
+ * @param {Array} payloads Code-owned source payloads.
+ * @returns {Number}
+ * @private
+ */
+function countExpectedProviderOperations(source, payloads) {
+    const contract = SOURCE_CONTRACT[source];
+
+    if (!contract || !Array.isArray(payloads)) {
+        throw new Error(`provider-lane workload source '${source}' has no countable contract`)
+    }
+
+    return contract.callKind === 'batch-array'
+        ? payloads.reduce((count, payload) => count + Math.ceil(payload.length / EMBEDDING_CHUNK_SIZE), 0)
+        : payloads.length
+}
+
+/**
+ * @summary Renders every candidate through the analyzer and preserves exact receipt bytes.
+ * @private
+ */
+async function renderAndArchiveCandidateReceipts({actor, artifactDir, plan}) {
+    const receipts = [];
+
+    for (const candidateInput of plan.candidateDeploymentInputs) {
+        const raw       = await actor.renderReceipt(candidateInput),
+              receipt   = JSON.parse(raw),
+              adapters  = resolveProviderLaneAdapters(receipt),
+              candidate = receipt.lanes.embedding.parallelSlots;
+
+        if (candidate !== candidateInput.candidate || !adapters.chat || !adapters.embedding) {
+            throw Object.assign(new Error('provider-lane rendered candidate does not match its input envelope'), {
+                code: 'CANDIDATE_RENDER_MISMATCH'
+            })
+        }
+
+        assertDeploymentInputsEqual(receipt.deploymentInputs, candidateInput.deploymentInputs, candidate);
+
+        const compositionReceiptDigest = digestRaw(raw),
+              file                     = path.join(artifactDir, `composition-candidate-${candidate}.json`);
+
+        await atomicWrite(file, raw);
+        if (digestRaw(await readFile(file, 'utf8')) !== compositionReceiptDigest) {
+            throw Object.assign(new Error('provider-lane archived receipt digest changed after write'), {
+                code: 'RECEIPT_ARCHIVE_MISMATCH'
+            })
+        }
+
+        receipts.push({candidate, compositionReceiptDigest, file, receipt, candidateInput})
+    }
+
+    return receipts.sort((left, right) => left.candidate - right.candidate)
+}
+
+/**
+ * @summary Refuses any analyzer echo that differs from the candidate input byte-for-byte by field.
+ * @private
+ */
+function assertDeploymentInputsEqual(actual, expected, candidate) {
+    if (stableSerialize(actual) !== stableSerialize(expected)) {
+        throw Object.assign(new Error(`candidate ${candidate} analyzer changed the deployment-input envelope`), {
+            code: 'DEPLOYMENT_INPUT_MISMATCH'
+        })
+    }
+}
+
+/**
+ * @summary Builds the run-owned host Compose actor without accepting a live project identity.
+ * @private
+ */
+function createComposeActor({dockerAuthority, plan, projectName, projectRoot, signal}) {
+    const baseArgs = [
+        '--host', dockerAuthority.endpoint,
+        'compose',
+        '--env-file', '/dev/null',
+        '--project-name', projectName,
+        '--file', BASE_COMPOSE_FILE,
+        '--file', LANE_COMPOSE_FILE,
+        '--profile', 'cloud',
+        '--profile', 'provider-lane-election'
+        ],
+        healthToken   = `election-${randomBytes(24).toString('hex')}`,
+        activeCommands = new Set();
+
+    const envFor = candidateInput => {
+        const env = {
+            HOME                     : process.env.HOME,
+            PATH                     : process.env.PATH,
+            NEO_DEPLOY_PROJECT_NAME  : projectName,
+            NEO_MCP_HEALTHCHECK_TOKEN: healthToken,
+            NEO_REVISION             : plan.revision
+        };
+
+        for (const input of Object.values(candidateInput.deploymentInputs)) {
+            env[input.env] = String(input.value)
+        }
+
+        return env
+    };
+
+    const runDocker = async (candidateInput, args, options = {}) => {
+        let command;
+
+        try {
+            command = execFileAsync('docker', [...baseArgs, ...args], {
+                cwd      : projectRoot,
+                env      : envFor(candidateInput),
+                maxBuffer: 16 * 1024 * 1024,
+                signal   : options.uninterruptible ? undefined : signal,
+                timeout  : options.timeout
+            });
+            if (!options.uninterruptible) activeCommands.add(command);
+            return await command
+        } catch (cause) {
+            const error = new Error(`provider-lane Docker actor failed at '${args[0]}'`);
+            error.code  = 'DOCKER_ACTOR_FAILED';
+            error.cause = cause;
+            throw error
+        } finally {
+            if (command) activeCommands.delete(command)
+        }
+    };
+
+    return {
+        async renderReceipt(candidateInput) {
+            const {stdout: composition} = await runDocker(candidateInput, ['config', '--format', 'json']);
+            return runAnalyzer({composition, projectRoot, signal})
+        },
+        async buildWorkers(receiptEntry) {
+            await runDocker(receiptEntry.candidateInput, ['build', 'provider-lane-worker'], {
+                timeout: plan.trialTimeoutMs
+            })
+        },
+        async activateCandidate(receiptEntry) {
+            await runDocker(receiptEntry.candidateInput, [
+                'up', '--detach', '--wait', '--no-deps', 'chat-model', 'embedding-model'
+            ], {timeout: plan.contextProbeTimeoutMs})
+        },
+        runContextWorker(receiptEntry, {includeOverLimit, timeoutMs}) {
+            return runComposeWorker({
+                args: [
+                    '--worker', includeOverLimit ? 'context' : 'observe',
+                    '--receipt', '/tmp/provider-lane-receipt.json',
+                    '--timeout-ms', String(timeoutMs)
+                ],
+                candidateInput: receiptEntry.candidateInput,
+                runDocker,
+                service       : 'provider-lane-worker',
+                timeout       : (includeOverLimit ? timeoutMs * 4 : timeoutMs) + 30_000,
+                volume        : `${receiptEntry.file}:/tmp/provider-lane-receipt.json:ro`
+            })
+        },
+        setChatResidency(receiptEntry, {resident, timeoutMs}) {
+            return runComposeWorker({
+                args: [
+                    '--worker', 'prepare',
+                    '--receipt', '/tmp/provider-lane-receipt.json',
+                    '--resident', String(resident),
+                    '--timeout-ms', String(timeoutMs)
+                ],
+                candidateInput: receiptEntry.candidateInput,
+                runDocker,
+                service       : 'provider-lane-worker',
+                timeout       : timeoutMs + 30_000,
+                volume        : `${receiptEntry.file}:/tmp/provider-lane-receipt.json:ro`
+            })
+        },
+        runWorkloadWorker(receiptEntry, source, timeout) {
+            return runComposeWorker({
+                args: [
+                    '--worker', 'workload',
+                    '--source', source,
+                    '--receipt', '/tmp/provider-lane-receipt.json'
+                ],
+                candidateInput: receiptEntry.candidateInput,
+                runDocker,
+                service       : 'provider-lane-worker',
+                timeout,
+                volume        : `${receiptEntry.file}:/tmp/provider-lane-receipt.json:ro`
+            })
+        },
+        async teardown() {
+            const candidateInput = plan.candidateDeploymentInputs[0];
+
+            try {
+                await Promise.allSettled([...activeCommands]);
+                await runDocker(candidateInput, ['down', '--volumes', '--remove-orphans', '--rmi', 'local'], {
+                    timeout        : 120_000,
+                    uninterruptible: true
+                })
+            } catch (error) {
+                error.code = 'DISPOSABLE_PROJECT_CLEANUP_FAILED';
+                throw error
+            }
+        }
+    }
+}
+
+/**
+ * @summary Feeds rendered Compose to the canonical analyzer without persisting or logging it.
+ * @private
+ */
+function runAnalyzer({composition, projectRoot, signal}) {
+    return new Promise((resolve, reject) => {
+        const child = spawn(process.execPath, [COMPOSITION_ANALYZER], {
+            cwd  : projectRoot,
+            env  : {HOME: process.env.HOME, PATH: process.env.PATH},
+            signal,
+            stdio: ['pipe', 'pipe', 'pipe']
+        });
+        const stdout = [];
+
+        child.stdout.on('data', chunk => stdout.push(chunk));
+        child.stderr.resume();
+        child.on('error', reject);
+        child.on('close', code => {
+            if (code !== 0) {
+                const error = new Error('provider-lane canonical composition analyzer refused the render');
+                error.code  = 'COMPOSITION_ANALYZER_REFUSED';
+                reject(error);
+                return
+            }
+
+            resolve(Buffer.concat(stdout).toString('utf8'))
+        });
+        child.stdin.end(composition)
+    })
+}
+
+/**
+ * @summary Launches one dedicated exact-revision worker and parses only its final sentinel receipt.
+ * @private
+ */
+async function runComposeWorker({args, candidateInput, runDocker, service, timeout, volume}) {
+    const command = [
+        'run', '--rm', '-T', '--no-deps',
+        ...(volume ? ['--volume', volume] : []),
+        '--entrypoint', 'node',
+        service,
+        `./${RUNNER_ENTRYPOINT}`,
+        ...args
+    ];
+    const {stdout} = await runDocker(candidateInput, command, {timeout});
+    return parseWorkerOutput(stdout)
+}
+
+/**
+ * @summary Creates a read-only runtime observer scoped to the internally minted project.
+ * @private
+ */
+async function createRuntimeObserver({dockerAuthority, projectName}) {
+    const {default: Neo} = await import('../../../src/Neo.mjs');
+    await import('../../../src/core/_export.mjs');
+    const [
+        {default: DeploymentRuntimeAccessService},
+        {dockerSocketRequest},
+        {calculateDockerCpuPercent}
+    ] = await Promise.all([
+        import('../../daemons/orchestrator/services/DeploymentRuntimeAccessService.mjs'),
+        import('../../daemons/orchestrator/services/DeploymentRuntimeAccessService.mjs'),
+        import('../../daemons/orchestrator/services/ContainerHealthDiagnosisService.mjs')
+    ]);
+
+    const service = Neo.create(DeploymentRuntimeAccessService, {
+        runtimeAccessConfig: {
+            allowedServices    : ['chat-model', 'embedding-model'],
+            auditMode          : 'metadata',
+            composeProject     : projectName,
+            enabled            : true,
+            lifecycleOperations: [],
+            mechanism          : 'docker-socket',
+            readOperations     : ['inspect', 'stats'],
+            responseMaxBytes   : 1024 * 1024,
+            socketPath         : dockerAuthority.socketPath,
+            timeoutMs          : 5000
+        }
+    });
+
+    return {
+        calculateDockerCpuPercent,
+        async readContainerRssBytes(containerId) {
+            if (!/^[0-9a-f]{64}$/.test(containerId ?? '')) {
+                throw Object.assign(new Error('provider-lane RSS probe requires the exact inspected container id'), {
+                    code: 'DOCKER_TOP_RSS_INVALID'
+                })
+            }
+
+            const response = await dockerSocketRequest({
+                maxBytes  : DOCKER_TOP_BYTE_CAP,
+                method    : 'GET',
+                path      : `/containers/${containerId}/top?ps_args=${encodeURIComponent('-eo pid,rss')}`,
+                socketPath: dockerAuthority.socketPath,
+                timeoutMs : 5000
+            });
+
+            return parseProviderLaneDockerTopRss(response.body)
+        },
+        service
+    }
+}
+
+/**
+ * @summary Runs one timed workload window and derives only proof-bound trial inputs.
+ * @private
+ */
+async function runMeasuredTrial({actor, chatResidentBefore, plan, receiptEntry, runtime, slot, workloadDigest}) {
+    await actor.setChatResidency(receiptEntry, {
+        resident : chatResidentBefore,
+        timeoutMs: plan.contextProbeTimeoutMs
+    });
+
+    const observation = await actor.runContextWorker(receiptEntry, {
+              includeOverLimit: false,
+              timeoutMs       : plan.contextProbeTimeoutMs
+          }),
+          inspect = await inspectRuntimeLanes({
+              expectedChatResident: chatResidentBefore,
+              observation,
+              receiptEntry,
+              runtime
+          }),
+          samples = {chat: [], embedding: []},
+          workers = [CHAT_SOURCE, ...EMBEDDING_SOURCES].map(async expectedSource => ({
+              expectedSource,
+              receipt: await actor.runWorkloadWorker(receiptEntry, expectedSource, plan.trialTimeoutMs)
+          })),
+          allWorkers = Promise.all(workers);
+
+    let finished = false;
+    allWorkers.then(() => {finished = true}, () => {finished = true});
+
+    do {
+        await sampleRuntimeLanes({inspect, runtime, samples});
+        if (!finished) {
+            await Promise.race([
+                allWorkers,
+                delay(plan.resourceSampling.expectedIntervalMs)
+            ])
+        }
+    } while (!finished);
+
+    const workerReceipts = await allWorkers;
+    const laneEvidence   = normalizeProviderLaneWorkerOperations({receiptEntry, workerReceipts}),
+          allSourceCalls = [...laneEvidence.chat.sourceCalls, ...laneEvidence.embedding.sourceCalls],
+          startedAtMs    = Math.min(...allSourceCalls.map(call => call.demandAtMs)),
+          completedAtMs  = Math.max(...allSourceCalls.map(call => call.completedAtMs)),
+          windowSamples = Object.fromEntries(LANE_NAMES.map(laneName => [laneName,
+              samples[laneName].filter(sample => sample.atMs >= startedAtMs && sample.atMs <= completedAtMs)
+          ]));
+
+    if (!Number.isFinite(startedAtMs) || !Number.isFinite(completedAtMs) || completedAtMs <= startedAtMs ||
+        windowSamples.chat.length < 2 || windowSamples.embedding.length < 2) {
+        throw Object.assign(new Error('provider-lane trial lacks two in-window resource samples'), {
+            code: 'RESOURCE_SAMPLE_WINDOW_INCOMPLETE'
+        })
+    }
+
+    return {
+        candidate               : slot.candidate,
+        completedAtMs,
+        compositionReceiptDigest: receiptEntry.compositionReceiptDigest,
+        executionIndex          : slot.executionIndex,
+        lanes                   : {
+            chat: {
+                operations     : laneEvidence.chat.operations,
+                resourceSamples: windowSamples.chat,
+                runtimeProfile : inspect.chat.runtimeProfile,
+                sourceCalls    : laneEvidence.chat.sourceCalls
+            },
+            embedding: {
+                operations     : laneEvidence.embedding.operations,
+                resourceSamples: windowSamples.embedding,
+                runtimeProfile : inspect.embedding.runtimeProfile,
+                sourceCalls    : laneEvidence.embedding.sourceCalls
+            }
+        },
+        residencyBefore: {
+            lanes: Object.fromEntries(LANE_NAMES.map(laneName => [laneName, {
+                modelDigest: observation.lanes[laneName].resident
+                    ? receiptEntry.receipt.lanes[laneName].model.digest
+                    : null,
+                resident: observation.lanes[laneName].resident
+            }])),
+            observedAtMs: observation.completedAtMs
+        },
+        scheduleId    : slot.id,
+        startedAtMs,
+        workloadDigest
+    }
+}
+
+/**
+ * @summary Inspects both provider containers and binds resource/runtime identity to the receipt.
+ * @private
+ */
+async function inspectRuntimeLanes({expectedChatResident, receiptEntry, runtime, observation}) {
+    return Object.fromEntries(await Promise.all(LANE_NAMES.map(async laneName => {
+        const lane          = receiptEntry.receipt.lanes[laneName],
+              result        = await runtime.service.readObserve({serviceKey: lane.serviceKey, operation: 'inspect'}),
+              actualImage   = result.data?.Config?.Image,
+              expectedImage = `${lane.image.reference}@${lane.image.digest}`,
+              cpuCores      = Number(result.data?.HostConfig?.NanoCpus) / 1e9,
+              memoryBytes   = Number(result.data?.HostConfig?.Memory),
+              parallelism   = observation.lanes[laneName].parallelism;
+
+        const expectedResident = laneName === 'chat' ? expectedChatResident : true;
+
+        if (result.proof?.target?.containerId !== result.data?.Id ||
+            result.proof?.serviceKey !== lane.serviceKey || actualImage !== expectedImage ||
+            cpuCores !== lane.cpuCores || memoryBytes !== lane.memoryBytes ||
+            parallelism !== lane.parallelSlots || observation.lanes[laneName].resident !== expectedResident) {
+            throw Object.assign(new Error(`provider-lane ${laneName} runtime does not match its composition receipt`), {
+                code: 'RUNTIME_PROFILE_MISMATCH'
+            })
+        }
+
+        return [laneName, {
+            containerId   : result.data.Id,
+            runtimeProfile: {
+                cpuCores,
+                imageDigest: lane.image.digest,
+                memoryBytes,
+                modelDigest: lane.model.digest,
+                parallelism,
+                serviceKey : lane.serviceKey
+            }
+        }]
+    })))
+}
+
+/**
+ * @summary Samples CPU and aggregate Docker Top process RSS for both exact container incarnations.
+ * @private
+ */
+async function sampleRuntimeLanes({inspect, runtime, samples}) {
+    await Promise.all(LANE_NAMES.map(async laneName => {
+        const serviceKey = inspect[laneName].runtimeProfile.serviceKey,
+              result     = await runtime.service.readObserve({serviceKey, operation: 'stats'}),
+              cpuPercent = calculateProviderLaneDockerCpuPercent(result.data, runtime.calculateDockerCpuPercent),
+              rssBytes   = await runtime.readContainerRssBytes(inspect[laneName].containerId),
+              atMs       = result.proof?.observedAt;
+
+        if (result.proof?.target?.containerId !== inspect[laneName].containerId ||
+            !Number.isFinite(atMs) || !Number.isFinite(cpuPercent) || cpuPercent < 0 ||
+            !Number.isFinite(rssBytes) || rssBytes < 0 ||
+            samples[laneName].some(sample => sample.atMs >= atMs)) {
+            throw Object.assign(new Error(`provider-lane ${laneName} resource sample is incomplete or changed incarnation`), {
+                code: 'RESOURCE_SAMPLE_INVALID'
+            })
+        }
+
+        samples[laneName].push({atMs, cpuPercent, rssBytes})
+    }))
+}
+
+/**
+ * @summary Normalizes candidate-level context evidence into the pure core's bounded input.
+ * @private
+ */
+function normalizeCandidateContextEvidence({receiptEntry, worker}) {
+    if (worker.schemaVersion !== WORKER_SCHEMA ||
+        !Number.isFinite(worker.startedAtMs) || !Number.isFinite(worker.completedAtMs) ||
+        worker.completedAtMs <= worker.startedAtMs) {
+        throw Object.assign(new Error('provider-lane context worker returned an invalid evidence window'), {
+            code: 'CONTEXT_WORKER_INVALID'
+        })
+    }
+
+    return {
+        candidate               : receiptEntry.candidate,
+        completedAtMs           : worker.completedAtMs,
+        compositionReceiptDigest: receiptEntry.compositionReceiptDigest,
+        lanes                   : Object.fromEntries(LANE_NAMES.map(laneName => {
+            const lane = worker.lanes?.[laneName];
+
+            if (!lane?.overLimitProbe || lane.resident !== true ||
+                lane.parallelism !== receiptEntry.receipt.lanes[laneName].parallelSlots) {
+                throw Object.assign(new Error(`provider-lane ${laneName} context evidence is incomplete`), {
+                    code: 'CONTEXT_EVIDENCE_INVALID'
+                })
+            }
+
+            return [laneName, {
+                observedContextTokensPerSlot: lane.observedContextTokensPerSlot,
+                overLimitProbe              : structuredClone(lane.overLimitProbe)
+            }]
+        })),
+        startedAtMs: worker.startedAtMs
+    }
+}
+
+/**
+ * @summary Maps worker lifecycle rows to fixed source identities selected by the controller.
+ * @param {Object} options
+ * @param {Object} options.receiptEntry Validated candidate receipt wrapper.
+ * @param {Object[]} options.workerReceipts Controller-bound worker lifecycle receipts.
+ * @returns {{chat: Object[], embedding: Object[]}}
+ */
+export function normalizeProviderLaneWorkerOperations({receiptEntry, workerReceipts}) {
+    const output = {
+              chat     : {operations: [], sourceCalls: []},
+              embedding: {operations: [], sourceCalls: []}
+          },
+          expectedSources = [CHAT_SOURCE, ...EMBEDDING_SOURCES],
+          receivedSources = Array.isArray(workerReceipts)
+              ? workerReceipts.map(envelope => envelope?.expectedSource)
+              : [];
+
+    if (receivedSources.length !== expectedSources.length ||
+        new Set(receivedSources).size !== expectedSources.length ||
+        expectedSources.some(source => !receivedSources.includes(source))) {
+        throw Object.assign(new Error('provider-lane workload requires each closed source exactly once'), {
+            code: 'WORKLOAD_WORKER_INVALID'
+        })
+    }
+
+    for (const envelope of workerReceipts) {
+        const expectedSource = envelope?.expectedSource,
+              worker         = envelope?.receipt,
+              expected       = SOURCE_CONTRACT[expectedSource],
+              payloads       = WORKLOAD_PAYLOADS[expectedSource];
+
+        requireExactKeys(worker, ['callKind', 'operations', 'results', 'schemaVersion', 'source'],
+            `provider-lane ${expectedSource} worker`);
+
+        if (worker?.callKind !== expected?.callKind || worker?.source !== expectedSource ||
+            worker?.schemaVersion !== WORKER_SCHEMA || !expected ||
+            !Array.isArray(worker.operations) || !Array.isArray(worker.results) ||
+            worker.operations.length < payloads.length ||
+            worker.operations.length > countExpectedProviderOperations(expectedSource, payloads) ||
+            worker.results.length !== payloads.length) {
+            throw Object.assign(new Error('provider-lane workload worker returned an invalid receipt'), {
+                code: 'WORKLOAD_WORKER_INVALID'
+            })
+        }
+
+        const laneName         = expectedSource === CHAT_SOURCE ? 'chat' : 'embedding',
+              lane             = receiptEntry.receipt.lanes[laneName],
+              operationsByCall = new Map(payloads.map((payload, index) => [`${expectedSource}-${index}`, []])),
+              resultsByCall    = new Map();
+
+        worker.results.forEach((result, index) => {
+            const callId          = `${expectedSource}-${index}`,
+                  expectedOutputs = expectedSource === CHAT_SOURCE
+                      ? 1
+                      : Array.isArray(payloads[index]) ? payloads[index].length : 1;
+
+            requireExactKeys(result, ['callId', 'completedAtMs', 'demandAtMs', 'outcome', 'outputCount'],
+                `provider-lane ${expectedSource} result ${index}`);
+
+            if (result.callId !== callId || !['completed', 'error', 'unexpected-refusal'].includes(result.outcome) ||
+                !Number.isInteger(result.outputCount) || result.outputCount < 0 ||
+                !Number.isFinite(result.demandAtMs) || !Number.isFinite(result.completedAtMs) ||
+                result.completedAtMs <= result.demandAtMs ||
+                (result.outcome === 'completed' ? result.outputCount !== expectedOutputs : result.outputCount !== 0)) {
+                throw Object.assign(new Error(`provider-lane ${expectedSource} result cannot be bound to its source call`), {
+                    code: 'WORKLOAD_LIFECYCLE_INVALID'
+                })
+            }
+
+            resultsByCall.set(callId, result)
+        });
+
+        for (const row of worker.operations) {
+            requireExactKeys(row, [
+                'callId',
+                'completedAtMs',
+                'enqueuedAtMs',
+                'failureStage',
+                'id',
+                'model',
+                'operationStage',
+                'outcome',
+                'priority',
+                'provider',
+                'providerStartedAtMs',
+                'queueDisposition',
+                'role',
+                'service'
+            ], `provider-lane ${expectedSource} lifecycle`);
+
+            const queueDisposition = row.queueDisposition === 'neo-queued'
+                ? 'queued'
+                : row.queueDisposition === 'not-applicable'
+                    ? 'not-applicable'
+                    : null;
+
+            if (!operationsByCall.has(row.callId) || row.priority !== expected.priority ||
+                row.service !== expected.service || row.operationStage !== expected.stage ||
+                row.role !== expected.role || row.provider !== lane.provider || row.model !== lane.model.id ||
+                !['completed', 'error'].includes(row.outcome) || !queueDisposition ||
+                !Number.isFinite(row.providerStartedAtMs) || !Number.isFinite(row.completedAtMs)) {
+                throw Object.assign(new Error(`provider-lane ${expectedSource} lifecycle cannot be bound to its exact lane`), {
+                    code: 'WORKLOAD_LIFECYCLE_INVALID'
+                })
+            }
+
+            operationsByCall.get(row.callId).push({queueDisposition, row})
+        }
+
+        payloads.forEach((payload, callIndex) => {
+            const callId           = `${expectedSource}-${callIndex}`,
+                  group            = operationsByCall.get(callId),
+                  result           = resultsByCall.get(callId),
+                  normalizedCallId = `${expectedSource}:${callId}:${randomBytes(4).toString('hex')}`,
+                  groupLength      = expected.callKind === 'batch-array'
+                      ? Math.ceil(payload.length / EMBEDDING_CHUNK_SIZE)
+                      : 1;
+
+            if (group.length === 0 || group.length > groupLength ||
+                (result.outcome === 'completed' && (group.length !== groupLength ||
+                    group.some(item => item.row.outcome !== 'completed'))) ||
+                group.some(item => item.row.completedAtMs > result.completedAtMs ||
+                    item.row.providerStartedAtMs < result.demandAtMs ||
+                    (item.queueDisposition === 'queued' && item.row.enqueuedAtMs < result.demandAtMs)) ||
+                (result.outcome === 'unexpected-refusal' && group.every(item => item.row.outcome !== 'error'))) {
+                throw Object.assign(new Error(`provider-lane ${expectedSource} source-call evidence is incomplete`), {
+                    code: 'WORKLOAD_LIFECYCLE_INVALID'
+                })
+            }
+
+            output[laneName].sourceCalls.push({
+                completedAtMs: result.completedAtMs,
+                demandAtMs   : result.demandAtMs,
+                id           : normalizedCallId,
+                outcome      : result.outcome,
+                source       : expectedSource
+            });
+
+            group.forEach(({queueDisposition, row}) => output[laneName].operations.push({
+                callId             : normalizedCallId,
+                completedAtMs      : row.completedAtMs,
+                enqueuedAtMs       : queueDisposition === 'queued' ? row.enqueuedAtMs : null,
+                id                 : `${expectedSource}:${row.id}:${randomBytes(4).toString('hex')}`,
+                outcome            : row.outcome,
+                providerStartedAtMs: row.providerStartedAtMs,
+                queueDisposition,
+                source             : expectedSource
+            }))
+        })
+    }
+
+    return output
+}
+
+/**
+ * @summary Parses only the final base64 worker sentinel, ignoring bounded service log noise.
+ * @private
+ */
+function parseWorkerOutput(stdout) {
+    const line = String(stdout).split(/\r?\n/).reverse().find(item => item.startsWith(WORKER_SENTINEL));
+
+    if (!line) throw Object.assign(new Error('provider-lane worker emitted no receipt sentinel'), {
+        code: 'WORKER_RECEIPT_MISSING'
+    });
+
+    const encoded = line.slice(WORKER_SENTINEL.length);
+
+    if (encoded.length > 2 * 1024 * 1024) {
+        throw Object.assign(new Error('provider-lane worker receipt exceeded the bounded envelope'), {
+            code: 'WORKER_RECEIPT_TOO_LARGE'
+        })
+    }
+
+    return JSON.parse(Buffer.from(encoded, 'base64url').toString('utf8'))
+}
+
+/**
+ * @summary Runs the CLI controller or internal dedicated-worker mode.
+ * @returns {Promise<void>}
+ * @private
+ */
+async function main() {
+    const program = new Command()
+        .option('--worker <mode>', 'internal worker mode (workload | context | observe | prepare)')
+        .option('--source <source>', 'closed workload source')
+        .option('--receipt <file>', 'validated candidate receipt for internal workers')
+        .option('--resident <boolean>', 'explicit chat residency target for prepare mode')
+        .option('--timeout-ms <number>', 'explicit context worker timeout')
+        .option('--plan <file>', 'versioned election plan')
+        .option('--out <file>', 'persistent bounded report path')
+        .parse(process.argv);
+    const options = program.opts();
+
+    if (options.worker) {
+        await runWorkerMode(options);
+        return
+    }
+
+    if (!options.plan || !options.out) {
+        throw Object.assign(new Error('provider-lane controller requires --plan and --out'), {
+            code: 'CLI_INPUT_REQUIRED'
+        })
+    }
+
+    const projectRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../..'),
+          plan        = validateProviderLaneRunPlan(JSON.parse(await readFile(path.resolve(options.plan), 'utf8'))),
+          outFile     = path.resolve(options.out),
+          artifactDir = `${outFile}.artifacts`,
+          projectName = createDisposableProjectName(plan.revision);
+
+    let report,
+        measuredHead = null;
+
+    try {
+        measuredHead = await getExactRepositoryHead(projectRoot);
+
+        const dockerAuthority = await resolveProviderLaneDockerAuthority();
+
+        report = await runProviderLaneElectionController({
+            artifactDir,
+            dockerAuthority,
+            head: measuredHead,
+            plan,
+            projectName,
+            projectRoot
+        })
+    } catch (error) {
+        report = createIncompleteProviderLaneReport({
+            code: error?.code || 'RUN_ABORTED',
+            measuredHead,
+            projectName
+        });
+        await atomicWrite(outFile, `${JSON.stringify(report, null, 2)}\n`);
+        throw error
+    }
+
+    await atomicWrite(outFile, `${JSON.stringify(report, null, 2)}\n`);
+    process.stdout.write(`[provider-lane-election] ${report.status} report=${outFile}\n`)
+}
+
+/**
+ * @summary Executes one internal worker mode and emits one base64 sentinel receipt.
+ * @private
+ */
+async function runWorkerMode(options) {
+    const timeoutMs = Number(options.timeoutMs);
+    let   receipt;
+
+    if (options.worker === 'workload') {
+        const candidateReceipt = JSON.parse(await readFile(path.resolve(options.receipt), 'utf8'));
+
+        receipt = await runProviderLaneWorkloadWorker({receipt: candidateReceipt, source: options.source})
+    } else if (options.worker === 'context' || options.worker === 'observe') {
+        const candidateReceipt = JSON.parse(await readFile(path.resolve(options.receipt), 'utf8'));
+
+        receipt = await runProviderLaneContextWorker({
+            includeOverLimit: options.worker === 'context',
+            receipt         : candidateReceipt,
+            timeoutMs
+        })
+    } else if (options.worker === 'prepare') {
+        const candidateReceipt = JSON.parse(await readFile(path.resolve(options.receipt), 'utf8')),
+              resident         = options.resident === 'true'
+                  ? true
+                  : options.resident === 'false' ? false : null;
+
+        receipt = await runProviderLanePreparationWorker({receipt: candidateReceipt, resident, timeoutMs})
+    } else {
+        throw new Error(`provider-lane worker mode '${options.worker}' is unknown`)
+    }
+
+    const encoded = Buffer.from(JSON.stringify(receipt)).toString('base64url');
+    process.stdout.write(`${WORKER_SENTINEL}${encoded}\n`)
+}
+
+/**
+ * @summary Creates a collision-resistant project name owned only by this process.
+ * @private
+ */
+function createDisposableProjectName(revision) {
+    return `neo-provider-election-${revision.slice(0, 10)}-${randomBytes(6).toString('hex')}`
+}
+
+/**
+ * @summary Resolves the exact repository head through argv-safe git execution.
+ * @private
+ */
+async function getExactRepositoryHead(projectRoot) {
+    const {stdout} = await execFileAsync('git', ['rev-parse', 'HEAD'], {cwd: projectRoot});
+    const head     = stdout.trim();
+
+    if (!REVISION_PATTERN.test(head)) throw new Error('provider-lane runner could not resolve a full repository head');
+    return head
+}
+
+/**
+ * @summary Refuses tracked worktree drift while ignoring unrelated untracked operator files.
+ * @private
+ */
+async function assertTrackedWorktreeClean(projectRoot) {
+    const {stdout} = await execFileAsync('git', ['status', '--porcelain', '--untracked-files=no'], {cwd: projectRoot});
+
+    if (stdout.trim()) {
+        throw Object.assign(new Error('provider-lane exact-head mode requires no tracked worktree changes'), {
+            code: 'TRACKED_WORKTREE_DIRTY'
+        })
+    }
+}
+
+/**
+ * @summary Atomically writes one run-owned artifact without shell redirection.
+ * @private
+ */
+async function atomicWrite(file, content) {
+    await writeFileAtomic(file, content, {mode: 0o600})
+}
+
+/**
+ * @summary Requires one exact enumerable key set.
+ * @private
+ */
+function requireExactKeys(value, keys, label) {
+    const actual = value && typeof value === 'object' && !Array.isArray(value)
+        ? Object.keys(value).sort()
+        : [];
+    const expected = [...keys].sort();
+
+    if (stableSerialize(actual) !== stableSerialize(expected)) {
+        throw new Error(`${label} requires exact fields ${expected.join(', ')}`)
+    }
+}
+
+/**
+ * @summary Stable recursively-key-sorted serialization for receipt identity.
+ * @private
+ */
+function stableSerialize(value) {
+    const normalize = item => {
+        if (Array.isArray(item)) return item.map(normalize);
+        if (item && typeof item === 'object') {
+            return Object.fromEntries(Object.keys(item).sort().map(key => [key, normalize(item[key])]))
+        }
+        return item
+    };
+
+    return JSON.stringify(normalize(value))
+}
+
+/**
+ * @summary Returns parsed JSON or null for classification-only provider bodies.
+ * @private
+ */
+function safeJson(value) {
+    try {
+        return JSON.parse(value)
+    } catch {
+        return null
+    }
+}
+
+/**
+ * @summary Finds only the closed provider error discriminator through bounded object depth.
+ * @private
+ */
+function findProviderErrorType(value, depth = 0) {
+    if (!value || typeof value !== 'object' || depth > 4) return null;
+
+    for (const key of ['error_type', 'errorType', 'type']) {
+        if (typeof value[key] === 'string') return value[key]
+    }
+    for (const key of ['error', 'detail', 'cause']) {
+        const found = findProviderErrorType(value[key], depth + 1);
+        if (found) return found
+    }
+
+    return null
+}
+
+/**
+ * @summary Finds only a bounded provider error string through closed wrapper fields.
+ * @private
+ */
+function findProviderErrorMessage(value, depth = 0) {
+    if (!value || typeof value !== 'object' || depth > 4) return null;
+    if (typeof value.error === 'string') return value.error;
+    if (typeof value.message === 'string') return value.message;
+
+    for (const key of ['error', 'detail', 'cause']) {
+        const found = findProviderErrorMessage(value[key], depth + 1);
+        if (found) return found
+    }
+
+    return null
+}
+
+/**
+ * @summary Projects a positive provider output indicator without retaining generated content.
+ * @private
+ */
+function inferObservedOutput(value) {
+    const count = Number(value?.eval_count ?? value?.usage?.completion_tokens);
+
+    if (Number.isInteger(count) && count >= 0) return count;
+    if (Array.isArray(value?.data) && value.data.length > 0) return 1;
+    if (typeof value?.message?.content === 'string' && value.message.content.length > 0) return 1;
+    return 0
+}
+
+/**
+ * @summary Digests exact raw bytes.
+ * @private
+ */
+function digestRaw(value) {
+    return `sha256:${createHash('sha256').update(value).digest('hex')}`
+}
+
+/**
+ * @summary Async delay used only between bounded samples.
+ * @private
+ */
+function delay(ms) {
+    return new Promise(resolve => setTimeout(resolve, ms))
+}
+
+const isDirectRun = process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href;
+
+if (isDirectRun) {
+    main().catch(error => {
+        process.stderr.write(`[provider-lane-election] ${error?.code || 'RUN_ABORTED'}\n`);
+        process.exitCode = 1
+    })
+}

--- a/ai/scripts/benchmark/provider-lane-election.mjs
+++ b/ai/scripts/benchmark/provider-lane-election.mjs
@@ -18,6 +18,8 @@ import {
 } from './helpers/providerLaneElectionCore.mjs';
 import {writeFileAtomic} from '../../services/shared/atomicFileWrite.mjs';
 
+export const PROVIDER_LANE_ELECTION_REPORT_SCHEMA_VERSION = 'provider-lane-election-report.v1';
+
 const
     execFileAsync = promisify(execFile),
 
@@ -26,7 +28,6 @@ const
     EMBEDDING_SOURCES = Object.freeze(['knowledge-base', 'memory-core', 'orchestrator']),
     LANE_NAMES        = Object.freeze(['chat', 'embedding']),
     PLAN_SCHEMA       = 'provider-lane-election-plan.v1',
-    REPORT_SCHEMA     = 'provider-lane-election-report.v1',
     WORKER_SCHEMA     = 'provider-lane-election-worker.v1',
     WORKER_SENTINEL   = 'NEO_PROVIDER_LANE_WORKER:',
     DIGEST_PATTERN    = /^sha256:[a-f0-9]{64}$/,
@@ -55,15 +56,19 @@ const
         workloadKind : 'ollamaChat'
     }),
     EMBEDDING_ADAPTER = Object.freeze({
-        id              : 'llama-cpp-openai-embeddings-b10380',
-        imageDigest     : 'sha256:9b518883e8faab479650ec802e02c9e37c6bb21d36168509efd8fb3c87fc1648',
-        imageReference  : 'ghcr.io/ggml-org/llama.cpp:server-b10380',
-        lane            : 'embedding',
-        modelDigest     : 'sha256:3fcd3febec8b3fd64435204db75bf0dd73b91e8d0661e0331acfe7e7c3120b85',
-        provider        : 'openAiCompatible',
-        refusalErrorType: 'exceed_context_size_error',
-        refusalStatus   : 400,
-        workloadKind    : 'openAiEmbeddings'
+        id                               : 'llama-cpp-openai-embeddings-b10380',
+        imageDigest                      : 'sha256:9b518883e8faab479650ec802e02c9e37c6bb21d36168509efd8fb3c87fc1648',
+        imageReference                   : 'ghcr.io/ggml-org/llama.cpp:server-b10380',
+        lane                             : 'embedding',
+        modelDigest                      : 'sha256:3fcd3febec8b3fd64435204db75bf0dd73b91e8d0661e0331acfe7e7c3120b85',
+        physicalBatchRefusalErrorType    : 'server_error',
+        physicalBatchRefusalMessagePrefix: 'input (',
+        physicalBatchRefusalMessageSuffix: ') is too large to process. increase the physical batch size (current batch size: ',
+        physicalBatchRefusalStatus       : 500,
+        provider                         : 'openAiCompatible',
+        refusalErrorType                 : 'exceed_context_size_error',
+        refusalStatus                    : 400,
+        workloadKind                     : 'openAiEmbeddings'
     }),
     CLOSED_ADAPTERS = Object.freeze({
         chat     : CHAT_ADAPTER,
@@ -267,7 +272,7 @@ export function resolveProviderLaneAdapters(receipt) {
 /**
  * @summary Projects one validated composition receipt into the pure core's immutable profile.
  * @param {Object} options
- * @param {String} options.compositionReceiptDigest Digest of the exact archived receipt bytes.
+ * @param {String} options.compositionReceiptDigest Canonical digest of the validated receipt value.
  * @param {Object} options.receipt Validated composition receipt.
  * @returns {Object}
  */
@@ -335,12 +340,20 @@ export function classifyProviderLaneProbeResponse({adapter, body, status}) {
                   ? errorType === adapter.refusalErrorType
                   : adapter.refusalErrorMessages?.includes(errorMessage)
           ),
+          physicalBatchRefused = status === adapter.physicalBatchRefusalStatus &&
+              errorType === adapter.physicalBatchRefusalErrorType &&
+              typeof errorMessage === 'string' &&
+              errorMessage.startsWith(adapter.physicalBatchRefusalMessagePrefix ?? '\0') &&
+              errorMessage.includes(adapter.physicalBatchRefusalMessageSuffix ?? '\0') &&
+              /\d+\)$/.test(errorMessage),
           completed = status >= 200 && status < 300;
 
     return {
         observedOutputTokens: completed ? inferObservedOutput(parsed) : 0,
         responseBodyDigest  : digestRaw(body),
-        responseClass       : refused ? 'context-limit-refusal' : completed ? 'completed' : 'provider-error',
+        responseClass       : physicalBatchRefused
+            ? 'physical-batch-refusal'
+            : refused ? 'context-limit-refusal' : completed ? 'completed' : 'provider-error',
         transportStatus     : status
     }
 }
@@ -569,6 +582,7 @@ export function projectProviderLaneOutcome({election, receipts}) {
 
     if (sortedReceipts.some((entry, index) => entry?.candidate !== CANDIDATES[index] ||
         !DIGEST_PATTERN.test(entry?.compositionReceiptDigest ?? '') ||
+        entry.compositionReceiptDigest !== digestProviderLaneValue(entry.receipt) ||
         entry?.receipt?.lanes?.embedding?.parallelSlots !== entry.candidate)) {
         throw new Error('provider-lane outcome projection requires exact validated candidate receipts')
     }
@@ -587,51 +601,10 @@ export function projectProviderLaneOutcome({election, receipts}) {
     }
 
     return {
-        deploymentInputs   : receipt ? structuredClone(receipt.receipt.deploymentInputs) : null,
-        selectedComposition: receipt ? projectSelectedProviderLaneComposition(receipt) : null,
-        status             : winner === null ? 'NO_ELECTION' : 'ELECTED'
-    }
-}
-
-/**
- * @summary Projects the self-describing immutable composition selected by the measured winner.
- *
- * The profile digest proves which archived receipt was measured, but downstream generation identity
- * cannot recover model coordinates, endpoints, role routing, or the fixed resource envelope from a
- * digest alone. This projection is therefore copied from the same already-validated receipt as the
- * deployment inputs. It contains no operator secrets and never re-derives configuration.
- *
- * @param {Object} receiptEntry Validated archived candidate receipt wrapper.
- * @returns {Object} Allowlisted immutable composition artifact.
- */
-function projectSelectedProviderLaneComposition(receiptEntry) {
-    const receipt = receiptEntry.receipt;
-
-    resolveProviderLaneAdapters(receipt);
-
-    return {
-        candidate               : receiptEntry.candidate,
-        compositionReceiptDigest: receiptEntry.compositionReceiptDigest,
-        envelope                : structuredClone(receipt.envelope),
-        lanes                   : Object.fromEntries(LANE_NAMES.map(laneName => {
-            const lane = receipt.lanes[laneName];
-
-            return [laneName, {
-                baseUrl                     : lane.baseUrl,
-                contextTokensPerSlotRequired: lane.contextTokensPerSlotRequired,
-                cpuCores                    : lane.cpuCores,
-                endpoints                   : structuredClone(lane.endpoints),
-                image                       : structuredClone(lane.image),
-                memoryBytes                 : lane.memoryBytes,
-                model                       : structuredClone(lane.model),
-                parallelSlots               : lane.parallelSlots,
-                provider                    : lane.provider,
-                serviceKey                  : lane.serviceKey,
-                totalContextTokens          : lane.totalContextTokens
-            }]
-        })),
-        roles        : structuredClone(receipt.roles),
-        schemaVersion: receipt.schemaVersion
+        deploymentInputs     : receipt ? structuredClone(receipt.receipt.deploymentInputs) : null,
+        selectedReceipt      : receipt ? structuredClone(receipt.receipt) : null,
+        selectedReceiptDigest: receipt?.compositionReceiptDigest ?? null,
+        status               : winner === null ? 'NO_ELECTION' : 'ELECTED'
     }
 }
 
@@ -639,28 +612,45 @@ function projectSelectedProviderLaneComposition(receiptEntry) {
  * @summary Finalizes live-controller evidence without exposing an authority-minting public seam.
  * @private
  */
-function finalizeProviderLaneElection({artifacts, election, head, projectName, receipts}) {
+function finalizeProviderLaneElection({artifacts, election, evidence, head, projectName, receipts}) {
     if (!REVISION_PATTERN.test(head ?? '') || typeof projectName !== 'string' || !projectName) {
         throw new Error('provider-lane finalizer requires an exact live controller identity')
     }
 
-    const outcome = projectProviderLaneOutcome({election, receipts});
+    const outcome           = projectProviderLaneOutcome({election, receipts}),
+          candidateReceipts = receipts.map(({candidate, compositionReceiptDigest, receipt}) => ({
+              candidate,
+              compositionReceiptDigest,
+              receipt: structuredClone(receipt)
+          })),
+          evidenceDigest = digestProviderLaneValue({
+              candidateReceiptDigests: candidateReceipts.map(item => item.compositionReceiptDigest),
+              evidence,
+              projectName,
+              repositoryHead         : head
+          });
 
-    return {
-        artifacts: structuredClone(artifacts),
+    const report = {
+        artifacts: {...structuredClone(artifacts), evidenceDigest},
         authority: {
             authoritative: true,
             evidenceClass: 'canonical-disposable-plane',
             reason       : 'complete validated matrix on a run-owned disposable Compose project'
         },
-        deploymentInputs   : outcome.deploymentInputs,
+        candidateReceipts,
+        deploymentInputs     : outcome.deploymentInputs,
         election,
+        evidence             : structuredClone(evidence),
         projectName,
-        repositoryHead     : head,
-        schemaVersion      : REPORT_SCHEMA,
-        selectedComposition: outcome.selectedComposition,
-        status             : outcome.status
-    }
+        repositoryHead       : head,
+        schemaVersion        : PROVIDER_LANE_ELECTION_REPORT_SCHEMA_VERSION,
+        selectedReceipt      : outcome.selectedReceipt,
+        selectedReceiptDigest: outcome.selectedReceiptDigest,
+        status               : outcome.status
+    };
+
+    validateProviderLaneElectionReport(report, {requireElected: false});
+    return report
 }
 
 /**
@@ -670,19 +660,309 @@ function finalizeProviderLaneElection({artifacts, election, head, projectName, r
  */
 export function createIncompleteProviderLaneReport({code = 'RUN_ABORTED', measuredHead = null, projectName = null} = {}) {
     return {
-        artifacts: {candidateReceipts: []},
+        artifacts: {
+            candidateReceipts: [],
+            evidenceDigest   : null,
+            planDigest       : null,
+            workloadDigest   : null
+        },
         authority: {
             authoritative: false,
             evidenceClass: 'incomplete',
             reason       : String(code).slice(0, 120)
         },
-        deploymentInputs   : null,
-        election           : null,
+        candidateReceipts    : [],
+        deploymentInputs     : null,
+        election             : null,
+        evidence             : null,
         projectName,
-        repositoryHead     : REVISION_PATTERN.test(measuredHead ?? '') ? measuredHead : null,
-        schemaVersion      : REPORT_SCHEMA,
-        selectedComposition: null,
-        status             : 'INCOMPLETE'
+        repositoryHead       : REVISION_PATTERN.test(measuredHead ?? '') ? measuredHead : null,
+        schemaVersion        : PROVIDER_LANE_ELECTION_REPORT_SCHEMA_VERSION,
+        selectedReceipt      : null,
+        selectedReceiptDigest: null,
+        status               : 'INCOMPLETE'
+    }
+}
+
+/**
+ * @summary Recomputes and validates the complete election handoff consumed by downstream runtime proof.
+ *
+ * The report's `authority` and `status` fields are never trusted as inputs. This validator first
+ * validates every full canonical composition receipt, reconstructs the pure plan, reruns the complete
+ * matrix from raw bounded evidence, and only then checks the elected receipt and deployment inputs.
+ * `INCOMPLETE` is never consumable; `NO_ELECTION` is accepted only for archival callers which
+ * explicitly set `requireElected:false`.
+ *
+ * @param {Object} report Persisted provider-lane election report.
+ * @param {Object} [options]
+ * @param {Boolean} [options.requireElected=true] Require an elected downstream input.
+ * @returns {Object} Defensive clone of the validated report.
+ */
+export function validateProviderLaneElectionReport(report, {requireElected = true} = {}) {
+    requireExactKeys(report, [
+        'artifacts',
+        'authority',
+        'candidateReceipts',
+        'deploymentInputs',
+        'election',
+        'evidence',
+        'projectName',
+        'repositoryHead',
+        'schemaVersion',
+        'selectedReceipt',
+        'selectedReceiptDigest',
+        'status'
+    ], 'provider-lane election report');
+
+    if (report.schemaVersion !== PROVIDER_LANE_ELECTION_REPORT_SCHEMA_VERSION ||
+        !['ELECTED', 'NO_ELECTION'].includes(report.status) ||
+        !REVISION_PATTERN.test(report.repositoryHead ?? '') ||
+        !/^neo-provider-election-[0-9a-f]{10}-[0-9a-f]{12}$/.test(report.projectName ?? '') ||
+        typeof requireElected !== 'boolean') {
+        throw Object.assign(new Error('provider-lane election report has no complete canonical controller identity'), {
+            code: 'ELECTION_REPORT_INVALID'
+        })
+    }
+
+    requireExactKeys(report.authority, ['authoritative', 'evidenceClass', 'reason'],
+        'provider-lane election authority');
+    if (report.authority.authoritative !== true ||
+        report.authority.evidenceClass !== 'canonical-disposable-plane' ||
+        report.authority.reason !== 'complete validated matrix on a run-owned disposable Compose project') {
+        throw Object.assign(new Error('provider-lane election report carries a forged authority assertion'), {
+            code: 'ELECTION_REPORT_INVALID'
+        })
+    }
+
+    const receipts = validateProviderLaneElectionReceipts(report.candidateReceipts, report.projectName);
+
+    requireExactKeys(report.evidence, ['contextEvidence', 'trials'], 'provider-lane election evidence');
+    assertProviderLaneElectionEvidenceShape(report.evidence);
+
+    const plan       = reconstructProviderLaneElectionPlan({election: report.election, receipts}),
+          recomputed = evaluateProviderLaneElection({
+              contextEvidence: report.evidence.contextEvidence,
+              plan,
+              trials         : report.evidence.trials
+          });
+
+    if (stableSerialize(recomputed) !== stableSerialize(report.election)) {
+        throw Object.assign(new Error('provider-lane election report does not reproduce from its bounded evidence'), {
+            code: 'ELECTION_REPORT_EVIDENCE_DRIFT'
+        })
+    }
+
+    const outcome = projectProviderLaneOutcome({election: recomputed, receipts});
+
+    if (outcome.status !== report.status ||
+        stableSerialize(outcome.deploymentInputs) !== stableSerialize(report.deploymentInputs) ||
+        stableSerialize(outcome.selectedReceipt) !== stableSerialize(report.selectedReceipt) ||
+        outcome.selectedReceiptDigest !== report.selectedReceiptDigest) {
+        throw Object.assign(new Error('provider-lane election report selected a receipt other than the smallest PASS'), {
+            code: 'ELECTION_REPORT_SELECTION_DRIFT'
+        })
+    }
+
+    validateProviderLaneElectionArtifacts({
+        artifacts     : report.artifacts,
+        evidence      : report.evidence,
+        plan,
+        projectName   : report.projectName,
+        receipts,
+        repositoryHead: report.repositoryHead
+    });
+
+    if (requireElected && report.status !== 'ELECTED') {
+        throw Object.assign(new Error('provider-lane downstream proof requires an elected report'), {
+            code: 'ELECTION_REQUIRED'
+        })
+    }
+
+    return structuredClone(report)
+}
+
+/**
+ * @summary Validates the three full canonical composition receipts embedded in a report.
+ * @private
+ */
+function validateProviderLaneElectionReceipts(candidateReceipts, projectName) {
+    if (!Array.isArray(candidateReceipts) || candidateReceipts.length !== CANDIDATES.length) {
+        throw new Error('provider-lane election report requires full receipts for candidates 1, 2, and 4')
+    }
+
+    const receipts = [...candidateReceipts].sort((left, right) => left?.candidate - right?.candidate);
+
+    receipts.forEach((entry, index) => {
+        requireExactKeys(entry, ['candidate', 'compositionReceiptDigest', 'receipt'],
+            `provider-lane candidate receipt ${CANDIDATES[index]}`);
+        if (entry.candidate !== CANDIDATES[index] ||
+            entry.compositionReceiptDigest !== digestProviderLaneValue(entry.receipt) ||
+            entry.receipt?.composeProject !== projectName ||
+            entry.receipt?.lanes?.embedding?.parallelSlots !== entry.candidate) {
+            throw new Error('provider-lane election report contains a drifted candidate receipt')
+        }
+        resolveProviderLaneAdapters(entry.receipt)
+    });
+
+    return receipts
+}
+
+/**
+ * @summary Reconstructs the exact pure plan only from validated receipts and projected policy coordinates.
+ * @private
+ */
+function reconstructProviderLaneElectionPlan({election, receipts}) {
+    requireExactKeys(election, ['candidates', 'jointSlo', 'planCoordinates', 'winnerCandidate'],
+        'provider-lane election result');
+    requireExactKeys(election.jointSlo, ['lanes'], 'provider-lane joint SLO');
+    requireExactKeys(election.planCoordinates, [
+        'blocks',
+        'candidateRunCount',
+        'planDigest',
+        'resourceSampling',
+        'totalRunCount',
+        'uncertaintyMethod',
+        'workloadDigest',
+        'workloadOfferedOperations'
+    ], 'provider-lane plan coordinates');
+
+    return {
+        blocks           : election.planCoordinates.blocks,
+        candidateProfiles: receipts.map(createProviderLaneCandidateProfile),
+        resourceSampling : structuredClone(election.planCoordinates.resourceSampling),
+        slo              : structuredClone(election.jointSlo),
+        workload         : {
+            digest           : election.planCoordinates.workloadDigest,
+            offeredOperations: structuredClone(election.planCoordinates.workloadOfferedOperations)
+        }
+    }
+}
+
+/**
+ * @summary Rejects unknown fields from the raw evidence envelope before pure-core projection.
+ * @private
+ */
+function assertProviderLaneElectionEvidenceShape(evidence) {
+    if (!Array.isArray(evidence.contextEvidence) || !Array.isArray(evidence.trials)) {
+        throw new Error('provider-lane election evidence requires context and trial arrays')
+    }
+
+    for (const context of evidence.contextEvidence) {
+        requireExactKeys(context, [
+            'candidate', 'completedAtMs', 'compositionReceiptDigest', 'lanes', 'startedAtMs'
+        ], 'provider-lane context evidence');
+        requireExactKeys(context.lanes, LANE_NAMES, 'provider-lane context lanes');
+
+        for (const laneName of LANE_NAMES) {
+            const lane = context.lanes[laneName];
+            requireExactKeys(lane, laneName === 'embedding'
+                ? ['observedContextTokensPerSlot', 'overLimitProbe', 'supportedLimitProbe']
+                : ['observedContextTokensPerSlot', 'overLimitProbe'], `provider-lane ${laneName} context lane`);
+            assertProviderLaneProbeShape(lane.overLimitProbe, `${laneName} over-limit probe`);
+            if (laneName === 'embedding') {
+                assertProviderLaneProbeShape(lane.supportedLimitProbe, 'embedding supported-limit probe')
+            }
+        }
+    }
+
+    for (const trial of evidence.trials) {
+        requireExactKeys(trial, [
+            'candidate',
+            'completedAtMs',
+            'compositionReceiptDigest',
+            'executionIndex',
+            'lanes',
+            'residencyBefore',
+            'scheduleId',
+            'startedAtMs',
+            'workloadDigest'
+        ], 'provider-lane trial evidence');
+        requireExactKeys(trial.lanes, LANE_NAMES, 'provider-lane trial lanes');
+        requireExactKeys(trial.residencyBefore, ['lanes', 'observedAtMs'], 'provider-lane residency evidence');
+        requireExactKeys(trial.residencyBefore.lanes, LANE_NAMES, 'provider-lane residency lanes');
+
+        for (const laneName of LANE_NAMES) {
+            const lane = trial.lanes[laneName];
+            requireExactKeys(lane, ['operations', 'resourceSamples', 'runtimeProfile', 'sourceCalls'],
+                `provider-lane ${laneName} trial lane`);
+            requireExactKeys(trial.residencyBefore.lanes[laneName], ['modelDigest', 'resident'],
+                `provider-lane ${laneName} residency`);
+            lane.operations.forEach(operation => requireExactKeys(operation, [
+                'callId',
+                'completedAtMs',
+                'enqueuedAtMs',
+                'id',
+                'outcome',
+                'providerStartedAtMs',
+                'queueDisposition',
+                'source'
+            ], `provider-lane ${laneName} operation`));
+            lane.resourceSamples.forEach(sample => requireExactKeys(sample, ['atMs', 'cpuPercent', 'rssBytes'],
+                `provider-lane ${laneName} resource sample`));
+            requireExactKeys(lane.runtimeProfile, [
+                'cpuCores', 'imageDigest', 'memoryBytes', 'modelDigest', 'parallelism', 'serviceKey'
+            ], `provider-lane ${laneName} runtime profile`);
+            lane.sourceCalls.forEach(call => requireExactKeys(call, [
+                'completedAtMs', 'demandAtMs', 'id', 'outcome', 'source'
+            ], `provider-lane ${laneName} source call`))
+        }
+    }
+}
+
+/**
+ * @summary Requires the exact bounded structural provider-probe fields.
+ * @private
+ */
+function assertProviderLaneProbeShape(probe, label) {
+    requireExactKeys(probe, [
+        'completedAtMs',
+        'id',
+        'modelDigest',
+        'observedOutputTokens',
+        'protocolAdapter',
+        'requestedContextTokens',
+        'responseBodyDigest',
+        'responseClass',
+        'serviceKey',
+        'startedAtMs',
+        'transportStatus'
+    ], label)
+}
+
+/**
+ * @summary Verifies report artifact coordinates against recomputed canonical evidence.
+ * @private
+ */
+function validateProviderLaneElectionArtifacts({artifacts, evidence, plan, projectName, receipts, repositoryHead}) {
+    requireExactKeys(artifacts, [
+        'candidateReceipts', 'evidenceDigest', 'planDigest', 'workloadDigest'
+    ], 'provider-lane election artifacts');
+
+    if (!Array.isArray(artifacts.candidateReceipts) || artifacts.candidateReceipts.length !== CANDIDATES.length) {
+        throw new Error('provider-lane election artifacts require three archived candidate receipts')
+    }
+
+    const archived = [...artifacts.candidateReceipts].sort((left, right) => left?.candidate - right?.candidate);
+    archived.forEach((entry, index) => {
+        requireExactKeys(entry, ['archiveByteDigest', 'candidate', 'digest', 'file'],
+            `provider-lane archived candidate ${CANDIDATES[index]}`);
+        if (entry.candidate !== CANDIDATES[index] || entry.digest !== receipts[index].compositionReceiptDigest ||
+            !DIGEST_PATTERN.test(entry.archiveByteDigest ?? '') ||
+            entry.file !== `composition-candidate-${entry.candidate}.json`) {
+            throw new Error('provider-lane election artifact metadata drifted from its canonical receipt')
+        }
+    });
+
+    const evidenceDigest = digestProviderLaneValue({
+        candidateReceiptDigests: receipts.map(item => item.compositionReceiptDigest),
+        evidence,
+        projectName,
+        repositoryHead
+    });
+
+    if (artifacts.planDigest !== createProviderLanePlanDigest(plan) ||
+        artifacts.workloadDigest !== plan.workload.digest || artifacts.evidenceDigest !== evidenceDigest) {
+        throw new Error('provider-lane election artifact digests do not bind the recomputed report')
     }
 }
 
@@ -779,6 +1059,14 @@ export async function runProviderLaneContextWorker({includeOverLimit, receipt, t
         };
 
         if (includeOverLimit) {
+            if (laneName === 'embedding') {
+                lanes[laneName].supportedLimitProbe = await runSupportedLimitProbe({
+                    adapter                     : adapters[laneName],
+                    lane,
+                    observedContextTokensPerSlot: observation.contextTokensPerSlot,
+                    timeoutMs
+                })
+            }
             lanes[laneName].overLimitProbe = await runOverLimitProbe({
                 adapter                     : adapters[laneName],
                 lane,
@@ -1229,6 +1517,69 @@ async function runOverLimitProbe({adapter, lane, observedContextTokensPerSlot, t
 }
 
 /**
+ * @summary Executes one exact-size embedding request which must fit both context and physical batch.
+ * @private
+ */
+async function runSupportedLimitProbe({adapter, lane, observedContextTokensPerSlot, timeoutMs}) {
+    const {body, requestedContextTokens} = createProviderLaneSupportedLimitRequest({
+              adapter,
+              lane,
+              observedContextTokensPerSlot
+          }),
+          startedAtMs                    = Date.now(),
+          response                       = await fetchBounded(lane.endpoints.workload.url, {
+              body,
+              method: lane.endpoints.workload.method,
+              timeoutMs
+          });
+
+    return {
+        completedAtMs  : Date.now(),
+        id             : `${lane.serviceKey}:${startedAtMs}:supported:${randomBytes(8).toString('hex')}`,
+        modelDigest    : lane.model.digest,
+        protocolAdapter: adapter.id,
+        requestedContextTokens,
+        serviceKey     : lane.serviceKey,
+        startedAtMs,
+        ...classifyProviderLaneProbeResponse({adapter, body: response.body, status: response.status})
+    }
+}
+
+/**
+ * @summary Builds one exact-token embedding request at the declared supported single-request limit.
+ * @param {Object} options
+ * @param {Object} options.adapter Closed exact-image adapter.
+ * @param {Object} options.lane Validated embedding lane receipt.
+ * @param {Number} options.observedContextTokensPerSlot Runtime-observed exact supported limit.
+ * @returns {{body: String, requestedContextTokens: Number}}
+ */
+export function createProviderLaneSupportedLimitRequest({adapter, lane, observedContextTokensPerSlot}) {
+    const requestedContextTokens = Number(observedContextTokensPerSlot),
+          batchTokens            = Number(lane?.batchTokens),
+          ubatchTokens           = Number(lane?.ubatchTokens),
+          requiredTokens         = Number(lane?.contextTokensPerSlotRequired),
+          modelCeiling           = Number(lane?.model?.contextTokensMax);
+
+    if (adapter !== EMBEDDING_ADAPTER || !Number.isInteger(requestedContextTokens) ||
+        !Number.isInteger(batchTokens) || !Number.isInteger(ubatchTokens) ||
+        !Number.isInteger(requiredTokens) || !Number.isInteger(modelCeiling) ||
+        requestedContextTokens < requiredTokens || requestedContextTokens > modelCeiling ||
+        requestedContextTokens > batchTokens || requestedContextTokens > ubatchTokens) {
+        throw Object.assign(new Error('provider-lane supported-limit probe exceeds declared batch authority'), {
+            code: 'SUPPORTED_LIMIT_BATCH_INVALID'
+        })
+    }
+
+    return {
+        body: JSON.stringify({
+            input: Array(requestedContextTokens).fill(1),
+            model: lane.model.id
+        }),
+        requestedContextTokens
+    }
+}
+
+/**
  * @summary Builds one bounded closed-adapter over-limit request from verified runtime context truth.
  * @param {Object} options
  * @returns {{body: String, requestedContextTokens: Number}}
@@ -1246,8 +1597,9 @@ export function createProviderLaneOverLimitRequest({adapter, lane, observedConte
         })
     }
 
-    const requestedContextTokens = observedContextTokensPerSlot + 1,
-          body                   = adapter === CHAT_ADAPTER
+    const requestedContextTokens = observedContextTokensPerSlot + 1;
+
+    const body = adapter === CHAT_ADAPTER
               ? JSON.stringify({
                   messages: [{content: 'x '.repeat(requestedContextTokens), role: 'user'}],
                   model   : lane.model.id,
@@ -1257,7 +1609,7 @@ export function createProviderLaneOverLimitRequest({adapter, lane, observedConte
                   truncate: false
               })
               : JSON.stringify({
-                  input: 'x '.repeat(requestedContextTokens),
+                  input: Array(requestedContextTokens).fill(1),
                   model: lane.model.id
               });
 
@@ -1410,9 +1762,10 @@ async function runProviderLaneElectionController({artifactDir, dockerAuthority, 
         const election  = evaluateProviderLaneElection({contextEvidence, plan: purePlan, trials}),
               artifacts = {
                   candidateReceipts: receipts.map(item => ({
-                      candidate: item.candidate,
-                      digest   : item.compositionReceiptDigest,
-                      file     : path.basename(item.file)
+                      archiveByteDigest: item.archiveByteDigest,
+                      candidate        : item.candidate,
+                      digest           : item.compositionReceiptDigest,
+                      file             : path.basename(item.file)
                   })),
                   planDigest,
                   workloadDigest: workload.digest
@@ -1421,6 +1774,7 @@ async function runProviderLaneElectionController({artifactDir, dockerAuthority, 
         return finalizeProviderLaneElection({
             artifacts,
             election,
+            evidence: {contextEvidence, trials},
             head,
             projectName,
             receipts
@@ -1436,16 +1790,31 @@ async function runProviderLaneElectionController({artifactDir, dockerAuthority, 
  */
 function createWorkloadContract(plan) {
     const offeredOperations = Object.fromEntries(Object.entries(WORKLOAD_PAYLOADS).map(([source, payloads]) => [
-        source,
-        payloads.length
-    ]));
+              source,
+              payloads.length
+          ])),
+          embeddingInputs = EMBEDDING_SOURCES.flatMap(source => WORKLOAD_PAYLOADS[source].flat()),
+          maxEmbeddingInputBytes = Math.max(...embeddingInputs.map(value => Buffer.byteLength(value, 'utf8'))),
+          supportedEmbeddingTokens = plan.slo?.lanes?.embedding?.minContextTokensPerSlot;
+
+    // Every fixed embedding fixture is ASCII. Byte length plus one optional special token is a
+    // conservative upper bound for its tokenized single-input size; the exact-token runtime probe
+    // independently proves that the declared limit itself completes on the pinned provider.
+    if (!Number.isInteger(supportedEmbeddingTokens) ||
+        maxEmbeddingInputBytes + 1 > supportedEmbeddingTokens) {
+        throw Object.assign(new Error('provider-lane embedding fixture exceeds the supported single-request contract'), {
+            code: 'WORKLOAD_INPUT_CAPACITY_INVALID'
+        })
+    }
 
     return {
         digest: digestProviderLaneValue({
             contextProbeTimeoutMs: plan.contextProbeTimeoutMs,
             embeddingChunkSize   : EMBEDDING_CHUNK_SIZE,
             fixtures             : WORKLOAD_PAYLOADS,
+            maxEmbeddingInputBytes,
             schemaVersion        : 'provider-lane-workload.v1',
+            supportedEmbeddingTokens,
             trialTimeoutMs       : plan.trialTimeoutMs
         }),
         offeredOperations
@@ -1492,17 +1861,18 @@ async function renderAndArchiveCandidateReceipts({actor, artifactDir, plan}) {
 
         assertDeploymentInputsEqual(receipt.deploymentInputs, candidateInput.deploymentInputs, candidate);
 
-        const compositionReceiptDigest = digestRaw(raw),
+        const compositionReceiptDigest = digestProviderLaneValue(receipt),
+              archiveByteDigest        = digestRaw(raw),
               file                     = path.join(artifactDir, `composition-candidate-${candidate}.json`);
 
         await atomicWrite(file, raw);
-        if (digestRaw(await readFile(file, 'utf8')) !== compositionReceiptDigest) {
+        if (digestRaw(await readFile(file, 'utf8')) !== archiveByteDigest) {
             throw Object.assign(new Error('provider-lane archived receipt digest changed after write'), {
                 code: 'RECEIPT_ARCHIVE_MISMATCH'
             })
         }
 
-        receipts.push({candidate, compositionReceiptDigest, file, receipt, candidateInput})
+        receipts.push({archiveByteDigest, candidate, compositionReceiptDigest, file, receipt, candidateInput})
     }
 
     return receipts.sort((left, right) => left.candidate - right.candidate)
@@ -1602,7 +1972,7 @@ function createComposeActor({dockerAuthority, plan, projectName, projectRoot, si
                 candidateInput: receiptEntry.candidateInput,
                 runDocker,
                 service       : 'provider-lane-worker',
-                timeout       : (includeOverLimit ? timeoutMs * 4 : timeoutMs) + 30_000,
+                timeout       : (includeOverLimit ? timeoutMs * 5 : timeoutMs) + 30_000,
                 volume        : `${receiptEntry.file}:/tmp/provider-lane-receipt.json:ro`
             })
         },
@@ -1930,6 +2300,7 @@ function normalizeCandidateContextEvidence({receiptEntry, worker}) {
             const lane = worker.lanes?.[laneName];
 
             if (!lane?.overLimitProbe || lane.resident !== true ||
+                (laneName === 'embedding' && !lane.supportedLimitProbe) ||
                 lane.parallelism !== receiptEntry.receipt.lanes[laneName].parallelSlots) {
                 throw Object.assign(new Error(`provider-lane ${laneName} context evidence is incomplete`), {
                     code: 'CONTEXT_EVIDENCE_INVALID'
@@ -1938,7 +2309,10 @@ function normalizeCandidateContextEvidence({receiptEntry, worker}) {
 
             return [laneName, {
                 observedContextTokensPerSlot: lane.observedContextTokensPerSlot,
-                overLimitProbe              : structuredClone(lane.overLimitProbe)
+                overLimitProbe              : structuredClone(lane.overLimitProbe),
+                ...(laneName === 'embedding' ? {
+                    supportedLimitProbe: structuredClone(lane.supportedLimitProbe)
+                } : {})
             }]
         })),
         startedAtMs: worker.startedAtMs

--- a/ai/scripts/diagnostics/providerLaneComposition.mjs
+++ b/ai/scripts/diagnostics/providerLaneComposition.mjs
@@ -34,7 +34,9 @@ export const PROVIDER_LANE_DEPLOYMENT_INPUT_ENVS       = Object.freeze({
     embeddingMemoryBytes                 : 'NEO_PROVIDER_LANE_EMBEDDING_MEMORY_BYTES',
     embeddingParallelSlots               : 'NEO_PROVIDER_LANE_EMBEDDING_SLOTS',
     embeddingTotalContextTokens          : 'NEO_PROVIDER_LANE_EMBEDDING_TOTAL_CONTEXT_TOKENS',
-    embeddingContextTokensPerSlotRequired: 'NEO_PROVIDER_LANE_EMBEDDING_CONTEXT_TOKENS_PER_SLOT_REQUIRED'
+    embeddingContextTokensPerSlotRequired: 'NEO_PROVIDER_LANE_EMBEDDING_CONTEXT_TOKENS_PER_SLOT_REQUIRED',
+    embeddingBatchTokens                 : 'NEO_PROVIDER_LANE_EMBEDDING_BATCH_TOKENS',
+    embeddingUbatchTokens                : 'NEO_PROVIDER_LANE_EMBEDDING_UBATCH_TOKENS'
 });
 export const PROVIDER_LANE_MODEL_CONTRACT               = Object.freeze({
     chat: Object.freeze({
@@ -249,6 +251,10 @@ function laneReceipt(name, declaration = {}) {
         parallelSlots               : integerAboveZero(declaration.slots),
         totalContextTokens          : integerAboveZero(declaration.totalContextTokens),
         contextTokensPerSlotRequired: integerAboveZero(declaration.contextTokensPerSlotRequired),
+        ...(name === 'embedding' ? {
+            batchTokens : integerAboveZero(declaration.batchTokens),
+            ubatchTokens: integerAboveZero(declaration.ubatchTokens)
+        } : {}),
         endpoints                   : Object.fromEntries(Object.entries(declaration.endpoints || {}).map(([key, value]) => [key, endpointReceipt(value)]))
     }
 }
@@ -280,9 +286,46 @@ export function validateProviderLaneCompositionReceipt(receipt, {requireReady = 
     const fail   = (condition, code, pathName, expected, actual) =>
         assertValue(errors, condition, code, pathName, expected, actual);
 
+    const receiptFields = [
+        'composeProject',
+        'consumerCensus',
+        'deploymentInputs',
+        'envelope',
+        'errors',
+        'lanes',
+        'ready',
+        'roles',
+        'schemaVersion'
+    ];
+
+    fail(sameSet(Object.keys(receipt || {}), receiptFields), 'receipt-field-set',
+        'receipt', receiptFields, Object.keys(receipt || {}));
+
     fail(receipt?.schemaVersion === PROVIDER_LANE_COMPOSITION_SCHEMA_VERSION,
         'schema-version', 'schemaVersion', PROVIDER_LANE_COMPOSITION_SCHEMA_VERSION, receipt?.schemaVersion);
-    if (requireReady) fail(receipt?.ready === true, 'receipt-not-ready', 'ready', true, receipt?.ready);
+    if (requireReady) {
+        fail(receipt?.ready === true, 'receipt-not-ready', 'ready', true, receipt?.ready);
+        fail(Array.isArray(receipt?.errors) && receipt.errors.length === 0,
+            'receipt-errors', 'errors', [], receipt?.errors)
+    }
+    fail(typeof receipt?.composeProject === 'string' && receipt.composeProject.length > 0 &&
+        receipt.composeProject.length <= 128, 'compose-project', 'composeProject', 'bounded nonempty string', receipt?.composeProject);
+    fail(JSON.stringify(receipt?.consumerCensus) === JSON.stringify(PROVIDER_LANE_CONSUMER_CENSUS),
+        'consumer-census', 'consumerCensus', PROVIDER_LANE_CONSUMER_CENSUS, receipt?.consumerCensus);
+
+    const envelope = receipt?.envelope || {};
+    fail(sameSet(Object.keys(envelope), ['allocations', 'scope', 'total']),
+        'envelope-field-set', 'envelope', ['allocations', 'scope', 'total'], Object.keys(envelope));
+    fail(envelope.scope === 'provider-runtimes', 'envelope-scope', 'envelope.scope', 'provider-runtimes', envelope.scope);
+    fail(sameSet(Object.keys(envelope.total || {}), ['cpuCores', 'memoryBytes']),
+        'envelope-total-field-set', 'envelope.total', ['cpuCores', 'memoryBytes'], Object.keys(envelope.total || {}));
+    fail(sameSet(Object.keys(envelope.allocations || {}), PROVIDER_LANE_KEYS),
+        'envelope-allocation-set', 'envelope.allocations', PROVIDER_LANE_KEYS, Object.keys(envelope.allocations || {}));
+    for (const laneName of PROVIDER_LANE_KEYS) {
+        fail(sameSet(Object.keys(envelope.allocations?.[laneName] || {}), ['cpuCores', 'memoryBytes']),
+            'envelope-allocation-field-set', `envelope.allocations.${laneName}`,
+            ['cpuCores', 'memoryBytes'], Object.keys(envelope.allocations?.[laneName] || {}))
+    }
 
     const lanes = receipt?.lanes || {};
     fail(sameSet(Object.keys(lanes), PROVIDER_LANE_KEYS), 'lane-set', 'lanes', PROVIDER_LANE_KEYS, Object.keys(lanes));
@@ -290,6 +333,25 @@ export function validateProviderLaneCompositionReceipt(receipt, {requireReady = 
     for (const laneName of PROVIDER_LANE_KEYS) {
         const lane          = lanes[laneName] || {};
         const expectedModel = PROVIDER_LANE_MODEL_CONTRACT[laneName];
+        const laneFields    = [
+            'baseUrl',
+            'contextTokensPerSlotRequired',
+            'cpuCores',
+            'dnsName',
+            'endpoints',
+            'image',
+            'memoryBytes',
+            'model',
+            'parallelSlots',
+            'provider',
+            'serviceKey',
+            'totalContextTokens',
+            ...(laneName === 'embedding' ? ['batchTokens', 'ubatchTokens'] : [])
+        ];
+        fail(sameSet(Object.keys(lane), laneFields), 'lane-field-set',
+            `lanes.${laneName}`, laneFields, Object.keys(lane));
+        fail(sameSet(Object.keys(lane.image || {}), ['digest', 'reference']), 'image-field-set',
+            `lanes.${laneName}.image`, ['digest', 'reference'], Object.keys(lane.image || {}));
         fail(lane.serviceKey === PROVIDER_LANE_SERVICE_KEYS[laneName], 'service-key', `lanes.${laneName}.serviceKey`, PROVIDER_LANE_SERVICE_KEYS[laneName], lane.serviceKey);
         fail(lane.dnsName === lane.serviceKey, 'lane-dns', `lanes.${laneName}.dnsName`, lane.serviceKey, lane.dnsName);
         fail(isSha256(lane.image?.digest), 'image-digest', `lanes.${laneName}.image.digest`, 'sha256:<64hex>', lane.image?.digest);
@@ -336,6 +398,16 @@ export function validateProviderLaneCompositionReceipt(receipt, {requireReady = 
     }
 
     fail(lanes.chat?.parallelSlots === 1, 'chat-parallelism', 'lanes.chat.parallelSlots', 1, lanes.chat?.parallelSlots);
+    fail(integerAboveZero(lanes.embedding?.batchTokens) !== null,
+        'embedding-batch', 'lanes.embedding.batchTokens', 'positive integer', lanes.embedding?.batchTokens);
+    fail(integerAboveZero(lanes.embedding?.ubatchTokens) !== null,
+        'embedding-ubatch', 'lanes.embedding.ubatchTokens', 'positive integer', lanes.embedding?.ubatchTokens);
+    fail(lanes.embedding?.batchTokens === lanes.embedding?.ubatchTokens,
+        'embedding-batch-ubatch-coupling', 'lanes.embedding.batchTokens',
+        '=== lanes.embedding.ubatchTokens', lanes.embedding?.batchTokens);
+    fail(lanes.embedding?.ubatchTokens === lanes.embedding?.totalContextTokens,
+        'embedding-batch-context-coupling', 'lanes.embedding.ubatchTokens',
+        '=== lanes.embedding.totalContextTokens', lanes.embedding?.ubatchTokens);
     fail(lanes.chat?.serviceKey !== lanes.embedding?.serviceKey, 'lane-collapse', 'lanes', 'distinct service keys', lanes.chat?.serviceKey);
     fail(lanes.chat?.provider !== lanes.embedding?.provider, 'provider-collapse', 'lanes', 'distinct provider families', lanes.chat?.provider);
     const total       = receipt?.envelope?.total || {};
@@ -358,7 +430,9 @@ export function validateProviderLaneCompositionReceipt(receipt, {requireReady = 
         embeddingMemoryBytes                 : {env: PROVIDER_LANE_DEPLOYMENT_INPUT_ENVS.embeddingMemoryBytes, value: lanes.embedding?.memoryBytes},
         embeddingParallelSlots               : {env: PROVIDER_LANE_DEPLOYMENT_INPUT_ENVS.embeddingParallelSlots, value: lanes.embedding?.parallelSlots},
         embeddingTotalContextTokens          : {env: PROVIDER_LANE_DEPLOYMENT_INPUT_ENVS.embeddingTotalContextTokens, value: lanes.embedding?.totalContextTokens},
-        embeddingContextTokensPerSlotRequired: {env: PROVIDER_LANE_DEPLOYMENT_INPUT_ENVS.embeddingContextTokensPerSlotRequired, value: lanes.embedding?.contextTokensPerSlotRequired}
+        embeddingContextTokensPerSlotRequired: {env: PROVIDER_LANE_DEPLOYMENT_INPUT_ENVS.embeddingContextTokensPerSlotRequired, value: lanes.embedding?.contextTokensPerSlotRequired},
+        embeddingBatchTokens                 : {env: PROVIDER_LANE_DEPLOYMENT_INPUT_ENVS.embeddingBatchTokens, value: lanes.embedding?.batchTokens},
+        embeddingUbatchTokens                : {env: PROVIDER_LANE_DEPLOYMENT_INPUT_ENVS.embeddingUbatchTokens, value: lanes.embedding?.ubatchTokens}
     };
 
     fail(sameSet(Object.keys(deploymentInputs), Object.keys(expectedDeploymentInputs)), 'deployment-input-set',
@@ -377,6 +451,11 @@ export function validateProviderLaneCompositionReceipt(receipt, {requireReady = 
         const role         = roles[roleName] || {};
         const lane         = lanes[role.lane];
         const expectedRole = PROVIDER_LANE_ROLE_CONTRACT[roleName];
+        fail(sameSet(Object.keys(role), [
+            'baseUrl', 'configPath', 'consumers', 'lane', 'modelId', 'provider', 'roleKey', 'serviceKey'
+        ]), 'role-field-set', `roles.${roleName}`,
+        ['baseUrl', 'configPath', 'consumers', 'lane', 'modelId', 'provider', 'roleKey', 'serviceKey'], Object.keys(role));
+        fail(role.roleKey === roleName, 'role-key', `roles.${roleName}.roleKey`, roleName, role.roleKey);
         fail(role.configPath === expectedRole.configPath, 'role-config-path', `roles.${roleName}.configPath`, expectedRole.configPath, role.configPath);
         fail(role.lane === expectedRole.lane, 'role-lane-assignment', `roles.${roleName}.lane`, expectedRole.lane, role.lane);
         fail(Boolean(lane), 'role-lane', `roles.${roleName}.lane`, PROVIDER_LANE_KEYS, role.lane);
@@ -436,7 +515,9 @@ export function analyzeProviderLaneComposition(composition, {
         embeddingMemoryBytes                 : input('embeddingMemoryBytes', lanes.embedding.memoryBytes),
         embeddingParallelSlots               : input('embeddingParallelSlots', lanes.embedding.parallelSlots),
         embeddingTotalContextTokens          : input('embeddingTotalContextTokens', lanes.embedding.totalContextTokens),
-        embeddingContextTokensPerSlotRequired: input('embeddingContextTokensPerSlotRequired', lanes.embedding.contextTokensPerSlotRequired)
+        embeddingContextTokensPerSlotRequired: input('embeddingContextTokensPerSlotRequired', lanes.embedding.contextTokensPerSlotRequired),
+        embeddingBatchTokens                 : input('embeddingBatchTokens', lanes.embedding.batchTokens),
+        embeddingUbatchTokens                : input('embeddingUbatchTokens', lanes.embedding.ubatchTokens)
     };
 
     const receipt = {
@@ -472,6 +553,12 @@ export function analyzeProviderLaneComposition(composition, {
         fail(bytes(limits.memory) === lane.memoryBytes, 'service-memory-drift', `services.${lane.serviceKey}.deploy.resources.limits.memory`, lane.memoryBytes, limits.memory);
         fail(integerAboveZero(env[controls.contextEnv]) === lane.totalContextTokens, 'service-context-drift', `services.${lane.serviceKey}.environment.${controls.contextEnv}`, lane.totalContextTokens, env[controls.contextEnv]);
         fail(integerAboveZero(env[controls.slotsEnv]) === lane.parallelSlots, 'service-slots-drift', `services.${lane.serviceKey}.environment.${controls.slotsEnv}`, lane.parallelSlots, env[controls.slotsEnv]);
+        if (laneName === 'embedding') {
+            fail(integerAboveZero(env[controls.batchEnv]) === lane.batchTokens,
+                'service-batch-drift', `services.${lane.serviceKey}.environment.${controls.batchEnv}`, lane.batchTokens, env[controls.batchEnv]);
+            fail(integerAboveZero(env[controls.ubatchEnv]) === lane.ubatchTokens,
+                'service-ubatch-drift', `services.${lane.serviceKey}.environment.${controls.ubatchEnv}`, lane.ubatchTokens, env[controls.ubatchEnv]);
+        }
         fail(lane.dnsName === lane.serviceKey, 'service-dns-drift', `x-provider-lane-contract.lanes.${laneName}.endpoints`, lane.serviceKey, lane.dnsName);
     }
 

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
         "ai:probe-community-activity-shadow"   : "node ./ai/scripts/maintenance/probeCommunityActivityShadow.mjs",
         "ai:probe-keep-alive"                  : "node ./ai/scripts/benchmark/keep-alive-probe.mjs",
         "ai:provider-lane-composition"         : "node ./ai/scripts/diagnostics/providerLaneComposition.mjs",
+        "ai:provider-lane-election"            : "node ./ai/scripts/benchmark/provider-lane-election.mjs",
         "ai:prune-worktrees"                   : "node ./ai/scripts/migrations/bootstrapWorktree.mjs --prune-stale",
         "ai:prune-worktrees:dry-run"           : "node ./ai/scripts/migrations/bootstrapWorktree.mjs --prune-stale --dry-run",
         "ai:prune-worktrees:schedule-dangerous": "node ./ai/scripts/migrations/bootstrapWorktree.mjs --prune-stale --schedule-local --include-dirty --interval-ms 21600000",

--- a/test/playwright/unit/ai/scripts/benchmark/ProviderLaneElectionCore.spec.mjs
+++ b/test/playwright/unit/ai/scripts/benchmark/ProviderLaneElectionCore.spec.mjs
@@ -55,10 +55,11 @@ function buildFixture() {
         }
     };
 
-    const schedule = buildProviderLaneCandidateSchedule({blocks: plan.blocks}),
-          trials   = schedule.map(slot => buildTrial({plan, slot}));
+    const schedule        = buildProviderLaneCandidateSchedule({blocks: plan.blocks}),
+          contextEvidence = [1, 2, 4].map(candidate => buildContextEvidence({candidate, plan})),
+          trials          = schedule.map(slot => buildTrial({plan, slot}));
 
-    return {plan, schedule, trials}
+    return {contextEvidence, plan, schedule, trials}
 }
 
 /**
@@ -146,9 +147,26 @@ function buildLaneSlo({
  * resource samples.
  */
 function buildTrial({plan, slot}) {
-    const startedAtMs   = 10_000 + slot.executionIndex * 10_000,
-          completedAtMs = startedAtMs + 5000,
-          profile       = plan.candidateProfiles.find(item => item.embeddingSlots === slot.candidate);
+    const startedAtMs    = 10_000 + slot.executionIndex * 10_000,
+          completedAtMs  = startedAtMs + 5000,
+          profile        = plan.candidateProfiles.find(item => item.embeddingSlots === slot.candidate),
+          chatOperations = [
+              buildOperation({
+                  completedAtMs      : startedAtMs + 1500,
+                  enqueuedAtMs       : startedAtMs + 100,
+                  id                 : `${slot.id}:chat:0`,
+                  providerStartedAtMs: startedAtMs + 200,
+                  source             : 'chat'
+              }),
+              buildOperation({
+                  completedAtMs      : startedAtMs + 2500,
+                  enqueuedAtMs       : startedAtMs + 200,
+                  id                 : `${slot.id}:chat:1`,
+                  providerStartedAtMs: startedAtMs + 1500,
+                  source             : 'chat'
+              })
+          ],
+          embeddingOperations = buildEmbeddingOperations({slot, startedAtMs});
 
     return {
         candidate               : slot.candidate,
@@ -157,45 +175,16 @@ function buildTrial({plan, slot}) {
         executionIndex          : slot.executionIndex,
         lanes                   : {
             chat: {
-                observedContextTokensPerSlot: 131_072,
-                operations                  : [
-                    buildOperation({
-                        completedAtMs      : startedAtMs + 1500,
-                        enqueuedAtMs       : startedAtMs + 100,
-                        id                 : `${slot.id}:chat:0`,
-                        providerStartedAtMs: startedAtMs + 200,
-                        source             : 'chat'
-                    }),
-                    buildOperation({
-                        completedAtMs      : startedAtMs + 2500,
-                        enqueuedAtMs       : startedAtMs + 200,
-                        id                 : `${slot.id}:chat:1`,
-                        providerStartedAtMs: startedAtMs + 1500,
-                        source             : 'chat'
-                    })
-                ],
-                overLimitProbe : buildOverLimitProbe({
-                    laneName             : 'chat',
-                    observedContextTokens: 131_072,
-                    profile,
-                    slot,
-                    startedAtMs
-                }),
+                operations     : chatOperations,
                 resourceSamples: buildResourceSamples({cpuPercent: 180, rssBytes: 2_500_000_000, startedAtMs}),
-                runtimeProfile : {...profile.lanes.chat}
+                runtimeProfile : {...profile.lanes.chat},
+                sourceCalls    : buildSourceCalls(chatOperations)
             },
             embedding: {
-                observedContextTokensPerSlot: 8192,
-                operations                  : buildEmbeddingOperations({slot, startedAtMs}),
-                overLimitProbe              : buildOverLimitProbe({
-                    laneName             : 'embedding',
-                    observedContextTokens: 8192,
-                    profile,
-                    slot,
-                    startedAtMs
-                }),
+                operations     : embeddingOperations,
                 resourceSamples: buildResourceSamples({cpuPercent: 190, rssBytes: 4_000_000_000, startedAtMs}),
-                runtimeProfile : {...profile.lanes.embedding}
+                runtimeProfile : {...profile.lanes.embedding},
+                sourceCalls    : buildSourceCalls(embeddingOperations)
             }
         },
         residencyBefore: {
@@ -212,12 +201,52 @@ function buildTrial({plan, slot}) {
 }
 
 /**
+ * @summary Shapes one candidate-level context observation and refusal pair outside workload timing.
+ */
+function buildContextEvidence({candidate, plan}) {
+    const profile       = plan.candidateProfiles.find(item => item.embeddingSlots === candidate),
+          startedAtMs   = candidate * 1000,
+          completedAtMs = startedAtMs + 500;
+
+    return {
+        candidate,
+        completedAtMs,
+        compositionReceiptDigest: profile.compositionReceiptDigest,
+        lanes                   : {
+            chat: {
+                observedContextTokensPerSlot: 131_072,
+                overLimitProbe              : buildOverLimitProbe({
+                    candidate,
+                    completedAtMs,
+                    laneName             : 'chat',
+                    observedContextTokens: 131_072,
+                    profile,
+                    startedAtMs
+                })
+            },
+            embedding: {
+                observedContextTokensPerSlot: 8192,
+                overLimitProbe              : buildOverLimitProbe({
+                    candidate,
+                    completedAtMs,
+                    laneName             : 'embedding',
+                    observedContextTokens: 8192,
+                    profile,
+                    startedAtMs
+                })
+            }
+        },
+        startedAtMs
+    }
+}
+
+/**
  * @summary Shapes a raw, identity-bound provider refusal receipt for one over-limit request.
  */
-function buildOverLimitProbe({laneName, observedContextTokens, profile, slot, startedAtMs}) {
+function buildOverLimitProbe({candidate, completedAtMs, laneName, observedContextTokens, profile, startedAtMs}) {
     return {
-        completedAtMs         : startedAtMs + 4400,
-        id                    : `${slot.id}:${laneName}:over-limit`,
+        completedAtMs         : completedAtMs - 10,
+        id                    : `candidate-${candidate}:${laneName}:over-limit`,
         modelDigest           : profile.lanes[laneName].modelDigest,
         observedOutputTokens  : 0,
         protocolAdapter       : profile.lanes[laneName].protocolAdapter,
@@ -225,7 +254,7 @@ function buildOverLimitProbe({laneName, observedContextTokens, profile, slot, st
         responseBodyDigest    : `sha256:${'8'.repeat(64)}`,
         responseClass         : 'context-limit-refusal',
         serviceKey            : profile.lanes[laneName].serviceKey,
-        startedAtMs           : startedAtMs + 4300,
+        startedAtMs           : completedAtMs - 100,
         transportStatus       : 400
     }
 }
@@ -259,6 +288,7 @@ function buildEmbeddingOperations({slot, startedAtMs}) {
  */
 function buildOperation({completedAtMs, enqueuedAtMs, id, providerStartedAtMs, source}) {
     return {
+        callId          : `${id}:call`,
         completedAtMs,
         enqueuedAtMs,
         id,
@@ -267,6 +297,19 @@ function buildOperation({completedAtMs, enqueuedAtMs, id, providerStartedAtMs, s
         queueDisposition: 'queued',
         source
     }
+}
+
+/**
+ * @summary Projects caller-visible progress separately from provider-operation timing.
+ */
+function buildSourceCalls(operations) {
+    return operations.map(operation => ({
+        completedAtMs: operation.completedAtMs,
+        demandAtMs   : operation.enqueuedAtMs ?? operation.providerStartedAtMs,
+        id           : operation.callId,
+        outcome      : operation.outcome,
+        source       : operation.source
+    }))
 }
 
 /**
@@ -305,11 +348,11 @@ test.describe('providerLaneElectionCore', () => {
     });
 
     test('computes the smallest measured winner without minting deployment authority', () => {
-        const fixture                 = buildFixture(),
-              firstCandidateOperation = fixture.trials.find(trial => trial.candidate === 1)
-                  .lanes.embedding.operations[0];
+        const fixture            = buildFixture(),
+              firstCandidateCall = fixture.trials.find(trial => trial.candidate === 1)
+                  .lanes.embedding.sourceCalls[0];
 
-        firstCandidateOperation.outcome = 'error';
+        firstCandidateCall.outcome = 'error';
 
         const result = evaluateProviderLaneElection(fixture);
 
@@ -333,10 +376,10 @@ test.describe('providerLaneElectionCore', () => {
     });
 
     test('does not accept or echo caller-supplied authority and deployment-input envelopes', () => {
-        const fixture   = buildFixture(),
-              operation = fixture.trials.find(trial => trial.candidate === 1).lanes.embedding.operations[0];
+        const fixture = buildFixture(),
+              call    = fixture.trials.find(trial => trial.candidate === 1).lanes.embedding.sourceCalls[0];
 
-        operation.outcome = 'error';
+        call.outcome = 'error';
         fixture.plan.evidence = {canonicalPlane: true, token: 'AUTHORITY_SECRET'};
         fixture.plan.candidateProfiles[1].deploymentInputs = {
             embeddingParallelSlots: {
@@ -359,7 +402,7 @@ test.describe('providerLaneElectionCore', () => {
         const fixture = buildFixture();
 
         for (const candidate of [1, 2, 4]) {
-            fixture.trials.find(trial => trial.candidate === candidate).lanes.chat.operations[0].outcome = 'error'
+            fixture.trials.find(trial => trial.candidate === candidate).lanes.chat.sourceCalls[0].outcome = 'error'
         }
 
         const result = evaluateProviderLaneElection(fixture);
@@ -387,6 +430,44 @@ test.describe('providerLaneElectionCore', () => {
         expect(trial.maxProviderDurationMs).toBe(900);
         expect(trial.throughputPerSecond).toBe(0.8);
         expect(queue).toEqual({max: null, median: null, min: null, n: 0, observedRange: null, p95: null})
+    });
+
+    test('derives durable progress from source calls while retaining every provider chunk', () => {
+        const fixture    = buildFixture(),
+              trial      = fixture.trials.find(item => item.candidate === 4),
+              lane       = trial.lanes.embedding,
+              memoryCall = lane.sourceCalls.find(call => call.source === 'memory-core');
+
+        const memoryOperation = lane.operations.find(operation => operation.source === 'memory-core');
+        lane.operations.push(
+            {...memoryOperation, completedAtMs: trial.startedAtMs + 2100, id: `${memoryOperation.id}:chunk-2`, providerStartedAtMs: trial.startedAtMs + 1300},
+            {...memoryOperation, completedAtMs: trial.startedAtMs + 3000, id: `${memoryOperation.id}:chunk-3`, providerStartedAtMs: trial.startedAtMs + 2200},
+            {...memoryOperation, completedAtMs: trial.startedAtMs + 3900, id: `${memoryOperation.id}:chunk-4`, providerStartedAtMs: trial.startedAtMs + 3100}
+        );
+        memoryCall.completedAtMs = trial.startedAtMs + 4000;
+
+        const result    = evaluateProviderLaneElection(fixture),
+              candidate = result.candidates.find(item => item.candidate === 4),
+              observed  = candidate.trials[0].lanes.embedding;
+
+        expect(observed.providerOperationCount).toBe(7);
+        expect(observed.completedOperations).toBe(4);
+        expect(observed.throughputPerSecond).toBe(0.8);
+        expect(observed.sourceCalls.filter(call => call.source === 'memory-core')).toHaveLength(1);
+
+        const failedFixture = buildFixture(),
+              failedTrial   = failedFixture.trials.find(item => item.candidate === 4),
+              failedCall    = failedTrial.lanes.embedding.sourceCalls.find(call => call.source === 'memory-core');
+
+        failedCall.outcome = 'error';
+
+        const failedCandidate = evaluateProviderLaneElection(failedFixture).candidates.find(item => item.candidate === 4),
+              failedObserved  = failedCandidate.trials[0].lanes.embedding;
+
+        expect(failedObserved.providerOperationCount).toBe(4);
+        expect(failedObserved.completedOperations).toBe(3);
+        expect(failedObserved.errorCount).toBe(1);
+        expect(failedCandidate.failures.map(failure => failure.code)).toContain('ERROR_BUDGET_EXCEEDED')
     });
 
     test('derives CPU/RSS coverage from raw chronological samples and fails real coverage gaps', () => {
@@ -435,7 +516,9 @@ test.describe('providerLaneElectionCore', () => {
         expect(() => evaluateProviderLaneElection(digestDrift)).toThrow(/changed the immutable workload digest/);
 
         const missingSource = buildFixture();
-        missingSource.trials[0].lanes.embedding.operations.pop();
+        const removedCall   = missingSource.trials[0].lanes.embedding.sourceCalls.pop();
+        missingSource.trials[0].lanes.embedding.operations = missingSource.trials[0].lanes.embedding.operations
+            .filter(operation => operation.callId !== removedCall.id);
         expect(() => evaluateProviderLaneElection(missingSource)).toThrow(/source orchestrator offered 1; fixed workload requires 2/);
 
         const sequential = buildFixture(),
@@ -445,7 +528,12 @@ test.describe('providerLaneElectionCore', () => {
         operations.forEach((operation, index) => {
             operation.enqueuedAtMs = trial.startedAtMs + 2600 + index * 900;
             operation.providerStartedAtMs = trial.startedAtMs + 2700 + index * 900;
-            operation.completedAtMs = trial.startedAtMs + 3500 + index * 900
+            operation.completedAtMs = trial.startedAtMs + 3500 + index * 900;
+
+            const sourceCall = trial.lanes.embedding.sourceCalls.find(item => item.id === operation.callId);
+
+            sourceCall.completedAtMs = operation.completedAtMs;
+            sourceCall.demandAtMs = operation.enqueuedAtMs
         });
 
         const result = evaluateProviderLaneElection(sequential),
@@ -488,16 +576,17 @@ test.describe('providerLaneElectionCore', () => {
 
     test('fails context/refusal/progress from derived receipts rather than configured knobs', () => {
         const fixture = buildFixture(),
+              context = fixture.contextEvidence.find(item => item.candidate === 2),
               trial   = fixture.trials.find(item => item.candidate === 2);
 
-        trial.lanes.embedding.observedContextTokensPerSlot = 4096;
-        Object.assign(trial.lanes.embedding.overLimitProbe, {
+        context.lanes.embedding.observedContextTokensPerSlot = 4096;
+        Object.assign(context.lanes.embedding.overLimitProbe, {
             observedOutputTokens: 32,
             responseClass       : 'completed',
             transportStatus     : 200
         });
-        trial.lanes.embedding.operations.forEach(operation => {
-            operation.outcome = 'error'
+        trial.lanes.embedding.sourceCalls.forEach(call => {
+            call.outcome = 'error'
         });
 
         const result = evaluateProviderLaneElection(fixture),
@@ -515,9 +604,9 @@ test.describe('providerLaneElectionCore', () => {
         const fixture = buildFixture();
 
         fixture.plan.slo.lanes.embedding.minContextTokensPerSlot = 4096;
-        for (const trial of fixture.trials) {
-            trial.lanes.embedding.observedContextTokensPerSlot = 4096;
-            trial.lanes.embedding.overLimitProbe.requestedContextTokens = 4097
+        for (const context of fixture.contextEvidence) {
+            context.lanes.embedding.observedContextTokensPerSlot = 4096;
+            context.lanes.embedding.overLimitProbe.requestedContextTokens = 4097
         }
 
         expect(() => evaluateProviderLaneElection(fixture)).toThrow(
@@ -559,6 +648,8 @@ test.describe('providerLaneElectionCore', () => {
               trial   = fixture.trials.find(item => item.candidate === 2);
 
         fixture.plan.candidateProfiles[1].compositionReceiptDigest = `sha256:${'9'.repeat(64)}`;
+        fixture.contextEvidence.find(item => item.candidate === 2).compositionReceiptDigest =
+            fixture.plan.candidateProfiles[1].compositionReceiptDigest;
 
         expect(() => evaluateProviderLaneElection(fixture)).toThrow(
             /does not match candidate 2's composition receipt/
@@ -584,19 +675,19 @@ test.describe('providerLaneElectionCore', () => {
 
     test('requires a normalized identity-bound refusal receipt instead of an asserted boolean', () => {
         const fixture = buildFixture(),
-              probe   = fixture.trials[0].lanes.embedding.overLimitProbe;
+              probe   = fixture.contextEvidence[0].lanes.embedding.overLimitProbe;
 
         probe.serviceKey = 'wrong-provider';
-        expect(() => evaluateProviderLaneElection(fixture)).toThrow(/truthful identity-bound over-limit probe/);
+        expect(() => evaluateProviderLaneElection(fixture)).toThrow(/truthful identity-bound context evidence/);
 
         const inconsistent = buildFixture();
-        inconsistent.trials[0].lanes.embedding.overLimitProbe.transportStatus = 200;
+        inconsistent.contextEvidence[0].lanes.embedding.overLimitProbe.transportStatus = 200;
         expect(() => evaluateProviderLaneElection(inconsistent)).toThrow(/inconsistent over-limit provider response/)
     });
 
     test('treats a runner-normalized provider error as a failed over-limit probe', () => {
         const fixture = buildFixture(),
-              probe   = fixture.trials.find(item => item.candidate === 2).lanes.embedding.overLimitProbe;
+              probe   = fixture.contextEvidence.find(item => item.candidate === 2).lanes.embedding.overLimitProbe;
 
         Object.assign(probe, {
             responseClass  : 'provider-error',
@@ -604,7 +695,7 @@ test.describe('providerLaneElectionCore', () => {
         });
 
         const result = evaluateProviderLaneElection(fixture),
-              lane   = result.candidates.find(item => item.candidate === 2).trials[0].lanes.embedding,
+              lane   = result.candidates.find(item => item.candidate === 2).contextEvidence.lanes.embedding,
               codes  = result.candidates.find(item => item.candidate === 2).failures.map(failure => failure.code);
 
         expect(lane.overLimitProbe.responseClass).toBe('provider-error');
@@ -629,11 +720,12 @@ test.describe('providerLaneElectionCore', () => {
         fixture.plan.resourceSampling.token = 'SAMPLER_SECRET';
         trial.lanes.embedding.runtimeProfile.token = 'RUNTIME_SECRET';
         trial.lanes.embedding.operations[0].id = '/tenant/private/corpus/row';
-        trial.lanes.embedding.overLimitProbe.id = 'sk-private-provider-token';
+        fixture.contextEvidence[0].lanes.embedding.overLimitProbe.id = 'sk-private-provider-token';
 
         const result     = evaluateProviderLaneElection(fixture),
               serialized = JSON.stringify(result),
-              lane       = result.candidates[0].trials[0].lanes.embedding;
+              lane       = result.candidates[0].trials[0].lanes.embedding,
+              context    = result.candidates[0].contextEvidence.lanes.embedding;
 
         expect(serialized).not.toContain('SECRET');
         expect(serialized).not.toContain('/tenant/private/corpus/row');
@@ -642,6 +734,6 @@ test.describe('providerLaneElectionCore', () => {
         expect(result.planCoordinates.resourceSampling.token).toBeUndefined();
         expect(lane.runtimeProfile.token).toBeUndefined();
         expect(lane.operations[0].id).toMatch(/^sha256:[0-9a-f]{64}$/);
-        expect(lane.overLimitProbe.id).toMatch(/^sha256:[0-9a-f]{64}$/)
+        expect(context.overLimitProbe.id).toMatch(/^sha256:[0-9a-f]{64}$/)
     });
 });

--- a/test/playwright/unit/ai/scripts/benchmark/ProviderLaneElectionCore.spec.mjs
+++ b/test/playwright/unit/ai/scripts/benchmark/ProviderLaneElectionCore.spec.mjs
@@ -11,43 +11,17 @@ const
     CHAT_MODEL_DIGEST      = `sha256:${'b'.repeat(64)}`,
     EMBEDDING_IMAGE_DIGEST = `sha256:${'c'.repeat(64)}`,
     EMBEDDING_MODEL_DIGEST = `sha256:${'d'.repeat(64)}`,
+    ROLE_MAP_DIGEST        = `sha256:${'f'.repeat(64)}`,
     WORKLOAD_DIGEST        = `sha256:${'e'.repeat(64)}`;
 
 /**
- * @summary Builds a complete synthetic matrix. Synthetic controls intentionally cannot emit
- * deployment inputs; tests mutate causal coordinates and inspect the provisional evaluation.
+ * @summary Builds a complete synthetic matrix for pure measurement and election tests.
  */
-function buildFixture({evidenceClass = 'synthetic-control'} = {}) {
+function buildFixture() {
     const plan = {
         blocks           : 1,
-        candidateProfiles: [1, 2, 4].map(embeddingSlots => ({
-            embeddingSlots,
-            lanes: {
-                chat: {
-                    contextLimitCode  : 'CONTEXT_LIMIT_EXCEEDED',
-                    contextLimitStatus: 400,
-                    cpuCores          : 2,
-                    imageDigest       : CHAT_IMAGE_DIGEST,
-                    memoryBytes       : 3_000_000_000,
-                    modelDigest       : CHAT_MODEL_DIGEST,
-                    parallelism       : 1,
-                    serviceKey        : 'chat-model'
-                },
-                embedding: {
-                    contextLimitCode  : 'CONTEXT_LIMIT_EXCEEDED',
-                    contextLimitStatus: 400,
-                    cpuCores          : 2,
-                    imageDigest       : EMBEDDING_IMAGE_DIGEST,
-                    memoryBytes       : 5_000_000_000,
-                    modelDigest       : EMBEDDING_MODEL_DIGEST,
-                    parallelism       : embeddingSlots,
-                    serviceKey        : 'embedding-model'
-                }
-            },
-            totalResources: {cpuCores: 4, memoryBytes: 8_000_000_000}
-        })),
-        evidence        : {evidenceClass: 'synthetic-control'},
-        resourceSampling: {
+        candidateProfiles: [1, 2, 4].map(buildCandidateProfile),
+        resourceSampling : {
             activeCpuThreshold: 1,
             expectedIntervalMs: 1000,
             gapFactor         : 2
@@ -81,21 +55,63 @@ function buildFixture({evidenceClass = 'synthetic-control'} = {}) {
         }
     };
 
-    if (evidenceClass === 'exact-head-candidate') {
-        plan.evidence = {
-            canonicalPlane: true,
-            evidenceClass,
-            hardwareId    : 'canonical-cpu-plane',
-            profileDigest : createProviderLanePlanDigest(plan),
-            repositoryHead: '1'.repeat(40),
-            runnerDigest  : `sha256:${'2'.repeat(64)}`
-        }
-    }
-
     const schedule = buildProviderLaneCandidateSchedule({blocks: plan.blocks}),
           trials   = schedule.map(slot => buildTrial({plan, slot}));
 
     return {plan, schedule, trials}
+}
+
+/**
+ * @summary Shapes one composition-derived candidate profile.
+ */
+function buildCandidateProfile(embeddingSlots) {
+    const profile = {
+        compositionReceiptDigest: `sha256:${String(embeddingSlots).repeat(64)}`,
+        compositionSchemaVersion: 'provider-lane-composition.v1',
+        embeddingSlots,
+        lanes                   : {
+            chat: {
+                baseUrl                     : 'http://chat-model:11434',
+                contextTokensPerSlotRequired: 131_072,
+                cpuCores                    : 2,
+                endpointDigest              : `sha256:${'6'.repeat(64)}`,
+                imageDigest                 : CHAT_IMAGE_DIGEST,
+                imageReference              : 'ollama/ollama:0.32.9',
+                memoryBytes                 : 3_000_000_000,
+                modelCoordinate             : 'ollama://gemma4:26b@immutable',
+                modelDigest                 : CHAT_MODEL_DIGEST,
+                modelDigestKind             : 'ollama-model-weights',
+                modelId                     : 'gemma4:26b',
+                parallelism                 : 1,
+                protocolAdapter             : 'ollama-chat-v0.32.9',
+                provider                    : 'ollama',
+                serviceKey                  : 'chat-model',
+                totalContextTokens          : 131_072
+            },
+            embedding: {
+                baseUrl                     : 'http://embedding-model:8080',
+                contextTokensPerSlotRequired: 8192,
+                cpuCores                    : 2,
+                endpointDigest              : `sha256:${'7'.repeat(64)}`,
+                imageDigest                 : EMBEDDING_IMAGE_DIGEST,
+                imageReference              : 'ghcr.io/ggml-org/llama.cpp:server-b10380',
+                memoryBytes                 : 5_000_000_000,
+                modelCoordinate             : 'hf://Qwen/Qwen3-Embedding-8B-GGUF@immutable/model.gguf',
+                modelDigest                 : EMBEDDING_MODEL_DIGEST,
+                modelDigestKind             : 'gguf-file',
+                modelId                     : 'qwen3-embedding-8b',
+                parallelism                 : embeddingSlots,
+                protocolAdapter             : 'llama-cpp-openai-embeddings-b10380',
+                provider                    : 'openAiCompatible',
+                serviceKey                  : 'embedding-model',
+                totalContextTokens          : embeddingSlots * 8192
+            }
+        },
+        roleMapDigest : ROLE_MAP_DIGEST,
+        totalResources: {cpuCores: 4, memoryBytes: 8_000_000_000}
+    };
+
+    return profile
 }
 
 /**
@@ -135,10 +151,11 @@ function buildTrial({plan, slot}) {
           profile       = plan.candidateProfiles.find(item => item.embeddingSlots === slot.candidate);
 
     return {
-        candidate     : slot.candidate,
+        candidate               : slot.candidate,
         completedAtMs,
-        executionIndex: slot.executionIndex,
-        lanes         : {
+        compositionReceiptDigest: profile.compositionReceiptDigest,
+        executionIndex          : slot.executionIndex,
+        lanes                   : {
             chat: {
                 observedContextTokensPerSlot: 131_072,
                 operations                  : [
@@ -203,9 +220,10 @@ function buildOverLimitProbe({laneName, observedContextTokens, profile, slot, st
         id                    : `${slot.id}:${laneName}:over-limit`,
         modelDigest           : profile.lanes[laneName].modelDigest,
         observedOutputTokens  : 0,
-        providerErrorCode     : 'CONTEXT_LIMIT_EXCEEDED',
+        protocolAdapter       : profile.lanes[laneName].protocolAdapter,
         requestedContextTokens: observedContextTokens + 1,
-        responseClass         : 'provider-error',
+        responseBodyDigest    : `sha256:${'8'.repeat(64)}`,
+        responseClass         : 'context-limit-refusal',
         serviceKey            : profile.lanes[laneName].serviceKey,
         startedAtMs           : startedAtMs + 4300,
         transportStatus       : 400
@@ -220,7 +238,7 @@ function buildEmbeddingOperations({slot, startedAtMs}) {
           startsByCandidate = {
               1: [300, 1300, 2300, 3300],
               2: [300, 300, 1300, 1300],
-              4: [300, 300, 300, 300]
+              4: [300, 300, 300, 1300]
           };
 
     return sources.map((source, index) => {
@@ -286,7 +304,7 @@ test.describe('providerLaneElectionCore', () => {
         expect(Math.max(...pairCounts) - Math.min(...pairCounts)).toBe(1)
     });
 
-    test('synthetic evidence computes the smallest provisional candidate but cannot mint deployment inputs', () => {
+    test('computes the smallest measured winner without minting deployment authority', () => {
         const fixture                 = buildFixture(),
               firstCandidateOperation = fixture.trials.find(trial => trial.candidate === 1)
                   .lanes.embedding.operations[0];
@@ -295,14 +313,15 @@ test.describe('providerLaneElectionCore', () => {
 
         const result = evaluateProviderLaneElection(fixture);
 
-        expect(result.status).toBe('NON_AUTHORITATIVE');
-        expect(result.computedOutcome).toBe('ELECTED');
-        expect(result.provisionalCandidate).toBe(2);
-        expect(result.electedCandidate).toBeNull();
-        expect(result.immutableInputs).toBeNull();
-        expect(result.authority).toEqual({authoritative: false, evidenceClass: 'synthetic-control'});
+        expect(result.winnerCandidate).toBe(2);
+        expect(result.authority).toBeUndefined();
+        expect(result.electedCandidate).toBeUndefined();
+        expect(result.immutableInputs).toBeUndefined();
         expect(result.planCoordinates.workloadOfferedOperations).toEqual(fixture.plan.workload.offeredOperations);
         expect(result.jointSlo.lanes.embedding.minContextTokensPerSlot).toBe(8192);
+        expect(result.candidates[0].trials[0].compositionReceiptDigest).toBe(
+            fixture.trials[0].compositionReceiptDigest
+        );
         expect(result.candidates[0].trials[0].lanes.embedding.resourceSamples).toEqual(
             fixture.trials[0].lanes.embedding.resourceSamples
         );
@@ -313,45 +332,31 @@ test.describe('providerLaneElectionCore', () => {
         ])
     });
 
-    test('exact-head canonical evidence emits immutable inputs for the smallest passing candidate', () => {
-        const fixture   = buildFixture({evidenceClass: 'exact-head-candidate'}),
+    test('does not accept or echo caller-supplied authority and deployment-input envelopes', () => {
+        const fixture   = buildFixture(),
               operation = fixture.trials.find(trial => trial.candidate === 1).lanes.embedding.operations[0];
 
         operation.outcome = 'error';
+        fixture.plan.evidence = {canonicalPlane: true, token: 'AUTHORITY_SECRET'};
+        fixture.plan.candidateProfiles[1].deploymentInputs = {
+            embeddingParallelSlots: {
+                env  : 'NEO_PROVIDER_LANE_EMBEDDING_SLOT_COUNT',
+                value: 2
+            }
+        };
 
-        const result = evaluateProviderLaneElection(fixture);
+        const result     = evaluateProviderLaneElection(fixture),
+              serialized = JSON.stringify(result);
 
-        expect(result.status).toBe('ELECTED');
-        expect(result.electedCandidate).toBe(2);
-        expect(result.immutableInputs).toEqual({
-            chatParallelism: 1,
-            embeddingSlots : 2,
-            laneIdentities : {
-                chat     : {imageDigest: CHAT_IMAGE_DIGEST, modelDigest: CHAT_MODEL_DIGEST, serviceKey: 'chat-model'},
-                embedding: {
-                    imageDigest: EMBEDDING_IMAGE_DIGEST,
-                    modelDigest: EMBEDDING_MODEL_DIGEST,
-                    serviceKey : 'embedding-model'
-                }
-            },
-            laneResources: {
-                chat     : {cpuCores: 2, memoryBytes: 3_000_000_000},
-                embedding: {cpuCores: 2, memoryBytes: 5_000_000_000}
-            },
-            perSlotContextTarget: {chat: 131_072, embedding: 8192},
-            totalResources      : {cpuCores: 4, memoryBytes: 8_000_000_000}
-        });
-        expect(result.authority).toMatchObject({
-            authoritative : true,
-            canonicalPlane: true,
-            evidenceClass : 'exact-head-candidate',
-            profileDigest : result.planCoordinates.planDigest,
-            repositoryHead: '1'.repeat(40)
-        })
+        expect(result.winnerCandidate).toBe(2);
+        expect(serialized).not.toContain('AUTHORITY_SECRET');
+        expect(serialized).not.toContain('NEO_PROVIDER_LANE_EMBEDDING_SLOT_COUNT');
+        expect(result.authority).toBeUndefined();
+        expect(result.immutableInputs).toBeUndefined()
     });
 
-    test('returns exact-head NO_ELECTION without fallback or clamp when every candidate fails', () => {
-        const fixture = buildFixture({evidenceClass: 'exact-head-candidate'});
+    test('returns no measured winner without fallback or clamp when every candidate fails', () => {
+        const fixture = buildFixture();
 
         for (const candidate of [1, 2, 4]) {
             fixture.trials.find(trial => trial.candidate === candidate).lanes.chat.operations[0].outcome = 'error'
@@ -359,9 +364,8 @@ test.describe('providerLaneElectionCore', () => {
 
         const result = evaluateProviderLaneElection(fixture);
 
-        expect(result.status).toBe('NO_ELECTION');
-        expect(result.electedCandidate).toBeNull();
-        expect(result.immutableInputs).toBeNull()
+        expect(result.winnerCandidate).toBeNull();
+        expect(result.candidates.every(candidate => candidate.status === 'FAIL')).toBe(true)
     });
 
     test('derives queue/provider/throughput/progress and preserves not-applicable queue wait as null', () => {
@@ -469,21 +473,17 @@ test.describe('providerLaneElectionCore', () => {
         expect(() => evaluateProviderLaneElection(fixture)).toThrow(/exceeds its runtime parallelism/)
     });
 
-    test('fails a candidate whose declared embedding slots were never observed concurrently', () => {
+    test('separates provisioned slots from the three-process workload concurrency ceiling', () => {
         const fixture = buildFixture(),
               trial   = fixture.trials.find(item => item.candidate === 4);
 
-        trial.lanes.embedding.operations.forEach((operation, index) => {
-            operation.providerStartedAtMs = trial.startedAtMs + 300 + index * 1000;
-            operation.completedAtMs = operation.providerStartedAtMs + 900
-        });
+        const result    = evaluateProviderLaneElection(fixture),
+              candidate = result.candidates.find(item => item.candidate === 4),
+              lane      = candidate.trials[0].lanes.embedding;
 
-        const result = evaluateProviderLaneElection(fixture),
-              codes  = result.candidates.find(item => item.candidate === 4).failures.map(failure => failure.code);
-
-        expect(codes).toContain('CANDIDATE_CONCURRENCY_NOT_OBSERVED');
-        expect(result.candidates.find(item => item.candidate === 4).trials[0]
-            .lanes.embedding.observedMaxProviderConcurrency).toBe(1)
+        expect(candidate.status).toBe('PASS');
+        expect(lane.runtimeProfile.parallelism).toBe(4);
+        expect(lane.observedMaxProviderConcurrency).toBe(3)
     });
 
     test('fails context/refusal/progress from derived receipts rather than configured knobs', () => {
@@ -493,7 +493,6 @@ test.describe('providerLaneElectionCore', () => {
         trial.lanes.embedding.observedContextTokensPerSlot = 4096;
         Object.assign(trial.lanes.embedding.overLimitProbe, {
             observedOutputTokens: 32,
-            providerErrorCode   : null,
             responseClass       : 'completed',
             transportStatus     : 200
         });
@@ -512,6 +511,20 @@ test.describe('providerLaneElectionCore', () => {
         ]))
     });
 
+    test('cannot lower the joint SLO beneath the composition-required per-slot context', () => {
+        const fixture = buildFixture();
+
+        fixture.plan.slo.lanes.embedding.minContextTokensPerSlot = 4096;
+        for (const trial of fixture.trials) {
+            trial.lanes.embedding.observedContextTokensPerSlot = 4096;
+            trial.lanes.embedding.overLimitProbe.requestedContextTokens = 4097
+        }
+
+        expect(() => evaluateProviderLaneElection(fixture)).toThrow(
+            /embedding context floor must equal the composition-required per-slot context/
+        )
+    });
+
     test('aborts on fixed-envelope, identity, service-separation, or allocation drift', () => {
         const envelope = buildFixture();
         envelope.plan.candidateProfiles[2].totalResources.cpuCores = 5;
@@ -524,6 +537,7 @@ test.describe('providerLaneElectionCore', () => {
 
         const sameService = buildFixture();
         sameService.plan.candidateProfiles[0].lanes.embedding.serviceKey = 'chat-model';
+        sameService.plan.candidateProfiles[0].lanes.embedding.baseUrl = 'http://chat-model:8080';
         expect(() => evaluateProviderLaneElection(sameService)).toThrow(/distinct chat and embedding service identities/);
 
         const allocation = buildFixture();
@@ -531,22 +545,44 @@ test.describe('providerLaneElectionCore', () => {
         expect(() => evaluateProviderLaneElection(allocation)).toThrow(/must exactly consume/)
     });
 
-    test('requires complete exact-head provenance before any authoritative verdict', () => {
-        const fixture = buildFixture({evidenceClass: 'exact-head-candidate'});
-        delete fixture.plan.evidence.runnerDigest;
-
-        expect(() => evaluateProviderLaneElection(fixture)).toThrow(/requires runnerDigest/)
-    });
-
-    test('binds exact-head provenance to the complete canonical plan coordinates', () => {
-        const fixture = buildFixture({evidenceClass: 'exact-head-candidate'});
+    test('binds the canonical plan digest to complete measurement coordinates', () => {
+        const fixture = buildFixture(),
+              before  = createProviderLanePlanDigest(fixture.plan);
 
         fixture.plan.slo.lanes.embedding.maxProviderDurationMs++;
 
-        expect(() => evaluateProviderLaneElection(fixture)).toThrow(/profileDigest does not match the canonical election plan digest/)
+        expect(createProviderLanePlanDigest(fixture.plan)).not.toBe(before)
     });
 
-    test('requires a raw identity-bound refusal receipt instead of an asserted refusal boolean', () => {
+    test('binds each captured trial to its exact candidate composition receipt', () => {
+        const fixture = buildFixture(),
+              trial   = fixture.trials.find(item => item.candidate === 2);
+
+        fixture.plan.candidateProfiles[1].compositionReceiptDigest = `sha256:${'9'.repeat(64)}`;
+
+        expect(() => evaluateProviderLaneElection(fixture)).toThrow(
+            /does not match candidate 2's composition receipt/
+        );
+        expect(trial.compositionReceiptDigest).not.toBe(
+            fixture.plan.candidateProfiles[1].compositionReceiptDigest
+        )
+    });
+
+    test('rejects alternate spellings of canonical sha256 digests', () => {
+        const missingPrefix = buildFixture();
+        missingPrefix.plan.candidateProfiles[0].compositionReceiptDigest = '1'.repeat(64);
+        expect(() => createProviderLanePlanDigest(missingPrefix.plan)).toThrow(
+            /requires immutable validated composition provenance/
+        );
+
+        const uppercase = buildFixture();
+        uppercase.plan.candidateProfiles[0].compositionReceiptDigest = `sha256:${'A'.repeat(64)}`;
+        expect(() => createProviderLanePlanDigest(uppercase.plan)).toThrow(
+            /requires immutable validated composition provenance/
+        )
+    });
+
+    test('requires a normalized identity-bound refusal receipt instead of an asserted boolean', () => {
         const fixture = buildFixture(),
               probe   = fixture.trials[0].lanes.embedding.overLimitProbe;
 
@@ -558,13 +594,13 @@ test.describe('providerLaneElectionCore', () => {
         expect(() => evaluateProviderLaneElection(inconsistent)).toThrow(/inconsistent over-limit provider response/)
     });
 
-    test('does not let a caller relabel rate limits or provider failures as context refusals', () => {
+    test('treats a runner-normalized provider error as a failed over-limit probe', () => {
         const fixture = buildFixture(),
               probe   = fixture.trials.find(item => item.candidate === 2).lanes.embedding.overLimitProbe;
 
         Object.assign(probe, {
-            providerErrorCode: 'RATE_LIMIT',
-            transportStatus  : 429
+            responseClass  : 'provider-error',
+            transportStatus: 429
         });
 
         const result = evaluateProviderLaneElection(fixture),
@@ -573,6 +609,16 @@ test.describe('providerLaneElectionCore', () => {
 
         expect(lane.overLimitProbe.responseClass).toBe('provider-error');
         expect(codes).toContain('OVER_LIMIT_NOT_REFUSED')
+    });
+
+    test('binds immutable composition coordinates without owning deployment inputs', () => {
+        const endpointDrift = buildFixture();
+        endpointDrift.plan.candidateProfiles[2].lanes.embedding.endpointDigest = `sha256:${'9'.repeat(64)}`;
+        expect(() => evaluateProviderLaneElection(endpointDrift)).toThrow(/changed embedding\.endpointDigest/);
+
+        const receiptDrift = buildFixture();
+        receiptDrift.plan.candidateProfiles[2].compositionReceiptDigest = `sha256:${'9'.repeat(64)}`;
+        expect(createProviderLanePlanDigest(receiptDrift.plan)).not.toBe(createProviderLanePlanDigest(buildFixture().plan))
     });
 
     test('projects allowlisted fields and hashes caller-owned request identifiers', () => {

--- a/test/playwright/unit/ai/scripts/benchmark/ProviderLaneElectionCore.spec.mjs
+++ b/test/playwright/unit/ai/scripts/benchmark/ProviderLaneElectionCore.spec.mjs
@@ -226,6 +226,12 @@ function buildContextEvidence({candidate, plan}) {
             },
             embedding: {
                 observedContextTokensPerSlot: 8192,
+                supportedLimitProbe         : buildSupportedLimitProbe({
+                    candidate,
+                    completedAtMs,
+                    profile,
+                    startedAtMs
+                }),
                 overLimitProbe              : buildOverLimitProbe({
                     candidate,
                     completedAtMs,
@@ -237,6 +243,25 @@ function buildContextEvidence({candidate, plan}) {
             }
         },
         startedAtMs
+    }
+}
+
+/**
+ * @summary Shapes a successful exact-limit embedding receipt independent of the refusal probe.
+ */
+function buildSupportedLimitProbe({candidate, completedAtMs, profile, startedAtMs}) {
+    return {
+        completedAtMs         : completedAtMs - 110,
+        id                    : `candidate-${candidate}:embedding:supported-limit`,
+        modelDigest           : profile.lanes.embedding.modelDigest,
+        observedOutputTokens  : 1,
+        protocolAdapter       : profile.lanes.embedding.protocolAdapter,
+        requestedContextTokens: profile.lanes.embedding.contextTokensPerSlotRequired,
+        responseBodyDigest    : `sha256:${'7'.repeat(64)}`,
+        responseClass         : 'completed',
+        serviceKey            : profile.lanes.embedding.serviceKey,
+        startedAtMs           : startedAtMs + 10,
+        transportStatus       : 200
     }
 }
 
@@ -580,6 +605,7 @@ test.describe('providerLaneElectionCore', () => {
               trial   = fixture.trials.find(item => item.candidate === 2);
 
         context.lanes.embedding.observedContextTokensPerSlot = 4096;
+        context.lanes.embedding.supportedLimitProbe.requestedContextTokens = 4096;
         Object.assign(context.lanes.embedding.overLimitProbe, {
             observedOutputTokens: 32,
             responseClass       : 'completed',
@@ -598,6 +624,45 @@ test.describe('providerLaneElectionCore', () => {
             'ERROR_BUDGET_EXCEEDED',
             'PROGRESS_BELOW_SLO'
         ]))
+    });
+
+    test('fails a candidate whose supported embedding limit does not complete', () => {
+        const fixture = buildFixture(),
+              probe   = fixture.contextEvidence.find(item => item.candidate === 2)
+                  .lanes.embedding.supportedLimitProbe;
+
+        Object.assign(probe, {
+            observedOutputTokens: 0,
+            responseClass       : 'provider-error',
+            transportStatus     : 500
+        });
+
+        const result = evaluateProviderLaneElection(fixture),
+              codes  = result.candidates.find(item => item.candidate === 2).failures.map(failure => failure.code);
+
+        expect(codes).toContain('SUPPORTED_LIMIT_NOT_COMPLETED')
+    });
+
+    test('accepts a physical refusal only beyond the embedding lane physical context envelope', () => {
+        const fixture = buildFixture(),
+              lane    = fixture.contextEvidence.find(item => item.candidate === 1).lanes.embedding;
+
+        Object.assign(lane.overLimitProbe, {
+            responseClass  : 'physical-batch-refusal',
+            transportStatus: 500
+        });
+
+        const result = evaluateProviderLaneElection(fixture),
+              codes  = result.candidates.find(item => item.candidate === 1).failures
+                  .map(failure => failure.code);
+        expect(codes).not.toContain('OVER_LIMIT_NOT_REFUSED');
+
+        const impossible = buildFixture();
+        Object.assign(impossible.contextEvidence.find(item => item.candidate === 2).lanes.embedding.overLimitProbe, {
+            responseClass  : 'physical-batch-refusal',
+            transportStatus: 500
+        });
+        expect(() => evaluateProviderLaneElection(impossible)).toThrow(/impossible physical-batch refusal/)
     });
 
     test('cannot lower the joint SLO beneath the composition-required per-slot context', () => {
@@ -721,6 +786,7 @@ test.describe('providerLaneElectionCore', () => {
         trial.lanes.embedding.runtimeProfile.token = 'RUNTIME_SECRET';
         trial.lanes.embedding.operations[0].id = '/tenant/private/corpus/row';
         fixture.contextEvidence[0].lanes.embedding.overLimitProbe.id = 'sk-private-provider-token';
+        fixture.contextEvidence[0].lanes.embedding.supportedLimitProbe.id = '/tenant/private/supported-probe';
 
         const result     = evaluateProviderLaneElection(fixture),
               serialized = JSON.stringify(result),
@@ -735,5 +801,6 @@ test.describe('providerLaneElectionCore', () => {
         expect(lane.runtimeProfile.token).toBeUndefined();
         expect(lane.operations[0].id).toMatch(/^sha256:[0-9a-f]{64}$/);
         expect(context.overLimitProbe.id).toMatch(/^sha256:[0-9a-f]{64}$/)
+        expect(context.supportedLimitProbe.id).toMatch(/^sha256:[0-9a-f]{64}$/)
     });
 });

--- a/test/playwright/unit/ai/scripts/benchmark/ProviderLaneElectionCore.spec.mjs
+++ b/test/playwright/unit/ai/scripts/benchmark/ProviderLaneElectionCore.spec.mjs
@@ -1,0 +1,601 @@
+import {test, expect} from '@playwright/test';
+
+import {
+    buildProviderLaneCandidateSchedule,
+    createProviderLanePlanDigest,
+    evaluateProviderLaneElection
+} from '../../../../../../ai/scripts/benchmark/helpers/providerLaneElectionCore.mjs';
+
+const
+    CHAT_IMAGE_DIGEST      = `sha256:${'a'.repeat(64)}`,
+    CHAT_MODEL_DIGEST      = `sha256:${'b'.repeat(64)}`,
+    EMBEDDING_IMAGE_DIGEST = `sha256:${'c'.repeat(64)}`,
+    EMBEDDING_MODEL_DIGEST = `sha256:${'d'.repeat(64)}`,
+    WORKLOAD_DIGEST        = `sha256:${'e'.repeat(64)}`;
+
+/**
+ * @summary Builds a complete synthetic matrix. Synthetic controls intentionally cannot emit
+ * deployment inputs; tests mutate causal coordinates and inspect the provisional evaluation.
+ */
+function buildFixture({evidenceClass = 'synthetic-control'} = {}) {
+    const plan = {
+        blocks           : 1,
+        candidateProfiles: [1, 2, 4].map(embeddingSlots => ({
+            embeddingSlots,
+            lanes: {
+                chat: {
+                    contextLimitCode  : 'CONTEXT_LIMIT_EXCEEDED',
+                    contextLimitStatus: 400,
+                    cpuCores          : 2,
+                    imageDigest       : CHAT_IMAGE_DIGEST,
+                    memoryBytes       : 3_000_000_000,
+                    modelDigest       : CHAT_MODEL_DIGEST,
+                    parallelism       : 1,
+                    serviceKey        : 'chat-model'
+                },
+                embedding: {
+                    contextLimitCode  : 'CONTEXT_LIMIT_EXCEEDED',
+                    contextLimitStatus: 400,
+                    cpuCores          : 2,
+                    imageDigest       : EMBEDDING_IMAGE_DIGEST,
+                    memoryBytes       : 5_000_000_000,
+                    modelDigest       : EMBEDDING_MODEL_DIGEST,
+                    parallelism       : embeddingSlots,
+                    serviceKey        : 'embedding-model'
+                }
+            },
+            totalResources: {cpuCores: 4, memoryBytes: 8_000_000_000}
+        })),
+        evidence        : {evidenceClass: 'synthetic-control'},
+        resourceSampling: {
+            activeCpuThreshold: 1,
+            expectedIntervalMs: 1000,
+            gapFactor         : 2
+        },
+        slo: {
+            lanes: {
+                chat: buildLaneSlo({
+                    maxCpuHighWaterPercent : 200,
+                    maxRssHighWaterBytes   : 3_000_000_000,
+                    minCompletedOperations : 2,
+                    minContextTokensPerSlot: 131_072,
+                    minThroughputPerSecond : 0.3
+                }),
+                embedding: buildLaneSlo({
+                    maxCpuHighWaterPercent : 400,
+                    maxRssHighWaterBytes   : 5_000_000_000,
+                    minCompletedOperations : 4,
+                    minContextTokensPerSlot: 8192,
+                    minThroughputPerSecond : 0.5
+                })
+            }
+        },
+        workload: {
+            digest           : WORKLOAD_DIGEST,
+            offeredOperations: {
+                chat            : 2,
+                'knowledge-base': 1,
+                'memory-core'   : 1,
+                orchestrator    : 2
+            }
+        }
+    };
+
+    if (evidenceClass === 'exact-head-candidate') {
+        plan.evidence = {
+            canonicalPlane: true,
+            evidenceClass,
+            hardwareId    : 'canonical-cpu-plane',
+            profileDigest : createProviderLanePlanDigest(plan),
+            repositoryHead: '1'.repeat(40),
+            runnerDigest  : `sha256:${'2'.repeat(64)}`
+        }
+    }
+
+    const schedule = buildProviderLaneCandidateSchedule({blocks: plan.blocks}),
+          trials   = schedule.map(slot => buildTrial({plan, slot}));
+
+    return {plan, schedule, trials}
+}
+
+/**
+ * @summary Shapes one explicit lane SLO.
+ */
+function buildLaneSlo({
+    maxCpuHighWaterPercent,
+    maxRssHighWaterBytes,
+    minCompletedOperations,
+    minContextTokensPerSlot,
+    minThroughputPerSecond
+}) {
+    return {
+        maxCpuHighWaterPercent,
+        maxErrors               : 0,
+        maxNeoQueueWaitMs       : 1500,
+        maxProgressGapMs        : 4000,
+        maxProviderDurationMs   : 3000,
+        maxResourceGapCount     : 0,
+        maxRssHighWaterBytes,
+        maxUnexpectedRefusals   : 0,
+        minCompletedOperations,
+        minContextTokensPerSlot,
+        minResourceCoverageRatio: 0.95,
+        minThroughputPerSecond,
+        requiredQueueDisposition: 'queued'
+    }
+}
+
+/**
+ * @summary Shapes one chronological trial with four overlapping demand sources and raw
+ * resource samples.
+ */
+function buildTrial({plan, slot}) {
+    const startedAtMs   = 10_000 + slot.executionIndex * 10_000,
+          completedAtMs = startedAtMs + 5000,
+          profile       = plan.candidateProfiles.find(item => item.embeddingSlots === slot.candidate);
+
+    return {
+        candidate     : slot.candidate,
+        completedAtMs,
+        executionIndex: slot.executionIndex,
+        lanes         : {
+            chat: {
+                observedContextTokensPerSlot: 131_072,
+                operations                  : [
+                    buildOperation({
+                        completedAtMs      : startedAtMs + 1500,
+                        enqueuedAtMs       : startedAtMs + 100,
+                        id                 : `${slot.id}:chat:0`,
+                        providerStartedAtMs: startedAtMs + 200,
+                        source             : 'chat'
+                    }),
+                    buildOperation({
+                        completedAtMs      : startedAtMs + 2500,
+                        enqueuedAtMs       : startedAtMs + 200,
+                        id                 : `${slot.id}:chat:1`,
+                        providerStartedAtMs: startedAtMs + 1500,
+                        source             : 'chat'
+                    })
+                ],
+                overLimitProbe : buildOverLimitProbe({
+                    laneName             : 'chat',
+                    observedContextTokens: 131_072,
+                    profile,
+                    slot,
+                    startedAtMs
+                }),
+                resourceSamples: buildResourceSamples({cpuPercent: 180, rssBytes: 2_500_000_000, startedAtMs}),
+                runtimeProfile : {...profile.lanes.chat}
+            },
+            embedding: {
+                observedContextTokensPerSlot: 8192,
+                operations                  : buildEmbeddingOperations({slot, startedAtMs}),
+                overLimitProbe              : buildOverLimitProbe({
+                    laneName             : 'embedding',
+                    observedContextTokens: 8192,
+                    profile,
+                    slot,
+                    startedAtMs
+                }),
+                resourceSamples: buildResourceSamples({cpuPercent: 190, rssBytes: 4_000_000_000, startedAtMs}),
+                runtimeProfile : {...profile.lanes.embedding}
+            }
+        },
+        residencyBefore: {
+            lanes: {
+                chat     : {modelDigest: CHAT_MODEL_DIGEST, resident: true},
+                embedding: {modelDigest: null, resident: false}
+            },
+            observedAtMs: startedAtMs - 1
+        },
+        scheduleId    : slot.id,
+        startedAtMs,
+        workloadDigest: WORKLOAD_DIGEST
+    }
+}
+
+/**
+ * @summary Shapes a raw, identity-bound provider refusal receipt for one over-limit request.
+ */
+function buildOverLimitProbe({laneName, observedContextTokens, profile, slot, startedAtMs}) {
+    return {
+        completedAtMs         : startedAtMs + 4400,
+        id                    : `${slot.id}:${laneName}:over-limit`,
+        modelDigest           : profile.lanes[laneName].modelDigest,
+        observedOutputTokens  : 0,
+        providerErrorCode     : 'CONTEXT_LIMIT_EXCEEDED',
+        requestedContextTokens: observedContextTokens + 1,
+        responseClass         : 'provider-error',
+        serviceKey            : profile.lanes[laneName].serviceKey,
+        startedAtMs           : startedAtMs + 4300,
+        transportStatus       : 400
+    }
+}
+
+/**
+ * @summary Shapes four embedding operations whose provider concurrency matches the candidate.
+ */
+function buildEmbeddingOperations({slot, startedAtMs}) {
+    const sources           = ['knowledge-base', 'memory-core', 'orchestrator', 'orchestrator'],
+          startsByCandidate = {
+              1: [300, 1300, 2300, 3300],
+              2: [300, 300, 1300, 1300],
+              4: [300, 300, 300, 300]
+          };
+
+    return sources.map((source, index) => {
+        const providerStartedAtMs = startedAtMs + startsByCandidate[slot.candidate][index];
+
+        return buildOperation({
+            completedAtMs: providerStartedAtMs + 900,
+            enqueuedAtMs : startedAtMs + 150 + index * 10,
+            id           : `${slot.id}:${source}:${index}`,
+            providerStartedAtMs,
+            source
+        })
+    })
+}
+
+/**
+ * @summary Shapes one queued provider lifecycle row.
+ */
+function buildOperation({completedAtMs, enqueuedAtMs, id, providerStartedAtMs, source}) {
+    return {
+        completedAtMs,
+        enqueuedAtMs,
+        id,
+        outcome         : 'completed',
+        providerStartedAtMs,
+        queueDisposition: 'queued',
+        source
+    }
+}
+
+/**
+ * @summary Shapes raw chronological CPU/RSS samples covering one 5-second trial.
+ */
+function buildResourceSamples({cpuPercent, rssBytes, startedAtMs}) {
+    return Array.from({length: 6}, (_, index) => ({
+        atMs      : startedAtMs + index * 1000,
+        cpuPercent: cpuPercent + index,
+        rssBytes  : rssBytes + index
+    }))
+}
+
+test.describe('providerLaneElectionCore', () => {
+    test('builds one genuinely counterbalanced continuous stream across all sequence boundaries', () => {
+        const schedule = buildProviderLaneCandidateSchedule({blocks: 1}),
+              counts   = new Map();
+
+        expect(schedule).toHaveLength(18);
+        expect(new Set(schedule.map(slot => slot.id)).size).toBe(18);
+        expect(schedule.filter(slot => slot.candidate === 1)).toHaveLength(6);
+        expect(schedule.filter(slot => slot.candidate === 2)).toHaveLength(6);
+        expect(schedule.filter(slot => slot.candidate === 4)).toHaveLength(6);
+
+        for (let index = 1; index < schedule.length; index++) {
+            const prior = schedule[index - 1].candidate,
+                  next  = schedule[index].candidate,
+                  key   = `${prior}->${next}`;
+
+            expect(next).not.toBe(prior);
+            counts.set(key, (counts.get(key) ?? 0) + 1)
+        }
+
+        const pairCounts = ['1->2', '1->4', '2->1', '2->4', '4->1', '4->2'].map(key => counts.get(key));
+        expect(Math.max(...pairCounts) - Math.min(...pairCounts)).toBe(1)
+    });
+
+    test('synthetic evidence computes the smallest provisional candidate but cannot mint deployment inputs', () => {
+        const fixture                 = buildFixture(),
+              firstCandidateOperation = fixture.trials.find(trial => trial.candidate === 1)
+                  .lanes.embedding.operations[0];
+
+        firstCandidateOperation.outcome = 'error';
+
+        const result = evaluateProviderLaneElection(fixture);
+
+        expect(result.status).toBe('NON_AUTHORITATIVE');
+        expect(result.computedOutcome).toBe('ELECTED');
+        expect(result.provisionalCandidate).toBe(2);
+        expect(result.electedCandidate).toBeNull();
+        expect(result.immutableInputs).toBeNull();
+        expect(result.authority).toEqual({authoritative: false, evidenceClass: 'synthetic-control'});
+        expect(result.planCoordinates.workloadOfferedOperations).toEqual(fixture.plan.workload.offeredOperations);
+        expect(result.jointSlo.lanes.embedding.minContextTokensPerSlot).toBe(8192);
+        expect(result.candidates[0].trials[0].lanes.embedding.resourceSamples).toEqual(
+            fixture.trials[0].lanes.embedding.resourceSamples
+        );
+        expect(result.candidates.map(candidate => [candidate.candidate, candidate.status])).toEqual([
+            [1, 'FAIL'],
+            [2, 'PASS'],
+            [4, 'PASS']
+        ])
+    });
+
+    test('exact-head canonical evidence emits immutable inputs for the smallest passing candidate', () => {
+        const fixture   = buildFixture({evidenceClass: 'exact-head-candidate'}),
+              operation = fixture.trials.find(trial => trial.candidate === 1).lanes.embedding.operations[0];
+
+        operation.outcome = 'error';
+
+        const result = evaluateProviderLaneElection(fixture);
+
+        expect(result.status).toBe('ELECTED');
+        expect(result.electedCandidate).toBe(2);
+        expect(result.immutableInputs).toEqual({
+            chatParallelism: 1,
+            embeddingSlots : 2,
+            laneIdentities : {
+                chat     : {imageDigest: CHAT_IMAGE_DIGEST, modelDigest: CHAT_MODEL_DIGEST, serviceKey: 'chat-model'},
+                embedding: {
+                    imageDigest: EMBEDDING_IMAGE_DIGEST,
+                    modelDigest: EMBEDDING_MODEL_DIGEST,
+                    serviceKey : 'embedding-model'
+                }
+            },
+            laneResources: {
+                chat     : {cpuCores: 2, memoryBytes: 3_000_000_000},
+                embedding: {cpuCores: 2, memoryBytes: 5_000_000_000}
+            },
+            perSlotContextTarget: {chat: 131_072, embedding: 8192},
+            totalResources      : {cpuCores: 4, memoryBytes: 8_000_000_000}
+        });
+        expect(result.authority).toMatchObject({
+            authoritative : true,
+            canonicalPlane: true,
+            evidenceClass : 'exact-head-candidate',
+            profileDigest : result.planCoordinates.planDigest,
+            repositoryHead: '1'.repeat(40)
+        })
+    });
+
+    test('returns exact-head NO_ELECTION without fallback or clamp when every candidate fails', () => {
+        const fixture = buildFixture({evidenceClass: 'exact-head-candidate'});
+
+        for (const candidate of [1, 2, 4]) {
+            fixture.trials.find(trial => trial.candidate === candidate).lanes.chat.operations[0].outcome = 'error'
+        }
+
+        const result = evaluateProviderLaneElection(fixture);
+
+        expect(result.status).toBe('NO_ELECTION');
+        expect(result.electedCandidate).toBeNull();
+        expect(result.immutableInputs).toBeNull()
+    });
+
+    test('derives queue/provider/throughput/progress and preserves not-applicable queue wait as null', () => {
+        const fixture = buildFixture();
+
+        fixture.plan.slo.lanes.embedding.requiredQueueDisposition = 'not-applicable';
+        for (const trial of fixture.trials) {
+            for (const operation of trial.lanes.embedding.operations) {
+                operation.enqueuedAtMs = null;
+                operation.queueDisposition = 'not-applicable'
+            }
+        }
+
+        const result = evaluateProviderLaneElection(fixture),
+              trial  = result.candidates[0].trials[0].lanes.embedding,
+              queue  = result.candidates[0].uncertainty.embedding.maxNeoQueueWaitMs;
+
+        expect(trial.maxNeoQueueWaitMs).toBeNull();
+        expect(trial.maxProviderDurationMs).toBe(900);
+        expect(trial.throughputPerSecond).toBe(0.8);
+        expect(queue).toEqual({max: null, median: null, min: null, n: 0, observedRange: null, p95: null})
+    });
+
+    test('derives CPU/RSS coverage from raw chronological samples and fails real coverage gaps', () => {
+        const fixture = buildFixture(),
+              trial   = fixture.trials.find(item => item.candidate === 2);
+
+        trial.lanes.embedding.resourceSamples = [
+            trial.lanes.embedding.resourceSamples[0],
+            trial.lanes.embedding.resourceSamples.at(-1)
+        ];
+
+        const result    = evaluateProviderLaneElection(fixture),
+              candidate = result.candidates.find(item => item.candidate === 2),
+              codes     = candidate.failures.map(failure => failure.code);
+
+        expect(codes).toEqual(expect.arrayContaining([
+            'RESOURCE_COVERAGE_BELOW_SLO',
+            'RESOURCE_GAPS_EXCEEDED'
+        ]));
+        expect(candidate.trials[0].lanes.embedding.resourceSampleCount).toBe(2);
+        expect(candidate.trials[0].lanes.embedding.resourceCoverageRatio).toBe(0)
+    });
+
+    test('fails runtime allocation, CPU, and RSS containment independently of the joint SLO', () => {
+        const fixture = buildFixture(),
+              trial   = fixture.trials.find(item => item.candidate === 4);
+
+        trial.lanes.embedding.resourceSamples[2].cpuPercent = 201;
+        trial.lanes.embedding.resourceSamples[2].rssBytes = 5_000_000_001;
+
+        const result = evaluateProviderLaneElection(fixture),
+              codes  = result.candidates.find(item => item.candidate === 4).failures.map(failure => failure.code);
+
+        expect(codes).toEqual(expect.arrayContaining([
+            'CPU_ALLOCATION_EXCEEDED',
+            'RSS_ALLOCATION_EXCEEDED'
+        ]));
+
+        trial.lanes.embedding.runtimeProfile.cpuCores = 3;
+        expect(() => evaluateProviderLaneElection(fixture)).toThrow(/runtime profile does not match declared cpuCores/)
+    });
+
+    test('requires exact workload identity, per-source cardinality, and lifecycle-proven concurrency', () => {
+        const digestDrift = buildFixture();
+        digestDrift.trials[0].workloadDigest = `sha256:${'9'.repeat(64)}`;
+        expect(() => evaluateProviderLaneElection(digestDrift)).toThrow(/changed the immutable workload digest/);
+
+        const missingSource = buildFixture();
+        missingSource.trials[0].lanes.embedding.operations.pop();
+        expect(() => evaluateProviderLaneElection(missingSource)).toThrow(/source orchestrator offered 1; fixed workload requires 2/);
+
+        const sequential = buildFixture(),
+              trial      = sequential.trials.find(item => item.candidate === 2),
+              operations = trial.lanes.embedding.operations.filter(item => item.source === 'orchestrator');
+
+        operations.forEach((operation, index) => {
+            operation.enqueuedAtMs = trial.startedAtMs + 2600 + index * 900;
+            operation.providerStartedAtMs = trial.startedAtMs + 2700 + index * 900;
+            operation.completedAtMs = trial.startedAtMs + 3500 + index * 900
+        });
+
+        const result = evaluateProviderLaneElection(sequential),
+              codes  = result.candidates.find(item => item.candidate === 2).failures.map(failure => failure.code);
+
+        expect(codes).toContain('WORKLOAD_NOT_CONCURRENT')
+    });
+
+    test('requires chronological execution timestamps matching the real counterbalanced stream', () => {
+        const relabeled = buildFixture();
+        [relabeled.trials[0], relabeled.trials[1]] = [relabeled.trials[1], relabeled.trials[0]];
+        expect(() => evaluateProviderLaneElection(relabeled)).toThrow(/does not match counterbalanced slot/);
+
+        const overlapping = buildFixture();
+        overlapping.trials[1].startedAtMs = overlapping.trials[0].completedAtMs - 1;
+        expect(() => evaluateProviderLaneElection(overlapping)).toThrow(/overlaps the previous candidate trial/)
+    });
+
+    test('rejects provider execution which exceeds the observed candidate parallelism', () => {
+        const fixture = buildFixture(),
+              trial   = fixture.trials.find(item => item.candidate === 1);
+
+        trial.lanes.embedding.operations[1].providerStartedAtMs = trial.lanes.embedding.operations[0].providerStartedAtMs;
+
+        expect(() => evaluateProviderLaneElection(fixture)).toThrow(/exceeds its runtime parallelism/)
+    });
+
+    test('fails a candidate whose declared embedding slots were never observed concurrently', () => {
+        const fixture = buildFixture(),
+              trial   = fixture.trials.find(item => item.candidate === 4);
+
+        trial.lanes.embedding.operations.forEach((operation, index) => {
+            operation.providerStartedAtMs = trial.startedAtMs + 300 + index * 1000;
+            operation.completedAtMs = operation.providerStartedAtMs + 900
+        });
+
+        const result = evaluateProviderLaneElection(fixture),
+              codes  = result.candidates.find(item => item.candidate === 4).failures.map(failure => failure.code);
+
+        expect(codes).toContain('CANDIDATE_CONCURRENCY_NOT_OBSERVED');
+        expect(result.candidates.find(item => item.candidate === 4).trials[0]
+            .lanes.embedding.observedMaxProviderConcurrency).toBe(1)
+    });
+
+    test('fails context/refusal/progress from derived receipts rather than configured knobs', () => {
+        const fixture = buildFixture(),
+              trial   = fixture.trials.find(item => item.candidate === 2);
+
+        trial.lanes.embedding.observedContextTokensPerSlot = 4096;
+        Object.assign(trial.lanes.embedding.overLimitProbe, {
+            observedOutputTokens: 32,
+            providerErrorCode   : null,
+            responseClass       : 'completed',
+            transportStatus     : 200
+        });
+        trial.lanes.embedding.operations.forEach(operation => {
+            operation.outcome = 'error'
+        });
+
+        const result = evaluateProviderLaneElection(fixture),
+              codes  = result.candidates.find(item => item.candidate === 2).failures.map(failure => failure.code);
+
+        expect(codes).toEqual(expect.arrayContaining([
+            'CONTEXT_BELOW_SLO',
+            'OVER_LIMIT_NOT_REFUSED',
+            'ERROR_BUDGET_EXCEEDED',
+            'PROGRESS_BELOW_SLO'
+        ]))
+    });
+
+    test('aborts on fixed-envelope, identity, service-separation, or allocation drift', () => {
+        const envelope = buildFixture();
+        envelope.plan.candidateProfiles[2].totalResources.cpuCores = 5;
+        envelope.plan.candidateProfiles[2].lanes.embedding.cpuCores = 3;
+        expect(() => evaluateProviderLaneElection(envelope)).toThrow(/changed the fixed total CPU\/memory envelope/);
+
+        const identity = buildFixture();
+        identity.plan.candidateProfiles[2].lanes.embedding.modelDigest = `sha256:${'8'.repeat(64)}`;
+        expect(() => evaluateProviderLaneElection(identity)).toThrow(/changed embedding\.modelDigest/);
+
+        const sameService = buildFixture();
+        sameService.plan.candidateProfiles[0].lanes.embedding.serviceKey = 'chat-model';
+        expect(() => evaluateProviderLaneElection(sameService)).toThrow(/distinct chat and embedding service identities/);
+
+        const allocation = buildFixture();
+        allocation.plan.candidateProfiles[0].lanes.embedding.memoryBytes--;
+        expect(() => evaluateProviderLaneElection(allocation)).toThrow(/must exactly consume/)
+    });
+
+    test('requires complete exact-head provenance before any authoritative verdict', () => {
+        const fixture = buildFixture({evidenceClass: 'exact-head-candidate'});
+        delete fixture.plan.evidence.runnerDigest;
+
+        expect(() => evaluateProviderLaneElection(fixture)).toThrow(/requires runnerDigest/)
+    });
+
+    test('binds exact-head provenance to the complete canonical plan coordinates', () => {
+        const fixture = buildFixture({evidenceClass: 'exact-head-candidate'});
+
+        fixture.plan.slo.lanes.embedding.maxProviderDurationMs++;
+
+        expect(() => evaluateProviderLaneElection(fixture)).toThrow(/profileDigest does not match the canonical election plan digest/)
+    });
+
+    test('requires a raw identity-bound refusal receipt instead of an asserted refusal boolean', () => {
+        const fixture = buildFixture(),
+              probe   = fixture.trials[0].lanes.embedding.overLimitProbe;
+
+        probe.serviceKey = 'wrong-provider';
+        expect(() => evaluateProviderLaneElection(fixture)).toThrow(/truthful identity-bound over-limit probe/);
+
+        const inconsistent = buildFixture();
+        inconsistent.trials[0].lanes.embedding.overLimitProbe.transportStatus = 200;
+        expect(() => evaluateProviderLaneElection(inconsistent)).toThrow(/inconsistent over-limit provider response/)
+    });
+
+    test('does not let a caller relabel rate limits or provider failures as context refusals', () => {
+        const fixture = buildFixture(),
+              probe   = fixture.trials.find(item => item.candidate === 2).lanes.embedding.overLimitProbe;
+
+        Object.assign(probe, {
+            providerErrorCode: 'RATE_LIMIT',
+            transportStatus  : 429
+        });
+
+        const result = evaluateProviderLaneElection(fixture),
+              lane   = result.candidates.find(item => item.candidate === 2).trials[0].lanes.embedding,
+              codes  = result.candidates.find(item => item.candidate === 2).failures.map(failure => failure.code);
+
+        expect(lane.overLimitProbe.responseClass).toBe('provider-error');
+        expect(codes).toContain('OVER_LIMIT_NOT_REFUSED')
+    });
+
+    test('projects allowlisted fields and hashes caller-owned request identifiers', () => {
+        const fixture = buildFixture(),
+              trial   = fixture.trials[0];
+
+        fixture.plan.slo.lanes.embedding.token = 'SLO_SECRET';
+        fixture.plan.resourceSampling.token = 'SAMPLER_SECRET';
+        trial.lanes.embedding.runtimeProfile.token = 'RUNTIME_SECRET';
+        trial.lanes.embedding.operations[0].id = '/tenant/private/corpus/row';
+        trial.lanes.embedding.overLimitProbe.id = 'sk-private-provider-token';
+
+        const result     = evaluateProviderLaneElection(fixture),
+              serialized = JSON.stringify(result),
+              lane       = result.candidates[0].trials[0].lanes.embedding;
+
+        expect(serialized).not.toContain('SECRET');
+        expect(serialized).not.toContain('/tenant/private/corpus/row');
+        expect(serialized).not.toContain('sk-private-provider-token');
+        expect(result.jointSlo.lanes.embedding.token).toBeUndefined();
+        expect(result.planCoordinates.resourceSampling.token).toBeUndefined();
+        expect(lane.runtimeProfile.token).toBeUndefined();
+        expect(lane.operations[0].id).toMatch(/^sha256:[0-9a-f]{64}$/);
+        expect(lane.overLimitProbe.id).toMatch(/^sha256:[0-9a-f]{64}$/)
+    });
+});

--- a/test/playwright/unit/ai/scripts/benchmark/ProviderLaneElectionRunner.spec.mjs
+++ b/test/playwright/unit/ai/scripts/benchmark/ProviderLaneElectionRunner.spec.mjs
@@ -9,6 +9,7 @@ import {
     validateProviderLaneCompositionReceipt
 } from '../../../../../../ai/scripts/diagnostics/providerLaneComposition.mjs';
 import {
+    PROVIDER_LANE_ELECTION_REPORT_SCHEMA_VERSION,
     calculateProviderLaneDockerCpuPercent,
     classifyProviderLaneOperationResult,
     classifyProviderLaneProbeResponse,
@@ -17,6 +18,7 @@ import {
     createProviderLaneCleanup,
     createProviderLaneCandidateProfile,
     createProviderLaneOverLimitRequest,
+    createProviderLaneSupportedLimitRequest,
     digestProviderLaneValue,
     installProviderLaneSignalHandlers,
     invokeProviderLaneEmbeddingSource,
@@ -27,8 +29,13 @@ import {
     readBoundedProviderLaneResponseBody,
     resolveProviderLaneDockerAuthority,
     resolveProviderLaneAdapters,
+    validateProviderLaneElectionReport,
     validateProviderLaneRunPlan
 } from '../../../../../../ai/scripts/benchmark/provider-lane-election.mjs';
+import {
+    buildProviderLaneCandidateSchedule,
+    evaluateProviderLaneElection
+} from '../../../../../../ai/scripts/benchmark/helpers/providerLaneElectionCore.mjs';
 
 const
     repoRoot    = path.resolve(process.cwd()),
@@ -46,7 +53,9 @@ function buildComposition(candidate) {
         NEO_PROVIDER_LANE_EMBEDDING_MEMORY_BYTES                    : '17179869184',
         NEO_PROVIDER_LANE_EMBEDDING_SLOTS                           : String(candidate),
         NEO_PROVIDER_LANE_EMBEDDING_TOTAL_CONTEXT_TOKENS            : String(candidate * 8192),
-        NEO_PROVIDER_LANE_EMBEDDING_CONTEXT_TOKENS_PER_SLOT_REQUIRED: '8192'
+        NEO_PROVIDER_LANE_EMBEDDING_CONTEXT_TOKENS_PER_SLOT_REQUIRED: '8192',
+        NEO_PROVIDER_LANE_EMBEDDING_BATCH_TOKENS                    : String(candidate * 8192),
+        NEO_PROVIDER_LANE_EMBEDDING_UBATCH_TOKENS                   : String(candidate * 8192)
     };
     const source = fs.readFileSync(profilePath, 'utf8').replace(
         /\$\{([A-Z0-9_]+):\?[^}]+}/g,
@@ -168,6 +177,217 @@ function buildWorkerReceipt(source, receipt) {
     }
 }
 
+/**
+ * @summary Builds one complete controller-shaped report without exposing a production authority minter.
+ */
+function buildElectionReport({failAll = false} = {}) {
+    const projectName = `neo-provider-election-${REVISION.slice(0, 10)}-${'a'.repeat(12)}`,
+          receipts    = [1, 2, 4].map(candidate => {
+              const receipt = buildReceipt(candidate);
+              receipt.composeProject = projectName;
+
+              return {
+                  candidate,
+                  compositionReceiptDigest: digestProviderLaneValue(receipt),
+                  receipt
+              }
+          }),
+          workload = {
+              digest           : digestProviderLaneValue({fixture: 'provider-lane-report'}),
+              offeredOperations: {chat: 2, 'knowledge-base': 1, 'memory-core': 1, orchestrator: 2}
+          },
+          runPlan = buildRunPlan(receipts.map(item => item.receipt)),
+          plan = {
+              blocks           : 1,
+              candidateProfiles: receipts.map(createProviderLaneCandidateProfile),
+              resourceSampling : runPlan.resourceSampling,
+              slo              : runPlan.slo,
+              workload
+          },
+          contextEvidence = receipts.map(item => buildReportContextEvidence(item)),
+          trials = buildProviderLaneCandidateSchedule({blocks: 1})
+              .map(slot => buildReportTrial({plan, slot})),
+          election = evaluateProviderLaneElection({contextEvidence, plan, trials}),
+          evidence = {contextEvidence, trials},
+          evidenceDigest = digestProviderLaneValue({
+              candidateReceiptDigests: receipts.map(item => item.compositionReceiptDigest),
+              evidence,
+              projectName,
+              repositoryHead         : REVISION
+          });
+
+    if (failAll) {
+        for (const context of contextEvidence) {
+            context.lanes.embedding.overLimitProbe.responseClass = 'provider-error';
+            context.lanes.embedding.overLimitProbe.transportStatus = 500
+        }
+    }
+
+    const measuredElection = failAll
+              ? evaluateProviderLaneElection({contextEvidence, plan, trials})
+              : election,
+          selected = measuredElection.winnerCandidate === null
+              ? null
+              : receipts.find(item => item.candidate === measuredElection.winnerCandidate);
+
+    return {
+        artifacts: {
+            candidateReceipts: receipts.map(item => ({
+                archiveByteDigest: digestProviderLaneValue({archive: item.candidate}),
+                candidate        : item.candidate,
+                digest           : item.compositionReceiptDigest,
+                file             : `composition-candidate-${item.candidate}.json`
+            })),
+            evidenceDigest: failAll ? digestProviderLaneValue({
+                candidateReceiptDigests: receipts.map(item => item.compositionReceiptDigest),
+                evidence,
+                projectName,
+                repositoryHead         : REVISION
+            }) : evidenceDigest,
+            planDigest    : measuredElection.planCoordinates.planDigest,
+            workloadDigest: workload.digest
+        },
+        authority: {
+            authoritative: true,
+            evidenceClass: 'canonical-disposable-plane',
+            reason       : 'complete validated matrix on a run-owned disposable Compose project'
+        },
+        candidateReceipts    : receipts,
+        deploymentInputs     : selected ? structuredClone(selected.receipt.deploymentInputs) : null,
+        election             : measuredElection,
+        evidence,
+        projectName,
+        repositoryHead       : REVISION,
+        schemaVersion        : PROVIDER_LANE_ELECTION_REPORT_SCHEMA_VERSION,
+        selectedReceipt      : selected ? structuredClone(selected.receipt) : null,
+        selectedReceiptDigest: selected?.compositionReceiptDigest ?? null,
+        status               : selected ? 'ELECTED' : 'NO_ELECTION'
+    }
+}
+
+/**
+ * @summary Builds exact supported and over-limit receipts for one candidate.
+ */
+function buildReportContextEvidence(entry) {
+    const startedAtMs   = entry.candidate * 1000,
+          completedAtMs = startedAtMs + 500,
+          probe         = (laneName, mode) => {
+              const lane      = entry.receipt.lanes[laneName],
+                    supported = mode === 'supported';
+
+              return {
+                  completedAtMs       : completedAtMs - (supported ? 110 : 10),
+                  id                  : `${entry.candidate}:${laneName}:${mode}`,
+                  modelDigest         : lane.model.digest,
+                  observedOutputTokens: supported ? 1 : 0,
+                  protocolAdapter     : laneName === 'chat'
+                      ? 'ollama-chat-v0.32.9'
+                      : 'llama-cpp-openai-embeddings-b10380',
+                  requestedContextTokens: supported
+                      ? lane.contextTokensPerSlotRequired
+                      : lane.contextTokensPerSlotRequired + 1,
+                  responseBodyDigest: digestProviderLaneValue({candidate: entry.candidate, laneName, mode}),
+                  responseClass     : supported ? 'completed' : 'context-limit-refusal',
+                  serviceKey        : lane.serviceKey,
+                  startedAtMs       : supported ? startedAtMs + 10 : completedAtMs - 100,
+                  transportStatus   : supported ? 200 : 400
+              }
+          };
+
+    return {
+        candidate               : entry.candidate,
+        completedAtMs,
+        compositionReceiptDigest: entry.compositionReceiptDigest,
+        lanes                   : {
+            chat: {
+                observedContextTokensPerSlot: 131072,
+                overLimitProbe              : probe('chat', 'over-limit')
+            },
+            embedding: {
+                observedContextTokensPerSlot: 8192,
+                overLimitProbe              : probe('embedding', 'over-limit'),
+                supportedLimitProbe         : probe('embedding', 'supported')
+            }
+        },
+        startedAtMs
+    }
+}
+
+/**
+ * @summary Builds one chronological production-source trial for report-validator falsifiers.
+ */
+function buildReportTrial({plan, slot}) {
+    const startedAtMs   = 10_000 + slot.executionIndex * 10_000,
+          completedAtMs = startedAtMs + 5000,
+          profile       = plan.candidateProfiles.find(item => item.embeddingSlots === slot.candidate),
+          operation     = ({completedOffset, id, laneName, source, startedOffset}) => ({
+              callId             : `${slot.id}:${id}`,
+              completedAtMs      : startedAtMs + completedOffset,
+              enqueuedAtMs       : startedAtMs + 100,
+              id                 : `${slot.id}:${laneName}:${id}`,
+              outcome            : 'completed',
+              providerStartedAtMs: startedAtMs + startedOffset,
+              queueDisposition   : 'queued',
+              source
+          }),
+          chatOperations = [
+              operation({completedOffset: 1000, id: 'chat-0', laneName: 'chat', source: 'chat', startedOffset: 200}),
+              operation({completedOffset: 2000, id: 'chat-1', laneName: 'chat', source: 'chat', startedOffset: 1200})
+          ],
+          starts = {
+              1: [200, 1000, 1800, 2600],
+              2: [200, 200, 1200, 1200],
+              4: [200, 200, 200, 1200]
+          }[slot.candidate],
+          embeddingSources = ['knowledge-base', 'memory-core', 'orchestrator', 'orchestrator'],
+          embeddingOperations = embeddingSources.map((source, index) => operation({
+              completedOffset: starts[index] + 600,
+              id             : `${source}-${index}`,
+              laneName       : 'embedding',
+              source,
+              startedOffset  : starts[index]
+          })),
+          lane = (laneName, operations) => ({
+              operations,
+              resourceSamples: Array.from({length: 6}, (_, index) => ({
+                  atMs      : startedAtMs + index * 1000,
+                  cpuPercent: laneName === 'chat' ? 100 : 150,
+                  rssBytes  : laneName === 'chat' ? 2_000_000_000 : 3_000_000_000
+              })),
+              runtimeProfile: Object.fromEntries([
+                  'cpuCores', 'imageDigest', 'memoryBytes', 'modelDigest', 'parallelism', 'serviceKey'
+              ].map(field => [field, profile.lanes[laneName][field]])),
+              sourceCalls   : operations.map(row => ({
+                  completedAtMs: row.completedAtMs + 100,
+                  demandAtMs   : startedAtMs + 100,
+                  id           : row.callId,
+                  outcome      : 'completed',
+                  source       : row.source
+              }))
+          });
+
+    return {
+        candidate               : slot.candidate,
+        completedAtMs,
+        compositionReceiptDigest: profile.compositionReceiptDigest,
+        executionIndex          : slot.executionIndex,
+        lanes                   : {
+            chat     : lane('chat', chatOperations),
+            embedding: lane('embedding', embeddingOperations)
+        },
+        residencyBefore: {
+            lanes: {
+                chat     : {modelDigest: profile.lanes.chat.modelDigest, resident: true},
+                embedding: {modelDigest: profile.lanes.embedding.modelDigest, resident: true}
+            },
+            observedAtMs: startedAtMs - 1
+        },
+        scheduleId    : slot.id,
+        startedAtMs,
+        workloadDigest: plan.workload.digest
+    }
+}
+
 test.describe('provider-lane election runner authority seams', () => {
     test('consumes exact canonical deployment envelopes for candidates 1, 2, and 4', () => {
         const receipts = [1, 2, 4].map(buildReceipt),
@@ -223,6 +443,16 @@ test.describe('provider-lane election runner authority seams', () => {
         }).responseClass).toBe('provider-error');
         expect(classifyProviderLaneProbeResponse({
             adapter,
+            body  : '{"error":{"type":"server_error","message":"input (32769 tokens) is too large to process. increase the physical batch size (current batch size: 32768)"}}',
+            status: 500
+        }).responseClass).toBe('physical-batch-refusal');
+        expect(classifyProviderLaneProbeResponse({
+            adapter,
+            body  : '{"error":{"type":"server_error","message":"unrelated server failure"}}',
+            status: 500
+        }).responseClass).toBe('provider-error');
+        expect(classifyProviderLaneProbeResponse({
+            adapter,
             body  : '{"data":[{"embedding":[0]}]}',
             status: 200
         })).toMatchObject({responseClass: 'completed', observedOutputTokens: 1});
@@ -243,16 +473,32 @@ test.describe('provider-lane election runner authority seams', () => {
               adapter = resolveProviderLaneAdapters(receipt).embedding,
               lane    = receipt.lanes.embedding;
 
-        expect(createProviderLaneOverLimitRequest({
-            adapter,
-            lane,
-            observedContextTokensPerSlot: 8192
-        })).toMatchObject({requestedContextTokens: 8193});
+        const supportedMinimum = createProviderLaneSupportedLimitRequest({
+                  adapter,
+                  lane,
+                  observedContextTokensPerSlot: 8192
+              }),
+              overLimit        = createProviderLaneOverLimitRequest({
+                  adapter,
+                  lane,
+                  observedContextTokensPerSlot: 8192
+              });
+
+        expect(supportedMinimum.requestedContextTokens).toBe(8192);
+        expect(JSON.parse(supportedMinimum.body).input).toHaveLength(8192);
+        expect(overLimit.requestedContextTokens).toBe(8193);
+        expect(JSON.parse(overLimit.body).input).toHaveLength(8193);
         expect(() => createProviderLaneOverLimitRequest({
             adapter,
             lane,
             observedContextTokensPerSlot: lane.model.contextTokensMax + 1
         })).toThrow(/unbounded runtime context/)
+
+        expect(() => createProviderLaneSupportedLimitRequest({
+            adapter,
+            lane,
+            observedContextTokensPerSlot: 8193
+        })).toThrow(/exceeds declared batch authority/)
     });
 
     test('builds the Ollama over-limit probe with truncation and shifting disabled', () => {
@@ -502,6 +748,51 @@ test.describe('provider-lane election runner authority seams', () => {
         })
     });
 
+    test('recomputes the public handoff and rejects self-attested election authority', () => {
+        const report = buildElectionReport();
+
+        expect(validateProviderLaneElectionReport(report)).toEqual(report);
+        expect(report.selectedReceipt).toEqual(report.candidateReceipts[0].receipt);
+        expect(report.selectedReceiptDigest).toBe(report.candidateReceipts[0].compositionReceiptDigest);
+
+        const forgedWinner = structuredClone(report);
+        forgedWinner.election.winnerCandidate = 2;
+        forgedWinner.selectedReceipt = structuredClone(forgedWinner.candidateReceipts[1].receipt);
+        forgedWinner.selectedReceiptDigest = forgedWinner.candidateReceipts[1].compositionReceiptDigest;
+        forgedWinner.deploymentInputs = structuredClone(forgedWinner.selectedReceipt.deploymentInputs);
+        expect(() => validateProviderLaneElectionReport(forgedWinner)).toThrow(/does not reproduce/);
+
+        const reducedSelection = structuredClone(report);
+        delete reducedSelection.selectedReceipt.roles;
+        expect(() => validateProviderLaneElectionReport(reducedSelection)).toThrow(/smallest PASS/);
+
+        const digestDrift = structuredClone(report);
+        digestDrift.candidateReceipts[0].compositionReceiptDigest = `sha256:${'f'.repeat(64)}`;
+        expect(() => validateProviderLaneElectionReport(digestDrift)).toThrow(/drifted candidate receipt/);
+
+        const receiptExtra = structuredClone(report);
+        receiptExtra.candidateReceipts[0].receipt.token = 'SECRET';
+        receiptExtra.candidateReceipts[0].compositionReceiptDigest =
+            digestProviderLaneValue(receiptExtra.candidateReceipts[0].receipt);
+        expect(() => validateProviderLaneElectionReport(receiptExtra)).toThrow(/canonical validation/);
+
+        const unknownField = structuredClone(report);
+        unknownField.evidence.trials[0].lanes.embedding.operations[0].token = 'SECRET';
+        expect(() => validateProviderLaneElectionReport(unknownField)).toThrow(/requires exact fields/);
+
+        const forgedAuthority = structuredClone(report);
+        forgedAuthority.authority.authoritative = false;
+        expect(() => validateProviderLaneElectionReport(forgedAuthority)).toThrow(/forged authority/);
+
+        const noElection = buildElectionReport({failAll: true});
+        expect(() => validateProviderLaneElectionReport(noElection)).toThrow(/requires an elected report/);
+        expect(validateProviderLaneElectionReport(noElection, {requireElected: false}).status).toBe('NO_ELECTION');
+
+        const extra = structuredClone(report);
+        extra.selfAttested = true;
+        expect(() => validateProviderLaneElectionReport(extra)).toThrow(/requires exact fields/)
+    });
+
     test('publishes only the winning archived deployment inputs and never falls back', () => {
         const receipts = [1, 2, 4].map(candidate => {
             const receipt = buildReceipt(candidate);
@@ -525,9 +816,8 @@ test.describe('provider-lane election runner authority seams', () => {
 
         expect(report.status).toBe('ELECTED');
         expect(report.deploymentInputs).toEqual(receipts[1].receipt.deploymentInputs);
-        expect(report.selectedComposition).toMatchObject({
-            candidate: 2,
-            lanes    : {
+        expect(report.selectedReceipt).toMatchObject({
+            lanes: {
                 chat: {
                     image: {digest: receipts[1].receipt.lanes.chat.image.digest},
                     model: {coordinate: receipts[1].receipt.lanes.chat.model.coordinate}
@@ -539,6 +829,7 @@ test.describe('provider-lane election runner authority seams', () => {
             },
             roles: receipts[1].receipt.roles
         });
+        expect(report.selectedReceiptDigest).toBe(receipts[1].compositionReceiptDigest);
 
         const noElection = projectProviderLaneOutcome({
             election: {
@@ -549,7 +840,8 @@ test.describe('provider-lane election runner authority seams', () => {
         });
         expect(noElection.status).toBe('NO_ELECTION');
         expect(noElection.deploymentInputs).toBeNull();
-        expect(noElection.selectedComposition).toBeNull();
+        expect(noElection.selectedReceipt).toBeNull();
+        expect(noElection.selectedReceiptDigest).toBeNull();
 
         expect(() => projectProviderLaneOutcome({
             election: {
@@ -560,12 +852,15 @@ test.describe('provider-lane election runner authority seams', () => {
         })).toThrow(/incoherent measured winner/);
 
         expect(createIncompleteProviderLaneReport({code: 'EVIDENCE_GAP'})).toMatchObject({
-            status             : 'INCOMPLETE',
-            deploymentInputs   : null,
-            repositoryHead     : null,
-            selectedComposition: null,
-            authority          : {authoritative: false}
+            status          : 'INCOMPLETE',
+            deploymentInputs: null,
+            repositoryHead  : null,
+            selectedReceipt : null,
+            authority       : {authoritative: false}
         });
+
+        expect(() => validateProviderLaneElectionReport(createIncompleteProviderLaneReport()))
+            .toThrow(/no complete canonical controller identity/);
 
         const requestedHead = 'a'.repeat(40),
               measuredHead  = 'b'.repeat(40),

--- a/test/playwright/unit/ai/scripts/benchmark/ProviderLaneElectionRunner.spec.mjs
+++ b/test/playwright/unit/ai/scripts/benchmark/ProviderLaneElectionRunner.spec.mjs
@@ -1,0 +1,579 @@
+import {test, expect}     from '@playwright/test';
+import {EventEmitter}     from 'node:events';
+import fs                 from 'node:fs';
+import path               from 'node:path';
+import {load as loadYaml} from 'js-yaml';
+
+import {
+    analyzeProviderLaneComposition,
+    validateProviderLaneCompositionReceipt
+} from '../../../../../../ai/scripts/diagnostics/providerLaneComposition.mjs';
+import {
+    calculateProviderLaneDockerCpuPercent,
+    classifyProviderLaneOperationResult,
+    classifyProviderLaneProbeResponse,
+    completeProviderLaneCleanup,
+    createIncompleteProviderLaneReport,
+    createProviderLaneCleanup,
+    createProviderLaneCandidateProfile,
+    createProviderLaneOverLimitRequest,
+    digestProviderLaneValue,
+    installProviderLaneSignalHandlers,
+    invokeProviderLaneEmbeddingSource,
+    normalizeProviderLaneWorkerOperations,
+    parseProviderLaneDockerEndpoint,
+    parseProviderLaneDockerTopRss,
+    projectProviderLaneOutcome,
+    readBoundedProviderLaneResponseBody,
+    resolveProviderLaneDockerAuthority,
+    resolveProviderLaneAdapters,
+    validateProviderLaneRunPlan
+} from '../../../../../../ai/scripts/benchmark/provider-lane-election.mjs';
+
+const
+    repoRoot    = path.resolve(process.cwd()),
+    profilePath = path.join(repoRoot, 'ai/deploy/docker-compose.provider-lanes.yml'),
+    REVISION    = '1'.repeat(40);
+
+function buildComposition(candidate) {
+    const environment = {
+        NEO_PROVIDER_LANES_CPU_TOTAL                                : '4',
+        NEO_PROVIDER_LANES_MEMORY_BYTES_TOTAL                       : '51539607552',
+        NEO_PROVIDER_LANE_CHAT_CPUS                                 : '2',
+        NEO_PROVIDER_LANE_CHAT_MEMORY_BYTES                         : '34359738368',
+        NEO_PROVIDER_LANE_CHAT_CONTEXT_TOKENS                       : '131072',
+        NEO_PROVIDER_LANE_EMBEDDING_CPUS                            : '2',
+        NEO_PROVIDER_LANE_EMBEDDING_MEMORY_BYTES                    : '17179869184',
+        NEO_PROVIDER_LANE_EMBEDDING_SLOTS                           : String(candidate),
+        NEO_PROVIDER_LANE_EMBEDDING_TOTAL_CONTEXT_TOKENS            : String(candidate * 8192),
+        NEO_PROVIDER_LANE_EMBEDDING_CONTEXT_TOKENS_PER_SLOT_REQUIRED: '8192'
+    };
+    const source = fs.readFileSync(profilePath, 'utf8').replace(
+        /\$\{([A-Z0-9_]+):\?[^}]+}/g,
+        (match, name) => {
+            if (!Object.hasOwn(environment, name)) throw new Error(`missing fixture env ${name}`);
+            return environment[name]
+        }
+    );
+    const composition = {name: 'neo-provider-lane-election-test', ...loadYaml(source)},
+          shared      = composition['x-provider-lane-env'];
+
+    for (const serviceKey of ['kb-server', 'mc-server', 'orchestrator']) {
+        composition.services[serviceKey].environment = {
+            ...shared,
+            ...composition.services[serviceKey].environment
+        }
+    }
+
+    return composition
+}
+
+function buildReceipt(candidate) {
+    const receipt = analyzeProviderLaneComposition(buildComposition(candidate));
+
+    expect(receipt.ready, JSON.stringify(receipt.errors, null, 2)).toBe(true);
+    return receipt
+}
+
+function buildRunPlan(receipts = [1, 2, 4].map(buildReceipt)) {
+    return {
+        blocks                   : 1,
+        candidateDeploymentInputs: receipts.map((receipt, index) => ({
+            candidate       : [1, 2, 4][index],
+            deploymentInputs: structuredClone(receipt.deploymentInputs)
+        })),
+        contextProbeTimeoutMs: 300_000,
+        resourceSampling     : {activeCpuThreshold: 1, expectedIntervalMs: 1000, gapFactor: 2},
+        revision             : REVISION,
+        schemaVersion        : 'provider-lane-election-plan.v1',
+        slo                  : {
+            lanes: {
+                chat     : buildLaneSlo({context: 131072, cpu: 200, memory: 34359738368, operations: 2}),
+                embedding: buildLaneSlo({context: 8192, cpu: 200, memory: 17179869184, operations: 4})
+            }
+        },
+        trialTimeoutMs: 900_000
+    }
+}
+
+function buildLaneSlo({context, cpu, memory, operations}) {
+    return {
+        maxCpuHighWaterPercent  : cpu,
+        maxErrors               : 0,
+        maxNeoQueueWaitMs       : 60_000,
+        maxProgressGapMs        : 300_000,
+        maxProviderDurationMs   : 300_000,
+        maxResourceGapCount     : 0,
+        maxRssHighWaterBytes    : memory,
+        maxUnexpectedRefusals   : 0,
+        minCompletedOperations  : operations,
+        minContextTokensPerSlot : context,
+        minResourceCoverageRatio: 0.9,
+        minThroughputPerSecond  : 0.001,
+        requiredQueueDisposition: 'queued'
+    }
+}
+
+function buildWorkerReceipt(source, receipt) {
+    const contract = {
+        chat: {
+            callKind: 'chat-queue', operationCounts: [1, 1], outputCounts: [1, 1], priority: 'interactive', role: 'chat', service: 'knowledge-base', stage: 'kb-ask-synthesis'
+        },
+        'knowledge-base': {
+            callKind: 'interactive-single', operationCounts: [1], outputCounts: [1], priority: 'interactive', role: 'embedding', service: 'knowledge-base', stage: 'kb-query-embedding'
+        },
+        'memory-core': {
+            callKind: 'batch-array', operationCounts: [4], outputCounts: [20], priority: 'batch', role: 'embedding', service: 'memory-core', stage: 'mc-wal-drain-embedding'
+        },
+        orchestrator: {
+            callKind: 'batch-array', operationCounts: [2, 2], outputCounts: [8, 8], priority: 'batch', role: 'embedding', service: 'orchestrator', stage: 'unknown'
+        }
+    }[source];
+    const lane           = receipt.lanes[source === 'chat' ? 'chat' : 'embedding'];
+    let   operationIndex = 0;
+    const operations     = contract.operationCounts.flatMap((count, callIndex) => Array.from({length: count}, () => {
+        const index = operationIndex++;
+
+        return {
+            callId             : `${source}-${callIndex}`,
+            completedAtMs      : 2000 + index,
+            enqueuedAtMs       : 1000 + index,
+            failureStage       : null,
+            id                 : `${source}-activity-${index}`,
+            model              : lane.model.id,
+            operationStage     : contract.stage,
+            outcome            : 'completed',
+            priority           : contract.priority,
+            provider           : lane.provider,
+            providerStartedAtMs: 1500 + index,
+            queueDisposition   : 'neo-queued',
+            role               : contract.role,
+            service            : contract.service
+        }
+    }));
+
+    return {
+        callKind: contract.callKind,
+        operations,
+        results : contract.outputCounts.map((outputCount, index) => ({
+            callId       : `${source}-${index}`,
+            completedAtMs: Math.max(...operations.filter(row => row.callId === `${source}-${index}`)
+                .map(row => row.completedAtMs)) + 100,
+            demandAtMs: 900 + index,
+            outcome   : 'completed',
+            outputCount
+        })),
+        schemaVersion: 'provider-lane-election-worker.v1',
+        source
+    }
+}
+
+test.describe('provider-lane election runner authority seams', () => {
+    test('consumes exact canonical deployment envelopes for candidates 1, 2, and 4', () => {
+        const receipts = [1, 2, 4].map(buildReceipt),
+              plan     = validateProviderLaneRunPlan(buildRunPlan(receipts));
+
+        expect(plan.candidateDeploymentInputs.map(row => row.candidate)).toEqual([1, 2, 4]);
+        expect(plan.candidateDeploymentInputs[1].deploymentInputs.embeddingParallelSlots).toEqual({
+            env  : 'NEO_PROVIDER_LANE_EMBEDDING_SLOTS',
+            value: 2
+        });
+
+        const wrongEnv = buildRunPlan(receipts);
+        wrongEnv.candidateDeploymentInputs[0].deploymentInputs.embeddingParallelSlots.env = 'NEO_FOREIGN_SLOTS';
+        expect(() => validateProviderLaneRunPlan(wrongEnv)).toThrow(/invalid canonical deployment input/)
+    });
+
+    test('selects adapters by exact provider, endpoint, model, and image tuple', () => {
+        const receipt = buildReceipt(1);
+
+        expect(resolveProviderLaneAdapters(receipt)).toMatchObject({
+            chat     : {id: 'ollama-chat-v0.32.9'},
+            embedding: {id: 'llama-cpp-openai-embeddings-b10380'}
+        });
+
+        const alternateImage = structuredClone(receipt);
+        alternateImage.lanes.chat.image.digest = `sha256:${'9'.repeat(64)}`;
+        expect(validateProviderLaneCompositionReceipt(alternateImage).valid).toBe(true);
+        expect(() => resolveProviderLaneAdapters(alternateImage)).toThrow(/closed exact-image adapter/);
+
+        const external = structuredClone(receipt);
+        external.lanes.embedding.endpoints.workload.url = 'https://external.example/v1/embeddings';
+        expect(() => resolveProviderLaneAdapters(external)).toThrow(/canonical validation/)
+    });
+
+    test('normalizes only exact context refusal codes and statuses from raw provider bodies', () => {
+        const adapters = resolveProviderLaneAdapters(buildReceipt(1)),
+              adapter  = adapters.embedding;
+
+        expect(classifyProviderLaneProbeResponse({
+            adapter,
+            body  : '{"error":{"type":"exceed_context_size_error"}}',
+            status: 400
+        })).toMatchObject({responseClass: 'context-limit-refusal', observedOutputTokens: 0});
+        expect(classifyProviderLaneProbeResponse({
+            adapter,
+            body  : '{"error":{"type":"exceed_context_size_error"}}',
+            status: 429
+        }).responseClass).toBe('provider-error');
+        expect(classifyProviderLaneProbeResponse({
+            adapter,
+            body  : '{"error":{"type":"internal_error"}}',
+            status: 500
+        }).responseClass).toBe('provider-error');
+        expect(classifyProviderLaneProbeResponse({
+            adapter,
+            body  : '{"data":[{"embedding":[0]}]}',
+            status: 200
+        })).toMatchObject({responseClass: 'completed', observedOutputTokens: 1});
+        expect(classifyProviderLaneProbeResponse({
+            adapter: adapters.chat,
+            body   : '{"error":"the prompt is longer than the context length currently available to the model; shorten the prompt, adjust the context length in settings, or use a model with a longer context length"}',
+            status : 400
+        })).toMatchObject({responseClass: 'context-limit-refusal', observedOutputTokens: 0});
+        expect(classifyProviderLaneProbeResponse({
+            adapter: adapters.chat,
+            body   : '{"error":"rate limited"}',
+            status : 429
+        }).responseClass).toBe('provider-error')
+    });
+
+    test('bounds over-limit request allocation by the exact receipt model ceiling', () => {
+        const receipt = buildReceipt(1),
+              adapter = resolveProviderLaneAdapters(receipt).embedding,
+              lane    = receipt.lanes.embedding;
+
+        expect(createProviderLaneOverLimitRequest({
+            adapter,
+            lane,
+            observedContextTokensPerSlot: 8192
+        })).toMatchObject({requestedContextTokens: 8193});
+        expect(() => createProviderLaneOverLimitRequest({
+            adapter,
+            lane,
+            observedContextTokensPerSlot: lane.model.contextTokensMax + 1
+        })).toThrow(/unbounded runtime context/)
+    });
+
+    test('builds the Ollama over-limit probe with truncation and shifting disabled', () => {
+        const receipt = buildReceipt(1),
+              request = createProviderLaneOverLimitRequest({
+                  adapter                     : resolveProviderLaneAdapters(receipt).chat,
+                  lane                        : receipt.lanes.chat,
+                  observedContextTokensPerSlot: 131072
+              }),
+              body = JSON.parse(request.body);
+
+        expect(body).toMatchObject({shift: false, stream: false, truncate: false});
+        expect(request.requestedContextTokens).toBe(131073)
+    });
+
+    test('derives zero CPU and aggregate process RSS from raw Docker receipts', () => {
+        const idleStats = {
+            cpu_stats   : {cpu_usage: {total_usage: 100}, system_cpu_usage: 1000},
+            precpu_stats: {cpu_usage: {total_usage: 100}, system_cpu_usage: 900}
+        };
+
+        expect(calculateProviderLaneDockerCpuPercent(idleStats, () => null)).toBe(0);
+        expect(parseProviderLaneDockerTopRss({
+            Titles   : ['PID', 'RSS'],
+            Processes: [['793773', '279664'], ['1141586', '367664']]
+        })).toBe((279664 + 367664) * 1024);
+        expect(() => parseProviderLaneDockerTopRss({Titles: ['PID'], Processes: [['1']]}))
+            .toThrow(/requires PID and RSS/);
+        expect(() => parseProviderLaneDockerTopRss({Titles: ['PID', 'RSS'], Processes: []}))
+            .toThrow(/requires PID and RSS/)
+    });
+
+    test('pins one canonical local Unix Docker authority before mutation', async () => {
+        expect(parseProviderLaneDockerEndpoint('unix:///Users/operator/.colima/default/docker.sock'))
+            .toBe('/Users/operator/.colima/default/docker.sock');
+
+        const metadata  = {isSocket: () => true},
+              authority = await resolveProviderLaneDockerAuthority({
+                  inspectEndpoint: async () => 'unix:///tmp/provider-lane.sock',
+                  realpathFn     : async value => `${value}.canonical`,
+                  statFn         : async () => metadata
+              });
+
+        expect(authority).toEqual({
+            endpoint  : 'unix:///tmp/provider-lane.sock.canonical',
+            socketPath: '/tmp/provider-lane.sock.canonical'
+        });
+        expect(Object.isFrozen(authority)).toBe(true);
+
+        for (const endpoint of [
+            'tcp://127.0.0.1:2375',
+            'ssh://operator@example.test',
+            'unix://remote.example/tmp/docker.sock',
+            'unix:relative.sock'
+        ]) {
+            expect(() => parseProviderLaneDockerEndpoint(endpoint)).toThrow(/local Unix Docker endpoint/)
+        }
+
+        await expect(resolveProviderLaneDockerAuthority({
+            inspectEndpoint: async () => 'unix:///tmp/not-a-socket',
+            realpathFn     : async value => value,
+            statFn         : async () => ({isSocket: () => false})
+        })).rejects.toMatchObject({code: 'DOCKER_ENDPOINT_NOT_LOCAL_UNIX'})
+    });
+
+    test('stream-bounds provider responses before retaining oversized evidence', async () => {
+        await expect(readBoundedProviderLaneResponseBody(new Response('bounded'))).resolves.toBe('bounded');
+
+        const oversized = new Response(new ReadableStream({
+            start(controller) {
+                controller.enqueue(new Uint8Array(700_000));
+                controller.enqueue(new Uint8Array(400_000));
+                controller.close()
+            }
+        }));
+
+        await expect(readBoundedProviderLaneResponseBody(oversized)).rejects.toMatchObject({
+            code: 'PROVIDER_RESPONSE_TOO_LARGE'
+        })
+    });
+
+    test('retains signal ownership through one idempotent teardown and refuses success after interruption', async () => {
+        const processTarget = new EventEmitter(),
+              controller    = new AbortController();
+        let   teardownCount = 0,
+              releaseTeardown;
+        const cleanup = createProviderLaneCleanup({
+                  teardown: async () => {
+                      teardownCount++;
+                      await new Promise(resolve => {releaseTeardown = resolve})
+                  }
+              }),
+              dispose  = installProviderLaneSignalHandlers({cleanup, controller, processTarget}),
+              terminal = completeProviderLaneCleanup({cleanup, controller, dispose});
+
+        await new Promise(resolve => setImmediate(resolve));
+        expect(processTarget.listenerCount('SIGINT')).toBe(1);
+        expect(processTarget.listenerCount('SIGTERM')).toBe(1);
+
+        processTarget.emit('SIGTERM');
+        releaseTeardown();
+
+        await expect(terminal).rejects.toMatchObject({code: 'PROVIDER_LANE_INTERRUPTED'});
+        expect(controller.signal.aborted).toBe(true);
+        expect(controller.signal.reason).toMatchObject({code: 'PROVIDER_LANE_INTERRUPTED'});
+        expect(teardownCount).toBe(1);
+        expect(processTarget.listenerCount('SIGINT')).toBe(0);
+        expect(processTarget.listenerCount('SIGTERM')).toBe(0)
+    });
+
+    test('builds a pure profile only from validated receipt coordinates and its archive digest', () => {
+        const receipt = buildReceipt(2),
+              digest  = digestProviderLaneValue(receipt),
+              profile = createProviderLaneCandidateProfile({compositionReceiptDigest: digest, receipt});
+
+        expect(profile).toMatchObject({
+            compositionReceiptDigest: digest,
+            embeddingSlots          : 2,
+            lanes                   : {
+                chat     : {parallelism: 1, protocolAdapter: 'ollama-chat-v0.32.9'},
+                embedding: {parallelism: 2, protocolAdapter: 'llama-cpp-openai-embeddings-b10380'}
+            }
+        });
+        expect(profile.deploymentInputs).toBeUndefined()
+    });
+
+    test('binds worker identities to controller-selected sources instead of trusting labels', () => {
+        const receipt      = buildReceipt(2),
+              receiptEntry = {receipt},
+              workers      = ['chat', 'knowledge-base', 'memory-core', 'orchestrator']
+                  .map(source => ({expectedSource: source, receipt: buildWorkerReceipt(source, receipt)})),
+              normalized   = normalizeProviderLaneWorkerOperations({receiptEntry, workerReceipts: workers});
+
+        expect(normalized.chat.operations).toHaveLength(2);
+        expect(normalized.chat.sourceCalls).toHaveLength(2);
+        expect(normalized.embedding.operations.map(row => row.source)).toEqual([
+            'knowledge-base',
+            'memory-core', 'memory-core', 'memory-core', 'memory-core',
+            'orchestrator', 'orchestrator', 'orchestrator', 'orchestrator'
+        ]);
+        expect(normalized.embedding.sourceCalls.map(row => row.source)).toEqual([
+            'knowledge-base', 'memory-core', 'orchestrator', 'orchestrator'
+        ]);
+        expect(workers[2].receipt.operations.map(row => row.callId)).toEqual([
+            'memory-core-0', 'memory-core-0', 'memory-core-0', 'memory-core-0'
+        ]);
+        expect(workers[3].receipt.operations.map(row => row.callId)).toEqual([
+            'orchestrator-0', 'orchestrator-0', 'orchestrator-1', 'orchestrator-1'
+        ]);
+
+        workers[0].receipt.results[0] = {
+            callId       : 'chat-0',
+            completedAtMs: 2100,
+            demandAtMs   : 900,
+            outcome      : 'error',
+            outputCount  : 0
+        };
+        expect(normalizeProviderLaneWorkerOperations({receiptEntry, workerReceipts: workers}).chat.sourceCalls[0].outcome)
+            .toBe('error');
+        workers[0].receipt = buildWorkerReceipt('chat', receipt);
+
+        workers[1].receipt.operations[0].service = 'orchestrator';
+        expect(() => normalizeProviderLaneWorkerOperations({receiptEntry, workerReceipts: workers}))
+            .toThrow(/cannot be bound to its exact lane/)
+
+        workers[1].receipt = buildWorkerReceipt('orchestrator', receipt);
+        expect(() => normalizeProviderLaneWorkerOperations({receiptEntry, workerReceipts: workers}))
+            .toThrow(/invalid receipt/);
+
+        workers[1].receipt = buildWorkerReceipt('knowledge-base', receipt);
+        workers[1].receipt.results[0].callId = 'foreign-operation';
+        expect(() => normalizeProviderLaneWorkerOperations({receiptEntry, workerReceipts: workers}))
+            .toThrow(/cannot be bound to its source call/)
+
+        workers[1].receipt = buildWorkerReceipt('knowledge-base', receipt);
+        workers[2].receipt.operations[3].callId = 'memory-core-1';
+        expect(() => normalizeProviderLaneWorkerOperations({receiptEntry, workerReceipts: workers}))
+            .toThrow(/cannot be bound to its exact lane/)
+    });
+
+    test('uses production-shaped interactive and true batch scheduler seams', async () => {
+        const calls            = [],
+              embeddingService = {
+                  embedText(text, provider, options) {
+                      calls.push({kind: 'interactive-single', options, provider, texts: [text]});
+                      return Promise.resolve('interactive')
+                  },
+                  embedTexts(texts, provider, options) {
+                      calls.push({kind: 'batch-array', options, provider, texts});
+                      return Promise.resolve(texts.map(() => [0]))
+                  }
+              };
+
+        await invokeProviderLaneEmbeddingSource({
+            embeddingService, options: {stage: 'kb'}, payload: 'kb', provider: 'openAiCompatible', source: 'knowledge-base'
+        });
+        await invokeProviderLaneEmbeddingSource({
+            embeddingService, options: {stage: 'mc'}, payload: ['mc-1', 'mc-2'], provider: 'openAiCompatible', source: 'memory-core'
+        });
+        await invokeProviderLaneEmbeddingSource({
+            embeddingService, options: {stage: 'oc'}, payload: ['oc-1', 'oc-2'], provider: 'openAiCompatible', source: 'orchestrator'
+        });
+
+        expect(calls.map(call => call.kind)).toEqual([
+            'interactive-single', 'batch-array', 'batch-array'
+        ]);
+        expect(calls.map(call => call.texts)).toEqual([['kb'], ['mc-1', 'mc-2'], ['oc-1', 'oc-2']]);
+        expect(() => invokeProviderLaneEmbeddingSource({
+            embeddingService, options: {}, payload: ['singleton'], provider: 'openAiCompatible', source: 'memory-core'
+        })).toThrow(/multiple strings/);
+        expect(() => invokeProviderLaneEmbeddingSource({
+            embeddingService, options: {}, payload: 'wrong-lane', provider: 'openAiCompatible', source: 'chat'
+        })).toThrow(/no closed scheduler contract/)
+    });
+
+    test('classifies caller-visible provider output rather than lifecycle status alone', () => {
+        expect(classifyProviderLaneOperationResult({status: 'fulfilled', value: undefined}, {
+            expectedOutputCount: 1,
+            kind               : 'embedding'
+        })).toBe('error');
+        expect(classifyProviderLaneOperationResult({status: 'fulfilled', value: [[0, 1], [2, 3]]}, {
+            expectedOutputCount: 2,
+            kind               : 'embedding'
+        })).toBe('completed');
+        expect(classifyProviderLaneOperationResult({
+            reason: new Error('OpenAI-Compatible API error: 413 payload refused'),
+            status: 'rejected'
+        }, {expectedOutputCount: 1, kind: 'embedding'})).toBe('unexpected-refusal')
+    });
+
+    test('keeps the benchmark worker free of host binds, sockets, secrets, and public ports', () => {
+        const worker     = buildComposition(1).services['provider-lane-worker'],
+              serialized = JSON.stringify(worker);
+
+        expect(worker.profiles).toEqual(['provider-lane-election']);
+        expect(worker.volumes).toEqual([]);
+        expect(worker.networks).toEqual(['neo-mcp-network']);
+        expect(worker.ports).toBeUndefined();
+        expect(worker.secrets).toBeUndefined();
+        expect(serialized).not.toContain('/var/run/docker.sock');
+        expect(serialized).not.toContain('.neo-ai/backups');
+        expect(worker.environment).toMatchObject({
+            GEMINI_API_KEY                                  : '',
+            NEO_KB_ASK_API_KEY                              : '',
+            NEO_OPENAI_COMPATIBLE_API_KEY                   : '',
+            NEO_OPENAI_COMPATIBLE_BATCH_EMBEDDING_CHUNK_SIZE: '5'
+        })
+    });
+
+    test('publishes only the winning archived deployment inputs and never falls back', () => {
+        const receipts = [1, 2, 4].map(candidate => {
+            const receipt = buildReceipt(candidate);
+            return {
+                candidate,
+                compositionReceiptDigest: digestProviderLaneValue(receipt),
+                receipt
+            }
+        });
+        const report = projectProviderLaneOutcome({
+            election: {
+                candidates: [
+                    {candidate: 1, status: 'FAIL'},
+                    {candidate: 2, status: 'PASS'},
+                    {candidate: 4, status: 'PASS'}
+                ],
+                winnerCandidate: 2
+            },
+            receipts
+        });
+
+        expect(report.status).toBe('ELECTED');
+        expect(report.deploymentInputs).toEqual(receipts[1].receipt.deploymentInputs);
+        expect(report.selectedComposition).toMatchObject({
+            candidate: 2,
+            lanes    : {
+                chat: {
+                    image: {digest: receipts[1].receipt.lanes.chat.image.digest},
+                    model: {coordinate: receipts[1].receipt.lanes.chat.model.coordinate}
+                },
+                embedding: {
+                    endpoints: receipts[1].receipt.lanes.embedding.endpoints,
+                    model    : {digest: receipts[1].receipt.lanes.embedding.model.digest}
+                }
+            },
+            roles: receipts[1].receipt.roles
+        });
+
+        const noElection = projectProviderLaneOutcome({
+            election: {
+                candidates     : [1, 2, 4].map(candidate => ({candidate, status: 'FAIL'})),
+                winnerCandidate: null
+            },
+            receipts
+        });
+        expect(noElection.status).toBe('NO_ELECTION');
+        expect(noElection.deploymentInputs).toBeNull();
+        expect(noElection.selectedComposition).toBeNull();
+
+        expect(() => projectProviderLaneOutcome({
+            election: {
+                candidates     : [{candidate: 1, status: 'PASS'}, {candidate: 2, status: 'PASS'}],
+                winnerCandidate: 2
+            },
+            receipts
+        })).toThrow(/incoherent measured winner/);
+
+        expect(createIncompleteProviderLaneReport({code: 'EVIDENCE_GAP'})).toMatchObject({
+            status             : 'INCOMPLETE',
+            deploymentInputs   : null,
+            repositoryHead     : null,
+            selectedComposition: null,
+            authority          : {authoritative: false}
+        });
+
+        const requestedHead = 'a'.repeat(40),
+              measuredHead  = 'b'.repeat(40),
+              mismatch      = createIncompleteProviderLaneReport({
+                  code: 'REVISION_MISMATCH', measuredHead, projectName: 'neo-provider-lane-test'
+              });
+
+        expect(mismatch.repositoryHead).toBe(measuredHead);
+        expect(mismatch.repositoryHead).not.toBe(requestedHead)
+    })
+});

--- a/test/playwright/unit/ai/scripts/diagnostics/providerLaneComposition.spec.mjs
+++ b/test/playwright/unit/ai/scripts/diagnostics/providerLaneComposition.spec.mjs
@@ -22,7 +22,9 @@ const FIXTURE_ENV = Object.freeze({
     NEO_PROVIDER_LANE_EMBEDDING_MEMORY_BYTES                    : '17179869184',
     NEO_PROVIDER_LANE_EMBEDDING_SLOTS                           : '1',
     NEO_PROVIDER_LANE_EMBEDDING_TOTAL_CONTEXT_TOKENS            : '32768',
-    NEO_PROVIDER_LANE_EMBEDDING_CONTEXT_TOKENS_PER_SLOT_REQUIRED: '32768'
+    NEO_PROVIDER_LANE_EMBEDDING_CONTEXT_TOKENS_PER_SLOT_REQUIRED: '8192',
+    NEO_PROVIDER_LANE_EMBEDDING_BATCH_TOKENS                    : '32768',
+    NEO_PROVIDER_LANE_EMBEDDING_UBATCH_TOKENS                   : '32768'
 });
 
 function renderRequiredInputs(source) {
@@ -215,9 +217,42 @@ test.describe('provider-lane composition receipt (#17021)', () => {
 
         const contextMutation = loadComposition();
         contextMutation['x-provider-lane-contract'].lanes.embedding.slots = 2;
+        contextMutation['x-provider-lane-contract'].lanes.embedding.contextTokensPerSlotRequired = 32768;
         contextMutation.services['embedding-model'].environment.LLAMA_ARG_N_PARALLEL = '2';
         const contextReceipt = analyzeProviderLaneComposition(contextMutation);
         expect(errorCodes(contextReceipt)).toContain('context-allocation')
+    });
+
+    test('the pinned embedding runtime declares logical and physical batch authority', () => {
+        const good = analyzeProviderLaneComposition(loadComposition());
+
+        expect(good.lanes.embedding).toMatchObject({batchTokens: 32768, ubatchTokens: 32768});
+        expect(good.deploymentInputs).toMatchObject({
+            embeddingBatchTokens : {env: 'NEO_PROVIDER_LANE_EMBEDDING_BATCH_TOKENS', value: 32768},
+            embeddingUbatchTokens: {env: 'NEO_PROVIDER_LANE_EMBEDDING_UBATCH_TOKENS', value: 32768}
+        });
+
+        const missingBatch = loadComposition();
+        delete missingBatch.services['embedding-model'].environment.LLAMA_ARG_BATCH;
+        expect(errorCodes(analyzeProviderLaneComposition(missingBatch))).toContain('service-batch-drift');
+
+        const driftedUbatch = loadComposition();
+        driftedUbatch.services['embedding-model'].environment.LLAMA_ARG_UBATCH = '512';
+        expect(errorCodes(analyzeProviderLaneComposition(driftedUbatch))).toContain('service-ubatch-drift');
+
+        const decoupled = clone(good);
+        decoupled.lanes.embedding.batchTokens = 65536;
+        decoupled.deploymentInputs.embeddingBatchTokens.value = 65536;
+        expect(validateProviderLaneCompositionReceipt(decoupled).errors.map(error => error.code))
+            .toContain('embedding-batch-ubatch-coupling');
+
+        const insufficient = clone(good);
+        insufficient.lanes.embedding.batchTokens = 8192;
+        insufficient.lanes.embedding.ubatchTokens = 8192;
+        insufficient.deploymentInputs.embeddingBatchTokens.value = 8192;
+        insufficient.deploymentInputs.embeddingUbatchTokens.value = 8192;
+        expect(validateProviderLaneCompositionReceipt(insufficient).errors.map(error => error.code))
+            .toContain('embedding-batch-context-coupling')
     });
 
     test('the pure receipt cannot exceed or forge either pinned model context ceiling', () => {
@@ -271,7 +306,17 @@ test.describe('provider-lane composition receipt (#17021)', () => {
 
         const extraField = clone(good);
         extraField.deploymentInputs.totalCpuCores.source = 'untrusted';
-        expect(validateProviderLaneCompositionReceipt(extraField).errors.map(error => error.code)).toContain('deployment-input-field-set')
+        expect(validateProviderLaneCompositionReceipt(extraField).errors.map(error => error.code)).toContain('deployment-input-field-set');
+
+        const extraReceiptField = clone(good);
+        extraReceiptField.selfAttested = true;
+        expect(validateProviderLaneCompositionReceipt(extraReceiptField).errors.map(error => error.code))
+            .toContain('receipt-field-set');
+
+        const extraLaneField = clone(good);
+        extraLaneField.lanes.embedding.token = 'SECRET';
+        expect(validateProviderLaneCompositionReceipt(extraLaneField).errors.map(error => error.code))
+            .toContain('lane-field-set')
     });
 
     test('the llama.cpp slot oracle is required and cannot be description-only', () => {


### PR DESCRIPTION
Resolves #17034

Refs #17024

Related: #17018

Refs #17021

Refs #17022

Refs #17023

Adds the canonical, disposable provider-lane election path for the graduated two-lane profile. The runner consumes only validated composition receipts, evaluates the counterbalanced `{1,2,4}` matrix under one fixed envelope, separates provider-chunk timing from caller-visible durable progress, and emits deployment inputs only for the smallest fully passing candidate. It cannot attach to an existing project, address a remote Docker daemon, use external provider credentials, or silently clamp/fallback when evidence is incomplete.

Evidence: L2 (93 focused contract/integration tests plus bounded static checks of the canonical Compose render, local Unix Docker authority, and read-only Engine observations) -> L3 required (#17024 remains open for the complete exact-head production-shaped candidate matrix and secret-free elected machine receipt). Residual-Owner: #17024.

Decision Record: REQUIRED — satisfied by the merged ADR-0014 role-isolated provider amendment; this PR implements its Row-F validation/election stage without adding another ADR or AiConfig leaf.

## Deltas from ticket

- The pure election core remains deliberately non-authoritative. The live controller binds validated archived receipts, exact repository head, disposable-project identity, and complete raw evidence into `ELECTED` / `NO_ELECTION`; the exported exact report validator independently reconstructs the plan, reruns the election, and rejects forged authority, selection drift, extra fields, incomplete evidence, and downstream `NO_ELECTION` consumption.
- The report embeds the complete selected canonical `provider-lane-composition.v1` receipt and canonical digest. #17022 can import the validator instead of reconstructing election authority.
- Pinned llama.cpp b10380 logical batch and physical ubatch are explicit elected inputs, equal the candidate's total embedding context, and bind `LLAMA_ARG_BATCH` plus `LLAMA_ARG_UBATCH`. The context worker proves the observed per-slot supported limit first, then classifies context-limit and physical-batch refusals separately.
- Over-limit context evidence runs once per candidate outside the timed workload, preventing large refusal probes from distorting joint-load measurements.
- Provider lifecycle rows and source-call receipts are separate: queue wait, provider duration, and concurrency use every real provider chunk; throughput, progress, errors, and refusals use caller-visible source-call completion.
- A dedicated volume-free worker service replaces resident service inheritance, which would otherwise expose the orchestrator Docker socket and host backup bind to benchmark workers.
- Its service declaration remains volume-free; the private controller adds exactly one validated candidate receipt as a per-run read-only mount for `compose run`.
- Docker mutation and observation share one canonical local Unix socket. Resource evidence uses Docker CPU counter deltas plus bounded Docker Top process RSS, never summed request wall time or anonymous-memory-only counters.
- Final disconnect/restart isolation remains with #17022, and vector-generation election remains with #17023. The full live matrix remains the close gate on #17024 itself; this PR does not close it.

## Test Evidence

- Provider election + composition + provider scheduler surfaces: `NEO_TEST_SKIP_CI=true npm run test-unit -- test/playwright/unit/ai/scripts/benchmark/ProviderLaneElectionCore.spec.mjs test/playwright/unit/ai/scripts/benchmark/ProviderLaneElectionRunner.spec.mjs test/playwright/unit/ai/scripts/diagnostics/providerLaneComposition.spec.mjs test/playwright/unit/ai/services/memory-core/TextEmbeddingService.retry.spec.mjs` — 93/93 passed.
- AiConfig/config-template authority: `npm run ai:lint-config-template-ssot` — passed with zero violations.
- Atomic receipt persistence: `node buildScripts/util/check-atomic-write-shape.mjs ai/scripts/benchmark/provider-lane-election.mjs ai/scripts/benchmark/helpers/providerLaneElectionCore.mjs` — passed.
- Semantic preflight: `npm run agent-preflight -- --no-fix --change-class capability --commit-subject 'feat(ai): harden provider-lane election handoff (#17024)' ...` — passed for all seven changed files.
- Guide lint: `npm run ai:lint-guides` — zero hard failures (pre-existing warnings only).
- Syntax, block alignment, and `git diff --check origin/dev...HEAD` — passed.
- Credential-empty canonical Compose render: candidate 4 emits `slots/context/batch/ubatch = 4/32768/32768/32768`; the dedicated worker declares no static volumes, ports, or secrets, and no nonempty credential-like environment value was rendered. The controller-owned `compose run` path injects only the validated receipt as a read-only mount.

## Post-Merge Validation

- [ ] Keep #17024 open and run `npm run ai:provider-lane-election -- --plan <reviewed-versioned-plan.json> --out <receipt.json>` on Neo's canonical disposable plane at an exact revision.
- [ ] Attach the secret-free `ELECTED` or `NO_ELECTION` report to #17024; close it only after its complete L3 matrix and acceptance criteria are discharged.
- [ ] Feed only an `ELECTED` report accepted by `validateProviderLaneElectionReport()` into #17022's disconnect/restart-isolation proof.

Residual-Owner: #17024

## Commits

- `bfe0fd1c1b` — pure counterbalanced measurement/election core.
- `fd39714f23` — separate non-authoritative measurement from live deployment authority.
- `55dba3dac3` — disposable live runner, isolated worker, raw evidence adapters, and adversarial coverage.
- `ff3efa3eb7` — exact downstream report validator plus pinned batch/ubatch authority.
- `da1e461241` — explicit static-volume versus per-run receipt-mount boundary.

## Evolution

The implementation began as a pure evaluator, then split authority after falsifiers showed that synthetic facts could otherwise mint deployment-looking outputs. The live runner subsequently moved context probes outside workload timing, replaced inherited resident containers with a capability-minimal worker, bound one local Docker daemon for mutation and observation, and split provider chunks from durable source-call progress. Review then exposed two final authority gaps: the public handoff could be self-attested, and llama.cpp's physical ubatch could pre-empt a context probe. The repaired head embeds and revalidates the complete elected receipt, and models b10380 batch/ubatch refusal as a distinct measured capacity axis.

## Signal Ledger

| Family | Signal | Version anchor |
|---|---|---|
| Claude (author) | `[AUTHOR_SIGNAL by @neo-opus-vega]` | `body-r6-2026-08-12T11:56Z` |
| GPT (non-author) | `[GRADUATION_APPROVED by @neo-gpt-emmy]` | `DC_kwDODSospM4BEntH` / body r6 |

## Unresolved Dissent

None. Both Step-Back blockers were folded before the r6 signals; the D+F topology and Row-F election remained converged.

## Unresolved Liveness

Gemini family was operator-benched for the graduation window. The revalidation trigger remains owned by #17018: family reactivation reopens the substrate for retroactive signal review.

## Discussion Criteria Mapping

| Graduated criterion | Delivered here |
|---|---|
| OQ4 / OQ6 — per-slot truth and refusal | Runtime `/api/ps` + `/slots` observations, explicit b10380 batch/ubatch authority, exact supported-limit probes, and closed context/physical refusal adapters. |
| OQ7 / Row F — fixed-envelope election | Counterbalanced `{1,2,4}` schedule, fixed resource/identity digest, source-shaped joint demand, raw queue/provider/CPU/RSS evidence, smallest-pass selection, and `NO_ELECTION` without fallback. |
| AC-D stage 3 — canonical validation/election | Consumes #17021's exact receipt and publishes a validator-backed full winning receipt plus immutable inputs; leaves final runtime isolation to #17022 and vector-generation cutover to #17023. |

Authored by Euclid (GPT-5.6 Sol Ultra, Codex) consuming Vega's handoff — session A 35e0863b-4d45-4b94-90ff-5e66278bea7d, session B 019fe0b1-114b-7c30-aaf4-8317c1f99d4b.
