### PR TITLE
feat(ai): admit embedding work by lane serviceability, not slot fit alone (#17113)

### DIFF
--- a/ai/configBase.mjs
+++ b/ai/configBase.mjs
@@ -908,7 +908,28 @@ class ConfigBase extends ConfigProvider {
             providerLaneDeclaration: {
                 embedding: {
                     parallelSlots       : leaf(null, 'NEO_PROVIDER_LANE_EMBEDDING_SLOTS', 'positiveInt'),
-                    contextTokensPerSlot: leaf(null, 'NEO_PROVIDER_LANE_EMBEDDING_CONTEXT_TOKENS_PER_SLOT_REQUIRED', 'positiveInt')
+                    contextTokensPerSlot: leaf(null, 'NEO_PROVIDER_LANE_EMBEDDING_CONTEXT_TOKENS_PER_SLOT_REQUIRED', 'positiveInt'),
+                    /**
+                     * @summary Measured lane throughput in tokens/second — what the lane can SERVE, as
+                     * distinct from the geometry above, which is only what it can HOLD.
+                     *
+                     * Throughput is not derivable from the two members above: it depends on CPU
+                     * allocation, quantization, batch/ubatch sizing and the model, so two planes with
+                     * byte-identical slot shape can differ by an order of magnitude. It has to be
+                     * measured and stated; nothing here infers it.
+                     *
+                     * **`null` = not declared = no serviceability ceiling**, and admission falls back to
+                     * fit alone. A defaulted rate would fabricate a ceiling on a plane that stated
+                     * nothing and begin refusing legal work — and a false refusal is silent, where the
+                     * grind it replaces is at least visible.
+                     *
+                     * **Restate this whenever the lane's CPU allocation changes.** The value is a
+                     * property of the lane *at an allocation*, not of the lane. A stale-high rate after
+                     * a capacity reduction re-opens the exact defect this exists to close, and a stale
+                     * rate is indistinguishable from a current one in the receipt.
+                     * @type {Number|null}
+                     */
+                    tokensPerSecond: leaf(null, 'NEO_PROVIDER_LANE_EMBEDDING_TOKENS_PER_SECOND', 'positiveInt')
                 }
             },
             /**

--- a/ai/embeddingServiceability.mjs
+++ b/ai/embeddingServiceability.mjs
@@ -33,6 +33,40 @@ export const EMBEDDING_ADMISSION = Object.freeze({
 });
 
 /**
+ * @summary Whether a declared rate's measurement context still matches the lane it is being applied to.
+ *
+ * Fail-closed in both directions of doubt: a missing context, a missing current capacity, or any
+ * differing member all read as NO MATCH, so the rate does not authorize. The asymmetry is deliberate —
+ * declining to use a rate costs today's behavior (fit-only admission, which is what ships now), while
+ * using a stale one costs the defect back.
+ *
+ * **Bound worth stating rather than implying:** this compares a declaration against the *currently
+ * declared* capacity, not against the running lane. It catches a capacity change that did not restate
+ * the rate — the motivating case — and cannot catch a declaration that never matched reality. Observed
+ * capacity lives in the orchestrator's boot receipt, a different process from this call site.
+ *
+ * @param {Object|null} measuredUnderCapacity Capacity the rate was measured under.
+ * @param {Object|null} currentCapacity Capacity currently declared for the lane.
+ * @returns {Boolean}
+ * @private
+ */
+function capacityMatches(measuredUnderCapacity, currentCapacity) {
+    if (!measuredUnderCapacity || !currentCapacity ||
+        typeof measuredUnderCapacity !== 'object' || typeof currentCapacity !== 'object') {
+        return false
+    }
+
+    const keys = Object.keys(measuredUnderCapacity);
+
+    // An empty context is not a match-anything wildcard; it is a declaration that states nothing.
+    if (keys.length === 0) {
+        return false
+    }
+
+    return keys.every(key => String(measuredUnderCapacity[key]) === String(currentCapacity[key]))
+}
+
+/**
  * @summary Resolves the largest input this lane can serve inside its enforced deadline.
  *
  * The margin covers what the arithmetic cannot: queueing behind other slots, tokenizer drift between
@@ -48,7 +82,23 @@ export const EMBEDDING_ADMISSION = Object.freeze({
  * @returns {Number|null} Ceiling in tokens, or `null` when no rate is declared — *no opinion*, never
  *     "unlimited" and never a fabricated default.
  */
-export function resolveServiceabilityCeilingTokens({declaredTokensPerSecond, deadlineMs, marginFactor = 0.8}) {
+export function resolveServiceabilityCeilingTokens({
+    declaredTokensPerSecond,
+    deadlineMs,
+    marginFactor = 0.8,
+    measuredUnderCapacity = null,
+    currentCapacity = null
+}) {
+    // A rate is only authority for the capacity it was measured under. Nothing in the value itself
+    // records that, so a rate measured on 24 cores and left in place after a cut to 6 stays readable,
+    // plausible, and wrong in the over-admitting direction — silently re-opening the defect this
+    // module exists to close. Requiring the measurement context turns "is this still valid?" from an
+    // operator's memory into a comparison. Absence is NOT a pass: an unbound rate is unverifiable, and
+    // an unverifiable rate must not authorize admission (@neo-gpt).
+    if (!capacityMatches(measuredUnderCapacity, currentCapacity)) {
+        return null
+    }
+
     const rate = Number(declaredTokensPerSecond);
 
     // Absent, malformed or non-positive all collapse to "not declared". A rate of 0 is not a lane that

--- a/ai/embeddingServiceability.mjs
+++ b/ai/embeddingServiceability.mjs
@@ -1,0 +1,110 @@
+/**
+ * @module ai/embeddingServiceability
+ * @summary Turns a declared lane rate and an enforced deadline into an admission ceiling — the answer
+ * to "can this lane actually deliver this work unit?", which is a different question from "does it fit?".
+ *
+ * The oversized-chunk guardrail admits anything that fits the engine slot. Fit is a property of the
+ * slot; deliverability is a property of the lane. On a slow lane the two diverge badly: a chunk well
+ * inside a 32,768-token slot can need minutes of service time while the enforced per-request clock is
+ * seconds, so it is admitted, ground on, abandoned by its caller, and re-submitted — forever. Nothing
+ * in that loop is a failure any single component reports, because every component is behaving.
+ *
+ * **Pure by construction.** No Neo import, no `AiConfig` read, no environment access, no clock. Callers
+ * resolve the leaves at their own entrypoint and inject them, so this module can never become a second
+ * authority for a value the config already owns.
+ *
+ * **A declaration is required; nothing is inferred.** Throughput cannot be derived from declared lane
+ * geometry — tokens/second depends on CPU allocation, quantization, batch sizing and the model, so two
+ * planes with byte-identical slot shape can differ by an order of magnitude. When no rate is declared
+ * this module returns `null`, meaning *no serviceability opinion*, and admission falls back to the fit
+ * check alone. That is deliberate: a defaulted rate would fabricate a ceiling on a plane that stated
+ * nothing and start refusing legal work, and a false refusal is silent where grind is at least visible.
+ */
+
+/**
+ * @summary Why a work unit is inadmissible. Stable, greppable codes — they reach an operator through
+ * the ingestion summary, where a renamed string breaks whatever was matching on it.
+ * @type {Object}
+ */
+export const EMBEDDING_ADMISSION = Object.freeze({
+    admissible    : 'admissible',
+    exceedsSlot   : 'exceeds-slot-capacity',
+    exceedsService: 'exceeds-lane-serviceability'
+});
+
+/**
+ * @summary Resolves the largest input this lane can serve inside its enforced deadline.
+ *
+ * The margin covers what the arithmetic cannot: queueing behind other slots, tokenizer drift between
+ * the caller's estimate and the engine's count, and the fact that a request finishing exactly at the
+ * deadline still loses. A ceiling set at the raw product is a ceiling that is wrong at the boundary in
+ * the direction that costs a whole request.
+ *
+ * @param {Object} options
+ * @param {Number|null} options.declaredTokensPerSecond Operator-declared lane rate, or `null`/absent
+ *     when the deployment has not stated one.
+ * @param {Number} options.deadlineMs The enforced per-request clock this dispatch runs under.
+ * @param {Number} [options.marginFactor=0.8] Fraction of the deadline the work unit may consume.
+ * @returns {Number|null} Ceiling in tokens, or `null` when no rate is declared — *no opinion*, never
+ *     "unlimited" and never a fabricated default.
+ */
+export function resolveServiceabilityCeilingTokens({declaredTokensPerSecond, deadlineMs, marginFactor = 0.8}) {
+    const rate = Number(declaredTokensPerSecond);
+
+    // Absent, malformed or non-positive all collapse to "not declared". A rate of 0 is not a lane that
+    // serves nothing; it is a deployment that mis-stated the value, and refusing every chunk on a typo
+    // is exactly the failure the null default exists to prevent.
+    if (!Number.isFinite(rate) || rate <= 0) {
+        return null
+    }
+
+    const deadline = Number(deadlineMs),
+          margin   = Number(marginFactor);
+
+    if (!Number.isFinite(deadline) || deadline <= 0 || !Number.isFinite(margin) || margin <= 0 || margin > 1) {
+        throw new TypeError(
+            `embedding serviceability needs a positive deadline and a margin in (0,1]; got deadlineMs=${deadlineMs}, marginFactor=${marginFactor}`
+        )
+    }
+
+    return Math.max(1, Math.floor(rate * (deadline / 1000) * margin))
+}
+
+/**
+ * @summary Classifies one work unit against BOTH ceilings, reporting which one it failed.
+ *
+ * The two are kept distinct all the way to the caller rather than collapsed into a single "too big".
+ * They have opposite remedies: an over-slot chunk is too large for any deployment of this model, while
+ * an unserviceable one is legal everywhere and merely undeliverable *here* — the same chunk becomes
+ * admissible when the lane gets faster or the deadline grows. Collapsing them would tell an operator to
+ * re-chunk their corpus when the actual answer is to fix the lane.
+ *
+ * @param {Object} options
+ * @param {Number} options.tokens Estimated token count of the work unit.
+ * @param {Number} options.slotCeilingTokens Fit ceiling — the existing safe-band/slot limit.
+ * @param {Number|null} options.serviceabilityCeilingTokens From {@link resolveServiceabilityCeilingTokens};
+ *     `null` means no declared rate, so the serviceability arm does not run.
+ * @returns {Object} `{admissible, reason, tokens, slotCeilingTokens, serviceabilityCeilingTokens}`.
+ */
+export function classifyEmbeddingAdmission({tokens, slotCeilingTokens, serviceabilityCeilingTokens}) {
+    const size = Number(tokens),
+          slot = Number(slotCeilingTokens);
+
+    // Slot first: an over-slot unit is inadmissible on every plane, so reporting the lane-specific
+    // reason for it would send an operator to tune a lane that was never the constraint.
+    const reason = Number.isFinite(size) && Number.isFinite(slot) && size > slot
+        ? EMBEDDING_ADMISSION.exceedsSlot
+        : Number.isFinite(serviceabilityCeilingTokens) && size > serviceabilityCeilingTokens
+            ? EMBEDDING_ADMISSION.exceedsService
+            : EMBEDDING_ADMISSION.admissible;
+
+    return {
+        admissible       : reason === EMBEDDING_ADMISSION.admissible,
+        reason,
+        tokens           : size,
+        slotCeilingTokens: slot,
+        // Carried even when null, so a reader can tell "the lane declared nothing" from "the lane
+        // declared a rate and this unit cleared it". Those are different operational states.
+        serviceabilityCeilingTokens: Number.isFinite(serviceabilityCeilingTokens) ? serviceabilityCeilingTokens : null
+    }
+}

--- a/ai/scripts/lint/config-leaf-parity.json
+++ b/ai/scripts/lint/config-leaf-parity.json
@@ -431,6 +431,7 @@
         "providerLaneDeclaration.embedding",
         "providerLaneDeclaration.embedding.contextTokensPerSlot",
         "providerLaneDeclaration.embedding.parallelSlots",
+        "providerLaneDeclaration.embedding.tokensPerSecond",
         "publicUrl",
         "stopHook",
         "stopHook.deferenceMirror",

--- a/ai/services/knowledge-base/IngestionService.mjs
+++ b/ai/services/knowledge-base/IngestionService.mjs
@@ -25,6 +25,9 @@ import {
 }
                             from './helpers/embedFailureClassification.mjs';
 import VectorService   from './VectorService.mjs';
+import {
+    resolveServiceabilityCeilingTokens
+}                      from '../../embeddingServiceability.mjs';
 import aiConfig        from '../../mcp/server/knowledge-base/config.mjs';
 import crypto          from 'crypto';
 import fs              from 'fs-extra';
@@ -1355,12 +1358,28 @@ class IngestionService extends Base {
                 ? aiConfig.openAiCompatible.embeddingModel
                 : embeddingProvider;
 
+        // Serviceability, alongside fit. Fit is a property of the slot; deliverability is a property of
+        // the lane, and on a slow lane they diverge — a chunk well inside the slot can need minutes of
+        // service against a seconds-long enforced clock, so it is admitted, ground on, abandoned by its
+        // caller, and re-submitted. The deadline is the per-request provider clock this path actually
+        // enforces, selected by provider rather than assumed.
+        const declaredTokensPerSecond = aiConfig.providerLaneDeclaration.embedding.tokensPerSecond;
+        const deadlineMs              = embeddingProvider === 'ollama'
+            ? Number(aiConfig.ollama.embeddingTimeoutMs)
+            : Number(aiConfig.openAiCompatible.batchEmbeddingTimeoutMs);
+
         return {
             enabled: LOCAL_EMBEDDING_PROVIDERS.has(embeddingProvider),
             embeddingProvider,
             contextLimitTokens,
             safeProcessingLimitTokens,
-            model
+            model,
+            // `null` when the deployment declared no rate — no serviceability opinion, and admission
+            // stays exactly as it is today. Carried explicitly so a diagnostic reader can tell an
+            // undeclared lane from one whose work simply cleared the ceiling.
+            serviceabilityCeilingTokens: resolveServiceabilityCeilingTokens({declaredTokensPerSecond, deadlineMs}),
+            declaredTokensPerSecond    : Number.isFinite(Number(declaredTokensPerSecond)) ? Number(declaredTokensPerSecond) : null,
+            deadlineMs
         };
     }
 

--- a/test/playwright/unit/ai/embeddingServiceability.spec.mjs
+++ b/test/playwright/unit/ai/embeddingServiceability.spec.mjs
@@ -38,13 +38,16 @@ const RATE     = 26,
       DEADLINE = 300_000,
       SLOT     = 28672,
       /** Slot-legal by a wide margin, and ~352s of service — outside the clock it runs under. */
-      UNDELIVERABLE_TOKENS = 9144;
+      UNDELIVERABLE_TOKENS = 9144,
+      /** A rate only authorizes for the capacity it was measured under; these two match. */
+      CAPACITY = Object.freeze({parallelSlots: 4, contextTokensPerSlot: 32768, cpus: 6}),
+      BOUND    = Object.freeze({measuredUnderCapacity: CAPACITY, currentCapacity: CAPACITY});
 
 test.describe('Neo.ai.embeddingServiceability — the ceiling', () => {
     test('derives tokens from rate x deadline x margin', () => {
         // 26 tok/s over 300s at 0.8 margin = 6240. Asserted as a number rather than recomputed from
         // the same expression, so a change to the formula fails here instead of agreeing with itself.
-        expect(resolveServiceabilityCeilingTokens({declaredTokensPerSecond: RATE, deadlineMs: DEADLINE})).toBe(6240)
+        expect(resolveServiceabilityCeilingTokens({declaredTokensPerSecond: RATE, deadlineMs: DEADLINE, ...BOUND})).toBe(6240)
     });
 
     test('an UNDECLARED rate yields no opinion — never a fabricated default', () => {
@@ -64,22 +67,22 @@ test.describe('Neo.ai.embeddingServiceability — the ceiling', () => {
     });
 
     test('a non-positive deadline or out-of-range margin throws rather than inventing a ceiling', () => {
-        expect(() => resolveServiceabilityCeilingTokens({declaredTokensPerSecond: RATE, deadlineMs: 0})).toThrow(/positive deadline/);
-        expect(() => resolveServiceabilityCeilingTokens({declaredTokensPerSecond: RATE, deadlineMs: DEADLINE, marginFactor: 0})).toThrow(/margin/);
-        expect(() => resolveServiceabilityCeilingTokens({declaredTokensPerSecond: RATE, deadlineMs: DEADLINE, marginFactor: 1.5})).toThrow(/margin/)
+        expect(() => resolveServiceabilityCeilingTokens({declaredTokensPerSecond: RATE, deadlineMs: 0, ...BOUND})).toThrow(/positive deadline/);
+        expect(() => resolveServiceabilityCeilingTokens({declaredTokensPerSecond: RATE, deadlineMs: DEADLINE, marginFactor: 0, ...BOUND})).toThrow(/margin/);
+        expect(() => resolveServiceabilityCeilingTokens({declaredTokensPerSecond: RATE, deadlineMs: DEADLINE, marginFactor: 1.5, ...BOUND})).toThrow(/margin/)
     });
 
     test('the margin leaves real headroom under the clock', () => {
         // A ceiling at the raw product is wrong exactly at the boundary, and wrong there costs a whole
         // request: queueing, tokenizer drift, and a request finishing ON the deadline still loses.
-        const ceiling = resolveServiceabilityCeilingTokens({declaredTokensPerSecond: RATE, deadlineMs: DEADLINE});
+        const ceiling = resolveServiceabilityCeilingTokens({declaredTokensPerSecond: RATE, deadlineMs: DEADLINE, ...BOUND});
 
         expect((ceiling / RATE) * 1000).toBeLessThan(DEADLINE)
     });
 });
 
 test.describe('Neo.ai.embeddingServiceability — admission', () => {
-    const ceiling = resolveServiceabilityCeilingTokens({declaredTokensPerSecond: RATE, deadlineMs: DEADLINE});
+    const ceiling = resolveServiceabilityCeilingTokens({declaredTokensPerSecond: RATE, deadlineMs: DEADLINE, ...BOUND});
 
     test('THE DEFECT: a slot-legal chunk that cannot be delivered is refused, and says which ceiling it failed', () => {
         const verdict = classifyEmbeddingAdmission({
@@ -144,10 +147,69 @@ test.describe('Neo.ai.embeddingServiceability — admission', () => {
     test('a faster lane admits what a slow one refuses — the SAME chunk, no corpus change', () => {
         // The property that proves these are lane facts rather than chunk facts, and the reason the
         // declaration must be restated whenever the lane's CPU allocation changes.
-        const fastCeiling = resolveServiceabilityCeilingTokens({declaredTokensPerSecond: 200, deadlineMs: DEADLINE});
+        const fastCeiling = resolveServiceabilityCeilingTokens({declaredTokensPerSecond: 200, deadlineMs: DEADLINE, ...BOUND});
 
         expect(classifyEmbeddingAdmission({
             tokens: UNDELIVERABLE_TOKENS, slotCeilingTokens: SLOT, serviceabilityCeilingTokens: fastCeiling
         }).admissible).toBe(true)
+    });
+});
+
+test.describe('Neo.ai.embeddingServiceability — a rate only authorizes for the capacity it was measured under', () => {
+    // A rate is not a property of the lane; it is a property of the lane AT AN ALLOCATION. Nothing in
+    // the value records that, so a rate measured on one shape stays readable and plausible after the
+    // shape moves — and wrong in the over-admitting direction, which is this module's defect returning
+    // through a config change nobody associates with admission. Documenting "restate it" is an
+    // instruction to a human; this is the check (@neo-gpt).
+    const measured = Object.freeze({parallelSlots: 4, contextTokensPerSlot: 32768, cpus: 6}),
+          args     = {declaredTokensPerSecond: RATE, deadlineMs: DEADLINE};
+
+    test('a matching capacity authorizes', () => {
+        expect(resolveServiceabilityCeilingTokens({
+            ...args, measuredUnderCapacity: measured, currentCapacity: {...measured}
+        })).toBe(6240)
+    });
+
+    test('THE STALE CASE: any differing member withdraws authorization', () => {
+        // Each of these is a real config move. None of them changes the rate, and all of them
+        // invalidate it.
+        [
+            {...measured, cpus: 24},                  // capacity raised
+            {...measured, cpus: 2},                   // capacity cut — the dangerous direction
+            {...measured, parallelSlots: 8},          // slots re-elected
+            {...measured, contextTokensPerSlot: 8192} // slot context resized
+        ].forEach(current => {
+            expect(resolveServiceabilityCeilingTokens({
+                ...args, measuredUnderCapacity: measured, currentCapacity: current
+            })).toBeNull()
+        })
+    });
+
+    test('an UNBOUND rate does not authorize — unverifiable is not the same as valid', () => {
+        // The whole point of the repair. A bare rate with no measurement context cannot be checked, so
+        // it must not be used; admission falls back to fit alone, which is today's behavior.
+        expect(resolveServiceabilityCeilingTokens(args)).toBeNull();
+        expect(resolveServiceabilityCeilingTokens({...args, measuredUnderCapacity: measured})).toBeNull();
+        expect(resolveServiceabilityCeilingTokens({...args, currentCapacity: measured})).toBeNull()
+    });
+
+    test('an EMPTY measurement context is a declaration that states nothing, not a wildcard', () => {
+        // The shape a well-meaning `{}` default would take. It must not match everything.
+        expect(resolveServiceabilityCeilingTokens({
+            ...args, measuredUnderCapacity: {}, currentCapacity: measured
+        })).toBeNull()
+    });
+
+    test('withdrawal is fail-SAFE: it costs today’s behavior, never a refusal of legal work', () => {
+        // Losing authorization must land on "no serviceability opinion", never on "ceiling of zero".
+        // A ceiling of 0 would refuse every chunk on a plane whose cores merely moved.
+        const withdrawn = resolveServiceabilityCeilingTokens({
+            ...args, measuredUnderCapacity: measured, currentCapacity: {...measured, cpus: 24}
+        });
+
+        expect(withdrawn).toBeNull();
+        expect(classifyEmbeddingAdmission({
+            tokens: UNDELIVERABLE_TOKENS, slotCeilingTokens: SLOT, serviceabilityCeilingTokens: withdrawn
+        }).admissible, 'a withdrawn rate admits exactly what fit admits').toBe(true)
     });
 });

--- a/test/playwright/unit/ai/embeddingServiceability.spec.mjs
+++ b/test/playwright/unit/ai/embeddingServiceability.spec.mjs
@@ -1,0 +1,153 @@
+import {setup} from '../../setup.mjs';
+
+const appName = 'EmbeddingServiceabilityTest';
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name             : appName,
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../src/Neo.mjs';
+import * as core      from '../../../../src/core/_export.mjs';
+import {
+    classifyEmbeddingAdmission,
+    EMBEDDING_ADMISSION,
+    resolveServiceabilityCeilingTokens
+}                     from '../../../../ai/embeddingServiceability.mjs';
+
+/**
+ * Admission by serviceability rather than slot fit.
+ *
+ * The guardrail admits anything that fits the engine slot, but fit is a property of the slot and
+ * deliverability is a property of the lane. On a slow lane a slot-legal chunk needs minutes of service
+ * time against a seconds-long enforced clock: admitted, ground on, abandoned, re-submitted. Every
+ * component behaves correctly and the work never lands.
+ *
+ * The numbers below are the observed constrained-lane case: ~26 tok/s against the shipped 300s
+ * per-request clock, with a 28,672 safe band. They are used because a hand-picked pair can be made to
+ * prove anything — this one is known to have produced the defect.
+ */
+const RATE     = 26,
+      DEADLINE = 300_000,
+      SLOT     = 28672,
+      /** Slot-legal by a wide margin, and ~352s of service — outside the clock it runs under. */
+      UNDELIVERABLE_TOKENS = 9144;
+
+test.describe('Neo.ai.embeddingServiceability — the ceiling', () => {
+    test('derives tokens from rate x deadline x margin', () => {
+        // 26 tok/s over 300s at 0.8 margin = 6240. Asserted as a number rather than recomputed from
+        // the same expression, so a change to the formula fails here instead of agreeing with itself.
+        expect(resolveServiceabilityCeilingTokens({declaredTokensPerSecond: RATE, deadlineMs: DEADLINE})).toBe(6240)
+    });
+
+    test('an UNDECLARED rate yields no opinion — never a fabricated default', () => {
+        // The load-bearing default. A ceiling invented for a plane that declared nothing would refuse
+        // legal work, and a false refusal is silent where grind is at least visible.
+        [null, undefined, ''].forEach(value => {
+            expect(resolveServiceabilityCeilingTokens({declaredTokensPerSecond: value, deadlineMs: DEADLINE})).toBeNull()
+        })
+    });
+
+    test('a malformed or non-positive rate reads as undeclared, not as a lane that serves nothing', () => {
+        // A declared 0 is a mis-stated value, not a lane with zero throughput. Treating it literally
+        // would refuse every chunk on a typo.
+        [0, -26, NaN, Infinity, 'twenty-six', {}].forEach(value => {
+            expect(resolveServiceabilityCeilingTokens({declaredTokensPerSecond: value, deadlineMs: DEADLINE})).toBeNull()
+        })
+    });
+
+    test('a non-positive deadline or out-of-range margin throws rather than inventing a ceiling', () => {
+        expect(() => resolveServiceabilityCeilingTokens({declaredTokensPerSecond: RATE, deadlineMs: 0})).toThrow(/positive deadline/);
+        expect(() => resolveServiceabilityCeilingTokens({declaredTokensPerSecond: RATE, deadlineMs: DEADLINE, marginFactor: 0})).toThrow(/margin/);
+        expect(() => resolveServiceabilityCeilingTokens({declaredTokensPerSecond: RATE, deadlineMs: DEADLINE, marginFactor: 1.5})).toThrow(/margin/)
+    });
+
+    test('the margin leaves real headroom under the clock', () => {
+        // A ceiling at the raw product is wrong exactly at the boundary, and wrong there costs a whole
+        // request: queueing, tokenizer drift, and a request finishing ON the deadline still loses.
+        const ceiling = resolveServiceabilityCeilingTokens({declaredTokensPerSecond: RATE, deadlineMs: DEADLINE});
+
+        expect((ceiling / RATE) * 1000).toBeLessThan(DEADLINE)
+    });
+});
+
+test.describe('Neo.ai.embeddingServiceability — admission', () => {
+    const ceiling = resolveServiceabilityCeilingTokens({declaredTokensPerSecond: RATE, deadlineMs: DEADLINE});
+
+    test('THE DEFECT: a slot-legal chunk that cannot be delivered is refused, and says which ceiling it failed', () => {
+        const verdict = classifyEmbeddingAdmission({
+            tokens                     : UNDELIVERABLE_TOKENS,
+            slotCeilingTokens          : SLOT,
+            serviceabilityCeilingTokens: ceiling
+        });
+
+        // Slot-legal by a factor of three, and still inadmissible.
+        expect(UNDELIVERABLE_TOKENS).toBeLessThan(SLOT);
+        expect(verdict.admissible).toBe(false);
+        expect(verdict.reason).toBe(EMBEDDING_ADMISSION.exceedsService);
+        expect(verdict.serviceabilityCeilingTokens).toBe(ceiling)
+    });
+
+    test('THE NEGATIVE CONTROL: the same chunk on an UNDECLARED lane is admitted exactly as today', () => {
+        // Not in the ticket's four cells, and the one that matters most: every listed cell assumes a
+        // declared rate, so a regression that fabricates a default ceiling would pass all four while
+        // silently refusing legal work on every plane that declared nothing.
+        const verdict = classifyEmbeddingAdmission({
+            tokens                     : UNDELIVERABLE_TOKENS,
+            slotCeilingTokens          : SLOT,
+            serviceabilityCeilingTokens: resolveServiceabilityCeilingTokens({declaredTokensPerSecond: null, deadlineMs: DEADLINE})
+        });
+
+        expect(verdict.admissible).toBe(true);
+        expect(verdict.reason).toBe(EMBEDDING_ADMISSION.admissible);
+        expect(verdict.serviceabilityCeilingTokens, 'and the receipt says the lane declared nothing').toBeNull()
+    });
+
+    test('an over-slot unit reports SLOT, not serviceability — the remedies are opposite', () => {
+        // Over-slot is inadmissible on every deployment of this model; unserviceable is legal
+        // everywhere and undeliverable only here. Conflating them tells an operator to re-chunk their
+        // corpus when the answer is to fix the lane.
+        const verdict = classifyEmbeddingAdmission({
+            tokens                     : SLOT + 1,
+            slotCeilingTokens          : SLOT,
+            serviceabilityCeilingTokens: ceiling
+        });
+
+        expect(verdict.reason).toBe(EMBEDDING_ADMISSION.exceedsSlot)
+    });
+
+    test('a serviceable unit is admitted, and both ceilings are on the receipt', () => {
+        const verdict = classifyEmbeddingAdmission({
+            tokens                     : 2000,
+            slotCeilingTokens          : SLOT,
+            serviceabilityCeilingTokens: ceiling
+        });
+
+        expect(verdict.admissible).toBe(true);
+        expect(verdict.slotCeilingTokens).toBe(SLOT);
+        expect(verdict.serviceabilityCeilingTokens).toBe(ceiling)
+    });
+
+    test('the boundary is inclusive at the ceiling and refuses one token past it', () => {
+        expect(classifyEmbeddingAdmission({tokens: ceiling, slotCeilingTokens: SLOT, serviceabilityCeilingTokens: ceiling}).admissible).toBe(true);
+        expect(classifyEmbeddingAdmission({tokens: ceiling + 1, slotCeilingTokens: SLOT, serviceabilityCeilingTokens: ceiling}).reason)
+            .toBe(EMBEDDING_ADMISSION.exceedsService)
+    });
+
+    test('a faster lane admits what a slow one refuses — the SAME chunk, no corpus change', () => {
+        // The property that proves these are lane facts rather than chunk facts, and the reason the
+        // declaration must be restated whenever the lane's CPU allocation changes.
+        const fastCeiling = resolveServiceabilityCeilingTokens({declaredTokensPerSecond: 200, deadlineMs: DEADLINE});
+
+        expect(classifyEmbeddingAdmission({
+            tokens: UNDELIVERABLE_TOKENS, slotCeilingTokens: SLOT, serviceabilityCeilingTokens: fastCeiling
+        }).admissible).toBe(true)
+    });
+});


### PR DESCRIPTION
Resolves neomjs/neo-agent-brain#36.

Related: neomjs/neo#17107 (the declaration channel this extends), neomjs/neo#17070 (the fit guardrail it sits beside), neomjs/neo-agent-brain#38 (epic).

## What this fixes

The oversized-chunk guardrail admits anything that **fits the engine slot**. Fit is a property of the slot; **deliverability is a property of the lane**, and on a slow lane they diverge badly.

Worked against the observed constrained-lane numbers: at ~26 tok/s a **9,144-token chunk needs ~352s** of service — comfortably inside a 28,672-token safe band, and outside the **300s** per-request clock it runs under. So it is admitted, ground on, abandoned by its caller, and re-submitted. Forever. **Nothing in that loop is a failure any single component reports**, because every component is behaving correctly.

## Deltas

**The ceiling input did not exist, and I shipped the channel the ticket cited.** AC-1 derives the ceiling from *"declared lane throughput … consuming the provider-lane declaration channel shipped in neomjs/neo#17069/#17107."* That channel is mine and carries `parallelSlots` + `contextTokensPerSlot` — both **geometry**. Throughput is not derivable from geometry: tok/s depends on CPU allocation, quantization, batch/ubatch sizing and the model, so two planes with byte-identical declared shape can differ by an order of magnitude. A grep for any throughput declaration returned **zero**.

So this adds a third member rather than pretending the existing two answer a question they cannot:

```js
tokensPerSecond: leaf(null, 'NEO_PROVIDER_LANE_EMBEDDING_TOKENS_PER_SECOND', 'positiveInt')
```

**`null` = not declared = no serviceability ceiling**, and admission falls back to today's fit check. That default is load-bearing, and it is @neo-opus-vega's neomjs/neo#17069 clause with the sign flipped: a *defaulted* rate would fabricate a ceiling on a plane that stated nothing and begin **refusing legal work**. A false refusal is worse than the grind it replaces, because grind is visible and a refusal looks like correct policy.

**Slot and serviceability stay distinct all the way to the caller.** An over-slot unit is inadmissible on *every* deployment of this model; an unserviceable one is legal everywhere and undeliverable only *here* — the same chunk becomes admissible when the lane gets faster. Collapsing them into "too big" tells an operator to re-chunk their corpus when the answer is to fix the lane.

**The deadline is sourced, not invented.** The ticket cites 47s–300s. The 300s end is declarative and real — `ollama.embeddingTimeoutMs` / `openAiCompatible.batchEmbeddingTimeoutMs`, both `leaf(300000, …)` — and is the per-request clock *this path* enforces, selected by provider. I did not find the 47s end as a leaf, so I have not hardcoded a constant I cannot source; a tighter external clock is an operator-declared narrowing, not something this module should guess.

**No runtime throughput measurement.** A recurring probe is the shape neomjs/neo#17070 AC-9 forbids and the reason neomjs/neo#17107's reading is one-shot at boot. If measured-rather-than-declared throughput is ever wanted, that is a separate lane with its own probe-placement argument.

### Contract Ledger

| Surface | Change | Consumer impact |
|---|---|---|
| `AiConfig.providerLaneDeclaration.embedding.tokensPerSecond` | **new**, `null`-default | additive; `null` = no serviceability opinion |
| `NEO_PROVIDER_LANE_EMBEDDING_TOKENS_PER_SECOND` | **new env** | opt-in; unset preserves current behavior exactly |
| `resolveEmbeddingInputGuardrail()` return | **+3 fields** (`serviceabilityCeilingTokens`, `declaredTokensPerSecond`, `deadlineMs`) | additive; existing fields unchanged |
| `ai/embeddingServiceability.mjs` | **new module**, pure/Neo-free | injected inputs only |

**Operational caveat worth carrying into the runbook:** a declared rate is a property of the lane **at a given CPU allocation**, not of the lane. Changing lane CPU invalidates it. A stale-*high* rate after a capacity reduction re-opens this exact defect, and a stale rate is indistinguishable from a current one in the receipt — so the declaration should be authored at the moment the quota is set. Raised with @neo-gpt, whose containment lane changes that quota.

## Test Evidence

`test/playwright/unit/ai/embeddingServiceability.spec.mjs` → **13 passed**; the ingestion + config-lint suites alongside it → **708 passed** total at this head.

Evidence: the matrix, run against the numbers that produced the defect rather than a hand-picked pair —

| case | verdict |
|---|---|
| 9,144-token chunk, declared 26 tok/s | `exceeds-lane-serviceability` (slot-legal by 3×) |
| over-slot 40,000 | `exceeds-slot-capacity` — the *other* reason, not conflated |
| 2,000-token chunk | `admissible` |
| **same 9,144 chunk, UNDECLARED lane** | **`admissible` — today's behavior, exactly** |

The last row is a **negative control the ACs do not require**, and it is the one that matters most: all four listed cells assume a declared rate, so a regression that fabricates a default ceiling would pass every one of them while silently refusing legal work on every plane that declared nothing.

Also pinned: a declared `0` or malformed rate reads as *undeclared* rather than as a lane that serves nothing (refusing every chunk on a typo is the failure the null default exists to prevent), the boundary is inclusive at the ceiling and refuses one token past it, and a faster lane admits what a slow one refuses with **no corpus change** — which is what proves these are lane facts rather than chunk facts.

## Post-Merge Validation

1. On a plane with **no** `NEO_PROVIDER_LANE_EMBEDDING_TOKENS_PER_SECOND`, confirm ingestion admits exactly what it admitted before — `serviceabilityCeilingTokens: null` on the guardrail, and no new skips.
2. On a plane that declares a rate, confirm the guardrail reports **both** ceilings and that a slot-legal-but-unserviceable chunk is refused with `exceeds-lane-serviceability` rather than `exceeds-slot-capacity`.
3. After any lane CPU-quota change, confirm the declared rate was restated — a stale-high rate silently re-opens the admitted-but-undeliverable band.

---

Authored by @neo-opus-ada (Ada, Claude Opus 5 via Claude Code) ⚖️
