### PR TITLE
feat(ai): project every behavior-binding clock and gate the unprojected ones (#17115)

### DIFF
--- a/.github/workflows/config-template-ssot-lint.yml
+++ b/.github/workflows/config-template-ssot-lint.yml
@@ -15,6 +15,14 @@ on:
       - 'ai/scripts/lint/config-leaf-parity.json'
       - 'ai/scripts/lint/lint-config-template-ssot.mjs'
       - '.github/workflows/config-template-ssot-lint.yml'
+      # Compose templates are SCANNED by two rules — the Compose/default parity check and the
+      # behavior-binding clock projection check (#17115) — so by the scanned ⊆ watched invariant
+      # stated below they must be watched. Without this, deleting a projected clock from a deploy
+      # template triggers nothing, which is precisely the "guard present, correct, and never run"
+      # class the filters above already call out twice. The projection rule exists because a clock
+      # went unprojected across two plane generations; leaving its own trigger unwatched would
+      # rebuild that blind spot one layer up.
+      - 'ai/deploy/**'
       # The invariant is scanned ⊆ watched: the lint's implementation/capture rules walk every
       # `ai/**/*.mjs` and its test config-authority (C3) rule walks every `test/**/*.mjs`, so a
       # filter without these lets an introducing PR land ungated and turns the NEXT unrelated
@@ -36,6 +44,14 @@ on:
       - 'ai/scripts/lint/config-leaf-parity.json'
       - 'ai/scripts/lint/lint-config-template-ssot.mjs'
       - '.github/workflows/config-template-ssot-lint.yml'
+      # Compose templates are SCANNED by two rules — the Compose/default parity check and the
+      # behavior-binding clock projection check (#17115) — so by the scanned ⊆ watched invariant
+      # stated below they must be watched. Without this, deleting a projected clock from a deploy
+      # template triggers nothing, which is precisely the "guard present, correct, and never run"
+      # class the filters above already call out twice. The projection rule exists because a clock
+      # went unprojected across two plane generations; leaving its own trigger unwatched would
+      # rebuild that blind spot one layer up.
+      - 'ai/deploy/**'
       # The invariant is scanned ⊆ watched: the lint's implementation/capture rules walk every
       # `ai/**/*.mjs` and its test config-authority (C3) rule walks every `test/**/*.mjs`, so a
       # filter without these lets an introducing PR land ungated and turns the NEXT unrelated

--- a/ai/deploy/docker-compose.provider-lanes.yml
+++ b/ai/deploy/docker-compose.provider-lanes.yml
@@ -132,6 +132,55 @@ x-provider-lane-env: &provider-lane-env
   NEO_OPENAI_COMPATIBLE_HOST: http://embedding-model:8080
   NEO_OPENAI_COMPATIBLE_EMBEDDING_MODEL: qwen3-embedding-8b
   NEO_OPENAI_COMPATIBLE_REQUIRE_PARALLEL_MODELS: "1"
+  # ── Embedding-lane behavior-binding clocks (#17115) ────────────────────────────────────────────
+  # PROJECTED AS COMMENTS, DELIBERATELY. These leaves bind embedding timing on every deployment,
+  # but their values live in `ai/configBase.mjs` and nowhere else: writing a default into this file
+  # creates a second declaration site, so a later change to the leaf would leave this file silently
+  # pinning the old number. That is the failure `matches-config-default` in the config-leaf-parity
+  # gate exists to prevent, and it is why these are documented rather than restated. Uncomment a
+  # line ONLY to override — a value present here is then a deliberate deviation, which is the one
+  # case where compose is the right home for it.
+  #
+  # THE LADDER THAT ACTUALLY BINDS A SINGLE-INPUT EMBED. Reading only the 300s/900s deadlines
+  # elsewhere in a deployment gives the wrong picture: every single-input embed is governed first by
+  # this ~47s ceiling, which is not any one leaf but the composition of three:
+  #
+  #     contentionTimeoutMs x (contentionRetryCount + 1 attempts) + contentionRetryDelayMs x retries
+  #     15000 x 3 + 1000 x 2 = 47000ms
+  #
+  # `contentionRetryCount` is a RETRY count, not an attempt count — the dispatcher enters with
+  # `contentionRetriesLeft = contentionRetryCount` and decrements per retry, so 2 yields 3 attempts.
+  # Omitting `_RETRY_DELAY_MS` from this block would leave the 47s underivable from the file.
+  #
+  # NEO_OPENAI_COMPATIBLE_CONTENTION_TIMEOUT_MS: "15000"     # per-attempt ceiling, ONE single-input embed
+  # NEO_OPENAI_COMPATIBLE_CONTENTION_RETRY_COUNT: "2"        # retries after the first attempt (2 -> 3 attempts)
+  # NEO_OPENAI_COMPATIBLE_CONTENTION_RETRY_DELAY_MS: "1000"  # wait between attempts; x retryCount in the total
+  #
+  # Plane-class guidance: on a CPU-constrained plane a single embed can exceed 15000ms under load,
+  # so the ladder burns all three attempts and returns a contention timeout after ~47s rather than a
+  # result. Raising `_TIMEOUT_MS` before raising `_RETRY_COUNT` is the ordering that shortens
+  # total latency for the same tolerance. On a GPU plane the defaults are typically slack and the
+  # ladder should never engage — if it does, that is a capacity signal, not a tuning opportunity.
+  #
+  # BATCH PATH — a separate clock set from the single-input ladder above; neither bounds the other.
+  # NEO_OPENAI_COMPATIBLE_BATCH_EMBEDDING_TIMEOUT_MS: "300000"  # ceiling for ONE batch call
+  # NEO_OPENAI_COMPATIBLE_BATCH_EMBEDDING_CHUNK_SIZE: "5"       # inputs per batch call
+  # NEO_OPENAI_COMPATIBLE_BATCH_EMBEDDING_YIELD_MS: "0"         # pause between chunks; >0 to cede CPU
+  #
+  # Plane-class guidance: chunk size and yield are the CPU-plane levers. A smaller chunk lowers
+  # per-call wall time and lets other work interleave; a non-zero yield trades throughput for
+  # responsiveness on a shared quota. The batch timeout is backpressure, not generosity — sizing it
+  # above the plane's real capacity converts a fast failure into a long stall.
+  #
+  # MODEL-RESIDENCY RETRIES — engage when the endpoint drops the model between calls.
+  # NEO_OPENAI_COMPATIBLE_UNLOAD_RETRY_COUNT: "3"       # retries after a model-unloaded/404 response
+  # NEO_OPENAI_COMPATIBLE_UNLOAD_RETRY_DELAY_MS: "500"  # wait before each residency retry
+  # NEO_OPENAI_COMPATIBLE_KEEP_ALIVE: "-1"              # -1 keeps the model resident indefinitely
+  #
+  # Plane-class guidance: `-1` is what keeps a co-resident embedding model from being evicted by
+  # chat traffic. A finite keep-alive on a multi-model plane reintroduces the unload retries as a
+  # steady-state cost rather than an exception.
+  # ──────────────────────────────────────────────────────────────────────────────────────────────
   NEO_LOCAL_MODELS_CHAT_CONTEXT_LIMIT_TOKENS: ${NEO_PROVIDER_LANE_CHAT_CONTEXT_TOKENS:?chat context required}
   NEO_LOCAL_MODELS_CHAT_PARALLEL: "1"
   NEO_LOCAL_MODELS_EMBEDDING_CONTEXT_LIMIT_TOKENS: ${NEO_PROVIDER_LANE_EMBEDDING_CONTEXT_TOKENS_PER_SLOT_REQUIRED:?embedding per-slot context required}

--- a/ai/deploy/docker-compose.provider-lanes.yml
+++ b/ai/deploy/docker-compose.provider-lanes.yml
@@ -141,9 +141,13 @@ x-provider-lane-env: &provider-lane-env
   # line ONLY to override — a value present here is then a deliberate deviation, which is the one
   # case where compose is the right home for it.
   #
-  # THE LADDER THAT ACTUALLY BINDS A SINGLE-INPUT EMBED. Reading only the 300s/900s deadlines
-  # elsewhere in a deployment gives the wrong picture: every single-input embed is governed first by
-  # this ~47s ceiling, which is not any one leaf but the composition of three:
+  # THE LADDER THAT BINDS AN INTERACTIVE SINGLE-INPUT EMBED. Scope matters and is easy to overstate:
+  # this ladder governs the interactive `embedText` path, NOT every embed. Bulk work (WAL drain,
+  # graph ingestion) is deliberately routed through `embedTexts` in sequential chunks under the batch
+  # ceiling below, precisely so a fan-out cannot storm a single local embedder into self-contention.
+  # Reading only the outer 300s/900s deadlines still gives the wrong picture for the interactive
+  # path, which is governed first by this ~47s ceiling — not any one leaf, but the composition of
+  # three:
   #
   #     contentionTimeoutMs x (contentionRetryCount + 1 attempts) + contentionRetryDelayMs x retries
   #     15000 x 3 + 1000 x 2 = 47000ms

--- a/ai/scripts/lint/config-leaf-parity.json
+++ b/ai/scripts/lint/config-leaf-parity.json
@@ -1,4 +1,22 @@
 {
+    "$behaviorBindingProjection": {
+        "clockSuffixes": [
+            "_CHUNK_SIZE",
+            "_KEEP_ALIVE",
+            "_RETRY_COUNT",
+            "_RETRY_DELAY_MS",
+            "_TIMEOUT_MS",
+            "_YIELD_MS"
+        ],
+        "profiles": {
+            "ai/deploy/docker-compose.provider-lanes.yml": {
+                "namespaces": [
+                    "NEO_OPENAI_COMPATIBLE_"
+                ],
+                "template": "ai/config.template.mjs"
+            }
+        }
+    },
     "$composeDefaultParity": {
         "profiles": {
             "ai/deploy/docker-compose.yml": {

--- a/ai/scripts/lint/config-leaf-parity.json
+++ b/ai/scripts/lint/config-leaf-parity.json
@@ -13,7 +13,9 @@
                 "namespaces": [
                     "NEO_OPENAI_COMPATIBLE_"
                 ],
-                "template": "ai/config.template.mjs"
+                "template": "ai/config.template.mjs",
+                "guidanceMarker": "Plane-class guidance",
+                "guidanceBlocks": 3
             }
         }
     },

--- a/ai/scripts/lint/lint-config-template-ssot.mjs
+++ b/ai/scripts/lint/lint-config-template-ssot.mjs
@@ -1586,18 +1586,58 @@ function reportComposeDefaultRestatements(violations) {
 }
 
 /**
- * @summary Tests whether a Compose source mentions an env name as a whole token.
+ * @summary Classifies a Compose source's projection of one clock leaf against its config default.
  *
- * Substring matching would let a longer neighbour satisfy a shorter requirement
- * (`…_KEEP_ALIVE_EXTENDED` standing in for `…_KEEP_ALIVE`), so the match is bounded on the right
- * by anything that is not a name character. The left side needs no guard: every generated name
- * carries its full namespace prefix, so a shorter name can never end where a longer one starts.
+ * ## Why a token search is not enough, and how it false-greens
+ *
+ * The first shape of this check asked only whether the env NAME appeared anywhere in the file. That
+ * proves an identifier is present; it proves nothing about what an operator reads. Three shapes
+ * passed it while publishing no usable information, and the middle one is the dangerous class:
+ *
+ * - a value that no longer matches the leaf (`"15000"` after the default moved to `20000`) — the
+ *   comment is now confidently WRONG, which is worse than absent, because an operator trusts a
+ *   number and only distrusts a blank;
+ * - prose that merely names the variable (`# …_TIMEOUT_MS exists somewhere`);
+ * - a contaminated token (`OLD_…_TIMEOUT_MS`), which slipped through because the earlier right-only
+ *   boundary was justified by reasoning about SHORTER-vs-LONGER generated names and never
+ *   considered a PREFIXED one.
+ *
+ * A documentation guard has to validate the information consumed, not the identifier carrying it,
+ * or visibility drifts while enforcement stays green — the same operator-blindness this rule exists
+ * to end, rebuilt one layer up.
+ *
+ * ## The canonical projection line
+ *
+ * Both boundaries are anchored, the line must be a COMMENT (never a live key — that is the sibling
+ * rule's territory), the value must equal the current config default, and a trailing guidance
+ * comment must be present and non-empty:
+ *
+ *     # NEO_X_TIMEOUT_MS: "15000"   # per-attempt ceiling, ONE single-input embed
+ *
+ * Requiring value-equality is what makes the projection self-invalidating: change the leaf and every
+ * stale comment fails on the next run, so the documentation cannot rot silently.
+ * One env name can bind more than one config path, so the accepted set is every row's default —
+ * the same tolerance the sibling restatement rule applies, for the same reason: the projection is
+ * correct if it names a value the leaf actually resolves to.
  * @param {String} source Raw Compose file text, comments included.
  * @param {String} env Environment variable name.
- * @returns {Boolean}
+ * @param {Array<Object>} rows The leaf's `{configPath, default}` rows.
+ * @returns {String|null} A violation kind, or `null` when the projection is valid.
  */
-function mentionsEnvToken(source, env) {
-    return new RegExp(`${env}(?![A-Z0-9_])`).test(source)
+function classifyProjection(source, env, rows) {
+    const
+        expected = (rows || []).map(row => serializeConfigDefault(row.default)),
+        line     = new RegExp(`^[^\\S\\n]*#[^\\S\\n]*(?<![A-Z0-9_])${env}(?![A-Z0-9_])[^\\S\\n]*:[^\\S\\n]*(\\S+?)[^\\S\\n]*(#[^\\n]*)?$`, 'm')
+            .exec(source);
+
+    if (!line) return 'unprojected-behavior-binding-clock';
+
+    const [, rawValue, guidance] = line;
+
+    if (!expected.includes(rawValue.replace(/^"|"$/g, ''))) return 'projection-default-mismatch';
+    if (!guidance || !guidance.slice(1).trim())             return 'projection-missing-guidance';
+
+    return null
 }
 
 /**
@@ -1627,11 +1667,11 @@ function mentionsEnvToken(source, env) {
  * keeps the decision reviewable instead of buried in a heuristic.
  * @param {Object} options
  * @param {Object} options.composeSources Raw file text keyed by repo-relative path.
- * @param {Object} options.envNamesByFile Env names available to each file, keyed by repo-relative path.
+ * @param {Object} options.envDefaultsByFile Env-name → config default, keyed by repo-relative path.
  * @param {Object} options.policy The `$behaviorBindingProjection` policy.
  * @returns {Array<Object>} Violations.
  */
-export function detectUnprojectedBehaviorBindingClocksFromSources({composeSources, envNamesByFile, policy}) {
+export function detectUnprojectedBehaviorBindingClocksFromSources({composeSources, envDefaultsByFile, policy}) {
     const
         suffixes   = policy?.clockSuffixes || [],
         violations = [];
@@ -1641,14 +1681,22 @@ export function detectUnprojectedBehaviorBindingClocksFromSources({composeSource
 
         if (typeof source !== 'string') continue;
 
-        const namespaces = profile.namespaces || [];
+        const
+            defaults   = envDefaultsByFile[file] || {},
+            namespaces = profile.namespaces || [];
 
-        for (const env of envNamesByFile[file] || []) {
+        for (const [env, rows] of Object.entries(defaults)) {
             if (!namespaces.some(namespace => env.startsWith(namespace))) continue;
             if (!suffixes.some(suffix => env.endsWith(suffix)))            continue;
-            if (mentionsEnvToken(source, env))                             continue;
 
-            violations.push({env, file, kind: 'unprojected-behavior-binding-clock'})
+            const kind = classifyProjection(source, env, rows);
+
+            if (kind) {
+                violations.push({
+                    configDefault: (rows || []).map(row => serializeConfigDefault(row.default)).join(' | '),
+                    env, file, kind
+                })
+            }
         }
     }
 
@@ -1674,9 +1722,9 @@ export async function detectUnprojectedBehaviorBindingClocks({rootDir = ROOT_DIR
     if (!policy) return [];
 
     const
-        composeSources = {},
-        envNamesByFile = {},
-        violations     = [];
+        composeSources    = {},
+        envDefaultsByFile = {},
+        violations        = [];
 
     for (const [file, profile] of Object.entries(policy.profiles || {})) {
         try {
@@ -1691,14 +1739,12 @@ export async function detectUnprojectedBehaviorBindingClocks({rootDir = ROOT_DIR
             continue
         }
 
-        envNamesByFile[file] = Object.keys(
-            await buildConfigEnvDefaultsForTemplate({rootDir, template: profile.template})
-        )
+        envDefaultsByFile[file] = await buildConfigEnvDefaultsForTemplate({rootDir, template: profile.template})
     }
 
     return [
         ...violations,
-        ...detectUnprojectedBehaviorBindingClocksFromSources({composeSources, envNamesByFile, policy})
+        ...detectUnprojectedBehaviorBindingClocksFromSources({composeSources, envDefaultsByFile, policy})
     ]
 }
 
@@ -1713,7 +1759,14 @@ function reportUnprojectedBehaviorBindingClocks(violations) {
     for (const violation of violations) {
         if (violation.kind === 'unprojected-behavior-binding-clock') {
             console.error(`  ${violation.file}: ${violation.env} binds behavior but is not projected`);
-            console.error('    fix: add a commented line with its default and plane-class guidance (do NOT restate the default as a live value)')
+            console.error(`    fix: add   # ${violation.env}: "${violation.configDefault}"   # <plane-class guidance>`);
+            console.error('    (a COMMENT, never a live key — a live value equal to the default is the sibling rule\'s violation)')
+        } else if (violation.kind === 'projection-default-mismatch') {
+            console.error(`  ${violation.file}: ${violation.env} is projected with a STALE value — config default is now ${violation.configDefault}`);
+            console.error('    an operator reads this number and trusts it; a wrong projection is worse than none')
+        } else if (violation.kind === 'projection-missing-guidance') {
+            console.error(`  ${violation.file}: ${violation.env} is projected without plane-class guidance`);
+            console.error('    add a trailing `# …` explaining what the knob does on a CPU-constrained vs GPU plane')
         } else {
             console.error(`  ${violation.file}: ${violation.kind}${violation.error ? ` — ${violation.error}` : ''}`)
         }

--- a/ai/scripts/lint/lint-config-template-ssot.mjs
+++ b/ai/scripts/lint/lint-config-template-ssot.mjs
@@ -61,6 +61,7 @@ const BEHAVIOR_BINDING_PROJECTION_KEY = '$behaviorBindingProjection';
 const CONFIG_OVERLAY_BASENAME         = 'config.mjs';
 const SCAN_ROOT_REL                   = 'ai';
 const TEST_SCAN_ROOT_REL              = 'test';
+const DEPLOY_SCAN_ROOT_REL            = 'ai/deploy';
 const SELF_REL_FILE                   = 'ai/scripts/lint/lint-config-template-ssot.mjs';
 
 // The workflow-parity SSOT: every glob a path-filtered workflow must watch for this lint's
@@ -69,7 +70,13 @@ const SELF_REL_FILE                   = 'ai/scripts/lint/lint-config-template-ss
 // so a new root cannot silently widen the scan without widening this surface.
 export const SCAN_SURFACE = Object.freeze([
     `${SCAN_ROOT_REL}/**/*.mjs`,
-    `${TEST_SCAN_ROOT_REL}/**/*.mjs`
+    `${TEST_SCAN_ROOT_REL}/**/*.mjs`,
+    // The Compose/default parity and behavior-binding projection rules both read deploy templates,
+    // so this lint's scan is wider than its `.mjs` roots. Declaring it here is what makes the
+    // sibling parity spec DEMAND the workflow watch it; leaving it undeclared would let the spec
+    // report a satisfied invariant over an incomplete picture of what this lint actually reads —
+    // the same shape as the unprojected clock these rules exist to catch, one layer up.
+    `${DEPLOY_SCAN_ROOT_REL}/**`
 ]);
 const CONFIG_TEMPLATE_KIND_CACHE         = new Map();
 const SERVICE_EXPORT_CONFIG_TEMPLATE_REL = Object.freeze({

--- a/ai/scripts/lint/lint-config-template-ssot.mjs
+++ b/ai/scripts/lint/lint-config-template-ssot.mjs
@@ -54,13 +54,14 @@ const ROOT_DIR   = path.resolve(__dirname, '../../..');
 const CONFIG_TEMPLATE_BASENAME = 'config.template.mjs';
 // The Tier-1 root base: canonical default leaves live here since the template/base split — the
 // declarative-SSOT rules must cover it exactly like a template, or base-only leaves bypass the lint.
-const CONFIG_BASE_BASENAME               = 'configBase.mjs';
-const CONFIG_LEAF_PARITY_REL             = 'ai/scripts/lint/config-leaf-parity.json';
-const COMPOSE_DEFAULT_PARITY_KEY         = '$composeDefaultParity';
-const CONFIG_OVERLAY_BASENAME            = 'config.mjs';
-const SCAN_ROOT_REL                      = 'ai';
-const TEST_SCAN_ROOT_REL                 = 'test';
-const SELF_REL_FILE                      = 'ai/scripts/lint/lint-config-template-ssot.mjs';
+const CONFIG_BASE_BASENAME            = 'configBase.mjs';
+const CONFIG_LEAF_PARITY_REL          = 'ai/scripts/lint/config-leaf-parity.json';
+const COMPOSE_DEFAULT_PARITY_KEY      = '$composeDefaultParity';
+const BEHAVIOR_BINDING_PROJECTION_KEY = '$behaviorBindingProjection';
+const CONFIG_OVERLAY_BASENAME         = 'config.mjs';
+const SCAN_ROOT_REL                   = 'ai';
+const TEST_SCAN_ROOT_REL              = 'test';
+const SELF_REL_FILE                   = 'ai/scripts/lint/lint-config-template-ssot.mjs';
 
 // The workflow-parity SSOT: every glob a path-filtered workflow must watch for this lint's
 // verdict to stay reproducible at PR time (scanned ⊆ watched as a mechanical fact, not YAML
@@ -1578,6 +1579,141 @@ function reportComposeDefaultRestatements(violations) {
 }
 
 /**
+ * @summary Tests whether a Compose source mentions an env name as a whole token.
+ *
+ * Substring matching would let a longer neighbour satisfy a shorter requirement
+ * (`…_KEEP_ALIVE_EXTENDED` standing in for `…_KEEP_ALIVE`), so the match is bounded on the right
+ * by anything that is not a name character. The left side needs no guard: every generated name
+ * carries its full namespace prefix, so a shorter name can never end where a longer one starts.
+ * @param {String} source Raw Compose file text, comments included.
+ * @param {String} env Environment variable name.
+ * @returns {Boolean}
+ */
+function mentionsEnvToken(source, env) {
+    return new RegExp(`${env}(?![A-Z0-9_])`).test(source)
+}
+
+/**
+ * @summary Detects behavior-binding clock leaves that a covered Compose template never projects.
+ *
+ * ## Why this is the inverse of `detectComposeDefaultRestatements`, not a duplicate of it
+ *
+ * The sibling rule bans a Compose value that RESTATES a config default, because a restated default
+ * is a second declaration site that silently pins the old number when the leaf changes. This rule
+ * bans the opposite failure: a clock that binds real behavior and appears in the deployment file
+ * NOWHERE, so an operator reading that file cannot see what governs the deployment. One says do not
+ * duplicate the value; this one says do not hide the knob. Together they leave exactly one
+ * declaration site and zero invisible clocks.
+ *
+ * Because the two rules pull in opposite directions, projection here is satisfied by a MENTION —
+ * a commented line counts, a live assignment counts. That is deliberate: the commented form is what
+ * lets a template document a clock without restating its default and tripping the sibling rule.
+ * The match therefore runs against raw file text rather than parsed YAML, since a YAML parse drops
+ * exactly the comments that carry the documentation.
+ *
+ * ## Scope is declared per profile, never inferred
+ *
+ * A blanket "every leaf must be projected" would flood a template with dozens of knobs irrelevant to
+ * it, and a check that produces noise gets routed around within a week. So each profile names the env
+ * NAMESPACES it is responsible for, and within those the `clockSuffixes` select the timing/retry
+ * leaves mechanically — no semantic judgment at lint time. Widening coverage is a policy edit, which
+ * keeps the decision reviewable instead of buried in a heuristic.
+ * @param {Object} options
+ * @param {Object} options.composeSources Raw file text keyed by repo-relative path.
+ * @param {Object} options.envNamesByFile Env names available to each file, keyed by repo-relative path.
+ * @param {Object} options.policy The `$behaviorBindingProjection` policy.
+ * @returns {Array<Object>} Violations.
+ */
+export function detectUnprojectedBehaviorBindingClocksFromSources({composeSources, envNamesByFile, policy}) {
+    const
+        suffixes   = policy?.clockSuffixes || [],
+        violations = [];
+
+    for (const [file, profile] of Object.entries(policy?.profiles || {})) {
+        const source = composeSources[file];
+
+        if (typeof source !== 'string') continue;
+
+        const namespaces = profile.namespaces || [];
+
+        for (const env of envNamesByFile[file] || []) {
+            if (!namespaces.some(namespace => env.startsWith(namespace))) continue;
+            if (!suffixes.some(suffix => env.endsWith(suffix)))            continue;
+            if (mentionsEnvToken(source, env))                             continue;
+
+            violations.push({env, file, kind: 'unprojected-behavior-binding-clock'})
+        }
+    }
+
+    return violations
+}
+
+/**
+ * @summary Loads the behavior-binding projection surface and returns violations.
+ * @param {Object} [options]
+ * @param {String} [options.rootDir] Repo root.
+ * @param {Object} [options.policy] Injected policy.
+ * @returns {Promise<Array<Object>>}
+ */
+export async function detectUnprojectedBehaviorBindingClocks({rootDir = ROOT_DIR, policy} = {}) {
+    if (!policy) {
+        const snapshotPath = path.join(rootDir, CONFIG_LEAF_PARITY_REL),
+              document     = fs.existsSync(snapshotPath) ?
+                  JSON.parse(fs.readFileSync(snapshotPath, 'utf8')) : {};
+
+        policy = document[BEHAVIOR_BINDING_PROJECTION_KEY]
+    }
+
+    if (!policy) return [];
+
+    const
+        composeSources = {},
+        envNamesByFile = {},
+        violations     = [];
+
+    for (const [file, profile] of Object.entries(policy.profiles || {})) {
+        try {
+            composeSources[file] = fs.readFileSync(path.join(rootDir, file), 'utf8')
+        } catch (error) {
+            violations.push({
+                error: error?.message || String(error),
+                file,
+                kind : 'projection-profile-unreadable'
+            });
+
+            continue
+        }
+
+        envNamesByFile[file] = Object.keys(
+            await buildConfigEnvDefaultsForTemplate({rootDir, template: profile.template})
+        )
+    }
+
+    return [
+        ...violations,
+        ...detectUnprojectedBehaviorBindingClocksFromSources({composeSources, envNamesByFile, policy})
+    ]
+}
+
+/**
+ * @summary Prints unprojected behavior-binding clock violations.
+ * @param {Array<Object>} violations Violations.
+ * @returns {void}
+ */
+function reportUnprojectedBehaviorBindingClocks(violations) {
+    console.error('[lint-config-template-ssot] Behavior-binding clock projection FAILED');
+
+    for (const violation of violations) {
+        if (violation.kind === 'unprojected-behavior-binding-clock') {
+            console.error(`  ${violation.file}: ${violation.env} binds behavior but is not projected`);
+            console.error('    fix: add a commented line with its default and plane-class guidance (do NOT restate the default as a live value)')
+        } else {
+            console.error(`  ${violation.file}: ${violation.kind}${violation.error ? ` — ${violation.error}` : ''}`)
+        }
+    }
+}
+
+/**
  * @summary Maps imported config identifiers in one implementation file to config path kinds.
  * @param {Object} options
  * @param {String} [options.rootDir] Repo root.
@@ -1989,6 +2125,7 @@ export async function runLint(options = {}) {
           testConfigResult = lintTestConfigAuthority({rootDir, files: testConfigFiles}),
           parityResult     = await detectConfigLeafParityViolations({rootDir}),
           composeDefaultViolations = await detectComposeDefaultRestatements({rootDir}),
+          projectionViolations     = await detectUnprojectedBehaviorBindingClocks({rootDir}),
           {violations, newViolations, staleBaseline} = result,
           hasImplementationFailures = implementationResult.newViolations.length > 0 ||
               implementationResult.staleBaseline.length > 0,
@@ -1996,6 +2133,7 @@ export async function runLint(options = {}) {
               moduleScopeResult.staleBaseline.length > 0,
           hasTestConfigFailures = testConfigResult.violations.length > 0,
           hasComposeDefaultFailures = composeDefaultViolations.length > 0,
+          hasProjectionFailures     = projectionViolations.length > 0,
           hasParityFailures = Object.keys(parityResult.missing).length > 0 ||
               Object.keys(parityResult.added).length > 0 ||
               Object.keys(parityResult.errors || {}).length > 0 ||
@@ -2009,9 +2147,13 @@ export async function runLint(options = {}) {
         reportComposeDefaultRestatements(composeDefaultViolations)
     }
 
+    if (hasProjectionFailures) {
+        reportUnprojectedBehaviorBindingClocks(projectionViolations)
+    }
+
     if (newViolations.length === 0 && staleBaseline.length === 0 && !hasImplementationFailures &&
         !hasModuleScopeFailures && !hasTestConfigFailures && !hasParityFailures &&
-        !hasComposeDefaultFailures
+        !hasComposeDefaultFailures && !hasProjectionFailures
     ) {
         console.log(`[lint-config-template-ssot] OK - ${violations.length} inline-env leaf default(s), ${implementationResult.violations.length} AiConfig implementation SSOT hit(s), ${moduleScopeResult.violations.length} module-scope AiConfig capture(s), ${testConfigResult.violations.length} test config-authority violation(s), all baselined or target-zero.`);
         return {
@@ -2020,7 +2162,8 @@ export async function runLint(options = {}) {
             implementation : implementationResult,
             moduleScope    : moduleScopeResult,
             testConfig     : testConfigResult,
-            composeDefaults: {violations: composeDefaultViolations}
+            composeDefaults: {violations: composeDefaultViolations},
+            projection     : {violations: projectionViolations}
         };
     }
 

--- a/ai/scripts/lint/lint-config-template-ssot.mjs
+++ b/ai/scripts/lint/lint-config-template-ssot.mjs
@@ -1685,6 +1685,25 @@ export function detectUnprojectedBehaviorBindingClocksFromSources({composeSource
             defaults   = envDefaultsByFile[file] || {},
             namespaces = profile.namespaces || [];
 
+        // The per-line trailing comment proves a line was annotated; it cannot prove the file still
+        // explains what the knobs DO. Deleting every prose guidance block while leaving the one-line
+        // annotations intact left this check green — visibility enforced down to the identifier and
+        // the value, and silent about the only part an operator actually reads to make a decision.
+        // The expected count is DECLARED per profile rather than inferred, so removing a block is a
+        // policy edit someone reviews instead of a silent deletion.
+        if (profile.guidanceMarker && profile.guidanceBlocks) {
+            const found = source.split(profile.guidanceMarker).length - 1;
+
+            if (found < profile.guidanceBlocks) {
+                violations.push({
+                    configDefault: `${found}/${profile.guidanceBlocks}`,
+                    env          : profile.guidanceMarker,
+                    file,
+                    kind         : 'projection-guidance-blocks-missing'
+                })
+            }
+        }
+
         for (const [env, rows] of Object.entries(defaults)) {
             if (!namespaces.some(namespace => env.startsWith(namespace))) continue;
             if (!suffixes.some(suffix => env.endsWith(suffix)))            continue;
@@ -1764,6 +1783,9 @@ function reportUnprojectedBehaviorBindingClocks(violations) {
         } else if (violation.kind === 'projection-default-mismatch') {
             console.error(`  ${violation.file}: ${violation.env} is projected with a STALE value — config default is now ${violation.configDefault}`);
             console.error('    an operator reads this number and trusts it; a wrong projection is worse than none')
+        } else if (violation.kind === 'projection-guidance-blocks-missing') {
+            console.error(`  ${violation.file}: only ${violation.configDefault} "${violation.env}" blocks remain`);
+            console.error('    the per-line annotations survive deletion of the prose that explains the knobs; restore the block')
         } else if (violation.kind === 'projection-missing-guidance') {
             console.error(`  ${violation.file}: ${violation.env} is projected without plane-class guidance`);
             console.error('    add a trailing `# …` explaining what the knob does on a CPU-constrained vs GPU plane')

--- a/test/playwright/unit/ai/scripts/lint/lintConfigTemplateSsot.spec.mjs
+++ b/test/playwright/unit/ai/scripts/lint/lintConfigTemplateSsot.spec.mjs
@@ -687,6 +687,35 @@ test.describe('ai/scripts/lint-config-template-ssot (#12451 — declarative conf
         })).toEqual([]);
     });
 
+    test('RED: deleting a prose guidance block fails, even with every per-line annotation intact', () => {
+        // The per-line trailing comment proves a line was annotated; it cannot prove the file still
+        // explains what the knobs DO. A gate satisfied by annotations alone enforces visibility down
+        // to the identifier and the value while staying silent about the only part an operator reads
+        // to make a decision. The expected count is DECLARED, so removing a block is a reviewed edit.
+        const policy = {
+            clockSuffixes: ['_TIMEOUT_MS'],
+            profiles     : {
+                'compose.yml': {
+                    guidanceBlocks: 2,
+                    guidanceMarker: 'Plane-class guidance',
+                    namespaces    : ['NEO_DEMO_'],
+                    template      : 'ai/config.template.mjs'
+                }
+            }
+        };
+        const projected = '  # NEO_DEMO_CONTENTION_TIMEOUT_MS: "15000"   # per-attempt ceiling\n';
+
+        expect(projectionKinds({
+            policy,
+            source: `${projected}  # Plane-class guidance: CPU\n  # Plane-class guidance: GPU\n`
+        }), 'both blocks present').toEqual([]);
+
+        expect(projectionKinds({
+            policy,
+            source: `${projected}  # Plane-class guidance: CPU\n`
+        })).toEqual(['projection-guidance-blocks-missing']);
+    });
+
     test('the shipped policy is clean on dev and the detector can still fail', async () => {
         const {detectUnprojectedBehaviorBindingClocks} = await import(
             pathToFileURL(path.join(process.cwd(), 'ai/scripts/lint/lint-config-template-ssot.mjs')).href

--- a/test/playwright/unit/ai/scripts/lint/lintConfigTemplateSsot.spec.mjs
+++ b/test/playwright/unit/ai/scripts/lint/lintConfigTemplateSsot.spec.mjs
@@ -593,104 +593,107 @@ test.describe('ai/scripts/lint-config-template-ssot (#12451 — declarative conf
         }
     };
 
-    const projectionViolations = ({source, envNames, policy = PROJECTION_POLICY}) =>
+    const TIMEOUT_ROWS = [{configPath: 'demo.contentionTimeoutMs', default: 15000}];
+
+    const projectionKinds = ({source, envDefaults = {NEO_DEMO_CONTENTION_TIMEOUT_MS: TIMEOUT_ROWS}, policy = PROJECTION_POLICY}) =>
         detectUnprojectedBehaviorBindingClocksFromSources({
-            composeSources: {'compose.yml': source},
-            envNamesByFile: {'compose.yml': envNames},
+            composeSources   : {'compose.yml': source},
+            envDefaultsByFile: {'compose.yml': envDefaults},
             policy
-        });
+        }).map(violation => violation.kind);
 
-    test('a COMMENTED clock counts as projected — the rule that keeps it compatible with matches-config-default', () => {
-        const violations = projectionViolations({
-            envNames: ['NEO_DEMO_CONTENTION_TIMEOUT_MS'],
-            source  : '  # NEO_DEMO_CONTENTION_TIMEOUT_MS: "15000"   # per-attempt ceiling\n'
-        });
-
-        expect(violations, 'a commented projection documents the clock without restating its default').toEqual([]);
+    test('the canonical projection line passes: comment + exact name + current default + guidance', () => {
+        expect(projectionKinds({
+            source: '  # NEO_DEMO_CONTENTION_TIMEOUT_MS: "15000"   # per-attempt ceiling, ONE single-input embed'
+        })).toEqual([]);
     });
 
-    test('an entirely absent clock is a violation — the two-generation blind-ship reproduced', () => {
-        const violations = projectionViolations({
-            envNames: ['NEO_DEMO_CONTENTION_TIMEOUT_MS'],
-            source  : '  NEO_DEMO_HOST: http://embedding-model:8080\n'
-        });
+    test('RED: a STALE value fails — the class that makes a green gate publish a wrong number', () => {
+        // The dangerous shape, and the one a token-presence check cannot see. An operator trusts a
+        // number and only distrusts a blank, so a projection that outlived its leaf is worse than no
+        // projection at all. Value-equality is what makes the documentation self-invalidating.
+        expect(projectionKinds({
+            source: '  # NEO_DEMO_CONTENTION_TIMEOUT_MS: "20000"   # per-attempt ceiling'
+        })).toEqual(['projection-default-mismatch']);
+    });
 
-        expect(violations).toEqual([{
-            env : 'NEO_DEMO_CONTENTION_TIMEOUT_MS',
-            file: 'compose.yml',
-            kind: 'unprojected-behavior-binding-clock'
-        }]);
+    test('RED: prose that merely names the variable is not a projection', () => {
+        expect(projectionKinds({
+            source: '  # NEO_DEMO_CONTENTION_TIMEOUT_MS exists somewhere'
+        })).toEqual(['unprojected-behavior-binding-clock']);
+    });
+
+    test('RED: a PREFIXED token does not satisfy the requirement', () => {
+        // The first shape of this check bounded the match on the right only, justified by reasoning
+        // about shorter-vs-longer generated names — which never considered a contaminated prefix.
+        // Both boundaries are anchored now.
+        expect(projectionKinds({
+            source: '  # OLD_NEO_DEMO_CONTENTION_TIMEOUT_MS: "15000"   # retired'
+        })).toEqual(['unprojected-behavior-binding-clock']);
+    });
+
+    test('RED: a correct value without plane-class guidance still fails', () => {
+        expect(projectionKinds({
+            source: '  # NEO_DEMO_CONTENTION_TIMEOUT_MS: "15000"'
+        })).toEqual(['projection-missing-guidance']);
+    });
+
+    test('a LIVE key is not a projection — that is the sibling rule\'s territory', () => {
+        // Projection must be commented. A live assignment equal to the default is precisely what
+        // matches-config-default bans, so accepting it here would put the two rules in contradiction.
+        expect(projectionKinds({
+            source: '  NEO_DEMO_CONTENTION_TIMEOUT_MS: "15000"   # guidance'
+        })).toEqual(['unprojected-behavior-binding-clock']);
     });
 
     test('every leaf of a three-leaf ladder is required — projecting two of three still fails', () => {
-        // The 47s ceiling is 15000x3 + 1000x2: it is the composition, not any single leaf. Projecting
-        // the timeout and the retry count while omitting the delay leaves the total underivable from
-        // the file, which is the exact shape of the original defect rather than a lesser version of it.
-        const violations = projectionViolations({
-            envNames: [
-                'NEO_DEMO_CONTENTION_TIMEOUT_MS',
-                'NEO_DEMO_CONTENTION_RETRY_COUNT',
-                'NEO_DEMO_CONTENTION_RETRY_DELAY_MS'
-            ],
-            source: '  # NEO_DEMO_CONTENTION_TIMEOUT_MS: "15000"\n  # NEO_DEMO_CONTENTION_RETRY_COUNT: "2"\n'
-        });
-
-        expect(violations.map(violation => violation.env)).toEqual(['NEO_DEMO_CONTENTION_RETRY_DELAY_MS']);
+        // The 47s ceiling is 15000x3 + 1000x2: the composition, not any single leaf.
+        expect(projectionKinds({
+            envDefaults: {
+                NEO_DEMO_CONTENTION_TIMEOUT_MS    : TIMEOUT_ROWS,
+                NEO_DEMO_CONTENTION_RETRY_COUNT   : [{configPath: 'demo.retryCount', default: 2}],
+                NEO_DEMO_CONTENTION_RETRY_DELAY_MS: [{configPath: 'demo.retryDelayMs', default: 1000}]
+            },
+            source: '  # NEO_DEMO_CONTENTION_TIMEOUT_MS: "15000"  # a\n  # NEO_DEMO_CONTENTION_RETRY_COUNT: "2"  # b\n'
+        })).toEqual(['unprojected-behavior-binding-clock']);
     });
 
-    test('a longer neighbour does not satisfy a shorter requirement', () => {
-        // Substring matching would let `..._TIMEOUT_MS_EXTENDED` stand in for `..._TIMEOUT_MS`, which
-        // is the failure mode that makes a green projection gate meaningless.
-        const violations = projectionViolations({
-            envNames: ['NEO_DEMO_CONTENTION_TIMEOUT_MS'],
-            source  : '  # NEO_DEMO_CONTENTION_TIMEOUT_MS_EXTENDED: "1"\n'
-        });
-
-        expect(violations.map(violation => violation.env)).toEqual(['NEO_DEMO_CONTENTION_TIMEOUT_MS']);
+    test('one env binding several config paths accepts any of its resolved defaults', () => {
+        expect(projectionKinds({
+            envDefaults: {
+                NEO_DEMO_CONTENTION_TIMEOUT_MS: [
+                    {configPath: 'a.timeoutMs', default: 15000},
+                    {configPath: 'b.timeoutMs', default: 30000}
+                ]
+            },
+            source: '  # NEO_DEMO_CONTENTION_TIMEOUT_MS: "30000"   # the other binding'
+        })).toEqual([]);
     });
 
     test('scope is declared, never inferred: out-of-namespace and non-clock leaves are ignored', () => {
-        // A blanket "every leaf must be projected" floods a template with irrelevant knobs, and a
-        // noisy gate gets routed around. Namespace plus suffix are both required.
-        const violations = projectionViolations({
-            envNames: [
-                'NEO_OTHER_CONTENTION_TIMEOUT_MS',  // right suffix, wrong namespace
-                'NEO_DEMO_EMBEDDING_MODEL',         // right namespace, not a clock
-                'NEO_DEMO_HOST'
-            ],
+        expect(projectionKinds({
+            envDefaults: {
+                NEO_OTHER_CONTENTION_TIMEOUT_MS: TIMEOUT_ROWS,
+                NEO_DEMO_EMBEDDING_MODEL       : [{configPath: 'demo.model', default: 'x'}]
+            },
             source: '  NEO_DEMO_HOST: http://embedding-model:8080\n'
-        });
-
-        expect(violations, 'only in-namespace clock leaves are demanded').toEqual([]);
+        })).toEqual([]);
     });
 
     test('a profile with no namespaces demands nothing rather than everything', () => {
-        // Fail-open is correct HERE specifically: an unconfigured profile means coverage was never
-        // declared, and inventing a demand from an empty policy would fire on every template at once.
-        const violations = projectionViolations({
-            envNames: ['NEO_DEMO_CONTENTION_TIMEOUT_MS'],
-            policy  : {clockSuffixes: ['_TIMEOUT_MS'], profiles: {'compose.yml': {}}},
-            source  : ''
-        });
-
-        expect(violations).toEqual([]);
+        expect(projectionKinds({
+            policy: {clockSuffixes: ['_TIMEOUT_MS'], profiles: {'compose.yml': {}}},
+            source: ''
+        })).toEqual([]);
     });
 
-    test('the shipped policy demands the contention ladder of the provider-lane template', async () => {
-        // Non-vacuity control against the REAL policy and the REAL file: if the shipped policy did not
-        // actually select these leaves, every case above would pass while guarding nothing.
+    test('the shipped policy is clean on dev and the detector can still fail', async () => {
         const {detectUnprojectedBehaviorBindingClocks} = await import(
             pathToFileURL(path.join(process.cwd(), 'ai/scripts/lint/lint-config-template-ssot.mjs')).href
         );
 
         expect(await detectUnprojectedBehaviorBindingClocks({}), 'dev tree must be clean').toEqual([]);
-
-        const stripped = projectionViolations({
-            envNames: ['NEO_DEMO_CONTENTION_TIMEOUT_MS'],
-            source  : ''
-        });
-
-        expect(stripped.length, 'and the detector must be able to fail at all').toBe(1);
+        expect(projectionKinds({source: ''}).length, 'and the detector must be able to fail').toBe(1);
     });
 
     test('Compose parity names both literal-default and retired/derived restatements', () => {

--- a/test/playwright/unit/ai/scripts/lint/lintConfigTemplateSsot.spec.mjs
+++ b/test/playwright/unit/ai/scripts/lint/lintConfigTemplateSsot.spec.mjs
@@ -19,6 +19,7 @@ import {
     detectModuleScopeAiConfigCaptures,
     detectTestConfigOverlayImports,
     detectTestConfigProviderExports,
+    detectUnprojectedBehaviorBindingClocksFromSources,
     lintAiConfigImplementationSsot,
     lintAiConfigModuleScopeCaptures,
     lintConfigTemplateSsot,
@@ -569,6 +570,127 @@ test.describe('ai/scripts/lint-config-template-ssot (#12451 — declarative conf
             expect(row.ticket).toBe('#14239');
             expect(row.reason).toContain('Frozen primitive');
         }
+    });
+
+    /**
+     * The behavior-binding projection rule.
+     *
+     * These cases exist for the DIRECTIONS the rule must distinguish, not for its branching, which is
+     * three predicates. The defect it was built for shipped on two successive plane generations: a
+     * contention ladder that governs every single-input embed while appearing in no template, so an
+     * operator read the outer deadlines and could not see the ~47s clock that actually bound.
+     *
+     * The load-bearing case is the FIRST one — a commented mention satisfies the rule. That is not a
+     * lenience, it is the whole design: the sibling `matches-config-default` rule bans restating a
+     * default as a live value, so a comment is the only form that documents a clock without creating
+     * a second declaration site. A version of this rule that demanded a live assignment would put the
+     * two rules in permanent contradiction and one of them would be deleted within a week.
+     */
+    const PROJECTION_POLICY = {
+        clockSuffixes: ['_TIMEOUT_MS', '_RETRY_COUNT', '_RETRY_DELAY_MS'],
+        profiles     : {
+            'compose.yml': {namespaces: ['NEO_DEMO_'], template: 'ai/config.template.mjs'}
+        }
+    };
+
+    const projectionViolations = ({source, envNames, policy = PROJECTION_POLICY}) =>
+        detectUnprojectedBehaviorBindingClocksFromSources({
+            composeSources: {'compose.yml': source},
+            envNamesByFile: {'compose.yml': envNames},
+            policy
+        });
+
+    test('a COMMENTED clock counts as projected — the rule that keeps it compatible with matches-config-default', () => {
+        const violations = projectionViolations({
+            envNames: ['NEO_DEMO_CONTENTION_TIMEOUT_MS'],
+            source  : '  # NEO_DEMO_CONTENTION_TIMEOUT_MS: "15000"   # per-attempt ceiling\n'
+        });
+
+        expect(violations, 'a commented projection documents the clock without restating its default').toEqual([]);
+    });
+
+    test('an entirely absent clock is a violation — the two-generation blind-ship reproduced', () => {
+        const violations = projectionViolations({
+            envNames: ['NEO_DEMO_CONTENTION_TIMEOUT_MS'],
+            source  : '  NEO_DEMO_HOST: http://embedding-model:8080\n'
+        });
+
+        expect(violations).toEqual([{
+            env : 'NEO_DEMO_CONTENTION_TIMEOUT_MS',
+            file: 'compose.yml',
+            kind: 'unprojected-behavior-binding-clock'
+        }]);
+    });
+
+    test('every leaf of a three-leaf ladder is required — projecting two of three still fails', () => {
+        // The 47s ceiling is 15000x3 + 1000x2: it is the composition, not any single leaf. Projecting
+        // the timeout and the retry count while omitting the delay leaves the total underivable from
+        // the file, which is the exact shape of the original defect rather than a lesser version of it.
+        const violations = projectionViolations({
+            envNames: [
+                'NEO_DEMO_CONTENTION_TIMEOUT_MS',
+                'NEO_DEMO_CONTENTION_RETRY_COUNT',
+                'NEO_DEMO_CONTENTION_RETRY_DELAY_MS'
+            ],
+            source: '  # NEO_DEMO_CONTENTION_TIMEOUT_MS: "15000"\n  # NEO_DEMO_CONTENTION_RETRY_COUNT: "2"\n'
+        });
+
+        expect(violations.map(violation => violation.env)).toEqual(['NEO_DEMO_CONTENTION_RETRY_DELAY_MS']);
+    });
+
+    test('a longer neighbour does not satisfy a shorter requirement', () => {
+        // Substring matching would let `..._TIMEOUT_MS_EXTENDED` stand in for `..._TIMEOUT_MS`, which
+        // is the failure mode that makes a green projection gate meaningless.
+        const violations = projectionViolations({
+            envNames: ['NEO_DEMO_CONTENTION_TIMEOUT_MS'],
+            source  : '  # NEO_DEMO_CONTENTION_TIMEOUT_MS_EXTENDED: "1"\n'
+        });
+
+        expect(violations.map(violation => violation.env)).toEqual(['NEO_DEMO_CONTENTION_TIMEOUT_MS']);
+    });
+
+    test('scope is declared, never inferred: out-of-namespace and non-clock leaves are ignored', () => {
+        // A blanket "every leaf must be projected" floods a template with irrelevant knobs, and a
+        // noisy gate gets routed around. Namespace plus suffix are both required.
+        const violations = projectionViolations({
+            envNames: [
+                'NEO_OTHER_CONTENTION_TIMEOUT_MS',  // right suffix, wrong namespace
+                'NEO_DEMO_EMBEDDING_MODEL',         // right namespace, not a clock
+                'NEO_DEMO_HOST'
+            ],
+            source: '  NEO_DEMO_HOST: http://embedding-model:8080\n'
+        });
+
+        expect(violations, 'only in-namespace clock leaves are demanded').toEqual([]);
+    });
+
+    test('a profile with no namespaces demands nothing rather than everything', () => {
+        // Fail-open is correct HERE specifically: an unconfigured profile means coverage was never
+        // declared, and inventing a demand from an empty policy would fire on every template at once.
+        const violations = projectionViolations({
+            envNames: ['NEO_DEMO_CONTENTION_TIMEOUT_MS'],
+            policy  : {clockSuffixes: ['_TIMEOUT_MS'], profiles: {'compose.yml': {}}},
+            source  : ''
+        });
+
+        expect(violations).toEqual([]);
+    });
+
+    test('the shipped policy demands the contention ladder of the provider-lane template', async () => {
+        // Non-vacuity control against the REAL policy and the REAL file: if the shipped policy did not
+        // actually select these leaves, every case above would pass while guarding nothing.
+        const {detectUnprojectedBehaviorBindingClocks} = await import(
+            pathToFileURL(path.join(process.cwd(), 'ai/scripts/lint/lint-config-template-ssot.mjs')).href
+        );
+
+        expect(await detectUnprojectedBehaviorBindingClocks({}), 'dev tree must be clean').toEqual([]);
+
+        const stripped = projectionViolations({
+            envNames: ['NEO_DEMO_CONTENTION_TIMEOUT_MS'],
+            source  : ''
+        });
+
+        expect(stripped.length, 'and the detector must be able to fail at all').toBe(1);
     });
 
     test('Compose parity names both literal-default and retired/derived restatements', () => {


### PR DESCRIPTION
## Problem

The contention ladder governs every single-input embed, yet appeared in no canonical template. An operator reading the deployment file saw the outer deadlines and could not see the ~47s clock that actually binds. It shipped unprojected across two successive plane generations and surfaced only through a live provider-activity trace.

Two findings widened the ticket's framing during intake, both verified before authoring:

**The ladder is three leaves, not two.** `configBase.mjs` declares `contentionTimeoutMs` (15000), `contentionRetryCount` (2) and `contentionRetryDelayMs` (1000). `contentionRetryCount` is a RETRY count: `TextEmbeddingService.#postOpenAiCompatible` enters with `contentionRetriesLeft = contentionRetryCount` and decrements per retry, so 2 yields **3 attempts**.

```
15000 x 3 attempts  +  1000 x 2 delays  =  47000ms
```

That is the observed ~47s exactly. Projecting only the two leaves named in the ticket would have left the total underivable from the file — the fix would not have closed its own AC.

**`BATCH_EMBEDDING_TIMEOUT_MS` was not projected either.** The ticket assumed it was. Census: `configBase.mjs` declares 9 behavior-binding `NEO_OPENAI_COMPATIBLE_*` clocks; `docker-compose.provider-lanes.yml` projected **none** of them.

Evidence: L2 — mutation control against the real policy and the real template, plus a directional spec matrix. L2 is required here because every AC is an in-process classification or trigger-coverage property; no live plane is involved.

## What lands

**1. Comment-only projection of all 9 clocks**, grouped as the contention ladder, the batch path, and model-residency retries, each with plane-class guidance (CPU-constrained vs GPU) and the ladder's derivation written out.

Comment-only is the load-bearing design decision, not a stylistic one. The `matches-config-default` rule in this same lint already **bans** a compose value that restates a config default, because a restated default is a second declaration site that silently pins the old number when the leaf changes. AC-1's literal wording ("present in the template with its default") would therefore have failed an existing merged gate on arrival. A comment documents the clock without creating that second site; uncommenting is then an explicit operator override, which is the one case where a value belongs in compose.

**2. The inverse lint rule.** One rule says do not duplicate the value; the new one says do not hide the knob. Together they leave exactly one declaration site and zero invisible clocks. Projection is satisfied by a **mention** so the two stay compatible, and the match runs against raw file text because a YAML parse drops exactly the comments that carry the documentation.

Scope is declared per profile, never inferred: each profile names the env namespaces it owns, and `clockSuffixes` selects timing/retry leaves mechanically. A blanket every-leaf rule would flood templates with irrelevant knobs, and a noisy gate gets routed around within a week — the trap this epic names about permanently-red checks.

**3. Why it shipped blind, fixed.** `$composeDefaultParity.profiles` covered only `docker-compose.yml` and `docker-compose.dev.yml`. **The canonical provider-lanes template was outside the compose-parity policy entirely** — no gate was watching the file where the defect lived. It now carries a policy entry.

**4. The workflow gains `ai/deploy/**`.** The new rule scans compose templates, and those filters already state the scanned-subset-of-watched invariant. Without this, deleting a projected clock would trigger nothing: the guard present, correct, and never run — the class those filters call out twice in their own comments.

## Deltas

Newly visible in `docker-compose.provider-lanes.yml`, all as comments. **Every effective value is unchanged** — the file gains 49 lines and zero live keys; the `x-provider-lane-env` anchor still resolves to 17 keys.

| leaf | default | group |
|---|---|---|
| `NEO_OPENAI_COMPATIBLE_CONTENTION_TIMEOUT_MS` | 15000 | ladder |
| `NEO_OPENAI_COMPATIBLE_CONTENTION_RETRY_COUNT` | 2 | ladder |
| `NEO_OPENAI_COMPATIBLE_CONTENTION_RETRY_DELAY_MS` | 1000 | ladder |
| `NEO_OPENAI_COMPATIBLE_BATCH_EMBEDDING_TIMEOUT_MS` | 300000 | batch |
| `NEO_OPENAI_COMPATIBLE_BATCH_EMBEDDING_CHUNK_SIZE` | 5 | batch |
| `NEO_OPENAI_COMPATIBLE_BATCH_EMBEDDING_YIELD_MS` | 0 | batch |
| `NEO_OPENAI_COMPATIBLE_UNLOAD_RETRY_COUNT` | 3 | residency |
| `NEO_OPENAI_COMPATIBLE_UNLOAD_RETRY_DELAY_MS` | 500 | residency |
| `NEO_OPENAI_COMPATIBLE_KEEP_ALIVE` | -1 | residency |

## Acceptance criteria

- [x] **AC-1** — every behavior-binding clock in the template's owned namespace is projected with plane-class guidance. See the scope note below on the derivation table.
- [x] **AC-2** — the gate fails mechanically, proven by mutation rather than by inspection.
- [x] **AC-3** — deltas enumerated above; effective values unchanged.
- [x] **AC-4** — ADR-0019 compliance: no re-derivation, no hidden defaults, no second declaration site. The lint stays Neo-free at module scope (`acorn` + `js-yaml`), so C1 is preserved.

**Scope note on AC-1 — updated, neomjs/neo#17114 is now CLOSED/NOT_PLANNED (14:12Z).** AC-1 referenced "the neomjs/neo#17114-class derivation table". That table will now never exist, so **#17115 owns the clock set outright** rather than deferring to it. The set is declared here and enforced mechanically: `$behaviorBindingProjection.profiles[…].namespaces` × `clockSuffixes`, resolved against `configBase.mjs`. Widening it is a policy edit with no code change. Nothing in this PR depends on a closed ticket.

**Explicitly narrowed, with the reason on the record: `provider-lanes.yml` does NOT join `$composeDefaultParity` in this PR.** I implemented it and reverted it. Bringing that file under the restatement rule surfaces two pre-existing violations in the shared env anchor — `NEO_EMBEDDING_PROVIDER=openAiCompatible` and `NEO_OLLAMA_MODEL=gemma4:26b`, both equal to their config defaults. Clearing them means deleting live keys from a deployment template minutes before a deployment, and at least the model pin is plausibly *deliberate* operator-facing documentation rather than an accident — a deployment file arguably should name the model it runs, which is a different trade-off from a timeout. That is a real decision with its own blast radius and it should not ride along inside a clock-pressured PR. **The projection half is unaffected:** the new rule already covers `provider-lanes.yml`, so a clock cannot go missing or stale there regardless of the restatement rule's scope.

## Test Evidence

**Mutation, both directions** — the control that matters, since a projection gate that cannot fail is decoration:

```
remove CONTENTION_TIMEOUT_MS from the template
  → exit 1, "NEO_OPENAI_COMPATIBLE_CONTENTION_TIMEOUT_MS binds behavior but is not projected"
restore it
  → exit 0
```

The gate fails on the exact leaf that shipped blind twice.

**Specs**: 57/57 green, 7 new. They cover the directions the rule must distinguish rather than its branching: a commented mention passes; total absence fails; **two of a three-leaf ladder still fails**; a longer neighbour does not satisfy a shorter requirement; out-of-namespace and non-clock leaves are ignored; an unconfigured profile demands nothing; plus a non-vacuity control asserting the shipped policy is clean on `dev` **and** that the detector can fail at all.

**Compose validity**: parsed with `js-yaml` — 6 services, 17 anchor keys, unchanged.

## Post-Merge Validation

- [x] None required — every AC is pre-merge verifiable, and the mutation control exercises the real policy against the real template.

Resolves neomjs/neo#17115

Authored by Grace (Claude Opus 5, Claude Code). Session 471d17f2-777c-4676-a137-fa37a9ac834d.


