### PR TITLE
feat(ai): fleet admission derives the ownerPrincipal subject + the R3 verb-class split (#16736)

### DIFF
--- a/ai/scripts/lifecycle/local-agent-os/README.md
+++ b/ai/scripts/lifecycle/local-agent-os/README.md
@@ -105,6 +105,15 @@ the same provider-PAT authority as KB/MC and verifies `/app/.neo-ai-data/fleet` 
 the service healthy. Ingress does not depend on Fleet, so omitting the profile leaves `/fleet` at an
 honest `404` while KB/MC remain available.
 
+Fleet admission adds a derived subject on top of that shared authority: every admitted request
+carries an opaque `ownerPrincipal` built from the provider-stable tuple (provider, normalized
+API base URL, provider user id) — never the mutable login — and the probe's `identity` echoes it
+back, which is the quickest way to verify a deployment resolves the subject it will key ownership
+and grants on. Wire verbs are class-split at admission: read-observe verbs serve any
+authenticated caller, lifecycle-write verbs refuse callers without a forge-resolved subject (the
+possession-only local bearer can observe, never mutate). The full contract:
+`learn/agentos/cloud-deployment/ClientAuthentication.md`.
+
 The canonical project is `neo-local-agent-os` unless
 `NEO_LOCAL_AGENT_OS_PROJECT_NAME` explicitly overrides it.
 

--- a/ai/services/fleet/fleetServer.mjs
+++ b/ai/services/fleet/fleetServer.mjs
@@ -101,10 +101,58 @@ export function assertFleetPlaneReady({aiConfig=AiConfig, rootDir=REPO_ROOT}={})
 }
 
 /**
+ * @summary Derives the stable admission subject — the opaque `ownerPrincipal` — from the frozen
+ * request context's provider-validated facts, and nothing else.
+ *
+ * The subject is the immutable tuple `(authProvider, normalizedProviderBaseUrl, providerUserId)`:
+ * the facts a forge cannot re-issue to someone else. The mutable login NEVER participates — a
+ * rename must not move ownership, and a login recycled to a different account must not inherit it.
+ * Fail-closed by construction: any absent tuple member (a possession-only admission mode, a
+ * provider answer without a numeric id, an unparseable base URL) derives NO subject — the caller
+ * renders the refusal; there is no login fallback and no partial principal.
+ *
+ * Base-URL normalization here is deliberately MINIMAL (URL-parse: lowercased scheme/host by the
+ * parser, trailing slashes stripped) and is documented as owned by the durable ownership
+ * normalization contract — that contract may reshape these internals; the call sites and the
+ * derived-key shape stay.
+ * @param {Object|null} requestContext Frozen context from {@link createFleetRequestContext}.
+ * @returns {String|null} The opaque principal key
+ *     `principal:<authProvider>:<encoded normalized base>:<providerUserId>`, or null.
+ */
+export function deriveOwnerPrincipal(requestContext) {
+    const
+        authProvider    = requestContext?.authProvider,
+        providerBaseUrl = requestContext?.providerBaseUrl,
+        providerUserId  = requestContext?.providerUserId;
+
+    if (typeof authProvider !== 'string' || authProvider === '' ||
+        typeof providerBaseUrl !== 'string' || providerBaseUrl === '' ||
+        typeof providerUserId !== 'string' || providerUserId === '') {
+        return null
+    }
+
+    let normalizedProviderBaseUrl;
+
+    try {
+        const url = new URL(providerBaseUrl.trim());
+
+        normalizedProviderBaseUrl = `${url.protocol}//${url.host}${url.pathname.replace(/\/+$/, '')}`
+    } catch {
+        return null
+    }
+
+    return `principal:${authProvider}:${encodeURIComponent(normalizedProviderBaseUrl)}:${providerUserId}`
+}
+
+/**
  * @summary Copies the provider-validated identity facts AuthService emitted into an immutable
- * Fleet request context. This is an explicit allowlist: credential/authz fields (`token`, scopes,
- * expiry, arbitrary SDK extras), graph subjects, and the future `ownerPrincipal` cannot cross the
- * S1 boundary by object spread or SDK evolution.
+ * Fleet request context, then stamps the DERIVED admission subject. This is an explicit
+ * allowlist: credential/authz fields (`token`, scopes, expiry, arbitrary SDK extras) and graph
+ * subjects cannot cross the S1 boundary by object spread or SDK evolution — and `ownerPrincipal`
+ * cannot arrive from the outside either: it exists on a context ONLY as this function's own
+ * derivation over the allowlisted facts. A context without a derivable subject stays admitted
+ * (possession-proven identity can still read); the verb-class policy decides what such a context
+ * may do.
  * @param {Object|undefined} authInfo AuthService-populated `req.auth`.
  * @returns {Readonly<Object>|null} Frozen safe projection, or null when admission proved no identity.
  */
@@ -121,6 +169,12 @@ export function createFleetRequestContext(authInfo) {
         if (value !== undefined && value !== null && ['string', 'number', 'boolean'].includes(typeof value)) {
             context[field] = value
         }
+    }
+
+    const ownerPrincipal = deriveOwnerPrincipal(context);
+
+    if (ownerPrincipal) {
+        context.ownerPrincipal = ownerPrincipal
     }
 
     return Object.freeze(context)
@@ -270,7 +324,7 @@ export async function createFleetServerApp({
     authService       = AuthService,
     transportService  = TransportService,
     logger            = defaultLogger,
-    dispatch          = request => dispatchFleetS1Request(request, FleetControlBridge),
+    dispatch          = (request, requestContext) => dispatchFleetS1Request(request, FleetControlBridge, requestContext),
     runInContext      = (context, callback) => RequestContextService.run(context, callback),
     planeGuard        = assertFleetPlaneReady,
     maxBodyBytes      = 1024 * 1024,
@@ -453,7 +507,7 @@ export async function createFleetServerApp({
         let envelope;
 
         try {
-            envelope = await runInContext(req.fleetRequestContext, () => dispatch(req.body ?? {}))
+            envelope = await runInContext(req.fleetRequestContext, () => dispatch(req.body ?? {}, req.fleetRequestContext))
         } catch (error) {
             logger.error('[FleetServer] dispatch failed');
             envelope = createFleetWireResponse(FLEET_WIRE_RESPONSE_STATES.operationFailed, {

--- a/ai/services/fleet/fleetServerPolicy.mjs
+++ b/ai/services/fleet/fleetServerPolicy.mjs
@@ -29,7 +29,7 @@ export const FLEET_S1_METHOD_POLICY = Object.freeze({
     removeAgent           : 'awaiting-s5',
     fleetStatus           : 'awaiting-s3',
     fleetRuntimeStatus    : 'awaiting-s3',
-    getBootIdentity       : 'awaiting-s2',
+    getBootIdentity       : 'ready',
     fleetActivity         : 'awaiting-s3',
     fleetHistory          : 'awaiting-s3',
     fleetMemories         : 'awaiting-s5',
@@ -43,6 +43,48 @@ export const FLEET_S1_METHOD_POLICY = Object.freeze({
     fleetWakeRoutes       : 'awaiting-s3'
 });
 
+/**
+ * @summary The R3 verb-class ledger: every wire verb is `read-observe` or `lifecycle-write`, and
+ * the split is enforced AT ADMISSION — before availability negotiation — so authority shape never
+ * leaks feature topology to a caller the shape refuses. Read-observe verbs admit any
+ * authenticated context (possession-proven identity may look). Lifecycle-write verbs additionally
+ * require the forge-resolved admission subject (`ownerPrincipal`): possession admits the
+ * transport, identity owns the records — a caller without a stable subject cannot mutate what
+ * nothing stable would own. The grant families later hang their envelopes on exactly these
+ * classes; this ledger is the seam they consume.
+ *
+ * Same contract discipline as the slice ledger above: extending `FLEET_WIRE_METHODS` without
+ * classifying the verb here is a boot/test-visible breach, and an UNCLASSIFIED verb refuses
+ * fail-closed rather than defaulting into either class.
+ * @type {Readonly<Record<String, 'read-observe'|'lifecycle-write'>>}
+ */
+export const FLEET_METHOD_SCOPE_CLASSES = Object.freeze({
+    defineAgent           : 'lifecycle-write',
+    configureAgent        : 'lifecycle-write',
+    setRepo               : 'lifecycle-write',
+    setAvatar             : 'lifecycle-write',
+    listAgents            : 'read-observe',
+    getAgent              : 'read-observe',
+    startAgent            : 'lifecycle-write',
+    stopAgent             : 'lifecycle-write',
+    restartAgent          : 'lifecycle-write',
+    removeAgent           : 'lifecycle-write',
+    fleetStatus           : 'read-observe',
+    fleetRuntimeStatus    : 'read-observe',
+    getBootIdentity       : 'read-observe',
+    fleetActivity         : 'read-observe',
+    fleetHistory          : 'read-observe',
+    fleetMemories         : 'read-observe',
+    fleetRoster           : 'read-observe',
+    fleetMailboxMirror    : 'read-observe',
+    connectTenant         : 'lifecycle-write',
+    listTenants           : 'read-observe',
+    composeOperatorMessage: 'lifecycle-write',
+    markFleetCaughtUp     : 'lifecycle-write',
+    resolveViewerIdentity : 'read-observe',
+    fleetWakeRoutes       : 'read-observe'
+});
+
 const SLICE_LABELS = Object.freeze({
     'awaiting-s2': 'S2 admission policy',
     'awaiting-s3': 'S3 viewer projection',
@@ -52,7 +94,9 @@ const SLICE_LABELS = Object.freeze({
 });
 
 /**
- * @summary The exact Fleet wire operations S1 exposes; empty until data authorization exists.
+ * @summary The exact Fleet wire operations the composed service currently serves. The S2
+ * admission subject opened the first one: `getBootIdentity`, a read-observe advisory whose bridge
+ * answer degrades honestly when no boot-identity source is wired.
  * @type {ReadonlyArray<String>}
  */
 export const FLEET_S1_READY_METHODS = Object.freeze(
@@ -62,22 +106,45 @@ export const FLEET_S1_READY_METHODS = Object.freeze(
 );
 
 /**
- * @summary Negotiate one composed-service request before applying the S1 availability boundary.
- * Unknown verbs retain the canonical `unsupported-method` state; known future-slice verbs return a
- * versioned `degraded` state naming their semantic owner and never touch `FleetControlBridge`.
+ * @summary Negotiate one composed-service request: protocol, then the R3 verb-class boundary AT
+ * ADMISSION, then the S1 availability boundary. Unknown verbs retain the canonical
+ * `unsupported-method` state; a KNOWN verb missing from the scope-class ledger refuses fail-closed
+ * (never a defaulted class); a `lifecycle-write` verb without a forge-resolved admission subject
+ * refuses BEFORE availability is negotiated — authority shape precedes feature topology, so an
+ * unauthorized caller learns nothing about slice ownership; known future-slice verbs then return
+ * a versioned `degraded` state naming their semantic owner and never touch `FleetControlBridge`.
  * @param {Object} request Versioned Fleet wire request (`{method, params, protocol}`).
  * @param {Object} [bridge] Injectable bridge used by the canonical dispatcher.
- * @returns {Promise<Object>} Versioned finite-state response or named-slice degradation.
+ * @param {Object|null} [requestContext] Frozen admission context (`createFleetRequestContext`
+ *     shape); its `ownerPrincipal` is the derived subject the lifecycle-write class requires.
+ * @returns {Promise<Object>} Versioned finite-state response, refusal, or named-slice degradation.
  */
-export async function dispatchFleetS1Request(request={}, bridge) {
+export async function dispatchFleetS1Request(request={}, bridge, requestContext=null) {
     const
         selection   = selectFleetWireContract(request?.protocol),
-        disposition = Object.hasOwn(FLEET_S1_METHOD_POLICY, request?.method)
-        ? FLEET_S1_METHOD_POLICY[request.method]
-        : null;
+        known       = Object.hasOwn(FLEET_S1_METHOD_POLICY, request?.method),
+        disposition = known ? FLEET_S1_METHOD_POLICY[request.method] : null;
 
     if (!selection.ok) {
         return createFleetWireResponse(selection.state, selection)
+    }
+
+    if (known) {
+        const scopeClass = FLEET_METHOD_SCOPE_CLASSES[request.method];
+
+        if (scopeClass !== 'read-observe' && scopeClass !== 'lifecycle-write') {
+            return createFleetWireResponse(FLEET_WIRE_RESPONSE_STATES.refused, {
+                error   : `fleet: '${request.method}' carries no scope class — the verb-class ledger must classify every wire verb`,
+                protocol: selection.protocol
+            })
+        }
+
+        if (scopeClass === 'lifecycle-write' && !requestContext?.ownerPrincipal) {
+            return createFleetWireResponse(FLEET_WIRE_RESPONSE_STATES.refused, {
+                error   : `fleet: '${request.method}' is a lifecycle-write verb and requires a forge-resolved admission subject — possession admits the transport, identity owns the records`,
+                protocol: selection.protocol
+            })
+        }
     }
 
     if (disposition?.startsWith('awaiting-')) {

--- a/learn/agentos/cloud-deployment/ClientAuthentication.md
+++ b/learn/agentos/cloud-deployment/ClientAuthentication.md
@@ -32,6 +32,33 @@ client → Authorization: Bearer <GitLab OAuth token | PAT> → MCP server
 
 `/api/v4/user` validation proves the bearer belongs to **a valid user on the configured GitLab instance**. It does **not** prove the token was minted *for this MCP server*: GitLab issues no audience-bound ([RFC 8707](https://www.rfc-editor.org/rfc/rfc8707.html)) token, so there is no `aud` to match — the MCP spec permits this *"when the Authorization Server supports the capability."* For a deployment that needs per-app / per-user **authorization** (an enterprise bar), an opt-in server-side hardening is planned: bind the token's owning OAuth app via GitLab's `/oauth/token/info`, and gate access on a user / group allowlist. It stays **off by default** so the zero-config path keeps working; the client-id-binding and user-allowlist env knobs ship with that change.
 
+### The Fleet surface — same seat, plus a derived admission subject
+
+The composed Fleet service admits clients through the **same `AuthService` modes** as the MCP
+surfaces — no separate issuance machinery exists, deliberately. What Fleet adds sits *after*
+authentication, at its own boundary:
+
+- **The admission subject is derived, never claimed.** Every admitted request context carries an
+  opaque `ownerPrincipal` derived from the provider-stable tuple
+  `(authProvider, normalizedProviderBaseUrl, providerUserId)` — the facts a forge cannot re-issue
+  to someone else. The **mutable login never participates**: a rename does not move ownership,
+  and a recycled login cannot inherit it; the login is retained strictly as a display projection.
+  The subject cannot be injected from the outside — it exists on a context only as the Fleet
+  boundary's own derivation, and the caller's `/fleet/probe` launch receipt echoes it back for
+  verification.
+- **Verb classes are enforced at admission.** Every Fleet wire verb is classified `read-observe`
+  or `lifecycle-write`. Read-observe verbs admit any authenticated context. Lifecycle-write verbs
+  additionally require the forge-resolved subject — **possession admits the transport, identity
+  owns the records** — and the refusal fires *before* feature-availability negotiation, so an
+  unauthorized caller learns nothing about which slice serves a verb. The Fleet grant families
+  later hang their per-verb-class envelopes on exactly this split.
+- **`local-bearer` stays, bounded by the split.** The possession-only local-bearer mode remains
+  the sanctioned dev-transport admission (the loopback cockpit path needs it), but it resolves no
+  provider tuple, so it derives **no subject**: a local-bearer caller can observe, and every
+  lifecycle-write verb refuses it. Requiring a PAT everywhere was considered and rejected — it
+  would break the zero-config local loop for zero authority gain, because the subject requirement
+  already closes the mutation surface the PAT requirement was for.
+
 ## Server configuration
 
 Set these on the MCP server (Knowledge Base and/or Memory Core):

--- a/test/playwright/unit/ai/services/fleet/fleetServer.spec.mjs
+++ b/test/playwright/unit/ai/services/fleet/fleetServer.spec.mjs
@@ -22,11 +22,13 @@ import {
     assertFleetPlaneReady,
     createFleetRequestContext,
     createFleetServerApp,
+    deriveOwnerPrincipal,
     resolveFleetResourceUrl,
     startFleetServer
 }                                  from '../../../../../../ai/services/fleet/fleetServer.mjs';
 import {
     dispatchFleetS1Request,
+    FLEET_METHOD_SCOPE_CLASSES,
     FLEET_S1_METHOD_POLICY,
     FLEET_S1_READY_METHODS
 }                                  from '../../../../../../ai/services/fleet/fleetServerPolicy.mjs';
@@ -166,7 +168,10 @@ test.describe('composed Fleet S1 server', () => {
                         providerBaseUrl    : 'https://api.github.test',
                         providerUserId     : '280105177',
                         providerUsername   : 'neo-gpt',
-                        providerDisplayName: 'Euclid'
+                        providerDisplayName: 'Euclid',
+                        // The launch receipt carries the caller's own DERIVED admission subject —
+                        // the immutable-tuple key, never the mutable login.
+                        ownerPrincipal     : 'principal:github:https%3A%2F%2Fapi.github.test:280105177'
                     },
                     fleetDataDir: '/app/.neo-ai-data/fleet',
                     pid         : expect.any(Number),
@@ -659,8 +664,43 @@ test.describe('composed Fleet S1 server', () => {
         expect(context).not.toHaveProperty('expiresAt');
         expect(context).not.toHaveProperty('extra');
         expect(context).not.toHaveProperty('agentIdentityNodeId');
-        expect(context).not.toHaveProperty('ownerPrincipal');
+
+        // The subject cannot be INJECTED: the fixture's poisoned `ownerPrincipal` is discarded by
+        // the allowlist, and the context carries only this boundary's OWN derivation over the
+        // provider-validated facts.
+        expect(context.ownerPrincipal).toBe('principal:github:https%3A%2F%2Fapi.github.test:280105177');
         expect(createFleetRequestContext({source: 'local-bearer'})).toBeNull()
+    });
+
+    test('deriveOwnerPrincipal: immutable facts only — login mutation cannot move the subject, absent members derive nothing', () => {
+        const facts = {
+            authProvider   : 'github',
+            providerBaseUrl: 'https://API.github.test/',
+            providerUserId : '280105177'
+        };
+
+        // Minimal normalization pinned: parser-lowercased scheme/host, trailing slashes stripped,
+        // the base encoded into the opaque key.
+        const principal = deriveOwnerPrincipal(facts);
+
+        expect(principal).toBe('principal:github:https%3A%2F%2Fapi.github.test:280105177');
+
+        // The rename invariance the mutable login can never break: no login-bearing field
+        // participates in the derivation at all.
+        expect(deriveOwnerPrincipal({...facts, providerUsername: 'renamed-login', username: 'New Display'}))
+            .toBe(principal);
+
+        // Fail-closed: any absent tuple member derives NO subject — never a partial principal,
+        // never a login fallback.
+        expect(deriveOwnerPrincipal({...facts, providerUserId: undefined})).toBeNull();
+        expect(deriveOwnerPrincipal({...facts, providerBaseUrl: ''})).toBeNull();
+        expect(deriveOwnerPrincipal({...facts, authProvider: undefined})).toBeNull();
+        expect(deriveOwnerPrincipal({...facts, providerBaseUrl: 'not a url'})).toBeNull();
+        expect(deriveOwnerPrincipal(null)).toBeNull();
+
+        // The possession-only admission mode carries no provider tuple: transport admitted,
+        // subject absent — the verb-class policy owns what such a caller may do.
+        expect(deriveOwnerPrincipal({userId: 'local', source: 'local-bearer'})).toBeNull()
     });
 
     test('identityless admitted middleware refuses with zero dispatch', async () => {
@@ -838,12 +878,19 @@ test.describe('composed Fleet S1 server', () => {
 });
 
 test.describe('Fleet S1 wire policy', () => {
-    test('classifies every wire verb and exposes no authentication-only data reads', () => {
+    const PRINCIPAL_CONTEXT = Object.freeze({ownerPrincipal: 'principal:github:https%3A%2F%2Fapi.github.com:9'});
+
+    test('classifies every wire verb in BOTH ledgers — slice ownership and scope class — with getBootIdentity as the one served verb', () => {
         expect(Object.keys(FLEET_S1_METHOD_POLICY).sort()).toEqual([...FLEET_WIRE_METHODS].sort());
-        expect(FLEET_S1_READY_METHODS).toEqual([])
+        expect(Object.keys(FLEET_METHOD_SCOPE_CLASSES).sort()).toEqual([...FLEET_WIRE_METHODS].sort());
+        expect(FLEET_S1_READY_METHODS).toEqual(['getBootIdentity']);
+
+        for (const scopeClass of Object.values(FLEET_METHOD_SCOPE_CLASSES)) {
+            expect(['read-observe', 'lifecycle-write']).toContain(scopeClass)
+        }
     });
 
-    test('refuses every data verb with its owning semantic slice and never dispatches the bridge', async () => {
+    test('serves ready verbs, refuses lifecycle-write without a subject BEFORE naming slices, and degrades the rest with their owning slice', async () => {
         const calls  = [];
         const bridge = Object.fromEntries(FLEET_WIRE_METHODS.map(method => [method, params => {
             calls.push([method, params]);
@@ -856,7 +903,6 @@ test.describe('Fleet S1 wire policy', () => {
         }
 
         const expectedSlices = {
-            getBootIdentity       : 'awaiting-s2',
             listAgents            : 'awaiting-s3',
             getAgent              : 'awaiting-s3',
             fleetStatus           : 'awaiting-s3',
@@ -883,11 +929,30 @@ test.describe('Fleet S1 wire policy', () => {
         };
 
         for (const [method, degraded] of Object.entries(expectedSlices)) {
-            expect(await dispatchFleetS1Request(createFleetWireRequest(method, 'x'), bridge)).toMatchObject({
+            const withSubject = await dispatchFleetS1Request(createFleetWireRequest(method, 'x'), bridge, PRINCIPAL_CONTEXT);
+
+            // WITH a forge-resolved subject, every awaiting verb names its owning slice.
+            expect(withSubject).toMatchObject({
                 ok   : false,
                 state: FLEET_WIRE_RESPONSE_STATES.degraded,
                 degraded
-            })
+            });
+
+            const withoutSubject = await dispatchFleetS1Request(createFleetWireRequest(method, 'x'), bridge);
+
+            if (FLEET_METHOD_SCOPE_CLASSES[method] === 'lifecycle-write') {
+                // WITHOUT one, a lifecycle-write verb refuses at the authority boundary and the
+                // slice name never leaks — authority shape precedes feature topology.
+                expect(withoutSubject.state).toBe(FLEET_WIRE_RESPONSE_STATES.refused);
+                expect(withoutSubject.error).toContain('forge-resolved admission subject');
+                expect(withoutSubject.error).not.toContain('awaits')
+            } else {
+                expect(withoutSubject).toMatchObject({
+                    ok   : false,
+                    state: FLEET_WIRE_RESPONSE_STATES.degraded,
+                    degraded
+                })
+            }
         }
 
         expect(Object.keys(expectedSlices).sort())


### PR DESCRIPTION
Resolves neomjs/neo#16736

The S2 slice of the FM client topology: the fleet surface already authenticated through `AuthService`'s adopted modes (AC-1 was shipped substrate — verified at intake, the ticket's own "adopt, never rebuild" design), so what lands here is the **authority shape on top of authentication**.

- **The admission subject is derived, never claimed** (`deriveOwnerPrincipal`, `fleetServer.mjs`): an opaque `ownerPrincipal` from the provider-stable tuple `(authProvider, normalizedProviderBaseUrl, providerUserId)` — the facts a forge cannot re-issue. The mutable login **never participates** (rename invariance is a pinned falsifier); an injected `ownerPrincipal` is discarded by the S1 allowlist and the boundary's own derivation wins (the fixture's poisoned field proves it); any absent tuple member derives **nothing** — fail-closed, no partial principal, no login fallback. `createFleetRequestContext` stamps the derived subject into the frozen context, and the `/fleet/probe` launch receipt echoes it — the live-verification hook for a deployed plane. Base-URL normalization is deliberately minimal (parser-lowercased scheme/host, trailing slashes stripped) and documented as owned by the durable ownership contract (S4, neomjs/neo-agent-brain#52) — the seam's internals may move; its call sites and key shape stay. Tier 2.5 fork recorded with @neo-opus-ada before the seam was cut.
- **The R3 verb-class split, enforced at admission** (`fleetServerPolicy.mjs`): a second total-coverage ledger classifies every wire verb `read-observe` | `lifecycle-write` (extending `FLEET_WIRE_METHODS` without classifying is a test-visible breach, same discipline as the slice ledger; an unclassified verb refuses fail-closed rather than defaulting into either class). Read-observe admits any authenticated context. Lifecycle-write requires the forge-resolved subject, and the refusal fires **before** availability negotiation — authority shape precedes feature topology, so an unauthorized caller never learns which slice serves a verb. The grant families (S5) hang their envelopes on exactly these classes.
- **`local-bearer` decision (OQ4), recorded**: the possession-only dev-transport admission **stays** — it derives no subject, so it can observe and never mutate ("possession admits the transport, identity owns the records"). Requiring a PAT everywhere was considered and rejected: it would break the zero-config local loop for zero authority gain, because the subject requirement already closes the mutation surface. Documented in `ClientAuthentication.md` (new Fleet-surface section) + the local-agent-os lifecycle README.
- **`getBootIdentity` flips `awaiting-s2` → `ready`** — the one verb gated on this slice, served over its honest advisory-unknown bridge fallback (`no-boot-identity-source` when unwired; verified before flipping).

Evidence: L2 (falsifiers below) → L3 (the rebuilt composed plane's probe echoing the derived subject for a real PAT admission). Residual: live probe receipt on the rebuilt composition, Residual-Owner: neomjs/neo-agent-brain#83.

## Deltas from ticket

- AC-2's "(— S4's build)" resolved via the recorded fork (intake comment + A2A to the S4 owner): S2 derives and stamps the tuple at admission behind the ONE named seam; S4 owns the durable normalization contract and may reshape the seam's internals without the admission call sites moving.
- The Contract Ledger row on `resolveViewerStreamKey` resolved to **documented divergence**: the stream key stays a transport-scoped viewer key (per-connection caps/fan-out, single-plane by construction) while `ownerPrincipal` is the durable ownership subject — both derive from the same immutable facts, neither touches the login; converging them would churn the in-review S7 surfaces for zero authority gain.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/ai/services/fleet/` → 599 passed (full directory). New falsifiers: derivation (minimal normalization pinned; login/rename invariance; every absent-member fail-closed case; possession-only mode derives nothing), injection-discarded-derivation-wins on the frozen context, the probe receipt carrying the subject, BOTH ledgers' total coverage over `FLEET_WIRE_METHODS`, lifecycle-write-without-subject refused at the authority boundary with the slice name withheld, the same verb degrading with its slice once a subject is present, and the ready-verb dispatch reaching the bridge.
- `npm run agent-preflight -- --change-class capability …` → all gates passed.

## Post-Merge Validation

Residual-Owner: neomjs/neo-agent-brain#83

- [ ] Live probe receipt on the rebuilt composed plane: an authenticated forge-PAT `GET /fleet/probe` echoes `identity.ownerPrincipal` as the derived tuple key, and a lifecycle-write wire verb without a subject-bearing admission is refused with the authority-boundary reason.

## Commits (if multi-commit)

Single commit.

Related: neomjs/neo-agent-brain#83 (epic) · D#16720 (design origin, Concept 3) · neomjs/neo-agent-brain#52 (S4 — consumes the stamped subject; fork recorded) · neomjs/neo-agent-brain#53 / neomjs/neo-agent-brain#51 (S4/S5 siblings unblocked by this slice) · PR neomjs/neo#17116 / PR neomjs/neo#17119 (S7 siblings in review).

Authored by Clio (Fable 5, Claude Code). Session c4996813-01b9-4234-8bdd-ed3bf22c0970.
