### PR TITLE
fix(ai): a durable fence of either family completes the run instead of deferring forever (#17139)

### DIFF
--- a/ai/daemons/orchestrator/services/DeploymentStateBridgeService.mjs
+++ b/ai/daemons/orchestrator/services/DeploymentStateBridgeService.mjs
@@ -2577,10 +2577,16 @@ function summarizeTenantRepoState({
         // carries no identity and no message — a count, a state, and two timestamps.
         corpusOutstanding                 : normalizedCheckpoint?.corpusOutstanding ?? null,
         // Same unconditional rule, and for a stronger reason: a fence-only run COMPLETES (streak
-        // zero, checkpoint advanced), so this census is the ONLY snapshot evidence that N documents
-        // are deferred pending a geometry/ceiling change. Hashed chunk ids and a count — validated
-        // fail-closed by the checkpoint normalizer above.
+        // zero, checkpoint advanced), so these censuses are the ONLY snapshot evidence that N documents
+        // are fenced. Hashed chunk ids and a count — validated fail-closed by the checkpoint
+        // normalizer above.
+        //
+        // Two fields rather than one total, because they prescribe OPPOSITE operator actions:
+        // `undeliverableChunks` is healthy content the plane's geometry cannot deliver (raise the
+        // ceiling), `contentPoisonChunks` is content whose own shape defeated embedding (fix the file).
+        // A merged count reliably sends the operator at the wrong one.
         undeliverableChunks               : normalizedCheckpoint?.undeliverableChunks ?? null,
+        contentPoisonChunks               : normalizedCheckpoint?.contentPoisonChunks ?? null,
         ingestContractVersion             : normalizedCheckpoint?.ingestContractVersion ?? null,
         lastAttemptedIngestContractVersion: normalizedCheckpoint?.lastAttemptedIngestContractVersion ?? null,
         effectiveCadenceMs                : dueState.effectiveCadenceMs,

--- a/ai/daemons/orchestrator/services/TenantRepoSyncService.mjs
+++ b/ai/daemons/orchestrator/services/TenantRepoSyncService.mjs
@@ -22,7 +22,6 @@ import {
     BOUNDED_KB_ERROR_CODE_PATTERN,
     EMBED_DISPOSITION,
     KB_VECTOR_EMBED_PROVIDER_CIRCUIT_OPEN,
-    KB_VECTOR_EMBED_UNDELIVERABLE_AT_GEOMETRY,
     classifyEmbedDisposition,
     isEmbedFailureCode
 }                                from '../../../services/knowledge-base/helpers/embedFailureClassification.mjs';
@@ -323,6 +322,60 @@ function getAccessReadinessMaxAgeMs(repo, globalCadenceMs) {
 }
 
 /**
+ * @summary Tenant-aware chunk hash, the shape a fence row's `chunkId` must carry.
+ * @type {RegExp}
+ */
+const CHUNK_ID_PATTERN = /^[a-f0-9]{64}$/u;
+
+/**
+ * @summary The closed vocabulary of durable fence dispositions the ingestion writer emits.
+ *
+ * Two families share the poison store and assert DIFFERENT things — `proven-content-poison` is bad
+ * content to fix, `undeliverable-at-geometry` is healthy content the current geometry cannot deliver.
+ * Both are durable: no amount of coming back changes either at the current generation. They stay
+ * separately named here for the same reason `IngestionService` writes them separately — telling an
+ * operator to fix a file whose only fault is the plane's ceiling is the confusion worth preventing.
+ * @type {Set<String>}
+ */
+const FENCE_DISPOSITIONS = Object.freeze(new Set(['proven-content-poison', 'undeliverable-at-geometry']));
+
+/**
+ * @summary Decides whether one error row is a DURABLE FENCE rather than live work.
+ *
+ * **The code alone cannot answer this, which is why the row's details are read at all.** An
+ * undeliverable fence could be recognised by its code because that code is minted only at
+ * graduation; a content poison carries the ORIGINAL embed-domain code it failed with, so
+ * `KB_VECTOR_EMBED_TIMEOUT` is a fence row on one sweep and a live failure on the next. The
+ * disposition is the writer's own assertion about which, and it is the only thing that knows.
+ *
+ * **`classifyIngestionOutcome` reads codes only, deliberately — `details` is unvalidated free
+ * shape.** So this read takes the same gate a code gets, and all three clauses are load-bearing:
+ * a closed vocabulary (not merely "a string is present"), coherence between `details.reasonCode`
+ * and the top-level `code` (the writer assigns both from one local, so disagreement means the row
+ * did not come from this contract), and the same bounded id gate the census applies.
+ *
+ * Every clause fails toward LIVE. A missing, malformed, unknown, or incoherent row keeps its run
+ * deferring exactly as today — the direction where a wrong answer costs a wasted sweep rather than
+ * a checkpoint advanced over work that never landed.
+ *
+ * @param {Object} item One `summary.errors` row.
+ * @returns {Boolean}
+ * @private
+ */
+function isDurableFenceRow(item) {
+    const details = item?.details;
+
+    if (!details || typeof details !== 'object' || Array.isArray(details)) {
+        return false;
+    }
+
+    return FENCE_DISPOSITIONS.has(details.disposition)
+        && details.reasonCode === item.code
+        && typeof details.chunkId === 'string'
+        && CHUNK_ID_PATTERN.test(details.chunkId);
+}
+
+/**
  * @summary Decides whether an ingestion run COMPLETED, DEFERRED, or FAILED.
  *
  * `KnowledgeBaseIngestionService.ingestSourceFiles()` is intentionally fail-soft: failures are
@@ -347,11 +400,21 @@ function getAccessReadinessMaxAgeMs(repo, globalCadenceMs) {
  * error, or one error with no code at all fails the run exactly as before. Deferring a permanently
  * malformed file would be silently stuck, which is worse than loudly broken.
  *
+ * **Within the deferrable domain there is a fourth distinction, and it decides `complete` vs
+ * `deferred`: a durable FENCE is not incomplete work.** A fenced chunk is excised until its
+ * generation, geometry, ceiling, or content changes, so deferring on one asserts a return that can
+ * change nothing — and the held checkpoint makes every later sweep re-materialise the same delta.
+ * A run whose every error is a fence (either family) completes; the persisted censuses, not a held
+ * checkpoint, carry the fenced chunks to the operator. See {@link isDurableFenceRow} for why the
+ * row's details rather than its code answer this, and for the fail-closed gate that read takes.
+ *
  * Error messages and details are still never copied into the thrown error. The bounded `KB_*` codes
  * are retained separately as source provenance for `lastSourceErrorCode`.
  *
  * @param {Object} summary Returned KB ingestion summary.
- * @returns {{outcome: 'complete'|'deferred', summary: Object, deferredCodes: String[]}}
+ * @returns {{outcome: 'complete'|'deferred', summary: Object, deferredCodes: String[]}} `deferredCodes`
+ *     carries the codes of LIVE rows only — never a fence row's code, which would otherwise be
+ *     indistinguishable downstream and could arm an embedding-recovery episode.
  * @throws {Error} When the summary shape is ambiguous, or it carries any error that is not a
  *     deferrable embed failure.
  */
@@ -372,21 +435,29 @@ function classifyIngestionOutcome(summary) {
 
         if (deferrable) {
             // Deferral means "incomplete, come back": the checkpoint holds because a later run may
-            // finish the work. The undeliverable-at-geometry fence asserts the OPPOSITE — the chunk
-            // is durably excised until the geometry, ceiling, or content changes, so no amount of
-            // coming back changes anything. A run whose every error is that fence therefore
-            // COMPLETES: the checkpoint advances, sibling rotation proceeds, and the census below
-            // (not a held checkpoint) is what keeps the fenced chunks visible to the operator.
-            // One live deferrable failure beside the fences still defers the run as before.
-            const undeliverableOnly = summary.errors.every(item =>
-                item.code === KB_VECTOR_EMBED_UNDELIVERABLE_AT_GEOMETRY
-            );
+            // finish the work. A durable fence asserts the OPPOSITE — the chunk is excised until the
+            // generation, geometry, ceiling, or content changes, so no amount of coming back changes
+            // anything. A run whose every error is a fence therefore COMPLETES: the checkpoint
+            // advances, sibling rotation proceeds, and the censuses (not a held checkpoint) are what
+            // keep the fenced chunks visible to the operator. One live failure beside the fences
+            // still defers the run as before.
+            //
+            // BOTH fence families qualify. Restricting this to the undeliverable code left every
+            // content-poisoned repo deferring forever — re-materialising and re-parsing the same
+            // delta each sweep for a state no later sweep can change.
+            const liveRows = summary.errors.filter(item => !isDurableFenceRow(item));
 
-            if (!undeliverableOnly) {
+            if (liveRows.length > 0) {
+                // Live rows ONLY. Both families carry ordinary embed-domain codes, so a flat set of
+                // every row's code cannot be filtered back to live causes downstream — the row
+                // identity that distinguishes a fenced `KB_VECTOR_EMBED_TIMEOUT` from a live one
+                // exists here and nowhere after. Selecting the cause anywhere else would let a fence
+                // arm the embedding-recovery canary: a health probe whose success cannot re-offer
+                // the fenced chunk, because only a generation change can.
                 return {
                     outcome      : 'deferred',
                     summary,
-                    deferredCodes: [...new Set(summary.errors.map(item => item.code))]
+                    deferredCodes: [...new Set(liveRows.map(item => item.code))]
                 }
             }
 
@@ -487,38 +558,67 @@ function buildCorpusOutstandingObservation({summary, priorState, observedAt}) {
 export const UNDELIVERABLE_CENSUS_MAX_IDS = 32;
 
 /**
- * @summary Builds the AC-3 undeliverable census (`{count, ids}`) from one run's own ingestion summary.
+ * @summary Builds one fence census (`{count, ids}`) from one run's own ingestion summary.
  *
- * The census answers "how many documents is this plane's geometry deferring, and which" — the
- * observable that replaces silence when a monster chunk is fenced instead of blocking the corpus.
- * Derived from the summary's fence rows rather than re-reading the poison store: the run's summary
- * is what the sync lane already trusts for every other scheduling decision, and a second reader
- * could disagree with the writer that produced it.
+ * The census answers "how many documents is this plane fencing, and which" — the observable that
+ * replaces silence when a chunk is fenced instead of blocking the corpus. Once a fence-only run
+ * COMPLETES, it is also the only standing signal left: the held checkpoint that used to say
+ * "something is wrong here" is gone by design.
  *
- * Ids are tenant-aware chunk hashes — bounded by construction — and re-validated here anyway; a row
- * whose id fails the gate is COUNTED but not enumerated, so a malformed writer can inflate nothing
- * into the projection. `null` means "no census observed" (no fence rows), never "zero measured".
+ * Derived from the summary's own rows rather than re-reading the poison store: the run's summary is
+ * what the sync lane already trusts for every other scheduling decision, and a second reader could
+ * disagree with the writer that produced it.
  *
- * @param {Object} summary Ingestion summary returned by the run.
+ * The two families stay SEPARATE censuses rather than one total. `IngestionService` writes them
+ * apart for the operator-facing reason that a merged number destroys — a content poison is a file to
+ * fix, an undeliverable chunk is a ceiling to raise, and a single count tells you to do the wrong one.
+ *
+ * Ids are tenant-aware chunk hashes, re-validated here even though {@link isDurableFenceRow} already
+ * gated them — this builder must stay correct if it is ever pointed at rows from another path.
+ * A row that cannot name its chunk never reaches here: it fails the fence gate and keeps its run
+ * DEFERRING, which is the load-bearing direction now that completion hands observability to this
+ * census. Completing on rows nobody can enumerate would leave an operator with a fenced corpus and
+ * no signal at all. `null` means "no census observed" (no rows of this family), never "zero measured".
+ *
+ * @param {Object}   summary   Ingestion summary returned by the run.
+ * @param {String}   dispositionValue The {@link FENCE_DISPOSITIONS} member selecting one family.
  * @returns {{count: Number, ids: String[]}|null}
  */
-function buildUndeliverableCensus(summary) {
+function buildFenceCensus(summary, dispositionValue) {
     const rows = (Array.isArray(summary?.errors) ? summary.errors : [])
-        .filter(item => item?.code === KB_VECTOR_EMBED_UNDELIVERABLE_AT_GEOMETRY);
+        .filter(item => isDurableFenceRow(item) && item.details.disposition === dispositionValue);
 
     if (rows.length === 0) {
         return null;
     }
 
     const ids = [...new Set(
-        rows.map(item => item?.details?.chunkId)
-            .filter(id => typeof id === 'string' && /^[a-f0-9]{64}$/u.test(id))
+        rows.map(item => item.details.chunkId)
+            .filter(id => typeof id === 'string' && CHUNK_ID_PATTERN.test(id))
     )].sort();
 
     return {
         count: rows.length,
         ids  : ids.slice(0, UNDELIVERABLE_CENSUS_MAX_IDS)
     };
+}
+
+/**
+ * @summary Builds the undeliverable-at-geometry census — healthy content the plane cannot deliver.
+ * @param {Object} summary Ingestion summary returned by the run.
+ * @returns {{count: Number, ids: String[]}|null}
+ */
+function buildUndeliverableCensus(summary) {
+    return buildFenceCensus(summary, 'undeliverable-at-geometry');
+}
+
+/**
+ * @summary Builds the proven-content-poison census — content whose own shape defeated embedding.
+ * @param {Object} summary Ingestion summary returned by the run.
+ * @returns {{count: Number, ids: String[]}|null}
+ */
+function buildContentPoisonCensus(summary) {
+    return buildFenceCensus(summary, 'proven-content-poison');
 }
 
 /**
@@ -2236,13 +2336,15 @@ class TenantRepoSyncService extends Base {
                     //
                     // Bounded `KB_*` codes only, never messages or details: identical credential
                     // boundary to the failure path, which is why these are safe to persist at all.
-                    // The undeliverable fence is excluded from cause selection: it is a durable
-                    // disposition, not a live failure, and letting it arm the embedding-recovery
-                    // canary would probe for a health change that cannot re-offer the chunk — only a
+                    // Fences of BOTH families are already excluded — `deferredCodes` carries live
+                    // rows only, filtered where the row identity still exists. It cannot be done
+                    // here: a content poison carries the ordinary embed code it failed with, so a
+                    // fenced `KB_VECTOR_EMBED_TIMEOUT` and a live one are the same string by the
+                    // time this sees them. Letting a fence through would arm the embedding-recovery
+                    // canary — a health probe whose success cannot re-offer the chunk, since only a
                     // generation change can. A deferred outcome always carries at least one live
-                    // code beside any fences (fence-only runs classify as complete above).
-                    const liveDeferredCodes = ingestOutcome.deferredCodes
-                        .filter(code => code !== KB_VECTOR_EMBED_UNDELIVERABLE_AT_GEOMETRY);
+                    // code (fence-only runs classify as complete above).
+                    const liveDeferredCodes = ingestOutcome.deferredCodes;
                     const deferredCauseCode = liveDeferredCodes.find(isEmbeddingRecoverySourceCode)
                         ?? liveDeferredCodes[0]
                         ?? priorState?.lastSourceErrorCode
@@ -2268,6 +2370,9 @@ class TenantRepoSyncService extends Base {
                     const deferredCensus = buildUndeliverableCensus(rawSummary)
                         ?? priorState?.undeliverableChunks
                         ?? null;
+                    const deferredPoisonCensus = buildContentPoisonCensus(rawSummary)
+                        ?? priorState?.contentPoisonChunks
+                        ?? null;
 
                     persistedRevisions[repoLabel] = {
                         ...priorState,
@@ -2279,6 +2384,7 @@ class TenantRepoSyncService extends Base {
                         lastErrorAt                       : startedMs,
                         corpusOutstanding                 : deferredOutstanding,
                         undeliverableChunks               : deferredCensus,
+                        contentPoisonChunks               : deferredPoisonCensus,
                         // Recovery eligibility, on the SAME episode a failure would advance. A
                         // consumed generation folds into `lastConsumedGenerationId/At` and a newly
                         // healthy canary generation is required before another bypass, so a
@@ -2319,7 +2425,8 @@ class TenantRepoSyncService extends Base {
                             observedAt        : startedMs
                         }),
                         corpusOutstanding  : deferredOutstanding,
-                        undeliverableChunks: deferredCensus
+                        undeliverableChunks: deferredCensus,
+                        contentPoisonChunks: deferredPoisonCensus
                     });
 
                     healthService?.recordTaskOutcome?.(taskName, 'deferred', {
@@ -2341,11 +2448,14 @@ class TenantRepoSyncService extends Base {
                     observedAt: startedMs
                 });
 
-                // The completed path carries the census too — this is the AC-3 surface's load-bearing
+                // The completed path carries the censuses too — this is the surface's load-bearing
                 // half: a fence-only run COMPLETES (checkpoint advances, rotation proceeds), so the
-                // held-checkpoint signal is gone by design and the census is the only thing standing
-                // between the operator and "N documents silently missing".
-                const completedCensus = buildUndeliverableCensus(ingestResult);
+                // held-checkpoint signal is gone by design and the censuses are the only thing standing
+                // between the operator and "N documents silently missing". Both families are written
+                // in this one checkpoint object, so completion cannot land while the signal it replaces
+                // the held checkpoint with is lost.
+                const completedCensus       = buildUndeliverableCensus(ingestResult);
+                const completedPoisonCensus = buildContentPoisonCensus(ingestResult);
 
                 const materializationReceipt = assertFullMaterializationEffect(
                     envelope,
@@ -2381,7 +2491,8 @@ class TenantRepoSyncService extends Base {
                     // would leave `corpusOutstanding` absent on exactly the state that proves the
                     // observable can reach zero, and an absent field reads as unknown.
                     corpusOutstanding  : completedOutstanding,
-                    undeliverableChunks: completedCensus
+                    undeliverableChunks: completedCensus,
+                    contentPoisonChunks: completedPoisonCensus
                 };
 
                 const durationMs = Date.now() - startedMs;
@@ -2400,7 +2511,8 @@ class TenantRepoSyncService extends Base {
                     checkpointStatus    : TenantRepoCheckpointStatus.COMPLETE,
                     lastSyncDeletedCount: deleted,
                     corpusOutstanding   : completedOutstanding,
-                    undeliverableChunks : completedCensus
+                    undeliverableChunks : completedCensus,
+                    contentPoisonChunks : completedPoisonCensus
                 });
                 completedCount++;
                 healthService?.recordTaskOutcome?.(taskName, 'completed', {

--- a/ai/daemons/orchestrator/services/tenantRepoCheckpointValidity.mjs
+++ b/ai/daemons/orchestrator/services/tenantRepoCheckpointValidity.mjs
@@ -111,8 +111,9 @@ export function normalizeTenantRepoCheckpointState(value) {
             // A bare SHA also predates the outstanding-work observable. Null means "never measured",
             // which is the honest reading — not a corpus with nothing left to do.
             corpusOutstanding  : null,
-            // And the undeliverable census: null is "never observed", never "zero fenced".
-            undeliverableChunks: null
+            // And the fence censuses: null is "never observed", never "zero fenced".
+            undeliverableChunks: null,
+            contentPoisonChunks: null
         };
     }
 
@@ -147,24 +148,31 @@ export function normalizeTenantRepoCheckpointState(value) {
         lastErrorAt        : normalizeNonNegativeNumber(value.lastErrorAt) || null,
         embeddingRecovery  : normalizeEmbeddingRecovery(value.embeddingRecovery),
         corpusOutstanding  : normalizeCorpusOutstanding(value.corpusOutstanding),
-        undeliverableChunks: normalizeUndeliverableChunks(value.undeliverableChunks)
+        // Two fence families, two censuses, one reader. A record written before the content-poison
+        // census existed normalizes to null — "never observed", which is exactly what it is.
+        undeliverableChunks: normalizeFenceCensus(value.undeliverableChunks),
+        contentPoisonChunks: normalizeFenceCensus(value.contentPoisonChunks)
     };
 }
 
 /**
- * @summary Normalizes one persisted undeliverable census without manufacturing an observation.
+ * @summary Normalizes one persisted fence census without manufacturing an observation.
  *
- * The census carries "N chunks are fenced as undeliverable at the current geometry, these are (up
- * to a cap) their ids". Same reader discipline as `normalizeCorpusOutstanding`: a record that does
- * not cohere degrades WHOLE to `null` (unobserved), never to a smaller census — repairing a torn
- * row into a count would assert an observation nobody made. Ids are tenant-aware chunk hashes and
- * pass the same bounded gate the writer applied; the id list may be shorter than the count (the
- * writer caps enumeration) but never longer, and never contains a non-hash or a duplicate.
+ * The census carries "N chunks are fenced, these are (up to a cap) their ids". It is family-neutral
+ * by construction and is the reader for BOTH persisted censuses — undeliverable-at-geometry and
+ * proven-content-poison. The families stay separate FIELDS (a merged count would tell an operator to
+ * fix a file whose only fault is the plane's ceiling) but share this one shape and this one reader.
+ *
+ * Same reader discipline as `normalizeCorpusOutstanding`: a record that does not cohere degrades
+ * WHOLE to `null` (unobserved), never to a smaller census — repairing a torn row into a count would
+ * assert an observation nobody made. Ids are tenant-aware chunk hashes and pass the same bounded gate
+ * the writer applied; the id list may be shorter than the count (the writer caps enumeration) but
+ * never longer, and never contains a non-hash or a duplicate.
  *
  * @param {*} value Candidate persisted census.
  * @returns {{count: Number, ids: String[]}|null}
  */
-function normalizeUndeliverableChunks(value) {
+function normalizeFenceCensus(value) {
     if (!value || typeof value !== 'object' || Array.isArray(value)) {
         return null;
     }

--- a/test/playwright/unit/ai/daemons/orchestrator/services/DeploymentStateBridgeService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/DeploymentStateBridgeService.spec.mjs
@@ -1706,6 +1706,49 @@ test.describe('Neo.ai.daemons.services.DeploymentStateBridgeService', () => {
 
         expect(tornCensusSnap.repos[0].undeliverableChunks).toBeNull();
         tornCensus.destroy();
+
+        // The content-poison census is a SECOND field on the same chain, and it must be asserted on
+        // this surface rather than inferred from the sibling above: the two are separate projection
+        // lines, so a missing one fails here and nowhere else. Two fields rather than one total
+        // because they prescribe OPPOSITE operator actions — raise the plane's ceiling for an
+        // undeliverable chunk, fix the file for a proven poison — and a merged count sends the
+        // operator at the wrong one.
+        const
+            poisonId   = 'a'.repeat(64),
+            bothFenced = makeService({
+                ...baseCheckpoint,
+                undeliverableChunks: {count: 3, ids: [monsterId]},
+                contentPoisonChunks: {count: 2, ids: [poisonId]}
+            }),
+            bothSnap    = await bothFenced.collectTenantRepoSyncSnapshot({observedAt: OBSERVED_AT});
+
+        // Both project, and each keeps its OWN ids — a swap or a merge fails here.
+        expect(bothSnap.repos[0].undeliverableChunks).toEqual({count: 3, ids: [monsterId]});
+        expect(bothSnap.repos[0].contentPoisonChunks).toEqual({count: 2, ids: [poisonId]});
+        bothFenced.destroy();
+
+        // A record written before the content-poison census existed reads as UNOBSERVED, never as a
+        // zero census — the shape of every record persisted before that field existed, which today
+        // is all of them.
+        const legacyRecord = makeService({...baseCheckpoint, undeliverableChunks: {count: 1, ids: [monsterId]}}),
+              legacySnap   = await legacyRecord.collectTenantRepoSyncSnapshot({observedAt: OBSERVED_AT});
+
+        expect(legacySnap.repos[0].contentPoisonChunks).toBeNull();
+        expect(legacySnap.repos[0].undeliverableChunks).toEqual({count: 1, ids: [monsterId]});
+        legacyRecord.destroy();
+
+        // …and the torn-record discipline is per FIELD: one census degrading whole must not erase the
+        // other's observation, or a half-written row would take a valid census down with it.
+        const tornPoison = makeService({
+                  ...baseCheckpoint,
+                  undeliverableChunks: {count: 2, ids: [monsterId]},
+                  contentPoisonChunks: {count: 1, ids: ['not-a-hash']}
+              }),
+              tornPoisonSnap = await tornPoison.collectTenantRepoSyncSnapshot({observedAt: OBSERVED_AT});
+
+        expect(tornPoisonSnap.repos[0].contentPoisonChunks).toBeNull();
+        expect(tornPoisonSnap.repos[0].undeliverableChunks).toEqual({count: 2, ids: [monsterId]});
+        tornPoison.destroy();
     });
 
     test('collectTenantRepoSyncSnapshot projects mixed access readiness through a deep allowlist', async () => {

--- a/test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncService.spec.mjs
@@ -560,16 +560,22 @@ test.describe('TenantRepoSyncService (#11790)', () => {
             gitMirror                    : makeFakeGitMirror(),
             envelopeBuilder              : makeFakeEnvelopeBuilder(),
             knowledgeBaseIngestionService: makeFakeIngestionService({
-                // The ambiguity in its sharpest form: BOTH rows carry `KB_VECTOR_EMBED_TIMEOUT`. One is
-                // a durable fence, one is this sweep's live failure. A classifier reading codes alone
-                // cannot separate them — it either defers forever or completes over live work.
+                // The two rows carry DIFFERENT codes on purpose, and the fence is FIRST. Both match
+                // `EMBEDDING_RECOVERY_SOURCE_CODE_PATTERN`, and cause selection is a `.find()` over
+                // the code list in row order — so if the fence ever leaked back into `deferredCodes`,
+                // `find` would return the FENCE code and every assertion below would fail.
+                //
+                // An earlier version of this arm gave both rows the same code. That could not fail:
+                // the retained value was identical whichever row supplied it, so it proved deferral
+                // and nothing about selection. A test that cannot fail on the defect it names is not
+                // coverage, however carefully its comment describes the intent.
                 summaryFactory: () => ({ingested: 1, deleted: 0, embeddingsGenerated: 1, errors: [
                     {
                         code   : 'KB_VECTOR_EMBED_TIMEOUT',
                         message: 'A proven embedding poison remains fenced.',
                         details: {chunkId: poisonId, reasonCode: 'KB_VECTOR_EMBED_TIMEOUT', disposition: 'proven-content-poison'}
                     },
-                    {code: 'KB_VECTOR_EMBED_TIMEOUT', message: 'one live timeout-class attempt ended'}
+                    {code: 'KB_VECTOR_EMBED_PROVIDER_TIMEOUT', message: 'one live provider-timeout attempt ended'}
                 ]})
             }),
             revisionsFilePath: revisionsFile,
@@ -584,9 +590,15 @@ test.describe('TenantRepoSyncService (#11790)', () => {
         // Live work present ⇒ the checkpoint holds, exactly as before.
         expect(state.lastIngestedRev).toBeNull();
 
-        // The retained cause comes from the live row. Both rows carry the same string here, so this
-        // asserts the SELECTION path stayed row-aware rather than the value being distinguishable.
-        expect(state.lastSourceErrorCode).toBe('KB_VECTOR_EMBED_TIMEOUT');
+        // The retained cause is the LIVE row's code, and it is NOT the fence's — the two assertions
+        // together are what make this arm discriminating rather than merely green.
+        expect(state.lastSourceErrorCode).toBe('KB_VECTOR_EMBED_PROVIDER_TIMEOUT');
+        expect(state.lastSourceErrorCode).not.toBe('KB_VECTOR_EMBED_TIMEOUT');
+
+        // The canary-arming input is the same selection, so it carries the live cause too. This is the
+        // assertion the second-order defect actually lands on: an episode armed off a fence row probes
+        // for a health change that cannot re-offer the fenced chunk.
+        expect(state.embeddingRecovery?.causeCode).toBe('KB_VECTOR_EMBED_PROVIDER_TIMEOUT');
 
         // The fence is still visible through the deferral.
         expect(state.contentPoisonChunks).toEqual({count: 1, ids: [poisonId]});

--- a/test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncService.spec.mjs
@@ -418,6 +418,242 @@ test.describe('TenantRepoSyncService (#11790)', () => {
         expect(mixedRow.undeliverableChunks).toEqual({count: 1, ids: [monsterId]});
     });
 
+    test('a content-poison-only summary COMPLETES with its own census, and never arms recovery (#17139)', async () => {
+        const
+            taskStateService = createInMemoryTaskStateService(),
+            poisonSlug       = 'org/poison-only',
+            bothSlug         = 'org/both-families',
+            poisonId         = 'a'.repeat(64),
+            monsterId        = 'b'.repeat(64),
+            startedAt        = Date.now(),
+            // The defining property of a content-poison row: it carries the ORDINARY embed-domain code
+            // it failed with. `KB_VECTOR_EMBED_TIMEOUT` is a fence row here and a LIVE failure in the
+            // next test — the code cannot tell them apart, which is the whole reason the disposition
+            // is read. It is also an `isEmbeddingRecoverySourceCode` match, so if this row ever
+            // reached cause selection it would arm a canary whose success cannot re-offer the chunk.
+            poisonRow        = {
+                code   : 'KB_VECTOR_EMBED_TIMEOUT',
+                message: 'A proven embedding poison remains fenced pending changed content, generation, or explicit replay.',
+                details: {
+                    chunkId    : poisonId,
+                    reasonCode : 'KB_VECTOR_EMBED_TIMEOUT',
+                    disposition: 'proven-content-poison'
+                }
+            },
+            geometryRow      = {
+                code   : 'KB_VECTOR_EMBED_UNDELIVERABLE_AT_GEOMETRY',
+                message: 'A chunk remains fenced as undeliverable at the current embedding geometry.',
+                details: {
+                    chunkId    : monsterId,
+                    reasonCode : 'KB_VECTOR_EMBED_UNDELIVERABLE_AT_GEOMETRY',
+                    disposition: 'undeliverable-at-geometry'
+                }
+            };
+
+        await provisionMirrorDir({tenantId: 't1', repoSlug: poisonSlug});
+        await provisionMirrorDir({tenantId: 't1', repoSlug: bothSlug});
+        await TenantRepoSyncService.writePersistedRevisions({
+            filePath : revisionsFile,
+            revisions: Object.fromEntries([poisonSlug, bothSlug].map(repoSlug => [`t1/${repoSlug}`, {
+                lastIngestedRev                   : null,
+                lastRunAttemptAt                  : startedAt - 120_000,
+                consecutiveFailures               : 0,
+                ingestContractVersion             : TENANT_REPO_INGEST_CONTRACT_VERSION,
+                lastAttemptedIngestContractVersion: TENANT_REPO_INGEST_CONTRACT_VERSION
+            }]))
+        });
+
+        const result = await TenantRepoSyncService.runTask({
+            reason           : 'periodic-sweep:60000',
+            taskStateService,
+            tenantReposConfig: {tenantRepos: [poisonSlug, bothSlug].map(repoSlug => ({
+                tenantId: 't1', repoSlug, mirrorRoot, cloneUrl: `https://github.com/neomjs/${repoSlug.split('/')[1]}.git`
+            }))},
+            gitMirror                    : makeFakeGitMirror(),
+            envelopeBuilder              : makeFakeEnvelopeBuilder(),
+            knowledgeBaseIngestionService: makeFakeIngestionService({
+                summaryFactory(payload) {
+                    // One repo fenced by content poison alone; one fenced by BOTH families at once.
+                    // Both are fence-only, so both must complete — a repo does not deserve perpetual
+                    // deferral for carrying two kinds of durable fence instead of one.
+                    return payload.repoSlug === poisonSlug
+                        ? {ingested: 2, deleted: 0, embeddingsGenerated: 2, errors: [{...poisonRow}]}
+                        : {ingested: 3, deleted: 0, embeddingsGenerated: 3, errors: [{...poisonRow}, {...geometryRow}]}
+                }
+            }),
+            revisionsFilePath: revisionsFile,
+            globalCadenceMs  : 60_000,
+            jitterRatio      : 0,
+            backoffCapMs     : 60_000,
+            seedBootstrap    : false
+        });
+
+        const persisted   = (await fs.readJson(revisionsFile)).revisions;
+        const poisonState = persisted[`t1/${poisonSlug}`];
+        const bothState   = persisted[`t1/${bothSlug}`];
+
+        // Content-poison-only: COMPLETE. A classifier that completed only on the undeliverable code
+        // left this repo deferring on every sweep forever, re-materializing and re-parsing the same
+        // delta for a state no later sweep can change.
+        expect(poisonState.lastIngestedRev).toBe(`sha-head-${poisonSlug}`);
+        expect(poisonState.consecutiveFailures).toBe(0);
+        expect(poisonState.lastSourceErrorCode).toBeNull();
+
+        // The two families are SEPARATE censuses, never one total: a merged count would tell the
+        // operator to fix a file whose only fault is the plane's ceiling, or vice versa.
+        expect(poisonState.contentPoisonChunks).toEqual({count: 1, ids: [poisonId]});
+        expect(poisonState.undeliverableChunks).toBeNull();
+
+        // No canary. `KB_VECTOR_EMBED_TIMEOUT` IS a recovery-source code, so this assertion fails the
+        // moment a fence row reaches cause selection — the second-order defect, armed by construction.
+        expect(poisonState.embeddingRecovery ?? null).toBeNull();
+
+        // Both families fenced on one repo: still complete, each census populated independently.
+        expect(bothState.lastIngestedRev).toBe(`sha-head-${bothSlug}`);
+        expect(bothState.contentPoisonChunks).toEqual({count: 1, ids: [poisonId]});
+        expect(bothState.undeliverableChunks).toEqual({count: 1, ids: [monsterId]});
+        expect(bothState.embeddingRecovery ?? null).toBeNull();
+
+        // The strict checkpoint reader admits both censuses it just round-tripped — completion is
+        // worthless if the only surviving signal cannot be read back.
+        const readBack = normalizeTenantRepoCheckpointState(bothState);
+
+        expect(readBack.contentPoisonChunks).toEqual({count: 1, ids: [poisonId]});
+        expect(readBack.undeliverableChunks).toEqual({count: 1, ids: [monsterId]});
+
+        // Run-level projection carries both.
+        const poisonRowOut = result.details.repos.find(repo => repo.repoSlug === poisonSlug);
+        const bothRowOut   = result.details.repos.find(repo => repo.repoSlug === bothSlug);
+
+        expect(poisonRowOut.status).toBe('active');
+        expect(poisonRowOut.contentPoisonChunks).toEqual({count: 1, ids: [poisonId]});
+        expect(bothRowOut.status).toBe('active');
+        expect(bothRowOut.contentPoisonChunks).toEqual({count: 1, ids: [poisonId]});
+        expect(bothRowOut.undeliverableChunks).toEqual({count: 1, ids: [monsterId]});
+    });
+
+    test('a live row sharing a fence code still defers, and the retained cause is the LIVE one (#17139)', async () => {
+        const
+            taskStateService = createInMemoryTaskStateService(),
+            repoSlug         = 'org/live-beside-fence',
+            poisonId         = 'c'.repeat(64),
+            startedAt        = Date.now();
+
+        await provisionMirrorDir({tenantId: 't1', repoSlug});
+        await TenantRepoSyncService.writePersistedRevisions({
+            filePath : revisionsFile,
+            revisions: {[`t1/${repoSlug}`]: {
+                lastIngestedRev                   : null,
+                lastRunAttemptAt                  : startedAt - 120_000,
+                consecutiveFailures               : 0,
+                ingestContractVersion             : TENANT_REPO_INGEST_CONTRACT_VERSION,
+                lastAttemptedIngestContractVersion: TENANT_REPO_INGEST_CONTRACT_VERSION
+            }}
+        });
+
+        await TenantRepoSyncService.runTask({
+            reason           : 'periodic-sweep:60000',
+            taskStateService,
+            tenantReposConfig: {tenantRepos: [{
+                tenantId: 't1', repoSlug, mirrorRoot, cloneUrl: 'https://github.com/neomjs/live-beside-fence.git'
+            }]},
+            gitMirror                    : makeFakeGitMirror(),
+            envelopeBuilder              : makeFakeEnvelopeBuilder(),
+            knowledgeBaseIngestionService: makeFakeIngestionService({
+                // The ambiguity in its sharpest form: BOTH rows carry `KB_VECTOR_EMBED_TIMEOUT`. One is
+                // a durable fence, one is this sweep's live failure. A classifier reading codes alone
+                // cannot separate them — it either defers forever or completes over live work.
+                summaryFactory: () => ({ingested: 1, deleted: 0, embeddingsGenerated: 1, errors: [
+                    {
+                        code   : 'KB_VECTOR_EMBED_TIMEOUT',
+                        message: 'A proven embedding poison remains fenced.',
+                        details: {chunkId: poisonId, reasonCode: 'KB_VECTOR_EMBED_TIMEOUT', disposition: 'proven-content-poison'}
+                    },
+                    {code: 'KB_VECTOR_EMBED_TIMEOUT', message: 'one live timeout-class attempt ended'}
+                ]})
+            }),
+            revisionsFilePath: revisionsFile,
+            globalCadenceMs  : 60_000,
+            jitterRatio      : 0,
+            backoffCapMs     : 60_000,
+            seedBootstrap    : false
+        });
+
+        const state = (await fs.readJson(revisionsFile)).revisions[`t1/${repoSlug}`];
+
+        // Live work present ⇒ the checkpoint holds, exactly as before.
+        expect(state.lastIngestedRev).toBeNull();
+
+        // The retained cause comes from the live row. Both rows carry the same string here, so this
+        // asserts the SELECTION path stayed row-aware rather than the value being distinguishable.
+        expect(state.lastSourceErrorCode).toBe('KB_VECTOR_EMBED_TIMEOUT');
+
+        // The fence is still visible through the deferral.
+        expect(state.contentPoisonChunks).toEqual({count: 1, ids: [poisonId]});
+    });
+
+    test('a row failing ANY fence-gate clause is treated as LIVE work and keeps deferring (#17139)', async () => {
+        const
+            chunkId   = 'f'.repeat(64),
+            startedAt = Date.now(),
+            // Each variant breaks exactly one clause of the gate. `details` is unvalidated free shape,
+            // so every one of these is a row some other writer — or a hand-edited record — could
+            // produce, and each must fail toward LIVE. Completing on any of them would advance a
+            // checkpoint over work that never landed, and leave a census nobody can enumerate.
+            variants  = {
+                'unknown vocabulary'    : {chunkId, reasonCode: 'KB_VECTOR_EMBED_TIMEOUT', disposition: 'probably-fine'},
+                'missing disposition'   : {chunkId, reasonCode: 'KB_VECTOR_EMBED_TIMEOUT'},
+                'non-string disposition': {chunkId, reasonCode: 'KB_VECTOR_EMBED_TIMEOUT', disposition: true},
+                'incoherent reasonCode' : {chunkId, reasonCode: 'KB_VECTOR_EMBED_ABORTED', disposition: 'proven-content-poison'},
+                'missing reasonCode'    : {chunkId, disposition: 'proven-content-poison'},
+                'malformed chunkId'     : {chunkId: 'not-a-hash', reasonCode: 'KB_VECTOR_EMBED_TIMEOUT', disposition: 'proven-content-poison'},
+                'missing chunkId'       : {reasonCode: 'KB_VECTOR_EMBED_TIMEOUT', disposition: 'proven-content-poison'}
+            };
+
+        for (const [label, details] of Object.entries(variants)) {
+            const
+                taskStateService = createInMemoryTaskStateService(),
+                repoSlug         = `org/gate-${label.replace(/\W+/gu, '-')}`;
+
+            await provisionMirrorDir({tenantId: 't1', repoSlug});
+            await TenantRepoSyncService.writePersistedRevisions({
+                filePath : revisionsFile,
+                revisions: {[`t1/${repoSlug}`]: {
+                    lastIngestedRev                   : null,
+                    lastRunAttemptAt                  : startedAt - 120_000,
+                    consecutiveFailures               : 0,
+                    ingestContractVersion             : TENANT_REPO_INGEST_CONTRACT_VERSION,
+                    lastAttemptedIngestContractVersion: TENANT_REPO_INGEST_CONTRACT_VERSION
+                }}
+            });
+
+            await TenantRepoSyncService.runTask({
+                reason           : 'periodic-sweep:60000',
+                taskStateService,
+                tenantReposConfig: {tenantRepos: [{
+                    tenantId: 't1', repoSlug, mirrorRoot, cloneUrl: 'https://github.com/neomjs/gate.git'
+                }]},
+                gitMirror                    : makeFakeGitMirror(),
+                envelopeBuilder              : makeFakeEnvelopeBuilder(),
+                knowledgeBaseIngestionService: makeFakeIngestionService({
+                    summaryFactory: () => ({ingested: 1, deleted: 0, embeddingsGenerated: 1, errors: [
+                        {code: 'KB_VECTOR_EMBED_TIMEOUT', message: 'a row claiming to be a fence', details}
+                    ]})
+                }),
+                revisionsFilePath: revisionsFile,
+                globalCadenceMs  : 60_000,
+                jitterRatio      : 0,
+                backoffCapMs     : 60_000,
+                seedBootstrap    : false
+            });
+
+            const state = (await fs.readJson(revisionsFile)).revisions[`t1/${repoSlug}`];
+
+            expect(state.lastIngestedRev, `${label}: checkpoint must hold`).toBeNull();
+            expect(state.contentPoisonChunks ?? null, `${label}: must not enter the census`).toBeNull();
+        }
+    });
+
     test('the undeliverable census normalizer degrades torn records WHOLE (#17129)', () => {
         const monsterId = 'e'.repeat(64);
         const base      = {
@@ -445,6 +681,27 @@ test.describe('TenantRepoSyncService (#11790)', () => {
         expect(censusOf({count: 2, ids: [monsterId, monsterId]}), 'duplicate id').toBeNull();
         expect(censusOf({count: '1', ids: [monsterId]}),    'stringly count').toBeNull();
         expect(censusOf([monsterId]),                       'array shape').toBeNull();
+
+        // The content-poison census is the SAME reader over a second field, so it inherits the whole
+        // discipline rather than re-deriving it — including a record written before the field existed,
+        // which reads as "never observed" and not as "nothing fenced".
+        const poisonCensusOf = contentPoisonChunks =>
+            normalizeTenantRepoCheckpointState({...base, contentPoisonChunks}).contentPoisonChunks;
+
+        expect(poisonCensusOf({count: 3, ids: [monsterId]})).toEqual({count: 3, ids: [monsterId]});
+        expect(poisonCensusOf(undefined),                   'field absent on a pre-#17139 record').toBeNull();
+        expect(poisonCensusOf({count: 1, ids: ['not-a-hash']}), 'non-hash id').toBeNull();
+        expect(poisonCensusOf({count: 0, ids: []}),         'zero-count census').toBeNull();
+
+        // The two fields are independent: one torn census must not erase the other's observation.
+        const mixed = normalizeTenantRepoCheckpointState({
+            ...base,
+            undeliverableChunks: {count: 2, ids: [monsterId]},
+            contentPoisonChunks: {count: 1, ids: ['not-a-hash']}
+        });
+
+        expect(mixed.undeliverableChunks).toEqual({count: 2, ids: [monsterId]});
+        expect(mixed.contentPoisonChunks).toBeNull();
     });
 
     test('embedding recovery releases only the affected repo once, then rearms after a failed retry (#16692)', async () => {


### PR DESCRIPTION
Resolves neomjs/neo#17139

A repo whose only remaining ingestion errors were proven-content-poison fences classified `deferred` on every sweep, forever — the checkpoint never advanced, so each 60s sweep re-materialized and re-parsed the same delta for a state no later sweep could change. `classifyIngestionOutcome` now completes on a run whose every error row is a durable fence of **either** family, and the held checkpoint it gives up is replaced by a persisted `contentPoisonChunks` census beside the existing `undeliverableChunks`.

Evidence: L4 (production-composition arms through `runTask` against fake git/envelope/ingestion seams, asserting the persisted checkpoint file, plus arms on `collectTenantRepoSyncSnapshot` itself for the deployment surface) → L4 required (every close-target AC is a classifier/persistence/projection observable reachable in-process). Residual: none — no AC requires a live constrained plane.

Round 1 declared this same L4 while two of its arms could not fail on the regressions they named — the mixed-row arm used one code for both the fence and the live row, and the deployment claim was armed on `result.details.repos`, a different surface from the projection it cited. @neo-gpt's review caught both. Repaired and red-proved in `0041c8a7dd`; the mechanism itself was already correct and is unchanged.

## Deltas from ticket

**The mechanism fork was decided in-ticket, not in-diff.** The ticket shipped with a 3-way fork open (A: read `details.disposition` · B: a dedicated fence wrapper code · C: leave it). @neo-gpt's intake required it pinned before branch work, and recommended A. The body now records A with its rejected alternative and the falsifier that decided it: the distinction is metadata about a cause, not a cause, so a wrapper code would mutate every existing `deferredCauseCode`, recovery-arming, and persisted `lastSourceErrorCode` consumer to encode it.

**Cause selection moved into the classifier — this was not in the ticket and is load-bearing.** The intake's requirement was "`deferredCauseCode` comes only from live rows"; the ticket assumed that stayed a downstream filter, as it is on `dev` for the single undeliverable code. It cannot. A content poison carries the *ordinary* embed-domain code it failed with, so a fenced `KB_VECTOR_EMBED_TIMEOUT` and a live one are the same string by the time the deferred branch sees a flat code set. The row identity that separates them exists only inside the classifier, so `deferredCodes` is now computed from live rows there and the downstream filter is deleted.

**The fence gate requires a well-formed `chunkId`, which is stricter than the ticket's wording implies.** A row that cannot name its chunk cannot be enumerated in the census — and after completion the census is the *only* standing signal. So such a row fails toward LIVE and keeps deferring. This retires the previous census docblock's "COUNTED but not enumerated" clause for the id-gate case, which is now unreachable by construction.

**Two census fields, not one generalized total.** The ticket offered either. `IngestionService` already states the operator-facing reason for keeping the families apart: a content poison is a file to fix, an undeliverable chunk is a ceiling to raise. A merged count reliably sends the operator at the wrong one. The additive shape also means no migration — the existing normalizer was already family-neutral, so it is reused verbatim (renamed `normalizeFenceCensus`) and a pre-existing record reads `contentPoisonChunks: null` = never observed, never zero.

`corpusOutstanding` remains deliberately unchanged and is documented as an exclusion in the ticket rather than left to drift.

## Test Evidence

```
npx playwright test -c test/playwright/playwright.config.unit.mjs \
  test/playwright/unit/ai/daemons/orchestrator/ --workers=1
→ 1598 passed (1.5m)   [post-rebase onto 88f97780a5]
```

New arms — the first, second and fourth in `TenantRepoSyncService.spec.mjs` driving `runTask` rather than the classifier directly; the third in `DeploymentStateBridgeService.spec.mjs` on the snapshot collector itself:

| Arm | Proves |
|---|---|
| content-poison-only COMPLETES, and never arms recovery | checkpoint advances, streak resets, `contentPoisonChunks` persisted and round-tripped through the strict reader, `undeliverableChunks` stays `null`; a second repo carrying **both** families completes with each census populated independently. The fence code used is `KB_VECTOR_EMBED_TIMEOUT` — itself an `isEmbeddingRecoverySourceCode` match — so `embeddingRecovery` staying null is armed by construction, not by a code that could never have armed it |
| a live row beside a fence still defers, and the retained cause is the LIVE one | the fence row and the live row carry **distinguishable** codes with the fence **first**. Cause selection is a `.find()` over the code list in row order and both codes match the recovery-source pattern, so a fence leaking back into `deferredCodes` returns the fence code and the arm fails. Also asserts `embeddingRecovery.causeCode`, where the second-order defect actually lands |
| both censuses reach the **deployment snapshot** | on `collectTenantRepoSyncSnapshot` itself, not the run-level projection: both project with their own ids (a swap or a merge fails), a pre-existing record reads `contentPoisonChunks: null` rather than zero, and torn-record degradation is per-field so one half-written census cannot take a valid one down with it |
| any failing gate clause is LIVE | seven variants, one broken clause each (unknown vocabulary · missing / non-string disposition · incoherent / missing `reasonCode` · malformed / missing `chunkId`); every one holds the checkpoint and enters no census |

Normalizer arms extended for the new field, including a pre-#17139-shaped record and an independence check proving one torn census does not erase the other's observation.

**Red-proof (round 2 — the two arms above are proven able to fail, not asserted to be):**

| Mutation | Result |
|---|---|
| live-row filter → `summary.errors.slice()` (fences leak into `deferredCodes`) | cause arm **fails** at the retained-code assertion |
| delete the `contentPoisonChunks` projection line in `DeploymentStateBridgeService` | snapshot arm **fails** at the both-project assertion |

Production files restored byte-identical afterwards (`git diff --stat -- ai/` empty), then `1598 passed` across the orchestrator directory.

Directly touched surfaces: `TenantRepoSyncService` — the spec above. `tenantRepoCheckpointValidity` — same spec's normalizer arms. `DeploymentStateBridgeService` — `DeploymentStateBridgeService.spec.mjs`, green in the run above; the added line is a pure projection of a field the normalizer validates fail-closed.

Pre-commit gates run on the changed files ahead of the commit: whitespace, shorthand, jsdoc-types, ticket-archaeology, block-alignment, parse, atomic-write-shape, aiconfig-test-mutation — all pass, and all re-ran green in the hook itself.

## Post-Merge Validation

Nothing is owed after merge. Every close-target AC is a classifier, checkpoint-persistence, or projection observable reachable in-process, and each is armed above — including the two that a live plane would otherwise be needed for: checkpoint persistence across a completing sweep, asserted against the written revisions file, and snapshot visibility, asserted on `collectTenantRepoSyncSnapshot` itself rather than on the run-level projection beside it.

For readers watching the constrained plane, the expected effects — consequences of the arms above, not validation gates standing in for missing evidence — are that a repo previously pinned at `deferred` with content-poison-only errors advances its `lastIngestedRev` on the next sweep, that `contentPoisonChunks` appears on its snapshot row, and that its sweep wall-clock drops by the re-materialization it no longer repeats.

## Commits

- `69d27bcdce` — the classifier gate, the generalized per-family census, the normalizer rename, the projection line, and the three composition arms.
- `0041c8a7dd` — evidence repair after review: the fence-vs-live cause arm and the deployment-snapshot census arms made able to fail, both red-proved. No production change.

## Evolution

The ticket was filed with the fence-identification mechanism deliberately unresolved, because choosing it inside PR neomjs/neo#17133's review round would have made a wide-blast-radius decision a rider on someone else's cycle. Pinning it in the ticket under intake pressure was the right sequencing: the falsifier that decided A (metadata-vs-cause) is also what predicted the downstream cause-selection problem, which the diff then confirmed. Reading the writer at `IngestionService` for the gate's coherence clause is what surfaced that `details.reasonCode` already sits beside the top-level `code` — the redundancy that makes the gate free of new writer state, and which the ticket's original divergence note did not know about.

Related: neomjs/neo-agent-brain#38
Refs neomjs/neo#17129

Authored by Vega (Claude Opus 5, Claude Code). Session 5cd926fa-77e1-4309-8bbf-ca563ab07403.
