### PR TITLE
fix(devindex): restore the stargazer read and stop a dead phase killing the working one (#17150)

### DIFF
--- a/.github/workflows/data-sync-pipeline.yml
+++ b/.github/workflows/data-sync-pipeline.yml
@@ -112,16 +112,17 @@ jobs:
           # reach. The #15744 property that matters — the intake identity cannot publish to this
           # repository — is intact.
           #
-          # This line and the App grant are ONE unit: revoking `contents` on the App while this line
-          # stays kills the stargazer read again, so any future permission cleanup on
-          # `neomjs-devindex-intake` must leave `contents` in place or land in the same commit that
-          # removes this line.
+          # This line and the App grant are ONE unit, and the coupling has teeth in BOTH directions.
+          # Revoking `contents` on the App while this line stays does not merely lose the stargazer
+          # read: `create-github-app-token` FAILS the step outright, measured at run 31877595849 —
+          # "The permissions requested are not granted to this installation." So any future
+          # permission cleanup on `neomjs-devindex-intake` must leave `contents` in place or land in
+          # the same commit that removes this line.
           #
-          # It does NOT take the mint down, and an earlier revision of this comment claimed it did.
-          # Measured (run 31877595849): the step was asked for `permission-deployments: write`, which
-          # this installation does not hold, and it SUCCEEDED. So the action does not validate
-          # requested permissions against the installation — meaning a mint success proves nothing
-          # about what the token actually carries, and only a capability probe does.
+          # A revision of this comment briefly claimed the opposite, on the grounds that the failing
+          # step showed green. It did — because #17162's `continue-on-error` guard sets
+          # `conclusion: success` on a failed step while `outcome` keeps the failure. Check the mint
+          # by reading its LOG, never its step status.
           permission-contents: write
           # OptOut comments on and closes issues.
           permission-issues: write

--- a/.github/workflows/data-sync-pipeline.yml
+++ b/.github/workflows/data-sync-pipeline.yml
@@ -112,11 +112,16 @@ jobs:
           # reach. The #15744 property that matters — the intake identity cannot publish to this
           # repository — is intact.
           #
-          # This line and the App grant are ONE unit. `create-github-app-token` fails the step outright
-          # when asked for a permission the installation lacks, so revoking `contents` on the App
-          # without removing this line takes the pipeline down before it can emit a corpus. Any future
-          # permission cleanup on `neomjs-devindex-intake` must leave `contents` in place or land in
-          # the same commit that removes this.
+          # This line and the App grant are ONE unit: revoking `contents` on the App while this line
+          # stays kills the stargazer read again, so any future permission cleanup on
+          # `neomjs-devindex-intake` must leave `contents` in place or land in the same commit that
+          # removes this line.
+          #
+          # It does NOT take the mint down, and an earlier revision of this comment claimed it did.
+          # Measured (run 31877595849): the step was asked for `permission-deployments: write`, which
+          # this installation does not hold, and it SUCCEEDED. So the action does not validate
+          # requested permissions against the installation — meaning a mint success proves nothing
+          # about what the token actually carries, and only a capability probe does.
           permission-contents: write
           # OptOut comments on and closes issues.
           permission-issues: write

--- a/.github/workflows/data-sync-pipeline.yml
+++ b/.github/workflows/data-sync-pipeline.yml
@@ -90,9 +90,35 @@ jobs:
           repositories: |
             devindex-opt-in
             devindex-opt-out
-          # OptIn reads stargazers (metadata); OptOut comments on and closes issues. Nothing here
-          # needs `contents`, and this token must never be able to write code anywhere — the
-          # publisher/intake split exists precisely so the intake identity cannot publish.
+          # `contents: write` is here for the STARGAZER READ, not to write anything. GitHub limited
+          # the stargazers endpoint to repository admins and collaborators (announced 2026-06-30) and
+          # infers that status from contents-write; `metadata: read` used to carry the read and no
+          # longer does. Measured, not assumed — four `preflight_only` probes, one variable each:
+          #
+          #   issues:write + metadata:read          -> DENIED   (run 31870344604)
+          #   + administration:read                 -> DENIED   (run 31874111382)
+          #   + contents:WRITE                      -> reachable (run 31875177082)
+          #   + contents:READ                       -> DENIED   (run 31875769230)
+          #
+          # So read does not suffice and there is no lesser lever. `devindex-opt-out.issues` stayed
+          # reachable in all four, which is what rules out a sick token and isolates the connection.
+          #
+          # THE COST, stated rather than buried: the previous note here said this token "must never be
+          # able to write code anywhere". That is no longer true and pretending otherwise would be the
+          # more expensive lie. What it can now write is `neomjs/devindex-opt-in` and
+          # `neomjs/devindex-opt-out` — 3 KB and 1 KB respectively, each a README, a `.gitignore` and
+          # issue templates, no code and no data. The DevIndex corpus lives in `neomjs/neo` under
+          # `apps/devindex/resources/data/`, which this App has no installation on and still cannot
+          # reach. The #15744 property that matters — the intake identity cannot publish to this
+          # repository — is intact.
+          #
+          # This line and the App grant are ONE unit. `create-github-app-token` fails the step outright
+          # when asked for a permission the installation lacks, so revoking `contents` on the App
+          # without removing this line takes the pipeline down before it can emit a corpus. Any future
+          # permission cleanup on `neomjs-devindex-intake` must leave `contents` in place or land in
+          # the same commit that removes this.
+          permission-contents: write
+          # OptOut comments on and closes issues.
           permission-issues: write
           permission-metadata: read
 

--- a/apps/devindex/services/OptIn.mjs
+++ b/apps/devindex/services/OptIn.mjs
@@ -37,85 +37,45 @@ class OptIn extends Base {
 
     async run() {
         console.log('[OptIn] Checking for new opt-in requests...');
-        const syncState = await Storage.getOptInSync();
-        const lastCheck = syncState.lastCheck;
-        let newLastCheck = lastCheck;
-
-        let hasNextPage = true;
-        let cursor = null;
-        let optedInLogins = [];
+        const syncState    = await Storage.getOptInSync();
+        const lastCheck    = syncState.lastCheck;
+        let   newLastCheck = lastCheck;
 
         // 1. Check Stargazers
-        while (hasNextPage) {
-            const query = `
-                query($owner: String!, $name: String!, $cursor: String) {
-                    repository(owner: $owner, name: $name) {
-                        stargazers(first: 100, orderBy: {field: STARRED_AT, direction: DESC}, after: $cursor) {
-                            pageInfo {
-                                hasNextPage
-                                endCursor
-                            }
-                            edges {
-                                starredAt
-                                node {
-                                    login
-                                }
-                            }
-                        }
-                    }
-                }`;
+        //
+        // ISOLATED from the issue path below. Both read the SAME repository, but over DIFFERENT
+        // connections — `stargazers` here, `issues` in `processIssues()` — and GitHub restricted
+        // access at connection granularity: it limited stargazer reads to repository admins and
+        // collaborators (announced 2026-06-30) while leaving the issues connection readable. So
+        // these two opt-in mechanisms genuinely can fail independently, and today exactly one of
+        // them does.
+        //
+        // A throw here used to abort `run()` before `processIssues()` was ever reached, so a
+        // permanently unavailable half took the working half down with it and intake went to zero
+        // rather than halving. The repository-not-found branch had the same defect for the same
+        // reason — it `return`ed out of `run()` — and `processIssues()` already handles that case
+        // for itself by returning null, so pre-empting it was never buying anything.
+        //
+        // DEFERRED, never swallowed. The error is rethrown at the end of `run()`, after the issue
+        // path has done its work, so the run still fails and the loss stays visible — a catch that
+        // quietly returned would leave a dead intake mechanism reporting success indefinitely.
+        let deferredStargazerError = null,
+            optedInLogins          = [];
 
-            const variables = {
-                owner: this.optInRepoOwner,
-                name:  this.optInRepoName,
-                cursor: cursor
-            };
-
-            let data;
-            try {
-                data = await GitHub.query(query, variables, 3, 'OptIn Stars');
-            } catch (err) {
-                if (err.message.includes('NOT_FOUND') || err.message.includes('Could not resolve')) {
-                    console.warn(`[OptIn] Opt-in repository ${this.optInRepoOwner}/${this.optInRepoName} not found. Skipping.`);
-                    return;
-                }
-                throw err;
-            }
-
-            const stargazers = data?.repository?.stargazers;
-            if (!stargazers) break;
-
-            const edges = stargazers.edges || [];
-            let stopFetching = false;
-
-            for (const edge of edges) {
-                const starredAt = edge.starredAt;
-                const login = edge.node.login;
-
-                if (lastCheck && starredAt <= lastCheck) {
-                    stopFetching = true;
-                    break;
-                }
-
-                if (!newLastCheck || starredAt > newLastCheck) {
-                    newLastCheck = starredAt;
-                }
-
-                optedInLogins.push(login);
-            }
-
-            if (stopFetching) {
-                break;
-            }
-
-            hasNextPage = stargazers.pageInfo.hasNextPage;
-            cursor = stargazers.pageInfo.endCursor;
+        try {
+            ({newLastCheck, optedInLogins} = await this.collectStargazerOptIns(lastCheck))
+        } catch (error) {
+            deferredStargazerError = error;
+            console.warn(
+                `[OptIn] Stargazer intake failed (${error.message}). Continuing to the issue path; ` +
+                'this run will fail after it.'
+            )
         }
 
         // 2. Check Issues
         const issueResults = await this.processIssues();
-        
-        let uniqueLogins = [...new Set(optedInLogins)];
+
+        let uniqueLogins  = [...new Set(optedInLogins)];
         let loginsToReAdd = [...uniqueLogins]; // Stars can reverse blocklist
         let issuesToClose = [];
 
@@ -124,18 +84,18 @@ class OptIn extends Base {
             uniqueLogins.push(...issueResults.othersLogins);
             loginsToReAdd.push(...issueResults.selfLogins); // ONLY self issues reverse blocklist
             issuesToClose.push(...issueResults.issuesToClose);
-            
+
             uniqueLogins = [...new Set(uniqueLogins)];
             loginsToReAdd = [...new Set(loginsToReAdd)];
         }
 
         if (uniqueLogins.length > 0) {
             console.log(`[OptIn] Found ${uniqueLogins.length} new opt-in requests:`, uniqueLogins);
-            
+
             // 1. Remove from blocklist if they are there (ONLY stargazers and self-issues)
-            const blocklist = await Storage.getBlocklist();
+            const blocklist           = await Storage.getBlocklist();
             const blockedUsersToReAdd = loginsToReAdd.filter(login => blocklist.has(login.toLowerCase()));
-            
+
             if (blockedUsersToReAdd.length > 0) {
                 console.log(`[OptIn] Removing from blocklist:`, blockedUsersToReAdd);
                 await Storage.removeFromBlocklist(blockedUsersToReAdd);
@@ -143,10 +103,10 @@ class OptIn extends Base {
 
             // 2. Add to tracker
             // We want to avoid adding users who are already in the tracker.
-            const tracker = await Storage.getTracker();
+            const tracker         = await Storage.getTracker();
             const existingTracker = new Set(tracker.map(t => t.login.toLowerCase()));
 
-            // We must also ensure we don't add "othersLogins" that are on the blocklist, 
+            // We must also ensure we don't add "othersLogins" that are on the blocklist,
             // since we didn't remove them above.
             const currentBlocklist = await Storage.getBlocklist();
 
@@ -171,20 +131,115 @@ class OptIn extends Base {
 
         // 3. Close Issues and Leave Comment
         if (issuesToClose.length > 0) {
-            const tracker = await Storage.getTracker();
-            const existingTracker = new Set(tracker.map(t => t.login.toLowerCase()));
+            const tracker          = await Storage.getTracker();
+            const existingTracker  = new Set(tracker.map(t => t.login.toLowerCase()));
             const currentBlocklist = await Storage.getBlocklist();
 
             await this.closeIssues(issuesToClose, existingTracker, currentBlocklist);
         }
+
+        // LAST, so everything above has already run and been persisted. Isolating the stargazer
+        // phase buys the issue path a chance to work; it must not buy a dead phase silence. The
+        // run still fails, and it fails naming the phase that failed.
+        if (deferredStargazerError) {
+            throw deferredStargazerError;
+        }
+    }
+
+    /**
+     * @summary Pages the opt-in repository's stargazers, newest first, stopping at the last
+     * processed star.
+     *
+     * Extracted from `run()` so a failure here is one phase failing rather than the whole intake
+     * aborting: the caller isolates it from `processIssues()`, which reads a different repository
+     * over a different connection and is unaffected by anything that goes wrong in this one.
+     * @param {String|null} lastCheck ISO timestamp of the newest star already processed, or null.
+     * @returns {Promise<{newLastCheck: String|null, optedInLogins: String[]}>}
+     */
+    async collectStargazerOptIns(lastCheck) {
+        let cursor        = null,
+            hasNextPage   = true,
+            newLastCheck  = lastCheck,
+            optedInLogins = [];
+
+        while (hasNextPage) {
+            const query = `
+                query($owner: String!, $name: String!, $cursor: String) {
+                    repository(owner: $owner, name: $name) {
+                        stargazers(first: 100, orderBy: {field: STARRED_AT, direction: DESC}, after: $cursor) {
+                            pageInfo {
+                                hasNextPage
+                                endCursor
+                            }
+                            edges {
+                                starredAt
+                                node {
+                                    login
+                                }
+                            }
+                        }
+                    }
+                }`;
+
+            const variables = {
+                owner : this.optInRepoOwner,
+                name  : this.optInRepoName,
+                cursor: cursor
+            };
+
+            let data;
+            try {
+                data = await GitHub.query(query, variables, 3, 'OptIn Stars');
+            } catch (err) {
+                if (err.message.includes('NOT_FOUND') || err.message.includes('Could not resolve')) {
+                    // `break`, not `return`: this used to return out of `run()` entirely, so a
+                    // missing opt-in repository also skipped the issue path in a DIFFERENT
+                    // repository. Ending this phase is the whole of what the finding supports.
+                    console.warn(`[OptIn] Opt-in repository ${this.optInRepoOwner}/${this.optInRepoName} not found. Skipping stargazer intake.`);
+                    break;
+                }
+                throw err;
+            }
+
+            const stargazers = data?.repository?.stargazers;
+            if (!stargazers) break;
+
+            const edges        = stargazers.edges || [];
+            let   stopFetching = false;
+
+            for (const edge of edges) {
+                const starredAt = edge.starredAt;
+                const login     = edge.node.login;
+
+                if (lastCheck && starredAt <= lastCheck) {
+                    stopFetching = true;
+                    break;
+                }
+
+                if (!newLastCheck || starredAt > newLastCheck) {
+                    newLastCheck = starredAt;
+                }
+
+                optedInLogins.push(login);
+            }
+
+            if (stopFetching) {
+                break;
+            }
+
+            hasNextPage = stargazers.pageInfo.hasNextPage;
+            cursor = stargazers.pageInfo.endCursor;
+        }
+
+        return {newLastCheck, optedInLogins};
     }
 
     async processIssues() {
         console.log('[OptIn] Checking for new opt-in issue requests...');
-        let hasNextPage = true;
-        let cursor = null;
-        let selfLogins = [];
-        let othersLogins = [];
+        let hasNextPage   = true;
+        let cursor        = null;
+        let selfLogins    = [];
+        let othersLogins  = [];
         let issuesToClose = [];
 
         while (hasNextPage) {
@@ -209,8 +264,8 @@ class OptIn extends Base {
                 }`;
 
             const variables = {
-                owner: this.optInRepoOwner,
-                name:  this.optInRepoName,
+                owner : this.optInRepoOwner,
+                name  : this.optInRepoName,
                 cursor: cursor
             };
 
@@ -233,14 +288,14 @@ class OptIn extends Base {
                 const match = issue.body.match(/### GitHub Usernames\s*([\s\S]*?)(?:###|$)/);
 
                 if (match) {
-                    const text = match[1];
+                    const text      = match[1];
                     const usernames = text.split('\n')
                         .map(u => u.trim())
                         .filter(u => u && !u.startsWith('-') && !u.startsWith('['));
-                    
-                    const validUsernames = [];
+
+                    const validUsernames   = [];
                     const invalidUsernames = [];
-                    
+
                     for (const uname of usernames) {
                         try {
                             await GitHub.rest(`users/${uname}`);
@@ -250,11 +305,11 @@ class OptIn extends Base {
                             invalidUsernames.push(uname);
                         }
                     }
-                    
-                    issuesToClose.push({ 
-                        id: issue.id, 
-                        type: 'others', 
-                        validLogins: validUsernames,
+
+                    issuesToClose.push({
+                        id           : issue.id,
+                        type         : 'others',
+                        validLogins  : validUsernames,
                         invalidLogins: invalidUsernames
                     });
                 } else {
@@ -286,10 +341,10 @@ class OptIn extends Base {
                 } else if (issue.type === 'others') {
                     if (issue.validLogins && issue.validLogins.length > 0) {
                         commentBody = `Thank you for your nominations!\n\n`;
-                        
-                        const newlyAdded = [];
+
+                        const newlyAdded     = [];
                         const alreadyTracked = [];
-                        const blocked = [];
+                        const blocked        = [];
 
                         issue.validLogins.forEach(u => {
                             const lLogin = u.toLowerCase();
@@ -335,7 +390,7 @@ class OptIn extends Base {
                     }`;
                 await GitHub.query(commentQuery, {
                     subjectId: issue.id,
-                    body: commentBody
+                    body     : commentBody
                 }, 3, `OptIn Comment ${issue.id}`);
 
                 // Close Issue

--- a/test/playwright/unit/app/devindex/OptInPhaseIsolation.spec.mjs
+++ b/test/playwright/unit/app/devindex/OptInPhaseIsolation.spec.mjs
@@ -1,0 +1,159 @@
+import {setup} from '../../../setup.mjs';
+
+setup({
+    appConfig: {
+        name: 'DevIndexOptInPhaseIsolationTest'
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../../src/Neo.mjs';
+import * as core      from '../../../../../src/core/_export.mjs';
+import GitHub         from '../../../../../apps/devindex/services/GitHub.mjs';
+import OptIn          from '../../../../../apps/devindex/services/OptIn.mjs';
+import Storage        from '../../../../../apps/devindex/services/Storage.mjs';
+
+/**
+ * Opt-in has TWO independent intake mechanisms — stargazers and issues — reading the same
+ * repository over different connections. GitHub restricted access at connection granularity: it
+ * limited stargazer reads to repository admins and collaborators (announced 2026-06-30) while
+ * leaving the issues connection readable.
+ *
+ * Before this fix the stargazer loop ran first and threw straight out of `run()`, so the readable
+ * half never executed and opt-in intake went to ZERO rather than halving. The isolation must not
+ * become suppression: a dead phase that reported success would leave the loss invisible, so every
+ * test proving the issue path survived is paired with one proving the run still fails.
+ */
+test.describe.serial('DevIndex OptIn phase isolation (#17150)', () => {
+    let calls,
+        originalCloseIssues,
+        originalGetBlocklist,
+        originalGetOptInSync,
+        originalGetTracker,
+        originalQuery,
+        originalRemoveFromBlocklist,
+        originalRest,
+        originalSaveOptInSync,
+        originalUpdateTracker;
+
+    /** One open issue nominating `issue-opted-in`, the shape `processIssues` parses. */
+    const issuePayload = {
+        repository: {
+            issues: {
+                pageInfo: {hasNextPage: false, endCursor: null},
+                nodes   : [{
+                    id    : 'I_kwDO',
+                    number: 7,
+                    body  : '### GitHub Usernames\nissue-opted-in\n',
+                    author: {login: 'nominator'}
+                }]
+            }
+        }
+    };
+
+    test.beforeEach(() => {
+        originalCloseIssues         = OptIn.closeIssues;
+        originalGetBlocklist        = Storage.getBlocklist;
+        originalGetOptInSync        = Storage.getOptInSync;
+        originalGetTracker          = Storage.getTracker;
+        originalQuery               = GitHub.query;
+        originalRemoveFromBlocklist = Storage.removeFromBlocklist;
+        originalRest                = GitHub.rest;
+        originalSaveOptInSync       = Storage.saveOptInSync;
+        originalUpdateTracker       = Storage.updateTracker;
+
+        calls = {queryLabels: [], tracked: []};
+
+        Storage.getOptInSync        = async () => ({lastCheck: null});
+        Storage.getBlocklist        = async () => new Set();
+        Storage.getTracker          = async () => [];
+        Storage.removeFromBlocklist = async () => {};
+        Storage.saveOptInSync       = async () => {};
+        Storage.updateTracker       = async updates => {calls.tracked.push(...updates.map(entry => entry.login))};
+        GitHub.rest                 = async () => ({login: 'issue-opted-in'});
+        OptIn.closeIssues           = async () => {}
+    });
+
+    test.afterEach(() => {
+        GitHub.query                = originalQuery;
+        GitHub.rest                 = originalRest;
+        OptIn.closeIssues           = originalCloseIssues;
+        Storage.getBlocklist        = originalGetBlocklist;
+        Storage.getOptInSync        = originalGetOptInSync;
+        Storage.getTracker          = originalGetTracker;
+        Storage.removeFromBlocklist = originalRemoveFromBlocklist;
+        Storage.saveOptInSync       = originalSaveOptInSync;
+        Storage.updateTracker       = originalUpdateTracker
+    });
+
+    /** Fails the stargazer connection with `reason`; serves the issue connection normally. */
+    function denyStargazers(reason) {
+        GitHub.query = async (query, variables, retries, label) => {
+            calls.queryLabels.push(label);
+
+            if (label === 'OptIn Stars') {
+                throw new Error(reason)
+            }
+
+            return issuePayload
+        }
+    }
+
+    test('a denied stargazer read no longer prevents the issue path from running', async () => {
+        // The exact production denial. Before the fix this threw out of `run()` and `processIssues`
+        // was never reached, so the working half of opt-in died with the restricted half.
+        denyStargazers('GraphQL Query Errors: Resource not accessible by integration');
+
+        await expect(OptIn.run()).rejects.toThrow(/Resource not accessible by integration/);
+
+        expect(calls.queryLabels).toContain('OptIn Stars');
+        expect(calls.queryLabels, 'the issue phase must still be reached').toContain('OptIn Issues');
+        // Not merely reached — its result was carried through to the tracker, so the surviving
+        // mechanism genuinely still admits users rather than running and being discarded.
+        expect(calls.tracked).toContain('issue-opted-in')
+    });
+
+    test('the run still FAILS after the issue path completes — isolation is not suppression', async () => {
+        // Pinning the ordering, not just the outcome: the throw must come AFTER the issue work is
+        // persisted. A rethrow placed earlier would restore the original defect while still
+        // reporting the same error, and an assertion on the error alone could not tell them apart.
+        denyStargazers('GraphQL Query Errors: Resource not accessible by integration');
+
+        let threw = null;
+
+        await OptIn.run().catch(error => {threw = error});
+
+        expect(threw, 'a dead intake phase must never report success').toBeTruthy();
+        expect(calls.tracked).toContain('issue-opted-in')
+    });
+
+    test('a missing opt-in repository ends the stargazer phase without pre-empting the issue phase', async () => {
+        // This branch used to `return` out of `run()`. `processIssues` handles NOT_FOUND for itself
+        // by returning null, so pre-empting it bought nothing and cost the other phase its turn.
+        // Here the issue connection still answers, and the run completes without throwing.
+        denyStargazers('NOT_FOUND: Could not resolve to a Repository');
+
+        await expect(OptIn.run()).resolves.toBeUndefined();
+
+        expect(calls.queryLabels).toContain('OptIn Issues');
+        expect(calls.tracked).toContain('issue-opted-in')
+    });
+
+    test('collectStargazerOptIns reports the phase result rather than mutating run() state', async () => {
+        // The extraction is what makes the isolation expressible: the phase returns its own result,
+        // so the caller can lose it to a failure without leaving `run()` holding half-updated state.
+        GitHub.query = async () => ({
+            repository: {
+                stargazers: {
+                    pageInfo: {hasNextPage: false, endCursor: null},
+                    edges   : [{starredAt: '2026-08-15T09:00:00Z', node: {login: 'star-opted-in'}}]
+                }
+            }
+        });
+
+        expect(await OptIn.collectStargazerOptIns(null)).toEqual({
+            newLastCheck : '2026-08-15T09:00:00Z',
+            optedInLogins: ['star-opted-in']
+        })
+    })
+});


### PR DESCRIPTION
Resolves #17150

Closes the DevIndex half of the 2026-08-14 data-sync incident. #17149 stopped an intake denial from freezing corpus publication; this restores the intake itself and stops one dead phase from taking a working one with it.

## Two independent defects, both surfaced by the same GitHub change

**1. A dead phase killed a working one.** `OptIn.run()` has two intake mechanisms reading the *same* repository over *different* connections — `stargazers` and `issues`. The stargazer loop ran first and threw straight out of `run()`, so `processIssues()` was never reached and opt-in intake went to **zero rather than halving**. The repository-not-found branch had the same defect for the same reason: it `return`ed out of `run()`, and `processIssues` already handles NOT_FOUND for itself, so pre-empting it bought nothing.

**2. The stargazer read needed a permission nobody had identified.** GitHub limited the endpoint to repository admins and collaborators and infers that status from contents-write.

## The permission finding, measured rather than argued

Four `preflight_only` probes, one variable each, each mutating nothing:

| requested intake permissions | `devindex-opt-in.stargazers` | run |
|---|---|---|
| `issues:write`, `metadata:read` (shipped) | **DENIED** | 31870344604 |
| + `administration:read` | **DENIED** | 31874111382 |
| + `contents:` **write** | **reachable** ✅ | 31875177082 |
| + `contents:` **read** | **DENIED** | 31875769230 |

Read does not suffice; there is no lesser lever. `devindex-opt-out.issues` stayed reachable in all four, which rules out a sick token and isolates the finding to the connection.

**These results are only trustworthy because #17148 merged first.** The old preflight probed `repository{id}`, which resolves from metadata and would have printed `reachable` in all four rows. The instrument had to be fixed before the experiment could mean anything — that is the whole reason the probe change was worth shipping separately.

## The cost, stated rather than buried

The workflow's previous note claimed this token *"must never be able to write code anywhere"*. That is no longer true, and the comment now says so instead of quietly contradicting itself.

| repo | contents | size |
|---|---|---|
| `neomjs/devindex-opt-in` | `.github/`, `.gitignore`, `README.md` | 3 KB |
| `neomjs/devindex-opt-out` | same shape | 1 KB |

No code, no data. The DevIndex corpus lives in `neomjs/neo` under `apps/devindex/resources/data/`, which this App has **no installation on** and still cannot reach. The `#15744` property that matters — the intake identity cannot publish to this repository — is intact.

**Operational coupling — corrected at `f5ce78fe4a`, and the original claim is retained here struck through because it was wrong in the direction that raises alarm:**

> ~~`create-github-app-token` fails the step outright when asked for a permission the installation lacks, so a cleanup that drops `contents` takes the pipeline down before it can emit a corpus.~~

**The claim above is TRUE. I briefly "corrected" it into a falsehood and have withdrawn that — recording the round trip because the mechanism is worth more than the conclusion.**

I asserted this action does not validate requested permissions, citing run 31877595849 as a success. It was not a success: that run logs `##[error]The permissions requested are not granted to this installation` (HTTP 422). I had read `conclusion` from the jobs API — the field that `#17162`'s `continue-on-error` guard, present on that probe branch, rewrites to `success` on a **failed** step while `outcome` retains the failure. **Check a mint by reading its log, never its step status.** Caught by @neo-gpt.

**The coupling is real and it has teeth in both directions.** This line and the App grant must move together, and getting it wrong is *worse* than losing the stargazer read: `create-github-app-token` **fails the mint outright** — HTTP 422, *"The permissions requested are not granted to this installation"* ([run 31877595849](https://github.com/neomjs/neo/actions/runs/31877595849)). @tobiu: `administration` and `organization administration` are safe to revoke whenever; **`contents` is not** — dropping it while this line remains fails the mint, which without `#17162`'s guard kills the job before a corpus byte exists. That is the original warning, restored.

**What a successful mint does and does not prove — the distinction, narrowed.** It proves the *requested grant was available to the action*: `create-github-app-token` fails when a requested permission is not granted (HTTP 422) or the named repository has no installation (404), so a clean mint means neither happened. It does **not** prove the *endpoint capability* — that the token can actually perform the read the stage needs. Only the direct `stargazers` probe settles that, which is why `#17150`'s matrix rests on the capability observation rather than on the mint. Both halves matter here: the mint result validates the credential topology, the probe validates the capability, and conflating them is what produced this PR's correction round-trip.

## Deltas

- `apps/devindex/services/OptIn.mjs` — stargazer phase extracted to `collectStargazerOptIns`, which returns its own result rather than mutating `run()` state; `run()` isolates it, continues to the issue path, and rethrows **last**; NOT_FOUND `return` → `break`. Also strips pre-existing trailing whitespace (12 lines) and applies block-alignment, both forced by whole-staged-file hooks once the loop moved.
- `.github/workflows/data-sync-pipeline.yml` — `permission-contents: write` on the intake mint, with the probe matrix and the cost recorded inline.
- `test/playwright/unit/app/devindex/OptInPhaseIsolation.spec.mjs` — new, 4 tests.

## Rejected

- **Adding the denial string to `OptIn.mjs`'s NOT_FOUND skip branch.** One line, turns everything green, and converts a real permission regression into a silent no-op — the intake would rot undetected. The deferral keeps the failure loud.
- **Retiring the star path** (this ticket's option A). It was the right plan while option B looked falsified; the `contents: write` probe reopened it, and one-click opt-in is materially lower friction than "file an issue from a template" for a community-facing index.
- **`administration: read`.** Tested first on the theory that "admins and collaborators" maps to an administration permission. It does not — probe 2 above.

Evidence: L2 (unit specs) + L4 (four live `preflight_only` runs against the real installation, cited above) → L4 obtained for the permission claim, which is the one no unit test can reach. Residual: none — the deferred-behaviour claims are unit-verified and the access claim is verified against production credentials.

## Test Evidence

```
npx playwright test -c test/playwright/playwright.config.unit.mjs \
  test/playwright/unit/app/devindex/
  2633 passed (11.0s)
```

New coverage, each pinning a distinct half:

- `a denied stargazer read no longer prevents the issue path from running` — the exact production denial; asserts the issue phase is reached **and** that its opt-ins reach the tracker, so the surviving mechanism genuinely still admits users.
- `the run still FAILS after the issue path completes — isolation is not suppression` — pins the ordering, not just the outcome. A rethrow placed earlier would restore the original defect while reporting the same error.
- `a missing opt-in repository ends the stargazer phase without pre-empting the issue phase`.
- `collectStargazerOptIns reports the phase result rather than mutating run() state`.

**Every test was verified RED against the pre-fix source individually.** A single suite run reported `1 failed` — which looks like three vacuous tests but was `describe.serial` skipping after the first failure (`3 did not run`). Run with `-g`, all four fail against the old code. Flagging the trap because its inverse is worse: had test 1 been the failing one and 2–4 genuinely vacuous, that same summary would have rubber-stamped them.

## Post-Merge Validation

Observable only on a scheduled `dev` run, which cannot exist before merge. Owned by the standing alarm rather than this PR's close target: `#17131` is refreshed on every breach evaluation and is still there when these become checkable.

Residual-Owner: #17131

- [ ] The first scheduled `dev` run after merge reports `neomjs/devindex-opt-in reachable (OptIn stargazer read)` in preflight — the restriction is satisfied by the shipped permission set, not just by a dispatch probe.
- [ ] `[OptIn]` completes both phases in the same run, and `#17131` closes on the recovery evaluation.
- [ ] A subsequent run publishes a corpus commit with no deferred intake failure.

---

⚖️ **Ada** · `@neo-opus-ada` · Claude Opus 5 · Claude Code

<!-- Authored by @neo-opus-ada (Ada) -->






