### PR TITLE
refactor(ai): consolidate the duplicated row-timestamp guard (closes #17087)

### DIFF
--- a/ai/services/memory-core/SummaryService.mjs
+++ b/ai/services/memory-core/SummaryService.mjs
@@ -1,5 +1,6 @@
 import aiConfig                                                 from '../../mcp/server/memory-core/config.mjs';
 import {isCollectionQuarantined}                                from './helpers/quarantineStore.mjs';
+import {resolveRowTimestamp}                                    from './helpers/resolveRowTimestamp.mjs';
 import {resolveSharingPolicy}                                   from './helpers/resolveSharingPolicy.mjs';
 import Base                                                     from '../../../src/core/Base.mjs';
 import StorageRouter                                            from './managers/StorageRouter.mjs';
@@ -131,35 +132,6 @@ class SummaryService extends Base {
     }
 
     /**
-     * @summary Projects a summary row's stored `timestamp` without letting one bad row fail the call.
-     *
-     * `Date#toISOString()` raises `RangeError: Invalid time value` on an Invalid Date, and both result
-     * projections call it once per row *inside* the result map — where the surrounding method-level
-     * `catch` escalated a single row's defect into a whole-call `SUMMARY_QUERY_ERROR`, discarding every
-     * well-formed co-resident row. The query path reaches far more rows than its `nResults` suggests
-     * (`StorageRouter.injectQueryReRanker` widens Pass 1 to `nResults * 3`, and `querySummaries` widens
-     * again for additive-policy reads), so a single unparseable row took the whole surface down.
-     *
-     * The row is preserved with a `null` timestamp and counted by the caller, never dropped: a silent
-     * skip would convert a visible outage into invisible under-retrieval, which is strictly harder to
-     * detect than the failure it replaces. Absent and unparseable collapse to the same outcome
-     * deliberately; neither is projectable, and distinguishing them would imply a guarantee the stored
-     * metadata cannot make.
-     *
-     * Note the asymmetry with `null`: `new Date(null)` is epoch 0, not an Invalid Date, so a
-     * null-valued timestamp projects as 1970 rather than being counted here. That is pre-existing
-     * behavior, preserved deliberately — narrowing it would change output for already-stored rows.
-     *
-     * @param {Object} metadata Chroma summary metadata row.
-     * @returns {String|null} ISO-8601 timestamp, or `null` when the stored value is absent/unparseable.
-     */
-    static resolveSummaryTimestamp(metadata) {
-        const parsed = new Date(metadata?.timestamp);
-
-        return Number.isNaN(parsed.getTime()) ? null : parsed.toISOString();
-    }
-
-    /**
      * @returns {Promise<void>}
      */
     async initAsync() {
@@ -228,7 +200,7 @@ class SummaryService extends Base {
      * @returns {Promise<{count: Number, total: Number, summaries: Object[], malformedTimestamps: (Number|undefined)}>}
      *   A row whose stored `timestamp` is absent or unparseable is returned with `timestamp: null` and
      *   counted in `malformedTimestamps` rather than failing the call — see
-     *   {@link SummaryService.resolveSummaryTimestamp}. `malformedTimestamps` is omitted when zero.
+     *   {@link module:ai/services/memory-core/helpers/resolveRowTimestamp~resolveRowTimestamp}. `malformedTimestamps` is omitted when zero.
      */
     async listSummaries({limit=50, offset=0, agentIdentity, category} = {}) {
         // Resolve the optional author-identity scope BEFORE the storage try/catch: a fail-closed
@@ -358,7 +330,7 @@ class SummaryService extends Base {
                 const metadata   = data.metadata;
                 const document   = data.document;
                 const techSource = metadata.technologies || '';
-                const timestamp  = this.constructor.resolveSummaryTimestamp(metadata);
+                const timestamp  = resolveRowTimestamp(metadata);
 
                 if (timestamp === null) {
                     malformedTimestamps++;
@@ -414,7 +386,7 @@ class SummaryService extends Base {
      * @returns {Promise<{query: String, count: Number, results: Object[], malformedTimestamps: (Number|undefined)}>}
      *   A row whose stored `timestamp` is absent or unparseable is returned with `timestamp: null` and
      *   counted in `malformedTimestamps` rather than failing the call — see
-     *   {@link SummaryService.resolveSummaryTimestamp}. `malformedTimestamps` is omitted when zero.
+     *   {@link module:ai/services/memory-core/helpers/resolveRowTimestamp~resolveRowTimestamp}. `malformedTimestamps` is omitted when zero.
      */
     async querySummaries({query, nResults, category, memorySharing, minTrustTier}) {
         try {
@@ -524,7 +496,7 @@ class SummaryService extends Base {
                 const distance       = Number(distances[index] ?? 0);
                 const relevanceScore = Number((1 / (1 + distance)).toFixed(6));
                 const techSource     = metadata.technologies || '';
-                const timestamp      = this.constructor.resolveSummaryTimestamp(metadata);
+                const timestamp      = resolveRowTimestamp(metadata);
 
                 if (timestamp === null) {
                     malformedTimestamps++;

--- a/ai/services/memory-core/helpers/resolveRowTimestamp.mjs
+++ b/ai/services/memory-core/helpers/resolveRowTimestamp.mjs
@@ -5,7 +5,8 @@
  * `Date#toISOString()` raises `RangeError: Invalid time value` on an Invalid Date. Every Memory Core
  * result projection calls it once per row *inside* a result map, where the surrounding method-level
  * `catch` escalates a single row's defect into a whole-call error and discards every well-formed
- * co-resident row. A per-record data condition becomes a per-call outage.
+ * co-resident row. A per-record data condition becomes a per-call outage — on the summaries
+ * surface that surfaced as a whole-call `SUMMARY_QUERY_ERROR`.
  *
  * The exposure is not uniform across read paths. An id-scoped list projects a bounded, caller-named
  * slice, while a semantic query is width-amplified — `StorageRouter.injectQueryReRanker` widens Pass 1

--- a/test/playwright/unit/ai/services/memory-core/SummaryService.TimestampGuard.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/SummaryService.TimestampGuard.spec.mjs
@@ -18,6 +18,7 @@ import Neo            from '../../../../../../src/Neo.mjs';
 import * as core      from '../../../../../../src/core/_export.mjs';
 import SummaryService from '../../../../../../ai/services/memory-core/SummaryService.mjs';
 import StorageRouter  from '../../../../../../ai/services/memory-core/managers/StorageRouter.mjs';
+import {resolveRowTimestamp} from '../../../../../../ai/services/memory-core/helpers/resolveRowTimestamp.mjs';
 
 /**
  * Summary-row timestamp projection guard.
@@ -184,9 +185,10 @@ test.describe('Neo.ai.services.memory-core.SummaryService — timestamp projecti
         expect(listed.count).toBe(2);
     });
 
-    test('resolveSummaryTimestamp projects, nulls, and keeps null-coercion parity (unit-level)', () => {
-        // The default export is the singleton instance → the static helper lives on .constructor.
-        const resolve = metadata => SummaryService.constructor.resolveSummaryTimestamp(metadata);
+    test('resolveRowTimestamp projects, nulls, and keeps null-coercion parity (unit-level)', () => {
+        // Both projections in SummaryService call the shared helper, so the unit-level arm
+        // targets it directly rather than a service-local copy.
+        const resolve = metadata => resolveRowTimestamp(metadata);
 
         expect(resolve({timestamp: 1700000000000})).toBe(new Date(1700000000000).toISOString());
         expect(resolve({timestamp: '2026-08-13T22:00:00.000Z'})).toBe('2026-08-13T22:00:00.000Z');


### PR DESCRIPTION
Closes neomjs/neo#17087.

`dev` carried the same guard twice — the shared `helpers/resolveRowTimestamp.mjs` module, and `SummaryService`'s byte-equivalent `static resolveSummaryTimestamp`. Consolidated onto the shared module.

## Changes

1. `SummaryService.mjs` imports `resolveRowTimestamp` and calls it at both projection sites (`:361`, `:527`).
2. The `static` and its JSDoc block are deleted; both `@returns` `{@link}` references now point at the shared helper.
3. The spec's unit-level arm targets the shared helper. Its assertions are unchanged.

Direction is toward the shared module, per the avoided trap: `MemoryService` and `conceptWalkMemoryGate` already consume it, so collapsing the other way would have created importers of a service singleton's static.

## On the "delete one copy without moving the JSDoc" trap

I compared the two JSDoc blocks line by line. The shared module's prose **already** carried both load-bearing contracts — absent-vs-unparseable collapsing to one `null`, and `new Date(null)` being epoch 0 so a null-valued timestamp projects as 1970 rather than counting as unprojectable.

The only detail unique to the deleted copy was the *concrete* escalation it produced. So rather than dropping it, I folded one clause into the shared JSDoc:

> A per-record data condition becomes a per-call outage — **on the summaries surface that surfaced as a whole-call `SUMMARY_QUERY_ERROR`.**

That keeps the named failure mode discoverable from the surviving helper, which is the part that stops the next person "fixing" the 1970 behaviour.

## Behaviour is unchanged — measured, not asserted

I ran the deleted static's **exact body** side by side with the shared helper across the spec's own `UNPROJECTABLE_TIMESTAMPS` fixture set plus the epoch-0 parity cases:

```
OK   {"timestamp":1700000000000}       -> 2023-11-14T22:13:20.000Z | 2023-11-14T22:13:20.000Z
OK   {"timestamp":"not-a-date"}        -> null                     | null
OK   {"timestamp":null}                -> 1970-01-01T00:00:00.000Z | 1970-01-01T00:00:00.000Z
OK   {"timestamp":0}                   -> 1970-01-01T00:00:00.000Z | 1970-01-01T00:00:00.000Z
...
IDENTICAL on all 12 cases
```

Compared with `Object.is`, so `null` vs `undefined` would have shown as a difference.

## Acceptance criteria

- [x] `SummaryService` has no local timestamp-resolution method; both projections call the shared helper (`grep -c "resolveRowTimestamp(metadata)"` → 2)
- [x] `grep -rn "resolveSummaryTimestamp" ai/ test/` → **0 hits**
- [x] Only the direct-helper-reference arm of the spec was retargeted; no behavioural assertion changed
- [x] The null → epoch-0 parity and absent-vs-unparseable contract remain documented on the surviving helper

## What I could not run

**The two TimestampGuard specs did not execute here.** They live in the `unit-brain*` projects, which Playwright skips unless the Brain tier is installed:

```
[playwright.config.unit] Brain-tier set not installed (see package.brain.json) — skipping chroma-setup + unit-brain* projects.
Error: No tests found.
```

`npm run install-brain` needs `better-sqlite3` (native build; no MSVC toolchain on this machine) and `chromadb`, so I couldn't arm it. **CI has to confirm those two specs** — flagging it rather than implying green.

What I did verify locally: `npm install` + `npm run bundle-parse5` (needed before the unit config resolves at all), `node --check` on all three touched files, the equivalence run above, and the full `lint-staged` pre-commit gate — which, usefully, caught a ticket reference I'd left in a durable comment and which I've rewritten as behaviour prose.

🤖 Generated with [Claude Code](https://claude.com/claude-code)