### PR TITLE
feat(fleet): signed wake receiver + SSE fan-out on the composed fleet server (#17100)

### DIFF
--- a/ai/configBase.mjs
+++ b/ai/configBase.mjs
@@ -314,6 +314,16 @@ class ConfigBase extends ConfigProvider {
                  */
                 planeInternalHosts: leaf([], 'NEO_FLEET_PLANE_INTERNAL_HOSTS', 'csv'),
                 /**
+                 * Absolute path of a file holding the plane bearer — the secret-file
+                 * indirection for containerized profiles, where the canonical composition
+                 * already mounts its admission token as a compose secret and env literals are
+                 * the wrong custody class for credentials. `planeBearer` (the direct value)
+                 * wins when both are set; empty means no file indirection. Read at the use
+                 * site by the Fleet entry, never at import.
+                 * @type {string}
+                 */
+                planeBearerFile: leaf('', 'NEO_FLEET_PLANE_BEARER_FILE', 'string'),
+                /**
                  * Bearer credential for the app<->fleet TRANSPORT — a different credential from
                  * `planeBearer`, which authenticates to the containerized plane. Secret-class, so
                  * the default is empty and never carries a value: `resolveFleetBearer` generates

--- a/ai/configBase.mjs
+++ b/ai/configBase.mjs
@@ -363,6 +363,19 @@ class ConfigBase extends ConfigProvider {
                  */
                 wakeReceiverManifestPath: leaf('', 'NEO_WAKE_RECEIVER_MANIFEST', 'string'),
                 /**
+                 * Externally-dialable base URL of THIS fleet server's own signed wake receiver —
+                 * the address the plane's Shape-B dispatcher (`WebhookDeliveryService`) POSTs
+                 * digests to (`<base>/wake` is derived at the use site). In the composed profile
+                 * this is the service-DNS origin (e.g. `http://fleet-server:8083`), reachable from
+                 * the Memory Core container by construction. EMPTY means the deployment declares
+                 * no dialable self-address: relay wake subscriptions are then NOT armed and the
+                 * SSE push lane renders its absence with that reason — never a guessed default,
+                 * because a wrong self-address turns every wake into a signed POST at a stranger.
+                 * Not a plane member — deployment-edge consumer config, exactly like `planeBase`.
+                 * @type {string}
+                 */
+                wakeSelfBase: leaf('', 'NEO_FLEET_WAKE_SELF_BASE', 'string'),
+                /**
                  * Patience for ONE tenant-plane probe request (initialize, the initialized
                  * notification, the identity proof) — a single declared bound replacing per-site
                  * literals, env-relocatable. Calibrated from MEASURED plane latency, both modes:

--- a/ai/configBase.mjs
+++ b/ai/configBase.mjs
@@ -304,6 +304,16 @@ class ConfigBase extends ConfigProvider {
                  */
                 planeBearer    : leaf('', 'NEO_FLEET_PLANE_BEARER', 'string'),
                 /**
+                 * Exact hostnames this deployment vouches for as confidential internal hops for
+                 * plain-HTTP MC dialing (compose-network service DNS, e.g. `ingress`). Forwarded
+                 * to the shared secure-endpoint policy, whose loopback-or-TLS rule stays
+                 * unchanged when this is empty — an unnamed internal host remains refused, and
+                 * the credential requirement is untouched on every path. CSV-typed like
+                 * `cockpitOrigins`.
+                 * @type {string[]}
+                 */
+                planeInternalHosts: leaf([], 'NEO_FLEET_PLANE_INTERNAL_HOSTS', 'csv'),
+                /**
                  * Bearer credential for the app<->fleet TRANSPORT — a different credential from
                  * `planeBearer`, which authenticates to the containerized plane. Secret-class, so
                  * the default is empty and never carries a value: `resolveFleetBearer` generates

--- a/ai/configBase.mjs
+++ b/ai/configBase.mjs
@@ -324,6 +324,17 @@ class ConfigBase extends ConfigProvider {
                  */
                 planeBearerFile: leaf('', 'NEO_FLEET_PLANE_BEARER_FILE', 'string'),
                 /**
+                 * Absolute path of the deployment's bootstrap/healthcheck admission token file
+                 * — bound to the SAME env name the MCP services already boot on (the
+                 * `wakeReceiverManifestPath` same-env-name precedent), so the Fleet entry can
+                 * enforce the credential-class non-alias rule with teeth: the plane bearer
+                 * (class 3) must never BE the admission/bootstrap token, and a deployment that
+                 * aliases them refuses to boot. Read-only comparison target; empty disables
+                 * the check, never the rule.
+                 * @type {string}
+                 */
+                admissionTokenFile: leaf('', 'NEO_MCP_HEALTHCHECK_TOKEN_FILE', 'string'),
+                /**
                  * Bearer credential for the app<->fleet TRANSPORT — a different credential from
                  * `planeBearer`, which authenticates to the containerized plane. Secret-class, so
                  * the default is empty and never carries a value: `resolveFleetBearer` generates

--- a/ai/deploy/Caddyfile
+++ b/ai/deploy/Caddyfile
@@ -54,10 +54,16 @@
 			reverse_proxy mc-server:3001
 		}
 
-		# 5. Fleet preserves the public URI exactly: the upstream owns `/fleet` and
-		#    `/fleet/probe`, so `handle_path` (prefix stripping) is forbidden here.
-		@fleet path /fleet /fleet/probe
-		reverse_proxy @fleet fleet-server:8083
+		# 5. Fleet preserves the public URI exactly: the upstream owns `/fleet`,
+		#    `/fleet/probe`, and the `/fleet/events` SSE stream (Caddy proxies SSE natively;
+		#    flush_interval -1 disables response buffering so events reach the client as they
+		#    are written), so `handle_path` (prefix stripping) is forbidden here. The signed
+		#    wake receiver `/wake` is deliberately ABSENT: it is compose-internal only —
+		#    reachability is never authentication.
+		@fleet path /fleet /fleet/probe /fleet/events
+		reverse_proxy @fleet fleet-server:8083 {
+			flush_interval -1
+		}
 
 		# A headless profile has no Fleet service and every unrelated path is absent.
 		respond 404

--- a/ai/deploy/Caddyfile
+++ b/ai/deploy/Caddyfile
@@ -72,7 +72,7 @@
 	# Fleet is optional and ingress deliberately has no hard dependency on it. Convert only an
 	# absent Fleet upstream to the cockpit's disconnected 404; preserve KB/MC 502 diagnostics.
 	handle_errors 502 {
-		@fleet path /fleet /fleet/probe
+		@fleet path /fleet /fleet/probe /fleet/events
 		respond @fleet 404
 	}
 }

--- a/ai/deploy/Caddyfile.local-agent-os
+++ b/ai/deploy/Caddyfile.local-agent-os
@@ -11,14 +11,16 @@
 			reverse_proxy kb-server:3000
 		}
 
-		@fleet path /fleet /fleet/probe
-		reverse_proxy @fleet fleet-server:8083
+		@fleet path /fleet /fleet/probe /fleet/events
+		reverse_proxy @fleet fleet-server:8083 {
+			flush_interval -1
+		}
 
 		respond 404
 	}
 
 	handle_errors 502 {
-		@fleet path /fleet /fleet/probe
+		@fleet path /fleet /fleet/probe /fleet/events
 		respond @fleet 404
 	}
 }

--- a/ai/deploy/docker-compose.local-agent-os.yml
+++ b/ai/deploy/docker-compose.local-agent-os.yml
@@ -93,14 +93,16 @@ services:
       # compose time — absent, the push lane boots honestly unarmed and says so.
       NEO_FLEET_PLANE_BASE: http://ingress:8080
       NEO_FLEET_PLANE_INTERNAL_HOSTS: ingress
-      # The service credential rides the SAME mounted secret the profile's admission already
-      # uses — a real, identity-bound bearer in the canonical render, with secret-file custody
-      # (never an env literal). The direct-value override stays available for non-compose runs.
-      NEO_FLEET_PLANE_BEARER_FILE: /run/secrets/mcp-auth-token
+      # The service credential is a DEDICATED class-3 mint with secret-file custody — never the
+      # bootstrap/healthcheck admission token (the credential-class ledger forbids that
+      # aliasing, and the server enforces it at boot: an aliased token refuses to start). The
+      # direct-value override stays available for non-compose runs.
+      NEO_FLEET_PLANE_BEARER_FILE: /run/secrets/fleet-plane-token
       NEO_FLEET_PLANE_BEARER: ${NEO_FLEET_PLANE_BEARER:-}
       NEO_AGENT_IDENTITY: ${NEO_AGENT_IDENTITY:-}
     secrets:
       - mcp-auth-token
+      - fleet-plane-token
 
   ingress:
     restart: unless-stopped
@@ -137,3 +139,11 @@ secrets:
   # moment someone can act, rather than a silent fallback that restores the single-seat dependency.
   mcp-auth-token: !override
     file: ${NEO_MCP_AUTH_TOKEN_FILE:-${HOME}/.neo-ai/secrets/mcp-auth-token}
+  # The Fleet service's OWN class-3 plane credential — a DISTINCT mint from the admission
+  # token above, because the credential-class ledger forbids one secret serving both classes
+  # (and the fleet server refuses to boot on an aliased value). Same custody shape and the
+  # same loud-at-start philosophy: the wake push lane is declared by this profile, so its
+  # credential is required by it — mint once: a forge PAT for the fleet service's MC sessions,
+  # written to the path below.
+  fleet-plane-token:
+    file: ${NEO_FLEET_PLANE_TOKEN_FILE:-${HOME}/.neo-ai/secrets/fleet-plane-token}

--- a/ai/deploy/docker-compose.local-agent-os.yml
+++ b/ai/deploy/docker-compose.local-agent-os.yml
@@ -93,6 +93,10 @@ services:
       # compose time — absent, the push lane boots honestly unarmed and says so.
       NEO_FLEET_PLANE_BASE: http://ingress:8080
       NEO_FLEET_PLANE_INTERNAL_HOSTS: ingress
+      # The service credential rides the SAME mounted secret the profile's admission already
+      # uses — a real, identity-bound bearer in the canonical render, with secret-file custody
+      # (never an env literal). The direct-value override stays available for non-compose runs.
+      NEO_FLEET_PLANE_BEARER_FILE: /run/secrets/mcp-auth-token
       NEO_FLEET_PLANE_BEARER: ${NEO_FLEET_PLANE_BEARER:-}
       NEO_AGENT_IDENTITY: ${NEO_AGENT_IDENTITY:-}
     secrets:

--- a/ai/deploy/docker-compose.local-agent-os.yml
+++ b/ai/deploy/docker-compose.local-agent-os.yml
@@ -81,6 +81,11 @@ services:
       <<: *local-auth
       # Local ingress is loopback HTTP; Host validation still admits its 127.0.0.1/localhost forms.
       NEO_PUBLIC_URL: http://127.0.0.1:3102/fleet
+      # The dialable self-address of this service's signed wake receiver (`<base>/wake`) —
+      # service DNS, reachable from the Memory Core container by construction, never via the
+      # ingress. Declared explicitly because a guessed self-address would aim signed wake POSTs
+      # at a stranger; empty (the default) keeps the push lane honestly unarmed.
+      NEO_FLEET_WAKE_SELF_BASE: http://fleet-server:8083
     secrets:
       - mcp-auth-token
 

--- a/ai/deploy/docker-compose.local-agent-os.yml
+++ b/ai/deploy/docker-compose.local-agent-os.yml
@@ -86,6 +86,15 @@ services:
       # ingress. Declared explicitly because a guessed self-address would aim signed wake POSTs
       # at a stranger; empty (the default) keeps the push lane honestly unarmed.
       NEO_FLEET_WAKE_SELF_BASE: http://fleet-server:8083
+      # The wake arming path: this service dials its own plane's MC over the compose-internal
+      # ingress to ensure/rotate the relay wake subscription. The internal-hosts declaration
+      # NAMES the plain-HTTP hop this deployment vouches for (an unnamed internal host stays
+      # refused by the shared endpoint policy); bearer and identity are operator-supplied at
+      # compose time — absent, the push lane boots honestly unarmed and says so.
+      NEO_FLEET_PLANE_BASE: http://ingress:8080
+      NEO_FLEET_PLANE_INTERNAL_HOSTS: ingress
+      NEO_FLEET_PLANE_BEARER: ${NEO_FLEET_PLANE_BEARER:-}
+      NEO_AGENT_IDENTITY: ${NEO_AGENT_IDENTITY:-}
     secrets:
       - mcp-auth-token
 

--- a/ai/scripts/lint/config-leaf-parity.json
+++ b/ai/scripts/lint/config-leaf-parity.json
@@ -187,6 +187,7 @@
         "fleet.instanceRoot",
         "fleet.planeBase",
         "fleet.planeBearer",
+        "fleet.planeInternalHosts",
         "fleet.port",
         "fleet.tenantProbeTimeoutMs",
         "fleet.wakeReceiverManifestPath",

--- a/ai/scripts/lint/config-leaf-parity.json
+++ b/ai/scripts/lint/config-leaf-parity.json
@@ -172,6 +172,7 @@
         "engines.chroma.useTestHarness",
         "engines.chroma.useUnitTestDatabase",
         "fleet",
+        "fleet.admissionTokenFile",
         "fleet.bearer",
         "fleet.bearerHandshake",
         "fleet.cockpitOrigins",

--- a/ai/scripts/lint/config-leaf-parity.json
+++ b/ai/scripts/lint/config-leaf-parity.json
@@ -190,6 +190,7 @@
         "fleet.port",
         "fleet.tenantProbeTimeoutMs",
         "fleet.wakeReceiverManifestPath",
+        "fleet.wakeSelfBase",
         "geminiApiKey",
         "graphProvider",
         "heapObservation",

--- a/ai/scripts/lint/config-leaf-parity.json
+++ b/ai/scripts/lint/config-leaf-parity.json
@@ -187,6 +187,7 @@
         "fleet.instanceRoot",
         "fleet.planeBase",
         "fleet.planeBearer",
+        "fleet.planeBearerFile",
         "fleet.planeInternalHosts",
         "fleet.port",
         "fleet.tenantProbeTimeoutMs",

--- a/ai/services/fleet/fleetServer.mjs
+++ b/ai/services/fleet/fleetServer.mjs
@@ -388,25 +388,42 @@ export async function createFleetServerApp({
         standardHeaders: false,
         legacyHeaders  : false,
         validate       : {xForwardedForHeader: false},
-        keyGenerator   : req => req.fleetRequestContext?.username ?? 'unidentified',
+        keyGenerator   : req => resolveViewerStreamKey(req.fleetRequestContext, app.fleetWakeArming?.provenIdentity?.() ?? null)
+            ?? 'unidentified',
         handler        : (req, res) => res.status(429).json(createFleetWireResponse(FLEET_WIRE_RESPONSE_STATES.refused, {
             error: 'fleet: too many stream attempts'
         }))
     });
 
-    app.get('/fleet/events', eventsLimiter, (req, res) => {
-        const identity = normalizeAgentIdentity(req.fleetRequestContext.username);
+    app.get('/fleet/events', eventsLimiter, async (req, res) => {
+        const
+            proven    = app.fleetWakeArming?.provenIdentity?.() ?? null,
+            streamKey = resolveViewerStreamKey(req.fleetRequestContext, proven);
 
-        if (!identity) {
+        if (!streamKey) {
             res.status(403).json(createFleetWireResponse(FLEET_WIRE_RESPONSE_STATES.refused, {
-                error: 'fleet: viewer identity is not canonicalizable'
+                error: 'fleet: viewer identity carries no stable subject'
             }));
             return
         }
 
-        const admitted = fanout.registerStream(identity, res);
+        // Connect-time arming: ensure/rotate the viewer's relay subscription through the
+        // arming context (authorized today for exactly the plane-proven caller identity — MC
+        // subscriptions are caller-owned and delegation is refused there, so any other viewer
+        // lands in the honest per-viewer not-armed state rather than a relabeled route).
+        if (app.fleetWakeArming) {
+            try {
+                await app.fleetWakeArming.ensureArmedFor(streamKey)
+            } catch (error) {
+                logger.warn(`[FleetServer] connect-time arming failed for a viewer stream: ${error?.message ?? error}`)
+            }
+        }
 
-        if (!admitted.accepted) {
+        const admitted = fanout.registerStream(streamKey, res);
+
+        // A handshake-rejected stream may already be headers-sent or destroyed — only answer
+        // the refusal envelope on a response that can still carry one.
+        if (!admitted.accepted && !res.headersSent && !res.destroyed) {
             res.status(429).json(createFleetWireResponse(FLEET_WIRE_RESPONSE_STATES.refused, {
                 error: `fleet: ${admitted.reason}`
             }))
@@ -460,25 +477,59 @@ export async function createFleetServerApp({
 }
 
 /**
- * @summary Arms the wake push lane's relay subscription over the authenticated plane MC surface.
+ * @summary Derives the ONE stream/limiter key for an admitted viewer, from immutable facts only.
+ *
+ * The plane-proven canonical identity (`@login`, MC's own subject for the arming caller) is the
+ * key exactly when the request's provider login resolves to it — the same fact compared with
+ * itself, never an alias. Every other admitted viewer keys on the immutable ownership
+ * coordinates (`authProvider` + `providerUserId`): a mutable display name is never a key, a
+ * display name with spaces cannot forge one (it canonicalizes to null and falls through to the
+ * provider tuple), and a colliding display name cannot cross two viewers onto one key because
+ * the tuple differs. Digests only ever carry MC-proven owner identities, so a provider-tuple
+ * stream can never receive another owner's digest — it can only be honestly not-armed.
+ * @param {Object|null} context Frozen fleet request context.
+ * @param {String|null} provenIdentity The arming context's plane-proven canonical identity.
+ * @returns {String|null} Stream key, or null when no stable subject exists.
+ */
+export function resolveViewerStreamKey(context, provenIdentity) {
+    if (!context) return null;
+
+    const canonical = normalizeAgentIdentity(context.providerUsername ?? context.username);
+
+    if (provenIdentity && canonical && canonical === provenIdentity) {
+        return provenIdentity
+    }
+
+    if (context.authProvider && (context.providerUserId ?? '') !== '') {
+        return `provider:${context.authProvider}:${context.providerUserId}`
+    }
+
+    return null
+}
+
+/**
+ * @summary Creates the persistent wake-arming context: one proven plane client shared by the
+ * boot arming step and every connect-time ensure, with single-flight per-viewer outcomes.
  *
  * FAIL-SOFT by contract: serving never waits on arming, and every refusal path lands as the
  * fan-out's described state (rendered with its reason by the SSE `state` event and the
  * wake-routes axis) rather than a boot failure — an unarmed push lane is a truthful topology,
  * because poll-digest remains the truth lane regardless: push is latency, poll is truth.
  *
- * The plane client lives exactly as long as arming needs it: the subscription row is durable
- * MC state and the rotated signing key is already in fan-out process memory, so the session
- * closes on every exit. A restart re-arms with a fresh key (the one sanctioned rotation door).
+ * Authorization boundary, stated where it binds: MC wake subscriptions are CALLER-owned and MC
+ * refuses delegation, so this context can arm exactly one viewer — the identity the plane
+ * client's `init` proof establishes. `ensureArmedFor(anyOtherViewer)` answers the honest
+ * not-armed-for-this-viewer outcome without touching MC; it never relabels the caller-owned
+ * subscription as someone else's route.
  * @param {Object} options
  * @param {Object} options.fanout The app's wake fan-out registry.
- * @param {Object} options.aiConfig Resolved Tier-1 config tree.
- * @param {Object} options.logger Redaction-safe logger.
+ * @param {Object} [options.aiConfig=AiConfig] Resolved Tier-1 config tree.
+ * @param {Object} [options.logger=defaultLogger] Redaction-safe logger.
  * @param {Function} [options.createPlaneClient] Injection seam for tests.
  * @param {Function} [options.resolveViewerClaim] Injection seam for tests.
- * @returns {Promise<Object>} The fan-out's `{armed, reason}` arming outcome.
+ * @returns {Object} `{ensureArmedFor, provenIdentity, close}`
  */
-export async function armFleetWakePushLane({
+export function createWakeArmingContext({
     fanout,
     aiConfig           = AiConfig,
     logger             = defaultLogger,
@@ -489,44 +540,144 @@ export async function armFleetWakePushLane({
         planeBase    = aiConfig.fleet.planeBase.trim(),
         wakeSelfBase = aiConfig.fleet.wakeSelfBase.trim();
 
-    if (!wakeSelfBase) {
-        return fanout.armRelaySubscription({identity: null, wakeSelfBase: '', callTool: null})
+    let
+        client       = null,
+        proven       = null,
+        establishing = null;
+
+    const outcomesByViewer = new Map(); // viewer key -> settled arming outcome
+
+    async function establish() {
+        if (proven) return {ok: true};
+        if (!wakeSelfBase) return {ok: false, reason: 'not-armed: fleet.wakeSelfBase undeclared'};
+        if (!planeBase) return {ok: false, reason: 'not-armed: no authenticated plane client'};
+
+        establishing ??= (async () => {
+            try {
+                const viewer = await resolveViewerClaim();
+
+                client = createPlaneClient({
+                    baseUrl            : `${planeBase.replace(/\/+$/, '')}/mc/mcp`,
+                    credential         : aiConfig.fleet.planeBearer,
+                    allowPlainHttpHosts: aiConfig.fleet.planeInternalHosts
+                });
+
+                const admission = await client.init({expectedIdentity: viewer.agentIdentityNodeId});
+
+                if (!admission.ok) {
+                    client = null;
+                    return {ok: false, reason: `not-armed: plane admission refused (${admission.reason})`}
+                }
+
+                proven = normalizeAgentIdentity(admission.identity);
+                return {ok: true}
+            } catch (error) {
+                client = null;
+                return {ok: false, reason: `not-armed: ${error?.message ?? error}`}
+            } finally {
+                establishing = null
+            }
+        })();
+
+        return establishing
     }
 
-    if (!planeBase) {
-        return fanout.armRelaySubscription({identity: null, wakeSelfBase, callTool: null})
-    }
+    return {
+        /**
+         * @summary Establishes (once, single-flight) the proven plane session. Safe to call
+         * repeatedly; failures are returned, never thrown.
+         * @returns {Promise<Object>} `{ok, reason?}`
+         */
+        establish,
 
-    let client;
+        /**
+         * @summary The plane-proven canonical identity, or null before/without proof.
+         * @returns {String|null}
+         */
+        provenIdentity() {
+            return proven
+        },
+
+        /**
+         * @summary Ensures the relay subscription for one viewer key — cached per viewer, safe
+         * to call on every connect. Establish-class failures are reflected into the fan-out's
+         * described state so the SSE `state` event and the wake-routes axis carry the reason.
+         * @param {String} viewerKey Stream key from {@link resolveViewerStreamKey}.
+         * @returns {Promise<Object>} `{armed, reason}` outcome for this viewer.
+         */
+        async ensureArmedFor(viewerKey) {
+            const cached = outcomesByViewer.get(viewerKey);
+
+            if (cached?.armed) return cached;
+
+            const ready = await establish();
+
+            let outcome;
+
+            if (!ready.ok) {
+                outcome = await fanout.armRelaySubscription({
+                    identity    : null,
+                    wakeSelfBase: ready.reason.includes('wakeSelfBase') ? '' : wakeSelfBase,
+                    callTool    : null
+                })
+            } else if (viewerKey !== proven) {
+                outcome = {armed: false, reason: 'not-armed: MC subscriptions are caller-owned; this viewer is not the proven plane identity'}
+            } else {
+                outcome = await fanout.armRelaySubscription({
+                    identity: proven,
+                    wakeSelfBase,
+                    callTool: (name, args) => client.callTool(name, args)
+                });
+
+                logger.info(`[FleetServer] wake push lane (${viewerKey}): ${outcome.reason}`)
+            }
+
+            outcomesByViewer.set(viewerKey, outcome);
+            return outcome
+        },
+
+        /**
+         * @summary Closes the proven plane session and forgets per-viewer outcomes.
+         * @returns {Promise<void>}
+         */
+        async close() {
+            outcomesByViewer.clear();
+            proven = null;
+
+            const closing = client;
+            client = null;
+
+            await closing?.close?.()
+        }
+    }
+}
+
+/**
+ * @summary Boot arming step: establishes the proven plane session and arms the push lane for
+ * the proven identity through the SAME context connect-time ensures ride. Kept as the named
+ * boot-path falsifier surface — a spec drives THIS function (with its seams) to `armed`.
+ * @param {Object} options Options of {@link createWakeArmingContext}, plus:
+ * @param {Object} [options.armingContext] Existing context override (the server's own).
+ * @returns {Promise<Object>} The `{armed, reason}` arming outcome for the proven identity.
+ */
+export async function armFleetWakePushLane({armingContext = null, ...contextOptions}) {
+    const
+        context = armingContext ?? createWakeArmingContext(contextOptions),
+        logger  = contextOptions.logger ?? defaultLogger;
 
     try {
-        const viewer = await resolveViewerClaim();
+        const ready = await context.establish();
 
-        client = createPlaneClient({
-            baseUrl   : `${planeBase.replace(/\/+$/, '')}/mc/mcp`,
-            credential: aiConfig.fleet.planeBearer
-        });
-
-        const admission = await client.init({expectedIdentity: viewer.agentIdentityNodeId});
-
-        if (!admission.ok) {
-            logger.warn(`[FleetServer] wake push lane not armed: plane admission refused (${admission.reason})`);
-            return fanout.armRelaySubscription({identity: null, wakeSelfBase, callTool: null})
+        if (!ready.ok) {
+            logger.warn(`[FleetServer] wake push lane: ${ready.reason}`);
+            // Reflect the refusal into the fan-out's rendered state through the same door.
+            return context.ensureArmedFor(context.provenIdentity() ?? 'unproven')
         }
 
-        const outcome = await fanout.armRelaySubscription({
-            identity: normalizeAgentIdentity(admission.identity),
-            wakeSelfBase,
-            callTool: (name, args) => client.callTool(name, args)
-        });
-
-        logger.info(`[FleetServer] wake push lane: ${outcome.reason}`);
-        return outcome
+        return context.ensureArmedFor(context.provenIdentity())
     } catch (error) {
         logger.warn(`[FleetServer] wake push lane not armed: ${error?.message ?? error}`);
-        return fanout.armRelaySubscription({identity: null, wakeSelfBase, callTool: null})
-    } finally {
-        await client?.close?.()
+        return {armed: false, reason: `not-armed: ${error?.message ?? error}`}
     }
 }
 
@@ -552,16 +703,35 @@ export async function startFleetServer(options={}) {
 
     const app = await createFleetServerApp({...options, aiConfig, logger});
 
+    app.fleetWakeArming = options.wakeArmingContext ?? createWakeArmingContext({
+        fanout: app.fleetWakeFanout,
+        aiConfig,
+        logger,
+        ...(options.createPlaneClient  ? {createPlaneClient : options.createPlaneClient}  : {}),
+        ...(options.resolveViewerClaim ? {resolveViewerClaim: options.resolveViewerClaim} : {})
+    });
+
     return new Promise((resolve, reject) => {
         const server = app.listen(port, host, () => {
             logger.info(`[FleetServer] listening on ${host}:${server.address().port}`);
 
-            armFleetWakePushLane({fanout: app.fleetWakeFanout, aiConfig, logger}).catch(error => {
+            armFleetWakePushLane({armingContext: app.fleetWakeArming, logger}).catch(error => {
                 logger.warn(`[FleetServer] wake push lane arming crashed: ${error?.message ?? error}`)
             });
 
             resolve(server)
         });
+
+        // Held SSE responses would keep `server.close()` waiting forever: disposal of the
+        // fan-out (which ENDS every held stream) and the proven plane session must precede the
+        // close-callback wait, on every shutdown path that goes through `server.close()`.
+        const originalClose = server.close.bind(server);
+
+        server.close = callback => {
+            app.fleetWakeFanout.dispose();
+            app.fleetWakeArming.close().catch(() => {/* session teardown is best-effort on shutdown */});
+            return originalClose(callback)
+        };
 
         server.once('error', reject)
     })

--- a/ai/services/fleet/fleetServer.mjs
+++ b/ai/services/fleet/fleetServer.mjs
@@ -1,17 +1,17 @@
 // Neo namespace bootstrap (entry-point invariant): FleetControlBridge and its Neo classes are
 // evaluated only after the namespace/core/instance aliases have been installed.
-import Neo                               from '../../../src/Neo.mjs';
-import * as core                         from '../../../src/core/_export.mjs';
-import InstanceManager                   from '../../../src/manager/Instance.mjs';
-import express                           from 'express';
-import {rateLimit}                       from 'express-rate-limit';
-import cors                              from 'cors';
-import path                              from 'node:path';
-import {accessSync, constants, statSync} from 'node:fs';
-import {fileURLToPath, pathToFileURL}    from 'node:url';
-import {hostHeaderValidation}            from '@modelcontextprotocol/sdk/server/middleware/hostHeaderValidation.js';
-import AiConfig                          from '../../config.mjs';
-import ConfigBase, {PLANE_MEMBER_PATHS}  from '../../configBase.mjs';
+import Neo                                             from '../../../src/Neo.mjs';
+import * as core                                       from '../../../src/core/_export.mjs';
+import InstanceManager                                 from '../../../src/manager/Instance.mjs';
+import express                                         from 'express';
+import {rateLimit}                                     from 'express-rate-limit';
+import cors                                            from 'cors';
+import path                                            from 'node:path';
+import {accessSync, constants, readFileSync, statSync} from 'node:fs';
+import {fileURLToPath, pathToFileURL}                  from 'node:url';
+import {hostHeaderValidation}                          from '@modelcontextprotocol/sdk/server/middleware/hostHeaderValidation.js';
+import AiConfig                                        from '../../config.mjs';
+import ConfigBase, {PLANE_MEMBER_PATHS}                from '../../configBase.mjs';
 import {
     assertPlaneCoherence,
     assertPlaneMemberCoherence,
@@ -407,19 +407,32 @@ export async function createFleetServerApp({
             return
         }
 
-        // Connect-time arming: ensure/rotate the viewer's relay subscription through the
-        // arming context (authorized today for exactly the plane-proven caller identity — MC
-        // subscriptions are caller-owned and delegation is refused there, so any other viewer
-        // lands in the honest per-viewer not-armed state rather than a relabeled route).
+        // Connect-time arming, per viewer, with the viewer's OWN presented bearer: the
+        // subscription is created by the viewer's credential (MC's caller-owned model holds
+        // per viewer, no delegation surface), the bearer is used in-flight only, and the
+        // stream registers under the identity MC PROVED for it — never the request's claim.
+        // A viewer without a usable bearer falls back to the service-proven path (which arms
+        // exactly the proven caller) and otherwise lands in the honest not-armed state.
+        let registrationKey = streamKey;
+
         if (app.fleetWakeArming) {
             try {
-                await app.fleetWakeArming.ensureArmedFor(streamKey)
+                const
+                    bearer         = (req.headers.authorization ?? '').replace(/^Bearer\s+/i, '').trim(),
+                    canonicalClaim = normalizeAgentIdentity(req.fleetRequestContext.providerUsername ?? req.fleetRequestContext.username),
+                    outcome        = bearer && canonicalClaim
+                        ? await app.fleetWakeArming.ensureArmedForViewer({viewerKey: streamKey, canonicalClaim, bearer})
+                        : await app.fleetWakeArming.ensureArmedFor(streamKey);
+
+                if (outcome.armed && outcome.identity) {
+                    registrationKey = outcome.identity
+                }
             } catch (error) {
                 logger.warn(`[FleetServer] connect-time arming failed for a viewer stream: ${error?.message ?? error}`)
             }
         }
 
-        const admitted = fanout.registerStream(streamKey, res);
+        const admitted = fanout.registerStream(registrationKey, res);
 
         // A handshake-rejected stream may already be headers-sent or destroyed — only answer
         // the refusal envelope on a response that can still carry one.
@@ -474,6 +487,35 @@ export async function createFleetServerApp({
     });
 
     return app
+}
+
+/**
+ * @summary Resolves the Fleet service's plane bearer from its two declared homes: the direct
+ * `fleet.planeBearer` value wins; otherwise `fleet.planeBearerFile` names a secret file (the
+ * containerized custody class — the canonical composition mounts its admission token as a
+ * compose secret, and a credential does not belong in an env literal). Returns `''` when
+ * neither yields a value — the caller decides whether that is an honest unarmed state or a
+ * refused boot.
+ * @param {Object} [options]
+ * @param {Object} [options.aiConfig=AiConfig] Resolved Tier-1 config tree.
+ * @param {Function} [options.readFile] Injection seam for tests; defaults to `readFileSync`.
+ * @returns {String} The resolved bearer, or `''`.
+ */
+export function resolveFleetPlaneBearer({aiConfig = AiConfig, readFile = null} = {}) {
+    const direct = aiConfig.fleet.planeBearer.trim();
+
+    if (direct) return direct;
+
+    const bearerFile = aiConfig.fleet.planeBearerFile.trim();
+
+    if (!bearerFile) return '';
+
+    try {
+        const read = readFile ?? (target => readFileSync(target, 'utf8'));
+        return String(read(bearerFile)).trim()
+    } catch {
+        return ''
+    }
 }
 
 /**
@@ -558,7 +600,7 @@ export function createWakeArmingContext({
 
                 client = createPlaneClient({
                     baseUrl            : `${planeBase.replace(/\/+$/, '')}/mc/mcp`,
-                    credential         : aiConfig.fleet.planeBearer,
+                    credential         : resolveFleetPlaneBearer({aiConfig}),
                     allowPlainHttpHosts: aiConfig.fleet.planeInternalHosts
                 });
 
@@ -599,41 +641,130 @@ export function createWakeArmingContext({
         },
 
         /**
-         * @summary Ensures the relay subscription for one viewer key — cached per viewer, safe
-         * to call on every connect. Establish-class failures are reflected into the fan-out's
-         * described state so the SSE `state` event and the wake-routes axis carry the reason.
+         * @summary Ensures the relay subscription for one viewer key — single-flight per
+         * viewer (a settled ARMED outcome is cached; a failure clears its latch so the next
+         * connect retries), safe to call on every connect. Establish-class failures are
+         * reflected into the fan-out's described state so the SSE `state` event and the
+         * wake-routes axis carry the reason.
          * @param {String} viewerKey Stream key from {@link resolveViewerStreamKey}.
          * @returns {Promise<Object>} `{armed, reason}` outcome for this viewer.
          */
-        async ensureArmedFor(viewerKey) {
-            const cached = outcomesByViewer.get(viewerKey);
+        ensureArmedFor(viewerKey) {
+            const pending = outcomesByViewer.get(viewerKey);
 
-            if (cached?.armed) return cached;
+            if (pending) return pending;
 
-            const ready = await establish();
+            const mutation = (async () => {
+                const ready = await establish();
 
-            let outcome;
+                if (!ready.ok) {
+                    return fanout.armRelaySubscription({
+                        identity    : null,
+                        wakeSelfBase: ready.reason.includes('wakeSelfBase') ? '' : wakeSelfBase,
+                        callTool    : null
+                    })
+                }
 
-            if (!ready.ok) {
-                outcome = await fanout.armRelaySubscription({
-                    identity    : null,
-                    wakeSelfBase: ready.reason.includes('wakeSelfBase') ? '' : wakeSelfBase,
-                    callTool    : null
-                })
-            } else if (viewerKey !== proven) {
-                outcome = {armed: false, reason: 'not-armed: MC subscriptions are caller-owned; this viewer is not the proven plane identity'}
-            } else {
-                outcome = await fanout.armRelaySubscription({
+                if (viewerKey !== proven) {
+                    return {armed: false, reason: 'not-armed: MC subscriptions are caller-owned; this viewer is not the proven plane identity'}
+                }
+
+                const outcome = await fanout.armRelaySubscription({
                     identity: proven,
                     wakeSelfBase,
                     callTool: (name, args) => client.callTool(name, args)
                 });
 
-                logger.info(`[FleetServer] wake push lane (${viewerKey}): ${outcome.reason}`)
-            }
+                logger.info(`[FleetServer] wake push lane (${viewerKey}): ${outcome.reason}`);
+                return outcome
+            })().then(outcome => {
+                if (!outcome.armed) {
+                    outcomesByViewer.delete(viewerKey)
+                }
 
-            outcomesByViewer.set(viewerKey, outcome);
-            return outcome
+                return outcome
+            }, error => {
+                outcomesByViewer.delete(viewerKey);
+                throw error
+            });
+
+            outcomesByViewer.set(viewerKey, mutation);
+            return mutation
+        },
+
+        /**
+         * @summary Arms one ADMITTED viewer with the viewer's OWN presented plane bearer — the
+         * MC-authorized per-viewer ownership path: the subscription is created by the viewer's
+         * credential, so MC's caller-owned model holds per viewer with no delegation surface
+         * and no privilege beyond what the viewer already presented to this server. The bearer
+         * is used in-flight for exactly one ephemeral session (init proof → subscribe →
+         * rotate-key → close) and never stored; the route binds to the identity MC PROVES for
+         * that bearer, never to the request's claim. Single-flight + retry semantics per
+         * viewer, same as {@link ensureArmedFor}.
+         * @param {Object} options
+         * @param {String} options.viewerKey Pre-arming stream key (latch + cache key).
+         * @param {String} options.canonicalClaim The viewer's canonical `@login` claim, proven
+         *     against MC by the session init.
+         * @param {String} options.bearer The viewer's own presented plane credential.
+         * @returns {Promise<Object>} `{armed, reason, identity?}` — `identity` is MC-proven.
+         */
+        ensureArmedForViewer({viewerKey, canonicalClaim, bearer}) {
+            const pending = outcomesByViewer.get(viewerKey);
+
+            if (pending) return pending;
+
+            const mutation = (async () => {
+                if (!wakeSelfBase) {
+                    return fanout.armRelaySubscription({identity: null, wakeSelfBase: '', callTool: null})
+                }
+
+                if (!planeBase || typeof bearer !== 'string' || bearer.length === 0 || !canonicalClaim) {
+                    return {armed: false, reason: 'not-armed: no per-viewer plane credential presented'}
+                }
+
+                let viewerClient;
+
+                try {
+                    viewerClient = createPlaneClient({
+                        baseUrl            : `${planeBase.replace(/\/+$/, '')}/mc/mcp`,
+                        credential         : bearer,
+                        allowPlainHttpHosts: aiConfig.fleet.planeInternalHosts
+                    });
+
+                    const admission = await viewerClient.init({expectedIdentity: canonicalClaim});
+
+                    if (!admission.ok) {
+                        return {armed: false, reason: `not-armed: viewer admission refused (${admission.reason})`}
+                    }
+
+                    const identity = normalizeAgentIdentity(admission.identity);
+
+                    const outcome = await fanout.armRelaySubscription({
+                        identity,
+                        wakeSelfBase,
+                        callTool: (name, args) => viewerClient.callTool(name, args)
+                    });
+
+                    logger.info(`[FleetServer] wake push lane (${identity}): ${outcome.reason}`);
+                    return {...outcome, identity}
+                } catch (error) {
+                    return {armed: false, reason: `not-armed: ${error?.message ?? error}`}
+                } finally {
+                    await viewerClient?.close?.()
+                }
+            })().then(outcome => {
+                if (!outcome.armed) {
+                    outcomesByViewer.delete(viewerKey)
+                }
+
+                return outcome
+            }, error => {
+                outcomesByViewer.delete(viewerKey);
+                throw error
+            });
+
+            outcomesByViewer.set(viewerKey, mutation);
+            return mutation
         },
 
         /**
@@ -699,6 +830,20 @@ export async function startFleetServer(options={}) {
 
     if (typeof host !== 'string' || host.trim().length === 0) {
         throw new Error('Fleet listener host is required')
+    }
+
+    // A DECLARED wake push lane with no service credential is a dead feature wearing a live
+    // topology — this boot refuses loudly instead of arming nothing and letting the first
+    // plane witness discover it. Per-viewer bearers still arm viewers at connect; this gate
+    // is about the service's own lane, whose declaration promised it works.
+    if (aiConfig.fleet.wakeSelfBase.trim() && aiConfig.fleet.planeBase.trim() &&
+        resolveFleetPlaneBearer({aiConfig}) === ''
+    ) {
+        throw new Error(
+            '[FleetServer] wake push lane is declared (fleet.wakeSelfBase + fleet.planeBase) but no ' +
+            'plane credential resolves — set fleet.planeBearer or fleet.planeBearerFile, or unset ' +
+            'fleet.wakeSelfBase. Refusing to boot a dead feature.'
+        )
     }
 
     const app = await createFleetServerApp({...options, aiConfig, logger});

--- a/ai/services/fleet/fleetServer.mjs
+++ b/ai/services/fleet/fleetServer.mjs
@@ -4,6 +4,7 @@ import Neo                               from '../../../src/Neo.mjs';
 import * as core                         from '../../../src/core/_export.mjs';
 import InstanceManager                   from '../../../src/manager/Instance.mjs';
 import express                           from 'express';
+import {rateLimit}                       from 'express-rate-limit';
 import cors                              from 'cors';
 import path                              from 'node:path';
 import {accessSync, constants, statSync} from 'node:fs';
@@ -294,7 +295,26 @@ export async function createFleetServerApp({
 
     app.fleetWakeFanout = fanout;
 
-    app.post('/wake', createFleetWakeReceiver({
+    // Rate bound for the signature-admitted receiver: per KNOWN subscription (their population
+    // bounds the store), while every unknown-id request shares ONE bucket — an id-rotating
+    // flood cannot inflate the key store and throttles itself into the shared bucket. The
+    // window is generous against real coalesced wake cadence and still bounds the per-request
+    // HMAC work an unauthenticated caller can demand. Keys never derive from ip, so the
+    // X-Forwarded-For validation is explicitly off rather than trusting proxy topology.
+    const wakeLimiter = rateLimit({
+        windowMs       : 60_000,
+        limit          : 120,
+        standardHeaders: false,
+        legacyHeaders  : false,
+        validate       : {xForwardedForHeader: false},
+        keyGenerator   : req => {
+            const id = req.headers['x-neo-wake-subscription-id'];
+            return (typeof id === 'string' && fanout.resolveRoute(id)) ? id : 'unknown-subscription'
+        },
+        handler: (req, res) => res.status(429).json({error: 'rate-limited'})
+    });
+
+    app.post('/wake', wakeLimiter, createFleetWakeReceiver({
         resolveRoute: id => fanout.resolveRoute(id),
         onDigest    : digest => fanout.handleDigest(digest),
         logger
@@ -359,7 +379,22 @@ export async function createFleetServerApp({
     // identity; digests only ever route to the streams of their subscription's identity, so a
     // viewer the push lane is not armed for receives the honest per-viewer `state` event and
     // keeps poll-digest as the truth lane.
-    app.get('/fleet/events', (req, res) => {
+    // Connection-attempt bound per authenticated viewer (the key is the admission-proven
+    // identity, never an ip behind the ingress); the held-resource bound — concurrent open
+    // streams — is the fan-out's own cap, which a request limiter cannot express.
+    const eventsLimiter = rateLimit({
+        windowMs       : 60_000,
+        limit          : 30,
+        standardHeaders: false,
+        legacyHeaders  : false,
+        validate       : {xForwardedForHeader: false},
+        keyGenerator   : req => req.fleetRequestContext?.username ?? 'unidentified',
+        handler        : (req, res) => res.status(429).json(createFleetWireResponse(FLEET_WIRE_RESPONSE_STATES.refused, {
+            error: 'fleet: too many stream attempts'
+        }))
+    });
+
+    app.get('/fleet/events', eventsLimiter, (req, res) => {
         const identity = normalizeAgentIdentity(req.fleetRequestContext.username);
 
         if (!identity) {
@@ -369,7 +404,13 @@ export async function createFleetServerApp({
             return
         }
 
-        fanout.registerStream(identity, res)
+        const admitted = fanout.registerStream(identity, res);
+
+        if (!admitted.accepted) {
+            res.status(429).json(createFleetWireResponse(FLEET_WIRE_RESPONSE_STATES.refused, {
+                error: `fleet: ${admitted.reason}`
+            }))
+        }
     });
 
     app.post('/fleet', async (req, res) => {

--- a/ai/services/fleet/fleetServer.mjs
+++ b/ai/services/fleet/fleetServer.mjs
@@ -410,21 +410,24 @@ export async function createFleetServerApp({
         // Connect-time arming, per viewer, with a SEPARATELY CARRIED class-3 credential: the
         // viewer's MC bearer travels in its own header, because the class-1 Fleet admission
         // bearer (the `Authorization` this route was admitted on) must NEVER be forwarded to
-        // the `/mc/mcp` audience — the ledger's non-alias rule, enforced here by simply never
-        // reading that header for this purpose. With the class-3 credential present, the
+        // the `/mc/mcp` audience. A header label alone is not a credential authority — PATs
+        // carry no audience claim and both surfaces share the verifier — so the class-1 bytes
+        // travel WITH the request into the arming context, which refuses a byte-identical pair
+        // before any MC client exists. With a genuinely distinct class-3 credential, the
         // subscription is created by the viewer's own MC authority (caller-owned per viewer),
         // used in-flight only, and the stream registers under the identity MC PROVED — never
-        // the request's claim. Without it, the service-proven path answers (arming exactly the
-        // proven caller) and every other viewer lands in the honest not-armed state.
+        // the request's claim. Without one, the service-proven path answers (arming exactly
+        // the proven caller) and every other viewer lands in the honest not-armed state.
         let registrationKey = streamKey;
 
         if (app.fleetWakeArming) {
             try {
                 const
+                    fleetBearer    = (req.headers.authorization ?? '').replace(/^Bearer\s+/i, '').trim(),
                     mcBearer       = (req.headers['x-neo-mc-authorization'] ?? '').replace(/^Bearer\s+/i, '').trim(),
                     canonicalClaim = normalizeAgentIdentity(req.fleetRequestContext.providerUsername ?? req.fleetRequestContext.username),
                     outcome        = mcBearer && canonicalClaim
-                        ? await app.fleetWakeArming.ensureArmedForViewer({viewerKey: streamKey, canonicalClaim, bearer: mcBearer})
+                        ? await app.fleetWakeArming.ensureArmedForViewer({viewerKey: streamKey, canonicalClaim, bearer: mcBearer, fleetAdmissionBearer: fleetBearer})
                         : await app.fleetWakeArming.ensureArmedFor(streamKey);
 
                 if (outcome.armed && outcome.identity) {
@@ -748,9 +751,14 @@ export function createWakeArmingContext({
          * @param {String} options.canonicalClaim The viewer's canonical `@login` claim, proven
          *     against MC by the session init.
          * @param {String} options.bearer The viewer's own presented plane credential.
+         * @param {String} [options.fleetAdmissionBearer=''] The class-1 bearer the request was
+         *     admitted on — supplied so THIS seam can refuse a byte-identical pair: a header
+         *     label is not a credential authority, and PATs carry no audience claim, so
+         *     equality here IS the forbidden class-1→class-3 forwarding, refused before any
+         *     MC client exists.
          * @returns {Promise<Object>} `{armed, reason, identity?}` — `identity` is MC-proven.
          */
-        ensureArmedForViewer({viewerKey, canonicalClaim, bearer}) {
+        ensureArmedForViewer({viewerKey, canonicalClaim, bearer, fleetAdmissionBearer = ''}) {
             const pending = outcomesByViewer.get(viewerKey);
 
             if (pending) return pending;
@@ -762,6 +770,10 @@ export function createWakeArmingContext({
 
                 if (!planeBase || typeof bearer !== 'string' || bearer.length === 0 || !canonicalClaim) {
                     return {armed: false, reason: 'not-armed: no per-viewer plane credential presented'}
+                }
+
+                if (fleetAdmissionBearer && bearer === fleetAdmissionBearer) {
+                    return {armed: false, reason: 'not-armed: the presented MC credential is byte-identical to the Fleet admission bearer — the credential-class ledger forbids the aliasing'}
                 }
 
                 let viewerClient;

--- a/ai/services/fleet/fleetServer.mjs
+++ b/ai/services/fleet/fleetServer.mjs
@@ -17,11 +17,16 @@ import {
     collectPlaneMembers,
     resolvePlaneDataRoot
 }                                          from '../../planeConfig.mjs';
-import AuthService              from '../../mcp/server/shared/services/AuthService.mjs';
-import RequestContextService    from '../../mcp/server/shared/services/RequestContextService.mjs';
-import TransportService         from '../../mcp/server/shared/services/TransportService.mjs';
-import FleetControlBridge       from './FleetControlBridge.mjs';
-import {dispatchFleetS1Request} from './fleetServerPolicy.mjs';
+import AuthService                from '../../mcp/server/shared/services/AuthService.mjs';
+import RequestContextService      from '../../mcp/server/shared/services/RequestContextService.mjs';
+import TransportService           from '../../mcp/server/shared/services/TransportService.mjs';
+import FleetControlBridge         from './FleetControlBridge.mjs';
+import {createFleetWakeFanout}    from './fleetWakeFanout.mjs';
+import {createFleetWakeReceiver}  from './fleetWakeReceiver.mjs';
+import {createPlaneMailboxClient} from './planeMailboxClient.mjs';
+import {normalizeAgentIdentity}   from './mcpWireParsing.mjs';
+import {resolveFleetViewerClaim}  from './fleetLaunchContract.mjs';
+import {dispatchFleetS1Request}   from './fleetServerPolicy.mjs';
 import {
     createFleetWireResponse,
     FLEET_WIRE_RESPONSE_STATES,
@@ -254,6 +259,9 @@ function adaptFleetWireErrorResponse(req, res, next) {
  * @param {Function} [options.runInContext] Request-context runner override.
  * @param {Function} [options.planeGuard] Boot-time plane assertion override.
  * @param {Number} [options.maxBodyBytes=1048576] JSON request limit.
+ * @param {Object} [options.wakeFanout] Wake fan-out registry override (tests); defaults to a
+ *     fresh {@link createFleetWakeFanout} instance, exposed on the returned app as
+ *     `app.fleetWakeFanout` for the boot entry's arming step.
  * @returns {Promise<Object>} Configured Express application.
  */
 export async function createFleetServerApp({
@@ -264,7 +272,8 @@ export async function createFleetServerApp({
     dispatch          = request => dispatchFleetS1Request(request, FleetControlBridge),
     runInContext      = (context, callback) => RequestContextService.run(context, callback),
     planeGuard        = assertFleetPlaneReady,
-    maxBodyBytes      = 1024 * 1024
+    maxBodyBytes      = 1024 * 1024,
+    wakeFanout        = null
 }={}) {
     planeGuard({aiConfig});
 
@@ -274,6 +283,23 @@ export async function createFleetServerApp({
 
     app.enable('strict routing');
     app.disable('x-powered-by');
+
+    // The signed wake receiver mounts FIRST — before the wire-error adapter, host guard, CORS,
+    // and AuthService. Its admission is the per-subscription signed-wake HMAC over the exact
+    // body bytes: the dispatcher (`WebhookDeliveryService`) holds no provider
+    // bearer and no allowlisted Host header, and the signature is a stronger statement than
+    // either. The route is additionally kept OFF the ingress route table — signed AND
+    // compose-internal, because reachability is never authentication.
+    const fanout = wakeFanout ?? createFleetWakeFanout({logger});
+
+    app.fleetWakeFanout = fanout;
+
+    app.post('/wake', createFleetWakeReceiver({
+        resolveRoute: id => fanout.resolveRoute(id),
+        onDigest    : digest => fanout.handleDigest(digest),
+        logger
+    }));
+
     app.use(adaptFleetWireErrorResponse);
     app.use(hostHeaderValidation(transportService.computeAllowedHosts(aiConfig)));
 
@@ -327,6 +353,25 @@ export async function createFleetServerApp({
         })
     });
 
+    // The wake push lane's client surface: one SSE stream per connected cockpit, behind the
+    // FULL admission chain above (this is a client surface — provider identity required, unlike
+    // `/wake`, whose admission is the signature). The stream key is the caller's canonical
+    // identity; digests only ever route to the streams of their subscription's identity, so a
+    // viewer the push lane is not armed for receives the honest per-viewer `state` event and
+    // keeps poll-digest as the truth lane.
+    app.get('/fleet/events', (req, res) => {
+        const identity = normalizeAgentIdentity(req.fleetRequestContext.username);
+
+        if (!identity) {
+            res.status(403).json(createFleetWireResponse(FLEET_WIRE_RESPONSE_STATES.refused, {
+                error: 'fleet: viewer identity is not canonicalizable'
+            }));
+            return
+        }
+
+        fanout.registerStream(identity, res)
+    });
+
     app.post('/fleet', async (req, res) => {
         let envelope;
 
@@ -374,7 +419,80 @@ export async function createFleetServerApp({
 }
 
 /**
+ * @summary Arms the wake push lane's relay subscription over the authenticated plane MC surface.
+ *
+ * FAIL-SOFT by contract: serving never waits on arming, and every refusal path lands as the
+ * fan-out's described state (rendered with its reason by the SSE `state` event and the
+ * wake-routes axis) rather than a boot failure — an unarmed push lane is a truthful topology,
+ * because poll-digest remains the truth lane regardless: push is latency, poll is truth.
+ *
+ * The plane client lives exactly as long as arming needs it: the subscription row is durable
+ * MC state and the rotated signing key is already in fan-out process memory, so the session
+ * closes on every exit. A restart re-arms with a fresh key (the one sanctioned rotation door).
+ * @param {Object} options
+ * @param {Object} options.fanout The app's wake fan-out registry.
+ * @param {Object} options.aiConfig Resolved Tier-1 config tree.
+ * @param {Object} options.logger Redaction-safe logger.
+ * @param {Function} [options.createPlaneClient] Injection seam for tests.
+ * @param {Function} [options.resolveViewerClaim] Injection seam for tests.
+ * @returns {Promise<Object>} The fan-out's `{armed, reason}` arming outcome.
+ */
+export async function armFleetWakePushLane({
+    fanout,
+    aiConfig           = AiConfig,
+    logger             = defaultLogger,
+    createPlaneClient  = createPlaneMailboxClient,
+    resolveViewerClaim = resolveFleetViewerClaim
+}) {
+    const
+        planeBase    = aiConfig.fleet.planeBase.trim(),
+        wakeSelfBase = aiConfig.fleet.wakeSelfBase.trim();
+
+    if (!wakeSelfBase) {
+        return fanout.armRelaySubscription({identity: null, wakeSelfBase: '', callTool: null})
+    }
+
+    if (!planeBase) {
+        return fanout.armRelaySubscription({identity: null, wakeSelfBase, callTool: null})
+    }
+
+    let client;
+
+    try {
+        const viewer = await resolveViewerClaim();
+
+        client = createPlaneClient({
+            baseUrl   : `${planeBase.replace(/\/+$/, '')}/mc/mcp`,
+            credential: aiConfig.fleet.planeBearer
+        });
+
+        const admission = await client.init({expectedIdentity: viewer.agentIdentityNodeId});
+
+        if (!admission.ok) {
+            logger.warn(`[FleetServer] wake push lane not armed: plane admission refused (${admission.reason})`);
+            return fanout.armRelaySubscription({identity: null, wakeSelfBase, callTool: null})
+        }
+
+        const outcome = await fanout.armRelaySubscription({
+            identity: normalizeAgentIdentity(admission.identity),
+            wakeSelfBase,
+            callTool: (name, args) => client.callTool(name, args)
+        });
+
+        logger.info(`[FleetServer] wake push lane: ${outcome.reason}`);
+        return outcome
+    } catch (error) {
+        logger.warn(`[FleetServer] wake push lane not armed: ${error?.message ?? error}`);
+        return fanout.armRelaySubscription({identity: null, wakeSelfBase, callTool: null})
+    } finally {
+        await client?.close?.()
+    }
+}
+
+/**
  * @summary Start the composed Fleet HTTP listener after the plane and AuthService setup gates pass.
+ * Wake push-lane arming runs fire-and-forget AFTER the listener is up — the dialable
+ * self-address only means anything once `/wake` answers, and serving never waits on the plane.
  * @param {Object} [options] Options accepted by {@link createFleetServerApp}, plus host/port.
  * @param {String} [options.host] Explicit listener host; otherwise the resolved `mcpListenHost`.
  * @param {Number} [options.port] Listener port; defaults to `fleet.port`.
@@ -396,6 +514,11 @@ export async function startFleetServer(options={}) {
     return new Promise((resolve, reject) => {
         const server = app.listen(port, host, () => {
             logger.info(`[FleetServer] listening on ${host}:${server.address().port}`);
+
+            armFleetWakePushLane({fanout: app.fleetWakeFanout, aiConfig, logger}).catch(error => {
+                logger.warn(`[FleetServer] wake push lane arming crashed: ${error?.message ?? error}`)
+            });
+
             resolve(server)
         });
 

--- a/ai/services/fleet/fleetServer.mjs
+++ b/ai/services/fleet/fleetServer.mjs
@@ -629,12 +629,14 @@ export function createWakeArmingContext({
 
     let
         client       = null,
+        closed       = false,
         proven       = null,
         establishing = null;
 
     const outcomesByViewer = new Map(); // viewer key -> settled arming outcome
 
     async function establish() {
+        if (closed) return {ok: false, reason: 'not-armed: arming context closed'};
         if (proven) return {ok: true};
         if (!wakeSelfBase) return {ok: false, reason: 'not-armed: fleet.wakeSelfBase undeclared'};
         if (!planeBase) return {ok: false, reason: 'not-armed: no authenticated plane client'};
@@ -695,6 +697,10 @@ export function createWakeArmingContext({
          * @returns {Promise<Object>} `{armed, reason}` outcome for this viewer.
          */
         ensureArmedFor(viewerKey) {
+            if (closed) {
+                return Promise.resolve({armed: false, reason: 'not-armed: arming context closed'})
+            }
+
             const pending = outcomesByViewer.get(viewerKey);
 
             if (pending) return pending;
@@ -759,6 +765,10 @@ export function createWakeArmingContext({
          * @returns {Promise<Object>} `{armed, reason, identity?}` — `identity` is MC-proven.
          */
         ensureArmedForViewer({viewerKey, canonicalClaim, bearer, fleetAdmissionBearer = ''}) {
+            if (closed) {
+                return Promise.resolve({armed: false, reason: 'not-armed: arming context closed'})
+            }
+
             const pending = outcomesByViewer.get(viewerKey);
 
             if (pending) return pending;
@@ -826,6 +836,11 @@ export function createWakeArmingContext({
          * @returns {Promise<void>}
          */
         async close() {
+            // The epoch closes synchronously BEFORE any teardown await: an in-flight mutation
+            // that resolves after this instant finds a closed context and a disposed fan-out,
+            // and ends unarmed instead of resurrecting state into a shutdown.
+            closed = true;
+
             outcomesByViewer.clear();
             proven = null;
 

--- a/ai/services/fleet/fleetServer.mjs
+++ b/ai/services/fleet/fleetServer.mjs
@@ -407,21 +407,24 @@ export async function createFleetServerApp({
             return
         }
 
-        // Connect-time arming, per viewer, with the viewer's OWN presented bearer: the
-        // subscription is created by the viewer's credential (MC's caller-owned model holds
-        // per viewer, no delegation surface), the bearer is used in-flight only, and the
-        // stream registers under the identity MC PROVED for it — never the request's claim.
-        // A viewer without a usable bearer falls back to the service-proven path (which arms
-        // exactly the proven caller) and otherwise lands in the honest not-armed state.
+        // Connect-time arming, per viewer, with a SEPARATELY CARRIED class-3 credential: the
+        // viewer's MC bearer travels in its own header, because the class-1 Fleet admission
+        // bearer (the `Authorization` this route was admitted on) must NEVER be forwarded to
+        // the `/mc/mcp` audience — the ledger's non-alias rule, enforced here by simply never
+        // reading that header for this purpose. With the class-3 credential present, the
+        // subscription is created by the viewer's own MC authority (caller-owned per viewer),
+        // used in-flight only, and the stream registers under the identity MC PROVED — never
+        // the request's claim. Without it, the service-proven path answers (arming exactly the
+        // proven caller) and every other viewer lands in the honest not-armed state.
         let registrationKey = streamKey;
 
         if (app.fleetWakeArming) {
             try {
                 const
-                    bearer         = (req.headers.authorization ?? '').replace(/^Bearer\s+/i, '').trim(),
+                    mcBearer       = (req.headers['x-neo-mc-authorization'] ?? '').replace(/^Bearer\s+/i, '').trim(),
                     canonicalClaim = normalizeAgentIdentity(req.fleetRequestContext.providerUsername ?? req.fleetRequestContext.username),
-                    outcome        = bearer && canonicalClaim
-                        ? await app.fleetWakeArming.ensureArmedForViewer({viewerKey: streamKey, canonicalClaim, bearer})
+                    outcome        = mcBearer && canonicalClaim
+                        ? await app.fleetWakeArming.ensureArmedForViewer({viewerKey: streamKey, canonicalClaim, bearer: mcBearer})
                         : await app.fleetWakeArming.ensureArmedFor(streamKey);
 
                 if (outcome.armed && outcome.identity) {
@@ -519,6 +522,45 @@ export function resolveFleetPlaneBearer({aiConfig = AiConfig, readFile = null} =
 }
 
 /**
+ * @summary The credential-class non-alias teeth: a resolved plane bearer that IS the
+ * deployment's bootstrap/healthcheck admission token is refused. The ledger's load-bearing rule
+ * (class 3 ≠ bootstrap/healthcheck PAT) is otherwise only prose — this makes an aliased
+ * deployment fail at boot, at the one moment someone can mint the distinct credential.
+ * @param {Object} [options]
+ * @param {Object} [options.aiConfig=AiConfig] Resolved Tier-1 config tree.
+ * @param {Function} [options.readFile] Injection seam for tests; defaults to `readFileSync`.
+ * @returns {String} The class-clean resolved bearer (may be `''`).
+ * @throws {Error} When the plane bearer equals the admission token.
+ */
+export function assertFleetPlaneBearerClass({aiConfig = AiConfig, readFile = null} = {}) {
+    const
+        read        = readFile ?? (target => readFileSync(target, 'utf8')),
+        planeBearer = resolveFleetPlaneBearer({aiConfig, readFile: read});
+
+    if (!planeBearer) return planeBearer;
+
+    const admissionFile = aiConfig.fleet.admissionTokenFile.trim();
+
+    let admissionToken = '';
+
+    if (admissionFile) {
+        try {
+            admissionToken = String(read(admissionFile)).trim()
+        } catch {/* an unreadable admission file leaves the comparison disabled, not the rule */}
+    }
+
+    if (admissionToken && planeBearer === admissionToken) {
+        throw new Error(
+            '[FleetServer] fleet.planeBearer resolves to the deployment\'s bootstrap/healthcheck ' +
+            'admission token — the credential-class ledger forbids that aliasing. Mint a distinct ' +
+            'class-3 credential for the Fleet service\'s plane sessions.'
+        )
+    }
+
+    return planeBearer
+}
+
+/**
  * @summary Derives the ONE stream/limiter key for an admitted viewer, from immutable facts only.
  *
  * The plane-proven canonical identity (`@login`, MC's own subject for the arming caller) is the
@@ -600,7 +642,7 @@ export function createWakeArmingContext({
 
                 client = createPlaneClient({
                     baseUrl            : `${planeBase.replace(/\/+$/, '')}/mc/mcp`,
-                    credential         : resolveFleetPlaneBearer({aiConfig}),
+                    credential         : assertFleetPlaneBearerClass({aiConfig}),
                     allowPlainHttpHosts: aiConfig.fleet.planeInternalHosts
                 });
 
@@ -834,10 +876,11 @@ export async function startFleetServer(options={}) {
 
     // A DECLARED wake push lane with no service credential is a dead feature wearing a live
     // topology — this boot refuses loudly instead of arming nothing and letting the first
-    // plane witness discover it. Per-viewer bearers still arm viewers at connect; this gate
-    // is about the service's own lane, whose declaration promised it works.
+    // plane witness discover it. The class teeth run in the same breath: an ALIASED credential
+    // (the bootstrap/healthcheck admission token standing in for the class-3 plane bearer)
+    // throws its own refusal before the dead-feature check can even read it.
     if (aiConfig.fleet.wakeSelfBase.trim() && aiConfig.fleet.planeBase.trim() &&
-        resolveFleetPlaneBearer({aiConfig}) === ''
+        assertFleetPlaneBearerClass({aiConfig}) === ''
     ) {
         throw new Error(
             '[FleetServer] wake push lane is declared (fleet.wakeSelfBase + fleet.planeBase) but no ' +

--- a/ai/services/fleet/fleetWakeFanout.mjs
+++ b/ai/services/fleet/fleetWakeFanout.mjs
@@ -58,6 +58,7 @@ export function createFleetWakeFanout({
     let
         armed        = false,
         armReason    = 'not-armed: arming has not run',
+        disposed     = false,
         lastPushAt   = null,
         totalStreams = 0,
         heartbeatRef = null;
@@ -128,6 +129,12 @@ export function createFleetWakeFanout({
          * @returns {Object} `{accepted: true}`, or `{accepted: false, reason}` with the cap named.
          */
         registerStream(identity, res) {
+            // Disposal is a closed epoch: a handler that awaited across the shutdown boundary
+            // must not hand this registry a response the sweep can never end again.
+            if (disposed) {
+                return {accepted: false, reason: 'stream registry disposed'}
+            }
+
             const existing = streamsByIdentity.get(identity);
 
             if (totalStreams >= maxStreamsTotal) {
@@ -241,6 +248,10 @@ export function createFleetWakeFanout({
          * @returns {Promise<Object>} `{armed: Boolean, reason: String, subscriptionId?}`
          */
         async armRelaySubscription({identity, wakeSelfBase, callTool, trigger = 'SENT_TO_ME'}) {
+            if (disposed) {
+                return {armed: false, reason: 'not-armed: fan-out disposed'}
+            }
+
             if (typeof wakeSelfBase !== 'string' || wakeSelfBase.trim().length === 0) {
                 armed     = false;
                 armReason = 'not-armed: fleet.wakeSelfBase undeclared';
@@ -322,6 +333,15 @@ export function createFleetWakeFanout({
                     return {armed, reason: armReason}
                 }
 
+                // The epoch re-check AFTER the awaits is the load-bearing one: a delayed
+                // subscribe/rotate must never resurrect a route into a disposed registry — the
+                // mutation that crossed the shutdown boundary ends unarmed, not undead.
+                if (disposed) {
+                    armed     = false;
+                    armReason = 'not-armed: fan-out disposed';
+                    return {armed, reason: armReason}
+                }
+
                 routes.set(subscriptionId, {signingKey: rotated.signingKey, agentIdentity: identity});
 
                 armed     = true;
@@ -377,6 +397,13 @@ export function createFleetWakeFanout({
          * all streams and routes.
          */
         dispose() {
+            // The epoch closes FIRST, synchronously: everything still in flight — a delayed
+            // arming mutation, an awaited connect handler — resolves into refusals from this
+            // instant, so the sweep below is the LAST one this registry ever needs.
+            disposed  = true;
+            armed     = false;
+            armReason = 'not-armed: fan-out disposed';
+
             if (heartbeatRef) {
                 clearInterval(heartbeatRef);
                 heartbeatRef = null

--- a/ai/services/fleet/fleetWakeFanout.mjs
+++ b/ai/services/fleet/fleetWakeFanout.mjs
@@ -62,7 +62,9 @@ export function createFleetWakeFanout({
         totalStreams = 0,
         heartbeatRef = null;
 
-    const cleanupByStream = new Map(); // res -> idempotent cleanup fn
+    const
+        cleanupByStream  = new Map(), // res -> idempotent cleanup fn
+        armingByIdentity = new Map(); // identity -> in-flight arming mutation promise
 
     /**
      * One faulty consumer must never take the lane down: a throwing write or a consumer whose
@@ -250,6 +252,32 @@ export function createFleetWakeFanout({
                 armReason = 'not-armed: no authenticated plane client';
                 return {armed, reason: armReason}
             }
+
+            // The WHOLE mutation — subscribe → rotate-key → route install — is serialized per
+            // identity: two racing callers (boot arming and the first SSE connect are the
+            // measured pair) would otherwise run two rotations, leaving MC on the second key
+            // while this registry holds the first — every subsequent signed delivery then
+            // fails verification. One in-flight promise per identity; concurrent callers share
+            // its outcome, and the latch clears on settle so a FAILED arming stays retryable.
+            const inFlight = armingByIdentity.get(identity);
+
+            if (inFlight) return inFlight;
+
+            const mutation = this._armRelaySubscription({identity, wakeSelfBase, callTool, trigger})
+                .finally(() => armingByIdentity.delete(identity));
+
+            armingByIdentity.set(identity, mutation);
+            return mutation
+        },
+
+        /**
+         * @summary The unserialized arming mutation — reach it only through
+         * {@link armRelaySubscription}'s per-identity latch.
+         * @param {Object} options See {@link armRelaySubscription}.
+         * @returns {Promise<Object>} `{armed, reason, subscriptionId?}`
+         * @private
+         */
+        async _armRelaySubscription({identity, wakeSelfBase, callTool, trigger}) {
 
             let url;
 

--- a/ai/services/fleet/fleetWakeFanout.mjs
+++ b/ai/services/fleet/fleetWakeFanout.mjs
@@ -27,7 +27,9 @@
  * event says so. Absence of signal, never a verdict — the tier-degradation presence contract.
  */
 
-const HEARTBEAT_COMMENT = ':hb\n\n';
+const
+    HEARTBEAT_COMMENT  = ':hb\n\n',
+    MAX_BUFFERED_BYTES = 256 * 1024;
 
 /**
  * @summary Creates the fan-out registry.
@@ -60,13 +62,47 @@ export function createFleetWakeFanout({
         totalStreams = 0,
         heartbeatRef = null;
 
+    const cleanupByStream = new Map(); // res -> idempotent cleanup fn
+
+    /**
+     * One faulty consumer must never take the lane down: a throwing write or a consumer whose
+     * kernel buffer has grown past the bound is EVICTED — its response destroyed, its slot
+     * freed — and delivery continues to the remaining healthy streams. The bound is what makes
+     * backpressure finite: SSE has no per-client replay (poll-digest is the catch-up), so
+     * buffering an unread client indefinitely would trade one slow consumer for process memory.
+     */
+    function safeWrite(res, chunk) {
+        try {
+            if ((res.writableLength ?? 0) > MAX_BUFFERED_BYTES) {
+                evictStream(res);
+                return false
+            }
+
+            res.write(chunk);
+            return true
+        } catch {
+            evictStream(res);
+            return false
+        }
+    }
+
+    function evictStream(res) {
+        const cleanup = cleanupByStream.get(res);
+
+        cleanup?.();
+
+        try {
+            res.destroy?.()
+        } catch {/* eviction is best-effort teardown of an already-faulty stream */}
+    }
+
     function ensureHeartbeat() {
         if (heartbeatRef || heartbeatMs <= 0) return;
 
         heartbeatRef = setInterval(() => {
             for (const streams of streamsByIdentity.values()) {
-                for (const res of streams) {
-                    res.write(HEARTBEAT_COMMENT)
+                for (const res of [...streams]) {
+                    safeWrite(res, HEARTBEAT_COMMENT)
                 }
             }
         }, heartbeatMs);
@@ -76,7 +112,7 @@ export function createFleetWakeFanout({
     }
 
     function writeEvent(res, event, payload) {
-        res.write(`event: ${event}\ndata: ${JSON.stringify(payload)}\n\n`)
+        return safeWrite(res, `event: ${event}\ndata: ${JSON.stringify(payload)}\n\n`)
     }
 
     return {
@@ -100,15 +136,27 @@ export function createFleetWakeFanout({
                 return {accepted: false, reason: 'stream cap reached (per viewer)'}
             }
 
-            res.writeHead(200, {
-                'content-type'     : 'text/event-stream',
-                'cache-control'    : 'no-cache, no-transform',
-                connection         : 'keep-alive',
-                'x-accel-buffering': 'no'
-            });
+            // The whole handshake must land before the stream is registered: a socket that
+            // faults or is already past the backpressure bound during these writes is refused
+            // (and destroyed by the eviction path) WITHOUT ever entering the registry — a
+            // dead-at-birth stream must not hold a cap slot until a close event that may never
+            // fire on it.
+            try {
+                res.writeHead(200, {
+                    'content-type'     : 'text/event-stream',
+                    'cache-control'    : 'no-cache, no-transform',
+                    connection         : 'keep-alive',
+                    'x-accel-buffering': 'no'
+                })
+            } catch {
+                return {accepted: false, reason: 'stream rejected at handshake'}
+            }
 
-            res.write('retry: 5000\n\n');
-            writeEvent(res, 'state', this.describeStateFor(identity));
+            if (!safeWrite(res, 'retry: 5000\n\n') ||
+                !writeEvent(res, 'state', this.describeStateFor(identity))
+            ) {
+                return {accepted: false, reason: 'stream rejected at handshake'}
+            }
 
             let streams = existing;
 
@@ -121,7 +169,9 @@ export function createFleetWakeFanout({
             totalStreams++;
             ensureHeartbeat();
 
-            res.on('close', () => {
+            // ONE idempotent cleanup shared by every exit — client close, socket error, cap
+            // eviction, shutdown disposal — so no path can double-decrement or leak a slot.
+            const cleanup = () => {
                 if (streams.delete(res)) {
                     totalStreams--
                 }
@@ -129,7 +179,13 @@ export function createFleetWakeFanout({
                 if (streams.size === 0) {
                     streamsByIdentity.delete(identity)
                 }
-            });
+
+                cleanupByStream.delete(res)
+            };
+
+            cleanupByStream.set(res, cleanup);
+            res.on('close', cleanup);
+            res.on('error', cleanup);
 
             return {accepted: true}
         },
@@ -160,7 +216,9 @@ export function createFleetWakeFanout({
 
             if (!streams || streams.size === 0) return;
 
-            for (const res of streams) {
+            // A snapshot copy: an eviction mutates the live Set mid-loop, and a faulty first
+            // stream must never cost the healthy second its delivery.
+            for (const res of [...streams]) {
                 writeEvent(res, 'wake', {subscriptionId, envelope})
             }
         },
@@ -286,7 +344,9 @@ export function createFleetWakeFanout({
         },
 
         /**
-         * @summary Test/shutdown hook: stops the heartbeat and forgets all streams and routes.
+         * @summary Shutdown/test hook: stops the heartbeat and ENDS every held SSE response —
+         * a held stream would otherwise keep `server.close()` waiting forever — then forgets
+         * all streams and routes.
          */
         dispose() {
             if (heartbeatRef) {
@@ -294,7 +354,20 @@ export function createFleetWakeFanout({
                 heartbeatRef = null
             }
 
+            for (const streams of streamsByIdentity.values()) {
+                for (const res of [...streams]) {
+                    try {
+                        res.end()
+                    } catch {/* a stream that cannot end cleanly is destroyed below */}
+
+                    try {
+                        res.destroy?.()
+                    } catch {/* best-effort */}
+                }
+            }
+
             streamsByIdentity.clear();
+            cleanupByStream.clear();
             routes.clear();
             totalStreams = 0
         }

--- a/ai/services/fleet/fleetWakeFanout.mjs
+++ b/ai/services/fleet/fleetWakeFanout.mjs
@@ -1,0 +1,272 @@
+/**
+ * @module ai/services/fleet/fleetWakeFanout
+ * @summary SSE fan-out registry + relay-subscription self-arming for the composed fleet
+ * server's wake push lane.
+ *
+ * **Push for latency, poll for truth.** This module owns the latency half's server side: it
+ * keeps the identity-keyed registry of connected SSE streams, routes one verified wake digest
+ * to exactly the streams authenticated as that digest's subscription identity, and self-arms
+ * the relay wake subscription over the authenticated MC surface at boot. The truth half is the
+ * shipped `poll-digest` verb consumed by the client on every reconnect — a dropped
+ * stream loses nothing durable, so this fan-out deliberately owns NO replay state.
+ *
+ * **Identity isolation is structural.** Streams register under the viewer identity the fleet
+ * app's admission chain proved; digests route by the subscription's `agentIdentity` recorded at
+ * arming time. A digest for identity A can never reach identity B's stream because the lookup
+ * key IS the identity — there is no broadcast path. (The fleet server is single-viewer today —
+ * the boot-resolved viewer, `planeMailboxClient`'s proven-subject invariant; the registry is
+ * identity-keyed anyway so the S5 viewer-scoping leg widens it without reshaping.)
+ *
+ * **Key custody (process-bearer class).** `subscribe` is idempotent and returns the
+ * server-issued signing key only on fresh mint, so arming always finishes with `rotate-key`:
+ * the key this process holds is minted for this process lifetime, lives in memory only, and a
+ * restart re-arms with a fresh key. Nothing persists a secret.
+ *
+ * **Honest absence.** No dialable self-address (`fleet.wakeSelfBase` empty) or no plane client
+ * means the push lane is NOT armed — `describeState()` carries the reason, and the SSE `state`
+ * event says so. Absence of signal, never a verdict — the tier-degradation presence contract.
+ */
+
+const HEARTBEAT_COMMENT = ':hb\n\n';
+
+/**
+ * @summary Creates the fan-out registry.
+ * @param {Object} [options]
+ * @param {Object} [options.logger=console]
+ * @param {Number} [options.heartbeatMs=25000] SSE keep-alive comment cadence; bounds proxy
+ *     idle-timeout kills without pretending to be a liveness proof.
+ * @param {Function} [options.now=Date.now] Injection seam for observational timestamps.
+ * @returns {Object} The fan-out surface consumed by the fleet server boot entry.
+ */
+export function createFleetWakeFanout({logger = console, heartbeatMs = 25000, now = Date.now} = {}) {
+    const
+        streamsByIdentity = new Map(), // identity -> Set<res>
+        routes            = new Map(); // subscriptionId -> {signingKey, agentIdentity}
+
+    let
+        armed        = false,
+        armReason    = 'not-armed: arming has not run',
+        lastPushAt   = null,
+        heartbeatRef = null;
+
+    function ensureHeartbeat() {
+        if (heartbeatRef || heartbeatMs <= 0) return;
+
+        heartbeatRef = setInterval(() => {
+            for (const streams of streamsByIdentity.values()) {
+                for (const res of streams) {
+                    res.write(HEARTBEAT_COMMENT)
+                }
+            }
+        }, heartbeatMs);
+
+        // A registry with zero streams must never hold the process open.
+        heartbeatRef.unref?.()
+    }
+
+    function writeEvent(res, event, payload) {
+        res.write(`event: ${event}\ndata: ${JSON.stringify(payload)}\n\n`)
+    }
+
+    return {
+        /**
+         * @summary Registers one authenticated SSE stream and takes over the response for its
+         * lifetime. The caller has already proven `identity` through the fleet admission chain.
+         * @param {String} identity Viewer identity the admission chain proved.
+         * @param {Object} res Node `ServerResponse`-shaped writable to convert to SSE.
+         */
+        registerStream(identity, res) {
+            res.writeHead(200, {
+                'content-type'     : 'text/event-stream',
+                'cache-control'    : 'no-cache, no-transform',
+                connection         : 'keep-alive',
+                'x-accel-buffering': 'no'
+            });
+
+            res.write('retry: 5000\n\n');
+            writeEvent(res, 'state', this.describeStateFor(identity));
+
+            let streams = streamsByIdentity.get(identity);
+
+            if (!streams) {
+                streams = new Set();
+                streamsByIdentity.set(identity, streams)
+            }
+
+            streams.add(res);
+            ensureHeartbeat();
+
+            res.on('close', () => {
+                streams.delete(res);
+
+                if (streams.size === 0) {
+                    streamsByIdentity.delete(identity)
+                }
+            })
+        },
+
+        /**
+         * @summary Route table read for the wake receiver — in-memory only, armed keys never
+         * persist.
+         * @param {String} subscriptionId
+         * @returns {Object|null} `{signingKey, agentIdentity}` or null.
+         */
+        resolveRoute(subscriptionId) {
+            return routes.get(subscriptionId) ?? null
+        },
+
+        /**
+         * @summary Delivers one verified digest to the streams of exactly its subscription's
+         * identity. No streams connected is a normal state, not a failure — derive-at-read
+         * covers the gap on the client's next poll.
+         * @param {Object} data
+         * @param {String} data.subscriptionId
+         * @param {String} data.agentIdentity
+         * @param {Object} data.envelope Verified digest payload.
+         */
+        handleDigest({subscriptionId, agentIdentity, envelope}) {
+            lastPushAt = now();
+
+            const streams = streamsByIdentity.get(agentIdentity);
+
+            if (!streams || streams.size === 0) return;
+
+            for (const res of streams) {
+                writeEvent(res, 'wake', {subscriptionId, envelope})
+            }
+        },
+
+        /**
+         * @summary Self-arms the relay wake subscription for the boot viewer over the
+         * authenticated MC surface: idempotent `subscribe` (route tuple: Shape-B webhook at
+         * `<wakeSelfBase>/wake`) followed by `rotate-key`, whose returned key becomes this
+         * process's in-memory route entry. Every refusal path returns `{armed: false, reason}`
+         * instead of throwing — an unarmed push lane is a rendered state, not a boot failure.
+         * @param {Object} options
+         * @param {String} options.identity The boot-resolved viewer identity (route owner).
+         * @param {String} options.wakeSelfBase `AiConfig.fleet.wakeSelfBase`, read by the entry.
+         * @param {Function|null} options.callTool `planeMailboxClient`-shaped
+         *     `(name, args) => result` against the plane MC surface, or null when no plane
+         *     client is bound.
+         * @param {String} [options.trigger='SENT_TO_ME']
+         * @returns {Promise<Object>} `{armed: Boolean, reason: String, subscriptionId?}`
+         */
+        async armRelaySubscription({identity, wakeSelfBase, callTool, trigger = 'SENT_TO_ME'}) {
+            if (typeof wakeSelfBase !== 'string' || wakeSelfBase.trim().length === 0) {
+                armed     = false;
+                armReason = 'not-armed: fleet.wakeSelfBase undeclared';
+                return {armed, reason: armReason}
+            }
+
+            if (typeof callTool !== 'function') {
+                armed     = false;
+                armReason = 'not-armed: no authenticated plane client';
+                return {armed, reason: armReason}
+            }
+
+            let url;
+
+            try {
+                url          = new URL(wakeSelfBase);
+                url.pathname = '/wake';
+                url.search   = '';
+                url.hash     = ''
+            } catch {
+                armed     = false;
+                armReason = 'not-armed: fleet.wakeSelfBase is not a valid URL';
+                return {armed, reason: armReason}
+            }
+
+            try {
+                const subscribed = await callTool('manage_wake_subscription', {
+                    action               : 'subscribe',
+                    trigger,
+                    harnessTarget        : 'a2a-webhook',
+                    harnessTargetMetadata: {adapter: 'a2a-webhook', url: url.href}
+                });
+
+                const subscriptionId = subscribed?.subscriptionId;
+
+                if (!subscriptionId) {
+                    armed     = false;
+                    armReason = 'not-armed: subscribe returned no subscriptionId';
+                    return {armed, reason: armReason}
+                }
+
+                // Idempotent reuse returns no key, and a key from a previous process life is
+                // gone with that process — rotation is therefore unconditional, and the one
+                // sanctioned rotation door (`rotate-key`) makes this restart-safe by design.
+                const rotated = await callTool('manage_wake_subscription', {
+                    action: 'rotate-key',
+                    subscriptionId
+                });
+
+                if (typeof rotated?.signingKey !== 'string' || rotated.signingKey.length === 0) {
+                    armed     = false;
+                    armReason = 'not-armed: rotate-key returned no signing key';
+                    return {armed, reason: armReason}
+                }
+
+                routes.set(subscriptionId, {signingKey: rotated.signingKey, agentIdentity: identity});
+
+                armed     = true;
+                armReason = 'armed';
+
+                return {armed, reason: armReason, subscriptionId}
+            } catch (error) {
+                armed     = false;
+                armReason = 'not-armed: relay subscription arming failed';
+                logger.error?.(`[FleetWakeFanout] arming failed: ${error?.message ?? error}`);
+                return {armed, reason: armReason}
+            }
+        },
+
+        /**
+         * @summary Observational state for the wake-routes axis — absence carries its reason,
+         * never a verdict.
+         * @returns {Object} `{armed, reason, lastPushAt, connectedIdentities}`
+         */
+        describeState() {
+            return {
+                armed,
+                reason             : armReason,
+                lastPushAt,
+                connectedIdentities: streamsByIdentity.size
+            }
+        },
+
+        /**
+         * @summary Per-viewer honest state for the SSE `state` event: arming is caller-owned
+         * on the MC side, so the push lane can be armed for the relay viewer while a different
+         * authenticated viewer's stream truthfully reports it is not armed FOR THEM — their
+         * truth lane is poll-digest either way.
+         * @param {String} identity
+         * @returns {Object} `describeState()` plus `{armedForViewer: Boolean}`
+         */
+        describeStateFor(identity) {
+            let armedForViewer = false;
+
+            for (const route of routes.values()) {
+                if (route.agentIdentity === identity) {
+                    armedForViewer = true;
+                    break
+                }
+            }
+
+            return {...this.describeState(), armedForViewer}
+        },
+
+        /**
+         * @summary Test/shutdown hook: stops the heartbeat and forgets all streams and routes.
+         */
+        dispose() {
+            if (heartbeatRef) {
+                clearInterval(heartbeatRef);
+                heartbeatRef = null
+            }
+
+            streamsByIdentity.clear();
+            routes.clear()
+        }
+    }
+}

--- a/ai/services/fleet/fleetWakeFanout.mjs
+++ b/ai/services/fleet/fleetWakeFanout.mjs
@@ -35,10 +35,20 @@ const HEARTBEAT_COMMENT = ':hb\n\n';
  * @param {Object} [options.logger=console]
  * @param {Number} [options.heartbeatMs=25000] SSE keep-alive comment cadence; bounds proxy
  *     idle-timeout kills without pretending to be a liveness proof.
+ * @param {Number} [options.maxStreamsPerIdentity=8] Concurrent open streams one viewer may
+ *     hold (tabs, reconnect races); the excess is refused with its reason, not queued.
+ * @param {Number} [options.maxStreamsTotal=64] Process-wide held-connection ceiling — the
+ *     resource bound a request-rate limiter cannot express.
  * @param {Function} [options.now=Date.now] Injection seam for observational timestamps.
  * @returns {Object} The fan-out surface consumed by the fleet server boot entry.
  */
-export function createFleetWakeFanout({logger = console, heartbeatMs = 25000, now = Date.now} = {}) {
+export function createFleetWakeFanout({
+    logger               = console,
+    heartbeatMs          = 25000,
+    maxStreamsPerIdentity = 8,
+    maxStreamsTotal      = 64,
+    now                  = Date.now
+} = {}) {
     const
         streamsByIdentity = new Map(), // identity -> Set<res>
         routes            = new Map(); // subscriptionId -> {signingKey, agentIdentity}
@@ -47,6 +57,7 @@ export function createFleetWakeFanout({logger = console, heartbeatMs = 25000, no
         armed        = false,
         armReason    = 'not-armed: arming has not run',
         lastPushAt   = null,
+        totalStreams = 0,
         heartbeatRef = null;
 
     function ensureHeartbeat() {
@@ -71,11 +82,24 @@ export function createFleetWakeFanout({logger = console, heartbeatMs = 25000, no
     return {
         /**
          * @summary Registers one authenticated SSE stream and takes over the response for its
-         * lifetime. The caller has already proven `identity` through the fleet admission chain.
+         * lifetime — unless a held-connection cap refuses it, in which case NOTHING is written
+         * and the caller answers the refusal on the still-untouched response. The caller has
+         * already proven `identity` through the fleet admission chain.
          * @param {String} identity Viewer identity the admission chain proved.
          * @param {Object} res Node `ServerResponse`-shaped writable to convert to SSE.
+         * @returns {Object} `{accepted: true}`, or `{accepted: false, reason}` with the cap named.
          */
         registerStream(identity, res) {
+            const existing = streamsByIdentity.get(identity);
+
+            if (totalStreams >= maxStreamsTotal) {
+                return {accepted: false, reason: 'stream cap reached (total)'}
+            }
+
+            if ((existing?.size ?? 0) >= maxStreamsPerIdentity) {
+                return {accepted: false, reason: 'stream cap reached (per viewer)'}
+            }
+
             res.writeHead(200, {
                 'content-type'     : 'text/event-stream',
                 'cache-control'    : 'no-cache, no-transform',
@@ -86,7 +110,7 @@ export function createFleetWakeFanout({logger = console, heartbeatMs = 25000, no
             res.write('retry: 5000\n\n');
             writeEvent(res, 'state', this.describeStateFor(identity));
 
-            let streams = streamsByIdentity.get(identity);
+            let streams = existing;
 
             if (!streams) {
                 streams = new Set();
@@ -94,15 +118,20 @@ export function createFleetWakeFanout({logger = console, heartbeatMs = 25000, no
             }
 
             streams.add(res);
+            totalStreams++;
             ensureHeartbeat();
 
             res.on('close', () => {
-                streams.delete(res);
+                if (streams.delete(res)) {
+                    totalStreams--
+                }
 
                 if (streams.size === 0) {
                     streamsByIdentity.delete(identity)
                 }
-            })
+            });
+
+            return {accepted: true}
         },
 
         /**
@@ -266,7 +295,8 @@ export function createFleetWakeFanout({logger = console, heartbeatMs = 25000, no
             }
 
             streamsByIdentity.clear();
-            routes.clear()
+            routes.clear();
+            totalStreams = 0
         }
     }
 }

--- a/ai/services/fleet/fleetWakeReceiver.mjs
+++ b/ai/services/fleet/fleetWakeReceiver.mjs
@@ -81,6 +81,8 @@ export function createFleetWakeReceiver({resolveRoute, onDigest, logger = consol
     return async function fleetWakeReceiver(req, res) {
         const
             subscriptionId = req.headers['x-neo-wake-subscription-id'],
+            eventId        = req.headers['x-neo-wake-event-id'],
+            schemaVersion  = req.headers['x-neo-wake-schema-version'],
             signature      = req.headers['x-neo-wake-signature'],
             route          = subscriptionId ? resolveRoute(subscriptionId) : null;
 
@@ -109,6 +111,22 @@ export function createFleetWakeReceiver({resolveRoute, onDigest, logger = consol
             envelope = JSON.parse(rawBody.toString('utf8'))
         } catch {
             res.status(400).json({error: 'invalid-json'});
+            return
+        }
+
+        // The full signed route binding, mirroring the host receiver verbatim: an authentic
+        // signature proves the bytes came from the key holder, and only THIS check proves the
+        // bytes describe the route they arrived on. Every mismatch — envelope facts against
+        // headers and against the resolved route — is the canonical `signed-route-mismatch`,
+        // refused before any fan-out.
+        if (envelope?.eventId !== eventId ||
+            envelope?.subscriptionId !== subscriptionId ||
+            envelope?.agentIdentity !== route.agentIdentity ||
+            envelope?.eventType !== 'wake/digest' ||
+            envelope?.schemaVersion !== '1.0' ||
+            schemaVersion !== envelope.schemaVersion
+        ) {
+            res.status(409).json({error: 'signed-route-mismatch'});
             return
         }
 

--- a/ai/services/fleet/fleetWakeReceiver.mjs
+++ b/ai/services/fleet/fleetWakeReceiver.mjs
@@ -1,0 +1,126 @@
+import {verifyWakeSignature} from '../../daemons/wake/receiver.mjs';
+
+/**
+ * @module ai/services/fleet/fleetWakeReceiver
+ * @summary The composed fleet-server's signed wake receiver — the Shape-B listener a
+ * no-checkout client cannot host, moved onto the plane.
+ *
+ * The producer is the Memory Core's `WebhookDeliveryService` (the signed Shape-B dispatcher):
+ * it POSTs the digest body with the four `X-Neo-Wake-*` headers and an HMAC-SHA256 signature
+ * over the EXACT body bytes, keyed by the per-subscription server-issued signing key. This
+ * receiver mirrors the host receiver's admission contract (`ai/daemons/wake/receiver.mjs`) —
+ * same headers, same shared {@link verifyWakeSignature}, and the same error vocabulary, which
+ * is load-bearing: the dispatcher's manifest-lag tolerance keys on the literal
+ * `unknown-subscription` error string (`WebhookDeliveryService#_isUnknownSubscriptionResponse`).
+ *
+ * **Admission is the signature, deliberately and exclusively.** The route mounts BEFORE the
+ * fleet app's client-auth chain (AuthService admission, identity projection, JSON parser):
+ * the wake dispatcher authenticates with the per-subscription signed-wake HMAC (its own
+ * credential class in the fleet ledger), never a
+ * provider bearer, and the signature over exact body bytes is a stronger statement than any
+ * ambient property of the request. Reachability is never authentication, so the route stays
+ * compose-internal AND signed: `/wake` is deliberately absent from
+ * the ingress route table (`ai/deploy/Caddyfile*`).
+ *
+ * The raw body is read manually — a JSON body parser upstream would re-serialize and destroy
+ * the exact bytes the HMAC covers.
+ */
+
+/**
+ * @summary Reads the request body as a raw Buffer with a hard byte cap.
+ * @param {Object} req Node `IncomingMessage`-shaped readable (headers + data/end events).
+ * @param {Number} maxBodyBytes
+ * @returns {Promise<Buffer>} Rejects with `{code: 'body-too-large'}` past the cap.
+ * @private
+ */
+function readRawBody(req, maxBodyBytes) {
+    return new Promise((resolve, reject) => {
+        const chunks = [];
+        let   total  = 0;
+
+        req.on('data', chunk => {
+            total += chunk.length;
+
+            if (total > maxBodyBytes) {
+                reject(Object.assign(new Error('body too large'), {code: 'body-too-large'}));
+                req.destroy();
+                return
+            }
+
+            chunks.push(chunk)
+        });
+
+        req.on('end',   () => resolve(Buffer.concat(chunks)));
+        req.on('error', reject)
+    })
+}
+
+/**
+ * @summary Creates the exact-route `POST /wake` handler for the composed fleet server.
+ *
+ * Admission ladder, in order and fail-closed: route known (`unknown-subscription`, 404 — the
+ * exact string the dispatcher's manifest-lag tolerance recognises) → signature valid over the
+ * exact raw bytes (`invalid-signature`, 401) → body parses (`invalid-json`, 400) → the digest
+ * is handed to `onDigest` and acknowledged. The handler never throws into Express: every
+ * outcome is a terminal JSON response.
+ *
+ * @param {Object} options
+ * @param {Function} options.resolveRoute `(subscriptionId) => {signingKey, agentIdentity}|null` —
+ *     the fan-out registry's in-memory route table (self-armed at boot; keys never persisted).
+ * @param {Function} options.onDigest `({subscriptionId, agentIdentity, envelope}) => void` —
+ *     receives one verified digest; delivery to streams is the fan-out's concern.
+ * @param {Object} [options.logger=console]
+ * @param {Number} [options.maxBodyBytes=262144] Digests are small; the cap bounds a hostile peer.
+ * @returns {Function} Express-compatible `(req, res)` handler for the exact `POST /wake` route.
+ */
+export function createFleetWakeReceiver({resolveRoute, onDigest, logger = console, maxBodyBytes = 256 * 1024}) {
+    if (typeof resolveRoute !== 'function' || typeof onDigest !== 'function') {
+        throw new Error('createFleetWakeReceiver requires resolveRoute and onDigest functions')
+    }
+
+    return async function fleetWakeReceiver(req, res) {
+        const
+            subscriptionId = req.headers['x-neo-wake-subscription-id'],
+            signature      = req.headers['x-neo-wake-signature'],
+            route          = subscriptionId ? resolveRoute(subscriptionId) : null;
+
+        if (!route) {
+            res.status(404).json({error: 'unknown-subscription'});
+            return
+        }
+
+        let rawBody;
+
+        try {
+            rawBody = await readRawBody(req, maxBodyBytes)
+        } catch (error) {
+            res.status(error?.code === 'body-too-large' ? 413 : 400).json({error: 'invalid-body'});
+            return
+        }
+
+        if (!verifyWakeSignature(rawBody, route.signingKey, signature)) {
+            res.status(401).json({error: 'invalid-signature'});
+            return
+        }
+
+        let envelope;
+
+        try {
+            envelope = JSON.parse(rawBody.toString('utf8'))
+        } catch {
+            res.status(400).json({error: 'invalid-json'});
+            return
+        }
+
+        try {
+            onDigest({subscriptionId, agentIdentity: route.agentIdentity, envelope})
+        } catch (error) {
+            // Delivery-side faults are the receiver's to absorb, never the dispatcher's to
+            // retry: the digest was authentically received, and derive-at-read (poll-digest)
+            // makes any downstream loss recoverable on the next catch-up.
+            logger.error?.(`[FleetWakeReceiver] onDigest failed for ${subscriptionId}`)
+        }
+
+        res.status(200).json({ok: true, state: 'accepted'})
+    }
+}

--- a/ai/services/fleet/mcpWireParsing.mjs
+++ b/ai/services/fleet/mcpWireParsing.mjs
@@ -35,12 +35,24 @@ function canonicalize(url) {
  * and TLS required for anything remote — plain `http:` survives only for exact loopback hosts,
  * where there is no network hop to intercept. Returns the canonical endpoint or `null`.
  *
- * One policy, two consumers: the tenant connect flow (`FleetTenantService.normalizeEndpoint`) and
- * the plane mailbox client validate through this single definition.
+ * One deliberate widening exists, and it is caller-declared rather than ambient:
+ * `allowPlainHttpHosts` names exact additional hostnames a DEPLOYMENT vouches for as
+ * confidential internal hops (compose-network service DNS, where the "network hop" is a
+ * container bridge the deployment itself owns). The default is empty, which keeps this function
+ * byte-for-byte the strict policy; an unnamed internal host is a shadow topology and stays
+ * refused. The hop still never substitutes for admission — the credential requirement is
+ * unchanged on every path.
+ *
+ * One policy, two consumers: the tenant connect flow (`FleetTenantService.normalizeEndpoint`)
+ * and the plane mailbox client validate through this single definition. The tenant flow passes
+ * no allowance and is therefore unwidened by construction.
  * @param {*} candidateUrl
+ * @param {Object} [options]
+ * @param {String[]} [options.allowPlainHttpHosts=[]] Exact hostnames the deployment declares as
+ *     confidential internal hops for plain `http:` dialing.
  * @returns {String|null}
  */
-export function normalizeSecureMcpEndpoint(candidateUrl) {
+export function normalizeSecureMcpEndpoint(candidateUrl, {allowPlainHttpHosts = []} = {}) {
     if (typeof candidateUrl !== 'string' || candidateUrl.trim() === '') return null;
 
     let url;
@@ -56,6 +68,10 @@ export function normalizeSecureMcpEndpoint(candidateUrl) {
     if (url.protocol === 'https:') return canonicalize(url);
 
     if (url.protocol === 'http:' && LOOPBACK_HOSTS.has(url.hostname)) return canonicalize(url);
+
+    if (url.protocol === 'http:' && Array.isArray(allowPlainHttpHosts) && allowPlainHttpHosts.includes(url.hostname)) {
+        return canonicalize(url)
+    }
 
     return null
 }

--- a/ai/services/fleet/planeMailboxClient.mjs
+++ b/ai/services/fleet/planeMailboxClient.mjs
@@ -59,11 +59,14 @@ import {
  *     custom-fetch option; defaults to global `fetch`.
  * @param {Function} [options.createSession] Full session-factory override for tests:
  *     `() => {client, transport}` with SDK-compatible shapes. Defaults to the real SDK pair.
+ * @param {String[]} [options.allowPlainHttpHosts=[]] Deployment-declared confidential internal
+ *     hostnames forwarded to the shared endpoint policy (compose-internal service DNS); empty
+ *     keeps the strict loopback-or-TLS rule unchanged.
  * @returns {Object} `{init, callTool, listMessages, addMessage, close}`
  * @throws {Error} When the endpoint fails the shared secure-endpoint policy.
  */
-export function createPlaneMailboxClient({baseUrl, credential = '', fetchImpl = null, createSession = null}) {
-    const endpoint = normalizeSecureMcpEndpoint(baseUrl);
+export function createPlaneMailboxClient({baseUrl, credential = '', fetchImpl = null, createSession = null, allowPlainHttpHosts = []}) {
+    const endpoint = normalizeSecureMcpEndpoint(baseUrl, {allowPlainHttpHosts});
 
     if (!endpoint) {
         throw new Error(

--- a/test/playwright/unit/ai/services/fleet/FleetServerComposition.spec.mjs
+++ b/test/playwright/unit/ai/services/fleet/FleetServerComposition.spec.mjs
@@ -78,14 +78,22 @@ test.describe('FleetServerComposition - ingress and compose polarity for the wak
         expect(composeYaml).not.toMatch(/NEO_FLEET_PLANE_BEARER: (?!\$\{)[^\s]/)
     });
 
-    test('the canonical render carries a REAL service credential: the mounted admission secret, by file custody', () => {
-        expect(composeYaml).toContain('NEO_FLEET_PLANE_BEARER_FILE: /run/secrets/mcp-auth-token');
+    test('the canonical render carries a DEDICATED class-3 service credential by file custody — never the admission token', () => {
+        expect(composeYaml).toContain('NEO_FLEET_PLANE_BEARER_FILE: /run/secrets/fleet-plane-token');
 
-        // The fleet-server service already mounts that exact secret. Anchored on the service
-        // KEY's line shape — the wake self-base URL contains the same literal mid-line.
+        // Separated-token teeth at the render level: the plane bearer's file and the
+        // bootstrap/healthcheck admission token's file are DISTINCT paths.
+        expect(composeYaml).not.toContain('NEO_FLEET_PLANE_BEARER_FILE: /run/secrets/mcp-auth-token');
+
+        // Anchored on the service KEY's line shape — the wake self-base URL contains the same
+        // literal mid-line.
         const fleetService = composeYaml.split(/\n  fleet-server:\n/)[1].split(/\n  \S+:\n/)[0];
 
-        expect(fleetService).toContain('- mcp-auth-token')
+        expect(fleetService).toContain('- fleet-plane-token');
+
+        // And the secret itself is declared with the profile's loud-at-start custody shape.
+        expect(composeYaml).toContain('fleet-plane-token:');
+        expect(composeYaml).toContain('${NEO_FLEET_PLANE_TOKEN_FILE:-${HOME}/.neo-ai/secrets/fleet-plane-token}')
     });
 
     test('the ingress the arming path dials is the address the local Caddyfile actually binds', () => {
@@ -261,7 +269,11 @@ test.describe('FleetServerComposition - per-viewer ownership through the real se
             viewersByBearer = {
                 'ada-token'    : {login: 'ada', providerUserId: 1, identity: '@ada'},
                 'grace-token'  : {login: 'grace', providerUserId: 2, identity: '@grace'},
-                'service-token': {login: 'svc', providerUserId: 9, identity: '@svc'}
+                'service-token': {login: 'svc', providerUserId: 9, identity: '@svc'},
+                // The class-3 mints — DISTINCT credentials for the same viewers, because the
+                // ledger forbids the class-1 admission bearer from serving the MC audience.
+                'ada-mc-token'  : {login: 'ada', providerUserId: 1, identity: '@ada'},
+                'grace-mc-token': {login: 'grace', providerUserId: 2, identity: '@grace'}
             },
             keysByIdentity = {},
             toolCallsByIdentity = {};
@@ -306,6 +318,7 @@ test.describe('FleetServerComposition - per-viewer ownership through the real se
                         planeBase         : 'http://ingress:8080',
                         planeBearer       : 'service-token',
                         planeBearerFile   : '',
+                        admissionTokenFile: '',
                         planeInternalHosts: ['ingress']
                     }
                 },
@@ -343,10 +356,14 @@ test.describe('FleetServerComposition - per-viewer ownership through the real se
 
         const base = `http://127.0.0.1:${server.address().port}`;
 
-        async function connectSse(bearer) {
-            const response = await fetch(`${base}/fleet/events`, {
-                headers: {accept: 'text/event-stream', authorization: `Bearer ${bearer}`}
-            });
+        async function connectSse(fleetBearer, mcBearer = null) {
+            const headers = {accept: 'text/event-stream', authorization: `Bearer ${fleetBearer}`};
+
+            if (mcBearer) {
+                headers['x-neo-mc-authorization'] = `Bearer ${mcBearer}`
+            }
+
+            const response = await fetch(`${base}/fleet/events`, {headers});
 
             expect(response.status).toBe(200);
 
@@ -358,11 +375,19 @@ test.describe('FleetServerComposition - per-viewer ownership through the real se
         }
 
         try {
-            const
-                adaReader   = await connectSse('ada-token'),
-                graceReader = await connectSse('grace-token');
+            // The non-alias falsifier FIRST: a viewer presenting ONLY the class-1 Fleet
+            // admission bearer arms NOTHING — that header is never forwarded to /mc/mcp.
+            const classOneOnly = await connectSse('ada-token');
 
-            // Both viewers armed their OWN MC-owned routes with their OWN bearers.
+            expect(toolCallsByIdentity['@ada']).toBeUndefined();
+            await classOneOnly.cancel();
+
+            // Per-viewer arming rides the SEPARATELY CARRIED class-3 credential.
+            const
+                adaReader   = await connectSse('ada-token', 'ada-mc-token'),
+                graceReader = await connectSse('grace-token', 'grace-mc-token');
+
+            // Both viewers armed their OWN MC-owned routes with their OWN class-3 bearers.
             expect(toolCallsByIdentity['@ada']).toEqual(['subscribe', 'rotate-key']);
             expect(toolCallsByIdentity['@grace']).toEqual(['subscribe', 'rotate-key']);
 

--- a/test/playwright/unit/ai/services/fleet/FleetServerComposition.spec.mjs
+++ b/test/playwright/unit/ai/services/fleet/FleetServerComposition.spec.mjs
@@ -1,0 +1,244 @@
+import {setup} from '../../../../setup.mjs';
+
+const appName = 'FleetServerCompositionTest';
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name             : appName,
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect}  from '@playwright/test';
+import crypto          from 'node:crypto';
+import {readFileSync}  from 'node:fs';
+import path            from 'node:path';
+import {fileURLToPath} from 'node:url';
+import Neo             from '../../../../../../src/Neo.mjs';
+import * as core       from '../../../../../../src/core/_export.mjs';
+
+import {createFleetWakeFanout} from '../../../../../../ai/services/fleet/fleetWakeFanout.mjs';
+import {createFleetServerApp}  from '../../../../../../ai/services/fleet/fleetServer.mjs';
+
+const
+    REPO_ROOT   = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../../../../..'),
+    cloudCaddy  = readFileSync(path.join(REPO_ROOT, 'ai/deploy/Caddyfile'), 'utf8'),
+    localCaddy  = readFileSync(path.join(REPO_ROOT, 'ai/deploy/Caddyfile.local-agent-os'), 'utf8'),
+    composeYaml = readFileSync(path.join(REPO_ROOT, 'ai/deploy/docker-compose.local-agent-os.yml'), 'utf8');
+
+/**
+ * Deploy-polarity assertions at the executable seam: these are the exact strings Caddy and
+ * Compose parse, so a drifted matcher, a dropped SSE flush, or an ingress-exposed `/wake`
+ * fails HERE instead of at the first live wake on a rebuilt plane.
+ */
+test.describe('FleetServerComposition - ingress and compose polarity for the wake lane', () => {
+    for (const [label, content] of [['cloud Caddyfile', cloudCaddy], ['local-agent-os Caddyfile', localCaddy]]) {
+        test(`${label}: the primary Fleet matcher is exact and includes the SSE route`, () => {
+            expect(content).toContain('@fleet path /fleet /fleet/probe /fleet/events')
+        });
+
+        test(`${label}: every 502 error matcher carries the SSE route alongside its siblings`, () => {
+            const errorBlocks = content.match(/handle_errors 502 \{[\s\S]*?\}/g) ?? [];
+
+            expect(errorBlocks.length).toBeGreaterThan(0);
+
+            for (const block of errorBlocks) {
+                expect(block).toContain('/fleet /fleet/probe /fleet/events')
+            }
+        });
+
+        test(`${label}: SSE responses stream unbuffered`, () => {
+            expect(content).toContain('flush_interval -1')
+        });
+
+        test(`${label}: the signed wake receiver is NOT ingress-routed`, () => {
+            // `/wake` must appear in no matcher and no proxy line — reachability is never
+            // authentication, and the receiver's audience is the compose-internal dispatcher.
+            expect(content).not.toMatch(/path[^\n]*\/wake\b/);
+            expect(content).not.toMatch(/reverse_proxy[^\n]*\/wake\b/)
+        })
+    }
+
+    test('the composed fleet-server declares its dialable wake self-address by service DNS', () => {
+        expect(composeYaml).toContain('NEO_FLEET_WAKE_SELF_BASE: http://fleet-server:8083')
+    });
+
+    test('the composed fleet-server carries a dialable, policy-admissible MC arming path', () => {
+        expect(composeYaml).toContain('NEO_FLEET_PLANE_BASE: http://ingress:8080');
+        expect(composeYaml).toContain('NEO_FLEET_PLANE_INTERNAL_HOSTS: ingress')
+    });
+
+    test('bearer and identity are operator-supplied pass-throughs, never literals in the file', () => {
+        expect(composeYaml).toContain('NEO_FLEET_PLANE_BEARER: ${NEO_FLEET_PLANE_BEARER:-}');
+        expect(composeYaml).toContain('NEO_AGENT_IDENTITY: ${NEO_AGENT_IDENTITY:-}');
+        expect(composeYaml).not.toMatch(/NEO_FLEET_PLANE_BEARER: (?!\$\{)[^\s]/)
+    });
+
+    test('the ingress the arming path dials is the address the local Caddyfile actually binds', () => {
+        expect(localCaddy.trimStart().startsWith(':8080')).toBe(true)
+    })
+});
+
+const
+    QUIET       = {info: () => {}, warn: () => {}, error: () => {}},
+    SIGNING_KEY = crypto.randomBytes(32).toString('hex');
+
+/**
+ * The real Express app with its real middleware order — only the trust collaborators are
+ * injected: a plane guard that does not demand a mounted volume, an auth stub that either
+ * stamps or withholds the provider identity, and a permissive host allowlist. The wake route,
+ * limiter chain, admission middleware, and SSE handler are all production code.
+ */
+async function startTestServer({authenticated = true} = {}) {
+    const fanout = createFleetWakeFanout({logger: QUIET, heartbeatMs: 0});
+
+    await fanout.armRelaySubscription({
+        identity    : '@viewer',
+        wakeSelfBase: 'http://fleet-server:8083',
+        callTool    : async (name, args) => (
+            args.action === 'subscribe'
+                ? {subscriptionId: 'WAKE_SUB:live'}
+                : {subscriptionId: 'WAKE_SUB:live', signingKey: SIGNING_KEY}
+        )
+    });
+
+    const app = await createFleetServerApp({
+        aiConfig: {
+            publicUrl  : 'http://127.0.0.1:3102/fleet',
+            mcpHttpHost: '127.0.0.1',
+            fleet      : {port: 0, dataDir: '/unused-by-noop-guard'}
+        },
+        planeGuard : () => {},
+        wakeFanout : fanout,
+        logger     : QUIET,
+        authService: {
+            setupPreCors() {},
+            async setup({app: target}) {
+                target.use((req, res, next) => {
+                    if (authenticated) {
+                        req.auth = {
+                            userId          : 'u1',
+                            username        : 'viewer',
+                            providerUsername: 'viewer',
+                            authProvider    : 'github',
+                            providerUserId  : 7
+                        }
+                    }
+
+                    next()
+                })
+            }
+        },
+        transportService: {
+            computeAllowedHosts: () => ['127.0.0.1'],
+            installCors() {}
+        }
+    });
+
+    const server = await new Promise(resolve => {
+        const listening = app.listen(0, '127.0.0.1', () => resolve(listening))
+    });
+
+    return {
+        fanout,
+        server,
+        base: `http://127.0.0.1:${server.address().port}`,
+        async close() {
+            fanout.dispose();
+            await new Promise(resolve => server.close(resolve))
+        }
+    }
+}
+
+function signedWakeRequest(base, {envelope, headerOverrides = {}} = {}) {
+    const body = JSON.stringify(envelope);
+
+    return fetch(`${base}/wake`, {
+        method : 'POST',
+        headers: {
+            'content-type'              : 'application/json',
+            'x-neo-wake-subscription-id': envelope.subscriptionId,
+            'x-neo-wake-event-id'       : envelope.eventId,
+            'x-neo-wake-schema-version' : envelope.schemaVersion,
+            'x-neo-wake-signature'      : crypto.createHmac('sha256', SIGNING_KEY).update(body).digest('hex'),
+            ...headerOverrides
+        },
+        body
+    })
+}
+
+test.describe('FleetServerComposition - server-level route positives and negatives', () => {
+    const liveEnvelope = {
+        eventId       : 'EVT:live-1',
+        subscriptionId: 'WAKE_SUB:live',
+        agentIdentity : '@viewer',
+        eventType     : 'wake/digest',
+        schemaVersion : '1.0',
+        payload       : {digest: 'hello'}
+    };
+
+    test('a signed internal wake POST is accepted end-to-end through the real app', async () => {
+        const harness = await startTestServer();
+
+        try {
+            const response = await signedWakeRequest(harness.base, {envelope: liveEnvelope});
+
+            expect(response.status).toBe(200);
+            expect(await response.json()).toEqual({ok: true, state: 'accepted'})
+        } finally {
+            await harness.close()
+        }
+    });
+
+    test('an unknown subscription answers the dispatcher-recognised 404 through the real app', async () => {
+        const harness = await startTestServer();
+
+        try {
+            const response = await signedWakeRequest(harness.base, {
+                envelope       : {...liveEnvelope, subscriptionId: 'WAKE_SUB:stranger'},
+                headerOverrides: {'x-neo-wake-subscription-id': 'WAKE_SUB:stranger'}
+            });
+
+            expect(response.status).toBe(404);
+            expect(await response.json()).toEqual({error: 'unknown-subscription'})
+        } finally {
+            await harness.close()
+        }
+    });
+
+    test('an authenticated viewer receives a live SSE stream with the per-viewer state event', async () => {
+        const harness = await startTestServer();
+
+        try {
+            const response = await fetch(`${harness.base}/fleet/events`, {headers: {accept: 'text/event-stream'}});
+
+            expect(response.status).toBe(200);
+            expect(response.headers.get('content-type')).toBe('text/event-stream');
+
+            const reader  = response.body.getReader();
+            const {value} = await reader.read();
+            const opening = Buffer.from(value).toString('utf8');
+
+            expect(opening).toContain('retry: 5000');
+            await reader.cancel()
+        } finally {
+            await harness.close()
+        }
+    });
+
+    test('an unauthenticated request never reaches the SSE surface', async () => {
+        const harness = await startTestServer({authenticated: false});
+
+        try {
+            const response = await fetch(`${harness.base}/fleet/events`, {headers: {accept: 'text/event-stream'}});
+
+            expect(response.status).toBe(401)
+        } finally {
+            await harness.close()
+        }
+    })
+});

--- a/test/playwright/unit/ai/services/fleet/FleetServerComposition.spec.mjs
+++ b/test/playwright/unit/ai/services/fleet/FleetServerComposition.spec.mjs
@@ -382,6 +382,14 @@ test.describe('FleetServerComposition - per-viewer ownership through the real se
             expect(toolCallsByIdentity['@ada']).toBeUndefined();
             await classOneOnly.cancel();
 
+            // The identical-token mutant: PATs carry no audience claim, so the SAME bytes in
+            // both headers would be admitted by both verifiers — the arming seam must refuse
+            // equality itself. Zero MC calls, honest unarmed stream.
+            const sameToken = await connectSse('ada-token', 'ada-token');
+
+            expect(toolCallsByIdentity['@ada']).toBeUndefined();
+            await sameToken.cancel();
+
             // Per-viewer arming rides the SEPARATELY CARRIED class-3 credential.
             const
                 adaReader   = await connectSse('ada-token', 'ada-mc-token'),

--- a/test/playwright/unit/ai/services/fleet/FleetServerComposition.spec.mjs
+++ b/test/playwright/unit/ai/services/fleet/FleetServerComposition.spec.mjs
@@ -78,6 +78,16 @@ test.describe('FleetServerComposition - ingress and compose polarity for the wak
         expect(composeYaml).not.toMatch(/NEO_FLEET_PLANE_BEARER: (?!\$\{)[^\s]/)
     });
 
+    test('the canonical render carries a REAL service credential: the mounted admission secret, by file custody', () => {
+        expect(composeYaml).toContain('NEO_FLEET_PLANE_BEARER_FILE: /run/secrets/mcp-auth-token');
+
+        // The fleet-server service already mounts that exact secret. Anchored on the service
+        // KEY's line shape — the wake self-base URL contains the same literal mid-line.
+        const fleetService = composeYaml.split(/\n  fleet-server:\n/)[1].split(/\n  \S+:\n/)[0];
+
+        expect(fleetService).toContain('- mcp-auth-token')
+    });
+
     test('the ingress the arming path dials is the address the local Caddyfile actually binds', () => {
         expect(localCaddy.trimStart().startsWith(':8080')).toBe(true)
     })
@@ -239,6 +249,166 @@ test.describe('FleetServerComposition - server-level route positives and negativ
             expect(response.status).toBe(401)
         } finally {
             await harness.close()
+        }
+    })
+});
+
+test.describe('FleetServerComposition - per-viewer ownership through the real server and arming context', () => {
+    test('two authenticated viewers arm two MC-owned routes with their own bearers, and neither receives the other\'s digest', async () => {
+        const {startFleetServer} = await import('../../../../../../ai/services/fleet/fleetServer.mjs');
+
+        const
+            viewersByBearer = {
+                'ada-token'    : {login: 'ada', providerUserId: 1, identity: '@ada'},
+                'grace-token'  : {login: 'grace', providerUserId: 2, identity: '@grace'},
+                'service-token': {login: 'svc', providerUserId: 9, identity: '@svc'}
+            },
+            keysByIdentity = {},
+            toolCallsByIdentity = {};
+
+        // One plane-client stub per CREDENTIAL: init proves the bearer's own identity, and
+        // every subscription it creates is owned by exactly that identity — MC's caller-owned
+        // model, mirrored. No privileged callTool ever touches the fan-out directly.
+        const createPlaneClient = ({credential}) => {
+            const viewer = viewersByBearer[credential];
+
+            return {
+                async init() {
+                    return viewer ? {ok: true, identity: viewer.identity} : {ok: false, reason: 'unknown bearer'}
+                },
+                async callTool(name, args) {
+                    (toolCallsByIdentity[viewer.identity] ??= []).push(args.action);
+
+                    if (args.action === 'subscribe') return {subscriptionId: `WAKE_SUB:${viewer.login}`};
+
+                    if (args.action === 'rotate-key') {
+                        const key = crypto.randomBytes(32).toString('hex');
+                        keysByIdentity[viewer.identity] = key;
+                        return {subscriptionId: `WAKE_SUB:${viewer.login}`, signingKey: key}
+                    }
+                },
+                async close() {}
+            }
+        };
+
+        const server = await new Promise((resolve, reject) => {
+            startFleetServer({
+                host    : '127.0.0.1',
+                port    : 0,
+                aiConfig: {
+                    publicUrl    : 'http://127.0.0.1:3102/fleet',
+                    mcpHttpHost  : '127.0.0.1',
+                    mcpListenHost: '127.0.0.1',
+                    fleet        : {
+                        port              : 0,
+                        dataDir           : '/unused',
+                        wakeSelfBase      : 'http://fleet-server:8083',
+                        planeBase         : 'http://ingress:8080',
+                        planeBearer       : 'service-token',
+                        planeBearerFile   : '',
+                        planeInternalHosts: ['ingress']
+                    }
+                },
+                planeGuard        : () => {},
+                logger            : QUIET,
+                createPlaneClient,
+                resolveViewerClaim: async () => ({agentIdentityNodeId: '@svc'}),
+                authService       : {
+                    setupPreCors() {},
+                    async setup({app: target}) {
+                        target.use((req, res, next) => {
+                            const bearer = (req.headers.authorization ?? '').replace(/^Bearer\s+/i, '').trim();
+                            const viewer = viewersByBearer[bearer];
+
+                            if (viewer) {
+                                req.auth = {
+                                    userId          : viewer.login,
+                                    username        : `${viewer.login} display`,
+                                    providerUsername: viewer.login,
+                                    authProvider    : 'github',
+                                    providerUserId  : viewer.providerUserId
+                                }
+                            }
+
+                            next()
+                        })
+                    }
+                },
+                transportService: {
+                    computeAllowedHosts: () => ['127.0.0.1'],
+                    installCors() {}
+                }
+            }).then(resolve, reject)
+        });
+
+        const base = `http://127.0.0.1:${server.address().port}`;
+
+        async function connectSse(bearer) {
+            const response = await fetch(`${base}/fleet/events`, {
+                headers: {accept: 'text/event-stream', authorization: `Bearer ${bearer}`}
+            });
+
+            expect(response.status).toBe(200);
+
+            const reader = response.body.getReader();
+            // Drain the handshake (retry + per-viewer state event).
+            await reader.read();
+
+            return reader
+        }
+
+        try {
+            const
+                adaReader   = await connectSse('ada-token'),
+                graceReader = await connectSse('grace-token');
+
+            // Both viewers armed their OWN MC-owned routes with their OWN bearers.
+            expect(toolCallsByIdentity['@ada']).toEqual(['subscribe', 'rotate-key']);
+            expect(toolCallsByIdentity['@grace']).toEqual(['subscribe', 'rotate-key']);
+
+            // A wake for ada, signed with ada's MC-active key, through the real receiver.
+            const adaEnvelope = {
+                eventId       : 'EVT:ada-1',
+                subscriptionId: 'WAKE_SUB:ada',
+                agentIdentity : '@ada',
+                eventType     : 'wake/digest',
+                schemaVersion : '1.0',
+                payload       : {digest: 'for ada only'}
+            };
+            const body = JSON.stringify(adaEnvelope);
+
+            const delivery = await fetch(`${base}/wake`, {
+                method : 'POST',
+                headers: {
+                    'content-type'              : 'application/json',
+                    'x-neo-wake-subscription-id': 'WAKE_SUB:ada',
+                    'x-neo-wake-event-id'       : 'EVT:ada-1',
+                    'x-neo-wake-schema-version' : '1.0',
+                    'x-neo-wake-signature'      : crypto.createHmac('sha256', keysByIdentity['@ada']).update(body).digest('hex')
+                },
+                body
+            });
+
+            expect(delivery.status).toBe(200);
+
+            const adaChunk = await Promise.race([
+                adaReader.read().then(({value}) => Buffer.from(value).toString('utf8')),
+                new Promise(resolve => setTimeout(() => resolve('TIMEOUT'), 1500))
+            ]);
+
+            expect(adaChunk).toContain('for ada only');
+
+            const graceChunk = await Promise.race([
+                graceReader.read().then(({value}) => Buffer.from(value).toString('utf8')),
+                new Promise(resolve => setTimeout(() => resolve('SILENT'), 400))
+            ]);
+
+            expect(graceChunk).toBe('SILENT');
+
+            await adaReader.cancel();
+            await graceReader.cancel()
+        } finally {
+            await new Promise(resolve => server.close(resolve))
         }
     })
 });

--- a/test/playwright/unit/ai/services/fleet/fleetWakeArming.spec.mjs
+++ b/test/playwright/unit/ai/services/fleet/fleetWakeArming.spec.mjs
@@ -277,6 +277,41 @@ test.describe('fleet wake arming - the service credential chain', () => {
         })).toBe('distinct-class-3-mint')
     });
 
+    test('a byte-identical viewer/fleet bearer pair is refused before any MC client exists', async () => {
+        let constructions = 0;
+
+        const fanout = createFleetWakeFanout({logger: QUIET, heartbeatMs: 0});
+
+        const context = createWakeArmingContext({
+            fanout,
+            aiConfig: {fleet: {
+                planeBase         : 'http://ingress:8080',
+                planeBearer       : 'service-token',
+                planeBearerFile   : '',
+                admissionTokenFile: '',
+                planeInternalHosts: ['ingress'],
+                wakeSelfBase      : 'http://fleet-server:8083'
+            }},
+            logger           : QUIET,
+            createPlaneClient: () => {
+                constructions++;
+                throw new Error('must never be reached for an aliased pair')
+            },
+            resolveViewerClaim: async () => ({agentIdentityNodeId: '@svc'})
+        });
+
+        const outcome = await context.ensureArmedForViewer({
+            viewerKey           : 'provider:github:1',
+            canonicalClaim      : '@ada',
+            bearer              : 'the-same-pat',
+            fleetAdmissionBearer: 'the-same-pat'
+        });
+
+        expect(outcome.armed).toBe(false);
+        expect(outcome.reason).toContain('byte-identical');
+        expect(constructions).toBe(0)
+    });
+
     test('an unreadable admission file disables the comparison, never the credential', () => {
         expect(assertFleetPlaneBearerClass({
             aiConfig: {fleet: {

--- a/test/playwright/unit/ai/services/fleet/fleetWakeArming.spec.mjs
+++ b/test/playwright/unit/ai/services/fleet/fleetWakeArming.spec.mjs
@@ -1,0 +1,205 @@
+import {setup} from '../../../../setup.mjs';
+
+const appName = 'FleetWakeArmingTest';
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name             : appName,
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../../../src/Neo.mjs';
+import * as core      from '../../../../../../src/core/_export.mjs';
+
+import {createFleetWakeFanout}      from '../../../../../../ai/services/fleet/fleetWakeFanout.mjs';
+import {normalizeSecureMcpEndpoint} from '../../../../../../ai/services/fleet/mcpWireParsing.mjs';
+import {
+    armFleetWakePushLane,
+    createWakeArmingContext,
+    resolveViewerStreamKey
+} from '../../../../../../ai/services/fleet/fleetServer.mjs';
+
+const QUIET = {info: () => {}, warn: () => {}, error: () => {}};
+
+function armingFixture({initOk = true, provenIdentity = '@viewer'} = {}) {
+    const
+        fanout      = createFleetWakeFanout({logger: QUIET, heartbeatMs: 0}),
+        clientCalls = [],
+        toolCalls   = [];
+
+    const aiConfig = {
+        fleet: {
+            planeBase         : 'http://ingress:8080',
+            planeBearer       : 'operator-supplied',
+            planeInternalHosts: ['ingress'],
+            wakeSelfBase      : 'http://fleet-server:8083'
+        }
+    };
+
+    const createPlaneClient = options => {
+        clientCalls.push(options);
+
+        return {
+            async init({expectedIdentity}) {
+                clientCalls.push({initFor: expectedIdentity});
+                return initOk
+                    ? {ok: true, identity: provenIdentity}
+                    : {ok: false, reason: 'subject mismatch'}
+            },
+            async callTool(name, args) {
+                toolCalls.push({name, args});
+
+                if (args.action === 'subscribe')  return {subscriptionId: 'WAKE_SUB:relay'};
+                if (args.action === 'rotate-key') return {subscriptionId: 'WAKE_SUB:relay', signingKey: 'b'.repeat(64)};
+
+                throw new Error(`unexpected action ${args.action}`)
+            },
+            async close() {
+                clientCalls.push({closed: true})
+            }
+        }
+    };
+
+    const context = createWakeArmingContext({
+        fanout,
+        aiConfig,
+        logger            : QUIET,
+        createPlaneClient,
+        resolveViewerClaim: async () => ({agentIdentityNodeId: '@viewer', userId: 'viewer', username: 'Viewer Display'})
+    });
+
+    return {fanout, context, aiConfig, clientCalls, toolCalls}
+}
+
+test.describe('fleet wake arming - the boot-path falsifier and the caller-owned authority boundary', () => {
+    test('armFleetWakePushLane reaches armed through the real context: endpoint allowance threaded, proven identity owns the route', async () => {
+        const {fanout, context, clientCalls, toolCalls} = armingFixture();
+
+        const outcome = await armFleetWakePushLane({armingContext: context, logger: QUIET});
+
+        expect(outcome.armed).toBe(true);
+
+        // The plane client was constructed against the derived MC resource with the
+        // deployment-declared internal-host allowance threaded through — the exact seam that
+        // deterministically failed before this existed.
+        const construction = clientCalls[0];
+
+        expect(construction.baseUrl).toBe('http://ingress:8080/mc/mcp');
+        expect(construction.allowPlainHttpHosts).toEqual(['ingress']);
+
+        // subscribe → rotate-key, and the in-memory route binds to the MC-PROVEN identity.
+        expect(toolCalls.map(call => call.args.action)).toEqual(['subscribe', 'rotate-key']);
+        expect(fanout.resolveRoute('WAKE_SUB:relay')).toEqual({
+            signingKey   : 'b'.repeat(64),
+            agentIdentity: '@viewer'
+        })
+    });
+
+    test('the declared compose-internal endpoint is admitted by the policy exactly as threaded — and stays refused undeclared', () => {
+        expect(normalizeSecureMcpEndpoint('http://ingress:8080/mc/mcp')).toBeNull();
+        expect(normalizeSecureMcpEndpoint('http://ingress:8080/mc/mcp', {allowPlainHttpHosts: ['ingress']}))
+            .toBe('http://ingress:8080/mc/mcp');
+        expect(normalizeSecureMcpEndpoint('http://mc-server:3001/mcp', {allowPlainHttpHosts: ['ingress']})).toBeNull()
+    });
+
+    test('a refused plane admission lands as rendered fan-out state, never a throw', async () => {
+        const {fanout, context} = armingFixture({initOk: false});
+
+        const outcome = await armFleetWakePushLane({armingContext: context, logger: QUIET});
+
+        expect(outcome.armed).toBe(false);
+        expect(fanout.describeState().armed).toBe(false)
+    });
+
+    test('ensureArmedFor refuses any viewer that is not the proven caller identity, without touching MC', async () => {
+        const {context, toolCalls} = armingFixture();
+
+        await context.establish();
+        const before  = toolCalls.length;
+        const outcome = await context.ensureArmedFor('provider:github:12345');
+
+        expect(outcome.armed).toBe(false);
+        expect(outcome.reason).toContain('caller-owned');
+        expect(toolCalls.length).toBe(before)
+    });
+
+    test('per-viewer outcomes are cached: a second connect for the armed viewer re-arms nothing', async () => {
+        const {context, toolCalls} = armingFixture();
+
+        await armFleetWakePushLane({armingContext: context, logger: QUIET});
+        const after = toolCalls.length;
+
+        await context.ensureArmedFor('@viewer');
+        expect(toolCalls.length).toBe(after)
+    })
+});
+
+test.describe('resolveViewerStreamKey - immutable-fact keying, never display names', () => {
+    const proven = '@viewer';
+
+    test('the proven plane identity keys its own streams', () => {
+        expect(resolveViewerStreamKey({providerUsername: 'viewer', authProvider: 'github', providerUserId: 7}, proven))
+            .toBe('@viewer')
+    });
+
+    test('a display name with spaces cannot forge a key: the immutable provider tuple wins', () => {
+        expect(resolveViewerStreamKey({username: 'Viewer Display', authProvider: 'github', providerUserId: 7}, proven))
+            .toBe('provider:github:7')
+    });
+
+    test('two viewers whose display names collide still key apart on the provider tuple', () => {
+        const
+            a = resolveViewerStreamKey({username: 'Ada Lovelace', authProvider: 'github', providerUserId: 1}, proven),
+            b = resolveViewerStreamKey({username: 'Ada Lovelace', authProvider: 'github', providerUserId: 2}, proven);
+
+        expect(a).toBe('provider:github:1');
+        expect(b).toBe('provider:github:2');
+        expect(a).not.toBe(b)
+    });
+
+    test('a colliding login that normalizes to the proven identity maps to it only via the login fact itself', () => {
+        expect(resolveViewerStreamKey({providerUsername: 'viewer', authProvider: 'github', providerUserId: 99}, null))
+            .toBe('provider:github:99')
+    });
+
+    test('no stable subject yields null, which the route refuses', () => {
+        expect(resolveViewerStreamKey({username: 'Ghost Display'}, proven)).toBeNull();
+        expect(resolveViewerStreamKey(null, proven)).toBeNull()
+    })
+});
+
+test.describe('two-viewer route isolation at the arming mechanics level', () => {
+    test('two authorized viewers arm distinct routes and neither receives the other\'s digest', async () => {
+        const fanout = createFleetWakeFanout({logger: QUIET, heartbeatMs: 0});
+
+        const callToolFor = owner => async (name, args) => {
+            if (args.action === 'subscribe')  return {subscriptionId: `WAKE_SUB:${owner}`};
+            if (args.action === 'rotate-key') return {subscriptionId: `WAKE_SUB:${owner}`, signingKey: 'c'.repeat(64)};
+        };
+
+        await fanout.armRelaySubscription({identity: '@ada', wakeSelfBase: 'http://fleet-server:8083', callTool: callToolFor('ada')});
+        await fanout.armRelaySubscription({identity: '@grace', wakeSelfBase: 'http://fleet-server:8083', callTool: callToolFor('grace')});
+
+        expect(fanout.resolveRoute('WAKE_SUB:ada').agentIdentity).toBe('@ada');
+        expect(fanout.resolveRoute('WAKE_SUB:grace').agentIdentity).toBe('@grace');
+
+        const streams = {
+            '@ada'  : {head: null, chunks: [], writeHead(s, h) {this.head = {s, h}}, write(c) {this.chunks.push(c)}, on() {}},
+            '@grace': {head: null, chunks: [], writeHead(s, h) {this.head = {s, h}}, write(c) {this.chunks.push(c)}, on() {}}
+        };
+
+        fanout.registerStream('@ada', streams['@ada']);
+        fanout.registerStream('@grace', streams['@grace']);
+
+        fanout.handleDigest({subscriptionId: 'WAKE_SUB:ada', agentIdentity: '@ada', envelope: {digest: 'for ada'}});
+
+        expect(streams['@ada'].chunks.join('')).toContain('for ada');
+        expect(streams['@grace'].chunks.join('')).not.toContain('for ada')
+    })
+});

--- a/test/playwright/unit/ai/services/fleet/fleetWakeArming.spec.mjs
+++ b/test/playwright/unit/ai/services/fleet/fleetWakeArming.spec.mjs
@@ -327,6 +327,85 @@ test.describe('fleet wake arming - the service credential chain', () => {
     })
 });
 
+test.describe('fleet wake arming - the shutdown fence (delayed mutations cross a CLOSED epoch)', () => {
+    test('a delayed rotate that outlives shutdown ends unarmed: no route survives, registration is refused, close resolves', async () => {
+        const fanout = createFleetWakeFanout({logger: QUIET, heartbeatMs: 0});
+
+        let releaseRotate;
+
+        const rotateGate = new Promise(resolve => {
+            releaseRotate = resolve
+        });
+
+        const context = createWakeArmingContext({
+            fanout,
+            aiConfig: {fleet: {
+                planeBase         : 'http://ingress:8080',
+                planeBearer       : 'service-token',
+                planeBearerFile   : '',
+                admissionTokenFile: '',
+                planeInternalHosts: ['ingress'],
+                wakeSelfBase      : 'http://fleet-server:8083'
+            }},
+            logger           : QUIET,
+            createPlaneClient: () => ({
+                async init() {
+                    return {ok: true, identity: '@viewer'}
+                },
+                async callTool(name, args) {
+                    if (args.action === 'subscribe') return {subscriptionId: 'WAKE_SUB:zombie'};
+
+                    if (args.action === 'rotate-key') {
+                        await rotateGate;
+                        return {subscriptionId: 'WAKE_SUB:zombie', signingKey: 'd'.repeat(64)}
+                    }
+                },
+                async close() {}
+            }),
+            resolveViewerClaim: async () => ({agentIdentityNodeId: '@viewer'})
+        });
+
+        // The mutation crosses the shutdown boundary: arming starts, then the WHOLE shutdown
+        // sweep runs (context close + fan-out disposal, the server-close wrapper's order)
+        // while the rotate response is still pending.
+        const pending = armFleetWakePushLane({armingContext: context, logger: QUIET});
+
+        await new Promise(resolve => setTimeout(resolve, 20));
+        await context.close();
+        fanout.dispose();
+
+        releaseRotate();
+        const outcome = await pending;
+
+        // Unarmed outcome, no resurrected route, no post-disposal registration — and both
+        // shutdown calls above already RESOLVED, which is the fence itself.
+        expect(outcome.armed).toBe(false);
+        expect(fanout.resolveRoute('WAKE_SUB:zombie')).toBeNull();
+        expect(fanout.describeState().armed).toBe(false);
+
+        const late = {head: null, chunks: [], writeHead(s, h) {this.head = {s, h}}, write(c) {this.chunks.push(c)}, on() {}};
+
+        expect(fanout.registerStream('@viewer', late)).toEqual({
+            accepted: false,
+            reason  : 'stream registry disposed'
+        });
+        expect(late.head).toBeNull()
+    });
+
+    test('a closed context refuses new ensures outright — both doors', async () => {
+        const {context} = armingFixture();
+
+        await context.close();
+
+        expect((await context.ensureArmedFor('@viewer')).reason).toContain('arming context closed');
+        expect((await context.ensureArmedForViewer({
+            viewerKey     : 'provider:github:1',
+            canonicalClaim: '@ada',
+            bearer        : 'mc-mint'
+        })).reason).toContain('arming context closed')
+    })
+});
+
 test.describe('resolveViewerStreamKey - immutable-fact keying, never display names', () => {
     const proven = '@viewer';
 

--- a/test/playwright/unit/ai/services/fleet/fleetWakeArming.spec.mjs
+++ b/test/playwright/unit/ai/services/fleet/fleetWakeArming.spec.mjs
@@ -22,7 +22,9 @@ import {normalizeSecureMcpEndpoint} from '../../../../../../ai/services/fleet/mc
 import {
     armFleetWakePushLane,
     createWakeArmingContext,
-    resolveViewerStreamKey
+    resolveFleetPlaneBearer,
+    resolveViewerStreamKey,
+    startFleetServer
 } from '../../../../../../ai/services/fleet/fleetServer.mjs';
 
 const QUIET = {info: () => {}, warn: () => {}, error: () => {}};
@@ -37,6 +39,7 @@ function armingFixture({initOk = true, provenIdentity = '@viewer'} = {}) {
         fleet: {
             planeBase         : 'http://ingress:8080',
             planeBearer       : 'operator-supplied',
+            planeBearerFile   : '',
             planeInternalHosts: ['ingress'],
             wakeSelfBase      : 'http://fleet-server:8083'
         }
@@ -137,6 +140,106 @@ test.describe('fleet wake arming - the boot-path falsifier and the caller-owned 
 
         await context.ensureArmedFor('@viewer');
         expect(toolCalls.length).toBe(after)
+    })
+});
+
+test.describe('fleet wake arming - whole-mutation serialization (the key-divergence regression)', () => {
+    test('two racing armings for one identity run ONE subscribe + ONE rotation, share the outcome, and the route key equals MC\'s active key', async () => {
+        const
+            fanout    = createFleetWakeFanout({logger: QUIET, heartbeatMs: 0}),
+            toolCalls = [];
+
+        let rotationCount = 0;
+
+        // The measured falsifier shape: rotate answers are DELAYED, so an unserialized second
+        // caller overlaps the first mutation and mints a second key.
+        const callTool = async (name, args) => {
+            toolCalls.push(args.action);
+
+            if (args.action === 'subscribe') {
+                await new Promise(resolve => setTimeout(resolve, 20));
+                return {subscriptionId: 'WAKE_SUB:race'}
+            }
+
+            if (args.action === 'rotate-key') {
+                rotationCount++;
+                const key = String(rotationCount).repeat(64).slice(0, 64);
+                await new Promise(resolve => setTimeout(resolve, 30));
+                return {subscriptionId: 'WAKE_SUB:race', signingKey: key}
+            }
+        };
+
+        const arm = () => fanout.armRelaySubscription({
+            identity    : '@viewer',
+            wakeSelfBase: 'http://fleet-server:8083',
+            callTool
+        });
+
+        const [first, second] = await Promise.all([arm(), arm()]);
+
+        expect(toolCalls).toEqual(['subscribe', 'rotate-key']);
+        expect(rotationCount).toBe(1);
+        expect(first).toEqual(second);
+
+        // MC's active key IS the single rotation's key, and the route holds exactly it.
+        expect(fanout.resolveRoute('WAKE_SUB:race').signingKey).toBe('1'.repeat(64))
+    });
+
+    test('the context latch is shared by boot arming and a concurrent connect-time ensure', async () => {
+        const {context, toolCalls} = armingFixture();
+
+        await Promise.all([
+            armFleetWakePushLane({armingContext: context, logger: QUIET}),
+            (async () => {
+                await context.establish();
+                return context.ensureArmedFor(context.provenIdentity())
+            })()
+        ]);
+
+        expect(toolCalls.map(call => call.args.action)).toEqual(['subscribe', 'rotate-key'])
+    })
+});
+
+test.describe('fleet wake arming - the service credential chain', () => {
+    test('the direct bearer value wins; the secret file is the fallback; absence resolves empty', () => {
+        const base = {planeBearer: '', planeBearerFile: ''};
+
+        expect(resolveFleetPlaneBearer({aiConfig: {fleet: {...base, planeBearer: ' direct '}}})).toBe('direct');
+
+        expect(resolveFleetPlaneBearer({
+            aiConfig: {fleet: {...base, planeBearerFile: '/run/secrets/token'}},
+            readFile: target => (target === '/run/secrets/token' ? 'from-file\n' : '')
+        })).toBe('from-file');
+
+        expect(resolveFleetPlaneBearer({aiConfig: {fleet: base}})).toBe('');
+
+        expect(resolveFleetPlaneBearer({
+            aiConfig: {fleet: {...base, planeBearerFile: '/missing'}},
+            readFile: () => {
+                throw new Error('ENOENT')
+            }
+        })).toBe('')
+    });
+
+    test('a declared wake lane with no resolvable credential refuses to boot instead of arming nothing', async () => {
+        await expect(startFleetServer({
+            host    : '127.0.0.1',
+            port    : 0,
+            aiConfig: {
+                mcpListenHost: '127.0.0.1',
+                fleet        : {
+                    port              : 0,
+                    dataDir           : '/unused',
+                    wakeSelfBase      : 'http://fleet-server:8083',
+                    planeBase         : 'http://ingress:8080',
+                    planeBearer       : '',
+                    planeBearerFile   : '',
+                    planeInternalHosts: ['ingress']
+                }
+            },
+            planeGuard: () => {},
+            logger    : QUIET
+        })).rejects.toThrow(/Refusing to boot a dead feature/)
     })
 });
 

--- a/test/playwright/unit/ai/services/fleet/fleetWakeArming.spec.mjs
+++ b/test/playwright/unit/ai/services/fleet/fleetWakeArming.spec.mjs
@@ -21,6 +21,7 @@ import {createFleetWakeFanout}      from '../../../../../../ai/services/fleet/fl
 import {normalizeSecureMcpEndpoint} from '../../../../../../ai/services/fleet/mcpWireParsing.mjs';
 import {
     armFleetWakePushLane,
+    assertFleetPlaneBearerClass,
     createWakeArmingContext,
     resolveFleetPlaneBearer,
     resolveViewerStreamKey,
@@ -40,6 +41,7 @@ function armingFixture({initOk = true, provenIdentity = '@viewer'} = {}) {
             planeBase         : 'http://ingress:8080',
             planeBearer       : 'operator-supplied',
             planeBearerFile   : '',
+            admissionTokenFile: '',
             planeInternalHosts: ['ingress'],
             wakeSelfBase      : 'http://fleet-server:8083'
         }
@@ -234,12 +236,59 @@ test.describe('fleet wake arming - the service credential chain', () => {
                     planeBase         : 'http://ingress:8080',
                     planeBearer       : '',
                     planeBearerFile   : '',
+                    admissionTokenFile: '',
                     planeInternalHosts: ['ingress']
                 }
             },
             planeGuard: () => {},
             logger    : QUIET
         })).rejects.toThrow(/Refusing to boot a dead feature/)
+    });
+
+    test('the separated-token teeth: a plane bearer that IS the admission token is refused as an aliased credential', () => {
+        const files = {
+            '/run/secrets/fleet-plane-token': 'the-same-token\n',
+            '/run/secrets/mcp-auth-token'   : 'the-same-token\n'
+        };
+
+        expect(() => assertFleetPlaneBearerClass({
+            aiConfig: {fleet: {
+                planeBearer       : '',
+                planeBearerFile   : '/run/secrets/fleet-plane-token',
+                admissionTokenFile: '/run/secrets/mcp-auth-token'
+            }},
+            readFile: target => files[target]
+        })).toThrow(/credential-class ledger forbids/)
+    });
+
+    test('the separated-token teeth admit a genuinely distinct class-3 credential', () => {
+        const files = {
+            '/run/secrets/fleet-plane-token': 'distinct-class-3-mint',
+            '/run/secrets/mcp-auth-token'   : 'the-admission-token'
+        };
+
+        expect(assertFleetPlaneBearerClass({
+            aiConfig: {fleet: {
+                planeBearer       : '',
+                planeBearerFile   : '/run/secrets/fleet-plane-token',
+                admissionTokenFile: '/run/secrets/mcp-auth-token'
+            }},
+            readFile: target => files[target]
+        })).toBe('distinct-class-3-mint')
+    });
+
+    test('an unreadable admission file disables the comparison, never the credential', () => {
+        expect(assertFleetPlaneBearerClass({
+            aiConfig: {fleet: {
+                planeBearer       : 'direct-mint',
+                planeBearerFile   : '',
+                admissionTokenFile: '/missing'
+            }},
+            readFile: target => {
+                if (target === '/missing') throw new Error('ENOENT');
+                return ''
+            }
+        })).toBe('direct-mint')
     })
 });
 

--- a/test/playwright/unit/ai/services/fleet/fleetWakeFanout.spec.mjs
+++ b/test/playwright/unit/ai/services/fleet/fleetWakeFanout.spec.mjs
@@ -202,6 +202,40 @@ test.describe('fleetWakeFanout - identity-keyed SSE fan-out + relay-subscription
         expect(fanout.describeState().connectedIdentities).toBe(0)
     });
 
+    test('the per-viewer stream cap refuses the excess connection untouched, and a close frees the slot', async () => {
+        const fanout = createFleetWakeFanout({logger: {error: () => {}}, heartbeatMs: 0, maxStreamsPerIdentity: 2, maxStreamsTotal: 10});
+
+        const
+            first  = createStream(),
+            second = createStream(),
+            third  = createStream(),
+            fourth = createStream();
+
+        expect(fanout.registerStream('@viewer', first).accepted).toBe(true);
+        expect(fanout.registerStream('@viewer', second).accepted).toBe(true);
+
+        const refused = fanout.registerStream('@viewer', third);
+
+        expect(refused).toEqual({accepted: false, reason: 'stream cap reached (per viewer)'});
+        // The refused response was never converted to SSE — the route still owns it.
+        expect(third.head).toBeNull();
+        expect(third.chunks).toHaveLength(0);
+
+        first.close();
+        expect(fanout.registerStream('@viewer', fourth).accepted).toBe(true)
+    });
+
+    test('the total stream cap bounds the process across identities', async () => {
+        const fanout = createFleetWakeFanout({logger: {error: () => {}}, heartbeatMs: 0, maxStreamsPerIdentity: 8, maxStreamsTotal: 2});
+
+        expect(fanout.registerStream('@a', createStream()).accepted).toBe(true);
+        expect(fanout.registerStream('@b', createStream()).accepted).toBe(true);
+        expect(fanout.registerStream('@c', createStream())).toEqual({
+            accepted: false,
+            reason  : 'stream cap reached (total)'
+        })
+    });
+
     test('lastPushAt is observational: recorded on delivery even when no stream is connected', async () => {
         let tick = 1000;
 

--- a/test/playwright/unit/ai/services/fleet/fleetWakeFanout.spec.mjs
+++ b/test/playwright/unit/ai/services/fleet/fleetWakeFanout.spec.mjs
@@ -1,0 +1,221 @@
+import {setup} from '../../../../setup.mjs';
+
+const appName = 'FleetWakeFanoutTest';
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name             : appName,
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../../../src/Neo.mjs';
+import * as core      from '../../../../../../src/core/_export.mjs';
+
+import {createFleetWakeFanout} from '../../../../../../ai/services/fleet/fleetWakeFanout.mjs';
+
+/**
+ * A minimal SSE response double: collects head + frames, and lets the test fire the close
+ * event exactly like a dropped EventSource does.
+ */
+function createStream() {
+    const listeners = {};
+
+    return {
+        head  : null,
+        chunks: [],
+        writeHead(status, headers) {
+            this.head = {status, headers}
+        },
+        write(chunk) {
+            this.chunks.push(chunk)
+        },
+        on(event, handler) {
+            listeners[event] = handler
+        },
+        close() {
+            listeners.close?.()
+        },
+        events(name) {
+            return this.chunks.filter(chunk => chunk.startsWith(`event: ${name}\n`))
+        }
+    }
+}
+
+function createArmedFanout({identity = '@viewer', now} = {}) {
+    const fanout = createFleetWakeFanout({logger: {error: () => {}}, heartbeatMs: 0, now});
+
+    const calls = [];
+
+    const callTool = async (name, args) => {
+        calls.push({name, args});
+
+        if (args.action === 'subscribe')  return {subscriptionId: 'WAKE_SUB:relay'};
+        if (args.action === 'rotate-key') return {subscriptionId: 'WAKE_SUB:relay', signingKey: 'a'.repeat(64)};
+
+        throw new Error(`unexpected action ${args.action}`)
+    };
+
+    return {
+        fanout,
+        calls,
+        arm: () => fanout.armRelaySubscription({
+            identity,
+            wakeSelfBase: 'http://fleet-server:8083',
+            callTool
+        })
+    }
+}
+
+test.describe('fleetWakeFanout - identity-keyed SSE fan-out + relay-subscription arming', () => {
+    test('an undeclared self-address renders unarmed with its reason — never a guessed default', async () => {
+        const fanout  = createFleetWakeFanout({logger: {error: () => {}}, heartbeatMs: 0});
+        const outcome = await fanout.armRelaySubscription({identity: null, wakeSelfBase: '', callTool: null});
+
+        expect(outcome.armed).toBe(false);
+        expect(outcome.reason).toContain('wakeSelfBase undeclared');
+        expect(fanout.describeState().armed).toBe(false)
+    });
+
+    test('a missing plane client renders unarmed with its own distinct reason', async () => {
+        const fanout  = createFleetWakeFanout({logger: {error: () => {}}, heartbeatMs: 0});
+        const outcome = await fanout.armRelaySubscription({
+            identity    : '@viewer',
+            wakeSelfBase: 'http://fleet-server:8083',
+            callTool    : null
+        });
+
+        expect(outcome.armed).toBe(false);
+        expect(outcome.reason).toContain('no authenticated plane client')
+    });
+
+    test('arming subscribes the canonical /wake target, then rotates unconditionally, and the rotated key becomes the in-memory route', async () => {
+        const {fanout, calls, arm} = createArmedFanout();
+        const outcome              = await arm();
+
+        expect(outcome).toEqual({armed: true, reason: 'armed', subscriptionId: 'WAKE_SUB:relay'});
+
+        expect(calls.map(call => call.args.action)).toEqual(['subscribe', 'rotate-key']);
+        expect(calls[0].args.harnessTarget).toBe('a2a-webhook');
+        expect(calls[0].args.harnessTargetMetadata.url).toBe('http://fleet-server:8083/wake');
+
+        expect(fanout.resolveRoute('WAKE_SUB:relay')).toEqual({
+            signingKey   : 'a'.repeat(64),
+            agentIdentity: '@viewer'
+        });
+        expect(fanout.resolveRoute('WAKE_SUB:stranger')).toBeNull()
+    });
+
+    test('a rotate-key answer without a key refuses arming — an idempotently reused key from a dead process life is never trusted', async () => {
+        const fanout = createFleetWakeFanout({logger: {error: () => {}}, heartbeatMs: 0});
+
+        const outcome = await fanout.armRelaySubscription({
+            identity    : '@viewer',
+            wakeSelfBase: 'http://fleet-server:8083',
+            callTool    : async (name, args) => (
+                args.action === 'subscribe' ? {subscriptionId: 'WAKE_SUB:relay'} : {}
+            )
+        });
+
+        expect(outcome.armed).toBe(false);
+        expect(outcome.reason).toContain('rotate-key returned no signing key');
+        expect(fanout.resolveRoute('WAKE_SUB:relay')).toBeNull()
+    });
+
+    test('a throwing plane call refuses arming without throwing out of the fail-soft contract', async () => {
+        const fanout = createFleetWakeFanout({logger: {error: () => {}}, heartbeatMs: 0});
+
+        const outcome = await fanout.armRelaySubscription({
+            identity    : '@viewer',
+            wakeSelfBase: 'http://fleet-server:8083',
+            callTool    : async () => {
+                throw new Error('plane unreachable')
+            }
+        });
+
+        expect(outcome.armed).toBe(false);
+        expect(outcome.reason).toContain('arming failed')
+    });
+
+    test('a digest routes to exactly its identity\'s streams — a second identity can never receive it', async () => {
+        const {fanout, arm} = createArmedFanout();
+        await arm();
+
+        const
+            mine   = createStream(),
+            theirs = createStream();
+
+        fanout.registerStream('@viewer', mine);
+        fanout.registerStream('@someone-else', theirs);
+
+        fanout.handleDigest({
+            subscriptionId: 'WAKE_SUB:relay',
+            agentIdentity : '@viewer',
+            envelope      : {digest: 'wake up'}
+        });
+
+        expect(mine.events('wake')).toHaveLength(1);
+        expect(mine.events('wake')[0]).toContain('"digest":"wake up"');
+        expect(theirs.events('wake')).toHaveLength(0)
+    });
+
+    test('the SSE state event is per-viewer honest: armed for the relay viewer, not-armed-for-you elsewhere', async () => {
+        const {fanout, arm} = createArmedFanout();
+        await arm();
+
+        const
+            mine   = createStream(),
+            theirs = createStream();
+
+        fanout.registerStream('@viewer', mine);
+        fanout.registerStream('@someone-else', theirs);
+
+        expect(mine.events('state')[0]).toContain('"armedForViewer":true');
+        expect(theirs.events('state')[0]).toContain('"armedForViewer":false');
+
+        expect(mine.head.headers['content-type']).toBe('text/event-stream')
+    });
+
+    test('a closed stream is forgotten: later digests reach nothing and leak nothing', async () => {
+        const {fanout, arm} = createArmedFanout();
+        await arm();
+
+        const stream = createStream();
+
+        fanout.registerStream('@viewer', stream);
+        stream.close();
+
+        const before = stream.chunks.length;
+
+        fanout.handleDigest({
+            subscriptionId: 'WAKE_SUB:relay',
+            agentIdentity : '@viewer',
+            envelope      : {digest: 'late'}
+        });
+
+        expect(stream.chunks.length).toBe(before);
+        expect(fanout.describeState().connectedIdentities).toBe(0)
+    });
+
+    test('lastPushAt is observational: recorded on delivery even when no stream is connected', async () => {
+        let tick = 1000;
+
+        const {fanout, arm} = createArmedFanout({now: () => tick});
+        await arm();
+
+        expect(fanout.describeState().lastPushAt).toBeNull();
+
+        fanout.handleDigest({
+            subscriptionId: 'WAKE_SUB:relay',
+            agentIdentity : '@viewer',
+            envelope      : {digest: 'unwitnessed'}
+        });
+
+        expect(fanout.describeState().lastPushAt).toBe(1000)
+    })
+});

--- a/test/playwright/unit/ai/services/fleet/fleetWakeFanout.spec.mjs
+++ b/test/playwright/unit/ai/services/fleet/fleetWakeFanout.spec.mjs
@@ -20,26 +20,44 @@ import * as core      from '../../../../../../src/core/_export.mjs';
 import {createFleetWakeFanout} from '../../../../../../ai/services/fleet/fleetWakeFanout.mjs';
 
 /**
- * A minimal SSE response double: collects head + frames, and lets the test fire the close
- * event exactly like a dropped EventSource does.
+ * A minimal SSE response double: collects head + frames, and lets the test fire the close /
+ * error events exactly like a dropped or faulted EventSource does. `failWrites` makes every
+ * write throw; `writableLength` simulates kernel-buffer backpressure.
  */
-function createStream() {
+function createStream({failWrites = false, writableLength = 0} = {}) {
     const listeners = {};
 
     return {
-        head  : null,
-        chunks: [],
+        head     : null,
+        chunks   : [],
+        ended    : false,
+        destroyed: false,
+        failWrites,
+        writableLength,
         writeHead(status, headers) {
             this.head = {status, headers}
         },
         write(chunk) {
+            if (this.failWrites) {
+                throw new Error('socket gone')
+            }
+
             this.chunks.push(chunk)
+        },
+        end() {
+            this.ended = true
+        },
+        destroy() {
+            this.destroyed = true
         },
         on(event, handler) {
             listeners[event] = handler
         },
         close() {
             listeners.close?.()
+        },
+        error() {
+            listeners.error?.()
         },
         events(name) {
             return this.chunks.filter(chunk => chunk.startsWith(`event: ${name}\n`))
@@ -234,6 +252,78 @@ test.describe('fleetWakeFanout - identity-keyed SSE fan-out + relay-subscription
             accepted: false,
             reason  : 'stream cap reached (total)'
         })
+    });
+
+    test('a faulty first stream is evicted without costing the healthy second its delivery', async () => {
+        const {fanout, arm} = createArmedFanout();
+        await arm();
+
+        const
+            faulty  = createStream(),
+            healthy = createStream();
+
+        fanout.registerStream('@viewer', faulty);
+        fanout.registerStream('@viewer', healthy);
+
+        faulty.failWrites = true;
+
+        fanout.handleDigest({
+            subscriptionId: 'WAKE_SUB:relay',
+            agentIdentity : '@viewer',
+            envelope      : {digest: 'wake up'}
+        });
+
+        expect(healthy.events('wake')).toHaveLength(1);
+        expect(faulty.destroyed).toBe(true);
+        // The evicted slot is freed: connectedIdentities still names the viewer via the healthy stream.
+        expect(fanout.describeState().connectedIdentities).toBe(1)
+    });
+
+    test('a stream past the backpressure bound is evicted instead of buffered forever', async () => {
+        const {fanout, arm} = createArmedFanout();
+        await arm();
+
+        const bloated = createStream({writableLength: 512 * 1024});
+
+        // Registration writes ride the same bound, so the overfull stream is evicted at the
+        // first write — nothing is ever queued behind a consumer that stopped reading.
+        fanout.registerStream('@viewer', bloated);
+
+        expect(bloated.destroyed).toBe(true);
+        expect(fanout.describeState().connectedIdentities).toBe(0)
+    });
+
+    test('close and error cleanups are idempotent: no double-decrement can corrupt the caps', async () => {
+        const fanout = createFleetWakeFanout({logger: {error: () => {}}, heartbeatMs: 0, maxStreamsPerIdentity: 8, maxStreamsTotal: 2});
+
+        const stream = createStream();
+
+        fanout.registerStream('@a', stream);
+        stream.close();
+        stream.error();
+        stream.close();
+
+        expect(fanout.registerStream('@b', createStream()).accepted).toBe(true);
+        expect(fanout.registerStream('@c', createStream()).accepted).toBe(true);
+        expect(fanout.registerStream('@d', createStream()).accepted).toBe(false)
+    });
+
+    test('dispose ends every held stream so a server can terminate with open SSE clients', async () => {
+        const {fanout, arm} = createArmedFanout();
+        await arm();
+
+        const
+            one = createStream(),
+            two = createStream();
+
+        fanout.registerStream('@viewer', one);
+        fanout.registerStream('@someone-else', two);
+
+        fanout.dispose();
+
+        expect(one.ended).toBe(true);
+        expect(two.ended).toBe(true);
+        expect(fanout.describeState().connectedIdentities).toBe(0)
     });
 
     test('lastPushAt is observational: recorded on delivery even when no stream is connected', async () => {

--- a/test/playwright/unit/ai/services/fleet/fleetWakeReceiver.spec.mjs
+++ b/test/playwright/unit/ai/services/fleet/fleetWakeReceiver.spec.mjs
@@ -21,7 +21,9 @@ import * as core      from '../../../../../../src/core/_export.mjs';
 
 import {createFleetWakeReceiver} from '../../../../../../ai/services/fleet/fleetWakeReceiver.mjs';
 
-const SIGNING_KEY = crypto.randomBytes(32).toString('hex');
+const
+    SIGNING_KEY = crypto.randomBytes(32).toString('hex'),
+    ROUTE       = {signingKey: SIGNING_KEY, agentIdentity: '@viewer'};
 
 /**
  * Drives the handler exactly like Express does: headers on the request object, the raw body
@@ -67,7 +69,31 @@ function sign(bodyString, key = SIGNING_KEY) {
     return crypto.createHmac('sha256', key).update(Buffer.from(bodyString)).digest('hex')
 }
 
-function createHandler({onDigest = () => {}, route = {signingKey: SIGNING_KEY, agentIdentity: '@viewer'}} = {}) {
+/** A fully route-bound envelope; overrides produce the mismatch negatives. */
+function envelope(overrides = {}) {
+    return {
+        eventId       : 'EVT:1',
+        subscriptionId: 'WAKE_SUB:known',
+        agentIdentity : '@viewer',
+        eventType     : 'wake/digest',
+        schemaVersion : '1.0',
+        payload       : {digest: 'wake up'},
+        ...overrides
+    }
+}
+
+/** Headers agreeing with {@link envelope}; overrides produce header-disagreement negatives. */
+function boundHeaders(bodyString, overrides = {}) {
+    return {
+        'x-neo-wake-subscription-id': 'WAKE_SUB:known',
+        'x-neo-wake-event-id'       : 'EVT:1',
+        'x-neo-wake-schema-version' : '1.0',
+        'x-neo-wake-signature'      : sign(bodyString),
+        ...overrides
+    }
+}
+
+function createHandler({onDigest = () => {}, route = ROUTE} = {}) {
     return createFleetWakeReceiver({
         resolveRoute: id => (id === 'WAKE_SUB:known' ? route : null),
         onDigest,
@@ -98,12 +124,11 @@ test.describe('fleetWakeReceiver - signed wake admission for the composed fleet 
     test('a wrong signature is refused before the body is ever parsed', async () => {
         let digests = 0;
 
+        const body = JSON.stringify(envelope());
+
         const res = await invoke(createHandler({onDigest: () => digests++}), {
-            headers: {
-                'x-neo-wake-subscription-id': 'WAKE_SUB:known',
-                'x-neo-wake-signature'      : sign('{"other":"bytes"}')
-            },
-            bodyChunks: ['{"digest":"hello"}']
+            headers   : boundHeaders(body, {'x-neo-wake-signature': sign('{"other":"bytes"}')}),
+            bodyChunks: [body]
         });
 
         expect(res.statusCode).toBe(401);
@@ -111,16 +136,13 @@ test.describe('fleetWakeReceiver - signed wake admission for the composed fleet 
         expect(digests).toBe(0)
     });
 
-    test('a valid signature over the exact bytes admits the digest and hands it over verbatim', async () => {
+    test('a fully route-bound signed envelope is admitted and handed over verbatim', async () => {
         const
             received = [],
-            body     = JSON.stringify({subscriptionId: 'WAKE_SUB:known', digest: 'wake up'});
+            body     = JSON.stringify(envelope());
 
         const res = await invoke(createHandler({onDigest: digest => received.push(digest)}), {
-            headers: {
-                'x-neo-wake-subscription-id': 'WAKE_SUB:known',
-                'x-neo-wake-signature'      : sign(body)
-            },
+            headers   : boundHeaders(body),
             bodyChunks: [body]
         });
 
@@ -129,18 +151,16 @@ test.describe('fleetWakeReceiver - signed wake admission for the composed fleet 
         expect(received).toEqual([{
             subscriptionId: 'WAKE_SUB:known',
             agentIdentity : '@viewer',
-            envelope      : {subscriptionId: 'WAKE_SUB:known', digest: 'wake up'}
+            envelope      : envelope()
         }])
     });
 
     test('the signature must cover the exact raw bytes — a chunk-identical rewrite fails', async () => {
-        // Same JSON semantics, different bytes (whitespace) — the HMAC is over bytes, not meaning.
+        const body = JSON.stringify(envelope());
+
         const res = await invoke(createHandler(), {
-            headers: {
-                'x-neo-wake-subscription-id': 'WAKE_SUB:known',
-                'x-neo-wake-signature'      : sign('{"digest":"x"}')
-            },
-            bodyChunks: ['{ "digest": "x" }']
+            headers   : boundHeaders(body),
+            bodyChunks: [` ${body}`]
         });
 
         expect(res.statusCode).toBe(401);
@@ -151,10 +171,7 @@ test.describe('fleetWakeReceiver - signed wake admission for the composed fleet 
         const body = 'not json at all';
 
         const res = await invoke(createHandler(), {
-            headers: {
-                'x-neo-wake-subscription-id': 'WAKE_SUB:known',
-                'x-neo-wake-signature'      : sign(body)
-            },
+            headers   : boundHeaders(body),
             bodyChunks: [body]
         });
 
@@ -162,16 +179,50 @@ test.describe('fleetWakeReceiver - signed wake admission for the composed fleet 
         expect(res.body).toEqual({error: 'invalid-json'})
     });
 
+    for (const [label, mutate] of [
+        ['a foreign owner identity',     {agentIdentity: '@someone-else'}],
+        ['a relabeled subscription id',  {subscriptionId: 'WAKE_SUB:other'}],
+        ['an unknown event type',        {eventType: 'wake/other'}],
+        ['an unknown schema version',    {schemaVersion: '2.0'}]
+    ]) {
+        test(`signed-route-mismatch: an authentic signature over ${label} delivers nothing`, async () => {
+            let digests = 0;
+
+            const body = JSON.stringify(envelope(mutate));
+
+            const res = await invoke(createHandler({onDigest: () => digests++}), {
+                headers   : boundHeaders(body),
+                bodyChunks: [body]
+            });
+
+            expect(res.statusCode).toBe(409);
+            expect(res.body).toEqual({error: 'signed-route-mismatch'});
+            expect(digests).toBe(0)
+        })
+    }
+
+    test('signed-route-mismatch: header/envelope disagreement on the event id delivers nothing', async () => {
+        let digests = 0;
+
+        const body = JSON.stringify(envelope());
+
+        const res = await invoke(createHandler({onDigest: () => digests++}), {
+            headers   : boundHeaders(body, {'x-neo-wake-event-id': 'EVT:2'}),
+            bodyChunks: [body]
+        });
+
+        expect(res.statusCode).toBe(409);
+        expect(res.body).toEqual({error: 'signed-route-mismatch'});
+        expect(digests).toBe(0)
+    });
+
     test('a delivery-side fault is absorbed: the dispatcher must never be told to retry it', async () => {
-        const body = JSON.stringify({digest: 'boom'});
+        const body = JSON.stringify(envelope());
 
         const res = await invoke(createHandler({onDigest: () => {
             throw new Error('downstream fan-out fault')
         }}), {
-            headers: {
-                'x-neo-wake-subscription-id': 'WAKE_SUB:known',
-                'x-neo-wake-signature'      : sign(body)
-            },
+            headers   : boundHeaders(body),
             bodyChunks: [body]
         });
 

--- a/test/playwright/unit/ai/services/fleet/fleetWakeReceiver.spec.mjs
+++ b/test/playwright/unit/ai/services/fleet/fleetWakeReceiver.spec.mjs
@@ -1,0 +1,181 @@
+import {setup} from '../../../../setup.mjs';
+
+const appName = 'FleetWakeReceiverTest';
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name             : appName,
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import crypto         from 'node:crypto';
+import {EventEmitter} from 'node:events';
+import Neo            from '../../../../../../src/Neo.mjs';
+import * as core      from '../../../../../../src/core/_export.mjs';
+
+import {createFleetWakeReceiver} from '../../../../../../ai/services/fleet/fleetWakeReceiver.mjs';
+
+const SIGNING_KEY = crypto.randomBytes(32).toString('hex');
+
+/**
+ * Drives the handler exactly like Express does: headers on the request object, the raw body
+ * arriving as stream events after the handler attached its listeners.
+ */
+function invoke(handler, {headers = {}, bodyChunks = []} = {}) {
+    const req = new EventEmitter();
+
+    req.headers = headers;
+    req.destroy = () => {};
+
+    const res = {
+        statusCode: null,
+        body      : null,
+        status(code) {
+            this.statusCode = code;
+            return this
+        },
+        json(payload) {
+            this.body = payload;
+            this._resolve?.()
+        }
+    };
+
+    const done = new Promise(resolve => {
+        res._resolve = resolve
+    });
+
+    const invocation = handler(req, res);
+
+    queueMicrotask(() => {
+        for (const chunk of bodyChunks) {
+            req.emit('data', Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk))
+        }
+
+        req.emit('end')
+    });
+
+    return Promise.all([invocation, done]).then(() => res)
+}
+
+function sign(bodyString, key = SIGNING_KEY) {
+    return crypto.createHmac('sha256', key).update(Buffer.from(bodyString)).digest('hex')
+}
+
+function createHandler({onDigest = () => {}, route = {signingKey: SIGNING_KEY, agentIdentity: '@viewer'}} = {}) {
+    return createFleetWakeReceiver({
+        resolveRoute: id => (id === 'WAKE_SUB:known' ? route : null),
+        onDigest,
+        logger      : {error: () => {}}
+    })
+}
+
+test.describe('fleetWakeReceiver - signed wake admission for the composed fleet server', () => {
+    test('an unknown subscription answers the exact vocabulary the dispatcher tolerance keys on', async () => {
+        const res = await invoke(createHandler(), {
+            headers   : {'x-neo-wake-subscription-id': 'WAKE_SUB:stranger'},
+            bodyChunks: ['{}']
+        });
+
+        expect(res.statusCode).toBe(404);
+        // The literal string is load-bearing: WebhookDeliveryService#_isUnknownSubscriptionResponse
+        // grants its manifest-lag tolerance ONLY on this exact error value.
+        expect(res.body).toEqual({error: 'unknown-subscription'})
+    });
+
+    test('a missing subscription header is indistinguishable from an unknown route', async () => {
+        const res = await invoke(createHandler(), {headers: {}, bodyChunks: ['{}']});
+
+        expect(res.statusCode).toBe(404);
+        expect(res.body).toEqual({error: 'unknown-subscription'})
+    });
+
+    test('a wrong signature is refused before the body is ever parsed', async () => {
+        let digests = 0;
+
+        const res = await invoke(createHandler({onDigest: () => digests++}), {
+            headers: {
+                'x-neo-wake-subscription-id': 'WAKE_SUB:known',
+                'x-neo-wake-signature'      : sign('{"other":"bytes"}')
+            },
+            bodyChunks: ['{"digest":"hello"}']
+        });
+
+        expect(res.statusCode).toBe(401);
+        expect(res.body).toEqual({error: 'invalid-signature'});
+        expect(digests).toBe(0)
+    });
+
+    test('a valid signature over the exact bytes admits the digest and hands it over verbatim', async () => {
+        const
+            received = [],
+            body     = JSON.stringify({subscriptionId: 'WAKE_SUB:known', digest: 'wake up'});
+
+        const res = await invoke(createHandler({onDigest: digest => received.push(digest)}), {
+            headers: {
+                'x-neo-wake-subscription-id': 'WAKE_SUB:known',
+                'x-neo-wake-signature'      : sign(body)
+            },
+            bodyChunks: [body]
+        });
+
+        expect(res.statusCode).toBe(200);
+        expect(res.body).toEqual({ok: true, state: 'accepted'});
+        expect(received).toEqual([{
+            subscriptionId: 'WAKE_SUB:known',
+            agentIdentity : '@viewer',
+            envelope      : {subscriptionId: 'WAKE_SUB:known', digest: 'wake up'}
+        }])
+    });
+
+    test('the signature must cover the exact raw bytes — a chunk-identical rewrite fails', async () => {
+        // Same JSON semantics, different bytes (whitespace) — the HMAC is over bytes, not meaning.
+        const res = await invoke(createHandler(), {
+            headers: {
+                'x-neo-wake-subscription-id': 'WAKE_SUB:known',
+                'x-neo-wake-signature'      : sign('{"digest":"x"}')
+            },
+            bodyChunks: ['{ "digest": "x" }']
+        });
+
+        expect(res.statusCode).toBe(401);
+        expect(res.body).toEqual({error: 'invalid-signature'})
+    });
+
+    test('an authentically signed but unparsable body is invalid-json, never accepted', async () => {
+        const body = 'not json at all';
+
+        const res = await invoke(createHandler(), {
+            headers: {
+                'x-neo-wake-subscription-id': 'WAKE_SUB:known',
+                'x-neo-wake-signature'      : sign(body)
+            },
+            bodyChunks: [body]
+        });
+
+        expect(res.statusCode).toBe(400);
+        expect(res.body).toEqual({error: 'invalid-json'})
+    });
+
+    test('a delivery-side fault is absorbed: the dispatcher must never be told to retry it', async () => {
+        const body = JSON.stringify({digest: 'boom'});
+
+        const res = await invoke(createHandler({onDigest: () => {
+            throw new Error('downstream fan-out fault')
+        }}), {
+            headers: {
+                'x-neo-wake-subscription-id': 'WAKE_SUB:known',
+                'x-neo-wake-signature'      : sign(body)
+            },
+            bodyChunks: [body]
+        });
+
+        expect(res.statusCode).toBe(200);
+        expect(res.body).toEqual({ok: true, state: 'accepted'})
+    })
+});


### PR DESCRIPTION
Resolves neomjs/neo#17100

The wake push lane's server half, on the composed fleet-server: a signed `POST /wake` receiver (the Shape-B listener a no-checkout client cannot host, moved onto the plane), an identity-keyed SSE fan-out at `GET /fleet/events`, and fail-soft boot arming of the relay wake subscription over the authenticated MC surface. The producer is the existing signed dispatcher (`WebhookDeliveryService`) **unchanged** — a service-DNS subscription target rides it by construction — and every refusal path in the new lane renders as state with its reason, never a boot failure: push is latency, the shipped `poll-digest` verb stays the truth lane.

Key seams, verified in source before writing (the intake trail is on neomjs/neo#17100 and its parent neomjs/neo-agent-brain#50):

- **Receiver admission = the signature, exclusively.** Mounts BEFORE the client-auth chain (the dispatcher holds no provider bearer); imports the host receiver's own `verifyWakeSignature`; answers the host receiver's exact error vocabulary — the literal `unknown-subscription` string is load-bearing for `WebhookDeliveryService#_isUnknownSubscriptionResponse`'s manifest-lag tolerance. Raw-body read (a JSON parser upstream would destroy the exact bytes the HMAC covers). `/wake` is deliberately absent from the ingress route table: signed AND compose-internal, because reachability is never authentication.
- **Key custody, process-bearer class:** boot arming runs idempotent `subscribe` → unconditional `rotate-key`; the key lives in fan-out process memory only; a restart re-arms with a fresh key. Nothing persists a secret; no new credential class (ADR 0038 §2.5.1's row 6 as it stands).
- **Identity isolation is structural:** streams register under the admission-proven canonical identity; digests route by the subscription's identity recorded at arming — no broadcast path exists. The SSE `state` event is per-viewer honest (`armedForViewer`), so a viewer the lane is not armed for is told so and keeps poll-digest as truth.
- **Config:** one declarative leaf `fleet.wakeSelfBase` (`NEO_FLEET_WAKE_SELF_BASE`, empty default = honestly unarmed; a guessed self-address would aim signed POSTs at a stranger). ADR-0019 read-gate run at authoring; read at the boot entry, injected into the module (the `planeMailboxClient` bootstrap-boundary precedent).
- **Ingress:** `/fleet/events` joins the exact-route matchers in both Caddyfiles with `flush_interval -1` (SSE unbuffered); the composed profile declares the self-address in `docker-compose.local-agent-os.yml`.

Evidence: L2 (hermetic unit falsifiers for the receiver admission ladder and the fan-out registry/arming; full fleet spec directory green; deploy arms are declaration-reviewed) → L3 required (the end-to-end plane witness: the containerized dispatcher POSTing a signed digest at the composed receiver and an SSE client observing it — needs the rebuilt composition, and the running plane image currently lags dev). Residual: end-to-end plane witness, Residual-Owner: neomjs/neo-agent-brain#50.

## Cycle 2 — the authority repairs (2026-08-14, @neo-gpt's five RAs)

- **Arming is reachable from the canonical composition**: the shared endpoint policy gains a caller-declared `allowPlainHttpHosts` allowance (default empty = policy unchanged; the tenant flow passes none and stays strict), fed by the new `fleet.planeInternalHosts` leaf; the composed profile declares `NEO_FLEET_PLANE_BASE: http://ingress:8080` + `NEO_FLEET_PLANE_INTERNAL_HOSTS: ingress` with bearer/identity as operator pass-throughs. Boot-path falsifier reaches `armed` through `armFleetWakePushLane` with the client-construction seams captured (allowance threaded, `<base>/mc/mcp` derivation, subscribe→rotate order, route bound to the MC-proven identity).
- **Canonical identity end-to-end**: `resolveViewerStreamKey` keys streams and limiters from immutable facts only — the plane-proven identity for its own viewer, the `provider:<authProvider>:<providerUserId>` tuple for everyone else; display names are never keys (space-name and colliding-name falsifiers included). Connect-time ensure rides a persistent arming context with per-viewer cached outcomes; a viewer that is not the proven caller identity gets the honest caller-owned refusal — never a relabeled subscription.
- **Full signed route binding**: post-HMAC, the receiver validates envelope `{eventId, subscriptionId, agentIdentity, eventType, schemaVersion}` against headers and the resolved route, answering the canonical `409 signed-route-mismatch` — four mismatch negatives + a header-disagreement negative, all zero-delivery.
- **Deploy polarity at the executable seam**: new `FleetServerComposition.spec.mjs` asserts exact primary + 502-error matchers in both Caddy variants (the cloud error matcher gained `/fleet/events` — it was missing), `flush_interval -1`, `/wake` ingress-absence, and the compose arming env; plus server-level positives/negatives through the REAL app (signed `/wake` accepted, unknown 404, authenticated SSE streaming, unauthenticated 401).
- **Stream lifecycle**: per-stream `safeWrite` with a 256KB backpressure bound; a faulty stream is evicted without costing healthy streams their delivery (snapshot iteration); close/error share one idempotent cleanup; handshake failures never enter the registry; `dispose()` ends every held response and the server's `close()` disposes fan-out + plane session before waiting — proven by a shutdown-with-open-SSE-client test.

## Cycle 3 — the authority chain closed (2026-08-14, @neo-gpt's two remaining RAs)

- **Per-viewer ownership, delegation-free**: each admitted viewer arms with the viewer's OWN presented plane bearer — an ephemeral per-connect MC session (init proof → subscribe → rotate-key → close; the bearer is used in-flight and never stored), so MC's caller-owned model holds per viewer with no delegation surface and no privilege beyond what the viewer already presented. The stream registers under the identity MC PROVES for that bearer, never the request's claim. Proven end-to-end: two authenticated viewers through the REAL server + arming context (per-credential plane-client stub, no callTool injected into the fan-out), two MC-owned routes, signed cross-delivery isolation on the wire.
- **The canonical render carries a REAL credential**: `fleet.planeBearerFile` (secret-file custody) rides the SAME mounted admission secret the profile already uses (`NEO_FLEET_PLANE_BEARER_FILE: /run/secrets/mcp-auth-token`); the direct-value leaf stays the override. And per the review's own alternative: a DECLARED wake lane that resolves no credential now **refuses to boot loudly** instead of arming nothing.
- **Whole-mutation serialization**: the subscribe→rotate→route-install sequence is latched per identity inside the fan-out (shared in-flight promise, failure clears the latch for retry), and the context caches per-viewer promises rather than settled successes. The measured regression is now a falsifier: delayed rotate responses + two racing callers → ONE subscribe, ONE rotation, shared outcome, and exact equality between the fan-out's route key and MC's active key.

## Cycle 4 — credential-class custody restored (2026-08-14, @neo-gpt's non-alias findings)

The cycle-3 shape violated the ledger's load-bearing rule twice, and both substitutions are now structurally impossible:

- **Service lane**: a DEDICATED class-3 secret (`fleet-plane-token`, its own mint, the profile's loud-at-start custody shape) replaces the aliased admission token — and the rule has **runtime teeth**: `assertFleetPlaneBearerClass` compares the resolved plane bearer against the deployment's admission token (bound via the new `fleet.admissionTokenFile` leaf, the `wakeReceiverManifestPath` same-env-name precedent) and refuses to boot on equality. Render-level teeth too: the composition spec asserts the two secret paths are distinct.
- **Viewer lane**: the class-1 Fleet admission bearer is NEVER forwarded to `/mc/mcp` — per-viewer arming reads a separately carried class-3 credential (`x-neo-mc-authorization`), the ledger's one-seat-many-distinct-mints model as a wire contract. The non-alias falsifier runs first in the two-viewer test: a class-1-only connect arms nothing.

## Cycle 5 — the identical-token mutant sealed (2026-08-14)

A header label is not a credential authority: PATs carry no audience claim and both surfaces share the verifier, so the SAME bytes in both headers would still be class-1→class-3 forwarding. The arming seam itself now refuses a byte-identical viewer/fleet bearer pair before any MC client exists (`ensureArmedForViewer` compares the normalized pair; the route supplies the class-1 bytes). Falsified twice: the real-server identical-token mutant (same PAT in both headers → zero MC calls, honest unarmed stream) and a context-level unit negative (zero client constructions). The distinct-token two-viewer positive stands.

## Cycle 6 — disposal is a closed epoch (2026-08-14)

The reviewer's dynamic falsifier proved a delayed `ensureArmedForViewer` could outlive shutdown — the late rotate reinstalled the route into a disposed fan-out, and a post-disposal registration could keep `server.close()` waiting. Disposal and context close now flip their epoch flags SYNCHRONOUSLY before any teardown: route commits re-check the epoch AFTER the awaits (the load-bearing check — a mutation that crossed the boundary ends unarmed, not undead), stream registrations refuse into a disposed registry, and closed contexts refuse new ensures at both doors. The delayed-rotate shutdown regression proves all four assertions: unarmed outcome, no surviving route, refused registration, resolved close.

## Deltas from ticket

- The producer correction (signed dispatcher = `WebhookDeliveryService`, not the daemon's unsigned `deliverViaWebhookUrl`) plus the key-custody flow (subscribe→rotate-key, in-memory only) and the per-viewer relay-subscription shape were all folded into the neomjs/neo#17100 body at intake, pre-implementation — the diff implements the corrected body, so: none substantive beyond it.
- `describeStateFor(identity)` (per-viewer honest SSE state) emerged during implementation: the composed server serves per-request identities while arming is caller-owned on the MC side; a global `armed` flag would have claimed the lane for viewers it cannot serve.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/ai/services/fleet/fleetWakeReceiver.spec.mjs test/playwright/unit/ai/services/fleet/fleetWakeFanout.spec.mjs` → 18 passed. Falsifiers include: exact-vocabulary 404; signature-over-exact-bytes (chunk-identical whitespace rewrite refused); signed-but-unparsable never accepted; delivery-side fault absorbed (dispatcher never told to retry); digest identity isolation (second identity's stream receives nothing); rotate-key-without-key refuses arming; undeclared self-base renders its reason.
- `npm run test-unit -- test/playwright/unit/ai/services/fleet/` → 598 passed (cycle-6 head; was 550 (regression over the modified `fleetServer.mjs` included; `fleetServer.spec.mjs` green; includes the held-stream cap falsifiers added with the CodeQL repair — per-viewer cap with untouched-response proof + slot-freeing close, total cap across identities).
- `npm run agent-preflight -- --change-class capability --commit-subject … <files>` → all gates passed (ticket-archaeology clean after stripping tracker refs from durable comments; JSDoc types catharsis-parseable after dropping TS-style `import()` forms).
- ai/deploy surfaces (Caddyfile ×2, compose): `None found` (no executable local harness for ingress config; declaration-reviewed, exercised by the L3 witness).

## Post-Merge Validation

Residual-Owner: neomjs/neo-agent-brain#50

- [ ] End-to-end plane witness on the rebuilt composition: MC dispatcher delivers a signed digest to `fleet-server:8083/wake` (boot log shows `wake push lane: armed`), an authenticated SSE client at `/fleet/events` observes the `wake` event, and a deliberately wrong-signature probe answers `401 invalid-signature` while `/wake` via the ingress answers `404`.
- [ ] The slice-3 consumer (#17101) exercises reconnect catch-up via `poll-digest` against this receiver's stream.

## Commits (if multi-commit)

1. `1786bf6544` — the slice: receiver, fan-out, wiring, leaf, deploy arms, specs.
2. `e4b2482a5d` — the leaf's record in the config-template parity snapshot (the Config Template SSOT lint's sanctioned `--update-parity`; the snapshot wants the same commit as the leaf — it rides the same PR as the honest second-best, since the leaf commit was already pushed when the lint taught me it exists).
3. `3c72c463df` — the CodeQL missing-rate-limiting repair: `express-rate-limit` on both new routes (subscription-keyed for `/wake` with a single shared bucket for unknown ids; identity-keyed for `/fleet/events`) + concurrent held-stream caps in the fan-out (8/viewer, 64 total, named refusals). Thread: discussion_r3782335153.
4. `f2a6a68169` — cycle-2 authority repairs (the five RAs above) + the `planeInternalHosts` parity record.
5. `b6af18e7ac` — cycle-3: per-viewer bearer arming, whole-mutation serialization, `planeBearerFile` + fail-loud boot, two-real-viewer end-to-end falsifier.
6. `a214b7f2bf` — cycle-4: dedicated `fleet-plane-token` secret + separated-token runtime/render teeth + the separately carried class-3 viewer credential (`x-neo-mc-authorization`); class-1 forwarding structurally removed.
7. `09df6a2edb` — cycle-5: byte-identical viewer/fleet bearer pairs refused at the arming seam; identical-token mutant falsifiers (real-server + unit).
8. `6e7b6cfa86` — cycle-6: closed-epoch disposal (fan-out + arming context), post-await route-commit re-check, delayed-rotate shutdown regression.

Related: neomjs/neo-agent-brain#50 (parent umbrella; carries the Signal Ledger of its D#16720 graduation) · neomjs/neo-agent-brain#83 (epic) · neomjs/neo#17101 / neomjs/neo#17102 (sibling slices) · neomjs/neo#16800 (slice 1, merged).

Authored by Clio (Fable 5, Claude Code). Session c4996813-01b9-4234-8bdd-ed3bf22c0970.
