### PR TITLE
fix(memory-core): bound wake GraphLog drains (#16677)

### DIFF
--- a/ai/graph/storage/Base.mjs
+++ b/ai/graph/storage/Base.mjs
@@ -77,9 +77,12 @@ class Base extends NeoBase {
      * Evaluates Database Logs verifying structurally exactly which remote Application Workers modified Graph limits.
      * @see Neo.ai.graph.Database#syncCache
      * @param {Number} sinceId
-     * @returns {Object} { lastLogId, invalidNodes, invalidEdges, events }
+     * @param {Object} [options]
+     * @param {Number|null} [options.limit=null] Maximum raw GraphLog rows to materialize.
+     * @param {Number|null} [options.untilId=null] Inclusive upper log-id boundary for a frozen page sequence.
+     * @returns {Object} { lastLogId, invalidNodes, invalidEdges, events, entityLogIds, hasMore }
      */
-    getDeltaLog(sinceId) {}
+    getDeltaLog(sinceId, options) {}
 
     /**
      * @summary Appends one immutable typed GraphLog event.

--- a/ai/graph/storage/SQLite.mjs
+++ b/ai/graph/storage/SQLite.mjs
@@ -654,23 +654,72 @@ class SQLite extends Base {
      * Executes localized sequence polling isolating un-processed Native SQL edits securely resolving Cache Coherence natively cleanly.
      * Maps `AFTER UPDATE/INSERT/DELETE` trigger records stored in `GraphLog` locally comparing explicitly sequentially securely validating remote worker diffs internally perfectly accurately.
      * @see Neo.ai.graph.Database#syncCache
+     * The optional raw-row limit is applied by SQLite before result materialization. Consumers
+     * that need to remain schedulable under a large mutation wave can therefore page the journal
+     * without first allocating or walking the full tail. Existing callers retain the historical
+     * unbounded behavior by omitting `options.limit`.
+     *
      * @param {Number} sinceId
-     * @returns {Object} { lastLogId, invalidNodes, invalidEdges, events }
+     * @param {Object} [options]
+     * @param {Number|null} [options.limit=null] Positive maximum raw GraphLog rows to materialize.
+     * @param {Number|null} [options.untilId=null] Inclusive upper log-id boundary for a frozen page sequence.
+     * @returns {Object} { lastLogId, invalidNodes, invalidEdges, events, entityLogIds, hasMore }
      */
-    getDeltaLog(sinceId = 0) {
-        if (!this.db) return {lastLogId: sinceId, invalidNodes: [], invalidEdges: [], events: []};
+    getDeltaLog(sinceId = 0, {limit = null, untilId = null} = {}) {
+        const isBounded     = limit !== null && limit !== undefined;
+        const hasUpperBound = untilId !== null && untilId !== undefined;
+
+        if (isBounded && (!Number.isInteger(limit) || limit <= 0)) {
+            throw new TypeError('GraphLog delta limit must be a positive integer.');
+        }
+        if (hasUpperBound && (!Number.isInteger(untilId) || untilId < 0)) {
+            throw new TypeError('GraphLog delta upper bound must be a non-negative integer.');
+        }
+
+        if (!this.db) return {
+            lastLogId: sinceId, invalidNodes: [], invalidEdges: [], events: [], entityLogIds: new Map(), hasMore: false
+        };
         if (!this.db.open) throw new Error('SQLite connection is closed (lifecycle violation).');
 
-        let logs            = this.db.prepare('SELECT log_id, entity_id, entity_type, event_id, event_payload FROM GraphLog WHERE log_id > ? ORDER BY log_id ASC').all(sinceId);
+        let query = `
+            SELECT log_id, entity_id, entity_type, event_id, event_payload
+            FROM GraphLog
+            WHERE log_id > ?
+        `;
+        const queryArgs = [sinceId];
+
+        if (hasUpperBound) {
+            query += ' AND log_id <= ?';
+            queryArgs.push(untilId);
+        }
+
+        query += ' ORDER BY log_id ASC';
+        if (isBounded) {
+            query += ' LIMIT ?';
+            queryArgs.push(limit + 1);
+        }
+
+        let logs = this.db.prepare(query).all(...queryArgs);
+
+        const hasMore = isBounded && logs.length > limit;
+        if (hasMore) logs = logs.slice(0, limit);
+
         let maxId           = sinceId;
         let invalidNodes    = new Set();
         let invalidEdgesMap = new Map();
         let events          = [];
+        let entityLogIds    = new Map();
 
         for (let trace of logs) {
             maxId = trace.log_id > maxId ? trace.log_id : maxId;
-            if (trace.entity_type === 'nodes') invalidNodes.add(trace.entity_id);
-            else if (trace.entity_type === 'edges') invalidEdgesMap.set(trace.entity_id, { id: trace.entity_id });
+            if (trace.entity_type === 'nodes') {
+                invalidNodes.add(trace.entity_id);
+                entityLogIds.set(trace.entity_id, trace.log_id);
+            }
+            else if (trace.entity_type === 'edges') {
+                invalidEdgesMap.set(trace.entity_id, {id: trace.entity_id, logId: trace.log_id});
+                entityLogIds.set(trace.entity_id, trace.log_id);
+            }
             else if (trace.event_id && trace.event_payload) events.push(trace);
         }
 
@@ -683,7 +732,7 @@ class SQLite extends Base {
                 let edgesQuery   = this.db.prepare(`SELECT id, source, target FROM Edges WHERE id IN (${placeholders})`);
                 let edgesData    = edgesQuery.all(...chunk);
                 for (let row of edgesData) {
-                    invalidEdgesMap.set(row.id, { id: row.id, source: row.source, target: row.target });
+                    invalidEdgesMap.set(row.id, {...invalidEdgesMap.get(row.id), source: row.source, target: row.target});
                 }
             }
         }
@@ -692,7 +741,9 @@ class SQLite extends Base {
             lastLogId   : maxId,
             invalidNodes: Array.from(invalidNodes),
             invalidEdges: Array.from(invalidEdgesMap.values()),
-            events
+            events,
+            entityLogIds,
+            hasMore
         };
     }
 

--- a/ai/services/memory-core/WakeSubscriptionService.mjs
+++ b/ai/services/memory-core/WakeSubscriptionService.mjs
@@ -326,6 +326,8 @@ class WakeSubscriptionService extends Base {
                 if (typeof storage.getLatestLogId === 'function' && storage.getLatestLogId() > this.liveCursor) {
                     this._pumpRequested = true;
                 }
+
+                if (this._pumpRequested) await this._yieldPumpTurn();
             } while (this._pumpRequested);
         } catch (e) {
             logger.error('[WakeSubscription] Background pump failed:', e);
@@ -335,8 +337,8 @@ class WakeSubscriptionService extends Base {
     }
 
     /**
-     * @summary Yields between bounded GraphLog pages so MCP transport, health timers, and WAL
-     * acceptance work can run while a large wake backlog drains.
+     * @summary Yields between bounded GraphLog work units so MCP transport, health timers, and WAL
+     * acceptance work can run between pages and before a coalesced tail drain re-enters.
      * @returns {Promise<void>}
      * @protected
      */

--- a/ai/services/memory-core/WakeSubscriptionService.mjs
+++ b/ai/services/memory-core/WakeSubscriptionService.mjs
@@ -219,12 +219,30 @@ class WakeSubscriptionService extends Base {
     _pumping = false
 
     /**
+     * @member {Boolean} _pumpRequested=false
+     * A trigger arriving during a drain is folded into the active single-flight. The active drain
+     * rechecks the tail after its current page sequence instead of silently discarding the trigger.
+     * @protected
+     */
+    _pumpRequested = false
+
+    /**
+     * @member {Number} pumpBatchSize=512
+     * Maximum raw GraphLog rows materialized and evaluated in one event-loop turn. This is an
+     * internal liveness boundary rather than deployment policy: every page is eventually consumed,
+     * and changing it does not alter delivery eligibility.
+     * @protected
+     */
+    pumpBatchSize = 512
+
+    /**
      * Evaluates recent GraphLog deltas and pushes matching events to active Shape A
      * (MCP notification) and Shape B (signed webhook) routes. Intended to be called by
      * mutation paths (e.g. MailboxService, PermissionService) for low-latency delivery.
      * @returns {Promise<void>}
      */
     async pump() {
+        this._pumpRequested = true;
         if (this._pumping) return;
 
         try {
@@ -235,54 +253,95 @@ class WakeSubscriptionService extends Base {
             const storage = db.storage;
             if (!storage?.getDeltaLog) return;
 
-            const delta       = storage.getDeltaLog(this.liveCursor);
-            const typedEvents = delta.events || [];
-            if (delta.invalidEdges.length === 0 && delta.invalidNodes.length === 0 && typedEvents.length === 0) {
-                this._setLiveCursor(delta.lastLogId);
-                return;
-            }
+            do {
+                this._pumpRequested = false;
 
-            // Live push needs every active Shape A/B subscription, not only routes that were
-            // touched through this process's lazy cache.
-            this._warmPushSubscriptions();
+                // Live push needs every active Shape A/B subscription, not only routes that were
+                // touched through this process's lazy cache. Re-warm for an explicitly coalesced
+                // trigger so a route added during a long catch-up joins the next tail check.
+                this._warmPushSubscriptions();
 
-            // Shared predicate, NOT `sub.status === 'active'`. This is the hot push path, and the cache
-            // is warmed from `_hydrateSubscriptionFromDurableNode`, which preserves an absent `status`
-            // as absent rather than synthesizing one. A strict compare here publishes a route into the
-            // manifest and then never dispatches through it — a live route that reads armed everywhere
-            // and delivers nothing, which is worse than either consistent answer.
-            const activeSubs = Array.from(this.subscriptionCache.values())
-                .filter(sub => ['mcp-notifications', 'a2a-webhook'].includes(sub.harnessTarget) && isActiveWakeSubscriptionStatus(sub.status));
+                // Shared predicate, NOT `sub.status === 'active'`. This is the hot push path, and the cache
+                // is warmed from `_hydrateSubscriptionFromDurableNode`, which preserves an absent `status`
+                // as absent rather than synthesizing one. A strict compare here publishes a route into the
+                // manifest and then never dispatches through it — a live route that reads armed everywhere
+                // and delivers nothing, which is worse than either consistent answer.
+                const activeSubs = Array.from(this.subscriptionCache.values())
+                    .filter(sub => ['mcp-notifications', 'a2a-webhook'].includes(sub.harnessTarget) && isActiveWakeSubscriptionStatus(sub.status));
 
-            if (activeSubs.length === 0) {
-                this._setLiveCursor(delta.lastLogId);
-                return;
-            }
+                const snapshotMaxLogId = typeof storage.getLatestLogId === 'function'
+                    ? storage.getLatestLogId()
+                    : null;
+                const evaluatedEntities = new Set();
+                let hasMore;
+                do {
+                    const delta = storage.getDeltaLog(this.liveCursor, {
+                        limit  : this.pumpBatchSize,
+                        untilId: snapshotMaxLogId
+                    });
+                    const typedEvents = delta.events || [];
+                    const pageMatches = [];
 
-            for (const sub of activeSubs) {
-                for (const edgeRef of delta.invalidEdges) {
-                    const logId   = this._getEntityLogId(edgeRef.id) || delta.lastLogId;
-                    const matched = this._evaluateEdgeAgainstSubscription(edgeRef, sub, logId);
-                    if (matched) CoalescingEngineService.enqueue(sub, matched);
+                    for (const sub of activeSubs) {
+                        for (const edgeRef of delta.invalidEdges) {
+                            const entityKey = `edge:${edgeRef.id}`;
+                            if (evaluatedEntities.has(entityKey)) continue;
+
+                            const logId   = edgeRef.logId || delta.entityLogIds?.get(edgeRef.id) || delta.lastLogId;
+                            const matched = this._evaluateEdgeAgainstSubscription(edgeRef, sub, logId);
+                            if (matched) pageMatches.push({sub, matched});
+                        }
+                        for (const nodeId of delta.invalidNodes) {
+                            const entityKey = `node:${nodeId}`;
+                            if (evaluatedEntities.has(entityKey)) continue;
+
+                            const logId   = delta.entityLogIds?.get(nodeId) || delta.lastLogId;
+                            const matched = this._evaluateNodeAgainstSubscription(nodeId, sub, logId);
+                            if (matched) pageMatches.push({sub, matched});
+                        }
+                        for (const trace of typedEvents) {
+                            const matched = this._evaluateTypedEventAgainstSubscription(trace, sub);
+                            if (matched) pageMatches.push({sub, matched});
+                        }
+                    }
+
+                    for (const edgeRef of delta.invalidEdges) evaluatedEntities.add(`edge:${edgeRef.id}`);
+                    for (const nodeId of delta.invalidNodes) evaluatedEntities.add(`node:${nodeId}`);
+
+                    // Evaluate the full page before dispatching any match. An evaluator failure
+                    // therefore leaves the page both cursor-replayable and delivery-replayable,
+                    // rather than leaking a partial raw-MCP page before retry.
+                    for (const {sub, matched} of pageMatches) {
+                        CoalescingEngineService.enqueue(sub, matched);
+                    }
+
+                    // Cursor advancement is page-atomic for evaluation: an exception above leaves
+                    // this page replayable instead of skipping work that was never evaluated.
+                    this._setLiveCursor(delta.lastLogId);
+                    hasMore = delta.hasMore;
+
+                    if (hasMore) await this._yieldPumpTurn();
+                } while (hasMore);
+
+                if (typeof storage.getLatestLogId === 'function' && storage.getLatestLogId() > this.liveCursor) {
+                    this._pumpRequested = true;
                 }
-                for (const nodeId of delta.invalidNodes) {
-                    const logId   = this._getEntityLogId(nodeId) || delta.lastLogId;
-                    const matched = this._evaluateNodeAgainstSubscription(nodeId, sub, logId);
-                    if (matched) CoalescingEngineService.enqueue(sub, matched);
-                }
-                for (const trace of typedEvents) {
-                    const matched = this._evaluateTypedEventAgainstSubscription(trace, sub);
-                    if (matched) CoalescingEngineService.enqueue(sub, matched);
-                }
-            }
-
-
-            this._setLiveCursor(delta.lastLogId);
+            } while (this._pumpRequested);
         } catch (e) {
             logger.error('[WakeSubscription] Background pump failed:', e);
         } finally {
             this._pumping = false;
         }
+    }
+
+    /**
+     * @summary Yields between bounded GraphLog pages so MCP transport, health timers, and WAL
+     * acceptance work can run while a large wake backlog drains.
+     * @returns {Promise<void>}
+     * @protected
+     */
+    _yieldPumpTurn() {
+        return new Promise(resolve => setImmediate(resolve));
     }
 
     /**
@@ -1587,12 +1646,12 @@ class WakeSubscriptionService extends Base {
         // immutable typed-event rows returned separately by getDeltaLog().
         // Filter spec is applied to the matched candidate's payload; non-matches are skipped.
         for (const edgeRef of delta.invalidEdges) {
-            const logId   = this._getEntityLogId(edgeRef.id) || delta.lastLogId;
+            const logId   = edgeRef.logId || delta.entityLogIds?.get(edgeRef.id) || delta.lastLogId;
             const matched = this._evaluateEdgeAgainstSubscription(edgeRef, subscription, logId);
             if (matched) events.push(matched);
         }
         for (const nodeId of delta.invalidNodes) {
-            const logId   = this._getEntityLogId(nodeId) || delta.lastLogId;
+            const logId   = delta.entityLogIds?.get(nodeId) || delta.lastLogId;
             const matched = this._evaluateNodeAgainstSubscription(nodeId, subscription, logId);
             if (matched) events.push(matched);
         }

--- a/test/playwright/unit/ai/graph/Database.spec.mjs
+++ b/test/playwright/unit/ai/graph/Database.spec.mjs
@@ -363,6 +363,51 @@ test.describe('Neo.ai.graph.Database', () => {
         }
     });
 
+    test('SQLite pages GraphLog before materialization and carries per-entity log ids (#16677)', async () => {
+        const storage = Neo.create(SQLite, {dbPath});
+        await storage.initAsync();
+
+        try {
+            const insert = storage.db.prepare('INSERT INTO GraphLog(entity_id, entity_type) VALUES (?, ?)');
+            insert.run('page-node-1', 'nodes');
+            insert.run('page-node-2', 'nodes');
+            insert.run('page-node-3', 'nodes');
+
+            const first = storage.getDeltaLog(0, {limit: 2});
+
+            expect(first.invalidNodes).toEqual(['page-node-1', 'page-node-2']);
+            expect(first.entityLogIds.get('page-node-1')).toBe(1);
+            expect(first.entityLogIds.get('page-node-2')).toBe(2);
+            expect(first.lastLogId).toBe(2);
+            expect(first.hasMore).toBe(true);
+
+            const second = storage.getDeltaLog(first.lastLogId, {limit: 2});
+
+            expect(second.invalidNodes).toEqual(['page-node-3']);
+            expect(second.entityLogIds.get('page-node-3')).toBe(3);
+            expect(second.lastLogId).toBe(3);
+            expect(second.hasMore).toBe(false);
+
+            insert.run('page-node-4', 'nodes');
+
+            const frozen = storage.getDeltaLog(first.lastLogId, {limit: 2, untilId: second.lastLogId});
+            expect(frozen.invalidNodes).toEqual(['page-node-3']);
+            expect(frozen.lastLogId).toBe(3);
+            expect(frozen.hasMore).toBe(false);
+
+            const tail = storage.getDeltaLog(frozen.lastLogId, {limit: 2});
+            expect(tail.invalidNodes).toEqual(['page-node-4']);
+            expect(tail.lastLogId).toBe(4);
+
+            expect(() => storage.getDeltaLog(0, {limit: 0})).toThrow(/positive integer/);
+            expect(() => storage.getDeltaLog(0, {limit: 1.5})).toThrow(/positive integer/);
+            expect(() => storage.getDeltaLog(0, {untilId: -1})).toThrow(/non-negative integer/);
+        } finally {
+            if (storage.db?.open) storage.db.close();
+            storage.destroy();
+        }
+    });
+
     test('SQLite migrates legacy SummarizationJobs rows with nullable durable receipt columns (#16105)', async () => {
         seedLegacyGraphFile();
 

--- a/test/playwright/unit/ai/services/memory-core/WakeSubscriptionService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/WakeSubscriptionService.spec.mjs
@@ -2492,6 +2492,63 @@ test.describe('Neo.ai.services.memory-core.WakeSubscriptionService', () => {
             }
         });
 
+        test('yields before draining a coalesced sub-page tail (#16677)', async () => {
+            CoalescingEngineService.addMcpServer(mockMcpServer);
+
+            await RequestContextService.run({agentIdentityNodeId: '@alice'}, async () => {
+                await WakeSubscriptionService.subscribe({trigger: 'TASK_STATE_CHANGED', harnessTarget: 'mcp-notifications'});
+            });
+
+            const storage = GraphService.db.storage;
+            const sqlite  = storage.db;
+            WakeSubscriptionService.liveCursor = sqlite.prepare('SELECT MAX(log_id) AS maxId FROM GraphLog').get().maxId || 0;
+
+            const firstLogId = appendTaskEvent({
+                eventId: 'task-coalesced-page-event',
+                taskId : 'MSG:COALESCED-PAGE'
+            }).logId;
+            const originalGetLatestLogId = storage.getLatestLogId;
+            let   latestReadCount        = 0;
+            let   tailLogId              = null;
+            let   cursorAtControl        = null;
+
+            storage.getLatestLogId = function() {
+                latestReadCount += 1;
+                // The first read freezes the snapshot; the second is its tail check. Injecting here
+                // models an external writer advancing the shared journal between those statements.
+                if (latestReadCount === 2) {
+                    tailLogId = appendTaskEvent({
+                        eventId: 'task-coalesced-tail-event',
+                        taskId : 'MSG:COALESCED-TAIL'
+                    }).logId;
+                }
+
+                return originalGetLatestLogId.call(this);
+            };
+
+            try {
+                const controlTurn = new Promise(resolve => setImmediate(() => {
+                    cursorAtControl = WakeSubscriptionService.liveCursor;
+                    resolve();
+                }));
+                const pump = WakeSubscriptionService.pump();
+
+                await Promise.all([controlTurn, pump]);
+                expect(cursorAtControl).toBe(firstLogId);
+                expect(cursorAtControl).toBeLessThan(tailLogId);
+
+                await CoalescingEngineService.flushAll();
+
+                expect(WakeSubscriptionService.liveCursor).toBe(tailLogId);
+                expect(emittedEvents.map(event => event.params.sourceEventId)).toEqual([
+                    'task-coalesced-page-event',
+                    'task-coalesced-tail-event'
+                ]);
+            } finally {
+                storage.getLatestLogId = originalGetLatestLogId;
+            }
+        });
+
         test('evaluates a repeatedly rewritten entity once per frozen paged snapshot (#16677)', async () => {
             CoalescingEngineService.addMcpServer(mockMcpServer);
 

--- a/test/playwright/unit/ai/services/memory-core/WakeSubscriptionService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/WakeSubscriptionService.spec.mjs
@@ -2177,8 +2177,8 @@ test.describe('Neo.ai.services.memory-core.WakeSubscriptionService', () => {
             WakeSubscriptionService.subscriptionCache.clear();
 
             GraphService.upsertNode({
-                id        : 'MSG:COLD-WEBHOOK-ROUTE',
-                type      : 'MESSAGE',
+                id  : 'MSG:COLD-WEBHOOK-ROUTE',
+                type: 'MESSAGE',
                 // Production MESSAGE rows always carry the canonical `sentAt` (MailboxService
                 // stamps it); the digest path age-gates on it, so the fixture must too.
                 properties: {from: '@bob', subject: 'first post-restart webhook', sentAt: new Date().toISOString()}
@@ -2404,6 +2404,175 @@ test.describe('Neo.ai.services.memory-core.WakeSubscriptionService', () => {
 
             // If the race condition was present, both might emit the same event
             expect(emittedEvents.length).toBe(1);
+        });
+
+        test('yields between bounded GraphLog pages before the full backlog is drained (#16677)', async () => {
+            CoalescingEngineService.addMcpServer(mockMcpServer);
+
+            await RequestContextService.run({agentIdentityNodeId: '@alice'}, async () => {
+                await WakeSubscriptionService.subscribe({trigger: 'TASK_STATE_CHANGED', harnessTarget: 'mcp-notifications'});
+            });
+
+            const sqlite = GraphService.db.storage.db;
+            WakeSubscriptionService.liveCursor = sqlite.prepare('SELECT MAX(log_id) AS maxId FROM GraphLog').get().maxId || 0;
+
+            const sourceEventIds = [];
+            for (let index = 0; index < 5; index++) {
+                const sourceEventId = `task-page-event-${index}`;
+                sourceEventIds.push(sourceEventId);
+                appendTaskEvent({eventId: sourceEventId, taskId: `MSG:PAGE-${index}`});
+            }
+
+            const initialCursor   = WakeSubscriptionService.liveCursor;
+            const finalCursor     = sqlite.prepare('SELECT MAX(log_id) AS maxId FROM GraphLog').get().maxId;
+            const originalSize    = WakeSubscriptionService.pumpBatchSize;
+            let   cursorAtControl = null;
+
+            WakeSubscriptionService.pumpBatchSize = 2;
+
+            try {
+                const controlTurn = new Promise(resolve => setImmediate(() => {
+                    cursorAtControl = WakeSubscriptionService.liveCursor;
+                    resolve();
+                }));
+                const pump = WakeSubscriptionService.pump();
+
+                await controlTurn;
+                expect(cursorAtControl).toBeGreaterThan(initialCursor);
+                expect(cursorAtControl).toBeLessThan(finalCursor);
+
+                await pump;
+                await CoalescingEngineService.flushAll();
+
+                expect(WakeSubscriptionService.liveCursor).toBe(finalCursor);
+                expect(emittedEvents.map(event => event.params.sourceEventId)).toEqual(sourceEventIds);
+            } finally {
+                WakeSubscriptionService.pumpBatchSize = originalSize;
+            }
+        });
+
+        test('folds a pump trigger and new event arriving during a paged drain into the same single-flight (#16677)', async () => {
+            CoalescingEngineService.addMcpServer(mockMcpServer);
+
+            await RequestContextService.run({agentIdentityNodeId: '@alice'}, async () => {
+                await WakeSubscriptionService.subscribe({trigger: 'TASK_STATE_CHANGED', harnessTarget: 'mcp-notifications'});
+            });
+
+            const sqlite = GraphService.db.storage.db;
+            WakeSubscriptionService.liveCursor = sqlite.prepare('SELECT MAX(log_id) AS maxId FROM GraphLog').get().maxId || 0;
+
+            for (let index = 0; index < 4; index++) {
+                appendTaskEvent({eventId: `task-concurrent-event-${index}`, taskId: `MSG:CONCURRENT-${index}`});
+            }
+
+            const originalSize = WakeSubscriptionService.pumpBatchSize;
+            WakeSubscriptionService.pumpBatchSize = 2;
+
+            try {
+                const appendDuringYield = new Promise(resolve => setImmediate(() => {
+                    appendTaskEvent({eventId: 'task-concurrent-event-tail', taskId: 'MSG:CONCURRENT-TAIL'});
+                    void WakeSubscriptionService.pump();
+                    resolve();
+                }));
+
+                await Promise.all([WakeSubscriptionService.pump(), appendDuringYield]);
+                await CoalescingEngineService.flushAll();
+
+                const finalCursor = sqlite.prepare('SELECT MAX(log_id) AS maxId FROM GraphLog').get().maxId;
+                expect(WakeSubscriptionService.liveCursor).toBe(finalCursor);
+                expect(emittedEvents.map(event => event.params.sourceEventId)).toEqual([
+                    'task-concurrent-event-0',
+                    'task-concurrent-event-1',
+                    'task-concurrent-event-2',
+                    'task-concurrent-event-3',
+                    'task-concurrent-event-tail'
+                ]);
+            } finally {
+                WakeSubscriptionService.pumpBatchSize = originalSize;
+            }
+        });
+
+        test('evaluates a repeatedly rewritten entity once per frozen paged snapshot (#16677)', async () => {
+            CoalescingEngineService.addMcpServer(mockMcpServer);
+
+            await RequestContextService.run({agentIdentityNodeId: '@alice'}, async () => {
+                await WakeSubscriptionService.subscribe({trigger: 'SENT_TO_ME', harnessTarget: 'mcp-notifications'});
+            });
+
+            GraphService.upsertNode({id: 'MSG:PAGED-REWRITE', type: 'MESSAGE', properties: {from: '@bob'}});
+            GraphService.linkNodes('MSG:PAGED-REWRITE', '@alice', 'SENT_TO', 1.0);
+
+            const sqlite = GraphService.db.storage.db;
+            WakeSubscriptionService.liveCursor = sqlite.prepare('SELECT MAX(log_id) AS maxId FROM GraphLog').get().maxId || 0;
+
+            GraphService.linkNodes('MSG:PAGED-REWRITE', '@alice', 'SENT_TO', 1.0, {revision: 1});
+            GraphService.linkNodes('MSG:PAGED-REWRITE', '@alice', 'SENT_TO', 1.0, {revision: 2});
+            GraphService.linkNodes('MSG:PAGED-REWRITE', '@alice', 'SENT_TO', 1.0, {revision: 3});
+
+            const originalSize = WakeSubscriptionService.pumpBatchSize;
+            const finalLogId   = sqlite.prepare('SELECT MAX(log_id) AS maxId FROM GraphLog').get().maxId;
+            WakeSubscriptionService.pumpBatchSize = 1;
+
+            try {
+                await WakeSubscriptionService.pump();
+                await CoalescingEngineService.flushAll();
+
+                expect(emittedEvents).toHaveLength(1);
+                expect(emittedEvents[0].params.payload.messageId).toBe('MSG:PAGED-REWRITE');
+                expect(WakeSubscriptionService.liveCursor).toBe(finalLogId);
+            } finally {
+                WakeSubscriptionService.pumpBatchSize = originalSize;
+            }
+        });
+
+        test('does not advance the cursor past a page whose evaluation fails (#16677)', async () => {
+            CoalescingEngineService.addMcpServer(mockMcpServer);
+
+            await RequestContextService.run({agentIdentityNodeId: '@alice'}, async () => {
+                await WakeSubscriptionService.subscribe({trigger: 'TASK_STATE_CHANGED', harnessTarget: 'mcp-notifications'});
+            });
+
+            const sqlite = GraphService.db.storage.db;
+            WakeSubscriptionService.liveCursor = sqlite.prepare('SELECT MAX(log_id) AS maxId FROM GraphLog').get().maxId || 0;
+
+            const logIds = [];
+            for (let index = 0; index < 4; index++) {
+                logIds.push(appendTaskEvent({eventId: `task-failure-event-${index}`, taskId: `MSG:FAILURE-${index}`}).logId);
+            }
+
+            const originalSize     = WakeSubscriptionService.pumpBatchSize;
+            const originalEvaluate = WakeSubscriptionService._evaluateTypedEventAgainstSubscription;
+            WakeSubscriptionService.pumpBatchSize = 2;
+            WakeSubscriptionService._evaluateTypedEventAgainstSubscription = (trace, subscription) => {
+                if (trace.event_id === 'task-failure-event-3') throw new Error('injected page failure');
+                return originalEvaluate.call(WakeSubscriptionService, trace, subscription);
+            };
+
+            try {
+                await WakeSubscriptionService.pump();
+                await CoalescingEngineService.flushAll();
+
+                expect(WakeSubscriptionService.liveCursor).toBe(logIds[1]);
+                expect(emittedEvents.map(event => event.params.sourceEventId)).toEqual([
+                    'task-failure-event-0',
+                    'task-failure-event-1'
+                ]);
+
+                WakeSubscriptionService._evaluateTypedEventAgainstSubscription = originalEvaluate;
+                await WakeSubscriptionService.pump();
+                await CoalescingEngineService.flushAll();
+
+                expect(WakeSubscriptionService.liveCursor).toBe(logIds[3]);
+                expect(emittedEvents.map(event => event.params.sourceEventId)).toEqual([
+                    'task-failure-event-0',
+                    'task-failure-event-1',
+                    'task-failure-event-2',
+                    'task-failure-event-3'
+                ]);
+            } finally {
+                WakeSubscriptionService.pumpBatchSize = originalSize;
+                WakeSubscriptionService._evaluateTypedEventAgainstSubscription = originalEvaluate;
+            }
         });
     });
 


### PR DESCRIPTION
Resolves neomjs/neo#16677
Related: neomjs/neo#17056

Memory Core wake evaluation now consumes frozen GraphLog snapshots in SQL-bounded work units and yields between pages and before a coalesced tail drain re-enters. Concurrent pump triggers coalesce into the active drain; immutable typed events retain log order, mutable entity invalidations evaluate once per frozen snapshot, and a failed page cannot leak partial raw deliveries or advance the cursor past completed work.

Evidence: L2 (real SQLite-backed storage and WakeSubscriptionService regression suites exercise bounded materialization, event-loop yield, tail folding, mutable invalidation dedupe, and failed-page replay) → L2 required (the close target is a deterministic in-process liveness and delivery contract). Residual: producer-side unchanged filesystem-edge amplification, Residual-Owner: neomjs/neo#17056.

## Deltas from ticket

- Kept the existing unbounded `getDeltaLog()` behavior for callers that do not opt into `{limit, untilId}`; only the live wake pump uses bounded pages.
- Buffered every page's matches until all subscriptions/candidates evaluate, so an evaluator failure emits nothing from that page and a retry cannot duplicate a partial raw delivery.
- Yields before re-entering a coalesced sub-page tail, preserving the ordinary one-page/no-tail fast path while preventing sustained external writers from reopening an unbounded synchronous span.
- Deliberately added no global GraphLog entity index: the measured canonical store retains about 9.35 million journal rows, so an urgent liveness repair must not introduce an unmeasured synchronous startup migration.
- Narrowed mutable node/edge semantics to current-state invalidations evaluated once per frozen snapshot; exact once/in-order delivery remains the contract for immutable typed events.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/ai/graph/Database.spec.mjs test/playwright/unit/ai/services/memory-core/WakeSubscriptionService.spec.mjs --workers=1 --retries=0` — 148/148 passed at `b493b84b72`.
- `node --check` — all five changed modules/specs passed.
- `git diff --check origin/dev...HEAD` — passed.
- `npm run agent-preflight -- --change-class restoration --commit-subject "fix(memory-core): bound wake GraphLog drains (#16677)" --pr-title "fix(memory-core): bound wake GraphLog drains (#16677)" --no-fix <five changed files>` — passed; unrelated stale-overlay warnings only.
- Independent source audit after the final page-buffer/index-removal repairs: CLEAR, no source-proven blockers.

## Post-Merge Validation

No post-merge step is required to satisfy the close target. Recording MC responsiveness and cursor progress during the next natural GraphLog burst after a cumulative Agent OS update is supplementary production evidence; neomjs/neo#17056 separately owns reducing the producer burst itself.

Authored by Emmy (GPT-5.6 Sol Ultra, Codex). Session ec35ab33-684f-40a9-804b-83fc32b21ac1.
