### PR TITLE
fix(ai): serialize LM Studio readiness hooks (#17051)

### DIFF
--- a/ai/daemons/orchestrator/services/ProcessSupervisorService.mjs
+++ b/ai/daemons/orchestrator/services/ProcessSupervisorService.mjs
@@ -1087,7 +1087,7 @@ export class ProcessSupervisorService extends Base {
             .then(up => {
                 if (up) {
                     this._livenessConfirmedAt[taskName] = Date.now();
-                    this.runLivenessReadinessHook(taskName, task, 'liveness-confirmed', () => this.runTask(taskName, 'supervisor-restart'));
+                    return this.runLivenessReadinessHook(taskName, task, 'liveness-confirmed', () => this.runTask(taskName, 'supervisor-restart'));
                 } else {
                     this.clearReadinessSuccessLogState(taskName, 'liveness');
                     this.runTask(taskName, 'supervisor-restart');

--- a/test/playwright/unit/ai/daemons/orchestrator/services/ProcessSupervisorService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/ProcessSupervisorService.spec.mjs
@@ -1007,6 +1007,59 @@ test.describe('Neo.ai.daemons.services.ProcessSupervisorService', () => {
         }));
     });
 
+    test('#17051: liveness admission remains held until deferred readiness settles', async () => {
+        const {service} = createTestService();
+        const calls     = [];
+        const cooldown  = 15000;
+        let   rejectReadiness;
+        let livenessCalls  = 0;
+        let readinessCalls = 0;
+
+        service.runTask = (taskName, reason) => { calls.push({taskName, reason}); return true; };
+        service.taskStateService.getTaskState = () => ({running: false, lastRunAt: 0});
+        service.taskDefinitions = {
+            probeTask: {
+                label        : 'Probe Task',
+                livenessProbe: async () => { livenessCalls++; return true; },
+                postSpawn    : async () => {
+                    readinessCalls++;
+
+                    if (readinessCalls === 1) {
+                        return new Promise((resolve, reject) => { rejectReadiness = reject; });
+                    }
+
+                    return {ready: true};
+                }
+            }
+        };
+
+        const firstPollAt = Date.now();
+
+        service.superviseTask('probeTask', firstPollAt, cooldown);
+        await new Promise(resolve => setTimeout(resolve, 0));
+
+        expect(service._livenessProbeInFlight.probeTask).toBe(true);
+        expect({livenessCalls, readinessCalls}).toEqual({livenessCalls: 1, readinessCalls: 1});
+
+        service.superviseTask('probeTask', firstPollAt + cooldown + 1, cooldown);
+        await new Promise(resolve => setTimeout(resolve, 0));
+
+        expect({livenessCalls, readinessCalls}).toEqual({livenessCalls: 1, readinessCalls: 1});
+
+        rejectReadiness(new Error('readiness failed'));
+        await new Promise(resolve => setTimeout(resolve, 0));
+
+        expect(service._livenessProbeInFlight.probeTask).toBe(false);
+        expect(calls).toEqual([{taskName: 'probeTask', reason: 'supervisor-restart'}]);
+
+        service.superviseTask('probeTask', Date.now() + cooldown + 1, cooldown);
+        await new Promise(resolve => setTimeout(resolve, 0));
+        await new Promise(resolve => setTimeout(resolve, 0));
+
+        expect({livenessCalls, readinessCalls}).toEqual({livenessCalls: 2, readinessCalls: 2});
+        expect(service._livenessProbeInFlight.probeTask).toBe(false);
+    });
+
     test('superviseTask gates a fire-and-exit lane on its liveness probe — DOWN triggers a restart', async () => {
         const {service} = createTestService();
         const calls     = [];


### PR DESCRIPTION
Resolves neomjs/neo#17051

The LM Studio liveness supervisor now keeps its existing per-task admission latch held until the model-readiness hook settles. A later poll can no longer overlap chat and embedding load/unload repair with an earlier hook.

Related: neomjs/neo-agent-brain#131, neomjs/neo#13948

Evidence: L2 (exact source reach, live host-edge timeline, process ancestry, and deterministic deferred-readiness unit witness) → L3 required. Residual: the merged revision must be deployed to the local Agent OS and show both configured roles resident with zero supervisor-driven unload churn across repeated requests.

## Deltas from ticket

- Added one `return` at the existing Promise boundary; no new service, scheduler, config leaf, provider abstraction, or readiness actuator.
- Added one deferred-hook regression test that crosses the cooldown, rejects the first readiness hook, and proves both no overlap and later recovery.
- Falsified the adjacent cross-lane-classifier hypothesis before widening scope: `TextEmbeddingService` does not call the mutating LMS readiness helper; superseded-model cleanup only matches the same model id plus a numeric suffix; and the supervisor preload set already contains both configured roles.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/ai/daemons/orchestrator/services/ProcessSupervisorService.spec.mjs --project=unit-brain --workers=1 --retries=0` — 57 passed after rebasing onto current `dev`.
- Pre-commit alignment, parsing, JSDoc, AiConfig-mutation, ticket-archaeology, atomic-write, shorthand, and whitespace gates — passed.
- `git diff origin/dev...HEAD --check` — passed.

## Post-Merge Validation

Deploy the merged Neo revision to the local Agent OS, then retain both configured LM Studio roles across repeated chat and embedding requests for at least two supervisor cooldowns. Require zero new `lms unload` operations, no canceled model loads, and normal embedding latency after initial convergence. This validation is local-only; it does not claim to repair the separate split-provider deployment incident.

Authored by Emmy (GPT-5.6 Sol Ultra, Codex). Session 019fe0b3-53bc-7ef2-8665-41a0ef3f7b62.
