### PR TITLE
feat(fleet): broken viewer binding renders binding-unavailable, never an empty fleet (#17157)

### DIFF
--- a/ai/services/fleet/fleetPresenceStateAdapter.mjs
+++ b/ai/services/fleet/fleetPresenceStateAdapter.mjs
@@ -126,6 +126,16 @@ export function beaconFreshAtBound({turnPresence, boundAt = null} = {}) {
 export const PRESENCE_SOURCE_LABEL = 'fleet:presenceState'
 
 /**
+ * The closed set of typed capability reason codes this adapter will pass through — the render
+ * contract's side of the binding-signal chain. The producing client stamps `planeBlockerCode`
+ * at the refusal sites that KNOW (identity-oracle refusals); this adapter passes a RECOGNIZED
+ * stamp through verbatim and drops everything else — never message-matching, never inventing a
+ * code, the same closed-set admission every other tier gets.
+ * @type {String[]}
+ */
+export const PRESENCE_CAPABILITY_REASON_CODES = Object.freeze(['viewer-binding-unavailable'])
+
+/**
  * @summary Reads the fleet-wide presence snapshot: one band row per registered agent plus a
  * capability envelope declaring whether the presence producer answered.
  *
@@ -171,8 +181,9 @@ export async function readFleetPresenceSnapshot({
           capturedAtMs  = new Date(capturedAtIso).getTime(),
           states        = []
 
-    let byIdentity = null,
-        readReason = hasReader
+    let byIdentity     = null,
+        readReasonCode = null,
+        readReason     = hasReader
             ? null
             : 'no presence truth source exists for this mode: plane mode injects the who_is_online reader; a host presence surface has not landed'
 
@@ -203,7 +214,11 @@ export async function readFleetPresenceSnapshot({
                 }
             }
         } catch (error) {
-            readReason = redactReason(error) || 'presence read failed'
+            readReason = redactReason(error) || 'presence read failed';
+
+            if (PRESENCE_CAPABILITY_REASON_CODES.includes(error?.planeBlockerCode)) {
+                readReasonCode = error.planeBlockerCode
+            }
         }
     }
 
@@ -254,7 +269,8 @@ export async function readFleetPresenceSnapshot({
             state     : producerAnswered ? 'wired' : 'degraded',
             confidence: producerAnswered ? 'observed' : 'none',
             capturedAt: capturedAtIso,
-            reason    : producerAnswered ? null : readReason
+            reason    : producerAnswered ? null : readReason,
+            ...(readReasonCode ? {reasonCode: readReasonCode} : {})
         },
         states
     }

--- a/ai/services/fleet/planeMailboxClient.mjs
+++ b/ai/services/fleet/planeMailboxClient.mjs
@@ -65,6 +65,18 @@ import {
  * @returns {Object} `{init, callTool, listMessages, addMessage, close}`
  * @throws {Error} When the endpoint fails the shared secure-endpoint policy.
  */
+/**
+ * The typed binding-class blocker code this client stamps on refusals it KNOWS are viewer-binding
+ * failures — the identity-oracle refusals in `connectProven` (no canonical identity / identity
+ * mismatch), the one class whose leak would re-attribute the whole surface. Transport failures,
+ * timeouts, and 5xx stay UNSTAMPED: they are ambiguous, and an ambiguous stamp would misclassify
+ * exactly the way the mirror adapter's bare-`Unauthorized` warning names. Consumers (the presence
+ * adapter's `reasonCode` passthrough) bind to this string BY CONTRACT and guard with their own
+ * closed set — never by message-matching.
+ * @type {String}
+ */
+export const VIEWER_BINDING_UNAVAILABLE = 'viewer-binding-unavailable'
+
 export function createPlaneMailboxClient({baseUrl, credential = '', fetchImpl = null, createSession = null, allowPlainHttpHosts = []}) {
     const endpoint = normalizeSecureMcpEndpoint(baseUrl, {allowPlainHttpHosts});
 
@@ -155,7 +167,7 @@ export function createPlaneMailboxClient({baseUrl, credential = '', fetchImpl = 
         if (!identity) {
             await teardown(candidate);
 
-            return {ok: false, reason: 'plane identity probe returned no canonical identity'}
+            return {ok: false, reason: 'plane identity probe returned no canonical identity', blockerCode: VIEWER_BINDING_UNAVAILABLE}
         }
 
         if (identity !== expected) {
@@ -163,7 +175,7 @@ export function createPlaneMailboxClient({baseUrl, credential = '', fetchImpl = 
             // to a different subject would silently re-attribute the whole surface.
             await teardown(candidate);
 
-            return {ok: false, reason: 'plane identity mismatch'}
+            return {ok: false, reason: 'plane identity mismatch', blockerCode: VIEWER_BINDING_UNAVAILABLE}
         }
 
         session = {...candidate, identity};
@@ -202,6 +214,25 @@ export function createPlaneMailboxClient({baseUrl, credential = '', fetchImpl = 
      * @returns {Boolean}
      * @private
      */
+    /**
+     * @summary Build the session-lost throw, carrying the readmission's typed blocker code
+     * verbatim when the refusal site stamped one — the refusal site already classified; the
+     * throw only CARRIES the type, never derives it.
+     * @param {String} name
+     * @param {Object} readmission
+     * @returns {Error}
+     * @private
+     */
+    function sessionLostError(name, readmission) {
+        const failure = new Error(`plane ${name} failed: session lost and ${readmission.reason}`);
+
+        if (readmission.blockerCode) {
+            failure.planeBlockerCode = readmission.blockerCode
+        }
+
+        return failure
+    }
+
     function isSessionInvalid(error) {
         return error?.code === 404 || /\bHTTP 404\b/.test(error?.message ?? '')
     }
@@ -285,7 +316,7 @@ export function createPlaneMailboxClient({baseUrl, credential = '', fetchImpl = 
                 const readmission = await acquireProven();
 
                 if (!readmission.ok) {
-                    throw new Error(`plane ${name} failed: session lost and ${readmission.reason}`)
+                    throw sessionLostError(name, readmission)
                 }
 
                 recovered = true
@@ -325,7 +356,7 @@ export function createPlaneMailboxClient({baseUrl, credential = '', fetchImpl = 
                     const readmission = await acquireProven();
 
                     if (!readmission.ok) {
-                        throw new Error(`plane ${name} failed: session lost and ${readmission.reason}`)
+                        throw sessionLostError(name, readmission)
                     }
 
                     fresh = session

--- a/test/playwright/unit/ai/planeMailboxClient.spec.mjs
+++ b/test/playwright/unit/ai/planeMailboxClient.spec.mjs
@@ -217,7 +217,7 @@ test.describe('planeMailboxClient: init (SDK handshake + single-viewer proof)', 
     test('identity mismatch refuses fail-closed AND tears the session down (awaited DELETE)', async () => {
         const {admission, plane} = await initializedClient({identityBySession: ['@someone-else']});
 
-        expect(admission).toEqual({ok: false, reason: 'plane identity mismatch'});
+        expect(admission).toEqual({ok: false, reason: 'plane identity mismatch', blockerCode: 'viewer-binding-unavailable'});
         expect(plane.calls.some(call => call.method === 'DELETE')).toBe(true)
     });
 
@@ -455,11 +455,25 @@ test.describe('planeMailboxClient: session loss (one bounded recovery, identity 
             toolResponder    : () => ({status: 404})
         });
 
-        await expect(client.listMessages())
-            .rejects.toThrow('plane list_messages failed: session lost and plane identity mismatch');
+        const failure = await client.listMessages().then(() => null, error => error);
+
+        expect(failure?.message).toBe('plane list_messages failed: session lost and plane identity mismatch');
+        // the binding-class stamp travels the throw: the refusal site classified, the error CARRIES
+        expect(failure?.planeBlockerCode).toBe('viewer-binding-unavailable');
 
         expect(plane.calls.filter(call => call.toolName === 'list_messages')).toHaveLength(1);
         expect(plane.calls.filter(call => call.toolName === 'list_permissions')).toHaveLength(2)
+    });
+
+    test('an ambiguous transport failure carries NO binding stamp — ambiguity never classifies', async () => {
+        const {client} = await initializedClient({
+            toolResponder: () => ({status: 500})
+        });
+
+        const failure = await client.listMessages().then(() => null, error => error);
+
+        expect(failure).toBeInstanceOf(Error);
+        expect(failure.planeBlockerCode).toBeUndefined()
     });
 
     test('a reconnect against a dead plane throws through, not into a retry loop', async () => {

--- a/test/playwright/unit/ai/services/fleet/fleetCockpitStatus.spec.mjs
+++ b/test/playwright/unit/ai/services/fleet/fleetCockpitStatus.spec.mjs
@@ -308,6 +308,26 @@ test.describe('fleetCockpitStatus - Body-side cockpit DTO contract', () => {
         expect(snapshot.capabilities.presence).toMatchObject({state: 'wired'})
     })
 
+    test('a degraded presence capability carries its typed reasonCode to the DTO intact — supplied object wins whole', () => {
+        const snapshot = createFleetCockpitStatus({
+            agents      : [{id: 'clio', githubUsername: 'neo-fable-clio'}],
+            capabilities: {presence: {
+                source    : FLEET_COCKPIT_SOURCES.presence,
+                state     : 'degraded',
+                confidence: 'none',
+                reason    : 'plane who_is_online failed: session lost and plane identity mismatch',
+                reasonCode: 'viewer-binding-unavailable'
+            }}
+        })
+
+        // the binding-signal chain's last hop: the adapter's typed code reaches the cockpit DTO
+        // unchanged — C3 renders "binding unavailable" from THIS field, never from prose-matching
+        expect(snapshot.capabilities.presence).toMatchObject({
+            state     : 'degraded',
+            reasonCode: 'viewer-binding-unavailable'
+        })
+    })
+
     test('an unwired throttle producer reads unknown/none in the ROW, not-wired only in the wiring axes', () => {
         const snapshot = createFleetCockpitStatus({agents: [{id: 'grace'}]}),
               row      = snapshot.rows[0]

--- a/test/playwright/unit/ai/services/fleet/fleetPresenceStateAdapter.spec.mjs
+++ b/test/playwright/unit/ai/services/fleet/fleetPresenceStateAdapter.spec.mjs
@@ -21,6 +21,7 @@ import {
     beaconFreshAtBound,
     gradePresenceBand,
     PRESENCE_BANDS,
+    PRESENCE_CAPABILITY_REASON_CODES,
     PRESENCE_SOURCE_LABEL,
     PRESENCE_STATES,
     presenceIdentityForAgent,
@@ -81,6 +82,45 @@ test.describe('fleetPresenceStateAdapter — capability envelope (producer healt
         expect(capability.confidence).toBe('none')
         expect(capability.reason).toBe('plane unreachable')
         expect(states.every(row => row.presence === 'unknown')).toBe(true)
+    })
+
+    test('a binding-classified read degrades WITH the typed reasonCode — and never an empty fleet', async () => {
+        const {capability, states} = await readFleetPresenceSnapshot({
+            agents,
+            readPresence: () => {
+                throw Object.assign(new Error('plane who_is_online failed: session lost and plane identity mismatch'), {
+                    planeBlockerCode: 'viewer-binding-unavailable'
+                })
+            }
+        })
+
+        expect(capability.state).toBe('degraded')
+        expect(capability.reasonCode).toBe('viewer-binding-unavailable')
+        expect(PRESENCE_CAPABILITY_REASON_CODES).toContain(capability.reasonCode)
+
+        // binding-unavailable is NEVER rendered as an empty/dark fleet: every roster row answers
+        expect(states).toHaveLength(agents.length)
+        expect(states.every(row => row.presence === 'unknown')).toBe(true)
+    })
+
+    test('an unclassified failure carries NO reasonCode — and an unrecognized stamp is dropped, never admitted', async () => {
+        const plain = await readFleetPresenceSnapshot({
+            agents,
+            readPresence: () => { throw new Error('plane unreachable') }
+        })
+
+        expect(plain.capability.state).toBe('degraded')
+        expect('reasonCode' in plain.capability).toBe(false)
+
+        // the closed-set guard: an out-of-vocabulary stamp must not leak an open enum downstream
+        const unrecognized = await readFleetPresenceSnapshot({
+            agents,
+            readPresence: () => {
+                throw Object.assign(new Error('weird'), {planeBlockerCode: 'made-up-code'})
+            }
+        })
+
+        expect('reasonCode' in unrecognized.capability).toBe(false)
     })
 
     test('a malformed answer (no agents array) is unreadable, never an empty fleet', async () => {


### PR DESCRIPTION
Resolves neomjs/neo#17157

Refs neomjs/neo-agent-brain#53

The identity-binding third signal is now typed end-to-end: the plane client stamps `planeBlockerCode: 'viewer-binding-unavailable'` at the two refusal sites that KNOW they are binding-class (the identity-oracle's no-canonical-identity and identity-mismatch refusals in `connectProven` — "the one refusal that protects every admission decision downstream"), the thrown session-lost errors CARRY the stamp verbatim (a shared `sessionLostError` builder copies, never derives), the presence adapter passes a recognized code through as `capability.reasonCode` behind its own closed set (`PRESENCE_CAPABILITY_REASON_CODES` — an unrecognized stamp is dropped, never admitted), and the cockpit DTO delivers it intact. A post-admission viewer-binding failure — binding drift or a failed reacquisition — is now RENDERABLE as "binding unavailable" from a typed field — never inferred from prose, and never mistakable for an empty fleet (every roster row still answers `unknown`); the initial-admission refusal stays terminal by design (`devFleetServer` exits before any capability DTO exists) and fabricates nothing. Ambiguous failures (transport, timeout, 5xx) deliberately stay unstamped: ambiguity never classifies, per the `fleetMailboxMirrorAdapter` anti-misclassification precedent (bare-`Unauthorized` warning) this design follows.

Evidence: L2 (scoped unit receipts across all three chain hops — client refusal/throw sites via the scripted-plane harness, adapter passthrough via the reader seam, cockpit DTO via the pure map) → L2 sufficient for the close-target ACs (every AC adapter/client/DTO-side and specable). Residual: C3's render-side consumption of the typed field (the pane state itself), Residual-Owner: neomjs/neo-agent-brain#53.

## Deltas from ticket

One narrowing, stated: the ticket's Fix step 1 mentioned enumerating plane-side admission-denial texts as a second stamp class; the enumeration found the presence path's binding-class failures all route through the identity-oracle refusals (who_is_online is roster-wide — no per-subject admission scope like the mirror's `CAN_READ_INBOX_OF`), so the two `connectProven` sites are the complete stamp set for this chain. No tool-text matching was added anywhere — which is the stricter reading of the ticket's own anti-misclassification requirement.

Post-merge body correction (reviewer phase-wording catch, @neo-gpt): the renderability claim above originally said "a broken viewer binding" unqualified, overclaiming by one phase — what this PR types is the post-admission phase only; the initial binding refusal was and remains terminal before any capability DTO exists. No code change.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/ai/planeMailboxClient.spec.mjs test/playwright/unit/ai/services/fleet/fleetPresenceStateAdapter.spec.mjs` → **45 passed (2.8s)**.
- `npm run test-unit -- test/playwright/unit/ai/services/fleet/fleetCockpitStatus.spec.mjs` → **21 passed (2.4s)**.
- New coverage: mismatch refusal `toEqual` now VERIFIES the stamp; the changed-identity reconnect test asserts the thrown error carries `planeBlockerCode`; ambiguity-never-classifies (500-class → no stamp); binding-classified read → `reasonCode` + full roster of `unknown` rows (never an empty fleet); unclassified failure → no `reasonCode` field; unrecognized stamp → dropped (closed-set guard); degraded presence capability with `reasonCode` reaches the cockpit DTO intact.
- Surface `ai/services/fleet` (plane client + presence axis + cockpit map): the three spec files above are the existing coverage, extended; no app/UI surface touched.

## Post-Merge Validation

- [x] All three touched spec files re-runnable on dev post-merge (self-contained scripted-plane/fixture harnesses, no deployment dependency).

Branch note: sibling PR neomjs/neo#17154 (leg 1, in verification) touches the same adapter on adjacent lines (envelope `capturedAt` line vs the added `reasonCode` spread; different let/const blocks) — zero-to-trivial merge in either landing order; whichever lands second rebases mechanically.

Authored by Clio (Claude Fable 5, Claude Code). Session 1deebbe1-b7e6-4f76-b39d-9cfcbe342596.
