### PR TITLE
fix(ai): scope provider-lane progress to active demand (#17034)

### DIFF
--- a/ai/scripts/benchmark/helpers/providerLaneElectionCore.mjs
+++ b/ai/scripts/benchmark/helpers/providerLaneElectionCore.mjs
@@ -56,8 +56,7 @@ const
         'maxUnexpectedRefusals',
         'minCompletedOperations',
         'minContextTokensPerSlot',
-        'minResourceCoverageRatio',
-        'minThroughputPerSecond'
+        'minResourceCoverageRatio'
     ]),
 
     SUMMARY_FIELDS = Object.freeze([
@@ -453,8 +452,14 @@ function validateCandidateProfile(profile) {
  * @param {Object} slo Joint SLO.
  */
 function validateSlo(slo) {
+    requireExactKeys(slo, ['lanes'], 'provider-lane SLO');
+    requireExactKeys(slo.lanes, LANE_NAMES, 'provider-lane SLO lanes');
+
     for (const laneName of LANE_NAMES) {
-        const lane = slo?.lanes?.[laneName];
+        const lane = slo.lanes[laneName];
+
+        requireExactKeys(lane, [...SLO_FIELDS, 'requiredQueueDisposition'],
+            `provider-lane SLO lanes.${laneName}`);
 
         if (!lane || !QUEUE_DISPOSITIONS.includes(lane.requiredQueueDisposition)) {
             throw new Error(`provider-lane SLO requires lanes.${laneName} with an explicit queue disposition`)
@@ -478,10 +483,27 @@ function validateSlo(slo) {
             }
         }
 
-        if (lane.minCompletedOperations <= 0 || lane.minContextTokensPerSlot <= 0 || lane.minThroughputPerSecond <= 0 ||
+        if (lane.minCompletedOperations <= 0 || lane.minContextTokensPerSlot <= 0 ||
             lane.minResourceCoverageRatio <= 0 || lane.minResourceCoverageRatio > 1) {
-            throw new Error(`provider-lane SLO lanes.${laneName} requires positive progress, context, throughput, and coverage targets`)
+            throw new Error(`provider-lane SLO lanes.${laneName} requires positive progress, context, and coverage targets`)
         }
+    }
+}
+
+/**
+ * @summary Requires one exact enumerable key set at a plan-owned authority boundary.
+ * @param {*} value Candidate object.
+ * @param {String[]} keys Expected keys.
+ * @param {String} label Error label.
+ */
+function requireExactKeys(value, keys, label) {
+    const actual = value && typeof value === 'object' && !Array.isArray(value)
+        ? Object.keys(value).sort()
+        : [];
+    const expected = [...keys].sort();
+
+    if (stableSerialize(actual) !== stableSerialize(expected)) {
+        throw new Error(`${label} requires exact fields ${expected.join(', ')}`)
     }
 }
 
@@ -618,6 +640,7 @@ function deriveLaneReceipt({ids, lane, laneName, plan, profile, trial}) {
           queueWaits = operations.filter(operation => operation.queueWaitMs !== null).map(operation => operation.queueWaitMs),
           providerDurations = operations.map(operation => operation.providerDurationMs),
           completions = sourceCalls.filter(call => call.outcome === 'completed').map(call => call.completedAtMs),
+          progress = deriveLaneProgress(sourceCalls),
           windowMs = trial.completedAtMs - trial.startedAtMs,
           maxResourceSamples = Math.ceil(windowMs / plan.resourceSampling.expectedIntervalMs) + 2;
 
@@ -664,7 +687,7 @@ function deriveLaneReceipt({ids, lane, laneName, plan, profile, trial}) {
         cpuHighWaterPercent  : Math.max(...lane.resourceSamples.map(sample => sample.cpuPercent)),
         errorCount           : sourceCalls.filter(call => call.outcome === 'error').length,
         maxNeoQueueWaitMs    : queueWaits.length > 0 ? Math.max(...queueWaits) : null,
-        maxProgressGapMs     : deriveMaxProgressGap(trial.startedAtMs, trial.completedAtMs, completions),
+        maxProgressGapMs     : progress.maxProgressGapMs,
         maxProviderDurationMs: Math.max(...providerDurations),
         observedMaxProviderConcurrency,
         offeredOperations    : sourceCalls.length,
@@ -690,7 +713,7 @@ function deriveLaneReceipt({ids, lane, laneName, plan, profile, trial}) {
             outcome      : call.outcome,
             source       : call.source
         })),
-        throughputPerSecond   : completions.length / (windowMs / 1000),
+        throughputPerSecond   : completions.length / (progress.activeDurationMs / 1000),
         unexpectedRefusalCount: sourceCalls.filter(call => call.outcome === 'unexpected-refusal').length
     }
 }
@@ -1097,7 +1120,6 @@ function evaluateLane({allocation, failures, lane, laneName, runId, slo}) {
     requiredCount !== lane.providerOperationCount && fail('QUEUE_DISPOSITION_MISMATCH');
     lane.maxNeoQueueWaitMs !== null && lane.maxNeoQueueWaitMs > slo.maxNeoQueueWaitMs && fail('QUEUE_WAIT_EXCEEDED');
     lane.maxProviderDurationMs > slo.maxProviderDurationMs && fail('PROVIDER_DURATION_EXCEEDED');
-    lane.throughputPerSecond < slo.minThroughputPerSecond && fail('THROUGHPUT_BELOW_SLO');
     lane.cpuHighWaterPercent > slo.maxCpuHighWaterPercent && fail('CPU_HIGH_WATER_EXCEEDED');
     lane.rssHighWaterBytes > slo.maxRssHighWaterBytes && fail('RSS_HIGH_WATER_EXCEEDED');
     lane.cpuHighWaterPercent > allocation.cpuCores * 100 && fail('CPU_ALLOCATION_EXCEEDED');
@@ -1158,16 +1180,74 @@ function getProfile(plan, candidate) {
 }
 
 /**
- * @summary Derives the largest no-completion interval across one measured trial.
- * @param {Number} startedAtMs Trial start.
- * @param {Number} completedAtMs Trial completion.
- * @param {Number[]} completions Durable completion timestamps.
- * @returns {Number}
+ * @summary Derives demand-active duration and the largest lane-local no-progress interval.
+ *
+ * Idle time before, after, or between lane-local demand waves is not starvation. Timestamp
+ * groups make adjacent demand/completion transitions deterministic: successful source-call
+ * completion resets the progress clock, while errors and refusals only close their outstanding
+ * call. An all-failure demand wave therefore retains its full active duration as the gap.
+ *
+ * @param {Object[]} sourceCalls Validated lane-local source-call lifecycles.
+ * @returns {{activeDurationMs: Number, maxProgressGapMs: Number}}
  */
-function deriveMaxProgressGap(startedAtMs, completedAtMs, completions) {
-    const points = [startedAtMs, ...completions.sort((a, b) => a - b), completedAtMs];
+function deriveLaneProgress(sourceCalls) {
+    const events = new Map();
 
-    return Math.max(...points.slice(1).map((point, index) => point - points[index]))
+    for (const call of sourceCalls) {
+        const demand = events.get(call.demandAtMs) ?? {
+                  atMs                 : call.demandAtMs,
+                  completions          : 0,
+                  demands              : 0,
+                  successfulCompletions: 0
+              },
+              completion = events.get(call.completedAtMs) ?? {
+                  atMs                 : call.completedAtMs,
+                  completions          : 0,
+                  demands              : 0,
+                  successfulCompletions: 0
+              };
+
+        demand.demands++;
+        completion.completions++;
+        call.outcome === 'completed' && completion.successfulCompletions++;
+
+        events.set(call.demandAtMs, demand);
+        events.set(call.completedAtMs, completion)
+    }
+
+    let activeDurationMs = 0,
+        gapStartedAtMs   = null,
+        maxGapMs         = 0,
+        outstanding      = 0,
+        priorAtMs        = null;
+
+    for (const event of [...events.values()].sort((a, b) => a.atMs - b.atMs)) {
+        if (outstanding > 0) {
+            activeDurationMs += event.atMs - priorAtMs
+        }
+
+        if (outstanding === 0 && event.demands > 0) {
+            gapStartedAtMs = event.atMs
+        }
+
+        outstanding += event.demands;
+
+        if (event.successfulCompletions > 0) {
+            maxGapMs = Math.max(maxGapMs, event.atMs - gapStartedAtMs);
+            gapStartedAtMs = event.atMs
+        }
+
+        outstanding -= event.completions;
+
+        if (outstanding === 0) {
+            maxGapMs = Math.max(maxGapMs, event.atMs - gapStartedAtMs);
+            gapStartedAtMs = null
+        }
+
+        priorAtMs = event.atMs
+    }
+
+    return {activeDurationMs, maxProgressGapMs: maxGapMs}
 }
 
 /**

--- a/test/playwright/unit/ai/scripts/benchmark/ProviderLaneElectionCore.spec.mjs
+++ b/test/playwright/unit/ai/scripts/benchmark/ProviderLaneElectionCore.spec.mjs
@@ -32,15 +32,13 @@ function buildFixture() {
                     maxCpuHighWaterPercent : 200,
                     maxRssHighWaterBytes   : 3_000_000_000,
                     minCompletedOperations : 2,
-                    minContextTokensPerSlot: 131_072,
-                    minThroughputPerSecond : 0.3
+                    minContextTokensPerSlot: 131_072
                 }),
                 embedding: buildLaneSlo({
                     maxCpuHighWaterPercent : 400,
                     maxRssHighWaterBytes   : 5_000_000_000,
                     minCompletedOperations : 4,
-                    minContextTokensPerSlot: 8192,
-                    minThroughputPerSecond : 0.5
+                    minContextTokensPerSlot: 8192
                 })
             }
         },
@@ -122,8 +120,7 @@ function buildLaneSlo({
     maxCpuHighWaterPercent,
     maxRssHighWaterBytes,
     minCompletedOperations,
-    minContextTokensPerSlot,
-    minThroughputPerSecond
+    minContextTokensPerSlot
 }) {
     return {
         maxCpuHighWaterPercent,
@@ -137,7 +134,6 @@ function buildLaneSlo({
         minCompletedOperations,
         minContextTokensPerSlot,
         minResourceCoverageRatio: 0.95,
-        minThroughputPerSecond,
         requiredQueueDisposition: 'queued'
     }
 }
@@ -453,7 +449,7 @@ test.describe('providerLaneElectionCore', () => {
 
         expect(trial.maxNeoQueueWaitMs).toBeNull();
         expect(trial.maxProviderDurationMs).toBe(900);
-        expect(trial.throughputPerSecond).toBe(0.8);
+        expect(trial.throughputPerSecond).toBeCloseTo(4 / 4.05);
         expect(queue).toEqual({max: null, median: null, min: null, n: 0, observedRange: null, p95: null})
     });
 
@@ -477,7 +473,7 @@ test.describe('providerLaneElectionCore', () => {
 
         expect(observed.providerOperationCount).toBe(7);
         expect(observed.completedOperations).toBe(4);
-        expect(observed.throughputPerSecond).toBe(0.8);
+        expect(observed.throughputPerSecond).toBeCloseTo(4 / 3.85);
         expect(observed.sourceCalls.filter(call => call.source === 'memory-core')).toHaveLength(1);
 
         const failedFixture = buildFixture(),
@@ -493,6 +489,74 @@ test.describe('providerLaneElectionCore', () => {
         expect(failedObserved.completedOperations).toBe(3);
         expect(failedObserved.errorCount).toBe(1);
         expect(failedCandidate.failures.map(failure => failure.code)).toContain('ERROR_BUDGET_EXCEEDED')
+    });
+
+    test('measures progress gaps only while the lane has outstanding demand', () => {
+        const fixture = buildFixture(),
+              trial   = fixture.trials.find(item => item.candidate === 1),
+              lane    = trial.lanes.chat,
+              timings = [
+                  {completedAtMs: trial.startedAtMs + 500, demandAtMs: trial.startedAtMs + 100},
+                  {completedAtMs: trial.startedAtMs + 800, demandAtMs: trial.startedAtMs + 200}
+              ];
+
+        lane.sourceCalls.forEach((call, index) => {
+            const operation = lane.operations[index],
+                  timing    = timings[index];
+
+            call.demandAtMs = operation.enqueuedAtMs = timing.demandAtMs;
+            operation.providerStartedAtMs = index === 0 ? timing.demandAtMs + 100 : timings[index - 1].completedAtMs;
+            call.completedAtMs = operation.completedAtMs = timing.completedAtMs
+        });
+
+        const result    = evaluateProviderLaneElection(fixture),
+              candidate = result.candidates.find(item => item.candidate === 1),
+              observed  = candidate.trials[0].lanes.chat;
+
+        expect(observed.maxProgressGapMs).toBe(400);
+        expect(observed.throughputPerSecond).toBeCloseTo(2 / 0.7);
+        expect(candidate.failures.map(failure => failure.code)).not.toContain('PROGRESS_GAP_EXCEEDED')
+    });
+
+    test('excludes idle demand gaps and does not count errors or refusals as progress', () => {
+        const fixture = buildFixture(),
+              trial   = fixture.trials.find(item => item.candidate === 4),
+              lane    = trial.lanes.embedding,
+              timings = [
+                  {completedAtMs: 1000, demandAtMs: 100, outcome: 'error'},
+                  {completedAtMs: 900, demandAtMs: 200, outcome: 'error'},
+                  {completedAtMs: 1100, demandAtMs: 300, outcome: 'unexpected-refusal'},
+                  {completedAtMs: 3400, demandAtMs: 3000, outcome: 'completed'}
+              ];
+
+        lane.sourceCalls.forEach((call, index) => {
+            const operation = lane.operations[index],
+                  timing    = timings[index];
+
+            call.demandAtMs = operation.enqueuedAtMs = trial.startedAtMs + timing.demandAtMs;
+            operation.providerStartedAtMs = call.demandAtMs + 100;
+            call.completedAtMs = operation.completedAtMs = trial.startedAtMs + timing.completedAtMs;
+            call.outcome = timing.outcome;
+            operation.outcome = timing.outcome === 'completed' ? 'completed' : 'error'
+        });
+
+        const result    = evaluateProviderLaneElection(fixture),
+              candidate = result.candidates.find(item => item.candidate === 4),
+              observed  = candidate.trials[0].lanes.embedding;
+
+        expect(observed.completedOperations).toBe(1);
+        expect(observed.maxProgressGapMs).toBe(1000);
+        expect(observed.throughputPerSecond).toBeCloseTo(1 / 1.4);
+        expect(observed.errorCount).toBe(2);
+        expect(observed.unexpectedRefusalCount).toBe(1)
+    });
+
+    test('rejects obsolete throughput gates instead of silently omitting them', () => {
+        const fixture = buildFixture();
+
+        fixture.plan.slo.lanes.chat.minThroughputPerSecond = Number.MAX_SAFE_INTEGER;
+
+        expect(() => evaluateProviderLaneElection(fixture)).toThrow(/requires exact fields/)
     });
 
     test('derives CPU/RSS coverage from raw chronological samples and fails real coverage gaps', () => {
@@ -781,7 +845,6 @@ test.describe('providerLaneElectionCore', () => {
         const fixture = buildFixture(),
               trial   = fixture.trials[0];
 
-        fixture.plan.slo.lanes.embedding.token = 'SLO_SECRET';
         fixture.plan.resourceSampling.token = 'SAMPLER_SECRET';
         trial.lanes.embedding.runtimeProfile.token = 'RUNTIME_SECRET';
         trial.lanes.embedding.operations[0].id = '/tenant/private/corpus/row';
@@ -796,7 +859,6 @@ test.describe('providerLaneElectionCore', () => {
         expect(serialized).not.toContain('SECRET');
         expect(serialized).not.toContain('/tenant/private/corpus/row');
         expect(serialized).not.toContain('sk-private-provider-token');
-        expect(result.jointSlo.lanes.embedding.token).toBeUndefined();
         expect(result.planCoordinates.resourceSampling.token).toBeUndefined();
         expect(lane.runtimeProfile.token).toBeUndefined();
         expect(lane.operations[0].id).toMatch(/^sha256:[0-9a-f]{64}$/);

--- a/test/playwright/unit/ai/scripts/benchmark/ProviderLaneElectionRunner.spec.mjs
+++ b/test/playwright/unit/ai/scripts/benchmark/ProviderLaneElectionRunner.spec.mjs
@@ -118,7 +118,6 @@ function buildLaneSlo({context, cpu, memory, operations}) {
         minCompletedOperations  : operations,
         minContextTokensPerSlot : context,
         minResourceCoverageRatio: 0.9,
-        minThroughputPerSecond  : 0.001,
         requiredQueueDisposition: 'queued'
     }
 }


### PR DESCRIPTION
Resolves #17034

Related: #17024

Corrects the provider-lane election core after the first execution attempt falsified its progress metric. Lane progress gaps and measured throughput now use the union of lane-local, demand-active source-call intervals instead of the global joint-trial window. Successful calls reset progress; errors and refusals terminate demand without masquerading as progress; idle time before, after, or between demand waves is excluded. Throughput remains a reported measurement, while the ungrounded minimum-throughput policy is removed and obsolete SLO keys fail closed.

Evidence: L2 (pure-core behavior, receipt recomputation, and regression matrix) achieved. The live L3 election is outside this runner-substrate repair and remains independently owned by `#17024`. No benchmark workload ran after the host-isolation falsifier; a resident plane and disposable election plane will not run concurrently.

## Deltas from ticket

This reopens the existing runner-substrate leaf `#17034` only long enough to repair a pre-L3 measurement defect in the substrate delivered by PR `#17031`. The execution contract is tightened operationally: use one exclusive plane in a maintenance window or a clean separate host. Host swap is not an election metric.

## Test Evidence

- `NEO_TEST_SKIP_CI=true npm run test-unit -- test/playwright/unit/ai/scripts/benchmark/ProviderLaneElectionCore.spec.mjs test/playwright/unit/ai/scripts/benchmark/ProviderLaneElectionRunner.spec.mjs test/playwright/unit/ai/scripts/diagnostics/ProviderLaneComposition.spec.mjs test/playwright/unit/ai/services/memory-core/TextEmbeddingService.retry.spec.mjs` — 96/96 passed.
- `node --check` — all three changed `.mjs` files passed.
- `git diff --check` — passed.
- `check-block-alignment.mjs` — passed for all changed files.
- `npm run agent-preflight -- --no-fix --change-class restoration ...` — passed.

## Post-Merge Validation

- None for this repair leaf. The separate live-election outcome remains owned by `#17024`.

## Evolution

The first bounded run exposed two false policies before workload evidence was accepted: a global trial tail was being counted as lane-local starvation, and `minThroughputPerSecond: 0.001` could not independently reject any receipt that survived the worker deadline. The repair moves progress and throughput to demand-active lane time, keeps throughput observable but report-only, and rejects stale throughput-policy keys rather than silently dropping them from the plan digest.

Authored by Euclid (GPT-5, Codex Desktop). Session 019fe0b1-114b-7c30-aaf4-8317c1f99d4b.
