### PR TITLE
fix(ai): honor caller-owned embedding probe deadlines (#17111)

### DIFF
--- a/ai/services/memory-core/TextEmbeddingService.mjs
+++ b/ai/services/memory-core/TextEmbeddingService.mjs
@@ -237,6 +237,7 @@ function normalizeEmbeddingOptions(options, defaultOperationLabel) {
     }
 
     const allowedKeys = [
+        'deadlineMs',
         'operationLabel',
         'operationStage',
         'onProviderTimeout',
@@ -256,6 +257,12 @@ function normalizeEmbeddingOptions(options, defaultOperationLabel) {
         typeof options.signal?.removeEventListener !== 'function'
     )) {
         throw new TypeError('TextEmbeddingService: options.signal must be an AbortSignal');
+    }
+    if (options.deadlineMs !== undefined && (!Number.isFinite(options.deadlineMs) || options.deadlineMs <= 0)) {
+        throw new TypeError('TextEmbeddingService: options.deadlineMs must be a positive number');
+    }
+    if (options.deadlineMs !== undefined && options.signal === undefined) {
+        throw new TypeError('TextEmbeddingService: options.deadlineMs requires options.signal');
     }
     if (options.operationLabel !== undefined && typeof options.operationLabel !== 'string') {
         throw new TypeError('TextEmbeddingService: options.operationLabel must be a string');
@@ -279,6 +286,7 @@ function normalizeEmbeddingOptions(options, defaultOperationLabel) {
     const requestedLabel = options.operationLabel?.trim() || defaultOperationLabel;
 
     return {
+        deadlineMs              : options.deadlineMs,
         operationLabel          : requestedLabel.substring(0, EMBEDDING_OPERATION_LABEL_MAX_LENGTH),
         operationStage          : options.operationStage || 'unknown',
         onProviderTimeout       : options.onProviderTimeout,
@@ -1864,11 +1872,16 @@ class TextEmbeddingService extends Base {
      *
      * The OpenAI-compatible branch uses the contention retry budget because single embeddings are
      * latency-sensitive (`add_memory`, query, frontier) and must fail/retry inside the service before
-     * the MCP request envelope times out.
+     * the MCP request envelope times out. A caller that supplies `deadlineMs` alongside its abort
+     * signal owns the aggregate deadline instead: that call receives one timed contention attempt
+     * whose socket timeout matches the caller budget, so a shorter fixed contention ladder cannot
+     * silently replace the declared deadline or multiply abandoned work. Model-residency failures
+     * retain their separate bounded retry semantics.
      *
      * @param {String} text The text to embed.
      * @param {String} explicitProvider The embedding provider to use.
      * @param {Object} [options={}] Abort/diagnostic options.
+     * @param {Number} [options.deadlineMs] Caller-owned whole-call deadline carried by `options.signal`.
      * @param {AbortSignal} [options.signal] Caller-owned cancellation signal.
      * @param {String} [options.operationLabel] Bounded diagnostic label.
      * @param {String} [options.operationStage='unknown'] Stable low-cardinality stage.
@@ -1884,6 +1897,7 @@ class TextEmbeddingService extends Base {
                   ? 'TextEmbeddingService.embedText native Ollama embedding'
                   : `TextEmbeddingService.embedText ${explicitProvider} embedding`,
               {
+                  deadlineMs,
                   operationLabel,
                   operationStage,
                   onProviderTimeout,
@@ -1910,11 +1924,12 @@ class TextEmbeddingService extends Base {
                     contentionRetryCount      = 2,
                     contentionTimeoutMs       = 15000
                 } = aiConfig.openAiCompatible;
-                const requestText = await this.#prepareOpenAiCompatibleEmbeddingInput(text, signal, operationLabel, operation);
-                const result      = await this.#enqueueOpenAiCompatiblePost(requestText, {
+                const requestText       = await this.#prepareOpenAiCompatibleEmbeddingInput(text, signal, operationLabel, operation);
+                const hasCallerDeadline = deadlineMs !== undefined;
+                const result            = await this.#enqueueOpenAiCompatiblePost(requestText, {
                     unloadRetriesLeft    : unloadRetryCount,
-                    contentionRetriesLeft: contentionRetryCount,
-                    requestTimeoutMs     : contentionTimeoutMs,
+                    contentionRetriesLeft: hasCallerDeadline ? 0 : contentionRetryCount,
+                    requestTimeoutMs     : hasCallerDeadline ? deadlineMs : contentionTimeoutMs,
                     signal,
                     operationLabel,
                     onProviderTimeout,

--- a/ai/services/shared/embeddingProbe.mjs
+++ b/ai/services/shared/embeddingProbe.mjs
@@ -68,7 +68,9 @@ export function describeEmbeddingProbeFailure(error) {
  *
  * This module owns only the attempt boundary: deadline, abort propagation, dimension validation,
  * and bounded failure classification. Consumers own provider/config selection, scheduling,
- * backoff, and the policy that maps observations into their public health envelope.
+ * backoff, and the policy that maps observations into their public health envelope. The numeric
+ * deadline travels beside the signal so provider clients cannot substitute a shorter aggregate
+ * retry horizon; the signal remains the whole-call cancellation authority.
  *
  * @param {Object} options
  * @param {Object} options.cfg Provider config carrying `embeddingProvider` and `vectorDimension`.
@@ -120,7 +122,8 @@ export async function buildEmbeddingProbeBlock({
               }),
               embedding    = await Promise.race([
                   Promise.resolve(embedText(input, provider, {
-                      signal: controller.signal,
+                      deadlineMs: timeoutMs,
+                      signal    : controller.signal,
                       operationLabel
                   })),
                   deadline

--- a/test/playwright/unit/ai/services/knowledge-base/HealthService.providerReady.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/HealthService.providerReady.spec.mjs
@@ -378,9 +378,11 @@ test.describe('Neo.ai.services.knowledge-base.HealthService observed embedding r
             errorCode          : 'EMBEDDING_PROBE_TIMEOUT'
         });
         expect(observedOptions).toMatchObject({
+            deadlineMs    : 5,
             operationStage: 'embedding-canary',
             service       : 'knowledge-base'
         });
+        expect(observedOptions.signal).toBeInstanceOf(AbortSignal);
     });
 
     test('public receipts distinguish transport refusal and a non-resident embedding model', async () => {

--- a/test/playwright/unit/ai/services/memory-core/HealthService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/HealthService.spec.mjs
@@ -1680,6 +1680,7 @@ test.describe('HealthService #12487 — buildEmbeddingWriteCanaryBlock', () => {
             embedText: async (input, provider, options) => {
                 expect(input).toBe('neo-healthcheck-embedding-write-canary');
                 expect(provider).toBe('openAiCompatible');
+                expect(options.deadlineMs).toBe(10);
                 expect(options.operationLabel).toBe('Embedding write canary');
                 expect(options.operationStage).toBe('embedding-canary');
                 expect(options.service).toBe('memory-core');

--- a/test/playwright/unit/ai/services/memory-core/TextEmbeddingService.retry.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/TextEmbeddingService.retry.spec.mjs
@@ -13,14 +13,15 @@ setup({
     }
 });
 
-import {test, expect} from '@playwright/test';
-import Neo            from '../../../../../../src/Neo.mjs';
-import * as core      from '../../../../../../src/core/_export.mjs';
-import fs             from 'fs';
-import http           from 'http';
-import os             from 'os';
-import path           from 'path';
-import aiConfig       from '../../../../../../ai/mcp/server/memory-core/config.template.mjs';
+import {test, expect}             from '@playwright/test';
+import Neo                        from '../../../../../../src/Neo.mjs';
+import * as core                  from '../../../../../../src/core/_export.mjs';
+import fs                         from 'fs';
+import http                       from 'http';
+import os                         from 'os';
+import path                       from 'path';
+import aiConfig                   from '../../../../../../ai/mcp/server/memory-core/config.template.mjs';
+import {buildEmbeddingProbeBlock} from '../../../../../../ai/services/shared/embeddingProbe.mjs';
 import {
     clearLmsEmbeddingInputSuffixCache,
     readGgufTokenizerMetadata,
@@ -192,6 +193,11 @@ test.describe.serial('TextEmbeddingService #11393/#11402/#12487/#12509 — openA
                     res.end(JSON.stringify({ data: [{ embedding: [1.4, 1.5, 1.6] }] }));
                 } else if (serverBehavior === 'timeout-all') {
                     return;
+                } else if (serverBehavior === 'delayed-single-succeed') {
+                    setTimeout(() => {
+                        res.writeHead(200, { 'Content-Type': 'application/json' });
+                        res.end(JSON.stringify({ data: [{ embedding: [1.4, 1.5, 1.6] }] }));
+                    }, 100);
                 } else if (serverBehavior === 'http-timeout-then-succeed') {
                     if (requestCount === 1) {
                         res.writeHead(503, { 'Content-Type': 'application/json' });
@@ -647,6 +653,117 @@ test.describe.serial('TextEmbeddingService #11393/#11402/#12487/#12509 — openA
 
         // Initial request + 1 contention retry = 2 total requests
         expect(requestCount).toBe(2);
+    });
+
+    test('a caller-owned probe deadline outlives the shorter contention ladder with one dispatch (#17111)', async () => {
+        serverBehavior = 'delayed-single-succeed';
+        aiConfig.openAiCompatible.contentionTimeoutMs       = 20;
+        aiConfig.openAiCompatible.contentionRetryCount      = 2;
+        aiConfig.openAiCompatible.contentionRetryDelayMs    = 10;
+
+        const startedAt = Date.now();
+        const result    = await buildEmbeddingProbeBlock({
+            cfg: {
+                embeddingProvider: 'openAiCompatible',
+                vectorDimension  : 3
+            },
+            embedText     : TextEmbeddingService.embedText.bind(TextEmbeddingService),
+            input         : 'deadline-owned-probe',
+            operationLabel: 'Deadline-owned embedding probe',
+            timeoutMs     : 200
+        });
+
+        expect(result).toMatchObject({
+            status    : 'healthy',
+            provider  : 'openAiCompatible',
+            dimensions: 3
+        });
+        expect(Date.now() - startedAt, 'the request remained alive beyond the old 80ms aggregate ladder')
+            .toBeGreaterThanOrEqual(85);
+        expect(requestCount, 'the caller deadline must not be converted into repeated provider aborts').toBe(1);
+    });
+
+    test('a caller deadline expires in the queue without dispatching behind active provider work (#17111)', async () => {
+        serverBehavior = 'delayed-single-succeed';
+        aiConfig.openAiCompatible.contentionTimeoutMs    = 250;
+        aiConfig.openAiCompatible.contentionRetryCount   = 0;
+
+        const laneHolder = TextEmbeddingService.embedText('active-provider-work', 'openAiCompatible');
+
+        await waitForCondition(() => requestCount === 1, 'the first request to hold the provider lane');
+
+        const result = await buildEmbeddingProbeBlock({
+            cfg: {
+                embeddingProvider: 'openAiCompatible',
+                vectorDimension  : 3
+            },
+            embedText     : TextEmbeddingService.embedText.bind(TextEmbeddingService),
+            input         : 'queued-deadline-probe',
+            operationLabel: 'Queued deadline embedding probe',
+            timeoutMs     : 40
+        });
+
+        expect(result).toMatchObject({
+            status             : 'failed',
+            errorClassification: 'consumer-probe-timeout',
+            errorCode          : 'EMBEDDING_PROBE_TIMEOUT'
+        });
+        expect(requestCount, 'the queued probe must make zero provider calls').toBe(1);
+
+        await expect(laneHolder).resolves.toEqual([1.4, 1.5, 1.6]);
+        await new Promise(resolve => setTimeout(resolve, 25));
+
+        expect(requestCount, 'releasing the lane must not dispatch the already-aborted probe').toBe(1);
+    });
+
+    test('a caller deadline shorter than one contention attempt aborts once with no post-abort retry (#17111)', async () => {
+        serverBehavior = 'timeout-all';
+        aiConfig.openAiCompatible.contentionTimeoutMs    = 100;
+        aiConfig.openAiCompatible.contentionRetryCount   = 2;
+        aiConfig.openAiCompatible.contentionRetryDelayMs = 25;
+
+        const result = await buildEmbeddingProbeBlock({
+            cfg: {
+                embeddingProvider: 'openAiCompatible',
+                vectorDimension  : 3
+            },
+            embedText     : TextEmbeddingService.embedText.bind(TextEmbeddingService),
+            input         : 'deadline-aborted-probe',
+            operationLabel: 'Deadline-aborted embedding probe',
+            timeoutMs     : 40
+        });
+
+        expect(result).toMatchObject({
+            status             : 'failed',
+            errorClassification: 'consumer-probe-timeout',
+            errorCode          : 'EMBEDDING_PROBE_TIMEOUT'
+        });
+        expect(requestCount).toBe(1);
+
+        await new Promise(resolve => setTimeout(resolve, 75));
+        expect(requestCount, 'no retry may dispatch after the caller aborted the aggregate operation').toBe(1);
+    });
+
+    test('a deadline-bearing probe preserves an immediate terminal provider failure', async () => {
+        serverBehavior = 'fail-other';
+
+        const result = await buildEmbeddingProbeBlock({
+            cfg: {
+                embeddingProvider: 'openAiCompatible',
+                vectorDimension  : 3
+            },
+            embedText     : TextEmbeddingService.embedText.bind(TextEmbeddingService),
+            input         : 'terminal-failure-probe',
+            operationLabel: 'Terminal failure embedding probe',
+            timeoutMs     : 200
+        });
+
+        expect(result).toMatchObject({
+            status             : 'failed',
+            errorClassification: 'provider-failure',
+            errorCode          : 'EMBEDDING_PROVIDER_ERROR'
+        });
+        expect(requestCount).toBe(1);
     });
 
     test('HTTP contention status single embedding retries and succeeds', async () => {


### PR DESCRIPTION
Resolves neomjs/neo#17111

Related: neomjs/neo-agent-brain#38
Related: neomjs/neo#17115

The KB and MC embedding canaries declared caller-owned deadlines, but `TextEmbeddingService.embedText()` replaced them with a fixed 15s × 3 contention ladder. On a saturated serialized lane, one logical probe therefore became three abandoned provider attempts and failed after roughly 47 seconds even when its caller had declared a much longer budget.

This PR restores one deadline authority:

1. `buildEmbeddingProbeBlock()` now carries the numeric deadline beside its existing whole-call `AbortSignal`.
2. A deadline-bearing OpenAI-compatible single embed gets one timed contention dispatch. The outer signal remains authoritative across preflight, queue wait, and the active socket, so queue time cannot restart or extend the caller budget.
3. Ordinary interactive single embeds with no caller deadline retain the existing bounded contention retry ladder. Model-residency retries remain separately bounded.
4. KB and MC production-owner specs pin both the deadline magnitude and abort signal; the transport spec pins immediate dispatch, queued expiry, terminal fail-fast, and the legacy no-deadline control.

Evidence: L2 (production probe wrapper through the real TextEmbeddingService queue and a real local HTTP transport) → L4 required (constrained-plane canary settlement and durable-ingestion acceptance). Residual: live provider-settlement and durable-ingestion validation, Residual-Owner: neomjs/neo-agent-brain#38.

## Deltas from ticket

- The ticket contract now distinguishes aggregate deadline authority from terminal fail-fast behavior. Persistent retryable contention must not preempt the caller deadline; a definitive provider error still returns immediately.
- Configuration projection is explicitly owned by neomjs/neo#17115 and was removed from this runtime ticket's close conditions. This PR adds no config leaf or deployment override.
- Deadline-bearing probes use one contention attempt instead of deriving a larger retry count from a longer deadline. This prevents a longer health budget from manufacturing more abandoned provider work.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/ai/services/memory-core/TextEmbeddingService.retry.spec.mjs test/playwright/unit/ai/services/knowledge-base/HealthService.providerReady.spec.mjs test/playwright/unit/ai/services/memory-core/HealthService.spec.mjs` — **175 passed**.
- The long-deadline arm survives beyond the former 20ms × 3 ladder and completes with exactly one provider dispatch.
- The queue-wait arm holds one provider request active, expires the probe behind it, releases the lane, and still observes exactly one total provider request.
- The short-deadline arm returns the caller-owned `EMBEDDING_PROBE_TIMEOUT` and proves no retry dispatch appears after abort.
- The terminal-failure arm returns immediately with the original provider classification; existing tests retain the bounded no-deadline retry behavior.
- Pre-commit gates passed: whitespace, shorthand, AiConfig mutation, JSDoc types, derived-domain, ticket archaeology, block alignment, and parse.

## Post-Merge Validation

Residual-Owner: neomjs/neo-agent-brain#38

- [ ] On the constrained provider plane, a deadline-bearing canary emits at most one provider attempt rather than the former three-attempt ~47s ladder.
- [ ] A canary queued behind active work either completes within its caller budget or expires without adding provider work.
- [ ] The neomjs/neo-agent-brain#38 deployment acceptance shows durable repository progress and CPU returning to idle after bounded work.

## Evolution

The abort signal already covered the entire operation. The missing datum was the deadline magnitude at the provider client boundary. Carrying that one value removes the hidden aggregate ladder without adding another scheduler, retry policy, config leaf, or recovery loop.

Authored by Emmy (GPT-5.6 Sol Ultra, Codex). Session 019fe0b3-53bc-7ef2-8665-41a0ef3f7b62.
