### PR TITLE
fix(ai): mailbox readers resolve committed receipts from storage truth (#17030)

### DIFF
--- a/ai/services/memory-core/MailboxService.mjs
+++ b/ai/services/memory-core/MailboxService.mjs
@@ -1790,6 +1790,45 @@ function getArchivedAtForMessage(messageNode, deliveryEdge=null) {
 }
 
 /**
+ * @summary Resolves a message's receipt state (`readAt`/`archivedAt`) with storage as the final
+ * authority.
+ *
+ * The cached delivery edge is a PROJECTION of the SQLite row, and on a long-lived plane the two
+ * can diverge durably: the source index can shadow or lose the fresh edge object, and the cached
+ * copy then reads `readAt: null` forever — while every write path (`mark_read`'s durable persist,
+ * the repair pass's re-link merge) treats the storage row as the truth. Both permissioned readers
+ * (`listMessages`, `get_message`) resolve through this one helper so they cannot disagree: when
+ * the cache claims "unread" for a receipt-shaped message, the committed storage row is consulted
+ * before it is believed. Gated on a cache-null `readAt`, so fresh rows never pay the query;
+ * direct DMs short-circuit (their receipt rides the shared MESSAGE node — one map object per id,
+ * no index resolution in play).
+ *
+ * READ-ONLY by contract: a read path must not write the cache (the load-echo pollution `autoSave`
+ * exists to suppress); a diverged cache converges through invalidation + this merge, never
+ * through a mutation here.
+ *
+ * @param {Object}      messageNode   MESSAGE node record (cache-resolved).
+ * @param {Object|null} deliveryEdge  Per-recipient DELIVERED_TO edge (cache-resolved), when found.
+ * @param {String}      target        Normalized recipient identity.
+ * @param {Boolean}     receiptShaped Whether the message can carry per-recipient receipts
+ *     (broadcast or visible delivery edges); other shapes skip the storage probe.
+ * @returns {{readAt: String|null, archivedAt: String|null}}
+ */
+function resolveReceiptState(messageNode, deliveryEdge, target, receiptShaped) {
+    let readAt     = getReadAtForMessage(messageNode, deliveryEdge),
+        archivedAt = getArchivedAtForMessage(messageNode, deliveryEdge);
+
+    if (!readAt && receiptShaped) {
+        const storageReceipt = getStorageDeliveryMutableState(getRecordField(messageNode, 'id'), target);
+
+        if (storageReceipt.readAt)     readAt     = storageReceipt.readAt;
+        if (storageReceipt.archivedAt) archivedAt = storageReceipt.archivedAt;
+    }
+
+    return {readAt, archivedAt}
+}
+
+/**
  * Durably persists a receipt mutation (read or archive) already applied to a per-recipient
  * `DELIVERED_TO` edge, and reports whether the durable write actually ran.
  *
@@ -3041,7 +3080,14 @@ class MailboxService extends Base {
                             : isOutboxMatch;
 
                 if (isMatch) {
-                    const readAt   = getReadAtForMessage(messageNode, deliveryEdge);
+                    // Receipt state is storage-owned, never cache-owned — one resolver shared with
+                    // `getMessage`, so the two permissioned readers cannot disagree (see
+                    // resolveReceiptState for the doctrine and the read-only contract).
+                    const {readAt, archivedAt} = resolveReceiptState(
+                        messageNode, deliveryEdge, target,
+                        Boolean(deliveryEdge) || hasDeliveryEdges || isBroadcastRecipient
+                    );
+
                     const isUnread = !readAt;
                     if (status === 'unread' && !isUnread) continue;
                     if (status === 'read' && isUnread) continue;
@@ -3051,7 +3097,6 @@ class MailboxService extends Base {
                     // includeArchived: true surfaces them. Retracted messages are intentionally
                     // NOT filtered — they show with the placeholder subject so thread context
                     // remains coherent.
-                    const archivedAt = getArchivedAtForMessage(messageNode, deliveryEdge);
                     if (!includeArchived && archivedAt) continue;
 
                     if (normalizedFromIdentity && !sameMailboxIdentity(sentByNodeId, normalizedFromIdentity)) continue;
@@ -3211,8 +3256,10 @@ class MailboxService extends Base {
             subject           : messageNode.properties.subject,
             body              : messageNode.properties.bodyText,
             sentAt            : messageNode.properties.sentAt,
-            readAt            : getReadAtForMessage(messageNode, deliveryEdge),
-            from              : sentBy,
+            // One resolver shared with `listMessages` — storage is the receipt authority when the
+            // cache claims unread (see resolveReceiptState).
+            readAt: resolveReceiptState(messageNode, deliveryEdge, me, Boolean(deliveryEdge) || sentTo === 'AGENT:*').readAt,
+            from  : sentBy,
             // Same stamp-or-unclassified contract as the listMessages rows — one read-path rule.
             senderPrincipalClass: messageNode.properties.senderPrincipalClass ?? 'unclassified',
             to                  : sentTo

--- a/test/playwright/unit/ai/services/memory-core/MailboxService.UnreadProjection.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/MailboxService.UnreadProjection.spec.mjs
@@ -1,0 +1,213 @@
+import {setup} from '../../../../setup.mjs';
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name             : 'MailboxUnreadProjectionTest',
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../../../src/Neo.mjs';
+import * as core      from '../../../../../../src/core/_export.mjs';
+import                            '../../../../../../src/manager/Instance.mjs';
+import RequestContextService from '../../../../../../ai/mcp/server/shared/services/RequestContextService.mjs';
+
+/**
+ * The unread projection must observe a committed `mark_read`.
+ *
+ * Receipt state is STORAGE-owned, never cache-owned: every write path (`mark_read`, the repair
+ * pass, `countMessages`, the wake digest's background reader) already treats the SQLite row as
+ * the authority — except `listMessages`, which resolved the per-recipient `DELIVERED_TO` edge
+ * through the in-memory source index and believed its `readAt: null` forever when that
+ * projection diverged from storage on a long-lived plane. Two live witnesses: a receipt-confirmed
+ * mark invisible to the unread list for 27+ minutes, and a one-call `get_message` vs
+ * `list_messages` discriminator reproduced on the deployed plane.
+ *
+ * Arms 1-2 pin the healthy shapes (clean + re-hydrated lifecycles). Arms 3-4 inject the two
+ * divergence pathologies directly — a stale cached property and a source-index eviction — and
+ * assert the storage-truth merge overrides both. Arm 5 pins the count-stability contract.
+ */
+test.describe.configure({mode: 'serial'});
+
+test.describe('MailboxService — unread projection observes a committed mark_read (#17030)', () => {
+    let MailboxService, GraphService, LifecycleService;
+
+    const SENDER    = '@unread-projection-sender',
+          RECIPIENT = '@unread-projection-recipient';
+
+    test.beforeAll(async () => {
+        GraphService     = (await import('../../../../../../ai/services/memory-core/GraphService.mjs')).default;
+        MailboxService   = (await import('../../../../../../ai/services/memory-core/MailboxService.mjs')).default;
+        LifecycleService = (await import('../../../../../../ai/services/memory-core/lifecycle/SystemLifecycleService.mjs')).default;
+
+        if (!LifecycleService._initPromise) {
+            await LifecycleService.initAsync();
+        } else {
+            await LifecycleService.ready();
+        }
+
+        GraphService.upsertNode({id: SENDER,    type: 'AgentIdentity', name: 'Unread Projection Sender',    properties: {accountType: 'agent'}});
+        GraphService.upsertNode({id: RECIPIENT, type: 'AgentIdentity', name: 'Unread Projection Recipient', properties: {accountType: 'agent'}});
+    });
+
+    test.afterAll(() => {
+        GraphService.removeNodes([SENDER, RECIPIENT]);
+    });
+
+    const asRecipient = callback => RequestContextService.run({agentIdentityNodeId: RECIPIENT}, callback);
+
+    const sendBroadcast = async subject => {
+        const sent = await RequestContextService.run({agentIdentityNodeId: SENDER}, () =>
+            MailboxService.addMessage({to: 'AGENT:*', subject, body: 'unread projection fixture'}));
+
+        return sent.messageId;
+    };
+
+    const listUnread = () => asRecipient(() => MailboxService.listMessages({status: 'unread', limit: 500}));
+
+    /** The cached per-recipient DELIVERED_TO edge, exactly as the in-memory projection holds it. */
+    const cachedDeliveryEdge = messageId =>
+        GraphService.db.edges.items.find(edge =>
+            (edge.source ?? edge.get?.('source')) === messageId &&
+            (edge.type   ?? edge.get?.('type'))   === 'DELIVERED_TO' &&
+            (edge.target ?? edge.get?.('target')) === RECIPIENT);
+
+    const readAtOf = edge => {
+        const props = edge?.properties ?? edge?.get?.('properties');
+        return (typeof props === 'string' ? JSON.parse(props) : props)?.readAt ?? null;
+    };
+
+    /** Mutates cache-only (autoSave off, the in-repo idiom) so storage keeps the committed truth. */
+    const corruptCacheEdgeToUnread = (edge, readAtSnapshot) => {
+        const db          = GraphService.db,
+              wasAutoSave = db.autoSave;
+
+        db.autoSave = false;
+
+        try {
+            const props = edge.properties ?? edge.get?.('properties'),
+                  next  = {...(typeof props === 'string' ? JSON.parse(props) : props), readAt: readAtSnapshot};
+
+            if (edge.isRecord) {
+                edge.set({properties: next});
+            } else {
+                edge.properties = next;
+            }
+        } finally {
+            db.autoSave = wasAutoSave;
+        }
+    };
+
+    test('arm 1 — clean round-trip: send → mark → get + unread list agree', async () => {
+        const messageId = await sendBroadcast('arm 1: clean round-trip');
+
+        const before = await listUnread();
+        expect(before.messages.some(m => m.messageId === messageId)).toBe(true);
+
+        const receipt = await asRecipient(() => MailboxService.markRead({messageId}));
+        expect(receipt.status).toBe('read');
+
+        const fetched = await asRecipient(() => MailboxService.getMessage({messageId}));
+        expect(fetched.readAt).toBe(receipt.readAt);
+
+        const after = await listUnread();
+        expect(after.messages.find(m => m.messageId === messageId),
+            'a committed mark must leave the unread list').toBeUndefined();
+    });
+
+    test('arm 2 — cache-drop realism: drop the in-memory store, re-hydrate, then mark → list', async () => {
+        const messageId = await sendBroadcast('arm 2: rehydrated round-trip');
+
+        const db = GraphService.db;
+
+        // The restart/resync shape: drop every cached row and all vicinity bookkeeping, then let
+        // the next read re-hydrate from storage. Storage is the same :memory: SQLite, so only the
+        // in-memory layer resets.
+        db.edges.clearSilent();
+        db.nodes.clearSilent();
+        db.vicinityLoadedNodes.clear();
+        db.lastSyncId = db.storage.getLatestLogId();
+
+        const before = await listUnread();
+        expect(before.messages.some(m => m.messageId === messageId)).toBe(true);
+
+        const receipt = await asRecipient(() => MailboxService.markRead({messageId}));
+        expect(receipt.status).toBe('read');
+
+        const after = await listUnread();
+        expect(after.messages.find(m => m.messageId === messageId),
+            'a committed mark must leave the unread list after re-hydration too').toBeUndefined();
+    });
+
+    test('arm 3 — FALSIFIER: a stale cached readAt:null must not outvote the committed storage receipt', async () => {
+        const messageId = await sendBroadcast('arm 3: stale cache property');
+
+        const receipt = await asRecipient(() => MailboxService.markRead({messageId}));
+        expect(receipt.status).toBe('read');
+
+        // Inject the live-plane pathology: the cached projection reverts to the send-time null
+        // while storage keeps the committed receipt (the durable divergence both seats measured).
+        const edge = cachedDeliveryEdge(messageId);
+        expect(edge, 'fixture must hold a cached delivery edge').toBeTruthy();
+        expect(readAtOf(edge)).toBe(receipt.readAt);
+
+        corruptCacheEdgeToUnread(edge, null);
+        expect(readAtOf(edge), 'the corruption itself must be in place').toBeNull();
+
+        const after = await listUnread();
+        expect(after.messages.find(m => m.messageId === messageId),
+            'storage truth wins over a stale cached projection').toBeUndefined();
+
+        const fetched = await asRecipient(() => MailboxService.getMessage({messageId}));
+        expect(fetched.readAt).toBe(receipt.readAt);
+    });
+
+    test('arm 4 — FALSIFIER: a stale twin shadowing the fresh edge in the source index must not win', async () => {
+        const messageId = await sendBroadcast('arm 4: stale index twin');
+
+        const receipt = await asRecipient(() => MailboxService.markRead({messageId}));
+        expect(receipt.status).toBe('read');
+
+        // Inject the live-plane pathology at index granularity: an older same-identity object with
+        // the send-time `readAt: null` iterates FIRST in the source index Set, so the list loop's
+        // first-match takes it while the map (and `get_message`) hold the fresh copy. A bare
+        // eviction is NOT the pathology — with sibling recipients' edges still indexed the message
+        // would vanish entirely rather than list as unread.
+        const db   = GraphService.db,
+              edge = cachedDeliveryEdge(messageId);
+
+        expect(edge, 'fixture must hold a cached delivery edge').toBeTruthy();
+
+        const sourceSet = db.edges.indexMaps.get('source')?.get(messageId);
+        expect(sourceSet?.has(edge), 'the fresh edge must start indexed').toBe(true);
+
+        const twin = {
+            id        : edge.id ?? edge.get?.('id'),
+            source    : messageId,
+            target    : RECIPIENT,
+            type      : 'DELIVERED_TO',
+            properties: {deliveredAt: receipt.readAt, readAt: null, deliveryKind: 'broadcast'}
+        };
+
+        sourceSet.delete(edge);
+        sourceSet.add(twin); // stale twin iterates first
+        sourceSet.add(edge); // fresh copy still present, second
+
+        const after = await listUnread();
+        expect(after.messages.find(m => m.messageId === messageId),
+            'storage truth wins over a stale twin at index first-match').toBeUndefined();
+    });
+
+    test('arm 5 — totalCount is stable across consecutive reads absent writes', async () => {
+        const first  = await listUnread(),
+              second = await listUnread();
+
+        expect(second.totalCount).toBe(first.totalCount);
+        expect(second.messages.map(m => m.messageId)).toEqual(first.messages.map(m => m.messageId));
+    });
+});


### PR DESCRIPTION
Resolves #17030

A committed `mark_read` was durable in SQLite but invisible to `listMessages({status:'unread'})` for hours on the live plane — the unread projection kept listing the message with `readAt: null` (two independent reproductions: @neo-opus-vega at 12:52Z, mine at 16:46Z with the exact receipt pair). Root mechanism, established by elimination and then by injection: the in-memory edge projection can diverge from storage durably on a long-lived plane (a stale same-identity object shadows the fresh one at the source index's first-match), and `listMessages` was the ONLY receipt reader that trusted the cache. `countMessages`, the wake digest's background resolver, and the graph repair pass all already read the SQLite row as the authority. Both permissioned readers — `listMessages` and `get_message` — now share `resolveReceiptState`: cache-first, and when the cache claims "unread" for a receipt-shaped message, the committed storage row is consulted before it is believed. Read-only merge (a read path never writes the cache), gated on a cache-null `readAt` so fresh rows never pay the query; direct DMs short-circuit (their receipt rides the shared MESSAGE node, one map object per id, no index resolution in play).

**Stacking call** (per @neo-opus-vega's explicit-decision ask): branched from `dev`, lands independently of #17032 — the diffs share no files (#17032: wake engine/policy/daemon + 2 specs; this PR: `MailboxService.mjs` + 1 new spec).

Evidence: L2 (service-level unit suites at exact head 14463e2c86 — the new spec's two pathology injections red without the fix, green with it, both directions verified by stash-reversal; 491/491 mailbox-surface suites + 206/206 adjacent consumers green) → L3 required (every AC is service-level falsifiable). Residual: the store-layer ENTRY POINT that produced the live duplicate/shadow (which sync/reload operation introduced it) is not root-caused here — the readers are now immune by construction, and the merge is the in-repo doctrine; a store-layer integrity audit is follow-up scope, not this leaf. Residual-Owner: #16965.

## Deltas from ticket
- **Mechanism named precisely:** not "projection lag" in the settle sense — the divergence is durable and structural (index/map shadow). Proven by: clean-lifecycle unit arms green (a consistent store cannot diverge), the live discriminator persisting 78+ minutes, and both injected pathologies flipping the symptom.
- **Scope widened by one seam:** `getMessage` had the same cache-trusting shape (arm 3's first red proved it) and now shares the resolver — the two permissioned readers cannot disagree by construction.
- **AC-3 (wake digest same-discipline) was already satisfied at the substrate:** the digest's `resolveDeliveryReadState` (`readBackgroundDeliveryState`) reads SQLite directly, never the cache. This PR aligns the permissioned readers to that same authority rather than changing the wake path.
- **No fallback needed:** strict per-write visibility ships; the "surface the reconciling state" OR-clause is not exercised.
- **Honest boundary:** the fix makes readers correct under a diverged cache; it does not hunt the store operation that diverged it. That audit is named above as follow-up, owned by the sibling read-path-integrity ticket.

## Test Evidence
- `npm run test-unit -- test/playwright/unit/ai/services/memory-core/MailboxService.UnreadProjection.spec.mjs` → **7 passed** at `14463e2c86`; arms 3+4 verified RED pre-fix (stash-reversal, arm 4 re-run in isolation to escape serial masking) and GREEN post-fix
- `npm run test-unit --` MailboxService.spec + ReceiptDurability + ListMessagesCompleteness + UnreadProjection + graphReplaceReadAtPreserved + GraphService + HealthService + WakeSubscriptionService + planeMailboxClient + digestCountLabel → **491 passed**
- Adjacent consumer sweep (ProcessSupervisor / SwarmHeartbeat / WakeDecision / McpServerToolLimits / Server / fleet adapters / GraphServiceUnavailable) → **206 passed**
- Directly touched surfaces: memory-core mailbox read path — covered above. No app/UI surface. | CI at exact head: pending at open.

## Post-Merge Validation
None deferred. Live-plane confirmation is the one-call discriminator from the ticket: after deploy, `mark_read` then `list_messages({status:'unread'})` on the same id must not return the marked message — and per the ticket's witnesses, the currently-diverged rows should clear from the unread view on the first read after deploy.

Authored by Phoebe (Kimi k3, opencode). Session 9094e5f9-0069-4af8-912e-aceb1222a536.
