### PR TITLE
docs(learn): FM guide D1 — the wake daemon lives host-side (#17104)

### DIFF
--- a/learn/agentos/FleetManagerArchitecture.md
+++ b/learn/agentos/FleetManagerArchitecture.md
@@ -21,38 +21,39 @@ flowchart TD
         Page["AgentOS app<br/>(App Worker)"]
     end
 
-    subgraph Host["Host machine (relay · seats · actuation)"]
+    subgraph Host["Host machine (relay · seats · wake · actuation)"]
         Transport["Transitional fleet relay<br/>devFleetServer :8083"]
         Seat["Managed harness seat<br/>+ its signed wake receiver"]
+        HostWake["Wake daemon — launchd<br/>mini-orchestrator (osascript/tmux<br/>prompt injection is host-only)"]
         Actuator["Host actuator<br/>(spawn/stop, signed receipts)"]
     end
 
     subgraph Plane["Dockerized Agent OS (the plane — local or cloud)"]
         Ingress["Caddy ingress :3102"]
-        MC["Memory Core service"]
+        MC["Memory Core service<br/>+ signed wake dispatcher"]
         KB["Knowledge Base service"]
         FS["Composed fleet-server<br/>(optional per profile — #16168)"]
-        WakeD["Wake daemon"]
     end
 
     Forge["Forge<br/>(GitHub / GitLab)"]
     GraphStore[("Graph + WAL<br/>(named volumes)")]
 
-    Main -- "class-2 IPC session capability<br/>(in-process, never a network hop)" --> Page
-    Page -- "process-lifetime bearer<br/>(handshake-redeemed, in-memory only)" --> Transport
-    Transport -- "PAT-class plane credential<br/>(one process's deployment input)" --> Ingress
-    Page -. "class-1 FM admission bearer —<br/>the cutover: the cockpit dials ingress" .-> Ingress
-    Seat -- "class-3 seat MCP bearer<br/>(/mc/mcp · /kb/mcp)" --> Ingress
-    Seat -- "class-4 repo-workflow PAT<br/>(forge writes, never plane admission)" --> Forge
-    Ingress -- "routes /fleet + /fleet/probe<br/>to the optional service" --> FS
+    Main -- "class-2 IPC capability<br/>(never a network hop)" --> Page
+    Page -- "process-lifetime bearer<br/>(handshake-redeemed, in-memory)" --> Transport
+    Transport -- "PAT-class plane credential<br/>(deployment input)" --> Ingress
+    Page -. "class-1 FM admission bearer —<br/>the cutover: cockpit dials ingress" .-> Ingress
+    Seat -- "class-3 seat MCP bearer" --> Ingress
+    Seat -- "class-4 repo PAT" --> Forge
+    Ingress -- "routes /fleet*" --> FS
     Ingress --> MC
     Ingress --> KB
     MC --> GraphStore
+    MC -. "class-6 signed-wake HMAC<br/>(per subscription, Shape B)" .-> Seat
+    HostWake -- "Shape-C harness injection<br/>(unsigned, host-local)" --> Seat
     FS -. "class-5 signed command envelope<br/>(per-command, replay-bounded)" .-> Actuator
-    WakeD -. "class-6 signed-wake HMAC<br/>(per subscription; host-local today,<br/>ingress-wake = S7 #16741)" .-> Seat
 ```
 
-*Authority: ADR 0038 §2.1 (topology) and §2.5.1 (the six-row credential-class ledger — all six rows placed at their boundaries above, numbered as the ledger numbers them; the page→relay process-lifetime bearer is the transitional pre-cutover credential, ADR 0019 §10.8's process-bearer class, and retires with the relay). The ingress routes `/fleet` + `/fleet/probe` to the optional composed service today (`ai/deploy/Caddyfile`; optionality per §2.7). Live receipt: [#16694's closing trail](https://github.com/neomjs/neo/issues/16694) — the boot log line `viewer @neo-fable-clio verified plane-side; host graph not consulted` prints only after a successful authenticated round-trip through every hop drawn above.*
+*Authority: ADR 0038 §2.1 (topology) and §2.5.1 (the six-row credential-class ledger — all six rows placed at their boundaries above, numbered as the ledger numbers them; the page→relay process-lifetime bearer is the transitional pre-cutover credential, ADR 0019 §10.8's process-bearer class, and retires with the relay). The ingress routes `/fleet` + `/fleet/probe` to the optional composed service today (`ai/deploy/Caddyfile`; optionality per §2.7). **The wake corner is two actors, two homes** — the plane's signed dispatcher (`WebhookDeliveryService`, in the Memory Core container) POSTs class-6-signed Shape-B digests at seat receivers, while the host-side wake daemon — a launchd mini-orchestrator pair on client machines — owns Shape-C harness injection, because `osascript` prompt delivery can only execute at the host, never from inside a container. Live receipt: [#16694's closing trail](https://github.com/neomjs/neo/issues/16694) — the boot log line `viewer @neo-fable-clio verified plane-side; host graph not consulted` prints only after a successful authenticated round-trip through every hop drawn above.*
 
 Walk the hops. The **page** holds exactly one secret: a 32-byte process-lifetime bearer for the transport one port away — never a PAT, never anything that outlives the process that minted it. The **transport** holds the plane credential and presents it to the **ingress**; the plane resolves that credential to a subject and the transport *refuses to serve* unless that subject matches its own boot-resolved viewer — a fail-closed identity handshake, not a hopeful one. And the browser never touches the plane credential at all. The remaining ledger rows live off the cockpit path, each at its own boundary: every managed seat holds a plane MCP bearer (class 3) and a separate repo-workflow PAT (class 4) — the same forge may mint both, and neither ever serves the other's audience; lifecycle commands reach a host only as class-5 signed one-shot envelopes, replay-bounded, with no standing bearer on that hop; and wake delivery carries class-6 per-subscription HMACs bearing zero read or write authority. When the composed fleet-server takes over the relay's job — [#16168](https://github.com/neomjs/neo/issues/16168), Euclid's epic, authored and steered by him on its own record, its service already composed and ingress-routed at `/fleet` today — the cutover is the dashed class-1 arrow above: the cockpit authenticates to the plane as the *operator's* provider identity, a different credential class with its own custody rules, and the relay retires.
 

--- a/learn/agentos/FleetManagerArchitecture.md
+++ b/learn/agentos/FleetManagerArchitecture.md
@@ -23,8 +23,8 @@ flowchart TD
 
     subgraph Host["Host machine (relay · seats · wake · actuation)"]
         Transport["Transitional fleet relay<br/>devFleetServer :8083"]
-        Seat["Managed harness seat<br/>+ its signed wake receiver"]
-        HostWake["Wake daemon — launchd<br/>mini-orchestrator (osascript/tmux<br/>prompt injection is host-only)"]
+        Seat["Managed harness seat"]
+        Receiver["Signed graphless wake<br/>receiver — launchd (osascript/tmux<br/>final mile is host-only)"]
         Actuator["Host actuator<br/>(spawn/stop, signed receipts)"]
     end
 
@@ -48,12 +48,12 @@ flowchart TD
     Ingress --> MC
     Ingress --> KB
     MC --> GraphStore
-    MC -. "class-6 signed-wake HMAC<br/>(per subscription, Shape B)" .-> Seat
-    HostWake -- "Shape-C harness injection<br/>(unsigned, host-local)" --> Seat
+    MC -. "class-6 signed-wake HMAC<br/>(per subscription, Shape B)" .-> Receiver
+    Receiver -- "host-local adapter delivery<br/>(the prompt-injection final mile)" --> Seat
     FS -. "class-5 signed command envelope<br/>(per-command, replay-bounded)" .-> Actuator
 ```
 
-*Authority: ADR 0038 §2.1 (topology) and §2.5.1 (the six-row credential-class ledger — all six rows placed at their boundaries above, numbered as the ledger numbers them; the page→relay process-lifetime bearer is the transitional pre-cutover credential, ADR 0019 §10.8's process-bearer class, and retires with the relay). The ingress routes `/fleet` + `/fleet/probe` to the optional composed service today (`ai/deploy/Caddyfile`; optionality per §2.7). **The wake corner is two actors, two homes** — the plane's signed dispatcher (`WebhookDeliveryService`, in the Memory Core container) POSTs class-6-signed Shape-B digests at seat receivers, while the host-side wake daemon — a launchd mini-orchestrator pair on client machines — owns Shape-C harness injection, because `osascript` prompt delivery can only execute at the host, never from inside a container. Live receipt: [#16694's closing trail](https://github.com/neomjs/neo/issues/16694) — the boot log line `viewer @neo-fable-clio verified plane-side; host graph not consulted` prints only after a successful authenticated round-trip through every hop drawn above.*
+*Authority: ADR 0038 §2.1 (topology) and §2.5.1 (the six-row credential-class ledger — all six rows placed at their boundaries above, numbered as the ledger numbers them; the page→relay process-lifetime bearer is the transitional pre-cutover credential, ADR 0019 §10.8's process-bearer class, and retires with the relay). The ingress routes `/fleet` + `/fleet/probe` to the optional composed service today (`ai/deploy/Caddyfile`; optionality per §2.7). **The wake corner is two actors, two homes** — the plane's signed dispatcher (`WebhookDeliveryService`, in the Memory Core container) POSTs class-6-signed Shape-B digests at the host's **signed graphless wake receiver** (`receiver.mjs`, run by launchd on client machines), which verifies the signature and then performs the host-local adapter final mile — `osascript`/`tmux` prompt injection can only execute at the host, never from inside a container, which is exactly why the receiver lives there. Live receipt: [#16694's closing trail](https://github.com/neomjs/neo/issues/16694) — the boot log line `viewer @neo-fable-clio verified plane-side; host graph not consulted` prints only after a successful authenticated round-trip through every hop drawn above.*
 
 Walk the hops. The **page** holds exactly one secret: a 32-byte process-lifetime bearer for the transport one port away — never a PAT, never anything that outlives the process that minted it. The **transport** holds the plane credential and presents it to the **ingress**; the plane resolves that credential to a subject and the transport *refuses to serve* unless that subject matches its own boot-resolved viewer — a fail-closed identity handshake, not a hopeful one. And the browser never touches the plane credential at all. The remaining ledger rows live off the cockpit path, each at its own boundary: every managed seat holds a plane MCP bearer (class 3) and a separate repo-workflow PAT (class 4) — the same forge may mint both, and neither ever serves the other's audience; lifecycle commands reach a host only as class-5 signed one-shot envelopes, replay-bounded, with no standing bearer on that hop; and wake delivery carries class-6 per-subscription HMACs bearing zero read or write authority. When the composed fleet-server takes over the relay's job — [#16168](https://github.com/neomjs/neo/issues/16168), Euclid's epic, authored and steered by him on its own record, its service already composed and ingress-routed at `/fleet` today — the cutover is the dashed class-1 arrow above: the cockpit authenticates to the plane as the *operator's* provider identity, a different credential class with its own custody rules, and the relay retires.
 


### PR DESCRIPTION
Resolves neomjs/neo#17104

The guide's D1 no longer homes the wake actor inside the plane. The wake corner draws the two-actor truth the operator flagged and the ticket source-anchored — with the actor named per source authority (reviewer correction, cycle 2): the **plane's signed dispatcher** (`WebhookDeliveryService`, in the Memory Core container) POSTs class-6-signed Shape-B digests at the host's **signed graphless wake receiver** (`receiver.mjs`, run by launchd on client machines), which verifies the signature and performs the **host-local adapter final mile** — `osascript`/`tmux` prompt injection can only execute at the host, never from inside a container. The class-6 arrow terminates at the receiver; the final mile is its own labeled edge; the retired Shape-C GraphLog daemon is neither relabeled nor reinstated.

The same edit delivers the cosmetic half: every D1 label shortened (the densest were three-line), so the diagram renders tighter at the same information content — all six ledger classes remain placed at their boundaries.

D5 stays untouched, deliberately: its "Wake daemon (delivery attempt)" is an abstract delivery actor homed in NO subgraph, so it asserts no false home — the falsehood lived only in D1's placement. (The ticket body's rationale clause for this was imprecise and is corrected in place.)

Evidence: L2 (docs-only; all six diagrams re-rendered clean under repository `mermaid@11.16.0` via the playwright harness; `ai:lint-tree-json` OK, 223 nodes; content verified against the source anchors in neomjs/neo#17104 — `CoalescingEngineService.mjs:680/:739`, `Server.mjs:300`, the daemon's Shape-C adapters) → L2 sufficient (no runtime surface).

## Deltas from ticket

None substantive — the layout polish landed as label-shortening within D1 rather than edge regrouping; edge count rose by one (the Shape-C edge is the taught content) while total label mass shrank.

## Test Evidence

- Playwright render harness (repo `mermaid@11.16.0`): all 6 diagrams parse and render clean at head.
- `npm run ai:lint-tree-json` → OK (223 nodes).
- learn surface: docs-only — no unit suite applies.

## Post-Merge Validation

- [x] Diagram render verified pre-merge (harness receipt above); KB re-ingestion of the updated guide rides the standing pipeline and the neomjs/neo-agent-brain#37 verification lane.

## Commits (if multi-commit)

1. `98d437b226` — the homing + density fix (cycle 1).
2. `70437ce1ee` — cycle-2 terminology correction: the active host actor is the signed graphless wake receiver; class-6 terminates at it; the final mile is its own edge; retired Shape-C identity removed.

Review note: docs-only with no runtime impact — the §6.1 pure-documentation exception applies; stated here for the record rather than claiming a seat from the review board mid-release-focus.

Related: `#16798` (the guide) · PR neomjs/neo#16936 (the carrier) · neomjs/neo#17100 / PR neomjs/neo#17103 (where the two-actor split is source-anchored in shipping code).

Authored by Clio (Fable 5, Claude Code). Session c4996813-01b9-4234-8bdd-ed3bf22c0970.
