### PR TITLE
fix(ai): leave embedding slot headroom for interactive work (#17048)

### DIFF
--- a/ai/services/memory-core/TextEmbeddingService.mjs
+++ b/ai/services/memory-core/TextEmbeddingService.mjs
@@ -1585,7 +1585,8 @@ class TextEmbeddingService extends Base {
      * Local OpenAI-compatible embedding servers often serialize model requests. Sending the whole
      * KB-sync batch as one provider call can monopolize that server for minutes. Chunking keeps
      * batch ingestion moving while yielding between chunks so interactive single embeddings can
-     * enter the provider queue before the next batch chunk.
+     * enter the provider queue before the next batch chunk. Multi-slot lanes additionally reserve
+     * one declared slot from each batch request so another provider request remains admissible.
      *
      * @param {String[]} texts The texts to embed.
      * @param {Object} options Abort and observability context.
@@ -1608,10 +1609,18 @@ class TextEmbeddingService extends Base {
             batchEmbeddingTimeoutMs = DEFAULT_OPENAI_COMPATIBLE_REQUEST_TIMEOUT_MS,
             batchEmbeddingYieldMs   = 0
         } = aiConfig.openAiCompatible;
-        const chunkSize        = Math.max(1, Math.floor(batchEmbeddingChunkSize || texts.length)),
-              requestTimeoutMs = assertPositiveTimeoutMs(batchEmbeddingTimeoutMs, 'openAiCompatible.batchEmbeddingTimeoutMs'),
-              totalChunkCount  = Math.ceil(texts.length / chunkSize),
-              data             = [];
+        const configuredChunkSize = Math.max(1, Math.floor(batchEmbeddingChunkSize || texts.length)),
+              embeddingParallel   = aiConfig.localModels.embedding.parallel,
+              // llama.cpp expands a multi-input embedding POST into one task per input. Keeping one
+              // declared slot outside this request makes interleaving possible without inventing a
+              // second slot-count authority or collapsing single-slot / generic remote endpoints.
+              slotHeadroomWidth = Number.isInteger(embeddingParallel) && embeddingParallel > 1 ?
+                  embeddingParallel - 1 :
+                  configuredChunkSize,
+              chunkSize          = Math.min(configuredChunkSize, slotHeadroomWidth),
+              requestTimeoutMs   = assertPositiveTimeoutMs(batchEmbeddingTimeoutMs, 'openAiCompatible.batchEmbeddingTimeoutMs'),
+              totalChunkCount    = Math.ceil(texts.length / chunkSize),
+              data               = [];
 
         let completedChunkCount = 0;
 

--- a/test/playwright/unit/ai/services/memory-core/TextEmbeddingService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/TextEmbeddingService.spec.mjs
@@ -1447,6 +1447,71 @@ test.describe.serial('TextEmbeddingService #15694 — provider-neutral cancellat
         });
     });
 
+    test('OpenAI-compatible batches reserve one declared engine slot without mutating shared config (#17048)', async () => {
+        const probe = async () => {
+            const http          = await import('node:http');
+            const requestInputs = [];
+            const server        = http.createServer((request, response) => {
+                let body = '';
+
+                request.on('data', chunk => body += chunk);
+                request.on('end', () => {
+                    const payload = JSON.parse(body),
+                          inputs  = Array.isArray(payload.input) ? payload.input : [payload.input];
+
+                    requestInputs.push(inputs);
+                    response.writeHead(200, {'Content-Type': 'application/json'});
+                    response.end(JSON.stringify({
+                        data: inputs.map((input, index) => ({
+                            index,
+                            embedding: [requestInputs.length, index]
+                        }))
+                    }));
+                });
+            });
+            await new Promise(resolve => server.listen(0, '127.0.0.1', resolve));
+
+            try {
+                process.env.NEO_OPENAI_COMPATIBLE_HOST = `http://127.0.0.1:${server.address().port}`;
+
+                const {default: Service} = await import('./ai/services/memory-core/TextEmbeddingService.mjs');
+                const embeddings         = await Service.embedTexts(
+                    ['a', 'b', 'c', 'd', 'e'],
+                    'openAiCompatible'
+                );
+
+                console.log(JSON.stringify({requestInputs, embeddings}));
+            } finally {
+                server.closeAllConnections?.();
+                await new Promise(resolve => server.close(resolve));
+            }
+        };
+        const commonEnv = {
+            NEO_OPENAI_COMPATIBLE_BATCH_EMBEDDING_CHUNK_SIZE: '5',
+            NEO_OPENAI_COMPATIBLE_UNLOAD_RETRY_COUNT        : '0'
+        };
+        const [multiSlot, singleSlot] = await Promise.all([
+            runIsolatedEmbeddingProbe(probe, {
+                ...commonEnv,
+                NEO_LOCAL_MODELS_EMBEDDING_PARALLEL: '4'
+            }),
+            runIsolatedEmbeddingProbe(probe, {
+                ...commonEnv,
+                NEO_LOCAL_MODELS_EMBEDDING_PARALLEL: '1'
+            })
+        ]);
+
+        expect(multiSlot.requestInputs).toEqual([
+            ['a', 'b', 'c'],
+            ['d', 'e']
+        ]);
+        expect(singleSlot.requestInputs).toEqual([
+            ['a', 'b', 'c', 'd', 'e']
+        ]);
+        expect(multiSlot.embeddings).toHaveLength(5);
+        expect(singleSlot.embeddings).toHaveLength(5);
+    });
+
     test('OpenAI-compatible retry and batch delays stop before later work in an isolated config process', async () => {
         const evidence = await runIsolatedEmbeddingProbe(async () => {
             const http                = await import('node:http');


### PR DESCRIPTION
Resolves neomjs/neo#17048

Related: neomjs/neo-agent-brain#38

Keeps one declared llama.cpp embedding slot admissible while tenant batch ingestion is active. For a multi-slot OpenAI-compatible lane, each provider request is now bounded to `min(configuredChunkSize, parallel - 1)` inputs; single-slot and generic remote endpoints preserve the existing configured width.

Evidence: L2 (fresh-process provider fixtures prove a four-slot lane emits widths `3 + 2`, while a one-slot lane preserves width `5`) → L2 required. Residual: live provider interleaving and corpus-progress witness, Residual-Owner: neomjs/neo-agent-brain#38.

## Deltas from ticket

Intake falsified most of the original mechanism. OpenAI-compatible batch chunking, caller-class deadlines, and interactive-before-next-chunk scheduling already ship; the incident evidence also did not prove one shared Neo queue across the KB server, MC server, and orchestrator. The ticket was narrowed publicly before implementation to the one surviving source-backed invariant: because pinned llama.cpp expands one multi-input embedding POST into one task per input, a declared `P > 1` lane must cap a batch request at `P - 1` inputs to leave one slot admissible to another request.

This does not alter the provider's context geometry. The canonical four-slot lane remains `131072 / 4 = 32768` context per slot, above Neo's 28,672-token safe band.

## Test Evidence

- `NEO_TEST_SKIP_CI=true npm run test-unit -- test/playwright/unit/ai/services/memory-core/TextEmbeddingService.spec.mjs` — 42/42 passed.
- `NEO_TEST_SKIP_CI=true npm run test-unit -- test/playwright/unit/ai/services/memory-core/TextEmbeddingService.retry.spec.mjs` — 38/38 passed before the config-sensitive assertions were moved into isolated processes; production code is unchanged since that run.
- Complete unit suite on the same production diff: 13,224 passed, 11 skipped, with only the unrelated existing Neural Link health fixture failure in `McpServersHealth.spec.mjs`.
- `git diff --check` — passed.
- `npm run agent-preflight -- --change-class restoration ...` — passed.

## Post-Merge Validation

Residual-Owner: neomjs/neo-agent-brain#38

- [ ] On a deployed four-slot provider lane, run tenant ingestion alongside an interactive embedding and prove the tenant request width never exceeds three, the interactive request becomes admissible, and the corpus checkpoint advances without a provider restart.

## Evolution

The implementation reuses the resolved `localModels.embedding.parallel` leaf as the only slot-count authority and changes two files. An initial shared-singleton test was rejected before commit under ADR-0019; the final coverage constructs each config arm in a fresh process instead.

Authored by Euclid (GPT-5.6 Sol Ultra, Codex). Session 019ffcf3-1a96-7020-b1fc-e1673092fcca.
