### PR TITLE
fix(ai): serialize LM Studio residency mutations (#17054)

### DIFF
--- a/ai/services/graph/providerReadinessHelper.mjs
+++ b/ai/services/graph/providerReadinessHelper.mjs
@@ -20,7 +20,8 @@ import {
     observeUnqueuedProviderActivity
 } from '../shared/providerActivityLedger.mjs';
 
-let openAiCompatibleEmbeddingServingProbeQueue = Promise.resolve();
+let openAiCompatibleEmbeddingServingProbeQueue = Promise.resolve(),
+    lmsResidencyMutationQueue                  = Promise.resolve();
 
 const
     providerDiscoveryCache         = new Map(),
@@ -1323,6 +1324,11 @@ export function getInsufficientLmsLoadedModels({
  * endpoint enumerates both. Parameters come from config-owned callers so the helper
  * has no hidden retry or timeout defaults.
  *
+ * Every call runs behind one process-wide FIFO so the supervisor readiness hook and recovery
+ * actuator cannot overlap destructive `lms unload` / `lms load` sequences. Calls are serialized,
+ * never coalesced: each queued caller re-probes with its own role set, shape requirements, and
+ * authority oracle after its predecessor settles.
+ *
  * Per-model context-length overrides flow through the optional `contextLengths`
  * map (`{[modelId]: tokens}`). When present, the helper invokes
  * `lms load <model> --context-length <N>` for that model so the loaded context
@@ -1351,7 +1357,22 @@ export function getInsufficientLmsLoadedModels({
  * @param {Object} [options.log=logger] Logger seam.
  * @returns {Promise<Object>}
  */
-export async function ensureLmsModelsLoaded({
+export function ensureLmsModelsLoaded(options = {}) {
+    const queuedRepair = lmsResidencyMutationQueue
+        .catch(() => {})
+        .then(() => ensureLmsModelsLoadedOnce(options));
+
+    lmsResidencyMutationQueue = queuedRepair.catch(() => {});
+
+    return queuedRepair;
+}
+
+/**
+ * @summary Executes one LMS residency repair after the process-wide mutation queue admits it.
+ * @param {Object} options Validated by the repair body.
+ * @returns {Promise<Object>}
+ */
+async function ensureLmsModelsLoadedOnce({
     host,
     models,
     attempts,

--- a/test/playwright/unit/ai/services/graph/providerReadinessHelper.spec.mjs
+++ b/test/playwright/unit/ai/services/graph/providerReadinessHelper.spec.mjs
@@ -133,6 +133,126 @@ test.describe('lmsExecOptions — embedding-readiness PATH fix', () => {
     });
 });
 
+test.describe('LM Studio residency mutation queue (#17054)', () => {
+    let ensureLmsModelsLoaded;
+
+    test.beforeAll(async () => {
+        ({ensureLmsModelsLoaded} = await import('../../../../../../ai/services/graph/providerReadinessHelper.mjs'));
+    });
+
+    test('serializes concurrent repairs without coalescing their role sets', async () => {
+        let releaseFirst, signalFirstStarted, activeLoads = 0, maxActiveLoads = 0;
+        const events       = [],
+              firstGate    = new Promise(resolve => { releaseFirst = resolve; }),
+              firstStarted = new Promise(resolve => { signalFirstStarted = resolve; }),
+              createRepair = (model, waitForRelease = false) => {
+                  let loaded = false;
+
+                  return ensureLmsModelsLoaded({
+                      host         : 'http://127.0.0.1:1234',
+                      models       : [model],
+                      attempts     : 1,
+                      delayMs      : 0,
+                      timeoutMs    : 10,
+                      fetchModelIds: async () => {
+                          events.push(`discover:${model}`);
+                          return loaded ? [model] : [];
+                      },
+                      async loadModel() {
+                          events.push(`load:${model}`);
+                          activeLoads += 1;
+                          maxActiveLoads = Math.max(maxActiveLoads, activeLoads);
+
+                          if (waitForRelease) {
+                              signalFirstStarted();
+                              await firstGate;
+                          }
+
+                          loaded = true;
+                          activeLoads -= 1;
+                      },
+                      unloadModel: async () => {},
+                      log        : {info() {}, warn() {}}
+                  });
+              },
+              first = createRepair('chat-model', true);
+
+        await firstStarted;
+
+        const second = createRepair('embedding-model');
+
+        await Promise.resolve();
+        expect(events).toEqual(['discover:chat-model', 'load:chat-model']);
+
+        releaseFirst();
+
+        const [firstResult, secondResult] = await Promise.all([first, second]);
+
+        expect(maxActiveLoads).toBe(1);
+        expect(firstResult.requiredModels).toEqual(['chat-model']);
+        expect(secondResult.requiredModels).toEqual(['embedding-model']);
+        expect(events).toEqual([
+            'discover:chat-model',
+            'load:chat-model',
+            'discover:chat-model',
+            'discover:embedding-model',
+            'load:embedding-model',
+            'discover:embedding-model'
+        ]);
+    });
+
+    test('releases a rejected predecessor and rechecks queued caller authority', async () => {
+        let rejectFirst, signalFirstStarted, authorityHeld = true, secondDiscoveries = 0, secondLoads = 0;
+        const firstGate    = new Promise((resolve, reject) => { rejectFirst = reject; }),
+              firstStarted = new Promise(resolve => { signalFirstStarted = resolve; }),
+              first        = ensureLmsModelsLoaded({
+                  host         : 'http://127.0.0.1:1234',
+                  models       : ['chat-model'],
+                  attempts     : 1,
+                  delayMs      : 0,
+                  timeoutMs    : 10,
+                  fetchModelIds: async () => [],
+                  async loadModel() {
+                      signalFirstStarted();
+                      await firstGate;
+                  },
+                  unloadModel: async () => {},
+                  log        : {info() {}, warn() {}}
+              });
+
+        await firstStarted;
+
+        const second = ensureLmsModelsLoaded({
+            host         : 'http://127.0.0.1:1234',
+            models       : ['embedding-model'],
+            attempts     : 1,
+            delayMs      : 0,
+            timeoutMs    : 10,
+            fetchModelIds: async () => {
+                secondDiscoveries += 1;
+                return [];
+            },
+            async loadModel() {
+                secondLoads += 1;
+            },
+            unloadModel    : async () => {},
+            isAuthorityHeld: () => authorityHeld,
+            log            : {info() {}, warn() {}}
+        });
+
+        authorityHeld = false;
+        await Promise.resolve();
+        expect(secondDiscoveries).toBe(0);
+
+        rejectFirst(new Error('first repair failed'));
+
+        await expect(first).rejects.toThrow('first repair failed');
+        await expect(second).rejects.toMatchObject({reason: 'runtime-authority-lost'});
+        expect(secondDiscoveries).toBe(1);
+        expect(secondLoads).toBe(0);
+    });
+});
+
 test.describe('provider residency helpers — production mutation authority fences (#16837)', () => {
     let ensureLmsModelsLoaded, ensureOllamaModelsReady;
 


### PR DESCRIPTION
Resolves neomjs/neo#17054
Related: neomjs/neo-agent-brain#131

LM Studio residency repair now has one process-wide FIFO at the destructive helper boundary. Supervisor readiness and recovery-actuator callers retain their own role sets, collaborators, authority checks, results, and errors, but their discovery and unload/load lifecycles can no longer overlap.

Evidence: L2 (deterministic concurrent-call and caller-regression unit evidence) → L2 required (all close-target ACs are in-process serialization, authority, and compatibility contracts). No close-target residuals.

## Deltas from ticket

None substantive. The implementation uses the ticket's existing Promise-tail sibling pattern and adds no service, daemon, config leaf, or durable lock.

## Test Evidence

- Red control before the production change: the two new queue specs failed because the second caller entered discovery while the first repair was still active.
- `npm run test-unit -- test/playwright/unit/ai/services/graph/providerReadinessHelper.spec.mjs test/playwright/unit/ai/daemons/orchestrator/services/ProcessSupervisorService.spec.mjs test/playwright/unit/ai/scripts/runners/runSandman.spec.mjs --workers=1 --retries=0` — 145/145 passed.
- `npm run agent-preflight -- --change-class restoration --commit-subject "fix(ai): serialize LM Studio residency mutations (#17054)" ai/services/graph/providerReadinessHelper.mjs test/playwright/unit/ai/services/graph/providerReadinessHelper.spec.mjs` — passed; unrelated stale-overlay warnings only.
- Directly touched surface, LM Studio residency mutation helper: concurrent FIFO, rejection recovery, and moved-authority refusal covered by `providerReadinessHelper.spec.mjs`.
- Existing callers: supervisor and Sandman/provider-readiness suites passed unchanged.

## Post-Merge Validation

No post-merge step is required to satisfy the close target. Live Agent OS convergence after a cumulative `dev` deployment remains parent-series evidence under `#14154`.

Authored by Emmy (GPT-5.6 Sol Ultra, Codex). Session 019fe0b3-53bc-7ef2-8665-41a0ef3f7b62.
