### PR TITLE
feat(ai): make filesystem structural edges write-idempotent (#17056)

### DIFF
--- a/ai/services/memory-core/FileSystemIngestor.mjs
+++ b/ai/services/memory-core/FileSystemIngestor.mjs
@@ -216,14 +216,29 @@ class FileSystemIngestor extends Base {
     }
 
     /**
-     * Executes the recursive file system sync into the native Graph database.
+     * Executes the recursive file system sync into the Native Edge Graph and returns a truthful
+     * mutation/verification receipt. `rootDir` is injectable for the real-SQLite unit fixture;
+     * production callers retain the no-argument Neo-repository default.
+     *
+     * @param {Object} [options={}]
+     * @param {String} [options.rootDir=neoRootDir] Filesystem root to project.
+     * @returns {Promise<{status: String, pathNodesUpserted: Number, edgesCreated: Number, edgesVerified: Number, edgesDrifted: Number, edgesCulled: Number, edgesUnavailable: Number}>}
      */
-    async syncWorkspaceToGraph() {
+    async syncWorkspaceToGraph({rootDir = neoRootDir} = {}) {
         logger.info('[FileSystemIngestor] Initiating dynamic filesystem-to-graph sync...');
 
-        if (!GraphService.db || !GraphService.db.nodes) {
+        const stats = {
+            pathNodesUpserted: 0,
+            edgesCreated     : 0,
+            edgesVerified    : 0,
+            edgesDrifted     : 0,
+            edgesCulled      : 0,
+            edgesUnavailable : 0
+        };
+
+        if (!GraphService.db?.nodes || !GraphService.db?.storage?.db) {
             logger.warn('[FileSystemIngestor] GraphService DB not mounted. Aborting sync.');
-            return;
+            return {status: 'unavailable', ...stats}
         }
 
         // Precache existing mtimeMs dynamically bypassing RAM bloat cleanly natively
@@ -256,10 +271,15 @@ class FileSystemIngestor extends Base {
             description: 'The physical root directory of the Neo.mjs project.'
         });
 
-        const stats = { nodes: 0, edges: 0 };
-        await this.walkDirectory(neoRootDir, neoRootDir, rootNodeId, stats, mtimeMap, hashMap);
+        await this.walkDirectory(rootDir, rootDir, rootNodeId, stats, mtimeMap, hashMap);
 
-        logger.info(`[FileSystemIngestor] Workspace Sync Complete. Upserted/Verified ${stats.nodes} Nodes and ${stats.edges} tracked CONTAINS Edges.`);
+        logger.info(
+            `[FileSystemIngestor] Workspace Sync Complete. Upserted ${stats.pathNodesUpserted} path nodes; ` +
+            `CONTAINS edges created=${stats.edgesCreated}, verified=${stats.edgesVerified}, ` +
+            `drifted=${stats.edgesDrifted}, culled=${stats.edgesCulled}, unavailable=${stats.edgesUnavailable}.`
+        );
+
+        return {status: 'completed', ...stats}
     }
 
     /**
@@ -267,7 +287,7 @@ class FileSystemIngestor extends Base {
      * @param {String} dir Current directory path
      * @param {String} rootDir The base root path determining relative node ids natively
      * @param {String|null} parentId Graph ID of the parent directory Node
-     * @param {Object} stats Reference counter
+     * @param {{pathNodesUpserted: Number, edgesCreated: Number, edgesVerified: Number, edgesDrifted: Number, edgesCulled: Number, edgesUnavailable: Number}} stats Mutation/verification counters.
      * @param {Map} mtimeMap Precaching SQLite map
      * @param {Map} hashMap Precaching SQLite hash map
      */
@@ -331,13 +351,25 @@ class FileSystemIngestor extends Base {
                         ...(fileHash && { hash: fileHash })
                     }
                 });
-                stats.nodes++;
+                stats.pathNodesUpserted++;
             }
 
-            // Create hierarchical structural edge tracking deduplication safely via GraphService native logic
+            // Filesystem hierarchy is an asserted fact, not a learning signal. Verify it on every
+            // walk so missing topology self-heals, but never reinforce an unchanged relation.
             if (parentId) {
-                GraphService.linkNodes(parentId, nodeId, 'CONTAINS', 1.0);
-                stats.edges++; // Tracks 'verified or created' topological state
+                const {status} = GraphService.ensureStructuralEdge(parentId, nodeId, 'CONTAINS', 1.0);
+
+                if (status === 'created') {
+                    stats.edgesCreated++
+                } else if (status === 'verified') {
+                    stats.edgesVerified++
+                } else if (status === 'drifted') {
+                    stats.edgesDrifted++
+                } else if (status === 'culled') {
+                    stats.edgesCulled++
+                } else {
+                    stats.edgesUnavailable++
+                }
             }
 
             if (isDir) {

--- a/ai/services/memory-core/GraphService.mjs
+++ b/ai/services/memory-core/GraphService.mjs
@@ -10,6 +10,7 @@ import {createGraphBootSeedNodeRecord} from '../../../ai/graph/bootSeedManifest.
 import {getGraphBootSeedNodeSpec}      from '../../../ai/graph/bootSeedManifest.mjs';
 import { normalizeUserId }             from '../../mcp/server/shared/services/RequestContextService.mjs';
 import fsExtra                         from 'fs-extra';
+import {isDeepStrictEqual}             from 'node:util';
 import {projectNode}                   from './nodeProjection.mjs';
 
 /**
@@ -511,6 +512,180 @@ class GraphService extends Base {
      */
     linkGlobalNodes(source, target, relationship, weight = 1.0) {
         this.linkNodes(source, target, relationship, weight, {userId: null});
+    }
+
+    /**
+     * Creates a structural relation exactly once and reports verification without reinforcing
+     * an existing edge.
+     *
+     * @summary This is the write-idempotent counterpart to {@link GraphService#linkNodes}.
+     * Structural projectors repeatedly assert topology that is already authoritative; routing
+     * those assertions through `linkNodes` would increase weight, execute `UPDATE Edges`, and
+     * append a false GraphLog invalidation on every verification pass. The creation weight is
+     * therefore deliberately NOT an equivalence invariant: an existing edge may carry legitimate
+     * or historical reinforcement and must remain byte-stable.
+     *
+     * Caller-declared `properties` ARE structural invariants. A mismatch is returned as
+     * `drifted` with the divergent keys and is never silently rewritten or reinforced. Missing
+     * endpoints retain `linkNodes`' cache-warm/cull posture. The operation owns one atomic graph
+     * transaction and rejects an outer transaction rather than pretending that SQLite alone can
+     * represent its queued node/edge additions and removals. The table still has no unique
+     * `(source, target, type)` constraint, so this method does not claim cross-process exactly-once
+     * creation.
+     *
+     * @param {String} source Source node id.
+     * @param {String} target Target node id.
+     * @param {String} relationship Edge type.
+     * @param {Number} [weight=1.0] Initial weight used only when the edge is created.
+     * @param {Object} [properties={}] Structural properties that must match when already present.
+     * @returns {{status: String, divergentKeys: (String[]|undefined)}}
+     * @throws {Error} When called inside an existing Graph Database transaction.
+     */
+    ensureStructuralEdge(source, target, relationship, weight = 1.0, properties = {}) {
+        if (!this.db?.storage?.db) {
+            return {status: 'unavailable'}
+        }
+
+        if (this.db.isExecutingTransaction) {
+            throw new Error('ensureStructuralEdge owns its transaction and cannot run inside another Graph Database transaction')
+        }
+
+        const
+            findEdge = this.db.storage.db.prepare(`
+                SELECT id, user_id, data
+                FROM Edges
+                WHERE source = ?
+                  AND target = ?
+                  AND type = ?
+                LIMIT 1
+            `),
+            findCachedEdges = () => this.db.edges.getByIndex('source', source)
+                .filter(edge => edge.target === target && edge.type === relationship),
+            findPersistedEdgeIds = () => new Set(this.db.storage.db.prepare(`
+                SELECT id
+                FROM Edges
+                WHERE source = ?
+                  AND target = ?
+                  AND type = ?
+            `).all(source, target, relationship).map(edge => edge.id)),
+            reconcileCachedTuple = () => {
+                const persistedEdgeIds = findPersistedEdgeIds();
+                const staleEdges       = findCachedEdges()
+                    .filter(edge => !persistedEdgeIds.has(edge.id));
+
+                if (staleEdges.length === 0) return
+
+                const wasAutoSave = this.db.autoSave;
+                this.db.autoSave = false;
+
+                try {
+                    this.db.edges.remove(staleEdges.map(edge => edge.id));
+                    // Store.remove() clears the current map records. Also remove exact stale
+                    // references that a prior refresh may have left in secondary index Sets.
+                    this.db.edges.updateIndexMaps?.(null, staleEdges)
+                } finally {
+                    this.db.autoSave = wasAutoSave
+                }
+            },
+            expectedUserId = properties.userId === undefined
+                ? resolveRlsUserId(this.db.storage?.RequestContextService) ?? null
+                : properties.userId == null ? null : normalizeUserId(properties.userId),
+            classifyExisting = existing => {
+                const
+                    existingProperties = existing.data
+                        ? JSON.parse(existing.data)?.properties || {}
+                        : existing.get?.('properties') || existing.properties || {},
+                    existingUserId = existing.user_id === undefined
+                        ? existingProperties.userId == null ? null : normalizeUserId(existingProperties.userId)
+                        : existing.user_id == null ? null : normalizeUserId(existing.user_id),
+                    existingJsonUserId = existingProperties.userId == null
+                        ? null
+                        : normalizeUserId(existingProperties.userId),
+                    structuralProperties = {...properties};
+
+                // Weight is creation-time topology metadata, not a verification invariant. Preserve
+                // any intentional or historical reinforcement instead of normalizing it back to 1.
+                delete structuralProperties.weight;
+                delete structuralProperties.userId;
+
+                const divergentKeys = Object.entries(structuralProperties)
+                    .filter(([key, value]) => !isDeepStrictEqual(existingProperties[key], value))
+                    .map(([key]) => key);
+
+                // SQL `user_id` is the RLS authority. JSON historically omitted `userId` for a
+                // global edge, so missing and null are equivalent; a present divergent value is not.
+                if ((existingUserId !== expectedUserId || existingJsonUserId !== expectedUserId)
+                    && !divergentKeys.includes('userId')) {
+                    divergentKeys.push('userId')
+                }
+
+                return divergentKeys.length > 0
+                    ? {status: 'drifted', divergentKeys}
+                    : {status: 'verified'}
+            },
+            findCurrentEdge = () => findEdge.get(source, target, relationship),
+            cachedBeforeSync = findCachedEdges();
+
+        // An absent persisted tuple makes any same-tuple RAM record stale. Consume pending peer
+        // invalidations before the local transaction can acknowledge beyond them, then reconcile
+        // any orphaned cache record that predates the retained GraphLog window.
+        if (!findCurrentEdge() && cachedBeforeSync.length > 0) {
+            this.db.syncCache()
+        }
+
+        const existing = findCurrentEdge();
+        reconcileCachedTuple();
+
+        if (existing) return classifyExisting(existing);
+
+        let outcome;
+
+        const createIfStillAbsent = () => {
+            const concurrent = findCurrentEdge();
+            if (concurrent) {
+                outcome = classifyExisting(concurrent);
+                return
+            }
+
+            const
+                endpointCount = this.db.storage.db.prepare(
+                    'SELECT count(*) AS count FROM Nodes WHERE id IN (?, ?)'
+                ).get(source, target).count,
+                expectedCount = source === target ? 1 : 2;
+
+            if (endpointCount !== expectedCount) {
+                // Preserve linkNodes' cache-warm/cull behavior without ever invoking its
+                // reinforcing existing-edge branch.
+                this.db.getAdjacentNodes?.(source, 'both');
+                this.db.getAdjacentNodes?.(target, 'both');
+
+                const warmedCount = this.db.storage.db.prepare(
+                    'SELECT count(*) AS count FROM Nodes WHERE id IN (?, ?)'
+                ).get(source, target).count;
+
+                if (warmedCount !== expectedCount) {
+                    logger.warn(`[GraphService] Culling hallucinated structural edge mapping: ${source} -> ${target} (count was ${warmedCount})`);
+                    outcome = {status: 'culled'};
+                    return
+                }
+            }
+
+            const edge = {
+                id        : globalThis.crypto.randomUUID(),
+                source,
+                target,
+                type      : relationship,
+                properties: {weight, ...properties, userId: expectedUserId}
+            };
+
+            this.db.addEdge(edge);
+            outcome = {status: 'created'}
+        };
+
+        this.db.transaction(createIfStillAbsent);
+        reconcileCachedTuple();
+
+        return outcome
     }
 
     /**

--- a/ai/services/memory-core/GraphService.mjs
+++ b/ai/services/memory-core/GraphService.mjs
@@ -538,7 +538,7 @@ class GraphService extends Base {
      * @param {String} relationship Edge type.
      * @param {Number} [weight=1.0] Initial weight used only when the edge is created.
      * @param {Object} [properties={}] Structural properties that must match when already present.
-     * @returns {{status: String, divergentKeys: (String[]|undefined)}}
+     * @returns {{status: ('unavailable'|'drifted'|'verified'|'culled'|'created'), divergentKeys: (String[]|undefined)}}
      * @throws {Error} When called inside an existing Graph Database transaction.
      */
     ensureStructuralEdge(source, target, relationship, weight = 1.0, properties = {}) {
@@ -551,25 +551,17 @@ class GraphService extends Base {
         }
 
         const
-            findEdge = this.db.storage.db.prepare(`
+            findEdges = this.db.storage.db.prepare(`
                 SELECT id, user_id, data
                 FROM Edges
                 WHERE source = ?
                   AND target = ?
                   AND type = ?
-                LIMIT 1
             `),
             findCachedEdges = () => this.db.edges.getByIndex('source', source)
                 .filter(edge => edge.target === target && edge.type === relationship),
-            findPersistedEdgeIds = () => new Set(this.db.storage.db.prepare(`
-                SELECT id
-                FROM Edges
-                WHERE source = ?
-                  AND target = ?
-                  AND type = ?
-            `).all(source, target, relationship).map(edge => edge.id)),
-            reconcileCachedTuple = () => {
-                const persistedEdgeIds = findPersistedEdgeIds();
+            reconcileCachedTuple = persistedEdges => {
+                const persistedEdgeIds = new Set(persistedEdges.map(edge => edge.id));
                 const staleEdges       = findCachedEdges()
                     .filter(edge => !persistedEdgeIds.has(edge.id));
 
@@ -623,25 +615,28 @@ class GraphService extends Base {
                     ? {status: 'drifted', divergentKeys}
                     : {status: 'verified'}
             },
-            findCurrentEdge = () => findEdge.get(source, target, relationship),
+            findCurrentEdges = () => findEdges.all(source, target, relationship),
             cachedBeforeSync = findCachedEdges();
 
         // An absent persisted tuple makes any same-tuple RAM record stale. Consume pending peer
         // invalidations before the local transaction can acknowledge beyond them, then reconcile
         // any orphaned cache record that predates the retained GraphLog window.
-        if (!findCurrentEdge() && cachedBeforeSync.length > 0) {
+        let persistedEdges = findCurrentEdges();
+
+        if (persistedEdges.length === 0 && cachedBeforeSync.length > 0) {
             this.db.syncCache()
+            persistedEdges = findCurrentEdges()
         }
 
-        const existing = findCurrentEdge();
-        reconcileCachedTuple();
+        const existing = persistedEdges[0];
+        reconcileCachedTuple(persistedEdges);
 
         if (existing) return classifyExisting(existing);
 
         let outcome;
 
         const createIfStillAbsent = () => {
-            const concurrent = findCurrentEdge();
+            const concurrent = findCurrentEdges()[0];
             if (concurrent) {
                 outcome = classifyExisting(concurrent);
                 return
@@ -683,7 +678,7 @@ class GraphService extends Base {
         };
 
         this.db.transaction(createIfStillAbsent);
-        reconcileCachedTuple();
+        reconcileCachedTuple(findCurrentEdges());
 
         return outcome
     }
@@ -708,6 +703,8 @@ class GraphService extends Base {
      * @param {String} relationship
      * @param {Number} weight
      * @param {Object} [properties={}] Additional edge metadata (e.g. justification, context_source).
+     * @see {@link GraphService#ensureStructuralEdge} for asserted topology that must not reinforce
+     *     an equivalent existing relation.
      */
     linkNodes(source, target, relationship, weight = 1.0, properties = {}) {
         if (!this.db?.storage?.db) {

--- a/test/playwright/unit/ai/services/memory-core/FileSystemIngestor.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/FileSystemIngestor.spec.mjs
@@ -162,7 +162,14 @@ test.describe('Neo.ai.services.memory-core.FileSystemIngestor', () => {
     });
 
     test('should dynamically ignore high-noise path patterns while preserving structural mapping', async () => {
-        const stats = { nodes: 0, edges: 0 };
+        const stats = {
+            pathNodesUpserted: 0,
+            edgesCreated     : 0,
+            edgesVerified    : 0,
+            edgesDrifted     : 0,
+            edgesCulled      : 0,
+            edgesUnavailable : 0
+        };
 
         // Override walk logic root physically mimicking neoRootDir logic natively
         await FileSystemIngestor.walkDirectory(mockFsRoot, mockFsRoot, null, stats, new Map(), new Map());
@@ -203,5 +210,84 @@ test.describe('Neo.ai.services.memory-core.FileSystemIngestor', () => {
         const link = GraphService.db.edges.items.find(e => e.source === srcNode.id && e.target === fileNode.id);
         expect(link).toBeDefined();
         expect(link.type).toBe('CONTAINS');
+    });
+
+    test('re-verifies an unchanged tree without rewriting CONTAINS edges (#17056)', async () => {
+        const root = fs.mkdtempSync(path.join(os.tmpdir(), 'neo-filesystem-idempotency-'));
+
+        try {
+            fs.ensureDirSync(path.join(root, 'left'));
+            fs.ensureDirSync(path.join(root, 'right'));
+            fs.writeFileSync(path.join(root, 'left', 'a.mjs'), 'export const a = true');
+            fs.writeFileSync(path.join(root, 'right', 'b.mjs'), 'export const b = true');
+
+            const
+                sqlite    = GraphService.db.storage.db,
+                readEdges = () => sqlite.prepare(`
+                    SELECT id, source, target, type, data
+                    FROM Edges
+                    WHERE type = 'CONTAINS'
+                    ORDER BY source, target, id
+                `).all(),
+                readEdgeLogs = () => sqlite.prepare("SELECT * FROM GraphLog WHERE entity_type = 'edges' ORDER BY log_id").all();
+
+            const firstStats = await FileSystemIngestor.syncWorkspaceToGraph({rootDir: root});
+
+            const firstEdges = readEdges();
+            expect(firstStats).toEqual({
+                status           : 'completed',
+                pathNodesUpserted: 4,
+                edgesCreated     : 4,
+                edgesVerified    : 0,
+                edgesDrifted     : 0,
+                edgesCulled      : 0,
+                edgesUnavailable : 0
+            });
+            expect(firstEdges).toHaveLength(4);
+
+            sqlite.exec('DELETE FROM GraphLog');
+
+            const secondStats = await FileSystemIngestor.syncWorkspaceToGraph({rootDir: root});
+
+            expect(secondStats).toEqual({
+                status           : 'completed',
+                pathNodesUpserted: 0,
+                edgesCreated     : 0,
+                edgesVerified    : 4,
+                edgesDrifted     : 0,
+                edgesCulled      : 0,
+                edgesUnavailable : 0
+            });
+            expect(readEdges()).toEqual(firstEdges);
+            expect(readEdgeLogs()).toEqual([]);
+
+            const beforeAdd = readEdges();
+            fs.writeFileSync(path.join(root, 'left', 'new.mjs'), 'export const added = true');
+            const changedAt = new Date(Date.now() + 2000);
+            fs.utimesSync(path.join(root, 'left'), changedAt, changedAt);
+            sqlite.exec('DELETE FROM GraphLog');
+
+            const thirdStats = await FileSystemIngestor.syncWorkspaceToGraph({rootDir: root});
+
+            const afterAdd  = readEdges();
+            const addedEdge = afterAdd.find(edge => !beforeAdd.some(before => before.id === edge.id));
+
+            expect(thirdStats).toEqual({
+                status           : 'completed',
+                pathNodesUpserted: 2,
+                edgesCreated     : 1,
+                edgesVerified    : 4,
+                edgesDrifted     : 0,
+                edgesCulled      : 0,
+                edgesUnavailable : 0
+            });
+            expect(afterAdd).toHaveLength(5);
+            expect(readEdgeLogs()).toEqual([
+                expect.objectContaining({entity_id: addedEdge.id, entity_type: 'edges'})
+            ]);
+            expect(afterAdd.filter(edge => beforeAdd.some(before => before.id === edge.id))).toEqual(beforeAdd);
+        } finally {
+            fs.removeSync(root)
+        }
     });
 });

--- a/test/playwright/unit/ai/services/memory-core/GraphService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/GraphService.spec.mjs
@@ -168,6 +168,171 @@ test.describe('Neo.ai.services.memory-core.GraphService', () => {
         expect(storedProperties.weight).toBeCloseTo(1.2);
         expect(GraphService.db.edges.get(initialRow.id)).toBe(cachedEdge);
         expect(cachedEdge.get('properties')).toEqual(storedProperties);
+
+        const reinforcementLogs = GraphService.db.storage.db.prepare(`
+            SELECT entity_id
+            FROM GraphLog
+            WHERE entity_type = 'edges'
+              AND entity_id = ?
+        `).all(initialRow.id);
+
+        expect(reinforcementLogs).toHaveLength(2);
+    });
+
+    test('structural edge verification is write-idempotent while property drift stays explicit (#17056)', () => {
+        GraphService.upsertNode({id: 'StructuralSource', type: 'TEST_NODE'});
+        GraphService.upsertNode({id: 'StructuralTarget', type: 'TEST_NODE'});
+
+        const
+            sqlite     = GraphService.db.storage.db,
+            selectEdge = sqlite.prepare(`
+                SELECT id, data
+                FROM Edges
+                WHERE source = ?
+                  AND target = ?
+                  AND type = ?
+            `),
+            edgeLogs   = () => sqlite.prepare("SELECT * FROM GraphLog WHERE entity_type = 'edges' ORDER BY log_id").all();
+
+        sqlite.exec('DELETE FROM GraphLog');
+
+        const created = GraphService.ensureStructuralEdge(
+            'StructuralSource',
+            'StructuralTarget',
+            'CONTAINS',
+            1,
+            {projection: 'filesystem'}
+        );
+
+        expect(created).toEqual({status: 'created'});
+        expect(edgeLogs()).toHaveLength(1);
+
+        // Intentional learning can raise the historical weight; structural verification must
+        // preserve that authority rather than normalize it back to the creation weight.
+        GraphService.linkNodes(
+            'StructuralSource',
+            'StructuralTarget',
+            'CONTAINS',
+            2,
+            {projection: 'filesystem'}
+        );
+
+        const reinforcedRow = selectEdge.get('StructuralSource', 'StructuralTarget', 'CONTAINS');
+        expect(JSON.parse(reinforcedRow.data).properties.weight).toBeCloseTo(1.2);
+
+        sqlite.exec('DELETE FROM GraphLog');
+
+        const verified = GraphService.ensureStructuralEdge(
+            'StructuralSource',
+            'StructuralTarget',
+            'CONTAINS',
+            1,
+            {projection: 'filesystem'}
+        );
+
+        expect(verified).toEqual({status: 'verified'});
+        expect(selectEdge.get('StructuralSource', 'StructuralTarget', 'CONTAINS').data).toBe(reinforcedRow.data);
+        expect(edgeLogs()).toEqual([]);
+
+        const drifted = GraphService.ensureStructuralEdge(
+            'StructuralSource',
+            'StructuralTarget',
+            'CONTAINS',
+            1,
+            {projection: 'different-authority'}
+        );
+
+        expect(drifted).toMatchObject({
+            status       : 'drifted',
+            divergentKeys: ['projection']
+        });
+        expect(selectEdge.get('StructuralSource', 'StructuralTarget', 'CONTAINS').data).toBe(reinforcedRow.data);
+        expect(edgeLogs()).toEqual([]);
+
+        GraphService.upsertNode({id: 'PrivateTarget', type: 'TEST_NODE'});
+        GraphService.linkNodes(
+            'StructuralSource',
+            'PrivateTarget',
+            'CONTAINS',
+            1,
+            {userId: 'tenant-a'}
+        );
+        sqlite.exec('DELETE FROM GraphLog');
+
+        expect(GraphService.ensureStructuralEdge(
+            'StructuralSource',
+            'PrivateTarget',
+            'CONTAINS'
+        )).toEqual({status: 'drifted', divergentKeys: ['userId']});
+        expect(edgeLogs()).toEqual([]);
+    });
+
+    test('structural edge verification rejects an outer transaction instead of reading a partial overlay (#17056)', () => {
+        GraphService.upsertNode({id: 'QueuedSource', type: 'TEST_NODE'});
+        GraphService.upsertNode({id: 'QueuedTarget', type: 'TEST_NODE'});
+        GraphService.db.storage.db.exec('DELETE FROM GraphLog');
+
+        expect(() => GraphService.db.transaction(() => {
+            GraphService.ensureStructuralEdge('QueuedSource', 'QueuedTarget', 'CONTAINS')
+        })).toThrow(/owns its transaction/);
+        expect(GraphService.db.storage.db.prepare(`
+            SELECT COUNT(*) AS count
+            FROM Edges
+            WHERE source = 'QueuedSource'
+              AND target = 'QueuedTarget'
+              AND type = 'CONTAINS'
+        `).get().count).toBe(0);
+        expect(GraphService.db.storage.db.prepare(
+            "SELECT COUNT(*) AS count FROM GraphLog WHERE entity_type = 'edges'"
+        ).get().count).toBe(0)
+    });
+
+    test('structural edge verification recreates a peer-deleted SQLite edge despite stale RAM (#17056)', () => {
+        GraphService.upsertNode({id: 'StaleSource', type: 'TEST_NODE'});
+        GraphService.upsertNode({id: 'StaleTarget', type: 'TEST_NODE'});
+        GraphService.ensureStructuralEdge('StaleSource', 'StaleTarget', 'CONTAINS');
+
+        const
+            sqlite      = GraphService.db.storage.db,
+            originalRow = sqlite.prepare(`
+                SELECT id
+                FROM Edges
+                WHERE source = 'StaleSource'
+                  AND target = 'StaleTarget'
+                  AND type = 'CONTAINS'
+            `).get();
+
+        // Simulate a peer-process delete before this process consumes the GraphLog invalidation.
+        // The old edge deliberately remains in the RAM store and must not satisfy verification.
+        sqlite.exec('DELETE FROM GraphLog');
+        sqlite.prepare('DELETE FROM Edges WHERE id = ?').run(originalRow.id);
+
+        expect(GraphService.db.edges.has(originalRow.id)).toBe(true);
+        expect(GraphService.ensureStructuralEdge(
+            'StaleSource',
+            'StaleTarget',
+            'CONTAINS'
+        )).toEqual({status: 'created'});
+
+        const persisted = sqlite.prepare(`
+            SELECT id
+            FROM Edges
+            WHERE source = 'StaleSource'
+              AND target = 'StaleTarget'
+              AND type = 'CONTAINS'
+        `).all();
+
+        expect(persisted).toHaveLength(1);
+        expect(persisted[0].id).not.toBe(originalRow.id);
+
+        const cachedTuple = GraphService.db.edges.getByIndex('source', 'StaleSource')
+            .filter(edge => edge.target === 'StaleTarget' && edge.type === 'CONTAINS');
+
+        expect(cachedTuple.map(edge => edge.id)).toEqual([persisted[0].id]);
+        expect(GraphService.db.edges.has(originalRow.id)).toBe(false);
+        expect(sqlite.prepare(
+            "SELECT entity_id FROM GraphLog WHERE entity_type = 'edges' ORDER BY log_id"
+        ).all().map(row => row.entity_id)).toEqual([originalRow.id, persisted[0].id])
     });
 
     test('removeNodes rejects invalid node ids before Database.removeNode null path (#11698)', async () => {


### PR DESCRIPTION
Resolves #17056

Filesystem projection now verifies authoritative `CONTAINS` topology without replaying the reinforcing `linkNodes()` operation. A new GraphService structural-edge primitive creates missing relations, leaves equivalent persisted rows byte-stable, surfaces property or tenancy drift, and reconciles stale RAM state against SQLite before a replacement write. Filesystem receipts now separate created, verified, drifted, culled, and unavailable edges from path-node upserts.

Evidence: L2 (real SQLite-backed production-entrypoint matrix; repository-wide baseline classified separately) → L2 required (all close-target ACs are internal graph mutation semantics exercised in-process). No residuals.

## Deltas from ticket

- Kept `linkNodes()` byte-for-byte unchanged so intentional learning/reinforcement remains intact.
- Made the structural operation own its transaction and fail loud under an outer Graph Database transaction; a partial transaction overlay would misclassify queued node and edge mutations.
- Bound verification to SQLite tenancy authority and preserved historically reinforced weights.
- Added stale-cache reconciliation for peer-deleted edges so SQLite and RAM converge on the same replacement identity.
- Named the node counter `pathNodesUpserted` because the existing project-root anchor remains an unconditional separate upsert.

## Review-response repairs at `977362fd6f`

- Collapsed the verified structural-edge path from three same-tuple SQLite reads to one prepared tuple query while retaining the full persisted duplicate set for cache reconciliation.
- Backfilled the #17056 Contract Ledger with the production receipt/failure contract and the explicit outer-transaction refusal boundary.
- Added the reverse `linkNodes()` JSDoc reference so callers can discover the non-reinforcing structural operation from the legacy reinforcing API.
- Tightened the structural-edge result union to its five named statuses.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/ai/services/memory-core/GraphService.spec.mjs test/playwright/unit/ai/services/memory-core/FileSystemIngestor.spec.mjs` — 57/57 passed against the source now committed as `977362fd6f`.
- `npm run test-unit -- --reporter=dot` — source-equivalent full-suite run: 13,035 passed and 32 failed in untouched host/process/permission/live-MCP/clean-tree guards; neither changed spec failed. Exact-head GitHub CI owns the repository-wide merge gate.
- `npm run agent-preflight -- --change-class restoration --commit-subject "fix(ai): collapse structural-edge verification queries (#17056)" ai/services/memory-core/GraphService.mjs` — passed for the review-response repair.
- The commit-time whitespace, shorthand, atomic-write, JSDoc-type, ticket-archaeology, block-alignment, parse, and OpenAPI/service parity gates all passed.
- `FileSystemIngestor`: real SQLite first/unchanged/add sync matrix proves full receipts, byte-stable prior edges, and zero unchanged edge GraphLog writes.
- `GraphService`: real SQLite matrix proves create/verify/drift, RLS mismatch, intentional reinforcement, outer-transaction refusal, stale-RAM peer-delete recovery, and persisted/RAM identity convergence.

## Post-Merge Validation

- None required beyond ordinary CI; no operator-only surface is involved.

## Evolution

The implementation initially tried to share more of the reinforcing path and to support surrounding graph transactions. Adversarial source review showed both directions widened authority: the shared path could still reinforce after a race, while partial transaction support could not represent queued node and edge removals. The final shape is additive and narrower: direct creation, SQLite-authoritative verification, one owned transaction, and explicit fail-loud behavior outside that contract.

The formal review then found a smaller performance regression inside that correct shape: verification re-read the same tuple three times. The repaired head keeps the full duplicate set as one authoritative observation and reuses it for classification plus cache reconciliation.

🪡

Authored by Emmy (GPT-5.6 Sol Ultra, Codex). Session 019fe0b3-53bc-7ef2-8665-41a0ef3f7b62.

