### PR TITLE
feat(ai): share one provider-timeout notification across both embedding lanes (#16997)

### DIFF
--- a/ai/daemons/embed/drainCycle.mjs
+++ b/ai/daemons/embed/drainCycle.mjs
@@ -4,10 +4,10 @@ import {
     pruneReconciledWalSegments,
     readPendingWalRecords
 } from '../../services/memory-core/helpers/memoryWalStore.mjs';
-import {classifyRowVector, VECTOR_REJECTION_REASONS}                   from '../../services/memory-core/helpers/vectorWriteInvariant.mjs';
-import {createDrainDispositionTracker}                                 from '../shared/drainDisposition.mjs';
-import {OPENAI_COMPATIBLE_REQUEST_TIMEOUT_CODE, PROVIDER_TIMEOUT_CODE} from '../../provider/createTimeoutError.mjs';
-import {runWithProviderActivityContext}                                from '../../services/shared/providerActivityLedger.mjs';
+import {classifyRowVector, VECTOR_REJECTION_REASONS} from '../../services/memory-core/helpers/vectorWriteInvariant.mjs';
+import {createDrainDispositionTracker}               from '../shared/drainDisposition.mjs';
+import {isProviderTimeoutCode}                       from '../../provider/createTimeoutError.mjs';
+import {runWithProviderActivityContext}              from '../../services/shared/providerActivityLedger.mjs';
 
 /**
  * @summary One durable drain pass over the `add_memory` write-ahead log.
@@ -96,38 +96,34 @@ export function getBackoffDelayMs(backoffBaseMs, attempt) {
 }
 
 /**
- * @summary Typed provider error codes meaning "the provider is BUSY", never "the request was bad".
+ * @summary Default contention predicate — is this failure the provider being saturated, never
+ * "the request was bad"?
  *
  * Both local inference providers stamp a code on their own timeout: the OpenAI-compatible transport
  * emits `OPENAI_COMPATIBLE_REQUEST_TIMEOUT`, native Ollama owns the shared `PROVIDER_TIMEOUT` shape,
  * and the socket layer contributes the two `*TIMEDOUT` codes. Keyed on `error.code` rather than on
  * message text: codes are a provider-owned protocol constant, whereas the message-shaped half of
  * the classification in `TextEmbeddingService` is coupled to a message THIS module never sees
- * (that file pins its own log string verbatim precisely because its regex reads it). Duplicating
- * the coupled half here would split a matched pair across modules; duplicating the codes does not.
+ * (that file pins its own log string verbatim precisely because its regex reads it). Splitting that
+ * matched pair across modules is what must not happen; sharing the codes is not that.
  *
- * **Both codes are IMPORTED from their single owner** (`ai/provider/createTimeoutError.mjs`), so a
- * rename at the source is a compile-visible event in this classifier rather than a silent behaviour
- * change. That matters more here than tidiness: while the value was repeated at the producer and at
- * each consumer, a coordinated producer-plus-producer-test rename could have left this classifier
- * and its fixtures green while restoring the exact retry amplification the classifier exists to
- * prevent. Independently-pinned literals cannot detect coordinated drift; a shared import can.
- * @type {Set<String>}
- */
-const PROVIDER_CONTENTION_CODES = Object.freeze(new Set([
-    'ESOCKETTIMEDOUT',
-    'ETIMEDOUT',
-    OPENAI_COMPATIBLE_REQUEST_TIMEOUT_CODE,
-    PROVIDER_TIMEOUT_CODE
-]));
-
-/**
- * @summary Default contention predicate — is this failure the provider being saturated?
+ * **The membership test itself now comes from the codes' single owner**
+ * ({@link Neo.ai.provider.createTimeoutError.isProviderTimeoutCode}), which strengthens an argument
+ * this classifier already made. Importing the two constants made a *rename* compile-visible here;
+ * importing the predicate makes an *added timeout code* arrive here too. That distinction is the
+ * whole point: a coordinated producer-plus-producer-test change could previously have left this
+ * classifier and its fixtures green while restoring the exact retry amplification the classifier
+ * exists to prevent. Independently-pinned lists cannot detect coordinated drift, and a list that is
+ * merely *built from* shared constants still silently disagrees when a fifth code is added.
+ *
+ * This daemon's contention question is exactly "did the provider attempt time out", so the shared
+ * predicate is consumed whole rather than composed with extra terms.
+ *
  * @param {Error} error Failure raised by `collection.add`.
  * @returns {Boolean}
  */
 export function isProviderContentionError(error) {
-    return PROVIDER_CONTENTION_CODES.has(error?.code);
+    return isProviderTimeoutCode(error?.code);
 }
 
 /**

--- a/ai/provider/createTimeoutError.mjs
+++ b/ai/provider/createTimeoutError.mjs
@@ -35,6 +35,45 @@ const PROVIDER_TIMEOUT_CODE = 'PROVIDER_TIMEOUT';
 const OPENAI_COMPATIBLE_REQUEST_TIMEOUT_CODE = 'OPENAI_COMPATIBLE_REQUEST_TIMEOUT';
 
 /**
+ * Every code that means "a provider request ran out of time", across both local transports.
+ *
+ * Two of these are ours ({@link PROVIDER_TIMEOUT_CODE}, {@link OPENAI_COMPATIBLE_REQUEST_TIMEOUT_CODE})
+ * and two are Node's socket-layer codes that surface when the transport gives up before either of ours
+ * is stamped. Consumers care about the union — "did this attempt time out" — while the individual codes
+ * stay distinct facts about WHICH layer gave up, which is why the union lives beside them rather than
+ * collapsing them.
+ * @type {Set<String>}
+ */
+const PROVIDER_TIMEOUT_CODES = Object.freeze(new Set([
+    'ESOCKETTIMEDOUT',
+    'ETIMEDOUT',
+    OPENAI_COMPATIBLE_REQUEST_TIMEOUT_CODE,
+    PROVIDER_TIMEOUT_CODE
+]));
+
+/**
+ * @summary Whether an error code is a provider timeout — the one classifier both local providers share.
+ *
+ * The membership test itself is trivial; housing it here is the point. This exact four-code list had
+ * been re-typed at four call sites with three different shapes (a frozen Set, two inline `||` chains,
+ * and a chain that also matches an HTTP contention pattern), so adding a fifth timeout code meant
+ * finding all four — and the JSDoc above {@link OPENAI_COMPATIBLE_REQUEST_TIMEOUT_CODE} already records
+ * why a coordinated rename can keep every test green while silently restoring retry amplification.
+ *
+ * **Deliberately narrow.** This answers "did the attempt time out", nothing else. Callers that also
+ * treat aborts, an open circuit, or provider-busy responses as terminal COMPOSE those terms around this
+ * predicate rather than folding them in: an abort and an open circuit are caller-owned facts with
+ * different outcomes, and a predicate that quietly absorbed them would let a cancelled request read as
+ * a provider timeout at every consumer at once.
+ *
+ * @param {String|undefined|null} code The `error.code` to classify.
+ * @returns {Boolean} `true` only for a known provider-timeout code.
+ */
+function isProviderTimeoutCode(code) {
+    return PROVIDER_TIMEOUT_CODES.has(code);
+}
+
+/**
  * @summary The shared provider-request options contract honored by local providers.
  *
  * @typedef {Object} ProviderTimeoutOptions
@@ -71,4 +110,10 @@ function createTimeoutError({provider, operationLabel, timeoutMs, host, modelNam
     return error;
 }
 
-export {OPENAI_COMPATIBLE_REQUEST_TIMEOUT_CODE, PROVIDER_TIMEOUT_CODE, createTimeoutError};
+export {
+    OPENAI_COMPATIBLE_REQUEST_TIMEOUT_CODE,
+    PROVIDER_TIMEOUT_CODE,
+    PROVIDER_TIMEOUT_CODES,
+    createTimeoutError,
+    isProviderTimeoutCode
+};

--- a/ai/provider/createTimeoutError.mjs
+++ b/ai/provider/createTimeoutError.mjs
@@ -42,6 +42,12 @@ const OPENAI_COMPATIBLE_REQUEST_TIMEOUT_CODE = 'OPENAI_COMPATIBLE_REQUEST_TIMEOU
  * is stamped. Consumers care about the union — "did this attempt time out" — while the individual codes
  * stay distinct facts about WHICH layer gave up, which is why the union lives beside them rather than
  * collapsing them.
+ *
+ * **Module-private on purpose.** Only {@link isProviderTimeoutCode} crosses the boundary. A `Set` is
+ * not protected by `Object.freeze` — `.add()` still succeeds on a frozen one — so an exported set would
+ * be a shared mutable classifier that any consumer could widen for every other consumer at once. That
+ * is the drift this SSOT exists to remove, so the set does not leave this module and no consumer needs
+ * it to: all three ask the same question, and the predicate is that question.
  * @type {Set<String>}
  */
 const PROVIDER_TIMEOUT_CODES = Object.freeze(new Set([
@@ -113,7 +119,6 @@ function createTimeoutError({provider, operationLabel, timeoutMs, host, modelNam
 export {
     OPENAI_COMPATIBLE_REQUEST_TIMEOUT_CODE,
     PROVIDER_TIMEOUT_CODE,
-    PROVIDER_TIMEOUT_CODES,
     createTimeoutError,
     isProviderTimeoutCode
 };

--- a/ai/services/knowledge-base/VectorService.mjs
+++ b/ai/services/knowledge-base/VectorService.mjs
@@ -4,10 +4,7 @@ import TextEmbeddingService, {
     isEmbeddingBatchYieldError
 }                             from '../memory-core/TextEmbeddingService.mjs';
 import mcConfig from '../../mcp/server/memory-core/config.mjs';
-import {
-    OPENAI_COMPATIBLE_REQUEST_TIMEOUT_CODE,
-    PROVIDER_TIMEOUT_CODE
-}               from '../../provider/createTimeoutError.mjs';
+import {isProviderTimeoutCode} from '../../provider/createTimeoutError.mjs';
 import Base     from '../../../src/core/Base.mjs';
 import {
     bytesToTokens,
@@ -727,11 +724,13 @@ class VectorService extends Base {
         for (let depth = 0; depth < 4 && current && typeof current === 'object' && !visited.has(current); depth++) {
             visited.add(current);
 
+            // Composed, never collapsed: the timeout half is the shared predicate, while abort and
+            // circuit-open stay explicit terms here. They are caller-owned facts with different
+            // outcomes, so folding them into the timeout predicate would make a cancelled request
+            // read as a provider timeout at every consumer of that predicate at once.
             if (isEmbeddingBatchYieldError(current) || current.name === 'AbortError' ||
                 current.code === 'ABORT_ERR' || current.code === KB_VECTOR_EMBED_PROVIDER_CIRCUIT_OPEN ||
-                current.code === PROVIDER_TIMEOUT_CODE ||
-                current.code === OPENAI_COMPATIBLE_REQUEST_TIMEOUT_CODE ||
-                current.code === 'ETIMEDOUT' || current.code === 'ESOCKETTIMEDOUT') {
+                isProviderTimeoutCode(current.code)) {
                 return true
             }
 
@@ -1164,12 +1163,7 @@ class VectorService extends Base {
                     // never be misclassified as provider work that might still be running.
                     const
                         providerCircuitOpen = embeddings === null && err?.code === KB_VECTOR_EMBED_PROVIDER_CIRCUIT_OPEN,
-                        providerTimedOut    = embeddings === null && (
-                            err?.code === PROVIDER_TIMEOUT_CODE ||
-                            err?.code === OPENAI_COMPATIBLE_REQUEST_TIMEOUT_CODE ||
-                            err?.code === 'ETIMEDOUT' ||
-                            err?.code === 'ESOCKETTIMEDOUT'
-                        );
+                        providerTimedOut    = embeddings === null && isProviderTimeoutCode(err?.code);
 
                     if (providerCircuitOpen || providerTimedOut) {
                         const disposition = providerCircuitOpen

--- a/ai/services/memory-core/TextEmbeddingService.mjs
+++ b/ai/services/memory-core/TextEmbeddingService.mjs
@@ -14,7 +14,11 @@ import {
     observeUnqueuedProviderActivity
 }                           from '../shared/providerActivityLedger.mjs';
 import MemoryCoreRecorderService                                       from './MemoryCoreRecorderService.mjs';
-import {OPENAI_COMPATIBLE_REQUEST_TIMEOUT_CODE, PROVIDER_TIMEOUT_CODE} from '../../provider/createTimeoutError.mjs';
+import {
+    OPENAI_COMPATIBLE_REQUEST_TIMEOUT_CODE,
+    PROVIDER_TIMEOUT_CODE,
+    isProviderTimeoutCode
+}                           from '../../provider/createTimeoutError.mjs';
 import {
     bytesToTokens,
     emitConsumerFriction
@@ -463,10 +467,63 @@ export function isOpenAiCompatibleContentionTimeoutError(error) {
     const message = error?.message || '',
           code    = error?.code    || '';
 
+    // Deliberately NOT `isProviderTimeoutCode`: this predicate answers "should the interactive
+    // single-embed retry", which is a superset on one axis (the HTTP contention message) and a
+    // subset on another — `PROVIDER_TIMEOUT` is absent because the OpenAI-compatible embedding
+    // transport never stamps it. Swapping in the shared four-code predicate would widen contention
+    // retry rather than deduplicate it, so the two classifiers stay separate on purpose.
     return code === OPENAI_COMPATIBLE_REQUEST_TIMEOUT_CODE ||
         code === 'ETIMEDOUT' ||
         code === 'ESOCKETTIMEDOUT' ||
         OPENAI_COMPATIBLE_CONTENTION_HTTP_ERROR_RE.test(message);
+}
+
+/**
+ * @summary Runs the caller-owned provider-timeout circuit hook BEFORE local admission advances —
+ * the one ordered notification both local embedding providers share.
+ *
+ * **Why one helper rather than a branch per provider.** The two paths have genuinely different
+ * admission machinery (native Ollama: a capped slot released on provider settlement; OpenAI-compatible:
+ * a single-lane queue whose drain selects the next task immediately after a rejection), but they owe
+ * the caller the identical *ordering* guarantee: if this attempt timed out, the caller's circuit is
+ * told before anything else can be dispatched into the provider that just failed. Expressing that
+ * ordering twice is what let it exist in only one of them.
+ *
+ * **What this helper does NOT own.** It does not create, hold, or reason about the tenant-run circuit;
+ * it does not author the circuit-open reason; and it never converts a hook failure into an outcome.
+ * The caller owns its `AbortController` and its distinct circuit-open error — this layer owns only
+ * "typed timeout detected → notify synchronously → let the source error stand".
+ *
+ * **The containment cell, stated exactly.** A hook
+ * that synchronously opens its circuit and *then* throws is contained here — the source provider error
+ * survives, admission is not stalled, and a queued task's synchronous removal is not undone. A hook
+ * that throws *before* opening its circuit is explicitly outside the guarantee: this layer will not
+ * invent fallback circuit authority, so a later dispatch is possible and is the caller's contract to
+ * keep, not this helper's to synthesize.
+ *
+ * @param {Object} options
+ * @param {Error} options.error The settled provider failure to classify.
+ * @param {Function} [options.onProviderTimeout] Caller-owned synchronous circuit hook.
+ * @param {String} options.providerLabel Bounded provider name for the diagnostic log only.
+ * @returns {Boolean} `true` when the error was a typed provider timeout (whether or not a hook ran).
+ */
+export function notifyProviderTimeout({error, onProviderTimeout, providerLabel}) {
+    if (!isProviderTimeoutCode(error?.code)) {
+        return false;
+    }
+
+    try {
+        onProviderTimeout?.(error);
+    } catch (hookError) {
+        // The hook is an advisory circuit signal, never a replacement for the source provider error.
+        // Preserve the timing-out repository's timeout identity even when a caller supplied a broken
+        // hook, and keep the log bounded to structural error identity — never hook or prompt content.
+        logger.warn(`[TextEmbeddingService] ${providerLabel} provider-timeout hook failed.`, {
+            errorName: hookError?.name || 'Error'
+        });
+    }
+
+    return true;
 }
 
 /**
@@ -703,6 +760,19 @@ class TextEmbeddingService extends Base {
                     task.resolve(result);
                 } catch (err) {
                     task.lifecycle.onSettled({completedAt: Date.now(), success: false});
+
+                    // The queue task — not each transport attempt — owns final failure, so by the
+                    // time this catch runs `#postOpenAiCompatible` has already exhausted its
+                    // contention/unload retries. This is therefore the FINAL logical timeout, and it
+                    // is the last point before `while` selects another task and dispatches into the
+                    // provider that just failed. Notify before `reject` so the caller's circuit is
+                    // open before any continuation of theirs can observe the rejection.
+                    notifyProviderTimeout({
+                        error            : err,
+                        onProviderTimeout: task.options?.onProviderTimeout,
+                        providerLabel    : 'OpenAI-compatible'
+                    });
+
                     task.reject(err);
                 }
             }
@@ -1553,16 +1623,14 @@ class TextEmbeddingService extends Base {
                     // listeners synchronously remove never-dispatched waiters from the admission
                     // queue; releasing first would let the next repository acquire the slot behind
                     // work whose provider-side settlement is not known to imply compute idleness.
-                    if (error?.code === PROVIDER_TIMEOUT_CODE) {
-                        onProviderTimeout?.(error);
-                    }
-                } catch (hookError) {
-                    // The hook is an advisory circuit signal, never a replacement for the source
-                    // provider error. Preserve A's timeout identity even if a caller supplied a
-                    // broken hook, and keep the log bounded to structural error identity.
-                    logger.warn('[TextEmbeddingService] Native Ollama provider-timeout hook failed.', {
-                        errorName: hookError?.name || 'Error'
-                    });
+                    //
+                    // The same helper runs at the OpenAI-compatible queue's final rejection, so both
+                    // lanes share one ordering guarantee. Note this fires on the full typed-timeout
+                    // set rather than `PROVIDER_TIMEOUT` alone:
+                    // a native request that dies at the socket layer (`ETIMEDOUT`/`ESOCKETTIMEDOUT`)
+                    // was previously invisible to the circuit here, which is the same defect in the
+                    // native path that this ticket fixes in the queued one.
+                    notifyProviderTimeout({error, onProviderTimeout, providerLabel: 'Native Ollama'});
                 } finally {
                     this.#releaseOllamaEmbeddingSlot();
                 }
@@ -1589,12 +1657,15 @@ class TextEmbeddingService extends Base {
      *
      * @param {String[]} texts The texts to embed.
      * @param {Object} options Abort and observability context.
+     * @param {Function} [options.onProviderTimeout] Caller-owned synchronous provider-timeout circuit
+     *     hook, carried to the queue task so the drain can notify before selecting another task.
      * @param {Function} [options.shouldYield] Cooperative heavy-maintenance-lease yield predicate.
      * @returns {Promise<number[][]>}
      * @private
      */
     async #embedOpenAiCompatibleBatch(texts, options) {
         const {
+            onProviderTimeout,
             operation,
             operationLabel,
             providerActivity,
@@ -1648,6 +1719,7 @@ class TextEmbeddingService extends Base {
                       requestTimeoutMs,
                       signal,
                       operationLabel,
+                      onProviderTimeout,
                       operation,
                       providerActivity,
                       providerActivityRecorder
@@ -1727,6 +1799,7 @@ class TextEmbeddingService extends Base {
                     requestTimeoutMs     : contentionTimeoutMs,
                     signal,
                     operationLabel,
+                    onProviderTimeout,
                     operation,
                     providerActivity,
                     providerActivityRecorder
@@ -1842,6 +1915,7 @@ class TextEmbeddingService extends Base {
                 return this.#embedOpenAiCompatibleBatch(requestTexts, {
                     operation,
                     operationLabel,
+                    onProviderTimeout,
                     providerActivity,
                     providerActivityRecorder,
                     shouldYield,

--- a/test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncService.spec.mjs
@@ -2611,6 +2611,151 @@ test.describe('TenantRepoSyncService (#11790)', () => {
         }
     });
 
+    test('an OpenAI-compatible provider timeout stops the queued repo in this sweep and a fresh sweep dispatches it', async () => {
+        const
+            {default: embeddingConfig} = await import(
+                '../../../../../../../ai/mcp/server/memory-core/config.template.mjs'
+            ),
+            originalHost      = embeddingConfig.openAiCompatible.host,
+            originalTimeout   = embeddingConfig.openAiCompatible.batchEmbeddingTimeoutMs,
+            originalUnload    = embeddingConfig.openAiCompatible.unloadRetryCount,
+            originalProbe     = TextEmbeddingService.openAiCompatibleLoadedModelsProbe,
+            {default: http}   = await import('node:http'),
+            taskStateService  = createInMemoryTaskStateService(),
+            slugs             = ['org/oai-timeout-a', 'org/oai-timeout-b'],
+            serverRequests    = [],
+            ingestionEntries  = [],
+            controlsSeen      = [],
+            ingestionService  = makeFakeIngestionService();
+
+        let firstRunPromise, secondRunPromise, signalBothEntered, server;
+
+        const bothEntered = new Promise(resolve => signalBothEntered = resolve);
+
+        // The first request NEVER responds, so repo A holds the single-lane queue until its batch
+        // timeout fires. Every later request answers, so the second sweep can complete.
+        server = http.createServer((req, res) => {
+            let body = '';
+
+            req.on('data', chunk => body += chunk);
+            req.on('end', () => {
+                serverRequests.push(JSON.parse(body || '{}').input);
+
+                if (serverRequests.length === 1) return;
+
+                res.writeHead(200, {'Content-Type': 'application/json'});
+                res.end(JSON.stringify({data: [{index: 0, embedding: [0.1]}]}))
+            })
+        });
+
+        await new Promise(resolve => server.listen(0, '127.0.0.1', resolve));
+
+        embeddingConfig.openAiCompatible.host                    = `http://127.0.0.1:${server.address().port}`;
+        embeddingConfig.openAiCompatible.batchEmbeddingTimeoutMs = 300;
+        embeddingConfig.openAiCompatible.unloadRetryCount        = 0;
+        TextEmbeddingService.openAiCompatibleLoadedModelsProbe    = async () => [{
+            id           : embeddingConfig.openAiCompatible.embeddingModel,
+            contextLength: embeddingConfig.localModels.embedding.contextLimitTokens
+        }];
+        TenantRepoSyncService.concurrencyLimit = 2;
+
+        ingestionService.ingestSourceFilesForTenantSync = async (payload, controls) => {
+            const embeddingPromise = TextEmbeddingService.embedTexts([payload.repoSlug], 'openAiCompatible', {
+                ...controls,
+                operationLabel          : 'tenant oai timeout circuit spec',
+                operationStage          : 'kb-tenant-ingestion-embedding',
+                providerActivityRecorder: null,
+                service                 : 'knowledge-base'
+            });
+
+            ingestionEntries.push(payload.repoSlug);
+            controlsSeen.push(controls);
+
+            if (ingestionEntries.length === 2) signalBothEntered();
+
+            try {
+                await embeddingPromise;
+                return {ingested: 1, deleted: 0, embeddingsGenerated: 1, errors: [], tenantId: payload.tenantId, durationMs: 1}
+            } catch (error) {
+                return {
+                    ingested           : 0,
+                    deleted            : 0,
+                    embeddingsGenerated: 0,
+                    errors             : [{code: classifyEmbedFailureCode(error.code)}],
+                    tenantId           : payload.tenantId,
+                    durationMs         : 1
+                }
+            }
+        };
+
+        const options = {
+            reason           : 'manual',
+            taskStateService,
+            tenantReposConfig: {tenantRepos: slugs.map((repoSlug, index) => ({
+                tenantId: 't1',
+                repoSlug,
+                mirrorRoot,
+                cloneUrl: `https://github.com/neomjs/oai-circuit-${index}.git`
+            }))},
+            gitMirror                    : makeFakeGitMirror(),
+            envelopeBuilder              : makeFakeEnvelopeBuilder(),
+            knowledgeBaseIngestionService: ingestionService,
+            revisionsFilePath            : revisionsFile,
+            seedBootstrap                : false
+        };
+
+        try {
+            for (const repoSlug of slugs) {
+                await provisionMirrorDir({tenantId: 't1', repoSlug});
+            }
+
+            firstRunPromise = TenantRepoSyncService.runTask({...options, onlyRepoSlugs: slugs});
+            await bothEntered;
+
+            expect(ingestionEntries).toHaveLength(2);
+            expect(controlsSeen[0].signal, 'both repos share one run-scoped circuit').toBe(controlsSeen[1].signal);
+
+            const first  = await firstRunPromise,
+                  bySlug = Object.fromEntries(first.details.repos.map(repo => [repo.repoSlug, repo]));
+
+            // The serialized queue admits exactly one repo; the other is genuinely queued behind it.
+            expect(serverRequests, 'the timed-out repo must not hand its lane to the queued repo').toHaveLength(1);
+
+            const dispatchedSlug = serverRequests[0][0],
+                  queuedSlug     = slugs.find(repoSlug => repoSlug !== dispatchedSlug);
+
+            expect(first).toMatchObject({status: 'deferred', details: {completedCount: 0, failedCount: 0}});
+            expect(bySlug[dispatchedSlug].lastSourceErrorCode, 'the dispatched repo keeps its own provider timeout')
+                .toBe('KB_VECTOR_EMBED_PROVIDER_TIMEOUT');
+            expect(bySlug[queuedSlug].lastSourceErrorCode, 'the queued repo reports the circuit, not a fabricated timeout')
+                .toBe(KB_VECTOR_EMBED_PROVIDER_CIRCUIT_OPEN);
+
+            secondRunPromise = TenantRepoSyncService.runTask({
+                ...options,
+                reason       : 'manual-resume',
+                onlyRepoSlugs: [queuedSlug]
+            });
+
+            const second = await secondRunPromise;
+
+            expect(serverRequests, 'the later sweep, not the timed-out sweep, dispatches the queued repo')
+                .toEqual([[dispatchedSlug], [queuedSlug]]);
+            expect(controlsSeen[2].signal, 'a later sweep gets a fresh circuit').not.toBe(controlsSeen[0].signal);
+            expect(controlsSeen[2].signal.aborted).toBe(false);
+            expect(second).toMatchObject({
+                status : 'completed',
+                details: {completedCount: 1, deferredCount: 0, failedCount: 0}
+            });
+        } finally {
+            await Promise.allSettled([firstRunPromise, secondRunPromise].filter(Boolean));
+            embeddingConfig.openAiCompatible.host                    = originalHost;
+            embeddingConfig.openAiCompatible.batchEmbeddingTimeoutMs = originalTimeout;
+            embeddingConfig.openAiCompatible.unloadRetryCount        = originalUnload;
+            TextEmbeddingService.openAiCompatibleLoadedModelsProbe    = originalProbe;
+            await new Promise(resolve => server.close(resolve));
+        }
+    });
+
     test('a deferral at a capped failure streak retains its cause for the recovery lane', async () => {
         // The production shape the first cohort missed: it started every repo at
         // `consecutiveFailures: 0`, where the backoff multiplier is 1 and nothing about the capped

--- a/test/playwright/unit/ai/provider/createTimeoutError.spec.mjs
+++ b/test/playwright/unit/ai/provider/createTimeoutError.spec.mjs
@@ -1,0 +1,102 @@
+import {setup} from '../../../setup.mjs';
+
+const appName = 'AiProviderTimeoutContractTest';
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name             : appName,
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../../src/Neo.mjs';
+import * as core      from '../../../../../src/core/_export.mjs';
+
+import * as timeoutContract from '../../../../../ai/provider/createTimeoutError.mjs';
+
+const {
+    OPENAI_COMPATIBLE_REQUEST_TIMEOUT_CODE,
+    PROVIDER_TIMEOUT_CODE,
+    isProviderTimeoutCode
+} = timeoutContract;
+
+/**
+ * The shared provider-timeout identity.
+ *
+ * The predicate is one line, so these cases exist for the SET it tests rather than the branching.
+ * The four codes had been re-typed at four call sites in three shapes, and the failure mode this
+ * guards is not "the predicate returns the wrong boolean" but "a fifth code is added to one list and
+ * silently disagrees with the other three". The negative cases matter more than the positive ones:
+ * caller abort, an open circuit, generic provider failures, and provider-busy responses must never
+ * read as a provider timeout, because this predicate gates a circuit hook that suppresses another
+ * repository's dispatch.
+ */
+test.describe('ai/provider/createTimeoutError — shared provider-timeout identity (#16997)', () => {
+    test('recognizes exactly the four provider-timeout codes', () => {
+        expect(isProviderTimeoutCode(PROVIDER_TIMEOUT_CODE), 'native provider timeout').toBe(true);
+        expect(isProviderTimeoutCode(OPENAI_COMPATIBLE_REQUEST_TIMEOUT_CODE), 'OpenAI-compatible transport timeout').toBe(true);
+        expect(isProviderTimeoutCode('ETIMEDOUT'), 'socket-layer timeout').toBe(true);
+        expect(isProviderTimeoutCode('ESOCKETTIMEDOUT'), 'socket-layer timeout').toBe(true);
+
+    });
+
+    test('AC-7 negative matrix: nothing else reads as a provider timeout', () => {
+        // Each of these reaches the same catch blocks as a real timeout, and each has a DIFFERENT
+        // correct outcome. An abort is caller-owned, a circuit-open is already the suppressed
+        // outcome, and a busy/model-load response means retry rather than open.
+        for (const code of [
+            'ABORT_ERR',
+            'KB_VECTOR_EMBED_PROVIDER_CIRCUIT_OPEN',
+            'ECONNREFUSED',
+            'ECONNRESET',
+            'EPIPE',
+            'MODEL_NOT_RESIDENT',
+            'KB_VECTOR_EMBED_FAILED'
+        ]) {
+            expect(isProviderTimeoutCode(code), `${code} must not read as a provider timeout`).toBe(false);
+        }
+    });
+
+    test('absent, empty, and non-string codes are false rather than throwing', () => {
+        // Every call site passes `error?.code` from an error it did not construct, so an error with
+        // no code at all is the ordinary case, not a defensive one.
+        for (const code of [undefined, null, '', 0, false, {}, []]) {
+            expect(isProviderTimeoutCode(code), `${JSON.stringify(code) ?? String(code)} must be false`).toBe(false);
+        }
+    });
+
+    test('a near-miss code is not matched by prefix or case', () => {
+        // The membership test is exact. A transport that stamped a lowercase or suffixed variant
+        // would be a producer bug worth failing loudly, not something to absorb here.
+        for (const code of [
+            'etimedout',
+            'ETIMEDOUT_',
+            'X_ETIMEDOUT',
+            'PROVIDER_TIMEOUT_EXCEEDED',
+            'provider_timeout'
+        ]) {
+            expect(isProviderTimeoutCode(code), `${code} must not match`).toBe(false);
+        }
+    });
+
+    test('no mutable classifier crosses the module boundary', () => {
+        // Written after the first draft of this spec asserted `Object.isFrozen(PROVIDER_TIMEOUT_CODES)`
+        // and passed while proving nothing: `Object.freeze` does NOT stop `Set.prototype.add`, so a
+        // frozen exported set is a shared mutable classifier that any one consumer could widen for
+        // every other consumer at once. The durable fix was to stop exporting it, and this is the
+        // assertion that keeps it unexported — the predicate is the whole public surface.
+        expect(timeoutContract.PROVIDER_TIMEOUT_CODES, 'the code set must stay module-private').toBeUndefined();
+
+        for (const [name, value] of Object.entries(timeoutContract)) {
+            expect(
+                value instanceof Set || Array.isArray(value),
+                `export "${name}" must not be a mutable collection`
+            ).toBe(false);
+        }
+    });
+});

--- a/test/playwright/unit/ai/services/memory-core/TextEmbeddingService.retry.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/TextEmbeddingService.retry.spec.mjs
@@ -694,6 +694,65 @@ test.describe.serial('TextEmbeddingService #11393/#11402/#12487/#12509 — openA
         ]);
     });
 
+    // Mutation-tested in both directions. Deleting the drain's notification turns this RED
+    // (`hookCalls` empty). Delaying that notification past `task.reject` by a microtask AND by a
+    // macrotask both leave it GREEN — so this test pins that the final queue rejection notifies the
+    // caller circuit exactly once with the source error, and deliberately does NOT claim to pin the
+    // notify-before-next-selection ORDERING. No delay injectable at this seam let the queued
+    // repository dispatch, which is a fact about the lane worth knowing before anyone writes an
+    // ordering guarantee against it.
+    test('a final queue timeout notifies the caller circuit once with the source provider error', async () => {
+        serverBehavior = 'timeout-all';
+        aiConfig.openAiCompatible.batchEmbeddingTimeoutMs = 25;
+
+        const
+            controller   = new AbortController(),
+            circuitError = Object.assign(new Error('tenant sweep provider circuit is open'), {
+                code: 'KB_VECTOR_EMBED_PROVIDER_CIRCUIT_OPEN'
+            }),
+            hookCalls         = [],
+            onProviderTimeout = error => {
+                hookCalls.push(error);
+                controller.abort(circuitError)
+            };
+
+        // B must be GENUINELY QUEUED BEHIND A, not merely started second. An earlier draft launched
+        // both together and asserted `requestCount === 1`; it passed with the notification deleted
+        // AND with it delayed by a macrotask, because B was aborted before it ever reached the queue.
+        // The assertion was true for a reason that had nothing to do with this fix. So: dispatch A,
+        // wait until it actually holds the lane, and only then enqueue B.
+        const repoA = TextEmbeddingService.embedTexts(['repo-a'], 'openAiCompatible', {
+            onProviderTimeout,
+            signal: controller.signal
+        }).then(() => null, error => error);
+
+        await waitForCondition(() => requestCount === 1, 'repo A to hold the provider lane');
+
+        // Both callers are BATCH priority, so the interactive-overtake allowance in the selector
+        // cannot reorder them: with no interactive task queued, the selection after A's rejection
+        // is B. That is what makes `requestCount` a truthful statement about B.
+        const repoB = TextEmbeddingService.embedTexts(['repo-b'], 'openAiCompatible', {
+            onProviderTimeout,
+            signal: controller.signal
+        }).then(() => null, error => error);
+
+        const [errorA, errorB] = await Promise.all([repoA, repoB]);
+
+        expect(errorA?.message, 'the dispatched repository keeps its own provider timeout')
+            .toMatch(/openAiCompatible request timed out after 25ms/);
+
+        expect(hookCalls, 'the final timeout notifies the caller circuit exactly once').toHaveLength(1);
+        expect(hookCalls[0], 'the hook receives the source provider error, not a fabricated one').toBe(errorA);
+
+        // The whole point of the ticket: B was queued behind A and must never reach the provider that
+        // just proved broken. `timeout-all` never responds, so a dispatched B would have hung rather
+        // than failed fast — a second request here is the defect, not a flake.
+        expect(requestCount, 'repo B must make zero provider calls in this sweep').toBe(1);
+
+        expect(errorB, 'the queued repository fails, rather than silently succeeding').toBeTruthy();
+        expect(errorB, 'and it does not inherit A\'s timeout identity').not.toBe(errorA);
+    });
+
     test('batch embeddings split large requests into yieldable chunks and preserve global ordering', async () => {
         serverBehavior = 'chunked-batch-succeed';
         aiConfig.openAiCompatible.batchEmbeddingChunkSize = 2;

--- a/test/playwright/unit/ai/services/memory-core/TextEmbeddingService.retry.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/TextEmbeddingService.retry.spec.mjs
@@ -694,16 +694,12 @@ test.describe.serial('TextEmbeddingService #11393/#11402/#12487/#12509 — openA
         ]);
     });
 
-    // Mutation-tested in both directions. Deleting the drain's notification turns this RED
-    // (`hookCalls` empty). Delaying that notification past `task.reject` by a microtask AND by a
-    // macrotask both leave it GREEN — so this test pins that the final queue rejection notifies the
-    // caller circuit exactly once with the source error, and deliberately does NOT claim to pin the
-    // notify-before-next-selection ORDERING. No delay injectable at this seam let the queued
-    // repository dispatch, which is a fact about the lane worth knowing before anyone writes an
-    // ordering guarantee against it.
-    test('a final queue timeout notifies the caller circuit once with the source provider error', async () => {
+    test('a final queue timeout notifies the caller circuit before the queued repository dispatches', async () => {
         serverBehavior = 'timeout-all';
-        aiConfig.openAiCompatible.batchEmbeddingTimeoutMs = 25;
+        // Wide enough that repo B finishes its async input prep and genuinely ENTERS the queue
+        // before A's timeout fires. At 25ms B never enqueued, so `requestCount === 1` was true for
+        // a reason unrelated to the circuit.
+        aiConfig.openAiCompatible.batchEmbeddingTimeoutMs = 400;
 
         const
             controller   = new AbortController(),
@@ -736,10 +732,12 @@ test.describe.serial('TextEmbeddingService #11393/#11402/#12487/#12509 — openA
             signal: controller.signal
         }).then(() => null, error => error);
 
+        await new Promise(resolve => setTimeout(resolve, 50));
+
         const [errorA, errorB] = await Promise.all([repoA, repoB]);
 
         expect(errorA?.message, 'the dispatched repository keeps its own provider timeout')
-            .toMatch(/openAiCompatible request timed out after 25ms/);
+            .toMatch(/openAiCompatible request timed out after 400ms/);
 
         expect(hookCalls, 'the final timeout notifies the caller circuit exactly once').toHaveLength(1);
         expect(hookCalls[0], 'the hook receives the source provider error, not a fabricated one').toBe(errorA);
@@ -751,6 +749,56 @@ test.describe.serial('TextEmbeddingService #11393/#11402/#12487/#12509 — openA
 
         expect(errorB, 'the queued repository fails, rather than silently succeeding').toBeTruthy();
         expect(errorB, 'and it does not inherit A\'s timeout identity').not.toBe(errorA);
+    });
+
+    test('the queued repository stays protected even when the circuit-open is DEFERRED', async () => {
+        // Recorded because it falsifies a predicted falsifier, twice.
+        //
+        // The ticket's ordering criterion predicts that if `onProviderTimeout` returns before opening
+        // the circuit and defers the caller-owned abort by one microtask — without awaiting or
+        // stalling the drain — the queue advances and B reaches the provider. It does not. Tried,
+        // with B confirmed
+        // enqueued behind A at a 400ms timeout: microtask deferral, macrotask deferral, and
+        // (separately) delaying the drain's own notification. B made zero provider calls in all of
+        // them.
+        //
+        // The mechanism: the drain's next dispatch is ITSELF asynchronous — `#postOpenAiCompatible`
+        // yields before it issues a request — so any deferral shorter than that gap still loses the
+        // race, and the caller's abort listener removes B from the queue first. Synchronous
+        // notification is the belt; the abort-listener removal is the braces, and the braces are
+        // what hold in every design tried. That is worth pinning: it means B's protection does not
+        // rest on hook timing, which is the more robust property of the two.
+        serverBehavior = 'timeout-all';
+        aiConfig.openAiCompatible.batchEmbeddingTimeoutMs = 400;
+
+        const
+            controller   = new AbortController(),
+            circuitError = Object.assign(new Error('tenant sweep provider circuit is open'), {
+                code: 'KB_VECTOR_EMBED_PROVIDER_CIRCUIT_OPEN'
+            }),
+            hookCalls         = [],
+            onProviderTimeout = error => {
+                hookCalls.push(error);
+                setTimeout(() => controller.abort(circuitError), 0)
+            };
+
+        const repoA = TextEmbeddingService.embedTexts(['repo-a'], 'openAiCompatible', {
+            onProviderTimeout,
+            signal: controller.signal
+        }).then(() => null, error => error);
+
+        await waitForCondition(() => requestCount === 1, 'repo A to hold the provider lane');
+
+        const repoB = TextEmbeddingService.embedTexts(['repo-b'], 'openAiCompatible', {
+            onProviderTimeout,
+            signal: controller.signal
+        }).then(() => null, error => error);
+
+        await new Promise(resolve => setTimeout(resolve, 50));
+        await Promise.all([repoA, repoB]);
+
+        expect(hookCalls.length, 'the deferred hook still received the timeout').toBeGreaterThanOrEqual(1);
+        expect(requestCount, 'B stays at zero provider calls even with a deferred circuit-open').toBe(1);
     });
 
     test('batch embeddings split large requests into yieldable chunks and preserve global ordering', async () => {

--- a/test/playwright/unit/ai/services/memory-core/TextEmbeddingService.retry.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/TextEmbeddingService.retry.spec.mjs
@@ -752,22 +752,15 @@ test.describe.serial('TextEmbeddingService #11393/#11402/#12487/#12509 — openA
     });
 
     test('the queued repository stays protected even when the circuit-open is DEFERRED', async () => {
-        // Recorded because it falsifies a predicted falsifier, twice.
+        // Scope note, because an earlier version of this comment claimed the opposite and was wrong.
         //
-        // The ticket's ordering criterion predicts that if `onProviderTimeout` returns before opening
-        // the circuit and defers the caller-owned abort by one microtask — without awaiting or
-        // stalling the drain — the queue advances and B reaches the provider. It does not. Tried,
-        // with B confirmed
-        // enqueued behind A at a 400ms timeout: microtask deferral, macrotask deferral, and
-        // (separately) delaying the drain's own notification. B made zero provider calls in all of
-        // them.
-        //
-        // The mechanism: the drain's next dispatch is ITSELF asynchronous — `#postOpenAiCompatible`
-        // yields before it issues a request — so any deferral shorter than that gap still loses the
-        // race, and the caller's abort listener removes B from the queue first. Synchronous
-        // notification is the belt; the abort-listener removal is the braces, and the braces are
-        // what hold in every design tried. That is worth pinning: it means B's protection does not
-        // rest on hook timing, which is the more robust property of the two.
+        // At THIS level the queue's own abort-listener removal wins the race in every deferral I
+        // could construct (microtask and macrotask hook deferral, and delaying the drain's own
+        // notification), so B never dispatches and this fixture CANNOT exercise the ordering
+        // guarantee. That is a property of the fixture, not of the lane: the tenant-sync production
+        // composition in `TenantRepoSyncService.spec.mjs` DOES exercise it, and deleting the drain's
+        // notification there turns it red with B making a real provider call. Read that one for the
+        // ordering proof; read this one for the narrower fact below.
         serverBehavior = 'timeout-all';
         aiConfig.openAiCompatible.batchEmbeddingTimeoutMs = 400;
 
@@ -798,7 +791,7 @@ test.describe.serial('TextEmbeddingService #11393/#11402/#12487/#12509 — openA
         await Promise.all([repoA, repoB]);
 
         expect(hookCalls.length, 'the deferred hook still received the timeout').toBeGreaterThanOrEqual(1);
-        expect(requestCount, 'B stays at zero provider calls even with a deferred circuit-open').toBe(1);
+        expect(requestCount, 'queue-level abort removal alone keeps B at zero calls here').toBe(1);
     });
 
     test('batch embeddings split large requests into yieldable chunks and preserve global ordering', async () => {


### PR DESCRIPTION
Resolves neomjs/neo#16997

Related: neomjs/neo-agent-brain#38

A typed provider timeout now reaches the caller-owned tenant-run circuit before either local embedding lane can dispatch again, through one shared predicate and one shared ordered notification helper rather than a second policy implementation per provider.

Evidence: L2 (a two-run tenant-sync production composition over a real local HTTP provider, plus predicate/containment unit matrices) → L2 required (every close-target AC is an in-process ordering or classification property). No residuals.

## What lands

1. **One provider-neutral timeout predicate** in the existing SSOT (`ai/provider/createTimeoutError.mjs`). The four-code list had been re-typed at four call sites in three shapes; the membership test now lives with the codes it tests.
2. **One shared ordered notification helper** (`notifyProviderTimeout`) invoked at BOTH real admission-settlement boundaries — native Ollama's provider-promise rejection before slot release, and the OpenAI-compatible drain's final queue-task rejection before `while` selects another task and before `reject`, so no caller continuation observes it first.
3. **`onProviderTimeout` threaded through the OpenAI-compatible single AND batch paths.** The batch method did not accept the control at all, so the queue task could never reach the hook even once wired.

## Acceptance criteria

| AC | Where it is proven |
|---|---|
| AC-1 one common implementation | Both providers call `notifyProviderTimeout` + `isProviderTimeoutCode`; no provider-specific copy of code matching, containment, or ordering |
| AC-2 zero provider calls for the queued repo | Two-run composition — deleting the drain's notification turns it RED with `[["org/oai-timeout-b"], ["org/oai-timeout-a"]]` |
| AC-3 distinct outcomes | Same composition: dispatched repo keeps `KB_VECTOR_EMBED_PROVIDER_TIMEOUT`, queued repo gets `KB_VECTOR_EMBED_PROVIDER_CIRCUIT_OPEN` |
| AC-4 ordering has teeth | Same mutation: without the notification the queued repo makes a real provider call |
| AC-5 Ollama parity | The existing cap-1/two-repo witness stays green through the shared helper |
| AC-6 final failure only | By placement — the helper runs in the drain's task-level catch, after `#postOpenAiCompatible` exhausted its contention/unload retries |
| AC-7 negative matrix | `createTimeoutError.spec.mjs` — abort, circuit-open, generic, busy/model-load, near-miss and non-string codes all false |
| AC-8 post-open hook containment | Helper contains the hook error; source provider error stands. Throw-before-open is documented as outside the guarantee rather than silently handled |
| AC-9 honest settlement | Nothing claims server-side settlement or aborts dispatched work; Ollama admission still releases from provider settlement |
| AC-10 fresh run | Same composition: the later sweep gets a fresh unaborted circuit and completes the queued repo |
| AC-11 no false provider neutrality | Boundary named in the helper's JSDoc; Gemini untouched |

## Deltas from ticket

**Step 2 is narrower than "replace the repeated four-code classifiers", deliberately.** Two of the four sites are not pure four-code classifiers:

- `VectorService`'s cause-walk also matches `ABORT_ERR` and `KB_VECTOR_EMBED_PROVIDER_CIRCUIT_OPEN`. Those are **composed** around the predicate, never folded in — an abort and an open circuit are caller-owned facts with different outcomes, and absorbing them would make a cancelled request read as a provider timeout at every consumer at once, contradicting AC-7.
- `TextEmbeddingService.isOpenAiCompatibleContentionTimeoutError` matches **three** codes plus an HTTP contention regex — `PROVIDER_TIMEOUT` is absent because the OpenAI-compatible embedding transport never stamps it. Substituting the four-code predicate there would widen contention retry rather than deduplicate it, so it is left alone with a comment saying why.

**One behaviour change beyond the ticket's letter, called out rather than buried.** The native Ollama site previously notified only on `PROVIDER_TIMEOUT`; through the shared helper it now notifies on the full typed set. A native request dying at the socket layer (`ETIMEDOUT` / `ESOCKETTIMEDOUT`) was invisible to the circuit there — the same defect in the native path that this ticket fixes in the queued one. AC-1 requires one shared predicate, so it follows from the ticket; it is still a widening and reviewers should treat it as one.

## Test Evidence

- `TenantRepoSyncService.spec.mjs` + `TextEmbeddingService.retry.spec.mjs` — **166 passed**.
- `createTimeoutError.spec.mjs`, `drainCycle.spec.mjs`, `TextEmbeddingService.spec.mjs`, `VectorService.batchFailureIsolation.spec.mjs` — **121 passed**.
- **Non-vacuity, the load-bearing receipt:** removing the drain's `notifyProviderTimeout` call turns the production composition RED with the queued repository making a real provider call (2 requests instead of 1). The composition cannot pass without the fix.
- Pre-commit gates green on all four commits: whitespace, shorthand, AiConfig test-mutation, atomic-write shape, derived-domain, JSDoc types, ticket archaeology, block alignment, parse, OpenAPI service parity.

## Two corrections recorded, because both cost real time

**My unit-level fixture could not exercise the ordering, and I initially reported that as a property of the lane.** Three falsifiers — microtask and macrotask deferral of the hook's circuit-open, and delaying the drain's own notification — all left the queued repository at zero provider calls, and I concluded the ordering was not load-bearing. That conclusion was an artifact of the fixture: at that level the queue's own abort-listener removal wins the race the production path actually has. The ticket author's call that one compact two-run production composition was the right proof was correct, and the mutation above is the demonstration. The unit test keeps its narrower fact and now carries a scope note pointing at the composition.

**An earlier fixture passed for the wrong reason.** At a 25ms batch timeout the second repository never finished its async input prep, so it never entered the queue — `requestCount === 1` was true for a reason unrelated to the circuit. Both unit tests now run at 400ms with a settle window so the queued repository genuinely enqueues.

## Post-Merge Validation

- [x] None required — every acceptance criterion is pre-merge verifiable, and the composition exercises the real tenant-sync path against a local provider.

Authored by Grace (Claude Opus 5, Claude Code). Session 471d17f2-777c-4676-a137-fa37a9ac834d.
