### PR TITLE
fix(ai): carry and persist completed embedding prefixes across batch failures (#17112)

### DIFF
--- a/ai/scripts/lint/retry-bound-registry.json
+++ b/ai/scripts/lint/retry-bound-registry.json
@@ -206,19 +206,19 @@
             "witness": "`retry.maxTotalDelayMs - totalDelayMs` remaining-budget clamp in #getCollectionResolveRetryDelay",
             "note": "The only max-window instance: bounded by TOTAL delay spent, not by a per-delay cap alone (it also carries maxDelayMs)."
         },
-        "ai/services/knowledge-base/VectorService.mjs#createFirstBatchAbort:2603053b": {
+        "ai/services/knowledge-base/VectorService.mjs#persistCarriedPrefix:2603053b": {
             "kind": "retry-growth",
             "lifetime": "in-cycle",
             "boundCarrier": "max-attempts",
             "witness": "`retries < maxRetries` bounds non-timeout failures; timeout-class provider failures throw after their first provider offer",
             "note": "Embedding batch retry inside one pass. A provider timeout terminates the whole sweep so the outer scheduler, not this exponential ladder, owns the later attempt."
         },
-        "ai/services/knowledge-base/VectorService.mjs#createFirstBatchAbort:ca44af32": {
+        "ai/services/knowledge-base/VectorService.mjs#persistCarriedPrefix:ca44af32": {
             "kind": "retry-growth",
             "lifetime": "in-cycle",
             "boundCarrier": "max-attempts",
             "witness": "`retries++` precedes the sleep and `if (retries >= maxRetries) throw writeError` exits before the delay can run again; the write retries spend the surrounding batch's shared `maxRetries` budget",
-            "note": "Carried-prefix WRITE retry inside the provider-error catch: vectors already in hand retry the upsert only — never the provider — and budget exhaustion rethrows the storage error so the sweep ends loudly."
+            "note": "Carried-prefix WRITE retry shared by the yield AND failure arms (persistCarriedPrefix): vectors already in hand retry the upsert only — never the provider — and budget exhaustion rethrows the storage error so the sweep ends loudly."
         },
         "ai/services/memory-core/helpers/freezeReprobeDecision.mjs#decideFreezeReprobe:5b01edc6": {
             "kind": "retry-growth",

--- a/ai/scripts/lint/retry-bound-registry.json
+++ b/ai/scripts/lint/retry-bound-registry.json
@@ -213,6 +213,13 @@
             "witness": "`retries < maxRetries` bounds non-timeout failures; timeout-class provider failures throw after their first provider offer",
             "note": "Embedding batch retry inside one pass. A provider timeout terminates the whole sweep so the outer scheduler, not this exponential ladder, owns the later attempt."
         },
+        "ai/services/knowledge-base/VectorService.mjs#createFirstBatchAbort:ca44af32": {
+            "kind": "retry-growth",
+            "lifetime": "in-cycle",
+            "boundCarrier": "max-attempts",
+            "witness": "`retries++` precedes the sleep and `if (retries >= maxRetries) throw writeError` exits before the delay can run again; the write retries spend the surrounding batch's shared `maxRetries` budget",
+            "note": "Carried-prefix WRITE retry inside the provider-error catch: vectors already in hand retry the upsert only — never the provider — and budget exhaustion rethrows the storage error so the sweep ends loudly."
+        },
         "ai/services/memory-core/helpers/freezeReprobeDecision.mjs#decideFreezeReprobe:5b01edc6": {
             "kind": "retry-growth",
             "lifetime": "persisted",

--- a/ai/services/knowledge-base/VectorService.mjs
+++ b/ai/services/knowledge-base/VectorService.mjs
@@ -1096,6 +1096,44 @@ class VectorService extends Base {
             // grows — indistinguishable from progress from the outside.
             let embeddings = null;
 
+            // One persistence contract for EVERY carried prefix — the yield arm and the failure arm
+            // alike: validate positional binding against the count the PRODUCER states (a short
+            // payload sliced positionally shifts every later vector onto its neighbour's id with no
+            // length mismatch to catch it), then write under the batch's shared retry budget — the
+            // write retries with the vectors in hand, never re-entering the provider. Budget
+            // exhaustion rethrows the storage error so a carry is never silently dropped; an
+            // un-persisted prefix is re-selected by a later sweep.
+            const persistCarriedPrefix = async (carried, expected, arm) => {
+                if (carried.length !== expected) {
+                    throw new Error(`${arm} batch ${i / batchSize + 1} carried ${carried.length} embedding(s) for ${expected} completed input(s); refusing to bind vectors to chunk ids by position.`);
+                }
+
+                if (carried.length === 0) return 0;
+
+                const partialChunks = batchToEmbed.slice(0, carried.length);
+
+                for (;;) {
+                    try {
+                        await collection.upsert({
+                            ids       : partialChunks.map(chunk => chunk.id),
+                            embeddings: carried,
+                            metadatas : partialChunks.map(chunk => buildChunkMetadata(chunk))
+                        });
+                        break;
+                    } catch (writeError) {
+                        lastError = writeError;
+                        retries++;
+                        if (retries >= maxRetries) throw writeError;
+                        console.error(`Persisting the carried prefix of ${arm.toLowerCase()} batch ${i / batchSize + 1} failed. Retrying the write (${retries}/${maxRetries})...`, writeError.message);
+                        await new Promise(res => setTimeout(res, 2 ** retries * 1000));
+                    }
+                }
+
+                embeddedCount += partialChunks.length;
+
+                return partialChunks.length
+            };
+
             while (retries < maxRetries && !success) {
                 try {
                     embeddings ??= await TextEmbeddingService.embedTexts(textsToEmbed, mcConfig.embeddingProvider, {
@@ -1129,29 +1167,12 @@ class VectorService extends Base {
                         // Persist what the yield already paid for. Without this the acquisition completes
                         // provider chunks, stores zero ids, and the next sweep re-selects the identical
                         // prefix — so a holder that yields at the same chunk every time never advances.
-                        // A reached checkpoint is not a durable one.
-                        // Sliced by the count the PRODUCER states it completed, and only after asserting the
-                        // payload matches it. Deriving the slice from `carried.length` alone would let a
-                        // short provider response define its own correctness: one missing vector shifts every
-                        // later one onto its neighbour's id, with no length mismatch to catch it.
-                        const carried  = err.embeddings || [],
-                              expected = err.completedTextCount;
+                        // A reached checkpoint is not a durable one — and durable includes surviving a
+                        // TRANSIENT write failure, which is why the shared carry contract (positional
+                        // guard + budgeted write retry) applies here exactly as on the failure arm.
+                        const carried = err.embeddings || [];
 
-                        if (carried.length !== expected) {
-                            throw new Error(`Yielded batch ${i / batchSize + 1} carried ${carried.length} embedding(s) for ${expected} completed input(s); refusing to bind vectors to chunk ids by position.`);
-                        }
-
-                        if (carried.length > 0) {
-                            const partialChunks = batchToEmbed.slice(0, carried.length);
-
-                            await collection.upsert({
-                                ids       : partialChunks.map(chunk => chunk.id),
-                                embeddings: carried,
-                                metadatas : partialChunks.map(chunk => buildChunkMetadata(chunk))
-                            });
-
-                            embeddedCount += partialChunks.length;
-                        }
+                        await persistCarriedPrefix(carried, err.completedTextCount, 'Yielded');
 
                         logger.log(`Yielding the heavy-maintenance lease inside batch ${i / batchSize + 1} after ${err.completedChunkCount}/${err.totalChunkCount} provider chunk(s); ${carried.length} partial embedding(s) persisted (${embeddedCount} embedded total). This batch is not retried; the next sweep resumes after the persisted prefix.`);
                         break;
@@ -1168,42 +1189,14 @@ class VectorService extends Base {
                     // refuse-loudly guard as the yield arm: a payload disagreeing with its stated count
                     // would bind vectors to wrong ids if sliced positionally.
                     if (embeddings === null && Number.isInteger(err?.completedTextCount) && err.completedTextCount > 0) {
-                        const carried = err.embeddings || [];
+                        const persistedCount = await persistCarriedPrefix(err.embeddings || [], err.completedTextCount, 'Failed');
 
-                        if (carried.length !== err.completedTextCount) {
-                            throw new Error(`Failed batch ${i / batchSize + 1} carried ${carried.length} embedding(s) for ${err.completedTextCount} completed input(s); refusing to bind vectors to chunk ids by position.`);
+                        if (persistedCount > 0) {
+                            batchToEmbed = batchToEmbed.slice(persistedCount);
+                            textsToEmbed = textsToEmbed.slice(persistedCount);
+
+                            logger.log(`Persisted ${persistedCount} carried embedding(s) from failed batch ${i / batchSize + 1} (${err.completedChunkCount}/${err.totalChunkCount} provider chunk(s) completed before the failure); ${batchToEmbed.length} chunk(s) remain for the retry or a later sweep.`);
                         }
-
-                        const partialChunks = batchToEmbed.slice(0, carried.length);
-
-                        // The prefix write rides the SHARED retry budget — with the vectors in hand it
-                        // retries the WRITE, never re-entering the provider, matching the cached-vector
-                        // invariant of the ordinary path: a persistence failure must neither re-purchase
-                        // provider work nor escape retry accounting. Exhaustion surfaces the storage
-                        // error loudly; an un-persisted prefix is re-selected by a later sweep, never
-                        // silently dropped under a provider error it did not cause.
-                        for (;;) {
-                            try {
-                                await collection.upsert({
-                                    ids       : partialChunks.map(chunk => chunk.id),
-                                    embeddings: carried,
-                                    metadatas : partialChunks.map(chunk => buildChunkMetadata(chunk))
-                                });
-                                break;
-                            } catch (writeError) {
-                                lastError = writeError;
-                                retries++;
-                                if (retries >= maxRetries) throw writeError;
-                                console.error(`Persisting the carried prefix of batch ${i / batchSize + 1} failed. Retrying the write (${retries}/${maxRetries})...`, writeError.message);
-                                await new Promise(res => setTimeout(res, 2 ** retries * 1000));
-                            }
-                        }
-
-                        embeddedCount += partialChunks.length;
-                        batchToEmbed   = batchToEmbed.slice(carried.length);
-                        textsToEmbed   = textsToEmbed.slice(carried.length);
-
-                        logger.log(`Persisted ${partialChunks.length} carried embedding(s) from failed batch ${i / batchSize + 1} (${err.completedChunkCount}/${err.totalChunkCount} provider chunk(s) completed before the failure); ${batchToEmbed.length} chunk(s) remain for the retry or a later sweep.`);
                     }
 
                     // A provider timeout is evidence that OUR wait ended, not that the provider work did.

--- a/ai/services/knowledge-base/VectorService.mjs
+++ b/ai/services/knowledge-base/VectorService.mjs
@@ -3,9 +3,9 @@ import TextEmbeddingService, {
     getEmbeddingModel,
     isEmbeddingBatchYieldError
 }                             from '../memory-core/TextEmbeddingService.mjs';
-import mcConfig from '../../mcp/server/memory-core/config.mjs';
+import mcConfig                from '../../mcp/server/memory-core/config.mjs';
 import {isProviderTimeoutCode} from '../../provider/createTimeoutError.mjs';
-import Base     from '../../../src/core/Base.mjs';
+import Base                    from '../../../src/core/Base.mjs';
 import {
     bytesToTokens,
     emitConsumerFriction
@@ -1176,11 +1176,28 @@ class VectorService extends Base {
 
                         const partialChunks = batchToEmbed.slice(0, carried.length);
 
-                        await collection.upsert({
-                            ids       : partialChunks.map(chunk => chunk.id),
-                            embeddings: carried,
-                            metadatas : partialChunks.map(chunk => buildChunkMetadata(chunk))
-                        });
+                        // The prefix write rides the SHARED retry budget — with the vectors in hand it
+                        // retries the WRITE, never re-entering the provider, matching the cached-vector
+                        // invariant of the ordinary path: a persistence failure must neither re-purchase
+                        // provider work nor escape retry accounting. Exhaustion surfaces the storage
+                        // error loudly; an un-persisted prefix is re-selected by a later sweep, never
+                        // silently dropped under a provider error it did not cause.
+                        for (;;) {
+                            try {
+                                await collection.upsert({
+                                    ids       : partialChunks.map(chunk => chunk.id),
+                                    embeddings: carried,
+                                    metadatas : partialChunks.map(chunk => buildChunkMetadata(chunk))
+                                });
+                                break;
+                            } catch (writeError) {
+                                lastError = writeError;
+                                retries++;
+                                if (retries >= maxRetries) throw writeError;
+                                console.error(`Persisting the carried prefix of batch ${i / batchSize + 1} failed. Retrying the write (${retries}/${maxRetries})...`, writeError.message);
+                                await new Promise(res => setTimeout(res, 2 ** retries * 1000));
+                            }
+                        }
 
                         embeddedCount += partialChunks.length;
                         batchToEmbed   = batchToEmbed.slice(carried.length);

--- a/ai/services/knowledge-base/VectorService.mjs
+++ b/ai/services/knowledge-base/VectorService.mjs
@@ -1071,8 +1071,14 @@ class VectorService extends Base {
                 continue;
             }
 
-            const batchToEmbed = embeddable.map(input => input.chunk);
-            const textsToEmbed = embeddable.map(input => input.text);
+            // `let`, not `const`: the failure-carry arm below persists a completed prefix and shrinks
+            // both arrays to the un-persisted remainder, so a retry cannot re-purchase carried vectors.
+            let batchToEmbed = embeddable.map(input => input.chunk);
+            let textsToEmbed = embeddable.map(input => input.text);
+
+            // Captured before any failure-carry shrink: after a shrink, deriving this from
+            // `batchToEmbed.length` would report persisted work as "skipped" in the success log.
+            const guardrailSkipped = batch.length - batchToEmbed.length;
 
             let retries   = 0;
             let success   = false;
@@ -1111,7 +1117,7 @@ class VectorService extends Base {
                     });
 
                     embeddedCount += batchToEmbed.length;
-                    logger.log(`Processed and embedded batch ${i / batchSize + 1} of ${Math.ceil(chunksToProcess.length / batchSize)} (${batchToEmbed.length} embedded, ${batch.length - batchToEmbed.length} skipped).`);
+                    logger.log(`Processed and embedded batch ${i / batchSize + 1} of ${Math.ceil(chunksToProcess.length / batchSize)} (${batchToEmbed.length} embedded, ${guardrailSkipped} skipped).`);
                     success = true;
                 } catch (err) {
                     // A cooperative yield is a DECISION, not a failure. Falling through to the retry arm would
@@ -1149,6 +1155,38 @@ class VectorService extends Base {
 
                         logger.log(`Yielding the heavy-maintenance lease inside batch ${i / batchSize + 1} after ${err.completedChunkCount}/${err.totalChunkCount} provider chunk(s); ${carried.length} partial embedding(s) persisted (${embeddedCount} embedded total). This batch is not retried; the next sweep resumes after the persisted prefix.`);
                         break;
+                    }
+
+                    // Work conservation on the failure path: a mid-batch provider failure may
+                    // carry the completed prefix under the same contract the yield error declares —
+                    // positional binding validated by the producer, count derived from what was SENT.
+                    // Persist it BEFORE the timeout classification ends the sweep and BEFORE the retry
+                    // arm re-runs the batch: a carried prefix the sweep discards is re-purchased on every
+                    // later attempt, which on a slow lane is the difference between a corpus that grows
+                    // and one that burns full compute forever at a constant count. The batch then shrinks
+                    // to the un-persisted remainder so a retry buys only what is actually missing. Same
+                    // refuse-loudly guard as the yield arm: a payload disagreeing with its stated count
+                    // would bind vectors to wrong ids if sliced positionally.
+                    if (embeddings === null && Number.isInteger(err?.completedTextCount) && err.completedTextCount > 0) {
+                        const carried = err.embeddings || [];
+
+                        if (carried.length !== err.completedTextCount) {
+                            throw new Error(`Failed batch ${i / batchSize + 1} carried ${carried.length} embedding(s) for ${err.completedTextCount} completed input(s); refusing to bind vectors to chunk ids by position.`);
+                        }
+
+                        const partialChunks = batchToEmbed.slice(0, carried.length);
+
+                        await collection.upsert({
+                            ids       : partialChunks.map(chunk => chunk.id),
+                            embeddings: carried,
+                            metadatas : partialChunks.map(chunk => buildChunkMetadata(chunk))
+                        });
+
+                        embeddedCount += partialChunks.length;
+                        batchToEmbed   = batchToEmbed.slice(carried.length);
+                        textsToEmbed   = textsToEmbed.slice(carried.length);
+
+                        logger.log(`Persisted ${partialChunks.length} carried embedding(s) from failed batch ${i / batchSize + 1} (${err.completedChunkCount}/${err.totalChunkCount} provider chunk(s) completed before the failure); ${batchToEmbed.length} chunk(s) remain for the retry or a later sweep.`);
                     }
 
                     // A provider timeout is evidence that OUR wait ended, not that the provider work did.

--- a/ai/services/memory-core/TextEmbeddingService.mjs
+++ b/ai/services/memory-core/TextEmbeddingService.mjs
@@ -1831,17 +1831,46 @@ class TextEmbeddingService extends Base {
 
             recordEmbeddingSubmissions(providerActivityRecorder, chunk);
 
-            const
-                  result = await this.#enqueueOpenAiCompatiblePost(chunk, {
-                      unloadRetriesLeft: unloadRetryCount,
-                      requestTimeoutMs,
-                      signal,
-                      operationLabel,
-                      onProviderTimeout,
-                      operation,
-                      providerActivity,
-                      providerActivityRecorder
-                  }, 'batch');
+            let result;
+
+            try {
+                result = await this.#enqueueOpenAiCompatiblePost(chunk, {
+                    unloadRetriesLeft: unloadRetryCount,
+                    requestTimeoutMs,
+                    signal,
+                    operationLabel,
+                    onProviderTimeout,
+                    operation,
+                    providerActivity,
+                    providerActivityRecorder
+                }, 'batch');
+            } catch (err) {
+                // Work conservation on the FAILURE path. The yield-point above carries its
+                // completed prefix; a provider failure mid-batch used to discard it, so the caller's
+                // retry — and every later sweep — re-purchased vectors the provider had already
+                // returned. The ORIGINAL error is decorated rather than replaced: its `code` is what
+                // the caller's timeout/circuit classification reads. Completed chunks are full-width
+                // by the same boundary argument the yield error makes (only a batch's final chunk can
+                // be short, and a completed final chunk leaves nothing to fail), so the expected count
+                // derives from what was SENT. If the accumulated data cannot satisfy the positional-
+                // binding guard, the error travels undecorated — carrying nothing beats binding
+                // vectors to the wrong ids.
+                if (completedChunkCount > 0) {
+                    try {
+                        const completedTextCount = completedChunkCount * chunkSize,
+                              embeddings         = toOrderedEmbeddings(data, completedTextCount);
+
+                        err.completedChunkCount = completedChunkCount;
+                        err.totalChunkCount     = totalChunkCount;
+                        err.completedTextCount  = completedTextCount;
+                        err.embeddings          = embeddings;
+                    } catch {
+                        // Positional binding could not be proven; the failure travels uncarried.
+                    }
+                }
+
+                throw err;
+            }
 
             data.push(...(result.data || []).map(item => ({
                 ...item,

--- a/test/playwright/unit/ai/services/knowledge-base/VectorService.failureCarry.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/VectorService.failureCarry.spec.mjs
@@ -1,0 +1,262 @@
+import {setup} from '../../../../setup.mjs';
+
+const appName = 'KBFailureCarryTest';
+
+setup({
+    neoConfig: {
+        allowVdomUpdatesInTests: false,
+        unitTestMode           : true,
+        useDomApiRenderer      : false
+    },
+    appConfig: {
+        name             : appName,
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../../../src/Neo.mjs';
+import * as core      from '../../../../../../src/core/_export.mjs';
+
+/**
+ * Work conservation on the FAILURE path of `VectorService.embedChunks`.
+ *
+ * The yield arm already persists the completed prefix a lease-yield carries. A provider FAILURE
+ * mid-batch discarded it: the timeout arm ended the sweep with the prefix unpersisted, and the retry
+ * arm re-ran the whole batch — so every completed-but-unpersisted embedding was re-purchased on every
+ * attempt and on every later sweep. On a slow lane that composes into full compute at a constant
+ * corpus count: the plane-observed "all discarded" loop.
+ *
+ * These tests drive `embedChunks` with the leaseYield spec's spy-collection harness and a stubbed
+ * embedder that throws errors decorated with the carry contract (`completedTextCount`, `embeddings`),
+ * asserting the four load-bearing properties:
+ *   - a timeout-class failure persists its carried prefix BEFORE the sweep ends,
+ *   - a retryable failure persists the prefix and retries ONLY the remainder,
+ *   - a payload disagreeing with its stated count is refused, never sliced positionally,
+ *   - an uncarried failure keeps its existing behavior (nothing persisted, classification unchanged).
+ */
+test.describe.configure({mode: 'serial'});
+
+function createSpyCollection() {
+    const calls       = {upsert: 0};
+    const upsertedIds = [];
+    // id -> vector, so a test can assert WHICH vector landed under WHICH id. Recording ids alone
+    // cannot see a misalignment, and neither can identical vectors — both halves are required.
+    const storedByIds = new Map();
+
+    return {
+        calls,
+        storedByIds,
+        upsertedIds,
+        name: 'spy-knowledge-base',
+        async upsert({ids, embeddings}) {
+            calls.upsert++;
+            upsertedIds.push(...ids);
+            ids.forEach((id, position) => storedByIds.set(id, embeddings?.[position]));
+        }
+    };
+}
+
+/**
+ * A vector that names its own chunk — an all-zero embedder cannot fail on a positional slide.
+ */
+function makeEmbedding(chunkIndex) {
+    const vector = new Array(384).fill(0);
+
+    vector[0] = chunkIndex;
+
+    return vector
+}
+
+function chunkIndexOf(chunk) {
+    return Number(chunk.id.replace('chunk-', ''))
+}
+
+function makeChunks(count) {
+    return Array.from({length: count}, (_, i) => ({
+        id     : `chunk-${i}`,
+        type   : 'guide',
+        name   : `symbol-${i}`,
+        content: `deterministic small body for chunk ${i}`
+    }));
+}
+
+/**
+ * Builds a failure decorated with the carry contract the producer attaches: the ORIGINAL
+ * error identity (message + code) with the completed prefix alongside it.
+ */
+function makeCarriedFailure({code, completedChunkCount, totalChunkCount, completedTextCount, embeddings}) {
+    const error = new Error('openAiCompatible embedding error HTTP 500: provider died mid-batch');
+
+    if (code) error.code = code;
+    error.completedChunkCount = completedChunkCount;
+    error.totalChunkCount     = totalChunkCount;
+    error.completedTextCount  = completedTextCount;
+    error.embeddings          = embeddings;
+
+    return error
+}
+
+test.describe('VectorService.embedChunks — failure-path work conservation (#17112)', () => {
+    let SDK, KB_VectorService, KB_Config, TextEmbeddingService;
+    let originalEmbedTexts, originalBatchConfig;
+
+    test.beforeAll(async () => {
+        SDK                  = await import('../../../../../../ai/services.mjs');
+        KB_Config            = SDK.KB_Config;
+        TextEmbeddingService = SDK.Memory_TextEmbeddingService;
+
+        const VectorServiceModule = await import('../../../../../../ai/services/knowledge-base/VectorService.mjs');
+        KB_VectorService          = VectorServiceModule.default;
+
+        originalEmbedTexts  = TextEmbeddingService.embedTexts.bind(TextEmbeddingService);
+        originalBatchConfig = {
+            batchSize : KB_Config.data.batchSize,
+            batchDelay: KB_Config.data.batchDelay,
+            maxRetries: KB_Config.data.maxRetries
+        };
+    });
+
+    test.afterAll(() => {
+        TextEmbeddingService.embedTexts = originalEmbedTexts;
+        Object.assign(KB_Config.data, originalBatchConfig);
+    });
+
+    test.beforeEach(() => {
+        Object.assign(KB_Config.data, {batchSize: 50, batchDelay: 0, maxRetries: 3});
+    });
+
+    test('a timeout-class failure PERSISTS its carried prefix before the sweep ends', async () => {
+        const spy    = createSpyCollection();
+        const chunks = makeChunks(50); // 1 batch
+
+        TextEmbeddingService.embedTexts = async () => {
+            throw makeCarriedFailure({
+                code               : 'OPENAI_COMPATIBLE_REQUEST_TIMEOUT',
+                completedChunkCount: 2,
+                totalChunkCount    : 10,
+                completedTextCount : 10,
+                embeddings         : Array.from({length: 10}, (_, i) => makeEmbedding(i))
+            });
+        };
+
+        const outcome = await KB_VectorService.embedChunks({
+            collection     : spy,
+            chunksToProcess: chunks,
+            shouldYield    : () => false
+        }).then(() => null, error => error);
+
+        // The sweep still ends — a timeout means OUR wait ended, not the provider's work, and queueing
+        // more batches behind a possibly-running predecessor stays wrong. What changes is what survives:
+        // the 10 completed embeddings are durable, so the next sweep's re-selection excludes them.
+        expect(outcome, 'the timeout classification must still end the sweep').toBeInstanceOf(Error);
+        expect(outcome.code).toBe('OPENAI_COMPATIBLE_REQUEST_TIMEOUT');
+        expect(spy.calls.upsert, 'the carried prefix must be persisted before the sweep ends').toBe(1);
+        expect(spy.upsertedIds).toEqual(chunks.slice(0, 10).map(chunk => chunk.id));
+
+        // Under the RIGHT ids: each vector names its chunk, so a one-position slide fails here.
+        chunks.slice(0, 10).forEach(chunk => {
+            expect(
+                spy.storedByIds.get(chunk.id)?.[0],
+                `${chunk.id} must store its own vector, not a neighbour's`
+            ).toBe(chunkIndexOf(chunk));
+        });
+    });
+
+    test('a retryable failure persists the prefix and retries ONLY the un-persisted remainder', async () => {
+        const spy    = createSpyCollection();
+        const chunks = makeChunks(50); // 1 batch
+
+        const receivedTextCounts = [];
+
+        let embedCalls = 0;
+
+        TextEmbeddingService.embedTexts = async texts => {
+            embedCalls++;
+            receivedTextCounts.push(texts.length);
+
+            // Attempt 1: 10 completed, then a retryable (non-timeout) failure.
+            if (embedCalls === 1) {
+                throw makeCarriedFailure({
+                    completedChunkCount: 2,
+                    totalChunkCount    : 10,
+                    completedTextCount : 10,
+                    embeddings         : chunks.slice(0, 10).map(chunk => makeEmbedding(chunkIndexOf(chunk)))
+                });
+            }
+
+            // Attempt 2 succeeds for whatever it was asked to embed.
+            return texts.map((_, position) => makeEmbedding(chunkIndexOf(chunks[10 + position])))
+        };
+
+        const result = await KB_VectorService.embedChunks({
+            collection     : spy,
+            chunksToProcess: chunks,
+            shouldYield    : () => false
+        });
+
+        // The retry must not re-purchase the 10 persisted embeddings: attempt 1 sees all 50 inputs,
+        // attempt 2 exactly the 40 that were never completed. Re-sending 50 is the re-purchase loop
+        // this repair removes — it passes every other assertion here, so the count is load-bearing.
+        expect(receivedTextCounts).toEqual([50, 40]);
+        expect(result.embedded).toBe(50);
+        expect(spy.calls.upsert, 'one prefix persist plus one remainder persist').toBe(2);
+        expect(spy.upsertedIds).toEqual(chunks.map(chunk => chunk.id));
+
+        chunks.forEach(chunk => {
+            expect(
+                spy.storedByIds.get(chunk.id)?.[0],
+                `${chunk.id} must store its own vector across the persist/retry boundary`
+            ).toBe(chunkIndexOf(chunk));
+        });
+    });
+
+    test('a carried payload disagreeing with its stated count is REFUSED, never sliced positionally', async () => {
+        const spy    = createSpyCollection();
+        const chunks = makeChunks(50);
+
+        TextEmbeddingService.embedTexts = async () => {
+            throw makeCarriedFailure({
+                completedChunkCount: 2,
+                totalChunkCount    : 10,
+                completedTextCount : 10,
+                embeddings         : Array.from({length: 9}, (_, i) => makeEmbedding(i)) // one short
+            });
+        };
+
+        const outcome = await KB_VectorService.embedChunks({
+            collection     : spy,
+            chunksToProcess: chunks,
+            shouldYield    : () => false
+        }).then(() => null, error => error);
+
+        // One missing vector slides every later one onto its neighbour's id with no length mismatch
+        // downstream — refusing loudly beats storing 9 vectors under the wrong 9 ids.
+        expect(outcome).toBeInstanceOf(Error);
+        expect(outcome.message).toContain('refusing to bind vectors to chunk ids by position');
+        expect(spy.calls.upsert, 'nothing may be written on a disagreement').toBe(0);
+    });
+
+    test('an UNCARRIED timeout keeps its existing behavior: sweep ends, nothing persisted', async () => {
+        const spy    = createSpyCollection();
+        const chunks = makeChunks(50);
+
+        TextEmbeddingService.embedTexts = async () => {
+            const error = new Error('request timed out');
+
+            error.code = 'OPENAI_COMPATIBLE_REQUEST_TIMEOUT';
+            throw error
+        };
+
+        const outcome = await KB_VectorService.embedChunks({
+            collection     : spy,
+            chunksToProcess: chunks,
+            shouldYield    : () => false
+        }).then(() => null, error => error);
+
+        expect(outcome).toBeInstanceOf(Error);
+        expect(outcome.code).toBe('OPENAI_COMPATIBLE_REQUEST_TIMEOUT');
+        expect(spy.calls.upsert).toBe(0);
+    });
+});

--- a/test/playwright/unit/ai/services/knowledge-base/VectorService.failureCarry.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/VectorService.failureCarry.spec.mjs
@@ -350,69 +350,6 @@ test.describe('VectorService.embedChunks — failure-path work conservation (#17
         });
     });
 
-    test('AC-2 re-sweep witness: a second sweep re-submits ONLY chunks without persisted vectors', async () => {
-        const spy       = createSpyCollection();
-        const allChunks = makeChunks(50);
-
-        const receivedTexts = [];
-        let   sweepChunks   = allChunks;
-        let   embedCalls    = 0;
-
-        TextEmbeddingService.embedTexts = async texts => {
-            embedCalls++;
-            receivedTexts.push(texts.length);
-
-            // Sweep 1: a timeout-class failure carrying 10 completed embeddings — the sweep ends
-            // (provider-timeout classification) with the prefix persisted.
-            if (embedCalls === 1) {
-                throw makeCarriedFailure({
-                    code               : 'OPENAI_COMPATIBLE_REQUEST_TIMEOUT',
-                    completedChunkCount: 2,
-                    totalChunkCount    : 10,
-                    completedTextCount : 10,
-                    embeddings         : sweepChunks.slice(0, 10).map(chunk => makeEmbedding(chunkIndexOf(chunk)))
-                });
-            }
-
-            // Sweep 2 completes whatever it is asked for.
-            return texts.map((_, position) => makeEmbedding(chunkIndexOf(sweepChunks[position])))
-        };
-
-        const firstSweep = await KB_VectorService.embedChunks({
-            collection     : spy,
-            chunksToProcess: sweepChunks,
-            shouldYield    : () => false
-        }).then(() => null, error => error);
-
-        expect(firstSweep, 'sweep 1 ends on the provider timeout').toBeInstanceOf(Error);
-        expect(spy.upsertedIds).toHaveLength(10);
-
-        // The production re-selection contract: the next sweep selects only what the collection
-        // does not already hold — mirrored here exactly as the sibling yield spec models it.
-        sweepChunks = allChunks.filter(chunk => !spy.storedByIds.has(chunk.id));
-        expect(sweepChunks, 'the persisted prefix must drop out of re-selection').toHaveLength(40);
-        expect(sweepChunks[0].id, 'the remainder starts exactly after the persisted prefix').toBe('chunk-10');
-
-        const secondSweep = await KB_VectorService.embedChunks({
-            collection     : spy,
-            chunksToProcess: sweepChunks,
-            shouldYield    : () => false
-        });
-
-        // The witness: the second sweep purchased exactly the 40 un-persisted chunks — never the 10
-        // completed ones — and the corpus completes correctly bound.
-        expect(receivedTexts).toEqual([50, 40]);
-        expect(secondSweep.embedded).toBe(40);
-        expect(spy.upsertedIds).toHaveLength(50);
-
-        allChunks.forEach(chunk => {
-            expect(
-                spy.storedByIds.get(chunk.id)?.[0],
-                `${chunk.id} must hold its own vector across the sweep boundary`
-            ).toBe(chunkIndexOf(chunk));
-        });
-    });
-
     test('an UNCARRIED timeout keeps its existing behavior: sweep ends, nothing persisted', async () => {
         const spy    = createSpyCollection();
         const chunks = makeChunks(50);

--- a/test/playwright/unit/ai/services/knowledge-base/VectorService.failureCarry.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/VectorService.failureCarry.spec.mjs
@@ -212,6 +212,64 @@ test.describe('VectorService.embedChunks — failure-path work conservation (#17
         });
     });
 
+    test('a TRANSIENT prefix-write failure retries the WRITE inside the shared budget — never re-entering the provider', async () => {
+        const spy    = createSpyCollection();
+        const chunks = makeChunks(50); // 1 batch
+
+        // First upsert call rejects (transient storage failure), every later call delegates.
+        // The invariant under test is the cached-vector rule the ordinary path already holds:
+        // vectors in hand retry the WRITE — a write failure must consume retry budget, not
+        // escape the accounting and lose the carried work.
+        const realUpsert  = spy.upsert.bind(spy);
+        let   upsertCalls = 0;
+
+        spy.upsert = async payload => {
+            upsertCalls++;
+            if (upsertCalls === 1) throw new Error('transient storage failure');
+            return realUpsert(payload)
+        };
+
+        const receivedTextCounts = [];
+        let   embedCalls         = 0;
+
+        TextEmbeddingService.embedTexts = async texts => {
+            embedCalls++;
+            receivedTextCounts.push(texts.length);
+
+            if (embedCalls === 1) {
+                throw makeCarriedFailure({
+                    completedChunkCount: 2,
+                    totalChunkCount    : 10,
+                    completedTextCount : 10,
+                    embeddings         : chunks.slice(0, 10).map(chunk => makeEmbedding(chunkIndexOf(chunk)))
+                });
+            }
+
+            return texts.map((_, position) => makeEmbedding(chunkIndexOf(chunks[10 + position])))
+        };
+
+        const result = await KB_VectorService.embedChunks({
+            collection     : spy,
+            chunksToProcess: chunks,
+            shouldYield    : () => false
+        });
+
+        // Three write calls: the rejected prefix attempt, the successful prefix retry, and the
+        // remainder — while the provider is entered exactly twice ([50, 40]): the write retry
+        // must never re-purchase provider work.
+        expect(upsertCalls).toBe(3);
+        expect(receivedTextCounts).toEqual([50, 40]);
+        expect(result.embedded).toBe(50);
+        expect(spy.upsertedIds).toEqual(chunks.map(chunk => chunk.id));
+
+        chunks.forEach(chunk => {
+            expect(
+                spy.storedByIds.get(chunk.id)?.[0],
+                `${chunk.id} must store its own vector across the write-retry boundary`
+            ).toBe(chunkIndexOf(chunk));
+        });
+    });
+
     test('a carried payload disagreeing with its stated count is REFUSED, never sliced positionally', async () => {
         const spy    = createSpyCollection();
         const chunks = makeChunks(50);

--- a/test/playwright/unit/ai/services/knowledge-base/VectorService.failureCarry.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/VectorService.failureCarry.spec.mjs
@@ -15,9 +15,10 @@ setup({
     }
 });
 
-import {test, expect} from '@playwright/test';
-import Neo            from '../../../../../../src/Neo.mjs';
-import * as core      from '../../../../../../src/core/_export.mjs';
+import {test, expect}                 from '@playwright/test';
+import Neo                            from '../../../../../../src/Neo.mjs';
+import * as core                      from '../../../../../../src/core/_export.mjs';
+import {EMBEDDING_BATCH_YIELDED_CODE} from '../../../../../../ai/services/memory-core/TextEmbeddingService.mjs';
 
 /**
  * Work conservation on the FAILURE path of `VectorService.embedChunks`.
@@ -294,6 +295,122 @@ test.describe('VectorService.embedChunks — failure-path work conservation (#17
         expect(outcome).toBeInstanceOf(Error);
         expect(outcome.message).toContain('refusing to bind vectors to chunk ids by position');
         expect(spy.calls.upsert, 'nothing may be written on a disagreement').toBe(0);
+    });
+
+    test('a transient YIELD-prefix write failure retries the write under the same shared contract', async () => {
+        const spy    = createSpyCollection();
+        const chunks = makeChunks(50); // 1 batch
+
+        // The symmetry gap a reviewer named: the failure arm got the budgeted write retry while the
+        // yield arm still wrote bare — a transient rejection there escaped before `yielded: true`
+        // could return with durable progress, so the next acquisition re-purchased the prefix.
+        const realUpsert  = spy.upsert.bind(spy);
+        let   upsertCalls = 0;
+
+        spy.upsert = async payload => {
+            upsertCalls++;
+            if (upsertCalls === 1) throw new Error('transient storage failure');
+            return realUpsert(payload)
+        };
+
+        let embedCalls = 0;
+
+        TextEmbeddingService.embedTexts = async () => {
+            embedCalls++;
+
+            const error = new Error('openAiCompatible batch embedding yielded the heavy-maintenance lease after 2/10 provider chunk(s), 10 embedding(s) carried');
+
+            error.code                = EMBEDDING_BATCH_YIELDED_CODE;
+            error.completedChunkCount = 2;
+            error.totalChunkCount     = 10;
+            error.completedTextCount  = 10;
+            error.embeddings          = chunks.slice(0, 10).map(chunk => makeEmbedding(chunkIndexOf(chunk)));
+            throw error
+        };
+
+        const result = await KB_VectorService.embedChunks({
+            collection     : spy,
+            chunksToProcess: chunks,
+            shouldYield    : () => false
+        });
+
+        // One rejected write, one successful retry, ZERO extra provider entries — the yield stays a
+        // decision, and its paid-for prefix survives the storage hiccup.
+        expect(upsertCalls).toBe(2);
+        expect(embedCalls, 'a write retry must never re-enter the provider').toBe(1);
+        expect(result.yielded).toBe(true);
+        expect(result.embedded).toBe(10);
+        expect(spy.upsertedIds).toEqual(chunks.slice(0, 10).map(chunk => chunk.id));
+
+        chunks.slice(0, 10).forEach(chunk => {
+            expect(
+                spy.storedByIds.get(chunk.id)?.[0],
+                `${chunk.id} must store its own vector across the yield write-retry boundary`
+            ).toBe(chunkIndexOf(chunk));
+        });
+    });
+
+    test('AC-2 re-sweep witness: a second sweep re-submits ONLY chunks without persisted vectors', async () => {
+        const spy       = createSpyCollection();
+        const allChunks = makeChunks(50);
+
+        const receivedTexts = [];
+        let   sweepChunks   = allChunks;
+        let   embedCalls    = 0;
+
+        TextEmbeddingService.embedTexts = async texts => {
+            embedCalls++;
+            receivedTexts.push(texts.length);
+
+            // Sweep 1: a timeout-class failure carrying 10 completed embeddings — the sweep ends
+            // (provider-timeout classification) with the prefix persisted.
+            if (embedCalls === 1) {
+                throw makeCarriedFailure({
+                    code               : 'OPENAI_COMPATIBLE_REQUEST_TIMEOUT',
+                    completedChunkCount: 2,
+                    totalChunkCount    : 10,
+                    completedTextCount : 10,
+                    embeddings         : sweepChunks.slice(0, 10).map(chunk => makeEmbedding(chunkIndexOf(chunk)))
+                });
+            }
+
+            // Sweep 2 completes whatever it is asked for.
+            return texts.map((_, position) => makeEmbedding(chunkIndexOf(sweepChunks[position])))
+        };
+
+        const firstSweep = await KB_VectorService.embedChunks({
+            collection     : spy,
+            chunksToProcess: sweepChunks,
+            shouldYield    : () => false
+        }).then(() => null, error => error);
+
+        expect(firstSweep, 'sweep 1 ends on the provider timeout').toBeInstanceOf(Error);
+        expect(spy.upsertedIds).toHaveLength(10);
+
+        // The production re-selection contract: the next sweep selects only what the collection
+        // does not already hold — mirrored here exactly as the sibling yield spec models it.
+        sweepChunks = allChunks.filter(chunk => !spy.storedByIds.has(chunk.id));
+        expect(sweepChunks, 'the persisted prefix must drop out of re-selection').toHaveLength(40);
+        expect(sweepChunks[0].id, 'the remainder starts exactly after the persisted prefix').toBe('chunk-10');
+
+        const secondSweep = await KB_VectorService.embedChunks({
+            collection     : spy,
+            chunksToProcess: sweepChunks,
+            shouldYield    : () => false
+        });
+
+        // The witness: the second sweep purchased exactly the 40 un-persisted chunks — never the 10
+        // completed ones — and the corpus completes correctly bound.
+        expect(receivedTexts).toEqual([50, 40]);
+        expect(secondSweep.embedded).toBe(40);
+        expect(spy.upsertedIds).toHaveLength(50);
+
+        allChunks.forEach(chunk => {
+            expect(
+                spy.storedByIds.get(chunk.id)?.[0],
+                `${chunk.id} must hold its own vector across the sweep boundary`
+            ).toBe(chunkIndexOf(chunk));
+        });
     });
 
     test('an UNCARRIED timeout keeps its existing behavior: sweep ends, nothing persisted', async () => {

--- a/test/playwright/unit/ai/services/knowledge-base/VectorService.persistenceNonConvergence.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/VectorService.persistenceNonConvergence.spec.mjs
@@ -521,4 +521,80 @@ test.describe('VectorService — persistence failure is an unbounded re-embed lo
             .toEqual([3, 0]);
         expect(converging.landed.size, 'because the first one actually landed').toBe(3);
     });
+
+    test('a carried-prefix persist bounds the DEPLOYED re-sweep: embed() re-selects only un-persisted chunks (#17112 AC-2)', async () => {
+        // The failure-carry siblings prove persist/retry mechanics against a hand-supplied chunk
+        // array; per this file's charter, THIS arm is the one that may claim re-selection — because
+        // nothing in it selects anything. `embed()` reads its own corpus off disk, reads existing ids
+        // off the collection, and decides what to embed. The only stub is the provider-response seam
+        // one layer up (`embedTexts`, where the carry contract is produced — its production construction
+        // is pinned by the real-transport retry spec), so sweep 1 can end on a carried timeout exactly
+        // as the constrained plane's sweeps did.
+        writeFixtureJsonl(corpusPath, 50);
+
+        const collection          = createCollection({persists: true});
+        const receivedTextCounts  = [];
+        const originalEmbedTexts  = TextEmbeddingService.embedTexts;
+        const originalBatchLeaves = {
+            batchSize : KB_Config.data.batchSize,
+            batchDelay: KB_Config.data.batchDelay,
+            maxRetries: KB_Config.data.maxRetries
+        };
+
+        let embedTextsCalls = 0;
+
+        try {
+            Object.assign(KB_Config.data, {batchSize: 50, batchDelay: 0, maxRetries: 3});
+
+            TextEmbeddingService.embedTexts = async texts => {
+                embedTextsCalls++;
+                receivedTextCounts.push(texts.length);
+
+                // Sweep 1: a timeout-class provider failure carrying 10 completed embeddings — the
+                // carried prefix persists, then the timeout classification ends the sweep.
+                if (embedTextsCalls === 1) {
+                    const error = new Error('openAiCompatible request timed out');
+
+                    error.code                = 'OPENAI_COMPATIBLE_REQUEST_TIMEOUT';
+                    error.completedChunkCount = 2;
+                    error.totalChunkCount     = 10;
+                    error.completedTextCount  = 10;
+                    error.embeddings          = texts.slice(0, 10).map(() => new Array(384).fill(0.1));
+                    throw error
+                }
+
+                return texts.map(() => new Array(384).fill(0.1))
+            };
+
+            KB_ChromaManager.getKnowledgeBaseCollection = async () => collection;
+            KB_ChromaManager.invalidateKnowledgeBaseCollectionCache();
+
+            const firstSweep = await KB_VectorService.embed(corpusPath).then(() => null, error => error);
+
+            expect(firstSweep, 'sweep 1 ends on the carried provider timeout').toBeInstanceOf(Error);
+            expect(collection.landed.size, 'the carried prefix is durable before the sweep ends').toBe(10);
+
+            const secondSweep = await KB_VectorService.embed(corpusPath).then(() => null, error => error);
+
+            expect(secondSweep, 'sweep 2 completes').toBeNull();
+
+            // The witness AC-2 names: production selection — not a test-authored filter — excluded
+            // the persisted prefix, so the provider was paid for exactly the 40 missing chunks.
+            expect(receivedTextCounts, 'the deployed re-sweep purchased only the un-persisted remainder')
+                .toEqual([50, 40]);
+            expect(collection.landed.size, 'the corpus completes').toBe(50);
+
+            // And the prefix ids are the ones sweep 2 skipped: the second upsert attempt starts
+            // exactly where the persisted prefix ends.
+            expect(collection.upsertAttempts[0]).toHaveLength(10);
+            expect(collection.upsertAttempts[1]).toHaveLength(40);
+            expect(
+                collection.upsertAttempts[1].some(id => collection.upsertAttempts[0].includes(id)),
+                'no persisted chunk may be re-purchased or re-written by the re-sweep'
+            ).toBe(false);
+        } finally {
+            TextEmbeddingService.embedTexts = originalEmbedTexts;
+            Object.assign(KB_Config.data, originalBatchLeaves);
+        }
+    });
 });

--- a/test/playwright/unit/ai/services/memory-core/TextEmbeddingService.retry.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/TextEmbeddingService.retry.spec.mjs
@@ -239,6 +239,27 @@ test.describe.serial('TextEmbeddingService #11393/#11402/#12487/#12509 — openA
                             embedding: [requestCount, index]
                         })).reverse()
                     }));
+                } else if (serverBehavior === 'chunk-succeeds-then-dies') {
+                    // Chunk 1 embeds normally (dense, per-input indexed); every later request fails with
+                    // a non-retryable provider error — the failure-carry producer shape.
+                    if (requestCount === 1) {
+                        const inputs = lastRequest.body.input;
+                        res.writeHead(200, { 'Content-Type': 'application/json' });
+                        res.end(JSON.stringify({data: inputs.map((_, index) => ({index, embedding: [100 + index]}))}));
+                        return;
+                    }
+                    res.writeHead(400, { 'Content-Type': 'application/json' });
+                    res.end(JSON.stringify({ error: 'Some other bad request error' }));
+                } else if (serverBehavior === 'sparse-chunk-then-dies') {
+                    // Chunk 1 "succeeds" SPARSE (one vector for two inputs) — poisoning the accumulated
+                    // prefix — then the next request fails. The carry must refuse to decorate.
+                    if (requestCount === 1) {
+                        res.writeHead(200, { 'Content-Type': 'application/json' });
+                        res.end(JSON.stringify({data: [{index: 0, embedding: [100]}]}));
+                        return;
+                    }
+                    res.writeHead(400, { 'Content-Type': 'application/json' });
+                    res.end(JSON.stringify({ error: 'Some other bad request error' }));
                 } else if (serverBehavior === 'qos-priority') {
                     inFlightRequests++;
                     maxInFlightRequests = Math.max(maxInFlightRequests, inFlightRequests);
@@ -796,6 +817,44 @@ test.describe.serial('TextEmbeddingService #11393/#11402/#12487/#12509 — openA
 
         expect(hookCalls.length, 'the deferred hook still received the timeout').toBeGreaterThanOrEqual(1);
         expect(requestCount, 'queue-level abort removal alone keeps B at zero calls here').toBe(1);
+    });
+
+    test('a mid-batch provider failure carries the completed prefix on the ORIGINAL error (#17112)', async () => {
+        serverBehavior = 'chunk-succeeds-then-dies';
+        aiConfig.openAiCompatible.batchEmbeddingChunkSize = 2;
+        aiConfig.openAiCompatible.unloadRetryCount        = 0; // a non-retryable failure needs no ladder
+
+        const outcome = await TextEmbeddingService.embedTexts(['t0', 't1', 't2', 't3'], 'openAiCompatible')
+            .then(() => null, error => error);
+
+        // The original identity survives — the caller's timeout/circuit classification reads it.
+        expect(outcome).toBeInstanceOf(Error);
+        expect(outcome.message).toContain('Some other bad request error');
+
+        // The carry contract: derived from what was SENT (1 completed chunk × width 2), vectors in
+        // input order. Discarding these is what re-purchased completed provider work on every retry.
+        expect(outcome.completedChunkCount).toBe(1);
+        expect(outcome.totalChunkCount).toBe(2);
+        expect(outcome.completedTextCount).toBe(2);
+        expect(outcome.embeddings).toEqual([[100], [101]]);
+    });
+
+    test('a prefix that cannot prove positional binding leaves the failure UNCARRIED (#17112)', async () => {
+        serverBehavior = 'sparse-chunk-then-dies';
+        aiConfig.openAiCompatible.batchEmbeddingChunkSize = 2;
+        aiConfig.openAiCompatible.unloadRetryCount        = 0;
+
+        const outcome = await TextEmbeddingService.embedTexts(['t0', 't1', 't2', 't3'], 'openAiCompatible')
+            .then(() => null, error => error);
+
+        // The sparse chunk-1 response (one vector for two inputs) means the accumulated data cannot
+        // satisfy the positional-binding guard. Decorating anyway would hand the consumer a payload
+        // it will slice onto wrong ids; the failure must travel with the original identity and
+        // NO carry fields.
+        expect(outcome).toBeInstanceOf(Error);
+        expect(outcome.message).toContain('Some other bad request error');
+        expect(outcome.completedTextCount).toBeUndefined();
+        expect(outcome.embeddings).toBeUndefined();
     });
 
     test('batch embeddings split large requests into yieldable chunks and preserve global ordering', async () => {


### PR DESCRIPTION
Resolves neomjs/neo#17112

Related: neomjs/neo-agent-brain#38
Related: neomjs/neo#16972

Extends work conservation from the yield path to the FAILURE path of batch embedding. The yield arm already carried and persisted its completed prefix; a provider failure mid-batch discarded it — the timeout arm ended the sweep with completed vectors unpersisted, and the retry arm re-ran the whole batch. On a slow lane that composes into the observed zero-progress loop: completed provider work thrown away above the provider, re-selected by the next sweep, re-computed at full compute, forever.

Two changes, one contract:

1. **Producer** (`TextEmbeddingService.#embedOpenAiCompatibleBatch`): a mid-batch provider failure now decorates the ORIGINAL error with the same carry fields the yield error declares (`completedChunkCount`, `totalChunkCount`, `completedTextCount`, `embeddings` via the shared `toOrderedEmbeddings` positional-binding guard). The original error identity (message + `code`) is preserved — it drives the caller's timeout/circuit classification. If the accumulated data cannot prove positional binding (sparse prior chunk), the failure travels UNCARRIED rather than carrying a payload that would slice onto wrong ids.
2. **Consumer** (`VectorService.embedChunks` catch): before the timeout classification ends the sweep and before the retry arm re-runs, a carried prefix is persisted under the yield arm's exact refuse-loudly guard (payload length must equal the stated completed count), and the batch shrinks to the un-persisted remainder so a retry buys only what is missing. The timeout arm still ends the sweep — a timeout means OUR wait ended, not the provider's work — but what completed is now durable, so the next sweep's re-selection excludes it.

Evidence: L2 (producer arms through the retry spec's REAL local HTTP provider — chunk 1 succeeds, chunk 2 dies, thrown error carries the validated prefix with original identity; sparse-prior-chunk leaves the failure uncarried; consumer arms through the spy-collection harness — timeout-class carried failure persists-then-ends-sweep under the right ids, retryable carried failure retries ONLY the 40-input remainder with `receivedTextCounts` = [50, 40], disagreeing payload refused with zero writes, uncarried timeout unchanged) → L2 required (the discard was a unit-boundary defect between the two services; both seams are exercised with real collaborator contracts on each side).

## Deltas from ticket

- AC-1 shipped as exit-boundary work conservation rather than literal per-chunk upsert: completed prefixes persist at every non-crash exit of the embed call (success, yield, failure, timeout) via the carry contract, instead of coupling `VectorService` to the provider's internal chunking with a per-chunk callback. The observable contract the AC names — a successfully embedded chunk is never re-purchased; a mid-slice failure preserves prior successes — is met and spec-proven (the `[50, 40]` retry arm and the persist-before-sweep-end arm). Process-crash residue (completed chunks lost if the process dies mid-slice) is out of scope: the pathology was failure-path discard, not crash loss.
- AC-4 (`NEO_KB_EMBEDDING_BATCH_SIZE=1` as deployment-side containment) needs no code: the leaf exists and is projected; the deployment MR owns setting it.
- The success-path log line now reports guardrail-skipped counts from a value captured before any failure-carry shrink, so persisted-carried work is never reported as "skipped".

## Test Evidence

*(All verdicts read from the runner's exit code, never a tail slice.)*

- `npx playwright test test/playwright/unit/ai/services/knowledge-base/VectorService.failureCarry.spec.mjs test/playwright/unit/ai/services/memory-core/TextEmbeddingService.retry.spec.mjs --workers=1` — **exit 0, 43 passed** (includes the 6 new arms).
- Full importer sweep (every spec importing `TextEmbeddingService` or `VectorService`, 39 files, `--workers=1`) launched and running at PR-open time; its exit-code verdict lands as a PR comment when it completes. PR CI runs the full unit suite regardless.
- Producer arms run against the spec file's REAL local HTTP server (no transport mocks); consumer arms use the established spy-collection + stubbed-embedder harness of the sibling yield specs, with self-naming vectors so positional slides cannot pass.
- Pre-commit gate battery passed (whitespace, shorthand, aiconfig-test-mutation, jsdoc-types, derived-domain, ticket-archaeology, block-alignment).

## Post-Merge Validation

On the next constrained-plane revision advance: the tenant-sync sweep following a provider-phase timeout must show a persisted prefix (corpus count strictly greater than before the sweep) instead of a constant count — the exact signature this repairs.

## Evolution

The yield arm's carry contract (`completedTextCount` + validated `embeddings`) turned out to be the whole design: the failure path needed no new machinery, only the same contract honored on a second exit. The refuse-loudly guard and self-naming-vector fixtures came straight from the sibling specs — the hardening pattern transfers unchanged.

Authored by Vega (Claude Fable 5, Claude Code). Session d697d846-508f-47c2-a928-95610fac1cdd.
