### PR TITLE
fix(ai): bind the resolved embedding safe band and classify exact overflow (#17070)

### DIFF
--- a/ai/configBase.mjs
+++ b/ai/configBase.mjs
@@ -827,7 +827,7 @@ class ConfigBase extends ConfigProvider {
                  */
                 embedding: {
                     contextLimitTokens       : leaf(32768, 'NEO_LOCAL_MODELS_EMBEDDING_CONTEXT_LIMIT_TOKENS', 'number'),
-                    safeProcessingLimitTokens: leaf(EMBEDDING_SAFE_PROCESSING_LIMIT_TOKENS, 'NEO_LOCAL_MODELS_EMBEDDING_SAFE_PROCESSING_LIMIT_TOKENS', 'number'),
+                    safeProcessingLimitTokens: leaf(EMBEDDING_SAFE_PROCESSING_LIMIT_TOKENS, 'NEO_LOCAL_MODELS_EMBEDDING_SAFE_PROCESSING_LIMIT_TOKENS', 'positiveInt'),
                     // lms `--parallel` request-slot count for the embedding model. Same primitive as
                     // `localModels.chat.parallel`: each slot carries its own KV cache, so slot count
                     // multiplies resident RAM. Default 1 keeps the embedding role resident without

--- a/ai/configBase.mjs
+++ b/ai/configBase.mjs
@@ -2,6 +2,7 @@ import os                                                          from 'os';
 import path                                                        from 'path';
 import {fileURLToPath}                                             from 'url';
 import ConfigProvider, {leaf}                                      from './ConfigProvider.mjs';
+import {EMBEDDING_SAFE_PROCESSING_LIMIT_TOKENS}                    from './embeddingSafeBand.mjs';
 import {CANONICAL_PLANE_ID, parsePlaneIdEnv, resolvePlaneDataRoot} from './planeConfig.mjs';
 
 const __filename = fileURLToPath(import.meta.url);
@@ -826,7 +827,7 @@ class ConfigBase extends ConfigProvider {
                  */
                 embedding: {
                     contextLimitTokens       : leaf(32768, 'NEO_LOCAL_MODELS_EMBEDDING_CONTEXT_LIMIT_TOKENS', 'number'),
-                    safeProcessingLimitTokens: leaf(28672, 'NEO_LOCAL_MODELS_EMBEDDING_SAFE_PROCESSING_LIMIT_TOKENS', 'number'),
+                    safeProcessingLimitTokens: leaf(EMBEDDING_SAFE_PROCESSING_LIMIT_TOKENS, 'NEO_LOCAL_MODELS_EMBEDDING_SAFE_PROCESSING_LIMIT_TOKENS', 'number'),
                     // lms `--parallel` request-slot count for the embedding model. Same primitive as
                     // `localModels.chat.parallel`: each slot carries its own KV cache, so slot count
                     // multiplies resident RAM. Default 1 keeps the embedding role resident without

--- a/ai/daemons/orchestrator/services/ConfiguredTaskDefinitionsService.mjs
+++ b/ai/daemons/orchestrator/services/ConfiguredTaskDefinitionsService.mjs
@@ -3,7 +3,8 @@ import AiConfig         from '../../../config.mjs';
 import neuralLinkConfig from '../../../mcp/server/neural-link/config.mjs';
 import {
     buildLmsPreloadConfig,
-    buildOllamaReadinessConfig
+    buildOllamaReadinessConfig,
+    checkOpenAiCompatibleEmbeddingServing
 } from '../../../services/graph/providerReadinessHelper.mjs';
 import {
     buildOllamaServeEnv,
@@ -25,12 +26,14 @@ import {attachTaskAuthority} from '../taskAuthority.mjs';
  * @param {String} options.scriptDir Script directory.
  * @param {String} options.nodeBin Node executable.
  * @param {Number} options.neuralLinkBridgeLivenessTimeoutMs Neural Link Bridge liveness timeout.
+ * @param {Function|null} [options.ensureLmsModelsLoadedFn] Optional process-free unit-test seam.
  * @returns {Object}
  */
 export function buildConfiguredTaskDefinitions({
     scriptDir,
     nodeBin,
-    neuralLinkBridgeLivenessTimeoutMs
+    neuralLinkBridgeLivenessTimeoutMs,
+    ensureLmsModelsLoadedFn = null
 }) {
     const tasks = buildTaskDefinitions({
         scriptDir,
@@ -46,7 +49,7 @@ export function buildConfiguredTaskDefinitions({
 
     applyConfiguredGraphLogCompaction(tasks);
     applyConfiguredMlxTask(tasks, {scriptDir});
-    applyConfiguredLmsTask(tasks);
+    applyConfiguredLmsTask(tasks, {ensureLmsModelsLoadedFn});
     applyConfiguredOllamaTask(tasks);
 
     return attachTaskAuthority(tasks);
@@ -94,9 +97,11 @@ function applyConfiguredMlxTask(tasks, {scriptDir}) {
 /**
  * @summary Adds the orchestrator-owned LM Studio server task when enabled.
  * @param {Object} tasks Task table.
+ * @param {Object} options
+ * @param {Function|null} options.ensureLmsModelsLoadedFn Optional process-free unit-test seam.
  * @returns {void}
  */
-function applyConfiguredLmsTask(tasks) {
+function applyConfiguredLmsTask(tasks, {ensureLmsModelsLoadedFn}) {
     if (!AiConfig.orchestrator.lms.enabled) {
         return;
     }
@@ -104,7 +109,11 @@ function applyConfiguredLmsTask(tasks) {
     const preloadConfig  = buildLmsPreloadConfig(AiConfig),
           requiredModels = Array.isArray(preloadConfig.models)
               ? [...new Set(preloadConfig.models.filter(Boolean))]
-              : [AiConfig.orchestrator.lms.model].filter(Boolean);
+              : [AiConfig.orchestrator.lms.model].filter(Boolean),
+          embeddingModel = AiConfig.embeddingProvider === 'openAiCompatible' &&
+              requiredModels.includes(AiConfig.openAiCompatible.embeddingModel)
+                  ? AiConfig.openAiCompatible.embeddingModel
+                  : null;
 
     tasks.lms = {
         label          : 'lms server (LM Studio CLI)',
@@ -134,7 +143,8 @@ function applyConfiguredLmsTask(tasks) {
             }
         },
         postSpawn      : async () => {
-            const {ensureLmsModelsLoaded} = await import('../../../services/graph/providerReadinessHelper.mjs');
+            const ensureLmsModelsLoaded = ensureLmsModelsLoadedFn ||
+                (await import('../../../services/graph/providerReadinessHelper.mjs')).ensureLmsModelsLoaded;
 
             if (requiredModels.length === 0) {
                 return {
@@ -158,7 +168,17 @@ function applyConfiguredLmsTask(tasks) {
                 delayMs                 : AiConfig.orchestrator.providerReadiness.delayMs,
                 timeoutMs               : AiConfig.orchestrator.providerReadiness.timeoutMs,
                 modelDiscoveryFreshness : 'routine',
-                modelDiscoveryCacheTtlMs: AiConfig.orchestrator.providerReadiness.routineCacheTtlMs
+                modelDiscoveryCacheTtlMs: AiConfig.orchestrator.providerReadiness.routineCacheTtlMs,
+                embeddingServingProbe   : embeddingModel
+                    ? ({host, timeoutMs, lmsLoadedModels}) => checkOpenAiCompatibleEmbeddingServing({
+                        host,
+                        model       : embeddingModel,
+                        timeoutMs,
+                        apiKey      : AiConfig.openAiCompatible.apiKey,
+                        lmsLoadedModels,
+                        metadataOnly: true
+                    })
+                    : undefined
             });
         }
     };

--- a/ai/deploy/docker-compose.provider-lanes.yml
+++ b/ai/deploy/docker-compose.provider-lanes.yml
@@ -10,7 +10,7 @@
 #   | node ai/scripts/diagnostics/providerLaneComposition.mjs
 
 x-provider-lane-contract:
-  schemaVersion: provider-lane-composition.v1
+  schemaVersion: provider-lane-composition.v2
   envelope:
     cpus: ${NEO_PROVIDER_LANES_CPU_TOTAL:?total provider CPU envelope required}
     memoryBytes: ${NEO_PROVIDER_LANES_MEMORY_BYTES_TOTAL:?total provider memory envelope required}
@@ -135,6 +135,7 @@ x-provider-lane-env: &provider-lane-env
   NEO_LOCAL_MODELS_CHAT_CONTEXT_LIMIT_TOKENS: ${NEO_PROVIDER_LANE_CHAT_CONTEXT_TOKENS:?chat context required}
   NEO_LOCAL_MODELS_CHAT_PARALLEL: "1"
   NEO_LOCAL_MODELS_EMBEDDING_CONTEXT_LIMIT_TOKENS: ${NEO_PROVIDER_LANE_EMBEDDING_CONTEXT_TOKENS_PER_SLOT_REQUIRED:?embedding per-slot context required}
+  NEO_LOCAL_MODELS_EMBEDDING_SAFE_PROCESSING_LIMIT_TOKENS: ${NEO_LOCAL_MODELS_EMBEDDING_SAFE_PROCESSING_LIMIT_TOKENS:?embedding safe-processing band required}
   NEO_LOCAL_MODELS_EMBEDDING_PARALLEL: ${NEO_PROVIDER_LANE_EMBEDDING_SLOTS:?embedding slots required}
 
 services:

--- a/ai/embeddingSafeBand.mjs
+++ b/ai/embeddingSafeBand.mjs
@@ -1,0 +1,43 @@
+/**
+ * @module ai/embeddingSafeBand
+ * @summary The embedding safe-processing band as ONE shared constant, plus the floor predicate.
+ *
+ * The band is the largest single embedding input Neo will send: a vector computed from a prefix does
+ * not represent the document it is indexed under, so an input larger than a lane's per-slot context
+ * must be refused — never silently truncated by the provider. The literal lives here exactly once so
+ * the `AiConfig` leaf (`localModels.embedding.safeProcessingLimitTokens`) declares its default FROM
+ * this module while Neo-free deploy tooling (the provider-lane election/composition scripts, which
+ * cannot import the config Provider) reads the same declaration. Env binding stays in the leaf,
+ * unconditionally and alone; a script that needs deployment variance takes the value from its own
+ * entrypoint environment and injects it — never a second resolver inside library code.
+ *
+ * 28,672 leaves headroom under the shipped 32,768-token embedding slot context: prompt-template
+ * tokens and tokenizer drift consume the difference, and the margin is deliberate — a band equal to
+ * the slot context would sit one suffix away from silent truncation.
+ */
+
+/**
+ * @summary Canonical default for `localModels.embedding.safeProcessingLimitTokens`.
+ * @type {Number}
+ */
+export const EMBEDDING_SAFE_PROCESSING_LIMIT_TOKENS = 28672;
+
+/**
+ * @summary Whether a per-slot engine context cannot hold a safe-band input.
+ *
+ * Pure and total: non-finite or non-positive inputs report BELOW the band, because a lane whose
+ * context is unknown must not wave safe-band inputs through — the failure this predicate exists to
+ * prevent is silent, permanent, and indistinguishable from correct indexing at every later stage.
+ *
+ * @param {Number} contextTokensPerSlot Engine per-slot context in tokens.
+ * @param {Number} [safeProcessingLimitTokens=EMBEDDING_SAFE_PROCESSING_LIMIT_TOKENS] The band.
+ * @returns {Boolean}
+ */
+export function isEmbeddingContextBelowSafeBand(contextTokensPerSlot, safeProcessingLimitTokens = EMBEDDING_SAFE_PROCESSING_LIMIT_TOKENS) {
+    const context = Number(contextTokensPerSlot),
+          band    = Number(safeProcessingLimitTokens);
+
+    if (!Number.isFinite(band) || band <= 0) return false;
+
+    return !Number.isFinite(context) || context <= 0 || context < band
+}

--- a/ai/embeddingSafeBand.mjs
+++ b/ai/embeddingSafeBand.mjs
@@ -2,18 +2,18 @@
  * @module ai/embeddingSafeBand
  * @summary The embedding safe-processing band as ONE shared constant, plus the floor predicate.
  *
- * The band is the largest single embedding input Neo will send: a vector computed from a prefix does
- * not represent the document it is indexed under, so an input larger than a lane's per-slot context
- * must be refused — never silently truncated by the provider. The literal lives here exactly once so
+ * The band is the operational workload floor every canonical embedding lane must prove it can hold:
+ * an undersized lane either refuses valid workload or risks provider-specific truncation semantics.
+ * Inputs may be smaller or, when observed context proves room, somewhat larger; this value governs
+ * deployment/readiness safety rather than imposing a second request-size cap. The literal lives here exactly once so
  * the `AiConfig` leaf (`localModels.embedding.safeProcessingLimitTokens`) declares its default FROM
- * this module while Neo-free deploy tooling (the provider-lane election/composition scripts, which
- * cannot import the config Provider) reads the same declaration. Env binding stays in the leaf,
- * unconditionally and alone; a script that needs deployment variance takes the value from its own
- * entrypoint environment and injects it — never a second resolver inside library code.
+ * this module. Operational consumers read the resolved leaf at their entrypoint/use site and inject
+ * it into pure helpers; they never treat this default as the active deployment value or create a
+ * second environment resolver.
  *
  * 28,672 leaves headroom under the shipped 32,768-token embedding slot context: prompt-template
  * tokens and tokenizer drift consume the difference, and the margin is deliberate — a band equal to
- * the slot context would sit one suffix away from silent truncation.
+ * the slot context would sit one suffix away from refusal or provider-specific truncation.
  */
 
 /**
@@ -25,19 +25,22 @@ export const EMBEDDING_SAFE_PROCESSING_LIMIT_TOKENS = 28672;
 /**
  * @summary Whether a per-slot engine context cannot hold a safe-band input.
  *
- * Pure and total: non-finite or non-positive inputs report BELOW the band, because a lane whose
+ * Pure and fail-closed: non-finite or non-positive contexts report BELOW the band, because a lane whose
  * context is unknown must not wave safe-band inputs through — the failure this predicate exists to
- * prevent is silent, permanent, and indistinguishable from correct indexing at every later stage.
+ * prevent may otherwise appear only as provider refusal or provider-specific truncated output.
+ * An invalid resolved band is a caller/configuration defect and throws instead of creating a fallback.
  *
  * @param {Number} contextTokensPerSlot Engine per-slot context in tokens.
- * @param {Number} [safeProcessingLimitTokens=EMBEDDING_SAFE_PROCESSING_LIMIT_TOKENS] The band.
+ * @param {Number} safeProcessingLimitTokens The resolved band.
  * @returns {Boolean}
  */
-export function isEmbeddingContextBelowSafeBand(contextTokensPerSlot, safeProcessingLimitTokens = EMBEDDING_SAFE_PROCESSING_LIMIT_TOKENS) {
+export function isEmbeddingContextBelowSafeBand(contextTokensPerSlot, safeProcessingLimitTokens) {
     const context = Number(contextTokensPerSlot),
           band    = Number(safeProcessingLimitTokens);
 
-    if (!Number.isFinite(band) || band <= 0) return false;
+    if (!Number.isSafeInteger(band) || band <= 0) {
+        throw new TypeError(`embedding safe-processing limit must be a positive integer, got ${safeProcessingLimitTokens}`)
+    }
 
-    return !Number.isFinite(context) || context <= 0 || context < band
+    return !Number.isSafeInteger(context) || context <= 0 || context < band
 }

--- a/ai/scripts/benchmark/helpers/providerLaneElectionCore.mjs
+++ b/ai/scripts/benchmark/helpers/providerLaneElectionCore.mjs
@@ -18,7 +18,7 @@ import {median, percentile} from './stats.mjs';
 
 const
     CANDIDATES             = Object.freeze([1, 2, 4]),
-    COMPOSITION_SCHEMA     = 'provider-lane-composition.v1',
+    COMPOSITION_SCHEMA     = 'provider-lane-composition.v2',
     DIGEST_PATTERN         = /^sha256:[0-9a-f]{64}$/,
     EMBED_SOURCES          = Object.freeze(['knowledge-base', 'memory-core', 'orchestrator']),
     LANE_NAMES             = Object.freeze(['chat', 'embedding']),

--- a/ai/scripts/benchmark/provider-lane-election.mjs
+++ b/ai/scripts/benchmark/provider-lane-election.mjs
@@ -18,7 +18,7 @@ import {
 } from './helpers/providerLaneElectionCore.mjs';
 import {writeFileAtomic} from '../../services/shared/atomicFileWrite.mjs';
 
-export const PROVIDER_LANE_ELECTION_REPORT_SCHEMA_VERSION = 'provider-lane-election-report.v1';
+export const PROVIDER_LANE_ELECTION_REPORT_SCHEMA_VERSION = 'provider-lane-election-report.v2';
 
 const
     execFileAsync = promisify(execFile),
@@ -27,7 +27,7 @@ const
     CHAT_SOURCE       = 'chat',
     EMBEDDING_SOURCES = Object.freeze(['knowledge-base', 'memory-core', 'orchestrator']),
     LANE_NAMES        = Object.freeze(['chat', 'embedding']),
-    PLAN_SCHEMA       = 'provider-lane-election-plan.v1',
+    PLAN_SCHEMA       = 'provider-lane-election-plan.v2',
     WORKER_SCHEMA     = 'provider-lane-election-worker.v1',
     WORKER_SENTINEL   = 'NEO_PROVIDER_LANE_WORKER:',
     DIGEST_PATTERN    = /^sha256:[a-f0-9]{64}$/,
@@ -213,7 +213,7 @@ function validateCandidateDeploymentInputs(rows) {
         throw new Error('provider-lane deployment envelopes require candidates 1, 2, and 4 exactly once')
     }
 
-    return sorted.map(row => {
+    const normalized = sorted.map(row => {
         requireExactKeys(row, ['candidate', 'deploymentInputs'], `candidate ${row.candidate}`);
         requireExactKeys(row.deploymentInputs, expectedKeys, `candidate ${row.candidate}.deploymentInputs`);
 
@@ -233,9 +233,20 @@ function validateCandidateDeploymentInputs(rows) {
         if (deploymentInputs.embeddingParallelSlots.value !== row.candidate) {
             throw new Error(`candidate ${row.candidate} deployment envelope changed its embedding slot value`)
         }
+        if (!Number.isSafeInteger(deploymentInputs.embeddingSafeProcessingLimitTokens.value)) {
+            throw new Error(`candidate ${row.candidate} has an invalid integer embedding safe-processing limit`)
+        }
 
         return {candidate: row.candidate, deploymentInputs}
-    })
+    });
+
+    const safeBands = new Set(normalized.map(row =>
+        row.deploymentInputs.embeddingSafeProcessingLimitTokens.value));
+    if (safeBands.size !== 1) {
+        throw new Error('provider-lane deployment envelopes must share one embedding safe-processing limit')
+    }
+
+    return normalized
 }
 
 /**
@@ -803,6 +814,12 @@ function validateProviderLaneElectionReceipts(candidateReceipts, projectName) {
         }
         resolveProviderLaneAdapters(entry.receipt)
     });
+
+    const safeBands = new Set(receipts.map(entry =>
+        entry.receipt.deploymentInputs.embeddingSafeProcessingLimitTokens.value));
+    if (safeBands.size !== 1) {
+        throw new Error('provider-lane election report receipts must share one embedding safe-processing limit')
+    }
 
     return receipts
 }
@@ -1920,7 +1937,6 @@ function createComposeActor({dockerAuthority, plan, projectName, projectRoot, si
         for (const input of Object.values(candidateInput.deploymentInputs)) {
             env[input.env] = String(input.value)
         }
-
         return env
     };
 
@@ -1950,7 +1966,12 @@ function createComposeActor({dockerAuthority, plan, projectName, projectRoot, si
     return {
         async renderReceipt(candidateInput) {
             const {stdout: composition} = await runDocker(candidateInput, ['config', '--format', 'json']);
-            return runAnalyzer({composition, projectRoot, signal})
+            return runAnalyzer({
+                composition,
+                projectRoot,
+                safeProcessingLimitTokensEmbedding: candidateInput.deploymentInputs.embeddingSafeProcessingLimitTokens.value,
+                signal
+            })
         },
         async buildWorkers(receiptEntry) {
             await runDocker(receiptEntry.candidateInput, ['build', 'provider-lane-worker'], {
@@ -2026,11 +2047,15 @@ function createComposeActor({dockerAuthority, plan, projectName, projectRoot, si
  * @summary Feeds rendered Compose to the canonical analyzer without persisting or logging it.
  * @private
  */
-function runAnalyzer({composition, projectRoot, signal}) {
+function runAnalyzer({composition, projectRoot, safeProcessingLimitTokensEmbedding, signal}) {
     return new Promise((resolve, reject) => {
         const child = spawn(process.execPath, [COMPOSITION_ANALYZER], {
-            cwd  : projectRoot,
-            env  : {HOME: process.env.HOME, PATH: process.env.PATH},
+            cwd: projectRoot,
+            env: {
+                HOME                                                                    : process.env.HOME,
+                PATH                                                                    : process.env.PATH,
+                [PROVIDER_LANE_DEPLOYMENT_INPUT_ENVS.embeddingSafeProcessingLimitTokens]: String(safeProcessingLimitTokensEmbedding)
+            },
             signal,
             stdio: ['pipe', 'pipe', 'pipe']
         });

--- a/ai/scripts/diagnostics/providerLaneComposition.mjs
+++ b/ai/scripts/diagnostics/providerLaneComposition.mjs
@@ -2,7 +2,7 @@ import fs                             from 'node:fs';
 import path                           from 'node:path';
 import {fileURLToPath, pathToFileURL} from 'node:url';
 
-import {EMBEDDING_SAFE_PROCESSING_LIMIT_TOKENS, isEmbeddingContextBelowSafeBand} from '../../embeddingSafeBand.mjs';
+import {isEmbeddingContextBelowSafeBand} from '../../embeddingSafeBand.mjs';
 
 /**
  * @module ai/scripts/diagnostics/providerLaneComposition
@@ -21,7 +21,7 @@ const __filename   = fileURLToPath(import.meta.url);
 const __dirname    = path.dirname(__filename);
 const PROJECT_ROOT = path.resolve(__dirname, '../../..');
 
-export const PROVIDER_LANE_COMPOSITION_SCHEMA_VERSION = 'provider-lane-composition.v1';
+export const PROVIDER_LANE_COMPOSITION_SCHEMA_VERSION = 'provider-lane-composition.v2';
 
 /**
  * @summary The exact steady-state liveness probe the embedding lane must run.
@@ -57,7 +57,8 @@ export const PROVIDER_LANE_DEPLOYMENT_INPUT_ENVS       = Object.freeze({
     embeddingTotalContextTokens          : 'NEO_PROVIDER_LANE_EMBEDDING_TOTAL_CONTEXT_TOKENS',
     embeddingContextTokensPerSlotRequired: 'NEO_PROVIDER_LANE_EMBEDDING_CONTEXT_TOKENS_PER_SLOT_REQUIRED',
     embeddingBatchTokens                 : 'NEO_PROVIDER_LANE_EMBEDDING_BATCH_TOKENS',
-    embeddingUbatchTokens                : 'NEO_PROVIDER_LANE_EMBEDDING_UBATCH_TOKENS'
+    embeddingUbatchTokens                : 'NEO_PROVIDER_LANE_EMBEDDING_UBATCH_TOKENS',
+    embeddingSafeProcessingLimitTokens   : 'NEO_LOCAL_MODELS_EMBEDDING_SAFE_PROCESSING_LIMIT_TOKENS'
 });
 export const PROVIDER_LANE_MODEL_CONTRACT               = Object.freeze({
     chat: Object.freeze({
@@ -445,7 +446,13 @@ export function validateProviderLaneCompositionReceipt(receipt, {requireReady = 
         fail(allocations[laneName]?.memoryBytes === lanes[laneName]?.memoryBytes, 'allocation-memory-drift', `envelope.allocations.${laneName}.memoryBytes`, lanes[laneName]?.memoryBytes, allocations[laneName]?.memoryBytes);
     }
 
-    const deploymentInputs         = receipt?.deploymentInputs || {};
+    const deploymentInputs = receipt?.deploymentInputs || {};
+    const receiptSafeBand  = integerAboveZero(
+        deploymentInputs.embeddingSafeProcessingLimitTokens?.value
+    );
+    fail(receiptSafeBand !== null, 'embedding-safe-processing-limit',
+        'deploymentInputs.embeddingSafeProcessingLimitTokens.value',
+        'positive integer', deploymentInputs.embeddingSafeProcessingLimitTokens?.value);
     const expectedDeploymentInputs = {
         totalCpuCores                        : {env: PROVIDER_LANE_DEPLOYMENT_INPUT_ENVS.totalCpuCores, value: total.cpuCores},
         totalMemoryBytes                     : {env: PROVIDER_LANE_DEPLOYMENT_INPUT_ENVS.totalMemoryBytes, value: total.memoryBytes},
@@ -458,7 +465,8 @@ export function validateProviderLaneCompositionReceipt(receipt, {requireReady = 
         embeddingTotalContextTokens          : {env: PROVIDER_LANE_DEPLOYMENT_INPUT_ENVS.embeddingTotalContextTokens, value: lanes.embedding?.totalContextTokens},
         embeddingContextTokensPerSlotRequired: {env: PROVIDER_LANE_DEPLOYMENT_INPUT_ENVS.embeddingContextTokensPerSlotRequired, value: lanes.embedding?.contextTokensPerSlotRequired},
         embeddingBatchTokens                 : {env: PROVIDER_LANE_DEPLOYMENT_INPUT_ENVS.embeddingBatchTokens, value: lanes.embedding?.batchTokens},
-        embeddingUbatchTokens                : {env: PROVIDER_LANE_DEPLOYMENT_INPUT_ENVS.embeddingUbatchTokens, value: lanes.embedding?.ubatchTokens}
+        embeddingUbatchTokens                : {env: PROVIDER_LANE_DEPLOYMENT_INPUT_ENVS.embeddingUbatchTokens, value: lanes.embedding?.ubatchTokens},
+        embeddingSafeProcessingLimitTokens   : {env: PROVIDER_LANE_DEPLOYMENT_INPUT_ENVS.embeddingSafeProcessingLimitTokens, value: receiptSafeBand}
     };
 
     fail(sameSet(Object.keys(deploymentInputs), Object.keys(expectedDeploymentInputs)), 'deployment-input-set',
@@ -469,7 +477,12 @@ export function validateProviderLaneCompositionReceipt(receipt, {requireReady = 
         fail(actual.env === expected.env, 'deployment-input-env', `deploymentInputs.${key}.env`, expected.env, actual.env);
         fail(actual.value === expected.value, 'deployment-input-value', `deploymentInputs.${key}.value`, expected.value, actual.value);
     }
-
+    if (receiptSafeBand !== null) {
+        fail(!isEmbeddingContextBelowSafeBand(lanes.embedding?.contextTokensPerSlotRequired, receiptSafeBand),
+            'lane-slot-context-below-safe-band', 'lanes.embedding.contextTokensPerSlotRequired',
+            `>= deploymentInputs.embeddingSafeProcessingLimitTokens.value (${receiptSafeBand})`,
+            lanes.embedding?.contextTokensPerSlotRequired)
+    }
     const roles = receipt?.roles || {};
     fail(sameSet(Object.keys(roles), PROVIDER_LANE_ROLE_KEYS), 'role-set', 'roles', PROVIDER_LANE_ROLE_KEYS, Object.keys(roles));
     const seenConsumers = new Map();
@@ -507,16 +520,18 @@ export function validateProviderLaneCompositionReceipt(receipt, {requireReady = 
  * @param {Object} [options]
  * @param {String} [options.projectRoot=PROJECT_ROOT] Checkout root for consumer anchors.
  * @param {Boolean} [options.verifySources=true] Verify current source anchors.
+ * @param {Number} options.safeProcessingLimitTokensEmbedding Resolved embedding safe band.
  * @returns {Object} Stable provider-lane receipt.
  */
 export function analyzeProviderLaneComposition(composition, {
     projectRoot   = PROJECT_ROOT,
     verifySources = true,
-    // Opt-in because the analyzer also serves deliberately small fixture lanes that never carry
-    // safe-band inputs. The production CLI (`main`) supplies the canonical band, so a forked compose
-    // declaring a per-slot context below it fails composition instead of running undetected.
     safeProcessingLimitTokensEmbedding = null
 } = {}) {
+    if (!Number.isSafeInteger(safeProcessingLimitTokensEmbedding) || safeProcessingLimitTokensEmbedding <= 0) {
+        throw new TypeError('analyzeProviderLaneComposition requires a positive integer safeProcessingLimitTokensEmbedding')
+    }
+
     const errors      = [];
     const declaration = composition?.['x-provider-lane-contract'];
     const services    = composition?.services || {};
@@ -547,7 +562,8 @@ export function analyzeProviderLaneComposition(composition, {
         embeddingTotalContextTokens          : input('embeddingTotalContextTokens', lanes.embedding.totalContextTokens),
         embeddingContextTokensPerSlotRequired: input('embeddingContextTokensPerSlotRequired', lanes.embedding.contextTokensPerSlotRequired),
         embeddingBatchTokens                 : input('embeddingBatchTokens', lanes.embedding.batchTokens),
-        embeddingUbatchTokens                : input('embeddingUbatchTokens', lanes.embedding.ubatchTokens)
+        embeddingUbatchTokens                : input('embeddingUbatchTokens', lanes.embedding.ubatchTokens),
+        embeddingSafeProcessingLimitTokens   : input('embeddingSafeProcessingLimitTokens', safeProcessingLimitTokensEmbedding)
     };
 
     const receipt = {
@@ -670,10 +686,11 @@ export function analyzeProviderLaneComposition(composition, {
             fail(env[envName] === expectedValue, 'application-route-drift', `services.${serviceKey}.environment.${envName}`, expectedValue, env[envName]);
         }
         for (const [envName, expectedValue] of Object.entries({
-            NEO_LOCAL_MODELS_CHAT_CONTEXT_LIMIT_TOKENS     : lanes.chat.contextTokensPerSlotRequired,
-            NEO_LOCAL_MODELS_CHAT_PARALLEL                 : lanes.chat.parallelSlots,
-            NEO_LOCAL_MODELS_EMBEDDING_CONTEXT_LIMIT_TOKENS: lanes.embedding.contextTokensPerSlotRequired,
-            NEO_LOCAL_MODELS_EMBEDDING_PARALLEL            : lanes.embedding.parallelSlots
+            NEO_LOCAL_MODELS_CHAT_CONTEXT_LIMIT_TOKENS                              : lanes.chat.contextTokensPerSlotRequired,
+            NEO_LOCAL_MODELS_CHAT_PARALLEL                                          : lanes.chat.parallelSlots,
+            NEO_LOCAL_MODELS_EMBEDDING_CONTEXT_LIMIT_TOKENS                         : lanes.embedding.contextTokensPerSlotRequired,
+            [PROVIDER_LANE_DEPLOYMENT_INPUT_ENVS.embeddingSafeProcessingLimitTokens]: safeProcessingLimitTokensEmbedding,
+            NEO_LOCAL_MODELS_EMBEDDING_PARALLEL                                     : lanes.embedding.parallelSlots
         })) {
             fail(integerAboveZero(env[envName]) === expectedValue, 'application-runtime-contract-drift',
                 `services.${serviceKey}.environment.${envName}`, expectedValue, env[envName]);
@@ -715,17 +732,6 @@ export function analyzeProviderLaneComposition(composition, {
     const structural = validateProviderLaneCompositionReceipt(receipt, {requireReady: false});
     errors.push(...structural.errors);
 
-    // The structural validator enforces the profile against itself; this floor ties the embedding
-    // lane to the safe band Neo actually sends. A per-slot context below the band passes every
-    // self-referential gate while guaranteeing that inputs Neo classifies as safe will not fit —
-    // and the provider's answer to an oversized input is a silent prefix-truncation, not an error.
-    // Both numbers are named because the actionable surface is whichever one is wrong.
-    if (safeProcessingLimitTokensEmbedding !== null) {
-        fail(isEmbeddingContextBelowSafeBand(lanes.embedding.contextTokensPerSlotRequired, safeProcessingLimitTokensEmbedding) !== true,
-            'lane-slot-context-below-safe-band', 'lanes.embedding.contextTokensPerSlotRequired',
-            `>= safeProcessingLimitTokens (${safeProcessingLimitTokensEmbedding})`, lanes.embedding.contextTokensPerSlotRequired);
-    }
-
     receipt.ready = errors.length === 0;
     return receipt
 }
@@ -756,15 +762,17 @@ export function parseArgs(argv = []) {
 /**
  * @summary Reads rendered Compose JSON and emits exactly one JSON receipt.
  * @param {String[]} [argv] Arguments without node/script.
- * @returns {Object} Emitted receipt.
+ * @returns {Promise<Object>} Emitted receipt.
  */
-export function main(argv = process.argv.slice(2)) {
+export async function main(argv = process.argv.slice(2)) {
     const options     = parseArgs(argv);
     const source      = options.input ? fs.readFileSync(options.input, 'utf8') : fs.readFileSync(0, 'utf8');
     const composition = JSON.parse(source);
-    const receipt     = analyzeProviderLaneComposition(composition, {
+    await import('../../../src/Neo.mjs');
+    const {default: AiConfig} = await import('../../config.mjs');
+    const receipt             = analyzeProviderLaneComposition(composition, {
         verifySources                     : options.verifySources,
-        safeProcessingLimitTokensEmbedding: EMBEDDING_SAFE_PROCESSING_LIMIT_TOKENS
+        safeProcessingLimitTokensEmbedding: AiConfig.localModels.embedding.safeProcessingLimitTokens
     });
 
     process.stdout.write(`${JSON.stringify(receipt, null, 2)}\n`);
@@ -773,10 +781,8 @@ export function main(argv = process.argv.slice(2)) {
 }
 
 if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
-    try {
-        main()
-    } catch (error) {
+    main().catch(error => {
         process.stderr.write(`providerLaneComposition: ${error.message}\n`);
         process.exitCode = 2;
-    }
+    })
 }

--- a/ai/scripts/diagnostics/providerLaneComposition.mjs
+++ b/ai/scripts/diagnostics/providerLaneComposition.mjs
@@ -2,6 +2,8 @@ import fs                             from 'node:fs';
 import path                           from 'node:path';
 import {fileURLToPath, pathToFileURL} from 'node:url';
 
+import {EMBEDDING_SAFE_PROCESSING_LIMIT_TOKENS, isEmbeddingContextBelowSafeBand} from '../../embeddingSafeBand.mjs';
+
 /**
  * @module ai/scripts/diagnostics/providerLaneComposition
  * @summary Turns rendered Compose JSON into the stable, machine-readable provider-lane receipt
@@ -509,7 +511,11 @@ export function validateProviderLaneCompositionReceipt(receipt, {requireReady = 
  */
 export function analyzeProviderLaneComposition(composition, {
     projectRoot   = PROJECT_ROOT,
-    verifySources = true
+    verifySources = true,
+    // Opt-in because the analyzer also serves deliberately small fixture lanes that never carry
+    // safe-band inputs. The production CLI (`main`) supplies the canonical band, so a forked compose
+    // declaring a per-slot context below it fails composition instead of running undetected.
+    safeProcessingLimitTokensEmbedding = null
 } = {}) {
     const errors      = [];
     const declaration = composition?.['x-provider-lane-contract'];
@@ -708,6 +714,18 @@ export function analyzeProviderLaneComposition(composition, {
 
     const structural = validateProviderLaneCompositionReceipt(receipt, {requireReady: false});
     errors.push(...structural.errors);
+
+    // The structural validator enforces the profile against itself; this floor ties the embedding
+    // lane to the safe band Neo actually sends. A per-slot context below the band passes every
+    // self-referential gate while guaranteeing that inputs Neo classifies as safe will not fit —
+    // and the provider's answer to an oversized input is a silent prefix-truncation, not an error.
+    // Both numbers are named because the actionable surface is whichever one is wrong.
+    if (safeProcessingLimitTokensEmbedding !== null) {
+        fail(isEmbeddingContextBelowSafeBand(lanes.embedding.contextTokensPerSlotRequired, safeProcessingLimitTokensEmbedding) !== true,
+            'lane-slot-context-below-safe-band', 'lanes.embedding.contextTokensPerSlotRequired',
+            `>= safeProcessingLimitTokens (${safeProcessingLimitTokensEmbedding})`, lanes.embedding.contextTokensPerSlotRequired);
+    }
+
     receipt.ready = errors.length === 0;
     return receipt
 }
@@ -744,7 +762,10 @@ export function main(argv = process.argv.slice(2)) {
     const options     = parseArgs(argv);
     const source      = options.input ? fs.readFileSync(options.input, 'utf8') : fs.readFileSync(0, 'utf8');
     const composition = JSON.parse(source);
-    const receipt     = analyzeProviderLaneComposition(composition, {verifySources: options.verifySources});
+    const receipt     = analyzeProviderLaneComposition(composition, {
+        verifySources                     : options.verifySources,
+        safeProcessingLimitTokensEmbedding: EMBEDDING_SAFE_PROCESSING_LIMIT_TOKENS
+    });
 
     process.stdout.write(`${JSON.stringify(receipt, null, 2)}\n`);
     if (!receipt.ready) process.exitCode = 1;

--- a/ai/services/graph/providerReadinessHelper.mjs
+++ b/ai/services/graph/providerReadinessHelper.mjs
@@ -1,9 +1,10 @@
-import http       from 'http';
-import {execFile} from 'child_process';
-import os         from 'os';
-import path       from 'path';
-import aiConfig   from '../../mcp/server/memory-core/config.mjs';
-import logger     from '../../mcp/server/memory-core/logger.mjs';
+import http                              from 'http';
+import {execFile}                        from 'child_process';
+import os                                from 'os';
+import path                              from 'path';
+import aiConfig                          from '../../mcp/server/memory-core/config.mjs';
+import {isEmbeddingContextBelowSafeBand} from '../../embeddingSafeBand.mjs';
+import logger                            from '../../mcp/server/memory-core/logger.mjs';
 import {
     buildOllamaEvalAttribution,
     extractOllamaEvalSample
@@ -758,6 +759,27 @@ export async function checkOpenAiCompatibleEmbeddingServing({
     const
         loadedModel  = Array.isArray(lmsLoadedModels) ? lmsLoadedModels.find(item => item?.id === model) : null,
         requestInput = withLmsEmbeddingInputSuffix(input, loadedModel);
+
+    // The probe input is deliberately tiny, so it answers "can the provider answer at all" — and a
+    // lane whose per-slot context is below the safe band would pass it while being unable to hold a
+    // single safe-band input. Readiness must answer the harder question: when the loaded context is
+    // known and below the band, the lane is NOT ready, and both numbers are named because the
+    // actionable surface is whichever one is wrong. A truncated embed is silent and permanent; a
+    // false not-ready is loud and recoverable, so the floor fires on knowledge, not on doubt.
+    const safeProcessingLimitTokens = aiConfig.localModels.embedding.safeProcessingLimitTokens;
+
+    if (loadedModel && Number.isFinite(Number(loadedModel.contextLength)) &&
+        isEmbeddingContextBelowSafeBand(loadedModel.contextLength, safeProcessingLimitTokens)) {
+        return {
+            ready   : false,
+            degraded: true,
+            provider: 'openAiCompatible',
+            host,
+            model,
+            reason  : 'embedding-context-below-safe-band',
+            warning : `[provider/openAiCompatible] embedding lane for '${model}' cannot hold a safe-band input (loadedContext=${loadedModel.contextLength}, safeProcessingLimitTokens=${safeProcessingLimitTokens})`
+        };
+    }
 
     const runProbe = async () => {
         const response = await fetchFn(new URL('/v1/embeddings', host).toString(), {

--- a/ai/services/graph/providerReadinessHelper.mjs
+++ b/ai/services/graph/providerReadinessHelper.mjs
@@ -692,22 +692,24 @@ export async function fetchOpenAiCompatibleModelIds({
 }
 
 /**
- * @summary Runs one tiny OpenAI-compatible embedding-serving canary.
+ * @summary Checks OpenAI-compatible embedding readiness through metadata or one tiny canary.
  *
- * This probe verifies `/v1/embeddings` can serve the configured embedding model
- * without returning or logging vector bodies. The caller owns load gating through
- * `shouldRun`; a skipped decision returns an explicit degraded envelope instead
- * of issuing a provider request during heavy maintenance or known contention.
+ * Metadata-only mode evaluates authoritative LM Studio resident-context rows and performs no
+ * embedding request or input-suffix work. Canary mode verifies `/v1/embeddings` can serve the
+ * configured model without returning or logging vector bodies. In canary mode, the caller owns
+ * load gating through `shouldRun`; a skipped decision returns an explicit degraded envelope instead
+ * of issuing provider work during heavy maintenance or known contention.
  *
  * @param {Object} options
  * @param {String} options.host Provider host.
  * @param {String} options.model Embedding model identifier.
- * @param {String} options.input Tiny canary text. Required and capped at 256 UTF-8 bytes.
+ * @param {String} [options.input] Tiny canary text. Required unless `metadataOnly`; capped at 256 UTF-8 bytes.
  * @param {Number} options.timeoutMs HTTP timeout. Required; no module-level default.
  * @param {String} [options.apiKey] Optional OpenAI-compatible bearer token.
- * @param {Object[]} [options.lmsLoadedModels] Optional LMS metadata rows for suffix parity with TextEmbeddingService.
+ * @param {Object[]} [options.lmsLoadedModels] LMS metadata rows; required evidence in metadata-only mode and optional suffix metadata in canary mode.
+ * @param {Boolean} [options.metadataOnly=false] Check authoritative LMS context without issuing an embedding canary.
  * @param {Function} [options.fetchFn=fetch] Fetch seam for tests.
- * @param {Function} [options.shouldRun] Optional load/backpressure gate.
+ * @param {Function} [options.shouldRun] Optional canary-mode load/backpressure gate.
  * @returns {Promise<Object>}
  */
 export async function checkOpenAiCompatibleEmbeddingServing({
@@ -717,6 +719,7 @@ export async function checkOpenAiCompatibleEmbeddingServing({
     timeoutMs,
     apiKey,
     lmsLoadedModels = [],
+    metadataOnly = false,
     fetchFn = fetch,
     shouldRun
 } = {}) {
@@ -729,14 +732,14 @@ export async function checkOpenAiCompatibleEmbeddingServing({
     if (typeof timeoutMs !== 'number') {
         throw new TypeError('checkOpenAiCompatibleEmbeddingServing: timeoutMs is required');
     }
-    if (!Neo.isString(input) || input.length === 0) {
+    if (!metadataOnly && (!Neo.isString(input) || input.length === 0)) {
         throw new TypeError('checkOpenAiCompatibleEmbeddingServing: non-empty input is required');
     }
-    if (Buffer.byteLength(input, 'utf8') > 256) {
+    if (!metadataOnly && Buffer.byteLength(input, 'utf8') > 256) {
         throw new TypeError('checkOpenAiCompatibleEmbeddingServing: input must be <= 256 UTF-8 bytes');
     }
 
-    const gate = shouldRun ? await shouldRun({host, model, timeoutMs}) : true;
+    const gate = !metadataOnly && shouldRun ? await shouldRun({host, model, timeoutMs}) : true;
 
     if (gate === false || gate?.run === false || gate?.skipped === true) {
         return {
@@ -751,14 +754,9 @@ export async function checkOpenAiCompatibleEmbeddingServing({
         };
     }
 
-    const headers = {'content-type': 'application/json'};
-    if (apiKey) {
-        headers.authorization = `Bearer ${apiKey}`;
-    }
-
-    const
-        loadedModel  = Array.isArray(lmsLoadedModels) ? lmsLoadedModels.find(item => item?.id === model) : null,
-        requestInput = withLmsEmbeddingInputSuffix(input, loadedModel);
+    const loadedModel = Array.isArray(lmsLoadedModels)
+        ? lmsLoadedModels.find(item => item?.id === model)
+        : null;
 
     // The probe input is deliberately tiny, so it answers "can the provider answer at all" — and a
     // lane whose per-slot context is below the safe band would pass it while being unable to hold a
@@ -780,6 +778,35 @@ export async function checkOpenAiCompatibleEmbeddingServing({
             warning : `[provider/openAiCompatible] embedding lane for '${model}' cannot hold a safe-band input (loadedContext=${loadedModel.contextLength}, safeProcessingLimitTokens=${safeProcessingLimitTokens})`
         };
     }
+
+    if (metadataOnly) {
+        if (!loadedModel || !Number.isFinite(Number(loadedModel.contextLength))) {
+            return {
+                ready   : false,
+                degraded: true,
+                provider: 'openAiCompatible',
+                host,
+                model,
+                reason  : 'embedding-context-unobservable',
+                warning : `[provider/openAiCompatible] embedding lane context for '${model}' is not observable`
+            };
+        }
+
+        return {
+            ready                : true,
+            degraded             : false,
+            provider             : 'openAiCompatible',
+            host,
+            model,
+            observedContextLength: Number(loadedModel.contextLength)
+        }
+    }
+
+    const headers = {'content-type': 'application/json'};
+    if (apiKey) {
+        headers.authorization = `Bearer ${apiKey}`;
+    }
+    const requestInput = withLmsEmbeddingInputSuffix(input, loadedModel);
 
     const runProbe = async () => {
         const response = await fetchFn(new URL('/v1/embeddings', host).toString(), {

--- a/ai/services/knowledge-base/helpers/embedFailureClassification.mjs
+++ b/ai/services/knowledge-base/helpers/embedFailureClassification.mjs
@@ -106,6 +106,7 @@ const INTERNAL_EMBED_ERROR_CODES = Object.freeze(new Set([
 const PROVIDER_ERROR_CODE_MAP = Object.freeze({
     ABORT_ERR                        : 'KB_VECTOR_EMBED_ABORTED',
     ECONNREFUSED                     : 'KB_VECTOR_EMBED_CONNECTION_REFUSED',
+    EMBEDDING_INPUT_TRUNCATED        : 'KB_VECTOR_EMBED_INPUT_TRUNCATED',
     EMBEDDING_MODEL_NOT_RESIDENT     : 'KB_VECTOR_EMBED_MODEL_NOT_RESIDENT',
     EMBEDDING_PROBE_TIMEOUT          : 'KB_VECTOR_EMBED_TIMEOUT',
     OPENAI_COMPATIBLE_REQUEST_TIMEOUT: 'KB_VECTOR_EMBED_PROVIDER_TIMEOUT',
@@ -230,7 +231,12 @@ export const EMBED_DISPOSITION = Object.freeze({
 const REJECTED_EMBED_ERROR_CODES = Object.freeze(new Set([
     'KB_EMBEDDING_INPUT_SIZE_EXCEEDED',
     'KB_SYNC_VOLUME_EXCEEDED',
-    'KB_TENANT_SPOOF_REJECTED'
+    'KB_TENANT_SPOOF_REJECTED',
+    // Truncation is permanent for the input that produced it: re-ingesting the same content under
+    // the same lane shape reproduces the same cut vector, so a later retry is futile by
+    // construction. Rejected, never deferred — the actionable surface is the slot-context floor,
+    // not the retry budget.
+    'KB_VECTOR_EMBED_INPUT_TRUNCATED'
 ]));
 
 /**

--- a/ai/services/knowledge-base/helpers/embedFailureClassification.mjs
+++ b/ai/services/knowledge-base/helpers/embedFailureClassification.mjs
@@ -99,13 +99,14 @@ const INTERNAL_EMBED_ERROR_CODES = Object.freeze(new Set([
  * Two timeout sources map to different codes on purpose: a consumer-owned deadline expiring
  * (`EMBEDDING_PROBE_TIMEOUT`, raised by our own caller) and the provider's own request timeout are
  * different faults with different fixes — raise our deadline, versus the provider is too slow or
- * wedged. The map also translates a source-owned model-residency code and Node's foreign transport
- * refusal code; neither is echoed. Collapsing them would rebuild the ambiguity this module removes.
+ * wedged. The map also translates source-owned context/residency codes and Node's foreign transport
+ * refusal code; none is echoed. Collapsing them would rebuild the ambiguity this module removes.
  * @type {Object}
  */
 const PROVIDER_ERROR_CODE_MAP = Object.freeze({
     ABORT_ERR                        : 'KB_VECTOR_EMBED_ABORTED',
     ECONNREFUSED                     : 'KB_VECTOR_EMBED_CONNECTION_REFUSED',
+    EMBEDDING_CONTEXT_INSUFFICIENT   : 'KB_VECTOR_EMBED_CONTEXT_INSUFFICIENT',
     EMBEDDING_INPUT_TRUNCATED        : 'KB_VECTOR_EMBED_INPUT_TRUNCATED',
     EMBEDDING_MODEL_NOT_RESIDENT     : 'KB_VECTOR_EMBED_MODEL_NOT_RESIDENT',
     EMBEDDING_PROBE_TIMEOUT          : 'KB_VECTOR_EMBED_TIMEOUT',
@@ -222,20 +223,21 @@ export const EMBED_DISPOSITION = Object.freeze({
  * over the embedding budget is over it on every retry; a work-volume gate refused on purpose and a
  * silent requeue would launder that refusal; a rejected tenant must never be retried into success.
  *
- * These are exactly the codes {@link classifyEmbedFailureCode} passes through by membership, and
- * that is not a coincidence — a code we mint is one whose permanence we actually know. Everything
- * arriving in the provider's vocabulary describes a fault we are inferring about someone else's
- * process, which is not a basis for discarding a corpus.
+ * Most entries pass through {@link classifyEmbedFailureCode} directly. The truncation entry is the
+ * bounded translation of `TextEmbeddingService`'s source-owned current-input overflow: either its
+ * bounded estimate exceeds an otherwise policy-compliant trusted resident context, or the exact
+ * structured refusal proves the input/context relation. Arbitrary provider prose and foreign
+ * provider codes remain deferrable: inference about another process is not a basis for discarding a
+ * corpus.
  * @type {Set<String>}
  */
 const REJECTED_EMBED_ERROR_CODES = Object.freeze(new Set([
     'KB_EMBEDDING_INPUT_SIZE_EXCEEDED',
     'KB_SYNC_VOLUME_EXCEEDED',
     'KB_TENANT_SPOOF_REJECTED',
-    // Truncation is permanent for the input that produced it: re-ingesting the same content under
-    // the same lane shape reproduces the same cut vector, so a later retry is futile by
-    // construction. Rejected, never deferred — the actionable surface is the slot-context floor,
-    // not the retry budget.
+    // The current input is classified too large for a policy-compliant observed context, or the
+    // provider emitted the exact structured refusal. A context-policy mismatch takes precedence and
+    // uses the distinct deferrable code because repairing the resident may make the same input fit.
     'KB_VECTOR_EMBED_INPUT_TRUNCATED'
 ]));
 

--- a/ai/services/memory-core/TextEmbeddingService.mjs
+++ b/ai/services/memory-core/TextEmbeddingService.mjs
@@ -85,21 +85,72 @@ function markEmbeddingModelNotResidentError(error) {
 export const EMBEDDING_BATCH_YIELDED_CODE = 'EMBEDDING_BATCH_YIELDED';
 
 /**
- * @summary Source-owned code for an embedding input the provider could only answer by truncating.
+ * @summary Source-owned code for a current embedding input classified beyond provider context.
  *
- * Minted on two arms of the same fact: a pre-dispatch refusal when the observed per-slot context
- * cannot hold the input (or cannot hold the safe band at all), and a provider refusal after the
- * request asked for `truncate: false`. A truncated embedding must never be stored — a vector
- * computed from a prefix does not represent the document it is indexed under, and the failure is
- * silent, permanent, and invisible to every later stage. Retry cannot help: the same input under the
- * same lane shape truncates again, so the KB boundary classifies the bounded translation as
- * rejected, not deferrable.
+ * Minted when Neo's bounded LM Studio token estimate exceeds an otherwise policy-compliant resident
+ * context, or when an OpenAI-compatible provider returns the exact structured
+ * `exceed_context_size_error` refusal. If the resident itself is below the declared lane policy,
+ * that repairable context cause takes precedence because reloading the model may make the same input
+ * fit. A truncated embedding must never be stored, so the KB boundary rejects only this input cause.
  *
  * This shared Memory Core service must not mint a downstream Knowledge Base `KB_*` code; the KB
  * ingestion boundary translates this cause into its own durable vocabulary.
  * @type {String}
  */
 export const EMBEDDING_INPUT_TRUNCATED_CODE = 'EMBEDDING_INPUT_TRUNCATED';
+
+/**
+ * @summary Source-owned code for a loaded embedding context below Neo's active lane contract.
+ *
+ * A resident may be below the configured requirement or safe-processing band while still holding
+ * the current input. That is a repairable deployment/context-policy mismatch, not proof that this
+ * input was or would be truncated. Knowledge Base therefore translates it distinctly and keeps it
+ * deferrable rather than discarding work under the permanent-input refusal.
+ * @type {String}
+ */
+export const EMBEDDING_CONTEXT_INSUFFICIENT_CODE = 'EMBEDDING_CONTEXT_INSUFFICIENT';
+
+/**
+ * @summary Marks a bounded estimate-based or exact structured current-input overflow.
+ * @param {Error} error A trusted-metadata estimate failure or exact structured provider refusal.
+ * @returns {Error} The same typed error.
+ */
+function markEmbeddingInputTruncatedError(error) {
+    error.code = EMBEDDING_INPUT_TRUNCATED_CODE;
+    return error
+}
+
+/**
+ * @summary Marks a repairable loaded-context policy mismatch without claiming input truncation.
+ * @param {Error} error The trusted-metadata context-policy failure.
+ * @returns {Error} The same typed error.
+ */
+function markEmbeddingContextInsufficientError(error) {
+    error.code = EMBEDDING_CONTEXT_INSUFFICIENT_CODE;
+    return error
+}
+
+/**
+ * @summary Recognizes the pinned llama.cpp context-overflow refusal without provider-prose inference.
+ * @param {Number} statusCode HTTP status code.
+ * @param {String} body Raw response body.
+ * @returns {Boolean}
+ */
+function isStructuredEmbeddingContextOverflow(statusCode, body) {
+    if (statusCode !== 400 || typeof body !== 'string' || body.length === 0) return false;
+
+    try {
+        const payload = JSON.parse(body),
+              detail  = payload?.error ?? payload;
+
+        return detail?.code === 400 && detail?.type === 'exceed_context_size_error' &&
+            Number.isSafeInteger(detail.n_prompt_tokens) && detail.n_prompt_tokens > 0 &&
+            Number.isSafeInteger(detail.n_ctx) && detail.n_ctx > 0 &&
+            detail.n_prompt_tokens >= detail.n_ctx
+    } catch {
+        return false
+    }
+}
 
 /**
  * @summary Classifies a cooperative batch-yield abandonment at the consumer boundary.
@@ -945,7 +996,7 @@ class TextEmbeddingService extends Base {
     }
 
     /**
-     * @summary Fails before OpenAI-compatible embeddings can be silently provider-truncated.
+     * @summary Enforces the loaded LM Studio context contract and refuses current-input overflow.
      * @param {String|String[]} inputData The text or array of texts to embed.
      * @param {{configuredContextLength: Number, loadedModel: Object, model: String}|null} runtime LMS runtime metadata.
      * @returns {void}
@@ -958,10 +1009,16 @@ class TextEmbeddingService extends Base {
 
         const
             {configuredContextLength, loadedModel, model} = runtime,
+            safeProcessingLimitTokens                     = aiConfig.localModels.embedding.safeProcessingLimitTokens,
             estimate                                      = this.#getOpenAiCompatibleInputEstimate(inputData);
 
-        if (loadedModel.contextLength < configuredContextLength || estimate.inputTokensEstimate > loadedModel.contextLength) {
-            if (estimate.inputTokensEstimate > loadedModel.contextLength) {
+        const belowConfiguredContext = loadedModel.contextLength < configuredContextLength,
+              belowSafeBand          = isEmbeddingContextBelowSafeBand(loadedModel.contextLength, safeProcessingLimitTokens),
+              contextInsufficient    = belowConfiguredContext || belowSafeBand,
+              inputExceedsContext    = estimate.inputTokensEstimate > loadedModel.contextLength;
+
+        if (contextInsufficient || inputExceedsContext) {
+            if (!contextInsufficient && inputExceedsContext) {
                 emitConsumerFriction({
                     assetRef                 : `openAiCompatible:${model}`,
                     consumer                 : 'TextEmbeddingService.openAiCompatible',
@@ -978,114 +1035,19 @@ class TextEmbeddingService extends Base {
                 });
             }
 
-            logger.warn('[TextEmbeddingService] Refusing OpenAI-compatible embedding before provider-side truncation.', {
+            logger.warn('[TextEmbeddingService] Refusing OpenAI-compatible embedding after LM Studio context verification failed.', {
                 model,
                 loadedContextLength: loadedModel.contextLength,
                 configuredContextLength,
+                safeProcessingLimitTokens,
                 inputTokensEstimate: estimate.inputTokensEstimate
             });
 
-            throw new Error(`TextEmbeddingService: LM Studio embedding context too small for '${model}' (loaded=${loadedModel.contextLength}, configured>=${configuredContextLength}, inputEstimate=${estimate.inputTokensEstimate})`);
-        }
-    }
+            const error = new Error(`TextEmbeddingService: LM Studio embedding context too small for '${model}' (loaded=${loadedModel.contextLength}, configured>=${configuredContextLength}, safeProcessingLimitTokens=${safeProcessingLimitTokens}, inputEstimate=${estimate.inputTokensEstimate})`);
 
-    /**
-     * @summary Observes the provider's per-slot context on non-LM-Studio OpenAI-compatible lanes.
-     *
-     * The LMS preflight above is blind on every other flavor — llama.cpp, vLLM, fixture servers —
-     * because its metadata comes from the `lms` CLI. Those flavors publish per-slot context over
-     * HTTP instead: llama.cpp's `/slots` endpoint (enabled on the canonical lane) reports `n_ctx`
-     * per slot. A lane that cannot answer `/slots` reports `null` here and the wire-level
-     * `truncate: false` request flag remains the only defense — documented, not silent.
-     *
-     * Test seam: tests set `TextEmbeddingService.openAiCompatibleSlotContextProbe` directly with a
-     * fake to bypass the network, mirroring `openAiCompatibleLoadedModelsProbe`.
-     *
-     * @param {AbortSignal|undefined} signal Upstream cancellation signal.
-     * @param {String} operationLabel Bounded operation label.
-     * @returns {Promise<Number|null>} The smallest per-slot context in tokens, or null when unobservable.
-     * @private
-     */
-    async #getOpenAiCompatibleSlotContextTokens(signal, operationLabel) {
-        if (this.openAiCompatibleSlotContextProbe) {
-            return this.openAiCompatibleSlotContextProbe();
-        }
-        if (Neo.config.unitTestMode) {
-            return null;
-        }
-
-        const
-            host      = aiConfig.openAiCompatible.host,
-            timeoutMs = aiConfig.orchestrator.providerReadiness.timeoutMs;
-
-        let response;
-
-        try {
-            response = await fetch(new URL('/slots', host).toString(), {
-                signal: signal && typeof AbortSignal.any === 'function'
-                    ? AbortSignal.any([signal, AbortSignal.timeout(timeoutMs)])
-                    : AbortSignal.timeout(timeoutMs)
-            });
-        } catch {
-            return null; // endpoint absent or unreachable: unobservable, not zero
-        }
-
-        if (!response.ok) return null;
-
-        let slots;
-
-        try {
-            slots = await response.json();
-        } catch {
-            return null;
-        }
-
-        if (!Array.isArray(slots) || slots.length === 0) return null;
-
-        const contexts = slots
-            .map(slot => Number(slot?.n_ctx))
-            .filter(value => Number.isFinite(value) && value > 0);
-
-        return contexts.length > 0 ? Math.min(...contexts) : null;
-    }
-
-    /**
-     * @summary Refuses an embedding input the provider could only answer by truncating, on any flavor.
-     *
-     * Two distinct floors, one code, because both name the same operator action — raise the lane's
-     * per-slot context or lower the band:
-     *
-     * - **Lane floor:** a per-slot context below `safeProcessingLimitTokens` can never hold a
-     *   safe-band input; embedding into it manufactures silently-wrong vectors at scale.
-     * - **Input floor:** this input's estimate exceeds the observed per-slot context right now.
-     *
-     * @param {String|String[]} inputData The provider-bound text input.
-     * @param {AbortSignal|undefined} signal Upstream cancellation signal.
-     * @param {String} operationLabel Bounded operation label.
-     * @returns {Promise<void>}
-     * @private
-     */
-    async #assertOpenAiCompatibleSlotFloor(inputData, signal, operationLabel) {
-        const slotContextTokens = await this.#getOpenAiCompatibleSlotContextTokens(signal, operationLabel);
-
-        if (slotContextTokens === null) return; // unobservable lane: the wire flag is the defense
-
-        const
-            band     = aiConfig.localModels.embedding.safeProcessingLimitTokens,
-            estimate = this.#getOpenAiCompatibleInputEstimate(inputData);
-
-        if (isEmbeddingContextBelowSafeBand(slotContextTokens, band)) {
-            const error = new Error(`TextEmbeddingService: provider per-slot context cannot hold a safe-band input (slotContext=${slotContextTokens}, safeProcessingLimitTokens=${band})`);
-
-            error.code = EMBEDDING_INPUT_TRUNCATED_CODE;
-            throw error;
-        }
-
-        if (estimate.inputTokensEstimate > slotContextTokens) {
-            const error = new Error(`TextEmbeddingService: embedding input would be truncated by the provider (inputEstimate=${estimate.inputTokensEstimate}, slotContext=${slotContextTokens})`);
-
-            error.code = EMBEDDING_INPUT_TRUNCATED_CODE;
-            throw error;
+            throw contextInsufficient
+                ? markEmbeddingContextInsufficientError(error)
+                : markEmbeddingInputTruncatedError(error)
         }
     }
 
@@ -1105,13 +1067,6 @@ class TextEmbeddingService extends Base {
 
         throwIfEmbeddingAborted(signal, operationLabel);
         this.#assertOpenAiCompatibleEmbeddingContext(requestInputData, runtime);
-
-        if (!runtime) {
-            // Non-LMS flavors have no `lms`-CLI metadata, so the runtime getter above returns null
-            // and skips its context assert entirely. The slot floor runs against the provider's
-            // HTTP-reported per-slot context instead; an unobservable lane keeps only the wire flag.
-            await this.#assertOpenAiCompatibleSlotFloor(requestInputData, signal, operationLabel);
-        }
 
         return requestInputData;
     }
@@ -1204,14 +1159,8 @@ class TextEmbeddingService extends Base {
                         // stay verbatim: OPENAI_COMPATIBLE_CONTENTION_HTTP_ERROR_RE classifies on it.
                         const httpError = new Error(`openAiCompatible embedding error HTTP ${res.statusCode}: ${body} [endpoint=${parsedUrl.href}, model='${embeddingModel}']`);
 
-                        // The request asked for `truncate: false`, so a refusal whose body names the
-                        // input/context bound is the provider REPORTING truncation rather than
-                        // performing it — translate that report into the source-owned typed code
-                        // instead of leaving it an unclassified HTTP error.
-                        if (res.statusCode === 400 || res.statusCode === 413) {
-                            if (/truncat|too (large|long|many)|context.*(exceed|overflow|length)|exceed.*context/i.test(body)) {
-                                httpError.code = EMBEDDING_INPUT_TRUNCATED_CODE;
-                            }
+                        if (isStructuredEmbeddingContextOverflow(res.statusCode, body)) {
+                            markEmbeddingInputTruncatedError(httpError)
                         }
 
                         rejectOnce(httpError);
@@ -1250,11 +1199,7 @@ class TextEmbeddingService extends Base {
                 abortHandler();
             } else {
                 providerActivityLifecycle?.onDispatch({model: embeddingModel});
-                // `truncate: false` asks the provider to REFUSE an over-context input rather than
-                // silently answering it with a prefix-computed vector (llama.cpp honors the flag;
-                // spec-tolerant servers ignore it, and the slot-floor refusal above is the guard
-                // that does not depend on provider cooperation).
-                req.write(JSON.stringify({ model: embeddingModel, input: inputData, truncate: false }));
+                req.write(JSON.stringify({model: embeddingModel, input: inputData}));
                 req.end();
             }
 

--- a/ai/services/memory-core/TextEmbeddingService.mjs
+++ b/ai/services/memory-core/TextEmbeddingService.mjs
@@ -7,6 +7,9 @@ import Base           from '../../../src/core/Base.mjs';
 import logger         from '../../mcp/server/memory-core/logger.mjs';
 import OllamaProvider from '../../provider/Ollama.mjs';
 import {
+    isEmbeddingContextBelowSafeBand
+}                           from '../../embeddingSafeBand.mjs';
+import {
     withLmsEmbeddingInputSuffix
 }                           from '../shared/vector/lmsEmbeddingInputSuffix.mjs';
 import {
@@ -80,6 +83,23 @@ function markEmbeddingModelNotResidentError(error) {
  * @type {String}
  */
 export const EMBEDDING_BATCH_YIELDED_CODE = 'EMBEDDING_BATCH_YIELDED';
+
+/**
+ * @summary Source-owned code for an embedding input the provider could only answer by truncating.
+ *
+ * Minted on two arms of the same fact: a pre-dispatch refusal when the observed per-slot context
+ * cannot hold the input (or cannot hold the safe band at all), and a provider refusal after the
+ * request asked for `truncate: false`. A truncated embedding must never be stored — a vector
+ * computed from a prefix does not represent the document it is indexed under, and the failure is
+ * silent, permanent, and invisible to every later stage. Retry cannot help: the same input under the
+ * same lane shape truncates again, so the KB boundary classifies the bounded translation as
+ * rejected, not deferrable.
+ *
+ * This shared Memory Core service must not mint a downstream Knowledge Base `KB_*` code; the KB
+ * ingestion boundary translates this cause into its own durable vocabulary.
+ * @type {String}
+ */
+export const EMBEDDING_INPUT_TRUNCATED_CODE = 'EMBEDDING_INPUT_TRUNCATED';
 
 /**
  * @summary Classifies a cooperative batch-yield abandonment at the consumer boundary.
@@ -970,6 +990,106 @@ class TextEmbeddingService extends Base {
     }
 
     /**
+     * @summary Observes the provider's per-slot context on non-LM-Studio OpenAI-compatible lanes.
+     *
+     * The LMS preflight above is blind on every other flavor — llama.cpp, vLLM, fixture servers —
+     * because its metadata comes from the `lms` CLI. Those flavors publish per-slot context over
+     * HTTP instead: llama.cpp's `/slots` endpoint (enabled on the canonical lane) reports `n_ctx`
+     * per slot. A lane that cannot answer `/slots` reports `null` here and the wire-level
+     * `truncate: false` request flag remains the only defense — documented, not silent.
+     *
+     * Test seam: tests set `TextEmbeddingService.openAiCompatibleSlotContextProbe` directly with a
+     * fake to bypass the network, mirroring `openAiCompatibleLoadedModelsProbe`.
+     *
+     * @param {AbortSignal|undefined} signal Upstream cancellation signal.
+     * @param {String} operationLabel Bounded operation label.
+     * @returns {Promise<Number|null>} The smallest per-slot context in tokens, or null when unobservable.
+     * @private
+     */
+    async #getOpenAiCompatibleSlotContextTokens(signal, operationLabel) {
+        if (this.openAiCompatibleSlotContextProbe) {
+            return this.openAiCompatibleSlotContextProbe();
+        }
+        if (Neo.config.unitTestMode) {
+            return null;
+        }
+
+        const
+            host      = aiConfig.openAiCompatible.host,
+            timeoutMs = aiConfig.orchestrator.providerReadiness.timeoutMs;
+
+        let response;
+
+        try {
+            response = await fetch(new URL('/slots', host).toString(), {
+                signal: signal && typeof AbortSignal.any === 'function'
+                    ? AbortSignal.any([signal, AbortSignal.timeout(timeoutMs)])
+                    : AbortSignal.timeout(timeoutMs)
+            });
+        } catch {
+            return null; // endpoint absent or unreachable: unobservable, not zero
+        }
+
+        if (!response.ok) return null;
+
+        let slots;
+
+        try {
+            slots = await response.json();
+        } catch {
+            return null;
+        }
+
+        if (!Array.isArray(slots) || slots.length === 0) return null;
+
+        const contexts = slots
+            .map(slot => Number(slot?.n_ctx))
+            .filter(value => Number.isFinite(value) && value > 0);
+
+        return contexts.length > 0 ? Math.min(...contexts) : null;
+    }
+
+    /**
+     * @summary Refuses an embedding input the provider could only answer by truncating, on any flavor.
+     *
+     * Two distinct floors, one code, because both name the same operator action — raise the lane's
+     * per-slot context or lower the band:
+     *
+     * - **Lane floor:** a per-slot context below `safeProcessingLimitTokens` can never hold a
+     *   safe-band input; embedding into it manufactures silently-wrong vectors at scale.
+     * - **Input floor:** this input's estimate exceeds the observed per-slot context right now.
+     *
+     * @param {String|String[]} inputData The provider-bound text input.
+     * @param {AbortSignal|undefined} signal Upstream cancellation signal.
+     * @param {String} operationLabel Bounded operation label.
+     * @returns {Promise<void>}
+     * @private
+     */
+    async #assertOpenAiCompatibleSlotFloor(inputData, signal, operationLabel) {
+        const slotContextTokens = await this.#getOpenAiCompatibleSlotContextTokens(signal, operationLabel);
+
+        if (slotContextTokens === null) return; // unobservable lane: the wire flag is the defense
+
+        const
+            band     = aiConfig.localModels.embedding.safeProcessingLimitTokens,
+            estimate = this.#getOpenAiCompatibleInputEstimate(inputData);
+
+        if (isEmbeddingContextBelowSafeBand(slotContextTokens, band)) {
+            const error = new Error(`TextEmbeddingService: provider per-slot context cannot hold a safe-band input (slotContext=${slotContextTokens}, safeProcessingLimitTokens=${band})`);
+
+            error.code = EMBEDDING_INPUT_TRUNCATED_CODE;
+            throw error;
+        }
+
+        if (estimate.inputTokensEstimate > slotContextTokens) {
+            const error = new Error(`TextEmbeddingService: embedding input would be truncated by the provider (inputEstimate=${estimate.inputTokensEstimate}, slotContext=${slotContextTokens})`);
+
+            error.code = EMBEDDING_INPUT_TRUNCATED_CODE;
+            throw error;
+        }
+    }
+
+    /**
      * @summary Prepares OpenAI-compatible embedding input at the provider request boundary.
      * @param {String|String[]} inputData The caller's original text input.
      * @param {AbortSignal|undefined} signal Upstream cancellation signal.
@@ -985,6 +1105,13 @@ class TextEmbeddingService extends Base {
 
         throwIfEmbeddingAborted(signal, operationLabel);
         this.#assertOpenAiCompatibleEmbeddingContext(requestInputData, runtime);
+
+        if (!runtime) {
+            // Non-LMS flavors have no `lms`-CLI metadata, so the runtime getter above returns null
+            // and skips its context assert entirely. The slot floor runs against the provider's
+            // HTTP-reported per-slot context instead; an unobservable lane keeps only the wire flag.
+            await this.#assertOpenAiCompatibleSlotFloor(requestInputData, signal, operationLabel);
+        }
 
         return requestInputData;
     }
@@ -1075,7 +1202,19 @@ class TextEmbeddingService extends Base {
                         // default vs :1234 LM Studio) or a non-resident model is diagnosable from the error
                         // alone — not a bare "resource could not be found". The `HTTP <status>:` prefix MUST
                         // stay verbatim: OPENAI_COMPATIBLE_CONTENTION_HTTP_ERROR_RE classifies on it.
-                        rejectOnce(new Error(`openAiCompatible embedding error HTTP ${res.statusCode}: ${body} [endpoint=${parsedUrl.href}, model='${embeddingModel}']`));
+                        const httpError = new Error(`openAiCompatible embedding error HTTP ${res.statusCode}: ${body} [endpoint=${parsedUrl.href}, model='${embeddingModel}']`);
+
+                        // The request asked for `truncate: false`, so a refusal whose body names the
+                        // input/context bound is the provider REPORTING truncation rather than
+                        // performing it — translate that report into the source-owned typed code
+                        // instead of leaving it an unclassified HTTP error.
+                        if (res.statusCode === 400 || res.statusCode === 413) {
+                            if (/truncat|too (large|long|many)|context.*(exceed|overflow|length)|exceed.*context/i.test(body)) {
+                                httpError.code = EMBEDDING_INPUT_TRUNCATED_CODE;
+                            }
+                        }
+
+                        rejectOnce(httpError);
                     } else {
                         try {
                             const result = JSON.parse(body);
@@ -1111,7 +1250,11 @@ class TextEmbeddingService extends Base {
                 abortHandler();
             } else {
                 providerActivityLifecycle?.onDispatch({model: embeddingModel});
-                req.write(JSON.stringify({ model: embeddingModel, input: inputData }));
+                // `truncate: false` asks the provider to REFUSE an over-context input rather than
+                // silently answering it with a prefix-computed vector (llama.cpp honors the flag;
+                // spec-tolerant servers ignore it, and the slot-floor refusal above is the guard
+                // that does not depend on provider cooperation).
+                req.write(JSON.stringify({ model: embeddingModel, input: inputData, truncate: false }));
                 req.end();
             }
 

--- a/test/playwright/unit/ai/config.template.spec.mjs
+++ b/test/playwright/unit/ai/config.template.spec.mjs
@@ -1,4 +1,5 @@
 import { test, expect } from '@playwright/test';
+import {execFileSync}   from 'node:child_process';
 import fs               from 'fs/promises';
 import os               from 'os';
 import path             from 'path';
@@ -370,6 +371,28 @@ test.describe('Tier 1 Config Immutability', () => {
             expect(isolatedConfig.localModels.chat.contextLimitTokens).toBe(Number(process.env.NEO_LOCAL_MODELS_CHAT_CONTEXT_LIMIT_TOKENS) || 131072);
         } finally {
             isolatedConfig.destroy();
+        }
+    });
+
+    test('invalid embedding safe-band env values fall back before reaching consumers', () => {
+        const script = `
+            import './src/Neo.mjs';
+            const {default: AiConfig} = await import('./ai/config.mjs');
+            console.log('SAFE_BAND=' + AiConfig.localModels.embedding.safeProcessingLimitTokens);
+        `;
+
+        for (const invalidValue of ['-1', '1.5']) {
+            const output = execFileSync(process.execPath, ['--input-type=module', '-e', script], {
+                cwd     : process.cwd(),
+                encoding: 'utf8',
+                env     : {
+                    ...process.env,
+                    NEO_LOCAL_MODELS_EMBEDDING_SAFE_PROCESSING_LIMIT_TOKENS: invalidValue,
+                    UNIT_TEST_MODE                                         : 'true'
+                }
+            });
+
+            expect(output).toContain('SAFE_BAND=28672')
         }
     });
 

--- a/test/playwright/unit/ai/daemons/orchestrator/Orchestrator.invariants.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/Orchestrator.invariants.spec.mjs
@@ -324,6 +324,61 @@ test.describe('Orchestrator config getters delegate to AiConfig (data env/parse 
         }).lms).toBeUndefined();
     });
 
+    test('the production LMS postSpawn owner applies the embedding safe band without a recurring canary', async () => {
+        const script = `
+            import './src/Neo.mjs';
+            const {buildConfiguredTaskDefinitions} = await import('./ai/daemons/orchestrator/services/ConfiguredTaskDefinitionsService.mjs');
+
+            let observedContextLength = 8192;
+            let ensureOptions;
+            const tasks = buildConfiguredTaskDefinitions({
+                scriptDir: '/repo/ai/scripts',
+                nodeBin: '/node',
+                neuralLinkBridgeLivenessTimeoutMs: 100,
+                ensureLmsModelsLoadedFn: async options => {
+                    ensureOptions = options;
+                    return options.embeddingServingProbe({
+                        host: options.host,
+                        timeoutMs: options.timeoutMs,
+                        lmsLoadedModels: [{id: 'embedding-from-config', contextLength: observedContextLength}]
+                    });
+                }
+            });
+
+            const belowBand = await tasks.lms.postSpawn();
+            if (ensureOptions.contextLengths['embedding-from-config'] !== 8192 ||
+                belowBand.ready !== false || belowBand.reason !== 'embedding-context-below-safe-band' ||
+                !belowBand.warning.includes('8192') || !belowBand.warning.includes('28672')) {
+                throw new Error('production LMS owner did not apply the resolved embedding safe band');
+            }
+
+            observedContextLength = 32768;
+            const sufficient = await tasks.lms.postSpawn();
+            if (sufficient.ready !== true || sufficient.observedContextLength !== 32768) {
+                throw new Error('production LMS owner issued a canary instead of the metadata-only sufficient check');
+            }
+        `;
+
+        await execFileAsync(process.execPath, ['--input-type=module', '-e', script], {
+            cwd: REPO_ROOT,
+            env: {
+                ...process.env,
+                NEO_EMBEDDING_PROVIDER                                 : 'openAiCompatible',
+                NEO_GRAPH_PROVIDER                                     : 'gemini',
+                NEO_LOCAL_MODELS_EMBEDDING_CONTEXT_LIMIT_TOKENS        : '8192',
+                NEO_LOCAL_MODELS_EMBEDDING_SAFE_PROCESSING_LIMIT_TOKENS: '28672',
+                NEO_MODEL_PROVIDER                                     : 'gemini',
+                NEO_OPENAI_COMPATIBLE_EMBEDDING_MODEL                  : 'embedding-from-config',
+                NEO_OPENAI_COMPATIBLE_HOST                             : 'http://127.0.0.1:4242',
+                NEO_ORCHESTRATOR_LMS_ENABLED                           : 'true',
+                NEO_ORCHESTRATOR_LMS_MODEL                             : 'unused',
+                NEO_ORCHESTRATOR_LMS_PORT                              : '4242',
+                UNIT_TEST_MODE                                         : 'true'
+            },
+            maxBuffer: 1024 * 1024
+        })
+    });
+
     test('buildConfiguredTaskDefinitions composes native Ollama from AiConfig provider-role selectors', () => {
         AiConfig.orchestrator.ollama = {enabled: true};
         AiConfig.ollama = {

--- a/test/playwright/unit/ai/scripts/benchmark/ProviderLaneElectionCore.spec.mjs
+++ b/test/playwright/unit/ai/scripts/benchmark/ProviderLaneElectionCore.spec.mjs
@@ -66,7 +66,7 @@ function buildFixture() {
 function buildCandidateProfile(embeddingSlots) {
     const profile = {
         compositionReceiptDigest: `sha256:${String(embeddingSlots).repeat(64)}`,
-        compositionSchemaVersion: 'provider-lane-composition.v1',
+        compositionSchemaVersion: 'provider-lane-composition.v2',
         embeddingSlots,
         lanes                   : {
             chat: {

--- a/test/playwright/unit/ai/scripts/benchmark/ProviderLaneElectionRunner.spec.mjs
+++ b/test/playwright/unit/ai/scripts/benchmark/ProviderLaneElectionRunner.spec.mjs
@@ -1,8 +1,9 @@
-import {test, expect}     from '@playwright/test';
-import {EventEmitter}     from 'node:events';
-import fs                 from 'node:fs';
-import path               from 'node:path';
-import {load as loadYaml} from 'js-yaml';
+import {test, expect}                           from '@playwright/test';
+import {EventEmitter}                           from 'node:events';
+import fs                                       from 'node:fs';
+import path                                     from 'node:path';
+import {load as loadYaml}                       from 'js-yaml';
+import {EMBEDDING_SAFE_PROCESSING_LIMIT_TOKENS} from '../../../../../../ai/embeddingSafeBand.mjs';
 
 import {
     analyzeProviderLaneComposition,
@@ -52,10 +53,11 @@ function buildComposition(candidate) {
         NEO_PROVIDER_LANE_EMBEDDING_CPUS                            : '2',
         NEO_PROVIDER_LANE_EMBEDDING_MEMORY_BYTES                    : '17179869184',
         NEO_PROVIDER_LANE_EMBEDDING_SLOTS                           : String(candidate),
-        NEO_PROVIDER_LANE_EMBEDDING_TOTAL_CONTEXT_TOKENS            : String(candidate * 8192),
-        NEO_PROVIDER_LANE_EMBEDDING_CONTEXT_TOKENS_PER_SLOT_REQUIRED: '8192',
-        NEO_PROVIDER_LANE_EMBEDDING_BATCH_TOKENS                    : String(candidate * 8192),
-        NEO_PROVIDER_LANE_EMBEDDING_UBATCH_TOKENS                   : String(candidate * 8192)
+        NEO_PROVIDER_LANE_EMBEDDING_TOTAL_CONTEXT_TOKENS            : String(candidate * 32768),
+        NEO_PROVIDER_LANE_EMBEDDING_CONTEXT_TOKENS_PER_SLOT_REQUIRED: '32768',
+        NEO_PROVIDER_LANE_EMBEDDING_BATCH_TOKENS                    : String(candidate * 32768),
+        NEO_PROVIDER_LANE_EMBEDDING_UBATCH_TOKENS                   : String(candidate * 32768),
+        NEO_LOCAL_MODELS_EMBEDDING_SAFE_PROCESSING_LIMIT_TOKENS     : String(EMBEDDING_SAFE_PROCESSING_LIMIT_TOKENS)
     };
     const source = fs.readFileSync(profilePath, 'utf8').replace(
         /\$\{([A-Z0-9_]+):\?[^}]+}/g,
@@ -78,7 +80,9 @@ function buildComposition(candidate) {
 }
 
 function buildReceipt(candidate) {
-    const receipt = analyzeProviderLaneComposition(buildComposition(candidate));
+    const receipt = analyzeProviderLaneComposition(buildComposition(candidate), {
+        safeProcessingLimitTokensEmbedding: EMBEDDING_SAFE_PROCESSING_LIMIT_TOKENS
+    });
 
     expect(receipt.ready, JSON.stringify(receipt.errors, null, 2)).toBe(true);
     return receipt
@@ -94,11 +98,11 @@ function buildRunPlan(receipts = [1, 2, 4].map(buildReceipt)) {
         contextProbeTimeoutMs: 300_000,
         resourceSampling     : {activeCpuThreshold: 1, expectedIntervalMs: 1000, gapFactor: 2},
         revision             : REVISION,
-        schemaVersion        : 'provider-lane-election-plan.v1',
+        schemaVersion        : 'provider-lane-election-plan.v2',
         slo                  : {
             lanes: {
                 chat     : buildLaneSlo({context: 131072, cpu: 200, memory: 34359738368, operations: 2}),
-                embedding: buildLaneSlo({context: 8192, cpu: 200, memory: 17179869184, operations: 4})
+                embedding: buildLaneSlo({context: 32768, cpu: 200, memory: 17179869184, operations: 4})
             }
         },
         trialTimeoutMs: 900_000
@@ -303,7 +307,7 @@ function buildReportContextEvidence(entry) {
                 overLimitProbe              : probe('chat', 'over-limit')
             },
             embedding: {
-                observedContextTokensPerSlot: 8192,
+                observedContextTokensPerSlot: 32768,
                 overLimitProbe              : probe('embedding', 'over-limit'),
                 supportedLimitProbe         : probe('embedding', 'supported')
             }
@@ -397,6 +401,20 @@ test.describe('provider-lane election runner authority seams', () => {
             env  : 'NEO_PROVIDER_LANE_EMBEDDING_SLOTS',
             value: 2
         });
+        expect(plan.candidateDeploymentInputs[1].deploymentInputs.embeddingSafeProcessingLimitTokens).toEqual({
+            env  : 'NEO_LOCAL_MODELS_EMBEDDING_SAFE_PROCESSING_LIMIT_TOKENS',
+            value: EMBEDDING_SAFE_PROCESSING_LIMIT_TOKENS
+        });
+
+        const divergentBand = buildRunPlan(receipts);
+        divergentBand.candidateDeploymentInputs[2].deploymentInputs.embeddingSafeProcessingLimitTokens.value = 30000;
+        expect(() => validateProviderLaneRunPlan(divergentBand)).toThrow(/must share one embedding safe-processing limit/);
+
+        const fractionalBand = buildRunPlan(receipts);
+        for (const row of fractionalBand.candidateDeploymentInputs) {
+            row.deploymentInputs.embeddingSafeProcessingLimitTokens.value = 28672.5
+        }
+        expect(() => validateProviderLaneRunPlan(fractionalBand)).toThrow(/invalid integer embedding safe-processing limit/);
 
         const wrongEnv = buildRunPlan(receipts);
         wrongEnv.candidateDeploymentInputs[0].deploymentInputs.embeddingParallelSlots.env = 'NEO_FOREIGN_SLOTS';
@@ -473,20 +491,20 @@ test.describe('provider-lane election runner authority seams', () => {
               lane    = receipt.lanes.embedding;
 
         const supportedMinimum = createProviderLaneSupportedLimitRequest({
-                  adapter,
-                  lane,
-                  observedContextTokensPerSlot: 8192
-              }),
+              adapter,
+              lane,
+              observedContextTokensPerSlot: 32768
+          }),
               overLimit        = createProviderLaneOverLimitRequest({
                   adapter,
                   lane,
-                  observedContextTokensPerSlot: 8192
+                  observedContextTokensPerSlot: 32768
               });
 
-        expect(supportedMinimum.requestedContextTokens).toBe(8192);
-        expect(JSON.parse(supportedMinimum.body).input).toHaveLength(8192);
-        expect(overLimit.requestedContextTokens).toBe(8193);
-        expect(JSON.parse(overLimit.body).input).toHaveLength(8193);
+        expect(supportedMinimum.requestedContextTokens).toBe(32768);
+        expect(JSON.parse(supportedMinimum.body).input).toHaveLength(32768);
+        expect(overLimit.requestedContextTokens).toBe(32769);
+        expect(JSON.parse(overLimit.body).input).toHaveLength(32769);
         expect(() => createProviderLaneOverLimitRequest({
             adapter,
             lane,
@@ -496,7 +514,7 @@ test.describe('provider-lane election runner authority seams', () => {
         expect(() => createProviderLaneSupportedLimitRequest({
             adapter,
             lane,
-            observedContextTokensPerSlot: 8193
+            observedContextTokensPerSlot: 32769
         })).toThrow(/exceeds declared batch authority/)
     });
 
@@ -750,6 +768,7 @@ test.describe('provider-lane election runner authority seams', () => {
     test('recomputes the public handoff and rejects self-attested election authority', () => {
         const report = buildElectionReport();
 
+        expect(report.schemaVersion).toBe('provider-lane-election-report.v2');
         expect(validateProviderLaneElectionReport(report)).toEqual(report);
         expect(report.selectedReceipt).toEqual(report.candidateReceipts[0].receipt);
         expect(report.selectedReceiptDigest).toBe(report.candidateReceipts[0].compositionReceiptDigest);
@@ -774,6 +793,14 @@ test.describe('provider-lane election runner authority seams', () => {
         receiptExtra.candidateReceipts[0].compositionReceiptDigest =
             digestProviderLaneValue(receiptExtra.candidateReceipts[0].receipt);
         expect(() => validateProviderLaneElectionReport(receiptExtra)).toThrow(/canonical validation/);
+
+        const divergentReceiptBand = structuredClone(report);
+        divergentReceiptBand.candidateReceipts[2].receipt
+            .deploymentInputs.embeddingSafeProcessingLimitTokens.value = 30000;
+        divergentReceiptBand.candidateReceipts[2].compositionReceiptDigest =
+            digestProviderLaneValue(divergentReceiptBand.candidateReceipts[2].receipt);
+        expect(() => validateProviderLaneElectionReport(divergentReceiptBand))
+            .toThrow(/receipts must share one embedding safe-processing limit/);
 
         const unknownField = structuredClone(report);
         unknownField.evidence.trials[0].lanes.embedding.operations[0].token = 'SECRET';

--- a/test/playwright/unit/ai/scripts/diagnostics/providerLaneComposition.spec.mjs
+++ b/test/playwright/unit/ai/scripts/diagnostics/providerLaneComposition.spec.mjs
@@ -1,7 +1,8 @@
-import {test, expect}     from '@playwright/test';
-import fs                 from 'node:fs';
-import path               from 'node:path';
-import {load as loadYaml} from 'js-yaml';
+import {test, expect}                           from '@playwright/test';
+import fs                                       from 'node:fs';
+import path                                     from 'node:path';
+import {load as loadYaml}                       from 'js-yaml';
+import {EMBEDDING_SAFE_PROCESSING_LIMIT_TOKENS} from '../../../../../../ai/embeddingSafeBand.mjs';
 import {
     PROVIDER_LANE_COMPOSITION_SCHEMA_VERSION,
     PROVIDER_LANE_DEPLOYMENT_INPUT_ENVS,
@@ -28,17 +29,19 @@ const FIXTURE_ENV = Object.freeze({
     NEO_PROVIDER_LANE_EMBEDDING_UBATCH_TOKENS                   : '32768'
 });
 
-function renderRequiredInputs(source) {
+function renderRequiredInputs(source, overrides = {}) {
+    const values = {...FIXTURE_ENV, ...overrides};
+
     return source.replace(/\$\{([A-Z0-9_]+):\?[^}]+}/g, (match, name) => {
-        if (!Object.hasOwn(FIXTURE_ENV, name)) {
+        if (!Object.hasOwn(values, name)) {
             throw new Error(`provider-lane fixture has no value for ${name}`)
         }
-        return FIXTURE_ENV[name]
+        return values[name]
     })
 }
 
-function loadComposition() {
-    const source      = renderRequiredInputs(fs.readFileSync(profilePath, 'utf8'));
+function loadComposition(overrides = {}) {
+    const source      = renderRequiredInputs(fs.readFileSync(profilePath, 'utf8'), overrides);
     const composition = {name: 'neo-agent-os-test', ...loadYaml(source)};
     const shared      = composition['x-provider-lane-env'];
 
@@ -284,6 +287,43 @@ test.describe('provider-lane composition receipt (#17021)', () => {
         chatMutation.lanes.chat.totalContextTokens = 262145;
         chatMutation.deploymentInputs.chatContextTokens.value = 262145;
         expect(validateProviderLaneCompositionReceipt(chatMutation).errors.map(error => error.code)).toContain('model-context-ceiling')
+    });
+
+    test('the safe-band floor ties the embedding lane to the band Neo sends, naming both numbers', () => {
+        // Fixture lanes run at toy scale and never carry safe-band inputs: without an injected band
+        // there is no floor, and the fixture composition analyzes clean.
+        const unfloored = analyzeProviderLaneComposition(loadComposition());
+        expect(unfloored.ready).toBe(true);
+        expect(unfloored.errors).toEqual([]);
+
+        // With the canonical band supplied, the fixture's 8,192 per-slot requirement IS the defect
+        // shape: it passes every self-referential gate while being unable to hold a safe-band input.
+        const floored = analyzeProviderLaneComposition(loadComposition(), {safeProcessingLimitTokensEmbedding: EMBEDDING_SAFE_PROCESSING_LIMIT_TOKENS});
+
+        expect(floored.ready).toBe(false);
+
+        const floorError = floored.errors.find(error => error.code === 'lane-slot-context-below-safe-band');
+
+        expect(floorError).toBeDefined();
+        expect(floorError.expected).toContain(String(EMBEDDING_SAFE_PROCESSING_LIMIT_TOKENS));
+        expect(floorError.actual).toBe(8192);
+
+        // A compliant lane passes: the shipped shape (32,768 per slot against a 28,672 band) is
+        // correct by construction — the floor is a floor, not an equality pin. The override flows
+        // through the one env var the template binds to BOTH the contract and the runtime context
+        // leaf, so the composition stays internally consistent.
+        const compliantComposition = loadComposition({NEO_PROVIDER_LANE_EMBEDDING_CONTEXT_TOKENS_PER_SLOT_REQUIRED: '32768'});
+        expect(analyzeProviderLaneComposition(compliantComposition, {safeProcessingLimitTokensEmbedding: EMBEDDING_SAFE_PROCESSING_LIMIT_TOKENS}))
+            .toMatchObject({ready: true, errors: []});
+
+        // The floor never leaks onto the chat lane, whose band is a different leaf entirely: with
+        // the embedding lane compliant, a below-band chat requirement stays clean.
+        const chatBelow = loadComposition({
+            NEO_PROVIDER_LANE_CHAT_CONTEXT_TOKENS                       : '8192',
+            NEO_PROVIDER_LANE_EMBEDDING_CONTEXT_TOKENS_PER_SLOT_REQUIRED: '32768'
+        });
+        expect(analyzeProviderLaneComposition(chatBelow, {safeProcessingLimitTokensEmbedding: EMBEDDING_SAFE_PROCESSING_LIMIT_TOKENS})
+            .errors.map(error => error.code)).not.toContain('lane-slot-context-below-safe-band')
     });
 
     test('the pure validator binds every deployment input name and value to receipt authority', () => {

--- a/test/playwright/unit/ai/scripts/diagnostics/providerLaneComposition.spec.mjs
+++ b/test/playwright/unit/ai/scripts/diagnostics/providerLaneComposition.spec.mjs
@@ -1,12 +1,16 @@
-import {test, expect}                           from '@playwright/test';
-import fs                                       from 'node:fs';
-import path                                     from 'node:path';
-import {load as loadYaml}                       from 'js-yaml';
-import {EMBEDDING_SAFE_PROCESSING_LIMIT_TOKENS} from '../../../../../../ai/embeddingSafeBand.mjs';
+import {test, expect}     from '@playwright/test';
+import {spawnSync}        from 'node:child_process';
+import fs                 from 'node:fs';
+import path               from 'node:path';
+import {load as loadYaml} from 'js-yaml';
+import {
+    EMBEDDING_SAFE_PROCESSING_LIMIT_TOKENS,
+    isEmbeddingContextBelowSafeBand
+} from '../../../../../../ai/embeddingSafeBand.mjs';
 import {
     PROVIDER_LANE_COMPOSITION_SCHEMA_VERSION,
     PROVIDER_LANE_DEPLOYMENT_INPUT_ENVS,
-    analyzeProviderLaneComposition,
+    analyzeProviderLaneComposition as analyzeProviderLaneCompositionRaw,
     parseArgs,
     validateProviderLaneCompositionReceipt
 } from '../../../../../../ai/scripts/diagnostics/providerLaneComposition.mjs';
@@ -24,10 +28,18 @@ const FIXTURE_ENV = Object.freeze({
     NEO_PROVIDER_LANE_EMBEDDING_MEMORY_BYTES                    : '17179869184',
     NEO_PROVIDER_LANE_EMBEDDING_SLOTS                           : '1',
     NEO_PROVIDER_LANE_EMBEDDING_TOTAL_CONTEXT_TOKENS            : '32768',
-    NEO_PROVIDER_LANE_EMBEDDING_CONTEXT_TOKENS_PER_SLOT_REQUIRED: '8192',
+    NEO_PROVIDER_LANE_EMBEDDING_CONTEXT_TOKENS_PER_SLOT_REQUIRED: '32768',
     NEO_PROVIDER_LANE_EMBEDDING_BATCH_TOKENS                    : '32768',
-    NEO_PROVIDER_LANE_EMBEDDING_UBATCH_TOKENS                   : '32768'
+    NEO_PROVIDER_LANE_EMBEDDING_UBATCH_TOKENS                   : '32768',
+    NEO_LOCAL_MODELS_EMBEDDING_SAFE_PROCESSING_LIMIT_TOKENS     : String(EMBEDDING_SAFE_PROCESSING_LIMIT_TOKENS)
 });
+
+function analyzeProviderLaneComposition(composition, options = {}) {
+    return analyzeProviderLaneCompositionRaw(composition, {
+        safeProcessingLimitTokensEmbedding: EMBEDDING_SAFE_PROCESSING_LIMIT_TOKENS,
+        ...options
+    })
+}
 
 function renderRequiredInputs(source, overrides = {}) {
     const values = {...FIXTURE_ENV, ...overrides};
@@ -209,7 +221,13 @@ test.describe('provider-lane composition receipt (#17021)', () => {
 
         const parallelMutation = loadComposition();
         parallelMutation.services['orchestrator'].environment.NEO_LOCAL_MODELS_CHAT_PARALLEL = '2';
-        expect(errorCodes(analyzeProviderLaneComposition(parallelMutation))).toContain('application-runtime-contract-drift')
+        expect(errorCodes(analyzeProviderLaneComposition(parallelMutation))).toContain('application-runtime-contract-drift');
+
+        const safeBandMutation = loadComposition();
+        safeBandMutation.services['mc-server'].environment[
+            PROVIDER_LANE_DEPLOYMENT_INPUT_ENVS.embeddingSafeProcessingLimitTokens
+        ] = '20000';
+        expect(errorCodes(analyzeProviderLaneComposition(safeBandMutation))).toContain('application-runtime-contract-drift')
     });
 
     test('chat parallelism stays one and embedding total context cannot masquerade as per-slot context', () => {
@@ -290,15 +308,16 @@ test.describe('provider-lane composition receipt (#17021)', () => {
     });
 
     test('the safe-band floor ties the embedding lane to the band Neo sends, naming both numbers', () => {
-        // Fixture lanes run at toy scale and never carry safe-band inputs: without an injected band
-        // there is no floor, and the fixture composition analyzes clean.
-        const unfloored = analyzeProviderLaneComposition(loadComposition());
-        expect(unfloored.ready).toBe(true);
-        expect(unfloored.errors).toEqual([]);
+        expect(() => analyzeProviderLaneCompositionRaw(loadComposition()))
+            .toThrow(/requires a positive integer safeProcessingLimitTokensEmbedding/);
+        expect(() => isEmbeddingContextBelowSafeBand(32768, 1.5))
+            .toThrow(/safe-processing limit must be a positive integer/);
 
-        // With the canonical band supplied, the fixture's 8,192 per-slot requirement IS the defect
+        // The fixture's 8,192 per-slot requirement IS the defect
         // shape: it passes every self-referential gate while being unable to hold a safe-band input.
-        const floored = analyzeProviderLaneComposition(loadComposition(), {safeProcessingLimitTokensEmbedding: EMBEDDING_SAFE_PROCESSING_LIMIT_TOKENS});
+        const floored = analyzeProviderLaneComposition(loadComposition({
+            NEO_PROVIDER_LANE_EMBEDDING_CONTEXT_TOKENS_PER_SLOT_REQUIRED: '8192'
+        }));
 
         expect(floored.ready).toBe(false);
 
@@ -312,8 +331,17 @@ test.describe('provider-lane composition receipt (#17021)', () => {
         // correct by construction — the floor is a floor, not an equality pin. The override flows
         // through the one env var the template binds to BOTH the contract and the runtime context
         // leaf, so the composition stays internally consistent.
-        const compliantComposition = loadComposition({NEO_PROVIDER_LANE_EMBEDDING_CONTEXT_TOKENS_PER_SLOT_REQUIRED: '32768'});
-        expect(analyzeProviderLaneComposition(compliantComposition, {safeProcessingLimitTokensEmbedding: EMBEDDING_SAFE_PROCESSING_LIMIT_TOKENS}))
+        const compliantComposition = loadComposition();
+        expect(analyzeProviderLaneComposition(compliantComposition))
+            .toMatchObject({ready: true, errors: []});
+
+        const exactBandComposition = loadComposition({
+            NEO_PROVIDER_LANE_EMBEDDING_TOTAL_CONTEXT_TOKENS            : '28672',
+            NEO_PROVIDER_LANE_EMBEDDING_CONTEXT_TOKENS_PER_SLOT_REQUIRED: '28672',
+            NEO_PROVIDER_LANE_EMBEDDING_BATCH_TOKENS                    : '28672',
+            NEO_PROVIDER_LANE_EMBEDDING_UBATCH_TOKENS                   : '28672'
+        });
+        expect(analyzeProviderLaneComposition(exactBandComposition))
             .toMatchObject({ready: true, errors: []});
 
         // The floor never leaks onto the chat lane, whose band is a different leaf entirely: with
@@ -322,8 +350,41 @@ test.describe('provider-lane composition receipt (#17021)', () => {
             NEO_PROVIDER_LANE_CHAT_CONTEXT_TOKENS                       : '8192',
             NEO_PROVIDER_LANE_EMBEDDING_CONTEXT_TOKENS_PER_SLOT_REQUIRED: '32768'
         });
-        expect(analyzeProviderLaneComposition(chatBelow, {safeProcessingLimitTokensEmbedding: EMBEDDING_SAFE_PROCESSING_LIMIT_TOKENS})
+        expect(analyzeProviderLaneComposition(chatBelow)
             .errors.map(error => error.code)).not.toContain('lane-slot-context-below-safe-band')
+    });
+
+    test('the real CLI consumes and records the resolved non-default safe band in the v2 receipt', () => {
+        const scriptPath = path.join(repoRoot, 'ai/scripts/diagnostics/providerLaneComposition.mjs');
+        const runCli     = safeBand => spawnSync(process.execPath, [scriptPath, '--skip-source-census'], {
+            cwd     : repoRoot,
+            encoding: 'utf8',
+            env     : {
+                ...process.env,
+                NEO_LOCAL_MODELS_EMBEDDING_SAFE_PROCESSING_LIMIT_TOKENS: String(safeBand)
+            },
+            input: JSON.stringify(loadComposition({
+                NEO_LOCAL_MODELS_EMBEDDING_SAFE_PROCESSING_LIMIT_TOKENS: String(safeBand)
+            }))
+        });
+
+        const refused = runCli(40000);
+        expect(refused.status, refused.stderr).toBe(1);
+        const refusedReceipt = JSON.parse(refused.stdout);
+        expect(refusedReceipt.errors).toContainEqual(expect.objectContaining({
+            code    : 'lane-slot-context-below-safe-band',
+            actual  : 32768,
+            expected: expect.stringContaining('40000')
+        }));
+
+        const accepted = runCli(30000);
+        expect(accepted.status, accepted.stderr).toBe(0);
+        const acceptedReceipt = JSON.parse(accepted.stdout);
+        expect(acceptedReceipt.ready).toBe(true);
+        expect(acceptedReceipt.deploymentInputs.embeddingSafeProcessingLimitTokens).toEqual({
+            env  : 'NEO_LOCAL_MODELS_EMBEDDING_SAFE_PROCESSING_LIMIT_TOKENS',
+            value: 30000
+        })
     });
 
     test('the pure validator binds every deployment input name and value to receipt authority', () => {
@@ -444,7 +505,7 @@ test.describe('provider-lane composition receipt (#17021)', () => {
     test('the pure downstream validator rejects unknown and unready receipts without Compose', () => {
         const good    = analyzeProviderLaneComposition(loadComposition());
         const unknown = clone(good);
-        unknown.schemaVersion = 'provider-lane-composition.v2';
+        unknown.schemaVersion = 'provider-lane-composition.v3';
         expect(validateProviderLaneCompositionReceipt(unknown).errors.map(error => error.code)).toContain('schema-version');
 
         const unready = clone(good);

--- a/test/playwright/unit/ai/services/graph/providerReadinessHelper.spec.mjs
+++ b/test/playwright/unit/ai/services/graph/providerReadinessHelper.spec.mjs
@@ -7,13 +7,13 @@ setup({
     appConfig: {name: appName, isMounted: () => true, vnodeInitialising: false}
 });
 
-import {test, expect}                           from '@playwright/test';
-import {execFile}                               from 'child_process';
-import Neo                                      from '../../../../../../src/Neo.mjs';
-import * as core                                from '../../../../../../src/core/_export.mjs';
-import os                                       from 'os';
-import path                                     from 'path';
-import {EMBEDDING_SAFE_PROCESSING_LIMIT_TOKENS} from '../../../../../../ai/embeddingSafeBand.mjs';
+import {test, expect} from '@playwright/test';
+import {execFile}     from 'child_process';
+import Neo            from '../../../../../../src/Neo.mjs';
+import * as core      from '../../../../../../src/core/_export.mjs';
+import os             from 'os';
+import path           from 'path';
+import aiConfig       from '../../../../../../ai/mcp/server/memory-core/config.template.mjs';
 
 // Pure helper (no I/O) — imported dynamically after the Neo bootstrap (the module's import chain
 // references Neo at load). It guarantees LM Studio's CLI bin dir (~/.lmstudio/bin) is on the
@@ -838,12 +838,16 @@ test.describe('provider readiness follows declared lane ownership (#17021)', () 
 });
 
 test.describe('embedding serving canary — safe-band floor (#17070)', () => {
-    let checkOpenAiCompatibleEmbeddingServing;
+    let checkOpenAiCompatibleEmbeddingServing,
+        ensureLmsModelsLoaded,
+        resolvedSafeProcessingLimitTokens;
 
     test.beforeAll(async () => {
         const mod = await import('../../../../../../ai/services/graph/providerReadinessHelper.mjs');
 
         checkOpenAiCompatibleEmbeddingServing = mod.checkOpenAiCompatibleEmbeddingServing;
+        ensureLmsModelsLoaded                  = mod.ensureLmsModelsLoaded;
+        resolvedSafeProcessingLimitTokens     = aiConfig.localModels.embedding.safeProcessingLimitTokens;
     });
 
     test('a loaded context below the safe band is NOT ready, names both numbers, and never probes', async () => {
@@ -854,7 +858,10 @@ test.describe('embedding serving canary — safe-band floor (#17070)', () => {
             model          : 'qwen3-embedding',
             input          : 'probe',
             timeoutMs      : 1000,
-            lmsLoadedModels: [{id: 'qwen3-embedding', contextLength: 8192}],
+            lmsLoadedModels: [{
+                id           : 'qwen3-embedding',
+                contextLength: resolvedSafeProcessingLimitTokens - 1
+            }],
             fetchFn        : async () => {
                 probed = true;
                 throw new Error('the floor must fire before any provider probe');
@@ -863,8 +870,8 @@ test.describe('embedding serving canary — safe-band floor (#17070)', () => {
 
         expect(result.ready).toBe(false);
         expect(result.reason).toBe('embedding-context-below-safe-band');
-        expect(result.warning).toContain('8192');
-        expect(result.warning).toContain(String(EMBEDDING_SAFE_PROCESSING_LIMIT_TOKENS));
+        expect(result.warning).toContain(String(resolvedSafeProcessingLimitTokens - 1));
+        expect(result.warning).toContain(String(resolvedSafeProcessingLimitTokens));
         expect(probed, 'a too-small lane must not even be probed — the tiny canary would pass it').toBe(false);
     });
 
@@ -874,16 +881,66 @@ test.describe('embedding serving canary — safe-band floor (#17070)', () => {
             model          : 'qwen3-embedding',
             input          : 'probe',
             timeoutMs      : 1000,
-            lmsLoadedModels: [{id: 'qwen3-embedding', contextLength: 32768}],
+            lmsLoadedModels: [{
+                id           : 'qwen3-embedding',
+                contextLength: resolvedSafeProcessingLimitTokens
+            }],
             fetchFn        : async () => ({ok: true, json: async () => ({data: [{embedding: [0.1, 0.2]}]})})
         });
 
         expect(result).toMatchObject({ready: true, degraded: false, vectorLength: 2});
     });
 
+    test('ensureLmsModelsLoaded propagates a metadata-only below-band result to outer readiness', async () => {
+        const model = 'qwen3-embedding',
+              rows  = [{id: model, contextLength: resolvedSafeProcessingLimitTokens}];
+        let   loads = 0,
+              servingProbeOptions,
+              servingProbes = 0;
+
+        const result = await ensureLmsModelsLoaded({
+            host             : 'http://embedding-model:8080',
+            models           : [model],
+            attempts         : 1,
+            delayMs          : 0,
+            timeoutMs        : 1000,
+            contextLengths   : {[model]: resolvedSafeProcessingLimitTokens},
+            fetchModelIds    : async () => [model],
+            fetchLoadedModels: async () => rows,
+            loadModel        : async () => loads++,
+            embeddingServingProbe(options) {
+                servingProbes++;
+                servingProbeOptions = options;
+
+                return {
+                    ready   : false,
+                    degraded: true,
+                    reason  : 'embedding-context-below-safe-band',
+                    warning : 'metadata-only embedding context is below the safe band'
+                }
+            },
+            log: {info() {}, warn() {}}
+        });
+
+        expect(result).toMatchObject({
+            ready           : false,
+            degraded        : true,
+            embeddingServing: {
+                ready : false,
+                reason: 'embedding-context-below-safe-band'
+            }
+        });
+        expect(servingProbeOptions).toMatchObject({
+            host           : 'http://embedding-model:8080',
+            requiredModels : [model],
+            lmsLoadedModels: rows
+        });
+        expect({loads, servingProbes}).toEqual({loads: 0, servingProbes: 1})
+    });
+
     test('a lane without discovered context metadata answers the probe question only (fail-open)', async () => {
-        // The floor fires on knowledge, not on doubt: a lane whose context is unobservable keeps
-        // the pre-existing behavior, and the wire-level truncate flag is the remaining defense.
+        // The floor fires on knowledge, not on doubt: this generic readiness helper preserves the
+        // pre-existing serving probe. Live non-LMS lane-shape verification belongs at provider boot.
         const result = await checkOpenAiCompatibleEmbeddingServing({
             host           : 'http://embedding-model:8080',
             model          : 'qwen3-embedding',

--- a/test/playwright/unit/ai/services/graph/providerReadinessHelper.spec.mjs
+++ b/test/playwright/unit/ai/services/graph/providerReadinessHelper.spec.mjs
@@ -7,12 +7,13 @@ setup({
     appConfig: {name: appName, isMounted: () => true, vnodeInitialising: false}
 });
 
-import {test, expect} from '@playwright/test';
-import {execFile}     from 'child_process';
-import Neo            from '../../../../../../src/Neo.mjs';
-import * as core      from '../../../../../../src/core/_export.mjs';
-import os             from 'os';
-import path           from 'path';
+import {test, expect}                           from '@playwright/test';
+import {execFile}                               from 'child_process';
+import Neo                                      from '../../../../../../src/Neo.mjs';
+import * as core                                from '../../../../../../src/core/_export.mjs';
+import os                                       from 'os';
+import path                                     from 'path';
+import {EMBEDDING_SAFE_PROCESSING_LIMIT_TOKENS} from '../../../../../../ai/embeddingSafeBand.mjs';
 
 // Pure helper (no I/O) — imported dynamically after the Neo bootstrap (the module's import chain
 // references Neo at load). It guarantees LM Studio's CLI bin dir (~/.lmstudio/bin) is on the
@@ -833,5 +834,65 @@ test.describe('provider readiness follows declared lane ownership (#17021)', () 
             requiredModels: ['gemma4:26b'],
             missingModels : []
         });
+    });
+});
+
+test.describe('embedding serving canary — safe-band floor (#17070)', () => {
+    let checkOpenAiCompatibleEmbeddingServing;
+
+    test.beforeAll(async () => {
+        const mod = await import('../../../../../../ai/services/graph/providerReadinessHelper.mjs');
+
+        checkOpenAiCompatibleEmbeddingServing = mod.checkOpenAiCompatibleEmbeddingServing;
+    });
+
+    test('a loaded context below the safe band is NOT ready, names both numbers, and never probes', async () => {
+        let probed = false;
+
+        const result = await checkOpenAiCompatibleEmbeddingServing({
+            host           : 'http://embedding-model:8080',
+            model          : 'qwen3-embedding',
+            input          : 'probe',
+            timeoutMs      : 1000,
+            lmsLoadedModels: [{id: 'qwen3-embedding', contextLength: 8192}],
+            fetchFn        : async () => {
+                probed = true;
+                throw new Error('the floor must fire before any provider probe');
+            }
+        });
+
+        expect(result.ready).toBe(false);
+        expect(result.reason).toBe('embedding-context-below-safe-band');
+        expect(result.warning).toContain('8192');
+        expect(result.warning).toContain(String(EMBEDDING_SAFE_PROCESSING_LIMIT_TOKENS));
+        expect(probed, 'a too-small lane must not even be probed — the tiny canary would pass it').toBe(false);
+    });
+
+    test('a compliant context proceeds to the serving probe (negative control)', async () => {
+        const result = await checkOpenAiCompatibleEmbeddingServing({
+            host           : 'http://embedding-model:8080',
+            model          : 'qwen3-embedding',
+            input          : 'probe',
+            timeoutMs      : 1000,
+            lmsLoadedModels: [{id: 'qwen3-embedding', contextLength: 32768}],
+            fetchFn        : async () => ({ok: true, json: async () => ({data: [{embedding: [0.1, 0.2]}]})})
+        });
+
+        expect(result).toMatchObject({ready: true, degraded: false, vectorLength: 2});
+    });
+
+    test('a lane without discovered context metadata answers the probe question only (fail-open)', async () => {
+        // The floor fires on knowledge, not on doubt: a lane whose context is unobservable keeps
+        // the pre-existing behavior, and the wire-level truncate flag is the remaining defense.
+        const result = await checkOpenAiCompatibleEmbeddingServing({
+            host           : 'http://embedding-model:8080',
+            model          : 'qwen3-embedding',
+            input          : 'probe',
+            timeoutMs      : 1000,
+            lmsLoadedModels: [],
+            fetchFn        : async () => ({ok: true, json: async () => ({data: [{embedding: [0.3]}]})})
+        });
+
+        expect(result.ready).toBe(true);
     });
 });

--- a/test/playwright/unit/ai/services/knowledge-base/embedFailureClassification.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/embedFailureClassification.spec.mjs
@@ -117,6 +117,26 @@ test.describe('embed failure classification (#16647)', () => {
         expect(refused).not.toBe(nonResident);
     });
 
+    test('a truncation report is its own bounded code, distinct from timeouts and refusals, and never retried', () => {
+        const truncated = classifyEmbedFailureCode('EMBEDDING_INPUT_TRUNCATED');
+
+        expect(truncated).toBe('KB_VECTOR_EMBED_INPUT_TRUNCATED');
+        // Separately countable from every transient class the incident family already owns.
+        expect(truncated).not.toBe(classifyEmbedFailureCode('ECONNREFUSED'));
+        expect(truncated).not.toBe(classifyEmbedFailureCode('PROVIDER_TIMEOUT'));
+
+        // Permanence: the same input under the same lane shape truncates again on every retry, so
+        // the disposition is rejection, not deferral — re-ingesting cannot repair a cut vector.
+        expect(classifyEmbedDisposition(truncated)).toBe(EMBED_DISPOSITION.rejected);
+        expect(isEmbedFailureCode(truncated)).toBe(true);
+
+        // The classifier reaches the code through a wrapper's cause chain, matching how the
+        // ingestion boundary actually receives it.
+        const wrapped = new Error('ingest envelope failed');
+        wrapped.cause = Object.assign(new Error('provider refused a truncating input'), {code: 'EMBEDDING_INPUT_TRUNCATED'});
+        expect(classifyEmbedFailureError(wrapped)).toBe('KB_VECTOR_EMBED_INPUT_TRUNCATED');
+    });
+
     test('a DECLARED internal code is passed through, not overwritten', () => {
         // Our own layers produce codes more specific than anything the map could add. Rewriting them
         // would be a regression disguised as classification. It passes because it is a declared

--- a/test/playwright/unit/ai/services/memory-core/TextEmbeddingService.retry.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/TextEmbeddingService.retry.spec.mjs
@@ -434,7 +434,7 @@ test.describe.serial('TextEmbeddingService #11393/#11402/#12487/#12509 — openA
         ]);
     });
 
-    test('openAiCompatible refuses single embeddings when LM Studio loaded context is below the configured embedding context (#13944)', async () => {
+    test('LM Studio context-policy insufficiency wins over an input that only exceeds the invalid resident (#13944)', async () => {
         serverBehavior = 'succeed';
         TextEmbeddingService.openAiCompatibleLoadedModelsProbe = async () => [{
             id           : aiConfig.openAiCompatible.embeddingModel,
@@ -444,7 +444,10 @@ test.describe.serial('TextEmbeddingService #11393/#11402/#12487/#12509 — openA
         const providerTruncatedInput = 'x'.repeat(12746 * 3);
 
         await expect(TextEmbeddingService.embedText(providerTruncatedInput, 'openAiCompatible'))
-            .rejects.toThrow(/loaded=8192, configured>=32768, inputEstimate=12746/);
+            .rejects.toMatchObject({
+                code   : 'EMBEDDING_CONTEXT_INSUFFICIENT',
+                message: expect.stringMatching(/loaded=8192, configured>=32768, safeProcessingLimitTokens=28672, inputEstimate=12746/)
+            });
 
         expect(requestCount).toBe(0);
     });
@@ -495,15 +498,7 @@ test.describe.serial('TextEmbeddingService #11393/#11402/#12487/#12509 — openA
 
             expect(result).toEqual([0.1, 0.2, 0.3]);
 
-            // The standing contract: no LMS-specific probing (the `lms` CLI loaded-models spawn) on a
-            // non-LMS endpoint. The flavor-agnostic slot-floor probe (one GET /slots per embed
-            // call) is a different, newer class — the mock answers it with the embeddings payload,
-            // which parses as unobservable, so the floor stays out of the way.
-            const embedPosts = allRequests.filter(request => request.url === '/v1/embeddings');
-            const slotProbes = allRequests.filter(request => request.url === '/slots');
-
-            expect(embedPosts).toHaveLength(1);
-            expect(slotProbes.length).toBeLessThanOrEqual(1);
+            expect(requestCount).toBe(1);
             expect(lastRequest.body.input).toBe('hello');
         } finally {
             Neo.config.unitTestMode = originalUnitTestMode;

--- a/test/playwright/unit/ai/services/memory-core/TextEmbeddingService.retry.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/TextEmbeddingService.retry.spec.mjs
@@ -494,7 +494,16 @@ test.describe.serial('TextEmbeddingService #11393/#11402/#12487/#12509 — openA
             const result = await TextEmbeddingService.embedText('hello', 'openAiCompatible');
 
             expect(result).toEqual([0.1, 0.2, 0.3]);
-            expect(requestCount).toBe(1);
+
+            // The standing contract: no LMS-specific probing (the `lms` CLI loaded-models spawn) on a
+            // non-LMS endpoint. The flavor-agnostic slot-floor probe (one GET /slots per embed
+            // call) is a different, newer class — the mock answers it with the embeddings payload,
+            // which parses as unobservable, so the floor stays out of the way.
+            const embedPosts = allRequests.filter(request => request.url === '/v1/embeddings');
+            const slotProbes = allRequests.filter(request => request.url === '/slots');
+
+            expect(embedPosts).toHaveLength(1);
+            expect(slotProbes.length).toBeLessThanOrEqual(1);
             expect(lastRequest.body.input).toBe('hello');
         } finally {
             Neo.config.unitTestMode = originalUnitTestMode;

--- a/test/playwright/unit/ai/services/memory-core/TextEmbeddingService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/TextEmbeddingService.spec.mjs
@@ -647,7 +647,7 @@ test.describe('TextEmbeddingService #11965 Sub-2 — native Ollama dispatch', ()
             expect(providerCalls, 'repo B must never reach native Ollama in this sweep').toBe(1);
 
             const
-                queuedRow       = activities.filter(item => item.type === 'begin').at(-1),
+                queuedRow        = activities.filter(item => item.type === 'begin').at(-1),
                 queuedCompletion = activities.find(item => item.type === 'complete' && item.id === queuedRow.id);
 
             expect(queuedCompletion?.outcome).toMatchObject({failureStage: 'queue', success: false});
@@ -1814,6 +1814,113 @@ test.describe.serial('TextEmbeddingService #15694 — provider-neutral cancellat
             code        : 'OPENAI_COMPATIBLE_REQUEST_TIMEOUT',
             listeners   : 0,
             requestCount: 1
+        });
+    });
+
+    test('OpenAI-compatible truncation floors: wire flag, slot/band refusals, refusal mapping, fail-open (isolated)', async () => {
+        const evidence = await runIsolatedEmbeddingProbe(async () => {
+            const http = await import('node:http');
+
+            let behavior      = 'success',
+                requestBodies = [];
+
+            const server = http.createServer((request, response) => {
+                let body = '';
+                request.on('data', chunk => body += chunk);
+                request.on('end', () => {
+                    requestBodies.push(JSON.parse(body));
+
+                    if (behavior === 'truncation-refusal') {
+                        response.writeHead(400, {'Content-Type': 'application/json'});
+                        response.end(JSON.stringify({error: {message: 'input (32769 tokens) is too large to process. increase the physical batch size (current batch size: 32768)'}}));
+                        return;
+                    }
+
+                    const inputs = Array.isArray(JSON.parse(body).input) ? JSON.parse(body).input : [JSON.parse(body).input];
+                    response.writeHead(200, {'Content-Type': 'application/json'});
+                    response.end(JSON.stringify({
+                        data: inputs.map((input, index) => ({index, embedding: [index + 0.1]}))
+                    }));
+                });
+            });
+            await new Promise(resolve => server.listen(0, '127.0.0.1', resolve));
+
+            try {
+                Object.assign(process.env, {
+                    NEO_OPENAI_COMPATIBLE_HOST                  : `http://127.0.0.1:${server.address().port}`,
+                    NEO_OPENAI_COMPATIBLE_UNLOAD_RETRY_COUNT    : '0',
+                    NEO_OPENAI_COMPATIBLE_CONTENTION_RETRY_COUNT: '0'
+                });
+
+                const {default: Service} = await import('./ai/services/memory-core/TextEmbeddingService.mjs');
+                const capture            = async promise => {
+                    try {
+                        return {resolved: await promise};
+                    } catch (error) {
+                        return {code: error?.code || null, message: error?.message || String(error)};
+                    }
+                };
+
+                const out = {};
+
+                // A — wire flag + negative control: a fitting input on a compliant lane embeds
+                // normally, and the request asks the provider to refuse rather than truncate.
+                Service.openAiCompatibleSlotContextProbe = async () => 32768;
+                const fitting = await capture(Service.embedText('small input', 'openAiCompatible', {operationLabel: 'floor probe A'}));
+                out.negativeControl = {
+                    resolved    : Boolean(fitting.resolved),
+                    truncateFlag: requestBodies.at(-1)?.truncate === false,
+                    requestCount: requestBodies.length
+                };
+
+                // B — lane floor: a per-slot context below the safe band refuses BEFORE dispatch,
+                // so nothing truncating is ever sent, let alone persisted.
+                Service.openAiCompatibleSlotContextProbe = async () => 8192;
+                const beforeB   = requestBodies.length;
+                const laneFloor = await capture(Service.embedText('small input', 'openAiCompatible', {operationLabel: 'floor probe B'}));
+                out.laneFloor = {
+                    code      : laneFloor.code,
+                    namesBoth : laneFloor.message.includes('8192') && laneFloor.message.includes('28672'),
+                    noDispatch: requestBodies.length === beforeB
+                };
+
+                // C — input floor: an input whose estimate exceeds the observed slot context is
+                // refused pre-dispatch with the same typed code.
+                Service.openAiCompatibleSlotContextProbe = async () => 32768;
+                const bigInput   = 'x'.repeat(400_000);
+                const beforeC    = requestBodies.length;
+                const inputFloor = await capture(Service.embedText(bigInput, 'openAiCompatible', {operationLabel: 'floor probe C'}));
+                out.inputFloor = {
+                    code      : inputFloor.code,
+                    noDispatch: requestBodies.length === beforeC
+                };
+
+                // D — provider-refusal mapping: a 400 reporting the input/context bound translates
+                // to the typed code instead of an unclassified HTTP error.
+                behavior = 'truncation-refusal';
+                const refusal = await capture(Service.embedText('small input', 'openAiCompatible', {operationLabel: 'floor probe D'}));
+                out.refusalMapping = {code: refusal.code};
+
+                // E — fail-open on an unobservable lane: no slot metadata means the wire flag is
+                // the only defense, and the call proceeds.
+                behavior = 'success';
+                Service.openAiCompatibleSlotContextProbe = async () => null;
+                const unobservable = await capture(Service.embedText('small input', 'openAiCompatible', {operationLabel: 'floor probe E'}));
+                out.unobservableProceeds = Boolean(unobservable.resolved);
+
+                console.log(JSON.stringify(out));
+            } finally {
+                server.closeAllConnections?.();
+                await new Promise(resolve => server.close(resolve));
+            }
+        });
+
+        expect(evidence).toEqual({
+            negativeControl     : {resolved: true, truncateFlag: true, requestCount: 1},
+            laneFloor           : {code: 'EMBEDDING_INPUT_TRUNCATED', namesBoth: true, noDispatch: true},
+            inputFloor          : {code: 'EMBEDDING_INPUT_TRUNCATED', noDispatch: true},
+            refusalMapping      : {code: 'EMBEDDING_INPUT_TRUNCATED'},
+            unobservableProceeds: true
         });
     });
 });

--- a/test/playwright/unit/ai/services/memory-core/TextEmbeddingService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/TextEmbeddingService.spec.mjs
@@ -1817,30 +1817,40 @@ test.describe.serial('TextEmbeddingService #15694 — provider-neutral cancellat
         });
     });
 
-    test('OpenAI-compatible truncation floors: wire flag, slot/band refusals, refusal mapping, fail-open (isolated)', async () => {
+    test('exact structured provider overflow is typed and never yields a vector (isolated)', async () => {
         const evidence = await runIsolatedEmbeddingProbe(async () => {
             const http = await import('node:http');
 
-            let behavior      = 'success',
-                requestBodies = [];
-
+            const exactOverflow = {
+                error: {
+                    code           : 400,
+                    type           : 'exceed_context_size_error',
+                    n_prompt_tokens: 9002,
+                    n_ctx          : 8192
+                }
+            };
+            const responseBodies = [
+                exactOverflow,
+                'exceed_context_size_error: 9002 prompt tokens exceed n_ctx 8192',
+                {error: {code: 400, n_prompt_tokens: 9002, n_ctx: 8192}},
+                {error: {code: 400, type: 'wrong_context_error', n_prompt_tokens: 9002, n_ctx: 8192}},
+                {error: {code: 400, type: 'exceed_context_size_error', n_prompt_tokens: '9002', n_ctx: 8192}},
+                {error: {code: 400, type: 'exceed_context_size_error', n_ctx: 8192}},
+                {error: {code: 400, type: 'exceed_context_size_error', n_prompt_tokens: 9002, n_ctx: '8192'}},
+                {error: {code: 400, type: 'exceed_context_size_error', n_prompt_tokens: 9002}}
+            ];
+            let embeddingPosts  = 0,
+                vectorsReturned = 0;
             const server = http.createServer((request, response) => {
-                let body = '';
-                request.on('data', chunk => body += chunk);
+                embeddingPosts++;
+                request.resume();
                 request.on('end', () => {
-                    requestBodies.push(JSON.parse(body));
+                    const body = responseBodies.shift();
 
-                    if (behavior === 'truncation-refusal') {
-                        response.writeHead(400, {'Content-Type': 'application/json'});
-                        response.end(JSON.stringify({error: {message: 'input (32769 tokens) is too large to process. increase the physical batch size (current batch size: 32768)'}}));
-                        return;
-                    }
-
-                    const inputs = Array.isArray(JSON.parse(body).input) ? JSON.parse(body).input : [JSON.parse(body).input];
-                    response.writeHead(200, {'Content-Type': 'application/json'});
-                    response.end(JSON.stringify({
-                        data: inputs.map((input, index) => ({index, embedding: [index + 0.1]}))
-                    }));
+                    response.writeHead(400, {
+                        'Content-Type': typeof body === 'string' ? 'text/plain' : 'application/json'
+                    });
+                    response.end(typeof body === 'string' ? body : JSON.stringify(body));
                 });
             });
             await new Promise(resolve => server.listen(0, '127.0.0.1', resolve));
@@ -1853,62 +1863,43 @@ test.describe.serial('TextEmbeddingService #15694 — provider-neutral cancellat
                 });
 
                 const {default: Service} = await import('./ai/services/memory-core/TextEmbeddingService.mjs');
-                const capture            = async promise => {
+                const {
+                    classifyEmbedDisposition,
+                    classifyEmbedFailureError
+                } = await import('./ai/services/knowledge-base/helpers/embedFailureClassification.mjs');
+                const capture = async operationLabel => {
                     try {
-                        return {resolved: await promise};
+                        const result = await Service.embedText('small input', 'openAiCompatible', {operationLabel});
+
+                        vectorsReturned += Array.isArray(result) ? result.length : 0;
+                        return {error: null, rejected: false};
                     } catch (error) {
-                        return {code: error?.code || null, message: error?.message || String(error)};
+                        return {error, rejected: true};
                     }
                 };
+                const exact           = await capture('exact structured context overflow'),
+                      nearMissResults = [],
+                      nearMissCount   = responseBodies.length;
 
-                const out = {};
+                for (let index = 0; index < nearMissCount; index++) {
+                    const result = await capture(`structured context overflow near-miss ${index + 1}`);
 
-                // A — wire flag + negative control: a fitting input on a compliant lane embeds
-                // normally, and the request asks the provider to refuse rather than truncate.
-                Service.openAiCompatibleSlotContextProbe = async () => 32768;
-                const fitting = await capture(Service.embedText('small input', 'openAiCompatible', {operationLabel: 'floor probe A'}));
-                out.negativeControl = {
-                    resolved    : Boolean(fitting.resolved),
-                    truncateFlag: requestBodies.at(-1)?.truncate === false,
-                    requestCount: requestBodies.length
-                };
+                    nearMissResults.push({
+                        code    : result.error?.code ?? null,
+                        rejected: result.rejected
+                    });
+                }
 
-                // B — lane floor: a per-slot context below the safe band refuses BEFORE dispatch,
-                // so nothing truncating is ever sent, let alone persisted.
-                Service.openAiCompatibleSlotContextProbe = async () => 8192;
-                const beforeB   = requestBodies.length;
-                const laneFloor = await capture(Service.embedText('small input', 'openAiCompatible', {operationLabel: 'floor probe B'}));
-                out.laneFloor = {
-                    code      : laneFloor.code,
-                    namesBoth : laneFloor.message.includes('8192') && laneFloor.message.includes('28672'),
-                    noDispatch: requestBodies.length === beforeB
-                };
+                const kbCode = classifyEmbedFailureError(new Error('KB wrapper', {cause: exact.error}));
 
-                // C — input floor: an input whose estimate exceeds the observed slot context is
-                // refused pre-dispatch with the same typed code.
-                Service.openAiCompatibleSlotContextProbe = async () => 32768;
-                const bigInput   = 'x'.repeat(400_000);
-                const beforeC    = requestBodies.length;
-                const inputFloor = await capture(Service.embedText(bigInput, 'openAiCompatible', {operationLabel: 'floor probe C'}));
-                out.inputFloor = {
-                    code      : inputFloor.code,
-                    noDispatch: requestBodies.length === beforeC
-                };
-
-                // D — provider-refusal mapping: a 400 reporting the input/context bound translates
-                // to the typed code instead of an unclassified HTTP error.
-                behavior = 'truncation-refusal';
-                const refusal = await capture(Service.embedText('small input', 'openAiCompatible', {operationLabel: 'floor probe D'}));
-                out.refusalMapping = {code: refusal.code};
-
-                // E — fail-open on an unobservable lane: no slot metadata means the wire flag is
-                // the only defense, and the call proceeds.
-                behavior = 'success';
-                Service.openAiCompatibleSlotContextProbe = async () => null;
-                const unobservable = await capture(Service.embedText('small input', 'openAiCompatible', {operationLabel: 'floor probe E'}));
-                out.unobservableProceeds = Boolean(unobservable.resolved);
-
-                console.log(JSON.stringify(out));
+                console.log(JSON.stringify({
+                    code         : exact.error?.code,
+                    kbCode,
+                    kbDisposition: classifyEmbedDisposition(kbCode),
+                    embeddingPosts,
+                    nearMissResults,
+                    vectorsReturned
+                }));
             } finally {
                 server.closeAllConnections?.();
                 await new Promise(resolve => server.close(resolve));
@@ -1916,11 +1907,93 @@ test.describe.serial('TextEmbeddingService #15694 — provider-neutral cancellat
         });
 
         expect(evidence).toEqual({
-            negativeControl     : {resolved: true, truncateFlag: true, requestCount: 1},
-            laneFloor           : {code: 'EMBEDDING_INPUT_TRUNCATED', namesBoth: true, noDispatch: true},
-            inputFloor          : {code: 'EMBEDDING_INPUT_TRUNCATED', noDispatch: true},
-            refusalMapping      : {code: 'EMBEDDING_INPUT_TRUNCATED'},
-            unobservableProceeds: true
+            code           : 'EMBEDDING_INPUT_TRUNCATED',
+            kbCode         : 'KB_VECTOR_EMBED_INPUT_TRUNCATED',
+            kbDisposition  : 'rejected',
+            embeddingPosts : 8,
+            nearMissResults: Array.from({length: 7}, () => ({code: null, rejected: true})),
+            vectorsReturned: 0
+        })
+    });
+
+    test('LM Studio safe-band and oversized-input refusals retain the core code through KB classification (isolated)', async () => {
+        const evidence = await runIsolatedEmbeddingProbe(async () => {
+            const http = await import('node:http');
+
+            let   embeddingPosts = 0;
+            const server         = http.createServer((request, response) => {
+                embeddingPosts++;
+                response.writeHead(500);
+                response.end();
+            });
+            await new Promise(resolve => server.listen(0, '127.0.0.1', resolve));
+
+            try {
+                const port = String(server.address().port);
+                Object.assign(process.env, {
+                    NEO_OPENAI_COMPATIBLE_HOST                             : `http://127.0.0.1:${port}`,
+                    NEO_OPENAI_COMPATIBLE_EMBEDDING_MODEL                  : 'embedding-from-config',
+                    NEO_OPENAI_COMPATIBLE_UNLOAD_RETRY_COUNT               : '0',
+                    NEO_ORCHESTRATOR_LMS_ENABLED                           : 'true',
+                    NEO_ORCHESTRATOR_LMS_PORT                              : port,
+                    NEO_LOCAL_MODELS_EMBEDDING_CONTEXT_LIMIT_TOKENS        : '8192',
+                    NEO_LOCAL_MODELS_EMBEDDING_SAFE_PROCESSING_LIMIT_TOKENS: '28672'
+                });
+
+                const {default: Service} = await import('./ai/services/memory-core/TextEmbeddingService.mjs');
+                const {
+                    classifyEmbedDisposition,
+                    classifyEmbedFailureError
+                } = await import('./ai/services/knowledge-base/helpers/embedFailureClassification.mjs');
+                const captureError = promise => promise.then(() => null, error => error);
+
+                Service.openAiCompatibleLoadedModelsProbe = async () => [{
+                    id           : 'embedding-from-config',
+                    contextLength: 8192
+                }];
+                const belowBand = await captureError(Service.embedText('small input', 'openAiCompatible', {
+                    operationLabel: 'LM Studio below-band preflight'
+                }));
+                const overlap = await captureError(Service.embedText('x'.repeat(12746 * 3), 'openAiCompatible', {
+                    operationLabel: 'LM Studio policy-shortfall precedence'
+                }));
+
+                Service.openAiCompatibleLoadedModelsProbe = async () => [{
+                    id           : 'embedding-from-config',
+                    contextLength: 32768
+                }];
+                const oversized = await captureError(Service.embedText('x'.repeat(400_000), 'openAiCompatible', {
+                    operationLabel: 'LM Studio oversized preflight'
+                }));
+
+                const kbCode        = classifyEmbedFailureError(new Error('KB wrapper', {cause: belowBand})),
+                      overlapKbCode = classifyEmbedFailureError(new Error('KB wrapper', {cause: overlap}));
+
+                console.log(JSON.stringify({
+                    belowBandCode     : belowBand?.code,
+                    kbCode,
+                    kbDisposition     : classifyEmbedDisposition(kbCode),
+                    overlapCode       : overlap?.code,
+                    overlapKbCode,
+                    overlapDisposition: classifyEmbedDisposition(overlapKbCode),
+                    oversizedCode     : oversized?.code,
+                    embeddingPosts
+                }));
+            } finally {
+                server.closeAllConnections?.();
+                await new Promise(resolve => server.close(resolve));
+            }
         });
+
+        expect(evidence).toEqual({
+            belowBandCode     : 'EMBEDDING_CONTEXT_INSUFFICIENT',
+            kbCode            : 'KB_VECTOR_EMBED_CONTEXT_INSUFFICIENT',
+            kbDisposition     : 'deferrable',
+            overlapCode       : 'EMBEDDING_CONTEXT_INSUFFICIENT',
+            overlapKbCode     : 'KB_VECTOR_EMBED_CONTEXT_INSUFFICIENT',
+            overlapDisposition: 'deferrable',
+            oversizedCode     : 'EMBEDDING_INPUT_TRUNCATED',
+            embeddingPosts    : 0
+        })
     });
 });


### PR DESCRIPTION
Resolves neomjs/neo#17070

This revision binds the resolved embedding safe band through provider-lane composition and election v2, adds metadata-only LM Studio boot readiness, and gives Knowledge Base ingestion truthful failure semantics: a repairable resident-context mismatch is deferrable, while a current input whose estimate crosses trusted resident context or the pinned llama.cpp structured overflow refusal is rejected as truncation. It deliberately removes every per-request `/slots` probe and preserves generic OpenAI-compatible `{model, input}` transport.

Evidence: L2 (pinned-source proof plus isolated production-owner, real-service, transport, config, composition, and election tests) → L3 required (deployed boot-time live-shape receipt and canonical runtime observation). Residual: live provider shape versus elected envelope, Residual-Owner: neomjs/neo#17069.

Related: neomjs/neo#17069  
Related: neomjs/neo-agent-brain#38

## Deltas from ticket

- **Source correction:** the pinned llama.cpp handler ignores `truncate`, but its scheduler [refuses over-context embeddings before compute](https://github.com/ggml-org/llama.cpp/blob/0b1bad14ff204627636aeb1de22ddcd5acb859d4/tools/server/server-context.cpp#L3189-L3208) and returns a structured HTTP 400 [`exceed_context_size_error`](https://github.com/ggml-org/llama.cpp/blob/0b1bad14ff204627636aeb1de22ddcd5acb859d4/tools/server/server-common.cpp#L17-L53) containing [`n_prompt_tokens` and `n_ctx`](https://github.com/ggml-org/llama.cpp/blob/0b1bad14ff204627636aeb1de22ddcd5acb859d4/tools/server/server-task.cpp#L1527-L1536). The implementation classifies that exact receipt and no response prose.
- **`[SCOPE_TRANSFERRED]` live llama shape:** neomjs/neo#17069 already owns boot-time live shape versus elected envelope, health degradation, and deployment-state projection. Per-request `/slots` probing was removed because the live `#17024` receipt proves the endpoint starves under full grind; turning that expected state into a request failure would recreate zero-progress diagnostics.
- **Versioned authority:** composition receipts, election plans, and election reports move to v2 because candidate deployment inputs now carry the resolved safe band. Candidates must agree on it, analyzer subprocesses receive it explicitly, and application env drift fails validation.
- **Failure split:** `EMBEDDING_CONTEXT_INSUFFICIENT` / `KB_VECTOR_EMBED_CONTEXT_INSUFFICIENT` is deferrable and takes precedence while the resident is below policy; only an estimate above an otherwise policy-compliant trusted resident context and the exact pinned structured refusal become `EMBEDDING_INPUT_TRUNCATED` / `KB_VECTOR_EMBED_INPUT_TRUNCATED` with rejected disposition.
- **No embedding compute in the added LM Studio gate:** `postSpawn` uses strict resident rows already fetched by `ensureLmsModelsLoaded`; metadata-only mode performs no embedding canary or tokenizer/model-file work.
- Generic OpenAI-compatible request bodies remain `{model, input}`. No `truncate` field, slot-capability leaf, prose regex, or recurring `/slots` request was added.

## Commits

- `c344cd43a2` — Phoebe's original safe-band predicate, composition, and failure-typing substrate.
- `5a1b1c7f20` — Emmy's takeover repair: current authority correction, v2 binding, production readiness, causal failure split, and falsifier coverage.

## Test Evidence

- Full changed-surface matrix:
  `npm run test-unit -- test/playwright/unit/ai/config.template.spec.mjs test/playwright/unit/ai/daemons/orchestrator/Orchestrator.invariants.spec.mjs test/playwright/unit/ai/scripts/benchmark/ProviderLaneElectionCore.spec.mjs test/playwright/unit/ai/scripts/benchmark/ProviderLaneElectionRunner.spec.mjs test/playwright/unit/ai/scripts/diagnostics/providerLaneComposition.spec.mjs test/playwright/unit/ai/services/graph/providerReadinessHelper.spec.mjs test/playwright/unit/ai/services/knowledge-base/embedFailureClassification.spec.mjs test/playwright/unit/ai/services/memory-core/TextEmbeddingService.retry.spec.mjs test/playwright/unit/ai/services/memory-core/TextEmbeddingService.spec.mjs`
  → **255/255 passed (4.8s)**. This covers invalid-env fallback, non-default resolved-band CLI flow, composition/election v2, cross-candidate and archived-report equality, application-env drift, the production LMS owner and direct readiness propagation, zero-canary metadata mode, causal-precedence and distinct KB dispositions, exact structured overflow plus seven near-misses, generic transport, and zero-POST LMS preflight.
- `npm run --silent ai:lint-config-template-ssot` → **OK**, zero new AiConfig authority violations.
- `node buildScripts/util/check-aiconfig-test-mutation.mjs` → **1,204 test files scanned, zero new violations**.
- `git diff --check origin/dev` → **clean**.
- Directly touched app/feature coverage not listed above: None found.

## Post-Merge Validation

- [ ] Resolve the deployed revision and confirm the canonical v2 composition receipt reports the same safe band in deployment inputs and application env.
- [ ] On an LM Studio-owned embedding lane, confirm an undersized resident makes `postSpawn` not-ready without issuing an embedding request.
- [ ] Against the pinned llama.cpp image, confirm an over-context embedding returns the exact structured HTTP 400 refusal and is counted as `KB_VECTOR_EMBED_INPUT_TRUNCATED`.
- [ ] Confirm normal generic OpenAI-compatible embedding requests issue no `/slots` traffic.
- [ ] Complete `#17069`'s boot-time live-shape versus elected-envelope receipt before making any broader runtime-shape guarantee.

Residual-Owner: neomjs/neo#17069

## Evolution

The first implementation tried to manufacture a per-request safety contract from `truncate: false`, provider prose, and `/slots`. Exact pinned-source inspection falsified the first two; the live `#17024` receipt falsified the third under saturation. The reduced design now uses each authority where it is trustworthy: resolved config in composition, strict resident metadata for LM Studio, the pinned structured refusal at transport, and neomjs/neo#17069 for boot-time live shape.

Authored by Emmy (GPT-5.6 Sol Ultra, Codex) consuming Phoebe's handoff — session A d042176b-fba3-4eed-8f96-b376f2cc2113, session B 019fe0b3-53bc-7ef2-8665-41a0ef3f7b62.
