### PR TITLE
feat(fleet): the relay observes the composed wake stream — delivery liveness goes live (#17101)

### DIFF
--- a/ai/configBase.mjs
+++ b/ai/configBase.mjs
@@ -324,6 +324,25 @@ class ConfigBase extends ConfigProvider {
                  */
                 planeBearerFile: leaf('', 'NEO_FLEET_PLANE_BEARER_FILE', 'string'),
                 /**
+                 * Bearer credential for the PLANE'S FLEET SURFACE (`/fleet`, `/fleet/probe`,
+                 * `/fleet/events`) when this process consumes a containerized plane as a fleet
+                 * client — a DIFFERENT MINT from `planeBearer`, which serves the plane's MCP
+                 * resources. The two audiences can share a verifier, so only distinct mints keep
+                 * the credential classes apart: the Fleet entry refuses a value whose bytes alias
+                 * either `planeBearer` or the bootstrap admission token. Empty means the
+                 * deployment declares no fleet-surface credential; plane-stream consumers then
+                 * stay honestly unarmed with that reason instead of dialing with the wrong class.
+                 * @type {string}
+                 */
+                planeAdmissionBearer: leaf('', 'NEO_FLEET_PLANE_ADMISSION_BEARER', 'string'),
+                /**
+                 * Secret-file indirection for `planeAdmissionBearer` — the same custody split as
+                 * `planeBearerFile`: the direct value wins when both are set, empty means no file
+                 * indirection, and the Fleet entry reads it at the use site, never at import.
+                 * @type {string}
+                 */
+                planeAdmissionBearerFile: leaf('', 'NEO_FLEET_PLANE_ADMISSION_BEARER_FILE', 'string'),
+                /**
                  * Absolute path of the deployment's bootstrap/healthcheck admission token file
                  * — bound to the SAME env name the MCP services already boot on (the
                  * `wakeReceiverManifestPath` same-env-name precedent), so the Fleet entry can

--- a/ai/scripts/lint/config-leaf-parity.json
+++ b/ai/scripts/lint/config-leaf-parity.json
@@ -186,6 +186,8 @@
         "fleet.harnessBinaries.kimiCode",
         "fleet.harnessBinaries.openCode",
         "fleet.instanceRoot",
+        "fleet.planeAdmissionBearer",
+        "fleet.planeAdmissionBearerFile",
         "fleet.planeBase",
         "fleet.planeBearer",
         "fleet.planeBearerFile",

--- a/ai/scripts/lint/retry-bound-registry.json
+++ b/ai/scripts/lint/retry-bound-registry.json
@@ -259,6 +259,12 @@
             "boundCarrier": "max-delay",
             "witness": "`Math.min(5000, ...)` plus a clamped exponent `Math.min(dispositionAttempts - 1, 4)`",
             "note": "Bounded twice — the delay is capped AND the exponent itself is clamped."
+        },
+        "ai/services/fleet/fleetWakeSseConsumer.mjs#runLoop:5f68f770": {
+            "kind": "retry-growth",
+            "lifetime": "process-local",
+            "boundCarrier": "max-delay",
+            "witness": "`Math.min(..., MAX_BACKOFF_MS)` caps the exponential reconnect delay at 60s, and the loop exits terminally on `stopped` or an epoch change (`stop()` bumps the epoch) — the spec `fleetWakeSseConsumer.spec.mjs` drives a drop→reconnect cycle on the injected floor and `stop()` ends the loop."
         }
     }
 }

--- a/ai/services/fleet/devFleetServer.mjs
+++ b/ai/services/fleet/devFleetServer.mjs
@@ -56,6 +56,7 @@ import {probeExistingFleetServer, resolveFleetBearer, resolveFleetViewer,
         resolveFleetViewerClaim}                                          from './fleetLaunchContract.mjs';
 import {createPlaneMailboxClient}                                        from './planeMailboxClient.mjs';
 import {createPlaneWakeIdentitiesReader}                                 from './planeWakeIdentitiesReader.mjs';
+import {createFleetWakeSseConsumer}                                      from './fleetWakeSseConsumer.mjs';
 import {createPlaneWhoIsOnlineReader}                                    from './planeWhoIsOnlineReader.mjs';
 import {readActiveWakeSubscriptionIdentities}                            from '../memory-core/readActiveWakeSubscriptionIdentities.mjs';
 import {createTerminalDeliveryFailuresFileReader, resolveDaemonLiveness} from './fleetWakeStateAdapter.mjs';
@@ -96,7 +97,9 @@ async function boot() {
               credential: AiConfig.fleet.planeBearer
           }) : null;
 
-    let viewer;
+    let
+        fleetWakeStreamConsumer = null,
+        viewer;
 
     if (planeClient) {
         viewer = await resolveFleetViewerClaim();
@@ -141,16 +144,29 @@ async function boot() {
     // until the plane exposes a vouching surface: delivery runs container-side and behind the
     // signed host receiver, and neither is observable from this process today.
     if (planeClient) {
+        // The plane NOW exposes the vouching surface this branch was honestly waiting for: the
+        // composed fleet-server's `/fleet/events` stream. This process consumes it with its own
+        // fleet-admission bearer (one credential, deliberately — no second header is synthesized,
+        // and the composed server's boot arming covers the shared viewer identity), and the
+        // delivery-liveness axis renders the live observation instead of a typed unknown.
+        // Reconnect catch-up rides `poll-digest` through the proven plane client. Fail-soft: a
+        // dead stream degrades the axis back to honest `unknown` with the disconnect reason.
+        const wakeStreamConsumer = createFleetWakeSseConsumer({
+            eventsUrl : `${planeBase.replace(/\/+$/, '')}/fleet/events`,
+            credential: AiConfig.fleet.planeBearer,
+            pollDigest: args => planeClient.callTool('manage_wake_subscription', {action: 'poll-digest', ...args})
+        });
+
+        wakeStreamConsumer.start();
+        fleetWakeStreamConsumer = wakeStreamConsumer;
+
         FleetManager.wakeStateOptions = {
             // The proven client returns PARSED payloads (its mapToolResult owns envelope handling)
             // — the reader consumes them directly; a second parse here would reject every healthy
             // answer and silently blind the whole axis.
             listActiveSubscriptionIdentities: createPlaneWakeIdentitiesReader(planeClient),
-            resolveDeliveryLiveness         : () => ({
-                alive : 'unknown',
-                reason: 'delivery-lane liveness is not exposed by the containerized plane yet'
-            }),
-            resolveTerminalDeliveryFailures: () => ({
+            resolveDeliveryLiveness         : () => wakeStreamConsumer.resolveDeliveryLiveness(),
+            resolveTerminalDeliveryFailures : () => ({
                 state     : 'unknown',
                 reason    : 'terminal delivery receipts live with the containerized delivery authority; not exposed yet',
                 byIdentity: new Map()
@@ -162,7 +178,7 @@ async function boot() {
             wakeReceiverManifestPath: AiConfig.fleet.wakeReceiverManifestPath
         };
 
-        console.log(`[fleet] wake-state seam bound to the containerized plane at ${planeBase} (subscription axis plane-side; delivery axes honest-unknown pending a plane vouching surface)`)
+        console.log(`[fleet] wake-state seam bound to the containerized plane at ${planeBase} (subscription axis plane-side; delivery liveness observed from the composed wake stream; terminal receipts honest-unknown)`)
     } else {
         // The `wakeDaemon` subtree is owned by the memory-core config, NOT Tier-1 `AiConfig` (which
         // carries only the flat `wakeDaemonHeartbeatAlivePath` leaf) — so the daemon's own authority
@@ -339,6 +355,7 @@ async function boot() {
         // leaks the proven plane session (the server reaps it only on its own timeline).
         const cleanShutdown = async signal => {
             console.log(`[fleet] received ${signal}; stopping.`);
+            fleetWakeStreamConsumer?.stop();
             await planeClient?.close();
             server.close(() => process.exit(0))
         };
@@ -352,8 +369,10 @@ async function boot() {
     } catch (error) {
         // EVERY exit below this line closes the proven plane session AWAITED — startup failures,
         // probe failures, reuse, and refusal alike would otherwise orphan it on the plane. The
-        // client's close() is a shared terminal barrier, so overlapping closers are safe.
+        // client's close() is a shared terminal barrier, so overlapping closers are safe. The
+        // wake-stream consumer stops on the same paths: its reconnect loop must not outlive boot.
         if (error?.code !== 'EADDRINUSE') {
+            fleetWakeStreamConsumer?.stop();
             await planeClient?.close();
             throw error
         }
@@ -369,17 +388,20 @@ async function boot() {
                 agentIdentityNodeId: viewer.agentIdentityNodeId
             })
         } catch (probeError) {
+            fleetWakeStreamConsumer?.stop();
             await planeClient?.close();
             throw probeError
         }
 
         if (probe.reusable) {
             console.log(`[fleet] healthy Fleet already listening on port ${port} (${probe.reason}; viewer: ${probe.viewer}, pid: ${probe.pid}) — reusing it.`);
+            fleetWakeStreamConsumer?.stop();
             await planeClient?.close();
             process.exit(0)
         }
 
         console.error(`[fleet] port ${port} is occupied and NOT reusable: ${probe.reason}`);
+        fleetWakeStreamConsumer?.stop();
         await planeClient?.close();
         process.exit(1)
     }

--- a/ai/services/fleet/devFleetServer.mjs
+++ b/ai/services/fleet/devFleetServer.mjs
@@ -54,6 +54,7 @@ import FleetManager             from './FleetManager.mjs';
 import {startFleetBridgeServer} from './fleetBridgeServer.mjs';
 import {probeExistingFleetServer, resolveFleetBearer, resolveFleetViewer,
         resolveFleetViewerClaim}                                          from './fleetLaunchContract.mjs';
+import {assertFleetPlaneAdmissionBearerClass}                            from './fleetServer.mjs';
 import {createPlaneMailboxClient}                                        from './planeMailboxClient.mjs';
 import {createPlaneWakeIdentitiesReader}                                 from './planeWakeIdentitiesReader.mjs';
 import {createFleetWakeSseConsumer}                                      from './fleetWakeSseConsumer.mjs';
@@ -145,27 +146,40 @@ async function boot() {
     // signed host receiver, and neither is observable from this process today.
     if (planeClient) {
         // The plane NOW exposes the vouching surface this branch was honestly waiting for: the
-        // composed fleet-server's `/fleet/events` stream. This process consumes it with its own
-        // fleet-admission bearer (one credential, deliberately — no second header is synthesized,
-        // and the composed server's boot arming covers the shared viewer identity), and the
-        // delivery-liveness axis renders the live observation instead of a typed unknown.
-        // Reconnect catch-up rides `poll-digest` through the proven plane client. Fail-soft: a
-        // dead stream degrades the axis back to honest `unknown` with the disconnect reason.
-        const wakeStreamConsumer = createFleetWakeSseConsumer({
-            eventsUrl : `${planeBase.replace(/\/+$/, '')}/fleet/events`,
-            credential: AiConfig.fleet.planeBearer,
-            pollDigest: args => planeClient.callTool('manage_wake_subscription', {action: 'poll-digest', ...args})
-        });
+        // composed fleet-server's `/fleet/events` stream. This process consumes it with the
+        // fleet-client PLANE-ADMISSION bearer — its own mint, class-checked at resolution: the
+        // plane-MCP credential must never dial the fleet surface, and an ALIASED declaration
+        // refuses the boot loudly right here (the structural close below still runs). An EMPTY
+        // declaration arms nothing: the axis renders the honest reason and poll stays the truth
+        // lane. One credential either way — no second header is synthesized, and the composed
+        // server's boot arming covers the shared viewer identity. Connection catch-up rides
+        // `poll-digest` through the proven plane client, cold start included (the stream's
+        // `state` handshake vouches the subscription id). Fail-soft past construction: a dead
+        // stream degrades the axis back to honest `unknown` with the disconnect reason.
+        const planeAdmissionBearer = assertFleetPlaneAdmissionBearerClass();
 
-        wakeStreamConsumer.start();
-        fleetWakeStreamConsumer = wakeStreamConsumer;
+        if (planeAdmissionBearer) {
+            const wakeStreamConsumer = createFleetWakeSseConsumer({
+                eventsUrl : `${planeBase.replace(/\/+$/, '')}/fleet/events`,
+                credential: planeAdmissionBearer,
+                pollDigest: args => planeClient.callTool('manage_wake_subscription', {action: 'poll-digest', ...args})
+            });
+
+            wakeStreamConsumer.start();
+            fleetWakeStreamConsumer = wakeStreamConsumer
+        }
 
         FleetManager.wakeStateOptions = {
             // The proven client returns PARSED payloads (its mapToolResult owns envelope handling)
             // — the reader consumes them directly; a second parse here would reject every healthy
             // answer and silently blind the whole axis.
             listActiveSubscriptionIdentities: createPlaneWakeIdentitiesReader(planeClient),
-            resolveDeliveryLiveness         : () => wakeStreamConsumer.resolveDeliveryLiveness(),
+            resolveDeliveryLiveness         : fleetWakeStreamConsumer
+                ? () => fleetWakeStreamConsumer.resolveDeliveryLiveness()
+                : () => ({
+                    alive : 'unknown',
+                    reason: 'no fleet-surface credential declared (fleet.planeAdmissionBearer / fleet.planeAdmissionBearerFile) — poll remains the truth lane'
+                }),
             resolveTerminalDeliveryFailures : () => ({
                 state     : 'unknown',
                 reason    : 'terminal delivery receipts live with the containerized delivery authority; not exposed yet',
@@ -178,7 +192,7 @@ async function boot() {
             wakeReceiverManifestPath: AiConfig.fleet.wakeReceiverManifestPath
         };
 
-        console.log(`[fleet] wake-state seam bound to the containerized plane at ${planeBase} (subscription axis plane-side; delivery liveness observed from the composed wake stream; terminal receipts honest-unknown)`)
+        console.log(`[fleet] wake-state seam bound to the containerized plane at ${planeBase} (subscription axis plane-side; delivery liveness ${fleetWakeStreamConsumer ? 'observed from the composed wake stream' : 'unarmed — no fleet-surface credential declared'}; terminal receipts honest-unknown)`)
     } else {
         // The `wakeDaemon` subtree is owned by the memory-core config, NOT Tier-1 `AiConfig` (which
         // carries only the flat `wakeDaemonHeartbeatAlivePath` leaf) — so the daemon's own authority

--- a/ai/services/fleet/fleetServer.mjs
+++ b/ai/services/fleet/fleetServer.mjs
@@ -564,6 +564,85 @@ export function assertFleetPlaneBearerClass({aiConfig = AiConfig, readFile = nul
 }
 
 /**
+ * @summary Resolves the credential this process presents to a containerized plane's FLEET
+ * surface — the fleet-client admission bearer, a DIFFERENT MINT from the plane-MCP bearer
+ * (`resolveFleetPlaneBearer`). Same two declared homes, same precedence: the direct
+ * `fleet.planeAdmissionBearer` value wins; otherwise `fleet.planeAdmissionBearerFile` names a
+ * secret file. Returns `''` when neither yields a value — the caller renders that as an honest
+ * unarmed state, never a fallback onto a different credential class.
+ * @param {Object} [options]
+ * @param {Object} [options.aiConfig=AiConfig] Resolved Tier-1 config tree.
+ * @param {Function} [options.readFile] Injection seam for tests; defaults to `readFileSync`.
+ * @returns {String} The resolved fleet-surface bearer, or `''`.
+ */
+export function resolveFleetPlaneAdmissionBearer({aiConfig = AiConfig, readFile = null} = {}) {
+    const direct = aiConfig.fleet.planeAdmissionBearer.trim();
+
+    if (direct) return direct;
+
+    const bearerFile = aiConfig.fleet.planeAdmissionBearerFile.trim();
+
+    if (!bearerFile) return '';
+
+    try {
+        const read = readFile ?? (target => readFileSync(target, 'utf8'));
+        return String(read(bearerFile)).trim()
+    } catch {
+        return ''
+    }
+}
+
+/**
+ * @summary The non-alias teeth for the fleet-client admission bearer: the resolved value must
+ * not BE the plane-MCP bearer, and must not BE the bootstrap/healthcheck admission token. Both
+ * surfaces can share a verifier, so byte-identity is exactly how one mint silently serves two
+ * audiences — this refuses the aliasing at resolution time, at the one moment someone can mint
+ * the distinct credential.
+ * @param {Object} [options]
+ * @param {Object} [options.aiConfig=AiConfig] Resolved Tier-1 config tree.
+ * @param {Function} [options.readFile] Injection seam for tests; defaults to `readFileSync`.
+ * @returns {String} The class-clean resolved bearer (may be `''`).
+ * @throws {Error} When the fleet-surface bearer aliases the plane-MCP bearer or the admission token.
+ */
+export function assertFleetPlaneAdmissionBearerClass({aiConfig = AiConfig, readFile = null} = {}) {
+    const
+        read            = readFile ?? (target => readFileSync(target, 'utf8')),
+        admissionBearer = resolveFleetPlaneAdmissionBearer({aiConfig, readFile: read});
+
+    if (!admissionBearer) return admissionBearer;
+
+    const planeBearer = resolveFleetPlaneBearer({aiConfig, readFile: read});
+
+    if (planeBearer && admissionBearer === planeBearer) {
+        throw new Error(
+            '[FleetServer] fleet.planeAdmissionBearer resolves to the same bytes as the plane-MCP ' +
+            'bearer — the credential-class ledger forbids presenting the MC credential to the ' +
+            'fleet surface. Mint a distinct fleet-client admission credential.'
+        )
+    }
+
+    const admissionFile = aiConfig.fleet.admissionTokenFile.trim();
+
+    let admissionToken = '';
+
+    if (admissionFile) {
+        try {
+            admissionToken = String(read(admissionFile)).trim()
+        } catch {/* an unreadable admission file leaves the comparison disabled, not the rule */}
+    }
+
+    if (admissionToken && admissionBearer === admissionToken) {
+        throw new Error(
+            '[FleetServer] fleet.planeAdmissionBearer resolves to the deployment\'s ' +
+            'bootstrap/healthcheck admission token — the credential-class ledger forbids that ' +
+            'aliasing. Mint a distinct fleet-client admission credential.'
+        )
+    }
+
+    return admissionBearer
+}
+
+/**
  * @summary Derives the ONE stream/limiter key for an admitted viewer, from immutable facts only.
  *
  * The plane-proven canonical identity (`@login`, MC's own subject for the arming caller) is the

--- a/ai/services/fleet/fleetWakeFanout.mjs
+++ b/ai/services/fleet/fleetWakeFanout.mjs
@@ -379,16 +379,27 @@ export function createFleetWakeFanout({
          * @returns {Object} `describeState()` plus `{armedForViewer: Boolean}`
          */
         describeStateFor(identity) {
-            let armedForViewer = false;
+            let
+                armedForViewer = false,
+                subscriptionId = null;
 
-            for (const route of routes.values()) {
+            // The routes map is keyed by subscription id, so the armed viewer's own key IS the
+            // id this frame vouches. Carrying it lets a stream consumer run poll-digest catch-up
+            // from a COLD start — before any live wake has taught it which subscription the
+            // stream serves — instead of silently skipping pending wakes until one arrives.
+            for (const [routeSubscriptionId, route] of routes) {
                 if (route.agentIdentity === identity) {
                     armedForViewer = true;
+                    subscriptionId = routeSubscriptionId;
                     break
                 }
             }
 
-            return {...this.describeState(), armedForViewer}
+            return {
+                ...this.describeState(),
+                armedForViewer,
+                ...(subscriptionId ? {subscriptionId} : {})
+            }
         },
 
         /**

--- a/ai/services/fleet/fleetWakeSseConsumer.mjs
+++ b/ai/services/fleet/fleetWakeSseConsumer.mjs
@@ -1,0 +1,330 @@
+/**
+ * @module ai/services/fleet/fleetWakeSseConsumer
+ * @summary The relay-side consumer of the composed fleet-server's wake stream — the plane
+ * vouching surface the delivery-liveness axis has been honestly waiting for.
+ *
+ * The transitional cockpit cannot present fleet-surface admission itself, so THIS process (the
+ * relay, which already authenticates to the plane) opens the fetch-streaming connection to
+ * `<planeBase>/fleet/events`, observes the per-viewer `state` event and `wake` frames, and
+ * derives an OBSERVATION the wake-routes axis renders through the existing pipeline:
+ *
+ * - Stream open + a `state` frame ⇒ the push lane is observed alive, with the server's own
+ *   per-viewer arming answer carried verbatim in the reason.
+ * - Stream down ⇒ honestly `unknown` with the disconnect reason and the staleness horizon —
+ *   absence of signal, never a fabricated verdict (a dead stream does not prove dead delivery;
+ *   poll remains the truth lane).
+ *
+ * Catch-up rides `poll-digest` on every reconnect once a subscription id is known, with the
+ * client-held watermark — a dropped stream loses nothing durable, and the observation carries
+ * how much was pending at reconnect. Reconnects respect the server's `retry:` hint as a floor.
+ *
+ * One credential, deliberately: the connection presents the relay's own fleet-admission bearer
+ * and nothing else. No second header is synthesized from it — the composed server refuses
+ * byte-identical pairs by design, and the boot-armed shared viewer identity means listening is
+ * sufficient in the transitional topology.
+ */
+
+const
+    DEFAULT_RETRY_FLOOR_MS = 5000,
+    MAX_BACKOFF_MS         = 60_000,
+    STALE_AFTER_MS         = 90_000;
+
+/**
+ * @summary Parses complete `text/event-stream` frames out of an accumulating buffer.
+ * @param {String} buffer
+ * @returns {Object} `{frames: [{event, data, retry}], rest}` — `rest` is the trailing partial.
+ * @private
+ */
+export function parseSseFrames(buffer) {
+    const
+        frames = [],
+        parts  = buffer.split('\n\n'),
+        rest   = parts.pop();
+
+    for (const part of parts) {
+        const frame = {event: 'message', data: null, retry: null};
+
+        for (const line of part.split('\n')) {
+            if (line.startsWith(':')) continue;
+
+            if (line.startsWith('event: ')) {
+                frame.event = line.slice(7).trim()
+            } else if (line.startsWith('data: ')) {
+                frame.data = frame.data === null ? line.slice(6) : `${frame.data}\n${line.slice(6)}`
+            } else if (line.startsWith('retry: ')) {
+                const value = Number(line.slice(7).trim());
+
+                if (Number.isFinite(value) && value > 0) {
+                    frame.retry = value
+                }
+            }
+        }
+
+        frames.push(frame)
+    }
+
+    return {frames, rest}
+}
+
+/**
+ * @summary Creates the wake-stream consumer. Passive until `start()`; every failure path is an
+ * observation, never a throw — the axis this feeds renders reasons, not stack traces.
+ * @param {Object} options
+ * @param {String} options.eventsUrl Absolute URL of the composed server's SSE endpoint.
+ * @param {String} [options.credential=''] The relay's fleet-admission bearer.
+ * @param {Function} [options.pollDigest] `({subscriptionId, sinceLogId}) => result` seam for
+ *     reconnect catch-up (the plane client's `manage_wake_subscription poll-digest` action);
+ *     absent means catch-up is skipped and the observation says so.
+ * @param {Function} [options.fetchImpl] Injection seam; defaults to global `fetch`.
+ * @param {Function} [options.now=Date.now]
+ * @param {Object} [options.logger=console]
+ * @param {Number} [options.retryFloorMs=5000] Initial reconnect floor; a server `retry:` hint
+ *     can only raise it (tests inject a small floor, production keeps the default).
+ * @returns {Object} `{start, stop, resolveDeliveryLiveness, describe}`
+ */
+export function createFleetWakeSseConsumer({
+    eventsUrl,
+    credential           = '',
+    pollDigest           = null,
+    fetchImpl            = null,
+    now                  = Date.now,
+    logger               = console,
+    retryFloorMs: initialRetryFloorMs = DEFAULT_RETRY_FLOOR_MS
+}) {
+    if (typeof eventsUrl !== 'string' || eventsUrl.trim().length === 0) {
+        throw new Error('createFleetWakeSseConsumer requires an eventsUrl')
+    }
+
+    const doFetch = fetchImpl ?? ((...args) => fetch(...args));
+
+    let
+        stopped            = true,
+        connected          = false,
+        connectionEpoch    = 0,
+        retryFloorMs       = initialRetryFloorMs,
+        consecutiveDrops   = 0,
+        lastFrameAt        = null,
+        lastWakeAt         = null,
+        lastState          = null,
+        lastDisconnect     = 'not started',
+        subscriptionId     = null,
+        watermark          = 0,
+        pendingAtReconnect = null,
+        abortController    = null;
+
+    function observeFrame(frame) {
+        lastFrameAt = now();
+
+        if (frame.retry) {
+            retryFloorMs = Math.max(frame.retry, initialRetryFloorMs)
+        }
+
+        if (frame.data === null) return;
+
+        let payload;
+
+        try {
+            payload = JSON.parse(frame.data)
+        } catch {
+            return // a malformed frame is dropped; the stream's liveness is already recorded
+        }
+
+        if (frame.event === 'state') {
+            lastState = payload
+        } else if (frame.event === 'wake') {
+            lastWakeAt     = now();
+            subscriptionId = payload.subscriptionId ?? subscriptionId;
+
+            const logId = payload.envelope?.payload?.watermark ?? payload.envelope?.logId;
+
+            if (Number.isFinite(logId) && logId > watermark) {
+                watermark = logId
+            }
+        }
+    }
+
+    async function catchUp() {
+        if (!pollDigest || !subscriptionId) {
+            pendingAtReconnect = null;
+            return
+        }
+
+        try {
+            const result = await pollDigest({subscriptionId, sinceLogId: watermark});
+
+            pendingAtReconnect = result?.counts?.pending ?? result?.pending ?? 0;
+
+            if (Number.isFinite(result?.watermark) && result.watermark > watermark) {
+                watermark = result.watermark
+            }
+        } catch (error) {
+            pendingAtReconnect = null;
+            logger.warn?.(`[FleetWakeSseConsumer] reconnect catch-up failed: ${error?.message ?? error}`)
+        }
+    }
+
+    async function connectOnce(epoch) {
+        abortController = new AbortController();
+
+        const response = await doFetch(eventsUrl, {
+            headers: {
+                accept: 'text/event-stream',
+                ...(credential ? {authorization: `Bearer ${credential}`} : {})
+            },
+            signal: abortController.signal
+        });
+
+        if (!response.ok || !response.body) {
+            lastDisconnect = `stream refused: HTTP ${response.status}`;
+            return
+        }
+
+        // A (re)connect is the catch-up moment: everything the dropped stream missed is
+        // derivable at read time — push is latency, poll is truth.
+        await catchUp();
+
+        connected        = true;
+        consecutiveDrops = 0;
+        lastFrameAt      = now();
+
+        const reader = response.body.getReader();
+
+        let buffer = '';
+
+        try {
+            for (;;) {
+                const {value, done} = await reader.read();
+
+                if (done || stopped || epoch !== connectionEpoch) break;
+
+                buffer = ((buffer + Buffer.from(value).toString('utf8')));
+
+                const {frames, rest} = parseSseFrames(buffer);
+
+                buffer = rest;
+                frames.forEach(observeFrame)
+            }
+
+            lastDisconnect = 'stream ended'
+        } catch (error) {
+            lastDisconnect = `stream error: ${error?.message ?? error}`
+        } finally {
+            connected = false;
+
+            try {
+                await reader.cancel()
+            } catch {/* teardown of a dead reader is best-effort */}
+        }
+    }
+
+    async function runLoop(epoch) {
+        while (!stopped && epoch === connectionEpoch) {
+            try {
+                await connectOnce(epoch)
+            } catch (error) {
+                connected      = false;
+                lastDisconnect = `connect failed: ${error?.message ?? error}`
+            }
+
+            if (stopped || epoch !== connectionEpoch) return;
+
+            consecutiveDrops++;
+
+            // The server's retry hint is the floor; drops back off exponentially under a cap so
+            // a dead endpoint costs a bounded trickle, never a tight loop.
+            const backoff = Math.min(retryFloorMs * Math.max(1, 2 ** (consecutiveDrops - 1)), MAX_BACKOFF_MS);
+
+            await new Promise(resolve => {
+                const timer = setTimeout(resolve, backoff);
+                timer.unref?.()
+            })
+        }
+    }
+
+    return {
+        /**
+         * @summary Opens the stream and keeps it open until `stop()`. Idempotent.
+         */
+        start() {
+            if (!stopped) return;
+
+            stopped = false;
+            connectionEpoch++;
+
+            runLoop(connectionEpoch).catch(error => {
+                logger.error?.(`[FleetWakeSseConsumer] loop crashed: ${error?.message ?? error}`)
+            })
+        },
+
+        /**
+         * @summary Closes the stream and stops reconnecting. Idempotent.
+         */
+        stop() {
+            stopped = true;
+            connectionEpoch++;
+            connected = false;
+
+            try {
+                abortController?.abort()
+            } catch {/* aborting an already-settled fetch is a no-op */}
+        },
+
+        /**
+         * @summary The delivery-liveness observation for the wake-routes axis — the shape
+         * `fleetWakeRoutesSource` documents for `resolveDeliveryLiveness`. Absence carries its
+         * reason; a dead stream renders `unknown`, never a fabricated `false` about delivery
+         * itself.
+         * @returns {Object} `{alive: Boolean|'unknown', reason: String}`
+         */
+        resolveDeliveryLiveness() {
+            if (stopped) {
+                return {alive: 'unknown', reason: 'wake stream consumer not running'}
+            }
+
+            if (connected) {
+                const
+                    age   = lastFrameAt === null ? null : now() - lastFrameAt,
+                    stale = age !== null && age > STALE_AFTER_MS;
+
+                if (stale) {
+                    return {
+                        alive : 'unknown',
+                        reason: `wake stream silent for ${Math.round(age / 1000)}s — liveness unconfirmed`
+                    }
+                }
+
+                const armedNote = lastState
+                    ? (lastState.armedForViewer ? 'armed for this viewer' : `not armed for this viewer (${lastState.reason ?? 'no reason carried'})`)
+                    : 'state event pending';
+
+                const pendingNote = pendingAtReconnect ? ` · ${pendingAtReconnect} pending caught up at reconnect` : '';
+
+                return {alive: true, reason: `composed wake stream connected · ${armedNote}${pendingNote}`}
+            }
+
+            return {
+                alive : 'unknown',
+                reason: `wake stream disconnected (${lastDisconnect}) — poll remains the truth lane`
+            }
+        },
+
+        /**
+         * @summary Full observational snapshot for diagnostics and specs.
+         * @returns {Object}
+         */
+        describe() {
+            return {
+                connected,
+                lastFrameAt,
+                lastWakeAt,
+                lastState,
+                lastDisconnect,
+                subscriptionId,
+                watermark,
+                pendingAtReconnect,
+                consecutiveDrops,
+                retryFloorMs
+            }
+        }
+    }
+}

--- a/ai/services/fleet/fleetWakeSseConsumer.mjs
+++ b/ai/services/fleet/fleetWakeSseConsumer.mjs
@@ -14,14 +14,18 @@
  *   absence of signal, never a fabricated verdict (a dead stream does not prove dead delivery;
  *   poll remains the truth lane).
  *
- * Catch-up rides `poll-digest` on every reconnect once a subscription id is known, with the
- * client-held watermark — a dropped stream loses nothing durable, and the observation carries
- * how much was pending at reconnect. Reconnects respect the server's `retry:` hint as a floor.
+ * Catch-up rides `poll-digest` on every connection, cold start included: the composed server's
+ * `state` handshake frame vouches the armed viewer's subscription id, so a fresh consumer with
+ * pending wakes catches up immediately — never waiting for a live wake to teach it which
+ * subscription the stream serves. The client-held watermark rides along, so a dropped stream
+ * loses nothing durable, and the observation carries how much was pending at catch-up.
+ * Reconnects respect the server's `retry:` hint as a floor.
  *
- * One credential, deliberately: the connection presents the relay's own fleet-admission bearer
- * and nothing else. No second header is synthesized from it — the composed server refuses
- * byte-identical pairs by design, and the boot-armed shared viewer identity means listening is
- * sufficient in the transitional topology.
+ * One credential, deliberately: the connection presents the relay's fleet-client PLANE-ADMISSION
+ * bearer — a distinct mint from its plane-MCP credential, which must never dial the fleet
+ * surface — and nothing else. No second header is synthesized from it: the composed server
+ * refuses byte-identical pairs by design, and the boot-armed shared viewer identity means
+ * listening is sufficient in the transitional topology.
  */
 
 const
@@ -71,9 +75,11 @@ export function parseSseFrames(buffer) {
  * observation, never a throw — the axis this feeds renders reasons, not stack traces.
  * @param {Object} options
  * @param {String} options.eventsUrl Absolute URL of the composed server's SSE endpoint.
- * @param {String} [options.credential=''] The relay's fleet-admission bearer.
+ * @param {String} [options.credential=''] The relay's fleet-client plane-admission bearer —
+ *     never the plane-MCP credential; the entry that constructs this consumer enforces the
+ *     class split.
  * @param {Function} [options.pollDigest] `({subscriptionId, sinceLogId}) => result` seam for
- *     reconnect catch-up (the plane client's `manage_wake_subscription poll-digest` action);
+ *     connection catch-up (the plane client's `manage_wake_subscription poll-digest` action);
  *     absent means catch-up is skipped and the observation says so.
  * @param {Function} [options.fetchImpl] Injection seam; defaults to global `fetch`.
  * @param {Function} [options.now=Date.now]
@@ -98,19 +104,20 @@ export function createFleetWakeSseConsumer({
     const doFetch = fetchImpl ?? ((...args) => fetch(...args));
 
     let
-        stopped            = true,
-        connected          = false,
-        connectionEpoch    = 0,
-        retryFloorMs       = initialRetryFloorMs,
-        consecutiveDrops   = 0,
-        lastFrameAt        = null,
-        lastWakeAt         = null,
-        lastState          = null,
-        lastDisconnect     = 'not started',
-        subscriptionId     = null,
-        watermark          = 0,
-        pendingAtReconnect = null,
-        abortController    = null;
+        stopped          = true,
+        connected        = false,
+        connectionEpoch  = 0,
+        retryFloorMs     = initialRetryFloorMs,
+        consecutiveDrops = 0,
+        lastFrameAt      = null,
+        lastWakeAt       = null,
+        lastState        = null,
+        lastDisconnect   = 'not started',
+        subscriptionId   = null,
+        watermark        = 0,
+        pendingAtCatchUp = null,
+        catchUpFired     = false,
+        abortController  = null;
 
     function observeFrame(frame) {
         lastFrameAt = now();
@@ -130,7 +137,14 @@ export function createFleetWakeSseConsumer({
         }
 
         if (frame.event === 'state') {
-            lastState = payload
+            lastState = payload;
+
+            // The handshake vouches the armed viewer's subscription id — the server's arming
+            // context created that subscription, so this is the authoritative source, available
+            // BEFORE any live wake arrives.
+            if (payload.subscriptionId) {
+                subscriptionId = payload.subscriptionId
+            }
         } else if (frame.event === 'wake') {
             lastWakeAt     = now();
             subscriptionId = payload.subscriptionId ?? subscriptionId;
@@ -141,24 +155,33 @@ export function createFleetWakeSseConsumer({
                 watermark = logId
             }
         }
+
+        // Catch-up fires once per connection, the moment the subscription id is known. The
+        // `state` handshake is the first frame every connection carries, so a COLD consumer
+        // with pending wakes catches up right here — no live wake has to arrive first. A server
+        // that vouches no id leaves this honestly unfired; poll remains the truth lane.
+        if (!catchUpFired && subscriptionId && pollDigest) {
+            catchUpFired = true;
+            catchUp() // absorbs its own faults; the observation carries the outcome
+        }
     }
 
     async function catchUp() {
         if (!pollDigest || !subscriptionId) {
-            pendingAtReconnect = null;
+            pendingAtCatchUp = null;
             return
         }
 
         try {
             const result = await pollDigest({subscriptionId, sinceLogId: watermark});
 
-            pendingAtReconnect = result?.counts?.pending ?? result?.pending ?? 0;
+            pendingAtCatchUp = result?.counts?.pending ?? result?.pending ?? 0;
 
             if (Number.isFinite(result?.watermark) && result.watermark > watermark) {
                 watermark = result.watermark
             }
         } catch (error) {
-            pendingAtReconnect = null;
+            pendingAtCatchUp = null;
             logger.warn?.(`[FleetWakeSseConsumer] reconnect catch-up failed: ${error?.message ?? error}`)
         }
     }
@@ -179,13 +202,15 @@ export function createFleetWakeSseConsumer({
             return
         }
 
-        // A (re)connect is the catch-up moment: everything the dropped stream missed is
-        // derivable at read time — push is latency, poll is truth.
-        await catchUp();
-
-        connected        = true;
-        consecutiveDrops = 0;
-        lastFrameAt      = now();
+        // Every connection is a catch-up moment — the trigger lives in `observeFrame`, on the
+        // first frame that makes the subscription id known (the handshake `state` frame on a
+        // server that vouches it). The per-connection observation resets here so a connection
+        // that CANNOT catch up never wears the previous one's count.
+        connected          = true;
+        consecutiveDrops   = 0;
+        lastFrameAt        = now();
+        catchUpFired       = false;
+        pendingAtCatchUp = null;
 
         const reader = response.body.getReader();
 
@@ -297,7 +322,7 @@ export function createFleetWakeSseConsumer({
                     ? (lastState.armedForViewer ? 'armed for this viewer' : `not armed for this viewer (${lastState.reason ?? 'no reason carried'})`)
                     : 'state event pending';
 
-                const pendingNote = pendingAtReconnect ? ` · ${pendingAtReconnect} pending caught up at reconnect` : '';
+                const pendingNote = pendingAtCatchUp ? ` · ${pendingAtCatchUp} pending caught up` : '';
 
                 return {alive: true, reason: `composed wake stream connected · ${armedNote}${pendingNote}`}
             }
@@ -321,7 +346,7 @@ export function createFleetWakeSseConsumer({
                 lastDisconnect,
                 subscriptionId,
                 watermark,
-                pendingAtReconnect,
+                pendingAtCatchUp,
                 consecutiveDrops,
                 retryFloorMs
             }

--- a/test/playwright/unit/ai/services/fleet/FleetServerComposition.spec.mjs
+++ b/test/playwright/unit/ai/services/fleet/FleetServerComposition.spec.mjs
@@ -445,3 +445,153 @@ test.describe('FleetServerComposition - per-viewer ownership through the real se
         }
     })
 });
+
+test.describe('FleetServerComposition - the relay stream consumer against the composed admission chain', () => {
+    test('the production credential chain end-to-end: the resolved fleet-client mint is admitted and drives cold catch-up; the plane-MCP mint is refused with an honest observation', async () => {
+        const {startFleetServer, assertFleetPlaneAdmissionBearerClass} = await import('../../../../../../ai/services/fleet/fleetServer.mjs');
+        const {createFleetWakeSseConsumer}                             = await import('../../../../../../ai/services/fleet/fleetWakeSseConsumer.mjs');
+
+        const waitUntil = async (predicate, timeoutMs = 2000) => {
+            const deadline = Date.now() + timeoutMs;
+
+            while (Date.now() < deadline) {
+                if (predicate()) return true;
+                await new Promise(resolve => setTimeout(resolve, 20))
+            }
+
+            return predicate()
+        };
+
+        // The deployed plane's admission shape, mirrored: the fleet surface admits the relay
+        // viewer's fleet-client mint and does NOT admit the relay's plane-MCP mint — a minted
+        // MC credential resolves to no provider subject there.
+        const server = await startFleetServer({
+            host    : '127.0.0.1',
+            port    : 0,
+            aiConfig: {
+                publicUrl    : 'http://127.0.0.1:3102/fleet',
+                mcpHttpHost  : '127.0.0.1',
+                mcpListenHost: '127.0.0.1',
+                fleet        : {
+                    port              : 0,
+                    dataDir           : '/unused',
+                    wakeSelfBase      : 'http://fleet-server:8083',
+                    planeBase         : 'http://ingress:8080',
+                    planeBearer       : 'service-token',
+                    planeBearerFile   : '',
+                    admissionTokenFile: '',
+                    planeInternalHosts: ['ingress']
+                }
+            },
+            planeGuard       : () => {},
+            logger           : QUIET,
+            createPlaneClient: ({credential}) => ({
+                async init() {
+                    return credential === 'service-token'
+                        ? {ok: true, identity: '@svc'}
+                        : {ok: false, reason: 'unknown bearer'}
+                },
+                async callTool(name, args) {
+                    if (args.action === 'subscribe')  return {subscriptionId: 'WAKE_SUB:svc'};
+                    if (args.action === 'rotate-key') return {subscriptionId: 'WAKE_SUB:svc', signingKey: 'b'.repeat(64)}
+                },
+                async close() {}
+            }),
+            resolveViewerClaim: async () => ({agentIdentityNodeId: '@svc'}),
+            authService       : {
+                setupPreCors() {},
+                async setup({app: target}) {
+                    target.use((req, res, next) => {
+                        const bearer = (req.headers.authorization ?? '').replace(/^Bearer\s+/i, '').trim();
+
+                        if (bearer === 'relay-fleet-pat') {
+                            req.auth = {
+                                userId          : 'svc',
+                                username        : 'svc display',
+                                providerUsername: 'svc',
+                                authProvider    : 'github',
+                                providerUserId  : 9
+                            }
+                        }
+
+                        next()
+                    })
+                }
+            },
+            transportService: {
+                computeAllowedHosts: () => ['127.0.0.1'],
+                installCors() {}
+            }
+        });
+
+        const base = `http://127.0.0.1:${server.address().port}`;
+
+        // The RELAY's own config, resolved the way production resolves it: a distinct
+        // fleet-client mint declared BESIDE the plane-MCP mint. The class teeth pass exactly
+        // because the mints differ.
+        const credential = assertFleetPlaneAdmissionBearerClass({
+            aiConfig: {fleet: {
+                planeBearer             : 'relay-mc-mint',
+                planeBearerFile         : '',
+                planeAdmissionBearer    : 'relay-fleet-pat',
+                planeAdmissionBearerFile: '',
+                admissionTokenFile      : ''
+            }}
+        });
+
+        expect(credential).toBe('relay-fleet-pat');
+
+        const pollCalls = [];
+
+        const consumer = createFleetWakeSseConsumer({
+            eventsUrl   : `${base}/fleet/events`,
+            credential,
+            retryFloorMs: 50,
+            logger      : QUIET,
+            pollDigest  : async args => {
+                pollCalls.push(args);
+                return {counts: {pending: 4}, watermark: 30}
+            }
+        });
+
+        // The pre-repair defect, pinned at the wire: production used to hand this consumer the
+        // plane-MCP credential, which the fleet surface refuses — and the axis must render that
+        // refusal, never a fabricated verdict. The long floor keeps the retry loop out of the
+        // assertion window.
+        const wrongClass = createFleetWakeSseConsumer({
+            eventsUrl   : `${base}/fleet/events`,
+            credential  : 'relay-mc-mint',
+            retryFloorMs: 5000,
+            logger      : QUIET
+        });
+
+        try {
+            consumer.start();
+
+            // The composed handshake vouches the boot-armed subscription id, and that alone
+            // drives the cold catch-up — no live wake exists anywhere in this test.
+            await waitUntil(() => consumer.resolveDeliveryLiveness().reason?.includes?.('caught up'));
+
+            expect(consumer.describe().subscriptionId).toBe('WAKE_SUB:svc');
+            expect(pollCalls).toEqual([{subscriptionId: 'WAKE_SUB:svc', sinceLogId: 0}]);
+            expect(consumer.describe().watermark).toBe(30);
+
+            const liveness = consumer.resolveDeliveryLiveness();
+
+            expect(liveness.alive).toBe(true);
+            expect(liveness.reason).toContain('armed for this viewer');
+            expect(liveness.reason).toContain('4 pending caught up');
+
+            wrongClass.start();
+            await waitUntil(() => wrongClass.describe().lastDisconnect === 'stream refused: HTTP 401');
+
+            expect(wrongClass.describe().lastDisconnect).toBe('stream refused: HTTP 401');
+            expect(wrongClass.resolveDeliveryLiveness().alive).toBe('unknown');
+            expect(wrongClass.describe().subscriptionId).toBeNull()
+        } finally {
+            consumer.stop();
+            wrongClass.stop();
+            await new Promise(resolve => server.close(resolve))
+        }
+    })
+});

--- a/test/playwright/unit/ai/services/fleet/fleetWakeArming.spec.mjs
+++ b/test/playwright/unit/ai/services/fleet/fleetWakeArming.spec.mjs
@@ -21,8 +21,10 @@ import {createFleetWakeFanout}      from '../../../../../../ai/services/fleet/fl
 import {normalizeSecureMcpEndpoint} from '../../../../../../ai/services/fleet/mcpWireParsing.mjs';
 import {
     armFleetWakePushLane,
+    assertFleetPlaneAdmissionBearerClass,
     assertFleetPlaneBearerClass,
     createWakeArmingContext,
+    resolveFleetPlaneAdmissionBearer,
     resolveFleetPlaneBearer,
     resolveViewerStreamKey,
     startFleetServer
@@ -324,6 +326,75 @@ test.describe('fleet wake arming - the service credential chain', () => {
                 return ''
             }
         })).toBe('direct-mint')
+    })
+});
+
+test.describe('fleet wake arming - the fleet-client plane-admission credential chain', () => {
+    const cleanFleet = overrides => ({
+        planeBearer             : '',
+        planeBearerFile         : '',
+        planeAdmissionBearer    : '',
+        planeAdmissionBearerFile: '',
+        admissionTokenFile      : '',
+        ...overrides
+    });
+
+    test('the direct value wins; the secret file is the fallback; absence resolves empty — never a fallback onto the plane-MCP bearer', () => {
+        expect(resolveFleetPlaneAdmissionBearer({
+            aiConfig: {fleet: cleanFleet({planeAdmissionBearer: ' direct-pat '})}
+        })).toBe('direct-pat');
+
+        expect(resolveFleetPlaneAdmissionBearer({
+            aiConfig: {fleet: cleanFleet({planeAdmissionBearerFile: '/run/secrets/fleet-admission'})},
+            readFile: target => (target === '/run/secrets/fleet-admission' ? 'from-file\n' : '')
+        })).toBe('from-file');
+
+        // The shipped-defect regression pinned: a deployment that declares ONLY the plane-MCP
+        // bearer resolves NO fleet-surface credential — absence, not substitution.
+        expect(resolveFleetPlaneAdmissionBearer({
+            aiConfig: {fleet: cleanFleet({planeBearer: 'class-3-mint'})}
+        })).toBe('');
+
+        expect(resolveFleetPlaneAdmissionBearer({
+            aiConfig: {fleet: cleanFleet({planeAdmissionBearerFile: '/missing'})},
+            readFile: () => {
+                throw new Error('ENOENT')
+            }
+        })).toBe('')
+    });
+
+    test('a fleet-surface bearer that IS the plane-MCP bearer is refused — the MC credential never dials the fleet surface', () => {
+        expect(() => assertFleetPlaneAdmissionBearerClass({
+            aiConfig: {fleet: cleanFleet({
+                planeAdmissionBearer: 'one-mint-two-audiences',
+                planeBearer         : 'one-mint-two-audiences'
+            })}
+        })).toThrow(/credential-class ledger forbids/)
+    });
+
+    test('a fleet-surface bearer that IS the bootstrap admission token is refused', () => {
+        const files = {'/run/secrets/mcp-auth-token': 'bootstrap-token\n'};
+
+        expect(() => assertFleetPlaneAdmissionBearerClass({
+            aiConfig: {fleet: cleanFleet({
+                planeAdmissionBearer: 'bootstrap-token',
+                admissionTokenFile  : '/run/secrets/mcp-auth-token'
+            })},
+            readFile: target => files[target]
+        })).toThrow(/credential-class ledger forbids/)
+    });
+
+    test('a genuinely distinct fleet-client mint passes the teeth; absence passes as empty (the honest-unarmed path)', () => {
+        expect(assertFleetPlaneAdmissionBearerClass({
+            aiConfig: {fleet: cleanFleet({
+                planeAdmissionBearer: 'distinct-fleet-client-pat',
+                planeBearer         : 'distinct-class-3-mint'
+            })}
+        })).toBe('distinct-fleet-client-pat');
+
+        expect(assertFleetPlaneAdmissionBearerClass({
+            aiConfig: {fleet: cleanFleet({planeBearer: 'class-3-mint'})}
+        })).toBe('')
     })
 });
 

--- a/test/playwright/unit/ai/services/fleet/fleetWakeFanout.spec.mjs
+++ b/test/playwright/unit/ai/services/fleet/fleetWakeFanout.spec.mjs
@@ -196,6 +196,12 @@ test.describe('fleetWakeFanout - identity-keyed SSE fan-out + relay-subscription
         expect(mine.events('state')[0]).toContain('"armedForViewer":true');
         expect(theirs.events('state')[0]).toContain('"armedForViewer":false');
 
+        // The handshake vouches the armed viewer's OWN subscription id — the cold catch-up
+        // authority for a consumer with pending wakes and no live wake yet. A viewer the lane
+        // is not armed for gets no id: nothing to poll, nothing to guess.
+        expect(mine.events('state')[0]).toContain('"subscriptionId":"WAKE_SUB:relay"');
+        expect(theirs.events('state')[0]).not.toContain('subscriptionId');
+
         expect(mine.head.headers['content-type']).toBe('text/event-stream')
     });
 

--- a/test/playwright/unit/ai/services/fleet/fleetWakeSseConsumer.spec.mjs
+++ b/test/playwright/unit/ai/services/fleet/fleetWakeSseConsumer.spec.mjs
@@ -69,7 +69,7 @@ test.describe('parseSseFrames - the text/event-stream frame grammar', () => {
 });
 
 test.describe('fleetWakeSseConsumer - the delivery-liveness observation', () => {
-    test('the full arc: connect → observe state+wake → drop → poll-digest catch-up at reconnect → honest liveness throughout', async () => {
+    test('the full arc: connect → handshake-vouched cold catch-up → wake → drop → reconnect catch-up at the held watermark', async () => {
         const
             responses = [],
             pollCalls = [];
@@ -95,7 +95,10 @@ test.describe('fleetWakeSseConsumer - the delivery-liveness observation', () => 
             },
             pollDigest: async args => {
                 pollCalls.push(args);
-                return {counts: {pending: 2}, watermark: 9}
+                // The cold catch-up finds nothing pending; the reconnect catch-up finds 2.
+                return pollCalls.length === 1
+                    ? {counts: {pending: 0}, watermark: 0}
+                    : {counts: {pending: 2}, watermark: 9}
             }
         });
 
@@ -107,13 +110,17 @@ test.describe('fleetWakeSseConsumer - the delivery-liveness observation', () => 
         consumer.start();
         await wait(30);
 
-        // First connect: no subscription id is known yet, so catch-up is skipped by contract.
+        // Connected but pre-handshake: no subscription id has been vouched yet, so catch-up has
+        // nothing to target.
         expect(pollCalls).toHaveLength(0);
 
         // No retry hint here on purpose: a server hint can only RAISE the floor, and this arc's
-        // reconnect timing rides the injected 10ms test floor.
-        responses[0].push('event: state\ndata: {"armed":true,"armedForViewer":true,"reason":"armed"}\n\n');
+        // reconnect timing rides the injected 10ms test floor. The handshake vouches the
+        // subscription id, which is the cold catch-up trigger.
+        responses[0].push('event: state\ndata: {"armed":true,"armedForViewer":true,"reason":"armed","subscriptionId":"WAKE_SUB:live"}\n\n');
         await wait(20);
+
+        expect(pollCalls).toEqual([{subscriptionId: 'WAKE_SUB:live', sinceLogId: 0}]);
 
         let liveness = consumer.resolveDeliveryLiveness();
 
@@ -126,20 +133,23 @@ test.describe('fleetWakeSseConsumer - the delivery-liveness observation', () => 
         expect(consumer.describe().subscriptionId).toBe('WAKE_SUB:live');
         expect(consumer.describe().watermark).toBe(7);
 
-        // Drop the stream: the reconnect (floor 10ms) must run catch-up with the held watermark.
+        // Drop the stream: the reconnect (floor 10ms) re-runs the handshake, and ITS catch-up
+        // carries the held watermark — nothing durable was lost with the stream.
         responses[0].close();
         await wait(80);
 
         expect(responses.length).toBeGreaterThanOrEqual(2);
-        expect(pollCalls).toEqual([{subscriptionId: 'WAKE_SUB:live', sinceLogId: 7}]);
-        expect(consumer.describe().watermark).toBe(9);
+        expect(pollCalls).toHaveLength(1);
 
-        responses[1].push('event: state\ndata: {"armed":true,"armedForViewer":true,"reason":"armed"}\n\n');
+        responses[1].push('event: state\ndata: {"armed":true,"armedForViewer":true,"reason":"armed","subscriptionId":"WAKE_SUB:live"}\n\n');
         await wait(20);
+
+        expect(pollCalls[1]).toEqual({subscriptionId: 'WAKE_SUB:live', sinceLogId: 7});
+        expect(consumer.describe().watermark).toBe(9);
 
         liveness = consumer.resolveDeliveryLiveness();
         expect(liveness.alive).toBe(true);
-        expect(liveness.reason).toContain('2 pending caught up at reconnect');
+        expect(liveness.reason).toContain('2 pending caught up');
 
         consumer.stop();
 
@@ -147,6 +157,78 @@ test.describe('fleetWakeSseConsumer - the delivery-liveness observation', () => 
             alive : 'unknown',
             reason: 'wake stream consumer not running'
         })
+    });
+
+    test('the cold window: pending wakes + a fresh consumer + NO live wake — the vouched handshake id alone drives catch-up', async () => {
+        const
+            response  = sseResponse(),
+            pollCalls = [];
+
+        const consumer = createFleetWakeSseConsumer({
+            eventsUrl   : 'http://127.0.0.1:3102/fleet/events',
+            credential  : 'relay-admission',
+            retryFloorMs: 10,
+            logger      : QUIET,
+            fetchImpl   : async () => response,
+            pollDigest  : async args => {
+                pollCalls.push(args);
+                return {counts: {pending: 3}, watermark: 12}
+            }
+        });
+
+        consumer.start();
+        await wait(30);
+
+        response.push('event: state\ndata: {"armed":true,"armedForViewer":true,"reason":"armed","subscriptionId":"WAKE_SUB:cold"}\n\n');
+        await wait(20);
+
+        // The shipped-defect falsifier: before the handshake vouched the id, a cold consumer
+        // skipped catch-up entirely, and pending wakes waited on a live wake that might never
+        // come. Now the handshake alone drains them.
+        expect(pollCalls).toEqual([{subscriptionId: 'WAKE_SUB:cold', sinceLogId: 0}]);
+        expect(consumer.describe().watermark).toBe(12);
+
+        const liveness = consumer.resolveDeliveryLiveness();
+
+        expect(liveness.alive).toBe(true);
+        expect(liveness.reason).toContain('3 pending caught up');
+
+        consumer.stop();
+        response.close()
+    });
+
+    test('a server that vouches no subscription id leaves catch-up honestly unfired — no guessed target, no fabricated count', async () => {
+        const
+            response  = sseResponse(),
+            pollCalls = [];
+
+        const consumer = createFleetWakeSseConsumer({
+            eventsUrl   : 'http://127.0.0.1:3102/fleet/events',
+            credential  : 'relay-admission',
+            retryFloorMs: 10,
+            logger      : QUIET,
+            fetchImpl   : async () => response,
+            pollDigest  : async args => {
+                pollCalls.push(args);
+                return {counts: {pending: 5}, watermark: 40}
+            }
+        });
+
+        consumer.start();
+        await wait(30);
+
+        response.push('event: state\ndata: {"armed":true,"armedForViewer":true,"reason":"armed"}\n\n');
+        await wait(20);
+
+        expect(pollCalls).toHaveLength(0);
+
+        const liveness = consumer.resolveDeliveryLiveness();
+
+        expect(liveness.alive).toBe(true);
+        expect(liveness.reason).not.toContain('caught up');
+
+        consumer.stop();
+        response.close()
     });
 
     test('a refused stream renders unknown with the HTTP reason — never a fabricated verdict', async () => {

--- a/test/playwright/unit/ai/services/fleet/fleetWakeSseConsumer.spec.mjs
+++ b/test/playwright/unit/ai/services/fleet/fleetWakeSseConsumer.spec.mjs
@@ -1,0 +1,199 @@
+import {setup} from '../../../../setup.mjs';
+
+const appName = 'FleetWakeSseConsumerTest';
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name             : appName,
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../../../src/Neo.mjs';
+import * as core      from '../../../../../../src/core/_export.mjs';
+
+import {createFleetWakeSseConsumer, parseSseFrames} from '../../../../../../ai/services/fleet/fleetWakeSseConsumer.mjs';
+
+const QUIET = {info: () => {}, warn: () => {}, error: () => {}};
+
+const wait = ms => new Promise(resolve => setTimeout(resolve, ms));
+
+/** A scriptable SSE response: the test pushes encoded chunks and closes the stream at will. */
+function sseResponse() {
+    let controller;
+
+    const stream = new ReadableStream({
+        start(c) {
+            controller = c
+        }
+    });
+
+    const encoder = new TextEncoder();
+
+    return {
+        ok    : true,
+        status: 200,
+        body  : stream,
+        push(text) {
+            controller.enqueue(encoder.encode(text))
+        },
+        close() {
+            try {
+                controller.close()
+            } catch {/* already closed */}
+        }
+    }
+}
+
+test.describe('parseSseFrames - the text/event-stream frame grammar', () => {
+    test('complete frames parse; the trailing partial stays as rest', () => {
+        const {frames, rest} = parseSseFrames('event: state\ndata: {"a":1}\n\nevent: wake\ndata: {"b"');
+
+        expect(frames).toHaveLength(1);
+        expect(frames[0]).toEqual({event: 'state', data: '{"a":1}', retry: null});
+        expect(rest).toBe('event: wake\ndata: {"b"')
+    });
+
+    test('multi-line data joins; comments are ignored; retry hints parse', () => {
+        const {frames} = parseSseFrames('retry: 7000\n:hb\nevent: wake\ndata: {"x":\ndata: 1}\n\n');
+
+        expect(frames[0].retry).toBe(7000);
+        expect(frames[0].event).toBe('wake');
+        expect(frames[0].data).toBe('{"x":\n1}')
+    })
+});
+
+test.describe('fleetWakeSseConsumer - the delivery-liveness observation', () => {
+    test('the full arc: connect → observe state+wake → drop → poll-digest catch-up at reconnect → honest liveness throughout', async () => {
+        const
+            responses = [],
+            pollCalls = [];
+
+        const nextResponse = () => {
+            const response = sseResponse();
+            responses.push(response);
+            return response
+        };
+
+        const consumer = createFleetWakeSseConsumer({
+            eventsUrl   : 'http://127.0.0.1:3102/fleet/events',
+            credential  : 'relay-admission',
+            retryFloorMs: 10,
+            logger      : QUIET,
+            fetchImpl   : async (url, options) => {
+                expect(url).toBe('http://127.0.0.1:3102/fleet/events');
+                expect(options.headers.authorization).toBe('Bearer relay-admission');
+                // The non-alias discipline as a wire assertion: no second credential header is
+                // ever synthesized by this consumer.
+                expect(options.headers['x-neo-mc-authorization']).toBeUndefined();
+                return nextResponse()
+            },
+            pollDigest: async args => {
+                pollCalls.push(args);
+                return {counts: {pending: 2}, watermark: 9}
+            }
+        });
+
+        expect(consumer.resolveDeliveryLiveness()).toEqual({
+            alive : 'unknown',
+            reason: 'wake stream consumer not running'
+        });
+
+        consumer.start();
+        await wait(30);
+
+        // First connect: no subscription id is known yet, so catch-up is skipped by contract.
+        expect(pollCalls).toHaveLength(0);
+
+        // No retry hint here on purpose: a server hint can only RAISE the floor, and this arc's
+        // reconnect timing rides the injected 10ms test floor.
+        responses[0].push('event: state\ndata: {"armed":true,"armedForViewer":true,"reason":"armed"}\n\n');
+        await wait(20);
+
+        let liveness = consumer.resolveDeliveryLiveness();
+
+        expect(liveness.alive).toBe(true);
+        expect(liveness.reason).toContain('armed for this viewer');
+
+        responses[0].push('event: wake\ndata: {"subscriptionId":"WAKE_SUB:live","envelope":{"payload":{"watermark":7}}}\n\n');
+        await wait(20);
+
+        expect(consumer.describe().subscriptionId).toBe('WAKE_SUB:live');
+        expect(consumer.describe().watermark).toBe(7);
+
+        // Drop the stream: the reconnect (floor 10ms) must run catch-up with the held watermark.
+        responses[0].close();
+        await wait(80);
+
+        expect(responses.length).toBeGreaterThanOrEqual(2);
+        expect(pollCalls).toEqual([{subscriptionId: 'WAKE_SUB:live', sinceLogId: 7}]);
+        expect(consumer.describe().watermark).toBe(9);
+
+        responses[1].push('event: state\ndata: {"armed":true,"armedForViewer":true,"reason":"armed"}\n\n');
+        await wait(20);
+
+        liveness = consumer.resolveDeliveryLiveness();
+        expect(liveness.alive).toBe(true);
+        expect(liveness.reason).toContain('2 pending caught up at reconnect');
+
+        consumer.stop();
+
+        expect(consumer.resolveDeliveryLiveness()).toEqual({
+            alive : 'unknown',
+            reason: 'wake stream consumer not running'
+        })
+    });
+
+    test('a refused stream renders unknown with the HTTP reason — never a fabricated verdict', async () => {
+        const consumer = createFleetWakeSseConsumer({
+            eventsUrl   : 'http://127.0.0.1:3102/fleet/events',
+            retryFloorMs: 10,
+            logger      : QUIET,
+            fetchImpl   : async () => ({ok: false, status: 401, body: null})
+        });
+
+        consumer.start();
+        await wait(30);
+        consumer.stop();
+
+        expect(consumer.describe().lastDisconnect).toBe('stream refused: HTTP 401')
+    });
+
+    test('a silent-but-open stream degrades to unknown past the staleness horizon', async () => {
+        let tick = 1_000_000;
+
+        const response = sseResponse();
+
+        const consumer = createFleetWakeSseConsumer({
+            eventsUrl   : 'http://127.0.0.1:3102/fleet/events',
+            retryFloorMs: 10,
+            logger      : QUIET,
+            now         : () => tick,
+            fetchImpl   : async () => response
+        });
+
+        consumer.start();
+        await wait(30);
+
+        response.push('event: state\ndata: {"armed":true,"armedForViewer":false,"reason":"not armed"}\n\n');
+        await wait(20);
+
+        expect(consumer.resolveDeliveryLiveness().alive).toBe(true);
+
+        // 91 seconds of silence on an open socket: liveness is UNCONFIRMED, not asserted.
+        tick += 91_000;
+
+        const liveness = consumer.resolveDeliveryLiveness();
+
+        expect(liveness.alive).toBe('unknown');
+        expect(liveness.reason).toContain('silent for 91s');
+
+        consumer.stop();
+        response.close()
+    })
+});


### PR DESCRIPTION
Resolves neomjs/neo#17101

The wake push lane reaches the cockpit: the relay now consumes the composed fleet-server's `/fleet/events` stream (merged this morning as slice 2) and the delivery-liveness axis renders a **live observation** instead of the typed unknown whose own comment said it was waiting "until the plane exposes a vouching surface" — this stream is that surface. Topology-honest v1 per the corrected ticket body: the consumer lands in the **relay** (`ai/services/fleet/`, Node fetch-streaming), because the transitional cockpit holds only the process bearer and cannot present fleet-surface admission itself; the browser-direct consumer with the class-3 header is the C2-cutover follow-up the ticket's contract section specifies.

- **`fleetWakeSseConsumer.mjs`** (new): fetch-streaming `text/event-stream` reader — frame parser (exported, unit-tested), per-viewer `state` + `wake` observation, client-held watermark from wake envelopes, reconnect loop honoring the server `retry:` hint as a floor with capped exponential backoff, and **`poll-digest` catch-up on every connection, cold start included**: the composed server's `state` handshake vouches the armed viewer's subscription id (the fan-out's route key, added in `fleetWakeFanout.mjs describeStateFor`), so a fresh consumer with pending wakes drains them from the handshake alone — no live wake required (push is latency, poll is truth — a dropped stream loses nothing durable, and the observation carries the pending count caught up). One credential, deliberately: the relay's fleet-client **plane-admission** bearer — the new `fleet.planeAdmissionBearer` / `planeAdmissionBearerFile` leaves, its own mint, with class teeth (`assertFleetPlaneAdmissionBearerClass`) refusing a value that aliases the plane-MCP bearer or the bootstrap admission token — and no second header is ever synthesized from it, asserted in the spec as a wire fact (the composed server refuses byte-identical pairs; the boot-armed shared viewer identity means listening suffices in this topology).
- **`devFleetServer.mjs`**: the plane branch resolves the fleet-surface credential through the class teeth — an ALIASED declaration refuses the boot loudly, an EMPTY one arms nothing and the axis renders `no fleet-surface credential declared (fleet.planeAdmissionBearer / fleet.planeAdmissionBearerFile)` — then constructs and starts the consumer (`<planeBase>/fleet/events`, the class-1 credential, `poll-digest` via the proven plane client) and `resolveDeliveryLiveness` becomes the live observation; **terminal-delivery failures stay honestly `unknown`** — the stream does not vouch receipts, and over-claiming that axis would fabricate. The consumer stops on every exit path (clean shutdown, startup failure, probe failure, reuse, refusal) so its reconnect loop can never outlive the boot. The cockpit renders the axis through the EXISTING `fleetWakeRoutesSource` → `sourceHealth` pipeline: zero `apps/**` changes. Custody note: the class-1 credential is CLIENT-side by the ledger's custodian shapes, so the canonical compose is deliberately untouched — no plane-side secret exists for it.
- **Honest-absence throughout**: not-running / refused (HTTP reason) / disconnected (reason + "poll remains the truth lane") / silent-past-90s (unconfirmed, not asserted) / no-credential-declared / no-vouched-id (catch-up honestly unfired, no guessed target) all render as `unknown` or reasoned absence — a dead stream never fabricates a verdict about delivery itself.

Evidence: L2 (hermetic falsifiers for the frame grammar, the full connect→cold-catch-up→wake→drop→reconnect-catch-up arc with wire-level header assertions, the cold window, the credential-class chain, refused-stream honesty, and the staleness horizon; full fleet directory green) → L3 required (the live relay observation against a running composed plane — the rebuilt composition). Residual: live plane observation, Residual-Owner: neomjs/neo-agent-brain#50.

## Deltas from ticket

- Topology correction recorded on the ticket BEFORE building (the v1 consumer is the relay, not the browser — the transitional cockpit cannot present fleet-surface admission); the browser-direct fetch-streaming consumer rides the C2 cutover as the ticket now states.
- Terminal-delivery failures deliberately stay `unknown` (the ticket's delivery-axis wiring scope narrowed to the axis the new surface actually vouches: liveness).
- Review repair (@neo-gpt-emmy, pre-formal single-repair): production wiring passed the plane-MCP credential (class 3) into `/fleet/events`, whose admission requires the distinct fleet-client mint — refused outright by a deployed plane; and cold-start catch-up waited on a live wake to learn the subscription id, so a fresh consumer with pending wakes and no later wake never caught up. Both repaired in `66458f303a`: the dedicated class-1 leaf pair + non-alias teeth + production binding, and the handshake-vouched subscription id.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/ai/services/fleet/fleetWakeSseConsumer.spec.mjs` → 7 passed (frame grammar incl. chunk-split partials and multi-line data; the full arc: handshake-vouched cold catch-up `{sinceLogId: 0}` → wake watermark 7 → drop → reconnect catch-up `{sinceLogId: 7}` → watermark 9 → "2 pending caught up"; **the cold window**: pending wakes + a fresh consumer + NO live wake, drained from the handshake alone; a no-vouch server leaves catch-up honestly unfired; no-second-header wire assertion; refused-stream reason; 91s-silence degradation).
- `npm run test-unit -- test/playwright/unit/ai/services/fleet/` → 610 passed (full directory), including the new credential-chain falsifiers (`fleetWakeArming.spec.mjs`: precedence, both alias refusals, distinct-mint pass, absence-not-substitution) and the composition-level end-to-end (`FleetServerComposition.spec.mjs`: the production resolver chain feeds a real consumer against the real composed admission — admitted mint connects and cold-catches-up with zero live wakes; the plane-MCP mint is refused HTTP 401 and the axis renders honest `unknown`).
- `npm run agent-preflight -- --change-class capability …` → all gates passed.

## Post-Merge Validation

Residual-Owner: neomjs/neo-agent-brain#50

- [ ] Live relay observation on the rebuilt local composition: `[fleet] wake-state seam … delivery liveness observed from the composed wake stream` in the relay's boot log, the cockpit's wake-routes axis rendering `alive` with the armed-for-viewer reason, and a stream drop degrading the axis to honest `unknown` within the staleness horizon.

## Commits (if multi-commit)

1. `b3714c9525` — the consumer + wiring + falsifiers.
2. `f32ef92cd7` — the reconnect backoff classified in the retry-bound registry (`retry-growth`, `max-delay` carrier, witness = the `MAX_BACKOFF_MS` cap + terminal stop/epoch exits).
3. `66458f303a` — review repair: the fleet-client plane-admission credential chain (leaves + class teeth + production binding; empty ⇒ honest-unarmed, aliased ⇒ loud refusal) and handshake-vouched cold catch-up (the fan-out's `state` frame carries the armed viewer's subscription id; the consumer catches up once per connection the moment the id is known).

Related: neomjs/neo-agent-brain#50 (umbrella; slices 1+2 merged) · neomjs/neo#17102 (telemetry sibling, in review as PR neomjs/neo#17119) · PR neomjs/neo#17103 (the surface this consumes) · the C2 cutover client (browser-direct consumer follow-up per the ticket contract).

Authored by Clio (Fable 5, Claude Code). Session c4996813-01b9-4234-8bdd-ed3bf22c0970.
