### PR TITLE
feat(agentos): client profile contract + verified CAS-safe session custody (#17181)

### DIFF
--- a/apps/agentos/app.mjs
+++ b/apps/agentos/app.mjs
@@ -1,8 +1,8 @@
-import Viewport             from './view/Viewport.mjs';
+import Viewport                                           from './view/Viewport.mjs';
 import {createFleetProfile, retireBearerIngressSlot}      from './fleet/connectionProfiles.mjs';
 import {FLEET_LOCAL_TRANSPORT_ERRORS, installFleetBridge} from './fleet/installFleetBridge.mjs';
 import {redeemFleetBearerHandshake}                       from './fleet/redeemFleetBearerHandshake.mjs';
-import WindowManager        from '../../src/manager/Window.mjs';
+import WindowManager                                      from '../../src/manager/Window.mjs';
 
 /**
  * @summary Resolve a currently connected AgentOS window for App-Worker→main RMA. `onStart()` runs
@@ -66,26 +66,46 @@ if (bootUrl?.href && resolveFleetTransportMode(bootUrl) === 'browser' && !global
 }
 
 /**
- * @summary Establish session-only Fleet custody for one boot or healing pass: derive the connection
- * profile from the endpoint, install the bridge — the bearer moves into transport closures, the
- * establish phase — and on a live-bearer install retire the launcher pre-boot slot, the retire
- * phase. A throwing install leaves the slot untouched, which IS the rollback: the prior ingress
- * state survives for the next producer or retry. Exported for unit specs; the injectable
- * `installImpl`/`target` keep the runtime global and the network out of the test process.
+ * @summary Establish session-only Fleet custody for one boot or healing pass, with the full
+ * migration lifecycle made real:
+ *
+ * - **read-old / no-downgrade:** a bearer-less pass NEVER replaces an existing bridge — `onStart()`
+ *   runs for every joining SharedWorker window, and after the first join retires the launcher slot
+ *   a later join would otherwise overwrite the live capability with a fail-closed one.
+ * - **establish:** the install moves the bearer into transport closures (synchronous — the bridge
+ *   is published before this function returns).
+ * - **verify:** an authenticated `resolveViewerIdentity` round-trip through the NEW bridge — a
+ *   constructed closure is not verification; only the server's stamped answer is.
+ * - **retire:** the launcher pre-boot slot is cleared only after verify succeeds, and only while it
+ *   still holds the exact established credential (the CAS guard) — a rejected bearer, an
+ *   unreachable endpoint, and a value rotated in during verification all preserve the ingress,
+ *   which IS the rollback truth. A throwing install preserves it the same way.
+ *
  * @param {Object}   opts
  * @param {String}   opts.fleetUrl                         Raw dial endpoint; identity derives from its canonical form.
  * @param {String}   [opts.bearerToken=null]               Redeemed or launcher-placed bearer; `null` boots fail-closed.
  * @param {Function} [opts.installImpl=installFleetBridge] Injectable install for tests.
  * @param {Object}   [opts.target=globalThis]              Injectable global for tests.
- * @returns {Object} the installed registry bridge.
+ * @returns {Object} `{bridge, custodySettled}` — the installed (or preserved) registry bridge, and
+ *     a never-rejecting promise resolving `true` exactly when the ingress slot was verified-retired.
  */
 export function establishFleetSessionCustody({fleetUrl, bearerToken = null, installImpl = installFleetBridge, target = globalThis} = {}) {
+    const existing = target.AgentOS?.fleet?.registryBridge;
+
+    if (bearerToken === null && existing) {
+        return {bridge: existing, custodySettled: Promise.resolve(false)}
+    }
+
     const profile = createFleetProfile({custodian: 'session-only', endpoint: fleetUrl}),
           bridge  = installImpl({url: fleetUrl, bearerToken, profileId: profile.profileId, target});
 
-    bearerToken && retireBearerIngressSlot(target);
+    const custodySettled = bearerToken === null
+        ? Promise.resolve(false)
+        : bridge.resolveViewerIdentity()
+            .then(() => retireBearerIngressSlot(target, {expected: bearerToken}))
+            .catch(() => false);
 
-    return bridge
+    return {bridge, custodySettled}
 }
 
 export const onStart = () => {
@@ -114,11 +134,13 @@ export const onStart = () => {
         // hand-off: the module-private handshake redemption above, or the launcher pre-boot slot
         // (Electron main, the Neural Link, a test init-script places it BEFORE app start) — read
         // here (the read-old phase), moved into transport closures by the install (establish), and
-        // the slot retired once the live bridge stands (retire). Deliberately never read from URL
-        // params — a secret in a URL persists in history, logs, and referrers, so installFleetBridge
-        // refuses credential-shaped query params outright. Without a bearer the bridge installs
-        // fail-closed: every call rejects locally, named — and the slot stays as it was, which is
-        // the rollback truth.
+        // the slot retired only after the bridge's authenticated whoami round-trip proves the
+        // credential, and only while the slot still holds that exact value (verify → CAS retire).
+        // Deliberately never read from URL params — a secret in a URL persists in history, logs,
+        // and referrers, so installFleetBridge refuses credential-shaped query params outright.
+        // Without a bearer the bridge installs fail-closed (every call rejects locally, named) —
+        // or, on a SharedWorker re-join, an existing bridge is PRESERVED rather than downgraded —
+        // and the slot stays as it was, which is the rollback truth.
         const bearerToken = redeemedBearer ?? globalThis.AgentOS?.fleet?.bearerToken ?? null;
 
         establishFleetSessionCustody({bearerToken, fleetUrl});

--- a/apps/agentos/app.mjs
+++ b/apps/agentos/app.mjs
@@ -1,4 +1,5 @@
 import Viewport             from './view/Viewport.mjs';
+import {createFleetProfile, retireBearerIngressSlot}      from './fleet/connectionProfiles.mjs';
 import {FLEET_LOCAL_TRANSPORT_ERRORS, installFleetBridge} from './fleet/installFleetBridge.mjs';
 import {redeemFleetBearerHandshake}                       from './fleet/redeemFleetBearerHandshake.mjs';
 import WindowManager        from '../../src/manager/Window.mjs';
@@ -48,24 +49,43 @@ export function resolveFleetUrl() {
     return params.has('fleetUrl') ? params.get('fleetUrl') : 'http://127.0.0.1:8083/fleet'
 }
 
-// The one-command hand-off, page half: in direct-browser mode with the designed slot still empty,
+// The one-command hand-off, page half: in direct-browser mode with the launcher slot still empty,
 // redeem the bearer from the transport's armed handshake BEFORE the app boots — this module-level
-// await completes inside `importApp`'s dynamic import, ahead of every `onStart` call, so the boot
-// install below sees the bearer exactly as if a launcher had placed it. Fail-closed: an unarmed or
+// await completes inside `importApp`'s dynamic import, ahead of every `onStart` call. The redeemed
+// value stays MODULE-PRIVATE: unlike the launcher pre-boot slot it never touches Body-readable
+// state (the custody discipline in ./fleet/connectionProfiles.mjs). Fail-closed: an unarmed or
 // absent transport resolves null and the existing bearer-less boot proceeds unchanged. The
 // URL-envelope guard keeps the module importable OUTSIDE the worker boot (unit specs import this
 // module for its pure exports; there is no serialized boot URL there, so there is nothing to dial).
 const bootUrl = globalThis.Neo?.config?.url;
 
+let redeemedBearer = null;
+
 if (bootUrl?.href && resolveFleetTransportMode(bootUrl) === 'browser' && !globalThis.AgentOS?.fleet?.bearerToken) {
-    const token = await redeemFleetBearerHandshake({url: resolveFleetUrl()});
+    redeemedBearer = await redeemFleetBearerHandshake({url: resolveFleetUrl()})
+}
 
-    if (token) {
-        const agentOS = globalThis.AgentOS = globalThis.AgentOS || {};
+/**
+ * @summary Establish session-only Fleet custody for one boot or healing pass: derive the connection
+ * profile from the endpoint, install the bridge — the bearer moves into transport closures, the
+ * establish phase — and on a live-bearer install retire the launcher pre-boot slot, the retire
+ * phase. A throwing install leaves the slot untouched, which IS the rollback: the prior ingress
+ * state survives for the next producer or retry. Exported for unit specs; the injectable
+ * `installImpl`/`target` keep the runtime global and the network out of the test process.
+ * @param {Object}   opts
+ * @param {String}   opts.fleetUrl                         Raw dial endpoint; identity derives from its canonical form.
+ * @param {String}   [opts.bearerToken=null]               Redeemed or launcher-placed bearer; `null` boots fail-closed.
+ * @param {Function} [opts.installImpl=installFleetBridge] Injectable install for tests.
+ * @param {Object}   [opts.target=globalThis]              Injectable global for tests.
+ * @returns {Object} the installed registry bridge.
+ */
+export function establishFleetSessionCustody({fleetUrl, bearerToken = null, installImpl = installFleetBridge, target = globalThis} = {}) {
+    const profile = createFleetProfile({custodian: 'session-only', endpoint: fleetUrl}),
+          bridge  = installImpl({url: fleetUrl, bearerToken, profileId: profile.profileId, target});
 
-        agentOS.fleet             = agentOS.fleet || {};
-        agentOS.fleet.bearerToken = token
-    }
+    bearerToken && retireBearerIngressSlot(target);
+
+    return bridge
 }
 
 export const onStart = () => {
@@ -73,17 +93,12 @@ export const onStart = () => {
         fallbackWindowId = Neo.bootingWindowId,
         fleetUrl         = resolveFleetUrl();
 
-    // The process bearer is an IN-MEMORY hand-off only: the Electron main process, the
-    // Neural Link, a test init-script — or the armed-handshake redemption above — places it at
-    // globalThis.AgentOS.fleet.bearerToken BEFORE app start. Deliberately never read from URL
-    // params — a secret in a URL persists in history, logs, and referrers, so installFleetBridge
-    // refuses credential-shaped query params outright.
-    // Without the bearer the bridge installs fail-closed: every call rejects locally, named.
-    const bearerToken = globalThis.AgentOS?.fleet?.bearerToken ?? null;
-
     if (resolveFleetTransportMode(Neo.config.url) === 'shell') {
         const route = () => resolveFleetWindowId({fallbackWindowId});
 
+        // Packaged custody is the electron-main custodian shape: endpoint, credential, and profile
+        // identity all live with main; the worker receives only the send capability, so there is
+        // no profileId to stamp and nothing to retire on this side of the boundary.
         installFleetBridge({
             credentialIngress: 'shell',
             send             : request => {
@@ -95,9 +110,19 @@ export const onStart = () => {
             }
         })
     } else {
-        // Direct-browser dev mode remains the distinct transitional topology: its in-memory bearer
-        // and App-Worker credential field are supported here, never in the packaged app:// path.
-        installFleetBridge({url: fleetUrl, bearerToken});
+        // Direct-browser dev mode is the session-only custodian shape. The bearer is an IN-MEMORY
+        // hand-off: the module-private handshake redemption above, or the launcher pre-boot slot
+        // (Electron main, the Neural Link, a test init-script places it BEFORE app start) — read
+        // here (the read-old phase), moved into transport closures by the install (establish), and
+        // the slot retired once the live bridge stands (retire). Deliberately never read from URL
+        // params — a secret in a URL persists in history, logs, and referrers, so installFleetBridge
+        // refuses credential-shaped query params outright. Without a bearer the bridge installs
+        // fail-closed: every call rejects locally, named — and the slot stays as it was, which is
+        // the rollback truth.
+        const bearerToken = redeemedBearer ?? globalThis.AgentOS?.fleet?.bearerToken ?? null;
+
+        establishFleetSessionCustody({bearerToken, fleetUrl});
+        redeemedBearer = null;
 
         // Late-transport healing: the module-level redemption races the fleet child's boot (plane
         // admission alone can take seconds), and on a SharedWorker topology a reload re-enters
@@ -107,14 +132,7 @@ export const onStart = () => {
         // stays the honest fail-closed state.
         if (!bearerToken) {
             redeemFleetBearerHandshake({url: fleetUrl}).then(token => {
-                if (token) {
-                    const agentOS = globalThis.AgentOS = globalThis.AgentOS || {};
-
-                    agentOS.fleet             = agentOS.fleet || {};
-                    agentOS.fleet.bearerToken = token;
-
-                    installFleetBridge({url: fleetUrl, bearerToken: token})
-                }
+                token && establishFleetSessionCustody({bearerToken: token, fleetUrl})
             })
         }
     }

--- a/apps/agentos/app.mjs
+++ b/apps/agentos/app.mjs
@@ -72,22 +72,29 @@ if (bootUrl?.href && resolveFleetTransportMode(bootUrl) === 'browser' && !global
  * - **read-old / no-downgrade:** a bearer-less pass NEVER replaces an existing bridge — `onStart()`
  *   runs for every joining SharedWorker window, and after the first join retires the launcher slot
  *   a later join would otherwise overwrite the live capability with a fail-closed one.
- * - **establish:** the install moves the bearer into transport closures (synchronous — the bridge
- *   is published before this function returns).
+ * - **establish:** the install moves the bearer into transport closures. With NO existing bridge
+ *   the install publishes synchronously (there is nothing to displace, and the pane needs the
+ *   fail-closed or live state immediately). With an existing bridge, the candidate is built
+ *   DETACHED: an unproven credential must never displace a proven capability, so the published
+ *   bridge stays the known-good one until the candidate verifies.
  * - **verify:** an authenticated `resolveViewerIdentity` round-trip through the NEW bridge — a
- *   constructed closure is not verification; only the server's stamped answer is.
+ *   constructed closure is not verification; only the server's stamped answer is. A detached
+ *   candidate is PROMOTED only after this proof, by re-installing into the real target —
+ *   `installFleetBridge` stays the slot's sole publisher.
  * - **retire:** the launcher pre-boot slot is cleared only after verify succeeds, and only while it
  *   still holds the exact established credential (the CAS guard) — a rejected bearer, an
  *   unreachable endpoint, and a value rotated in during verification all preserve the ingress,
- *   which IS the rollback truth. A throwing install preserves it the same way.
+ *   which IS the rollback truth. A throwing install preserves it the same way, and a failed
+ *   candidate leaves the known-good bridge published.
  *
  * @param {Object}   opts
  * @param {String}   opts.fleetUrl                         Raw dial endpoint; identity derives from its canonical form.
  * @param {String}   [opts.bearerToken=null]               Redeemed or launcher-placed bearer; `null` boots fail-closed.
  * @param {Function} [opts.installImpl=installFleetBridge] Injectable install for tests.
  * @param {Object}   [opts.target=globalThis]              Injectable global for tests.
- * @returns {Object} `{bridge, custodySettled}` — the installed (or preserved) registry bridge, and
- *     a never-rejecting promise resolving `true` exactly when the ingress slot was verified-retired.
+ * @returns {Object} `{bridge, custodySettled}` — the bridge PUBLISHED at return time (the fresh
+ *     install, or the preserved known-good one while a candidate proves itself), and a
+ *     never-rejecting promise resolving `true` exactly when the ingress slot was verified-retired.
  */
 export function establishFleetSessionCustody({fleetUrl, bearerToken = null, installImpl = installFleetBridge, target = globalThis} = {}) {
     const existing = target.AgentOS?.fleet?.registryBridge;
@@ -96,16 +103,21 @@ export function establishFleetSessionCustody({fleetUrl, bearerToken = null, inst
         return {bridge: existing, custodySettled: Promise.resolve(false)}
     }
 
-    const profile = createFleetProfile({custodian: 'session-only', endpoint: fleetUrl}),
-          bridge  = installImpl({url: fleetUrl, bearerToken, profileId: profile.profileId, target});
+    const
+        profile    = createFleetProfile({custodian: 'session-only', endpoint: fleetUrl}),
+        publishNow = !existing,
+        bridge     = installImpl({url: fleetUrl, bearerToken, profileId: profile.profileId, target: publishNow ? target : {}});
 
     const custodySettled = bearerToken === null
         ? Promise.resolve(false)
         : bridge.resolveViewerIdentity()
-            .then(() => retireBearerIngressSlot(target, {expected: bearerToken}))
+            .then(() => {
+                publishNow || installImpl({url: fleetUrl, bearerToken, profileId: profile.profileId, target});
+                return retireBearerIngressSlot(target, {expected: bearerToken})
+            })
             .catch(() => false);
 
-    return {bridge, custodySettled}
+    return {bridge: publishNow ? bridge : existing, custodySettled}
 }
 
 export const onStart = () => {

--- a/apps/agentos/fleet/connectionProfiles.mjs
+++ b/apps/agentos/fleet/connectionProfiles.mjs
@@ -1,0 +1,426 @@
+/**
+ * @module apps/agentos/fleet/connectionProfiles
+ * @summary The cockpit's client-side connection-profile contract: ONE versioned endpoint-normalization
+ * policy deriving stable profile identity, the closed record schema that keeps credential material out
+ * of Body-readable state, and the explicit custody-migration machine across the three custodian shapes.
+ *
+ * **Identity discipline (the client twin of the fleet's principal discipline).** A profile's identity
+ * is derived from exactly one durable coordinate — the canonical endpoint — through the same
+ * endpoint-boundary policy the Node side applies (`ai/services/fleet/mcpWireParsing.mjs`,
+ * `normalizeSecureMcpEndpoint`, unwidened). The realm boundary carries no imports, so the twin is
+ * duplicated by construction and the parity spec is the binding. Display labels, logins, and checkout
+ * paths are FORBIDDEN identity keys ({@link PROFILE_FORBIDDEN_IDENTITY_KEYS}): labels are mutable UX,
+ * the server stamps the viewer itself so a client-held login is a claim not a coordinate, and checkout
+ * paths are machine-local. Identity is also distinct from dialing: the transport may carry
+ * non-credential query params the canonical form drops, and the transport's own guards decide what may
+ * be dialed.
+ *
+ * **Custody discipline (the Option-D falsifier as code).** The Body receives a session capability,
+ * never the credential. A profile record is pane-renderable state, so the record schema is CLOSED and
+ * {@link assertStorableProfileRecord} refuses credential material by field name, by value shape, and
+ * by structure — for every custodian shape: the packaged shell stores nothing credential-adjacent
+ * (Electron main owns custody), the browser-dev session holds the bearer only in transport closures,
+ * and the headless client file stores the NAME of an environment variable, never its value.
+ *
+ * **Migration discipline.** Moving a profile between custodian shapes is an explicit four-phase
+ * transition — read the old custody state, establish the new custody, verify the new connection,
+ * retire the old ingress — with rollback legal until retire and a generation counter that advances
+ * only on completion, so revocation/rotation truth is never lost to a half-finished move.
+ *
+ * Worker-realm module: no Node imports, no Neo import — mirrors its siblings
+ * `installFleetBridge.mjs` and `redeemFleetBearerHandshake.mjs`, which import their shared security
+ * constants from here so the worker realm holds exactly one copy of each.
+ */
+
+/**
+ * The version of the endpoint-normalization + record contract, stamped into every profile id and
+ * record. A record whose `contractVersion` differs from this constant is STALE: its id may not be
+ * compared against freshly derived ids, and it must pass {@link rehydrateProfile} before use.
+ * @type {Number}
+ */
+export const FLEET_PROFILE_CONTRACT_VERSION = 1;
+
+/**
+ * Canonical shape of the Fleet process bearer: 32 random bytes as unpadded base64url (43 chars).
+ * A lightweight FORMAT check only — the Node side owns generation + constant-time verification
+ * (`ai/mcp/server/shared/helpers/localBearer.mjs`). The worker realm's single copy: the transport
+ * and handshake siblings import it from here, because per-module security copies are a known
+ * defect class.
+ * @type {RegExp}
+ */
+export const FLEET_BEARER_PATTERN = /^[A-Za-z0-9_-]{43}$/;
+
+/**
+ * The three custodian shapes a profile's credential custody can take:
+ * - `electron-main` — packaged shell; Electron main owns endpoint + credential, the worker holds
+ *   only the injected send capability.
+ * - `session-only` — direct-browser dev; the bearer lives in transport closures for the session
+ *   and is never persisted.
+ * - `env-indirection` — headless client file; the profile names an environment variable and the
+ *   consuming process resolves it, so the file carries indirection, never material.
+ * @type {String[]}
+ */
+export const PROFILE_CUSTODIANS = Object.freeze(['electron-main', 'session-only', 'env-indirection']);
+
+/**
+ * Keys that must NEVER contribute to profile identity, kept as a named list so record-schema and
+ * form code reviews have the contract in one place. Enforcement is by construction —
+ * {@link deriveFleetProfileId} accepts only the endpoint — and the spec pins that changing any of
+ * these never changes the id.
+ * @type {String[]}
+ */
+export const PROFILE_FORBIDDEN_IDENTITY_KEYS = Object.freeze(['label', 'login', 'checkoutPath']);
+
+/**
+ * Field names that may never appear on a profile record under ANY custodian: each one is a slot a
+ * credential VALUE would ride in. `bearerEnvVar` is deliberately absent — it carries a name, not
+ * material, and is admitted per-custodian by {@link CUSTODIAN_STORABLE_CREDENTIAL_FIELDS}.
+ * @type {String[]}
+ */
+export const PROFILE_FORBIDDEN_CREDENTIAL_FIELDS = Object.freeze([
+    'authorization', 'bearer', 'bearerToken', 'credential', 'password', 'secret', 'token'
+]);
+
+/**
+ * The credential-adjacent fields each custodian shape may store on a record. Two shapes store
+ * NOTHING — that absence is the design, not an omission: main-process custody and closure custody
+ * both leave the record free of anything to protect.
+ * @type {Readonly<Object>}
+ */
+export const CUSTODIAN_STORABLE_CREDENTIAL_FIELDS = Object.freeze({
+    'electron-main'  : Object.freeze([]),
+    'env-indirection': Object.freeze(['bearerEnvVar']),
+    'session-only'   : Object.freeze([])
+});
+
+/**
+ * The closed core schema of a profile record. Everything else is either a custodian-admitted
+ * credential-adjacent field or refused — an open schema would be a smuggling surface.
+ * @type {String[]}
+ */
+const PROFILE_RECORD_CORE_FIELDS = Object.freeze(['canonicalEndpoint', 'contractVersion', 'custodian', 'generation', 'label', 'profileId']);
+
+/**
+ * Hosts for which plain `http:` is accepted — the exact-set twin of the Node policy's loopback
+ * exception. `[::1]` keeps its brackets: compared against `URL#hostname`, which returns the IPv6
+ * literal bracketed.
+ * @type {Set<String>}
+ */
+const LOOPBACK_HOSTS = new Set(['localhost', '127.0.0.1', '[::1]']);
+
+/**
+ * Plausible environment-variable name for the env-indirection custodian: conventional upper-snake,
+ * so a pasted VALUE (spaces, lowercase base64url, punctuation) is refused as a name.
+ * @type {RegExp}
+ */
+const ENV_VAR_NAME_PATTERN = /^[A-Z][A-Z0-9_]*$/;
+
+/**
+ * @summary Normalize a candidate fleet endpoint to its canonical identity form, or `null` fail-closed.
+ *
+ * The client twin of the Node side's shared endpoint-boundary policy, unwidened: http/https only,
+ * no credentials-in-URL, TLS required for anything remote — plain `http:` survives only for exact
+ * loopback hosts. The canonical form is origin + pathname with trailing slashes stripped, so one
+ * endpoint maps to one identity regardless of query, hash, host case, or default-port spelling.
+ * The parity spec pins client and Node answers to the same fixture matrix.
+ *
+ * @param {*} candidateUrl
+ * @returns {String|null} the canonical endpoint, or `null` on every refused shape.
+ */
+export function normalizeFleetEndpoint(candidateUrl) {
+    if (typeof candidateUrl !== 'string' || candidateUrl.trim() === '') {
+        return null
+    }
+
+    let url;
+
+    try {
+        url = new URL(candidateUrl.trim())
+    } catch {
+        return null
+    }
+
+    if (url.username || url.password) {
+        return null
+    }
+
+    if (url.protocol !== 'https:' && !(url.protocol === 'http:' && LOOPBACK_HOSTS.has(url.hostname))) {
+        return null
+    }
+
+    return (url.origin + url.pathname).replace(/\/+$/, '')
+}
+
+/**
+ * @summary Derive the stable profile id for an endpoint, or `null` when normalization refuses it.
+ * The id embeds the contract version, so ids from different contract versions can never collide
+ * silently — a stale record re-derives through {@link rehydrateProfile} instead of being compared.
+ * @param {*} candidateUrl
+ * @returns {String|null}
+ */
+export function deriveFleetProfileId(candidateUrl) {
+    const canonical = normalizeFleetEndpoint(candidateUrl);
+
+    return canonical === null ? null : `fleet-profile:v${FLEET_PROFILE_CONTRACT_VERSION}:${canonical}`
+}
+
+/**
+ * @summary Assert a profile record is storable: closed schema, flat primitives, custodian-admitted
+ * fields only, and no credential material by name or by value shape. Returns a frozen shallow copy
+ * so the validated record cannot drift after the check.
+ *
+ * The value scan refuses ANY own string matching the bearer format — including in `label` — so a
+ * secret cannot be smuggled through a display field into pane-renderable state. Records from an
+ * older contract version pass shape checks and are the caller's cue to {@link rehydrateProfile};
+ * id self-consistency is enforced for current-version records, which catches hand-forged ids.
+ *
+ * @param {Object} record
+ * @returns {Readonly<Object>} the frozen validated record.
+ */
+export function assertStorableProfileRecord(record) {
+    if (record === null || typeof record !== 'object' || Array.isArray(record)) {
+        throw new TypeError('fleet profile record must be a plain object')
+    }
+
+    const {canonicalEndpoint, contractVersion, custodian, generation, profileId} = record;
+
+    if (!PROFILE_CUSTODIANS.includes(custodian)) {
+        throw new TypeError(`fleet profile custodian must be one of: ${PROFILE_CUSTODIANS.join(', ')}`)
+    }
+
+    if (typeof profileId !== 'string' || typeof canonicalEndpoint !== 'string') {
+        throw new TypeError('fleet profile record requires string profileId and canonicalEndpoint')
+    }
+
+    if (!Number.isInteger(contractVersion) || contractVersion < 1 || !Number.isInteger(generation) || generation < 1) {
+        throw new TypeError('fleet profile record requires positive-integer contractVersion and generation')
+    }
+
+    const admitted = [...PROFILE_RECORD_CORE_FIELDS, ...CUSTODIAN_STORABLE_CREDENTIAL_FIELDS[custodian]];
+
+    for (const [field, value] of Object.entries(record)) {
+        if (PROFILE_FORBIDDEN_CREDENTIAL_FIELDS.includes(field)) {
+            throw new TypeError(`fleet profile record refuses credential field '${field}' — the record is pane-renderable state and carries no credential material`)
+        }
+
+        if (!admitted.includes(field)) {
+            throw new TypeError(`fleet profile record refuses unknown field '${field}' — the schema is closed so there is no smuggling surface`)
+        }
+
+        if (value !== null && !['boolean', 'number', 'string'].includes(typeof value)) {
+            throw new TypeError(`fleet profile record field '${field}' must be a flat primitive — nested values defeat the credential scan`)
+        }
+
+        if (typeof value === 'string' && FLEET_BEARER_PATTERN.test(value)) {
+            throw new TypeError(`fleet profile record field '${field}' carries bearer-shaped material — a credential never enters Body-readable state`)
+        }
+    }
+
+    if (contractVersion === FLEET_PROFILE_CONTRACT_VERSION && deriveFleetProfileId(canonicalEndpoint) !== profileId) {
+        throw new TypeError('fleet profile id does not re-derive from its canonical endpoint — ids are derived, never hand-assigned')
+    }
+
+    return Object.freeze({...record})
+}
+
+/**
+ * @summary Create a validated, frozen profile record for one endpoint under one custodian shape.
+ * The single producer path: creation routes through {@link assertStorableProfileRecord}, so every
+ * live record has passed the same guard.
+ * @param {Object}  opts
+ * @param {String}  opts.endpoint               Raw endpoint; identity derives from its canonical form.
+ * @param {String}  opts.custodian              One of {@link PROFILE_CUSTODIANS}.
+ * @param {String}  [opts.label]                Display label — mutable UX, never identity.
+ * @param {String}  [opts.bearerEnvVar]         env-indirection only: the environment-variable NAME
+ *     the consuming process resolves; conventional upper-snake, so a pasted value is refused.
+ * @returns {Readonly<Object>}
+ */
+export function createFleetProfile({endpoint, custodian, label, bearerEnvVar} = {}) {
+    const canonicalEndpoint = normalizeFleetEndpoint(endpoint);
+
+    if (canonicalEndpoint === null) {
+        throw new TypeError('createFleetProfile requires an https endpoint, or plain http on an exact loopback host, with no credentials in the URL')
+    }
+
+    if (bearerEnvVar !== undefined) {
+        if (custodian !== 'env-indirection') {
+            throw new TypeError("createFleetProfile: bearerEnvVar is the env-indirection custodian's field — other shapes store nothing credential-adjacent")
+        }
+
+        if (typeof bearerEnvVar !== 'string' || !ENV_VAR_NAME_PATTERN.test(bearerEnvVar)) {
+            throw new TypeError('createFleetProfile: bearerEnvVar must be an environment-variable NAME (upper-snake), never a value')
+        }
+    }
+
+    return assertStorableProfileRecord({
+        canonicalEndpoint,
+        contractVersion: FLEET_PROFILE_CONTRACT_VERSION,
+        custodian,
+        generation     : 1,
+        profileId      : deriveFleetProfileId(canonicalEndpoint),
+        ...(label       !== undefined ? {label} : {}),
+        ...(bearerEnvVar !== undefined ? {bearerEnvVar} : {})
+    })
+}
+
+/**
+ * @summary Whether a record was written under a different contract version. A stale record's id is
+ * not comparable to freshly derived ids; pass it through {@link rehydrateProfile} before use.
+ * @param {Object} record
+ * @returns {Boolean}
+ */
+export function isStaleProfile(record) {
+    return record?.contractVersion !== FLEET_PROFILE_CONTRACT_VERSION
+}
+
+/**
+ * @summary Re-derive a stale record under the current contract, preserving custody truth: custodian,
+ * generation, label, and any custodian-admitted fields survive; identity is re-derived from the
+ * stored canonical endpoint. An endpoint the current contract refuses cannot be silently upgraded —
+ * that is the stale-profile behavior: refuse loudly, recreate from the raw endpoint deliberately.
+ * @param {Object} record
+ * @returns {Readonly<Object>} the current-version record.
+ */
+export function rehydrateProfile(record) {
+    const {canonicalEndpoint} = record ?? {},
+          rederived           = deriveFleetProfileId(canonicalEndpoint);
+
+    if (rederived === null) {
+        throw new TypeError(`fleet profile cannot rehydrate — its stored endpoint no longer normalizes under contract v${FLEET_PROFILE_CONTRACT_VERSION}; recreate the profile from its raw endpoint`)
+    }
+
+    return assertStorableProfileRecord({
+        ...record,
+        canonicalEndpoint: normalizeFleetEndpoint(canonicalEndpoint),
+        contractVersion  : FLEET_PROFILE_CONTRACT_VERSION,
+        profileId        : rederived
+    })
+}
+
+/**
+ * The four explicit phases of a custody migration, in execution order: read the old custody state,
+ * establish the new custody, verify the new connection, retire the old ingress.
+ * @type {String[]}
+ */
+export const CUSTODY_MIGRATION_PHASES = Object.freeze(['read-old', 'establish', 'verify', 'retire']);
+
+/**
+ * @summary Create the explicit state machine for moving one profile between custodian shapes.
+ *
+ * `advance()` declares the current phase done and returns the next (or `null` when retire
+ * completes). `rollback()` is legal until completion and is TERMINAL: the machine reports the old
+ * custodian and the unchanged generation, and a fresh migration must be created to try again —
+ * retire is the point of no return in both directions, so a rotation or revocation that happened
+ * mid-migration is never papered over by replaying phases. `nextGeneration` is readable only after
+ * completion: the generation counter advances exactly when the old ingress is retired.
+ *
+ * @param {Object} opts
+ * @param {String} opts.fromCustodian One of {@link PROFILE_CUSTODIANS}.
+ * @param {String} opts.toCustodian   One of {@link PROFILE_CUSTODIANS}, different from `fromCustodian`.
+ * @param {Number} opts.generation    The profile's current generation.
+ * @returns {Object} the migration machine.
+ */
+export function createCustodyMigration({fromCustodian, toCustodian, generation} = {}) {
+    if (!PROFILE_CUSTODIANS.includes(fromCustodian) || !PROFILE_CUSTODIANS.includes(toCustodian)) {
+        throw new TypeError(`custody migration requires custodians from: ${PROFILE_CUSTODIANS.join(', ')}`)
+    }
+
+    if (fromCustodian === toCustodian) {
+        throw new TypeError('custody migration requires two DIFFERENT custodian shapes — re-establishing the same custody is a reconnect, not a migration')
+    }
+
+    if (!Number.isInteger(generation) || generation < 1) {
+        throw new TypeError('custody migration requires the profile\'s positive-integer generation')
+    }
+
+    let phaseIndex = 0,
+        completed  = false,
+        rolledBack = false;
+
+    return Object.freeze({
+        fromCustodian,
+        toCustodian,
+
+        get phase() {
+            return completed || rolledBack ? null : CUSTODY_MIGRATION_PHASES[phaseIndex]
+        },
+
+        get completed() {
+            return completed
+        },
+
+        get rolledBack() {
+            return rolledBack
+        },
+
+        /**
+         * @summary The generation the profile carries after this migration — readable only once
+         * retire completed, because generation truth advances exactly there.
+         * @returns {Number}
+         */
+        get nextGeneration() {
+            if (!completed) {
+                throw new Error('custody migration generation advances only at retire — an incomplete or rolled-back migration keeps the old custody truth')
+            }
+
+            return generation + 1
+        },
+
+        /**
+         * @summary Declare the current phase done. Returns the next phase, or `null` when the
+         * retire phase completes the migration.
+         * @returns {String|null}
+         */
+        advance() {
+            if (completed || rolledBack) {
+                throw new Error('custody migration is terminal — create a new migration to move custody again')
+            }
+
+            if (phaseIndex === CUSTODY_MIGRATION_PHASES.length - 1) {
+                completed = true;
+                return null
+            }
+
+            phaseIndex++;
+            return CUSTODY_MIGRATION_PHASES[phaseIndex]
+        },
+
+        /**
+         * @summary Abandon the migration before retire: the old custodian remains the custody
+         * truth at the unchanged generation, and this machine becomes terminal.
+         * @returns {Object} `{custodian, generation}` — the restored custody truth.
+         */
+        rollback() {
+            if (completed) {
+                throw new Error('custody migration cannot roll back after retire — the old ingress is gone; create a new migration instead')
+            }
+
+            if (rolledBack) {
+                throw new Error('custody migration is terminal — create a new migration to move custody again')
+            }
+
+            rolledBack = true;
+            return {custodian: fromCustodian, generation}
+        }
+    })
+}
+
+/**
+ * @summary The executable retire phase for the cockpit's pre-boot bearer ingress: clear the
+ * launcher hand-off slot once transport custody holds the bearer in closure. External producers
+ * (Electron main, Neural Link init scripts, test setups) still PLACE the bearer there before app
+ * start — the slot remains the ingress; after establish + verify it stops being residence, which
+ * is what keeps the credential out of durable Body-readable state.
+ * @param {Object} target The global-shaped object carrying `AgentOS.fleet`.
+ * @returns {Boolean} whether a bearer was present and retired.
+ */
+export function retireBearerIngressSlot(target) {
+    const fleet = target?.AgentOS?.fleet;
+
+    if (fleet && 'bearerToken' in fleet) {
+        delete fleet.bearerToken;
+        return true
+    }
+
+    return false
+}

--- a/apps/agentos/fleet/connectionProfiles.mjs
+++ b/apps/agentos/fleet/connectionProfiles.mjs
@@ -411,13 +411,21 @@ export function createCustodyMigration({fromCustodian, toCustodian, generation} 
  * (Electron main, Neural Link init scripts, test setups) still PLACE the bearer there before app
  * start — the slot remains the ingress; after establish + verify it stops being residence, which
  * is what keeps the credential out of durable Body-readable state.
- * @param {Object} target The global-shaped object carrying `AgentOS.fleet`.
- * @returns {Boolean} whether a bearer was present and retired.
+ *
+ * `expected` is the compare-and-swap guard: when given, the slot is retired only while it still
+ * holds exactly that value — the credential that PROVABLY verified into closure custody. A value a
+ * producer rotated in during verification is a different credential that never verified, so it
+ * survives the retire attempt; deleting it would destroy rotation truth the migration contract
+ * promises to keep.
+ * @param {Object} target             The global-shaped object carrying `AgentOS.fleet`.
+ * @param {Object} [opts]
+ * @param {String} [opts.expected]    Retire only if the slot still equals this exact value.
+ * @returns {Boolean} whether a bearer was present (and matching, when guarded) and retired.
  */
-export function retireBearerIngressSlot(target) {
+export function retireBearerIngressSlot(target, {expected} = {}) {
     const fleet = target?.AgentOS?.fleet;
 
-    if (fleet && 'bearerToken' in fleet) {
+    if (fleet && 'bearerToken' in fleet && (expected === undefined || fleet.bearerToken === expected)) {
         delete fleet.bearerToken;
         return true
     }

--- a/apps/agentos/fleet/installFleetBridge.mjs
+++ b/apps/agentos/fleet/installFleetBridge.mjs
@@ -1,3 +1,4 @@
+import {FLEET_BEARER_PATTERN} from './connectionProfiles.mjs';
 import {
     createFleetWireOffer,
     createFleetWireRequest,
@@ -5,15 +6,6 @@ import {
     FLEET_WIRE_RESPONSE_STATES,
     inspectFleetWireResponse
 } from '../config/fleetWireMethods.mjs';
-
-/**
- * Canonical shape of the Fleet process bearer: 32 random bytes as unpadded base64url (43 chars).
- * A lightweight FORMAT check only — the Node side owns generation + constant-time verification
- * (`ai/mcp/server/shared/helpers/localBearer.mjs`); this module runs in the App Worker and must
- * stay free of Node crypto imports.
- * @type {RegExp}
- */
-const FLEET_BEARER_PATTERN = /^[A-Za-z0-9_-]{43}$/;
 
 /**
  * Query-param names that would smuggle credential material through a URL. The Fleet launch
@@ -72,6 +64,11 @@ export const FLEET_LOCAL_TRANSPORT_ERRORS = Object.freeze({
  * @param {Function} [opts.send=null]                      Packaged-shell intent transport; receives
  *     only `{method, params}` and is mutually exclusive with `url` / `bearerToken`.
  * @param {'worker'|'shell'} [opts.credentialIngress='worker'] Public credential-custody fact.
+ * @param {String}   [opts.profileId=null]                 The connection-profile identity this bridge
+ *     serves (`./connectionProfiles.mjs` derivation) — a renderable capability fact like
+ *     `credentialIngress`, never credential material; bearer-shaped values are refused outright.
+ *     `null` for installs whose identity lives with the custodian (the packaged shell) or predates
+ *     profile wiring.
  * @param {Boolean}  [opts.selected=false]                 Whether this install is an explicit source
  *     selection (the injector path) versus the boot default. Selected bridges render an empty
  *     registry's true zero state; unselected defaults keep the zero-setup sample.
@@ -84,6 +81,7 @@ export function installFleetBridge({
     fetchImpl = globalThis.fetch,
     send = null,
     credentialIngress = 'worker',
+    profileId = null,
     selected = false,
     target = globalThis
 } = {}) {
@@ -92,6 +90,10 @@ export function installFleetBridge({
 
     if (!['shell', 'worker'].includes(credentialIngress)) {
         throw new TypeError("installFleetBridge: credentialIngress must be 'shell' or 'worker'")
+    }
+
+    if (profileId !== null && (typeof profileId !== 'string' || !profileId.trim() || FLEET_BEARER_PATTERN.test(profileId))) {
+        throw new TypeError('installFleetBridge: profileId must be null or a non-empty identity string — bearer-shaped material is refused, the fact is pane-renderable')
     }
 
     if (send !== null) {
@@ -199,6 +201,13 @@ export function installFleetBridge({
     Object.defineProperty(registryBridge, 'credentialIngress', {
         configurable: true,
         value       : credentialIngress
+    });
+
+    // The identity twin of the custody fact above: WHICH connection profile this bridge serves,
+    // renderable by the pane without exposing anything the closure protects.
+    Object.defineProperty(registryBridge, 'profileId', {
+        configurable: true,
+        value       : profileId
     });
 
     // An explicitly wired bridge (the ViewportController injector — Neural Link, tests, dev

--- a/apps/agentos/fleet/redeemFleetBearerHandshake.mjs
+++ b/apps/agentos/fleet/redeemFleetBearerHandshake.mjs
@@ -1,9 +1,11 @@
 /**
  * @module apps/agentos/fleet/redeemFleetBearerHandshake
  * @summary The browser half of the one-command bearer hand-off: redeem the Fleet process bearer
- * from the transport's armed handshake endpoint (`GET /fleet/handshake`) so the cockpit page can
- * fill its designed pre-boot slot (`globalThis.AgentOS.fleet.bearerToken`) with no agent in the
- * loop — no Neural Link injection, no Electron shell, no hand-carried env var.
+ * from the transport's armed handshake endpoint (`GET /fleet/handshake`) so the cockpit boot can
+ * receive its bearer with no agent in the loop — no Neural Link injection, no Electron shell, no
+ * hand-carried env var. The boot holds the redeemed value module-privately; the launcher pre-boot
+ * slot (`globalThis.AgentOS.fleet.bearerToken`) remains the ingress for EXTERNAL producers and is
+ * retired once transport custody establishes (`./connectionProfiles.mjs` custody discipline).
  *
  * Trust posture, client half: the endpoint only answers armed launches (`fleet.bearerHandshake`,
  * armed by `buildScripts/devCockpit.mjs`) and only for exact-allowlisted browser Origins — this
@@ -15,15 +17,11 @@
  *
  * Worker-realm module: no Node imports, no Neo import — mirrors its sibling
  * `installFleetBridge.mjs`, including the format-only bearer check (generation + constant-time
- * verification stay Node-side in `ai/mcp/server/shared/helpers/localBearer.mjs`).
+ * verification stay Node-side in `ai/mcp/server/shared/helpers/localBearer.mjs`), imported from
+ * the shared contract module so the worker realm holds exactly one copy.
  */
 
-/**
- * Canonical shape of the Fleet process bearer — the same format-only gate its sibling
- * `installFleetBridge.mjs` applies before dialing the transport.
- * @type {RegExp}
- */
-const FLEET_BEARER_PATTERN = /^[A-Za-z0-9_-]{43}$/;
+import {FLEET_BEARER_PATTERN} from './connectionProfiles.mjs';
 
 /**
  * @summary Redeem the process bearer from an armed Fleet transport, or resolve `null` fail-closed.

--- a/test/playwright/unit/apps/agentos/app.spec.mjs
+++ b/test/playwright/unit/apps/agentos/app.spec.mjs
@@ -173,6 +173,66 @@ test.describe('AgentOS packaged Fleet window routing', () => {
             await expect(second.bridge.listAgents(), 'the surviving bridge still answers authenticated calls').resolves.toEqual({userId: 'operator'})
         });
 
+        test('the composed rotation→failed-retry sequence: the rejected candidate never displaces the verified bridge', async () => {
+            let releaseVerify;
+
+            const
+                gate       = new Promise(resolve => { releaseVerify = resolve }),
+                target     = {AgentOS: {fleet: {bearerToken: bearer}}},
+                gatedFetch = async () => {
+                    await gate;
+                    return {json: async () => createFleetWireResponse(FLEET_WIRE_RESPONSE_STATES.ok, {result: {userId: 'operator'}})}
+                };
+
+            // Bearer A establishes (first custody — published) and verifies while B rotates in.
+            const first = establishFleetSessionCustody({bearerToken: bearer, fleetUrl, installImpl: realInstall(gatedFetch), target});
+
+            target.AgentOS.fleet.bearerToken = rotated;
+            releaseVerify();
+
+            await expect(first.custodySettled, 'CAS preserves the rotated value').resolves.toBe(false);
+            expect(target.AgentOS.fleet.bearerToken).toBe(rotated);
+
+            // The next SharedWorker pass retries with B; the server rejects it. The candidate is
+            // built DETACHED, so the known-good A bridge must remain published throughout.
+            const second = establishFleetSessionCustody({bearerToken: rotated, fleetUrl, installImpl: realInstall(refusedFetch()), target});
+
+            expect(target.AgentOS.fleet.registryBridge, 'an unproven candidate must never be published').toBe(first.bridge);
+            expect(second.bridge, 'the caller sees the bridge that is actually live').toBe(first.bridge);
+
+            await expect(second.custodySettled).resolves.toBe(false);
+            expect(target.AgentOS.fleet.registryBridge, 'the known-good bridge survives the failed retry').toBe(first.bridge);
+            expect(target.AgentOS.fleet.bearerToken, 'the rotated ingress also survives — both rollback truths hold').toBe(rotated);
+            await expect(target.AgentOS.fleet.registryBridge.listAgents(), 'the surviving bridge still answers').resolves.toEqual({userId: 'operator'})
+        });
+
+        test('a candidate that VERIFIES is promoted: the published bridge switches only after proof', async () => {
+            const
+                bearersSeen   = [],
+                recordedFetch = async (url, init) => {
+                    bearersSeen.push(init.headers.Authorization);
+                    return {json: async () => createFleetWireResponse(FLEET_WIRE_RESPONSE_STATES.ok, {result: {userId: 'operator'}})}
+                },
+                target = {AgentOS: {fleet: {bearerToken: bearer}}};
+
+            const first = establishFleetSessionCustody({bearerToken: bearer, fleetUrl, installImpl: realInstall(recordedFetch), target});
+
+            await expect(first.custodySettled).resolves.toBe(true);
+
+            // A rotated-in credential that the server ACCEPTS: detached until proven, then promoted.
+            target.AgentOS.fleet.bearerToken = rotated;
+
+            const second = establishFleetSessionCustody({bearerToken: rotated, fleetUrl, installImpl: realInstall(recordedFetch), target});
+
+            expect(target.AgentOS.fleet.registryBridge, 'no displacement before proof').toBe(first.bridge);
+            await expect(second.custodySettled).resolves.toBe(true);
+            expect(target.AgentOS.fleet.registryBridge, 'proof promotes the candidate').not.toBe(first.bridge);
+            expect('bearerToken' in target.AgentOS.fleet, 'the verified rotation retires its own ingress copy').toBe(false);
+
+            await expect(target.AgentOS.fleet.registryBridge.listAgents()).resolves.toEqual({userId: 'operator'});
+            expect(bearersSeen.at(-1), 'the promoted bridge dials with the NEW credential').toBe(`Bearer ${rotated}`)
+        });
+
         test('handshake-unavailable twice: the first fail-closed bridge is retained, never re-created', async () => {
             const target = {};
 

--- a/test/playwright/unit/apps/agentos/app.spec.mjs
+++ b/test/playwright/unit/apps/agentos/app.spec.mjs
@@ -32,4 +32,43 @@ test.describe('AgentOS packaged Fleet window routing', () => {
         expect(resolveFleetTransportMode({href: 'https://example.test/apps/agentos/', search: ''})).toBe('browser');
         expect(() => resolveFleetTransportMode({search: ''})).toThrow()
     })
+
+    test('session custody: establish stamps the profile, retire clears the launcher slot, a throwing install rolls back', async () => {
+        const {establishFleetSessionCustody} = await import('../../../../../apps/agentos/app.mjs');
+        const
+            bearer   = 'A'.repeat(43),
+            fleetUrl = 'http://127.0.0.1:8083/fleet';
+
+        // establish + retire: a live-bearer install clears the pre-boot slot and carries the identity fact
+        const
+            calls  = [],
+            target = {AgentOS: {fleet: {bearerToken: bearer}}},
+            bridge = establishFleetSessionCustody({
+                bearerToken: bearer,
+                fleetUrl,
+                installImpl: opts => { calls.push(opts); return {installed: true} },
+                target
+            });
+
+        expect(bridge).toEqual({installed: true});
+        expect(calls).toEqual([{bearerToken: bearer, profileId: `fleet-profile:v1:${fleetUrl}`, target, url: fleetUrl}]);
+        expect('bearerToken' in target.AgentOS.fleet, 'retire: custody established means the slot is no longer residence').toBe(false);
+
+        // rollback: a throwing install leaves the slot untouched for the next producer or retry
+        const rollbackTarget = {AgentOS: {fleet: {bearerToken: bearer}}};
+
+        expect(() => establishFleetSessionCustody({
+            bearerToken: bearer,
+            fleetUrl,
+            installImpl: () => { throw new Error('install refused') },
+            target     : rollbackTarget
+        })).toThrow('install refused');
+        expect(rollbackTarget.AgentOS.fleet.bearerToken).toBe(bearer);
+
+        // fail-closed boot: no bearer means nothing established, so nothing retires
+        const idleTarget = {AgentOS: {fleet: {}}};
+
+        establishFleetSessionCustody({fleetUrl, installImpl: () => ({}), target: idleTarget});
+        expect(idleTarget.AgentOS.fleet).toEqual({})
+    })
 });

--- a/test/playwright/unit/apps/agentos/app.spec.mjs
+++ b/test/playwright/unit/apps/agentos/app.spec.mjs
@@ -33,42 +33,168 @@ test.describe('AgentOS packaged Fleet window routing', () => {
         expect(() => resolveFleetTransportMode({search: ''})).toThrow()
     })
 
-    test('session custody: establish stamps the profile, retire clears the launcher slot, a throwing install rolls back', async () => {
-        const {establishFleetSessionCustody} = await import('../../../../../apps/agentos/app.mjs');
+    test.describe('session custody lifecycle — real bridge, stubbed wire; verification is the server answer, never the closure', () => {
         const
             bearer   = 'A'.repeat(43),
+            rotated  = 'B'.repeat(43),
             fleetUrl = 'http://127.0.0.1:8083/fleet';
 
-        // establish + retire: a live-bearer install clears the pre-boot slot and carries the identity fact
+        let establishFleetSessionCustody, installFleetBridge, createFleetWireResponse, FLEET_WIRE_RESPONSE_STATES;
+
         const
-            calls  = [],
-            target = {AgentOS: {fleet: {bearerToken: bearer}}},
-            bridge = establishFleetSessionCustody({
+            okViewerFetch = () => async () => ({
+                json: async () => createFleetWireResponse(FLEET_WIRE_RESPONSE_STATES.ok, {result: {userId: 'operator'}})
+            }),
+            refusedFetch  = () => async () => ({
+                json: async () => ({
+                    ...createFleetWireResponse(FLEET_WIRE_RESPONSE_STATES.operationFailed),
+                    error: 'fleet: unauthorized'
+                })
+            }),
+            // The real installer with only the NETWORK stubbed — establish stays the true bridge
+            // (proxy map, profileId stamping, closure custody), so these specs can falsify
+            // authentication failure instead of certifying object construction.
+            realInstall = fetchImpl => opts => installFleetBridge({...opts, fetchImpl});
+
+        test.beforeAll(async () => {
+            ({establishFleetSessionCustody} = await import('../../../../../apps/agentos/app.mjs'));
+            ({installFleetBridge}           = await import('../../../../../apps/agentos/fleet/installFleetBridge.mjs'));
+            ({createFleetWireResponse, FLEET_WIRE_RESPONSE_STATES} = await import('../../../../../apps/agentos/config/fleetWireMethods.mjs'))
+        });
+
+        test('verified retire: the authenticated whoami succeeds, then and only then the ingress clears', async () => {
+            const target = {AgentOS: {fleet: {bearerToken: bearer}}};
+
+            const {bridge, custodySettled} = establishFleetSessionCustody({
                 bearerToken: bearer,
                 fleetUrl,
-                installImpl: opts => { calls.push(opts); return {installed: true} },
+                installImpl: realInstall(okViewerFetch()),
                 target
             });
 
-        expect(bridge).toEqual({installed: true});
-        expect(calls).toEqual([{bearerToken: bearer, profileId: `fleet-profile:v1:${fleetUrl}`, target, url: fleetUrl}]);
-        expect('bearerToken' in target.AgentOS.fleet, 'retire: custody established means the slot is no longer residence').toBe(false);
+            expect(bridge.profileId).toBe(`fleet-profile:v1:${fleetUrl}`);
+            expect(target.AgentOS.fleet.bearerToken, 'retire must NOT precede verification').toBe(bearer);
 
-        // rollback: a throwing install leaves the slot untouched for the next producer or retry
-        const rollbackTarget = {AgentOS: {fleet: {bearerToken: bearer}}};
+            await expect(custodySettled).resolves.toBe(true);
+            expect('bearerToken' in target.AgentOS.fleet, 'verified custody means the slot is no longer residence').toBe(false);
+            await expect(bridge.listAgents()).resolves.toEqual({userId: 'operator'})
+        });
 
-        expect(() => establishFleetSessionCustody({
-            bearerToken: bearer,
-            fleetUrl,
-            installImpl: () => { throw new Error('install refused') },
-            target     : rollbackTarget
-        })).toThrow('install refused');
-        expect(rollbackTarget.AgentOS.fleet.bearerToken).toBe(bearer);
+        test('a format-valid but REJECTED bearer preserves the ingress — rollback truth over optimism', async () => {
+            const target = {AgentOS: {fleet: {bearerToken: bearer}}};
 
-        // fail-closed boot: no bearer means nothing established, so nothing retires
-        const idleTarget = {AgentOS: {fleet: {}}};
+            const {custodySettled} = establishFleetSessionCustody({
+                bearerToken: bearer,
+                fleetUrl,
+                installImpl: realInstall(refusedFetch()),
+                target
+            });
 
-        establishFleetSessionCustody({fleetUrl, installImpl: () => ({}), target: idleTarget});
-        expect(idleTarget.AgentOS.fleet).toEqual({})
+            await expect(custodySettled).resolves.toBe(false);
+            expect(target.AgentOS.fleet.bearerToken).toBe(bearer)
+        });
+
+        test('an unreachable endpoint preserves the ingress', async () => {
+            const target = {AgentOS: {fleet: {bearerToken: bearer}}};
+
+            const {custodySettled} = establishFleetSessionCustody({
+                bearerToken: bearer,
+                fleetUrl,
+                installImpl: realInstall(async () => { throw new Error('ECONNREFUSED') }),
+                target
+            });
+
+            await expect(custodySettled).resolves.toBe(false);
+            expect(target.AgentOS.fleet.bearerToken).toBe(bearer)
+        });
+
+        test('a value rotated in DURING verification survives the retire attempt — the CAS guard', async () => {
+            let releaseVerify;
+
+            const
+                gate       = new Promise(resolve => { releaseVerify = resolve }),
+                target     = {AgentOS: {fleet: {bearerToken: bearer}}},
+                gatedFetch = async () => {
+                    await gate;
+                    return {json: async () => createFleetWireResponse(FLEET_WIRE_RESPONSE_STATES.ok, {result: {userId: 'operator'}})}
+                };
+
+            const {custodySettled} = establishFleetSessionCustody({
+                bearerToken: bearer,
+                fleetUrl,
+                installImpl: realInstall(gatedFetch),
+                target
+            });
+
+            target.AgentOS.fleet.bearerToken = rotated;
+            releaseVerify();
+
+            await expect(custodySettled).resolves.toBe(false);
+            expect(target.AgentOS.fleet.bearerToken, 'the rotated credential never verified and must survive').toBe(rotated)
+        });
+
+        test('a redeemed bearer retires nothing when the slot holds a DIFFERENT value', async () => {
+            const target = {AgentOS: {fleet: {bearerToken: rotated}}};
+
+            const {custodySettled} = establishFleetSessionCustody({
+                bearerToken: bearer, // established + verified, but never the slot's value
+                fleetUrl,
+                installImpl: realInstall(okViewerFetch()),
+                target
+            });
+
+            await expect(custodySettled).resolves.toBe(false);
+            expect(target.AgentOS.fleet.bearerToken).toBe(rotated)
+        });
+
+        test('second SharedWorker start never downgrades: the live bridge survives a bearer-less re-join', async () => {
+            const target = {AgentOS: {fleet: {bearerToken: bearer}}};
+
+            const first = establishFleetSessionCustody({
+                bearerToken: bearer,
+                fleetUrl,
+                installImpl: realInstall(okViewerFetch()),
+                target
+            });
+
+            await expect(first.custodySettled).resolves.toBe(true);
+
+            // The slot is retired now; a second joining window arrives with nothing to offer.
+            const second = establishFleetSessionCustody({
+                bearerToken: null,
+                fleetUrl,
+                installImpl: realInstall(okViewerFetch()),
+                target
+            });
+
+            expect(second.bridge, 'the established capability must be preserved, not overwritten').toBe(first.bridge);
+            expect(target.AgentOS.fleet.registryBridge).toBe(first.bridge);
+            await expect(second.custodySettled).resolves.toBe(false);
+            await expect(second.bridge.listAgents(), 'the surviving bridge still answers authenticated calls').resolves.toEqual({userId: 'operator'})
+        });
+
+        test('handshake-unavailable twice: the first fail-closed bridge is retained, never re-created', async () => {
+            const target = {};
+
+            const first  = establishFleetSessionCustody({fleetUrl, installImpl: realInstall(okViewerFetch()), target});
+            const second = establishFleetSessionCustody({fleetUrl, installImpl: realInstall(okViewerFetch()), target});
+
+            expect(second.bridge).toBe(first.bridge);
+            await expect(first.custodySettled).resolves.toBe(false);
+            await expect(second.custodySettled).resolves.toBe(false);
+            await expect(first.bridge.listAgents()).rejects.toThrow(/fleet bearer not injected/)
+        });
+
+        test('a throwing install preserves the ingress — the rollback needs no special path', async () => {
+            const target = {AgentOS: {fleet: {bearerToken: 'not-a-canonical-bearer'}}};
+
+            expect(() => establishFleetSessionCustody({
+                bearerToken: 'not-a-canonical-bearer',
+                fleetUrl,
+                installImpl: realInstall(okViewerFetch()),
+                target
+            })).toThrow(/canonical 32-byte/);
+            expect(target.AgentOS.fleet.bearerToken).toBe('not-a-canonical-bearer')
+        })
     })
 });

--- a/test/playwright/unit/apps/agentos/config/fleetVocabularyParity.spec.mjs
+++ b/test/playwright/unit/apps/agentos/config/fleetVocabularyParity.spec.mjs
@@ -246,11 +246,12 @@ test.describe('FM vocabulary parity — the realm boundary carries no imports, s
 
     test('the operable-cold app contract imports no ai or server trust authority', () => {
         const sources = [
-            ['mcpServers',         new URL('../../../../../../apps/agentos/config/mcpServers.mjs', import.meta.url),        []],
-            ['harnessTypes',       new URL('../../../../../../apps/agentos/config/harnessTypes.mjs', import.meta.url),      []],
-            ['fleetWireMethods',   new URL('../../../../../../apps/agentos/config/fleetWireMethods.mjs', import.meta.url),  []],
-            ['cockpitSources',     new URL('../../../../../../apps/agentos/config/cockpitSources.mjs', import.meta.url),    []],
-            ['installFleetBridge', new URL('../../../../../../apps/agentos/fleet/installFleetBridge.mjs', import.meta.url), ['../config/fleetWireMethods.mjs']]
+            ['mcpServers',         new URL('../../../../../../apps/agentos/config/mcpServers.mjs', import.meta.url),         []],
+            ['harnessTypes',       new URL('../../../../../../apps/agentos/config/harnessTypes.mjs', import.meta.url),       []],
+            ['fleetWireMethods',   new URL('../../../../../../apps/agentos/config/fleetWireMethods.mjs', import.meta.url),   []],
+            ['cockpitSources',     new URL('../../../../../../apps/agentos/config/cockpitSources.mjs', import.meta.url),     []],
+            ['connectionProfiles', new URL('../../../../../../apps/agentos/fleet/connectionProfiles.mjs', import.meta.url),  []],
+            ['installFleetBridge', new URL('../../../../../../apps/agentos/fleet/installFleetBridge.mjs', import.meta.url),  ['./connectionProfiles.mjs', '../config/fleetWireMethods.mjs']]
         ];
 
         for (const [label, url, expectedImports] of sources) {

--- a/test/playwright/unit/apps/agentos/fleet/connectionProfiles.spec.mjs
+++ b/test/playwright/unit/apps/agentos/fleet/connectionProfiles.spec.mjs
@@ -1,0 +1,231 @@
+import {expect, test} from '@playwright/test';
+
+import {normalizeSecureMcpEndpoint} from '../../../../../../ai/services/fleet/mcpWireParsing.mjs';
+
+import {
+    assertStorableProfileRecord,
+    createCustodyMigration,
+    createFleetProfile,
+    CUSTODIAN_STORABLE_CREDENTIAL_FIELDS,
+    CUSTODY_MIGRATION_PHASES,
+    deriveFleetProfileId,
+    FLEET_BEARER_PATTERN,
+    FLEET_PROFILE_CONTRACT_VERSION,
+    isStaleProfile,
+    normalizeFleetEndpoint,
+    PROFILE_CUSTODIANS,
+    PROFILE_FORBIDDEN_CREDENTIAL_FIELDS,
+    PROFILE_FORBIDDEN_IDENTITY_KEYS,
+    rehydrateProfile,
+    retireBearerIngressSlot
+} from '../../../../../../apps/agentos/fleet/connectionProfiles.mjs';
+
+// connectionProfiles.mjs is the pure client-side profile contract: identity from ONE versioned
+// endpoint-normalization policy (the twin of the Node side's normalizeSecureMcpEndpoint), a closed
+// record schema that refuses credential material, and the explicit custody-migration machine. The
+// realm boundary carries no imports, so THIS spec is the binding between twin and authority.
+
+const
+    loopbackFleet = 'http://127.0.0.1:8083/fleet',
+    testBearer    = 'A'.repeat(43), // canonical FORMAT only — the Node side owns real verification
+    validRecord   = overrides => ({
+        canonicalEndpoint: loopbackFleet,
+        contractVersion  : FLEET_PROFILE_CONTRACT_VERSION,
+        custodian        : 'session-only',
+        generation       : 1,
+        profileId        : deriveFleetProfileId(loopbackFleet),
+        ...overrides
+    });
+
+test.describe('connectionProfiles — endpoint normalization is the Node policy, twinned', () => {
+    // Every fixture runs through BOTH normalizers below; the pairs must agree on refusals and on
+    // canonical text alike, or the two realms disagree about what "the same endpoint" means.
+    const fixtures = [
+        {candidate: 'http://127.0.0.1:8083/fleet',        canonical: 'http://127.0.0.1:8083/fleet'},
+        {candidate: 'http://localhost:8083/fleet',        canonical: 'http://localhost:8083/fleet'},
+        {candidate: 'http://[::1]:8083/fleet',            canonical: 'http://[::1]:8083/fleet'},
+        {candidate: 'HTTP://LOCALHOST:8083/Fleet',        canonical: 'http://localhost:8083/Fleet'},
+        {candidate: 'http://127.0.0.1:80/fleet',          canonical: 'http://127.0.0.1/fleet'},
+        {candidate: ' http://127.0.0.1:8083/fleet ',      canonical: 'http://127.0.0.1:8083/fleet'},
+        {candidate: 'http://127.0.0.1:8083/fleet///',     canonical: 'http://127.0.0.1:8083/fleet'},
+        {candidate: 'http://127.0.0.1:8083/',             canonical: 'http://127.0.0.1:8083'},
+        {candidate: 'http://127.0.0.1:8083/fleet?a=1#x',  canonical: 'http://127.0.0.1:8083/fleet'},
+        {candidate: 'https://plane.example.test/fleet',   canonical: 'https://plane.example.test/fleet'},
+        {candidate: 'https://plane.example.test:443/f',   canonical: 'https://plane.example.test/f'},
+        {candidate: 'http://plane.example.test/fleet',    canonical: null}, // plain http is loopback-only
+        {candidate: 'https://user:pw@example.test/fleet', canonical: null}, // credentials-in-URL
+        {candidate: 'file:///tmp/fleet',                  canonical: null},
+        {candidate: 'not-a-url',                          canonical: null},
+        {candidate: '',                                   canonical: null},
+        {candidate: 42,                                   canonical: null},
+        {candidate: null,                                 canonical: null}
+    ];
+
+    test('the canonical matrix: one endpoint maps to one identity, refused shapes map to null', () => {
+        for (const {candidate, canonical} of fixtures) {
+            expect(normalizeFleetEndpoint(candidate), `client(${String(candidate)})`).toBe(canonical)
+        }
+    });
+
+    test('PARITY: the client twin and the Node authority answer every fixture identically', () => {
+        for (const {candidate} of fixtures) {
+            expect(normalizeFleetEndpoint(candidate), `parity(${String(candidate)})`)
+                .toBe(normalizeSecureMcpEndpoint(candidate))
+        }
+    });
+
+    test('profile ids embed the contract version and derive from the endpoint alone', () => {
+        expect(deriveFleetProfileId(loopbackFleet)).toBe(`fleet-profile:v${FLEET_PROFILE_CONTRACT_VERSION}:${loopbackFleet}`);
+        expect(deriveFleetProfileId(`${loopbackFleet}?a=1`)).toBe(deriveFleetProfileId(`${loopbackFleet}///`));
+        expect(deriveFleetProfileId('http://plane.example.test/fleet')).toBeNull()
+    });
+
+    test('forbidden identity keys never reach identity: labels vary, the id does not', () => {
+        expect(PROFILE_FORBIDDEN_IDENTITY_KEYS).toEqual(['label', 'login', 'checkoutPath']);
+
+        const a = createFleetProfile({custodian: 'session-only', endpoint: loopbackFleet, label: 'Local Plane'}),
+              b = createFleetProfile({custodian: 'session-only', endpoint: loopbackFleet, label: 'Renamed'});
+
+        expect(a.profileId).toBe(b.profileId)
+    });
+});
+
+test.describe('connectionProfiles — the record schema is closed and credential-free (Option-D as code)', () => {
+    test('creation produces a frozen, guard-validated record with exactly the admitted fields', () => {
+        const profile = createFleetProfile({custodian: 'session-only', endpoint: `${loopbackFleet}?x=1`, label: 'Dev'});
+
+        expect(Object.isFrozen(profile)).toBe(true);
+        expect(profile).toEqual({
+            canonicalEndpoint: loopbackFleet,
+            contractVersion  : FLEET_PROFILE_CONTRACT_VERSION,
+            custodian        : 'session-only',
+            generation       : 1,
+            label            : 'Dev',
+            profileId        : deriveFleetProfileId(loopbackFleet)
+        })
+    });
+
+    test('a refused endpoint fails creation with the named remediation', () => {
+        expect(() => createFleetProfile({custodian: 'session-only', endpoint: 'http://plane.example.test/fleet'}))
+            .toThrow(/https endpoint, or plain http on an exact loopback host/)
+    });
+
+    test('bearerEnvVar is env-indirection-only and must be a NAME, never a value', () => {
+        const profile = createFleetProfile({bearerEnvVar: 'FLEET_BEARER', custodian: 'env-indirection', endpoint: loopbackFleet});
+
+        expect(profile.bearerEnvVar).toBe('FLEET_BEARER');
+        expect(CUSTODIAN_STORABLE_CREDENTIAL_FIELDS['env-indirection']).toEqual(['bearerEnvVar']);
+
+        expect(() => createFleetProfile({bearerEnvVar: 'FLEET_BEARER', custodian: 'session-only', endpoint: loopbackFleet}))
+            .toThrow(/env-indirection custodian's field/);
+        expect(() => createFleetProfile({bearerEnvVar: 'not upper snake', custodian: 'env-indirection', endpoint: loopbackFleet}))
+            .toThrow(/NAME \(upper-snake\), never a value/)
+    });
+
+    test('every forbidden credential field name is refused under every custodian', () => {
+        for (const custodian of PROFILE_CUSTODIANS) {
+            for (const field of PROFILE_FORBIDDEN_CREDENTIAL_FIELDS) {
+                expect(() => assertStorableProfileRecord(validRecord({custodian, [field]: 'anything'})),
+                    `${custodian} must refuse '${field}'`).toThrow(/refuses credential field/)
+            }
+        }
+    });
+
+    test('a bearer-shaped VALUE is refused in ANY field — the label smuggle is caught by shape', () => {
+        expect(FLEET_BEARER_PATTERN.test(testBearer)).toBe(true);
+        expect(FLEET_BEARER_PATTERN.test(testBearer.slice(0, 42))).toBe(false);
+        expect(() => assertStorableProfileRecord(validRecord({label: testBearer})))
+            .toThrow(/bearer-shaped material/)
+    });
+
+    test('unknown fields, nested values, forged ids, and malformed core fields are refused', () => {
+        expect(() => assertStorableProfileRecord(validRecord({rememberMe: true}))).toThrow(/unknown field/);
+        expect(() => assertStorableProfileRecord(validRecord({label: {nested: 'x'}}))).toThrow(/flat primitive/);
+        expect(() => assertStorableProfileRecord(validRecord({profileId: 'fleet-profile:v1:http://forged.example.test'})))
+            .toThrow(/ids are derived, never hand-assigned/);
+        expect(() => assertStorableProfileRecord(validRecord({custodian: 'keychain'}))).toThrow(/custodian must be one of/);
+        expect(() => assertStorableProfileRecord(validRecord({generation: 0}))).toThrow(/positive-integer/);
+        expect(() => assertStorableProfileRecord(null)).toThrow(/plain object/)
+    });
+});
+
+test.describe('connectionProfiles — stale records rehydrate explicitly, never silently', () => {
+    test('a foreign contract version flags stale; rehydration re-derives identity and keeps custody truth', () => {
+        const stale = validRecord({contractVersion: 999, custodian: 'env-indirection', bearerEnvVar: 'FLEET_BEARER', generation: 7, profileId: 'fleet-profile:v999:http://127.0.0.1:8083/fleet'});
+
+        expect(isStaleProfile(stale)).toBe(true);
+        expect(isStaleProfile(validRecord())).toBe(false);
+
+        const fresh = rehydrateProfile(stale);
+
+        expect(fresh.contractVersion).toBe(FLEET_PROFILE_CONTRACT_VERSION);
+        expect(fresh.profileId).toBe(deriveFleetProfileId(loopbackFleet));
+        expect(fresh.custodian).toBe('env-indirection');
+        expect(fresh.bearerEnvVar).toBe('FLEET_BEARER');
+        expect(fresh.generation).toBe(7)
+    });
+
+    test('an endpoint the current contract refuses cannot be silently upgraded', () => {
+        expect(() => rehydrateProfile(validRecord({canonicalEndpoint: 'http://plane.example.test/fleet'})))
+            .toThrow(/cannot rehydrate/);
+        expect(() => rehydrateProfile(undefined)).toThrow(/cannot rehydrate/)
+    });
+});
+
+test.describe('connectionProfiles — the custody-migration machine', () => {
+    test('the four phases execute in order and generation advances exactly at retire', () => {
+        expect(CUSTODY_MIGRATION_PHASES).toEqual(['read-old', 'establish', 'verify', 'retire']);
+
+        const migration = createCustodyMigration({fromCustodian: 'session-only', generation: 3, toCustodian: 'electron-main'});
+
+        expect(migration.phase).toBe('read-old');
+        expect(() => migration.nextGeneration).toThrow(/advances only at retire/);
+
+        expect(migration.advance()).toBe('establish');
+        expect(migration.advance()).toBe('verify');
+        expect(migration.advance()).toBe('retire');
+        expect(migration.advance()).toBeNull();
+
+        expect(migration.completed).toBe(true);
+        expect(migration.phase).toBeNull();
+        expect(migration.nextGeneration).toBe(4);
+        expect(() => migration.advance()).toThrow(/terminal/);
+        expect(() => migration.rollback()).toThrow(/cannot roll back after retire/)
+    });
+
+    test('rollback before retire restores the old custody truth and is terminal', () => {
+        const migration = createCustodyMigration({fromCustodian: 'session-only', generation: 3, toCustodian: 'env-indirection'});
+
+        migration.advance(); // establish underway
+
+        expect(migration.rollback()).toEqual({custodian: 'session-only', generation: 3});
+        expect(migration.rolledBack).toBe(true);
+        expect(migration.phase).toBeNull();
+        expect(() => migration.advance()).toThrow(/terminal/);
+        expect(() => migration.rollback()).toThrow(/terminal/);
+        expect(() => migration.nextGeneration).toThrow(/keeps the old custody truth/)
+    });
+
+    test('a migration requires two different known custodians and the live generation', () => {
+        expect(() => createCustodyMigration({fromCustodian: 'session-only', generation: 1, toCustodian: 'session-only'}))
+            .toThrow(/reconnect, not a migration/);
+        expect(() => createCustodyMigration({fromCustodian: 'keychain', generation: 1, toCustodian: 'session-only'}))
+            .toThrow(/requires custodians from/);
+        expect(() => createCustodyMigration({fromCustodian: 'session-only', generation: 0, toCustodian: 'electron-main'}))
+            .toThrow(/positive-integer generation/)
+    });
+});
+
+test.describe('connectionProfiles — the pre-boot ingress retire helper', () => {
+    test('retires a present bearer, preserves siblings, and reports honestly when there is nothing to retire', () => {
+        const target = {AgentOS: {fleet: {bearerToken: testBearer, registryBridge: {live: true}}}};
+
+        expect(retireBearerIngressSlot(target)).toBe(true);
+        expect('bearerToken' in target.AgentOS.fleet).toBe(false);
+        expect(target.AgentOS.fleet.registryBridge).toEqual({live: true});
+
+        expect(retireBearerIngressSlot(target)).toBe(false);
+        expect(retireBearerIngressSlot({})).toBe(false);
+        expect(retireBearerIngressSlot(undefined)).toBe(false)
+    });
+});

--- a/test/playwright/unit/apps/agentos/fleet/connectionProfiles.spec.mjs
+++ b/test/playwright/unit/apps/agentos/fleet/connectionProfiles.spec.mjs
@@ -228,4 +228,17 @@ test.describe('connectionProfiles — the pre-boot ingress retire helper', () =>
         expect(retireBearerIngressSlot({})).toBe(false);
         expect(retireBearerIngressSlot(undefined)).toBe(false)
     });
+
+    test('the CAS guard: only the exact verified value retires; a rotated value survives', () => {
+        const rotated = 'B'.repeat(43),
+              target  = {AgentOS: {fleet: {bearerToken: rotated}}};
+
+        expect(retireBearerIngressSlot(target, {expected: testBearer}), 'a mismatched slot is a different credential').toBe(false);
+        expect(target.AgentOS.fleet.bearerToken).toBe(rotated);
+
+        expect(retireBearerIngressSlot(target, {expected: rotated})).toBe(true);
+        expect('bearerToken' in target.AgentOS.fleet).toBe(false);
+
+        expect(retireBearerIngressSlot(target, {expected: rotated}), 'an empty slot retires nothing under the guard').toBe(false)
+    });
 });

--- a/test/playwright/unit/apps/agentos/fleet/fleetTransport.integration.spec.mjs
+++ b/test/playwright/unit/apps/agentos/fleet/fleetTransport.integration.spec.mjs
@@ -317,6 +317,19 @@ test.describe('fleet transport — full-chain integration (real server + real re
         const refused         = establishFleetSessionCustody({bearerToken: wrongBearer, fleetUrl: url, target: preservedTarget});
 
         await expect(refused.custodySettled).resolves.toBe(false);
-        expect(preservedTarget.AgentOS.fleet.bearerToken).toBe(wrongBearer)
+        expect(preservedTarget.AgentOS.fleet.bearerToken).toBe(wrongBearer);
+
+        // The composed sequence over the REAL wire: the wrong bearer arrives where a VERIFIED
+        // bridge already lives — the candidate stays detached, is refused by the server, and the
+        // known-good bridge keeps answering authenticated calls throughout.
+        verifiedTarget.AgentOS.fleet.bearerToken = wrongBearer;
+
+        const retried = establishFleetSessionCustody({bearerToken: wrongBearer, fleetUrl: url, target: verifiedTarget});
+
+        expect(verifiedTarget.AgentOS.fleet.registryBridge, 'no displacement before proof').toBe(established.bridge);
+        await expect(retried.custodySettled).resolves.toBe(false);
+        expect(verifiedTarget.AgentOS.fleet.registryBridge, 'the verified bridge survives the failed live retry').toBe(established.bridge);
+        expect(verifiedTarget.AgentOS.fleet.bearerToken).toBe(wrongBearer);
+        await expect(verifiedTarget.AgentOS.fleet.registryBridge.listAgents()).resolves.toBeInstanceOf(Array)
     });
 });

--- a/test/playwright/unit/apps/agentos/fleet/fleetTransport.integration.spec.mjs
+++ b/test/playwright/unit/apps/agentos/fleet/fleetTransport.integration.spec.mjs
@@ -295,4 +295,28 @@ test.describe('fleet transport — full-chain integration (real server + real re
             FleetControlBridge.mailboxMirrorSource = priorSource
         }
     });
+
+    test('session custody over the REAL wire: the true bearer verified-retires the ingress, a wrong bearer preserves it', async () => {
+        // The L3 live non-destructive probe for the custody lifecycle: real server, real fetch,
+        // real authenticated whoami — "verify the new connection" is the server's stamped answer.
+        const {establishFleetSessionCustody} = await import('../../../../../../apps/agentos/app.mjs');
+        const url                            = `http://127.0.0.1:${server.address().port}/fleet`;
+
+        const verifiedTarget = {AgentOS: {fleet: {bearerToken}}};
+        const established    = establishFleetSessionCustody({bearerToken, fleetUrl: url, target: verifiedTarget});
+
+        expect(verifiedTarget.AgentOS.fleet.bearerToken, 'retire must wait for the wire').toBe(bearerToken);
+        await expect(established.custodySettled).resolves.toBe(true);
+        expect('bearerToken' in verifiedTarget.AgentOS.fleet).toBe(false);
+        expect(established.bridge.profileId).toBe(`fleet-profile:v1:${url}`);
+
+        // A DIFFERENT valid-format bearer: the server refuses it, so custody never verifies and the
+        // launcher ingress survives untouched — the rollback state a wrong credential must not burn.
+        const wrongBearer     = generateLocalBearerToken();
+        const preservedTarget = {AgentOS: {fleet: {bearerToken: wrongBearer}}};
+        const refused         = establishFleetSessionCustody({bearerToken: wrongBearer, fleetUrl: url, target: preservedTarget});
+
+        await expect(refused.custodySettled).resolves.toBe(false);
+        expect(preservedTarget.AgentOS.fleet.bearerToken).toBe(wrongBearer)
+    });
 });

--- a/test/playwright/unit/apps/agentos/fleet/installFleetBridge.spec.mjs
+++ b/test/playwright/unit/apps/agentos/fleet/installFleetBridge.spec.mjs
@@ -55,6 +55,24 @@ test.describe('installFleetBridge — App-Worker wiring of the dev-server app<->
         expect(Object.getOwnPropertyDescriptor(bridgeSelected, 'selected')).toMatchObject({enumerable: false, value: true});
     });
 
+    test('the profileId fact: null by default, stamped non-enumerable, bearer-shaped identity refused', () => {
+        const
+            identity      = 'fleet-profile:v1:http://127.0.0.1:8083/fleet',
+            targetDefault = {},
+            targetStamped = {};
+
+        const bridgeDefault = installFleetBridge({url: fleetUrl, fetchImpl: okFetch(), target: targetDefault});
+        const bridgeStamped = installFleetBridge({url: fleetUrl, fetchImpl: okFetch(), profileId: identity, target: targetStamped});
+
+        expect(Object.getOwnPropertyDescriptor(bridgeDefault, 'profileId')).toMatchObject({enumerable: false, value: null});
+        expect(Object.getOwnPropertyDescriptor(bridgeStamped, 'profileId')).toMatchObject({enumerable: false, value: identity});
+
+        expect(() => installFleetBridge({url: fleetUrl, fetchImpl: okFetch(), profileId: testBearer, target: {}}),
+            'a bearer-shaped profileId is a smuggled secret in a renderable slot').toThrow(/bearer-shaped material is refused/);
+        expect(() => installFleetBridge({url: fleetUrl, fetchImpl: okFetch(), profileId: '  ', target: {}}))
+            .toThrow(/null or a non-empty identity string/)
+    });
+
     test('publishes AgentOS.fleet.registryBridge with exactly the wire operations', () => {
         const target = {};
         const bridge = installFleetBridge({url: fleetUrl, fetchImpl: okFetch(), target});


### PR DESCRIPTION
Resolves #17181

Refs #16742, #13015

The client connection broker lands as ONE contract module plus its first executable custody migration — scoped, after the review round, to the leg its diff actually proves: #16742 stays open as the three-custodian umbrella (its body now carries the Leg Structure + Contract Ledger), and this PR closes leg 1. `apps/agentos/fleet/connectionProfiles.mjs` holds the versioned endpoint-normalization policy — the client twin of the Node side's `normalizeSecureMcpEndpoint` (`ai/services/fleet/mcpWireParsing.mjs`), unwidened, with a parity spec as the binding since the realm boundary carries no imports — deriving stable profile identity from the canonical endpoint ALONE (the client twin of S4's principal discipline; `label`/`login`/`checkoutPath` are named forbidden identity keys and the spec pins that changing them never changes the id). The record schema is CLOSED and credential-free by three independent guards (forbidden field names, bearer-shaped value scan over every field including `label`, flat-primitives-only structure) — the Option-D falsifier as code. The three custodian shapes are contract rows with per-shape storable-field sets: `electron-main` and `session-only` store NOTHING credential-adjacent (that absence is the design), `env-indirection` stores the environment-variable NAME under upper-snake validation so a pasted value is refused as a name.

The custody-migration machine is explicit: `read-old → establish → verify → retire`, rollback legal until retire and terminal in both directions, generation advancing exactly at retire — so revocation/rotation truth is never papered over by replaying phases. And the FIRST migration executes at boot with every phase REAL: the launcher pre-boot bearer slot (`globalThis.AgentOS.fleet.bearerToken`) converts from residence to TRANSIENT INGRESS — read at boot (read-old), moved into transport closures by the install (establish), **proven by an authenticated `resolveViewerIdentity` round-trip through the new bridge (verify — a constructed closure is not verification, the server's stamped answer is)**, and cleared only after that proof AND only while the slot still holds the exact established credential (**CAS retire** — a rejected bearer, an unreachable endpoint, and a value rotated in during verification all preserve the ingress, which IS the rollback). A second SharedWorker `onStart()` never downgrades: a bearer-less pass preserves an existing bridge instead of overwriting the live capability with a fail-closed one — and a bearer-CARRYING pass with an existing bridge builds its candidate DETACHED, promoting it (via the same installer — `installFleetBridge` stays the slot's sole publisher) only after the candidate's own authenticated proof, so an unproven credential never displaces a proven capability either. The module-level handshake redemption goes module-private (never touches Body-readable state at all), both boot and late-healing route through one `establishFleetSessionCustody` function returning `{bridge, custodySettled}`, and the bridge gains a non-enumerable `profileId` fact — the identity twin of `credentialIngress`, renderable by the pane, with bearer-shaped values refused in that slot. Bonus consolidation: `FLEET_BEARER_PATTERN` existed as two module copies in the worker realm (the named per-module-security-copy defect class); it now has one exporting home and two importers.

Evidence: L2 (lifecycle pins with the REAL installer and only the network stubbed — authentication failure is falsifiable, never construction-certified) + **L3 live non-destructive probe** (the full-chain fixture server: the true bearer verified-retires the ingress over the real wire; a wrong format-valid bearer is refused and preserves it) → meets the leaf's own evidence AC. Residual: pane-side rendering of the `profileId` fact + multi-profile persistence/selection UX (the cockpit pane lane), Residual-Owner: #13015.

## Migration census (AC 5)

| shipped consumer | disposition |
|---|---|
| `apps/agentos/app.mjs` | REWIRED — session-only custody routes through `establishFleetSessionCustody` (boot + late-healing, deduplicated); handshake redemption module-private; shell branch documents electron-main custody (identity + credential main-owned, deliberately no worker-side profile) |
| `apps/agentos/fleet/installFleetBridge.mjs` | EXTENDED — `profileId` non-enumerable fact with bearer-shaped refusal; bearer pattern imported from the contract module |
| `ai/services/fleet/FleetTenantService.mjs` | NO CHANGE — the tenant seam remains the CONNECTED service's downstream mechanism (provider bearer rides in via `connectTenant`, encrypted Node-side, never echoed); the client broker composes UPSTREAM of it |
| `ai/services/fleet/FleetControlBridge.mjs` | NO CHANGE — `connectTenant` delegation + ingress gates already stamp the server-resolved viewer; consumes no client profile state |

One file touched beyond the census: `apps/agentos/fleet/redeemFleetBearerHandshake.mjs` (pattern import + JSDoc updated to the slot's new transient-ingress truth).

**Lineage (AC 6):** #14574 / PR #15287 is the shipped remote-tenant custody producer this succeeds — supersession documented, never erased: the tenant seam is not replaced, the client broker bootstraps the cockpit's own connection that `connectTenant` (a Fleet wire verb) cannot bootstrap for itself.

## Deltas from ticket

- **Review refinement (composed falsifier on the repaired head):** the rejected-retry case preserved the ingress but DISPLACED the verified bridge, because the candidate published synchronously before its verify. Repaired with detached-candidate/promote-on-proof; pinned as the composed rotation→failed-retry sequence (known-good bridge survives, both rollback truths hold) plus the promote-on-success twin (published bridge switches only after proof, dials with the new credential), and mirrored over the real wire in the L3 probe.
- **Review round 1 (three P1s, all confirmed by the reviewer's executable falsifier and repaired here):** (1) second-SharedWorker-start downgrade — a bearer-less `establishFleetSessionCustody` pass now preserves an existing bridge; (2) verify was construction, not proof — retire now follows a successful authenticated `resolveViewerIdentity` through the new bridge, and the slot delete is CAS-guarded on the exact established credential; (3) the three-custodian close overclaimed — Resolves truthfully narrowed to leg 1 (#17181); #16742 stays open carrying legs 2 (electron-main binding) and 3 (env-indirection producer) plus the new Contract Ledger (the review's P2).
- The env-indirection custodian lands as contract row + guard enforcement in this leg; binding it to a production producer is leg 3 by design.
- Shell mode carries `profileId: null` deliberately — electron-main custody owns endpoint AND identity on the far side of the boundary; a worker-derived id there would assert knowledge the worker does not have (leg 2 produces the profile main-side).

## Test Evidence

- `npm run test-unit -- <app.spec, connectionProfiles.spec, installFleetBridge.spec, fleetTransport.integration.spec, fleetVocabularyParity.spec>` → **67 passed (1.8s)** across all five touched surfaces, including the live-wire custody probes.
- Lifecycle pins (real installer, stubbed network only): verified retire waits for the wire; rejected bearer preserves ingress; unreachable endpoint preserves ingress; mid-verification rotation survives the CAS guard; a redeemed bearer retires nothing when the slot holds a different value; two-start SharedWorker sequence preserves the live bridge (and the handshake-unavailable double-start preserves fail-closed); the composed rotation→failed-retry sequence never displaces the verified bridge; a verifying candidate is promoted only after proof and dials with the new credential; throwing install preserves ingress.
- L3 live probe (real fixture server, real fetch, real whoami): true bearer → `custodySettled: true` + slot retired; format-valid wrong bearer → refused, slot preserved; the composed failed live retry against a verified bridge leaves the known-good bridge answering.
- Contract coverage: 19-fixture canonical matrix + the PARITY loop (client twin === Node authority on every fixture); closed-schema refusals (forbidden names × 3 custodians, bearer-shaped label smuggle, nested values, forged ids); stale-record rehydration; migration machine happy path, rollback terminality, generation-at-retire; retire CAS rows; `profileId` fact + bearer-shaped refusal; operable-cold import allowlist extended to admit + guard `connectionProfiles.mjs`.
- Full staged-lint gate green at every commit (whitespace, shorthand, jsdoc-types, ticket-archaeology, block-alignment, parse, aiconfig-test-mutation, derived-domain).

## Post-Merge Validation

- [x] All four touched spec surfaces re-runnable on dev post-merge (pure/fixture/local-server harnesses, no deployment dependency).

Authored by Clio (Claude Fable 5, Claude Code). Session dd4568bd-d264-4448-998b-63a7ce35b792.
