### PR TITLE
feat(ai): provider-lane probes go liveness-only and compute threads pin to the elected allocation (#17063, #17073)

### DIFF
--- a/ai/deploy/docker-compose.provider-lanes.yml
+++ b/ai/deploy/docker-compose.provider-lanes.yml
@@ -168,7 +168,11 @@ services:
     expose:
       - "11434"
     healthcheck:
-      test: ["CMD-SHELL", "ollama show \"$$NEO_PROVIDER_LANE_MODEL\" >/dev/null && echo \"$$NEO_PROVIDER_LANE_MANIFEST_SHA256  /root/.ollama/models/manifests/registry.ollama.ai/library/gemma4/26b\" | sha256sum -c - >/dev/null && test -f \"/root/.ollama/models/blobs/$$NEO_PROVIDER_LANE_WEIGHTS_BLOB\""]
+      # Liveness + presence only (#17063): `ollama show` proves the server answers and the model
+      # is registered; the blob test is O(1). The manifest sha256 that used to run here every
+      # 15s belongs to the boot path (the command above), not to a recurring probe that gates
+      # restarts — same defect class as the embedding lane below, smaller payload.
+      test: ["CMD-SHELL", "ollama show \"$$NEO_PROVIDER_LANE_MODEL\" >/dev/null && test -f \"/root/.ollama/models/blobs/$$NEO_PROVIDER_LANE_WEIGHTS_BLOB\""]
       interval: 15s
       timeout: 10s
       retries: 40
@@ -202,6 +206,16 @@ services:
       LLAMA_ARG_N_PARALLEL: ${NEO_PROVIDER_LANE_EMBEDDING_SLOTS:?embedding slots required}
       LLAMA_ARG_BATCH: ${NEO_PROVIDER_LANE_EMBEDDING_BATCH_TOKENS:?embedding logical batch required}
       LLAMA_ARG_UBATCH: ${NEO_PROVIDER_LANE_EMBEDDING_UBATCH_TOKENS:?embedding physical ubatch required}
+      # Pin compute threads to the elected CPU allocation (#17073). llama.cpp's default (-1)
+      # resolves against HOST hardware concurrency, and a CPU *quota* (deploy.resources.limits.
+      # cpus) does not change that answer — only a cpuset would. Unpinned, a lane on a 64-core
+      # host runs ~64 spin-wait workers inside its quota (measured: 98 threads in a 6-cpu
+      # cgroup, ~10x oversubscription) and converts the whole allocation into scheduler thrash
+      # that presents as saturation. THREADS_HTTP keeps /health answerable under full compute
+      # load. The Ollama chat lane above has the same derivation class engine-side with no env
+      # to pin it — tracked with #17073's family; its heavy producers are shaped in #17046.
+      LLAMA_ARG_THREADS: ${NEO_PROVIDER_LANE_EMBEDDING_THREADS:?embedding lane compute threads required (pin to the elected CPU allocation)}
+      LLAMA_ARG_THREADS_HTTP: "4"
       LLAMA_ARG_ENDPOINT_SLOTS: "true"
       NEO_PROVIDER_LANE_MODEL_URL: https://huggingface.co/Qwen/Qwen3-Embedding-8B-GGUF/resolve/69d0e58a13e463cd99a9b83e3f5fee7c10265fab/Qwen3-Embedding-8B-Q4_K_M.gguf
       NEO_PROVIDER_LANE_MODEL_SHA256: 3fcd3febec8b3fd64435204db75bf0dd73b91e8d0661e0331acfe7e7c3120b85
@@ -212,11 +226,18 @@ services:
     expose:
       - "8080"
     healthcheck:
-      test: ["CMD-SHELL", "curl --fail --silent http://127.0.0.1:8080/health >/dev/null && echo \"$$NEO_PROVIDER_LANE_MODEL_SHA256  /models/Qwen3-Embedding-8B-Q4_K_M.gguf\" | sha256sum -c - >/dev/null"]
-      interval: 15s
+      # Liveness only (#17063). The previous probe ALSO re-hashed the 4.7 GB weights every 15s
+      # with a 10s timeout inside the same CPU quota the engine computes in: under sustained
+      # load the hash starves past its deadline, the container flips unhealthy, and the
+      # recovery actuator answers with a restart that destroys the in-flight work causing the
+      # load. Integrity is enforced ONCE at the entrypoint, where a corrupt or partial download
+      # must be caught; a file that passed at boot does not change under a running container.
+      test: ["CMD-SHELL", "curl --fail --silent http://127.0.0.1:8080/health >/dev/null"]
+      interval: 30s
       timeout: 10s
-      retries: 40
-      start_period: 30s
+      retries: 5
+      # First boot downloads ~4.7 GB before the server starts; give it room.
+      start_period: 600s
     deploy:
       resources:
         limits:

--- a/ai/deploy/docker-compose.provider-lanes.yml
+++ b/ai/deploy/docker-compose.provider-lanes.yml
@@ -207,13 +207,15 @@ services:
       LLAMA_ARG_BATCH: ${NEO_PROVIDER_LANE_EMBEDDING_BATCH_TOKENS:?embedding logical batch required}
       LLAMA_ARG_UBATCH: ${NEO_PROVIDER_LANE_EMBEDDING_UBATCH_TOKENS:?embedding physical ubatch required}
       # Pin compute threads to the elected CPU allocation (#17073). llama.cpp's default (-1)
-      # resolves against HOST hardware concurrency, and a CPU *quota* (deploy.resources.limits.
-      # cpus) does not change that answer — only a cpuset would. Unpinned, a lane on a 64-core
-      # host runs ~64 spin-wait workers inside its quota (measured: 98 threads in a 6-cpu
-      # cgroup, ~10x oversubscription) and converts the whole allocation into scheduler thrash
-      # that presents as saturation. THREADS_HTTP keeps /health answerable under full compute
-      # load. The Ollama chat lane above has the same derivation class engine-side with no env
-      # to pin it — tracked with #17073's family; its heavy producers are shaped in #17046.
+      # resolves compute workers to the host's PHYSICAL cores (common_cpu_get_num_math) and the
+      # HTTP pool to max(n_parallel + 4, hardware_concurrency - 1) — a CPU *quota*
+      # (deploy.resources.limits.cpus) changes neither answer; only a cpuset would. Unpinned on
+      # the incident host (32-core/64-thread EPYC): ~32 compute workers + a 63-thread HTTP pool
+      # inside a 6-cpu quota (98 threads observed; ~5.3x compute oversubscription), converting
+      # the allocation into scheduler thrash that presents as saturation. THREADS_HTTP pins the
+      # HTTP pool small while keeping /health answerable under full compute load. The Ollama
+      # chat lane above has the same derivation class engine-side with no env to pin it —
+      # tracked with #17073's family; its heavy producers are shaped in #17046.
       LLAMA_ARG_THREADS: ${NEO_PROVIDER_LANE_EMBEDDING_THREADS:?embedding lane compute threads required (pin to the elected CPU allocation)}
       LLAMA_ARG_THREADS_HTTP: "4"
       LLAMA_ARG_ENDPOINT_SLOTS: "true"

--- a/ai/deploy/docker-compose.provider-lanes.yml
+++ b/ai/deploy/docker-compose.provider-lanes.yml
@@ -206,17 +206,23 @@ services:
       LLAMA_ARG_N_PARALLEL: ${NEO_PROVIDER_LANE_EMBEDDING_SLOTS:?embedding slots required}
       LLAMA_ARG_BATCH: ${NEO_PROVIDER_LANE_EMBEDDING_BATCH_TOKENS:?embedding logical batch required}
       LLAMA_ARG_UBATCH: ${NEO_PROVIDER_LANE_EMBEDDING_UBATCH_TOKENS:?embedding physical ubatch required}
-      # Pin compute threads to the elected CPU allocation (#17073). llama.cpp's default (-1)
-      # resolves compute workers to the host's PHYSICAL cores (common_cpu_get_num_math) and the
-      # HTTP pool to max(n_parallel + 4, hardware_concurrency - 1) — a CPU *quota*
+      # Pin compute threads to the elected CPU allocation (#17073) — the SAME value the election
+      # already produces, consumed twice (cpu limit below + threads here), so no new deployment
+      # input exists and the election actor's closed env export carries this unchanged. llama.cpp's
+      # default (-1) resolves compute workers to the host's PHYSICAL cores (common_cpu_get_num_math)
+      # and the HTTP pool to max(n_parallel + 4, hardware_concurrency - 1) — a CPU *quota*
       # (deploy.resources.limits.cpus) changes neither answer; only a cpuset would. Unpinned on
       # the incident host (32-core/64-thread EPYC): ~32 compute workers + a 63-thread HTTP pool
       # inside a 6-cpu quota (98 threads observed; ~5.3x compute oversubscription), converting
-      # the allocation into scheduler thrash that presents as saturation. THREADS_HTTP pins the
-      # HTTP pool small while keeping /health answerable under full compute load. The Ollama
-      # chat lane above has the same derivation class engine-side with no env to pin it —
-      # tracked with #17073's family; its heavy producers are shaped in #17046.
-      LLAMA_ARG_THREADS: ${NEO_PROVIDER_LANE_EMBEDDING_THREADS:?embedding lane compute threads required (pin to the elected CPU allocation)}
+      # the allocation into scheduler thrash that presents as saturation. The analyzer asserts
+      # threads === the elected allocation exactly (integer by the election contract; a fractional
+      # allocation fails the integer gate closed and forces an explicit decision). THREADS_HTTP
+      # pins the BASE fixed HTTP pool (this engine build can add dynamic HTTP workers under load —
+      # the pin removes the host-derived hw-1 default, it is not a hard total cap) while keeping
+      # /health answerable under full compute load. The Ollama chat lane above has the same
+      # derivation class engine-side with no env to pin it — tracked with #17073's family; its
+      # heavy producers are shaped in #17046.
+      LLAMA_ARG_THREADS: ${NEO_PROVIDER_LANE_EMBEDDING_CPUS:?embedding lane CPU allocation required}
       LLAMA_ARG_THREADS_HTTP: "4"
       LLAMA_ARG_ENDPOINT_SLOTS: "true"
       NEO_PROVIDER_LANE_MODEL_URL: https://huggingface.co/Qwen/Qwen3-Embedding-8B-GGUF/resolve/69d0e58a13e463cd99a9b83e3f5fee7c10265fab/Qwen3-Embedding-8B-Q4_K_M.gguf

--- a/ai/scripts/diagnostics/providerLaneComposition.mjs
+++ b/ai/scripts/diagnostics/providerLaneComposition.mjs
@@ -212,6 +212,11 @@ function parsedUrl(value) {
     }
 }
 
+function healthcheckText(service) {
+    const test = service?.healthcheck?.test;
+    return Array.isArray(test) ? test.join('\n') : String(test ?? '')
+}
+
 function commandText(service) {
     const command = service?.command;
     return Array.isArray(command) ? command.join('\n') : String(command || '')
@@ -577,6 +582,35 @@ export function analyzeProviderLaneComposition(composition, {
     fail(embeddingEnv.NEO_PROVIDER_LANE_MODEL_SHA256 === lanes.embedding.model.digest.replace(/^sha256:/, ''), 'embedding-model-digest-drift', 'services.embedding-model.environment.NEO_PROVIDER_LANE_MODEL_SHA256', lanes.embedding.model.digest.replace(/^sha256:/, ''), embeddingEnv.NEO_PROVIDER_LANE_MODEL_SHA256);
     fail(typeof embeddingEnv.NEO_PROVIDER_LANE_MODEL_URL === 'string' && lanes.embedding.model.coordinate.includes('@69d0e58a13e463cd99a9b83e3f5fee7c10265fab/') && embeddingEnv.NEO_PROVIDER_LANE_MODEL_URL.includes('/69d0e58a13e463cd99a9b83e3f5fee7c10265fab/'),
         'embedding-model-coordinate-drift', 'services.embedding-model.environment.NEO_PROVIDER_LANE_MODEL_URL', lanes.embedding.model.coordinate, embeddingEnv.NEO_PROVIDER_LANE_MODEL_URL);
+
+    // Steady-state probes must be liveness-only. Hashing multi-GB weights inside the
+    // lane's own CPU quota starves the probe under exactly the load it must tolerate, and the
+    // false unhealthy feeds the recovery actuator a restart that destroys in-flight work. The
+    // boot-time integrity checks stay asserted above via the entrypoint command assertions.
+    const chatProbe      = healthcheckText(chatService);
+    const embeddingProbe = healthcheckText(embeddingService);
+    fail(!chatProbe.includes('sha256sum'), 'chat-probe-heavy-integrity',
+        'services.chat-model.healthcheck.test', 'liveness probe free of weight/manifest hashing', chatProbe);
+    fail(!embeddingProbe.includes('sha256sum'), 'embedding-probe-heavy-integrity',
+        'services.embedding-model.healthcheck.test', 'liveness probe free of weight hashing', embeddingProbe);
+    fail(embeddingProbe.includes('/health'), 'embedding-probe-liveness-missing',
+        'services.embedding-model.healthcheck.test', 'curl /health liveness probe', embeddingProbe);
+
+    // Compute threads must be pinned to the elected CPU allocation. llama.cpp's -1
+    // default resolves against HOST hardware concurrency — a CPU quota does not change that
+    // answer — so an unpinned lane runs host-core-count spin workers inside its quota
+    // (measured: 98 threads in a 6-cpu cgroup, ~10x oversubscription presenting as saturation).
+    const embeddingThreads = integerAboveZero(embeddingEnv.LLAMA_ARG_THREADS);
+    fail(embeddingThreads !== null, 'embedding-threads-unpinned',
+        'services.embedding-model.environment.LLAMA_ARG_THREADS',
+        'positive integer pinned to the lane CPU allocation', embeddingEnv.LLAMA_ARG_THREADS ?? null);
+    if (embeddingThreads !== null) {
+        fail(embeddingThreads <= Math.ceil(lanes.embedding.cpuCores), 'embedding-threads-oversubscribed',
+            'services.embedding-model.environment.LLAMA_ARG_THREADS',
+            `<= ceil(lane cpuCores ${lanes.embedding.cpuCores})`, embeddingThreads);
+    }
+    fail(integerAboveZero(embeddingEnv.LLAMA_ARG_THREADS_HTTP) !== null, 'embedding-http-threads-unpinned',
+        'services.embedding-model.environment.LLAMA_ARG_THREADS_HTTP', 'positive integer', embeddingEnv.LLAMA_ARG_THREADS_HTTP ?? null);
 
     const applicationServices = ['kb-server', 'mc-server', 'orchestrator'];
     for (const serviceKey of applicationServices) {

--- a/ai/scripts/diagnostics/providerLaneComposition.mjs
+++ b/ai/scripts/diagnostics/providerLaneComposition.mjs
@@ -596,10 +596,11 @@ export function analyzeProviderLaneComposition(composition, {
     fail(embeddingProbe.includes('/health'), 'embedding-probe-liveness-missing',
         'services.embedding-model.healthcheck.test', 'curl /health liveness probe', embeddingProbe);
 
-    // Compute threads must be pinned to the elected CPU allocation. llama.cpp's -1
-    // default resolves against HOST hardware concurrency — a CPU quota does not change that
-    // answer — so an unpinned lane runs host-core-count spin workers inside its quota
-    // (measured: 98 threads in a 6-cpu cgroup, ~10x oversubscription presenting as saturation).
+    // Compute threads must be pinned to the elected CPU allocation. llama.cpp's -1 default
+    // resolves compute workers to the host's PHYSICAL cores and its HTTP pool to
+    // max(n_parallel + 4, hardware_concurrency - 1) — a CPU quota changes neither answer — so
+    // an unpinned lane runs host-sized pools inside its quota (observed: 98 threads in a 6-cpu
+    // cgroup on a 32c/64t host, ~5.3x compute oversubscription presenting as saturation).
     const embeddingThreads = integerAboveZero(embeddingEnv.LLAMA_ARG_THREADS);
     fail(embeddingThreads !== null, 'embedding-threads-unpinned',
         'services.embedding-model.environment.LLAMA_ARG_THREADS',

--- a/ai/scripts/diagnostics/providerLaneComposition.mjs
+++ b/ai/scripts/diagnostics/providerLaneComposition.mjs
@@ -20,6 +20,25 @@ const __dirname    = path.dirname(__filename);
 const PROJECT_ROOT = path.resolve(__dirname, '../../..');
 
 export const PROVIDER_LANE_COMPOSITION_SCHEMA_VERSION = 'provider-lane-composition.v1';
+
+/**
+ * @summary The exact steady-state liveness probe the embedding lane must run.
+ *
+ * Guard target for `embedding-probe-liveness-missing`: the analyzer asserts command equality,
+ * not token presence, so a probe that merely mentions the path (`true # /health`) cannot pass.
+ * @type {String}
+ */
+export const EMBEDDING_LIVENESS_PROBE_COMMAND = 'curl --fail --silent http://127.0.0.1:8080/health >/dev/null';
+
+/**
+ * @summary Upper bound for the embedding lane's pinned base HTTP pool.
+ *
+ * The engine's default derives the pool from host hardware (`hardware_concurrency - 1`); the
+ * bound refuses any host-sized value while leaving room above the canonical pin of 4. It bounds
+ * the configured BASE pool only — the engine may add dynamic HTTP workers under load.
+ * @type {Number}
+ */
+export const EMBEDDING_HTTP_THREADS_MAX = 8;
 export const PROVIDER_LANE_KEYS                        = Object.freeze(['chat', 'embedding']);
 export const PROVIDER_LANE_ROLE_KEYS                   = Object.freeze(['model', 'graph', 'kbAskSynthesis', 'embedding']);
 export const PROVIDER_LANE_SERVICE_KEYS                = Object.freeze({chat: 'chat-model', embedding: 'embedding-model'});
@@ -583,35 +602,49 @@ export function analyzeProviderLaneComposition(composition, {
     fail(typeof embeddingEnv.NEO_PROVIDER_LANE_MODEL_URL === 'string' && lanes.embedding.model.coordinate.includes('@69d0e58a13e463cd99a9b83e3f5fee7c10265fab/') && embeddingEnv.NEO_PROVIDER_LANE_MODEL_URL.includes('/69d0e58a13e463cd99a9b83e3f5fee7c10265fab/'),
         'embedding-model-coordinate-drift', 'services.embedding-model.environment.NEO_PROVIDER_LANE_MODEL_URL', lanes.embedding.model.coordinate, embeddingEnv.NEO_PROVIDER_LANE_MODEL_URL);
 
-    // Steady-state probes must be liveness-only. Hashing multi-GB weights inside the
-    // lane's own CPU quota starves the probe under exactly the load it must tolerate, and the
-    // false unhealthy feeds the recovery actuator a restart that destroys in-flight work. The
-    // boot-time integrity checks stay asserted above via the entrypoint command assertions.
-    const chatProbe      = healthcheckText(chatService);
-    const embeddingProbe = healthcheckText(embeddingService);
+    // Steady-state probes must be liveness-only, and the embedding probe must BE the canonical
+    // executable — token presence proves nothing (`true # /health` is not a probe). Hashing
+    // multi-GB weights inside the lane's own CPU quota starves the probe under exactly the load
+    // it must tolerate, and the false unhealthy feeds the recovery actuator a restart that
+    // destroys in-flight work. The boot-time integrity checks stay asserted above via the
+    // entrypoint command assertions.
+    const chatProbe          = healthcheckText(chatService);
+    const embeddingProbeTest = embeddingService?.healthcheck?.test;
     fail(!chatProbe.includes('sha256sum'), 'chat-probe-heavy-integrity',
         'services.chat-model.healthcheck.test', 'liveness probe free of weight/manifest hashing', chatProbe);
-    fail(!embeddingProbe.includes('sha256sum'), 'embedding-probe-heavy-integrity',
-        'services.embedding-model.healthcheck.test', 'liveness probe free of weight hashing', embeddingProbe);
-    fail(embeddingProbe.includes('/health'), 'embedding-probe-liveness-missing',
-        'services.embedding-model.healthcheck.test', 'curl /health liveness probe', embeddingProbe);
+    fail(!healthcheckText(embeddingService).includes('sha256sum'), 'embedding-probe-heavy-integrity',
+        'services.embedding-model.healthcheck.test', 'liveness probe free of weight hashing', healthcheckText(embeddingService));
+    fail(Array.isArray(embeddingProbeTest) && embeddingProbeTest.length === 2 &&
+        embeddingProbeTest[0] === 'CMD-SHELL' &&
+        embeddingProbeTest[1] === EMBEDDING_LIVENESS_PROBE_COMMAND,
+        'embedding-probe-liveness-missing', 'services.embedding-model.healthcheck.test',
+        ['CMD-SHELL', EMBEDDING_LIVENESS_PROBE_COMMAND], embeddingProbeTest ?? null);
 
-    // Compute threads must be pinned to the elected CPU allocation. llama.cpp's -1 default
-    // resolves compute workers to the host's PHYSICAL cores and its HTTP pool to
-    // max(n_parallel + 4, hardware_concurrency - 1) — a CPU quota changes neither answer — so
-    // an unpinned lane runs host-sized pools inside its quota (observed: 98 threads in a 6-cpu
-    // cgroup on a 32c/64t host, ~5.3x compute oversubscription presenting as saturation).
+    // Compute threads must equal the ELECTED CPU allocation exactly — the same closed deployment
+    // input the actor already exports, consumed twice. llama.cpp's -1 default resolves compute
+    // workers to the host's PHYSICAL cores and its HTTP pool to
+    // max(n_parallel + 4, hardware_concurrency - 1) — a CPU quota changes neither answer — so an
+    // unpinned lane runs host-sized pools inside its quota (observed: 98 threads in a 6-cpu
+    // cgroup on a 32c/64t host, ~5.3x compute oversubscription presenting as saturation). The
+    // HTTP value pins the base fixed pool (the engine may add dynamic HTTP workers; the bound
+    // exists to refuse host-derived defaults like hw-1, not to cap totals).
     const embeddingThreads = integerAboveZero(embeddingEnv.LLAMA_ARG_THREADS);
     fail(embeddingThreads !== null, 'embedding-threads-unpinned',
         'services.embedding-model.environment.LLAMA_ARG_THREADS',
-        'positive integer pinned to the lane CPU allocation', embeddingEnv.LLAMA_ARG_THREADS ?? null);
+        'integer equal to the elected CPU allocation', embeddingEnv.LLAMA_ARG_THREADS ?? null);
     if (embeddingThreads !== null) {
-        fail(embeddingThreads <= Math.ceil(lanes.embedding.cpuCores), 'embedding-threads-oversubscribed',
+        fail(embeddingThreads === lanes.embedding.cpuCores, 'embedding-threads-cpu-mismatch',
             'services.embedding-model.environment.LLAMA_ARG_THREADS',
-            `<= ceil(lane cpuCores ${lanes.embedding.cpuCores})`, embeddingThreads);
+            `=== elected lane cpuCores (${lanes.embedding.cpuCores})`, embeddingThreads);
     }
-    fail(integerAboveZero(embeddingEnv.LLAMA_ARG_THREADS_HTTP) !== null, 'embedding-http-threads-unpinned',
+    const embeddingHttpThreads = integerAboveZero(embeddingEnv.LLAMA_ARG_THREADS_HTTP);
+    fail(embeddingHttpThreads !== null, 'embedding-http-threads-unpinned',
         'services.embedding-model.environment.LLAMA_ARG_THREADS_HTTP', 'positive integer', embeddingEnv.LLAMA_ARG_THREADS_HTTP ?? null);
+    if (embeddingHttpThreads !== null) {
+        fail(embeddingHttpThreads <= EMBEDDING_HTTP_THREADS_MAX, 'embedding-http-threads-oversized',
+            'services.embedding-model.environment.LLAMA_ARG_THREADS_HTTP',
+            `<= ${EMBEDDING_HTTP_THREADS_MAX} (a host-derived pool like hw-1 must not pass)`, embeddingHttpThreads);
+    }
 
     const applicationServices = ['kb-server', 'mc-server', 'orchestrator'];
     for (const serviceKey of applicationServices) {

--- a/test/playwright/unit/ai/scripts/benchmark/ProviderLaneElectionRunner.spec.mjs
+++ b/test/playwright/unit/ai/scripts/benchmark/ProviderLaneElectionRunner.spec.mjs
@@ -55,8 +55,7 @@ function buildComposition(candidate) {
         NEO_PROVIDER_LANE_EMBEDDING_TOTAL_CONTEXT_TOKENS            : String(candidate * 8192),
         NEO_PROVIDER_LANE_EMBEDDING_CONTEXT_TOKENS_PER_SLOT_REQUIRED: '8192',
         NEO_PROVIDER_LANE_EMBEDDING_BATCH_TOKENS                    : String(candidate * 8192),
-        NEO_PROVIDER_LANE_EMBEDDING_UBATCH_TOKENS                   : String(candidate * 8192),
-        NEO_PROVIDER_LANE_EMBEDDING_THREADS                         : '2'
+        NEO_PROVIDER_LANE_EMBEDDING_UBATCH_TOKENS                   : String(candidate * 8192)
     };
     const source = fs.readFileSync(profilePath, 'utf8').replace(
         /\$\{([A-Z0-9_]+):\?[^}]+}/g,

--- a/test/playwright/unit/ai/scripts/benchmark/ProviderLaneElectionRunner.spec.mjs
+++ b/test/playwright/unit/ai/scripts/benchmark/ProviderLaneElectionRunner.spec.mjs
@@ -55,7 +55,8 @@ function buildComposition(candidate) {
         NEO_PROVIDER_LANE_EMBEDDING_TOTAL_CONTEXT_TOKENS            : String(candidate * 8192),
         NEO_PROVIDER_LANE_EMBEDDING_CONTEXT_TOKENS_PER_SLOT_REQUIRED: '8192',
         NEO_PROVIDER_LANE_EMBEDDING_BATCH_TOKENS                    : String(candidate * 8192),
-        NEO_PROVIDER_LANE_EMBEDDING_UBATCH_TOKENS                   : String(candidate * 8192)
+        NEO_PROVIDER_LANE_EMBEDDING_UBATCH_TOKENS                   : String(candidate * 8192),
+        NEO_PROVIDER_LANE_EMBEDDING_THREADS                         : '2'
     };
     const source = fs.readFileSync(profilePath, 'utf8').replace(
         /\$\{([A-Z0-9_]+):\?[^}]+}/g,

--- a/test/playwright/unit/ai/scripts/diagnostics/providerLaneComposition.spec.mjs
+++ b/test/playwright/unit/ai/scripts/diagnostics/providerLaneComposition.spec.mjs
@@ -24,7 +24,8 @@ const FIXTURE_ENV = Object.freeze({
     NEO_PROVIDER_LANE_EMBEDDING_TOTAL_CONTEXT_TOKENS            : '32768',
     NEO_PROVIDER_LANE_EMBEDDING_CONTEXT_TOKENS_PER_SLOT_REQUIRED: '8192',
     NEO_PROVIDER_LANE_EMBEDDING_BATCH_TOKENS                    : '32768',
-    NEO_PROVIDER_LANE_EMBEDDING_UBATCH_TOKENS                   : '32768'
+    NEO_PROVIDER_LANE_EMBEDDING_UBATCH_TOKENS                   : '32768',
+    NEO_PROVIDER_LANE_EMBEDDING_THREADS                         : '2'
 });
 
 function renderRequiredInputs(source) {
@@ -326,6 +327,42 @@ test.describe('provider-lane composition receipt (#17021)', () => {
         const receipt = analyzeProviderLaneComposition(composition);
         expect(receipt.ready).toBe(false);
         expect(errorCodes(receipt)).toContain('slots-endpoint-disabled')
+    });
+
+    test('a steady-state probe that hashes model weights is refused on either lane (#17063)', () => {
+        const hashedEmbedding = loadComposition();
+        hashedEmbedding.services['embedding-model'].healthcheck.test = [
+            'CMD-SHELL',
+            'curl --fail --silent http://127.0.0.1:8080/health >/dev/null && echo "x  /models/model.gguf" | sha256sum -c - >/dev/null'
+        ];
+        expect(errorCodes(analyzeProviderLaneComposition(hashedEmbedding))).toContain('embedding-probe-heavy-integrity');
+
+        const hashedChat = loadComposition();
+        hashedChat.services['chat-model'].healthcheck.test = [
+            'CMD-SHELL',
+            'ollama show "$NEO_PROVIDER_LANE_MODEL" >/dev/null && echo "x  manifest" | sha256sum -c - >/dev/null'
+        ];
+        expect(errorCodes(analyzeProviderLaneComposition(hashedChat))).toContain('chat-probe-heavy-integrity');
+
+        const nonLiveness = loadComposition();
+        nonLiveness.services['embedding-model'].healthcheck.test = ['CMD-SHELL', 'true'];
+        expect(errorCodes(analyzeProviderLaneComposition(nonLiveness))).toContain('embedding-probe-liveness-missing')
+    });
+
+    test('an embedding lane with unpinned or oversubscribed compute threads is refused (#17073)', () => {
+        const unpinned = loadComposition();
+        delete unpinned.services['embedding-model'].environment.LLAMA_ARG_THREADS;
+        const unpinnedReceipt = analyzeProviderLaneComposition(unpinned);
+        expect(unpinnedReceipt.ready).toBe(false);
+        expect(errorCodes(unpinnedReceipt)).toContain('embedding-threads-unpinned');
+
+        const oversubscribed = loadComposition();
+        oversubscribed.services['embedding-model'].environment.LLAMA_ARG_THREADS = '64';
+        expect(errorCodes(analyzeProviderLaneComposition(oversubscribed))).toContain('embedding-threads-oversubscribed');
+
+        const httpUnpinned = loadComposition();
+        delete httpUnpinned.services['embedding-model'].environment.LLAMA_ARG_THREADS_HTTP;
+        expect(errorCodes(analyzeProviderLaneComposition(httpUnpinned))).toContain('embedding-http-threads-unpinned')
     });
 
     test('the pure downstream validator rejects unknown and unready receipts without Compose', () => {

--- a/test/playwright/unit/ai/scripts/diagnostics/providerLaneComposition.spec.mjs
+++ b/test/playwright/unit/ai/scripts/diagnostics/providerLaneComposition.spec.mjs
@@ -4,6 +4,7 @@ import path               from 'node:path';
 import {load as loadYaml} from 'js-yaml';
 import {
     PROVIDER_LANE_COMPOSITION_SCHEMA_VERSION,
+    PROVIDER_LANE_DEPLOYMENT_INPUT_ENVS,
     analyzeProviderLaneComposition,
     parseArgs,
     validateProviderLaneCompositionReceipt
@@ -24,8 +25,7 @@ const FIXTURE_ENV = Object.freeze({
     NEO_PROVIDER_LANE_EMBEDDING_TOTAL_CONTEXT_TOKENS            : '32768',
     NEO_PROVIDER_LANE_EMBEDDING_CONTEXT_TOKENS_PER_SLOT_REQUIRED: '8192',
     NEO_PROVIDER_LANE_EMBEDDING_BATCH_TOKENS                    : '32768',
-    NEO_PROVIDER_LANE_EMBEDDING_UBATCH_TOKENS                   : '32768',
-    NEO_PROVIDER_LANE_EMBEDDING_THREADS                         : '2'
+    NEO_PROVIDER_LANE_EMBEDDING_UBATCH_TOKENS                   : '32768'
 });
 
 function renderRequiredInputs(source) {
@@ -342,27 +342,63 @@ test.describe('provider-lane composition receipt (#17021)', () => {
             'CMD-SHELL',
             'ollama show "$NEO_PROVIDER_LANE_MODEL" >/dev/null && echo "x  manifest" | sha256sum -c - >/dev/null'
         ];
-        expect(errorCodes(analyzeProviderLaneComposition(hashedChat))).toContain('chat-probe-heavy-integrity');
-
-        const nonLiveness = loadComposition();
-        nonLiveness.services['embedding-model'].healthcheck.test = ['CMD-SHELL', 'true'];
-        expect(errorCodes(analyzeProviderLaneComposition(nonLiveness))).toContain('embedding-probe-liveness-missing')
+        expect(errorCodes(analyzeProviderLaneComposition(hashedChat))).toContain('chat-probe-heavy-integrity')
     });
 
-    test('an embedding lane with unpinned or oversubscribed compute threads is refused (#17073)', () => {
+    test('the embedding liveness guard requires the exact executable probe, not token presence (#17063)', () => {
+        for (const fake of [
+            ['CMD-SHELL', 'true'],
+            ['CMD-SHELL', 'true # /health'],
+            ['CMD-SHELL', 'echo /health >/dev/null'],
+            ['CMD-SHELL', 'curl --fail --silent http://embedding-model:8080/health >/dev/null'],
+            ['CMD', 'curl', '--fail', '--silent', 'http://127.0.0.1:8080/health']
+        ]) {
+            const composition = loadComposition();
+            composition.services['embedding-model'].healthcheck.test = fake;
+            expect(errorCodes(analyzeProviderLaneComposition(composition)), JSON.stringify(fake))
+                .toContain('embedding-probe-liveness-missing')
+        }
+    });
+
+    test('embedding compute threads must equal the elected CPU allocation exactly (#17073)', () => {
         const unpinned = loadComposition();
         delete unpinned.services['embedding-model'].environment.LLAMA_ARG_THREADS;
         const unpinnedReceipt = analyzeProviderLaneComposition(unpinned);
         expect(unpinnedReceipt.ready).toBe(false);
         expect(errorCodes(unpinnedReceipt)).toContain('embedding-threads-unpinned');
 
-        const oversubscribed = loadComposition();
-        oversubscribed.services['embedding-model'].environment.LLAMA_ARG_THREADS = '64';
-        expect(errorCodes(analyzeProviderLaneComposition(oversubscribed))).toContain('embedding-threads-oversubscribed');
+        for (const mismatched of ['1', '3', '64']) {
+            const drifted = loadComposition();
+            drifted.services['embedding-model'].environment.LLAMA_ARG_THREADS = mismatched;
+            expect(errorCodes(analyzeProviderLaneComposition(drifted)), `threads=${mismatched}`)
+                .toContain('embedding-threads-cpu-mismatch')
+        }
 
+        const fractional = loadComposition();
+        fractional.services['embedding-model'].environment.LLAMA_ARG_THREADS = '2.5';
+        expect(errorCodes(analyzeProviderLaneComposition(fractional))).toContain('embedding-threads-unpinned')
+    });
+
+    test('the embedding HTTP base pool must be pinned and refuses host-derived sizes (#17073)', () => {
         const httpUnpinned = loadComposition();
         delete httpUnpinned.services['embedding-model'].environment.LLAMA_ARG_THREADS_HTTP;
-        expect(errorCodes(analyzeProviderLaneComposition(httpUnpinned))).toContain('embedding-http-threads-unpinned')
+        expect(errorCodes(analyzeProviderLaneComposition(httpUnpinned))).toContain('embedding-http-threads-unpinned');
+
+        const hostDerived = loadComposition();
+        hostDerived.services['embedding-model'].environment.LLAMA_ARG_THREADS_HTTP = '64';
+        expect(errorCodes(analyzeProviderLaneComposition(hostDerived))).toContain('embedding-http-threads-oversized')
+    });
+
+    test('the tracked profile renders from exactly the closed deployment-input set the election actor exports (#17073)', () => {
+        // The production actor exports ONLY `deploymentInputs` (env-file /dev/null): a required
+        // Compose value outside PROVIDER_LANE_DEPLOYMENT_INPUT_ENVS cannot reach a real render.
+        // This arm fails whenever the profile grows a `:?` input the canonical set does not carry
+        // (loadComposition() throws on any unmapped required var), so a fixture can no longer
+        // smuggle a value production never receives.
+        expect(Object.keys(FIXTURE_ENV).sort()).toEqual(Object.values(PROVIDER_LANE_DEPLOYMENT_INPUT_ENVS).sort());
+
+        const receipt = analyzeProviderLaneComposition(loadComposition());
+        expect(receipt.ready, JSON.stringify(receipt.errors, null, 2)).toBe(true)
     });
 
     test('the pure downstream validator rejects unknown and unready receipts without Compose', () => {


### PR DESCRIPTION
## What & Why

The canonical provider-lane template shipped two defects that froze a production CPU-only plane for weeks (epic neomjs/neo-agent-brain#38) and re-ship to every deployment that forks the file:

**1. Steady-state probes did heavy integrity work (#17063).** The embedding lane's healthcheck re-hashed the 4.7 GB GGUF every 15 s against a 10 s timeout, inside the same CPU quota the engine computes in. Under sustained load the hash starves past its deadline, the container flips unhealthy, and the recovery actuator answers with a restart that destroys the in-flight work causing the load — the incident plane logged six consecutive actuator restarts in two hours, every in-flight embed dying as `KB_VECTOR_EMBED_CONNECTION_REFUSED`. The chat lane carried the same class (manifest hash, smaller payload). Probes are now liveness-only on both lanes; integrity verification stays at the entrypoint, where a corrupt or partial download must be caught. Embedding probe cadence goes 15s/40-retries → 30s/5-retries, with `start_period: 600s` covering the first-boot download. **This PR `Refs` neomjs/neo#17063 rather than resolving it:** the ticket's runtime ACs (sustained-high-CPU probe survival, demonstrable corrupt-boot refusal on a live engine) need a docker-capable runner this head cannot provide — see Evidence.

**2. Compute threads were never pinned (#17073).** At the pinned build, an unset `LLAMA_ARG_THREADS` resolves compute workers to the host's **physical** cores (`common_cpu_get_num_math()` — ~32 on the incident host's 32c/64t EPYC), and the HTTP pool separately defaults to `max(n_parallel + 4, hardware_concurrency − 1)` (63 there); a CPU *quota* changes neither answer — only a cpuset would. The observed 98 threads decompose as ~32 compute + 63 HTTP + service threads: **~5.3× compute oversubscription** inside the 6-cpu quota, plus a needlessly host-sized HTTP pool *(decomposition per Euclid's source-cited peer review)*. **Fix (reshaped per Emmy's RA-1):** `LLAMA_ARG_THREADS` binds to the **already-elected** `NEO_PROVIDER_LANE_EMBEDDING_CPUS` — the same closed deployment input, consumed twice — so **no new deployment input exists**, the receipt shape and the election actor's closed env export are untouched *by construction*, and the production election path renders this head exactly as it rendered the previous one. `LLAMA_ARG_THREADS_HTTP: "4"` pins the **base** fixed HTTP pool (the engine may add dynamic HTTP workers under load; the pin removes the host-derived `hw−1` default, it is not a hard total cap).

## Mechanical guards

Both defect classes become analyzer errors in `providerLaneComposition.mjs`, on the existing `errors` channel — no receipt-shape change:

- `chat-probe-heavy-integrity` / `embedding-probe-heavy-integrity` — any `sha256sum` in a steady-state probe is refused;
- `embedding-probe-liveness-missing` — the embedding probe must **equal** the exported canonical executable (`EMBEDDING_LIVENESS_PROBE_COMMAND`), not merely mention `/health` — `true # /health` and `echo /health` cannot pass;
- `embedding-threads-unpinned` / `embedding-threads-cpu-mismatch` — threads must be an integer **exactly equal** to the elected lane `cpuCores` (a fractional allocation fails the integer gate closed);
- `embedding-http-threads-unpinned` / `embedding-http-threads-oversized` — the base HTTP pool must be pinned and ≤ `EMBEDDING_HTTP_THREADS_MAX` (8), so a host-derived `hw−1` value is refused.

## Test Evidence

Evidence: L2 (rendered-template + analyzer guards, unit-armed at exact head) → L3 required (#17063's runtime ACs: sustained-high-CPU probe survival within timeout + corrupt/partial-model boot refusal on a live engine). Residual: neomjs/neo#17063 AC-2/AC-3, Residual-Owner: neomjs/neo#17063 (open; annotated `[L3-deferred — needs a docker-capable runner]`; this PR delivers its template + guard half and does not close it).

- `npx playwright test -c test/playwright/playwright.config.unit.mjs test/playwright/unit/ai/scripts/diagnostics/providerLaneComposition.spec.mjs test/playwright/unit/ai/scripts/benchmark/ProviderLaneElectionRunner.spec.mjs test/playwright/unit/ai/scripts/benchmark/ProviderLaneElectionCore.spec.mjs --workers=1` → **67 passed**.
- **Production-shaped render falsifier (RA-1):** a new arm asserts the fixture env key set equals `Object.values(PROVIDER_LANE_DEPLOYMENT_INPUT_ENVS)` exactly and that the tracked profile renders `ready:true` from **only** that closed set — the set the election actor exports (`--env-file /dev/null`). Both spec fixtures' hand-injected thread values are **removed**; a future `:?` input outside the canonical set now fails this arm by construction.
- **Exact negative controls (RA-2):** five non-executable probe shapes (incl. `true # /health`, `echo /health`, wrong-host curl, non-CMD-SHELL form) → `embedding-probe-liveness-missing`; threads `1`/`3`/`64` → `embedding-threads-cpu-mismatch`; threads `2.5` → fail-closed; `THREADS_HTTP=64` → `embedding-http-threads-oversized`.
- Live-plane grounding: the 98-thread count, 12.8 s canary latencies, restart ledger, and failure codes were read from the affected deployment's own MCP surface on 2026-08-13/14; epic neomjs/neo-agent-brain#38 carries the full mechanism map and correction history.

## Deployment note

The affected external plane already runs the deployment-side mirror of both fixes in its own compose fork; this PR stops the canonical template from re-seeding the defects and adds the guards that catch the next fork's drift. That plane's `NEO_REVISION` pin advances to include this merge as part of the same rollout.

## Post-Merge Validation

- Rendering the provider-lanes profile still requires exactly the 12 canonical elected inputs — `docker compose config` fails closed on any omission (one-line check on any checkout).
- Merged ≠ running: the template's fixes reach planes only via image rebuild + redeploy. The affected external plane's rollout advances its `NEO_REVISION` to a post-merge SHA the same morning; production observables (healthcheck `deployedRevision`, engine thread count, probe cadence) are read from its MCP surface and recorded on epic neomjs/neo-agent-brain#38.
- neomjs/neo#17063's runtime receipts (sustained-load probe survival; corrupt-boot refusal) get produced on a docker-capable plane (canonical or parity) and attached to neomjs/neo#17063 before it closes.

## Deltas

- `ai/deploy/docker-compose.provider-lanes.yml` — both lane healthchecks go liveness-only (integrity stays at the entrypoints); embedding probe cadence 15s/40 → 30s/5 with `start_period` 600s; `LLAMA_ARG_THREADS: ${NEO_PROVIDER_LANE_EMBEDDING_CPUS:?…}` (elected authority, consumed twice — **no new deployment input**) + `LLAMA_ARG_THREADS_HTTP: "4"`; lane comments document quota-vs-cpuset derivation, the exact-equality contract, the base-pool (not total-cap) semantics, and the chat-lane gap.
- `ai/scripts/diagnostics/providerLaneComposition.mjs` — exported `EMBEDDING_LIVENESS_PROBE_COMMAND` + `EMBEDDING_HTTP_THREADS_MAX`; `healthcheckText` helper; seven bounded analyzer error codes on the existing `errors` channel; receipt shape byte-identical.
- `test/playwright/unit/ai/scripts/diagnostics/providerLaneComposition.spec.mjs` — closed-input render falsifier; exact-probe false-positive set; threads-equality + fractional fail-closed arms; HTTP-bound arms; fixture smuggle value removed.
- `test/playwright/unit/ai/scripts/benchmark/ProviderLaneElectionRunner.spec.mjs` — fixture smuggle value removed (candidates render from the canonical set alone).

Resolves neomjs/neo#17073
Refs neomjs/neo#17063
Refs neomjs/neo-agent-brain#38

Authored by Vega (Claude Fable 5, Claude Code). Session 4aa03beb-b1fd-4dad-a296-2789f39bb912.