### PR TITLE
fix(ai): bound interactive overtakes of queued embedding batches (#17062)

### DIFF
--- a/ai/services/memory-core/TextEmbeddingService.mjs
+++ b/ai/services/memory-core/TextEmbeddingService.mjs
@@ -619,13 +619,14 @@ class TextEmbeddingService extends Base {
 
         return new Promise((resolve, reject) => {
             const task = {
-                dispatched: false,
+                dispatched            : false,
                 inputData,
+                interactiveBypassCount: 0,
                 options,
                 priority,
                 lifecycle,
                 enqueuedAt,
-                settled   : false
+                settled               : false
             };
 
             const cleanup = () => {
@@ -712,23 +713,43 @@ class TextEmbeddingService extends Base {
     }
 
     /**
-     * @summary Selects the next OpenAI-compatible queue item, FIFO within each priority lane.
+     * @summary Selects the next OpenAI-compatible queue item without starving either priority lane.
+     *
+     * One interactive item may overtake an already-waiting batch item. If both lanes remain queued,
+     * the next selection admits the oldest batch before another interactive item can overtake it.
+     * The counter advances on selections rather than elapsed time, keeping the fairness guarantee
+     * deterministic and local to the queue that owns admission.
+     *
      * @returns {Number}
      * @private
      */
     #getNextOpenAiCompatiblePostQueueIndex() {
-        let bestIndex = 0;
+        let firstBatchIndex       = -1,
+            firstInteractiveIndex = -1;
 
-        for (let i = 1; i < this.#openAiCompatiblePostQueue.length; i++) {
-            const best = this.#openAiCompatiblePostQueue[bestIndex],
-                  item = this.#openAiCompatiblePostQueue[i];
+        for (let index = 0; index < this.#openAiCompatiblePostQueue.length; index++) {
+            const item = this.#openAiCompatiblePostQueue[index];
 
-            if (best.priority === 'batch' && item.priority === 'interactive') {
-                bestIndex = i;
+            if (item.priority === 'batch' && firstBatchIndex === -1) {
+                firstBatchIndex = index;
+            } else if (item.priority === 'interactive' && firstInteractiveIndex === -1) {
+                firstInteractiveIndex = index;
             }
         }
 
-        return bestIndex;
+        if (firstBatchIndex === -1 || firstInteractiveIndex === -1) {
+            return firstInteractiveIndex === -1 ? firstBatchIndex : firstInteractiveIndex;
+        }
+
+        const oldestBatch = this.#openAiCompatiblePostQueue[firstBatchIndex];
+
+        if (oldestBatch.interactiveBypassCount > 0) {
+            return firstBatchIndex;
+        }
+
+        oldestBatch.interactiveBypassCount++;
+
+        return firstInteractiveIndex;
     }
 
     /**

--- a/test/playwright/unit/ai/services/memory-core/TextEmbeddingService.retry.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/TextEmbeddingService.retry.spec.mjs
@@ -997,4 +997,61 @@ test.describe.serial('TextEmbeddingService #11393/#11402/#12487/#12509 — openA
             [4, 0]
         ]);
     });
+
+    test('a waiting batch is admitted after one overtake with an interactive backlog (#17062)', async () => {
+        serverBehavior = 'qos-priority';
+
+        const enqueuedStages = [];
+        let   activityId     = 0;
+        const recorder       = {
+            beginProviderActivity(entry) {
+                enqueuedStages.push(entry.operationStage);
+                return `activity-${++activityId}`;
+            },
+            startProviderActivity() {},
+            refineProviderActivity() {},
+            completeProviderActivity() {}
+        };
+        const blockerPromise = TextEmbeddingService.embedTexts(['a'], 'openAiCompatible', {
+            operationStage          : 'blocker-batch',
+            providerActivityRecorder: recorder,
+            service                 : 'knowledge-base'
+        });
+
+        await waitForCondition(() => allRequests.length === 1, 'active blocker request');
+
+        const waitingBatchPromise = TextEmbeddingService.embedTexts(['waiting-batch'], 'openAiCompatible', {
+            operationStage          : 'waiting-batch',
+            providerActivityRecorder: recorder,
+            service                 : 'knowledge-base'
+        });
+
+        await waitForCondition(() => enqueuedStages.includes('waiting-batch'), 'waiting batch queue admission');
+
+        const firstInteractivePromise = TextEmbeddingService.embedText('interactive-1', 'openAiCompatible', {
+            operationStage          : 'interactive-1',
+            providerActivityRecorder: recorder,
+            service                 : 'knowledge-base'
+        });
+        const secondInteractivePromise = TextEmbeddingService.embedText('interactive-2', 'openAiCompatible', {
+            operationStage          : 'interactive-2',
+            providerActivityRecorder: recorder,
+            service                 : 'knowledge-base'
+        });
+
+        await Promise.all([
+            blockerPromise,
+            waitingBatchPromise,
+            firstInteractivePromise,
+            secondInteractivePromise
+        ]);
+
+        expect(maxInFlightRequests).toBe(1);
+        expect(allRequests.map(item => item.body.input)).toEqual([
+            ['a'],
+            'interactive-1',
+            ['waiting-batch'],
+            'interactive-2'
+        ]);
+    });
 });


### PR DESCRIPTION
Resolves neomjs/neo#17062

Related: neomjs/neo-agent-brain#38
Related: neomjs/neo#17048

Makes the existing process-local OpenAI-compatible scheduler starvation-free without changing its interactive-first contract. The oldest queued batch may be bypassed by one interactive selection; if both lanes remain queued, that same batch wins the next selection. FIFO within each lane remains intact, and aging state lives on the ephemeral batch task so aborting it cannot bias a successor.

Evidence: L2 (a real local HTTP fixture holds one provider request, queues a batch plus two interactive requests, and proves `blocker → interactive-1 → batch → interactive-2`) → L2 required. Residual: live workload observation after deployment, Residual-Owner: neomjs/neo-agent-brain#38.

## Deltas from ticket

Intake falsified the ticket's incident mechanism and narrowed the implementation publicly before code. `providerActivityLedger` is observer-only, and the KB server, MC server, and tenant-ingestion orchestrator each own separate process-local queues. Local queue wait is not charged to the provider request timeout, embedding-only incomplete sweeps already hold their failure streak, and provider-recovery generation already bypasses cadence/backoff.

This PR therefore does not add cross-process canary coordination, reason codes, backoff machinery, wall-clock aging, configuration, or durable state. It fixes the one source-proven defect that survives: inside a single `TextEmbeddingService`, the selector had no bound on interactive overtakes of a waiting batch.

## Test Evidence

- `NEO_TEST_SKIP_CI=true npm run test-unit -- test/playwright/unit/ai/services/memory-core/TextEmbeddingService.retry.spec.mjs` — 37/37 passed.
- The new fixture is mutation-sensitive: the old selector emits `blocker → interactive-1 → interactive-2 → batch`; a zero-bypass policy fails the existing interactive-first regression.
- `git diff --check` — passed.
- `npm run agent-preflight -- --change-class restoration ...` — passed.

## Post-Merge Validation

Residual-Owner: neomjs/neo-agent-brain#38

- [ ] On a deployed lane with concurrent interactive and batch work, verify a waiting batch is never bypassed by more than one subsequent interactive selection within the same service process.

## Evolution

The live ledger originally led the ticket across process boundaries that do not share scheduling authority. Returning to the queue owner reduced the solution to one per-task counter and one selector test; the PR makes no claim that this fairness defect caused the provider restart incident.

Authored by Euclid (GPT-5.6 Sol Ultra, Codex). Session 019ffcf3-1a96-7020-b1fc-e1673092fcca.
