### PR TITLE
feat(fleet): presence bands derive from vouched beacon horizons at the snapshot bound (#17153)

### DIFF
--- a/ai/services/fleet/fleetPresenceStateAdapter.mjs
+++ b/ai/services/fleet/fleetPresenceStateAdapter.mjs
@@ -104,16 +104,20 @@ export function beaconFreshAtBound({turnPresence, boundAt = null} = {}) {
         return booleanFallback
     }
 
+    const expiresAt = toTime(turnPresence.expiresAt)
+
+    // the expired-observation veto precedes EVERY other signal — including the boolean
+    // fallback for degraded horizon tiers: a row whose freshUntil is absent or malformed
+    // must still lose a validly expired observation, or the fallback re-opens the exact
+    // producer-clock trust this helper exists to close
+    if (expiresAt !== null && expiresAt <= boundAt) {
+        return false
+    }
+
     const freshUntil = toTime(turnPresence.freshUntil)
 
     if (freshUntil === null) {
         return booleanFallback
-    }
-
-    const expiresAt = toTime(turnPresence.expiresAt)
-
-    if (expiresAt !== null && expiresAt <= boundAt) {
-        return false
     }
 
     return freshUntil > boundAt

--- a/ai/services/fleet/fleetPresenceStateAdapter.mjs
+++ b/ai/services/fleet/fleetPresenceStateAdapter.mjs
@@ -19,11 +19,17 @@
  * capability — the producer answered in-contract; absence of one seat is that row's truth. Only a
  * missing, throwing, or out-of-contract PRODUCER degrades the capability envelope.
  *
- * Band refinement residual (deliberate): the ticket's full beacon-horizon vocabulary
- * (`active-turn / fresh / recent / dark` from `freshUntil`/`expiresAt`) lands when the plane's
- * verbose rows vouch those horizons per seat; until then this axis carries the plane's emitted
- * band set plus `lastSeenAt` recency verbatim — rendered tiers are named, absent tiers stay
- * absent, and nothing here manufactures a finer band than the producer emitted.
+ * Beacon-horizon derivation: the plane's verbose rows vouch the beacon horizons per seat
+ * (`signals.turnPresence.freshUntil` / `.expiresAt`, verbatim from the TurnPresenceService
+ * observation), and the `active-turn` grade DERIVES from those
+ * vouched horizons evaluated at THIS snapshot's own `capturedAt` bound — never from the
+ * producer-computed `fresh` boolean when horizons are present. The boolean was stamped at the
+ * producer's clock; the envelope declares `capturedAt` as the observation-time bound for every
+ * row, so the grade and the bound must share one clock value or the render lies by skew. Rows
+ * whose producers vouch NO horizons (older projection, degraded tier) fall back to the vouched
+ * boolean — absence of the horizon tier produces absence of refinement, never a verdict. No
+ * second clock authority: this module evaluates vouched instants against a vouched bound; it
+ * never re-computes liveness with windows of its own.
  */
 
 import {redactCredentials} from './redactCredentials.mjs'
@@ -71,6 +77,48 @@ export function gradePresenceBand({state, beaconFresh = false} = {}) {
     return state === 'online' ? 'fresh' : state === 'idle' ? 'recent' : state
 }
 
+/**
+ * @summary Derive one row's beacon freshness from its vouched horizons, evaluated at the
+ * snapshot's observation bound. Pure and total — the ONE place beacon freshness is decided.
+ *
+ * Precedence: an expired observation (`expiresAt` at/behind the bound) vouches nothing,
+ * whatever its `fresh` boolean claims; a present `freshUntil` governs against the bound (the
+ * producer's boolean was stamped at the PRODUCER's clock — trusting it across the skew is how a
+ * finished turn keeps rendering `active-turn`); horizons absent or unparseable fall back to the
+ * vouched boolean (tier degradation: no horizon tier ⇒ no refinement, never a verdict); no
+ * usable bound falls back the same way.
+ * @param {Object} options
+ * @param {Object|null} [options.turnPresence] The row's vouched beacon observation
+ *     (`{fresh, freshUntil, expiresAt, …}`) — `null` when the seat emitted none.
+ * @param {Number|null} [options.boundAt] The snapshot's observation bound as epoch ms.
+ * @returns {Boolean}
+ */
+export function beaconFreshAtBound({turnPresence, boundAt = null} = {}) {
+    if (!turnPresence || typeof turnPresence !== 'object') {
+        return false
+    }
+
+    const booleanFallback = turnPresence.fresh === true
+
+    if (!Number.isFinite(boundAt)) {
+        return booleanFallback
+    }
+
+    const freshUntil = toTime(turnPresence.freshUntil)
+
+    if (freshUntil === null) {
+        return booleanFallback
+    }
+
+    const expiresAt = toTime(turnPresence.expiresAt)
+
+    if (expiresAt !== null && expiresAt <= boundAt) {
+        return false
+    }
+
+    return freshUntil > boundAt
+}
+
 export const PRESENCE_SOURCE_LABEL = 'fleet:presenceState'
 
 /**
@@ -112,7 +160,12 @@ export async function readFleetPresenceSnapshot({
     capturedAt = new Date()
 } = {}) {
     const hasReader = typeof readPresence === 'function',
-          states    = []
+          // ONE resolved bound: the same instant the envelope declares as `capturedAt` is the
+          // instant every beacon horizon is evaluated against — bound and declaration can never
+          // drift apart by clock skew or a second `new Date()`
+          capturedAtIso = toIsoString(capturedAt),
+          capturedAtMs  = new Date(capturedAtIso).getTime(),
+          states        = []
 
     let byIdentity = null,
         readReason = hasReader
@@ -136,9 +189,10 @@ export async function readFleetPresenceSnapshot({
 
                     byIdentity.set(row.identity, {
                         state      : row.state,
-                        // the vouched beacon signal (the per-row turn-presence observation): the ONLY
-                        // input the recency grade adds over the plane's own verdict
-                        beaconFresh: row.signals?.turnPresence?.fresh === true,
+                        // the vouched beacon observation (horizons + boolean): the ONLY input the
+                        // recency grade adds over the plane's own verdict — evaluated at the
+                        // snapshot bound below, never trusted at the producer's clock
+                        beaconFresh: beaconFreshAtBound({turnPresence: row.signals?.turnPresence, boundAt: capturedAtMs}),
                         lastSeenAt : row.signals?.activityRecency?.lastActivityAt ?? null,
                         reason     : typeof row.reason === 'string' ? redactReason(row.reason) : null
                     })
@@ -195,7 +249,7 @@ export async function readFleetPresenceSnapshot({
             source    : PRESENCE_SOURCE_LABEL,
             state     : producerAnswered ? 'wired' : 'degraded',
             confidence: producerAnswered ? 'observed' : 'none',
-            capturedAt: toIsoString(capturedAt),
+            capturedAt: capturedAtIso,
             reason    : producerAnswered ? null : readReason
         },
         states
@@ -219,6 +273,14 @@ export function presenceIdentityForAgent(agent) {
 
 function asArray(value) {
     return Array.isArray(value) ? value : []
+}
+
+function toTime(value) {
+    if (value == null) return null
+
+    const time = new Date(value).getTime()
+
+    return Number.isNaN(time) ? null : time
 }
 
 function redactReason(value) {

--- a/test/playwright/unit/ai/services/fleet/fleetPresenceStateAdapter.spec.mjs
+++ b/test/playwright/unit/ai/services/fleet/fleetPresenceStateAdapter.spec.mjs
@@ -292,6 +292,12 @@ test.describe('fleetPresenceStateAdapter — beacon horizons (the vouched-bound 
         // an expired observation vouches nothing, whatever its horizons or boolean claim
         expect(beaconFreshAtBound({turnPresence: {fresh: true, freshUntil: '2026-08-11T00:30:00.000Z', expiresAt: '2026-08-11T00:00:00.000Z'}, boundAt})).toBe(false)
 
+        // the veto also beats the DEGRADED-tier boolean fallback: absent or malformed freshUntil
+        // must not smuggle a fresh:true past a validly expired observation (the reviewer's
+        // exact-head falsifier pair)
+        expect(beaconFreshAtBound({turnPresence: {fresh: true, expiresAt: '2026-08-10T23:00:00.000Z'}, boundAt})).toBe(false)
+        expect(beaconFreshAtBound({turnPresence: {fresh: true, expiresAt: '2026-08-10T23:00:00.000Z', freshUntil: 'not-a-date'}, boundAt})).toBe(false)
+
         // horizon tier absent or unparseable → the vouched boolean is the only signal
         // (tier degradation: no refinement, never a fabricated verdict)
         expect(beaconFreshAtBound({turnPresence: {fresh: true},  boundAt})).toBe(true)

--- a/test/playwright/unit/ai/services/fleet/fleetPresenceStateAdapter.spec.mjs
+++ b/test/playwright/unit/ai/services/fleet/fleetPresenceStateAdapter.spec.mjs
@@ -18,6 +18,7 @@ import Neo            from '../../../../../../src/Neo.mjs'
 import * as core      from '../../../../../../src/core/_export.mjs'
 
 import {
+    beaconFreshAtBound,
     gradePresenceBand,
     PRESENCE_BANDS,
     PRESENCE_SOURCE_LABEL,
@@ -134,6 +135,9 @@ test.describe('fleetPresenceStateAdapter — healthy report (band join)', () => 
                 {id: 'long-turn', githubUsername: 'long-turn'},
                 {id: 'benched',   githubUsername: 'benched'}
             ],
+            // the bound is pinned BEFORE the vouched freshUntil — the beacon is fresh AT THIS
+            // SNAPSHOT, deterministically (never an implicit wall-clock `new Date()`)
+            capturedAt  : '2026-08-11T00:00:00.000Z',
             readPresence: () => ({agents: [
                 // fresh beacon + fresh activity: mid-turn RIGHT NOW
                 {identity: '@mid-turn', state: 'online', signals: {turnPresence: {fresh: true, freshUntil: '2026-08-11T00:30:00.000Z'}}},
@@ -270,5 +274,59 @@ test.describe('fleetPresenceStateAdapter — healthy report (band join)', () => 
 
         expect(states).toHaveLength(1)
         expect(states[0].agentId).toBe('real')
+    })
+})
+
+test.describe('fleetPresenceStateAdapter — beacon horizons (the vouched-bound derivation)', () => {
+    test('beaconFreshAtBound is pure and total: horizons govern at the bound; the boolean is only the degraded-tier fallback', () => {
+        const boundAt = Date.parse('2026-08-11T00:00:00.000Z')
+
+        // no observation → never fresh
+        expect(beaconFreshAtBound({})).toBe(false)
+        expect(beaconFreshAtBound({turnPresence: null, boundAt})).toBe(false)
+
+        // a vouched horizon governs — in BOTH directions, whatever the producer boolean claims
+        expect(beaconFreshAtBound({turnPresence: {fresh: false, freshUntil: '2026-08-11T00:30:00.000Z'}, boundAt})).toBe(true)
+        expect(beaconFreshAtBound({turnPresence: {fresh: true,  freshUntil: '2026-08-10T23:59:00.000Z'}, boundAt})).toBe(false)
+
+        // an expired observation vouches nothing, whatever its horizons or boolean claim
+        expect(beaconFreshAtBound({turnPresence: {fresh: true, freshUntil: '2026-08-11T00:30:00.000Z', expiresAt: '2026-08-11T00:00:00.000Z'}, boundAt})).toBe(false)
+
+        // horizon tier absent or unparseable → the vouched boolean is the only signal
+        // (tier degradation: no refinement, never a fabricated verdict)
+        expect(beaconFreshAtBound({turnPresence: {fresh: true},  boundAt})).toBe(true)
+        expect(beaconFreshAtBound({turnPresence: {fresh: false}, boundAt})).toBe(false)
+        expect(beaconFreshAtBound({turnPresence: {fresh: true, freshUntil: 'not-a-date'}, boundAt})).toBe(true)
+
+        // no usable bound → boolean fallback (never NaN comparisons)
+        expect(beaconFreshAtBound({turnPresence: {fresh: true, freshUntil: '2026-08-10T00:00:00.000Z'}})).toBe(true)
+    })
+
+    test('the skew falsifier: ONE payload, two bounds — the grade derives from the vouched horizon, never the producer clock', async () => {
+        const
+            roster  = [{id: 'seat', githubUsername: 'seat'}],
+            payload = {agents: [{
+                identity: '@seat',
+                state   : 'online',
+                signals : {turnPresence: {fresh: true, freshUntil: '2026-08-11T00:30:00.000Z', expiresAt: '2026-08-11T01:00:00.000Z'}}
+            }]}
+
+        // bound BEFORE freshUntil: mid-turn right now
+        const early = await readFleetPresenceSnapshot({agents: roster, readPresence: () => payload, capturedAt: '2026-08-11T00:15:00.000Z'})
+
+        expect(early.states[0].presence).toBe('active-turn')
+
+        // the SAME payload at a later bound: the producer boolean still claims fresh, the vouched
+        // horizon says the turn ended — the grade follows the horizon down to the plane verdict
+        const late = await readFleetPresenceSnapshot({agents: roster, readPresence: () => payload, capturedAt: '2026-08-11T00:45:00.000Z'})
+
+        expect(late.states[0].presence).toBe('fresh')
+
+        // past expiry the observation vouches nothing at all; the envelope bound is the same
+        // instant the horizons were evaluated against — one clock value, declared
+        const expired = await readFleetPresenceSnapshot({agents: roster, readPresence: () => payload, capturedAt: '2026-08-11T01:30:00.000Z'})
+
+        expect(expired.states[0].presence).toBe('fresh')
+        expect(expired.capability.capturedAt).toBe('2026-08-11T01:30:00.000Z')
     })
 })


### PR DESCRIPTION
Resolves neomjs/neo#17153

Refs neomjs/neo-agent-brain#53

The roster's `active-turn` grade now DERIVES from the producer-vouched beacon horizons (`signals.turnPresence.freshUntil` / `.expiresAt`) evaluated at the snapshot's own `capturedAt` bound — closing the documented residual where the grade trusted the producer-computed `fresh` boolean across clock skew (a finished turn could keep rendering `active-turn`: the inverse of the 70-minute-flap the boolean was built for). One resolved `capturedAt` now serves as BOTH the envelope declaration and every horizon evaluation, so bound and declaration cannot drift by a second `new Date()`; rows whose producers vouch no horizons keep the boolean fallback (tier degradation: absence of the horizon tier produces absence of refinement, never a verdict). New pure exported helper `beaconFreshAtBound` is the one place beacon freshness is decided — NaN-safe, total, expired-observation veto first.

Evidence: L2 (scoped unit receipts — pure-module derivation + snapshot-seam fixtures) → L2 sufficient for the close-target ACs (all adapter-side and specable). Residual: one live `active-turn` observation against a beacon-emitting deployment (the current deployment's beacon WRITE path is down: `turnPresence: null` fleet-wide in verbose `who_is_online`, `presenceTerminal: failed` on every `add_memory`), Residual-Owner: neomjs/neo-agent-brain#53.

## Deltas from ticket

None substantive — the flap-falsifier fixture re-pin to explicit bounds is part of the leg's determinism claim (the prior fixture's implicit wall-clock bound went stale when the calendar passed its pinned horizon strings, which is itself the defect class this PR closes).

## Test Evidence

- `npm run test-unit -- test/playwright/unit/ai/services/fleet/fleetPresenceStateAdapter.spec.mjs` → **18 passed (4.9s)** pre-commit, re-verified **18 passed (2.6s)** at the committed head after the block-alignment auto-fix.
- Coverage delta: +1 pure matrix spec for `beaconFreshAtBound` (absent observation · horizon-over-boolean both directions · expired-observation veto · boolean fallback for absent/unparseable horizons · absent bound) and +1 skew falsifier (ONE payload, three bounds: `active-turn` → `fresh` → expired) proving horizon-derivation over producer-clock trust; the 16 pre-existing specs stay green unchanged (boolean-fallback compatibility).
- Surface `ai/services/fleet` (roster presence axis): the spec above is the existing coverage, extended; no app/UI surface touched.

## Post-Merge Validation

- [x] Scoped spec suite re-runnable on dev post-merge: `npm run test-unit -- test/playwright/unit/ai/services/fleet/fleetPresenceStateAdapter.spec.mjs` (18 specs, self-contained fixtures, no deployment dependency).

The live skew observation (one `active-turn` row decaying to `fresh` past its vouched `freshUntil` in verbose `who_is_online`) deliberately carries NO checkbox here: it is gated on the deployment's beacon write path (currently down: `turnPresence` null fleet-wide, `presenceTerminal: failed`), not on this merge — the obligation is owned by neomjs/neo-agent-brain#53's delivery-state, per the Evidence residual above.

Authored by Clio (Claude Fable 5, Claude Code). Session 1deebbe1-b7e6-4f76-b39d-9cfcbe342596.
