### PR TITLE
feat(ai): charge the review budget per reviewer family, and make the exception checkable (#17163)

### DIFF
--- a/ai/services/github-workflow/PullRequestService.mjs
+++ b/ai/services/github-workflow/PullRequestService.mjs
@@ -1681,12 +1681,30 @@ function parseRepairMintedReceipt(reason, priorHeads = [], currentHead = '') {
     // The falsifiable clause. Everything above checks the sentence against itself; this checks it
     // against the PR's own history, which is the only part a mistaken or invented receipt cannot
     // satisfy by being better written.
-    if (priorHeads.length && !priorHeads.includes(fields['old-head'])) {
+    // `priorHeads` carries ONLY the spending family's prior review heads. Checking against every
+    // family's heads let a GPT re-entry cite a head only Claude ever reviewed — the causal claim is
+    // "the defect did not exist at the head I reviewed", so a head someone else reviewed proves
+    // nothing about this family's Round 1.
+    //
+    // An EMPTY set refuses rather than skipping. The earlier `priorHeads.length &&` short-circuit
+    // meant that when commit evidence was missing, the one clause a receipt cannot talk its way past
+    // simply stopped running — reversing the guard exactly where evidence is unavailable, which is
+    // where a false receipt is most likely and least detectable.
+    if (priorHeads.length === 0) {
         return {
             valid  : false,
             missing,
             fields,
-            failure: `old-head ${fields['old-head']} matches no head a prior review was submitted against (${priorHeads.join(', ') || 'none recorded'}).`
+            failure: 'No prior review head is recorded for this family, so the receipt\'s old-head cannot be corroborated. Refusing rather than accepting an uncheckable causal claim.'
+        }
+    }
+
+    if (!priorHeads.includes(fields['old-head'])) {
+        return {
+            valid  : false,
+            missing,
+            fields,
+            failure: `old-head ${fields['old-head']} matches no head THIS family submitted a prior review against (${priorHeads.join(', ')}).`
         }
     }
 
@@ -2112,9 +2130,17 @@ function validatePrReviewBudget({
             }
         }
 
+        // Only THIS family's prior review heads. The exception is granted to a family on the strength
+        // of what that family reviewed, so corroboration drawn from another family's history would
+        // let a reviewer borrow a causal claim they never made.
+        const currentFamilyPriorHeads = priorRequestChanges
+            .filter(review => resolveReviewerFamily(review).family === reviewerFamily.family)
+            .map(review => review?.commit?.oid)
+            .filter(Boolean);
+
         const receipt = parseRepairMintedReceipt(
             override.reason,
-            priorRequestChanges.map(review => review?.commit?.oid).filter(Boolean),
+            currentFamilyPriorHeads,
             pullRequest?.headRefOid || ''
         );
 

--- a/ai/services/github-workflow/PullRequestService.mjs
+++ b/ai/services/github-workflow/PullRequestService.mjs
@@ -7,7 +7,12 @@ import Base                 from '../../../src/core/Base.mjs';
 import GraphqlService       from './GraphqlService.mjs';
 import aiConfig             from '../../mcp/server/github-workflow/config.mjs';
 import logger               from '../../mcp/server/github-workflow/logger.mjs';
+import RepositoryService    from './RepositoryService.mjs';
 import {validateMergeReady} from '../../scripts/lifecycle/validateMergeReady.mjs';
+import {
+    groupReviewsByFamily,
+    resolveReviewerFamily
+}                           from '../graph/agentFamilyResolution.mjs';
 import {
     ADD_PULL_REQUEST_REVIEW,
     GET_PULL_REQUEST_ID,
@@ -1860,10 +1865,12 @@ function resolveReviewBudgetActivation({
  * @param {Number} options.activationIssueNumber Source issue for the cohort cutover.
  * @param {Number} options.activationPullRequestNumber Merged closing PR that activated the cohort.
  * @param {String} options.body Validated review body.
- * @param {Number} options.ordinaryLimit Ordinary Request Changes ceiling.
+ * @param {Number} options.ordinaryLimit Ordinary Request Changes ceiling, PER REVIEWER FAMILY.
  * @param {Number} options.pr_number PR number.
  * @param {Object} options.pullRequest GraphQL PR projection.
  * @param {String} [options.reviewBudgetOverrideReason] Named bypass reason.
+ * @param {String|null} options.reviewerLogin Authenticated submitting login; the budget is charged to
+ * its family, and an unclassifiable login is refused rather than granted a free round.
  * @returns {{failure: Object|null, body: String, audit: Object|null}}
  */
 function validatePrReviewBudget({
@@ -1874,7 +1881,8 @@ function validatePrReviewBudget({
     ordinaryLimit,
     pr_number,
     pullRequest,
-    reviewBudgetOverrideReason
+    reviewBudgetOverrideReason,
+    reviewerLogin
 }) {
     const activatedMs = Date.parse(activatedAt || '');
     const createdMs   = Date.parse(pullRequest?.createdAt || '');
@@ -1940,12 +1948,41 @@ function validatePrReviewBudget({
     const priorRequestChanges = reviews.nodes.filter(isSubmittedRequestChangesReview);
     const priorTerminal       = priorRequestChanges.filter(review => classifyDropSupersedeReview(review?.body || '').valid);
     const incomingTerminal    = classifyDropSupersedeReview(body);
-    const audit               = {
+
+    // WHOSE round is being spent. The budget's unit is the reviewer FAMILY, so the count that matters
+    // is this family's prior rounds — not the PR's total. A global count let one family's exhausted
+    // budget silence a family that had never reviewed, and let a family buy extra rounds by rotating
+    // identities; both are answered by counting the same way the authority defines membership.
+    const reviewerFamily = resolveReviewerFamily({author: {login: reviewerLogin}});
+    const grouped        = groupReviewsByFamily(priorRequestChanges);
+    const familyPrior    = reviewerFamily.classified ? (grouped.byFamily[reviewerFamily.family] || 0) : 0;
+
+    const audit = {
         ...baseAudit,
-        applicable                : true,
-        submittedRequestChanges   : priorRequestChanges.length,
-        priorTerminalDropSupersede: priorTerminal.length
+        applicable                   : true,
+        submittedRequestChanges      : priorRequestChanges.length,
+        priorTerminalDropSupersede   : priorTerminal.length,
+        reviewerFamily               : reviewerFamily.family,
+        reviewerLogin                : reviewerFamily.login,
+        familySubmittedRequestChanges: familyPrior,
+        unclassifiedPriorReviewers   : grouped.unclassified.map(entry => entry.login)
     };
+
+    // Fail CLOSED on a reviewer the identity graph cannot classify. The alternative reads as
+    // generosity and is the opposite: an unrostered login would spend nobody's budget, so it could
+    // request changes without limit while every rostered family stayed bounded. A gate that cannot
+    // name the spender must refuse the charge, not waive it.
+    if (!reviewerFamily.classified) {
+        return {
+            failure: getReviewBudgetFailure(
+                pr_number,
+                `The submitting reviewer (${reviewerFamily.login || 'no resolvable login'}) is not a classifiable maintainer family, so this REQUEST_CHANGES cannot be charged to a review budget. Refusing rather than granting an unbounded round.`,
+                audit
+            ),
+            body,
+            audit: null
+        }
+    }
 
     if (override.provided && !override.valid) {
         return {
@@ -1979,7 +2016,7 @@ function validatePrReviewBudget({
         }
     }
 
-    if (priorRequestChanges.length < ordinaryLimit) {
+    if (familyPrior < ordinaryLimit) {
         const withinBudgetAudit = {...audit, outcome: 'within-budget'};
 
         return {
@@ -2011,7 +2048,7 @@ function validatePrReviewBudget({
     return {
         failure: getReviewBudgetFailure(
             pr_number,
-            `PR #${pr_number} already has ${priorRequestChanges.length} submitted CHANGES_REQUESTED reviews; the ordinary limit is ${ordinaryLimit}. Use COMMENT for the RC2 closure packet, APPROVED when merge-safe, or one validated Drop+Supersede terminal verdict.`,
+            `The ${reviewerFamily.family} family has already spent its ${familyPrior}-of-${ordinaryLimit} ordinary CHANGES_REQUESTED round on PR #${pr_number}. Post the terminal disposition over the existing actions, APPROVED when merge-safe, or one validated Drop+Supersede. Another family's independent round is unaffected by this refusal.`,
             audit
         ),
         body,
@@ -2161,10 +2198,16 @@ class PullRequestService extends Base {
          */
         reviewBudgetActivationBaseRefName: 'dev',
         /**
-         * Maximum ordinary submitted CHANGES_REQUESTED reviews on a post-cutover PR.
-         * @member {Number} reviewBudgetOrdinaryRcLimit=2
+         * Maximum ordinary submitted CHANGES_REQUESTED reviews PER REVIEWER FAMILY on a post-cutover PR.
+         *
+         * One, not two, and per family rather than per PR. The prior global ceiling of two measured the
+         * wrong thing in both directions: one family's two rounds silenced a family that had never
+         * reviewed, while a single family could spend both rounds itself and call it a budget. Counting
+         * by family makes each family's one comprehensive round independent, which is the shape the
+         * terminal-review decision actually describes.
+         * @member {Number} reviewBudgetOrdinaryRcLimit=1
          */
-        reviewBudgetOrdinaryRcLimit: 2,
+        reviewBudgetOrdinaryRcLimit: 1,
         /**
          * @member {Boolean} singleton=true
          * @protected
@@ -2732,7 +2775,14 @@ class PullRequestService extends Base {
                             ordinaryLimit              : this.reviewBudgetOrdinaryRcLimit,
                             pr_number,
                             pullRequest,
-                            reviewBudgetOverrideReason
+                            reviewBudgetOverrideReason,
+                            // The STARTUP-CACHED login, deliberately not the awaiting getter. Admission
+                            // is a hot path and must not acquire an identity over the network while
+                            // deciding whether to admit: a validator that makes its own round trip can
+                            // fail for reasons that have nothing to do with the review it is judging.
+                            // A cold cache resolves to null, which the budget already treats as
+                            // unclassifiable and refuses — the safe direction.
+                            reviewerLogin              : RepositoryService.viewerLogin
                         });
 
                         if (budgetValidation.failure) {

--- a/ai/services/github-workflow/PullRequestService.mjs
+++ b/ai/services/github-workflow/PullRequestService.mjs
@@ -1641,6 +1641,68 @@ function getReviewBudgetFailure(pr_number, message, audit = {}) {
 }
 
 /**
+ * @summary Parses a repair-minted re-entry receipt out of an override disclosure.
+ *
+ * The exceptional second round exists for exactly one situation: a defect that did NOT exist, or was
+ * undiscoverable, at the head Round 1 reviewed — and that the author's own repair created or exposed.
+ * "I noticed it later" is not that situation, and free prose cannot tell the two apart. So the receipt
+ * names four things and each is checked against something outside the sentence:
+ *
+ * - `old-head` must be a head some prior review was actually submitted against. This is the clause
+ *   that makes the receipt falsifiable rather than merely well-formed: it is verified against the PR's
+ *   own review population, so a receipt cannot invent the history it claims to have reviewed.
+ * - `new-head` must differ from `old-head`. A re-entry across an unchanged head describes no repair.
+ * - `prior-fact` states what about the old head made the defect nonexistent or undiscoverable.
+ * - `repair-coordinate` names where the repair created or exposed it.
+ *
+ * Deliberately not a free-text reason with a length rule. A single-line non-empty check accepts
+ * "release safety exception", which asserts nothing checkable and is indistinguishable from the
+ * ordinary later discovery this clause refuses.
+ * @param {String} reason Trimmed single-line disclosure.
+ * @param {String[]} priorHeads Commit oids that prior submitted reviews were made against.
+ * @param {String} currentHead The PR head this review is being submitted against.
+ * @returns {{valid: Boolean, missing: String[], fields: Object, failure: String|null}}
+ */
+function parseRepairMintedReceipt(reason, priorHeads = [], currentHead = '') {
+    const
+        fields  = {},
+        pattern = /(old-head|new-head|prior-fact|repair-coordinate)\s*:\s*([^|]+)/g;
+
+    for (const match of reason.matchAll(pattern)) fields[match[1]] = match[2].trim();
+
+    const missing = ['old-head', 'new-head', 'prior-fact', 'repair-coordinate'].filter(key => !fields[key]);
+
+    if (missing.length) return {valid: false, missing, fields, failure: null};
+
+    if (fields['old-head'] === fields['new-head']) {
+        return {valid: false, missing, fields, failure: 'old-head and new-head are identical, so the receipt describes no repair between them.'}
+    }
+
+    // The falsifiable clause. Everything above checks the sentence against itself; this checks it
+    // against the PR's own history, which is the only part a mistaken or invented receipt cannot
+    // satisfy by being better written.
+    if (priorHeads.length && !priorHeads.includes(fields['old-head'])) {
+        return {
+            valid  : false,
+            missing,
+            fields,
+            failure: `old-head ${fields['old-head']} matches no head a prior review was submitted against (${priorHeads.join(', ') || 'none recorded'}).`
+        }
+    }
+
+    if (currentHead && fields['new-head'] !== currentHead) {
+        return {
+            valid  : false,
+            missing,
+            fields,
+            failure: `new-head ${fields['new-head']} is not the head under review (${currentHead}); a repair-minted re-entry is bound to the repaired head.`
+        }
+    }
+
+    return {valid: true, missing: [], fields, failure: null}
+}
+
+/**
  * @summary Validates and normalizes the named review-budget override disclosure.
  * @param {*} value Candidate override reason.
  * @returns {{provided: Boolean, valid: Boolean, reason: String}}
@@ -2029,10 +2091,50 @@ function validatePrReviewBudget({
     }
 
     if (override.valid) {
+        // ONE re-entry, and it is terminal. A family that has already spent its repair-minted round has
+        // spent the exception too — otherwise the exception becomes the budget, reachable indefinitely
+        // by writing a well-formed receipt each time. Prior re-entries are countable because the
+        // override audit is appended durably to the review body it authorized.
+        const priorReEntries = priorRequestChanges.filter(review =>
+            (review?.body || '').includes(REVIEW_BUDGET_OVERRIDE_MARKER) &&
+            resolveReviewerFamily(review).family === reviewerFamily.family
+        );
+
+        if (priorReEntries.length > 0) {
+            return {
+                failure: getReviewBudgetFailure(
+                    pr_number,
+                    `The ${reviewerFamily.family} family has already used its one repair-minted re-entry on PR #${pr_number}. A second is refused: post the terminal disposition, APPROVE when merge-safe, or one validated Drop+Supersede.`,
+                    {...audit, priorRepairMintedReEntries: priorReEntries.length}
+                ),
+                body,
+                audit: null
+            }
+        }
+
+        const receipt = parseRepairMintedReceipt(
+            override.reason,
+            priorRequestChanges.map(review => review?.commit?.oid).filter(Boolean),
+            pullRequest?.headRefOid || ''
+        );
+
+        if (!receipt.valid) {
+            return {
+                failure: getReviewBudgetFailure(
+                    pr_number,
+                    receipt.failure || `A repair-minted re-entry must name old-head, new-head, prior-fact, and repair-coordinate; missing: ${receipt.missing.join(', ')}. An ordinary later discovery does not qualify — the defect must not have existed, or not have been discoverable, at the head Round 1 reviewed.`,
+                    {...audit, repairMintedReceipt: receipt.fields}
+                ),
+                body,
+                audit: null
+            }
+        }
+
         const overrideAudit = {
             ...audit,
-            outcome       : 'disclosed-override',
-            overrideReason: override.reason
+            outcome            : 'disclosed-override',
+            overrideReason     : override.reason,
+            repairMintedReceipt: receipt.fields
         };
 
         return {

--- a/ai/services/github-workflow/RepositoryService.mjs
+++ b/ai/services/github-workflow/RepositoryService.mjs
@@ -38,6 +38,20 @@ class RepositoryService extends Base {
     viewerPermission = null;
 
     /**
+     * The authenticated user's GitHub login, cached alongside the permission it was fetched with.
+     *
+     * The permission answers "may this seat act?"; the login answers "which seat is acting?" — and a
+     * per-family review budget needs the second question answered before it can charge a round to
+     * anyone. The two are cached together because they come from the same authenticated call: asking
+     * separately would invite them to disagree about who the viewer is.
+     *
+     * Deliberately the login rather than anything parsed from a review body. The submitting identity
+     * IS the act; a signature in prose is a claim about it, and the two can differ.
+     * @member {String|null} viewerLogin=null
+     */
+    viewerLogin = null;
+
+    /**
      * Fetches the current user's permission level from the API and caches it.
      * This method is intended for internal use at startup but can be called on demand.
      * @returns {Promise<string|null>} The permission string or null on failure.
@@ -51,7 +65,11 @@ class RepositoryService extends Base {
         try {
             const data = await GraphqlService.query(GET_VIEWER_PERMISSION, variables);
             this.viewerPermission = data.repository.viewerPermission;
-            logger.info(`Fetched and cached viewer permission: ${this.viewerPermission}`);
+            // Null rather than undefined on a payload without it, so a consumer can tell "the viewer
+            // has no login" from "nobody has asked yet" — a budget that cannot identify its spender
+            // must refuse, and it can only refuse if the two states are distinguishable.
+            this.viewerLogin      = data.viewer?.login ?? null;
+            logger.info(`Fetched and cached viewer permission: ${this.viewerPermission} (${this.viewerLogin || 'unknown login'})`);
             return this.viewerPermission;
         } catch (error) {
             logger.error('Error fetching viewer permission via GraphQL:', error);
@@ -72,6 +90,21 @@ class RepositoryService extends Base {
         }
 
         return {permission: this.viewerPermission};
+    }
+
+    /**
+     * @summary Returns the authenticated user's login, fetching it if the startup cache is cold.
+     *
+     * Shares `fetchAndCacheViewerPermission`'s single authenticated call rather than adding a second
+     * round trip, because the permission and the identity must describe the same viewer.
+     * @returns {Promise<String|null>} The login, or `null` when it cannot be resolved.
+     */
+    async getViewerLogin() {
+        if (!this.viewerLogin) {
+            await this.fetchAndCacheViewerPermission();
+        }
+
+        return this.viewerLogin
     }
 }
 

--- a/ai/services/github-workflow/queries/repositoryQueries.mjs
+++ b/ai/services/github-workflow/queries/repositoryQueries.mjs
@@ -19,6 +19,9 @@ export const GET_VIEWER_PERMISSION = `
     $owner: String!
     $repo: String!
   ) {
+    viewer {
+      login
+    }
     repository(owner: $owner, name: $repo) {
       viewerPermission
     }

--- a/ai/services/graph/agentFamilyResolution.mjs
+++ b/ai/services/graph/agentFamilyResolution.mjs
@@ -187,6 +187,67 @@ export function resolveAuthorFamily(pr, agentFamilies) {
 }
 
 /**
+ * @summary Resolves the model family that a submitted review SPENDS budget against.
+ *
+ * Separate from {@link resolveAuthorFamily} because the two answer different questions from
+ * different evidence. An author is resolved through the PR body's self-id, which survives an
+ * opener whose login mis-resolved. A reviewer has no such body convention: the submitting login
+ * IS the act, so the login is the only honest source and no fallback exists to soften it.
+ *
+ * The verdict is a pair rather than a bare family, and that distinction is the whole point of
+ * this function. A budget consumer must be able to tell "resolved to `gpt`" from "could not be
+ * resolved", because those demand opposite handling — one spends a family's round, the other
+ * must refuse rather than quietly spend nobody's. Returning `undefined` for both would let an
+ * unclassifiable reviewer slip through whichever branch happened to be the permissive one.
+ *
+ * @param {Object} review GitHub review payload; `author.login` is the subject.
+ * @param {Object} [agentFamilies=getCoreSwarmAgentFamilies()] Login-to-family map.
+ * @returns {{classified: Boolean, family: (String|null), login: (String|null)}}
+ */
+export function resolveReviewerFamily(review, agentFamilies = getCoreSwarmAgentFamilies()) {
+    const login = review?.author?.login || null;
+
+    if (!login) return {classified: false, family: null, login: null};
+
+    const family = agentFamilies[login.replace(/^@/, '')];
+
+    return family
+        ? {classified: true,  family, login}
+        : {classified: false, family: null, login}
+}
+
+/**
+ * @summary Groups submitted reviews by the family whose budget each one spends.
+ *
+ * The counting unit is the FAMILY, never the identity: two identities of one family reviewing the
+ * same PR are one family's round, or a family could buy extra rounds by rotating seats. Counting
+ * is by occurrence across the whole review population, so later heads and retractions cannot
+ * refund a round that was already spent — a spent round is a fact about the review economy, not
+ * about the current diff.
+ *
+ * Unclassifiable reviewers are returned SEPARATELY rather than dropped or bucketed under a
+ * placeholder family. Dropping them would let an unrostered login review without limit; bucketing
+ * them together would let two unrelated strangers share one budget. Neither is a decision this
+ * function may make silently, so it reports and lets the admission point fail closed.
+ *
+ * @param {Object[]} reviews Submitted review payloads.
+ * @param {Object} [agentFamilies=getCoreSwarmAgentFamilies()] Login-to-family map.
+ * @returns {{byFamily: Object<String,Number>, unclassified: Array<{login: (String|null)}>}}
+ */
+export function groupReviewsByFamily(reviews = [], agentFamilies = getCoreSwarmAgentFamilies()) {
+    const byFamily = {}, unclassified = [];
+
+    for (const review of reviews) {
+        const resolved = resolveReviewerFamily(review, agentFamilies);
+
+        if (resolved.classified) byFamily[resolved.family] = (byFamily[resolved.family] || 0) + 1;
+        else                     unclassified.push({login: resolved.login})
+    }
+
+    return {byFamily, unclassified}
+}
+
+/**
  * @summary Determines whether a PR has cross-family review coverage.
  *
  * @param {Object} pr GitHub PR payload from `gh pr list`.

--- a/test/playwright/unit/ai/services/github-workflow/PullRequestService.spec.mjs
+++ b/test/playwright/unit/ai/services/github-workflow/PullRequestService.spec.mjs
@@ -2219,6 +2219,124 @@ test.describe('Neo.ai.services.github-workflow.PullRequestService — managePrRe
         expect(mutationCallCount, 'neither unclassified submitter reached a mutation').toBe(0);
     });
 
+    test('#17141: a repair-minted re-entry is refused unless every clause checks out', async () => {
+        // The exception exists for one situation: a defect that did NOT exist, or was undiscoverable,
+        // at the head Round 1 reviewed, and that the author's own repair created or exposed. "Noticed
+        // later" is not that situation, and free prose cannot tell the two apart — which is why the
+        // prior contract accepted "release safety exception" and asserted nothing checkable.
+        //
+        // Each row removes exactly ONE clause from an otherwise-valid receipt, so a refusal cannot be
+        // inherited from any other check.
+        const valid = {
+            'old-head'         : '1111111111111111111111111111111111111111',
+            'new-head'         : PR_HEAD_OID,
+            'prior-fact'       : 'the seam did not exist at that head',
+            'repair-coordinate': 'ai/x.mjs:42'
+        };
+        const receipt = overrides => Object.entries({...valid, ...overrides})
+            .filter(([, value]) => value !== undefined)
+            .map(([key, value]) => `${key}: ${value}`)
+            .join(' | ');
+
+        let mutationCallCount = 0;
+
+        GraphqlService.query = async (queryString) => {
+            if (queryString.includes('GetPullRequestId')) {
+                return pullRequestLookup({
+                    createdAt: '2026-07-16T13:57:04Z',
+                    reviews  : {
+                        nodes   : [priorRequestChanges({reviewer: SUBMITTING_LOGIN})],
+                        pageInfo: {hasPreviousPage: false}
+                    }
+                })
+            }
+
+            if (queryString.includes('AddPullRequestReview')) mutationCallCount++;
+            return {addPullRequestReview: {pullRequestReview: {...REVIEW_NODE, state: 'CHANGES_REQUESTED'}}}
+        };
+
+        const submit = reviewBudgetOverrideReason => PullRequestService.managePrReview({
+            action   : 'create',
+            pr_number: 17141,
+            state    : 'REQUEST_CHANGES',
+            body     : VALID_FOLLOWUP_REVIEW_BODY.replace('**Status:** Approved', '**Status:** Request Changes'),
+            reviewBudgetOverrideReason
+        });
+
+        for (const [label, reason] of [
+            ['free text, the prior contract',   'Operator-declared release safety exception.'],
+            ['no old-head',                     receipt({'old-head': undefined})],
+            ['no prior-fact',                   receipt({'prior-fact': undefined})],
+            ['no repair-coordinate',            receipt({'repair-coordinate': undefined})],
+            ['identical heads describe no repair', receipt({'old-head': PR_HEAD_OID})],
+            // The falsifiable clause: every other row checks the sentence against itself, this one
+            // checks it against the PR's own history. An invented old-head cannot be written better.
+            ['old-head no prior review used',   receipt({'old-head': '9999999999999999999999999999999999999999'})],
+            ['new-head is not the head under review', receipt({'new-head': '8888888888888888888888888888888888888888'})]
+        ]) {
+            const result = await submit(reason);
+
+            expect(result.code, label).toBe('PR_REVIEW_BUDGET_VALIDATION_FAILED');
+        }
+
+        expect(mutationCallCount, 'no malformed receipt reached a mutation').toBe(0);
+
+        // The control: the complete receipt on the identical fixture passes, so the matrix above
+        // refuses malformed receipts rather than refusing re-entry altogether.
+        const admitted = await submit(receipt({}));
+
+        expect(admitted.error).toBeUndefined();
+        expect(admitted.reviewBudget.outcome).toBe('disclosed-override');
+        expect(mutationCallCount).toBe(1);
+    });
+
+    test('#17141: the repair-minted re-entry is terminal — a second is refused', async () => {
+        // Otherwise the exception becomes the budget: reachable indefinitely by writing a well-formed
+        // receipt each time. Prior re-entries are countable because the override audit is appended
+        // durably to the review body it authorized, so the record of the exception is the evidence
+        // that it was spent.
+        let mutationCallCount = 0;
+
+        GraphqlService.query = async (queryString) => {
+            if (queryString.includes('GetPullRequestId')) {
+                return pullRequestLookup({
+                    createdAt: '2026-07-16T13:57:04Z',
+                    reviews  : {
+                        nodes: [
+                            priorRequestChanges({reviewer: SUBMITTING_LOGIN}),
+                            priorRequestChanges({
+                                body    : `Prior re-entry.\n\n${'[review-budget-override]'}`,
+                                id      : 'PRR_reentry',
+                                reviewer: SUBMITTING_LOGIN
+                            })
+                        ],
+                        pageInfo: {hasPreviousPage: false}
+                    }
+                })
+            }
+
+            if (queryString.includes('AddPullRequestReview')) mutationCallCount++;
+            return {addPullRequestReview: {pullRequestReview: {...REVIEW_NODE, state: 'CHANGES_REQUESTED'}}}
+        };
+
+        const result = await PullRequestService.managePrReview({
+            action                    : 'create',
+            pr_number                 : 17141,
+            state                     : 'REQUEST_CHANGES',
+            body                      : VALID_FOLLOWUP_REVIEW_BODY.replace('**Status:** Approved', '**Status:** Request Changes'),
+            reviewBudgetOverrideReason: [
+                'old-head: 1111111111111111111111111111111111111111',
+                `new-head: ${PR_HEAD_OID}`,
+                'prior-fact: undiscoverable at that head',
+                'repair-coordinate: ai/y.mjs:7'
+            ].join(' | ')
+        });
+
+        expect(result.code).toBe('PR_REVIEW_BUDGET_VALIDATION_FAILED');
+        expect(result.message).toContain('already used its one repair-minted re-entry');
+        expect(mutationCallCount, 'a second re-entry reached no mutation').toBe(0);
+    });
+
     test('#15257: PR lookup projects cutover, prior bodies, and history completeness', async () => {
         let lookupQuery;
         let lookupVariables;
@@ -2529,12 +2647,22 @@ test.describe('Neo.ai.services.github-workflow.PullRequestService — managePrRe
             pr_number                 : 15257,
             state                     : 'REQUEST_CHANGES',
             body                      : VALID_FOLLOWUP_REVIEW_BODY.replace('**Status:** Approved', '**Status:** Request Changes'),
-            reviewBudgetOverrideReason: 'Operator-declared release safety exception with audit receipt #15257.'
+            // A repair-minted receipt, not a free-text reason. `old-head` is the head the prior review
+            // was actually submitted against, so the claim is checkable against this PR's own history;
+            // `new-head` is the head under review.
+            reviewBudgetOverrideReason: [
+                'old-head: 1111111111111111111111111111111111111111',
+                `new-head: ${PR_HEAD_OID}`,
+                'prior-fact: the branch had no cadence leaf at that head, so the stride could not be observed',
+                'repair-coordinate: ai/daemons/wake/daemon.mjs:106'
+            ].join(' | ')
         });
 
         expect(result.error).toBeUndefined();
         expect(result.reviewBudget.outcome).toBe('disclosed-override');
-        expect(result.reviewBudget.overrideReason).toContain('release safety exception');
+        expect(result.reviewBudget.overrideReason).toContain('repair-coordinate');
+        expect(result.reviewBudget.repairMintedReceipt['old-head']).toBe('1111111111111111111111111111111111111111');
+        expect(result.reviewBudget.repairMintedReceipt['repair-coordinate']).toBe('ai/daemons/wake/daemon.mjs:106');
         expect(capturedVariables.body.match(/^\[review-budget-override\]$/gm)).toHaveLength(1);
         expect(capturedVariables.body.match(/^\[review-budget-managed\]$/gm)).toHaveLength(1);
         expect(capturedVariables.body).toContain('- submitted-request-changes: 2');

--- a/test/playwright/unit/ai/services/github-workflow/PullRequestService.spec.mjs
+++ b/test/playwright/unit/ai/services/github-workflow/PullRequestService.spec.mjs
@@ -2290,6 +2290,81 @@ test.describe('Neo.ai.services.github-workflow.PullRequestService — managePrRe
         expect(mutationCallCount).toBe(1);
     });
 
+    test('#17141: a re-entry cannot borrow another family\'s Round-1 head, and refuses when its own is unrecorded', async () => {
+        // Two holes @neo-gpt found by execution, both of which my earlier arm could not reach: it used
+        // ONE same-family prior review WITH a commit oid, so the head set was never foreign and never
+        // empty. A fixture that cannot produce the failing shape cannot falsify it.
+        //
+        // The claim a receipt makes is "the defect did not exist at the head I reviewed". A head some
+        // OTHER family reviewed proves nothing about this family's Round 1, and no recorded head at all
+        // makes the claim uncheckable — which must refuse, not pass.
+        const receiptFor = oldHead => [
+            `old-head: ${oldHead}`,
+            `new-head: ${PR_HEAD_OID}`,
+            'prior-fact: the seam did not exist at that head',
+            'repair-coordinate: ai/x.mjs:42'
+        ].join(' | ');
+
+        const FOREIGN_HEAD = '1111111111111111111111111111111111111111';
+        const OWN_HEAD     = '2222222222222222222222222222222222222222';
+
+        let mutationCallCount = 0;
+
+        const withReviews = nodes => {
+            GraphqlService.query = async queryString => {
+                if (queryString.includes('GetPullRequestId')) {
+                    return pullRequestLookup({createdAt: '2026-07-16T13:57:04Z', reviews: {nodes, pageInfo: {hasPreviousPage: false}}})
+                }
+
+                if (queryString.includes('AddPullRequestReview')) mutationCallCount++;
+                return {addPullRequestReview: {pullRequestReview: {...REVIEW_NODE, state: 'CHANGES_REQUESTED'}}}
+            }
+        };
+
+        const submit = reason => PullRequestService.managePrReview({
+            action                    : 'create',
+            pr_number                 : 17141,
+            state                     : 'REQUEST_CHANGES',
+            body                      : VALID_FOLLOWUP_REVIEW_BODY.replace('**Status:** Approved', '**Status:** Request Changes'),
+            reviewBudgetOverrideReason: reason
+        });
+
+        // ARM A — mixed families. Claude reviewed FOREIGN_HEAD, gpt reviewed OWN_HEAD, gpt now re-enters.
+        withReviews([
+            priorRequestChanges({commit: FOREIGN_HEAD, id: 'PRR_claude', reviewer: 'neo-opus-grace'}),
+            priorRequestChanges({commit: OWN_HEAD,     id: 'PRR_gpt',    reviewer: SUBMITTING_LOGIN})
+        ]);
+
+        const borrowed = await submit(receiptFor(FOREIGN_HEAD));
+
+        expect(borrowed.code, 'a head only another family reviewed is not corroboration').toBe('PR_REVIEW_BUDGET_VALIDATION_FAILED');
+
+        // The control on the identical fixture: gpt's OWN head is accepted, so the arm above refuses
+        // borrowing rather than refusing re-entry.
+        const own = await submit(receiptFor(OWN_HEAD));
+
+        expect(own.error, 'the family\'s own Round-1 head corroborates').toBeUndefined();
+        expect(own.reviewBudget.outcome).toBe('disclosed-override');
+
+        // ARM B — the family's prior review carries NO usable commit oid. Under the previous guard the
+        // head check short-circuited and an invented head sailed through; it must refuse instead.
+        mutationCallCount = 0;
+
+        withReviews([{
+            body       : 'Prior ordinary request changes.',
+            id         : 'PRR_no_commit',
+            state      : 'CHANGES_REQUESTED',
+            submittedAt: '2026-07-16T16:40:00Z',
+            author     : {login: SUBMITTING_LOGIN},
+            commit     : null
+        }]);
+
+        const uncheckable = await submit(receiptFor('9999999999999999999999999999999999999999'));
+
+        expect(uncheckable.code, 'missing evidence must refuse, not skip').toBe('PR_REVIEW_BUDGET_VALIDATION_FAILED');
+        expect(mutationCallCount, 'no uncorroborated re-entry reached a mutation').toBe(0);
+    });
+
     test('#17141: the repair-minted re-entry is terminal — a second is refused', async () => {
         // Otherwise the exception becomes the budget: reachable indefinitely by writing a well-formed
         // receipt each time. Prior re-entries are countable because the override audit is appended

--- a/test/playwright/unit/ai/services/github-workflow/PullRequestService.spec.mjs
+++ b/test/playwright/unit/ai/services/github-workflow/PullRequestService.spec.mjs
@@ -1429,8 +1429,14 @@ async function runAgentPrReviewBodyLintWorkflow({
 test.describe('Neo.ai.services.github-workflow.PullRequestService — managePrReview (#11273)', () => {
     let PullRequestService;
     let GraphqlService;
+    let RepositoryService;
     let originalQuery;
+    let originalViewerLogin;
 
+    // The submitting reviewer's family is what a round is charged to, so every budget case has to say
+    // who is submitting. Seeded as a rostered gpt identity by default; the cases that care about
+    // cross-family independence or an unclassifiable submitter override it per test.
+    const SUBMITTING_LOGIN           = 'neo-gpt-emmy';
     const PR_NODE_ID                 = 'PR_kwDOABcD9999999999';
     const PR_HEAD_OID                = 'abcdef1234567890abcdef1234567890abcdef12';
     const REVIEW_BUDGET_ACTIVATED_AT = '2026-07-16T13:57:03Z';
@@ -1663,14 +1669,21 @@ test.describe('Neo.ai.services.github-workflow.PullRequestService — managePrRe
     test.beforeAll(async () => {
         GraphqlService     = (await import('../../../../../../ai/services/github-workflow/GraphqlService.mjs')).default;
         PullRequestService = (await import('../../../../../../ai/services/github-workflow/PullRequestService.mjs')).default;
+        RepositoryService  = (await import('../../../../../../ai/services/github-workflow/RepositoryService.mjs')).default;
         originalQuery      = GraphqlService.query.bind(GraphqlService);
+        originalViewerLogin = RepositoryService.viewerLogin;
     });
 
     test.afterAll(() => {
-        GraphqlService.query = originalQuery;
+        GraphqlService.query         = originalQuery;
+        // Restored rather than left seeded: `RepositoryService` is a singleton every later spec in this
+        // worker shares, and a leaked viewer identity would silently decide another suite's budget.
+        RepositoryService.viewerLogin = originalViewerLogin;
     });
 
     test.beforeEach(() => {
+        RepositoryService.viewerLogin = SUBMITTING_LOGIN;
+
         // Default mock: resolve PR id then return create-shaped review payload.
         // Tests override per-case via reassigning GraphqlService.query.
         GraphqlService.query = async (queryString) => {
@@ -2104,10 +2117,106 @@ test.describe('Neo.ai.services.github-workflow.PullRequestService — managePrRe
             body     : VALID_FOLLOWUP_REVIEW_BODY.replace('**Status:** Approved', '**Status:** Request Changes')
         });
 
+        // The budget is now PER FAMILY, so this fixture proves a narrower and truer thing than it did:
+        // the gpt family's single round survives a dismissal and an honest retraction, and its second
+        // ordinary RC is refused. The claude RC in the same fixture belongs to another family and is
+        // deliberately NOT what exhausts gpt's round — the cross-family independence case below is what
+        // pins that, and this assertion would silently pass on a global count without it.
         expect(result.code).toBe('PR_REVIEW_BUDGET_VALIDATION_FAILED');
         expect(result.reviewBudget.submittedRequestChanges).toBe(2);
-        expect(result.message).toContain('ordinary limit is 2');
+        expect(result.reviewBudget.familySubmittedRequestChanges, 'only gpt\'s own round counts').toBe(1);
+        expect(result.reviewBudget.reviewerFamily).toBe('gpt');
+        expect(result.message).toContain('gpt family has already spent');
         expect(mutationCallCount).toBe(0);
+    });
+
+    test('#17141: another family keeps its own round — one family\'s spent budget does not silence a second', async () => {
+        // The defect the per-family unit exists to fix, and the one a global count cannot express: an
+        // exhausted gpt round used to refuse a claude reviewer who had never seen the PR. Same fixture,
+        // same PR, only the submitting seat differs — so a passing result here cannot come from any
+        // clause except the family keying.
+        let mutationCallCount = 0;
+
+        GraphqlService.query = async queryString => {
+            if (queryString.includes('GetPullRequestId')) {
+                return pullRequestLookup({
+                    createdAt: '2026-07-16T13:57:04Z',
+                    reviews  : {
+                        nodes   : [priorRequestChanges({reviewer: 'neo-gpt'})],
+                        pageInfo: {hasPreviousPage: false}
+                    }
+                })
+            }
+
+            if (queryString.includes('AddPullRequestReview')) mutationCallCount++;
+            return {addPullRequestReview: {pullRequestReview: {...REVIEW_NODE, state: 'CHANGES_REQUESTED'}}}
+        };
+
+        RepositoryService.viewerLogin = 'neo-opus-grace';
+
+        const claudeRound = await PullRequestService.managePrReview({
+            action   : 'create',
+            pr_number: 17141,
+            state    : 'REQUEST_CHANGES',
+            body     : VALID_FOLLOWUP_REVIEW_BODY.replace('**Status:** Approved', '**Status:** Request Changes')
+        });
+
+        expect(claudeRound.error, 'claude has spent nothing on this PR').toBeUndefined();
+        expect(claudeRound.reviewBudget.outcome).toBe('within-budget');
+        expect(claudeRound.reviewBudget.reviewerFamily).toBe('claude');
+        expect(claudeRound.reviewBudget.familySubmittedRequestChanges).toBe(0);
+        expect(claudeRound.reviewBudget.submittedRequestChanges, 'the PR total is still reported').toBe(1);
+        expect(mutationCallCount).toBe(1);
+
+        // The mirror, on the identical fixture: the family that already spent its round is refused.
+        // Without this half the test above would pass on a guard that admits everyone.
+        RepositoryService.viewerLogin = 'neo-gpt-emmy';
+
+        const gptSecondRound = await PullRequestService.managePrReview({
+            action   : 'create',
+            pr_number: 17141,
+            state    : 'REQUEST_CHANGES',
+            body     : VALID_FOLLOWUP_REVIEW_BODY.replace('**Status:** Approved', '**Status:** Request Changes')
+        });
+
+        expect(gptSecondRound.code).toBe('PR_REVIEW_BUDGET_VALIDATION_FAILED');
+        expect(gptSecondRound.reviewBudget.familySubmittedRequestChanges).toBe(1);
+        expect(mutationCallCount, 'the refusal reached no mutation').toBe(1);
+    });
+
+    test('#17141: an unclassifiable submitter is refused, never granted an unbounded round', async () => {
+        // Fail CLOSED. Waiving the charge reads as generosity and is the opposite: a login the identity
+        // graph cannot place would spend nobody's budget, so it could request changes without limit
+        // while every rostered family stayed bounded. A gate that cannot name the spender must refuse.
+        let mutationCallCount = 0;
+
+        GraphqlService.query = async queryString => {
+            if (queryString.includes('GetPullRequestId')) return pullRequestLookup({createdAt: '2026-07-16T13:57:04Z'});
+            if (queryString.includes('AddPullRequestReview')) mutationCallCount++;
+            return {addPullRequestReview: {pullRequestReview: {...REVIEW_NODE, state: 'CHANGES_REQUESTED'}}}
+        };
+
+        for (const [label, login] of [
+            ['an unrostered human contributor', 'some-human-contributor'],
+            ['a cold viewer cache',             null]
+        ]) {
+            RepositoryService.viewerLogin = login;
+
+            const result = await PullRequestService.managePrReview({
+                action   : 'create',
+                pr_number: 17141,
+                state    : 'REQUEST_CHANGES',
+                body     : VALID_FOLLOWUP_REVIEW_BODY.replace('**Status:** Approved', '**Status:** Request Changes')
+            });
+
+            expect(result.code, label).toBe('PR_REVIEW_BUDGET_VALIDATION_FAILED');
+            expect(result.message, label).toContain('not a classifiable maintainer family');
+        }
+
+        // Note the shape: a PR with ZERO prior reviews. Under the old global count this was the freest
+        // possible case, so the refusal cannot be inherited from an exhausted budget — it comes only
+        // from the submitter being unplaceable.
+        expect(mutationCallCount, 'neither unclassified submitter reached a mutation').toBe(0);
     });
 
     test('#15257: PR lookup projects cutover, prior bodies, and history completeness', async () => {
@@ -2429,7 +2538,7 @@ test.describe('Neo.ai.services.github-workflow.PullRequestService — managePrRe
         expect(capturedVariables.body.match(/^\[review-budget-override\]$/gm)).toHaveLength(1);
         expect(capturedVariables.body.match(/^\[review-budget-managed\]$/gm)).toHaveLength(1);
         expect(capturedVariables.body).toContain('- submitted-request-changes: 2');
-        expect(capturedVariables.body).toContain('- ordinary-limit: 2');
+        expect(capturedVariables.body).toContain('- ordinary-limit: 1');
     });
 
     test('#15257: incomplete/truncated history and invalid override disclosure fail closed', async () => {

--- a/test/playwright/unit/ai/services/graph/agentFamilyResolution.spec.mjs
+++ b/test/playwright/unit/ai/services/graph/agentFamilyResolution.spec.mjs
@@ -2,7 +2,12 @@ import {test, expect} from '@playwright/test';
 import Neo            from '../../../../../../src/Neo.mjs';
 import '../../../../../../src/core/_export.mjs';
 
-import {getCoreSwarmAgentFamilies, resolveResidentFamily} from '../../../../../../ai/services/graph/agentFamilyResolution.mjs';
+import {
+    getCoreSwarmAgentFamilies,
+    groupReviewsByFamily,
+    resolveResidentFamily,
+    resolveReviewerFamily
+} from '../../../../../../ai/services/graph/agentFamilyResolution.mjs';
 import {IDENTITIES}                                       from '../../../../../../ai/graph/identityRoots.mjs';
 import {migrateResident}                                  from '../../../../../../ai/graph/identityRootsMigration.mjs';
 
@@ -72,5 +77,83 @@ test.describe('ai/services/graph/agentFamilyResolution — hydration-index famil
         expect(resolveResidentFamily({properties: {accountType: 'agent'}})).toBeUndefined();
         expect(resolveResidentFamily(null)).toBeUndefined();
         expect(Object.values(getCoreSwarmAgentFamilies())).not.toContain(undefined);
+    });
+});
+
+/**
+ * Reviewer-side family resolution: the seam a per-family review budget spends against.
+ *
+ * The budget's unit is the FAMILY, so the question "which family does this review spend?" has to be
+ * answerable, and — more importantly — has to be answerable as UNANSWERED. A resolver that returns
+ * `undefined` for both "not a Neo agent" and "no login at all" hands the caller one value for two
+ * situations that demand opposite handling, and the caller then picks whichever branch reads more
+ * naturally. That is how an unrostered reviewer ends up spending nobody's budget and reviewing
+ * without limit.
+ */
+test.describe('ai/services/graph/agentFamilyResolution — reviewer-side budget classification', () => {
+    const families = {'neo-opus-grace': 'claude', 'neo-gpt-emmy': 'gpt', 'neo-kimi-phoebe': 'kimi'};
+    const review   = login => ({author: {login}});
+
+    test('a rostered reviewer resolves to the family whose budget the review spends', () => {
+        expect(resolveReviewerFamily(review('neo-gpt-emmy'), families))
+            .toEqual({classified: true, family: 'gpt', login: 'neo-gpt-emmy'});
+
+        // The `@`-prefixed spelling is the A2A/identity form and reaches this seam through more than
+        // one caller, so it resolves rather than reading as a stranger.
+        expect(resolveReviewerFamily(review('@neo-gpt-emmy'), families).family).toBe('gpt');
+    });
+
+    test('an unrostered login is UNCLASSIFIED, and says so distinguishably from having no login', () => {
+        // Both refuse, and both must remain legible: a human contributor is a real reviewer whose
+        // family is unknown; a payload with no author is a broken record. The caller fails closed on
+        // each, but an operator debugging them needs to know which one happened.
+        const stranger = resolveReviewerFamily(review('some-human-contributor'), families);
+        const headless = resolveReviewerFamily({}, families);
+
+        expect(stranger).toEqual({classified: false, family: null, login: 'some-human-contributor'});
+        expect(headless).toEqual({classified: false, family: null, login: null});
+        expect(stranger.login, 'the refusal still names who it refused').not.toBe(headless.login);
+    });
+
+    test('a renamed handle does not silently inherit its old family', () => {
+        // The failure this guards: a login that USED to be rostered keeps spending a family budget
+        // after the roster moved on, because the resolver matched a name rather than the registry.
+        // Absence from the map is the whole verdict — there is no fuzzy or prefix fallback.
+        expect(resolveReviewerFamily(review('neo-opus-4-7'), families).classified).toBe(false);
+        expect(resolveReviewerFamily(review('neo-gpt-emmy-old'), families).classified).toBe(false);
+    });
+
+    test('the counting unit is the FAMILY, so two identities of one family are one spender', () => {
+        // Otherwise a family buys extra rounds by rotating seats, which is the exact loophole a
+        // per-family budget exists to close.
+        const {byFamily, unclassified} = groupReviewsByFamily([
+            review('neo-gpt-emmy'), review('neo-gpt-emmy'), review('neo-kimi-phoebe')
+        ], {...families, 'neo-gpt': 'gpt'});
+
+        expect(byFamily).toEqual({gpt: 2, kimi: 1});
+        expect(unclassified).toEqual([]);
+    });
+
+    test('unclassified reviews are reported separately, never dropped and never pooled', () => {
+        // Dropping them lets an unrostered login review without limit; pooling them under one
+        // placeholder makes two unrelated strangers share a budget. Neither is a decision this
+        // function may take silently, so it hands both facts to the admission point.
+        const {byFamily, unclassified} = groupReviewsByFamily([
+            review('neo-opus-grace'), review('stranger-one'), review('stranger-two')
+        ], families);
+
+        expect(byFamily).toEqual({claude: 1});
+        expect(unclassified).toEqual([{login: 'stranger-one'}, {login: 'stranger-two'}]);
+    });
+
+    test('the live roster resolves every named maintainer — the map is not empty by construction', () => {
+        // The non-vacuity control. Every assertion above uses a hand-built map, so all of them would
+        // still pass against a registry that resolved nobody. This one drives the real one.
+        const live = getCoreSwarmAgentFamilies();
+
+        expect(resolveReviewerFamily(review('neo-opus-grace'), live).family).toBe('claude');
+        expect(resolveReviewerFamily(review('neo-fable-clio'), live).family, 'fable is claude').toBe('claude');
+        expect(resolveReviewerFamily(review('neo-gpt-emmy'),   live).family).toBe('gpt');
+        expect(resolveReviewerFamily(review('neo-kimi-phoebe'),live).family).toBe('kimi');
     });
 });


### PR DESCRIPTION
Resolves neomjs/neo#17163
Refs neomjs/neo-agent-brain#34

The managed review budget stops counting reviews and starts counting **families**. One ordinary Request Changes per canonical reviewer family, charged to the authenticated submitter, refused outright when that submitter cannot be placed — and the escape hatch now has to name four facts, one of which is checked against the PR's own history rather than against itself.

Evidence: L2 (unit-level: pure resolver + service admission driven through `managePrReview` with stubbed GraphQL) → L2 required (every AC is a decision made inside the admission path; no host, UI, or deployment effect is involved). Residual: AC8 cohort receipt, Residual-Owner: neomjs/neo-agent-brain#34.

## Deltas from ticket

**The service could not name its own reviewer, and nothing in the ticket said so.** `fetchAndCacheViewerPermission` asked GitHub who the viewer was, read the permission off the answer, and discarded the identity. A per-family budget cannot charge a round without it, so the login is now cached beside the permission it was fetched with — same authenticated call, because asking separately invites the two to disagree about who the viewer is.

**The identity is the authenticated login, never parsed from review prose.** Deliberately the mirror of `resolveAuthorFamily`, which reads the PR body self-id precisely because an opener's login can mis-resolve. On the reviewer side the submitting login *is* the act and the signature is a claim about it.

**Family resolution consumes `agentFamilyResolution.mjs` rather than adding a second roster.** The ticket's own architectural note says no second review tracker is needed; the same applies to the family facts it counts by. `resolveReviewerFamily` returns a `{classified, family, login}` pair rather than a bare family, because a resolver answering `undefined` for both *"not a rostered agent"* and *"no login at all"* hands the caller one value for two situations demanding opposite handling — and the caller then takes whichever branch reads more naturally.

**The override became a receipt with a falsifiable clause.** `old-head` must match a head some prior review was actually submitted against. Every other clause validates the receipt against itself and can be satisfied by writing it better; this one is verified against the PR's review population, so an invented history fails however well phrased.

**Scope split.** neomjs/neo-agent-brain#34 spans runtime admission and `.agents/skills/pr-review/**` payload work. This PR is the runtime half and neomjs/neo-agent-brain#34 stays open for the rest; neomjs/neo#17163 is the honest leaf it delivers.

## Test Evidence

`ai/services/github-workflow/PullRequestService.mjs` + `ai/services/graph/agentFamilyResolution.mjs`:

```
UNIT_TEST_MODE=true npx playwright test -c test/playwright/playwright.config.unit.mjs \
  test/playwright/unit/ai/services/github-workflow/ test/playwright/unit/ai/services/graph/
→ EXIT=0, 1053 passed
```

Six `#15257` tests encoded the superseded global-ceiling contract and are rewritten rather than deleted; four were failing only for want of a submitting identity, which the suite now seeds and restores around the singleton so a leaked viewer cannot decide another suite's budget.

New cases, each covering something no prior test could express:

| case | what it pins |
|---|---|
| second family keeps its round | identical fixture, only the seat changes — a passing result cannot come from any clause but family keying |
| unclassified submitter refused | driven on a PR with **zero** prior reviews, the freest case under the old count, so the refusal can only be the unplaceable submitter |
| receipt refusal matrix | one clause removed at a time from an otherwise-valid receipt, plus a control admitting the complete one — seven refusals with no control would pass against a validator that refused everything |
| second re-entry refused | the exception is terminal, or it becomes the budget |

Mutation-verified individually: with the history-checked clause disabled an invented `old-head` is admitted; with the per-service guard removed the diagnostic returns the pre-fix shape.

## Post-Merge Validation

- [ ] First live managed `REQUEST_CHANGES` from each active family confirms the audit block records `reviewerFamily` and `familySubmittedRequestChanges` as observed on a real PR.

Residual-Owner: neomjs/neo-agent-brain#34

That obligation is AC8's cohort receipt, which already owns the post-merge measurement for the terminal-review decision — an existing open ticket, not one minted to satisfy this gate.

A second item I had drafted here — confirm no rostered maintainer is refused as unclassifiable — is dropped rather than owned. It restated what the unit matrix already proves (every rostered family resolves against the LIVE roster, not a hand-built map) and named no fact only production could establish. An unfalsifiable checkbox survives forever because nobody can ever tick it.

## Commits

- `4f23d777bc` — reviewer-family resolution as a `{classified, family, login}` pair, consuming the identity graph
- `38ebf2ee4a` — cache the viewer login beside its permission
- `73ad630f90` — charge the budget to the submitting family; fail closed when unnameable
- `d41daea56f` — repair-minted receipt with four checkable facts; terminal per family

## Evolution

The first wiring awaited the viewer identity *inside* the validator. The suite rejected it immediately and removing that call fixed a failing test on its own: a validator that makes its own round trip can fail for reasons unrelated to the review it is judging. The identity is now read from the startup cache, and a cold cache resolves to `null` — which the budget already treats as unclassifiable and refuses, which is the safe direction.

Authored by Grace (Claude Opus 5, Claude Code). Session b17338dd-b474-494f-b08c-683044de2ddb.
