### PR TITLE
fix(ai): keep KB diagnostics available during embedding outages (#17066)

### DIFF
--- a/ai/mcp/server/knowledge-base/Server.mjs
+++ b/ai/mcp/server/knowledge-base/Server.mjs
@@ -124,11 +124,25 @@ class Server extends BaseServer {
     getHeapObservationServiceKey() { return 'kb-server' }
 
     /**
-     * @summary Tools allowed without the healthcheck gate.
+     * @summary Tools allowed without the aggregate health gate.
+     *
+     * Recovery reads stay available when only the embedding provider is degraded. The deployment
+     * snapshot readers touch one orchestrator-written file, while `list_documents` performs a
+     * tenant-scoped Chroma metadata/document read; none embeds request input. Their own storage
+     * failures still surface from the handlers. Semantic queries remain gated because they require
+     * a live embedding provider to serve a result.
      * @returns {Array<String>}
      */
     getHealthExemptTools() {
-        return ['healthcheck', 'get_ingestion_progress', 'list_agent_faqs', 'manage_knowledge_base'];
+        return [
+            'healthcheck',
+            'get_ingestion_progress',
+            'list_agent_faqs',
+            'manage_knowledge_base',
+            'list_documents',
+            'get_deployment_state_snapshot',
+            'inspect_deployment'
+        ];
     }
 
     /**

--- a/test/playwright/unit/ai/mcp/server/knowledge-base/Server.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/knowledge-base/Server.spec.mjs
@@ -13,9 +13,10 @@ setup({
     }
 });
 
-import {test, expect} from '@playwright/test';
-import Neo            from '../../../../../../../src/Neo.mjs';
-import * as core      from '../../../../../../../src/core/_export.mjs';
+import {test, expect}          from '@playwright/test';
+import {CallToolRequestSchema} from '@modelcontextprotocol/sdk/types.js';
+import Neo                     from '../../../../../../../src/Neo.mjs';
+import * as core               from '../../../../../../../src/core/_export.mjs';
 import '../../../../../../../src/manager/Instance.mjs';
 
 test.describe('Neo.ai.mcp.server.knowledge-base.Server', () => {
@@ -119,16 +120,97 @@ test.describe('Neo.ai.mcp.server.knowledge-base.Server', () => {
         expect(() => serverInstance.assertPlaneIdentity()).not.toThrow(/\[Server]/);
     });
 
-    test('#12752/#13464: health exemptions expose recovery tools but not retired database lifecycle tools', async () => {
+    test('#12752/#13464/#17066: health exemptions expose recovery tools but not retired database lifecycle tools', async () => {
         const serverInstance = await createServerWithoutBoot();
 
         try {
             const exemptTools = serverInstance.getHealthExemptTools();
 
-            expect(exemptTools).toEqual(['healthcheck', 'get_ingestion_progress', 'list_agent_faqs', 'manage_knowledge_base']);
+            expect(exemptTools).toEqual([
+                'healthcheck',
+                'get_ingestion_progress',
+                'list_agent_faqs',
+                'manage_knowledge_base',
+                'list_documents',
+                'get_deployment_state_snapshot',
+                'inspect_deployment'
+            ]);
             expect(exemptTools).not.toContain('start_database');
             expect(exemptTools).not.toContain('stop_database');
         } finally {
+            serverInstance.destroy();
+        }
+    });
+
+    test('#17066: non-embedding diagnostics bypass an embedder-degraded gate while semantic queries remain gated', async () => {
+        const serverInstance = await createServerWithoutBoot();
+        const handlers       = new Map();
+        const healthCalls    = [];
+        const toolCalls      = [];
+        const degradedError  = new Error([
+            'Knowledge Base is not fully operational:',
+            '  - Knowledge Base embedding probe failed: provider-timeout'
+        ].join('\n'));
+
+        const mcpServer = {
+            server: {
+                setRequestHandler(schema, handler) {
+                    handlers.set(schema, handler);
+                }
+            }
+        };
+        const originalGetToolService   = serverInstance.getToolService;
+        const originalGetHealthService = serverInstance.getHealthService;
+
+        serverInstance.getToolService = () => ({
+            listTools: () => ({tools: [], nextCursor: undefined}),
+            callTool : (name, args) => {
+                toolCalls.push({name, args});
+                return {ok: true, name};
+            }
+        });
+        serverInstance.getHealthService = () => ({
+            ensureHealthy: async () => {
+                healthCalls.push('ensureHealthy');
+                throw degradedError;
+            }
+        });
+
+        serverInstance.setupRequestHandlers(mcpServer);
+
+        try {
+            const callTool = handlers.get(CallToolRequestSchema);
+
+            for (const [name, args] of [
+                ['list_documents',                {limit: 5}],
+                ['get_deployment_state_snapshot', {}],
+                ['inspect_deployment',            {staleAfterMs: 1000}]
+            ]) {
+                const result = await callTool({params: {name, arguments: args}});
+
+                expect(result.isError).toBe(false);
+                expect(result.structuredContent).toEqual({ok: true, name});
+            }
+
+            expect(healthCalls).toEqual([]);
+            expect(toolCalls).toEqual([
+                {name: 'list_documents',                args: {limit: 5}},
+                {name: 'get_deployment_state_snapshot', args: {}},
+                {name: 'inspect_deployment',            args: {staleAfterMs: 1000}}
+            ]);
+
+            for (const name of ['query_documents', 'ask_knowledge_base']) {
+                const result = await callTool({params: {name, arguments: {query: 'q'}}});
+
+                expect(result.isError).toBe(true);
+                expect(result.content[0].text).toContain(`Cannot execute ${name}: Knowledge Base is not fully operational`);
+            }
+
+            expect(healthCalls).toEqual(['ensureHealthy', 'ensureHealthy']);
+            expect(toolCalls).toHaveLength(3);
+        } finally {
+            serverInstance.getToolService   = originalGetToolService;
+            serverInstance.getHealthService = originalGetHealthService;
             serverInstance.destroy();
         }
     });


### PR DESCRIPTION
Resolves neomjs/neo#17066

Related: neomjs/neo-agent-brain#38
Related: neomjs/neo-agent-brain#54

Keeps Knowledge Base corpus and deployment diagnostics available when only the embedding provider is degraded. The change extends the existing per-server health exemption list for three handlers that never embed request input, while semantic queries remain behind the aggregate health gate.

Evidence: L2 (MCP request-boundary fixture proves diagnostic dispatch and semantic-query refusal; focused KB and MC server suites pass) → L2 required (all neomjs/neo#17066 acceptance criteria are hermetic gate behavior). Residual: external-plane rollout witness, Residual-Owner: neomjs/neo-agent-brain#54.

## Deltas from ticket

Intake narrowed the original prescription. Memory Core already carries the equivalent repair from `#14124` / `#14162`, and Knowledge Base already has the correct `getHealthExemptTools()` seam. This PR therefore adds no dependency framework and changes no MCP response schema; it restores the three missing Knowledge Base entries only: `list_documents`, `get_deployment_state_snapshot`, and `inspect_deployment`.

## Test Evidence

- Knowledge Base MCP server: `npm run test-unit -- test/playwright/unit/ai/mcp/server/knowledge-base/Server.spec.mjs` — 8/8 passed.
- Memory Core precedent control: `npm run test-unit -- test/playwright/unit/ai/mcp/server/memory-core/Server.spec.mjs` — 34/34 passed.
- Complete unit suite: 13,218 passed, 11 skipped, 1 unrelated existing environment failure. `McpServersHealth.spec.mjs` receives Neural Link status `unhealthy` when bridge auto-connect is deferred, while the spec admits only `healthy` / `degraded`; an isolated rerun reproduced that same Neural Link-only failure. The changed Knowledge Base spec passed in the complete run.
- `git diff --check` — passed.
- `npm run agent-preflight -- --change-class restoration ...` — passed.

## Post-Merge Validation

Residual-Owner: neomjs/neo-agent-brain#54

- [ ] During the neomjs/neo-agent-brain#54 external-plane rollout, prove that a deployed revision containing this PR serves `list_documents` and both deployment-state reads while the embedding provider is degraded and storage remains live.

## Evolution

The intake replayed the earlier Memory Core catch-22 and found that the ticket had generalized beyond the remaining defect. Reusing the existing exemption seam keeps this restoration small and avoids a second health-policy substrate.

Authored by Euclid (GPT-5.6 Sol Ultra, Codex). Session 019ffcf3-1a96-7020-b1fc-e1673092fcca.
