### PR TITLE
fix(ai): comment_id accepts the spelling a peer actually holds, and a scoped fetch stops paying for the thread head (#17142)

### DIFF
--- a/ai/mcp/server/github-workflow/openapi.yaml
+++ b/ai/mcp/server/github-workflow/openapi.yaml
@@ -399,7 +399,9 @@ paths:
         Use this tool to get the context of a pull request or issue — the initial proposal/body and the discussion history.
 
         **Comment selectors (optional, first-match precedence):**
-        - `comment_id`: fetch ONLY the comment whose GitHub node ID matches. Used for A2A
+        - `comment_id`: fetch ONLY the matching comment. Accepts the node ID (`IC_kwDO…`), the
+          numeric database id (`5301580683`), a URL anchor (`issuecomment-5301580683`), or a full
+          comment URL — an unrecognised shape ERRORS rather than returning an empty list. Used for A2A
           hand-off — a reviewer mailboxes the `commentId` (returned by `manage_issue_comment`
           action:`create`) to the peer, and the peer fetches just-this-comment rather than
           re-walking the whole thread. Scales linearly with new-comment volume.
@@ -431,12 +433,19 @@ paths:
                   description: Response projection. `merge-readiness` requires `pr_number`, is identity-bound, and cannot be combined with comment selectors.
                 comment_id:
                   type: string
-                  description: Return only the comment whose GitHub global node ID matches. Elides all other comments; PR title/body are still returned.
-                  example: "IC_kwDOABcD1234567890"
+                  description: >-
+                    Return only the matching comment. Accepts a node ID, the numeric database id, a
+                    `issuecomment-N` URL anchor, or a full comment URL. An unrecognised shape returns
+                    a MALFORMED_COMMENT_ID error; a well-formed id absent from the thread returns an
+                    empty comments list. Scoped requests omit the parent body (`bodyOmitted: true`).
+                  example: "issuecomment-5301580683"
                 since_comment_id:
                   type: string
-                  description: Return only comments AFTER the one with this ID (exclusive). If the ID isn't found, returns empty comments.
-                  example: "IC_kwDOABcD1234567890"
+                  description: >-
+                    Return only comments AFTER the one with this ID (exclusive). Accepts the same
+                    four spellings as `comment_id`. Unrecognised shape errors; a well-formed but
+                    absent id returns empty comments. Scoped requests omit the parent body.
+                  example: "issuecomment-5301580683"
                 last_n:
                   type: integer
                   description: Return only the last N comments (by creation order).
@@ -1504,7 +1513,9 @@ paths:
         a delta after a known comment, or a small tail of recent comments is needed.
 
         **Comment selectors (optional, first-match precedence):**
-        - `comment_id`: fetch ONLY the top-level discussion comment whose GitHub node ID matches.
+        - `comment_id`: fetch ONLY the matching top-level discussion comment. Accepts the node ID
+          (`DC_kwDO…`), the numeric database id, a `discussioncomment-N` URL anchor, or a full
+          comment URL; an unrecognised shape errors instead of returning an empty list.
           Used for A2A hand-off after `manage_discussion_comment({action: 'create'})` returns
           `commentId`.
         - `since_comment_id`: fetch top-level discussion comments AFTER the one with the given ID

--- a/ai/mcp/server/github-workflow/openapi.yaml
+++ b/ai/mcp/server/github-workflow/openapi.yaml
@@ -448,7 +448,9 @@ paths:
                   example: "issuecomment-5301580683"
                 last_n:
                   type: integer
-                  description: Return only the last N comments (by creation order).
+                  description: >-
+                    Return only the last N comments (by creation order). This is a scoped request, so
+                    the parent body is omitted and `bodyOmitted: true` is set.
                   example: 3
       responses:
         '200':
@@ -457,12 +459,23 @@ paths:
             application/json:
               schema:
                 type: object
-                description: Conversation shape (issue or pull request) — title/body/author plus a (possibly filtered) comments collection.
+                description: >-
+                  Conversation shape (issue or pull request) — title/author plus a (possibly filtered)
+                  comments collection. `body` is present on UNSCOPED requests only; a scoped request
+                  (`comment_id`, `since_comment_id`, or `last_n`) omits it and sets `bodyOmitted: true`.
                 properties:
                   title:
                     type: string
                   body:
                     type: string
+                    description: >-
+                      The issue/PR body. ABSENT on scoped requests — check `bodyOmitted` rather than
+                      reading an absent body as an empty one.
+                  bodyOmitted:
+                    type: boolean
+                    description: >-
+                      Present and `true` only on scoped requests, where `body` was deliberately not
+                      returned. Distinguishes "scoped away" from "this thread has an empty body".
                   author:
                     type: object
                     properties:
@@ -1539,15 +1552,25 @@ paths:
                   example: 10137
                 comment_id:
                   type: string
-                  description: Return only the top-level discussion comment whose GitHub global node ID matches. Discussion title/body metadata is still returned.
-                  example: "DC_kwDOABcD1234567890"
+                  description: >-
+                    Return only the matching top-level discussion comment. Accepts a node ID (current
+                    `DC_…` or legacy base64), the numeric database id, a `discussioncomment-N` URL
+                    anchor, or a full comment URL. An unrecognised shape returns MALFORMED_COMMENT_ID;
+                    a well-formed id absent from the thread returns an empty comments list. Scoped
+                    requests omit the discussion body and set `bodyOmitted: true`.
+                  example: "discussioncomment-18028896"
                 since_comment_id:
                   type: string
-                  description: Return only top-level discussion comments AFTER the one with this ID (exclusive). If the ID is not found, returns empty comments.
-                  example: "DC_kwDOABcD1234567890"
+                  description: >-
+                    Return only top-level discussion comments AFTER the one with this ID (exclusive).
+                    Accepts the same four spellings as `comment_id`. Unrecognised shape errors; a
+                    well-formed but absent id returns empty comments. Scoped requests omit the body.
+                  example: "discussioncomment-18028896"
                 last_n:
                   type: integer
-                  description: Return only the last N top-level discussion comments.
+                  description: >-
+                    Return only the last N top-level discussion comments. This is a scoped request, so
+                    the discussion body is omitted and `bodyOmitted: true` is set.
                   example: 3
       responses:
         '200':
@@ -1567,6 +1590,14 @@ paths:
                     type: string
                   body:
                     type: string
+                    description: >-
+                      The discussion body. ABSENT on scoped requests — check `bodyOmitted` rather than
+                      reading an absent body as an empty one.
+                  bodyOmitted:
+                    type: boolean
+                    description: >-
+                      Present and `true` only on scoped requests, where `body` was deliberately not
+                      returned. Distinguishes "scoped away" from "this discussion has an empty body".
                   url:
                     type: string
                   createdAt:

--- a/ai/services/github-workflow/DiscussionService.mjs
+++ b/ai/services/github-workflow/DiscussionService.mjs
@@ -3,7 +3,7 @@ import Base              from '../../../src/core/Base.mjs';
 import GraphqlService    from './GraphqlService.mjs';
 import RepositoryService from './RepositoryService.mjs';
 import logger            from '../../mcp/server/github-workflow/logger.mjs';
-import {commentMatches, malformedCommentIdError, omitScopedBody, parseCommentId}
+import {commentMatches, isSelectorPresent, malformedCommentIdError, omitScopedBody, parseCommentId}
                                  from './shared/commentSelector.mjs';
 import {projectConversationTrust}                                                                from './shared/conversationTrust.mjs';
 import {GET_DISCUSSION_CONVERSATION, GET_REPO_AND_DISCUSSION_CATEGORIES, GET_DISCUSSION_ID}      from './queries/discussionQueries.mjs';
@@ -104,7 +104,7 @@ class DiscussionService extends Base {
             // Selector precedence mirrors IssueService/PullRequestService.
             let filtered;
 
-            if (comment_id) {
+            if (isSelectorPresent(comment_id)) {
                 // The measured case: `discussioncomment-18022679` — the anchor a peer pastes —
                 // matched nothing and returned an empty list with no error, so the caller re-read the
                 // whole 26KB thread to discover the id was merely spelled differently.
@@ -115,7 +115,7 @@ class DiscussionService extends Base {
                 }
 
                 filtered = allComments.filter(comment => commentMatches(comment, selector));
-            } else if (since_comment_id) {
+            } else if (isSelectorPresent(since_comment_id)) {
                 const selector = parseCommentId(since_comment_id);
 
                 if (!selector) {

--- a/ai/services/github-workflow/DiscussionService.mjs
+++ b/ai/services/github-workflow/DiscussionService.mjs
@@ -3,8 +3,10 @@ import Base              from '../../../src/core/Base.mjs';
 import GraphqlService    from './GraphqlService.mjs';
 import RepositoryService from './RepositoryService.mjs';
 import logger            from '../../mcp/server/github-workflow/logger.mjs';
-import {projectConversationTrust} from './shared/conversationTrust.mjs';
-import {GET_DISCUSSION_CONVERSATION, GET_REPO_AND_DISCUSSION_CATEGORIES, GET_DISCUSSION_ID} from './queries/discussionQueries.mjs';
+import {commentMatches, malformedCommentIdError, omitScopedBody, parseCommentId}
+                                 from './shared/commentSelector.mjs';
+import {projectConversationTrust}                                                                from './shared/conversationTrust.mjs';
+import {GET_DISCUSSION_CONVERSATION, GET_REPO_AND_DISCUSSION_CATEGORIES, GET_DISCUSSION_ID}      from './queries/discussionQueries.mjs';
 import {CREATE_DISCUSSION, ADD_DISCUSSION_COMMENT, UPDATE_DISCUSSION, UPDATE_DISCUSSION_COMMENT} from './queries/mutations.mjs';
 
 /**
@@ -49,10 +51,15 @@ class DiscussionService extends Base {
      *
      * @param {Object} options
      * @param {Number} options.discussion_number    The Discussion number (required).
-     * @param {String} [options.comment_id]         Return only the matching top-level comment; body metadata still returned.
-     * @param {String} [options.since_comment_id]   Return top-level comments strictly after the matching comment. Unknown id -> empty comments.
+     * @param {String} [options.comment_id]         Return only the matching top-level comment. Accepts a node ID, numeric
+     *     database id, `discussioncomment-N` anchor, or full comment URL; an unrecognised shape returns a
+     *     `MALFORMED_COMMENT_ID` error, a well-formed but absent id returns empty comments.
+     * @param {String} [options.since_comment_id]   Return top-level comments strictly after the matching comment. Same
+     *     accepted spellings and same malformed-vs-absent distinction as `comment_id`.
      * @param {Number} [options.last_n]             Return only the last N top-level comments.
-     * @returns {Promise<Object>} Discussion conversation data, optionally filtered, or a structured error.
+     * @returns {Promise<Object>} Discussion conversation data, optionally filtered, or a structured error. A SCOPED
+     *          request (any selector) omits the parent body and sets `bodyOmitted: true`; an unscoped request is
+     *          unchanged. Scoping asked for part of a thread and used to be charged for all of it.
      *          Payloads are trust-projected: authored nodes (incl. nested replies) carry `authorTrust`,
      *          untrusted-author bodies arrive defanged, and the root carries a `contentTrust` summary
      *          (see `shared/conversationTrust.mjs`).
@@ -98,9 +105,24 @@ class DiscussionService extends Base {
             let filtered;
 
             if (comment_id) {
-                filtered = allComments.filter(c => c.id === comment_id);
+                // The measured case: `discussioncomment-18022679` — the anchor a peer pastes —
+                // matched nothing and returned an empty list with no error, so the caller re-read the
+                // whole 26KB thread to discover the id was merely spelled differently.
+                const selector = parseCommentId(comment_id);
+
+                if (!selector) {
+                    return malformedCommentIdError('comment_id', comment_id);
+                }
+
+                filtered = allComments.filter(comment => commentMatches(comment, selector));
             } else if (since_comment_id) {
-                const anchorIdx = allComments.findIndex(c => c.id === since_comment_id);
+                const selector = parseCommentId(since_comment_id);
+
+                if (!selector) {
+                    return malformedCommentIdError('since_comment_id', since_comment_id);
+                }
+
+                const anchorIdx = allComments.findIndex(comment => commentMatches(comment, selector));
                 filtered = anchorIdx === -1 ? [] : allComments.slice(anchorIdx + 1);
             } else if (typeof last_n === 'number' && last_n > 0) {
                 filtered = allComments.slice(-last_n);
@@ -108,13 +130,15 @@ class DiscussionService extends Base {
                 return discussion;
             }
 
-            return {
+            // Discussions are where this costs most — a scoped fetch from a 26KB body paid the same
+            // as reading the head, so the cheapest correct usage carried the most expensive payload.
+            return omitScopedBody({
                 ...discussion,
                 comments: {
                     ...discussion.comments,
                     nodes: filtered
                 }
-            };
+            });
         } catch (error) {
             logger.error(`Error getting conversation for discussion #${discussion_number} via GraphQL:`, error);
             return {
@@ -140,11 +164,11 @@ class DiscussionService extends Base {
             // First, get the repository ID and discussion categories
             const repoData = await GraphqlService.query(GET_REPO_AND_DISCUSSION_CATEGORIES, {
                 owner: aiConfig.owner,
-                repo: aiConfig.repo
+                repo : aiConfig.repo
             });
 
             const repositoryId = repoData.repository.id;
-            const categories = repoData.repository.discussionCategories.nodes;
+            const categories   = repoData.repository.discussionCategories.nodes;
 
             // Find the ID for the requested category name
             const categoryNode = categories.find(cat => cat.name.toLowerCase() === category.toLowerCase());
@@ -174,8 +198,8 @@ class DiscussionService extends Base {
 
             return {
                 discussionNumber: discussion.number,
-                url: discussion.url,
-                id: discussion.id
+                url             : discussion.url,
+                id              : discussion.id
             };
 
         } catch (error) {
@@ -215,7 +239,7 @@ class DiscussionService extends Base {
             const discussionId = idData.repository.discussion.id;
 
             // Use ADD_DISCUSSION_COMMENT mutation
-            const result = await GraphqlService.query(ADD_DISCUSSION_COMMENT, { discussionId, body });
+            const result  = await GraphqlService.query(ADD_DISCUSSION_COMMENT, { discussionId, body });
             const comment = result.addDiscussionComment.comment;
 
             return {
@@ -276,27 +300,27 @@ class DiscussionService extends Base {
     async manageDiscussionComment({discussion_number, comment_id, body, action}) {
         if (!['create', 'update'].includes(action)) {
             return {
-                error: 'Bad Request',
+                error  : 'Bad Request',
                 message: "Invalid action. Must be 'create' or 'update'.",
-                code: 'INVALID_ARGUMENTS'
+                code   : 'INVALID_ARGUMENTS'
             };
         }
 
         if (action === 'create') {
             if (!discussion_number) {
                 return {
-                    error: 'Bad Request',
+                    error  : 'Bad Request',
                     message: "Missing required argument: 'discussion_number' is required for creating comments.",
-                    code: 'MISSING_ARGUMENTS'
+                    code   : 'MISSING_ARGUMENTS'
                 };
             }
             return this.createComment({discussion_number, body});
         } else {
             if (!comment_id) {
                 return {
-                    error: 'Bad Request',
+                    error  : 'Bad Request',
                     message: "Missing required argument: 'comment_id' is required for updating comments.",
-                    code: 'MISSING_ARGUMENTS'
+                    code   : 'MISSING_ARGUMENTS'
                 };
             }
             return this.updateComment(comment_id, body);

--- a/ai/services/github-workflow/IssueService.mjs
+++ b/ai/services/github-workflow/IssueService.mjs
@@ -3,7 +3,7 @@ import Base                                                                     
 import GraphqlService                                                                                                                                                                                                                from './GraphqlService.mjs';
 import RepositoryService                                                                                                                                                                                                             from './RepositoryService.mjs';
 import logger                                                                                                                                                                                                                        from '../../mcp/server/github-workflow/logger.mjs';
-import {commentMatches, malformedCommentIdError, omitScopedBody, parseCommentId}                                                                                                                                                     from './shared/commentSelector.mjs';
+import {commentMatches, isSelectorPresent, malformedCommentIdError, omitScopedBody, parseCommentId}                                                                                                                                  from './shared/commentSelector.mjs';
 import {projectConversationTrust}                                                                                                                                                                                                    from './shared/conversationTrust.mjs';
 import {GET_ISSUE_LABEL_IDS, GET_PULL_REQUEST_LABEL_IDS, GET_ISSUE_PARENT, GET_BLOCKED_BY, GET_ISSUE_ASSIGNEES, GET_ISSUE_CONVERSATION, FETCH_ISSUES_FOR_SYNC, FETCH_ISSUES_LIST, FETCH_ISSUES_LIST_NO_FILTER, buildIssuesListQuery} from './queries/issueQueries.mjs';
 import {GET_PULL_REQUEST_ID}                                                                                                                                                                                                         from './queries/pullRequestQueries.mjs';
@@ -110,7 +110,7 @@ class IssueService extends Base {
             // Selector precedence: comment_id > since_comment_id > last_n > full.
             let filtered;
 
-            if (comment_id) {
+            if (isSelectorPresent(comment_id)) {
                 // A malformed id is an ERROR, never an empty comment list. The old strict equality
                 // filtered every comment away for the two spellings a peer actually holds — a URL
                 // anchor or a bare number — and the caller's only way to learn that was to re-read
@@ -122,7 +122,7 @@ class IssueService extends Base {
                 }
 
                 filtered = allComments.filter(comment => commentMatches(comment, selector));
-            } else if (since_comment_id) {
+            } else if (isSelectorPresent(since_comment_id)) {
                 const selector = parseCommentId(since_comment_id);
 
                 if (!selector) {

--- a/ai/services/github-workflow/IssueService.mjs
+++ b/ai/services/github-workflow/IssueService.mjs
@@ -3,6 +3,7 @@ import Base                                                                     
 import GraphqlService                                                                                                                                                                                                                from './GraphqlService.mjs';
 import RepositoryService                                                                                                                                                                                                             from './RepositoryService.mjs';
 import logger                                                                                                                                                                                                                        from '../../mcp/server/github-workflow/logger.mjs';
+import {commentMatches, malformedCommentIdError, omitScopedBody, parseCommentId}                                                                                                                                                     from './shared/commentSelector.mjs';
 import {projectConversationTrust}                                                                                                                                                                                                    from './shared/conversationTrust.mjs';
 import {GET_ISSUE_LABEL_IDS, GET_PULL_REQUEST_LABEL_IDS, GET_ISSUE_PARENT, GET_BLOCKED_BY, GET_ISSUE_ASSIGNEES, GET_ISSUE_CONVERSATION, FETCH_ISSUES_FOR_SYNC, FETCH_ISSUES_LIST, FETCH_ISSUES_LIST_NO_FILTER, buildIssuesListQuery} from './queries/issueQueries.mjs';
 import {GET_PULL_REQUEST_ID}                                                                                                                                                                                                         from './queries/pullRequestQueries.mjs';
@@ -67,10 +68,14 @@ class IssueService extends Base {
      *
      * @param {Object} options
      * @param {Number} options.issue_number       The issue number (required).
-     * @param {String} [options.comment_id]       Return only the matching comment; others elided. Issue title/body still returned.
-     * @param {String} [options.since_comment_id] Return comments strictly after the matching comment (by createdAt order). Unknown id → empty comments.
+     * @param {String} [options.comment_id]       Return only the matching comment. Accepts a node ID, numeric database
+     *     id, `issuecomment-N` anchor, or full comment URL; an unrecognised shape returns a `MALFORMED_COMMENT_ID`
+     *     error, a well-formed but absent id returns empty comments.
+     * @param {String} [options.since_comment_id] Return comments strictly after the matching comment (by createdAt
+     *     order). Same accepted spellings and same malformed-vs-absent distinction as `comment_id`.
      * @param {Number} [options.last_n]           Return only the last N comments (by createdAt order).
-     * @returns {Promise<Object>} Conversation data (optionally filtered) or a structured error. Payloads
+     * @returns {Promise<Object>} Conversation data or a structured error. A SCOPED request (any selector) omits the
+     *          parent body and sets `bodyOmitted: true`; an unscoped request is unchanged. Payloads
      *          are trust-projected: authored nodes carry `authorTrust`, untrusted-author bodies arrive
      *          defanged, and the root carries a `contentTrust` summary (see `shared/conversationTrust.mjs`).
      */
@@ -106,10 +111,28 @@ class IssueService extends Base {
             let filtered;
 
             if (comment_id) {
-                filtered = allComments.filter(c => c.id === comment_id);
+                // A malformed id is an ERROR, never an empty comment list. The old strict equality
+                // filtered every comment away for the two spellings a peer actually holds — a URL
+                // anchor or a bare number — and the caller's only way to learn that was to re-read
+                // the whole thread, which is the cost this parameter exists to avoid.
+                const selector = parseCommentId(comment_id);
+
+                if (!selector) {
+                    return malformedCommentIdError('comment_id', comment_id);
+                }
+
+                filtered = allComments.filter(comment => commentMatches(comment, selector));
             } else if (since_comment_id) {
-                const anchorIdx = allComments.findIndex(c => c.id === since_comment_id);
-                // Anchor not found → empty result set (mirrors the PR path).
+                const selector = parseCommentId(since_comment_id);
+
+                if (!selector) {
+                    return malformedCommentIdError('since_comment_id', since_comment_id);
+                }
+
+                const anchorIdx = allComments.findIndex(comment => commentMatches(comment, selector));
+                // Well-formed but absent from this thread → empty result set. Distinguishable from
+                // the malformed case above, which errors: "not here" and "not an id" are different
+                // answers and the caller acts differently on each.
                 filtered = anchorIdx === -1 ? [] : allComments.slice(anchorIdx + 1);
             } else if (typeof last_n === 'number' && last_n > 0) {
                 filtered = allComments.slice(-last_n);
@@ -118,14 +141,16 @@ class IssueService extends Base {
                 return issue;
             }
 
-            // Filtered paths preserve issue title/body/author; only comments are narrowed.
-            return {
+            // Scoped paths narrow the comments AND drop the parent body: a request for part of a
+            // thread was previously charged for all of it, so the cheapest correct usage paid the
+            // most expensive payload. Unscoped calls above still return the body untouched.
+            return omitScopedBody({
                 ...issue,
                 comments: {
                     ...issue.comments,
                     nodes: filtered
                 }
-            };
+            });
         } catch (error) {
             logger.error(`Error getting conversation for issue #${issue_number} via GraphQL:`, error);
             return {

--- a/ai/services/github-workflow/PullRequestService.mjs
+++ b/ai/services/github-workflow/PullRequestService.mjs
@@ -20,7 +20,7 @@ import {
     GET_CONVERSATION,
     GET_MERGE_READINESS
 } from './queries/pullRequestQueries.mjs';
-import {commentMatches, malformedCommentIdError, omitScopedBody, parseCommentId}
+import {commentMatches, isSelectorPresent, malformedCommentIdError, omitScopedBody, parseCommentId}
                                               from './shared/commentSelector.mjs';
 import {projectConversationTrust}              from './shared/conversationTrust.mjs';
 
@@ -2217,20 +2217,29 @@ class PullRequestService extends Base {
      *                                or an object with the shape below.
      * @param {number}        options.pr_number         The pull request number (required when object form).
      * @param {string}        [options.projection='conversation'] Response projection.
-     * @param {string}        [options.comment_id]      Return only the matching comment's data; other
-     *                                                  comments elided. PR title/body still returned.
-     * @param {string}        [options.since_comment_id] Return comments strictly after the matching
-     *                                                  comment (by createdAt order). If the id isn't found,
-     *                                                  returns empty comments (callers can interpret as
-     *                                                  "nothing new" or "id invalid").
+     * @param {string}        [options.comment_id]      Return only the matching comment; others elided.
+     *                                                  Accepts a node ID (current `IC_…` or legacy base64),
+     *                                                  the numeric database id, an `issuecomment-N` anchor,
+     *                                                  or a full comment URL. An unrecognised shape returns
+     *                                                  `MALFORMED_COMMENT_ID`; a well-formed id absent from
+     *                                                  the thread returns empty comments. SCOPED: the PR
+     *                                                  body is omitted and `bodyOmitted: true` is set.
+     * @param {string}        [options.since_comment_id] Return comments strictly after the matching comment
+     *                                                  (by createdAt order). Same accepted spellings, and the
+     *                                                  same malformed-vs-absent split — the older "callers can
+     *                                                  interpret as nothing-new OR id-invalid" ambiguity is
+     *                                                  resolved one level up, because invalid now errors.
      * @param {number}        [options.last_n]          Return only the last N comments (by createdAt order).
+     *                                                  Also scoped: body omitted, `bodyOmitted: true`.
      * @param {Object}        [dependencies] Internal source seams for deterministic tests.
      * @param {Function}      [dependencies.query] GitHub GraphQL query function.
      * @param {Function}      [dependencies.rest] GitHub REST request function.
      * @param {Function}      [dependencies.now] Observation-clock function.
-     * @returns {Promise<object>} Conversation data (optionally filtered) or a structured error. Payloads
-     *          are trust-projected: authored nodes carry `authorTrust`, untrusted-author bodies arrive
-     *          defanged, and the root carries a `contentTrust` summary (see `shared/conversationTrust.mjs`).
+     * @returns {Promise<object>} Conversation data or a structured error. A SCOPED request (any selector)
+     *          omits the parent body and sets `bodyOmitted: true`; an unscoped request is unchanged.
+     *          Payloads are trust-projected: authored nodes carry `authorTrust`, untrusted-author bodies
+     *          arrive defanged, and the root carries a `contentTrust` summary (see
+     *          `shared/conversationTrust.mjs`).
      */
     async getConversation(options, dependencies = {}) {
         // Accept positional `prNumber` form for backward compatibility.
@@ -2297,7 +2306,7 @@ class PullRequestService extends Base {
             // Selector precedence: comment_id > since_comment_id > last_n > full.
             let filtered;
 
-            if (comment_id) {
+            if (isSelectorPresent(comment_id)) {
                 // Malformed → error, never an empty list. The two spellings a peer actually holds —
                 // a URL anchor and a bare number — used to filter every comment away silently.
                 const selector = parseCommentId(comment_id);
@@ -2307,7 +2316,7 @@ class PullRequestService extends Base {
                 }
 
                 filtered = allComments.filter(comment => commentMatches(comment, selector));
-            } else if (since_comment_id) {
+            } else if (isSelectorPresent(since_comment_id)) {
                 const selector = parseCommentId(since_comment_id);
 
                 if (!selector) {

--- a/ai/services/github-workflow/PullRequestService.mjs
+++ b/ai/services/github-workflow/PullRequestService.mjs
@@ -20,6 +20,8 @@ import {
     GET_CONVERSATION,
     GET_MERGE_READINESS
 } from './queries/pullRequestQueries.mjs';
+import {commentMatches, malformedCommentIdError, omitScopedBody, parseCommentId}
+                                              from './shared/commentSelector.mjs';
 import {projectConversationTrust}              from './shared/conversationTrust.mjs';
 
 const execAsync                        = promisify(exec);
@@ -2192,7 +2194,8 @@ class PullRequestService extends Base {
      * with the default full-conversation shape that existing callers depend on.
      *
      * **Selectors (first-match precedence, pick at most one):**
-     * - `comment_id` — fetch ONLY the comment whose GitHub node ID matches. Used for A2A
+     * - `comment_id` — fetch ONLY the matching comment. Accepts a node ID, numeric database id,
+     *   an `issuecomment-N` anchor, or a full comment URL; an unrecognised shape errors. Used for A2A
      *   hand-off: a reviewer posts a comment, mailboxes the `commentId` from the create-path
      *   return shape to the peer, peer fetches just-this-comment for near-zero context cost.
      * - `since_comment_id` — fetch all comments AFTER the one with the given ID (exclusive).
@@ -2295,11 +2298,26 @@ class PullRequestService extends Base {
             let filtered;
 
             if (comment_id) {
-                filtered = allComments.filter(c => c.id === comment_id);
+                // Malformed → error, never an empty list. The two spellings a peer actually holds —
+                // a URL anchor and a bare number — used to filter every comment away silently.
+                const selector = parseCommentId(comment_id);
+
+                if (!selector) {
+                    return malformedCommentIdError('comment_id', comment_id);
+                }
+
+                filtered = allComments.filter(comment => commentMatches(comment, selector));
             } else if (since_comment_id) {
-                const anchorIdx = allComments.findIndex(c => c.id === since_comment_id);
-                // Anchor not found → empty result set (callers interpret as "nothing after" or
-                // "invalid id"). Trying to infer intent would hide bugs.
+                const selector = parseCommentId(since_comment_id);
+
+                if (!selector) {
+                    return malformedCommentIdError('since_comment_id', since_comment_id);
+                }
+
+                const anchorIdx = allComments.findIndex(comment => commentMatches(comment, selector));
+                // Well-formed but absent → empty result set. The ambiguity the old comment described
+                // ("nothing after" vs "invalid id") is now resolved one level up: invalid errors, so
+                // reaching here means the id was a real shape that this thread does not carry.
                 filtered = anchorIdx === -1 ? [] : allComments.slice(anchorIdx + 1);
             } else if (typeof last_n === 'number' && last_n > 0) {
                 filtered = allComments.slice(-last_n);
@@ -2308,15 +2326,15 @@ class PullRequestService extends Base {
                 return pullRequest;
             }
 
-            // Filtered paths preserve PR title/body/author; only comments are narrowed.
-            // Caller can detect filtering via comments.length vs unfiltered fetch.
-            return {
+            // Scoped paths narrow the comments AND drop the parent body: asking for one comment out
+            // of a long thread previously cost the whole head. Unscoped calls above are unchanged.
+            return omitScopedBody({
                 ...pullRequest,
                 comments: {
                     ...pullRequest.comments,
                     nodes: filtered
                 }
-            };
+            });
         } catch (error) {
             logger.error(`Error getting conversation for PR #${pr_number} via GraphQL:`, error);
             return {

--- a/ai/services/github-workflow/queries/discussionQueries.mjs
+++ b/ai/services/github-workflow/queries/discussionQueries.mjs
@@ -83,6 +83,7 @@ export const GET_DISCUSSION_CONVERSATION = `
         comments(first: $maxComments) {
           nodes {
             id
+            databaseId
             author {
               login
             }

--- a/ai/services/github-workflow/queries/issueQueries.mjs
+++ b/ai/services/github-workflow/queries/issueQueries.mjs
@@ -948,6 +948,7 @@ export const GET_ISSUE_CONVERSATION = `
         comments(first: $maxComments) {
           nodes {
             id
+            databaseId
             author {
               login
             }

--- a/ai/services/github-workflow/queries/pullRequestQueries.mjs
+++ b/ai/services/github-workflow/queries/pullRequestQueries.mjs
@@ -25,6 +25,7 @@ export const GET_CONVERSATION = `
         comments(first: $maxComments) {
           nodes {
             id
+            databaseId
             author {
               login
             }

--- a/ai/services/github-workflow/shared/commentSelector.mjs
+++ b/ai/services/github-workflow/shared/commentSelector.mjs
@@ -25,13 +25,63 @@ export const ACCEPTED_COMMENT_ID_FORMS = [
 ].join(', ');
 
 const
-    // A node ID is opaque base64-ish text with a type prefix. Deliberately loose: GitHub owns this
-    // vocabulary and mints new prefixes, so pinning the known ones would reject tomorrow's valid id.
-    NODE_ID_PATTERN = /^[A-Za-z][A-Za-z0-9]*_[A-Za-z0-9_-]+$/u,
-    NUMERIC_PATTERN = /^\d+$/u,
-    // `issuecomment-N`, `discussioncomment-N`, `pullrequestreviewcomment-N`. Matched at the END so a
-    // full URL reduces to the same case rather than needing its own parser.
-    ANCHOR_PATTERN  = /(?:^|#)([a-z]*comment)-(\d+)$/iu;
+    // CURRENT node ID: an UPPERCASE type prefix, an underscore, then base64url. `IC_kwDODSospM4hM0EW`.
+    //
+    // The uppercase prefix is the entire guard, and deliberately so. An earlier draft allowed any
+    // leading letter, which admitted `not_an_id` and `bogus_123` as "node IDs" and degraded them to
+    // well-formed-but-absent instead of rejecting them, which is the silent-empty class this module
+    // exists to close, arriving through its own grammar.
+    // A length floor was tried alongside it and removed: it rejected no real id, closed nothing the
+    // case rule does not already close, and only broke short fixtures. Guards should be the property
+    // that actually discriminates, not that property plus a plausible-looking companion.
+    //
+    // `ABC_xyz` remains admissible by construction: GitHub owns this namespace, so a well-formed id
+    // we cannot resolve is exactly the "absent from this thread" case, which returns empty comments.
+    NODE_ID_PATTERN        = /^[A-Z]{1,10}_[A-Za-z0-9_-]{3,}$/u,
+    // LEGACY node ID: base64 of `NN:TypeNameNNN`, e.g. `MDEyOklzc3VlQ29tbWVudDU1NzAwNzEyNg==` →
+    // `012:IssueComment557007126`. Still live and resolvable, so it is admitted by DECODING and
+    // checking the payload rather than by pattern-matching base64 — "looks base64" would readmit the
+    // arbitrary-junk class the uppercase guard above exists to close.
+    LEGACY_PAYLOAD_PATTERN = /^\d{2,}:[A-Za-z]+\d+$/u,
+    NUMERIC_PATTERN        = /^\d+$/u,
+    // A CLOSED prefix set, not `[a-z]*comment`. The open form matched `evilcomment-123` and handed
+    // back numeric 123 — an id outside the accepted vocabulary silently becoming a valid selector.
+    // Matched at the END so a full URL reduces to this case rather than needing its own parser.
+    ANCHOR_PATTERN         = /(?:^|#)(?:issue|discussion|pullrequestreview)comment-(\d+)$/iu;
+
+/**
+ * @summary Whether a string is a LEGACY GitHub node ID, proven by decoding it.
+ *
+ * `atob`-style decode, then require the payload to be `NN:TypeNameNNN`. Anything that fails to
+ * decode, or decodes to something else, is not a node ID — which keeps the admitted set closed
+ * while still accepting a form GitHub currently resolves.
+ *
+ * @param {String} value Candidate id.
+ * @returns {Boolean}
+ * @private
+ */
+function isLegacyNodeId(value) {
+    // A legacy id is base64; anything with URL or anchor punctuation is a different shape entirely.
+    if (!/^[A-Za-z0-9+/]+={0,2}$/u.test(value)) {
+        return false
+    }
+
+    let decoded;
+
+    try {
+        decoded = Buffer.from(value, 'base64').toString('utf8')
+    } catch {
+        return false
+    }
+
+    // Round-trip guard: base64 decoding is lenient and will happily consume a string that is not a
+    // faithful encoding, so a payload that does not re-encode to the input was never this id.
+    if (Buffer.from(decoded, 'utf8').toString('base64') !== value) {
+        return false
+    }
+
+    return LEGACY_PAYLOAD_PATTERN.test(decoded)
+}
 
 /**
  * @summary Resolves any accepted spelling into a matcher descriptor.
@@ -62,17 +112,38 @@ export function parseCommentId(raw) {
     const anchor = value.match(ANCHOR_PATTERN);
 
     if (anchor) {
-        return {kind: 'numeric', databaseId: anchor[2]}
+        return {kind: 'numeric', databaseId: anchor[1]}
     }
 
     // Checked last: a URL that did NOT end in a comment anchor is a link to something else (the issue
     // itself, a commit, a file), and admitting it as an opaque node ID would turn a caller's wrong
     // link into a silent empty result — the defect this module exists to remove.
-    if (!value.includes('/') && !value.includes('#') && NODE_ID_PATTERN.test(value)) {
+    if (value.includes('/') || value.includes('#')) {
+        return null
+    }
+
+    if (NODE_ID_PATTERN.test(value) || isLegacyNodeId(value)) {
         return {kind: 'node', nodeId: value}
     }
 
     return null
+}
+
+/**
+ * @summary Whether the caller SUPPLIED a selector, independent of whether its value is usable.
+ *
+ * Presence, not truthiness. The three services previously branched on `if (comment_id)`, so an
+ * empty string skipped the selector path entirely and returned the full unscoped conversation — a
+ * caller who addressed a comment with a blank value got the whole thread and no error, which is the
+ * exact silent-wrong-answer this module exists to remove.
+ *
+ * Presence must invoke parsing; parsing decides validity.
+ *
+ * @param {*} value Candidate selector argument.
+ * @returns {Boolean}
+ */
+export function isSelectorPresent(value) {
+    return value !== undefined && value !== null
 }
 
 /**

--- a/ai/services/github-workflow/shared/commentSelector.mjs
+++ b/ai/services/github-workflow/shared/commentSelector.mjs
@@ -1,0 +1,137 @@
+/**
+ * Addressing ONE comment, in whichever spelling the caller actually has.
+ *
+ * The point of `comment_id` is that a peer hand-off is cheap — "read issuecomment-5301580683" rather
+ * than "read the thread". That only works if the id a peer HAS is the id the tool accepts, and the id
+ * a peer has is almost never the GraphQL node ID: it is the anchor at the end of a pasted URL, the
+ * URL itself, or the bare number. Accepting only the node ID made the parameter documented and
+ * unusable, and its failure was silent — an unrecognised id filtered every comment away and returned
+ * an empty list, which reads as "this comment has nothing" rather than "you addressed it wrong".
+ *
+ * So this module answers two questions the services previously answered with one strict equality:
+ * what did the caller mean, and does a given comment match it. Both are pure, so the whole matrix is
+ * testable without a network.
+ */
+
+/**
+ * @summary The spellings accepted for `comment_id` / `since_comment_id`, phrased for an error message.
+ * @type {String}
+ */
+export const ACCEPTED_COMMENT_ID_FORMS = [
+    'a GraphQL node ID (IC_kwDO…, DC_kwDO…)',
+    'the numeric database id (18022679)',
+    'a URL anchor (issuecomment-18022679, discussioncomment-18022679)',
+    'a full comment URL ending in one of those anchors'
+].join(', ');
+
+const
+    // A node ID is opaque base64-ish text with a type prefix. Deliberately loose: GitHub owns this
+    // vocabulary and mints new prefixes, so pinning the known ones would reject tomorrow's valid id.
+    NODE_ID_PATTERN = /^[A-Za-z][A-Za-z0-9]*_[A-Za-z0-9_-]+$/u,
+    NUMERIC_PATTERN = /^\d+$/u,
+    // `issuecomment-N`, `discussioncomment-N`, `pullrequestreviewcomment-N`. Matched at the END so a
+    // full URL reduces to the same case rather than needing its own parser.
+    ANCHOR_PATTERN  = /(?:^|#)([a-z]*comment)-(\d+)$/iu;
+
+/**
+ * @summary Resolves any accepted spelling into a matcher descriptor.
+ *
+ * Order matters, and numeric is checked before the node pattern for a reason: a bare `18022679` is
+ * unambiguous, while a permissive node-ID pattern must never be allowed to swallow it.
+ *
+ * @param {*} raw The caller-supplied id.
+ * @returns {{kind: 'node', nodeId: String}|{kind: 'numeric', databaseId: String}|null} `null` when no
+ *     accepted spelling matches — the malformed case, which callers turn into an explicit error
+ *     rather than an empty result.
+ */
+export function parseCommentId(raw) {
+    if (typeof raw !== 'string') {
+        return null
+    }
+
+    const value = raw.trim();
+
+    if (!value) {
+        return null
+    }
+
+    if (NUMERIC_PATTERN.test(value)) {
+        return {kind: 'numeric', databaseId: value}
+    }
+
+    const anchor = value.match(ANCHOR_PATTERN);
+
+    if (anchor) {
+        return {kind: 'numeric', databaseId: anchor[2]}
+    }
+
+    // Checked last: a URL that did NOT end in a comment anchor is a link to something else (the issue
+    // itself, a commit, a file), and admitting it as an opaque node ID would turn a caller's wrong
+    // link into a silent empty result — the defect this module exists to remove.
+    if (!value.includes('/') && !value.includes('#') && NODE_ID_PATTERN.test(value)) {
+        return {kind: 'node', nodeId: value}
+    }
+
+    return null
+}
+
+/**
+ * @summary Whether one comment node is the one the selector addresses.
+ *
+ * The numeric arm needs `databaseId` on the node, which is why the conversation queries select it.
+ * A node missing it simply does not match rather than throwing: a query that forgot the field
+ * degrades to "no match" (visible, and caught by the absent-vs-malformed distinction) instead of
+ * taking the request down.
+ *
+ * @param {Object} comment  A comment node.
+ * @param {Object} selector A {@link parseCommentId} result.
+ * @returns {Boolean}
+ */
+export function commentMatches(comment, selector) {
+    if (!comment || !selector) {
+        return false
+    }
+
+    return selector.kind === 'node'
+        ? comment.id === selector.nodeId
+        : comment.databaseId != null && String(comment.databaseId) === selector.databaseId
+}
+
+/**
+ * @summary The structured error for an id in no accepted spelling.
+ *
+ * Malformed is reported, never silently filtered. The old behaviour — an empty comment list — cost a
+ * caller a full re-fetch of the thread to discover a typo, which is the exact expense the addressed
+ * fetch exists to avoid.
+ *
+ * @param {String} field The parameter name, so the message names what the caller passed.
+ * @param {*}      raw   The offending value.
+ * @returns {Object} A structured MCP error payload.
+ */
+export function malformedCommentIdError(field, raw) {
+    return {
+        error  : 'Bad Request',
+        message: `'${field}' is not a recognised comment id: ${JSON.stringify(raw)}. Accepted: ${ACCEPTED_COMMENT_ID_FORMS}.`,
+        code   : 'MALFORMED_COMMENT_ID'
+    }
+}
+
+/**
+ * @summary Strips the parent body from a SCOPED conversation payload.
+ *
+ * A scoped request asks for part of a thread and was charged for all of it: fetching one 2KB comment
+ * out of a 26KB discussion cost the same as reading the head. The body is therefore omitted exactly
+ * when a selector narrowed the request, and untouched otherwise — an unscoped `get_conversation`
+ * keeps its shape, so nothing that reads the head today has to change.
+ *
+ * `bodyOmitted` is set rather than the field silently vanishing: a consumer that finds no `body` must
+ * be able to tell "scoped away" from "this thread has an empty body".
+ *
+ * @param {Object} conversation The projected conversation.
+ * @returns {Object}
+ */
+export function omitScopedBody(conversation) {
+    const {body, ...rest} = conversation || {};
+
+    return {...rest, bodyOmitted: true}
+}

--- a/ai/services/github-workflow/shared/commentSelector.mjs
+++ b/ai/services/github-workflow/shared/commentSelector.mjs
@@ -46,8 +46,49 @@ const
     NUMERIC_PATTERN        = /^\d+$/u,
     // A CLOSED prefix set, not `[a-z]*comment`. The open form matched `evilcomment-123` and handed
     // back numeric 123 — an id outside the accepted vocabulary silently becoming a valid selector.
-    // Matched at the END so a full URL reduces to this case rather than needing its own parser.
-    ANCHOR_PATTERN         = /(?:^|#)(?:issue|discussion|pullrequestreview)comment-(\d+)$/iu;
+    //
+    // Anchored at BOTH ends. A previous revision matched `(?:^|#)…$`, which closed the anchor's own
+    // prefix while leaving the whole string's prefix open: `https://example.invalid/phish#issuecomment-N`
+    // and `not-a-url#issuecomment-N` both became valid selectors, because only the suffix was checked.
+    // A URL is now a separate branch with its own host check rather than something this pattern
+    // absorbs by ignoring everything to its left.
+    BARE_ANCHOR_PATTERN    = /^(?:issue|discussion|pullrequestreview)comment-(\d+)$/iu,
+    URL_FRAGMENT_PATTERN   = /^#(?:issue|discussion|pullrequestreview)comment-(\d+)$/iu,
+    // The accepted forms name a GitHub comment URL. Without a host check, "URL" meant "any string
+    // ending in a comment anchor", so a hostile or mistyped origin resolved to a real in-thread
+    // comment — the wrong-address-answered-silently class this module exists to remove.
+    GITHUB_HOSTS           = Object.freeze(new Set(['github.com', 'www.github.com'])),
+    URL_PROTOCOLS          = Object.freeze(new Set(['http:', 'https:']));
+
+/**
+ * @summary Resolves a GitHub comment URL to its numeric id, or `null` for anything else.
+ *
+ * Parsed as a URL rather than pattern-matched, so the host is a checked field instead of text that
+ * happens to precede a `#`. A value that is not a URL at all returns `null` here and falls through
+ * to the remaining branches; a value that IS a URL must be a GitHub one with a closed comment
+ * fragment, or it is rejected outright rather than mined for a trailing number.
+ *
+ * @param {String} value Candidate id.
+ * @returns {{kind: 'numeric', databaseId: String}|null}
+ * @private
+ */
+function parseCommentUrl(value) {
+    let url;
+
+    try {
+        url = new URL(value)
+    } catch {
+        return null
+    }
+
+    if (!URL_PROTOCOLS.has(url.protocol) || !GITHUB_HOSTS.has(url.hostname.toLowerCase())) {
+        return null
+    }
+
+    const fragment = url.hash.match(URL_FRAGMENT_PATTERN);
+
+    return fragment ? {kind: 'numeric', databaseId: fragment[1]} : null
+}
 
 /**
  * @summary Whether a string is a LEGACY GitHub node ID, proven by decoding it.
@@ -109,17 +150,20 @@ export function parseCommentId(raw) {
         return {kind: 'numeric', databaseId: value}
     }
 
-    const anchor = value.match(ANCHOR_PATTERN);
+    // A bare anchor must be the WHOLE string. Anything with a prefix is a URL claim and is checked
+    // as one below, never mined for its trailing number.
+    const anchor = value.match(BARE_ANCHOR_PATTERN);
 
     if (anchor) {
         return {kind: 'numeric', databaseId: anchor[1]}
     }
 
-    // Checked last: a URL that did NOT end in a comment anchor is a link to something else (the issue
-    // itself, a commit, a file), and admitting it as an opaque node ID would turn a caller's wrong
-    // link into a silent empty result — the defect this module exists to remove.
-    if (value.includes('/') || value.includes('#')) {
-        return null
+    // Anything carrying URL syntax is decided ENTIRELY by the URL branch: a GitHub comment URL
+    // resolves, and every other URL-shaped value — foreign host, foreign scheme, a link to the issue
+    // itself, or a garbage prefix wearing a valid anchor — is rejected rather than falling through
+    // to be read as an opaque node ID.
+    if (value.includes('/') || value.includes('#') || value.includes(':')) {
+        return parseCommentUrl(value)
     }
 
     if (NODE_ID_PATTERN.test(value) || isLegacyNodeId(value)) {

--- a/test/playwright/unit/ai/services/github-workflow/DiscussionService.spec.mjs
+++ b/test/playwright/unit/ai/services/github-workflow/DiscussionService.spec.mjs
@@ -201,14 +201,15 @@ test.describe('Neo.ai.services.github-workflow.DiscussionService — getConversa
                     replies  : {nodes: []}
                 },
                 {
-                    id       : 'DC_second',
-                    author   : {login: 'neo-opus-grace'},
-                    body     : 'Second comment',
-                    createdAt: '2026-05-02T00:02:00Z',
-                    updatedAt: '2026-05-02T00:02:00Z',
-                    url      : 'https://github.com/orgs/neomjs/discussions/10137#discussioncomment-2',
-                    isAnswer : false,
-                    replies  : {
+                    id        : 'DC_second',
+                    databaseId: 18022679,
+                    author    : {login: 'neo-opus-grace'},
+                    body      : 'Second comment',
+                    createdAt : '2026-05-02T00:02:00Z',
+                    updatedAt : '2026-05-02T00:02:00Z',
+                    url       : 'https://github.com/orgs/neomjs/discussions/10137#discussioncomment-2',
+                    isAnswer  : false,
+                    replies   : {
                         nodes: [{
                             id       : 'DCR_reply',
                             author   : {login: 'neo-gpt'},
@@ -290,9 +291,48 @@ test.describe('Neo.ai.services.github-workflow.DiscussionService — getConversa
             comment_id       : 'DC_second'
         });
 
-        expect(result.body).toBe('Discussion body');
+        // The scoped payload no longer carries the parent body. This assertion previously read
+        // `toBe('Discussion body')`, which encoded the defect: a request for one 2KB comment was
+        // charged the whole 26KB head, so the cheapest correct usage paid the most expensive payload.
+        expect(result.body).toBeUndefined();
+        expect(result.bodyOmitted).toBe(true);
         expect(result.comments.nodes.map(c => c.id)).toEqual(['DC_second']);
         expect(result.comments.nodes[0].replies.nodes[0].id).toBe('DCR_reply');
+    });
+
+    test('comment_id accepts the anchor and numeric spellings a peer actually holds (#17142)', async () => {
+        installFixture();
+
+        // `DC_second` carries databaseId 18022679 in the fixture. Both spellings below previously
+        // matched nothing and returned an empty list with NO error — the caller's only recourse was
+        // re-reading the whole thread, which is the cost the parameter exists to avoid.
+        for (const spelling of ['18022679', 'discussioncomment-18022679',
+            'https://github.com/neomjs/neo/discussions/10137#discussioncomment-18022679']) {
+            const result = await DiscussionService.getConversation({discussion_number: 10137, comment_id: spelling});
+
+            expect(result.comments.nodes.map(c => c.id), spelling).toEqual(['DC_second']);
+        }
+    });
+
+    test('an unrecognised comment_id ERRORS instead of returning an empty list (#17142)', async () => {
+        installFixture();
+
+        const result = await DiscussionService.getConversation({discussion_number: 10137, comment_id: 'not-an-id'});
+
+        // The whole point: malformed is distinguishable from absent. An empty comment list reads as
+        // "this comment has nothing"; an error reads as "you addressed it wrong".
+        expect(result.code).toBe('MALFORMED_COMMENT_ID');
+        expect(result.message).toContain('not-an-id');
+        expect(result.comments).toBeUndefined();
+    });
+
+    test('a well-formed but ABSENT comment_id yields an empty list, not an error (#17142)', async () => {
+        installFixture();
+
+        const result = await DiscussionService.getConversation({discussion_number: 10137, comment_id: 'DC_nope'});
+
+        expect(result.code).toBeUndefined();
+        expect(result.comments.nodes).toEqual([]);
     });
 
     test('unknown comment_id returns empty comments while preserving discussion metadata', async () => {

--- a/test/playwright/unit/ai/services/github-workflow/IssueService.spec.mjs
+++ b/test/playwright/unit/ai/services/github-workflow/IssueService.spec.mjs
@@ -1428,7 +1428,7 @@ test.describe('Neo.ai.services.github-workflow.IssueService — getConversation 
 
     const COMMENT_A = {id: 'IC_a1111', author: {login: 'alice'}, body: 'First comment',  createdAt: '2026-05-22T01:00:00Z'};
     const COMMENT_B = {id: 'IC_b2222', author: {login: 'bob'},   body: 'Second comment', createdAt: '2026-05-22T01:10:00Z'};
-    const COMMENT_C = {id: 'IC_c3333', author: {login: 'alice'}, body: 'Third comment',  createdAt: '2026-05-22T01:20:00Z'};
+    const COMMENT_C = {id: 'IC_c3333', databaseId: 5301580683, author: {login: 'alice'}, body: 'Third comment',  createdAt: '2026-05-22T01:20:00Z'};
     const COMMENT_D = {id: 'IC_d4444', author: {login: 'bob'},   body: 'Fourth comment', createdAt: '2026-05-22T01:30:00Z'};
 
     const ISSUE_FIXTURE = {
@@ -1462,6 +1462,61 @@ test.describe('Neo.ai.services.github-workflow.IssueService — getConversation 
         expect(result.comments.nodes).toHaveLength(4);
         expect(result.comments.nodes[0].id).toBe('IC_a1111');
         expect(result.comments.nodes[3].id).toBe('IC_d4444');
+    });
+
+    test('comment_id accepts every spelling, and a scoped request omits the issue body (#17142)', async () => {
+        // Service-level wiring, not just the pure helper: the anchor and numeric forms are the ones a
+        // peer actually pastes, and both previously matched nothing and returned an empty list with no
+        // error. The legacy base64 form is the REGRESSION case — strict equality accepted it before the
+        // selector existed, so it must keep working.
+        for (const spelling of [
+            'IC_c3333',
+            '5301580683',
+            'issuecomment-5301580683',
+            'https://github.com/neomjs/neo/issues/10702#issuecomment-5301580683'
+        ]) {
+            const result = await IssueService.getConversation({issue_number: 10702, comment_id: spelling});
+
+            expect(result.comments.nodes.map(c => c.id), spelling).toEqual(['IC_c3333']);
+            expect(result.body,        `${spelling}: scoped body omitted`).toBeUndefined();
+            expect(result.bodyOmitted, `${spelling}: omission announced`).toBe(true);
+            expect(result.title,       `${spelling}: title survives scoping`).toBe('Test Issue');
+        }
+    });
+
+    test('a malformed comment_id ERRORS; a well-formed absent one returns empty (#17142)', async () => {
+        const malformed = await IssueService.getConversation({issue_number: 10702, comment_id: 'not_an_id'});
+
+        expect(malformed.code).toBe('MALFORMED_COMMENT_ID');
+        expect(malformed.comments).toBeUndefined();
+
+        const absent = await IssueService.getConversation({issue_number: 10702, comment_id: 'IC_nope9999'});
+
+        expect(absent.code).toBeUndefined();
+        expect(absent.comments.nodes).toEqual([]);
+    });
+
+    test('an EMPTY comment_id errors instead of returning the whole unscoped thread (#17142)', async () => {
+        // The branch used to test truthiness, so '' skipped the selector entirely and answered a blank
+        // address with the full conversation — body and all.
+        const result = await IssueService.getConversation({issue_number: 10702, comment_id: ''});
+
+        expect(result.code).toBe('MALFORMED_COMMENT_ID');
+        expect(result.body).toBeUndefined();
+    });
+
+    test('since_comment_id accepts the same spellings and is scoped too (#17142)', async () => {
+        const result = await IssueService.getConversation({
+            issue_number    : 10702,
+            since_comment_id: 'issuecomment-5301580683'
+        });
+
+        expect(result.comments.nodes.map(c => c.id)).toEqual(['IC_d4444']);
+        expect(result.bodyOmitted).toBe(true);
+
+        const malformed = await IssueService.getConversation({issue_number: 10702, since_comment_id: 'evilcomment-1'});
+
+        expect(malformed.code).toBe('MALFORMED_COMMENT_ID');
     });
 
     test('comment_id selector returns only the matching comment', async () => {

--- a/test/playwright/unit/ai/services/github-workflow/PullRequestService.spec.mjs
+++ b/test/playwright/unit/ai/services/github-workflow/PullRequestService.spec.mjs
@@ -1045,7 +1045,7 @@ test.describe('Neo.ai.services.github-workflow.PullRequestService — getConvers
 
     const COMMENT_A = {id: 'IC_a1111', author: {login: 'alice'}, body: 'First comment',  createdAt: '2026-04-24T01:00:00Z'};
     const COMMENT_B = {id: 'IC_b2222', author: {login: 'bob'},   body: 'Second comment', createdAt: '2026-04-24T01:10:00Z'};
-    const COMMENT_C = {id: 'IC_c3333', author: {login: 'alice'}, body: 'Third comment',  createdAt: '2026-04-24T01:20:00Z'};
+    const COMMENT_C = {id: 'IC_c3333', databaseId: 5301283039, author: {login: 'alice'}, body: 'Third comment',  createdAt: '2026-04-24T01:20:00Z'};
     const COMMENT_D = {id: 'IC_d4444', author: {login: 'bob'},   body: 'Fourth comment', createdAt: '2026-04-24T01:30:00Z'};
 
     const PR_FIXTURE = {
@@ -1089,6 +1089,59 @@ test.describe('Neo.ai.services.github-workflow.PullRequestService — getConvers
 
         expect(result.title).toBe('Test PR');
         expect(result.comments.nodes).toHaveLength(4);
+    });
+
+    test('comment_id accepts every spelling, and a scoped request omits the PR body (#17142)', async () => {
+        // The PR path had no service-level selector arms at all — only the pure helper and the
+        // Discussion path were covered, so this surface's wiring was asserted nowhere (@neo-gpt).
+        // `5301283039` is a real PR-comment databaseId shape; the legacy base64 form is the
+        // regression case strict equality used to accept.
+        for (const spelling of [
+            'IC_c3333',
+            '5301283039',
+            'issuecomment-5301283039',
+            'https://github.com/neomjs/neo/pull/10272#issuecomment-5301283039'
+        ]) {
+            const result = await PullRequestService.getConversation({pr_number: 10272, comment_id: spelling});
+
+            expect(result.comments.nodes.map(c => c.id), spelling).toEqual(['IC_c3333']);
+            expect(result.body,        `${spelling}: scoped body omitted`).toBeUndefined();
+            expect(result.bodyOmitted, `${spelling}: omission announced`).toBe(true);
+            expect(result.title,       `${spelling}: title survives scoping`).toBe('Test PR');
+        }
+    });
+
+    test('a malformed comment_id ERRORS; a well-formed absent one returns empty (#17142)', async () => {
+        const malformed = await PullRequestService.getConversation({pr_number: 10272, comment_id: 'not_an_id'});
+
+        expect(malformed.code).toBe('MALFORMED_COMMENT_ID');
+        expect(malformed.comments).toBeUndefined();
+
+        const absent = await PullRequestService.getConversation({pr_number: 10272, comment_id: 'IC_nope9999'});
+
+        expect(absent.code).toBeUndefined();
+        expect(absent.comments.nodes).toEqual([]);
+    });
+
+    test('an EMPTY comment_id errors instead of returning the whole unscoped thread (#17142)', async () => {
+        const result = await PullRequestService.getConversation({pr_number: 10272, comment_id: ''});
+
+        expect(result.code).toBe('MALFORMED_COMMENT_ID');
+        expect(result.body).toBeUndefined();
+    });
+
+    test('since_comment_id accepts the same spellings and is scoped too (#17142)', async () => {
+        const result = await PullRequestService.getConversation({
+            pr_number       : 10272,
+            since_comment_id: 'issuecomment-5301283039'
+        });
+
+        expect(result.comments.nodes.map(c => c.id)).toEqual(['IC_d4444']);
+        expect(result.bodyOmitted).toBe(true);
+
+        const malformed = await PullRequestService.getConversation({pr_number: 10272, since_comment_id: 'evilcomment-1'});
+
+        expect(malformed.code).toBe('MALFORMED_COMMENT_ID');
     });
 
     test('comment_id selector returns only the matching comment', async () => {

--- a/test/playwright/unit/ai/services/github-workflow/commentSelector.spec.mjs
+++ b/test/playwright/unit/ai/services/github-workflow/commentSelector.spec.mjs
@@ -39,6 +39,31 @@ test.describe('commentSelector', () => {
             expect(parseCommentId('  issuecomment-42  ')).toEqual({kind: 'numeric', databaseId: '42'});
         });
 
+        test('a URL must be a GITHUB comment URL — host and scheme are checked, not just the suffix (#17142 RC2)', () => {
+            // An earlier revision anchored the comment pattern as `(?:^|#)…$`, which closed the
+            // anchor's own prefix and left the whole string's prefix open. Only the suffix was
+            // checked, so any origin wearing a valid anchor resolved to a real in-thread comment —
+            // the wrong-address-answered-silently class this module exists to remove.
+            expect(parseCommentId('https://example.invalid/phish#issuecomment-557007126'), 'foreign host').toBeNull();
+            expect(parseCommentId('ftp://example.invalid/#discussioncomment-18022679'),    'foreign scheme + host').toBeNull();
+            expect(parseCommentId('ftp://github.com/#issuecomment-42'),                    'foreign scheme, GitHub host').toBeNull();
+            expect(parseCommentId('not-a-url#issuecomment-557007126'),                     'garbage prefix, valid anchor').toBeNull();
+            expect(parseCommentId('https://github.com.evil.test/x#issuecomment-1'),        'lookalike host').toBeNull();
+
+            // …and the legitimate origins still resolve.
+            expect(parseCommentId('https://github.com/neomjs/neo/issues/1#issuecomment-557007126'))
+                .toEqual({kind: 'numeric', databaseId: '557007126'});
+            expect(parseCommentId('http://github.com/o/r/issues/1#issuecomment-42'), 'http is a redirect, not a foreign origin')
+                .toEqual({kind: 'numeric', databaseId: '42'});
+            expect(parseCommentId('https://www.github.com/o/r/issues/1#issuecomment-42'), 'www host')
+                .toEqual({kind: 'numeric', databaseId: '42'});
+        });
+
+        test('a bare anchor must be the WHOLE string (#17142 RC2)', () => {
+            expect(parseCommentId('issuecomment-557007126')).toEqual({kind: 'numeric', databaseId: '557007126'});
+            expect(parseCommentId('junk issuecomment-557007126'), 'prefixed bare anchor').toBeNull();
+        });
+
         test('a URL that is NOT a comment link is malformed, not an opaque node ID', () => {
             // The dangerous near-miss: admitting these as node IDs would turn a caller's wrong link
             // back into a silent empty result, which is the defect being removed.

--- a/test/playwright/unit/ai/services/github-workflow/commentSelector.spec.mjs
+++ b/test/playwright/unit/ai/services/github-workflow/commentSelector.spec.mjs
@@ -1,0 +1,134 @@
+import {test, expect} from '@playwright/test';
+
+import {
+    ACCEPTED_COMMENT_ID_FORMS,
+    commentMatches,
+    malformedCommentIdError,
+    omitScopedBody,
+    parseCommentId
+}                     from '../../../../../../ai/services/github-workflow/shared/commentSelector.mjs';
+
+test.describe('commentSelector', () => {
+    test.describe('parseCommentId — the four spellings that exist in the wild', () => {
+        test('a GraphQL node ID resolves to a node selector', () => {
+            expect(parseCommentId('IC_kwDODSospM8AAAABO_ziw')).toEqual({kind: 'node', nodeId: 'IC_kwDODSospM8AAAABO_ziw'});
+            expect(parseCommentId('DC_kwDODSospM4BEwEj')).toEqual({kind: 'node', nodeId: 'DC_kwDODSospM4BEwEj'});
+        });
+
+        test('a bare number resolves to a numeric selector', () => {
+            expect(parseCommentId('18022679')).toEqual({kind: 'numeric', databaseId: '18022679'});
+        });
+
+        test('a URL anchor resolves to the same numeric selector', () => {
+            // The two spellings a peer actually holds. Both previously filtered every comment away
+            // and returned an empty list with no error.
+            expect(parseCommentId('discussioncomment-18022679')).toEqual({kind: 'numeric', databaseId: '18022679'});
+            expect(parseCommentId('issuecomment-5301580683')).toEqual({kind: 'numeric', databaseId: '5301580683'});
+            expect(parseCommentId('pullrequestreviewcomment-99')).toEqual({kind: 'numeric', databaseId: '99'});
+        });
+
+        test('a full comment URL reduces to its anchor', () => {
+            expect(parseCommentId('https://github.com/neomjs/neo/issues/17151#issuecomment-5301580683'))
+                .toEqual({kind: 'numeric', databaseId: '5301580683'});
+            expect(parseCommentId('https://github.com/neomjs/neo/discussions/17136#discussioncomment-18022679'))
+                .toEqual({kind: 'numeric', databaseId: '18022679'});
+        });
+
+        test('whitespace around a pasted id is tolerated', () => {
+            expect(parseCommentId('  issuecomment-42  ')).toEqual({kind: 'numeric', databaseId: '42'});
+        });
+
+        test('a URL that is NOT a comment link is malformed, not an opaque node ID', () => {
+            // The dangerous near-miss: admitting these as node IDs would turn a caller's wrong link
+            // back into a silent empty result, which is the defect being removed.
+            expect(parseCommentId('https://github.com/neomjs/neo/issues/17151')).toBeNull();
+            expect(parseCommentId('https://github.com/neomjs/neo/pull/17161/files')).toBeNull();
+        });
+
+        test('unrecognised shapes are malformed', () => {
+            for (const bad of ['', '   ', 'not an id', 'issuecomment-', 'comment-abc', '#', null, undefined, 42, {}, []]) {
+                expect(parseCommentId(bad), `must reject ${JSON.stringify(bad)}`).toBeNull();
+            }
+        });
+    });
+
+    test.describe('commentMatches', () => {
+        const comment = {id: 'IC_kwDOabc', databaseId: 5301580683, body: 'x'};
+
+        test('matches on node ID', () => {
+            expect(commentMatches(comment, parseCommentId('IC_kwDOabc'))).toBe(true);
+            expect(commentMatches(comment, parseCommentId('IC_kwDOother'))).toBe(false);
+        });
+
+        test('matches on numeric id, whatever spelling produced it', () => {
+            for (const spelling of [
+                '5301580683',
+                'issuecomment-5301580683',
+                'https://github.com/neomjs/neo/issues/1#issuecomment-5301580683'
+            ]) {
+                expect(commentMatches(comment, parseCommentId(spelling)), spelling).toBe(true);
+            }
+
+            expect(commentMatches(comment, parseCommentId('issuecomment-999'))).toBe(false);
+        });
+
+        test('a node missing databaseId does not match a numeric selector, and does not throw', () => {
+            // A query that forgot the field degrades to "no match" — visible via the absent-vs-
+            // malformed distinction — rather than taking the request down.
+            expect(commentMatches({id: 'IC_x'}, parseCommentId('123'))).toBe(false);
+        });
+
+        test('null inputs are false, never a throw', () => {
+            expect(commentMatches(null, parseCommentId('123'))).toBe(false);
+            expect(commentMatches(comment, null)).toBe(false);
+        });
+    });
+
+    test.describe('malformedCommentIdError — reported, never silently filtered', () => {
+        const err = malformedCommentIdError('comment_id', 'nonsense');
+
+        test('names the parameter, the value, and every accepted form', () => {
+            expect(err.code).toBe('MALFORMED_COMMENT_ID');
+            expect(err.message).toContain('comment_id');
+            expect(err.message).toContain('nonsense');
+            expect(err.message).toContain('node ID');
+            expect(err.message).toContain('numeric');
+            expect(err.message).toContain('anchor');
+        });
+
+        test('the accepted-forms list is what the error actually quotes', () => {
+            // Guards the drift where the constant is updated and the message keeps the old wording.
+            expect(err.message).toContain(ACCEPTED_COMMENT_ID_FORMS);
+        });
+    });
+
+    test.describe('omitScopedBody — the payload half', () => {
+        const conversation = {title: 'T', body: 'x'.repeat(26_224), author: {login: 'a'}, comments: {nodes: [{id: '1'}]}};
+        const scoped       = omitScopedBody(conversation);
+
+        test('drops the body and says so', () => {
+            expect(scoped.body).toBeUndefined();
+            expect(scoped.bodyOmitted).toBe(true);
+        });
+
+        test('keeps everything else the caller scoped FOR', () => {
+            expect(scoped.title).toBe('T');
+            expect(scoped.author).toEqual({login: 'a'});
+            expect(scoped.comments.nodes).toEqual([{id: '1'}]);
+        });
+
+        test('the scoped payload is bounded by what it returned, not by the thread head', () => {
+            // The assertion that fails if the body ever reappears — the ticket's explicit ask.
+            expect(JSON.stringify(scoped).length).toBeLessThan(conversation.body.length);
+        });
+
+        test('a consumer can tell "scoped away" from "empty body"', () => {
+            // Both have no readable body; only the flag distinguishes them.
+            expect(omitScopedBody({title: 'T', body: ''}).bodyOmitted).toBe(true);
+        });
+
+        test('null input degrades rather than throwing', () => {
+            expect(omitScopedBody(null)).toEqual({bodyOmitted: true});
+        });
+    });
+});

--- a/test/playwright/unit/ai/services/github-workflow/commentSelector.spec.mjs
+++ b/test/playwright/unit/ai/services/github-workflow/commentSelector.spec.mjs
@@ -3,6 +3,7 @@ import {test, expect} from '@playwright/test';
 import {
     ACCEPTED_COMMENT_ID_FORMS,
     commentMatches,
+    isSelectorPresent,
     malformedCommentIdError,
     omitScopedBody,
     parseCommentId
@@ -50,14 +51,51 @@ test.describe('commentSelector', () => {
                 expect(parseCommentId(bad), `must reject ${JSON.stringify(bad)}`).toBeNull();
             }
         });
+
+        test('a LEGACY base64 node ID is accepted — it is still live and resolvable (#17142 RC1)', () => {
+            // `012:IssueComment557007126`. Strict equality accepted this before the selector existed,
+            // so rejecting it was a REGRESSION on the one spelling that already worked, not a
+            // tightening. Admitted by DECODING, never by "looks base64".
+            expect(parseCommentId('MDEyOklzc3VlQ29tbWVudDU1NzAwNzEyNg=='))
+                .toEqual({kind: 'node', nodeId: 'MDEyOklzc3VlQ29tbWVudDU1NzAwNzEyNg=='});
+        });
+
+        test('the near-misses an open grammar used to admit are rejected (#17142 RC1)', () => {
+            // Every one of these previously produced a VALID selector and then degraded to
+            // well-formed-but-absent — recreating the silent-empty defect the module exists to remove.
+            // The original spec tested `'not an id'` WITH SPACES, which the pattern happened to reject;
+            // it never tested the underscore form one character away from the real shape.
+            expect(parseCommentId('evilcomment-123'), 'open anchor prefix').toBeNull();
+            expect(parseCommentId('not_an_id'),       'word_word').toBeNull();
+            expect(parseCommentId('bogus_123'),       'word_digits').toBeNull();
+            expect(parseCommentId('ic_kwDODSospM4hM0EW'), 'lowercase type prefix').toBeNull();
+            expect(parseCommentId('aGVsbG8gd29ybGQ='), 'base64 of unrelated text').toBeNull();
+            expect(parseCommentId('MDEyOklzc3VlQ29tbWVudDU1NzAwNzEyNg'), 'base64 that does not round-trip').toBeNull();
+        });
+    });
+
+    test.describe('isSelectorPresent — presence must invoke parsing', () => {
+        test('an EMPTY STRING is present, so it reaches the parser and errors', () => {
+            // The services branched on `if (comment_id)`, so '' skipped the selector path and returned
+            // the FULL unscoped conversation — a blank address silently answered with the whole thread.
+            expect(isSelectorPresent('')).toBe(true);
+            expect(parseCommentId('')).toBeNull();
+        });
+
+        test('only undefined and null are absent', () => {
+            expect(isSelectorPresent(undefined)).toBe(false);
+            expect(isSelectorPresent(null)).toBe(false);
+            expect(isSelectorPresent('IC_kwDODSospM4hM0EW')).toBe(true);
+            expect(isSelectorPresent(0)).toBe(true);
+        });
     });
 
     test.describe('commentMatches', () => {
-        const comment = {id: 'IC_kwDOabc', databaseId: 5301580683, body: 'x'};
+        const comment = {id: 'IC_kwDODSospM4hM0EW', databaseId: 5301580683, body: 'x'};
 
         test('matches on node ID', () => {
-            expect(commentMatches(comment, parseCommentId('IC_kwDOabc'))).toBe(true);
-            expect(commentMatches(comment, parseCommentId('IC_kwDOother'))).toBe(false);
+            expect(commentMatches(comment, parseCommentId('IC_kwDODSospM4hM0EW'))).toBe(true);
+            expect(commentMatches(comment, parseCommentId('IC_kwDODSospM4hZZZZ'))).toBe(false);
         });
 
         test('matches on numeric id, whatever spelling produced it', () => {


### PR DESCRIPTION
Resolves neomjs/neo#17142

> 🌿 An id it could not read answered exactly like a thread with nothing in it. Now the tool says which one you got — and stops charging you for the head you never asked for.

`comment_id` now accepts the spelling a peer actually holds — node ID, numeric database id, `issuecomment-N` / `discussioncomment-N` anchor, or a full comment URL — and reports an unrecognised shape as an error instead of an empty comment list. Scoped requests stop returning the parent body, so fetching one comment no longer costs the thread head.

Evidence: L2 (pure id-resolution and payload-shape assertions over recorded fixtures, plus service-level wiring arms across all three conversation services) → L2 required (the ticket's own evidence class; neither AC needs a live GitHub call). Residual: none.

Round 1 shipped four defects that 20/20 green did not cover, found by @neo-gpt's exact-head audit and recorded in full at [issuecomment-5302081600](https://github.com/neomjs/neo/pull/17166#issuecomment-5302081600). The sharpest was a **regression**: the node-ID pattern rejected a live, resolvable legacy id that the previous strict equality accepted, so a change premised on "stop failing silently" broke the one spelling that already worked. All four are repaired in `386fe4d51c`.

## Deltas from ticket

**I reproduced both defects independently before claiming, and the reproduction sharpened one of them.** Calling `get_conversation({issue_number, comment_id})` with a *valid* node ID returned the addressed comment **and** the full 6KB issue body — defect 2, exactly as filed. Separately I passed an id that was not present on that issue and got `comments: []` with no error — defect 1. I read that as "the tool returned the body", re-fetched the thread with `gh`, and paid the cost the parameter exists to avoid. That is the failure mode the ticket describes, encountered from the outside without knowing the ticket existed.

**A URL that is not a comment link is malformed, not an opaque node ID.** The ticket asked for four accepted spellings; it did not say what happens to a fifth. `https://…/issues/17151` (no anchor) is now rejected rather than admitted as an opaque id — admitting it would turn a caller's wrong link straight back into a silent empty result, which is the defect being removed. Two arms cover it.

**`bodyOmitted: true` rather than the field silently vanishing.** The ticket says a scoped request omits the body. A consumer that finds no `body` still has to distinguish "scoped away" from "this thread has an empty body", so the omission is announced. An arm asserts that distinction.

**The numeric arm needs `databaseId`, which none of the three conversation queries selected.** Matching an anchor or a bare number against a node ID is impossible without it, so `GET_ISSUE_CONVERSATION`, `GET_CONVERSATION` (PR) and `GET_DISCUSSION_CONVERSATION` now select it. A node missing the field degrades to "no match" rather than throwing, so a query that forgets it stays visible instead of taking requests down.

**One existing assertion changed, and it was encoding the defect.** `DiscussionService.spec.mjs` required `body === 'Discussion body'` on a `comment_id` request. That is precisely the behavior AC-3 removes, so it now asserts absence plus `bodyOmitted`. Flagging it because a changed existing assertion deserves to be looked at rather than skimmed.

## Test Evidence

```
npx playwright test -c test/playwright/playwright.config.unit.mjs \
  test/playwright/unit/ai/services/github-workflow/ \
  test/playwright/unit/ai/mcp/validation/ --workers=1
→ 741 passed (9.8s)   [round 2, post-rebase]
```

**Round-2 arms** — the wiring surfaces that had no service-level coverage, which is why round 1's defects survived to review:

| Added | Covers |
|---|---|
| `commentSelector.spec.mjs` | the **legacy base64 node ID** (the regression) · six near-misses an open grammar admitted (`evilcomment-123`, `not_an_id`, `bogus_123`, lowercase prefix, base64 of unrelated text, base64 that does not round-trip) · `isSelectorPresent` proving `''` is present and reaches the parser |
| `IssueService.spec.mjs` | comment_id across all four spellings with scoped-body assertions · malformed-vs-absent · the empty-string case · since_comment_id incl. its malformed path |
| `PullRequestService.spec.mjs` | the same four, on a surface that previously had **no** selector wiring arms at all |

**Red-proved, not asserted:**

| Mutation | Result |
|---|---|
| restore the open `NODE_ID_PATTERN` | near-miss arm **fails** |
| remove `isLegacyNodeId` from the node branch | regression arm **fails** |

Production restored byte-identical after each (`diff -q` against a pre-mutation copy).

`commentSelector.spec.mjs` — 20 new arms over the pure surface:

| Group | Covers |
|---|---|
| `parseCommentId` | all four spellings incl. both anchor families and full URLs · whitespace tolerance · a non-comment URL rejected · 11 malformed inputs incl. non-strings |
| `commentMatches` | node arm · numeric arm reached from all three numeric spellings · a node missing `databaseId` returns false without throwing · null inputs |
| `malformedCommentIdError` | names the parameter, the offending value, and every accepted form — asserted against the exported constant so the message cannot drift from it |
| `omitScopedBody` | body dropped and announced · everything scoped-for retained · **payload smaller than the body it replaced** (the assertion that fails if the body reappears) · empty-body vs scoped-away distinguishable · null degrades |

`DiscussionService.spec.mjs` — 4 arms through the service against its fixture: the anchor/numeric/URL spellings all resolve to the same comment, a malformed id returns `MALFORMED_COMMENT_ID` with no `comments` key, a well-formed-but-absent id returns an empty list with no error, and the scoped payload omits the body.

Directly touched surfaces: `shared/commentSelector.mjs` (new) — its own spec. `IssueService` / `PullRequestService` / `DiscussionService` — the suite above, 741 green. `openapi.yaml` — `lint-openapi-service-parity` ran green in the commit hook, twice (both trigger globs).

## Post-Merge Validation

Nothing is owed after merge. Both ACs are pure resolution and payload-shape properties, armed above; the ticket itself classifies this L2 for that reason.

The next peer hand-off that pastes an anchor is the behavior working, not a validation debt — and this PR's own thread is a place to try it.

## Commits

- `7264e2f824` — the shared selector, its arms, the three service call sites, `databaseId` on the three queries, the openapi descriptions, and the DiscussionService contract arms.
- `386fe4d51c` — round-2 repair after @neo-gpt's exact-head audit: legacy node IDs re-accepted (a regression round 1 introduced), the grammar closed in both directions, presence made to invoke parsing, every public schema/JSDoc surface caught up, and service-level wiring arms added for issue and PR. Both new selector arms red-proved.

## Evolution

The fix started as "normalize the id to a node ID before querying", which would have needed an extra API round-trip to translate a numeric id. Selecting `databaseId` on the existing queries and matching on *either* identity removes the translation step entirely — no extra call, and the resolver stays pure and testable without a network.

Related: neomjs/neo-agent-brain#35
Refs #17136

Authored by Vega (Claude Opus 5, Claude Code). Session 5cd926fa-77e1-4309-8bbf-ca563ab07403.
