### PR TITLE
feat(build): a deleted unit spec must say where its coverage went (#17151)

### DIFF
--- a/.github/workflows/spec-retirement-lint.yml
+++ b/.github/workflows/spec-retirement-lint.yml
@@ -14,6 +14,12 @@ on:
       - 'test/playwright/unit/**'
       - 'buildScripts/util/check-spec-retirement.mjs'
       - '.github/workflows/spec-retirement-lint.yml'
+  push:
+    branches: [dev]
+    paths:
+      - 'test/playwright/unit/**'
+      - 'buildScripts/util/check-spec-retirement.mjs'
+      - '.github/workflows/spec-retirement-lint.yml'
 
 concurrency:
   group: spec-retirement-lint-${{ github.run_attempt == '1' && github.ref || github.run_id }}

--- a/.github/workflows/spec-retirement-lint.yml
+++ b/.github/workflows/spec-retirement-lint.yml
@@ -1,11 +1,27 @@
 name: Spec Retirement Lint
 
-# CI mirror of the `.husky/pre-push` guard, so `git push --no-verify` cannot bypass it.
+# CI mirror of the `.husky/pre-push` guard — VISIBILITY, not yet enforcement.
+#
+# Read this before citing the job as a `--no-verify` closure, because it is not one yet. The live
+# `dev` ruleset (19087298) requires exactly ONE status context, `integration-parity`. This job runs
+# on every matching PR and goes red on a violation, but a red result does not make the PR ineligible
+# to merge, and `git push --no-verify` still bypasses the only blocking hook. Verified against
+# `gh api repos/neomjs/neo/rules/branches/dev`; the branch-protection endpoint 404s, so this ruleset
+# is the whole story.
+#
+# Workflow presence plus scan-root registration is REACHABILITY. Enforcement needs either this exact
+# guard executing inside the already-required context, or its own required context added to the
+# ruleset — a repo-admin mutation, which is operator-owned and therefore outside this workflow file.
+# Until one of those exists, the honest description of this job is "a loud, non-blocking signal".
+#
+# The gap is the FAMILY's, not this job's: 19 `*-lint.yml` workflows run on `dev` PRs and none of them
+# is a required context, several claiming `--no-verify` closure in the same words this comment first
+# did. #17171 carries the decision and the spec that reads the live ruleset, so do not close it here —
+# adding only this job to the ruleset would leave eighteen false headers standing beside one true one.
 #
 # The two existing pre-push guards (check-branch-discipline, check-commit-authorship) are hook-only
-# and therefore bypassable. This one is mirrored because the defect it catches is silent by
-# construction: a deleted suite takes its own assertions with it, so the run stays green with less
-# coverage behind the same number, and nothing else in the repo inspects deletions.
+# and have no CI mirror at all, so this is still strictly more coverage than the siblings — just not
+# the gate the first draft of this comment claimed.
 
 on:
   pull_request:

--- a/.github/workflows/spec-retirement-lint.yml
+++ b/.github/workflows/spec-retirement-lint.yml
@@ -1,0 +1,48 @@
+name: Spec Retirement Lint
+
+# CI mirror of the `.husky/pre-push` guard, so `git push --no-verify` cannot bypass it.
+#
+# The two existing pre-push guards (check-branch-discipline, check-commit-authorship) are hook-only
+# and therefore bypassable. This one is mirrored because the defect it catches is silent by
+# construction: a deleted suite takes its own assertions with it, so the run stays green with less
+# coverage behind the same number, and nothing else in the repo inspects deletions.
+
+on:
+  pull_request:
+    branches: [dev]
+    paths:
+      - 'test/playwright/unit/**'
+      - 'buildScripts/util/check-spec-retirement.mjs'
+      - '.github/workflows/spec-retirement-lint.yml'
+
+concurrency:
+  group: spec-retirement-lint-${{ github.run_attempt == '1' && github.ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          # Load-bearing. The guard reads a commit RANGE, and the default shallow checkout has no
+          # history to range over. With `fetch-depth: 1` the range cannot resolve — and a guard that
+          # cannot see its input has the exact failure shape it exists to prevent, so it now exits
+          # non-zero there rather than passing vacuously. This line is what keeps that path unreached.
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+
+      # `origin/dev` is the range boundary. Checkout creates a tracking ref for the PR head, not
+      # necessarily for the base branch, so it is fetched explicitly rather than assumed.
+      - name: Ensure the base ref is present
+        run: git fetch --no-tags origin dev:refs/remotes/origin/dev
+
+      # No stdin: the guard falls back to `origin/dev..HEAD`, which on a PR is exactly the commits
+      # under review. No npm install — the guard imports only node builtins.
+      - name: Require an account for deleted unit specs
+        run: node ./buildScripts/util/check-spec-retirement.mjs < /dev/null

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,2 +1,17 @@
-node ./buildScripts/util/check-branch-discipline.mjs
-node ./buildScripts/util/check-commit-authorship.mjs
+# Fail on the FIRST failing guard.
+#
+# Without this, sh reports only the LAST command's status, so a guard that fails anywhere but the
+# bottom of this file does not block the push — it prints its complaint and the push proceeds. Every
+# guard here was therefore blocking only by virtue of being last, which is a property of the file
+# ordering rather than of the guard. Measured, not assumed: `sh -c 'false-ish; true-ish'` exits 0.
+set -e
+
+# git sends the pre-push payload — `<localRef> <localSha> <remoteRef> <remoteSha>` per ref — on stdin
+# exactly ONCE. Read by the first guard that wants it, it is gone for every guard after, which
+# degrades those to a guessed range silently. Capturing it here and handing each guard its own copy
+# makes the payload a property of the hook rather than a race won by whoever runs first.
+payload="$(cat)"
+
+printf '%s\n' "$payload" | node ./buildScripts/util/check-branch-discipline.mjs
+printf '%s\n' "$payload" | node ./buildScripts/util/check-commit-authorship.mjs
+printf '%s\n' "$payload" | node ./buildScripts/util/check-spec-retirement.mjs

--- a/buildScripts/util/check-spec-retirement.mjs
+++ b/buildScripts/util/check-spec-retirement.mjs
@@ -1,0 +1,232 @@
+import {execSync} from 'node:child_process';
+import process    from 'node:process';
+
+/**
+ * A deleted spec is the one regression the test suite cannot report.
+ *
+ * Every other class of failure announces itself by turning something red. A suite that stops existing
+ * takes its own assertions with it, so the run goes green with less coverage behind the same number.
+ * The silence is indistinguishable from success.
+ *
+ * The repo had exactly one place that thought about deletions and it thought about EXCLUDING them:
+ * `check-ticket-archaeology.mjs` passes `--diff-filter=d` because a deleted file carries no comments
+ * to audit. `agent-preflight.mjs` reads `--diff-filter=ACMR` — Added, Copied, Modified, Renamed, with
+ * `D` the one letter left out. Nothing looked at disappearance.
+ *
+ * This guard asks for an ACCOUNT, never a veto. Deleting a spec is routine and correct: it gets
+ * renamed, split, folded into a sibling, or its subject genuinely goes away. Each of those is one line
+ * to say. What must not stay free is deletion with no account at all, because that is the only case
+ * indistinguishable from an accident.
+ *
+ * It runs pre-push rather than pre-commit for a mechanical reason: the account lives in the commit
+ * message (the file is gone, so it cannot live in the file), and at pre-commit time the message does
+ * not exist yet. `check-commit-authorship.mjs` reads commit messages from the same hook for the same
+ * reason, and this guard lifts its range handling.
+ */
+
+const
+    ZERO_SHA = '0'.repeat(40),
+    exec     = command => execSync(command, {encoding: 'utf8', stdio: ['pipe', 'pipe', 'ignore']}).trim(),
+    tryExec  = command => { try { return exec(command) } catch { return '' } };
+
+/**
+ * @summary Spec files this guard protects — the unit tree, where a silent deletion is unobservable.
+ *
+ * Scoped rather than repo-wide on purpose. Source deletion is already loud: something stops importing
+ * it, or a test goes red. Integration and e2e suites are excluded because their runners report suite
+ * counts a human reads per run; the unit tree is the population where a missing file vanishes into a
+ * four-digit pass total.
+ * @type {RegExp}
+ */
+export const SPEC_PATH_PATTERN = /^test\/playwright\/unit\/.+\.spec\.mjs$/u;
+
+/**
+ * @summary The account a deleting commit must carry.
+ *
+ * Deliberately a marker plus free prose rather than a structured field: the useful part is "where this
+ * coverage went", which no enum can hold. The guard checks that an account exists, never that it is
+ * true — a guard that graded the prose would be a rule nobody could satisfy mechanically.
+ * @type {String}
+ */
+export const RETIREMENT_MARKER = 'spec-retired:';
+
+/**
+ * @summary The commits this push will actually send, read from git's own ref tuples.
+ *
+ * git hands a pre-push hook `<localRef> <localSha> <remoteRef> <remoteSha>` per ref on stdin.
+ * `remoteSha..localSha` is the exact set git will apply; a new remote branch reports the zero-sha,
+ * where `origin/dev..localSha` is the honest fallback, and a ref deletion sends no commits at all.
+ * Same contract as `check-commit-authorship.mjs`, whose comment records why guessing the range with a
+ * hard-coded `origin/dev..HEAD` let a push to a sibling ref sail past the guard it was meant to hit.
+ *
+ * @param {String} stdin Raw hook payload.
+ * @returns {String[]} Rev-list ranges to scan.
+ */
+export function pendingRanges(stdin) {
+    const rows = String(stdin || '').split('\n').map(line => line.trim()).filter(Boolean);
+
+    if (rows.length === 0) {
+        // Invoked outside the hook, or a git that sent nothing: scan the branch's own range rather
+        // than no-opping. A guard that passes when it cannot see its input has the failure shape it exists to catch.
+        return ['origin/dev..HEAD']
+    }
+
+    return rows.map(row => {
+        const [, localSha, , remoteSha] = row.split(/\s+/);
+
+        if (!localSha || localSha === ZERO_SHA) {
+            return null
+        }
+
+        return !remoteSha || remoteSha === ZERO_SHA ? `origin/dev..${localSha}` : `${remoteSha}..${localSha}`
+    }).filter(Boolean)
+}
+
+/**
+ * @summary Extracts DELETED spec paths from `git show --name-status -M` output.
+ *
+ * **The rename exclusion lives here rather than in a `--diff-filter` flag, and that is the point.**
+ * Rename detection is configurable (`diff.renames`), so a flag combination that excludes renames on
+ * one machine can report them as delete-plus-add on another — the guard would then fire on a `git mv`
+ * for half the team. Parsing the status letter makes the rule explicit, machine-independent, and
+ * testable without a repository.
+ *
+ * `R100 old new` is a rename and never a deletion. `D path` is. A copy (`C`) leaves the source in
+ * place, so it is not a deletion either. Only a leading `D` counts.
+ *
+ * @param {String} output Raw `--name-status` block.
+ * @returns {String[]} Deleted spec paths, in encounter order.
+ */
+export function parseDeletedSpecs(output) {
+    return String(output || '')
+        .split('\n')
+        .map(line => line.trim())
+        .filter(Boolean)
+        .map(line => {
+            const [status, ...paths] = line.split(/\t/);
+
+            // A rename/copy row carries TWO paths and a similarity-scored status (`R100`, `C75`). Its
+            // first path is the source, which is exactly what a naive "take field 1 when it looks
+            // deleted" reader would mistake for a deletion.
+            return status?.startsWith('D') && paths.length === 1 ? paths[0] : null
+        })
+        .filter(path => path && SPEC_PATH_PATTERN.test(path))
+}
+
+/**
+ * @summary Whether a commit message carries a retirement account.
+ * @param {String} message Full commit message (subject + body).
+ * @returns {Boolean}
+ */
+export function hasRetirementAccount(message) {
+    return String(message || '').toLowerCase().includes(RETIREMENT_MARKER);
+}
+
+/**
+ * @summary Renders the failure text.
+ *
+ * It names the paths and the marker and does NOT tell the author to restore the file. Restoring is
+ * frequently the wrong repair — the deletion is usually intentional and simply unaccounted — and a
+ * guard that prescribes the wrong fix trains people to route around it.
+ *
+ * @param {Array<{sha: String, subject: String, specs: String[]}>} violations
+ * @returns {String}
+ */
+export function formatFailure(violations) {
+    const lines = [
+        `check-spec-retirement: ${violations.length} commit(s) delete unit spec files with no account.`,
+        '',
+        'A deleted suite cannot fail on its own absence — CI stays green with less coverage behind it.',
+        `Say where the coverage went by adding a \`${RETIREMENT_MARKER} <where it lives now, or why the behavior is gone>\``,
+        'line to the deleting commit message (amend, or rebase the commit that removed them).',
+        '',
+        'This is an account, not a veto: renaming, splitting, folding into a sibling, or removing a',
+        'retired behavior are all legitimate, and each is one line to state. Restoring the file is',
+        'usually NOT the right repair.',
+        ''
+    ];
+
+    violations.forEach(({sha, subject, specs}) => {
+        lines.push(`  ${sha.slice(0, 10)} ${subject}`);
+        specs.forEach(spec => lines.push(`      deleted: ${spec}`));
+    });
+
+    return lines.join('\n')
+}
+
+/**
+ * @summary Collects unaccounted spec deletions across the pushed ranges.
+ * @param {String[]} ranges Rev-list ranges.
+ * @returns {Array<{sha: String, subject: String, specs: String[]}>}
+ */
+function collectViolations(ranges) {
+    const violations = [];
+
+    ranges.forEach(range => {
+        // `--no-merges`: a merge commit's combined diff attributes nothing, and the deletion is already
+        // carried by the commit that made it. Scanning merges would double-report a branch's own work
+        // and under-report nothing.
+        //
+        // STRICT, not `tryExec`: an unresolvable range (a missing `origin/dev` in a shallow CI
+        // checkout is the live case) must fail loudly. Swallowing it returns zero commits, the guard
+        // exits green, and the result is a silence indistinguishable from success — precisely the
+        // defect this file exists to catch, reproduced inside the catcher.
+        let shas;
+
+        try {
+            shas = exec(`git rev-list --no-merges ${range}`).split('\n').map(s => s.trim()).filter(Boolean)
+        } catch {
+            console.error(
+                `check-spec-retirement: cannot resolve the range \`${range}\`.\n` +
+                'The guard refuses to pass on a range it could not read — in CI this usually means a\n' +
+                'shallow checkout (needs `fetch-depth: 0`) or a missing `origin/dev` remote-tracking ref.'
+            );
+            process.exit(1)
+        }
+
+        shas.forEach(sha => {
+            // `-M` forces rename detection ON regardless of the user's `diff.renames`, so a `git mv`
+            // arrives as an `R` row that the parser drops. Without it, a machine with renames disabled
+            // reports the move as delete-plus-add and the guard fires on a legitimate rename.
+            const specs = parseDeletedSpecs(tryExec(`git show ${sha} --name-status -M --format=`));
+
+            if (specs.length === 0) {
+                return
+            }
+
+            if (hasRetirementAccount(tryExec(`git log -1 ${sha} --format=%B`))) {
+                return
+            }
+
+            violations.push({sha, subject: tryExec(`git log -1 ${sha} --format=%s`), specs})
+        })
+    });
+
+    return violations
+}
+
+/**
+ * @summary Entry point. Reads git's pre-push payload from stdin and exits non-zero on unaccounted deletions.
+ * @returns {Promise<void>}
+ */
+async function main() {
+    let stdin = '';
+
+    if (!process.stdin.isTTY) {
+        for await (const chunk of process.stdin) {
+            stdin += chunk
+        }
+    }
+
+    const violations = collectViolations(pendingRanges(stdin));
+
+    if (violations.length > 0) {
+        console.error(formatFailure(violations));
+        process.exit(1)
+    }
+}
+
+// Import-safe: the spec imports the pure exports above without running the git scan.
+if (process.argv[1] && process.argv[1].endsWith('check-spec-retirement.mjs')) {
+    await main()
+}

--- a/buildScripts/util/check-spec-retirement.mjs
+++ b/buildScripts/util/check-spec-retirement.mjs
@@ -94,6 +94,12 @@ export function pendingRanges(stdin) {
  * `R100 old new` is a rename and never a deletion. `D path` is. A copy (`C`) leaves the source in
  * place, so it is not a deletion either. Only a leading `D` counts.
  *
+ * **Combined-diff rows parse through the same rule.** A merge renders one status letter per parent,
+ * so a resolution-deleted file arrives as `DD path` (`DDD` for an octopus) and a resolution-renamed
+ * one as `RR path` — note the single path, unlike the two-path `R100 old new` of an ordinary diff.
+ * `startsWith('D')` is what separates them, and it is doing real work rather than being incidental:
+ * were the test `status === 'D'`, every merge-resolution deletion would slip past.
+ *
  * @param {String} output Raw `--name-status` block.
  * @returns {String[]} Deleted spec paths, in encounter order.
  */
@@ -179,9 +185,13 @@ function collectViolations(ranges) {
     const violations = [];
 
     ranges.forEach(range => {
-        // `--no-merges`: a merge commit's combined diff attributes nothing, and the deletion is already
-        // carried by the commit that made it. Scanning merges would double-report a branch's own work
-        // and under-report nothing.
+        // Merges are scanned. An earlier draft passed `--no-merges` on the reasoning that a deletion
+        // is always carried by the commit that made it — false for a spec deleted while RESOLVING a
+        // merge, where neither parent deletes it and the merge is the only commit that could hold an
+        // account. Skipping merges left exactly this file's defect class reachable through a rebase.
+        //
+        // What makes including them safe is the diff rendering, not the traversal: see the combined-
+        // diff note in `collectViolations`' git show call.
         //
         // STRICT, not `tryExec`: an unresolvable range (a missing `origin/dev` in a shallow CI
         // checkout is the live case) must fail loudly. Swallowing it returns zero commits, the guard
@@ -190,7 +200,7 @@ function collectViolations(ranges) {
         let shas;
 
         try {
-            shas = exec(`git rev-list --no-merges ${range}`).split('\n').map(s => s.trim()).filter(Boolean)
+            shas = exec(`git rev-list ${range}`).split('\n').map(s => s.trim()).filter(Boolean)
         } catch {
             console.error(
                 `check-spec-retirement: cannot resolve the range \`${range}\`.\n` +
@@ -201,9 +211,24 @@ function collectViolations(ranges) {
         }
 
         shas.forEach(sha => {
+            // Two properties of this exact invocation are load-bearing.
+            //
             // `-M` forces rename detection ON regardless of the user's `diff.renames`, so a `git mv`
             // arrives as an `R` row that the parser drops. Without it, a machine with renames disabled
             // reports the move as delete-plus-add and the guard fires on a legitimate rename.
+            //
+            // On a MERGE, `git show` with no `--first-parent` renders the COMBINED diff, which lists
+            // only paths differing from EVERY parent — precisely what the merge resolution itself did.
+            // That is the correct attribution and it is why merges can be scanned at all:
+            //
+            //   - resolution deletes a spec neither parent deleted  -> `DD <path>`, caught (no other
+            //     commit could carry the account, so the merge must)
+            //   - a branch deletes a spec WITH an account and the merge merely takes it -> the
+            //     combined diff is EMPTY, silent, because the branch commit already answered for it
+            //
+            // `--first-parent` would report the second case as a deletion too, demanding an account on
+            // every merge that carries an already-accounted retirement — a false positive on exactly
+            // the workflow this guard is meant to permit.
             const specs = parseDeletedSpecs(tryExec(`git show ${sha} --name-status -M --format=`));
 
             if (specs.length === 0) {

--- a/buildScripts/util/check-spec-retirement.mjs
+++ b/buildScripts/util/check-spec-retirement.mjs
@@ -114,12 +114,28 @@ export function parseDeletedSpecs(output) {
 }
 
 /**
+ * @summary The account line: the marker at the head of its own line, followed by actual content.
+ *
+ * A substring test is not a grammar. `includes('spec-retired:')` accepted the marker with nothing
+ * after it, the marker followed only by whitespace, a passing mention inside a docs sentence, and —
+ * the one that settles it — `not-spec-retired: no account`, in which a message explicitly DENYING an
+ * account contains the marker and satisfies the guard. A rule that a denial can satisfy is costume.
+ *
+ * So: line-anchored (leading quote / list punctuation tolerated, because commit bodies get wrapped
+ * and bulleted), and a non-whitespace payload is required after the colon. The guard still never
+ * grades the prose — it cannot know whether "folded into X" is true — but it can insist that
+ * something was said.
+ * @type {RegExp}
+ */
+const RETIREMENT_ACCOUNT_PATTERN = /^[ \t>*-]*spec-retired:[ \t]*(\S.*)$/im;
+
+/**
  * @summary Whether a commit message carries a retirement account.
  * @param {String} message Full commit message (subject + body).
  * @returns {Boolean}
  */
 export function hasRetirementAccount(message) {
-    return String(message || '').toLowerCase().includes(RETIREMENT_MARKER);
+    return RETIREMENT_ACCOUNT_PATTERN.test(String(message || ''));
 }
 
 /**

--- a/test/playwright/unit/ai/scripts/lint/lintWorkflowScanRootParity.spec.mjs
+++ b/test/playwright/unit/ai/scripts/lint/lintWorkflowScanRootParity.spec.mjs
@@ -66,6 +66,11 @@ const REGISTRY = Object.freeze({
         source   : 'declared',
         surface  : ['ai/**/*.mjs']
     },
+    'spec-retirement-lint.yml': {
+        scriptRel: 'buildScripts/util/check-spec-retirement.mjs',
+        source   : 'declared',
+        surface  : ['test/playwright/unit/**']
+    },
     'config-template-ssot-lint.yml': {
         scriptRel: 'ai/scripts/lint/lint-config-template-ssot.mjs',
         source   : 'imported',

--- a/test/playwright/unit/buildScripts/checkSpecRetirement.spec.mjs
+++ b/test/playwright/unit/buildScripts/checkSpecRetirement.spec.mjs
@@ -75,6 +75,43 @@ test.describe('check-spec-retirement', () => {
         });
     });
 
+    test.describe('parseDeletedSpecs — combined-diff rows from a merge', () => {
+        // A merge renders ONE status letter per parent. Scanning merges is what closes the
+        // resolution-deletion hole (a spec neither parent deleted, dropped while resolving), and it is
+        // only safe because these rows keep the same delete-vs-rename discrimination.
+        const SPEC = 'test/playwright/unit/buildScripts/prepare.spec.mjs';
+
+        test('a two-parent resolution deletion (`DD`) is reported', () => {
+            expect(parseDeletedSpecs(`DD\t${SPEC}`)).toEqual([SPEC]);
+        });
+
+        test('an octopus resolution deletion (`DDD`) is reported', () => {
+            expect(parseDeletedSpecs(`DDD\t${SPEC}`)).toEqual([SPEC]);
+        });
+
+        test('a resolution RENAME (`RR`) is NOT a deletion', () => {
+            // Load-bearing, and the shape differs from an ordinary diff: a combined rename row carries
+            // ONE path (the new one), not the two of `R100 old new`. So the path-count test cannot be
+            // what saves us here — only the status letter can.
+            expect(parseDeletedSpecs(`RR\t${SPEC}`)).toEqual([]);
+        });
+
+        test('resolution modifications and additions are not deletions', () => {
+            expect(parseDeletedSpecs([`MM\t${SPEC}`, `AA\t${SPEC}`, `AM\t${SPEC}`].join('\n'))).toEqual([]);
+        });
+
+        test('a mixed merge block reports only the deleted spec', () => {
+            const block = [
+                `MM\ttest/playwright/unit/buildScripts/installBrain.spec.mjs`,
+                `DD\t${SPEC}`,
+                `RR\ttest/playwright/unit/buildScripts/prepare.renamed.spec.mjs`,
+                'DD\tsrc/some/source.mjs'
+            ].join('\n');
+
+            expect(parseDeletedSpecs(block)).toEqual([SPEC]);
+        });
+    });
+
     test.describe('hasRetirementAccount', () => {
         test('accepts the marker anywhere in the message, case-insensitively', () => {
             expect(hasRetirementAccount(`refactor: fold suites\n\n${RETIREMENT_MARKER} merged into sibling.spec.mjs`)).toBe(true);

--- a/test/playwright/unit/buildScripts/checkSpecRetirement.spec.mjs
+++ b/test/playwright/unit/buildScripts/checkSpecRetirement.spec.mjs
@@ -1,0 +1,155 @@
+import {test, expect} from '@playwright/test';
+
+import {
+    RETIREMENT_MARKER,
+    SPEC_PATH_PATTERN,
+    formatFailure,
+    hasRetirementAccount,
+    parseDeletedSpecs,
+    pendingRanges
+}                     from '../../../../buildScripts/util/check-spec-retirement.mjs';
+
+test.describe('check-spec-retirement', () => {
+    test.describe('parseDeletedSpecs — the rename exclusion', () => {
+        test('a deletion row is reported', () => {
+            const out = 'D\ttest/playwright/unit/buildScripts/prepare.spec.mjs';
+
+            expect(parseDeletedSpecs(out)).toEqual(['test/playwright/unit/buildScripts/prepare.spec.mjs']);
+        });
+
+        test('a RENAME is not a deletion, even though its first path looks like one', () => {
+            // The control the whole guard turns on. `git mv` produces `R100 <old> <new>`; a reader that
+            // took field 1 whenever the row "looked deleted" would report `<old>` and fire on every
+            // legitimate move. Two paths on the row is what distinguishes them.
+            const renamed = 'R100\ttest/playwright/unit/a.spec.mjs\ttest/playwright/unit/b.spec.mjs';
+
+            expect(parseDeletedSpecs(renamed)).toEqual([]);
+
+            // …and a partial-similarity rename behaves identically — the score varies, the shape does not.
+            expect(parseDeletedSpecs('R087\ttest/playwright/unit/a.spec.mjs\ttest/playwright/unit/c.spec.mjs')).toEqual([]);
+        });
+
+        test('a COPY is not a deletion — the source survives', () => {
+            expect(parseDeletedSpecs('C75\ttest/playwright/unit/a.spec.mjs\ttest/playwright/unit/b.spec.mjs')).toEqual([]);
+        });
+
+        test('added and modified rows are ignored', () => {
+            const out = [
+                'A\ttest/playwright/unit/buildScripts/new.spec.mjs',
+                'M\ttest/playwright/unit/buildScripts/old.spec.mjs'
+            ].join('\n');
+
+            expect(parseDeletedSpecs(out)).toEqual([]);
+        });
+
+        test('deletions OUTSIDE the unit tree are out of scope', () => {
+            // Source deletion is already loud (something stops importing it); e2e/integration suites
+            // report counts a human reads per run. The unit tree is where a file vanishes into a total.
+            const out = [
+                'D\tsrc/component/Base.mjs',
+                'D\ttest/playwright/e2e/some.spec.mjs',
+                'D\ttest/playwright/unit/buildScripts/kept.spec.mjs'
+            ].join('\n');
+
+            expect(parseDeletedSpecs(out)).toEqual(['test/playwright/unit/buildScripts/kept.spec.mjs']);
+        });
+
+        test('a non-spec deletion inside the unit tree is out of scope', () => {
+            expect(parseDeletedSpecs('D\ttest/playwright/unit/buildScripts/helper.mjs')).toEqual([]);
+        });
+
+        test('empty and malformed input degrade to no findings, never to a throw', () => {
+            expect(parseDeletedSpecs('')).toEqual([]);
+            expect(parseDeletedSpecs(null)).toEqual([]);
+            expect(parseDeletedSpecs('garbage-with-no-tab')).toEqual([]);
+        });
+
+        test('reproduces the incident population', () => {
+            // The five suites a lint-matcher branch removed while CI stayed green. Restored in
+            // `c7cb86b3fb`; all five sit inside this guard's scope, which is what makes the scope right.
+            const deleted = [
+                'checkCommitAuthorship', 'checkContentLogicalIdentity', 'checkDerivedDomain', 'installBrain', 'prepare'
+            ].map(name => `test/playwright/unit/buildScripts/${name}.spec.mjs`);
+
+            expect(parseDeletedSpecs(deleted.map(path => `D\t${path}`).join('\n'))).toEqual(deleted);
+        });
+    });
+
+    test.describe('hasRetirementAccount', () => {
+        test('accepts the marker anywhere in the message, case-insensitively', () => {
+            expect(hasRetirementAccount(`refactor: fold suites\n\n${RETIREMENT_MARKER} merged into sibling.spec.mjs`)).toBe(true);
+            expect(hasRetirementAccount('refactor: fold\n\nSpec-Retired: behavior removed in #123')).toBe(true);
+        });
+
+        test('rejects a message with no account', () => {
+            expect(hasRetirementAccount('fix(build): tighten the lint matcher')).toBe(false);
+            expect(hasRetirementAccount('')).toBe(false);
+            expect(hasRetirementAccount(null)).toBe(false);
+        });
+
+        test('a near-miss spelling does NOT satisfy the account', () => {
+            // The marker is the machine-checkable half of the contract; a guard that accepted
+            // "spec retired" or "retired spec" would accept prose that no tool can find later.
+            expect(hasRetirementAccount('chore: spec retired, coverage moved')).toBe(false);
+            expect(hasRetirementAccount('chore: retired the spec')).toBe(false);
+        });
+    });
+
+    test.describe('pendingRanges — guarding the push, not a guess about it', () => {
+        const zero = '0'.repeat(40);
+
+        test('uses the remote boundary git actually supplies', () => {
+            expect(pendingRanges('refs/heads/x aaa refs/heads/x bbb')).toEqual(['bbb..aaa']);
+        });
+
+        test('a NEW remote branch falls back to the trunk range', () => {
+            expect(pendingRanges(`refs/heads/x aaa refs/heads/x ${zero}`)).toEqual(['origin/dev..aaa']);
+        });
+
+        test('a ref DELETION sends no commits', () => {
+            expect(pendingRanges(`refs/heads/x ${zero} refs/heads/x bbb`)).toEqual([]);
+        });
+
+        test('empty stdin scans the branch rather than no-opping', () => {
+            // A guard that passes when it cannot see its input has the exact failure shape it exists
+            // to catch — silence indistinguishable from success.
+            expect(pendingRanges('')).toEqual(['origin/dev..HEAD']);
+            expect(pendingRanges(null)).toEqual(['origin/dev..HEAD']);
+        });
+
+        test('multiple refs each contribute a range', () => {
+            expect(pendingRanges('refs/heads/a 111 refs/heads/a 222\nrefs/heads/b 333 refs/heads/b 444'))
+                .toEqual(['222..111', '444..333']);
+        });
+    });
+
+    test.describe('formatFailure', () => {
+        const rendered = formatFailure([
+            {sha: 'abcdef1234567890', subject: 'fix(build): tighten the lint matcher', specs: ['test/playwright/unit/buildScripts/prepare.spec.mjs']}
+        ]);
+
+        test('names the deleted path and the marker', () => {
+            expect(rendered).toContain('test/playwright/unit/buildScripts/prepare.spec.mjs');
+            expect(rendered).toContain(RETIREMENT_MARKER);
+            expect(rendered).toContain('abcdef1234');
+        });
+
+        test('does NOT tell the author to restore the file', () => {
+            // The deletion is usually intentional and merely unaccounted, so prescribing a restore
+            // trains people to route around the guard. Asserted rather than trusted to review.
+            expect(rendered.toLowerCase()).not.toMatch(/restore the file|re-?add|revert the deletion|put it back/u);
+        });
+
+        test('states that legitimate deletion stays cheap', () => {
+            expect(rendered).toMatch(/account, not a veto/u);
+        });
+    });
+
+    test('SPEC_PATH_PATTERN admits the unit tree and nothing else', () => {
+        expect(SPEC_PATH_PATTERN.test('test/playwright/unit/a.spec.mjs')).toBe(true);
+        expect(SPEC_PATH_PATTERN.test('test/playwright/unit/deep/nested/a.spec.mjs')).toBe(true);
+        expect(SPEC_PATH_PATTERN.test('test/playwright/e2e/a.spec.mjs')).toBe(false);
+        expect(SPEC_PATH_PATTERN.test('test/playwright/unit/a.mjs')).toBe(false);
+        expect(SPEC_PATH_PATTERN.test('src/a.spec.mjs')).toBe(false);
+    });
+});

--- a/test/playwright/unit/buildScripts/checkSpecRetirement.spec.mjs
+++ b/test/playwright/unit/buildScripts/checkSpecRetirement.spec.mjs
@@ -87,6 +87,30 @@ test.describe('check-spec-retirement', () => {
             expect(hasRetirementAccount(null)).toBe(false);
         });
 
+        test('the marker WITHOUT content does not satisfy the account (#17151 RC1)', () => {
+            // A substring test is not a grammar. `includes()` accepted every line below, so the
+            // guard could be satisfied by costume — including by a message that DENIES having one.
+            expect(hasRetirementAccount('spec-retired:'),        'marker alone, zero information').toBe(false);
+            expect(hasRetirementAccount('spec-retired:     '),   'marker + whitespace only').toBe(false);
+            expect(hasRetirementAccount('spec-retired:\t\t'),    'marker + tabs only').toBe(false);
+        });
+
+        test('a NEGATED or merely-mentioned marker does not satisfy the account (#17151 RC1)', () => {
+            // `not-spec-retired:` contains the marker as a substring, so a commit explicitly stating
+            // there is no account previously passed the guard. This is the arm that settles why the
+            // check had to become line-anchored rather than merely stricter about payload.
+            expect(hasRetirementAccount('not-spec-retired: no account'), 'negated mention').toBe(false);
+            expect(hasRetirementAccount('see the docs: add a spec-retired: line to account for it'),
+                'the marker mentioned mid-sentence in prose').toBe(false);
+        });
+
+        test('real accounts survive the tightening, including wrapped and bulleted bodies (#17151 RC1)', () => {
+            expect(hasRetirementAccount('refactor: fold suites\n\nspec-retired: merged into sibling.spec.mjs')).toBe(true);
+            expect(hasRetirementAccount('x\n\n- spec-retired: split into two files'), 'list-bulleted').toBe(true);
+            expect(hasRetirementAccount('x\n\n> spec-retired: quoted in a reply'),    'quote-prefixed').toBe(true);
+            expect(hasRetirementAccount('x\n\n  spec-retired: indented'),             'indented').toBe(true);
+        });
+
         test('a near-miss spelling does NOT satisfy the account', () => {
             // The marker is the machine-checkable half of the contract; a guard that accepted
             // "spec retired" or "retired spec" would accept prose that no tool can find later.


### PR DESCRIPTION
Resolves #17151

> 🌿 The one defect a test suite cannot report is its own absence. Now the commit that causes it reports it instead.

A deleted unit spec now has to say where its coverage went. `check-spec-retirement.mjs` runs pre-push and in CI, refusing a commit that removes a `test/playwright/unit/**/*.spec.mjs` with no `spec-retired:` account in its message — an account, never a veto.

Evidence: L4 (the guard exercised end-to-end against real git objects — a staged deletion, an amended account, and a real `git mv` — plus unit arms over the pure parsers) → L4 required (every deliverable AC is a local, in-process observable). Residual: AC-3's enforcement half, Residual-Owner: #17171.

## Deltas from ticket

**Three of the ticket's anchors did not survive to implementation, and @neo-opus-grace confirmed all three at intake.**

1. **Both cited SHAs were unreachable.** `5107dbb67c` / `c6f928281a` resolved from nothing — not `origin/dev`, not any remote branch, not `refs/pull/17126/head` (positive control: the same API returned that PR's ten commits). Grace had rebased the branch under them ~90 minutes after filing. Her live mapping — `688cb5f82c` (deletion) and `c7cb86b3fb` (restore) — matches what I found independently.

   **So AC-4's control is a fixture, not a SHA.** A commit id on an unmerged feature branch is stale-by-construction the moment its author rebases; it cannot be durable evidence for a guard that must keep working afterwards. The incident is instead reproduced by content: the five suite paths, asserted against the parser. I verified the substitution is honest — `c7cb86b3fb` restores exactly those five, all under `test/playwright/unit/buildScripts/`, i.e. **inside** this guard's scope, which is what makes the scope right rather than merely plausible.

2. **`check-fixed-sleeps.mjs` is not on `dev`.** The ticket says to mirror its marker discipline; it ships unmerged in PR #17126, currently `CHANGES_REQUESTED`. Coupling a merged guard to a convention still under review means blocking on it or shipping a moving reference, so `spec-retired:` is defined independently. Both are commit-message markers, so unifying later is a rename — the fork and my reasoning are on the ticket for Grace.

3. **AC-3 was withdrawn by its author mid-review, and the replacement still carries two clauses this PR does not meet.**

   @neo-opus-grace [withdrew AC-3 as written](https://github.com/neomjs/neo/issues/17151#issuecomment-5302222911) once #17171 established that no lint workflow is a required context: no implementation of her guard could make "so `--no-verify` cannot bypass it" true, because the property lives in branch protection, not in the guard. Her replacement, carried here at her request so the amendment lands with its delivery:

   > The guard is wired the same way its siblings are: `lint-staged`, a CI mirror that **reports** the same verdict on the PR, and `lint-guard-ci-parity` registration. Whether a red mirror **blocks** a merge is not this guard's property — it is branch-protection configuration, tracked at #17171.

   The CI-mirror clause is met. **The other two are still not, and I would rather say so than let an amendment paper over it** — the reason is mechanical and unchanged by the withdrawal.** The account lives in the commit message (the file is gone, so it cannot live in the file), and at pre-commit time the message does not exist yet. The guard therefore runs **pre-push**, beside `check-commit-authorship.mjs`, which reads commit messages from that hook for exactly the same reason. `lint-guard-ci-parity` registration is correspondingly N/A — verified, not assumed: that registry's population is read from `package.json`'s lint-staged config, and neither existing pre-push guard appears in it. So `lint-staged` wiring is impossible for this guard specifically, and `lint-guard-ci-parity` registration is correspondingly N/A — verified, not assumed: that registry's population is read from `package.json`'s lint-staged config, and neither existing pre-push guard appears in it. The sibling-parity clause therefore reads as satisfied-in-spirit and unmet-in-letter, which is the honest description.

**Two latent bugs in `.husky/pre-push` had to be fixed for the guard to work at all.** Both are measured, and both make the two existing guards stronger:

- **No `set -e`.** sh reports only the *last* command's status, so a guard failing anywhere but the bottom of the file printed its complaint and the push proceeded. Every guard there was blocking purely by being last — a property of the file ordering, not of the guard. My own would have inherited exactly that. Measured: `sh -c 'exit-1-cmd; exit-0-cmd'` → `0`.
- **stdin is delivered once.** git sends the pre-push payload on stdin a single time, so the first guard that reads it leaves every later guard silently falling back to a guessed range. `check-commit-authorship.mjs` reads it via `readFileSync(0)`; a third guard added naively would have been guessing. The hook now captures the payload once and pipes each guard its own copy.

This is a deliberate widening beyond the ticket, confined to five lines, and I would rather flag it than let it pass as incidental.

**One hardening the ticket did not ask for:** an unresolvable range exits non-zero instead of scanning zero commits. A guard that passes when it cannot see its input reproduces the exact defect it exists to catch — silence indistinguishable from success — inside the catcher. The CI job's `fetch-depth: 0` is what keeps that path unreached; without it the range cannot resolve at all.

## Enforcement gap — this PR ships visibility, not a `--no-verify` closure

Found by @neo-gpt at exact head, and it falsifies a claim I made in this body and in the workflow header.

The live `dev` ruleset (`19087298`) requires exactly **one** status context: `integration-parity`. `Spec Retirement Lint / lint` runs on every matching PR and goes red on a violation, but **a red result does not make a PR ineligible to merge**, and `git push --no-verify` still bypasses the only blocking hook. Verified independently:

```
gh api repos/neomjs/neo/rules/branches/dev --jq '…required_status_checks[]?.context'
→ integration-parity          # the whole list
```

The branch-protection endpoint 404s, so that ruleset is the entire story. **Workflow presence plus scan-root registration is reachability, not enforcement** — I had treated "the job runs and is registered" as "the hole is closed", which is a category error about what a required context is.

What this PR therefore delivers: a guard that blocks on the pre-push hook, plus a loud non-blocking CI signal that catches the `--no-verify` case *visibly* without *preventing* it. That is strictly more than the two sibling pre-push guards have, and less than AC-3 asks for.

**And the gap is not this guard's.** Checking the family: **19 `*-lint.yml` workflows run on `dev` PRs and zero are required contexts.** Several of their headers claim `--no-verify` closure in the same words mine did. Fixing it only for `spec-retirement-lint` would close my instance, leave eighteen open, and make the substrate *more* misleading — one honest header among nineteen false ones.

So the enforcement half is split out as **#17171**, filed at the family's scope with the three candidate shapes, the live-ruleset ACs, and the enforcement twin of `lintWorkflowScanRootParity`'s reachability spec. It is operator-gated because every option mutates repo settings. @tobiu — that ticket is the decision, and the ruleset is yours to change.

## Merge-resolution deletions — the hole the first draft's own comment argued for

@neo-gpt's re-review blocker, and the comment I wrote was the wrong part. `--no-merges` was justified with *"the deletion is already carried by the commit that made it"*. **False for a spec deleted while RESOLVING a merge**: neither parent deletes it, so no parent commit can carry an account, and the one commit that could — the merge — was excluded from the traversal. This guard's own defect class, reachable through a rebase.

Verified on a real merge object before changing anything: `git rev-list <p1>..<merge>` includes the merge; the exact `--no-merges` traversal omits it.

**The repair is the traversal, not the rendering.** Dropping `--no-merges` suffices, because `git show` on a merge already renders the **combined diff** — only paths differing from *every* parent, which is exactly what the resolution itself did:

| scenario | combined diff | outcome |
|---|---|---|
| resolution deletes a spec neither parent deleted | `DD <path>` | **caught** — the merge is the only place an account could live |
| a branch deletes a spec **with** an account; the merge takes it | *empty* | **silent** — the branch commit already answered |

Euclid's suggested `--first-parent` was checked and rejected **on evidence, not preference**: it renders the second case as a deletion too, demanding an account on every merge carrying an already-accounted retirement — a false positive on precisely the workflow this guard exists to permit. Measured by mutating the guard to `--first-parent` and running the accounted-branch fixture: **exit 1**.

One incidental thing turned load-bearing: `startsWith('D')`. `DD`/`DDD` are deletions; `RR` is a resolution rename carrying **one** path (unlike `R100 old new`), so the path-count test cannot discriminate on combined rows and only the status letter can. Now stated in the JSDoc and pinned by five arms.

## Test Evidence

```
npx playwright test -c test/playwright/playwright.config.unit.mjs \
  test/playwright/unit/buildScripts/ --workers=1
→ 85 passed (3.3s)
```

**End-to-end against real git objects** — the part unit tests over pure functions cannot prove:

| Scenario | Result |
|---|---|
| `git rm` a real spec, commit with no account | guard **exits 1**, names the commit and the path |
| same commit amended with `spec-retired: …` | guard **exits 0** |
| `git mv` a real spec (git reports `R100`), no account | guard **exits 0** — rename correctly not a deletion |
| merge **resolution** deletes a spec, no account | guard **exits 1** — the hole Euclid found |
| the same merge amended with `spec-retired: …` | guard **exits 0** |
| branch deletes **with** an account, merge merely takes it | guard **exits 0** — no false positive |

The rename control is the load-bearing one, and it is why the exclusion lives in a parsed status letter rather than a `--diff-filter` flag: rename detection is configurable, so a flag combination that excludes renames on one machine reports them as delete-plus-add on another, and the guard would fire on every `git mv` for half the team.

The **push that opened this PR is itself the hook's end-to-end test** — all three guards ran through the restructured payload fan-out and passed.

Unit arms cover: the rename/copy/add/modify status matrix, out-of-scope paths (source, e2e, non-spec), malformed input degrading to no findings rather than a throw, the five-suite incident population, marker matching incl. case-insensitivity and near-miss spellings that must NOT satisfy it, all four `pendingRanges` branches, and an assertion that the failure text does **not** tell the author to restore the file.

Directly touched surfaces: `buildScripts/util/check-spec-retirement.mjs` — new, spec above. `.husky/pre-push` — exercised by this PR's own push. `.github/workflows/spec-retirement-lint.yml` — new; `lint-guard-ci-parity` ran green on it in the commit hook.

## Post-Merge Validation

One residual, owned elsewhere: **AC-3's enforcement half is not delivered here and is carried by #17171** — the repo-wide finding that nineteen lint workflows run on `dev` PRs and none is a required status context. That needs a repo-admin ruleset mutation, which no PR can perform. #17171 also carries the spec that reads the live ruleset, so the gap cannot silently reopen.

Everything else is a local observable and each is armed above, including the two ACs the ticket framed as needing an incident replay — reproduced by content rather than by a commit id, which is the durable form and the one that survives the next rebase.

The first PR that legitimately retires a spec will exercise the account path in anger; that is the guard working, not a validation debt.

## Commits

- `f40c97aa2a` — the guard, its unit arms, the CI mirror, and the two `.husky/pre-push` fixes.
- `832063e0ee` — scan-root registration + both workflow triggers, after CI caught the omission.
- `67db298a4c` — @neo-gpt's re-review blocker: merges are scanned, and the combined diff is what makes that safe. Red-proved on one commit — `--no-merges` exits 0, the repair exits 1.
- `e3f8442364` — @neo-gpt's two exact-head blockers: the account grammar tightened from a substring test to a line-anchored one requiring content, and the enforcement claim narrowed to what the live ruleset actually supports. Guard behaviour is unchanged by the second; only the claims about it are.

## Evolution

The ticket prescribed `lint-staged` wiring and a SHA-pinned control, and neither survived contact — not because the ticket was careless but because both were pinned to things that move: a hook phase that cannot see commit messages, and commit ids on a branch that got rebased ninety minutes later. Grace's own conclusion on the second is the durable one and it shaped AC-4 here: an incident receipt should cite content-addressable evidence — file sets, path anchors, counts — rather than branch-local commit identity.

Related: #17124
Refs #17126

Authored by Vega (Claude Opus 5, Claude Code). Session 5cd926fa-77e1-4309-8bbf-ca563ab07403.
