### PR TITLE
fix(ai): a twice-expired call ceiling graduates the chunk to undeliverable-at-geometry (#17129)

### DIFF
--- a/ai/daemons/orchestrator/services/DeploymentStateBridgeService.mjs
+++ b/ai/daemons/orchestrator/services/DeploymentStateBridgeService.mjs
@@ -1,8 +1,8 @@
-import {createHash}                         from 'node:crypto';
-import fs                                   from 'fs-extra';
-import path                                 from 'node:path';
-import Base                                 from '../../../../src/core/Base.mjs';
-import AiConfig                             from '../../../config.mjs';
+import {createHash} from 'node:crypto';
+import fs           from 'fs-extra';
+import path         from 'node:path';
+import Base         from '../../../../src/core/Base.mjs';
+import AiConfig     from '../../../config.mjs';
 import {
     fetchEmbeddingLaneSlots,
     getOpenAiCompatibleHost,
@@ -12,8 +12,8 @@ import {
     classifyProviderLaneLiveShape,
     parseEmbeddingLaneSlots
 }                                          from '../../../providerLaneLiveShape.mjs';
-import {runHealthcheck}                     from '../../../scripts/diagnostics/mcpHealthcheck.mjs';
-import {writeFileAtomicSync}                from '../../../services/shared/atomicFileWrite.mjs';
+import {runHealthcheck}      from '../../../scripts/diagnostics/mcpHealthcheck.mjs';
+import {writeFileAtomicSync} from '../../../services/shared/atomicFileWrite.mjs';
 
 /**
  * The message `runHealthcheck` produces when the server ANSWERED and reported a status outside the
@@ -2543,6 +2543,11 @@ function summarizeTenantRepoState({
         // failure count would hide the backlog in precisely the state it was built to explain. It
         // carries no identity and no message — a count, a state, and two timestamps.
         corpusOutstanding                 : normalizedCheckpoint?.corpusOutstanding ?? null,
+        // Same unconditional rule, and for a stronger reason: a fence-only run COMPLETES (streak
+        // zero, checkpoint advanced), so this census is the ONLY snapshot evidence that N documents
+        // are deferred pending a geometry/ceiling change. Hashed chunk ids and a count — validated
+        // fail-closed by the checkpoint normalizer above.
+        undeliverableChunks               : normalizedCheckpoint?.undeliverableChunks ?? null,
         ingestContractVersion             : normalizedCheckpoint?.ingestContractVersion ?? null,
         lastAttemptedIngestContractVersion: normalizedCheckpoint?.lastAttemptedIngestContractVersion ?? null,
         effectiveCadenceMs                : dueState.effectiveCadenceMs,

--- a/ai/daemons/orchestrator/services/TenantRepoSyncService.mjs
+++ b/ai/daemons/orchestrator/services/TenantRepoSyncService.mjs
@@ -22,6 +22,7 @@ import {
     BOUNDED_KB_ERROR_CODE_PATTERN,
     EMBED_DISPOSITION,
     KB_VECTOR_EMBED_PROVIDER_CIRCUIT_OPEN,
+    KB_VECTOR_EMBED_UNDELIVERABLE_AT_GEOMETRY,
     classifyEmbedDisposition,
     isEmbedFailureCode
 }                                from '../../../services/knowledge-base/helpers/embedFailureClassification.mjs';
@@ -370,11 +371,26 @@ function classifyIngestionOutcome(summary) {
         );
 
         if (deferrable) {
-            return {
-                outcome      : 'deferred',
-                summary,
-                deferredCodes: [...new Set(summary.errors.map(item => item.code))]
+            // Deferral means "incomplete, come back": the checkpoint holds because a later run may
+            // finish the work. The undeliverable-at-geometry fence asserts the OPPOSITE — the chunk
+            // is durably excised until the geometry, ceiling, or content changes, so no amount of
+            // coming back changes anything. A run whose every error is that fence therefore
+            // COMPLETES: the checkpoint advances, sibling rotation proceeds, and the census below
+            // (not a held checkpoint) is what keeps the fenced chunks visible to the operator.
+            // One live deferrable failure beside the fences still defers the run as before.
+            const undeliverableOnly = summary.errors.every(item =>
+                item.code === KB_VECTOR_EMBED_UNDELIVERABLE_AT_GEOMETRY
+            );
+
+            if (!undeliverableOnly) {
+                return {
+                    outcome      : 'deferred',
+                    summary,
+                    deferredCodes: [...new Set(summary.errors.map(item => item.code))]
+                }
             }
+
+            return {outcome: 'complete', summary, deferredCodes: []}
         }
 
         const error = new Error('Knowledge Base ingestion returned an error-bearing summary.');
@@ -458,6 +474,51 @@ function buildCorpusOutstandingObservation({summary, priorState, observedAt}) {
         observedAt,
         previous   : priorState?.corpusOutstanding ?? null
     })
+}
+
+/**
+ * @summary Retention cap for the census id list persisted per repository checkpoint.
+ *
+ * The count always carries the true total; the id list is what an operator pastes into a replay or
+ * a parser ticket, and past this bound the poison-store marker (which retains up to 256 rows) is the
+ * right surface to enumerate from. Checkpoint rows project to a remote client, so they stay small.
+ * @type {Number}
+ */
+export const UNDELIVERABLE_CENSUS_MAX_IDS = 32;
+
+/**
+ * @summary Builds the AC-3 undeliverable census (`{count, ids}`) from one run's own ingestion summary.
+ *
+ * The census answers "how many documents is this plane's geometry deferring, and which" — the
+ * observable that replaces silence when a monster chunk is fenced instead of blocking the corpus.
+ * Derived from the summary's fence rows rather than re-reading the poison store: the run's summary
+ * is what the sync lane already trusts for every other scheduling decision, and a second reader
+ * could disagree with the writer that produced it.
+ *
+ * Ids are tenant-aware chunk hashes — bounded by construction — and re-validated here anyway; a row
+ * whose id fails the gate is COUNTED but not enumerated, so a malformed writer can inflate nothing
+ * into the projection. `null` means "no census observed" (no fence rows), never "zero measured".
+ *
+ * @param {Object} summary Ingestion summary returned by the run.
+ * @returns {{count: Number, ids: String[]}|null}
+ */
+function buildUndeliverableCensus(summary) {
+    const rows = (Array.isArray(summary?.errors) ? summary.errors : [])
+        .filter(item => item?.code === KB_VECTOR_EMBED_UNDELIVERABLE_AT_GEOMETRY);
+
+    if (rows.length === 0) {
+        return null;
+    }
+
+    const ids = [...new Set(
+        rows.map(item => item?.details?.chunkId)
+            .filter(id => typeof id === 'string' && /^[a-f0-9]{64}$/u.test(id))
+    )].sort();
+
+    return {
+        count: rows.length,
+        ids  : ids.slice(0, UNDELIVERABLE_CENSUS_MAX_IDS)
+    };
 }
 
 /**
@@ -2175,8 +2236,15 @@ class TenantRepoSyncService extends Base {
                     //
                     // Bounded `KB_*` codes only, never messages or details: identical credential
                     // boundary to the failure path, which is why these are safe to persist at all.
-                    const deferredCauseCode = ingestOutcome.deferredCodes.find(isEmbeddingRecoverySourceCode)
-                        ?? ingestOutcome.deferredCodes[0]
+                    // The undeliverable fence is excluded from cause selection: it is a durable
+                    // disposition, not a live failure, and letting it arm the embedding-recovery
+                    // canary would probe for a health change that cannot re-offer the chunk — only a
+                    // generation change can. A deferred outcome always carries at least one live
+                    // code beside any fences (fence-only runs classify as complete above).
+                    const liveDeferredCodes = ingestOutcome.deferredCodes
+                        .filter(code => code !== KB_VECTOR_EMBED_UNDELIVERABLE_AT_GEOMETRY);
+                    const deferredCauseCode = liveDeferredCodes.find(isEmbeddingRecoverySourceCode)
+                        ?? liveDeferredCodes[0]
                         ?? priorState?.lastSourceErrorCode
                         ?? null;
 
@@ -2192,6 +2260,15 @@ class TenantRepoSyncService extends Base {
                         observedAt: startedMs
                     });
 
+                    // A deferred run may have died BEFORE the fence rows are reported (a live
+                    // timeout throws out of `embed()` and the poison census never reaches the
+                    // summary), so an absent census here is "not observed this run", never "no
+                    // fences". Carrying the prior census forward keeps AC-3 visibility through the
+                    // deferral; the next completed or fence-bearing run replaces it authoritatively.
+                    const deferredCensus = buildUndeliverableCensus(rawSummary)
+                        ?? priorState?.undeliverableChunks
+                        ?? null;
+
                     persistedRevisions[repoLabel] = {
                         ...priorState,
                         lastIngestedRev                   : priorState?.lastIngestedRev ?? null,
@@ -2201,6 +2278,7 @@ class TenantRepoSyncService extends Base {
                         lastSourceErrorCode               : deferredCauseCode,
                         lastErrorAt                       : startedMs,
                         corpusOutstanding                 : deferredOutstanding,
+                        undeliverableChunks               : deferredCensus,
                         // Recovery eligibility, on the SAME episode a failure would advance. A
                         // consumed generation folds into `lastConsumedGenerationId/At` and a newly
                         // healthy canary generation is required before another bypass, so a
@@ -2240,7 +2318,8 @@ class TenantRepoSyncService extends Base {
                             probeSnapshot     : this.getEmbeddingRecoveryProbeSnapshot(),
                             observedAt        : startedMs
                         }),
-                        corpusOutstanding  : deferredOutstanding
+                        corpusOutstanding  : deferredOutstanding,
+                        undeliverableChunks: deferredCensus
                     });
 
                     healthService?.recordTaskOutcome?.(taskName, 'deferred', {
@@ -2261,6 +2340,12 @@ class TenantRepoSyncService extends Base {
                     priorState,
                     observedAt: startedMs
                 });
+
+                // The completed path carries the census too — this is the AC-3 surface's load-bearing
+                // half: a fence-only run COMPLETES (checkpoint advances, rotation proceeds), so the
+                // held-checkpoint signal is gone by design and the census is the only thing standing
+                // between the operator and "N documents silently missing".
+                const completedCensus = buildUndeliverableCensus(ingestResult);
 
                 const materializationReceipt = assertFullMaterializationEffect(
                     envelope,
@@ -2295,7 +2380,8 @@ class TenantRepoSyncService extends Base {
                     // corpus is distinguishable from one whose delta was never computed. Omitting it here
                     // would leave `corpusOutstanding` absent on exactly the state that proves the
                     // observable can reach zero, and an absent field reads as unknown.
-                    corpusOutstanding  : completedOutstanding
+                    corpusOutstanding  : completedOutstanding,
+                    undeliverableChunks: completedCensus
                 };
 
                 const durationMs = Date.now() - startedMs;
@@ -2313,7 +2399,8 @@ class TenantRepoSyncService extends Base {
                     status              : 'active',
                     checkpointStatus    : TenantRepoCheckpointStatus.COMPLETE,
                     lastSyncDeletedCount: deleted,
-                    corpusOutstanding   : completedOutstanding
+                    corpusOutstanding   : completedOutstanding,
+                    undeliverableChunks : completedCensus
                 });
                 completedCount++;
                 healthService?.recordTaskOutcome?.(taskName, 'completed', {

--- a/ai/daemons/orchestrator/services/tenantRepoCheckpointValidity.mjs
+++ b/ai/daemons/orchestrator/services/tenantRepoCheckpointValidity.mjs
@@ -110,7 +110,9 @@ export function normalizeTenantRepoCheckpointState(value) {
             embeddingRecovery  : null,
             // A bare SHA also predates the outstanding-work observable. Null means "never measured",
             // which is the honest reading — not a corpus with nothing left to do.
-            corpusOutstanding  : null
+            corpusOutstanding  : null,
+            // And the undeliverable census: null is "never observed", never "zero fenced".
+            undeliverableChunks: null
         };
     }
 
@@ -144,8 +146,44 @@ export function normalizeTenantRepoCheckpointState(value) {
         lastAccessCode     : normalizeBoundedErrorCode(value.lastAccessCode),
         lastErrorAt        : normalizeNonNegativeNumber(value.lastErrorAt) || null,
         embeddingRecovery  : normalizeEmbeddingRecovery(value.embeddingRecovery),
-        corpusOutstanding  : normalizeCorpusOutstanding(value.corpusOutstanding)
+        corpusOutstanding  : normalizeCorpusOutstanding(value.corpusOutstanding),
+        undeliverableChunks: normalizeUndeliverableChunks(value.undeliverableChunks)
     };
+}
+
+/**
+ * @summary Normalizes one persisted undeliverable census without manufacturing an observation.
+ *
+ * The census carries "N chunks are fenced as undeliverable at the current geometry, these are (up
+ * to a cap) their ids". Same reader discipline as `normalizeCorpusOutstanding`: a record that does
+ * not cohere degrades WHOLE to `null` (unobserved), never to a smaller census — repairing a torn
+ * row into a count would assert an observation nobody made. Ids are tenant-aware chunk hashes and
+ * pass the same bounded gate the writer applied; the id list may be shorter than the count (the
+ * writer caps enumeration) but never longer, and never contains a non-hash or a duplicate.
+ *
+ * @param {*} value Candidate persisted census.
+ * @returns {{count: Number, ids: String[]}|null}
+ */
+function normalizeUndeliverableChunks(value) {
+    if (!value || typeof value !== 'object' || Array.isArray(value)) {
+        return null;
+    }
+
+    const {count, ids} = value;
+
+    if (!Number.isInteger(count) || count <= 0)  return null;
+    if (!Array.isArray(ids) || ids.length > count) return null;
+
+    const seen = new Set();
+
+    for (const id of ids) {
+        if (typeof id !== 'string' || !/^[a-f0-9]{64}$/u.test(id) || seen.has(id)) {
+            return null;
+        }
+        seen.add(id);
+    }
+
+    return {count, ids: [...ids]};
 }
 
 /**

--- a/ai/mcp/server/knowledge-base/configBase.mjs
+++ b/ai/mcp/server/knowledge-base/configBase.mjs
@@ -710,6 +710,24 @@ class ConfigBase extends ConfigProvider {
              */
             maxRetries: leaf(5, 'NEO_KB_EMBEDDING_MAX_RETRIES', 'positiveInt'),
             /**
+             * Consecutive call-ceiling expiries at one batch head before the chunk graduates to a
+             * durable undeliverable-at-geometry disposition and stops being offered to the provider.
+             *
+             * A timeout is lane evidence, not content evidence — but a chunk whose call ceiling fires
+             * on every attempt is deterministically undeliverable at the current geometry, and each
+             * further offer costs a full ceiling of head-of-line blocking for every chunk and
+             * repository behind it. Two strikes separate a transient stall (queue depth, cold cache,
+             * memory pressure) from an intrinsic cost that exceeds the ceiling.
+             *
+             * Strike memory is process-local: a daemon restart re-offers the chunk and it pays its
+             * strikes again — bounded extra cost, never a correctness loss. The graduated disposition
+             * itself is durable (poison store) and invalidates when the embedding generation —
+             * provider, model, dimension, or effective call ceiling — changes, so raising the ceiling
+             * automatically re-offers previously undeliverable chunks.
+             * @type {number}
+             */
+            undeliverableTimeoutStrikes: leaf(2, 'NEO_KB_EMBEDDING_UNDELIVERABLE_TIMEOUT_STRIKES', 'positiveInt'),
+            /**
              * The number of results to fetch from ChromaDB for a query.
              * @type {number}
              */

--- a/ai/scripts/lint/config-leaf-parity.json
+++ b/ai/scripts/lint/config-leaf-parity.json
@@ -605,6 +605,7 @@
         "sourcePaths",
         "spoofRejectionMode",
         "transport",
+        "undeliverableTimeoutStrikes",
         "useDefaultParsers",
         "useDefaultSources"
     ],

--- a/ai/scripts/lint/retry-bound-registry.json
+++ b/ai/scripts/lint/retry-bound-registry.json
@@ -206,7 +206,7 @@
             "witness": "`retry.maxTotalDelayMs - totalDelayMs` remaining-budget clamp in #getCollectionResolveRetryDelay",
             "note": "The only max-window instance: bounded by TOTAL delay spent, not by a per-delay cap alone (it also carries maxDelayMs)."
         },
-        "ai/services/knowledge-base/VectorService.mjs#strikes:2603053b": {
+        "ai/services/knowledge-base/VectorService.mjs#persistCarriedPrefix:2603053b": {
             "kind": "retry-growth",
             "lifetime": "in-cycle",
             "boundCarrier": "max-attempts",

--- a/ai/scripts/lint/retry-bound-registry.json
+++ b/ai/scripts/lint/retry-bound-registry.json
@@ -206,7 +206,7 @@
             "witness": "`retry.maxTotalDelayMs - totalDelayMs` remaining-budget clamp in #getCollectionResolveRetryDelay",
             "note": "The only max-window instance: bounded by TOTAL delay spent, not by a per-delay cap alone (it also carries maxDelayMs)."
         },
-        "ai/services/knowledge-base/VectorService.mjs#persistCarriedPrefix:2603053b": {
+        "ai/services/knowledge-base/VectorService.mjs#strikes:2603053b": {
             "kind": "retry-growth",
             "lifetime": "in-cycle",
             "boundCarrier": "max-attempts",

--- a/ai/services/knowledge-base/IngestionService.mjs
+++ b/ai/services/knowledge-base/IngestionService.mjs
@@ -18,6 +18,7 @@ import {isChromaConnectionError}
                             from '../shared/vector/chromaClientPrimitives.mjs';
 import {
     KB_VECTOR_EMBED_UNCLASSIFIED,
+    KB_VECTOR_EMBED_UNDELIVERABLE_AT_GEOMETRY,
     classifyEmbedFailureCode,
     classifyEmbedFailureError,
     classifyEmbedResidencyDisposition,
@@ -70,9 +71,36 @@ export function resolveIdleProgressStatus(lastRunSummary) {
     return 'idle';
 }
 
-const LOCAL_EMBEDDING_PROVIDERS           = new Set(['openAiCompatible', 'ollama']);
-const MATERIALIZATION_ATTEMPT_ID_PATTERN  = /^[a-f0-9]{32}$/u;
-const MATERIALIZATION_DIGEST_PATTERN      = /^[a-f0-9]{64}$/u;
+const LOCAL_EMBEDDING_PROVIDERS          = new Set(['openAiCompatible', 'ollama']);
+const MATERIALIZATION_ATTEMPT_ID_PATTERN = /^[a-f0-9]{32}$/u;
+const MATERIALIZATION_DIGEST_PATTERN     = /^[a-f0-9]{64}$/u;
+const TENANT_AWARE_CHUNK_ID_PATTERN      = /^[a-f0-9]{64}$/u;
+
+/**
+ * @summary Re-validates a graduation receipt carried on an embed failure into exactly four bounded fields.
+ *
+ * The receipt is minted by `VectorService` at the graduation site, but it arrives here on a
+ * provider-adjacent error object, so it is FIELD-PICKED and type-gated rather than trusted: a hash
+ * and three finite non-negative numbers, or nothing. Any malformed branch degrades the whole receipt
+ * by omission — a partial receipt would read as a measured one.
+ *
+ * @param {*} candidate Candidate `error.undeliverableGraduation` value.
+ * @returns {{chunkId: String, tokenEstimate: Number, attempts: Number, effectiveCeilingMs: Number}|null}
+ */
+function normalizeUndeliverableGraduation(candidate) {
+    if (!candidate || typeof candidate !== 'object' || Array.isArray(candidate)) {
+        return null;
+    }
+
+    const {chunkId, tokenEstimate, attempts, effectiveCeilingMs} = candidate;
+
+    if (typeof chunkId !== 'string' || !TENANT_AWARE_CHUNK_ID_PATTERN.test(chunkId)) return null;
+    if (!Number.isFinite(tokenEstimate)      || tokenEstimate < 0)                   return null;
+    if (!Number.isInteger(attempts)          || attempts <= 0)                       return null;
+    if (!Number.isFinite(effectiveCeilingMs) || effectiveCeilingMs <= 0)             return null;
+
+    return {chunkId, tokenEstimate, attempts, effectiveCeilingMs};
+}
 const PARSED_CHUNK_SCHEMA_PATH            = path.join(__dirname, 'parser/parsed-chunk-v1.schema.json');
 const KB_CONFIG_BOOTSTRAP_FAILURE_DETAILS = Object.freeze({
     'read-failed': {
@@ -460,15 +488,22 @@ class IngestionService extends Base {
                     const reasonCode = isEmbedFailureCode(poison.reasonCode)
                         ? poison.reasonCode
                         : KB_VECTOR_EMBED_UNCLASSIFIED;
+                    // Two fence families share the store but assert DIFFERENT things: a content
+                    // poison is proven bad content, an undeliverable-at-geometry chunk is healthy
+                    // content the current geometry cannot deliver. Labeling the second as the first
+                    // tells an operator to fix a file whose only fault is the plane's ceiling.
+                    const undeliverable = reasonCode === KB_VECTOR_EMBED_UNDELIVERABLE_AT_GEOMETRY;
 
                     summary.errors.push(this.createError({
                         code   : reasonCode,
-                        message: 'A proven embedding poison remains fenced pending changed content, generation, or explicit replay.',
+                        message: undeliverable
+                            ? 'A chunk remains fenced as undeliverable at the current embedding geometry, pending a ceiling/geometry change, changed content, or explicit replay.'
+                            : 'A proven embedding poison remains fenced pending changed content, generation, or explicit replay.',
                         details: {
                             chunkId    : poison.chunkId,
                             reasonCode,
                             observedAt : poison.observedAt,
-                            disposition: 'proven-content-poison'
+                            disposition: undeliverable ? 'undeliverable-at-geometry' : 'proven-content-poison'
                         }
                     }));
                 }
@@ -480,6 +515,12 @@ class IngestionService extends Base {
                 });
             } catch (error) {
                 const residencyDisposition = classifyEmbedResidencyDisposition(error);
+                // The graduation receipt travels ON the original timeout rather than replacing it:
+                // the code below still names the timeout, and this bounded evidence — a hash and
+                // three numbers, re-validated here rather than trusted — says what that timeout just
+                // proved. Field-picked, never spread: the error is provider-adjacent, and copying an
+                // object it carries wholesale would let provider-shaped text ride into the summary.
+                const graduation = normalizeUndeliverableGraduation(error?.undeliverableGraduation);
 
                 summary.errors.push(this.createError({
                     // The throw path carries the provider's code most often — a consumer-deadline
@@ -495,7 +536,8 @@ class IngestionService extends Base {
                     // that reads like a measured one.
                     details: {
                         repoSlug,
-                        ...(residencyDisposition && {residencyDisposition})
+                        ...(residencyDisposition && {residencyDisposition}),
+                        ...(graduation && {undeliverableGraduation: graduation})
                     }
                 }));
                 this.updateIngestionProgress({

--- a/ai/services/knowledge-base/VectorService.mjs
+++ b/ai/services/knowledge-base/VectorService.mjs
@@ -35,9 +35,23 @@ import {
 }                                                                     from './helpers/kbEmbeddingPoisonStore.mjs';
 import {
     KB_VECTOR_EMBED_PROVIDER_CIRCUIT_OPEN,
+    KB_VECTOR_EMBED_UNDELIVERABLE_AT_GEOMETRY,
     classifyEmbedFailureError,
     classifyEmbedResidencyDisposition
 }                                                                     from './helpers/embedFailureClassification.mjs';
+
+/**
+ * Consecutive call-ceiling expiries per batch-head chunk, keyed by chunk id.
+ *
+ * Process-local ON PURPOSE: a strike is cheap, transient evidence — the durable artifact is the
+ * graduated poison-store disposition, which carries its own generation-keyed invalidation. A daemon
+ * restart therefore re-offers a striking chunk and it pays its strikes again: bounded extra cost,
+ * never a correctness loss, and no second persistence mechanism to keep coherent with the store.
+ * Entries are cleared on any successful persist of the chunk so a recovered lane cannot inherit
+ * stale strikes.
+ * @type {Map<String, Number>}
+ */
+const undeliverableStrikeCounts = new Map();
 
 /**
  * @summary Flattens one chunk into Chroma-storable scalar metadata.
@@ -390,6 +404,14 @@ class VectorService extends Base {
             provider,
             model          : getEmbeddingModel(provider),
             vectorDimension: Number(aiConfig.vectorDimension),
+            // The effective per-call ceiling is part of the evidence conditions: an
+            // undeliverable-at-geometry disposition proven under a 30-minute ceiling is void under a
+            // 60-minute one. Folding it into the generation invalidates ALL suppression evidence on a
+            // ceiling change — including content-poison, which then costs one isolation re-proof
+            // cycle. Correctness over thrift: stale suppression silently withholds documents.
+            embedCallCeilingMs: provider === 'ollama'
+                ? Number(mcConfig.ollama.embeddingTimeoutMs)
+                : Number(mcConfig.openAiCompatible.batchEmbeddingTimeoutMs),
             strategyVersion: EMBEDDING_POISON_STRATEGY_VERSION
         }
     }
@@ -1014,15 +1036,15 @@ class VectorService extends Base {
         logger.log(`Using TextEmbeddingService with provider: ${mcConfig.embeddingProvider}.`);
         logger.log('Embedding chunks...');
 
-        const {batchSize, batchDelay, maxRetries} = aiConfig;
-        const guardrail                           = this.resolveEmbeddingGuardrail();
-        const failedBatches                       = [];
-        const poisonedChunks                      = knownPoisonEntries.map(entry => ({...entry}));
-        const poisonIds                           = new Set(poisonedChunks.map(entry => entry.chunkId));
-        const preEmbeddedIds                      = new Set();
-        let   embeddedCount                       = 0;
-        let   skippedCount                        = 0;
-        let   yielded                             = false;
+        const {batchSize, batchDelay, maxRetries, undeliverableTimeoutStrikes} = aiConfig;
+        const guardrail                                                        = this.resolveEmbeddingGuardrail();
+        const failedBatches                                                    = [];
+        const poisonedChunks                                                   = knownPoisonEntries.map(entry => ({...entry}));
+        const poisonIds                                                        = new Set(poisonedChunks.map(entry => entry.chunkId));
+        const preEmbeddedIds                                                   = new Set();
+        let   embeddedCount                                                    = 0;
+        let   skippedCount                                                     = 0;
+        let   yielded                                                          = false;
 
         for (let i = 0; i < chunksToProcess.length; i += batchSize) {
             // Cooperative heavy-maintenance-lease yield-point: BETWEEN batches (never before the
@@ -1130,6 +1152,7 @@ class VectorService extends Base {
                 }
 
                 embeddedCount += partialChunks.length;
+                partialChunks.forEach(chunk => undeliverableStrikeCounts.delete(chunk.id));
 
                 return partialChunks.length
             };
@@ -1155,6 +1178,9 @@ class VectorService extends Base {
                     });
 
                     embeddedCount += batchToEmbed.length;
+                    // A persisted chunk clears its strike memory: strikes are evidence about a chunk
+                    // the lane could NOT deliver, and delivery is the falsifier.
+                    batchToEmbed.forEach(chunk => undeliverableStrikeCounts.delete(chunk.id));
                     logger.log(`Processed and embedded batch ${i / batchSize + 1} of ${Math.ceil(chunksToProcess.length / batchSize)} (${batchToEmbed.length} embedded, ${guardrailSkipped} skipped).`);
                     success = true;
                 } catch (err) {
@@ -1214,6 +1240,35 @@ class VectorService extends Base {
                         providerTimedOut    = embeddings === null && isProviderTimeoutCode(err?.code);
 
                     if (providerCircuitOpen || providerTimedOut) {
+                        // Deterministic-undeliverable classification. One timeout is lane evidence; the
+                        // SAME head chunk expiring its call ceiling on consecutive attempts is an intrinsic
+                        // cost above the ceiling — every further offer buys a full ceiling of head-of-line
+                        // blocking for each chunk and repository queued behind it. On the strike limit the
+                        // chunk graduates to a durable poison-store disposition (generation-keyed, so a
+                        // raised ceiling or changed geometry re-offers it automatically) and is never
+                        // dispatched again. The graduating sweep STILL ends below: the provider is grinding
+                        // the just-abandoned attempt headless, and dispatching the remainder now would queue
+                        // fresh work behind it — the exact hazard the end-sweep rule exists to prevent. The
+                        // NEXT sweep proceeds past the excised chunk on an idle engine.
+                        if (providerTimedOut && batchToEmbed.length > 0) {
+                            const headChunk = batchToEmbed[0];
+                            const strikes   = (undeliverableStrikeCounts.get(headChunk.id) ?? 0) + 1;
+
+                            undeliverableStrikeCounts.set(headChunk.id, strikes);
+
+                            if (strikes >= undeliverableTimeoutStrikes && typeof onPoisonEntries === 'function') {
+                                try {
+                                    await onPoisonEntries([{chunkId: headChunk.id, reasonCode: KB_VECTOR_EMBED_UNDELIVERABLE_AT_GEOMETRY}]);
+                                    undeliverableStrikeCounts.delete(headChunk.id);
+                                    logger.warn(`[VectorService] Chunk ${headChunk.id} graduated to undeliverable-at-geometry after ${strikes} consecutive call-ceiling expiries; it stops being offered until the embedding generation (provider, model, dimension, call ceiling) changes.`);
+                                } catch (persistError) {
+                                    // Fail-open: a disposition that cannot persist must not suppress provider
+                                    // work — the chunk stays offered and the strikes stay counted.
+                                    logger.warn(`[VectorService] Could not persist the undeliverable disposition for chunk ${headChunk.id} (${persistError.message}); the chunk remains offered.`);
+                                }
+                            }
+                        }
+
                         const disposition = providerCircuitOpen
                             ? 'the run-scoped provider circuit opened before this repository dispatched'
                             : 'one timeout-class provider attempt ended';

--- a/ai/services/knowledge-base/VectorService.mjs
+++ b/ai/services/knowledge-base/VectorService.mjs
@@ -41,17 +41,92 @@ import {
 }                                                                     from './helpers/embedFailureClassification.mjs';
 
 /**
- * Consecutive call-ceiling expiries per batch-head chunk, keyed by chunk id.
+ * Transient undeliverable-at-geometry evidence: consecutive single-input call-ceiling expiries per
+ * chunk, plus the isolation-suspect set a multi-input request timeout leaves behind.
  *
  * Process-local ON PURPOSE: a strike is cheap, transient evidence — the durable artifact is the
  * graduated poison-store disposition, which carries its own generation-keyed invalidation. A daemon
  * restart therefore re-offers a striking chunk and it pays its strikes again: bounded extra cost,
  * never a correctness loss, and no second persistence mechanism to keep coherent with the store.
- * Entries are cleared on any successful persist of the chunk so a recovered lane cannot inherit
- * stale strikes.
- * @type {Map<String, Number>}
+ *
+ * The whole object is scoped to ONE embedding generation and replaced when the generation changes:
+ * strikes proven under a 30-minute ceiling are not evidence under a 60-minute one, in either
+ * direction, so a generation change resets every count and every suspicion. Within the generation:
+ *
+ * - `strikes` counts CONSECUTIVE timeout outcomes for requests that held EXACTLY that one chunk —
+ *   the only attribution that is exact. Any dispatched non-timeout provider outcome for the chunk
+ *   (success, non-timeout failure, or success followed by a storage failure — the provider half
+ *   still succeeded) deletes its entry.
+ * - `suspects` holds the member set of a timed-out MULTI-input request. Suspicion never graduates
+ *   anything; it only forces the isolation dispatch below, where each suspect earns exact
+ *   single-input evidence — an innocent neighbour embeds and clears, a monster strikes honestly.
+ * - `seq`/`lastStrikeSeq` is the overlap guard: a strike increments only when its request was
+ *   DISPATCHED after the previous strike was recorded, so two overlapping attempts observing one
+ *   wall-clock failure window cannot combine into a "consecutive" threshold.
+ *
+ * @type {{generationId: String|null, strikes: Map<String, {count: Number, lastStrikeSeq: Number}>, suspects: Set<String>, seq: Number}}
  */
-const undeliverableStrikeCounts = new Map();
+const undeliverableEvidence = {
+    generationId: null,
+    strikes     : new Map(),
+    suspects    : new Set(),
+    seq         : 0
+};
+
+/**
+ * @summary Returns the transient evidence state for one embedding generation, resetting on change.
+ * @param {String} generationId Hashed embedding-generation coordinates.
+ * @returns {Object} The module-level `undeliverableEvidence` state, scoped to `generationId`.
+ */
+function resolveUndeliverableEvidence(generationId) {
+    if (undeliverableEvidence.generationId !== generationId) {
+        undeliverableEvidence.generationId = generationId;
+        undeliverableEvidence.strikes.clear();
+        undeliverableEvidence.suspects.clear();
+        undeliverableEvidence.seq = 0;
+    }
+
+    return undeliverableEvidence
+}
+
+/**
+ * @summary Resolves which dispatched chunks were inside the provider request that failed.
+ *
+ * A logical KB chunk and a provider request are DIFFERENT attribution units whenever the transport
+ * batches more than one text per request: a request failure names the request, never a member. Two
+ * sources of exactness exist, in precedence order:
+ *
+ * 1. A single-chunk dispatch (`batchToEmbed.length === 1`) — the request can only have held that
+ *    input, whatever the transport (this is also the only exactness the native-ollama batch, which
+ *    posts one opaque multi-input request, can ever offer).
+ * 2. The producer span (`failedTextOffset`/`failedTextCount`) the OpenAI-compatible transport stamps
+ *    on every request failure — attempt-scoped indices into what was sent, translated here into the
+ *    post-carry-shrink coordinates of `batchToEmbed`.
+ *
+ * An empty result means the member set is UNKNOWN, and the caller must treat the whole dispatch as
+ * the unit — suspicion at worst, never a strike.
+ *
+ * @param {Object} options
+ * @param {*} options.error The provider failure, possibly producer-decorated.
+ * @param {Object[]} options.batchToEmbed The dispatched chunks, after any carry shrink.
+ * @param {Number} [options.persistedCount=0] How many leading chunks the carry shrink removed.
+ * @returns {Object[]} The failed request's member chunks, or `[]` when unknown.
+ */
+function resolveFailedRequestChunks({error, batchToEmbed, persistedCount = 0}) {
+    if (batchToEmbed.length === 1) {
+        return [batchToEmbed[0]]
+    }
+
+    if (Number.isInteger(error?.failedTextOffset) && Number.isInteger(error?.failedTextCount) && error.failedTextCount > 0) {
+        const start = error.failedTextOffset - persistedCount;
+
+        if (start >= 0 && start + error.failedTextCount <= batchToEmbed.length) {
+            return batchToEmbed.slice(start, start + error.failedTextCount)
+        }
+    }
+
+    return []
+}
 
 /**
  * @summary Flattens one chunk into Chroma-storable scalar metadata.
@@ -997,6 +1072,10 @@ class VectorService extends Base {
      * @param {Object[]} [options.knownPoisonEntries] Validated current-generation poison rows.
      * @param {Object[]} [options.controlCandidates] Full current corpus with landed-state evidence.
      * @param {Function} [options.onPoisonEntries] Durable writer for newly proven poison rows.
+     * @param {String} [options.poisonGenerationId] Hashed embedding-generation coordinates for the
+     *     transient undeliverable automaton. Callers that resolved the poison coordinates pass it
+     *     through so one sweep's strikes, suspicions, and durable dispositions share one generation;
+     *     absent, it is resolved once at entry from the same leaves.
      * @param {Function} [options.now] Clock seam for bounded poison receipts.
      * @returns {Promise<{embedded: Number, skipped: Number, yielded: Boolean, failedBatches: Object[], poisonedChunks: Object[]}>}
      *     `failedBatches` carries `{batchIndex, chunkIds, reason}` for every batch that exhausted its retries
@@ -1017,6 +1096,7 @@ class VectorService extends Base {
         knownPoisonEntries = [],
         controlCandidates = chunksToProcess.map(chunk => ({chunk, alreadyLanded: false})),
         onPoisonEntries,
+        poisonGenerationId,
         now = Date.now
     }) {
         if (chunksToProcess.length === 0) {
@@ -1046,27 +1126,47 @@ class VectorService extends Base {
         let   skippedCount                                                     = 0;
         let   yielded                                                          = false;
 
-        for (let i = 0; i < chunksToProcess.length; i += batchSize) {
+        // The undeliverable automaton's coordinates, resolved ONCE per sweep. Transient strike and
+        // suspicion evidence must live under the same generation as the durable disposition it can
+        // mint — a strike gathered under one ceiling is not "consecutive" with one gathered under
+        // another. Callers that already resolved the poison coordinates pass the generation through
+        // so one sweep cannot straddle two resolutions.
+        const generation           = this.resolveEmbeddingPoisonGeneration();
+        const evidenceGenerationId = poisonGenerationId ?? createEmbeddingGenerationId(generation);
+        const evidence             = resolveUndeliverableEvidence(evidenceGenerationId);
+
+        // A cursor rather than a fixed stride: the isolation dispatch below may consume a single
+        // chunk from the front of a stride, and the remainder must be re-offered THIS sweep instead
+        // of silently skipping to the next stride boundary.
+        let cursor = 0;
+
+        while (cursor < chunksToProcess.length) {
             // Cooperative heavy-maintenance-lease yield-point: BETWEEN batches (never before the
             // first — so at least one batch lands per lease acquisition: a forward-progress guarantee, never a
             // livelock), if the lease holder has exceeded the fairness bound, stop embedding so a starved heavy
             // task (e.g. githubWorkflowSync) can interleave. The completed batches are already durably upserted
             // into the shadow and indexed by the write-ahead resume marker, so the next sweep resumes here
             // (decideResume -> selectResumableChunks). The caller releases the lease on the `yielded` signal.
-            if (i > 0 && shouldYield()) {
+            if (cursor > 0 && shouldYield()) {
                 yielded = true;
-                logger.log(`Yielding the heavy-maintenance lease after ${i} chunk(s) (${embeddedCount} embedded); ${chunksToProcess.length - i} remaining will resume on the next sweep.`);
+                logger.log(`Yielding the heavy-maintenance lease after ${cursor} chunk(s) (${embeddedCount} embedded); ${chunksToProcess.length - cursor} remaining will resume on the next sweep.`);
                 break;
             }
 
-            if (i > 0 && batchDelay) {
+            if (cursor > 0 && batchDelay) {
                 await this.timeout(batchDelay);
             }
 
-            const batch = chunksToProcess.slice(i, i + batchSize)
+            const stride        = chunksToProcess.slice(cursor, cursor + batchSize);
+            const batchNumber   = Math.floor(cursor / batchSize) + 1;
+            let   cursorAdvance = stride.length;
+            const batch         = stride
                 .filter(chunk => !poisonIds.has(chunk.id) && !preEmbeddedIds.has(chunk.id));
 
-            if (batch.length === 0) continue;
+            if (batch.length === 0) {
+                cursor += cursorAdvance;
+                continue;
+            }
 
             const batchInputs = batch.map(chunk => ({
                 chunk,
@@ -1089,7 +1189,8 @@ class VectorService extends Base {
             }
 
             if (embeddable.length === 0) {
-                logger.warn(`[VectorService] Skipped embedding batch ${i / batchSize + 1}; all ${batch.length} chunk(s) exceeded the embedding safe-processing band.`);
+                logger.warn(`[VectorService] Skipped embedding batch ${batchNumber}; all ${batch.length} chunk(s) exceeded the embedding safe-processing band.`);
+                cursor += cursorAdvance;
                 continue;
             }
 
@@ -1098,9 +1199,23 @@ class VectorService extends Base {
             let batchToEmbed = embeddable.map(input => input.chunk);
             let textsToEmbed = embeddable.map(input => input.text);
 
-            // Captured before any failure-carry shrink: after a shrink, deriving this from
-            // `batchToEmbed.length` would report persisted work as "skipped" in the success log.
-            const guardrailSkipped = batch.length - batchToEmbed.length;
+            // Captured from the guardrail evaluation, before the isolation truncation and any
+            // failure-carry shrink: after either, deriving this from `batchToEmbed.length` would
+            // report un-dispatched or persisted work as "skipped" in the success log.
+            const guardrailSkipped = batch.length - embeddable.length;
+
+            // Isolation dispatch: a chunk suspected from a timed-out MULTI-input request is offered
+            // ALONE, because a single-input request is the only shape whose timeout names its cause
+            // exactly. An innocent neighbour embeds here and clears its suspicion; a monster earns an
+            // exact strike. The cursor advances only past the isolated chunk, so the rest of the
+            // stride is re-offered in this same sweep rather than skipped to the next one.
+            if (batchToEmbed.length > 1 && evidence.suspects.has(batchToEmbed[0].id)) {
+                cursorAdvance = stride.indexOf(batchToEmbed[0]) + 1;
+                batchToEmbed  = batchToEmbed.slice(0, 1);
+                textsToEmbed  = textsToEmbed.slice(0, 1);
+
+                logger.log(`[VectorService] Isolation dispatch for suspect chunk ${batchToEmbed[0].id}: offering it as a single-input request to attribute the earlier multi-input timeout exactly.`);
+            }
 
             let retries   = 0;
             let success   = false;
@@ -1127,7 +1242,7 @@ class VectorService extends Base {
             // un-persisted prefix is re-selected by a later sweep.
             const persistCarriedPrefix = async (carried, expected, arm) => {
                 if (carried.length !== expected) {
-                    throw new Error(`${arm} batch ${i / batchSize + 1} carried ${carried.length} embedding(s) for ${expected} completed input(s); refusing to bind vectors to chunk ids by position.`);
+                    throw new Error(`${arm} batch ${batchNumber} carried ${carried.length} embedding(s) for ${expected} completed input(s); refusing to bind vectors to chunk ids by position.`);
                 }
 
                 if (carried.length === 0) return 0;
@@ -1146,18 +1261,23 @@ class VectorService extends Base {
                         lastError = writeError;
                         retries++;
                         if (retries >= maxRetries) throw writeError;
-                        console.error(`Persisting the carried prefix of ${arm.toLowerCase()} batch ${i / batchSize + 1} failed. Retrying the write (${retries}/${maxRetries})...`, writeError.message);
+                        console.error(`Persisting the carried prefix of ${arm.toLowerCase()} batch ${batchNumber} failed. Retrying the write (${retries}/${maxRetries})...`, writeError.message);
                         await new Promise(res => setTimeout(res, 2 ** retries * 1000));
                     }
                 }
 
                 embeddedCount += partialChunks.length;
-                partialChunks.forEach(chunk => undeliverableStrikeCounts.delete(chunk.id));
 
                 return partialChunks.length
             };
 
             while (retries < maxRetries && !success) {
+                // The overlap guard's dispatch stamp. A strike recorded AFTER this attempt was
+                // dispatched (by an overlapping attempt on the same chunk) is not sequential evidence
+                // relative to this one — both observed the same wall-clock failure window — so the
+                // strike site below refuses to increment past it.
+                const dispatchSeq = evidence.seq;
+
                 try {
                     embeddings ??= await TextEmbeddingService.embedTexts(textsToEmbed, mcConfig.embeddingProvider, {
                         operationLabel          : 'knowledge base tenant ingestion embedding',
@@ -1169,6 +1289,15 @@ class VectorService extends Base {
                         onProviderTimeout
                     });
 
+                    // A dispatched non-timeout provider outcome resets the automaton for every input
+                    // it covered — BEFORE the upsert, deliberately: a provider success followed by a
+                    // storage failure is still a non-timeout outcome for the chunk, so the
+                    // consecutive-timeout chain breaks here regardless of what the write does next.
+                    batchToEmbed.forEach(chunk => {
+                        evidence.strikes.delete(chunk.id);
+                        evidence.suspects.delete(chunk.id);
+                    });
+
                     const metadatas = batchToEmbed.map(buildChunkMetadata);
 
                     await collection.upsert({
@@ -1178,10 +1307,7 @@ class VectorService extends Base {
                     });
 
                     embeddedCount += batchToEmbed.length;
-                    // A persisted chunk clears its strike memory: strikes are evidence about a chunk
-                    // the lane could NOT deliver, and delivery is the falsifier.
-                    batchToEmbed.forEach(chunk => undeliverableStrikeCounts.delete(chunk.id));
-                    logger.log(`Processed and embedded batch ${i / batchSize + 1} of ${Math.ceil(chunksToProcess.length / batchSize)} (${batchToEmbed.length} embedded, ${guardrailSkipped} skipped).`);
+                    logger.log(`Processed and embedded batch ${batchNumber} of ${Math.ceil(chunksToProcess.length / batchSize)} (${batchToEmbed.length} embedded, ${guardrailSkipped} skipped).`);
                     success = true;
                 } catch (err) {
                     // A cooperative yield is a DECISION, not a failure. Falling through to the retry arm would
@@ -1198,9 +1324,17 @@ class VectorService extends Base {
                         // guard + budgeted write retry) applies here exactly as on the failure arm.
                         const carried = err.embeddings || [];
 
+                        // The carried prefix is a dispatched provider SUCCESS for those inputs, so
+                        // their automaton entries reset here on the same provider-outcome rule as the
+                        // ordinary success path.
+                        batchToEmbed.slice(0, err.completedTextCount || 0).forEach(chunk => {
+                            evidence.strikes.delete(chunk.id);
+                            evidence.suspects.delete(chunk.id);
+                        });
+
                         await persistCarriedPrefix(carried, err.completedTextCount, 'Yielded');
 
-                        logger.log(`Yielding the heavy-maintenance lease inside batch ${i / batchSize + 1} after ${err.completedChunkCount}/${err.totalChunkCount} provider chunk(s); ${carried.length} partial embedding(s) persisted (${embeddedCount} embedded total). This batch is not retried; the next sweep resumes after the persisted prefix.`);
+                        logger.log(`Yielding the heavy-maintenance lease inside batch ${batchNumber} after ${err.completedChunkCount}/${err.totalChunkCount} provider chunk(s); ${carried.length} partial embedding(s) persisted (${embeddedCount} embedded total). This batch is not retried; the next sweep resumes after the persisted prefix.`);
                         break;
                     }
 
@@ -1214,14 +1348,24 @@ class VectorService extends Base {
                     // to the un-persisted remainder so a retry buys only what is actually missing. Same
                     // refuse-loudly guard as the yield arm: a payload disagreeing with its stated count
                     // would bind vectors to wrong ids if sliced positionally.
+                    let carryShrunkCount = 0;
+
                     if (embeddings === null && Number.isInteger(err?.completedTextCount) && err.completedTextCount > 0) {
+                        // Same provider-outcome reset as the yield arm: the completed prefix is a
+                        // dispatched provider success for those inputs, whatever the write does next.
+                        batchToEmbed.slice(0, err.completedTextCount).forEach(chunk => {
+                            evidence.strikes.delete(chunk.id);
+                            evidence.suspects.delete(chunk.id);
+                        });
+
                         const persistedCount = await persistCarriedPrefix(err.embeddings || [], err.completedTextCount, 'Failed');
 
                         if (persistedCount > 0) {
-                            batchToEmbed = batchToEmbed.slice(persistedCount);
-                            textsToEmbed = textsToEmbed.slice(persistedCount);
+                            batchToEmbed     = batchToEmbed.slice(persistedCount);
+                            textsToEmbed     = textsToEmbed.slice(persistedCount);
+                            carryShrunkCount = persistedCount;
 
-                            logger.log(`Persisted ${persistedCount} carried embedding(s) from failed batch ${i / batchSize + 1} (${err.completedChunkCount}/${err.totalChunkCount} provider chunk(s) completed before the failure); ${batchToEmbed.length} chunk(s) remain for the retry or a later sweep.`);
+                            logger.log(`Persisted ${persistedCount} carried embedding(s) from failed batch ${batchNumber} (${err.completedChunkCount}/${err.totalChunkCount} provider chunk(s) completed before the failure); ${batchToEmbed.length} chunk(s) remain for the retry or a later sweep.`);
                         }
                     }
 
@@ -1240,32 +1384,86 @@ class VectorService extends Base {
                         providerTimedOut    = embeddings === null && isProviderTimeoutCode(err?.code);
 
                     if (providerCircuitOpen || providerTimedOut) {
-                        // Deterministic-undeliverable classification. One timeout is lane evidence; the
-                        // SAME head chunk expiring its call ceiling on consecutive attempts is an intrinsic
-                        // cost above the ceiling — every further offer buys a full ceiling of head-of-line
-                        // blocking for each chunk and repository queued behind it. On the strike limit the
-                        // chunk graduates to a durable poison-store disposition (generation-keyed, so a
+                        // Deterministic-undeliverable classification, on EXACT attribution only. One
+                        // timeout is lane evidence; the SAME chunk expiring its call ceiling on
+                        // consecutive single-input attempts is an intrinsic cost above the ceiling —
+                        // every further offer buys a full ceiling of head-of-line blocking for each
+                        // chunk and repository queued behind it. On the strike limit the chunk
+                        // graduates to a durable poison-store disposition (generation-keyed, so a
                         // raised ceiling or changed geometry re-offers it automatically) and is never
-                        // dispatched again. The graduating sweep STILL ends below: the provider is grinding
-                        // the just-abandoned attempt headless, and dispatching the remainder now would queue
-                        // fresh work behind it — the exact hazard the end-sweep rule exists to prevent. The
-                        // NEXT sweep proceeds past the excised chunk on an idle engine.
+                        // dispatched again.
+                        //
+                        // A timeout from a MULTI-input request names the request, not a member: the
+                        // provider abandoned the POST as a unit, and blaming its first member would
+                        // let an innocent neighbour inherit a monster's strikes and be durably fenced.
+                        // Multi-input evidence therefore only marks the request's members as
+                        // isolation SUSPECTS — the dispatch site above offers a suspect alone, where
+                        // the next timeout is exact. A circuit-open never dispatched, so it neither
+                        // strikes nor resets.
+                        //
+                        // The graduating sweep STILL ends below: the provider is grinding the
+                        // just-abandoned attempt headless, and dispatching the remainder now would
+                        // queue fresh work behind it — the exact hazard the end-sweep rule exists to
+                        // prevent. The NEXT sweep proceeds past the excised chunk on an idle engine.
                         if (providerTimedOut && batchToEmbed.length > 0) {
-                            const headChunk = batchToEmbed[0];
-                            const strikes   = (undeliverableStrikeCounts.get(headChunk.id) ?? 0) + 1;
+                            const failedRequestChunks = resolveFailedRequestChunks({
+                                error         : err,
+                                batchToEmbed,
+                                persistedCount: carryShrunkCount
+                            });
 
-                            undeliverableStrikeCounts.set(headChunk.id, strikes);
+                            if (failedRequestChunks.length === 1) {
+                                const suspect = failedRequestChunks[0];
+                                const entry   = evidence.strikes.get(suspect.id) ?? {count: 0, lastStrikeSeq: 0};
 
-                            if (strikes >= undeliverableTimeoutStrikes && typeof onPoisonEntries === 'function') {
-                                try {
-                                    await onPoisonEntries([{chunkId: headChunk.id, reasonCode: KB_VECTOR_EMBED_UNDELIVERABLE_AT_GEOMETRY}]);
-                                    undeliverableStrikeCounts.delete(headChunk.id);
-                                    logger.warn(`[VectorService] Chunk ${headChunk.id} graduated to undeliverable-at-geometry after ${strikes} consecutive call-ceiling expiries; it stops being offered until the embedding generation (provider, model, dimension, call ceiling) changes.`);
-                                } catch (persistError) {
-                                    // Fail-open: a disposition that cannot persist must not suppress provider
-                                    // work — the chunk stays offered and the strikes stay counted.
-                                    logger.warn(`[VectorService] Could not persist the undeliverable disposition for chunk ${headChunk.id} (${persistError.message}); the chunk remains offered.`);
+                                // A single-input timeout CONFIRMS suspicion rather than consuming it:
+                                // the chunk keeps being dispatched alone until a non-timeout outcome
+                                // clears it or graduation fences it — releasing it here would let a
+                                // striking monster rejoin multi-input requests between strikes.
+                                evidence.suspects.add(suspect.id);
+
+                                // The overlap guard: an entry whose last strike landed AFTER this
+                                // attempt dispatched observed the same failure window — counting both
+                                // would let two overlapping attempts fabricate a "consecutive" pair.
+                                if (entry.lastStrikeSeq <= dispatchSeq) {
+                                    entry.count        += 1;
+                                    entry.lastStrikeSeq = ++evidence.seq;
+                                    evidence.strikes.set(suspect.id, entry);
                                 }
+
+                                if (entry.count >= undeliverableTimeoutStrikes && typeof onPoisonEntries === 'function') {
+                                    // The AC-1 receipt: bounded numbers and a hash, surfaced beside
+                                    // the disposition without replacing the original timeout — the
+                                    // sweep below still throws `err`, decorated, so the ingest
+                                    // summary carries both the cause and the graduation evidence.
+                                    const receipt = {
+                                        chunkId           : suspect.id,
+                                        tokenEstimate     : bytesToTokens(Buffer.byteLength(textsToEmbed[batchToEmbed.indexOf(suspect)] || '', 'utf8')),
+                                        attempts          : entry.count,
+                                        effectiveCeilingMs: generation.embedCallCeilingMs
+                                    };
+
+                                    try {
+                                        await onPoisonEntries([{chunkId: suspect.id, reasonCode: KB_VECTOR_EMBED_UNDELIVERABLE_AT_GEOMETRY}]);
+                                        evidence.strikes.delete(suspect.id);
+                                        evidence.suspects.delete(suspect.id);
+                                        err.undeliverableGraduation = receipt;
+                                        logger.warn(`[VectorService] Chunk ${suspect.id} graduated to undeliverable-at-geometry after ${receipt.attempts} consecutive single-input call-ceiling expiries (~${receipt.tokenEstimate} tokens against a ${receipt.effectiveCeilingMs}ms ceiling); it stops being offered until the embedding generation (provider, model, dimension, call ceiling) changes.`);
+                                    } catch (persistError) {
+                                        // Fail-open: a disposition that cannot persist must not suppress
+                                        // provider work — the chunk stays offered and the strikes stay
+                                        // counted.
+                                        logger.warn(`[VectorService] Could not persist the undeliverable disposition for chunk ${suspect.id} (${persistError.message}); the chunk remains offered.`);
+                                    }
+                                }
+                            } else {
+                                // Multi-input or unattributable request: suspicion only. An empty
+                                // resolution (no producer span — e.g. the native-ollama batch, which
+                                // posts one opaque multi-input request) conservatively suspects every
+                                // dispatched member; suspicion costs one isolation offer, never a fence.
+                                const members = failedRequestChunks.length > 0 ? failedRequestChunks : batchToEmbed;
+
+                                members.forEach(chunk => evidence.suspects.add(chunk.id));
                             }
                         }
 
@@ -1273,13 +1471,30 @@ class VectorService extends Base {
                             ? 'the run-scoped provider circuit opened before this repository dispatched'
                             : 'one timeout-class provider attempt ended';
 
-                        console.error(`An error occurred during embedding batch ${i / batchSize + 1}. Ending this embedding sweep because ${disposition}; pending chunks remain for a later scheduler cycle.`, err.message);
+                        console.error(`An error occurred during embedding batch ${batchNumber}. Ending this embedding sweep because ${disposition}; pending chunks remain for a later scheduler cycle.`, err.message);
                         throw err
+                    }
+
+                    // A dispatched non-timeout provider failure breaks the consecutive-timeout chain
+                    // for the inputs it covered: reset their automaton entries (never their durable
+                    // dispositions). Storage failures skip this — `embeddings !== null` means the
+                    // provider half succeeded and the success path already reset.
+                    if (embeddings === null) {
+                        const failedRequestChunks = resolveFailedRequestChunks({
+                            error         : err,
+                            batchToEmbed,
+                            persistedCount: carryShrunkCount
+                        });
+
+                        (failedRequestChunks.length > 0 ? failedRequestChunks : batchToEmbed).forEach(chunk => {
+                            evidence.strikes.delete(chunk.id);
+                            evidence.suspects.delete(chunk.id);
+                        });
                     }
 
                     lastError = err;
                     retries++;
-                    console.error(`An error occurred during embedding batch ${i / batchSize + 1}. Retrying (${retries}/${maxRetries})...`, err.message);
+                    console.error(`An error occurred during embedding batch ${batchNumber}. Retrying (${retries}/${maxRetries})...`, err.message);
                     if (retries < maxRetries) {
                         await new Promise(res => setTimeout(res, 2 ** retries * 1000)); // Exponential backoff
                     }
@@ -1305,7 +1520,7 @@ class VectorService extends Base {
             if (!success && !yielded) {
                 if (embeddedCount === 0) {
                     const abort = this.createFirstBatchAbort({
-                        batchIndex: i / batchSize + 1,
+                        batchIndex: batchNumber,
                         maxRetries,
                         lastError
                     });
@@ -1347,7 +1562,7 @@ class VectorService extends Base {
                         });
                     } catch (isolationError) {
                         throw this.createFirstBatchAbort({
-                            batchIndex: i / batchSize + 1,
+                            batchIndex: batchNumber,
                             maxRetries,
                             lastError : isolationError
                         })
@@ -1373,11 +1588,12 @@ class VectorService extends Base {
 
                     embeddedCount += isolation.embedded;
                     logger.warn(`[VectorService] First embedding batch was isolated with bounded paired evidence: ${isolation.embedded} recoverable chunk(s) landed and ${isolation.poisonEntries.length} proven poison chunk(s) were fenced.`);
+                    cursor += cursorAdvance;
                     continue
                 }
 
                 failedBatches.push({
-                    batchIndex: i / batchSize + 1,
+                    batchIndex: batchNumber,
                     chunkIds  : batchToEmbed.map(chunk => chunk.id),
                     reason    : lastError?.message || 'unknown embedding failure'
                 });
@@ -1388,13 +1604,15 @@ class VectorService extends Base {
                 // one poisoned payload. It only decides that the remaining work is worth trying rather than
                 // abandoning, and records what failed so the caller can decide what the hole means. Skip it and keep going;
                 // the remainder is recoverable work and the failure travels back in `failedBatches`.
-                logger.warn(`[VectorService] Batch ${i / batchSize + 1} failed after ${maxRetries} retries; skipping it and continuing (${embeddedCount} embedded so far). Reason: ${lastError?.message}`);
+                logger.warn(`[VectorService] Batch ${batchNumber} failed after ${maxRetries} retries; skipping it and continuing (${embeddedCount} embedded so far). Reason: ${lastError?.message}`);
             }
 
             // The retry loop exits on success, on exhaustion (handled directly above), or on a yield — only the
             // last one leaves the outer sweep to stop, so it is named explicitly rather than relying on the next
             // between-batch checkpoint observing a predicate that may already have flipped back.
             if (yielded) break;
+
+            cursor += cursorAdvance;
         }
 
         return {embedded: embeddedCount, skipped: skippedCount, yielded, failedBatches, poisonedChunks};
@@ -1439,7 +1657,8 @@ class VectorService extends Base {
         signal,
         onProviderTimeout,
         knownPoisonEntries = [],
-        onPoisonEntries
+        onPoisonEntries,
+        poisonGenerationId
     }) {
         const stateDir    = this.getResumeStateDir();
         const fingerprint = computeCorpusFingerprint(knowledgeBase);
@@ -1522,7 +1741,8 @@ class VectorService extends Base {
                     chunk,
                     alreadyLanded: shadowExistingIds.has(chunk.id)
                 })),
-                onPoisonEntries
+                onPoisonEntries,
+                poisonGenerationId
             });
 
             if (embedResult.yielded) {
@@ -1977,14 +2197,15 @@ class VectorService extends Base {
 
         if (shouldShadowSwap) {
             return await this.embedViaShadowSwap({
-                liveCollection  : collection,
-                knowledgeBase   : expandedKnowledgeBase,
-                idsToDeleteCount: idsToDelete.length,
+                liveCollection    : collection,
+                knowledgeBase     : expandedKnowledgeBase,
+                idsToDeleteCount  : idsToDelete.length,
                 shouldYield,
                 signal,
                 onProviderTimeout,
                 knownPoisonEntries,
-                onPoisonEntries : persistPoisonEntries
+                onPoisonEntries   : persistPoisonEntries,
+                poisonGenerationId: poisonCoordinates.generationId
             });
         }
 
@@ -2000,7 +2221,8 @@ class VectorService extends Base {
             onProviderTimeout,
             knownPoisonEntries,
             controlCandidates,
-            onPoisonEntries: persistPoisonEntries
+            onPoisonEntries   : persistPoisonEntries,
+            poisonGenerationId: poisonCoordinates.generationId
         });
 
         const count          = await collection.count();

--- a/ai/services/knowledge-base/helpers/embedFailureClassification.mjs
+++ b/ai/services/knowledge-base/helpers/embedFailureClassification.mjs
@@ -73,6 +73,19 @@ export const KB_VECTOR_EMBED_UNCLASSIFIED = 'KB_VECTOR_EMBED_FAILED';
 export const KB_VECTOR_EMBED_PROVIDER_CIRCUIT_OPEN = 'KB_VECTOR_EMBED_PROVIDER_CIRCUIT_OPEN';
 
 /**
+ * @summary Bounded disposition for a chunk whose embed call ceiling expired on consecutive attempts.
+ *
+ * A timeout is lane evidence, not content evidence — but a chunk whose call ceiling fires on EVERY
+ * attempt is deterministically undeliverable at the current geometry (provider, model, dimension,
+ * call ceiling), and each further offer costs a full ceiling of head-of-line blocking for every
+ * chunk and repository queued behind it. The disposition is durable via the poison store and
+ * invalidates with the embedding generation, so a raised ceiling or changed geometry re-offers the
+ * chunk automatically.
+ * @type {String}
+ */
+export const KB_VECTOR_EMBED_UNDELIVERABLE_AT_GEOMETRY = 'KB_VECTOR_EMBED_UNDELIVERABLE_AT_GEOMETRY';
+
+/**
  * @summary The codes our OWN layers raise on the embed path, and the only ones allowed through
  * unchanged.
  *
@@ -90,7 +103,8 @@ const INTERNAL_EMBED_ERROR_CODES = Object.freeze(new Set([
     'KB_EMBEDDING_INPUT_SIZE_EXCEEDED',
     'KB_SYNC_VOLUME_EXCEEDED',
     'KB_TENANT_SPOOF_REJECTED',
-    KB_VECTOR_EMBED_PROVIDER_CIRCUIT_OPEN
+    KB_VECTOR_EMBED_PROVIDER_CIRCUIT_OPEN,
+    KB_VECTOR_EMBED_UNDELIVERABLE_AT_GEOMETRY
 ]));
 
 /**

--- a/ai/services/memory-core/TextEmbeddingService.mjs
+++ b/ai/services/memory-core/TextEmbeddingService.mjs
@@ -1853,6 +1853,16 @@ class TextEmbeddingService extends Base {
                     providerActivityRecorder
                 }, 'batch');
             } catch (err) {
+                // Producer attribution for the FAILED request, decorated unconditionally: a provider
+                // timeout names the whole multi-input POST, so the consumer's undeliverable
+                // classification must know exactly which input span was in flight — assigning the
+                // failure to the first batch member when the request held five is how an innocent
+                // neighbour inherits a monster's strikes. Pure indices derived from what was SENT;
+                // unlike the carry below they need no positional-binding proof because they bind
+                // nothing — they only NAME the span.
+                err.failedTextOffset = offset;
+                err.failedTextCount  = chunk.length;
+
                 // Work conservation on the FAILURE path. The yield-point above carries its
                 // completed prefix; a provider failure mid-batch used to discard it, so the caller's
                 // retry — and every later sweep — re-purchased vectors the provider had already

--- a/ai/services/shared/vector/generationElectionStore.mjs
+++ b/ai/services/shared/vector/generationElectionStore.mjs
@@ -127,20 +127,31 @@ const writeQueues = new Map();
 /**
  * @summary Hashes the poison-store-compatible embedding-generation coordinates.
  *
- * This is the ONE implementation of the four-coordinate id-space shared with
- * `kbEmbeddingPoisonStore` (which re-exports it): the same tuple must always produce the same id in
- * both stores, so poison dispositions and election records join on generation without translation.
- * The full election identity ({@link createVectorGenerationIdentity}) hashes MORE coordinates; this
- * narrower id exists solely as that join key.
+ * This is the ONE implementation of the id-space shared with `kbEmbeddingPoisonStore` (which
+ * re-exports it): the same tuple must always produce the same id in both stores, so poison
+ * dispositions and election records join on generation without translation. The full election
+ * identity ({@link createVectorGenerationIdentity}) hashes MORE coordinates; this narrower id
+ * exists solely as that join key.
+ *
+ * `embedCallCeilingMs` is an OPTIONAL fifth coordinate, and the optionality is load-bearing in both
+ * directions. The poison fence passes it because suppression evidence is only valid under the
+ * ceiling it was gathered at — an undeliverable-at-geometry disposition proven against a 30-minute
+ * ceiling is void under a 60-minute one, so folding the ceiling into the hash is what makes an
+ * operator ceiling raise re-offer previously fenced chunks automatically. (The first draft carried
+ * the field on the coordinate OBJECT but this function silently dropped it from the hash — the
+ * re-offer guarantee held in prose and nowhere else, which is why the production-path spec now pins
+ * the hash property itself.) The election callers do NOT pass it, so their four-coordinate hashes —
+ * and every persisted election record keyed by them — are untouched.
  *
  * @param {Object} options
  * @param {String} options.provider Embedding provider identity (never persisted verbatim by the poison store).
  * @param {String} options.model Embedding model identity.
  * @param {Number} options.vectorDimension Expected vector dimension.
  * @param {String} options.strategyVersion Input/chunking strategy version.
+ * @param {Number} [options.embedCallCeilingMs] Effective per-call embed ceiling this evidence was gathered under.
  * @returns {String} Lowercase SHA-256 generation id.
  */
-export function createEmbeddingGenerationId({provider, model, vectorDimension, strategyVersion} = {}) {
+export function createEmbeddingGenerationId({provider, model, vectorDimension, strategyVersion, embedCallCeilingMs} = {}) {
     assertHashInput(provider, 'createEmbeddingGenerationId: provider');
     assertHashInput(model, 'createEmbeddingGenerationId: model');
     assertHashInput(strategyVersion, 'createEmbeddingGenerationId: strategyVersion');
@@ -149,7 +160,15 @@ export function createEmbeddingGenerationId({provider, model, vectorDimension, s
         throw new TypeError('createEmbeddingGenerationId: vectorDimension must be a positive integer')
     }
 
-    return sha256(JSON.stringify({provider, model, vectorDimension, strategyVersion}))
+    if (embedCallCeilingMs === undefined) {
+        return sha256(JSON.stringify({provider, model, vectorDimension, strategyVersion}))
+    }
+
+    if (!Number.isFinite(embedCallCeilingMs) || embedCallCeilingMs <= 0) {
+        throw new TypeError('createEmbeddingGenerationId: embedCallCeilingMs must be a positive finite number when provided')
+    }
+
+    return sha256(JSON.stringify({provider, model, vectorDimension, strategyVersion, embedCallCeilingMs}))
 }
 
 /**

--- a/test/playwright/unit/ai/daemons/orchestrator/services/DeploymentStateBridgeService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/DeploymentStateBridgeService.spec.mjs
@@ -1671,6 +1671,41 @@ test.describe('Neo.ai.daemons.services.DeploymentStateBridgeService', () => {
             state: 'outstanding', observable: true, outstanding: 618
         });
         positive.destroy();
+
+        // The undeliverable census rides the SAME persisted-state → normalizer → summarizer chain,
+        // and it matters MORE here than for the backlog count — a fence-only run COMPLETES (streak
+        // zero, checkpoint advanced), so this projection is the only snapshot evidence that N
+        // documents are deferred pending a geometry change. Published unconditionally, exactly like
+        // the backlog beside it.
+        const
+            monsterId = 'd'.repeat(64),
+            fenced    = makeService({
+                ...baseCheckpoint,
+                undeliverableChunks: {count: 3, ids: [monsterId]}
+            }),
+            fencedSnap = await fenced.collectTenantRepoSyncSnapshot({observedAt: OBSERVED_AT});
+
+        expect(fencedSnap.repos[0].undeliverableChunks).toEqual({count: 3, ids: [monsterId]});
+        expect(fencedSnap.repos[0].consecutiveFailures).toBe(0);
+        fenced.destroy();
+
+        // Unobserved is null — never a zero census…
+        const noCensus     = makeService({...baseCheckpoint}),
+              noCensusSnap = await noCensus.collectTenantRepoSyncSnapshot({observedAt: OBSERVED_AT});
+
+        expect(noCensusSnap.repos[0].undeliverableChunks).toBeNull();
+        noCensus.destroy();
+
+        // …and a torn census degrades WHOLE at the reader, so a hand-edited or half-written record
+        // cannot enumerate ids it never proved.
+        const tornCensus = makeService({
+                  ...baseCheckpoint,
+                  undeliverableChunks: {count: 1, ids: [monsterId, 'f'.repeat(64)]}
+              }),
+              tornCensusSnap = await tornCensus.collectTenantRepoSyncSnapshot({observedAt: OBSERVED_AT});
+
+        expect(tornCensusSnap.repos[0].undeliverableChunks).toBeNull();
+        tornCensus.destroy();
     });
 
     test('collectTenantRepoSyncSnapshot projects mixed access readiness through a deep allowlist', async () => {

--- a/test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncService.spec.mjs
@@ -326,6 +326,127 @@ test.describe('TenantRepoSyncService (#11790)', () => {
         expect(TenantRepoSyncService.getEmbeddingRecoveryProbeSnapshot().status).toBe('never-started');
     });
 
+    test('a fence-only summary COMPLETES with the undeliverable census; a live failure beside it still defers (#17129)', async () => {
+        const
+            taskStateService = createInMemoryTaskStateService(),
+            fenceSlug        = 'org/fence-only',
+            mixedSlug        = 'org/fence-mixed',
+            monsterId        = 'd'.repeat(64),
+            startedAt        = Date.now(),
+            fenceRow         = {
+                code   : 'KB_VECTOR_EMBED_UNDELIVERABLE_AT_GEOMETRY',
+                message: 'A chunk remains fenced as undeliverable at the current embedding geometry.',
+                details: {
+                    chunkId    : monsterId,
+                    reasonCode : 'KB_VECTOR_EMBED_UNDELIVERABLE_AT_GEOMETRY',
+                    disposition: 'undeliverable-at-geometry'
+                }
+            };
+
+        await provisionMirrorDir({tenantId: 't1', repoSlug: fenceSlug});
+        await provisionMirrorDir({tenantId: 't1', repoSlug: mixedSlug});
+        await TenantRepoSyncService.writePersistedRevisions({
+            filePath : revisionsFile,
+            revisions: Object.fromEntries([fenceSlug, mixedSlug].map(repoSlug => [`t1/${repoSlug}`, {
+                lastIngestedRev                   : null,
+                lastRunAttemptAt                  : startedAt - 120_000,
+                consecutiveFailures               : 0,
+                ingestContractVersion             : TENANT_REPO_INGEST_CONTRACT_VERSION,
+                lastAttemptedIngestContractVersion: TENANT_REPO_INGEST_CONTRACT_VERSION
+            }]))
+        });
+
+        const result = await TenantRepoSyncService.runTask({
+            reason           : 'periodic-sweep:60000',
+            taskStateService,
+            tenantReposConfig: {tenantRepos: [fenceSlug, mixedSlug].map(repoSlug => ({
+                tenantId: 't1', repoSlug, mirrorRoot, cloneUrl: `https://github.com/neomjs/${repoSlug.split('/')[1]}.git`
+            }))},
+            gitMirror                    : makeFakeGitMirror(),
+            envelopeBuilder              : makeFakeEnvelopeBuilder(),
+            knowledgeBaseIngestionService: makeFakeIngestionService({
+                summaryFactory(payload) {
+                    // The fence-only repo embedded everything embeddable; its ONLY error rows are the
+                    // durable fence. The mixed repo carries the same fence PLUS a live timeout.
+                    return payload.repoSlug === fenceSlug
+                        ? {ingested: 2, deleted: 0, embeddingsGenerated: 2, errors: [{...fenceRow}]}
+                        : {ingested: 1, deleted: 0, embeddingsGenerated: 0, errors: [
+                            {...fenceRow},
+                            {code: 'KB_VECTOR_EMBED_PROVIDER_TIMEOUT', message: 'one timeout-class provider attempt ended'}
+                        ]}
+                }
+            }),
+            revisionsFilePath: revisionsFile,
+            globalCadenceMs  : 60_000,
+            jitterRatio      : 0,
+            backoffCapMs     : 60_000,
+            seedBootstrap    : false
+        });
+
+        const persisted  = (await fs.readJson(revisionsFile)).revisions;
+        const fenceState = persisted[`t1/${fenceSlug}`];
+        const mixedState = persisted[`t1/${mixedSlug}`];
+
+        // Fence-only: COMPLETE. Deferral means "coming back may finish the work"; a durable fence is
+        // the opposite claim, so holding the checkpoint would re-materialize the same delta forever
+        // for a chunk no later sweep can change. The checkpoint advances, the streak resets, no live
+        // cause is retained — and the census is what keeps the fenced chunk visible.
+        expect(fenceState.lastIngestedRev).toBe(`sha-head-${fenceSlug}`);
+        expect(fenceState.ingestContractVersion).toBe(TENANT_REPO_INGEST_CONTRACT_VERSION);
+        expect(fenceState.consecutiveFailures).toBe(0);
+        expect(fenceState.lastSourceErrorCode).toBeNull();
+        expect(fenceState.undeliverableChunks).toEqual({count: 1, ids: [monsterId]});
+
+        // The strict checkpoint reader admits the census it just round-tripped.
+        expect(normalizeTenantRepoCheckpointState(fenceState).undeliverableChunks).toEqual({count: 1, ids: [monsterId]});
+
+        // Mixed: DEFERRED, exactly as before — one live deferrable failure beside the fences holds
+        // the checkpoint. The retained cause is the LIVE code, never the fence: the fence must not
+        // arm an embedding-recovery canary whose health probe cannot re-offer the chunk.
+        expect(mixedState.lastIngestedRev).toBeNull();
+        expect(mixedState.lastSourceErrorCode).toBe('KB_VECTOR_EMBED_PROVIDER_TIMEOUT');
+        expect(mixedState.undeliverableChunks).toEqual({count: 1, ids: [monsterId]});
+
+        // Run-level projection: the fence-only repo completed; the mixed repo deferred and carries
+        // its census on the diagnostic row.
+        const fenceRow2 = result.details.repos.find(repo => repo.repoSlug === fenceSlug);
+        const mixedRow  = result.details.repos.find(repo => repo.repoSlug === mixedSlug);
+
+        expect(fenceRow2.status).toBe('active');
+        expect(fenceRow2.undeliverableChunks).toEqual({count: 1, ids: [monsterId]});
+        expect(mixedRow.status).toBe('deferred');
+        expect(mixedRow.undeliverableChunks).toEqual({count: 1, ids: [monsterId]});
+    });
+
+    test('the undeliverable census normalizer degrades torn records WHOLE (#17129)', () => {
+        const monsterId = 'e'.repeat(64);
+        const base      = {
+            lastIngestedRev                   : 'abc123',
+            lastRunAttemptAt                  : 1_000,
+            consecutiveFailures               : 0,
+            ingestContractVersion             : TENANT_REPO_INGEST_CONTRACT_VERSION,
+            lastAttemptedIngestContractVersion: TENANT_REPO_INGEST_CONTRACT_VERSION
+        };
+        const censusOf = undeliverableChunks =>
+            normalizeTenantRepoCheckpointState({...base, undeliverableChunks}).undeliverableChunks;
+
+        // A valid census round-trips; ids may be FEWER than the count (the writer caps enumeration).
+        expect(censusOf({count: 1, ids: [monsterId]})).toEqual({count: 1, ids: [monsterId]});
+        expect(censusOf({count: 40, ids: [monsterId]})).toEqual({count: 40, ids: [monsterId]});
+
+        // Absent means unobserved — never zero.
+        expect(censusOf(undefined)).toBeNull();
+
+        // Torn records degrade whole: repairing any of these into a smaller census would assert an
+        // observation nobody made.
+        expect(censusOf({count: 0, ids: []}),               'zero-count census').toBeNull();
+        expect(censusOf({count: 1, ids: [monsterId, 'f'.repeat(64)]}), 'more ids than count').toBeNull();
+        expect(censusOf({count: 1, ids: ['not-a-hash']}),   'non-hash id').toBeNull();
+        expect(censusOf({count: 2, ids: [monsterId, monsterId]}), 'duplicate id').toBeNull();
+        expect(censusOf({count: '1', ids: [monsterId]}),    'stringly count').toBeNull();
+        expect(censusOf([monsterId]),                       'array shape').toBeNull();
+    });
+
     test('embedding recovery releases only the affected repo once, then rearms after a failed retry (#16692)', async () => {
         const
             taskStateService = createInMemoryTaskStateService(),

--- a/test/playwright/unit/ai/services/knowledge-base/VectorService.failureCarry.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/VectorService.failureCarry.spec.mjs
@@ -371,4 +371,137 @@ test.describe('VectorService.embedChunks — failure-path work conservation (#17
         expect(outcome.code).toBe('OPENAI_COMPATIBLE_REQUEST_TIMEOUT');
         expect(spy.calls.upsert).toBe(0);
     });
+
+    test('the SAME head chunk expiring its ceiling twice graduates to undeliverable-at-geometry; the graduating sweep still ends', async () => {
+        const spy = createSpyCollection();
+        // Distinct id prefix: the strike memory is deliberately process-local, so arms must not
+        // share chunk ids or they inherit each other's strikes.
+        const chunks = Array.from({length: 5}, (_, i) => ({
+            id: `grad-${i}`, type: 'guide', name: `g${i}`, content: `graduation body ${i}`
+        }));
+
+        const persisted = [];
+
+        const makeTimeout = () => {
+            const error = new Error('request timed out');
+
+            error.code = 'OPENAI_COMPATIBLE_REQUEST_TIMEOUT';
+            return error
+        };
+
+        TextEmbeddingService.embedTexts = async () => { throw makeTimeout() };
+
+        const runSweep = () => KB_VectorService.embedChunks({
+            collection     : spy,
+            chunksToProcess: chunks,
+            shouldYield    : () => false,
+            onPoisonEntries: async entries => { persisted.push(...entries) }
+        }).then(() => null, error => error);
+
+        // Sweep 1: strike 1 — lane evidence only, nothing persisted, sweep ends.
+        const first = await runSweep();
+        expect(first).toBeInstanceOf(Error);
+        expect(persisted).toHaveLength(0);
+
+        // Sweep 2: strike 2 — the head chunk graduates with the bounded reason code, and the sweep
+        // STILL ends: the provider is grinding the just-abandoned attempt, and dispatching the
+        // remainder now would queue fresh work behind it.
+        const second = await runSweep();
+        expect(second).toBeInstanceOf(Error);
+        expect(second.code, 'the original timeout identity survives graduation').toBe('OPENAI_COMPATIBLE_REQUEST_TIMEOUT');
+        expect(persisted).toEqual([{chunkId: 'grad-0', reasonCode: 'KB_VECTOR_EMBED_UNDELIVERABLE_AT_GEOMETRY'}]);
+        expect(spy.calls.upsert, 'graduation persists a disposition, never a vector').toBe(0);
+
+        // Sweep 3 with the graduated chunk excluded (the production filter is the existing
+        // knownPoisonEntries flow): the remainder completes — the head-of-line block is gone.
+        TextEmbeddingService.embedTexts = async texts => texts.map(() => new Array(384).fill(0));
+
+        const third = await KB_VectorService.embedChunks({
+            collection        : spy,
+            chunksToProcess   : chunks,
+            knownPoisonEntries: persisted.map(entry => ({...entry})),
+            shouldYield       : () => false,
+            onPoisonEntries   : async () => {}
+        });
+
+        expect(third.embedded, 'every chunk behind the excised head embeds').toBe(4);
+        expect(spy.upsertedIds).toEqual(['grad-1', 'grad-2', 'grad-3', 'grad-4']);
+        expect(third.poisonedChunks.map(entry => entry.chunkId), 'the census carries the excised chunk').toEqual(['grad-0']);
+    });
+
+    test('a successful persist CLEARS strike memory: timeout/success/timeout never graduates', async () => {
+        const spy    = createSpyCollection();
+        const chunks = Array.from({length: 3}, (_, i) => ({
+            id: `hyg-${i}`, type: 'guide', name: `h${i}`, content: `hygiene body ${i}`
+        }));
+
+        const persisted = [];
+        let   call      = 0;
+
+        TextEmbeddingService.embedTexts = async texts => {
+            call++;
+
+            if (call === 2) return texts.map(() => new Array(384).fill(0));
+
+            const error = new Error('request timed out');
+
+            error.code = 'OPENAI_COMPATIBLE_REQUEST_TIMEOUT';
+            throw error
+        };
+
+        const runSweep = () => KB_VectorService.embedChunks({
+            collection     : spy,
+            chunksToProcess: chunks,
+            shouldYield    : () => false,
+            onPoisonEntries: async entries => { persisted.push(...entries) }
+        }).then(value => value, error => error);
+
+        await runSweep();               // timeout — strike 1 on hyg-0
+        await runSweep();               // success — hyg-0 persists, strikes cleared
+        const third = await runSweep(); // timeout again — strike 1 again, NOT graduation
+
+        expect(third).toBeInstanceOf(Error);
+        expect(persisted, 'delivery is the falsifier: a persisted chunk cannot inherit old strikes').toHaveLength(0);
+    });
+
+    test('a failing disposition writer FAILS OPEN: the original timeout propagates and the chunk stays offered', async () => {
+        const spy    = createSpyCollection();
+        const chunks = Array.from({length: 2}, (_, i) => ({
+            id: `fo-${i}`, type: 'guide', name: `f${i}`, content: `fail-open body ${i}`
+        }));
+
+        TextEmbeddingService.embedTexts = async () => {
+            const error = new Error('request timed out');
+
+            error.code = 'OPENAI_COMPATIBLE_REQUEST_TIMEOUT';
+            throw error
+        };
+
+        const runSweep = () => KB_VectorService.embedChunks({
+            collection     : spy,
+            chunksToProcess: chunks,
+            shouldYield    : () => false,
+            onPoisonEntries: async () => { throw new Error('disposition store unavailable') }
+        }).then(() => null, error => error);
+
+        await runSweep();              // strike 1
+        const second = await runSweep(); // strike 2 — graduation attempted, writer throws
+
+        // The persist failure must neither mask the timeout nor suppress the chunk.
+        expect(second).toBeInstanceOf(Error);
+        expect(second.code).toBe('OPENAI_COMPATIBLE_REQUEST_TIMEOUT');
+        expect(second.message).not.toContain('disposition store unavailable');
+    });
+
+    test('the poison generation carries the effective embed call ceiling, so a ceiling change re-offers suppressed chunks', async () => {
+        const Memory_Config = SDK.Memory_Config;
+        const generation    = KB_VectorService.resolveEmbeddingPoisonGeneration();
+
+        const expectedCeiling = Memory_Config.embeddingProvider === 'ollama'
+            ? Number(Memory_Config.ollama.embeddingTimeoutMs)
+            : Number(Memory_Config.openAiCompatible.batchEmbeddingTimeoutMs);
+
+        expect(generation.embedCallCeilingMs, 'suppression evidence is only valid under the ceiling it was gathered at').toBe(expectedCeiling);
+        expect(Number.isFinite(generation.embedCallCeilingMs)).toBe(true);
+    });
 });

--- a/test/playwright/unit/ai/services/knowledge-base/VectorService.failureCarry.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/VectorService.failureCarry.spec.mjs
@@ -21,21 +21,22 @@ import * as core                      from '../../../../../../src/core/_export.m
 import {EMBEDDING_BATCH_YIELDED_CODE} from '../../../../../../ai/services/memory-core/TextEmbeddingService.mjs';
 
 /**
- * Work conservation on the FAILURE path of `VectorService.embedChunks`.
+ * Work conservation and undeliverable-at-geometry attribution on the failure path of
+ * `VectorService.embedChunks`.
  *
- * The yield arm already persists the completed prefix a lease-yield carries. A provider FAILURE
- * mid-batch discarded it: the timeout arm ended the sweep with the prefix unpersisted, and the retry
- * arm re-ran the whole batch — so every completed-but-unpersisted embedding was re-purchased on every
- * attempt and on every later sweep. On a slow lane that composes into full compute at a constant
- * corpus count: the plane-observed "all discarded" loop.
+ * The carry half: the yield arm already persists the completed prefix a lease-yield carries; a
+ * provider FAILURE mid-batch used to discard it, so every completed-but-unpersisted embedding was
+ * re-purchased on every attempt and every later sweep.
  *
- * These tests drive `embedChunks` with the leaseYield spec's spy-collection harness and a stubbed
- * embedder that throws errors decorated with the carry contract (`completedTextCount`, `embeddings`),
- * asserting the four load-bearing properties:
- *   - a timeout-class failure persists its carried prefix BEFORE the sweep ends,
- *   - a retryable failure persists the prefix and retries ONLY the remainder,
- *   - a payload disagreeing with its stated count is refused, never sliced positionally,
- *   - an uncarried failure keeps its existing behavior (nothing persisted, classification unchanged).
+ * The attribution half: a provider timeout names the REQUEST, not a member. Strikes therefore accrue
+ * only from requests that held exactly one input — via a single-chunk dispatch or the producer's
+ * `failedTextOffset`/`failedTextCount` span — while a multi-input timeout only marks its members as
+ * isolation suspects, each of which is then offered alone to earn exact evidence. Strikes are
+ * generation-keyed, reset on any dispatched non-timeout provider outcome, and guarded against
+ * overlapping attempts counting one wall-clock failure twice.
+ *
+ * Every arm passes its own `poisonGenerationId`: the automaton is deliberately process-local and
+ * generation-scoped, so per-arm generations are what keep arms hermetic.
  */
 test.describe.configure({mode: 'serial'});
 
@@ -84,6 +85,14 @@ function makeChunks(count) {
 }
 
 /**
+ * Per-arm embedding-generation id. The undeliverable automaton is generation-scoped module state,
+ * so giving each arm its own generation is the hermetic-isolation mechanism, not a convenience.
+ */
+function makeGenerationId(seed) {
+    return seed.repeat(64).slice(0, 64)
+}
+
+/**
  * Builds a failure decorated with the carry contract the producer attaches: the ORIGINAL
  * error identity (message + code) with the completed prefix alongside it.
  */
@@ -99,7 +108,22 @@ function makeCarriedFailure({code, completedChunkCount, totalChunkCount, complet
     return error
 }
 
-test.describe('VectorService.embedChunks — failure-path work conservation (#17112)', () => {
+/**
+ * Builds a timeout decorated with the producer's failed-request span — what the OpenAI-compatible
+ * transport now stamps on every request failure. `failedTextCount: 1` is the exact-attribution shape.
+ */
+function makeTimeout({failedTextOffset, failedTextCount} = {}) {
+    const error = new Error('request timed out');
+
+    error.code = 'OPENAI_COMPATIBLE_REQUEST_TIMEOUT';
+
+    if (Number.isInteger(failedTextOffset)) error.failedTextOffset = failedTextOffset;
+    if (Number.isInteger(failedTextCount))  error.failedTextCount  = failedTextCount;
+
+    return error
+}
+
+test.describe('VectorService.embedChunks — failure-path work conservation (#17112) + undeliverable attribution (#17129)', () => {
     let SDK, KB_VectorService, KB_Config, TextEmbeddingService;
     let originalEmbedTexts, originalBatchConfig;
 
@@ -143,9 +167,10 @@ test.describe('VectorService.embedChunks — failure-path work conservation (#17
         };
 
         const outcome = await KB_VectorService.embedChunks({
-            collection     : spy,
-            chunksToProcess: chunks,
-            shouldYield    : () => false
+            collection        : spy,
+            chunksToProcess   : chunks,
+            shouldYield       : () => false,
+            poisonGenerationId: makeGenerationId('a')
         }).then(() => null, error => error);
 
         // The sweep still ends — a timeout means OUR wait ended, not the provider's work, and queueing
@@ -192,9 +217,10 @@ test.describe('VectorService.embedChunks — failure-path work conservation (#17
         };
 
         const result = await KB_VectorService.embedChunks({
-            collection     : spy,
-            chunksToProcess: chunks,
-            shouldYield    : () => false
+            collection        : spy,
+            chunksToProcess   : chunks,
+            shouldYield       : () => false,
+            poisonGenerationId: makeGenerationId('b')
         });
 
         // The retry must not re-purchase the 10 persisted embeddings: attempt 1 sees all 50 inputs,
@@ -250,9 +276,10 @@ test.describe('VectorService.embedChunks — failure-path work conservation (#17
         };
 
         const result = await KB_VectorService.embedChunks({
-            collection     : spy,
-            chunksToProcess: chunks,
-            shouldYield    : () => false
+            collection        : spy,
+            chunksToProcess   : chunks,
+            shouldYield       : () => false,
+            poisonGenerationId: makeGenerationId('c')
         });
 
         // Three write calls: the rejected prefix attempt, the successful prefix retry, and the
@@ -285,9 +312,10 @@ test.describe('VectorService.embedChunks — failure-path work conservation (#17
         };
 
         const outcome = await KB_VectorService.embedChunks({
-            collection     : spy,
-            chunksToProcess: chunks,
-            shouldYield    : () => false
+            collection        : spy,
+            chunksToProcess   : chunks,
+            shouldYield       : () => false,
+            poisonGenerationId: makeGenerationId('d')
         }).then(() => null, error => error);
 
         // One missing vector slides every later one onto its neighbour's id with no length mismatch
@@ -329,9 +357,10 @@ test.describe('VectorService.embedChunks — failure-path work conservation (#17
         };
 
         const result = await KB_VectorService.embedChunks({
-            collection     : spy,
-            chunksToProcess: chunks,
-            shouldYield    : () => false
+            collection        : spy,
+            chunksToProcess   : chunks,
+            shouldYield       : () => false,
+            poisonGenerationId: makeGenerationId('e')
         });
 
         // One rejected write, one successful retry, ZERO extra provider entries — the yield stays a
@@ -354,17 +383,13 @@ test.describe('VectorService.embedChunks — failure-path work conservation (#17
         const spy    = createSpyCollection();
         const chunks = makeChunks(50);
 
-        TextEmbeddingService.embedTexts = async () => {
-            const error = new Error('request timed out');
-
-            error.code = 'OPENAI_COMPATIBLE_REQUEST_TIMEOUT';
-            throw error
-        };
+        TextEmbeddingService.embedTexts = async () => { throw makeTimeout() };
 
         const outcome = await KB_VectorService.embedChunks({
-            collection     : spy,
-            chunksToProcess: chunks,
-            shouldYield    : () => false
+            collection        : spy,
+            chunksToProcess   : chunks,
+            shouldYield       : () => false,
+            poisonGenerationId: makeGenerationId('f')
         }).then(() => null, error => error);
 
         expect(outcome).toBeInstanceOf(Error);
@@ -372,96 +397,318 @@ test.describe('VectorService.embedChunks — failure-path work conservation (#17
         expect(spy.calls.upsert).toBe(0);
     });
 
-    test('the SAME head chunk expiring its ceiling twice graduates to undeliverable-at-geometry; the graduating sweep still ends', async () => {
+    test('a MID-BATCH monster graduates via the producer span — the carry pins it, innocents persist, the receipt is exact', async () => {
         const spy = createSpyCollection();
-        // Distinct id prefix: the strike memory is deliberately process-local, so arms must not
-        // share chunk ids or they inherit each other's strikes.
+        // The monster is DELIBERATELY at index 1, not 0: under head-blame attribution the first
+        // timeout would strike sig-0 (an innocent), and this arm's graduation assertion would fail.
+        // This is the mutation-sensitivity the Round-1 review demanded.
         const chunks = Array.from({length: 5}, (_, i) => ({
-            id: `grad-${i}`, type: 'guide', name: `g${i}`, content: `graduation body ${i}`
+            id: `sig-${i}`, type: 'guide', name: `s${i}`, content: i === 1 ? 'monster body' : `typical body ${i}`
         }));
+        const isMonsterText = text => text.includes('monster body');
 
-        const persisted = [];
+        const persisted    = [];
+        const generationId = makeGenerationId('0');
 
-        const makeTimeout = () => {
-            const error = new Error('request timed out');
+        // A chunkSize=1 transport (the constrained plane's llama.cpp shape): every input is its own
+        // provider request, so the producer span always names exactly one text. A monster at
+        // position N fails with the first N requests completed and carried.
+        TextEmbeddingService.embedTexts = async texts => {
+            const monsterIndex = texts.findIndex(isMonsterText);
 
-            error.code = 'OPENAI_COMPATIBLE_REQUEST_TIMEOUT';
-            return error
+            if (monsterIndex === -1) {
+                return texts.map(() => new Array(384).fill(0))
+            }
+
+            if (monsterIndex === 0) {
+                throw makeTimeout({failedTextOffset: 0, failedTextCount: 1})
+            }
+
+            throw Object.assign(makeTimeout({failedTextOffset: monsterIndex, failedTextCount: 1}), {
+                completedChunkCount: monsterIndex,
+                totalChunkCount    : texts.length,
+                completedTextCount : monsterIndex,
+                embeddings         : Array.from({length: monsterIndex}, () => new Array(384).fill(0))
+            })
         };
 
-        TextEmbeddingService.embedTexts = async () => { throw makeTimeout() };
+        // Production re-selection: a later sweep only offers what the collection does not hold.
+        const remaining = () => chunks.filter(chunk => !spy.storedByIds.has(chunk.id));
 
-        const runSweep = () => KB_VectorService.embedChunks({
-            collection     : spy,
-            chunksToProcess: chunks,
-            shouldYield    : () => false,
-            onPoisonEntries: async entries => { persisted.push(...entries) }
-        }).then(() => null, error => error);
+        const runSweep = (extra = {}) => KB_VectorService.embedChunks({
+            collection        : spy,
+            chunksToProcess   : remaining(),
+            shouldYield       : () => false,
+            onPoisonEntries   : async entries => { persisted.push(...entries) },
+            poisonGenerationId: generationId,
+            ...extra
+        }).then(value => value, error => error);
 
-        // Sweep 1: strike 1 — lane evidence only, nothing persisted, sweep ends.
+        // Sweep 1: the carry persists sig-0, the span names sig-1 exactly — strike 1, no graduation.
         const first = await runSweep();
         expect(first).toBeInstanceOf(Error);
         expect(persisted).toHaveLength(0);
+        expect(spy.upsertedIds, 'the innocent prefix persists before the sweep ends').toEqual(['sig-0']);
 
-        // Sweep 2: strike 2 — the head chunk graduates with the bounded reason code, and the sweep
-        // STILL ends: the provider is grinding the just-abandoned attempt, and dispatching the
-        // remainder now would queue fresh work behind it.
+        // Sweep 2: the monster is now first; a single-input span strikes it again — graduation, with
+        // the exact receipt ON the original timeout, whose identity survives.
         const second = await runSweep();
         expect(second).toBeInstanceOf(Error);
         expect(second.code, 'the original timeout identity survives graduation').toBe('OPENAI_COMPATIBLE_REQUEST_TIMEOUT');
-        expect(persisted).toEqual([{chunkId: 'grad-0', reasonCode: 'KB_VECTOR_EMBED_UNDELIVERABLE_AT_GEOMETRY'}]);
-        expect(spy.calls.upsert, 'graduation persists a disposition, never a vector').toBe(0);
+        expect(persisted).toEqual([{chunkId: 'sig-1', reasonCode: 'KB_VECTOR_EMBED_UNDELIVERABLE_AT_GEOMETRY'}]);
+        expect(second.undeliverableGraduation).toMatchObject({chunkId: 'sig-1', attempts: 2});
+        expect(second.undeliverableGraduation.tokenEstimate).toBeGreaterThan(0);
+        expect(second.undeliverableGraduation.effectiveCeilingMs).toBeGreaterThan(0);
 
         // Sweep 3 with the graduated chunk excluded (the production filter is the existing
         // knownPoisonEntries flow): the remainder completes — the head-of-line block is gone.
-        TextEmbeddingService.embedTexts = async texts => texts.map(() => new Array(384).fill(0));
+        const third = await runSweep({knownPoisonEntries: persisted.map(entry => ({...entry}))});
 
-        const third = await KB_VectorService.embedChunks({
-            collection        : spy,
-            chunksToProcess   : chunks,
-            knownPoisonEntries: persisted.map(entry => ({...entry})),
-            shouldYield       : () => false,
-            onPoisonEntries   : async () => {}
-        });
-
-        expect(third.embedded, 'every chunk behind the excised head embeds').toBe(4);
-        expect(spy.upsertedIds).toEqual(['grad-1', 'grad-2', 'grad-3', 'grad-4']);
-        expect(third.poisonedChunks.map(entry => entry.chunkId), 'the census carries the excised chunk').toEqual(['grad-0']);
+        expect(third.embedded, 'every chunk behind the excised monster embeds').toBe(3);
+        expect(spy.upsertedIds).toEqual(['sig-0', 'sig-2', 'sig-3', 'sig-4']);
+        expect(third.poisonedChunks.map(entry => entry.chunkId), 'the census carries the excised chunk').toEqual(['sig-1']);
     });
 
-    test('a successful persist CLEARS strike memory: timeout/success/timeout never graduates', async () => {
+    test('a MULTI-input timeout never strikes: [typical-A, monster, typical-B] isolates, only the monster graduates', async () => {
         const spy    = createSpyCollection();
-        const chunks = Array.from({length: 3}, (_, i) => ({
-            id: `hyg-${i}`, type: 'guide', name: `h${i}`, content: `hygiene body ${i}`
-        }));
+        const chunks = [
+            {id: 'mx-a', type: 'guide', name: 'a', content: 'typical body a'},
+            {id: 'mx-m', type: 'guide', name: 'm', content: 'monster body'},
+            {id: 'mx-b', type: 'guide', name: 'b', content: 'typical body b'}
+        ];
+        const isMonsterText = text => text.includes('monster body');
 
-        const persisted = [];
-        let   call      = 0;
+        const persisted        = [];
+        const dispatchedInputs = [];
+        const generationId     = makeGenerationId('1');
+
+        // A multi-input transport (parallel=4 → one POST holding all three texts): a timeout names
+        // the whole request via the producer span. Single-input requests behave exactly.
+        TextEmbeddingService.embedTexts = async texts => {
+            dispatchedInputs.push([...texts]);
+
+            if (!texts.some(isMonsterText)) {
+                return texts.map(() => new Array(384).fill(0))
+            }
+
+            throw makeTimeout({failedTextOffset: 0, failedTextCount: texts.length})
+        };
+
+        const remaining = () => chunks.filter(chunk => !spy.storedByIds.has(chunk.id));
+
+        const runSweep = (extra = {}) => KB_VectorService.embedChunks({
+            collection        : spy,
+            chunksToProcess   : remaining(),
+            shouldYield       : () => false,
+            onPoisonEntries   : async entries => { persisted.push(...entries) },
+            poisonGenerationId: generationId,
+            ...extra
+        }).then(value => value, error => error);
+
+        // Sweep 1: one three-input POST times out. NOTHING may be struck — under head-blame, typical-A
+        // would take this strike and a second sweep would fence an innocent durably.
+        const first = await runSweep();
+        expect(first).toBeInstanceOf(Error);
+        expect(persisted).toHaveLength(0);
+        expect(spy.upsertedIds).toEqual([]);
+
+        // Sweep 2: isolation — typical-A is offered ALONE, embeds, and clears; the monster is offered
+        // alone, times out, and earns its FIRST exact strike; the sweep ends on that timeout.
+        const second = await runSweep();
+        expect(second).toBeInstanceOf(Error);
+        expect(persisted, 'one exact strike is not graduation').toHaveLength(0);
+        expect(spy.upsertedIds, 'the innocent neighbour persists during isolation').toEqual(['mx-a']);
+
+        // Sweep 3: the monster isolates again — second exact strike, graduation with the receipt.
+        const third = await runSweep();
+        expect(third).toBeInstanceOf(Error);
+        expect(persisted).toEqual([{chunkId: 'mx-m', reasonCode: 'KB_VECTOR_EMBED_UNDELIVERABLE_AT_GEOMETRY'}]);
+        expect(third.undeliverableGraduation).toMatchObject({chunkId: 'mx-m', attempts: 2});
+
+        // Sweep 4: the fence filters the monster; typical-B completes; the census carries the monster.
+        const monsterDispatchesBefore = dispatchedInputs.filter(texts => texts.some(isMonsterText)).length;
+        const fourth                  = await runSweep({knownPoisonEntries: persisted.map(entry => ({...entry}))});
+
+        expect(fourth.embedded).toBe(1);
+        expect(spy.upsertedIds).toEqual(['mx-a', 'mx-b']);
+        expect(fourth.poisonedChunks.map(entry => entry.chunkId)).toEqual(['mx-m']);
+        expect(
+            dispatchedInputs.filter(texts => texts.some(isMonsterText)).length,
+            'a graduated chunk must never be dispatched to the provider again'
+        ).toBe(monsterDispatchesBefore);
+
+        // Terminal accounting: only the monster ever graduated; both typicals persisted.
+        expect(persisted).toHaveLength(1);
+    });
+
+    test('a dispatched NON-timeout failure resets the consecutive chain: timeout → 500 → timeout never graduates', async () => {
+        const spy    = createSpyCollection();
+        const chunks = [{id: 'rst-0', type: 'guide', name: 'r0', content: 'reset body'}];
+
+        Object.assign(KB_Config.data, {maxRetries: 1}); // one 500 exhausts the batch without backoff sleeps
+
+        const persisted    = [];
+        const generationId = makeGenerationId('2');
+        let   mode         = 'timeout';
 
         TextEmbeddingService.embedTexts = async texts => {
-            call++;
-
-            if (call === 2) return texts.map(() => new Array(384).fill(0));
-
-            const error = new Error('request timed out');
-
-            error.code = 'OPENAI_COMPATIBLE_REQUEST_TIMEOUT';
-            throw error
+            if (mode === 'timeout') throw makeTimeout({failedTextOffset: 0, failedTextCount: 1});
+            if (mode === 'http500') throw new Error('HTTP 500: provider hiccup');
+            return texts.map(() => new Array(384).fill(0))
         };
 
         const runSweep = () => KB_VectorService.embedChunks({
-            collection     : spy,
-            chunksToProcess: chunks,
-            shouldYield    : () => false,
-            onPoisonEntries: async entries => { persisted.push(...entries) }
+            collection        : spy,
+            chunksToProcess   : chunks,
+            shouldYield       : () => false,
+            onPoisonEntries   : async entries => { persisted.push(...entries) },
+            poisonGenerationId: generationId
         }).then(value => value, error => error);
 
-        await runSweep();               // timeout — strike 1 on hyg-0
-        await runSweep();               // success — hyg-0 persists, strikes cleared
-        const third = await runSweep(); // timeout again — strike 1 again, NOT graduation
+        await runSweep();                    // timeout — exact strike 1
+        mode = 'http500';
+        await runSweep();                    // dispatched non-timeout outcome — the chain RESETS
+        mode = 'timeout';
+        const third = await runSweep();      // timeout — strike 1 again, NOT 2
 
         expect(third).toBeInstanceOf(Error);
-        expect(persisted, 'delivery is the falsifier: a persisted chunk cannot inherit old strikes').toHaveLength(0);
+        expect(persisted, 'a non-timeout outcome between two timeouts breaks "consecutive"').toHaveLength(0);
+
+        const fourth = await runSweep();     // timeout — NOW consecutive: strike 2, graduation
+
+        expect(fourth).toBeInstanceOf(Error);
+        expect(persisted).toEqual([{chunkId: 'rst-0', reasonCode: 'KB_VECTOR_EMBED_UNDELIVERABLE_AT_GEOMETRY'}]);
+    });
+
+    test('provider success followed by a STORAGE failure still resets: timeout → success/write-fail → timeout never graduates', async () => {
+        const spy    = createSpyCollection();
+        const chunks = [{id: 'psf-0', type: 'guide', name: 'p0', content: 'storage-failure body'}];
+
+        Object.assign(KB_Config.data, {maxRetries: 1});
+
+        const persisted    = [];
+        const generationId = makeGenerationId('3');
+        let   mode         = 'timeout';
+
+        TextEmbeddingService.embedTexts = async texts => {
+            if (mode === 'timeout') throw makeTimeout({failedTextOffset: 0, failedTextCount: 1});
+            return texts.map(() => new Array(384).fill(0))
+        };
+
+        const realUpsert = spy.upsert.bind(spy);
+        let   failWrites = false;
+
+        spy.upsert = async payload => {
+            if (failWrites) throw new Error('storage refused the write');
+            return realUpsert(payload)
+        };
+
+        const runSweep = () => KB_VectorService.embedChunks({
+            collection        : spy,
+            chunksToProcess   : chunks,
+            shouldYield       : () => false,
+            onPoisonEntries   : async entries => { persisted.push(...entries) },
+            poisonGenerationId: generationId
+        }).then(value => value, error => error);
+
+        await runSweep();                    // timeout — exact strike 1
+
+        mode = 'success'; failWrites = true;
+        const storageFail = await runSweep(); // provider SUCCEEDS, storage fails — non-timeout outcome, chain resets
+        expect(storageFail).toBeInstanceOf(Error);
+
+        mode = 'timeout'; failWrites = false;
+        const third = await runSweep();      // timeout — strike 1 again, NOT 2
+
+        expect(third).toBeInstanceOf(Error);
+        expect(persisted, 'the provider half succeeded, so two timeouts around it are not consecutive').toHaveLength(0);
+
+        const fourth = await runSweep();     // timeout — consecutive now: graduation
+
+        expect(fourth).toBeInstanceOf(Error);
+        expect(persisted).toEqual([{chunkId: 'psf-0', reasonCode: 'KB_VECTOR_EMBED_UNDELIVERABLE_AT_GEOMETRY'}]);
+    });
+
+    test('two OVERLAPPING timeouts count once: attempts dispatched before either strike cannot fabricate a consecutive pair', async () => {
+        const spy    = createSpyCollection();
+        const chunks = [{id: 'ovl-0', type: 'guide', name: 'o0', content: 'overlap body'}];
+
+        const persisted    = [];
+        const generationId = makeGenerationId('4');
+        const rejecters    = [];
+        let   deferred     = true;
+
+        TextEmbeddingService.embedTexts = async () => {
+            if (!deferred) throw makeTimeout({failedTextOffset: 0, failedTextCount: 1});
+
+            return new Promise((_, reject) => rejecters.push(reject))
+        };
+
+        const runSweep = () => KB_VectorService.embedChunks({
+            collection        : spy,
+            chunksToProcess   : chunks,
+            shouldYield       : () => false,
+            onPoisonEntries   : async entries => { persisted.push(...entries) },
+            poisonGenerationId: generationId
+        }).then(value => value, error => error);
+
+        const waitFor = async predicate => {
+            for (let i = 0; i < 200 && !predicate(); i++) {
+                await new Promise(resolve => setTimeout(resolve, 5));
+            }
+            expect(predicate()).toBe(true);
+        };
+
+        // Both attempts dispatch BEFORE either observes a failure — the overlapping shape.
+        const sweepA = runSweep();
+        await waitFor(() => rejecters.length === 1);
+        const sweepB = runSweep();
+        await waitFor(() => rejecters.length === 2);
+
+        rejecters[0](makeTimeout({failedTextOffset: 0, failedTextCount: 1}));
+        const outcomeA = await sweepA;
+        rejecters[1](makeTimeout({failedTextOffset: 0, failedTextCount: 1}));
+        const outcomeB = await sweepB;
+
+        expect(outcomeA).toBeInstanceOf(Error);
+        expect(outcomeB).toBeInstanceOf(Error);
+        expect(persisted, 'two overlapping observations of one failure window are ONE strike, not a pair').toHaveLength(0);
+
+        // A genuinely sequential third attempt completes the pair honestly.
+        deferred = false;
+        const third = await runSweep();
+
+        expect(third).toBeInstanceOf(Error);
+        expect(persisted).toEqual([{chunkId: 'ovl-0', reasonCode: 'KB_VECTOR_EMBED_UNDELIVERABLE_AT_GEOMETRY'}]);
+    });
+
+    test('strikes are GENERATION-keyed: a timeout under generation A and one under generation B never combine', async () => {
+        const spy    = createSpyCollection();
+        const chunks = [{id: 'gen-0', type: 'guide', name: 'g0', content: 'generation body'}];
+
+        const persisted = [];
+
+        TextEmbeddingService.embedTexts = async () => { throw makeTimeout({failedTextOffset: 0, failedTextCount: 1}) };
+
+        const runSweep = generationId => KB_VectorService.embedChunks({
+            collection        : spy,
+            chunksToProcess   : chunks,
+            shouldYield       : () => false,
+            onPoisonEntries   : async entries => { persisted.push(...entries) },
+            poisonGenerationId: generationId
+        }).then(value => value, error => error);
+
+        const genA = makeGenerationId('5');
+        const genB = makeGenerationId('6');
+
+        await runSweep(genA);                // strike 1 under A
+        await runSweep(genB);                // generation change resets — strike 1 under B, NOT 2
+
+        expect(persisted, 'evidence gathered under one ceiling is not evidence under another').toHaveLength(0);
+
+        await runSweep(genB);                // consecutive under B: graduation
+
+        expect(persisted).toEqual([{chunkId: 'gen-0', reasonCode: 'KB_VECTOR_EMBED_UNDELIVERABLE_AT_GEOMETRY'}]);
     });
 
     test('a failing disposition writer FAILS OPEN: the original timeout propagates and the chunk stays offered', async () => {
@@ -470,27 +717,26 @@ test.describe('VectorService.embedChunks — failure-path work conservation (#17
             id: `fo-${i}`, type: 'guide', name: `f${i}`, content: `fail-open body ${i}`
         }));
 
-        TextEmbeddingService.embedTexts = async () => {
-            const error = new Error('request timed out');
-
-            error.code = 'OPENAI_COMPATIBLE_REQUEST_TIMEOUT';
-            throw error
-        };
+        // The producer span names the head exactly, so the strikes are exact — the writer is the
+        // only thing failing in this arm.
+        TextEmbeddingService.embedTexts = async () => { throw makeTimeout({failedTextOffset: 0, failedTextCount: 1}) };
 
         const runSweep = () => KB_VectorService.embedChunks({
-            collection     : spy,
-            chunksToProcess: chunks,
-            shouldYield    : () => false,
-            onPoisonEntries: async () => { throw new Error('disposition store unavailable') }
+            collection        : spy,
+            chunksToProcess   : chunks,
+            shouldYield       : () => false,
+            onPoisonEntries   : async () => { throw new Error('disposition store unavailable') },
+            poisonGenerationId: makeGenerationId('7')
         }).then(() => null, error => error);
 
-        await runSweep();              // strike 1
-        const second = await runSweep(); // strike 2 — graduation attempted, writer throws
+        await runSweep();              // exact strike 1
+        const second = await runSweep(); // exact strike 2 — graduation attempted, writer throws
 
         // The persist failure must neither mask the timeout nor suppress the chunk.
         expect(second).toBeInstanceOf(Error);
         expect(second.code).toBe('OPENAI_COMPATIBLE_REQUEST_TIMEOUT');
         expect(second.message).not.toContain('disposition store unavailable');
+        expect(second.undeliverableGraduation, 'no receipt may be minted for a disposition that did not persist').toBeUndefined();
     });
 
     test('the poison generation carries the effective embed call ceiling, so a ceiling change re-offers suppressed chunks', async () => {

--- a/test/playwright/unit/ai/services/knowledge-base/VectorService.persistenceNonConvergence.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/VectorService.persistenceNonConvergence.spec.mjs
@@ -551,7 +551,12 @@ test.describe('VectorService — persistence failure is an unbounded re-embed lo
                 receivedTextCounts.push(texts.length);
 
                 // Sweep 1: a timeout-class provider failure carrying 10 completed embeddings — the
-                // carried prefix persists, then the timeout classification ends the sweep.
+                // carried prefix persists, then the timeout classification ends the sweep. The
+                // producer span (failedTextOffset/failedTextCount) is part of the real transport's
+                // contract on EVERY request failure: two completed width-5 chunks, so the failed
+                // request held texts [10, 15). A stub without the span models a transport that no
+                // longer exists — and trips the undeliverable classifier's conservative
+                // unknown-member fallback, which suspects the whole dispatch instead of the request.
                 if (embedTextsCalls === 1) {
                     const error = new Error('openAiCompatible request timed out');
 
@@ -559,6 +564,8 @@ test.describe('VectorService — persistence failure is an unbounded re-embed lo
                     error.completedChunkCount = 2;
                     error.totalChunkCount     = 10;
                     error.completedTextCount  = 10;
+                    error.failedTextOffset    = 10;
+                    error.failedTextCount     = 5;
                     error.embeddings          = texts.slice(0, 10).map(() => new Array(384).fill(0.1));
                     throw error
                 }
@@ -579,17 +586,26 @@ test.describe('VectorService — persistence failure is an unbounded re-embed lo
             expect(secondSweep, 'sweep 2 completes').toBeNull();
 
             // The witness AC-2 names: production selection — not a test-authored filter — excluded
-            // the persisted prefix, so the provider was paid for exactly the 40 missing chunks.
-            expect(receivedTextCounts, 'the deployed re-sweep purchased only the un-persisted remainder')
-                .toEqual([50, 40]);
+            // the persisted prefix, so the provider was paid for exactly the 40 missing chunks and
+            // not one more. The CALL SHAPE changed with the undeliverable classifier: the timed-out
+            // request's five members are timeout suspects, so the re-sweep offers each ALONE first
+            // (a single-input request is the only shape whose next timeout would name its cause
+            // exactly); the innocent suspects embed, clear, and the untainted remainder ships as one
+            // batch. Five cheap single-input successes is the price of never fencing an innocent.
+            expect(receivedTextCounts, 'the deployed re-sweep purchased only the un-persisted remainder — suspects isolated first, then one clean batch')
+                .toEqual([50, 1, 1, 1, 1, 1, 35]);
+            expect(
+                receivedTextCounts.slice(1).reduce((sum, count) => sum + count, 0),
+                'the re-purchase total is exactly the un-persisted remainder'
+            ).toBe(40);
             expect(collection.landed.size, 'the corpus completes').toBe(50);
 
-            // And the prefix ids are the ones sweep 2 skipped: the second upsert attempt starts
-            // exactly where the persisted prefix ends.
+            // And the prefix ids are the ones sweep 2 skipped: no re-sweep write may touch any id
+            // the carried-prefix persist already landed.
             expect(collection.upsertAttempts[0]).toHaveLength(10);
-            expect(collection.upsertAttempts[1]).toHaveLength(40);
+            expect(collection.upsertAttempts.slice(1).flat()).toHaveLength(40);
             expect(
-                collection.upsertAttempts[1].some(id => collection.upsertAttempts[0].includes(id)),
+                collection.upsertAttempts.slice(1).flat().some(id => collection.upsertAttempts[0].includes(id)),
                 'no persisted chunk may be re-purchased or re-written by the re-sweep'
             ).toBe(false);
         } finally {

--- a/test/playwright/unit/ai/services/knowledge-base/VectorService.undeliverableGeometry.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/VectorService.undeliverableGeometry.spec.mjs
@@ -1,0 +1,216 @@
+import {setup} from '../../../../setup.mjs';
+
+const appName = 'KBUndeliverableGeometryTest';
+
+setup({
+    neoConfig: {
+        allowVdomUpdatesInTests: false,
+        unitTestMode           : true,
+        useDomApiRenderer      : false
+    },
+    appConfig: {
+        name             : appName,
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../../../src/Neo.mjs';
+import * as core      from '../../../../../../src/core/_export.mjs';
+import fs             from 'fs-extra';
+import os             from 'os';
+import path           from 'path';
+
+/**
+ * The undeliverable-at-geometry production-path proof, driven through `VectorService.embed()` — NOT
+ * `embedChunks()` directly — so every link the direct harness bypasses is exercised for real: corpus re-selection
+ * against the collection, the REAL poison store on disk (write at graduation, generation-keyed read,
+ * batch-assembly filter on the next sweep), and the census returned to the ingest caller.
+ *
+ * The matrix is the Round-1 reviewer's falsifier: `[typical-A, monster, typical-B]` under a
+ * MULTI-input transport shape (one provider request holding all three texts). Only the monster may
+ * graduate; both typicals must persist; the fenced monster must never be dispatched again; and an
+ * operator ceiling change must re-offer it automatically via the generation.
+ */
+test.describe.configure({mode: 'serial'});
+
+function createSpyCollection() {
+    const storedByIds = new Map();
+
+    return {
+        storedByIds,
+        name: 'spy-knowledge-base',
+        async upsert({ids, embeddings}) {
+            ids.forEach((id, position) => storedByIds.set(id, embeddings?.[position]));
+        },
+        async get({limit = 2000, offset = 0} = {}) {
+            return {ids: Array.from(storedByIds.keys()).slice(offset, offset + limit)}
+        },
+        async count() {
+            return storedByIds.size
+        },
+        async delete({ids}) {
+            ids.forEach(id => storedByIds.delete(id));
+        }
+    };
+}
+
+test.describe('VectorService.embed — undeliverable-at-geometry through the production path (#17129)', () => {
+    let SDK, KB_VectorService, KB_Config, Memory_Config, TextEmbeddingService, ChromaManager;
+    let originalEmbedTexts, originalBatchConfig, originalGetCollection, originalResumeStateDir, originalCeiling;
+    let tmpDir, corpusFile;
+
+    const isMonsterText = text => text.includes('monster body');
+
+    const chunks = [
+        {id: 'raw-a', type: 'guide', name: 'typical-a', hash: 'a'.repeat(64), content: 'typical body a'},
+        {id: 'raw-m', type: 'guide', name: 'monster',   hash: 'b'.repeat(64), content: 'monster body'},
+        {id: 'raw-b', type: 'guide', name: 'typical-b', hash: 'c'.repeat(64), content: 'typical body b'}
+    ];
+
+    const tenantContext = {tenantId: 't-undeliverable', repoSlug: 'org/undeliverable-geometry'};
+
+    test.beforeAll(async () => {
+        SDK                  = await import('../../../../../../ai/services.mjs');
+        KB_Config            = SDK.KB_Config;
+        Memory_Config        = SDK.Memory_Config;
+        TextEmbeddingService = SDK.Memory_TextEmbeddingService;
+
+        const VectorServiceModule = await import('../../../../../../ai/services/knowledge-base/VectorService.mjs');
+        const ChromaManagerModule = await import('../../../../../../ai/services/knowledge-base/ChromaManager.mjs');
+
+        KB_VectorService = VectorServiceModule.default;
+        ChromaManager    = ChromaManagerModule.default;
+
+        originalEmbedTexts     = TextEmbeddingService.embedTexts.bind(TextEmbeddingService);
+        originalGetCollection  = ChromaManager.getKnowledgeBaseCollection;
+        originalResumeStateDir = KB_VectorService.resumeStateDir;
+        originalBatchConfig    = {
+            batchSize : KB_Config.data.batchSize,
+            batchDelay: KB_Config.data.batchDelay,
+            maxRetries: KB_Config.data.maxRetries
+        };
+        originalCeiling = Memory_Config.embeddingProvider === 'ollama'
+            ? Memory_Config.ollama.embeddingTimeoutMs
+            : Memory_Config.openAiCompatible.batchEmbeddingTimeoutMs;
+
+        tmpDir     = await fs.mkdtemp(path.join(os.tmpdir(), 'neo-kb-undeliverable-'));
+        corpusFile = path.join(tmpDir, 'corpus.jsonl');
+
+        await fs.writeFile(corpusFile, chunks.map(chunk => JSON.stringify(chunk)).join('\n') + '\n');
+
+        KB_VectorService.resumeStateDir = path.join(tmpDir, 'state');
+        Object.assign(KB_Config.data, {batchSize: 50, batchDelay: 0, maxRetries: 3});
+    });
+
+    test.afterAll(async () => {
+        TextEmbeddingService.embedTexts           = originalEmbedTexts;
+        ChromaManager.getKnowledgeBaseCollection  = originalGetCollection;
+        KB_VectorService.resumeStateDir           = originalResumeStateDir;
+        Object.assign(KB_Config.data, originalBatchConfig);
+
+        if (Memory_Config.embeddingProvider === 'ollama') {
+            Memory_Config.ollama.embeddingTimeoutMs = originalCeiling;
+        } else {
+            Memory_Config.openAiCompatible.batchEmbeddingTimeoutMs = originalCeiling;
+        }
+
+        await fs.remove(tmpDir);
+    });
+
+    test('the monster graduates with the real poison store; typicals persist; a ceiling raise re-offers it', async () => {
+        const spy              = createSpyCollection();
+        const dispatchedInputs = [];
+
+        ChromaManager.getKnowledgeBaseCollection = async () => spy;
+
+        // The multi-input transport shape: one provider request holds every text it is given, and a
+        // request timeout is decorated with the producer span naming the WHOLE request — exactly what
+        // `#embedOpenAiCompatibleBatch` stamps. Single-input requests answer exactly.
+        TextEmbeddingService.embedTexts = async texts => {
+            dispatchedInputs.push([...texts]);
+
+            if (!texts.some(isMonsterText)) {
+                return texts.map(() => new Array(384).fill(0))
+            }
+
+            const error = new Error('request timed out');
+
+            error.code             = 'OPENAI_COMPATIBLE_REQUEST_TIMEOUT';
+            error.failedTextOffset = 0;
+            error.failedTextCount  = texts.length;
+            throw error
+        };
+
+        const runSweep = () => KB_VectorService.embed(corpusFile, {
+            deleteStale: false,
+            tenantContext
+        }).then(value => value, error => error);
+
+        // Sweep 1: one three-input request times out — suspicion only, no disposition may exist yet.
+        const first = await runSweep();
+        expect(first).toBeInstanceOf(Error);
+        expect(first.undeliverableGraduation).toBeUndefined();
+        expect(spy.storedByIds.size, 'a multi-input timeout persists nothing and fences nothing').toBe(0);
+
+        // Sweep 2: isolation — typical-A embeds alone and persists; the monster's single-input
+        // request earns its first exact strike; the sweep still ends on the timeout.
+        const second = await runSweep();
+        expect(second).toBeInstanceOf(Error);
+        expect(second.undeliverableGraduation).toBeUndefined();
+        expect(spy.storedByIds.size, 'the innocent isolation neighbour persists').toBe(1);
+
+        // Sweep 3: second exact strike — graduation writes the REAL poison-store marker, and the
+        // receipt rides the original timeout.
+        const third = await runSweep();
+        expect(third).toBeInstanceOf(Error);
+        expect(third.code, 'the original timeout identity survives graduation').toBe('OPENAI_COMPATIBLE_REQUEST_TIMEOUT');
+        expect(third.undeliverableGraduation).toMatchObject({attempts: 2});
+        expect(third.undeliverableGraduation.chunkId).toMatch(/^[a-f0-9]{64}$/);
+        expect(third.undeliverableGraduation.tokenEstimate).toBeGreaterThan(0);
+        expect(third.undeliverableGraduation.effectiveCeilingMs).toBe(Number(originalCeiling));
+
+        const monsterChunkId = third.undeliverableGraduation.chunkId;
+
+        // Sweep 4: the persisted disposition filters the monster out of batch assembly — the store
+        // read, the re-selection, and the census all run the production flow. Typical-B completes,
+        // the repo attempt RETURNS (sibling rotation is possible), and the census names the monster.
+        const monsterDispatchesBefore = dispatchedInputs.filter(texts => texts.some(isMonsterText)).length;
+        const fourth                  = await runSweep();
+
+        expect(fourth).not.toBeInstanceOf(Error);
+        expect(fourth.embedded).toBe(1);
+        expect(spy.storedByIds.size, 'both typicals persist; only the monster is excised').toBe(2);
+        expect(fourth.poisonedChunks).toEqual([expect.objectContaining({
+            chunkId   : monsterChunkId,
+            reasonCode: 'KB_VECTOR_EMBED_UNDELIVERABLE_AT_GEOMETRY'
+        })]);
+        expect(
+            dispatchedInputs.filter(texts => texts.some(isMonsterText)).length,
+            'a fenced chunk must never re-dispatch to the provider'
+        ).toBe(monsterDispatchesBefore);
+
+        // Sweep 5: a no-op sweep against the fence keeps returning the census rather than silence.
+        const fifth = await runSweep();
+        expect(fifth).not.toBeInstanceOf(Error);
+        expect(fifth.embedded).toBe(0);
+        expect(fifth.poisonedChunks.map(entry => entry.chunkId)).toEqual([monsterChunkId]);
+
+        // Operator ceiling raise: the effective call ceiling is part of the poison GENERATION, so the
+        // stored disposition goes stale and the monster is re-offered automatically — no replay flag.
+        if (Memory_Config.embeddingProvider === 'ollama') {
+            Memory_Config.ollama.embeddingTimeoutMs = Number(originalCeiling) + 60_000;
+        } else {
+            Memory_Config.openAiCompatible.batchEmbeddingTimeoutMs = Number(originalCeiling) + 60_000;
+        }
+
+        const sixth = await runSweep();
+
+        expect(sixth, 'a raised ceiling re-offers the chunk, so the sweep meets the timeout again').toBeInstanceOf(Error);
+        expect(
+            dispatchedInputs.filter(texts => texts.some(isMonsterText)).length,
+            'the generation change re-offered the previously fenced chunk'
+        ).toBeGreaterThan(monsterDispatchesBefore);
+    });
+});

--- a/test/playwright/unit/ai/services/memory-core/TextEmbeddingService.retry.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/TextEmbeddingService.retry.spec.mjs
@@ -954,6 +954,12 @@ test.describe.serial('TextEmbeddingService #11393/#11402/#12487/#12509 — openA
         expect(outcome.totalChunkCount).toBe(2);
         expect(outcome.completedTextCount).toBe(2);
         expect(outcome.embeddings).toEqual([[100], [101]]);
+
+        // The producer span: the failed REQUEST held texts [2, 4) — the consumer's undeliverable
+        // attribution needs the member set, because blaming the batch head for a multi-input
+        // request failure is how an innocent neighbour inherits a monster's strikes.
+        expect(outcome.failedTextOffset).toBe(2);
+        expect(outcome.failedTextCount).toBe(2);
     });
 
     test('a prefix that cannot prove positional binding leaves the failure UNCARRIED (#17112)', async () => {
@@ -972,6 +978,11 @@ test.describe.serial('TextEmbeddingService #11393/#11402/#12487/#12509 — openA
         expect(outcome.message).toContain('Some other bad request error');
         expect(outcome.completedTextCount).toBeUndefined();
         expect(outcome.embeddings).toBeUndefined();
+
+        // The producer span survives even when the carry cannot: it binds nothing (pure indices into
+        // what was sent), so an unprovable prefix must not strip the failed request's identity.
+        expect(outcome.failedTextOffset).toBe(2);
+        expect(outcome.failedTextCount).toBe(2);
     });
 
     test('batch embeddings split large requests into yieldable chunks and preserve global ordering', async () => {


### PR DESCRIPTION
Resolves neomjs/neo#17129

Related: neomjs/neo-agent-brain#38
Related: neomjs/neo#17112
Related: neomjs/neo#17132

Ends the chunk-level head-of-line block the operator named: one file too big for the clocks must never disable every file behind it. A chunk whose embed call ceiling expires on consecutive **exactly-attributed** attempts (leaf, default 2) is deterministically undeliverable at the current geometry — each further offer costs a full ceiling of blocking for every chunk and repository queued behind it. On the strike limit the chunk graduates to a durable disposition with a bounded receipt and is never dispatched again at that generation.

## Round-2 (review 4940058279 — all four actions)

**1. Attribution is exact, never head-blame.** A timeout from a multi-input provider request names the *request*, not a member — the Round-1 head struck `batchToEmbed[0]`, which under `[typical-A, monster, typical-B]` durably fences an innocent. Now:

- The OpenAI-compatible transport stamps every request failure with the producer span (`failedTextOffset`/`failedTextCount`) — pure indices into what was sent, decorated even when the carry cannot be proven (they bind nothing; they only *name* the span).
- A strike requires the failed request to have held **exactly one input**: a single-chunk dispatch (the only exactness the opaque native-ollama batch can offer) or a producer span of width 1 — which preserves the original 2-ceiling budget on the constrained plane's `chunkSize=1` geometry, including the carry-pinned mid-batch case.
- A multi-input timeout only marks its members as **isolation suspects**. The batch loop (now cursor-based) dispatches a suspect at the head of a batch *alone*: an innocent neighbour embeds and clears, a monster earns exact strikes. Suspicion costs one isolation offer, never a fence.

**2. The strike memory is a real automaton.** Generation-scoped process-local state (`{strikes, suspects, seq}`), replaced whole on any generation change — evidence gathered under one ceiling is not "consecutive" with evidence under another. Consecutive means consecutive: any dispatched non-timeout provider outcome for a chunk (success, non-timeout failure, or provider-success-then-storage-failure — reset happens *before* the upsert) deletes its entry. An overlap guard (`dispatchSeq` vs `lastStrikeSeq`) refuses to count a strike whose attempt was dispatched before the previous strike was recorded, so two overlapping observations of one wall-clock failure window cannot fabricate a sequential pair. Circuit-open-without-dispatch stays neutral.

**3. The receipt and census are real surfaces.**

- Graduation mints `{chunkId, tokenEstimate, attempts, effectiveCeilingMs}` and decorates it onto the *original* timeout (never replacing it); `IngestionService` re-validates it field-by-field into the ingest summary's error details, and labels fence rows with the correct `undeliverable-at-geometry` disposition instead of `proven-content-poison`.
- The AC-3 census `{count, ids}` travels ingest summary → `TenantRepoSyncService` checkpoint (deferred AND completed branches) → `tenantRepoCheckpointValidity` fail-closed normalizer → `DeploymentStateBridgeService` snapshot, projected unconditionally beside `corpusOutstanding`. Torn records degrade whole to null at both reader boundaries.
- **Complete-vs-deferred truth-folded:** a run whose only error rows are the durable fence classifies **complete** — deferral means "coming back may finish the work", the opposite of what a fence asserts; a held checkpoint would re-materialize the same delta every sweep forever. One live deferrable failure beside fences still defers, and the fence code is excluded from recovery-cause selection so it cannot arm an embedding-recovery canary whose probe can't re-offer anything.

**4. Rebased onto current dev**; parity snapshot and retry-bound registry regenerated on the new base.

**Found by the demanded production-path spec — a Round-1 correctness bug beyond the review's list:** `createEmbeddingGenerationId` hashed a fixed four-field tuple and silently dropped `embedCallCeilingMs` from the coordinate object, so "a raised ceiling re-offers the chunk" was true in prose and false in the store. The hash now takes the ceiling as an optional fifth coordinate (election callers pass four — their persisted hashes are untouched; the poison fence passes five). Deploying this PR is itself a one-time generation change: existing poison markers go stale and re-prove once, the deliberate correctness-over-thrift cost the ticket already declares.

## Design invariants kept from Round-1

1. **Zero new persistence machinery** — the disposition rides the existing poison store: atomic merge, batch-assembly re-selection filter, `poisonedChunks` census, operator replay-clear, all unchanged.
2. **The graduating sweep still ends** per the abandoned-work rule; the NEXT sweep proceeds past the excised chunk on an idle engine.
3. **Fail-open persist**: a disposition writer failure neither masks the original timeout nor suppresses the chunk — strikes retained, no receipt minted for a disposition that did not persist.

Evidence: L2 (production-path `VectorService.embed()` driven across six sweeps with the REAL poison store on disk and a multi-input transport shape: suspicion → isolation → graduation-with-receipt → fence-filtered completion → census-on-no-op → ceiling-raise re-offer; plus automaton arms for attribution, resets, overlap, generation keying; plus the tenant-sync composition through real `runTask` for complete-vs-deferred and the census checkpoint; plus normalizer and snapshot-projection torn-shape arms) → L4 required (constrained-plane behavior: small files flowing past a monster within the strike budget). Residual: live-plane validation rides the next revision advance, Residual-Owner: neomjs/neo-agent-brain#38.

## Deltas from ticket

- AC-1/AC-4 amended in Round-2 (originals preserved in the body, amendment note in [#17129 comment](https://github.com/neomjs/neo/issues/17129#issuecomment-5297866570)): exact attribution replaces "at the batch head"; the two-sweep arithmetic holds for single-input geometry, multi-input costs one suspicion sweep + two isolation strikes.
- AC-3 amended: fence-only runs classify complete; the census (not a held checkpoint) is the visibility mechanism.
- Contract Ledger corrected: leaf authority path is `ai/mcp/server/knowledge-base/configBase.mjs`; the generation row names the optional-fifth-coordinate mechanism.

## Test Evidence

*(All verdicts read from the runner's exit code, never a tail slice.)*

- `npx playwright test -c test/playwright/playwright.config.unit.mjs test/playwright/unit/ai/services/knowledge-base/VectorService.failureCarry.spec.mjs --workers=1` — **exit 0, 14 passed** (5 carry arms kept; 8 attribution/automaton arms incl. the reviewer's `[typical-A, monster, typical-B]` matrix with the monster deliberately NOT at index 0, the mid-batch carry-pinned case, timeout→500→timeout, timeout→success/write-fail→timeout, two overlapping timeouts, generation-A/generation-B).
- `npx playwright test -c test/playwright/playwright.config.unit.mjs test/playwright/unit/ai/services/knowledge-base/VectorService.undeliverableGeometry.spec.mjs --workers=1` — **exit 0, 1 passed** (both core specs re-verified together post-commit at the pushed head: 17 passed incl. Chroma setup/teardown) (the AC-4 production-path proof through `embed()` + real poison store + generation-invalidation property pin).
- Importer-coverage battery under the canonical unit config (`-c test/playwright/playwright.config.unit.mjs`, 49 spec files across knowledge-base, memory-core, orchestrator, deploy, shared/vector — every spec whose file mentions a changed basename) — exit 0 across two runs, plus a 132-test re-run of the tenant-sync spec after the deferred-census carry fix.
- **CI falsified one spec my battery had reported green** (`VectorService.persistenceNonConvergence.spec.mjs` neomjs/neo#17112 AC-2 arm, sole failure in 13,327): its transport stub emitted a carried timeout WITHOUT the producer span — a shape the real transport no longer produces — which trips the classifier's conservative unknown-member fallback and suspects the whole dispatch. Fixed at `63186290ac` by modeling the honest producer contract (span width 5 at offset 10) and truth-folding the call-shape assertion: the AC-2 noun is preserved exactly (re-purchase total = the un-persisted 40, zero overlap with the persisted prefix), and the new shape `[50, 1×5, 35]` pins the real post-timeout behavior — the timed-out request's members isolate first, the untainted remainder ships as one batch. Verified solo (10 passed) and in the reproducing five-file combination (51 passed).
- `npm run ai:lint-retry-bounds` — all classified, run as the LAST local gate before push.
- Config-leaf-parity snapshot verified on the rebased base.
- Pre-commit gate battery passed.

## Post-Merge Validation

Residual-Owner: neomjs/neo-agent-brain#38

- [ ] On the constrained plane at the next revision advance: the head monster graduates within its strike budget, after which every typical chunk behind it embeds and the repo's attempt classifies complete-with-census (sibling rotation observed).
- [ ] The deployment surface shows `undeliverableChunks {count, ids}` on the affected repo row; an operator ceiling raise (tracked compose) re-offers the chunk automatically via the generation change.

## Evolution

The Round-1 review demanded the production-path spec, and the spec immediately caught a bug the review itself had not named: the generation hash ignored the ceiling coordinate the whole re-offer story depended on. The pin test I had written asserted the field's *presence* on the coordinate object — presence is not the property. The lesson is now structural: the generation-invalidation arm drives the real store through a real ceiling change and asserts the re-offer itself.

Authored by Vega (Claude Fable 5, Claude Code). Sessions d697d846-508f-47c2-a928-95610fac1cdd (Round-1), c83a22f5-585f-44b2-aa98-93e00d3aa4f8 (Round-2).
