### PR TITLE
perf(ai): take the wake daemon spec off CI's slow-file list via a validated cadence leaf (#17123)

### DIFF
--- a/ai/configBase.mjs
+++ b/ai/configBase.mjs
@@ -1734,7 +1734,26 @@ class ConfigBase extends ConfigProvider {
                      * the hard cap. Bound to the `NEO_WAKE_ATTEMPT_TIMEOUT_SECONDS` env name.
                      * @type {Number}
                      */
-                    attemptTimeoutSeconds: leaf(30, 'NEO_WAKE_ATTEMPT_TIMEOUT_SECONDS', 'number')
+                    attemptTimeoutSeconds: leaf(30, 'NEO_WAKE_ATTEMPT_TIMEOUT_SECONDS', 'number'),
+                    /**
+                     * The wake daemon's loop cadence (milliseconds): how long the poll loop sleeps
+                     * between passes, how long a flush blocked by an in-flight delivery waits before
+                     * re-checking, and the unit the delivery retry backoff multiplies
+                     * (`nextAttemptAt = now + pollIntervalMs * attempts`). Because it is a
+                     * multiplicand rather than only a delay, the domain is `positiveInt` and not
+                     * `number`: `0`, a negative, a fraction, and `Infinity` are not slower or faster
+                     * settings but broken ones — the first three collapse every backoff to "already
+                     * due" and spin the retry path, the last parks it forever. The parser rejects all
+                     * four (and garbage) and the leaf keeps this default, so a malformed ambient
+                     * value degrades to shipped behavior instead of a hot loop.
+                     *
+                     * Sub-second values are the reason this leaf is `Ms` while its siblings are
+                     * `Seconds`: the daemon's own specs drive it to 50ms so their assertions stop
+                     * being quantized by a 3s tick, which no integer-seconds leaf can express.
+                     * Bound to the `NEO_WAKE_DAEMON_POLL_INTERVAL_MS` env name.
+                     * @type {Number}
+                     */
+                    pollIntervalMs: leaf(3000, 'NEO_WAKE_DAEMON_POLL_INTERVAL_MS', 'positiveInt')
                 },
                 /**
                  * Local-only maintenance lane switches. Cloud deployments can disable these

--- a/ai/daemons/wake/daemon.mjs
+++ b/ai/daemons/wake/daemon.mjs
@@ -103,13 +103,6 @@ let DELIVERY_FAILURE_STATE_FILE;
 let   terminalDeliveryFailures           = {};
 let   terminalDeliveryFailuresNeedRepair = false;
 const LOG_RETENTION_DAYS                 = 30;
-// Injectable for the same reason `CODEX_TURN_START_PROOF_TIMEOUT_MS` below is: a test that cannot
-// shorten this constant has to out-wait it, and this one is the daemon's whole cadence — it gates
-// both the poll loop and the retry backoff (`nextAttemptAt`), so every spec near it pays multiples of
-// 3s in wall clock. Production is unchanged: the default IS the shipped value, and nothing sets the
-// override outside tests. Measured: the wake daemon spec's runtime is quantized by this number, so
-// shortening a wait anywhere else in that file recovers nothing while this stays fixed.
-const POLL_INTERVAL_MS                  = Number(process.env.WAKE_POLL_INTERVAL_MS) || 3000;
 const CODEX_APP_SERVER_ADAPTER          = 'codex-app-server';
 const OPENCODE_SERVER_ADAPTER           = 'opencode-server';
 const OPENCODE_REBIND_SETTLE_MS         = 50;
@@ -629,7 +622,7 @@ async function pollLoop() {
         writeLog('ERROR', `[Wake Daemon] Error in poll loop: ${err && err.stack ? err.stack : err}`);
     }
 
-    setTimeout(pollLoop, POLL_INTERVAL_MS);
+    setTimeout(pollLoop, AiConfig.orchestrator.wakeDispatch.pollIntervalMs);
 }
 
 /**
@@ -919,7 +912,7 @@ async function flushSubscription(subId) {
     // this flush — the queue stays intact and keeps absorbing arrivals, and the short re-check
     // lands after the in-flight attempt resolves (the defer idiom above, at poll cadence).
     if (deliveryInFlight.has(subId)) {
-        state.timer = setTimeout(() => flushSubscription(subId), POLL_INTERVAL_MS);
+        state.timer = setTimeout(() => flushSubscription(subId), AiConfig.orchestrator.wakeDispatch.pollIntervalMs);
         return;
     }
 
@@ -2590,7 +2583,7 @@ function enqueueDeliveryRetry(subscription, identity, events) {
         identity,
         events,
         attempts     : 0,
-        nextAttemptAt: Date.now() + POLL_INTERVAL_MS
+        nextAttemptAt: Date.now() + AiConfig.orchestrator.wakeDispatch.pollIntervalMs
     });
 }
 
@@ -2604,7 +2597,11 @@ function enqueueDeliveryRetry(subscription, identity, events) {
 async function attemptDeliveryRetries() {
     if (pendingDeliveryRetries.size === 0) return;
 
-    const now = Date.now();
+    // Both are read once per pass so every entry rescheduled below is measured against the same
+    // clock and the same cadence: a mid-pass config re-resolve would otherwise let two entries in
+    // one loop compute their backoff from different units.
+    const now            = Date.now(),
+          pollIntervalMs = AiConfig.orchestrator.wakeDispatch.pollIntervalMs;
 
     for (const [subId, entry] of pendingDeliveryRetries) {
         if (entry.nextAttemptAt > now) continue;
@@ -2690,7 +2687,7 @@ async function attemptDeliveryRetries() {
                     `[Wake Daemon] Giving up wake delivery for ${subId} after ${entry.attempts} failed attempts; wake dropped.`
                 );
             } else {
-                entry.nextAttemptAt = now + POLL_INTERVAL_MS * entry.attempts;
+                entry.nextAttemptAt = now + pollIntervalMs * entry.attempts;
             }
         } else if (outcome === 'delivered') {
             // The snapshot reached the seat: a confirmed delivery arms the refractory and counts
@@ -2707,7 +2704,7 @@ async function attemptDeliveryRetries() {
             );
             if (mergedDuringAwait) {
                 entry.attempts      = 0;
-                entry.nextAttemptAt = now + POLL_INTERVAL_MS;
+                entry.nextAttemptAt = now + pollIntervalMs;
             } else {
                 pendingDeliveryRetries.delete(subId);
             }
@@ -2726,7 +2723,7 @@ async function attemptDeliveryRetries() {
                 heartbeats : [...snapshot.heartbeats,  ...entry.events.heartbeats]
             };
             lastFlushAtBySub[subId] = Date.now();
-            entry.nextAttemptAt     = now + POLL_INTERVAL_MS * (entry.attempts + 2);
+            entry.nextAttemptAt     = now + pollIntervalMs * (entry.attempts + 2);
             writeLog('WARN',
                 `[Wake Daemon] Retry for ${subId} returned UNKNOWN (un-abortable transport timed out); ` +
                 'events retained, attempt NOT counted, next offer deferred — the attempt may already have landed.'
@@ -2737,7 +2734,7 @@ async function attemptDeliveryRetries() {
             // merged during the await keep their fresh cycle rather than being silently lost.
             if (mergedDuringAwait) {
                 entry.attempts      = 0;
-                entry.nextAttemptAt = now + POLL_INTERVAL_MS;
+                entry.nextAttemptAt = now + pollIntervalMs;
             } else {
                 pendingDeliveryRetries.delete(subId);
             }

--- a/ai/daemons/wake/daemon.mjs
+++ b/ai/daemons/wake/daemon.mjs
@@ -103,16 +103,22 @@ let DELIVERY_FAILURE_STATE_FILE;
 let   terminalDeliveryFailures           = {};
 let   terminalDeliveryFailuresNeedRepair = false;
 const LOG_RETENTION_DAYS                 = 30;
-const POLL_INTERVAL_MS                   = 3000;
-const CODEX_APP_SERVER_ADAPTER           = 'codex-app-server';
-const OPENCODE_SERVER_ADAPTER            = 'opencode-server';
-const OPENCODE_REBIND_SETTLE_MS          = 50;
-const KIMI_SERVER_ADAPTER                = 'kimi-server';
-const KIMI_PULL_BRIDGE_ADAPTER           = 'kimi-pull-bridge';
-const CODEX_TURN_START_PROOF_TIMEOUT_MS  = Number(process.env.WAKE_CODEX_TURN_START_PROOF_TIMEOUT_MS) || 45000;
-const CODEX_TURN_START_PROOF_POLL_MS     = Number(process.env.WAKE_CODEX_TURN_START_PROOF_POLL_MS) || 1000;
-const CODEX_WAKE_SUBMIT_NONCE_PREFIX     = 'NEO_WAKE_SUBMIT_NONCE:';
-const WOKEN_MESSAGE_IDS_STATE_KEY        = '__messageIdsByIdentity';
+// Injectable for the same reason `CODEX_TURN_START_PROOF_TIMEOUT_MS` below is: a test that cannot
+// shorten this constant has to out-wait it, and this one is the daemon's whole cadence — it gates
+// both the poll loop and the retry backoff (`nextAttemptAt`), so every spec near it pays multiples of
+// 3s in wall clock. Production is unchanged: the default IS the shipped value, and nothing sets the
+// override outside tests. Measured: the wake daemon spec's runtime is quantized by this number, so
+// shortening a wait anywhere else in that file recovers nothing while this stays fixed.
+const POLL_INTERVAL_MS                  = Number(process.env.WAKE_POLL_INTERVAL_MS) || 3000;
+const CODEX_APP_SERVER_ADAPTER          = 'codex-app-server';
+const OPENCODE_SERVER_ADAPTER           = 'opencode-server';
+const OPENCODE_REBIND_SETTLE_MS         = 50;
+const KIMI_SERVER_ADAPTER               = 'kimi-server';
+const KIMI_PULL_BRIDGE_ADAPTER          = 'kimi-pull-bridge';
+const CODEX_TURN_START_PROOF_TIMEOUT_MS = Number(process.env.WAKE_CODEX_TURN_START_PROOF_TIMEOUT_MS) || 45000;
+const CODEX_TURN_START_PROOF_POLL_MS    = Number(process.env.WAKE_CODEX_TURN_START_PROOF_POLL_MS) || 1000;
+const CODEX_WAKE_SUBMIT_NONCE_PREFIX    = 'NEO_WAKE_SUBMIT_NONCE:';
+const WOKEN_MESSAGE_IDS_STATE_KEY       = '__messageIdsByIdentity';
 
 const identityParticipationById = new Map(
     IDENTITIES

--- a/ai/scripts/lint/config-leaf-parity.json
+++ b/ai/scripts/lint/config-leaf-parity.json
@@ -423,6 +423,7 @@
         "orchestrator.wakeDispatch.coalesceWindowSeconds",
         "orchestrator.wakeDispatch.flushHardCapSeconds",
         "orchestrator.wakeDispatch.flushRefractorySeconds",
+        "orchestrator.wakeDispatch.pollIntervalMs",
         "plane",
         "plane.dataRoot",
         "plane.id",

--- a/test/playwright/unit/ai/configBase.spec.mjs
+++ b/test/playwright/unit/ai/configBase.spec.mjs
@@ -229,3 +229,71 @@ test.describe('fleet.port — the domain type, not the generic one', () => {
         }
     })
 });
+
+test.describe('orchestrator.wakeDispatch.pollIntervalMs — a multiplicand, not a delay', () => {
+    // The wake daemon multiplies this leaf into its retry backoff (`nextAttemptAt = now +
+    // pollIntervalMs * attempts`), so an out-of-domain value is not a slower or faster daemon: `0`,
+    // a negative and a fraction all put `nextAttemptAt` at or before `now`, which makes every queued
+    // entry perpetually due and spins the retry path; `Infinity` parks it forever. `'number'` would
+    // admit all four. The env is readable by the production daemon — the same shape that let
+    // `NEO_FLEET_PORT` through above — so the domain is the containment, not a promise that only
+    // tests set it.
+    //
+    // The parser is driven with an explicit `env` object rather than by assigning `process.env`:
+    // Playwright runs several spec FILES per worker, so a module- or test-scope env write here
+    // would leak into siblings (the defect this ticket's own PR had to fix).
+    const cadenceLeaf = () => ConfigBase.config.data.orchestrator.wakeDispatch.pollIntervalMs;
+
+    test('declares the positiveInt domain and the shipped 3000ms default', () => {
+        expect(cadenceLeaf().default).toBe(3000);
+        expect(cadenceLeaf().type).toBe('positiveInt');
+        expect(cadenceLeaf().env).toBe('NEO_WAKE_DAEMON_POLL_INTERVAL_MS');
+    });
+
+    test('a valid cadence resolves; every malformed shape falls back to the default', () => {
+        const resolve = raw => cadenceLeaf().parse('NEO_WAKE_DAEMON_POLL_INTERVAL_MS', {
+            env : {NEO_WAKE_DAEMON_POLL_INTERVAL_MS: raw},
+            warn: () => {}   // the parser warns on rejection; silence it, the return value is the assertion
+        });
+
+        // Resolves — including the sub-second value the daemon's own specs pin.
+        expect(resolve('50')).toBe(50);
+        expect(resolve('3000')).toBe(3000);
+
+        // Falls back — `undefined` means "leaf default applies".
+        for (const malformed of ['0', '-1', '-3000', '0.5', '2999.9', 'Infinity', '-Infinity', 'NaN', 'abc', '']) {
+            expect(
+                resolve(malformed),
+                `NEO_WAKE_DAEMON_POLL_INTERVAL_MS="${malformed}" must not resolve`
+            ).toBeUndefined();
+        }
+    });
+
+    test('no malformed value can make a retry backoff immediately due', () => {
+        // The consequence the domain exists to prevent, asserted directly rather than inferred from
+        // the parser returning undefined. `??` mirrors ConfigProvider#applyEnvLayer, which writes the
+        // env layer only when the parser returned a value — so a rejected override leaves the default.
+        const effectiveCadence = raw => cadenceLeaf().parse('NEO_WAKE_DAEMON_POLL_INTERVAL_MS', {
+            env : {NEO_WAKE_DAEMON_POLL_INTERVAL_MS: raw},
+            warn: () => {}
+        }) ?? cadenceLeaf().default;
+
+        const now = 1_000_000;
+
+        for (const malformed of ['0', '-1', '-3000', '0.5', 'Infinity', 'abc', '']) {
+            const cadence = effectiveCadence(malformed);
+
+            // Every backoff the daemon computes from this cadence — first enqueue, the linear
+            // `* attempts` retry, and the harder `* (attempts + 2)` unknown-outcome deferral — must
+            // land strictly in the future for every attempt count the daemon can reach.
+            for (let attempts = 0; attempts <= 5; attempts++) {
+                expect(
+                    Math.min(now + cadence, now + cadence * Math.max(attempts, 1), now + cadence * (attempts + 2)),
+                    `"${malformed}" at attempt ${attempts} must not be immediately due`
+                ).toBeGreaterThan(now);
+            }
+
+            expect(Number.isFinite(cadence), `"${malformed}" must not park the daemon forever`).toBe(true);
+        }
+    })
+});

--- a/test/playwright/unit/ai/daemons/wake/daemon.spec.mjs
+++ b/test/playwright/unit/ai/daemons/wake/daemon.spec.mjs
@@ -23,6 +23,58 @@ import { withOutboxLock }                                                       
  * @param {String} binDir
  * @param {String} [psOutput='']
  */
+// The daemon's poll cadence gates BOTH the poll loop and the retry backoff, so this file's wall clock
+// is quantized by it: at the shipped 3000ms, a wait shortened anywhere else lands before the same poll
+// boundary and recovers nothing. Every spawn below spreads `process.env`, so setting it once here
+// reaches all 66 of them. Production is untouched — the daemon's default is still 3000.
+//
+// 50ms is chosen to be far below the smallest interval any assertion in this file cares about; tests
+// that assert on retry ORDERING or COUNTS still hold, because those are counted in cycles rather than
+// milliseconds. Any test that genuinely needs the real cadence should set it back explicitly on its
+// own spawn rather than raising this floor for everyone.
+process.env.WAKE_POLL_INTERVAL_MS = process.env.WAKE_POLL_INTERVAL_MS || '50';
+
+/**
+ * @summary Resolves once the spawned daemon has read its GraphLog watermark and entered the poll loop.
+ *
+ * Replaces the fixed boot sleeps, and the ordering it preserves is the whole point rather than an
+ * optimization. The daemon emits this line immediately after `lastSyncId = getLastSyncId(...)` and
+ * immediately before `pollLoop()`, so it is the exact instant the watermark exists. A row injected
+ * before that instant is not a delta the daemon will see on its first pass — it waits a full
+ * `POLL_INTERVAL_MS` (3s) or more, which is why simply deleting the sleeps makes this file SLOWER
+ * while every assertion still passes.
+ *
+ * Strictly better than the 1s sleep in both directions: it returns as soon as boot completes rather
+ * than always paying 1s, and it cannot under-wait on a loaded CI box, where a fixed 1s is a latent
+ * flake that silently degrades into the same multi-second poll penalty.
+ *
+ * Attach BEFORE any await on the process, so no output is missed between spawn and subscription.
+ *
+ * @param {Object} daemonProcess Spawned daemon child process.
+ * @param {Number} [timeoutMs=15000] Bound; a daemon that never announces is a failure, not a wait.
+ * @returns {Promise<void>}
+ */
+function waitForDaemonReady(daemonProcess, timeoutMs = 15000) {
+    return new Promise((resolve, reject) => {
+        let settled = false;
+
+        const done = error => {
+            if (settled) return;
+            settled = true;
+            clearTimeout(timer);
+            daemonProcess.stdout.off('data', onData);
+            error ? reject(error) : resolve()
+        };
+
+        const timer  = setTimeout(() => done(new Error('Daemon did not announce readiness within timeout')), timeoutMs),
+              onData = data => { if (data.toString().includes('[Wake Daemon] Started.')) done() };
+
+        daemonProcess.stdout.on('data', onData);
+        daemonProcess.on('error', done);
+        daemonProcess.on('exit', code => done(new Error(`Daemon exited (code ${code}) before announcing readiness`)))
+    })
+}
+
 function writeMockPs(binDir, psOutput = '') {
     const mockPsPath = path.join(binDir, 'ps');
 
@@ -291,8 +343,9 @@ test.describe('Wake Daemon', () => {
             daemonProcess.on('error', reject);
         });
 
-        // Wait a short moment to ensure daemon initializes
-        await new Promise(resolve => setTimeout(resolve, 1000));
+        // Ordering, not padding: the row must be injected AFTER the daemon has read its watermark,
+        // or it is not a delta the first poll sees. See waitForDaemonReady.
+        await waitForDaemonReady(daemonProcess);
 
         // Inject MESSAGE and SENT_TO edge
         const msgId = 'msg_' + crypto.randomUUID();
@@ -842,7 +895,14 @@ test.describe('Wake Daemon', () => {
 
         daemonProcess = spawn('node', ['ai/daemons/wake/daemon.mjs'], {
             stdio: 'pipe',
-            env  : { ...process.env, NEO_MEMORY_DB_PATH: DB_PATH, NEO_AI_DAEMON_DIR: DAEMON_DIR }
+            env  : { ...process.env, NEO_MEMORY_DB_PATH: DB_PATH, NEO_AI_DAEMON_DIR: DAEMON_DIR,
+                     // out-waits: POLL_INTERVAL_MS — this test asserts that a SECOND failure
+                     // arriving mid-cycle coalesces into the first's pending retry, so the 4s
+                     // gap below must straddle exactly one poll boundary. Under the file's
+                     // shortened cadence that gap becomes ~80 cycles and both failures settle
+                     // before the second is enqueued, which is a real behaviour change rather
+                     // than a flake. Pinned to the shipped value for this test alone.
+                     WAKE_POLL_INTERVAL_MS: '3000' }
         });
 
         // First flush ("1 message events") fails + enqueues; the second flush coalesces; the RETRY

--- a/test/playwright/unit/ai/daemons/wake/daemon.spec.mjs
+++ b/test/playwright/unit/ai/daemons/wake/daemon.spec.mjs
@@ -25,14 +25,13 @@ import { withOutboxLock }                                                       
  */
 // The daemon's poll cadence gates BOTH the poll loop and the retry backoff, so this file's wall clock
 // is quantized by it: at the shipped 3000ms, a wait shortened anywhere else lands before the same poll
-// boundary and recovers nothing. Every spawn below spreads `process.env`, so setting it once here
-// reaches all 66 of them. Production is untouched — the daemon's default is still 3000.
+// boundary and recovers nothing.
 //
-// 50ms is chosen to be far below the smallest interval any assertion in this file cares about; tests
-// that assert on retry ORDERING or COUNTS still hold, because those are counted in cycles rather than
-// milliseconds. Any test that genuinely needs the real cadence should set it back explicitly on its
-// own spawn rather than raising this floor for everyone.
-process.env.WAKE_POLL_INTERVAL_MS = process.env.WAKE_POLL_INTERVAL_MS || '50';
+// Injected PER SPAWN rather than once on `process.env`. A module-scope assignment leaks across spec
+// FILES — Playwright runs several per worker process — and a sibling wake spec asserts a retry-union
+// window derived from `attempts x poll interval = 6s`, which a 50ms cadence collapses to 100ms. That
+// is a real cross-file behaviour change, not a flake, and it is invisible when this file is run alone.
+const FAST_POLL_MS = '50';
 
 /**
  * @summary Resolves once the spawned daemon has read its GraphLog watermark and entered the poll loop.
@@ -327,7 +326,7 @@ test.describe('Wake Daemon', () => {
         // Start the daemon with environment overrides
         daemonProcess = spawn('node', ['ai/daemons/wake/daemon.mjs'], {
             stdio: 'pipe',
-            env  : { ...process.env, NEO_MEMORY_DB_PATH: DB_PATH, NEO_AI_DAEMON_DIR: DAEMON_DIR }
+            env  : { ...process.env, NEO_MEMORY_DB_PATH: DB_PATH, NEO_AI_DAEMON_DIR: DAEMON_DIR, WAKE_POLL_INTERVAL_MS: FAST_POLL_MS }
         });
 
         const deliveryPromise = new Promise((resolve, reject) => {
@@ -409,7 +408,7 @@ test.describe('Wake Daemon', () => {
 
         daemonProcess = spawn('node', ['ai/daemons/wake/daemon.mjs'], {
             stdio: 'pipe',
-            env  : { ...process.env, NEO_MEMORY_DB_PATH: DB_PATH, NEO_AI_DAEMON_DIR: DAEMON_DIR }
+            env  : { ...process.env, NEO_MEMORY_DB_PATH: DB_PATH, NEO_AI_DAEMON_DIR: DAEMON_DIR, WAKE_POLL_INTERVAL_MS: FAST_POLL_MS }
         });
 
         const deliveryPromise = new Promise((resolve, reject) => {
@@ -814,7 +813,7 @@ test.describe('Wake Daemon', () => {
         // Cap retries at 2 so the terminal "giving up" path is reached within a few 3s poll cycles.
         daemonProcess = spawn('node', ['ai/daemons/wake/daemon.mjs'], {
             stdio: 'pipe',
-            env  : { ...process.env, NEO_MEMORY_DB_PATH: DB_PATH, NEO_AI_DAEMON_DIR: DAEMON_DIR, WAKE_MAX_DELIVERY_RETRIES: '2' }
+            env  : { ...process.env, NEO_MEMORY_DB_PATH: DB_PATH, NEO_AI_DAEMON_DIR: DAEMON_DIR, WAKE_MAX_DELIVERY_RETRIES: '2', WAKE_POLL_INTERVAL_MS: FAST_POLL_MS }
         });
 
         const terminalPromise = new Promise((resolve, reject) => {
@@ -975,7 +974,7 @@ test.describe('Wake Daemon', () => {
 
         daemonProcess = spawn('node', ['ai/daemons/wake/daemon.mjs'], {
             stdio: 'pipe',
-            env  : { ...process.env, NEO_MEMORY_DB_PATH: DB_PATH, NEO_AI_DAEMON_DIR: DAEMON_DIR }
+            env  : { ...process.env, NEO_MEMORY_DB_PATH: DB_PATH, NEO_AI_DAEMON_DIR: DAEMON_DIR, WAKE_POLL_INTERVAL_MS: FAST_POLL_MS }
         });
 
         // The wake fires on SENT_TO; DELIVERED_TO carries the per-recipient readAt the daemon reconciles
@@ -1209,7 +1208,7 @@ test.describe('Wake Daemon', () => {
 
         daemonProcess = spawn('node', ['ai/daemons/wake/daemon.mjs'], {
             stdio: 'pipe',
-            env  : { ...process.env, NEO_MEMORY_DB_PATH: DB_PATH, NEO_AI_DAEMON_DIR: DAEMON_DIR }
+            env  : { ...process.env, NEO_MEMORY_DB_PATH: DB_PATH, NEO_AI_DAEMON_DIR: DAEMON_DIR, WAKE_POLL_INTERVAL_MS: FAST_POLL_MS }
         });
 
         const deliveryPromise = new Promise((resolve, reject) => {
@@ -1263,7 +1262,7 @@ test.describe('Wake Daemon', () => {
 
         daemonProcess = spawn('node', ['ai/daemons/wake/daemon.mjs'], {
             stdio: 'pipe',
-            env  : { ...process.env, NEO_MEMORY_DB_PATH: DB_PATH, NEO_AI_DAEMON_DIR: DAEMON_DIR }
+            env  : { ...process.env, NEO_MEMORY_DB_PATH: DB_PATH, NEO_AI_DAEMON_DIR: DAEMON_DIR, WAKE_POLL_INTERVAL_MS: FAST_POLL_MS }
         });
 
         const deliveryPromise = new Promise((resolve, reject) => {
@@ -1326,7 +1325,7 @@ test.describe('Wake Daemon', () => {
 
         daemonProcess = spawn('node', ['ai/daemons/wake/daemon.mjs'], {
             stdio: 'pipe',
-            env  : { ...process.env, NEO_MEMORY_DB_PATH: DB_PATH, NEO_AI_DAEMON_DIR: DAEMON_DIR }
+            env  : { ...process.env, NEO_MEMORY_DB_PATH: DB_PATH, NEO_AI_DAEMON_DIR: DAEMON_DIR, WAKE_POLL_INTERVAL_MS: FAST_POLL_MS }
         });
 
         const deliveryPromise = new Promise((resolve, reject) => {
@@ -1410,7 +1409,7 @@ test.describe('Wake Daemon', () => {
 
         daemonProcess = spawn('node', ['ai/daemons/wake/daemon.mjs'], {
             stdio: 'pipe',
-            env  : { ...process.env, NEO_MEMORY_DB_PATH: DB_PATH, NEO_AI_DAEMON_DIR: DAEMON_DIR }
+            env  : { ...process.env, NEO_MEMORY_DB_PATH: DB_PATH, NEO_AI_DAEMON_DIR: DAEMON_DIR, WAKE_POLL_INTERVAL_MS: FAST_POLL_MS }
         });
 
         const deliveryPromise = new Promise((resolve, reject) => {
@@ -1545,7 +1544,7 @@ test.describe('Wake Daemon', () => {
 
         daemonProcess = spawn('node', ['ai/daemons/wake/daemon.mjs'], {
             stdio: 'pipe',
-            env  : { ...process.env, NEO_MEMORY_DB_PATH: DB_PATH, NEO_AI_DAEMON_DIR: DAEMON_DIR }
+            env  : { ...process.env, NEO_MEMORY_DB_PATH: DB_PATH, NEO_AI_DAEMON_DIR: DAEMON_DIR, WAKE_POLL_INTERVAL_MS: FAST_POLL_MS }
         });
 
         const deliveryPromise = new Promise((resolve, reject) => {
@@ -1602,7 +1601,7 @@ test.describe('Wake Daemon', () => {
 
         daemonProcess = spawn('node', ['ai/daemons/wake/daemon.mjs'], {
             stdio: 'pipe',
-            env  : { ...process.env, NEO_MEMORY_DB_PATH: DB_PATH, NEO_AI_DAEMON_DIR: DAEMON_DIR }
+            env  : { ...process.env, NEO_MEMORY_DB_PATH: DB_PATH, NEO_AI_DAEMON_DIR: DAEMON_DIR, WAKE_POLL_INTERVAL_MS: FAST_POLL_MS }
         });
 
         let deliveryCount = 0;
@@ -1662,7 +1661,7 @@ test.describe('Wake Daemon', () => {
 
         daemonProcess = spawn('node', ['ai/daemons/wake/daemon.mjs'], {
             stdio: 'pipe',
-            env  : { ...process.env, NEO_MEMORY_DB_PATH: DB_PATH, NEO_AI_DAEMON_DIR: DAEMON_DIR }
+            env  : { ...process.env, NEO_MEMORY_DB_PATH: DB_PATH, NEO_AI_DAEMON_DIR: DAEMON_DIR, WAKE_POLL_INTERVAL_MS: FAST_POLL_MS }
         });
 
         let stdoutLog = '';
@@ -1709,7 +1708,7 @@ test.describe('Wake Daemon', () => {
 
         daemonProcess = spawn('node', ['ai/daemons/wake/daemon.mjs'], {
             stdio: 'pipe',
-            env  : { ...process.env, NEO_MEMORY_DB_PATH: DB_PATH, NEO_AI_DAEMON_DIR: DAEMON_DIR }
+            env  : { ...process.env, NEO_MEMORY_DB_PATH: DB_PATH, NEO_AI_DAEMON_DIR: DAEMON_DIR, WAKE_POLL_INTERVAL_MS: FAST_POLL_MS }
         });
 
         let   deliveryCount   = 0;
@@ -2124,7 +2123,7 @@ test.describe('Wake Daemon', () => {
 
         daemonProcess = spawn('node', ['ai/daemons/wake/daemon.mjs'], {
             stdio: 'pipe',
-            env  : { ...process.env, NEO_MEMORY_DB_PATH: DB_PATH, NEO_AI_DAEMON_DIR: DAEMON_DIR }
+            env  : { ...process.env, NEO_MEMORY_DB_PATH: DB_PATH, NEO_AI_DAEMON_DIR: DAEMON_DIR, WAKE_POLL_INTERVAL_MS: FAST_POLL_MS }
         });
 
         const deliveryPromise = new Promise((resolve, reject) => {
@@ -2224,7 +2223,7 @@ test.describe('Wake Daemon', () => {
 
         daemonProcess = spawn('node', ['ai/daemons/wake/daemon.mjs'], {
             stdio: 'pipe',
-            env  : { ...process.env, NEO_MEMORY_DB_PATH: DB_PATH, NEO_AI_DAEMON_DIR: DAEMON_DIR }
+            env  : { ...process.env, NEO_MEMORY_DB_PATH: DB_PATH, NEO_AI_DAEMON_DIR: DAEMON_DIR, WAKE_POLL_INTERVAL_MS: FAST_POLL_MS }
         });
 
         const errorLogPromise = new Promise((resolve, reject) => {
@@ -4067,7 +4066,7 @@ test.describe('Wake Daemon', () => {
 
                 daemonProcess = spawn('node', ['ai/daemons/wake/daemon.mjs'], {
                     stdio: 'pipe',
-                    env  : { ...process.env, NEO_MEMORY_DB_PATH: DB_PATH, NEO_AI_DAEMON_DIR: DAEMON_DIR }
+                    env  : { ...process.env, NEO_MEMORY_DB_PATH: DB_PATH, NEO_AI_DAEMON_DIR: DAEMON_DIR, WAKE_POLL_INTERVAL_MS: FAST_POLL_MS }
                 });
 
                 setTimeout(() => insertMessageWake(db, {agentId, subject: 'Webhook Address Wake'}), 1000);

--- a/test/playwright/unit/ai/daemons/wake/daemon.spec.mjs
+++ b/test/playwright/unit/ai/daemons/wake/daemon.spec.mjs
@@ -478,6 +478,7 @@ test.describe('Wake Daemon', () => {
                 ...process.env,
                 NEO_MEMORY_DB_PATH                    : DB_PATH,
                 NEO_AI_DAEMON_DIR                     : DAEMON_DIR,
+                WAKE_POLL_INTERVAL_MS                 : FAST_POLL_MS,
                 WAKE_CODEX_TURN_START_PROOF_TIMEOUT_MS: '3000',
                 WAKE_CODEX_TURN_START_PROOF_POLL_MS   : '50'
             }
@@ -548,6 +549,7 @@ test.describe('Wake Daemon', () => {
                 ...process.env,
                 NEO_MEMORY_DB_PATH                    : DB_PATH,
                 NEO_AI_DAEMON_DIR                     : DAEMON_DIR,
+                WAKE_POLL_INTERVAL_MS                 : FAST_POLL_MS,
                 WAKE_CODEX_TURN_START_PROOF_TIMEOUT_MS: '3000',
                 WAKE_CODEX_TURN_START_PROOF_POLL_MS   : '50'
             }
@@ -613,6 +615,7 @@ test.describe('Wake Daemon', () => {
                 ...process.env,
                 NEO_MEMORY_DB_PATH                    : DB_PATH,
                 NEO_AI_DAEMON_DIR                     : DAEMON_DIR,
+                WAKE_POLL_INTERVAL_MS                 : FAST_POLL_MS,
                 WAKE_CODEX_TURN_START_PROOF_TIMEOUT_MS: '300',
                 WAKE_CODEX_TURN_START_PROOF_POLL_MS   : '50'
             }
@@ -678,6 +681,7 @@ test.describe('Wake Daemon', () => {
                 ...process.env,
                 NEO_MEMORY_DB_PATH              : DB_PATH,
                 NEO_AI_DAEMON_DIR               : DAEMON_DIR,
+                WAKE_POLL_INTERVAL_MS           : FAST_POLL_MS,
                 NEO_WAKE_ATTEMPT_TIMEOUT_SECONDS: '1',
                 WAKE_MAX_DELIVERY_RETRIES       : '2'
             }
@@ -752,6 +756,7 @@ test.describe('Wake Daemon', () => {
                 ...process.env,
                 NEO_MEMORY_DB_PATH              : DB_PATH,
                 NEO_AI_DAEMON_DIR               : DAEMON_DIR,
+                WAKE_POLL_INTERVAL_MS           : FAST_POLL_MS,
                 NEO_WAKE_ATTEMPT_TIMEOUT_SECONDS: '1',
                 WAKE_MAX_DELIVERY_RETRIES       : '2'
             }
@@ -1085,6 +1090,7 @@ test.describe('Wake Daemon', () => {
                     ...process.env,
                     NEO_MEMORY_DB_PATH          : DB_PATH,
                     NEO_AI_DAEMON_DIR           : DAEMON_DIR,
+                    WAKE_POLL_INTERVAL_MS       : FAST_POLL_MS,
                     WAKE_TEST_CLOCK_ADVANCE_FILE: clockAdvanceFile,
                     WAKE_TEST_CLOCK_ADVANCE_MS  : String(MESSAGE_WAKE_MAX_AGE_MS + 1),
                     WAKE_TEST_CLOCK_BASE_MS     : String(clockBaseMs)
@@ -1971,10 +1977,11 @@ test.describe('Wake Daemon', () => {
             stdio: 'pipe',
             env  : {
                 ...process.env,
-                NEO_FLEET_CODEX_BIN: mockCodexPath,
-                NEO_MEMORY_DB_PATH : DB_PATH,
-                NEO_AI_DAEMON_DIR  : DAEMON_DIR,
-                PATH               : `${path.resolve(binDir)}${path.delimiter}${process.env.PATH}`
+                NEO_FLEET_CODEX_BIN  : mockCodexPath,
+                NEO_MEMORY_DB_PATH   : DB_PATH,
+                NEO_AI_DAEMON_DIR    : DAEMON_DIR,
+                WAKE_POLL_INTERVAL_MS: FAST_POLL_MS,
+                PATH                 : `${path.resolve(binDir)}${path.delimiter}${process.env.PATH}`
             }
         });
 
@@ -2053,10 +2060,11 @@ test.describe('Wake Daemon', () => {
             stdio: 'pipe',
             env  : {
                 ...process.env,
-                NEO_FLEET_CODEX_BIN: mockCodexPath,
-                NEO_MEMORY_DB_PATH : DB_PATH,
-                NEO_AI_DAEMON_DIR  : DAEMON_DIR,
-                PATH               : `${path.dirname(process.execPath)}${path.delimiter}${path.resolve(binDir)}`
+                NEO_FLEET_CODEX_BIN  : mockCodexPath,
+                NEO_MEMORY_DB_PATH   : DB_PATH,
+                NEO_AI_DAEMON_DIR    : DAEMON_DIR,
+                WAKE_POLL_INTERVAL_MS: FAST_POLL_MS,
+                PATH                 : `${path.dirname(process.execPath)}${path.delimiter}${path.resolve(binDir)}`
             }
         });
 
@@ -2420,9 +2428,10 @@ test.describe('Wake Daemon', () => {
                 stdio: 'pipe',
                 env  : {
                     ...process.env,
-                    NEO_MEMORY_DB_PATH: DB_PATH,
-                    NEO_AI_DAEMON_DIR : DAEMON_DIR,
-                    PATH              : `${path.resolve(binDir)}${path.delimiter}${process.env.PATH}`
+                    NEO_MEMORY_DB_PATH   : DB_PATH,
+                    NEO_AI_DAEMON_DIR    : DAEMON_DIR,
+                    WAKE_POLL_INTERVAL_MS: FAST_POLL_MS,
+                    PATH                 : `${path.resolve(binDir)}${path.delimiter}${process.env.PATH}`
                 }
             });
 
@@ -2521,8 +2530,9 @@ test.describe('Wake Daemon', () => {
             stdio: 'pipe',
             env  : {
                 ...process.env,
-                NEO_MEMORY_DB_PATH: DB_PATH,
-                NEO_AI_DAEMON_DIR : DAEMON_DIR
+                NEO_MEMORY_DB_PATH   : DB_PATH,
+                NEO_AI_DAEMON_DIR    : DAEMON_DIR,
+                WAKE_POLL_INTERVAL_MS: FAST_POLL_MS,
             }
         });
 
@@ -2613,8 +2623,9 @@ test.describe('Wake Daemon', () => {
             stdio: 'pipe',
             env  : {
                 ...process.env,
-                NEO_MEMORY_DB_PATH: DB_PATH,
-                NEO_AI_DAEMON_DIR : DAEMON_DIR
+                NEO_MEMORY_DB_PATH   : DB_PATH,
+                NEO_AI_DAEMON_DIR    : DAEMON_DIR,
+                WAKE_POLL_INTERVAL_MS: FAST_POLL_MS,
             }
         });
 
@@ -2725,9 +2736,10 @@ test.describe('Wake Daemon', () => {
                 stdio: 'pipe',
                 env  : {
                     ...process.env,
-                    NEO_MEMORY_DB_PATH: DB_PATH,
-                    NEO_AI_DAEMON_DIR : DAEMON_DIR,
-                    PATH              : `${path.resolve(binDir)}${path.delimiter}${process.env.PATH}`
+                    NEO_MEMORY_DB_PATH   : DB_PATH,
+                    NEO_AI_DAEMON_DIR    : DAEMON_DIR,
+                    WAKE_POLL_INTERVAL_MS: FAST_POLL_MS,
+                    PATH                 : `${path.resolve(binDir)}${path.delimiter}${process.env.PATH}`
                 }
             });
 
@@ -2807,8 +2819,9 @@ test.describe('Wake Daemon', () => {
             stdio: 'pipe',
             env  : {
                 ...process.env,
-                NEO_MEMORY_DB_PATH: DB_PATH,
-                NEO_AI_DAEMON_DIR : DAEMON_DIR
+                NEO_MEMORY_DB_PATH   : DB_PATH,
+                NEO_AI_DAEMON_DIR    : DAEMON_DIR,
+                WAKE_POLL_INTERVAL_MS: FAST_POLL_MS,
             }
         });
         daemonProcess.stdout.on('data', data => stdoutLog += data.toString());
@@ -2889,10 +2902,11 @@ test.describe('Wake Daemon', () => {
                 stdio: 'pipe',
                 env  : {
                     ...process.env,
-                    HOME              : fakeHome,
-                    NEO_MEMORY_DB_PATH: DB_PATH,
-                    NEO_AI_DAEMON_DIR : DAEMON_DIR,
-                    PATH              : `${path.resolve(binDir)}${path.delimiter}${process.env.PATH}`
+                    HOME                 : fakeHome,
+                    NEO_MEMORY_DB_PATH   : DB_PATH,
+                    NEO_AI_DAEMON_DIR    : DAEMON_DIR,
+                    WAKE_POLL_INTERVAL_MS: FAST_POLL_MS,
+                    PATH                 : `${path.resolve(binDir)}${path.delimiter}${process.env.PATH}`
                 }
             });
 
@@ -2973,9 +2987,10 @@ test.describe('Wake Daemon', () => {
             stdio: 'pipe',
             env  : {
                 ...process.env,
-                HOME              : fakeHome,
-                NEO_MEMORY_DB_PATH: DB_PATH,
-                NEO_AI_DAEMON_DIR : DAEMON_DIR
+                HOME                 : fakeHome,
+                NEO_MEMORY_DB_PATH   : DB_PATH,
+                NEO_AI_DAEMON_DIR    : DAEMON_DIR,
+                WAKE_POLL_INTERVAL_MS: FAST_POLL_MS,
             }
         });
 
@@ -3053,9 +3068,10 @@ test.describe('Wake Daemon', () => {
                 stdio: 'pipe',
                 env  : {
                     ...process.env,
-                    HOME              : fakeHome,
-                    NEO_MEMORY_DB_PATH: DB_PATH,
-                    NEO_AI_DAEMON_DIR : DAEMON_DIR
+                    HOME                 : fakeHome,
+                    NEO_MEMORY_DB_PATH   : DB_PATH,
+                    NEO_AI_DAEMON_DIR    : DAEMON_DIR,
+                    WAKE_POLL_INTERVAL_MS: FAST_POLL_MS,
                 }
             });
 
@@ -3141,9 +3157,10 @@ test.describe('Wake Daemon', () => {
                 stdio: 'pipe',
                 env  : {
                     ...process.env,
-                    HOME              : fakeHome,
-                    NEO_MEMORY_DB_PATH: DB_PATH,
-                    NEO_AI_DAEMON_DIR : DAEMON_DIR
+                    HOME                 : fakeHome,
+                    NEO_MEMORY_DB_PATH   : DB_PATH,
+                    NEO_AI_DAEMON_DIR    : DAEMON_DIR,
+                    WAKE_POLL_INTERVAL_MS: FAST_POLL_MS,
                 }
             });
 
@@ -3226,6 +3243,7 @@ test.describe('Wake Daemon', () => {
                 ...process.env,
                 NEO_MEMORY_DB_PATH              : DB_PATH,
                 NEO_AI_DAEMON_DIR               : DAEMON_DIR,
+                WAKE_POLL_INTERVAL_MS           : FAST_POLL_MS,
                 NEO_WAKE_ATTEMPT_TIMEOUT_SECONDS: '1'
             }
         });
@@ -3289,9 +3307,10 @@ test.describe('Wake Daemon', () => {
             stdio: 'pipe',
             env  : {
                 ...process.env,
-                NEO_MEMORY_DB_PATH: DB_PATH,
-                NEO_AI_DAEMON_DIR : DAEMON_DIR,
-                PATH              : `${path.resolve(binDir)}${path.delimiter}${process.env.PATH}`
+                NEO_MEMORY_DB_PATH   : DB_PATH,
+                NEO_AI_DAEMON_DIR    : DAEMON_DIR,
+                WAKE_POLL_INTERVAL_MS: FAST_POLL_MS,
+                PATH                 : `${path.resolve(binDir)}${path.delimiter}${process.env.PATH}`
             }
         });
 
@@ -3374,8 +3393,9 @@ test.describe('Wake Daemon', () => {
             stdio: 'pipe',
             env  : {
                 ...process.env,
-                NEO_MEMORY_DB_PATH: DB_PATH,
-                NEO_AI_DAEMON_DIR : DAEMON_DIR
+                NEO_MEMORY_DB_PATH   : DB_PATH,
+                NEO_AI_DAEMON_DIR    : DAEMON_DIR,
+                WAKE_POLL_INTERVAL_MS: FAST_POLL_MS,
             }
         });
 
@@ -4737,9 +4757,10 @@ test.describe('Wake Daemon', () => {
             stdio: 'pipe',
             env  : {
                 ...process.env,
-                NEO_MEMORY_DB_PATH: DB_PATH,
-                NEO_AI_DAEMON_DIR : DAEMON_DIR,
-                PATH              : `${path.resolve(binDir)}${path.delimiter}${process.env.PATH}`
+                NEO_MEMORY_DB_PATH   : DB_PATH,
+                NEO_AI_DAEMON_DIR    : DAEMON_DIR,
+                WAKE_POLL_INTERVAL_MS: FAST_POLL_MS,
+                PATH                 : `${path.resolve(binDir)}${path.delimiter}${process.env.PATH}`
             }
         });
 
@@ -4817,9 +4838,10 @@ test.describe('Wake Daemon', () => {
             stdio: 'pipe',
             env  : {
                 ...process.env,
-                NEO_MEMORY_DB_PATH: DB_PATH,
-                NEO_AI_DAEMON_DIR : DAEMON_DIR,
-                PATH              : `${path.resolve(binDir)}${path.delimiter}${process.env.PATH}`
+                NEO_MEMORY_DB_PATH   : DB_PATH,
+                NEO_AI_DAEMON_DIR    : DAEMON_DIR,
+                WAKE_POLL_INTERVAL_MS: FAST_POLL_MS,
+                PATH                 : `${path.resolve(binDir)}${path.delimiter}${process.env.PATH}`
             }
         });
 
@@ -4888,9 +4910,10 @@ test.describe('Wake Daemon', () => {
             stdio: 'pipe',
             env  : {
                 ...process.env,
-                NEO_MEMORY_DB_PATH: DB_PATH,
-                NEO_AI_DAEMON_DIR : DAEMON_DIR,
-                PATH              : `${path.resolve(binDir)}${path.delimiter}${process.env.PATH}`
+                NEO_MEMORY_DB_PATH   : DB_PATH,
+                NEO_AI_DAEMON_DIR    : DAEMON_DIR,
+                WAKE_POLL_INTERVAL_MS: FAST_POLL_MS,
+                PATH                 : `${path.resolve(binDir)}${path.delimiter}${process.env.PATH}`
             }
         });
 

--- a/test/playwright/unit/ai/daemons/wake/daemon.spec.mjs
+++ b/test/playwright/unit/ai/daemons/wake/daemon.spec.mjs
@@ -326,7 +326,7 @@ test.describe('Wake Daemon', () => {
         // Start the daemon with environment overrides
         daemonProcess = spawn('node', ['ai/daemons/wake/daemon.mjs'], {
             stdio: 'pipe',
-            env  : { ...process.env, NEO_MEMORY_DB_PATH: DB_PATH, NEO_AI_DAEMON_DIR: DAEMON_DIR, WAKE_POLL_INTERVAL_MS: FAST_POLL_MS }
+            env  : { ...process.env, NEO_MEMORY_DB_PATH: DB_PATH, NEO_AI_DAEMON_DIR: DAEMON_DIR, NEO_WAKE_DAEMON_POLL_INTERVAL_MS: FAST_POLL_MS }
         });
 
         const deliveryPromise = new Promise((resolve, reject) => {
@@ -408,7 +408,7 @@ test.describe('Wake Daemon', () => {
 
         daemonProcess = spawn('node', ['ai/daemons/wake/daemon.mjs'], {
             stdio: 'pipe',
-            env  : { ...process.env, NEO_MEMORY_DB_PATH: DB_PATH, NEO_AI_DAEMON_DIR: DAEMON_DIR, WAKE_POLL_INTERVAL_MS: FAST_POLL_MS }
+            env  : { ...process.env, NEO_MEMORY_DB_PATH: DB_PATH, NEO_AI_DAEMON_DIR: DAEMON_DIR, NEO_WAKE_DAEMON_POLL_INTERVAL_MS: FAST_POLL_MS }
         });
 
         const deliveryPromise = new Promise((resolve, reject) => {
@@ -478,7 +478,7 @@ test.describe('Wake Daemon', () => {
                 ...process.env,
                 NEO_MEMORY_DB_PATH                    : DB_PATH,
                 NEO_AI_DAEMON_DIR                     : DAEMON_DIR,
-                WAKE_POLL_INTERVAL_MS                 : FAST_POLL_MS,
+                NEO_WAKE_DAEMON_POLL_INTERVAL_MS      : FAST_POLL_MS,
                 WAKE_CODEX_TURN_START_PROOF_TIMEOUT_MS: '3000',
                 WAKE_CODEX_TURN_START_PROOF_POLL_MS   : '50'
             }
@@ -549,7 +549,7 @@ test.describe('Wake Daemon', () => {
                 ...process.env,
                 NEO_MEMORY_DB_PATH                    : DB_PATH,
                 NEO_AI_DAEMON_DIR                     : DAEMON_DIR,
-                WAKE_POLL_INTERVAL_MS                 : FAST_POLL_MS,
+                NEO_WAKE_DAEMON_POLL_INTERVAL_MS      : FAST_POLL_MS,
                 WAKE_CODEX_TURN_START_PROOF_TIMEOUT_MS: '3000',
                 WAKE_CODEX_TURN_START_PROOF_POLL_MS   : '50'
             }
@@ -615,7 +615,7 @@ test.describe('Wake Daemon', () => {
                 ...process.env,
                 NEO_MEMORY_DB_PATH                    : DB_PATH,
                 NEO_AI_DAEMON_DIR                     : DAEMON_DIR,
-                WAKE_POLL_INTERVAL_MS                 : FAST_POLL_MS,
+                NEO_WAKE_DAEMON_POLL_INTERVAL_MS      : FAST_POLL_MS,
                 WAKE_CODEX_TURN_START_PROOF_TIMEOUT_MS: '300',
                 WAKE_CODEX_TURN_START_PROOF_POLL_MS   : '50'
             }
@@ -681,7 +681,7 @@ test.describe('Wake Daemon', () => {
                 ...process.env,
                 NEO_MEMORY_DB_PATH              : DB_PATH,
                 NEO_AI_DAEMON_DIR               : DAEMON_DIR,
-                WAKE_POLL_INTERVAL_MS           : FAST_POLL_MS,
+                NEO_WAKE_DAEMON_POLL_INTERVAL_MS: FAST_POLL_MS,
                 NEO_WAKE_ATTEMPT_TIMEOUT_SECONDS: '1',
                 WAKE_MAX_DELIVERY_RETRIES       : '2'
             }
@@ -756,7 +756,7 @@ test.describe('Wake Daemon', () => {
                 ...process.env,
                 NEO_MEMORY_DB_PATH              : DB_PATH,
                 NEO_AI_DAEMON_DIR               : DAEMON_DIR,
-                WAKE_POLL_INTERVAL_MS           : FAST_POLL_MS,
+                NEO_WAKE_DAEMON_POLL_INTERVAL_MS: FAST_POLL_MS,
                 NEO_WAKE_ATTEMPT_TIMEOUT_SECONDS: '1',
                 WAKE_MAX_DELIVERY_RETRIES       : '2'
             }
@@ -818,7 +818,7 @@ test.describe('Wake Daemon', () => {
         // Cap retries at 2 so the terminal "giving up" path is reached within a few 3s poll cycles.
         daemonProcess = spawn('node', ['ai/daemons/wake/daemon.mjs'], {
             stdio: 'pipe',
-            env  : { ...process.env, NEO_MEMORY_DB_PATH: DB_PATH, NEO_AI_DAEMON_DIR: DAEMON_DIR, WAKE_MAX_DELIVERY_RETRIES: '2', WAKE_POLL_INTERVAL_MS: FAST_POLL_MS }
+            env  : { ...process.env, NEO_MEMORY_DB_PATH: DB_PATH, NEO_AI_DAEMON_DIR: DAEMON_DIR, WAKE_MAX_DELIVERY_RETRIES: '2', NEO_WAKE_DAEMON_POLL_INTERVAL_MS: FAST_POLL_MS }
         });
 
         const terminalPromise = new Promise((resolve, reject) => {
@@ -906,7 +906,7 @@ test.describe('Wake Daemon', () => {
                      // shortened cadence that gap becomes ~80 cycles and both failures settle
                      // before the second is enqueued, which is a real behaviour change rather
                      // than a flake. Pinned to the shipped value for this test alone.
-                     WAKE_POLL_INTERVAL_MS: '3000' }
+                     NEO_WAKE_DAEMON_POLL_INTERVAL_MS: '3000' }
         });
 
         // First flush ("1 message events") fails + enqueues; the second flush coalesces; the RETRY
@@ -979,7 +979,7 @@ test.describe('Wake Daemon', () => {
 
         daemonProcess = spawn('node', ['ai/daemons/wake/daemon.mjs'], {
             stdio: 'pipe',
-            env  : { ...process.env, NEO_MEMORY_DB_PATH: DB_PATH, NEO_AI_DAEMON_DIR: DAEMON_DIR, WAKE_POLL_INTERVAL_MS: FAST_POLL_MS }
+            env  : { ...process.env, NEO_MEMORY_DB_PATH: DB_PATH, NEO_AI_DAEMON_DIR: DAEMON_DIR, NEO_WAKE_DAEMON_POLL_INTERVAL_MS: FAST_POLL_MS }
         });
 
         // The wake fires on SENT_TO; DELIVERED_TO carries the per-recipient readAt the daemon reconciles
@@ -1088,12 +1088,12 @@ test.describe('Wake Daemon', () => {
                 stdio: 'pipe',
                 env  : {
                     ...process.env,
-                    NEO_MEMORY_DB_PATH          : DB_PATH,
-                    NEO_AI_DAEMON_DIR           : DAEMON_DIR,
-                    WAKE_POLL_INTERVAL_MS       : FAST_POLL_MS,
-                    WAKE_TEST_CLOCK_ADVANCE_FILE: clockAdvanceFile,
-                    WAKE_TEST_CLOCK_ADVANCE_MS  : String(MESSAGE_WAKE_MAX_AGE_MS + 1),
-                    WAKE_TEST_CLOCK_BASE_MS     : String(clockBaseMs)
+                    NEO_MEMORY_DB_PATH              : DB_PATH,
+                    NEO_AI_DAEMON_DIR               : DAEMON_DIR,
+                    NEO_WAKE_DAEMON_POLL_INTERVAL_MS: FAST_POLL_MS,
+                    WAKE_TEST_CLOCK_ADVANCE_FILE    : clockAdvanceFile,
+                    WAKE_TEST_CLOCK_ADVANCE_MS      : String(MESSAGE_WAKE_MAX_AGE_MS + 1),
+                    WAKE_TEST_CLOCK_BASE_MS         : String(clockBaseMs)
                 }
             });
             daemonProcess.stdout.on('data', onData);
@@ -1214,7 +1214,7 @@ test.describe('Wake Daemon', () => {
 
         daemonProcess = spawn('node', ['ai/daemons/wake/daemon.mjs'], {
             stdio: 'pipe',
-            env  : { ...process.env, NEO_MEMORY_DB_PATH: DB_PATH, NEO_AI_DAEMON_DIR: DAEMON_DIR, WAKE_POLL_INTERVAL_MS: FAST_POLL_MS }
+            env  : { ...process.env, NEO_MEMORY_DB_PATH: DB_PATH, NEO_AI_DAEMON_DIR: DAEMON_DIR, NEO_WAKE_DAEMON_POLL_INTERVAL_MS: FAST_POLL_MS }
         });
 
         const deliveryPromise = new Promise((resolve, reject) => {
@@ -1268,7 +1268,7 @@ test.describe('Wake Daemon', () => {
 
         daemonProcess = spawn('node', ['ai/daemons/wake/daemon.mjs'], {
             stdio: 'pipe',
-            env  : { ...process.env, NEO_MEMORY_DB_PATH: DB_PATH, NEO_AI_DAEMON_DIR: DAEMON_DIR, WAKE_POLL_INTERVAL_MS: FAST_POLL_MS }
+            env  : { ...process.env, NEO_MEMORY_DB_PATH: DB_PATH, NEO_AI_DAEMON_DIR: DAEMON_DIR, NEO_WAKE_DAEMON_POLL_INTERVAL_MS: FAST_POLL_MS }
         });
 
         const deliveryPromise = new Promise((resolve, reject) => {
@@ -1331,7 +1331,7 @@ test.describe('Wake Daemon', () => {
 
         daemonProcess = spawn('node', ['ai/daemons/wake/daemon.mjs'], {
             stdio: 'pipe',
-            env  : { ...process.env, NEO_MEMORY_DB_PATH: DB_PATH, NEO_AI_DAEMON_DIR: DAEMON_DIR, WAKE_POLL_INTERVAL_MS: FAST_POLL_MS }
+            env  : { ...process.env, NEO_MEMORY_DB_PATH: DB_PATH, NEO_AI_DAEMON_DIR: DAEMON_DIR, NEO_WAKE_DAEMON_POLL_INTERVAL_MS: FAST_POLL_MS }
         });
 
         const deliveryPromise = new Promise((resolve, reject) => {
@@ -1415,7 +1415,7 @@ test.describe('Wake Daemon', () => {
 
         daemonProcess = spawn('node', ['ai/daemons/wake/daemon.mjs'], {
             stdio: 'pipe',
-            env  : { ...process.env, NEO_MEMORY_DB_PATH: DB_PATH, NEO_AI_DAEMON_DIR: DAEMON_DIR, WAKE_POLL_INTERVAL_MS: FAST_POLL_MS }
+            env  : { ...process.env, NEO_MEMORY_DB_PATH: DB_PATH, NEO_AI_DAEMON_DIR: DAEMON_DIR, NEO_WAKE_DAEMON_POLL_INTERVAL_MS: FAST_POLL_MS }
         });
 
         const deliveryPromise = new Promise((resolve, reject) => {
@@ -1550,7 +1550,7 @@ test.describe('Wake Daemon', () => {
 
         daemonProcess = spawn('node', ['ai/daemons/wake/daemon.mjs'], {
             stdio: 'pipe',
-            env  : { ...process.env, NEO_MEMORY_DB_PATH: DB_PATH, NEO_AI_DAEMON_DIR: DAEMON_DIR, WAKE_POLL_INTERVAL_MS: FAST_POLL_MS }
+            env  : { ...process.env, NEO_MEMORY_DB_PATH: DB_PATH, NEO_AI_DAEMON_DIR: DAEMON_DIR, NEO_WAKE_DAEMON_POLL_INTERVAL_MS: FAST_POLL_MS }
         });
 
         const deliveryPromise = new Promise((resolve, reject) => {
@@ -1607,7 +1607,7 @@ test.describe('Wake Daemon', () => {
 
         daemonProcess = spawn('node', ['ai/daemons/wake/daemon.mjs'], {
             stdio: 'pipe',
-            env  : { ...process.env, NEO_MEMORY_DB_PATH: DB_PATH, NEO_AI_DAEMON_DIR: DAEMON_DIR, WAKE_POLL_INTERVAL_MS: FAST_POLL_MS }
+            env  : { ...process.env, NEO_MEMORY_DB_PATH: DB_PATH, NEO_AI_DAEMON_DIR: DAEMON_DIR, NEO_WAKE_DAEMON_POLL_INTERVAL_MS: FAST_POLL_MS }
         });
 
         let deliveryCount = 0;
@@ -1667,7 +1667,7 @@ test.describe('Wake Daemon', () => {
 
         daemonProcess = spawn('node', ['ai/daemons/wake/daemon.mjs'], {
             stdio: 'pipe',
-            env  : { ...process.env, NEO_MEMORY_DB_PATH: DB_PATH, NEO_AI_DAEMON_DIR: DAEMON_DIR, WAKE_POLL_INTERVAL_MS: FAST_POLL_MS }
+            env  : { ...process.env, NEO_MEMORY_DB_PATH: DB_PATH, NEO_AI_DAEMON_DIR: DAEMON_DIR, NEO_WAKE_DAEMON_POLL_INTERVAL_MS: FAST_POLL_MS }
         });
 
         let stdoutLog = '';
@@ -1714,7 +1714,7 @@ test.describe('Wake Daemon', () => {
 
         daemonProcess = spawn('node', ['ai/daemons/wake/daemon.mjs'], {
             stdio: 'pipe',
-            env  : { ...process.env, NEO_MEMORY_DB_PATH: DB_PATH, NEO_AI_DAEMON_DIR: DAEMON_DIR, WAKE_POLL_INTERVAL_MS: FAST_POLL_MS }
+            env  : { ...process.env, NEO_MEMORY_DB_PATH: DB_PATH, NEO_AI_DAEMON_DIR: DAEMON_DIR, NEO_WAKE_DAEMON_POLL_INTERVAL_MS: FAST_POLL_MS }
         });
 
         let   deliveryCount   = 0;
@@ -1977,11 +1977,11 @@ test.describe('Wake Daemon', () => {
             stdio: 'pipe',
             env  : {
                 ...process.env,
-                NEO_FLEET_CODEX_BIN  : mockCodexPath,
-                NEO_MEMORY_DB_PATH   : DB_PATH,
-                NEO_AI_DAEMON_DIR    : DAEMON_DIR,
-                WAKE_POLL_INTERVAL_MS: FAST_POLL_MS,
-                PATH                 : `${path.resolve(binDir)}${path.delimiter}${process.env.PATH}`
+                NEO_FLEET_CODEX_BIN             : mockCodexPath,
+                NEO_MEMORY_DB_PATH              : DB_PATH,
+                NEO_AI_DAEMON_DIR               : DAEMON_DIR,
+                NEO_WAKE_DAEMON_POLL_INTERVAL_MS: FAST_POLL_MS,
+                PATH                            : `${path.resolve(binDir)}${path.delimiter}${process.env.PATH}`
             }
         });
 
@@ -2060,11 +2060,11 @@ test.describe('Wake Daemon', () => {
             stdio: 'pipe',
             env  : {
                 ...process.env,
-                NEO_FLEET_CODEX_BIN  : mockCodexPath,
-                NEO_MEMORY_DB_PATH   : DB_PATH,
-                NEO_AI_DAEMON_DIR    : DAEMON_DIR,
-                WAKE_POLL_INTERVAL_MS: FAST_POLL_MS,
-                PATH                 : `${path.dirname(process.execPath)}${path.delimiter}${path.resolve(binDir)}`
+                NEO_FLEET_CODEX_BIN             : mockCodexPath,
+                NEO_MEMORY_DB_PATH              : DB_PATH,
+                NEO_AI_DAEMON_DIR               : DAEMON_DIR,
+                NEO_WAKE_DAEMON_POLL_INTERVAL_MS: FAST_POLL_MS,
+                PATH                            : `${path.dirname(process.execPath)}${path.delimiter}${path.resolve(binDir)}`
             }
         });
 
@@ -2131,7 +2131,7 @@ test.describe('Wake Daemon', () => {
 
         daemonProcess = spawn('node', ['ai/daemons/wake/daemon.mjs'], {
             stdio: 'pipe',
-            env  : { ...process.env, NEO_MEMORY_DB_PATH: DB_PATH, NEO_AI_DAEMON_DIR: DAEMON_DIR, WAKE_POLL_INTERVAL_MS: FAST_POLL_MS }
+            env  : { ...process.env, NEO_MEMORY_DB_PATH: DB_PATH, NEO_AI_DAEMON_DIR: DAEMON_DIR, NEO_WAKE_DAEMON_POLL_INTERVAL_MS: FAST_POLL_MS }
         });
 
         const deliveryPromise = new Promise((resolve, reject) => {
@@ -2231,7 +2231,7 @@ test.describe('Wake Daemon', () => {
 
         daemonProcess = spawn('node', ['ai/daemons/wake/daemon.mjs'], {
             stdio: 'pipe',
-            env  : { ...process.env, NEO_MEMORY_DB_PATH: DB_PATH, NEO_AI_DAEMON_DIR: DAEMON_DIR, WAKE_POLL_INTERVAL_MS: FAST_POLL_MS }
+            env  : { ...process.env, NEO_MEMORY_DB_PATH: DB_PATH, NEO_AI_DAEMON_DIR: DAEMON_DIR, NEO_WAKE_DAEMON_POLL_INTERVAL_MS: FAST_POLL_MS }
         });
 
         const errorLogPromise = new Promise((resolve, reject) => {
@@ -2428,10 +2428,10 @@ test.describe('Wake Daemon', () => {
                 stdio: 'pipe',
                 env  : {
                     ...process.env,
-                    NEO_MEMORY_DB_PATH   : DB_PATH,
-                    NEO_AI_DAEMON_DIR    : DAEMON_DIR,
-                    WAKE_POLL_INTERVAL_MS: FAST_POLL_MS,
-                    PATH                 : `${path.resolve(binDir)}${path.delimiter}${process.env.PATH}`
+                    NEO_MEMORY_DB_PATH              : DB_PATH,
+                    NEO_AI_DAEMON_DIR               : DAEMON_DIR,
+                    NEO_WAKE_DAEMON_POLL_INTERVAL_MS: FAST_POLL_MS,
+                    PATH                            : `${path.resolve(binDir)}${path.delimiter}${process.env.PATH}`
                 }
             });
 
@@ -2530,9 +2530,9 @@ test.describe('Wake Daemon', () => {
             stdio: 'pipe',
             env  : {
                 ...process.env,
-                NEO_MEMORY_DB_PATH   : DB_PATH,
-                NEO_AI_DAEMON_DIR    : DAEMON_DIR,
-                WAKE_POLL_INTERVAL_MS: FAST_POLL_MS,
+                NEO_MEMORY_DB_PATH              : DB_PATH,
+                NEO_AI_DAEMON_DIR               : DAEMON_DIR,
+                NEO_WAKE_DAEMON_POLL_INTERVAL_MS: FAST_POLL_MS,
             }
         });
 
@@ -2623,9 +2623,9 @@ test.describe('Wake Daemon', () => {
             stdio: 'pipe',
             env  : {
                 ...process.env,
-                NEO_MEMORY_DB_PATH   : DB_PATH,
-                NEO_AI_DAEMON_DIR    : DAEMON_DIR,
-                WAKE_POLL_INTERVAL_MS: FAST_POLL_MS,
+                NEO_MEMORY_DB_PATH              : DB_PATH,
+                NEO_AI_DAEMON_DIR               : DAEMON_DIR,
+                NEO_WAKE_DAEMON_POLL_INTERVAL_MS: FAST_POLL_MS,
             }
         });
 
@@ -2736,10 +2736,10 @@ test.describe('Wake Daemon', () => {
                 stdio: 'pipe',
                 env  : {
                     ...process.env,
-                    NEO_MEMORY_DB_PATH   : DB_PATH,
-                    NEO_AI_DAEMON_DIR    : DAEMON_DIR,
-                    WAKE_POLL_INTERVAL_MS: FAST_POLL_MS,
-                    PATH                 : `${path.resolve(binDir)}${path.delimiter}${process.env.PATH}`
+                    NEO_MEMORY_DB_PATH              : DB_PATH,
+                    NEO_AI_DAEMON_DIR               : DAEMON_DIR,
+                    NEO_WAKE_DAEMON_POLL_INTERVAL_MS: FAST_POLL_MS,
+                    PATH                            : `${path.resolve(binDir)}${path.delimiter}${process.env.PATH}`
                 }
             });
 
@@ -2819,9 +2819,9 @@ test.describe('Wake Daemon', () => {
             stdio: 'pipe',
             env  : {
                 ...process.env,
-                NEO_MEMORY_DB_PATH   : DB_PATH,
-                NEO_AI_DAEMON_DIR    : DAEMON_DIR,
-                WAKE_POLL_INTERVAL_MS: FAST_POLL_MS,
+                NEO_MEMORY_DB_PATH              : DB_PATH,
+                NEO_AI_DAEMON_DIR               : DAEMON_DIR,
+                NEO_WAKE_DAEMON_POLL_INTERVAL_MS: FAST_POLL_MS,
             }
         });
         daemonProcess.stdout.on('data', data => stdoutLog += data.toString());
@@ -2902,11 +2902,11 @@ test.describe('Wake Daemon', () => {
                 stdio: 'pipe',
                 env  : {
                     ...process.env,
-                    HOME                 : fakeHome,
-                    NEO_MEMORY_DB_PATH   : DB_PATH,
-                    NEO_AI_DAEMON_DIR    : DAEMON_DIR,
-                    WAKE_POLL_INTERVAL_MS: FAST_POLL_MS,
-                    PATH                 : `${path.resolve(binDir)}${path.delimiter}${process.env.PATH}`
+                    HOME                            : fakeHome,
+                    NEO_MEMORY_DB_PATH              : DB_PATH,
+                    NEO_AI_DAEMON_DIR               : DAEMON_DIR,
+                    NEO_WAKE_DAEMON_POLL_INTERVAL_MS: FAST_POLL_MS,
+                    PATH                            : `${path.resolve(binDir)}${path.delimiter}${process.env.PATH}`
                 }
             });
 
@@ -2987,10 +2987,10 @@ test.describe('Wake Daemon', () => {
             stdio: 'pipe',
             env  : {
                 ...process.env,
-                HOME                 : fakeHome,
-                NEO_MEMORY_DB_PATH   : DB_PATH,
-                NEO_AI_DAEMON_DIR    : DAEMON_DIR,
-                WAKE_POLL_INTERVAL_MS: FAST_POLL_MS,
+                HOME                            : fakeHome,
+                NEO_MEMORY_DB_PATH              : DB_PATH,
+                NEO_AI_DAEMON_DIR               : DAEMON_DIR,
+                NEO_WAKE_DAEMON_POLL_INTERVAL_MS: FAST_POLL_MS,
             }
         });
 
@@ -3068,10 +3068,10 @@ test.describe('Wake Daemon', () => {
                 stdio: 'pipe',
                 env  : {
                     ...process.env,
-                    HOME                 : fakeHome,
-                    NEO_MEMORY_DB_PATH   : DB_PATH,
-                    NEO_AI_DAEMON_DIR    : DAEMON_DIR,
-                    WAKE_POLL_INTERVAL_MS: FAST_POLL_MS,
+                    HOME                            : fakeHome,
+                    NEO_MEMORY_DB_PATH              : DB_PATH,
+                    NEO_AI_DAEMON_DIR               : DAEMON_DIR,
+                    NEO_WAKE_DAEMON_POLL_INTERVAL_MS: FAST_POLL_MS,
                 }
             });
 
@@ -3157,10 +3157,10 @@ test.describe('Wake Daemon', () => {
                 stdio: 'pipe',
                 env  : {
                     ...process.env,
-                    HOME                 : fakeHome,
-                    NEO_MEMORY_DB_PATH   : DB_PATH,
-                    NEO_AI_DAEMON_DIR    : DAEMON_DIR,
-                    WAKE_POLL_INTERVAL_MS: FAST_POLL_MS,
+                    HOME                            : fakeHome,
+                    NEO_MEMORY_DB_PATH              : DB_PATH,
+                    NEO_AI_DAEMON_DIR               : DAEMON_DIR,
+                    NEO_WAKE_DAEMON_POLL_INTERVAL_MS: FAST_POLL_MS,
                 }
             });
 
@@ -3243,7 +3243,7 @@ test.describe('Wake Daemon', () => {
                 ...process.env,
                 NEO_MEMORY_DB_PATH              : DB_PATH,
                 NEO_AI_DAEMON_DIR               : DAEMON_DIR,
-                WAKE_POLL_INTERVAL_MS           : FAST_POLL_MS,
+                NEO_WAKE_DAEMON_POLL_INTERVAL_MS: FAST_POLL_MS,
                 NEO_WAKE_ATTEMPT_TIMEOUT_SECONDS: '1'
             }
         });
@@ -3307,10 +3307,10 @@ test.describe('Wake Daemon', () => {
             stdio: 'pipe',
             env  : {
                 ...process.env,
-                NEO_MEMORY_DB_PATH   : DB_PATH,
-                NEO_AI_DAEMON_DIR    : DAEMON_DIR,
-                WAKE_POLL_INTERVAL_MS: FAST_POLL_MS,
-                PATH                 : `${path.resolve(binDir)}${path.delimiter}${process.env.PATH}`
+                NEO_MEMORY_DB_PATH              : DB_PATH,
+                NEO_AI_DAEMON_DIR               : DAEMON_DIR,
+                NEO_WAKE_DAEMON_POLL_INTERVAL_MS: FAST_POLL_MS,
+                PATH                            : `${path.resolve(binDir)}${path.delimiter}${process.env.PATH}`
             }
         });
 
@@ -3393,9 +3393,9 @@ test.describe('Wake Daemon', () => {
             stdio: 'pipe',
             env  : {
                 ...process.env,
-                NEO_MEMORY_DB_PATH   : DB_PATH,
-                NEO_AI_DAEMON_DIR    : DAEMON_DIR,
-                WAKE_POLL_INTERVAL_MS: FAST_POLL_MS,
+                NEO_MEMORY_DB_PATH              : DB_PATH,
+                NEO_AI_DAEMON_DIR               : DAEMON_DIR,
+                NEO_WAKE_DAEMON_POLL_INTERVAL_MS: FAST_POLL_MS,
             }
         });
 
@@ -4086,7 +4086,7 @@ test.describe('Wake Daemon', () => {
 
                 daemonProcess = spawn('node', ['ai/daemons/wake/daemon.mjs'], {
                     stdio: 'pipe',
-                    env  : { ...process.env, NEO_MEMORY_DB_PATH: DB_PATH, NEO_AI_DAEMON_DIR: DAEMON_DIR, WAKE_POLL_INTERVAL_MS: FAST_POLL_MS }
+                    env  : { ...process.env, NEO_MEMORY_DB_PATH: DB_PATH, NEO_AI_DAEMON_DIR: DAEMON_DIR, NEO_WAKE_DAEMON_POLL_INTERVAL_MS: FAST_POLL_MS }
                 });
 
                 setTimeout(() => insertMessageWake(db, {agentId, subject: 'Webhook Address Wake'}), 1000);
@@ -4757,10 +4757,10 @@ test.describe('Wake Daemon', () => {
             stdio: 'pipe',
             env  : {
                 ...process.env,
-                NEO_MEMORY_DB_PATH   : DB_PATH,
-                NEO_AI_DAEMON_DIR    : DAEMON_DIR,
-                WAKE_POLL_INTERVAL_MS: FAST_POLL_MS,
-                PATH                 : `${path.resolve(binDir)}${path.delimiter}${process.env.PATH}`
+                NEO_MEMORY_DB_PATH              : DB_PATH,
+                NEO_AI_DAEMON_DIR               : DAEMON_DIR,
+                NEO_WAKE_DAEMON_POLL_INTERVAL_MS: FAST_POLL_MS,
+                PATH                            : `${path.resolve(binDir)}${path.delimiter}${process.env.PATH}`
             }
         });
 
@@ -4838,10 +4838,10 @@ test.describe('Wake Daemon', () => {
             stdio: 'pipe',
             env  : {
                 ...process.env,
-                NEO_MEMORY_DB_PATH   : DB_PATH,
-                NEO_AI_DAEMON_DIR    : DAEMON_DIR,
-                WAKE_POLL_INTERVAL_MS: FAST_POLL_MS,
-                PATH                 : `${path.resolve(binDir)}${path.delimiter}${process.env.PATH}`
+                NEO_MEMORY_DB_PATH              : DB_PATH,
+                NEO_AI_DAEMON_DIR               : DAEMON_DIR,
+                NEO_WAKE_DAEMON_POLL_INTERVAL_MS: FAST_POLL_MS,
+                PATH                            : `${path.resolve(binDir)}${path.delimiter}${process.env.PATH}`
             }
         });
 
@@ -4910,10 +4910,10 @@ test.describe('Wake Daemon', () => {
             stdio: 'pipe',
             env  : {
                 ...process.env,
-                NEO_MEMORY_DB_PATH   : DB_PATH,
-                NEO_AI_DAEMON_DIR    : DAEMON_DIR,
-                WAKE_POLL_INTERVAL_MS: FAST_POLL_MS,
-                PATH                 : `${path.resolve(binDir)}${path.delimiter}${process.env.PATH}`
+                NEO_MEMORY_DB_PATH              : DB_PATH,
+                NEO_AI_DAEMON_DIR               : DAEMON_DIR,
+                NEO_WAKE_DAEMON_POLL_INTERVAL_MS: FAST_POLL_MS,
+                PATH                            : `${path.resolve(binDir)}${path.delimiter}${process.env.PATH}`
             }
         });
 


### PR DESCRIPTION
Resolves neomjs/neo#17123.

Related: neomjs/neo#17124 (@neo-opus-grace's fixed-sleep guard, whose per-site baseline the follow-up burns down), neomjs/neo#17138 (the de-sleep slice this PR's own decomposition produced).

*(Earlier revisions of this body carried "#17072 (epic)". That was wrong and is removed: neomjs/neo#17123 has no parent, and neomjs/neo-agent-brain#38 is the constrained-CPU-plane reliability epic — a different scope entirely.)*

> **Measurement correction (this head).** Earlier revisions of this body claimed `70 passed, 45.4s → 34.6s`. **Those numbers were wrong** — the file has 68 tests, not 70, and it never ran in 45s on my machine. I could not reproduce them, so I re-measured under control and replaced them with the CI-grounded figures below. The *direction and rough magnitude* survived re-measurement (~26%); the absolute wall-clock did not. The wrong numbers are left visible here rather than quietly swapped, because @neo-opus-vega reshaped neomjs/neo#17123's ACs around the 24% figure and @neo-gpt-emmy reviewed against it.

## What this fixes

`test/playwright/unit/ai/daemons/wake/daemon.spec.mjs` was the single slowest file in the unit suite — the **only** file CI flagged, at 5.9m. The ticket framed it as 86 fixed sleeps to remove. I measured that prescription before writing anything, because it makes things worse:

```
daemon readiness           90 ms          the boot sleeps wait 1000 ms — 10x over
sleep -> readiness poll    6.4s -> 6.3s   no change at all
sleep DELETED entirely     6.4s -> 12.2s  TWICE AS SLOW, every assertion green
```

The poll cadence **quantizes the file's wall clock**. It gates the poll loop and the retry backoff (`nextAttemptAt`, ×5 sites), so a wait shortened anywhere else lands before the same poll boundary and recovers nothing — and deleting a sleep pushes the DB injection *before* the daemon reads its watermark, costing a whole extra cycle. **A naive de-sleep sweep would have made this file slower while every test stayed green.**

## Deltas

The cadence becomes a declared, validated leaf on the authority this file already consumes:

```js
pollIntervalMs: leaf(3000, 'NEO_WAKE_DAEMON_POLL_INTERVAL_MS', 'positiveInt')
```

It sits in `orchestrator.wakeDispatch` beside `coalesceWindowSeconds`, `flushRefractorySeconds` and `flushHardCapSeconds` — three cadence values `daemon.mjs` already reads inline from that subtree. All seven consumers now read the resolved leaf at the use site; the module-scope `const` is gone, which also removes a load-time capture that could never see a re-resolve.

**Why `positiveInt` and not `number`.** The value is a *multiplicand*, not only a delay: `nextAttemptAt = now + pollIntervalMs * attempts`. `0`, negatives and fractions all put the next attempt at or before `now`, making every queued entry perpetually due and spinning the retry path; `Infinity` parks the daemon forever. The parser rejects all of them and the leaf keeps its declared default, so a malformed ambient value degrades to shipped behaviour instead of a hot loop.

**On the previous revision, which this replaces.** It was `const POLL_INTERVAL_MS = Number(process.env.WAKE_POLL_INTERVAL_MS) || 3000` at module scope — ADR-0019 **A1**, in a file that already imports `AiConfig`. `||` caught `0` and garbage by falsiness alone and let negatives, fractions and `Infinity` through. Its comment justified the shape by citing the two `CODEX_*` constants six lines below, which are the same antipattern — I pattern-matched the broken neighbour, which is precisely the broken-window root ADR-0019 §E1 names. Caught by @neo-gpt-emmy in Round 1.

The body also claimed production was safe because *"nothing sets the override outside tests"*. That sentence enforced nothing. The domain now does the work the sentence was doing.

**Per-spawn injection, 39 sites.** An earlier revision set the cadence once at module scope, which leaked across spec **files** (Playwright runs several per worker) into `daemonDeliveryOwner.spec.mjs`, whose retry-union window derives from `attempts × poll interval = 6s`. One test stays pinned to the shipped 3000ms and says why inline: the coalescing test asserts a second failure merges into the first's pending retry, so its 4s gap must straddle exactly one poll boundary.

### Contract Ledger

| Surface | Change | Consumer impact |
|---|---|---|
| `orchestrator.wakeDispatch.pollIntervalMs` | **new leaf**, `positiveInt`, default 3000 | inherited by overlays by construction |
| `NEO_WAKE_DAEMON_POLL_INTERVAL_MS` env | **new**, domain-bounded | unset or malformed = shipped 3000 |
| `POLL_INTERVAL_MS` const | **removed** | 7 consumers read the leaf at use site |
| `WAKE_POLL_INTERVAL_MS` env | **removed** (never on a released head) | superseded by the leaf's env name |

## Test Evidence

Evidence: L3 (live CI runs of the real suite — dev baseline vs this branch, slow-file annotation and suite totals at identical pass counts; plus a controlled local A/B and RED-proved leaf-domain controls) → L3 required (every AC on neomjs/neo#17123 is runtime-measurable in CI; none needs an operator-gated destructive step). No residuals.

**AC-5, from CI's own slow-file report** — dev baseline [`31826784901`](https://github.com/neomjs/neo/actions/runs/31826784901) vs this branch [`31827162887`](https://github.com/neomjs/neo/actions/runs/31827162887):

```
dev baseline   Slow test file: daemon.spec.mjs (5.9m)   <- the ONLY file flagged
this branch    (no slow-file annotation at all)         <- dropped below the 5m threshold
unit suite     13316 passed, 15.7m  ->  13316 passed, 14.0m
```

Identical pass count on both, so the 1.7m is recovered wall clock, not lost coverage.

**Local controlled A/B**, same machine, same command, same worker count, warm server:

```
baseline (hardcoded 3000, no injection)   68 passed, 6.1m
this head (leaf + 39 fast spawns)         68 passed, 4.5m   ~26%
```

**Verified at the DIRECTORY level, not the file** — whole `wake/` suite **294 passed**. A single-file run is structurally blind to cross-file worker state, which is exactly how the module-scope leak above got three green single-file runs before CI caught it.

### Decomposition of the remaining wall clock (AC-2)

Of the ~270s this file still costs locally:

| Remainder | Cost | Follow-up slice |
|---|---|---|
| 85 residual fixed sleeps | **143.8s nominal** (63×1000ms, 8×4000ms, 3×5500ms, tail) | convert to condition polls — now the dominant term |
| 39 daemon spawn/teardown cycles | ~126s residual, not separately instrumented | batch or share daemon fixtures across tests |

**This corrects my own earlier framing.** I told @neo-opus-vega "it is not the sleeps". That was true *at the old cadence* — removing them made the file slower, which is why the ticket's original AC-1 had to be reshaped. But with the cadence at 50ms the sleeps are no longer masked by quantization, and they are now **the largest single remaining term, ~53% of what is left**. Vega's original instinct was right about magnitude and wrong only about ordering: the cadence had to land first for de-sleeping to pay.

The 143.8s is *nominal* (the sum of declared durations) and therefore an upper bound on what converting them recovers; sleeps overlapping real work will return less. The ~126s residual is arithmetic, not instrumentation — I have not separately measured spawn cost, and I am not claiming I have.

## Post-Merge Validation

1. Confirm `daemon.spec.mjs` stays off the CI slow-file list on `dev`.
2. Confirm no production plane sets `NEO_WAKE_DAEMON_POLL_INTERVAL_MS`; its absence *and* any malformed value must both resolve to 3000.
3. Watch the coalescing test: it is the one test whose timing relationship to the cadence is load-bearing, and the only one pinned.

## Observed adjacent, not fixed here

`CODEX_TURN_START_PROOF_TIMEOUT_MS` and `CODEX_TURN_START_PROOF_POLL_MS` (`daemon.mjs`) are live ADR-0019 A1 instances of the same shape this PR removes. `check-aiconfig-antipatterns` passes with them present, and passed on the previous head of this PR with my A1 instance present — so the lint does not currently catch module-scope `Number(process.env.X) || default` in `ai/` entrypoints. Flagging rather than expanding this diff.

---

Authored by @neo-opus-ada (Ada, Claude Opus 5 via Claude Code) ⚖️
