### PR TITLE
feat(ai): leaf the retry backoff base and require fixed waits to name what they wait for (#17124)

### DIFF
--- a/.github/workflows/fixed-sleep-lint.yml
+++ b/.github/workflows/fixed-sleep-lint.yml
@@ -39,6 +39,17 @@ jobs:
         with:
           node-version: '24'
 
-      # No install: the guard reads files and matches one regex. Nothing to resolve.
+      # The comment that used to sit here said "No install: the guard reads files and matches one
+      # regex. Nothing to resolve." It was true, it stopped being true the moment discovery moved to
+      # the parse tree, and it named its own assumption plainly enough that it should have been the
+      # tripwire rather than the failure. A workflow that states WHY it skips a step has to be re-read
+      # whenever that reason changes — @neo-gpt caught this one on re-review.
+      #
+      # Install cost is not mergeable wall-clock, and `test.yml` already runs `npm ci`, so registry
+      # flakiness was priced into the merge gate long before this leg joined. Same shape as
+      # `aiconfig-antipattern-lint.yml`, which resolves acorn for the same reason.
+      - name: Install dependencies (acorn — the guard's parser)
+        run: npm ci --ignore-scripts
+
       - name: Require fixed second-scale waits to name what they wait for
         run: node ./buildScripts/util/check-fixed-sleeps.mjs

--- a/.github/workflows/fixed-sleep-lint.yml
+++ b/.github/workflows/fixed-sleep-lint.yml
@@ -1,0 +1,44 @@
+name: Fixed Sleep Lint
+
+# CI mirror of the `.husky/pre-commit` guard, so `git commit --no-verify` cannot bypass it.
+
+on:
+  pull_request:
+    branches: [dev]
+    paths:
+      # The invariant is scanned ⊆ watched. The guard walks every unit spec, so every unit spec must
+      # re-run it; a filter narrower than the scan lets the introducing PR land ungated and turns the
+      # NEXT unrelated run red — late, misattributed enforcement.
+      - 'test/playwright/unit/**/*.mjs'
+      # The baseline is an INPUT to the verdict, so editing it must re-run the check. Otherwise a site
+      # can be blessed by editing the record of what exists, with nothing re-reading reality.
+      - 'buildScripts/util/check-fixed-sleeps-baseline.json'
+      - 'buildScripts/util/check-fixed-sleeps.mjs'
+      - '.github/workflows/fixed-sleep-lint.yml'
+  push:
+    branches: [dev]
+    paths:
+      - 'test/playwright/unit/**/*.mjs'
+      - 'buildScripts/util/check-fixed-sleeps-baseline.json'
+      - 'buildScripts/util/check-fixed-sleeps.mjs'
+      - '.github/workflows/fixed-sleep-lint.yml'
+
+concurrency:
+  group: fixed-sleep-lint-${{ github.run_attempt == '1' && github.ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+
+      # No install: the guard reads files and matches one regex. Nothing to resolve.
+      - name: Require fixed second-scale waits to name what they wait for
+        run: node ./buildScripts/util/check-fixed-sleeps.mjs

--- a/ai/mcp/server/knowledge-base/configBase.mjs
+++ b/ai/mcp/server/knowledge-base/configBase.mjs
@@ -741,11 +741,19 @@ class ConfigBase extends ConfigProvider {
              * hides the retry depth actually shipping. Test contexts pin this to `1` through the env
              * layer, so timing-independent assertions cost nothing and keep the real retry count.
              *
-             * Sibling of `memoryWal.backoffBaseMs` / `messageWal.backoffBaseMs`, same default and
-             * same role, so the three read alike.
+             * The domain is the delay one, not the loose numeric one. A base multiplies out as
+             * `base * 2 ** n`, so a negative value inverts the ladder into scheduling in the past and
+             * a fractional one produces sub-millisecond timers the runtime rounds unpredictably.
+             * `nonNegativeInt` exists for exactly this case and keeps zero legitimate — retry with no
+             * delay — and `batchDelay` above already uses it.
+             *
+             * `memoryWal.backoffBaseMs` and `messageWal.backoffBaseMs` spell the same role as
+             * `'number'`. Matching them would have been consistency with a defect rather than with a
+             * convention, which is precisely how a wrong shape spreads by adjacency: the next site
+             * copies whichever neighbour it lands nearest.
              * @type {number}
              */
-            backoffBaseMs: leaf(1000, 'NEO_KB_EMBEDDING_BACKOFF_BASE_MS', 'number'),
+            backoffBaseMs: leaf(1000, 'NEO_KB_EMBEDDING_BACKOFF_BASE_MS', 'nonNegativeInt'),
             /**
              * The number of results to fetch from ChromaDB for a query.
              * @type {number}

--- a/ai/mcp/server/knowledge-base/configBase.mjs
+++ b/ai/mcp/server/knowledge-base/configBase.mjs
@@ -728,6 +728,25 @@ class ConfigBase extends ConfigProvider {
              */
             undeliverableTimeoutStrikes: leaf(2, 'NEO_KB_EMBEDDING_UNDELIVERABLE_TIMEOUT_STRIKES', 'positiveInt'),
             /**
+             * Base delay for the embedding retry's exponential backoff, in milliseconds.
+             *
+             * The delay for retry `n` is `backoffBaseMs * 2 ** n`, so the base multiplies out fast:
+             * at `1000` a `maxRetries: 5` run sleeps 2s + 4s + 8s + 16s = 30s of pure waiting on top
+             * of the provider time it is already paying.
+             *
+             * It is a leaf rather than a literal for one concrete reason: it was hardcoded, so every
+             * spec that exercised a retry paid the production delay in real wall-clock. Tests then
+             * worked around the symptom — the leaseYield spec shrank `maxRetries` because a
+             * five-retry mutation run exhausted its timeout — which trades coverage for seconds and
+             * hides the retry depth actually shipping. Test contexts pin this to `1` through the env
+             * layer, so timing-independent assertions cost nothing and keep the real retry count.
+             *
+             * Sibling of `memoryWal.backoffBaseMs` / `messageWal.backoffBaseMs`, same default and
+             * same role, so the three read alike.
+             * @type {number}
+             */
+            backoffBaseMs: leaf(1000, 'NEO_KB_EMBEDDING_BACKOFF_BASE_MS', 'number'),
+            /**
              * The number of results to fetch from ChromaDB for a query.
              * @type {number}
              */

--- a/ai/scripts/lint/config-leaf-parity.json
+++ b/ai/scripts/lint/config-leaf-parity.json
@@ -574,6 +574,7 @@
         "askSynthesis.timeoutMs",
         "askSynthesis.timeoutMsRemote",
         "authMiddleware",
+        "backoffBaseMs",
         "batchDelay",
         "batchSize",
         "chromaDatabaseProd",

--- a/ai/scripts/lint/retry-bound-registry.json
+++ b/ai/scripts/lint/retry-bound-registry.json
@@ -20,20 +20,129 @@
         "regenerate": "node ai/scripts/lint/lint-retry-bounds.mjs --list"
     },
     "sites": {
+        "ai/agent/Loop.mjs#processEvent:e3df926d": {
+            "kind": "retry-growth",
+            "lifetime": "process-local",
+            "boundCarrier": "max-attempts",
+            "witness": "`retryCount < this.maxRetries` guard at ai/agent/Loop.mjs#processEvent; `maxRetries: 3` config member",
+            "note": "Recursive retry; the guard is the bound, the delay is uncapped by design (1s/2s/4s then stop)."
+        },
+        "ai/daemons/embed/drainCycle.mjs#getBackoffDelayMs:c791d8f6": {
+            "kind": "retry-growth",
+            "lifetime": "persisted",
+            "boundCarrier": "max-delay",
+            "witness": "`MAX_RECORD_COOLDOWN_MS` clamp in the same expression; test/playwright/unit/ai/daemons/embed/drainCycle.spec.mjs",
+            "note": "Per-record attempt persists across cycles in retryState, so a delay cap is required — an attempt budget would not bound wall-clock."
+        },
+        "ai/daemons/message/drainCycle.mjs#getMessageDrainBackoffDelayMs:39b52338": {
+            "kind": "retry-growth",
+            "lifetime": "in-cycle",
+            "boundCarrier": "max-attempts",
+            "witness": "caller loop `for (let attempt = 0; attempt <= maxRetries; attempt++)` at ai/daemons/message/drainCycle.mjs#processMessageBatch",
+            "note": "Returns a RAW exponential and is indistinguishable from a defect at the growth site; the bound is the caller. This is the case that defeats any returned-vs-consumed heuristic."
+        },
+        "ai/daemons/orchestrator/scheduling/tenantRepoSync.mjs#isRepoDue:6475b546": {
+            "kind": "retry-growth",
+            "lifetime": "persisted",
+            "boundCarrier": "max-delay",
+            "witness": "`backoffCapMs` leaf (ai/configBase.mjs orchestrator.tenantRepoSync); test/playwright/unit/ai/daemons/orchestrator/scheduling/tenantRepoSync.spec.mjs",
+            "note": "consecutiveFailures persists in the orchestrator state volume and survives restart; uncapped it stranded a deployment ~128h (#16224)."
+        },
+        "ai/daemons/orchestrator/services/RecoveryActuatorService.mjs#computeBackoffUntil:2cfb36dc": {
+            "kind": "retry-growth",
+            "lifetime": "persisted",
+            "boundCarrier": "max-delay",
+            "witness": "`Math.min(maxBackoffMs, ...)` in the same expression",
+            "note": "Heal-attempt backoff; cap is co-located with the growth."
+        },
         "ai/scripts/benchmark/setupClass-cold-start.mjs#roundMetric:1a518c5e": {
             "kind": "not-a-retry",
             "witness": "`10 ** decimals` is decimal-place rounding: the exponent is a formatting precision argument, not an attempt counter. No loop encloses it.",
             "note": "Classified because every growth expression is gated, not because it was suspected."
+        },
+        "ai/services/fleet/fleetWakeSseConsumer.mjs#runLoop:5f68f770": {
+            "kind": "retry-growth",
+            "lifetime": "process-local",
+            "boundCarrier": "max-delay",
+            "witness": "`Math.min(..., MAX_BACKOFF_MS)` caps the exponential reconnect delay at 60s, and the loop exits terminally on `stopped` or an epoch change (`stop()` bumps the epoch) — the spec `fleetWakeSseConsumer.spec.mjs` drives a drop→reconnect cycle on the injected floor and `stop()` ends the loop."
+        },
+        "ai/services/github-workflow/GraphqlService.mjs##getRetryDelay:626883e2": {
+            "kind": "retry-growth",
+            "lifetime": "process-local",
+            "boundCarrier": "max-delay",
+            "witness": "`Math.min(this.retryMaxDelayMs, ...)` in the same expression",
+            "note": "GitHub GraphQL transport retry."
+        },
+        "ai/services/gitlab-workflow/GitLabClient.mjs##getRetryDelay:626883e2": {
+            "kind": "retry-growth",
+            "lifetime": "process-local",
+            "boundCarrier": "max-delay",
+            "witness": "`Math.min(this.retryMaxDelayMs, ...)` in the same expression",
+            "note": "GitLab transport retry; mirrors GraphqlService."
+        },
+        "ai/services/knowledge-base/ChromaManager.mjs##getCollectionResolveRetryDelay:247f4675": {
+            "kind": "retry-growth",
+            "lifetime": "process-local",
+            "boundCarrier": "max-window",
+            "witness": "`retry.maxTotalDelayMs - totalDelayMs` remaining-budget clamp in #getCollectionResolveRetryDelay",
+            "note": "The only max-window instance: bounded by TOTAL delay spent, not by a per-delay cap alone (it also carries maxDelayMs)."
+        },
+        "ai/services/knowledge-base/VectorService.mjs#persistCarriedPrefix:a17aac7c": {
+            "kind": "retry-growth",
+            "lifetime": "in-cycle",
+            "boundCarrier": "max-attempts",
+            "witness": "`retries++` precedes the sleep and `if (retries >= maxRetries) throw writeError` exits before the delay can run again; the write retries spend the surrounding batch's shared `maxRetries` budget",
+            "note": "Carried-prefix WRITE retry shared by the yield AND failure arms (persistCarriedPrefix): vectors already in hand retry the upsert only — never the provider — and budget exhaustion rethrows the storage error so the sweep ends loudly. The backoff BASE is now the kb.backoffBaseMs leaf rather than a hardcoded 1000, so a test context pins it; the bound is unchanged because the base scales the delay and never the attempt count."
+        },
+        "ai/services/knowledge-base/VectorService.mjs#persistCarriedPrefix:a17aac7c#1": {
+            "kind": "retry-growth",
+            "lifetime": "in-cycle",
+            "boundCarrier": "max-attempts",
+            "witness": "`retries < maxRetries` bounds non-timeout failures; timeout-class provider failures throw after their first provider offer",
+            "note": "Embedding batch retry inside one pass. A provider timeout terminates the whole sweep so the outer scheduler, not this exponential ladder, owns the later attempt. The backoff BASE is now the kb.backoffBaseMs leaf rather than a hardcoded 1000, so a test context pins it; the bound is unchanged because the base scales the delay and never the attempt count."
+        },
+        "ai/services/memory-core/MemoryService.mjs#_scheduleMemoryGraphProjection:f2eb13d7": {
+            "kind": "retry-growth",
+            "lifetime": "process-local",
+            "boundCarrier": "max-delay",
+            "witness": "`Math.min(..., aiConfig.memoryService.graphProjectionRetryMaxMs)` in the same expression"
+        },
+        "ai/services/memory-core/WebhookDeliveryService.mjs#deliver:f7f23e9f": {
+            "kind": "retry-growth",
+            "lifetime": "in-cycle",
+            "boundCarrier": "max-attempts",
+            "witness": "`attempt <= maxRetries` guard in the same loop",
+            "note": "Multiplicative mutation (`backoff *= 2`) — the syntax family a base-2 exponent census misses entirely."
+        },
+        "ai/services/memory-core/helpers/freezeReprobeDecision.mjs#decideFreezeReprobe:5b01edc6": {
+            "kind": "retry-growth",
+            "lifetime": "persisted",
+            "boundCarrier": "terminal-state",
+            "witness": "`attempts >= maxUnfreezeAttempts` => status `contained` in the same function; test/playwright/unit/ai/services/memory-core/helpers/freezeReprobeDecision.spec.mjs",
+            "note": "The delay value GROWS without a cap by design (anti-thrash widening); the series is bounded because a terminal state stops it. No delay-shaped check can see this bound."
+        },
+        "ai/services/memory-core/helpers/recoveryKnobRegistry.mjs#<module>:092bcbf7": {
+            "kind": "not-a-retry",
+            "witness": "`16 * 1024 ** 3` — the same GiB-to-bytes unit arithmetic for the band cap; literal exponent 3, module-load constant.",
+            "note": "Sibling of bf9ea77a; the two constants ARE the bound a growth curve would need, which is why they look adjacent to one."
         },
         "ai/services/memory-core/helpers/recoveryKnobRegistry.mjs#<module>:bf9ea77a": {
             "kind": "not-a-retry",
             "witness": "`8 * 1024 ** 3` is byte-unit arithmetic — GiB to bytes for the container-memory-ceiling knob's band floor. The exponent is the literal 3 (KiB→MiB→GiB), evaluated once at module load; no loop, no attempt series.",
             "note": "The band itself is the anti-thrash VALUE bound: growth terminates at the registry max by thrown violation, asserted in recoveryKnobRegistry.spec.mjs."
         },
-        "ai/services/memory-core/helpers/recoveryKnobRegistry.mjs#<module>:092bcbf7": {
-            "kind": "not-a-retry",
-            "witness": "`16 * 1024 ** 3` — the same GiB-to-bytes unit arithmetic for the band cap; literal exponent 3, module-load constant.",
-            "note": "Sibling of bf9ea77a; the two constants ARE the bound a growth curve would need, which is why they look adjacent to one."
+        "ai/services/shared/boundedRetryGate.mjs#settleFlight:e1ea3176": {
+            "kind": "retry-growth",
+            "lifetime": "process-local",
+            "boundCarrier": "max-delay",
+            "witness": "`Math.min(failureTtlMaxMs, ...)` in the same expression",
+            "note": "The shared flight gate; #16307 records why it is NOT the right mechanism for persisted cadence state."
+        },
+        "apps/devindex/services/GitHub.mjs##getRetryDelay:41482917": {
+            "kind": "retry-growth",
+            "lifetime": "process-local",
+            "boundCarrier": "max-delay",
+            "witness": "`Math.min(this.restRetryMaxDelayMs, ...)` applied twice (pre- and post-jitter)"
         },
         "apps/devindex/services/Spider.mjs#pickStrategy:af20cfdb": {
             "kind": "not-a-retry",
@@ -135,6 +244,13 @@
             "witness": "Second term of the same squared distance — `(pointY - center.y) ** 2`.",
             "note": "Represented separately for occurrence multiplicity."
         },
+        "src/data/connection/WebSocket.mjs#<module>:a5cd8f47": {
+            "kind": "retry-growth",
+            "lifetime": "process-local",
+            "boundCarrier": "max-delay",
+            "witness": "`Math.min(1000 * Math.pow(2, attempt - 1), 30000)` in the default backoffStrategy",
+            "note": "Body-side reconnect. One of three retry-growth sites outside ai/, alongside apps/devindex/services/GitHub.mjs and src/manager/DragCoordinator.mjs."
+        },
         "src/form/field/FileUpload.mjs#formatSize:38dbd980": {
             "kind": "not-a-retry",
             "witness": "`bytes / (1000 ** i)` converts to an SI magnitude; `i` is an index into the `sizes` unit array, bounded by that array's length.",
@@ -150,128 +266,12 @@
             "witness": "Second term of the same distance — `(y2 - y1) ** 2`.",
             "note": "Represented separately for occurrence multiplicity."
         },
-        "ai/agent/Loop.mjs#processEvent:e3df926d": {
-            "kind": "retry-growth",
-            "lifetime": "process-local",
-            "boundCarrier": "max-attempts",
-            "witness": "`retryCount < this.maxRetries` guard at ai/agent/Loop.mjs#processEvent; `maxRetries: 3` config member",
-            "note": "Recursive retry; the guard is the bound, the delay is uncapped by design (1s/2s/4s then stop)."
-        },
-        "ai/daemons/embed/drainCycle.mjs#getBackoffDelayMs:c791d8f6": {
-            "kind": "retry-growth",
-            "lifetime": "persisted",
-            "boundCarrier": "max-delay",
-            "witness": "`MAX_RECORD_COOLDOWN_MS` clamp in the same expression; test/playwright/unit/ai/daemons/embed/drainCycle.spec.mjs",
-            "note": "Per-record attempt persists across cycles in retryState, so a delay cap is required — an attempt budget would not bound wall-clock."
-        },
-        "ai/daemons/message/drainCycle.mjs#getMessageDrainBackoffDelayMs:39b52338": {
-            "kind": "retry-growth",
-            "lifetime": "in-cycle",
-            "boundCarrier": "max-attempts",
-            "witness": "caller loop `for (let attempt = 0; attempt <= maxRetries; attempt++)` at ai/daemons/message/drainCycle.mjs#processMessageBatch",
-            "note": "Returns a RAW exponential and is indistinguishable from a defect at the growth site; the bound is the caller. This is the case that defeats any returned-vs-consumed heuristic."
-        },
-        "ai/daemons/orchestrator/scheduling/tenantRepoSync.mjs#isRepoDue:6475b546": {
-            "kind": "retry-growth",
-            "lifetime": "persisted",
-            "boundCarrier": "max-delay",
-            "witness": "`backoffCapMs` leaf (ai/configBase.mjs orchestrator.tenantRepoSync); test/playwright/unit/ai/daemons/orchestrator/scheduling/tenantRepoSync.spec.mjs",
-            "note": "consecutiveFailures persists in the orchestrator state volume and survives restart; uncapped it stranded a deployment ~128h (#16224)."
-        },
-        "ai/daemons/orchestrator/services/RecoveryActuatorService.mjs#computeBackoffUntil:2cfb36dc": {
-            "kind": "retry-growth",
-            "lifetime": "persisted",
-            "boundCarrier": "max-delay",
-            "witness": "`Math.min(maxBackoffMs, ...)` in the same expression",
-            "note": "Heal-attempt backoff; cap is co-located with the growth."
-        },
-        "ai/services/github-workflow/GraphqlService.mjs##getRetryDelay:626883e2": {
-            "kind": "retry-growth",
-            "lifetime": "process-local",
-            "boundCarrier": "max-delay",
-            "witness": "`Math.min(this.retryMaxDelayMs, ...)` in the same expression",
-            "note": "GitHub GraphQL transport retry."
-        },
-        "ai/services/gitlab-workflow/GitLabClient.mjs##getRetryDelay:626883e2": {
-            "kind": "retry-growth",
-            "lifetime": "process-local",
-            "boundCarrier": "max-delay",
-            "witness": "`Math.min(this.retryMaxDelayMs, ...)` in the same expression",
-            "note": "GitLab transport retry; mirrors GraphqlService."
-        },
-        "ai/services/knowledge-base/ChromaManager.mjs##getCollectionResolveRetryDelay:247f4675": {
-            "kind": "retry-growth",
-            "lifetime": "process-local",
-            "boundCarrier": "max-window",
-            "witness": "`retry.maxTotalDelayMs - totalDelayMs` remaining-budget clamp in #getCollectionResolveRetryDelay",
-            "note": "The only max-window instance: bounded by TOTAL delay spent, not by a per-delay cap alone (it also carries maxDelayMs)."
-        },
-        "ai/services/knowledge-base/VectorService.mjs#persistCarriedPrefix:2603053b": {
-            "kind": "retry-growth",
-            "lifetime": "in-cycle",
-            "boundCarrier": "max-attempts",
-            "witness": "`retries < maxRetries` bounds non-timeout failures; timeout-class provider failures throw after their first provider offer",
-            "note": "Embedding batch retry inside one pass. A provider timeout terminates the whole sweep so the outer scheduler, not this exponential ladder, owns the later attempt."
-        },
-        "ai/services/knowledge-base/VectorService.mjs#persistCarriedPrefix:ca44af32": {
-            "kind": "retry-growth",
-            "lifetime": "in-cycle",
-            "boundCarrier": "max-attempts",
-            "witness": "`retries++` precedes the sleep and `if (retries >= maxRetries) throw writeError` exits before the delay can run again; the write retries spend the surrounding batch's shared `maxRetries` budget",
-            "note": "Carried-prefix WRITE retry shared by the yield AND failure arms (persistCarriedPrefix): vectors already in hand retry the upsert only — never the provider — and budget exhaustion rethrows the storage error so the sweep ends loudly."
-        },
-        "ai/services/memory-core/helpers/freezeReprobeDecision.mjs#decideFreezeReprobe:5b01edc6": {
-            "kind": "retry-growth",
-            "lifetime": "persisted",
-            "boundCarrier": "terminal-state",
-            "witness": "`attempts >= maxUnfreezeAttempts` => status `contained` in the same function; test/playwright/unit/ai/services/memory-core/helpers/freezeReprobeDecision.spec.mjs",
-            "note": "The delay value GROWS without a cap by design (anti-thrash widening); the series is bounded because a terminal state stops it. No delay-shaped check can see this bound."
-        },
-        "ai/services/memory-core/MemoryService.mjs#_scheduleMemoryGraphProjection:f2eb13d7": {
-            "kind": "retry-growth",
-            "lifetime": "process-local",
-            "boundCarrier": "max-delay",
-            "witness": "`Math.min(..., aiConfig.memoryService.graphProjectionRetryMaxMs)` in the same expression"
-        },
-        "ai/services/memory-core/WebhookDeliveryService.mjs#deliver:f7f23e9f": {
-            "kind": "retry-growth",
-            "lifetime": "in-cycle",
-            "boundCarrier": "max-attempts",
-            "witness": "`attempt <= maxRetries` guard in the same loop",
-            "note": "Multiplicative mutation (`backoff *= 2`) — the syntax family a base-2 exponent census misses entirely."
-        },
-        "ai/services/shared/boundedRetryGate.mjs#settleFlight:e1ea3176": {
-            "kind": "retry-growth",
-            "lifetime": "process-local",
-            "boundCarrier": "max-delay",
-            "witness": "`Math.min(failureTtlMaxMs, ...)` in the same expression",
-            "note": "The shared flight gate; #16307 records why it is NOT the right mechanism for persisted cadence state."
-        },
-        "apps/devindex/services/GitHub.mjs##getRetryDelay:41482917": {
-            "kind": "retry-growth",
-            "lifetime": "process-local",
-            "boundCarrier": "max-delay",
-            "witness": "`Math.min(this.restRetryMaxDelayMs, ...)` applied twice (pre- and post-jitter)"
-        },
-        "src/data/connection/WebSocket.mjs#<module>:a5cd8f47": {
-            "kind": "retry-growth",
-            "lifetime": "process-local",
-            "boundCarrier": "max-delay",
-            "witness": "`Math.min(1000 * Math.pow(2, attempt - 1), 30000)` in the default backoffStrategy",
-            "note": "Body-side reconnect. One of three retry-growth sites outside ai/, alongside apps/devindex/services/GitHub.mjs and src/manager/DragCoordinator.mjs."
-        },
         "src/manager/DragCoordinator.mjs#settleNativeWindowDisposition:acca199c": {
             "kind": "retry-growth",
             "lifetime": "process-local",
             "boundCarrier": "max-delay",
             "witness": "`Math.min(5000, ...)` plus a clamped exponent `Math.min(dispositionAttempts - 1, 4)`",
             "note": "Bounded twice — the delay is capped AND the exponent itself is clamped."
-        },
-        "ai/services/fleet/fleetWakeSseConsumer.mjs#runLoop:5f68f770": {
-            "kind": "retry-growth",
-            "lifetime": "process-local",
-            "boundCarrier": "max-delay",
-            "witness": "`Math.min(..., MAX_BACKOFF_MS)` caps the exponential reconnect delay at 60s, and the loop exits terminally on `stopped` or an epoch change (`stop()` bumps the epoch) — the spec `fleetWakeSseConsumer.spec.mjs` drives a drop→reconnect cycle on the injected floor and `stop()` ends the loop."
         }
     }
 }

--- a/ai/services/knowledge-base/VectorService.mjs
+++ b/ai/services/knowledge-base/VectorService.mjs
@@ -1116,15 +1116,15 @@ class VectorService extends Base {
         logger.log(`Using TextEmbeddingService with provider: ${mcConfig.embeddingProvider}.`);
         logger.log('Embedding chunks...');
 
-        const {batchSize, batchDelay, maxRetries, undeliverableTimeoutStrikes} = aiConfig;
-        const guardrail                                                        = this.resolveEmbeddingGuardrail();
-        const failedBatches                                                    = [];
-        const poisonedChunks                                                   = knownPoisonEntries.map(entry => ({...entry}));
-        const poisonIds                                                        = new Set(poisonedChunks.map(entry => entry.chunkId));
-        const preEmbeddedIds                                                   = new Set();
-        let   embeddedCount                                                    = 0;
-        let   skippedCount                                                     = 0;
-        let   yielded                                                          = false;
+        const {backoffBaseMs, batchSize, batchDelay, maxRetries, undeliverableTimeoutStrikes} = aiConfig;
+        const guardrail                                                                       = this.resolveEmbeddingGuardrail();
+        const failedBatches                                                                   = [];
+        const poisonedChunks                                                                  = knownPoisonEntries.map(entry => ({...entry}));
+        const poisonIds                                                                       = new Set(poisonedChunks.map(entry => entry.chunkId));
+        const preEmbeddedIds                                                                  = new Set();
+        let   embeddedCount                                                                   = 0;
+        let   skippedCount                                                                    = 0;
+        let   yielded                                                                         = false;
 
         // The undeliverable automaton's coordinates, resolved ONCE per sweep. Transient strike and
         // suspicion evidence must live under the same generation as the durable disposition it can
@@ -1262,7 +1262,7 @@ class VectorService extends Base {
                         retries++;
                         if (retries >= maxRetries) throw writeError;
                         console.error(`Persisting the carried prefix of ${arm.toLowerCase()} batch ${batchNumber} failed. Retrying the write (${retries}/${maxRetries})...`, writeError.message);
-                        await new Promise(res => setTimeout(res, 2 ** retries * 1000));
+                        await new Promise(res => setTimeout(res, backoffBaseMs * 2 ** retries));
                     }
                 }
 
@@ -1496,7 +1496,10 @@ class VectorService extends Base {
                     retries++;
                     console.error(`An error occurred during embedding batch ${batchNumber}. Retrying (${retries}/${maxRetries})...`, err.message);
                     if (retries < maxRetries) {
-                        await new Promise(res => setTimeout(res, 2 ** retries * 1000)); // Exponential backoff
+                        // Exponential backoff. The base is a leaf so a test context can pin it to
+                        // 1ms: the retry DEPTH is what these specs assert, and paying the production
+                        // delay to assert it only buys wall-clock. See kb.backoffBaseMs.
+                        await new Promise(res => setTimeout(res, backoffBaseMs * 2 ** retries));
                     }
                 }
             }

--- a/ai/services/knowledge-base/VectorService.mjs
+++ b/ai/services/knowledge-base/VectorService.mjs
@@ -1262,6 +1262,9 @@ class VectorService extends Base {
                         retries++;
                         if (retries >= maxRetries) throw writeError;
                         console.error(`Persisting the carried prefix of ${arm.toLowerCase()} batch ${batchNumber} failed. Retrying the write (${retries}/${maxRetries})...`, writeError.message);
+                        // Same leaf as the embed retry below: a spec exercising this arm asserts the
+                        // retry depth, not the delay, so a test context pins the base rather than
+                        // paying the production wait. See kb.backoffBaseMs.
                         await new Promise(res => setTimeout(res, backoffBaseMs * 2 ** retries));
                     }
                 }

--- a/buildScripts/util/check-fixed-sleeps-baseline.json
+++ b/buildScripts/util/check-fixed-sleeps-baseline.json
@@ -1,0 +1,334 @@
+[
+    {
+        "file": "test/playwright/unit/ai/daemons/wake/daemon.spec.mjs",
+        "text": "await new Promise(resolve => setTimeout(resolve, 1000));"
+    },
+    {
+        "file": "test/playwright/unit/ai/daemons/wake/daemon.spec.mjs",
+        "text": "await new Promise(resolve => setTimeout(resolve, 1000));"
+    },
+    {
+        "file": "test/playwright/unit/ai/daemons/wake/daemon.spec.mjs",
+        "text": "await new Promise(resolve => setTimeout(resolve, 1000));"
+    },
+    {
+        "file": "test/playwright/unit/ai/daemons/wake/daemon.spec.mjs",
+        "text": "await new Promise(resolve => setTimeout(resolve, 1000));"
+    },
+    {
+        "file": "test/playwright/unit/ai/daemons/wake/daemon.spec.mjs",
+        "text": "await new Promise(resolve => setTimeout(resolve, 1000));"
+    },
+    {
+        "file": "test/playwright/unit/ai/daemons/wake/daemon.spec.mjs",
+        "text": "await new Promise(resolve => setTimeout(resolve, 1000));"
+    },
+    {
+        "file": "test/playwright/unit/ai/daemons/wake/daemon.spec.mjs",
+        "text": "await new Promise(resolve => setTimeout(resolve, 1000));"
+    },
+    {
+        "file": "test/playwright/unit/ai/daemons/wake/daemon.spec.mjs",
+        "text": "await new Promise(resolve => setTimeout(resolve, 1000));"
+    },
+    {
+        "file": "test/playwright/unit/ai/daemons/wake/daemon.spec.mjs",
+        "text": "await new Promise(resolve => setTimeout(resolve, 1000));"
+    },
+    {
+        "file": "test/playwright/unit/ai/daemons/wake/daemon.spec.mjs",
+        "text": "await new Promise(resolve => setTimeout(resolve, 4000)); // let it enqueue before the 2nd"
+    },
+    {
+        "file": "test/playwright/unit/ai/daemons/wake/daemon.spec.mjs",
+        "text": "await new Promise(resolve => setTimeout(resolve, 1000));"
+    },
+    {
+        "file": "test/playwright/unit/ai/daemons/wake/daemon.spec.mjs",
+        "text": "await new Promise(resolve => setTimeout(resolve, 1000));"
+    },
+    {
+        "file": "test/playwright/unit/ai/daemons/wake/daemon.spec.mjs",
+        "text": "await new Promise(resolve => setTimeout(resolve, 1000));"
+    },
+    {
+        "file": "test/playwright/unit/ai/daemons/wake/daemon.spec.mjs",
+        "text": "await new Promise(resolve => setTimeout(resolve, 4500));"
+    },
+    {
+        "file": "test/playwright/unit/ai/daemons/wake/daemon.spec.mjs",
+        "text": "await new Promise(resolve => setTimeout(resolve, 1000));"
+    },
+    {
+        "file": "test/playwright/unit/ai/daemons/wake/daemon.spec.mjs",
+        "text": "await new Promise(resolve => setTimeout(resolve, 1000));"
+    },
+    {
+        "file": "test/playwright/unit/ai/daemons/wake/daemon.spec.mjs",
+        "text": "await new Promise(resolve => setTimeout(resolve, 1000));"
+    },
+    {
+        "file": "test/playwright/unit/ai/daemons/wake/daemon.spec.mjs",
+        "text": "await new Promise(resolve => setTimeout(resolve, 1000));"
+    },
+    {
+        "file": "test/playwright/unit/ai/daemons/wake/daemon.spec.mjs",
+        "text": "await new Promise(resolve => setTimeout(resolve, 1000));"
+    },
+    {
+        "file": "test/playwright/unit/ai/daemons/wake/daemon.spec.mjs",
+        "text": "await new Promise(resolve => setTimeout(resolve, 1000));"
+    },
+    {
+        "file": "test/playwright/unit/ai/daemons/wake/daemon.spec.mjs",
+        "text": "await new Promise(resolve => setTimeout(resolve, 1000));"
+    },
+    {
+        "file": "test/playwright/unit/ai/daemons/wake/daemon.spec.mjs",
+        "text": "await new Promise(resolve => setTimeout(resolve, 5500));"
+    },
+    {
+        "file": "test/playwright/unit/ai/daemons/wake/daemon.spec.mjs",
+        "text": "await new Promise(resolve => setTimeout(resolve, 1000));"
+    },
+    {
+        "file": "test/playwright/unit/ai/daemons/wake/daemon.spec.mjs",
+        "text": "await new Promise(resolve => setTimeout(resolve, 5500));"
+    },
+    {
+        "file": "test/playwright/unit/ai/daemons/wake/daemon.spec.mjs",
+        "text": "await new Promise(resolve => setTimeout(resolve, 1000));"
+    },
+    {
+        "file": "test/playwright/unit/ai/daemons/wake/daemon.spec.mjs",
+        "text": "await new Promise(resolve => setTimeout(resolve, 1000));"
+    },
+    {
+        "file": "test/playwright/unit/ai/daemons/wake/daemon.spec.mjs",
+        "text": "await new Promise(resolve => setTimeout(resolve, 3500));"
+    },
+    {
+        "file": "test/playwright/unit/ai/daemons/wake/daemon.spec.mjs",
+        "text": "await new Promise(resolve => setTimeout(resolve, 3500));"
+    },
+    {
+        "file": "test/playwright/unit/ai/daemons/wake/daemon.spec.mjs",
+        "text": "await new Promise(resolve => setTimeout(resolve, 1000));"
+    },
+    {
+        "file": "test/playwright/unit/ai/daemons/wake/daemon.spec.mjs",
+        "text": "await new Promise(resolve => setTimeout(resolve, 4500));"
+    },
+    {
+        "file": "test/playwright/unit/ai/daemons/wake/daemon.spec.mjs",
+        "text": "await new Promise(resolve => setTimeout(resolve, 4000));"
+    },
+    {
+        "file": "test/playwright/unit/ai/daemons/wake/daemon.spec.mjs",
+        "text": "await new Promise(resolve => setTimeout(resolve, 1000));"
+    },
+    {
+        "file": "test/playwright/unit/ai/daemons/wake/daemon.spec.mjs",
+        "text": "await new Promise(resolve => setTimeout(resolve, 1000));"
+    },
+    {
+        "file": "test/playwright/unit/ai/daemons/wake/daemon.spec.mjs",
+        "text": "await new Promise(resolve => setTimeout(resolve, 1000));"
+    },
+    {
+        "file": "test/playwright/unit/ai/daemons/wake/daemon.spec.mjs",
+        "text": "await new Promise(resolve => setTimeout(resolve, 1000));"
+    },
+    {
+        "file": "test/playwright/unit/ai/daemons/wake/daemon.spec.mjs",
+        "text": "await new Promise(resolve => setTimeout(resolve, 1000));"
+    },
+    {
+        "file": "test/playwright/unit/ai/daemons/wake/daemon.spec.mjs",
+        "text": "await new Promise(resolve => setTimeout(resolve, 1000));"
+    },
+    {
+        "file": "test/playwright/unit/ai/daemons/wake/daemon.spec.mjs",
+        "text": "await new Promise(resolve => setTimeout(resolve, 1000));"
+    },
+    {
+        "file": "test/playwright/unit/ai/daemons/wake/daemon.spec.mjs",
+        "text": "await new Promise(resolve => setTimeout(resolve, 1000));"
+    },
+    {
+        "file": "test/playwright/unit/ai/daemons/wake/daemon.spec.mjs",
+        "text": "await new Promise(resolve => setTimeout(resolve, 1000));"
+    },
+    {
+        "file": "test/playwright/unit/ai/daemons/wake/daemon.spec.mjs",
+        "text": "await new Promise(resolve => setTimeout(resolve, 1000));"
+    },
+    {
+        "file": "test/playwright/unit/ai/daemons/wake/daemon.spec.mjs",
+        "text": "await new Promise(resolve => setTimeout(resolve, 4000));"
+    },
+    {
+        "file": "test/playwright/unit/ai/daemons/wake/daemon.spec.mjs",
+        "text": "await new Promise(resolve => setTimeout(resolve, 1000));"
+    },
+    {
+        "file": "test/playwright/unit/ai/daemons/wake/daemon.spec.mjs",
+        "text": "await new Promise(resolve => setTimeout(resolve, 1000));"
+    },
+    {
+        "file": "test/playwright/unit/ai/daemons/wake/daemon.spec.mjs",
+        "text": "await new Promise(resolve => setTimeout(resolve, 4000));"
+    },
+    {
+        "file": "test/playwright/unit/ai/daemons/wake/daemon.spec.mjs",
+        "text": "await new Promise(resolve => setTimeout(resolve, 1000));"
+    },
+    {
+        "file": "test/playwright/unit/ai/daemons/wake/daemon.spec.mjs",
+        "text": "await new Promise(resolve => setTimeout(resolve, 4000));"
+    },
+    {
+        "file": "test/playwright/unit/ai/daemons/wake/daemon.spec.mjs",
+        "text": "await new Promise(resolve => setTimeout(resolve, 1000));"
+    },
+    {
+        "file": "test/playwright/unit/ai/daemons/wake/daemon.spec.mjs",
+        "text": "await new Promise(resolve => setTimeout(resolve, 1000));"
+    },
+    {
+        "file": "test/playwright/unit/ai/daemons/wake/daemon.spec.mjs",
+        "text": "await new Promise(resolve => setTimeout(resolve, 2800));"
+    },
+    {
+        "file": "test/playwright/unit/ai/daemons/wake/daemon.spec.mjs",
+        "text": "await new Promise(resolve => setTimeout(resolve, 1000));"
+    },
+    {
+        "file": "test/playwright/unit/ai/daemons/wake/daemon.spec.mjs",
+        "text": "await new Promise(resolve => setTimeout(resolve, 1000));"
+    },
+    {
+        "file": "test/playwright/unit/ai/daemons/wake/daemon.spec.mjs",
+        "text": "await new Promise(resolve => setTimeout(resolve, 1000));"
+    },
+    {
+        "file": "test/playwright/unit/ai/daemons/wake/daemon.spec.mjs",
+        "text": "await new Promise(resolve => setTimeout(resolve, 1000));"
+    },
+    {
+        "file": "test/playwright/unit/ai/daemons/wake/daemon.spec.mjs",
+        "text": "await new Promise(resolve => setTimeout(resolve, 1000));"
+    },
+    {
+        "file": "test/playwright/unit/ai/daemons/wake/daemon.spec.mjs",
+        "text": "await new Promise(resolve => setTimeout(resolve, 1000));"
+    },
+    {
+        "file": "test/playwright/unit/ai/daemons/wake/daemon.spec.mjs",
+        "text": "await new Promise(resolve => setTimeout(resolve, 1000));"
+    },
+    {
+        "file": "test/playwright/unit/ai/daemons/wake/daemon.spec.mjs",
+        "text": "await new Promise(resolve => setTimeout(resolve, 1000));"
+    },
+    {
+        "file": "test/playwright/unit/ai/daemons/wake/daemon.spec.mjs",
+        "text": "await new Promise(resolve => setTimeout(resolve, 1000));"
+    },
+    {
+        "file": "test/playwright/unit/ai/daemons/wake/daemon.spec.mjs",
+        "text": "await new Promise(resolve => setTimeout(resolve, 1000));"
+    },
+    {
+        "file": "test/playwright/unit/ai/daemons/wake/daemon.spec.mjs",
+        "text": "await new Promise(resolve => setTimeout(resolve, 1000));"
+    },
+    {
+        "file": "test/playwright/unit/ai/daemons/wake/daemon.spec.mjs",
+        "text": "await new Promise(resolve => setTimeout(resolve, 1000));"
+    },
+    {
+        "file": "test/playwright/unit/ai/daemons/wake/daemon.spec.mjs",
+        "text": "await new Promise(resolve => setTimeout(resolve, 1000));"
+    },
+    {
+        "file": "test/playwright/unit/ai/daemons/wake/daemon.spec.mjs",
+        "text": "await new Promise(resolve => setTimeout(resolve, 5000));"
+    },
+    {
+        "file": "test/playwright/unit/ai/daemons/wake/daemon.spec.mjs",
+        "text": "await new Promise(resolve => setTimeout(resolve, 1000));"
+    },
+    {
+        "file": "test/playwright/unit/ai/daemons/wake/daemon.spec.mjs",
+        "text": "await new Promise(resolve => setTimeout(resolve, 1000));"
+    },
+    {
+        "file": "test/playwright/unit/ai/daemons/wake/daemon.spec.mjs",
+        "text": "await new Promise(resolve => setTimeout(resolve, 1000));"
+    },
+    {
+        "file": "test/playwright/unit/ai/daemons/wake/daemon.spec.mjs",
+        "text": "await new Promise(resolve => setTimeout(resolve, 5000));"
+    },
+    {
+        "file": "test/playwright/unit/ai/daemons/wake/daemon.spec.mjs",
+        "text": "await new Promise(resolve => setTimeout(resolve, 1000));"
+    },
+    {
+        "file": "test/playwright/unit/ai/daemons/wake/daemon.spec.mjs",
+        "text": "await new Promise(resolve => setTimeout(resolve, 1000));"
+    },
+    {
+        "file": "test/playwright/unit/ai/daemons/wake/daemon.spec.mjs",
+        "text": "await new Promise(resolve => setTimeout(resolve, 5500));"
+    },
+    {
+        "file": "test/playwright/unit/ai/daemons/wake/daemon.spec.mjs",
+        "text": "await new Promise(resolve => setTimeout(resolve, 1000));"
+    },
+    {
+        "file": "test/playwright/unit/ai/daemons/wake/daemon.spec.mjs",
+        "text": "await new Promise(resolve => setTimeout(resolve, 1000));"
+    },
+    {
+        "file": "test/playwright/unit/ai/daemons/wake/daemon.spec.mjs",
+        "text": "await new Promise(resolve => setTimeout(resolve, 1000));"
+    },
+    {
+        "file": "test/playwright/unit/ai/daemons/wake/daemon.spec.mjs",
+        "text": "await new Promise(resolve => setTimeout(resolve, 1000));"
+    },
+    {
+        "file": "test/playwright/unit/ai/daemons/wake/daemon.spec.mjs",
+        "text": "await new Promise(resolve => setTimeout(resolve, 1000));"
+    },
+    {
+        "file": "test/playwright/unit/ai/daemons/wake/daemon.spec.mjs",
+        "text": "await new Promise(resolve => setTimeout(resolve, 4000));"
+    },
+    {
+        "file": "test/playwright/unit/ai/daemons/wake/daemon.spec.mjs",
+        "text": "await new Promise(resolve => setTimeout(resolve, 1000));"
+    },
+    {
+        "file": "test/playwright/unit/ai/daemons/wake/daemon.spec.mjs",
+        "text": "await new Promise(resolve => setTimeout(resolve, 4000));"
+    },
+    {
+        "file": "test/playwright/unit/ai/daemons/wake/daemon.spec.mjs",
+        "text": "await new Promise(resolve => setTimeout(resolve, 1000));"
+    },
+    {
+        "file": "test/playwright/unit/ai/daemons/wake/daemon.spec.mjs",
+        "text": "await new Promise(resolve => setTimeout(resolve, 4000));"
+    },
+    {
+        "file": "test/playwright/unit/ai/daemons/wake/daemon.spec.mjs",
+        "text": "await new Promise(resolve => setTimeout(resolve, 1000));"
+    },
+    {
+        "file": "test/playwright/unit/ai/daemons/wake/daemon.spec.mjs",
+        "text": "await new Promise(resolve => setTimeout(resolve, 2600));"
+    }
+]

--- a/buildScripts/util/check-fixed-sleeps-baseline.json
+++ b/buildScripts/util/check-fixed-sleeps-baseline.json
@@ -2,7 +2,7 @@
     {
         "file": "test/playwright/unit/ai/daemons/wake/daemon.spec.mjs",
         "text": "await new Promise(resolve => setTimeout(resolve, 1000));",
-        "count": 64
+        "count": 63
     },
     {
         "file": "test/playwright/unit/ai/daemons/wake/daemon.spec.mjs",

--- a/buildScripts/util/check-fixed-sleeps-baseline.json
+++ b/buildScripts/util/check-fixed-sleeps-baseline.json
@@ -1,334 +1,47 @@
 [
     {
         "file": "test/playwright/unit/ai/daemons/wake/daemon.spec.mjs",
-        "text": "await new Promise(resolve => setTimeout(resolve, 1000));"
+        "text": "await new Promise(resolve => setTimeout(resolve, 1000));",
+        "count": 64
     },
     {
         "file": "test/playwright/unit/ai/daemons/wake/daemon.spec.mjs",
-        "text": "await new Promise(resolve => setTimeout(resolve, 1000));"
+        "text": "await new Promise(resolve => setTimeout(resolve, 4000)); // let it enqueue before the 2nd",
+        "count": 1
     },
     {
         "file": "test/playwright/unit/ai/daemons/wake/daemon.spec.mjs",
-        "text": "await new Promise(resolve => setTimeout(resolve, 1000));"
+        "text": "await new Promise(resolve => setTimeout(resolve, 4500));",
+        "count": 2
     },
     {
         "file": "test/playwright/unit/ai/daemons/wake/daemon.spec.mjs",
-        "text": "await new Promise(resolve => setTimeout(resolve, 1000));"
+        "text": "await new Promise(resolve => setTimeout(resolve, 5500));",
+        "count": 3
     },
     {
         "file": "test/playwright/unit/ai/daemons/wake/daemon.spec.mjs",
-        "text": "await new Promise(resolve => setTimeout(resolve, 1000));"
+        "text": "await new Promise(resolve => setTimeout(resolve, 3500));",
+        "count": 2
     },
     {
         "file": "test/playwright/unit/ai/daemons/wake/daemon.spec.mjs",
-        "text": "await new Promise(resolve => setTimeout(resolve, 1000));"
+        "text": "await new Promise(resolve => setTimeout(resolve, 4000));",
+        "count": 7
     },
     {
         "file": "test/playwright/unit/ai/daemons/wake/daemon.spec.mjs",
-        "text": "await new Promise(resolve => setTimeout(resolve, 1000));"
+        "text": "await new Promise(resolve => setTimeout(resolve, 2800));",
+        "count": 1
     },
     {
         "file": "test/playwright/unit/ai/daemons/wake/daemon.spec.mjs",
-        "text": "await new Promise(resolve => setTimeout(resolve, 1000));"
+        "text": "await new Promise(resolve => setTimeout(resolve, 5000));",
+        "count": 2
     },
     {
         "file": "test/playwright/unit/ai/daemons/wake/daemon.spec.mjs",
-        "text": "await new Promise(resolve => setTimeout(resolve, 1000));"
-    },
-    {
-        "file": "test/playwright/unit/ai/daemons/wake/daemon.spec.mjs",
-        "text": "await new Promise(resolve => setTimeout(resolve, 4000)); // let it enqueue before the 2nd"
-    },
-    {
-        "file": "test/playwright/unit/ai/daemons/wake/daemon.spec.mjs",
-        "text": "await new Promise(resolve => setTimeout(resolve, 1000));"
-    },
-    {
-        "file": "test/playwright/unit/ai/daemons/wake/daemon.spec.mjs",
-        "text": "await new Promise(resolve => setTimeout(resolve, 1000));"
-    },
-    {
-        "file": "test/playwright/unit/ai/daemons/wake/daemon.spec.mjs",
-        "text": "await new Promise(resolve => setTimeout(resolve, 1000));"
-    },
-    {
-        "file": "test/playwright/unit/ai/daemons/wake/daemon.spec.mjs",
-        "text": "await new Promise(resolve => setTimeout(resolve, 4500));"
-    },
-    {
-        "file": "test/playwright/unit/ai/daemons/wake/daemon.spec.mjs",
-        "text": "await new Promise(resolve => setTimeout(resolve, 1000));"
-    },
-    {
-        "file": "test/playwright/unit/ai/daemons/wake/daemon.spec.mjs",
-        "text": "await new Promise(resolve => setTimeout(resolve, 1000));"
-    },
-    {
-        "file": "test/playwright/unit/ai/daemons/wake/daemon.spec.mjs",
-        "text": "await new Promise(resolve => setTimeout(resolve, 1000));"
-    },
-    {
-        "file": "test/playwright/unit/ai/daemons/wake/daemon.spec.mjs",
-        "text": "await new Promise(resolve => setTimeout(resolve, 1000));"
-    },
-    {
-        "file": "test/playwright/unit/ai/daemons/wake/daemon.spec.mjs",
-        "text": "await new Promise(resolve => setTimeout(resolve, 1000));"
-    },
-    {
-        "file": "test/playwright/unit/ai/daemons/wake/daemon.spec.mjs",
-        "text": "await new Promise(resolve => setTimeout(resolve, 1000));"
-    },
-    {
-        "file": "test/playwright/unit/ai/daemons/wake/daemon.spec.mjs",
-        "text": "await new Promise(resolve => setTimeout(resolve, 1000));"
-    },
-    {
-        "file": "test/playwright/unit/ai/daemons/wake/daemon.spec.mjs",
-        "text": "await new Promise(resolve => setTimeout(resolve, 5500));"
-    },
-    {
-        "file": "test/playwright/unit/ai/daemons/wake/daemon.spec.mjs",
-        "text": "await new Promise(resolve => setTimeout(resolve, 1000));"
-    },
-    {
-        "file": "test/playwright/unit/ai/daemons/wake/daemon.spec.mjs",
-        "text": "await new Promise(resolve => setTimeout(resolve, 5500));"
-    },
-    {
-        "file": "test/playwright/unit/ai/daemons/wake/daemon.spec.mjs",
-        "text": "await new Promise(resolve => setTimeout(resolve, 1000));"
-    },
-    {
-        "file": "test/playwright/unit/ai/daemons/wake/daemon.spec.mjs",
-        "text": "await new Promise(resolve => setTimeout(resolve, 1000));"
-    },
-    {
-        "file": "test/playwright/unit/ai/daemons/wake/daemon.spec.mjs",
-        "text": "await new Promise(resolve => setTimeout(resolve, 3500));"
-    },
-    {
-        "file": "test/playwright/unit/ai/daemons/wake/daemon.spec.mjs",
-        "text": "await new Promise(resolve => setTimeout(resolve, 3500));"
-    },
-    {
-        "file": "test/playwright/unit/ai/daemons/wake/daemon.spec.mjs",
-        "text": "await new Promise(resolve => setTimeout(resolve, 1000));"
-    },
-    {
-        "file": "test/playwright/unit/ai/daemons/wake/daemon.spec.mjs",
-        "text": "await new Promise(resolve => setTimeout(resolve, 4500));"
-    },
-    {
-        "file": "test/playwright/unit/ai/daemons/wake/daemon.spec.mjs",
-        "text": "await new Promise(resolve => setTimeout(resolve, 4000));"
-    },
-    {
-        "file": "test/playwright/unit/ai/daemons/wake/daemon.spec.mjs",
-        "text": "await new Promise(resolve => setTimeout(resolve, 1000));"
-    },
-    {
-        "file": "test/playwright/unit/ai/daemons/wake/daemon.spec.mjs",
-        "text": "await new Promise(resolve => setTimeout(resolve, 1000));"
-    },
-    {
-        "file": "test/playwright/unit/ai/daemons/wake/daemon.spec.mjs",
-        "text": "await new Promise(resolve => setTimeout(resolve, 1000));"
-    },
-    {
-        "file": "test/playwright/unit/ai/daemons/wake/daemon.spec.mjs",
-        "text": "await new Promise(resolve => setTimeout(resolve, 1000));"
-    },
-    {
-        "file": "test/playwright/unit/ai/daemons/wake/daemon.spec.mjs",
-        "text": "await new Promise(resolve => setTimeout(resolve, 1000));"
-    },
-    {
-        "file": "test/playwright/unit/ai/daemons/wake/daemon.spec.mjs",
-        "text": "await new Promise(resolve => setTimeout(resolve, 1000));"
-    },
-    {
-        "file": "test/playwright/unit/ai/daemons/wake/daemon.spec.mjs",
-        "text": "await new Promise(resolve => setTimeout(resolve, 1000));"
-    },
-    {
-        "file": "test/playwright/unit/ai/daemons/wake/daemon.spec.mjs",
-        "text": "await new Promise(resolve => setTimeout(resolve, 1000));"
-    },
-    {
-        "file": "test/playwright/unit/ai/daemons/wake/daemon.spec.mjs",
-        "text": "await new Promise(resolve => setTimeout(resolve, 1000));"
-    },
-    {
-        "file": "test/playwright/unit/ai/daemons/wake/daemon.spec.mjs",
-        "text": "await new Promise(resolve => setTimeout(resolve, 1000));"
-    },
-    {
-        "file": "test/playwright/unit/ai/daemons/wake/daemon.spec.mjs",
-        "text": "await new Promise(resolve => setTimeout(resolve, 4000));"
-    },
-    {
-        "file": "test/playwright/unit/ai/daemons/wake/daemon.spec.mjs",
-        "text": "await new Promise(resolve => setTimeout(resolve, 1000));"
-    },
-    {
-        "file": "test/playwright/unit/ai/daemons/wake/daemon.spec.mjs",
-        "text": "await new Promise(resolve => setTimeout(resolve, 1000));"
-    },
-    {
-        "file": "test/playwright/unit/ai/daemons/wake/daemon.spec.mjs",
-        "text": "await new Promise(resolve => setTimeout(resolve, 4000));"
-    },
-    {
-        "file": "test/playwright/unit/ai/daemons/wake/daemon.spec.mjs",
-        "text": "await new Promise(resolve => setTimeout(resolve, 1000));"
-    },
-    {
-        "file": "test/playwright/unit/ai/daemons/wake/daemon.spec.mjs",
-        "text": "await new Promise(resolve => setTimeout(resolve, 4000));"
-    },
-    {
-        "file": "test/playwright/unit/ai/daemons/wake/daemon.spec.mjs",
-        "text": "await new Promise(resolve => setTimeout(resolve, 1000));"
-    },
-    {
-        "file": "test/playwright/unit/ai/daemons/wake/daemon.spec.mjs",
-        "text": "await new Promise(resolve => setTimeout(resolve, 1000));"
-    },
-    {
-        "file": "test/playwright/unit/ai/daemons/wake/daemon.spec.mjs",
-        "text": "await new Promise(resolve => setTimeout(resolve, 2800));"
-    },
-    {
-        "file": "test/playwright/unit/ai/daemons/wake/daemon.spec.mjs",
-        "text": "await new Promise(resolve => setTimeout(resolve, 1000));"
-    },
-    {
-        "file": "test/playwright/unit/ai/daemons/wake/daemon.spec.mjs",
-        "text": "await new Promise(resolve => setTimeout(resolve, 1000));"
-    },
-    {
-        "file": "test/playwright/unit/ai/daemons/wake/daemon.spec.mjs",
-        "text": "await new Promise(resolve => setTimeout(resolve, 1000));"
-    },
-    {
-        "file": "test/playwright/unit/ai/daemons/wake/daemon.spec.mjs",
-        "text": "await new Promise(resolve => setTimeout(resolve, 1000));"
-    },
-    {
-        "file": "test/playwright/unit/ai/daemons/wake/daemon.spec.mjs",
-        "text": "await new Promise(resolve => setTimeout(resolve, 1000));"
-    },
-    {
-        "file": "test/playwright/unit/ai/daemons/wake/daemon.spec.mjs",
-        "text": "await new Promise(resolve => setTimeout(resolve, 1000));"
-    },
-    {
-        "file": "test/playwright/unit/ai/daemons/wake/daemon.spec.mjs",
-        "text": "await new Promise(resolve => setTimeout(resolve, 1000));"
-    },
-    {
-        "file": "test/playwright/unit/ai/daemons/wake/daemon.spec.mjs",
-        "text": "await new Promise(resolve => setTimeout(resolve, 1000));"
-    },
-    {
-        "file": "test/playwright/unit/ai/daemons/wake/daemon.spec.mjs",
-        "text": "await new Promise(resolve => setTimeout(resolve, 1000));"
-    },
-    {
-        "file": "test/playwright/unit/ai/daemons/wake/daemon.spec.mjs",
-        "text": "await new Promise(resolve => setTimeout(resolve, 1000));"
-    },
-    {
-        "file": "test/playwright/unit/ai/daemons/wake/daemon.spec.mjs",
-        "text": "await new Promise(resolve => setTimeout(resolve, 1000));"
-    },
-    {
-        "file": "test/playwright/unit/ai/daemons/wake/daemon.spec.mjs",
-        "text": "await new Promise(resolve => setTimeout(resolve, 1000));"
-    },
-    {
-        "file": "test/playwright/unit/ai/daemons/wake/daemon.spec.mjs",
-        "text": "await new Promise(resolve => setTimeout(resolve, 1000));"
-    },
-    {
-        "file": "test/playwright/unit/ai/daemons/wake/daemon.spec.mjs",
-        "text": "await new Promise(resolve => setTimeout(resolve, 5000));"
-    },
-    {
-        "file": "test/playwright/unit/ai/daemons/wake/daemon.spec.mjs",
-        "text": "await new Promise(resolve => setTimeout(resolve, 1000));"
-    },
-    {
-        "file": "test/playwright/unit/ai/daemons/wake/daemon.spec.mjs",
-        "text": "await new Promise(resolve => setTimeout(resolve, 1000));"
-    },
-    {
-        "file": "test/playwright/unit/ai/daemons/wake/daemon.spec.mjs",
-        "text": "await new Promise(resolve => setTimeout(resolve, 1000));"
-    },
-    {
-        "file": "test/playwright/unit/ai/daemons/wake/daemon.spec.mjs",
-        "text": "await new Promise(resolve => setTimeout(resolve, 5000));"
-    },
-    {
-        "file": "test/playwright/unit/ai/daemons/wake/daemon.spec.mjs",
-        "text": "await new Promise(resolve => setTimeout(resolve, 1000));"
-    },
-    {
-        "file": "test/playwright/unit/ai/daemons/wake/daemon.spec.mjs",
-        "text": "await new Promise(resolve => setTimeout(resolve, 1000));"
-    },
-    {
-        "file": "test/playwright/unit/ai/daemons/wake/daemon.spec.mjs",
-        "text": "await new Promise(resolve => setTimeout(resolve, 5500));"
-    },
-    {
-        "file": "test/playwright/unit/ai/daemons/wake/daemon.spec.mjs",
-        "text": "await new Promise(resolve => setTimeout(resolve, 1000));"
-    },
-    {
-        "file": "test/playwright/unit/ai/daemons/wake/daemon.spec.mjs",
-        "text": "await new Promise(resolve => setTimeout(resolve, 1000));"
-    },
-    {
-        "file": "test/playwright/unit/ai/daemons/wake/daemon.spec.mjs",
-        "text": "await new Promise(resolve => setTimeout(resolve, 1000));"
-    },
-    {
-        "file": "test/playwright/unit/ai/daemons/wake/daemon.spec.mjs",
-        "text": "await new Promise(resolve => setTimeout(resolve, 1000));"
-    },
-    {
-        "file": "test/playwright/unit/ai/daemons/wake/daemon.spec.mjs",
-        "text": "await new Promise(resolve => setTimeout(resolve, 1000));"
-    },
-    {
-        "file": "test/playwright/unit/ai/daemons/wake/daemon.spec.mjs",
-        "text": "await new Promise(resolve => setTimeout(resolve, 4000));"
-    },
-    {
-        "file": "test/playwright/unit/ai/daemons/wake/daemon.spec.mjs",
-        "text": "await new Promise(resolve => setTimeout(resolve, 1000));"
-    },
-    {
-        "file": "test/playwright/unit/ai/daemons/wake/daemon.spec.mjs",
-        "text": "await new Promise(resolve => setTimeout(resolve, 4000));"
-    },
-    {
-        "file": "test/playwright/unit/ai/daemons/wake/daemon.spec.mjs",
-        "text": "await new Promise(resolve => setTimeout(resolve, 1000));"
-    },
-    {
-        "file": "test/playwright/unit/ai/daemons/wake/daemon.spec.mjs",
-        "text": "await new Promise(resolve => setTimeout(resolve, 4000));"
-    },
-    {
-        "file": "test/playwright/unit/ai/daemons/wake/daemon.spec.mjs",
-        "text": "await new Promise(resolve => setTimeout(resolve, 1000));"
-    },
-    {
-        "file": "test/playwright/unit/ai/daemons/wake/daemon.spec.mjs",
-        "text": "await new Promise(resolve => setTimeout(resolve, 2600));"
+        "text": "await new Promise(resolve => setTimeout(resolve, 2600));",
+        "count": 1
     }
 ]

--- a/buildScripts/util/check-fixed-sleeps.mjs
+++ b/buildScripts/util/check-fixed-sleeps.mjs
@@ -1,0 +1,186 @@
+#!/usr/bin/env node
+/**
+ * @summary Fails a unit spec that waits a fixed second-scale sleep without saying what it is waiting for.
+ *
+ * ## The defect this is actually about
+ *
+ * The visible shape is `await new Promise(r => setTimeout(r, 1000))` in a spec, and the visible cost is
+ * wall clock — a suite that crossed 16 CI-minutes with most of it spent asleep. But the bare sleep is a
+ * SYMPTOM. In every site censused when this guard was written, the spec was out-waiting a **hardcoded
+ * production constant** it had no way to inject: a poll interval, a lock-hold threshold, a token TTL, a
+ * spawn startup delay. The test cannot pin what the source does not expose, so it guesses a number
+ * larger than the constant and pays it on every run, forever.
+ *
+ * So the rule is not "no sleeps". It is: **a fixed second-scale wait must name what it is waiting for.**
+ * Naming it is the cheap part; the naming is also the census that finds the next non-injectable constant,
+ * which is the repair that actually removes the wall clock.
+ *
+ * ## Deleting a sleep is NOT the sanctioned fix, and this guard must not imply that it is
+ *
+ * Measured on the wake daemon spec while this guard was being written:
+ *
+ *     daemon readiness            90 ms actual, against sleeps waiting 1000 ms
+ *     sleep -> readiness poll     6.4s -> 6.3s     (no material change)
+ *     sleep DELETED entirely      6.4s -> 12.2s    (twice as slow, every assertion still green)
+ *
+ * The wall clock is quantized by the production poll interval: injecting at 90 ms or at 1000 ms lands
+ * before the same boundary, so sub-interval savings are absorbed whole — and deleting the wait pushes
+ * injection BEFORE the watermark, costing a full extra cycle. **A naive deletion makes the suite slower
+ * while staying green**, which is the worst available outcome because nothing reports it.
+ *
+ * That is why `wall-clock-under-test:` is a first-class, legitimate answer rather than a confession, and
+ * why this guard's failure text never says "remove the sleep". A guard that nudges toward the wrong
+ * repair is worse than no guard: it converts a visible cost into an invisible one and prints green.
+ *
+ * ## What satisfies it
+ *
+ * Either marker, on the sleep's line or within the three lines above it:
+ *
+ *     wall-clock-under-test: <why the elapsed time is the thing being asserted>
+ *     out-waits: <the production constant this is larger than>
+ *
+ * `out-waits:` is the one that pays forward — it names a leaf candidate, and a constant named here is a
+ * constant somebody can make injectable.
+ *
+ * ## Baseline
+ *
+ * Pre-existing sites are grandfathered per-site in `check-fixed-sleeps-baseline.json`. A baseline row
+ * whose site no longer matches **also fails**: the baseline may only shrink, and it cannot outlive the
+ * sites it grandfathers. Per-site rather than per-file deliberately — these sites tend to CONVERT rather
+ * than vanish (a sleep becomes a readiness poll), and a file count would silently absorb a conversion
+ * that left the site present.
+ */
+import fs   from 'node:fs';
+import path from 'node:path';
+
+const
+    BASELINE_REL   = 'buildScripts/util/check-fixed-sleeps-baseline.json',
+    JUSTIFICATIONS = ['wall-clock-under-test:', 'out-waits:'],
+    LOOKBEHIND     = 3,
+    ROOT_DIR       = process.cwd(),
+    SCAN_ROOT      = 'test/playwright/unit',
+    SLEEP_RE       = /setTimeout\(\s*[A-Za-z_$][\w$]*\s*,\s*(\d+)\s*\)/,
+    THRESHOLD_MS   = 1000;
+
+/**
+ * @summary Recursively collects `.mjs` files under one directory.
+ * @param {String} dir Absolute directory.
+ * @param {String[]} [out] Accumulator.
+ * @returns {String[]} Absolute file paths.
+ */
+function collectSpecs(dir, out = []) {
+    if (!fs.existsSync(dir)) return out;
+
+    for (const entry of fs.readdirSync(dir, {withFileTypes: true})) {
+        const abs = path.join(dir, entry.name);
+
+        if (entry.isDirectory())            collectSpecs(abs, out);
+        else if (entry.name.endsWith('.mjs')) out.push(abs)
+    }
+
+    return out
+}
+
+/**
+ * @summary Finds unjustified fixed second-scale sleeps across the unit spec tree.
+ *
+ * A justification is accepted from the sleep's own line or the three lines above it, because the idiom
+ * puts the explanation in a comment block over the `await`, not trailing it.
+ * @param {Object} [options]
+ * @param {String} [options.rootDir] Repo root.
+ * @param {String[]} [options.files] Absolute spec paths; defaults to the whole unit tree.
+ * @returns {Array<{file: String, line: Number, ms: Number, text: String}>}
+ */
+export function findUnjustifiedSleeps({rootDir = ROOT_DIR, files} = {}) {
+    const
+        specs = files || collectSpecs(path.join(rootDir, SCAN_ROOT)),
+        found = [];
+
+    for (const abs of specs) {
+        const lines = fs.readFileSync(abs, 'utf8').split('\n');
+
+        lines.forEach((text, index) => {
+            const match = SLEEP_RE.exec(text);
+
+            if (!match || Number(match[1]) < THRESHOLD_MS) return;
+
+            const context = lines.slice(Math.max(0, index - LOOKBEHIND), index + 1).join('\n');
+
+            if (JUSTIFICATIONS.some(marker => context.includes(marker))) return;
+
+            found.push({
+                file: path.relative(rootDir, abs).replaceAll('\\', '/'),
+                line: index + 1,
+                ms  : Number(match[1]),
+                text: text.trim()
+            })
+        })
+    }
+
+    return found
+}
+
+/**
+ * @summary Reconciles live findings against the baseline in both directions.
+ * @param {Object} options
+ * @param {Array<Object>} options.found Live findings.
+ * @param {Array<Object>} options.baseline Baseline rows.
+ * @returns {{fresh: Array<Object>, stale: Array<Object>}}
+ */
+export function reconcile({found, baseline}) {
+    const
+        key      = row => `${row.file}::${row.text}`,
+        liveKeys = new Set(found.map(key)),
+        rowKeys  = new Set(baseline.map(key));
+
+    return {
+        fresh: found.filter(row => !rowKeys.has(key(row))),
+        stale: baseline.filter(row => !liveKeys.has(key(row)))
+    }
+}
+
+const
+    baselinePath   = path.join(ROOT_DIR, BASELINE_REL),
+    baseline       = fs.existsSync(baselinePath) ? JSON.parse(fs.readFileSync(baselinePath, 'utf8')) : [],
+    found          = findUnjustifiedSleeps({}),
+    {fresh, stale} = reconcile({found, baseline});
+
+if (fresh.length === 0 && stale.length === 0) {
+    console.log(`check-fixed-sleeps: OK — ${found.length} baselined site(s), 0 new, 0 stale.`);
+    process.exit(0)
+}
+
+if (fresh.length) {
+    console.error(`check-fixed-sleeps: ${fresh.length} fixed sleep(s) >= ${THRESHOLD_MS}ms with nothing said about what they wait for:\n`);
+
+    for (const row of fresh) {
+        console.error(`  ${row.file}:${row.line}  (${row.ms}ms)`);
+        console.error(`    ${row.text}`)
+    }
+
+    console.error(`
+Say what the wait is FOR. Either marker, on the line or within ${LOOKBEHIND} lines above it:
+
+  // out-waits: <the production constant this is larger than>
+  // wall-clock-under-test: <why elapsed time is the thing being asserted>
+
+Both are legitimate outcomes. \`out-waits:\` is the one that pays forward — a named constant is a
+constant somebody can make injectable, which is the repair that actually removes the wall clock.
+
+Do NOT reach for deleting the wait. Where the surrounding code polls on a fixed interval, removing a
+sleep pushes injection before the next watermark and costs a WHOLE extra cycle: one measured spec went
+6.4s -> 12.2s on deletion, with every assertion still passing. A sleep you cannot explain is a finding;
+a sleep you delete without measuring is a slower suite that reports green.`)
+}
+
+if (stale.length) {
+    console.error(`\ncheck-fixed-sleeps: ${stale.length} baseline row(s) no longer match a live site — the baseline may only shrink:\n`);
+
+    for (const row of stale) console.error(`  ${row.file}  ${row.text}`);
+
+    console.error(`
+Remove these rows. A site that was converted (a sleep becoming a readiness poll) or removed leaves its
+row behind, and a baseline permitted to outlive its sites stops describing anything.`)
+}
+
+process.exit(1)

--- a/buildScripts/util/check-fixed-sleeps.mjs
+++ b/buildScripts/util/check-fixed-sleeps.mjs
@@ -42,7 +42,26 @@
  * `out-waits:` is the one that pays forward — it names a leaf candidate, and a constant named here is a
  * constant somebody can make injectable.
  *
- * ## Baseline
+ * ## The baseline is annotation debt. It is NOT a wall-clock metric.
+ *
+ * This guard reports two numbers with opposite meanings, and conflating them would defeat it.
+ *
+ * **Baseline** counts waits nobody has accounted for. It should reach zero.
+ *
+ * **Backlog** counts `out-waits:` sites — waits that ARE accounted for and are *still being paid*,
+ * because the constant they name is still hardcoded. Its rising is a finding, not a failure.
+ *
+ * The trap, found by the author of the largest affected spec while reviewing this guard: every one of
+ * her 83 sites would **truthfully** earn `out-waits: POLL_INTERVAL_MS`. Annotating all of them is the
+ * correct local action and it drives the baseline to zero **while recovering zero wall clock**. A
+ * burndown that completes without the suite getting one millisecond faster is exactly the
+ * metric-moves-goal-doesn't shape this guard exists to prevent, reappearing inside the guard itself.
+ *
+ * So: a zeroed baseline means every wait is *explained*. It does not mean the suite is fast. Anything
+ * reading it as a speed metric is reading the wrong number — which is why both counts print together
+ * on success, rather than this paragraph being the only place the distinction lives.
+ *
+ * ## Baseline mechanics
  *
  * Pre-existing sites are grandfathered per-site in `check-fixed-sleeps-baseline.json`. A baseline row
  * whose site no longer matches **also fails**: the baseline may only shrink, and it cannot outlive the
@@ -93,8 +112,9 @@ function collectSpecs(dir, out = []) {
  */
 export function findUnjustifiedSleeps({rootDir = ROOT_DIR, files} = {}) {
     const
-        specs = files || collectSpecs(path.join(rootDir, SCAN_ROOT)),
-        found = [];
+        specs   = files || collectSpecs(path.join(rootDir, SCAN_ROOT)),
+        backlog = [],
+        found   = [];
 
     for (const abs of specs) {
         const lines = fs.readFileSync(abs, 'utf8').split('\n');
@@ -106,6 +126,19 @@ export function findUnjustifiedSleeps({rootDir = ROOT_DIR, files} = {}) {
 
             const context = lines.slice(Math.max(0, index - LOOKBEHIND), index + 1).join('\n');
 
+            // An `out-waits:` site is DISCHARGED here and simultaneously recorded as backlog. Both
+            // are true at once and the distinction is the whole point: the wait is now accounted for,
+            // and the constant it names is still hardcoded, so the wall clock is still being paid.
+            if (context.includes('out-waits:')) {
+                backlog.push({
+                    file: path.relative(rootDir, abs).replaceAll('\\', '/'),
+                    line: index + 1,
+                    ms  : Number(match[1])
+                });
+
+                return
+            }
+
             if (JUSTIFICATIONS.some(marker => context.includes(marker))) return;
 
             found.push({
@@ -116,6 +149,8 @@ export function findUnjustifiedSleeps({rootDir = ROOT_DIR, files} = {}) {
             })
         })
     }
+
+    found.backlog = backlog;
 
     return found
 }
@@ -145,8 +180,22 @@ const
     found          = findUnjustifiedSleeps({}),
     {fresh, stale} = reconcile({found, baseline});
 
+const backlogMs = (found.backlog || []).reduce((sum, row) => sum + row.ms, 0);
+
 if (fresh.length === 0 && stale.length === 0) {
-    console.log(`check-fixed-sleeps: OK — ${found.length} baselined site(s), 0 new, 0 stale.`);
+    console.log(`check-fixed-sleeps: OK — ${found.length} unaccounted site(s) baselined, 0 new, 0 stale.`);
+
+    // TWO numbers, opposite meanings, printed together because a reader consumes the printed line and
+    // not the docstring. The baseline measures ANNOTATION DEBT and should reach zero. The backlog
+    // measures WALL CLOCK STILL BEING PAID and reaching zero is a different, harder thing: every
+    // `out-waits:` site can be annotated truthfully, emptying the baseline, without the suite getting
+    // one millisecond faster. A zeroed baseline means every wait is accounted for. It does NOT mean
+    // the suite is fast, and anything reading it as a speed metric is reading the wrong number.
+    if (found.backlog?.length) {
+        console.log(`check-fixed-sleeps: ${found.backlog.length} site(s) carry \`out-waits:\` — ~${(backlogMs / 1000).toFixed(1)}s of wall clock still paid to hardcoded constants.`);
+        console.log('  This is a LEAF-CANDIDATE BACKLOG, not a failure. It rising is a finding; it falling means a constant became injectable.')
+    }
+
     process.exit(0)
 }
 

--- a/buildScripts/util/check-fixed-sleeps.mjs
+++ b/buildScripts/util/check-fixed-sleeps.mjs
@@ -88,8 +88,25 @@ const
     LOOKBEHIND     = 3,
     ROOT_DIR       = process.cwd(),
     SCAN_ROOT      = 'test/playwright/unit',
-    SLEEP_RE       = /setTimeout\(\s*[A-Za-z_$][\w$]*\s*,\s*(\d+)\s*\)/,
+    // Global, and the delay is captured as a NUMERIC LITERAL rather than a digit run. `(\d+)` could not
+    // see `1_000` or `1e3` at all — both are ordinary JavaScript spellings of this threshold, and both
+    // slipped the gate completely rather than merely being mis-measured. A guard that reads source has
+    // to read the language's literals, not the subset its author happened to type.
+    SLEEP_RE       = /setTimeout\(\s*[A-Za-z_$][\w$]*\s*,\s*([0-9][0-9_]*(?:\.[0-9_]+)?(?:[eE][+-]?[0-9]+)?)\s*\)/g,
     THRESHOLD_MS   = 1000;
+
+/**
+ * @summary Reads a JavaScript numeric literal as milliseconds.
+ *
+ * Separators are cosmetic to the language, so they are cosmetic here; exponential form is left to
+ * `Number`, which is the same parser the runtime uses. Comparing by VALUE is the point — the guard's
+ * subject is how long a spec waits, never how the author spelled it.
+ * @param {String} literal As captured from source.
+ * @returns {Number} Milliseconds, or `NaN` when the literal is unreadable.
+ */
+function toMs(literal) {
+    return Number(literal.replaceAll('_', ''))
+}
 
 // The workflow-parity SSOT: every glob this guard READS, so the sibling scanned-subset-of-watched
 // spec can demand the workflow watch them. The baseline belongs here as much as the specs do — it is
@@ -139,47 +156,56 @@ export function findUnjustifiedSleeps({rootDir = ROOT_DIR, files} = {}) {
         const lines = fs.readFileSync(abs, 'utf8').split('\n');
 
         lines.forEach((text, index) => {
-            const match = SLEEP_RE.exec(text);
-
-            if (!match || Number(match[1]) < THRESHOLD_MS) return;
-
             // A guard that fires on prose ABOUT itself is a noise generator, and a noisy gate gets
             // routed around within a week — the trap this whole ticket is against. The pattern appears
             // legitimately in comments explaining the rule and in fixture strings inside this guard's
-            // own spec, neither of which sleeps. Skip a match that is inside a comment line or inside a
-            // quoted literal on its own line.
-            const before = text.slice(0, match.index),
-                  head   = text.trimStart();
+            // own spec, neither of which sleeps. A comment LINE is skipped whole; a quoted literal is
+            // judged per match, because one line can hold both a string and a real call.
+            const head = text.trimStart();
 
             if (head.startsWith('//') || head.startsWith('*') || head.startsWith('/*')) return;
-            if (/['"`]/.test(before.slice(before.lastIndexOf(' ') + 1))) return;
-            if ((before.match(/'/g) || []).length % 2 === 1) return;
-            if ((before.match(/"/g) || []).length % 2 === 1) return;
-            if ((before.match(/`/g) || []).length % 2 === 1) return;
 
-            const context = lines.slice(Math.max(0, index - LOOKBEHIND), index + 1).join('\n');
+            // EVERY candidate on the line, not just the leftmost. A non-global `exec` returns one match,
+            // so a sub-threshold call earlier on the same line consumed the only inspection the line
+            // ever got and the real site behind it was never examined. A gate that stops at the first
+            // thing it sees is not a census — it is a sample of size one, and the bypass costs nothing
+            // to write by accident.
+            for (const match of text.matchAll(SLEEP_RE)) {
+                const ms = toMs(match[1]);
 
-            // An `out-waits:` site is DISCHARGED here and simultaneously recorded as backlog. Both
-            // are true at once and the distinction is the whole point: the wait is now accounted for,
-            // and the constant it names is still hardcoded, so the wall clock is still being paid.
-            if (context.includes('out-waits:')) {
-                backlog.push({
+                if (!Number.isFinite(ms) || ms < THRESHOLD_MS) continue;
+
+                const before = text.slice(0, match.index);
+
+                if (/['"`]/.test(before.slice(before.lastIndexOf(' ') + 1))) continue;
+                if ((before.match(/'/g) || []).length % 2 === 1) continue;
+                if ((before.match(/"/g) || []).length % 2 === 1) continue;
+                if ((before.match(/`/g) || []).length % 2 === 1) continue;
+
+                const context = lines.slice(Math.max(0, index - LOOKBEHIND), index + 1).join('\n');
+
+                // An `out-waits:` site is DISCHARGED here and simultaneously recorded as backlog. Both
+                // are true at once and the distinction is the whole point: the wait is now accounted for,
+                // and the constant it names is still hardcoded, so the wall clock is still being paid.
+                if (context.includes('out-waits:')) {
+                    backlog.push({
+                        file: path.relative(rootDir, abs).replaceAll('\\', '/'),
+                        line: index + 1,
+                        ms
+                    });
+
+                    continue
+                }
+
+                if (JUSTIFICATIONS.some(marker => context.includes(marker))) continue;
+
+                found.push({
                     file: path.relative(rootDir, abs).replaceAll('\\', '/'),
                     line: index + 1,
-                    ms  : Number(match[1])
-                });
-
-                return
+                    ms,
+                    text: text.trim()
+                })
             }
-
-            if (JUSTIFICATIONS.some(marker => context.includes(marker))) return;
-
-            found.push({
-                file: path.relative(rootDir, abs).replaceAll('\\', '/'),
-                line: index + 1,
-                ms  : Number(match[1]),
-                text: text.trim()
-            })
         })
     }
 

--- a/buildScripts/util/check-fixed-sleeps.mjs
+++ b/buildScripts/util/check-fixed-sleeps.mjs
@@ -63,11 +63,20 @@
  *
  * ## Baseline mechanics
  *
- * Pre-existing sites are grandfathered per-site in `check-fixed-sleeps-baseline.json`. A baseline row
- * whose site no longer matches **also fails**: the baseline may only shrink, and it cannot outlive the
- * sites it grandfathers. Per-site rather than per-file deliberately — these sites tend to CONVERT rather
- * than vanish (a sleep becomes a readiness poll), and a file count would silently absorb a conversion
- * that left the site present.
+ * Pre-existing sites are grandfathered in `check-fixed-sleeps-baseline.json` as `{file, text, count}`
+ * entries, and reconciliation compares OCCURRENCE COUNTS in both directions: above the allowance is
+ * fresh, below it is stale. The baseline may only shrink and cannot outlive the sites it grandfathers.
+ *
+ * Counting rather than testing membership is load-bearing. These sites are overwhelmingly the
+ * byte-identical line `setTimeout(resolve, 1000)` — 64 occurrences in one file — so a key of file+text
+ * collapses them into a single entry, and removing 63 of the 64 leaves that key still matching, nothing
+ * stale, and the guard green. Site granularity was chosen precisely so a conversion (a sleep becoming a
+ * readiness poll) could not be absorbed silently; membership keys hand back the very weakness the
+ * choice rejected.
+ *
+ * Line numbers stay OUT of the key on purpose: they shift under any edit above them, so keying on them
+ * turns every unrelated change into a wall of false staleness — and a guard nobody can keep green gets
+ * routed around, which is the failure this ticket is about.
  */
 import fs              from 'node:fs';
 import path            from 'node:path';
@@ -118,7 +127,7 @@ function collectSpecs(dir, out = []) {
  * @param {Object} [options]
  * @param {String} [options.rootDir] Repo root.
  * @param {String[]} [options.files] Absolute spec paths; defaults to the whole unit tree.
- * @returns {Array<{file: String, line: Number, ms: Number, text: String}>}
+ * @returns {{backlog: Array<Object>, sites: Array<{file: String, line: Number, ms: Number, text: String}>}}
  */
 export function findUnjustifiedSleeps({rootDir = ROOT_DIR, files} = {}) {
     const
@@ -133,6 +142,20 @@ export function findUnjustifiedSleeps({rootDir = ROOT_DIR, files} = {}) {
             const match = SLEEP_RE.exec(text);
 
             if (!match || Number(match[1]) < THRESHOLD_MS) return;
+
+            // A guard that fires on prose ABOUT itself is a noise generator, and a noisy gate gets
+            // routed around within a week — the trap this whole ticket is against. The pattern appears
+            // legitimately in comments explaining the rule and in fixture strings inside this guard's
+            // own spec, neither of which sleeps. Skip a match that is inside a comment line or inside a
+            // quoted literal on its own line.
+            const before = text.slice(0, match.index),
+                  head   = text.trimStart();
+
+            if (head.startsWith('//') || head.startsWith('*') || head.startsWith('/*')) return;
+            if (/['"`]/.test(before.slice(before.lastIndexOf(' ') + 1))) return;
+            if ((before.match(/'/g) || []).length % 2 === 1) return;
+            if ((before.match(/"/g) || []).length % 2 === 1) return;
+            if ((before.match(/`/g) || []).length % 2 === 1) return;
 
             const context = lines.slice(Math.max(0, index - LOOKBEHIND), index + 1).join('\n');
 
@@ -160,9 +183,9 @@ export function findUnjustifiedSleeps({rootDir = ROOT_DIR, files} = {}) {
         })
     }
 
-    found.backlog = backlog;
-
-    return found
+    // A plain object, never an array carrying an extra property: `toEqual([])` fails against an array
+    // with own properties, so the smuggled field turned a passing assertion into a confusing red.
+    return {backlog, sites: found}
 }
 
 /**
@@ -174,14 +197,32 @@ export function findUnjustifiedSleeps({rootDir = ROOT_DIR, files} = {}) {
  */
 export function reconcile({found, baseline}) {
     const
-        key      = row => `${row.file}::${row.text}`,
-        liveKeys = new Set(found.map(key)),
-        rowKeys  = new Set(baseline.map(key));
+        key   = row => `${row.file}::${row.text}`,
+        tally = rows => rows.reduce((map, row) => map.set(key(row), (map.get(key(row)) || 0) + (row.count || 1)), new Map()),
+        live  = tally(found),
+        rowed = tally(baseline),
+        fresh = [],
+        stale = [];
 
-    return {
-        fresh: found.filter(row => !rowKeys.has(key(row))),
-        stale: baseline.filter(row => !liveKeys.has(key(row)))
+    // COUNTS, not membership. 64 of these sites are the byte-identical line `setTimeout(resolve,
+    // 1000)`, so a Set keyed on file+text collapses them to ONE entry — and removing 63 of the 64
+    // would leave the key still matching, nothing stale, and the guard green. That is weaker than the
+    // per-file count the baseline was chosen OVER, wearing per-site clothes. Counting occurrences
+    // restores site granularity without keying on line numbers, which shift under any edit above them
+    // and would turn every unrelated change into a wall of false staleness.
+    for (const [id, count] of live) {
+        const allowed = rowed.get(id) || 0;
+
+        if (count > allowed) fresh.push({...found.find(row => key(row) === id), count: count - allowed})
     }
+
+    for (const [id, count] of rowed) {
+        const actual = live.get(id) || 0;
+
+        if (actual < count) stale.push({...baseline.find(row => key(row) === id), count: count - actual})
+    }
+
+    return {fresh, stale}
 }
 
 /**
@@ -197,15 +238,15 @@ export function reconcile({found, baseline}) {
  */
 function main() {
     const
-        baselinePath   = path.join(ROOT_DIR, BASELINE_REL),
-        baseline       = fs.existsSync(baselinePath) ? JSON.parse(fs.readFileSync(baselinePath, 'utf8')) : [],
-        found          = findUnjustifiedSleeps({}),
-        {fresh, stale} = reconcile({found, baseline});
+        baselinePath     = path.join(ROOT_DIR, BASELINE_REL),
+        baseline         = fs.existsSync(baselinePath) ? JSON.parse(fs.readFileSync(baselinePath, 'utf8')) : [],
+        {backlog, sites} = findUnjustifiedSleeps({}),
+        {fresh, stale}   = reconcile({baseline, found: sites});
 
-    const backlogMs = (found.backlog || []).reduce((sum, row) => sum + row.ms, 0);
+    const backlogMs = backlog.reduce((sum, row) => sum + row.ms, 0);
 
     if (fresh.length === 0 && stale.length === 0) {
-        console.log(`check-fixed-sleeps: OK — ${found.length} unaccounted site(s) baselined, 0 new, 0 stale.`);
+        console.log(`check-fixed-sleeps: OK — ${sites.length} unaccounted site(s) baselined, 0 new, 0 stale.`);
 
         // TWO numbers, opposite meanings, printed together because a reader consumes the printed line and
         // not the docstring. The baseline measures ANNOTATION DEBT and should reach zero. The backlog
@@ -213,8 +254,8 @@ function main() {
         // `out-waits:` site can be annotated truthfully, emptying the baseline, without the suite getting
         // one millisecond faster. A zeroed baseline means every wait is accounted for. It does NOT mean
         // the suite is fast, and anything reading it as a speed metric is reading the wrong number.
-        if (found.backlog?.length) {
-            console.log(`check-fixed-sleeps: ${found.backlog.length} site(s) carry \`out-waits:\` — ~${(backlogMs / 1000).toFixed(1)}s of wall clock still paid to hardcoded constants.`);
+        if (backlog.length) {
+            console.log(`check-fixed-sleeps: ${backlog.length} site(s) carry \`out-waits:\` — ~${(backlogMs / 1000).toFixed(1)}s of wall clock still paid to hardcoded constants.`);
             console.log('  This is a LEAF-CANDIDATE BACKLOG, not a failure. It rising is a finding; it falling means a constant became injectable.')
         }
 

--- a/buildScripts/util/check-fixed-sleeps.mjs
+++ b/buildScripts/util/check-fixed-sleeps.mjs
@@ -88,11 +88,18 @@ const
     LOOKBEHIND     = 3,
     ROOT_DIR       = process.cwd(),
     SCAN_ROOT      = 'test/playwright/unit',
-    // Global, and the delay is captured as a NUMERIC LITERAL rather than a digit run. `(\d+)` could not
-    // see `1_000` or `1e3` at all — both are ordinary JavaScript spellings of this threshold, and both
-    // slipped the gate completely rather than merely being mis-measured. A guard that reads source has
-    // to read the language's literals, not the subset its author happened to type.
-    SLEEP_RE       = /setTimeout\(\s*[A-Za-z_$][\w$]*\s*,\s*([0-9][0-9_]*(?:\.[0-9_]+)?(?:[eE][+-]?[0-9]+)?)\s*\)/g,
+    // Global, and the delay is captured as a permissive TOKEN rather than a hand-rolled numeric
+    // grammar. This pattern has now been wrong twice in the same direction: `(\d+)` missed `1_000` and
+    // `1e3`, and the decimal-shaped replacement still missed `0x3e8`, `0o1750`, `0b1111101000`, `1000.`
+    // and `.1e4` — every one a legal spelling of this exact threshold. Enumerating spellings loses to
+    // the language, because the language keeps having more of them.
+    //
+    // So the token is matched loosely and `Number` decides, since `Number` IS the parser the runtime
+    // uses on this argument. Anything that is not a number — an identifier, a named constant, a call —
+    // yields NaN and is skipped, which is the verdict a stricter pattern reached by failing to match.
+    // Delegating to the real parser is not a shortcut here; it is the only way the guard's claim can be
+    // true for spellings its author never thought of.
+    SLEEP_RE       = /setTimeout\(\s*[A-Za-z_$][\w$]*\s*,\s*([\w.+\-]+)\s*\)/g,
     THRESHOLD_MS   = 1000;
 
 /**

--- a/buildScripts/util/check-fixed-sleeps.mjs
+++ b/buildScripts/util/check-fixed-sleeps.mjs
@@ -249,10 +249,15 @@ export function reconcile({found, baseline}) {
         if (count > allowed) fresh.push({...found.find(row => key(row) === id), count: count - allowed})
     }
 
+    // `remaining` rides along because the surplus alone cannot tell a row that lost every site from one
+    // that lost some, and those take OPPOSITE remedies: the first is deleted, the second is reduced to
+    // the survivors. Deleting a partially-converted row un-accounts the sites it still legitimately
+    // grandfathers, which re-reports them as `fresh` — the guard fails from the other side, and the
+    // author reads a conversion they just made as a regression they just introduced.
     for (const [id, count] of rowed) {
         const actual = live.get(id) || 0;
 
-        if (actual < count) stale.push({...baseline.find(row => key(row) === id), count: count - actual})
+        if (actual < count) stale.push({...baseline.find(row => key(row) === id), count: count - actual, remaining: actual})
     }
 
     return {fresh, stale}
@@ -321,11 +326,15 @@ function main() {
     if (stale.length) {
         console.error(`\ncheck-fixed-sleeps: ${stale.length} baseline row(s) no longer match a live site — the baseline may only shrink:\n`);
 
-        for (const row of stale) console.error(`  ${row.file}  ${row.text}`);
+        for (const row of stale) console.error(row.remaining
+            ? `  ${row.file}  ${row.text}\n      ${row.count} of these are gone — set "count" to ${row.remaining}, do NOT delete the row.`
+            : `  ${row.file}  ${row.text}\n      every site is gone — delete the row.`);
 
         console.error(`
-    Remove these rows. A site that was converted (a sleep becoming a readiness poll) or removed leaves its
-    row behind, and a baseline permitted to outlive its sites stops describing anything.`)
+    A site that was converted (a sleep becoming a readiness poll) or removed leaves its row behind, and a
+    baseline permitted to outlive its sites stops describing anything. Reduce the count to the survivors;
+    delete only a row that has none. Deleting a row that still has live sites un-accounts them, and they
+    come straight back as NEW unaccounted waits — the conversion you just made, reported as a regression.`)
     }
 
     process.exit(1)

--- a/buildScripts/util/check-fixed-sleeps.mjs
+++ b/buildScripts/util/check-fixed-sleeps.mjs
@@ -69,8 +69,9 @@
  * than vanish (a sleep becomes a readiness poll), and a file count would silently absorb a conversion
  * that left the site present.
  */
-import fs   from 'node:fs';
-import path from 'node:path';
+import fs              from 'node:fs';
+import path            from 'node:path';
+import {fileURLToPath} from 'node:url';
 
 const
     BASELINE_REL   = 'buildScripts/util/check-fixed-sleeps-baseline.json',
@@ -80,6 +81,15 @@ const
     SCAN_ROOT      = 'test/playwright/unit',
     SLEEP_RE       = /setTimeout\(\s*[A-Za-z_$][\w$]*\s*,\s*(\d+)\s*\)/,
     THRESHOLD_MS   = 1000;
+
+// The workflow-parity SSOT: every glob this guard READS, so the sibling scanned-subset-of-watched
+// spec can demand the workflow watch them. The baseline belongs here as much as the specs do — it is
+// an INPUT to the verdict, so a run that does not re-trigger on a baseline edit would let a site be
+// blessed by editing the record of what exists, with nothing re-reading reality.
+export const SCAN_SURFACE = Object.freeze([
+    `${SCAN_ROOT}/**/*.mjs`,
+    BASELINE_REL
+]);
 
 /**
  * @summary Recursively collects `.mjs` files under one directory.
@@ -174,62 +184,79 @@ export function reconcile({found, baseline}) {
     }
 }
 
-const
-    baselinePath   = path.join(ROOT_DIR, BASELINE_REL),
-    baseline       = fs.existsSync(baselinePath) ? JSON.parse(fs.readFileSync(baselinePath, 'utf8')) : [],
-    found          = findUnjustifiedSleeps({}),
-    {fresh, stale} = reconcile({found, baseline});
+/**
+ * @summary Runs the guard as a CLI and exits with its verdict.
+ *
+ * Guarded on direct invocation, and that guard is load-bearing rather than tidy. This module EXPORTS
+ * its scan surface so the workflow-parity spec can import it as authority instead of hand-copying
+ * globs — and an unguarded top-level body then runs the entire lint, including `process.exit()`,
+ * inside every process that imports it. Inside a Playwright worker that exit kills the worker with no
+ * failure message: the suite reports NOTHING rather than reporting red, which is strictly worse than
+ * a normal failure because nobody can see it.
+ * @returns {void}
+ */
+function main() {
+    const
+        baselinePath   = path.join(ROOT_DIR, BASELINE_REL),
+        baseline       = fs.existsSync(baselinePath) ? JSON.parse(fs.readFileSync(baselinePath, 'utf8')) : [],
+        found          = findUnjustifiedSleeps({}),
+        {fresh, stale} = reconcile({found, baseline});
 
-const backlogMs = (found.backlog || []).reduce((sum, row) => sum + row.ms, 0);
+    const backlogMs = (found.backlog || []).reduce((sum, row) => sum + row.ms, 0);
 
-if (fresh.length === 0 && stale.length === 0) {
-    console.log(`check-fixed-sleeps: OK — ${found.length} unaccounted site(s) baselined, 0 new, 0 stale.`);
+    if (fresh.length === 0 && stale.length === 0) {
+        console.log(`check-fixed-sleeps: OK — ${found.length} unaccounted site(s) baselined, 0 new, 0 stale.`);
 
-    // TWO numbers, opposite meanings, printed together because a reader consumes the printed line and
-    // not the docstring. The baseline measures ANNOTATION DEBT and should reach zero. The backlog
-    // measures WALL CLOCK STILL BEING PAID and reaching zero is a different, harder thing: every
-    // `out-waits:` site can be annotated truthfully, emptying the baseline, without the suite getting
-    // one millisecond faster. A zeroed baseline means every wait is accounted for. It does NOT mean
-    // the suite is fast, and anything reading it as a speed metric is reading the wrong number.
-    if (found.backlog?.length) {
-        console.log(`check-fixed-sleeps: ${found.backlog.length} site(s) carry \`out-waits:\` — ~${(backlogMs / 1000).toFixed(1)}s of wall clock still paid to hardcoded constants.`);
-        console.log('  This is a LEAF-CANDIDATE BACKLOG, not a failure. It rising is a finding; it falling means a constant became injectable.')
+        // TWO numbers, opposite meanings, printed together because a reader consumes the printed line and
+        // not the docstring. The baseline measures ANNOTATION DEBT and should reach zero. The backlog
+        // measures WALL CLOCK STILL BEING PAID and reaching zero is a different, harder thing: every
+        // `out-waits:` site can be annotated truthfully, emptying the baseline, without the suite getting
+        // one millisecond faster. A zeroed baseline means every wait is accounted for. It does NOT mean
+        // the suite is fast, and anything reading it as a speed metric is reading the wrong number.
+        if (found.backlog?.length) {
+            console.log(`check-fixed-sleeps: ${found.backlog.length} site(s) carry \`out-waits:\` — ~${(backlogMs / 1000).toFixed(1)}s of wall clock still paid to hardcoded constants.`);
+            console.log('  This is a LEAF-CANDIDATE BACKLOG, not a failure. It rising is a finding; it falling means a constant became injectable.')
+        }
+
+        process.exit(0)
     }
 
-    process.exit(0)
-}
+    if (fresh.length) {
+        console.error(`check-fixed-sleeps: ${fresh.length} fixed sleep(s) >= ${THRESHOLD_MS}ms with nothing said about what they wait for:\n`);
 
-if (fresh.length) {
-    console.error(`check-fixed-sleeps: ${fresh.length} fixed sleep(s) >= ${THRESHOLD_MS}ms with nothing said about what they wait for:\n`);
+        for (const row of fresh) {
+            console.error(`  ${row.file}:${row.line}  (${row.ms}ms)`);
+            console.error(`    ${row.text}`)
+        }
 
-    for (const row of fresh) {
-        console.error(`  ${row.file}:${row.line}  (${row.ms}ms)`);
-        console.error(`    ${row.text}`)
+        console.error(`
+    Say what the wait is FOR. Either marker, on the line or within ${LOOKBEHIND} lines above it:
+
+      // out-waits: <the production constant this is larger than>
+      // wall-clock-under-test: <why elapsed time is the thing being asserted>
+
+    Both are legitimate outcomes. \`out-waits:\` is the one that pays forward — a named constant is a
+    constant somebody can make injectable, which is the repair that actually removes the wall clock.
+
+    Do NOT reach for deleting the wait. Where the surrounding code polls on a fixed interval, removing a
+    sleep pushes injection before the next watermark and costs a WHOLE extra cycle: one measured spec went
+    6.4s -> 12.2s on deletion, with every assertion still passing. A sleep you cannot explain is a finding;
+    a sleep you delete without measuring is a slower suite that reports green.`)
     }
 
-    console.error(`
-Say what the wait is FOR. Either marker, on the line or within ${LOOKBEHIND} lines above it:
+    if (stale.length) {
+        console.error(`\ncheck-fixed-sleeps: ${stale.length} baseline row(s) no longer match a live site — the baseline may only shrink:\n`);
 
-  // out-waits: <the production constant this is larger than>
-  // wall-clock-under-test: <why elapsed time is the thing being asserted>
+        for (const row of stale) console.error(`  ${row.file}  ${row.text}`);
 
-Both are legitimate outcomes. \`out-waits:\` is the one that pays forward — a named constant is a
-constant somebody can make injectable, which is the repair that actually removes the wall clock.
+        console.error(`
+    Remove these rows. A site that was converted (a sleep becoming a readiness poll) or removed leaves its
+    row behind, and a baseline permitted to outlive its sites stops describing anything.`)
+    }
 
-Do NOT reach for deleting the wait. Where the surrounding code polls on a fixed interval, removing a
-sleep pushes injection before the next watermark and costs a WHOLE extra cycle: one measured spec went
-6.4s -> 12.2s on deletion, with every assertion still passing. A sleep you cannot explain is a finding;
-a sleep you delete without measuring is a slower suite that reports green.`)
+    process.exit(1)
 }
 
-if (stale.length) {
-    console.error(`\ncheck-fixed-sleeps: ${stale.length} baseline row(s) no longer match a live site — the baseline may only shrink:\n`);
-
-    for (const row of stale) console.error(`  ${row.file}  ${row.text}`);
-
-    console.error(`
-Remove these rows. A site that was converted (a sleep becoming a readiness poll) or removed leaves its
-row behind, and a baseline permitted to outlive its sites stops describing anything.`)
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+    main()
 }
-
-process.exit(1)

--- a/buildScripts/util/check-fixed-sleeps.mjs
+++ b/buildScripts/util/check-fixed-sleeps.mjs
@@ -67,17 +67,23 @@
  * entries, and reconciliation compares OCCURRENCE COUNTS in both directions: above the allowance is
  * fresh, below it is stale. The baseline may only shrink and cannot outlive the sites it grandfathers.
  *
- * Counting rather than testing membership is load-bearing. These sites are overwhelmingly the
- * byte-identical line `setTimeout(resolve, 1000)` — 64 occurrences in one file — so a key of file+text
- * collapses them into a single entry, and removing 63 of the 64 leaves that key still matching, nothing
- * stale, and the guard green. Site granularity was chosen precisely so a conversion (a sleep becoming a
- * readiness poll) could not be absorbed silently; membership keys hand back the very weakness the
- * choice rejected.
+ * Counting rather than testing membership is load-bearing. These sites are overwhelmingly ONE
+ * byte-identical line, `setTimeout(resolve, 1000)`, repeated dozens of times in a single file — so a
+ * key of file+text collapses them into a single entry, and removing all but one of them leaves that
+ * key still matching, nothing stale, and the guard green. Site granularity was chosen precisely so a
+ * conversion (a sleep becoming a readiness poll) could not be absorbed silently; membership keys hand
+ * back the very weakness the choice rejected.
+ *
+ * The live count is deliberately NOT written here. It is in the baseline, which is the one place that
+ * has to be right, and a second copy in prose is a second thing to keep true: this comment said 64
+ * while the tree held 63 for as long as it took a reviewer to notice, inside the file whose whole
+ * subject is counts being accurate. A number worth citing is worth reading from its source.
  *
  * Line numbers stay OUT of the key on purpose: they shift under any edit above them, so keying on them
  * turns every unrelated change into a wall of false staleness — and a guard nobody can keep green gets
  * routed around, which is the failure this ticket is about.
  */
+import {parse}         from 'acorn';
 import fs              from 'node:fs';
 import path            from 'node:path';
 import {fileURLToPath} from 'node:url';
@@ -88,31 +94,61 @@ const
     LOOKBEHIND     = 3,
     ROOT_DIR       = process.cwd(),
     SCAN_ROOT      = 'test/playwright/unit',
-    // Global, and the delay is captured as a permissive TOKEN rather than a hand-rolled numeric
-    // grammar. This pattern has now been wrong twice in the same direction: `(\d+)` missed `1_000` and
-    // `1e3`, and the decimal-shaped replacement still missed `0x3e8`, `0o1750`, `0b1111101000`, `1000.`
-    // and `.1e4` — every one a legal spelling of this exact threshold. Enumerating spellings loses to
-    // the language, because the language keeps having more of them.
-    //
-    // So the token is matched loosely and `Number` decides, since `Number` IS the parser the runtime
-    // uses on this argument. Anything that is not a number — an identifier, a named constant, a call —
-    // yields NaN and is skipped, which is the verdict a stricter pattern reached by failing to match.
-    // Delegating to the real parser is not a shortcut here; it is the only way the guard's claim can be
-    // true for spellings its author never thought of.
-    SLEEP_RE       = /setTimeout\(\s*[A-Za-z_$][\w$]*\s*,\s*([\w.+\-]+)\s*\)/g,
     THRESHOLD_MS   = 1000;
 
 /**
- * @summary Reads a JavaScript numeric literal as milliseconds.
+ * @summary Yields every `CallExpression` in an ESTree tree.
  *
- * Separators are cosmetic to the language, so they are cosmetic here; exponential form is left to
- * `Number`, which is the same parser the runtime uses. Comparing by VALUE is the point — the guard's
- * subject is how long a spec waits, never how the author spelled it.
- * @param {String} literal As captured from source.
- * @returns {Number} Milliseconds, or `NaN` when the literal is unreadable.
+ * A generic descent rather than a dependency: the walk needs one node type, and `acorn-walk` would be
+ * a second package to keep in step with the parser for that. `loc` is skipped because it is metadata
+ * with a `start` object that the descent would otherwise recurse into for nothing.
+ * @param {Object} node Any ESTree node, array of nodes, or leaf.
+ * @yields {Object} Each `CallExpression`, in source order.
  */
-function toMs(literal) {
-    return Number(literal.replaceAll('_', ''))
+function* callExpressions(node) {
+    if (node === null || typeof node !== 'object') return;
+
+    if (Array.isArray(node)) {
+        for (const child of node) yield* callExpressions(child);
+        return
+    }
+
+    if (node.type === 'CallExpression') yield node;
+
+    for (const key of Object.keys(node)) {
+        if (key !== 'loc') yield* callExpressions(node[key])
+    }
+}
+
+/**
+ * @summary Reads a `setTimeout` call's delay in milliseconds, or `NaN` when it is not a fixed wait.
+ *
+ * The delay comes off the parsed node rather than off text, so every spelling of this threshold —
+ * `1_000`, `1e3`, `0x3e8`, `0o1750`, `0b1111101000`, `1000.`, `.1e4`, and `(1000)` — arrives as the
+ * same `Literal` value of 1000. That is the whole reason this moved to the AST: the previous matcher
+ * was wrong twice in the same direction while enumerating spellings, because the language keeps
+ * having more of them, and it was wrong a third time on FORMATTING, which has no bottom at all.
+ *
+ * A named constant is an `Identifier`, not a `Literal`, so it yields `NaN` and is skipped — the wait
+ * names what it waits for, which is exactly what this guard asks of it.
+ * @param {Object} node A `CallExpression` node.
+ * @returns {Number} Milliseconds, or `NaN` when this is not a fixed-delay `setTimeout`.
+ */
+function fixedWaitMs(node) {
+    if (node.callee?.type !== 'Identifier' || node.callee.name !== 'setTimeout') return NaN;
+
+    // The callback arm stays an IDENTIFIER, which is the contract the previous matcher enforced through
+    // its `[A-Za-z_$][\w$]*` group. Dropping the restriction is defensible on the merits — an inline
+    // `setTimeout(() => {…}, 8000)` waits just as long — but it is a widening of SCOPE, not the
+    // formatting-independence this change is for, and it is not free: measured against the tree at this
+    // head, the unrestricted walk surfaces 63 further unaccounted sites. Baselining 63 rows inside a fix
+    // for three parse forms would make one diff argue two different cases. Deferred with its number
+    // taken, so the successor starts from evidence instead of re-measuring.
+    if (node.arguments[0]?.type !== 'Identifier') return NaN;
+
+    const delay = node.arguments[1];
+
+    return delay?.type === 'Literal' && typeof delay.value === 'number' ? delay.value : NaN
 }
 
 // The workflow-parity SSOT: every glob this guard READS, so the sibling scanned-subset-of-watched
@@ -160,60 +196,63 @@ export function findUnjustifiedSleeps({rootDir = ROOT_DIR, files} = {}) {
         found   = [];
 
     for (const abs of specs) {
-        const lines = fs.readFileSync(abs, 'utf8').split('\n');
+        const
+            source = fs.readFileSync(abs, 'utf8'),
+            lines  = source.split('\n');
 
-        lines.forEach((text, index) => {
-            // A guard that fires on prose ABOUT itself is a noise generator, and a noisy gate gets
-            // routed around within a week — the trap this whole ticket is against. The pattern appears
-            // legitimately in comments explaining the rule and in fixture strings inside this guard's
-            // own spec, neither of which sleeps. A comment LINE is skipped whole; a quoted literal is
-            // judged per match, because one line can hold both a string and a real call.
-            const head = text.trimStart();
+        let tree;
 
-            if (head.startsWith('//') || head.startsWith('*') || head.startsWith('/*')) return;
+        // A file the guard cannot read is reported, never skipped. Skipping is the exact failure this
+        // guard exists to prevent — an unscanned file is indistinguishable from a clean one, and the
+        // difference only surfaces as a wait nobody accounted for.
+        try {
+            tree = parse(source, {ecmaVersion: 'latest', locations: true, sourceType: 'module'})
+        } catch (cause) {
+            throw new Error(`check-fixed-sleeps: cannot parse ${path.relative(rootDir, abs)}`, {cause})
+        }
 
-            // EVERY candidate on the line, not just the leftmost. A non-global `exec` returns one match,
-            // so a sub-threshold call earlier on the same line consumed the only inspection the line
-            // ever got and the real site behind it was never examined. A gate that stops at the first
-            // thing it sees is not a census — it is a sample of size one, and the bypass costs nothing
-            // to write by accident.
-            for (const match of text.matchAll(SLEEP_RE)) {
-                const ms = toMs(match[1]);
+        // Candidates come off the PARSE TREE, not off text. The matcher this replaced read one source
+        // line at a time, so a call split across lines, a delay in parentheses, and an interposed
+        // comment each produced zero candidates — three parser-valid fixed waits, silently green.
+        // Formatting has no bottom: every fix to a text pattern invites the next spelling.
+        //
+        // It also DELETES work rather than adding it. The old path needed a comment-line skip and four
+        // quote-balancing tests to keep prose and fixture strings from firing the guard; the parser
+        // never hands those over in the first place, because they are not calls.
+        for (const node of callExpressions(tree)) {
+            const ms = fixedWaitMs(node);
 
-                if (!Number.isFinite(ms) || ms < THRESHOLD_MS) continue;
+            if (!Number.isFinite(ms) || ms < THRESHOLD_MS) continue;
 
-                const before = text.slice(0, match.index);
+            const
+                index   = node.loc.start.line - 1,
+                // The site's FIRST line keys the baseline, which is what keeps existing rows matching:
+                // for a single-line call this is the same string the line-based matcher produced.
+                text    = lines[index] ?? '',
+                context = lines.slice(Math.max(0, index - LOOKBEHIND), index + 1).join('\n');
 
-                if (/['"`]/.test(before.slice(before.lastIndexOf(' ') + 1))) continue;
-                if ((before.match(/'/g) || []).length % 2 === 1) continue;
-                if ((before.match(/"/g) || []).length % 2 === 1) continue;
-                if ((before.match(/`/g) || []).length % 2 === 1) continue;
-
-                const context = lines.slice(Math.max(0, index - LOOKBEHIND), index + 1).join('\n');
-
-                // An `out-waits:` site is DISCHARGED here and simultaneously recorded as backlog. Both
-                // are true at once and the distinction is the whole point: the wait is now accounted for,
-                // and the constant it names is still hardcoded, so the wall clock is still being paid.
-                if (context.includes('out-waits:')) {
-                    backlog.push({
-                        file: path.relative(rootDir, abs).replaceAll('\\', '/'),
-                        line: index + 1,
-                        ms
-                    });
-
-                    continue
-                }
-
-                if (JUSTIFICATIONS.some(marker => context.includes(marker))) continue;
-
-                found.push({
+            // An `out-waits:` site is DISCHARGED here and simultaneously recorded as backlog. Both
+            // are true at once and the distinction is the whole point: the wait is now accounted for,
+            // and the constant it names is still hardcoded, so the wall clock is still being paid.
+            if (context.includes('out-waits:')) {
+                backlog.push({
                     file: path.relative(rootDir, abs).replaceAll('\\', '/'),
                     line: index + 1,
-                    ms,
-                    text: text.trim()
-                })
+                    ms
+                });
+
+                continue
             }
-        })
+
+            if (JUSTIFICATIONS.some(marker => context.includes(marker))) continue;
+
+            found.push({
+                file: path.relative(rootDir, abs).replaceAll('\\', '/'),
+                line: index + 1,
+                ms,
+                text: text.trim()
+            })
+        }
     }
 
     // A plain object, never an array carrying an extra property: `toEqual([])` fails against an array
@@ -237,12 +276,12 @@ export function reconcile({found, baseline}) {
         fresh = [],
         stale = [];
 
-    // COUNTS, not membership. 64 of these sites are the byte-identical line `setTimeout(resolve,
-    // 1000)`, so a Set keyed on file+text collapses them to ONE entry — and removing 63 of the 64
-    // would leave the key still matching, nothing stale, and the guard green. That is weaker than the
-    // per-file count the baseline was chosen OVER, wearing per-site clothes. Counting occurrences
-    // restores site granularity without keying on line numbers, which shift under any edit above them
-    // and would turn every unrelated change into a wall of false staleness.
+    // COUNTS, not membership. Most of these sites are ONE byte-identical line, `setTimeout(resolve,
+    // 1000)`, repeated dozens of times in a single file, so a Set keyed on file+text collapses them to
+    // ONE entry — and removing all but one would leave the key still matching, nothing stale, and the
+    // guard green. That is weaker than the per-file count the baseline was chosen OVER, wearing
+    // per-site clothes. Counting occurrences restores site granularity without keying on line numbers,
+    // which shift under any edit above them and would turn every unrelated change into false staleness.
     for (const [id, count] of live) {
         const allowed = rowed.get(id) || 0;
 

--- a/package.json
+++ b/package.json
@@ -262,7 +262,8 @@
         ],
         "test/**/*.mjs": [
             "node ./buildScripts/util/check-aiconfig-test-mutation.mjs",
-            "node ./buildScripts/util/check-derived-domain.mjs"
+            "node ./buildScripts/util/check-derived-domain.mjs",
+            "node ./buildScripts/util/check-fixed-sleeps.mjs"
         ],
         "ai/**/*.mjs": [
             "node ./buildScripts/util/check-atomic-write-shape.mjs"

--- a/test/playwright/playwright.config.unit.mjs
+++ b/test/playwright/playwright.config.unit.mjs
@@ -11,6 +11,25 @@ const repoRoot   = path.resolve(__dirname, '../..');
 
 process.env.UNIT_TEST_MODE = 'true';
 
+// Retry backoff bases resolve to 1ms for the whole unit run.
+//
+// These belong HERE rather than in the leaf. A `process.env.UNIT_TEST_MODE ? 1 : 1000` branch inside
+// `leaf(...)` bakes imperative env-resolution into the declarative config SSOT, and a per-spec write
+// to the resolved config mutates a singleton every other spec shares. The env layer is the sanctioned
+// seam: the leaf keeps one declarative default, and the test context overrides it the same way any
+// deployment would.
+// ticket-ref-ok: ADR-0019 names both shapes (A4, B4) and is the authority a reader needs to check
+// this placement against; the rule outlives any ticket.
+//
+// What this buys is coverage that was previously traded away for seconds. A retry spec asserts the
+// retry DEPTH and the terminal disposition; the sleep between attempts is not under test, so paying
+// it in real wall-clock is pure cost. The leaseYield spec had already shrunk its `maxRetries` to fit
+// a timeout — a workaround that quietly tested a shallower retry than production ships. Pinning the
+// base lets those specs assert the real depth for free.
+//
+// A spec that genuinely tests timing must not rely on these values; it sets its own and says so.
+process.env.NEO_KB_EMBEDDING_BACKOFF_BASE_MS = '1';
+
 // Brain specs retain the Chroma capability by default. Body-focused runs do not select this
 // project, so Playwright omits its setup dependency entirely instead of booting Chroma before it
 // knows what the command selected. The structural boundary is deliberately conservative: a Brain

--- a/test/playwright/unit/ai/buildScripts/util/check-fixed-sleeps.spec.mjs
+++ b/test/playwright/unit/ai/buildScripts/util/check-fixed-sleeps.spec.mjs
@@ -12,12 +12,17 @@ const
 /**
  * check-fixed-sleeps.mjs — baseline reconciliation.
  *
- * The load-bearing case is the third one. These sites are overwhelmingly the byte-identical line
- * `setTimeout(resolve, 1000)` — 64 occurrences in a single spec file — so any reconciliation keyed on
- * file+text alone collapses them into ONE entry. Removing 63 of the 64 then leaves the key still
- * matching, nothing stale, and the guard green: a baseline that permits 64 sites forever while one
- * remains. That is weaker than the per-file count this baseline was deliberately chosen OVER, wearing
- * per-site clothes, and it is why reconciliation counts occurrences rather than testing membership.
+ * The load-bearing case is the third one. These sites are overwhelmingly ONE byte-identical line,
+ * `setTimeout(resolve, 1000)`, repeated dozens of times in a single spec file — so any reconciliation
+ * keyed on file+text alone collapses them into ONE entry. Removing all but one then leaves the key
+ * still matching, nothing stale, and the guard green: a baseline that permits the original population
+ * forever while a single site remains. That is weaker than the per-file count this baseline was
+ * deliberately chosen OVER, wearing per-site clothes, and it is why reconciliation counts occurrences
+ * rather than testing membership.
+ *
+ * The fixtures below say 64 because a fixture is a stated premise, not a measurement — `site(64)` is
+ * true by construction. The prose above deliberately does NOT, because that would be a claim about a
+ * tree that moves: it read 64 while the tree held 63 until a reviewer caught it.
  *
  * Line numbers are deliberately NOT part of the key: they shift under any edit above them, so keying
  * on them turns every unrelated change into a wall of false staleness — a guard nobody can keep green
@@ -144,6 +149,76 @@ test.describe('check-fixed-sleeps.mjs — baseline reconciliation (#17124)', () 
             expect(sites.map(entry => entry.ms), 'every legal spelling of the threshold is read as milliseconds')
                 .toEqual([5000, 1000, 1000, 1000, 1000, 1000, 1000, 1000, 1000]);
             expect(sites.length, 'the second call on line 1 is not shadowed by the first').toBe(9);
+        } finally {
+            fs.rmSync(dir, {force: true, recursive: true})
+        }
+    });
+
+    test('FORMATTING is not a bypass either — multiline, parenthesised, and comment-interposed calls', async () => {
+        // Found by @neo-gpt on re-review, after the spelling bypasses above were already closed: the
+        // matcher was applied one source LINE at a time, so a call the parser reads as a single
+        // 1000ms wait produced zero candidates whenever a newline or a comment fell inside it. Three
+        // more legal ways to write the same wait, each reported as no wait at all.
+        //
+        // This is why discovery moved to the parse tree. Spellings are enumerable and the previous
+        // fix enumerated them; FORMATTING is not, because whitespace and comments may sit between any
+        // two tokens. A text pattern cannot be made complete here — it can only be made longer.
+        const {findUnjustifiedSleeps} = await import(modulePath);
+
+        const
+            dir     = fs.mkdtempSync(path.join(os.tmpdir(), 'check-fixed-sleeps-fmt-')),
+            fixture = path.join(dir, 'formatting.spec.mjs');
+
+        try {
+            fs.writeFileSync(fixture, [
+                // The control: the single-line form the line-based matcher already caught. It anchors
+                // the other three — without it a zero-detection bug would read as a passing test.
+                "await new Promise(resolve => setTimeout(resolve, 1000));",
+                // 1. The call spans lines, so no single line holds the whole pattern.
+                "await new Promise(resolve => setTimeout(",
+                "    resolve,",
+                "    1000",
+                "));",
+                // 2. The delay is parenthesised — the parser reads the same Literal 1000.
+                "await new Promise(resolve => setTimeout(resolve, (1000)));",
+                // 3. A comment sits between the arguments.
+                "await new Promise(resolve => setTimeout(resolve, /* settle */ 1000));",
+                // The negative control travels with them: widening what the guard SEES must not widen
+                // what it REFUSES, and a named constant stays out regardless of how it is formatted.
+                "await new Promise(resolve => setTimeout(",
+                "    resolve,",
+                "    DELAY_MS",
+                "));"
+            ].join('\n'), 'utf8');
+
+            const {sites} = findUnjustifiedSleeps({files: [fixture], rootDir: dir});
+
+            expect(sites.map(entry => entry.ms), 'all four forms are one 1000ms wait each')
+                .toEqual([1000, 1000, 1000, 1000]);
+            // Line numbers, because "four sites" would also pass if the guard found the control four
+            // times. Each must be the site it claims: the multiline call reports its FIRST line, which
+            // is what keys the baseline.
+            expect(sites.map(entry => entry.line), 'each form is found at its own call site')
+                .toEqual([1, 2, 6, 7]);
+        } finally {
+            fs.rmSync(dir, {force: true, recursive: true})
+        }
+    });
+
+    test('an unparseable spec is reported, never skipped', async () => {
+        // A guard that swallows a parse failure reports the same OK for "nothing to find" and "could
+        // not look", and those differ by exactly the thing it exists to catch.
+        const {findUnjustifiedSleeps} = await import(modulePath);
+
+        const
+            dir     = fs.mkdtempSync(path.join(os.tmpdir(), 'check-fixed-sleeps-bad-')),
+            fixture = path.join(dir, 'broken.spec.mjs');
+
+        try {
+            fs.writeFileSync(fixture, 'const = ;', 'utf8');
+
+            expect(() => findUnjustifiedSleeps({files: [fixture], rootDir: dir}))
+                .toThrow(/cannot parse/)
         } finally {
             fs.rmSync(dir, {force: true, recursive: true})
         }

--- a/test/playwright/unit/ai/buildScripts/util/check-fixed-sleeps.spec.mjs
+++ b/test/playwright/unit/ai/buildScripts/util/check-fixed-sleeps.spec.mjs
@@ -102,14 +102,24 @@ test.describe('check-fixed-sleeps.mjs — baseline reconciliation (#17124)', () 
             fs.writeFileSync(fixture, [
                 "await new Promise(resolve => setTimeout(resolve, 50)); await new Promise(resolve => setTimeout(resolve, 5000));",
                 "await new Promise(resolve => setTimeout(resolve, 1_000));",
-                "await new Promise(resolve => setTimeout(resolve, 1e3));"
+                "await new Promise(resolve => setTimeout(resolve, 1e3));",
+                "await new Promise(resolve => setTimeout(resolve, 1e+3));",
+                "await new Promise(resolve => setTimeout(resolve, 0x3e8));",
+                "await new Promise(resolve => setTimeout(resolve, 0o1750));",
+                "await new Promise(resolve => setTimeout(resolve, 0b1111101000));",
+                "await new Promise(resolve => setTimeout(resolve, 1000.));",
+                "await new Promise(resolve => setTimeout(resolve, .1e4));",
+                // Not a fixed literal: a named constant is already injectable, so it is not this
+                // guard's subject. It is the control proving the loose token match did not turn into
+                // a match-everything — `Number('DELAY_MS')` is NaN and the site is skipped.
+                "await new Promise(resolve => setTimeout(resolve, DELAY_MS));"
             ].join('\n'), 'utf8');
 
             const {sites} = findUnjustifiedSleeps({files: [fixture], rootDir: dir});
 
-            expect(sites.map(entry => entry.ms), 'all three spellings are read as milliseconds')
-                .toEqual([5000, 1000, 1000]);
-            expect(sites.length, 'the second call on line 1 is not shadowed by the first').toBe(3);
+            expect(sites.map(entry => entry.ms), 'every legal spelling of the threshold is read as milliseconds')
+                .toEqual([5000, 1000, 1000, 1000, 1000, 1000, 1000, 1000, 1000]);
+            expect(sites.length, 'the second call on line 1 is not shadowed by the first').toBe(9);
         } finally {
             fs.rmSync(dir, {force: true, recursive: true})
         }

--- a/test/playwright/unit/ai/buildScripts/util/check-fixed-sleeps.spec.mjs
+++ b/test/playwright/unit/ai/buildScripts/util/check-fixed-sleeps.spec.mjs
@@ -1,0 +1,87 @@
+import {test, expect}  from '@playwright/test';
+import path            from 'node:path';
+import {fileURLToPath} from 'node:url';
+
+const
+    __filename = fileURLToPath(import.meta.url),
+    __dirname  = path.dirname(__filename),
+    modulePath = path.resolve(__dirname, '../../../../../../buildScripts/util/check-fixed-sleeps.mjs');
+
+/**
+ * check-fixed-sleeps.mjs — baseline reconciliation.
+ *
+ * The load-bearing case is the third one. These sites are overwhelmingly the byte-identical line
+ * `setTimeout(resolve, 1000)` — 64 occurrences in a single spec file — so any reconciliation keyed on
+ * file+text alone collapses them into ONE entry. Removing 63 of the 64 then leaves the key still
+ * matching, nothing stale, and the guard green: a baseline that permits 64 sites forever while one
+ * remains. That is weaker than the per-file count this baseline was deliberately chosen OVER, wearing
+ * per-site clothes, and it is why reconciliation counts occurrences rather than testing membership.
+ *
+ * Line numbers are deliberately NOT part of the key: they shift under any edit above them, so keying
+ * on them turns every unrelated change into a wall of false staleness — a guard nobody can keep green
+ * gets routed around, which is the failure this whole ticket is about.
+ */
+test.describe('check-fixed-sleeps.mjs — baseline reconciliation (#17124)', () => {
+    let reconcile;
+
+    test.beforeAll(async () => {
+        ({reconcile} = await import(modulePath))
+    });
+
+    const site = (count = 1) => ({count, file: 'a.spec.mjs', text: 'setTimeout(resolve, 1000);'}),
+          many = n => Array.from({length: n}, () => site());
+
+    test('a matching occurrence count is clean in both directions', () => {
+        const {fresh, stale} = reconcile({baseline: [site(64)], found: many(64)});
+
+        expect(fresh, 'nothing new').toEqual([]);
+        expect(stale, 'nothing stale').toEqual([]);
+    });
+
+    test('an ADDED occurrence is fresh even though its text already has a baseline entry', () => {
+        const {fresh, stale} = reconcile({baseline: [site(64)], found: many(65)});
+
+        expect(fresh.length).toBe(1);
+        expect(fresh[0].count, 'one occurrence beyond the allowance').toBe(1);
+        expect(stale).toEqual([]);
+    });
+
+    test('removing ONE of 64 identical sites goes stale — the key-collapse blind spot', () => {
+        const {fresh, stale} = reconcile({baseline: [site(64)], found: many(63)});
+
+        expect(stale.length, 'the shrink must be visible').toBe(1);
+        expect(stale[0].count, 'exactly one occurrence went away').toBe(1);
+        expect(fresh).toEqual([]);
+    });
+
+    test('a fully removed text goes stale for its whole count', () => {
+        const {fresh, stale} = reconcile({baseline: [site(64)], found: []});
+
+        expect(stale[0].count).toBe(64);
+        expect(fresh).toEqual([]);
+    });
+
+    test('the pattern in a COMMENT or a STRING is not a sleep — this file is the fixture', async () => {
+        // This spec's own docstring and its `site()` fixture both contain the literal text the guard
+        // matches, and neither sleeps. A guard that fires on prose about itself is a noise generator,
+        // and a noisy gate gets routed around within a week — the trap this whole ticket is against.
+        // Scanning this very file is the control: it would report two findings under the naive match.
+        const {findUnjustifiedSleeps} = await import(modulePath);
+
+        const {sites} = findUnjustifiedSleeps({
+            files  : [__filename],
+            rootDir: path.resolve(__dirname, '../../../../../..')
+        });
+
+        expect(sites).toEqual([]);
+    });
+
+    test('importing the module runs no lint and exits no process', () => {
+        // The module exports SCAN_SURFACE so the workflow-parity spec can import it as authority. Its
+        // CLI body must therefore stay behind a direct-invocation guard: an unguarded top-level body
+        // calls process.exit() inside whatever imports it, which kills a Playwright worker with NO
+        // failure message — the suite reports nothing rather than red. Reaching this assertion at all
+        // is the proof, since the import happens in beforeAll.
+        expect(typeof reconcile, 'the module imported without exiting the worker').toBe('function');
+    });
+});

--- a/test/playwright/unit/ai/buildScripts/util/check-fixed-sleeps.spec.mjs
+++ b/test/playwright/unit/ai/buildScripts/util/check-fixed-sleeps.spec.mjs
@@ -1,4 +1,6 @@
 import {test, expect}  from '@playwright/test';
+import fs              from 'node:fs';
+import os              from 'node:os';
 import path            from 'node:path';
 import {fileURLToPath} from 'node:url';
 
@@ -74,6 +76,68 @@ test.describe('check-fixed-sleeps.mjs — baseline reconciliation (#17124)', () 
         });
 
         expect(sites).toEqual([]);
+    });
+
+    test('a bypass is a spelling the guard cannot read — every candidate, and the delay by VALUE', async () => {
+        // Three executable bypasses, found by @neo-gpt reading the matcher rather than trusting its
+        // green run against the tree. Each is a legal way to write a one-second wait that the guard
+        // reported as no wait at all — the most expensive kind of gate, because it prints OK.
+        //
+        //   1. `exec` without /g returns the LEFTMOST match, so a sub-threshold call earlier on the
+        //      line consumed the line's only inspection and the real site behind it went unexamined.
+        //   2. `1_000` and 3. `1e3` are ordinary JavaScript spellings of 1000 that a `(\d+)` capture
+        //      cannot match at all — not mis-measured, invisible.
+        //
+        // The fixture lives on disk rather than in this file because the guard's own noise-control
+        // asserts THIS file yields nothing; embedding real call sites here would make two correct
+        // tests contradict each other. Each line is written from inside a quoted string for the same
+        // reason the `site()` fixture is.
+        const {findUnjustifiedSleeps} = await import(modulePath);
+
+        const
+            dir     = fs.mkdtempSync(path.join(os.tmpdir(), 'check-fixed-sleeps-')),
+            fixture = path.join(dir, 'bypass.spec.mjs');
+
+        try {
+            fs.writeFileSync(fixture, [
+                "await new Promise(resolve => setTimeout(resolve, 50)); await new Promise(resolve => setTimeout(resolve, 5000));",
+                "await new Promise(resolve => setTimeout(resolve, 1_000));",
+                "await new Promise(resolve => setTimeout(resolve, 1e3));"
+            ].join('\n'), 'utf8');
+
+            const {sites} = findUnjustifiedSleeps({files: [fixture], rootDir: dir});
+
+            expect(sites.map(entry => entry.ms), 'all three spellings are read as milliseconds')
+                .toEqual([5000, 1000, 1000]);
+            expect(sites.length, 'the second call on line 1 is not shadowed by the first').toBe(3);
+        } finally {
+            fs.rmSync(dir, {force: true, recursive: true})
+        }
+    });
+
+    test('a justified bypass spelling is still discharged — the widened matcher did not widen the verdict', async () => {
+        // The mirror of the case above, and the reason it matters: widening what the guard can SEE must
+        // not widen what it REFUSES. A `1e3` wait carrying the marker is an accounted wait exactly as a
+        // `1000` one is, or the repair would have converted a bypass into a false positive.
+        const {findUnjustifiedSleeps} = await import(modulePath);
+
+        const
+            dir     = fs.mkdtempSync(path.join(os.tmpdir(), 'check-fixed-sleeps-')),
+            fixture = path.join(dir, 'justified.spec.mjs');
+
+        try {
+            fs.writeFileSync(fixture, [
+                "// wall-clock-under-test: the scheduler's own elapsed time is the assertion",
+                "await new Promise(resolve => setTimeout(resolve, 1e3));"
+            ].join('\n'), 'utf8');
+
+            const {backlog, sites} = findUnjustifiedSleeps({files: [fixture], rootDir: dir});
+
+            expect(sites, 'the marker discharges it').toEqual([]);
+            expect(backlog, 'wall-clock-under-test is not leaf backlog').toEqual([]);
+        } finally {
+            fs.rmSync(dir, {force: true, recursive: true})
+        }
     });
 
     test('importing the module runs no lint and exits no process', () => {

--- a/test/playwright/unit/ai/buildScripts/util/check-fixed-sleeps.spec.mjs
+++ b/test/playwright/unit/ai/buildScripts/util/check-fixed-sleeps.spec.mjs
@@ -63,6 +63,30 @@ test.describe('check-fixed-sleeps.mjs — baseline reconciliation (#17124)', () 
         expect(fresh).toEqual([]);
     });
 
+    test('a stale row reports its SURVIVORS, because the surplus alone picks the wrong remedy', () => {
+        const partial = reconcile({baseline: [site(64)], found: many(21)}),
+              total   = reconcile({baseline: [site(64)], found: []});
+
+        // Both lost sites, so both are stale by `count` alone — and the two take OPPOSITE remedies.
+        expect(partial.stale[0].count, 'the surplus is what the allowance overstates by').toBe(43);
+        expect(total.stale[0].count).toBe(64);
+
+        expect(partial.stale[0].remaining, 'reduce the row to these').toBe(21);
+        expect(total.stale[0].remaining, 'nothing survives, so the row goes').toBe(0);
+    });
+
+    test('deleting a PARTIALLY converted row fails the guard from the other side', () => {
+        // The remedy the old message prescribed, executed literally: 43 of 64 converted, row removed.
+        // The 21 survivors were legitimately grandfathered and now are not, so they re-enter as NEW —
+        // a conversion reported back to its author as a regression, which is why the row must be
+        // REDUCED. This is the failure the `remaining` field exists to stop, not a hypothetical.
+        const {fresh, stale} = reconcile({baseline: [], found: many(21)});
+
+        expect(fresh.length, 'the survivors come back as unaccounted').toBe(1);
+        expect(fresh[0].count, 'all 21 of them').toBe(21);
+        expect(stale, 'and the row that would have explained them is gone').toEqual([]);
+    });
+
     test('the pattern in a COMMENT or a STRING is not a sleep — this file is the fixture', async () => {
         // This spec's own docstring and its `site()` fixture both contain the literal text the guard
         // matches, and neither sleeps. A guard that fires on prose about itself is a noise generator,

--- a/test/playwright/unit/ai/daemons/wake/consumeWakeOutbox.spec.mjs
+++ b/test/playwright/unit/ai/daemons/wake/consumeWakeOutbox.spec.mjs
@@ -159,6 +159,9 @@ test.describe('ai/daemons/wake/consumeWakeOutbox (#15665)', () => {
                 fs.promises.appendFile(outboxPath, JSON.stringify(validEntry('hhh888', 'post-hold wake')) + '\n', {mode: 0o600})
             );
 
+            // wall-clock-under-test: the assertion IS that a second writer stays blocked while the
+            // lock is held, so elapsed time is the observable rather than an inconvenience.
+            // out-waits: the outbox lock-hold threshold in withOutboxLock.
             await new Promise(resolve => setTimeout(resolve, 2600));
 
             const heldLines = fs.readFileSync(outboxPath, 'utf8').trim().split('\n').filter(Boolean);

--- a/test/playwright/unit/ai/mcp/server/knowledge-base/config.template.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/knowledge-base/config.template.spec.mjs
@@ -181,9 +181,10 @@ test.describe('Knowledge Base Config Tier-1 defaults (#11963)', () => {
         // (`NEO_OPENAI_COMPATIBLE_BATCH_EMBEDDING_CHUNK_SIZE`, the timeouts) while every dial shaping
         // the unit that must succeed together was not — so an operator whose corpus will not start
         // could make each request smaller and still not shrink the bet. These three close that.
-        process.env.NEO_KB_EMBEDDING_BATCH_SIZE     = '1';
-        process.env.NEO_KB_EMBEDDING_BATCH_DELAY_MS = '0';
-        process.env.NEO_KB_EMBEDDING_MAX_RETRIES    = '2';
+        process.env.NEO_KB_EMBEDDING_BATCH_SIZE       = '1';
+        process.env.NEO_KB_EMBEDDING_BATCH_DELAY_MS   = '0';
+        process.env.NEO_KB_EMBEDDING_MAX_RETRIES      = '2';
+        process.env.NEO_KB_EMBEDDING_BACKOFF_BASE_MS  = '1';
 
         const freshKB = createConfigProxy(Neo.create(ConfigProvider, {data: config._data}));
 
@@ -191,13 +192,17 @@ test.describe('Knowledge Base Config Tier-1 defaults (#11963)', () => {
             // Typed as numbers by the leaf's own env decoding — a string here would mean the `'number'`
             // type argument was dropped, which reads correct and silently breaks the `i += batchSize`
             // loop arithmetic.
-            expect(freshKB.batchSize) .toBe(1);
-            expect(freshKB.batchDelay).toBe(0);
-            expect(freshKB.maxRetries).toBe(2);
+            expect(freshKB.batchSize)    .toBe(1);
+            expect(freshKB.batchDelay)   .toBe(0);
+            expect(freshKB.maxRetries)   .toBe(2);
+            // The override the unit harness itself relies on: pinning the base to 1ms is what lets a
+            // spec keep production's retry DEPTH while paying none of its wall clock.
+            expect(freshKB.backoffBaseMs).toBe(1);
         } finally {
             delete process.env.NEO_KB_EMBEDDING_BATCH_SIZE;
             delete process.env.NEO_KB_EMBEDDING_BATCH_DELAY_MS;
             delete process.env.NEO_KB_EMBEDDING_MAX_RETRIES;
+            delete process.env.NEO_KB_EMBEDDING_BACKOFF_BASE_MS;
             freshKB.destroy();
         }
     });
@@ -209,9 +214,10 @@ test.describe('Knowledge Base Config Tier-1 defaults (#11963)', () => {
         // `maxRetries: 0` skips the retry loop entirely and returns a clean zero-embedded result with
         // no provider call at all. Neither is a "smaller" setting — they are broken ones, which is why
         // the domain lives on the leaf type (as `port`'s does) rather than in a consumer-side guard.
-        process.env.NEO_KB_EMBEDDING_BATCH_SIZE     = '0';
-        process.env.NEO_KB_EMBEDDING_MAX_RETRIES    = '0';
-        process.env.NEO_KB_EMBEDDING_BATCH_DELAY_MS = '-1';
+        process.env.NEO_KB_EMBEDDING_BATCH_SIZE      = '0';
+        process.env.NEO_KB_EMBEDDING_MAX_RETRIES     = '0';
+        process.env.NEO_KB_EMBEDDING_BATCH_DELAY_MS  = '-1';
+        process.env.NEO_KB_EMBEDDING_BACKOFF_BASE_MS = '-1';
 
         const invalidKB = createConfigProxy(Neo.create(ConfigProvider, {data: config._data}));
 
@@ -219,11 +225,31 @@ test.describe('Knowledge Base Config Tier-1 defaults (#11963)', () => {
             expect(invalidKB.batchSize) .toBe(50);
             expect(invalidKB.maxRetries).toBe(5);
             expect(invalidKB.batchDelay).toBe(10000);
+            // A negative base does not make the ladder gentler — `base * 2 ** n` schedules every retry
+            // in the past, so the backoff silently stops being a backoff. Under the loose `'number'`
+            // domain this branch shipped accepting it.
+            expect(invalidKB.backoffBaseMs).toBe(1000);
         } finally {
             delete process.env.NEO_KB_EMBEDDING_BATCH_SIZE;
             delete process.env.NEO_KB_EMBEDDING_MAX_RETRIES;
             delete process.env.NEO_KB_EMBEDDING_BATCH_DELAY_MS;
+            delete process.env.NEO_KB_EMBEDDING_BACKOFF_BASE_MS;
             invalidKB.destroy();
+        }
+
+        process.env.NEO_KB_EMBEDDING_BACKOFF_BASE_MS = '1.5';
+
+        const fractionalKB = createConfigProxy(Neo.create(ConfigProvider, {data: config._data}));
+
+        try {
+            // The second half of the delay domain, and the reason `'number'` was the wrong choice
+            // rather than merely a loose one: a fractional base yields sub-millisecond timers the
+            // runtime rounds on its own terms, so the configured ladder and the observed one diverge
+            // with nothing reporting it.
+            expect(fractionalKB.backoffBaseMs).toBe(1000);
+        } finally {
+            delete process.env.NEO_KB_EMBEDDING_BACKOFF_BASE_MS;
+            fractionalKB.destroy();
         }
     });
 

--- a/test/playwright/unit/ai/mcp/server/shared/AuthService.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/shared/AuthService.spec.mjs
@@ -1849,6 +1849,9 @@ test.describe('AuthService — GitHub-PAT stale-serve boundary', () => {
         stubFetch([{status: 200}]);
         await verifier.verifyAccessToken('tok');
 
+        // wall-clock-under-test: this crosses a real TTL boundary — the point is that the token is
+        // past expiry and still inside grace, which only a real clock can put it on the far side of.
+        // out-waits: the verifier's access-token TTL.
         await new Promise(resolve => setTimeout(resolve, 1100));   // past ttl, inside grace
         stubFetch([{throws: new Error('unreachable')}]);
 

--- a/test/playwright/unit/ai/scripts/lint/lintWorkflowScanRootParity.spec.mjs
+++ b/test/playwright/unit/ai/scripts/lint/lintWorkflowScanRootParity.spec.mjs
@@ -4,6 +4,7 @@ import * as yaml      from 'js-yaml';
 import path           from 'node:path';
 
 import {SCAN_SURFACE as CONFIG_TEMPLATE_SURFACE} from '../../../../../../ai/scripts/lint/lint-config-template-ssot.mjs';
+import {SCAN_SURFACE as FIXED_SLEEP_SURFACE}     from '../../../../../../buildScripts/util/check-fixed-sleeps.mjs';
 import {SCAN_SURFACE as GUARD_CI_PARITY_SURFACE} from '../../../../../../ai/scripts/lint/lint-guard-ci-parity.mjs';
 import {SCAN_SURFACE as MCP_LOCATION_SURFACE}    from '../../../../../../ai/scripts/lint/lint-mcp-test-locations.mjs';
 import {SCAN_SURFACE as RETRY_BOUND_SURFACE}     from '../../../../../../ai/scripts/lint/lint-retry-bounds.mjs';
@@ -80,6 +81,11 @@ const REGISTRY = Object.freeze({
         scriptRel: 'buildScripts/util/check-content-logical-identity.mjs',
         source   : 'declared',
         surface  : ['resources/content/archive/**']
+    },
+    'fixed-sleep-lint.yml': {
+        scriptRel: 'buildScripts/util/check-fixed-sleeps.mjs',
+        source   : 'imported',
+        surface  : FIXED_SLEEP_SURFACE
     },
     'guard-ci-parity-lint.yml': {
         scriptRel: 'ai/scripts/lint/lint-guard-ci-parity.mjs',

--- a/test/playwright/unit/ai/services/neural-link/bridgeAutoConnectOrdering.spec.mjs
+++ b/test/playwright/unit/ai/services/neural-link/bridgeAutoConnectOrdering.spec.mjs
@@ -270,6 +270,9 @@ test.describe('ai/services/neural-link — Bridge auto-connect ordering (#16429)
 
         // Longer than `spawnBridge`'s 2000ms startupDelayMs, so a server that dies during the spawn
         // attempt has finished dying before the assertion reads.
+        // out-waits: spawnBridge's 2000ms startupDelayMs, named in the comment above. That constant is
+        // hardcoded, so this spec can only guess a number larger than it — the leaf candidate is the
+        // delay itself, not this wait.
         await new Promise(resolve => setTimeout(resolve, 5000));
 
         try {


### PR DESCRIPTION
## Problem

`VectorService`'s retry backoff was a hardcoded `2 ** retries * 1000`, so every spec exercising a retry paid the production delay in real wall-clock. Tests then worked around the symptom rather than the cause: the leaseYield spec shrank `maxRetries` because a five-retry mutation run exhausted its timeout — trading coverage for seconds and quietly asserting a shallower retry than production ships. The unit suite crossed 16 CI-minutes and the operator ruled coverage stays, so the wall clock goes.

Evidence: source census of the backoff site, measured before/after spec runs, and a full unit-tree census of fixed sleeps (2026-08-14).

## What lands

**1. The backoff base becomes a leaf.** `kb.backoffBaseMs`, default 1000, sibling to the existing `memoryWal.backoffBaseMs` and `messageWal.backoffBaseMs` — same default, same role, so the three read alike rather than coining a third spelling for one concept.

The test pin lives in the unit Playwright config beside `UNIT_TEST_MODE`, **not** in the leaf: an inline branch inside `leaf(...)` bakes imperative env-resolution into the declarative SSOT, and a per-spec write mutates a singleton every other spec shares. The env layer is the sanctioned seam, so the leaf keeps one default and the test context overrides it exactly as a deployment would.

**2. A guard so the class cannot regrow — but not the guard the ticket asked for.**

The census changed the rule. The bare sleep is a *symptom*: in **every** site examined, the spec was out-waiting a **hardcoded production constant it had no way to inject** — a poll interval, a lock-hold threshold, a token TTL, a spawn startup delay. A test cannot pin what the source does not expose, so it guesses a number larger than the constant and pays it forever.

So the rule is not "no sleeps". A fixed second-scale wait must carry either marker:

```
// out-waits: <the production constant this is larger than>
// wall-clock-under-test: <why elapsed time is the thing being asserted>
```

`out-waits:` is the one that pays forward — **naming the constant is the census that finds the next leaf candidate.** The justification comment becomes a discovery mechanism rather than only documentation.

## Deltas from ticket

**RETRACTED — the ticket was right about two sites; I was wrong.** I originally claimed one, in this body, a commit message and a lane-claim broadcast. My `grep` ran **before this branch rebased onto #17120**, which is the PR that *added* the carried-prefix write retry. The second site did not exist on the tree I censused, and the rebase then carried it in silently while the one-site claim was already written down.

**A census is only valid against the tree it ran on.** A rebase invalidates it exactly as an edit does, and nothing re-ran it because the conclusion had already been recorded. CI caught it via `lint-retry-bounds`, whose site hash went stale — not via anything I did.

Both sites now read the leaf (`:1131` carried-prefix write, `:1235` embed batch retry). They sit in the same function with `backoffBaseMs` already destructured at `:1017`, so the second needed no plumbing — only noticing.

**The leaf shape already existed twice**, so AC-1's suggested `kb.retryBackoffBaseMs`-class name got the established `backoffBaseMs` / `NEO_*_BACKOFF_BASE_MS` spelling instead, in the **knowledge-base per-server** configBase rather than the root.

**AC-3's rule is sharper than specified**, per the census above and @neo-opus-ada's independent measurement from the other end: her sites all out-wait one hardcoded `POLL_INTERVAL_MS = 3000` at `ai/daemons/wake/daemon.mjs:106` — while the injectable idiom sits **six lines below it** at `:112`.

## Deleting a sleep is NOT the sanctioned fix

This is the part that changed the guard's design, and it is measured (@neo-opus-ada, wake daemon spec):

```
daemon readiness           90 ms actual, against sleeps waiting 1000 ms
sleep -> readiness poll     6.4s -> 6.3s     no material change
sleep DELETED entirely      6.4s -> 12.2s    twice as slow, every assertion green
```

The wall clock is **quantized by the production poll interval**: injecting at 90ms or 1000ms lands before the same boundary, so sub-interval savings are absorbed whole — and deleting the wait pushes injection *before* the watermark, costing a full extra cycle.

**A naive deletion makes the suite slower while staying green**, which is the worst available outcome because nothing reports it. So `wall-clock-under-test:` is a first-class legitimate answer rather than a confession, and the guard's failure text never says "remove the sleep". A guard that nudges toward the wrong repair converts a visible cost into an invisible one and prints green.

## Baseline

82 pre-existing sites are grandfathered **per site, not per file** (measured at `7e35cd9c7e`; it was 83 until #17128 converted one after this branch's merge base — the drift that made the census-expiry commit necessary). These convert rather than vanish — a sleep becomes a readiness poll — and a file count would silently absorb a conversion that left the site present. **A stale baseline row fails too**, so the baseline may only shrink and cannot outlive what it grandfathers.

That coupling was a fork on @neo-opus-ada's surface (82 of 85 sites are her active #17123) and she chose it explicitly, accepting that her de-sleep PR must delete baseline rows alongside the sleeps.

## AC-4 sweep

Three non-daemon sites, each genuinely wall-clock-under-test **and** each waiting on a leaf candidate — annotated rather than baselined, which is the escape hatch working:

| site | wait | out-waits |
|---|---|---|
| `consumeWakeOutbox.spec.mjs:162` | 2600ms | outbox lock-hold threshold in `withOutboxLock` |
| `AuthService.spec.mjs:1852` | 1100ms | the verifier's access-token TTL |
| `bridgeAutoConnectOrdering.spec.mjs:273` | 5000ms | `spawnBridge`'s 2000ms `startupDelayMs` |

The third names its own constant in the spec's existing comment. Already-parameterised and therefore fine: `boundedRetryGate.mjs:200`, `GitLabClient.mjs:140`, both drainCycles (already leaf-backed).

## Test Evidence

**Measured, both arms, same suite** — `test/playwright/unit/ai/services/knowledge-base/`:

```
before   649 passed   15.9s
after    649 passed    9.6s
```

**Guard controls, both directions:**

```
a NEW unjustified sleep        -> exit 1, site named
a baseline row with no site    -> exit 1, "the baseline may only shrink"
intact tree                    -> exit 0, 82 baselined, 0 new, 0 stale
```

Mirrored in CI so `--no-verify` cannot bypass it; `lint-guard-ci-parity` green at 14 guards. The workflow watches `test/playwright/unit/**/*.mjs` **and** the baseline file, because the baseline is an input to the verdict — otherwise a site could be blessed by editing the record of what exists, with nothing re-reading reality.

## Post-Merge Validation

- [x] None required — every AC is pre-merge verifiable, and both guard directions are exercised against the real tree.

Resolves #17124

Authored by Grace (Claude Opus 5, Claude Code). Session 471d17f2-771c-4676-a137-fa37a9ac834d.


