### PR TITLE
fix(ai): fail the embedding oversize guard closed on unrecognized providers and give the provider selector a domain (#17155)

### DIFF
--- a/ai/configBase.mjs
+++ b/ai/configBase.mjs
@@ -2,6 +2,7 @@ import os                                                          from 'os';
 import path                                                        from 'path';
 import {fileURLToPath}                                             from 'url';
 import ConfigProvider, {leaf}                                      from './ConfigProvider.mjs';
+import {parseEmbeddingProviderEnv}                                 from './embeddingProviders.mjs';
 import {EMBEDDING_SAFE_PROCESSING_LIMIT_TOKENS}                    from './embeddingSafeBand.mjs';
 import {CANONICAL_PLANE_ID, parsePlaneIdEnv, resolvePlaneDataRoot} from './planeConfig.mjs';
 
@@ -716,10 +717,12 @@ class ConfigBase extends ConfigProvider {
              * @summary Deployment-wide embedding provider selector.
              *
              * Shared by Memory Core embedding consumers and Knowledge Base ingestion
-             * paths.
+             * paths. The domain is the implemented provider set: the custom parse hook
+             * throws a named diagnostic on an unknown name at config resolution, because
+             * an unrecognized provider must never boot quietly.
              * @type {String}
              */
-            embeddingProvider: leaf('openAiCompatible', 'NEO_EMBEDDING_PROVIDER', 'string'),
+            embeddingProvider: leaf('openAiCompatible', 'NEO_EMBEDDING_PROVIDER', 'string', {parse: parseEmbeddingProviderEnv}),
             /**
              * @summary Deployment-wide Ollama provider defaults.
              *

--- a/ai/embeddingProviders.mjs
+++ b/ai/embeddingProviders.mjs
@@ -1,0 +1,68 @@
+/**
+ * @module ai/embeddingProviders
+ * @summary The implemented embedding-provider vocabulary as ONE shared constant, plus the env
+ * parse hook that makes an unknown provider name a loud config-resolution failure.
+ *
+ * The set lives here exactly once so the `AiConfig` leaf (`embeddingProvider`) declares its
+ * domain FROM this module and every guardrail/dispatch site measures against the same
+ * vocabulary. Before this module existed, the ingestion guard kept its own hand-maintained
+ * provider subset and the leaf accepted any string, so a typo silently disabled the
+ * oversize-input guard; the dispatch vocabulary already existed as prose inside
+ * `TextEmbeddingService`'s unsupported-provider throws.
+ *
+ * Plain by contract (no Neo imports, no env reads outside the parse hook): config files must
+ * be able to consume this module before any Provider exists.
+ */
+
+/**
+ * The embedding providers with a production dispatch path, in canonical (alphabetical) order.
+ * @type {ReadonlyArray<String>}
+ */
+export const IMPLEMENTED_EMBEDDING_PROVIDERS = Object.freeze(['gemini', 'openAiCompatible', 'ollama']);
+
+/**
+ * @summary Env parser for the `embeddingProvider` leaf — the loud half of the domain contract.
+ *
+ * Follows the `parsePlaneIdEnv` convention: an unset value is no opinion (`undefined`, so the
+ * leaf default applies); a set-but-unknown value throws a named diagnostic at config
+ * resolution, because an unrecognized provider must never boot quietly.
+ *
+ * @param {String} envVarName The bound env var (diagnostic text names it).
+ * @param {Object} [options]
+ * @param {Object} [options.env=process.env] Environment source.
+ * @returns {String|undefined} The valid provider name, or `undefined` when unset.
+ */
+export function parseEmbeddingProviderEnv(envVarName, {env = process.env} = {}) {
+    const rawValue = env[envVarName];
+
+    if (rawValue === undefined || rawValue === null || rawValue === '') return;
+
+    if (!IMPLEMENTED_EMBEDDING_PROVIDERS.includes(rawValue)) {
+        throw new Error(
+            `embeddingProviders: ${envVarName}="${rawValue}" is not an implemented embedding provider — ` +
+            `expected one of: ${IMPLEMENTED_EMBEDDING_PROVIDERS.join(', ')}.`
+        );
+    }
+
+    return rawValue
+}
+
+/**
+ * @summary Resolves the display model for a provider from the resolved config tree.
+ *
+ * The single home of a branch both ingestion guardrail resolvers hand-rolled — and neither
+ * copy could resolve `gemini`, whose model lives at the tree's top-level historical leaf. An
+ * unrecognized provider resolves to its own name: in that defect case the name is the most
+ * informative diagnostic label available.
+ *
+ * @param {Object} options
+ * @param {String} options.embeddingProvider The resolved provider selector.
+ * @param {Object} options.aiConfig          The resolved config tree (read at the caller's use site).
+ * @returns {String}
+ */
+export function resolveEmbeddingProviderModel({embeddingProvider, aiConfig}) {
+    return embeddingProvider === 'ollama'          ? aiConfig.ollama.embeddingModel
+         : embeddingProvider === 'openAiCompatible' ? aiConfig.openAiCompatible.embeddingModel
+         : embeddingProvider === 'gemini'           ? aiConfig.embeddingModel
+         : embeddingProvider;
+}

--- a/ai/services/knowledge-base/IngestionService.mjs
+++ b/ai/services/knowledge-base/IngestionService.mjs
@@ -35,6 +35,8 @@ import os              from 'os';
 import path            from 'path';
 import * as yaml       from 'js-yaml';
 import {fileURLToPath} from 'url';
+import {IMPLEMENTED_EMBEDDING_PROVIDERS, resolveEmbeddingProviderModel}
+                       from '../../embeddingProviders.mjs';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname  = path.dirname(__filename);
@@ -71,7 +73,6 @@ export function resolveIdleProgressStatus(lastRunSummary) {
     return 'idle';
 }
 
-const LOCAL_EMBEDDING_PROVIDERS          = new Set(['openAiCompatible', 'ollama']);
 const MATERIALIZATION_ATTEMPT_ID_PATTERN = /^[a-f0-9]{32}$/u;
 const MATERIALIZATION_DIGEST_PATTERN     = /^[a-f0-9]{64}$/u;
 const TENANT_AWARE_CHUNK_ID_PATTERN      = /^[a-f0-9]{64}$/u;
@@ -1383,26 +1384,24 @@ class IngestionService extends Base {
     }
 
     /**
-     * @summary Resolves the local embedding input-budget guardrail for ingestion diagnostics.
-     * @returns {{enabled: Boolean, embeddingProvider: String, contextLimitTokens: Number, safeProcessingLimitTokens: Number, model: String}}
+     * @summary Resolves the embedding input-budget guardrail for ingestion diagnostics.
+     *
+     * The band is provider-independent, so the guard measures EVERY provider — `recognized`
+     * is a diagnostic flag for skip receipts, never a licence to skip the measurement.
+     * @returns {{recognized: Boolean, embeddingProvider: String, contextLimitTokens: Number, safeProcessingLimitTokens: Number, model: String}}
      * @protected
      */
     resolveEmbeddingInputGuardrail() {
         const embeddingProvider         = mcConfig.embeddingProvider;
         const contextLimitTokens        = Number(aiConfig.localModels.embedding.contextLimitTokens);
         const safeProcessingLimitTokens = Number(aiConfig.localModels.embedding.safeProcessingLimitTokens);
-        const model                     = embeddingProvider === 'ollama'
-            ? aiConfig.ollama.embeddingModel
-            : embeddingProvider === 'openAiCompatible'
-                ? aiConfig.openAiCompatible.embeddingModel
-                : embeddingProvider;
 
         return {
-            enabled: LOCAL_EMBEDDING_PROVIDERS.has(embeddingProvider),
+            recognized: IMPLEMENTED_EMBEDDING_PROVIDERS.includes(embeddingProvider),
             embeddingProvider,
             contextLimitTokens,
             safeProcessingLimitTokens,
-            model
+            model     : resolveEmbeddingProviderModel({embeddingProvider, aiConfig})
         };
     }
 
@@ -1417,11 +1416,14 @@ class IngestionService extends Base {
     }
 
     /**
-     * @summary Drops local-provider oversized chunks before writing the VectorService temp JSONL.
+     * @summary Drops oversized chunks before writing the VectorService temp JSONL — for EVERY
+     * provider, recognized or not.
      *
      * `VectorService` remains the final safety net, but doing the same bounded check here
      * gives ingestion callers and daemon diagnostics a durable skip signal even when no
-     * graph row can be written for the offending source file.
+     * graph row can be written for the offending source file. The band is provider-independent;
+     * an unrecognized provider is exactly the case where the limit is least known, so the
+     * measurement never gates on recognition.
      *
      * @param {Object} options
      * @param {Array<Object>} options.chunks Normalized parsed chunks.
@@ -1432,10 +1434,6 @@ class IngestionService extends Base {
      */
     filterEmbeddingInputBudget({chunks, tenantContext, summary}) {
         const guardrail = this.resolveEmbeddingInputGuardrail();
-
-        if (!guardrail.enabled) {
-            return chunks;
-        }
 
         const embeddable = [];
 

--- a/ai/services/knowledge-base/VectorService.mjs
+++ b/ai/services/knowledge-base/VectorService.mjs
@@ -6,6 +6,8 @@ import TextEmbeddingService, {
 import mcConfig                from '../../mcp/server/memory-core/config.mjs';
 import {isProviderTimeoutCode} from '../../provider/createTimeoutError.mjs';
 import Base                    from '../../../src/core/Base.mjs';
+import {IMPLEMENTED_EMBEDDING_PROVIDERS, resolveEmbeddingProviderModel}
+                              from '../../embeddingProviders.mjs';
 import {
     bytesToTokens,
     emitConsumerFriction
@@ -440,26 +442,23 @@ class VectorService extends Base {
     }
 
     /**
-     * Resolves the local embedding-model guardrail used before provider invocation.
+     * Resolves the embedding-model guardrail consulted before provider invocation.
      *
-     * @returns {{enabled: Boolean, contextLimitTokens: Number, safeProcessingLimitTokens: Number, model: String}}
+     * The band is provider-independent, so the guard measures EVERY provider — `recognized`
+     * is a diagnostic flag for skip receipts, never a licence to skip the measurement.
+     *
+     * @returns {{recognized: Boolean, contextLimitTokens: Number, safeProcessingLimitTokens: Number, model: String}}
      */
     resolveEmbeddingGuardrail() {
-        const localEmbeddingProviders   = new Set(['openAiCompatible', 'ollama']);
         const embeddingProvider         = mcConfig.embeddingProvider;
         const contextLimitTokens        = Number(aiConfig.localModels.embedding.contextLimitTokens);
         const safeProcessingLimitTokens = Number(aiConfig.localModels.embedding.safeProcessingLimitTokens);
-        const model                     = embeddingProvider === 'ollama'
-            ? aiConfig.ollama.embeddingModel
-            : embeddingProvider === 'openAiCompatible'
-                ? aiConfig.openAiCompatible.embeddingModel
-                : embeddingProvider;
 
         return {
-            enabled                  : localEmbeddingProviders.has(embeddingProvider),
+            recognized: IMPLEMENTED_EMBEDDING_PROVIDERS.includes(embeddingProvider),
             contextLimitTokens,
             safeProcessingLimitTokens,
-            model
+            model     : resolveEmbeddingProviderModel({embeddingProvider, aiConfig})
         };
     }
 
@@ -529,10 +528,6 @@ class VectorService extends Base {
     expandOversizedEmbeddingChunks(chunks) {
         const guardrail = this.resolveEmbeddingGuardrail();
 
-        if (!guardrail.enabled) {
-            return chunks;
-        }
-
         const expanded = [];
 
         for (const chunk of chunks) {
@@ -540,6 +535,13 @@ class VectorService extends Base {
                   evaluation = this.measureEmbeddingInput({text: inputText, guardrail});
 
             if (!evaluation.skip) {
+                expanded.push(chunk);
+                continue;
+            }
+
+            if (evaluation.measured === false) {
+                // An unmeasurable input cannot be split-planned against an unresolvable band;
+                // keep it whole — the pre-invocation boundary refuses it with the same flag.
                 expanded.push(chunk);
                 continue;
             }
@@ -736,21 +738,28 @@ class VectorService extends Base {
     /**
      * Measures provider input size without recording a final refusal diagnostic.
      *
+     * Measurement is unconditional: no provider recognition check may wave an input through
+     * unmeasured. The one unmeasurable case — a band that does not resolve to a positive
+     * finite number — refuses (`skip: true`) and says so (`measured: false`), because
+     * "cannot check" must never read as "checked, tiny".
+     *
      * @param {Object} options
      * @param {String} options.text Provider input text.
      * @param {Object} options.guardrail Resolved embedding guardrail.
-     * @returns {{skip: Boolean, inputBytes: Number, inputTokensEstimate: Number}}
+     * @returns {{skip: Boolean, measured: Boolean, inputBytes: Number, inputTokensEstimate: Number}}
      */
     measureEmbeddingInput({text, guardrail}) {
-        if (!guardrail.enabled) {
-            return {skip: false, inputBytes: 0, inputTokensEstimate: 0};
+        const inputBytes          = Buffer.byteLength(text || '', 'utf8'),
+              inputTokensEstimate = bytesToTokens(inputBytes),
+              band                = Number(guardrail.safeProcessingLimitTokens);
+
+        if (!Number.isFinite(band) || band <= 0) {
+            return {skip: true, measured: false, inputBytes, inputTokensEstimate};
         }
 
-        const inputBytes          = Buffer.byteLength(text || '', 'utf8');
-        const inputTokensEstimate = bytesToTokens(inputBytes);
-
         return {
-            skip: inputTokensEstimate > guardrail.safeProcessingLimitTokens,
+            skip    : inputTokensEstimate > band,
+            measured: true,
             inputBytes,
             inputTokensEstimate
         };
@@ -763,14 +772,17 @@ class VectorService extends Base {
      * @param {Object} options.chunk Tenant-stamped chunk.
      * @param {String} options.text Provider input text.
      * @param {Object} options.guardrail Resolved embedding guardrail.
-     * @returns {{skip: Boolean, inputBytes: Number, inputTokensEstimate: Number}}
+     * @returns {{skip: Boolean, measured: Boolean, inputBytes: Number, inputTokensEstimate: Number}}
      */
     evaluateEmbeddingInput({chunk, text, guardrail}) {
-        const {skip, inputBytes, inputTokensEstimate} = this.measureEmbeddingInput({text, guardrail});
+        const evaluation = this.measureEmbeddingInput({text, guardrail});
 
-        if (!skip) {
-            return {skip: false, inputBytes, inputTokensEstimate};
+        if (!evaluation.skip) {
+            return evaluation;
         }
+
+        const {inputBytes, inputTokensEstimate} = evaluation,
+              unmeasurable                      = evaluation.measured === false;
 
         emitConsumerFriction({
             assetRef                 : chunk.id || chunk.source || chunk.name || 'kb-chunk',
@@ -784,7 +796,9 @@ class VectorService extends Base {
             contextLimitTokens       : guardrail.contextLimitTokens,
             safeProcessingLimitTokens: guardrail.safeProcessingLimitTokens,
             serviceDomain            : 'other',
-            note                     : 'KB embedding input exceeds safe processing band; split or reduce the source chunk before embedding.'
+            note                     : unmeasurable
+                ? 'Embedding safe-processing band is unresolvable; refusing to send an unmeasured input.'
+                : 'KB embedding input exceeds safe processing band; split or reduce the source chunk before embedding.'
         });
 
         logger.warn('[VectorService] Skipping over-budget embedding chunk before provider invocation.', {
@@ -798,7 +812,7 @@ class VectorService extends Base {
             contextLimitTokens       : guardrail.contextLimitTokens
         });
 
-        return {skip: true, inputBytes, inputTokensEstimate};
+        return {...evaluation, skip: true};
     }
 
     /**

--- a/ai/services/memory-core/MemoryCoreRecorderService.mjs
+++ b/ai/services/memory-core/MemoryCoreRecorderService.mjs
@@ -185,6 +185,11 @@ class MemoryCoreRecorderService extends Base {
 
     /**
      * Initializes the SQLite schema for Memory Core MCP tool telemetry.
+     *
+     * The database path resolves from an injected `this.dbPath` first and the
+     * `config.storagePaths.graph` leaf second: unit suites rebind this worker-shared singleton to
+     * a fixture database by construction, without reaching into the runtime config overlay.
+     * Production leaves `dbPath` unset, so the config leaf wins there.
      * @returns {Promise<void>}
      */
     async initAsync() {
@@ -193,11 +198,13 @@ class MemoryCoreRecorderService extends Base {
         if (this.db) return;
 
         try {
-            const dbPath = config.storagePaths.graph;
+            const dbPath = this.dbPath || config.storagePaths.graph;
             if (!dbPath) {
                 logger.warn('[MemoryCoreRecorderService] storagePaths.graph not configured. Disabling tool telemetry.');
                 return;
             }
+
+            this.dbPath = dbPath;
 
             this.providerActivityStatusWriter = createProviderActivityStatusWriter({
                 dbPath,
@@ -728,7 +735,9 @@ class MemoryCoreRecorderService extends Base {
         let   reembedRatio = this.getReembedRatioProjection({sinceTs});
 
         const sidecarStatus = inspectProviderActivityStatus({
-            dbPath: config.storagePaths.graph,
+            // The path this service actually opened — never a re-read of the config singleton,
+            // whose cached leaves can belong to another suite's env inside a shared worker.
+            dbPath: this.dbPath || config.storagePaths.graph,
             sinceTs
         }).status;
 

--- a/test/playwright/unit/ai/deploy/OllamaProviderEnvCoordinates.spec.mjs
+++ b/test/playwright/unit/ai/deploy/OllamaProviderEnvCoordinates.spec.mjs
@@ -79,9 +79,10 @@ const REQUIRED = [{
 }, {
     service : 'kb-server',
     env     : 'NEO_OLLAMA_EMBEDDING_MODEL',
-    consumer: 'ai/services/knowledge-base/VectorService.mjs',
+    consumer: 'ai/embeddingProviders.mjs',
     anchors : ['? aiConfig.ollama.embeddingModel'],
-    why     : 'the ingest path names the embedding model when the provider is ollama, and the model ' +
+    why     : 'the ingest path names the embedding model when the provider is ollama — VectorService ' +
+              'and IngestionService both resolve it through this shared guard — and the model ' +
               'decides the vector dimension the corpus is written with'
 }, {
     service : 'kb-server',

--- a/test/playwright/unit/ai/embeddingProviders.spec.mjs
+++ b/test/playwright/unit/ai/embeddingProviders.spec.mjs
@@ -1,0 +1,44 @@
+import {test, expect} from '@playwright/test';
+import {
+    IMPLEMENTED_EMBEDDING_PROVIDERS,
+    parseEmbeddingProviderEnv,
+    resolveEmbeddingProviderModel
+} from '../../../../ai/embeddingProviders.mjs';
+
+// Pure module — no Neo runtime, no config singleton; the aiConfig tree is a plain stub. Mirrors
+// planeConfig.spec.mjs (same config-legible module class).
+
+test.describe('ai/embeddingProviders — the shared provider vocabulary', () => {
+    test('the implemented set is exact, alphabetical, and frozen', () => {
+        expect([...IMPLEMENTED_EMBEDDING_PROVIDERS]).toEqual(['gemini', 'openAiCompatible', 'ollama']);
+        expect(Object.isFrozen(IMPLEMENTED_EMBEDDING_PROVIDERS)).toBe(true);
+    });
+
+    test('parseEmbeddingProviderEnv: unset is no opinion, a valid name passes through', () => {
+        expect(parseEmbeddingProviderEnv('NEO_EMBEDDING_PROVIDER', {env: {}})).toBeUndefined();
+        expect(parseEmbeddingProviderEnv('NEO_EMBEDDING_PROVIDER', {env: {NEO_EMBEDDING_PROVIDER: ''}})).toBeUndefined();
+        expect(parseEmbeddingProviderEnv('NEO_EMBEDDING_PROVIDER', {env: {NEO_EMBEDDING_PROVIDER: 'gemini'}})).toBe('gemini');
+    });
+
+    test('parseEmbeddingProviderEnv: an unknown name throws a named diagnostic at config resolution', () => {
+        // The defect this closes: `openaicompatible` (a typo) used to parse clean and silently
+        // disabled the oversize-input guard on trees that keyed the guard on recognition.
+        expect(() => parseEmbeddingProviderEnv('NEO_EMBEDDING_PROVIDER', {env: {NEO_EMBEDDING_PROVIDER: 'openaicompatible'}}))
+            .toThrow(/NEO_EMBEDDING_PROVIDER="openaicompatible" is not an implemented embedding provider — expected one of: gemini, openAiCompatible, ollama/);
+    });
+
+    test('resolveEmbeddingProviderModel: every implemented provider resolves its own model leaf', () => {
+        const aiConfig = {
+            embeddingModel  : 'gemini-embedding-001',
+            ollama          : {embeddingModel: 'qwen3-embedding'},
+            openAiCompatible: {embeddingModel: 'text-embedding-qwen3-embedding-8b'}
+        };
+
+        expect(resolveEmbeddingProviderModel({embeddingProvider: 'ollama', aiConfig})).toBe('qwen3-embedding');
+        expect(resolveEmbeddingProviderModel({embeddingProvider: 'openAiCompatible', aiConfig})).toBe('text-embedding-qwen3-embedding-8b');
+        // The branch both hand-rolled resolvers lacked: gemini's model lives at the top-level leaf.
+        expect(resolveEmbeddingProviderModel({embeddingProvider: 'gemini', aiConfig})).toBe('gemini-embedding-001');
+        // An unrecognized provider keeps its own name as the diagnostic label.
+        expect(resolveEmbeddingProviderModel({embeddingProvider: 'not-a-provider', aiConfig})).toBe('not-a-provider');
+    });
+});

--- a/test/playwright/unit/ai/mcp/server/memory-core/config.template.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/memory-core/config.template.spec.mjs
@@ -250,6 +250,17 @@ test.describe('Memory Core Config (#10010)', () => {
         );
     });
 
+    test('invalid NEO_EMBEDDING_PROVIDER throws a named diagnostic at config resolution', () => {
+        process.env.NEO_EMBEDDING_PROVIDER = 'openaicompatible';
+
+        // The leaf is Tier-1-owned, so the throwing parse hook (parseEmbeddingProviderEnv) fires
+        // at the Tier-1 root construction inside #applyEnvLayer — an unrecognized provider must
+        // never boot quietly.
+        expect(() => Neo.create(RootConfigBase)).toThrow(
+            /NEO_EMBEDDING_PROVIDER="openaicompatible" is not an implemented embedding provider/
+        );
+    });
+
     test('storagePaths.graph resolves by construction from the useTestDatabase toggle (ADR 0019 §A4/A8; #12491)', () => {
         // The reshape replaced the inline `process.env.UNIT_TEST_MODE ? ':memory:' : prod` leaf ternary
         // with two declarative leaves + a formula. Under the unit suite (UNIT_TEST_MODE=true) the toggle

--- a/test/playwright/unit/ai/services/knowledge-base/IngestionService.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/IngestionService.spec.mjs
@@ -101,7 +101,7 @@ function createGraphStub() {
 
 function createEmbeddingGuardrail(overrides = {}) {
     return {
-        enabled                  : true,
+        recognized               : true,
         embeddingProvider        : 'openAiCompatible',
         contextLimitTokens       : 100,
         safeProcessingLimitTokens: 80,
@@ -1109,19 +1109,53 @@ test.describe('IngestionService.ingestSourceFiles', () => {
         });
     });
 
-    test('does not apply local embedding caps to non-local ingestion providers', async () => {
+    test('applies the band on a non-local provider too — an over-band input is refused with a receipt, never waved through unmeasured', async () => {
+        // The pre-fix shape keyed the guard on a hand-maintained local set: gemini ingestion
+        // skipped the measurement entirely and this document sailed past the band. The guard
+        // now measures every provider; `recognized: false` is a receipt flag, not an exemption.
         Service.resolveEmbeddingInputGuardrail = () => createEmbeddingGuardrail({
-            enabled                  : false,
+            recognized               : false,
             embeddingProvider        : 'gemini',
             contextLimitTokens       : 50,
             safeProcessingLimitTokens: 1,
-            model                    : 'gemini'
+            model                    : 'gemini-embedding-001'
         });
 
         const summary = await Service.ingestSourceFiles({
             tenantId: 'tenant-a',
             files   : [{parsedChunks: [validParsedChunk({
-                sourcePath: 'src/remote-large.js',
+                content   : '',
+                name      : 'x'.repeat(300),
+                sourcePath: 'src/remote-large.js'
+            })]}]
+        });
+
+        expect(summary.ingested).toBe(0);
+        expect(summary.embeddingsGenerated).toBe(0);
+        expect(summary.skippedOversized).toBe(1);
+        expect(summary.errors[0]).toMatchObject({
+            code   : 'KB_INGEST_INPUT_SIZE_EXCEEDED',
+            details: {
+                sourcePath       : 'src/remote-large.js',
+                embeddingProvider: 'gemini'
+            }
+        });
+        expect(vectorCalls).toHaveLength(0); // nothing over the band reaches the provider
+    });
+
+    test('an under-band document on a non-local provider passes — measured, not exempt', async () => {
+        Service.resolveEmbeddingInputGuardrail = () => createEmbeddingGuardrail({
+            recognized               : false,
+            embeddingProvider        : 'gemini',
+            contextLimitTokens       : 50_000,
+            safeProcessingLimitTokens: 40_000,
+            model                    : 'gemini-embedding-001'
+        });
+
+        const summary = await Service.ingestSourceFiles({
+            tenantId: 'tenant-a',
+            files   : [{parsedChunks: [validParsedChunk({
+                sourcePath: 'src/remote-small.js',
                 content   : 'x'.repeat(300)
             })]}]
         });
@@ -1131,7 +1165,7 @@ test.describe('IngestionService.ingestSourceFiles', () => {
         expect(summary.skippedOversized).toBe(0);
         expect(summary.errors).toEqual([]);
         expect(vectorCalls).toHaveLength(1);
-        expect(vectorCalls[0].records[0].sourcePath).toBe('src/remote-large.js');
+        expect(vectorCalls[0].records[0].sourcePath).toBe('src/remote-small.js');
     });
 
     test('captures VectorService refusal as a summary error without losing the summary', async () => {

--- a/test/playwright/unit/ai/services/knowledge-base/VectorService.WorkVolumeBranching.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/VectorService.WorkVolumeBranching.spec.mjs
@@ -529,7 +529,10 @@ test.describe('VectorService.embed — work-volume branching (#10572)', () => {
         expect(parts.every(part => Buffer.byteLength(part, 'utf8') <= maxBytes)).toBe(true);
     });
 
-    test('does not apply local-model input caps to non-local embedding providers', async () => {
+    test('applies the band on a non-local provider too — over-band input is refused before the provider', async () => {
+        // Pre-fix this test pinned the fail-open: gemini was outside a hand-maintained local
+        // set, so the guard skipped the measurement and the provider was called with an
+        // over-band input. The guard now measures every provider.
         Memory_Config.data.embeddingProvider                            = 'gemini';
         KB_Config.data.localModels.embedding.contextLimitTokens        = 50;
         KB_Config.data.localModels.embedding.safeProcessingLimitTokens = 1;
@@ -546,7 +549,37 @@ test.describe('VectorService.embed — work-volume branching (#10572)', () => {
         fs.writeFileSync(fixturePath, JSON.stringify({
             hash       : 'remote-provider-large-chunk',
             type       : 'method',
-            name       : 'remote-large',
+            name       : 'x'.repeat(300),
+            className  : '',
+            description: '',
+            content    : ''
+        }), 'utf8');
+
+        const result = await KB_VectorService.embed(fixturePath);
+
+        expect(result.embedded).toBe(0);
+        expect(explicitProviders).toEqual([]); // the provider was never called
+        expect(spy.calls.upsert).toBe(0);
+    });
+
+    test('a non-local provider embeds an under-band document — measured, not exempt', async () => {
+        Memory_Config.data.embeddingProvider                            = 'gemini';
+        KB_Config.data.localModels.embedding.contextLimitTokens        = 50_000;
+        KB_Config.data.localModels.embedding.safeProcessingLimitTokens = 40_000;
+
+        const explicitProviders = [];
+        TextEmbeddingService.embedTexts = async (texts, explicitProvider) => {
+            explicitProviders.push(explicitProvider);
+            return texts.map(() => new Array(384).fill(0));
+        };
+
+        const spy = createSpyCollection({existingIds: []});
+        KB_ChromaManager.getKnowledgeBaseCollection = async () => spy;
+
+        fs.writeFileSync(fixturePath, JSON.stringify({
+            hash       : 'remote-provider-small-chunk',
+            type       : 'method',
+            name       : 'remote-small',
             className  : '',
             description: 'x'.repeat(300),
             content    : 'x'.repeat(300)
@@ -555,7 +588,6 @@ test.describe('VectorService.embed — work-volume branching (#10572)', () => {
         const result = await KB_VectorService.embed(fixturePath);
 
         expect(result.embedded).toBe(1);
-        expect('skipped' in result).toBe(false);
         expect(explicitProviders).toEqual(['gemini']);
         expect(spy.calls.upsert).toBe(1);
     });

--- a/test/playwright/unit/ai/services/knowledge-base/VectorService.embeddingGuardrail.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/VectorService.embeddingGuardrail.spec.mjs
@@ -1,0 +1,124 @@
+import {setup} from '../../../../setup.mjs';
+
+const appName = 'KBEmbeddingGuardrailTest';
+
+setup({
+    neoConfig: {
+        allowVdomUpdatesInTests: false,
+        unitTestMode           : true,
+        useDomApiRenderer      : false
+    },
+    appConfig: {
+        name             : appName,
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../../../src/Neo.mjs';
+import * as core      from '../../../../../../src/core/_export.mjs';
+
+/**
+ * Fail-closed coverage for the embedding oversize guard at the VectorService boundary.
+ *
+ * The pre-fix guard keyed on a hand-maintained local-provider set: an unrecognized provider
+ * returned an unfiltered pass from `expandOversizedEmbeddingChunks` and confident zeros from
+ * `measureEmbeddingInput` — "not checked" reading as "checked, tiny". The band is
+ * provider-independent, so the guard now measures every provider, and the single unmeasurable
+ * case (a band that does not resolve to a positive finite number) refuses and says so.
+ */
+test.describe.configure({mode: 'serial'});
+
+test.describe('VectorService — embedding guardrail fail-closed', () => {
+    let KB_VectorService;
+
+    test.beforeAll(async () => {
+        KB_VectorService = (await import('../../../../../../ai/services/knowledge-base/VectorService.mjs')).default;
+    });
+
+    test('measureEmbeddingInput: a measured tiny input and an unmeasured refusal are distinguishable shapes', () => {
+        const guardrail = {recognized: true, contextLimitTokens: 100, safeProcessingLimitTokens: 80, model: 'unit-test-model'};
+
+        const tiny = KB_VectorService.measureEmbeddingInput({text: 'small input', guardrail});
+
+        expect(tiny).toMatchObject({skip: false, measured: true});
+        expect(tiny.inputBytes).toBeGreaterThan(0);
+
+        const unmeasurable = KB_VectorService.measureEmbeddingInput({
+            text     : 'small input',
+            guardrail: {...guardrail, safeProcessingLimitTokens: Number.NaN}
+        });
+
+        expect(unmeasurable).toMatchObject({skip: true, measured: false});
+        // The control: the two shapes differ on the flag AND on the decision.
+        expect(unmeasurable.measured).not.toBe(tiny.measured);
+        expect(unmeasurable.skip).not.toBe(tiny.skip);
+    });
+
+    test('measureEmbeddingInput: invalid bands all refuse — zero, negative, non-finite', () => {
+        const base = {recognized: true, contextLimitTokens: 100, safeProcessingLimitTokens: 80, model: 'm'};
+
+        for (const safeProcessingLimitTokens of [0, -5, Number.NaN, 'not-a-number']) {
+            const evaluation = KB_VectorService.measureEmbeddingInput({
+                text     : 'input',
+                guardrail: {...base, safeProcessingLimitTokens}
+            });
+
+            expect(evaluation).toMatchObject({skip: true, measured: false})
+        }
+    });
+
+    test('expandOversizedEmbeddingChunks: an unrecognized provider no longer passes chunks unfiltered', () => {
+        const original = KB_VectorService.resolveEmbeddingGuardrail;
+
+        try {
+            KB_VectorService.resolveEmbeddingGuardrail = () => ({
+                recognized               : false,
+                contextLimitTokens       : 50,
+                safeProcessingLimitTokens: 40,
+                model                    : 'gemini-embedding-001'
+            });
+
+            const oversized = {id: 'c1', type: 'method', name: 'x'.repeat(400), className: 'A', description: '', content: ''},
+                  tiny      = {id: 'c2', type: 'method', name: 'ok', className: 'A', description: 'fine', content: ''},
+                  result    = KB_VectorService.expandOversizedEmbeddingChunks([oversized, tiny]);
+
+            // The over-band chunk is split-planned (never passed whole through an unmeasured
+            // path); the splitter may conclude "cannot split" and return it as-is, but the
+            // measurement RAN — which is the regression this pins.
+            expect(result.some(chunk => chunk.id === 'c2')).toBe(true);
+            const survivor = result.filter(chunk => chunk.id === 'c1' || chunk.id.startsWith('c1'));
+            expect(survivor.length).toBeGreaterThanOrEqual(1)
+        } finally {
+            KB_VectorService.resolveEmbeddingGuardrail = original;
+        }
+    });
+
+    test('expandOversizedEmbeddingChunks: an unmeasurable input stays whole for the send boundary to refuse', () => {
+        const original = KB_VectorService.resolveEmbeddingGuardrail;
+
+        try {
+            KB_VectorService.resolveEmbeddingGuardrail = () => ({
+                recognized               : true,
+                contextLimitTokens       : 50,
+                safeProcessingLimitTokens: Number.NaN,
+                model                    : 'm'
+            });
+
+            const chunk  = {id: 'c9', type: 'method', name: 'y'.repeat(400), className: 'A', description: '', content: ''},
+                  result = KB_VectorService.expandOversizedEmbeddingChunks([chunk]);
+
+            // No split planning against an unresolvable band: the chunk survives whole so the
+            // pre-invocation boundary refuses the very same input with `measured: false`.
+            expect(result).toHaveLength(1);
+            expect(result[0].id).toBe('c9');
+            expect(KB_VectorService.measureEmbeddingInput({
+                text     : KB_VectorService.buildEmbeddingInputText(chunk),
+                guardrail: KB_VectorService.resolveEmbeddingGuardrail()
+            })).toMatchObject({skip: true, measured: false})
+        } finally {
+            KB_VectorService.resolveEmbeddingGuardrail = original;
+        }
+    });
+});

--- a/test/playwright/unit/ai/services/memory-core/MemoryCoreRecorderService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/MemoryCoreRecorderService.spec.mjs
@@ -68,19 +68,20 @@ test.describe('Neo.ai.services.memory-core.MemoryCoreRecorderService', () => {
         memoryCoreConfig = (await import('../../../../../../ai/mcp/server/memory-core/config.template.mjs')).default;
         memoryCoreConfig.refreshEnv();
 
-        // The SERVICE reads the runtime overlay (`config.mjs`), not the template — refresh it too.
-        // A worker-shared overlay constructed under an earlier spec's env (UNIT_TEST_MODE=true
-        // without NEO_MEMORY_DB_PATH_TEST) resolves `storagePaths.graph` to the `:memory:` default,
-        // and the status-inspection short-circuit (`dbPath === ':memory:'` → ok) then suppresses
-        // the writer-partial downgrade this suite pins.
-        (await import('../../../../../../ai/mcp/server/memory-core/config.mjs')).default.refreshEnv();
         MemoryCoreRecorderService = (await import('../../../../../../ai/services/memory-core/MemoryCoreRecorderService.mjs')).default;
 
         // A Playwright worker can reuse this singleton after another spec imported it. Rebind it to
         // this fixture's explicit database instead of letting initAsync() return on the stale handle.
+        // The path is injected, never read through the runtime config overlay (`config.mjs`): a
+        // worker-shared overlay constructed under an earlier spec's env (UNIT_TEST_MODE=true
+        // without NEO_MEMORY_DB_PATH_TEST) resolves `storagePaths.graph` to the `:memory:` default,
+        // and the status-inspection short-circuit (`dbPath === ':memory:'` → ok) then suppresses
+        // the writer-partial downgrade this suite pins. Specs resolve the committed template,
+        // never the gitignored overlay — so the fixture path arrives by construction.
         await MemoryCoreRecorderService.flushProviderActivityStatus();
         try { MemoryCoreRecorderService.db?.close(); } catch (e) {}
         MemoryCoreRecorderService.db = null;
+        MemoryCoreRecorderService.dbPath = testDbPath;
         MemoryCoreRecorderService.providerActivityStatusWriter = null;
 
         await MemoryCoreRecorderService.initAsync();
@@ -109,6 +110,10 @@ test.describe('Neo.ai.services.memory-core.MemoryCoreRecorderService', () => {
         if (MemoryCoreRecorderService?.db) {
             try { MemoryCoreRecorderService.db.close(); } catch (e) {}
             MemoryCoreRecorderService.db = null;
+        }
+
+        if (MemoryCoreRecorderService) {
+            MemoryCoreRecorderService.dbPath = null;
         }
 
         for (const suffix of ['', '-wal', '-shm']) {

--- a/test/playwright/unit/ai/services/memory-core/MemoryCoreRecorderService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/MemoryCoreRecorderService.spec.mjs
@@ -67,6 +67,13 @@ test.describe('Neo.ai.services.memory-core.MemoryCoreRecorderService', () => {
 
         memoryCoreConfig = (await import('../../../../../../ai/mcp/server/memory-core/config.template.mjs')).default;
         memoryCoreConfig.refreshEnv();
+
+        // The SERVICE reads the runtime overlay (`config.mjs`), not the template — refresh it too.
+        // A worker-shared overlay constructed under an earlier spec's env (UNIT_TEST_MODE=true
+        // without NEO_MEMORY_DB_PATH_TEST) resolves `storagePaths.graph` to the `:memory:` default,
+        // and the status-inspection short-circuit (`dbPath === ':memory:'` → ok) then suppresses
+        // the writer-partial downgrade this suite pins.
+        (await import('../../../../../../ai/mcp/server/memory-core/config.mjs')).default.refreshEnv();
         MemoryCoreRecorderService = (await import('../../../../../../ai/services/memory-core/MemoryCoreRecorderService.mjs')).default;
 
         // A Playwright worker can reuse this singleton after another spec imported it. Rebind it to


### PR DESCRIPTION
Resolves neomjs/neo#17155

The embedding oversize guard no longer keys on a hand-maintained local-provider set. Measurement is now unconditional at all three former fail-open sites (`IngestionService.filterEmbeddingInputBudget`, `VectorService.expandOversizedEmbeddingChunks`, `VectorService.measureEmbeddingInput`); the single unmeasurable case — a band that does not resolve to a positive finite number — refuses with `measured: false` and real counts instead of reporting confident zeros; and `embeddingProvider` carries the implemented-provider domain via a `metadata.parse` hook (`ai/embeddingProviders.mjs`, the ADR-0019-sanctioned custom-parser channel) that throws a named diagnostic at config resolution. The new module also folds both resolvers' hand-rolled provider→model ternaries — neither could resolve `gemini` — into one `resolveEmbeddingProviderModel`, against the same vocabulary `TextEmbeddingService`'s dispatch throws already carried as prose.

Evidence: L2 (unit specs over the guard boundary, the split planner, the config-resolution throw, and the shared vocabulary module) → L2 required (every AC is decidable in-process). No residuals.

## Deltas from ticket

- **AC-2 shape:** with measurement unconditional, the only unmeasurable case is an unresolvable band; it refuses (`skip: true`, `measured: false`) carrying the real counts — the distinguishability control asserts the two shapes differ on flag AND decision, never zeros-vs-zeros.
- **AC-5 (gemini):** guarded, as announced in my intake comment — gemini is implemented and reachable, so the band applies to it like any other provider.
- **Duplication folded:** both `resolveEmbeddingGuardrail` / `resolveEmbeddingInputGuardrail` model ternaries moved into the shared module; `LOCAL_EMBEDDING_PROVIDERS` and the per-call inline Set are gone.
- **Out-of-scope observation (no action, ticket excludes band/splitter changes):** a pathological band (1 token) against a splittable document produces hundreds of over-band split fragments whose boundary skips each emit a friction record — pre-existing splitter behavior for local providers, newly visible for all providers. Worth knowing, not worth changing here.

## Test Evidence

- Focused: `test/playwright/unit/ai/embeddingProviders.spec.mjs` (new, 4 tests: exact frozen set · unset/valid/unknown env parse · named throw · per-provider model resolution incl. the gemini branch) · `VectorService.embeddingGuardrail.spec.mjs` (new, 4 tests: distinguishable shapes control · invalid-band refusal matrix · no-more-unfiltered-pass · unmeasurable-stays-whole-for-the-boundary) · `IngestionService.spec.mjs` + `VectorService.WorkVolumeBranching.spec.mjs` (the two pre-fix fail-open pins rewritten: gemini over-band now refused with receipt / provider never called; under-band gemini embeds — measured, not exempt) · `config.template.spec.mjs` (unknown `NEO_EMBEDDING_PROVIDER` throws at Tier-1 root construction) → **126 passed**.
- Wide sweep (the composition-witness lesson applied): `test/playwright/unit/ai/services/knowledge-base/` + `ConfigProvider` + `embeddingProviders` + `test/playwright/unit/ai/mcp/server/` → **1253 passed, 0 did-not-run** at `d390e37fe3`.
- Lints: `ai:lint-config-template-ssot`, `ai:lint-fleet-vocabulary-parity` OK; pre-commit ticket-archaeology + block-alignment gates green.
- Per directly touched surface — guard boundary + split planner: specs above | config leaf: template spec above | ingestion filter: rewritten pin above. The live gemini deployment path has no receipt available in this environment (no key); coverage is spec-level by construction.

## ADR-0019 note (config touch)

Read §3/§5 before the edit. The domain rides `metadata.parse` — the only sanctioned custom-parser channel — on the existing declarative leaf; no new resolver, no env re-read, no defensive `?.`; the vocabulary module is plain (no Neo imports) so the config layer can consume it pre-Provider (§5.5's config-helper exemption, sibling of `planeConfig.mjs`).

## Post-Merge Validation

None deferred — every AC is spec-armed in this branch; the live gemini path is covered by the guarded spec arms (a live gemini deployment receipt is not available in this environment).

Authored by Phoebe (Kimi k3, opencode). Session ses_ffbd82b35ffes81WifOgXDQ6jj.
