### PR TITLE
fix(build): an intake credential fault no longer freezes corpus publication (#17162)

### DIFF
--- a/.github/workflows/data-sync-pipeline.yml
+++ b/.github/workflows/data-sync-pipeline.yml
@@ -80,8 +80,29 @@ jobs:
           permission-contents: write
 
       # Installed on the DevIndex repos, not this one, so the installation must be named explicitly.
+      #
+      # NON-FATAL, unlike the Publisher mint above. This step ran before checkout, before Node and
+      # before emission, with nothing tolerating its failure — so any intake credential fault killed
+      # the job before a single corpus byte existed. That is the #17148 blast radius one layer up:
+      # the corpus is emitted under the READER identity and does not consume this token at all, yet
+      # an ENRICHMENT credential decided whether the whole repository published.
+      #
+      # `create-github-app-token` fails outright when asked for a permission the installation lacks,
+      # so the realistic triggers are ordinary administration: a revoked permission, a rotated key,
+      # an installation removed from one repository. #17150 adds a `contents` grant to this step,
+      # which widens that surface further — the workflow line and the App grant become a pair that
+      # must move together, and this guard is what keeps a drift between them from freezing the
+      # corpus rather than merely disabling intake.
+      #
+      # Degrading here needs no new error path. A failed mint leaves `outputs.token` empty, the empty
+      # `DATA_SYNC_INTAKE_TOKEN` reaches `assertDataSyncAccess`, which throws "No intake token was
+      # provided", and `emitGeneratedData` already DEFERS a preflight failure: every stage still runs,
+      # the corpus publishes, and the deferred error is rethrown so the run still exits non-zero. The
+      # failure moves later; it does not disappear. A silently green run over a dead intake would be
+      # strictly worse than the freeze this replaces.
       - name: Mint Intake installation token
         id: intake-token
+        continue-on-error: true
         uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ secrets.DATA_SYNC_INTAKE_APP_ID }}

--- a/.github/workflows/data-sync-pipeline.yml
+++ b/.github/workflows/data-sync-pipeline.yml
@@ -87,23 +87,23 @@ jobs:
       # the corpus is emitted under the READER identity and does not consume this token at all, yet
       # an ENRICHMENT credential decided whether the whole repository published.
       #
-      # The realistic triggers are ordinary administration: a rotated or expired private key, or an
-      # installation removed from a repository this step names. Both fail the mint for real.
+      # `create-github-app-token` fails the step when the credential cannot serve the request —
+      # measured both ways, and BOTH are real triggers:
       #
-      # NOT a trigger, contrary to an earlier revision of this comment: requesting a permission the
-      # installation lacks. Measured (run 31877595849) — the step was asked for
-      # `permission-deployments: write`, which this installation does not hold, and it SUCCEEDED.
-      # The action does not validate requested permissions against the installation, so a permission
-      # revoked on the App degrades the CAPABILITY (and #17148's deferral absorbs that) rather than
-      # killing the mint. Worth stating because the inverse belief makes a mint success look like
-      # proof the token carries what was asked for, and it is not.
+      #   permission not granted to the installation -> "The permissions requested are not granted
+      #     to this installation."                                          (run 31877595849)
+      #   named repository has no installation       -> "Not Found"         (run 31879164402)
       #
-      # Degrading here needs no new error path. A failed mint leaves `outputs.token` empty, the empty
-      # `DATA_SYNC_INTAKE_TOKEN` reaches `assertDataSyncAccess`, which throws "No intake token was
-      # provided", and `emitGeneratedData` already DEFERS a preflight failure: every stage still runs,
-      # the corpus publishes, and the deferred error is rethrown so the run still exits non-zero. The
-      # failure moves later; it does not disappear. A silently green run over a dead intake would be
-      # strictly worse than the freeze this replaces.
+      # plus a rotated or expired private key, untestable here. So an ordinary administration action
+      # on `neomjs-devindex-intake` can fail this mint, and #17150 adds a `contents` grant that
+      # widens that surface — workflow line and App grant become a pair that must move together.
+      #
+      # READ THE LOG, NOT THE STEP STATUS, when checking whether this mint worked. `continue-on-error`
+      # sets `conclusion: success` on a FAILED step (`outcome` keeps the failure), so once this guard
+      # is in place a failed mint renders green in `gh run view --json jobs`. That is the guard
+      # working, not the mint succeeding — and reading the status instead of the log is how an earlier
+      # revision of this comment came to assert, wrongly, that the mint cannot fail at all.
+
       - name: Mint Intake installation token
         id: intake-token
         continue-on-error: true

--- a/.github/workflows/data-sync-pipeline.yml
+++ b/.github/workflows/data-sync-pipeline.yml
@@ -87,12 +87,16 @@ jobs:
       # the corpus is emitted under the READER identity and does not consume this token at all, yet
       # an ENRICHMENT credential decided whether the whole repository published.
       #
-      # `create-github-app-token` fails outright when asked for a permission the installation lacks,
-      # so the realistic triggers are ordinary administration: a revoked permission, a rotated key,
-      # an installation removed from one repository. #17150 adds a `contents` grant to this step,
-      # which widens that surface further — the workflow line and the App grant become a pair that
-      # must move together, and this guard is what keeps a drift between them from freezing the
-      # corpus rather than merely disabling intake.
+      # The realistic triggers are ordinary administration: a rotated or expired private key, or an
+      # installation removed from a repository this step names. Both fail the mint for real.
+      #
+      # NOT a trigger, contrary to an earlier revision of this comment: requesting a permission the
+      # installation lacks. Measured (run 31877595849) — the step was asked for
+      # `permission-deployments: write`, which this installation does not hold, and it SUCCEEDED.
+      # The action does not validate requested permissions against the installation, so a permission
+      # revoked on the App degrades the CAPABILITY (and #17148's deferral absorbs that) rather than
+      # killing the mint. Worth stating because the inverse belief makes a mint success look like
+      # proof the token carries what was asked for, and it is not.
       #
       # Degrading here needs no new error path. A failed mint leaves `outputs.token` empty, the empty
       # `DATA_SYNC_INTAKE_TOKEN` reaches `assertDataSyncAccess`, which throws "No intake token was

--- a/test/playwright/unit/ai/buildScripts/DataSyncPipeline.spec.mjs
+++ b/test/playwright/unit/ai/buildScripts/DataSyncPipeline.spec.mjs
@@ -781,6 +781,32 @@ test.describe('an intake denial cannot freeze corpus publication (#17148)', () =
         expect(aggregateDeferredFailures([failures[0]])).toBe(failures[0])
     });
 
+    test('an ABSENT intake token degrades exactly like a denied one (#17162)', async () => {
+        // The runtime contract the workflow's `continue-on-error` on the intake mint depends on. A
+        // failed mint leaves the token empty rather than wrong, which reaches `assertDataSyncAccess`
+        // as "No intake token was provided" — a different message on the same deferral path. Pinning
+        // it here because the workflow change is otherwise trusting an unasserted code path: if this
+        // ever threw instead of deferring, a credential fault would resume killing publication and
+        // the workflow guard would look like it was working.
+        const
+            absent   = new Error('[DataSync preflight] No intake token was provided.'),
+            executed = [];
+
+        const {deferredError} = await emitGeneratedData({
+            attempt  : 1,
+            cwd      : '/tmp',
+            execute  : async (_command, args) => {executed.push(args.join(' '))},
+            log      : () => {},
+            preflight: async () => {throw absent}
+        });
+
+        expect(deferredError).toBe(absent);
+        // The corpus stages are reader-scoped and never consumed the intake token, so they must be
+        // wholly unaffected by its absence — that is the entire point of moving the failure later.
+        expect(executed.some(args => args.includes('--emit-only'))).toBe(true);
+        expect(executed.some(args => args.includes('--include-labels'))).toBe(true)
+    });
+
     test('a preflight denial defers and does NOT abort the run', async () => {
         const
             denial   = new Error('[DataSync preflight] neomjs/devindex-opt-in DENIED (OptIn stargazer read)'),


### PR DESCRIPTION
Resolves #17162

Branched off `dev`, **not** stacked on #17160 — the stacked-ticket lint correctly refuses a branch whose commits claim a ticket the PR does not declare. The two touch the same mint step, so whichever merges second takes a small conflict; this one is one line plus a comment, so it is the cheaper rebase.

## The gap

`#17148` established the principle for this pipeline: an optional DevIndex intake failure must not decide whether the corpus publishes. It fixed that at the **stage** level. The same defect sits one layer up at the **step** level, and it is now the larger exposure.

| line | step |
|---|---|
| 69 | Mint Publisher installation token |
| ~102 | **Mint Intake installation token** ← no guard |
| ~125 | Checkout repository |
| ~164 | Setup Node.js |
| ~176 | Run bounded Data Sync emission and publish |

The intake mint had no `continue-on-error` and runs *before checkout, Node and emission*, so any intake credential fault killed the job **before a single corpus byte existed**. The corpus is emitted under the `reader` identity and never consumes the intake token — an *enrichment* credential was deciding whether the whole repository published.

> **⚠ PREMISE ROUND-TRIP, RESOLVED — the premise above stands as filed.** After opening I claimed two fault injections could not make the mint fail, and re-scoped this PR as thin on that basis. **Both claims were wrong.** Both probes *did* fail the mint: [31877595849](https://github.com/neomjs/neo/actions/runs/31877595849) → HTTP 422 *"The permissions requested are not granted to this installation"*; [31879164402](https://github.com/neomjs/neo/actions/runs/31879164402) → 404 *Not Found*. I had read `conclusion` from the jobs API — the field **this PR's own `continue-on-error` guard rewrites to `success` on a failed step**. The guard masked the failures that justify it, and I read that masking as evidence the guard was unnecessary. @neo-gpt falsified it. The re-scoping is withdrawn: this PR is better evidenced than at opening.

So a permission cleanup on `neomjs-devindex-intake` **does** fail the mint — HTTP 422, *"The permissions requested are not granted to this installation"* ([run 31877595849](https://github.com/neomjs/neo/actions/runs/31877595849)) — and a removed installation fails it with 404 ([run 31879164402](https://github.com/neomjs/neo/actions/runs/31879164402)). `#17160` adds `permission-contents: write`, so workflow line and App grant are a coupled pair whose drift takes the mint down, not merely the stargazer read. A rotated or expired private key is a third trigger, untested. **All three are exactly what this guard exists for**, and 31879164402 is the live L4 proof it works: mint failed, job continued through checkout and Node to the preflight.

## Why one line is the whole fix

`continue-on-error: true` needs no new error path behind it, because `#17148` already built the landing zone:

1. failed mint ⇒ `steps.intake-token.outputs.token` is empty
2. empty `DATA_SYNC_INTAKE_TOKEN` ⇒ `assertDataSyncAccess` throws *"No intake token was provided"*
3. `emitGeneratedData` **defers** a preflight failure ⇒ every stage runs, corpus publishes
4. the deferred error is rethrown ⇒ **run still exits non-zero**

The failure moves later; it does not disappear. That fourth step is the load-bearing one — without it this would trade a loud freeze for indefinitely green runs over a dead intake, which is strictly worse. The Publisher mint stays fatal: it is the publish credential, and without it there is nothing to salvage.

## Deltas

- `.github/workflows/data-sync-pipeline.yml` — `continue-on-error: true` on the intake mint, with the rationale and the asymmetry against the Publisher recorded inline.
- `test/playwright/unit/ai/buildScripts/DataSyncPipeline.spec.mjs` — one test pinning the runtime half.

## Rejected

- **Marking the step non-fatal and stopping there.** Without the preserved non-zero exit, a revoked intake permission yields green runs forever over a dead intake. The point is to move the failure, not remove it.
- **Guarding the Publisher mint too.** It is the credential that performs the publish; degrading past it would produce a run that cannot do the one thing it exists for.
- **Handling the empty token explicitly in `dataSyncPipeline.mjs`.** `assertDataSyncAccess` already rejects a falsy token with a specific message, and `#17148`'s deferral already carries it. A second path would be a second thing to keep in sync.

Evidence: L2 (unit, complete) + L4 (a live dispatch that fails the mint for real — dispatched, still queued at time of opening) → L4 is the class the workflow half needs and no unit test can reach. Residual: the L4 observation itself, posted as a comment when the run lands; do not merge on the L2 half alone.

## Test Evidence

```
npx playwright test -c test/playwright/playwright.config.unit.mjs \
  test/playwright/unit/ai/buildScripts/DataSyncPipeline.spec.mjs
  45 passed (3.6s)
```

New test: `an ABSENT intake token degrades exactly like a denied one (#17162)` — asserts the absent-token error is *deferred* rather than thrown, and that both reader-scoped stages (`--emit-only`, `--include-labels`) still execute. It exists because the workflow change otherwise trusts an unasserted path: if that case ever threw instead of deferring, a credential fault would resume killing publication while the workflow guard still looked correct.

**Live falsifier — IN FLIGHT at time of opening, result to be posted as a comment either way.** It is queued behind the first post-#17149 scheduled run (shared `concurrency: data-sync-pipeline`), so do not read this section as a completed observation yet.

**The mint made to fail for real, not simulated.** A throwaway branch requested `permission-deployments: write`, which `neomjs-devindex-intake` does not hold, so `create-github-app-token` fails the step genuinely: [run 31877595849](https://github.com/neomjs/neo/actions/runs/31877595849). The observable claim is that the job proceeds *past* the failed mint to checkout, Node and preflight, rather than dying at the mint. (A `preflight_only` dispatch then correctly aborts at the preflight, which is that mode's contract — it is asserting the credential topology, and the topology is genuinely broken. The point being proved here is reaching the preflight at all.)

An accidental first attempt put the bad permission on the **Publisher** mint instead ([run 31877572286](https://github.com/neomjs/neo/actions/runs/31877572286), superseded/cancelled) — recording it because it is the control this PR's asymmetry claims: the Publisher mint has no guard and must stay fatal.

## Post-Merge Validation

Observable only on a scheduled `dev` run. Owned by the standing alarm rather than this PR's close target, which will be closed:

Residual-Owner: #17131

- [ ] A scheduled run whose intake mint fails still produces a `chore(data): Hourly data sync pipeline update [skip ci]` commit.
- [ ] That run still exits non-zero and names the absent intake credential.
- [ ] Normal runs are unchanged: the mint succeeds and no `continue-on-error` annotation appears.

---

⚖️ **Ada** · `@neo-opus-ada` · Claude Opus 5 · Claude Code

<!-- Authored by @neo-opus-ada (Ada) -->






