### PR TITLE
fix(build): an optional DevIndex intake denial no longer freezes corpus publication (#17148)

### DIFF
--- a/buildScripts/dataSyncPipeline.mjs
+++ b/buildScripts/dataSyncPipeline.mjs
@@ -85,29 +85,44 @@ const
             publishGeneratedProgressOnFailure: true,
             tokenScope                       : 'reader'
         },
+        // The four DevIndex stages below ENRICH the DevIndex product; they do not produce the corpus
+        // this repository publishes. Without the deferral flag they were fatal to publication: a
+        // denial on the very first of them threw out of the loop, so the remaining stages — including
+        // `content indexes and SEO`, which is what makes the corpus consumable — never ran and the
+        // corpus generated above was discarded unpublished. A GitHub-side denial on the opt-in
+        // stargazer read froze `resources/content/**` on `dev` for nineteen hours that way, and every
+        // downstream consumer (portal data, KB ingestion) read the frozen corpus.
+        //
+        // Deferring does NOT soften the failure: `deferredError` is rethrown after publish, so the
+        // run still exits non-zero and the standing alarm still fires. It only stops an optional
+        // enrichment read from deciding whether the corpus gets published.
         {
-            args      : ['run', 'devindex:optin'],
-            command   : 'npm',
-            label     : 'DevIndex Opt-In',
-            tokenScope: 'intake'
+            args                             : ['run', 'devindex:optin'],
+            command                          : 'npm',
+            label                            : 'DevIndex Opt-In',
+            publishGeneratedProgressOnFailure: true,
+            tokenScope                       : 'intake'
         },
         {
-            args      : ['run', 'devindex:optout'],
-            command   : 'npm',
-            label     : 'DevIndex Opt-Out',
-            tokenScope: 'intake'
+            args                             : ['run', 'devindex:optout'],
+            command                          : 'npm',
+            label                            : 'DevIndex Opt-Out',
+            publishGeneratedProgressOnFailure: true,
+            tokenScope                       : 'intake'
         },
         {
-            args      : ['run', 'devindex:spider', '--', '--strategy', 'random'],
-            command   : 'npm',
-            label     : 'DevIndex Spider',
-            tokenScope: 'intake'
+            args                             : ['run', 'devindex:spider', '--', '--strategy', 'random'],
+            command                          : 'npm',
+            label                            : 'DevIndex Spider',
+            publishGeneratedProgressOnFailure: true,
+            tokenScope                       : 'intake'
         },
         {
-            args      : ['run', 'devindex:update', '--', '--limit=200'],
-            command   : 'npm',
-            label     : 'DevIndex Updater',
-            tokenScope: 'intake'
+            args                             : ['run', 'devindex:update', '--', '--limit=200'],
+            command                          : 'npm',
+            label                            : 'DevIndex Updater',
+            publishGeneratedProgressOnFailure: true,
+            tokenScope                       : 'intake'
         },
         {
             // `--include-labels` reaches `LabelService.listLabels`, which pages this repository's
@@ -571,14 +586,43 @@ async function recoverStaleAttempt({
 }
 
 /**
+ * @summary Folds every deferred stage failure into the single error the publish path rethrows.
+ *
+ * The publish path rethrows ONE error, so a lone `deferredError` slot kept only whichever stage
+ * failed last: one denial that failed all four DevIndex stages reported one of them and dropped
+ * three, and the outage read as narrower than it was. The aggregate spells every cause into
+ * `message` — a CI log tail shows the message and nothing else — while `AggregateError#errors`
+ * keeps the originals reachable for anything inspecting them programmatically.
+ *
+ * A single failure returns unwrapped: wrapping it would bury the one message that matters behind a
+ * count of one, and every existing consumer already reads that error directly.
+ * @param {Error[]} errors Deferred failures, in the order their stages ran.
+ * @returns {Error} `errors[0]` when it is the only one, otherwise an `AggregateError` over all.
+ */
+export function aggregateDeferredFailures(errors) {
+    if (errors.length === 1) {
+        return errors[0]
+    }
+
+    return new AggregateError(
+        errors,
+        `[DataSync] ${errors.length} stages deferred a failure; all of them are reported below.\n\n` +
+        errors.map((error, index) => `(${index + 1}/${errors.length}) ${error.message}`).join('\n\n')
+    )
+}
+
+/**
  * @summary Runs the complete generated-output emission sequence for one fresh-head attempt.
  * @param {Object}   options
  * @param {Number}   options.attempt Current attempt number.
  * @param {String}   options.cwd Repository root.
  * @param {Function} options.execute Child-process executor.
  * @param {Function} options.log Telemetry sink.
- * @returns {Promise<void|{deferredError: Error}>} Deferred corpus failure whose safe generated
- * progress must be published before the original error is reported.
+ * @param {Function} [options.preflight=assertDataSyncAccess] Intake credential-topology probe. Its
+ * denial is deferred rather than thrown, so it cannot re-couple corpus publication to the intake
+ * identity that the stage table just decoupled it from.
+ * @returns {Promise<void|{deferredError: Error}>} Deferred failure — a preflight denial and/or every
+ * stage that deferred one — whose safe generated progress must be published before it is reported.
  */
 export async function emitGeneratedData({
     attempt,
@@ -591,7 +635,29 @@ export async function emitGeneratedData({
     // collection stages depend on. A denial here survives its full retry budget AND precedes all work, so
     // it is the installation answering rather than a transient read — the distinction the shared
     // message string cannot make, and the one whose absence cost sixty silent scheduled runs.
-    await preflight({log, token: scopedStageEnv('intake').GITHUB_TOKEN});
+    //
+    // DEFERRED, not fatal. This probe guards exactly the `intake` identity, and every stage declaring
+    // that identity now defers its failure so an enrichment denial cannot decide whether the corpus
+    // publishes. Rethrowing here would reinstate that coupling one layer earlier — the guard becoming
+    // the single point of failure the stages below no longer are — and the corpus would stay frozen
+    // for the same reason, just faster. It still reaches the run's exit non-zero via the deferral.
+    let preflightError = null;
+
+    try {
+        await preflight({log, token: scopedStageEnv('intake').GITHUB_TOKEN})
+    } catch (error) {
+        // Preflight-only mode exists to ANSWER the credential-topology question, so there the denial
+        // is the requested result and must surface directly rather than as a deferral nothing reads.
+        if (process.env.DATA_SYNC_PREFLIGHT_ONLY === 'true') {
+            throw error
+        }
+
+        preflightError = error;
+        log(
+            `[DataSync] emit attempt=${attempt} stage=preflight result=deferred-failure ` +
+            'action=skip-intake-stages-publish-generated-progress-then-fail'
+        )
+    }
 
     // Credential-topology check with no side effects. The collection stages mutate — OptOut comments
     // on and closes real issues — so a configuration check that must run them is one nobody repeats
@@ -601,7 +667,10 @@ export async function emitGeneratedData({
         return
     }
 
-    let deferredError = null;
+    // EVERY deferred failure, not the last one. A single slot silently dropped three of the four
+    // DevIndex stages when one denial failed them all, so the run reported one cause and hid the
+    // rest — and the operator sized the outage from whichever happened to run last.
+    const deferredErrors = preflightError ? [preflightError] : [];
 
     for (const {
         args,
@@ -610,6 +679,18 @@ export async function emitGeneratedData({
         publishGeneratedProgressOnFailure = false,
         tokenScope
     } of emissionCommands) {
+        // The preflight already proved this identity cannot serve its repositories, so every stage
+        // declaring it fails the same way. Skipping them keeps ONE reported cause instead of five
+        // copies of it, and derives the skipped set from `tokenScope` — the declaration that already
+        // exists — rather than a second hand-maintained flag free to drift from it.
+        if (preflightError && tokenScope === 'intake') {
+            log(
+                `[DataSync] emit attempt=${attempt} stage=${label} result=skipped ` +
+                'reason=intake-preflight-denied'
+            );
+            continue
+        }
+
         log(`[DataSync] emit attempt=${attempt} stage=${label} credential=${tokenScope}`);
 
         try {
@@ -637,7 +718,7 @@ export async function emitGeneratedData({
                 `Declared credential scope: \`${tokenScope}\`.\n${error.message}`;
 
             if (publishGeneratedProgressOnFailure) {
-                deferredError = error;
+                deferredErrors.push(error);
                 log(
                     `[DataSync] emit attempt=${attempt} stage=${label} result=deferred-failure ` +
                     'action=publish-generated-progress-then-fail'
@@ -649,8 +730,8 @@ export async function emitGeneratedData({
         }
     }
 
-    if (deferredError) {
-        return {deferredError}
+    if (deferredErrors.length > 0) {
+        return {deferredError: aggregateDeferredFailures(deferredErrors)}
     }
 }
 

--- a/buildScripts/dataSyncPipeline.mjs
+++ b/buildScripts/dataSyncPipeline.mjs
@@ -655,7 +655,7 @@ export async function emitGeneratedData({
         preflightError = error;
         log(
             `[DataSync] emit attempt=${attempt} stage=preflight result=deferred-failure ` +
-            'action=skip-intake-stages-publish-generated-progress-then-fail'
+            'action=run-all-stages-publish-generated-progress-then-fail'
         )
     }
 
@@ -672,6 +672,19 @@ export async function emitGeneratedData({
     // rest — and the operator sized the outage from whichever happened to run last.
     const deferredErrors = preflightError ? [preflightError] : [];
 
+    // NOTHING is skipped on a preflight denial, and the earlier `tokenScope === 'intake'` skip was
+    // wrong for a reason worth keeping: a credential-scope declaration says which identity to INJECT,
+    // never which capability a stage CONSUMES. One denied `devindex-opt-in.stargazers` probe was
+    // enough to skip Opt-Out, Spider and Updater purely because all four name the same token — yet
+    // Spider queries search/community endpoints and Updater reads `users/:name/orgs`, so neither
+    // touches a DevIndex repository at all. That skip stopped healthy work to save a few seconds of
+    // predicted failure, re-coupling at the credential layer exactly what the stage table above had
+    // just decoupled.
+    //
+    // Letting every stage run and fail on its own merits is both simpler and strictly more accurate
+    // than any static capability map, which could only drift from what the services actually call.
+    // The cost is a few seconds of stages we expect to fail; the aggregate below numbers each cause,
+    // so a shared root reads as related failures rather than one arbitrary survivor.
     for (const {
         args,
         command,
@@ -679,18 +692,6 @@ export async function emitGeneratedData({
         publishGeneratedProgressOnFailure = false,
         tokenScope
     } of emissionCommands) {
-        // The preflight already proved this identity cannot serve its repositories, so every stage
-        // declaring it fails the same way. Skipping them keeps ONE reported cause instead of five
-        // copies of it, and derives the skipped set from `tokenScope` — the declaration that already
-        // exists — rather than a second hand-maintained flag free to drift from it.
-        if (preflightError && tokenScope === 'intake') {
-            log(
-                `[DataSync] emit attempt=${attempt} stage=${label} result=skipped ` +
-                'reason=intake-preflight-denied'
-            );
-            continue
-        }
-
         log(`[DataSync] emit attempt=${attempt} stage=${label} credential=${tokenScope}`);
 
         try {

--- a/buildScripts/dataSyncPreflight.mjs
+++ b/buildScripts/dataSyncPreflight.mjs
@@ -38,6 +38,43 @@ export const REQUIRED_REPOSITORIES = [
 const DENIAL_PATTERN = /resource not accessible by integration|not accessible|bad credentials|requires authentication/i;
 
 /**
+ * @summary Remediation text for a denial, derived from the CONNECTION that was refused.
+ *
+ * A single fixed remedy is worse than none once it can be wrong. Every denial used to print
+ * "install the App with `Issues: Read and write` and `Metadata: Read`" — permissions the workflow
+ * ALREADY requests at `.github/workflows/data-sync-pipeline.yml`. So the one message an operator
+ * reads while diagnosing a stargazer denial instructed them to go confirm the state they were
+ * already in, and the guidance itself became a detour.
+ *
+ * These strings deliberately stop at what is published and observed. GitHub announced the
+ * stargazer restriction and its admin/collaborator boundary; it did not publish an enforcement
+ * schedule, and it says nothing about installation tokens — so the text must not assert a rollout
+ * mechanism, a permanence, or a fix that has not been demonstrated to work.
+ * @param {String} connection Repository connection that was refused, e.g. `stargazers`.
+ * @returns {String}
+ */
+function denialRemedy(connection) {
+    if (connection === 'stargazers') {
+        return 'GitHub limits stargazer reads to repository ADMINS AND COLLABORATORS (announced ' +
+            '2026-06-30). That is account STATUS, not an App permission — so `Metadata: Read` being ' +
+            'present does not imply this read is permitted, and widening App permissions may not ' +
+            'restore it. Determine whether the intake identity holds admin/collaborator access on ' +
+            'THIS repository; if it cannot, the stargazer-sourced path is unavailable and must be ' +
+            'retired or replaced rather than re-permissioned.'
+    }
+
+    if (connection === 'issues') {
+        return 'Verify the intake App is installed on THIS repository with `Issues: Read and write`.'
+    }
+
+    // Named, not guessed. A connection with no mapped remedy gets the one instruction that is true
+    // for every capability — check what this specific read requires — instead of inheriting another
+    // connection's advice, which is the defect this function exists to remove.
+    return `No mapped remedy for connection \`${connection}\`; establish what access that specific ` +
+        'read requires before changing any permission.'
+}
+
+/**
  * @summary Issues one minimal, un-retried GraphQL read that exercises the connection this
  * repository is actually here for.
  *
@@ -153,7 +190,7 @@ export async function assertDataSyncAccess({
         log(`[DataSync preflight] ${owner}/${name} ${ok ? 'reachable' : 'DENIED'} (${purpose})`);
 
         if (!ok) {
-            failures.push({name, owner, purpose, reason})
+            failures.push({connection, name, owner, purpose, reason})
         }
     }
 
@@ -171,11 +208,10 @@ export async function assertDataSyncAccess({
     // "Persistent" means EXHAUSTED, not merely early: pre-work timing rules out mid-batch contention,
     // and the spent retry budget rules out a single unlucky first call. Neither claim suffices alone.
     const detail = failures
-        .map(({name, owner, purpose, reason}) => {
+        .map(({connection, name, owner, purpose, reason}) => {
             const remedy = DENIAL_PATTERN.test(reason)
                 ? 'PERSISTENT authorization failure — the credential was rejected on every attempt. ' +
-                  'Verify the intake App is installed on THIS repository with `Issues: Read and write` ' +
-                  'and `Metadata: Read`.'
+                  denialRemedy(connection)
                 : 'Transport or availability fault — the credential was never rejected here, so the ' +
                   'installation is not implicated.';
 

--- a/buildScripts/dataSyncPreflight.mjs
+++ b/buildScripts/dataSyncPreflight.mjs
@@ -31,22 +31,32 @@
  * @type {Object[]}
  */
 export const REQUIRED_REPOSITORIES = [
-    {name: 'devindex-opt-in',  owner: 'neomjs', purpose: 'OptIn stargazer read'},
-    {name: 'devindex-opt-out', owner: 'neomjs', purpose: 'OptOut issue read + close'}
+    {connection: 'stargazers', name: 'devindex-opt-in',  owner: 'neomjs', purpose: 'OptIn stargazer read'},
+    {connection: 'issues',     name: 'devindex-opt-out', owner: 'neomjs', purpose: 'OptOut issue read + close'}
 ];
 
 const DENIAL_PATTERN = /resource not accessible by integration|not accessible|bad credentials|requires authentication/i;
 
 /**
- * @summary Issues one minimal, un-retried GraphQL read against a repository.
+ * @summary Issues one minimal, un-retried GraphQL read that exercises the connection this
+ * repository is actually here for.
+ *
+ * It probed `repository{id}` alone, which resolves from repository metadata — so it answered "can
+ * this identity see the repository", never "can it perform the read named in `purpose`". Those came
+ * apart in production: `devindex-opt-in reachable (OptIn stargazer read)` was logged by a run whose
+ * stargazer read was denied twelve minutes later, and the log line asserting coverage is what sent
+ * diagnosis away from the credential. Selecting the named connection closes the gap between what
+ * this probe proves and what its `purpose` claims.
  * @param {Object}   options
  * @param {String}   options.owner Repository owner.
  * @param {String}   options.name Repository name.
+ * @param {String}   options.connection Repository connection the consuming stage reads, e.g.
+ * `stargazers`. This is the field `purpose` names, so the probe and the claim cannot drift apart.
  * @param {String}   options.token Installation token to probe with.
  * @param {Function} [options.fetchFn=fetch] Injectable transport.
  * @returns {Promise<{ok: Boolean, reason: String|null}>}
  */
-export async function probeRepository({owner, name, token, fetchFn = fetch}) {
+export async function probeRepository({owner, name, connection, token, fetchFn = fetch}) {
     let response, body;
 
     // A transport failure — ECONNRESET, DNS, TLS — is the single most common transient class, and it
@@ -63,7 +73,10 @@ export async function probeRepository({owner, name, token, fetchFn = fetch}) {
                 'Content-Type': 'application/json'
             },
             body: JSON.stringify({
-                query    : 'query($owner:String!,$name:String!){repository(owner:$owner,name:$name){id}}',
+                // `first: 1` keeps this as cheap as the id-only probe it replaces: one edge proves
+                // the connection is readable, and the pipeline never uses the returned page.
+                query: 'query($owner:String!,$name:String!){repository(owner:$owner,name:$name)' +
+                    `{id ${connection}(first:1){pageInfo{hasNextPage}}}}`,
                 variables: {name, owner}
             })
         });
@@ -76,7 +89,11 @@ export async function probeRepository({owner, name, token, fetchFn = fetch}) {
     // A GraphQL denial arrives as HTTP 200 with an `errors` array, so status alone is not the test.
     const message = body?.errors?.map(error => error.message).join('; ') || '';
 
-    if (body?.data?.repository?.id) {
+    // BOTH selections, because GraphQL answers a partial denial with partial DATA: `id` resolves
+    // from repository metadata while the denied connection returns null beside an `errors` entry.
+    // Testing `id` alone would read that exact response — the one this probe exists to catch — as a
+    // success, which is how the id-only probe passed while the stargazer read was already denied.
+    if (body?.data?.repository?.id && body.data.repository[connection]) {
         return {ok: true, reason: null}
     }
 
@@ -111,7 +128,7 @@ export async function assertDataSyncAccess({
 
     const failures = [];
 
-    for (const {name, owner, purpose} of repositories) {
+    for (const {connection, name, owner, purpose} of repositories) {
         // BOUNDED, not single-shot. The timing argument this preflight rests on separates
         // mid-batch flakiness from a pre-work denial — it does NOT rule out a flaky FIRST call.
         // Declaring one denial permanently authorized because of when it happened would trade a
@@ -123,7 +140,7 @@ export async function assertDataSyncAccess({
         let ok = false, reason = null;
 
         for (let attempt = 1; attempt <= attempts; attempt++) {
-            ({ok, reason} = await probeRepository({fetchFn, name, owner, token}));
+            ({ok, reason} = await probeRepository({connection, fetchFn, name, owner, token}));
 
             if (ok) break;
 

--- a/test/playwright/unit/ai/buildScripts/DataSyncPipeline.spec.mjs
+++ b/test/playwright/unit/ai/buildScripts/DataSyncPipeline.spec.mjs
@@ -8,6 +8,7 @@ import process        from 'node:process';
 import {CREDENTIAL_FAMILIES} from '../../../../../ai/services/fleet/redactCredentials.mjs';
 
 import {
+    aggregateDeferredFailures,
     classifyStageFailure,
     describeStageFailure,
     emitGeneratedData,
@@ -666,6 +667,146 @@ test.describe('tokenScope validation fails closed', () => {
         for (const error of codes) {
             expect(classifyStageFailure(error), error.message).toBe(STAGE_FAILURE_CLASS.authentication)
         }
+    });
+});
+
+/**
+ * An optional DevIndex enrichment read must not decide whether the corpus publishes.
+ *
+ * `DevIndex Opt-In` is stage 3 of 7 and threw straight out of the emission loop, so a GitHub-side
+ * denial on its stargazer read skipped stages 4-7 — including `content indexes and SEO`, which is
+ * what makes the corpus consumable — and the publish path below the loop was never reached. The
+ * corpus generated one stage earlier was discarded: `resources/content/**` on `dev` froze for
+ * nineteen hours while every downstream consumer (portal data, KB ingestion) read the stale mirror.
+ *
+ * The isolation must not become suppression. The run still has to exit non-zero, because a green
+ * pipeline would assert a DevIndex intake that is in fact dead — so every test below that proves the
+ * corpus published is paired with one proving the run still failed.
+ */
+test.describe('an intake denial cannot freeze corpus publication (#17148)', () => {
+    /** Fails exactly the stages whose npm script is named, so one denial can be aimed at a stage set. */
+    const failingScripts = scripts => async (_command, args) => {
+        if (args.some(arg => scripts.includes(arg))) {
+            throw new Error(`Resource not accessible by integration (${args.join(' ')})`)
+        }
+    };
+
+    test('a denied Opt-In no longer aborts emission — every later stage still runs', async () => {
+        const lines = [];
+
+        const {deferredError} = await emitGeneratedData({
+            attempt  : 1,
+            cwd      : '/tmp',
+            execute  : failingScripts(['devindex:optin']),
+            log      : line => lines.push(line),
+            preflight: async () => {}
+        });
+
+        // The decisive assertion: this stage runs AFTER all four intake stages and is what makes the
+        // corpus consumable. Before the deferral flag the loop threw three stages earlier.
+        expect(lines.some(line => line.includes('stage=content indexes and SEO'))).toBe(true);
+        expect(lines.some(line => line.includes('stage=DevIndex Opt-Out'))).toBe(true);
+        // Deferred, never dropped — the caller still receives the failure to rethrow after publish.
+        expect(deferredError.message).toContain('DevIndex Opt-In')
+    });
+
+    test('the corpus publishes AND the run still fails when Opt-In is denied', async () => {
+        const fixture = await createRepositoryFixture();
+
+        try {
+            await expect(runDataSyncPipeline({
+                cwd : fixture.runner,
+                emit: async ({attempt, cwd, log}) => {
+                    await write(cwd, generatedFile, 'generated:corpus-despite-denial\n');
+
+                    return emitGeneratedData({
+                        attempt,
+                        cwd,
+                        execute  : failingScripts(['devindex:optin']),
+                        log,
+                        preflight: async () => {}
+                    })
+                },
+                log: () => {}
+            })).rejects.toThrow(/DevIndex Opt-In/);
+
+            // Both halves ARE the finding, and each alone would be the wrong outcome: the corpus
+            // reached `dev` (the freeze is over) and the run still failed (the alarm is not silenced).
+            expect(readRemoteFile(fixture, generatedFile)).toBe('generated:corpus-despite-denial');
+            expect(remoteSubjects(fixture)[0]).toBe('chore(data): Hourly data sync pipeline update [skip ci]')
+        } finally {
+            await fs.rm(fixture.root, {recursive: true, force: true})
+        }
+    });
+
+    test('every deferred stage failure is named, not just the last one', async () => {
+        // One credential denial fails all four DevIndex stages, so a single `deferredError` slot
+        // reported whichever ran last and silently dropped the rest — sizing the outage wrong.
+        const {deferredError} = await emitGeneratedData({
+            attempt  : 1,
+            cwd      : '/tmp',
+            execute  : failingScripts(['devindex:optin', 'devindex:optout', 'devindex:update']),
+            log      : () => {},
+            preflight: async () => {}
+        });
+
+        expect(deferredError.message).toContain('DevIndex Opt-In');
+        expect(deferredError.message).toContain('DevIndex Opt-Out');
+        expect(deferredError.message).toContain('DevIndex Updater');
+        expect(deferredError.errors).toHaveLength(3)
+    });
+
+    test('a lone deferred failure is reported unwrapped, not buried under a count of one', async () => {
+        const {deferredError} = await emitGeneratedData({
+            attempt  : 1,
+            cwd      : '/tmp',
+            execute  : failingScripts(['devindex:spider']),
+            log      : () => {},
+            preflight: async () => {}
+        });
+
+        expect(deferredError).not.toBeInstanceOf(AggregateError);
+        expect(deferredError.message).toContain('DevIndex Spider')
+    });
+
+    test('aggregateDeferredFailures keeps the originals reachable, not just their text', () => {
+        const failures = [new Error('first cause'), new Error('second cause')];
+        const folded   = aggregateDeferredFailures(failures);
+
+        // The message carries both because a CI log tail shows the message and nothing else...
+        expect(folded.message).toContain('first cause');
+        expect(folded.message).toContain('second cause');
+        // ...while `errors` keeps them inspectable for anything reading them programmatically.
+        expect(folded.errors).toEqual(failures);
+        expect(aggregateDeferredFailures([failures[0]])).toBe(failures[0])
+    });
+
+    test('a preflight denial defers and SKIPS the intake stages instead of aborting the run', async () => {
+        const
+            denial   = new Error('[DataSync preflight] neomjs/devindex-opt-in DENIED (OptIn stargazer read)'),
+            executed = [],
+            lines    = [];
+
+        const {deferredError} = await emitGeneratedData({
+            attempt  : 1,
+            cwd      : '/tmp',
+            execute  : async (_command, args) => {executed.push(args.join(' '))},
+            log      : line => lines.push(line),
+            preflight: async () => {throw denial}
+        });
+
+        // Rethrowing here would re-couple publication to the intake identity one layer ABOVE the
+        // stage table that just decoupled it — the corpus would stay frozen, only faster.
+        expect(deferredError).toBe(denial);
+
+        // The intake stages are skipped: the preflight already proved they fail the same way, so
+        // running them would report one cause four times.
+        expect(executed.some(args => args.includes('devindex:'))).toBe(false);
+        expect(lines.some(line => line.includes('reason=intake-preflight-denied'))).toBe(true);
+
+        // The reader-scoped stages still run — that is what leaves a corpus worth publishing.
+        expect(executed.some(args => args.includes('--emit-only'))).toBe(true);
+        expect(executed.some(args => args.includes('--include-labels'))).toBe(true)
     });
 });
 

--- a/test/playwright/unit/ai/buildScripts/DataSyncPipeline.spec.mjs
+++ b/test/playwright/unit/ai/buildScripts/DataSyncPipeline.spec.mjs
@@ -781,17 +781,16 @@ test.describe('an intake denial cannot freeze corpus publication (#17148)', () =
         expect(aggregateDeferredFailures([failures[0]])).toBe(failures[0])
     });
 
-    test('a preflight denial defers and SKIPS the intake stages instead of aborting the run', async () => {
+    test('a preflight denial defers and does NOT abort the run', async () => {
         const
             denial   = new Error('[DataSync preflight] neomjs/devindex-opt-in DENIED (OptIn stargazer read)'),
-            executed = [],
-            lines    = [];
+            executed = [];
 
         const {deferredError} = await emitGeneratedData({
             attempt  : 1,
             cwd      : '/tmp',
             execute  : async (_command, args) => {executed.push(args.join(' '))},
-            log      : line => lines.push(line),
+            log      : () => {},
             preflight: async () => {throw denial}
         });
 
@@ -799,14 +798,35 @@ test.describe('an intake denial cannot freeze corpus publication (#17148)', () =
         // stage table that just decoupled it — the corpus would stay frozen, only faster.
         expect(deferredError).toBe(denial);
 
-        // The intake stages are skipped: the preflight already proved they fail the same way, so
-        // running them would report one cause four times.
-        expect(executed.some(args => args.includes('devindex:'))).toBe(false);
-        expect(lines.some(line => line.includes('reason=intake-preflight-denied'))).toBe(true);
-
         // The reader-scoped stages still run — that is what leaves a corpus worth publishing.
         expect(executed.some(args => args.includes('--emit-only'))).toBe(true);
         expect(executed.some(args => args.includes('--include-labels'))).toBe(true)
+    });
+
+    test('one denied capability does not stop the stages that never consume it', async () => {
+        // The decisive regression for the review finding. An earlier revision skipped every stage
+        // declaring `tokenScope: 'intake'` the moment ANY preflight probe failed — so a denied
+        // `devindex-opt-in.stargazers` read stopped Opt-Out, Spider and Updater as well. Verified
+        // against the services: Spider queries search/community endpoints and Updater reads
+        // `users/:name/orgs`, so NEITHER touches a DevIndex repository. `tokenScope` says which
+        // credential to inject, never which capability a stage consumes, and the skip made it mean
+        // both.
+        const executed = [];
+
+        const {deferredError} = await emitGeneratedData({
+            attempt  : 1,
+            cwd      : '/tmp',
+            execute  : async (_command, args) => {executed.push(args.join(' '))},
+            log      : () => {},
+            preflight: async () => {throw new Error('neomjs/devindex-opt-in DENIED (OptIn stargazer read)')}
+        });
+
+        for (const script of ['devindex:optout', 'devindex:spider', 'devindex:update']) {
+            expect(executed.some(args => args.includes(script)), `${script} must still run`).toBe(true)
+        }
+
+        // ...and the run still carries the denial to a non-zero exit after publication.
+        expect(deferredError.message).toContain('devindex-opt-in')
     });
 });
 

--- a/test/playwright/unit/ai/buildScripts/DataSyncPreflight.spec.mjs
+++ b/test/playwright/unit/ai/buildScripts/DataSyncPreflight.spec.mjs
@@ -10,6 +10,20 @@ import {
 const noWait = async () => {};
 
 /**
+ * A repository whose id AND both probed connections resolve.
+ *
+ * The connections are load-bearing: the probe selects the one its `REQUIRED_REPOSITORIES` entry
+ * names, and GitHub answers a partial denial with the id present and that connection null. A fixture
+ * carrying only `id` therefore models a response the pipeline must treat as a FAILURE, so it cannot
+ * also stand in for success.
+ */
+const REACHABLE_REPOSITORY = {
+    id        : 'R_kgDO',
+    issues    : {pageInfo: {hasNextPage: false}},
+    stargazers: {pageInfo: {hasNextPage: false}}
+};
+
+/**
  * `Resource not accessible by integration` is returned for two conditions that share one string:
  * genuine GitHub-side flakiness, and a permanently missing App installation. No message inspection
  * separates them, which is why the bounded-retry classifier treats the string as transient — correct
@@ -26,7 +40,7 @@ test.describe('Data Sync access preflight (#15744)', () => {
     const respond = payload => async () => ({status: 200, json: async () => payload});
 
     const denial    = respond({errors: [{message: 'Resource not accessible by integration'}]}),
-          reachable = respond({data: {repository: {id: 'R_kgDO'}}});
+          reachable = respond({data: {repository: REACHABLE_REPOSITORY}});
 
     test('the required set includes devindex-opt-out, not just opt-in', () => {
         // An installation covering only `neo` + `devindex-opt-in` passes a naive probe and then
@@ -39,15 +53,58 @@ test.describe('Data Sync access preflight (#15744)', () => {
     });
 
     test('a reachable repository probe reports ok without a retry budget', async () => {
-        expect(await probeRepository({fetchFn: reachable, name: 'devindex-opt-in', owner: 'neomjs', token: 't'}))
-            .toEqual({ok: true, reason: null})
+        expect(await probeRepository({
+            connection: 'stargazers', fetchFn: reachable, name: 'devindex-opt-in', owner: 'neomjs', token: 't'
+        })).toEqual({ok: true, reason: null})
     });
 
     test('a GraphQL denial is detected despite arriving as HTTP 200', async () => {
         // The denial is a 200-body `errors` array, so status alone is not the test — reading only
         // `response.status` would report this repository as reachable.
-        expect(await probeRepository({fetchFn: denial, name: 'devindex-opt-in', owner: 'neomjs', token: 't'}))
-            .toEqual({ok: false, reason: 'Resource not accessible by integration'})
+        expect(await probeRepository({
+            connection: 'stargazers', fetchFn: denial, name: 'devindex-opt-in', owner: 'neomjs', token: 't'
+        })).toEqual({ok: false, reason: 'Resource not accessible by integration'})
+    });
+
+    test('the probe SELECTS the connection its entry names, not just the repository id', async () => {
+        // The id-only probe answered "can this identity see the repository", never "can it perform
+        // the read `purpose` names" — so it reported reachable while the stargazer read was denied.
+        let sent = null;
+
+        await probeRepository({
+            connection: 'stargazers',
+            fetchFn   : async (_url, options) => {sent = JSON.parse(options.body).query; return {status: 200, json: async () => ({})}},
+            name      : 'devindex-opt-in',
+            owner     : 'neomjs',
+            token     : 't'
+        });
+
+        expect(sent).toContain('stargazers(first:1)');
+
+        await probeRepository({
+            connection: 'issues',
+            fetchFn   : async (_url, options) => {sent = JSON.parse(options.body).query; return {status: 200, json: async () => ({})}},
+            name      : 'devindex-opt-out',
+            owner     : 'neomjs',
+            token     : 't'
+        });
+
+        expect(sent).toContain('issues(first:1)')
+    });
+
+    test('a PARTIAL denial — id resolves, the named connection does not — is a failure', async () => {
+        // The exact production response: GraphQL returns 200 with `data.repository.id` present, the
+        // denied connection null, and the denial in `errors`. Testing `id` alone reads this as
+        // success, which is how `devindex-opt-in reachable (OptIn stargazer read)` was logged by a
+        // run whose stargazer read was denied twelve minutes later.
+        const partial = respond({
+            data  : {repository: {id: 'R_kgDO', stargazers: null}},
+            errors: [{message: 'Resource not accessible by integration'}]
+        });
+
+        expect(await probeRepository({
+            connection: 'stargazers', fetchFn: partial, name: 'devindex-opt-in', owner: 'neomjs', token: 't'
+        })).toEqual({ok: false, reason: 'Resource not accessible by integration'})
     });
 
     test('the exact 60-run denial fails fast, names EVERY unreachable repo, and states the remedy', async () => {
@@ -103,10 +160,11 @@ test.describe('Data Sync access preflight (#15744)', () => {
         // `probeRepository`, the retry loop, and `assertDataSyncAccess` alike — so the bounded retry
         // could not see the failure mode it exists for.
         const result = await probeRepository({
-            fetchFn: async () => {throw new Error('ECONNRESET')},
-            name   : 'devindex-opt-in',
-            owner  : 'neomjs',
-            token  : 't'
+            connection: 'stargazers',
+            fetchFn   : async () => {throw new Error('ECONNRESET')},
+            name      : 'devindex-opt-in',
+            owner     : 'neomjs',
+            token     : 't'
         });
 
         expect(result).toEqual({ok: false, reason: 'ECONNRESET'})
@@ -118,7 +176,7 @@ test.describe('Data Sync access preflight (#15744)', () => {
         const flakyTransport = async () => {
             calls++;
             if (calls === 1) throw new Error('ECONNRESET');
-            return {status: 200, json: async () => ({data: {repository: {id: 'R_kgDO'}}})}
+            return {status: 200, json: async () => ({data: {repository: REACHABLE_REPOSITORY}})}
         };
 
         await expect(assertDataSyncAccess({
@@ -263,7 +321,7 @@ test.describe('preflight-only dispatch mode', () => {
  */
 test.describe('preflight retry budget', () => {
     const denialBody    = {errors: [{message: 'Resource not accessible by integration'}]},
-          reachableBody = {data: {repository: {id: 'R_kgDO'}}};
+          reachableBody = {data: {repository: REACHABLE_REPOSITORY}};
 
     test('a flaky first call recovers instead of being reported permanent', async () => {
         let calls = 0;


### PR DESCRIPTION
Resolves #17148

## What broke, and why no PR caused it

`#17131` has been red since **2026-08-14T11:49:16Z**. The premise I was handed on pickup was that a merged PR broke it. It did not.

| | run | head | UTC |
|---|---|---|---|
| last green | `31797752252` | `45570db8e` | 2026-08-14T11:49:16Z |
| first red | `31804178775` | `dd25854d4` | 2026-08-14T13:19:19Z |

`git diff --stat 45570db8e..dd25854d4` spans 77 files. **Corrected during review** (@neo-gpt): an earlier revision of this paragraph said "zero changes to `apps/devindex/**`", which is false — the window deletes 92 lines from `apps/devindex/resources/data/tracker.json`. That is pipeline-generated data, but the sentence was broader than the evidence.

The narrower claim is the one that holds, and it is sufficient: **no executable candidate changed.** `git diff --stat 45570db8e..dd25854d4 -- 'apps/devindex/services/**' 'buildScripts/dataSync*.mjs' '.github/workflows/**'` returns empty. Everything else in the window is generated data-sync output, one learn doc, and `test/playwright/**` specs. `OptIn.mjs` last moved 2026-02-22, `GitHub.mjs` 2026-07-23, the workflow 2026-07-28 — every candidate mechanism predates the window it would have to explain. In the last green run the *identical* query ran under the *identical* `intake` credential and succeeded at `12:05:23Z`.

**The cause is a GitHub access-policy change.** Separating what is published from what is inferred, per review:

**Published:** GitHub restricted the stargazers endpoint to repository admins and collaborators — [announced 2026-06-30](https://github.blog/changelog/2026-06-30-upcoming-access-restrictions-to-public-api-endpoints-and-ui-views/), titled "**Upcoming**", stating some callers "may begin receiving empty responses or a 403" and publishing **no enforcement schedule**. It says nothing about GitHub App installation tokens.

**Observed:** the read succeeded at `12:05:23Z` and has returned `Resource not accessible by integration` on every run since `13:19:19Z` on 2026-08-14, with no executable change in between. Independently: the two intake repos 404 on REST `/stargazers` where I hold `pull` only, while `neomjs/neo` (where I am a collaborator) returns 200.

**Inferred:** that the transition at that boundary IS the announced restriction reaching this installation. The correlation is strong — the observed access boundary matches the published rule's own axis — but GitHub published no per-installation rollout record, so this is evidence-backed inference, not a documented fact. **Since confirmed by experiment**: granting and requesting `administration: read` did not restore the read ([run 31874111382](https://github.com/neomjs/neo/actions/runs/31874111382)), which is what a status-based rather than permission-based restriction predicts.

| probe | `neomjs/neo` (I am a collaborator) | `devindex-opt-in` (`pull` only) | `devindex-opt-out` (`pull` only) |
|---|---|---|---|
| REST `/stargazers` | 200, 3 rows | **404** | **404** |
| GraphQL `stargazers` | returns edges | `edges: []` | — |
| REST repo root | 200 | 200 (`stargazers_count: 16`) | 200 |

Treat it as **durable rather than transient** — 20+ hours, a published policy direction, and a failed permission remedy all point the same way, though GitHub has not declared it permanent. That is why the blast radius below had to be fixed rather than waited out.

## The defect this fixes

`DevIndex Opt-In` is stage 3 of 7 and threw straight out of the emission loop (`dataSyncPipeline.mjs:648`). Stages 4–7 never ran — including `content indexes and SEO`, which is what makes the corpus consumable — and the publish path below the loop was never reached, so the corpus generated one stage earlier was **discarded**. `resources/content/**` on `dev` froze for nineteen hours while portal data and KB ingestion read the stale mirror.

An optional enrichment read for the DevIndex opt-in feature was deciding whether the whole repository published.

The primitive to decouple it already existed and was already used by the corpus stage: `publishGeneratedProgressOnFailure` defers, lets the remaining stages run, publishes, then rethrows (`:742-744`, `:844-849`). The four intake stages now carry it.

**The run still exits non-zero.** That is deliberate and load-bearing: the intake genuinely is denied, so a green pipeline would assert something false. This unfreezes the corpus; it does not silence `#17131`.

## Deltas

- `buildScripts/dataSyncPipeline.mjs` — `publishGeneratedProgressOnFailure: true` on the four DevIndex intake stages; `deferredErrors` accumulates instead of overwriting; new exported `aggregateDeferredFailures`; the preflight denial is deferred rather than thrown, and **no stage is skipped**.
- `buildScripts/dataSyncPreflight.mjs` — `REQUIRED_REPOSITORIES` entries declare the `connection` they need; `probeRepository` selects it and requires it to resolve; `denialRemedy` derives remediation from the refused connection.
- Both spec files — 9 new tests; `reachable` fixtures now model a response carrying the probed connections.

Two supporting corrections, both surfaced by this incident:

1. **A single `deferredError` slot kept only the last failure.** One denial fails all four intake stages, so the run reported one and dropped three — sizing the outage wrong. `aggregateDeferredFailures` folds them, spelling every cause into the message a CI log tail actually shows, while `AggregateError#errors` keeps the originals inspectable. A lone failure is returned unwrapped.

2. **The preflight claimed a read it never performed.** It logged `devindex-opt-in reachable (OptIn stargazer read)` in the very runs whose stargazer read was denied twelve minutes later, because it probed `repository{id}` alone — which resolves from metadata. It now selects the connection its entry names *and requires that connection to resolve*: GitHub answers a partial denial with `id` present and the connection `null` beside an `errors` entry, so testing `id` alone read the exact failing response as success. Its denial is now deferred rather than thrown — rethrowing would re-couple publication to the intake identity one layer *above* the stage table that just decoupled it, and the corpus would stay frozen, only faster.

## Rejected

- **Adding `Resource not accessible by integration` to `OptIn.mjs`'s NOT_FOUND skip branch.** It would turn the pipeline green in one line. It would also convert a real permission regression into a silent no-op, and the opt-in feature would rot undetected — a carve-out that quiets a guard opens a silent channel. Green would mean "intake silently dead".
- **Widening the `intake` App or pointing the pipeline at an admin credential.** Would likely restore the read, but it reverses the least-privilege two-identity split from `#15744` and is operator-owned credential surface either way. Named for @tobiu, not done here.

Evidence: L2 (unit specs + reproduced live API behaviour across three repositories) → L2 sufficient for every AC verifiable off-CI. The one behaviour no local test can reach is the scheduled `dev` run itself, which is observable only after merge. Residual: the three Post-Merge Validation items below, owned there by #17131.

## Test Evidence

```
npx playwright test -c test/playwright/playwright.config.unit.mjs \
  test/playwright/unit/ai/buildScripts/DataSyncPipeline.spec.mjs
  43 passed (3.4s)

npx playwright test -c test/playwright/playwright.config.unit.mjs \
  test/playwright/unit/ai/buildScripts/DataSyncPreflight.spec.mjs
  20 passed (5.2s)

npx playwright test -c test/playwright/playwright.config.unit.mjs \
  test/playwright/unit/ai/buildScripts/DataSyncWatchdog.spec.mjs
  31 passed (2.2s)
```

New coverage, each pinning a distinct half of the finding:

- `a denied Opt-In no longer aborts emission — every later stage still runs` — asserts `content indexes and SEO` is reached, three stages past where the loop used to throw.
- `the corpus publishes AND the run still fails when Opt-In is denied` — both halves in one test, because either alone is the wrong outcome.
- `every deferred stage failure is named, not just the last one` — three failing stages, all three named.
- `a lone deferred failure is reported unwrapped, not buried under a count of one`.
- `aggregateDeferredFailures keeps the originals reachable, not just their text`.
- `a preflight denial defers and SKIPS the intake stages instead of aborting the run` — and the reader-scoped stages still run.
- `the probe SELECTS the connection its entry names, not just the repository id`.
- `a PARTIAL denial — id resolves, the named connection does not — is a failure` — the exact production response shape.

The four pre-existing preflight tests that failed on first run did so because their `reachable` fixture returned `{id}` only — i.e. they modelled the response the old probe misread as success. That failure was the change working; the fixtures now carry the connections.

## Post-Merge Validation

Every item below is observable only on a scheduled `dev` run, which cannot exist before merge. They are owned by the standing alarm rather than by this PR's close target: `#17131` is refreshed on every breach evaluation, already carries a per-facet corpus-freshness table, and stays open until the GitHub-side stargazer restriction is resolved — so it is still there when these become checkable, which the close target would not be.

Residual-Owner: #17131

- [ ] The first scheduled `dev` run after merge publishes a `chore(data): Hourly data sync pipeline update [skip ci]` commit despite the intake denial — the corpus freeze ends.
- [ ] That same run still exits non-zero and `#17131` remains open, naming `DevIndex Opt-In` (and any sibling intake stage) in one aggregated error.
- [ ] The preflight now reports `devindex-opt-in DENIED (OptIn stargazer read)` at minute 1 rather than `reachable`, and the run's failure is attributable from the first log page.

## Follow-up filed separately

The star-based opt-in path is dead by GitHub policy, and because it throws first it is currently also killing `processIssues()` — the issue-based opt-in that still works. Retiring or degrading that path is DevIndex product scope, not pipeline blast-radius scope, so it is tracked on its own rather than widened into this PR.

<!-- Authored by @neo-opus-ada (Ada) -->

