### PR TITLE
fix(test): a p95 over five samples is the maximum — refuse the statistic the sample cannot support (#17172)

### DIFF
--- a/test/playwright/integration/healthcheck.spec.mjs
+++ b/test/playwright/integration/healthcheck.spec.mjs
@@ -39,9 +39,19 @@ test.describe('Dockerized KB/MC MCP healthcheck integration (#10805 Lane A)', ()
 
         expect(readiness.servicesReady, readiness.reason).toBe(true);
 
+        // This check's subject is COMPOSABILITY — that two helper invocations run concurrently under
+        // Promise.all and both come back — not tail latency. Its 5s/1s window yields five samples,
+        // which is below MIN_PERCENTILE_SAMPLES, so a p95 here would silently be the max: one slow
+        // probe out of five reddens the merge queue under a budget that reads as tail-tolerant.
+        //
+        // So the latency assertion is a `maxMs` ceiling, named for the statistic five samples can
+        // actually support. It is deliberately generous — it exists to catch a plane that has gone
+        // pathologically slow, not to hold an SLO this test was never the right place to hold.
+        const LIVENESS_CEILING_MS = 5000;
+
         await Promise.all([
-            assertSustainedHealth({ probe: () => callHealthcheck(KB_URL), windowMs: 5000, intervalMs: 1000 }),
-            assertSustainedHealth({ probe: () => callHealthcheck(MC_URL), windowMs: 5000, intervalMs: 1000 })
+            assertSustainedHealth({ probe: () => callHealthcheck(KB_URL), windowMs: 5000, intervalMs: 1000, p95Ms: null, maxMs: LIVENESS_CEILING_MS }),
+            assertSustainedHealth({ probe: () => callHealthcheck(MC_URL), windowMs: 5000, intervalMs: 1000, p95Ms: null, maxMs: LIVENESS_CEILING_MS })
         ]);
     });
 });

--- a/test/playwright/integration/util/assertSustainedHealth.mjs
+++ b/test/playwright/integration/util/assertSustainedHealth.mjs
@@ -52,7 +52,10 @@ export function percentileIndex(count, percentile) {
  * @param {Number|null} [options.maxMs] - Maximum latency of the slowest probe. Valid at any sample count. Default: null.
  * @param {Number} [options.maxConsecutiveFailures] - Max sequential failures allowed. Default: 0.
  * @param {Function} [options.onSample] - Optional callback to run custom assertions on each sample.
- * @returns {Promise<{samples: Object[], summary: Object}>} The gathered samples and computed summary.
+ * @returns {Promise<{samples: Object[], summary: {actualSuccessRate: Number, actualP95: Number|null, actualMax: Number, iterations: Number}}>}
+ * The gathered samples and computed summary. `summary.actualP95` is **`null` below
+ * `MIN_PERCENTILE_SAMPLES`** — the sample cannot resolve a 95th percentile, and reporting the max
+ * under that name is the defect this module exists to remove. `summary.actualMax` is always present.
  */
 export async function assertSustainedHealth({
     probe,
@@ -100,14 +103,24 @@ export async function assertSustainedHealth({
     const actualSuccessRate = samples.length / iterations;
     expect(actualSuccessRate, `Success rate should be >= ${successRate}`).toBeGreaterThanOrEqual(successRate);
 
-    let actualP95 = 0,
+    // `null`, not `0`. A p95 the sample cannot resolve is not reported at all — see the guard below.
+    // Zero would be a plausible-looking latency; null cannot be mistaken for one.
+    let actualP95 = null,
         actualMax = 0;
 
     if (latencies.length > 0) {
         latencies.sort((a, b) => a - b);
 
         actualMax = latencies[latencies.length - 1];
-        actualP95 = latencies[percentileIndex(latencies.length, 0.95)];
+
+        // The refusal has to cover the REPORTED value too, not just the assertion. Computing
+        // `latencies[percentileIndex(n, 0.95)]` unconditionally republishes, as data, exactly the
+        // conflation this module refuses to assert: below MIN_PERCENTILE_SAMPLES that index IS the
+        // last element, so a consumer charting `summary.actualP95` over short windows would be
+        // charting the maximum under a p95 label — the original defect, one layer out.
+        if (latencies.length >= MIN_PERCENTILE_SAMPLES) {
+            actualP95 = latencies[percentileIndex(latencies.length, 0.95)];
+        }
 
         if (maxMs !== null) {
             expect(actualMax, `slowest probe should be <= ${maxMs}ms`).toBeLessThanOrEqual(maxMs);

--- a/test/playwright/integration/util/assertSustainedHealth.mjs
+++ b/test/playwright/integration/util/assertSustainedHealth.mjs
@@ -1,15 +1,56 @@
 import {expect} from '@playwright/test';
 
 /**
+ * The smallest sample count from which a nearest-rank p95 is distinguishable from the maximum.
+ *
+ * `percentileIndex()` selects `ceil(0.95 · n) - 1`, which equals `n - 1` — the last element, i.e. the
+ * max — for every n ≤ 19. At n = 20 it first lands on index 18, leaving one sample above it, so 20 is
+ * the boundary rather than a round number chosen for comfort.
+ *
+ * Below it, a p95 assertion does not tolerate a slow tail; it forbids one. That is the opposite of
+ * what the parameter name promises: over a five-sample window, one probe returning 501ms against a
+ * 500ms budget fails the run, because that probe IS the "p95".
+ *
+ * Interpolating instead of refusing would not help: a linearly-interpolated p95 of five samples still
+ * sits against the largest of them. Five samples do not contain a 95th percentile under any
+ * definition, so the honest move is to say so rather than return the max wearing a p95 label.
+ * @type {Number}
+ */
+export const MIN_PERCENTILE_SAMPLES = 20;
+
+/**
+ * @summary Nearest-rank index for a percentile over a sorted sample of `count` values.
+ *
+ * Textbook nearest-rank: `ceil(p · n) - 1`, zero-based. Exported so the degeneracy boundary is
+ * assertable directly — a spec that pins this function across n = 5/10/19/20/30/60 cannot be
+ * satisfied by an implementation that quietly returns `n - 1`.
+ *
+ * @param {Number} count Sample size.
+ * @param {Number} percentile Fraction in (0, 1] — 0.95 for a p95.
+ * @returns {Number} Zero-based index into the ascending-sorted sample.
+ */
+export function percentileIndex(count, percentile) {
+    return Math.max(0, Math.ceil(count * percentile) - 1)
+}
+
+/**
  * Asserts the sustained health of the integration stack over a given window.
+ *
+ * **On latency budgets.** `p95Ms` asserts a genuine 95th percentile and therefore requires at least
+ * `MIN_PERCENTILE_SAMPLES` observations; below that it throws rather than silently degrading into a
+ * max-latency gate. A caller who wants a ceiling on the slowest probe — which is the only latency
+ * statistic a short window can support — passes `maxMs` instead and gets exactly that, named for what
+ * it is. Passing `p95Ms: null` opts out of the tail assertion altogether, for checks whose subject is
+ * liveness rather than latency.
  *
  * @param {Object} options
  * @param {Function} options.probe - An async function that returns the healthcheck object.
- * @param {number} [options.windowMs] - Total time to observe. Default: process.env.NEO_INTEGRATION_SUSTAINED_WINDOW_MS || 30000.
- * @param {number} [options.intervalMs] - Polling interval. Default: process.env.NEO_INTEGRATION_SUSTAINED_INTERVAL_MS || 1000.
- * @param {number} [options.successRate] - Minimum success rate. Default: 1.0.
- * @param {number} [options.p95Ms] - Maximum p95 latency. Default: process.env.NEO_INTEGRATION_SUSTAINED_P95_MS || 500.
- * @param {number} [options.maxConsecutiveFailures] - Max sequential failures allowed. Default: 0.
+ * @param {Number} [options.windowMs] - Total time to observe. Default: process.env.NEO_INTEGRATION_SUSTAINED_WINDOW_MS || 30000.
+ * @param {Number} [options.intervalMs] - Polling interval. Default: process.env.NEO_INTEGRATION_SUSTAINED_INTERVAL_MS || 1000.
+ * @param {Number} [options.successRate] - Minimum success rate. Default: 1.0.
+ * @param {Number|null} [options.p95Ms] - Maximum p95 latency; requires >= MIN_PERCENTILE_SAMPLES samples. `null` skips it. Default: process.env.NEO_INTEGRATION_SUSTAINED_P95_MS || 500.
+ * @param {Number|null} [options.maxMs] - Maximum latency of the slowest probe. Valid at any sample count. Default: null.
+ * @param {Number} [options.maxConsecutiveFailures] - Max sequential failures allowed. Default: 0.
  * @param {Function} [options.onSample] - Optional callback to run custom assertions on each sample.
  * @returns {Promise<{samples: Object[], summary: Object}>} The gathered samples and computed summary.
  */
@@ -19,6 +60,7 @@ export async function assertSustainedHealth({
     intervalMs = Number(process.env.NEO_INTEGRATION_SUSTAINED_INTERVAL_MS || 1000),
     successRate = 1.0,
     p95Ms = Number(process.env.NEO_INTEGRATION_SUSTAINED_P95_MS || 500),
+    maxMs = null,
     maxConsecutiveFailures = 0,
     onSample
 }) {
@@ -58,13 +100,37 @@ export async function assertSustainedHealth({
     const actualSuccessRate = samples.length / iterations;
     expect(actualSuccessRate, `Success rate should be >= ${successRate}`).toBeGreaterThanOrEqual(successRate);
 
-    let actualP95 = 0;
+    let actualP95 = 0,
+        actualMax = 0;
+
     if (latencies.length > 0) {
         latencies.sort((a, b) => a - b);
-        const p95Index = Math.max(0, Math.ceil(latencies.length * 0.95) - 1);
-        actualP95 = latencies[p95Index];
 
-        expect(actualP95, `p95 latency should be <= ${p95Ms}ms`).toBeLessThanOrEqual(p95Ms);
+        actualMax = latencies[latencies.length - 1];
+        actualP95 = latencies[percentileIndex(latencies.length, 0.95)];
+
+        if (maxMs !== null) {
+            expect(actualMax, `slowest probe should be <= ${maxMs}ms`).toBeLessThanOrEqual(maxMs);
+        }
+
+        if (p95Ms !== null && p95Ms !== undefined) {
+            // Refuse rather than mislead. A p95 over fewer than MIN_PERCENTILE_SAMPLES samples IS the
+            // max, so asserting one here would gate on the single slowest probe while reporting itself
+            // as a tail-tolerant budget — the failure is then indistinguishable from a real latency
+            // regression, which is how an unrelated author ends up debugging a plane they never touched.
+            if (latencies.length < MIN_PERCENTILE_SAMPLES) {
+                throw new Error(
+                    `assertSustainedHealth: cannot assert a p95 from ${latencies.length} sample(s) — ` +
+                    `below ${MIN_PERCENTILE_SAMPLES} the nearest-rank p95 is the maximum, so the budget ` +
+                    'would forbid a slow tail rather than tolerate one.\n' +
+                    'Either widen the window (windowMs / intervalMs) until it yields enough samples, ' +
+                    'pass `maxMs` to bound the slowest probe instead, or pass `p95Ms: null` if the ' +
+                    'check\'s subject is liveness rather than latency.'
+                );
+            }
+
+            expect(actualP95, `p95 latency should be <= ${p95Ms}ms`).toBeLessThanOrEqual(p95Ms);
+        }
     }
 
     return {
@@ -72,6 +138,7 @@ export async function assertSustainedHealth({
         summary: {
             actualSuccessRate,
             actualP95,
+            actualMax,
             iterations
         }
     };

--- a/test/playwright/unit/test/assertSustainedHealth.spec.mjs
+++ b/test/playwright/unit/test/assertSustainedHealth.spec.mjs
@@ -1,0 +1,143 @@
+import {test, expect} from '@playwright/test';
+
+import {
+    MIN_PERCENTILE_SAMPLES,
+    assertSustainedHealth,
+    percentileIndex
+} from '../../integration/util/assertSustainedHealth.mjs';
+
+/**
+ * The helper's latency budget is the subject here, not the plane it probes.
+ *
+ * A p95 assertion exists to tolerate a slow tail. Over a small sample it does the opposite: the
+ * nearest-rank index lands on the last element, so the "p95" is the maximum and a single slow probe
+ * fails the run under a budget that reads as tolerant — 501ms against a 500ms budget, on a
+ * five-sample window, in a spec whose own name calls it a composability check.
+ *
+ * These arms pin the boundary rather than the symptom. `percentileIndex` is exported precisely so the
+ * degeneracy is assertable as arithmetic — an implementation that quietly returns `n - 1` cannot
+ * satisfy the table below, and no amount of CI-runner luck can make it pass.
+ */
+
+// Probes fast enough that Date.now() deltas stay at 0-1ms, so sample COUNT is what the arms vary.
+// windowFor: iterations === floor(windowMs / intervalMs), and an intervalMs of 1 keeps the
+// inter-sample sleep negligible, so a 20-sample arm still runs in milliseconds.
+const
+    fastProbe = () => Promise.resolve({status: 'healthy'}),
+    slowProbe = ms => () => new Promise(resolve => setTimeout(() => resolve({status: 'healthy'}), ms)),
+    windowFor = sampleCount => ({windowMs: sampleCount, intervalMs: 1});
+
+test.describe('integration/util/assertSustainedHealth — the latency budget must mean what it says', () => {
+    test.describe('percentileIndex — nearest-rank, and where it degenerates', () => {
+        // The load-bearing table. Rank is 1-based from smallest; `above` is how many samples the
+        // budget tolerates over the selected value, which is the whole point of a percentile.
+        //
+        // 19 -> 20 is the boundary: at 19 the index is the last element (tolerates nothing), at 20 it
+        // finally steps back one. MIN_PERCENTILE_SAMPLES is derived from exactly this transition, so
+        // if someone "rounds" that constant to 25 or 10, these arms answer for it.
+        const CASES = [
+            {n: 1,  index: 0,  above: 0},
+            {n: 5,  index: 4,  above: 0},
+            {n: 10, index: 9,  above: 0},
+            {n: 19, index: 18, above: 0},
+            {n: 20, index: 18, above: 1},
+            {n: 30, index: 28, above: 1},
+            {n: 60, index: 56, above: 3}
+        ];
+
+        CASES.forEach(({n, index, above}) => {
+            test(`n=${n} selects index ${index}, tolerating ${above} sample(s) above it`, () => {
+                expect(percentileIndex(n, 0.95)).toBe(index);
+                expect(n - index - 1).toBe(above);
+            });
+        });
+
+        test('below MIN_PERCENTILE_SAMPLES the p95 index IS the last element — the max', () => {
+            for (let n = 1; n < MIN_PERCENTILE_SAMPLES; n++) {
+                expect(percentileIndex(n, 0.95), `n=${n} should degenerate to the max`).toBe(n - 1);
+            }
+        });
+
+        test('MIN_PERCENTILE_SAMPLES is the SMALLEST n where p95 differs from the max', () => {
+            // Both halves matter. The first proves the constant is not larger than it needs to be;
+            // the second proves it is not smaller. A constant justified only from one side drifts.
+            expect(percentileIndex(MIN_PERCENTILE_SAMPLES, 0.95)).toBeLessThan(MIN_PERCENTILE_SAMPLES - 1);
+            expect(percentileIndex(MIN_PERCENTILE_SAMPLES - 1, 0.95)).toBe(MIN_PERCENTILE_SAMPLES - 2);
+        });
+
+        test('never returns a negative index for an empty sample', () => {
+            expect(percentileIndex(0, 0.95)).toBe(0);
+        });
+    });
+
+    test.describe('the p95 budget refuses a sample it cannot resolve', () => {
+        test('throws on a five-sample window rather than gating on the slowest probe', async () => {
+            const run = assertSustainedHealth({probe: fastProbe, ...windowFor(5), p95Ms: 500});
+
+            await expect(run).rejects.toThrow(/cannot assert a p95 from 5 sample\(s\)/);
+        });
+
+        test('the refusal names the sample count AND the remedies', async () => {
+            const run = assertSustainedHealth({probe: fastProbe, ...windowFor(5), p95Ms: 500});
+
+            // A guard that refuses without saying what to do instead gets routed around.
+            await expect(run).rejects.toThrow(/maxMs/);
+            await expect(assertSustainedHealth({probe: fastProbe, ...windowFor(5), p95Ms: 500}))
+                .rejects.toThrow(/p95Ms: null/);
+        });
+
+        test('accepts the sample at exactly MIN_PERCENTILE_SAMPLES — the positive control', async () => {
+            // Without this arm the refusal could be unconditional and every arm above would still pass.
+            const {summary} = await assertSustainedHealth({
+                probe: fastProbe, ...windowFor(MIN_PERCENTILE_SAMPLES), p95Ms: 500
+            });
+
+            expect(summary.iterations).toBe(MIN_PERCENTILE_SAMPLES);
+        });
+
+        test('p95Ms: null opts out entirely, so a liveness check can use a short window', async () => {
+            const {summary} = await assertSustainedHealth({probe: fastProbe, ...windowFor(5), p95Ms: null});
+
+            expect(summary.iterations).toBe(5);
+            expect(summary.actualSuccessRate).toBe(1);
+        });
+    });
+
+    test.describe('maxMs — the statistic a short window CAN support', () => {
+        test('passes when every probe is under the ceiling', async () => {
+            const {summary} = await assertSustainedHealth({
+                probe: fastProbe, ...windowFor(5), p95Ms: null, maxMs: 5000
+            });
+
+            expect(summary.actualMax).toBeLessThanOrEqual(5000);
+        });
+
+        test('fails on the slowest probe, and says so in the max\'s own words', async () => {
+            const run = assertSustainedHealth({
+                probe: slowProbe(40), ...windowFor(3), p95Ms: null, maxMs: 1
+            });
+
+            // The message must not say "p95" — mislabelling is the defect this file exists to pin.
+            await expect(run).rejects.toThrow(/slowest probe should be <= 1ms/);
+        });
+
+        test('composes with a resolvable p95 rather than replacing it', async () => {
+            const {summary} = await assertSustainedHealth({
+                probe: fastProbe, ...windowFor(MIN_PERCENTILE_SAMPLES), p95Ms: 5000, maxMs: 5000
+            });
+
+            expect(summary.actualP95).toBeLessThanOrEqual(summary.actualMax);
+        });
+    });
+
+    test.describe('the summary reports both statistics', () => {
+        test('actualMax is the largest observed latency, not the percentile', async () => {
+            const {summary} = await assertSustainedHealth({
+                probe: slowProbe(20), ...windowFor(3), p95Ms: null, maxMs: 5000
+            });
+
+            expect(summary.actualMax).toBeGreaterThanOrEqual(summary.actualP95);
+            expect(summary.actualMax).toBeGreaterThan(0);
+        });
+    });
+});

--- a/test/playwright/unit/test/assertSustainedHealth.spec.mjs
+++ b/test/playwright/unit/test/assertSustainedHealth.spec.mjs
@@ -130,14 +130,52 @@ test.describe('integration/util/assertSustainedHealth — the latency budget mus
         });
     });
 
-    test.describe('the summary reports both statistics', () => {
-        test('actualMax is the largest observed latency, not the percentile', async () => {
+    test.describe('the SUMMARY refuses the statistic too, not just the assertion', () => {
+        // The first version of these arms asserted `actualMax >= actualP95` at n=3 — where the two are
+        // EQUAL, so it passed on the very conflation it was written to catch. @neo-gpt found the live
+        // consequence: with `p95Ms: null` the exact head still returned `actualP95 === actualMax`, so
+        // the summary republished as DATA what the assertion path refuses to claim. A test that cannot
+        // fail on its own subject is worse than no test — it certifies the defect.
+        //
+        // One slow probe among fast ones is what separates the two statistics: it IS the max, and a
+        // genuine p95 at n=20 must not select it.
+        const oneSlowProbeAmong = () => {
+            let call = 0;
+
+            return () => {
+                call++;
+                return call === 1 ? new Promise(resolve => setTimeout(() => resolve({status: 'healthy'}), 40))
+                                  : Promise.resolve({status: 'healthy'})
+            }
+        };
+
+        test('n=5 — actualP95 is null, and actualMax still reports the outlier', async () => {
             const {summary} = await assertSustainedHealth({
-                probe: slowProbe(20), ...windowFor(3), p95Ms: null, maxMs: 5000
+                probe: oneSlowProbeAmong(), ...windowFor(5), p95Ms: null, maxMs: 5000
             });
 
-            expect(summary.actualMax).toBeGreaterThanOrEqual(summary.actualP95);
-            expect(summary.actualMax).toBeGreaterThan(0);
+            expect(summary.actualP95, 'five samples cannot resolve a p95').toBeNull();
+            expect(summary.actualMax, 'the max is always reportable').toBeGreaterThanOrEqual(35);
+        });
+
+        test('n=20 — actualP95 resolves and is STRICTLY below the outlier max', async () => {
+            const {summary} = await assertSustainedHealth({
+                probe: oneSlowProbeAmong(), ...windowFor(MIN_PERCENTILE_SAMPLES), p95Ms: null, maxMs: 5000
+            });
+
+            // Strictly less, not <=. Equality here is the conflation, so `toBeLessThan` is the only
+            // form of this assertion that can fail when the guard regresses.
+            expect(summary.actualP95).not.toBeNull();
+            expect(summary.actualP95).toBeLessThan(summary.actualMax);
+            expect(summary.actualMax).toBeGreaterThanOrEqual(35);
+        });
+
+        test('a null p95 is never mistakable for a fast one', async () => {
+            // `0` would be a plausible latency; the distinction has to survive a consumer reading it.
+            const {summary} = await assertSustainedHealth({probe: fastProbe, ...windowFor(5), p95Ms: null});
+
+            expect(summary.actualP95).toBeNull();
+            expect(summary.actualP95).not.toBe(0);
         });
     });
 });


### PR DESCRIPTION
Resolves #17172

> 🌿 A percentile exists to forgive the slow tail. Over five samples it forgives nothing, and still answers to the name.

`assertSustainedHealth` now refuses to assert a statistic its sample cannot support. Below twenty observations a nearest-rank p95 *is* the maximum, so the helper says so instead of returning the max wearing a p95 label.

Evidence: L4 (18 unit arms over the pure index function and the helper's own control flow, red-proved three independent ways) → L4 required (every AC is a local, in-process observable; the integration plane is not needed to decide any of them). Residual: none.

## What happened

CI reddened PR #17166 with `p95 latency should be <= 500ms / Received: 501`. That PR touches `ai/services/github-workflow/**` and nothing else; the failing spec probes the Dockerized KB/MC plane. The diff and the failure share no surface, and I spent a good part of a turn establishing that before I could look at the actual cause.

## Deltas from ticket

I authored #17172 an hour before this PR, so there is no age-decay to report — but three things did move between ticket and implementation, and one of them is a correction to my own filing.

1. **The ticket's first version called the formula wrong. It is not.** I wrote that the index "does not select a 95th percentile"; `ceil(p·n) - 1` is textbook nearest-rank and the original author implemented it faithfully. I corrected the ticket before starting work rather than defend the framing, because the accusation matters to whoever reads it next: the defect is applying a correct formula to a sample too small for the statistic, which is a different and more interesting bug than bad arithmetic.

2. **The AC asked for the index table at n = 5/10/19/20/30/60; the spec also pins n = 1.** A one-sample window is the degenerate-degenerate case and `Math.max(0, …)` is the only thing standing between it and index `-1`. Cheap arm, real boundary.

3. **The AC offered "either pass an explicit generous budget with a comment, or let the latency assertion be opt-in". The implementation does both**, because they answer different questions: `p95Ms: null` records that this check has no opinion on latency, and `maxMs` records the ceiling it does hold. Collapsing them would have made the call site say less than it knows.

One AC deliberately discharged in prose rather than code: *"the two HeartbeatPropagation call sites are reviewed under the same lens and either kept deliberately or adjusted — a decision, not an omission."* They are correct as written, so the decision lives in this body rather than as two comments explaining why nothing changed. A permanent comment recording a transient review is the bloat that discipline exists to prevent.

## The defect

**The formula is correct and the original author implemented it faithfully.** `ceil(p·n) - 1` is textbook nearest-rank. The defect is where it is applied:

| samples | index | rank | tolerated above | effective |
|---|---|---|---|---|
| **5** | 4 | 5 of 5 | **0** | **100%** |
| 10 | 9 | 10 of 10 | **0** | **100%** |
| 19 | 18 | 19 of 19 | **0** | **100%** |
| 20 | 18 | 19 of 20 | 1 | 95% |
| 30 | 28 | 29 of 30 | 1 | 96.7% |

`ceil(0.95n) - 1 === n - 1` for every n ≤ 19. `healthcheck.spec.mjs` runs a 5s/1s window — **five samples** — so the assertion labelled *"p95 latency should be ≤ 500ms"* actually demanded that **every** probe be ≤ 500ms. A budget whose entire purpose is tolerating a slow tail was forbidding one, and a single 501ms probe failed the build for the whole team.

Interpolating instead would not have rescued it: a linear p95 of five samples still lands against the largest of them. **Five samples do not contain a 95th percentile under any definition** — which is the thing the helper has to say, rather than paper over.

## Why the call site makes it sharper

The test is named `Sustained liveness composability check (Lane B helper) — 5s/1s`. Its stated job is proving the helper *composes* — two probes under `Promise.all`, both return. It is not a latency benchmark, yet it inherited the full default budget and gated the merge queue on a 500ms tail it never meant to measure.

## The shape

- **`MIN_PERCENTILE_SAMPLES = 20`**, derived from the 19→20 transition rather than chosen for roundness, and asserted **from both sides** — that 20 works and that 19 does not. A constant justified from one side drifts.
- **`p95Ms` below that count throws**, naming the sample count *and* both remedies. A guard that refuses without saying what to do instead gets routed around — that is the same lesson the failure text in #17151 encodes.
- **`maxMs`** bounds the slowest probe and is valid at any n: the statistic a short window genuinely supports, named for what it is.
- **`percentileIndex` is exported**, so the degeneracy is assertable as arithmetic. An implementation that quietly returns `n - 1` cannot satisfy the pinned table, and no CI-runner luck can make it pass.
- The 5s/1s call site now passes `p95Ms: null, maxMs: <generous liveness ceiling>`, with the reason at the call site rather than in the ticket.
- **`summary.actualP95` is `null` below the floor**, not a number — the refusal covers the reported value, not only the assertion. See the round-2 section.

## Deliberately not done

**Raising 500 → 600.** That buys quiet until the next noisy runner and leaves the label lying. The number is not the defect.

**Touching the two `HeartbeatPropagation` call sites.** They run at the n=30 default where the p95 is genuine (index 28, one sample tolerated), so they are correct as written. Reviewed under the same lens and left alone — a decision, recorded here rather than an omission.

One thing I checked rather than assumed, because the refusal could otherwise break those specs in CI: `NEO_INTEGRATION_SUSTAINED_WINDOW_MS` and its siblings are **read only inside this helper and set nowhere in the repo** (grep across yml/yaml/json/mjs/env). No environment shortens those windows into the refusal path.

## Round 2 — @neo-gpt: the summary republished the defect as data

I fixed the *assertion* and left the same conflation in the *reported value*. `actualP95` was computed unconditionally, so with `p95Ms: null` and n=5 the summary returned `actualP95 === actualMax`. Reproduced before repairing, using one slow probe among fast ones so the two statistics can differ at all:

```
n= 5   actualP95=40  actualMax=40   CONFLATED
n=20   actualP95=0   actualMax=41   separated
```

A consumer charting `summary.actualP95` over short windows would have been charting the maximum under a p95 label — the original defect, one layer out. Below `MIN_PERCENTILE_SAMPLES`, `actualP95` is now **`null`**; `null` rather than `0` because zero is a plausible latency and a reader cannot tell it from a fast probe.

**My own spec arm certified the defect.** It asserted `actualMax >= actualP95` at n=3, where the two are equal — so it passed on exactly the conflation it was written to catch, which is worse than no arm because it reads as coverage. The replacement uses strict `toBeLessThan`, the only form that can fail when the guard regresses:

```
old:  actualMax >= actualP95   ->  true  on (40, 40)   passes on the conflation
new:  actualP95 <  actualMax   ->  false on (40, 40)   fails on it
```

Consumer sweep before changing the return shape: **no integration spec and no module outside `test/` reads the summary** — all three call sites discard the return value — so the null breaks nothing. `@returns` now states the nullability rather than leaving it to be found.

## Test Evidence

```
npx playwright test -c test/playwright/playwright.config.unit.mjs \
  test/playwright/unit/test/ --workers=1
→ 41 passed (2.6s)     [20 of them new]
```

**Red-proved three ways** — each mutation is a plausible wrong implementation, not a strawman:

| mutation | arms failed |
|---|---|
| `percentileIndex` returns `n - 1` always (the degeneracy, generalized) | **4** |
| the small-sample refusal removed (the behaviour as it shipped) | **2** |
| `MIN_PERCENTILE_SAMPLES` raised to 25 (an unjustified round number) | **2** |
| `actualP95` computed unconditionally (the round-1 head @neo-gpt reviewed) | **2** |

The third matters most: it is what stops the constant drifting later to whatever number makes a future red go away.

Arms cover the index table at n = 1/5/10/19/20/30/60, the exhaustive claim that *every* n below the boundary degenerates to the max, both sides of the boundary itself, the empty sample, the refusal and its message content, the positive control at exactly `MIN_PERCENTILE_SAMPLES` (without which the refusal could be unconditional and every other arm would still pass), `p95Ms: null` opting out, `maxMs` passing and failing in the max's own words, and the summary reporting both statistics.

## Precedent

#10918 was this same helper failing this same way: `toBeGreaterThan` on consecutive `process.uptime()` samples, broken by a CI runner fast enough to return identical fractional seconds. Fixed in PR #10920 by loosening the comparison.

Same family, same root class — an assertion tuned to a developer's intuition about a real environment and violated by CI's, without the system being unhealthy. One instance is a fix; two is the template, which is why this went to a ticket rather than a re-run.

## Honest sizing

**This is not a major flake source and the ticket says so.** Over the last 60 `Tests` runs there were 7 failures and all 7 were `unit` — mine is the only `integration-unified` red in that window, ~1.6%.

What earns the lane is that the defect is structural rather than statistical, provable with `node -e` and independent of how often it fires, and that it fails in the most expensive direction: an unrelated author debugging a plane they never touched.

## Post-Merge Validation

Nothing is owed. Every AC is a local observable and each is armed above. The integration suite exercises the new call-site configuration on its next run, which is confirmation rather than validation debt.

## Evolution

The re-run is what unblocked #17166, and re-running is not a fix — it converts a wrong assertion into a coin flip and teaches the team to read integration reds as noise, which is how a real regression eventually gets waved through. The cost of *not* filing this is not the 1.6%; it is the next person who assumes their own red is this one.

Related: #17166 · #10896 · #10918
Refs #17171 — same shape, found the same afternoon: an artifact whose label claims more than its mechanism delivers.

Authored by Vega (Claude Opus 5, Claude Code). Session 5cd926fa-77e1-4309-8bbf-ca563ab07403.
