### PR TITLE
fix(ai): reconcile uncertain Docker restarts (#17065)

### DIFF
--- a/ai/daemons/orchestrator/services/DeploymentRuntimeAccessService.mjs
+++ b/ai/daemons/orchestrator/services/DeploymentRuntimeAccessService.mjs
@@ -72,6 +72,24 @@ export function dockerSocketRequest({
     maxBytes = DEFAULT_RESPONSE_MAX_BYTES
 }) {
     return new Promise((resolve, reject) => {
+        let requestFinished     = false,
+            requestSocket       = null,
+            socketBytesAtAttach = 0;
+
+        const asTransportFailure = error => {
+            const wroteRequestBytes = requestSocket &&
+                Number.isFinite(requestSocket.bytesWritten) &&
+                requestSocket.bytesWritten > socketBytesAtAttach;
+
+            error.dockerTransportFailure = true;
+            // `finish` proves the full request reached Node's transport. A positive byte delta is
+            // deliberately weaker but still enough to make a negative effect claim unsafe: Docker
+            // may have received a partial or complete request before the socket failed.
+            error.requestDispatched = requestFinished || Boolean(wroteRequestBytes);
+
+            return error
+        };
+
         const req = http.request({
             socketPath,
             method,
@@ -107,10 +125,35 @@ export function dockerSocketRequest({
                     body      : responseBody
                 });
             });
+            res.on('aborted', () => {
+                const error = new Error(`Docker API ${method} ${path} response aborted before completion`);
+
+                error.code   = 'ECONNRESET';
+                error.reason = 'docker-api-response-aborted';
+
+                reject(asTransportFailure(error))
+            });
+            res.on('error', error => reject(asTransportFailure(error)));
         });
 
-        req.on('timeout', () => req.destroy(new Error(`Docker API ${method} ${path} timed out after ${timeoutMs}ms`)));
-        req.on('error', reject);
+        req.on('socket', socket => {
+            requestSocket       = socket;
+            socketBytesAtAttach = Number.isFinite(socket.bytesWritten) ? socket.bytesWritten : 0
+        });
+        // `finish` proves the complete request left Node's writable side. It does NOT prove Docker
+        // acknowledged or applied it — that is precisely why any later transport loss is uncertain.
+        req.on('finish', () => {
+            requestFinished = true
+        });
+        req.on('timeout', () => {
+            const error = new Error(`Docker API ${method} ${path} timed out after ${timeoutMs}ms`);
+
+            error.code   = 'ETIMEDOUT';
+            error.reason = 'docker-api-timeout';
+
+            req.destroy(asTransportFailure(error))
+        });
+        req.on('error', error => reject(asTransportFailure(error)));
 
         if (body !== null) {
             req.write(body);
@@ -209,6 +252,14 @@ export class DeploymentRuntimeAccessService extends Base {
     }
 
     /**
+     * @summary Declares support for the pre-dispatch durable restart interlock callback.
+     * @returns {Boolean}
+     */
+    get supportsRestartDispatchInterlock() {
+        return true
+    }
+
+    /**
      * Resolves the bounded response cap.
      * @returns {Number}
      */
@@ -263,9 +314,10 @@ export class DeploymentRuntimeAccessService extends Base {
      * keeps today's behaviour exactly.
      * @param {Function|null} [options.isEffectStillAdmitted=null] Live effect-admission oracle.
      * @param {String|null} [options.expectedContainerId=null] Diagnosed container incarnation.
+     * @param {Function|null} [options.onBeforeRestartDispatch=null] Durable restart-interlock writer.
      * @returns {Promise<Object>} Lifecycle result plus structured proof metadata.
      */
-    async applyLifecycle({serviceKey, operation = 'restart', reason = 'manual', restartTimeoutSeconds, memoryLimitBytes, isAuthorityHeld = null, isEffectStillAdmitted = null, expectedContainerId = null} = {}) {
+    async applyLifecycle({serviceKey, operation = 'restart', reason = 'manual', restartTimeoutSeconds, memoryLimitBytes, isAuthorityHeld = null, isEffectStillAdmitted = null, expectedContainerId = null, onBeforeRestartDispatch = null} = {}) {
         this.assertEnabled();
         this.assertMechanismSupported();
         this.assertOperationAllowed('lifecycle-write', operation);
@@ -313,7 +365,13 @@ export class DeploymentRuntimeAccessService extends Base {
         }
 
         if (operation === 'restart') {
-            return this.restartTarget(target, {reason, restartTimeoutSeconds});
+            return this.restartTarget(target, {
+                reason,
+                restartTimeoutSeconds,
+                isAuthorityHeld,
+                isEffectStillAdmitted,
+                onBeforeRestartDispatch
+            });
         }
 
         if (operation === 'update-memory-limit') {
@@ -770,14 +828,125 @@ export class DeploymentRuntimeAccessService extends Base {
      * @param {Object} options
      * @param {String} options.reason Audit reason.
      * @param {Number} [options.restartTimeoutSeconds] Docker restart timeout.
+     * @param {Function|null} [options.isAuthorityHeld=null] Current-authority oracle.
+     * @param {Function|null} [options.isEffectStillAdmitted=null] Live effect-admission oracle.
+     * @param {Function|null} [options.onBeforeRestartDispatch=null] Durable restart-interlock writer.
      * @returns {Promise<Object>}
      */
-    async restartTarget(target, {reason, restartTimeoutSeconds} = {}) {
-        const timeoutSeconds = restartTimeoutSeconds ?? this.configValues.defaultRestartTimeoutSeconds ?? 10,
-              response       = await this.dockerRequest({
-                  method: 'POST',
-                  path  : `/containers/${encodeURIComponent(target.containerId)}/restart?t=${encodeURIComponent(String(timeoutSeconds))}`
-              });
+    async restartTarget(target, {
+        reason,
+        restartTimeoutSeconds,
+        isAuthorityHeld = null,
+        isEffectStillAdmitted = null,
+        onBeforeRestartDispatch = null
+    } = {}) {
+        const timeoutSeconds  = restartTimeoutSeconds ?? this.configValues.defaultRestartTimeoutSeconds ?? 10,
+              requestMarginMs = this.timeoutMs;
+
+        if (!Number.isInteger(timeoutSeconds) || timeoutSeconds < 0) {
+            throw new TypeError('Docker restart timeout must be a non-negative integer number of seconds');
+        }
+        if (!Number.isFinite(requestMarginMs) || requestMarginMs <= 0) {
+            throw new TypeError('Docker runtime-access timeout margin must be a positive finite number of milliseconds');
+        }
+
+        const clientTimeoutMs = timeoutSeconds * 1000 + requestMarginMs;
+
+        if (!Number.isSafeInteger(clientTimeoutMs) || clientTimeoutMs <= timeoutSeconds * 1000) {
+            throw new TypeError('Docker restart client timeout must safely exceed the daemon stop budget');
+        }
+
+        const inspection  = await this.inspectTarget(target),
+              inspectedId = inspection.data?.Id || target.containerId,
+              baseline    = {
+                  containerId: inspectedId,
+                  startedAt  : normalizeDockerTime(inspection.data?.State?.StartedAt)
+              };
+
+        if (inspectedId !== target.containerId) {
+            throw createRuntimeAccessError({
+                reason : 'runtime-target-incarnation-changed',
+                message: `Container '${target.serviceKey}' changed from '${target.containerId}' to '${inspectedId}' before restart dispatch.`,
+                details: {serviceKey: target.serviceKey, operation: 'restart', expectedContainerId: target.containerId, actualContainerId: inspectedId}
+            });
+        }
+
+        // The baseline inspect above is awaited, so the guards in `applyLifecycle` are no longer at
+        // the last-owned boundary. Re-ask both immediately before the POST; no await separates these
+        // checks from the mutating request.
+        if (typeof isAuthorityHeld === 'function' && isAuthorityHeld() !== true) {
+            throw createRuntimeAccessError({
+                reason : 'runtime-authority-lost',
+                message: `Authority moved while preparing '${target.serviceKey}'; refusing the restart.`,
+                details: {serviceKey: target.serviceKey, operation: 'restart'}
+            });
+        }
+        if (typeof isEffectStillAdmitted === 'function' && isEffectStillAdmitted() !== true) {
+            throw createRuntimeAccessError({
+                reason : 'runtime-effect-not-admitted',
+                message: `Lifecycle write for '${target.serviceKey}' is no longer admitted by live evidence.`,
+                details: {serviceKey: target.serviceKey, operation: 'restart'}
+            });
+        }
+
+        if (typeof onBeforeRestartDispatch === 'function') {
+            await onBeforeRestartDispatch({
+                baseline,
+                clientTimeoutMs,
+                restartTimeoutSeconds: timeoutSeconds
+            })
+        }
+
+        // The durable marker above is awaited. Re-ask both guards so neither the marker write nor its
+        // filesystem latency opens a stale-holder / stale-admission window before the POST.
+        if (typeof isAuthorityHeld === 'function' && isAuthorityHeld() !== true) {
+            throw createRuntimeAccessError({
+                reason : 'runtime-authority-lost',
+                message: `Authority moved after preparing '${target.serviceKey}'; refusing the restart.`,
+                details: {serviceKey: target.serviceKey, operation: 'restart'}
+            });
+        }
+        if (typeof isEffectStillAdmitted === 'function' && isEffectStillAdmitted() !== true) {
+            throw createRuntimeAccessError({
+                reason : 'runtime-effect-not-admitted',
+                message: `Lifecycle write for '${target.serviceKey}' is no longer admitted after preparation.`,
+                details: {serviceKey: target.serviceKey, operation: 'restart'}
+            });
+        }
+
+        // Docker's `t` is the daemon-side graceful-stop budget. The HTTP client remains alive for
+        // that whole interval PLUS its validated ordinary request margin.
+        let response;
+
+        try {
+            response = await this.dockerRequest({
+                method   : 'POST',
+                path     : `/containers/${encodeURIComponent(target.containerId)}/restart?t=${encodeURIComponent(String(timeoutSeconds))}`,
+                timeoutMs: clientTimeoutMs
+            });
+        } catch (error) {
+            if (error?.dockerTransportFailure === true && error.requestDispatched === true) {
+                const uncertain = createRuntimeAccessError({
+                    reason : 'runtime-effect-disposition-uncertain',
+                    message: error.message,
+                    code   : error.code || 'ETIMEDOUT',
+                    details: {
+                        serviceKey           : target.serviceKey,
+                        operation            : 'restart',
+                        baseline,
+                        restartTimeoutSeconds: timeoutSeconds,
+                        clientTimeoutMs
+                    }
+                });
+
+                uncertain.effectDisposition         = 'uncertain';
+                uncertain.restartObservationBaseline = baseline;
+
+                throw uncertain
+            }
+
+            throw error
+        }
 
         return {
             ok        : true,

--- a/ai/daemons/orchestrator/services/RecoveryActuatorService.mjs
+++ b/ai/daemons/orchestrator/services/RecoveryActuatorService.mjs
@@ -1,15 +1,18 @@
-import fs   from 'fs-extra';
-import path from 'path';
+import {randomUUID} from 'node:crypto';
+import fs           from 'fs-extra';
+import path         from 'path';
 
 import Base                             from '../../../../src/core/Base.mjs';
 import AiConfig                         from '../../../config.mjs';
 import {repairProviderRoleSetResidency} from '../../../services/graph/providerReadinessHelper.mjs';
 import {
+    ACTIVE_RECOVERY_RUN_RETENTION_CLASS,
     appendRecoveryRunState,
     createRecoveryDiagnosisEvent,
     createRecoveryReobserveRequest,
     createRecoveryRunStateEntry,
-    createRecoveryTargetIdentity
+    createRecoveryTargetIdentity,
+    readActiveRecoveryRunStates
 } from '../../../services/memory-core/helpers/recoveryRunStateStore.mjs';
 import {
     appendHealEvent,
@@ -27,8 +30,9 @@ import {
 } from '../../../services/memory-core/helpers/recoveryKnobRegistry.mjs';
 import {isStoreBackedService} from './ContainerHealthDiagnosisService.mjs';
 
-const DEFAULT_ACTIONS        = Object.freeze(['reconfigure', 'restart', 'redeploy', 'warm-provider', 'raise-ceiling']);
-const DEFAULT_DEPLOY_TARGETS = Object.freeze(['cloud-deploy']);
+const DEFAULT_ACTIONS         = Object.freeze(['reconfigure', 'restart', 'redeploy', 'warm-provider', 'raise-ceiling']);
+const DEFAULT_DEPLOY_TARGETS  = Object.freeze(['cloud-deploy']);
+const COMPOSE_RESTART_ACTIONS = Object.freeze(['reconfigure', 'restart']);
 
 /**
  * @summary Normalizes string/object recovery-target entries into stable descriptors.
@@ -322,8 +326,27 @@ export class RecoveryActuatorService extends Base {
             return this.rejectAction({serviceKey, action, now, reasonCode: 'action-not-allowed-for-target', target});
         }
 
-        const attempts = await this.readHealAttempts(),
-              gate     = this.evaluateEnvelope({attempts, serviceKey, action, now});
+        const composeRestartAction = target.kind === 'compose-service' &&
+            COMPOSE_RESTART_ACTIONS.includes(action);
+
+        if (composeRestartAction) {
+            const pendingRestart = await this.readPendingRestartRun({serviceKey, target});
+
+            if (pendingRestart) {
+                return this.reconcileUncertainRestart({
+                    pending: pendingRestart,
+                    serviceKey,
+                    action : pendingRestart.details?.action || action,
+                    target,
+                    now,
+                    isAuthorityHeld
+                });
+            }
+        }
+
+        const attempts = await this.readHealAttempts();
+
+        const gate = this.evaluateEnvelope({attempts, serviceKey, action, now});
 
         // REVALIDATED HERE, after the awaited preparation above and before ANY write — not by the
         // caller before `apply` was entered. `readHealAttempts` is I/O, so a caller that checked
@@ -391,10 +414,74 @@ export class RecoveryActuatorService extends Base {
             };
         }
 
-        const startedAt = now;
+        const startedAt   = now,
+              diagnosis   = this.resolveDiagnosisEvent({diagnosisEvent, action, target, now: startedAt}),
+              nextAttempt = gate.attempt + 1,
+              runId       = this.getRecoveryRunId({recoveryRunId, serviceKey, action, startedAt});
+
+        let restartDispatchMarker = null;
+
+        const onBeforeRestartDispatch = composeRestartAction &&
+            this.deploymentRuntimeAccessService?.supportsRestartDispatchInterlock === true
+            ? async ({baseline, clientTimeoutMs, restartTimeoutSeconds}) => {
+                  const requestedAt      = Date.now(),
+                        nextBackoffAt    = this.computeBackoffUntil({attempt: nextAttempt, now: requestedAt}),
+                        reobserveRequest = createRecoveryReobserveRequest({
+                            recoveryRunId : runId,
+                            diagnosisEvent: diagnosis,
+                            requestedAt,
+                            // A successor must not judge an in-flight Docker call before the
+                            // observer's own response window has elapsed.
+                            cooldownMs                 : Math.max(this.getVerifyCooldownMs(), clientTimeoutMs),
+                            healthyObservationThreshold: this.getHealthyObservationThreshold(),
+                            reason                     : 'effect-disposition-uncertain'
+                        }),
+                        restartReobserve = {
+                            schemaVersion : 1,
+                            diagnosisEvent: diagnosis,
+                            baseline,
+                            restartTimeoutSeconds,
+                            clientTimeoutMs
+                        },
+                        entry = createRecoveryRunStateEntry({
+                            recoveryRunId : runId,
+                            diagnosisEvent: diagnosis,
+                            rung          : this.getRungForTarget(target),
+                            attempt       : nextAttempt,
+                            status        : 'pending',
+                            startedAt,
+                            updatedAt     : requestedAt,
+                            completedAt   : null,
+                            backoffUntil  : nextBackoffAt,
+                            reobserveRequest,
+                            details       : {
+                                status           : 'pending',
+                                reasonCode       : 'restart-dispatch-pending',
+                                retentionClass   : ACTIVE_RECOVERY_RUN_RETENTION_CLASS,
+                                serviceKey,
+                                action,
+                                targetIdentity   : createRecoveryTargetIdentity({kind: target.kind, id: target.id}),
+                                effectDisposition: 'uncertain',
+                                restartReobserve
+                            }
+                        });
+
+                  // This is the durable interlock, not post-hoc audit. It lands before the POST and
+                  // is read by every successor. If authority moves while it is being written, the
+                  // store refuses and the runtime never dispatches.
+                  await this.appendRecoveryRunEntry(entry, {
+                      isAuthorityHeld,
+                      preserveOnAuthorityLoss: false
+                  });
+
+                  restartDispatchMarker = {reobserveRequest, restartReobserve}
+              }
+            : null;
+
+        let result;
 
         try {
-            const result = await this.executeTargetAction({
+            result = await this.executeTargetAction({
                 target,
                 action,
                 knob,
@@ -402,75 +489,8 @@ export class RecoveryActuatorService extends Base {
                 reason,
                 isAuthorityHeld,
                 isEffectStillAdmitted,
-                expectedContainerId
-            });
-
-            const updatedAt     = Date.now(),
-                  diagnosis     = this.resolveDiagnosisEvent({diagnosisEvent, action, target, now: startedAt}),
-                  nextAttempt   = gate.attempt + 1,
-                  nextBackoffAt = this.computeBackoffUntil({attempt: nextAttempt, now: updatedAt});
-
-            // POST-EFFECT, and the two shared surfaces get OPPOSITE treatment on purpose — this is the
-            // distinction four review cycles converged on, and collapsing it either way is wrong.
-            //
-            // `heal-attempts.json` is MUTABLE state the successor reads to make its own anti-thrash
-            // decisions. A displaced holder writing it corrupts a decision that is no longer its to
-            // make, so it is skipped outright.
-            //
-            // The recovery-run ledger is APPEND-ONLY audit. The action genuinely landed — refusing to
-            // record it would erase the only evidence that a restart happened, which is worse than a
-            // marked record. So it is written WITH provenance: `authorityLostAfterEffect` says this
-            // entry was produced by a holder that had been displaced by the time it wrote, which is
-            // exactly the "capability-bound receipt with explicit provenance" shape rather than an
-            // unbound post-loss success claim.
-            const heldAfterEffect = typeof isAuthorityHeld !== 'function' || isAuthorityHeld() === true;
-
-            if (heldAfterEffect) {
-                this.persistAttempt({
-                    attempts,
-                    serviceKey,
-                    action,
-                    attempt     : nextAttempt,
-                    backoffUntil: nextBackoffAt,
-                    now         : updatedAt,
-                    status      : target.kind === 'deploy-target' ? 'recorded' : 'actioned'
-                });
-                await this.writeHealAttempts(attempts);
-            } else {
-                this.writeLog?.('WARN', `[RecoveryActuator] Authority moved during the ${serviceKey} ${action}; not writing the successor's heal-attempt state.`);
-            }
-
-            return this.finishAction({
-                action,
-                attempts,
-                attempt       : nextAttempt,
-                backoffUntil  : nextBackoffAt,
-                diagnosisEvent: diagnosis,
-                outcome       : {
-                    status        : target.kind === 'deploy-target' ? 'recorded' : 'actioned',
-                    serviceKey,
-                    action,
-                    targetIdentity: createRecoveryTargetIdentity({kind: target.kind, id: target.id}),
-                    // Provenance, not a status. The action landed; this says under what authority the
-                    // RECORD of it was written, so a successor reading the ledger can tell its own
-                    // entries from a displaced predecessor's without inferring from timestamps.
-                    ...(heldAfterEffect ? {} : {authorityLostAfterEffect: true}),
-                    runtimeAccess    : result.runtimeAccess || null,
-                    supervisor       : result.supervisor || null,
-                    recorded         : result.recorded || null,
-                    providerResidency: result.providerResidency || null,
-                    // The raise receipt (previous + new ceiling in bytes) rides into the durable
-                    // recovery-run ledger, which is what makes a raise attempt observable without
-                    // reading logs — the origin ticket's post-merge observability criterion.
-                    ceilingRaise     : result.ceilingRaise || null
-                },
-                recoveryRunId,
-                serviceKey,
-                startedAt,
-                target,
-                taskStatus: 'completed',
-                updatedAt,
-                isAuthorityHeld
+                expectedContainerId,
+                onBeforeRestartDispatch
             });
         } catch (error) {
             // A refusal by the runtime's own authority guard is NOT an executor failure, and collapsing
@@ -486,8 +506,10 @@ export class RecoveryActuatorService extends Base {
             // here with an ordinary transport error and was reported `declined` with no audit at
             // all. A possibly-landed restart was erased — and erased silently, which is worse than
             // a loud failure because nothing observes it.
-            if (error?.reason === 'runtime-authority-lost' || error?.reason === 'runtime-effect-not-admitted' ||
+            if (!restartDispatchMarker && (
+                error?.reason === 'runtime-authority-lost' || error?.reason === 'runtime-effect-not-admitted' ||
                 error?.reason === 'runtime-target-incarnation-changed'
+            )
             ) {
                 return {
                     status    : 'declined',
@@ -506,18 +528,33 @@ export class RecoveryActuatorService extends Base {
             // UNKNOWN, not absent. Represented on the existing `failed` terminal with structured
             // detail rather than a new terminal value: the action set is closed (ADR-0026 AC-9 — // ticket-ref-ok: the ADR is the authority forbidding a widened action set) and
             // an unknown outcome is a property of this run, not a new kind of run.
-            const authorityLostAfterDispatch = typeof isAuthorityHeld === 'function' && isAuthorityHeld() !== true;
+            const authorityLostAfterDispatch = typeof isAuthorityHeld === 'function' && isAuthorityHeld() !== true,
+                  preparedButNotDispatched   = Boolean(restartDispatchMarker) && [
+                      'runtime-authority-lost',
+                      'runtime-effect-not-admitted',
+                      'runtime-target-incarnation-changed'
+                  ].includes(error?.reason);
 
-            const updatedAt     = Date.now(),
-                  diagnosis     = this.resolveDiagnosisEvent({diagnosisEvent, action, target, now: startedAt}),
-                  nextAttempt   = gate.attempt + 1,
-                  nextBackoffAt = this.computeBackoffUntil({attempt: nextAttempt, now: updatedAt});
+            const updatedAt        = Date.now(),
+                  nextBackoffAt    = this.computeBackoffUntil({attempt: nextAttempt, now: updatedAt}),
+                  uncertainRestart = composeRestartAction &&
+                      error?.effectDisposition === 'uncertain' && error?.restartObservationBaseline,
+                  reobserveRequest = uncertainRestart
+                      ? restartDispatchMarker?.reobserveRequest || createRecoveryReobserveRequest({
+                            recoveryRunId              : runId,
+                            diagnosisEvent             : diagnosis,
+                            requestedAt                : updatedAt,
+                            cooldownMs                 : this.getVerifyCooldownMs(),
+                            healthyObservationThreshold: this.getHealthyObservationThreshold(),
+                            reason                     : 'effect-disposition-uncertain'
+                        })
+                      : undefined;
 
             // The append-only audit below is written in BOTH cases; the mutable shared state is not.
             // A displaced holder must not charge an attempt against a budget the successor now owns
             // — that is the same reasoning the pre-effect refusal uses — but the record of a
             // possibly-landed effect belongs to the ledger regardless of who holds the lease now.
-            if (!authorityLostAfterDispatch) {
+            if (!authorityLostAfterDispatch && !preparedButNotDispatched) {
                 this.persistAttempt({
                     attempts,
                     serviceKey,
@@ -527,7 +564,8 @@ export class RecoveryActuatorService extends Base {
                     now         : updatedAt,
                     status      : 'failed'
                 });
-                await this.writeHealAttempts(attempts);
+
+                await this.writeHealAttempts(attempts, {isAuthorityHeld});
             }
 
             return this.finishAction({
@@ -537,11 +575,15 @@ export class RecoveryActuatorService extends Base {
                 backoffUntil  : nextBackoffAt,
                 diagnosisEvent: diagnosis,
                 outcome       : {
-                    status    : 'failed',
-                    reasonCode: error?.reason === 'runtime-effect-partially-applied'
+                    status    : preparedButNotDispatched ? 'declined' : 'failed',
+                    reasonCode: preparedButNotDispatched
+                        ? 'restart-effect-not-dispatched'
+                        : error?.reason === 'runtime-effect-partially-applied'
                         ? 'effect-no-longer-admitted-after-partial'
                         : error?.reason === 'runtime-effect-disposition-uncertain'
-                            ? 'effect-no-longer-admitted-after-uncertain-attempt'
+                            ? (error?.restartObservationBaseline
+                                ? 'restart-effect-disposition-uncertain'
+                                : 'effect-no-longer-admitted-after-uncertain-attempt')
                             : 'executor-failed',
                     serviceKey,
                     action,
@@ -550,20 +592,92 @@ export class RecoveryActuatorService extends Base {
                     // `not-applied` is a claim; `uncertain` is the absence of one. A reader that
                     // cannot tell them apart will assume the effect did not happen, which is the
                     // assumption that makes a duplicate restart look safe.
-                    effectDisposition         : error?.effectDisposition ||
-                        (authorityLostAfterDispatch ? 'uncertain' : 'not-applied'),
+                    effectDisposition         : preparedButNotDispatched
+                        ? 'not-applied'
+                        : error?.effectDisposition || (authorityLostAfterDispatch ? 'uncertain' : 'not-applied'),
+                    ...(error?.restartObservationBaseline
+                        ? {
+                            restartObservationBaseline: error.restartObservationBaseline,
+                            restartReobserve          : {
+                                schemaVersion        : 1,
+                                diagnosisEvent       : diagnosis,
+                                baseline             : error.restartObservationBaseline,
+                                restartTimeoutSeconds: restartDispatchMarker?.restartReobserve?.restartTimeoutSeconds ?? null,
+                                clientTimeoutMs      : restartDispatchMarker?.restartReobserve?.clientTimeoutMs ?? null
+                            }
+                        }
+                        : {}),
+                    ...(uncertainRestart
+                        ? {retentionClass: ACTIVE_RECOVERY_RUN_RETENTION_CLASS}
+                        : {}),
                     ...(error?.providerResidency ? {providerResidency: error.providerResidency} : {}),
                     authorityLostAfterDispatch
                 },
-                recoveryRunId,
+                recoveryRunId              : runId,
                 serviceKey,
                 startedAt,
                 target,
-                taskStatus: 'failed',
+                taskStatus                 : preparedButNotDispatched ? 'skipped' : 'failed',
                 updatedAt,
-                isAuthorityHeld
+                isAuthorityHeld,
+                reobserveRequest,
+                settlesPreDispatchInterlock: preparedButNotDispatched
             });
         }
+
+        // From this point onward the executor returned successfully. Persistence and audit failures
+        // are deliberately OUTSIDE the executor-classification catch above: no later bookkeeping
+        // failure may rewrite a known-applied effect as pre-dispatch `not-applied`. For production
+        // compose restarts, a failed mutable-state commit therefore leaves the pre-POST ledger
+        // interlock latest so a successor re-observes before any further POST.
+        const updatedAt       = Date.now(),
+              nextBackoffAt   = this.computeBackoffUntil({attempt: nextAttempt, now: updatedAt}),
+              heldAfterEffect = typeof isAuthorityHeld !== 'function' || isAuthorityHeld() === true;
+
+        // POST-EFFECT, and the two shared surfaces get OPPOSITE treatment on purpose. Mutable
+        // anti-thrash state is successor-owned and fenced; the append-only action audit survives a
+        // takeover with explicit provenance because the effect genuinely landed.
+        if (heldAfterEffect) {
+            this.persistAttempt({
+                attempts,
+                serviceKey,
+                action,
+                attempt     : nextAttempt,
+                backoffUntil: nextBackoffAt,
+                now         : updatedAt,
+                status      : target.kind === 'deploy-target' ? 'recorded' : 'actioned'
+            });
+            await this.writeHealAttempts(attempts, {isAuthorityHeld});
+        } else {
+            this.writeLog?.('WARN', `[RecoveryActuator] Authority moved during the ${serviceKey} ${action}; not writing the successor's heal-attempt state.`);
+        }
+
+        return this.finishAction({
+            action,
+            attempts,
+            attempt       : nextAttempt,
+            backoffUntil  : nextBackoffAt,
+            diagnosisEvent: diagnosis,
+            outcome       : {
+                status        : target.kind === 'deploy-target' ? 'recorded' : 'actioned',
+                serviceKey,
+                action,
+                targetIdentity: createRecoveryTargetIdentity({kind: target.kind, id: target.id}),
+                ...(heldAfterEffect ? {} : {authorityLostAfterEffect: true}),
+                runtimeAccess    : result.runtimeAccess || null,
+                supervisor       : result.supervisor || null,
+                recorded         : result.recorded || null,
+                providerResidency: result.providerResidency || null,
+                ceilingRaise     : result.ceilingRaise || null
+            },
+            recoveryRunId: runId,
+            serviceKey,
+            startedAt,
+            target,
+            taskStatus   : 'completed',
+            updatedAt,
+            isAuthorityHeld
+        });
     }
 
     /**
@@ -776,7 +890,7 @@ export class RecoveryActuatorService extends Base {
      * @param {Object} options
      * @returns {Promise<Object>}
      */
-    async reconfigureComposeService({target, knob, knobValues, reason, isAuthorityHeld = null}) {
+    async reconfigureComposeService({target, knob, knobValues, reason, isAuthorityHeld = null, onBeforeRestartDispatch = null}) {
         const context = {};
 
         for (const leafPath of requiredContextForKnob(knob)) {
@@ -806,7 +920,12 @@ export class RecoveryActuatorService extends Base {
         // check in `executeTargetAction` is no longer the last point we own before this container is
         // actually restarted — and `restartComposeService` already re-asserts after it resolves the
         // container, which is the boundary that matters.
-        const restart = await this.restartComposeService({target, reason, isAuthorityHeld});
+        const restart = await this.restartComposeService({
+            target,
+            reason,
+            isAuthorityHeld,
+            onBeforeRestartDispatch
+        });
 
         return {...restart, knob, overridePath}
     }
@@ -963,7 +1082,7 @@ export class RecoveryActuatorService extends Base {
      * @param {Object} options
      * @returns {Promise<Object>}
      */
-    async executeTargetAction({target, action, reason, knob, knobValues, isAuthorityHeld = null, isEffectStillAdmitted = null, expectedContainerId = null}) {
+    async executeTargetAction({target, action, reason, knob, knobValues, isAuthorityHeld = null, isEffectStillAdmitted = null, expectedContainerId = null, onBeforeRestartDispatch = null}) {
         // The last COMMON point before every effect kind dispatches — common in syntax, which is not
         // the same as last-owned in time. It fences an action whose effect begins immediately
         // (`warm-provider` awaits its repair as its first statement), and it is NOT sufficient for an
@@ -981,7 +1100,14 @@ export class RecoveryActuatorService extends Base {
         }
 
         if (action === 'reconfigure') {
-            return this.reconfigureComposeService({knob, knobValues, reason, target, isAuthorityHeld});
+            return this.reconfigureComposeService({
+                knob,
+                knobValues,
+                reason,
+                target,
+                isAuthorityHeld,
+                onBeforeRestartDispatch
+            });
         }
 
         if (action === 'raise-ceiling') {
@@ -994,7 +1120,8 @@ export class RecoveryActuatorService extends Base {
                 reason,
                 isAuthorityHeld,
                 isEffectStillAdmitted,
-                expectedContainerId
+                expectedContainerId,
+                onBeforeRestartDispatch
             });
         }
 
@@ -1035,7 +1162,7 @@ export class RecoveryActuatorService extends Base {
      * @param {Object} options
      * @returns {Promise<Object>}
      */
-    async restartComposeService({target, reason, isAuthorityHeld = null, isEffectStillAdmitted = null, expectedContainerId = null}) {
+    async restartComposeService({target, reason, isAuthorityHeld = null, isEffectStillAdmitted = null, expectedContainerId = null, onBeforeRestartDispatch = null}) {
         if (!this.deploymentRuntimeAccessService?.applyLifecycle) {
             throw new Error('Deployment runtime access service is unavailable');
         }
@@ -1050,7 +1177,8 @@ export class RecoveryActuatorService extends Base {
             // to loosen to `toMatchObject` and stop noticing unexpected arguments.
             ...(typeof isAuthorityHeld === 'function' ? {isAuthorityHeld} : {}),
             ...(typeof isEffectStillAdmitted === 'function' ? {isEffectStillAdmitted} : {}),
-            ...(typeof expectedContainerId === 'string' ? {expectedContainerId} : {})
+            ...(typeof expectedContainerId === 'string' ? {expectedContainerId} : {}),
+            ...(typeof onBeforeRestartDispatch === 'function' ? {onBeforeRestartDispatch} : {})
         });
 
         return {
@@ -1152,6 +1280,211 @@ export class RecoveryActuatorService extends Base {
     }
 
     /**
+     * @summary Reads the newest recovery-run state for a compose restart and returns it only while
+     * dispatch or effect settlement is unresolved.
+     *
+     * The append-only run ledger is the interlock because it survives process recreation, authority
+     * handoff, and ordinary audit pruning. Only retention-protected active rows are considered; a
+     * terminal append in the same run omits the class and atomically releases the guard.
+     *
+     * @param {Object} options
+     * @param {String} options.serviceKey Recovery service key.
+     * @param {Object} options.target Typed compose target.
+     * @returns {Promise<Object|null>} Pending latest run state, or null.
+     */
+    async readPendingRestartRun({serviceKey, target}) {
+        const entries = await readActiveRecoveryRunStates({
+                  dir           : this.recoveryRunStateDir,
+                  retentionClass: ACTIVE_RECOVERY_RUN_RETENTION_CLASS
+              }),
+              latest  = entries
+                  .filter(entry => (
+                      entry?.details?.serviceKey === serviceKey &&
+                      COMPOSE_RESTART_ACTIONS.includes(entry?.details?.action) &&
+                      entry?.targetIdentity?.kind === target.kind &&
+                      entry?.targetIdentity?.id === target.id
+                  ))
+                  .sort((left, right) => (right.updatedAt || 0) - (left.updatedAt || 0))[0] || null;
+
+        if (!latest) return null;
+
+        const dispatchPending = latest.status === 'pending' &&
+                  latest.details?.reasonCode === 'restart-dispatch-pending',
+              effectUncertain = latest.status === 'reobserve-requested' &&
+                  latest.reobserveRequest?.reason === 'effect-disposition-uncertain' &&
+                  latest.details?.reasonCode === 'restart-effect-disposition-uncertain';
+
+        return dispatchPending || effectUncertain ? latest : null
+    }
+
+    /**
+     * @summary Settles one durable uncertain Docker restart through fresh container inspection.
+     *
+     * No branch dispatches a restart. Before the requested cooldown, or while inspect evidence is
+     * unreadable/conflicting, the ledger interlock remains latest and the action defers. Only a
+     * positively moved `StartedAt` proves the effect landed; unchanged evidence remains uncertain.
+     * A replaced container supersedes the stale diagnosis without claiming service recovery.
+     *
+     * @param {Object} options
+     * @returns {Promise<Object>} Reconciliation outcome.
+     */
+    async reconcileUncertainRestart({pending, serviceKey, action, target, now, isAuthorityHeld = null}) {
+        const context     = pending.details?.restartReobserve || {},
+              request     = pending.reobserveRequest,
+              baseOutcome = {
+                  status           : 'deferred',
+                  serviceKey,
+                  action,
+                  targetIdentity   : createRecoveryTargetIdentity({kind: target.kind, id: target.id}),
+                  effectDisposition: 'uncertain',
+                  recoveryRunId    : pending.recoveryRunId,
+                  backoffUntil     : pending.backoffUntil || null,
+                  reobserveRequest : request
+              };
+
+        if (!request || !context.diagnosisEvent || !context.baseline) {
+            return {
+                ...baseOutcome,
+                reasonCode: 'restart-effect-reobserve-unreadable'
+            }
+        }
+
+        if (now < request.earliestObservationAt) {
+            return {
+                ...baseOutcome,
+                reasonCode: 'restart-effect-reobserve-pending'
+            }
+        }
+
+        let observation;
+
+        try {
+            observation = await this.deploymentRuntimeAccessService.readObserve({
+                serviceKey: target.id,
+                operation : 'inspect'
+            })
+        } catch (error) {
+            return {
+                ...baseOutcome,
+                reasonCode: 'restart-effect-reobserve-unreadable',
+                error     : error.message
+            }
+        }
+
+        if (typeof isAuthorityHeld === 'function' && isAuthorityHeld() !== true) {
+            return {
+                status        : 'declined',
+                reasonCode    : 'authority-lost',
+                serviceKey,
+                action,
+                targetIdentity: baseOutcome.targetIdentity
+            }
+        }
+
+        const baseline            = context.baseline,
+              observedContainerId = observation.proof?.target?.containerId || observation.data?.Id || null,
+              observedStartedAt   = normalizeObservedContainerTime(observation.data?.State?.StartedAt),
+              baselineStartedAt   = normalizeObservedContainerTime(baseline.startedAt),
+              reobservation       = {
+                  baseline,
+                  observed: {
+                      containerId: observedContainerId,
+                      startedAt  : observedStartedAt
+                  },
+                  runtimeAccess: observation.proof || null
+              };
+
+        if (!observedContainerId) {
+            return {
+                ...baseOutcome,
+                reasonCode : 'restart-effect-reobserve-unreadable',
+                reobservation
+            }
+        }
+
+        let outcome, taskStatus;
+
+        if (observedContainerId !== baseline.containerId) {
+            outcome = {
+                status           : 'recorded',
+                reasonCode       : 'restart-effect-superseded-by-incarnation-change',
+                serviceKey,
+                action,
+                targetIdentity   : baseOutcome.targetIdentity,
+                effectDisposition: 'uncertain',
+                reobservation
+            };
+            taskStatus = 'skipped'
+        } else {
+            const baselineMs = Date.parse(baselineStartedAt || ''),
+                  observedMs = Date.parse(observedStartedAt || '');
+
+            if (!Number.isFinite(baselineMs) || !Number.isFinite(observedMs) || observedMs < baselineMs) {
+                return {
+                    ...baseOutcome,
+                    reasonCode: 'restart-effect-reobserve-unreadable',
+                    reobservation
+                }
+            }
+
+            if (observedMs === baselineMs) {
+                return {
+                    ...baseOutcome,
+                    reasonCode: 'restart-effect-not-yet-observed',
+                    reobservation
+                }
+            }
+
+            outcome = {
+                status           : 'actioned',
+                reasonCode       : 'restart-effect-observed-applied',
+                serviceKey,
+                action,
+                targetIdentity   : baseOutcome.targetIdentity,
+                effectDisposition: 'applied',
+                reobservation
+            };
+            taskStatus = 'completed'
+        }
+
+        // Append FIRST and do not clear a second mutable marker: this terminal row supersedes the
+        // pending row atomically within the run's JSONL. An append failure leaves the pending row as
+        // latest, so the next cadence re-observes instead of redispatching.
+        return this.finishAction({
+            action,
+            attempt       : pending.attempt,
+            backoffUntil  : pending.backoffUntil || null,
+            diagnosisEvent: context.diagnosisEvent,
+            outcome,
+            recoveryRunId : pending.recoveryRunId,
+            serviceKey,
+            startedAt     : pending.startedAt,
+            target,
+            taskStatus,
+            updatedAt     : now,
+            isAuthorityHeld,
+            // This observation settles the dispatch question. Health recovery remains the next
+            // controller observation; emitting another dispatch-settlement request would recreate
+            // the write-only loop this method closes.
+            reobserveRequest: null
+        })
+    }
+
+    /**
+     * @summary Appends one recovery-run state through an overridable fault-injection seam.
+     * @param {Object} entry Recovery-run state entry.
+     * @param {Object} options Append options.
+     * @returns {Promise<String>} Written ledger path.
+     */
+    async appendRecoveryRunEntry(entry, options = {}) {
+        return appendRecoveryRunState(entry, {
+            dir           : this.recoveryRunStateDir,
+            retentionLimit: this.cfg.recoveryRunRetentionLimit,
+            ...options
+        })
+    }
+
+    /**
      * @summary Reads the persisted heal-attempt state file.
      * @returns {Promise<Object>}
      */
@@ -1167,13 +1500,43 @@ export class RecoveryActuatorService extends Base {
     }
 
     /**
-     * @summary Writes the persisted heal-attempt state file.
+     * @summary Atomically writes persisted heal-attempt state under a commit-adjacent authority fence.
+     *
+     * JSON is staged to a unique sibling path, then authority is sampled immediately before rename,
+     * the single commit point. A displaced holder may leave no successor-visible anti-thrash state.
+     * The unique name also prevents two independently initialized writers from sharing scratch data.
+     *
      * @param {Object} attempts Attempt state.
+     * @param {Object} [options]
+     * @param {Function|null} [options.isAuthorityHeld=null] Live authority oracle.
+     * @param {Object} [options.fileSystem=fs] File-system adapter for deterministic commit-boundary tests.
      * @returns {Promise<void>}
      */
-    async writeHealAttempts(attempts) {
-        await fs.ensureDir(path.dirname(this.healAttemptsPath));
-        await fs.writeJson(this.healAttemptsPath, attempts, {spaces: 2});
+    async writeHealAttempts(attempts, {isAuthorityHeld = null, fileSystem = fs} = {}) {
+        const targetPath = this.healAttemptsPath,
+              tempPath   = `${targetPath}.${randomUUID()}.tmp`;
+
+        const assertHeld = () => {
+            if (typeof isAuthorityHeld === 'function' && isAuthorityHeld() !== true) {
+                const error = new Error('Authority moved before the heal-attempt state commit; refusing.');
+
+                error.reason = 'runtime-authority-lost';
+
+                throw error
+            }
+        };
+
+        assertHeld();
+        await fileSystem.ensureDir(path.dirname(targetPath));
+        assertHeld();
+
+        try {
+            await fileSystem.writeJson(tempPath, attempts, {spaces: 2});
+            assertHeld();
+            await fileSystem.rename(tempPath, targetPath); // atomic-write-ok: assertHeld() fences the commit rename
+        } finally {
+            await fileSystem.remove(tempPath).catch(() => {})
+        }
     }
 
     /**
@@ -1281,7 +1644,9 @@ export class RecoveryActuatorService extends Base {
         target,
         taskStatus,
         updatedAt,
-        isAuthorityHeld = null
+        isAuthorityHeld = null,
+        reobserveRequest: requestedReobserve = undefined,
+        settlesPreDispatchInterlock = false
     }) {
         // FRESHLY CLASSIFIED, here rather than at the caller. Everything between the caller's own
         // measurement and this point is awaited — `writeHealAttempts`, the executor, the heal-event
@@ -1298,16 +1663,18 @@ export class RecoveryActuatorService extends Base {
                   : (heldAtAppend === null ? outcome : {...outcome, heldAtAppend});
 
         const runId            = this.getRecoveryRunId({recoveryRunId, serviceKey, action, startedAt}),
-              reobserveRequest = outcome.status === 'actioned'
-                  ? createRecoveryReobserveRequest({
-                        recoveryRunId              : runId,
-                        diagnosisEvent,
-                        requestedAt                : updatedAt,
-                        cooldownMs                 : this.getVerifyCooldownMs(),
-                        healthyObservationThreshold: this.getHealthyObservationThreshold()
-                    })
-                  : null,
-              ledgerStatus = this.getLedgerStatus({outcome}),
+              reobserveRequest = requestedReobserve === undefined
+                  ? (outcome.status === 'actioned'
+                      ? createRecoveryReobserveRequest({
+                            recoveryRunId              : runId,
+                            diagnosisEvent,
+                            requestedAt                : updatedAt,
+                            cooldownMs                 : this.getVerifyCooldownMs(),
+                            healthyObservationThreshold: this.getHealthyObservationThreshold()
+                        })
+                      : null)
+                  : requestedReobserve,
+              ledgerStatus = this.getLedgerStatus({outcome, reobserveRequest}),
               entry = createRecoveryRunStateEntry({
                   recoveryRunId: runId,
                   diagnosisEvent,
@@ -1322,9 +1689,7 @@ export class RecoveryActuatorService extends Base {
                   details      : finalOutcome
               });
 
-        await appendRecoveryRunState(entry, {
-            dir           : this.recoveryRunStateDir,
-            retentionLimit: this.cfg.recoveryRunRetentionLimit,
+        await this.appendRecoveryRunEntry(entry, {
             // Carried into the store so the refusal sits adjacent to the append itself: the
             // classification above is fresh, but `appendRecoveryRunState` awaits `mkdir` before it
             // writes — one more yield this method cannot see from here.
@@ -1334,11 +1699,12 @@ export class RecoveryActuatorService extends Base {
             // bought a dispatched audit its survival at the cost of the record no longer saying
             // whether the holder still held the lease when it landed.
             isAuthorityHeld,
-            // Whether an effect was DISPATCHED, which is what decides survival — not whether
-            // authority is still held. `actioned` and `failed` both mean the executor ran, so those
-            // records must outlive a takeover; `recorded`, `skipped` and `declined` mean nothing
-            // reached a container, so a displaced holder has nothing to attribute and must not write.
-            preserveOnAuthorityLoss: ['actioned', 'failed'].includes(finalOutcome.status)
+            // A dispatched effect must outlive takeover. The one safe non-dispatched exception is
+            // the terminal settlement of a pre-POST interlock already written by this run: refusing
+            // that append would leave `pending` authoritative forever. It is stamped as displaced,
+            // claims `not-applied`, and can only remove permission to infer that a POST occurred.
+            preserveOnAuthorityLoss: settlesPreDispatchInterlock ||
+                ['actioned', 'failed'].includes(finalOutcome.status)
         });
 
         this.recordTaskOutcome(serviceKey, taskStatus, {
@@ -1511,9 +1877,12 @@ export class RecoveryActuatorService extends Base {
      * @param {Object} options
      * @returns {String}
      */
-    getLedgerStatus({outcome}) {
-        if (outcome.status === 'actioned') {
+    getLedgerStatus({outcome, reobserveRequest = null}) {
+        if (reobserveRequest) {
             return 'reobserve-requested';
+        }
+        if (outcome.status === 'actioned') {
+            return 'actioned';
         }
         if (outcome.status === 'recorded') {
             return 'recorded';
@@ -1523,6 +1892,20 @@ export class RecoveryActuatorService extends Base {
         }
         return 'no-action';
     }
+}
+
+/**
+ * @summary Normalizes one Docker `StartedAt` value for exact incarnation comparison.
+ * @param {*} value Candidate Docker timestamp.
+ * @returns {String|null} Original timestamp when finite and positive, otherwise null.
+ */
+function normalizeObservedContainerTime(value) {
+    if (value === null || value === undefined) return null;
+
+    const stamp  = String(value),
+          parsed = Date.parse(stamp);
+
+    return Number.isFinite(parsed) && parsed > 0 ? stamp : null
 }
 
 export default Neo.setupClass(RecoveryActuatorService);

--- a/ai/services/memory-core/helpers/recoveryRunStateStore.mjs
+++ b/ai/services/memory-core/helpers/recoveryRunStateStore.mjs
@@ -34,6 +34,8 @@ export const RECOVERY_RUN_STATUSES = Object.freeze([
     'reobserve-requested'
 ]);
 
+export const ACTIVE_RECOVERY_RUN_RETENTION_CLASS = 'active-effect-interlock';
+
 export const RECOVERY_RUN_GRAPH_NODE_TYPES = Object.freeze({
     diagnosis       : 'RECOVERY_DIAGNOSIS',
     recoveryRun     : 'RECOVERY_RUN',
@@ -468,12 +470,22 @@ export async function pruneRecoveryRunStates({dir, retentionLimit} = {}) {
     }
 
     const files = await Promise.all(jsonlNames.map(async name => {
-        const filePath = path.join(dir, name);
-        const stat     = await fs.stat(filePath);
-        return {filePath, mtimeMs: stat.mtimeMs};
+        const filePath            = path.join(dir, name);
+        const [stat, latestEntry] = await Promise.all([
+            fs.stat(filePath),
+            readLatestValidRecoveryRunState(filePath)
+        ]);
+
+        return {filePath, mtimeMs: stat.mtimeMs, latestEntry};
     }));
 
-    const toRemove = files
+    // An unresolved effect is not audit history yet: it is a live, fail-safe dispatch interlock.
+    // Count only ordinary/settled files against the audit retention window. A terminal append to
+    // the same JSONL omits the retention class and automatically makes the artifact prunable again.
+    const ordinaryFiles = files.filter(file =>
+              file.latestEntry?.details?.retentionClass !== ACTIVE_RECOVERY_RUN_RETENTION_CLASS
+          ),
+          toRemove = ordinaryFiles
         .sort((a, b) => b.mtimeMs - a.mtimeMs)
         .slice(retentionLimit);
 
@@ -600,21 +612,85 @@ export async function readRecentRecoveryRunStates({dir, limit} = {}) {
     for (const file of files.sort((a, b) => b.mtimeMs - a.mtimeMs)) {
         if (entries.length >= limit) break;
 
-        const text  = await fs.readFile(file.filePath, 'utf8');
-        const lines = text.trim().split('\n').filter(Boolean);
-        const line  = lines.length > 0 ? lines[lines.length - 1] : null;
-        if (!line) continue;
+        const entry = await readLatestValidRecoveryRunState(file.filePath);
 
-        try {
-            entries.push(JSON.parse(line));
-        } catch (e) {
-            // A corrupt recovery artifact should not take down the healthcheck surface.
-        }
+        if (entry) entries.push(entry);
     }
 
     return entries
         .sort((a, b) => getEntrySortTime(b) - getEntrySortTime(a))
         .slice(0, limit);
+}
+
+/**
+ * @summary Reads every active recovery-run interlock independently of the ordinary recency window.
+ *
+ * Active effect interlocks are retention-exempt until a terminal row supersedes them in the same
+ * JSONL file. Reading the complete directory is deliberate: admission safety cannot depend on the
+ * volume of unrelated recovery audit traffic.
+ *
+ * @param {Object} options
+ * @param {String} options.dir Directory for per-run state files.
+ * @param {String} [options.retentionClass=ACTIVE_RECOVERY_RUN_RETENTION_CLASS] Active class to read.
+ * @returns {Promise<Object[]>} Active latest entries, newest first.
+ */
+export async function readActiveRecoveryRunStates({
+    dir,
+    retentionClass = ACTIVE_RECOVERY_RUN_RETENTION_CLASS
+} = {}) {
+    if (!dir || typeof retentionClass !== 'string' || retentionClass.length === 0) {
+        return [];
+    }
+
+    let names;
+    try {
+        names = await fs.readdir(dir);
+    } catch (error) {
+        if (error?.code === 'ENOENT') return [];
+        throw error;
+    }
+
+    const entries = await Promise.all(names
+        .filter(name => name.endsWith('.jsonl'))
+        .map(name => readLatestValidRecoveryRunState(path.join(dir, name))));
+
+    return entries
+        .filter(entry => entry?.details?.retentionClass === retentionClass)
+        .sort((left, right) => getEntrySortTime(right) - getEntrySortTime(left));
+}
+
+/**
+ * @summary Reads the newest valid JSONL row, falling back across a torn final append.
+ * @param {String} filePath Recovery-run JSONL path.
+ * @returns {Promise<Object|null>} Latest valid object row, or null.
+ * @private
+ */
+async function readLatestValidRecoveryRunState(filePath) {
+    let text;
+    try {
+        text = await fs.readFile(filePath, 'utf8');
+    } catch (error) {
+        if (error?.code === 'ENOENT') return null;
+        throw error;
+    }
+
+    const lines = text.split('\n');
+
+    for (let index = lines.length - 1; index >= 0; index--) {
+        const line = lines[index].trim();
+
+        if (!line) continue;
+
+        try {
+            const entry = JSON.parse(line);
+
+            if (entry && typeof entry === 'object' && !Array.isArray(entry)) return entry;
+        } catch (error) {
+            // A torn final append cannot erase the preceding durable interlock.
+        }
+    }
+
+    return null;
 }
 
 function getEntrySortTime(entry) {

--- a/test/playwright/unit/ai/daemons/orchestrator/services/DeploymentRuntimeAccessService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/DeploymentRuntimeAccessService.spec.mjs
@@ -1,10 +1,15 @@
 import {readFileSync} from 'node:fs';
+import {rm}           from 'node:fs/promises';
+import {createServer} from 'node:http';
+import {tmpdir}       from 'node:os';
+import path           from 'node:path';
 import {test, expect} from '@playwright/test';
 import Neo            from '../../../../../../../src/Neo.mjs';
 import * as core      from '../../../../../../../src/core/_export.mjs';
 import {
     DeploymentRuntimeAccessService,
-    DEPLOYMENT_RUNTIME_SELF_SERVICE_KEY
+    DEPLOYMENT_RUNTIME_SELF_SERVICE_KEY,
+    dockerSocketRequest
 } from '../../../../../../../ai/daemons/orchestrator/services/DeploymentRuntimeAccessService.mjs';
 import {RECOVERY_KNOBS} from '../../../../../../../ai/services/memory-core/helpers/recoveryKnobRegistry.mjs';
 
@@ -41,7 +46,11 @@ function makeContainer(overrides = {}) {
 function createService({
     config = {},
     containers = [makeContainer()],
-    inspectData = {Name: '/neo-mc-server-1'},
+    inspectData = {
+        Id   : 'container-abc',
+        Name : '/neo-mc-server-1',
+        State: {StartedAt: '2026-08-13T20:00:00.000Z'}
+    },
     statsData = {cpu_stats: {}},
     logText = 'ready',
     requestError = null
@@ -51,8 +60,10 @@ function createService({
     const dockerRequestFn = async request => {
         calls.push(request);
 
-        if (requestError) {
-            throw requestError;
+        const error = typeof requestError === 'function' ? requestError(request) : requestError;
+
+        if (error) {
+            throw error;
         }
 
         if (request.path.startsWith('/containers/json')) {
@@ -111,7 +122,7 @@ test.describe('Neo.ai.daemons.services.DeploymentRuntimeAccessService', () => {
 
         expect(service).toBeInstanceOf(core.Base);
         expect(result.ok).toBe(true);
-        expect(result.data).toEqual({Name: '/neo-mc-server-1'});
+        expect(result.data).toMatchObject({Name: '/neo-mc-server-1'});
         expect(result.proof).toMatchObject({
             recordType        : 'deployment-runtime-access',
             runtimeMechanism  : 'docker-socket',
@@ -282,10 +293,140 @@ test.describe('Neo.ai.daemons.services.DeploymentRuntimeAccessService', () => {
             auditLabel        : 'lifecycle-write:restart',
             reason            : 'diagnosis:crash'
         });
-        expect(calls[1]).toMatchObject({
-            method: 'POST',
-            path  : '/containers/container-abc/restart?t=4'
+        expect(calls[2]).toMatchObject({
+            method   : 'POST',
+            path     : '/containers/container-abc/restart?t=4',
+            timeoutMs: 9_000
         });
+    });
+
+    test('a post-dispatch restart timeout is uncertain and carries its incarnation baseline', async () => {
+        const timeoutError = Object.assign(
+            new Error('Docker API POST /containers/container-abc/restart?t=10 timed out after 15000ms'),
+            {
+                code                  : 'ETIMEDOUT',
+                reason                : 'docker-api-timeout',
+                dockerTransportFailure: true,
+                requestDispatched     : true
+            }
+        );
+        const {service, calls} = createService({
+            requestError: request => request.path.includes('/restart?') ? timeoutError : null
+        });
+
+        let error;
+
+        try {
+            await service.applyLifecycle({serviceKey: 'mc-server', operation: 'restart'});
+        } catch (caught) {
+            error = caught
+        }
+
+        expect(error).toMatchObject({
+            reason                    : 'runtime-effect-disposition-uncertain',
+            code                      : 'ETIMEDOUT',
+            effectDisposition         : 'uncertain',
+            restartObservationBaseline: {
+                containerId: 'container-abc',
+                startedAt  : '2026-08-13T20:00:00.000Z'
+            }
+        });
+        expect(calls.at(-1)).toMatchObject({
+            path     : '/containers/container-abc/restart?t=10',
+            timeoutMs: 15_000
+        });
+    });
+
+    test('a pre-dispatch restart failure never claims an uncertain effect', async () => {
+        const preDispatchError = Object.assign(new Error('Docker socket unavailable'), {
+            code             : 'ECONNREFUSED',
+            reason           : 'docker-socket-unavailable',
+            requestDispatched: false
+        });
+        const {service} = createService({
+            requestError: request => request.path.includes('/restart?') ? preDispatchError : null
+        });
+
+        let error;
+
+        try {
+            await service.applyLifecycle({serviceKey: 'mc-server', operation: 'restart'});
+        } catch (caught) {
+            error = caught
+        }
+
+        expect(error).toBe(preDispatchError);
+        expect(error.effectDisposition).toBeUndefined();
+    });
+
+    test('a post-finish socket reset is structurally tagged as a dispatched transport failure', async () => {
+        const socketPath = path.join(tmpdir(), `neo-docker-reset-${process.pid}-${Date.now()}.sock`),
+              server     = createServer(request => request.socket.destroy());
+
+        await new Promise((resolve, reject) => {
+            server.once('error', reject);
+            server.listen(socketPath, resolve)
+        });
+
+        let error;
+
+        try {
+            await dockerSocketRequest({
+                socketPath,
+                method   : 'POST',
+                path     : '/containers/container-abc/restart?t=10',
+                timeoutMs: 1_000
+            })
+        } catch (caught) {
+            error = caught
+        } finally {
+            await new Promise(resolve => server.close(resolve));
+            await rm(socketPath, {force: true})
+        }
+
+        expect(error).toMatchObject({
+            dockerTransportFailure: true,
+            requestDispatched     : true
+        });
+    });
+
+    test('generic post-dispatch transport loss is uncertain, not only the timeout subtype', async () => {
+        const resetError = Object.assign(new Error('socket hang up'), {
+            code                  : 'ECONNRESET',
+            reason                : 'docker-api-transport-error',
+            dockerTransportFailure: true,
+            requestDispatched     : true
+        });
+        const {service} = createService({
+            requestError: request => request.path.includes('/restart?') ? resetError : null
+        });
+
+        await expect(service.applyLifecycle({serviceKey: 'mc-server', operation: 'restart'}))
+            .rejects.toMatchObject({
+                reason           : 'runtime-effect-disposition-uncertain',
+                effectDisposition: 'uncertain',
+                code             : 'ECONNRESET'
+            });
+    });
+
+    test('restart timing rejects invalid grace or margin values before the POST', async () => {
+        for (const restartTimeoutSeconds of [-1, 1.5, Number.NaN]) {
+            const {service, calls} = createService();
+
+            await expect(service.applyLifecycle({
+                serviceKey: 'mc-server',
+                operation : 'restart',
+                restartTimeoutSeconds
+            })).rejects.toThrow(/non-negative integer/);
+
+            expect(calls.some(call => /\/restart/.test(call.path))).toBe(false);
+        }
+
+        const {service, calls} = createService({config: {timeoutMs: 0}});
+
+        await expect(service.applyLifecycle({serviceKey: 'mc-server', operation: 'restart'}))
+            .rejects.toThrow(/positive finite/);
+        expect(calls.some(call => /\/restart/.test(call.path))).toBe(false);
     });
 
     test('denies cross-envelope and non-allowlisted operations before Docker access', async () => {
@@ -893,6 +1034,45 @@ test.describe('applyLifecycle — authority is rechecked AFTER target resolution
         });
 
         expect(calls.some(call => /\/restart/.test(call.path))).toBe(true);
+    });
+
+    test('authority moving during the durable restart marker refuses before the POST', async () => {
+        let held = true;
+
+        const {service, calls} = createService();
+
+        await expect(service.applyLifecycle({
+            serviceKey     : 'mc-server',
+            operation      : 'restart',
+            isAuthorityHeld: () => held,
+            onBeforeRestartDispatch({baseline, clientTimeoutMs}) {
+                expect(baseline).toEqual({
+                    containerId: 'container-abc',
+                    startedAt  : '2026-08-13T20:00:00.000Z'
+                });
+                expect(clientTimeoutMs).toBe(15_000);
+                held = false
+            }
+        })).rejects.toMatchObject({reason: 'runtime-authority-lost'});
+
+        expect(calls.some(call => /\/restart/.test(call.path))).toBe(false);
+    });
+
+    test('admission moving during the durable restart marker refuses before the POST', async () => {
+        let admitted = true;
+
+        const {service, calls} = createService();
+
+        await expect(service.applyLifecycle({
+            serviceKey           : 'mc-server',
+            operation            : 'restart',
+            isEffectStillAdmitted: () => admitted,
+            onBeforeRestartDispatch() {
+                admitted = false
+            }
+        })).rejects.toMatchObject({reason: 'runtime-effect-not-admitted'});
+
+        expect(calls.some(call => /\/restart/.test(call.path))).toBe(false);
     });
 
     test('live demand admitted during target resolution vetoes the restart at the last boundary', async () => {

--- a/test/playwright/unit/ai/daemons/orchestrator/services/DeploymentStateBridgeService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/DeploymentStateBridgeService.spec.mjs
@@ -2161,7 +2161,16 @@ test.describe('restart churn reaches the deployment record', () => {
             defaultRestartTimeoutSeconds: 10,
             auditMode                   : 'metadata'
         },
-        dockerRequestFn: async () => ({statusCode: 204, headers: {}, body: ''}),
+        dockerRequestFn: async ({method}) => method === 'GET'
+            ? {
+                  statusCode: 200,
+                  headers   : {},
+                  body      : JSON.stringify({
+                      Id   : 'c1',
+                      State: {StartedAt: new Date(at - 1000).toISOString()}
+                  })
+              }
+            : {statusCode: 204, headers: {}, body: ''},
         nowFn          : () => at
     });
 

--- a/test/playwright/unit/ai/daemons/orchestrator/services/RecoveryActuatorService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/RecoveryActuatorService.spec.mjs
@@ -1,6 +1,7 @@
 import {test, expect}                   from '@playwright/test';
 import {existsSync, readdirSync}        from 'fs';
 import {mkdtemp, readdir, rm, readFile} from 'fs/promises';
+import fs                               from 'fs-extra';
 import os                               from 'os';
 import path                             from 'path';
 
@@ -13,6 +14,7 @@ import {
 } from '../../../../../../../ai/daemons/orchestrator/services/RecoveryActuatorService.mjs';
 import {
     createRecoveryDiagnosisEvent,
+    createRecoveryRunStateEntry,
     createRecoveryTargetIdentity
 } from '../../../../../../../ai/services/memory-core/helpers/recoveryRunStateStore.mjs';
 import {RECOVERY_OVERRIDE_FILENAME} from '../../../../../../../ai/services/memory-core/helpers/recoveryOverrideStore.mjs';
@@ -35,6 +37,7 @@ test.describe('Neo.ai.daemons.services.RecoveryActuatorService', () => {
 
     function createService(overrides = {}) {
         const runtimeCalls                 = [],
+              runtimeReadCalls             = [],
               supervisorCalls              = [],
               providerResidencyRepairCalls = [],
               taskOutcomes                 = [],
@@ -79,6 +82,17 @@ test.describe('Neo.ai.daemons.services.RecoveryActuatorService', () => {
                               }
                           };
                       },
+                      async readObserve(options) {
+                          runtimeReadCalls.push(options);
+
+                          return {
+                              data : {
+                                  Id   : 'container-abc',
+                                  State: {StartedAt: '2026-08-13T20:00:00.000Z'}
+                              },
+                              proof: {target: {containerId: 'container-abc'}}
+                          }
+                      },
                       ...overrides.deploymentRuntimeAccessService
                   },
                   processSupervisorService: {
@@ -103,11 +117,30 @@ test.describe('Neo.ai.daemons.services.RecoveryActuatorService', () => {
                   ...overrides.serviceConfig
               });
 
-        return {service, runtimeCalls, supervisorCalls, providerResidencyRepairCalls, taskOutcomes, actuatorConfig};
+        return {
+            service,
+            runtimeCalls,
+            runtimeReadCalls,
+            supervisorCalls,
+            providerResidencyRepairCalls,
+            taskOutcomes,
+            actuatorConfig
+        };
     }
 
     async function readAttempts() {
         return JSON.parse(await readFile(path.join(tmpDir, 'heal-attempts.json'), 'utf8'));
+    }
+
+    function createUncertainRestartError() {
+        return Object.assign(new Error('Docker restart response timed out after dispatch'), {
+            reason                    : 'runtime-effect-disposition-uncertain',
+            effectDisposition         : 'uncertain',
+            restartObservationBaseline: {
+                containerId: 'container-abc',
+                startedAt  : '2026-08-13T20:00:00.000Z'
+            }
+        })
     }
 
     function createScratchSensitiveAuthorityOracle(overrideDir) {
@@ -138,6 +171,40 @@ test.describe('Neo.ai.daemons.services.RecoveryActuatorService', () => {
             },
             ...overrides
         });
+    }
+
+    async function appendUnrelatedRecoveryRuns(service, count, startAt = 1_000_000) {
+        for (let index = 0; index < count; index++) {
+            const updatedAt = startAt + index,
+                  runId     = `unrelated-recovery-${startAt}-${index}`,
+                  diagnosis = createRecoveryDiagnosisEvent({
+                      diagnosisId   : `unrelated-diagnosis-${startAt}-${index}`,
+                      recoveryClass : 'crash',
+                      confidence    : 1,
+                      targetIdentity: createRecoveryTargetIdentity({
+                          kind: 'supervised-task',
+                          id  : `unrelated-${index}`
+                      }),
+                      evidenceFacts: [],
+                      observedAt   : updatedAt
+                  });
+
+            await service.appendRecoveryRunEntry(createRecoveryRunStateEntry({
+                recoveryRunId : runId,
+                diagnosisEvent: diagnosis,
+                rung          : 'rung-0',
+                attempt       : 1,
+                status        : 'actioned',
+                startedAt     : updatedAt,
+                updatedAt,
+                completedAt   : updatedAt,
+                details       : {
+                    status    : 'actioned',
+                    serviceKey: `unrelated-${index}`,
+                    action    : 'restart'
+                }
+            }));
+        }
     }
 
     test('normalizes string and object recovery target entries', () => {
@@ -393,6 +460,544 @@ test.describe('Neo.ai.daemons.services.RecoveryActuatorService', () => {
             .trim().split('\n').map(line => JSON.parse(line));
 
         expect(rows.at(-1).heldAtWrite).toBe(false);
+    });
+
+    test('an uncertain Docker restart survives actuator recreation and settles applied before redispatch', async () => {
+        const lifecycleCalls = [],
+              readCalls      = [],
+              runtime        = {
+                  supportsRestartDispatchInterlock: true,
+                  async applyLifecycle(options) {
+                      lifecycleCalls.push(options);
+                      throw createUncertainRestartError()
+                  },
+                  async readObserve(options) {
+                      readCalls.push(options);
+
+                      return {
+                          data : {
+                              Id   : 'container-abc',
+                              State: {StartedAt: '2026-08-13T20:01:00.000Z'}
+                          },
+                          proof: {target: {containerId: 'container-abc'}}
+                      }
+                  }
+              },
+              firstService = createService({
+                  actuatorConfig                : {recoveryRunRetentionLimit: 2},
+                  deploymentRuntimeAccessService: runtime
+              }).service,
+              first        = await firstService.apply('mc-server', 'restart', {now: 10_000});
+
+        expect(first).toMatchObject({
+            status           : 'failed',
+            reasonCode       : 'restart-effect-disposition-uncertain',
+            effectDisposition: 'uncertain',
+            reobserveRequest : {reason: 'effect-disposition-uncertain'}
+        });
+        expect(lifecycleCalls).toHaveLength(1);
+
+        const runDir  = path.join(tmpDir, 'recovery-runs'),
+              runFile = path.join(runDir, (await readdir(runDir))[0]);
+
+        await fs.utimes(runFile, new Date(1), new Date(1));
+        await appendUnrelatedRecoveryRuns(firstService, 6);
+
+        let rows = (await readFile(runFile, 'utf8')).trim().split('\n').map(line => JSON.parse(line));
+
+        expect(rows.at(-1)).toMatchObject({
+            recoveryRunId: first.recoveryRunId,
+            status       : 'reobserve-requested',
+            details      : {
+                restartReobserve: {baseline: {containerId: 'container-abc'}}
+            }
+        });
+
+        // A fresh service instance proves the guard is durable, not an in-memory latch.
+        const recreated = createService({
+                  actuatorConfig                : {recoveryRunRetentionLimit: 2},
+                  deploymentRuntimeAccessService: runtime
+              }).service,
+              early     = await recreated.apply('mc-server', 'reconfigure', {
+                  now: first.reobserveRequest.earliestObservationAt - 1
+              });
+
+        expect(early).toMatchObject({
+            status           : 'deferred',
+            reasonCode       : 'restart-effect-reobserve-pending',
+            effectDisposition: 'uncertain'
+        });
+        expect(lifecycleCalls).toHaveLength(1);
+        expect(readCalls).toHaveLength(0);
+
+        const settled = await recreated.apply('mc-server', 'reconfigure', {
+            now: first.reobserveRequest.earliestObservationAt
+        });
+
+        expect(settled).toMatchObject({
+            status           : 'actioned',
+            reasonCode       : 'restart-effect-observed-applied',
+            effectDisposition: 'applied',
+            recoveryRunId    : first.recoveryRunId,
+            reobserveRequest : null
+        });
+        expect(settled.reobservation.observed).toEqual({
+            containerId: 'container-abc',
+            startedAt  : '2026-08-13T20:01:00.000Z'
+        });
+        expect(lifecycleCalls).toHaveLength(1);
+        expect(readCalls).toEqual([{serviceKey: 'mc-server', operation: 'inspect'}]);
+
+        rows = (await readFile(runFile, 'utf8')).trim().split('\n').map(line => JSON.parse(line));
+
+        expect(rows.map(row => row.status)).toEqual(['reobserve-requested', 'actioned']);
+        expect(rows.at(-1).recoveryRunId).toBe(first.recoveryRunId);
+
+        await fs.utimes(runFile, new Date(1), new Date(1));
+        await appendUnrelatedRecoveryRuns(recreated, 3, 2_000_000);
+        expect(existsSync(runFile), 'terminal settlement makes the former interlock prunable').toBe(false);
+    });
+
+    test('timeout plus authority takeover hands the interlock to the successor before any redispatch', async () => {
+        let held = true;
+
+        const lifecycleCalls = [],
+              readCalls      = [],
+              runtime        = {
+                  supportsRestartDispatchInterlock: true,
+                  async applyLifecycle(options) {
+                      lifecycleCalls.push(options);
+                      await options.onBeforeRestartDispatch({
+                          baseline: {
+                              containerId: 'container-abc',
+                              startedAt  : '2026-08-13T20:00:00.000Z'
+                          },
+                          clientTimeoutMs      : 15_000,
+                          restartTimeoutSeconds: 10
+                      });
+                      held = false;
+                      throw createUncertainRestartError()
+                  },
+                  async readObserve(options) {
+                      readCalls.push(options);
+
+                      return {
+                          data : {
+                              Id   : 'container-abc',
+                              State: {StartedAt: '2026-08-13T20:01:00.000Z'}
+                          },
+                          proof: {target: {containerId: 'container-abc'}}
+                      }
+                  }
+              },
+              firstService = createService({deploymentRuntimeAccessService: runtime}).service,
+              first        = await firstService.apply('mc-server', 'restart', {
+                  now            : 15_000,
+                  isAuthorityHeld: () => held
+              });
+
+        expect(first).toMatchObject({
+            status           : 'failed',
+            effectDisposition: 'uncertain',
+            reobserveRequest : {reason: 'effect-disposition-uncertain'}
+        });
+        expect(lifecycleCalls).toHaveLength(1);
+
+        held = true;
+
+        const successor = createService({deploymentRuntimeAccessService: runtime}).service,
+              settled   = await successor.apply('mc-server', 'restart', {
+                  now            : first.reobserveRequest.earliestObservationAt,
+                  isAuthorityHeld: () => held
+              });
+
+        expect(settled).toMatchObject({
+            status           : 'actioned',
+            reasonCode       : 'restart-effect-observed-applied',
+            effectDisposition: 'applied',
+            recoveryRunId    : first.recoveryRunId
+        });
+        expect(lifecycleCalls, 'the successor inspected the inherited uncertainty instead of POSTing').toHaveLength(1);
+        expect(readCalls).toEqual([{serviceKey: 'mc-server', operation: 'inspect'}]);
+    });
+
+    test('reconfigure inherits the Docker restart interlock and blocks a cross-action redispatch', async () => {
+        const readCalls = [],
+              runtime   = {
+                  supportsRestartDispatchInterlock: true,
+                  async readObserve(options) {
+                      readCalls.push(options);
+
+                      return {
+                          data : {
+                              Id   : 'container-abc',
+                              State: {StartedAt: '2026-08-13T20:01:00.000Z'}
+                          },
+                          proof: {target: {containerId: 'container-abc'}}
+                      }
+                  }
+              },
+              firstService = createService({
+                  actuatorConfig                : {recoveryRunRetentionLimit: 2},
+                  deploymentRuntimeAccessService: runtime
+              }).service;
+
+        let reconfigureCalls = 0;
+
+        firstService.reconfigureComposeService = async ({onBeforeRestartDispatch}) => {
+            reconfigureCalls++;
+            await onBeforeRestartDispatch({
+                baseline: {
+                    containerId: 'container-abc',
+                    startedAt  : '2026-08-13T20:00:00.000Z'
+                },
+                clientTimeoutMs      : 15_000,
+                restartTimeoutSeconds: 10
+            });
+            throw createUncertainRestartError()
+        };
+
+        const first = await firstService.apply('mc-server', 'reconfigure', {now: 15_500});
+
+        expect(first).toMatchObject({
+            status           : 'failed',
+            action           : 'reconfigure',
+            reasonCode       : 'restart-effect-disposition-uncertain',
+            effectDisposition: 'uncertain',
+            reobserveRequest : {reason: 'effect-disposition-uncertain'}
+        });
+
+        const runDir  = path.join(tmpDir, 'recovery-runs'),
+              runFile = path.join(runDir, (await readdir(runDir))[0]);
+
+        await fs.utimes(runFile, new Date(1), new Date(1));
+        await appendUnrelatedRecoveryRuns(firstService, 6, 3_000_000);
+
+        // A different restart-bearing action for the same target must consume the unresolved
+        // reconfigure restart instead of bypassing it under a different outer action label.
+        const successor = createService({
+                  actuatorConfig                : {recoveryRunRetentionLimit: 2},
+                  deploymentRuntimeAccessService: runtime
+              }).service,
+              settled   = await successor.apply('mc-server', 'restart', {
+                  now: first.reobserveRequest.earliestObservationAt
+              });
+
+        expect(settled).toMatchObject({
+            status           : 'actioned',
+            action           : 'reconfigure',
+            reasonCode       : 'restart-effect-observed-applied',
+            effectDisposition: 'applied',
+            recoveryRunId    : first.recoveryRunId
+        });
+        expect(reconfigureCalls, 'the successor reconciled instead of issuing another restart').toBe(1);
+        expect(readCalls).toEqual([{serviceKey: 'mc-server', operation: 'inspect'}]);
+    });
+
+    test('post-effect attempt-store failure leaves the pre-POST interlock authoritative', async () => {
+        let held = true;
+
+        const lifecycleCalls = [],
+              readCalls      = [],
+              runtime        = {
+                  supportsRestartDispatchInterlock: true,
+                  async applyLifecycle(options) {
+                      lifecycleCalls.push(options);
+                      await options.onBeforeRestartDispatch({
+                          baseline: {
+                              containerId: 'container-abc',
+                              startedAt  : '2026-08-13T20:00:00.000Z'
+                          },
+                          clientTimeoutMs      : 15_000,
+                          restartTimeoutSeconds: 10
+                      });
+
+                      return {runtimeAccess: {operation: 'restart'}}
+                  },
+                  async readObserve(options) {
+                      readCalls.push(options);
+
+                      return {
+                          data : {
+                              Id   : 'container-abc',
+                              State: {StartedAt: '2026-08-13T20:01:00.000Z'}
+                          },
+                          proof: {target: {containerId: 'container-abc'}}
+                      }
+                  }
+              },
+              firstService = createService({deploymentRuntimeAccessService: runtime}).service;
+
+        firstService.writeHealAttempts = async () => {
+            held = false;
+            throw Object.assign(new Error('authority moved at the mutable-state commit'), {
+                reason: 'runtime-authority-lost'
+            })
+        };
+
+        await expect(firstService.apply('mc-server', 'restart', {
+            now            : 16_000,
+            isAuthorityHeld: () => held
+        })).rejects.toMatchObject({reason: 'runtime-authority-lost'});
+
+        const runDir  = path.join(tmpDir, 'recovery-runs'),
+              runFile = path.join(runDir, (await readdir(runDir))[0]);
+
+        let rows = (await readFile(runFile, 'utf8')).trim().split('\n').map(line => JSON.parse(line));
+
+        expect(rows.map(row => row.status)).toEqual(['pending']);
+        expect(rows.at(-1).details).toMatchObject({
+            reasonCode       : 'restart-dispatch-pending',
+            effectDisposition: 'uncertain'
+        });
+
+        held = true;
+
+        const successor = createService({deploymentRuntimeAccessService: runtime}).service,
+              settled   = await successor.apply('mc-server', 'restart', {
+                  now            : rows.at(-1).reobserveRequest.earliestObservationAt,
+                  isAuthorityHeld: () => held
+              });
+
+        expect(settled).toMatchObject({
+            status           : 'actioned',
+            reasonCode       : 'restart-effect-observed-applied',
+            effectDisposition: 'applied'
+        });
+        expect(lifecycleCalls, 'the post-effect persistence failure never reopened restart dispatch').toHaveLength(1);
+        expect(readCalls).toEqual([{serviceKey: 'mc-server', operation: 'inspect'}]);
+
+        rows = (await readFile(runFile, 'utf8')).trim().split('\n').map(line => JSON.parse(line));
+        expect(rows.map(row => row.status)).toEqual(['pending', 'actioned']);
+    });
+
+    test('a failed settlement append leaves the uncertain ledger row as the redispatch guard', async () => {
+        const lifecycleCalls = [],
+              runtime        = {
+                  supportsRestartDispatchInterlock: true,
+                  async applyLifecycle(options) {
+                      lifecycleCalls.push(options);
+                      throw createUncertainRestartError()
+                  },
+                  async readObserve() {
+                      return {
+                          data : {
+                              Id   : 'container-abc',
+                              State: {StartedAt: '2026-08-13T20:01:00.000Z'}
+                          },
+                          proof: {target: {containerId: 'container-abc'}}
+                      }
+                  }
+              },
+              firstService = createService({deploymentRuntimeAccessService: runtime}).service,
+              first        = await firstService.apply('mc-server', 'restart', {now: 17_000}),
+              broken       = createService({deploymentRuntimeAccessService: runtime}).service;
+
+        broken.appendRecoveryRunEntry = async () => {
+            throw new Error('forced recovery-run append failure')
+        };
+
+        await expect(broken.apply('mc-server', 'restart', {
+            now: first.reobserveRequest.earliestObservationAt
+        })).rejects.toThrow('forced recovery-run append failure');
+
+        const runDir  = path.join(tmpDir, 'recovery-runs'),
+              runFile = path.join(runDir, (await readdir(runDir))[0]);
+
+        let rows = (await readFile(runFile, 'utf8')).trim().split('\n').map(line => JSON.parse(line));
+
+        expect(rows.map(row => row.status)).toEqual(['reobserve-requested']);
+
+        const recovered = createService({deploymentRuntimeAccessService: runtime}).service,
+              settled   = await recovered.apply('mc-server', 'restart', {
+                  now: first.reobserveRequest.earliestObservationAt + 1
+              });
+
+        expect(settled.status).toBe('actioned');
+        expect(lifecycleCalls, 'neither settlement attempt redispatched the restart').toHaveLength(1);
+
+        rows = (await readFile(runFile, 'utf8')).trim().split('\n').map(line => JSON.parse(line));
+        expect(rows.map(row => row.status)).toEqual(['reobserve-requested', 'actioned']);
+    });
+
+    test('unchanged restart evidence stays uncertain without a second POST', async () => {
+        const lifecycleCalls = [],
+              runtime        = {
+                  supportsRestartDispatchInterlock: true,
+                  async applyLifecycle(options) {
+                      lifecycleCalls.push(options);
+                      throw createUncertainRestartError()
+                  },
+                  async readObserve() {
+                      return {
+                          data : {
+                              Id   : 'container-abc',
+                              State: {StartedAt: '2026-08-13T20:00:00.000Z'}
+                          },
+                          proof: {target: {containerId: 'container-abc'}}
+                      }
+                  }
+              },
+              {service} = createService({deploymentRuntimeAccessService: runtime}),
+              first     = await service.apply('mc-server', 'restart', {now: 20_000}),
+              settled   = await service.apply('mc-server', 'restart', {
+                  now: first.reobserveRequest.earliestObservationAt
+              });
+
+        expect(settled).toMatchObject({
+            status           : 'deferred',
+            reasonCode       : 'restart-effect-not-yet-observed',
+            effectDisposition: 'uncertain',
+            recoveryRunId    : first.recoveryRunId
+        });
+        expect(lifecycleCalls).toHaveLength(1);
+
+        const runDir  = path.join(tmpDir, 'recovery-runs'),
+              runFile = path.join(runDir, (await readdir(runDir))[0]),
+              rows    = (await readFile(runFile, 'utf8')).trim().split('\n').map(line => JSON.parse(line));
+
+        expect(rows.map(row => row.status)).toEqual(['reobserve-requested']);
+    });
+
+    test('unreadable restart reobservation stays uncertain and suppresses redispatch', async () => {
+        const lifecycleCalls = [],
+              runtime        = {
+                  supportsRestartDispatchInterlock: true,
+                  async applyLifecycle(options) {
+                      lifecycleCalls.push(options);
+                      throw createUncertainRestartError()
+                  },
+                  async readObserve() {
+                      throw new Error('Docker inspect unavailable')
+                  }
+              },
+              {service} = createService({deploymentRuntimeAccessService: runtime}),
+              first     = await service.apply('mc-server', 'restart', {now: 30_000}),
+              deferred  = await service.apply('mc-server', 'restart', {
+                  now: first.reobserveRequest.earliestObservationAt
+              });
+
+        expect(deferred).toMatchObject({
+            status           : 'deferred',
+            reasonCode       : 'restart-effect-reobserve-unreadable',
+            effectDisposition: 'uncertain',
+            error            : 'Docker inspect unavailable'
+        });
+        expect(lifecycleCalls).toHaveLength(1);
+
+        const runDir  = path.join(tmpDir, 'recovery-runs'),
+              runFile = path.join(runDir, (await readdir(runDir))[0]),
+              rows    = (await readFile(runFile, 'utf8')).trim().split('\n').map(line => JSON.parse(line));
+
+        expect(rows.at(-1).status).toBe('reobserve-requested');
+    });
+
+    test('a pre-dispatch restart error remains not-applied and creates no reobserve marker', async () => {
+        const {service} = createService({
+            deploymentRuntimeAccessService: {
+                async applyLifecycle() {
+                    throw new Error('Docker socket unavailable before dispatch')
+                }
+            }
+        });
+
+        const result = await service.apply('mc-server', 'restart', {now: 40_000});
+
+        expect(result).toMatchObject({
+            status           : 'failed',
+            reasonCode       : 'executor-failed',
+            effectDisposition: 'not-applied',
+            reobserveRequest : null
+        });
+        expect((await readAttempts())['mc-server:restart'].pendingRestartReobserve).toBeUndefined();
+    });
+
+    test('authority loss after the durable marker settles not-dispatched without leaving a stale guard', async () => {
+        let held = true;
+
+        const lifecycleCalls = [],
+              runtime        = {
+                  supportsRestartDispatchInterlock: true,
+                  async applyLifecycle(options) {
+                      lifecycleCalls.push(options);
+                      await options.onBeforeRestartDispatch({
+                          baseline: {
+                              containerId: 'container-abc',
+                              startedAt  : '2026-08-13T20:00:00.000Z'
+                          },
+                          clientTimeoutMs      : 15_000,
+                          restartTimeoutSeconds: 10
+                      });
+                      held = false;
+
+                      throw Object.assign(new Error('authority moved before POST'), {
+                          reason: 'runtime-authority-lost'
+                      })
+                  },
+                  async readObserve() {
+                      throw new Error('a terminal no-dispatch row must make reobservation unnecessary')
+                  }
+              },
+              firstService = createService({deploymentRuntimeAccessService: runtime}).service,
+              result       = await firstService.apply('mc-server', 'restart', {
+                  now            : 45_000,
+                  isAuthorityHeld: () => held
+              });
+
+        expect(result).toMatchObject({
+            status           : 'declined',
+            reasonCode       : 'restart-effect-not-dispatched',
+            effectDisposition: 'not-applied'
+        });
+        expect(await readAttempts().catch(error => error.code === 'ENOENT' ? {} : Promise.reject(error))).toEqual({});
+
+        const runDir  = path.join(tmpDir, 'recovery-runs'),
+              runFile = path.join(runDir, (await readdir(runDir))[0]),
+              rows    = (await readFile(runFile, 'utf8')).trim().split('\n').map(line => JSON.parse(line));
+
+        expect(rows.map(row => row.status)).toEqual(['pending', 'no-action']);
+
+        held = true;
+        runtime.applyLifecycle = async options => {
+            lifecycleCalls.push(options);
+            return {proof: {operation: 'restart'}}
+        };
+
+        const successor = createService({deploymentRuntimeAccessService: runtime}).service,
+              next      = await successor.apply('mc-server', 'restart', {
+                  now            : 50_000,
+                  isAuthorityHeld: () => held
+              });
+
+        expect(next.status).toBe('actioned');
+        expect(lifecycleCalls).toHaveLength(2);
+    });
+
+    test('heal-attempt commit rechecks authority after staging and cannot overwrite successor state', async () => {
+        let held          = true,
+            renameReached = false;
+
+        const {service}  = createService(),
+              fileSystem = {
+                  ensureDir: (...args) => fs.ensureDir(...args),
+                  async writeJson(...args) {
+                      await fs.writeJson(...args);
+                      held = false
+                  },
+                  async rename(...args) {
+                      renameReached = true;
+                      return fs.rename(...args)
+                  },
+                  remove: (...args) => fs.remove(...args)
+              };
+
+        await expect(service.writeHealAttempts({successor: false}, {
+            isAuthorityHeld: () => held,
+            fileSystem
+        })).rejects.toMatchObject({reason: 'runtime-authority-lost'});
+
+        expect(renameReached, 'the ownership fence refused before the atomic commit').toBe(false);
+        expect(await readAttempts().catch(error => error.code === 'ENOENT' ? {} : Promise.reject(error))).toEqual({});
     });
 
     test('warm-provider carries the oracle into the selected repair adapter', async () => {

--- a/test/playwright/unit/ai/services/memory-core/helpers/recoveryRunStateStore.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/helpers/recoveryRunStateStore.spec.mjs
@@ -13,6 +13,7 @@ import os   from 'os';
 import path from 'path';
 
 import {
+    ACTIVE_RECOVERY_RUN_RETENTION_CLASS,
     appendRecoveryRunState,
     createRecoveryDiagnosisEvent,
     createRecoveryRunGraphNodes,
@@ -26,6 +27,7 @@ import {
     getRecoveryRunStateFileName,
     publishRecoveryRunStateToGraph,
     pruneRecoveryRunStates,
+    readActiveRecoveryRunStates,
     readRecentRecoveryRunStates,
     RECOVERY_RUN_GRAPH_NODE_TYPES,
     selectRecoveryRunGraphRecords
@@ -436,6 +438,74 @@ test.describe('RecoveryRunStateStore', () => {
 
         const recent = await readRecentRecoveryRunStates({dir: tmpDir, limit: 3});
         expect(recent.map(entry => entry.recoveryRunId)).toEqual(['recovery-09', 'recovery-08', 'recovery-07']);
+    });
+
+    test('retention protects an active effect interlock outside the ordinary recency window', async () => {
+        const activeId   = 'recovery-active',
+              activePath = path.join(tmpDir, getRecoveryRunStateFileName(activeId));
+
+        await appendRecoveryRunState(runEntry(activeId, 1000, {
+            details: {retentionClass: ACTIVE_RECOVERY_RUN_RETENTION_CLASS}
+        }), {dir: tmpDir, retentionLimit: 2});
+        await utimes(activePath, new Date(1), new Date(1));
+
+        for (let i = 0; i < 6; i++) {
+            await appendRecoveryRunState(runEntry(`ordinary-${i}`, 2000 + i, {
+                status          : 'actioned',
+                completedAt     : 2000 + i,
+                reobserveRequest: null
+            }), {dir: tmpDir, retentionLimit: 2});
+        }
+
+        expect(await jsonlCount(tmpDir)).toBe(3);
+        expect(await readActiveRecoveryRunStates({dir: tmpDir})).toMatchObject([{
+            recoveryRunId: activeId,
+            details      : {retentionClass: ACTIVE_RECOVERY_RUN_RETENTION_CLASS}
+        }]);
+
+        await appendRecoveryRunState(runEntry(activeId, 3000, {
+            status          : 'actioned',
+            completedAt     : 3000,
+            reobserveRequest: null,
+            details         : {reasonCode: 'effect-settled'}
+        }), {dir: tmpDir, retentionLimit: 2});
+
+        expect(await readActiveRecoveryRunStates({dir: tmpDir})).toEqual([]);
+
+        await utimes(activePath, new Date(1), new Date(1));
+        await appendRecoveryRunState(runEntry('ordinary-final', 4000, {
+            status          : 'actioned',
+            completedAt     : 4000,
+            reobserveRequest: null
+        }), {dir: tmpDir, retentionLimit: 2});
+
+        expect((await readdir(tmpDir))).not.toContain(getRecoveryRunStateFileName(activeId));
+    });
+
+    test('active reader and pruning fall back across a torn final JSONL row', async () => {
+        const activeId   = 'recovery-torn',
+              activePath = path.join(tmpDir, getRecoveryRunStateFileName(activeId));
+
+        await appendRecoveryRunState(runEntry(activeId, 1000, {
+            details: {retentionClass: ACTIVE_RECOVERY_RUN_RETENTION_CLASS}
+        }), {dir: tmpDir, retentionLimit: 1});
+
+        const durable = await readFile(activePath, 'utf8');
+        await writeFile(activePath, `${durable}{"type":"recovery-run-state"`, 'utf8');
+        await utimes(activePath, new Date(1), new Date(1));
+
+        for (let i = 0; i < 3; i++) {
+            await appendRecoveryRunState(runEntry(`ordinary-torn-${i}`, 2000 + i, {
+                status          : 'actioned',
+                completedAt     : 2000 + i,
+                reobserveRequest: null
+            }), {dir: tmpDir, retentionLimit: 1});
+        }
+
+        expect(await readActiveRecoveryRunStates({dir: tmpDir})).toMatchObject([{
+            recoveryRunId: activeId
+        }]);
+        expect((await readdir(tmpDir))).toContain(getRecoveryRunStateFileName(activeId));
     });
 
     test('readRecentRecoveryRunStates tolerates corrupt diagnostic artifacts', async () => {


### PR DESCRIPTION
Docker restart effects that lose their response are now represented as `uncertain`, durably interlocked before dispatch, and reconciled from fresh container-incarnation evidence before another restart-bearing action can run. The same guard covers direct restart and reconfiguration, survives authority handoff, process recreation, ordinary recovery-ledger pruning, and torn final JSONL writes, and releases only after a terminal settlement.

Resolves neomjs/neo#17065

Evidence: L2 (real Unix-socket post-finish reset plus production-bound runtime, authority, persistence, retention, and cross-action tests) -> L4 required after merge (live external-plane restart under saturated load). Residual: deployment validation, Residual-Owner: neomjs/neo-agent-brain#38.

## Deltas from ticket

- Uses the established `uncertain` effect disposition rather than adding `unknown`.
- Covers every compose actuator path that issues Docker restart: `restart` and restart-bearing `reconfigure`.
- Keeps general cross-window futility policy in neomjs/neo#17044; this PR owns uncertain-effect settlement and duplicate-dispatch prevention.
- Makes unresolved effect interlocks retention-exempt inside the existing recovery-run JSONL source; a terminal row in the same run makes the artifact prunable again.

## Contract Ledger

| Surface | Contract |
|---|---|
| Docker transport failure | Post-dispatch timeout/reset/abort is `effectDisposition: uncertain`; pre-dispatch failure remains `not-applied`. |
| Restart deadline | Client deadline is validated and strictly exceeds Docker's requested stop grace. |
| Recovery ledger | `pending` is written before POST; uncertain response becomes `reobserve-requested`; only positive `StartedAt` advancement settles `applied`. |
| Authority | Runtime and durable stores recheck authority at their mutation/commit boundaries. |
| Retention | `active-effect-interlock` rows are never ordinary retention candidates; terminal rows unpin the same run. |

## Test Evidence

- `235 passed` — focused runtime access, recovery actuator, controller, deployment bridge, and recovery-run store suite.
- `npm run test-unit` — 13,178 passed, 11 skipped, 1 failed out of 13,190. The sole failure was the unrelated live Neural Link MCP boot smoke; an isolated rerun completed with 2 passed and 1 skipped, zero failures.
- `agent-preflight` — restoration classification, ticket archaeology, and block alignment passed.
- `node --check` passed for all seven touched modules/specs; `git diff --check` passed.
- Adversarial blocker-only review: PASS after retention-overflow and cross-action falsifiers were added.

## Post-Merge Validation

Residual-Owner: neomjs/neo-agent-brain#38

- [ ] Deploy the merged `dev` revision to the external plane.
- [ ] Under saturated load, force a Docker restart response beyond the former 5-second client deadline and verify no false `not-applied` record.
- [ ] If the response is lost, verify the next unhealthy cadence inspects the incarnation and sends zero second restart POSTs until positive settlement.
- [ ] Repeat through restart-bearing reconfiguration to prove cross-action coverage.
- [ ] Run a real long provider request while provider-lane recovery lands; verify no duplicate recovery restart interrupts it.

Authored by Euclid (GPT-5.6, Codex Desktop). Session 019ffcf3-1a96-7020-b1fc-e1673092fcca.
