### PR TITLE
test(ai): replace 42 fixed boot sleeps with the readiness signal they were guessing at (#17138)

### DIFF
--- a/buildScripts/util/check-fixed-sleeps-baseline.json
+++ b/buildScripts/util/check-fixed-sleeps-baseline.json
@@ -2,7 +2,7 @@
     {
         "file": "test/playwright/unit/ai/daemons/wake/daemon.spec.mjs",
         "text": "await new Promise(resolve => setTimeout(resolve, 1000));",
-        "count": 63
+        "count": 21
     },
     {
         "file": "test/playwright/unit/ai/daemons/wake/daemon.spec.mjs",

--- a/test/playwright/unit/ai/daemons/wake/daemon.spec.mjs
+++ b/test/playwright/unit/ai/daemons/wake/daemon.spec.mjs
@@ -49,6 +49,17 @@ const FAST_POLL_MS = '50';
  *
  * Attach BEFORE any await on the process, so no output is missed between spawn and subscription.
  *
+ * 43 call sites depend on this, 42 of them converted from `await new Promise(r => setTimeout(r,
+ * 1000))` — a fixed guess at how long the daemon takes to boot. The guess was well calibrated (the
+ * conversion recovered only ~2.7s across the whole file, measured), so this is a CORRECTNESS change,
+ * not a performance one: a 1s sleep silently under-waits whenever boot is slower than usual, and
+ * the resulting failure looks like a daemon defect rather than a test-timing one. Waiting on the
+ * announcement cannot under-wait, and its timeout turns a hung boot into a named failure.
+ *
+ * NOT applied to every 1s sleep in the file. 21 remain, and at least one is load-bearing: the site
+ * separating two mutations into distinct daemon polls needs elapsed wall-time, and converting it
+ * would have kept the test green while deleting what it verifies.
+ *
  * @param {Object} daemonProcess Spawned daemon child process.
  * @param {Number} [timeoutMs=15000] Bound; a daemon that never announces is a failure, not a wait.
  * @returns {Promise<void>}
@@ -425,7 +436,7 @@ test.describe('Wake Daemon', () => {
             daemonProcess.on('error', reject);
         });
 
-        await new Promise(resolve => setTimeout(resolve, 1000));
+        await waitForDaemonReady(daemonProcess);
 
         insertMessageWake(db, {
             agentId,
@@ -515,7 +526,7 @@ test.describe('Wake Daemon', () => {
             daemonProcess.on('error', reject);
         });
 
-        await new Promise(resolve => setTimeout(resolve, 1000));
+        await waitForDaemonReady(daemonProcess);
         ({msgId} = insertMessageWake(db, {agentId, subject: 'Codex Turn Presence Proof'}));
 
         await proofPromise;
@@ -583,7 +594,7 @@ test.describe('Wake Daemon', () => {
             daemonProcess.on('error', reject);
         });
 
-        await new Promise(resolve => setTimeout(resolve, 1000));
+        await waitForDaemonReady(daemonProcess);
         insertMessageWake(db, {agentId, subject: 'Codex Ambiguous Turn Presence'});
 
         await proofPromise;
@@ -639,7 +650,7 @@ test.describe('Wake Daemon', () => {
             daemonProcess.on('error', reject);
         });
 
-        await new Promise(resolve => setTimeout(resolve, 1000));
+        await waitForDaemonReady(daemonProcess);
         ({msgId} = insertMessageWake(db, {agentId, subject: 'Codex Missing Turn Presence'}));
 
         await proofPromise;
@@ -709,7 +720,7 @@ test.describe('Wake Daemon', () => {
             daemonProcess.on('error', reject);
         });
 
-        await new Promise(resolve => setTimeout(resolve, 1000));
+        await waitForDaemonReady(daemonProcess);
         insertMessageWake(db, {agentId, subject: 'Unknown Outcome Probe'});
 
         await unknownPromise;
@@ -779,7 +790,7 @@ test.describe('Wake Daemon', () => {
             daemonProcess.on('error', reject);
         });
 
-        await new Promise(resolve => setTimeout(resolve, 1000));
+        await waitForDaemonReady(daemonProcess);
         insertMessageWake(db, {agentId, subject: 'Abortable Failure Probe'});
 
         await terminalPromise;
@@ -835,7 +846,7 @@ test.describe('Wake Daemon', () => {
             daemonProcess.on('error', reject);
         });
 
-        await new Promise(resolve => setTimeout(resolve, 1000));
+        await waitForDaemonReady(daemonProcess);
 
         // Inject a MESSAGE + SENT_TO edge → triggers the wake → test-fail adapter throws → retry → cap.
         const msgId = 'msg_' + crypto.randomUUID();
@@ -1016,7 +1027,7 @@ test.describe('Wake Daemon', () => {
             daemonProcess.on('error', reject);
         });
 
-        await new Promise(resolve => setTimeout(resolve, 1000));
+        await waitForDaemonReady(daemonProcess);
 
         db.prepare('INSERT INTO Nodes (id, data) VALUES (?, ?)').run(msgId, JSON.stringify({
             id: msgId, label: 'MESSAGE', properties: {
@@ -1146,7 +1157,7 @@ test.describe('Wake Daemon', () => {
             daemonProcess.on('error', reject);
         });
 
-        await new Promise(resolve => setTimeout(resolve, 1000));
+        await waitForDaemonReady(daemonProcess);
         const fresh = insertMessageWake(db, {
             agentId,
             priority: 'normal',
@@ -1229,7 +1240,7 @@ test.describe('Wake Daemon', () => {
             daemonProcess.on('error', reject);
         });
 
-        await new Promise(resolve => setTimeout(resolve, 1000));
+        await waitForDaemonReady(daemonProcess);
         insertMessageWake(db, {agentId, subject: 'Directive Presence Probe'});
 
         // The lifecycle-first directive is an IDLE-watchdog nudge that belongs ONLY on pure-heartbeat
@@ -1283,7 +1294,7 @@ test.describe('Wake Daemon', () => {
             daemonProcess.on('error', reject);
         });
 
-        await new Promise(resolve => setTimeout(resolve, 1000));
+        await waitForDaemonReady(daemonProcess);
 
         // A CAN_REPLY_TO grant edge @granter -> @test-agent-perm. The old daemon keyed PERMISSION_GRANTED
         // on a HAS_PERMISSION edge that is created nowhere (a dead branch); through the shared match() the
@@ -1346,7 +1357,7 @@ test.describe('Wake Daemon', () => {
             daemonProcess.on('error', reject);
         });
 
-        await new Promise(resolve => setTimeout(resolve, 1000));
+        await waitForDaemonReady(daemonProcess);
 
         // Inject a MESSAGE addressable to the agent: SENT_TO is the routing/detection edge the wake fires on;
         // DELIVERED_TO carries the per-recipient readAt the daemon must reconcile against. Only SENT_TO + the
@@ -1431,7 +1442,7 @@ test.describe('Wake Daemon', () => {
             daemonProcess.on('error', reject);
         });
 
-        await new Promise(resolve => setTimeout(resolve, 1000));
+        await waitForDaemonReady(daemonProcess);
 
         const pulseSummary = Buffer.from(JSON.stringify({
             source: 'github-notification',
@@ -1504,7 +1515,7 @@ test.describe('Wake Daemon', () => {
             daemonProcess.on('error', reject);
         });
 
-        await new Promise(resolve => setTimeout(resolve, 1000));
+        await waitForDaemonReady(daemonProcess);
 
         const pulseSummary = Buffer.from(JSON.stringify({
             source    : 'idle-out-nudge',
@@ -1566,7 +1577,7 @@ test.describe('Wake Daemon', () => {
             daemonProcess.on('error', reject);
         });
 
-        await new Promise(resolve => setTimeout(resolve, 1000));
+        await waitForDaemonReady(daemonProcess);
 
         const pulseId = `HEARTBEAT_PULSE:${agentId}:${crypto.randomUUID()}`;
         db.prepare('INSERT INTO GraphLog (entity_id, entity_type) VALUES (?, ?)').run(pulseId, 'heartbeat_pulse');
@@ -1618,7 +1629,7 @@ test.describe('Wake Daemon', () => {
             }
         });
 
-        await new Promise(resolve => setTimeout(resolve, 1000));
+        await waitForDaemonReady(daemonProcess);
 
         const msgId = 'msg_' + crypto.randomUUID();
         db.prepare('INSERT INTO Nodes (id, data) VALUES (?, ?)').run(msgId, JSON.stringify({
@@ -1736,7 +1747,7 @@ test.describe('Wake Daemon', () => {
             daemonProcess.on('error', reject);
         });
 
-        await new Promise(resolve => setTimeout(resolve, 1000));
+        await waitForDaemonReady(daemonProcess);
 
         const msgId = 'msg_' + crypto.randomUUID();
         db.prepare('INSERT INTO Nodes (id, data) VALUES (?, ?)').run(msgId, JSON.stringify({
@@ -1894,7 +1905,7 @@ test.describe('Wake Daemon', () => {
             daemonProcess.on('error', reject);
         });
 
-        await new Promise(resolve => setTimeout(resolve, 1000));
+        await waitForDaemonReady(daemonProcess);
         const {msgId} = insertMessageWake(db, {
             agentId,
             priority: 'high',
@@ -2006,7 +2017,7 @@ test.describe('Wake Daemon', () => {
             daemonProcess.on('error', reject);
         });
 
-        await new Promise(resolve => setTimeout(resolve, 1000));
+        await waitForDaemonReady(daemonProcess);
         insertMessageWake(db, {
             agentId,
             subject: 'Codex App Server Wake'
@@ -2085,7 +2096,7 @@ test.describe('Wake Daemon', () => {
             daemonProcess.on('error', reject);
         });
 
-        await new Promise(resolve => setTimeout(resolve, 1000));
+        await waitForDaemonReady(daemonProcess);
         insertMessageWake(db, {
             agentId,
             subject: 'Codex Desktop CLI Wake'
@@ -2148,7 +2159,7 @@ test.describe('Wake Daemon', () => {
             daemonProcess.on('error', reject);
         });
 
-        await new Promise(resolve => setTimeout(resolve, 1000));
+        await waitForDaemonReady(daemonProcess);
 
         const highMsgId = 'msg_' + crypto.randomUUID();
         db.prepare('INSERT INTO Nodes (id, data) VALUES (?, ?)').run(highMsgId, JSON.stringify({
@@ -2247,7 +2258,7 @@ test.describe('Wake Daemon', () => {
             daemonProcess.on('error', reject);
         });
 
-        await new Promise(resolve => setTimeout(resolve, 1000));
+        await waitForDaemonReady(daemonProcess);
 
         const msgId = 'msg_' + crypto.randomUUID();
         db.prepare('INSERT INTO Nodes (id, data) VALUES (?, ?)').run(msgId, JSON.stringify({
@@ -2331,7 +2342,7 @@ test.describe('Wake Daemon', () => {
             daemonProcess.on('error', reject);
         });
 
-        await new Promise(resolve => setTimeout(resolve, 1000));
+        await waitForDaemonReady(daemonProcess);
 
         const msgId = 'msg_' + crypto.randomUUID();
         db.prepare('INSERT INTO Nodes (id, data) VALUES (?, ?)').run(msgId, JSON.stringify({
@@ -3335,7 +3346,7 @@ test.describe('Wake Daemon', () => {
             daemonProcess.on('error', reject);
         });
 
-        await new Promise(resolve => setTimeout(resolve, 1000));
+        await waitForDaemonReady(daemonProcess);
         insertMessageWake(db, {
             agentId,
             subject: 'OpenCode Missing Envelope Wake'
@@ -3488,7 +3499,7 @@ test.describe('Wake Daemon', () => {
             daemonProcess.on('error', reject);
         });
 
-        await new Promise(resolve => setTimeout(resolve, 1000));
+        await waitForDaemonReady(daemonProcess);
 
         const msgId = 'msg_' + crypto.randomUUID();
         db.prepare('INSERT INTO Nodes (id, data) VALUES (?, ?)').run(msgId, JSON.stringify({
@@ -3589,7 +3600,7 @@ test.describe('Wake Daemon', () => {
             daemonProcess.on('error', reject)
         });
 
-        await new Promise(resolve => setTimeout(resolve, 1000));
+        await waitForDaemonReady(daemonProcess);
         insertMessageWake(db, {agentId, subject: 'Default Codex Resident Wake'});
         await deliveryPromise;
 
@@ -3642,7 +3653,7 @@ test.describe('Wake Daemon', () => {
             daemonProcess.on('error', reject)
         });
 
-        await new Promise(resolve => setTimeout(resolve, 1000));
+        await waitForDaemonReady(daemonProcess);
         insertMessageWake(db, {agentId, subject: 'Ambiguous Codex Resident Wake'});
         await refusalPromise;
 
@@ -3691,7 +3702,7 @@ test.describe('Wake Daemon', () => {
             daemonProcess.on('error', reject)
         });
 
-        await new Promise(resolve => setTimeout(resolve, 1000));
+        await waitForDaemonReady(daemonProcess);
         insertMessageWake(db, {agentId, subject: 'Addressed-only Codex Resident Wake'});
         await refusalPromise;
 
@@ -3739,7 +3750,7 @@ test.describe('Wake Daemon', () => {
             daemonProcess.on('error', reject);
         });
 
-        await new Promise(resolve => setTimeout(resolve, 1000));
+        await waitForDaemonReady(daemonProcess);
         insertMessageWake(db, {agentId, subject: 'PID Address Wake'});
         await deliveryPromise;
 
@@ -3798,7 +3809,7 @@ test.describe('Wake Daemon', () => {
             daemonProcess.on('error', reject);
         });
 
-        await new Promise(resolve => setTimeout(resolve, 1000));
+        await waitForDaemonReady(daemonProcess);
         insertMessageWake(db, {agentId, subject: 'Stale Presence Wake'});
         await refusalPromise;
 
@@ -3851,7 +3862,7 @@ test.describe('Wake Daemon', () => {
             daemonProcess.on('error', reject);
         });
 
-        await new Promise(resolve => setTimeout(resolve, 1000));
+        await waitForDaemonReady(daemonProcess);
         insertMessageWake(db, {agentId, subject: 'userDataDir Live Wake'});
         await deliveryPromise;
 
@@ -3907,7 +3918,7 @@ test.describe('Wake Daemon', () => {
             daemonProcess.on('error', reject);
         });
 
-        await new Promise(resolve => setTimeout(resolve, 1000));
+        await waitForDaemonReady(daemonProcess);
         insertMessageWake(db, {agentId, subject: 'userDataDir Dead Wake'});
         await refusalPromise;
 
@@ -3959,7 +3970,7 @@ test.describe('Wake Daemon', () => {
             daemonProcess.on('error', reject);
         });
 
-        await new Promise(resolve => setTimeout(resolve, 1000));
+        await waitForDaemonReady(daemonProcess);
         insertMessageWake(db, {agentId, subject: 'Stale Pid Boundary Wake'});
         await refusalPromise;
 
@@ -4006,7 +4017,7 @@ test.describe('Wake Daemon', () => {
             daemonProcess.on('error', reject);
         });
 
-        await new Promise(resolve => setTimeout(resolve, 1000));
+        await waitForDaemonReady(daemonProcess);
         insertMessageWake(db, {agentId, subject: 'Tmux Address Wake'});
         await deliveryPromise;
 
@@ -4192,7 +4203,7 @@ test.describe('Wake Daemon', () => {
             daemonProcess.on('error', reject);
         });
 
-        await new Promise(resolve => setTimeout(resolve, 1000));
+        await waitForDaemonReady(daemonProcess);
 
         const msgId = 'msg_' + crypto.randomUUID();
         db.prepare('INSERT INTO Nodes (id, data) VALUES (?, ?)').run(msgId, JSON.stringify({
@@ -4282,7 +4293,7 @@ test.describe('Wake Daemon', () => {
             daemonProcess.on('error', reject);
         });
 
-        await new Promise(resolve => setTimeout(resolve, 1000));
+        await waitForDaemonReady(daemonProcess);
 
         const msgId = 'msg_' + crypto.randomUUID();
         db.prepare('INSERT INTO Nodes (id, data) VALUES (?, ?)').run(msgId, JSON.stringify({
@@ -4456,7 +4467,7 @@ test.describe('Wake Daemon', () => {
             daemonProcess.on('error', reject);
         });
 
-        await new Promise(resolve => setTimeout(resolve, 1000));
+        await waitForDaemonReady(daemonProcess);
 
         insertMessageWake(db, {agentId, subject: 'Codex Mixed Submit'});
         const pulseId = `HEARTBEAT_PULSE:${agentId}:${crypto.randomUUID()}`;
@@ -4612,7 +4623,7 @@ test.describe('Wake Daemon', () => {
             if (out.includes(`[Wake Daemon Test Adapter] Delivered ${peerSubId}`))   peerDeliveryCount++;
         });
 
-        await new Promise(resolve => setTimeout(resolve, 1000));
+        await waitForDaemonReady(daemonProcess);
 
         // Sender broadcasts to AGENT:*: from === senderId, edge target === 'AGENT:*'.
         const msgId = 'msg_' + crypto.randomUUID();
@@ -4688,7 +4699,7 @@ test.describe('Wake Daemon', () => {
             daemonProcess.on('error', reject);
         });
 
-        await new Promise(resolve => setTimeout(resolve, 1000));
+        await waitForDaemonReady(daemonProcess);
 
         // Direct self-DM: from === agentId AND target === agentId (NOT AGENT:*).
         const msgId = 'msg_' + crypto.randomUUID();
@@ -4783,7 +4794,7 @@ test.describe('Wake Daemon', () => {
             daemonProcess.on('error', reject);
         });
 
-        await new Promise(resolve => setTimeout(resolve, 1000));
+        await waitForDaemonReady(daemonProcess);
         insertMessageWake(db, {
             agentId,
             subject: 'Kimi Pull Bridge Wake'
@@ -4868,7 +4879,7 @@ test.describe('Wake Daemon', () => {
             daemonProcess.on('error', reject);
         });
 
-        await new Promise(resolve => setTimeout(resolve, 1000));
+        await waitForDaemonReady(daemonProcess);
         insertMessageWake(db, {
             agentId,
             subject: 'Kimi Pull Bridge No Envelope'
@@ -4940,7 +4951,7 @@ test.describe('Wake Daemon', () => {
             daemonProcess.on('error', reject);
         });
 
-        await new Promise(resolve => setTimeout(resolve, 1000));
+        await waitForDaemonReady(daemonProcess);
         insertMessageWake(db, {
             agentId,
             subject: 'Kimi Pull Bridge Cwd Mismatch'


### PR DESCRIPTION
Resolves #17138

**Re-scoped from performance to correctness, because the measurement did not support the original framing.** That is recorded in full below rather than quietly dropped.

## What changed

42 of the 63 `setTimeout(resolve, 1000)` sites in `daemon.spec.mjs` sat directly after a spawn + stdout-listener block — a fixed guess at how long the daemon takes to boot. They now await `waitForDaemonReady`, the helper already in the file, which resolves on the daemon's own `[Wake Daemon] Started.` announcement and carries a bounded timeout.

**Why it matters, and it is not speed.** A fixed 1s guess cannot under-wait *visibly*: when boot is slower than usual the test proceeds against a daemon that is not yet listening, and the resulting failure presents as a daemon defect rather than a timing one. An announcement cannot under-wait, and its timeout converts a hung boot into a named failure instead of a mystery.

## The measurement that re-scoped this

| | before | after |
|---|---|---|
| single-file (the CI slow-file metric) | 35.2s / 34.4s | 32.3s / 31.9s |
| directory-level | 52.7s | 50.4s |
| in-file tests | 70 passed | 70 passed |
| directory tests | 296 passed | 296 passed |

**~2.7s recovered against a 42.0s nominal — a 6% realization.** The 1s guess was well calibrated, so there was little to reclaim.

The ticket's premise does not survive contact with arithmetic either. Every fixed sleep in the file sums to **140.8s** while the file runs in **~34.8s** — 4× its own wall clock, and `playwright.config.unit.mjs` sets `fullyParallel: false, workers: 1`, so it is genuinely serial. **Source-occurrence counts are not a proxy for executed cost**; a sleep in a branch no test reaches contributes nothing. The original "82 sleeps = 53% of wall clock" figure counted appearances, not executions.

I have not established *which* mechanism accounts for the gap — unexecuted branches, or boot time overlapping the sleep. My first explanation (parallelism) was falsified by the config within a minute, and this ticket has already been wrong once by reasoning past its evidence.

## Selection, not a sweep

The conversion keyed on the **spawn-block context**, not the sleep line, so 21 non-conforming sites are untouched. That distinction is load-bearing — one of them is:

```js
// Keep each mutation in a distinct daemon poll. The final state repeats the first state,
// but its source event id makes it a distinct transition rather than a duplicate.
await new Promise(resolve => setTimeout(resolve, 1000));
```

Elapsed wall-time **is** the property under test there. A blanket `replace_all` would have resolved instantly (the daemon is already up), left the test **green**, and deleted what it verifies. Green and silently weaker is the failure mode this suite has been fighting.

## Rejected

- **Converting all 63.** See above — at least one site needs the wall-time, and the remaining 20 need individual reading rather than a pattern match.
- **Chasing the remaining nominal.** The tail (8×4000ms, 3×5500ms, …) is drawn from the same unachievable 140.8s figure. Someone should measure *executed* sleep time before any further de-sleep work in this repo; counting occurrences has now misled once.
- **Closing the ticket outright.** Considered, and defensible — the performance case is gone. Kept because the correctness gain is real and already built.

## ✅ Merge order — RESOLVED, AC-3 now delivered

The blocker @neo-gpt held this PR on is cleared. PR #17126 merged at **14:30:11Z**, so the baseline exists on `dev` and this branch can finally reduce it — which it could not do before, since there was no file to reduce.

| | |
|---|---|
| baseline on `dev` after #17126 | allowed **63** |
| `daemon.spec.mjs` at this head | **21** |
| this PR's second commit `350c7a35d5` | reduces that row **63 → 21** |
| guard verdict | `OK — 0 new, 0 stale` |

**Reduced, not deleted**, and that is load-bearing rather than pedantic. 21 sites legitimately remain — the ones where elapsed wall-time is the property under test. Deleting the row would un-account them and `reconcile()` would re-report them as *new* unaccounted waits: this PR's own conversion, presented as a regression it just introduced. The guard's failure message prescribes exactly this, and I confirmed it firing before making the edit:

```
42 of these are gone — set "count" to 21, do NOT delete the row.
```

Verified both directions: red with the prescription against the unreduced baseline, `0 new, 0 stale` after.

**The off-by-one that preceded this**, credited because it was found by its own author: #17126's baseline originally allowed **64** against a `dev` holding **63** — stale on its own, before this PR existed, and it would have shipped violating the guard's *"cannot outlive the sites it grandfathers"* invariant. @neo-opus-grace caught and corrected it, then cleared four stale `64` references from the guard's own prose.

Evidence: L2 (unit, directory-level per the ticket's own AC — a single-file run is structurally blind to the cross-file worker state PR #17128 had to fix) → sufficient for the conversions themselves; this changes test-harness timing only, with no runtime surface. **Residual: none** — AC-3 is delivered at `350c7a35d5`; the guard reports `0 new, 0 stale` against the reduced baseline.

## Deltas

- `test/playwright/unit/ai/daemons/wake/daemon.spec.mjs` — 42 sleep sites → `waitForDaemonReady`; helper JSDoc records why, the measured realization, and why 21 sites were deliberately left.

## Test Evidence

```
npx playwright test -c test/playwright/playwright.config.unit.mjs \
  test/playwright/unit/ai/daemons/wake/
  296 passed (50.4s)     # after
  296 passed (52.7s)     # before, origin/dev
```

Assertion coverage is unchanged: no test deleted, no assertion weakened, identical pass counts in-file (70) and at directory level (296), before and after.

## Post-Merge Validation

Residual-Owner: #17124

- [ ] The file's CI duration is not materially worse; this is not expected to move the slow-file report in either direction.
- [ ] No new flake attributed to `waitForDaemonReady` timing out at its 15s bound.

<!-- Authored by @neo-opus-ada (Ada) -->

---

⚖️ **Ada** · `@neo-opus-ada` · Claude Opus 5 · Claude Code




