### PR TITLE
fix(ai): gate Shape-B wake digests by canonical message age (#17009)

### DIFF
--- a/ai/daemons/wake/daemon.mjs
+++ b/ai/daemons/wake/daemon.mjs
@@ -75,7 +75,7 @@ import {
 import {
     computeFlushDelayMs,
     computeFlushHoldMs,
-    isMessageWakeFresh,
+    partitionMessageWakesByFreshness,
     resolveCoalesceWindowMs
 } from '../../services/memory-core/wakeCoalescePolicy.mjs';
 import {
@@ -861,42 +861,6 @@ function isMessageReadFor(db, messageId, recipient) {
     ).get(messageId);
 
     return node ? node.readAt != null : false;
-}
-
-/**
- * @summary Partitions message events by canonical mailbox age at the delivery boundary.
- *
- * The event's `sentAt` comes from the immutable MESSAGE node through the shared `SENT_TO_ME`
- * evaluator. GraphLog position is intentionally not consulted: projection replay can append a new
- * position for an old message. Suppressed events are returned to the caller so it can still advance
- * durable consumption state without exposing their subjects or mutating mailbox read state.
- *
- * @param {Object[]} messages Coalesced message wake events.
- * @param {Number}   [now=Date.now()] Current epoch ms, shared across one partition pass.
- * @returns {{eligible: Object[], suppressed: Object[], oldestAgeMs: Number|null}}
- * @private
- */
-function partitionMessageWakesByFreshness(messages, now = Date.now()) {
-    const eligible    = [], suppressed = [];
-    let   oldestAgeMs = null;
-
-    for (const message of messages) {
-        if (isMessageWakeFresh({sentAt: message.sentAt, now})) {
-            eligible.push(message);
-            continue;
-        }
-
-        suppressed.push(message);
-
-        const sentAtMs = typeof message.sentAt === 'string' ? Date.parse(message.sentAt) : NaN,
-              ageMs    = now - sentAtMs;
-
-        if (Number.isFinite(ageMs) && ageMs >= 0) {
-            oldestAgeMs = Math.max(oldestAgeMs ?? 0, ageMs);
-        }
-    }
-
-    return {eligible, suppressed, oldestAgeMs}
 }
 
 /**

--- a/ai/services/memory-core/CoalescingEngineService.mjs
+++ b/ai/services/memory-core/CoalescingEngineService.mjs
@@ -5,6 +5,7 @@ import logger                 from '../../mcp/server/memory-core/logger.mjs';
 import {
     computeFlushDelayMs,
     computeFlushHoldMs,
+    partitionMessageWakesByFreshness,
     resolveCoalesceWindowMs
 } from './wakeCoalescePolicy.mjs';
 
@@ -432,7 +433,24 @@ class CoalescingEngineService extends Base {
 
         this.coalesceState.delete(subscriptionId);
 
-        const digest          = this._buildDigestEnvelope(subscription, queue, firstQueuedAt);
+        // Canonical mailbox-age admission, applied BEFORE any digest field is derived — the Shape
+        // A/B twin of the daemon's flush-time gate. A replayed GraphLog `DELIVERED_TO` edge
+        // re-surfaces an old unread MESSAGE as a fresh delta; without this gate the digest counts
+        // it, names it `latest`, and lets a dead lane's HIGH priority spoof an interruption — a
+        // replayed lane-claim is the highest-cost shape, since it points one peer at another over
+        // territory both already hold correctly. Mailbox state stays untouched — old unread mail
+        // remains listable; it simply cannot manufacture live interruption urgency.
+        const surviving = this._partitionExpiredMessageWakes(subscription, queue);
+
+        if (surviving.length === 0) {
+            // Every queued message event was past the admission horizon (or carried no verifiable
+            // `sentAt` — fail-closed, daemon-symmetric): consume the queue WITHOUT dispatching a
+            // zero-event wake. No `lastFlushAtBySub` arming — nothing was delivered, so no
+            // refractory may be claimed.
+            return;
+        }
+
+        const digest          = this._buildDigestEnvelope(subscription, surviving, firstQueuedAt);
         const dispatchPromise = this._dispatchDigest(subscription, digest)
             .then(outcome => {
                 if (outcome === 'delivered') {
@@ -448,6 +466,42 @@ class CoalescingEngineService extends Base {
 
         this.dispatchInFlight.set(subscriptionId, dispatchPromise);
         await dispatchPromise;
+    }
+
+    /**
+     * @summary Drops expired `wake/sent_to_me` events before ANY digest field is derived.
+     *
+     * Only message events are age-gated — task transitions, permission grants, and heartbeat pulses
+     * carry their own clocks and contracts and pass through untouched. The partition itself is the
+     * shared policy in `wakeCoalescePolicy.mjs` (one admission pass for daemon + engine, so the two
+     * producers cannot drift); this wrapper only routes the mixed queue through it while preserving
+     * arrival order, and emits bounded observability — count and oldest age, never mailbox content.
+     *
+     * Because the filter runs ahead of `_buildDigestEnvelope`, `totalEvents`, `sourceEventIds`, the
+     * digest identity hash, `logId`, every bucket `count` / `latest`, and `highestPriority` all
+     * describe the SAME surviving read: the preview can never name a message outside the set the
+     * count describes.
+     *
+     * @protected
+     * @param {Object}   subscription Owning cached subscription (observability only).
+     * @param {Object[]} events       Raw queued wake-event envelopes, in arrival order.
+     * @returns {Object[]} Surviving envelopes in arrival order (the SAME array when nothing expired).
+     */
+    _partitionExpiredMessageWakes(subscription, events) {
+        const messageEvents = events.filter(event => event?.eventType === 'wake/sent_to_me');
+
+        if (messageEvents.length === 0) return events;
+
+        const {suppressed, oldestAgeMs} = partitionMessageWakesByFreshness(messageEvents);
+
+        if (suppressed.length === 0) return events;
+
+        logger.info(`[CoalescingEngine] Suppressed ${suppressed.length} stale/invalid message wake event(s) for ` +
+            `${subscription.agentIdentity || subscription.id} at flush; oldestAgeMs=${oldestAgeMs ?? 'unknown'}.`);
+
+        const suppressedSet = new Set(suppressed);
+
+        return events.filter(event => !suppressedSet.has(event))
     }
 
     /**

--- a/ai/services/memory-core/wakeCoalescePolicy.mjs
+++ b/ai/services/memory-core/wakeCoalescePolicy.mjs
@@ -25,6 +25,8 @@
  * - **Canonical message age:** a MESSAGE may create live interruption urgency for one hour after
  *   its server-stamped `sentAt`. Older, future, missing, or malformed timestamps stay mailbox data
  *   but fail closed for wake delivery; replay GraphLog position never substitutes for authored age.
+ *   Admission itself ({@link isMessageWakeFresh}) and the flush-time partition
+ *   ({@link partitionMessageWakesByFreshness}) both live here, consumed by every wake producer.
  *
  * Kept pure (no timers, DB, config, or daemon state) so the policy is unit-testable in isolation,
  * mirroring the daemon's other focused modules (`flushDeferPolicy.mjs`, `queries.mjs`,
@@ -91,6 +93,53 @@ export function isMessageWakeFresh({sentAt, now = Date.now(), maxAgeMs = MESSAGE
     const ageMs = now - sentAtMs;
 
     return ageMs >= 0 && ageMs <= maxAgeMs
+}
+
+/**
+ * @summary Partitions message wake events by canonical mailbox age at the flush / delivery boundary.
+ *
+ * The single age-admission pass shared by BOTH wake producers — the standalone daemon (Shape C)
+ * and `CoalescingEngineService` (Shapes A/B) — so the turn-priced wake contract cannot fork across
+ * the cutover: the engine once shipped without the daemon's gate, and a replayed day-old
+ * lane-claim surfaced as a digest `latest`.
+ *
+ * The event's `sentAt` comes from the immutable MESSAGE node through the shared `SENT_TO_ME`
+ * evaluator (`buildSentToMeInner`). GraphLog position and envelope arrival time are intentionally
+ * not consulted: projection replay can append a new position for an old message. The daemon's
+ * events carry `sentAt` at the top level; the engine's envelopes carry it at `payload.sentAt` —
+ * both resolve here, and a missing or malformed value fails closed via {@link isMessageWakeFresh}.
+ *
+ * Suppressed events are returned to the caller so it can still advance durable consumption state
+ * without exposing their subjects or mutating mailbox read state.
+ *
+ * @param {Object[]} messages Coalesced message-class wake events (message events only — task,
+ *     permission, and heartbeat events carry their own clocks and are never age-gated).
+ * @param {Number}   [now=Date.now()] Current epoch ms, shared across one partition pass.
+ * @returns {{eligible: Object[], suppressed: Object[], oldestAgeMs: Number|null}}
+ */
+export function partitionMessageWakesByFreshness(messages, now = Date.now()) {
+    const eligible    = [], suppressed = [];
+    let   oldestAgeMs = null;
+
+    for (const event of messages) {
+        const sentAt = event?.sentAt ?? event?.payload?.sentAt;
+
+        if (isMessageWakeFresh({sentAt, now})) {
+            eligible.push(event);
+            continue;
+        }
+
+        suppressed.push(event);
+
+        const sentAtMs = typeof sentAt === 'string' ? Date.parse(sentAt) : NaN,
+              ageMs    = now - sentAtMs;
+
+        if (Number.isFinite(ageMs) && ageMs >= 0) {
+            oldestAgeMs = Math.max(oldestAgeMs ?? 0, ageMs);
+        }
+    }
+
+    return {eligible, suppressed, oldestAgeMs}
 }
 
 /**

--- a/test/playwright/unit/ai/services/memory-core/CoalescingEngineService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/CoalescingEngineService.spec.mjs
@@ -19,6 +19,9 @@ import fs              from 'fs-extra';
 import path            from 'path';
 import {fileURLToPath} from 'url';
 
+// Pure policy module (no Neo dependency) — safe as a static import ahead of the dynamic service loads.
+import {MESSAGE_WAKE_MAX_AGE_MS} from '../../../../../../ai/services/memory-core/wakeCoalescePolicy.mjs';
+
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../../../../../');
 
 let CoalescingEngineService;
@@ -31,7 +34,12 @@ const buildEnvelope = (eventType, payload, logId = 1) => ({
     logId,
     agentIdentity : '@alice',
     subscriptionId: 'WAKE_SUB:test',
-    payload,
+    // Production `SENT_TO_ME` payloads always carry the MESSAGE node's canonical `sentAt`
+    // (`buildSentToMeInner`); fixtures default to a FRESH stamp so the flush-time age gate
+    // admits them. Pass `sentAt: undefined` explicitly to keep a timestamp-less payload.
+    payload       : eventType === 'wake/sent_to_me' && !('sentAt' in payload)
+        ? {sentAt: new Date().toISOString(), ...payload}
+        : payload,
     emittedAt     : new Date().toISOString()
 });
 
@@ -390,7 +398,7 @@ test.describe('CoalescingEngineService', () => {
 
     test('timestamp-less payloads fall back to last-write-wins, never re-ordered by guesswork', () => {
         const noTs = subject => {
-            const env = buildEnvelope('wake/sent_to_me', {subject});
+            const env = buildEnvelope('wake/sent_to_me', {subject, sentAt: undefined});
             delete env.emittedAt;
             return env;
         };
@@ -405,7 +413,7 @@ test.describe('CoalescingEngineService', () => {
 
     test('the envelope emittedAt is the recency fallback when the payload carries no sentAt', () => {
         const noSentAt = (subject, emittedAt) => {
-            const env = buildEnvelope('wake/sent_to_me', {subject});
+            const env = buildEnvelope('wake/sent_to_me', {subject, sentAt: undefined});
             env.emittedAt = emittedAt;
             return env;
         };
@@ -688,6 +696,113 @@ test.describe('CoalescingEngineService', () => {
             .not.toMatch(/configure\(\s*\{\s*\.\.\.\s*wakeDispatch/);
         expect(serverSource, 'the node must still reach configure by reference')
             .toMatch(/CoalescingEngineService\.configure\(\s*wakeDispatch\s*,/)
+    });
+
+    // -----------------------------------------------------------------------------
+    // Flush-time age admission
+    //
+    // The daemon gated replayed backlog by canonical `sentAt` from the start; the engine's Shape
+    // A/B flush did not — so a replayed GraphLog `DELIVERED_TO` edge surfaced a 25-hour-old
+    // lane-claim as the digest `latest`, the highest-cost payload class there is (one peer nearly
+    // pointed at another over territory both were correctly building inside). These arms pin the
+    // gate, the surviving-set derivation (count / latest / priority / sourceEventIds / logId all
+    // describe the SAME read), and the fail-closed boundary. The daemon sibling pins the shared
+    // partition policy in `daemon.spec.mjs`; the pure boundary lives in `coalescePolicy.spec.mjs`.
+    // -----------------------------------------------------------------------------
+
+    test('AC-1 — a message older than MESSAGE_WAKE_MAX_AGE_MS produces NO wake; the queue is consumed', async () => {
+        const sub = buildSubscription({harnessTargetMetadata: {url: 'https://example.com/wake', coalesceWindow: 0.05}});
+        CoalescingEngineService.enqueue(sub, buildEnvelope('wake/sent_to_me', {
+            messageId: 'M-STALE',
+            subject  : 'replayed backlog',
+            sentAt   : new Date(Date.now() - MESSAGE_WAKE_MAX_AGE_MS - 1).toISOString()
+        }));
+
+        await new Promise(resolve => setTimeout(resolve, 100));
+
+        expect(deliverCalls.length, 'an expired message must consume its queue without a zero-event wake').toBe(0);
+        expect(CoalescingEngineService.coalesceState.size, 'the queue is consumed, not re-armed').toBe(0);
+        expect(CoalescingEngineService.lastFlushAtBySub.has(sub.id),
+            'nothing was delivered, so no refractory may be claimed').toBe(false);
+        // Mailbox state is structurally untouched: the engine holds no mailbox handle, so
+        // suppression is digest-only — the old unread row remains listable via `list_messages`.
+    });
+
+    test('AC-5 — a 25-hour-old replayed lane-claim is never named latest, counted, or priority-shaping', async () => {
+        const staleSubject = '[lane-claim][#16906] orphaned Post-Merge Validation guard';
+        const sub          = buildSubscription({harnessTargetMetadata: {url: 'https://example.com/wake', coalesceWindow: 0.05}});
+        // Instance 2's exact shape: receipt appended at fresh GraphLog position 5829858 for a
+        // message authored 2026-08-10T20:09:25Z — position fresh, authored age ~25h.
+        CoalescingEngineService.enqueue(sub, buildEnvelope('wake/sent_to_me', {
+            messageId: 'M-STALE',
+            subject  : staleSubject,
+            priority : 'high',
+            sentAt   : new Date(Date.now() - 25 * 60 * 60 * 1000).toISOString()
+        }, 5829858));
+        CoalescingEngineService.enqueue(sub, buildEnvelope('wake/sent_to_me', {
+            messageId: 'M-FRESH',
+            subject  : 'actually new'
+        }, 5829859));
+
+        await new Promise(resolve => setTimeout(resolve, 100));
+
+        // The fresh sibling delivering IS the non-vacuity witness: a suppress-everything gate reds here.
+        expect(deliverCalls.length).toBe(1);
+        const digest = deliverCalls[0].eventData;
+        expect(digest.payload.totalEvents, 'the count describes the surviving read only').toBe(1);
+        expect(digest.payload.sourceEventIds).toEqual(['M-FRESH']);
+        expect(digest.logId, 'logId anchors to the last SURVIVING event, not the stale queue tail').toBe(5829859);
+        expect(digest.payload.breakdown.sent_to_me.count).toBe(1);
+        expect(digest.payload.breakdown.sent_to_me.latest.messageId).toBe('M-FRESH');
+        expect(digest.payload.breakdown.sent_to_me.highestPriority,
+            'a dead lane’s HIGH must not spoof the digest priority').toBe('normal');
+        expect(JSON.stringify(digest)).not.toContain('M-STALE');
+        expect(JSON.stringify(digest)).not.toContain(staleSubject);
+    });
+
+    test('non-message events are never age-gated — a fresh task transition survives a stale queue-mate', async () => {
+        const sub = buildSubscription({harnessTargetMetadata: {url: 'https://example.com/wake', coalesceWindow: 0.05}});
+        CoalescingEngineService.enqueue(sub, buildEnvelope('wake/sent_to_me', {
+            messageId: 'M-STALE',
+            sentAt   : new Date(Date.now() - 2 * 60 * 60 * 1000).toISOString()
+        }));
+        CoalescingEngineService.enqueue(sub, buildEnvelope('wake/task_state_changed', {
+            taskId: 'T1', newState: 'Working', lastModifiedAt: new Date().toISOString()
+        }));
+
+        await new Promise(resolve => setTimeout(resolve, 100));
+
+        expect(deliverCalls.length).toBe(1);
+        const digest = deliverCalls[0].eventData;
+        expect(digest.payload.totalEvents).toBe(1);
+        expect(digest.payload.breakdown.task_state_changed.count).toBe(1);
+        expect(digest.payload.breakdown.task_state_changed.latest.newState).toBe('Working');
+        expect(digest.payload.breakdown.sent_to_me.count).toBe(0);
+    });
+
+    test('fail-closed — a missing or malformed sentAt cannot manufacture a live wake', async () => {
+        const sub = buildSubscription({harnessTargetMetadata: {url: 'https://example.com/wake', coalesceWindow: 0.05}});
+        CoalescingEngineService.enqueue(sub, buildEnvelope('wake/sent_to_me', {messageId: 'M-NO-TS',  sentAt: undefined}));
+        CoalescingEngineService.enqueue(sub, buildEnvelope('wake/sent_to_me', {messageId: 'M-BAD-TS', sentAt: 'not-a-date'}));
+
+        await new Promise(resolve => setTimeout(resolve, 100));
+
+        expect(deliverCalls.length,
+            'unverifiable age fails closed, daemon-symmetric — mailbox data, never a wake').toBe(0);
+    });
+
+    test('the admission boundary itself is unchanged — a message inside the horizon still wakes', async () => {
+        const sub = buildSubscription({harnessTargetMetadata: {url: 'https://example.com/wake', coalesceWindow: 0.05}});
+        CoalescingEngineService.enqueue(sub, buildEnvelope('wake/sent_to_me', {
+            messageId: 'M-EDGE',
+            // 5s inside the horizon: pins the boundary semantics without a flush-timing flake.
+            sentAt   : new Date(Date.now() - MESSAGE_WAKE_MAX_AGE_MS + 5000).toISOString()
+        }));
+
+        await new Promise(resolve => setTimeout(resolve, 100));
+
+        expect(deliverCalls.length, 'inside the one-hour horizon the wake must still fire').toBe(1);
+        expect(deliverCalls[0].eventData.payload.breakdown.sent_to_me.latest.messageId).toBe('M-EDGE');
     });
 
 });

--- a/test/playwright/unit/ai/services/memory-core/WakeSubscriptionService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/WakeSubscriptionService.spec.mjs
@@ -2179,7 +2179,9 @@ test.describe('Neo.ai.services.memory-core.WakeSubscriptionService', () => {
             GraphService.upsertNode({
                 id        : 'MSG:COLD-WEBHOOK-ROUTE',
                 type      : 'MESSAGE',
-                properties: {from: '@bob', subject: 'first post-restart webhook'}
+                // Production MESSAGE rows always carry the canonical `sentAt` (MailboxService
+                // stamps it); the digest path age-gates on it, so the fixture must too.
+                properties: {from: '@bob', subject: 'first post-restart webhook', sentAt: new Date().toISOString()}
             });
             GraphService.linkNodes('MSG:COLD-WEBHOOK-ROUTE', '@alice', 'SENT_TO', 1.0);
 
@@ -2339,7 +2341,7 @@ test.describe('Neo.ai.services.memory-core.WakeSubscriptionService', () => {
                 await WakeSubscriptionService.subscribe({trigger: 'SENT_TO_ME', harnessTarget: 'disabled'});
             });
 
-            GraphService.upsertNode({id: 'MSG:6', type: 'MESSAGE', properties: {from: '@bob'}});
+            GraphService.upsertNode({id: 'MSG:6', type: 'MESSAGE', properties: {from: '@bob', sentAt: new Date().toISOString()}});
             GraphService.linkNodes('MSG:6', '@alice', 'SENT_TO', 1.0);
 
             await WakeSubscriptionService.pump();


### PR DESCRIPTION
Resolves #17009

The wake daemon (Shape C) has gated replayed mailbox backlog by canonical authored age since `#15704` shipped; `CoalescingEngineService` — the Shape A/B producer — never got the gate, so a replayed `DELIVERED_TO` GraphLog delta surfaced a 25-hour-old lane-claim as a digest `latest` (its HIGH priority spoofing the header) hours after `#16918`'s read/missing reconciliation merged. The flush now partitions expired `wake/sent_to_me` events through the shared policy module BEFORE any digest field is derived: `totalEvents`, `sourceEventIds`, the digest identity hash, `logId`, every bucket `count`/`latest`, and `highestPriority` all describe the same surviving read. An all-stale queue is consumed without dispatching a zero-event wake, mailbox state is untouched (old unread mail stays listable; it simply cannot manufacture live interruption urgency), and the daemon's private partition moves into `wakeCoalescePolicy.mjs` so both producers share one admission pass that cannot fork again.

Evidence: L2 (service-level unit suites at exact head 0307975cbc — 153/153 across the engine, daemon, delivery-owner, coalesce-policy, digest-builder, and digest-count-label specs, including 5 new age-admission arms; plus 116/116 on the subscription-service spec) → L3 required (every delivered AC is service-level falsifiable; no delivered AC requires a live-plane effect). Residual: AC4 (unread-projection / `totalCount` axis — a different mechanism, twice live-reproduced), Residual-Owner: #17030.

## Deltas from ticket
- **AC-1 reframed per the ported review correction** (@neo-gpt-emmy on `#17009`): the settled `#15704` contract is authored-age admission (`0 <= now - sentAt <= 1h`), not "newest undelivered." Implemented exactly so, daemon-symmetric; old unread mail remains mailbox data, never a wake.
- **AC-2 delivered as surviving-set derivation** — count and preview now provably describe the same read; `logId` anchors to the last SURVIVING event rather than the stale queue tail.
- **AC-3 (claim/request distinguishable) dropped per the same correction** — orthogonal to the defect; the freshness gate applies to every MESSAGE. Not delivered, not deferred: ruled out-of-mechanism by the ticket's own review trail.
- **AC-4 (`totalCount` stability) →** #17030 — @neo-opus-vega's 12:52Z witness plus my independent one-call reproduction at 16:46Z (`mark_read` persisted per `get_message`; `list_messages({status:'unread'})` still returns the message with `readAt: null`) pin the root as the unread-projection read path, not the wake path. Filed as its own leaf carrying both reproductions, per @neo-opus-vega's explicit-fold delegation (16:36Z A2A): this ticket's close must not silently claim the root.
- **AC-5 delivered** — the regression pin is instance 2's exact shape (fresh GraphLog position 5829858, ~25h authored age): never counted, never `latest`, never priority-shaping; the fresh sibling still wakes (non-vacuity).
- **Consolidation:** the daemon's private `partitionMessageWakesByFreshness` moves into `wakeCoalescePolicy.mjs` with a `sentAt ?? payload.sentAt` accessor generalization for the engine's envelope shape — one admission pass, both producers, un-forkable. Daemon behavior unchanged (all daemon suites green).

## Test Evidence
- `npm run test-unit -- test/playwright/unit/ai/services/memory-core/CoalescingEngineService.spec.mjs test/playwright/unit/ai/daemons/wake/daemon.spec.mjs test/playwright/unit/ai/daemons/wake/daemonDeliveryOwner.spec.mjs test/playwright/unit/ai/daemons/wake/coalescePolicy.spec.mjs test/playwright/unit/ai/daemons/wake/wakeDigestBuilder.spec.mjs test/playwright/unit/ai/daemons/wake/digestCountLabel.spec.mjs` → **153 passed** at `cc9d12d6cf`
- Post-lint-fix engine-spec re-run → **45 passed** at `cc9d12d6cf`
- `npm run test-unit -- test/playwright/unit/ai/services/memory-core/WakeSubscriptionService.spec.mjs` → **116 passed** at `0307975cbc` (the first run caught two digest-path fixtures carrying no `sentAt` — production rows always have one; fixed in the second commit)
- `npm run test-integration-unified` → **50 passed, 2 skipped** at `0307975cbc` (local Docker). The CI `integration-unified` job failed ambiently at 17:10Z — `fetch failed / SocketError: other side closed`, the dockerized stack dying mid-run, 30+ specs failing in <100ms each; zero integration specs reference the touched modules (grep-verified), and `dev`'s own 15:25Z run shows the same infra flake today. Failed job re-run requested.
- Directly touched surfaces: memory-core wake engine, wake daemon, shared wake policy, subscription pump fixtures — all covered above. No app/UI surface touched. | CI at exact head: green except the ambient `integration-unified` infra failure (re-run pending).

## Commits
- `cc9d12d6cf` — the age gate, surviving-set derivation, shared-policy move, and the engine regression arms
- `0307975cbc` — production-faithful `sentAt` on the two a2a-webhook MESSAGE fixtures the gate correctly caught

## Post-Merge Validation
None deferred. Live-plane confirmation is observational, not an obligation: any post-deploy digest naming an expired (>1h) message falsifies this fix in the open, and the swarm's wake traffic is the standing instrument (three seats filed symptoms within hours on the incident night).

Authored by Phoebe (Kimi k3, opencode). Session: not surfaced by harness (opencode desktop session, 2026-08-12).
