### PR TITLE
feat: one immutable cutover manifest copies every provider-lane coordinate from validated receipts (#17026)

### DIFF
--- a/ai/scripts/diagnostics/providerLaneCutoverManifest.mjs
+++ b/ai/scripts/diagnostics/providerLaneCutoverManifest.mjs
@@ -1,0 +1,315 @@
+import {createHash}                   from 'node:crypto';
+import {execFileSync}                 from 'node:child_process';
+import fs                             from 'node:fs';
+import path                           from 'node:path';
+import {fileURLToPath, pathToFileURL} from 'node:url';
+import {
+    digestProviderLaneValue,
+    validateProviderLaneElectionReport
+} from '../benchmark/provider-lane-election.mjs';
+import {projectVectorGenerationHealth} from '../../services/shared/vector/generationElectionStore.mjs';
+
+/**
+ * @module ai/scripts/diagnostics/providerLaneCutoverManifest
+ * @summary Aggregates the epic's validated receipts into ONE immutable cutover manifest — every
+ * manifest field is COPIED from a validated source, never derived or defaulted here.
+ *
+ * The generator owns zero configuration knowledge. The elected report is the single input
+ * authority for lane identities, envelopes, and deployment inputs (its embedded selected receipt
+ * is revalidated by {@link validateProviderLaneElectionReport} including a full election
+ * recomputation), git ancestry is the authority for revision containment, and the vector-plane
+ * election record projection is the authority for the current/rollback generation pair. A cutover
+ * copied from any OTHER mix of sources is exactly the partial-apply incident class this manifest
+ * exists to refuse.
+ *
+ * Completeness is honest, not optimistic: receipt slots that have no evidence yet stay `null`,
+ * the manifest reports `status: 'incomplete'` with the missing slot names, and the CLI exits
+ * non-zero. Preflight before handoff is the generator itself — the output carries no timestamps,
+ * so re-running against the same cut declaration must reproduce the manifest byte-for-byte; any
+ * drift means a coordinate changed underneath the package.
+ */
+
+const __filename   = fileURLToPath(import.meta.url);
+const __dirname    = path.dirname(__filename);
+const PROJECT_ROOT = path.resolve(__dirname, '../../..');
+
+export const PROVIDER_LANE_CUTOVER_MANIFEST_SCHEMA_VERSION = 'provider-lane-cutover-manifest.v1';
+
+/**
+ * The six receipt classes one cutover binds. `composition` and `resourceElection` fill from the
+ * validated elected report; the other four arrive as evidence files while the epic's proof lanes
+ * land, and stay `null` (⇒ incomplete) until they exist.
+ */
+export const PROVIDER_LANE_CUTOVER_RECEIPT_SLOTS = Object.freeze([
+    'composition', 'resourceElection', 'containment', 'rebuild', 'promotion', 'rollback'
+]);
+
+const EVIDENCE_SLOT_NAMES = Object.freeze(['containment', 'rebuild', 'promotion', 'rollback']);
+const REVISION_PATTERN    = /^[0-9a-f]{40}$/;
+const DIGEST_PATTERN      = /^sha256:[0-9a-f]{64}$/;
+
+/**
+ * @summary Builds the cutover manifest from one cut declaration, refusing partial coordinates.
+ *
+ * The seams default to the real authorities; fixtures inject fakes to exercise the generator's
+ * own refusal and copy semantics without rebuilding full election evidence.
+ *
+ * @param {Object} options
+ * @param {Object} options.cut Cut declaration: `{revision, requiredPullRequests, electionReportPath,
+ * vectorGenerationDir, receiptSlots}` — exact keys, no defaults.
+ * @param {Function} [options.gitIsAncestor] `(ancestor, descendant) => Boolean` seam.
+ * @param {Function} [options.readFileBytes] `path => Buffer` seam for receipt files.
+ * @param {Function} [options.projectHealth] Vector-generation health projection seam.
+ * @param {Function} [options.validateElectionReport] Elected-report validator seam.
+ * @returns {Promise<Object>} The manifest; `status: 'incomplete'` when evidence slots are empty.
+ * @throws {Error} On any invalid, mismatched, or non-contained coordinate.
+ */
+export async function buildProviderLaneCutoverManifest({
+    cut,
+    gitIsAncestor          = defaultGitIsAncestor,
+    readFileBytes          = defaultReadFileBytes,
+    projectHealth          = projectVectorGenerationHealth,
+    validateElectionReport = validateProviderLaneElectionReport
+} = {}) {
+    requireExactKeys(cut, [
+        'electionReportPath', 'receiptSlots', 'requiredPullRequests', 'revision', 'vectorGenerationDir'
+    ], 'cut declaration');
+
+    const {revision} = cut;
+
+    if (!REVISION_PATTERN.test(revision ?? '')) {
+        throw new Error(`cut declaration revision must be a full 40-hex commit, got '${revision}'`)
+    }
+
+    if (!Array.isArray(cut.requiredPullRequests) || cut.requiredPullRequests.length === 0) {
+        throw new Error('cut declaration requires at least one required pull request')
+    }
+
+    for (const entry of cut.requiredPullRequests) {
+        requireExactKeys(entry, ['mergeCommit', 'number'], 'required pull request');
+
+        if (!Number.isInteger(entry.number) || entry.number <= 0 || !REVISION_PATTERN.test(entry.mergeCommit ?? '')) {
+            throw new Error(`required pull request entry is malformed: ${JSON.stringify(entry)}`)
+        }
+
+        if (!gitIsAncestor(entry.mergeCommit, revision)) {
+            throw new Error(`revision ${revision} does not contain PR #${entry.number} (merge ${entry.mergeCommit}); refusing to package a partial epic`)
+        }
+    }
+
+    const reportBytes = readFileBytes(cut.electionReportPath);
+    const report      = validateElectionReport(JSON.parse(reportBytes.toString('utf8')));
+
+    if (!gitIsAncestor(report.repositoryHead, revision)) {
+        throw new Error(`election evidence was measured at ${report.repositoryHead}, which revision ${revision} does not contain; re-elect or re-pin before packaging`)
+    }
+
+    // The elected outcome and its embedded selected receipt must agree on the deployment inputs —
+    // the real validator enforces this via full recomputation, but the manifest re-checks the one
+    // equality it copies from, so an injected or future validator cannot silently hand us a mix.
+    if (JSON.stringify(report.deploymentInputs) !== JSON.stringify(report.selectedReceipt?.deploymentInputs)) {
+        throw new Error('election report deploymentInputs disagree with its selected receipt; refusing a mixed profile')
+    }
+
+    const missing = [];
+    const health  = await projectHealth({dir: cut.vectorGenerationDir});
+
+    let vectorGeneration;
+
+    if (health.status === 'committed' && health.elected && health.parked) {
+        vectorGeneration = {
+            bound   : true,
+            status  : health.status,
+            epoch   : health.epoch,
+            current : health.elected,
+            rollback: health.parked
+        }
+    } else {
+        // A cutover ships while rollback authority still EXISTS: elected current + parked prior,
+        // i.e. committed-not-yet-accepted. Anything else cannot name both generations.
+        missing.push('vector-generation-committed-pair');
+        vectorGeneration = {bound: false, status: health.status}
+    }
+
+    requireExactKeys(cut.receiptSlots, EVIDENCE_SLOT_NAMES.filter(name => name in cut.receiptSlots), 'receipt slots');
+
+    const receiptSlots = {
+        composition: {
+            sha256: report.selectedReceiptDigest,
+            source: 'election-report:selectedReceipt'
+        },
+        resourceElection: {
+            path  : cut.electionReportPath,
+            sha256: sha256OfBytes(reportBytes)
+        }
+    };
+
+    for (const name of EVIDENCE_SLOT_NAMES) {
+        const slotPath = cut.receiptSlots[name];
+
+        if (typeof slotPath === 'string' && slotPath.length > 0) {
+            receiptSlots[name] = {path: slotPath, sha256: sha256OfBytes(readFileBytes(slotPath))}
+        } else {
+            missing.push(name);
+            receiptSlots[name] = null
+        }
+    }
+
+    return {
+        schemaVersion         : PROVIDER_LANE_CUTOVER_MANIFEST_SCHEMA_VERSION,
+        status                : missing.length === 0 ? 'complete' : 'incomplete',
+        missing,
+        neoRevision           : revision,
+        requiredPullRequests  : cut.requiredPullRequests.map(({number, mergeCommit}) => ({number, mergeCommit})),
+        electionRepositoryHead: report.repositoryHead,
+        deploymentInputs      : report.deploymentInputs,
+        lanes                 : report.selectedReceipt.lanes,
+        envelope              : report.selectedReceipt.envelope,
+        roles                 : report.selectedReceipt.roles,
+        selectedReceiptDigest : report.selectedReceiptDigest,
+        electionReportDigest  : digestProviderLaneValue(report),
+        vectorGeneration,
+        receiptSlots,
+        cutDeclarationDigest  : digestProviderLaneValue(cut)
+    }
+}
+
+/**
+ * @summary Validates one cutover manifest without touching the filesystem.
+ * @param {Object} manifest Candidate manifest.
+ * @param {Object} [options]
+ * @param {Boolean} [options.requireComplete=true] Refuse manifests with empty evidence slots.
+ * @returns {Object} The validated manifest.
+ * @throws {Error} On schema drift, status inconsistency, or (when required) incompleteness.
+ */
+export function validateProviderLaneCutoverManifest(manifest, {requireComplete = true} = {}) {
+    requireExactKeys(manifest, [
+        'cutDeclarationDigest', 'deploymentInputs', 'electionReportDigest', 'electionRepositoryHead',
+        'envelope', 'lanes', 'missing', 'neoRevision', 'receiptSlots', 'requiredPullRequests',
+        'roles', 'schemaVersion', 'selectedReceiptDigest', 'status', 'vectorGeneration'
+    ], 'cutover manifest');
+
+    if (manifest.schemaVersion !== PROVIDER_LANE_CUTOVER_MANIFEST_SCHEMA_VERSION ||
+        !['complete', 'incomplete'].includes(manifest.status) ||
+        !REVISION_PATTERN.test(manifest.neoRevision ?? '') ||
+        !REVISION_PATTERN.test(manifest.electionRepositoryHead ?? '') ||
+        !DIGEST_PATTERN.test(manifest.selectedReceiptDigest ?? '') ||
+        !DIGEST_PATTERN.test(manifest.electionReportDigest ?? '') ||
+        !DIGEST_PATTERN.test(manifest.cutDeclarationDigest ?? '')) {
+        throw new Error('cutover manifest has no complete canonical identity')
+    }
+
+    if (!Array.isArray(manifest.missing) || (manifest.status === 'complete') !== (manifest.missing.length === 0)) {
+        throw new Error('cutover manifest status disagrees with its missing-evidence list')
+    }
+
+    requireExactKeys(manifest.receiptSlots, [...PROVIDER_LANE_CUTOVER_RECEIPT_SLOTS].sort(), 'manifest receipt slots');
+
+    for (const name of PROVIDER_LANE_CUTOVER_RECEIPT_SLOTS) {
+        const slot = manifest.receiptSlots[name];
+
+        if (slot === null) {
+            if (!manifest.missing.includes(name)) {
+                throw new Error(`cutover manifest slot '${name}' is empty but not declared missing`)
+            }
+            continue
+        }
+
+        if (!DIGEST_PATTERN.test(slot?.sha256 ?? '') || !(typeof slot.path === 'string' || typeof slot.source === 'string')) {
+            throw new Error(`cutover manifest slot '${name}' carries no checksum-bound evidence reference`)
+        }
+    }
+
+    if (manifest.vectorGeneration?.bound !== true && !manifest.missing.includes('vector-generation-committed-pair')) {
+        throw new Error('cutover manifest has no bound generation pair and does not declare it missing')
+    }
+
+    if (requireComplete && manifest.status !== 'complete') {
+        throw new Error(`cutover manifest is incomplete (missing: ${manifest.missing.join(', ')}); handoff refused`)
+    }
+
+    return manifest
+}
+
+function defaultGitIsAncestor(ancestor, descendant) {
+    try {
+        execFileSync('git', ['merge-base', '--is-ancestor', ancestor, descendant], {cwd: PROJECT_ROOT, stdio: 'ignore'});
+        return true
+    } catch {
+        return false
+    }
+}
+
+function defaultReadFileBytes(filePath) {
+    return fs.readFileSync(path.resolve(PROJECT_ROOT, filePath))
+}
+
+function sha256OfBytes(bytes) {
+    return `sha256:${createHash('sha256').update(bytes).digest('hex')}`
+}
+
+function requireExactKeys(value, keys, label) {
+    const actual = Object.keys(value ?? {}).sort();
+
+    if (JSON.stringify(actual) !== JSON.stringify([...keys].sort())) {
+        throw new Error(`${label} must carry exactly [${[...keys].sort().join(', ')}], got [${actual.join(', ')}]`)
+    }
+}
+
+/**
+ * @summary Parses CLI arguments for the manifest generator.
+ * @param {String[]} argv Arguments without node/script.
+ * @returns {Object} `{cutPath, outPath}`.
+ */
+export function parseArgs(argv) {
+    let cutPath = null,
+        outPath = null;
+
+    for (let index = 0; index < argv.length; index++) {
+        const argument = argv[index];
+
+        if (argument === '--cut') {
+            cutPath = argv[++index];
+            if (!cutPath) throw new Error('--cut requires a file path');
+        } else if (argument === '--out') {
+            outPath = argv[++index];
+            if (!outPath) throw new Error('--out requires a file path');
+        } else {
+            throw new Error(`Unknown argument '${argument}'`)
+        }
+    }
+
+    if (!cutPath) throw new Error('--cut <declaration.json> is required');
+
+    return {cutPath, outPath}
+}
+
+/**
+ * @summary Reads one cut declaration and emits exactly one manifest JSON.
+ * @param {String[]} [argv] Arguments without node/script.
+ * @returns {Promise<Object>} Emitted manifest.
+ */
+export async function main(argv = process.argv.slice(2)) {
+    const {cutPath, outPath} = parseArgs(argv);
+    const cut                = JSON.parse(fs.readFileSync(path.resolve(PROJECT_ROOT, cutPath), 'utf8'));
+    const manifest           = await buildProviderLaneCutoverManifest({cut});
+    const serialized         = `${JSON.stringify(manifest, null, 2)}\n`;
+
+    if (outPath) {
+        fs.writeFileSync(path.resolve(PROJECT_ROOT, outPath), serialized)
+    } else {
+        process.stdout.write(serialized)
+    }
+
+    if (manifest.status !== 'complete') process.exitCode = 1;
+    return manifest
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+    try {
+        await main()
+    } catch (error) {
+        process.stderr.write(`providerLaneCutoverManifest: ${error.message}\n`);
+        process.exitCode = 2;
+    }
+}

--- a/learn/agentos/cloud-deployment/LlamaCppProfile.md
+++ b/learn/agentos/cloud-deployment/LlamaCppProfile.md
@@ -104,6 +104,15 @@ timestamp-free by design — if regenerating it from the same cut declaration
 does not reproduce it byte-for-byte, a coordinate moved and the package must
 not ship.
 
+**Cutover and rollback:** a cutover applies exactly one declarative revision —
+the packaged compose/profile files plus the manifest's deployment inputs — with
+no external-plane experiments and no staged partial applies. Post-cutover
+acceptance verifies both lane healthchecks, durable corpus visibility on the
+ingesting plane, and the elected-generation identity reported by the
+vector-generation health surface. Rollback restores the prior code revision and
+the full prior vector generation together — the previous manifest names both
+coordinates — and a code-only or collection-partial rollback is invalid.
+
 ## Environment example
 
 Pin model names and context bands to the actually loaded GGUF models. The values

--- a/learn/agentos/cloud-deployment/LlamaCppProfile.md
+++ b/learn/agentos/cloud-deployment/LlamaCppProfile.md
@@ -61,10 +61,48 @@ Do not hide two unrelated llama.cpp hosts behind one Neo config by manually
 switching `NEO_OPENAI_COMPATIBLE_HOST` between calls. That recreates the
 model-swap failure this profile is meant to prevent.
 
-If your only safe llama.cpp topology requires separate chat and embedding hosts
-with no shared OpenAI-compatible router, current Neo config cannot express that
-cleanly. Keep that topology out of production until Neo supports role-specific
-OpenAI-compatible hosts instead of documenting a manual operator workaround.
+If the deployment needs separate chat and embedding hosts, do not hand-switch
+one shared base URL between calls. Use the role-isolated two-lane profile below,
+which expresses exactly that topology declaratively.
+
+## Role-isolated two-lane profile
+
+The 2026-08-12 amendment of
+[ADR-0014](../decisions/0014-cloud-plane-local-model-provider.md) adds a second
+supported topology for constrained cloud planes: two role-isolated provider
+lanes composed by `ai/deploy/docker-compose.provider-lanes.yml` on top of the
+base deployment. Each model role resolves through its declared lane — the chat
+lane serves the `model`, `graph`, and `kbAskSynthesis` roles; the embedding
+lane (a dedicated `llama-server`) serves the `embedding` role. Neither lane can
+evict the other, which discharges the residency invariant structurally instead
+of by operator discipline.
+
+Three rules govern the profile; their source of truth is code, not this guide:
+
+- **No defaults, elected inputs only.** The profile requires every
+  `NEO_PROVIDER_LANE*` value at compose time and fails fast when one is
+  missing. The exact input set is `PROVIDER_LANE_DEPLOYMENT_INPUT_ENVS` in
+  `ai/scripts/diagnostics/providerLaneComposition.mjs`; the values come from
+  the resource election (`ai/scripts/benchmark/provider-lane-election.mjs`),
+  which measures candidate envelopes on a disposable canonical plane and emits
+  one validated report. Operators never hand-tune these numbers.
+- **Slot truth.** For the embedding lane, `/slots` is the admission and
+  settlement truth. The per-slot context figure is a guaranteed floor per
+  parallel slot; the lane's context ceiling applies per request. Do not
+  reinterpret one as the other when sizing ingestion batches.
+- **Immutable cutover coordinates.** A deployment consumes the elected values
+  through the cutover manifest
+  (`ai/scripts/diagnostics/providerLaneCutoverManifest.mjs`), which copies
+  every coordinate from validated receipts and refuses partial or mismatched
+  evidence. Copying values from an older template recreates the incident class
+  this profile removes.
+
+**Bump-and-revalidate ritual:** when an engine image or model pin changes,
+re-render the composition receipt, re-run the election on the canonical plane,
+and regenerate the cutover manifest from the new receipts. The manifest is
+timestamp-free by design — if regenerating it from the same cut declaration
+does not reproduce it byte-for-byte, a coordinate moved and the package must
+not ship.
 
 ## Environment example
 

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
         "ai:probe-community-activity-shadow"   : "node ./ai/scripts/maintenance/probeCommunityActivityShadow.mjs",
         "ai:probe-keep-alive"                  : "node ./ai/scripts/benchmark/keep-alive-probe.mjs",
         "ai:provider-lane-composition"         : "node ./ai/scripts/diagnostics/providerLaneComposition.mjs",
+        "ai:provider-lane-cutover-manifest"    : "node ./ai/scripts/diagnostics/providerLaneCutoverManifest.mjs",
         "ai:provider-lane-election"            : "node ./ai/scripts/benchmark/provider-lane-election.mjs",
         "ai:prune-worktrees"                   : "node ./ai/scripts/migrations/bootstrapWorktree.mjs --prune-stale",
         "ai:prune-worktrees:dry-run"           : "node ./ai/scripts/migrations/bootstrapWorktree.mjs --prune-stale --dry-run",

--- a/test/playwright/unit/ai/scripts/diagnostics/ProviderLaneCutoverManifest.spec.mjs
+++ b/test/playwright/unit/ai/scripts/diagnostics/ProviderLaneCutoverManifest.spec.mjs
@@ -1,0 +1,279 @@
+import {test, expect} from '@playwright/test';
+import {createHash}   from 'node:crypto';
+import fs             from 'node:fs';
+import os             from 'node:os';
+import path           from 'node:path';
+import {
+    PROVIDER_LANE_CUTOVER_MANIFEST_SCHEMA_VERSION,
+    PROVIDER_LANE_CUTOVER_RECEIPT_SLOTS,
+    buildProviderLaneCutoverManifest,
+    parseArgs,
+    validateProviderLaneCutoverManifest
+} from '../../../../../../ai/scripts/diagnostics/providerLaneCutoverManifest.mjs';
+
+const REVISION       = 'a'.repeat(40);
+const ELECTION_HEAD  = 'b'.repeat(40);
+const OUTSIDE_COMMIT = 'e'.repeat(40);
+const PR_MERGE       = 'd'.repeat(40);
+
+const DEPLOYMENT_INPUTS = Object.freeze({
+    chatCpuCores : {env: 'NEO_PROVIDER_LANE_CHAT_CPUS', value: '2'},
+    totalCpuCores: {env: 'NEO_PROVIDER_LANES_CPU_TOTAL', value: '4'}
+});
+
+function createReport() {
+    return {
+        repositoryHead  : ELECTION_HEAD,
+        deploymentInputs: structuredClone(DEPLOYMENT_INPUTS),
+        selectedReceipt : {
+            deploymentInputs: structuredClone(DEPLOYMENT_INPUTS),
+            lanes           : {
+                chat     : {dnsName: 'chat-model', image: 'img@sha256:1', model: 'gemma@sha256:2'},
+                embedding: {dnsName: 'embedding-model', image: 'img@sha256:3', model: 'embed@sha256:4'}
+            },
+            envelope: {allocations: {}, scope: 'provider-runtimes', total: {cpuCores: 4, memoryBytes: 8}},
+            roles   : {embedding: 'embedding', graph: 'chat', kbAskSynthesis: 'chat', model: 'chat'}
+        },
+        selectedReceiptDigest: `sha256:${'c'.repeat(64)}`
+    }
+}
+
+function committedHealth() {
+    return {
+        status : 'committed',
+        epoch  : 3,
+        elected: {generationId: 'gen-2', embeddingGenerationId: 'embed-2', declaredAt: 't2', coordinates: {provider: 'llamaCpp'}},
+        parked : {generationId: 'gen-1', embeddingGenerationId: 'embed-1', declaredAt: 't1', coordinates: {provider: 'ollama'}}
+    }
+}
+
+function sha256(value) {
+    return `sha256:${createHash('sha256').update(value).digest('hex')}`
+}
+
+function createFixture({health = committedHealth(), report = createReport(), slots} = {}) {
+    const dir        = fs.mkdtempSync(path.join(os.tmpdir(), 'cutover-manifest-'));
+    const reportPath = path.join(dir, 'election-report.json');
+    const ancestry   = new Set([ELECTION_HEAD, PR_MERGE]);
+
+    fs.writeFileSync(reportPath, JSON.stringify(report));
+
+    const receiptSlots = {};
+
+    for (const [name, content] of Object.entries(slots ?? {})) {
+        const slotPath = path.join(dir, `${name}.json`);
+
+        fs.writeFileSync(slotPath, content);
+        receiptSlots[name] = slotPath
+    }
+
+    return {
+        cut: {
+            revision            : REVISION,
+            requiredPullRequests: [{number: 17020, mergeCommit: PR_MERGE}],
+            electionReportPath  : reportPath,
+            vectorGenerationDir : path.join(dir, 'vector-generation'),
+            receiptSlots
+        },
+        seams: {
+            gitIsAncestor         : ancestor => ancestry.has(ancestor),
+            readFileBytes         : filePath => fs.readFileSync(filePath),
+            projectHealth         : async () => health,
+            validateElectionReport: value => structuredClone(value)
+        },
+        dir,
+        reportPath
+    }
+}
+
+const ALL_SLOT_CONTENT = Object.freeze({
+    containment: '{"verdict":"PASS"}',
+    rebuild    : '{"resumed":true}',
+    promotion  : '{"promoted":5}',
+    rollback   : '{"restored":5}'
+});
+
+test.describe('providerLaneCutoverManifest (#17026)', () => {
+    test('a complete cut copies every coordinate from its validated sources', async () => {
+        const {cut, seams, reportPath} = createFixture({slots: ALL_SLOT_CONTENT});
+        const manifest                 = await buildProviderLaneCutoverManifest({cut, ...seams});
+
+        expect(manifest.schemaVersion).toBe(PROVIDER_LANE_CUTOVER_MANIFEST_SCHEMA_VERSION);
+        expect(manifest.status).toBe('complete');
+        expect(manifest.missing).toEqual([]);
+        expect(manifest.neoRevision).toBe(REVISION);
+        expect(manifest.electionRepositoryHead).toBe(ELECTION_HEAD);
+
+        // Copy-not-derive: the manifest's profile fields are byte-equal to the report's.
+        const report = createReport();
+
+        expect(manifest.deploymentInputs).toEqual(report.deploymentInputs);
+        expect(manifest.lanes).toEqual(report.selectedReceipt.lanes);
+        expect(manifest.envelope).toEqual(report.selectedReceipt.envelope);
+        expect(manifest.roles).toEqual(report.selectedReceipt.roles);
+        expect(manifest.selectedReceiptDigest).toBe(report.selectedReceiptDigest);
+
+        expect(manifest.vectorGeneration).toEqual({
+            bound   : true,
+            status  : 'committed',
+            epoch   : 3,
+            current : committedHealth().elected,
+            rollback: committedHealth().parked
+        });
+
+        expect(manifest.receiptSlots.composition).toEqual({
+            sha256: report.selectedReceiptDigest,
+            source: 'election-report:selectedReceipt'
+        });
+        expect(manifest.receiptSlots.resourceElection.sha256).toBe(sha256(fs.readFileSync(reportPath)));
+        expect(manifest.receiptSlots.containment.sha256).toBe(sha256(ALL_SLOT_CONTENT.containment));
+
+        validateProviderLaneCutoverManifest(manifest)
+    });
+
+    test('regenerating from the same cut reproduces the manifest byte-for-byte', async () => {
+        const {cut, seams} = createFixture({slots: ALL_SLOT_CONTENT});
+        const first        = await buildProviderLaneCutoverManifest({cut, ...seams});
+        const second       = await buildProviderLaneCutoverManifest({cut, ...seams});
+
+        expect(JSON.stringify(second)).toBe(JSON.stringify(first))
+    });
+
+    test('a revision that does not contain a required PR refuses by number', async () => {
+        const {cut, seams} = createFixture();
+
+        cut.requiredPullRequests = [{number: 17028, mergeCommit: OUTSIDE_COMMIT}];
+
+        await expect(buildProviderLaneCutoverManifest({cut, ...seams}))
+            .rejects.toThrow(/does not contain PR #17028/)
+    });
+
+    test('election evidence measured outside the pinned revision refuses', async () => {
+        const report = createReport();
+
+        report.repositoryHead = OUTSIDE_COMMIT;
+
+        const {cut, seams} = createFixture({report});
+
+        await expect(buildProviderLaneCutoverManifest({cut, ...seams}))
+            .rejects.toThrow(/measured at e{40}/)
+    });
+
+    test('an elected outcome disagreeing with its selected receipt refuses as a mixed profile', async () => {
+        const report = createReport();
+
+        report.selectedReceipt.deploymentInputs.chatCpuCores.value = '4';
+
+        const {cut, seams} = createFixture({report});
+
+        await expect(buildProviderLaneCutoverManifest({cut, ...seams}))
+            .rejects.toThrow(/mixed profile/)
+    });
+
+    test('the election validator refusal propagates before any packaging', async () => {
+        const {cut, seams} = createFixture();
+
+        seams.validateElectionReport = () => {
+            throw new Error('provider-lane downstream proof requires an elected report')
+        };
+
+        await expect(buildProviderLaneCutoverManifest({cut, ...seams}))
+            .rejects.toThrow(/requires an elected report/)
+    });
+
+    test('an uncommitted generation pair marks the manifest incomplete, never bound', async () => {
+        const {cut, seams} = createFixture({health: {status: 'accepted'}, slots: ALL_SLOT_CONTENT});
+        const manifest     = await buildProviderLaneCutoverManifest({cut, ...seams});
+
+        expect(manifest.status).toBe('incomplete');
+        expect(manifest.missing).toEqual(['vector-generation-committed-pair']);
+        expect(manifest.vectorGeneration).toEqual({bound: false, status: 'accepted'});
+
+        expect(() => validateProviderLaneCutoverManifest(manifest)).toThrow(/handoff refused/);
+        validateProviderLaneCutoverManifest(manifest, {requireComplete: false})
+    });
+
+    test('missing evidence files stay null slots and name themselves', async () => {
+        const {cut, seams} = createFixture({slots: {containment: ALL_SLOT_CONTENT.containment}});
+        const manifest     = await buildProviderLaneCutoverManifest({cut, ...seams});
+
+        expect(manifest.status).toBe('incomplete');
+        expect(manifest.missing).toEqual(['rebuild', 'promotion', 'rollback']);
+        expect(manifest.receiptSlots.containment).not.toBeNull();
+        expect(manifest.receiptSlots.rebuild).toBeNull()
+    });
+
+    test('cut declarations refuse unknown keys, foreign slots, and malformed PR entries', async () => {
+        const base = () => createFixture({slots: ALL_SLOT_CONTENT});
+
+        {
+            const {cut, seams} = base();
+
+            cut.surprise = true;
+            await expect(buildProviderLaneCutoverManifest({cut, ...seams})).rejects.toThrow(/cut declaration must carry exactly/)
+        }
+        {
+            const {cut, seams} = base();
+
+            cut.receiptSlots.bogus = '/tmp/x';
+            await expect(buildProviderLaneCutoverManifest({cut, ...seams})).rejects.toThrow(/receipt slots/)
+        }
+        {
+            const {cut, seams} = base();
+
+            cut.requiredPullRequests = [{number: 0, mergeCommit: PR_MERGE}];
+            await expect(buildProviderLaneCutoverManifest({cut, ...seams})).rejects.toThrow(/malformed/)
+        }
+        {
+            const {cut, seams} = base();
+
+            cut.revision = 'dev';
+            await expect(buildProviderLaneCutoverManifest({cut, ...seams})).rejects.toThrow(/full 40-hex commit/)
+        }
+    });
+
+    test('the manifest validator refuses tampered shapes', async () => {
+        const {cut, seams} = createFixture({slots: ALL_SLOT_CONTENT});
+        const manifest     = await buildProviderLaneCutoverManifest({cut, ...seams});
+
+        {
+            const tampered = structuredClone(manifest);
+
+            tampered.extra = 1;
+            expect(() => validateProviderLaneCutoverManifest(tampered)).toThrow(/must carry exactly/)
+        }
+        {
+            const tampered = structuredClone(manifest);
+
+            tampered.receiptSlots.rebuild = null;
+            expect(() => validateProviderLaneCutoverManifest(tampered)).toThrow(/empty but not declared missing/)
+        }
+        {
+            const tampered = structuredClone(manifest);
+
+            tampered.missing = ['rebuild'];
+            expect(() => validateProviderLaneCutoverManifest(tampered)).toThrow(/status disagrees/)
+        }
+        {
+            const tampered = structuredClone(manifest);
+
+            tampered.receiptSlots.containment = {path: 'x', sha256: 'sha256:short'};
+            expect(() => validateProviderLaneCutoverManifest(tampered)).toThrow(/checksum-bound/)
+        }
+        {
+            const tampered = structuredClone(manifest);
+
+            tampered.vectorGeneration = {bound: false, status: 'accepted'};
+            expect(() => validateProviderLaneCutoverManifest(tampered)).toThrow(/does not declare it missing/)
+        }
+
+        expect(PROVIDER_LANE_CUTOVER_RECEIPT_SLOTS).toHaveLength(6)
+    });
+
+    test('the CLI surface requires --cut and rejects unknown arguments', () => {
+        expect(() => parseArgs([])).toThrow(/--cut/);
+        expect(() => parseArgs(['--cut'])).toThrow(/requires a file path/);
+        expect(() => parseArgs(['--cut', 'a.json', '--nope'])).toThrow(/Unknown argument/);
+        expect(parseArgs(['--cut', 'a.json', '--out', 'b.json'])).toEqual({cutPath: 'a.json', outPath: 'b.json'})
+    })
+});


### PR DESCRIPTION
Resolves neomjs/neo#17026

Refs neomjs/neo#17023

Refs neomjs/neo#17035

Refs neomjs/neo#17018

One generator/validator pair turns the epic's validated receipts into a single immutable cutover coordinate. `buildProviderLaneCutoverManifest` copies — never derives — every profile field from its validated source: git ancestry proves the pinned revision contains each required PR merge, `validateProviderLaneElectionReport` supplies the elected deployment inputs and the embedded selected composition receipt (lanes, envelope, roles), and `projectVectorGenerationHealth` supplies the committed current/rollback generation pair. Evidence receipts (containment, rebuild, promotion, rollback) bind by file checksum; empty slots keep the manifest honestly `incomplete` with a non-zero exit, and `validateProviderLaneCutoverManifest` refuses handoff until it is `complete`. The manifest is timestamp-free, so preflight is the generator itself: regenerating from the same cut declaration must reproduce it byte-for-byte. `LlamaCppProfile.md` gains the role-isolated two-lane profile, slot-truth rule, immutable-election rule, bump-and-revalidate ritual, and the single-revision cutover/paired-rollback gates — all by reference to the owning code, no copied defaults.

**Stacked note:** this branch is currently stacked on the neomjs/neo#17035 primitives PR head (PR neomjs/neo#17029), because the generator imports `projectVectorGenerationHealth` from that leaf. Until PR neomjs/neo#17029 merges, its commits appear in this diff; the entire neomjs/neo#17026 delta is exactly commits `1d4a39fad2` + `263d333f2e` (637 + 9 lines). After neomjs/neo#17029 merges I rebase onto `dev` and the diff collapses to those two commits.

Evidence: L2 (11 unit fixtures over injected authority seams; no live canonical-plane run is reachable from this sandbox) → L3 required (AC-8: generate and validate the real manifest on the canonical plane once the election and rebuild/containment receipts exist). Residual: AC-8, Residual-Owner: neomjs/neo#17018.

## Deltas from ticket

- **The elected report is the single input authority.** The ticket sketched separate composition + election inputs; the election report already embeds and revalidates its selected composition receipt (full recomputation inside `validateProviderLaneElectionReport`), so a separate composition input would only add a mismatch class. The composition slot binds `selectedReceiptDigest` instead.
- **Preflight = deterministic regeneration.** Instead of a second verification instrument, the manifest carries no timestamps and the generator is pure over its inputs; byte-compare of a regeneration IS the refuse-partial/mismatched-coordinates preflight.
- **Committed-pair rule made explicit:** the generation slot binds only while the election is `committed` (elected current + parked rollback both live) — the exact window in which rollback authority provably exists.

## Test Evidence

- `npx playwright test test/playwright/unit/ai/scripts/diagnostics/ProviderLaneCutoverManifest.spec.mjs --workers=1` → **11 passed** (copy-not-derive equality, byte-identical regeneration, ancestry refusal by PR number, out-of-revision election evidence, mixed-profile refusal, validator-throw propagation, uncommitted-pair incompleteness, null-slot naming, malformed cut/slot/PR-entry refusals, tampered-manifest refusals, CLI argument surface).
- Touched surfaces: `ai/scripts/diagnostics/` — new spec above; `learn/agentos/cloud-deployment/LlamaCppProfile.md` — docs, None found; `package.json` — script entry, covered by CLI-surface arm.

## Post-Merge Validation

- [ ] Generate the real manifest on the canonical plane once the neomjs/neo#17024 election report and the neomjs/neo#17023/#17025 receipts exist (AC-8) and attach it to the epic closeout.
- [ ] Byte-identical regeneration check on that real manifest before operator handoff.
- [ ] External application remains an explicit L4 operator residual on the epic closeout matrix (AC-9).

Residual-Owner: neomjs/neo#17018

## Commits

- `1d4a39fad2` — generator, validator, CLI, 11-arm spec, npm script
- `263d333f2e` — profile-guide cutover/rollback gate sections

## Signal Ledger

| Family | Peer | Signal |
|---|---|---|
| GPT | Emmy, Euclid | D#17015 r6 convergence; epic neomjs/neo#17018 seven-leaf greenlight; neomjs/neo#17026 ticket authored by Emmy |
| Claude (author) | Vega | this PR, per the epic re-plan |
| Kimi | Phoebe | no dissent recorded; lane is epic-external |

Gemini seats remain benched (operator roster); quorum per D#17015 graduation carries GPT + Claude with no non-author-family dissent.

## Unresolved Dissent

None.

## Unresolved Liveness

None.

Authored by Vega (Claude Fable 5, Claude Code). Session 379c88ee-52c5-41ad-8973-8f28ebc8cbd6.
