### PR TITLE
feat(ai): lease waiters register durably and acquisition yields to bootstrap-critical and starving work (#16561)

### DIFF
--- a/ai/configBase.mjs
+++ b/ai/configBase.mjs
@@ -1312,7 +1312,12 @@ class ConfigBase extends ConfigProvider {
                  * @type {Object}
                  */
                 heavyMaintenanceLease: {
-                    staleAfterMs: leaf(6 * 60 * 60 * 1000, 'NEO_HEAVY_MAINTENANCE_LEASE_TTL_MS', 'number')
+                    staleAfterMs: leaf(6 * 60 * 60 * 1000, 'NEO_HEAVY_MAINTENANCE_LEASE_TTL_MS', 'number'),
+                    // Fairness bound: an acquirer that is NOT the waiter yields to a registered waiter
+                    // whose unbroken deferral streak exceeds this. Deliberately generous — sized as a
+                    // starvation ceiling, not a scheduling optimization — thresholds derived from a
+                    // misbehaving system's observations bound the wrong quantity.
+                    fairnessYieldAfterMs: leaf(30 * 60 * 1000, 'NEO_HEAVY_MAINTENANCE_LEASE_FAIRNESS_YIELD_MS', 'number')
                 },
                 /**
                  * Maintenance-loop intervals consumed by the orchestrator daemon.

--- a/ai/daemons/orchestrator/Orchestrator.mjs
+++ b/ai/daemons/orchestrator/Orchestrator.mjs
@@ -95,6 +95,15 @@ import {
 } from './services/heavyMaintenanceLeasePrimitives.mjs';
 import {resolveCloudOnlyDefault} from './services/deploymentDurabilityPosture.mjs';
 
+/**
+ * Deadline for the boot-time configured-tenant-repo coverage prewarm. An internal liveness bound
+ * rather than deployment policy: exceeding it costs ranking precision on the first sweep (the
+ * unresolved fail-safe posture still ranks bootstrap), while an unbounded wait would stop the
+ * daemon from polling at all.
+ * @type {Number}
+ */
+export const CONFIGURED_TENANT_REPO_PREWARM_TIMEOUT_MS = 10_000;
+
 /** @summary Opens/creates the orchestrator sqlite DB via the shared Memory Core schema bootstrap. */
 export async function initializeDatabaseSelfBootstrap(dbPath) {
     const storage = Neo.create(SQLite, {dbPath});
@@ -1521,19 +1530,59 @@ export class Orchestrator extends Base {
             }
         }
 
-        // Resolve configured tenant-repo coverage BEFORE the first sweep. The bootstrap-critical
-        // rank is evaluated synchronously inside the picker, so a fire-and-forget refresh would
-        // leave the very first scheduling decision running on unresolved coverage — on a first
-        // deployment that ranks the bootstrap lane as ordinary and hands the heavy lease to a
-        // more-stale REM cycle for its full duration, losing the one decision the class exists to
-        // win. Awaited rather than raced; the call never rejects, so a resolver outage delays
-        // nothing.
-        await this.maintenanceBackpressureService.ensureConfiguredTenantRepoLabels?.();
+        await this.prewarmConfiguredTenantRepoCoverage();
 
         this.isPolling = true;
         this.writeLog('INFO', `[Orchestrator] Started. authorityProfile=${this.authorityProfile} authorityReceipt=${this.authorityReceiptFile} summaryInterval=${AiConfig.orchestrator.intervals.summarySweepMs}ms kbSyncInterval=${AiConfig.orchestrator.intervals.kbSyncMs}ms poll=${AiConfig.orchestrator.intervals.pollMs}ms.`);
         this.announceDisabledLanes();
         this.poll();
+    }
+
+    /**
+     * @summary Resolves configured tenant-repo coverage before the first scheduling sweep, gated to
+     * the owning profile and bounded by a deadline.
+     *
+     * The bootstrap-critical rank is evaluated synchronously inside the picker, so a fire-and-forget
+     * refresh would leave the very first scheduling decision running on unresolved coverage — on a
+     * first deployment that ranks the bootstrap lane ordinary and hands the heavy lease to a
+     * more-stale REM cycle for its full duration.
+     *
+     * Two boundaries make that prewarm safe to put on the boot path:
+     *
+     * **Authority.** `tenant-repo-sync` is container-plane-owned. The canonical resolver reaches
+     * `listConfiguredTenantRepos()`, which awaits `graphService.ready()`, so running it
+     * unconditionally would pull a host-edge or graphless profile into container-plane
+     * configuration authority it does not hold. The prewarm therefore runs only for the profile
+     * that owns the lane and only while it is enabled — the same shape as the swarm-heartbeat init
+     * above. No optional chaining inside that branch: on the owned seam the method must exist, and
+     * a silently-absent invariant is worse than a crash.
+     *
+     * **Deadline.** `ensureConfiguredTenantRepoLabels()` contains rejection but is not a timeout: a
+     * resolver that never settles would leave `start()` pending forever and the daemon would never
+     * poll. Boot proceeds on the deadline and the already-implemented unresolved fail-safe posture
+     * covers the gap — an unresolved snapshot with no manifest ranks bootstrap rather than ordinary,
+     * so a slow resolver costs precision, never the decision.
+     *
+     * @param {Number} [timeoutMs=CONFIGURED_TENANT_REPO_PREWARM_TIMEOUT_MS] Deadline seam for tests.
+     * @returns {Promise<void>} Always resolves; never rejects and never hangs.
+     */
+    async prewarmConfiguredTenantRepoCoverage(timeoutMs = CONFIGURED_TENANT_REPO_PREWARM_TIMEOUT_MS) {
+        if (!this.isTaskAuthorityOwned('tenant-repo-sync') || !this.tenantRepoSyncEnabled) {
+            return;
+        }
+
+        let timer;
+
+        const settled = await Promise.race([
+            this.maintenanceBackpressureService.ensureConfiguredTenantRepoLabels().then(() => true),
+            new Promise(resolve => { timer = setTimeout(() => resolve(false), timeoutMs) })
+        ]);
+
+        clearTimeout(timer);
+
+        if (!settled) {
+            this.writeLog('WARN', `[Orchestrator] Configured tenant-repo coverage did not resolve within ${timeoutMs}ms; starting the scheduler on the unresolved fail-safe posture.`);
+        }
     }
 
     /**

--- a/ai/daemons/orchestrator/Orchestrator.mjs
+++ b/ai/daemons/orchestrator/Orchestrator.mjs
@@ -1521,6 +1521,15 @@ export class Orchestrator extends Base {
             }
         }
 
+        // Resolve configured tenant-repo coverage BEFORE the first sweep. The bootstrap-critical
+        // rank is evaluated synchronously inside the picker, so a fire-and-forget refresh would
+        // leave the very first scheduling decision running on unresolved coverage — on a first
+        // deployment that ranks the bootstrap lane as ordinary and hands the heavy lease to a
+        // more-stale REM cycle for its full duration, losing the one decision the class exists to
+        // win. Awaited rather than raced; the call never rejects, so a resolver outage delays
+        // nothing.
+        await this.maintenanceBackpressureService.ensureConfiguredTenantRepoLabels?.();
+
         this.isPolling = true;
         this.writeLog('INFO', `[Orchestrator] Started. authorityProfile=${this.authorityProfile} authorityReceipt=${this.authorityReceiptFile} summaryInterval=${AiConfig.orchestrator.intervals.summarySweepMs}ms kbSyncInterval=${AiConfig.orchestrator.intervals.kbSyncMs}ms poll=${AiConfig.orchestrator.intervals.pollMs}ms.`);
         this.announceDisabledLanes();

--- a/ai/daemons/orchestrator/scheduling/picker.mjs
+++ b/ai/daemons/orchestrator/scheduling/picker.mjs
@@ -27,8 +27,10 @@
  * @param {Object} options.policyContext Additional policy state. Recognized fields:
  *   `runningHeavyTasks` (Set) + `isHeavyMaintenanceConflict` (fn) for the heavy-conflict filter;
  *   and for the final selector: `now` (epoch ms), `taskMeta` (`{[taskName]: {lastRunAt, cadenceMs}}`),
- *   and `priorityZeroTasks` (String[]). When `taskMeta` is absent the selector degrades to
- *   registry-order, preserving legacy `selectFirstCandidate` behavior.
+ *   `priorityZeroTasks` (String[]), and `isBootstrapCriticalTask` (`(taskName) => Boolean`, the
+ *   live per-poll oracle that ranks an uninitialized corpus above ordinary enrichment). When
+ *   `taskMeta` is absent the selector degrades to registry-order, preserving legacy
+ *   `selectFirstCandidate` behavior.
  * @returns {Object|null} The winning candidate, or null if no candidate survives the pipeline.
  */
 export function pickNextCandidate({candidates, runningTasks, policyContext = {}}) {
@@ -114,6 +116,17 @@ function filterUnmetDependencies(candidates, runningSet) {
  *   1. **Priority-0** — data-safety tasks (e.g. `backup`) win unconditionally when present,
  *      so a daily backup is never deferred behind a backlog-draining task. Registry order
  *      breaks ties among multiple priority-0 survivors.
+ *   1b. **Bootstrap-critical** — a task whose durable corpus is still uninitialized (e.g. tenant
+ *      repos with no checkpoint yet) outranks ordinary enrichment, because a plane that has never
+ *      ingested cannot usefully enrich. Registry order breaks ties.
+ *
+ *      This rank lives in SELECTION, not in lease admission, and that placement is load-bearing.
+ *      The admission-side fairness gate can only make the picked winner *abstain*; since the
+ *      pipeline dispatches exactly one candidate per poll and then returns, a yield there spends
+ *      the poll without promoting anybody — the starved task is never dispatched, and the ledger
+ *      entry simply expires before it runs. Ranking here means the bootstrap task actually
+ *      executes. Admission-side fairness remains the second line of defence for holders that are
+ *      already running.
  *   2. **Staleness-ratio (eligible set only)** — among candidates carrying `taskMeta` (the
  *      lease-competing heavy tasks plus `golden-path`), the most overdue by `(now - lastRunAt) /
  *      cadenceMs` is the single eligible representative, so a weeks-stale `golden-path` or a
@@ -136,7 +149,7 @@ function filterUnmetDependencies(candidates, runningSet) {
 function selectByPriority(candidates, policyContext = {}) {
     if (candidates.length === 0) return null;
 
-    const {taskMeta, now, priorityZeroTasks} = policyContext;
+    const {taskMeta, now, priorityZeroTasks, isBootstrapCriticalTask} = policyContext;
 
     // Legacy / no-metadata path: registry-order priority (earlier descriptors win).
     if (!taskMeta) return candidates[0];
@@ -145,6 +158,21 @@ function selectByPriority(candidates, policyContext = {}) {
     if (Array.isArray(priorityZeroTasks) && priorityZeroTasks.length > 0) {
         const priorityZeroWinner = candidates.find(candidate => priorityZeroTasks.includes(candidate.taskName));
         if (priorityZeroWinner) return priorityZeroWinner;
+    }
+
+    // Bootstrap-critical: outranks staleness so an uninitialized corpus is DISPATCHED rather than
+    // merely deferred-to. The predicate is re-evaluated every poll and is fail-open — a throwing or
+    // absent oracle degrades to pure staleness ordering, never blocks the pick.
+    if (typeof isBootstrapCriticalTask === 'function') {
+        const bootstrapWinner = candidates.find(candidate => {
+            try {
+                return isBootstrapCriticalTask(candidate.taskName) === true;
+            } catch {
+                return false;
+            }
+        });
+
+        if (bootstrapWinner) return bootstrapWinner;
     }
 
     // Staleness reorders ONLY the eligible set (candidates carrying `taskMeta` — the

--- a/ai/daemons/orchestrator/scheduling/pipeline.mjs
+++ b/ai/daemons/orchestrator/scheduling/pipeline.mjs
@@ -228,7 +228,15 @@ export function runSchedulingPipeline({registry, context, services, runtime}) {
             ),
             now              : context.now,
             taskMeta         : buildTaskStalenessMeta({candidates, state: context.state, intervals: context.intervals}),
-            priorityZeroTasks: PRIORITY_ZERO_TASKS
+            priorityZeroTasks: PRIORITY_ZERO_TASKS,
+            // Selection-time bootstrap rank. Bound here rather than left to lease admission because
+            // this pipeline dispatches exactly one candidate per poll: an admission-side yield makes
+            // the winner abstain without promoting the starved task, so the bootstrap lane would
+            // never be dispatched at all. Optional-chained so a service build without the predicate
+            // degrades to staleness ordering.
+            isBootstrapCriticalTask: services.maintenanceBackpressureService.isBootstrapCriticalTask?.bind(
+                services.maintenanceBackpressureService
+            )
         }
     });
 

--- a/ai/daemons/orchestrator/services/MaintenanceBackpressureService.mjs
+++ b/ai/daemons/orchestrator/services/MaintenanceBackpressureService.mjs
@@ -33,6 +33,34 @@ import {
  */
 export const WAITER_ENTRY_STALE_AFTER_MS = 10 * 60 * 1000;
 
+/**
+ * Refresh throttle for the configured tenant-repo label snapshot consumed by
+ * `isBootstrapCriticalTask`. The snapshot only has to track operator config edits, which are rare
+ * next to the poll cadence that reads it, so a minute of staleness costs at most one scheduling
+ * cycle of ordinary ranking while keeping the resolver off the hot path.
+ * @type {Number}
+ */
+export const CONFIGURED_TENANT_REPO_LABELS_TTL_MS = 60 * 1000;
+
+/**
+ * @summary Default resolver for the configured `<tenantId>/<repoSlug>` label set.
+ *
+ * Dynamically imported so this policy service does not take a load-time dependency on the tenant
+ * sync lane, mirroring `TenantRepoSyncService.resolveIngestionService()`'s own pattern. Routed
+ * through the canonical tiered resolver rather than a direct config read so graph-node and
+ * bootstrap tiers are honoured.
+ *
+ * @returns {Promise<String[]>}
+ */
+async function resolveConfiguredTenantRepoLabels() {
+    const {default: TenantRepoSyncService} = await import('./TenantRepoSyncService.mjs');
+    const resolved                         = await TenantRepoSyncService.resolveTenantReposConfig();
+
+    return (resolved?.tenantRepos || [])
+        .filter(repo => repo?.tenantId && repo?.repoSlug)
+        .map(repo => `${repo.tenantId}/${repo.repoSlug}`);
+}
+
 export const DEFAULT_HEAVY_MAINTENANCE_TASK_NAMES = Object.freeze([
     'summary',
     'memory-summary-backfill',
@@ -421,6 +449,14 @@ export class MaintenanceBackpressureService extends Base {
          */
         writeLog_: () => {},
         /**
+         * Resolver seam for the configured tenant-repo label snapshot. Defaults to the canonical
+         * tiered resolver; tests inject a stub so the bootstrap predicate is exercised without
+         * booting the tenant sync lane.
+         * @member {Function} resolveConfiguredTenantRepoLabelsFn_=resolveConfiguredTenantRepoLabels
+         * @reactive
+         */
+        resolveConfiguredTenantRepoLabelsFn_: resolveConfiguredTenantRepoLabels,
+        /**
          * @member {Function} acquireLeaseFn_=acquireHeavyMaintenanceLeaseSync
          * @reactive
          */
@@ -652,23 +688,87 @@ export class MaintenanceBackpressureService extends Base {
     }
 
     /**
+     * @member {String[]|null} configuredTenantRepoLabels=null
+     * Snapshot of currently configured `<tenantId>/<repoSlug>` labels, refreshed off the
+     * canonical tiered resolver. `null` means "never resolved", which deliberately preserves the
+     * older manifest-only predicate rather than guessing coverage from an unresolved snapshot.
+     * @protected
+     */
+    configuredTenantRepoLabels = null
+    /**
+     * @member {Number} configuredTenantRepoLabelsAt=0
+     * Epoch ms of the last successful snapshot refresh; drives the refresh throttle.
+     * @protected
+     */
+    configuredTenantRepoLabelsAt = 0
+    /**
+     * @member {Boolean} refreshingConfiguredTenantRepoLabels=false
+     * Single-flight guard so a poll storm cannot stack resolver calls.
+     * @protected
+     */
+    refreshingConfiguredTenantRepoLabels = false
+
+    /**
+     * @summary Kicks a throttled background refresh of the configured tenant-repo label snapshot.
+     *
+     * Deliberately fire-and-forget. The consumer (`isBootstrapCriticalTask`) is synchronous — it
+     * runs inside the scheduling picker on every poll — while the canonical configured-repo truth
+     * is async (`resolveTenantReposConfig` → `listConfiguredTenantRepos`, tiered graph node >
+     * `kb-config.yaml` bootstrap > config default). Reading a config leaf directly here would be
+     * cheaper and wrong: that direct read is exactly what the tiered resolver replaced so the
+     * bootstrap/graph tiers are honoured, so it would misread every plane whose repos come from
+     * the graph tier.
+     *
+     * Bounded staleness is the accepted trade: a newly configured repo activates the class one
+     * refresh later, which costs at most one scheduling cycle of ordinary ranking. A resolver
+     * failure leaves the previous snapshot in place rather than downgrading coverage.
+     *
+     * @param {Number} [now=Date.now()] Clock seam.
+     * @returns {void}
+     * @protected
+     */
+    refreshConfiguredTenantRepoLabels(now = Date.now()) {
+        if (this.refreshingConfiguredTenantRepoLabels) return;
+        if (this.configuredTenantRepoLabels !== null && now - this.configuredTenantRepoLabelsAt < CONFIGURED_TENANT_REPO_LABELS_TTL_MS) return;
+
+        this.refreshingConfiguredTenantRepoLabels = true;
+
+        Promise.resolve()
+            .then(() => this.resolveConfiguredTenantRepoLabelsFn())
+            .then(labels => {
+                if (Array.isArray(labels)) {
+                    this.configuredTenantRepoLabels   = labels;
+                    this.configuredTenantRepoLabelsAt = Date.now();
+                }
+            })
+            .catch(e => {
+                this.writeLog('WARN', `[Orchestrator] Configured tenant-repo snapshot refresh failed: ${e.message} — keeping the previous snapshot.`);
+            })
+            .finally(() => {
+                this.refreshingConfiguredTenantRepoLabels = false;
+            });
+    }
+
+    /**
      * @summary Whether the task is bootstrap-critical: initializing durable state the plane
      * cannot function without.
      *
-     * For tenant-repo sync, the durable truth is the persisted revisions manifest the sync
-     * lane itself maintains beside its checkpoints: bootstrap-spread seeding writes an entry
-     * with `lastIngestedRev: null` for every configured repo on the first sweep, and a commit
-     * replaces the null with a revision. Any remaining null therefore means a configured repo
-     * has never completed its initial ingest — the knowledge base is still partially
-     * uninitialized, and enrichment cycles must not re-acquire ahead of it.
+     * Bootstrap truth is CURRENT CONFIGURED COVERAGE, not the manifest alone. The manifest is a
+     * record of what the sync lane has already seen, so deriving the class from it alone gets
+     * three cases wrong: a first deployment has no manifest at all and would read ordinary,
+     * exactly when the class is most needed; a newly added repo is absent from an existing
+     * manifest and would read ordinary until the next sweep seeds it; and a removed repo's stale
+     * null entry would keep granting priority forever.
      *
-     * Reads resolve fresh on every admission decision so the class evaporates the moment the
-     * last checkpoint commits. An absent manifest is NOT treated as bootstrap-critical (a plane
-     * with no tenant repos never writes one); the age-based fairness bound still guarantees the
-     * first sweep runs eventually on a contended plane, which seeds the manifest and activates
-     * this class for the repos that remain.
+     * So a configured `<tenantId>/<repoSlug>` label with no checkpoint — absent from the manifest
+     * or carrying a null `lastIngestedRev` — makes the lane bootstrap-critical, and manifest
+     * entries whose label is no longer configured are ignored. An empty configured set is
+     * ordinary (a plane with no tenant repos is not uninitialized). While the snapshot is still
+     * unresolved the older manifest-only predicate applies, so this never grants priority on
+     * less evidence than before.
      *
-     * Fail-closed on read errors: a corrupt manifest must not grant priority.
+     * Reads resolve fresh on every admission decision so the class evaporates the moment the last
+     * checkpoint commits. Fail-closed on read errors: a corrupt manifest must not grant priority.
      *
      * @param {String} taskName Stable orchestrator task name.
      * @returns {Boolean}
@@ -678,20 +778,31 @@ export class MaintenanceBackpressureService extends Base {
             return false;
         }
 
+        this.refreshConfiguredTenantRepoLabels();
+
         try {
+            const labels = this.configuredTenantRepoLabels;
+
+            // Configured, and empty: nothing to initialize.
+            if (Array.isArray(labels) && labels.length === 0) {
+                return false;
+            }
+
             const manifestPath = path.join(this.dataDir, 'tenant-repo-sync-revisions.json');
+            const rawRevisions = fs.existsSync(manifestPath)
+                ? JSON.parse(fs.readFileSync(manifestPath, 'utf8'))?.revisions
+                : null;
+            const revisions = rawRevisions && typeof rawRevisions === 'object' && !Array.isArray(rawRevisions)
+                ? rawRevisions
+                : {};
 
-            if (!fs.existsSync(manifestPath)) {
-                return false;
+            // Snapshot unresolved: fall back to the manifest-only predicate rather than treating an
+            // unknown configured set as full coverage.
+            if (!Array.isArray(labels)) {
+                return Object.values(revisions).some(entry => !entry?.lastIngestedRev);
             }
 
-            const revisions = JSON.parse(fs.readFileSync(manifestPath, 'utf8'))?.revisions;
-
-            if (!revisions || typeof revisions !== 'object' || Array.isArray(revisions)) {
-                return false;
-            }
-
-            return Object.values(revisions).some(entry => !entry?.lastIngestedRev);
+            return labels.some(label => !revisions[label]?.lastIngestedRev);
         } catch (e) {
             this.writeLog('WARN', `[Orchestrator] Bootstrap-critical check failed for ${taskName}: ${e.message} — treating as ordinary.`);
             return false;

--- a/ai/daemons/orchestrator/services/MaintenanceBackpressureService.mjs
+++ b/ai/daemons/orchestrator/services/MaintenanceBackpressureService.mjs
@@ -36,8 +36,9 @@ export const WAITER_ENTRY_STALE_AFTER_MS = 10 * 60 * 1000;
 /**
  * Refresh throttle for the configured tenant-repo label snapshot consumed by
  * `isBootstrapCriticalTask`. The snapshot only has to track operator config edits, which are rare
- * next to the poll cadence that reads it, so a minute of staleness costs at most one scheduling
- * cycle of ordinary ranking while keeping the resolver off the hot path.
+ * next to the poll cadence that reads it. Once the TTL expires the synchronous predicate starts a
+ * lazy refresh and treats the stale last-known array as unresolved for that decision, so a newly
+ * configured repo cannot lose the heavy lane to ordinary work while the resolver is in flight.
  * @type {Number}
  */
 export const CONFIGURED_TENANT_REPO_LABELS_TTL_MS = 60 * 1000;
@@ -724,8 +725,8 @@ export class MaintenanceBackpressureService extends Base {
      * sufficient: on a first deployment the first decision would run against an unresolved
      * snapshot, rank the bootstrap lane as ordinary, and hand the heavy lease to a more-stale REM
      * cycle for its full duration — losing precisely the decision the class exists to win. Steady
-     * state still refreshes lazily off the TTL, where bounded staleness costs at most one cycle of
-     * ordinary ranking.
+     * state still refreshes lazily off the TTL; the synchronous predicate fails safe while that
+     * refresh is pending rather than dispatching from stale coverage.
      *
      * A resolver failure leaves the previous snapshot in place rather than downgrading coverage,
      * and never rejects — boot must not be blocked by a resolver outage.
@@ -762,14 +763,16 @@ export class MaintenanceBackpressureService extends Base {
     /**
      * @summary Non-blocking lazy refresh used by the synchronous predicate on the steady-state path.
      * @param {Number} [now=Date.now()] Clock seam.
-     * @returns {void}
+     * @returns {Boolean} True while configured coverage is unresolved or refreshing.
      * @protected
      */
     refreshConfiguredTenantRepoLabels(now = Date.now()) {
-        if (this.configuredTenantRepoLabelsRefresh) return;
-        if (this.configuredTenantRepoLabels !== null && now - this.configuredTenantRepoLabelsAt < CONFIGURED_TENANT_REPO_LABELS_TTL_MS) return;
+        if (this.configuredTenantRepoLabelsRefresh) return true;
+        if (this.configuredTenantRepoLabels !== null && now - this.configuredTenantRepoLabelsAt < CONFIGURED_TENANT_REPO_LABELS_TTL_MS) return false;
 
         this.ensureConfiguredTenantRepoLabels(now);
+
+        return true;
     }
 
     /**
@@ -781,7 +784,9 @@ export class MaintenanceBackpressureService extends Base {
      * three cases wrong: a first deployment has no manifest at all and would read ordinary,
      * exactly when the class is most needed; a newly added repo is absent from an existing
      * manifest and would read ordinary until the next sweep seeds it; and a removed repo's stale
-     * null entry would keep granting priority forever.
+     * null entry would keep granting priority forever. When a last-known snapshot has expired, the
+     * canonical refresh cannot be awaited inside the synchronous picker; that current decision
+     * therefore fails safe instead of handing the heavy lane to ordinary work on stale coverage.
      *
      * So a configured `<tenantId>/<repoSlug>` label with no checkpoint — absent from the manifest
      * or carrying a null `lastIngestedRev` — makes the lane bootstrap-critical, and manifest
@@ -801,15 +806,10 @@ export class MaintenanceBackpressureService extends Base {
             return false;
         }
 
-        this.refreshConfiguredTenantRepoLabels();
+        const coverageRefreshPending = this.refreshConfiguredTenantRepoLabels();
 
         try {
             const labels = this.configuredTenantRepoLabels;
-
-            // Configured, and empty: nothing to initialize.
-            if (Array.isArray(labels) && labels.length === 0) {
-                return false;
-            }
 
             const manifestPath = path.join(this.dataDir, 'tenant-repo-sync-revisions.json');
             const rawRevisions = fs.existsSync(manifestPath)
@@ -818,6 +818,18 @@ export class MaintenanceBackpressureService extends Base {
             const revisions = rawRevisions && typeof rawRevisions === 'object' && !Array.isArray(rawRevisions)
                 ? rawRevisions
                 : {};
+
+            // The last-known array is stale and its canonical refresh is asynchronous. Even a
+            // previously complete or empty set cannot prove that no repo was added since it was
+            // captured, so the due tenant lane wins THIS decision while coverage resolves.
+            if (coverageRefreshPending && Array.isArray(labels)) {
+                return true;
+            }
+
+            // Configured, fresh, and empty: nothing to initialize.
+            if (Array.isArray(labels) && labels.length === 0) {
+                return false;
+            }
 
             // Snapshot unresolved. Boot awaits `ensureConfiguredTenantRepoLabels()` before the first
             // sweep, so this is the defensive path (a service composed outside that boot order, or a

--- a/ai/daemons/orchestrator/services/MaintenanceBackpressureService.mjs
+++ b/ai/daemons/orchestrator/services/MaintenanceBackpressureService.mjs
@@ -761,16 +761,35 @@ export class MaintenanceBackpressureService extends Base {
             return false;
         }
 
-        // Fairness gate: do not step past a measurably starving registered waiter. This
-        // sits at the single acquisition point, so the periodic scheduler and every lease-aware
-        // manual CLI inherit the same rule. Fail-open: a broken ledger read must not halt all
-        // maintenance — it logs and proceeds, degrading to pre-fairness behavior.
+        // Fairness gate: do not step past a starving registered waiter that outranks this acquirer.
+        //
+        // SCOPE: this is the orchestrator-owned admission point only. Manual/container CLI entry
+        // points acquire the global lease directly and do NOT pass through this service, so they
+        // inherit lease exclusion but not this fairness rule.
+        //
+        // This gate is the SECOND line of defence, not the mechanism. It can only make an admitted
+        // acquirer abstain, and the scheduling pipeline dispatches one candidate per poll — so a
+        // yield here spends the poll without promoting anyone. Selection-time rank in
+        // `scheduling/picker.mjs` is what actually gets a starved bootstrap lane executed; this
+        // gate covers the residue (a task that reached admission while a higher-ranked peer was
+        // registered mid-poll).
+        //
+        // Fail-open: a broken ledger read must not halt all maintenance — it logs and proceeds,
+        // degrading to pre-fairness behavior.
         try {
-            const {waiters} = listActiveWaitersSync({
+            const {waiters, unreadable} = listActiveWaitersSync({
                 leasePath   : this.resolveHeavyMaintenanceLeasePath(),
                 staleAfterMs: WAITER_ENTRY_STALE_AFTER_MS,
                 now
             });
+
+            // A corrupt entry is an invisible loss of fairness: the waiter it represents cannot be
+            // yielded to, so it silently starves while every surface reads healthy. Surface it —
+            // the ledger reports these rather than throwing precisely so a consumer can decide, and
+            // "broken reads log" is only true if someone actually logs them.
+            if (unreadable?.length > 0) {
+                this.writeLog('WARN', `[Orchestrator] Waiter ledger has ${unreadable.length} unreadable entr${unreadable.length === 1 ? 'y' : 'ies'} (${unreadable.join(', ')}); those waiters cannot be yielded to until repaired.`);
+            }
 
             const yieldTo = findWaiterToYieldTo({
                 taskName,

--- a/ai/daemons/orchestrator/services/MaintenanceBackpressureService.mjs
+++ b/ai/daemons/orchestrator/services/MaintenanceBackpressureService.mjs
@@ -1,3 +1,5 @@
+import fs       from 'fs-extra';
+import path     from 'node:path';
 import Neo      from '../../../../src/Neo.mjs';
 import Base     from '../../../../src/core/Base.mjs';
 import AiConfig from '../../../config.mjs';
@@ -6,6 +8,12 @@ import {
     releaseHeavyMaintenanceLeaseSync,
     resolveHeavyMaintenanceLeasePath as resolveLeasePath
 } from './HeavyMaintenanceLeaseService.mjs';
+import {
+    clearWaiterSync,
+    findWaiterToYieldTo,
+    listActiveWaitersSync,
+    registerWaiterSync
+} from './heavyMaintenanceWaiterLedger.mjs';
 
 /**
  * Canonical set of heavy-maintenance task names that participate in the cross-poll
@@ -15,6 +23,16 @@ import {
  *
  * @type {ReadonlyArray<String>}
  */
+/**
+ * Freshness bound for waiter-ledger entries. A live waiter refreshes its entry on every deferred
+ * poll (~60s cadence), so ten minutes of silence means the waiter's process is gone — its entry
+ * must stop making acquirers yield. Deliberately NOT the lease's 6h `staleAfterMs`: that bound is
+ * sized for the longest legitimate HOLD, and a dead waiter vetoing acquisitions for 6 hours would
+ * be a brand-new starvation shape.
+ * @type {Number}
+ */
+export const WAITER_ENTRY_STALE_AFTER_MS = 10 * 60 * 1000;
+
 export const DEFAULT_HEAVY_MAINTENANCE_TASK_NAMES = Object.freeze([
     'summary',
     'memory-summary-backfill',
@@ -316,6 +334,11 @@ export function recordDeferral({
     }
 
     healthService?.recordTaskOutcome?.(taskName, 'skipped', outcomePayload);
+
+    // The payload carries the durable `deferredSince` (when measurable) — returning it lets the
+    // instance layer register the waiter with the SAME quantity the starvation measurement records,
+    // instead of re-deriving a per-poll timestamp that resets on every blocker rotation.
+    return outcomePayload;
 }
 
 // ============================================================================
@@ -406,7 +429,14 @@ export class MaintenanceBackpressureService extends Base {
          * @member {Function} releaseLeaseFn_=releaseHeavyMaintenanceLeaseSync
          * @reactive
          */
-        releaseLeaseFn_: releaseHeavyMaintenanceLeaseSync
+        releaseLeaseFn_: releaseHeavyMaintenanceLeaseSync,
+        /**
+         * Priority-class mirror of `PRIORITY_ZERO_TASKS` (`scheduling/pipeline.mjs`) — execution
+         * policy needs the class without importing the selection module; a unit spec guards drift.
+         * @member {String[]} priorityZeroTaskNames_=['backup']
+         * @reactive
+         */
+        priorityZeroTaskNames_: ['backup']
     }
 
     /**
@@ -574,7 +604,7 @@ export class MaintenanceBackpressureService extends Base {
      * @returns {void}
      */
     recordDeferral({taskName, reasonCode, reasonText, blockingTaskName = null, holdingLease = null}) {
-        recordDeferral({
+        const outcome = recordDeferral({
             deferralLogKeys     : this.deferralLogKeys,
             deferralStreakStarts: this.deferralStreakStarts,
             taskName,
@@ -587,6 +617,85 @@ export class MaintenanceBackpressureService extends Base {
             healthService       : this.healthService,
             taskStateService    : this.taskStateService
         });
+
+        // Fairness half of the lease contract: a lease/backpressure deferral with a measurable streak becomes a
+        // REGISTERED waiter, so acquisition can stop stepping past measurably starving work. Only the
+        // contention classes register — a shed-window or dependency gate is policy, not competition.
+        if (outcome?.deferredSince && ['heavy-maintenance-lease-held', 'heavy-maintenance-backpressure', 'heavy-maintenance-yield-to-waiter'].includes(reasonCode)) {
+            try {
+                registerWaiterSync({
+                    leasePath        : this.resolveHeavyMaintenanceLeasePath(),
+                    taskName,
+                    priorityZero     : this.isPriorityZeroTask(taskName),
+                    bootstrapCritical: this.isBootstrapCriticalTask(taskName),
+                    deferredSince    : outcome.deferredSince
+                });
+            } catch (e) {
+                this.writeLog('ERROR', `[Orchestrator] Waiter registration failed for ${taskName}: ${e.message}`);
+            }
+        }
+    }
+
+    /**
+     * @summary Whether the task outranks ordinary maintenance in the scheduler's priority model.
+     *
+     * Mirrors `PRIORITY_ZERO_TASKS` in `scheduling/pipeline.mjs` without importing it — the
+     * scheduling module owns selection and this service owns execution, and a one-name constant
+     * is cheaper than coupling the layers. The mirror is drift-guarded by a unit spec asserting
+     * both arrays stay identical.
+     *
+     * @param {String} taskName Stable orchestrator task name.
+     * @returns {Boolean}
+     */
+    isPriorityZeroTask(taskName) {
+        return this.priorityZeroTaskNames.includes(taskName);
+    }
+
+    /**
+     * @summary Whether the task is bootstrap-critical: initializing durable state the plane
+     * cannot function without.
+     *
+     * For tenant-repo sync, the durable truth is the persisted revisions manifest the sync
+     * lane itself maintains beside its checkpoints: bootstrap-spread seeding writes an entry
+     * with `lastIngestedRev: null` for every configured repo on the first sweep, and a commit
+     * replaces the null with a revision. Any remaining null therefore means a configured repo
+     * has never completed its initial ingest — the knowledge base is still partially
+     * uninitialized, and enrichment cycles must not re-acquire ahead of it.
+     *
+     * Reads resolve fresh on every admission decision so the class evaporates the moment the
+     * last checkpoint commits. An absent manifest is NOT treated as bootstrap-critical (a plane
+     * with no tenant repos never writes one); the age-based fairness bound still guarantees the
+     * first sweep runs eventually on a contended plane, which seeds the manifest and activates
+     * this class for the repos that remain.
+     *
+     * Fail-closed on read errors: a corrupt manifest must not grant priority.
+     *
+     * @param {String} taskName Stable orchestrator task name.
+     * @returns {Boolean}
+     */
+    isBootstrapCriticalTask(taskName) {
+        if (taskName !== 'tenant-repo-sync') {
+            return false;
+        }
+
+        try {
+            const manifestPath = path.join(this.dataDir, 'tenant-repo-sync-revisions.json');
+
+            if (!fs.existsSync(manifestPath)) {
+                return false;
+            }
+
+            const revisions = JSON.parse(fs.readFileSync(manifestPath, 'utf8'))?.revisions;
+
+            if (!revisions || typeof revisions !== 'object' || Array.isArray(revisions)) {
+                return false;
+            }
+
+            return Object.values(revisions).some(entry => !entry?.lastIngestedRev);
+        } catch (e) {
+            this.writeLog('WARN', `[Orchestrator] Bootstrap-critical check failed for ${taskName}: ${e.message} — treating as ordinary.`);
+            return false;
+        }
     }
 
     // --- Executor wrappers (Group 3 entry points) ---
@@ -652,6 +761,40 @@ export class MaintenanceBackpressureService extends Base {
             return false;
         }
 
+        // Fairness gate: do not step past a measurably starving registered waiter. This
+        // sits at the single acquisition point, so the periodic scheduler and every lease-aware
+        // manual CLI inherit the same rule. Fail-open: a broken ledger read must not halt all
+        // maintenance — it logs and proceeds, degrading to pre-fairness behavior.
+        try {
+            const {waiters} = listActiveWaitersSync({
+                leasePath   : this.resolveHeavyMaintenanceLeasePath(),
+                staleAfterMs: WAITER_ENTRY_STALE_AFTER_MS,
+                now
+            });
+
+            const yieldTo = findWaiterToYieldTo({
+                taskName,
+                priorityZero        : this.isPriorityZeroTask(taskName),
+                bootstrapCritical   : this.isBootstrapCriticalTask(taskName),
+                ownDeferredSince    : this.taskStateService?.getTaskState?.(taskName)?.deferralStreakStartedAt ?? null,
+                waiters,
+                fairnessYieldAfterMs: AiConfig.orchestrator.heavyMaintenanceLease.fairnessYieldAfterMs,
+                now
+            });
+
+            if (yieldTo) {
+                this.recordDeferral({
+                    taskName,
+                    reasonCode      : 'heavy-maintenance-yield-to-waiter',
+                    reasonText      : `${reasonText}; yielding to starving ${yieldTo.taskName} (deferred since ${yieldTo.deferredSince})`,
+                    blockingTaskName: yieldTo.taskName
+                });
+                return false;
+            }
+        } catch (e) {
+            this.writeLog('ERROR', `[Orchestrator] Waiter fairness check failed for ${taskName}: ${e.message} — proceeding without it.`);
+        }
+
         let acquisition;
         try {
             acquisition = this.acquireLeaseFn({
@@ -688,6 +831,14 @@ export class MaintenanceBackpressureService extends Base {
         }
 
         this.clearDeferralLogState(taskName);
+
+        // The task proceeds (own lease or compatible-pair bypass): it is no longer a waiter, and a
+        // stale self-entry must not make OTHER acquirers yield to work that is already running.
+        try {
+            clearWaiterSync({leasePath: this.resolveHeavyMaintenanceLeasePath(), taskName});
+        } catch (e) {
+            this.writeLog('ERROR', `[Orchestrator] Waiter clear failed for ${taskName}: ${e.message}`);
+        }
 
         const releaseLease = () => {
             if (!leaseToken) return;

--- a/ai/daemons/orchestrator/services/MaintenanceBackpressureService.mjs
+++ b/ai/daemons/orchestrator/services/MaintenanceBackpressureService.mjs
@@ -702,38 +702,45 @@ export class MaintenanceBackpressureService extends Base {
      */
     configuredTenantRepoLabelsAt = 0
     /**
-     * @member {Boolean} refreshingConfiguredTenantRepoLabels=false
-     * Single-flight guard so a poll storm cannot stack resolver calls.
+     * @member {Promise|null} configuredTenantRepoLabelsRefresh=null
+     * The in-flight refresh, exposed so boot can AWAIT the first snapshot instead of racing it.
+     * Doubles as the single-flight guard: a poll storm joins this promise rather than stacking
+     * resolver calls.
      * @protected
      */
-    refreshingConfiguredTenantRepoLabels = false
+    configuredTenantRepoLabelsRefresh = null
 
     /**
-     * @summary Kicks a throttled background refresh of the configured tenant-repo label snapshot.
+     * @summary Resolves the configured tenant-repo label snapshot, awaitable and single-flight.
      *
-     * Deliberately fire-and-forget. The consumer (`isBootstrapCriticalTask`) is synchronous — it
-     * runs inside the scheduling picker on every poll — while the canonical configured-repo truth
-     * is async (`resolveTenantReposConfig` → `listConfiguredTenantRepos`, tiered graph node >
-     * `kb-config.yaml` bootstrap > config default). Reading a config leaf directly here would be
-     * cheaper and wrong: that direct read is exactly what the tiered resolver replaced so the
-     * bootstrap/graph tiers are honoured, so it would misread every plane whose repos come from
-     * the graph tier.
+     * The canonical configured-repo truth is async (`resolveTenantReposConfig` →
+     * `listConfiguredTenantRepos`, tiered graph node > `kb-config.yaml` bootstrap > config
+     * default) while the consumer (`isBootstrapCriticalTask`) is synchronous — it runs inside the
+     * scheduling picker on every poll. Reading a config leaf directly would be cheaper and wrong:
+     * that direct read is what the tiered resolver replaced so the bootstrap/graph tiers are
+     * honoured, so it would misread every plane whose repos come from the graph tier.
      *
-     * Bounded staleness is the accepted trade: a newly configured repo activates the class one
-     * refresh later, which costs at most one scheduling cycle of ordinary ranking. A resolver
-     * failure leaves the previous snapshot in place rather than downgrading coverage.
+     * **Boot must await this before the first scheduling sweep.** A fire-and-forget kick is not
+     * sufficient: on a first deployment the first decision would run against an unresolved
+     * snapshot, rank the bootstrap lane as ordinary, and hand the heavy lease to a more-stale REM
+     * cycle for its full duration — losing precisely the decision the class exists to win. Steady
+     * state still refreshes lazily off the TTL, where bounded staleness costs at most one cycle of
+     * ordinary ranking.
+     *
+     * A resolver failure leaves the previous snapshot in place rather than downgrading coverage,
+     * and never rejects — boot must not be blocked by a resolver outage.
      *
      * @param {Number} [now=Date.now()] Clock seam.
-     * @returns {void}
+     * @returns {Promise<String[]|null>} The current snapshot once any needed refresh settles.
      * @protected
      */
-    refreshConfiguredTenantRepoLabels(now = Date.now()) {
-        if (this.refreshingConfiguredTenantRepoLabels) return;
-        if (this.configuredTenantRepoLabels !== null && now - this.configuredTenantRepoLabelsAt < CONFIGURED_TENANT_REPO_LABELS_TTL_MS) return;
+    ensureConfiguredTenantRepoLabels(now = Date.now()) {
+        if (this.configuredTenantRepoLabelsRefresh) return this.configuredTenantRepoLabelsRefresh;
+        if (this.configuredTenantRepoLabels !== null && now - this.configuredTenantRepoLabelsAt < CONFIGURED_TENANT_REPO_LABELS_TTL_MS) {
+            return Promise.resolve(this.configuredTenantRepoLabels);
+        }
 
-        this.refreshingConfiguredTenantRepoLabels = true;
-
-        Promise.resolve()
+        this.configuredTenantRepoLabelsRefresh = Promise.resolve()
             .then(() => this.resolveConfiguredTenantRepoLabelsFn())
             .then(labels => {
                 if (Array.isArray(labels)) {
@@ -744,9 +751,25 @@ export class MaintenanceBackpressureService extends Base {
             .catch(e => {
                 this.writeLog('WARN', `[Orchestrator] Configured tenant-repo snapshot refresh failed: ${e.message} — keeping the previous snapshot.`);
             })
+            .then(() => this.configuredTenantRepoLabels)
             .finally(() => {
-                this.refreshingConfiguredTenantRepoLabels = false;
+                this.configuredTenantRepoLabelsRefresh = null;
             });
+
+        return this.configuredTenantRepoLabelsRefresh;
+    }
+
+    /**
+     * @summary Non-blocking lazy refresh used by the synchronous predicate on the steady-state path.
+     * @param {Number} [now=Date.now()] Clock seam.
+     * @returns {void}
+     * @protected
+     */
+    refreshConfiguredTenantRepoLabels(now = Date.now()) {
+        if (this.configuredTenantRepoLabelsRefresh) return;
+        if (this.configuredTenantRepoLabels !== null && now - this.configuredTenantRepoLabelsAt < CONFIGURED_TENANT_REPO_LABELS_TTL_MS) return;
+
+        this.ensureConfiguredTenantRepoLabels(now);
     }
 
     /**
@@ -796,10 +819,20 @@ export class MaintenanceBackpressureService extends Base {
                 ? rawRevisions
                 : {};
 
-            // Snapshot unresolved: fall back to the manifest-only predicate rather than treating an
-            // unknown configured set as full coverage.
+            // Snapshot unresolved. Boot awaits `ensureConfiguredTenantRepoLabels()` before the first
+            // sweep, so this is the defensive path (a service composed outside that boot order, or a
+            // resolver that has not settled yet) — and its posture must fail SAFE, because failing
+            // ordinary here loses the exact decision the class exists to win.
+            //
+            // An entirely absent manifest cannot prove the plane is initialized: it is equally the
+            // signature of a first deployment. Ranking bootstrap here costs at most one poll of
+            // priority on a plane that turns out to have no configured repos (the sweep no-ops and
+            // the snapshot resolves to empty on the next call); ranking ordinary costs a full REM
+            // hold on exactly the plane that needed the lane first.
             if (!Array.isArray(labels)) {
-                return Object.values(revisions).some(entry => !entry?.lastIngestedRev);
+                const manifestKeys = Object.keys(revisions);
+
+                return manifestKeys.length === 0 || manifestKeys.some(key => !revisions[key]?.lastIngestedRev);
             }
 
             return labels.some(label => !revisions[label]?.lastIngestedRev);

--- a/ai/daemons/orchestrator/services/heavyMaintenanceWaiterLedger.mjs
+++ b/ai/daemons/orchestrator/services/heavyMaintenanceWaiterLedger.mjs
@@ -166,16 +166,39 @@ export function listActiveWaitersSync({leasePath, staleAfterMs, fsModule = fs, n
 }
 
 /**
+ * @summary Ordinal fairness rank of a waiter entry or acquirer class. Higher wins.
+ *
+ * The three classes are strictly ordered, never additive: priority-0 (data-safety, must never
+ * sit behind a backlog) > bootstrap-critical (durable state the plane cannot function without)
+ * > ordinary enrichment/maintenance. Age is deliberately NOT part of the rank — it is a
+ * tie-breaker applied only WITHIN a rank by {@link findWaiterToYieldTo}, because an age bound
+ * that can promote across the class boundary would let a long-waiting ordinary task displace
+ * data-safety work.
+ *
+ * @param {Object} entry `{priorityZero, bootstrapCritical}` — a ledger entry or an acquirer class.
+ * @returns {Number} `2` priority-0 · `1` bootstrap-critical · `0` ordinary.
+ */
+function fairnessRank({priorityZero, bootstrapCritical} = {}) {
+    if (priorityZero === true)      return 2;
+    if (bootstrapCritical === true) return 1;
+    return 0;
+}
+
+/**
  * @summary The fairness decision: must `taskName` yield the acquisition to a registered waiter?
  *
- * A candidate yields when a live waiter (not itself) outranks it in the three-rank order:
- * priority-0 beats everything below it; bootstrap-critical (initializing durable state the
- * plane cannot function without) beats ordinary enrichment/maintenance immediately — an
- * uninitialized corpus must not wait out a starvation bound while cycles of downstream work
- * re-acquire ahead of it; and an ordinary waiter starving past `fairnessYieldAfterMs` beats a
- * candidate that has not been waiting at least as long itself. Ties in the same class do NOT
- * force a yield — the lease's normal contention handles peers; fairness only prevents a fresh
- * or lower-class acquirer from stepping past someone measurably starving.
+ * Rank is evaluated STRICTLY BEFORE age, and age never crosses the class boundary:
+ *
+ * - a waiter of a **higher** rank than the acquirer wins immediately, with no starvation bound —
+ *   an uninitialized corpus must not wait out a grace window while downstream cycles re-acquire;
+ * - a waiter of the **same** rank wins only once it has starved past `fairnessYieldAfterMs` and
+ *   has been waiting longer than the acquirer itself;
+ * - a waiter of a **lower** rank never wins, however long it has waited.
+ *
+ * Among qualifying waiters the highest rank is selected first, and age (oldest `deferredSince`)
+ * breaks ties only within that rank. Ties in the same class do NOT force a yield — the lease's
+ * normal contention handles peers; fairness only prevents a fresh or lower-class acquirer from
+ * stepping past someone measurably starving.
  *
  * @param {Object} options
  * @param {String} options.taskName The would-be acquirer.
@@ -183,7 +206,7 @@ export function listActiveWaitersSync({leasePath, staleAfterMs, fsModule = fs, n
  * @param {Boolean} [options.bootstrapCritical=false] Acquirer's bootstrap-critical class.
  * @param {String|null} [options.ownDeferredSince=null] Acquirer's own durable streak start, if any.
  * @param {Object[]} options.waiters Live entries from {@link listActiveWaitersSync}.
- * @param {Number} options.fairnessYieldAfterMs Starvation bound that activates seniority yielding.
+ * @param {Number} options.fairnessYieldAfterMs Starvation bound that activates same-rank seniority yielding.
  * @param {Date|Number} [options.now=new Date()] Clock seam.
  * @returns {Object|null} The waiter to yield to, or `null` when acquisition may proceed.
  */
@@ -196,24 +219,43 @@ export function findWaiterToYieldTo({taskName, priorityZero = false, bootstrapCr
         throw new TypeError('findWaiterToYieldTo: a positive fairnessYieldAfterMs is required');
     }
 
-    const nowMs   = typeof now === 'number' ? now : now.getTime();
-    const ownMs   = ownDeferredSince ? Date.parse(ownDeferredSince) : null;
-    let   yieldTo = null;
+    const
+        nowMs        = typeof now === 'number' ? now : now.getTime(),
+        ownMs        = ownDeferredSince ? Date.parse(ownDeferredSince) : null,
+        acquirerRank = fairnessRank({priorityZero, bootstrapCritical});
+
+    let yieldTo     = null,
+        yieldToRank = -1,
+        yieldToMs   = Infinity;
 
     for (const waiter of waiters) {
         if (waiter.taskName === taskName) continue;
 
-        const waiterMs   = Date.parse(waiter.deferredSince);
-        const starvingMs = nowMs - waiterMs;
+        const waiterMs = Date.parse(waiter.deferredSince);
 
-        const outranksByClass     = waiter.priorityZero === true && priorityZero !== true;
-        const outranksByBootstrap = waiter.bootstrapCritical === true && bootstrapCritical !== true && priorityZero !== true;
-        const outranksByAge       = starvingMs >= fairnessYieldAfterMs && (ownMs === null || waiterMs < ownMs);
+        if (Number.isNaN(waiterMs)) continue;
 
-        if (outranksByClass || outranksByBootstrap || outranksByAge) {
-            if (!yieldTo || Date.parse(yieldTo.deferredSince) > waiterMs) {
-                yieldTo = waiter;
-            }
+        const waiterRank = fairnessRank(waiter);
+
+        // Rank gate. A lower-ranked waiter can never displace a higher-ranked acquirer, no matter
+        // how long it has starved; same-rank contention still needs the measured starvation bound.
+        let qualifies;
+
+        if (waiterRank > acquirerRank) {
+            qualifies = true;
+        } else if (waiterRank === acquirerRank) {
+            qualifies = nowMs - waiterMs >= fairnessYieldAfterMs && (ownMs === null || waiterMs < ownMs);
+        } else {
+            qualifies = false;
+        }
+
+        if (!qualifies) continue;
+
+        // Highest admissible rank wins; oldest `deferredSince` breaks ties within that rank only.
+        if (waiterRank > yieldToRank || (waiterRank === yieldToRank && waiterMs < yieldToMs)) {
+            yieldTo     = waiter;
+            yieldToRank = waiterRank;
+            yieldToMs   = waiterMs;
         }
     }
 

--- a/ai/daemons/orchestrator/services/heavyMaintenanceWaiterLedger.mjs
+++ b/ai/daemons/orchestrator/services/heavyMaintenanceWaiterLedger.mjs
@@ -1,0 +1,221 @@
+import fs   from 'fs';
+import path from 'path';
+
+import {writeFileAtomicSync} from '../../../services/shared/atomicFileWrite.mjs';
+
+/**
+ * @module ai/daemons/orchestrator/services/heavyMaintenanceWaiterLedger
+ * @summary The waiter half of heavy-maintenance lease fairness — who is waiting, since when.
+ *
+ * The lease file records who HOLDS; nothing records who WAITS, which is why a short-cadence
+ * holder could structurally out-compete a starving priority task for hours while every health
+ * surface read green. This ledger closes that gap without touching the lease's CAS semantics:
+ * each deferred task upserts exactly one file it alone owns inside a sibling
+ * `heavy-maintenance-waiters/` directory, so writers never contend and readers only glob.
+ *
+ * Entries carry the DURABLE deferral streak start (`deferredSince`, from the persisted task
+ * envelope) rather than a per-poll timestamp — the streak survives blocker rotation and process
+ * restarts, and the fairness decision must reason about the same quantity the starvation
+ * measurement records. Entries expire by `updatedAt` age so a crashed waiter cannot veto
+ * acquisitions forever; a live waiter refreshes on every deferred poll.
+ *
+ * Pure and Neo-free by the same rule as the lease primitives: the AiConfig-aware boundary
+ * resolves directories and thresholds and passes them in.
+ */
+
+const WAITERS_DIR_NAME = 'heavy-maintenance-waiters';
+
+/**
+ * @summary Resolves the waiters directory next to the lease file.
+ * @param {Object} options
+ * @param {String} options.leasePath Resolved heavy-maintenance lease path.
+ * @returns {String} Absolute waiters directory path.
+ */
+export function resolveWaitersDir({leasePath} = {}) {
+    if (typeof leasePath !== 'string' || !leasePath.trim()) {
+        throw new TypeError('resolveWaitersDir: a resolved leasePath is required');
+    }
+
+    return path.join(path.dirname(leasePath), WAITERS_DIR_NAME);
+}
+
+function waiterFilePath(dir, taskName) {
+    // Task names are orchestrator-declared identifiers; the replace guards path traversal from
+    // any future dynamic name without changing legitimate names (letters, digits, dashes).
+    return path.join(dir, `${String(taskName).replace(/[^\w.-]/g, '_')}.json`);
+}
+
+/**
+ * @summary Upserts the calling task's waiter entry — one file, owned by exactly one writer.
+ *
+ * @param {Object} options
+ * @param {String} options.leasePath Resolved lease path (the ledger lives beside it).
+ * @param {String} options.taskName The deferred task.
+ * @param {Boolean} [options.priorityZero=false] Whether the task is scheduler priority-0.
+ * @param {Boolean} [options.bootstrapCritical=false] Whether the task is doing bootstrap-critical
+ * work — initializing durable state a plane cannot function without (e.g. a tenant corpus with
+ * uncheckpointed repos). Evaluated fresh on every registration so the class evaporates the
+ * moment the underlying state completes.
+ * @param {String} options.deferredSince Durable streak start (ISO) from the task envelope.
+ * @param {Object} [options.fsModule=fs] Injected fs for fixtures.
+ * @param {Date|Number} [options.now=new Date()] Clock seam.
+ * @param {Number} [options.pid=process.pid] Recorded for forensics, not liveness.
+ * @returns {Object} The persisted waiter entry.
+ */
+export function registerWaiterSync({leasePath, taskName, priorityZero = false, bootstrapCritical = false, deferredSince, fsModule = fs, now = new Date(), pid = process.pid} = {}) {
+    if (!taskName) {
+        throw new TypeError('registerWaiterSync: taskName is required');
+    }
+
+    if (typeof deferredSince !== 'string' || Number.isNaN(Date.parse(deferredSince))) {
+        throw new TypeError('registerWaiterSync: deferredSince must be the durable ISO streak start — an unmeasured wait must not register as a fresh one');
+    }
+
+    const dir = resolveWaitersDir({leasePath});
+
+    const entry = {
+        taskName,
+        priorityZero     : priorityZero === true,
+        bootstrapCritical: bootstrapCritical === true,
+        deferredSince,
+        updatedAt        : new Date(typeof now === 'number' ? now : now.getTime()).toISOString(),
+        pid
+    };
+
+    // Atomic per-file replace: the rename inside the primitive is the commit, so a reader
+    // never sees a torn entry.
+    writeFileAtomicSync(waiterFilePath(dir, taskName), JSON.stringify(entry, null, 2), {fsModule});
+
+    return entry;
+}
+
+/**
+ * @summary Removes the calling task's waiter entry — it acquired, ran, or stopped waiting.
+ * @param {Object} options
+ * @param {String} options.leasePath Resolved lease path.
+ * @param {String} options.taskName The task whose entry clears.
+ * @param {Object} [options.fsModule=fs] Injected fs.
+ */
+export function clearWaiterSync({leasePath, taskName, fsModule = fs} = {}) {
+    if (!taskName) return;
+
+    try {
+        fsModule.unlinkSync(waiterFilePath(resolveWaitersDir({leasePath}), taskName));
+    } catch (e) {
+        if (e.code !== 'ENOENT') {
+            throw e;
+        }
+    }
+}
+
+/**
+ * @summary Lists live waiter entries — expired and unreadable entries are reported, never thrown.
+ *
+ * Fail-open by design: a corrupt entry must not block lease acquisition plane-wide, but it is
+ * surfaced in `unreadable` so the caller can log it rather than silently losing a waiter.
+ *
+ * @param {Object} options
+ * @param {String} options.leasePath Resolved lease path.
+ * @param {Number} options.staleAfterMs Entry freshness bound (a dead waiter cannot veto forever).
+ * @param {Object} [options.fsModule=fs] Injected fs.
+ * @param {Date|Number} [options.now=new Date()] Clock seam.
+ * @returns {{waiters: Object[], unreadable: String[]}} Live entries plus unreadable file names.
+ */
+export function listActiveWaitersSync({leasePath, staleAfterMs, fsModule = fs, now = new Date()} = {}) {
+    if (!Number.isFinite(staleAfterMs) || staleAfterMs <= 0) {
+        throw new TypeError('listActiveWaitersSync: a positive staleAfterMs is required — an unexpirable waiter is a new starvation shape');
+    }
+
+    const dir   = resolveWaitersDir({leasePath});
+    const nowMs = typeof now === 'number' ? now : now.getTime();
+
+    let names;
+    try {
+        names = fsModule.readdirSync(dir);
+    } catch (e) {
+        if (e.code === 'ENOENT') {
+            return {waiters: [], unreadable: []};
+        }
+        throw e;
+    }
+
+    const waiters    = [];
+    const unreadable = [];
+
+    for (const name of names) {
+        if (!name.endsWith('.json')) continue;
+
+        try {
+            const entry     = JSON.parse(fsModule.readFileSync(path.join(dir, name), 'utf8'));
+            const updatedMs = Date.parse(entry?.updatedAt);
+
+            if (!entry?.taskName || Number.isNaN(updatedMs) || Number.isNaN(Date.parse(entry?.deferredSince))) {
+                unreadable.push(name);
+                continue;
+            }
+
+            if (nowMs - updatedMs <= staleAfterMs) {
+                waiters.push(entry);
+            }
+        } catch {
+            unreadable.push(name);
+        }
+    }
+
+    return {waiters, unreadable};
+}
+
+/**
+ * @summary The fairness decision: must `taskName` yield the acquisition to a registered waiter?
+ *
+ * A candidate yields when a live waiter (not itself) outranks it in the three-rank order:
+ * priority-0 beats everything below it; bootstrap-critical (initializing durable state the
+ * plane cannot function without) beats ordinary enrichment/maintenance immediately — an
+ * uninitialized corpus must not wait out a starvation bound while cycles of downstream work
+ * re-acquire ahead of it; and an ordinary waiter starving past `fairnessYieldAfterMs` beats a
+ * candidate that has not been waiting at least as long itself. Ties in the same class do NOT
+ * force a yield — the lease's normal contention handles peers; fairness only prevents a fresh
+ * or lower-class acquirer from stepping past someone measurably starving.
+ *
+ * @param {Object} options
+ * @param {String} options.taskName The would-be acquirer.
+ * @param {Boolean} [options.priorityZero=false] Acquirer's priority class.
+ * @param {Boolean} [options.bootstrapCritical=false] Acquirer's bootstrap-critical class.
+ * @param {String|null} [options.ownDeferredSince=null] Acquirer's own durable streak start, if any.
+ * @param {Object[]} options.waiters Live entries from {@link listActiveWaitersSync}.
+ * @param {Number} options.fairnessYieldAfterMs Starvation bound that activates seniority yielding.
+ * @param {Date|Number} [options.now=new Date()] Clock seam.
+ * @returns {Object|null} The waiter to yield to, or `null` when acquisition may proceed.
+ */
+export function findWaiterToYieldTo({taskName, priorityZero = false, bootstrapCritical = false, ownDeferredSince = null, waiters, fairnessYieldAfterMs, now = new Date()} = {}) {
+    if (!Array.isArray(waiters) || waiters.length === 0) {
+        return null;
+    }
+
+    if (!Number.isFinite(fairnessYieldAfterMs) || fairnessYieldAfterMs <= 0) {
+        throw new TypeError('findWaiterToYieldTo: a positive fairnessYieldAfterMs is required');
+    }
+
+    const nowMs   = typeof now === 'number' ? now : now.getTime();
+    const ownMs   = ownDeferredSince ? Date.parse(ownDeferredSince) : null;
+    let   yieldTo = null;
+
+    for (const waiter of waiters) {
+        if (waiter.taskName === taskName) continue;
+
+        const waiterMs   = Date.parse(waiter.deferredSince);
+        const starvingMs = nowMs - waiterMs;
+
+        const outranksByClass     = waiter.priorityZero === true && priorityZero !== true;
+        const outranksByBootstrap = waiter.bootstrapCritical === true && bootstrapCritical !== true && priorityZero !== true;
+        const outranksByAge       = starvingMs >= fairnessYieldAfterMs && (ownMs === null || waiterMs < ownMs);
+
+        if (outranksByClass || outranksByBootstrap || outranksByAge) {
+            if (!yieldTo || Date.parse(yieldTo.deferredSince) > waiterMs) {
+                yieldTo = waiter;
+            }
+        }
+    }
+
+    return yieldTo;
+}

--- a/ai/scripts/lint/config-leaf-parity.json
+++ b/ai/scripts/lint/config-leaf-parity.json
@@ -310,6 +310,7 @@
         "orchestrator.heavyMaintenance",
         "orchestrator.heavyMaintenance.maxActiveHoldMs",
         "orchestrator.heavyMaintenanceLease",
+        "orchestrator.heavyMaintenanceLease.fairnessYieldAfterMs",
         "orchestrator.heavyMaintenanceLease.staleAfterMs",
         "orchestrator.intervals",
         "orchestrator.intervals.backupMs",

--- a/ai/scripts/maintenance/syncTenantRepos.mjs
+++ b/ai/scripts/maintenance/syncTenantRepos.mjs
@@ -15,10 +15,13 @@
  *
  * Exit code: 0 on `completed`, 1 on `failed` or `skipped`
  * (no-tenant-repos-configured), 2 on argument error, 3 when a selected
- * repo slug is not configured, and 4 when another process (the orchestrator's
+ * repo slug is not configured, 4 when another process (the orchestrator's
  * periodic sweep or a second CLI run) holds the cross-process tenant-repo-sync
- * lease. The lease serializes both entry paths over the shared revisions
- * manifest; a held lease is a bounded busy result, never a silent race.
+ * lease, and 5 when the GLOBAL heavy-maintenance lease is held by another
+ * exclusive-heavy job (e.g. an active REM cycle) — tenant sync is substrate-heavy
+ * with no compatible pair, so the manual path competes for the same global lease
+ * as the scheduler instead of bypassing it. Every held lease is a bounded busy
+ * result with an owner receipt, never a silent race.
  *
  * Mirrors the operator-side pattern of `ai/scripts/maintenance/backup.mjs` and the
  * other `./maintenance/*` scripts — bootstrap Neo namespace then invoke a service.
@@ -31,11 +34,17 @@ import Neo             from '../../../src/Neo.mjs';
 import * as core       from '../../../src/core/_export.mjs';
 import {pathToFileURL} from 'url';
 
+import AiConfig              from '../../config.mjs';
 import TenantRepoSyncService from '../../daemons/orchestrator/services/TenantRepoSyncService.mjs';
 import {
     KB_TENANT_REPO_SYNC_LEASE_HELD,
     KB_TENANT_REPO_SYNC_REPO_NOT_CONFIGURED
 } from '../../daemons/orchestrator/services/TenantRepoSyncErrors.mjs';
+import {
+    acquireHeavyMaintenanceLeaseSync,
+    releaseHeavyMaintenanceLeaseSync,
+    resolveHeavyMaintenanceLeasePath
+} from '../../daemons/orchestrator/services/heavyMaintenanceLeasePrimitives.mjs';
 
 /**
  * @summary Parses manual tenant-repo-sync selectors and scoped replay intent.
@@ -92,6 +101,8 @@ Exit codes:
   1  failed (all repos failed) or skipped (no configured tenantRepos)
   3  --repo-slug requested but the named repo is not configured (KB_TENANT_REPO_SYNC_REPO_NOT_CONFIGURED)
   4  another process holds the tenant-repo-sync lease (KB_TENANT_REPO_SYNC_LEASE_HELD) — retry after it finishes
+  5  the GLOBAL heavy-maintenance lease is held (GLOBAL_HEAVY_LEASE_HELD) — another exclusive-heavy
+     job (e.g. REM) is active; retry after it finishes, never override
   2  argument-parse error`);
 }
 
@@ -157,11 +168,46 @@ async function main() {
     const taskStateService = createInMemoryTaskStateService();
     const writeLog         = (level, msg) => console.log(`[${level}] ${msg}`);
 
-    const result = await TenantRepoSyncService.runTask(buildRunTaskOptions({
-        parsed,
-        taskStateService,
-        writeLog
-    }));
+    // Global heavy-maintenance lease: tenant-repo-sync is an
+    // exclusive-heavy substrate job with no compatible pair, and this CLI previously acquired only
+    // the narrow tenant-sync lease — bypassing the cross-daemon serialization and making concurrent
+    // Chroma/SQLite maintenance possible against an active REM cycle. The manual path now competes
+    // for the SAME global lease as the orchestrator's scheduler; a held lease is a receipt and an
+    // exit code, never a race.
+    const leasePath   = resolveHeavyMaintenanceLeasePath({dataDir: AiConfig.orchestrator.dataDir});
+    const acquisition = acquireHeavyMaintenanceLeaseSync({
+        owner       : 'tenant-repo-sync',
+        reason      : 'manual-cli',
+        metadata    : {source: 'manual-cli'},
+        leasePath,
+        staleAfterMs: AiConfig.orchestrator.heavyMaintenanceLease.staleAfterMs
+    });
+
+    if (!acquisition.acquired) {
+        const holder = acquisition.lease || {};
+        console.error(
+            `GLOBAL_HEAVY_LEASE_HELD: the cross-daemon heavy-maintenance lease is held by ` +
+            `'${holder.owner || 'unknown'}' (pid: ${holder.pid ?? 'n/a'}, acquired: ${holder.acquiredAt ?? 'n/a'}, ` +
+            `expires: ${holder.expiresAt ?? 'n/a'}). Concurrent heavy substrate maintenance is unsafe — ` +
+            `retry after the holder finishes; do not override the lease.`
+        );
+        process.exit(5);
+    }
+
+    let result;
+    try {
+        result = await TenantRepoSyncService.runTask(buildRunTaskOptions({
+            parsed,
+            taskStateService,
+            writeLog
+        }));
+    } finally {
+        try {
+            releaseHeavyMaintenanceLeaseSync({token: acquisition.lease.token, leasePath});
+        } catch (e) {
+            console.error(`Heavy-maintenance lease release failed: ${e.message}`);
+        }
+    }
 
     console.log(JSON.stringify(result, null, 2));
 

--- a/ai/scripts/maintenance/syncTenantRepos.mjs
+++ b/ai/scripts/maintenance/syncTenantRepos.mjs
@@ -15,13 +15,10 @@
  *
  * Exit code: 0 on `completed`, 1 on `failed` or `skipped`
  * (no-tenant-repos-configured), 2 on argument error, 3 when a selected
- * repo slug is not configured, 4 when another process (the orchestrator's
+ * repo slug is not configured, and 4 when another process (the orchestrator's
  * periodic sweep or a second CLI run) holds the cross-process tenant-repo-sync
- * lease, and 5 when the GLOBAL heavy-maintenance lease is held by another
- * exclusive-heavy job (e.g. an active REM cycle) — tenant sync is substrate-heavy
- * with no compatible pair, so the manual path competes for the same global lease
- * as the scheduler instead of bypassing it. Every held lease is a bounded busy
- * result with an owner receipt, never a silent race.
+ * lease. The lease serializes both entry paths over the shared revisions
+ * manifest; a held lease is a bounded busy result, never a silent race.
  *
  * Mirrors the operator-side pattern of `ai/scripts/maintenance/backup.mjs` and the
  * other `./maintenance/*` scripts — bootstrap Neo namespace then invoke a service.
@@ -34,17 +31,11 @@ import Neo             from '../../../src/Neo.mjs';
 import * as core       from '../../../src/core/_export.mjs';
 import {pathToFileURL} from 'url';
 
-import AiConfig              from '../../config.mjs';
 import TenantRepoSyncService from '../../daemons/orchestrator/services/TenantRepoSyncService.mjs';
 import {
     KB_TENANT_REPO_SYNC_LEASE_HELD,
     KB_TENANT_REPO_SYNC_REPO_NOT_CONFIGURED
 } from '../../daemons/orchestrator/services/TenantRepoSyncErrors.mjs';
-import {
-    acquireHeavyMaintenanceLeaseSync,
-    releaseHeavyMaintenanceLeaseSync,
-    resolveHeavyMaintenanceLeasePath
-} from '../../daemons/orchestrator/services/heavyMaintenanceLeasePrimitives.mjs';
 
 /**
  * @summary Parses manual tenant-repo-sync selectors and scoped replay intent.
@@ -101,8 +92,6 @@ Exit codes:
   1  failed (all repos failed) or skipped (no configured tenantRepos)
   3  --repo-slug requested but the named repo is not configured (KB_TENANT_REPO_SYNC_REPO_NOT_CONFIGURED)
   4  another process holds the tenant-repo-sync lease (KB_TENANT_REPO_SYNC_LEASE_HELD) — retry after it finishes
-  5  the GLOBAL heavy-maintenance lease is held (GLOBAL_HEAVY_LEASE_HELD) — another exclusive-heavy
-     job (e.g. REM) is active; retry after it finishes, never override
   2  argument-parse error`);
 }
 
@@ -168,46 +157,11 @@ async function main() {
     const taskStateService = createInMemoryTaskStateService();
     const writeLog         = (level, msg) => console.log(`[${level}] ${msg}`);
 
-    // Global heavy-maintenance lease: tenant-repo-sync is an
-    // exclusive-heavy substrate job with no compatible pair, and this CLI previously acquired only
-    // the narrow tenant-sync lease — bypassing the cross-daemon serialization and making concurrent
-    // Chroma/SQLite maintenance possible against an active REM cycle. The manual path now competes
-    // for the SAME global lease as the orchestrator's scheduler; a held lease is a receipt and an
-    // exit code, never a race.
-    const leasePath   = resolveHeavyMaintenanceLeasePath({dataDir: AiConfig.orchestrator.dataDir});
-    const acquisition = acquireHeavyMaintenanceLeaseSync({
-        owner       : 'tenant-repo-sync',
-        reason      : 'manual-cli',
-        metadata    : {source: 'manual-cli'},
-        leasePath,
-        staleAfterMs: AiConfig.orchestrator.heavyMaintenanceLease.staleAfterMs
-    });
-
-    if (!acquisition.acquired) {
-        const holder = acquisition.lease || {};
-        console.error(
-            `GLOBAL_HEAVY_LEASE_HELD: the cross-daemon heavy-maintenance lease is held by ` +
-            `'${holder.owner || 'unknown'}' (pid: ${holder.pid ?? 'n/a'}, acquired: ${holder.acquiredAt ?? 'n/a'}, ` +
-            `expires: ${holder.expiresAt ?? 'n/a'}). Concurrent heavy substrate maintenance is unsafe — ` +
-            `retry after the holder finishes; do not override the lease.`
-        );
-        process.exit(5);
-    }
-
-    let result;
-    try {
-        result = await TenantRepoSyncService.runTask(buildRunTaskOptions({
-            parsed,
-            taskStateService,
-            writeLog
-        }));
-    } finally {
-        try {
-            releaseHeavyMaintenanceLeaseSync({token: acquisition.lease.token, leasePath});
-        } catch (e) {
-            console.error(`Heavy-maintenance lease release failed: ${e.message}`);
-        }
-    }
+    const result = await TenantRepoSyncService.runTask(buildRunTaskOptions({
+        parsed,
+        taskStateService,
+        writeLog
+    }));
 
     console.log(JSON.stringify(result, null, 2));
 

--- a/test/playwright/unit/ai/daemons/orchestrator/Orchestrator.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/Orchestrator.spec.mjs
@@ -66,8 +66,14 @@ function createTestOrchestrator(config = {}) {
         neuralLinkBridgeLivenessTimeoutMs: config.neuralLinkBridgeLivenessTimeoutMs ?? 50
     });
 
+    // Per-fixture DIRECTORY, not merely a per-fixture file: the waiter ledger lives in a
+    // `heavy-maintenance-waiters/` sibling derived from the lease path's dirname, so unique
+    // lease files inside one shared directory would still share one ledger — and a leftover
+    // priority-0 waiter entry from an earlier arm forces every later acquisition to yield.
     const heavyMaintenanceLeasePath = config.heavyMaintenanceLeasePath
-        || `/tmp/orchestrator-test/heavy-maintenance-lease-${process.pid}-${++testOrchestratorSeq}.json`;
+        || `/tmp/orchestrator-test/lease-${process.pid}-${++testOrchestratorSeq}/heavy-maintenance-lease.json`;
+
+    fs.mkdirSync(path.dirname(heavyMaintenanceLeasePath), {recursive: true});
 
     TaskStateService.configure({
         stateFile : '/tmp/orchestrator-test/state.json',

--- a/test/playwright/unit/ai/daemons/orchestrator/Orchestrator.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/Orchestrator.spec.mjs
@@ -1699,6 +1699,91 @@ test.describe('Neo.ai.daemons.Orchestrator (#11009)', () => {
         expect(started).toEqual([]);
     });
 
+    // The boot-time configured-coverage prewarm sits on the start path, so it needs both an
+    // authority gate and a deadline. Ungated it drags a host-edge or graphless profile into
+    // container-plane configuration authority (the canonical resolver awaits `graphService.ready()`);
+    // unbounded, a resolver that never settles stops the daemon polling at all. Gate and bound are
+    // exercised together here rather than separately — testing either alone is what let the
+    // composition defect through the previous cycle.
+    test.describe('prewarmConfiguredTenantRepoCoverage — boot-boundary gate and deadline', () => {
+        function orchestratorWithPrewarm({owned, enabled, ensureImpl}) {
+            const orchestrator = Neo.create(Orchestrator);
+            const logs         = [];
+
+            orchestrator.writeLog                       = (level, message) => logs.push({level, message});
+            orchestrator.isTaskAuthorityOwned           = taskName => owned && taskName === 'tenant-repo-sync';
+            orchestrator.maintenanceBackpressureService = {ensureConfiguredTenantRepoLabels: ensureImpl};
+
+            Object.defineProperty(orchestrator, 'tenantRepoSyncEnabled', {get: () => enabled, configurable: true});
+
+            return {orchestrator, logs}
+        }
+
+        test('a profile that does not own tenant-repo-sync never reaches the resolver', async () => {
+            let   calls          = 0;
+            const {orchestrator} = orchestratorWithPrewarm({
+                owned: false, enabled: true, ensureImpl: async () => { calls++; return [] }
+            });
+
+            await orchestrator.prewarmConfiguredTenantRepoCoverage(50);
+
+            expect(calls).toBe(0);
+            orchestrator.destroy()
+        });
+
+        test('an owning profile with the lane disabled never reaches the resolver', async () => {
+            let   calls          = 0;
+            const {orchestrator} = orchestratorWithPrewarm({
+                owned: true, enabled: false, ensureImpl: async () => { calls++; return [] }
+            });
+
+            await orchestrator.prewarmConfiguredTenantRepoCoverage(50);
+
+            expect(calls).toBe(0);
+            orchestrator.destroy()
+        });
+
+        test('a never-settling resolver cannot prevent the scheduler from starting', async () => {
+            const {orchestrator, logs} = orchestratorWithPrewarm({
+                owned: true, enabled: true, ensureImpl: () => new Promise(() => {})
+            });
+
+            // The assertion is that this await RETURNS at all — an unbounded prewarm hangs here
+            // forever and the daemon never polls.
+            await orchestrator.prewarmConfiguredTenantRepoCoverage(25);
+
+            expect(logs.some(entry => entry.level === 'WARN' && /did not resolve within 25ms/.test(entry.message))).toBe(true);
+            orchestrator.destroy()
+        });
+
+        test('an owned, enabled lane observes resolved coverage before returning', async () => {
+            let   resolved             = false;
+            const {orchestrator, logs} = orchestratorWithPrewarm({
+                owned     : true,
+                enabled   : true,
+                ensureImpl: async () => { await new Promise(r => setTimeout(r, 5)); resolved = true; return ['a/one'] }
+            });
+
+            await orchestrator.prewarmConfiguredTenantRepoCoverage(1000);
+
+            expect(resolved).toBe(true);
+            expect(logs.some(entry => entry.level === 'WARN')).toBe(false);
+            orchestrator.destroy()
+        });
+
+        test('start() awaits the prewarm before the first poll', async () => {
+            // Source-shape assertion: the gate/deadline above are worthless if the call site drifts
+            // after `poll()`. Mirrors the existing runSandman lease-window ordering test.
+            const source     = await fs.readFile(path.resolve(process.cwd(), 'ai/daemons/orchestrator/Orchestrator.mjs'), 'utf-8');
+            const prewarmIdx = source.indexOf('await this.prewarmConfiguredTenantRepoCoverage()');
+            const pollIdx    = source.indexOf('this.poll();');
+
+            expect(prewarmIdx).toBeGreaterThan(-1);
+            expect(pollIdx).toBeGreaterThan(-1);
+            expect(prewarmIdx).toBeLessThan(pollIdx)
+        })
+    });
+
     test('resolves default paths correctly without configuration overrides', () => {
         // With configure() removed, path resolution is direct instance-field
         // assignment + buildTaskDefinitions(), mirroring the substrate-correct shape used

--- a/test/playwright/unit/ai/daemons/orchestrator/scheduling/pipeline.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/scheduling/pipeline.spec.mjs
@@ -238,6 +238,102 @@ test.describe('orchestrator/scheduling/pipeline (#11862/#11900)', () => {
         expect(spawnedTask).toBe('temporal-summary');
     });
 
+    // Composition witness for the bootstrap rank. Gating the rank at lease admission alone is not
+    // enough: a yield there only makes the picked winner abstain, and because this pipeline
+    // dispatches exactly one candidate per poll and returns, that promotes nobody — the starved
+    // bootstrap lane is never dispatched and its waiter entry expires before it runs, producing a
+    // dead window followed by the original ordering. These arms pin the rank to SELECTION, where it
+    // determines what actually executes.
+    test.describe('bootstrap-critical rank is applied at selection, not only at admission', () => {
+        // dream is far more stale than tenant-repo-sync, so pure staleness picks dream.
+        const bootstrapCompetitionFixture = () => ({
+            registry: [
+                makeCandidateDescriptor({taskName: 'dream'}),
+                makeCandidateDescriptor({taskName: 'tenant-repo-sync'})
+            ],
+            context: makeContext({
+                now      : 1_000_000,
+                state    : {dream: {lastRunAt: 0}, 'tenant-repo-sync': {lastRunAt: 990_000}},
+                intervals: {dream: 10_000, tenantRepoSync: 10_000}
+            })
+        });
+
+        test('CONTROL — without the bootstrap oracle the more-stale REM lane wins the poll', () => {
+            const started             = [];
+            const {registry, context} = bootstrapCompetitionFixture();
+
+            const result = runSchedulingPipeline({
+                registry,
+                context,
+                services: makeServices({
+                    processSupervisorService: {runTask(taskName) { started.push(taskName); return true }}
+                }),
+                runtime: makeRuntime()
+            });
+
+            // Establishes that the assertion below is not vacuous: staleness genuinely favours dream.
+            expect(result.winner.taskName).toBe('dream');
+            expect(started).toEqual(['dream']);
+        });
+
+        test('a registered bootstrap-critical lane is DISPATCHED over the more-stale REM lane', () => {
+            const started             = [];
+            const {registry, context} = bootstrapCompetitionFixture();
+
+            const result = runSchedulingPipeline({
+                registry,
+                context,
+                services: makeServices({
+                    maintenanceBackpressureService: {
+                        acquireLeaseAndExecute({executeFn, taskName, reason, onSuccess, activeHeavyTask}) {
+                            return executeFn(taskName, reason, onSuccess, {activeHeavyTask});
+                        },
+                        executeWithGoldenPathDependencyGate({executeFn, taskName, reason}) {
+                            return executeFn(taskName, reason);
+                        },
+                        getActiveHeavyMaintenanceTask() { return null },
+                        isHeavyMaintenanceTask() { return false },
+                        recordDeferral() {},
+                        isBootstrapCriticalTask(taskName) { return taskName === 'tenant-repo-sync' }
+                    },
+                    processSupervisorService: {runTask(taskName) { started.push(taskName); return true }}
+                }),
+                runtime: makeRuntime()
+            });
+
+            // The whole point of RA-1: the bootstrap lane RUNS. A veto-only fix would leave `started`
+            // empty and the winner unexecuted, which is indistinguishable from progress on a dashboard.
+            expect(result.winner.taskName).toBe('tenant-repo-sync');
+            expect(started).toEqual(['tenant-repo-sync']);
+        });
+
+        test('a throwing bootstrap oracle fails open to staleness ordering', () => {
+            const {registry, context} = bootstrapCompetitionFixture();
+
+            const result = runSchedulingPipeline({
+                registry,
+                context,
+                services: makeServices({
+                    maintenanceBackpressureService: {
+                        acquireLeaseAndExecute({executeFn, taskName, reason, onSuccess, activeHeavyTask}) {
+                            return executeFn(taskName, reason, onSuccess, {activeHeavyTask});
+                        },
+                        executeWithGoldenPathDependencyGate({executeFn, taskName, reason}) {
+                            return executeFn(taskName, reason);
+                        },
+                        getActiveHeavyMaintenanceTask() { return null },
+                        isHeavyMaintenanceTask() { return false },
+                        recordDeferral() {},
+                        isBootstrapCriticalTask() { throw new Error('manifest unreadable') }
+                    }
+                }),
+                runtime: makeRuntime()
+            });
+
+            expect(result.winner.taskName).toBe('dream');
+        });
+    });
+
     test('reports descriptor errors and still dispatches the selected candidate', () => {
         const outcomes = [];
         const started  = [];

--- a/test/playwright/unit/ai/daemons/orchestrator/services/MaintenanceBackpressureService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/MaintenanceBackpressureService.spec.mjs
@@ -1,5 +1,6 @@
 import {test, expect} from '@playwright/test';
 import fs             from 'fs-extra';
+import os             from 'os';
 import path           from 'path';
 import Neo            from '../../../../../../../src/Neo.mjs';
 import * as core      from '../../../../../../../src/core/_export.mjs';
@@ -47,7 +48,12 @@ function buildService(overrides = {}) {
     return Neo.create(MaintenanceBackpressureService, {
         heavyMaintenanceTaskNames    : DEFAULT_HEAVY_MAINTENANCE_TASK_NAMES,
         goldenPathDependencyTaskNames: DEFAULT_GOLDEN_PATH_DEPENDENCY_TASK_NAMES,
-        writeLog                     : () => {},
+        // Isolated per-instance lease path: the waiter ledger persists deferral entries BESIDE
+        // the lease file by design, so a fixture inheriting the real plane path would leak one
+        // arm's registered waiters (including priority-0 ones, which force yields with no
+        // starvation bound) into every later arm's admission decision — and into the plane dir.
+        heavyMaintenanceLeasePath: path.join(fs.mkdtempSync(path.join(os.tmpdir(), 'mbs-lease-')), 'heavy-maintenance-lease.json'),
+        writeLog                 : () => {},
         ...overrides
     });
 }

--- a/test/playwright/unit/ai/daemons/orchestrator/services/MaintenanceBackpressureService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/MaintenanceBackpressureService.spec.mjs
@@ -54,6 +54,11 @@ function buildService(overrides = {}) {
         // starvation bound) into every later arm's admission decision — and into the plane dir.
         heavyMaintenanceLeasePath: path.join(fs.mkdtempSync(path.join(os.tmpdir(), 'mbs-lease-')), 'heavy-maintenance-lease.json'),
         writeLog                 : () => {},
+        // Same isolation reasoning applied to the coverage resolver: the admission fairness gate
+        // calls isBootstrapCriticalTask, which kicks a lazy refresh. Unstubbed, that runs the real
+        // tiered resolver in the background — importing the tenant sync lane and touching its lease
+        // guard directories after the arm returns, which races other specs' temp-dir teardown.
+        resolveConfiguredTenantRepoLabelsFn: async () => null,
         ...overrides
     });
 }

--- a/test/playwright/unit/ai/daemons/orchestrator/services/heavyMaintenanceWaiterLedger.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/heavyMaintenanceWaiterLedger.spec.mjs
@@ -392,6 +392,32 @@ test.describe('Neo.ai.daemons.orchestrator.services.heavyMaintenanceWaiterLedger
             service.destroy()
         });
 
+        test('an expired coverage snapshot cannot dispatch REM while a canonical refresh discovers a new repo', async () => {
+            const service = serviceWithManifest(JSON.stringify({revisions: {
+                'a/one': {lastIngestedRev: 'abc123'}
+            }}));
+
+            // The last-known snapshot is complete but stale. The canonical resolver now exposes a
+            // newly configured repo whose first checkpoint does not exist yet.
+            service.configuredTenantRepoLabels           = ['a/one'];
+            service.configuredTenantRepoLabelsAt         = 0;
+            service.resolveConfiguredTenantRepoLabelsFn = async () => ['a/one', 'a/two'];
+
+            const winner = pickNextCandidate({
+                candidates   : bootCandidates(),
+                runningTasks : [],
+                policyContext: bootPolicyContext(service)
+            });
+
+            // The synchronous picker cannot await the canonical refresh. It must therefore fail
+            // safe for THIS decision instead of handing the only heavy slot to more-stale REM.
+            expect(winner.taskName).toBe('tenant-repo-sync');
+
+            await service.ensureConfiguredTenantRepoLabels();
+            expect(service.configuredTenantRepoLabels).toEqual(['a/one', 'a/two']);
+            service.destroy()
+        });
+
         test('an unresolved snapshot with no manifest fails SAFE — cannot prove the plane is initialized', () => {
             const service = serviceWithManifest(undefined);
 

--- a/test/playwright/unit/ai/daemons/orchestrator/services/heavyMaintenanceWaiterLedger.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/heavyMaintenanceWaiterLedger.spec.mjs
@@ -18,6 +18,7 @@ import {
     recordDeferral
 } from '../../../../../../../ai/daemons/orchestrator/services/MaintenanceBackpressureService.mjs';
 import {PRIORITY_ZERO_TASKS} from '../../../../../../../ai/daemons/orchestrator/scheduling/pipeline.mjs';
+import {pickNextCandidate}   from '../../../../../../../ai/daemons/orchestrator/scheduling/picker.mjs';
 
 const T0   = Date.parse('2026-08-13T10:00:00.000Z');
 const HOUR = 60 * 60 * 1000;
@@ -218,14 +219,21 @@ test.describe('Neo.ai.daemons.orchestrator.services.heavyMaintenanceWaiterLedger
             complete.destroy()
         });
 
-        test('an absent or corrupt manifest never grants priority', () => {
-            const absent  = serviceWithManifest(undefined);
+        test('a corrupt manifest never grants priority — fail-closed on unreadable evidence', () => {
             const corrupt = serviceWithManifest('{not json');
 
-            expect(absent.isBootstrapCriticalTask('tenant-repo-sync')).toBe(false);
             expect(corrupt.isBootstrapCriticalTask('tenant-repo-sync')).toBe(false);
-            absent.destroy();
             corrupt.destroy()
+        });
+
+        test('an empty configured set is ordinary even before any manifest exists', () => {
+            const service = serviceWithManifest(undefined);
+
+            service.configuredTenantRepoLabels   = [];
+            service.configuredTenantRepoLabelsAt = Date.now();
+
+            expect(service.isBootstrapCriticalTask('tenant-repo-sync')).toBe(false);
+            service.destroy()
         });
 
         // Configured coverage, not the manifest alone, decides the class. The manifest only records
@@ -294,12 +302,111 @@ test.describe('Neo.ai.daemons.orchestrator.services.heavyMaintenanceWaiterLedger
             const service = serviceWithManifest(JSON.stringify({revisions: {'a/one': {lastIngestedRev: 'abc123'}}}));
 
             service.resolveConfiguredTenantRepoLabelsFn = async () => ['a/one', 'a/two'];
-            service.refreshConfiguredTenantRepoLabels();
-            await new Promise(resolve => setImmediate(resolve));
+            // Await the resolver promise rather than counting event-loop turns: tick-counting
+            // couples the test to the refresh chain's internal depth.
+            await service.ensureConfiguredTenantRepoLabels();
 
             expect(service.configuredTenantRepoLabels).toEqual(['a/one', 'a/two']);
             // 'a/two' is configured and uncheckpointed, so coverage now grants the class.
             expect(service.isBootstrapCriticalTask('tenant-repo-sync')).toBe(true);
+            service.destroy()
+        });
+
+        // The boot boundary. The arms above seed the snapshot or await a tick, which proves the
+        // predicate but MASKS the first production decision: on a fresh deployment the snapshot is
+        // unresolved at the first pick, and ranking ordinary there hands the heavy lease to a
+        // more-stale REM cycle for its full duration — losing the one decision the class exists to
+        // win. These two compose the real thing: real service, real async resolver, real absent
+        // manifest, no seeding and no setImmediate.
+        function bootCandidates() {
+            return [
+                {taskName: 'dream',            descriptor: {maintenanceClass: 'heavy', dependencies: []}},
+                {taskName: 'tenant-repo-sync', descriptor: {maintenanceClass: 'heavy', dependencies: []}}
+            ]
+        }
+
+        // dream is far more stale, so pure staleness picks dream.
+        function bootPolicyContext(service) {
+            return {
+                now                    : 1_000_000,
+                taskMeta               : {dream: {lastRunAt: 0, cadenceMs: 10_000}, 'tenant-repo-sync': {lastRunAt: 990_000, cadenceMs: 10_000}},
+                priorityZeroTasks      : PRIORITY_ZERO_TASKS,
+                isBootstrapCriticalTask: taskName => service.isBootstrapCriticalTask(taskName)
+            }
+        }
+
+        test('first scheduling decision after boot ranks tenant sync over more-stale REM', async () => {
+            const dataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'bootstrap-boot-'));
+            const service = Neo.create(MaintenanceBackpressureService, {
+                dataDir,
+                writeLog                           : () => {},
+                resolveConfiguredTenantRepoLabelsFn: async () => ['a/one']
+            });
+
+            // Exactly what Orchestrator.start() does before its first sweep.
+            await service.ensureConfiguredTenantRepoLabels();
+
+            const winner = pickNextCandidate({
+                candidates   : bootCandidates(),
+                runningTasks : [],
+                policyContext: bootPolicyContext(service)
+            });
+
+            expect(winner.taskName).toBe('tenant-repo-sync');
+            service.destroy()
+        });
+
+        test('CONTROL — with complete checkpoint coverage the more-stale REM lane wins that same decision', async () => {
+            const dataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'bootstrap-boot-covered-'));
+
+            fs.writeFileSync(
+                path.join(dataDir, 'tenant-repo-sync-revisions.json'),
+                JSON.stringify({revisions: {'a/one': {lastIngestedRev: 'abc123'}}})
+            );
+
+            const service = Neo.create(MaintenanceBackpressureService, {
+                dataDir,
+                writeLog                           : () => {},
+                resolveConfiguredTenantRepoLabelsFn: async () => ['a/one']
+            });
+
+            await service.ensureConfiguredTenantRepoLabels();
+
+            const winner = pickNextCandidate({
+                candidates   : bootCandidates(),
+                runningTasks : [],
+                policyContext: bootPolicyContext(service)
+            });
+
+            // Establishes the arm above is not vacuous: staleness genuinely favours dream here.
+            expect(winner.taskName).toBe('dream');
+            service.destroy()
+        });
+
+        test('an unresolved snapshot with no manifest fails SAFE — cannot prove the plane is initialized', () => {
+            const service = serviceWithManifest(undefined);
+
+            service.resolveConfiguredTenantRepoLabelsFn = () => new Promise(() => {}); // never settles
+
+            expect(service.configuredTenantRepoLabels).toBeNull();
+            expect(service.isBootstrapCriticalTask('tenant-repo-sync')).toBe(true);
+            service.destroy()
+        });
+
+        test('ensureConfiguredTenantRepoLabels is single-flight — concurrent callers share one resolver call', async () => {
+            const service = serviceWithManifest(undefined);
+            let   calls   = 0;
+
+            service.resolveConfiguredTenantRepoLabelsFn = async () => { calls++; return ['a/one'] };
+
+            const [a, b] = await Promise.all([
+                service.ensureConfiguredTenantRepoLabels(),
+                service.ensureConfiguredTenantRepoLabels()
+            ]);
+
+            expect(calls).toBe(1);
+            expect(a).toEqual(['a/one']);
+            expect(b).toEqual(['a/one']);
             service.destroy()
         });
 
@@ -308,8 +415,8 @@ test.describe('Neo.ai.daemons.orchestrator.services.heavyMaintenanceWaiterLedger
 
             service.resolveConfiguredTenantRepoLabelsFn = async () => { throw new Error('resolver down') };
             service.configuredTenantRepoLabelsAt        = 0;
-            service.refreshConfiguredTenantRepoLabels();
-            await new Promise(resolve => setImmediate(resolve));
+            // Must not reject: boot awaits this call, so a resolver outage cannot block startup.
+            await service.ensureConfiguredTenantRepoLabels();
 
             expect(service.configuredTenantRepoLabels).toEqual(['a/one']);
             expect(service.isBootstrapCriticalTask('tenant-repo-sync')).toBe(true);

--- a/test/playwright/unit/ai/daemons/orchestrator/services/heavyMaintenanceWaiterLedger.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/heavyMaintenanceWaiterLedger.spec.mjs
@@ -1,0 +1,315 @@
+import {test, expect} from '@playwright/test';
+import fs             from 'fs-extra';
+import os             from 'node:os';
+import path           from 'node:path';
+import Neo            from '../../../../../../../src/Neo.mjs';
+import * as core      from '../../../../../../../src/core/_export.mjs';
+import {
+    clearWaiterSync,
+    findWaiterToYieldTo,
+    listActiveWaitersSync,
+    registerWaiterSync,
+    resolveWaitersDir
+} from '../../../../../../../ai/daemons/orchestrator/services/heavyMaintenanceWaiterLedger.mjs';
+import {
+    DEFAULT_HEAVY_MAINTENANCE_TASK_NAMES,
+    MaintenanceBackpressureService,
+    WAITER_ENTRY_STALE_AFTER_MS,
+    recordDeferral
+} from '../../../../../../../ai/daemons/orchestrator/services/MaintenanceBackpressureService.mjs';
+import {PRIORITY_ZERO_TASKS} from '../../../../../../../ai/daemons/orchestrator/scheduling/pipeline.mjs';
+
+const T0   = Date.parse('2026-08-13T10:00:00.000Z');
+const HOUR = 60 * 60 * 1000;
+const iso  = ms => new Date(ms).toISOString();
+
+function tmpLeasePath() {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'waiter-ledger-'));
+    return path.join(dir, 'heavy-maintenance-lease.json');
+}
+
+test.describe('Neo.ai.daemons.orchestrator.services.heavyMaintenanceWaiterLedger (#16561)', () => {
+
+    test('register → list roundtrip carries the durable streak, and re-registering refreshes one entry', () => {
+        const leasePath = tmpLeasePath();
+
+        registerWaiterSync({leasePath, taskName: 'tenant-repo-sync', deferredSince: iso(T0 - 2 * HOUR), now: T0});
+        registerWaiterSync({leasePath, taskName: 'tenant-repo-sync', deferredSince: iso(T0 - 2 * HOUR), now: T0 + 60_000});
+
+        const {waiters, unreadable} = listActiveWaitersSync({leasePath, staleAfterMs: WAITER_ENTRY_STALE_AFTER_MS, now: T0 + 60_000});
+
+        expect(unreadable).toEqual([]);
+        expect(waiters).toHaveLength(1);
+        expect(waiters[0]).toMatchObject({
+            taskName     : 'tenant-repo-sync',
+            priorityZero : false,
+            deferredSince: iso(T0 - 2 * HOUR),
+            updatedAt    : iso(T0 + 60_000)
+        })
+    });
+
+    test('a silent waiter expires — a dead process cannot veto acquisitions forever', () => {
+        const leasePath = tmpLeasePath();
+
+        registerWaiterSync({leasePath, taskName: 'backup', priorityZero: true, deferredSince: iso(T0 - HOUR), now: T0});
+
+        const fresh = listActiveWaitersSync({leasePath, staleAfterMs: WAITER_ENTRY_STALE_AFTER_MS, now: T0 + WAITER_ENTRY_STALE_AFTER_MS});
+        const stale = listActiveWaitersSync({leasePath, staleAfterMs: WAITER_ENTRY_STALE_AFTER_MS, now: T0 + WAITER_ENTRY_STALE_AFTER_MS + 1});
+
+        expect(fresh.waiters).toHaveLength(1);
+        expect(stale.waiters).toHaveLength(0)
+    });
+
+    test('clear removes the entry and tolerates absence; a corrupt entry is reported, never thrown', () => {
+        const leasePath = tmpLeasePath();
+
+        registerWaiterSync({leasePath, taskName: 'dream', deferredSince: iso(T0), now: T0});
+        clearWaiterSync({leasePath, taskName: 'dream'});
+        clearWaiterSync({leasePath, taskName: 'dream'});
+
+        fs.writeFileSync(path.join(resolveWaitersDir({leasePath}), 'garbage.json'), '{not json');
+
+        const {waiters, unreadable} = listActiveWaitersSync({leasePath, staleAfterMs: WAITER_ENTRY_STALE_AFTER_MS, now: T0});
+
+        expect(waiters).toHaveLength(0);
+        expect(unreadable).toEqual(['garbage.json'])
+    });
+
+    test('an unmeasured wait must not register as a fresh one', () => {
+        const leasePath = tmpLeasePath();
+
+        expect(() => registerWaiterSync({leasePath, taskName: 'backup', deferredSince: undefined, now: T0})).toThrow(/durable ISO streak start/);
+        expect(() => registerWaiterSync({leasePath, taskName: 'backup', deferredSince: 'not-a-date', now: T0})).toThrow(/durable ISO streak start/)
+    });
+
+    test.describe('findWaiterToYieldTo — the fairness decision matrix', () => {
+        const bound = 30 * 60 * 1000;
+
+        test('priority-0 waiter beats an ordinary acquirer regardless of streak age', () => {
+            const waiters = [{taskName: 'backup', priorityZero: true, deferredSince: iso(T0 - 60_000)}];
+
+            expect(findWaiterToYieldTo({taskName: 'dream', waiters, fairnessYieldAfterMs: bound, now: T0})?.taskName).toBe('backup')
+        });
+
+        test('an ordinary waiter starving past the bound beats a fresh acquirer', () => {
+            const waiters = [{taskName: 'tenant-repo-sync', priorityZero: false, deferredSince: iso(T0 - bound)}];
+
+            expect(findWaiterToYieldTo({taskName: 'dream', waiters, fairnessYieldAfterMs: bound, now: T0})?.taskName).toBe('tenant-repo-sync')
+        });
+
+        test('the waiter itself proceeds — self-entries never force a yield', () => {
+            const waiters = [{taskName: 'tenant-repo-sync', priorityZero: false, deferredSince: iso(T0 - 2 * HOUR)}];
+
+            expect(findWaiterToYieldTo({taskName: 'tenant-repo-sync', waiters, fairnessYieldAfterMs: bound, now: T0})).toBeNull()
+        });
+
+        test('an acquirer with the OLDER streak does not yield to a younger starving waiter', () => {
+            const waiters = [{taskName: 'summary', priorityZero: false, deferredSince: iso(T0 - bound)}];
+
+            expect(findWaiterToYieldTo({
+                taskName: 'tenant-repo-sync', ownDeferredSince: iso(T0 - 2 * HOUR),
+                waiters, fairnessYieldAfterMs: bound, now: T0
+            })).toBeNull()
+        });
+
+        test('fresh same-class waiters do not force a yield — ordinary contention handles peers', () => {
+            const waiters = [{taskName: 'summary', priorityZero: false, deferredSince: iso(T0 - 60_000)}];
+
+            expect(findWaiterToYieldTo({taskName: 'dream', waiters, fairnessYieldAfterMs: bound, now: T0})).toBeNull()
+        });
+
+        test('the OLDEST qualifying waiter wins when several qualify', () => {
+            const waiters = [
+                {taskName: 'summary',          priorityZero: false, deferredSince: iso(T0 - bound - 1)},
+                {taskName: 'tenant-repo-sync', priorityZero: false, deferredSince: iso(T0 - 3 * HOUR)}
+            ];
+
+            expect(findWaiterToYieldTo({taskName: 'dream', waiters, fairnessYieldAfterMs: bound, now: T0})?.taskName).toBe('tenant-repo-sync')
+        });
+
+        test('a bootstrap-critical waiter beats an ordinary acquirer IMMEDIATELY — no starvation bound', () => {
+            const waiters = [{taskName: 'tenant-repo-sync', bootstrapCritical: true, deferredSince: iso(T0 - 60_000)}];
+
+            expect(findWaiterToYieldTo({taskName: 'dream', waiters, fairnessYieldAfterMs: bound, now: T0})?.taskName).toBe('tenant-repo-sync')
+        });
+
+        test('a bootstrap-critical waiter does not preempt a priority-0 acquirer', () => {
+            const waiters = [{taskName: 'tenant-repo-sync', bootstrapCritical: true, deferredSince: iso(T0 - 60_000)}];
+
+            expect(findWaiterToYieldTo({taskName: 'backup', priorityZero: true, waiters, fairnessYieldAfterMs: bound, now: T0})).toBeNull()
+        });
+
+        test('bootstrap-critical acquirer vs bootstrap-critical waiter falls through to the age rule', () => {
+            const waiters = [{taskName: 'other-bootstrap', bootstrapCritical: true, deferredSince: iso(T0 - 60_000)}];
+
+            expect(findWaiterToYieldTo({
+                taskName: 'tenant-repo-sync', bootstrapCritical: true,
+                waiters, fairnessYieldAfterMs: bound, now: T0
+            })).toBeNull()
+        })
+    });
+
+    test.describe('isBootstrapCriticalTask — the durable-manifest predicate', () => {
+
+        function serviceWithManifest(manifest) {
+            const dataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'bootstrap-critical-'));
+
+            if (manifest !== undefined) {
+                fs.writeFileSync(path.join(dataDir, 'tenant-repo-sync-revisions.json'), manifest);
+            }
+
+            return Neo.create(MaintenanceBackpressureService, {dataDir, writeLog: () => {}});
+        }
+
+        test('an uncheckpointed seeded repo makes tenant sync bootstrap-critical; full checkpoints end it', () => {
+            const pending = serviceWithManifest(JSON.stringify({revisions: {
+                'a/one': {lastIngestedRev: 'abc123'},
+                'a/two': {lastIngestedRev: null}
+            }}));
+            const complete = serviceWithManifest(JSON.stringify({revisions: {
+                'a/one': {lastIngestedRev: 'abc123'},
+                'a/two': {lastIngestedRev: 'def456'}
+            }}));
+
+            expect(pending.isBootstrapCriticalTask('tenant-repo-sync')).toBe(true);
+            expect(pending.isBootstrapCriticalTask('dream')).toBe(false);
+            expect(complete.isBootstrapCriticalTask('tenant-repo-sync')).toBe(false);
+            pending.destroy();
+            complete.destroy()
+        });
+
+        test('an absent or corrupt manifest never grants priority', () => {
+            const absent  = serviceWithManifest(undefined);
+            const corrupt = serviceWithManifest('{not json');
+
+            expect(absent.isBootstrapCriticalTask('tenant-repo-sync')).toBe(false);
+            expect(corrupt.isBootstrapCriticalTask('tenant-repo-sync')).toBe(false);
+            absent.destroy();
+            corrupt.destroy()
+        })
+    });
+
+    test('drift tripwire: the service priority-class mirror equals the scheduling module truth', () => {
+        const service = Neo.create(MaintenanceBackpressureService, {writeLog: () => {}});
+
+        expect([...service.priorityZeroTaskNames].sort()).toEqual([...PRIORITY_ZERO_TASKS].sort());
+        service.destroy()
+    });
+
+    test('module recordDeferral returns the outcome payload carrying the durable streak', () => {
+        const payload = recordDeferral({
+            deferralLogKeys : new Set(),
+            taskName        : 'tenant-repo-sync',
+            reasonCode      : 'heavy-maintenance-lease-held',
+            reasonText      : 'scheduled',
+            holdingLease    : {owner: 'dream', pid: 1},
+            taskStateService: {markDeferred: () => iso(T0 - 2 * HOUR)}
+        });
+
+        expect(payload.deferredSince).toBe(iso(T0 - 2 * HOUR));
+        expect(payload.holdingOwner).toBe('dream')
+    });
+
+    test.describe('acquireLeaseAndExecute integration — the gate at the single acquisition point', () => {
+
+        function buildService({leasePath, taskState = {}, acquireResult, dataDir}) {
+            const outcomes = [];
+            const service  = Neo.create(MaintenanceBackpressureService, {
+                heavyMaintenanceTaskNames: DEFAULT_HEAVY_MAINTENANCE_TASK_NAMES,
+                writeLog                 : () => {},
+                dataDir                  : dataDir ?? null,
+                healthService            : {recordTaskOutcome: (name, status, payload) => outcomes.push({name, status, payload})},
+                taskStateService         : {
+                    getTaskState: name => taskState[name] ?? null,
+                    markDeferred: name => taskState[name]?.deferralStreakStartedAt ?? null
+                },
+                acquireLeaseFn: () => acquireResult,
+                releaseLeaseFn: () => {}
+            });
+
+            service.resolveHeavyMaintenanceLeasePath = () => leasePath;
+            return {service, outcomes};
+        }
+
+        test('an acquirer yields to a registered starving waiter and records the deferral', () => {
+            const leasePath = tmpLeasePath();
+
+            registerWaiterSync({leasePath, taskName: 'tenant-repo-sync', deferredSince: iso(Date.now() - 2 * HOUR), now: Date.now()});
+
+            const {service, outcomes} = buildService({leasePath, acquireResult: {acquired: true, lease: {token: 't1'}}});
+            const executed            = [];
+
+            const result = service.acquireLeaseAndExecute({
+                taskName       : 'dream',
+                executeFn      : name => { executed.push(name); return true; },
+                reason         : 'scheduled',
+                activeHeavyTask: {name: null}
+            });
+
+            expect(result).toBe(false);
+            expect(executed).toEqual([]);
+            expect(outcomes.some(o => o.payload?.reasonCode === 'heavy-maintenance-yield-to-waiter' && o.payload?.blockingTaskName === 'tenant-repo-sync')).toBe(true);
+            service.destroy()
+        });
+
+        test('the starving waiter itself acquires, runs, and its ledger entry clears', () => {
+            const leasePath = tmpLeasePath();
+            const since     = iso(Date.now() - 2 * HOUR);
+
+            registerWaiterSync({leasePath, taskName: 'tenant-repo-sync', deferredSince: since, now: Date.now()});
+
+            const {service} = buildService({
+                leasePath,
+                taskState    : {'tenant-repo-sync': {deferralStreakStartedAt: since}},
+                acquireResult: {acquired: true, lease: {token: 't2'}}
+            });
+            const executed = [];
+
+            const result = service.acquireLeaseAndExecute({
+                taskName       : 'tenant-repo-sync',
+                executeFn      : name => { executed.push(name); return true; },
+                reason         : 'scheduled',
+                activeHeavyTask: {name: null}
+            });
+
+            expect(result).toBe(true);
+            expect(executed).toEqual(['tenant-repo-sync']);
+
+            const {waiters} = listActiveWaitersSync({leasePath, staleAfterMs: WAITER_ENTRY_STALE_AFTER_MS, now: Date.now()});
+            expect(waiters).toHaveLength(0);
+            service.destroy()
+        });
+
+        test('a lease-held deferral with a measurable streak registers the waiter durably — carrying its bootstrap class', () => {
+            const leasePath = tmpLeasePath();
+            const since     = iso(Date.now() - HOUR);
+            const dataDir   = path.dirname(leasePath);
+
+            fs.writeFileSync(
+                path.join(dataDir, 'tenant-repo-sync-revisions.json'),
+                JSON.stringify({revisions: {'a/one': {lastIngestedRev: null}}})
+            );
+
+            const {service} = buildService({
+                leasePath,
+                dataDir,
+                taskState    : {'tenant-repo-sync': {deferralStreakStartedAt: since}},
+                acquireResult: {acquired: false, lease: {owner: 'dream', pid: 42}}
+            });
+
+            const result = service.acquireLeaseAndExecute({
+                taskName       : 'tenant-repo-sync',
+                executeFn      : () => true,
+                reason         : 'scheduled',
+                activeHeavyTask: {name: null}
+            });
+
+            expect(result).toBe(false);
+
+            const {waiters} = listActiveWaitersSync({leasePath, staleAfterMs: WAITER_ENTRY_STALE_AFTER_MS, now: Date.now()});
+            expect(waiters).toHaveLength(1);
+            expect(waiters[0]).toMatchObject({taskName: 'tenant-repo-sync', deferredSince: since, bootstrapCritical: true});
+            service.destroy()
+        })
+    })
+});

--- a/test/playwright/unit/ai/daemons/orchestrator/services/heavyMaintenanceWaiterLedger.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/heavyMaintenanceWaiterLedger.spec.mjs
@@ -199,7 +199,16 @@ test.describe('Neo.ai.daemons.orchestrator.services.heavyMaintenanceWaiterLedger
                 fs.writeFileSync(path.join(dataDir, 'tenant-repo-sync-revisions.json'), manifest);
             }
 
-            return Neo.create(MaintenanceBackpressureService, {dataDir, writeLog: () => {}});
+            return Neo.create(MaintenanceBackpressureService, {
+                dataDir,
+                writeLog: () => {},
+                // ALWAYS inject the resolver seam. `isBootstrapCriticalTask` kicks a lazy refresh,
+                // so a service built without this would run the real tiered resolver in the
+                // background — dynamically importing the tenant sync lane and touching its lease
+                // guard directories after the test returns, which races other specs' temp-dir
+                // teardown. Arms that care about resolution override this explicitly.
+                resolveConfiguredTenantRepoLabelsFn: async () => null
+            });
         }
 
         test('an uncheckpointed seeded repo makes tenant sync bootstrap-critical; full checkpoints end it', () => {
@@ -453,8 +462,12 @@ test.describe('Neo.ai.daemons.orchestrator.services.heavyMaintenanceWaiterLedger
                 heavyMaintenanceTaskNames: DEFAULT_HEAVY_MAINTENANCE_TASK_NAMES,
                 writeLog                 : () => {},
                 dataDir                  : dataDir ?? null,
-                healthService            : {recordTaskOutcome: (name, status, payload) => outcomes.push({name, status, payload})},
-                taskStateService         : {
+                // acquireLeaseAndExecute's fairness gate calls isBootstrapCriticalTask, which kicks
+                // the lazy coverage refresh — without this seam these arms would run the real tiered
+                // resolver in the background and touch the tenant sync lane's lease guards.
+                resolveConfiguredTenantRepoLabelsFn: async () => null,
+                healthService                      : {recordTaskOutcome: (name, status, payload) => outcomes.push({name, status, payload})},
+                taskStateService                   : {
                     getTaskState: name => taskState[name] ?? null,
                     markDeferred: name => taskState[name]?.deferralStreakStartedAt ?? null
                 },

--- a/test/playwright/unit/ai/daemons/orchestrator/services/heavyMaintenanceWaiterLedger.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/heavyMaintenanceWaiterLedger.spec.mjs
@@ -226,6 +226,94 @@ test.describe('Neo.ai.daemons.orchestrator.services.heavyMaintenanceWaiterLedger
             expect(corrupt.isBootstrapCriticalTask('tenant-repo-sync')).toBe(false);
             absent.destroy();
             corrupt.destroy()
+        });
+
+        // Configured coverage, not the manifest alone, decides the class. The manifest only records
+        // what the sync lane has already seen, so a manifest-only predicate reads "ordinary" in the
+        // three states below — including a first deployment, which is when the class matters most.
+        function serviceWithCoverage(manifest, labels) {
+            const service = serviceWithManifest(manifest);
+
+            // Seed the snapshot directly and stamp it fresh so the throttle suppresses a live
+            // resolver call; the refresh path itself is covered by its own arm below.
+            service.configuredTenantRepoLabels   = labels;
+            service.configuredTenantRepoLabelsAt = Date.now();
+
+            return service
+        }
+
+        test('first deployment — configured repos with no manifest at all is bootstrap-critical', () => {
+            const service = serviceWithCoverage(undefined, ['a/one', 'a/two']);
+
+            expect(service.isBootstrapCriticalTask('tenant-repo-sync')).toBe(true);
+            service.destroy()
+        });
+
+        test('a newly added repo absent from an existing manifest is bootstrap-critical', () => {
+            const service = serviceWithCoverage(
+                JSON.stringify({revisions: {'a/one': {lastIngestedRev: 'abc123'}}}),
+                ['a/one', 'a/two']
+            );
+
+            expect(service.isBootstrapCriticalTask('tenant-repo-sync')).toBe(true);
+            service.destroy()
+        });
+
+        test('a removed repo\'s stale null entry no longer grants priority', () => {
+            const service = serviceWithCoverage(
+                JSON.stringify({revisions: {
+                    'a/one' : {lastIngestedRev: 'abc123'},
+                    'a/gone': {lastIngestedRev: null}
+                }}),
+                ['a/one']
+            );
+
+            expect(service.isBootstrapCriticalTask('tenant-repo-sync')).toBe(false);
+            service.destroy()
+        });
+
+        test('an empty configured set is ordinary even with a stale null-bearing manifest', () => {
+            const service = serviceWithCoverage(
+                JSON.stringify({revisions: {'a/gone': {lastIngestedRev: null}}}),
+                []
+            );
+
+            expect(service.isBootstrapCriticalTask('tenant-repo-sync')).toBe(false);
+            service.destroy()
+        });
+
+        test('an unresolved snapshot falls back to the manifest-only predicate', () => {
+            const service = serviceWithManifest(JSON.stringify({revisions: {'a/two': {lastIngestedRev: null}}}));
+
+            expect(service.configuredTenantRepoLabels).toBeNull();
+            expect(service.isBootstrapCriticalTask('tenant-repo-sync')).toBe(true);
+            service.destroy()
+        });
+
+        test('the snapshot refresh populates labels from the canonical resolver seam', async () => {
+            const service = serviceWithManifest(JSON.stringify({revisions: {'a/one': {lastIngestedRev: 'abc123'}}}));
+
+            service.resolveConfiguredTenantRepoLabelsFn = async () => ['a/one', 'a/two'];
+            service.refreshConfiguredTenantRepoLabels();
+            await new Promise(resolve => setImmediate(resolve));
+
+            expect(service.configuredTenantRepoLabels).toEqual(['a/one', 'a/two']);
+            // 'a/two' is configured and uncheckpointed, so coverage now grants the class.
+            expect(service.isBootstrapCriticalTask('tenant-repo-sync')).toBe(true);
+            service.destroy()
+        });
+
+        test('a failing resolver keeps the previous snapshot instead of downgrading coverage', async () => {
+            const service = serviceWithCoverage(undefined, ['a/one']);
+
+            service.resolveConfiguredTenantRepoLabelsFn = async () => { throw new Error('resolver down') };
+            service.configuredTenantRepoLabelsAt        = 0;
+            service.refreshConfiguredTenantRepoLabels();
+            await new Promise(resolve => setImmediate(resolve));
+
+            expect(service.configuredTenantRepoLabels).toEqual(['a/one']);
+            expect(service.isBootstrapCriticalTask('tenant-repo-sync')).toBe(true);
+            service.destroy()
         })
     });
 

--- a/test/playwright/unit/ai/daemons/orchestrator/services/heavyMaintenanceWaiterLedger.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/heavyMaintenanceWaiterLedger.spec.mjs
@@ -139,6 +139,46 @@ test.describe('Neo.ai.daemons.orchestrator.services.heavyMaintenanceWaiterLedger
             expect(findWaiterToYieldTo({taskName: 'backup', priorityZero: true, waiters, fairnessYieldAfterMs: bound, now: T0})).toBeNull()
         });
 
+        // Mixed-rank negatives. The original matrix tested each `outranks*` arm in isolation and
+        // every arm was green, but the arms were ORed and then resolved by oldest-wins — so age
+        // could promote a LOWER-ranked waiter across the class boundary. Each case below fails
+        // against that shape and passes only when rank is evaluated strictly before age.
+        test('an ancient ORDINARY waiter never preempts a priority-0 acquirer — age must not cross rank', () => {
+            const waiters = [{taskName: 'summary', priorityZero: false, deferredSince: iso(T0 - 12 * HOUR)}];
+
+            expect(findWaiterToYieldTo({
+                taskName: 'backup', priorityZero: true,
+                waiters, fairnessYieldAfterMs: bound, now: T0
+            })).toBeNull()
+        });
+
+        test('an ancient ORDINARY waiter never preempts a bootstrap-critical acquirer', () => {
+            const waiters = [{taskName: 'summary', priorityZero: false, deferredSince: iso(T0 - 12 * HOUR)}];
+
+            expect(findWaiterToYieldTo({
+                taskName: 'tenant-repo-sync', bootstrapCritical: true,
+                waiters, fairnessYieldAfterMs: bound, now: T0
+            })).toBeNull()
+        });
+
+        test('a YOUNGER priority-0 waiter outranks an older ordinary one — rank first, age only within rank', () => {
+            const waiters = [
+                {taskName: 'summary', priorityZero: false, deferredSince: iso(T0 - 6 * HOUR)},
+                {taskName: 'backup',  priorityZero: true,  deferredSince: iso(T0 - 30_000)}
+            ];
+
+            expect(findWaiterToYieldTo({taskName: 'dream', waiters, fairnessYieldAfterMs: bound, now: T0})?.taskName).toBe('backup')
+        });
+
+        test('age still breaks ties WITHIN a rank — oldest of two qualifying priority-0 waiters wins', () => {
+            const waiters = [
+                {taskName: 'backup',       priorityZero: true, deferredSince: iso(T0 - 60_000)},
+                {taskName: 'other-backup', priorityZero: true, deferredSince: iso(T0 - 5 * HOUR)}
+            ];
+
+            expect(findWaiterToYieldTo({taskName: 'dream', waiters, fairnessYieldAfterMs: bound, now: T0})?.taskName).toBe('other-backup')
+        });
+
         test('bootstrap-critical acquirer vs bootstrap-critical waiter falls through to the age rule', () => {
             const waiters = [{taskName: 'other-bootstrap', bootstrapCritical: true, deferredSince: iso(T0 - 60_000)}];
 


### PR DESCRIPTION
## Summary

Resolves #16561. Together with the merged measurement slice (durable `deferralStreakStartedAt`), this delivers the ticket's remaining fix-shape scope — item 1, the fairness half. The other two items are formally owned elsewhere and are **not** claimed here:

- item 2 (health-surface starvation degrade) → #17049, split so its config leaf ships with its consumer.
- item 3 (global-lease-wrapped CLI entry) → **PR #17052 / #17047 (@neo-gpt-emmy)**, merged. Ceded in commit `29cb94df09` after `git merge-tree` confirmed both branches rewrote the same dispatch block; Emmy's implementation uses the canonical `withHeavyMaintenanceLease` and enrolls the script in the shared lease-adoption census.

The global heavy-maintenance lease records who HOLDS but nothing records who WAITS — so on a contended plane, a short-cadence holder (REM/dream re-acquiring cycle after cycle) structurally out-competes bootstrap tenant ingestion for hours while every health surface reads green. This is the exact production shape on the affected cloud plane: 3 of 4 tenant repos have no durable checkpoint after hours of continuous enrichment work (falsifier matrix + source correction by @neo-gpt-emmy: https://github.com/neomjs/neo/issues/16561#issuecomment-5279883557).

## The mechanism, in three moves

**1. Durable waiter ledger** (`heavyMaintenanceWaiterLedger.mjs`, Neo-free): every lease/backpressure deferral with a measurable streak upserts one self-owned entry file (`heavy-maintenance-waiters/<task>.json`) beside the lease — writers never contend, readers only glob, silent entries expire in 10 minutes (a dead process cannot veto acquisitions).

**2. Rank at SELECTION, not only at admission.** This is the load-bearing correction from review cycle 1. `runSchedulingPipeline` picks exactly one candidate per poll and dispatches it, so a fairness gate that lives only in `acquireLeaseAndExecute` can make the picked winner *abstain* but can never promote the starved task — it spends the poll, the waiter entry expires, and the original ordering returns. The rank therefore lives in `selectByPriority`, between priority-0 and staleness, so the bootstrap lane is actually **executed**. The oracle is bound through `buildOrchestratorSchedulingOptions` → `policyContext.isBootstrapCriticalTask` and fails open to staleness ordering when absent or throwing. Admission-side fairness is retained as the second line of defence for a peer registered mid-poll, and `findWaiterToYieldTo` now enforces **rank strictly before age**: a higher-ranked waiter wins with no starvation bound, a same-ranked one must still starve past `fairnessYieldAfterMs` *and* out-age the acquirer, and a lower-ranked one never wins. Age breaks ties only within an admissible rank.

**3. Bootstrap-critical is derived from CURRENT CONFIGURED COVERAGE.** The revisions manifest only records what the sync lane has already *seen*, so a manifest-only predicate is wrong in three states: a first deployment has no manifest at all — exactly when the class matters most; a newly added repo is absent from an existing manifest until the next sweep seeds it; and a removed repo's stale null entry would grant priority forever. So a configured `<tenantId>/<repoSlug>` label with no checkpoint — absent from the manifest **or** carrying a null `lastIngestedRev` — makes the lane bootstrap-critical; manifest entries whose label is no longer configured are ignored; an empty configured set is ordinary.

Because the predicate runs synchronously inside the picker while configured-repo truth is async (`resolveTenantReposConfig` → `listConfiguredTenantRepos`, tiered graph node > `kb-config.yaml` bootstrap > config default), the label set is a snapshot behind an injectable seam with a 60s TTL. Reading a config leaf directly would be simpler and wrong — that direct read is what the tiered resolver replaced so the graph/bootstrap tiers are honoured. At TTL expiry, the synchronous predicate starts the canonical refresh and fails safe for that current decision while the last-known array is stale; once the refresh settles, fresh coverage controls the next decision.

**`Orchestrator.start()` resolves that coverage before the first sweep**, through a prewarm that is both gated and bounded (review cycles 2–3). A fire-and-forget kick would leave the very first scheduling decision on a fresh deployment running against unresolved coverage, ranking the bootstrap lane ordinary and handing the heavy lease to a more-stale REM cycle for its full duration. But the prewarm needs two boundaries to sit safely on the boot path: it runs **only for the profile that owns and enables `tenant-repo-sync`**, because the canonical resolver awaits `graphService.ready()` and an ungated prewarm would pull host-edge and graphless profiles into container-plane configuration authority they do not hold; and it races a **deadline**, because `ensureConfiguredTenantRepoLabels()` contains rejection but is not a timeout — a resolver that never settles would otherwise leave `start()` pending forever and the daemon would never poll. On expiry boot proceeds, and the unresolved fail-safe posture covers the gap: an unresolved snapshot with no manifest at all ranks bootstrap rather than ordinary, because an absent manifest cannot prove a plane is initialized. A slow resolver therefore costs ranking precision, never the decision.

Mapping onto the ticket's falsifier matrix:

| Falsifier | Mechanism | Proof |
|---|---|---|
| due bootstrap sync + due REM → sync wins | bootstrap rank applied at selection | spec: first scheduling decision after boot ranks tenant sync over more-stale REM, with a control proving staleness alone favours REM |
| REM releases with registered bootstrap waiter → waiter acquires before REM reacquires | picker dispatches the bootstrap lane; admission gate covers the mid-poll residue | spec: pipeline composition witness + integration arms |
| all checkpoints complete → no permanent priority | coverage predicate re-reads per decision | spec: complete-coverage control returns dream |
| repo not-due/backoff/refused → REM may proceed after the admitted tenant sweep settles | per-repo eligibility is evaluated inside `runTask`, not by waiter expiry; the bounded outcome returns through the normal lease release/clear path | `TenantRepoSyncService` not-due/backoff/refusal arms + `acquireLeaseAndExecute` release/clear integration; no waiter-TTL claim |

## Deltas

- `ai/daemons/orchestrator/scheduling/picker.mjs`: bootstrap-critical stage in `selectByPriority` between priority-0 and staleness; fail-open on an absent or throwing oracle.
- `ai/daemons/orchestrator/scheduling/pipeline.mjs`: binds `isBootstrapCriticalTask` into `policyContext`.
- `ai/daemons/orchestrator/Orchestrator.mjs`: `prewarmConfiguredTenantRepoCoverage()` resolves configured coverage before the first `poll()`, gated to the profile that owns and enables `tenant-repo-sync` (the canonical resolver awaits `graphService.ready()`, so an ungated prewarm would pull host-edge and graphless profiles into container-plane configuration authority) and bounded by a deadline so a never-settling resolver cannot stop the daemon polling.
- `ai/daemons/orchestrator/services/heavyMaintenanceWaiterLedger.mjs` (new): `registerWaiterSync` (atomic via `writeFileAtomicSync`), `clearWaiterSync`, `listActiveWaitersSync` (corrupt entries reported, never thrown), `findWaiterToYieldTo` (explicit `fairnessRank()` 2/1/0, rank strictly before age, self-exempt, oldest-wins within rank, unparseable `deferredSince` skipped).
- `ai/daemons/orchestrator/services/MaintenanceBackpressureService.mjs`: deferral path registers waiters (contention reason codes only); admission fairness gate; proceed path clears the entry; `isPriorityZeroTask` (spec-drift-guarded mirror) + `isBootstrapCriticalTask` (configured-coverage predicate); `ensureConfiguredTenantRepoLabels()` awaitable single-flight snapshot + lazy TTL refresh whose pending state fails safe for the current picker decision; the ledger's `unreadable` entries are consumed and WARN-logged rather than discarded; the source comment claiming manual/container CLIs inherit this gate is corrected — they acquire the global lease directly and do not pass through this service.
- `ai/configBase.mjs`: `heavyMaintenanceLease.fairnessYieldAfterMs` leaf (`NEO_HEAVY_MAINTENANCE_LEASE_FAIRNESS_YIELD_MS`, default 30 min) + parity snapshot in the same commit.

## Test Evidence

```
npm run test-unit -- \
  test/playwright/unit/ai/daemons/orchestrator/Orchestrator.spec.mjs \
  test/playwright/unit/ai/daemons/orchestrator/scheduling/picker.spec.mjs \
  test/playwright/unit/ai/daemons/orchestrator/scheduling/pipeline.spec.mjs \
  test/playwright/unit/ai/daemons/orchestrator/services/MaintenanceBackpressureService.spec.mjs \
  test/playwright/unit/ai/daemons/orchestrator/services/heavyMaintenanceWaiterLedger.spec.mjs \
  test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncService.spec.mjs \
  --project=unit-brain --workers=1 --retries=0
```

**341/341** at the exact head (runner total includes the Chroma setup/teardown pair).

- `heavyMaintenanceWaiterLedger.spec.mjs`: 37 declared `test(...)` arms — ledger roundtrip/refresh/expiry/corruption; the fairness matrix including four mixed-rank negatives (an ancient ordinary waiter never preempts priority-0 or bootstrap; a younger priority-0 outranks an older ordinary; age still breaks ties within a rank); the configured-coverage predicate (first deployment, newly-added repo, removed repo, empty set, corrupt manifest, unresolved fail-safe); snapshot mechanics (awaitable single-flight, resolver-failure retention, and stale-old-coverage refresh failing safe before the first pick); the **boot composition** — with a real service, a real async resolver, an absent manifest and a more-stale REM competitor, tenant sync must win the first scheduling decision, and a complete-coverage control returns dream; and 3 integration arms through `acquireLeaseAndExecute`.
- `pipeline.spec.mjs`: composition witness that the ranked lane is **dispatched** rather than merely deferred-to, with a control proving staleness alone favours REM and a fail-open arm for a throwing oracle.
- `picker.spec.mjs`, `MaintenanceBackpressureService.spec.mjs`, `Orchestrator.spec.mjs`, `TenantRepoSyncService.spec.mjs`: importer and regression coverage.
- Gates: `check-atomic-write-shape` 0 hand-rolled pairs; `check-ticket-archaeology`, `check-block-alignment`, config-template parity green via pre-commit.

Evidence: L2 (deterministic in-process scheduling, rank, and coverage contracts) → L2 required (all close-target ACs are internal code contracts). Residual: none for the close target.

## Post-Merge Validation

On the affected plane after the next image bump: with REM active and repos 2–4 uncheckpointed, the orchestrator log must show `heavy-maintenance-yield-to-waiter` deferrals on `dream` and a `tenant-repo-sync` acquisition within one REM release; once all four repos hold checkpoints, `isBootstrapCriticalTask` must read false (no permanent tenant priority). The CLI-side admission check moved with item 3 and is validated by the merged #17052.

Residual-Owner: @neo-opus-vega (#17049 — health-surface starvation degrade, the split follow-up slice)

Authored by Vega (Claude Code). Commits `3b51b6d1a0` / `d1ace5af68` under Claude Fable 5, session 37509548-6568-47fe-9e6c-2aabd27c2b11; commits `29cb94df09` / `6bf10af885` / `3f4bba1d81` and the cycle-2 boot-composition repair under Claude Opus 5, session bca898f2-667e-4ce7-9310-d35ad269632e.

