### PR TITLE
fix(ai): restore backup recovery after dependency restarts (#17068)

### DIFF
--- a/ai/daemons/orchestrator/scheduling/backup.mjs
+++ b/ai/daemons/orchestrator/scheduling/backup.mjs
@@ -208,8 +208,9 @@ function resolveNextBackupAttemptAtMs({
  * @summary AC5 requires budget exhaustion to reach a surface. An edge-triggered log would need
  * its own persisted "already warned" flag and would be lost on restart; every field this reads
  * is already persisted by `TaskStateService.writeState()`, so the phase is recomputable at any
- * time by any reader — including after a restart — and needs no state of its own. Exposed on the
- * orchestrator health payload, which is the surface that can actually see the backup lane.
+ * time by any reader — including after a restart — and needs no state of its own. Exposed through
+ * the orchestrator deployment-state bridge, whose current verdict is projected into the Memory Core
+ * healthcheck without giving that process direct backup-path authority.
  * @param {Object} options
  * @param {Object} [options.taskState={}] Persisted `backup` task state.
  * @param {Number} options.now Current timestamp in milliseconds.
@@ -308,6 +309,8 @@ export function describeBackupMaintenanceHealth({
     } else if (lastBackup?.backup?.status === 'failed') {
         reasonCodes.push('backup-last-run-failed')
     }
+    // `unanchored` is the expected pre-first-run state: it stays pending rather than turning every
+    // fresh deployment into a never-succeeded incident before the lane has had one opportunity.
     if (retryState && retryState.phase !== BACKUP_RETRY_PHASE.unanchored && !retryState.lastSuccessAt) {
         reasonCodes.push('backup-never-succeeded')
     }

--- a/ai/daemons/orchestrator/scheduling/backup.mjs
+++ b/ai/daemons/orchestrator/scheduling/backup.mjs
@@ -161,7 +161,49 @@ export function isFailedRunRetryDue({
 }
 
 /**
- * Reports the lane's retry phase as durable, readable STATE rather than a log edge.
+ * @summary Derives the backup lane's next scheduler eligibility from the same persisted facts and
+ * cadence bounds consumed by {@link buildBackupTrigger}.
+ *
+ * A closed retry burst is not a terminal lane: the ordinary periodic sweep remains eligible. This
+ * projection makes that fallback visible instead of asking an operator to infer it from
+ * `phase: exhausted`. `now` is returned when a path is already due; admission/backpressure may
+ * still defer its actual dispatch.
+ * @param {Object} options
+ * @param {Number} options.now Current timestamp in milliseconds.
+ * @param {Number} options.lastRunAt Last backup attempt timestamp.
+ * @param {Number} options.streakStartedAtMs Failure-streak anchor.
+ * @param {Number} options.intervalMs Ordinary periodic cadence.
+ * @param {Number} options.retryDelayMs Failed-run retry spacing.
+ * @param {Number} options.retryWindowMs Failed-run retry window.
+ * @returns {Number|null}
+ */
+function resolveNextBackupAttemptAtMs({
+    now,
+    lastRunAt,
+    streakStartedAtMs,
+    intervalMs,
+    retryDelayMs,
+    retryWindowMs
+}) {
+    const candidates = [];
+
+    if (intervalMs > 0) {
+        candidates.push(Math.max(now, lastRunAt + intervalMs))
+    }
+
+    if (retryDelayMs > 0 && isRetryWindowOpen({now, streakStartedAtMs, retryWindowMs})) {
+        const retryAtMs = Math.max(now, lastRunAt + retryDelayMs);
+
+        if (retryAtMs < streakStartedAtMs + retryWindowMs) {
+            candidates.push(retryAtMs)
+        }
+    }
+
+    return candidates.length > 0 ? Math.min(...candidates) : null
+}
+
+/**
+ * @summary Reports the lane's retry phase as durable, readable STATE rather than a log edge.
  *
  * @summary AC5 requires budget exhaustion to reach a surface. An edge-triggered log would need
  * its own persisted "already warned" flag and would be lost on restart; every field this reads
@@ -171,15 +213,33 @@ export function isFailedRunRetryDue({
  * @param {Object} options
  * @param {Object} [options.taskState={}] Persisted `backup` task state.
  * @param {Number} options.now Current timestamp in milliseconds.
+ * @param {Number} [options.intervalMs=0] Ordinary periodic cadence.
  * @param {Number} [options.retryDelayMs=0] Minimum spacing between retries.
  * @param {Number} [options.retryWindowMs=0] Retry window measured from the streak anchor.
- * @returns {{phase: String, retriesRemaining: Number, windowEndsAtMs: Number|null, streakStartedAtMs: Number, interruptedAt: String|null}}
+ * @returns {{phase: String, retriesRemaining: Number, windowEndsAtMs: Number|null, streakStartedAtMs: Number, interruptedAt: String|null, lastSuccessAt: String|null, lastSuccessAgeMs: Number|null, nextAttemptAtMs: Number|null}}
  */
-export function describeBackupRetryState({taskState = {}, now, retryDelayMs = 0, retryWindowMs = 0} = {}) {
+export function describeBackupRetryState({
+    taskState     = {},
+    now,
+    intervalMs    = 0,
+    retryDelayMs  = 0,
+    retryWindowMs = 0
+} = {}) {
     const streakStartedAtMs = toEpochMs(taskState.failureStreakStartedAt),
           lastSuccessAtMs   = toEpochMs(taskState.lastSuccessAt),
           interruptedAt     = taskState.interruptedAt || null,
-          base              = {retriesRemaining: 0, windowEndsAtMs: null, streakStartedAtMs, interruptedAt};
+          lastRunAt         = Number.isFinite(Number(taskState.lastRunAt)) ? Number(taskState.lastRunAt) : 0,
+          base              = {
+              interruptedAt,
+              lastSuccessAgeMs: lastSuccessAtMs > 0 ? Math.max(0, now - lastSuccessAtMs) : null,
+              lastSuccessAt   : lastSuccessAtMs > 0 ? taskState.lastSuccessAt : null,
+              nextAttemptAtMs : resolveNextBackupAttemptAtMs({
+                  now, lastRunAt, streakStartedAtMs, intervalMs, retryDelayMs, retryWindowMs
+              }),
+              retriesRemaining: 0,
+              streakStartedAtMs,
+              windowEndsAtMs  : null
+          };
 
     // No open streak: either known-good, or never ran at all. Both are reported, never conflated —
     // an interrupted run opens a streak (`readState` normalizes fail-closed), so it cannot land here.
@@ -195,11 +255,75 @@ export function describeBackupRetryState({taskState = {}, now, retryDelayMs = 0,
         phase           : open ? BACKUP_RETRY_PHASE.retrying : BACKUP_RETRY_PHASE.exhausted,
         retriesRemaining: open
             ? countRemainingRetries({
-                now, lastRunAt: taskState.lastRunAt || 0, streakStartedAtMs, retryDelayMs, retryWindowMs
+                now, lastRunAt, streakStartedAtMs, retryDelayMs, retryWindowMs
             })
             : 0,
         windowEndsAtMs
     };
+}
+
+/**
+ * @summary Reports a bounded, machine-readable maintenance-health verdict from backup facts the
+ * deployment snapshot already owns.
+ *
+ * The verdict adds no scheduler or persistence. It translates the existing retry state, last
+ * receipt, and durability posture into stable reason codes so consumers do not reverse-engineer a
+ * safety decision from several fields. Backup freshness becomes overdue after one ordinary cadence
+ * plus its bounded recovery window — the existing two configuration authorities, not a new hidden
+ * threshold.
+ * @param {Object} options
+ * @param {Object} [options.durability={}] Deployment durability posture.
+ * @param {Object|null} [options.lastBackup=null] Validated last-backup receipt projection.
+ * @param {Object|null} [options.retryState=null] Output of {@link describeBackupRetryState}.
+ * @param {Number} [options.backupIntervalMs=0] Ordinary backup cadence.
+ * @param {Number} [options.retryWindowMs=0] Bounded failed-run recovery window.
+ * @returns {{status: 'healthy'|'degraded'|'pending', reasonCodes: String[], staleAfterMs: Number|null}}
+ */
+export function describeBackupMaintenanceHealth({
+    durability       = {},
+    lastBackup       = null,
+    retryState       = null,
+    backupIntervalMs = 0,
+    retryWindowMs    = 0
+} = {}) {
+    const
+        reasonCodes  = [],
+        staleAfterMs = backupIntervalMs > 0
+            ? backupIntervalMs + Math.max(0, retryWindowMs)
+            : null;
+
+    if (durability.posture === 'unmet') {
+        reasonCodes.push('off-host-durability-unmet')
+    }
+    if (durability.configErrorCode) {
+        reasonCodes.push('off-host-config-invalid')
+    }
+    if (retryState?.phase === BACKUP_RETRY_PHASE.retrying) {
+        reasonCodes.push('backup-retry-open')
+    } else if (retryState?.phase === BACKUP_RETRY_PHASE.exhausted) {
+        reasonCodes.push('backup-retry-exhausted')
+    }
+    if (lastBackup?.status === 'unreadable') {
+        reasonCodes.push('backup-receipt-unreadable')
+    } else if (lastBackup?.backup?.status === 'failed') {
+        reasonCodes.push('backup-last-run-failed')
+    }
+    if (retryState && retryState.phase !== BACKUP_RETRY_PHASE.unanchored && !retryState.lastSuccessAt) {
+        reasonCodes.push('backup-never-succeeded')
+    }
+    if (staleAfterMs !== null && retryState?.lastSuccessAgeMs > staleAfterMs) {
+        reasonCodes.push('backup-success-overdue')
+    }
+
+    return {
+        reasonCodes: [...new Set(reasonCodes)],
+        staleAfterMs,
+        status     : reasonCodes.length > 0
+            ? 'degraded'
+            : (!lastBackup && (!retryState || retryState.phase === BACKUP_RETRY_PHASE.unanchored)
+                ? 'pending'
+                : 'healthy')
+    }
 }
 
 /**

--- a/ai/daemons/orchestrator/services/DeploymentStateBridgeService.mjs
+++ b/ai/daemons/orchestrator/services/DeploymentStateBridgeService.mjs
@@ -456,9 +456,9 @@ export class DeploymentStateBridgeService extends Base {
         // `retry` reports the backup lane's bounded-retry phase, and is omitted rather than nulled
         // when no task state was supplied so a detached invocation keeps its run-dependent shape.
         //
-        // Both ride HERE rather than on the Memory Core healthcheck's backup block: that block reads
-        // the backup DIRECTORY and `mc-server` holds no backup mount, so it reports from a blind
-        // container. This orchestrator owns the bind mount and the task state.
+        // Both are DERIVED here because the Memory Core process holds neither the backup mount nor
+        // the task state. The resulting bounded bridge verdict is then safe for Memory Core's
+        // operator healthcheck to consume without granting that container direct backup authority.
         const base = {
             durability,
             stagingResidue: await summarizeStagingResidue(stagingResidueRoot)

--- a/ai/daemons/orchestrator/services/DeploymentStateBridgeService.mjs
+++ b/ai/daemons/orchestrator/services/DeploymentStateBridgeService.mjs
@@ -68,7 +68,10 @@ import {
     readBackupReceipt,
     validateOffHostSyncConfig
 } from '../../../services/memory-core/helpers/offHostSyncStore.mjs';
-import {describeBackupRetryState}    from '../scheduling/backup.mjs';
+import {
+    describeBackupMaintenanceHealth,
+    describeBackupRetryState
+} from '../scheduling/backup.mjs';
 import {resolveDurabilityPosture}    from './deploymentDurabilityPosture.mjs';
 import {summarizeStagingResidue}     from '../../../scripts/maintenance/backupStagingResidueCore.mjs';
 import {readRecentRecoveryRunStates} from '../../../services/memory-core/helpers/recoveryRunStateStore.mjs';
@@ -461,42 +464,51 @@ export class DeploymentStateBridgeService extends Base {
             stagingResidue: await summarizeStagingResidue(stagingResidueRoot)
         };
 
+        let retryState = null,
+            lastBackup = null;
+
         if (backupTaskState) {
-            base.retry = describeBackupRetryState({
+            retryState = describeBackupRetryState({
                 now,
+                intervalMs   : AiConfig.orchestrator.intervals.backupMs,
                 retryDelayMs : AiConfig.orchestrator.intervals.backupRetryDelayMs,
                 retryWindowMs: AiConfig.orchestrator.intervals.backupRetryWindowMs,
                 taskState    : backupTaskState
-            })
+            });
+            base.retry = retryState
         }
 
         try {
             const outcome = await readBackupReceipt({filePath: receiptPath});
 
-            if (outcome.status === 'missing') return base;
-
             if (outcome.status === 'unreadable') {
-                return {
-                    ...base,
-                    lastBackup: {
-                        finishedAt: outcome.finishedAt,
-                        kind      : outcome.kind,
-                        status    : 'unreadable'
-                    }
-                }
-            }
-
-            return {...base, lastBackup: outcome.receipt}
-        } catch (error) {
-            return {
-                ...base,
-                lastBackup: {
-                    finishedAt: null,
-                    kind      : 'corrupt',
+                lastBackup = {
+                    finishedAt: outcome.finishedAt,
+                    kind      : outcome.kind,
                     status    : 'unreadable'
                 }
+            } else if (outcome.status === 'ok') {
+                lastBackup = outcome.receipt
+            }
+        } catch (error) {
+            lastBackup = {
+                finishedAt: null,
+                kind      : 'corrupt',
+                status    : 'unreadable'
             }
         }
+
+        if (lastBackup) base.lastBackup = lastBackup;
+
+        base.health = describeBackupMaintenanceHealth({
+            durability,
+            lastBackup,
+            retryState,
+            backupIntervalMs: AiConfig.orchestrator.intervals.backupMs,
+            retryWindowMs   : AiConfig.orchestrator.intervals.backupRetryWindowMs
+        });
+
+        return base
     }
 
 

--- a/ai/mcp/server/knowledge-base/configBase.mjs
+++ b/ai/mcp/server/knowledge-base/configBase.mjs
@@ -456,8 +456,9 @@ class ConfigBase extends ConfigProvider {
              * consumes these leaves only for transient `ChromaConnectionError` failures while
              * resolving the canonical collection name; not-found and shadow-swap promotion paths
              * keep their existing handling. `maxAttempts` includes the initial call. The shipped
-             * 15-second horizon spans a normal Chroma container restart while remaining bounded
-             * well below the orchestrator's outer 15-minute backup retry spacing.
+             * 15-second horizon is chosen to cover a typical Chroma container restart while remaining
+             * bounded well below the orchestrator's outer 15-minute backup retry spacing. A real
+             * external-plane restart witness remains outstanding.
              * @type {Object}
              */
             collectionResolveRetry: {

--- a/ai/mcp/server/knowledge-base/configBase.mjs
+++ b/ai/mcp/server/knowledge-base/configBase.mjs
@@ -455,14 +455,16 @@ class ConfigBase extends ConfigProvider {
              * Long-running syncs can overlap a local Chroma restart or recycle. `ChromaManager`
              * consumes these leaves only for transient `ChromaConnectionError` failures while
              * resolving the canonical collection name; not-found and shadow-swap promotion paths
-             * keep their existing handling. `maxAttempts` includes the initial call.
+             * keep their existing handling. `maxAttempts` includes the initial call. The shipped
+             * 15-second horizon spans a normal Chroma container restart while remaining bounded
+             * well below the orchestrator's outer 15-minute backup retry spacing.
              * @type {Object}
              */
             collectionResolveRetry: {
-                maxAttempts    : leaf(5,    'NEO_KB_COLLECTION_RESOLVE_RETRY_MAX_ATTEMPTS', 'number'),
+                maxAttempts    : leaf(10,   'NEO_KB_COLLECTION_RESOLVE_RETRY_MAX_ATTEMPTS', 'number'),
                 initialDelayMs : leaf(500,  'NEO_KB_COLLECTION_RESOLVE_RETRY_INITIAL_DELAY_MS', 'number'),
                 maxDelayMs     : leaf(2000, 'NEO_KB_COLLECTION_RESOLVE_RETRY_MAX_DELAY_MS', 'number'),
-                maxTotalDelayMs: leaf(5000, 'NEO_KB_COLLECTION_RESOLVE_RETRY_MAX_TOTAL_DELAY_MS', 'number')
+                maxTotalDelayMs: leaf(15000, 'NEO_KB_COLLECTION_RESOLVE_RETRY_MAX_TOTAL_DELAY_MS', 'number')
             },
             /**
              * @summary The Knowledge Base embedding-probe policy. Deployment-tunable, because the

--- a/ai/mcp/server/memory-core/openapi.yaml
+++ b/ai/mcp/server/memory-core/openapi.yaml
@@ -3426,6 +3426,31 @@ components:
               description: "True only when the backlog is empty. Null when not observable — never inferred from an unreadable WAL."
               example: true
           required: [observable, state, stallThresholdMs, pendingDrainDepth, oldestPendingAgeMs, allWritesSemanticallyQueryable]
+        maintenance:
+          type: object
+          description: "Operator-facing maintenance health projected from the orchestrator deployment-state bridge. A degraded backup verdict degrades this healthcheck; a stale or unavailable bridge observation remains explicit and cannot authorize a current degradation."
+          properties:
+            observationStatus:
+              type: string
+              enum: [available, stale, degraded, unavailable]
+              description: "Freshness/readability status of the deployment-state bridge observation used for this projection."
+            backup:
+              type: object
+              nullable: true
+              description: "Current bounded backup-maintenance verdict, or null when the bridge observation is not current and valid."
+              properties:
+                status:
+                  type: string
+                  enum: [healthy, degraded, pending]
+                reasonCodes:
+                  type: array
+                  items:
+                    type: string
+                staleAfterMs:
+                  type: number
+                  nullable: true
+              required: [status, reasonCodes, staleAfterMs]
+          required: [observationStatus, backup]
         plane:
           type: object
           description: "OBSERVED plane identity — the id/dataRoot THIS process resolved, read from the same per-server config the boot assertion verified (the deployment manifest's observed column). Always present."

--- a/ai/mcp/server/memory-core/toolService.mjs
+++ b/ai/mcp/server/memory-core/toolService.mjs
@@ -184,24 +184,43 @@ const explorePullRequestHistoryOp = args => PullRequestHistoryService.explorePul
 const ALL_FEATURES_OPERATIONAL_DETAIL = 'All features are operational';
 
 /**
- * @summary Reconciles the base Memory Core health verdict with its measured WAL-drain state.
+ * @summary Reconciles base Memory Core health with measured WAL and orchestrator maintenance state.
  *
  * A fresh asynchronous backlog is expected and leaves the base verdict unchanged. Once the shared
- * drain classifier reports `stalled`, the composed response cannot still claim every feature is
- * operational: healthy/degraded becomes degraded, an existing unhealthy verdict wins, and the
- * reason names the measured depth and age. This projection is diagnostic-only and never repairs or
- * mutates the WAL.
+ * drain classifier reports `stalled`, or the current orchestrator bridge reports degraded backup
+ * maintenance, the composed response cannot still claim every feature is operational:
+ * healthy/degraded becomes degraded, an existing unhealthy verdict wins, and the details name the
+ * observed cause. Stale/unavailable bridge state is explicit but cannot authorize a current backup
+ * degradation. This projection is diagnostic-only and never repairs either subsystem.
  *
  * @param {Object} options
  * @param {Object} options.health Base HealthService response.
  * @param {Object} options.memoryWalDrain Measured MemoryService drain response.
  * @param {Object} options.plane Observed Memory Core plane identity.
+ * @param {Object|null} [options.vectorGeneration=null] Vector-generation election health.
+ * @param {Object|null} [options.deploymentInspection=null] Current orchestrator bridge inspection.
  * @returns {Object}
  */
-export function composeMemoryCoreHealthcheck({health, memoryWalDrain, plane, vectorGeneration = null}) {
-    const response = {...health, memoryWalDrain, plane, vectorGeneration};
+export function composeMemoryCoreHealthcheck({
+    health,
+    memoryWalDrain,
+    plane,
+    vectorGeneration = null,
+    deploymentInspection = null
+}) {
+    const
+        backupHealth = deploymentInspection?.ok === true
+            ? deploymentInspection.snapshot?.maintenance?.health ?? null
+            : null,
+        maintenance  = {
+            observationStatus: deploymentInspection?.status ?? 'unavailable',
+            backup           : backupHealth
+        },
+        response       = {...health, memoryWalDrain, plane, vectorGeneration, maintenance},
+        drainStalled   = memoryWalDrain.state === 'stalled',
+        backupDegraded = backupHealth?.status === 'degraded';
 
-    if (memoryWalDrain.state !== 'stalled') {
+    if (!drainStalled && !backupDegraded) {
         return response
     }
 
@@ -209,11 +228,21 @@ export function composeMemoryCoreHealthcheck({health, memoryWalDrain, plane, vec
         ? health.details.filter(detail => detail !== ALL_FEATURES_OPERATIONAL_DETAIL)
         : [];
 
-    details.push(
-        `Memory WAL embed drain is stalled: ${memoryWalDrain.pendingDrainDepth} pending records; ` +
-        `oldest pending age ${memoryWalDrain.oldestPendingAgeMs} ms exceeds the ` +
-        `${memoryWalDrain.stallThresholdMs} ms threshold.`
-    );
+    if (drainStalled) {
+        details.push(
+            `Memory WAL embed drain is stalled: ${memoryWalDrain.pendingDrainDepth} pending records; ` +
+            `oldest pending age ${memoryWalDrain.oldestPendingAgeMs} ms exceeds the ` +
+            `${memoryWalDrain.stallThresholdMs} ms threshold.`
+        )
+    }
+
+    if (backupDegraded) {
+        const reasonCodes = Array.isArray(backupHealth.reasonCodes) && backupHealth.reasonCodes.length > 0
+            ? backupHealth.reasonCodes.join(', ')
+            : 'see maintenance.backup';
+
+        details.push(`Backup maintenance is degraded: ${reasonCodes}.`)
+    }
 
     return {
         ...response,
@@ -259,6 +288,9 @@ const serviceMapping = {
         health        : await HealthService.healthcheck(args),
         memoryWalDrain: await MemoryService.describeDrainState(),
         plane         : {id: mcConfig.plane.id, dataRoot: mcConfig.plane.dataRoot},
+        // Fresh bridge truth only. `composeMemoryCoreHealthcheck` keeps stale/unavailable
+        // observations explicit but prevents either from authorizing a backup degradation.
+        deploymentInspection: await readDeploymentInspection(),
         // Elected + parked vector-generation identities (never throws; `missing` on a plane that
         // has not declared an election) — acceptance for a generation cutover reads this block.
         vectorGeneration: await projectVectorGenerationHealth({

--- a/test/playwright/integration-parity/ParityTopology.integration.spec.mjs
+++ b/test/playwright/integration-parity/ParityTopology.integration.spec.mjs
@@ -133,6 +133,7 @@ test.describe('Parity topology lane (#15807) — the phase-3 stack with a CI wit
                 'ai/scripts/diagnostics/mcpHealthcheck.mjs',
                 '--url', url,
                 '--client-name', `neo-parity-ci-spec-${service}`,
+                '--expected-status', 'healthy,degraded',
                 '--expected-plane-id', PLANE_ID,
                 '--expected-plane-data-root', PLANE_DATA_ROOT
             ]);
@@ -160,6 +161,7 @@ test.describe('Parity topology lane (#15807) — the phase-3 stack with a CI wit
             'ai/scripts/diagnostics/mcpHealthcheck.mjs',
             '--url', MC_INTERNAL_URL,
             '--client-name', 'neo-parity-ci-spec-foreign-id',
+            '--expected-status', 'healthy,degraded',
             '--expected-plane-id', 'neo-canonical-durable-plane'
         ]);
 
@@ -170,6 +172,7 @@ test.describe('Parity topology lane (#15807) — the phase-3 stack with a CI wit
             'ai/scripts/diagnostics/mcpHealthcheck.mjs',
             '--url', MC_INTERNAL_URL,
             '--client-name', 'neo-parity-ci-spec-foreign-root',
+            '--expected-status', 'healthy,degraded',
             '--expected-plane-id', PLANE_ID,
             '--expected-plane-data-root', CANONICAL_DATA_ROOT
         ]);

--- a/test/playwright/integration-parity/fixtures/parityComposeWebServer.mjs
+++ b/test/playwright/integration-parity/fixtures/parityComposeWebServer.mjs
@@ -161,6 +161,7 @@ async function assertServedIdentity() {
             'node', 'ai/scripts/diagnostics/mcpHealthcheck.mjs',
             '--url', url,
             '--client-name', `neo-parity-ci-readiness-${service}`,
+            '--expected-status', 'healthy,degraded',
             '--expected-plane-id', projectName,
             '--expected-plane-data-root', PLANE_DATA_ROOT
         ]);

--- a/test/playwright/unit/ai/daemons/orchestrator/scheduling/backup.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/scheduling/backup.spec.mjs
@@ -3,6 +3,7 @@ import {
     BACKUP_RETRY_PHASE,
     buildBackupTrigger,
     countRemainingRetries,
+    describeBackupMaintenanceHealth,
     describeBackupRetryState,
     getDueTask,
     isFailedRunRetryDue
@@ -231,12 +232,36 @@ test.describe('orchestrator/scheduling/backup — retry phase reporting (#16348 
     test('reports exhausted once the window has closed, with no retries remaining', () => {
         const state = describeBackupRetryState({
             ...retryOpts(),
-            now      : T + DAY_MS + 1000 + WINDOW_MS + 1,
-            taskState: productionFailure()
+            intervalMs: DAY_MS,
+            now       : T + DAY_MS + 1000 + WINDOW_MS + 1,
+            taskState : productionFailure()
         });
 
         expect(state.phase).toBe(BACKUP_RETRY_PHASE.exhausted);
         expect(state.retriesRemaining).toBe(0);
+        expect(state.nextAttemptAtMs).toBe(T + DAY_MS * 2);
+        expect(state.lastSuccessAt).toBe(iso(T));
+        expect(state.lastSuccessAgeMs).toBe(DAY_MS + 1000 + WINDOW_MS + 1);
+    });
+
+    test('#17068: exhaustion exposes the existing periodic fallback and becomes due at that cadence', () => {
+        const
+            lastRunAt   = T + DAY_MS,
+            state       = productionFailure({lastRunAt}),
+            exhaustedAt = Date.parse(state.failureStreakStartedAt) + WINDOW_MS + 1,
+            retry       = describeBackupRetryState({
+                ...retryOpts(), intervalMs: DAY_MS, now: exhaustedAt, taskState: state
+            });
+
+        expect(retry.phase).toBe(BACKUP_RETRY_PHASE.exhausted);
+        expect(retry.nextAttemptAtMs).toBe(lastRunAt + DAY_MS);
+        expect(getDueTask({
+            state              : {backup: state},
+            now                : retry.nextAttemptAtMs,
+            backupIntervalMs   : DAY_MS,
+            backupRetryDelayMs : DELAY_MS,
+            backupRetryWindowMs: WINDOW_MS
+        })).toMatchObject({source: 'periodic-sweep'});
     });
 
     /**
@@ -274,5 +299,47 @@ test.describe('orchestrator/scheduling/backup — retry phase reporting (#16348 
             now      : T,
             taskState: {failureStreakStartedAt: 'not-a-date', lastSuccessAt: 'not-a-date'}
         }).phase).toBe(BACKUP_RETRY_PHASE.unanchored);
+    });
+});
+
+test.describe('orchestrator/scheduling/backup — maintenance health (#17068)', () => {
+    test('degrades with bounded reason codes for the observed failed/exhausted/unmet shape', () => {
+        const health = describeBackupMaintenanceHealth({
+            backupIntervalMs: DAY_MS,
+            durability      : {posture: 'unmet'},
+            lastBackup      : {backup: {status: 'failed'}},
+            retryState      : {
+                phase           : BACKUP_RETRY_PHASE.exhausted,
+                lastSuccessAgeMs: DAY_MS + WINDOW_MS + 1,
+                lastSuccessAt   : iso(T)
+            },
+            retryWindowMs: WINDOW_MS
+        });
+
+        expect(health).toEqual({
+            reasonCodes: [
+                'off-host-durability-unmet',
+                'backup-retry-exhausted',
+                'backup-last-run-failed',
+                'backup-success-overdue'
+            ],
+            staleAfterMs: DAY_MS + WINDOW_MS,
+            status      : 'degraded'
+        });
+    });
+
+    test('reports pending before a first receipt and healthy after a fresh successful run', () => {
+        expect(describeBackupMaintenanceHealth({durability: {posture: 'configured'}}).status).toBe('pending');
+        expect(describeBackupMaintenanceHealth({
+            backupIntervalMs: DAY_MS,
+            durability      : {posture: 'configured'},
+            lastBackup      : {backup: {status: 'success'}},
+            retryState      : {
+                phase           : BACKUP_RETRY_PHASE.healthy,
+                lastSuccessAgeMs: 1000,
+                lastSuccessAt   : iso(T)
+            },
+            retryWindowMs: WINDOW_MS
+        })).toEqual({reasonCodes: [], staleAfterMs: DAY_MS + WINDOW_MS, status: 'healthy'});
     });
 });

--- a/test/playwright/unit/ai/deploy/ParityPlaneVolumeScoping.spec.mjs
+++ b/test/playwright/unit/ai/deploy/ParityPlaneVolumeScoping.spec.mjs
@@ -270,6 +270,28 @@ test.describe('parity profile — volume scoping is the isolation mechanism', ()
         expect(orchestratorEnvironment).not.toContain('NEO_MCP_HEALTHCHECK_TOKEN')
     });
 
+    test('parity served-identity probes accept consumed maintenance degradation', () => {
+        const
+            serverSource      = fs.readFileSync(parityServerPath, 'utf8'),
+            specSource        = fs.readFileSync(paritySpecPath, 'utf8'),
+            commandPattern    = /'ai\/scripts\/diagnostics\/mcpHealthcheck\.mjs',([\s\S]*?)\]\);/g,
+            expectedStatusArg = "'--expected-status', 'healthy,degraded'";
+
+        for (const [label, source, expectedCount] of [
+            ['parity readiness fixture', serverSource, 1],
+            ['parity topology spec', specSource, 3]
+        ]) {
+            const commands = [...source.matchAll(commandPattern)].map(match => match[1]);
+
+            expect(commands, `${label} must retain every served-identity probe`).toHaveLength(expectedCount);
+
+            for (const command of commands) {
+                expect(command, `${label} must treat degraded as alive while preserving identity checks`)
+                    .toContain(expectedStatusArg);
+            }
+        }
+    });
+
     test('the CI overlay inherits placement and cannot override profile-pinned plane leaves', () => {
         const source = fs.readFileSync(parityOverlayPath, 'utf8');
 

--- a/test/playwright/unit/ai/mcp/server/knowledge-base/config.template.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/knowledge-base/config.template.spec.mjs
@@ -110,10 +110,10 @@ test.describe('Knowledge Base Config Tier-1 defaults (#11963)', () => {
         expect(config.collectionName).toBe('neo-knowledge-base');
         expect(config.path).toBe(tier1Template.engines.chroma.dataDir);
         expect(tier1Template.engines.chroma.dataDir).toBe(tier1Template.engines.chroma.dataDirTest);
-        expect(config.collectionResolveRetry.maxAttempts).toBe(5);
+        expect(config.collectionResolveRetry.maxAttempts).toBe(10);
         expect(config.collectionResolveRetry.initialDelayMs).toBe(500);
         expect(config.collectionResolveRetry.maxDelayMs).toBe(2000);
-        expect(config.collectionResolveRetry.maxTotalDelayMs).toBe(5000);
+        expect(config.collectionResolveRetry.maxTotalDelayMs).toBe(15000);
         expect(config.memoryCoreDbUseTestDatabase).toBe(true);
         expect(config.memoryCoreDbUseTestHarness).toBe(true);
         expect(config.memoryCoreDbPath).toBe(config.memoryCoreDbPathTest);

--- a/test/playwright/unit/ai/mcp/server/memory-core/McpServerToolLimits.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/memory-core/McpServerToolLimits.spec.mjs
@@ -320,6 +320,94 @@ test.describe('Neo.ai.mcp.server.memory-core Tool limits', () => {
         expect(unobservable.memoryWalDrain.state).toBe('unobservable');
     });
 
+    test('healthcheck projects current degraded backup maintenance without trusting stale bridge state (#17068)', async () => {
+        const
+            plane        = {id: 'test-plane', dataRoot: '/test-data'},
+            healthyDrain = {
+                observable                    : true,
+                state                         : 'caught-up',
+                stallThresholdMs              : 6 * 60 * 60 * 1000,
+                pendingDrainDepth             : 0,
+                oldestPendingAgeMs            : null,
+                allWritesSemanticallyQueryable: true
+            },
+            baseHealth   = {
+                status : 'healthy',
+                details: ['Connected to ChromaDB', 'All features are operational']
+            },
+            inspection  = {
+                ok      : true,
+                status  : 'available',
+                snapshot: {
+                    maintenance: {
+                        health: {
+                            status      : 'degraded',
+                            reasonCodes : ['backup-retry-exhausted', 'backup-last-run-failed'],
+                            staleAfterMs: 90000000
+                        }
+                    }
+                }
+            };
+
+        const degraded = toolService.composeMemoryCoreHealthcheck({
+            health              : baseHealth,
+            memoryWalDrain      : healthyDrain,
+            plane,
+            deploymentInspection: inspection
+        });
+
+        expect(degraded.status).toBe('degraded');
+        expect(degraded.maintenance).toEqual({
+            observationStatus: 'available',
+            backup           : inspection.snapshot.maintenance.health
+        });
+        expect(degraded.details).not.toContain('All features are operational');
+        expect(degraded.details.at(-1)).toContain('backup-retry-exhausted, backup-last-run-failed');
+
+        const stale = toolService.composeMemoryCoreHealthcheck({
+            health              : baseHealth,
+            memoryWalDrain      : healthyDrain,
+            plane,
+            deploymentInspection: {...inspection, ok: false, status: 'stale'}
+        });
+
+        expect(stale.status).toBe('healthy');
+        expect(stale.maintenance).toEqual({observationStatus: 'stale', backup: null});
+        expect(stale.details).toContain('All features are operational');
+
+        const unhealthy = toolService.composeMemoryCoreHealthcheck({
+            health              : {...baseHealth, status: 'unhealthy'},
+            memoryWalDrain      : healthyDrain,
+            plane,
+            deploymentInspection: inspection
+        });
+
+        expect(unhealthy.status).toBe('unhealthy');
+
+        const combined = toolService.composeMemoryCoreHealthcheck({
+            health        : baseHealth,
+            memoryWalDrain: {
+                ...healthyDrain,
+                state             : 'stalled',
+                pendingDrainDepth : 3,
+                oldestPendingAgeMs: healthyDrain.stallThresholdMs + 1
+            },
+            plane,
+            deploymentInspection: inspection
+        });
+
+        expect(combined.details.some(detail => detail.includes('Memory WAL embed drain is stalled'))).toBe(true);
+        expect(combined.details.some(detail => detail.includes('Backup maintenance is degraded'))).toBe(true);
+
+        const {tools}  = await toolService.listTools();
+        const declared = tools.find(item => item.name === 'healthcheck').outputSchema.properties.maintenance;
+
+        expect(declared).toBeTruthy();
+        expect(declared.properties.observationStatus.enum).toEqual(['available', 'stale', 'degraded', 'unavailable']);
+        expect(declared.properties.backup.properties.status.enum).toEqual(['healthy', 'degraded', 'pending']);
+        expect(declared.properties.backup.properties.reasonCodes.items.type).toBe('string');
+    });
+
     test('healthcheck dispatch passes diagnostic options as one object (#13460)', async () => {
         const observedArgs   = [];
         const spyToolService = Neo.create(ToolService, {

--- a/test/playwright/unit/ai/scripts/maintenance/offHostSync.spec.mjs
+++ b/test/playwright/unit/ai/scripts/maintenance/offHostSync.spec.mjs
@@ -11,14 +11,14 @@ setup({
     }
 });
 
-import Neo                                                             from '../../../../../../src/Neo.mjs';
-import * as core                                                       from '../../../../../../src/core/_export.mjs';
-import {test, expect}                                                  from '@playwright/test';
+import Neo                                                                        from '../../../../../../src/Neo.mjs';
+import * as core                                                                  from '../../../../../../src/core/_export.mjs';
+import {test, expect}                                                             from '@playwright/test';
 import {mkdirSync, mkdtempSync, rmSync, readFileSync, writeFileSync, readdirSync} from 'node:fs';
-import {open, rename}                                                  from 'node:fs/promises';
-import {spawn}                                                         from 'node:child_process';
-import {tmpdir}                                                        from 'node:os';
-import path                                                            from 'node:path';
+import {open, rename}                                                             from 'node:fs/promises';
+import {spawn}                                                                    from 'node:child_process';
+import {tmpdir}                                                                   from 'node:os';
+import path                                                                       from 'node:path';
 
 import {
     buildBackupReceipt,
@@ -694,6 +694,7 @@ test.describe('wrapper + projection behavioral witnesses', () => {
             expect(beforeFirstRun).not.toBe(null);
             expect(beforeFirstRun.lastBackup).toBeUndefined();
             expect(beforeFirstRun.durability.posture).toBeTruthy();
+            expect(beforeFirstRun.health.status).toBeTruthy();
 
             await writeBackupReceipt({
                 filePath: receiptPath,
@@ -707,10 +708,12 @@ test.describe('wrapper + projection behavioral witnesses', () => {
             const projected = await collect({receiptPath});
             expect(projected.lastBackup.bundleName).toBe('backup-2026-07-22');
             expect(projected.lastBackup.backup.status).toBe('success');
+            expect(projected.health.status).toBeTruthy();
 
             writeFileSync(receiptPath, 'not json{');
             const unreadable = await collect({receiptPath});
             expect(unreadable.lastBackup).toEqual({finishedAt: null, kind: 'corrupt', status: 'unreadable'});
+            expect(unreadable.health.reasonCodes).toContain('backup-receipt-unreadable');
         } finally {
             rmSync(root, {force: true, recursive: true})
         }

--- a/test/playwright/unit/ai/services/knowledge-base/ChromaManager.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/ChromaManager.spec.mjs
@@ -158,6 +158,33 @@ test.describe('Neo.ai.services.knowledge-base.ChromaManager', () => {
         expect(ChromaManager.knowledgeBaseCollection).toBe(null);
     });
 
+    test('#17068: the bounded resolver spans a dependency restart longer than the prior five-second horizon', async () => {
+        const delays   = [];
+        let   getCount = 0;
+
+        ChromaManager.collectionResolveRetrySleepFn = async delayMs => { delays.push(delayMs); };
+        ChromaManager.client = {
+            getCollection: async options => {
+                getCount++;
+
+                if (delays.reduce((total, delayMs) => total + delayMs, 0) <= 6000) {
+                    const error = new Error('Failed to connect to chromadb');
+                    error.name  = 'ChromaConnectionError';
+                    throw error;
+                }
+
+                return {name: options.name};
+            }
+        };
+
+        await expect(ChromaManager.getKnowledgeBaseCollection())
+            .resolves.toMatchObject({name: aiConfig.collectionName});
+        expect(getCount).toBeGreaterThan(aiConfig.collectionResolveRetry.maxAttempts / 2);
+        expect(delays.reduce((total, delayMs) => total + delayMs, 0)).toBeGreaterThan(6000);
+        expect(delays.reduce((total, delayMs) => total + delayMs, 0))
+            .toBeLessThanOrEqual(aiConfig.collectionResolveRetry.maxTotalDelayMs);
+    });
+
     test('getKnowledgeBaseCollection treats ChromaNotFoundError as missing canonical collection', async () => {
         let createCount = 0;
         let capturedOptions;


### PR DESCRIPTION
Resolves neomjs/neo#17068

Related: neomjs/neo-agent-brain#38
Related: neomjs/neo-agent-brain#54

Restores backup recovery across bounded Chroma restarts and makes the lane visible where operators already look. The Knowledge Base resolver remains available for a 15-second transient connection horizon; the deployment bridge derives retry, success-age, and maintenance risk from state it already owns; and the Memory Core healthcheck now consumes only a current bridge verdict. Degraded backup risk changes that health surface to `degraded`, while stale or unavailable bridge observations stay explicit and non-authoritative. Knowledge Base liveness is deliberately unchanged because its container probe accepts only `healthy`.

Evidence: L2 (injected Chroma outage beyond the former retry horizon, scheduler fallback, and deployment-state projection all pass hermetically) → L2 required (the corrected neomjs/neo#17068 code acceptance is bounded retry plus derived state). Residual: external-plane dependency-restart witness, Residual-Owner: neomjs/neo-agent-brain#54.

## Deltas from ticket

Intake falsified two mechanisms in the original ticket. Retry exhaustion already falls back to the ordinary periodic cadence, and off-host durability posture is already enforced by the backup wrapper. This PR therefore adds no re-arm scheduler, timestamp store, or durability control. It fixes the confirmed five-second dependency-resolve horizon, projects the existing fallback/success-age/risk state, and now lands that bounded verdict on the Memory Core healthcheck that operators and container diagnostics already read.

The health contract change is additive: `maintenance.observationStatus` says whether bridge truth is current, and `maintenance.backup` carries the bounded verdict only when the snapshot is valid. Stale or unavailable observations cannot manufacture a current backup degradation. Environment names and precedence are unchanged; only the shipped resolver fallbacks move from 5 attempts / 5 seconds to 10 attempts / 15 seconds.

## Test Evidence

- At `3339c09609`: 177/177 focused tests passed across backup scheduling, deployment-state bridge, Memory Core health composition/schema, OpenAPI compliance, Knowledge Base config, and Chroma resolver.
- At `1235bd3d69`: `npm run test-unit -- test/playwright/unit/ai/deploy/ParityPlaneVolumeScoping.spec.mjs` passed 21/21. Its mutation-sensitive guard requires every parity served-identity probe to accept the same `healthy,degraded` liveness contract as Compose while retaining plane-id and data-root checks.
- All three parity repair files passed `node --check`; `git diff --check` passed on the current head.
- Pre-commit gates passed: whitespace, shorthand, AiConfig mutation, JSDoc types, derived-domain, ticket archaeology, block alignment, and parse.

## Contract Ledger

- Additive Memory Core `healthcheck` output: `maintenance.observationStatus` plus nullable `maintenance.backup`; no input, tool-count, or configuration-source change.
- `maintenance.backup.status: degraded` degrades the composed healthcheck unless the base verdict is already `unhealthy`; stale/unavailable bridge state reports no backup verdict and cannot degrade.

## Post-Merge Validation

Residual-Owner: neomjs/neo-agent-brain#54

- [ ] On the external plane, restart Chroma during a backup, prove the same attempt reaches a successful receipt after the dependency returns, and verify `maintenance.health` plus `nextAttemptAtMs` converge without operator re-arming.

## Commits

- `a8d5115dc6` — restore the bounded dependency-recovery horizon and expose scheduler fallback state.
- `3339c09609` — project current backup risk into the consumed Memory Core health contract.
- `1235bd3d69` — align parity served-identity probes with the consumed degraded-health contract.

## Evolution

The live-state replay separated the short inner Chroma resolver from the already-bounded outer backup retry. Preserving the existing periodic scheduler and deriving observability from its persisted state avoids solving a disproven terminal-lane premise with new machinery.

Authored by Euclid (GPT-5.6 Sol Ultra, Codex). Session 019ffcf3-1a96-7020-b1fc-e1673092fcca.
