### PR TITLE
feat(ai): reap provider-activity in-flight records past their class deadline (#17064)

### DIFF
--- a/ai/daemons/orchestrator/Orchestrator.mjs
+++ b/ai/daemons/orchestrator/Orchestrator.mjs
@@ -555,7 +555,10 @@ export class Orchestrator extends Base {
 
         if (!db) return {status: 'unavailable', unavailableReason: 'graph-database-unavailable'};
 
-        const projection = getProviderActivityMetrics(db, {
+        let projection;
+
+        try {
+            projection = getProviderActivityMetrics(db, {
                 limit,
                 now    : observedAt,
                 sinceTs,
@@ -567,11 +570,21 @@ export class Orchestrator extends Base {
                     chat     : memoryCoreConfig.sessionSummaryTimeoutMs,
                     embedding: memoryCoreConfig.ollama.embeddingTimeoutMs
                 }
-            }),
-              observer   = this.providerActivityStatusReader({
-                  dbPath: memoryCoreConfig.storagePaths.graph,
-                  sinceTs
-              });
+            });
+        } catch (error) {
+            // Reap-on-read makes this a WRITING read: a lock storm or corruption now throws where
+            // the path previously only read. Degradation in this method is explicit by contract —
+            // an escaped throw would propagate through `isOllamaResidualRestartStillAdmitted` as an
+            // unstructured error instead of an unavailable state that can never mean idle.
+            this.deploymentStateBridgeWriteLog?.('ERROR', `provider-activity projection read failed: ${error?.message || error}`);
+
+            return {status: 'unavailable', unavailableReason: 'provider-activity-read-failed'};
+        }
+
+        const observer = this.providerActivityStatusReader({
+            dbPath: memoryCoreConfig.storagePaths.graph,
+            sinceTs
+        });
 
         return {
             ...projection,

--- a/ai/daemons/orchestrator/Orchestrator.mjs
+++ b/ai/daemons/orchestrator/Orchestrator.mjs
@@ -555,7 +555,19 @@ export class Orchestrator extends Base {
 
         if (!db) return {status: 'unavailable', unavailableReason: 'graph-database-unavailable'};
 
-        const projection = getProviderActivityMetrics(db, {sinceTs, limit, now: observedAt}),
+        const projection = getProviderActivityMetrics(db, {
+                limit,
+                now    : observedAt,
+                sinceTs,
+                // Reap-on-read bounds, read at this use site because the shared ledger must not
+                // import AiConfig. Same values the Memory Core recorder injects: the widest deadline
+                // per role class this reader can cite. Unknown classes are never reaped — the ledger
+                // over-reports demand rather than blinding it.
+                activityDeadlineMs: {
+                    chat     : memoryCoreConfig.sessionSummaryTimeoutMs,
+                    embedding: memoryCoreConfig.ollama.embeddingTimeoutMs
+                }
+            }),
               observer   = this.providerActivityStatusReader({
                   dbPath: memoryCoreConfig.storagePaths.graph,
                   sinceTs

--- a/ai/daemons/orchestrator/services/DeploymentStateBridgeService.mjs
+++ b/ai/daemons/orchestrator/services/DeploymentStateBridgeService.mjs
@@ -937,10 +937,14 @@ export class DeploymentStateBridgeService extends Base {
             totalActivities           : null,
             totalInFlight             : null,
             totalRecentCompletions    : null,
+            totalReaped               : null,
             inFlightTruncated         : null,
             recentCompletionsTruncated: null,
+            reapedTruncated           : null,
+            reapedThisRead            : null,
             inFlight                  : null,
-            recentCompletions         : null
+            recentCompletions         : null,
+            reaped                    : null
         });
 
         if (typeof this.providerActivityProbe !== 'function') return unavailable('probe-unconfigured');

--- a/ai/mcp/server/memory-core/openapi.yaml
+++ b/ai/mcp/server/memory-core/openapi.yaml
@@ -2938,6 +2938,9 @@ components:
         - nativeAdmission
         - totalActivities
         - totalInFlight
+        - totalReaped
+        - reaped
+        - reapedThisRead
         - aggregates
         - inFlight
         - recentCompletions
@@ -2993,6 +2996,33 @@ components:
           type: integer
           minimum: 0
           description: Activities without a completion boundary inside the effective lookback window.
+        totalReaped:
+          type: integer
+          minimum: 0
+          description: >-
+            Records reaped as definitionally leaked (age past a factor of their own role-class
+            deadline). Retained evidence, never demand and never completions: reaped rows are
+            excluded from every in-flight count and `completed_at` stays null on them.
+        reaped:
+          type: array
+          description: Newest-first reaped activities with their typed dispositions.
+          items:
+            $ref: '#/components/schemas/ProviderActivityReaped'
+        reapedThisRead:
+          type: object
+          required: [abandoned, unsettled]
+          description: >-
+            Rows reaped during THIS read, per disposition. Zero on both when the caller supplied no
+            reap bounds — reaping only runs where the reader injects class deadlines.
+          properties:
+            abandoned:
+              type: integer
+              minimum: 0
+              description: Never-started rows reaped this read (reversible on a later start boundary).
+            unsettled:
+              type: integer
+              minimum: 0
+              description: Started rows reaped this read (terminal; the settle was definitionally lost).
         aggregates:
           type: array
           description: Low-cardinality stage/service/provider/model aggregates.
@@ -3072,6 +3102,44 @@ components:
         queueDisposition: {type: string, enum: [neo-queued, not-applicable, unknown]}
         queueWaitMs:      {type: integer, nullable: true, minimum: 0}
         elapsedMs:        {type: integer, minimum: 0}
+
+    ProviderActivityReaped:
+      type: object
+      required:
+        - activityId
+        - service
+        - operationStage
+        - role
+        - provider
+        - model
+        - priority
+        - enqueuedAt
+        - startedAt
+        - queueDisposition
+        - queueWaitMs
+        - reapedAt
+        - disposition
+        - ageMs
+      properties:
+        activityId:       {type: string}
+        service:          {type: string, enum: [knowledge-base, memory-core, dream-pipeline, orchestrator, unknown]}
+        operationStage:   {type: string, enum: [kb-query-embedding, kb-ask-synthesis, kb-tenant-ingestion-embedding, mc-wal-drain-embedding, mc-mini-summary, mc-session-summary, rem-tri-vector, rem-topology, embedding-canary, unknown]}
+        role:             {type: string, enum: [chat, embedding, unknown]}
+        provider:         {type: string, enum: [gemini, ollama, openAiCompatible, unknown]}
+        model:            {type: string, maxLength: 160}
+        priority:         {type: string, enum: [interactive, batch, unknown]}
+        enqueuedAt:       {type: string, format: date-time}
+        startedAt:        {type: string, format: date-time, nullable: true}
+        queueDisposition: {type: string, enum: [neo-queued, not-applicable, unknown]}
+        queueWaitMs:      {type: integer, nullable: true, minimum: 0}
+        reapedAt:         {type: string, format: date-time}
+        disposition:
+          type: string
+          enum: [abandoned, unsettled]
+          description: >-
+            `abandoned` = never started (reversible: a later start boundary resurrects the row);
+            `unsettled` = started past its class deadline with no completion (terminal).
+        ageMs:            {type: integer, minimum: 0}
 
     ProviderActivityCompletion:
       type: object

--- a/ai/services/memory-core/MemoryCoreRecorderService.mjs
+++ b/ai/services/memory-core/MemoryCoreRecorderService.mjs
@@ -105,11 +105,15 @@ function emptyProviderActivity(status) {
         totalActivities           : 0,
         totalInFlight             : 0,
         totalRecentCompletions    : 0,
+        totalReaped               : 0,
         inFlightTruncated         : false,
         recentCompletionsTruncated: false,
+        reapedTruncated           : false,
+        reapedThisRead            : {abandoned: 0, unsettled: 0},
         aggregates                : [],
         inFlight                  : [],
-        recentCompletions         : []
+        recentCompletions         : [],
+        reaped                    : []
     };
 }
 
@@ -703,7 +707,17 @@ class MemoryCoreRecorderService extends Base {
                 // Keyed by SERVICE::provider, and this reader declares a cap for its OWN service only.
                 // Another process's rows report `cap: null` rather than borrowing this ceiling — the
                 // Knowledge Base runs its own limiter and this reader has no authority over it.
-                nativeAdmissionCaps: {'memory-core::ollama': config.ollama.maxInFlightEmbeddings}
+                nativeAdmissionCaps: {'memory-core::ollama': config.ollama.maxInFlightEmbeddings},
+                // The reap bound DERIVES FROM THE ITEM'S OWN CLASS and is read here, at the use
+                // site, for the same reason the cap is: the shared ledger must not import AiConfig.
+                // Each value is the WIDEST deadline this reader can cite for the role — the
+                // embedding request ceiling, and the widest chat-call budget (`sessionSummary`).
+                // Cross-service rows are reaped with these bounds too; the reap factor dwarfs the
+                // inter-service deadline variance, and an unknown class is simply never reaped.
+                activityDeadlineMs: {
+                    chat     : config.sessionSummaryTimeoutMs,
+                    embedding: config.ollama.embeddingTimeoutMs
+                }
             });
         } catch (error) {
             logger.warn('[MemoryCoreRecorderService] Failed to read provider activity telemetry:', error.message);

--- a/ai/services/shared/providerActivityLedger.mjs
+++ b/ai/services/shared/providerActivityLedger.mjs
@@ -27,6 +27,23 @@ export const PROVIDER_ACTIVITY_STAGES = Object.freeze([
 export const PROVIDER_ACTIVITY_BUSY_TIMEOUT_MS = 50;
 
 /**
+ * @summary Multiplier on an activity's own role-class deadline before its in-flight row may be reaped.
+ *
+ * Reaping is NOT liveness inference: a dead writer's fresh row and a live writer's slow row are
+ * byte-identical to age alone, so age only earns a reap past `factor x deadline`, where
+ * the row is definitionally leaked regardless of who wrote it — every provider request carries a hard
+ * client-side `timeoutMs`, and the row settles when that promise settles, so a started row that
+ * outlives its class deadline by a wide margin has lost its settle by construction. The factor is the
+ * safety margin that keeps this true across services whose per-class deadlines differ (a reader reaps
+ * another service's rows with its own bounds; 4x dwarfs that variance) and across clock skew between
+ * writer and reader processes. Unknown roles and unsupplied classes are never reaped: when in doubt,
+ * the ledger over-reports demand rather than blinding it — fabricating idle is the unsafe direction
+ * for every recovery consumer of this projection.
+ * @type {Number}
+ */
+export const PROVIDER_ACTIVITY_REAP_FACTOR = 4;
+
+/**
  * @summary Runs one collection operation with source-owned provider attribution in async context.
  * @param {Object} activity Stable stage/service attribution.
  * @param {Function} task Collection-operation thunk.
@@ -121,7 +138,9 @@ export function ensureProviderActivitySchema(db) {
             queue_wait_ms     INTEGER,
             execution_ms      INTEGER,
             success           INTEGER,
-            failure_stage     TEXT
+            failure_stage     TEXT,
+            reaped_at         INTEGER,
+            reap_disposition  TEXT
         );
         CREATE INDEX IF NOT EXISTS idx_provider_activity_enqueued
             ON provider_activity_log(enqueued_at);
@@ -130,6 +149,17 @@ export function ensureProviderActivitySchema(db) {
         CREATE INDEX IF NOT EXISTS idx_provider_activity_stage
             ON provider_activity_log(operation_stage);
     `);
+
+    // Additive migration for tables created before reaping existed. Column order must match the
+    // CREATE above, so a migrated table and a fresh one are indistinguishable to readers.
+    const columns = db.prepare(`PRAGMA table_info(provider_activity_log)`).all().map(column => column.name);
+
+    if (!columns.includes('reaped_at')) {
+        db.exec(`ALTER TABLE provider_activity_log ADD COLUMN reaped_at INTEGER`);
+    }
+    if (!columns.includes('reap_disposition')) {
+        db.exec(`ALTER TABLE provider_activity_log ADD COLUMN reap_disposition TEXT`);
+    }
 }
 
 /**
@@ -177,6 +207,10 @@ export function beginProviderActivity(db, entry = {}) {
 
 /**
  * @summary Marks the provider execution boundary for an admitted queued activity.
+ *
+ * A start is positive proof of life, so it clears a prior `abandoned` reap: that disposition inferred
+ * "no live caller remains to dispatch this" from age alone, and the start refutes it. Clearing
+ * resurrects the row into the in-flight counts it truthfully belongs to.
  * @param {Object} db Open better-sqlite3 database.
  * @param {String} activityId Opaque activity id.
  * @param {Number} [startedAt=Date.now()] Provider-start timestamp.
@@ -191,7 +225,9 @@ export function startProviderActivity(db, activityId, startedAt = Date.now()) {
                queue_wait_ms = CASE
                    WHEN queue_disposition = 'neo-queued' THEN MAX(0, @startedAt - enqueued_at)
                    ELSE NULL
-               END
+               END,
+               reaped_at        = NULL,
+               reap_disposition = NULL
          WHERE activity_id = @activityId
            AND completed_at IS NULL
     `).run({activityId, startedAt});
@@ -220,6 +256,10 @@ export function refineProviderActivity(db, activityId, activity = {}) {
 
 /**
  * @summary Completes one provider activity lifecycle with bounded structural outcome data.
+ *
+ * A reaped row is terminal bookkeeping, not an in-flight request: its settle arriving after the reap
+ * is the lost settle finally landing, so the guard absorbs it — a reaped record is neither success
+ * nor failure and must never surface as a completion.
  * @param {Object} db Open better-sqlite3 database.
  * @param {String} activityId Opaque activity id.
  * @param {Object} outcome Completion data.
@@ -241,6 +281,7 @@ export function completeProviderActivity(db, activityId, outcome = {}) {
                failure_stage = @failureStage
          WHERE activity_id = @activityId
            AND completed_at IS NULL
+           AND reaped_at IS NULL
     `).run({
         activityId,
         completedAt,
@@ -342,18 +383,99 @@ export async function observeUnqueuedProviderActivity({task, recorder, activity 
 }
 
 /**
+ * @summary Reaps in-flight rows whose age exceeds their own role-class deadline by `factor`.
+ *
+ * Marks — never deletes — definitionally-leaked records so the live-demand projections stop counting
+ * them while the evidence stays queryable. Two dispositions, because the two leak shapes differ:
+ *
+ * - `unsettled` (started, never completed): the provider request carries a hard client-side
+ *   `timeoutMs` and the row settles when that promise settles, so a started row older than
+ *   `factor x deadline` has lost its settle by construction (process death, provider-side work
+ *   stranded past a client disconnect, a boundary crossed mid-flight). Terminal: a settle landing
+ *   after the reap is the lost settle, and `completeProviderActivity` absorbs it.
+ * - `abandoned` (never started): the abort path settles a live caller's queued row, so a queued row
+ *   older than `factor x deadline` is a lost settle with overwhelming probability — but a caller
+ *   without a cancellation signal in a starvation regime could still be legitimately waiting.
+ *   Reversible on proof of life: `startProviderActivity` clears the reap and the row rejoins the
+ *   counts.
+ *
+ * The bound derives from the item's own class — `deadlineMsByRole` maps the row's `role` to the
+ * widest deadline the CALLER can cite for that class from its own config (the embedding deadline is
+ * a shared leaf; chat deadlines vary by service and the factor absorbs the variance). Rows whose
+ * role has no supplied deadline, and `unknown` rows, are never reaped: when provenance is missing the
+ * ledger keeps counting, because fabricated idleness is the unsafe direction for recovery consumers.
+ *
+ * @param {Object} db Open better-sqlite3 database.
+ * @param {Object} options Reap bounds.
+ * @param {Object<String,Number>} [options.deadlineMsByRole=null] Role-class deadline map, e.g. `{embedding: 300000}`.
+ * @param {Number} [options.now=Date.now()] Observation epoch.
+ * @param {Number} [options.factor=PROVIDER_ACTIVITY_REAP_FACTOR] Deadline multiplier.
+ * @returns {{abandoned: Number, unsettled: Number}} Rows reaped by this call, per disposition.
+ */
+export function reapProviderActivity(db, {deadlineMsByRole = null, now = Date.now(), factor = PROVIDER_ACTIVITY_REAP_FACTOR} = {}) {
+    const reaped = {abandoned: 0, unsettled: 0};
+
+    if (!db || !deadlineMsByRole || !Number.isFinite(now)) return reaped;
+
+    const safeFactor = Number.isFinite(factor) && factor > 0 ? factor : PROVIDER_ACTIVITY_REAP_FACTOR;
+
+    for (const [role, deadlineMs] of Object.entries(deadlineMsByRole)) {
+        if (!ACTIVITY_ROLES.has(role) || role === 'unknown') continue;
+        if (!Number.isFinite(deadlineMs) || deadlineMs <= 0) continue;
+
+        const bound = deadlineMs * safeFactor;
+
+        reaped.unsettled += db.prepare(`
+            UPDATE provider_activity_log
+               SET reaped_at        = @now,
+                   reap_disposition = 'unsettled'
+             WHERE completed_at IS NULL
+               AND reaped_at    IS NULL
+               AND started_at   IS NOT NULL
+               AND role = @role
+               AND @now - started_at > @bound
+        `).run({now, role, bound}).changes;
+
+        reaped.abandoned += db.prepare(`
+            UPDATE provider_activity_log
+               SET reaped_at        = @now,
+                   reap_disposition = 'abandoned'
+             WHERE completed_at IS NULL
+               AND reaped_at    IS NULL
+               AND started_at   IS NULL
+               AND role = @role
+               AND @now - enqueued_at > @bound
+        `).run({now, role, bound}).changes;
+    }
+
+    return reaped;
+}
+
+/**
  * @summary Returns bounded aggregate, in-flight, and recent provider activity projections.
+ *
+ * When `activityDeadlineMs` is supplied the read reaps first (`reapProviderActivity`), so a snapshot
+ * never reports a count the ledger itself can see is stale — the reap cadence rides the existing
+ * poll/read paths rather than a dedicated timer. Reaped rows stay in the table and surface under
+ * `reaped` with their disposition; they are excluded from every in-flight count and are never
+ * reported as completions.
  * @param {Object} db Open better-sqlite3 database.
  * @param {Object} options Observer bounds.
+ * @param {Object<String,Number>} [options.activityDeadlineMs=null] Role-class deadline map enabling reap-on-read.
+ * @param {Number} [options.reapFactor=PROVIDER_ACTIVITY_REAP_FACTOR] Deadline multiplier for reap-on-read.
  * @returns {Object}
  */
-export function getProviderActivityMetrics(db, {sinceTs, limit, now = Date.now(), nativeAdmissionCaps = null} = {}) {
+export function getProviderActivityMetrics(db, {sinceTs, limit, now = Date.now(), nativeAdmissionCaps = null, activityDeadlineMs = null, reapFactor = PROVIDER_ACTIVITY_REAP_FACTOR} = {}) {
+    const reapedThisRead = activityDeadlineMs
+        ? reapProviderActivity(db, {deadlineMsByRole: activityDeadlineMs, now, factor: reapFactor})
+        : {abandoned: 0, unsettled: 0};
+
     const
         aggregates = db.prepare(`
             SELECT service, operation_stage, role, provider, model, priority, queue_disposition,
                    COUNT(*) AS calls,
                    SUM(CASE WHEN success = 0 THEN 1 ELSE 0 END) AS failures,
-                   SUM(CASE WHEN completed_at IS NULL THEN 1 ELSE 0 END) AS in_flight,
+                   SUM(CASE WHEN completed_at IS NULL AND reaped_at IS NULL THEN 1 ELSE 0 END) AS in_flight,
                    ROUND(AVG(queue_wait_ms), 2) AS avg_queue_wait_ms,
                    MAX(queue_wait_ms) AS max_queue_wait_ms,
                    ROUND(AVG(execution_ms), 2) AS avg_execution_ms,
@@ -373,11 +495,13 @@ export function getProviderActivityMetrics(db, {sinceTs, limit, now = Date.now()
         // In-flight work is bounded by `limit`, never by the historical lookback. A caller may narrow
         // `sinceTs` to recent completions, but an unresolved provider call older than that window is
         // still live demand. Filtering it out manufactures an "idle" provider from an active one — the
-        // unsafe direction for every recovery consumer of this projection.
+        // unsafe direction for every recovery consumer of this projection. REAPED rows are excluded:
+        // they are leaked bookkeeping, not demand.
         totalInFlight = db.prepare(`
             SELECT COUNT(*) AS total
               FROM provider_activity_log
              WHERE completed_at IS NULL
+               AND reaped_at    IS NULL
         `).get()?.total || 0,
         totalRecentCompletions = db.prepare(`
             SELECT COUNT(*) AS total
@@ -389,6 +513,7 @@ export function getProviderActivityMetrics(db, {sinceTs, limit, now = Date.now()
                    enqueued_at, started_at, queue_disposition, queue_wait_ms
               FROM provider_activity_log
              WHERE completed_at IS NULL
+               AND reaped_at    IS NULL
              ORDER BY enqueued_at ASC, activity_id ASC
              LIMIT @limit
         `).all({limit}),
@@ -400,7 +525,24 @@ export function getProviderActivityMetrics(db, {sinceTs, limit, now = Date.now()
              WHERE completed_at >= @sinceTs
              ORDER BY completed_at DESC, activity_id ASC
              LIMIT @limit
-        `).all({sinceTs, limit});
+        `).all({sinceTs, limit}),
+        // Reaped rows are retained evidence, not demand and not completions. `reaped_at` is Neo
+        // bookkeeping, so it deliberately does NOT feed `last_seen_at` — that field answers "when
+        // did the provider last see traffic", and a reap is not provider traffic.
+        totalReaped = db.prepare(`
+            SELECT COUNT(*) AS total
+              FROM provider_activity_log
+             WHERE reaped_at IS NOT NULL
+        `).get()?.total || 0,
+        reapedRows = db.prepare(`
+            SELECT activity_id, service, operation_stage, role, provider, model, priority,
+                   enqueued_at, started_at, queue_disposition, queue_wait_ms,
+                   reaped_at, reap_disposition
+              FROM provider_activity_log
+             WHERE reaped_at IS NOT NULL
+             ORDER BY reaped_at DESC, activity_id ASC
+             LIMIT @limit
+        `).all({limit});
 
     const projectBase = row => ({
         activityId      : row.activity_id,
@@ -446,7 +588,7 @@ export function getProviderActivityMetrics(db, {sinceTs, limit, now = Date.now()
                SUM(CASE WHEN started_at IS NULL THEN 1 ELSE 0 END) AS waiting,
                SUM(CASE WHEN started_at IS NOT NULL THEN 1 ELSE 0 END) AS executing
           FROM provider_activity_log
-         WHERE completed_at IS NULL AND queue_disposition = 'neo-queued'
+         WHERE completed_at IS NULL AND reaped_at IS NULL AND queue_disposition = 'neo-queued'
          GROUP BY service, provider
     `).all()) {
         nativeAdmission[`${row.service}::${row.provider}`] = {
@@ -478,8 +620,11 @@ export function getProviderActivityMetrics(db, {sinceTs, limit, now = Date.now()
         totalActivities,
         totalInFlight,
         totalRecentCompletions,
+        totalReaped,
         inFlightTruncated         : totalInFlight > inFlightRows.length,
         recentCompletionsTruncated: totalRecentCompletions > recentRows.length,
+        reapedTruncated           : totalReaped > reapedRows.length,
+        reapedThisRead,
         aggregates                : aggregates.map(row => ({
             service         : row.service,
             operationStage  : row.operation_stage,
@@ -507,6 +652,12 @@ export function getProviderActivityMetrics(db, {sinceTs, limit, now = Date.now()
             executionMs : row.execution_ms ?? null,
             success     : row.success === 1,
             failureStage: row.failure_stage ?? null
+        })),
+        reaped: reapedRows.map(row => ({
+            ...projectBase(row),
+            reapedAt   : new Date(row.reaped_at).toISOString(),
+            disposition: row.reap_disposition,
+            ageMs      : Math.max(0, now - row.enqueued_at)
         }))
     };
 }

--- a/test/playwright/unit/ai/daemons/orchestrator/Orchestrator.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/Orchestrator.spec.mjs
@@ -930,6 +930,33 @@ test.describe('Neo.ai.daemons.Orchestrator (#11009)', () => {
         }
     });
 
+    test('a throwing provider-activity projection degrades to explicit unavailable, never an escaped error', () => {
+        // Reap-on-read makes the projection a WRITING read, so a lock storm or corruption can now
+        // throw where the path previously only read. The method's contract is that every degraded
+        // state is explicit — and the effect-boundary consumer must read that as "not idle".
+        const orchestrator = createTestOrchestrator({kbSyncEnabled: false});
+
+        orchestrator.db = {
+            prepare() { throw new Error('database is locked') }
+        };
+        orchestrator.providerActivityTelemetryEnabledReader = () => true;
+        orchestrator.providerActivityStatusReader = () => ({status: 'ok'});
+
+        const projection = orchestrator.readProviderActivityProjection({
+            sinceTs   : 0,
+            limit     : 50,
+            observedAt: Date.now()
+        });
+
+        expect(projection).toEqual({
+            status           : 'unavailable',
+            unavailableReason: 'provider-activity-read-failed'
+        });
+        expect(() => orchestrator.isOllamaResidualRestartStillAdmitted()).not.toThrow();
+        expect(orchestrator.isOllamaResidualRestartStillAdmitted(),
+            'an unreadable projection is not proof of idleness').toBe(false);
+    });
+
     test('provider activity projection reads the container-plane boot database without heartbeat readiness', async () => {
         const orchestrator = createTestOrchestrator({kbSyncEnabled: false});
 

--- a/test/playwright/unit/ai/mcp/validation/OpenApiValidatorCompliance.spec.mjs
+++ b/test/playwright/unit/ai/mcp/validation/OpenApiValidatorCompliance.spec.mjs
@@ -583,6 +583,9 @@ test.describe('OpenApiValidator: strict-client JSON-Schema compliance', () => {
             'nativeAdmission',
             'totalActivities',
             'totalInFlight',
+            'totalReaped',
+            'reaped',
+            'reapedThisRead',
             'aggregates',
             'inFlight',
             'recentCompletions'
@@ -637,6 +640,26 @@ test.describe('OpenApiValidator: strict-client JSON-Schema compliance', () => {
         ]);
         expect(completion.properties.queueDisposition.enum).toContain('not-applicable');
         expect(completion.properties.queueWaitMs.nullable).toBe(true);
+
+        const reaped = doc.components.schemas.ProviderActivityReaped;
+
+        expect(Object.keys(reaped.properties)).toEqual([
+            'activityId',
+            'service',
+            'operationStage',
+            'role',
+            'provider',
+            'model',
+            'priority',
+            'enqueuedAt',
+            'startedAt',
+            'queueDisposition',
+            'queueWaitMs',
+            'reapedAt',
+            'disposition',
+            'ageMs'
+        ]);
+        expect(reaped.properties.disposition.enum).toEqual(['abandoned', 'unsettled']);
         expect(() => new Ajv({strict: false}).compile(schema)).not.toThrow();
     });
 

--- a/test/playwright/unit/ai/services/memory-core/MemoryCoreRecorderService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/MemoryCoreRecorderService.spec.mjs
@@ -690,11 +690,15 @@ test.describe('Neo.ai.services.memory-core.MemoryCoreRecorderService', () => {
                 totalActivities           : 0,
                 totalInFlight             : 0,
                 totalRecentCompletions    : 0,
+                totalReaped               : 0,
                 inFlightTruncated         : false,
                 recentCompletionsTruncated: false,
+                reapedTruncated           : false,
+                reapedThisRead            : {abandoned: 0, unsettled: 0},
                 aggregates                : [],
                 inFlight                  : [],
-                recentCompletions         : []
+                recentCompletions         : [],
+                reaped                    : []
             });
         } finally {
             MemoryCoreRecorderService.db = originalDb;
@@ -766,11 +770,15 @@ test.describe('Neo.ai.services.memory-core.MemoryCoreRecorderService', () => {
                 totalActivities           : 0,
                 totalInFlight             : 0,
                 totalRecentCompletions    : 0,
+                totalReaped               : 0,
                 inFlightTruncated         : false,
                 recentCompletionsTruncated: false,
+                reapedTruncated           : false,
+                reapedThisRead            : {abandoned: 0, unsettled: 0},
                 aggregates                : [],
                 inFlight                  : [],
-                recentCompletions         : []
+                recentCompletions         : [],
+                reaped                    : []
             });
         } finally {
             fs.renameSync(withheldFile, kbFile);

--- a/test/playwright/unit/ai/services/shared/providerActivityLedger.spec.mjs
+++ b/test/playwright/unit/ai/services/shared/providerActivityLedger.spec.mjs
@@ -123,7 +123,9 @@ test.describe('providerActivityLedger', () => {
             'queue_wait_ms',
             'execution_ms',
             'success',
-            'failure_stage'
+            'failure_stage',
+            'reaped_at',
+            'reap_disposition'
         ]);
         expect(JSON.stringify(rows)).not.toContain('secret prompt');
         expect(JSON.stringify(rows)).not.toContain('session-123');
@@ -375,5 +377,240 @@ test.describe('providerActivityLedger', () => {
         expect(nativeAdmission['knowledge-base::ollama'],
             "another process's demand is visible, but its cap is unknown to this reader"
         ).toEqual({service: 'knowledge-base', provider: 'ollama', cap: null, executing: 4, waiting: 0})
+    });
+
+    test.describe('#17064: class-deadline-derived reaping', () => {
+        // deadline 100ms x factor 4 = 400ms bound. Enqueue at 1000, start at 1100, so `now: 1501`
+        // is 1ms past the bound for a started row and `now: 1401` for a never-started one.
+
+        test('a started row past factor x its class deadline is reaped unsettled and leaves every demand count', () => {
+            const leakedId = beginProviderActivity(db, {
+                service   : 'knowledge-base', provider: 'ollama', role: 'embedding',
+                enqueuedAt: 1000, queueDisposition: 'neo-queued'
+            });
+
+            startProviderActivity(db, leakedId, 1100);
+
+            const metrics = getProviderActivityMetrics(db, {
+                sinceTs            : 0, limit: 50, now: 1501,
+                nativeAdmissionCaps: {'knowledge-base::ollama': 4},
+                activityDeadlineMs : {embedding: 100}
+            });
+
+            expect(metrics.reapedThisRead).toEqual({abandoned: 0, unsettled: 1});
+            expect(metrics.totalInFlight).toBe(0);
+            expect(metrics.nativeAdmission['knowledge-base::ollama'])
+                .toEqual({service: 'knowledge-base', provider: 'ollama', cap: 4, executing: 0, waiting: 0});
+            expect(metrics.totalReaped).toBe(1);
+            expect(metrics.reapedTruncated).toBe(false);
+            expect(metrics.reaped).toEqual([expect.objectContaining({
+                activityId : leakedId,
+                disposition: 'unsettled',
+                ageMs      : 501
+            })]);
+            expect(metrics.aggregates.find(row => row.provider === 'ollama')).toMatchObject({
+                calls   : 1,  // retained evidence — the call happened
+                inFlight: 0   // but it is not demand
+            });
+        });
+
+        test('a never-started row past the queue-wait bound is reaped abandoned and leaves waiting', () => {
+            const waitingId = beginProviderActivity(db, {
+                service   : 'memory-core', provider: 'ollama', role: 'embedding',
+                enqueuedAt: 1000, queueDisposition: 'neo-queued'
+            });
+
+            const metrics = getProviderActivityMetrics(db, {
+                sinceTs            : 0, limit: 50, now: 1401,
+                nativeAdmissionCaps: {'memory-core::ollama': 1},
+                activityDeadlineMs : {embedding: 100}
+            });
+
+            expect(metrics.reapedThisRead).toEqual({abandoned: 1, unsettled: 0});
+            expect(metrics.nativeAdmission['memory-core::ollama'])
+                .toEqual({service: 'memory-core', provider: 'ollama', cap: 1, executing: 0, waiting: 0});
+            expect(metrics.reaped).toEqual([expect.objectContaining({
+                activityId : waitingId,
+                disposition: 'abandoned',
+                startedAt  : null
+            })]);
+        });
+
+        test('NEGATIVE CONTROL: live-but-slow work inside its deadline is never reaped', () => {
+            // The cross-process non-vacuity constraint inside the deadline domain: age alone must
+            // not condemn a row whose own class deadline has not been outlived by the factor.
+            const slowId = beginProviderActivity(db, {
+                service   : 'memory-core', provider: 'ollama', role: 'embedding',
+                enqueuedAt: 1000, queueDisposition: 'neo-queued'
+            });
+
+            startProviderActivity(db, slowId, 1100);
+
+            const metrics = getProviderActivityMetrics(db, {
+                sinceTs           : 0, limit: 50, now: 1500, // exactly AT the bound: 400 elapsed, not past it
+                activityDeadlineMs: {embedding: 100}
+            });
+
+            expect(metrics.reapedThisRead).toEqual({abandoned: 0, unsettled: 0});
+            expect(metrics.totalInFlight).toBe(1);
+            expect(metrics.totalReaped).toBe(0);
+            expect(metrics.inFlight).toEqual([expect.objectContaining({activityId: slowId})]);
+        });
+
+        test('rows of an UNSUPPLIED or unknown class are never reaped — doubt keeps counting', () => {
+            const chatId = beginProviderActivity(db, {
+                service   : 'memory-core', provider: 'gemini', role: 'chat',
+                enqueuedAt: 1000, startedAt: 1000, queueDisposition: 'not-applicable'
+            });
+            const unknownId = beginProviderActivity(db, {
+                service   : 'unknown', provider: 'ollama', role: 'unknown',
+                enqueuedAt: 1000, queueDisposition: 'neo-queued'
+            });
+
+            const metrics = getProviderActivityMetrics(db, {
+                sinceTs           : 0, limit: 50, now: 9_999_999,
+                activityDeadlineMs: {embedding: 100} // no chat bound supplied
+            });
+
+            expect(metrics.reapedThisRead).toEqual({abandoned: 0, unsettled: 0});
+            expect(metrics.totalInFlight).toBe(2);
+            expect(metrics.inFlight.map(row => row.activityId).sort())
+                .toEqual([chatId, unknownId].sort());
+        });
+
+        test('without injected bounds nothing is reaped (back-compat read)', () => {
+            beginProviderActivity(db, {
+                service   : 'memory-core', provider: 'ollama', role: 'embedding',
+                enqueuedAt: 1000, startedAt: 1000, queueDisposition: 'neo-queued'
+            });
+
+            const metrics = getProviderActivityMetrics(db, {sinceTs: 0, limit: 50, now: 9_999_999});
+
+            expect(metrics.reapedThisRead).toEqual({abandoned: 0, unsettled: 0});
+            expect(metrics.totalInFlight).toBe(1);
+            expect(metrics.totalReaped).toBe(0);
+        });
+
+        test('a reaped record is terminal bookkeeping: never a completion, never success, never failure', () => {
+            const leakedId = beginProviderActivity(db, {
+                service   : 'memory-core', provider: 'ollama', role: 'embedding',
+                enqueuedAt: 1000, queueDisposition: 'neo-queued'
+            });
+
+            startProviderActivity(db, leakedId, 1100);
+            getProviderActivityMetrics(db, {sinceTs: 0, limit: 50, now: 1501, activityDeadlineMs: {embedding: 100}});
+
+            // The lost settle finally lands AFTER the reap — it must be absorbed.
+            completeProviderActivity(db, leakedId, {completedAt: 1600, success: true});
+
+            const stored  = db.prepare('SELECT * FROM provider_activity_log WHERE activity_id = ?').get(leakedId),
+                  metrics = getProviderActivityMetrics(db, {sinceTs: 0, limit: 50, now: 1700});
+
+            expect(stored.completed_at).toBeNull();
+            expect(stored.success).toBeNull();
+            expect(stored.reap_disposition).toBe('unsettled');
+            expect(metrics.recentCompletions).toEqual([]);
+            expect(metrics.aggregates[0]).toMatchObject({calls: 1, failures: 0, inFlight: 0});
+            // Evidence survives across readers that carry no reap bounds.
+            expect(metrics.totalReaped).toBe(1);
+            expect(metrics.reaped[0]).toMatchObject({activityId: leakedId, disposition: 'unsettled'});
+        });
+
+        test('a start boundary RESURRECTS an abandoned reap — proof of life supersedes the age inference', () => {
+            const waitingId = beginProviderActivity(db, {
+                service   : 'knowledge-base', provider: 'ollama', role: 'embedding',
+                enqueuedAt: 1000, queueDisposition: 'neo-queued'
+            });
+
+            getProviderActivityMetrics(db, {sinceTs: 0, limit: 50, now: 1401, activityDeadlineMs: {embedding: 100}});
+            expect(getProviderActivityMetrics(db, {sinceTs: 0, limit: 50, now: 1401}).totalReaped).toBe(1);
+
+            startProviderActivity(db, waitingId, 1402);
+
+            const metrics = getProviderActivityMetrics(db, {
+                sinceTs            : 0, limit: 50, now: 1403,
+                nativeAdmissionCaps: {'knowledge-base::ollama': 2}
+            });
+
+            expect(metrics.totalReaped).toBe(0);
+            expect(metrics.totalInFlight).toBe(1);
+            expect(metrics.nativeAdmission['knowledge-base::ollama'])
+                .toEqual({service: 'knowledge-base', provider: 'ollama', cap: 2, executing: 1, waiting: 0});
+            expect(metrics.inFlight[0]).toMatchObject({activityId: waitingId, queueWaitMs: 402});
+        });
+
+        test('AC-5: an abandoned provider keeps no residual executing count after the reap', () => {
+            // The incident shape: a role's provider was switched away, yet the ledger reported
+            // thirteen executing on the abandoned provider half a day later.
+            for (const n of [1, 2, 3]) {
+                const id = beginProviderActivity(db, {
+                    service   : 'knowledge-base', provider: 'ollama', role: 'embedding',
+                    enqueuedAt: 1000 + n, queueDisposition: 'neo-queued'
+                });
+
+                startProviderActivity(db, id, 1100);
+            }
+
+            const metrics = getProviderActivityMetrics(db, {
+                sinceTs            : 0, limit: 50, now: 1501,
+                nativeAdmissionCaps: {'knowledge-base::ollama': 4, 'knowledge-base::gemini': 4},
+                activityDeadlineMs : {embedding: 100}
+            });
+
+            expect(metrics.reapedThisRead).toEqual({abandoned: 0, unsettled: 3});
+            expect(metrics.nativeAdmission['knowledge-base::ollama'],
+                'the abandoned provider shows its cap with ZERO demand'
+            ).toEqual({service: 'knowledge-base', provider: 'ollama', cap: 4, executing: 0, waiting: 0});
+            expect(metrics.nativeAdmission['knowledge-base::gemini'])
+                .toEqual({service: 'knowledge-base', provider: 'gemini', cap: 4, executing: 0, waiting: 0});
+        });
+
+        test('existing tables gain the reap columns via migration and keep their rows', () => {
+            db.close();
+
+            db = new Database(':memory:');
+            db.exec(`
+                CREATE TABLE provider_activity_log (
+                    activity_id       TEXT PRIMARY KEY,
+                    service           TEXT NOT NULL,
+                    operation_stage   TEXT NOT NULL,
+                    role              TEXT NOT NULL,
+                    provider          TEXT NOT NULL,
+                    model             TEXT NOT NULL,
+                    priority          TEXT NOT NULL,
+                    enqueued_at       INTEGER NOT NULL,
+                    started_at        INTEGER,
+                    completed_at      INTEGER,
+                    queue_disposition TEXT NOT NULL,
+                    queue_wait_ms     INTEGER,
+                    execution_ms      INTEGER,
+                    success           INTEGER,
+                    failure_stage     TEXT
+                );
+                INSERT INTO provider_activity_log (
+                    activity_id, service, operation_stage, role, provider, model, priority,
+                    enqueued_at, started_at, queue_disposition
+                ) VALUES (
+                    'pre-migration-leak', 'memory-core', 'embedding-canary', 'embedding', 'ollama',
+                    'qwen3-embedding:latest', 'batch', 1000, 1100, 'neo-queued'
+                );
+            `);
+
+            ensureProviderActivitySchema(db);
+
+            const columns = db.prepare('PRAGMA table_info(provider_activity_log)').all().map(column => column.name);
+            expect(columns).toContain('reaped_at');
+            expect(columns).toContain('reap_disposition');
+
+            const metrics = getProviderActivityMetrics(db, {
+                sinceTs           : 0, limit: 50, now: 1501,
+                activityDeadlineMs: {embedding: 100}
+            });
+
+            expect(metrics.reaped).toEqual([expect.objectContaining({
+                activityId : 'pre-migration-leak',
+                disposition: 'unsettled'
+            })]);
+        });
     });
 });


### PR DESCRIPTION
Resolves neomjs/neo#17064

Provider-activity in-flight rows no longer live forever. `getProviderActivityMetrics` now reaps on read: a row whose age outlives its own role-class deadline by a factor (`PROVIDER_ACTIVITY_REAP_FACTOR = 4`) is marked with a typed disposition (`abandoned` = never started, `unsettled` = started, never completed), excluded from every in-flight / `nativeAdmission` count, and retained as queryable evidence under a new `reaped` projection with `totalReaped` / `reapedThisRead` / `reapedTruncated`. Reaped rows are never counted as completions (`completed_at` stays NULL; a late settle is absorbed). The bound is injected at the two existing read sites (Memory Core recorder metrics, orchestrator deployment-state bridge probe) from their own config leaves — the shared ledger stays AiConfig-free per its standing contract. Existing tables gain the two columns via a guarded additive migration.

This is the deadline-domain half of the phantom-row family: a row past 4x its own class deadline is definitionally leaked regardless of writer liveness, because every provider request carries a hard client-side `timeoutMs` and the row settles when that promise settles. The liveness half (prompt exclusion of a dead writer's fresh rows) remains Related: neomjs/neo-agent-brain#45 — no ownership filtering was introduced, so the cross-service visibility that ticket protects is preserved: unknown roles and unsupplied classes are never reaped, and doubt keeps counting rather than fabricating idle.

Evidence: L2 (real-SQLite arms driven through the production read path; unit sandbox) → L3 required (AC-1/AC-5's live-plane manifestation: an external plane's snapshot showing zero residual `executing` on an abandoned provider). Residual: live-plane observation is deploy-gated (merged is not deployed). Residual-Owner: neomjs/neo-agent-brain#38.

## Deltas from ticket

- **Fix-shape point 2 ("reap on a timer") is derived, not literal:** the reap rides the two existing read paths (bridge poll, recorder metrics read), which already supply the cadence; a dedicated timer process would duplicate cadence without adding signal, since unread rows corrupt nothing. Flagged for the ticket author's review.
- **The `abandoned` reap is reversible:** `startProviderActivity` clears the reap markers, because a start boundary is positive proof of life that supersedes an age inference — a caller without a cancellation signal in a starvation regime could otherwise be permanently reaped out of the counts. `unsettled` stays terminal per the ticket's "never re-counted as a completion".
- **Contract surface:** `ProviderActivityResponse` gains required `totalReaped` / `reaped` / `reapedThisRead` plus the `ProviderActivityReaped` schema (all present on every arm, matching the schema's own every-arm invariant); the bridge's `unavailable` arm gains matching null fields.
- `reaped_at` deliberately does not feed aggregate `lastSeenAt`: a reap is Neo bookkeeping, not provider traffic.
- **Post-review addition (cycle-1 non-blocking finding, kept in-PR per reviewer preference):** `Orchestrator.readProviderActivityProjection` now wraps the probe call in try/catch and returns `{status: 'unavailable', unavailableReason: 'provider-activity-read-failed'}` — reap-on-read made the previously read-only path a writing one, and the method's own contract is that every degradation is explicit and can never mean idle. Fail-safe direction preserved: the effect-boundary consumer reads it as not-admitted.

## Test Evidence

- `providerActivityLedger.spec.mjs`: 8 new `#17064` arms (unsettled reap, abandoned reap, negative control at the exact bound, unsupplied/unknown-class safety, back-compat no-bounds read, terminal-bookkeeping absorb, start-boundary resurrection, AC-5 provider-switch, pre-existing-table migration) + updated column pin — 20/20 green.
- `MemoryCoreRecorderService.spec.mjs`: exact-shape degraded arms extended for the new fields — green.
- `OpenApiValidatorCompliance.spec.mjs`: required-list + `ProviderActivityReaped` key/disposition assertions — green.
- `Orchestrator.spec.mjs` (92/92): includes the new throwing-probe arm — a locked/corrupt read degrades to explicit `unavailable`, and the effect-boundary admission consumer reads it as not-idle without an escaped throw.
- `DeploymentStateBridgeService.spec.mjs`, `ContainerHealthDiagnosisService.spec.mjs`: green (real-probe and unavailable-arm paths).
- Full `--project=unit-brain`: 10,472 passed, 2 failed — both ambient: `McpServersHealth` neural-link boot reproduces identically on a clean `dev` worktree; `MemoryService.Lifecycle` timer arm passes in isolation.
- `--project=unit-brain-orchestrator-daemon`: 23/23.
- Pre-commit gates green: whitespace, shorthand, aiconfig-test-mutation, atomic-write-shape, jsdoc-types, derived-domain, ticket-archaeology (after stripping `#N` refs from durable comments), block-alignment, openapi-service-parity.

## Post-Merge Validation

- [ ] After the next canonical-plane deploy, the deployment-state snapshot's `providerActivity` reports the historically-leaked rows under `reaped` with dispositions, and `nativeAdmission` shows no residual `executing` on the abandoned provider.
Residual-Owner: neomjs/neo-agent-brain#38

## Commits

- `5a0f09507f` — the reaping feature (schema, reaper, projections, both read-site injections, contract surface, specs)
- `59108e07d5` — orchestrator probe-read guard from cycle-1 review (structured `unavailable` on a throwing reap/read)

Authored by Phoebe (Kimi k3, opencode). Session d042176b-fba3-4eed-8f96-b376f2cc2113.

